### PR TITLE
Correct debug! documentation

### DIFF
--- a/src/liblog/macros.rs
+++ b/src/liblog/macros.rs
@@ -135,9 +135,9 @@ macro_rules! info {
     ($($arg:tt)*) => (log!(::log::INFO, $($arg)*))
 }
 
-/// A convenience macro for logging at the debug log level. This macro can also
-/// be omitted at compile time by passing `-C debug-assertions` to the compiler. If
-/// this option is not passed, then debug statements will be compiled.
+/// A convenience macro for logging at the debug log level. This macro will
+/// be omitted at compile time in an optimized build unless `-C debug-assertions`
+/// is passed to the compiler.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
When --cfg ndebug changed to -C debug-assertions the documentation was
updated to reflect the new name, but not that the meaning was
reversed.
