### PR TITLE
Remove pandoc references

### DIFF
--- a/src/doc/README.md
+++ b/src/doc/README.md
@@ -1,11 +1,5 @@
 # Rust documentations
 
-## Dependencies
-
-[Pandoc](http://johnmacfarlane.net/pandoc/installing.html), a universal
-document converter, is required to generate docs as HTML from Rust's
-source code.
-
 ## Building
 
 To generate all the docs, just run `make docs` from the root of the repository.
@@ -26,15 +20,12 @@ To generate an HTML version of a doc from Markdown manually, you can do
 something like:
 
 ~~~~
-pandoc --from=markdown --to=html5 --number-sections -o reference.html reference.md
+rustdoc reference.md
 ~~~~
 
 (`reference.md` being the Rust Reference Manual.)
 
-The syntax for pandoc flavored markdown can be found at:
+An overview of how to use the `rustdoc` command is available [in the docs][1].
+Further details are available from the command line by with `rustdoc --help`.
 
-- http://johnmacfarlane.net/pandoc/README.html#pandocs-markdown
-
-A nice quick reference (for non-pandoc markdown) is at:
-
-- http://kramdown.gettalong.org/quickref.html
+[1]: https://github.com/rust-lang/rust/blob/master/src/doc/trpl/documentation.md


### PR DESCRIPTION
Per @steveklabnik's comment [here](https://github.com/rust-lang/cargo/issues/739#issuecomment-130085860), the Pandoc components of the Makefile are no longer used, and as such the corresponding components of the documentation are out of date.
- I've removed the Pandoc (and therefore also LaTeX) elements of the makefile and confirmed that the build proceeds correctly.
- I updated the documentation to reference `rustdoc` and  of Pandoc.

r? @steveklabnik
