### PR TITLE
Add macros for getting values of configuration flags

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -290,6 +290,79 @@ pub mod builtin {
         ($($e:ident),*) => ({ /* compiler built-in */ })
     }
 
+    /// Gets a configuration flag as an integer literal.
+    ///
+    /// This macro takes a configuration flag name as its only argument
+    /// and evaluates its value, returning it as an integer.
+    ///
+    /// Note that the macro expands to an integer with no suffix and no
+    /// specific integer type (i.e. `let val = 5`). This means that the
+    /// type inference engine will decide the type of the integer unless
+    /// it is explicitly specified.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(cfg_values)]
+    ///
+    /// # fn main() {
+    /// One boolean for every bit in a pointer.
+    /// let vals = [false; cfg_int!(target_pointer_width)];
+    ///
+    /// // On a 64-bit system, prints 64, etc
+    /// println!("Total bit count: {}", vals.len());
+    ///
+    /// for (i,val) in vals.iter().enumerate() {
+    ///     println!("Bit {} is {}", i, val);
+    /// }
+    /// # }
+    /// ```
+    #[macro_export]
+    macro_rules! cfg_int {
+        ($name:ident) => ({ /* compiler built-in */ })
+    }
+
+    /// Gets a configuration flag as a floating point literal.
+    /// This macro takes a configuration flag name as its only argument
+    /// and evaluates its value, returning it as a float.
+    ///
+    /// Note that the macro expands to a float with no suffix and no
+    /// specific floating point type (i.e. `let val = 5.0`). This means
+    /// that the type inference engine will decide the type of the float
+    /// (`f32` vs `f64`) unless it is explicitly specified.
+    #[macro_export]
+    macro_rules! cfg_float {
+        ($name:ident) => ({ /* compiler built-in */ })
+    }
+
+    /// Gets a configuration flag as a string literal.
+    /// This macro takes a configuration flag name as its only argument
+    /// and evaluates its value, returning it as a string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(cfg_values)]
+    ///
+    /// const TARGET_OS: &'static str = cfg_str!(target_os);
+    /// const TARGET_FAMILY: &'static str = cfg_str!(target_family);
+    /// const TARGET_ARCH: &'static str = cfg_str!(target_arch);
+    /// const TARGET_ENDIAN: &'static str = cfg_str!(target_endian);
+    /// const TARGET_ENV: &'static str = cfg_str!(target_env);
+    ///
+    /// fn main() {
+    ///     println!("OS: {}", TARGET_OS);
+    ///     println!("Family: {}", TARGET_FAMILY);
+    ///     println!("Architecture: {}", TARGET_ARCH);
+    ///     println!("Endianness: {}", TARGET_ENDIAN);
+    ///     println!("Target envionment: {}", TARGET_ENV);
+    /// }
+    /// ```
+    #[macro_export]
+    macro_rules! cfg_str {
+        ($name:ident) => ({ /* compiler built-in */ })
+    }
+
     /// Concatenates literals into a static string slice.
     ///
     /// This macro takes any number of comma-separated literals, yielding an

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -306,7 +306,7 @@ pub mod builtin {
     /// #![feature(cfg_values)]
     ///
     /// # fn main() {
-    /// One boolean for every bit in a pointer.
+    /// // One boolean for every bit in a pointer.
     /// let vals = [false; cfg_int!(target_pointer_width)];
     ///
     /// // On a 64-bit system, prints 64, etc

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -611,6 +611,9 @@ fn initial_syntax_expander_table<'feat>(ecfg: &expand::ExpansionConfig<'feat>)
     syntax_expanders.insert(intern("cfg"),
                             builtin_normal_expander(
                                     ext::cfg::expand_cfg));
+    syntax_expanders.insert(intern("cfg_int"),
+                            builtin_normal_expander(
+                                    ext::cfg::expand_cfg_int));
     syntax_expanders.insert(intern("push_unsafe"),
                             builtin_normal_expander(
                                 ext::pushpop_safe::expand_push_unsafe));

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -614,6 +614,9 @@ fn initial_syntax_expander_table<'feat>(ecfg: &expand::ExpansionConfig<'feat>)
     syntax_expanders.insert(intern("cfg_int"),
                             builtin_normal_expander(
                                     ext::cfg::expand_cfg_int));
+    syntax_expanders.insert(intern("cfg_str"),
+                            builtin_normal_expander(
+                                    ext::cfg::expand_cfg_str));
     syntax_expanders.insert(intern("push_unsafe"),
                             builtin_normal_expander(
                                 ext::pushpop_safe::expand_push_unsafe));

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -614,6 +614,9 @@ fn initial_syntax_expander_table<'feat>(ecfg: &expand::ExpansionConfig<'feat>)
     syntax_expanders.insert(intern("cfg_int"),
                             builtin_normal_expander(
                                     ext::cfg::expand_cfg_int));
