### PR TITLE
Show appropriate feature flags in docs

### DIFF
--- a/src/doc/trpl/choosing-your-guarantees.md
+++ b/src/doc/trpl/choosing-your-guarantees.md
@@ -127,7 +127,8 @@ If a field is wrapped in `Cell`, it's a nice indicator that the chunk of data is
 stay the same between the time you first read it and when you intend to use it.
 
 ```rust
-# use std::cell::Cell;
+use std::cell::Cell;
+
 let x = Cell::new(1);
 let y = &x;
 let z = &x;
@@ -185,7 +186,8 @@ any other borrows active when a mutable borrow is active. If the programmer atte
 borrow, the thread will panic.
 
 ```rust
-# use std::cell::RefCell;
+use std::cell::RefCell;
+
 let x = RefCell::new(vec![1,2,3,4]);
 {
     println!("{:?}", *x.borrow())

--- a/src/doc/trpl/intrinsics.md
+++ b/src/doc/trpl/intrinsics.md
@@ -11,7 +11,7 @@ perform efficient pointer arithmetic, one would import those functions
 via a declaration like
 
 ```rust
-# #![feature(intrinsics)]
+#![feature(intrinsics)]
 # fn main() {}
 
 extern "rust-intrinsic" {

--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -200,7 +200,8 @@ impl<T: ?Sized> Arc<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(arc_weak)]
+    /// #![feature(arc_weak)]
+    ///
     /// use std::sync::Arc;
     ///
     /// let five = Arc::new(5);
@@ -337,7 +338,8 @@ impl<T: Clone> Arc<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(arc_unique)]
+    /// #![feature(arc_unique)]
+    ///
     /// use std::sync::Arc;
     ///
     /// let mut five = Arc::new(5);
@@ -408,7 +410,8 @@ impl<T: ?Sized> Arc<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(arc_unique, alloc)]
+    /// #![feature(arc_unique, alloc)]
+    ///
     /// extern crate alloc;
     /// # fn main() {
     /// use alloc::arc::Arc;
@@ -555,7 +558,8 @@ impl<T: ?Sized> Weak<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(arc_weak)]
+    /// #![feature(arc_weak)]
+    ///
     /// use std::sync::Arc;
     ///
     /// let five = Arc::new(5);
@@ -599,7 +603,8 @@ impl<T: ?Sized> Clone for Weak<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(arc_weak)]
+    /// #![feature(arc_weak)]
+    ///
     /// use std::sync::Arc;
     ///
     /// let weak_five = Arc::new(5).downgrade();
@@ -626,7 +631,8 @@ impl<T: ?Sized> Drop for Weak<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(arc_weak)]
+    /// #![feature(arc_weak)]
+    ///
     /// use std::sync::Arc;
     ///
     /// {

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -74,7 +74,8 @@ use core::raw::{TraitObject};
 /// The following two examples are equivalent:
 ///
 /// ```
-/// # #![feature(box_heap)]
+/// #![feature(box_heap)]
+///
 /// #![feature(box_syntax, placement_in_syntax)]
 /// use std::boxed::HEAP;
 ///
@@ -237,7 +238,8 @@ impl<T : ?Sized> Box<T> {
     ///
     /// # Examples
     /// ```
-    /// # #![feature(box_raw)]
+    /// #![feature(box_raw)]
+    ///
     /// let seventeen = Box::new(17u32);
     /// let raw = Box::into_raw(seventeen);
     /// let boxed_again = unsafe { Box::from_raw(raw) };
@@ -260,7 +262,8 @@ impl<T : ?Sized> Box<T> {
 ///
 /// # Examples
 /// ```
-/// # #![feature(box_raw)]
+/// #![feature(box_raw)]
+///
 /// use std::boxed;
 ///
 /// let seventeen = Box::new(17u32);
@@ -303,7 +306,8 @@ impl<T: Clone> Clone for Box<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(box_raw)]
+    /// #![feature(box_raw)]
+    ///
     /// let x = Box::new(5);
     /// let mut y = Box::new(10);
     ///

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -91,7 +91,8 @@
 //! documentation for more details on interior mutability.
 //!
 //! ```rust
-//! # #![feature(rc_weak)]
+//! #![feature(rc_weak)]
+//!
 //! use std::rc::Rc;
 //! use std::rc::Weak;
 //! use std::cell::RefCell;
@@ -227,7 +228,8 @@ impl<T> Rc<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(rc_unique)]
+    /// #![feature(rc_unique)]
+    ///
     /// use std::rc::Rc;
     ///
     /// let x = Rc::new(3);
@@ -262,7 +264,8 @@ impl<T: ?Sized> Rc<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(rc_weak)]
+    /// #![feature(rc_weak)]
+    ///
     /// use std::rc::Rc;
     ///
     /// let five = Rc::new(5);
@@ -292,7 +295,8 @@ impl<T: ?Sized> Rc<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(rc_unique)]
+    /// #![feature(rc_unique)]
+    ///
     /// use std::rc::Rc;
     ///
     /// let five = Rc::new(5);
@@ -313,7 +317,8 @@ impl<T: ?Sized> Rc<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(rc_unique)]
+    /// #![feature(rc_unique)]
+    ///
     /// use std::rc::Rc;
     ///
     /// let mut x = Rc::new(3);
@@ -353,7 +358,8 @@ pub fn strong_count<T: ?Sized>(this: &Rc<T>) -> usize { Rc::strong_count(this) }
 /// # Examples
 ///
 /// ```
-/// # #![feature(rc_unique)]
+/// #![feature(rc_unique)]
+///
 /// use std::rc;
 /// use std::rc::Rc;
 ///
@@ -373,7 +379,8 @@ pub fn is_unique<T>(rc: &Rc<T>) -> bool { Rc::is_unique(rc) }
 /// # Examples
 ///
 /// ```
-/// # #![feature(rc_unique)]
+/// #![feature(rc_unique)]
+///
 /// use std::rc::{self, Rc};
 ///
 /// let x = Rc::new(3);
@@ -395,7 +402,8 @@ pub fn try_unwrap<T>(rc: Rc<T>) -> Result<T, Rc<T>> { Rc::try_unwrap(rc) }
 /// # Examples
 ///
 /// ```
-/// # #![feature(rc_unique)]
+/// #![feature(rc_unique)]
+///
 /// use std::rc::{self, Rc};
 ///
 /// let mut x = Rc::new(3);
@@ -419,7 +427,8 @@ impl<T: Clone> Rc<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(rc_unique)]
+    /// #![feature(rc_unique)]
+    ///
     /// use std::rc::Rc;
     ///
     /// let mut five = Rc::new(5);
@@ -750,7 +759,8 @@ impl<T: ?Sized> Weak<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(rc_weak)]
+    /// #![feature(rc_weak)]
+    ///
     /// use std::rc::Rc;
     ///
     /// let five = Rc::new(5);
@@ -778,7 +788,8 @@ impl<T: ?Sized> Drop for Weak<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(rc_weak)]
+    /// #![feature(rc_weak)]
+    ///
     /// use std::rc::Rc;
     ///
     /// {
@@ -825,7 +836,8 @@ impl<T: ?Sized> Clone for Weak<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(rc_weak)]
+    /// #![feature(rc_weak)]
+    ///
     /// use std::rc::Rc;
     ///
     /// let weak_five = Rc::new(5).downgrade();

