### PR TITLE
Fix a documentation bug for memory orderings

### DIFF
--- a/src/libcore/atomic.rs
+++ b/src/libcore/atomic.rs
@@ -145,7 +145,7 @@ unsafe impl<T> Sync for AtomicPtr<T> {}
 /// "relaxed" atomics allow all reorderings.
 ///
 /// Rust's memory orderings are [the same as
-/// C++'s](http://gcc.gnu.org/wiki/Atomic/GCCMM/AtomicSync).
+/// LLVM's](http://llvm.org/docs/LangRef.html#memory-model-for-concurrent-operations).
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Copy, Clone)]
 pub enum Ordering {


### PR DESCRIPTION
As described in the module documentation, the memory orderings in Rust
are the same with that of LLVM.  However, the documentation for the
memory orderings enum says the memory orderings are the same of that of
C++.  Note that they differ in that C++'s support the consume reads,
while LLVM's does not.  Hence this commit fixes the bug in the
documentation for the enum.
