### PR TITLE
Revert "Completely disable distcheck"

### DIFF
--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -288,7 +288,8 @@ endif
 
 dist: $(MAYBE_DIST_TAR_SRC) dist-tar-bins $(MAYBE_DIST_DOCS)
 
-distcheck:
+distcheck: $(MAYBE_DISTCHECK_TAR_SRC) distcheck-tar-bins $(MAYBE_DISTCHECK_DOCS)
+	$(Q)rm -Rf tmp/distcheck
 	@echo
 	@echo -----------------------------------------------
 	@echo "Rust ready for distribution (see ./dist)"


### PR DESCRIPTION
This reverts commit 1430229b18c2b47a013f2943489557b810bf71db.

Don't merge until 1.3.0-beta.1 is successfully released.
