### PR TITLE
Improve handling of immediate values

### DIFF
--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -1559,6 +1559,7 @@ extern {
     /* Selected entries from the downcasts. */
     pub fn LLVMIsATerminatorInst(Inst: ValueRef) -> ValueRef;
     pub fn LLVMIsAStoreInst(Inst: ValueRef) -> ValueRef;
+    pub fn LLVMIsAZExtInst(Inst: ValueRef) -> ValueRef;
 
     /// Writes a module to the specified path. Returns 0 on success.
     pub fn LLVMWriteBitcodeToFile(M: ModuleRef, Path: *const c_char) -> c_int;

--- a/src/librustc_trans/trans/basic_block.rs
+++ b/src/librustc_trans/trans/basic_block.rs
@@ -13,7 +13,7 @@ use llvm::BasicBlockRef;
 use trans::value::{Users, Value};
 use std::iter::{Filter, Map};
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct BasicBlock(pub BasicBlockRef);
 
 pub type Preds = Map<Filter<Users, fn(&Value) -> bool>, fn(Value) -> BasicBlock>;

--- a/src/librustc_trans/trans/builder.rs
+++ b/src/librustc_trans/trans/builder.rs
@@ -507,6 +507,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     }
 
     pub fn volatile_store(&self, val: ValueRef, ptr: ValueRef) -> ValueRef {
+        debug!("Volatile Store {} -> {}",
+               self.ccx.tn().val_to_string(val),
+               self.ccx.tn().val_to_string(ptr));
         assert!(!self.llbuilder.is_null());
         self.count_insn("store.volatile");
         unsafe {

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -2094,7 +2094,7 @@ fn trans_imm_cast<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     if type_is_fat_ptr(bcx.tcx(), t_in) {
         if type_is_fat_ptr(bcx.tcx(), t_out) {
             // If the datum is by-ref, just do a pointer cast, otherwise
-            // construct the casted fat pointer manually
+            // construct the casted fat pointer manually.
             if datum.kind.is_by_ref() {
                 return DatumBlock::new(bcx, Datum::new(
                     PointerCast(bcx, datum.val, ll_t_out.ptr_to()),

--- a/src/librustc_trans/trans/value.rs
+++ b/src/librustc_trans/trans/value.rs
@@ -14,7 +14,7 @@ use trans::basic_block::BasicBlock;
 use trans::common::Block;
 use libc::c_uint;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct Value(pub ValueRef);
 
 macro_rules! opt_val { ($e:expr) => (
@@ -57,6 +57,13 @@ impl Value {
     pub fn get_dominating_store(self, bcx: Block) -> Option<Value> {
         match self.get_single_user().and_then(|user| user.as_store_inst()) {
             Some(store) => {
+                // Make sure that the store instruction is /to/ this value,
+                // not *of* this value
+                if let Some(loc) = store.get_operand(1) {
+                    if loc != self {
+                        return None;
+                    }
+                }
                 store.get_parent().and_then(|store_bb| {
                     let mut bb = BasicBlock(bcx.llbb);
                     let mut ret = Some(store);
@@ -114,6 +121,10 @@ impl Value {
     /// Returns the Store represent by this value, if any
     pub fn as_store_inst(self) -> Option<Value> {
         opt_val!(llvm::LLVMIsAStoreInst(self.get()))
+    }
+
+    pub fn as_zext_inst(self) -> Option<Value> {
+        opt_val!(llvm::LLVMIsAZExtInst(self.get()))
     }
 
     /// Tests if this value is a terminator instruction

--- a/src/librustc_trans/trans/value.rs
+++ b/src/librustc_trans/trans/value.rs
@@ -80,6 +80,19 @@ impl Value {
         }
     }
 
+    pub fn get_stored_value_opt(self, bcx: Block) -> Option<Value> {
+        let bb = Some(BasicBlock(bcx.llbb));
+        if let Some(val) = self.get_dominating_store(bcx) {
+            let valbb = val.get_parent();
+
+            if bb == valbb {
+                return val.get_operand(0);
+            }
+        }
+
+        None
+    }
+
     /// Returns the first use of this value, if any
     pub fn get_first_use(self) -> Option<Use> {
         unsafe {


### PR DESCRIPTION
The primary improvement here is to handle function calls that return
imemdiate values such that it doesn't force the use of a stack slot. It
also avoids loads from slots that have an store to it in the same block.

This especially improves the codegen for intrinsics, as most of them
produce immediate values.

cc @rust-lang/compiler 
