### PR TITLE
rustc: Allow changing the default allocator

### DIFF
--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -184,8 +184,6 @@ $$(JEMALLOC_LOCAL_$(1)): $$(JEMALLOC_DEPS) $$(MKFILE_DEPS)
 		EXTRA_CFLAGS="-g1 -ffunction-sections -fdata-sections"
 	$$(Q)$$(MAKE) -C "$$(JEMALLOC_BUILD_DIR_$(1))" build_lib_static
 
-ifeq ($$(CFG_DISABLE_JEMALLOC),)
-RUSTFLAGS_alloc := --cfg jemalloc
 ifeq ($(1),$$(CFG_BUILD))
 ifneq ($$(CFG_JEMALLOC_ROOT),)
 $$(JEMALLOC_LIB_$(1)): $$(CFG_JEMALLOC_ROOT)/libjemalloc_pic.a
@@ -198,10 +196,6 @@ endif
 else
 $$(JEMALLOC_LIB_$(1)): $$(JEMALLOC_LOCAL_$(1))
 	$$(Q)cp $$< $$@
-endif
-else
-$$(JEMALLOC_LIB_$(1)): $$(MKFILE_DEPS)
-	$$(Q)touch $$@
 endif
 
 ################################################################################

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -22,7 +22,8 @@ $(eval $(call RUST_CRATE,coretest))
 DEPS_collectionstest :=
 $(eval $(call RUST_CRATE,collectionstest))
 
