### PR TITLE
std: Remove the curious inner module

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -157,21 +157,23 @@ pub mod fmt;
 // note: does not need to be public
 mod tuple;
 
+// A curious inner-module that's not exported that contains the bindings of core
+// so that compiler-expanded references to `core::$foo` can be resolved within
+// core itself.
+//
+// Note that no crate-defined macros require this module due to the existence of
+// the `$crate` meta variable, only those expansions defined in the compiler
+// require this. This is because the compiler doesn't currently know that it's
+// compiling the core library when it's compiling this library, so it expands
+// all references to `::core::$foo`
 #[doc(hidden)]
 mod core {
-    pub use intrinsics;
-    pub use panicking;
-    pub use fmt;
-    pub use clone;
-    pub use cmp;
-    pub use hash;
-    pub use marker;
-    pub use option;
-    pub use iter;
-}
-
-#[doc(hidden)]
-mod std {
-    // range syntax
-    pub use ops;
+    pub use intrinsics;     // derive(PartialOrd)
+    pub use fmt;            // format_args!
+    pub use clone;          // derive(Clone)
+    pub use cmp;            // derive(Ord)
+    pub use hash;           // derive(Hash)
+    pub use marker;         // derive(Copy)
+    pub use option;         // iterator protocol
+    pub use iter;           // iterator protocol
 }

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -17,7 +17,7 @@ macro_rules! panic {
     );
     ($msg:expr) => ({
         static _MSG_FILE_LINE: (&'static str, &'static str, u32) = ($msg, file!(), line!());
-        ::core::panicking::panic(&_MSG_FILE_LINE)
+        $crate::panicking::panic(&_MSG_FILE_LINE)
     });
     ($fmt:expr, $($arg:tt)*) => ({
         // The leading _'s are to avoid dead code warnings if this is
@@ -25,7 +25,7 @@ macro_rules! panic {
         // insufficient, since the user may have
         // `#[forbid(dead_code)]` and which cannot be overridden.
         static _FILE_LINE: (&'static str, u32) = (file!(), line!());
-        ::core::panicking::panic_fmt(format_args!($fmt, $($arg)*), &_FILE_LINE)
+        $crate::panicking::panic_fmt(format_args!($fmt, $($arg)*), &_FILE_LINE)
     });
 }
 

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -20,7 +20,7 @@ use mem;
 use clone::Clone;
 use intrinsics;
 use ops::Deref;
-use core::fmt;
+use fmt;
 use option::Option::{self, Some, None};
 use marker::{PhantomData, Send, Sized, Sync};
 use nonzero::NonZero;

--- a/src/libcore/str/pattern.rs
+++ b/src/libcore/str/pattern.rs
@@ -17,7 +17,7 @@
             reason = "API not fully fleshed out and ready to be stabilized")]
 
 use prelude::*;
