### PR TITLE
Use correct target CPU for iOS simulator.

### DIFF
--- a/src/librustc_back/target/apple_ios_base.rs
+++ b/src/librustc_back/target/apple_ios_base.rs
@@ -77,8 +77,8 @@ fn target_cpu(arch: Arch) -> String {
         Armv7 => "cortex-a8", // iOS7 is supported on iPhone 4 and higher
         Armv7s => "cortex-a9",
         Arm64 => "cyclone",
-        I386 => "generic",
-        X86_64 => "x86-64",
+        I386 => "yonah",
+        X86_64 => "core2",
     }.to_string()
 }
 


### PR DESCRIPTION
This matches the behavior of clang.

See also discussion on #27307.