-TEST_TARGET_CRATES = $(filter-out core rustc_unicode,$(TARGET_CRATES)) \
+TEST_TARGET_CRATES = $(filter-out core rustc_unicode alloc_system \
+		     		  alloc_jemalloc,$(TARGET_CRATES)) \
 			collectionstest coretest
 TEST_DOC_CRATES = $(DOC_CRATES)
 TEST_HOST_CRATES = $(filter-out rustc_typeck rustc_borrowck rustc_resolve \

--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -16,6 +16,18 @@
 
 use core::{isize, usize};
 
+#[allow(improper_ctypes)]
+extern {
+    #[allocator]
+    fn __rust_allocate(size: usize, align: usize) -> *mut u8;
+    fn __rust_deallocate(ptr: *mut u8, old_size: usize, align: usize);
+    fn __rust_reallocate(ptr: *mut u8, old_size: usize, size: usize,
+                         align: usize) -> *mut u8;
+    fn __rust_reallocate_inplace(ptr: *mut u8, old_size: usize, size: usize,
+                               align: usize) -> usize;
+    fn __rust_usable_size(size: usize, align: usize) -> usize;
+}
+
 #[inline(always)]
 fn check_size_and_alignment(size: usize, align: usize) {
     debug_assert!(size != 0);
@@ -35,7 +47,7 @@ fn check_size_and_alignment(size: usize, align: usize) {
 #[inline]
 pub unsafe fn allocate(size: usize, align: usize) -> *mut u8 {
     check_size_and_alignment(size, align);
-    imp::allocate(size, align)
+    __rust_allocate(size, align)
 }
 
 /// Resize the allocation referenced by `ptr` to `size` bytes.
@@ -55,7 +67,7 @@ pub unsafe fn allocate(size: usize, align: usize) -> *mut u8 {
 #[inline]
 pub unsafe fn reallocate(ptr: *mut u8, old_size: usize, size: usize, align: usize) -> *mut u8 {
     check_size_and_alignment(size, align);
-    imp::reallocate(ptr, old_size, size, align)
+    __rust_reallocate(ptr, old_size, size, align)
 }
 
 /// Resize the allocation referenced by `ptr` to `size` bytes.
@@ -74,7 +86,7 @@ pub unsafe fn reallocate(ptr: *mut u8, old_size: usize, size: usize, align: usiz
 pub unsafe fn reallocate_inplace(ptr: *mut u8, old_size: usize, size: usize,
                                  align: usize) -> usize {
     check_size_and_alignment(size, align);
-    imp::reallocate_inplace(ptr, old_size, size, align)
+    __rust_reallocate_inplace(ptr, old_size, size, align)
 }
 
 /// Deallocates the memory referenced by `ptr`.
@@ -86,28 +98,20 @@ pub unsafe fn reallocate_inplace(ptr: *mut u8, old_size: usize, size: usize,
 /// any value in range_inclusive(requested_size, usable_size).
 #[inline]
 pub unsafe fn deallocate(ptr: *mut u8, old_size: usize, align: usize) {
-    imp::deallocate(ptr, old_size, align)
+    __rust_deallocate(ptr, old_size, align)
 }
 
 /// Returns the usable size of an allocation created with the specified the
 /// `size` and `align`.
 #[inline]
 pub fn usable_size(size: usize, align: usize) -> usize {
-    imp::usable_size(size, align)
-}
-
-/// Prints implementation-defined allocator statistics.
-///
-/// These statistics may be inconsistent if other threads use the allocator
-/// during the call.
-pub fn stats_print() {
-    imp::stats_print();
+    unsafe { __rust_usable_size(size, align) }
 }
 
 /// An arbitrary non-null address to represent zero-size allocations.
 ///
-/// This preserves the non-null invariant for types like `Box<T>`. The address may overlap with
-/// non-zero-size memory allocations.
+/// This preserves the non-null invariant for types like `Box<T>`. The address
+/// may overlap with non-zero-size memory allocations.
 pub const EMPTY: *mut () = 0x1 as *mut ();
 
 /// The allocator for unique pointers.
@@ -129,362 +133,6 @@ unsafe fn exchange_malloc(size: usize, align: usize) -> *mut u8 {
 #[inline]
 unsafe fn exchange_free(ptr: *mut u8, old_size: usize, align: usize) {
     deallocate(ptr, old_size, align);
-}
-
-// The minimum alignment guaranteed by the architecture. This value is used to
-// add fast paths for low alignment values. In practice, the alignment is a
-// constant at the call site and the branch will be optimized out.
-#[cfg(all(not(feature = "external_funcs"),
-          not(feature = "external_crate"),
-          any(target_arch = "arm",
-              target_arch = "mips",
-              target_arch = "mipsel",
-              target_arch = "powerpc")))]
-const MIN_ALIGN: usize = 8;
-#[cfg(all(not(feature = "external_funcs"),
-          not(feature = "external_crate"),
-          any(target_arch = "x86",
-              target_arch = "x86_64",
-              target_arch = "aarch64")))]
-const MIN_ALIGN: usize = 16;
-
-#[cfg(feature = "external_funcs")]
-mod imp {
-    #[allow(improper_ctypes)]
-    extern {
-        fn rust_allocate(size: usize, align: usize) -> *mut u8;
-        fn rust_deallocate(ptr: *mut u8, old_size: usize, align: usize);
-        fn rust_reallocate(ptr: *mut u8, old_size: usize, size: usize, align: usize) -> *mut u8;
-        fn rust_reallocate_inplace(ptr: *mut u8, old_size: usize, size: usize,
-                                   align: usize) -> usize;
-        fn rust_usable_size(size: usize, align: usize) -> usize;
-        fn rust_stats_print();
-    }
-
-    #[inline]
-    pub unsafe fn allocate(size: usize, align: usize) -> *mut u8 {
-        rust_allocate(size, align)
-    }
-
-    #[inline]
-    pub unsafe fn deallocate(ptr: *mut u8, old_size: usize, align: usize) {
-        rust_deallocate(ptr, old_size, align)
-    }
-
-    #[inline]
-    pub unsafe fn reallocate(ptr: *mut u8, old_size: usize, size: usize, align: usize) -> *mut u8 {
-        rust_reallocate(ptr, old_size, size, align)
-    }
-
-    #[inline]
-    pub unsafe fn reallocate_inplace(ptr: *mut u8, old_size: usize, size: usize,
-                                     align: usize) -> usize {
-        rust_reallocate_inplace(ptr, old_size, size, align)
-    }
-
-    #[inline]
-    pub fn usable_size(size: usize, align: usize) -> usize {
-        unsafe { rust_usable_size(size, align) }
-    }
-
-    #[inline]
-    pub fn stats_print() {
-        unsafe { rust_stats_print() }
-    }
-}
-
-#[cfg(feature = "external_crate")]
-mod imp {
-    extern crate external;
-    pub use self::external::{allocate, deallocate, reallocate_inplace, reallocate};
-    pub use self::external::{usable_size, stats_print};
-}
-
-#[cfg(all(not(feature = "external_funcs"),
-          not(feature = "external_crate"),
-          jemalloc))]
-mod imp {
-    use core::option::Option;
-    use core::option::Option::None;
-    use core::ptr::{null_mut, null};
-    use libc::{c_char, c_int, c_void, size_t};
-    use super::MIN_ALIGN;
-
-    #[link(name = "jemalloc", kind = "static")]
-    #[cfg(not(test))]
-    extern {}
-
-    extern {
-        #[allocator]
-        fn je_mallocx(size: size_t, flags: c_int) -> *mut c_void;
-        fn je_rallocx(ptr: *mut c_void, size: size_t, flags: c_int) -> *mut c_void;
-        fn je_xallocx(ptr: *mut c_void, size: size_t, extra: size_t, flags: c_int) -> size_t;
-        fn je_sdallocx(ptr: *mut c_void, size: size_t, flags: c_int);
-        fn je_nallocx(size: size_t, flags: c_int) -> size_t;
-        fn je_malloc_stats_print(write_cb: Option<extern "C" fn(cbopaque: *mut c_void,
-                                                                *const c_char)>,
-                                 cbopaque: *mut c_void,
-                                 opts: *const c_char);
-    }
-
-    // -lpthread needs to occur after -ljemalloc, the earlier argument isn't enough
-    #[cfg(all(not(windows),
-              not(target_os = "android"),
-              not(target_env = "musl")))]
-    #[link(name = "pthread")]
-    extern {}
-
-    // MALLOCX_ALIGN(a) macro
-    #[inline(always)]
-    fn mallocx_align(a: usize) -> c_int { a.trailing_zeros() as c_int }
-
-    #[inline(always)]
-    fn align_to_flags(align: usize) -> c_int {
-        if align <= MIN_ALIGN { 0 } else { mallocx_align(align) }
-    }
-
-    #[inline]
-    pub unsafe fn allocate(size: usize, align: usize) -> *mut u8 {
-        let flags = align_to_flags(align);
-        je_mallocx(size as size_t, flags) as *mut u8
-    }
-
-    #[inline]
-    pub unsafe fn reallocate(ptr: *mut u8, _old_size: usize, size: usize, align: usize) -> *mut u8 {
-        let flags = align_to_flags(align);
-        je_rallocx(ptr as *mut c_void, size as size_t, flags) as *mut u8
-    }
-
-    #[inline]
-    pub unsafe fn reallocate_inplace(ptr: *mut u8, _old_size: usize, size: usize,
-                                     align: usize) -> usize {
-        let flags = align_to_flags(align);
-        je_xallocx(ptr as *mut c_void, size as size_t, 0, flags) as usize
-    }
-
-    #[inline]
-    pub unsafe fn deallocate(ptr: *mut u8, old_size: usize, align: usize) {
-        let flags = align_to_flags(align);
-        je_sdallocx(ptr as *mut c_void, old_size as size_t, flags)
-    }
-
-    #[inline]
-    pub fn usable_size(size: usize, align: usize) -> usize {
-        let flags = align_to_flags(align);
-        unsafe { je_nallocx(size as size_t, flags) as usize }
-    }
-
-    pub fn stats_print() {
-        unsafe {
-            je_malloc_stats_print(None, null_mut(), null())
-        }
-    }
-}
-
-#[cfg(all(not(feature = "external_funcs"),
-          not(feature = "external_crate"),
-          not(jemalloc),
-          unix))]
-mod imp {
-    use core::cmp;
-    use core::ptr;
-    use libc;
-    use super::MIN_ALIGN;
-
-    extern {
-        fn posix_memalign(memptr: *mut *mut libc::c_void,
-                          align: libc::size_t,
-                          size: libc::size_t) -> libc::c_int;
-    }
-
-    #[inline]
-    pub unsafe fn allocate(size: usize, align: usize) -> *mut u8 {
-        if align <= MIN_ALIGN {
-            libc::malloc(size as libc::size_t) as *mut u8
-        } else {
-            let mut out = ptr::null_mut();
-            let ret = posix_memalign(&mut out,
-                                     align as libc::size_t,
-                                     size as libc::size_t);
-            if ret != 0 {
-                ptr::null_mut()
-            } else {
-                out as *mut u8
-            }
-        }
-    }
-
-    #[inline]
-    pub unsafe fn reallocate(ptr: *mut u8, old_size: usize, size: usize, align: usize) -> *mut u8 {
-        if align <= MIN_ALIGN {
-            libc::realloc(ptr as *mut libc::c_void, size as libc::size_t) as *mut u8
-        } else {
-            let new_ptr = allocate(size, align);
-            ptr::copy(ptr, new_ptr, cmp::min(size, old_size));
-            deallocate(ptr, old_size, align);
-            new_ptr
-        }
-    }
-
-    #[inline]
-    pub unsafe fn reallocate_inplace(_ptr: *mut u8, old_size: usize, _size: usize,
-                                     _align: usize) -> usize {
-        old_size
-    }
-
-    #[inline]
-    pub unsafe fn deallocate(ptr: *mut u8, _old_size: usize, _align: usize) {
-        libc::free(ptr as *mut libc::c_void)
-    }
-
-    #[inline]
-    pub fn usable_size(size: usize, _align: usize) -> usize {
-        size
-    }
-
-    pub fn stats_print() {}
-}
-
-#[cfg(all(not(feature = "external_funcs"),
-          not(feature = "external_crate"),
-          not(jemalloc),
-          windows))]
-mod imp {
-    use core::mem::size_of;
-    use libc::{BOOL, DWORD, HANDLE, LPVOID, SIZE_T, INVALID_HANDLE_VALUE};
-    use libc::{WriteFile};
-    use super::MIN_ALIGN;
-
-    extern "system" {
-        fn GetProcessHeap() -> HANDLE;
-        fn GetStdHandle(nStdHandle: DWORD) -> HANDLE;
-        fn HeapAlloc(hHeap: HANDLE, dwFlags: DWORD, dwBytes: SIZE_T) -> LPVOID;
-        fn HeapReAlloc(hHeap: HANDLE, dwFlags: DWORD, lpMem: LPVOID, dwBytes: SIZE_T) -> LPVOID;
-        fn HeapFree(hHeap: HANDLE, dwFlags: DWORD, lpMem: LPVOID) -> BOOL;
-        fn HeapSummary(hHeap: HANDLE, dwFlags: DWORD, lpSummary: LPHEAP_SUMMARY) -> BOOL;
-    }
-
-    #[repr(C)] #[allow(non_snake_case)]
-    struct HEAP_SUMMARY {
-        cb: DWORD,
-        cbAllocated: SIZE_T,
-        cbCommitted: SIZE_T,
-        cbReserved: SIZE_T,
-        cbMaxReserve: SIZE_T,
-    }
-    #[allow(non_camel_case_types)]
-    type LPHEAP_SUMMARY = *mut HEAP_SUMMARY;
-
-    #[repr(C)]
-    struct Header(*mut u8);
-
-    const HEAP_REALLOC_IN_PLACE_ONLY: DWORD = 0x00000010;
-    const STD_OUTPUT_HANDLE: DWORD = -11i32 as u32;
-
-    #[inline]
-    unsafe fn get_header<'a>(ptr: *mut u8) -> &'a mut Header {
-        &mut *(ptr as *mut Header).offset(-1)
-    }
-
-    #[inline]
-    unsafe fn align_ptr(ptr: *mut u8, align: usize) -> *mut u8 {
-        let aligned = ptr.offset((align - (ptr as usize & (align - 1))) as isize);
-        *get_header(aligned) = Header(ptr);
-        aligned
-    }
-
-    #[inline]
-    pub unsafe fn allocate(size: usize, align: usize) -> *mut u8 {
-        if align <= MIN_ALIGN {
-            HeapAlloc(GetProcessHeap(), 0, size as SIZE_T) as *mut u8
-        } else {
-            let ptr = HeapAlloc(GetProcessHeap(), 0, (size + align) as SIZE_T) as *mut u8;
-            if ptr.is_null() { return ptr }
-            align_ptr(ptr, align)
-        }
-    }
-
-    #[inline]
-    pub unsafe fn reallocate(ptr: *mut u8, _old_size: usize, size: usize, align: usize) -> *mut u8 {
-        if align <= MIN_ALIGN {
-            HeapReAlloc(GetProcessHeap(), 0, ptr as LPVOID, size as SIZE_T) as *mut u8
-        } else {
-            let header = get_header(ptr);
-            let new = HeapReAlloc(GetProcessHeap(), 0, header.0 as LPVOID,
-                                  (size + align) as SIZE_T) as *mut u8;
-            if new.is_null() { return new }
-            align_ptr(new, align)
-        }
-    }
-
-    #[inline]
-    pub unsafe fn reallocate_inplace(ptr: *mut u8, old_size: usize, size: usize,
-                                     align: usize) -> usize {
-        if align <= MIN_ALIGN {
-            let new = HeapReAlloc(GetProcessHeap(), HEAP_REALLOC_IN_PLACE_ONLY, ptr as LPVOID,
-                                  size as SIZE_T) as *mut u8;
-            if new.is_null() { old_size } else { size }
-        } else {
-            old_size
-        }
-    }
-
-    #[inline]
-    pub unsafe fn deallocate(ptr: *mut u8, _old_size: usize, align: usize) {
-        if align <= MIN_ALIGN {
-            let err = HeapFree(GetProcessHeap(), 0, ptr as LPVOID);
-            debug_assert!(err != 0);
-        } else {
-            let header = get_header(ptr);
-            let err = HeapFree(GetProcessHeap(), 0, header.0 as LPVOID);
-            debug_assert!(err != 0);
-        }
-    }
-
-    #[inline]
-    pub fn usable_size(size: usize, _align: usize) -> usize {
-        size
-    }
-
-    pub fn stats_print() {
-        use core::fmt::{Error, Result, Write};
-        use core::ptr::null_mut;
-        use core::raw::Repr;
-        use core::result::Result::{Ok, Err};
-        struct Console(HANDLE);
-        impl Write for Console {
-            fn write_str(&mut self, s: &str) -> Result {
-                let repr = s.repr();
-                let mut written = 0;
-                let err = unsafe { WriteFile(self.0, repr.data as LPVOID, repr.len as DWORD,
-                                             &mut written, null_mut()) };
-                if written as usize != repr.len { return Err(Error) }
-                if err == 0 { return Err(Error) }
-                Ok(())
-            }
-        }
-        let mut hs = HEAP_SUMMARY {
-            cb: size_of::<HEAP_SUMMARY>() as DWORD,
-            cbAllocated: 0,
-            cbCommitted: 0,
-            cbReserved: 0,
-            cbMaxReserve: 0,
-        };
-        let err = unsafe { HeapSummary(GetProcessHeap(), 0, &mut hs) };
-        assert!(err != 0);
-        let handle = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) };
-        if handle.is_null() || handle == INVALID_HANDLE_VALUE { panic!("Failed to open stdout") }
-        let mut out = Console(handle);
-        writeln!(&mut out, "Allocated: {}", hs.cbAllocated).unwrap();
-        writeln!(&mut out, "Committed: {}", hs.cbCommitted).unwrap();
-        writeln!(&mut out, "Reserved: {}", hs.cbReserved).unwrap();
-        writeln!(&mut out, "MaxReserve: {}", hs.cbMaxReserve).unwrap();
-    }
-
-    #[test]
-    fn alignment_header_size() {
-        assert!(size_of::<Header>() <= MIN_ALIGN);
-    }
 }
 
 #[cfg(test)]

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -61,6 +61,7 @@
 #![crate_name = "alloc"]
 #![crate_type = "rlib"]
 #![staged_api]
