### PR TITLE
Require issue annotations for #[unstable] features

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -137,7 +137,8 @@ impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Arc<U>> for Arc<T> {}
 /// used to break cycles between `Arc` pointers.
 #[unsafe_no_drop_flag]
 #[unstable(feature = "arc_weak",
-           reason = "Weak pointers may not belong in this module.")]
+           reason = "Weak pointers may not belong in this module.",
+           issue = "27718")]
 pub struct Weak<T: ?Sized> {
     // FIXME #12808: strange name to try to avoid interfering with
     // field accesses of the contained type via Deref
@@ -209,7 +210,8 @@ impl<T: ?Sized> Arc<T> {
     /// let weak_five = five.downgrade();
     /// ```
     #[unstable(feature = "arc_weak",
-               reason = "Weak pointers may not belong in this module.")]
+               reason = "Weak pointers may not belong in this module.",
+               issue = "27718")]
     pub fn downgrade(&self) -> Weak<T> {
         loop {
             // This Relaxed is OK because we're checking the value in the CAS
@@ -234,14 +236,14 @@ impl<T: ?Sized> Arc<T> {
 
     /// Get the number of weak references to this value.
     #[inline]
-    #[unstable(feature = "arc_counts")]
+    #[unstable(feature = "arc_counts", issue = "27718")]
     pub fn weak_count(this: &Arc<T>) -> usize {
         this.inner().weak.load(SeqCst) - 1
     }
 
     /// Get the number of strong references to this value.
     #[inline]
-    #[unstable(feature = "arc_counts")]
+    #[unstable(feature = "arc_counts", issue = "27718")]
     pub fn strong_count(this: &Arc<T>) -> usize {
         this.inner().strong.load(SeqCst)
     }
@@ -349,7 +351,7 @@ impl<T: Clone> Arc<T> {
     /// let mut_five = Arc::make_unique(&mut five);
     /// ```
     #[inline]
-    #[unstable(feature = "arc_unique")]
+    #[unstable(feature = "arc_unique", issue = "27718")]
     pub fn make_unique(this: &mut Arc<T>) -> &mut T {
         // Note that we hold both a strong reference and a weak reference.
         // Thus, releasing our strong reference only will not, by itself, cause
@@ -427,7 +429,7 @@ impl<T: ?Sized> Arc<T> {
     /// # }
     /// ```
     #[inline]
-    #[unstable(feature = "arc_unique")]
+    #[unstable(feature = "arc_unique", issue = "27718")]
     pub fn get_mut(this: &mut Arc<T>) -> Option<&mut T> {
         if this.is_unique() {
             // This unsafety is ok because we're guaranteed that the pointer
@@ -541,7 +543,8 @@ impl<T: ?Sized> Drop for Arc<T> {
 }
 
 #[unstable(feature = "arc_weak",
-           reason = "Weak pointers may not belong in this module.")]
+           reason = "Weak pointers may not belong in this module.",
+           issue = "27718")]
 impl<T: ?Sized> Weak<T> {
     /// Upgrades a weak reference to a strong reference.
     ///
@@ -589,7 +592,8 @@ impl<T: ?Sized> Weak<T> {
 }
 
 #[unstable(feature = "arc_weak",
-           reason = "Weak pointers may not belong in this module.")]
+           reason = "Weak pointers may not belong in this module.",
+           issue = "27718")]
 impl<T: ?Sized> Clone for Weak<T> {
     /// Makes a clone of the `Weak<T>`.
     ///

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -85,13 +85,15 @@ use core::raw::{TraitObject};
 /// ```
 #[lang = "exchange_heap"]
 #[unstable(feature = "box_heap",
-           reason = "may be renamed; uncertain about custom allocator design")]
+           reason = "may be renamed; uncertain about custom allocator design",
+           issue = "27779")]
 pub const HEAP: ExchangeHeapSingleton =
     ExchangeHeapSingleton { _force_singleton: () };
 
 /// This the singleton type used solely for `boxed::HEAP`.
 #[unstable(feature = "box_heap",
-           reason = "may be renamed; uncertain about custom allocator design")]
+           reason = "may be renamed; uncertain about custom allocator design",
+           issue = "27779")]
 #[derive(Copy, Clone)]
 pub struct ExchangeHeapSingleton { _force_singleton: () }
 
@@ -121,7 +123,9 @@ pub struct Box<T: ?Sized>(Unique<T>);
 /// the fact that the `align_of` intrinsic currently requires the
 /// input type to be Sized (which I do not think is strictly
 /// necessary).
-#[unstable(feature = "placement_in", reason = "placement box design is still being worked out.")]
+#[unstable(feature = "placement_in",
+           reason = "placement box design is still being worked out.",
+           issue = "27779")]
 pub struct IntermediateBox<T: ?Sized>{
     ptr: *mut u8,
     size: usize,
@@ -222,7 +226,8 @@ impl<T : ?Sized> Box<T> {
     /// lead to memory problems like double-free, for example if the
     /// function is called twice on the same raw pointer.
     #[unstable(feature = "box_raw",
-               reason = "may be renamed or moved out of Box scope")]
+               reason = "may be renamed or moved out of Box scope",
+               issue = "27768")]
     #[inline]
     // NB: may want to be called from_ptr, see comments on CStr::from_ptr
     pub unsafe fn from_raw(raw: *mut T) -> Self {
@@ -245,7 +250,8 @@ impl<T : ?Sized> Box<T> {
     /// let raw = Box::into_raw(seventeen);
     /// let boxed_again = unsafe { Box::from_raw(raw) };
     /// ```
-    #[unstable(feature = "box_raw", reason = "may be renamed")]
+    #[unstable(feature = "box_raw", reason = "may be renamed",
+               issue = "27768")]
     #[inline]
     // NB: may want to be called into_ptr, see comments on CStr::from_ptr
     pub fn into_raw(b: Box<T>) -> *mut T {
@@ -470,7 +476,7 @@ impl<I: ExactSizeIterator + ?Sized> ExactSizeIterator for Box<I> {}
 /// }
 /// ```
 #[rustc_paren_sugar]
-#[unstable(feature = "fnbox", reason = "Newly introduced")]
+#[unstable(feature = "fnbox", reason = "Newly introduced", issue = "0")]
 pub trait FnBox<A> {
     type Output;
 

--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -12,7 +12,8 @@
             reason = "the precise API and guarantees it provides may be tweaked \
                       slightly, especially to possibly take into account the \
                       types being stored to make room for a future \
-                      tracing garbage collector")]
+                      tracing garbage collector",
+            issue = "27700")]
 
 use core::{isize, usize};
 

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -64,7 +64,8 @@
 #![allow(unused_attributes)]
 #![unstable(feature = "alloc",
             reason = "this library is unlikely to be stabilized in its current \
-                      form or name")]
+                      form or name",
+            issue = "27783")]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/",
@@ -131,7 +132,8 @@ pub mod raw_vec;
 /// Common out-of-memory routine
 #[cold]
 #[inline(never)]
-#[unstable(feature = "oom", reason = "not a scrutinized interface")]
+#[unstable(feature = "oom", reason = "not a scrutinized interface",
+           issue = "27700")]
 pub fn oom() -> ! {
     // FIXME(#14674): This really needs to do something other than just abort
     //                here, but any printing done must be *guaranteed* to not

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -238,7 +238,7 @@ impl<T> Rc<T> {
     /// assert_eq!(Rc::try_unwrap(x), Err(Rc::new(4)));
     /// ```
     #[inline]
-    #[unstable(feature = "rc_unique")]
+    #[unstable(feature = "rc_unique", issue = "27718")]
     pub fn try_unwrap(rc: Rc<T>) -> Result<T, Rc<T>> {
         if Rc::is_unique(&rc) {
             unsafe {
@@ -271,7 +271,8 @@ impl<T: ?Sized> Rc<T> {
     /// let weak_five = five.downgrade();
     /// ```
     #[unstable(feature = "rc_weak",
-               reason = "Weak pointers may not belong in this module")]
+               reason = "Weak pointers may not belong in this module",
+               issue = "27718")]
     pub fn downgrade(&self) -> Weak<T> {
         self.inc_weak();
         Weak { _ptr: self._ptr }
@@ -279,12 +280,12 @@ impl<T: ?Sized> Rc<T> {
 
     /// Get the number of weak references to this value.
     #[inline]
-    #[unstable(feature = "rc_counts")]
+    #[unstable(feature = "rc_counts", issue = "27718")]
     pub fn weak_count(this: &Rc<T>) -> usize { this.weak() - 1 }
 
     /// Get the number of strong references to this value.
     #[inline]
-    #[unstable(feature = "rc_counts")]
+    #[unstable(feature = "rc_counts", issue= "27718")]
     pub fn strong_count(this: &Rc<T>) -> usize { this.strong() }
 
     /// Returns true if there are no other `Rc` or `Weak<T>` values that share
@@ -302,7 +303,7 @@ impl<T: ?Sized> Rc<T> {
     /// assert!(Rc::is_unique(&five));
     /// ```
     #[inline]
-    #[unstable(feature = "rc_unique")]
+    #[unstable(feature = "rc_unique", issue = "27718")]
     pub fn is_unique(rc: &Rc<T>) -> bool {
         Rc::weak_count(rc) == 0 && Rc::strong_count(rc) == 1
     }
@@ -327,7 +328,7 @@ impl<T: ?Sized> Rc<T> {
     /// assert!(Rc::get_mut(&mut x).is_none());
     /// ```
     #[inline]
-    #[unstable(feature = "rc_unique")]
+    #[unstable(feature = "rc_unique", issue = "27718")]
     pub fn get_mut(rc: &mut Rc<T>) -> Option<&mut T> {
         if Rc::is_unique(rc) {
             let inner = unsafe { &mut **rc._ptr };
@@ -356,7 +357,7 @@ impl<T: Clone> Rc<T> {
     /// let mut_five = five.make_unique();
     /// ```
     #[inline]
-    #[unstable(feature = "rc_unique")]
+    #[unstable(feature = "rc_unique", issue = "27718")]
     pub fn make_unique(&mut self) -> &mut T {
         if !Rc::is_unique(self) {
             *self = Rc::new((**self).clone())
@@ -653,7 +654,8 @@ impl<T> fmt::Pointer for Rc<T> {
 /// See the [module level documentation](./index.html) for more.
 #[unsafe_no_drop_flag]
 #[unstable(feature = "rc_weak",
-           reason = "Weak pointers may not belong in this module.")]
+           reason = "Weak pointers may not belong in this module.",
+           issue = "27718")]
 pub struct Weak<T: ?Sized> {
     // FIXME #12808: strange names to try to avoid interfering with
     // field accesses of the contained type via Deref
@@ -666,7 +668,8 @@ impl<T: ?Sized> !marker::Sync for Weak<T> {}
 impl<T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<Weak<U>> for Weak<T> {}
 
 #[unstable(feature = "rc_weak",
-           reason = "Weak pointers may not belong in this module.")]
+           reason = "Weak pointers may not belong in this module.",
+           issue = "27718")]
 impl<T: ?Sized> Weak<T> {
 
     /// Upgrades a weak reference to a strong reference.
@@ -746,7 +749,8 @@ impl<T: ?Sized> Drop for Weak<T> {
 }
 
 #[unstable(feature = "rc_weak",
-           reason = "Weak pointers may not belong in this module.")]
+           reason = "Weak pointers may not belong in this module.",
+           issue = "27718")]
 impl<T: ?Sized> Clone for Weak<T> {
 
     /// Makes a clone of the `Weak<T>`.

--- a/src/liballoc_jemalloc/lib.rs
+++ b/src/liballoc_jemalloc/lib.rs
@@ -16,7 +16,8 @@
 #![cfg_attr(not(stage0), allocator)]
 #![unstable(feature = "alloc_jemalloc",
             reason = "this library is unlikely to be stabilized in its current \
-                      form or name")]
+                      form or name",
+            issue = "27783")]
 #![feature(allocator)]
 #![feature(libc)]
 #![feature(no_std)]

--- a/src/liballoc_system/lib.rs
+++ b/src/liballoc_system/lib.rs
@@ -16,7 +16,8 @@
 #![cfg_attr(not(stage0), allocator)]
 #![unstable(feature = "alloc_system",
             reason = "this library is unlikely to be stabilized in its current \
-                      form or name")]
+                      form or name",
+            issue = "27783")]
 #![feature(allocator)]
 #![feature(libc)]
 #![feature(no_std)]

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -22,7 +22,7 @@
 // Do not remove on snapshot creation. Needed for bootstrap. (Issue #22364)
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "arena"]
-#![unstable(feature = "rustc_private")]
+#![unstable(feature = "rustc_private", issue = "27812")]
 #![staged_api]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]

--- a/src/libcollections/binary_heap.rs
+++ b/src/libcollections/binary_heap.rs
@@ -547,7 +547,8 @@ impl<T: Ord> BinaryHeap<T> {
     #[inline]
     #[unstable(feature = "drain",
                reason = "matches collection reform specification, \
-                         waiting for dust to settle")]
+                         waiting for dust to settle",
+               issue = "27711")]
     pub fn drain(&mut self) -> Drain<T> {
         Drain { iter: self.data.drain(..) }
     }
@@ -685,7 +686,7 @@ impl<T> DoubleEndedIterator for IntoIter<T> {
 impl<T> ExactSizeIterator for IntoIter<T> {}
 
 /// An iterator that drains a `BinaryHeap`.
-#[unstable(feature = "drain", reason = "recent addition")]
+#[unstable(feature = "drain", reason = "recent addition", issue = "27711")]
 pub struct Drain<'a, T: 'a> {
     iter: vec::Drain<'a, T>,
 }

--- a/src/libcollections/borrow.rs
+++ b/src/libcollections/borrow.rs
@@ -344,7 +344,8 @@ impl<'a, B: ?Sized> Hash for Cow<'a, B> where B: Hash + ToOwned
 }
 
 /// Trait for moving into a `Cow`.
-#[unstable(feature = "into_cow", reason = "may be replaced by `convert::Into`")]
+#[unstable(feature = "into_cow", reason = "may be replaced by `convert::Into`",
+           issue = "27735")]
 pub trait IntoCow<'a, B: ?Sized> where B: ToOwned {
     /// Moves `self` into `Cow`
     fn into_cow(self) -> Cow<'a, B>;

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -157,6 +157,9 @@ impl<K: Ord, V> BTreeMap<K, V> {
     /// Makes a new empty BTreeMap with the given B.
     ///
     /// B cannot be less than 2.
+    #[unstable(feature = "btree_b",
+               reason = "probably want this to be on the type, eventually",
+               issue = "27795")]
     pub fn with_b(b: usize) -> BTreeMap<K, V> {
         assert!(b > 1, "B must be greater than 1");
         BTreeMap {
@@ -1504,7 +1507,8 @@ impl<K: Ord, V> BTreeMap<K, V> {
     /// assert_eq!(Some((&5, &"b")), map.range(Included(&4), Unbounded).next());
     /// ```
     #[unstable(feature = "btree_range",
-               reason = "matches collection reform specification, waiting for dust to settle")]
+               reason = "matches collection reform specification, waiting for dust to settle",
+               issue = "27787")]
     pub fn range<Min: ?Sized + Ord = K, Max: ?Sized + Ord = K>(&self, min: Bound<&Min>,
                                                                max: Bound<&Max>)
         -> Range<K, V> where
@@ -1537,7 +1541,8 @@ impl<K: Ord, V> BTreeMap<K, V> {
     /// }
     /// ```
     #[unstable(feature = "btree_range",
-               reason = "matches collection reform specification, waiting for dust to settle")]
+               reason = "matches collection reform specification, waiting for dust to settle",
+               issue = "27787")]
     pub fn range_mut<Min: ?Sized + Ord = K, Max: ?Sized + Ord = K>(&mut self, min: Bound<&Min>,
                                                                    max: Bound<&Max>)
         -> RangeMut<K, V> where

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -101,7 +101,8 @@ impl<T: Ord> BTreeSet<T> {
     ///
     /// B cannot be less than 2.
     #[unstable(feature = "btree_b",
-               reason = "probably want this to be on the type, eventually")]
+               reason = "probably want this to be on the type, eventually",
+               issue = "27795")]
     pub fn with_b(b: usize) -> BTreeSet<T> {
         BTreeSet { map: BTreeMap::with_b(b) }
     }
@@ -154,7 +155,8 @@ impl<T: Ord> BTreeSet<T> {
     /// assert_eq!(Some(&5), set.range(Included(&4), Unbounded).next());
     /// ```
     #[unstable(feature = "btree_range",
-               reason = "matches collection reform specification, waiting for dust to settle")]
+               reason = "matches collection reform specification, waiting for dust to settle",
+               issue = "27787")]
     pub fn range<'a, Min: ?Sized + Ord = T, Max: ?Sized + Ord = T>(&'a self, min: Bound<&Min>,
                                                                    max: Bound<&Max>)
         -> Range<'a, T> where

--- a/src/libcollections/enum_set.rs
+++ b/src/libcollections/enum_set.rs
@@ -15,7 +15,8 @@
 
 #![unstable(feature = "enumset",
             reason = "matches collection reform specification, \
-                      waiting for dust to settle")]
+                      waiting for dust to settle",
+            issue = "0")]
 
 use core::marker;
 use core::fmt;

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -20,7 +20,8 @@
 #![crate_type = "rlib"]
 #![unstable(feature = "collections",
             reason = "library is unlikely to be stabilized with the current \
-                      layout and name, use std::collections instead")]
+                      layout and name, use std::collections instead",
+            issue = "27783")]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/",
@@ -110,7 +111,7 @@ mod std {
 }
 
 /// An endpoint of a range of keys.
-#[unstable(feature = "collections_bound")]
+#[unstable(feature = "collections_bound", issue = "27711")]
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub enum Bound<T> {
     /// An inclusive bound.

--- a/src/libcollections/linked_list.rs
+++ b/src/libcollections/linked_list.rs
@@ -801,7 +801,8 @@ impl<'a, A> IterMut<'a, A> {
     /// ```
     #[inline]
     #[unstable(feature = "linked_list_extras",
-               reason = "this is probably better handled by a cursor type -- we'll see")]
+               reason = "this is probably better handled by a cursor type -- we'll see",
+               issue = "27794")]
     pub fn insert_next(&mut self, elt: A) {
         self.insert_next_node(box Node::new(elt))
     }
@@ -825,7 +826,8 @@ impl<'a, A> IterMut<'a, A> {
     /// ```
     #[inline]
     #[unstable(feature = "linked_list_extras",
-               reason = "this is probably better handled by a cursor type -- we'll see")]
+               reason = "this is probably better handled by a cursor type -- we'll see",
+               issue = "27794")]
     pub fn peek_next(&mut self) -> Option<&mut A> {
         if self.nelem == 0 {
             return None

--- a/src/libcollections/range.rs
+++ b/src/libcollections/range.rs
@@ -8,7 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![unstable(feature = "collections_range", reason = "was just added")]
+#![unstable(feature = "collections_range", reason = "was just added",
+            issue = "27711")]
 
 //! Range syntax.
 

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -214,21 +214,21 @@ impl<T> [T] {
     }
 
     /// Returns the first and all the rest of the elements of a slice.
-    #[unstable(feature = "slice_splits", reason = "new API")]
+    #[unstable(feature = "slice_splits", reason = "new API", issue = "27742")]
     #[inline]
     pub fn split_first(&self) -> Option<(&T, &[T])> {
         core_slice::SliceExt::split_first(self)
     }
 
     /// Returns the first and all the rest of the elements of a slice.
-    #[unstable(feature = "slice_splits", reason = "new API")]
+    #[unstable(feature = "slice_splits", reason = "new API", issue = "27742")]
     #[inline]
     pub fn split_first_mut(&mut self) -> Option<(&mut T, &mut [T])> {
         core_slice::SliceExt::split_first_mut(self)
     }
 
     /// Returns the last and all the rest of the elements of a slice.
-    #[unstable(feature = "slice_splits", reason = "new API")]
+    #[unstable(feature = "slice_splits", reason = "new API", issue = "27742")]
     #[inline]
     pub fn split_last(&self) -> Option<(&T, &[T])> {
         core_slice::SliceExt::split_last(self)
@@ -236,7 +236,7 @@ impl<T> [T] {
     }
 
     /// Returns the last and all the rest of the elements of a slice.
-    #[unstable(feature = "slice_splits", since = "1.3.0")]
+    #[unstable(feature = "slice_splits", reason = "new API", issue = "27742")]
     #[inline]
     pub fn split_last_mut(&mut self) -> Option<(&mut T, &mut [T])> {
         core_slice::SliceExt::split_last_mut(self)
@@ -785,7 +785,7 @@ impl<T> [T] {
     /// assert!(dst.clone_from_slice(&src2) == 3);
     /// assert!(dst == [3, 4, 5]);
     /// ```
-    #[unstable(feature = "clone_from_slice")]
+    #[unstable(feature = "clone_from_slice", issue = "27750")]
     pub fn clone_from_slice(&mut self, src: &[T]) -> usize where T: Clone {
         core_slice::SliceExt::clone_from_slice(self, src)
     }
@@ -811,11 +811,13 @@ impl<T> [T] {
 // Extension traits for slices over specific kinds of data
 ////////////////////////////////////////////////////////////////////////////////
 #[unstable(feature = "slice_concat_ext",
-           reason = "trait should not have to exist")]
+           reason = "trait should not have to exist",
+           issue = "27747")]
 /// An extension trait for concatenating slices
 pub trait SliceConcatExt<T: ?Sized> {
     #[unstable(feature = "slice_concat_ext",
-               reason = "trait should not have to exist")]
+               reason = "trait should not have to exist",
+               issue = "27747")]
     /// The resulting type after concatenation
     type Output;
 

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -105,7 +105,7 @@ impl<S: Borrow<str>> SliceConcatExt<str> for [S] {
 ///
 /// For use with the `std::iter` module.
 #[derive(Clone)]
-#[unstable(feature = "str_utf16")]
+#[unstable(feature = "str_utf16", issue = "27714")]
 pub struct Utf16Units<'a> {
     encoder: Utf16Encoder<Chars<'a>>
 }
