### PR TITLE
Tidy up some uses of `csearch::get_item_path`

### DIFF
--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -95,6 +95,12 @@ pub fn get_item_path(tcx: &ty::ctxt, def: ast::DefId) -> Vec<ast_map::PathElem> 
     })
 }
 
+pub fn get_item_name(tcx: &ty::ctxt, def: ast::DefId) -> ast::Name {
+    let cstore = &tcx.sess.cstore;
+    let cdata = cstore.get_crate_data(def.krate);
+    decoder::get_item_name(&cstore.intr, &cdata, def.node)
+}
+
 pub enum FoundAst<'ast> {
     Found(&'ast ast::InlinedItem),
     FoundParent(ast::DefId, &'ast ast::InlinedItem),

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -770,6 +770,10 @@ pub fn get_item_path(cdata: Cmd, id: ast::NodeId) -> Vec<ast_map::PathElem> {
     item_path(lookup_item(id, cdata.data()))
 }
 
+pub fn get_item_name(intr: &IdentInterner, cdata: Cmd, id: ast::NodeId) -> ast::Name {
+    item_name(intr, lookup_item(id, cdata.data()))
+}
+
 pub type DecodeInlinedItem<'a> =
     Box<for<'tcx> FnMut(Cmd,
                         &ty::ctxt<'tcx>,

--- a/src/librustc/middle/intrinsicck.rs
+++ b/src/librustc/middle/intrinsicck.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ast_map::NodeForeignItem;
-use metadata::csearch;
 use middle::def::DefFn;
 use middle::subst::{Subst, Substs, EnumeratedItems};
 use middle::ty::{TransmuteRestriction, ctxt, TyBareFn};
@@ -57,21 +55,7 @@ impl<'a, 'tcx> IntrinsicCheckingVisitor<'a, 'tcx> {
             ty::TyBareFn(_, ref bfty) => bfty.abi == RustIntrinsic,
             _ => return false
         };
-        if def_id.krate == ast::LOCAL_CRATE {
-            match self.tcx.map.get(def_id.node) {
-                NodeForeignItem(ref item) if intrinsic => {
-                    item.ident.name == "transmute"
-                }
-                _ => false,
-            }
-        } else {
-            match csearch::get_item_path(self.tcx, def_id).last() {
-                Some(ref last) if intrinsic => {
-                    last.name() == "transmute"
-                }
-                _ => false,
-            }
-        }
+        intrinsic && self.tcx.item_name(def_id) == "transmute"
     }
 
     fn check_transmute(&self, span: Span, from: Ty<'tcx>, to: Ty<'tcx>, id: ast::NodeId) {

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -5683,13 +5683,9 @@ impl<'tcx> ctxt<'tcx> {
                                             &format!("a default was defined here..."));
                     }
                     (_, _) => {
-                        let elems = csearch::get_item_path(self, expected.def_id)
-                                        .into_iter()
-                                        .map(|p| p.to_string())
-                                        .collect::<Vec<_>>();
                         self.sess.note(
                             &format!("a default is defined on `{}`",
-                                     elems.join("::")));
+                                     self.item_path_str(expected.def_id)));
                     }
                 }
 
@@ -5704,13 +5700,9 @@ impl<'tcx> ctxt<'tcx> {
                                             &format!("a second default was defined here..."));
                     }
                     (_, _) => {
-                        let elems = csearch::get_item_path(self, found.def_id)
-                                        .into_iter()
-                                        .map(|p| p.to_string())
-                                        .collect::<Vec<_>>();
-
                         self.sess.note(
-                            &format!("a second default is defined on `{}`", elems.join(" ")));
+                            &format!("a second default is defined on `{}`",
+                                     self.item_path_str(found.def_id)));
                     }
                 }
 

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -5927,6 +5927,14 @@ impl<'tcx> ctxt<'tcx> {
         }
     }
 
+    pub fn item_name(&self, id: ast::DefId) -> ast::Name {
+        if id.krate == ast::LOCAL_CRATE {
+            self.map.get_path_elem(id.node).name()
+        } else {
+            csearch::get_item_name(self, id)
+        }
+    }
+
     /// Returns `(normalized_type, ty)`, where `normalized_type` is the
     /// IntType representation of one of {i64,i32,i16,i8,u64,u32,u16,u8},
     /// and `ty` is the original type (i.e. may include `isize` or

--- a/src/librustc_trans/trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/trans/debuginfo/metadata.rs
@@ -23,7 +23,6 @@ use super::{declare_local, VariableKind, VariableAccess};
 use llvm::{self, ValueRef};
 use llvm::debuginfo::{DIType, DIFile, DIScope, DIDescriptor, DICompositeType};
 
-use metadata::csearch;
 use middle::pat_util;
 use middle::subst::{self, Substs};
 use rustc::ast_map;
@@ -1686,13 +1685,7 @@ fn prepare_enum_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
     fn get_enum_discriminant_name(cx: &CrateContext,
                                   def_id: ast::DefId)
                                   -> token::InternedString {
-        let name = if def_id.krate == ast::LOCAL_CRATE {
-            cx.tcx().map.get_path_elem(def_id.node).name()
-        } else {
-            csearch::get_item_path(cx.tcx(), def_id).last().unwrap().name()
-        };
-
-        name.as_str()
+        cx.tcx().item_name(def_id).as_str()
     }
 }
 

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -12,12 +12,10 @@ use arena::TypedArena;
 use back::abi;
 use back::link;
 use llvm::{ValueRef, get_params};
-use metadata::csearch;
 use middle::subst::{Subst, Substs};
 use middle::subst::VecPerParamSpace;
 use middle::subst;
 use middle::traits;
-use rustc::ast_map;
 use trans::base::*;
 use trans::build::*;
 use trans::callee::*;
@@ -165,14 +163,8 @@ pub fn trans_static_method_callee<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
            tcx.item_path_str(trait_id),
            expr_id);
 
-    let mname = if method_id.krate == ast::LOCAL_CRATE {
-        match tcx.map.get(method_id.node) {
-            ast_map::NodeTraitItem(trait_item) => trait_item.ident.name,
-            _ => panic!("callee is not a trait method")
-        }
-    } else {
-        csearch::get_item_path(tcx, method_id).last().unwrap().name()
-    };
+    let mname = tcx.item_name(method_id);
+
     debug!("trans_static_method_callee: method_id={:?}, expr_id={}, \
             name={}", method_id, expr_id, mname);
 

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -113,11 +113,10 @@ fn try_inline_def(cx: &DocContext, tcx: &ty::ctxt,
         }
         _ => return None,
     };
-    let fqn = csearch::get_item_path(tcx, did);
     cx.inlined.borrow_mut().as_mut().unwrap().insert(did);
     ret.push(clean::Item {
         source: clean::Span::empty(),
-        name: Some(fqn.last().unwrap().to_string()),
+        name: Some(tcx.item_name(did).to_string()),
         attrs: load_attrs(cx, tcx, did),
         inner: inner,
         visibility: Some(ast::Public),


### PR DESCRIPTION
(this incidentally fixes an error message where the paths separator is " " instead of "::")