+    syntax_expanders.insert(intern("cfg_float"),
+                            builtin_normal_expander(
+                                    ext::cfg::expand_cfg_float));
     syntax_expanders.insert(intern("cfg_str"),
                             builtin_normal_expander(
                                     ext::cfg::expand_cfg_str));

--- a/src/libsyntax/ext/cfg.rs
+++ b/src/libsyntax/ext/cfg.rs
@@ -143,7 +143,7 @@ pub fn expand_cfg_val(cx: &mut ExtCtxt,
                     unreachable!();
                 },
                 None => { // the cfg is not defined
-                    cx.span_err(cfg.span, "configuration flag is not set");
+                    cx.span_err(cfg.span, "configuration flag does not have a value");
                     None
                 }
             }

--- a/src/libsyntax/ext/cfg.rs
+++ b/src/libsyntax/ext/cfg.rs
@@ -20,20 +20,114 @@ use ext::build::AstBuilder;
 use attr;
 use attr::*;
 use parse::attr::ParserAttr;
-use parse::token;
+use parse::token::{self,InternedString};
+use ptr::P;
 
 pub fn expand_cfg<'cx>(cx: &mut ExtCtxt,
                        sp: Span,
                        tts: &[ast::TokenTree])
                        -> Box<base::MacResult+'static> {
+
+    let cfg = match get_cfg_meta_item(cx, sp, tts) {
+        Some(cfg) => cfg,
+        None => { return DummyResult::expr(sp); },
+    };
+
+    let matches_cfg = attr::cfg_matches(&cx.parse_sess.span_diagnostic, &cx.cfg, &*cfg);
+    MacEager::expr(cx.expr_bool(sp, matches_cfg))
+}
+
+pub fn expand_cfg_int(cx: &mut ExtCtxt,
+                      sp: Span,
+                      tts: &[ast::TokenTree])
+                      -> Box<base::MacResult+'static> {
+
+    match expand_cfg_val(cx, sp, tts) {
+        Some(val) => {
+            match val.parse::<i64>() {
+                Ok(i) => {
+
+                    let sign = if i < 0 { ast::Minus } else { ast::Plus };
+                    let magnitude = i.abs() as u64;
+
+                    let ty = ast::UnsuffixedIntLit(sign);
+                    let lit = ast::LitInt(magnitude, ty);
+
+                    MacEager::expr(cx.expr_lit(sp, lit))
+                },
+                Err(..) => {
+                    cx.span_err(sp, &format!("{} is not an integer", val));
+                    DummyResult::expr(sp)
+                },
+            }
+        },
+        None => {
+            DummyResult::expr(sp)
+        }
+    }
+}
+
+pub fn expand_cfg_val(cx: &mut ExtCtxt,
+                      sp: Span,
+                      tts: &[ast::TokenTree])
+                      -> Option<InternedString> {
+
+    let cfg = match get_cfg_meta_item(cx, sp, tts) {
+        Some(cfg) => cfg,
+        None => { return None; },
+    };
+
+    match cfg.node {
+        ast::MetaList(..) |
+        ast::MetaNameValue(..) => {
+            cx.span_err(cfg.span, "expected a single configuration flag name");
+            return None;
+        },
+        ast::MetaWord(ref cfg_name) => {
+
+            // Look for the CFG meta item with the specified name.
+            let item = cx.cfg.iter().find(|item| {
+                if let ast::MetaNameValue(ref name,_) = item.node {
+                    cfg_name == name
+                } else {
+                    false
+                }
+            });
+
+            match item.map(|ref a| &a.node) {
+                // The CFG was found
+                Some(&ast::MetaNameValue(_, ref lit))=> {
+                    if let ast::LitStr(ref val, _) = lit.node {
+                        Some(val.clone())
+                    } else {
+                        // CFG values are always textual
+                        unreachable!();
+                    }
+                },
+                Some(_) => {
+                    unreachable!();
+                },
+                None => { // the cfg is not defined
+                    cx.span_err(cfg.span, "configuration flag is not set");
+                    None
+                }
+            }
+        }
+    }
+}
+
+fn get_cfg_meta_item(cx: &mut ExtCtxt,
+                     sp: Span,
+                     tts: &[ast::TokenTree])
+                     -> Option<P<ast::MetaItem>> {
     let mut p = cx.new_parser_from_tts(tts);
     let cfg = p.parse_meta_item();
 
     if !panictry!(p.eat(&token::Eof)){
         cx.span_err(sp, "expected 1 cfg-pattern");
-        return DummyResult::expr(sp);
+        None
+    } else {
+        Some(cfg)
     }
 
-    let matches_cfg = attr::cfg_matches(&cx.parse_sess.span_diagnostic, &cx.cfg, &*cfg);
-    MacEager::expr(cx.expr_bool(sp, matches_cfg))
-}
+} 

