### PR TITLE
Completely disable distcheck

### DIFF
--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -288,8 +288,7 @@ endif
 
 dist: $(MAYBE_DIST_TAR_SRC) dist-tar-bins $(MAYBE_DIST_DOCS)
 
-distcheck: $(MAYBE_DISTCHECK_TAR_SRC) distcheck-tar-bins $(MAYBE_DISTCHECK_DOCS)
-	$(Q)rm -Rf tmp/distcheck
+distcheck:
 	@echo
 	@echo -----------------------------------------------
 	@echo "Rust ready for distribution (see ./dist)"


### PR DESCRIPTION
This is a temporary measure to expedite the 1.3 beta, which besides
a single non-vital test failure on the dist builders have already
been validated.

This will be reverted for the next beta.

r? @aturon 
