### PR TITLE
Cleanup ty decoder

### DIFF
--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -14,6 +14,7 @@ use ast_map;
 use metadata::common::*;
 use metadata::cstore;
 use metadata::decoder;
+use metadata::inline::InlinedItem;
 use middle::lang_items;
 use middle::ty;
 
@@ -96,8 +97,8 @@ pub fn get_item_path(tcx: &ty::ctxt, def: ast::DefId) -> Vec<ast_map::PathElem> 
 }
 
 pub enum FoundAst<'ast> {
-    Found(&'ast ast::InlinedItem),
-    FoundParent(ast::DefId, &'ast ast::InlinedItem),
+    Found(&'ast InlinedItem),
+    FoundParent(ast::DefId, &'ast InlinedItem),
     NotFound,
 }
 

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -23,6 +23,7 @@ use metadata::csearch::MethodInfo;
 use metadata::csearch;
 use metadata::cstore;
 use metadata::encoder::def_to_u64;
+use metadata::inline::InlinedItem;
 use metadata::tydecode::{parse_ty_data, parse_region_data,
                          parse_type_param_def_data, parse_bare_fn_ty_data,
                          parse_trait_ref_data, parse_predicate_data};
@@ -776,7 +777,7 @@ pub type DecodeInlinedItem<'a> =
                         &ty::ctxt<'tcx>,
                         Vec<ast_map::PathElem>,
                         rbml::Doc)
-                        -> Result<&'tcx ast::InlinedItem, Vec<ast_map::PathElem>> + 'a>;
+                        -> Result<&'tcx InlinedItem, Vec<ast_map::PathElem>> + 'a>;
 
 pub fn maybe_get_item_ast<'tcx>(cdata: Cmd, tcx: &ty::ctxt<'tcx>, id: ast::NodeId,
                                 mut decode_inlined_item: DecodeInlinedItem)

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -13,8 +13,6 @@
 #![allow(unused_must_use)] // everything is just a MemWriter, can't fail
 #![allow(non_camel_case_types)]
 
-pub use self::InlinedItemRef::*;
-
 use ast_map::{self, LinkedPath, PathElem, PathElems};
 use back::svh::Svh;
 use session::config;
@@ -22,6 +20,7 @@ use metadata::common::*;
 use metadata::cstore;
 use metadata::decoder;
 use metadata::tyencode;
+use metadata::inline::InlinedItemRef;
 use middle::def;
 use middle::ty::{self, Ty};
 use middle::stability;
@@ -45,14 +44,6 @@ use syntax::visit::Visitor;
 use syntax::visit;
 use syntax;
 use rbml::writer::Encoder;
-
-/// A borrowed version of `ast::InlinedItem`.
-pub enum InlinedItemRef<'a> {
-    IIItemRef(&'a ast::Item),
-    IITraitItemRef(DefId, &'a ast::TraitItem),
-    IIImplItemRef(DefId, &'a ast::ImplItem),
-    IIForeignRef(&'a ast::ForeignItem)
-}
 
 pub type EncodeInlinedItem<'a> =
     Box<FnMut(&EncodeContext, &mut Encoder, InlinedItemRef) + 'a>;
@@ -830,7 +821,7 @@ fn encode_info_for_associated_const(ecx: &EncodeContext,
 
     if let Some(ii) = impl_item_opt {
         encode_attributes(rbml_w, &ii.attrs);
-        encode_inlined_item(ecx, rbml_w, IIImplItemRef(local_def(parent_id), ii));
+        encode_inlined_item(ecx, rbml_w, InlinedItemRef::ImplItem(local_def(parent_id), ii));
     }
 
     rbml_w.end_tag();
@@ -868,7 +859,7 @@ fn encode_info_for_method<'a, 'tcx>(ecx: &EncodeContext<'a, 'tcx>,
             let needs_inline = any_types || is_default_impl ||
                                attr::requests_inline(&impl_item.attrs);
             if needs_inline || sig.constness == ast::Constness::Const {
-                encode_inlined_item(ecx, rbml_w, IIImplItemRef(local_def(parent_id),
+                encode_inlined_item(ecx, rbml_w, InlinedItemRef::ImplItem(local_def(parent_id),
                                                                impl_item));
             }
             encode_constness(rbml_w, sig.constness);
@@ -1050,7 +1041,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         encode_name(rbml_w, item.ident.name);
         encode_path(rbml_w, path);
         encode_attributes(rbml_w, &item.attrs);
-        encode_inlined_item(ecx, rbml_w, IIItemRef(item));
+        encode_inlined_item(ecx, rbml_w, InlinedItemRef::Item(item));
         encode_visibility(rbml_w, vis);
         encode_stability(rbml_w, stab);
         rbml_w.end_tag();
@@ -1067,7 +1058,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         encode_attributes(rbml_w, &item.attrs);
         let needs_inline = tps_len > 0 || attr::requests_inline(&item.attrs);
         if needs_inline || constness == ast::Constness::Const {
-            encode_inlined_item(ecx, rbml_w, IIItemRef(item));
+            encode_inlined_item(ecx, rbml_w, InlinedItemRef::Item(item));
         }
         if tps_len == 0 {
             encode_symbol(ecx, rbml_w, item.id);
@@ -1132,7 +1123,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         for v in &enum_definition.variants {
             encode_variant_id(rbml_w, local_def(v.node.id));
         }
-        encode_inlined_item(ecx, rbml_w, IIItemRef(item));
+        encode_inlined_item(ecx, rbml_w, InlinedItemRef::Item(item));
         encode_path(rbml_w, path);
 
         // Encode inherent implementations for this enumeration.
@@ -1180,7 +1171,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         needs to know*/
         encode_struct_fields(rbml_w, variant, def_id);
 
-        encode_inlined_item(ecx, rbml_w, IIItemRef(item));
+        encode_inlined_item(ecx, rbml_w, InlinedItemRef::Item(item));
 
         // Encode inherent implementations for this structure.
         encode_inherent_implementations(ecx, rbml_w, def_id);
@@ -1455,7 +1446,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
             match trait_item.node {
                 ast::ConstTraitItem(_, _) => {
                     encode_inlined_item(ecx, rbml_w,
-                                        IITraitItemRef(def_id, trait_item));
+                                        InlinedItemRef::TraitItem(def_id, trait_item));
                 }
                 ast::MethodTraitItem(ref sig, ref body) => {
                     // If this is a static method, we've already
@@ -1469,7 +1460,8 @@ fn encode_info_for_item(ecx: &EncodeContext,
 
                     if body.is_some() {
                         encode_item_sort(rbml_w, 'p');
-                        encode_inlined_item(ecx, rbml_w, IITraitItemRef(def_id, trait_item));
+                        encode_inlined_item(ecx, rbml_w,
+                                            InlinedItemRef::TraitItem(def_id, trait_item));
                     } else {
                         encode_item_sort(rbml_w, 'r');
                     }
@@ -1508,7 +1500,7 @@ fn encode_info_for_foreign_item(ecx: &EncodeContext,
         encode_bounds_and_type_for_item(rbml_w, ecx, nitem.id);
         encode_name(rbml_w, nitem.ident.name);
         if abi == abi::RustIntrinsic {
-            encode_inlined_item(ecx, rbml_w, IIForeignRef(nitem));
+            encode_inlined_item(ecx, rbml_w, InlinedItemRef::Foreign(nitem));
         }
         encode_attributes(rbml_w, &*nitem.attrs);
         let stab = stability::lookup(ecx.tcx, ast_util::local_def(nitem.id));

--- a/src/librustc/metadata/inline.rs
+++ b/src/librustc/metadata/inline.rs
@@ -1,0 +1,64 @@
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use syntax::ast;
+use syntax::ast_util::{IdRange, IdRangeComputingVisitor,
+                       IdVisitor, IdVisitingOperation};
+use syntax::ptr::P;
+use syntax::visit::Visitor;
+use self::InlinedItem::*;
+
+/// The data we save and restore about an inlined item or method.  This is not
+/// part of the AST that we parse from a file, but it becomes part of the tree
+/// that we trans.
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum InlinedItem {
+    Item(P<ast::Item>),
+    TraitItem(ast::DefId /* impl id */, P<ast::TraitItem>),
+    ImplItem(ast::DefId /* impl id */, P<ast::ImplItem>),
+    Foreign(P<ast::ForeignItem>),
+}
+
+/// A borrowed version of `ast::InlinedItem`.
+pub enum InlinedItemRef<'a> {
+    Item(&'a ast::Item),
+    TraitItem(ast::DefId, &'a ast::TraitItem),
+    ImplItem(ast::DefId, &'a ast::ImplItem),
+    Foreign(&'a ast::ForeignItem)
+}
+
+impl InlinedItem {
+    pub fn visit<'ast,V>(&'ast self, visitor: &mut V)
+        where V: Visitor<'ast>
+    {
+        match *self {
+            Item(ref i) => visitor.visit_item(&**i),
+            Foreign(ref i) => visitor.visit_foreign_item(&**i),
+            TraitItem(_, ref ti) => visitor.visit_trait_item(ti),
+            ImplItem(_, ref ii) => visitor.visit_impl_item(ii),
+        }
+    }
+
+    pub fn visit_ids<O: IdVisitingOperation>(&self, operation: &mut O) {
+        let mut id_visitor = IdVisitor {
+            operation: operation,
+            pass_through_items: true,
+            visited_outermost: false,
+        };
+        self.visit(&mut id_visitor);
+    }
+
+    pub fn compute_id_range(&self) -> IdRange {
+        let mut visitor = IdRangeComputingVisitor::new();
+        self.visit_ids(&mut visitor);
+        visitor.result()
+    }
+}
+

--- a/src/librustc/metadata/mod.rs
+++ b/src/librustc/metadata/mod.rs
@@ -19,3 +19,4 @@ pub mod csearch;
 pub mod loader;
 pub mod filesearch;
 pub mod macro_import;
+pub mod inline;

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -65,7 +65,7 @@ pub fn parse_ty_closure_data<'tcx, F>(data: &[u8],
                                       -> ty::ClosureTy<'tcx> where
     F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
 {
-    let mut st = PState::new(data, crate_num, pos, tcx, &mut conv);
+    let mut st = TyDecoder::new(data, crate_num, pos, tcx, &mut conv);
     st.parse_closure_ty()
 }
 
@@ -74,7 +74,7 @@ pub fn parse_ty_data<'tcx, F>(data: &[u8], crate_num: ast::CrateNum, pos: usize,
     F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
 {
     debug!("parse_ty_data {}", data_log_string(data, pos));
-    let mut st = PState::new(data, crate_num, pos, tcx, &mut conv);
+    let mut st = TyDecoder::new(data, crate_num, pos, tcx, &mut conv);
     st.parse_ty()
 }
 
@@ -83,7 +83,7 @@ pub fn parse_region_data<F>(data: &[u8], crate_num: ast::CrateNum, pos: usize, t
     F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
 {
     debug!("parse_region_data {}", data_log_string(data, pos));
-    let mut st = PState::new(data, crate_num, pos, tcx, &mut conv);
+    let mut st = TyDecoder::new(data, crate_num, pos, tcx, &mut conv);
     st.parse_region()
 }
 
@@ -93,7 +93,7 @@ pub fn parse_bare_fn_ty_data<'tcx, F>(data: &[u8], crate_num: ast::CrateNum, pos
     F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
 {
     debug!("parse_bare_fn_ty_data {}", data_log_string(data, pos));
-    let mut st = PState::new(data, crate_num, pos, tcx, &mut conv);
+    let mut st = TyDecoder::new(data, crate_num, pos, tcx, &mut conv);
     st.parse_bare_fn_ty()
 }
 
@@ -103,7 +103,7 @@ pub fn parse_trait_ref_data<'tcx, F>(data: &[u8], crate_num: ast::CrateNum, pos:
     F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
 {
     debug!("parse_trait_ref_data {}", data_log_string(data, pos));
-    let mut st = PState::new(data, crate_num, pos, tcx, &mut conv);
+    let mut st = TyDecoder::new(data, crate_num, pos, tcx, &mut conv);
     st.parse_trait_ref()
 }
 
@@ -112,7 +112,7 @@ pub fn parse_substs_data<'tcx, F>(data: &[u8], crate_num: ast::CrateNum, pos: us
     F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
 {
     debug!("parse_substs_data{}", data_log_string(data, pos));
-    let mut st = PState::new(data, crate_num, pos, tcx, &mut conv);
+    let mut st = TyDecoder::new(data, crate_num, pos, tcx, &mut conv);
     st.parse_substs()
 }
 
@@ -121,7 +121,7 @@ pub fn parse_existential_bounds_data<'tcx, F>(data: &[u8], crate_num: ast::Crate
                                               -> ty::ExistentialBounds<'tcx> where
     F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
 {
-    let mut st = PState::new(data, crate_num, pos, tcx, &mut conv);
+    let mut st = TyDecoder::new(data, crate_num, pos, tcx, &mut conv);
     st.parse_existential_bounds()
 }
 
@@ -130,7 +130,7 @@ pub fn parse_builtin_bounds_data<F>(data: &[u8], crate_num: ast::CrateNum,
                                     -> ty::BuiltinBounds where
     F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
 {
-    let mut st = PState::new(data, crate_num, pos, tcx, &mut conv);
+    let mut st = TyDecoder::new(data, crate_num, pos, tcx, &mut conv);
     st.parse_builtin_bounds()
 }
 
@@ -139,7 +139,7 @@ pub fn parse_type_param_def_data<'tcx, F>(data: &[u8], start: usize,
                                           mut conv: F) -> ty::TypeParameterDef<'tcx> where
     F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
 {
-    let mut st = PState::new(data, crate_num, start, tcx, &mut conv);
+    let mut st = TyDecoder::new(data, crate_num, start, tcx, &mut conv);
     st.parse_type_param_def()
 }
 
@@ -151,13 +151,13 @@ pub fn parse_predicate_data<'tcx, F>(data: &[u8],
                                      -> ty::Predicate<'tcx> where
     F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
 {
-    let mut st = PState::new(data, crate_num, start, tcx, &mut conv);
+    let mut st = TyDecoder::new(data, crate_num, start, tcx, &mut conv);
     st.parse_predicate()
 }
 
 pub type DefIdConvert<'a> = &'a mut FnMut(DefIdSource, ast::DefId) -> ast::DefId;
 
-pub struct PState<'a, 'tcx: 'a> {
+pub struct TyDecoder<'a, 'tcx: 'a> {
     data: &'a [u8],
     krate: ast::CrateNum,
     pos: usize,
@@ -165,14 +165,14 @@ pub struct PState<'a, 'tcx: 'a> {
     conv_def_id: DefIdConvert<'a>,
 }
 
-impl<'a,'tcx> PState<'a,'tcx> {
+impl<'a,'tcx> TyDecoder<'a,'tcx> {
     pub fn new(data: &'a [u8],
                crate_num: ast::CrateNum,
                pos: usize,
                tcx: &'a ty::ctxt<'tcx>,
                conv: DefIdConvert<'a>)
-               -> PState<'a, 'tcx> {
-        PState {
+               -> TyDecoder<'a, 'tcx> {
+        TyDecoder {
             data: data,
             krate: crate_num,
             pos: pos,
@@ -231,7 +231,7 @@ impl<'a,'tcx> PState<'a,'tcx> {
     }
 
     fn parse_vec_per_param_space<T, F>(&mut self, mut f: F) -> VecPerParamSpace<T> where
-        F: FnMut(&mut PState<'a, 'tcx>) -> T,
+        F: FnMut(&mut TyDecoder<'a, 'tcx>) -> T,
     {
         let mut r = VecPerParamSpace::empty();
         for &space in &subst::ParamSpace::all() {
@@ -374,7 +374,7 @@ impl<'a,'tcx> PState<'a,'tcx> {
     }
 
     fn parse_opt<T, F>(&mut self, f: F) -> Option<T>
-        where F: FnOnce(&mut PState<'a, 'tcx>) -> T,
+        where F: FnOnce(&mut TyDecoder<'a, 'tcx>) -> T,
     {
         match self.next() {
             'n' => None,
@@ -503,11 +503,11 @@ impl<'a,'tcx> PState<'a,'tcx> {
                     None => {}
                 }
 
-                let mut substate = PState::new(self.data,
-                                               self.krate,
-                                               pos,
-                                               self.tcx,
-                                               self.conv_def_id);
+                let mut substate = TyDecoder::new(self.data,
+                                                  self.krate,
+                                                  pos,
+                                                  self.tcx,
+                                                  self.conv_def_id);
                 let tt = substate.parse_ty();
                 tcx.rcache.borrow_mut().insert(key, tt);
                 return tt;

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -211,7 +211,7 @@ impl<'a,'tcx> PState<'a,'tcx> {
         return &self.data[start_pos..end_pos];
     }
 
-    pub fn parse_name(&mut self, last: char) -> ast::Name {
+    fn parse_name(&mut self, last: char) -> ast::Name {
         fn is_last(b: char, c: char) -> bool { return c == b; }
         let bytes = self.scan(|a| is_last(last, a));
         token::intern(str::from_utf8(bytes).unwrap())
@@ -655,7 +655,7 @@ impl<'a,'tcx> PState<'a,'tcx> {
                               variadic: variadic})
     }
 
-    pub fn parse_predicate(&mut self) -> ty::Predicate<'tcx> {
+    fn parse_predicate(&mut self) -> ty::Predicate<'tcx> {
         match self.next() {
             't' => ty::Binder(self.parse_trait_ref()).to_predicate(),
             'e' => ty::Binder(ty::EquatePredicate(self.parse_ty(),
@@ -784,7 +784,7 @@ fn data_log_string(data: &[u8], pos: usize) -> String {
 }
 
 // Rust metadata parsing
-pub fn parse_defid(buf: &[u8]) -> ast::DefId {
+fn parse_defid(buf: &[u8]) -> ast::DefId {
     let mut colon_idx = 0;
     let len = buf.len();
     while colon_idx < len && buf[colon_idx] != ':' as u8 { colon_idx += 1; }

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -58,104 +58,6 @@ pub enum DefIdSource {
     ClosureSource
 }
 
-pub fn parse_ty_closure_data<'tcx, F>(data: &[u8],
-                                      crate_num: ast::CrateNum,
-                                      pos: usize,
-                                      tcx: &ty::ctxt<'tcx>,
-                                      mut conv: F)
-                                      -> ty::ClosureTy<'tcx> where
-    F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
-{
-    let mut st = TyDecoder::new(data, crate_num, pos, tcx, &mut conv);
-    st.parse_closure_ty()
-}
-
-pub fn parse_ty_data<'tcx, F>(data: &[u8], crate_num: ast::CrateNum, pos: usize,
-                              tcx: &ty::ctxt<'tcx>, mut conv: F) -> Ty<'tcx> where
-    F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
-{
-    debug!("parse_ty_data {}", data_log_string(data, pos));
-    let mut st = TyDecoder::new(data, crate_num, pos, tcx, &mut conv);
-    st.parse_ty()
-}
-
-pub fn parse_region_data<F>(data: &[u8], crate_num: ast::CrateNum, pos: usize, tcx: &ty::ctxt,
-                            mut conv: F) -> ty::Region where
-    F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
-{
-    debug!("parse_region_data {}", data_log_string(data, pos));
-    let mut st = TyDecoder::new(data, crate_num, pos, tcx, &mut conv);
-    st.parse_region()
-}
-
-pub fn parse_bare_fn_ty_data<'tcx, F>(data: &[u8], crate_num: ast::CrateNum, pos: usize,
-                                      tcx: &ty::ctxt<'tcx>, mut conv: F)
-                                      -> ty::BareFnTy<'tcx> where
-    F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
-{
-    debug!("parse_bare_fn_ty_data {}", data_log_string(data, pos));
-    let mut st = TyDecoder::new(data, crate_num, pos, tcx, &mut conv);
-    st.parse_bare_fn_ty()
-}
-
-pub fn parse_trait_ref_data<'tcx, F>(data: &[u8], crate_num: ast::CrateNum, pos: usize,
-                                     tcx: &ty::ctxt<'tcx>, mut conv: F)
-                                     -> ty::TraitRef<'tcx> where
-    F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
-{
-    debug!("parse_trait_ref_data {}", data_log_string(data, pos));
-    let mut st = TyDecoder::new(data, crate_num, pos, tcx, &mut conv);
-    st.parse_trait_ref()
-}
-
-pub fn parse_substs_data<'tcx, F>(data: &[u8], crate_num: ast::CrateNum, pos: usize,
-                                  tcx: &ty::ctxt<'tcx>, mut conv: F) -> subst::Substs<'tcx> where
-    F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
-{
-    debug!("parse_substs_data{}", data_log_string(data, pos));
-    let mut st = TyDecoder::new(data, crate_num, pos, tcx, &mut conv);
-    st.parse_substs()
-}
-
-pub fn parse_existential_bounds_data<'tcx, F>(data: &[u8], crate_num: ast::CrateNum,
-                                              pos: usize, tcx: &ty::ctxt<'tcx>, mut conv: F)
-                                              -> ty::ExistentialBounds<'tcx> where
-    F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
-{
-    let mut st = TyDecoder::new(data, crate_num, pos, tcx, &mut conv);
-    st.parse_existential_bounds()
-}
-
-pub fn parse_builtin_bounds_data<F>(data: &[u8], crate_num: ast::CrateNum,
-                                    pos: usize, tcx: &ty::ctxt, mut conv: F)
-                                    -> ty::BuiltinBounds where
-    F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
-{
-    let mut st = TyDecoder::new(data, crate_num, pos, tcx, &mut conv);
-    st.parse_builtin_bounds()
-}
-
-pub fn parse_type_param_def_data<'tcx, F>(data: &[u8], start: usize,
-                                          crate_num: ast::CrateNum, tcx: &ty::ctxt<'tcx>,
-                                          mut conv: F) -> ty::TypeParameterDef<'tcx> where
-    F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
-{
-    let mut st = TyDecoder::new(data, crate_num, start, tcx, &mut conv);
-    st.parse_type_param_def()
-}
-
-pub fn parse_predicate_data<'tcx, F>(data: &[u8],
-                                     start: usize,
-                                     crate_num: ast::CrateNum,
-                                     tcx: &ty::ctxt<'tcx>,
-                                     mut conv: F)
-                                     -> ty::Predicate<'tcx> where
-    F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
-{
-    let mut st = TyDecoder::new(data, crate_num, start, tcx, &mut conv);
-    st.parse_predicate()
-}
-
 pub type DefIdConvert<'a> = &'a mut FnMut(DefIdSource, ast::DefId) -> ast::DefId;
 
 pub struct TyDecoder<'a, 'tcx: 'a> {
@@ -292,7 +194,7 @@ impl<'a,'tcx> TyDecoder<'a,'tcx> {
         }
     }
 
-    fn parse_region(&mut self) -> ty::Region {
+    pub fn parse_region(&mut self) -> ty::Region {
         match self.next() {
             'b' => {
                 assert_eq!(self.next(), '[');
@@ -629,7 +531,7 @@ impl<'a,'tcx> TyDecoder<'a,'tcx> {
         }
     }
 
-    fn parse_bare_fn_ty(&mut self) -> ty::BareFnTy<'tcx> {
+    pub fn parse_bare_fn_ty(&mut self) -> ty::BareFnTy<'tcx> {
         let unsafety = parse_unsafety(self.next());
         let abi = self.parse_abi_set();
         let sig = self.parse_sig();
@@ -775,21 +677,6 @@ impl<'a,'tcx> TyDecoder<'a,'tcx> {
             }
         }
     }
-}
-
-fn data_log_string(data: &[u8], pos: usize) -> String {
-    let mut buf = String::new();
-    buf.push_str("<<");
-    for i in pos..data.len() {
-        let c = data[i];
-        if c > 0x20 && c <= 0x7F {
-            buf.push(c as char);
-        } else {
-            buf.push('.');
-        }
-    }
-    buf.push_str(">>");
-    buf
 }
 
 // Rust metadata parsing

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -1252,11 +1252,9 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
     fn read_substs<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>)
                            -> subst::Substs<'tcx> {
         self.read_opaque(|this, doc| {
-            Ok(tydecode::parse_substs_data(doc.data,
-                                           dcx.cdata.cnum,
-                                           doc.start,
-                                           dcx.tcx,
-                                           |s, a| this.convert_def_id(dcx, s, a)))
+            Ok(tydecode::TyDecoder::with_doc(dcx.tcx, dcx.cdata.cnum, doc,
+                                             &mut |s, a| this.convert_def_id(dcx, s, a))
+               .parse_substs())
         }).unwrap()
     }
 

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -17,16 +17,17 @@ use metadata::common as c;
 use metadata::cstore as cstore;
 use session::Session;
 use metadata::decoder;
-use middle::def;
 use metadata::encoder as e;
-use middle::region;
+use metadata::inline::{InlinedItem, InlinedItemRef};
 use metadata::tydecode;
 use metadata::tydecode::{DefIdSource, NominalType, TypeWithId};
 use metadata::tydecode::{RegionParameter, ClosureSource};
 use metadata::tyencode;
 use middle::cast;
 use middle::check_const::ConstQualif;
+use middle::def;
 use middle::privacy::{AllPublic, LastMod};
+use middle::region;
 use middle::subst;
 use middle::subst::VecPerParamSpace;
 use middle::ty::{self, Ty};
@@ -75,12 +76,12 @@ trait tr_intern {
 
 pub fn encode_inlined_item(ecx: &e::EncodeContext,
                            rbml_w: &mut Encoder,
-                           ii: e::InlinedItemRef) {
+                           ii: InlinedItemRef) {
     let id = match ii {
-        e::IIItemRef(i) => i.id,
-        e::IIForeignRef(i) => i.id,
-        e::IITraitItemRef(_, ti) => ti.id,
-        e::IIImplItemRef(_, ii) => ii.id,
+        InlinedItemRef::Item(i) => i.id,
+        InlinedItemRef::Foreign(i) => i.id,
+        InlinedItemRef::TraitItem(_, ti) => ti.id,
+        InlinedItemRef::ImplItem(_, ii) => ii.id,
     };
     debug!("> Encoding inlined item: {} ({:?})",
            ecx.tcx.map.path_to_string(id),
@@ -88,7 +89,7 @@ pub fn encode_inlined_item(ecx: &e::EncodeContext,
 
     // Folding could be avoided with a smarter encoder.
     let ii = simplify_ast(ii);
-    let id_range = ast_util::compute_id_range_for_inlined_item(&ii);
+    let id_range = ii.compute_id_range();
 
     rbml_w.start_tag(c::tag_ast as usize);
     id_range.encode(rbml_w);
@@ -124,7 +125,7 @@ pub fn decode_inlined_item<'tcx>(cdata: &cstore::crate_metadata,
                                  tcx: &ty::ctxt<'tcx>,
                                  path: Vec<ast_map::PathElem>,
                                  par_doc: rbml::Doc)
-                                 -> Result<&'tcx ast::InlinedItem, Vec<ast_map::PathElem>> {
+                                 -> Result<&'tcx InlinedItem, Vec<ast_map::PathElem>> {
     match par_doc.opt_child(c::tag_ast) {
       None => Err(path),
       Some(ast_doc) => {
@@ -150,10 +151,10 @@ pub fn decode_inlined_item<'tcx>(cdata: &cstore::crate_metadata,
         let ii = ast_map::map_decoded_item(&dcx.tcx.map, path, raw_ii, dcx);
 
         let ident = match *ii {
-            ast::IIItem(ref i) => i.ident,
-            ast::IIForeign(ref i) => i.ident,
-            ast::IITraitItem(_, ref ti) => ti.ident,
-            ast::IIImplItem(_, ref ii) => ii.ident
+            InlinedItem::Item(ref i) => i.ident,
+            InlinedItem::Foreign(ref i) => i.ident,
+            InlinedItem::TraitItem(_, ref ti) => ti.ident,
+            InlinedItem::ImplItem(_, ref ii) => ii.ident
         };
         debug!("Fn named: {}", ident);
         debug!("< Decoded inlined fn: {}::{}",
@@ -162,7 +163,7 @@ pub fn decode_inlined_item<'tcx>(cdata: &cstore::crate_metadata,
         region::resolve_inlined_item(&tcx.sess, &tcx.region_maps, ii);
         decode_side_tables(dcx, ast_doc);
         match *ii {
-          ast::IIItem(ref i) => {
+          InlinedItem::Item(ref i) => {
             debug!(">>> DECODED ITEM >>>\n{}\n<<< DECODED ITEM <<<",
                    syntax::print::pprust::item_to_string(&**i));
           }
@@ -349,7 +350,7 @@ impl<D:serialize::Decoder> def_id_decoder_helpers for D
 // We also have to adjust the spans: for now we just insert a dummy span,
 // but eventually we should add entries to the local codemap as required.
 
-fn encode_ast(rbml_w: &mut Encoder, item: &ast::InlinedItem) {
+fn encode_ast(rbml_w: &mut Encoder, item: &InlinedItem) {
     rbml_w.start_tag(c::tag_tree as usize);
     item.encode(rbml_w);
     rbml_w.end_tag();
@@ -399,34 +400,34 @@ impl Folder for NestedItemsDropper {
 // As it happens, trans relies on the fact that we do not export
 // nested items, as otherwise it would get confused when translating
 // inlined items.
-fn simplify_ast(ii: e::InlinedItemRef) -> ast::InlinedItem {
+fn simplify_ast(ii: InlinedItemRef) -> InlinedItem {
     let mut fld = NestedItemsDropper;
 
     match ii {
         // HACK we're not dropping items.
-        e::IIItemRef(i) => {
-            ast::IIItem(fold::noop_fold_item(P(i.clone()), &mut fld)
+        InlinedItemRef::Item(i) => {
+            InlinedItem::Item(fold::noop_fold_item(P(i.clone()), &mut fld)
                             .expect_one("expected one item"))
         }
-        e::IITraitItemRef(d, ti) => {
-            ast::IITraitItem(d,
+        InlinedItemRef::TraitItem(d, ti) => {
+            InlinedItem::TraitItem(d,
                 fold::noop_fold_trait_item(P(ti.clone()), &mut fld)
                     .expect_one("noop_fold_trait_item must produce \
                                  exactly one trait item"))
         }
-        e::IIImplItemRef(d, ii) => {
-            ast::IIImplItem(d,
+        InlinedItemRef::ImplItem(d, ii) => {
+            InlinedItem::ImplItem(d,
                 fold::noop_fold_impl_item(P(ii.clone()), &mut fld)
                     .expect_one("noop_fold_impl_item must produce \
                                  exactly one impl item"))
         }
-        e::IIForeignRef(i) => {
-            ast::IIForeign(fold::noop_fold_foreign_item(P(i.clone()), &mut fld))
+        InlinedItemRef::Foreign(i) => {
+            InlinedItem::Foreign(fold::noop_fold_foreign_item(P(i.clone()), &mut fld))
         }
     }
 }
 
-fn decode_ast(par_doc: rbml::Doc) -> ast::InlinedItem {
+fn decode_ast(par_doc: rbml::Doc) -> InlinedItem {
     let chi_doc = par_doc.get(c::tag_tree as usize);
     let mut d = reader::Decoder::new(chi_doc);
     Decodable::decode(&mut d).unwrap()
@@ -920,9 +921,9 @@ impl<'a, 'b, 'c, 'tcx> ast_util::IdVisitingOperation for
 
 fn encode_side_tables_for_ii(ecx: &e::EncodeContext,
                              rbml_w: &mut Encoder,
-                             ii: &ast::InlinedItem) {
+                             ii: &InlinedItem) {
     rbml_w.start_tag(c::tag_table as usize);
-    ast_util::visit_ids_for_inlined_item(ii, &mut SideTableEncodingIdVisitor {
+    ii.visit_ids(&mut SideTableEncodingIdVisitor {
         ecx: ecx,
         rbml_w: rbml_w
     });
@@ -1644,15 +1645,15 @@ fn test_simplification() {
             return alist {eq_fn: eq_int, data: Vec::new()};
         }
     ).unwrap();
-    let item_in = e::IIItemRef(&*item);
+    let item_in = InlinedItemRef::Item(&*item);
     let item_out = simplify_ast(item_in);
-    let item_exp = ast::IIItem(quote_item!(&cx,
+    let item_exp = InlinedItem::Item(quote_item!(&cx,
         fn new_int_alist<B>() -> alist<isize, B> {
             return alist {eq_fn: eq_int, data: Vec::new()};
         }
     ).unwrap());
     match (item_out, item_exp) {
-      (ast::IIItem(item_out), ast::IIItem(item_exp)) => {
+      (InlinedItem::Item(item_out), InlinedItem::Item(item_exp)) => {
         assert!(pprust::item_to_string(&*item_out) ==
                 pprust::item_to_string(&*item_exp));
       }

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -17,8 +17,9 @@
 //! `middle/typeck/infer/region_inference.rs`
 
 use ast_map;
-use session::Session;
+use metadata::inline::InlinedItem;
 use middle::ty::{self, Ty};
+use session::Session;
 use util::nodemap::{FnvHashMap, FnvHashSet, NodeMap};
 
 use std::cell::RefCell;
@@ -1231,7 +1232,7 @@ pub fn resolve_crate(sess: &Session, krate: &ast::Crate) -> RegionMaps {
 
 pub fn resolve_inlined_item(sess: &Session,
                             region_maps: &RegionMaps,
-                            item: &ast::InlinedItem) {
+                            item: &InlinedItem) {
     let mut visitor = RegionResolutionVisitor {
         sess: sess,
         region_maps: region_maps,
@@ -1241,5 +1242,5 @@ pub fn resolve_inlined_item(sess: &Session,
             var_parent: InnermostDeclaringBlock::None
         }
     };
-    visit::walk_inlined_item(&mut visitor, item);
+    item.visit(&mut visitor);
 }

--- a/src/librustc_trans/trans/inline.rs
+++ b/src/librustc_trans/trans/inline.rs
@@ -10,6 +10,7 @@
 
 use llvm::{AvailableExternallyLinkage, InternalLinkage, SetLinkage};
 use metadata::csearch;
+use metadata::inline::InlinedItem;
 use middle::astencode;
 use middle::subst::Substs;
 use trans::base::{push_ctxt, trans_item, get_item_val, trans_fn};
@@ -48,7 +49,7 @@ fn instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
             ccx.external().borrow_mut().insert(fn_id, None);
             return None;
         }
-        csearch::FoundAst::Found(&ast::IIItem(ref item)) => {
+        csearch::FoundAst::Found(&InlinedItem::Item(ref item)) => {
             ccx.external().borrow_mut().insert(fn_id, Some(item.id));
             ccx.external_srcs().borrow_mut().insert(item.id, fn_id);
 
@@ -91,12 +92,12 @@ fn instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
 
             item.id
         }
-        csearch::FoundAst::Found(&ast::IIForeign(ref item)) => {
+        csearch::FoundAst::Found(&InlinedItem::Foreign(ref item)) => {
             ccx.external().borrow_mut().insert(fn_id, Some(item.id));
             ccx.external_srcs().borrow_mut().insert(item.id, fn_id);
             item.id
         }
-        csearch::FoundAst::FoundParent(parent_id, &ast::IIItem(ref item)) => {
+        csearch::FoundAst::FoundParent(parent_id, &InlinedItem::Item(ref item)) => {
             ccx.external().borrow_mut().insert(parent_id, Some(item.id));
             ccx.external_srcs().borrow_mut().insert(item.id, parent_id);
 
@@ -131,7 +132,7 @@ fn instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
             ccx.sess().bug("maybe_get_item_ast returned a FoundParent \
                             with a non-item parent");
         }
-        csearch::FoundAst::Found(&ast::IITraitItem(_, ref trait_item)) => {
+        csearch::FoundAst::Found(&InlinedItem::TraitItem(_, ref trait_item)) => {
             ccx.external().borrow_mut().insert(fn_id, Some(trait_item.id));
             ccx.external_srcs().borrow_mut().insert(trait_item.id, fn_id);
 
@@ -150,7 +151,7 @@ fn instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
             // don't.
             trait_item.id
         }
-        csearch::FoundAst::Found(&ast::IIImplItem(impl_did, ref impl_item)) => {
+        csearch::FoundAst::Found(&InlinedItem::ImplItem(impl_did, ref impl_item)) => {
             ccx.external().borrow_mut().insert(fn_id, Some(impl_item.id));
             ccx.external_srcs().borrow_mut().insert(impl_item.id, fn_id);
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -23,7 +23,6 @@ pub use self::FloatTy::*;
 pub use self::FunctionRetTy::*;
 pub use self::ForeignItem_::*;
 pub use self::ImplItem_::*;
-pub use self::InlinedItem::*;
 pub use self::IntTy::*;
 pub use self::Item_::*;
 pub use self::KleeneOp::*;
@@ -1923,17 +1922,6 @@ impl ForeignItem_ {
             ForeignItemStatic(..) => "foreign static item"
         }
     }
-}
-
-/// The data we save and restore about an inlined item or method.  This is not
-/// part of the AST that we parse from a file, but it becomes part of the tree
-/// that we trans.
-#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
-pub enum InlinedItem {
-    IIItem(P<Item>),
-    IITraitItem(DefId /* impl id */, P<TraitItem>),
-    IIImplItem(DefId /* impl id */, P<ImplItem>),
-    IIForeign(P<ForeignItem>),
 }
 
 /// A macro definition, in this crate or imported from another.

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -142,17 +142,6 @@ pub trait Visitor<'v> : Sized {
     fn visit_attribute(&mut self, _attr: &'v Attribute) {}
 }
 
-pub fn walk_inlined_item<'v,V>(visitor: &mut V, item: &'v InlinedItem)
-                         where V: Visitor<'v> {
-    match *item {
-        IIItem(ref i) => visitor.visit_item(&**i),
-        IIForeign(ref i) => visitor.visit_foreign_item(&**i),
-        IITraitItem(_, ref ti) => visitor.visit_trait_item(ti),
-        IIImplItem(_, ref ii) => visitor.visit_impl_item(ii),
-    }
-}
-
-
 pub fn walk_crate<'v, V: Visitor<'v>>(visitor: &mut V, krate: &'v Crate) {
     visitor.visit_mod(&krate.module, krate.span, CRATE_NODE_ID);
     for attr in &krate.attrs {


### PR DESCRIPTION
Just a little code cleanup I was doing as part of another refactoring (which may turn out not to be needed). The main thrust of this is to cleanup the interface to `tydecode.rs` to be less ridiculously repetitive. I also purged the generic "def-id conversion" parameter in favor of a trait object, just to reduce code duplication a bit and make the signatures a bit less messy. I measured the bootstrapping time to build stage2 with these changes, it was identical. (But it'd be easy enough to restore the unboxed closure if we wanted it.)