--- a/src/libsyntax/ext/cfg.rs
+++ b/src/libsyntax/ext/cfg.rs
@@ -67,6 +67,17 @@ pub fn expand_cfg_int(cx: &mut ExtCtxt,
     }
 }
 
+pub fn expand_cfg_str(cx: &mut ExtCtxt,
+                      sp: Span,
+                      tts: &[ast::TokenTree])
+                      -> Box<base::MacResult+'static> {
+
+    match expand_cfg_val(cx, sp, tts) {
+        Some(val) => MacEager::expr(cx.expr_str(sp, val)),
+        None => DummyResult::expr(sp),
+    }
+}
+
 pub fn expand_cfg_val(cx: &mut ExtCtxt,
                       sp: Span,
                       tts: &[ast::TokenTree])

--- a/src/libsyntax/ext/cfg.rs
+++ b/src/libsyntax/ext/cfg.rs
@@ -183,5 +183,5 @@ fn parse_meta_item(cx: &mut ExtCtxt,
         Some(cfg)
     }
 
-} 
+}
 

--- a/src/libsyntax/ext/cfg.rs
+++ b/src/libsyntax/ext/cfg.rs
@@ -170,9 +170,9 @@ pub fn expand_cfg_val(cx: &mut ExtCtxt,
 }
 
 fn parse_meta_item(cx: &mut ExtCtxt,
-                     sp: Span,
-                     tts: &[ast::TokenTree])
-                     -> Option<P<ast::MetaItem>> {
+                   sp: Span,
+                   tts: &[ast::TokenTree])
+                   -> Option<P<ast::MetaItem>> {
     let mut p = cx.new_parser_from_tts(tts);
     let cfg = p.parse_meta_item();
 

--- a/src/libsyntax/ext/cfg.rs
+++ b/src/libsyntax/ext/cfg.rs
@@ -67,6 +67,30 @@ pub fn expand_cfg_int(cx: &mut ExtCtxt,
     }
 }
 