+#![allow(unused_attributes)]
 #![unstable(feature = "alloc",
             reason = "this library is unlikely to be stabilized in its current \
                       form or name")]
@@ -69,6 +70,7 @@
        html_root_url = "https://doc.rust-lang.org/nightly/",
        test(no_crate_inject))]
 #![no_std]
+#![cfg_attr(not(stage0), needs_allocator)]
 
 #![feature(allocator)]
 #![feature(box_syntax)]
@@ -92,13 +94,13 @@
 #![feature(unsize)]
 #![feature(core_slice_ext)]
 #![feature(core_str_ext)]
+#![cfg_attr(stage0, feature(alloc_system))]
+#![cfg_attr(not(stage0), feature(needs_allocator))]
 
 #![cfg_attr(test, feature(test, rustc_private, box_raw))]
-#![cfg_attr(all(not(feature = "external_funcs"), not(feature = "external_crate")),
-            feature(libc))]
 
-#[cfg(all(not(feature = "external_funcs"), not(feature = "external_crate")))]
-extern crate libc;
+#[cfg(stage0)]
+extern crate alloc_system;
 
 // Allow testing this library
 

--- a/src/liballoc_jemalloc/lib.rs
+++ b/src/liballoc_jemalloc/lib.rs
@@ -1,0 +1,96 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![cfg_attr(stage0, feature(custom_attribute))]
+#![crate_name = "alloc_jemalloc"]
+#![crate_type = "rlib"]
+#![staged_api]
+#![no_std]
+#![cfg_attr(not(stage0), allocator)]
+#![unstable(feature = "alloc_jemalloc",
+            reason = "this library is unlikely to be stabilized in its current \
+                      form or name")]
+#![feature(allocator)]
+#![feature(libc)]
+#![feature(no_std)]
+#![feature(staged_api)]
+
+extern crate libc;
+
+use libc::{c_int, c_void, size_t};
+
+#[link(name = "jemalloc", kind = "static")]
+extern {
+    fn je_mallocx(size: size_t, flags: c_int) -> *mut c_void;
+    fn je_rallocx(ptr: *mut c_void, size: size_t, flags: c_int) -> *mut c_void;
+    fn je_xallocx(ptr: *mut c_void, size: size_t, extra: size_t,
+                  flags: c_int) -> size_t;
+    fn je_sdallocx(ptr: *mut c_void, size: size_t, flags: c_int);
+    fn je_nallocx(size: size_t, flags: c_int) -> size_t;
+}
+
+// -lpthread needs to occur after -ljemalloc, the earlier argument isn't enough
+#[cfg(all(not(windows),
+          not(target_os = "android"),
+          not(target_env = "musl")))]
+#[link(name = "pthread")]
+extern {}
+
+// The minimum alignment guaranteed by the architecture. This value is used to
+// add fast paths for low alignment values. In practice, the alignment is a
+// constant at the call site and the branch will be optimized out.
+#[cfg(all(any(target_arch = "arm",
+              target_arch = "mips",
+              target_arch = "mipsel",
+              target_arch = "powerpc")))]
+const MIN_ALIGN: usize = 8;
+#[cfg(all(any(target_arch = "x86",
+              target_arch = "x86_64",
+              target_arch = "aarch64")))]
+const MIN_ALIGN: usize = 16;
+
+// MALLOCX_ALIGN(a) macro
+fn mallocx_align(a: usize) -> c_int { a.trailing_zeros() as c_int }
+
+fn align_to_flags(align: usize) -> c_int {
+    if align <= MIN_ALIGN { 0 } else { mallocx_align(align) }
+}
+
+#[no_mangle]
+pub extern fn __rust_allocate(size: usize, align: usize) -> *mut u8 {
+    let flags = align_to_flags(align);
+    unsafe { je_mallocx(size as size_t, flags) as *mut u8 }
+}
+
+#[no_mangle]
+pub extern fn __rust_reallocate(ptr: *mut u8, _old_size: usize, size: usize,
+                                align: usize) -> *mut u8 {
+    let flags = align_to_flags(align);
+    unsafe { je_rallocx(ptr as *mut c_void, size as size_t, flags) as *mut u8 }
+}
+
+#[no_mangle]
+pub extern fn __rust_reallocate_inplace(ptr: *mut u8, _old_size: usize,
+                                        size: usize, align: usize) -> usize {
+    let flags = align_to_flags(align);
+    unsafe { je_xallocx(ptr as *mut c_void, size as size_t, 0, flags) as usize }
+}
+
+#[no_mangle]
+pub extern fn __rust_deallocate(ptr: *mut u8, old_size: usize, align: usize) {
+    let flags = align_to_flags(align);
+    unsafe { je_sdallocx(ptr as *mut c_void, old_size as size_t, flags) }
+}
+
+#[no_mangle]
+pub extern fn __rust_usable_size(size: usize, align: usize) -> usize {
+    let flags = align_to_flags(align);
+    unsafe { je_nallocx(size as size_t, flags) as usize }
+}

