### PR TITLE
Fix "Ignoring variants" in "Patterns" chapter

### DIFF
--- a/src/doc/trpl/patterns.md
+++ b/src/doc/trpl/patterns.md
@@ -112,26 +112,55 @@ match x {
 }
 ```
 
-# Ignoring variants
+# Ignoring bindings
 
-If you’re matching on an enum which has variants, you can use `..` to
-ignore the value and type in the variant:
+You can use `_` in a pattern to disregard the type and value.
+For example, here’s a `match` against a `Result<T, E>`:
 
 ```rust
-enum OptionalInt {
-    Value(i32),
-    Missing,
-}
-
-let x = OptionalInt::Value(5);
-
-match x {
-    OptionalInt::Value(..) => println!("Got an int!"),
-    OptionalInt::Missing => println!("No such luck."),
+# let some_value: Result<i32, &'static str> = Err("There was an error");
+match some_value {
+    Ok(value) => println!("got a value: {}", value),
+    Err(_) => println!("an error occurred"),
 }
 ```
 
-This prints `Got an int!`.
+In the first arm, we bind the value inside the `Ok` variant to `value`. But
+in the `Err` arm, we use `_` to disregard the specific error, and just print
+a general error message.
+
+`_` is valid in any pattern that creates a binding. This can be useful to
+ignore parts of a larger structure:
+
+```rust
+fn coordinate() -> (i32, i32, i32) {
+    // generate and return some sort of triple tuple
+# (1, 2, 3)
+}
+
+let (x, _, z) = coordinate();
+```
+
+Here, we bind the first and last element of the tuple to `x` and `z`, but
+ignore the middle element.
+
+Similarly, you can use `..` in a pattern to disregard multiple values.
+
+```rust
+enum OptionalTuple {
+    Value(i32, i32, i32),
+    Missing,
+}
+
+let x = OptionalTuple::Value(5, -2, 3);
+
+match x {
+    OptionalTuple::Value(..) => println!("Got a tuple!"),
+    OptionalTuple::Missing => println!("No such luck."),
+}
+```
+
+This prints `Got a tuple!`.
 
 # Guards
 
@@ -281,38 +310,6 @@ This ‘destructuring’ behavior works on any compound data type, like
 
 [tuples]: primitive-types.html#tuples
 [enums]: enums.html
-
-# Ignoring bindings
-
-You can use `_` in a pattern to disregard the value. For example, here’s a
-`match` against a `Result<T, E>`:
-
-```rust
-# let some_value: Result<i32, &'static str> = Err("There was an error");
-match some_value {
-    Ok(value) => println!("got a value: {}", value),
-    Err(_) => println!("an error occurred"),
-}
-```
-
-In the first arm, we bind the value inside the `Ok` variant to `value`. But
-in the `Err` arm, we use `_` to disregard the specific error, and just print
-a general error message.
-
-`_` is valid in any pattern that creates a binding. This can be useful to
-ignore parts of a larger structure:
-
-```rust
-fn coordinate() -> (i32, i32, i32) {
-    // generate and return some sort of triple tuple
-# (1, 2, 3)
-}
-
-let (x, _, z) = coordinate();
-```
-
-Here, we bind the first and last element of the tuple to `x` and `z`, but
-ignore the middle element.
 
 # Mix and Match
 


### PR DESCRIPTION
- Fix #26968 by noting the difference between ".." and "_" more explicitly
- Change one of the examples to show the match-all behaviour of ".."
- Merge "Ignoring variants" and "Ignoring bindings" sections into the latter

r? @steveklabnik
