### PR TITLE
stop cross-crate associated types from being imported

### DIFF
--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -785,6 +785,11 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
               debug!("(building reduced graph for external \
                       crate) building type {}", final_ident);
 
+              let modifiers = match new_parent.kind.get() {
+                  NormalModuleKind => modifiers,
+                  _ => modifiers & !DefModifiers::IMPORTABLE
+              };
+
               child_name_bindings.define_type(def, DUMMY_SP, modifiers);
           }
           DefStruct(def_id) => {

--- a/src/test/auxiliary/use_from_trait_xc.rs
+++ b/src/test/auxiliary/use_from_trait_xc.rs
@@ -8,16 +8,22 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(associated_consts)]
+
 pub use self::sub::{Bar, Baz};
 
 pub trait Trait {
     fn foo(&self);
+    type Assoc;
+    const CONST: u32;
 }
 
 struct Foo;
 
 impl Foo {
     pub fn new() {}
+
+    pub const C: u32 = 0;
 }
 
 mod sub {

--- a/src/test/compile-fail/use-from-trait-xc.rs
+++ b/src/test/compile-fail/use-from-trait-xc.rs
@@ -15,8 +15,17 @@ extern crate use_from_trait_xc;
 use use_from_trait_xc::Trait::foo;
 //~^ ERROR `foo` is not directly importable
 
+use use_from_trait_xc::Trait::Assoc;
+//~^ ERROR `Assoc` is not directly importable
+
+use use_from_trait_xc::Trait::CONST;
+//~^ ERROR `CONST` is not directly importable
+
 use use_from_trait_xc::Foo::new;
 //~^ ERROR `new` is not directly importable
+
+use use_from_trait_xc::Foo::C;
+//~^ ERROR unresolved import `use_from_trait_xc::Foo::C`
 
 use use_from_trait_xc::Bar::new as bnew;
 //~^ ERROR `bnew` is not directly importable

--- a/src/test/compile-fail/use-from-trait.rs
+++ b/src/test/compile-fail/use-from-trait.rs
@@ -8,19 +8,32 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(associated_consts)]
+
 use Trait::foo;
 //~^ ERROR `foo` is not directly importable
+use Trait::Assoc;
+//~^ ERROR `Assoc` is not directly importable
+use Trait::C;
+//~^ ERROR `C` is not directly importable
+
 use Foo::new;
 //~^ ERROR unresolved import `Foo::new`. Not a module `Foo`
 
+use Foo::C2;
+//~^ ERROR unresolved import `Foo::C2`. Not a module `Foo`
+
 pub trait Trait {
     fn foo();
+    type Assoc;
+    const C: u32;
 }
 
 struct Foo;
 
 impl Foo {
     fn new() {}
+    const C2: u32 = 0;
 }
 
 fn main() {}


### PR DESCRIPTION
Fixes #22968
Probably fixes #27602 (the issue needs a reproduction)

r? @alexcrichton 
