### PR TITLE
Trim trailing newline from FormatMessageW

### DIFF
--- a/src/libstd/sys/windows/os.rs
+++ b/src/libstd/sys/windows/os.rs
@@ -84,9 +84,13 @@ pub fn error_string(errnum: i32) -> String {
         }
 
         let b = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
-        let msg = String::from_utf16(&buf[..b]);
-        match msg {
-            Ok(msg) => msg,
+        match String::from_utf16(&buf[..b]) {
+            Ok(mut msg) => {
+                // Trim trailing CRLF inserted by FormatMessageW
+                let len = msg.trim_right().len();
+                msg.truncate(len);
+                msg
+            },
             Err(..) => format!("OS Error {} (FormatMessageW() returned \
                                 invalid UTF-16)", errnum),
         }


### PR DESCRIPTION
`FormatMessageW` always inserts trailing `\r\n` to system messages which is a minor annoyance when they're fed to `Debug` but can break formatting with `Display`.

``` rust
fn main() {
    use std::env;
    if let Err(err) = env::set_current_dir("???") {
        println!("{:#?}\n{}", err, err);
    }
}
```

``` _
Error {
    repr: Os {
        code: 2,
        message: "The system cannot find the file specified.\r\n"
    }
}
The system cannot find the file specified.
 (os error 2)
```
