### PR TITLE
Use pentium4 for base CPU on i686-pc-windows-msvc

### DIFF
--- a/src/librustc_back/target/i686_pc_windows_msvc.rs
+++ b/src/librustc_back/target/i686_pc_windows_msvc.rs
@@ -12,7 +12,7 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::windows_msvc_base::opts();
-    base.cpu = "i686".to_string();
+    base.cpu = "pentium4".to_string();
 
     Target {
         llvm_target: "i686-pc-windows-msvc".to_string(),


### PR DESCRIPTION
This is in line with other targets.

Closes #27646
