### PR TITLE
Fix #27567: remove --crate-type=lib from pretty test

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -315,7 +315,6 @@ actual:\n\
         // FIXME (#9639): This needs to handle non-utf8 paths
         let mut args = vec!("-".to_string(),
                             "-Zno-trans".to_string(),
-                            "--crate-type=lib".to_string(),
                             format!("--target={}", target),
                             "-L".to_string(),
                             config.build_base.to_str().unwrap().to_string(),

--- a/src/test/pretty/blank-lines.rs
+++ b/src/test/pretty/blank-lines.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: --crate-type=lib
+
 // pp-exact
 fn f() -> [isize; 3] {
     let picard = 0;

--- a/src/test/pretty/block-comment-multiple-asterisks.rs
+++ b/src/test/pretty/block-comment-multiple-asterisks.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: --crate-type=lib
+
 // pp-exact
 /***
 More than two asterisks means that it isn't a doc comment.

--- a/src/test/pretty/block-comment-trailing-whitespace.rs
+++ b/src/test/pretty/block-comment-trailing-whitespace.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: --crate-type=lib
+
 // pp-exact
 fn f() {
     /*

--- a/src/test/pretty/block-comment-trailing-whitespace2.rs
+++ b/src/test/pretty/block-comment-trailing-whitespace2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: --crate-type=lib
+
 // pp-exact
 fn f() {
 } /*

--- a/src/test/pretty/block-disambig.rs
+++ b/src/test/pretty/block-disambig.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: --crate-type=lib
+
 // A bunch of tests for syntactic forms involving blocks that were
 // previously ambiguous (e.g. 'if true { } *val;' gets parsed as a
 // binop)

--- a/src/test/pretty/doc-comments.rs
+++ b/src/test/pretty/doc-comments.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: --crate-type=lib
+
 // pp-exact
 
 // some single-line non-doc comment

--- a/src/test/pretty/empty-impl.pp
+++ b/src/test/pretty/empty-impl.pp
@@ -1,5 +1,0 @@
-trait X { }
-impl X for uint { }
-
-trait Y { }
-impl Y for uint { }

--- a/src/test/pretty/empty-impl.rs
+++ b/src/test/pretty/empty-impl.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: --crate-type=lib
+
 trait X { fn dummy(&self) { } }
 impl X for usize { }
 

--- a/src/test/pretty/empty-lines.rs
+++ b/src/test/pretty/empty-lines.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: --crate-type=lib
+
 // Issue #759
 // Whitespace under block opening should not expand forever
 

--- a/src/test/pretty/for-comment.rs
+++ b/src/test/pretty/for-comment.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: --crate-type=lib
+
 // pp-exact
 
 fn f(v: &[isize]) -> isize {

--- a/src/test/pretty/import-renames.rs
+++ b/src/test/pretty/import-renames.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: --crate-type=lib
+
 // pp-exact
 
 use std::io::{self, Error as IoError};

--- a/src/test/pretty/unary-op-disambig.rs
+++ b/src/test/pretty/unary-op-disambig.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: --crate-type=lib
+
 // Preserve semicolons that disambiguate unops
 
 fn f() { }


### PR DESCRIPTION
Because I wanted to change the pretty test as little as possible I added `// compiler-flags: --crate-type=lib` to those test that failed because of a missing `main`. Passes `make check-stage1-pretty` locally.

cc @nrc
cc #27567
