### PR TITLE
Stabilize some Duration consuming methods

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -27,6 +27,7 @@ use std::io::prelude::*;
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, ExitStatus};
+use std::time::Duration;
 
 pub fn run(config: Config, testfile: &Path) {
     match &*config.target {
@@ -431,7 +432,7 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
                 .expect(&format!("failed to exec `{:?}`", config.adb_path));
             loop {
                 //waiting 1 second for gdbserver start
-                ::std::thread::sleep_ms(1000);
+                ::std::thread::sleep(Duration::new(1, 0));
                 if TcpStream::connect("127.0.0.1:5039").is_ok() {
                     break
                 }

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -467,6 +467,7 @@ pub fn catch_panic<F, R>(f: F) -> Result<R>
 /// specifics or platform-dependent functionality. Note that on unix platforms
 /// this function will not return early due to a signal being received or a
 /// spurious wakeup.
+#[deprecated(since = "1.4.0", reason = "use `thread::sleep` instead")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn sleep_ms(ms: u32) {
     sleep(Duration::from_millis(ms as u64))
@@ -483,7 +484,7 @@ pub fn sleep_ms(ms: u32) {
 /// signal being received or a spurious wakeup. Platforms which do not support
 /// nanosecond precision for sleeping will have `dur` rounded up to the nearest
 /// granularity of time they can sleep for.
-#[unstable(feature = "thread_sleep", reason = "waiting on Duration")]
+#[stable(feature = "thread_sleep", since = "1.4.0")]
 pub fn sleep(dur: Duration) {
     imp::Thread::sleep(dur)
 }
@@ -533,6 +534,7 @@ pub fn park() {
 /// amount of time waited to be precisely *ms* long.
 ///
 /// See the module doc for more detail.
+#[deprecated(since = "1.4.0", reason = "use `thread::park_timeout` instead")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn park_timeout_ms(ms: u32) {
     park_timeout(Duration::from_millis(ms as u64))
@@ -553,7 +555,7 @@ pub fn park_timeout_ms(ms: u32) {
 ///
 /// Platforms which do not support nanosecond precision for sleeping will have
 /// `dur` rounded up to the nearest granularity of time they can sleep for.
-#[unstable(feature = "park_timeout", reason = "waiting on Duration")]
+#[stable(feature = "park_timeout", since = "1.4.0")]
 pub fn park_timeout(dur: Duration) {
     let thread = current();
     let mut guard = thread.inner.lock.lock().unwrap();


### PR DESCRIPTION
These methods are simply the Duration consuming variants of existing
stable methods that take a u32 of milliseconds.

r? @alexcrichton 

Closes #27771
