### PR TITLE
Docs: Mention vec![x; len] syntax in Vec<T> docs, fix inconsistent use

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -112,6 +112,13 @@ use super::range::RangeArgument;
 /// assert_eq!(vec, [1, 2, 3, 4]);
 /// ```
 ///
+/// It can also initialize each element of a `Vec<T>` with a given value:
+///
+/// ```
+/// let vec = vec![0; 5];
+/// assert_eq!(vec, [0, 0, 0, 0, 0]);
+/// ```
+///
 /// Use a `Vec<T>` as an efficient stack:
 ///
 /// ```

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -581,7 +581,7 @@ impl<T> Vec<T> {
     /// # Examples
     ///
     /// ```
-    /// let mut vec = vec!(1, 2);
+    /// let mut vec = vec![1, 2];
     /// vec.push(3);
     /// assert_eq!(vec, [1, 2, 3]);
     /// ```


### PR DESCRIPTION
Noticed that syntax like `vec![0; 5]` is never mentioned in `Vec<T>`'s docs, nor used in any of its methods' docs, so I figured I should add a mention of it. Also noticed `vec!(1, 2)` being used in one spot while I was at it, so I fixed that as well for consistency's sake.

r? @steveklabnik
