### PR TITLE
Ignore PhantomData when checking CoerceUnsized implementations

### DIFF
--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -538,7 +538,12 @@ fn coerce_unsized<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                               Rvalue::new(ByRef)));
                 } else {
                     // Otherwise, simply copy the data from the source.
-                    assert_eq!(src_ty, target_ty);
+                    let is_phantom = if let &ty::TyStruct(def_id, _) = &src_ty.sty {
+                        Some(def_id) == bcx.tcx().lang_items.phantom_data()
+                    } else {
+                        false
+                    };
+                    assert!(is_phantom || src_ty == target_ty);
                     memcpy_ty(bcx, ll_target, ll_source, src_ty);
                 }
             }

--- a/src/test/compile-fail/issue-26905.rs
+++ b/src/test/compile-fail/issue-26905.rs
@@ -1,0 +1,33 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(unsize, coerce_unsized)]
+
+// Verfies that non-PhantomData ZSTs still cause coercions to fail.
+// They might have additional semantics that we don't want to bulldoze.
+
+use std::marker::{Unsize, PhantomData};
+use std::ops::CoerceUnsized;
+
+struct NotPhantomData<T>(PhantomData<T>);
+
+struct MyRc<T: ?Sized> {
+    _ptr: *const T,
+    _boo: NotPhantomData<T>, //~ERROR
+}
+
+impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<MyRc<U>> for MyRc<T>{ }
+
+fn main() {
+    let data = [1, 2, 3];
+    let iter = data.iter();
+    let x = MyRc { _ptr: &iter, _boo: NotPhantomData(PhantomData) };
+    let _y: MyRc<Iterator<Item=&u32>> = x;
+}

--- a/src/test/run-pass/issue-26905.rs
+++ b/src/test/run-pass/issue-26905.rs
@@ -1,0 +1,30 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(unsize, coerce_unsized)]
+
+// Verfies that PhantomData is ignored for DST coercions
+
+use std::marker::{Unsize, PhantomData};
+use std::ops::CoerceUnsized;
+
+struct MyRc<T: ?Sized> {
+    _ptr: *const T,
+    _boo: PhantomData<T>,
+}
+
+impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<MyRc<U>> for MyRc<T>{ }
+
+fn main() {
+    let data = [1, 2, 3];
+    let iter = data.iter();
+    let x = MyRc { _ptr: &iter, _boo: PhantomData };
+    let _y: MyRc<Iterator<Item=&u32>> = x;
+}


### PR DESCRIPTION
Fixes #26905 

May want to wait on https://github.com/rust-lang/rfcs/pull/1234

I'm not super happy with the duplicated logic in trans and typeck, and would love to know if there's a "better way". It's pretty minimal, regardless.

r? @nrc