--- a/src/liballoc_system/lib.rs
+++ b/src/liballoc_system/lib.rs
@@ -1,0 +1,212 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![cfg_attr(stage0, feature(custom_attribute))]
+#![crate_name = "alloc_system"]
+#![crate_type = "rlib"]
+#![staged_api]
+#![no_std]
+#![cfg_attr(not(stage0), allocator)]
+#![unstable(feature = "alloc_system",
+            reason = "this library is unlikely to be stabilized in its current \
+                      form or name")]
+#![feature(allocator)]
+#![feature(libc)]
+#![feature(no_std)]
+#![feature(staged_api)]
+
+extern crate libc;
+
+// The minimum alignment guaranteed by the architecture. This value is used to
+// add fast paths for low alignment values. In practice, the alignment is a
+// constant at the call site and the branch will be optimized out.
+#[cfg(all(any(target_arch = "arm",
+              target_arch = "mips",
+              target_arch = "mipsel",
+              target_arch = "powerpc")))]
+const MIN_ALIGN: usize = 8;
+#[cfg(all(any(target_arch = "x86",
+              target_arch = "x86_64",
+              target_arch = "aarch64")))]
+const MIN_ALIGN: usize = 16;
+
+#[no_mangle]
+pub extern fn __rust_allocate(size: usize, align: usize) -> *mut u8 {
+    unsafe { imp::allocate(size, align) }
+}
+
+#[no_mangle]
+pub extern fn __rust_deallocate(ptr: *mut u8, old_size: usize, align: usize) {
+    unsafe { imp::deallocate(ptr, old_size, align) }
+}
+
+#[no_mangle]
+pub extern fn __rust_reallocate(ptr: *mut u8, old_size: usize, size: usize,
+                                align: usize) -> *mut u8 {
+    unsafe { imp::reallocate(ptr, old_size, size, align) }
+}
+
+#[no_mangle]
+pub extern fn __rust_reallocate_inplace(ptr: *mut u8, old_size: usize,
+                                        size: usize, align: usize) -> usize {
+    unsafe { imp::reallocate_inplace(ptr, old_size, size, align) }
+}
+
+#[no_mangle]
+pub extern fn __rust_usable_size(size: usize, align: usize) -> usize {
+    imp::usable_size(size, align)
+}
+
+#[cfg(unix)]
+mod imp {
+    use core::cmp;
+    use core::ptr;
+    use libc;
+    use MIN_ALIGN;
+
+    extern {
+        // Apparently android doesn't have posix_memalign
+        #[cfg(target_os = "android")]
+        fn memalign(align: libc::size_t, size: libc::size_t) -> *mut libc::c_void;
+
+        #[cfg(not(target_os = "android"))]
+        fn posix_memalign(memptr: *mut *mut libc::c_void,
+                          align: libc::size_t,
+                          size: libc::size_t) -> libc::c_int;
+    }
+
+    pub unsafe fn allocate(size: usize, align: usize) -> *mut u8 {
+        if align <= MIN_ALIGN {
+            libc::malloc(size as libc::size_t) as *mut u8
+        } else {
+            #[cfg(target_os = "android")]
+            unsafe fn more_aligned_malloc(size: usize, align: usize) -> *mut u8 {
+                memalign(align as libc::size_t, size as libc::size_t) as *mut u8
+            }
+            #[cfg(not(target_os = "android"))]
+            unsafe fn more_aligned_malloc(size: usize, align: usize) -> *mut u8 {
+                let mut out = ptr::null_mut();
+                let ret = posix_memalign(&mut out,
+                                         align as libc::size_t,
+                                         size as libc::size_t);
+                if ret != 0 {
+                    ptr::null_mut()
+                } else {
+                    out as *mut u8
+                }
+            }
+            more_aligned_malloc(size, align)
+        }
+    }
+
+    pub unsafe fn reallocate(ptr: *mut u8, old_size: usize, size: usize,
+                             align: usize) -> *mut u8 {
+        if align <= MIN_ALIGN {
+            libc::realloc(ptr as *mut libc::c_void, size as libc::size_t) as *mut u8
+        } else {
+            let new_ptr = allocate(size, align);
+            ptr::copy(ptr, new_ptr, cmp::min(size, old_size));
+            deallocate(ptr, old_size, align);
+            new_ptr
+        }
+    }
+
+    pub unsafe fn reallocate_inplace(_ptr: *mut u8, old_size: usize, _size: usize,
+                                     _align: usize) -> usize {
+        old_size
+    }
+
+    pub unsafe fn deallocate(ptr: *mut u8, _old_size: usize, _align: usize) {
+        libc::free(ptr as *mut libc::c_void)
+    }
+
+    pub fn usable_size(size: usize, _align: usize) -> usize {
+        size
+    }
+}
+
+#[cfg(windows)]
+mod imp {
+    use libc::{BOOL, DWORD, HANDLE, LPVOID, SIZE_T};
+    use MIN_ALIGN;
+
+    extern "system" {
+        fn GetProcessHeap() -> HANDLE;
+        fn HeapAlloc(hHeap: HANDLE, dwFlags: DWORD, dwBytes: SIZE_T) -> LPVOID;
+        fn HeapReAlloc(hHeap: HANDLE, dwFlags: DWORD, lpMem: LPVOID,
+                       dwBytes: SIZE_T) -> LPVOID;
+        fn HeapFree(hHeap: HANDLE, dwFlags: DWORD, lpMem: LPVOID) -> BOOL;
+    }
+
+    #[repr(C)]
+    struct Header(*mut u8);
+
+    const HEAP_REALLOC_IN_PLACE_ONLY: DWORD = 0x00000010;
+
+    unsafe fn get_header<'a>(ptr: *mut u8) -> &'a mut Header {
+        &mut *(ptr as *mut Header).offset(-1)
+    }
+
+    unsafe fn align_ptr(ptr: *mut u8, align: usize) -> *mut u8 {
+        let aligned = ptr.offset((align - (ptr as usize & (align - 1))) as isize);
+        *get_header(aligned) = Header(ptr);
+        aligned
+    }
+
+    pub unsafe fn allocate(size: usize, align: usize) -> *mut u8 {
+        if align <= MIN_ALIGN {
+            HeapAlloc(GetProcessHeap(), 0, size as SIZE_T) as *mut u8
+        } else {
+            let ptr = HeapAlloc(GetProcessHeap(), 0,
+                                (size + align) as SIZE_T) as *mut u8;
+            if ptr.is_null() { return ptr }
+            align_ptr(ptr, align)
+        }
+    }
+
+    pub unsafe fn reallocate(ptr: *mut u8, _old_size: usize, size: usize,
+                             align: usize) -> *mut u8 {
+        if align <= MIN_ALIGN {
+            HeapReAlloc(GetProcessHeap(), 0, ptr as LPVOID, size as SIZE_T) as *mut u8
+        } else {
+            let header = get_header(ptr);
+            let new = HeapReAlloc(GetProcessHeap(), 0, header.0 as LPVOID,
+                                  (size + align) as SIZE_T) as *mut u8;
+            if new.is_null() { return new }
+            align_ptr(new, align)
+        }
+    }
+
+    pub unsafe fn reallocate_inplace(ptr: *mut u8, old_size: usize, size: usize,
+                                     align: usize) -> usize {
+        if align <= MIN_ALIGN {
+            let new = HeapReAlloc(GetProcessHeap(), HEAP_REALLOC_IN_PLACE_ONLY,
+                                  ptr as LPVOID, size as SIZE_T) as *mut u8;
+            if new.is_null() { old_size } else { size }
+        } else {
+            old_size
+        }
+    }
+
+    pub unsafe fn deallocate(ptr: *mut u8, _old_size: usize, align: usize) {
+        if align <= MIN_ALIGN {
+            let err = HeapFree(GetProcessHeap(), 0, ptr as LPVOID);
+            debug_assert!(err != 0);
+        } else {
+            let header = get_header(ptr);
+            let err = HeapFree(GetProcessHeap(), 0, header.0 as LPVOID);
+            debug_assert!(err != 0);
+        }
+    }
+
+    pub fn usable_size(size: usize, _align: usize) -> usize {
+        size
+    }
+}

--- a/src/librustc/metadata/common.rs
+++ b/src/librustc/metadata/common.rs
@@ -78,12 +78,13 @@ pub const tag_crate_crate_name: usize = 0x104; // top-level only
 
 pub const tag_crate_dep_crate_name: usize = 0x36;
 pub const tag_crate_dep_hash: usize = 0x37;
+pub const tag_crate_dep_explicitly_linked: usize = 0x38; // top-level only
 
-pub const tag_mod_impl: usize = 0x38;
+pub const tag_mod_impl: usize = 0x39;
 
-pub const tag_item_trait_item: usize = 0x39;
+pub const tag_item_trait_item: usize = 0x3a;
 
-pub const tag_item_trait_ref: usize = 0x3a;
+pub const tag_item_trait_ref: usize = 0x3b;
 
 // discriminator value for variants
 pub const tag_disr_val: usize = 0x3c;

--- a/src/librustc/middle/dependency_format.rs
+++ b/src/librustc/middle/dependency_format.rs
@@ -67,7 +67,6 @@ use session;
 use session::config;
 use metadata::cstore;
 use metadata::csearch;
-use middle::ty;
 use util::nodemap::FnvHashMap;
 
 /// A list of dependencies for a certain crate type.
@@ -76,19 +75,29 @@ use util::nodemap::FnvHashMap;
 /// The value is None if the crate does not need to be linked (it was found
 /// statically in another dylib), or Some(kind) if it needs to be linked as
 /// `kind` (either static or dynamic).
-pub type DependencyList = Vec<Option<cstore::LinkagePreference>>;
+pub type DependencyList = Vec<Linkage>;
 
 /// A mapping of all required dependencies for a particular flavor of output.
 ///
 /// This is local to the tcx, and is generally relevant to one session.
 pub type Dependencies = FnvHashMap<config::CrateType, DependencyList>;
 