--- a/src/libcollections/binary_heap.rs
+++ b/src/libcollections/binary_heap.rs
@@ -216,7 +216,8 @@ impl<T: Ord> BinaryHeap<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
+    /// #![feature(collections)]
+    ///
     /// use std::collections::BinaryHeap;
     /// let heap = BinaryHeap::from_vec(vec![9, 1, 2, 7, 3, 2]);
     /// ```
@@ -236,7 +237,8 @@ impl<T: Ord> BinaryHeap<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
+    /// #![feature(collections)]
+    ///
     /// use std::collections::BinaryHeap;
     /// let heap = BinaryHeap::from_vec(vec![1, 2, 3, 4]);
     ///
@@ -341,7 +343,8 @@ impl<T: Ord> BinaryHeap<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
+    /// #![feature(collections)]
+    ///
     /// use std::collections::BinaryHeap;
     /// let mut heap = BinaryHeap::from_vec(vec![1, 3]);
     ///
@@ -387,7 +390,8 @@ impl<T: Ord> BinaryHeap<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
+    /// #![feature(collections)]
+    ///
     /// use std::collections::BinaryHeap;
     /// let mut heap = BinaryHeap::new();
     /// heap.push(1);
@@ -419,7 +423,8 @@ impl<T: Ord> BinaryHeap<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
+    /// #![feature(collections)]
+    ///
     /// use std::collections::BinaryHeap;
     /// let mut heap = BinaryHeap::new();
     ///
@@ -445,7 +450,8 @@ impl<T: Ord> BinaryHeap<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
+    /// #![feature(collections)]
+    ///
     /// use std::collections::BinaryHeap;
     /// let heap = BinaryHeap::from_vec(vec![1, 2, 3, 4, 5, 6, 7]);
     /// let vec = heap.into_vec();
@@ -463,7 +469,8 @@ impl<T: Ord> BinaryHeap<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
+    /// #![feature(collections)]
+    ///
     /// use std::collections::BinaryHeap;
     ///
     /// let mut heap = BinaryHeap::from_vec(vec![1, 2, 4, 5, 7]);
@@ -724,7 +731,8 @@ impl<T: Ord> IntoIterator for BinaryHeap<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
+    /// #![feature(collections)]
+    ///
     /// use std::collections::BinaryHeap;
     /// let heap = BinaryHeap::from_vec(vec![1, 2, 3, 4]);
     ///

--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -43,7 +43,8 @@
 //! [sieve]: http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes
 //!
 //! ```
-//! # #![feature(bitset, bitvec, range_inclusive, step_by)]
+//! #![feature(bitset, bitvec, range_inclusive, step_by)]
+//!
 //! use std::collections::{BitSet, BitVec};
 //! use std::iter;
 //!
@@ -139,7 +140,8 @@ const FALSE: &'static bool = &false;
 /// # Examples
 ///
 /// ```
-/// # #![feature(bitvec)]
+/// #![feature(bitvec)]
+///
 /// use std::collections::BitVec;
 ///
 /// let mut bv = BitVec::from_elem(10, false);
@@ -256,7 +258,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     /// let mut bv = BitVec::new();
     /// ```
@@ -271,7 +274,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let bv = BitVec::from_elem(10, false);
@@ -312,7 +316,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let bv = BitVec::from_bytes(&[0b10100000, 0b00010010]);
@@ -355,7 +360,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let bv = BitVec::from_fn(5, |i| { i % 2 == 0 });
@@ -374,7 +380,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let bv = BitVec::from_bytes(&[0b01100000]);
@@ -407,7 +414,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let mut bv = BitVec::from_elem(5, false);
@@ -430,7 +438,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let before = 0b01100000;
@@ -451,7 +460,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let before = 0b01100000;
@@ -480,7 +490,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let a   = 0b01100100;
@@ -511,7 +522,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let a   = 0b01100100;
@@ -542,7 +554,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let a   = 0b01100100;
@@ -572,7 +585,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let mut bv = BitVec::from_elem(5, true);
@@ -597,7 +611,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let bv = BitVec::from_bytes(&[0b01110100, 0b10010010]);
@@ -614,7 +629,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec, append)]
+    /// #![feature(bitvec, append)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let mut a = BitVec::from_bytes(&[0b10000000]);
@@ -657,7 +673,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec, split_off)]
+    /// #![feature(bitvec, split_off)]
+    ///
     /// use std::collections::BitVec;
     /// let mut a = BitVec::new();
     /// a.push(true);
@@ -718,7 +735,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let mut bv = BitVec::from_elem(10, false);
@@ -736,7 +754,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let mut bv = BitVec::from_elem(10, false);
@@ -758,7 +777,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let mut bv = BitVec::from_elem(3, true);
@@ -806,7 +826,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let bv = BitVec::from_bytes(&[0b10100000]);
@@ -827,7 +848,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let mut bv = BitVec::from_bytes(&[0b01001011]);
@@ -854,7 +876,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let mut bv = BitVec::from_elem(3, false);
@@ -885,7 +908,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let mut bv = BitVec::from_elem(3, false);
@@ -908,7 +932,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let mut bv = BitVec::new();
@@ -930,7 +955,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let mut bv = BitVec::from_bytes(&[0b01001011]);
@@ -981,7 +1007,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let mut bv = BitVec::from_bytes(&[0b01001001]);
@@ -1012,7 +1039,8 @@ impl BitVec {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitvec)]
+    /// #![feature(bitvec)]
+    ///
     /// use std::collections::BitVec;
     ///
     /// let mut bv = BitVec::new();
@@ -1231,7 +1259,8 @@ impl<'a> IntoIterator for &'a BitVec {
 /// # Examples
 ///
 /// ```
-/// # #![feature(bitvec, bitset)]
+/// #![feature(bitvec, bitset)]
+///
 /// use std::collections::{BitSet, BitVec};
 ///
 /// // It's a regular set
@@ -1335,7 +1364,8 @@ impl BitSet {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitset)]
+    /// #![feature(bitset)]
+    ///
     /// use std::collections::BitSet;
     ///
     /// let mut s = BitSet::new();
@@ -1352,7 +1382,8 @@ impl BitSet {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitset)]
+    /// #![feature(bitset)]
+    ///
     /// use std::collections::BitSet;
     ///
     /// let mut s = BitSet::with_capacity(100);
@@ -1370,7 +1401,8 @@ impl BitSet {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitset, bitvec)]
+    /// #![feature(bitset, bitvec)]
+    ///
     /// use std::collections::{BitVec, BitSet};
     ///
     /// let bv = BitVec::from_bytes(&[0b01100000]);
@@ -1392,7 +1424,8 @@ impl BitSet {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitset)]
+    /// #![feature(bitset)]
+    ///
     /// use std::collections::BitSet;
     ///
     /// let mut s = BitSet::with_capacity(100);
@@ -1414,7 +1447,8 @@ impl BitSet {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitset)]
+    /// #![feature(bitset)]
+    ///
     /// use std::collections::BitSet;
     ///
     /// let mut s = BitSet::new();
@@ -1441,7 +1475,8 @@ impl BitSet {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitset)]
+    /// #![feature(bitset)]
+    ///
     /// use std::collections::BitSet;
     ///
     /// let mut s = BitSet::new();
