### PR TITLE
Add a safe way to use NonZero

### DIFF
--- a/src/libcore/nonzero.rs
+++ b/src/libcore/nonzero.rs
@@ -14,6 +14,9 @@
 
 use marker::Sized;
 use ops::{CoerceUnsized, Deref};
+use mem;
+use option::Option;
+use ptr;
 
 /// Unsafe trait to indicate what types are usable with the NonZero struct
 pub unsafe trait Zeroable {}
@@ -43,6 +46,20 @@ impl<T: Zeroable> NonZero<T> {
     #[inline(always)]
     pub unsafe fn new(inner: T) -> NonZero<T> {
         NonZero(inner)
+    }
+    /// Tries to create an instance of NonZero with the provided value.
+    /// If the value is actually "non-zero", the function will succeed,
+    /// returning `Some(NonZero(value))`. Otherwise, `None` will be
+    /// returned.
+    #[inline(always)]
+    pub fn new_option(inner: T) -> Option<NonZero<T>> {
+        unsafe {
+            // Work around the fact that `mem::transmute` will
+            // complain about generic types:
+            let result = ptr::read(&inner as *const T as *const Option<NonZero<T>>);
+            mem::forget(inner);
+            result
+        }
     }
 }
 

--- a/src/libcoretest/nonzero.rs
+++ b/src/libcoretest/nonzero.rs
@@ -42,6 +42,31 @@ fn test_match_on_nonzero_option() {
 }
 
 #[test]
+fn test_nonzero_new_option() {
+    let a = NonZero::new_option(42);
+    match a {
+        Some(val) => assert_eq!(*val, 42),
+        None => panic!("unexpected None while matching on NonZero::new_option(42)")
+    }
+
+    match NonZero::new_option(43) {
+        Some(val) => assert_eq!(*val, 43),
+        None => panic!("unexpected None while matching on NonZero::new_option(43)")
+    }
+
+    let b = NonZero::new_option(0);
+    match b {
+        Some(_) => panic!("unexpected Some(_) while matching on NonZero::new_option(0)"),
+        None => ()
+    }
+
+    match NonZero::new_option(0) {
+        Some(_) => panic!("unexpected Some(_) while matching on NonZero::new_option(0)"),
+        None => ()
+    }
+}
+
+#[test]
 fn test_match_option_empty_vec() {
     let a: Option<Vec<isize>> = Some(vec![]);
     match a {


### PR DESCRIPTION
It should be possible to go from a `T: Zeroable` to an `Option<NonZero<T>>` without requiring unsafe code, so this PR adds a new method, `NonZero::new_option(...)` for that purpose.

This should be a no-op, and ideally it would use `mem::transmute`, but that isn't possible in generic code, so I had to fall back to this slightly less safe alternative.
