### PR TITLE
Revert "Revert "Fix `missing_docs` lint for const and static.""

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1869,6 +1869,8 @@ impl LintPass for MissingDoc {
                 }
                 return
             },
+            ast::ItemConst(..) => "a constant",
+            ast::ItemStatic(..) => "a static",
             _ => return
         };
 

--- a/src/test/compile-fail/lint-missing-doc.rs
+++ b/src/test/compile-fail/lint-missing-doc.rs
@@ -150,6 +150,27 @@ pub enum PubBaz3 {
 #[doc(hidden)]
 pub fn baz() {}
 
+
+const FOO: u32 = 0;
+/// dox
+pub const FOO1: u32 = 0;
+#[allow(missing_docs)]
+pub const FOO2: u32 = 0;
+#[doc(hidden)]
+pub const FOO3: u32 = 0;
+pub const FOO4: u32 = 0; //~ ERROR: missing documentation for a const
+
+
+static BAR: u32 = 0;
+/// dox
+pub static BAR1: u32 = 0;
+#[allow(missing_docs)]
+pub static BAR2: u32 = 0;
+#[doc(hidden)]
+pub static BAR3: u32 = 0;
+pub static BAR4: u32 = 0; //~ ERROR: missing documentation for a static
+
+
 mod internal_impl {
     /// dox
     pub fn documented() {}


### PR DESCRIPTION
This reverts commit 9191a7895574ec3aa5a9b84ce0008d91e32ccd6a.

This was reverted previously until the `--cap-lints` option was implemented.