@@ -1462,7 +1497,8 @@ impl BitSet {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitset)]
+    /// #![feature(bitset)]
+    ///
     /// use std::collections::BitSet;
     ///
     /// let mut s = BitSet::new();
@@ -1483,7 +1519,8 @@ impl BitSet {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitset)]
+    /// #![feature(bitset)]
+    ///
     /// use std::collections::BitSet;
     ///
     /// let mut s = BitSet::new();
@@ -1530,7 +1567,8 @@ impl BitSet {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitset)]
+    /// #![feature(bitset)]
+    ///
     /// use std::collections::BitSet;
     ///
     /// let mut s = BitSet::new();
@@ -1563,7 +1601,8 @@ impl BitSet {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitset, bitvec)]
+    /// #![feature(bitset, bitvec)]
+    ///
     /// use std::collections::{BitVec, BitSet};
     ///
     /// let s = BitSet::from_bit_vec(BitVec::from_bytes(&[0b01001010]));
@@ -1585,7 +1624,8 @@ impl BitSet {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitset, bitvec)]
+    /// #![feature(bitset, bitvec)]
+    ///
     /// use std::collections::{BitVec, BitSet};
     ///
     /// let a = BitSet::from_bit_vec(BitVec::from_bytes(&[0b01101000]));
@@ -1615,7 +1655,8 @@ impl BitSet {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitset, bitvec)]
+    /// #![feature(bitset, bitvec)]
+    ///
     /// use std::collections::{BitVec, BitSet};
     ///
     /// let a = BitSet::from_bit_vec(BitVec::from_bytes(&[0b01101000]));
@@ -1646,7 +1687,8 @@ impl BitSet {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitset, bitvec)]
+    /// #![feature(bitset, bitvec)]
+    ///
     /// use std::collections::{BitSet, BitVec};
     ///
     /// let a = BitSet::from_bit_vec(BitVec::from_bytes(&[0b01101000]));
@@ -1684,7 +1726,8 @@ impl BitSet {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitset, bitvec)]
+    /// #![feature(bitset, bitvec)]
+    ///
     /// use std::collections::{BitSet, BitVec};
     ///
     /// let a = BitSet::from_bit_vec(BitVec::from_bytes(&[0b01101000]));
@@ -1712,7 +1755,8 @@ impl BitSet {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitset, bitvec)]
+    /// #![feature(bitset, bitvec)]
+    ///
     /// use std::collections::{BitSet, BitVec};
     ///
     /// let a   = 0b01101000;
@@ -1736,7 +1780,8 @@ impl BitSet {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitset, bitvec)]
+    /// #![feature(bitset, bitvec)]
+    ///
     /// use std::collections::{BitSet, BitVec};
     ///
     /// let a   = 0b01101000;
@@ -1761,7 +1806,8 @@ impl BitSet {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitset, bitvec)]
+    /// #![feature(bitset, bitvec)]
+    ///
     /// use std::collections::{BitSet, BitVec};
     ///
     /// let a   = 0b01101000;
@@ -1794,7 +1840,8 @@ impl BitSet {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitset, bitvec)]
+    /// #![feature(bitset, bitvec)]
+    ///
     /// use std::collections::{BitSet, BitVec};
     ///
     /// let a   = 0b01101000;
@@ -1818,7 +1865,8 @@ impl BitSet {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitset, bitvec, append)]
+    /// #![feature(bitset, bitvec, append)]
+    ///
     /// use std::collections::{BitVec, BitSet};
     ///
     /// let mut a = BitSet::new();
@@ -1849,7 +1897,8 @@ impl BitSet {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(bitset, bitvec, split_off)]
+    /// #![feature(bitset, bitvec, split_off)]
+    ///
     /// use std::collections::{BitSet, BitVec};
     /// let mut a = BitSet::new();
     /// a.insert(2);

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -1504,7 +1504,8 @@ impl<K: Ord, V> BTreeMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(btree_range, collections_bound)]
+    /// #![feature(btree_range, collections_bound)]
+    ///
     /// use std::collections::BTreeMap;
     /// use std::collections::Bound::{Included, Unbounded};
     ///
@@ -1531,7 +1532,8 @@ impl<K: Ord, V> BTreeMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(btree_range, collections_bound)]
+    /// #![feature(btree_range, collections_bound)]
+    ///
     /// use std::collections::BTreeMap;
     /// use std::collections::Bound::{Included, Excluded};
     ///

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -141,7 +141,8 @@ impl<T: Ord> BTreeSet<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(btree_range, collections_bound)]
+    /// #![feature(btree_range, collections_bound)]
+    ///
     /// use std::collections::BTreeSet;
     /// use std::collections::Bound::{Included, Unbounded};
     ///

--- a/src/libcollections/fmt.rs
+++ b/src/libcollections/fmt.rs
@@ -172,7 +172,7 @@
 //! like:
 //!
 //! ```
-//! # #![feature(fmt_flags)]
+//! #![feature(fmt_flags)]
 //! use std::fmt;
 //!
 //! #[derive(Debug)]

--- a/src/libcollections/linked_list.rs
+++ b/src/libcollections/linked_list.rs
@@ -784,7 +784,8 @@ impl<'a, A> IterMut<'a, A> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(linked_list_extras)]
+    /// #![feature(linked_list_extras)]
+    ///
     /// use std::collections::LinkedList;
     ///
     /// let mut list: LinkedList<_> = vec![1, 3, 4].into_iter().collect();
