### PR TITLE
TRPL: minor correction on how `chars().nth()` work

### DIFF
--- a/src/doc/trpl/strings.md
+++ b/src/doc/trpl/strings.md
@@ -115,7 +115,7 @@ You can get something similar to an index like this:
 let dog = hachiko.chars().nth(1); // kinda like hachiko[1]
 ```
 
-This emphasizes that we have to go through the whole list of `chars`.
+This emphasizes that we have to walk from the beginning of the list of `chars`.
 
 ## Slicing
 


### PR DESCRIPTION
The previous wording was confusing. While would we need to go through
the whole list just to find the first code point? `chars()` being an
iterator, we only need to walk from the beginning of the list.

Note that I am not a native English speaker and I have still difficulties to spot if a "the" is needed somewhere. Feel free to take this PR as a mere suggestion.

r? @steveklabnik 
