### PR TITLE
Rename the unstable option `--xpretty` to `--unpretty`

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -828,8 +828,8 @@ pub fn rustc_optgroups() -> Vec<RustcOptGroup> {
                    `typed` (crates expanded, with type annotations), or
                    `expanded,identified` (fully parenthesized, AST nodes with IDs).",
                  "TYPE"),
-        opt::flagopt_u("", "xpretty",
-                     "Pretty-print the input instead of compiling, unstable variants;
+        opt::flagopt_u("", "unpretty",
+                     "Present the input source, unstable (and less-pretty) variants;
                       valid types are any of the types for `--pretty`, as well as:
                       `flowgraph=<nodeid>` (graphviz formatted flowgraph for node), or
                       `everybody_loops` (all function bodies replaced with `loop {}`).",

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -339,7 +339,7 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
             None
         };
         if pretty.is_none() && sess.unstable_options() {
-            matches.opt_str("xpretty").map(|a| {
+            matches.opt_str("unpretty").map(|a| {
                 // extended with unstable pretty-print variants
                 pretty::parse_pretty(sess, &a, true)
             })

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -60,7 +60,7 @@ pub enum PpSourceMode {
 pub enum PpFlowGraphMode {
     Default,
     /// Drops the labels from the edges in the flowgraph output. This
-    /// is mostly for use in the --xpretty flowgraph run-make tests,
+    /// is mostly for use in the --unpretty flowgraph run-make tests,
     /// since the labels are largely uninteresting in those cases and
     /// have become a pain to maintain.
     UnlabelledEdges,
@@ -90,7 +90,7 @@ pub fn parse_pretty(sess: &Session,
         _ => {
             if extended {
                 sess.fatal(&format!(
-                    "argument to `xpretty` must be one of `normal`, \
+                    "argument to `unpretty` must be one of `normal`, \
                      `expanded`, `flowgraph[,unlabelled]=<nodeid>`, `typed`, `identified`, \
                      `expanded,identified`, or `everybody_loops`; got {}", name));
             } else {

--- a/src/test/run-make/graphviz-flowgraph/Makefile
+++ b/src/test/run-make/graphviz-flowgraph/Makefile
@@ -28,7 +28,7 @@ $(TMPDIR)/%.pp: %.rs
 
 $(TMPDIR)/%.dot: %.rs
 	$(eval $(call FIND_LAST_BLOCK,$<))
-	$(RUSTC_LIB) -Z unstable-options --xpretty flowgraph,unlabelled=$(LASTBLOCKNUM_$<) $< -o $@.tmp
+	$(RUSTC_LIB) -Z unstable-options --unpretty flowgraph,unlabelled=$(LASTBLOCKNUM_$<) $< -o $@.tmp
 	cat $@.tmp | sed -e 's@ (id=[0-9]*)@@g' \
                          -e 's@\[label=""\]@@' \
                          -e 's@digraph [a-zA-Z0-9_]* @digraph block @' \


### PR DESCRIPTION
Rename the unstable option `--xpretty` to `--unpretty`

(Inspired by discussion with Gankro.)

Make sure this gets a low priority if it gets r-plussed!
