### PR TITLE
Fix breakage from previous cherry pick

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -32,7 +32,6 @@
 #![feature(clone_from_slice)]
 #![feature(collections)]
 #![feature(const_fn)]
-#![feature(core)]
 #![feature(duration_span)]
 #![feature(dynamic_lib)]
 #![feature(enumset)]

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[cfg(stage0)]
 use prelude::v1::*;
 
 use ops::{Add, Sub, Mul, Div};


### PR DESCRIPTION
I think this is not due to a bad cherry-pick but because there are just differences on beta that caused the compilation failure (e.g. std appears to import the prelude now on master).

I've at least confirmed this builds.