+pub fn expand_cfg_float(cx: &mut ExtCtxt,
+                        sp: Span,
+                        tts: &[ast::TokenTree])
+                        -> Box<base::MacResult+'static> {
+
+    match expand_cfg_val(cx, sp, tts) {
+        Some(val) => {
+            match val.parse::<f64>() {
+                Ok(..) => { // the string is a valid float
+                    let lit = ast::LitFloatUnsuffixed(val);
+                    MacEager::expr(cx.expr_lit(sp, lit))
+                },
+                Err(..) => {
+                    cx.span_err(sp, &format!("{} is not a float", val));
+                    DummyResult::expr(sp)
+                },
+            }
+        },
+        None => {
+           DummyResult::expr(sp)
+        },
+    }
+}
+
 pub fn expand_cfg_str(cx: &mut ExtCtxt,
                       sp: Span,
                       tts: &[ast::TokenTree])

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1675,6 +1675,7 @@ impl<'feat> ExpansionConfig<'feat> {
         fn enable_asm = allow_asm,
         fn enable_log_syntax = allow_log_syntax,
         fn enable_concat_idents = allow_concat_idents,
+        fn enable_cfg_values = allow_cfg_values,
         fn enable_trace_macros = allow_trace_macros,
         fn enable_allow_internal_unstable = allow_internal_unstable,
         fn enable_custom_derive = allow_custom_derive,

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -58,6 +58,7 @@ const KNOWN_FEATURES: &'static [(&'static str, &'static str, Status)] = &[
     ("log_syntax", "1.0.0", Active),
     ("trace_macros", "1.0.0", Active),
     ("concat_idents", "1.0.0", Active),
+    ("cfg_values", "1.2.0", Active),
     ("intrinsics", "1.0.0", Active),
     ("lang_items", "1.0.0", Active),
 
@@ -352,6 +353,7 @@ pub struct Features {
     pub allow_asm: bool,
     pub allow_log_syntax: bool,
     pub allow_concat_idents: bool,
+    pub allow_cfg_values: bool,
     pub allow_trace_macros: bool,
     pub allow_internal_unstable: bool,
     pub allow_custom_derive: bool,
@@ -381,6 +383,7 @@ impl Features {
             allow_asm: false,
             allow_log_syntax: false,
             allow_concat_idents: false,
+            allow_cfg_values: false,
             allow_trace_macros: false,
             allow_internal_unstable: false,
             allow_custom_derive: false,
@@ -520,6 +523,9 @@ pub const EXPLAIN_LOG_SYNTAX: &'static str =
 pub const EXPLAIN_CONCAT_IDENTS: &'static str =
     "`concat_idents` is not stable enough for use and is subject to change";
 
+pub const EXPLAIN_CFG_VALUES: &'static str =
+    "`cfg_values` is not stable enough for use and is subject to change";
+
 pub const EXPLAIN_TRACE_MACROS: &'static str =
     "`trace_macros` is not stable enough for use and is subject to change";
 pub const EXPLAIN_ALLOW_INTERNAL_UNSTABLE: &'static str =
@@ -559,6 +565,10 @@ impl<'a, 'v> Visitor<'v> for MacroVisitor<'a> {
 
         else if id == token::str_to_ident("concat_idents") {
             self.context.gate_feature("concat_idents", path.span, EXPLAIN_CONCAT_IDENTS);
+        }
+
+        else if id.name.as_str().starts_with("cfg_") {
+            self.context.gate_feature("cfg_values", path.span, EXPLAIN_CFG_VALUES);
         }
     }
 
@@ -885,6 +895,7 @@ fn check_crate_inner<F>(cm: &CodeMap, span_handler: &SpanHandler,
         allow_asm: cx.has_feature("asm"),
         allow_log_syntax: cx.has_feature("log_syntax"),
         allow_concat_idents: cx.has_feature("concat_idents"),
+        allow_cfg_values: cx.has_feature("cfg_values"),
         allow_trace_macros: cx.has_feature("trace_macros"),
         allow_internal_unstable: cx.has_feature("allow_internal_unstable"),
         allow_custom_derive: cx.has_feature("custom_derive"),

--- a/src/test/run-pass/cfg-val-macros.rs
+++ b/src/test/run-pass/cfg-val-macros.rs
@@ -1,0 +1,29 @@
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[cfg(target_pointer_width = "32")]
+const EXPECTED_PTR_WIDTH: u32 = 32;
+#[cfg(target_pointer_width = "64")]
+const EXPECTED_PTR_WIDTH: u32 = 64;
+
+#[cfg(target_pointer_width = "32")]
+const EXPECTED_PTR_WIDTH_STR: &'static str = "32";
+#[cfg(target_pointer_width = "64")]
+const EXPECTED_PTR_WIDTH_STR: &'static str = "64";
+
+fn main() {
+    let ptr_width_int = cfg_int!(target_pointer_width);
+    let ptr_width_str = cfg_str!(target_pointer_width);
+    let ptr_width_float = cfg_float!(target_pointer_width);
+
+    assert_eq!(ptr_width_int, EXPECTED_PTR_WIDTH);
+    assert_eq!(ptr_width_str, EXPECTED_PTR_WIDTH_STR);
+    assert_eq!(ptr_width_float as u32, EXPECTED_PTR_WIDTH);
+}

--- a/src/test/run-pass/cfg-val-macros.rs
+++ b/src/test/run-pass/cfg-val-macros.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(cfg_vals)]
+
 #[cfg(target_pointer_width = "32")]
 const EXPECTED_PTR_WIDTH: u32 = 32;
 #[cfg(target_pointer_width = "64")]

--- a/src/test/run-pass/cfg-val-macros.rs
+++ b/src/test/run-pass/cfg-val-macros.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(cfg_vals)]
+#![feature(cfg_values)]
 
 #[cfg(target_pointer_width = "32")]
 const EXPECTED_PTR_WIDTH: u32 = 32;


### PR DESCRIPTION
This PR adds the following macros:
- `cfg_int!(flag_name)`
- `cfg_float!(flag_name)`
- `cfg_str!(flag_name)`

Under the `cfg_values` feature gate.

The purpose of these macros is to add the ability to use configuration values directly in the code (i.e. as string literals or integer constants).

This allows code to be rewritten like so:

Previous `src/libcore/num/isize.rs`:

``` rust
#[cfg(target_pointer_width = "32")]
int_module! { isize, 32 }
#[cfg(target_pointer_width = "64")]
int_module! { isize, 64 }
```

New `src/libcore/num/isize.rs`:

``` rust
int_module! { isize, cfg_int!(target_pointer_width) }
```

If this lands, I plan on converting the rest of the Rust library to be independent of the current pointer width. This allows us to clean up a little bit of the `#[cfg(..)]` mess, and eases porting Rust to other architectures.