@@ -211,7 +211,8 @@ impl str {
                reason = "it is unclear whether this method pulls its weight \
                          with the existence of the char_indices iterator or \
                          this method may want to be replaced with checked \
-                         slicing")]
+                         slicing",
+               issue = "27754")]
     #[inline]
     pub fn is_char_boundary(&self, index: usize) -> bool {
         core_str::StrExt::is_char_boundary(self, index)
@@ -275,7 +276,8 @@ impl str {
     /// Takes a bytewise mutable slice from a string.
     ///
     /// Same as `slice_unchecked`, but works with `&mut str` instead of `&str`.
-    #[unstable(feature = "str_slice_mut", reason = "recently added")]
+    #[unstable(feature = "str_slice_mut", reason = "recently added",
+               issue = "27793")]
     #[inline]
     pub unsafe fn slice_mut_unchecked(&mut self, begin: usize, end: usize) -> &mut str {
         core_str::StrExt::slice_mut_unchecked(self, begin, end)
@@ -329,7 +331,8 @@ impl str {
     #[unstable(feature = "str_char",
                reason = "often replaced by char_indices, this method may \
                          be removed in favor of just char_at() or eventually \
-                         removed altogether")]
+                         removed altogether",
+               issue = "27754")]
     #[inline]
     pub fn char_range_at(&self, start: usize) -> CharRange {
         core_str::StrExt::char_range_at(self, start)
@@ -388,7 +391,8 @@ impl str {
     #[unstable(feature = "str_char",
                reason = "often replaced by char_indices, this method may \
                          be removed in favor of just char_at_reverse() or \
-                         eventually removed altogether")]
+                         eventually removed altogether",
+               issue = "27754")]
     #[inline]
     pub fn char_range_at_reverse(&self, start: usize) -> CharRange {
         core_str::StrExt::char_range_at_reverse(self, start)
@@ -416,7 +420,8 @@ impl str {
                          method may be removed or possibly renamed in the \
                          future; it is normally replaced by chars/char_indices \
                          iterators or by getting the first char from a \
-                         subslice")]
+                         subslice",
+               issue = "27754")]
     #[inline]
     pub fn char_at(&self, i: usize) -> char {
         core_str::StrExt::char_at(self, i)
@@ -443,7 +448,8 @@ impl str {
     #[unstable(feature = "str_char",
                reason = "see char_at for more details, but reverse semantics \
                          are also somewhat unclear, especially with which \
-                         cases generate panics")]
+                         cases generate panics",
+               issue = "27754")]
     #[inline]
     pub fn char_at_reverse(&self, i: usize) -> char {
         core_str::StrExt::char_at_reverse(self, i)
@@ -478,7 +484,8 @@ impl str {
     #[unstable(feature = "str_char",
                reason = "awaiting conventions about shifting and slices and \
                          may not be warranted with the existence of the chars \
-                         and/or char_indices iterators")]
+                         and/or char_indices iterators",
+               issue = "27754")]
     #[inline]
     pub fn slice_shift_char(&self) -> Option<(char, &str)> {
         core_str::StrExt::slice_shift_char(self)
@@ -508,14 +515,16 @@ impl str {
     /// assert_eq!(b, " 老虎 Léopard");
     /// ```
     #[inline]
-    #[unstable(feature = "str_split_at", reason = "recently added")]
+    #[unstable(feature = "str_split_at", reason = "recently added",
+               issue = "27792")]
     pub fn split_at(&self, mid: usize) -> (&str, &str) {
         core_str::StrExt::split_at(self, mid)
     }
 
     /// Divide one mutable string slice into two at an index.
     #[inline]
-    #[unstable(feature = "str_split_at", reason = "recently added")]
+    #[unstable(feature = "str_split_at", reason = "recently added",
+               issue = "27792")]
     pub fn split_at_mut(&mut self, mid: usize) -> (&mut str, &mut str) {
         core_str::StrExt::split_at_mut(self, mid)
     }
@@ -652,7 +661,8 @@ impl str {
 
     /// Returns an iterator of `u16` over the string encoded as UTF-16.
     #[unstable(feature = "str_utf16",
-               reason = "this functionality may only be provided by libunicode")]
+               reason = "this functionality may only be provided by libunicode",
+               issue = "27714")]
     pub fn utf16_units(&self) -> Utf16Units {
         Utf16Units { encoder: Utf16Encoder::new(self[..].chars()) }
     }
@@ -1186,7 +1196,8 @@ impl str {
     /// assert_eq!(v, [(0, 3)]); // only the first `aba`
     /// ```
     #[unstable(feature = "str_match_indices",
-               reason = "might have its iterator type changed")]
+               reason = "might have its iterator type changed",
+               issue = "27743")]
     // NB: Right now MatchIndices yields `(usize, usize)`, but it would
     // be more consistent with `matches` and `char_indices` to return `(usize, &str)`
     pub fn match_indices<'a, P: Pattern<'a>>(&'a self, pat: P) -> MatchIndices<'a, P> {
@@ -1231,7 +1242,8 @@ impl str {
     /// assert_eq!(v, [(2, 5)]); // only the last `aba`
     /// ```
     #[unstable(feature = "str_match_indices",
-               reason = "might have its iterator type changed")]
+               reason = "might have its iterator type changed",
+               issue = "27743")]
     // NB: Right now RMatchIndices yields `(usize, usize)`, but it would
     // be more consistent with `rmatches` and `char_indices` to return `(usize, &str)`
     pub fn rmatch_indices<'a, P: Pattern<'a>>(&'a self, pat: P) -> RMatchIndices<'a, P>
@@ -1476,21 +1488,24 @@ impl str {
 
     /// Escapes each char in `s` with `char::escape_default`.
     #[unstable(feature = "str_escape",
-               reason = "return type may change to be an iterator")]
+               reason = "return type may change to be an iterator",
+               issue = "27791")]
     pub fn escape_default(&self) -> String {
         self.chars().flat_map(|c| c.escape_default()).collect()
     }
 
     /// Escapes each char in `s` with `char::escape_unicode`.
     #[unstable(feature = "str_escape",
-               reason = "return type may change to be an iterator")]
+               reason = "return type may change to be an iterator",
+               issue = "27791")]
     pub fn escape_unicode(&self) -> String {
         self.chars().flat_map(|c| c.escape_unicode()).collect()
     }
 
     /// Converts the `Box<str>` into a `String` without copying or allocating.
     #[unstable(feature = "box_str",
-               reason = "recently added, matches RFC")]
+               reason = "recently added, matches RFC",
+               issue = "27785")]
     pub fn into_string(self: Box<str>) -> String {
         unsafe {
             let slice = mem::transmute::<Box<str>, Box<[u8]>>(self);

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -343,7 +343,8 @@ impl String {
     /// Extracts a string slice containing the entire string.
     #[inline]
     #[unstable(feature = "convert",
-               reason = "waiting on RFC revision")]
+               reason = "waiting on RFC revision",
+               issue = "27729")]
     pub fn as_str(&self) -> &str {
         self
     }
@@ -698,7 +699,8 @@ impl String {
     /// assert_eq!(s, "");
     /// ```
     #[unstable(feature = "drain",
-               reason = "recently added, matches RFC")]
+               reason = "recently added, matches RFC",
+               issue = "27711")]
     pub fn drain<R>(&mut self, range: R) -> Drain where R: RangeArgument<usize> {
         // Memory safety
         //
@@ -728,7 +730,8 @@ impl String {
     ///
     /// Note that this will drop any excess capacity.
     #[unstable(feature = "box_str",
-               reason = "recently added, matches RFC")]
+               reason = "recently added, matches RFC",
+               issue = "27785")]
     pub fn into_boxed_str(self) -> Box<str> {
         let slice = self.vec.into_boxed_slice();
         unsafe { mem::transmute::<Box<[u8]>, Box<str>>(slice) }
@@ -1019,7 +1022,8 @@ impl ops::DerefMut for String {
 
 /// Error returned from `String::from`
 #[unstable(feature = "str_parse_error", reason = "may want to be replaced with \
-                                                  Void if it ever exists")]
+                                                  Void if it ever exists",
+           issue = "27734")]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct ParseError(());
 
@@ -1110,7 +1114,8 @@ impl Into<Vec<u8>> for String {
     }
 }
 
-#[unstable(feature = "into_cow", reason = "may be replaced by `convert::Into`")]
+#[unstable(feature = "into_cow", reason = "may be replaced by `convert::Into`",
+           issue= "27735")]
 impl IntoCow<'static, str> for String {
     #[inline]
     fn into_cow(self) -> Cow<'static, str> {
@@ -1118,7 +1123,8 @@ impl IntoCow<'static, str> for String {
     }
 }
 
-#[unstable(feature = "into_cow", reason = "may be replaced by `convert::Into`")]
+#[unstable(feature = "into_cow", reason = "may be replaced by `convert::Into`",
+           issue = "27735")]
 impl<'a> IntoCow<'a, str> for &'a str {
     #[inline]
     fn into_cow(self) -> Cow<'a, str> {
@@ -1142,7 +1148,7 @@ impl fmt::Write for String {
 }
 
 /// A draining iterator for `String`.
-#[unstable(feature = "drain", reason = "recently added")]
+#[unstable(feature = "drain", reason = "recently added", issue = "27711")]
 pub struct Drain<'a> {
     /// Will be used as &'a mut String in the destructor
     string: *mut String,
@@ -1157,7 +1163,7 @@ pub struct Drain<'a> {
 unsafe impl<'a> Sync for Drain<'a> {}
 unsafe impl<'a> Send for Drain<'a> {}
 
-#[unstable(feature = "drain", reason = "recently added")]
+#[unstable(feature = "drain", reason = "recently added", issue = "27711")]
 impl<'a> Drop for Drain<'a> {
     fn drop(&mut self) {
         unsafe {
@@ -1171,7 +1177,7 @@ impl<'a> Drop for Drain<'a> {
     }
 }
 
-#[unstable(feature = "drain", reason = "recently added")]
+#[unstable(feature = "drain", reason = "recently added", issue = "27711")]
 impl<'a> Iterator for Drain<'a> {
     type Item = char;
 
@@ -1185,7 +1191,7 @@ impl<'a> Iterator for Drain<'a> {
     }
 }
 
-#[unstable(feature = "drain", reason = "recently added")]
+#[unstable(feature = "drain", reason = "recently added", issue = "27711")]
 impl<'a> DoubleEndedIterator for Drain<'a> {
     #[inline]
     fn next_back(&mut self) -> Option<char> {

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -384,7 +384,8 @@ impl<T> Vec<T> {
     /// Equivalent to `&s[..]`.
     #[inline]
     #[unstable(feature = "convert",
-               reason = "waiting on RFC revision")]
+               reason = "waiting on RFC revision",
+               issue = "27729")]
     pub fn as_slice(&self) -> &[T] {
         self
     }
@@ -394,7 +395,8 @@ impl<T> Vec<T> {
     /// Equivalent to `&mut s[..]`.
     #[inline]
     #[unstable(feature = "convert",
-               reason = "waiting on RFC revision")]
+               reason = "waiting on RFC revision",
+               issue = "27729")]
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         &mut self[..]
     }
@@ -622,7 +624,8 @@ impl<T> Vec<T> {
     /// ```
     #[inline]
     #[unstable(feature = "append",
-               reason = "new API, waiting for dust to settle")]
+               reason = "new API, waiting for dust to settle",
+               issue = "27765")]
     pub fn append(&mut self, other: &mut Self) {
         self.reserve(other.len());
         let len = self.len();
@@ -661,7 +664,8 @@ impl<T> Vec<T> {
     /// assert_eq!(u, &[1, 2, 3]);
     /// ```
     #[unstable(feature = "drain",
-               reason = "recently added, matches RFC")]
+               reason = "recently added, matches RFC",
+               issue = "27711")]
     pub fn drain<R>(&mut self, range: R) -> Drain<T> where R: RangeArgument<usize> {
         // Memory safety
         //
@@ -762,7 +766,8 @@ impl<T> Vec<T> {
     /// ```
     #[inline]
     #[unstable(feature = "split_off",
-               reason = "new API, waiting for dust to settle")]
+               reason = "new API, waiting for dust to settle",
+               issue = "27766")]
     pub fn split_off(&mut self, at: usize) -> Self {
         assert!(at <= self.len(), "`at` out of bounds");
 
@@ -804,7 +809,8 @@ impl<T: Clone> Vec<T> {
     /// assert_eq!(vec, [1, 2]);
     /// ```
     #[unstable(feature = "vec_resize",
-               reason = "matches collection reform specification; waiting for dust to settle")]
+               reason = "matches collection reform specification; waiting for dust to settle",
+               issue = "27790")]
     pub fn resize(&mut self, new_len: usize, value: T) {
         let len = self.len();
 
@@ -854,7 +860,8 @@ impl<T: Clone> Vec<T> {
     /// ```
     #[inline]
     #[unstable(feature = "vec_push_all",
-               reason = "likely to be replaced by a more optimized extend")]
+               reason = "likely to be replaced by a more optimized extend",
+               issue = "27744")]
     pub fn push_all(&mut self, other: &[T]) {
         self.reserve(other.len());
 
@@ -1495,7 +1502,7 @@ impl<T> Drop for IntoIter<T> {
 }
 
 /// A draining iterator for `Vec<T>`.
-#[unstable(feature = "drain", reason = "recently added")]
+#[unstable(feature = "drain", reason = "recently added", issue = "27711")]
 pub struct Drain<'a, T: 'a> {
     /// Index of tail to preserve
     tail_start: usize,

--- a/src/libcollections/vec_deque.rs
+++ b/src/libcollections/vec_deque.rs
@@ -467,7 +467,8 @@ impl<T> VecDeque<T> {
     /// assert_eq!(Some(&5), buf.get(0));
     /// ```
     #[unstable(feature = "deque_extras",
-               reason = "matches collection reform specification; waiting on panic semantics")]
+               reason = "matches collection reform specification; waiting on panic semantics",
+               issue = "27788")]
     pub fn truncate(&mut self, len: usize) {
         for _ in len..self.len() {
             self.pop_back();
@@ -528,7 +529,8 @@ impl<T> VecDeque<T> {
     /// `VecDeque`.
     #[inline]
     #[unstable(feature = "deque_extras",
-               reason = "matches collection reform specification, waiting for dust to settle")]
+               reason = "matches collection reform specification, waiting for dust to settle",
+               issue = "27788")]
     pub fn as_slices(&self) -> (&[T], &[T]) {
         unsafe {
             let contiguous = self.is_contiguous();
@@ -548,7 +550,8 @@ impl<T> VecDeque<T> {
     /// `VecDeque`.
     #[inline]
     #[unstable(feature = "deque_extras",
-               reason = "matches collection reform specification, waiting for dust to settle")]
+               reason = "matches collection reform specification, waiting for dust to settle",
+               issue = "27788")]
     pub fn as_mut_slices(&mut self) -> (&mut [T], &mut [T]) {
         unsafe {
             let contiguous = self.is_contiguous();
@@ -615,7 +618,8 @@ impl<T> VecDeque<T> {
     /// ```
     #[inline]
     #[unstable(feature = "drain",
-               reason = "matches collection reform specification, waiting for dust to settle")]
+               reason = "matches collection reform specification, waiting for dust to settle",
+               issue = "27711")]
     pub fn drain(&mut self) -> Drain<T> {
         Drain {
             inner: self,
@@ -864,7 +868,8 @@ impl<T> VecDeque<T> {
     /// assert_eq!(buf[1], 2);
     /// ```
     #[unstable(feature = "deque_extras",
-               reason = "the naming of this function may be altered")]
+               reason = "the naming of this function may be altered",
+               issue = "27788")]
     pub fn swap_back_remove(&mut self, index: usize) -> Option<T> {
         let length = self.len();
         if length > 0 && index < length - 1 {
@@ -901,7 +906,8 @@ impl<T> VecDeque<T> {
     /// assert_eq!(buf[1], 1);
     /// ```
     #[unstable(feature = "deque_extras",
-               reason = "the naming of this function may be altered")]
+               reason = "the naming of this function may be altered",
+               issue = "27788")]
     pub fn swap_front_remove(&mut self, index: usize) -> Option<T> {
         let length = self.len();
         if length > 0 && index < length && index != 0 {
@@ -1311,7 +1317,8 @@ impl<T> VecDeque<T> {
     /// ```
     #[inline]
     #[unstable(feature = "split_off",
-               reason = "new API, waiting for dust to settle")]
+               reason = "new API, waiting for dust to settle",
+               issue = "27766")]
     pub fn split_off(&mut self, at: usize) -> Self {
         let len = self.len();
         assert!(at <= len, "`at` out of bounds");
@@ -1375,7 +1382,8 @@ impl<T> VecDeque<T> {
     /// ```
     #[inline]
     #[unstable(feature = "append",
-               reason = "new API, waiting for dust to settle")]
+               reason = "new API, waiting for dust to settle",
+               issue = "27765")]
     pub fn append(&mut self, other: &mut Self) {
         // naive impl
         self.extend(other.drain());
@@ -1402,7 +1410,8 @@ impl<T> VecDeque<T> {
     /// assert_eq!(&v[..], &[2, 4]);
     /// ```
     #[unstable(feature = "vec_deque_retain",
-               reason = "new API, waiting for dust to settle")]
+               reason = "new API, waiting for dust to settle",
+               issue = "27767")]
     pub fn retain<F>(&mut self, mut f: F) where F: FnMut(&T) -> bool {
         let len = self.len();
         let mut del = 0;
@@ -1441,7 +1450,8 @@ impl<T: Clone> VecDeque<T> {
     /// }
     /// ```
     #[unstable(feature = "deque_extras",
-               reason = "matches collection reform specification; waiting on panic semantics")]
+               reason = "matches collection reform specification; waiting on panic semantics",
+               issue = "27788")]
     pub fn resize(&mut self, new_len: usize, value: T) {
         let len = self.len();
 
@@ -1610,7 +1620,8 @@ impl<T> ExactSizeIterator for IntoIter<T> {}
 
 /// A draining VecDeque iterator
 #[unstable(feature = "drain",
-           reason = "matches collection reform specification, waiting for dust to settle")]
+           reason = "matches collection reform specification, waiting for dust to settle",
+           issue = "27711")]
 pub struct Drain<'a, T: 'a> {
     inner: &'a mut VecDeque<T>,
 }

--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -91,7 +91,8 @@ use marker::{Reflect, Sized};
 pub trait Any: Reflect + 'static {
     /// Gets the `TypeId` of `self`.
     #[unstable(feature = "get_type_id",
-               reason = "this method will likely be replaced by an associated static")]
+               reason = "this method will likely be replaced by an associated static",
+               issue = "27745")]
     fn get_type_id(&self) -> TypeId;
 }
 

--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -16,7 +16,8 @@
 
 #![unstable(feature = "fixed_size_array",
             reason = "traits and impls are better expressed through generic \
-                      integer constants")]
+                      integer constants",
+            issue = "27778")]
 
 use clone::Clone;
 use cmp::{PartialEq, Eq, PartialOrd, Ord, Ordering};

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -230,7 +230,7 @@ impl<T:Copy> Cell<T> {
     /// let uc = unsafe { c.as_unsafe_cell() };
     /// ```
     #[inline]
-    #[unstable(feature = "as_unsafe_cell")]
+    #[unstable(feature = "as_unsafe_cell", issue = "27708")]
     pub unsafe fn as_unsafe_cell<'a>(&'a self) -> &'a UnsafeCell<T> {
         &self.value
     }
