### PR TITLE
Fix span of invalid metavariable repetition

### DIFF
--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -305,7 +305,7 @@ pub fn tt_next_token(r: &mut TtReader) -> TokenAndSpan {
                             }
                             MatchedSeq(..) => {
                                 panic!(r.sp_diag.span_fatal(
-                                    r.cur_span, /* blame the macro writer */
+                                    sp, /* blame the macro writer */
                                     &format!("variable '{}' is still repeating at this depth",
                                             ident)));
                             }

--- a/src/test/parse-fail/macro-repeat.rs
+++ b/src/test/parse-fail/macro-repeat.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! mac {
+    ( $($v:tt)* ) => (
+        $v  //~ ERROR still repeating at this depth
+    )
+}
+
+fn main() {
+    mac!(0);
+}


### PR DESCRIPTION
Current behaviour demo: http://is.gd/l3FEgo
(The span is printed at the start of the source code)

This patch moves the span to the use of `$i` in the macro rhs (as the code comment already claims)