-use core::cmp;
+use cmp;
 use usize;
 
 // Pattern

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -421,27 +421,10 @@ pub mod __rand {
 // because rustdoc only looks for these modules at the crate level.
 include!("primitive_docs.rs");
 
-// A curious inner-module that's not exported that contains the binding
-// 'std' so that macro-expanded references to std::error and such
-// can be resolved within libstd.
-#[doc(hidden)]
+// The expansion of --test has a few references to `::std::$foo` so this module
+// is necessary to get things to compile.
+#[cfg(test)]
 mod std {
-    pub use sync; // used for select!()
-    pub use error; // used for try!()
-    pub use fmt; // used for any formatting strings
-    pub use option; // used for thread_local!{}
-    pub use rt; // used for panic!()
-    pub use vec; // used for vec![]
-    pub use cell; // used for tls!
-    pub use thread; // used for thread_local!
-    pub use marker;  // used for tls!
-
-    // The test runner calls ::std::env::args() but really wants realstd
-    #[cfg(test)] pub use realstd::env as env;
-    // The test runner requires std::slice::Vector, so re-export std::slice just for it.
-    //
-    // It is also used in vec![]
-    pub use slice;
-
-    pub use boxed; // used for vec![]
+    pub use option;
+    pub use realstd::env;
 }

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -799,7 +799,7 @@ mod tests {
     #[cfg(not(target_os="android"))]
     #[test]
     fn test_inherit_env() {
-        use std::env;
+        use env;
 
         let result = env_cmd().output().unwrap();
         let output = String::from_utf8(result.stdout).unwrap();

--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -1107,7 +1107,7 @@ impl error::Error for TryRecvError {
 mod tests {
     use prelude::v1::*;
 
-    use std::env;
+    use env;
     use super::*;
     use thread;
 
@@ -1655,7 +1655,7 @@ mod tests {
 mod sync_tests {
     use prelude::v1::*;
 
-    use std::env;
+    use env;
     use thread;
     use super::*;
 

--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -107,14 +107,14 @@ pub struct LocalKey<T> {
 #[cfg(not(no_elf_tls))]
 macro_rules! thread_local {
     (static $name:ident: $t:ty = $init:expr) => (
-        static $name: ::std::thread::LocalKey<$t> =
+        static $name: $crate::thread::LocalKey<$t> =
             __thread_local_inner!($t, $init,
                 #[cfg_attr(all(any(target_os = "macos", target_os = "linux"),
                                not(target_arch = "aarch64")),
                            thread_local)]);
     );
     (pub static $name:ident: $t:ty = $init:expr) => (
-        pub static $name: ::std::thread::LocalKey<$t> =
+        pub static $name: $crate::thread::LocalKey<$t> =
             __thread_local_inner!($t, $init,
                 #[cfg_attr(all(any(target_os = "macos", target_os = "linux"),
                                not(target_arch = "aarch64")),
@@ -128,11 +128,11 @@ macro_rules! thread_local {
 #[cfg(no_elf_tls)]
 macro_rules! thread_local {
     (static $name:ident: $t:ty = $init:expr) => (
-        static $name: ::std::thread::LocalKey<$t> =
+        static $name: $crate::thread::LocalKey<$t> =
             __thread_local_inner!($t, $init, #[]);
     );
     (pub static $name:ident: $t:ty = $init:expr) => (
-        pub static $name: ::std::thread::LocalKey<$t> =
+        pub static $name: $crate::thread::LocalKey<$t> =
             __thread_local_inner!($t, $init, #[]);
     );
 }
@@ -145,11 +145,11 @@ macro_rules! thread_local {
 macro_rules! __thread_local_inner {
     ($t:ty, $init:expr, #[$($attr:meta),*]) => {{
         $(#[$attr])*
-        static __KEY: ::std::thread::__LocalKeyInner<$t> =
-            ::std::thread::__LocalKeyInner::new();
+        static __KEY: $crate::thread::__LocalKeyInner<$t> =
+            $crate::thread::__LocalKeyInner::new();
         fn __init() -> $t { $init }
-        fn __getit() -> &'static ::std::thread::__LocalKeyInner<$t> { &__KEY }
-        ::std::thread::LocalKey::new(__getit, __init)
+        fn __getit() -> &'static $crate::thread::__LocalKeyInner<$t> { &__KEY }
+        $crate::thread::LocalKey::new(__getit, __init)
     }}
 }
 

--- a/src/libstd/thread/scoped_tls.rs
+++ b/src/libstd/thread/scoped_tls.rs
@@ -70,11 +70,11 @@ pub struct ScopedKey<T> { inner: fn() -> &'static imp::KeyInner<T> }
 #[allow_internal_unstable]
 macro_rules! scoped_thread_local {
     (static $name:ident: $t:ty) => (
-        static $name: ::std::thread::ScopedKey<$t> =
+        static $name: $crate::thread::ScopedKey<$t> =
             __scoped_thread_local_inner!($t);
     );
     (pub static $name:ident: $t:ty) => (
-        pub static $name: ::std::thread::ScopedKey<$t> =
+        pub static $name: $crate::thread::ScopedKey<$t> =
             __scoped_thread_local_inner!($t);
     );
 }
@@ -87,10 +87,10 @@ macro_rules! scoped_thread_local {
 #[cfg(no_elf_tls)]
 macro_rules! __scoped_thread_local_inner {
     ($t:ty) => {{
-        static _KEY: ::std::thread::__ScopedKeyInner<$t> =
-            ::std::thread::__ScopedKeyInner::new();
-        fn _getit() -> &'static ::std::thread::__ScopedKeyInner<$t> { &_KEY }
-        ::std::thread::ScopedKey::new(_getit)
+        static _KEY: $crate::thread::__ScopedKeyInner<$t> =
+            $crate::thread::__ScopedKeyInner::new();
+        fn _getit() -> &'static $crate::thread::__ScopedKeyInner<$t> { &_KEY }
+        $crate::thread::ScopedKey::new(_getit)
     }}
 }
 
@@ -109,10 +109,10 @@ macro_rules! __scoped_thread_local_inner {
                            target_os = "openbsd",
                            target_arch = "aarch64")),
                    thread_local)]
-        static _KEY: ::std::thread::__ScopedKeyInner<$t> =
-            ::std::thread::__ScopedKeyInner::new();
-        fn _getit() -> &'static ::std::thread::__ScopedKeyInner<$t> { &_KEY }
-        ::std::thread::ScopedKey::new(_getit)
+        static _KEY: $crate::thread::__ScopedKeyInner<$t> =
+            $crate::thread::__ScopedKeyInner::new();
+        fn _getit() -> &'static $crate::thread::__ScopedKeyInner<$t> { &_KEY }
+        $crate::thread::ScopedKey::new(_getit)
     }}
 }
 
@@ -225,7 +225,7 @@ impl<T> ScopedKey<T> {
               no_elf_tls)))]
 #[doc(hidden)]
 mod imp {
-    use std::cell::Cell;
+    use cell::Cell;
 
     pub struct KeyInner<T> { inner: Cell<*mut T> }
 


### PR DESCRIPTION
This isn't actually necessary any more with the advent of `$crate` and changes
in the compiler to expand macros to `::core::$foo` in the context of a
`#![no_std]` crate.

The libcore inner module was also trimmed down a bit to the bare bones.
