### PR TITLE
Refactor and improve: Arena, TypedArena

### DIFF
--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -45,7 +45,7 @@ extern crate alloc;
 use std::cell::{Cell, RefCell};
 use std::cmp;
 use std::intrinsics;
-use std::marker;
+use std::marker::{PhantomData, Send};
 use std::mem;
 use std::ptr;
 use std::raw;
@@ -103,7 +103,7 @@ pub struct Arena<'longer_than_self> {
     head: RefCell<Chunk>,
     copy_head: RefCell<Chunk>,
     chunks: RefCell<Vec<Chunk>>,
-    _marker: marker::PhantomData<*mut &'longer_than_self ()>,
+    _marker: PhantomData<*mut &'longer_than_self ()>,
 }
 
 impl<'a> Arena<'a> {
@@ -118,7 +118,7 @@ impl<'a> Arena<'a> {
             head: RefCell::new(chunk(initial_size, false)),
             copy_head: RefCell::new(chunk(initial_size, true)),
             chunks: RefCell::new(Vec::new()),
-            _marker: marker::PhantomData,
+            _marker: PhantomData,
         }
     }
 }
@@ -382,7 +382,7 @@ pub struct TypedArena<T> {
 
     /// Marker indicating that dropping the arena causes its owned
     /// instances of `T` to be dropped.
-    _own: marker::PhantomData<T>,
+    _own: PhantomData<T>,
 }
 
 struct TypedArenaChunk<T> {
@@ -452,7 +452,7 @@ impl<T> TypedArena<T> {
                 ptr: Cell::new(chunk.start()),
                 end: Cell::new(chunk.end()),
                 chunks: RefCell::new(vec![chunk]),
-                _own: marker::PhantomData,
+                _own: PhantomData,
             }
         }
     }
@@ -530,6 +530,8 @@ impl<T> Drop for TypedArena<T> {
         }
     }
 }
+
+unsafe impl<T: Send> Send for TypedArena<T> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -630,11 +630,7 @@ mod tests {
     #[bench]
     pub fn bench_copy_nonarena(b: &mut Bencher) {
         b.iter(|| {
-            let _: Box<_> = Box::new(Point {
-                x: 1,
-                y: 2,
-                z: 3
-            });
+            let _: Box<_> = Box::new(Point { x: 1, y: 2, z: 3 });
         })
     }
 
@@ -676,11 +672,7 @@ mod tests {
             for _ in 0..100 {
                 arena.alloc(|| ());
             }
-            arena.alloc(|| Point {
-                x: 1,
-                y: 2,
-                z: 3,
-            });
+            arena.alloc(|| Point { x: 1, y: 2, z: 3 });
         }
     }
 
@@ -690,11 +682,7 @@ mod tests {
         for _ in 0..10 {
             arena.clear();
             for _ in 0..10000 {
-                arena.alloc(Point {
-                    x: 1,
-                    y: 2,
-                    z: 3,
-                });
+                arena.alloc(Point { x: 1, y: 2, z: 3 });
             }
         }
     }
@@ -705,14 +693,12 @@ mod tests {
         for _ in 0..10 {
             arena.clear();
             for _ in 0..10000 {
-                arena.alloc(|| Point {
-                    x: 1,
-                    y: 2,
-                    z: 3,
-                });
-                arena.alloc(|| Noncopy {
-                    string: "hello world".to_string(),
-                    array: vec![],
+                arena.alloc(|| Point { x: 1, y: 2, z: 3 });
+                arena.alloc(|| {
+                    Noncopy {
+                        string: "hello world".to_string(),
+                        array: vec![],
+                    }
                 });
             }
         }
@@ -722,11 +708,7 @@ mod tests {
     pub fn test_arena_alloc_bytes() {
         let arena = Arena::new();
         for i in 0..10000 {
-            arena.alloc(|| Point {
-                x: 1,
-                y: 2,
-                z: 3,
-            });
+            arena.alloc(|| Point { x: 1, y: 2, z: 3 });
             for byte in arena.alloc_bytes(i % 42).iter_mut() {
                 *byte = i as u8;
             }
@@ -754,10 +736,10 @@ mod tests {
         for i in 0..10 {
             // Arena allocate something with drop glue to make sure it
             // doesn't leak.
-            arena.alloc(|| { Rc::new(i) });
+            arena.alloc(|| Rc::new(i));
             // Allocate something with funny size and alignment, to keep
             // things interesting.
-            arena.alloc(|| { [0u8, 1, 2] });
+            arena.alloc(|| [0u8, 1, 2]);
         }
         // Now, panic while allocating
         arena.alloc::<Rc<i32>, _>(|| {
@@ -771,7 +753,7 @@ mod tests {
         b.iter(|| {
             arena.alloc(Noncopy {
                 string: "hello world".to_string(),
-                array: vec!( 1, 2, 3, 4, 5 ),
+                array: vec![1, 2, 3, 4, 5],
             })
         })
     }
@@ -781,7 +763,7 @@ mod tests {
         b.iter(|| {
             let _: Box<_> = Box::new(Noncopy {
                 string: "hello world".to_string(),
-                array: vec!( 1, 2, 3, 4, 5 ),
+                array: vec![1, 2, 3, 4, 5],
             });
         })
     }
@@ -790,9 +772,11 @@ mod tests {
     pub fn bench_noncopy_old_arena(b: &mut Bencher) {
         let arena = Arena::new();
         b.iter(|| {
-            arena.alloc(|| Noncopy {
-                string: "hello world".to_string(),
-                array: vec!( 1, 2, 3, 4, 5 ),
+            arena.alloc(|| {
+                Noncopy {
+                    string: "hello world".to_string(),
+                    array: vec![1, 2, 3, 4, 5],
+                }
             })
         })
     }

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -38,6 +38,8 @@
 #![feature(dropck_parametricity)]
 #![cfg_attr(test, feature(test))]
 
+#![allow(deprecated)]
+
 extern crate alloc;
 
 use std::cell::{Cell, RefCell};
@@ -122,6 +124,10 @@ impl Chunk {
 /// than objects without destructors. This reduces overhead when initializing
 /// plain-old-data (`Copy` types) and means we don't need to waste time running
 /// their destructors.
+#[unstable(feature = "rustc_private",
+           reason = "Private to rustc", issue = "0")]
+#[rustc_deprecated(since = "1.6.0-dev", reason =
+"The reflection-based arena is superseded by the any-arena crate")]
 pub struct Arena<'longer_than_self> {
     // The heads are separated out from the list as a unbenchmarked
     // microoptimization, to avoid needing to case on the list to access a head.


### PR DESCRIPTION
Fixes #18037 "TypedArena cannot handle zero-sized types".
Closes #17931 "improve chunk allocation scheme used by Arena / TypedArena".
Closes #22847 "TypedArena should implement Send". - N.B. Arena cannot implement Send, since it may contain non-Send values.
Closes #18471 "`Arena::alloc_copy_inner` (at least) should be renamed and made public." - Added `Arena::alloc_bytes`.
Closes #18261 "support clearing TypedArena with the chunks preserved". - Only the largest chunk is preserved.
