### PR TITLE
Use different numbers of `#`s when expanding documentation comments

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -365,6 +365,9 @@ pub mod builtin {
     /// stringification of all the tokens passed to the macro. No restrictions
     /// are placed on the syntax of the macro invocation itself.
     ///
+    /// Note that the expanded results of the input tokens may change in the
+    /// future. You should be careful if you rely on the output.
+    ///
     /// # Examples
     ///
     /// ```

--- a/src/test/run-pass/macro-doc-raw-str-hashes.rs
+++ b/src/test/run-pass/macro-doc-raw-str-hashes.rs
@@ -1,0 +1,39 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// The number of `#`s used to wrap the documentation comment should differ regarding the content.
+//
+// Related issue: #27489
+
+macro_rules! homura {
+    ($x:expr, #[$y:meta]) => (assert_eq!($x, stringify!($y)))
+}
+
+fn main() {
+    homura! {
+        r#"doc = r" Madoka""#,
+        /// Madoka
+    };
+
+    homura! {
+        r##"doc = r#" One quote mark: ["]"#"##,
+        /// One quote mark: ["]
+    };
+
+    homura! {
+        r##"doc = r#" Two quote marks: [""]"#"##,
+        /// Two quote marks: [""]
+    };
+
+    homura! {
+        r#####"doc = r####" Raw string ending sequences: ["###]"####"#####,
+        /// Raw string ending sequences: ["###]
+    };
+}


### PR DESCRIPTION
Any documentation comments that contain raw-string-looking sequences may pretty-print invalid code when expanding them, as the current logic always uses the `r"literal"` form, without appending any `#`s.

This commit calculates the minimum number of `#`s required to wrap a comment correctly and appends `#`s appropriately.

Fixes #27489.
