### PR TITLE
Fix buffer length in std::io::take

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -707,7 +707,7 @@ pub trait Read {
     ///
     /// # fn foo() -> io::Result<()> {
     /// let mut f = try!(File::open("foo.txt"));
-    /// let mut buffer = [0; 10];
+    /// let mut buffer = [0; 5];
     ///
     /// // read at most five bytes
     /// let mut handle = f.take(5);


### PR DESCRIPTION
This only reads five bytes, so don't use a ten byte buffer, that's confusing.

r? @alexcrichton 
