### PR TITLE
Make tidy-binaries find invocation work on Linux

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -267,7 +267,8 @@ tidy-basic:
 .PHONY: tidy-binaries
 tidy-binaries:
 		@$(call E, check: binaries)
-		$(Q)find $(S)src -type f -perm +a+x \
+		$(Q)find $(S)src -type f \
+		    \( -perm -u+x -or -perm -g+x -or -perm -o+x \) \
 		    -not -name '*.rs' -and -not -name '*.py' \
 		    -and -not -name '*.sh' \
 		| grep '^$(S)src/jemalloc' -v \

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -270,7 +270,7 @@ tidy-binaries:
 		$(Q)find $(S)src -type f \
 		    \( -perm -u+x -or -perm -g+x -or -perm -o+x \) \
 		    -not -name '*.rs' -and -not -name '*.py' \
-		    -and -not -name '*.sh' \
+		    -and -not -name '*.sh' -and -not -name '*.pp' \
 		| grep '^$(S)src/jemalloc' -v \
 		| grep '^$(S)src/libuv' -v \
 		| grep '^$(S)src/llvm' -v \


### PR DESCRIPTION
New enough find on Linux doesn't support "-perm +..." and suggests
using "-perm /..." instead, but that doesn't work on Windows.
Hopefully all platforms are happy with this expanded version.

I don't have access to a Windows development system to test this, so someone needs to verify that this actually works there before merging.

Closes #19981.