@@ -278,7 +278,7 @@ pub struct RefCell<T: ?Sized> {
 
 /// An enumeration of values returned from the `state` method on a `RefCell<T>`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-#[unstable(feature = "borrow_state")]
+#[unstable(feature = "borrow_state", issue = "27733")]
 pub enum BorrowState {
     /// The cell is currently being read, there is at least one active `borrow`.
     Reading,
@@ -340,7 +340,7 @@ impl<T: ?Sized> RefCell<T> {
     ///
     /// The returned value can be dispatched on to determine if a call to
     /// `borrow` or `borrow_mut` would succeed.
-    #[unstable(feature = "borrow_state")]
+    #[unstable(feature = "borrow_state", issue = "27733")]
     #[inline]
     pub fn borrow_state(&self) -> BorrowState {
         match self.borrow.get() {
@@ -449,7 +449,7 @@ impl<T: ?Sized> RefCell<T> {
     ///
     /// This function is `unsafe` because `UnsafeCell`'s field is public.
     #[inline]
-    #[unstable(feature = "as_unsafe_cell")]
+    #[unstable(feature = "as_unsafe_cell", issue = "27708")]
     pub unsafe fn as_unsafe_cell<'a>(&'a self) -> &'a UnsafeCell<T> {
         &self.value
     }
@@ -556,7 +556,8 @@ impl<'b, T: ?Sized> Ref<'b, T> {
     /// with the widespread use of `r.borrow().clone()` to clone the contents of
     /// a `RefCell`.
     #[unstable(feature = "cell_extras",
-               reason = "likely to be moved to a method, pending language changes")]
+               reason = "likely to be moved to a method, pending language changes",
+               issue = "27746")]
     #[inline]
     pub fn clone(orig: &Ref<'b, T>) -> Ref<'b, T> {
         Ref {
@@ -585,7 +586,8 @@ impl<'b, T: ?Sized> Ref<'b, T> {
     /// let b2: Ref<u32> = Ref::map(b1, |t| &t.0);
     /// assert_eq!(*b2, 5)
     /// ```
-    #[unstable(feature = "cell_extras", reason = "recently added")]
+    #[unstable(feature = "cell_extras", reason = "recently added",
+               issue = "27746")]
     #[inline]
     pub fn map<U: ?Sized, F>(orig: Ref<'b, T>, f: F) -> Ref<'b, U>
         where F: FnOnce(&T) -> &U
@@ -616,7 +618,8 @@ impl<'b, T: ?Sized> Ref<'b, T> {
     /// let b2: Ref<u32> = Ref::filter_map(b1, |o| o.as_ref().ok()).unwrap();
     /// assert_eq!(*b2, 5)
     /// ```
-    #[unstable(feature = "cell_extras", reason = "recently added")]
+    #[unstable(feature = "cell_extras", reason = "recently added",
+               issue = "27746")]
     #[inline]
     pub fn filter_map<U: ?Sized, F>(orig: Ref<'b, T>, f: F) -> Option<Ref<'b, U>>
         where F: FnOnce(&T) -> Option<&U>
@@ -653,7 +656,8 @@ impl<'b, T: ?Sized> RefMut<'b, T> {
     /// }
     /// assert_eq!(*c.borrow(), (42, 'b'));
     /// ```
-    #[unstable(feature = "cell_extras", reason = "recently added")]
+    #[unstable(feature = "cell_extras", reason = "recently added",
+               issue = "27746")]
     #[inline]
     pub fn map<U: ?Sized, F>(orig: RefMut<'b, T>, f: F) -> RefMut<'b, U>
         where F: FnOnce(&mut T) -> &mut U
@@ -690,7 +694,8 @@ impl<'b, T: ?Sized> RefMut<'b, T> {
     /// }
     /// assert_eq!(*c.borrow(), Ok(42));
     /// ```
-    #[unstable(feature = "cell_extras", reason = "recently added")]
+    #[unstable(feature = "cell_extras", reason = "recently added",
+               issue = "27746")]
     #[inline]
     pub fn filter_map<U: ?Sized, F>(orig: RefMut<'b, T>, f: F) -> Option<RefMut<'b, U>>
         where F: FnOnce(&mut T) -> Option<&mut U>

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -91,7 +91,8 @@ pub fn from_u32(i: u32) -> Option<char> {
 /// Converts a `u32` to an `char`, not checking whether it is a valid unicode
 /// codepoint.
 #[inline]
-#[unstable(feature = "char_from_unchecked", reason = "recently added API")]
+#[unstable(feature = "char_from_unchecked", reason = "recently added API",
+           issue = "27781")]
 pub unsafe fn from_u32_unchecked(i: u32) -> char {
     transmute(i)
 }
@@ -139,7 +140,8 @@ pub fn from_digit(num: u32, radix: u32) -> Option<char> {
 #[allow(missing_docs)] // docs in libunicode/u_char.rs
 #[doc(hidden)]
 #[unstable(feature = "core_char_ext",
-           reason = "the stable interface is `impl char` in later crate")]
+           reason = "the stable interface is `impl char` in later crate",
+           issue = "27701")]
 pub trait CharExt {
     fn is_digit(self, radix: u32) -> bool;
     fn to_digit(self, radix: u32) -> Option<u32>;
@@ -230,7 +232,8 @@ impl CharExt for char {
 /// and a `None` will be returned.
 #[inline]
 #[unstable(feature = "char_internals",
-           reason = "this function should not be exposed publicly")]
+           reason = "this function should not be exposed publicly",
+           issue = "0")]
 #[doc(hidden)]
 pub fn encode_utf8_raw(code: u32, dst: &mut [u8]) -> Option<usize> {
     // Marked #[inline] to allow llvm optimizing it away
@@ -264,7 +267,8 @@ pub fn encode_utf8_raw(code: u32, dst: &mut [u8]) -> Option<usize> {
 /// and a `None` will be returned.
 #[inline]
 #[unstable(feature = "char_internals",
-           reason = "this function should not be exposed publicly")]
+           reason = "this function should not be exposed publicly",
+           issue = "0")]
 #[doc(hidden)]
 pub fn encode_utf16_raw(mut ch: u32, dst: &mut [u16]) -> Option<usize> {
     // Marked #[inline] to allow llvm optimizing it away

--- a/src/libcore/fmt/builders.rs
+++ b/src/libcore/fmt/builders.rs
@@ -177,7 +177,8 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     }
 
     /// Returns the wrapped `Formatter`.
-    #[unstable(feature = "debug_builder_formatter", reason = "recently added")]
+    #[unstable(feature = "debug_builder_formatter", reason = "recently added",
+               issue = "27782")]
     pub fn formatter(&mut self) -> &mut fmt::Formatter<'b> {
         &mut self.fmt
     }

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -33,7 +33,8 @@ pub use self::builders::{DebugStruct, DebugTuple, DebugSet, DebugList, DebugMap}
 mod num;
 mod builders;
 
-#[unstable(feature = "fmt_internals", reason = "internal to format_args!")]
+#[unstable(feature = "fmt_internals", reason = "internal to format_args!",
+           issue = "0")]
 #[doc(hidden)]
 pub mod rt {
     pub mod v1;
@@ -146,7 +147,8 @@ enum Void {}
 /// compile time it is ensured that the function and the value have the correct
 /// types, and then this struct is used to canonicalize arguments to one type.
 #[derive(Copy)]
-#[unstable(feature = "fmt_internals", reason = "internal to format_args!")]
+#[unstable(feature = "fmt_internals", reason = "internal to format_args!",
+           issue = "0")]
 #[doc(hidden)]
 pub struct ArgumentV1<'a> {
     value: &'a Void,
@@ -166,7 +168,8 @@ impl<'a> ArgumentV1<'a> {
     }
 
     #[doc(hidden)]
-    #[unstable(feature = "fmt_internals", reason = "internal to format_args!")]
+    #[unstable(feature = "fmt_internals", reason = "internal to format_args!",
+               issue = "0")]
     pub fn new<'b, T>(x: &'b T,
                       f: fn(&T, &mut Formatter) -> Result) -> ArgumentV1<'b> {
         unsafe {
@@ -178,7 +181,8 @@ impl<'a> ArgumentV1<'a> {
     }
 
     #[doc(hidden)]
-    #[unstable(feature = "fmt_internals", reason = "internal to format_args!")]
+    #[unstable(feature = "fmt_internals", reason = "internal to format_args!",
+               issue = "0")]
     pub fn from_usize(x: &usize) -> ArgumentV1 {
         ArgumentV1::new(x, ArgumentV1::show_usize)
     }
@@ -201,7 +205,8 @@ impl<'a> Arguments<'a> {
     /// When using the format_args!() macro, this function is used to generate the
     /// Arguments structure.
     #[doc(hidden)] #[inline]
-    #[unstable(feature = "fmt_internals", reason = "internal to format_args!")]
+    #[unstable(feature = "fmt_internals", reason = "internal to format_args!",
+               issue = "0")]
     pub fn new_v1(pieces: &'a [&'a str],
                   args: &'a [ArgumentV1<'a>]) -> Arguments<'a> {
         Arguments {
@@ -218,7 +223,8 @@ impl<'a> Arguments<'a> {
     /// created with `argumentusize`. However, failing to do so doesn't cause
     /// unsafety, but will ignore invalid .
     #[doc(hidden)] #[inline]
-    #[unstable(feature = "fmt_internals", reason = "internal to format_args!")]
+    #[unstable(feature = "fmt_internals", reason = "internal to format_args!",
+               issue = "0")]
     pub fn new_v1_formatted(pieces: &'a [&'a str],
                             args: &'a [ArgumentV1<'a>],
                             fmt: &'a [rt::v1::Argument]) -> Arguments<'a> {
@@ -1077,19 +1083,23 @@ impl<'a> Formatter<'a> {
     pub fn flags(&self) -> u32 { self.flags }
 
     /// Character used as 'fill' whenever there is alignment
-    #[unstable(feature = "fmt_flags", reason = "method was just created")]
+    #[unstable(feature = "fmt_flags", reason = "method was just created",
+               issue = "27726")]
     pub fn fill(&self) -> char { self.fill }
 
     /// Flag indicating what form of alignment was requested
-    #[unstable(feature = "fmt_flags", reason = "method was just created")]
+    #[unstable(feature = "fmt_flags", reason = "method was just created",
+               issue = "27726")]
     pub fn align(&self) -> Alignment { self.align }
 
     /// Optionally specified integer width that the output should be
-    #[unstable(feature = "fmt_flags", reason = "method was just created")]
+    #[unstable(feature = "fmt_flags", reason = "method was just created",
+               issue = "27726")]
     pub fn width(&self) -> Option<usize> { self.width }
 
     /// Optionally specified precision for numeric types
-    #[unstable(feature = "fmt_flags", reason = "method was just created")]
+    #[unstable(feature = "fmt_flags", reason = "method was just created",
+               issue = "27726")]
     pub fn precision(&self) -> Option<usize> { self.precision }
 
     /// Creates a `DebugStruct` builder designed to assist with creation of

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -133,7 +133,8 @@ radix! { UpperHex, 16, "0x", x @  0 ...  9 => b'0' + x,
 /// A radix with in the range of `2..36`.
 #[derive(Clone, Copy, PartialEq)]
 #[unstable(feature = "fmt_radix",
-           reason = "may be renamed or move to a different module")]
+           reason = "may be renamed or move to a different module",
+           issue = "27728")]
 pub struct Radix {
     base: u8,
 }
@@ -158,7 +159,8 @@ impl GenericRadix for Radix {
 
 /// A helper type for formatting radixes.
 #[unstable(feature = "fmt_radix",
-           reason = "may be renamed or move to a different module")]
+           reason = "may be renamed or move to a different module",
+           issue = "27728")]
 #[derive(Copy, Clone)]
 pub struct RadixFmt<T, R>(T, R);
 
@@ -173,7 +175,8 @@ pub struct RadixFmt<T, R>(T, R);
 /// assert_eq!(format!("{}", radix(55, 36)), "1j".to_string());
 /// ```
 #[unstable(feature = "fmt_radix",
-           reason = "may be renamed or move to a different module")]
+           reason = "may be renamed or move to a different module",
+           issue = "27728")]
 pub fn radix<T>(x: T, base: u8) -> RadixFmt<T, Radix> {
     RadixFmt(x, Radix::new(base))
 }

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -42,7 +42,8 @@
 #![unstable(feature = "core_intrinsics",
             reason = "intrinsics are unlikely to ever be stabilized, instead \
                       they should be used through stabilized interfaces \
-                      in the rest of the standard library")]
+                      in the rest of the standard library",
+            issue = "0")]
 #![allow(missing_docs)]
 
 use marker::Sized;

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -820,7 +820,8 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[unstable(feature = "iter_cmp",
-               reason = "may want to produce an Ordering directly; see #15311")]
+               reason = "may want to produce an Ordering directly; see #15311",
+               issue = "27724")]
     fn max_by<B: Ord, F>(self, f: F) -> Option<Self::Item> where
         Self: Sized,
         F: FnMut(&Self::Item) -> B,
@@ -849,7 +850,8 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[unstable(feature = "iter_cmp",
-               reason = "may want to produce an Ordering directly; see #15311")]
+               reason = "may want to produce an Ordering directly; see #15311",
+               issue = "27724")]
     fn min_by<B: Ord, F>(self, f: F) -> Option<Self::Item> where
         Self: Sized,
         F: FnMut(&Self::Item) -> B,
@@ -972,7 +974,8 @@ pub trait Iterator {
     /// let it = a.iter();
     /// assert_eq!(it.sum::<i32>(), 15);
     /// ```
-    #[unstable(feature="iter_arith", reason = "bounds recently changed")]
+    #[unstable(feature = "iter_arith", reason = "bounds recently changed",
+               issue = "27739")]
     fn sum<S=<Self as Iterator>::Item>(self) -> S where
         S: Add<Self::Item, Output=S> + Zero,
         Self: Sized,
@@ -994,7 +997,8 @@ pub trait Iterator {
     /// assert_eq!(factorial(1), 1);
     /// assert_eq!(factorial(5), 120);
     /// ```
-    #[unstable(feature="iter_arith", reason = "bounds recently changed")]
+    #[unstable(feature="iter_arith", reason = "bounds recently changed",
+               issue = "27739")]
     fn product<P=<Self as Iterator>::Item>(self) -> P where
         P: Mul<Self::Item, Output=P> + One,
         Self: Sized,
@@ -2136,8 +2140,9 @@ impl<I: DoubleEndedIterator, F> DoubleEndedIterator for Inspect<I, F>
 /// The `steps_between` function provides a way to efficiently compare
 /// two `Step` objects.
 #[unstable(feature = "step_trait",
-           reason = "likely to be replaced by finer-grained traits")]
-pub trait Step: PartialOrd+Sized {
+           reason = "likely to be replaced by finer-grained traits",
+           issue = "27741")]
+pub trait Step: PartialOrd + Sized {
     /// Steps `self` if possible.
     fn step(&self, by: &Self) -> Option<Self>;
 
@@ -2247,7 +2252,8 @@ step_impl_no_between!(u64 i64);
 /// parameter is the type being iterated over, while `R` is the range
 /// type (usually one of `std::ops::{Range, RangeFrom}`.
 #[derive(Clone)]
-#[unstable(feature = "step_by", reason = "recent addition")]
+#[unstable(feature = "step_by", reason = "recent addition",
+           issue = "27741")]
 pub struct StepBy<A, R> {
     step_by: A,
     range: R,
@@ -2266,7 +2272,8 @@ impl<A: Step> RangeFrom<A> {
     /// ```
     ///
     /// This prints all even `u8` values.
-    #[unstable(feature = "step_by", reason = "recent addition")]
+    #[unstable(feature = "step_by", reason = "recent addition",
+               issue = "27741")]
     pub fn step_by(self, by: A) -> StepBy<A, Self> {
         StepBy {
             step_by: by,
@@ -2300,7 +2307,8 @@ impl<A: Step> ops::Range<A> {
     /// 6
     /// 8
     /// ```
-    #[unstable(feature = "step_by", reason = "recent addition")]
+    #[unstable(feature = "step_by", reason = "recent addition",
+               issue = "27741")]
     pub fn step_by(self, by: A) -> StepBy<A, Self> {
         StepBy {
             step_by: by,
@@ -2332,7 +2340,8 @@ impl<A> Iterator for StepBy<A, RangeFrom<A>> where
 /// An iterator over the range [start, stop]
 #[derive(Clone)]
 #[unstable(feature = "range_inclusive",
-           reason = "likely to be replaced by range notation and adapters")]
+           reason = "likely to be replaced by range notation and adapters",
+           issue = "27777")]
 pub struct RangeInclusive<A> {
     range: ops::Range<A>,
     done: bool,
@@ -2341,7 +2350,8 @@ pub struct RangeInclusive<A> {
 /// Returns an iterator over the range [start, stop].
 #[inline]
 #[unstable(feature = "range_inclusive",
-           reason = "likely to be replaced by range notation and adapters")]
+           reason = "likely to be replaced by range notation and adapters",
+           issue = "27777")]
 pub fn range_inclusive<A>(start: A, stop: A) -> RangeInclusive<A>
     where A: Step + One + Clone
 {
@@ -2352,7 +2362,8 @@ pub fn range_inclusive<A>(start: A, stop: A) -> RangeInclusive<A>
 }
 
 #[unstable(feature = "range_inclusive",
-           reason = "likely to be replaced by range notation and adapters")]
+           reason = "likely to be replaced by range notation and adapters",
+           issue = "27777")]
 impl<A> Iterator for RangeInclusive<A> where
     A: PartialEq + Step + One + Clone,
     for<'a> &'a A: Add<&'a A, Output = A>
@@ -2385,7 +2396,8 @@ impl<A> Iterator for RangeInclusive<A> where
 }
 
 #[unstable(feature = "range_inclusive",
-           reason = "likely to be replaced by range notation and adapters")]
+           reason = "likely to be replaced by range notation and adapters",
+           issue = "27777")]
 impl<A> DoubleEndedIterator for RangeInclusive<A> where
     A: PartialEq + Step + One + Clone,
     for<'a> &'a A: Add<&'a A, Output = A>,
@@ -2642,7 +2654,8 @@ pub fn once<T>(value: T) -> Once<T> {
 ///
 /// If two sequences are equal up until the point where one ends,
 /// the shorter sequence compares less.
-#[unstable(feature = "iter_order", reason = "needs review and revision")]
+#[unstable(feature = "iter_order", reason = "needs review and revision",
+           issue = "27737")]
 pub mod order {
     use cmp;
     use cmp::{Eq, Ord, PartialOrd, PartialEq};

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -51,7 +51,8 @@
 #![crate_name = "core"]
 #![unstable(feature = "core",
             reason = "the libcore library has not yet been scrutinized for \
-                      stabilization in terms of structure and naming")]
+                      stabilization in terms of structure and naming",
+            issue = "27701")]
 #![staged_api]
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -54,7 +54,7 @@ pub trait Sized {
 }
 
 /// Types that can be "unsized" to a dynamically sized type.
-#[unstable(feature = "unsize")]
+#[unstable(feature = "unsize", issue = "27779")]
 #[lang="unsize"]
 pub trait Unsize<T: ?Sized> {
     // Empty.
@@ -406,7 +406,8 @@ mod impls {
 /// [1]: http://en.wikipedia.org/wiki/Parametricity
 #[rustc_reflect_like]
 #[unstable(feature = "reflect_marker",
-           reason = "requires RFC and more experience")]
+           reason = "requires RFC and more experience",
+           issue = "27749")]
 #[rustc_on_unimplemented = "`{Self}` does not implement `Any`; \
                             ensure all type parameters are bounded by `Any`"]
 pub trait Reflect {}

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -247,7 +247,7 @@ pub unsafe fn zeroed<T>() -> T {
 /// This function is expected to be deprecated with the transition
 /// to non-zeroing drop.
 #[inline]
-#[unstable(feature = "filling_drop")]
+#[unstable(feature = "filling_drop", issue = "5016")]
 pub unsafe fn dropped<T>() -> T {
     #[inline(always)]
     unsafe fn dropped_impl<T>() -> T { intrinsics::init_dropped() }
@@ -510,22 +510,22 @@ macro_rules! repeat_u8_as_u64 {
 // But having the sign bit set is a pain, so 0x1d is probably better.
 //
 // And of course, 0x00 brings back the old world of zero'ing on drop.
-#[unstable(feature = "filling_drop")]
+#[unstable(feature = "filling_drop", issue = "5016")]
 #[allow(missing_docs)]
 pub const POST_DROP_U8: u8 = 0x1d;
-#[unstable(feature = "filling_drop")]
+#[unstable(feature = "filling_drop", issue = "5016")]
 #[allow(missing_docs)]
 pub const POST_DROP_U32: u32 = repeat_u8_as_u32!(POST_DROP_U8);
-#[unstable(feature = "filling_drop")]
+#[unstable(feature = "filling_drop", issue = "5016")]
 #[allow(missing_docs)]
 pub const POST_DROP_U64: u64 = repeat_u8_as_u64!(POST_DROP_U8);
 
 #[cfg(target_pointer_width = "32")]
-#[unstable(feature = "filling_drop")]
+#[unstable(feature = "filling_drop", issue = "5016")]
 #[allow(missing_docs)]
 pub const POST_DROP_USIZE: usize = POST_DROP_U32 as usize;
 #[cfg(target_pointer_width = "64")]
-#[unstable(feature = "filling_drop")]
+#[unstable(feature = "filling_drop", issue = "5016")]
 #[allow(missing_docs)]
 pub const POST_DROP_USIZE: usize = POST_DROP_U64 as usize;
 

--- a/src/libcore/nonzero.rs
+++ b/src/libcore/nonzero.rs
@@ -10,7 +10,8 @@
 
 //! Exposes the NonZero lang item which provides optimization hints.
 #![unstable(feature = "nonzero",
-            reason = "needs an RFC to flesh out the design")]
+            reason = "needs an RFC to flesh out the design",
+            issue = "27730")]
 
 use marker::Sized;
 use ops::{CoerceUnsized, Deref};

--- a/src/libcore/num/dec2flt/mod.rs
+++ b/src/libcore/num/dec2flt/mod.rs
@@ -92,7 +92,8 @@
 
 #![doc(hidden)]
 #![unstable(feature = "dec2flt",
-            reason = "internal routines only exposed for testing")]
+            reason = "internal routines only exposed for testing",
+            issue = "0")]
 
 use prelude::v1::*;
 use num::ParseFloatError as PFE;

--- a/src/libcore/num/flt2dec/mod.rs
+++ b/src/libcore/num/flt2dec/mod.rs
@@ -127,7 +127,8 @@ functions.
 // only made public for testing. do not expose us.
 #![doc(hidden)]
 #![unstable(feature = "flt2dec",
