### PR TITLE
Use raw pointers to avoid aliasing violation in split_at_mut

### DIFF
--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -288,11 +288,12 @@ impl<T> SliceExt for [T] {
 
     #[inline]
     fn split_at_mut(&mut self, mid: usize) -> (&mut [T], &mut [T]) {
+        let len = self.len();
+        let ptr = self.as_mut_ptr();
+        assert!(mid <= len);
         unsafe {
-            let self2: &mut [T] = mem::transmute_copy(&self);
-
-            (ops::IndexMut::index_mut(self, ops::RangeTo { end: mid } ),
-             ops::IndexMut::index_mut(self2, ops::RangeFrom { start: mid } ))
+            (from_raw_parts_mut(ptr, mid),
+             from_raw_parts_mut(ptr.offset(mid as isize), len - mid))
         }
     }
 


### PR DESCRIPTION
Use raw pointers to avoid aliasing violation in split_at_mut

Fixes #27357
