### PR TITLE
Remove reference to diabetes

### DIFF
--- a/src/doc/nomicon/lifetimes.md
+++ b/src/doc/nomicon/lifetimes.md
@@ -52,8 +52,7 @@ likely desugar to the following:
 }
 ```
 
-Wow. That's... awful. Let's all take a moment to thank Rust for being a
-diabetes-inducing torrent of syrupy-goodness.
+Wow. That’s... awful. Let’s all take a moment to thank Rust for making this easier. 
 
 Actually passing references to outer scopes will cause Rust to infer
 a larger lifetime:


### PR DESCRIPTION
1. this isn't actually true about diabetes
2. people with diabetes will get _real sad_ when reading this
3. it isn't actually necessary.

(backport of https://github.com/rust-lang/rust/pull/27576)