-            reason = "internal routines only exposed for testing")]
+            reason = "internal routines only exposed for testing",
+            issue = "0")]
 
 use prelude::v1::*;
 use i16;

--- a/src/libcore/num/int_macros.rs
+++ b/src/libcore/num/int_macros.rs
@@ -15,13 +15,15 @@ macro_rules! int_module { ($T:ty, $bits:expr) => (
 // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
 // calling the `mem::size_of` function.
 #[unstable(feature = "num_bits_bytes",
-           reason = "may want to be an associated function")]
+           reason = "may want to be an associated function",
+           issue = "27753")]
 #[allow(missing_docs)]
 pub const BITS : usize = $bits;
 // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
 // calling the `mem::size_of` function.
 #[unstable(feature = "num_bits_bytes",
-           reason = "may want to be an associated function")]
+           reason = "may want to be an associated function",
+           issue = "27753")]
 #[allow(missing_docs)]
 pub const BYTES : usize = ($bits / 8);
 

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -51,7 +51,8 @@ pub mod dec2flt;
 /// This trait is intended for use in conjunction with `Add`, as an identity:
 /// `x + T::zero() == x`.
 #[unstable(feature = "zero_one",
-           reason = "unsure of placement, wants to use associated constants")]
+           reason = "unsure of placement, wants to use associated constants",
+           issue = "27739")]
 pub trait Zero {
     /// The "zero" (usually, additive identity) for this type.
     fn zero() -> Self;
@@ -62,7 +63,8 @@ pub trait Zero {
 /// This trait is intended for use in conjunction with `Mul`, as an identity:
 /// `x * T::one() == x`.
 #[unstable(feature = "zero_one",
-           reason = "unsure of placement, wants to use associated constants")]
+           reason = "unsure of placement, wants to use associated constants",
+           issue = "27739")]
 pub trait One {
     /// The "one" (usually, multiplicative identity) for this type.
     fn one() -> Self;
@@ -1262,7 +1264,8 @@ pub enum FpCategory {
 /// A built-in floating point number.
 #[doc(hidden)]
 #[unstable(feature = "core_float",
-           reason = "stable interface is via `impl f{32,64}` in later crates")]
+           reason = "stable interface is via `impl f{32,64}` in later crates",
+           issue = "27702")]
 pub trait Float: Sized {
     /// Returns the NaN value.
     fn nan() -> Self;
@@ -1525,7 +1528,8 @@ enum IntErrorKind {
 impl ParseIntError {
     #[unstable(feature = "int_error_internals",
                reason = "available through Error trait and this method should \
-                         not be exposed publicly")]
+                         not be exposed publicly",
+               issue = "0")]
     #[doc(hidden)]
     pub fn __description(&self) -> &str {
         match self.kind {
@@ -1550,13 +1554,15 @@ impl fmt::Display for ParseIntError {
 pub struct ParseFloatError {
     #[doc(hidden)]
     #[unstable(feature = "float_error_internals",
-               reason = "should not be exposed publicly")]
+               reason = "should not be exposed publicly",
+               issue = "0")]
     pub __kind: FloatErrorKind
 }
 
 #[derive(Debug, Clone, PartialEq)]
 #[unstable(feature = "float_error_internals",
-           reason = "should not be exposed publicly")]
+           reason = "should not be exposed publicly",
+           issue = "0")]
 #[doc(hidden)]
 pub enum FloatErrorKind {
     Empty,

--- a/src/libcore/num/uint_macros.rs
+++ b/src/libcore/num/uint_macros.rs
@@ -13,11 +13,13 @@
 macro_rules! uint_module { ($T:ty, $T_SIGNED:ty, $bits:expr) => (
 
 #[unstable(feature = "num_bits_bytes",
-           reason = "may want to be an associated function")]
+           reason = "may want to be an associated function",
+           issue = "27753")]
 #[allow(missing_docs)]
 pub const BITS : usize = $bits;
 #[unstable(feature = "num_bits_bytes",
-           reason = "may want to be an associated function")]
+           reason = "may want to be an associated function",
+           issue = "27753")]
 #[allow(missing_docs)]
 pub const BYTES : usize = ($bits / 8);
 

--- a/src/libcore/num/wrapping.rs
+++ b/src/libcore/num/wrapping.rs
@@ -9,7 +9,8 @@
 // except according to those terms.
 
 #![allow(missing_docs)]
-#![unstable(feature = "wrapping", reason = "may be removed or relocated")]
+#![unstable(feature = "wrapping", reason = "may be removed or relocated",
+            issue = "27755")]
 
 use super::Wrapping;
 

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -1247,7 +1247,7 @@ mod impls {
 
 /// Trait that indicates that this is a pointer or a wrapper for one,
 /// where unsizing can be performed on the pointee.
-#[unstable(feature = "coerce_unsized")]
+#[unstable(feature = "coerce_unsized", issue = "27732")]
 #[lang="coerce_unsized"]
 pub trait CoerceUnsized<T> {
     // Empty.
@@ -1293,7 +1293,7 @@ impl<T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for *const T {}
 /// If evaluating EXPR fails, then the destructor for the
 /// implementation of Place to clean up any intermediate state
 /// (e.g. deallocate box storage, pop a stack, etc).
-#[unstable(feature = "placement_new_protocol")]
+#[unstable(feature = "placement_new_protocol", issue = "27779")]
 pub trait Place<Data: ?Sized> {
     /// Returns the address where the input value will be written.
     /// Note that the data at this address is generally uninitialized,
@@ -1324,7 +1324,7 @@ pub trait Place<Data: ?Sized> {
 /// Values for types implementing this trait usually are transient
 /// intermediate values (e.g. the return value of `Vec::emplace_back`)
 /// or `Copy`, since the `make_place` method takes `self` by value.
-#[unstable(feature = "placement_new_protocol")]
+#[unstable(feature = "placement_new_protocol", issue = "27779")]
 pub trait Placer<Data: ?Sized> {
     /// `Place` is the intermedate agent guarding the
     /// uninitialized state for `Data`.
@@ -1335,7 +1335,7 @@ pub trait Placer<Data: ?Sized> {
 }
 
 /// Specialization of `Place` trait supporting `in (PLACE) EXPR`.
-#[unstable(feature = "placement_new_protocol")]
+#[unstable(feature = "placement_new_protocol", issue = "27779")]
 pub trait InPlace<Data: ?Sized>: Place<Data> {
     /// `Owner` is the type of the end value of `in (PLACE) EXPR`
     ///
@@ -1372,7 +1372,7 @@ pub trait InPlace<Data: ?Sized>: Place<Data> {
 /// `<T as Boxed>` in turn dictates determines which
 /// implementation of `BoxPlace` to use, namely:
 /// `<<T as Boxed>::Place as BoxPlace>`.
-#[unstable(feature = "placement_new_protocol")]
+#[unstable(feature = "placement_new_protocol", issue = "27779")]
 pub trait Boxed {
     /// The kind of data that is stored in this kind of box.
     type Data;  /* (`Data` unused b/c cannot yet express below bound.) */
@@ -1386,7 +1386,7 @@ pub trait Boxed {
 }
 
 /// Specialization of `Place` trait supporting `box EXPR`.
-#[unstable(feature = "placement_new_protocol")]
+#[unstable(feature = "placement_new_protocol", issue = "27779")]
 pub trait BoxPlace<Data: ?Sized> : Place<Data> {
     /// Creates a globally fresh place.
     fn make_place() -> Self;

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -287,7 +287,8 @@ impl<T> Option<T> {
     /// ```
     #[inline]
     #[unstable(feature = "as_slice",
-               reason = "waiting for mut conventions")]
+               reason = "waiting for mut conventions",
+               issue = "27776")]
     pub fn as_mut_slice<'r>(&'r mut self) -> &'r mut [T] {
         match *self {
             Some(ref mut x) => {
@@ -689,7 +690,8 @@ impl<T> Option<T> {
 
     /// Converts from `Option<T>` to `&[T]` (without copying)
     #[inline]
-    #[unstable(feature = "as_slice", since = "unsure of the utility here")]
+    #[unstable(feature = "as_slice", since = "unsure of the utility here",
+               issue = "27776")]
     pub fn as_slice<'a>(&'a self) -> &'a [T] {
         match *self {
             Some(ref x) => slice::ref_slice(x),

--- a/src/libcore/panicking.rs
+++ b/src/libcore/panicking.rs
@@ -31,7 +31,8 @@
 #![allow(dead_code, missing_docs)]
 #![unstable(feature = "core_panic",
             reason = "internal details of the implementation of the `panic!` \
-                      and related macros")]
+                      and related macros",
+            issue = "0")]
 
 use fmt;
 

--- a/src/libcore/prelude/v1.rs
+++ b/src/libcore/prelude/v1.rs
@@ -16,7 +16,8 @@
 
 #![unstable(feature = "core_prelude",
             reason = "the libcore prelude has not been scrutinized and \
-                      stabilized yet")]
+                      stabilized yet",
+            issue = "27701")]
 
 // Reexported core operators
 pub use marker::{Copy, Send, Sized, Sync};

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -127,7 +127,8 @@ pub unsafe fn read<T>(src: *const T) -> T {
 /// (which may be more appropriate than zero).
 #[inline(always)]
 #[unstable(feature = "filling_drop",
-           reason = "may play a larger role in std::ptr future extensions")]
+           reason = "may play a larger role in std::ptr future extensions",
+           issue = "5016")]
 pub unsafe fn read_and_drop<T>(dest: *mut T) -> T {
     // Copy the data out from `dest`:
     let tmp = read(&*dest);
@@ -177,7 +178,8 @@ impl<T: ?Sized> *const T {
     #[unstable(feature = "ptr_as_ref",
                reason = "Option is not clearly the right return type, and we \
                          may want to tie the return lifetime to a borrow of \
-                         the raw pointer")]
+                         the raw pointer",
+               issue = "27780")]
     #[inline]
     pub unsafe fn as_ref<'a>(&self) -> Option<&'a T> where T: Sized {
         if self.is_null() {
@@ -225,7 +227,8 @@ impl<T: ?Sized> *mut T {
     #[unstable(feature = "ptr_as_ref",
                reason = "Option is not clearly the right return type, and we \
                          may want to tie the return lifetime to a borrow of \
-                         the raw pointer")]
+                         the raw pointer",
+               issue = "27780")]
     #[inline]
     pub unsafe fn as_ref<'a>(&self) -> Option<&'a T> where T: Sized {
         if self.is_null() {
@@ -258,7 +261,8 @@ impl<T: ?Sized> *mut T {
     /// of the returned pointer.
     #[unstable(feature = "ptr_as_ref",
                reason = "return value does not necessarily convey all possible \
-                         information")]
+                         information",
+               issue = "27780")]
     #[inline]
     pub unsafe fn as_mut<'a>(&self) -> Option<&'a mut T> where T: Sized {
         if self.is_null() {
@@ -415,7 +419,8 @@ impl<T: ?Sized> PartialOrd for *mut T {
 /// modified without a unique path to the `Unique` reference. Useful
 /// for building abstractions like `Vec<T>` or `Box<T>`, which
 /// internally use raw pointers to manage the memory that they own.
-#[unstable(feature = "unique", reason = "needs an RFC to flesh out design")]
+#[unstable(feature = "unique", reason = "needs an RFC to flesh out design",
+           issue = "27730")]
 pub struct Unique<T: ?Sized> {
     pointer: NonZero<*const T>,
     // NOTE: this marker has no consequences for variance, but is necessary
@@ -430,17 +435,17 @@ pub struct Unique<T: ?Sized> {
 /// reference is unaliased. Note that this aliasing invariant is
 /// unenforced by the type system; the abstraction using the
 /// `Unique` must enforce it.
-#[unstable(feature = "unique")]
+#[unstable(feature = "unique", issue = "27730")]
 unsafe impl<T: Send + ?Sized> Send for Unique<T> { }
 
 /// `Unique` pointers are `Sync` if `T` is `Sync` because the data they
 /// reference is unaliased. Note that this aliasing invariant is
 /// unenforced by the type system; the abstraction using the
 /// `Unique` must enforce it.
-#[unstable(feature = "unique")]
+#[unstable(feature = "unique", issue = "27730")]
 unsafe impl<T: Sync + ?Sized> Sync for Unique<T> { }
 
-#[unstable(feature = "unique")]
+#[unstable(feature = "unique", issue = "27730")]
 impl<T: ?Sized> Unique<T> {
     /// Creates a new `Unique`.
     pub unsafe fn new(ptr: *mut T) -> Unique<T> {
@@ -458,7 +463,7 @@ impl<T: ?Sized> Unique<T> {
     }
 }
 
-#[unstable(feature = "unique")]
+#[unstable(feature = "unique", issue= "27730")]
 impl<T:?Sized> Deref for Unique<T> {
     type Target = *mut T;
 

--- a/src/libcore/raw.rs
+++ b/src/libcore/raw.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #![allow(missing_docs)]
-#![unstable(feature = "raw")]
+#![unstable(feature = "raw", issue = "27751")]
 
 //! Contains struct definitions for the layout of compiler built-in types.
 //!

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -405,7 +405,8 @@ impl<T, E> Result<T, E> {
 
     /// Converts from `Result<T, E>` to `&[T]` (without copying)
     #[inline]
-    #[unstable(feature = "as_slice", since = "unsure of the utility here")]
+    #[unstable(feature = "as_slice", since = "unsure of the utility here",
+               issue = "27776")]
     pub fn as_slice(&self) -> &[T] {
         match *self {
             Ok(ref x) => slice::ref_slice(x),
@@ -436,7 +437,8 @@ impl<T, E> Result<T, E> {
     /// ```
     #[inline]
     #[unstable(feature = "as_slice",
-               reason = "waiting for mut conventions")]
+               reason = "waiting for mut conventions",
+               issue = "27776")]
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         match *self {
             Ok(ref mut x) => slice::mut_ref_slice(x),

--- a/src/libcore/simd.rs
+++ b/src/libcore/simd.rs
@@ -35,7 +35,8 @@
 //! warning.
 
 #![unstable(feature = "core_simd",
-            reason = "needs an RFC to flesh out the design")]
+            reason = "needs an RFC to flesh out the design",
+            issue = "27731")]
 
 #![allow(non_camel_case_types)]
 #![allow(missing_docs)]

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -64,7 +64,8 @@ use raw::Slice as RawSlice;
 #[allow(missing_docs)] // docs in libcollections
 #[doc(hidden)]
 #[unstable(feature = "core_slice_ext",
-           reason = "stable interface provided by `impl [T]` in later crates")]
+           reason = "stable interface provided by `impl [T]` in later crates",
+           issue = "27701")]
 pub trait SliceExt {
     type Item;
 
@@ -797,7 +798,7 @@ impl<'a, T> Iter<'a, T> {
     ///
     /// This has the same lifetime as the original slice, and so the
     /// iterator can continue to be used while this exists.
-    #[unstable(feature = "iter_to_slice")]
+    #[unstable(feature = "iter_to_slice", issue = "27775")]
     pub fn as_slice(&self) -> &'a [T] {
         make_slice!(self.ptr, self.end)
     }
@@ -845,7 +846,7 @@ impl<'a, T> IterMut<'a, T> {
     /// to consume the iterator. Consider using the `Slice` and
     /// `SliceMut` implementations for obtaining slices with more
     /// restricted lifetimes that do not consume the iterator.
-    #[unstable(feature = "iter_to_slice")]
+    #[unstable(feature = "iter_to_slice", issue = "27775")]
     pub fn into_slice(self) -> &'a mut [T] {
         make_mut_slice!(self.ptr, self.end)
     }
@@ -1408,7 +1409,7 @@ impl<'a, T> ExactSizeIterator for ChunksMut<'a, T> {}
 //
 
 /// Converts a pointer to A into a slice of length 1 (without copying).
-#[unstable(feature = "ref_slice")]
+#[unstable(feature = "ref_slice", issue = "27774")]
 pub fn ref_slice<'a, A>(s: &'a A) -> &'a [A] {
     unsafe {
         from_raw_parts(s, 1)
@@ -1416,7 +1417,7 @@ pub fn ref_slice<'a, A>(s: &'a A) -> &'a [A] {
 }
 
 /// Converts a pointer to A into a slice of length 1 (without copying).
-#[unstable(feature = "ref_slice")]
+#[unstable(feature = "ref_slice", issue = "27774")]
 pub fn mut_ref_slice<'a, A>(s: &'a mut A) -> &'a mut [A] {
     unsafe {
         from_raw_parts_mut(s, 1)
@@ -1478,7 +1479,8 @@ pub unsafe fn from_raw_parts_mut<'a, T>(p: *mut T, len: usize) -> &'a mut [T] {
 //
 
 /// Operations on `[u8]`.
-#[unstable(feature = "slice_bytes", reason = "needs review")]
+#[unstable(feature = "slice_bytes", reason = "needs review",
+           issue = "27740")]
 pub mod bytes {
     use ptr;
     use slice::SliceExt;

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -117,7 +117,8 @@ impl Utf8Error {
     ///
     /// Starting at the index provided, but not necessarily at it precisely, an
     /// invalid UTF-8 encoding sequence was found.
-    #[unstable(feature = "utf8_error", reason = "method just added")]
+    #[unstable(feature = "utf8_error", reason = "method just added",
+               issue = "27734")]
     pub fn valid_up_to(&self) -> usize { self.valid_up_to }
 }
 
@@ -190,7 +191,7 @@ fn unwrap_or_0(opt: Option<&u8>) -> u8 {
 
 /// Reads the next code point out of a byte iterator (assuming a
 /// UTF-8-like encoding).
-#[unstable(feature = "str_internals")]
+#[unstable(feature = "str_internals", issue = "0")]
 #[inline]
 pub fn next_code_point(bytes: &mut slice::Iter<u8>) -> Option<u32> {
     // Decode UTF-8
@@ -737,7 +738,8 @@ generate_pattern_iterators! {
         struct RMatchIndices;
     stability:
         #[unstable(feature = "str_match_indices",
-                   reason = "type may be removed or have its iterator impl changed")]
+                   reason = "type may be removed or have its iterator impl changed",
+                   issue = "27743")]
     internal:
         MatchIndicesInternal yielding ((usize, usize));
     delegate double ended;
@@ -1002,7 +1004,8 @@ static UTF8_CHAR_WIDTH: [u8; 256] = [
 #[unstable(feature = "str_char",
            reason = "existence of this struct is uncertain as it is frequently \
                      able to be replaced with char.len_utf8() and/or \
-                     char/char_indices iterators")]
+                     char/char_indices iterators",
+           issue = "27754")]
 pub struct CharRange {
     /// Current `char`
     pub ch: char,
@@ -1220,7 +1223,8 @@ mod traits {
 #[allow(missing_docs)]
 #[doc(hidden)]
 #[unstable(feature = "core_str_ext",
-           reason = "stable interface provided by `impl str` in later crates")]
+           reason = "stable interface provided by `impl str` in later crates",
+           issue = "27701")]
 pub trait StrExt {
     // NB there are no docs here are they're all located on the StrExt trait in
     // libcollections, not here.

--- a/src/libcore/str/pattern.rs
+++ b/src/libcore/str/pattern.rs
@@ -14,7 +14,8 @@
 //! `ReverseSearcher` and `DoubleEndedSearcher`.
 
 #![unstable(feature = "pattern",
-            reason = "API not fully fleshed out and ready to be stabilized")]
+            reason = "API not fully fleshed out and ready to be stabilized",
+            issue = "27721")]
 
 use prelude::v1::*;
 

--- a/src/libflate/lib.rs
+++ b/src/libflate/lib.rs
@@ -17,7 +17,7 @@
 // Do not remove on snapshot creation. Needed for bootstrap. (Issue #22364)
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "flate"]
-#![unstable(feature = "rustc_private")]
+#![unstable(feature = "rustc_private", issue = "27812")]
 #![staged_api]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -17,7 +17,7 @@
 // Do not remove on snapshot creation. Needed for bootstrap. (Issue #22364)
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "fmt_macros"]
-#![unstable(feature = "rustc_private")]
+#![unstable(feature = "rustc_private", issue = "27812")]
 #![staged_api]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -80,7 +80,8 @@
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "getopts"]
 #![unstable(feature = "rustc_private",
-            reason = "use the crates.io `getopts` library instead")]
+            reason = "use the crates.io `getopts` library instead",
+            issue = "27812")]
 #![staged_api]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -276,7 +276,7 @@
 // Do not remove on snapshot creation. Needed for bootstrap. (Issue #22364)
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "graphviz"]
-#![unstable(feature = "rustc_private")]
+#![unstable(feature = "rustc_private", issue = "27812")]
 #![feature(staged_api)]
 #![staged_api]
 #![crate_type = "rlib"]

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -12,8 +12,9 @@
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "libc"]
 #![crate_type = "rlib"]
-#![cfg_attr(not(feature = "cargo-build"), unstable(feature = "libc",
-                                                   reason = "use `libc` from crates.io"))]
+#![cfg_attr(not(feature = "cargo-build"),
+            unstable(feature = "libc", reason = "use `libc` from crates.io",
+                     issue = "27783"))]
 #![cfg_attr(not(feature = "cargo-build"), feature(staged_api, no_std))]
 #![cfg_attr(not(feature = "cargo-build"), staged_api)]
 #![cfg_attr(not(feature = "cargo-build"), no_std)]

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -159,7 +159,8 @@
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "log"]
 #![unstable(feature = "rustc_private",