@@ -812,7 +813,8 @@ impl<'a, A> IterMut<'a, A> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(linked_list_extras)]
+    /// #![feature(linked_list_extras)]
+    ///
     /// use std::collections::LinkedList;
     ///
     /// let mut list: LinkedList<_> = vec![1, 2, 3].into_iter().collect();

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -883,7 +883,8 @@ impl<T> [T] {
     /// # Examples
     ///
     /// ```rust
-    /// # #![feature(permutations)]
+    /// #![feature(permutations)]
+    ///
     /// let v = [1, 2, 3];
     /// let mut perms = v.permutations();
     ///
@@ -895,7 +896,8 @@ impl<T> [T] {
     /// Iterating through permutations one by one.
     ///
     /// ```rust
-    /// # #![feature(permutations)]
+    /// #![feature(permutations)]
+    ///
     /// let v = [1, 2, 3];
     /// let mut perms = v.permutations();
     ///
@@ -920,7 +922,8 @@ impl<T> [T] {
     /// # Example
     ///
     /// ```rust
-    /// # #![feature(permutations)]
+    /// #![feature(permutations)]
+    ///
     /// let v: &mut [_] = &mut [0, 1, 2];
     /// v.next_permutation();
     /// let b: &mut [_] = &mut [0, 2, 1];
@@ -945,7 +948,8 @@ impl<T> [T] {
     /// # Example
     ///
     /// ```rust
-    /// # #![feature(permutations)]
+    /// #![feature(permutations)]
+    ///
     /// let v: &mut [_] = &mut [1, 0, 2];
     /// v.prev_permutation();
     /// let b: &mut [_] = &mut [0, 2, 1];
@@ -969,7 +973,8 @@ impl<T> [T] {
     /// # Example
     ///
     /// ```rust
-    /// # #![feature(clone_from_slice)]
+    /// #![feature(clone_from_slice)]
+    ///
     /// let mut dst = [0, 0, 0];
     /// let src = [1, 2];
     ///
@@ -1000,7 +1005,8 @@ impl<T> [T] {
     /// # Examples
     ///
     /// ```rust
-    /// # #![feature(move_from)]
+    /// #![feature(move_from)]
+    ///
     /// let mut a = [1, 2, 3, 4, 5];
     /// let b = vec![6, 7, 8];
     /// let num_moved = a.move_from(b, 0, 3);

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -441,7 +441,8 @@ impl str {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(str_char)]
+    /// #![feature(str_char)]
+    ///
     /// let s = "Löwe 老虎 Léopard";
     /// assert!(s.is_char_boundary(0));
     /// // start of `老`
@@ -545,7 +546,8 @@ impl str {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(slice_chars)]
+    /// #![feature(slice_chars)]
+    ///
     /// let s = "Löwe 老虎 Léopard";
     ///
     /// assert_eq!(s.slice_chars(0, 4), "Löwe");
@@ -573,7 +575,8 @@ impl str {
     /// done by `.chars()` or `.char_indices()`.
     ///
     /// ```
-    /// # #![feature(str_char, core)]
+    /// #![feature(str_char, core)]
+    ///
     /// use std::str::CharRange;
     ///
     /// let s = "中华Việt Nam";
@@ -630,7 +633,8 @@ impl str {
     /// done by `.chars().rev()` or `.char_indices()`.
     ///
     /// ```
-    /// # #![feature(str_char, core)]
+    /// #![feature(str_char, core)]
+    ///
     /// use std::str::CharRange;
     ///
     /// let s = "中华Việt Nam";
@@ -676,7 +680,8 @@ impl str {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(str_char)]
+    /// #![feature(str_char)]
+    ///
     /// let s = "abπc";
     /// assert_eq!(s.char_at(1), 'b');
     /// assert_eq!(s.char_at(2), 'π');
@@ -703,7 +708,8 @@ impl str {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(str_char)]
+    /// #![feature(str_char)]
+    ///
     /// let s = "abπc";
     /// assert_eq!(s.char_at_reverse(1), 'a');
     /// assert_eq!(s.char_at_reverse(2), 'b');
@@ -730,7 +736,8 @@ impl str {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(str_char)]
+    /// #![feature(str_char)]
+    ///
     /// let s = "Łódź"; // \u{141}o\u{301}dz\u{301}
     /// let (c, s1) = s.slice_shift_char().unwrap();
     ///
@@ -764,7 +771,8 @@ impl str {
     ///
     /// # Examples
     /// ```
-    /// # #![feature(str_split_at)]
+    /// #![feature(str_split_at)]
+    ///
     /// let s = "Löwe 老虎 Léopard";
     /// let first_space = s.find(' ').unwrap_or(s.len());
     /// let (a, b) = s.split_at(first_space);
@@ -862,8 +870,9 @@ impl str {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(str_words)]
-    /// # #![allow(deprecated)]
+    /// #![feature(str_words)]
+    /// #![allow(deprecated)]
+    ///
     /// let some_words = " Mary   had\ta\u{2009}little  \n\t lamb";
     /// let v: Vec<&str> = some_words.words().collect();
     ///
@@ -1018,7 +1027,8 @@ impl str {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(unicode, core)]
+    /// #![feature(unicode, core)]
+    ///
     /// let gr1 = "a\u{310}e\u{301}o\u{308}\u{332}".graphemes(true).collect::<Vec<&str>>();
     /// let b: &[_] = &["a\u{310}", "e\u{301}", "o\u{308}\u{332}"];
     ///
@@ -1044,7 +1054,8 @@ impl str {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(unicode, core)]
+    /// #![feature(unicode, core)]
+    ///
     /// let gr_inds = "a̐éö̲\r\n".grapheme_indices(true).collect::<Vec<(usize, &str)>>();
     /// let b: &[_] = &[(0, "a̐"), (3, "é"), (6, "ö̲"), (11, "\r\n")];
     ///
@@ -1582,7 +1593,8 @@ impl str {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(str_match_indices)]
+    /// #![feature(str_match_indices)]
+    ///
     /// let v: Vec<(usize, usize)> = "abcXXXabcYYYabc".match_indices("abc").collect();
     /// assert_eq!(v, [(0, 3), (6, 9), (12, 15)]);
     ///
@@ -1626,7 +1638,8 @@ impl str {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(str_match_indices)]
+    /// #![feature(str_match_indices)]
+    ///
     /// let v: Vec<(usize, usize)> = "abcXXXabcYYYabc".rmatch_indices("abc").collect();
     /// assert_eq!(v, [(12, 15), (6, 9), (0, 3)]);
     ///
@@ -1656,7 +1669,8 @@ impl str {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(subslice_offset)]
+    /// #![feature(subslice_offset)]
+    ///
     /// let string = "a\nb\nc";
     /// let lines: Vec<&str> = string.lines().collect();
     ///

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -89,7 +89,8 @@ impl String {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
+    /// #![feature(collections)]
+    ///
     /// let s = String::from("hello");
     /// assert_eq!(&s[..], "hello");
     /// ```
@@ -702,7 +703,7 @@ impl String {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(drain)]
+    /// #![feature(drain)]
     ///
     /// let mut s = String::from("α is alpha, β is beta");
     /// let beta_offset = s.find('β').unwrap_or(s.len());

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -622,7 +622,8 @@ impl<T> Vec<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(append)]
+    /// #![feature(append)]
+    ///
     /// let mut vec = vec![1, 2, 3];
     /// let mut vec2 = vec![4, 5, 6];
     /// vec.append(&mut vec2);
@@ -661,7 +662,7 @@ impl<T> Vec<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(drain)]
+    /// #![feature(drain)]
     ///
     /// // Draining using `..` clears the whole vector.
     /// let mut v = vec![1, 2, 3];
@@ -759,7 +760,8 @@ impl<T> Vec<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(map_in_place)]
+    /// #![feature(map_in_place)]
+    ///
     /// let v = vec![0, 1, 2];
     /// let w = v.map_in_place(|i| i + 3);
     /// assert_eq!(&w[..], &[3, 4, 5]);
@@ -962,7 +964,8 @@ impl<T> Vec<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(split_off)]
+    /// #![feature(split_off)]
+    ///
     /// let mut vec = vec![1,2,3];
     /// let vec2 = vec.split_off(1);
     /// assert_eq!(vec, [1]);
@@ -1001,7 +1004,8 @@ impl<T: Clone> Vec<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vec_resize)]
+    /// #![feature(vec_resize)]
+    ///
     /// let mut vec = vec!["hello"];
     /// vec.resize(3, "world");
     /// assert_eq!(vec, ["hello", "world", "world"]);
@@ -1053,7 +1057,8 @@ impl<T: Clone> Vec<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vec_push_all)]
+    /// #![feature(vec_push_all)]
+    ///
     /// let mut vec = vec![1];
     /// vec.push_all(&[2, 3, 4]);
     /// assert_eq!(vec, [1, 2, 3, 4]);

--- a/src/libcollections/vec_deque.rs
+++ b/src/libcollections/vec_deque.rs
@@ -379,7 +379,8 @@ impl<T> VecDeque<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
+    /// #![feature(collections)]
+    ///
     /// use std::collections::VecDeque;
     ///
     /// let mut buf = VecDeque::with_capacity(15);
@@ -455,7 +456,8 @@ impl<T> VecDeque<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(deque_extras)]
+    /// #![feature(deque_extras)]
+    ///
     /// use std::collections::VecDeque;
     ///
     /// let mut buf = VecDeque::new();
@@ -604,7 +606,8 @@ impl<T> VecDeque<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(drain)]
+    /// #![feature(drain)]
+    ///
     /// use std::collections::VecDeque;
     ///
     /// let mut v = VecDeque::new();
