### PR TITLE
Cache a linear search for the #[staged_api] attribute.

### DIFF
--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -22,7 +22,6 @@ use rbml::reader;
 use std::rc::Rc;
 use syntax::ast;
 use syntax::attr;
-use syntax::attr::AttrMetaMethods;
 use syntax::diagnostic::expect;
 
 use std::collections::hash_map::HashMap;
@@ -386,15 +385,7 @@ pub fn get_stability(cstore: &cstore::CStore,
 }
 
 pub fn is_staged_api(cstore: &cstore::CStore, krate: ast::CrateNum) -> bool {
-    let cdata = cstore.get_crate_data(krate);
-    let attrs = decoder::get_crate_attributes(cdata.data());
-    for attr in &attrs {
-        if &attr.name()[..] == "staged_api" {
-            match attr.node.value.node { ast::MetaWord(_) => return true, _ => (/*pass*/) }
-        }
-    }
-
-    return false;
+    cstore.get_crate_data(krate).staged_api
 }
 
 pub fn get_repr_attrs(cstore: &cstore::CStore, def: ast::DefId)

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -63,6 +63,7 @@ pub struct crate_metadata {
     pub cnum: ast::CrateNum,
     pub codemap_import_info: RefCell<Vec<ImportedFileMap>>,
     pub span: codemap::Span,
+    pub staged_api: bool
 }
 
 #[derive(Copy, Debug, PartialEq, Clone)]


### PR DESCRIPTION
This search happens a lot! Locally, compiling hyper sees the following improvements:

before

real    0m30.843s
user    0m51.644s
sys     0m2.128s

real    0m30.164s
user    0m53.320s
sys     0m2.208s

after

real    0m28.438s
user    0m51.076s
sys     0m2.276s

real    0m28.612s
user    0m51.560s
sys     0m2.192s