-            reason = "use the crates.io `log` library instead")]
+            reason = "use the crates.io `log` library instead",
+            issue = "27812")]
 #![staged_api]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -27,7 +27,8 @@
 #![no_std]
 #![staged_api]
 #![unstable(feature = "rand",
-            reason = "use `rand` from crates.io")]
+            reason = "use `rand` from crates.io",
+            issue = "27703")]
 #![feature(core_float)]
 #![feature(core_slice_ext)]
 #![feature(no_std)]

--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -114,7 +114,7 @@
 // Do not remove on snapshot creation. Needed for bootstrap. (Issue #22364)
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "rbml"]
-#![unstable(feature = "rustc_private")]
+#![unstable(feature = "rustc_private", issue = "27812")]
 #![staged_api]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -17,7 +17,7 @@
 // Do not remove on snapshot creation. Needed for bootstrap. (Issue #22364)
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "rustc"]
-#![unstable(feature = "rustc_private")]
+#![unstable(feature = "rustc_private", issue = "27812")]
 #![staged_api]
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]

--- a/src/librustc_back/lib.rs
+++ b/src/librustc_back/lib.rs
@@ -24,7 +24,7 @@
 // Do not remove on snapshot creation. Needed for bootstrap. (Issue #22364)
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "rustc_back"]
-#![unstable(feature = "rustc_private")]
+#![unstable(feature = "rustc_private", issue = "27812")]
 #![staged_api]
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]

--- a/src/librustc_bitflags/lib.rs
+++ b/src/librustc_bitflags/lib.rs
@@ -18,7 +18,7 @@
 #![crate_type = "rlib"]
 #![feature(no_std)]
 #![no_std]
-#![unstable(feature = "rustc_private")]
+#![unstable(feature = "rustc_private", issue = "27812")]
 
 //! A typesafe bitmask flag generator.
 

--- a/src/librustc_borrowck/lib.rs
+++ b/src/librustc_borrowck/lib.rs
@@ -11,7 +11,7 @@
 // Do not remove on snapshot creation. Needed for bootstrap. (Issue #22364)
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "rustc_borrowck"]
-#![unstable(feature = "rustc_private")]
+#![unstable(feature = "rustc_private", issue = "27812")]
 #![staged_api]
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -19,7 +19,7 @@
 // Do not remove on snapshot creation. Needed for bootstrap. (Issue #22364)
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "rustc_data_structures"]
-#![unstable(feature = "rustc_private")]
+#![unstable(feature = "rustc_private", issue = "27812")]
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 #![staged_api]

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -17,7 +17,7 @@
 // Do not remove on snapshot creation. Needed for bootstrap. (Issue #22364)
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "rustc_driver"]
-#![unstable(feature = "rustc_private")]
+#![unstable(feature = "rustc_private", issue = "27812")]
 #![staged_api]
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -22,7 +22,7 @@
 // Do not remove on snapshot creation. Needed for bootstrap. (Issue #22364)
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "rustc_lint"]
-#![unstable(feature = "rustc_private")]
+#![unstable(feature = "rustc_private", issue = "27812")]
 #![staged_api]
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -17,7 +17,7 @@
 #![allow(trivial_casts)]
 
 #![crate_name = "rustc_llvm"]
-#![unstable(feature = "rustc_private")]
+#![unstable(feature = "rustc_private", issue = "27812")]
 #![staged_api]
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -11,7 +11,7 @@
 // Do not remove on snapshot creation. Needed for bootstrap. (Issue #22364)
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "rustc_privacy"]
-#![unstable(feature = "rustc_private")]
+#![unstable(feature = "rustc_private", issue = "27812")]
 #![staged_api]
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -11,7 +11,7 @@
 // Do not remove on snapshot creation. Needed for bootstrap. (Issue #22364)
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "rustc_resolve"]
-#![unstable(feature = "rustc_private")]
+#![unstable(feature = "rustc_private", issue = "27812")]
 #![staged_api]
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -17,7 +17,7 @@
 // Do not remove on snapshot creation. Needed for bootstrap. (Issue #22364)
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "rustc_trans"]
-#![unstable(feature = "rustc_private")]
+#![unstable(feature = "rustc_private", issue = "27812")]
 #![staged_api]
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -65,7 +65,7 @@ This API is completely unstable and subject to change.
 // Do not remove on snapshot creation. Needed for bootstrap. (Issue #22364)
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "rustc_typeck"]
-#![unstable(feature = "rustc_private")]
+#![unstable(feature = "rustc_private", issue = "27812")]
 #![staged_api]
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]

--- a/src/librustc_unicode/char.rs
+++ b/src/librustc_unicode/char.rs
@@ -295,7 +295,8 @@ impl char {
     /// assert_eq!(result, None);
     /// ```
     #[unstable(feature = "unicode",
-               reason = "pending decision about Iterator/Writer/Reader")]
+               reason = "pending decision about Iterator/Writer/Reader",
+               issue = "27784")]
     #[inline]
     pub fn encode_utf8(self, dst: &mut [u8]) -> Option<usize> {
         C::encode_utf8(self, dst)
@@ -334,7 +335,8 @@ impl char {
     /// assert_eq!(result, None);
     /// ```
     #[unstable(feature = "unicode",
-               reason = "pending decision about Iterator/Writer/Reader")]
+               reason = "pending decision about Iterator/Writer/Reader",
+               issue = "27784")]
     #[inline]
     pub fn encode_utf16(self, dst: &mut [u16]) -> Option<usize> {
         C::encode_utf16(self, dst)
@@ -359,7 +361,8 @@ impl char {
     /// [UAX #31](http://unicode.org/reports/tr31/#NFKC_Modifications),
     /// mostly similar to ID_Start but modified for closure under NFKx.
     #[unstable(feature = "unicode",
-               reason = "mainly needed for compiler internals")]
+               reason = "mainly needed for compiler internals",
+               issue = "0")]
     #[inline]
     pub fn is_xid_start(self) -> bool { derived_property::XID_Start(self) }
 
@@ -370,7 +373,8 @@ impl char {
     /// [UAX #31](http://unicode.org/reports/tr31/#NFKC_Modifications),
     /// mostly similar to 'ID_Continue' but modified for closure under NFKx.
     #[unstable(feature = "unicode",
-               reason = "mainly needed for compiler internals")]
+               reason = "mainly needed for compiler internals",
+               issue = "0")]
     #[inline]
     pub fn is_xid_continue(self) -> bool { derived_property::XID_Continue(self) }
 

--- a/src/librustc_unicode/lib.rs
+++ b/src/librustc_unicode/lib.rs
@@ -23,7 +23,7 @@
 // Do not remove on snapshot creation. Needed for bootstrap. (Issue #22364)
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "rustc_unicode"]
-#![unstable(feature = "unicode")]
+#![unstable(feature = "unicode", issue = "27783")]
 #![staged_api]
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -11,7 +11,7 @@
 // Do not remove on snapshot creation. Needed for bootstrap. (Issue #22364)
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "rustdoc"]
-#![unstable(feature = "rustdoc")]
+#![unstable(feature = "rustdoc", issue = "27812")]
 #![staged_api]
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -18,7 +18,8 @@ Core encoding and decoding interfaces.
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "serialize"]
 #![unstable(feature = "rustc_private",
-            reason = "deprecated in favor of rustc-serialize on crates.io")]
+            reason = "deprecated in favor of rustc-serialize on crates.io",
+            issue = "27812")]
 #![staged_api]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -117,7 +117,7 @@ pub trait AsciiExt {
     ///
     /// assert_eq!('A', ascii);
     /// ```
-    #[unstable(feature = "ascii")]
+    #[unstable(feature = "ascii", issue = "27809")]
     fn make_ascii_uppercase(&mut self);
 
     /// Converts this type to its ASCII lower case equivalent in-place.
@@ -137,7 +137,7 @@ pub trait AsciiExt {
     ///
     /// assert_eq!('a', ascii);
     /// ```
-    #[unstable(feature = "ascii")]
+    #[unstable(feature = "ascii", issue = "27809")]
     fn make_ascii_lowercase(&mut self);
 }
 

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -553,7 +553,8 @@ impl<K, V, S> HashMap<K, V, S>
     /// map.insert(1, 2);
     /// ```
     #[inline]
-    #[unstable(feature = "hashmap_hasher", reason = "hasher stuff is unclear")]
+    #[unstable(feature = "hashmap_hasher", reason = "hasher stuff is unclear",
+               issue = "27713")]
     pub fn with_hash_state(hash_state: S) -> HashMap<K, V, S> {
         HashMap {
             hash_state:    hash_state,
@@ -583,7 +584,8 @@ impl<K, V, S> HashMap<K, V, S>
     /// map.insert(1, 2);
     /// ```
     #[inline]
-    #[unstable(feature = "hashmap_hasher", reason = "hasher stuff is unclear")]
+    #[unstable(feature = "hashmap_hasher", reason = "hasher stuff is unclear",
+               issue = "27713")]
     pub fn with_capacity_and_hash_state(capacity: usize, hash_state: S)
                                         -> HashMap<K, V, S> {
         let resize_policy = DefaultResizePolicy::new();
@@ -998,7 +1000,8 @@ impl<K, V, S> HashMap<K, V, S>
     /// ```
     #[inline]
     #[unstable(feature = "drain",
-               reason = "matches collection reform specification, waiting for dust to settle")]
+               reason = "matches collection reform specification, waiting for dust to settle",
+               issue = "27711")]
     pub fn drain(&mut self) -> Drain<K, V> {
         fn last_two<A, B, C>((_, b, c): (A, B, C)) -> (B, C) { (b, c) }
         let last_two: fn((SafeHash, K, V)) -> (K, V) = last_two; // coerce to fn pointer
@@ -1311,7 +1314,8 @@ impl<'a, K, V> Clone for Values<'a, K, V> {
 
 /// HashMap drain iterator.
 #[unstable(feature = "drain",
-           reason = "matches collection reform specification, waiting for dust to settle")]
+           reason = "matches collection reform specification, waiting for dust to settle",
+           issue = "27711")]
 pub struct Drain<'a, K: 'a, V: 'a> {
     inner: iter::Map<table::Drain<'a, K, V>, fn((SafeHash, K, V)) -> (K, V)>
 }
@@ -1587,14 +1591,16 @@ impl<K, V, S> Extend<(K, V)> for HashMap<K, V, S>
 /// instances are unlikely to produce the same result for the same values.
 #[derive(Clone)]
 #[unstable(feature = "hashmap_hasher",
-           reason = "hashing an hash maps may be altered")]
+           reason = "hashing an hash maps may be altered",
+           issue = "27713")]
 pub struct RandomState {
     k0: u64,
     k1: u64,
 }
 
 #[unstable(feature = "hashmap_hasher",
-           reason = "hashing an hash maps may be altered")]
+           reason = "hashing an hash maps may be altered",
+           issue = "27713")]
 impl RandomState {
     /// Constructs a new `RandomState` that is initialized with random keys.
     #[inline]
@@ -1606,7 +1612,8 @@ impl RandomState {
 }
 
 #[unstable(feature = "hashmap_hasher",
-           reason = "hashing an hash maps may be altered")]
+           reason = "hashing an hash maps may be altered",
+           issue = "27713")]
 impl HashState for RandomState {
     type Hasher = SipHasher;
     #[inline]

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -164,7 +164,8 @@ impl<T, S> HashSet<T, S>
     /// set.insert(2);
     /// ```
     #[inline]
-    #[unstable(feature = "hashmap_hasher", reason = "hasher stuff is unclear")]
+    #[unstable(feature = "hashmap_hasher", reason = "hasher stuff is unclear",
+               issue = "27713")]
     pub fn with_hash_state(hash_state: S) -> HashSet<T, S> {
         HashSet::with_capacity_and_hash_state(INITIAL_CAPACITY, hash_state)
     }
@@ -190,7 +191,8 @@ impl<T, S> HashSet<T, S>
     /// set.insert(1);
     /// ```
     #[inline]
-    #[unstable(feature = "hashmap_hasher", reason = "hasher stuff is unclear")]
+    #[unstable(feature = "hashmap_hasher", reason = "hasher stuff is unclear",
+               issue = "27713")]
     pub fn with_capacity_and_hash_state(capacity: usize, hash_state: S)
                                         -> HashSet<T, S> {
         HashSet {
@@ -411,7 +413,8 @@ impl<T, S> HashSet<T, S>
     /// Clears the set, returning all elements in an iterator.
     #[inline]
     #[unstable(feature = "drain",
-               reason = "matches collection reform specification, waiting for dust to settle")]
+               reason = "matches collection reform specification, waiting for dust to settle",
+               issue = "27711")]
     pub fn drain(&mut self) -> Drain<T> {
         fn first<A, B>((a, _): (A, B)) -> A { a }
         let first: fn((T, ())) -> T = first; // coerce to fn pointer

--- a/src/libstd/collections/hash/state.rs
+++ b/src/libstd/collections/hash/state.rs
@@ -8,7 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![unstable(feature = "hashmap_hasher", reason = "hasher stuff is unclear")]
+#![unstable(feature = "hashmap_hasher", reason = "hasher stuff is unclear",
+            issue = "27713")]
 
 use clone::Clone;
 use default::Default;

--- a/src/libstd/collections/mod.rs
+++ b/src/libstd/collections/mod.rs
@@ -410,7 +410,8 @@ pub mod hash_set {
 
 /// Experimental support for providing custom hash algorithms to a HashMap and
 /// HashSet.
-#[unstable(feature = "hashmap_hasher", reason = "module was recently added")]
+#[unstable(feature = "hashmap_hasher", reason = "module was recently added",
+           issue = "27713")]
 pub mod hash_state {
     pub use super::hash::state::*;
 }

--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -14,7 +14,8 @@
 
 #![unstable(feature = "dynamic_lib",
             reason = "API has not been scrutinized and is highly likely to \
-                      either disappear or change")]
+                      either disappear or change",
+            issue = "27810")]
 #![allow(missing_docs)]
 
 use prelude::v1::*;

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -78,7 +78,8 @@ pub trait Error: Debug + Display + Reflect {
     /// Get the `TypeId` of `self`
     #[doc(hidden)]
     #[unstable(feature = "error_type_id",
-               reason = "unclear whether to commit to this public implementation detail")]
+               reason = "unclear whether to commit to this public implementation detail",
+               issue = "27745")]
     fn type_id(&self) -> TypeId where Self: 'static {
         TypeId::of::<Self>()
     }

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -205,7 +205,8 @@ impl CString {
     /// The only appropriate argument is a pointer obtained by calling
     /// `into_ptr`. The length of the string will be recalculated
     /// using the pointer.
-    #[unstable(feature = "cstr_memory", reason = "recently added")]
+    #[unstable(feature = "cstr_memory", reason = "recently added",
+               issue = "27769")]
     // NB: may want to be called from_raw, needs to consider CStr::from_ptr,
     //     Box::from_raw (or whatever it's currently called), and
     //     slice::from_raw_parts
@@ -223,7 +224,8 @@ impl CString {
     /// this string.
     ///
     /// Failure to call `from_ptr` will lead to a memory leak.
-    #[unstable(feature = "cstr_memory", reason = "recently added")]
+    #[unstable(feature = "cstr_memory", reason = "recently added",
+               issue = "27769")]
     // NB: may want to be called into_raw, see comments on from_ptr
     pub fn into_ptr(self) -> *const libc::c_char {
         // It is important that the bytes be sized to fit - we need
@@ -407,11 +409,13 @@ impl CStr {
     /// > after a 0-cost cast, but it is planned to alter its definition in the
     /// > future to perform the length calculation in addition to the UTF-8
     /// > check whenever this method is called.
-    #[unstable(feature = "cstr_to_str", reason = "recently added")]
+    #[unstable(feature = "cstr_to_str", reason = "recently added",
+               issue = "27764")]
     pub fn to_str(&self) -> Result<&str, str::Utf8Error> {
-        // NB: When CStr is changed to perform the length check in .to_bytes() instead of in
-        // from_ptr(), it may be worth considering if this should be rewritten to do the UTF-8
-        // check inline with the length calculation instead of doing it afterwards.
+        // NB: When CStr is changed to perform the length check in .to_bytes()
+        // instead of in from_ptr(), it may be worth considering if this should
+        // be rewritten to do the UTF-8 check inline with the length calculation
+        // instead of doing it afterwards.
         str::from_utf8(self.to_bytes())
     }
 
@@ -426,7 +430,8 @@ impl CStr {
     /// > after a 0-cost cast, but it is planned to alter its definition in the
     /// > future to perform the length calculation in addition to the UTF-8
     /// > check whenever this method is called.
-    #[unstable(feature = "cstr_to_str", reason = "recently added")]
+    #[unstable(feature = "cstr_to_str", reason = "recently added",
+               issue = "27764")]
     pub fn to_string_lossy(&self) -> Cow<str> {
         String::from_utf8_lossy(self.to_bytes())
     }

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -29,9 +29,6 @@
 //! for conversion to/from various other string types. Eventually these types
 //! will offer a full-fledged string API.
 
-#![unstable(feature = "os_str",
-            reason = "recently added as part of path/io reform")]
-
 use borrow::{Borrow, Cow, ToOwned};
 use ffi::CString;
 use fmt::{self, Debug};
@@ -74,7 +71,7 @@ impl OsString {
     ///
     /// On Windows system, only UTF-8 byte sequences will successfully
     /// convert; non UTF-8 data will produce `None`.
-    #[unstable(feature = "convert", reason = "recently added")]
+    #[unstable(feature = "convert", reason = "recently added", issue = "27704")]
     pub fn from_bytes<B>(bytes: B) -> Option<OsString> where B: Into<Vec<u8>> {
         #[cfg(unix)]
         fn from_bytes_inner(vec: Vec<u8>) -> Option<OsString> {
@@ -258,7 +255,7 @@ impl OsStr {
     /// On Windows systems, this returns `None` unless the `OsStr` is
     /// valid unicode, in which case it produces UTF-8-encoded
     /// data. This may entail checking validity.
-    #[unstable(feature = "convert", reason = "recently added")]
+    #[unstable(feature = "convert", reason = "recently added", issue = "27704")]
     pub fn to_bytes(&self) -> Option<&[u8]> {
         if cfg!(windows) {
             self.to_str().map(|s| s.as_bytes())
@@ -274,7 +271,7 @@ impl OsStr {
     /// This is a convenience for creating a `CString` from
     /// `self.to_bytes()`, and inherits the platform behavior of the
     /// `to_bytes` method.
-    #[unstable(feature = "convert", reason = "recently added")]
+    #[unstable(feature = "convert", reason = "recently added", issue = "27704")]
     pub fn to_cstring(&self) -> Option<CString> {
         self.to_bytes().and_then(|b| CString::new(b).ok())
     }

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -88,7 +88,8 @@ pub struct DirEntry(fs_imp::DirEntry);
 #[unstable(feature = "fs_walk",
            reason = "the precise semantics and defaults for a recursive walk \
                      may change and this may end up accounting for files such \
-                     as symlinks differently")]
+                     as symlinks differently",
+           issue = "27707")]
 pub struct WalkDir {
     cur: Option<ReadDir>,
     stack: Vec<io::Result<ReadDir>>,
@@ -154,7 +155,8 @@ pub struct FileType(fs_imp::FileType);
 /// A builder used to create directories in various manners.
 ///
 /// This builder also supports platform-specific options.
-#[unstable(feature = "dir_builder", reason = "recently added API")]
+#[unstable(feature = "dir_builder", reason = "recently added API",
+           issue = "27710")]
 pub struct DirBuilder {
     inner: fs_imp::DirBuilder,
     recursive: bool,
@@ -949,7 +951,8 @@ pub fn read_link<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
 
 /// Returns the canonical form of a path with all intermediate components
 /// normalized and symbolic links resolved.
-#[unstable(feature = "fs_canonicalize", reason = "recently added API")]
+#[unstable(feature = "fs_canonicalize", reason = "recently added API",
+           issue = "27706")]
 pub fn canonicalize<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
     fs_imp::canonicalize(path.as_ref())
 }
@@ -1107,13 +1110,14 @@ pub fn read_dir<P: AsRef<Path>>(path: P) -> io::Result<ReadDir> {
 #[unstable(feature = "fs_walk",
            reason = "the precise semantics and defaults for a recursive walk \
                      may change and this may end up accounting for files such \
-                     as symlinks differently")]
+                     as symlinks differently",
+           issue = "27707")]
 pub fn walk_dir<P: AsRef<Path>>(path: P) -> io::Result<WalkDir> {
     let start = try!(read_dir(path));
     Ok(WalkDir { cur: Some(start), stack: Vec::new() })
 }
 
-#[unstable(feature = "fs_walk")]
+#[unstable(feature = "fs_walk", issue = "27707")]
 impl Iterator for WalkDir {
     type Item = io::Result<DirEntry>;
 
@@ -1146,7 +1150,8 @@ impl Iterator for WalkDir {
 #[unstable(feature = "path_ext",
            reason = "The precise set of methods exposed on this trait may \
                      change and some methods may be removed.  For stable code, \
-                     see the std::fs::metadata function.")]
+                     see the std::fs::metadata function.",
+           issue = "27725")]
 pub trait PathExt {
     /// Gets information on the file, directory, etc at this path.
     ///
@@ -1242,7 +1247,8 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions)
     fs_imp::set_perm(path.as_ref(), perm.0)
 }
 