-pub fn calculate(tcx: &ty::ctxt) {
-    let mut fmts = tcx.dependency_formats.borrow_mut();
-    for &ty in tcx.sess.crate_types.borrow().iter() {
-        fmts.insert(ty, calculate_type(&tcx.sess, ty));
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum Linkage {
+    NotLinked,
+    IncludedFromDylib,
+    Static,
+    Dynamic,
+}
+
+pub fn calculate(sess: &session::Session) {
+    let mut fmts = sess.dependency_formats.borrow_mut();
+    for &ty in sess.crate_types.borrow().iter() {
+        let linkage = calculate_type(sess, ty);
+        verify_ok(sess, &linkage);
+        fmts.insert(ty, linkage);
     }
-    tcx.sess.abort_if_errors();
+    sess.abort_if_errors();
 }
 
 fn calculate_type(sess: &session::Session,
@@ -145,12 +154,12 @@ fn calculate_type(sess: &session::Session,
     sess.cstore.iter_crate_data(|cnum, data| {
         let src = sess.cstore.get_used_crate_source(cnum).unwrap();
         if src.dylib.is_some() {
-            debug!("adding dylib: {}", data.name);
+            info!("adding dylib: {}", data.name);
             add_library(sess, cnum, cstore::RequireDynamic, &mut formats);
             let deps = csearch::get_dylib_dependency_formats(&sess.cstore, cnum);
             for &(depnum, style) in &deps {
-                debug!("adding {:?}: {}", style,
-                       sess.cstore.get_crate_data(depnum).name.clone());
+                info!("adding {:?}: {}", style,
+                      sess.cstore.get_crate_data(depnum).name.clone());
                 add_library(sess, depnum, style, &mut formats);
             }
         }
@@ -158,23 +167,35 @@ fn calculate_type(sess: &session::Session,
 
     // Collect what we've got so far in the return vector.
     let mut ret = (1..sess.cstore.next_crate_num()).map(|i| {
-        match formats.get(&i).cloned() {
-            v @ Some(cstore::RequireDynamic) => v,
-            _ => None,
+        match formats.get(&i) {
+            Some(&cstore::RequireDynamic) => Linkage::Dynamic,
+            Some(&cstore::RequireStatic) => Linkage::IncludedFromDylib,
+            None => Linkage::NotLinked,
         }
     }).collect::<Vec<_>>();
 
     // Run through the dependency list again, and add any missing libraries as
     // static libraries.
+    //
+    // If the crate hasn't been included yet and it's not actually required
+    // (e.g. it's an allocator) then we skip it here as well.
     sess.cstore.iter_crate_data(|cnum, data| {
         let src = sess.cstore.get_used_crate_source(cnum).unwrap();
-        if src.dylib.is_none() && !formats.contains_key(&cnum) {
+        if src.dylib.is_none() &&
+           !formats.contains_key(&cnum) &&
+           data.explicitly_linked.get() {
             assert!(src.rlib.is_some());
-            debug!("adding staticlib: {}", data.name);
+            info!("adding staticlib: {}", data.name);
             add_library(sess, cnum, cstore::RequireStatic, &mut formats);
-            ret[cnum as usize - 1] = Some(cstore::RequireStatic);
+            ret[cnum as usize - 1] = Linkage::Static;
         }
     });
+
+    // We've gotten this far because we're emitting some form of a final
+    // artifact which means that we're going to need an allocator of some form.
+    // No allocator may have been required or linked so far, so activate one
+    // here if one isn't set.
+    activate_allocator(sess, &mut ret);
 
     // When dylib B links to dylib A, then when using B we must also link to A.
     // It could be the case, however, that the rlib for A is present (hence we
@@ -183,21 +204,22 @@ fn calculate_type(sess: &session::Session,
     // For situations like this, we perform one last pass over the dependencies,
     // making sure that everything is available in the requested format.
     for (cnum, kind) in ret.iter().enumerate() {
-        let cnum = cnum as ast::CrateNum;
-        let src = sess.cstore.get_used_crate_source(cnum + 1).unwrap();
+        let cnum = (cnum + 1) as ast::CrateNum;
+        let src = sess.cstore.get_used_crate_source(cnum).unwrap();
         match *kind {
-            None => continue,
-            Some(cstore::RequireStatic) if src.rlib.is_some() => continue,
-            Some(cstore::RequireDynamic) if src.dylib.is_some() => continue,
-            Some(kind) => {
-                let data = sess.cstore.get_crate_data(cnum + 1);
+            Linkage::NotLinked |
+            Linkage::IncludedFromDylib => {}
+            Linkage::Static if src.rlib.is_some() => continue,
+            Linkage::Dynamic if src.dylib.is_some() => continue,
+            kind => {
+                let kind = match kind {
+                    Linkage::Static => "rlib",
+                    _ => "dylib",
+                };
+                let data = sess.cstore.get_crate_data(cnum);
                 sess.err(&format!("crate `{}` required to be available in {}, \
                                   but it was not available in this form",
-                                 data.name,
-                                 match kind {
-                                     cstore::RequireStatic => "rlib",
-                                     cstore::RequireDynamic => "dylib",
-                                 }));
+                                 data.name, kind));
             }
         }
     }
@@ -221,8 +243,7 @@ fn add_library(sess: &session::Session,
             if link2 != link || link == cstore::RequireStatic {
                 let data = sess.cstore.get_crate_data(cnum);
                 sess.err(&format!("cannot satisfy dependencies so `{}` only \
-                                  shows up once",
-                                 data.name));
+                                   shows up once", data.name));
                 sess.help("having upstream crates all available in one format \
                            will likely make this go away");
             }
@@ -233,9 +254,79 @@ fn add_library(sess: &session::Session,
 
 fn attempt_static(sess: &session::Session) -> Option<DependencyList> {
     let crates = sess.cstore.get_used_crates(cstore::RequireStatic);
-    if crates.iter().by_ref().all(|&(_, ref p)| p.is_some()) {
-        Some(crates.into_iter().map(|_| Some(cstore::RequireStatic)).collect())
-    } else {
-        None
+    if !crates.iter().by_ref().all(|&(_, ref p)| p.is_some()) {
+        return None
+    }
+
+    // All crates are available in an rlib format, so we're just going to link
+    // everything in explicitly so long as it's actually required.
+    let mut ret = (1..sess.cstore.next_crate_num()).map(|cnum| {
+        if sess.cstore.get_crate_data(cnum).explicitly_linked.get() {
+            Linkage::Static
+        } else {
+            Linkage::NotLinked
+        }
+    }).collect::<Vec<_>>();
+
+    // Our allocator may not have been activated as it's not flagged with
+    // explicitly_linked, so flag it here if necessary.
+    activate_allocator(sess, &mut ret);
+
+    Some(ret)
+}
+
+// Given a list of how to link upstream dependencies so far, ensure that an
+// allocator is activated. This will not do anything if one was transitively
+// included already (e.g. via a dylib or explicitly so).
+//
+// If an allocator was not found then we're guaranteed the metadata::creader
+// module has injected an allocator dependency (not listed as a required
+// dependency) in the session's `injected_allocator` field. If this field is not
+// set then this compilation doesn't actually need an allocator and we can also
+// skip this step entirely.
+fn activate_allocator(sess: &session::Session, list: &mut DependencyList) {
+    let mut allocator_found = false;
+    for (i, slot) in list.iter().enumerate() {
+        let cnum = (i + 1) as ast::CrateNum;
+        if !sess.cstore.get_crate_data(cnum).is_allocator() {
+            continue
+        }
+        if let Linkage::NotLinked = *slot {
+            continue
+        }
+        allocator_found = true;
+    }
+    if !allocator_found {
+        if let Some(injected_allocator) = sess.injected_allocator.get() {
+            let idx = injected_allocator as usize - 1;
+            assert_eq!(list[idx], Linkage::NotLinked);
+            list[idx] = Linkage::Static;
+        }
+    }
+}
+
+// After the linkage for a crate has been determined we need to verify that
+// there's only going to be one allocator in the output.
+fn verify_ok(sess: &session::Session, list: &[Linkage]) {
+    if list.len() == 0 {
+        return
+    }
+    let mut allocator = None;
+    for (i, linkage) in list.iter().enumerate() {
+        let cnum = (i + 1) as ast::CrateNum;
+        let data = sess.cstore.get_crate_data(cnum);
+        if !data.is_allocator() {
+            continue
+        }
+        if let Linkage::NotLinked = *linkage {
+            continue
+        }
+        if let Some(prev_alloc) = allocator {
+            let prev = sess.cstore.get_crate_data(prev_alloc);
+            sess.err(&format!("cannot link together two \
+                               allocators: {} and {}",
+                              prev.name(), data.name()));
+        }
+        allocator = Some(cnum);
     }
 }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -47,7 +47,6 @@ use middle::check_const;
 use middle::const_eval::{self, ConstVal, ErrKind};
 use middle::const_eval::EvalHint::UncheckedExprHint;
 use middle::def::{self, DefMap, ExportMap};
-use middle::dependency_format;
 use middle::fast_reject;
 use middle::free_region::FreeRegionMap;
 use middle::lang_items::{FnTraitLangItem, FnMutTraitLangItem, FnOnceTraitLangItem};
@@ -839,8 +838,6 @@ pub struct ctxt<'tcx> {
     pub extern_const_statics: RefCell<DefIdMap<ast::NodeId>>,
     pub extern_const_variants: RefCell<DefIdMap<ast::NodeId>>,
     pub extern_const_fns: RefCell<DefIdMap<ast::NodeId>>,
-
-    pub dependency_formats: RefCell<dependency_format::Dependencies>,
 
     pub node_lint_levels: RefCell<FnvHashMap<(ast::NodeId, lint::LintId),
                                               lint::LevelSource>>,
@@ -3837,7 +3834,6 @@ impl<'tcx> ctxt<'tcx> {
             extern_const_statics: RefCell::new(DefIdMap()),
             extern_const_variants: RefCell::new(DefIdMap()),
             extern_const_fns: RefCell::new(DefIdMap()),
-            dependency_formats: RefCell::new(FnvHashMap()),
             node_lint_levels: RefCell::new(FnvHashMap()),
             transmute_restrictions: RefCell::new(Vec::new()),
             stability: RefCell::new(stability),

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -32,11 +32,11 @@ pub const FN_OUTPUT_NAME: &'static str = "Output";
 #[derive(Clone, Copy, Debug)]
 pub struct ErrorReported;
 
-pub fn time<T, U, F>(do_it: bool, what: &str, u: U, f: F) -> T where
-    F: FnOnce(U) -> T,
+pub fn time<T, F>(do_it: bool, what: &str, f: F) -> T where
+    F: FnOnce() -> T,
 {
     thread_local!(static DEPTH: Cell<usize> = Cell::new(0));
-    if !do_it { return f(u); }
+    if !do_it { return f(); }
 
     let old = DEPTH.with(|slot| {
         let r = slot.get();
@@ -49,7 +49,7 @@ pub fn time<T, U, F>(do_it: bool, what: &str, u: U, f: F) -> T where
         let ref mut rvp = rv;
 
         Duration::span(move || {
-            *rvp = Some(f(u))
+            *rvp = Some(f())
         })
     };
     let rv = rv.unwrap();

--- a/src/librustc_back/target/apple_base.rs
+++ b/src/librustc_back/target/apple_base.rs
@@ -24,6 +24,7 @@ pub fn opts() -> TargetOptions {
         dll_suffix: ".dylib".to_string(),
         archive_format: "bsd".to_string(),
         pre_link_args: Vec::new(),
+        exe_allocation_crate: super::best_allocator(),
         .. Default::default()
     }
 }

--- a/src/librustc_back/target/bitrig_base.rs
+++ b/src/librustc_back/target/bitrig_base.rs
@@ -20,6 +20,7 @@ pub fn opts() -> TargetOptions {
         has_rpath: true,
         position_independent_executables: true,
         archive_format: "gnu".to_string(),
+        exe_allocation_crate: super::best_allocator(),
 
         .. Default::default()
     }

--- a/src/librustc_back/target/dragonfly_base.rs
+++ b/src/librustc_back/target/dragonfly_base.rs
@@ -29,6 +29,7 @@ pub fn opts() -> TargetOptions {
         ),
         position_independent_executables: true,
         archive_format: "bsd".to_string(),
+        exe_allocation_crate: super::best_allocator(),
         .. Default::default()
     }
 }

--- a/src/librustc_back/target/freebsd_base.rs
+++ b/src/librustc_back/target/freebsd_base.rs
@@ -18,6 +18,7 @@ pub fn opts() -> TargetOptions {
         executables: true,
         has_rpath: true,
         archive_format: "gnu".to_string(),
+        exe_allocation_crate: super::best_allocator(),
 
         .. Default::default()
     }

--- a/src/librustc_back/target/linux_base.rs
+++ b/src/librustc_back/target/linux_base.rs
@@ -29,6 +29,7 @@ pub fn opts() -> TargetOptions {
         ],
         position_independent_executables: true,
         archive_format: "gnu".to_string(),
+        exe_allocation_crate: super::best_allocator(),
         .. Default::default()
     }
 }

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -173,6 +173,10 @@ pub struct TargetOptions {
     /// defined in libgcc.  If this option is enabled, the target must provide
     /// `eh_unwind_resume` lang item.
     pub custom_unwind_resume: bool,
+
+    /// Default crate for allocation symbols to link against
+    pub lib_allocation_crate: String,
+    pub exe_allocation_crate: String,
 }
 
 impl Default for TargetOptions {
@@ -211,6 +215,8 @@ impl Default for TargetOptions {
             post_link_objects: Vec::new(),
             archive_format: String::new(),
             custom_unwind_resume: false,
+            lib_allocation_crate: "alloc_system".to_string(),
+            exe_allocation_crate: "alloc_system".to_string(),
         }
     }
 }
@@ -422,5 +428,13 @@ impl Target {
         }
 
         Err(format!("Could not find specification for target {:?}", target))
+    }
+}
+
+fn best_allocator() -> String {
+    if cfg!(disable_jemalloc) {
+        "alloc_system".to_string()
+    } else {
+        "alloc_jemalloc".to_string()
     }
 }

--- a/src/librustc_back/target/openbsd_base.rs
+++ b/src/librustc_back/target/openbsd_base.rs
@@ -27,6 +27,7 @@ pub fn opts() -> TargetOptions {
         ),
         position_independent_executables: true,
         archive_format: "gnu".to_string(),
+        exe_allocation_crate: super::best_allocator(),
         .. Default::default()
     }
 }

--- a/src/librustc_back/target/windows_base.rs
+++ b/src/librustc_back/target/windows_base.rs
@@ -60,6 +60,7 @@ pub fn opts() -> TargetOptions {
             // Always enable DEP (NX bit) when it is available
             "-Wl,--nxcompat".to_string(),
         ),
+        exe_allocation_crate: super::best_allocator(),
 
         .. Default::default()
     }

--- a/src/librustc_back/target/windows_msvc_base.rs
+++ b/src/librustc_back/target/windows_msvc_base.rs
@@ -60,6 +60,7 @@ pub fn opts() -> TargetOptions {
             "/NXCOMPAT".to_string(),
         ],
         archive_format: "gnu".to_string(),
+        exe_allocation_crate: super::best_allocator(),
 
         .. Default::default()
     }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -383,10 +383,10 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
         if sess.opts.debugging_opts.save_analysis {
             control.after_analysis.callback = box |state| {
                 time(state.session.time_passes(),
-                     "save analysis", (),
-                     |_| save::process_crate(state.tcx.unwrap(),
-                                             state.analysis.unwrap(),
-                                             state.out_dir));
+                     "save analysis",
+                     || save::process_crate(state.tcx.unwrap(),
+                                            state.analysis.unwrap(),
+                                            state.out_dir));
             };
             control.make_glob_map = resolve::MakeGlobMap::Yes;
         }

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -23,6 +23,7 @@ use metadata::common::LinkMeta;
 use metadata::filesearch::FileDoesntMatch;
 use metadata::loader::METADATA_FILENAME;
 use metadata::{encoder, cstore, filesearch, csearch, creader};
+use middle::dependency_format::Linkage;
 use middle::ty::{self, Ty};
 use rustc::ast_map::{PathElem, PathElems, PathName};
 use trans::{CrateContext, CrateTranslation, gensym_name};
@@ -493,6 +494,31 @@ pub fn filename_for_input(sess: &Session,
     }
 }
 
+pub fn each_linked_rlib(sess: &Session,
+                        f: &mut FnMut(ast::CrateNum, &Path)) {
+    let crates = sess.cstore.get_used_crates(cstore::RequireStatic).into_iter();
+    let fmts = sess.dependency_formats.borrow();
+    let fmts = fmts.get(&config::CrateTypeExecutable).or_else(|| {
+        fmts.get(&config::CrateTypeStaticlib)
+    }).unwrap_or_else(|| {
+        sess.bug("could not find formats for rlibs")
+    });
+    for (cnum, path) in crates {
+        match fmts[cnum as usize - 1] {
+            Linkage::NotLinked | Linkage::IncludedFromDylib => continue,
+            _ => {}
+        }
+        let name = sess.cstore.get_crate_data(cnum).name.clone();
+        let path = match path {
+            Some(p) => p,
+            None => {
+                sess.fatal(&format!("could not find rlib for: `{}`", name));
+            }
+        };
+        f(cnum, &path);
+    }
+}
+
 fn link_binary_output(sess: &Session,
                       trans: &CrateTranslation,
                       crate_type: config::CrateType,
@@ -524,11 +550,11 @@ fn link_binary_output(sess: &Session,
             link_staticlib(sess, &objects, &out_filename, tmpdir.path());
         }
         config::CrateTypeExecutable => {
-            link_natively(sess, trans, false, &objects, &out_filename, outputs,
+            link_natively(sess, false, &objects, &out_filename, trans, outputs,
                           tmpdir.path());
         }
         config::CrateTypeDylib => {
-            link_natively(sess, trans, true, &objects, &out_filename, outputs,
+            link_natively(sess, true, &objects, &out_filename, trans, outputs,
                           tmpdir.path());
         }
     }
@@ -763,23 +789,15 @@ fn link_staticlib(sess: &Session, objects: &[PathBuf], out_filename: &Path,
         ab.add_native_library("compiler-rt").unwrap();
     }
 
-    let crates = sess.cstore.get_used_crates(cstore::RequireStatic);
     let mut all_native_libs = vec![];
 
-    for &(cnum, ref path) in &crates {
-        let ref name = sess.cstore.get_crate_data(cnum).name;
-        let p = match *path {
-            Some(ref p) => p.clone(), None => {
-                sess.err(&format!("could not find rlib for: `{}`",
-                                 name));
-                continue
-            }
-        };
-        ab.add_rlib(&p, &name[..], sess.lto()).unwrap();
+    each_linked_rlib(sess, &mut |cnum, path| {
+        let name = sess.cstore.get_crate_data(cnum).name();
+        ab.add_rlib(path, &name, sess.lto()).unwrap();
 
         let native_libs = csearch::get_native_libraries(&sess.cstore, cnum);
         all_native_libs.extend(native_libs);
-    }
+    });
 
     ab.update_symbols();
     ab.build();
@@ -805,8 +823,9 @@ fn link_staticlib(sess: &Session, objects: &[PathBuf], out_filename: &Path,
 //
 // This will invoke the system linker/cc to create the resulting file. This
 // links to all upstream files as well.
-fn link_natively(sess: &Session, trans: &CrateTranslation, dylib: bool,
+fn link_natively(sess: &Session, dylib: bool,
                  objects: &[PathBuf], out_filename: &Path,
+                 trans: &CrateTranslation,
                  outputs: &OutputFilenames,
                  tmpdir: &Path) {
     info!("preparing dylib? ({}) from {:?} to {:?}", dylib, objects,
@@ -829,7 +848,7 @@ fn link_natively(sess: &Session, trans: &CrateTranslation, dylib: bool,
             Box::new(GnuLinker { cmd: &mut cmd, sess: &sess }) as Box<Linker>
         };
         link_args(&mut *linker, sess, dylib, tmpdir,
-                  trans, objects, out_filename, outputs);
+                  objects, out_filename, trans, outputs);
         if !sess.target.target.options.no_compiler_rt {
             linker.link_staticlib("compiler-rt");
         }
@@ -848,7 +867,7 @@ fn link_natively(sess: &Session, trans: &CrateTranslation, dylib: bool,
 
     // Invoke the system linker
     info!("{:?}", &cmd);
-    let prog = time(sess.time_passes(), "running linker", (), |()| cmd.output());
+    let prog = time(sess.time_passes(), "running linker", || cmd.output());
     match prog {
         Ok(prog) => {
             if !prog.status.success() {
@@ -884,9 +903,9 @@ fn link_args(cmd: &mut Linker,
              sess: &Session,
              dylib: bool,
              tmpdir: &Path,
-             trans: &CrateTranslation,
              objects: &[PathBuf],
              out_filename: &Path,
+             trans: &CrateTranslation,
              outputs: &OutputFilenames) {
 
     // The default library location, we need this to find the runtime.
@@ -980,7 +999,7 @@ fn link_args(cmd: &mut Linker,
     // this kind of behavior is pretty platform specific and generally not
     // recommended anyway, so I don't think we're shooting ourself in the foot
     // much with that.
-    add_upstream_rust_crates(cmd, sess, dylib, tmpdir, trans);
+    add_upstream_rust_crates(cmd, sess, dylib, tmpdir);
     add_local_native_libraries(cmd, sess);
     add_upstream_native_libraries(cmd, sess);
 
@@ -1086,8 +1105,7 @@ fn add_local_native_libraries(cmd: &mut Linker, sess: &Session) {
 // dependencies will be linked when producing the final output (instead of
 // the intermediate rlib version)
 fn add_upstream_rust_crates(cmd: &mut Linker, sess: &Session,
-                            dylib: bool, tmpdir: &Path,
-                            trans: &CrateTranslation) {
+                            dylib: bool, tmpdir: &Path) {
     // All of the heavy lifting has previously been accomplished by the
     // dependency_format module of the compiler. This is just crawling the
     // output of that module, adding crates as necessary.
@@ -1096,10 +1114,11 @@ fn add_upstream_rust_crates(cmd: &mut Linker, sess: &Session,
     // will slurp up the object files inside), and linking to a dynamic library
     // involves just passing the right -l flag.
 
+    let formats = sess.dependency_formats.borrow();
     let data = if dylib {
-        trans.crate_formats.get(&config::CrateTypeDylib).unwrap()
+        formats.get(&config::CrateTypeDylib).unwrap()
     } else {
-        trans.crate_formats.get(&config::CrateTypeExecutable).unwrap()
+        formats.get(&config::CrateTypeExecutable).unwrap()
     };
 
     // Invoke get_used_crates to ensure that we get a topological sorting of
@@ -1110,20 +1129,17 @@ fn add_upstream_rust_crates(cmd: &mut Linker, sess: &Session,
         // We may not pass all crates through to the linker. Some crates may
         // appear statically in an existing dylib, meaning we'll pick up all the
         // symbols from the dylib.
-        let kind = match data[cnum as usize - 1] {
-            Some(t) => t,
-            None => continue
-        };
         let src = sess.cstore.get_used_crate_source(cnum).unwrap();
-        match kind {
-            cstore::RequireDynamic => {
-                add_dynamic_crate(cmd, sess, &src.dylib.unwrap().0)
-            }
-            cstore::RequireStatic => {
+        match data[cnum as usize - 1] {
+            Linkage::NotLinked |
+            Linkage::IncludedFromDylib => {}
+            Linkage::Static => {
                 add_static_crate(cmd, sess, tmpdir, dylib, &src.rlib.unwrap().0)
             }
+            Linkage::Dynamic => {
+                add_dynamic_crate(cmd, sess, &src.dylib.unwrap().0)
+            }
         }
-
     }
 
     // Converts a library file-stem into a cc -l argument
@@ -1174,7 +1190,7 @@ fn add_upstream_rust_crates(cmd: &mut Linker, sess: &Session,
         let name = cratepath.file_name().unwrap().to_str().unwrap();
         let name = &name[3..name.len() - 5]; // chop off lib/.rlib
 
-        time(sess.time_passes(), &format!("altering {}.rlib", name), (), |()| {
+        time(sess.time_passes(), &format!("altering {}.rlib", name), || {
             let cfg = archive_config(sess, &dst, Some(cratepath));
             let mut archive = ArchiveBuilder::new(cfg);
             archive.remove_file(METADATA_FILENAME);

--- a/src/librustc_trans/back/linker.rs
+++ b/src/librustc_trans/back/linker.rs
@@ -17,7 +17,7 @@ use std::process::Command;
 
 use back::archive;
 use metadata::csearch;
-use metadata::cstore;
+use middle::dependency_format::Linkage;
 use session::Session;
 use session::config::DebugInfoLevel::{NoDebugInfo, LimitedDebugInfo, FullDebugInfo};
 use session::config::CrateTypeDylib;
@@ -347,9 +347,10 @@ impl<'a> Linker for MsvcLinker<'a> {
             // dynamic library. For all statically linked libraries we take all
             // their reachable symbols and emit them as well.
             let cstore = &sess.cstore;
-            let symbols = trans.crate_formats[&CrateTypeDylib].iter();
+            let formats = sess.dependency_formats.borrow();
+            let symbols = formats[&CrateTypeDylib].iter();
             let symbols = symbols.enumerate().filter_map(|(i, f)| {
-                if let Some(cstore::RequireStatic) = *f {
+                if *f == Linkage::Static {
                     Some((i + 1) as ast::CrateNum)
                 } else {
                     None

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -484,9 +484,9 @@ unsafe fn optimize_and_codegen(cgcx: &CodegenContext,
         cgcx.handler.abort_if_errors();
 
         // Finally, run the actual optimization passes
-        time(config.time_passes, "llvm function passes", (), |()|
+        time(config.time_passes, "llvm function passes", ||
              llvm::LLVMRustRunFunctionPassManager(fpm, llmod));
-        time(config.time_passes, "llvm module passes", (), |()|
+        time(config.time_passes, "llvm module passes", ||
              llvm::LLVMRunPassManager(mpm, llmod));
 
         // Deallocate managers that we're now done with
@@ -495,7 +495,7 @@ unsafe fn optimize_and_codegen(cgcx: &CodegenContext,
 
         match cgcx.lto_ctxt {
             Some((sess, reachable)) if sess.lto() =>  {
-                time(sess.time_passes(), "all lto passes", (), |()|
+                time(sess.time_passes(), "all lto passes", ||
                      lto::run(sess, llmod, tm, reachable, &config));
 
                 if config.emit_lto_bc {
@@ -536,7 +536,7 @@ unsafe fn optimize_and_codegen(cgcx: &CodegenContext,
         llvm::LLVMWriteBitcodeToFile(llmod, out.as_ptr());
     }
 
-    time(config.time_passes, "codegen passes", (), |()| {
+    time(config.time_passes, "codegen passes", || {
         if config.emit_ir {
             let ext = format!("{}.ll", name_extra);
             let out = output_names.with_extension(&ext);

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -2822,7 +2822,6 @@ pub fn trans_crate(tcx: &ty::ctxt, analysis: ty::CrateAnalysis) -> CrateTranslat
         llcx: shared_ccx.metadata_llcx(),
         llmod: shared_ccx.metadata_llmod(),
     };
-    let formats = shared_ccx.tcx().dependency_formats.borrow().clone();
     let no_builtins = attr::contains_name(&krate.attrs, "no_builtins");
 
     CrateTranslation {
@@ -2831,7 +2830,6 @@ pub fn trans_crate(tcx: &ty::ctxt, analysis: ty::CrateAnalysis) -> CrateTranslat
         link: link_meta,
         metadata: metadata,
         reachable: reachable_symbols,
-        crate_formats: formats,
         no_builtins: no_builtins,
     }
 }

--- a/src/librustc_trans/trans/mod.rs
+++ b/src/librustc_trans/trans/mod.rs
@@ -10,7 +10,6 @@
 
 use llvm::{ContextRef, ModuleRef};
 use metadata::common::LinkMeta;
-use middle::dependency_format;
 
 pub use self::base::trans_crate;
 pub use self::context::CrateContext;
@@ -74,6 +73,5 @@ pub struct CrateTranslation {
     pub link: LinkMeta,
     pub metadata: Vec<u8>,
     pub reachable: Vec<String>,
-    pub crate_formats: dependency_format::Dependencies,
     pub no_builtins: bool,
 }

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -332,34 +332,34 @@ pub fn check_crate(tcx: &ty::ctxt, trait_map: ty::TraitMap) {
         tcx: tcx
     };
 
-    time(time_passes, "type collecting", (), |_|
+    time(time_passes, "type collecting", ||
          collect::collect_item_types(tcx));
 
     // this ensures that later parts of type checking can assume that items
     // have valid types and not error
     tcx.sess.abort_if_errors();
 
-    time(time_passes, "variance inference", (), |_|
+    time(time_passes, "variance inference", ||
          variance::infer_variance(tcx));
 
-    time(time_passes, "coherence checking", (), |_|
+    time(time_passes, "coherence checking", ||
         coherence::check_coherence(&ccx));
 
-    time(time_passes, "wf checking (old)", (), |_|
+    time(time_passes, "wf checking (old)", ||
         check::check_wf_old(&ccx));
 
-    time(time_passes, "item-types checking", (), |_|
+    time(time_passes, "item-types checking", ||
         check::check_item_types(&ccx));
 
-    time(time_passes, "item-bodies checking", (), |_|
+    time(time_passes, "item-bodies checking", ||
         check::check_item_bodies(&ccx));
 
-    time(time_passes, "drop-impl checking", (), |_|
+    time(time_passes, "drop-impl checking", ||
         check::check_drop_impls(&ccx));
 
     // Do this last so that if there are errors in the old code, they
     // get reported, and we don't get extra warnings.
-    time(time_passes, "wf checking (new)", (), |_|
+    time(time_passes, "wf checking (new)", ||
         check::check_wf_new(&ccx));
 
     check_for_entry_fn(&ccx);

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -275,8 +275,6 @@ extern crate alloc;
 extern crate rustc_unicode;
 extern crate libc;
 
-#[macro_use] #[no_link] extern crate rustc_bitflags;
-
 // Make std testable by not duplicating lang items and other globals. See #2912
 #[cfg(test)] extern crate std as realstd;
 

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -85,6 +85,7 @@ const KNOWN_FEATURES: &'static [(&'static str, &'static str, Status)] = &[
     ("on_unimplemented", "1.0.0", Active),
     ("simd_ffi", "1.0.0", Active),
     ("allocator", "1.0.0", Active),
+    ("needs_allocator", "1.4.0", Active),
     ("linked_from", "1.3.0", Active),
 
     ("if_let", "1.0.0", Accepted),
@@ -253,6 +254,9 @@ pub const KNOWN_ATTRIBUTES: &'static [(&'static str, AttributeType)] = &[
                                       is an experimental feature")),
     ("allocator", Gated("allocator",
                         "the `#[allocator]` attribute is an experimental feature")),
+    ("needs_allocator", Gated("needs_allocator", "the `#[needs_allocator]` \
+                                                  attribute is an experimental \
+                                                  feature")),
     ("rustc_variance", Gated("rustc_attrs",
                              "the `#[rustc_variance]` attribute \
                               is an experimental feature")),

--- a/src/test/auxiliary/allocator-dummy.rs
+++ b/src/test/auxiliary/allocator-dummy.rs
@@ -1,0 +1,55 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![feature(allocator, no_std, core, core_intrinsics, libc)]
+#![allocator]
+#![crate_type = "rlib"]
+#![no_std]
+
+extern crate libc;
+
+pub static mut HITS: usize = 0;
+
+#[no_mangle]
+pub extern fn __rust_allocate(size: usize, align: usize) -> *mut u8 {
+    unsafe {
+        HITS += 1;
+        libc::malloc(size as libc::size_t) as *mut u8
+    }
+}
+
+#[no_mangle]
+pub extern fn __rust_deallocate(ptr: *mut u8, old_size: usize, align: usize) {
+    unsafe {
+        HITS += 1;
+        libc::free(ptr as *mut _)
+    }
+}
+
+#[no_mangle]
+pub extern fn __rust_reallocate(ptr: *mut u8, old_size: usize, size: usize,
+                                align: usize) -> *mut u8 {
+    unsafe {
+        libc::realloc(ptr as *mut _, size as libc::size_t) as *mut u8
+    }
+}
+
+#[no_mangle]
+pub extern fn __rust_reallocate_inplace(ptr: *mut u8, old_size: usize,
+                                        size: usize, align: usize) -> usize {
+    unsafe { core::intrinsics::abort() }
+}
+
+#[no_mangle]
+pub extern fn __rust_usable_size(size: usize, align: usize) -> usize {
+    unsafe { core::intrinsics::abort() }
+}

--- a/src/test/auxiliary/allocator-dylib.rs
+++ b/src/test/auxiliary/allocator-dylib.rs
@@ -1,0 +1,15 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "dylib"]
+
+pub fn foo() {}

--- a/src/test/auxiliary/allocator-dylib2.rs
+++ b/src/test/auxiliary/allocator-dylib2.rs
@@ -1,0 +1,12 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn foo() {}
+

--- a/src/test/auxiliary/allocator1.rs
+++ b/src/test/auxiliary/allocator1.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![feature(allocator, no_std, core)]
+#![allocator]
+#![crate_type = "rlib"]
+#![no_std]

--- a/src/test/auxiliary/allocator2.rs
+++ b/src/test/auxiliary/allocator2.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![feature(allocator, no_std, core)]
+#![allocator]
+#![crate_type = "rlib"]
+#![no_std]

--- a/src/test/auxiliary/allocator3.rs
+++ b/src/test/auxiliary/allocator3.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![feature(no_std, allocator)]
+#![no_std]
+#![allocator]
+#![crate_type = "rlib"]
+
+extern crate needs_allocator;
+

--- a/src/test/auxiliary/needs_allocator.rs
+++ b/src/test/auxiliary/needs_allocator.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![feature(no_std, needs_allocator)]
+#![no_std]
+#![needs_allocator]
+#![crate_type = "rlib"]

--- a/src/test/compile-fail/allocator-depends-on-needs-allocators.rs
+++ b/src/test/compile-fail/allocator-depends-on-needs-allocators.rs
@@ -1,0 +1,21 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: `allocator3` cannot depend on a crate that needs an allocator
+// aux-build:needs_allocator.rs
+// aux-build:allocator3.rs
+
+// The needs_allocator crate is a dependency of the allocator crate allocator3,
+// which is not allowed
+
+extern crate allocator3;
+
+fn main() {
+}

--- a/src/test/compile-fail/allocator-dylib-is-system.rs
+++ b/src/test/compile-fail/allocator-dylib-is-system.rs
@@ -1,0 +1,27 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-msvc everything is the system allocator on msvc
+// aux-build:allocator-dylib.rs
+// no-prefer-dynamic
+// error-pattern: cannot link together two allocators
+
+// Verify that the allocator for statically linked dynamic libraries is the
+// system allocator. Do this by linking in jemalloc and making sure that we get
+// an error.
+
+#![feature(alloc_jemalloc)]
+
+extern crate allocator_dylib;
+extern crate alloc_jemalloc;
+
+fn main() {
+    allocator_dylib::foo();
+}

--- a/src/test/compile-fail/allocator-rust-dylib-is-jemalloc.rs
+++ b/src/test/compile-fail/allocator-rust-dylib-is-jemalloc.rs
@@ -1,0 +1,26 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-msvc everything is the system allocator on msvc
+// aux-build:allocator-dylib2.rs
+// error-pattern: cannot link together two allocators
+
+// Ensure that rust dynamic libraries use jemalloc as their allocator, verifying
+// by linking in the system allocator here and ensuring that we get a complaint.
+
+#![feature(alloc_system)]
+
+extern crate allocator_dylib2;
+extern crate alloc_system;
+
+fn main() {
+    allocator_dylib2::foo();
+}
+

--- a/src/test/compile-fail/feature-gate-allocator.rs
+++ b/src/test/compile-fail/feature-gate-allocator.rs
@@ -1,0 +1,13 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allocator] //~ ERROR: experimental feature
+
+fn main() {}

--- a/src/test/compile-fail/feature-gate-needs-allocator.rs
+++ b/src/test/compile-fail/feature-gate-needs-allocator.rs
@@ -1,0 +1,14 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![needs_allocator] //~ ERROR the `#[needs_allocator]` attribute is
+
+fn main() {}
+

--- a/src/test/compile-fail/two-allocators-2.rs
+++ b/src/test/compile-fail/two-allocators-2.rs
@@ -1,0 +1,21 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: cannot link together two allocators: allocator1 and allocator2
+// aux-build:allocator1.rs
+// aux-build:allocator2.rs
+
+// Make sure we can't link together two explicit allocators.
+
+extern crate allocator1;
+extern crate allocator2;
+
+fn main() {}
+

--- a/src/test/compile-fail/two-allocators-3.rs
+++ b/src/test/compile-fail/two-allocators-3.rs
@@ -1,0 +1,21 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:allocator1.rs
+// error-pattern: cannot link together two allocators
+
+// We're linking std dynamically (via -C prefer-dynamic for this test) which
+// has an allocator and then we're also linking in a new allocator (allocator1)
+// and this should be an error
+
+extern crate allocator1;
+
+fn main() {
+}

--- a/src/test/compile-fail/two-allocators.rs
+++ b/src/test/compile-fail/two-allocators.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: cannot link together two allocators
+
+// aux-build:allocator1.rs
+// aux-build:allocator2.rs
+
+extern crate allocator1;
+extern crate allocator2;
+
+fn main() {}

--- a/src/test/run-pass/allocator-default.rs
+++ b/src/test/run-pass/allocator-default.rs
@@ -1,0 +1,20 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(alloc_jemalloc, alloc_system)]
+
+#[cfg(not(target_env = "msvc"))]
+extern crate alloc_jemalloc;
+#[cfg(target_env = "msvc")]
+extern crate alloc_system;
+
+fn main() {
+    println!("{:?}", Box::new(3));
+}

--- a/src/test/run-pass/allocator-jemalloc.rs
+++ b/src/test/run-pass/allocator-jemalloc.rs
@@ -1,0 +1,20 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+// ignore-msvc no jemalloc on msvc
+
+#![feature(alloc_jemalloc)]
+
+extern crate alloc_jemalloc;
+
+fn main() {
+    println!("{:?}", Box::new(3));
+}

--- a/src/test/run-pass/allocator-override.rs
+++ b/src/test/run-pass/allocator-override.rs
@@ -1,0 +1,24 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+// aux-build:allocator-dummy.rs
+
+extern crate allocator_dummy;
+
+fn main() {
+    unsafe {
+        let before = allocator_dummy::HITS;
+        let b = Box::new(3);
+        assert_eq!(allocator_dummy::HITS - before, 1);
+        drop(b);
+        assert_eq!(allocator_dummy::HITS - before, 2);
+    }
+}

--- a/src/test/run-pass/allocator-system.rs
+++ b/src/test/run-pass/allocator-system.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![feature(alloc_system)]
+
+extern crate alloc_system;
+
+fn main() {
+    println!("{:?}", Box::new(3));
+}


### PR DESCRIPTION
This commit is an implementation of [RFC 1183](https://github.com/rust-lang/rfcs/pull/1183) which allows swapping out
the default allocator on nightly Rust. No new stable surface area should be
added as a part of this commit.

Two new attributes have been added to the compiler:
- `#![needs_allocator]` - this is used by liballoc (and likely only liballoc) to
  indicate that it requires an allocator crate to be in scope.
- `#![allocator]` - this is a indicator that the crate is an allocator which can
  satisfy the `needs_allocator` attribute above.

The ABI of the allocator crate is defined to be a set of symbols that implement
the standard Rust allocation/deallocation functions. The symbols are not
currently checked for exhaustiveness or typechecked. There are also a number of
restrictions on these crates:
- An allocator crate cannot transitively depend on a crate that is flagged as
  needing an allocator (e.g. allocator crates can't depend on liballoc).
- There can only be one explicitly linked allocator in a final image.
- If no allocator is explicitly requested one will be injected on behalf of the
  compiler. Binaries and Rust dylibs will use jemalloc by default where
  available and staticlibs/other dylibs will use the system allocator by
  default.

Two allocators are provided by the distribution by default, `alloc_system` and
`alloc_jemalloc` which operate as advertised.

Closes #27389
