### PR TITLE
Fix auto-linux-32-opt failure (#27619): Revert "Mark round_up_to_next as inline"

### DIFF
--- a/src/libstd/collections/hash/table.rs
+++ b/src/libstd/collections/hash/table.rs
@@ -511,7 +511,6 @@ impl<K, V, M: Deref<Target=RawTable<K, V>>> GapThenFull<K, V, M> {
 /// # Panics
 ///
 /// Panics if `target_alignment` is not a power of two.
-#[inline]
 fn round_up_to_next(unrounded: usize, target_alignment: usize) -> usize {
     assert!(target_alignment.is_power_of_two());
     (unrounded + target_alignment - 1) & !(target_alignment - 1)


### PR DESCRIPTION
I don't know how this single inline caused the breakage but it seems to be the cause of the issue (see https://github.com/rust-lang/rust/issues/27619#issuecomment-129420094).