-#[unstable(feature = "dir_builder", reason = "recently added API")]
+#[unstable(feature = "dir_builder", reason = "recently added API",
+           issue = "27710")]
 impl DirBuilder {
     /// Creates a new set of options with default mode/security settings for all
     /// platforms and also non-recursive.

--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -150,7 +150,8 @@ pub enum ErrorKind {
     /// Any I/O error not part of this list.
     #[unstable(feature = "io_error_internals",
                reason = "better expressed through extensible enums that this \
-                         enum cannot be exhaustively matched against")]
+                         enum cannot be exhaustively matched against",
+               issue = "0")]
     #[doc(hidden)]
     __Nonexhaustive,
 }

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -647,7 +647,8 @@ pub trait Read {
     /// ```
     #[unstable(feature = "io", reason = "the semantics of a partial read/write \
                                          of where errors happen is currently \
-                                         unclear and may change")]
+                                         unclear and may change",
+               issue = "27802")]
     fn chars(self) -> Chars<Self> where Self: Sized {
         Chars { inner: self }
     }
@@ -754,7 +755,8 @@ pub trait Read {
     /// ```
     #[unstable(feature = "io", reason = "the semantics of a partial read/write \
                                          of where errors happen is currently \
-                                         unclear and may change")]
+                                         unclear and may change",
+               issue = "27802")]
     fn tee<W: Write>(self, out: W) -> Tee<Self, W> where Self: Sized {
         Tee { reader: self, writer: out }
     }
@@ -1016,7 +1018,8 @@ pub trait Write {
     /// ```
     #[unstable(feature = "io", reason = "the semantics of a partial read/write \
                                          of where errors happen is currently \
-                                         unclear and may change")]
+                                         unclear and may change",
+               issue = "27802")]
     fn broadcast<W: Write>(self, other: W) -> Broadcast<Self, W>
         where Self: Sized
     {
@@ -1401,13 +1404,15 @@ pub trait BufRead: Read {
 /// writer. Please see the documentation of `broadcast()` for more details.
 ///
 /// [broadcast]: trait.Write.html#method.broadcast
-#[unstable(feature = "io", reason = "awaiting stability of Write::broadcast")]
+#[unstable(feature = "io", reason = "awaiting stability of Write::broadcast",
+           issue = "27802")]
 pub struct Broadcast<T, U> {
     first: T,
     second: U,
 }
 
-#[unstable(feature = "io", reason = "awaiting stability of Write::broadcast")]
+#[unstable(feature = "io", reason = "awaiting stability of Write::broadcast",
+           issue = "27802")]
 impl<T: Write, U: Write> Write for Broadcast<T, U> {
     fn write(&mut self, data: &[u8]) -> Result<usize> {
         let n = try!(self.first.write(data));
@@ -1509,13 +1514,15 @@ impl<T: BufRead> BufRead for Take<T> {
 /// Please see the documentation of `tee()` for more details.
 ///
 /// [tee]: trait.Read.html#method.tee
-#[unstable(feature = "io", reason = "awaiting stability of Read::tee")]
+#[unstable(feature = "io", reason = "awaiting stability of Read::tee",
+           issue = "27802")]
 pub struct Tee<R, W> {
     reader: R,
     writer: W,
 }
 
-#[unstable(feature = "io", reason = "awaiting stability of Read::tee")]
+#[unstable(feature = "io", reason = "awaiting stability of Read::tee",
+           issue = "27802")]
 impl<R: Read, W: Write> Read for Tee<R, W> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         let n = try!(self.reader.read(buf));
@@ -1556,7 +1563,8 @@ impl<R: Read> Iterator for Bytes<R> {
 /// Please see the documentation of `chars()` for more details.
 ///
 /// [chars]: trait.Read.html#method.chars
-#[unstable(feature = "io", reason = "awaiting stability of Read::chars")]
+#[unstable(feature = "io", reason = "awaiting stability of Read::chars",
+           issue = "27802")]
 pub struct Chars<R> {
     inner: R,
 }
@@ -1564,7 +1572,8 @@ pub struct Chars<R> {
 /// An enumeration of possible errors that can be generated from the `Chars`
 /// adapter.
 #[derive(Debug)]
-#[unstable(feature = "io", reason = "awaiting stability of Read::chars")]
+#[unstable(feature = "io", reason = "awaiting stability of Read::chars",
+           issue = "27802")]
 pub enum CharsError {
     /// Variant representing that the underlying stream was read successfully
     /// but it did not contain valid utf8 data.
@@ -1574,7 +1583,8 @@ pub enum CharsError {
     Other(Error),
 }
 
-#[unstable(feature = "io", reason = "awaiting stability of Read::chars")]
+#[unstable(feature = "io", reason = "awaiting stability of Read::chars",
+           issue = "27802")]
 impl<R: Read> Iterator for Chars<R> {
     type Item = result::Result<char, CharsError>;
 
@@ -1606,7 +1616,8 @@ impl<R: Read> Iterator for Chars<R> {
     }
 }
 
-#[unstable(feature = "io", reason = "awaiting stability of Read::chars")]
+#[unstable(feature = "io", reason = "awaiting stability of Read::chars",
+           issue = "27802")]
 impl std_error::Error for CharsError {
     fn description(&self) -> &str {
         match *self {
@@ -1622,7 +1633,8 @@ impl std_error::Error for CharsError {
     }
 }
 
-#[unstable(feature = "io", reason = "awaiting stability of Read::chars")]
+#[unstable(feature = "io", reason = "awaiting stability of Read::chars",
+           issue = "27802")]
 impl fmt::Display for CharsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -531,7 +531,8 @@ impl<'a> Write for StderrLock<'a> {
 /// output handle is to the process's stderr stream.
 #[unstable(feature = "set_stdio",
            reason = "this function may disappear completely or be replaced \
-                     with a more general mechanism")]
+                     with a more general mechanism",
+           issue = "0")]
 #[doc(hidden)]
 pub fn set_panic(sink: Box<Write + Send>) -> Option<Box<Write + Send>> {
     use panicking::LOCAL_STDERR;
@@ -554,7 +555,8 @@ pub fn set_panic(sink: Box<Write + Send>) -> Option<Box<Write + Send>> {
 /// output handle is to the process's stdout stream.
 #[unstable(feature = "set_stdio",
            reason = "this function may disappear completely or be replaced \
-                     with a more general mechanism")]
+                     with a more general mechanism",
+           issue = "0")]
 #[doc(hidden)]
 pub fn set_print(sink: Box<Write + Send>) -> Option<Box<Write + Send>> {
     use mem;
@@ -567,7 +569,8 @@ pub fn set_print(sink: Box<Write + Send>) -> Option<Box<Write + Send>> {
 }
 
 #[unstable(feature = "print",
-           reason = "implementation detail which may disappear or be replaced at any time")]
+           reason = "implementation detail which may disappear or be replaced at any time",
+           issue = "0")]
 #[doc(hidden)]
 pub fn _print(args: fmt::Arguments) {
     let result = LOCAL_STDOUT.with(|s| {

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -398,7 +398,7 @@ mod rand;
 // but it may be stabilized long-term. As a result we're exposing a hidden,
 // unstable module so we can get our build working.
 #[doc(hidden)]
-#[unstable(feature = "rand")]
+#[unstable(feature = "rand", issue = "0")]
 pub mod __rand {
     pub use rand::{thread_rng, ThreadRng, Rng};
 }

--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -48,7 +48,7 @@ pub struct SocketAddrV6 { inner: libc::sockaddr_in6 }
 
 impl SocketAddr {
     /// Creates a new socket address from the (ip, port) pair.
-    #[unstable(feature = "ip_addr", reason = "recent addition")]
+    #[unstable(feature = "ip_addr", reason = "recent addition", issue = "27801")]
     pub fn new(ip: IpAddr, port: u16) -> SocketAddr {
         match ip {
             IpAddr::V4(a) => SocketAddr::V4(SocketAddrV4::new(a, port)),
@@ -57,7 +57,7 @@ impl SocketAddr {
     }
 
     /// Returns the IP address associated with this socket address.
-    #[unstable(feature = "ip_addr", reason = "recent addition")]
+    #[unstable(feature = "ip_addr", reason = "recent addition", issue = "27801")]
     pub fn ip(&self) -> IpAddr {
         match *self {
             SocketAddr::V4(ref a) => IpAddr::V4(*a.ip()),

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -10,7 +10,8 @@
 
 #![unstable(feature = "ip", reason = "extra functionality has not been \
                                       scrutinized to the level that it should \
-                                      be stable")]
+                                      be stable",
+            issue = "27709")]
 
 use prelude::v1::*;
 
@@ -22,7 +23,7 @@ use sys_common::{AsInner, FromInner};
 use net::{hton, ntoh};
 
 /// An IP address, either a IPv4 or IPv6 address.
-#[unstable(feature = "ip_addr", reason = "recent addition")]
+#[unstable(feature = "ip_addr", reason = "recent addition", issue = "27801")]
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, PartialOrd, Ord)]
 pub enum IpAddr {
     /// Representation of an IPv4 address.

--- a/src/libstd/net/mod.rs
+++ b/src/libstd/net/mod.rs
@@ -84,12 +84,14 @@ fn each_addr<A: ToSocketAddrs, F, T>(addr: A, mut f: F) -> io::Result<T>
 /// An iterator over `SocketAddr` values returned from a host lookup operation.
 #[unstable(feature = "lookup_host", reason = "unsure about the returned \
                                               iterator and returning socket \
-                                              addresses")]
+                                              addresses",
+           issue = "27705")]
 pub struct LookupHost(net_imp::LookupHost);
 
 #[unstable(feature = "lookup_host", reason = "unsure about the returned \
                                               iterator and returning socket \
-                                              addresses")]
+                                              addresses",
+           issue = "27705")]
 impl Iterator for LookupHost {
     type Item = io::Result<SocketAddr>;
     fn next(&mut self) -> Option<io::Result<SocketAddr>> { self.0.next() }
@@ -116,7 +118,8 @@ impl Iterator for LookupHost {
 /// ```
 #[unstable(feature = "lookup_host", reason = "unsure about the returned \
                                               iterator and returning socket \
-                                              addresses")]
+                                              addresses",
+           issue = "27705")]
 pub fn lookup_host(host: &str) -> io::Result<LookupHost> {
     net_imp::lookup_host(host).map(LookupHost)
 }
@@ -126,7 +129,8 @@ pub fn lookup_host(host: &str) -> io::Result<LookupHost> {
 /// This function may perform a DNS query to resolve `addr` and may also inspect
 /// system configuration to resolve the specified address. If the address
 /// cannot be resolved, it is returned in string format.
-#[unstable(feature = "lookup_addr", reason = "recent addition")]
+#[unstable(feature = "lookup_addr", reason = "recent addition",
+           issue = "27705")]
 pub fn lookup_addr(addr: &IpAddr) -> io::Result<String> {
     net_imp::lookup_addr(addr)
 }

--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![unstable(feature = "tcp", reason = "remaining functions have not been \
-                                       scrutinized enough to be stabilized")]
-
 use prelude::v1::*;
 use io::prelude::*;
 
@@ -133,7 +130,8 @@ impl TcpStream {
     /// If the value specified is `None`, then `read` calls will block
     /// indefinitely. It is an error to pass the zero `Duration` to this
     /// method.
-    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added")]
+    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added",
+               issue = "27773")]
     pub fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
         self.0.set_read_timeout(dur)
     }
@@ -143,7 +141,8 @@ impl TcpStream {
     /// If the value specified is `None`, then `write` calls will block
     /// indefinitely. It is an error to pass the zero `Duration` to this
     /// method.
-    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added")]
+    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added",
+               issue = "27773")]
     pub fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
         self.0.set_write_timeout(dur)
     }
@@ -155,7 +154,8 @@ impl TcpStream {
     /// # Note
     ///
     /// Some platforms do not provide access to the current timeout.
-    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added")]
+    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added",
+               issue = "27773")]
     pub fn read_timeout(&self) -> io::Result<Option<Duration>> {
         self.0.read_timeout()
     }
@@ -167,7 +167,8 @@ impl TcpStream {
     /// # Note
     ///
     /// Some platforms do not provide access to the current timeout.
-    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added")]
+    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added",
+               issue = "27773")]
     pub fn write_timeout(&self) -> io::Result<Option<Duration>> {
         self.0.write_timeout()
     }

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![unstable(feature = "udp", reason = "remaining functions have not been \
-                                       scrutinized enough to be stabilized")]
-
 use fmt;
 use io::{self, Error, ErrorKind};
 use net::{ToSocketAddrs, SocketAddr};
@@ -100,7 +97,8 @@ impl UdpSocket {
     /// If the value specified is `None`, then `read` calls will block
     /// indefinitely. It is an error to pass the zero `Duration` to this
     /// method.
-    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added")]
+    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added",
+               issue = "27773")]
     pub fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
         self.0.set_read_timeout(dur)
     }
@@ -110,7 +108,8 @@ impl UdpSocket {
     /// If the value specified is `None`, then `write` calls will block
     /// indefinitely. It is an error to pass the zero `Duration` to this
     /// method.
-    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added")]
+    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added",
+               issue = "27773")]
     pub fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
         self.0.set_write_timeout(dur)
     }
@@ -118,7 +117,8 @@ impl UdpSocket {
     /// Returns the read timeout of this socket.
     ///
     /// If the timeout is `None`, then `read` calls will block indefinitely.
-    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added")]
+    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added",
+               issue = "27773")]
     pub fn read_timeout(&self) -> io::Result<Option<Duration>> {
         self.0.read_timeout()
     }
@@ -126,7 +126,8 @@ impl UdpSocket {
     /// Returns the write timeout of this socket.
     ///
     /// If the timeout is `None`, then `write` calls will block indefinitely.
-    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added")]
+    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added",
+               issue = "27773")]
     pub fn write_timeout(&self) -> io::Result<Option<Duration>> {
         self.0.write_timeout()
     }

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -124,7 +124,8 @@ mod cmath {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl f32 {
     /// Parses a float as with a given radix
-    #[unstable(feature = "float_from_str_radix", reason = "recently moved API")]
+    #[unstable(feature = "float_from_str_radix", reason = "recently moved API",
+               issue = "27736")]
     pub fn from_str_radix(s: &str, radix: u32) -> Result<f32, ParseFloatError> {
         num::Float::from_str_radix(s, radix)
     }
@@ -251,7 +252,8 @@ impl f32 {
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     /// [floating-point]: ../../../../../reference.html#machine-types
-    #[unstable(feature = "float_extras", reason = "signature is undecided")]
+    #[unstable(feature = "float_extras", reason = "signature is undecided",
+               issue = "27752")]
     #[inline]
     pub fn integer_decode(self) -> (u64, i16, i8) {
         num::Float::integer_decode(self)
@@ -607,7 +609,8 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[unstable(feature = "float_extras", reason = "desirability is unclear")]
+    #[unstable(feature = "float_extras", reason = "desirability is unclear",
+               issue = "27752")]
     #[inline]
     pub fn to_degrees(self) -> f32 { num::Float::to_degrees(self) }
 
@@ -624,7 +627,8 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[unstable(feature = "float_extras", reason = "desirability is unclear")]
+    #[unstable(feature = "float_extras", reason = "desirability is unclear",
+               issue = "27752")]
     #[inline]
     pub fn to_radians(self) -> f32 { num::Float::to_radians(self) }
 
@@ -640,7 +644,8 @@ impl f32 {
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[unstable(feature = "float_extras",
-               reason = "pending integer conventions")]
+               reason = "pending integer conventions",
+               issue = "27752")]
     #[inline]
     pub fn ldexp(x: f32, exp: isize) -> f32 {
         unsafe { cmath::ldexpf(x, exp as c_int) }
@@ -668,7 +673,8 @@ impl f32 {
     /// assert!(abs_difference_1 <= f32::EPSILON);
     /// ```
     #[unstable(feature = "float_extras",
-               reason = "pending integer conventions")]
+               reason = "pending integer conventions",
+               issue = "27752")]
     #[inline]
     pub fn frexp(self) -> (f32, isize) {
         unsafe {
@@ -693,7 +699,8 @@ impl f32 {
     /// assert!(abs_diff <= f32::EPSILON);
     /// ```
     #[unstable(feature = "float_extras",
-               reason = "unsure about its place in the world")]
+               reason = "unsure about its place in the world",
+               issue = "27752")]
     #[inline]
     pub fn next_after(self, other: f32) -> f32 {
         unsafe { cmath::nextafterf(self, other) }

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -80,7 +80,8 @@ mod cmath {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl f64 {
     /// Parses a float as with a given radix
-    #[unstable(feature = "float_from_str_radix", reason = "recently moved API")]
+    #[unstable(feature = "float_from_str_radix", reason = "recently moved API",
+               issue = "27736")]
     pub fn from_str_radix(s: &str, radix: u32) -> Result<f64, ParseFloatError> {
         num::Float::from_str_radix(s, radix)
     }
@@ -205,7 +206,8 @@ impl f64 {
     /// assert!(abs_difference < 1e-10);
     /// ```
     /// [floating-point]: ../../../../../reference.html#machine-types
-    #[unstable(feature = "float_extras", reason = "signature is undecided")]
+    #[unstable(feature = "float_extras", reason = "signature is undecided",
+               issue = "27752")]
     #[inline]
     pub fn integer_decode(self) -> (u64, i16, i8) { num::Float::integer_decode(self) }
 
@@ -575,7 +577,8 @@ impl f64 {
     /// assert!(abs_difference < 1e-10);
     /// ```
     #[unstable(feature = "float_extras",
-               reason = "pending integer conventions")]
+               reason = "pending integer conventions",
+               issue = "27752")]
     #[inline]
     pub fn ldexp(x: f64, exp: isize) -> f64 {
         unsafe { cmath::ldexp(x, exp as c_int) }
@@ -601,7 +604,8 @@ impl f64 {
     /// assert!(abs_difference_1 < 1e-10);
     /// ```
     #[unstable(feature = "float_extras",
-               reason = "pending integer conventions")]
+               reason = "pending integer conventions",
+               issue = "27752")]
     #[inline]
     pub fn frexp(self) -> (f64, isize) {
         unsafe {
@@ -624,7 +628,8 @@ impl f64 {
     /// assert!(abs_diff < 1e-10);
     /// ```
     #[unstable(feature = "float_extras",
-               reason = "unsure about its place in the world")]
+               reason = "unsure about its place in the world",
+               issue = "27752")]
     #[inline]
     pub fn next_after(self, other: f64) -> f64 {
         unsafe { cmath::nextafter(self, other) }

--- a/src/libstd/os/raw.rs
+++ b/src/libstd/os/raw.rs
@@ -49,9 +49,11 @@
 #[repr(u8)]
 #[stable(feature = "raw_os", since = "1.1.0")]
 pub enum c_void {
-    #[unstable(feature = "c_void_variant", reason = "should not have to exist")]
+    #[unstable(feature = "c_void_variant", reason = "should not have to exist",
+               issue = "0")]
     #[doc(hidden)] __variant1,
-    #[unstable(feature = "c_void_variant", reason = "should not have to exist")]
+    #[unstable(feature = "c_void_variant", reason = "should not have to exist",
+               issue = "0")]
     #[doc(hidden)] __variant2,
 }
 

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -725,7 +725,7 @@ impl<'a> Components<'a> {
     }
 
     /// Examine the next component without consuming it.
-    #[unstable(feature = "path_components_peek")]
+    #[unstable(feature = "path_components_peek", issue = "27727")]
     pub fn peek(&self) -> Option<Component<'a>> {
         self.clone().next()
     }
@@ -1358,7 +1358,9 @@ impl Path {
     /// Prefixes are relevant only for Windows paths, and consist of volumes
     /// like `C:`, UNC prefixes like `\\server`, and others described in more
     /// detail in `std::os::windows::PathExt`.
-    #[unstable(feature = "path_prefix", reason = "uncertain whether to expose this convenience")]
+    #[unstable(feature = "path_prefix",
+               reason = "uncertain whether to expose this convenience",
+               issue = "27722")]
     pub fn prefix(&self) -> Option<Prefix> {
         self.components().prefix
     }
@@ -1441,7 +1443,8 @@ impl Path {
     ///
     /// If `base` is not a prefix of `self` (i.e. `starts_with`
     /// returns false), then `relative_from` returns `None`.
-    #[unstable(feature = "path_relative_from", reason = "see #23284")]
+    #[unstable(feature = "path_relative_from", reason = "see #23284",
+               issue = "23284")]
     pub fn relative_from<'a, P: ?Sized + AsRef<Path>>(&'a self, base: &'a P) -> Option<&Path>
     {
         iter_after(self.components(), base.as_ref().components()).map(|c| c.as_path())

--- a/src/libstd/rand/mod.rs
+++ b/src/libstd/rand/mod.rs
@@ -55,7 +55,7 @@
 //!     between the two sources. (Also note that, on some systems e.g. FreeBSD, both `/dev/random`
 //!     and `/dev/urandom` may block once if the CSPRNG has not seeded yet.)
 
-#![unstable(feature = "rand")]
+#![unstable(feature = "rand", issue = "0")]
 
 use cell::RefCell;
 use io;

--- a/src/libstd/rt/mod.rs
+++ b/src/libstd/rt/mod.rs
@@ -18,7 +18,8 @@
 
 #![unstable(feature = "rt",
             reason = "this public module should not exist and is highly likely \
-                      to disappear")]
+                      to disappear",
+            issue = "0")]
 #![allow(missing_docs)]
 
 use prelude::v1::*;

