### PR TITLE
File descriptors leak control

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -5795,6 +5795,7 @@ pub mod funcs {
 
             extern {
                 pub fn closedir(dirp: *mut DIR) -> c_int;
+                pub fn dirfd(dirp: *const DIR) -> c_int;
                 pub fn rewinddir(dirp: *mut DIR);
                 pub fn seekdir(dirp: *mut DIR, loc: c_long);
                 pub fn telldir(dirp: *mut DIR) -> c_long;

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -3410,6 +3410,8 @@ pub mod consts {
             pub const F_GETFL : c_int = 3;
             pub const F_SETFL : c_int = 4;
 
+            pub const FD_CLOEXEC : c_int = 1;
+
             pub const O_ACCMODE : c_int = 3;
 
             pub const SIGTRAP : c_int = 5;
@@ -3521,6 +3523,8 @@ pub mod consts {
             pub const F_SETFD : c_int = 2;
             pub const F_GETFL : c_int = 3;
             pub const F_SETFL : c_int = 4;
+
+            pub const FD_CLOEXEC : c_int = 1;
 
             pub const SIGTRAP : c_int = 5;
             pub const SIG_IGN: size_t = 1;
@@ -4174,6 +4178,8 @@ pub mod consts {
             pub const F_GETFL : c_int = 3;
             pub const F_SETFL : c_int = 4;
 
+            pub const FD_CLOEXEC : c_int = 1;
+
             pub const SIGTRAP : c_int = 5;
             pub const SIG_IGN: size_t = 1;
 
@@ -4633,6 +4639,8 @@ pub mod consts {
             pub const F_SETLKW : c_int = 9;
             pub const F_DUPFD_CLOEXEC : c_int = 10;
 
+            pub const FD_CLOEXEC : c_int = 1;
+
             pub const SIGTRAP : c_int = 5;
             pub const SIG_IGN: size_t = 1;
 
@@ -5071,6 +5079,8 @@ pub mod consts {
             pub const F_SETFD : c_int = 2;
             pub const F_GETFL : c_int = 3;
             pub const F_SETFL : c_int = 4;
+
+            pub const FD_CLOEXEC : c_int = 1;
 
             pub const O_ACCMODE : c_int = 3;
 

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -674,6 +674,10 @@ impl Iterator for ReadDir {
     }
 }
 
+impl AsInner<fs_imp::ReadDir> for ReadDir {
+    fn as_inner(&self) -> &fs_imp::ReadDir { &self.0 }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl DirEntry {
     /// Returns the full path to the file that this entry represents.

--- a/src/libstd/sys/unix/ext/io.rs
+++ b/src/libstd/sys/unix/ext/io.rs
@@ -101,6 +101,10 @@ impl AsRawFd for net::TcpListener {
 impl AsRawFd for net::UdpSocket {
     fn as_raw_fd(&self) -> RawFd { *self.as_inner().socket().as_inner() }
 }
+#[unstable(feature = "raw_dirfd", reason = "recently added")]
+impl AsRawFd for fs::ReadDir {
+    fn as_raw_fd(&self) -> RawFd { self.as_inner().as_inner().dirfd() }
+}
 
 #[stable(feature = "from_raw_os", since = "1.1.0")]
 impl FromRawFd for net::TcpStream {

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -158,6 +158,16 @@ impl Iterator for ReadDir {
     }
 }
 
+impl AsInner<Dir> for ReadDir {
+    fn as_inner(&self) -> &Dir { &self.dirp }
+}
+
+impl Dir {
+    pub fn dirfd(&self) -> RawFd {
+        unsafe { ::libc::dirfd(self.0) }
+    }
+}
+
 impl Drop for Dir {
     fn drop(&mut self) {
         let r = unsafe { libc::closedir(self.0) };

--- a/src/test/run-pass/process-leak-fds.rs
+++ b/src/test/run-pass/process-leak-fds.rs
@@ -1,0 +1,145 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(convert)]
+#![feature(libc)]
+#![feature(process_leak_fds)]
+
+extern crate libc;
+
+use std::collections::HashSet;
+use std::fs::{File, read_dir};
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::process::CommandExt;
+use std::process::Command;
+use std::str::FromStr;
+
+#[cfg(any(target_os = "linux",
+          target_os = "android"))]
+fn check_fds(mut whitelist: HashSet<RawFd>) -> ! {
+    match read_dir("/dev/fd") {
+        Ok(dir) => {
+            let current = dir.as_raw_fd();
+            for ret in dir {
+                match ret {
+                    Ok(entry) => {
+                        let filename = entry.file_name();
+                        let filename = match filename.to_str() {
+                            Some(s) => s,
+                            None => panic!("Failed to convert {:?}", filename),
+                        };
+                        let fd = match FromStr::from_str(filename) {
+                            Ok(fd) => fd,
+                            Err(e) => panic!("Failed to convert {:?}: {}", filename, e),
+                        };
+                        if fd != current && !whitelist.contains(&fd) {
+                            panic!("Unexpected leaked FD {}", fd);
+                        }
+                        whitelist.remove(&fd);
+                    }
+                    Err(e) => panic!("Failed to get directory entry: {}", e),
+                }
+            }
+        }
+        Err(e) => panic!("Failed to get directory entry: {}", e),
+    }
+    if whitelist.len() != 0 {
+        panic!("Failed to leak FDs: {:?}", whitelist);
+    }
+    std::process::exit(0);
+}
+
+macro_rules! add_args {
+    ($cmd: expr, $whitelist: expr) => {
+        $cmd.args($whitelist.iter().map(|x| format!("{}", x)).collect::<Vec<_>>().as_slice())
+    }
+}
+
+#[cfg(any(target_os = "linux",
+          target_os = "android"))]
+fn main() {
+    let args = std::env::args().collect::<Vec<_>>();
+    if args.len() > 1 {
+        let whitelist = args[1..].iter().map(|x| FromStr::from_str(x).unwrap()).collect();
+        check_fds(whitelist);
+    } else {
+        let exe = std::env::current_exe().unwrap();
+        // Preload stdio
+        let mut whitelist = HashSet::new();
+        for fd in &[libc::STDIN_FILENO, libc::STDOUT_FILENO, libc::STDERR_FILENO] {
+            whitelist.insert(*fd);
+        }
+
+        let mut cmd = Command::new(exe.clone());
+        let ret = add_args!(cmd, whitelist).
+            status().unwrap().code().unwrap();
+        if ret != 0 {
+            panic!("Test #1 failed");
+        }
+
+        // Leak a first file descriptor
+        let fd1 = unsafe { libc::open(exe.to_str().unwrap().as_ptr() as *const i8,
+                                      libc::O_RDONLY, 0) };
+
+        // Launch a command without FD leak
+        let mut cmd = Command::new(exe.clone());
+        let ret = add_args!(cmd, whitelist).
+            leak_fds(false).
+            status().unwrap().code().unwrap();
+        if ret != 0 {
+            panic!("Test #2 failed");
+        }
+
+        // Launch a command with the first FD leak
+        whitelist.insert(fd1);
+        let mut cmd = Command::new(exe.clone());
+        let ret = add_args!(cmd, whitelist).
+            leak_fds_whitelist(whitelist.clone()).
+            status().unwrap().code().unwrap();
+        if ret != 0 {
+            panic!("Test #3 failed");
+        }
+
+        // Leak a second file descriptor
+        let _ = unsafe { libc::open(exe.to_str().unwrap().as_ptr() as *const i8,
+                                    libc::O_RDONLY, 0) };
+
+        // Open a third file descriptor but with O_CLOEXEC
+        let fd3 = File::open(&exe).unwrap();
+
+        // Launch a command with the first FD leak (but not the second nor the third)
+        let mut cmd = Command::new(exe.clone());
+        let ret = add_args!(cmd, whitelist).
+            leak_fds_whitelist(whitelist.clone()).
+            status().unwrap().code().unwrap();
+        if ret != 0 {
+            panic!("Test #4 failed");
+        }
+
+        // Launch a command with the first and the third FD (but not the second)
+        whitelist.insert(fd3.as_raw_fd());
+        let mut cmd = Command::new(exe.clone());
+        let ret = add_args!(cmd, whitelist).
+            leak_fds_whitelist(whitelist.clone()).
+            status().unwrap().code().unwrap();
+        if ret != 0 {
+            panic!("Test #5 failed");
+        }
+    }
+}
+
+#[cfg(any(target_os = "bitrig",
+          target_os = "dragonfly",
+          target_os = "freebsd",
+          target_os = "macos",
+          target_os = "netbsd",
+          target_os = "openbsd",
+          target_os = "windows"))]
+pub fn main() { }


### PR DESCRIPTION
The new `CommandExt::leak_fds(&mut self, on: bool)` allow to add a safeguard to not unintentionally leak a file descriptor from a FFI library or inherited from a parent process.

The new `CommandExt::leak_fds_whitelist(&mut self, whitelist: HashSet<RawFd>)` allow to intentionally and safely pass a file descriptor set to a child process, even if they come from a `libstd` object (e.g. `File`, `Socket`…) which use the `O_CLOEXEC` flag. This was the purpose of the (unimplemented) old I/O `extra_io()` API.

I think this two functions are easier to understand and use than a unique generic function.

cc #12148
cc #22678
cc #24237
cc rust-lang/rfcs#941
cc #26478
