### PR TITLE
Add OsStr::from_platform_bytes()

### DIFF
--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -41,6 +41,7 @@ use mem;
 use string::String;
 use ops;
 use cmp;
+use str;
 use hash::{Hash, Hasher};
 use vec::Vec;
 
@@ -262,6 +263,23 @@ impl OsStr {
             self.to_str().map(|s| s.as_bytes())
         } else {
             Some(self.bytes())
+        }
+    }
+
+    /// Converts a byte slice to an `OsStr` slice.
+    ///
+    /// # Platform behavior
+    ///
+    /// On Unix systems, this is a no-op.
+    ///
+    /// On Windows systems, only UTF-8 byte sequences will successfully
+    /// convert; non UTF-8 data will produce `None`.
+    #[unstable(feature = "convert", reason = "recently added")]
+    pub fn from_bytes_slice(bytes: &[u8]) -> Option<&OsStr> {
+        if cfg!(windows) {
+            str::from_utf8(bytes).ok().map(|s| s.as_ref())
+        } else {
+            Some(unsafe { mem::transmute(bytes) })
         }
     }
 

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -77,6 +77,21 @@ impl OsString {
     ///
     /// On Windows system, only UTF-8 byte sequences will successfully
     /// convert; non UTF-8 data will produce `None`.
+    #[deprecated(reason = "Renamed to from_platform_bytes", since = "1.2.0")]
+    #[unstable(feature = "convert", reason = "recently added")]
+    pub fn from_bytes<B>(bytes: B) -> Option<OsString> where B: Into<Vec<u8>> {
+        OsString::from_platform_bytes(bytes)
+    }
+
+    /// Constructs an `OsString` from a byte sequence.
+    ///
+    /// # Platform behavior
+    ///
+    /// On Unix systems, any byte sequence can be successfully
+    /// converted into an `OsString`.
+    ///
+    /// On Windows system, only UTF-8 byte sequences will successfully
+    /// convert; non UTF-8 data will produce `None`.
     #[unstable(feature = "convert", reason = "recently added")]
     pub fn from_platform_bytes<B>(bytes: B) -> Option<OsString> where B: Into<Vec<u8>> {
         #[cfg(unix)]

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -279,7 +279,8 @@ impl OsStr {
         if cfg!(windows) {
             str::from_utf8(bytes).ok().map(|s| s.as_ref())
         } else {
-            Some(unsafe { mem::transmute(bytes) })
+            use os::unix::ffi::OsStrExt;
+            Some(<OsStr as OsStrExt>::from_bytes(bytes))
         }
     }
 

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -275,7 +275,7 @@ impl OsStr {
     /// On Windows systems, only UTF-8 byte sequences will successfully
     /// convert; non UTF-8 data will produce `None`.
     #[unstable(feature = "convert", reason = "recently added")]
-    pub fn from_bytes_slice(bytes: &[u8]) -> Option<&OsStr> {
+    pub fn from_platform_bytes(bytes: &[u8]) -> Option<&OsStr> {
         if cfg!(windows) {
             str::from_utf8(bytes).ok().map(|s| s.as_ref())
         } else {

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -78,7 +78,7 @@ impl OsString {
     /// On Windows system, only UTF-8 byte sequences will successfully
     /// convert; non UTF-8 data will produce `None`.
     #[unstable(feature = "convert", reason = "recently added")]
-    pub fn from_bytes<B>(bytes: B) -> Option<OsString> where B: Into<Vec<u8>> {
+    pub fn from_platform_bytes<B>(bytes: B) -> Option<OsString> where B: Into<Vec<u8>> {
         #[cfg(unix)]
         fn from_bytes_inner(vec: Vec<u8>) -> Option<OsString> {
             use os::unix::ffi::OsStringExt;

--- a/src/test/run-pass/osstr_conversions.rs
+++ b/src/test/run-pass/osstr_conversions.rs
@@ -30,12 +30,12 @@ fn main() {
 
     // Valid UTF-8
     let by1: &[u8] = b"t\xC3\xA9st";
-    let oss1: &OsStr = OsStr::from_bytes_slice(by1).unwrap();
+    let oss1: &OsStr = OsStr::from_platform_bytes(by1).unwrap();
     assert_eq!(oss1.to_bytes().unwrap().as_ptr(), by1.as_ptr());
     assert_eq!(oss1.to_str().unwrap().as_ptr(), by1.as_ptr());
     // Not UTF-8
     let by2: &[u8] = b"t\xE9st";
-    let oss2: &OsStr = OsStr::from_bytes_slice(by2).unwrap();
+    let oss2: &OsStr = OsStr::from_platform_bytes(by2).unwrap();
     if cfg!(windows) {
         assert_eq!(oss2.to_bytes(), None);
     } else {

--- a/src/test/run-pass/osstr_conversions.rs
+++ b/src/test/run-pass/osstr_conversions.rs
@@ -15,12 +15,12 @@ use std::ffi::{OsStr, OsString};
 fn main() {
     // Valid UTF-8
     let vec1: Vec<u8> = b"t\xC3\xA9st".to_vec();
-    let oso1: OsString = OsString::from_bytes(vec1).unwrap();
+    let oso1: OsString = OsString::from_platform_bytes(vec1).unwrap();
     assert!(oso1.to_bytes() == Some(b"t\xC3\xA9st"));
     assert!(oso1.to_str() == Some("t\u{E9}st"));
     // Not UTF-8
     let vec2: Vec<u8> = b"t\xE9st".to_vec();
-    let oso2: OsString = OsString::from_bytes(vec2).unwrap();
+    let oso2: OsString = OsString::from_platform_bytes(vec2).unwrap();
     if cfg!(windows) {
         assert!(oso2.to_bytes() == None);
     } else {

--- a/src/test/run-pass/osstr_conversions.rs
+++ b/src/test/run-pass/osstr_conversions.rs
@@ -1,0 +1,49 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(convert)]
+
+use std::ffi::{OsStr, OsString};
+
+fn main() {
+    // Valid UTF-8
+    let vec1: Vec<u8> = b"t\xC3\xA9st".to_vec();
+    let oso1: OsString = OsString::from_bytes(vec1).unwrap();
+    assert!(oso1.to_bytes() == Some(b"t\xC3\xA9st"));
+    assert!(oso1.to_str() == Some("t\u{E9}st"));
+    // Not UTF-8
+    let vec2: Vec<u8> = b"t\xE9st".to_vec();
+    let oso2: OsString = OsString::from_bytes(vec2).unwrap();
+    if cfg!(windows) {
+        assert!(oso2.to_bytes() == None);
+    } else {
+        assert!(oso2.to_bytes() == Some(b"t\xE9st"));
+    }
+    assert_eq!(oso2.to_str(), None);
+
+    // Valid UTF-8
+    let by1: &[u8] = b"t\xC3\xA9st";
+    let oss1: &OsStr = OsStr::from_bytes_slice(by1).unwrap();
+    assert_eq!(oss1.to_bytes().unwrap().as_ptr(), by1.as_ptr());
+    assert_eq!(oss1.to_str().unwrap().as_ptr(), by1.as_ptr());
+    // Not UTF-8
+    let by2: &[u8] = b"t\xE9st";
+    let oss2: &OsStr = OsStr::from_bytes_slice(by2).unwrap();
+    if cfg!(windows) {
+        assert_eq!(oss2.to_bytes(), None);
+    } else {
+        assert_eq!(oss2.to_bytes().unwrap().as_ptr(), by2.as_ptr());
+    }
+    assert_eq!(oss2.to_str(), None);
+
+    if cfg!(windows) {
+        // FIXME: needs valid-windows-utf16-invalid-unicode test cases
+    }
+}


### PR DESCRIPTION
Rebased #26730

`OsString::from_bytes()` turns `Vec<u8>` into `OsString`.

This adds the same thing, from `&[u8]` to `&OsStr`, and renames both of them to `from_platform_bytes()` to avoid conflict with `OsStrExt::from_bytes()` already available on UNIX.

I don't know if the last commit is needed (should from_bytes() just be removed without deprecation? It was never stable), let me know.
