### PR TITLE
Make Condvar::wait_timeout return an enum instead of a bool

### DIFF
--- a/src/libstd/sync/condvar.rs
+++ b/src/libstd/sync/condvar.rs
@@ -21,11 +21,12 @@ use time::Duration;
 /// A type indicating whether a timed wait on a condition variable returned
 /// due to a time out or not.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
-#[unstable(feature = "wait_timeout", reason = "newly added")]
+#[unstable(feature = "wait_timeout", reason = "newly added", issue = "27772")]
 pub struct WaitTimeoutResult(bool);
 
 impl WaitTimeoutResult {
     /// Returns whether the wait was known to have timed out.
+    #[unstable(feature = "wait_timeout", reason = "newly added", issue = "27772")]
     pub fn timed_out(&self) -> bool {
         self.0
     }

--- a/src/libstd/sync/condvar.rs
+++ b/src/libstd/sync/condvar.rs
@@ -20,13 +20,20 @@ use time::Duration;
 
 /// A type indicating whether a timed wait on a condition variable returned
 /// due to a time out or not.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 #[unstable(feature = "wait_timeout", reason = "newly added")]
 pub enum TimedOut {
     /// The wait timed out.
     Yes,
     /// The wait did not time out.
     No
+}
+
+impl TimedOut {
+    /// Returns `true` iff the value of `self` is `Yes`.
+    pub fn timed_out(&self) -> bool {
+        *self == TimedOut::Yes
+    }
 }
 
 /// A Condition Variable

--- a/src/libstd/sync/mod.rs
+++ b/src/libstd/sync/mod.rs
@@ -21,7 +21,7 @@ pub use alloc::arc::{Arc, Weak};
 pub use core::atomic;
 
 pub use self::barrier::{Barrier, BarrierWaitResult};
-pub use self::condvar::{Condvar, StaticCondvar, TimedOut, CONDVAR_INIT};
+pub use self::condvar::{Condvar, StaticCondvar, WaitTimeoutResult, CONDVAR_INIT};
 pub use self::mutex::MUTEX_INIT;
 pub use self::mutex::{Mutex, MutexGuard, StaticMutex};
 pub use self::once::{Once, ONCE_INIT};

--- a/src/libstd/sync/mod.rs
+++ b/src/libstd/sync/mod.rs
@@ -21,7 +21,7 @@ pub use alloc::arc::{Arc, Weak};
 pub use core::atomic;
 
 pub use self::barrier::{Barrier, BarrierWaitResult};
-pub use self::condvar::{Condvar, StaticCondvar, CONDVAR_INIT};
+pub use self::condvar::{Condvar, StaticCondvar, TimedOut, CONDVAR_INIT};
 pub use self::mutex::MUTEX_INIT;
 pub use self::mutex::{Mutex, MutexGuard, StaticMutex};
 pub use self::once::{Once, ONCE_INIT};


### PR DESCRIPTION
Returning a primitive bool results in a somewhat confusing API - does
`true` indicate success - i.e. no timeout, or that a timeout has
occurred? An explicitly named enum makes it clearer.

[breaking-change]

r? @alexcrichton 
