### PR TITLE
adds FreeBSD i686 snapshot

### DIFF
--- a/src/snapshots.txt
+++ b/src/snapshots.txt
@@ -1,5 +1,6 @@
 S 2015-07-26 a5c12f4
   bitrig-x86_64 8734eb41ffbe6ddc1120aa2910db4162ec9cf270
+  freebsd-i386 2fee22adec101e2f952a5548fd1437ce1bd8d26f
   freebsd-x86_64 bc50b0f8d7f6d62f4f5ffa136f5387f5bf6524fd
   linux-i386 3459275cdf3896f678e225843fa56f0d9fdbabe8
   linux-x86_64 e451e3bd6e5fcef71e41ae6f3da9fb1cf0e13a0c


### PR DESCRIPTION
@alexcrichton please upload the FreeBSD 32-bit snapshot file when landing this patch:
https://github.com/dhuseby/rust-manual-snapshots/raw/master/rust-stage0-2015-07-26-a5c12f4-freebsd-i386-2fee22adec101e2f952a5548fd1437ce1bd8d26f.tar.bz2
