### PR TITLE
Update version number response for new version of rust

### DIFF
--- a/src/doc/trpl/installing-rust.md
+++ b/src/doc/trpl/installing-rust.md
@@ -85,10 +85,10 @@ $ rustc --version
 ```
 
 You should see the version number, commit hash, and commit date. If you just
-installed version 1.0.0, you should see:
+installed version 1.2.0, you should see:
 
 ```bash
-rustc 1.0.0 (a59de37e9 2015-05-13)
+rustc 1.2.0 (082e47636 2015-08-03)
 ```
 
 If you did, Rust has been installed successfully! Congrats!


### PR DESCRIPTION
PR for [Issue #27681](https://github.com/rust-lang/rust/issues/27681). A simple update to the latest version of rust when typing the command rustc --version.
