### PR TITLE
Minor grammatical changes to send-and-sync.

### DIFF
--- a/src/doc/tarpl/send-and-sync.md
+++ b/src/doc/tarpl/send-and-sync.md
@@ -5,8 +5,8 @@ multiply alias a location in memory while mutating it. Unless these types use
 synchronization to manage this access, they are absolutely not thread safe. Rust
 captures this with through the `Send` and `Sync` traits.
 
-* A type is Send if it is safe to send it to another thread. A type is Sync if
-* it is safe to share between threads (`&T` is Send).
+* A type is Send if it is safe to send it to another thread.
+* A type is Sync if it is safe to share between threads (`&T` is Send).
 
 Send and Sync are *very* fundamental to Rust's concurrency story. As such, a
 substantial amount of special tooling exists to make them work right. First and
@@ -25,9 +25,9 @@ ever interact with are Send and Sync.
 
 Major exceptions include:
 
-* raw pointers are neither Send nor Sync (because they have no safety guards)
-* `UnsafeCell` isn't Sync (and therefore `Cell` and `RefCell` aren't) `Rc` isn't
-* Send or Sync (because the refcount is shared and unsynchronized)
+* raw pointers are neither Send nor Sync (because they have no safety guards).
+* `UnsafeCell` isn't Sync (and therefore `Cell` and `RefCell` aren't).
+* `Rc` isn't Send or Sync (because the refcount is shared and unsynchronized).
 
 `Rc` and `UnsafeCell` are very fundamentally not thread-safe: they enable
 unsynchronized shared mutable state. However raw pointers are, strictly
@@ -71,7 +71,7 @@ possible cause trouble by being incorrectly Send or Sync.
 Most uses of raw pointers should be encapsulated behind a sufficient abstraction
 that Send and Sync can be derived. For instance all of Rust's standard
 collections are Send and Sync (when they contain Send and Sync types) in spite
-of their pervasive use raw pointers to manage allocations and complex ownership.
+of their pervasive use of raw pointers to manage allocations and complex ownership.
 Similarly, most iterators into these collections are Send and Sync because they
 largely behave like an `&` or `&mut` into the collection.
 


### PR DESCRIPTION
Corrects formatting of bullet-ed sentences and changes 'pervasive use raw pointers' to 'pervasive use of raw pointers'.