@@ -847,7 +850,8 @@ impl<T> VecDeque<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(deque_extras)]
+    /// #![feature(deque_extras)]
+    ///
     /// use std::collections::VecDeque;
     ///
     /// let mut buf = VecDeque::new();
@@ -881,7 +885,8 @@ impl<T> VecDeque<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(deque_extras)]
+    /// #![feature(deque_extras)]
+    ///
     /// use std::collections::VecDeque;
     ///
     /// let mut buf = VecDeque::new();
@@ -915,7 +920,8 @@ impl<T> VecDeque<T> {
     ///
     /// # Examples
     /// ```
-    /// # #![feature(collections)]
+    /// #![feature(collections)]
+    ///
     /// use std::collections::VecDeque;
     ///
     /// let mut buf = VecDeque::new();
@@ -1291,7 +1297,8 @@ impl<T> VecDeque<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(split_off)]
+    /// #![feature(split_off)]
+    ///
     /// use std::collections::VecDeque;
     ///
     /// let mut buf: VecDeque<_> = vec![1,2,3].into_iter().collect();
@@ -1354,7 +1361,8 @@ impl<T> VecDeque<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(append)]
+    /// #![feature(append)]
+    ///
     /// use std::collections::VecDeque;
     ///
     /// let mut buf: VecDeque<_> = vec![1, 2, 3].into_iter().collect();
@@ -1380,7 +1388,8 @@ impl<T> VecDeque<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vec_deque_retain)]
+    /// #![feature(vec_deque_retain)]
+    ///
     /// use std::collections::VecDeque;
     ///
     /// let mut buf = VecDeque::new();
@@ -1415,7 +1424,8 @@ impl<T: Clone> VecDeque<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(deque_extras)]
+    /// #![feature(deque_extras)]
+    ///
     /// use std::collections::VecDeque;
     ///
     /// let mut buf = VecDeque::new();

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -35,7 +35,8 @@ use vec::Vec;
 /// # Examples
 ///
 /// ```
-/// # #![feature(vecmap)]
+/// #![feature(vecmap)]
+///
 /// use std::collections::VecMap;
 ///
 /// let mut months = VecMap::new();
@@ -135,7 +136,8 @@ impl<V> VecMap<V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vecmap)]
+    /// #![feature(vecmap)]
+    ///
     /// use std::collections::VecMap;
     /// let mut map: VecMap<&str> = VecMap::new();
     /// ```
@@ -148,7 +150,8 @@ impl<V> VecMap<V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vecmap)]
+    /// #![feature(vecmap)]
+    ///
     /// use std::collections::VecMap;
     /// let mut map: VecMap<&str> = VecMap::with_capacity(10);
     /// ```
@@ -163,7 +166,8 @@ impl<V> VecMap<V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vecmap)]
+    /// #![feature(vecmap)]
+    ///
     /// use std::collections::VecMap;
     /// let map: VecMap<String> = VecMap::with_capacity(10);
     /// assert!(map.capacity() >= 10);
@@ -183,7 +187,8 @@ impl<V> VecMap<V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vecmap)]
+    /// #![feature(vecmap)]
+    ///
     /// use std::collections::VecMap;
     /// let mut map: VecMap<&str> = VecMap::new();
     /// map.reserve_len(10);
@@ -208,7 +213,8 @@ impl<V> VecMap<V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vecmap)]
+    /// #![feature(vecmap)]
+    ///
     /// use std::collections::VecMap;
     /// let mut map: VecMap<&str> = VecMap::new();
     /// map.reserve_len_exact(10);
@@ -248,7 +254,8 @@ impl<V> VecMap<V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vecmap)]
+    /// #![feature(vecmap)]
+    ///
     /// use std::collections::VecMap;
     ///
     /// let mut map = VecMap::new();
@@ -277,7 +284,8 @@ impl<V> VecMap<V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vecmap)]
+    /// #![feature(vecmap)]
+    ///
     /// use std::collections::VecMap;
     ///
     /// let mut map = VecMap::new();
@@ -307,7 +315,8 @@ impl<V> VecMap<V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vecmap, append)]
+    /// #![feature(vecmap, append)]
+    ///
     /// use std::collections::VecMap;
     ///
     /// let mut a = VecMap::new();
@@ -343,7 +352,8 @@ impl<V> VecMap<V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vecmap, split_off)]
+    /// #![feature(vecmap, split_off)]
+    ///
     /// use std::collections::VecMap;
     ///
     /// let mut a = VecMap::new();
@@ -400,7 +410,8 @@ impl<V> VecMap<V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vecmap, drain)]
+    /// #![feature(vecmap, drain)]
+    ///
     /// use std::collections::VecMap;
     ///
     /// let mut map = VecMap::new();
@@ -428,7 +439,8 @@ impl<V> VecMap<V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vecmap)]
+    /// #![feature(vecmap)]
+    ///
     /// use std::collections::VecMap;
     ///
     /// let mut a = VecMap::new();
@@ -446,7 +458,8 @@ impl<V> VecMap<V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vecmap)]
+    /// #![feature(vecmap)]
+    ///
     /// use std::collections::VecMap;
     ///
     /// let mut a = VecMap::new();
@@ -464,7 +477,8 @@ impl<V> VecMap<V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vecmap)]
+    /// #![feature(vecmap)]
+    ///
     /// use std::collections::VecMap;
     ///
     /// let mut a = VecMap::new();
@@ -480,7 +494,8 @@ impl<V> VecMap<V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vecmap)]
+    /// #![feature(vecmap)]
+    ///
     /// use std::collections::VecMap;
     ///
     /// let mut map = VecMap::new();
@@ -505,7 +520,8 @@ impl<V> VecMap<V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vecmap)]
+    /// #![feature(vecmap)]
+    ///
     /// use std::collections::VecMap;
     ///
     /// let mut map = VecMap::new();
@@ -524,7 +540,8 @@ impl<V> VecMap<V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vecmap)]
+    /// #![feature(vecmap)]
+    ///
     /// use std::collections::VecMap;
     ///
     /// let mut map = VecMap::new();
@@ -552,7 +569,8 @@ impl<V> VecMap<V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vecmap)]
+    /// #![feature(vecmap)]
+    ///
     /// use std::collections::VecMap;
     ///
     /// let mut map = VecMap::new();
@@ -578,7 +596,8 @@ impl<V> VecMap<V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vecmap)]
+    /// #![feature(vecmap)]
+    ///
     /// use std::collections::VecMap;
     ///
     /// let mut map = VecMap::new();
@@ -600,7 +619,8 @@ impl<V> VecMap<V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vecmap, entry)]
+    /// #![feature(vecmap, entry)]
+    ///
     /// use std::collections::VecMap;
     ///
     /// let mut count: VecMap<u32> = VecMap::new();
