### PR TITLE
Stabilize weak pointers on Rc and Arc, as well as the meaty uniqueness methods

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -21,7 +21,6 @@
 
 #![feature(associated_consts)]
 #![feature(borrow_state)]
-#![feature(rc_weak)]
 #![feature(rustc_diagnostic_macros)]
 #![feature(rustc_private)]
 #![feature(slice_splits)]

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -36,7 +36,6 @@
 #![feature(path_relative_from)]
 #![feature(path_relative_from)]
 #![feature(quote)]
-#![feature(rc_weak)]
 #![feature(rustc_diagnostic_macros)]
 #![feature(rustc_private)]
 #![feature(staged_api)]


### PR DESCRIPTION
The community has spoken: weak pointers are highly desirable!

Also Rc and Arc are kinda busted for recursive datastructures without these uniqueness methods!

The "read only" uniqueness introspection is punted on as neither critical nor obviously super useful (particularly for Arc, where such methods are inherently racy). Though they are harmless from a maintenance perspective.

Note that make_unique has been renamed to `make_mut` for symmery with `get_mut`.

This addresses the bulk of https://github.com/rust-lang/rust/issues/27718 

r? @aturon on the implementation of `Arc::try_unwrap` which I had to add since it was accidentally omitted in the past. Largely just derived from `drop` on the assumption that `try_unwrap` is "basically" just Drop.
