### PR TITLE
trans: Specify `archive_format` for MSVC

### DIFF
--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -243,6 +243,9 @@ $(foreach target,$(CFG_TARGET), \
 # Windows MSVC in the compiler, but the gist of it is that we use `llvm-ar.exe`
 # instead of `lib.exe` for assembling archives, so we need to inject this custom
 # dependency here.
+#
+# FIXME(stage0): remove this and all other relevant support in the makefiles
+#                after a snapshot is made
 define ADD_LLVM_AR_TO_MSVC_DEPS
 ifeq ($$(findstring msvc,$(1)),msvc)
 NATIVE_TOOL_DEPS_core_T_$(1) += llvm-ar.exe

--- a/mk/target.mk
+++ b/mk/target.mk
@@ -206,6 +206,9 @@ $(foreach host,$(CFG_HOST), \
 # $(3) - triple snapshot is built for
 # $(4) - crate
 # $(5) - tool
+#
+# FIXME(stage0): remove this and all other relevant support in the makefiles
+#                after a snapshot is made
 define MOVE_TOOLS_TO_SNAPSHOT_HOST_DIR
 ifneq (,$(3))
 $$(TLIB$(1)_T_$(2)_H_$(2))/stamp.$(4): $$(HLIB$(1)_H_$(2))/rustlib/$(3)/bin/$(5)
@@ -230,6 +233,9 @@ $(foreach target,$(CFG_TARGET), \
 #   path instead of MinGW's /usr/bin/link.exe (entirely unrelated)
 #
 # The values for these variables are detected by the configure script.
+#
+# FIXME(stage0): remove this and all other relevant support in the makefiles
+#                after a snapshot is made
 define SETUP_LIB_MSVC_ENV_VARS
 ifeq ($$(findstring msvc,$(2)),msvc)
 $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$(4): \

--- a/src/librustc_back/target/windows_msvc_base.rs
+++ b/src/librustc_back/target/windows_msvc_base.rs
@@ -60,6 +60,7 @@ pub fn opts() -> TargetOptions {
             "/NOLOGO".to_string(),
             "/NXCOMPAT".to_string(),
         ],
+        archive_format: "gnu".to_string(),
 
         .. Default::default()
     }


### PR DESCRIPTION
This means that we no longer need to ship the `llvm-ar.exe` binary in the MSVC
distribution, and after a snapshot we can remove a good bit of logic from the
makefiles!
