### PR TITLE
Disable nonzeroing move hint by default

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -596,8 +596,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
           "Force drop flag checks on or off"),
     trace_macros: bool = (false, parse_bool,
           "For every macro invocation, print its name and arguments"),
-    disable_nonzeroing_move_hints: bool = (false, parse_bool,
-          "Force nonzeroing move optimization off"),
+    enable_nonzeroing_move_hints: bool = (false, parse_bool,
+          "Force nonzeroing move optimization on"),
 }
 
 pub fn default_lib_output() -> CrateType {

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -273,7 +273,7 @@ impl Session {
         self.opts.debugging_opts.print_enum_sizes
     }
     pub fn nonzeroing_move_hints(&self) -> bool {
-        !self.opts.debugging_opts.disable_nonzeroing_move_hints
+        self.opts.debugging_opts.enable_nonzeroing_move_hints
     }
     pub fn sysroot<'a>(&'a self) -> &'a Path {
         match self.opts.maybe_sysroot {

--- a/src/test/run-pass/issue-27401-dropflag-reinit.rs
+++ b/src/test/run-pass/issue-27401-dropflag-reinit.rs
@@ -1,0 +1,34 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that when a `let`-binding occurs in a loop, its associated
+// drop-flag is reinitialized (to indicate "needs-drop" at the end of
+// the owning variable's scope).
+
+struct A<'a>(&'a mut i32);
+
+impl<'a> Drop for A<'a> {
+    fn drop(&mut self) {
+        *self.0 += 1;
+    }
+}
+
+fn main() {
+    let mut cnt = 0;
+    for i in 0..2 {
+        let a = A(&mut cnt);
+        if i == 1 { // Note that
+            break;  //  both this break
+        }           //   and also
+        drop(a);    //    this move of `a`
+        // are necessary to expose the bug
+    }
+    assert_eq!(cnt, 2);
+}

--- a/src/test/run-pass/issue-27401-dropflag-reinit.rs
+++ b/src/test/run-pass/issue-27401-dropflag-reinit.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-pretty #27582
+
 // Check that when a `let`-binding occurs in a loop, its associated
 // drop-flag is reinitialized (to indicate "needs-drop" at the end of
 // the owning variable's scope).


### PR DESCRIPTION
Turn nonzeroing move hints back off by default.

Works around bugs injected by PR #26173.
- (@pnkfelix is unavailable in the short-term (i.e. for the next week) to fix them.)
- When the bugs are fixed, we will turn nonzeroing move hints back on by default.

Fix #27401
