### PR TITLE
fix switched-round 'b' and 'c'

### DIFF
--- a/src/doc/tarpl/repr-rust.md
+++ b/src/doc/tarpl/repr-rust.md
@@ -31,8 +31,8 @@ type's size is a multiple of its alignment. For instance:
 ```rust
 struct A {
     a: u8,
-    c: u32,
-    b: u16,
+    b: u32,
+    c: u16,
 }
 ```
 


### PR DESCRIPTION
this makes the second code block consistent with the first code block -- other than being in reversed order, the first code block claims b is u16 and c is u32, whereas the second code block claims the opposite. seems to be an obvious typo.
