### PR TITLE
Rename String::into_boxed_slice -> into_boxed_str

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -749,9 +749,19 @@ impl String {
     /// Note that this will drop any excess capacity.
     #[unstable(feature = "box_str",
                reason = "recently added, matches RFC")]
-    pub fn into_boxed_slice(self) -> Box<str> {
+    pub fn into_boxed_str(self) -> Box<str> {
         let slice = self.vec.into_boxed_slice();
         unsafe { mem::transmute::<Box<[u8]>, Box<str>>(slice) }
+    }
+
+    /// Converts the string into `Box<str>`.
+    ///
+    /// Note that this will drop any excess capacity.
+    #[unstable(feature = "box_str",
+               reason = "recently added, matches RFC")]
+    #[deprecated(since = "1.4.0", reason = "renamed to `into_boxed_str`")]
+    pub fn into_boxed_slice(self) -> Box<str> {
+        self.into_boxed_str()
     }
 }
 

--- a/src/libcollectionstest/str.rs
+++ b/src/libcollectionstest/str.rs
@@ -1763,13 +1763,13 @@ fn test_into_string() {
     // The only way to acquire a Box<str> in the first place is through a String, so just
     // test that we can round-trip between Box<str> and String.
     let string = String::from("Some text goes here");
-    assert_eq!(string.clone().into_boxed_slice().into_string(), string);
+    assert_eq!(string.clone().into_boxed_str().into_string(), string);
 }
 
 #[test]
 fn test_box_slice_clone() {
     let data = String::from("hello HELLO hello HELLO yes YES 5 中ä华!!!");
-    let data2 = data.clone().into_boxed_slice().clone().into_string();
+    let data2 = data.clone().into_boxed_str().clone().into_string();
 
     assert_eq!(data, data2);
 }

--- a/src/libcollectionstest/string.rs
+++ b/src/libcollectionstest/string.rs
@@ -366,9 +366,9 @@ fn test_extend_ref() {
 }
 
 #[test]
-fn test_into_boxed_slice() {
+fn test_into_boxed_str() {
     let xs = String::from("hello my name is bob");
-    let ys = xs.into_boxed_slice();
+    let ys = xs.into_boxed_str();
     assert_eq!(&*ys, "hello my name is bob");
 }
 


### PR DESCRIPTION
Rename String::into_boxed_slice -> into_boxed_str

This is the name that was decided in rust-lang/rfcs#1152, and it's
better if we say “boxed str” for `Box<str>`.

The old name `String::into_boxed_slice` is deprecated.
