### PR TITLE
test: Fix tests for MUSL

### DIFF
--- a/src/test/compile-fail/allocator-dylib-is-system.rs
+++ b/src/test/compile-fail/allocator-dylib-is-system.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-msvc everything is the system allocator on msvc
+// ignore-musl no dylibs on musl yet
 // aux-build:allocator-dylib.rs
 // no-prefer-dynamic
 // error-pattern: cannot link together two allocators

--- a/src/test/compile-fail/allocator-rust-dylib-is-jemalloc.rs
+++ b/src/test/compile-fail/allocator-rust-dylib-is-jemalloc.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-msvc everything is the system allocator on msvc
+// ignore-musl no dylibs on musl right now
 // aux-build:allocator-dylib2.rs
 // error-pattern: cannot link together two allocators
 

--- a/src/test/compile-fail/two-allocators-3.rs
+++ b/src/test/compile-fail/two-allocators-3.rs
@@ -10,6 +10,7 @@
 
 // aux-build:allocator1.rs
 // error-pattern: cannot link together two allocators
+// ignore-musl no dylibs on musl yet
 
 // We're linking std dynamically (via -C prefer-dynamic for this test) which
 // has an allocator and then we're also linking in a new allocator (allocator1)


### PR DESCRIPTION
Some new allocator tests require dynamic libraries to run the full test, but
dylibs aren't currently working on MUSL.
