### PR TITLE
Implement read_exact for the Read trait

### DIFF
--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -147,6 +147,15 @@ pub enum ErrorKind {
     #[stable(feature = "rust1", since = "1.0.0")]
     Other,
 
+    /// An error returned when an operation could not be completed because an
+    /// "end of file" was reached prematurely.
+    ///
+    /// This typically means that an operation could only succeed if it read a
+    /// particular number of bytes but only a smaller number of bytes could be
+    /// read.
+    #[unstable(feature = "read_exact", reason = "recently added")]
+    UnexpectedEOF,
+
     /// Any I/O error not part of this list.
     #[unstable(feature = "io_error_internals",
                reason = "better expressed through extensible enums that this \

--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -153,7 +153,7 @@ pub enum ErrorKind {
     /// This typically means that an operation could only succeed if it read a
     /// particular number of bytes but only a smaller number of bytes could be
     /// read.
-    #[unstable(feature = "read_exact", reason = "recently added")]
+    #[unstable(feature = "read_exact", reason = "recently added", issue = "27585")]
     UnexpectedEOF,
 
     /// Any I/O error not part of this list.

--- a/src/libstd/io/impls.rs
+++ b/src/libstd/io/impls.rs
@@ -38,6 +38,11 @@ impl<'a, R: Read + ?Sized> Read for &'a mut R {
     fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
         (**self).read_to_string(buf)
     }
+
+    #[inline]
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        (**self).read_exact(buf)
+    }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, W: Write + ?Sized> Write for &'a mut W {
@@ -97,6 +102,11 @@ impl<R: Read + ?Sized> Read for Box<R> {
     fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
         (**self).read_to_string(buf)
     }
+
+    #[inline]
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        (**self).read_exact(buf)
+    }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<W: Write + ?Sized> Write for Box<W> {
@@ -152,6 +162,17 @@ impl<'a> Read for &'a [u8] {
         slice::bytes::copy_memory(a, buf);
         *self = b;
         Ok(amt)
+    }
+
+    #[inline]
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        if buf.len() > self.len() {
+            return Err(Error::new(ErrorKind::UnexpectedEOF, "failed to fill whole buffer"));
+        }
+        let (a, b) = self.split_at(buf.len());
+        slice::bytes::copy_memory(a, buf);
+        *self = b;
+        Ok(())
     }
 }
 

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -363,7 +363,7 @@ pub trait Read {
     /// # Ok(())
     /// # }
     /// ```
-    #[unstable(feature = "read_exact", reason = "recently added")]
+    #[unstable(feature = "read_exact", reason = "recently added", issue = "27585")]
     fn read_exact(&mut self, mut buf: &mut [u8]) -> Result<()> {
         while !buf.is_empty() {
             match self.read(buf) {

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -271,6 +271,9 @@ impl Read for Stdin {
     fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
         self.lock().read_to_string(buf)
     }
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        self.lock().read_exact(buf)
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
This implements the proposed "read_exact" RFC (https://github.com/rust-lang/rfcs/pull/980).

Tracking issue: https://github.com/rust-lang/rust/issues/27585
