### PR TITLE
Fix #27360's unused import

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -1096,7 +1096,7 @@ pub mod types {
             }
             pub mod posix01 {
                 use types::common::c95::{c_void};
-                use types::common::c99::{uint8_t, uint32_t, int32_t};
+                use types::common::c99::{uint32_t, int32_t};
                 use types::os::arch::c95::{c_long, time_t};
                 use types::os::arch::posix88::{dev_t, gid_t, ino_t};
                 use types::os::arch::posix88::{mode_t, off_t};


### PR DESCRIPTION
#27360 removed a padding field full of uint8_t's, but didn't remove

the use.  This didn't get picked up presumably because (a) bors
doesn't have any BSD builders, and/or (b) #[cfg]'d out blocks don't
get linted.

```
rustc: x86_64-unknown-freebsd/stage1/lib/rustlib/x86_64-unknown-freebsd/lib/liblibc
src/liblibc/lib.rs:1099:42: 1099:49 error: unused import, #[deny(unused_imports)] on by default
src/liblibc/lib.rs:1099                 use types::common::c99::{uint8_t, uint32_t, int32_t};
                                                                 ^~~~~~~
error: aborting due to previous error
fatal runtime error: Could not unwind stack, error = 159555904
```
