### PR TITLE
doc/core: fix description of `nth` function

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -148,8 +148,7 @@ pub trait Iterator {
         last
     }
 
-    /// Loops through `n` iterations, returning the `n`th element of the
-    /// iterator.
+    /// Skips the `n` first elements of the iterator and returns the next one.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
The "nth" element can be confusing. In an array context, we know indexes
start from 0 but one may believe this is not the case with "nth". For
example, would `.nth(1)` return the first (1th/1st) or the second
element?  Rephrase a bit to be less confusing.

r? @steveklabnik 
