### PR TITLE
Add detailed diagnostics for E0386.

### DIFF
--- a/src/librustc_borrowck/diagnostics.rs
+++ b/src/librustc_borrowck/diagnostics.rs
@@ -179,6 +179,14 @@ let mut x: i64 = 1;
 let mut y: Box<_> = Box::new(&mut x);
 **y = 2;
 ```
+
+It can also be fixed by using a type with interior mutability, such as `Cell` or
+`RefCell`:
+
+```
+let y: Cell<_> = Cell::new(1);
+y.set(2);
+```
 "##,
 
 E0387: r##"

--- a/src/librustc_borrowck/diagnostics.rs
+++ b/src/librustc_borrowck/diagnostics.rs
@@ -160,6 +160,27 @@ fn main(){
 ```
 "##,
 
+E0386: r##"
+This error occurs when an attempt is made to mutate the target of a mutable
+reference stored inside an immutable container.
+
+For example, this can happen when storing a `&mut` inside an immutable `Box`:
+
+```
+let mut x: i64 = 1;
+let y: Box<_> = Box::new(&mut x);
+**y = 2; // error, cannot assign to data in an immutable container
+```
+
+This error can be fixed by making the container mutable:
+
+```
+let mut x: i64 = 1;
+let mut y: Box<_> = Box::new(&mut x);
+**y = 2;
+```
+"##,
+
 E0387: r##"
 This error occurs when an attempt is made to mutate or mutably reference data
 that a closure has captured immutably. Examples of this error are shown below:
@@ -219,7 +240,6 @@ https://doc.rust-lang.org/std/cell/
 register_diagnostics! {
     E0383, // partial reinitialization of uninitialized structure
     E0385, // {} in an aliasable location
-    E0386, // {} in an immutable container
     E0388, // {} in a static location
     E0389  // {} in a `&` reference
 }

--- a/src/librustc_borrowck/diagnostics.rs
+++ b/src/librustc_borrowck/diagnostics.rs
@@ -184,7 +184,8 @@ It can also be fixed by using a type with interior mutability, such as `Cell` or
 `RefCell`:
 
 ```
-let y: Cell<_> = Cell::new(1);
+let x: i64 = 1;
+let y: Box<Cell<_>> = Box::new(Cell::new(x));
 y.set(2);
 ```
 "##,


### PR DESCRIPTION
This adds detailed diagnostics for E0386, 'cannot assign to data in an
immutable container'.

This is part of rust-lang/rust#24407.

r? @Manishearth