--- a/src/libstd/sync/condvar.rs
+++ b/src/libstd/sync/condvar.rs
@@ -76,7 +76,8 @@ pub struct Condvar { inner: Box<StaticCondvar> }
 /// static CVAR: StaticCondvar = CONDVAR_INIT;
 /// ```
 #[unstable(feature = "static_condvar",
-           reason = "may be merged with Condvar in the future")]
+           reason = "may be merged with Condvar in the future",
+           issue = "27717")]
 pub struct StaticCondvar {
     inner: sys::Condvar,
     mutex: AtomicUsize,
@@ -84,7 +85,8 @@ pub struct StaticCondvar {
 
 /// Constant initializer for a statically allocated condition variable.
 #[unstable(feature = "static_condvar",
-           reason = "may be merged with Condvar in the future")]
+           reason = "may be merged with Condvar in the future",
+           issue = "27717")]
 pub const CONDVAR_INIT: StaticCondvar = StaticCondvar::new();
 
 impl Condvar {
@@ -173,7 +175,8 @@ impl Condvar {
     ///
     /// Like `wait`, the lock specified will be re-acquired when this function
     /// returns, regardless of whether the timeout elapsed or not.
-    #[unstable(feature = "wait_timeout", reason = "waiting for Duration")]
+    #[unstable(feature = "wait_timeout", reason = "waiting for Duration",
+               issue = "27772")]
     pub fn wait_timeout<'a, T>(&self, guard: MutexGuard<'a, T>,
                                dur: Duration)
                                -> LockResult<(MutexGuard<'a, T>, bool)> {
@@ -190,7 +193,8 @@ impl Condvar {
     /// that the implementation will repeatedly wait while the duration has not
     /// passed and the provided function returns `false`.
     #[unstable(feature = "wait_timeout_with",
-               reason = "unsure if this API is broadly needed or what form it should take")]
+               reason = "unsure if this API is broadly needed or what form it should take",
+               issue = "27748")]
     pub fn wait_timeout_with<'a, T, F>(&self,
                                        guard: MutexGuard<'a, T>,
                                        dur: Duration,
@@ -234,7 +238,8 @@ impl Drop for Condvar {
 impl StaticCondvar {
     /// Creates a new condition variable
     #[unstable(feature = "static_condvar",
-               reason = "may be merged with Condvar in the future")]
+               reason = "may be merged with Condvar in the future",
+               issue = "27717")]
     pub const fn new() -> StaticCondvar {
         StaticCondvar {
             inner: sys::Condvar::new(),
@@ -247,7 +252,8 @@ impl StaticCondvar {
     ///
     /// See `Condvar::wait`.
     #[unstable(feature = "static_condvar",
-               reason = "may be merged with Condvar in the future")]
+               reason = "may be merged with Condvar in the future",
+               issue = "27717")]
     pub fn wait<'a, T>(&'static self, guard: MutexGuard<'a, T>)
                        -> LockResult<MutexGuard<'a, T>> {
         let poisoned = unsafe {
@@ -268,7 +274,8 @@ impl StaticCondvar {
     ///
     /// See `Condvar::wait_timeout`.
     #[unstable(feature = "static_condvar",
-               reason = "may be merged with Condvar in the future")]
+               reason = "may be merged with Condvar in the future",
+               issue = "27717")]
     pub fn wait_timeout_ms<'a, T>(&'static self, guard: MutexGuard<'a, T>, ms: u32)
                                   -> LockResult<(MutexGuard<'a, T>, bool)> {
         self.wait_timeout(guard, Duration::from_millis(ms as u64))
@@ -279,7 +286,8 @@ impl StaticCondvar {
     ///
     /// See `Condvar::wait_timeout`.
     #[unstable(feature = "static_condvar",
-               reason = "may be merged with Condvar in the future")]
+               reason = "may be merged with Condvar in the future",
+               issue = "27717")]
     pub fn wait_timeout<'a, T>(&'static self,
                                guard: MutexGuard<'a, T>,
                                timeout: Duration)
@@ -305,7 +313,8 @@ impl StaticCondvar {
     ///
     /// See `Condvar::wait_timeout_with`.
     #[unstable(feature = "static_condvar",
-               reason = "may be merged with Condvar in the future")]
+               reason = "may be merged with Condvar in the future",
+               issue = "27717")]
     pub fn wait_timeout_with<'a, T, F>(&'static self,
                                        guard: MutexGuard<'a, T>,
                                        dur: Duration,
@@ -351,14 +360,16 @@ impl StaticCondvar {
     ///
     /// See `Condvar::notify_one`.
     #[unstable(feature = "static_condvar",
-               reason = "may be merged with Condvar in the future")]
+               reason = "may be merged with Condvar in the future",
+               issue = "27717")]
     pub fn notify_one(&'static self) { unsafe { self.inner.notify_one() } }
 
     /// Wakes up all blocked threads on this condvar.
     ///
     /// See `Condvar::notify_all`.
     #[unstable(feature = "static_condvar",
-               reason = "may be merged with Condvar in the future")]
+               reason = "may be merged with Condvar in the future",
+               issue = "27717")]
     pub fn notify_all(&'static self) { unsafe { self.inner.notify_all() } }
 
     /// Deallocates all resources associated with this static condvar.
@@ -368,7 +379,8 @@ impl StaticCondvar {
     /// users of the condvar. This method is required to be called to not leak
     /// memory on all platforms.
     #[unstable(feature = "static_condvar",
-               reason = "may be merged with Condvar in the future")]
+               reason = "may be merged with Condvar in the future",
+               issue = "27717")]
     pub unsafe fn destroy(&'static self) {
         self.inner.destroy()
     }

--- a/src/libstd/sync/mpsc/select.rs
+++ b/src/libstd/sync/mpsc/select.rs
@@ -54,7 +54,8 @@
                       module will likely be replaced, and it is currently \
                       unknown how much API breakage that will cause. The ability \
                       to select over a number of channels will remain forever, \
-                      but no guarantees beyond this are being made")]
+                      but no guarantees beyond this are being made",
+            issue = "27800")]
 
 
 use core::cell::{Cell, UnsafeCell};

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -151,7 +151,8 @@ unsafe impl<T: ?Sized + Send> Sync for Mutex<T> { }
 /// // lock is unlocked here.
 /// ```
 #[unstable(feature = "static_mutex",
-           reason = "may be merged with Mutex in the future")]
+           reason = "may be merged with Mutex in the future",
+           issue = "27717")]
 pub struct StaticMutex {
     lock: sys::Mutex,
     poison: poison::Flag,
@@ -177,7 +178,8 @@ impl<'a, T: ?Sized> !marker::Send for MutexGuard<'a, T> {}
 /// Static initialization of a mutex. This constant can be used to initialize
 /// other mutex constants.
 #[unstable(feature = "static_mutex",
-           reason = "may be merged with Mutex in the future")]
+           reason = "may be merged with Mutex in the future",
+           issue = "27717")]
 pub const MUTEX_INIT: StaticMutex = StaticMutex::new();
 
 impl<T> Mutex<T> {
@@ -271,7 +273,8 @@ unsafe impl Sync for Dummy {}
 static DUMMY: Dummy = Dummy(UnsafeCell::new(()));
 
 #[unstable(feature = "static_mutex",
-           reason = "may be merged with Mutex in the future")]
+           reason = "may be merged with Mutex in the future",
+           issue = "27717")]
 impl StaticMutex {
     /// Creates a new mutex in an unlocked state ready for use.
     pub const fn new() -> StaticMutex {

--- a/src/libstd/sync/rwlock.rs
+++ b/src/libstd/sync/rwlock.rs
@@ -98,7 +98,8 @@ unsafe impl<T: ?Sized + Send + Sync> Sync for RwLock<T> {}
 /// unsafe { LOCK.destroy() } // free all resources
 /// ```
 #[unstable(feature = "static_rwlock",
-           reason = "may be merged with RwLock in the future")]
+           reason = "may be merged with RwLock in the future",
+           issue = "27717")]
 pub struct StaticRwLock {
     lock: sys::RWLock,
     poison: poison::Flag,
@@ -106,7 +107,8 @@ pub struct StaticRwLock {
 
 /// Constant initialization for a statically-initialized rwlock.
 #[unstable(feature = "static_rwlock",
-           reason = "may be merged with RwLock in the future")]
+           reason = "may be merged with RwLock in the future",
+           issue = "27717")]
 pub const RW_LOCK_INIT: StaticRwLock = StaticRwLock::new();
 
 /// RAII structure used to release the shared read access of a lock when
@@ -285,7 +287,8 @@ unsafe impl Sync for Dummy {}
 static DUMMY: Dummy = Dummy(UnsafeCell::new(()));
 
 #[unstable(feature = "static_rwlock",
-           reason = "may be merged with RwLock in the future")]
+           reason = "may be merged with RwLock in the future",
+           issue = "27717")]
 impl StaticRwLock {
     /// Creates a new rwlock.
     pub const fn new() -> StaticRwLock {

--- a/src/libstd/sync/semaphore.rs
+++ b/src/libstd/sync/semaphore.rs
@@ -10,7 +10,8 @@
 
 #![unstable(feature = "semaphore",
             reason = "the interaction between semaphores and the acquisition/release \
-                      of resources is currently unclear")]
+                      of resources is currently unclear",
+            issue = "27798")]
 
 use ops::Drop;
 use sync::{Mutex, Condvar};

--- a/src/libstd/sys/common/remutex.rs
+++ b/src/libstd/sys/common/remutex.rs
@@ -7,7 +7,9 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![unstable(feature = "reentrant_mutex", reason = "new API")]
+
+#![unstable(feature = "reentrant_mutex", reason = "new API",
+            issue = "27738")]
 
 use prelude::v1::*;
 

--- a/src/libstd/sys/common/thread_local.rs
+++ b/src/libstd/sys/common/thread_local.rs
@@ -55,7 +55,7 @@
 //! ```
 
 #![allow(non_camel_case_types)]
-#![unstable(feature = "thread_local_internals")]
+#![unstable(feature = "thread_local_internals", issue = "0")]
 #![allow(dead_code)] // sys isn't exported yet
 
 use sync::atomic::{self, AtomicUsize, Ordering};

--- a/src/libstd/sys/unix/ext/fs.rs
+++ b/src/libstd/sys/unix/ext/fs.rs
@@ -22,43 +22,43 @@ use sys::fs::MetadataExt as UnixMetadataExt;
 use sys;
 use sys_common::{FromInner, AsInner, AsInnerMut};
 
-#[unstable(feature = "fs_mode", reason = "recently added API")]
+#[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 pub const USER_READ: raw::mode_t = 0o400;
-#[unstable(feature = "fs_mode", reason = "recently added API")]
+#[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 pub const USER_WRITE: raw::mode_t = 0o200;
-#[unstable(feature = "fs_mode", reason = "recently added API")]
+#[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 pub const USER_EXECUTE: raw::mode_t = 0o100;
-#[unstable(feature = "fs_mode", reason = "recently added API")]
+#[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 pub const USER_RWX: raw::mode_t = 0o700;
-#[unstable(feature = "fs_mode", reason = "recently added API")]
+#[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 pub const GROUP_READ: raw::mode_t = 0o040;
-#[unstable(feature = "fs_mode", reason = "recently added API")]
+#[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 pub const GROUP_WRITE: raw::mode_t = 0o020;
-#[unstable(feature = "fs_mode", reason = "recently added API")]
+#[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 pub const GROUP_EXECUTE: raw::mode_t = 0o010;
-#[unstable(feature = "fs_mode", reason = "recently added API")]
+#[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 pub const GROUP_RWX: raw::mode_t = 0o070;
-#[unstable(feature = "fs_mode", reason = "recently added API")]
+#[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 pub const OTHER_READ: raw::mode_t = 0o004;
-#[unstable(feature = "fs_mode", reason = "recently added API")]
+#[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 pub const OTHER_WRITE: raw::mode_t = 0o002;
-#[unstable(feature = "fs_mode", reason = "recently added API")]
+#[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 pub const OTHER_EXECUTE: raw::mode_t = 0o001;
-#[unstable(feature = "fs_mode", reason = "recently added API")]
+#[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 pub const OTHER_RWX: raw::mode_t = 0o007;
-#[unstable(feature = "fs_mode", reason = "recently added API")]
+#[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 pub const ALL_READ: raw::mode_t = 0o444;
-#[unstable(feature = "fs_mode", reason = "recently added API")]
+#[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 pub const ALL_WRITE: raw::mode_t = 0o222;
-#[unstable(feature = "fs_mode", reason = "recently added API")]
+#[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 pub const ALL_EXECUTE: raw::mode_t = 0o111;
-#[unstable(feature = "fs_mode", reason = "recently added API")]
+#[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 pub const ALL_RWX: raw::mode_t = 0o777;
-#[unstable(feature = "fs_mode", reason = "recently added API")]
+#[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 pub const SETUID: raw::mode_t = 0o4000;
-#[unstable(feature = "fs_mode", reason = "recently added API")]
+#[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 pub const SETGID: raw::mode_t = 0o2000;
-#[unstable(feature = "fs_mode", reason = "recently added API")]
+#[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 pub const STICKY_BIT: raw::mode_t = 0o1000;
 
 /// Unix-specific extensions to `Permissions`
@@ -178,7 +178,8 @@ impl MetadataExt for fs::Metadata {
 }
 
 /// Add special unix types (block/char device, fifo and socket)
-#[unstable(feature = "file_type_ext", reason = "recently added API")]
+#[unstable(feature = "file_type_ext", reason = "recently added API",
+           issue = "27796")]
 pub trait FileTypeExt {
     /// Returns whether this file type is a block device.
     fn is_block_device(&self) -> bool;
@@ -190,7 +191,8 @@ pub trait FileTypeExt {
     fn is_socket(&self) -> bool;
 }
 
-#[unstable(feature = "file_type_ext", reason = "recently added API")]
+#[unstable(feature = "file_type_ext", reason = "recently added API",
+           issue = "27796")]
 impl FileTypeExt for fs::FileType {
     fn is_block_device(&self) -> bool { self.as_inner().is(libc::S_IFBLK) }
     fn is_char_device(&self) -> bool { self.as_inner().is(libc::S_IFCHR) }
@@ -240,7 +242,8 @@ pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()>
     sys::fs::symlink(src.as_ref(), dst.as_ref())
 }
 
-#[unstable(feature = "dir_builder", reason = "recently added API")]
+#[unstable(feature = "dir_builder", reason = "recently added API",
+           issue = "27710")]
 /// An extension trait for `fs::DirBuilder` for unix-specific options.
 pub trait DirBuilderExt {
     /// Sets the mode to create new directories with. This option defaults to

--- a/src/libstd/sys/unix/ext/io.rs
+++ b/src/libstd/sys/unix/ext/io.rs
@@ -61,7 +61,8 @@ pub trait FromRawFd {
 
 /// A trait to express the ability to consume an object and acquire ownership of
 /// its raw file descriptor.
-#[unstable(feature = "into_raw_os", reason = "recently added API")]
+#[unstable(feature = "into_raw_os", reason = "recently added API",
+           issue = "27797")]
 pub trait IntoRawFd {
     /// Consumes this object, returning the raw underlying file descriptor.
     ///

--- a/src/libstd/sys/unix/ext/process.rs
+++ b/src/libstd/sys/unix/ext/process.rs
@@ -32,15 +32,17 @@ pub trait CommandExt {
     #[stable(feature = "rust1", since = "1.0.0")]
     fn gid(&mut self, id: gid_t) -> &mut process::Command;
 
-    /// Create a new session (cf. `setsid(2)`) for the child process. This means that the child is
-    /// the leader of a new process group. The parent process remains the child reaper of the new
-    /// process.
+    /// Create a new session (cf. `setsid(2)`) for the child process. This means
+    /// that the child is the leader of a new process group. The parent process
+    /// remains the child reaper of the new process.
     ///
-    /// This is not enough to create a daemon process. The *init* process should be the child
-    /// reaper of a daemon. This can be achieved if the parent process exit. Moreover, a daemon
-    /// should not have a controlling terminal. To acheive this, a session leader (the child) must
-    /// spawn another process (the daemon) in the same session.
-    #[unstable(feature = "process_session_leader", reason = "recently added")]
+    /// This is not enough to create a daemon process. The *init* process should
+    /// be the child reaper of a daemon. This can be achieved if the parent
+    /// process exit. Moreover, a daemon should not have a controlling terminal.
+    /// To acheive this, a session leader (the child) must spawn another process
+    /// (the daemon) in the same session.
+    #[unstable(feature = "process_session_leader", reason = "recently added",
+               issue = "27811")]
     fn session_leader(&mut self, on: bool) -> &mut process::Command;
 }
 

--- a/src/libstd/sys/windows/ext/fs.rs
+++ b/src/libstd/sys/windows/ext/fs.rs
@@ -20,7 +20,8 @@ use sys_common::{AsInnerMut, AsInner};
 
 /// Windows-specific extensions to `OpenOptions`
 #[unstable(feature = "open_options_ext",
-           reason = "may require more thought/methods")]
+           reason = "may require more thought/methods",
+           issue = "27720")]
 pub trait OpenOptionsExt {
     /// Overrides the `dwDesiredAccess` argument to the call to `CreateFile`
     /// with the specified value.

--- a/src/libstd/sys/windows/ext/io.rs
+++ b/src/libstd/sys/windows/ext/io.rs
@@ -52,7 +52,8 @@ pub trait FromRawHandle {
 
 /// A trait to express the ability to consume an object and acquire ownership of
 /// its raw `HANDLE`.
-#[unstable(feature = "into_raw_os", reason = "recently added API")]
+#[unstable(feature = "into_raw_os", reason = "recently added API",
+           issue = "27797")]
 pub trait IntoRawHandle {
     /// Consumes this object, returning the raw underlying handle.
     ///
@@ -110,7 +111,8 @@ pub trait FromRawSocket {
 
 /// A trait to express the ability to consume an object and acquire ownership of
 /// its raw `SOCKET`.
-#[unstable(feature = "into_raw_os", reason = "recently added API")]
+#[unstable(feature = "into_raw_os", reason = "recently added API",
+           issue = "27797")]
 pub trait IntoRawSocket {
     /// Consumes this object, returning the raw underlying socket.
     ///

--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -10,7 +10,7 @@
 
 //! Thread local storage
 
-#![unstable(feature = "thread_local_internals")]
+#![unstable(feature = "thread_local_internals", issue = "0")]
 
 use cell::UnsafeCell;
 
@@ -137,7 +137,8 @@ macro_rules! thread_local {
 
 #[doc(hidden)]
 #[unstable(feature = "thread_local_internals",
-           reason = "should not be necessary")]
+           reason = "should not be necessary",
+           issue = "0")]
 #[macro_export]
 #[allow_internal_unstable]
 macro_rules! __thread_local_inner {
@@ -153,7 +154,8 @@ macro_rules! __thread_local_inner {
 
 /// Indicator of the state of a thread local storage key.
 #[unstable(feature = "thread_local_state",
-           reason = "state querying was recently added")]
+           reason = "state querying was recently added",
+           issue = "27716")]
 #[derive(Eq, PartialEq, Copy, Clone)]
 pub enum LocalKeyState {
     /// All keys are in this state whenever a thread starts. Keys will
@@ -185,7 +187,8 @@ pub enum LocalKeyState {
 impl<T: 'static> LocalKey<T> {
     #[doc(hidden)]
     #[unstable(feature = "thread_local_internals",
-               reason = "recently added to create a key")]
+               reason = "recently added to create a key",
+               issue = "0")]
     pub const fn new(inner: fn() -> &'static __KeyInner<T>,
                      init: fn() -> T) -> LocalKey<T> {
         LocalKey {
@@ -248,7 +251,8 @@ impl<T: 'static> LocalKey<T> {
     /// to be able to be accessed. Keys in the `Destroyed` state will panic on
     /// any call to `with`.
     #[unstable(feature = "thread_local_state",
-               reason = "state querying was recently added")]
+               reason = "state querying was recently added",
+               issue = "27716")]
     pub fn state(&'static self) -> LocalKeyState {
         unsafe {
             match (self.inner)().get() {

--- a/src/libstd/thread/scoped_tls.rs
+++ b/src/libstd/thread/scoped_tls.rs
@@ -40,7 +40,7 @@
 //! });
 //! ```
 
-#![unstable(feature = "thread_local_internals")]
+#![unstable(feature = "thread_local_internals", issue = "0")]
 
 #[doc(hidden)]
 pub use self::imp::KeyInner as __KeyInner;
@@ -54,7 +54,8 @@ pub use self::imp::KeyInner as __KeyInner;
 /// their contents.
 #[unstable(feature = "scoped_tls",
            reason = "scoped TLS has yet to have wide enough use to fully consider \
-                     stabilizing its interface")]
+                     stabilizing its interface",
+           issue = "27715")]
 pub struct ScopedKey<T:'static> { inner: fn() -> &'static imp::KeyInner<T> }
 
 /// Declare a new scoped thread local storage key.
