### PR TITLE
Fix DST size_of_val and align_of_val computations

### DIFF
--- a/src/librustc_trans/trans/glue.rs
+++ b/src/librustc_trans/trans/glue.rs
@@ -406,8 +406,12 @@ pub fn size_and_align_of_dst<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, t: Ty<'tcx>, in
            t, bcx.val_to_string(info));
     if type_is_sized(bcx.tcx(), t) {
         let sizing_type = sizing_type_of(bcx.ccx(), t);
-        let size = C_uint(bcx.ccx(), llsize_of_alloc(bcx.ccx(), sizing_type));
-        let align = C_uint(bcx.ccx(), align_of(bcx.ccx(), t));
+        let size = llsize_of_alloc(bcx.ccx(), sizing_type);
+        let align = align_of(bcx.ccx(), t);
+        debug!("size_and_align_of_dst t={} info={} size: {} align: {}",
+               t, bcx.val_to_string(info), size, align);
+        let size = C_uint(bcx.ccx(), size);
+        let align = C_uint(bcx.ccx(), align);
         return (size, align);
     }
     match t.sty {
@@ -417,9 +421,14 @@ pub fn size_and_align_of_dst<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, t: Ty<'tcx>, in
             // Don't use type_of::sizing_type_of because that expects t to be sized.
             assert!(!t.is_simd(bcx.tcx()));
             let repr = adt::represent_type(ccx, t);
-            let sizing_type = adt::sizing_type_of(ccx, &*repr, true);
-            let sized_size = C_uint(ccx, llsize_of_alloc(ccx, sizing_type));
-            let sized_align = C_uint(ccx, llalign_of_min(ccx, sizing_type));
+            let sizing_type = adt::sizing_type_context_of(ccx, &*repr, true);
+            debug!("DST {} sizing_type: {}", t, sizing_type.to_string());
+            let sized_size = llsize_of_alloc(ccx, sizing_type.prefix());
+            let sized_align = llalign_of_min(ccx, sizing_type.prefix());
+            debug!("DST {} statically sized prefix size: {} align: {}",
+                   t, sized_size, sized_align);
+            let sized_size = C_uint(ccx, sized_size);
+            let sized_align = C_uint(ccx, sized_align);
 
             // Recurse to get the size of the dynamically sized field (must be
             // the last field).
@@ -428,8 +437,22 @@ pub fn size_and_align_of_dst<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, t: Ty<'tcx>, in
             let field_ty = last_field.mt.ty;
             let (unsized_size, unsized_align) = size_and_align_of_dst(bcx, field_ty, info);
 
+            // #27023 FIXME: We should be adding any necessary padding
+            // to `sized_size` (to accommodate the `unsized_align`
+            // required of the unsized field that follows) before
+            // summing it with `sized_size`.
+
             // Return the sum of sizes and max of aligns.
-            let size = Add(bcx, sized_size, unsized_size, DebugLoc::None);
+            let mut size = Add(bcx, sized_size, unsized_size, DebugLoc::None);
+
+            // Issue #27023: If there is a drop flag, *now* we add 1
+            // to the size.  (We can do this without adding any
+            // padding because drop flags do not have any alignment
+            // constraints.)
+            if sizing_type.needs_drop_flag() {
+                size = Add(bcx, size, C_uint(bcx.ccx(), 1_u64), DebugLoc::None);
+            }
+
             let align = Select(bcx,
                                ICmp(bcx,
                                     llvm::IntULT,
@@ -438,6 +461,11 @@ pub fn size_and_align_of_dst<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, t: Ty<'tcx>, in
                                     DebugLoc::None),
                                sized_align,
                                unsized_align);
+
+            // #27023 FIXME: We should be adding any necessary padding
+            // to `size` (to make it a multiple of `align`) before
+            // returning it.
+
             (size, align)
         }
         ty::TyTrait(..) => {

--- a/src/librustc_trans/trans/glue.rs
+++ b/src/librustc_trans/trans/glue.rs
@@ -439,10 +439,12 @@ pub fn size_and_align_of_dst<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, t: Ty<'tcx>, in
 
             let dbloc = DebugLoc::None;
 
-            // #27023 FIXME: We should be adding any necessary padding
+            // FIXME (#26403, #27023): We should be adding padding
             // to `sized_size` (to accommodate the `unsized_align`
             // required of the unsized field that follows) before
-            // summing it with `sized_size`.
+            // summing it with `sized_size`. (Note that since #26403
+            // is unfixed, we do not yet add the necessary padding
+            // here. But this is where the add would go.)
 
             // Return the sum of sizes and max of aligns.
             let mut size = Add(bcx, sized_size, unsized_size, dbloc);

--- a/src/librustc_trans/trans/type_.rs
+++ b/src/librustc_trans/trans/type_.rs
@@ -50,6 +50,12 @@ impl Type {
         self.rf
     }
 
+    pub fn to_string(self: Type) -> String {
+        llvm::build_string(|s| unsafe {
+            llvm::LLVMWriteTypeToString(self.to_ref(), s);
+        }).expect("non-UTF8 type description from LLVM")
+    }
+
     pub fn void(ccx: &CrateContext) -> Type {
         ty!(llvm::LLVMVoidTypeInContext(ccx.llcx()))
     }
@@ -315,9 +321,7 @@ impl TypeNames {
     }
 
     pub fn type_to_string(&self, ty: Type) -> String {
-        llvm::build_string(|s| unsafe {
-                llvm::LLVMWriteTypeToString(ty.to_ref(), s);
-            }).expect("non-UTF8 type description from LLVM")
+        ty.to_string()
     }
 
     pub fn types_to_str(&self, tys: &[Type]) -> String {


### PR DESCRIPTION
Change the behavior of the glue code emitted for `size_and_align_of_dst`.

This thus changes the behavior of `std::mem::size_of_val` and `std::mem::align_of_val`.  It tries to move us towards a world where the following property holds:

Given type `T` implements `Trait` and a value `b: Box<T>`, where `std::mem::size_of::<T>()` returns `k`, then:
- `std::mem::size_of_val(b)` returns `k`
- `std::mem::size_of_val(b as Box<Trait>)` returns `k`

Note that one might legitimately question whether the above property _should_ hold.  The property certainly does not hold today, as illustrated by #27023.

(A follow-up task is to make various tests that check that the above property holds for a wide variety of types ... I chose not to invest effort in writing such a test before we actually determine that the above property is desirable.)

nmatsakis and pnkfelix agree that this PR does not require an RFC.  cc @rust-lang/lang (since others may disagree).

(It also _might_ break code, though it is hard for me to imagine that it could break code that wasn't already going to assert-fail when run in e.g. debug builds...)

Fix issue #27023

Also, this (or something like it) is a prerequisite for _fixing`make check` on `--enable-optimize --enable-debug` builds_