@@ -778,7 +798,8 @@ impl<T> IntoIterator for VecMap<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vecmap)]
+    /// #![feature(vecmap)]
+    ///
     /// use std::collections::VecMap;
     ///
     /// let mut map = VecMap::new();

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -221,7 +221,8 @@ impl<T:Copy> Cell<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(as_unsafe_cell)]
+    /// #![feature(as_unsafe_cell)]
+    ///
     /// use std::cell::Cell;
     ///
     /// let c = Cell::new(5);
@@ -589,7 +590,8 @@ impl<'b, T: ?Sized> Ref<'b, T> {
     /// # Example
     ///
     /// ```
-    /// # #![feature(cell_extras)]
+    /// #![feature(cell_extras)]
+    ///
     /// use std::cell::{RefCell, Ref};
     ///
     /// let c = RefCell::new((5, 'b'));

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -383,7 +383,8 @@ pub fn max<T: Ord>(v1: T, v2: T) -> T {
 /// # Examples
 ///
 /// ```
-/// # #![feature(cmp_partial)]
+/// #![feature(cmp_partial)]
+///
 /// use std::cmp;
 ///
 /// assert_eq!(Some(1), cmp::partial_min(1, 2));
@@ -393,7 +394,8 @@ pub fn max<T: Ord>(v1: T, v2: T) -> T {
 /// When comparison is impossible:
 ///
 /// ```
-/// # #![feature(cmp_partial)]
+/// #![feature(cmp_partial)]
+///
 /// use std::cmp;
 ///
 /// let result = cmp::partial_min(std::f64::NAN, 1.0);
@@ -416,7 +418,8 @@ pub fn partial_min<T: PartialOrd>(v1: T, v2: T) -> Option<T> {
 /// # Examples
 ///
 /// ```
-/// # #![feature(cmp_partial)]
+/// #![feature(cmp_partial)]
+///
 /// use std::cmp;
 ///
 /// assert_eq!(Some(2), cmp::partial_max(1, 2));
@@ -426,7 +429,8 @@ pub fn partial_min<T: PartialOrd>(v1: T, v2: T) -> Option<T> {
 /// When comparison is impossible:
 ///
 /// ```
-/// # #![feature(cmp_partial)]
+/// #![feature(cmp_partial)]
+///
 /// use std::cmp;
 ///
 /// let result = cmp::partial_max(std::f64::NAN, 1.0);

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -167,7 +167,8 @@ pub struct RadixFmt<T, R>(T, R);
 /// # Examples
 ///
 /// ```
-/// # #![feature(fmt_radix)]
+/// #![feature(fmt_radix)]
+///
 /// use std::fmt::radix;
 /// assert_eq!(format!("{}", radix(55, 36)), "1j".to_string());
 /// ```

--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -16,7 +16,8 @@
 //! # Examples
 //!
 //! ```rust
-//! # #![feature(hash_default)]
+//! #![feature(hash_default)]
+//!
 //! use std::hash::{hash, Hash, SipHasher};
 //!
 //! #[derive(Hash)]
@@ -36,7 +37,8 @@
 //! the trait `Hash`:
 //!
 //! ```rust
-//! # #![feature(hash_default)]
+//! #![feature(hash_default)]
+//!
 //! use std::hash::{hash, Hash, Hasher, SipHasher};
 //!
 //! struct Person {

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -822,7 +822,8 @@ pub trait Iterator {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(iter_min_max)]
+    /// #![feature(iter_min_max)]
+    ///
     /// use std::iter::MinMaxResult::{NoElements, OneElement, MinMax};
     ///
     /// let a: [i32; 0] = [];
@@ -894,7 +895,8 @@ pub trait Iterator {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(iter_cmp)]
+    /// #![feature(iter_cmp)]
+    ///
     /// let a = [-3_i32, 0, 1, 5, -10];
     /// assert_eq!(*a.iter().max_by(|x| x.abs()).unwrap(), -10);
     /// ```
@@ -922,7 +924,8 @@ pub trait Iterator {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(iter_cmp)]
+    /// #![feature(iter_cmp)]
+    ///
     /// let a = [-3_i32, 0, 1, 5, -10];
     /// assert_eq!(*a.iter().min_by(|x| x.abs()).unwrap(), 0);
     /// ```
@@ -1061,7 +1064,8 @@ pub trait Iterator {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(iter_arith)]
+    /// #![feature(iter_arith)]
+    ///
     /// let a = [1, 2, 3, 4, 5];
     /// let it = a.iter();
     /// assert_eq!(it.sum::<i32>(), 15);
@@ -1079,7 +1083,8 @@ pub trait Iterator {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(iter_arith)]
+    /// #![feature(iter_arith)]
+    ///
     /// fn factorial(n: u32) -> u32 {
     ///     (1..).take_while(|&i| i <= n).product()
     /// }
@@ -1359,7 +1364,8 @@ impl<T: Clone> MinMaxResult<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(iter_min_max)]
+    /// #![feature(iter_min_max)]
+    ///
     /// use std::iter::MinMaxResult::{self, NoElements, OneElement, MinMax};
     ///
     /// let r: MinMaxResult<i32> = NoElements;
@@ -2751,7 +2757,8 @@ impl<A: Step> ops::Range<A> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(step_by)]
+    /// #![feature(step_by)]
+    ///
     /// for i in (0..10).step_by(2) {
     ///     println!("{}", i);
     /// }

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -274,7 +274,8 @@ impl<T> Option<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(as_slice)]
+    /// #![feature(as_slice)]
+    ///
     /// let mut x = Some("Diamonds");
     /// {
     ///     let v = x.as_mut_slice();

--- a/src/libcore/raw.rs
+++ b/src/libcore/raw.rs
@@ -49,7 +49,8 @@ use mem;
 /// # Examples
 ///
 /// ```
-/// # #![feature(raw)]
+/// #![feature(raw)]
+///
 /// use std::raw::{self, Repr};
 ///
 /// let slice: &[u16] = &[1, 2, 3, 4];
@@ -98,7 +99,8 @@ impl<T> Clone for Slice<T> {
 /// # Examples
 ///
 /// ```
-/// # #![feature(raw)]
+/// #![feature(raw)]
+///
 /// use std::mem;
 /// use std::raw;
 ///

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -420,7 +420,8 @@ impl<T, E> Result<T, E> {
     /// Converts from `Result<T, E>` to `&mut [T]` (without copying)
     ///
     /// ```
-    /// # #![feature(as_slice)]
+    /// #![feature(as_slice)]
+    ///
     /// let mut x: Result<&str, u32> = Ok("Gold");
     /// {
     ///     let v = x.as_mut_slice();

--- a/src/libcore/simd.rs
+++ b/src/libcore/simd.rs
@@ -19,7 +19,8 @@
 //! provided beyond this module.
 //!
 //! ```rust
-//! # #![feature(core_simd)]
+//! #![feature(core_simd)]
+//!
 //! fn main() {
 //!     use std::simd::f32x4;
 //!     let a = f32x4(40.0, 41.0, 42.0, 43.0);

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -47,7 +47,8 @@
 //! which is cyclic.
 //!
 //! ```rust
-//! # #![feature(rustc_private, core, into_cow)]
+//! #![feature(rustc_private, core, into_cow)]
+//!
 //! use std::borrow::IntoCow;
 //! use std::io::Write;
 //! use graphviz as dot;
@@ -149,7 +150,8 @@
 //! entity `&sube`).
 //!
 //! ```rust
-//! # #![feature(rustc_private, core, into_cow)]
+//! #![feature(rustc_private, core, into_cow)]
+//!
 //! use std::borrow::IntoCow;
 //! use std::io::Write;
 //! use graphviz as dot;
@@ -207,7 +209,8 @@
 //! Hasse-diagram for the subsets of the set `{x, y}`.
 //!
 //! ```rust
-//! # #![feature(rustc_private, core, into_cow)]
+//! #![feature(rustc_private, core, into_cow)]
+//!
 //! use std::borrow::IntoCow;
 //! use std::io::Write;
 //! use graphviz as dot;

--- a/src/librustc_bitflags/lib.rs
+++ b/src/librustc_bitflags/lib.rs
@@ -34,8 +34,8 @@
 /// # Examples
 ///
 /// ```{.rust}
-/// # #![feature(rustc_private)]
-/// # #![feature(associated_consts)]
+/// #![feature(rustc_private)]
+/// #![feature(associated_consts)]
 /// #[macro_use] extern crate rustc_bitflags;
 ///
 /// bitflags! {
@@ -62,7 +62,7 @@
 /// The generated `struct`s can also be extended with type and trait implementations:
 ///
 /// ```{.rust}
-/// # #![feature(rustc_private)]
+/// #![feature(rustc_private)]
 /// #[macro_use] extern crate rustc_bitflags;
 ///
 /// use std::fmt;

--- a/src/librustc_unicode/char.rs
+++ b/src/librustc_unicode/char.rs
@@ -278,7 +278,8 @@ impl char {
     /// In both of these examples, 'ß' takes two bytes to encode.
     ///
     /// ```
-    /// # #![feature(unicode)]
+    /// #![feature(unicode)]
+    ///
     /// let mut b = [0; 2];
     ///
     /// let result = 'ß'.encode_utf8(&mut b);
@@ -289,7 +290,8 @@ impl char {
     /// A buffer that's too small:
     ///
     /// ```
-    /// # #![feature(unicode)]
+    /// #![feature(unicode)]
+    ///
     /// let mut b = [0; 1];
     ///
     /// let result = 'ß'.encode_utf8(&mut b);
@@ -315,7 +317,8 @@ impl char {
     /// In both of these examples, 'ß' takes one `u16` to encode.
     ///
     /// ```
-    /// # #![feature(unicode)]
+    /// #![feature(unicode)]
+    ///
     /// let mut b = [0; 1];
     ///
     /// let result = 'ß'.encode_utf16(&mut b);
@@ -326,7 +329,8 @@ impl char {
     /// A buffer that's too small:
     ///
     /// ```
-    /// # #![feature(unicode)]
+    /// #![feature(unicode)]
+    ///
     /// let mut b = [0; 0];
     ///
     /// let result = 'ß'.encode_utf8(&mut b);

--- a/src/librustc_unicode/u_str.rs
+++ b/src/librustc_unicode/u_str.rs
@@ -494,7 +494,8 @@ impl<'a> Iterator for Utf16Items<'a> {
 /// # Examples
 ///
 /// ```
-/// # #![feature(unicode)]
+/// #![feature(unicode)]
+///
 /// extern crate rustc_unicode;
 ///
 /// use rustc_unicode::str::Utf16Item::{ScalarValue, LoneSurrogate};

--- a/src/libserialize/hex.rs
+++ b/src/libserialize/hex.rs
@@ -30,7 +30,8 @@ impl ToHex for [u8] {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(rustc_private)]
+    /// #![feature(rustc_private)]
+    ///
     /// extern crate serialize;
     /// use serialize::hex::ToHex;
     ///
@@ -100,7 +101,8 @@ impl FromHex for str {
     /// This converts a string literal to hexadecimal and back.
     ///
     /// ```
-    /// # #![feature(rustc_private)]
+    /// #![feature(rustc_private)]
+    ///
     /// extern crate serialize;
     /// use serialize::hex::{FromHex, ToHex};
     ///

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -122,7 +122,8 @@ pub trait AsciiExt {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(ascii)]
+    /// #![feature(ascii)]
+    ///
     /// use std::ascii::AsciiExt;
     ///
     /// let mut ascii = 'a';
@@ -141,7 +142,8 @@ pub trait AsciiExt {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(ascii)]
+    /// #![feature(ascii)]
+    ///
     /// use std::ascii::AsciiExt;
     ///
     /// let mut ascii = 'A';

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -543,7 +543,8 @@ impl<K, V, S> HashMap<K, V, S>
     /// # Examples
     ///
     /// ```
-    /// # #![feature(hashmap_hasher)]
+    /// #![feature(hashmap_hasher)]
+    ///
     /// use std::collections::HashMap;
     /// use std::collections::hash_map::RandomState;
     ///
@@ -572,7 +573,8 @@ impl<K, V, S> HashMap<K, V, S>
     /// # Examples
     ///
     /// ```
-    /// # #![feature(hashmap_hasher)]
+    /// #![feature(hashmap_hasher)]
+    ///
     /// use std::collections::HashMap;
     /// use std::collections::hash_map::RandomState;
     ///
@@ -979,7 +981,8 @@ impl<K, V, S> HashMap<K, V, S>
     /// # Examples
     ///
     /// ```
-    /// # #![feature(drain)]
+    /// #![feature(drain)]
+    ///
     /// use std::collections::HashMap;
     ///
     /// let mut a = HashMap::new();

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -154,7 +154,8 @@ impl<T, S> HashSet<T, S>
     /// # Examples
     ///
     /// ```
-    /// # #![feature(hashmap_hasher)]
+    /// #![feature(hashmap_hasher)]
+    ///
     /// use std::collections::HashSet;
     /// use std::collections::hash_map::RandomState;
     ///
@@ -179,7 +180,8 @@ impl<T, S> HashSet<T, S>
     /// # Examples
     ///
     /// ```
-    /// # #![feature(hashmap_hasher)]
+    /// #![feature(hashmap_hasher)]
+    ///
     /// use std::collections::HashSet;
     /// use std::collections::hash_map::RandomState;
     ///

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -141,7 +141,8 @@ macro_rules! try {
 /// # Examples
 ///
 /// ```
-/// # #![feature(mpsc_select)]
+/// #![feature(mpsc_select)]
+///
 /// use std::thread;
 /// use std::sync::mpsc;
 ///

--- a/src/libstd/net/mod.rs
+++ b/src/libstd/net/mod.rs
@@ -103,7 +103,8 @@ impl Iterator for LookupHost {
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(lookup_host)]
+/// #![feature(lookup_host)]
+///
 /// use std::net;
 ///
 /// # fn foo() -> std::io::Result<()> {

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -235,7 +235,8 @@ impl f32 {
     /// The floating point encoding is documented in the [Reference][floating-point].
     ///
     /// ```
-    /// # #![feature(float_extras)]
+    /// #![feature(float_extras)]
+    ///
     /// use std::f32;
     ///
     /// let num = 2.0f32;
@@ -598,7 +599,8 @@ impl f32 {
     /// Converts radians to degrees.
     ///
     /// ```
-    /// # #![feature(float_extras)]
+    /// #![feature(float_extras)]
+    ///
     /// use std::f32::{self, consts};
     ///
     /// let angle = consts::PI;
@@ -614,7 +616,8 @@ impl f32 {
     /// Converts degrees to radians.
     ///
     /// ```
-    /// # #![feature(float_extras)]
+    /// #![feature(float_extras)]
+    ///
     /// use std::f32::{self, consts};
     ///
     /// let angle = 180.0f32;
@@ -630,7 +633,8 @@ impl f32 {
     /// Constructs a floating point number of `x*2^exp`.
     ///
     /// ```
-    /// # #![feature(float_extras)]
+    /// #![feature(float_extras)]
+    ///
     /// use std::f32;
     /// // 3*2^2 - 12 == 0
     /// let abs_difference = (f32::ldexp(3.0, 2) - 12.0).abs();
@@ -651,7 +655,8 @@ impl f32 {
     ///  * `0.5 <= abs(x) < 1.0`
     ///
     /// ```
-    /// # #![feature(float_extras)]
+    /// #![feature(float_extras)]
+    ///
     /// use std::f32;
     ///
     /// let x = 4.0f32;
@@ -679,7 +684,8 @@ impl f32 {
     /// `other`.
     ///
     /// ```
-    /// # #![feature(float_extras)]
+    /// #![feature(float_extras)]
+    ///
     /// use std::f32;
     ///
     /// let x = 1.0f32;

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -191,7 +191,8 @@ impl f64 {
     /// The floating point encoding is documented in the [Reference][floating-point].
     ///
     /// ```
-    /// # #![feature(float_extras)]
+    /// #![feature(float_extras)]
+    ///
     /// let num = 2.0f64;
     ///
     /// // (8388608, -22, 1)
@@ -568,7 +569,8 @@ impl f64 {
     /// Constructs a floating point number of `x*2^exp`.
     ///
     /// ```
-    /// # #![feature(float_extras)]
+    /// #![feature(float_extras)]
+    ///
     /// // 3*2^2 - 12 == 0
     /// let abs_difference = (f64::ldexp(3.0, 2) - 12.0).abs();
     ///
@@ -588,7 +590,8 @@ impl f64 {
     ///  * `0.5 <= abs(x) < 1.0`
     ///
     /// ```
-    /// # #![feature(float_extras)]
+    /// #![feature(float_extras)]
+    ///
     /// let x = 4.0_f64;
     ///
     /// // (1/2)*2^3 -> 1 * 8/2 -> 4.0
@@ -614,7 +617,7 @@ impl f64 {
     /// `other`.
     ///
     /// ```
-    /// # #![feature(float_extras)]
+    /// #![feature(float_extras)]
     ///
     /// let x = 1.0f32;
     ///

--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -111,7 +111,8 @@ mod prim_unit { }
 /// the raw pointer. It doesn't destroy `T` or deallocate any memory.
 ///
 /// ```
-/// # #![feature(box_raw)]
+/// #![feature(box_raw)]
+///
 /// let my_speed: Box<i32> = Box::new(88);
 /// let my_speed: *mut i32 = Box::into_raw(my_speed);
 ///

--- a/src/libstd/sync/condvar.rs
+++ b/src/libstd/sync/condvar.rs
@@ -69,7 +69,8 @@ pub struct Condvar { inner: Box<StaticCondvar> }
 /// # Examples
 ///
 /// ```
-/// # #![feature(static_condvar)]
+/// #![feature(static_condvar)]
+///
 /// use std::sync::{StaticCondvar, CONDVAR_INIT};
 ///
 /// static CVAR: StaticCondvar = CONDVAR_INIT;

--- a/src/libstd/sync/future.rs
+++ b/src/libstd/sync/future.rs
@@ -14,7 +14,8 @@
 //! # Examples
 //!
 //! ```
-//! # #![feature(future)]
+//! #![feature(future)]
+//!
 //! use std::sync::Future;
 //!
 //! // a fake, for now

--- a/src/libstd/sync/mpsc/select.rs
+++ b/src/libstd/sync/mpsc/select.rs
@@ -27,7 +27,8 @@
 //! # Examples
 //!
 //! ```rust
-//! # #![feature(mpsc_select)]
+//! #![feature(mpsc_select)]
+//!
 //! use std::sync::mpsc::channel;
 //!
 //! let (tx1, rx1) = channel();
@@ -124,7 +125,8 @@ impl Select {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(mpsc_select)]
+    /// #![feature(mpsc_select)]
+    ///
     /// use std::sync::mpsc::Select;
     ///
     /// let select = Select::new();

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -138,7 +138,8 @@ unsafe impl<T: ?Sized + Send> Sync for Mutex<T> { }
 /// # Examples
 ///
 /// ```
-/// # #![feature(static_mutex)]
+/// #![feature(static_mutex)]
+///
 /// use std::sync::{StaticMutex, MUTEX_INIT};
 ///
 /// static LOCK: StaticMutex = MUTEX_INIT;

--- a/src/libstd/sync/rwlock.rs
+++ b/src/libstd/sync/rwlock.rs
@@ -81,7 +81,8 @@ unsafe impl<T: ?Sized + Send + Sync> Sync for RwLock<T> {}
 /// # Examples
 ///
 /// ```
-/// # #![feature(static_rwlock)]
+/// #![feature(static_rwlock)]
+///
 /// use std::sync::{StaticRwLock, RW_LOCK_INIT};
 ///
 /// static LOCK: StaticRwLock = RW_LOCK_INIT;

--- a/src/libstd/sync/semaphore.rs
+++ b/src/libstd/sync/semaphore.rs
@@ -25,7 +25,8 @@ use sync::{Mutex, Condvar};
 /// # Examples
 ///
 /// ```
-/// # #![feature(semaphore)]
+/// #![feature(semaphore)]
+///
 /// use std::sync::Semaphore;
 ///
 /// // Create a semaphore that represents 5 resources

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -367,7 +367,8 @@ pub fn spawn<F, T>(f: F) -> JoinHandle<T> where
 /// a join before any relevant stack frames are popped:
 ///
 /// ```rust
-/// # #![feature(scoped)]
+/// #![feature(scoped)]
+///
 /// use std::thread;
 ///
 /// let guard = thread::scoped(move || {
@@ -447,7 +448,8 @@ pub fn panicking() -> bool {
 /// # Examples
 ///
 /// ```
-/// # #![feature(catch_panic)]
+/// #![feature(catch_panic)]
+///
 /// use std::thread;
 ///
 /// let result = thread::catch_panic(|| {

--- a/src/libstd/thread/scoped_tls.rs
+++ b/src/libstd/thread/scoped_tls.rs
@@ -24,7 +24,8 @@
 //! # Examples
 //!
 //! ```
-//! # #![feature(scoped_tls)]
+//! #![feature(scoped_tls)]
+//!
 //! scoped_thread_local!(static FOO: u32);
 //!
 //! // Initially each scoped slot is empty.
@@ -136,7 +137,8 @@ impl<T> ScopedKey<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(scoped_tls)]
+    /// #![feature(scoped_tls)]
+    ///
     /// scoped_thread_local!(static FOO: u32);
     ///
     /// FOO.set(&100, || {
@@ -189,7 +191,8 @@ impl<T> ScopedKey<T> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(scoped_tls)]
+    /// #![feature(scoped_tls)]
+    ///
     /// scoped_thread_local!(static FOO: u32);
     ///
     /// FOO.with(|slot| {


### PR DESCRIPTION
In spirit with https://internals.rust-lang.org/t/should-we-keep-including-obvious-imports-in-code-examples/2217, show the feature flags we're using in examples.

(also one instance of 'use')