@@ -116,7 +117,8 @@ macro_rules! __scoped_thread_local_inner {
 
 #[unstable(feature = "scoped_tls",
            reason = "scoped TLS has yet to have wide enough use to fully consider \
-                     stabilizing its interface")]
+                     stabilizing its interface",
+           issue = "27715")]
 impl<T> ScopedKey<T> {
     #[doc(hidden)]
     pub const fn new(inner: fn() -> &'static imp::KeyInner<T>) -> ScopedKey<T> {

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -64,7 +64,8 @@ impl Duration {
     #[unstable(feature = "duration_span",
                reason = "unsure if this is the right API or whether it should \
                          wait for a more general \"moment in time\" \
-                         abstraction")]
+                         abstraction",
+               issue = "27799")]
     pub fn span<F>(f: F) -> Duration where F: FnOnce() {
         let start = SteadyTime::now();
         f();

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -532,10 +532,9 @@ fn find_stability_generic<'a,
         }
     } else if stab.as_ref().map_or(false, |s| s.level == Unstable && s.issue.is_none()) {
         // non-deprecated unstable items need to point to issues.
-        // FIXME: uncomment this error
-        // diagnostic.span_err(item_sp,
-        //                     "non-deprecated unstable items need to point \
-        //                      to an issue with `issue = \"NNN\"`");
+        diagnostic.span_err(item_sp,
+                            "non-deprecated unstable items need to point \
+                             to an issue with `issue = \"NNN\"`");
     }
 
     (stab, used_attrs)

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -17,7 +17,7 @@
 // Do not remove on snapshot creation. Needed for bootstrap. (Issue #22364)
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "syntax"]
-#![unstable(feature = "rustc_private")]
+#![unstable(feature = "rustc_private", issue = "27812")]
 #![staged_api]
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -45,7 +45,8 @@
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "term"]
 #![unstable(feature = "rustc_private",
-            reason = "use the crates.io `term` library instead")]
+            reason = "use the crates.io `term` library instead",
+            issue = "27812")]
 #![staged_api]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -26,7 +26,7 @@
 // Do not remove on snapshot creation. Needed for bootstrap. (Issue #22364)
 #![cfg_attr(stage0, feature(custom_attribute))]
 #![crate_name = "test"]
-#![unstable(feature = "test")]
+#![unstable(feature = "test", issue = "27812")]
 #![staged_api]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]

--- a/src/test/auxiliary/inherited_stability.rs
+++ b/src/test/auxiliary/inherited_stability.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 #![crate_name="inherited_stability"]
 #![crate_type = "lib"]
-#![unstable(feature = "test_feature")]
+#![unstable(feature = "test_feature", issue = "0")]
 #![feature(staged_api)]
 #![staged_api]
 
@@ -26,7 +26,7 @@ pub mod stable_mod {
     pub fn stable() {}
 }
 
-#[unstable(feature = "test_feature")]
+#[unstable(feature = "test_feature", issue = "0")]
 pub mod unstable_mod {
     #[stable(feature = "test_feature", since = "1.0.0")]
     #[deprecated(since = "1.0.0")]

--- a/src/test/auxiliary/internal_unstable.rs
+++ b/src/test/auxiliary/internal_unstable.rs
@@ -12,24 +12,24 @@
 #![staged_api]
 #![stable(feature = "stable", since = "1.0.0")]
 
-#[unstable(feature = "function")]
+#[unstable(feature = "function", issue = "0")]
 pub fn unstable() {}
 
 
 #[stable(feature = "stable", since = "1.0.0")]
 pub struct Foo {
-    #[unstable(feature = "struct_field")]
+    #[unstable(feature = "struct_field", issue = "0")]
     pub x: u8
 }
 
 impl Foo {
-    #[unstable(feature = "method")]
+    #[unstable(feature = "method", issue = "0")]
     pub fn method(&self) {}
 }
 
 #[stable(feature = "stable", since = "1.0.0")]
 pub struct Bar {
-    #[unstable(feature = "struct2_field")]
+    #[unstable(feature = "struct2_field", issue = "0")]
     pub x: u8
 }
 

--- a/src/test/auxiliary/lint_output_format.rs
+++ b/src/test/auxiliary/lint_output_format.rs
@@ -12,7 +12,7 @@
 #![crate_type = "lib"]
 #![feature(staged_api)]
 #![staged_api]
-#![unstable(feature = "test_feature")]
+#![unstable(feature = "test_feature", issue = "0")]
 
 #[stable(feature = "test_feature", since = "1.0.0")]
 #[deprecated(since = "1.0.0")]
@@ -20,12 +20,12 @@ pub fn foo() -> usize {
     20
 }
 
-#[unstable(feature = "test_feature")]
+#[unstable(feature = "test_feature", issue = "0")]
 pub fn bar() -> usize {
     40
 }
 
-#[unstable(feature = "test_feature")]
+#[unstable(feature = "test_feature", issue = "0")]
 pub fn baz() -> usize {
     30
 }

--- a/src/test/auxiliary/lint_stability.rs
+++ b/src/test/auxiliary/lint_stability.rs
@@ -20,16 +20,16 @@ pub fn deprecated() {}
 #[deprecated(since = "1.0.0", reason = "text")]
 pub fn deprecated_text() {}
 
-#[unstable(feature = "test_feature")]
+#[unstable(feature = "test_feature", issue = "0")]
 #[deprecated(since = "1.0.0")]
 pub fn deprecated_unstable() {}
-#[unstable(feature = "test_feature")]
+#[unstable(feature = "test_feature", issue = "0")]
 #[deprecated(since = "1.0.0", reason = "text")]
 pub fn deprecated_unstable_text() {}
 
-#[unstable(feature = "test_feature")]
+#[unstable(feature = "test_feature", issue = "0")]
 pub fn unstable() {}
-#[unstable(feature = "test_feature", reason = "text")]
+#[unstable(feature = "test_feature", reason = "text", issue = "0")]
 pub fn unstable_text() {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -48,16 +48,16 @@ impl MethodTester {
     #[deprecated(since = "1.0.0", reason = "text")]
     pub fn method_deprecated_text(&self) {}
 
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     #[deprecated(since = "1.0.0")]
     pub fn method_deprecated_unstable(&self) {}
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     #[deprecated(since = "1.0.0", reason = "text")]
     pub fn method_deprecated_unstable_text(&self) {}
 
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     pub fn method_unstable(&self) {}
-    #[unstable(feature = "test_feature", reason = "text")]
+    #[unstable(feature = "test_feature", reason = "text", issue = "0")]
     pub fn method_unstable_text(&self) {}
 
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -75,16 +75,16 @@ pub trait Trait {
     #[deprecated(since = "1.0.0", reason = "text")]
     fn trait_deprecated_text(&self) {}
 
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     #[deprecated(since = "1.0.0")]
     fn trait_deprecated_unstable(&self) {}
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     #[deprecated(since = "1.0.0", reason = "text")]
     fn trait_deprecated_unstable_text(&self) {}
 
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     fn trait_unstable(&self) {}
-    #[unstable(feature = "test_feature", reason = "text")]
+    #[unstable(feature = "test_feature", reason = "text", issue = "0")]
     fn trait_unstable_text(&self) {}
 
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -95,7 +95,7 @@ pub trait Trait {
 
 impl Trait for MethodTester {}
 
-#[unstable(feature = "test_feature")]
+#[unstable(feature = "test_feature", issue = "0")]
 pub trait UnstableTrait { fn dummy(&self) { } }
 
 #[stable(feature = "test_feature", since = "1.0.0")]
@@ -103,12 +103,12 @@ pub trait UnstableTrait { fn dummy(&self) { } }
 pub struct DeprecatedStruct {
     #[stable(feature = "test_feature", since = "1.0.0")] pub i: isize
 }
-#[unstable(feature = "test_feature")]
+#[unstable(feature = "test_feature", issue = "0")]
 #[deprecated(since = "1.0.0")]
 pub struct DeprecatedUnstableStruct {
     #[stable(feature = "test_feature", since = "1.0.0")] pub i: isize
 }
-#[unstable(feature = "test_feature")]
+#[unstable(feature = "test_feature", issue = "0")]
 pub struct UnstableStruct {
     #[stable(feature = "test_feature", since = "1.0.0")] pub i: isize
 }
@@ -120,10 +120,10 @@ pub struct StableStruct {
 #[stable(feature = "test_feature", since = "1.0.0")]
 #[deprecated(since = "1.0.0")]
 pub struct DeprecatedUnitStruct;
-#[unstable(feature = "test_feature")]
+#[unstable(feature = "test_feature", issue = "0")]
 #[deprecated(since = "1.0.0")]
 pub struct DeprecatedUnstableUnitStruct;
-#[unstable(feature = "test_feature")]
+#[unstable(feature = "test_feature", issue = "0")]
 pub struct UnstableUnitStruct;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct StableUnitStruct;
@@ -133,10 +133,10 @@ pub enum Enum {
     #[stable(feature = "test_feature", since = "1.0.0")]
     #[deprecated(since = "1.0.0")]
     DeprecatedVariant,
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     #[deprecated(since = "1.0.0")]
     DeprecatedUnstableVariant,
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     UnstableVariant,
 
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -146,10 +146,10 @@ pub enum Enum {
 #[stable(feature = "test_feature", since = "1.0.0")]
 #[deprecated(since = "1.0.0")]
 pub struct DeprecatedTupleStruct(#[stable(feature = "rust1", since = "1.0.0")] pub isize);
-#[unstable(feature = "test_feature")]
+#[unstable(feature = "test_feature", issue = "0")]
 #[deprecated(since = "1.0.0")]
 pub struct DeprecatedUnstableTupleStruct(#[stable(feature = "rust1", since = "1.0.0")] pub isize);
-#[unstable(feature = "test_feature")]
+#[unstable(feature = "test_feature", issue = "0")]
 pub struct UnstableTupleStruct(#[stable(feature = "rust1", since = "1.0.0")] pub isize);
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct StableTupleStruct(#[stable(feature = "rust1", since = "1.0.0")] pub isize);

--- a/src/test/auxiliary/lint_stability_fields.rs
+++ b/src/test/auxiliary/lint_stability_fields.rs
@@ -16,45 +16,47 @@
 pub struct Stable {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub inherit: u8, // it's a lie (stable doesn't inherit)
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     pub override1: u8,
     #[deprecated(since = "1.0.0")]
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     pub override2: u8,
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Stable2(#[stable(feature = "rust1", since = "1.0.0")] pub u8,
-                   #[unstable(feature = "test_feature")] pub u8,
-                   #[unstable(feature = "test_feature")] #[deprecated(since = "1.0.0")] pub u8);
+                   #[unstable(feature = "test_feature", issue = "0")] pub u8,
+                   #[unstable(feature = "test_feature", issue = "0")]
+                   #[deprecated(since = "1.0.0")] pub u8);
 
-#[unstable(feature = "test_feature")]
+#[unstable(feature = "test_feature", issue = "0")]
 pub struct Unstable {
     pub inherit: u8,
     #[stable(feature = "rust1", since = "1.0.0")]
     pub override1: u8,
     #[deprecated(since = "1.0.0")]
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     pub override2: u8,
 }
 
-#[unstable(feature = "test_feature")]
+#[unstable(feature = "test_feature", issue = "0")]
 pub struct Unstable2(pub u8,
                      #[stable(feature = "rust1", since = "1.0.0")] pub u8,
-                     #[unstable(feature = "test_feature")] #[deprecated(since = "1.0.0")] pub u8);
+                     #[unstable(feature = "test_feature", issue = "0")]
+                     #[deprecated(since = "1.0.0")] pub u8);
 
-#[unstable(feature = "test_feature")]
+#[unstable(feature = "test_feature", issue = "0")]
 #[deprecated(feature = "rust1", since = "1.0.0")]
 pub struct Deprecated {
     pub inherit: u8,
     #[stable(feature = "rust1", since = "1.0.0")]
     pub override1: u8,
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     pub override2: u8,
 }
 
-#[unstable(feature = "test_feature")]
+#[unstable(feature = "test_feature", issue = "0")]
 #[deprecated(feature = "rust1", since = "1.0.0")]
 pub struct Deprecated2(pub u8,
                        #[stable(feature = "rust1", since = "1.0.0")] pub u8,
-                       #[unstable(feature = "test_feature")] pub u8);
+                       #[unstable(feature = "test_feature", issue = "0")] pub u8);

--- a/src/test/auxiliary/stability_cfg2.rs
+++ b/src/test/auxiliary/stability_cfg2.rs
@@ -10,7 +10,7 @@
 
 // compile-flags:--cfg foo
 
-#![cfg_attr(foo, unstable(feature = "test_feature"))]
+#![cfg_attr(foo, unstable(feature = "test_feature", issue = "0"))]
 #![cfg_attr(not(foo), stable(feature = "test_feature", since = "1.0.0"))]
 #![feature(staged_api)]
 #![staged_api]

--- a/src/test/compile-fail/lint-stability-fields.rs
+++ b/src/test/compile-fail/lint-stability-fields.rs
@@ -187,48 +187,50 @@ mod this_crate {
     #[stable(feature = "rust1", since = "1.0.0")]
     struct Stable {
         inherit: u8,
-        #[unstable(feature = "test_feature")]
+        #[unstable(feature = "test_feature", issue = "0")]
         override1: u8,
         #[deprecated(since = "1.0.0")]
-        #[unstable(feature = "test_feature")]
+        #[unstable(feature = "test_feature", issue = "0")]
         override2: u8,
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
     struct Stable2(u8,
                    #[stable(feature = "rust1", since = "1.0.0")] u8,
-                   #[unstable(feature = "test_feature")] #[deprecated(since = "1.0.0")] u8);
+                   #[unstable(feature = "test_feature", issue = "0")]
+                   #[deprecated(since = "1.0.0")] u8);
 
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     struct Unstable {
         inherit: u8,
         #[stable(feature = "rust1", since = "1.0.0")]
         override1: u8,
         #[deprecated(since = "1.0.0")]
-        #[unstable(feature = "test_feature")]
+        #[unstable(feature = "test_feature", issue = "0")]
         override2: u8,
     }
 
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     struct Unstable2(u8,
                      #[stable(feature = "rust1", since = "1.0.0")] u8,
-                     #[unstable(feature = "test_feature")] #[deprecated(since = "1.0.0")] u8);
+                     #[unstable(feature = "test_feature", issue = "0")]
+                     #[deprecated(since = "1.0.0")] u8);
 
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     #[deprecated(feature = "rust1", since = "1.0.0")]
     struct Deprecated {
         inherit: u8,
         #[stable(feature = "rust1", since = "1.0.0")]
         override1: u8,
-        #[unstable(feature = "test_feature")]
+        #[unstable(feature = "test_feature", issue = "0")]
         override2: u8,
     }
 
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     #[deprecated(feature = "rust1", since = "1.0.0")]
     struct Deprecated2(u8,
                        #[stable(feature = "rust1", since = "1.0.0")] u8,
-                       #[unstable(feature = "test_feature")] u8);
+                       #[unstable(feature = "test_feature", issue = "0")] u8);
 
     pub fn foo() {
         let x = Stable {

--- a/src/test/compile-fail/lint-stability.rs
+++ b/src/test/compile-fail/lint-stability.rs
@@ -257,16 +257,16 @@ mod inheritance {
 }
 
 mod this_crate {
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     #[deprecated(since = "1.0.0")]
     pub fn deprecated() {}
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     #[deprecated(since = "1.0.0", reason = "text")]
     pub fn deprecated_text() {}
 
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     pub fn unstable() {}
-    #[unstable(feature = "test_feature", reason = "text")]
+    #[unstable(feature = "test_feature", reason = "text", issue = "0")]
     pub fn unstable_text() {}
 
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -278,16 +278,16 @@ mod this_crate {
     pub struct MethodTester;
 
     impl MethodTester {
-        #[unstable(feature = "test_feature")]
+        #[unstable(feature = "test_feature", issue = "0")]
         #[deprecated(since = "1.0.0")]
         pub fn method_deprecated(&self) {}
-        #[unstable(feature = "test_feature")]
+        #[unstable(feature = "test_feature", issue = "0")]
         #[deprecated(since = "1.0.0", reason = "text")]
         pub fn method_deprecated_text(&self) {}
 
-        #[unstable(feature = "test_feature")]
+        #[unstable(feature = "test_feature", issue = "0")]
         pub fn method_unstable(&self) {}
-        #[unstable(feature = "test_feature", reason = "text")]
+        #[unstable(feature = "test_feature", reason = "text", issue = "0")]
         pub fn method_unstable_text(&self) {}
 
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -297,16 +297,16 @@ mod this_crate {
     }
 
     pub trait Trait {
-        #[unstable(feature = "test_feature")]
+        #[unstable(feature = "test_feature", issue = "0")]
         #[deprecated(since = "1.0.0")]
         fn trait_deprecated(&self) {}
-        #[unstable(feature = "test_feature")]
+        #[unstable(feature = "test_feature", issue = "0")]
         #[deprecated(since = "1.0.0", reason = "text")]
         fn trait_deprecated_text(&self) {}
 
-        #[unstable(feature = "test_feature")]
+        #[unstable(feature = "test_feature", issue = "0")]
         fn trait_unstable(&self) {}
-        #[unstable(feature = "test_feature", reason = "text")]
+        #[unstable(feature = "test_feature", reason = "text", issue = "0")]
         fn trait_unstable_text(&self) {}
 
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -317,12 +317,12 @@ mod this_crate {
 
     impl Trait for MethodTester {}
 
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     #[deprecated(since = "1.0.0")]
     pub struct DeprecatedStruct {
         #[stable(feature = "test_feature", since = "1.0.0")] i: isize
     }
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     pub struct UnstableStruct {
         #[stable(feature = "test_feature", since = "1.0.0")] i: isize
     }
@@ -331,29 +331,29 @@ mod this_crate {
         #[stable(feature = "test_feature", since = "1.0.0")] i: isize
     }
 
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     #[deprecated(since = "1.0.0")]
     pub struct DeprecatedUnitStruct;
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     pub struct UnstableUnitStruct;
     #[stable(feature = "rust1", since = "1.0.0")]
     pub struct StableUnitStruct;
 
     pub enum Enum {
-        #[unstable(feature = "test_feature")]
+        #[unstable(feature = "test_feature", issue = "0")]
         #[deprecated(since = "1.0.0")]
         DeprecatedVariant,
-        #[unstable(feature = "test_feature")]
+        #[unstable(feature = "test_feature", issue = "0")]
         UnstableVariant,
 
         #[stable(feature = "rust1", since = "1.0.0")]
         StableVariant,
     }
 
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     #[deprecated(since = "1.0.0")]
     pub struct DeprecatedTupleStruct(isize);
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     pub struct UnstableTupleStruct(isize);
     #[stable(feature = "rust1", since = "1.0.0")]
     pub struct StableTupleStruct(isize);
@@ -471,7 +471,7 @@ mod this_crate {
         foo.trait_stable();
     }
 
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     #[deprecated(since = "1.0.0")]
     fn test_fn_body() {
         fn fn_in_body() {}
@@ -479,7 +479,7 @@ mod this_crate {
     }
 
     impl MethodTester {
-        #[unstable(feature = "test_feature")]
+        #[unstable(feature = "test_feature", issue = "0")]
         #[deprecated(since = "1.0.0")]
         fn test_method_body(&self) {
             fn fn_in_body() {}
@@ -487,7 +487,7 @@ mod this_crate {
         }
     }
 
-    #[unstable(feature = "test_feature")]
+    #[unstable(feature = "test_feature", issue = "0")]
     #[deprecated(since = "1.0.0")]
     pub trait DeprecatedTrait {
         fn dummy(&self) { }

--- a/src/test/compile-fail/missing-stability.rs
+++ b/src/test/compile-fail/missing-stability.rs
@@ -19,7 +19,7 @@ pub fn unmarked() {
     ()
 }
 
-#[unstable(feature = "foo")]
+#[unstable(feature = "foo", issue = "0")]
 pub mod foo {
     // #[unstable] is inherited
     pub fn unmarked() {}

--- a/src/test/compile-fail/stability-attribute-sanity.rs
+++ b/src/test/compile-fail/stability-attribute-sanity.rs
@@ -56,11 +56,14 @@ mod bogus_attribute_types_2 {
 }
 
 mod missing_feature_names {
-    #[unstable(since = "a")] //~ ERROR missing 'feature'
+    #[unstable(since = "a", issue = "0")] //~ ERROR missing 'feature'
     fn f1() { }
 
+    #[unstable(feature = "a")]
+    fn f2() { } //~ ERROR need to point to an issue
+
     #[stable(since = "a")] //~ ERROR missing 'feature'
-    fn f2() { }
+    fn f3() { }
 }
 
 mod missing_version {
@@ -72,12 +75,12 @@ mod missing_version {
     fn f2() { }
 }
 
-#[unstable(feature = "a", since = "b")]
+#[unstable(feature = "a", since = "b", issue = "0")]
 #[stable(feature = "a", since = "b")]
 fn multiple1() { } //~ ERROR multiple stability levels
 
-#[unstable(feature = "a", since = "b")]
-#[unstable(feature = "a", since = "b")]
+#[unstable(feature = "a", since = "b", issue = "0")]
+#[unstable(feature = "a", since = "b", issue = "0")]
 fn multiple2() { } //~ ERROR multiple stability levels
 
 #[stable(feature = "a", since = "b")]

--- a/src/test/run-make/allow-warnings-cmdline-stability/bar.rs
+++ b/src/test/run-make/allow-warnings-cmdline-stability/bar.rs
@@ -11,6 +11,6 @@
 #![crate_type = "lib"]
 #![feature(staged_api)]
 #![staged_api]
-#![unstable(feature = "test_feature")]
+#![unstable(feature = "test_feature", issue = "0")]
 
 pub fn baz() { }


### PR DESCRIPTION
This commit turns `#[unstable]` attributes missing an `issue` annotation into a hard error. This will require the libs team to ensure that there's a tracking issue for all unstable features in the standard library.

All existing unstable features have had issues created and they've all been updated. Yay!

Closes #26868
