### PR TITLE
Update the ctags rules and targets.

### DIFF
--- a/mk/ctags.mk
+++ b/mk/ctags.mk
@@ -15,24 +15,11 @@
 
 .PHONY: TAGS.emacs TAGS.vi
 
-# This is using a blacklist approach, probably more durable than a whitelist.
-# We exclude: external dependencies (llvm, rt/{msvc,vg}),
-# tests (compiletest, test) and a couple of other things (rt/arch, etc)
-CTAGS_LOCATIONS=$(patsubst ${CFG_SRC_DIR}src/llvm,, \
-				$(patsubst ${CFG_SRC_DIR}src/compiletest,, \
-				$(patsubst ${CFG_SRC_DIR}src/test,, \
-				$(patsubst ${CFG_SRC_DIR}src/etc,, \
-				$(patsubst ${CFG_SRC_DIR}src/rt,, \
-				$(patsubst ${CFG_SRC_DIR}src/rt/arch,, \
-				$(patsubst ${CFG_SRC_DIR}src/rt/msvc,, \
-				$(patsubst ${CFG_SRC_DIR}src/rt/vg,, \
-				$(wildcard ${CFG_SRC_DIR}src/*) $(wildcard ${CFG_SRC_DIR}src/rt/*) \
-				))))))))
-CTAGS_OPTS=--options="${CFG_SRC_DIR}src/etc/ctags.rust" --languages=-javascript --recurse ${CTAGS_LOCATIONS}
-# We could use `--languages=Rust`, but there is value in producing tags for the
-# C++ parts of the code base too (at the time of writing, those are .h and .cpp
-# files in src/rt, src/rt/sync and src/rustllvm); we mainly just want to
-# exclude the external dependencies.
+CTAGS_LOCATIONS=$(wildcard ${CFG_SRC_DIR}src/lib*)
+CTAGS_LOCATIONS=$(patsubst ${CFG_SRC_DIR}src/librust%,, \
+                $(patsubst ${CFG_SRC_DIR}src/lib%test,, \
+				$(wildcard ${CFG_SRC_DIR}src/lib*))) ${CFG_SRC_DIR}src/libtest
+CTAGS_OPTS=--options="${CFG_SRC_DIR}src/etc/ctags.rust" --languages=Rust --recurse ${CTAGS_LOCATIONS}
 
 TAGS.emacs:
 	ctags -e -f $@ ${CTAGS_OPTS}

--- a/src/etc/ctags.rust
+++ b/src/etc/ctags.rust
@@ -5,7 +5,7 @@
 --regex-Rust=/^[ \t]*(pub[ \t]+)?enum[ \t]+([a-zA-Z0-9_]+)/\2/g,enum,enumeration names/
 --regex-Rust=/^[ \t]*(pub[ \t]+)?struct[ \t]+([a-zA-Z0-9_]+)/\2/s,structure names/
 --regex-Rust=/^[ \t]*(pub[ \t]+)?mod[ \t]+([a-zA-Z0-9_]+)/\2/m,modules,module names/
---regex-Rust=/^[ \t]*(pub[ \t]+)?static[ \t]+([a-zA-Z0-9_]+)/\2/c,consts,static constants/
---regex-Rust=/^[ \t]*(pub[ \t]+)?trait[ \t]+([a-zA-Z0-9_]+)/\2/t,traits,traits/
---regex-Rust=/^[ \t]*(pub[ \t]+)?impl([ \t\n]*<[^>]*>)?[ \t]+(([a-zA-Z0-9_:]+)[ \t]*(<[^>]*>)?[ \t]+(for)[ \t]+)?([a-zA-Z0-9_]+)/\4 \6 \7/i,impls,trait implementations/
+--regex-Rust=/^[ \t]*(pub[ \t]+)?(static|const)[ \t]+(mut[ \t]+)?([a-zA-Z0-9_]+)/\4/c,consts,static constants/
+--regex-Rust=/^[ \t]*(pub[ \t]+)?(unsafe[ \t]+)?trait[ \t]+([a-zA-Z0-9_]+)/\3/t,traits,traits/
+--regex-Rust=/^[ \t]*(pub[ \t]+)?(unsafe[ \t]+)?impl([ \t\n]*<[^>]*>)?[ \t]+(([a-zA-Z0-9_:]+)[ \t]*(<[^>]*>)?[ \t]+(for)[ \t]+)?([a-zA-Z0-9_]+)/\5 \7 \8/i,impls,trait implementations/
 --regex-Rust=/^[ \t]*macro_rules![ \t]+([a-zA-Z0-9_]+)/\1/d,macros,macro definitions/


### PR DESCRIPTION
As there’s no C++ runtime any more there’s really no point in having anything but Rust tags being made.

I’ve also taken the liberty of excluding the compiler parts of this in the `librust%,,` pattern substitution. Whether or not this is “correct” will depend on whether you want tags for the compiler or for general use. For myself, I want it for general use.

I’m not sure how much people use the tags files anyway. I definitely do, but with Racer existing the tags files aren’t quite so necessary.
