### PR TITLE
More perseverant resolve (second try)

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -278,7 +278,7 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
                                                 Some((&*import_path_to_string(
                                                         &import_directive.module_path,
                                                         import_directive.subclass),
-                                                      Some(&*help))))
+                                                      &*help)))
                                    );
                 }
                 ResolveResult::Indeterminate => break, // Bail out. We'll come around next time.

--- a/src/test/compile-fail/issue-25396.rs
+++ b/src/test/compile-fail/issue-25396.rs
@@ -11,14 +11,14 @@
 use foo::baz;
 use bar::baz; //~ ERROR a module named `baz` has already been imported
 
-use foo::Quux;
 use bar::Quux; //~ ERROR a trait named `Quux` has already been imported
+use foo::Quux;
 
-use foo::blah;
-use bar::blah; //~ ERROR a type named `blah` has already been imported
+use foo::blah; //~ ERROR a type named `blah` has already been imported
+use bar::blah;
 
-use foo::WOMP;
-use bar::WOMP; //~ ERROR a value named `WOMP` has already been imported
+use foo::WOMP; //~ ERROR a value named `WOMP` has already been imported
+use bar::WOMP;
 
 fn main() {}
 

--- a/src/test/run-pass/import-glob-1.rs
+++ b/src/test/run-pass/import-glob-1.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,7 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(unused_imports, dead_code)]
+// This should resolve fine. Prior to fix, the last import
+// was being tried too early, and marked as unrsolved before
+// the glob import had a chance to be resolved.
 
 mod bar {
     pub use self::middle::*;

--- a/src/test/run-pass/import-glob-1.rs
+++ b/src/test/run-pass/import-glob-1.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,23 +8,25 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Test that import shadowing using globs causes errors
-
-#![no_implicit_prelude]
-
-use qux::*; //~ERROR a type named `Baz` has already been imported in this module
-use foo::*;
-
-mod foo {
-    pub type Baz = isize;
-}
+#![allow(unused_imports, dead_code)]
 
 mod bar {
-    pub type Baz = isize;
+    pub use self::middle::*;
+
+    mod middle {
+        pub use self::baz::Baz;
+
+        mod baz {
+            pub enum Baz {
+                Baz1,
+                Baz2
+            }
+        }
+    }
 }
 
-mod qux {
-    pub use bar::Baz;
+mod foo {
+    use bar::Baz::{Baz1, Baz2};
 }
 
 fn main() {}

--- a/src/test/run-pass/issue-18083.rs
+++ b/src/test/run-pass/issue-18083.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,23 +8,22 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Test that import shadowing using globs causes errors
+mod a {
+    use b::{B};
+    pub use self::inner::A;
 
-#![no_implicit_prelude]
-
-use qux::*; //~ERROR a type named `Baz` has already been imported in this module
-use foo::*;
-
-mod foo {
-    pub type Baz = isize;
+    mod inner {
+        pub struct A;
+    }
 }
 
-mod bar {
-    pub type Baz = isize;
-}
+mod b {
+    use a::{A};
+    pub use self::inner::B;
 
-mod qux {
-    pub use bar::Baz;
+    mod inner {
+        pub struct B;
+    }
 }
 
 fn main() {}

--- a/src/test/run-pass/issue-18083.rs
+++ b/src/test/run-pass/issue-18083.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// These crossed imports should resolve fine, and not block on
+// each other and be reported as unresolved.
+
 mod a {
     use b::{B};
     pub use self::inner::A;

--- a/src/test/run-pass/issue-4865-1.rs
+++ b/src/test/run-pass/issue-4865-1.rs
@@ -8,6 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// This should resolve fine.
+// Prior to fix, the crossed imports between a and b
+// would block on the glob import, itself never being resolved
+// because these previous imports were not resolved.
+
 pub mod a {
     use b::fn_b;
     use c::*;

--- a/src/test/run-pass/issue-4865-1.rs
+++ b/src/test/run-pass/issue-4865-1.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,23 +8,29 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Test that import shadowing using globs causes errors
+pub mod a {
+    use b::fn_b;
+    use c::*;
 
-#![no_implicit_prelude]
-
-use qux::*; //~ERROR a type named `Baz` has already been imported in this module
-use foo::*;
-
-mod foo {
-    pub type Baz = isize;
+    pub fn fn_a(){
+    }
 }
 
-mod bar {
-    pub type Baz = isize;
+pub mod b {
+    use a::fn_a;
+    use c::*;
+
+    pub fn fn_b(){
+    }
 }
 
-mod qux {
-    pub use bar::Baz;
+pub mod c{
+    pub fn fn_c(){
+    }
 }
 
-fn main() {}
+use a::fn_a;
+use b::fn_b;
+
+fn main() {
+}


### PR DESCRIPTION
(This is a second try at #26242. This time I think things should be ok.)

The current algorithm handling import resolutions works sequentially, handling imports in the order they appear in the source file, and blocking/bailing on the first one generating an error/being unresolved.

This can lead to situations where the order of the `use` statements can make the difference between "this code compiles" and "this code fails on an unresolved import" (see #18083 for example). This is especially true when considering glob imports.

This PR changes the behaviour of the algorithm to instead try to resolve all imports in a module. If one fails, it is recorded and the next one is tried (instead of directly giving up). Also, all errors generated are stored (and not reported directly).

The main loop of the algorithms guaranties that the algorithm will always finish: if a round of resolution does not resolve anything new, we are stuck and give up. At this point, the new version of the algorithm will display all errors generated by the last round of resolve. This way we are sure to not silence relevant errors or help messages, but also to not give up too early.

**As a consequence, the import resolution becomes independent of the order in which the `use` statements are written in the source files.** I personally don't see any situations where this could be a problem, but this might need some thought.

I passed `rpass` and `cfail` tests on my computer, and now am compiling a full stage2 compiler to ensure the crates reporting errors in my previous attempts still build correctly. I guess once I have checked it, this will need a crater run?

Fixes #18083.

r? @alexcrichton , cc @nrc @brson 
