### PR TITLE
std: Deprecate extra TcpStream/UdpSocket methods

### DIFF
--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -129,6 +129,9 @@ impl TcpStream {
     }
 
     /// Sets the nodelay flag on this connection to the boolean specified.
+    #[deprecated(since = "1.3.0",
+                 reason = "available through the `net2` crate on crates.io")]
+    #[unstable(feature = "tcp_extras", reason = "available externally")]
     pub fn set_nodelay(&self, nodelay: bool) -> io::Result<()> {
         self.0.set_nodelay(nodelay)
     }
@@ -138,6 +141,9 @@ impl TcpStream {
     /// If the value specified is `None`, then the keepalive flag is cleared on
     /// this connection. Otherwise, the keepalive timeout will be set to the
     /// specified time, in seconds.
+    #[unstable(feature = "tcp_extras", reason = "available externally")]
+    #[deprecated(since = "1.3.0",
+                 reason = "available through the `net2` crate on crates.io")]
     pub fn set_keepalive(&self, seconds: Option<u32>) -> io::Result<()> {
         self.0.set_keepalive(seconds)
     }

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -98,6 +98,9 @@ impl UdpSocket {
     }
 
     /// Sets the broadcast flag on or off.
+    #[deprecated(since = "1.3.0",
+                 reason = "available through the `net2` crate on crates.io")]
+    #[unstable(feature = "udp_extras", reason = "available externally")]
     pub fn set_broadcast(&self, on: bool) -> io::Result<()> {
         self.0.set_broadcast(on)
     }
@@ -105,26 +108,41 @@ impl UdpSocket {
     /// Sets the multicast loop flag to the specified value.
     ///
     /// This lets multicast packets loop back to local sockets (if enabled)
+    #[deprecated(since = "1.3.0",
+                 reason = "available through the `net2` crate on crates.io")]
+    #[unstable(feature = "udp_extras", reason = "available externally")]
     pub fn set_multicast_loop(&self, on: bool) -> io::Result<()> {
         self.0.set_multicast_loop(on)
     }
 
     /// Joins a multicast IP address (becomes a member of it).
+    #[deprecated(since = "1.3.0",
+                 reason = "available through the `net2` crate on crates.io")]
+    #[unstable(feature = "udp_extras", reason = "available externally")]
     pub fn join_multicast(&self, multi: &IpAddr) -> io::Result<()> {
         self.0.join_multicast(multi)
     }
 
     /// Leaves a multicast IP address (drops membership from it).
+    #[deprecated(since = "1.3.0",
+                 reason = "available through the `net2` crate on crates.io")]
+    #[unstable(feature = "udp_extras", reason = "available externally")]
     pub fn leave_multicast(&self, multi: &IpAddr) -> io::Result<()> {
         self.0.leave_multicast(multi)
     }
 
     /// Sets the multicast TTL.
+    #[deprecated(since = "1.3.0",
+                 reason = "available through the `net2` crate on crates.io")]
+    #[unstable(feature = "udp_extras", reason = "available externally")]
     pub fn set_multicast_time_to_live(&self, ttl: i32) -> io::Result<()> {
         self.0.multicast_time_to_live(ttl)
     }
 
     /// Sets this socket's TTL.
+    #[deprecated(since = "1.3.0",
+                 reason = "available through the `net2` crate on crates.io")]
+    #[unstable(feature = "udp_extras", reason = "available externally")]
     pub fn set_time_to_live(&self, ttl: i32) -> io::Result<()> {
         self.0.time_to_live(ttl)
     }


### PR DESCRIPTION
These methods are all covered by [RFC 1158](https://github.com/rust-lang/rfcs/pull/1158) and are currently all available on
stable Rust via the [`net2` crate](http://crates.io/crates/net2) on crates.io. This commit does not
touch the timeout related functions as they're still waiting on `Duration` which
is unstable anyway, so punting in favor of the `net2` crate wouldn't buy much.
