### PR TITLE
Fix make check-stage1

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -612,8 +612,10 @@ define DEF_CTEST_VARS
 # $(3) is the host triple to test
 
 # Prerequisites for compiletest tests
+# Note that we always use a stage2 compiletest binary; a stage1
+# compiletest is unusable because stage1 binaries can't panic.
 TEST_SREQ$(1)_T_$(2)_H_$(3) = \
-	$$(HBIN$(1)_H_$(3))/compiletest$$(X_$(3)) \
+	$$(HBIN2_H_$(3))/compiletest$$(X_$(3)) \
 	$$(SREQ$(1)_T_$(2)_H_$(3))
 
 # Rules for the cfail/rfail/rpass/bench/perf test runner
@@ -735,7 +737,7 @@ $$(call TEST_OK_FILE,$(1),$(2),$(3),$(4)): \
                 $$(CTEST_DEPS_$(4)_$(1)-T-$(2)-H-$(3))
 	@$$(call E, run $(4) [$(2)]: $$<)
 	$$(Q)touch $$@.start_time
-	$$(Q)$$(call CFG_RUN_CTEST_$(2),$(1),$$<,$(3)) \
+	$$(Q)$$(call CFG_RUN_CTEST_$(2),2,$$<,$(3)) \
 		$$(CTEST_ARGS$(1)-T-$(2)-H-$(3)-$(4)) \
 		--logfile $$(call TEST_LOG_FILE,$(1),$(2),$(3),$(4)) \
                 && touch -r $$@.start_time $$@ && rm $$@.start_time

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -76,13 +76,15 @@ impl Session {
         if self.opts.treat_err_as_bug {
             self.span_bug(sp, msg);
         }
-        panic!(self.diagnostic().span_fatal(sp, msg))
+        let _ = self.diagnostic().span_fatal(sp, msg);
+        diagnostic::raise_fatal_error();
     }
     pub fn span_fatal_with_code(&self, sp: Span, msg: &str, code: &str) -> ! {
         if self.opts.treat_err_as_bug {
             self.span_bug(sp, msg);
         }
-        panic!(self.diagnostic().span_fatal_with_code(sp, msg, code))
+        let _ = self.diagnostic().span_fatal_with_code(sp, msg, code);
+        diagnostic::raise_fatal_error();
     }
     pub fn fatal(&self, msg: &str) -> ! {
         if self.opts.treat_err_as_bug {
@@ -454,7 +456,7 @@ pub fn expect<T, M>(sess: &Session, opt: Option<T>, msg: M) -> T where
 pub fn early_error(msg: &str) -> ! {
     let mut emitter = diagnostic::EmitterWriter::stderr(diagnostic::Auto, None);
     emitter.emit(None, msg, None, diagnostic::Fatal);
-    panic!(diagnostic::FatalError);
+    diagnostic::raise_fatal_error();
 }
 
 pub fn early_warn(msg: &str) {

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -32,7 +32,6 @@
 #![feature(libc)]
 #![feature(ref_slice)]
 #![feature(rustc_private)]
-#![feature(set_stdio)]
 #![feature(staged_api)]
 #![feature(str_char)]
 #![feature(str_escape)]
@@ -55,10 +54,10 @@ extern crate serialize as rustc_serialize; // used by deriving
 macro_rules! panictry {
     ($e:expr) => ({
         use std::result::Result::{Ok, Err};
-        use diagnostic::FatalError;
+        use diagnostic::{FatalError, raise_fatal_error};
         match $e {
             Ok(e) => e,
-            Err(FatalError) => panic!(FatalError)
+            Err(FatalError) => raise_fatal_error(),
         }
     })
 }

--- a/src/test/compile-fail/macro-incomplete-parse.rs
+++ b/src/test/compile-fail/macro-incomplete-parse.rs
@@ -17,8 +17,8 @@ macro_rules! ignored_item {
 }
 
 macro_rules! ignored_expr {
-    () => ( 1,  //~ ERROR unexpected token: `,`
-            2 ) //~ ERROR macro expansion ignores token `2`
+    () => ( 1,  //~ ERROR macro expansion ignores token `,`
+            2 )
 }
 
 macro_rules! ignored_pat {
@@ -28,7 +28,7 @@ macro_rules! ignored_pat {
 ignored_item!(); //~ NOTE caused by the macro expansion here
 
 fn main() {
-    ignored_expr!(); //~ NOTE caused by the macro expansion here
+    (ignored_expr!()); //~ NOTE caused by the macro expansion here
     match 1 {
         ignored_pat!() => (), //~ NOTE caused by the macro expansion here
         _ => (),


### PR DESCRIPTION
stage1 rustc doesn't support catching panics, so we have to just kill
the whole process on a fatal error.  This is a little hacky... but it's not
very much code, and we only use it for stage1 compilers.

Also, use stage2 compiletest to run tests.
