### PR TITLE
IO Docs: Fix Link in Cursor description

### DIFF
--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -15,10 +15,8 @@ use cmp;
 use io::{self, SeekFrom, Error, ErrorKind};
 use slice;
 
-/// A `Cursor` wraps another type and provides it with a [`Seek`][seek]
-/// implementation.
-///
-/// [seek]: trait.Seek.html
+/// A `Cursor` wraps another type and provides it with a
+/// [`Seek`](trait.Seek.html) implementation.
 ///
 /// Cursors are typically used with in-memory buffers to allow them to
 /// implement `Read` and/or `Write`, allowing these buffers to be used


### PR DESCRIPTION
The first paragraph of the docs of the Cursor struct ([src](https://github.com/rust-lang/rust/blob/ff6c6ce917bd6af9c5d9315708ae6be3ba0b7e91/src/libstd/io/cursor.rs#L18-L21)) contains a Markdown link. In listings (like http://doc.rust-lang.org/nightly/std/io/), this won't get rendered:

![std__io_-_rust](https://cloud.githubusercontent.com/assets/20063/8925843/5c5281a8-350b-11e5-8c63-09a369d746b0.png)

The hotfix would be to change the link by reference:

``` rust
/// A `Cursor` wraps another type and provides it with a [`Seek`][seek]
/// implementation.
///
/// [seek]: trait.Seek.html
```

to a direct link:

``` rust
/// A `Cursor` wraps another type and provides it with a
/// [`Seek`](trait.Seek.html) implementation.
```

_I have not tested this as I don't have access to a machine for compiling Rust right now._

(This seems to be a more general issue, but I think I have seen this mentioned before. This PR is just to hotfix on particular occurrence. Rustdoc seems to only read the first paragraph of a doc string for the description in index pages, and _after that_ convert Markdown to HTML.)

r? @steveklabnik
