### PR TITLE
Move the definition of `DefId` to librustc

### DIFF
--- a/src/librustc/ast_map/mod.rs
+++ b/src/librustc/ast_map/mod.rs
@@ -14,7 +14,7 @@ use self::MapEntry::*;
 
 use metadata::inline::InlinedItem;
 use metadata::inline::InlinedItem as II;
-use middle::def_id::{DefId, LOCAL_CRATE};
+use middle::def_id::DefId;
 use syntax::abi;
 use syntax::ast::*;
 use syntax::ast_util;
@@ -592,7 +592,7 @@ impl<'ast> Map<'ast> {
     }
 
     pub fn def_id_span(&self, def_id: DefId, fallback: Span) -> Span {
-        if def_id.krate == LOCAL_CRATE {
+        if def_id.is_local() {
             self.opt_span(def_id.node).unwrap_or(fallback)
         } else {
             fallback

--- a/src/librustc/ast_map/mod.rs
+++ b/src/librustc/ast_map/mod.rs
@@ -14,6 +14,7 @@ use self::MapEntry::*;
 
 use metadata::inline::InlinedItem;
 use metadata::inline::InlinedItem as II;
+use middle::def_id::{DefId, LOCAL_CRATE};
 use syntax::abi;
 use syntax::ast::*;
 use syntax::ast_util;
@@ -378,7 +379,7 @@ impl<'ast> Map<'ast> {
         match self.find_entry(parent) {
             Some(RootInlinedParent(&InlinedParent {ii: II::TraitItem(did, _), ..})) => did,
             Some(RootInlinedParent(&InlinedParent {ii: II::ImplItem(did, _), ..})) => did,
-            _ => ast_util::local_def(parent)
+            _ => DefId::local(parent)
         }
     }
 

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -118,6 +118,7 @@ pub mod middle {
     pub mod dataflow;
     pub mod dead;
     pub mod def;
+    pub mod def_id;
     pub mod dependency_format;
     pub mod effect;
     pub mod entry;

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -15,6 +15,7 @@ use metadata::common::*;
 use metadata::cstore;
 use metadata::decoder;
 use metadata::inline::InlinedItem;
+use middle::def_id::DefId;
 use middle::lang_items;
 use middle::ty;
 
@@ -30,11 +31,11 @@ use std::collections::hash_map::HashMap;
 #[derive(Copy, Clone)]
 pub struct MethodInfo {
     pub name: ast::Name,
-    pub def_id: ast::DefId,
+    pub def_id: DefId,
     pub vis: ast::Visibility,
 }
 
-pub fn get_symbol(cstore: &cstore::CStore, def: ast::DefId) -> String {
+pub fn get_symbol(cstore: &cstore::CStore, def: DefId) -> String {
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_symbol(cdata.data(), def.node)
 }
@@ -52,7 +53,7 @@ pub fn each_lang_item<F>(cstore: &cstore::CStore,
 
 /// Iterates over each child of the given item.
 pub fn each_child_of_item<F>(cstore: &cstore::CStore,
-                             def_id: ast::DefId,
+                             def_id: DefId,
                              callback: F) where
     F: FnMut(decoder::DefLike, ast::Name, ast::Visibility),
 {
@@ -83,7 +84,7 @@ pub fn each_top_level_item_of_crate<F>(cstore: &cstore::CStore,
                                           callback)
 }
 
-pub fn get_item_path(tcx: &ty::ctxt, def: ast::DefId) -> Vec<ast_map::PathElem> {
+pub fn get_item_path(tcx: &ty::ctxt, def: DefId) -> Vec<ast_map::PathElem> {
     let cstore = &tcx.sess.cstore;
     let cdata = cstore.get_crate_data(def.krate);
     let path = decoder::get_item_path(&*cdata, def.node);
@@ -96,7 +97,7 @@ pub fn get_item_path(tcx: &ty::ctxt, def: ast::DefId) -> Vec<ast_map::PathElem> 
     })
 }
 
-pub fn get_item_name(tcx: &ty::ctxt, def: ast::DefId) -> ast::Name {
+pub fn get_item_name(tcx: &ty::ctxt, def: DefId) -> ast::Name {
     let cstore = &tcx.sess.cstore;
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_item_name(&cstore.intr, &cdata, def.node)
@@ -104,14 +105,14 @@ pub fn get_item_name(tcx: &ty::ctxt, def: ast::DefId) -> ast::Name {
 
 pub enum FoundAst<'ast> {
     Found(&'ast InlinedItem),
-    FoundParent(ast::DefId, &'ast InlinedItem),
+    FoundParent(DefId, &'ast InlinedItem),
     NotFound,
 }
 
 // Finds the AST for this item in the crate metadata, if any.  If the item was
 // not marked for inlining, then the AST will not be present and hence none
 // will be returned.
-pub fn maybe_get_item_ast<'tcx>(tcx: &ty::ctxt<'tcx>, def: ast::DefId,
+pub fn maybe_get_item_ast<'tcx>(tcx: &ty::ctxt<'tcx>, def: DefId,
                                 decode_inlined_item: decoder::DecodeInlinedItem)
                                 -> FoundAst<'tcx> {
     let cstore = &tcx.sess.cstore;
@@ -120,13 +121,13 @@ pub fn maybe_get_item_ast<'tcx>(tcx: &ty::ctxt<'tcx>, def: ast::DefId,
 }
 
 /// Returns information about the given implementation.
-pub fn get_impl_items(cstore: &cstore::CStore, impl_def_id: ast::DefId)
+pub fn get_impl_items(cstore: &cstore::CStore, impl_def_id: DefId)
                       -> Vec<ty::ImplOrTraitItemId> {
     let cdata = cstore.get_crate_data(impl_def_id.krate);
     decoder::get_impl_items(&*cdata, impl_def_id.node)
 }
 
-pub fn get_impl_or_trait_item<'tcx>(tcx: &ty::ctxt<'tcx>, def: ast::DefId)
+pub fn get_impl_or_trait_item<'tcx>(tcx: &ty::ctxt<'tcx>, def: DefId)
                                     -> ty::ImplOrTraitItem<'tcx> {
     let cdata = tcx.sess.cstore.get_crate_data(def.krate);
     decoder::get_impl_or_trait_item(tcx.sess.cstore.intr.clone(),
@@ -135,97 +136,97 @@ pub fn get_impl_or_trait_item<'tcx>(tcx: &ty::ctxt<'tcx>, def: ast::DefId)
                                     tcx)
 }
 
-pub fn get_trait_name(cstore: &cstore::CStore, def: ast::DefId) -> ast::Name {
+pub fn get_trait_name(cstore: &cstore::CStore, def: DefId) -> ast::Name {
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_trait_name(cstore.intr.clone(),
                             &*cdata,
                             def.node)
 }
 
-pub fn is_static_method(cstore: &cstore::CStore, def: ast::DefId) -> bool {
+pub fn is_static_method(cstore: &cstore::CStore, def: DefId) -> bool {
     let cdata = cstore.get_crate_data(def.krate);
     decoder::is_static_method(&*cdata, def.node)
 }
 
-pub fn get_trait_item_def_ids(cstore: &cstore::CStore, def: ast::DefId)
+pub fn get_trait_item_def_ids(cstore: &cstore::CStore, def: DefId)
                               -> Vec<ty::ImplOrTraitItemId> {
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_trait_item_def_ids(&*cdata, def.node)
 }
 
 pub fn get_item_variances(cstore: &cstore::CStore,
-                          def: ast::DefId) -> ty::ItemVariances {
+                          def: DefId) -> ty::ItemVariances {
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_item_variances(&*cdata, def.node)
 }
 
 pub fn get_provided_trait_methods<'tcx>(tcx: &ty::ctxt<'tcx>,
-                                        def: ast::DefId)
+                                        def: DefId)
                                         -> Vec<Rc<ty::Method<'tcx>>> {
     let cstore = &tcx.sess.cstore;
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_provided_trait_methods(cstore.intr.clone(), &*cdata, def.node, tcx)
 }
 
-pub fn get_associated_consts<'tcx>(tcx: &ty::ctxt<'tcx>, def: ast::DefId)
+pub fn get_associated_consts<'tcx>(tcx: &ty::ctxt<'tcx>, def: DefId)
                                    -> Vec<Rc<ty::AssociatedConst<'tcx>>> {
     let cstore = &tcx.sess.cstore;
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_associated_consts(cstore.intr.clone(), &*cdata, def.node, tcx)
 }
 
-pub fn get_type_name_if_impl(cstore: &cstore::CStore, def: ast::DefId)
+pub fn get_type_name_if_impl(cstore: &cstore::CStore, def: DefId)
                           -> Option<ast::Name> {
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_type_name_if_impl(&*cdata, def.node)
 }
 
 pub fn get_methods_if_impl(cstore: &cstore::CStore,
-                                  def: ast::DefId)
+                                  def: DefId)
                                -> Option<Vec<MethodInfo> > {
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_methods_if_impl(cstore.intr.clone(), &*cdata, def.node)
 }
 
 pub fn get_item_attrs(cstore: &cstore::CStore,
-                      def_id: ast::DefId)
+                      def_id: DefId)
                       -> Vec<ast::Attribute> {
     let cdata = cstore.get_crate_data(def_id.krate);
     decoder::get_item_attrs(&*cdata, def_id.node)
 }
 
-pub fn get_struct_field_names(cstore: &cstore::CStore, def: ast::DefId) -> Vec<ast::Name> {
+pub fn get_struct_field_names(cstore: &cstore::CStore, def: DefId) -> Vec<ast::Name> {
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_struct_field_names(&cstore.intr, &*cdata, def.node)
 }
 
-pub fn get_struct_field_attrs(cstore: &cstore::CStore, def: ast::DefId) -> HashMap<ast::NodeId,
+pub fn get_struct_field_attrs(cstore: &cstore::CStore, def: DefId) -> HashMap<ast::NodeId,
         Vec<ast::Attribute>> {
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_struct_field_attrs(&*cdata)
 }
 
 pub fn get_type<'tcx>(tcx: &ty::ctxt<'tcx>,
-                      def: ast::DefId)
+                      def: DefId)
                       -> ty::TypeScheme<'tcx> {
     let cstore = &tcx.sess.cstore;
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_type(&*cdata, def.node, tcx)
 }
 
-pub fn get_trait_def<'tcx>(tcx: &ty::ctxt<'tcx>, def: ast::DefId) -> ty::TraitDef<'tcx> {
+pub fn get_trait_def<'tcx>(tcx: &ty::ctxt<'tcx>, def: DefId) -> ty::TraitDef<'tcx> {
     let cstore = &tcx.sess.cstore;
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_trait_def(&*cdata, def.node, tcx)
 }
 
-pub fn get_adt_def<'tcx>(tcx: &ty::ctxt<'tcx>, def: ast::DefId) -> ty::AdtDefMaster<'tcx> {
+pub fn get_adt_def<'tcx>(tcx: &ty::ctxt<'tcx>, def: DefId) -> ty::AdtDefMaster<'tcx> {
     let cstore = &tcx.sess.cstore;
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_adt_def(&cstore.intr, &*cdata, def.node, tcx)
 }
 
-pub fn get_predicates<'tcx>(tcx: &ty::ctxt<'tcx>, def: ast::DefId)
+pub fn get_predicates<'tcx>(tcx: &ty::ctxt<'tcx>, def: DefId)
                             -> ty::GenericPredicates<'tcx>
 {
     let cstore = &tcx.sess.cstore;
@@ -233,7 +234,7 @@ pub fn get_predicates<'tcx>(tcx: &ty::ctxt<'tcx>, def: ast::DefId)
     decoder::get_predicates(&*cdata, def.node, tcx)
 }
 
-pub fn get_super_predicates<'tcx>(tcx: &ty::ctxt<'tcx>, def: ast::DefId)
+pub fn get_super_predicates<'tcx>(tcx: &ty::ctxt<'tcx>, def: DefId)
                                   -> ty::GenericPredicates<'tcx>
 {
     let cstore = &tcx.sess.cstore;
@@ -241,8 +242,8 @@ pub fn get_super_predicates<'tcx>(tcx: &ty::ctxt<'tcx>, def: ast::DefId)
     decoder::get_super_predicates(&*cdata, def.node, tcx)
 }
 
-pub fn get_field_type<'tcx>(tcx: &ty::ctxt<'tcx>, class_id: ast::DefId,
-                            def: ast::DefId) -> ty::TypeScheme<'tcx> {
+pub fn get_field_type<'tcx>(tcx: &ty::ctxt<'tcx>, class_id: DefId,
+                            def: DefId) -> ty::TypeScheme<'tcx> {
     let cstore = &tcx.sess.cstore;
     let cdata = cstore.get_crate_data(class_id.krate);
     let all_items = reader::get_doc(rbml::Doc::new(cdata.data()), tag_items);
@@ -267,7 +268,7 @@ pub fn get_field_type<'tcx>(tcx: &ty::ctxt<'tcx>, class_id: ast::DefId,
 }
 
 pub fn get_impl_polarity<'tcx>(tcx: &ty::ctxt<'tcx>,
-                               def: ast::DefId)
+                               def: DefId)
                                -> Option<ast::ImplPolarity>
 {
     let cstore = &tcx.sess.cstore;
@@ -276,7 +277,7 @@ pub fn get_impl_polarity<'tcx>(tcx: &ty::ctxt<'tcx>,
 }
 
 pub fn get_custom_coerce_unsized_kind<'tcx>(tcx: &ty::ctxt<'tcx>,
-                                            def: ast::DefId)
+                                            def: DefId)
                                             -> Option<ty::CustomCoerceUnsized> {
     let cstore = &tcx.sess.cstore;
     let cdata = cstore.get_crate_data(def.krate);
@@ -286,7 +287,7 @@ pub fn get_custom_coerce_unsized_kind<'tcx>(tcx: &ty::ctxt<'tcx>,
 // Given a def_id for an impl, return the trait it implements,
 // if there is one.
 pub fn get_impl_trait<'tcx>(tcx: &ty::ctxt<'tcx>,
-                            def: ast::DefId)
+                            def: DefId)
                             -> Option<ty::TraitRef<'tcx>> {
     let cstore = &tcx.sess.cstore;
     let cdata = cstore.get_crate_data(def.krate);
@@ -300,18 +301,18 @@ pub fn get_native_libraries(cstore: &cstore::CStore, crate_num: ast::CrateNum)
 }
 
 pub fn each_inherent_implementation_for_type<F>(cstore: &cstore::CStore,
-                                                def_id: ast::DefId,
+                                                def_id: DefId,
                                                 callback: F) where
-    F: FnMut(ast::DefId),
+    F: FnMut(DefId),
 {
     let cdata = cstore.get_crate_data(def_id.krate);
     decoder::each_inherent_implementation_for_type(&*cdata, def_id.node, callback)
 }
 
 pub fn each_implementation_for_trait<F>(cstore: &cstore::CStore,
-                                        def_id: ast::DefId,
+                                        def_id: DefId,
                                         mut callback: F) where
-    F: FnMut(ast::DefId),
+    F: FnMut(DefId),
 {
     cstore.iter_crate_data(|_, cdata| {
         decoder::each_implementation_for_trait(cdata, def_id, &mut callback)
@@ -322,16 +323,16 @@ pub fn each_implementation_for_trait<F>(cstore: &cstore::CStore,
 /// default method or an implementation of a trait method), returns the ID of
 /// the trait that the method belongs to. Otherwise, returns `None`.
 pub fn get_trait_of_item(cstore: &cstore::CStore,
-                         def_id: ast::DefId,
+                         def_id: DefId,
                          tcx: &ty::ctxt)
-                         -> Option<ast::DefId> {
+                         -> Option<DefId> {
     let cdata = cstore.get_crate_data(def_id.krate);
     decoder::get_trait_of_item(&*cdata, def_id.node, tcx)
 }
 
 pub fn get_tuple_struct_definition_if_ctor(cstore: &cstore::CStore,
-                                           def_id: ast::DefId)
-    -> Option<ast::DefId>
+                                           def_id: DefId)
+    -> Option<DefId>
 {
     let cdata = cstore.get_crate_data(def_id.krate);
     decoder::get_tuple_struct_definition_if_ctor(&*cdata, def_id.node)
@@ -352,7 +353,7 @@ pub fn get_missing_lang_items(cstore: &cstore::CStore, cnum: ast::CrateNum)
     decoder::get_missing_lang_items(&*cdata)
 }
 
-pub fn get_method_arg_names(cstore: &cstore::CStore, did: ast::DefId)
+pub fn get_method_arg_names(cstore: &cstore::CStore, did: DefId)
     -> Vec<String>
 {
     let cdata = cstore.get_crate_data(did.krate);
@@ -360,29 +361,29 @@ pub fn get_method_arg_names(cstore: &cstore::CStore, did: ast::DefId)
 }
 
 pub fn get_reachable_ids(cstore: &cstore::CStore, cnum: ast::CrateNum)
-    -> Vec<ast::DefId>
+    -> Vec<DefId>
 {
     let cdata = cstore.get_crate_data(cnum);
     decoder::get_reachable_ids(&*cdata)
 }
 
-pub fn is_typedef(cstore: &cstore::CStore, did: ast::DefId) -> bool {
+pub fn is_typedef(cstore: &cstore::CStore, did: DefId) -> bool {
     let cdata = cstore.get_crate_data(did.krate);
     decoder::is_typedef(&*cdata, did.node)
 }
 
-pub fn is_const_fn(cstore: &cstore::CStore, did: ast::DefId) -> bool {
+pub fn is_const_fn(cstore: &cstore::CStore, did: DefId) -> bool {
     let cdata = cstore.get_crate_data(did.krate);
     decoder::is_const_fn(&*cdata, did.node)
 }
 
-pub fn is_impl(cstore: &cstore::CStore, did: ast::DefId) -> bool {
+pub fn is_impl(cstore: &cstore::CStore, did: DefId) -> bool {
     let cdata = cstore.get_crate_data(did.krate);
     decoder::is_impl(&*cdata, did.node)
 }
 
 pub fn get_stability(cstore: &cstore::CStore,
-                     def: ast::DefId)
+                     def: DefId)
                      -> Option<attr::Stability> {
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_stability(&*cdata, def.node)
@@ -392,23 +393,23 @@ pub fn is_staged_api(cstore: &cstore::CStore, krate: ast::CrateNum) -> bool {
     cstore.get_crate_data(krate).staged_api
 }
 
-pub fn get_repr_attrs(cstore: &cstore::CStore, def: ast::DefId)
+pub fn get_repr_attrs(cstore: &cstore::CStore, def: DefId)
                       -> Vec<attr::ReprAttr> {
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_repr_attrs(&*cdata, def.node)
 }
 
-pub fn is_defaulted_trait(cstore: &cstore::CStore, trait_def_id: ast::DefId) -> bool {
+pub fn is_defaulted_trait(cstore: &cstore::CStore, trait_def_id: DefId) -> bool {
     let cdata = cstore.get_crate_data(trait_def_id.krate);
     decoder::is_defaulted_trait(&*cdata, trait_def_id.node)
 }
 
-pub fn is_default_impl(cstore: &cstore::CStore, impl_did: ast::DefId) -> bool {
+pub fn is_default_impl(cstore: &cstore::CStore, impl_did: DefId) -> bool {
     let cdata = cstore.get_crate_data(impl_did.krate);
     decoder::is_default_impl(&*cdata, impl_did.node)
 }
 
-pub fn is_extern_fn(cstore: &cstore::CStore, did: ast::DefId,
+pub fn is_extern_fn(cstore: &cstore::CStore, did: DefId,
                     tcx: &ty::ctxt) -> bool {
     let cdata = cstore.get_crate_data(did.krate);
     decoder::is_extern_fn(&*cdata, did.node, tcx)

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1260,7 +1260,7 @@ pub fn list_crate_metadata(bytes: &[u8], out: &mut io::Write) -> io::Result<()> 
 // then we must translate the crate number from that encoded in the external
 // crate to the correct local crate number.
 pub fn translate_def_id(cdata: Cmd, did: DefId) -> DefId {
-    if did.krate == LOCAL_CRATE {
+    if did.is_local() {
         return DefId { krate: cdata.cnum, node: did.node };
     }
 

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1781,7 +1781,7 @@ fn encode_lang_items(ecx: &EncodeContext, rbml_w: &mut Encoder) {
 
     for (i, &def_id) in ecx.tcx.lang_items.items() {
         if let Some(id) = def_id {
-            if id.krate == LOCAL_CRATE {
+            if id.is_local() {
                 rbml_w.start_tag(tag_lang_items_item);
                 rbml_w.wr_tagged_u32(tag_lang_items_item_id, i as u32);
                 rbml_w.wr_tagged_u32(tag_lang_items_item_node_id, id.node as u32);

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -22,6 +22,7 @@ use metadata::decoder;
 use metadata::tyencode;
 use metadata::inline::InlinedItemRef;
 use middle::def;
+use middle::def_id::{DefId, LOCAL_CRATE};
 use middle::dependency_format::Linkage;
 use middle::stability;
 use middle::ty::{self, Ty};
@@ -34,9 +35,7 @@ use std::io::prelude::*;
 use std::io::{Cursor, SeekFrom};
 use std::rc::Rc;
 use syntax::abi;
-use syntax::ast::{self, DefId, NodeId};
-use syntax::ast_util::*;
-use syntax::ast_util;
+use syntax::ast::{self, NodeId};
 use syntax::attr;
 use syntax::attr::AttrMetaMethods;
 use syntax::diagnostic::SpanHandler;
@@ -123,7 +122,7 @@ pub fn def_to_string(did: DefId) -> String {
 fn encode_item_variances(rbml_w: &mut Encoder,
                          ecx: &EncodeContext,
                          id: NodeId) {
-    let v = ecx.tcx.item_variances(ast_util::local_def(id));
+    let v = ecx.tcx.item_variances(DefId::local(id));
     rbml_w.start_tag(tag_item_variances);
     v.encode(rbml_w);
     rbml_w.end_tag();
@@ -134,8 +133,8 @@ fn encode_bounds_and_type_for_item<'a, 'tcx>(rbml_w: &mut Encoder,
                                              id: ast::NodeId) {
     encode_bounds_and_type(rbml_w,
                            ecx,
-                           &ecx.tcx.lookup_item_type(local_def(id)),
-                           &ecx.tcx.lookup_predicates(local_def(id)));
+                           &ecx.tcx.lookup_item_type(DefId::local(id)),
+                           &ecx.tcx.lookup_predicates(DefId::local(id)));
 }
 
 fn encode_bounds_and_type<'a, 'tcx>(rbml_w: &mut Encoder,
@@ -282,10 +281,10 @@ fn encode_enum_variant_info(ecx: &EncodeContext,
     debug!("encode_enum_variant_info(id={})", id);
 
     let mut disr_val = 0;
-    let def = ecx.tcx.lookup_adt_def(local_def(id));
+    let def = ecx.tcx.lookup_adt_def(DefId::local(id));
     for variant in &def.variants {
         let vid = variant.did;
-        assert!(is_local(vid));
+        assert!(vid.is_local());
         index.push(entry {
             val: vid.node as i64,
             pos: rbml_w.mark_stable_position(),
@@ -297,7 +296,7 @@ fn encode_enum_variant_info(ecx: &EncodeContext,
             ty::VariantKind::Dict => 'V'
         });
         encode_name(rbml_w, variant.name);
-        encode_parent_item(rbml_w, local_def(id));
+        encode_parent_item(rbml_w, DefId::local(id));
         encode_visibility(rbml_w, vis);
 
         let attrs = ecx.tcx.get_attrs(vid);
@@ -504,7 +503,7 @@ fn encode_info_for_mod(ecx: &EncodeContext,
                        name: ast::Name,
                        vis: ast::Visibility) {
     rbml_w.start_tag(tag_items_data_item);
-    encode_def_id(rbml_w, local_def(id));
+    encode_def_id(rbml_w, DefId::local(id));
     encode_family(rbml_w, 'm');
     encode_name(rbml_w, name);
     debug!("(encoding info for module) encoding info for module ID {}", id);
@@ -512,11 +511,11 @@ fn encode_info_for_mod(ecx: &EncodeContext,
     // Encode info about all the module children.
     for item in &md.items {
         rbml_w.wr_tagged_u64(tag_mod_child,
-                             def_to_u64(local_def(item.id)));
+                             def_to_u64(DefId::local(item.id)));
 
         each_auxiliary_node_id(&**item, |auxiliary_node_id| {
             rbml_w.wr_tagged_u64(tag_mod_child,
-                                 def_to_u64(local_def(auxiliary_node_id)));
+                                 def_to_u64(DefId::local(auxiliary_node_id)));
             true
         });
 
@@ -526,14 +525,14 @@ fn encode_info_for_mod(ecx: &EncodeContext,
                    ident,
                    did, ecx.tcx.map.node_to_string(did));
 
-            rbml_w.wr_tagged_u64(tag_mod_impl, def_to_u64(local_def(did)));
+            rbml_w.wr_tagged_u64(tag_mod_impl, def_to_u64(DefId::local(did)));
         }
     }
 
     encode_path(rbml_w, path.clone());
     encode_visibility(rbml_w, vis);
 
-    let stab = stability::lookup(ecx.tcx, ast_util::local_def(id));
+    let stab = stability::lookup(ecx.tcx, DefId::local(id));
     encode_stability(rbml_w, stab);
 
     // Encode the reexports of this module, if this module is public.
@@ -644,7 +643,7 @@ fn encode_info_for_struct<'a, 'tcx>(ecx: &EncodeContext<'a, 'tcx>,
         encode_struct_field_family(rbml_w, field.vis);
         encode_name(rbml_w, nm);
         encode_bounds_and_type_for_item(rbml_w, ecx, id);
-        encode_def_id(rbml_w, local_def(id));
+        encode_def_id(rbml_w, DefId::local(id));
 
         let stab = stability::lookup(ecx.tcx, field.did);
         encode_stability(rbml_w, stab);
@@ -666,18 +665,18 @@ fn encode_info_for_struct_ctor(ecx: &EncodeContext,
     });
 
     rbml_w.start_tag(tag_items_data_item);
-    encode_def_id(rbml_w, local_def(ctor_id));
+    encode_def_id(rbml_w, DefId::local(ctor_id));
     encode_family(rbml_w, 'o');
     encode_bounds_and_type_for_item(rbml_w, ecx, ctor_id);
     encode_name(rbml_w, name);
     ecx.tcx.map.with_path(ctor_id, |path| encode_path(rbml_w, path));
-    encode_parent_item(rbml_w, local_def(struct_id));
+    encode_parent_item(rbml_w, DefId::local(struct_id));
 
     if ecx.item_symbols.borrow().contains_key(&ctor_id) {
         encode_symbol(ecx, rbml_w, ctor_id);
     }
 
-    let stab = stability::lookup(ecx.tcx, ast_util::local_def(ctor_id));
+    let stab = stability::lookup(ecx.tcx, DefId::local(ctor_id));
     encode_stability(rbml_w, stab);
 
     // indicate that this is a tuple struct ctor, because downstream users will normally want
@@ -810,7 +809,7 @@ fn encode_info_for_associated_const(ecx: &EncodeContext,
     encode_family(rbml_w, 'C');
     encode_provided_source(rbml_w, associated_const.default);
 
-    encode_parent_item(rbml_w, local_def(parent_id));
+    encode_parent_item(rbml_w, DefId::local(parent_id));
     encode_item_sort(rbml_w, 'C');
 
     encode_bounds_and_type_for_item(rbml_w, ecx, associated_const.def_id.local_id());
@@ -823,7 +822,7 @@ fn encode_info_for_associated_const(ecx: &EncodeContext,
 
     if let Some(ii) = impl_item_opt {
         encode_attributes(rbml_w, &ii.attrs);
-        encode_inlined_item(ecx, rbml_w, InlinedItemRef::ImplItem(local_def(parent_id), ii));
+        encode_inlined_item(ecx, rbml_w, InlinedItemRef::ImplItem(DefId::local(parent_id), ii));
     }
 
     rbml_w.end_tag();
@@ -842,7 +841,7 @@ fn encode_info_for_method<'a, 'tcx>(ecx: &EncodeContext<'a, 'tcx>,
     rbml_w.start_tag(tag_items_data_item);
 
     encode_method_ty_fields(ecx, rbml_w, m);
-    encode_parent_item(rbml_w, local_def(parent_id));
+    encode_parent_item(rbml_w, DefId::local(parent_id));
     encode_item_sort(rbml_w, 'r');
 
     let stab = stability::lookup(ecx.tcx, m.def_id);
@@ -861,7 +860,7 @@ fn encode_info_for_method<'a, 'tcx>(ecx: &EncodeContext<'a, 'tcx>,
             let needs_inline = any_types || is_default_impl ||
                                attr::requests_inline(&impl_item.attrs);
             if needs_inline || sig.constness == ast::Constness::Const {
-                encode_inlined_item(ecx, rbml_w, InlinedItemRef::ImplItem(local_def(parent_id),
+                encode_inlined_item(ecx, rbml_w, InlinedItemRef::ImplItem(DefId::local(parent_id),
                                                                impl_item));
             }
             encode_constness(rbml_w, sig.constness);
@@ -891,7 +890,7 @@ fn encode_info_for_associated_type<'a, 'tcx>(ecx: &EncodeContext<'a, 'tcx>,
     encode_name(rbml_w, associated_type.name);
     encode_visibility(rbml_w, associated_type.vis);
     encode_family(rbml_w, 'y');
-    encode_parent_item(rbml_w, local_def(parent_id));
+    encode_parent_item(rbml_w, DefId::local(parent_id));
     encode_item_sort(rbml_w, 't');
 
     let stab = stability::lookup(ecx.tcx, associated_type.def_id);
@@ -975,7 +974,7 @@ fn encode_inherent_implementations(ecx: &EncodeContext,
 fn encode_extension_implementations(ecx: &EncodeContext,
                                     rbml_w: &mut Encoder,
                                     trait_def_id: DefId) {
-    assert!(ast_util::is_local(trait_def_id));
+    assert!(trait_def_id.is_local());
     let def = ecx.tcx.lookup_trait_def(trait_def_id);
 
     def.for_each_impl(ecx.tcx, |impl_def_id| {
@@ -1012,8 +1011,8 @@ fn encode_info_for_item(ecx: &EncodeContext,
     debug!("encoding info for item at {}",
            tcx.sess.codemap().span_to_string(item.span));
 
-    let def_id = local_def(item.id);
-    let stab = stability::lookup(tcx, ast_util::local_def(item.id));
+    let def_id = DefId::local(item.id);
+    let stab = stability::lookup(tcx, DefId::local(item.id));
 
     match item.node {
       ast::ItemStatic(_, m, _) => {
@@ -1093,7 +1092,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         // Encode all the items in this module.
         for foreign_item in &fm.items {
             rbml_w.wr_tagged_u64(tag_mod_child,
-                                 def_to_u64(local_def(foreign_item.id)));
+                                 def_to_u64(DefId::local(foreign_item.id)));
         }
         encode_visibility(rbml_w, vis);
         encode_stability(rbml_w, stab);
@@ -1123,7 +1122,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         encode_attributes(rbml_w, &item.attrs);
         encode_repr_attrs(rbml_w, ecx, &item.attrs);
         for v in &enum_definition.variants {
-            encode_variant_id(rbml_w, local_def(v.node.id));
+            encode_variant_id(rbml_w, DefId::local(v.node.id));
         }
         encode_inlined_item(ecx, rbml_w, InlinedItemRef::Item(item));
         encode_path(rbml_w, path);
@@ -1199,7 +1198,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
           encode_name(rbml_w, item.ident.name);
           encode_unsafety(rbml_w, unsafety);
 
-          let trait_ref = tcx.impl_trait_ref(local_def(item.id)).unwrap();
+          let trait_ref = tcx.impl_trait_ref(DefId::local(item.id)).unwrap();
           encode_trait_ref(rbml_w, ecx, trait_ref, tag_item_trait_ref);
           rbml_w.end_tag();
       }
@@ -1219,7 +1218,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         encode_unsafety(rbml_w, unsafety);
         encode_polarity(rbml_w, polarity);
 
-        match tcx.custom_coerce_unsized_kinds.borrow().get(&local_def(item.id)) {
+        match tcx.custom_coerce_unsized_kinds.borrow().get(&DefId::local(item.id)) {
             Some(&kind) => {
                 rbml_w.start_tag(tag_impl_coerce_unsized_kind);
                 kind.encode(rbml_w);
@@ -1253,7 +1252,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
             }
             rbml_w.end_tag();
         }
-        if let Some(trait_ref) = tcx.impl_trait_ref(local_def(item.id)) {
+        if let Some(trait_ref) = tcx.impl_trait_ref(DefId::local(item.id)) {
             encode_trait_ref(rbml_w, ecx, trait_ref, tag_item_trait_ref);
         }
         encode_path(rbml_w, path.clone());
@@ -1361,7 +1360,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         // Now output the trait item info for each trait item.
         let r = tcx.trait_item_def_ids(def_id);
         for (i, &item_def_id) in r.iter().enumerate() {
-            assert_eq!(item_def_id.def_id().krate, ast::LOCAL_CRATE);
+            assert_eq!(item_def_id.def_id().krate, LOCAL_CRATE);
 
             index.push(entry {
                 val: item_def_id.def_id().node as i64,
@@ -1494,7 +1493,7 @@ fn encode_info_for_foreign_item(ecx: &EncodeContext,
     });
 
     rbml_w.start_tag(tag_items_data_item);
-    encode_def_id(rbml_w, local_def(nitem.id));
+    encode_def_id(rbml_w, DefId::local(nitem.id));
     encode_visibility(rbml_w, nitem.vis);
     match nitem.node {
       ast::ForeignItemFn(ref fndecl, _) => {
@@ -1505,7 +1504,7 @@ fn encode_info_for_foreign_item(ecx: &EncodeContext,
             encode_inlined_item(ecx, rbml_w, InlinedItemRef::Foreign(nitem));
         }
         encode_attributes(rbml_w, &*nitem.attrs);
-        let stab = stability::lookup(ecx.tcx, ast_util::local_def(nitem.id));
+        let stab = stability::lookup(ecx.tcx, DefId::local(nitem.id));
         encode_stability(rbml_w, stab);
         encode_symbol(ecx, rbml_w, nitem.id);
         encode_method_argument_names(rbml_w, &*fndecl);
@@ -1518,7 +1517,7 @@ fn encode_info_for_foreign_item(ecx: &EncodeContext,
         }
         encode_bounds_and_type_for_item(rbml_w, ecx, nitem.id);
         encode_attributes(rbml_w, &*nitem.attrs);
-        let stab = stability::lookup(ecx.tcx, ast_util::local_def(nitem.id));
+        let stab = stability::lookup(ecx.tcx, DefId::local(nitem.id));
         encode_stability(rbml_w, stab);
         encode_symbol(ecx, rbml_w, nitem.id);
         encode_name(rbml_w, nitem.ident.name);
@@ -1782,7 +1781,7 @@ fn encode_lang_items(ecx: &EncodeContext, rbml_w: &mut Encoder) {
 
     for (i, &def_id) in ecx.tcx.lang_items.items() {
         if let Some(id) = def_id {
-            if id.krate == ast::LOCAL_CRATE {
+            if id.krate == LOCAL_CRATE {
                 rbml_w.start_tag(tag_lang_items_item);
                 rbml_w.wr_tagged_u32(tag_lang_items_item_id, i as u32);
                 rbml_w.wr_tagged_u32(tag_lang_items_item_node_id, id.node as u32);
@@ -1900,9 +1899,9 @@ impl<'a, 'b, 'c, 'tcx, 'v> Visitor<'v> for ImplVisitor<'a, 'b, 'c, 'tcx> {
             // Load eagerly if this is an implementation of the Drop trait
             // or if the trait is not defined in this crate.
             if Some(def_id) == self.ecx.tcx.lang_items.drop_trait() ||
-                    def_id.krate != ast::LOCAL_CRATE {
+                    def_id.krate != LOCAL_CRATE {
                 self.rbml_w.start_tag(tag_impls_impl);
-                encode_def_id(self.rbml_w, local_def(item.id));
+                encode_def_id(self.rbml_w, DefId::local(item.id));
                 self.rbml_w.wr_tagged_u64(tag_impls_impl_trait_def_id, def_to_u64(def_id));
                 self.rbml_w.end_tag();
             }
@@ -1944,11 +1943,11 @@ fn encode_misc_info(ecx: &EncodeContext,
     rbml_w.start_tag(tag_misc_info_crate_items);
     for item in &krate.module.items {
         rbml_w.wr_tagged_u64(tag_mod_child,
-                             def_to_u64(local_def(item.id)));
+                             def_to_u64(DefId::local(item.id)));
 
         each_auxiliary_node_id(&**item, |auxiliary_node_id| {
             rbml_w.wr_tagged_u64(tag_mod_child,
-                                 def_to_u64(local_def(auxiliary_node_id)));
+                                 def_to_u64(DefId::local(auxiliary_node_id)));
             true
         });
     }

--- a/src/librustc/metadata/inline.rs
+++ b/src/librustc/metadata/inline.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use middle::def_id::DefId;
 use syntax::ast;
 use syntax::ast_util::{IdRange, IdRangeComputingVisitor,
                        IdVisitor, IdVisitingOperation};
@@ -21,16 +22,16 @@ use self::InlinedItem::*;
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub enum InlinedItem {
     Item(P<ast::Item>),
-    TraitItem(ast::DefId /* impl id */, P<ast::TraitItem>),
-    ImplItem(ast::DefId /* impl id */, P<ast::ImplItem>),
+    TraitItem(DefId /* impl id */, P<ast::TraitItem>),
+    ImplItem(DefId /* impl id */, P<ast::ImplItem>),
     Foreign(P<ast::ForeignItem>),
 }
 
 /// A borrowed version of `ast::InlinedItem`.
 pub enum InlinedItemRef<'a> {
     Item(&'a ast::Item),
-    TraitItem(ast::DefId, &'a ast::TraitItem),
-    ImplItem(ast::DefId, &'a ast::ImplItem),
+    TraitItem(DefId, &'a ast::TraitItem),
+    ImplItem(DefId, &'a ast::ImplItem),
     Foreign(&'a ast::ForeignItem)
 }
 

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -18,6 +18,7 @@
 
 pub use self::DefIdSource::*;
 
+use middle::def_id::DefId;
 use middle::region;
 use middle::subst;
 use middle::subst::VecPerParamSpace;
@@ -58,7 +59,7 @@ pub enum DefIdSource {
     ClosureSource
 }
 
-pub type DefIdConvert<'a> = &'a mut FnMut(DefIdSource, ast::DefId) -> ast::DefId;
+pub type DefIdConvert<'a> = &'a mut FnMut(DefIdSource, DefId) -> DefId;
 
 pub struct TyDecoder<'a, 'tcx: 'a> {
     data: &'a [u8],
@@ -473,7 +474,7 @@ impl<'a,'tcx> TyDecoder<'a,'tcx> {
         ty::TypeAndMut { ty: self.parse_ty(), mutbl: m }
     }
 
-    fn parse_def(&mut self, source: DefIdSource) -> ast::DefId {
+    fn parse_def(&mut self, source: DefIdSource) -> DefId {
         let def_id = parse_defid(self.scan(|c| c == '|'));
         return (self.conv_def_id)(source, def_id);
     }
@@ -680,7 +681,7 @@ impl<'a,'tcx> TyDecoder<'a,'tcx> {
 }
 
 // Rust metadata parsing
-fn parse_defid(buf: &[u8]) -> ast::DefId {
+fn parse_defid(buf: &[u8]) -> DefId {
     let mut colon_idx = 0;
     let len = buf.len();
     while colon_idx < len && buf[colon_idx] != ':' as u8 { colon_idx += 1; }
@@ -706,7 +707,7 @@ fn parse_defid(buf: &[u8]) -> ast::DefId {
         None => panic!("internal error: parse_defid: id expected, found {:?}",
                        def_part)
     };
-    ast::DefId { krate: crate_num, node: def_num }
+    DefId { krate: crate_num, node: def_num }
 }
 
 fn parse_unsafety(c: char) -> ast::Unsafety {

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -16,6 +16,7 @@
 use std::cell::RefCell;
 use std::io::prelude::*;
 
+use middle::def_id::DefId;
 use middle::region;
 use middle::subst;
 use middle::subst::VecPerParamSpace;
@@ -34,7 +35,7 @@ macro_rules! mywrite { ($w:expr, $($arg:tt)*) => ({ write!($w.writer, $($arg)*);
 pub struct ctxt<'a, 'tcx: 'a> {
     pub diag: &'a SpanHandler,
     // Def -> str Callback:
-    pub ds: fn(ast::DefId) -> String,
+    pub ds: fn(DefId) -> String,
     // The type context.
     pub tcx: &'a ty::ctxt<'tcx>,
     pub abbrevs: &'a abbrev_map<'tcx>

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -28,6 +28,7 @@ use middle::cast::{CastKind};
 use middle::const_eval;
 use middle::const_eval::EvalHint::ExprTypeChecked;
 use middle::def;
+use middle::def_id::DefId;
 use middle::expr_use_visitor as euv;
 use middle::infer;
 use middle::mem_categorization as mc;
@@ -204,7 +205,7 @@ impl<'a, 'tcx> CheckCrateVisitor<'a, 'tcx> {
     /// Returns true if the call is to a const fn or method.
     fn handle_const_fn_call(&mut self,
                             expr: &ast::Expr,
-                            def_id: ast::DefId,
+                            def_id: DefId,
                             ret_ty: Ty<'tcx>)
                             -> bool {
         if let Some(fn_like) = const_eval::lookup_const_fn_by_id(self.tcx, def_id) {

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -17,6 +17,7 @@ use middle::const_eval::{eval_const_expr, eval_const_expr_partial};
 use middle::const_eval::{const_expr_to_pat, lookup_const_by_id};
 use middle::const_eval::EvalHint::ExprTypeChecked;
 use middle::def::*;
+use middle::def_id::{DefId};
 use middle::expr_use_visitor::{ConsumeMode, Delegate, ExprUseVisitor, Init};
 use middle::expr_use_visitor::{JustWrite, LoanCause, MutateMode};
 use middle::expr_use_visitor::WriteAndRead;
@@ -111,7 +112,7 @@ pub enum Constructor {
     /// e.g. struct patterns and fixed-length arrays.
     Single,
     /// Enum variants.
-    Variant(ast::DefId),
+    Variant(DefId),
     /// Literal values.
     ConstantValue(ConstVal),
     /// Ranges of literal values (2..5).

--- a/src/librustc/middle/check_static_recursion.rs
+++ b/src/librustc/middle/check_static_recursion.rs
@@ -16,7 +16,7 @@ use session::Session;
 use middle::def::{DefStatic, DefConst, DefAssociatedConst, DefVariant, DefMap};
 use util::nodemap::NodeMap;
 
-use syntax::{ast, ast_util};
+use syntax::{ast};
 use syntax::codemap::Span;
 use syntax::feature_gate::emit_feature_err;
 use syntax::visit::Visitor;
@@ -239,8 +239,7 @@ impl<'a, 'ast: 'a> Visitor<'ast> for CheckItemRecursionVisitor<'a, 'ast> {
                 match self.def_map.borrow().get(&e.id).map(|d| d.base_def) {
                     Some(DefStatic(def_id, _)) |
                     Some(DefAssociatedConst(def_id)) |
-                    Some(DefConst(def_id))
-                           if ast_util::is_local(def_id) => {
+                    Some(DefConst(def_id)) if def_id.is_local() => {
                         match self.ast_map.get(def_id.node) {
                           ast_map::NodeItem(item) =>
                             self.visit_item(item),
@@ -261,8 +260,7 @@ impl<'a, 'ast: 'a> Visitor<'ast> for CheckItemRecursionVisitor<'a, 'ast> {
                     // affect the specific variant used, but we need to check
                     // the whole enum definition to see what expression that
                     // might be (if any).
-                    Some(DefVariant(enum_id, variant_id, false))
-                           if ast_util::is_local(enum_id) => {
+                    Some(DefVariant(enum_id, variant_id, false)) if enum_id.is_local() => {
                         if let ast::ItemEnum(ref enum_def, ref generics) =
                                self.ast_map.expect_item(enum_id.local_id()).node {
                             self.populate_enum_discriminants(enum_def);

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -14,12 +14,12 @@
 
 use ast_map;
 use middle::{def, pat_util, privacy, ty};
+use middle::def_id::{DefId};
 use lint;
 use util::nodemap::NodeSet;
 
 use std::collections::HashSet;
 use syntax::{ast, codemap};
-use syntax::ast_util::{local_def, is_local};
 use syntax::attr::{self, AttrMetaMethods};
 use syntax::visit::{self, Visitor};
 
@@ -27,8 +27,8 @@ use syntax::visit::{self, Visitor};
 // explored. For example, if it's a live NodeItem that is a
 // function, then we should explore its block to check for codes that
 // may need to be marked as live.
-fn should_explore(tcx: &ty::ctxt, def_id: ast::DefId) -> bool {
-    if !is_local(def_id) {
+fn should_explore(tcx: &ty::ctxt, def_id: DefId) -> bool {
+    if !def_id.is_local() {
         return false;
     }
 
@@ -65,7 +65,7 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
         }
     }
 
-    fn check_def_id(&mut self, def_id: ast::DefId) {
+    fn check_def_id(&mut self, def_id: DefId) {
         if should_explore(self.tcx, def_id) {
             self.worklist.push(def_id.node);
         }
@@ -475,7 +475,7 @@ impl<'a, 'tcx> DeadVisitor<'a, 'tcx> {
         // method of a private type is used, but the type itself is never
         // called directly.
         let impl_items = self.tcx.impl_items.borrow();
-        match self.tcx.inherent_impls.borrow().get(&local_def(id)) {
+        match self.tcx.inherent_impls.borrow().get(&DefId::local(id)) {
             None => (),
             Some(impl_list) => {
                 for impl_did in impl_list.iter() {

--- a/src/librustc/middle/def_id.rs
+++ b/src/librustc/middle/def_id.rs
@@ -1,0 +1,55 @@
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use syntax::ast::{CrateNum, NodeId};
+use std::cell::Cell;
+use std::fmt;
+
+#[derive(Clone, Eq, Ord, PartialOrd, PartialEq, RustcEncodable,
+           RustcDecodable, Hash, Copy)]
+pub struct DefId {
+    pub krate: CrateNum,
+    pub node: NodeId,
+}
+
+fn default_def_id_debug(_: DefId, _: &mut fmt::Formatter) -> fmt::Result { Ok(()) }
+
+thread_local!(pub static DEF_ID_DEBUG: Cell<fn(DefId, &mut fmt::Formatter) -> fmt::Result> =
+                Cell::new(default_def_id_debug));
+
+impl fmt::Debug for DefId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        try!(write!(f, "DefId {{ krate: {}, node: {} }}",
+                    self.krate, self.node));
+        DEF_ID_DEBUG.with(|def_id_debug| def_id_debug.get()(*self, f))
+    }
+}
+
+impl DefId {
+    pub fn local(id: NodeId) -> DefId {
+        DefId { krate: LOCAL_CRATE, node: id }
+    }
+
+    /// Read the node id, asserting that this def-id is krate-local.
+    pub fn local_id(&self) -> NodeId {
+        assert_eq!(self.krate, LOCAL_CRATE);
+        self.node
+    }
+
+    pub fn is_local(&self) -> bool {
+        self.krate == LOCAL_CRATE
+    }
+}
+
+
+/// Item definitions in the currently-compiled crate would have the CrateNum
+/// LOCAL_CRATE in their DefId.
+pub const LOCAL_CRATE: CrateNum = 0;
+

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -21,6 +21,7 @@ use self::TrackMatchMode::*;
 use self::OverloadedCallType::*;
 
 use middle::{def, region, pat_util};
+use middle::def_id::{DefId};
 use middle::infer;
 use middle::mem_categorization as mc;
 use middle::ty;
@@ -206,7 +207,7 @@ enum OverloadedCallType {
 }
 
 impl OverloadedCallType {
-    fn from_trait_id(tcx: &ty::ctxt, trait_id: ast::DefId)
+    fn from_trait_id(tcx: &ty::ctxt, trait_id: DefId)
                      -> OverloadedCallType {
         for &(maybe_function_trait, overloaded_call_type) in &[
             (tcx.lang_items.fn_once_trait(), FnOnceOverloadedCall),
@@ -224,7 +225,7 @@ impl OverloadedCallType {
         tcx.sess.bug("overloaded call didn't map to known function trait")
     }
 
-    fn from_method_id(tcx: &ty::ctxt, method_id: ast::DefId)
+    fn from_method_id(tcx: &ty::ctxt, method_id: DefId)
                       -> OverloadedCallType {
         let method = tcx.impl_or_trait_item(method_id);
         OverloadedCallType::from_trait_id(tcx, method.container().id())

--- a/src/librustc/middle/fast_reject.rs
+++ b/src/librustc/middle/fast_reject.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use middle::def_id::DefId;
 use middle::ty::{self, Ty};
 use syntax::ast;
 
@@ -21,14 +22,14 @@ pub enum SimplifiedType {
     IntSimplifiedType(ast::IntTy),
     UintSimplifiedType(ast::UintTy),
     FloatSimplifiedType(ast::FloatTy),
-    EnumSimplifiedType(ast::DefId),
+    EnumSimplifiedType(DefId),
     StrSimplifiedType,
     VecSimplifiedType,
     PtrSimplifiedType,
     TupleSimplifiedType(usize),
-    TraitSimplifiedType(ast::DefId),
-    StructSimplifiedType(ast::DefId),
-    ClosureSimplifiedType(ast::DefId),
+    TraitSimplifiedType(DefId),
+    StructSimplifiedType(DefId),
+    ClosureSimplifiedType(DefId),
     FunctionSimplifiedType(usize),
     ParameterSimplifiedType,
 }

--- a/src/librustc/middle/implicator.rs
+++ b/src/librustc/middle/implicator.rs
@@ -10,6 +10,7 @@
 
 // #![warn(deprecated_mode)]
 
+use middle::def_id::DefId;
 use middle::infer::{InferCtxt, GenericKind};
 use middle::subst::Substs;
 use middle::traits;
@@ -28,7 +29,7 @@ use util::nodemap::FnvHashSet;
 pub enum Implication<'tcx> {
     RegionSubRegion(Option<Ty<'tcx>>, ty::Region, ty::Region),
     RegionSubGeneric(Option<Ty<'tcx>>, ty::Region, GenericKind<'tcx>),
-    Predicate(ast::DefId, ty::Predicate<'tcx>),
+    Predicate(DefId, ty::Predicate<'tcx>),
 }
 
 struct Implicator<'a, 'tcx: 'a> {
@@ -265,7 +266,7 @@ impl<'a, 'tcx> Implicator<'a, 'tcx> {
 
     fn accumulate_from_adt(&mut self,
                            ty: Ty<'tcx>,
-                           def_id: ast::DefId,
+                           def_id: DefId,
                            _generics: &ty::Generics<'tcx>,
                            substs: &Substs<'tcx>)
     {

--- a/src/librustc/middle/infer/mod.rs
+++ b/src/librustc/middle/infer/mod.rs
@@ -19,6 +19,7 @@ pub use middle::ty::IntVarValue;
 pub use self::freshen::TypeFreshener;
 pub use self::region_inference::{GenericKind, VerifyBound};
 
+use middle::def_id::DefId;
 use middle::free_region::FreeRegionMap;
 use middle::mem_categorization as mc;
 use middle::mem_categorization::McResult;
@@ -1483,7 +1484,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     }
 
     pub fn node_method_id(&self, method_call: ty::MethodCall)
-                          -> Option<ast::DefId> {
+                          -> Option<DefId> {
         self.tables
             .borrow()
             .method_map
@@ -1517,14 +1518,14 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     }
 
     pub fn closure_kind(&self,
-                        def_id: ast::DefId)
+                        def_id: DefId)
                         -> Option<ty::ClosureKind>
     {
         self.tables.borrow().closure_kinds.get(&def_id).cloned()
     }
 
     pub fn closure_type(&self,
-                        def_id: ast::DefId,
+                        def_id: DefId,
                         substs: &ty::ClosureSubsts<'tcx>)
                         -> ty::ClosureTy<'tcx>
     {

--- a/src/librustc/middle/infer/type_variable.rs
+++ b/src/librustc/middle/infer/type_variable.rs
@@ -11,8 +11,8 @@
 pub use self::RelationDir::*;
 use self::TypeVariableValue::*;
 use self::UndoEntry::*;
+use middle::def_id::{DefId};
 use middle::ty::{self, Ty};
-use syntax::ast::DefId;
 use syntax::codemap::Span;
 
 use std::cmp::min;

--- a/src/librustc/middle/intrinsicck.rs
+++ b/src/librustc/middle/intrinsicck.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use middle::def::DefFn;
-use middle::def_id::{DefId, LOCAL_CRATE};
+use middle::def_id::DefId;
 use middle::subst::{Subst, Substs, EnumeratedItems};
 use middle::ty::{TransmuteRestriction, ctxt, TyBareFn};
 use middle::ty::{self, Ty, HasTypeFlags};

--- a/src/librustc/middle/intrinsicck.rs
+++ b/src/librustc/middle/intrinsicck.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use middle::def::DefFn;
+use middle::def_id::{DefId, LOCAL_CRATE};
 use middle::subst::{Subst, Substs, EnumeratedItems};
 use middle::ty::{TransmuteRestriction, ctxt, TyBareFn};
 use middle::ty::{self, Ty, HasTypeFlags};
@@ -16,7 +17,6 @@ use middle::ty::{self, Ty, HasTypeFlags};
 use std::fmt;
 
 use syntax::abi::RustIntrinsic;
-use syntax::ast::DefId;
 use syntax::ast;
 use syntax::codemap::Span;
 use syntax::visit::Visitor;

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -73,6 +73,7 @@ pub use self::categorization::*;
 use self::Aliasability::*;
 
 use ast_map;
+use middle::def_id::DefId;
 use middle::infer;
 use middle::check_const;
 use middle::def;
@@ -94,7 +95,7 @@ pub enum categorization<'tcx> {
     cat_local(ast::NodeId),                    // local variable
     cat_deref(cmt<'tcx>, usize, PointerKind),   // deref of a ptr
     cat_interior(cmt<'tcx>, InteriorKind),     // something interior: field, tuple, etc
-    cat_downcast(cmt<'tcx>, ast::DefId),       // selects a particular enum variant (*1)
+    cat_downcast(cmt<'tcx>, DefId),       // selects a particular enum variant (*1)
 
     // (*1) downcast is only required if the enum has more than one variant
 }
@@ -1132,7 +1133,7 @@ impl<'t, 'a,'tcx> MemCategorizationContext<'t, 'a, 'tcx> {
                                     node: &N,
                                     base_cmt: cmt<'tcx>,
                                     downcast_ty: Ty<'tcx>,
-                                    variant_did: ast::DefId)
+                                    variant_did: DefId)
                                     -> cmt<'tcx> {
         let ret = Rc::new(cmt_ {
             id: node.id(),

--- a/src/librustc/middle/pat_util.rs
+++ b/src/librustc/middle/pat_util.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use middle::def::*;
+use middle::def_id::DefId;
 use middle::ty;
 use util::nodemap::FnvHashMap;
 
@@ -191,7 +192,7 @@ pub fn simple_identifier<'a>(pat: &'a ast::Pat) -> Option<&'a ast::Ident> {
     }
 }
 
-pub fn def_to_path(tcx: &ty::ctxt, id: ast::DefId) -> ast::Path {
+pub fn def_to_path(tcx: &ty::ctxt, id: DefId) -> ast::Path {
     tcx.with_path(id, |path| ast::Path {
         global: false,
         segments: path.last().map(|elem| ast::PathSegment {

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -16,9 +16,8 @@ pub use self::PrivateDep::*;
 pub use self::ImportUse::*;
 pub use self::LastPrivate::*;
 
+use middle::def_id::DefId;
 use util::nodemap::{DefIdSet, NodeSet};
-
-use syntax::ast;
 
 /// A set of AST nodes exported by the crate.
 pub type ExportedItems = NodeSet;
@@ -49,7 +48,7 @@ pub enum LastPrivate {
 #[derive(Copy, Clone, Debug)]
 pub enum PrivateDep {
     AllPublic,
-    DependsOn(ast::DefId),
+    DependsOn(DefId),
 }
 
 // How an import is used.

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -203,7 +203,7 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
                             // Check the impl. If the generics on the self
                             // type of the impl require inlining, this method
                             // does too.
-                            assert!(impl_did.krate == LOCAL_CRATE);
+                            assert!(impl_did.is_local());
                             match self.tcx
                                       .map
                                       .expect_item(impl_did.node)
@@ -356,7 +356,7 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
     // reachability, which might result in a compile time loss.
     fn mark_destructors_reachable(&mut self) {
         for (_, destructor_def_id) in self.tcx.destructor_for_type.borrow().iter() {
-            if destructor_def_id.krate == LOCAL_CRATE {
+            if destructor_def_id.is_local() {
                 self.reachable_symbols.insert(destructor_def_id.node);
             }
         }

--- a/src/librustc/middle/traits/coherence.rs
+++ b/src/librustc/middle/traits/coherence.rs
@@ -186,7 +186,7 @@ pub fn orphan_check<'tcx>(tcx: &ty::ctxt<'tcx>,
     debug!("orphan_check: trait_ref={:?}", trait_ref);
 
     // If the *trait* is local to the crate, ok.
-    if trait_ref.def_id.krate == LOCAL_CRATE {
+    if trait_ref.def_id.is_local() {
         debug!("trait {:?} is local to current crate",
                trait_ref.def_id);
         return Ok(());
@@ -318,7 +318,7 @@ fn ty_is_local_constructor<'tcx>(tcx: &ty::ctxt<'tcx>,
 
         ty::TyEnum(def, _) |
         ty::TyStruct(def, _) => {
-            def.did.krate == LOCAL_CRATE
+            def.did.is_local()
         }
 
         ty::TyBox(_) => { // Box<T>
@@ -327,7 +327,7 @@ fn ty_is_local_constructor<'tcx>(tcx: &ty::ctxt<'tcx>,
         }
 
         ty::TyTrait(ref tt) => {
-            tt.principal_def_id().krate == LOCAL_CRATE
+            tt.principal_def_id().is_local()
         }
 
         ty::TyClosure(..) |

--- a/src/librustc/middle/traits/error_reporting.rs
+++ b/src/librustc/middle/traits/error_reporting.rs
@@ -24,13 +24,13 @@ use super::{
 };
 
 use fmt_macros::{Parser, Piece, Position};
+use middle::def_id::DefId;
 use middle::infer::InferCtxt;
 use middle::ty::{self, ToPredicate, HasTypeFlags, ToPolyTraitRef, TraitRef, Ty};
 use middle::ty_fold::TypeFoldable;
 use std::collections::HashMap;
 use std::fmt;
 use syntax::codemap::Span;
-use syntax::ast;
 use syntax::attr::{AttributeMethods, AttrMetaMethods};
 
 pub fn report_fulfillment_errors<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
@@ -294,7 +294,7 @@ pub fn report_selection_error<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
 
 pub fn report_object_safety_error<'tcx>(tcx: &ty::ctxt<'tcx>,
                                         span: Span,
-                                        trait_def_id: ast::DefId,
+                                        trait_def_id: DefId,
                                         is_warning: bool)
 {
     span_err_or_warn!(

--- a/src/librustc/middle/traits/mod.rs
+++ b/src/librustc/middle/traits/mod.rs
@@ -15,6 +15,7 @@ pub use self::FulfillmentErrorCode::*;
 pub use self::Vtable::*;
 pub use self::ObligationCauseCode::*;
 
+use middle::def_id::DefId;
 use middle::free_region::FreeRegionMap;
 use middle::subst;
 use middle::ty::{self, HasTypeFlags, Ty};
@@ -112,7 +113,7 @@ pub enum ObligationCauseCode<'tcx> {
 
     /// In an impl of trait X for type Y, type Y must
     /// also implement all supertraits of X.
-    ItemObligation(ast::DefId),
+    ItemObligation(DefId),
 
     /// A type like `&'a T` is WF only if `T: 'a`.
     ReferenceOutlivesReferent(Ty<'tcx>),
@@ -168,7 +169,7 @@ pub enum SelectionError<'tcx> {
     OutputTypeParameterMismatch(ty::PolyTraitRef<'tcx>,
                                 ty::PolyTraitRef<'tcx>,
                                 ty::TypeError<'tcx>),
-    TraitNotObjectSafe(ast::DefId),
+    TraitNotObjectSafe(DefId),
 }
 
 pub struct FulfillmentError<'tcx> {
@@ -274,14 +275,14 @@ pub enum Vtable<'tcx, N> {
 /// impl, and nested obligations are satisfied later.
 #[derive(Clone, PartialEq, Eq)]
 pub struct VtableImplData<'tcx, N> {
-    pub impl_def_id: ast::DefId,
+    pub impl_def_id: DefId,
     pub substs: subst::Substs<'tcx>,
     pub nested: Vec<N>
 }
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct VtableClosureData<'tcx, N> {
-    pub closure_def_id: ast::DefId,
+    pub closure_def_id: DefId,
     pub substs: ty::ClosureSubsts<'tcx>,
     /// Nested obligations. This can be non-empty if the closure
     /// signature contains associated types.
@@ -290,7 +291,7 @@ pub struct VtableClosureData<'tcx, N> {
 
 #[derive(Clone)]
 pub struct VtableDefaultImplData<N> {
-    pub trait_def_id: ast::DefId,
+    pub trait_def_id: DefId,
     pub nested: Vec<N>
 }
 

--- a/src/librustc/middle/traits/object_safety.rs
+++ b/src/librustc/middle/traits/object_safety.rs
@@ -20,6 +20,7 @@
 use super::supertraits;
 use super::elaborate_predicates;
 
+use middle::def_id::DefId;
 use middle::subst::{self, SelfSpace, TypeSpace};
 use middle::traits;
 use middle::ty::{self, ToPolyTraitRef, Ty};
@@ -53,7 +54,7 @@ pub enum MethodViolationCode {
 }
 
 pub fn is_object_safe<'tcx>(tcx: &ty::ctxt<'tcx>,
-                            trait_def_id: ast::DefId)
+                            trait_def_id: DefId)
                             -> bool
 {
     // Because we query yes/no results frequently, we keep a cache:
@@ -76,7 +77,7 @@ pub fn is_object_safe<'tcx>(tcx: &ty::ctxt<'tcx>,
 }
 
 pub fn object_safety_violations<'tcx>(tcx: &ty::ctxt<'tcx>,
-                                      trait_def_id: ast::DefId)
+                                      trait_def_id: DefId)
                                       -> Vec<ObjectSafetyViolation<'tcx>>
 {
     traits::supertrait_def_ids(tcx, trait_def_id)
@@ -85,7 +86,7 @@ pub fn object_safety_violations<'tcx>(tcx: &ty::ctxt<'tcx>,
 }
 
 fn object_safety_violations_for_trait<'tcx>(tcx: &ty::ctxt<'tcx>,
-                                            trait_def_id: ast::DefId)
+                                            trait_def_id: DefId)
                                             -> Vec<ObjectSafetyViolation<'tcx>>
 {
     // Check methods for violations.
@@ -119,7 +120,7 @@ fn object_safety_violations_for_trait<'tcx>(tcx: &ty::ctxt<'tcx>,
 }
 
 fn supertraits_reference_self<'tcx>(tcx: &ty::ctxt<'tcx>,
-                                    trait_def_id: ast::DefId)
+                                    trait_def_id: DefId)
                                     -> bool
 {
     let trait_def = tcx.lookup_trait_def(trait_def_id);
@@ -152,7 +153,7 @@ fn supertraits_reference_self<'tcx>(tcx: &ty::ctxt<'tcx>,
 }
 
 fn trait_has_sized_self<'tcx>(tcx: &ty::ctxt<'tcx>,
-                              trait_def_id: ast::DefId)
+                              trait_def_id: DefId)
                               -> bool
 {
     let trait_def = tcx.lookup_trait_def(trait_def_id);
@@ -194,7 +195,7 @@ fn generics_require_sized_self<'tcx>(tcx: &ty::ctxt<'tcx>,
 
 /// Returns `Some(_)` if this method makes the containing trait not object safe.
 fn object_safety_violation_for_method<'tcx>(tcx: &ty::ctxt<'tcx>,
-                                            trait_def_id: ast::DefId,
+                                            trait_def_id: DefId,
                                             method: &ty::Method<'tcx>)
                                             -> Option<MethodViolationCode>
 {
@@ -212,7 +213,7 @@ fn object_safety_violation_for_method<'tcx>(tcx: &ty::ctxt<'tcx>,
 /// non-vtable-safe methods, so long as they require `Self:Sized` or
 /// otherwise ensure that they cannot be used when `Self=Trait`.
 pub fn is_vtable_safe_method<'tcx>(tcx: &ty::ctxt<'tcx>,
-                                   trait_def_id: ast::DefId,
+                                   trait_def_id: DefId,
                                    method: &ty::Method<'tcx>)
                                    -> bool
 {
@@ -224,7 +225,7 @@ pub fn is_vtable_safe_method<'tcx>(tcx: &ty::ctxt<'tcx>,
 /// is not object safe, because the method might have a where clause
 /// `Self:Sized`.
 fn virtual_call_violation_for_method<'tcx>(tcx: &ty::ctxt<'tcx>,
-                                           trait_def_id: ast::DefId,
+                                           trait_def_id: DefId,
                                            method: &ty::Method<'tcx>)
                                            -> Option<MethodViolationCode>
 {
@@ -265,7 +266,7 @@ fn virtual_call_violation_for_method<'tcx>(tcx: &ty::ctxt<'tcx>,
 }
 
 fn contains_illegal_self_type_reference<'tcx>(tcx: &ty::ctxt<'tcx>,
-                                              trait_def_id: ast::DefId,
+                                              trait_def_id: DefId,
                                               ty: Ty<'tcx>)
                                               -> bool
 {

--- a/src/librustc/middle/traits/util.rs
+++ b/src/librustc/middle/traits/util.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use middle::subst::Substs;
+use middle::def_id::DefId;
 use middle::infer::InferCtxt;
+use middle::subst::Substs;
 use middle::ty::{self, HasTypeFlags, Ty, ToPredicate, ToPolyTraitRef};
 use std::fmt;
-use syntax::ast;
 use syntax::codemap::Span;
 use util::common::ErrorReported;
 use util::nodemap::FnvHashSet;
@@ -226,12 +226,12 @@ pub fn transitive_bounds<'cx, 'tcx>(tcx: &'cx ty::ctxt<'tcx>,
 
 pub struct SupertraitDefIds<'cx, 'tcx:'cx> {
     tcx: &'cx ty::ctxt<'tcx>,
-    stack: Vec<ast::DefId>,
-    visited: FnvHashSet<ast::DefId>,
+    stack: Vec<DefId>,
+    visited: FnvHashSet<DefId>,
 }
 
 pub fn supertrait_def_ids<'cx, 'tcx>(tcx: &'cx ty::ctxt<'tcx>,
-                                     trait_def_id: ast::DefId)
+                                     trait_def_id: DefId)
                                      -> SupertraitDefIds<'cx, 'tcx>
 {
     SupertraitDefIds {
@@ -242,9 +242,9 @@ pub fn supertrait_def_ids<'cx, 'tcx>(tcx: &'cx ty::ctxt<'tcx>,
 }
 
 impl<'cx, 'tcx> Iterator for SupertraitDefIds<'cx, 'tcx> {
-    type Item = ast::DefId;
+    type Item = DefId;
 
-    fn next(&mut self) -> Option<ast::DefId> {
+    fn next(&mut self) -> Option<DefId> {
         let def_id = match self.stack.pop() {
             Some(def_id) => def_id,
             None => { return None; }
@@ -307,7 +307,7 @@ impl<'tcx,I:Iterator<Item=ty::Predicate<'tcx>>> Iterator for FilterToTraits<I> {
 // variables.
 pub fn fresh_type_vars_for_impl<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
                                           span: Span,
-                                          impl_def_id: ast::DefId)
+                                          impl_def_id: DefId)
                                           -> Substs<'tcx>
 {
     let tcx = infcx.tcx;
@@ -368,7 +368,7 @@ pub fn predicate_for_trait_ref<'tcx>(
 pub fn predicate_for_trait_def<'tcx>(
     tcx: &ty::ctxt<'tcx>,
     cause: ObligationCause<'tcx>,
-    trait_def_id: ast::DefId,
+    trait_def_id: DefId,
     recursion_depth: usize,
     param_ty: Ty<'tcx>,
     ty_params: Vec<Ty<'tcx>>)
@@ -398,7 +398,7 @@ pub fn predicate_for_builtin_bound<'tcx>(
 /// supertrait.
 pub fn upcast<'tcx>(tcx: &ty::ctxt<'tcx>,
                     source_trait_ref: ty::PolyTraitRef<'tcx>,
-                    target_trait_def_id: ast::DefId)
+                    target_trait_def_id: DefId)
                     -> Vec<ty::PolyTraitRef<'tcx>>
 {
     if source_trait_ref.def_id() == target_trait_def_id {
@@ -432,7 +432,7 @@ pub fn count_own_vtable_entries<'tcx>(tcx: &ty::ctxt<'tcx>,
 /// `object.upcast_trait_ref`) within the vtable for `object`.
 pub fn get_vtable_index_of_object_method<'tcx>(tcx: &ty::ctxt<'tcx>,
                                                object: &super::VtableObjectData<'tcx>,
-                                               method_def_id: ast::DefId) -> usize {
+                                               method_def_id: DefId) -> usize {
     // Count number of methods preceding the one we are selecting and
     // add them to the total offset.
     // Skip over associated types and constants.
@@ -460,7 +460,7 @@ pub enum TupleArgumentsFlag { Yes, No }
 
 pub fn closure_trait_ref_and_return_type<'tcx>(
     tcx: &ty::ctxt<'tcx>,
-    fn_trait_def_id: ast::DefId,
+    fn_trait_def_id: DefId,
     self_ty: Ty<'tcx>,
     sig: &ty::PolyFnSig<'tcx>,
     tuple_arguments: TupleArgumentsFlag)

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -5468,7 +5468,7 @@ fn lookup_locally_or_in_crate_store<V, F>(descr: &str,
         None => { }
     }
 
-    if def_id.krate == LOCAL_CRATE {
+    if def_id.is_local() {
         panic!("No def'n found for {:?} in tcx.{}", def_id, descr);
     }
     let v = load_external();
@@ -5776,7 +5776,7 @@ impl<'tcx> ctxt<'tcx> {
                                              expected.ty,
                                              found.ty));
 
-                match (expected.def_id.krate == LOCAL_CRATE,
+                match (expected.def_id.is_local(),
                        self.map.opt_span(expected.def_id.node)) {
                     (true, Some(span)) => {
                         self.sess.span_note(span,
@@ -5793,7 +5793,7 @@ impl<'tcx> ctxt<'tcx> {
                     expected.origin_span,
                     &format!("...that was applied to an unconstrained type variable here"));
 
-                match (found.def_id.krate == LOCAL_CRATE,
+                match (found.def_id.is_local(),
                        self.map.opt_span(found.def_id.node)) {
                     (true, Some(span)) => {
                         self.sess.span_note(span,
@@ -5905,7 +5905,7 @@ impl<'tcx> ctxt<'tcx> {
     }
 
     pub fn trait_impl_polarity(&self, id: DefId) -> Option<ast::ImplPolarity> {
-        if id.krate == LOCAL_CRATE {
+        if id.is_local() {
             match self.map.find(id.node) {
                 Some(ast_map::NodeItem(item)) => {
                     match item.node {
@@ -5961,7 +5961,7 @@ impl<'tcx> ctxt<'tcx> {
 
     /// Returns whether this DefId refers to an impl
     pub fn is_impl(&self, id: DefId) -> bool {
-        if id.krate == LOCAL_CRATE {
+        if id.is_local() {
             if let Some(ast_map::NodeItem(
                 &ast::Item { node: ast::ItemImpl(..), .. })) = self.map.find(id.node) {
                 true
@@ -6012,7 +6012,7 @@ impl<'tcx> ctxt<'tcx> {
     pub fn with_path<T, F>(&self, id: DefId, f: F) -> T where
         F: FnOnce(ast_map::PathElems) -> T,
     {
-        if id.krate == LOCAL_CRATE {
+        if id.is_local() {
             self.map.with_path(id.node, f)
         } else {
             f(csearch::get_item_path(self, id).iter().cloned().chain(LinkedPath::empty()))
@@ -6135,7 +6135,7 @@ impl<'tcx> ctxt<'tcx> {
     /// Obtain the representation annotation for a struct definition.
     pub fn lookup_repr_hints(&self, did: DefId) -> Rc<Vec<attr::ReprAttr>> {
         memoized(&self.repr_hint_cache, did, |did: DefId| {
-            Rc::new(if did.krate == LOCAL_CRATE {
+            Rc::new(if did.is_local() {
                 self.get_attrs(did).iter().flat_map(|meta| {
                     attr::find_repr_attrs(self.sess.diagnostic(), meta).into_iter()
                 }).collect()
@@ -6315,7 +6315,7 @@ impl<'tcx> ctxt<'tcx> {
     /// Load primitive inherent implementations if necessary
     pub fn populate_implementations_for_primitive_if_necessary(&self,
                                                                primitive_def_id: DefId) {
-        if primitive_def_id.krate == LOCAL_CRATE {
+        if primitive_def_id.is_local() {
             return
         }
 
@@ -6337,7 +6337,7 @@ impl<'tcx> ctxt<'tcx> {
     /// the given type if necessary.
     pub fn populate_inherent_implementations_for_type_if_necessary(&self,
                                                                    type_id: DefId) {
-        if type_id.krate == LOCAL_CRATE {
+        if type_id.is_local() {
             return
         }
 
@@ -6365,7 +6365,7 @@ impl<'tcx> ctxt<'tcx> {
     /// Populates the type context with all the implementations for the given
     /// trait if necessary.
     pub fn populate_implementations_for_trait_if_necessary(&self, trait_id: DefId) {
-        if trait_id.krate == LOCAL_CRATE {
+        if trait_id.is_local() {
             return
         }
 

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -47,6 +47,7 @@ use middle::check_const;
 use middle::const_eval::{self, ConstVal, ErrKind};
 use middle::const_eval::EvalHint::UncheckedExprHint;
 use middle::def::{self, DefMap, ExportMap};
+use middle::def_id::{DefId, LOCAL_CRATE};
 use middle::fast_reject;
 use middle::free_region::FreeRegionMap;
 use middle::lang_items::{FnTraitLangItem, FnMutTraitLangItem, FnOnceTraitLangItem};
@@ -85,9 +86,8 @@ use core::nonzero::NonZero;
 use std::collections::{HashMap, HashSet};
 use rustc_data_structures::ivar;
 use syntax::abi;
-use syntax::ast::{CrateNum, DefId, ItemImpl, ItemTrait, LOCAL_CRATE};
+use syntax::ast::{CrateNum, ItemImpl, ItemTrait};
 use syntax::ast::{MutImmutable, MutMutable, Name, NodeId, Visibility};
-use syntax::ast_util::{self, is_local, local_def};
 use syntax::attr::{self, AttrMetaMethods, SignedInt, UnsignedInt};
 use syntax::codemap::Span;
 use syntax::parse::token::{InternedString, special_idents};
@@ -254,12 +254,12 @@ impl IntTypeExt for attr::IntType {
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum ImplOrTraitItemContainer {
-    TraitContainer(ast::DefId),
-    ImplContainer(ast::DefId),
+    TraitContainer(DefId),
+    ImplContainer(DefId),
 }
 
 impl ImplOrTraitItemContainer {
-    pub fn id(&self) -> ast::DefId {
+    pub fn id(&self) -> DefId {
         match *self {
             TraitContainer(id) => id,
             ImplContainer(id) => id,
@@ -287,7 +287,7 @@ impl<'tcx> ImplOrTraitItem<'tcx> {
         }
     }
 
-    pub fn def_id(&self) -> ast::DefId {
+    pub fn def_id(&self) -> DefId {
         match *self {
             ConstTraitItem(ref associated_const) => associated_const.def_id,
             MethodTraitItem(ref method) => method.def_id,
@@ -329,13 +329,13 @@ impl<'tcx> ImplOrTraitItem<'tcx> {
 
 #[derive(Clone, Copy, Debug)]
 pub enum ImplOrTraitItemId {
-    ConstTraitItemId(ast::DefId),
-    MethodTraitItemId(ast::DefId),
-    TypeTraitItemId(ast::DefId),
+    ConstTraitItemId(DefId),
+    MethodTraitItemId(DefId),
+    TypeTraitItemId(DefId),
 }
 
 impl ImplOrTraitItemId {
-    pub fn def_id(&self) -> ast::DefId {
+    pub fn def_id(&self) -> DefId {
         match *self {
             ConstTraitItemId(def_id) => def_id,
             MethodTraitItemId(def_id) => def_id,
@@ -352,11 +352,11 @@ pub struct Method<'tcx> {
     pub fty: BareFnTy<'tcx>,
     pub explicit_self: ExplicitSelfCategory,
     pub vis: ast::Visibility,
-    pub def_id: ast::DefId,
+    pub def_id: DefId,
     pub container: ImplOrTraitItemContainer,
 
     // If this method is provided, we need to know where it came from
-    pub provided_source: Option<ast::DefId>
+    pub provided_source: Option<DefId>
 }
 
 impl<'tcx> Method<'tcx> {
@@ -366,9 +366,9 @@ impl<'tcx> Method<'tcx> {
                fty: BareFnTy<'tcx>,
                explicit_self: ExplicitSelfCategory,
                vis: ast::Visibility,
-               def_id: ast::DefId,
+               def_id: DefId,
                container: ImplOrTraitItemContainer,
-               provided_source: Option<ast::DefId>)
+               provided_source: Option<DefId>)
                -> Method<'tcx> {
        Method {
             name: name,
@@ -383,7 +383,7 @@ impl<'tcx> Method<'tcx> {
         }
     }
 
-    pub fn container_id(&self) -> ast::DefId {
+    pub fn container_id(&self) -> DefId {
         match self.container {
             TraitContainer(id) => id,
             ImplContainer(id) => id,
@@ -396,9 +396,9 @@ pub struct AssociatedConst<'tcx> {
     pub name: ast::Name,
     pub ty: Ty<'tcx>,
     pub vis: ast::Visibility,
-    pub def_id: ast::DefId,
+    pub def_id: DefId,
     pub container: ImplOrTraitItemContainer,
-    pub default: Option<ast::DefId>,
+    pub default: Option<DefId>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -406,7 +406,7 @@ pub struct AssociatedType<'tcx> {
     pub name: ast::Name,
     pub ty: Option<Ty<'tcx>>,
     pub vis: ast::Visibility,
-    pub def_id: ast::DefId,
+    pub def_id: DefId,
     pub container: ImplOrTraitItemContainer,
 }
 
@@ -543,7 +543,7 @@ pub enum CustomCoerceUnsized {
 #[derive(Clone, Copy, Debug)]
 pub struct MethodCallee<'tcx> {
     /// Impl method ID, for inherent methods, or trait method ID, otherwise.
-    pub def_id: ast::DefId,
+    pub def_id: DefId,
     pub ty: Ty<'tcx>,
     pub substs: &'tcx subst::Substs<'tcx>
 }
@@ -789,7 +789,7 @@ pub struct ctxt<'tcx> {
     pub normalized_cache: RefCell<FnvHashMap<Ty<'tcx>, Ty<'tcx>>>,
     pub lang_items: middle::lang_items::LanguageItems,
     /// A mapping of fake provided method def_ids to the default implementation
-    pub provided_method_sources: RefCell<DefIdMap<ast::DefId>>,
+    pub provided_method_sources: RefCell<DefIdMap<DefId>>,
 
     /// Maps from def-id of a type or region parameter to its
     /// (inferred) variance.
@@ -802,7 +802,7 @@ pub struct ctxt<'tcx> {
     /// of the method that implements its destructor. If the type is not
     /// present in this map, it does not have a destructor. This map is
     /// populated during the coherence phase of typechecking.
-    pub destructor_for_type: RefCell<DefIdMap<ast::DefId>>,
+    pub destructor_for_type: RefCell<DefIdMap<DefId>>,
 
     /// A method will be in this list if and only if it is a destructor.
     pub destructors: RefCell<DefIdSet>,
@@ -810,7 +810,7 @@ pub struct ctxt<'tcx> {
     /// Maps a DefId of a type to a list of its inherent impls.
     /// Contains implementations of methods that are inherent to a type.
     /// Methods in these implementations don't need to be exported.
-    pub inherent_impls: RefCell<DefIdMap<Rc<Vec<ast::DefId>>>>,
+    pub inherent_impls: RefCell<DefIdMap<Rc<Vec<DefId>>>>,
 
     /// Maps a DefId of an impl to a list of its items.
     /// Note that this contains all of the impls that we know about,
@@ -1094,11 +1094,11 @@ impl<'tcx, T: Lift<'tcx>> Lift<'tcx> for Binder<T> {
 
 pub mod tls {
     use ast_map;
+    use middle::def_id::{DefId, DEF_ID_DEBUG, LOCAL_CRATE};
     use middle::ty;
     use session::Session;
 
     use std::fmt;
-    use syntax::ast;
     use syntax::codemap;
 
     /// Marker type used for the scoped TLS slot.
@@ -1108,12 +1108,12 @@ pub mod tls {
 
     scoped_thread_local!(static TLS_TCX: ThreadLocalTyCx);
 
-    fn def_id_debug(def_id: ast::DefId, f: &mut fmt::Formatter) -> fmt::Result {
+    fn def_id_debug(def_id: DefId, f: &mut fmt::Formatter) -> fmt::Result {
         // Unfortunately, there seems to be no way to attempt to print
         // a path for a def-id, so I'll just make a best effort for now
         // and otherwise fallback to just printing the crate/node pair
         with(|tcx| {
-            if def_id.krate == ast::LOCAL_CRATE {
+            if def_id.krate == LOCAL_CRATE {
                 match tcx.map.find(def_id.node) {
                     Some(ast_map::NodeItem(..)) |
                     Some(ast_map::NodeForeignItem(..)) |
@@ -1138,7 +1138,7 @@ pub mod tls {
 
     pub fn enter<'tcx, F: FnOnce(&ty::ctxt<'tcx>) -> R, R>(tcx: ty::ctxt<'tcx>, f: F)
                                                            -> (Session, R) {
-        let result = ast::DEF_ID_DEBUG.with(|def_id_dbg| {
+        let result = DEF_ID_DEBUG.with(|def_id_dbg| {
             codemap::SPAN_DEBUG.with(|span_dbg| {
                 let original_def_id_debug = def_id_dbg.get();
                 def_id_dbg.set(def_id_debug);
@@ -1711,7 +1711,7 @@ pub enum BoundRegion {
     ///
     /// The def-id is needed to distinguish free regions in
     /// the event of shadowing.
-    BrNamed(ast::DefId, ast::Name),
+    BrNamed(DefId, ast::Name),
 
     /// Fresh bound identifiers created during GLB computations.
     BrFresh(u32),
@@ -1907,7 +1907,7 @@ pub struct TraitTy<'tcx> {
 }
 
 impl<'tcx> TraitTy<'tcx> {
-    pub fn principal_def_id(&self) -> ast::DefId {
+    pub fn principal_def_id(&self) -> DefId {
         self.principal.0.def_id
     }
 
@@ -1984,7 +1984,7 @@ impl<'tcx> PolyTraitRef<'tcx> {
         self.0.self_ty()
     }
 
-    pub fn def_id(&self) -> ast::DefId {
+    pub fn def_id(&self) -> DefId {
         self.0.def_id
     }
 
@@ -2087,7 +2087,7 @@ pub enum TypeError<'tcx> {
     IntegerAsChar,
     IntMismatch(ExpectedFound<IntVarValue>),
     FloatMismatch(ExpectedFound<ast::FloatTy>),
-    Traits(ExpectedFound<ast::DefId>),
+    Traits(ExpectedFound<DefId>),
     BuiltinBoundsMismatch(ExpectedFound<BuiltinBounds>),
     VariadicMismatch(ExpectedFound<bool>),
     CyclicTy,
@@ -2304,7 +2304,7 @@ pub enum ObjectLifetimeDefault {
 #[derive(Clone)]
 pub struct TypeParameterDef<'tcx> {
     pub name: ast::Name,
-    pub def_id: ast::DefId,
+    pub def_id: DefId,
     pub space: subst::ParamSpace,
     pub index: u32,
     pub default_def_id: DefId, // for use in error reporing about defaults
@@ -2315,7 +2315,7 @@ pub struct TypeParameterDef<'tcx> {
 #[derive(RustcEncodable, RustcDecodable, Clone, Debug)]
 pub struct RegionParameterDef {
     pub name: ast::Name,
-    pub def_id: ast::DefId,
+    pub def_id: DefId,
     pub space: subst::ParamSpace,
     pub index: u32,
     pub bounds: Vec<ty::Region>,
@@ -2419,7 +2419,7 @@ pub enum Predicate<'tcx> {
     WellFormed(Ty<'tcx>),
 
     /// trait must be object-safe
-    ObjectSafe(ast::DefId),
+    ObjectSafe(DefId),
 }
 
 impl<'tcx> Predicate<'tcx> {
@@ -2520,7 +2520,7 @@ pub struct TraitPredicate<'tcx> {
 pub type PolyTraitPredicate<'tcx> = ty::Binder<TraitPredicate<'tcx>>;
 
 impl<'tcx> TraitPredicate<'tcx> {
-    pub fn def_id(&self) -> ast::DefId {
+    pub fn def_id(&self) -> DefId {
         self.trait_ref.def_id
     }
 
@@ -2534,7 +2534,7 @@ impl<'tcx> TraitPredicate<'tcx> {
 }
 
 impl<'tcx> PolyTraitPredicate<'tcx> {
-    pub fn def_id(&self) -> ast::DefId {
+    pub fn def_id(&self) -> DefId {
         self.0.def_id()
     }
 }
@@ -2574,7 +2574,7 @@ impl<'tcx> PolyProjectionPredicate<'tcx> {
         self.0.projection_ty.item_name // safe to skip the binder to access a name
     }
 
-    pub fn sort_key(&self) -> (ast::DefId, ast::Name) {
+    pub fn sort_key(&self) -> (DefId, ast::Name) {
         self.0.projection_ty.sort_key()
     }
 }
@@ -2591,7 +2591,7 @@ pub struct ProjectionTy<'tcx> {
 }
 
 impl<'tcx> ProjectionTy<'tcx> {
-    pub fn sort_key(&self) -> (ast::DefId, ast::Name) {
+    pub fn sort_key(&self) -> (DefId, ast::Name) {
         (self.trait_ref.def_id, self.item_name)
     }
 }
@@ -2780,7 +2780,7 @@ impl<'tcx> InstantiatedPredicates<'tcx> {
 }
 
 impl<'tcx> TraitRef<'tcx> {
-    pub fn new(def_id: ast::DefId, substs: &'tcx Substs<'tcx>) -> TraitRef<'tcx> {
+    pub fn new(def_id: DefId, substs: &'tcx Substs<'tcx>) -> TraitRef<'tcx> {
         TraitRef { def_id: def_id, substs: substs }
     }
 
@@ -2864,7 +2864,7 @@ impl<'a, 'tcx> ParameterEnvironment<'a, 'tcx> {
                         // associated types don't have their own entry (for some reason),
                         // so for now just grab environment for the impl
                         let impl_id = cx.map.get_parent(id);
-                        let impl_def_id = ast_util::local_def(impl_id);
+                        let impl_def_id = DefId::local(impl_id);
                         let scheme = cx.lookup_item_type(impl_def_id);
                         let predicates = cx.lookup_predicates(impl_def_id);
                         cx.construct_parameter_environment(impl_item.span,
@@ -2873,7 +2873,7 @@ impl<'a, 'tcx> ParameterEnvironment<'a, 'tcx> {
                                                            id)
                     }
                     ast::ConstImplItem(_, _) => {
-                        let def_id = ast_util::local_def(id);
+                        let def_id = DefId::local(id);
                         let scheme = cx.lookup_item_type(def_id);
                         let predicates = cx.lookup_predicates(def_id);
                         cx.construct_parameter_environment(impl_item.span,
@@ -2882,7 +2882,7 @@ impl<'a, 'tcx> ParameterEnvironment<'a, 'tcx> {
                                                            id)
                     }
                     ast::MethodImplItem(_, ref body) => {
-                        let method_def_id = ast_util::local_def(id);
+                        let method_def_id = DefId::local(id);
                         match cx.impl_or_trait_item(method_def_id) {
                             MethodTraitItem(ref method_ty) => {
                                 let method_generics = &method_ty.generics;
@@ -2909,7 +2909,7 @@ impl<'a, 'tcx> ParameterEnvironment<'a, 'tcx> {
                         // associated types don't have their own entry (for some reason),
                         // so for now just grab environment for the trait
                         let trait_id = cx.map.get_parent(id);
-                        let trait_def_id = ast_util::local_def(trait_id);
+                        let trait_def_id = DefId::local(trait_id);
                         let trait_def = cx.lookup_trait_def(trait_def_id);
                         let predicates = cx.lookup_predicates(trait_def_id);
                         cx.construct_parameter_environment(trait_item.span,
@@ -2918,7 +2918,7 @@ impl<'a, 'tcx> ParameterEnvironment<'a, 'tcx> {
                                                            id)
                     }
                     ast::ConstTraitItem(..) => {
-                        let def_id = ast_util::local_def(id);
+                        let def_id = DefId::local(id);
                         let scheme = cx.lookup_item_type(def_id);
                         let predicates = cx.lookup_predicates(def_id);
                         cx.construct_parameter_environment(trait_item.span,
@@ -2931,7 +2931,7 @@ impl<'a, 'tcx> ParameterEnvironment<'a, 'tcx> {
                         // block, unless this is a trait method with
                         // no default, then fallback to the method id.
                         let body_id = body.as_ref().map(|b| b.id).unwrap_or(id);
-                        let method_def_id = ast_util::local_def(id);
+                        let method_def_id = DefId::local(id);
                         match cx.impl_or_trait_item(method_def_id) {
                             MethodTraitItem(ref method_ty) => {
                                 let method_generics = &method_ty.generics;
@@ -2956,7 +2956,7 @@ impl<'a, 'tcx> ParameterEnvironment<'a, 'tcx> {
                 match item.node {
                     ast::ItemFn(_, _, _, _, _, ref body) => {
                         // We assume this is a function.
-                        let fn_def_id = ast_util::local_def(id);
+                        let fn_def_id = DefId::local(id);
                         let fn_scheme = cx.lookup_item_type(fn_def_id);
                         let fn_predicates = cx.lookup_predicates(fn_def_id);
 
@@ -2970,7 +2970,7 @@ impl<'a, 'tcx> ParameterEnvironment<'a, 'tcx> {
                     ast::ItemImpl(..) |
                     ast::ItemConst(..) |
                     ast::ItemStatic(..) => {
-                        let def_id = ast_util::local_def(id);
+                        let def_id = DefId::local(id);
                         let scheme = cx.lookup_item_type(def_id);
                         let predicates = cx.lookup_predicates(def_id);
                         cx.construct_parameter_environment(item.span,
@@ -2979,7 +2979,7 @@ impl<'a, 'tcx> ParameterEnvironment<'a, 'tcx> {
                                                            id)
                     }
                     ast::ItemTrait(..) => {
-                        let def_id = ast_util::local_def(id);
+                        let def_id = DefId::local(id);
                         let trait_def = cx.lookup_trait_def(def_id);
                         let predicates = cx.lookup_predicates(def_id);
                         cx.construct_parameter_environment(item.span,
@@ -3532,7 +3532,7 @@ pub enum ClosureKind {
 }
 
 impl ClosureKind {
-    pub fn trait_did(&self, cx: &ctxt) -> ast::DefId {
+    pub fn trait_did(&self, cx: &ctxt) -> DefId {
         let result = match *self {
             FnClosureKind => cx.lang_items.require(FnTraitLangItem),
             FnMutClosureKind => {
@@ -3902,12 +3902,12 @@ impl<'tcx> ctxt<'tcx> {
         region
     }
 
-    pub fn closure_kind(&self, def_id: ast::DefId) -> ty::ClosureKind {
+    pub fn closure_kind(&self, def_id: DefId) -> ty::ClosureKind {
         *self.tables.borrow().closure_kinds.get(&def_id).unwrap()
     }
 
     pub fn closure_type(&self,
-                        def_id: ast::DefId,
+                        def_id: DefId,
                         substs: &ClosureSubsts<'tcx>)
                         -> ty::ClosureTy<'tcx>
     {
@@ -4056,13 +4056,13 @@ impl<'tcx> ctxt<'tcx> {
     }
 
     pub fn mk_fn(&self,
-                 opt_def_id: Option<ast::DefId>,
+                 opt_def_id: Option<DefId>,
                  fty: &'tcx BareFnTy<'tcx>) -> Ty<'tcx> {
         self.mk_ty(TyBareFn(opt_def_id, fty))
     }
 
     pub fn mk_ctor_fn(&self,
-                      def_id: ast::DefId,
+                      def_id: DefId,
                       input_tys: &[Ty<'tcx>],
                       output: Ty<'tcx>) -> Ty<'tcx> {
         let input_args = input_tys.iter().cloned().collect();
@@ -4106,7 +4106,7 @@ impl<'tcx> ctxt<'tcx> {
     }
 
     pub fn mk_closure(&self,
-                      closure_id: ast::DefId,
+                      closure_id: DefId,
                       substs: &'tcx Substs<'tcx>,
                       tys: Vec<Ty<'tcx>>)
                       -> Ty<'tcx> {
@@ -4117,7 +4117,7 @@ impl<'tcx> ctxt<'tcx> {
     }
 
     pub fn mk_closure_from_closure_substs(&self,
-                                          closure_id: ast::DefId,
+                                          closure_id: DefId,
                                           closure_substs: Box<ClosureSubsts<'tcx>>)
                                           -> Ty<'tcx> {
         self.mk_ty(TyClosure(closure_id, closure_substs))
@@ -4424,7 +4424,7 @@ impl<'tcx> TyS<'tcx> {
         }
     }
 
-    pub fn ty_to_def_id(&self) -> Option<ast::DefId> {
+    pub fn ty_to_def_id(&self) -> Option<DefId> {
         match self.sty {
             TyTrait(ref tt) => Some(tt.principal_def_id()),
             TyStruct(def, _) |
@@ -4681,7 +4681,7 @@ impl<'tcx> TyS<'tcx> {
             result
         }
 
-        fn apply_lang_items(cx: &ctxt, did: ast::DefId, tc: TypeContents)
+        fn apply_lang_items(cx: &ctxt, did: DefId, tc: TypeContents)
                             -> TypeContents {
             if Some(did) == cx.lang_items.unsafe_cell_type() {
                 tc | TC::InteriorUnsafe
@@ -5457,7 +5457,7 @@ impl<'tcx> fmt::Display for TypeError<'tcx> {
 /// then we have to go consult the crate loading code (and cache the result for
 /// the future).
 fn lookup_locally_or_in_crate_store<V, F>(descr: &str,
-                                          def_id: ast::DefId,
+                                          def_id: DefId,
                                           map: &RefCell<DefIdMap<V>>,
                                           load_external: F) -> V where
     V: Clone,
@@ -5468,7 +5468,7 @@ fn lookup_locally_or_in_crate_store<V, F>(descr: &str,
         None => { }
     }
 
-    if def_id.krate == ast::LOCAL_CRATE {
+    if def_id.krate == LOCAL_CRATE {
         panic!("No def'n found for {:?} in tcx.{}", def_id, descr);
     }
     let v = load_external();
@@ -5515,7 +5515,7 @@ impl<'tcx> ctxt<'tcx> {
     pub fn positional_element_ty(&self,
                                  ty: Ty<'tcx>,
                                  i: usize,
-                                 variant: Option<ast::DefId>) -> Option<Ty<'tcx>> {
+                                 variant: Option<DefId>) -> Option<Ty<'tcx>> {
         match (&ty.sty, variant) {
             (&TyStruct(def, substs), None) => {
                 def.struct_variant().fields.get(i).map(|f| f.ty(self, substs))
@@ -5537,7 +5537,7 @@ impl<'tcx> ctxt<'tcx> {
     pub fn named_element_ty(&self,
                             ty: Ty<'tcx>,
                             n: ast::Name,
-                            variant: Option<ast::DefId>) -> Option<Ty<'tcx>> {
+                            variant: Option<DefId>) -> Option<Ty<'tcx>> {
         match (&ty.sty, variant) {
             (&TyStruct(def, substs), None) => {
                 def.struct_variant().find_field_named(n).map(|f| f.ty(self, substs))
@@ -5776,7 +5776,7 @@ impl<'tcx> ctxt<'tcx> {
                                              expected.ty,
                                              found.ty));
 
-                match (expected.def_id.krate == ast::LOCAL_CRATE,
+                match (expected.def_id.krate == LOCAL_CRATE,
                        self.map.opt_span(expected.def_id.node)) {
                     (true, Some(span)) => {
                         self.sess.span_note(span,
@@ -5793,7 +5793,7 @@ impl<'tcx> ctxt<'tcx> {
                     expected.origin_span,
                     &format!("...that was applied to an unconstrained type variable here"));
 
-                match (found.def_id.krate == ast::LOCAL_CRATE,
+                match (found.def_id.krate == LOCAL_CRATE,
                        self.map.opt_span(found.def_id.node)) {
                     (true, Some(span)) => {
                         self.sess.span_note(span,
@@ -5814,16 +5814,16 @@ impl<'tcx> ctxt<'tcx> {
         }
     }
 
-    pub fn provided_source(&self, id: ast::DefId) -> Option<ast::DefId> {
+    pub fn provided_source(&self, id: DefId) -> Option<DefId> {
         self.provided_method_sources.borrow().get(&id).cloned()
     }
 
-    pub fn provided_trait_methods(&self, id: ast::DefId) -> Vec<Rc<Method<'tcx>>> {
-        if is_local(id) {
+    pub fn provided_trait_methods(&self, id: DefId) -> Vec<Rc<Method<'tcx>>> {
+        if id.is_local() {
             if let ItemTrait(_, _, _, ref ms) = self.map.expect_item(id.node).node {
                 ms.iter().filter_map(|ti| {
                     if let ast::MethodTraitItem(_, Some(_)) = ti.node {
-                        match self.impl_or_trait_item(ast_util::local_def(ti.id)) {
+                        match self.impl_or_trait_item(DefId::local(ti.id)) {
                             MethodTraitItem(m) => Some(m),
                             _ => {
                                 self.sess.bug("provided_trait_methods(): \
@@ -5843,13 +5843,13 @@ impl<'tcx> ctxt<'tcx> {
         }
     }
 
-    pub fn associated_consts(&self, id: ast::DefId) -> Vec<Rc<AssociatedConst<'tcx>>> {
-        if is_local(id) {
+    pub fn associated_consts(&self, id: DefId) -> Vec<Rc<AssociatedConst<'tcx>>> {
+        if id.is_local() {
             match self.map.expect_item(id.node).node {
                 ItemTrait(_, _, _, ref tis) => {
                     tis.iter().filter_map(|ti| {
                         if let ast::ConstTraitItem(_, _) = ti.node {
-                            match self.impl_or_trait_item(ast_util::local_def(ti.id)) {
+                            match self.impl_or_trait_item(DefId::local(ti.id)) {
                                 ConstTraitItem(ac) => Some(ac),
                                 _ => {
                                     self.sess.bug("associated_consts(): \
@@ -5865,7 +5865,7 @@ impl<'tcx> ctxt<'tcx> {
                 ItemImpl(_, _, _, _, _, ref iis) => {
                     iis.iter().filter_map(|ii| {
                         if let ast::ConstImplItem(_, _) = ii.node {
-                            match self.impl_or_trait_item(ast_util::local_def(ii.id)) {
+                            match self.impl_or_trait_item(DefId::local(ii.id)) {
                                 ConstTraitItem(ac) => Some(ac),
                                 _ => {
                                     self.sess.bug("associated_consts(): \
@@ -5888,7 +5888,7 @@ impl<'tcx> ctxt<'tcx> {
         }
     }
 
-    pub fn trait_items(&self, trait_did: ast::DefId) -> Rc<Vec<ImplOrTraitItem<'tcx>>> {
+    pub fn trait_items(&self, trait_did: DefId) -> Rc<Vec<ImplOrTraitItem<'tcx>>> {
         let mut trait_items = self.trait_items_cache.borrow_mut();
         match trait_items.get(&trait_did).cloned() {
             Some(trait_items) => trait_items,
@@ -5904,8 +5904,8 @@ impl<'tcx> ctxt<'tcx> {
         }
     }
 
-    pub fn trait_impl_polarity(&self, id: ast::DefId) -> Option<ast::ImplPolarity> {
-        if id.krate == ast::LOCAL_CRATE {
+    pub fn trait_impl_polarity(&self, id: DefId) -> Option<ast::ImplPolarity> {
+        if id.krate == LOCAL_CRATE {
             match self.map.find(id.node) {
                 Some(ast_map::NodeItem(item)) => {
                     match item.node {
@@ -5920,9 +5920,9 @@ impl<'tcx> ctxt<'tcx> {
         }
     }
 
-    pub fn custom_coerce_unsized_kind(&self, did: ast::DefId) -> CustomCoerceUnsized {
+    pub fn custom_coerce_unsized_kind(&self, did: DefId) -> CustomCoerceUnsized {
         memoized(&self.custom_coerce_unsized_kinds, did, |did: DefId| {
-            let (kind, src) = if did.krate != ast::LOCAL_CRATE {
+            let (kind, src) = if did.krate != LOCAL_CRATE {
                 (csearch::get_custom_coerce_unsized_kind(self, did), "external")
             } else {
                 (None, "local")
@@ -5939,13 +5939,13 @@ impl<'tcx> ctxt<'tcx> {
         })
     }
 
-    pub fn impl_or_trait_item(&self, id: ast::DefId) -> ImplOrTraitItem<'tcx> {
+    pub fn impl_or_trait_item(&self, id: DefId) -> ImplOrTraitItem<'tcx> {
         lookup_locally_or_in_crate_store(
             "impl_or_trait_items", id, &self.impl_or_trait_items,
             || csearch::get_impl_or_trait_item(self, id))
     }
 
-    pub fn trait_item_def_ids(&self, id: ast::DefId) -> Rc<Vec<ImplOrTraitItemId>> {
+    pub fn trait_item_def_ids(&self, id: DefId) -> Rc<Vec<ImplOrTraitItemId>> {
         lookup_locally_or_in_crate_store(
             "trait_item_def_ids", id, &self.trait_item_def_ids,
             || Rc::new(csearch::get_trait_item_def_ids(&self.sess.cstore, id)))
@@ -5953,15 +5953,15 @@ impl<'tcx> ctxt<'tcx> {
 
     /// Returns the trait-ref corresponding to a given impl, or None if it is
     /// an inherent impl.
-    pub fn impl_trait_ref(&self, id: ast::DefId) -> Option<TraitRef<'tcx>> {
+    pub fn impl_trait_ref(&self, id: DefId) -> Option<TraitRef<'tcx>> {
         lookup_locally_or_in_crate_store(
             "impl_trait_refs", id, &self.impl_trait_refs,
             || csearch::get_impl_trait(self, id))
     }
 
     /// Returns whether this DefId refers to an impl
-    pub fn is_impl(&self, id: ast::DefId) -> bool {
-        if id.krate == ast::LOCAL_CRATE {
+    pub fn is_impl(&self, id: DefId) -> bool {
+        if id.krate == LOCAL_CRATE {
             if let Some(ast_map::NodeItem(
                 &ast::Item { node: ast::ItemImpl(..), .. })) = self.map.find(id.node) {
                 true
@@ -5973,12 +5973,12 @@ impl<'tcx> ctxt<'tcx> {
         }
     }
 
-    pub fn trait_ref_to_def_id(&self, tr: &ast::TraitRef) -> ast::DefId {
+    pub fn trait_ref_to_def_id(&self, tr: &ast::TraitRef) -> DefId {
         self.def_map.borrow().get(&tr.ref_id).expect("no def-map entry for trait").def_id()
     }
 
     pub fn try_add_builtin_trait(&self,
-                                 trait_def_id: ast::DefId,
+                                 trait_def_id: DefId,
                                  builtin_bounds: &mut EnumSet<BuiltinBound>)
                                  -> bool
     {
@@ -5993,7 +5993,7 @@ impl<'tcx> ctxt<'tcx> {
         }
     }
 
-    pub fn item_path_str(&self, id: ast::DefId) -> String {
+    pub fn item_path_str(&self, id: DefId) -> String {
         self.with_path(id, |path| ast_map::path_to_string(path))
     }
 
@@ -6009,18 +6009,18 @@ impl<'tcx> ctxt<'tcx> {
         }
     }
 
-    pub fn with_path<T, F>(&self, id: ast::DefId, f: F) -> T where
+    pub fn with_path<T, F>(&self, id: DefId, f: F) -> T where
         F: FnOnce(ast_map::PathElems) -> T,
     {
-        if id.krate == ast::LOCAL_CRATE {
+        if id.krate == LOCAL_CRATE {
             self.map.with_path(id.node, f)
         } else {
             f(csearch::get_item_path(self, id).iter().cloned().chain(LinkedPath::empty()))
         }
     }
 
-    pub fn item_name(&self, id: ast::DefId) -> ast::Name {
-        if id.krate == ast::LOCAL_CRATE {
+    pub fn item_name(&self, id: DefId) -> ast::Name {
+        if id.is_local() {
             self.map.get_path_elem(id.node).name()
         } else {
             csearch::get_item_name(self, id)
@@ -6056,20 +6056,20 @@ impl<'tcx> ctxt<'tcx> {
     }
 
     // Register a given item type
-    pub fn register_item_type(&self, did: ast::DefId, ty: TypeScheme<'tcx>) {
+    pub fn register_item_type(&self, did: DefId, ty: TypeScheme<'tcx>) {
         self.tcache.borrow_mut().insert(did, ty);
     }
 
     // If the given item is in an external crate, looks up its type and adds it to
     // the type cache. Returns the type parameters and type.
-    pub fn lookup_item_type(&self, did: ast::DefId) -> TypeScheme<'tcx> {
+    pub fn lookup_item_type(&self, did: DefId) -> TypeScheme<'tcx> {
         lookup_locally_or_in_crate_store(
             "tcache", did, &self.tcache,
             || csearch::get_type(self, did))
     }
 
     /// Given the did of a trait, returns its canonical trait ref.
-    pub fn lookup_trait_def(&self, did: ast::DefId) -> &'tcx TraitDef<'tcx> {
+    pub fn lookup_trait_def(&self, did: DefId) -> &'tcx TraitDef<'tcx> {
         lookup_locally_or_in_crate_store(
             "trait_defs", did, &self.trait_defs,
             || self.arenas.trait_defs.alloc(csearch::get_trait_def(self, did))
@@ -6079,7 +6079,7 @@ impl<'tcx> ctxt<'tcx> {
     /// Given the did of an ADT, return a master reference to its
     /// definition. Unless you are planning on fulfilling the ADT's fields,
     /// use lookup_adt_def instead.
-    pub fn lookup_adt_def_master(&self, did: ast::DefId) -> AdtDefMaster<'tcx> {
+    pub fn lookup_adt_def_master(&self, did: DefId) -> AdtDefMaster<'tcx> {
         lookup_locally_or_in_crate_store(
             "adt_defs", did, &self.adt_defs,
             || csearch::get_adt_def(self, did)
@@ -6087,21 +6087,21 @@ impl<'tcx> ctxt<'tcx> {
     }
 
     /// Given the did of an ADT, return a reference to its definition.
-    pub fn lookup_adt_def(&self, did: ast::DefId) -> AdtDef<'tcx> {
+    pub fn lookup_adt_def(&self, did: DefId) -> AdtDef<'tcx> {
         // when reverse-variance goes away, a transmute::<AdtDefMaster,AdtDef>
         // woud be needed here.
         self.lookup_adt_def_master(did)
     }
 
     /// Given the did of an item, returns its full set of predicates.
-    pub fn lookup_predicates(&self, did: ast::DefId) -> GenericPredicates<'tcx> {
+    pub fn lookup_predicates(&self, did: DefId) -> GenericPredicates<'tcx> {
         lookup_locally_or_in_crate_store(
             "predicates", did, &self.predicates,
             || csearch::get_predicates(self, did))
     }
 
     /// Given the did of a trait, returns its superpredicates.
-    pub fn lookup_super_predicates(&self, did: ast::DefId) -> GenericPredicates<'tcx> {
+    pub fn lookup_super_predicates(&self, did: DefId) -> GenericPredicates<'tcx> {
         lookup_locally_or_in_crate_store(
             "super_predicates", did, &self.super_predicates,
             || csearch::get_super_predicates(self, did))
@@ -6109,7 +6109,7 @@ impl<'tcx> ctxt<'tcx> {
 
     /// Get the attributes of a definition.
     pub fn get_attrs(&self, did: DefId) -> Cow<'tcx, [ast::Attribute]> {
-        if is_local(did) {
+        if did.is_local() {
             Cow::Borrowed(self.map.attrs(did.node))
         } else {
             Cow::Owned(csearch::get_item_attrs(&self.sess.cstore, did))
@@ -6293,7 +6293,7 @@ impl<'tcx> ctxt<'tcx> {
             .collect()
     }
 
-    pub fn item_variances(&self, item_id: ast::DefId) -> Rc<ItemVariances> {
+    pub fn item_variances(&self, item_id: DefId) -> Rc<ItemVariances> {
         lookup_locally_or_in_crate_store(
             "item_variance_map", item_id, &self.item_variance_map,
             || Rc::new(csearch::get_item_variances(&self.sess.cstore, item_id)))
@@ -6314,7 +6314,7 @@ impl<'tcx> ctxt<'tcx> {
 
     /// Load primitive inherent implementations if necessary
     pub fn populate_implementations_for_primitive_if_necessary(&self,
-                                                               primitive_def_id: ast::DefId) {
+                                                               primitive_def_id: DefId) {
         if primitive_def_id.krate == LOCAL_CRATE {
             return
         }
@@ -6336,7 +6336,7 @@ impl<'tcx> ctxt<'tcx> {
     /// Populates the type context with all the inherent implementations for
     /// the given type if necessary.
     pub fn populate_inherent_implementations_for_type_if_necessary(&self,
-                                                                   type_id: ast::DefId) {
+                                                                   type_id: DefId) {
         if type_id.krate == LOCAL_CRATE {
             return
         }
@@ -6364,7 +6364,7 @@ impl<'tcx> ctxt<'tcx> {
 
     /// Populates the type context with all the implementations for the given
     /// trait if necessary.
-    pub fn populate_implementations_for_trait_if_necessary(&self, trait_id: ast::DefId) {
+    pub fn populate_implementations_for_trait_if_necessary(&self, trait_id: DefId) {
         if trait_id.krate == LOCAL_CRATE {
             return
         }
@@ -6411,13 +6411,13 @@ impl<'tcx> ctxt<'tcx> {
 
     /// Given the def_id of an impl, return the def_id of the trait it implements.
     /// If it implements no trait, return `None`.
-    pub fn trait_id_of_impl(&self, def_id: ast::DefId) -> Option<ast::DefId> {
+    pub fn trait_id_of_impl(&self, def_id: DefId) -> Option<DefId> {
         self.impl_trait_ref(def_id).map(|tr| tr.def_id)
     }
 
     /// If the given def ID describes a method belonging to an impl, return the
     /// ID of the impl that the method belongs to. Otherwise, return `None`.
-    pub fn impl_of_method(&self, def_id: ast::DefId) -> Option<ast::DefId> {
+    pub fn impl_of_method(&self, def_id: DefId) -> Option<DefId> {
         if def_id.krate != LOCAL_CRATE {
             return match csearch::get_impl_or_trait_item(self,
                                                          def_id).container() {
@@ -6439,7 +6439,7 @@ impl<'tcx> ctxt<'tcx> {
     /// If the given def ID describes an item belonging to a trait (either a
     /// default method or an implementation of a trait method), return the ID of
     /// the trait that the method belongs to. Otherwise, return `None`.
-    pub fn trait_of_item(&self, def_id: ast::DefId) -> Option<ast::DefId> {
+    pub fn trait_of_item(&self, def_id: DefId) -> Option<DefId> {
         if def_id.krate != LOCAL_CRATE {
             return csearch::get_trait_of_item(&self.sess.cstore, def_id, self);
         }
@@ -6460,7 +6460,7 @@ impl<'tcx> ctxt<'tcx> {
     /// is already that of the original trait method, then the return value is
     /// the same).
     /// Otherwise, return `None`.
-    pub fn trait_item_of_item(&self, def_id: ast::DefId) -> Option<ImplOrTraitItemId> {
+    pub fn trait_item_of_item(&self, def_id: DefId) -> Option<ImplOrTraitItemId> {
         let impl_item = match self.impl_or_trait_items.borrow().get(&def_id) {
             Some(m) => m.clone(),
             None => return None,
@@ -6506,7 +6506,7 @@ impl<'tcx> ctxt<'tcx> {
                 }
             };
             let did = |state: &mut SipHasher, did: DefId| {
-                let h = if ast_util::is_local(did) {
+                let h = if did.is_local() {
                     svh.clone()
                 } else {
                     tcx.sess.cstore.get_crate_hash(did.krate)

--- a/src/librustc/middle/ty_relate/mod.rs
+++ b/src/librustc/middle/ty_relate/mod.rs
@@ -13,6 +13,7 @@
 //! can be other things. Examples of type relations are subtyping,
 //! type equality, etc.
 
+use middle::def_id::DefId;
 use middle::subst::{ErasedRegions, NonerasedRegions, ParamSpace, Substs};
 use middle::ty::{self, HasTypeFlags, Ty, TypeError};
 use middle::ty_fold::TypeFoldable;
@@ -117,7 +118,7 @@ impl<'a,'tcx:'a> Relate<'a,'tcx> for ty::TypeAndMut<'tcx> {
 // but they is an important subroutine for things that ARE relatable,
 // like traits etc.
 fn relate_item_substs<'a,'tcx:'a,R>(relation: &mut R,
-                                    item_def_id: ast::DefId,
+                                    item_def_id: DefId,
                                     a_subst: &Substs<'tcx>,
                                     b_subst: &Substs<'tcx>)
                                     -> RelateResult<'tcx, Substs<'tcx>>

--- a/src/librustc/middle/wf.rs
+++ b/src/librustc/middle/wf.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use middle::def_id::DefId;
 use middle::infer::InferCtxt;
 use middle::outlives::{self, Component};
 use middle::subst::Substs;
@@ -451,7 +452,7 @@ impl<'a,'tcx> WfPredicates<'a,'tcx> {
     }
 
     fn nominal_obligations(&mut self,
-                           def_id: ast::DefId,
+                           def_id: DefId,
                            substs: &Substs<'tcx>)
                            -> Vec<traits::PredicateObligation<'tcx>>
     {

--- a/src/librustc/util/nodemap.rs
+++ b/src/librustc/util/nodemap.rs
@@ -12,6 +12,7 @@
 
 #![allow(non_snake_case)]
 
+use middle::def_id::DefId;
 use std::collections::hash_state::DefaultState;
 use std::collections::{HashMap, HashSet};
 use std::default::Default;
@@ -22,10 +23,10 @@ pub type FnvHashMap<K, V> = HashMap<K, V, DefaultState<FnvHasher>>;
 pub type FnvHashSet<V> = HashSet<V, DefaultState<FnvHasher>>;
 
 pub type NodeMap<T> = FnvHashMap<ast::NodeId, T>;
-pub type DefIdMap<T> = FnvHashMap<ast::DefId, T>;
+pub type DefIdMap<T> = FnvHashMap<DefId, T>;
 
 pub type NodeSet = FnvHashSet<ast::NodeId>;
-pub type DefIdSet = FnvHashSet<ast::DefId>;
+pub type DefIdSet = FnvHashSet<DefId>;
 
 pub fn FnvHashMap<K: Hash + Eq, V>() -> FnvHashMap<K, V> {
     Default::default()

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 
-use middle::def_id::{DefId, LOCAL_CRATE};
+use middle::def_id::DefId;
 use middle::subst::{self, Subst};
 use middle::ty::{BoundRegion, BrAnon, BrNamed};
 use middle::ty::{ReEarlyBound, BrFresh, ctxt};
@@ -659,7 +659,7 @@ impl<'tcx> fmt::Display for ty::TypeVariants<'tcx> {
             TyParam(ref param_ty) => write!(f, "{}", param_ty),
             TyEnum(def, substs) | TyStruct(def, substs) => {
                 ty::tls::with(|tcx| {
-                    if def.did.krate == LOCAL_CRATE &&
+                    if def.did.is_local() &&
                           !tcx.tcache.borrow().contains_key(&def.did) {
                         write!(f, "{}<..>", tcx.item_path_str(def.did))
                     } else {
@@ -674,7 +674,7 @@ impl<'tcx> fmt::Display for ty::TypeVariants<'tcx> {
             TyClosure(ref did, ref substs) => ty::tls::with(|tcx| {
                 try!(write!(f, "[closure"));
 
-                if did.krate == LOCAL_CRATE {
+                if did.is_local() {
                     try!(write!(f, "@{:?}", tcx.map.span(did.node)));
                     let mut sep = " ";
                     try!(tcx.with_freevars(did.node, |freevars| {

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 
+use middle::def_id::{DefId, LOCAL_CRATE};
 use middle::subst::{self, Subst};
 use middle::ty::{BoundRegion, BrAnon, BrNamed};
 use middle::ty::{ReEarlyBound, BrFresh, ctxt};
@@ -64,7 +65,7 @@ fn fn_sig(f: &mut fmt::Formatter,
 
 fn parameterized<GG>(f: &mut fmt::Formatter,
                      substs: &subst::Substs,
-                     did: ast::DefId,
+                     did: DefId,
                      projections: &[ty::ProjectionPredicate],
                      get_generics: GG)
                      -> fmt::Result
@@ -229,7 +230,7 @@ fn in_binder<'tcx, T, U>(f: &mut fmt::Formatter,
             ty::BrEnv => {
                 let name = token::intern("'r");
                 let _ = write!(f, "{}", name);
-                ty::BrNamed(ast_util::local_def(ast::DUMMY_NODE_ID), name)
+                ty::BrNamed(DefId::local(ast::DUMMY_NODE_ID), name)
             }
         })
     }).0;
@@ -658,7 +659,7 @@ impl<'tcx> fmt::Display for ty::TypeVariants<'tcx> {
             TyParam(ref param_ty) => write!(f, "{}", param_ty),
             TyEnum(def, substs) | TyStruct(def, substs) => {
                 ty::tls::with(|tcx| {
-                    if def.did.krate == ast::LOCAL_CRATE &&
+                    if def.did.krate == LOCAL_CRATE &&
                           !tcx.tcache.borrow().contains_key(&def.did) {
                         write!(f, "{}<..>", tcx.item_path_str(def.did))
                     } else {
@@ -673,7 +674,7 @@ impl<'tcx> fmt::Display for ty::TypeVariants<'tcx> {
             TyClosure(ref did, ref substs) => ty::tls::with(|tcx| {
                 try!(write!(f, "[closure"));
 
-                if did.krate == ast::LOCAL_CRATE {
+                if did.krate == LOCAL_CRATE {
                     try!(write!(f, "@{:?}", tcx.map.span(did.node)));
                     let mut sep = " ";
                     try!(tcx.with_freevars(did.node, |freevars| {

--- a/src/librustc_borrowck/borrowck/fragments.rs
+++ b/src/librustc_borrowck/borrowck/fragments.rs
@@ -20,6 +20,7 @@ use borrowck::LoanPathKind::{LpVar, LpUpvar, LpDowncast, LpExtend};
 use borrowck::LoanPathElem::{LpDeref, LpInterior};
 use borrowck::move_data::InvalidMovePathIndex;
 use borrowck::move_data::{MoveData, MovePathIndex};
+use rustc::middle::def_id::{DefId, LOCAL_CRATE};
 use rustc::middle::ty;
 use rustc::middle::mem_categorization as mc;
 
@@ -132,7 +133,7 @@ pub fn build_unfragmented_map(this: &mut borrowck::BorrowckCtxt,
     }
 
     let mut fraginfo_map = this.tcx.fragment_infos.borrow_mut();
-    let fn_did = ast::DefId { krate: ast::LOCAL_CRATE, node: id };
+    let fn_did = DefId { krate: LOCAL_CRATE, node: id };
     let prev = fraginfo_map.insert(fn_did, fragment_infos);
     assert!(prev.is_none());
 }
@@ -412,7 +413,7 @@ fn add_fragment_siblings_for_extension<'tcx>(this: &MoveData<'tcx>,
                                              origin_field_name: &mc::FieldName,
                                              origin_lp: &Rc<LoanPath<'tcx>>,
                                              origin_id: Option<ast::NodeId>,
-                                             enum_variant_info: Option<(ast::DefId,
+                                             enum_variant_info: Option<(DefId,
                                                                         Rc<LoanPath<'tcx>>)>) {
     let parent_ty = parent_lp.to_type();
 
@@ -509,7 +510,7 @@ fn add_fragment_sibling_core<'tcx>(this: &MoveData<'tcx>,
                                    mc: mc::MutabilityCategory,
                                    new_field_name: mc::FieldName,
                                    origin_lp: &Rc<LoanPath<'tcx>>,
-                                   enum_variant_did: Option<ast::DefId>) -> MovePathIndex {
+                                   enum_variant_did: Option<DefId>) -> MovePathIndex {
     let opt_variant_did = match parent.kind {
         LpDowncast(_, variant_did) => Some(variant_did),
         LpVar(..) | LpUpvar(..) | LpExtend(..) => enum_variant_did,

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -27,6 +27,7 @@ use rustc::middle::dataflow::DataFlowContext;
 use rustc::middle::dataflow::BitwiseOperator;
 use rustc::middle::dataflow::DataFlowOperator;
 use rustc::middle::dataflow::KillFrom;
+use rustc::middle::def_id::{DefId, LOCAL_CRATE};
 use rustc::middle::expr_use_visitor as euv;
 use rustc::middle::free_region::FreeRegionMap;
 use rustc::middle::mem_categorization as mc;
@@ -349,7 +350,7 @@ impl<'tcx> PartialEq for LoanPath<'tcx> {
 pub enum LoanPathKind<'tcx> {
     LpVar(ast::NodeId),                         // `x` in README.md
     LpUpvar(ty::UpvarId),                       // `x` captured by-value into closure
-    LpDowncast(Rc<LoanPath<'tcx>>, ast::DefId), // `x` downcast to particular enum variant
+    LpDowncast(Rc<LoanPath<'tcx>>, DefId), // `x` downcast to particular enum variant
     LpExtend(Rc<LoanPath<'tcx>>, mc::MutabilityCategory, LoanPathElem)
 }
 
@@ -1192,7 +1193,7 @@ impl<'tcx> fmt::Debug for LoanPath<'tcx> {
             }
 
             LpDowncast(ref lp, variant_def_id) => {
-                let variant_str = if variant_def_id.krate == ast::LOCAL_CRATE {
+                let variant_str = if variant_def_id.krate == LOCAL_CRATE {
                     ty::tls::with(|tcx| tcx.item_path_str(variant_def_id))
                 } else {
                     format!("{:?}", variant_def_id)
@@ -1224,7 +1225,7 @@ impl<'tcx> fmt::Display for LoanPath<'tcx> {
             }
 
             LpDowncast(ref lp, variant_def_id) => {
-                let variant_str = if variant_def_id.krate == ast::LOCAL_CRATE {
+                let variant_str = if variant_def_id.krate == LOCAL_CRATE {
                     ty::tls::with(|tcx| tcx.item_path_str(variant_def_id))
                 } else {
                     format!("{:?}", variant_def_id)

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -27,7 +27,7 @@ use rustc::middle::dataflow::DataFlowContext;
 use rustc::middle::dataflow::BitwiseOperator;
 use rustc::middle::dataflow::DataFlowOperator;
 use rustc::middle::dataflow::KillFrom;
-use rustc::middle::def_id::{DefId, LOCAL_CRATE};
+use rustc::middle::def_id::DefId;
 use rustc::middle::expr_use_visitor as euv;
 use rustc::middle::free_region::FreeRegionMap;
 use rustc::middle::mem_categorization as mc;
@@ -1193,7 +1193,7 @@ impl<'tcx> fmt::Debug for LoanPath<'tcx> {
             }
 
             LpDowncast(ref lp, variant_def_id) => {
-                let variant_str = if variant_def_id.krate == LOCAL_CRATE {
+                let variant_str = if variant_def_id.is_local() {
                     ty::tls::with(|tcx| tcx.item_path_str(variant_def_id))
                 } else {
                     format!("{:?}", variant_def_id)
@@ -1225,7 +1225,7 @@ impl<'tcx> fmt::Display for LoanPath<'tcx> {
             }
 
             LpDowncast(ref lp, variant_def_id) => {
-                let variant_str = if variant_def_id.krate == LOCAL_CRATE {
+                let variant_str = if variant_def_id.is_local() {
                     ty::tls::with(|tcx| tcx.item_path_str(variant_def_id))
                 } else {
                     format!("{:?}", variant_def_id)

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -30,7 +30,7 @@
 
 use metadata::{csearch, decoder};
 use middle::{cfg, def, infer, pat_util, stability, traits};
-use middle::def_id::{DefId, LOCAL_CRATE};
+use middle::def_id::DefId;
 use middle::subst::Substs;
 use middle::ty::{self, Ty};
 use middle::const_eval::{eval_const_expr_partial, ConstVal};
@@ -2029,7 +2029,7 @@ impl LintPass for MissingDebugImplementations {
             let debug_def = cx.tcx.lookup_trait_def(debug);
             let mut impls = NodeSet();
             debug_def.for_each_impl(cx.tcx, |d| {
-                if d.krate == LOCAL_CRATE {
+                if d.is_local() {
                     if let Some(ty_def) = cx.tcx.node_id_to_type(d.node).ty_to_def_id() {
                         impls.insert(ty_def.node);
                     }
@@ -2569,7 +2569,7 @@ impl LintPass for DropWithReprExtern {
     fn check_crate(&mut self, ctx: &Context, _: &ast::Crate) {
         for dtor_did in ctx.tcx.destructors.borrow().iter() {
             let (drop_impl_did, dtor_self_type) =
-                if dtor_did.krate == LOCAL_CRATE {
+                if dtor_did.is_local() {
                     let impl_did = ctx.tcx.map.get_parent_did(dtor_did.node);
                     let ty = ctx.tcx.lookup_item_type(impl_did).ty;
                     (impl_did, ty)

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -56,6 +56,7 @@ use rustc::lint;
 use rustc::metadata::csearch;
 use rustc::metadata::decoder::{DefLike, DlDef, DlField, DlImpl};
 use rustc::middle::def::*;
+use rustc::middle::def_id::{DefId, LOCAL_CRATE};
 use rustc::middle::pat_util::pat_bindings;
 use rustc::middle::privacy::*;
 use rustc::middle::subst::{ParamSpace, FnSpace, TypeSpace};
@@ -65,7 +66,7 @@ use rustc::util::lev_distance::lev_distance;
 
 use syntax::ast::{Arm, BindByRef, BindByValue, BindingMode, Block};
 use syntax::ast::{ConstImplItem, Crate, CrateNum};
-use syntax::ast::{DefId, Expr, ExprAgain, ExprBreak, ExprField};
+use syntax::ast::{Expr, ExprAgain, ExprBreak, ExprField};
 use syntax::ast::{ExprLoop, ExprWhile, ExprMethodCall};
 use syntax::ast::{ExprPath, ExprStruct, FnDecl};
 use syntax::ast::{ForeignItemFn, ForeignItemStatic, Generics};
@@ -81,7 +82,7 @@ use syntax::ast::{TyPath, TyPtr};
 use syntax::ast::{TyRptr, TyStr, TyUs, TyU8, TyU16, TyU32, TyU64, TyUint};
 use syntax::ast::TypeImplItem;
 use syntax::ast;
-use syntax::ast_util::{local_def, walk_pat};
+use syntax::ast_util::{walk_pat};
 use syntax::attr::AttrMetaMethods;
 use syntax::ext::mtwt;
 use syntax::parse::token::{self, special_names, special_idents};
@@ -1255,7 +1256,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
     }
 
     fn get_trait_name(&self, did: DefId) -> Name {
-        if did.krate == ast::LOCAL_CRATE {
+        if did.krate == LOCAL_CRATE {
             self.ast_map.expect_item(did.node).ident.name
         } else {
             csearch::get_trait_name(&self.session.cstore, did)
@@ -2154,7 +2155,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                                                TypeSpace,
                                                                ItemRibKind),
                                              |this| {
-                    this.with_self_rib(DefSelfTy(Some(local_def(item.id)), None), |this| {
+                    this.with_self_rib(DefSelfTy(Some(DefId::local(item.id)), None), |this| {
                         this.visit_generics(generics);
                         visit::walk_ty_param_bounds_helper(this, bounds);
 
@@ -2248,7 +2249,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                     function_type_rib.bindings.insert(name,
                         DlDef(DefTyParam(space,
                                          index as u32,
-                                         local_def(type_parameter.id),
+                                         DefId::local(type_parameter.id),
                                          name)));
                 }
                 self.type_ribs.push(function_type_rib);
@@ -3466,7 +3467,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         }
 
         fn is_static_method(this: &Resolver, did: DefId) -> bool {
-            if did.krate == ast::LOCAL_CRATE {
+            if did.krate == LOCAL_CRATE {
                 let sig = match this.ast_map.get(did.node) {
                     ast_map::NodeTraitItem(trait_item) => match trait_item.node {
                         ast::MethodTraitItem(ref sig, _) => sig,

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -56,7 +56,7 @@ use rustc::lint;
 use rustc::metadata::csearch;
 use rustc::metadata::decoder::{DefLike, DlDef, DlField, DlImpl};
 use rustc::middle::def::*;
-use rustc::middle::def_id::{DefId, LOCAL_CRATE};
+use rustc::middle::def_id::DefId;
 use rustc::middle::pat_util::pat_bindings;
 use rustc::middle::privacy::*;
 use rustc::middle::subst::{ParamSpace, FnSpace, TypeSpace};
@@ -1256,7 +1256,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
     }
 
     fn get_trait_name(&self, did: DefId) -> Name {
-        if did.krate == LOCAL_CRATE {
+        if did.is_local() {
             self.ast_map.expect_item(did.node).ident.name
         } else {
             csearch::get_trait_name(&self.session.cstore, did)
@@ -3467,7 +3467,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         }
 
         fn is_static_method(this: &Resolver, did: DefId) -> bool {
-            if did.krate == LOCAL_CRATE {
+            if did.is_local() {
                 let sig = match this.ast_map.get(did.node) {
                     ast_map::NodeTraitItem(trait_item) => match trait_item.node {
                         ast::MethodTraitItem(ref sig, _) => sig,

--- a/src/librustc_resolve/record_exports.rs
+++ b/src/librustc_resolve/record_exports.rs
@@ -25,7 +25,6 @@ use build_reduced_graph;
 use module_to_string;
 
 use rustc::middle::def::Export;
-use rustc::middle::def_id::LOCAL_CRATE;
 use syntax::ast;
 
 use std::ops::{Deref, DerefMut};
@@ -57,7 +56,7 @@ impl<'a, 'b, 'tcx> ExportRecorder<'a, 'b, 'tcx> {
         // exports for nonlocal crates.
 
         match module_.def_id.get() {
-            Some(def_id) if def_id.krate == LOCAL_CRATE => {
+            Some(def_id) if def_id.is_local() => {
                 // OK. Continue.
                 debug!("(recording exports for module subtree) recording \
                         exports for local module `{}`",

--- a/src/librustc_resolve/record_exports.rs
+++ b/src/librustc_resolve/record_exports.rs
@@ -25,6 +25,7 @@ use build_reduced_graph;
 use module_to_string;
 
 use rustc::middle::def::Export;
+use rustc::middle::def_id::LOCAL_CRATE;
 use syntax::ast;
 
 use std::ops::{Deref, DerefMut};
@@ -56,7 +57,7 @@ impl<'a, 'b, 'tcx> ExportRecorder<'a, 'b, 'tcx> {
         // exports for nonlocal crates.
 
         match module_.def_id.get() {
-            Some(def_id) if def_id.krate == ast::LOCAL_CRATE => {
+            Some(def_id) if def_id.krate == LOCAL_CRATE => {
                 // OK. Continue.
                 debug!("(recording exports for module subtree) recording \
                         exports for local module `{}`",

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -27,9 +27,10 @@ use {resolve_error, ResolutionError};
 use build_reduced_graph;
 
 use rustc::middle::def::*;
+use rustc::middle::def_id::DefId;
 use rustc::middle::privacy::*;
 
-use syntax::ast::{DefId, NodeId, Name};
+use syntax::ast::{NodeId, Name};
 use syntax::attr::AttrMetaMethods;
 use syntax::codemap::Span;
 

--- a/src/librustc_trans/save/dump_csv.rs
+++ b/src/librustc_trans/save/dump_csv.rs
@@ -33,12 +33,13 @@ use super::{escape, generated_code, recorder, SaveContext, PathCollector, Data};
 use session::Session;
 
 use middle::def;
+use middle::def_id::DefId;
 use middle::ty::{self, Ty};
 
 use std::fs::File;
 use std::path::Path;
 
-use syntax::ast::{self, NodeId, DefId};
+use syntax::ast::{self, NodeId};
 use syntax::codemap::*;
 use syntax::parse::token::{self, keywords};
 use syntax::owned_slice::OwnedSlice;

--- a/src/librustc_trans/save/mod.rs
+++ b/src/librustc_trans/save/mod.rs
@@ -546,7 +546,7 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
             }
             def::DefMethod(decl_id) => {
                 let sub_span = self.span_utils.sub_span_for_meth_name(path.span);
-                let def_id = if decl_id.krate == LOCAL_CRATE {
+                let def_id = if decl_id.is_local() {
                     let ti = self.tcx.impl_or_trait_item(decl_id);
                     match ti.container() {
                         ty::TraitContainer(def_id) => {

--- a/src/librustc_trans/save/mod.rs
+++ b/src/librustc_trans/save/mod.rs
@@ -10,6 +10,7 @@
 
 use middle::ty;
 use middle::def;
+use middle::def_id::{DefId, LOCAL_CRATE};
 
 use std::env;
 use std::fs::{self, File};
@@ -18,7 +19,7 @@ use std::path::{Path, PathBuf};
 use rustc::ast_map::NodeItem;
 
 use syntax::{attr};
-use syntax::ast::{self, NodeId, DefId};
+use syntax::ast::{self, NodeId};
 use syntax::ast_util;
 use syntax::codemap::*;
 use syntax::parse::token::{self, keywords};
@@ -351,7 +352,7 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
                            span: Span) -> FunctionData {
         // The qualname for a method is the trait name or name of the struct in an impl in
         // which the method is declared in, followed by the method's name.
-        let qualname = match self.tcx.impl_of_method(ast_util::local_def(id)) {
+        let qualname = match self.tcx.impl_of_method(DefId::local(id)) {
             Some(impl_id) => match self.tcx.map.get(impl_id.node) {
                 NodeItem(item) => {
                     match item.node {
@@ -359,7 +360,7 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
                             let mut result = String::from("<");
                             result.push_str(&ty_to_string(&**ty));
 
-                            match self.tcx.trait_of_item(ast_util::local_def(id)) {
+                            match self.tcx.trait_of_item(DefId::local(id)) {
                                 Some(def_id) => {
                                     result.push_str(" as ");
                                     result.push_str(
@@ -383,7 +384,7 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
                                  impl_id.node, id, self.tcx.map.get(impl_id.node)));
                 },
             },
-            None => match self.tcx.trait_of_item(ast_util::local_def(id)) {
+            None => match self.tcx.trait_of_item(DefId::local(id)) {
                 Some(def_id) => {
                     match self.tcx.map.get(def_id.node) {
                         NodeItem(_) => {
@@ -405,10 +406,10 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
 
         let qualname = format!("{}::{}", qualname, name);
 
-        let decl_id = self.tcx.trait_item_of_item(ast_util::local_def(id))
+        let decl_id = self.tcx.trait_item_of_item(DefId::local(id))
             .and_then(|new_id| {
                 let def_id = new_id.def_id();
-                if def_id.node != 0 && def_id != ast_util::local_def(id) {
+                if def_id.node != 0 && def_id != DefId::local(id) {
                     Some(def_id)
                 } else {
                     None
@@ -545,7 +546,7 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
             }
             def::DefMethod(decl_id) => {
                 let sub_span = self.span_utils.sub_span_for_meth_name(path.span);
-                let def_id = if decl_id.krate == ast::LOCAL_CRATE {
+                let def_id = if decl_id.krate == LOCAL_CRATE {
                     let ti = self.tcx.impl_or_trait_item(decl_id);
                     match ti.container() {
                         ty::TraitContainer(def_id) => {
@@ -599,7 +600,7 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
 
     fn trait_method_has_body(&self, mr: &ty::ImplOrTraitItem) -> bool {
         let def_id = mr.def_id();
-        if def_id.krate != ast::LOCAL_CRATE {
+        if def_id.krate != LOCAL_CRATE {
             return false;
         }
 

--- a/src/librustc_trans/save/recorder.rs
+++ b/src/librustc_trans/save/recorder.rs
@@ -13,10 +13,12 @@ pub use self::Row::*;
 use super::escape;
 use super::span_utils::SpanUtils;
 
+use middle::def_id::DefId;
+
 use std::io::Write;
 
 use syntax::ast;
-use syntax::ast::{NodeId,DefId};
+use syntax::ast::{NodeId};
 use syntax::codemap::*;
 
 const ZERO_DEF_ID: DefId = DefId { node: 0, krate: 0 };

--- a/src/librustc_trans/trans/_match.rs
+++ b/src/librustc_trans/trans/_match.rs
@@ -194,6 +194,7 @@ use middle::check_match::StaticInliner;
 use middle::check_match;
 use middle::const_eval;
 use middle::def::{self, DefMap};
+use middle::def_id::DefId;
 use middle::expr_use_visitor as euv;
 use middle::infer;
 use middle::lang_items::StrEqFnLangItem;
@@ -247,7 +248,7 @@ impl<'a> ConstantExpr<'a> {
 enum Opt<'a, 'tcx> {
     ConstantValue(ConstantExpr<'a>, DebugLoc),
     ConstantRange(ConstantExpr<'a>, ConstantExpr<'a>, DebugLoc),
-    Variant(ty::Disr, Rc<adt::Repr<'tcx>>, ast::DefId, DebugLoc),
+    Variant(ty::Disr, Rc<adt::Repr<'tcx>>, DefId, DebugLoc),
     SliceLengthEqual(usize, DebugLoc),
     SliceLengthGreaterOrEqual(/* prefix length */ usize,
                               /* suffix length */ usize,

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -2247,7 +2247,7 @@ pub fn create_entry_wrapper(ccx: &CrateContext,
                     Ok(id) => id,
                     Err(s) => { ccx.sess().fatal(&s[..]); }
                 };
-                let start_fn = if start_def_id.krate == LOCAL_CRATE {
+                let start_fn = if start_def_id.is_local() {
                     get_item_val(ccx, start_def_id.node)
                 } else {
                     let start_fn_type = csearch::get_type(ccx.tcx(),

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -37,6 +37,7 @@ use llvm;
 use metadata::{csearch, encoder, loader};
 use middle::astencode;
 use middle::cfg;
+use middle::def_id::{DefId, LOCAL_CRATE};
 use middle::lang_items::{LangItem, ExchangeMallocFnLangItem, StartFnLangItem};
 use middle::weak_lang_items;
 use middle::pat_util::simple_identifier;
@@ -92,7 +93,6 @@ use std::mem;
 use std::str;
 use std::{i8, i16, i32, i64};
 use syntax::abi::{Rust, RustCall, RustIntrinsic, PlatformIntrinsic, Abi};
-use syntax::ast_util::local_def;
 use syntax::attr::AttrMetaMethods;
 use syntax::attr;
 use syntax::codemap::Span;
@@ -179,7 +179,7 @@ impl<'a, 'tcx> Drop for StatRecorder<'a, 'tcx> {
 }
 
 fn get_extern_rust_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, fn_ty: Ty<'tcx>,
-                                name: &str, did: ast::DefId) -> ValueRef {
+                                name: &str, did: DefId) -> ValueRef {
     match ccx.externs().borrow().get(name) {
         Some(n) => return *n,
         None => ()
@@ -195,7 +195,7 @@ fn get_extern_rust_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, fn_ty: Ty<'tcx>,
 }
 
 pub fn self_type_for_closure<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
-                                       closure_id: ast::DefId,
+                                       closure_id: DefId,
                                        fn_ty: Ty<'tcx>)
                                        -> Ty<'tcx>
 {
@@ -211,11 +211,11 @@ pub fn self_type_for_closure<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     }
 }
 
-pub fn kind_for_closure(ccx: &CrateContext, closure_id: ast::DefId) -> ty::ClosureKind {
+pub fn kind_for_closure(ccx: &CrateContext, closure_id: DefId) -> ty::ClosureKind {
     *ccx.tcx().tables.borrow().closure_kinds.get(&closure_id).unwrap()
 }
 
-pub fn get_extern_const<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, did: ast::DefId,
+pub fn get_extern_const<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, did: DefId,
                                   t: Ty<'tcx>) -> ValueRef {
     let name = csearch::get_symbol(&ccx.sess().cstore, did);
     let ty = type_of(ccx, t);
@@ -245,7 +245,7 @@ pub fn get_extern_const<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, did: ast::DefId,
 }
 
 fn require_alloc_fn<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
-                                info_ty: Ty<'tcx>, it: LangItem) -> ast::DefId {
+                                info_ty: Ty<'tcx>, it: LangItem) -> DefId {
     match bcx.tcx().lang_items.require(it) {
         Ok(id) => id,
         Err(s) => {
@@ -663,7 +663,7 @@ pub fn fail_if_zero_or_overflows<'blk, 'tcx>(
 }
 
 pub fn trans_external_path<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
-                                     did: ast::DefId, t: Ty<'tcx>) -> ValueRef {
+                                     did: DefId, t: Ty<'tcx>) -> ValueRef {
     let name = csearch::get_symbol(&ccx.sess().cstore, did);
     match t.sty {
         ty::TyBareFn(_, ref fn_ty) => {
@@ -1294,7 +1294,7 @@ pub fn init_function<'a, 'tcx>(fcx: &'a FunctionContext<'a, 'tcx>,
 
     // Create the drop-flag hints for every unfragmented path in the function.
     let tcx = fcx.ccx.tcx();
-    let fn_did = ast::DefId { krate: ast::LOCAL_CRATE, node: fcx.id };
+    let fn_did = DefId { krate: LOCAL_CRATE, node: fcx.id };
     let mut hints = fcx.lldropflag_hints.borrow_mut();
     let fragment_infos = tcx.fragment_infos.borrow();
 
@@ -2080,7 +2080,7 @@ pub fn trans_item(ccx: &CrateContext, item: &ast::Item) {
                     // error in trans. This is used to write compile-fail tests
                     // that actually test that compilation succeeds without
                     // reporting an error.
-                    if ccx.tcx().has_attr(local_def(item.id), "rustc_error") {
+                    if ccx.tcx().has_attr(DefId::local(item.id), "rustc_error") {
                         ccx.tcx().sess.span_fatal(item.span, "compilation successful");
                     }
                 }
@@ -2247,7 +2247,7 @@ pub fn create_entry_wrapper(ccx: &CrateContext,
                     Ok(id) => id,
                     Err(s) => { ccx.sess().fatal(&s[..]); }
                 };
-                let start_fn = if start_def_id.krate == ast::LOCAL_CRATE {
+                let start_fn = if start_def_id.krate == LOCAL_CRATE {
                     get_item_val(ccx, start_def_id.node)
                 } else {
                     let start_fn_type = csearch::get_type(ccx.tcx(),

--- a/src/librustc_trans/trans/callee.rs
+++ b/src/librustc_trans/trans/callee.rs
@@ -464,7 +464,7 @@ pub fn trans_fn_ref_with_substs<'a, 'tcx>(
     // or is a named tuple constructor.
     let must_monomorphise = if !substs.types.is_empty() || is_default {
         true
-    } else if def_id.krate == LOCAL_CRATE {
+    } else if def_id.is_local() {
         let map_node = session::expect(
             ccx.sess(),
             tcx.map.find(def_id.node),
@@ -524,7 +524,7 @@ pub fn trans_fn_ref_with_substs<'a, 'tcx>(
 
     // Find the actual function pointer.
     let mut val = {
-        if def_id.krate == LOCAL_CRATE {
+        if def_id.is_local() {
             // Internal reference.
             get_item_val(ccx, def_id.node)
         } else {

--- a/src/librustc_trans/trans/callee.rs
+++ b/src/librustc_trans/trans/callee.rs
@@ -23,6 +23,7 @@ use back::link;
 use session;
 use llvm::{self, ValueRef, get_params};
 use middle::def;
+use middle::def_id::{DefId, LOCAL_CRATE};
 use middle::subst;
 use middle::subst::{Subst, Substs};
 use trans::adt;
@@ -222,7 +223,7 @@ fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, expr: &ast::Expr)
 /// Translates a reference (with id `ref_id`) to the fn/method with id `def_id` into a function
 /// pointer. This may require monomorphization or inlining.
 pub fn trans_fn_ref<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
-                              def_id: ast::DefId,
+                              def_id: DefId,
                               node: ExprOrMethodCall,
                               param_substs: &'tcx subst::Substs<'tcx>)
                               -> Datum<'tcx, Rvalue> {
@@ -375,7 +376,7 @@ pub fn trans_fn_pointer_shim<'a, 'tcx>(
 /// - `substs`: values for each of the fn/method's parameters
 pub fn trans_fn_ref_with_substs<'a, 'tcx>(
     ccx: &CrateContext<'a, 'tcx>,
-    def_id: ast::DefId,
+    def_id: DefId,
     node: ExprOrMethodCall,
     param_substs: &'tcx subst::Substs<'tcx>,
     substs: subst::Substs<'tcx>)
@@ -463,7 +464,7 @@ pub fn trans_fn_ref_with_substs<'a, 'tcx>(
     // or is a named tuple constructor.
     let must_monomorphise = if !substs.types.is_empty() || is_default {
         true
-    } else if def_id.krate == ast::LOCAL_CRATE {
+    } else if def_id.krate == LOCAL_CRATE {
         let map_node = session::expect(
             ccx.sess(),
             tcx.map.find(def_id.node),
@@ -487,7 +488,7 @@ pub fn trans_fn_ref_with_substs<'a, 'tcx>(
     // Create a monomorphic version of generic functions
     if must_monomorphise {
         // Should be either intra-crate or inlined.
-        assert_eq!(def_id.krate, ast::LOCAL_CRATE);
+        assert_eq!(def_id.krate, LOCAL_CRATE);
 
         let opt_ref_id = match node {
             ExprId(id) => if id != 0 { Some(id) } else { None },
@@ -523,7 +524,7 @@ pub fn trans_fn_ref_with_substs<'a, 'tcx>(
 
     // Find the actual function pointer.
     let mut val = {
-        if def_id.krate == ast::LOCAL_CRATE {
+        if def_id.krate == LOCAL_CRATE {
             // Internal reference.
             get_item_val(ccx, def_id.node)
         } else {
@@ -604,7 +605,7 @@ pub fn trans_method_call<'a, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 }
 
 pub fn trans_lang_call<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
-                                   did: ast::DefId,
+                                   did: DefId,
                                    args: &[ValueRef],
                                    dest: Option<expr::Dest>,
                                    debug_loc: DebugLoc)

--- a/src/librustc_trans/trans/closure.rs
+++ b/src/librustc_trans/trans/closure.rs
@@ -11,6 +11,7 @@
 use arena::TypedArena;
 use back::link::{self, mangle_internal_name_by_path_and_seq};
 use llvm::{ValueRef, get_params};
+use middle::def_id::DefId;
 use middle::infer;
 use trans::adt;
 use trans::attributes;
@@ -30,7 +31,6 @@ use session::config::FullDebugInfo;
 
 use syntax::abi::RustCall;
 use syntax::ast;
-use syntax::ast_util;
 
 
 fn load_closure_environment<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
@@ -41,7 +41,7 @@ fn load_closure_environment<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let _icx = push_ctxt("closure::load_closure_environment");
 
     // Special case for small by-value selfs.
-    let closure_id = ast_util::local_def(bcx.fcx.id);
+    let closure_id = DefId::local(bcx.fcx.id);
     let self_type = self_type_for_closure(bcx.ccx(), closure_id,
                                                   node_id_type(bcx, closure_id.node));
     let kind = kind_for_closure(bcx.ccx(), closure_id);
@@ -128,7 +128,7 @@ impl<'a> ClosureEnv<'a> {
 /// Returns the LLVM function declaration for a closure, creating it if
 /// necessary. If the ID does not correspond to a closure ID, returns None.
 pub fn get_or_create_closure_declaration<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
-                                                   closure_id: ast::DefId,
+                                                   closure_id: DefId,
                                                    substs: &ty::ClosureSubsts<'tcx>)
                                                    -> ValueRef {
     // Normalize type so differences in regions and typedefs don't cause
@@ -188,7 +188,7 @@ pub fn trans_closure_expr<'a, 'tcx>(dest: Dest<'a, 'tcx>,
 
     debug!("trans_closure_expr()");
 
-    let closure_id = ast_util::local_def(id);
+    let closure_id = DefId::local(id);
     let llfn = get_or_create_closure_declaration(ccx, closure_id, closure_substs);
 
     // Get the type of this closure. Use the current `param_substs` as
@@ -250,7 +250,7 @@ pub fn trans_closure_expr<'a, 'tcx>(dest: Dest<'a, 'tcx>,
 }
 
 pub fn trans_closure_method<'a, 'tcx>(ccx: &'a CrateContext<'a, 'tcx>,
-                                      closure_def_id: ast::DefId,
+                                      closure_def_id: DefId,
                                       substs: ty::ClosureSubsts<'tcx>,
                                       trait_closure_kind: ty::ClosureKind)
                                       -> ValueRef
@@ -271,7 +271,7 @@ pub fn trans_closure_method<'a, 'tcx>(ccx: &'a CrateContext<'a, 'tcx>,
 
 fn trans_closure_adapter_shim<'a, 'tcx>(
     ccx: &'a CrateContext<'a, 'tcx>,
-    closure_def_id: ast::DefId,
+    closure_def_id: DefId,
     substs: ty::ClosureSubsts<'tcx>,
     llfn_closure_kind: ty::ClosureKind,
     trait_closure_kind: ty::ClosureKind,
@@ -323,7 +323,7 @@ fn trans_closure_adapter_shim<'a, 'tcx>(
 
 fn trans_fn_once_adapter_shim<'a, 'tcx>(
     ccx: &'a CrateContext<'a, 'tcx>,
-    closure_def_id: ast::DefId,
+    closure_def_id: DefId,
     substs: ty::ClosureSubsts<'tcx>,
     llreffn: ValueRef)
     -> ValueRef

--- a/src/librustc_trans/trans/common.rs
+++ b/src/librustc_trans/trans/common.rs
@@ -20,6 +20,7 @@ use llvm::{ValueRef, BasicBlockRef, BuilderRef, ContextRef};
 use llvm::{True, False, Bool};
 use middle::cfg;
 use middle::def;
+use middle::def_id::DefId;
 use middle::infer;
 use middle::lang_items::LangItem;
 use middle::subst::{self, Substs};
@@ -49,7 +50,6 @@ use std::cell::{Cell, RefCell};
 use std::result::Result as StdResult;
 use std::vec::Vec;
 use syntax::ast;
-use syntax::ast_util::local_def;
 use syntax::codemap::{DUMMY_SP, Span};
 use syntax::parse::token::InternedString;
 use syntax::parse::token;
@@ -1228,7 +1228,7 @@ pub fn langcall(bcx: Block,
                 span: Option<Span>,
                 msg: &str,
                 li: LangItem)
-                -> ast::DefId {
+                -> DefId {
     match bcx.tcx().lang_items.require(li) {
         Ok(id) => id,
         Err(s) => {
@@ -1257,7 +1257,7 @@ pub fn inlined_variant_def<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
         _ => ctor_ty
     }.ty_adt_def().unwrap();
     adt_def.variants.iter().find(|v| {
-        local_def(inlined_vid) == v.did ||
+        DefId::local(inlined_vid) == v.did ||
             ccx.external().borrow().get(&v.did) == Some(&Some(inlined_vid))
     }).unwrap_or_else(|| {
         ccx.sess().bug(&format!("no variant for {:?}::{}", adt_def, inlined_vid))

--- a/src/librustc_trans/trans/context.rs
+++ b/src/librustc_trans/trans/context.rs
@@ -12,6 +12,7 @@ use llvm;
 use llvm::{ContextRef, ModuleRef, ValueRef, BuilderRef};
 use metadata::common::LinkMeta;
 use middle::def::ExportMap;
+use middle::def_id::DefId;
 use middle::traits;
 use trans::adt;
 use trans::base;
@@ -91,7 +92,7 @@ pub struct LocalCrateContext<'tcx> {
     external: RefCell<DefIdMap<Option<ast::NodeId>>>,
     /// Backwards version of the `external` map (inlined items to where they
     /// came from)
-    external_srcs: RefCell<NodeMap<ast::DefId>>,
+    external_srcs: RefCell<NodeMap<DefId>>,
     /// Cache instances of monomorphized functions
     monomorphized: RefCell<FnvHashMap<MonoId<'tcx>, ValueRef>>,
     monomorphizing: RefCell<DefIdMap<usize>>,
@@ -120,7 +121,7 @@ pub struct LocalCrateContext<'tcx> {
     /// Cache of external const values
     extern_const_values: RefCell<DefIdMap<ValueRef>>,
 
-    impl_method_cache: RefCell<FnvHashMap<(ast::DefId, ast::Name), ast::DefId>>,
+    impl_method_cache: RefCell<FnvHashMap<(DefId, ast::Name), DefId>>,
 
     /// Cache of closure wrappers for bare fn's.
     closure_bare_wrapper_cache: RefCell<FnvHashMap<ValueRef, ValueRef>>,
@@ -626,7 +627,7 @@ impl<'b, 'tcx> CrateContext<'b, 'tcx> {
         &self.local.external
     }
 
-    pub fn external_srcs<'a>(&'a self) -> &'a RefCell<NodeMap<ast::DefId>> {
+    pub fn external_srcs<'a>(&'a self) -> &'a RefCell<NodeMap<DefId>> {
         &self.local.external_srcs
     }
 
@@ -664,7 +665,7 @@ impl<'b, 'tcx> CrateContext<'b, 'tcx> {
     }
 
     pub fn impl_method_cache<'a>(&'a self)
-            -> &'a RefCell<FnvHashMap<(ast::DefId, ast::Name), ast::DefId>> {
+            -> &'a RefCell<FnvHashMap<(DefId, ast::Name), DefId>> {
         &self.local.impl_method_cache
     }
 

--- a/src/librustc_trans/trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/trans/debuginfo/metadata.rs
@@ -23,6 +23,7 @@ use super::{declare_local, VariableKind, VariableAccess};
 use llvm::{self, ValueRef};
 use llvm::debuginfo::{DIType, DIFile, DIScope, DIDescriptor, DICompositeType};
 
+use middle::def_id::{DefId, LOCAL_CRATE};
 use middle::pat_util;
 use middle::subst::{self, Substs};
 use rustc::ast_map;
@@ -42,7 +43,7 @@ use std::ptr;
 use std::rc::Rc;
 use syntax::util::interner::Interner;
 use syntax::codemap::Span;
-use syntax::{ast, codemap, ast_util};
+use syntax::{ast, codemap};
 use syntax::parse::token;
 
 
@@ -316,12 +317,12 @@ impl<'tcx> TypeMap<'tcx> {
 
         fn from_def_id_and_substs<'a, 'tcx>(type_map: &mut TypeMap<'tcx>,
                                             cx: &CrateContext<'a, 'tcx>,
-                                            def_id: ast::DefId,
+                                            def_id: DefId,
                                             substs: &subst::Substs<'tcx>,
                                             output: &mut String) {
             // First, find out the 'real' def_id of the type. Items inlined from
             // other crates have to be mapped back to their source.
-            let source_def_id = if def_id.krate == ast::LOCAL_CRATE {
+            let source_def_id = if def_id.krate == LOCAL_CRATE {
                 match cx.external_srcs().borrow().get(&def_id.node).cloned() {
                     Some(source_def_id) => {
                         // The given def_id identifies the inlined copy of a
@@ -335,7 +336,7 @@ impl<'tcx> TypeMap<'tcx> {
             };
 
             // Get the crate hash as first part of the identifier.
-            let crate_hash = if source_def_id.krate == ast::LOCAL_CRATE {
+            let crate_hash = if source_def_id.krate == LOCAL_CRATE {
                 cx.link_meta().crate_hash.clone()
             } else {
                 cx.sess().cstore.get_crate_hash(source_def_id.krate)
@@ -1574,7 +1575,7 @@ fn describe_enum_variant<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
 
 fn prepare_enum_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                                    enum_type: Ty<'tcx>,
-                                   enum_def_id: ast::DefId,
+                                   enum_def_id: DefId,
                                    unique_type_id: UniqueTypeId,
                                    span: Span)
                                    -> RecursiveTypeDescription<'tcx> {
@@ -1699,7 +1700,7 @@ fn prepare_enum_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
     );
 
     fn get_enum_discriminant_name(cx: &CrateContext,
-                                  def_id: ast::DefId)
+                                  def_id: DefId)
                                   -> token::InternedString {
         cx.tcx().item_name(def_id).as_str()
     }
@@ -1884,7 +1885,7 @@ pub fn create_global_var_metadata(cx: &CrateContext,
     let is_local_to_unit = is_node_local_to_unit(cx, node_id);
     let variable_type = cx.tcx().node_id_to_type(node_id);
     let type_metadata = type_metadata(cx, variable_type, span);
-    let namespace_node = namespace_for_item(cx, ast_util::local_def(node_id));
+    let namespace_node = namespace_for_item(cx, DefId::local(node_id));
     let var_name = name.to_string();
     let linkage_name =
         namespace_node.mangled_name_of_contained_item(&var_name[..]);

--- a/src/librustc_trans/trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/trans/debuginfo/metadata.rs
@@ -23,7 +23,7 @@ use super::{declare_local, VariableKind, VariableAccess};
 use llvm::{self, ValueRef};
 use llvm::debuginfo::{DIType, DIFile, DIScope, DIDescriptor, DICompositeType};
 
-use middle::def_id::{DefId, LOCAL_CRATE};
+use middle::def_id::DefId;
 use middle::pat_util;
 use middle::subst::{self, Substs};
 use rustc::ast_map;
@@ -322,7 +322,7 @@ impl<'tcx> TypeMap<'tcx> {
                                             output: &mut String) {
             // First, find out the 'real' def_id of the type. Items inlined from
             // other crates have to be mapped back to their source.
-            let source_def_id = if def_id.krate == LOCAL_CRATE {
+            let source_def_id = if def_id.is_local() {
                 match cx.external_srcs().borrow().get(&def_id.node).cloned() {
                     Some(source_def_id) => {
                         // The given def_id identifies the inlined copy of a
@@ -336,7 +336,7 @@ impl<'tcx> TypeMap<'tcx> {
             };
 
             // Get the crate hash as first part of the identifier.
-            let crate_hash = if source_def_id.krate == LOCAL_CRATE {
+            let crate_hash = if source_def_id.is_local() {
                 cx.link_meta().crate_hash.clone()
             } else {
                 cx.sess().cstore.get_crate_hash(source_def_id.krate)

--- a/src/librustc_trans/trans/debuginfo/mod.rs
+++ b/src/librustc_trans/trans/debuginfo/mod.rs
@@ -26,6 +26,7 @@ use llvm;
 use llvm::{ModuleRef, ContextRef, ValueRef};
 use llvm::debuginfo::{DIFile, DIType, DIScope, DIBuilderRef, DISubprogram, DIArray,
                       DIDescriptor, FlagPrototyped};
+use middle::def_id::DefId;
 use middle::subst::{self, Substs};
 use rustc::ast_map;
 use trans::common::{NodeIdAndSpan, CrateContext, FunctionContext, Block};
@@ -75,7 +76,7 @@ pub struct CrateDebugContext<'tcx> {
     builder: DIBuilderRef,
     current_debug_location: Cell<InternalDebugLocation>,
     created_files: RefCell<FnvHashMap<String, DIFile>>,
-    created_enum_disr_types: RefCell<FnvHashMap<(ast::DefId, IntType), DIType>>,
+    created_enum_disr_types: RefCell<FnvHashMap<(DefId, IntType), DIType>>,
 
     type_map: RefCell<TypeMap<'tcx>>,
     namespace_map: RefCell<FnvHashMap<Vec<ast::Name>, Rc<NamespaceTreeNode>>>,
@@ -345,7 +346,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
     // somehow (storing a path in the ast_map, or construct a path using the
     // enclosing function).
     let (linkage_name, containing_scope) = if has_path {
-        let namespace_node = namespace_for_item(cx, ast_util::local_def(fn_ast_id));
+        let namespace_node = namespace_for_item(cx, DefId::local(fn_ast_id));
         let linkage_name = namespace_node.mangled_name_of_contained_item(
             &function_name[..]);
         let containing_scope = namespace_node.scope;

--- a/src/librustc_trans/trans/debuginfo/namespace.rs
+++ b/src/librustc_trans/trans/debuginfo/namespace.rs
@@ -15,7 +15,7 @@ use super::utils::{DIB, debug_context};
 use llvm;
 use llvm::debuginfo::DIScope;
 use rustc::ast_map;
-use rustc::middle::def_id::{DefId, LOCAL_CRATE};
+use rustc::middle::def_id::DefId;
 use trans::common::CrateContext;
 
 use std::ffi::CString;
@@ -58,7 +58,7 @@ pub fn crate_root_namespace<'a>(cx: &'a CrateContext) -> &'a str {
 pub fn namespace_for_item(cx: &CrateContext, def_id: DefId) -> Rc<NamespaceTreeNode> {
     cx.tcx().with_path(def_id, |path| {
         // prepend crate name if not already present
-        let krate = if def_id.krate == LOCAL_CRATE {
+        let krate = if def_id.is_local() {
             let crate_namespace_name = token::intern(crate_root_namespace(cx));
             Some(ast_map::PathMod(crate_namespace_name))
         } else {

--- a/src/librustc_trans/trans/debuginfo/namespace.rs
+++ b/src/librustc_trans/trans/debuginfo/namespace.rs
@@ -15,6 +15,7 @@ use super::utils::{DIB, debug_context};
 use llvm;
 use llvm::debuginfo::DIScope;
 use rustc::ast_map;
+use rustc::middle::def_id::{DefId, LOCAL_CRATE};
 use trans::common::CrateContext;
 
 use std::ffi::CString;
@@ -54,10 +55,10 @@ pub fn crate_root_namespace<'a>(cx: &'a CrateContext) -> &'a str {
     &cx.link_meta().crate_name
 }
 
-pub fn namespace_for_item(cx: &CrateContext, def_id: ast::DefId) -> Rc<NamespaceTreeNode> {
+pub fn namespace_for_item(cx: &CrateContext, def_id: DefId) -> Rc<NamespaceTreeNode> {
     cx.tcx().with_path(def_id, |path| {
         // prepend crate name if not already present
-        let krate = if def_id.krate == ast::LOCAL_CRATE {
+        let krate = if def_id.krate == LOCAL_CRATE {
             let crate_namespace_name = token::intern(crate_root_namespace(cx));
             Some(ast_map::PathMod(crate_namespace_name))
         } else {

--- a/src/librustc_trans/trans/debuginfo/type_names.rs
+++ b/src/librustc_trans/trans/debuginfo/type_names.rs
@@ -13,7 +13,7 @@
 use super::namespace::crate_root_namespace;
 
 use trans::common::CrateContext;
-use middle::def_id::{DefId, LOCAL_CRATE};
+use middle::def_id::DefId;
 use middle::subst::{self, Substs};
 use middle::ty::{self, Ty};
 
@@ -172,7 +172,7 @@ pub fn push_debuginfo_type_name<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                       output: &mut String) {
         cx.tcx().with_path(def_id, |path| {
             if qualified {
-                if def_id.krate == LOCAL_CRATE {
+                if def_id.is_local() {
                     output.push_str(crate_root_namespace(cx));
                     output.push_str("::");
                 }

--- a/src/librustc_trans/trans/debuginfo/type_names.rs
+++ b/src/librustc_trans/trans/debuginfo/type_names.rs
@@ -13,6 +13,7 @@
 use super::namespace::crate_root_namespace;
 
 use trans::common::CrateContext;
+use middle::def_id::{DefId, LOCAL_CRATE};
 use middle::subst::{self, Substs};
 use middle::ty::{self, Ty};
 
@@ -166,12 +167,12 @@ pub fn push_debuginfo_type_name<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
     }
 
     fn push_item_name(cx: &CrateContext,
-                      def_id: ast::DefId,
+                      def_id: DefId,
                       qualified: bool,
                       output: &mut String) {
         cx.tcx().with_path(def_id, |path| {
             if qualified {
-                if def_id.krate == ast::LOCAL_CRATE {
+                if def_id.krate == LOCAL_CRATE {
                     output.push_str(crate_root_namespace(cx));
                     output.push_str("::");
                 }

--- a/src/librustc_trans/trans/debuginfo/utils.rs
+++ b/src/librustc_trans/trans/debuginfo/utils.rs
@@ -13,7 +13,7 @@
 use super::{FunctionDebugContext, CrateDebugContext};
 use super::namespace::namespace_for_item;
 
-use middle::def_id::{DefId, LOCAL_CRATE};
+use middle::def_id::DefId;
 
 use llvm;
 use llvm::debuginfo::{DIScope, DIBuilderRef, DIDescriptor, DIArray};
@@ -99,7 +99,7 @@ pub fn assert_type_for_node_id(cx: &CrateContext,
 pub fn get_namespace_and_span_for_item(cx: &CrateContext, def_id: DefId)
                                    -> (DIScope, Span) {
     let containing_scope = namespace_for_item(cx, def_id).scope;
-    let definition_span = if def_id.krate == LOCAL_CRATE {
+    let definition_span = if def_id.is_local() {
         cx.tcx().map.span(def_id.node)
     } else {
         // For external items there is no span information

--- a/src/librustc_trans/trans/debuginfo/utils.rs
+++ b/src/librustc_trans/trans/debuginfo/utils.rs
@@ -13,6 +13,8 @@
 use super::{FunctionDebugContext, CrateDebugContext};
 use super::namespace::namespace_for_item;
 
+use middle::def_id::{DefId, LOCAL_CRATE};
+
 use llvm;
 use llvm::debuginfo::{DIScope, DIBuilderRef, DIDescriptor, DIArray};
 use trans::machine;
@@ -94,10 +96,10 @@ pub fn assert_type_for_node_id(cx: &CrateContext,
     }
 }
 
-pub fn get_namespace_and_span_for_item(cx: &CrateContext, def_id: ast::DefId)
+pub fn get_namespace_and_span_for_item(cx: &CrateContext, def_id: DefId)
                                    -> (DIScope, Span) {
     let containing_scope = namespace_for_item(cx, def_id).scope;
-    let definition_span = if def_id.krate == ast::LOCAL_CRATE {
+    let definition_span = if def_id.krate == LOCAL_CRATE {
         cx.tcx().map.span(def_id.node)
     } else {
         // For external items there is no span information

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -55,6 +55,7 @@ use back::abi;
 use llvm::{self, ValueRef, TypeKind};
 use middle::check_const;
 use middle::def;
+use middle::def_id::{LOCAL_CRATE};
 use middle::lang_items::CoerceUnsizedTraitLangItem;
 use middle::subst::{Substs, VecPerParamSpace};
 use middle::traits;
@@ -900,7 +901,7 @@ fn trans_def<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             let const_ty = expr_ty(bcx, ref_expr);
 
             // For external constants, we don't inline.
-            let val = if did.krate == ast::LOCAL_CRATE {
+            let val = if did.krate == LOCAL_CRATE {
                 // Case 1.
 
                 // The LLVM global has the type of its initializer,

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -55,7 +55,6 @@ use back::abi;
 use llvm::{self, ValueRef, TypeKind};
 use middle::check_const;
 use middle::def;
-use middle::def_id::{LOCAL_CRATE};
 use middle::lang_items::CoerceUnsizedTraitLangItem;
 use middle::subst::{Substs, VecPerParamSpace};
 use middle::traits;
@@ -901,7 +900,7 @@ fn trans_def<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             let const_ty = expr_ty(bcx, ref_expr);
 
             // For external constants, we don't inline.
-            let val = if did.krate == LOCAL_CRATE {
+            let val = if did.is_local() {
                 // Case 1.
 
                 // The LLVM global has the type of its initializer,

--- a/src/librustc_trans/trans/glue.rs
+++ b/src/librustc_trans/trans/glue.rs
@@ -340,7 +340,7 @@ pub fn get_res_dtor<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
         let (val, _, _) = monomorphize::monomorphic_fn(ccx, did, substs, None);
 
         val
-    } else if did.krate == LOCAL_CRATE {
+    } else if did.is_local() {
         get_item_val(ccx, did.node)
     } else {
         let tcx = ccx.tcx();

--- a/src/librustc_trans/trans/inline.rs
+++ b/src/librustc_trans/trans/inline.rs
@@ -12,7 +12,7 @@ use llvm::{AvailableExternallyLinkage, InternalLinkage, SetLinkage};
 use metadata::csearch;
 use metadata::inline::InlinedItem;
 use middle::astencode;
-use middle::def_id::{DefId, LOCAL_CRATE};
+use middle::def_id::DefId;
 use middle::subst::Substs;
 use trans::base::{push_ctxt, trans_item, get_item_val, trans_fn};
 use trans::common::*;
@@ -189,7 +189,7 @@ fn instantiate_inline(ccx: &CrateContext, fn_id: DefId)
 
 pub fn get_local_instance(ccx: &CrateContext, fn_id: DefId)
     -> Option<DefId> {
-    if fn_id.krate == LOCAL_CRATE {
+    if fn_id.is_local() {
         Some(fn_id)
     } else {
         instantiate_inline(ccx, fn_id)

--- a/src/librustc_trans/trans/inline.rs
+++ b/src/librustc_trans/trans/inline.rs
@@ -12,15 +12,15 @@ use llvm::{AvailableExternallyLinkage, InternalLinkage, SetLinkage};
 use metadata::csearch;
 use metadata::inline::InlinedItem;
 use middle::astencode;
+use middle::def_id::{DefId, LOCAL_CRATE};
 use middle::subst::Substs;
 use trans::base::{push_ctxt, trans_item, get_item_val, trans_fn};
 use trans::common::*;
 
 use syntax::ast;
-use syntax::ast_util::local_def;
 
-fn instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
-    -> Option<ast::DefId> {
+fn instantiate_inline(ccx: &CrateContext, fn_id: DefId)
+    -> Option<DefId> {
     debug!("instantiate_inline({:?})", fn_id);
     let _icx = push_ctxt("instantiate_inline");
 
@@ -29,7 +29,7 @@ fn instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
             // Already inline
             debug!("instantiate_inline({}): already inline as node id {}",
                    ccx.tcx().item_path_str(fn_id), node_id);
-            return Some(local_def(node_id));
+            return Some(DefId::local(node_id));
         }
         Some(&None) => {
             return None; // Not inlinable
@@ -144,7 +144,7 @@ fn instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
             // inlined items.
             let ty_trait_item = ccx.tcx().impl_or_trait_item(fn_id).clone();
             ccx.tcx().impl_or_trait_items.borrow_mut()
-                     .insert(local_def(trait_item.id), ty_trait_item);
+                     .insert(DefId::local(trait_item.id), ty_trait_item);
 
             // If this is a default method, we can't look up the
             // impl type. But we aren't going to translate anyways, so
@@ -184,18 +184,18 @@ fn instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
         }
     };
 
-    Some(local_def(inline_id))
+    Some(DefId::local(inline_id))
 }
 
-pub fn get_local_instance(ccx: &CrateContext, fn_id: ast::DefId)
-    -> Option<ast::DefId> {
-    if fn_id.krate == ast::LOCAL_CRATE {
+pub fn get_local_instance(ccx: &CrateContext, fn_id: DefId)
+    -> Option<DefId> {
+    if fn_id.krate == LOCAL_CRATE {
         Some(fn_id)
     } else {
         instantiate_inline(ccx, fn_id)
     }
 }
 
-pub fn maybe_instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId) -> ast::DefId {
+pub fn maybe_instantiate_inline(ccx: &CrateContext, fn_id: DefId) -> DefId {
     get_local_instance(ccx, fn_id).unwrap_or(fn_id)
 }

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -12,7 +12,7 @@ use arena::TypedArena;
 use back::abi;
 use back::link;
 use llvm::{ValueRef, get_params};
-use middle::def_id::{DefId, LOCAL_CRATE};
+use middle::def_id::DefId;
 use middle::subst::{Subst, Substs};
 use middle::subst::VecPerParamSpace;
 use middle::subst;

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -12,6 +12,7 @@ use arena::TypedArena;
 use back::abi;
 use back::link;
 use llvm::{ValueRef, get_params};
+use middle::def_id::{DefId, LOCAL_CRATE};
 use middle::subst::{Subst, Substs};
 use middle::subst::VecPerParamSpace;
 use middle::subst;
@@ -148,8 +149,8 @@ pub fn trans_method_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 }
 
 pub fn trans_static_method_callee<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
-                                            method_id: ast::DefId,
-                                            trait_id: ast::DefId,
+                                            method_id: DefId,
+                                            trait_id: DefId,
                                             expr_id: ast::NodeId,
                                             param_substs: &'tcx subst::Substs<'tcx>)
                                             -> Datum<'tcx, Rvalue>
@@ -265,8 +266,8 @@ pub fn trans_static_method_callee<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     }
 }
 
-fn method_with_name(ccx: &CrateContext, impl_id: ast::DefId, name: ast::Name)
-                    -> ast::DefId {
+fn method_with_name(ccx: &CrateContext, impl_id: DefId, name: ast::Name)
+                    -> DefId {
     match ccx.impl_method_cache().borrow().get(&(impl_id, name)).cloned() {
         Some(m) => return m,
         None => {}
@@ -290,8 +291,8 @@ fn method_with_name(ccx: &CrateContext, impl_id: ast::DefId, name: ast::Name)
 fn trans_monomorphized_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                           method_call: MethodCall,
                                           self_expr: Option<&ast::Expr>,
-                                          trait_id: ast::DefId,
-                                          method_id: ast::DefId,
+                                          trait_id: DefId,
+                                          method_id: DefId,
                                           method_ty: Ty<'tcx>,
                                           vtable: traits::Vtable<'tcx, ()>,
                                           arg_cleanup_scope: cleanup::ScopeId)
@@ -507,7 +508,7 @@ fn trans_trait_callee_from_llval<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 fn trans_object_shim<'a, 'tcx>(
     ccx: &'a CrateContext<'a, 'tcx>,
     upcast_trait_ref: ty::PolyTraitRef<'tcx>,
-    method_id: ast::DefId,
+    method_id: DefId,
     vtable_index: usize)
     -> Datum<'tcx, Rvalue>
 {
@@ -677,7 +678,7 @@ pub fn get_vtable<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
 }
 
 fn emit_vtable_methods<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
-                                 impl_id: ast::DefId,
+                                 impl_id: DefId,
                                  substs: subst::Substs<'tcx>,
                                  param_substs: &'tcx subst::Substs<'tcx>)
                                  -> Vec<ValueRef>

--- a/src/librustc_trans/trans/monomorphize.rs
+++ b/src/librustc_trans/trans/monomorphize.rs
@@ -12,6 +12,7 @@ use back::link::exported_name;
 use session;
 use llvm::ValueRef;
 use llvm;
+use middle::def_id::DefId;
 use middle::infer;
 use middle::subst;
 use middle::subst::{Subst, Substs};
@@ -34,7 +35,7 @@ use syntax::codemap::DUMMY_SP;
 use std::hash::{Hasher, Hash, SipHasher};
 
 pub fn monomorphic_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
-                                fn_id: ast::DefId,
+                                fn_id: DefId,
                                 psubsts: &'tcx subst::Substs<'tcx>,
                                 ref_id: Option<ast::NodeId>)
     -> (ValueRef, Ty<'tcx>, bool) {
@@ -272,7 +273,7 @@ pub fn monomorphic_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
 
 #[derive(PartialEq, Eq, Hash, Debug)]
 pub struct MonoId<'tcx> {
-    pub def: ast::DefId,
+    pub def: DefId,
     pub params: &'tcx subst::VecPerParamSpace<Ty<'tcx>>
 }
 

--- a/src/librustc_trans/trans/type_of.rs
+++ b/src/librustc_trans/trans/type_of.rs
@@ -10,6 +10,7 @@
 
 #![allow(non_camel_case_types)]
 
+use middle::def_id::DefId;
 use middle::subst;
 use trans::adt;
 use trans::common::*;
@@ -469,7 +470,7 @@ pub fn align_of<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>)
 }
 
 fn llvm_type_name<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
-                            did: ast::DefId,
+                            did: DefId,
                             tps: &[Ty<'tcx>])
                             -> String {
     let base = cx.tcx().item_path_str(did);

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -52,6 +52,7 @@ use middle::astconv_util::{prim_ty_to_ty, check_path_args, NO_TPS, NO_REGIONS};
 use middle::const_eval::{self, ConstVal};
 use middle::const_eval::EvalHint::UncheckedExprHint;
 use middle::def;
+use middle::def_id::{DefId, LOCAL_CRATE};
 use middle::wf::object_region_bounds;
 use middle::resolve_lifetime as rl;
 use middle::privacy::{AllPublic, LastMod};
@@ -67,7 +68,7 @@ use util::common::{ErrorReported, FN_OUTPUT_NAME};
 use util::nodemap::FnvHashSet;
 
 use std::slice;
-use syntax::{abi, ast, ast_util};
+use syntax::{abi, ast};
 use syntax::codemap::{Span, Pos};
 use syntax::feature_gate::emit_feature_err;
 use syntax::parse::token;
@@ -79,18 +80,18 @@ pub trait AstConv<'tcx> {
     /// Identify the type scheme for an item with a type, like a type
     /// alias, fn, or struct. This allows you to figure out the set of
     /// type parameters defined on the item.
-    fn get_item_type_scheme(&self, span: Span, id: ast::DefId)
+    fn get_item_type_scheme(&self, span: Span, id: DefId)
                             -> Result<ty::TypeScheme<'tcx>, ErrorReported>;
 
     /// Returns the `TraitDef` for a given trait. This allows you to
     /// figure out the set of type parameters defined on the trait.
-    fn get_trait_def(&self, span: Span, id: ast::DefId)
+    fn get_trait_def(&self, span: Span, id: DefId)
                      -> Result<&'tcx ty::TraitDef<'tcx>, ErrorReported>;
 
     /// Ensure that the super-predicates for the trait with the given
     /// id are available and also for the transitive set of
     /// super-predicates.
-    fn ensure_super_predicates(&self, span: Span, id: ast::DefId)
+    fn ensure_super_predicates(&self, span: Span, id: DefId)
                                -> Result<(), ErrorReported>;
 
     /// Returns the set of bounds in scope for the type parameter with
@@ -100,7 +101,7 @@ pub trait AstConv<'tcx> {
 
     /// Returns true if the trait with id `trait_def_id` defines an
     /// associated type with the name `name`.
-    fn trait_defines_associated_type_named(&self, trait_def_id: ast::DefId, name: ast::Name)
+    fn trait_defines_associated_type_named(&self, trait_def_id: DefId, name: ast::Name)
                                            -> bool;
 
     /// Return an (optional) substitution to convert bound type parameters that
@@ -164,7 +165,7 @@ pub fn ast_region_to_region(tcx: &ty::ctxt, lifetime: &ast::Lifetime)
         }
 
         Some(&rl::DefLateBoundRegion(debruijn, id)) => {
-            ty::ReLateBound(debruijn, ty::BrNamed(ast_util::local_def(id), lifetime.name))
+            ty::ReLateBound(debruijn, ty::BrNamed(DefId::local(id), lifetime.name))
         }
 
         Some(&rl::DefEarlyBoundRegion(space, index, id)) => {
@@ -179,7 +180,7 @@ pub fn ast_region_to_region(tcx: &ty::ctxt, lifetime: &ast::Lifetime)
         Some(&rl::DefFreeRegion(scope, id)) => {
             ty::ReFree(ty::FreeRegion {
                     scope: scope,
-                    bound_region: ty::BrNamed(ast_util::local_def(id),
+                    bound_region: ty::BrNamed(DefId::local(id),
                                               lifetime.name)
                 })
         }
@@ -667,7 +668,7 @@ pub fn instantiate_mono_trait_ref<'tcx>(
                                trait_ref.path.segments.last().unwrap())
 }
 
-fn trait_def_id<'tcx>(this: &AstConv<'tcx>, trait_ref: &ast::TraitRef) -> ast::DefId {
+fn trait_def_id<'tcx>(this: &AstConv<'tcx>, trait_ref: &ast::TraitRef) -> DefId {
     let path = &trait_ref.path;
     match ::lookup_full_def(this.tcx(), path.span, trait_ref.ref_id) {
         def::DefTrait(trait_def_id) => trait_def_id,
@@ -683,7 +684,7 @@ fn object_path_to_poly_trait_ref<'a,'tcx>(
     rscope: &RegionScope,
     span: Span,
     param_mode: PathParamMode,
-    trait_def_id: ast::DefId,
+    trait_def_id: DefId,
     trait_segment: &ast::PathSegment,
     mut projections: &mut Vec<ty::PolyProjectionPredicate<'tcx>>)
     -> ty::PolyTraitRef<'tcx>
@@ -703,7 +704,7 @@ fn ast_path_to_poly_trait_ref<'a,'tcx>(
     rscope: &RegionScope,
     span: Span,
     param_mode: PathParamMode,
-    trait_def_id: ast::DefId,
+    trait_def_id: DefId,
     self_ty: Option<Ty<'tcx>>,
     trait_segment: &ast::PathSegment,
     poly_projections: &mut Vec<ty::PolyProjectionPredicate<'tcx>>)
@@ -749,7 +750,7 @@ fn ast_path_to_mono_trait_ref<'a,'tcx>(this: &AstConv<'tcx>,
                                        rscope: &RegionScope,
                                        span: Span,
                                        param_mode: PathParamMode,
-                                       trait_def_id: ast::DefId,
+                                       trait_def_id: DefId,
                                        self_ty: Option<Ty<'tcx>>,
                                        trait_segment: &ast::PathSegment)
                                        -> ty::TraitRef<'tcx>
@@ -770,7 +771,7 @@ fn create_substs_for_ast_trait_ref<'a,'tcx>(this: &AstConv<'tcx>,
                                             rscope: &RegionScope,
                                             span: Span,
                                             param_mode: PathParamMode,
-                                            trait_def_id: ast::DefId,
+                                            trait_def_id: DefId,
                                             self_ty: Option<Ty<'tcx>>,
                                             trait_segment: &ast::PathSegment)
                                             -> (&'tcx Substs<'tcx>, Vec<ConvertedBinding<'tcx>>)
@@ -918,7 +919,7 @@ fn ast_path_to_ty<'tcx>(
     rscope: &RegionScope,
     span: Span,
     param_mode: PathParamMode,
-    did: ast::DefId,
+    did: DefId,
     item_segment: &ast::PathSegment)
     -> Ty<'tcx>
 {
@@ -1075,7 +1076,7 @@ fn make_object_type<'tcx>(this: &AstConv<'tcx>,
         return tcx.types.err;
     }
 
-    let mut associated_types: FnvHashSet<(ast::DefId, ast::Name)> =
+    let mut associated_types: FnvHashSet<(DefId, ast::Name)> =
         traits::supertraits(tcx, object_trait_ref)
         .flat_map(|tr| {
             let trait_def = tcx.lookup_trait_def(tr.def_id());
@@ -1214,7 +1215,7 @@ fn associated_path_def_to_ty<'tcx>(this: &AstConv<'tcx>,
         (_, def::DefSelfTy(Some(trait_did), Some((impl_id, _)))) => {
             // `Self` in an impl of a trait - we have a concrete self type and a
             // trait reference.
-            let trait_ref = tcx.impl_trait_ref(ast_util::local_def(impl_id)).unwrap();
+            let trait_ref = tcx.impl_trait_ref(DefId::local(impl_id)).unwrap();
             let trait_ref = if let Some(free_substs) = this.get_free_substs() {
                 trait_ref.subst(tcx, free_substs)
             } else {
@@ -1241,7 +1242,7 @@ fn associated_path_def_to_ty<'tcx>(this: &AstConv<'tcx>,
             }
         }
         (&ty::TyParam(_), def::DefSelfTy(Some(trait_did), None)) => {
-            assert_eq!(trait_did.krate, ast::LOCAL_CRATE);
+            assert_eq!(trait_did.krate, LOCAL_CRATE);
             match find_bound_for_assoc_item(this,
                                             trait_did.node,
                                             token::special_idents::type_self.name,
@@ -1252,7 +1253,7 @@ fn associated_path_def_to_ty<'tcx>(this: &AstConv<'tcx>,
             }
         }
         (&ty::TyParam(_), def::DefTyParam(_, _, param_did, param_name)) => {
-            assert_eq!(param_did.krate, ast::LOCAL_CRATE);
+            assert_eq!(param_did.krate, LOCAL_CRATE);
             match find_bound_for_assoc_item(this,
                                             param_did.node,
                                             param_name,
@@ -1275,7 +1276,7 @@ fn associated_path_def_to_ty<'tcx>(this: &AstConv<'tcx>,
     let trait_did = bound.0.def_id;
     let ty = this.projected_ty_from_poly_trait_ref(span, bound, assoc_name);
 
-    let item_did = if trait_did.krate == ast::LOCAL_CRATE {
+    let item_did = if trait_did.krate == LOCAL_CRATE {
         // `ty::trait_items` used below requires information generated
         // by type collection, which may be in progress at this point.
         match tcx.map.expect_item(trait_did.node).node {
@@ -1283,7 +1284,7 @@ fn associated_path_def_to_ty<'tcx>(this: &AstConv<'tcx>,
                 let item = trait_items.iter()
                                       .find(|i| i.ident.name == assoc_name)
                                       .expect("missing associated type");
-                ast_util::local_def(item.id)
+                DefId::local(item.id)
             }
             _ => unreachable!()
         }
@@ -1301,7 +1302,7 @@ fn qpath_to_ty<'tcx>(this: &AstConv<'tcx>,
                      span: Span,
                      param_mode: PathParamMode,
                      opt_self_ty: Option<Ty<'tcx>>,
-                     trait_def_id: ast::DefId,
+                     trait_def_id: DefId,
                      trait_segment: &ast::PathSegment,
                      item_segment: &ast::PathSegment)
                      -> Ty<'tcx>
@@ -1589,7 +1590,7 @@ pub fn ast_ty_to_ty<'tcx>(this: &AstConv<'tcx>,
             } else if let Some(ast::QSelf { position: 0, .. }) = *maybe_qself {
                 // Create some fake resolution that can't possibly be a type.
                 def::PathResolution {
-                    base_def: def::DefMod(ast_util::local_def(ast::CRATE_NODE_ID)),
+                    base_def: def::DefMod(DefId::local(ast::CRATE_NODE_ID)),
                     last_private: LastMod(AllPublic),
                     depth: path.segments.len()
                 }

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1276,7 +1276,7 @@ fn associated_path_def_to_ty<'tcx>(this: &AstConv<'tcx>,
     let trait_did = bound.0.def_id;
     let ty = this.projected_ty_from_poly_trait_ref(span, bound, assoc_name);
 
-    let item_did = if trait_did.krate == LOCAL_CRATE {
+    let item_did = if trait_did.is_local() {
         // `ty::trait_items` used below requires information generated
         // by type collection, which may be in progress at this point.
         match tcx.map.expect_item(trait_did.node).node {

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use middle::def;
+use middle::def_id::DefId;
 use middle::infer;
 use middle::pat_util::{PatIdMap, pat_id_map, pat_is_binding};
 use middle::pat_util::pat_is_resolved_const;
@@ -201,7 +202,7 @@ pub fn check_pat<'a, 'tcx>(pcx: &pat_ctxt<'a, 'tcx>,
             } else if qself.position == 0 {
                 def::PathResolution {
                     // This is just a sentinel for finish_resolving_def_to_ty.
-                    base_def: def::DefMod(ast_util::local_def(ast::CRATE_NODE_ID)),
+                    base_def: def::DefMod(DefId::local(ast::CRATE_NODE_ID)),
                     last_private: LastMod(AllPublic),
                     depth: path.segments.len()
                 }

--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -26,6 +26,7 @@ use super::UnresolvedTypeAction;
 use super::write_call;
 
 use CrateCtxt;
+use middle::def_id::{DefId, LOCAL_CRATE};
 use middle::infer;
 use middle::ty::{self, Ty};
 use syntax::ast;
@@ -36,7 +37,7 @@ use syntax::ptr::P;
 /// Check that it is legal to call methods of the trait corresponding
 /// to `trait_id` (this only cares about the trait, not the specific
 /// method that is called)
-pub fn check_legal_trait_for_method_call(ccx: &CrateCtxt, span: Span, trait_id: ast::DefId) {
+pub fn check_legal_trait_for_method_call(ccx: &CrateCtxt, span: Span, trait_id: DefId) {
     let tcx = ccx.tcx;
     let did = Some(trait_id);
     let li = &tcx.lang_items;
@@ -132,7 +133,7 @@ fn try_overloaded_call_step<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
         }
 
         ty::TyClosure(def_id, ref substs) => {
-            assert_eq!(def_id.krate, ast::LOCAL_CRATE);
+            assert_eq!(def_id.krate, LOCAL_CRATE);
 
             // Check whether this is a call to a closure where we
             // haven't yet decided on whether the closure is fn vs
@@ -334,7 +335,7 @@ struct CallResolution<'tcx> {
     adjusted_ty: Ty<'tcx>,
     autoderefs: usize,
     fn_sig: ty::FnSig<'tcx>,
-    closure_def_id: ast::DefId,
+    closure_def_id: DefId,
 }
 
 impl<'tcx> DeferredCallResolution<'tcx> for CallResolution<'tcx> {

--- a/src/librustc_typeck/check/cast.rs
+++ b/src/librustc_typeck/check/cast.rs
@@ -45,6 +45,7 @@ use super::structurally_resolved_type;
 
 use lint;
 use middle::cast::{CastKind, CastTy};
+use middle::def_id::DefId;
 use middle::ty::{self, Ty, HasTypeFlags};
 use syntax::ast;
 use syntax::ast::UintTy::{TyU8};
@@ -63,7 +64,7 @@ pub struct CastCheck<'tcx> {
 /// fat pointers if their unsize-infos have the same kind.
 #[derive(Copy, Clone, PartialEq, Eq)]
 enum UnsizeKind<'tcx> {
-    Vtable(ast::DefId),
+    Vtable(DefId),
     Length,
     /// The unsize info of this projection
     OfProjection(&'tcx ty::ProjectionTy<'tcx>),

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -13,13 +13,13 @@
 use super::{check_fn, Expectation, FnCtxt};
 
 use astconv;
+use middle::def_id::DefId;
 use middle::region;
 use middle::subst;
 use middle::ty::{self, ToPolyTraitRef, Ty};
 use std::cmp;
 use syntax::abi;
 use syntax::ast;
-use syntax::ast_util;
 
 pub fn check_expr_closure<'a,'tcx>(fcx: &FnCtxt<'a,'tcx>,
                                    expr: &ast::Expr,
@@ -47,7 +47,7 @@ fn check_closure<'a,'tcx>(fcx: &FnCtxt<'a,'tcx>,
                           decl: &'tcx ast::FnDecl,
                           body: &'tcx ast::Block,
                           expected_sig: Option<ty::FnSig<'tcx>>) {
-    let expr_def_id = ast_util::local_def(expr.id);
+    let expr_def_id = DefId::local(expr.id);
 
     debug!("check_closure opt_kind={:?} expected_sig={:?}",
            opt_kind,

--- a/src/librustc_typeck/check/dropck.rs
+++ b/src/librustc_typeck/check/dropck.rs
@@ -10,6 +10,7 @@
 
 use check::regionck::{self, Rcx};
 
+use middle::def_id::{DefId, LOCAL_CRATE};
 use middle::infer;
 use middle::region;
 use middle::subst::{self, Subst};
@@ -37,7 +38,7 @@ use syntax::parse::token::special_idents;
 ///    struct/enum definition for the nominal type itself (i.e.
 ///    cannot do `struct S<T>; impl<T:Clone> Drop for S<T> { ... }`).
 ///
-pub fn check_drop_impl(tcx: &ty::ctxt, drop_impl_did: ast::DefId) -> Result<(), ()> {
+pub fn check_drop_impl(tcx: &ty::ctxt, drop_impl_did: DefId) -> Result<(), ()> {
     let ty::TypeScheme { generics: ref dtor_generics,
                          ty: dtor_self_type } = tcx.lookup_item_type(drop_impl_did);
     let dtor_predicates = tcx.lookup_predicates(drop_impl_did);
@@ -69,10 +70,10 @@ pub fn check_drop_impl(tcx: &ty::ctxt, drop_impl_did: ast::DefId) -> Result<(), 
 
 fn ensure_drop_params_and_item_params_correspond<'tcx>(
     tcx: &ty::ctxt<'tcx>,
-    drop_impl_did: ast::DefId,
+    drop_impl_did: DefId,
     drop_impl_generics: &ty::Generics<'tcx>,
     drop_impl_ty: &ty::Ty<'tcx>,
-    self_type_did: ast::DefId) -> Result<(), ()>
+    self_type_did: DefId) -> Result<(), ()>
 {
     // New strategy based on review suggestion from nikomatsakis.
     //
@@ -135,9 +136,9 @@ fn ensure_drop_params_and_item_params_correspond<'tcx>(
 /// implied by assuming the predicates attached to self_type_did.
 fn ensure_drop_predicates_are_implied_by_item_defn<'tcx>(
     tcx: &ty::ctxt<'tcx>,
-    drop_impl_did: ast::DefId,
+    drop_impl_did: DefId,
     dtor_predicates: &ty::GenericPredicates<'tcx>,
-    self_type_did: ast::DefId,
+    self_type_did: DefId,
     self_to_impl_substs: &subst::Substs<'tcx>) -> Result<(), ()> {
 
     // Here is an example, analogous to that from
@@ -175,7 +176,7 @@ fn ensure_drop_predicates_are_implied_by_item_defn<'tcx>(
     // absent. So we report an error that the Drop impl injected a
     // predicate that is not present on the struct definition.
 
-    assert_eq!(self_type_did.krate, ast::LOCAL_CRATE);
+    assert_eq!(self_type_did.krate, LOCAL_CRATE);
 
     let drop_impl_span = tcx.map.def_id_span(drop_impl_did, codemap::DUMMY_SP);
 
@@ -321,7 +322,7 @@ enum Error<'tcx> {
 enum TypeContext {
     Root,
     ADT {
-        def_id: ast::DefId,
+        def_id: DefId,
         variant: ast::Name,
         field: ast::Name,
         field_index: usize

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -13,6 +13,7 @@
 
 use astconv::AstConv;
 use intrinsics;
+use middle::def_id::DefId;
 use middle::subst;
 use middle::ty::FnSig;
 use middle::ty::{self, Ty};
@@ -23,7 +24,6 @@ use std::collections::{HashMap};
 use syntax::abi;
 use syntax::attr::AttrMetaMethods;
 use syntax::ast;
-use syntax::ast_util::local_def;
 use syntax::codemap::Span;
 use syntax::parse::token;
 
@@ -41,7 +41,7 @@ fn equate_intrinsic_type<'a, 'tcx>(tcx: &ty::ctxt<'tcx>, it: &ast::ForeignItem,
             variadic: false,
         }),
     }));
-    let i_ty = tcx.lookup_item_type(local_def(it.id));
+    let i_ty = tcx.lookup_item_type(DefId::local(it.id));
     let i_n_tps = i_ty.generics.types.len(subst::FnSpace);
     if i_n_tps != n_tps {
         span_err!(tcx.sess, it.span, E0094,
@@ -363,7 +363,7 @@ pub fn check_platform_intrinsic_type(ccx: &CrateCtxt,
     };
 
     let tcx = ccx.tcx;
-    let i_ty = tcx.lookup_item_type(local_def(it.id));
+    let i_ty = tcx.lookup_item_type(DefId::local(it.id));
     let i_n_tps = i_ty.generics.types.len(subst::FnSpace);
     let name = it.ident.name.as_str();
 

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -12,6 +12,7 @@ use super::probe;
 
 use check::{self, FnCtxt, NoPreference, PreferMutLvalue, callee, demand};
 use check::UnresolvedTypeAction;
+use middle::def_id::DefId;
 use middle::subst::{self};
 use middle::traits;
 use middle::ty::{self, Ty};
@@ -631,7 +632,7 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
 
     fn upcast(&mut self,
               source_trait_ref: ty::PolyTraitRef<'tcx>,
-              target_trait_def_id: ast::DefId)
+              target_trait_def_id: DefId)
               -> ty::PolyTraitRef<'tcx>
     {
         let upcast_trait_refs = traits::upcast(self.tcx(),

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -13,13 +13,13 @@
 use astconv::AstConv;
 use check::FnCtxt;
 use middle::def;
+use middle::def_id::DefId;
 use middle::privacy::{AllPublic, DependsOn, LastPrivate, LastMod};
 use middle::subst;
 use middle::traits;
 use middle::ty::{self, ToPredicate, ToPolyTraitRef, TraitRef};
 use middle::infer;
 
-use syntax::ast::DefId;
 use syntax::ast;
 use syntax::codemap::Span;
 
@@ -40,7 +40,7 @@ pub enum MethodError<'tcx> {
     Ambiguity(Vec<CandidateSource>),
 
     // Using a `Fn`/`FnMut`/etc method on a raw closure type before we have inferred its kind.
-    ClosureAmbiguity(/* DefId of fn trait */ ast::DefId),
+    ClosureAmbiguity(/* DefId of fn trait */ DefId),
 }
 
 // Contains a list of static methods that may apply, a list of unsatisfied trait predicates which
@@ -48,14 +48,14 @@ pub enum MethodError<'tcx> {
 pub struct NoMatchData<'tcx> {
     pub static_candidates: Vec<CandidateSource>,
     pub unsatisfied_predicates: Vec<TraitRef<'tcx>>,
-    pub out_of_scope_traits: Vec<ast::DefId>,
+    pub out_of_scope_traits: Vec<DefId>,
     pub mode: probe::Mode
 }
 
 impl<'tcx> NoMatchData<'tcx> {
     pub fn new(static_candidates: Vec<CandidateSource>,
                unsatisfied_predicates: Vec<TraitRef<'tcx>>,
-               out_of_scope_traits: Vec<ast::DefId>,
+               out_of_scope_traits: Vec<DefId>,
                mode: probe::Mode) -> Self {
         NoMatchData {
             static_candidates: static_candidates,
@@ -70,8 +70,8 @@ impl<'tcx> NoMatchData<'tcx> {
 // candidate can arise. Used for error reporting only.
 #[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum CandidateSource {
-    ImplSource(ast::DefId),
-    TraitSource(/* trait id */ ast::DefId),
+    ImplSource(DefId),
+    TraitSource(/* trait id */ DefId),
 }
 
 /// Determines whether the type `self_ty` supports a method name `method_name` or not.
@@ -353,7 +353,7 @@ pub fn resolve_ufcs<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
 /// Find item with name `item_name` defined in `trait_def_id`
 /// and return it, or `None`, if no such item.
 fn trait_item<'tcx>(tcx: &ty::ctxt<'tcx>,
-                    trait_def_id: ast::DefId,
+                    trait_def_id: DefId,
                     item_name: ast::Name)
                     -> Option<ty::ImplOrTraitItem<'tcx>>
 {
@@ -364,7 +364,7 @@ fn trait_item<'tcx>(tcx: &ty::ctxt<'tcx>,
 }
 
 fn impl_item<'tcx>(tcx: &ty::ctxt<'tcx>,
-                   impl_def_id: ast::DefId,
+                   impl_def_id: DefId,
                    item_name: ast::Name)
                    -> Option<ty::ImplOrTraitItem<'tcx>>
 {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -86,6 +86,7 @@ use check::_match::pat_ctxt;
 use fmt_macros::{Parser, Piece, Position};
 use middle::astconv_util::{check_path_args, NO_TPS, NO_REGIONS};
 use middle::def;
+use middle::def_id::{DefId, LOCAL_CRATE};
 use middle::infer;
 use middle::infer::type_variable;
 use middle::pat_util::{self, pat_id_map};
@@ -114,8 +115,8 @@ use std::mem::replace;
 use std::slice;
 use syntax::{self, abi, attr};
 use syntax::attr::AttrMetaMethods;
-use syntax::ast::{self, DefId, Visibility};
-use syntax::ast_util::{self, local_def};
+use syntax::ast::{self, Visibility};
+use syntax::ast_util;
 use syntax::codemap::{self, Span};
 use syntax::feature_gate::emit_feature_err;
 use syntax::owned_slice::OwnedSlice;
@@ -426,7 +427,7 @@ pub fn check_item_bodies(ccx: &CrateCtxt) {
 
 pub fn check_drop_impls(ccx: &CrateCtxt) {
     for drop_method_did in ccx.tcx.destructors.borrow().iter() {
-        if drop_method_did.krate == ast::LOCAL_CRATE {
+        if drop_method_did.krate == LOCAL_CRATE {
             let drop_impl_did = ccx.tcx.map.get_parent_did(drop_method_did.node);
             match dropck::check_drop_impl(ccx.tcx, drop_impl_did) {
                 Ok(()) => {}
@@ -671,7 +672,7 @@ pub fn check_struct(ccx: &CrateCtxt, id: ast::NodeId, span: Span) {
     check_representable(tcx, span, id, "struct");
     check_instantiable(tcx, span, id);
 
-    if tcx.lookup_simd(local_def(id)) {
+    if tcx.lookup_simd(DefId::local(id)) {
         check_simd(tcx, span, id);
     }
 }
@@ -679,7 +680,7 @@ pub fn check_struct(ccx: &CrateCtxt, id: ast::NodeId, span: Span) {
 pub fn check_item_type<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx ast::Item) {
     debug!("check_item_type(it.id={}, it.ident={})",
            it.id,
-           ccx.tcx.item_path_str(local_def(it.id)));
+           ccx.tcx.item_path_str(DefId::local(it.id)));
     let _indenter = indenter();
     match it.node {
       // Consts can play a role in type-checking, so they are included here.
@@ -694,7 +695,7 @@ pub fn check_item_type<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx ast::Item) {
       ast::ItemFn(..) => {} // entirely within check_item_body
       ast::ItemImpl(_, _, _, _, _, ref impl_items) => {
           debug!("ItemImpl {} with id {}", it.ident, it.id);
-          match ccx.tcx.impl_trait_ref(local_def(it.id)) {
+          match ccx.tcx.impl_trait_ref(DefId::local(it.id)) {
               Some(impl_trait_ref) => {
                 check_impl_items_against_trait(ccx,
                                                it.span,
@@ -725,7 +726,7 @@ pub fn check_item_type<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx ast::Item) {
             }
         } else {
             for item in &m.items {
-                let pty = ccx.tcx.lookup_item_type(local_def(item.id));
+                let pty = ccx.tcx.lookup_item_type(DefId::local(item.id));
                 if !pty.generics.types.is_empty() {
                     span_err!(ccx.tcx.sess, item.span, E0044,
                         "foreign items may not have type parameters");
@@ -744,18 +745,18 @@ pub fn check_item_type<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx ast::Item) {
 pub fn check_item_body<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx ast::Item) {
     debug!("check_item_body(it.id={}, it.ident={})",
            it.id,
-           ccx.tcx.item_path_str(local_def(it.id)));
+           ccx.tcx.item_path_str(DefId::local(it.id)));
     let _indenter = indenter();
     match it.node {
       ast::ItemFn(ref decl, _, _, _, _, ref body) => {
-        let fn_pty = ccx.tcx.lookup_item_type(ast_util::local_def(it.id));
+        let fn_pty = ccx.tcx.lookup_item_type(DefId::local(it.id));
         let param_env = ParameterEnvironment::for_item(ccx.tcx, it.id);
         check_bare_fn(ccx, &**decl, &**body, it.id, it.span, fn_pty.ty, param_env);
       }
       ast::ItemImpl(_, _, _, _, _, ref impl_items) => {
         debug!("ItemImpl {} with id {}", it.ident, it.id);
 
-        let impl_pty = ccx.tcx.lookup_item_type(ast_util::local_def(it.id));
+        let impl_pty = ccx.tcx.lookup_item_type(DefId::local(it.id));
 
         for impl_item in impl_items {
             match impl_item.node {
@@ -774,7 +775,7 @@ pub fn check_item_body<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx ast::Item) {
         }
       }
       ast::ItemTrait(_, _, _, ref trait_items) => {
-        let trait_def = ccx.tcx.lookup_trait_def(local_def(it.id));
+        let trait_def = ccx.tcx.lookup_trait_def(DefId::local(it.id));
         for trait_item in trait_items {
             match trait_item.node {
                 ast::ConstTraitItem(_, Some(ref expr)) => {
@@ -893,7 +894,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
     // Check existing impl methods to see if they are both present in trait
     // and compatible with trait signature
     for impl_item in impl_items {
-        let ty_impl_item = ccx.tcx.impl_or_trait_item(local_def(impl_item.id));
+        let ty_impl_item = ccx.tcx.impl_or_trait_item(DefId::local(impl_item.id));
         let ty_trait_item = trait_items.iter()
             .find(|ac| ac.name() == ty_impl_item.name())
             .unwrap_or_else(|| {
@@ -1117,19 +1118,19 @@ fn report_cast_to_unsized_type<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
 impl<'a, 'tcx> AstConv<'tcx> for FnCtxt<'a, 'tcx> {
     fn tcx(&self) -> &ty::ctxt<'tcx> { self.ccx.tcx }
 
-    fn get_item_type_scheme(&self, _: Span, id: ast::DefId)
+    fn get_item_type_scheme(&self, _: Span, id: DefId)
                             -> Result<ty::TypeScheme<'tcx>, ErrorReported>
     {
         Ok(self.tcx().lookup_item_type(id))
     }
 
-    fn get_trait_def(&self, _: Span, id: ast::DefId)
+    fn get_trait_def(&self, _: Span, id: DefId)
                      -> Result<&'tcx ty::TraitDef<'tcx>, ErrorReported>
     {
         Ok(self.tcx().lookup_trait_def(id))
     }
 
-    fn ensure_super_predicates(&self, _: Span, _: ast::DefId) -> Result<(), ErrorReported> {
+    fn ensure_super_predicates(&self, _: Span, _: DefId) -> Result<(), ErrorReported> {
         // all super predicates are ensured during collect pass
         Ok(())
     }
@@ -1166,7 +1167,7 @@ impl<'a, 'tcx> AstConv<'tcx> for FnCtxt<'a, 'tcx> {
     }
 
     fn trait_defines_associated_type_named(&self,
-                                           trait_def_id: ast::DefId,
+                                           trait_def_id: DefId,
                                            assoc_name: ast::Name)
                                            -> bool
     {
@@ -1280,14 +1281,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     fn record_deferred_call_resolution(&self,
-                                       closure_def_id: ast::DefId,
+                                       closure_def_id: DefId,
                                        r: DeferredCallResolutionHandler<'tcx>) {
         let mut deferred_call_resolutions = self.inh.deferred_call_resolutions.borrow_mut();
         deferred_call_resolutions.entry(closure_def_id).or_insert(vec![]).push(r);
     }
 
     fn remove_deferred_call_resolutions(&self,
-                                        closure_def_id: ast::DefId)
+                                        closure_def_id: DefId)
                                         -> Vec<DeferredCallResolutionHandler<'tcx>>
     {
         let mut deferred_call_resolutions = self.inh.deferred_call_resolutions.borrow_mut();
@@ -1420,7 +1421,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// Note that this function is only intended to be used with type-paths,
     /// not with value-paths.
     pub fn instantiate_type(&self,
-                            did: ast::DefId,
+                            did: DefId,
                             path: &ast::Path)
                             -> Ty<'tcx>
     {
@@ -1937,7 +1938,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             .unwrap_or(type_variable::Default {
                                 ty: self.infcx().next_ty_var(),
                                 origin_span: codemap::DUMMY_SP,
-                                def_id: local_def(0) // what do I put here?
+                                def_id: DefId::local(0) // what do I put here?
                             });
 
                     // This is to ensure that we elimnate any non-determinism from the error
@@ -2721,7 +2722,7 @@ fn check_expr_with_lvalue_pref<'a,'tcx>(fcx: &FnCtxt<'a,'tcx>, expr: &'tcx ast::
 // variables.
 pub fn impl_self_ty<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                               span: Span, // (potential) receiver for this impl
-                              did: ast::DefId)
+                              did: DefId)
                               -> TypeAndSubsts<'tcx> {
     let tcx = fcx.tcx();
 
@@ -3002,7 +3003,7 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
                 continue;
             }
             // ignore private fields from non-local crates
-            if variant.did.krate != ast::LOCAL_CRATE && elem.vis != Visibility::Public {
+            if variant.did.krate != LOCAL_CRATE && elem.vis != Visibility::Public {
                 continue;
             }
             let dist = lev_distance(&n, &name);
@@ -3382,7 +3383,7 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
           } else if let Some(ast::QSelf { position: 0, .. }) = *maybe_qself {
                 // Create some fake resolution that can't possibly be a type.
                 def::PathResolution {
-                    base_def: def::DefMod(local_def(ast::CRATE_NODE_ID)),
+                    base_def: def::DefMod(DefId::local(ast::CRATE_NODE_ID)),
                     last_private: LastMod(AllPublic),
                     depth: path.segments.len()
                 }
@@ -4152,7 +4153,7 @@ fn check_const<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
     let inh = static_inherited_fields(ccx, &tables);
     let rty = ccx.tcx.node_id_to_type(id);
     let fcx = blank_fn_ctxt(ccx, &inh, ty::FnConverging(rty), e.id);
-    let declty = fcx.ccx.tcx.lookup_item_type(local_def(id)).ty;
+    let declty = fcx.ccx.tcx.lookup_item_type(DefId::local(id)).ty;
     check_const_with_ty(&fcx, sp, e, declty);
 }
 
@@ -4295,7 +4296,7 @@ pub fn check_enum_variants<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
             }
         }
 
-        let def_id = local_def(id);
+        let def_id = DefId::local(id);
 
         let variants = &ccx.tcx.lookup_adt_def(def_id).variants;
         for (v, variant) in vs.iter().zip(variants.iter()) {
@@ -4333,7 +4334,7 @@ pub fn check_enum_variants<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
         }
     }
 
-    let hint = *ccx.tcx.lookup_repr_hints(ast::DefId { krate: ast::LOCAL_CRATE, node: id })
+    let hint = *ccx.tcx.lookup_repr_hints(DefId { krate: LOCAL_CRATE, node: id })
         .get(0).unwrap_or(&attr::ReprAny);
 
     if hint != attr::ReprAny && vs.len() <= 1 {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -427,7 +427,7 @@ pub fn check_item_bodies(ccx: &CrateCtxt) {
 
 pub fn check_drop_impls(ccx: &CrateCtxt) {
     for drop_method_did in ccx.tcx.destructors.borrow().iter() {
-        if drop_method_did.krate == LOCAL_CRATE {
+        if drop_method_did.is_local() {
             let drop_impl_did = ccx.tcx.map.get_parent_did(drop_method_did.node);
             match dropck::check_drop_impl(ccx.tcx, drop_impl_did) {
                 Ok(()) => {}

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -20,6 +20,7 @@ use super::{
     PreferMutLvalue,
     structurally_resolved_type,
 };
+use middle::def_id::DefId;
 use middle::traits;
 use middle::ty::{Ty, HasTypeFlags};
 use syntax::ast;
@@ -208,7 +209,7 @@ fn check_overloaded_binop<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
 pub fn check_user_unop<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                                  op_str: &str,
                                  mname: &str,
-                                 trait_did: Option<ast::DefId>,
+                                 trait_did: Option<DefId>,
                                  ex: &'tcx ast::Expr,
                                  operand_expr: &'tcx ast::Expr,
                                  operand_ty: Ty<'tcx>,
@@ -230,7 +231,7 @@ pub fn check_user_unop<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
     }
 }
 
-fn name_and_trait_def_id(fcx: &FnCtxt, op: ast::BinOp) -> (&'static str, Option<ast::DefId>) {
+fn name_and_trait_def_id(fcx: &FnCtxt, op: ast::BinOp) -> (&'static str, Option<DefId>) {
     let lang = &fcx.tcx().lang_items;
     match op.node {
         ast::BiAdd => ("add", lang.add_trait()),
@@ -260,7 +261,7 @@ fn lookup_op_method<'a, 'tcx>(fcx: &'a FnCtxt<'a, 'tcx>,
                               lhs_ty: Ty<'tcx>,
                               other_tys: Vec<Ty<'tcx>>,
                               opname: ast::Name,
-                              trait_did: Option<ast::DefId>,
+                              trait_did: Option<DefId>,
                               lhs_expr: &'a ast::Expr)
                               -> Result<Ty<'tcx>,()>
 {

--- a/src/librustc_typeck/check/upvar.rs
+++ b/src/librustc_typeck/check/upvar.rs
@@ -43,13 +43,13 @@
 use super::FnCtxt;
 
 use check::demand;
+use middle::def_id::DefId;
 use middle::expr_use_visitor as euv;
 use middle::mem_categorization as mc;
 use middle::ty::{self, Ty};
 use middle::infer::{InferCtxt, UpvarRegion};
 use std::collections::HashSet;
 use syntax::ast;
-use syntax::ast_util;
 use syntax::codemap::Span;
 use syntax::visit::{self, Visitor};
 
@@ -115,7 +115,7 @@ impl<'a,'tcx> SeedBorrowKind<'a,'tcx> {
                      capture_clause: ast::CaptureClause,
                      _body: &ast::Block)
     {
-        let closure_def_id = ast_util::local_def(expr.id);
+        let closure_def_id = DefId::local(expr.id);
         if !self.fcx.inh.tables.borrow().closure_kinds.contains_key(&closure_def_id) {
             self.closures_with_inferred_kinds.insert(expr.id);
             self.fcx.inh.tables.borrow_mut().closure_kinds
@@ -214,7 +214,7 @@ impl<'a,'tcx> AdjustBorrowKind<'a,'tcx> {
 
         // Now we must process and remove any deferred resolutions,
         // since we have a concrete closure kind.
-        let closure_def_id = ast_util::local_def(id);
+        let closure_def_id = DefId::local(id);
         if self.closures_with_inferred_kinds.contains(&id) {
             let mut deferred_call_resolutions =
                 self.fcx.remove_deferred_call_resolutions(closure_def_id);
@@ -468,7 +468,7 @@ impl<'a,'tcx> AdjustBorrowKind<'a,'tcx> {
             return;
         }
 
-        let closure_def_id = ast_util::local_def(closure_id);
+        let closure_def_id = DefId::local(closure_id);
         let closure_kinds = &mut self.fcx.inh.tables.borrow_mut().closure_kinds;
         let existing_kind = *closure_kinds.get(&closure_def_id).unwrap();
 

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -15,7 +15,7 @@ use self::ResolveReason::*;
 
 use astconv::AstConv;
 use check::FnCtxt;
-use middle::def_id::{DefId, LOCAL_CRATE};
+use middle::def_id::DefId;
 use middle::pat_util;
 use middle::ty::{self, Ty, MethodCall, MethodCallee};
 use middle::ty_fold::{TypeFolder,TypeFoldable};
@@ -351,7 +351,7 @@ impl ResolveReason {
                 tcx.expr_span(upvar_id.closure_expr_id)
             }
             ResolvingClosure(did) => {
-                if did.krate == LOCAL_CRATE {
+                if did.is_local() {
                     tcx.expr_span(did.node)
                 } else {
                     DUMMY_SP

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -15,6 +15,7 @@ use self::ResolveReason::*;
 
 use astconv::AstConv;
 use check::FnCtxt;
+use middle::def_id::{DefId, LOCAL_CRATE};
 use middle::pat_util;
 use middle::ty::{self, Ty, MethodCall, MethodCallee};
 use middle::ty_fold::{TypeFolder,TypeFoldable};
@@ -337,7 +338,7 @@ enum ResolveReason {
     ResolvingLocal(Span),
     ResolvingPattern(Span),
     ResolvingUpvar(ty::UpvarId),
-    ResolvingClosure(ast::DefId),
+    ResolvingClosure(DefId),
 }
 
 impl ResolveReason {
@@ -350,7 +351,7 @@ impl ResolveReason {
                 tcx.expr_span(upvar_id.closure_expr_id)
             }
             ResolvingClosure(did) => {
-                if did.krate == ast::LOCAL_CRATE {
+                if did.krate == LOCAL_CRATE {
                     tcx.expr_span(did.node)
                 } else {
                     DUMMY_SP

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -16,6 +16,7 @@
 // mappings. That mapping code resides here.
 
 
+use middle::def_id::{DefId, LOCAL_CRATE};
 use middle::lang_items::UnsizeTraitLangItem;
 use middle::subst::{self, Subst};
 use middle::traits;
@@ -35,11 +36,9 @@ use middle::infer::{self, InferCtxt, new_infer_ctxt};
 use rustc::ast_map::{self, NodeItem};
 use std::cell::RefCell;
 use std::rc::Rc;
-use syntax::ast::{Crate, DefId};
+use syntax::ast::{Crate};
 use syntax::ast::{Item, ItemImpl};
-use syntax::ast::{LOCAL_CRATE};
 use syntax::ast;
-use syntax::ast_util::local_def;
 use syntax::codemap::Span;
 use syntax::parse::token;
 use syntax::visit;
@@ -89,7 +88,7 @@ fn get_base_type_def_id<'a, 'tcx>(inference_context: &InferCtxt<'a, 'tcx>,
 struct CoherenceChecker<'a, 'tcx: 'a> {
     crate_context: &'a CrateCtxt<'a, 'tcx>,
     inference_context: InferCtxt<'a, 'tcx>,
-    inherent_impls: RefCell<DefIdMap<Rc<RefCell<Vec<ast::DefId>>>>>,
+    inherent_impls: RefCell<DefIdMap<Rc<RefCell<Vec<DefId>>>>>,
 }
 
 struct CoherenceCheckVisitor<'a, 'tcx: 'a> {
@@ -138,7 +137,7 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
 
     fn check_implementation(&self, item: &Item) {
         let tcx = self.crate_context.tcx;
-        let impl_did = local_def(item.id);
+        let impl_did = DefId::local(item.id);
         let self_type = tcx.lookup_item_type(impl_did);
 
         // If there are no traits, then this implementation must have a
@@ -186,7 +185,7 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
         for trait_method in &prov {
             // Synthesize an ID.
             let new_id = tcx.sess.next_node_id();
-            let new_did = local_def(new_id);
+            let new_did = DefId::local(new_id);
 
             debug!("new_did={:?} trait_method={:?}", new_did, trait_method);
 
@@ -256,13 +255,13 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
                         impl_items.iter().map(|impl_item| {
                     match impl_item.node {
                         ast::ConstImplItem(..) => {
-                            ConstTraitItemId(local_def(impl_item.id))
+                            ConstTraitItemId(DefId::local(impl_item.id))
                         }
                         ast::MethodImplItem(..) => {
-                            MethodTraitItemId(local_def(impl_item.id))
+                            MethodTraitItemId(DefId::local(impl_item.id))
                         }
                         ast::TypeImplItem(_) => {
-                            TypeTraitItemId(local_def(impl_item.id))
+                            TypeTraitItemId(DefId::local(impl_item.id))
                         }
                         ast::MacImplItem(_) => {
                             self.crate_context.tcx.sess.span_bug(impl_item.span,
@@ -271,7 +270,7 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
                     }
                 }).collect();
 
-                let def_id = local_def(item.id);
+                let def_id = DefId::local(item.id);
                 if let Some(trait_ref) = self.crate_context.tcx.impl_trait_ref(def_id) {
                     self.instantiate_default_methods(def_id, &trait_ref, &mut items);
                 }
@@ -321,7 +320,7 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
                 }
                 _ => {
                     // Destructors only work on nominal types.
-                    if impl_did.krate == ast::LOCAL_CRATE {
+                    if impl_did.krate == LOCAL_CRATE {
                         {
                             match tcx.map.find(impl_did.node) {
                                 Some(ast_map::NodeItem(item)) => {
@@ -357,7 +356,7 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
             debug!("check_implementations_of_copy: impl_did={:?}",
                    impl_did);
 
-            if impl_did.krate != ast::LOCAL_CRATE {
+            if impl_did.krate != LOCAL_CRATE {
                 debug!("check_implementations_of_copy(): impl not in this \
                         crate");
                 return
@@ -426,7 +425,7 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
             debug!("check_implementations_of_coerce_unsized: impl_did={:?}",
                    impl_did);
 
-            if impl_did.krate != ast::LOCAL_CRATE {
+            if impl_did.krate != LOCAL_CRATE {
                 debug!("check_implementations_of_coerce_unsized(): impl not \
                         in this crate");
                 return;
@@ -555,7 +554,7 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
     }
 }
 
-fn enforce_trait_manually_implementable(tcx: &ty::ctxt, sp: Span, trait_def_id: ast::DefId) {
+fn enforce_trait_manually_implementable(tcx: &ty::ctxt, sp: Span, trait_def_id: DefId) {
     if tcx.sess.features.borrow().unboxed_closures {
         // the feature gate allows all of them
         return
@@ -578,12 +577,12 @@ fn enforce_trait_manually_implementable(tcx: &ty::ctxt, sp: Span, trait_def_id: 
 }
 
 fn subst_receiver_types_in_method_ty<'tcx>(tcx: &ty::ctxt<'tcx>,
-                                           impl_id: ast::DefId,
+                                           impl_id: DefId,
                                            impl_type_scheme: &ty::TypeScheme<'tcx>,
                                            trait_ref: &ty::TraitRef<'tcx>,
-                                           new_def_id: ast::DefId,
+                                           new_def_id: DefId,
                                            method: &ty::Method<'tcx>,
-                                           provided_source: Option<ast::DefId>)
+                                           provided_source: Option<DefId>)
                                            -> ty::Method<'tcx>
 {
     let combined_substs = tcx.make_substs_for_receiver_types(trait_ref, method);

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -320,7 +320,7 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
                 }
                 _ => {
                     // Destructors only work on nominal types.
-                    if impl_did.krate == LOCAL_CRATE {
+                    if impl_did.is_local() {
                         {
                             match tcx.map.find(impl_did.node) {
                                 Some(ast_map::NodeItem(item)) => {

--- a/src/librustc_typeck/coherence/orphan.rs
+++ b/src/librustc_typeck/coherence/orphan.rs
@@ -295,7 +295,7 @@ impl<'cx, 'tcx> OrphanChecker<'cx, 'tcx> {
                         // can't do `unsafe impl Send for Rc<SomethingLocal>` or
                         // `impl !Send for Box<SomethingLocalAndSend>`.
                         Some(self_def_id) => {
-                            if self_def_id.krate == LOCAL_CRATE {
+                            if self_def_id.is_local() {
                                 None
                             } else {
                                 Some(format!(

--- a/src/librustc_typeck/coherence/orphan.rs
+++ b/src/librustc_typeck/coherence/orphan.rs
@@ -11,11 +11,11 @@
 //! Orphan checker: every impl either implements a trait defined in this
 //! crate or pertains to a type defined in this crate.
 
+use middle::def_id::{DefId, LOCAL_CRATE};
 use middle::traits;
 use middle::ty;
 use syntax::ast::{Item, ItemImpl};
 use syntax::ast;
-use syntax::ast_util;
 use syntax::codemap::Span;
 use syntax::visit;
 
@@ -29,8 +29,8 @@ struct OrphanChecker<'cx, 'tcx:'cx> {
 }
 
 impl<'cx, 'tcx> OrphanChecker<'cx, 'tcx> {
-    fn check_def_id(&self, item: &ast::Item, def_id: ast::DefId) {
-        if def_id.krate != ast::LOCAL_CRATE {
+    fn check_def_id(&self, item: &ast::Item, def_id: DefId) {
+        if def_id.krate != LOCAL_CRATE {
             span_err!(self.tcx.sess, item.span, E0116,
                       "cannot define inherent `impl` for a type outside of the \
                        crate where the type is defined; define and implement \
@@ -39,8 +39,8 @@ impl<'cx, 'tcx> OrphanChecker<'cx, 'tcx> {
     }
 
     fn check_primitive_impl(&self,
-                            impl_def_id: ast::DefId,
-                            lang_def_id: Option<ast::DefId>,
+                            impl_def_id: DefId,
+                            lang_def_id: Option<DefId>,
                             lang: &str,
                             ty: &str,
                             span: Span) {
@@ -62,7 +62,7 @@ impl<'cx, 'tcx> OrphanChecker<'cx, 'tcx> {
     /// to prevent inundating the user with a bunch of similar error
     /// reports.
     fn check_item(&self, item: &ast::Item) {
-        let def_id = ast_util::local_def(item.id);
+        let def_id = DefId::local(item.id);
         match item.node {
             ast::ItemImpl(_, _, _, None, _, _) => {
                 // For inherent impls, self type must be a nominal type
@@ -277,7 +277,7 @@ impl<'cx, 'tcx> OrphanChecker<'cx, 'tcx> {
                        self.tcx.trait_has_default_impl(trait_def_id));
                 if
                     self.tcx.trait_has_default_impl(trait_def_id) &&
-                    trait_def_id.krate != ast::LOCAL_CRATE
+                    trait_def_id.krate != LOCAL_CRATE
                 {
                     let self_ty = trait_ref.self_ty();
                     let opt_self_def_id = match self_ty.sty {
@@ -295,7 +295,7 @@ impl<'cx, 'tcx> OrphanChecker<'cx, 'tcx> {
                         // can't do `unsafe impl Send for Rc<SomethingLocal>` or
                         // `impl !Send for Box<SomethingLocalAndSend>`.
                         Some(self_def_id) => {
-                            if self_def_id.krate == ast::LOCAL_CRATE {
+                            if self_def_id.krate == LOCAL_CRATE {
                                 None
                             } else {
                                 Some(format!(
@@ -338,7 +338,7 @@ impl<'cx, 'tcx> OrphanChecker<'cx, 'tcx> {
                 debug!("coherence2::orphan check: default trait impl {}",
                        self.tcx.map.node_to_string(item.id));
                 let trait_ref = self.tcx.impl_trait_ref(def_id).unwrap();
-                if trait_ref.def_id.krate != ast::LOCAL_CRATE {
+                if trait_ref.def_id.krate != LOCAL_CRATE {
                     span_err!(self.tcx.sess, item.span, E0318,
                               "cannot create default implementations for traits outside the \
                                crate they're defined in; define a new trait instead");

--- a/src/librustc_typeck/coherence/overlap.rs
+++ b/src/librustc_typeck/coherence/overlap.rs
@@ -150,7 +150,7 @@ impl<'cx, 'tcx> OverlapChecker<'cx, 'tcx> {
 
     fn report_overlap_note(&self, impl1: DefId, impl2: DefId) {
 
-        if impl2.krate == LOCAL_CRATE {
+        if impl2.is_local() {
             span_note!(self.tcx.sess, self.span_of_impl(impl2),
                        "note conflicting implementation here");
         } else {

--- a/src/librustc_typeck/coherence/overlap.rs
+++ b/src/librustc_typeck/coherence/overlap.rs
@@ -11,13 +11,11 @@
 //! Overlap: No two impls for the same trait are implemented for the
 //! same type.
 
+use middle::def_id::{DefId, LOCAL_CRATE};
 use middle::traits;
 use middle::ty;
 use middle::infer::{self, new_infer_ctxt};
-use syntax::ast::DefId;
-use syntax::ast::LOCAL_CRATE;
 use syntax::ast;
-use syntax::ast_util;
 use syntax::visit;
 use syntax::codemap::Span;
 use util::nodemap::DefIdMap;
@@ -100,17 +98,17 @@ impl<'cx, 'tcx> OverlapChecker<'cx, 'tcx> {
     // We need to coherently pick which impl will be displayed
     // as causing the error message, and it must be the in the current
     // crate. Just pick the smaller impl in the file.
-    fn order_impls(&self, impl1_def_id: ast::DefId, impl2_def_id: ast::DefId)
-            -> Option<(ast::DefId, ast::DefId)> {
-        if impl1_def_id.krate != ast::LOCAL_CRATE {
-            if impl2_def_id.krate != ast::LOCAL_CRATE {
+    fn order_impls(&self, impl1_def_id: DefId, impl2_def_id: DefId)
+            -> Option<(DefId, DefId)> {
+        if impl1_def_id.krate != LOCAL_CRATE {
+            if impl2_def_id.krate != LOCAL_CRATE {
                 // we don't need to check impls if both are external;
                 // that's the other crate's job.
                 None
             } else {
                 Some((impl2_def_id, impl1_def_id))
             }
-        } else if impl2_def_id.krate != ast::LOCAL_CRATE {
+        } else if impl2_def_id.krate != LOCAL_CRATE {
             Some((impl1_def_id, impl2_def_id))
         } else if impl1_def_id.node < impl2_def_id.node {
             Some((impl1_def_id, impl2_def_id))
@@ -121,9 +119,9 @@ impl<'cx, 'tcx> OverlapChecker<'cx, 'tcx> {
 
 
     fn check_if_impls_overlap(&self,
-                              trait_def_id: ast::DefId,
-                              impl1_def_id: ast::DefId,
-                              impl2_def_id: ast::DefId)
+                              trait_def_id: DefId,
+                              impl1_def_id: DefId,
+                              impl2_def_id: DefId)
     {
         if let Some((impl1_def_id, impl2_def_id)) = self.order_impls(
             impl1_def_id, impl2_def_id)
@@ -140,8 +138,8 @@ impl<'cx, 'tcx> OverlapChecker<'cx, 'tcx> {
         }
     }
 
-    fn report_overlap_error(&self, trait_def_id: ast::DefId,
-                            impl1: ast::DefId, impl2: ast::DefId) {
+    fn report_overlap_error(&self, trait_def_id: DefId,
+                            impl1: DefId, impl2: DefId) {
 
         span_err!(self.tcx.sess, self.span_of_impl(impl1), E0119,
                   "conflicting implementations for trait `{}`",
@@ -150,9 +148,9 @@ impl<'cx, 'tcx> OverlapChecker<'cx, 'tcx> {
         self.report_overlap_note(impl1, impl2);
     }
 
-    fn report_overlap_note(&self, impl1: ast::DefId, impl2: ast::DefId) {
+    fn report_overlap_note(&self, impl1: DefId, impl2: DefId) {
 
-        if impl2.krate == ast::LOCAL_CRATE {
+        if impl2.krate == LOCAL_CRATE {
             span_note!(self.tcx.sess, self.span_of_impl(impl2),
                        "note conflicting implementation here");
         } else {
@@ -164,8 +162,8 @@ impl<'cx, 'tcx> OverlapChecker<'cx, 'tcx> {
         }
     }
 
-    fn span_of_impl(&self, impl_did: ast::DefId) -> Span {
-        assert_eq!(impl_did.krate, ast::LOCAL_CRATE);
+    fn span_of_impl(&self, impl_did: DefId) -> Span {
+        assert_eq!(impl_did.krate, LOCAL_CRATE);
         self.tcx.map.span(impl_did.node)
     }
 }
@@ -178,20 +176,20 @@ impl<'cx, 'tcx,'v> visit::Visitor<'v> for OverlapChecker<'cx, 'tcx> {
                 // look for another default impl; note that due to the
                 // general orphan/coherence rules, it must always be
                 // in this crate.
-                let impl_def_id = ast_util::local_def(item.id);
+                let impl_def_id = DefId::local(item.id);
                 let trait_ref = self.tcx.impl_trait_ref(impl_def_id).unwrap();
                 let prev_default_impl = self.default_impls.insert(trait_ref.def_id, item.id);
                 match prev_default_impl {
                     Some(prev_id) => {
                         self.report_overlap_error(trait_ref.def_id,
                                                   impl_def_id,
-                                                  ast_util::local_def(prev_id));
+                                                  DefId::local(prev_id));
                     }
                     None => { }
                 }
             }
             ast::ItemImpl(_, _, _, Some(_), ref self_ty, _) => {
-                let impl_def_id = ast_util::local_def(item.id);
+                let impl_def_id = DefId::local(item.id);
                 let trait_ref = self.tcx.impl_trait_ref(impl_def_id).unwrap();
                 let trait_def_id = trait_ref.def_id;
                 match trait_ref.self_ty().sty {

--- a/src/librustc_typeck/coherence/unsafety.rs
+++ b/src/librustc_typeck/coherence/unsafety.rs
@@ -11,10 +11,10 @@
 //! Unsafety checker: every impl either implements a trait defined in this
 //! crate or pertains to a type defined in this crate.
 
+use middle::def_id::DefId;
 use middle::ty;
 use syntax::ast::{Item, ItemImpl};
 use syntax::ast;
-use syntax::ast_util;
 use syntax::visit;
 
 pub fn check(tcx: &ty::ctxt) {
@@ -30,7 +30,7 @@ impl<'cx, 'tcx, 'v> UnsafetyChecker<'cx, 'tcx> {
     fn check_unsafety_coherence(&mut self, item: &'v ast::Item,
                                 unsafety: ast::Unsafety,
                                 polarity: ast::ImplPolarity) {
-        match self.tcx.impl_trait_ref(ast_util::local_def(item.id)) {
+        match self.tcx.impl_trait_ref(DefId::local(item.id)) {
             None => {
                 // Inherent impl.
                 match unsafety {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -400,7 +400,7 @@ impl<'a, 'tcx> AstConv<'tcx> for ItemCtxt<'a, 'tcx> {
                                            assoc_name: ast::Name)
                                            -> bool
     {
-        if trait_def_id.krate == LOCAL_CRATE {
+        if trait_def_id.is_local() {
             trait_defines_associated_type_named(self.ccx, trait_def_id.node, assoc_name)
         } else {
             let trait_def = self.tcx().lookup_trait_def(trait_def_id);

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -66,6 +66,7 @@ There are some shortcomings in this design:
 
 use astconv::{self, AstConv, ty_of_arg, ast_ty_to_ty, ast_region_to_region};
 use middle::def;
+use middle::def_id::{DefId, LOCAL_CRATE};
 use constrained_type_params as ctp;
 use middle::lang_items::SizedTraitLangItem;
 use middle::free_region::FreeRegionMap;
@@ -91,7 +92,6 @@ use std::rc::Rc;
 
 use syntax::abi;
 use syntax::ast;
-use syntax::ast_util::local_def;
 use syntax::attr;
 use syntax::codemap::Span;
 use syntax::parse::token::special_idents;
@@ -140,9 +140,9 @@ struct ItemCtxt<'a,'tcx:'a> {
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 enum AstConvRequest {
-    GetItemTypeScheme(ast::DefId),
-    GetTraitDef(ast::DefId),
-    EnsureSuperPredicates(ast::DefId),
+    GetItemTypeScheme(DefId),
+    GetTraitDef(DefId),
+    EnsureSuperPredicates(DefId),
     GetTypeParameterBounds(ast::NodeId),
 }
 
@@ -196,7 +196,7 @@ impl<'a,'tcx> CrateCtxt<'a,'tcx> {
     }
 
     fn method_ty(&self, method_id: ast::NodeId) -> Rc<ty::Method<'tcx>> {
-        let def_id = local_def(method_id);
+        let def_id = DefId::local(method_id);
         match *self.tcx.impl_or_trait_items.borrow().get(&def_id).unwrap() {
             ty::MethodTraitItem(ref mty) => mty.clone(),
             _ => {
@@ -309,12 +309,12 @@ impl<'a,'tcx> CrateCtxt<'a,'tcx> {
     }
 
     /// Loads the trait def for a given trait, returning ErrorReported if a cycle arises.
-    fn get_trait_def(&self, trait_id: ast::DefId)
+    fn get_trait_def(&self, trait_id: DefId)
                      -> &'tcx ty::TraitDef<'tcx>
     {
         let tcx = self.tcx;
 
-        if trait_id.krate != ast::LOCAL_CRATE {
+        if trait_id.krate != LOCAL_CRATE {
             return tcx.lookup_trait_def(trait_id)
         }
 
@@ -329,7 +329,7 @@ impl<'a,'tcx> CrateCtxt<'a,'tcx> {
     /// Ensure that the (transitive) super predicates for
     /// `trait_def_id` are available. This will report a cycle error
     /// if a trait `X` (transitively) extends itself in some form.
-    fn ensure_super_predicates(&self, span: Span, trait_def_id: ast::DefId)
+    fn ensure_super_predicates(&self, span: Span, trait_def_id: DefId)
                                -> Result<(), ErrorReported>
     {
         self.cycle_check(span, AstConvRequest::EnsureSuperPredicates(trait_def_id), || {
@@ -353,7 +353,7 @@ impl<'a,'tcx> ItemCtxt<'a,'tcx> {
 impl<'a, 'tcx> AstConv<'tcx> for ItemCtxt<'a, 'tcx> {
     fn tcx(&self) -> &ty::ctxt<'tcx> { self.ccx.tcx }
 
-    fn get_item_type_scheme(&self, span: Span, id: ast::DefId)
+    fn get_item_type_scheme(&self, span: Span, id: DefId)
                             -> Result<ty::TypeScheme<'tcx>, ErrorReported>
     {
         self.ccx.cycle_check(span, AstConvRequest::GetItemTypeScheme(id), || {
@@ -361,7 +361,7 @@ impl<'a, 'tcx> AstConv<'tcx> for ItemCtxt<'a, 'tcx> {
         })
     }
 
-    fn get_trait_def(&self, span: Span, id: ast::DefId)
+    fn get_trait_def(&self, span: Span, id: DefId)
                      -> Result<&'tcx ty::TraitDef<'tcx>, ErrorReported>
     {
         self.ccx.cycle_check(span, AstConvRequest::GetTraitDef(id), || {
@@ -371,7 +371,7 @@ impl<'a, 'tcx> AstConv<'tcx> for ItemCtxt<'a, 'tcx> {
 
     fn ensure_super_predicates(&self,
                                span: Span,
-                               trait_def_id: ast::DefId)
+                               trait_def_id: DefId)
                                -> Result<(), ErrorReported>
     {
         debug!("ensure_super_predicates(trait_def_id={:?})",
@@ -396,11 +396,11 @@ impl<'a, 'tcx> AstConv<'tcx> for ItemCtxt<'a, 'tcx> {
     }
 
     fn trait_defines_associated_type_named(&self,
-                                           trait_def_id: ast::DefId,
+                                           trait_def_id: DefId,
                                            assoc_name: ast::Name)
                                            -> bool
     {
-        if trait_def_id.krate == ast::LOCAL_CRATE {
+        if trait_def_id.krate == LOCAL_CRATE {
             trait_defines_associated_type_named(self.ccx, trait_def_id.node, assoc_name)
         } else {
             let trait_def = self.tcx().lookup_trait_def(trait_def_id);
@@ -559,7 +559,7 @@ fn is_param<'tcx>(tcx: &ty::ctxt<'tcx>,
                 path_res.depth == 0 && def_id.node == param_id
             }
             def::DefTyParam(_, _, def_id, _) => {
-                path_res.depth == 0 && def_id == local_def(param_id)
+                path_res.depth == 0 && def_id == DefId::local(param_id)
             }
             _ => {
                 false
@@ -588,7 +588,7 @@ fn convert_method<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
         astconv::ty_of_method(&ccx.icx(&(rcvr_ty_predicates, &sig.generics)),
                               sig, untransformed_rcvr_ty);
 
-    let def_id = local_def(id);
+    let def_id = DefId::local(id);
     let ty_method = ty::Method::new(ident.name,
                                     ty_generics,
                                     ty_generic_predicates,
@@ -629,12 +629,12 @@ fn convert_field<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
     write_ty_to_tcx(ccx.tcx, v.node.id, tt);
 
     /* add the field to the tcache */
-    ccx.tcx.register_item_type(local_def(v.node.id),
+    ccx.tcx.register_item_type(DefId::local(v.node.id),
                                ty::TypeScheme {
                                    generics: struct_generics.clone(),
                                    ty: tt
                                });
-    ccx.tcx.predicates.borrow_mut().insert(local_def(v.node.id),
+    ccx.tcx.predicates.borrow_mut().insert(DefId::local(v.node.id),
                                            struct_predicates.clone());
 }
 
@@ -646,22 +646,22 @@ fn convert_associated_const<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                       ty: ty::Ty<'tcx>,
                                       default: Option<&ast::Expr>)
 {
-    ccx.tcx.predicates.borrow_mut().insert(local_def(id),
+    ccx.tcx.predicates.borrow_mut().insert(DefId::local(id),
                                            ty::GenericPredicates::empty());
 
     write_ty_to_tcx(ccx.tcx, id, ty);
-    let default_id = default.map(|expr| local_def(expr.id));
+    let default_id = default.map(|expr| DefId::local(expr.id));
 
     let associated_const = Rc::new(ty::AssociatedConst {
         name: ident.name,
         vis: vis,
-        def_id: local_def(id),
+        def_id: DefId::local(id),
         container: container,
         ty: ty,
         default: default_id,
     });
     ccx.tcx.impl_or_trait_items.borrow_mut()
-       .insert(local_def(id), ty::ConstTraitItem(associated_const));
+       .insert(DefId::local(id), ty::ConstTraitItem(associated_const));
 }
 
 fn convert_associated_type<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
@@ -675,11 +675,11 @@ fn convert_associated_type<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
         name: ident.name,
         vis: vis,
         ty: ty,
-        def_id: local_def(id),
+        def_id: DefId::local(id),
         container: container
     });
     ccx.tcx.impl_or_trait_items.borrow_mut()
-       .insert(local_def(id), ty::TypeTraitItem(associated_type));
+       .insert(DefId::local(id), ty::TypeTraitItem(associated_type));
 }
 
 fn convert_methods<'a,'tcx,'i,I>(ccx: &CrateCtxt<'a, 'tcx>,
@@ -750,7 +750,7 @@ fn convert_item(ccx: &CrateCtxt, it: &ast::Item) {
             let (scheme, predicates) = convert_typed_item(ccx, it);
             write_ty_to_tcx(tcx, it.id, scheme.ty);
             convert_enum_variant_types(ccx,
-                                       tcx.lookup_adt_def_master(local_def(it.id)),
+                                       tcx.lookup_adt_def_master(DefId::local(it.id)),
                                        scheme,
                                        predicates,
                                        &enum_definition.variants);
@@ -764,7 +764,7 @@ fn convert_item(ccx: &CrateCtxt, it: &ast::Item) {
 
             tcx.record_trait_has_default_impl(trait_ref.def_id);
 
-            tcx.impl_trait_refs.borrow_mut().insert(local_def(it.id), Some(trait_ref));
+            tcx.impl_trait_refs.borrow_mut().insert(DefId::local(it.id), Some(trait_ref));
         }
         ast::ItemImpl(_, _,
                       ref generics,
@@ -781,21 +781,21 @@ fn convert_item(ccx: &CrateCtxt, it: &ast::Item) {
             let selfty = ccx.icx(&ty_predicates).to_ty(&ExplicitRscope, &**selfty);
             write_ty_to_tcx(tcx, it.id, selfty);
 
-            tcx.register_item_type(local_def(it.id),
+            tcx.register_item_type(DefId::local(it.id),
                                    TypeScheme { generics: ty_generics.clone(),
                                                 ty: selfty });
-            tcx.predicates.borrow_mut().insert(local_def(it.id),
+            tcx.predicates.borrow_mut().insert(DefId::local(it.id),
                                                ty_predicates.clone());
             if let &Some(ref ast_trait_ref) = opt_trait_ref {
                 tcx.impl_trait_refs.borrow_mut().insert(
-                    local_def(it.id),
+                    DefId::local(it.id),
                     Some(astconv::instantiate_mono_trait_ref(&ccx.icx(&ty_predicates),
                                                              &ExplicitRscope,
                                                              ast_trait_ref,
                                                              Some(selfty)))
                         );
             } else {
-                tcx.impl_trait_refs.borrow_mut().insert(local_def(it.id), None);
+                tcx.impl_trait_refs.borrow_mut().insert(DefId::local(it.id), None);
             }
 
 
@@ -838,12 +838,12 @@ fn convert_item(ccx: &CrateCtxt, it: &ast::Item) {
                 if let ast::ConstImplItem(ref ty, ref expr) = impl_item.node {
                     let ty = ccx.icx(&ty_predicates)
                                 .to_ty(&ExplicitRscope, &*ty);
-                    tcx.register_item_type(local_def(impl_item.id),
+                    tcx.register_item_type(DefId::local(impl_item.id),
                                            TypeScheme {
                                                generics: ty_generics.clone(),
                                                ty: ty,
                                            });
-                    convert_associated_const(ccx, ImplContainer(local_def(it.id)),
+                    convert_associated_const(ccx, ImplContainer(DefId::local(it.id)),
                                              impl_item.ident, impl_item.id,
                                              impl_item.vis.inherit_from(parent_visibility),
                                              ty, Some(&*expr));
@@ -860,7 +860,7 @@ fn convert_item(ccx: &CrateCtxt, it: &ast::Item) {
 
                     let typ = ccx.icx(&ty_predicates).to_ty(&ExplicitRscope, ty);
 
-                    convert_associated_type(ccx, ImplContainer(local_def(it.id)),
+                    convert_associated_type(ccx, ImplContainer(DefId::local(it.id)),
                                             impl_item.ident, impl_item.id, impl_item.vis,
                                             Some(typ));
                 }
@@ -879,7 +879,7 @@ fn convert_item(ccx: &CrateCtxt, it: &ast::Item) {
                 }
             });
             convert_methods(ccx,
-                            ImplContainer(local_def(it.id)),
+                            ImplContainer(DefId::local(it.id)),
                             methods,
                             selfty,
                             &ty_generics,
@@ -899,15 +899,15 @@ fn convert_item(ccx: &CrateCtxt, it: &ast::Item) {
 
             enforce_impl_params_are_constrained(tcx,
                                                 generics,
-                                                local_def(it.id),
+                                                DefId::local(it.id),
                                                 impl_items);
         },
         ast::ItemTrait(_, _, _, ref trait_items) => {
             let trait_def = trait_def_of_item(ccx, it);
             let _: Result<(), ErrorReported> = // any error is already reported, can ignore
-                ccx.ensure_super_predicates(it.span, local_def(it.id));
+                ccx.ensure_super_predicates(it.span, DefId::local(it.id));
             convert_trait_predicates(ccx, it);
-            let trait_predicates = tcx.lookup_predicates(local_def(it.id));
+            let trait_predicates = tcx.lookup_predicates(DefId::local(it.id));
 
             debug!("convert: trait_bounds={:?}", trait_predicates);
 
@@ -917,12 +917,12 @@ fn convert_item(ccx: &CrateCtxt, it: &ast::Item) {
                     ast::ConstTraitItem(ref ty, ref default) => {
                         let ty = ccx.icx(&trait_predicates)
                                     .to_ty(&ExplicitRscope, ty);
-                        tcx.register_item_type(local_def(trait_item.id),
+                        tcx.register_item_type(DefId::local(trait_item.id),
                                                TypeScheme {
                                                    generics: trait_def.generics.clone(),
                                                    ty: ty,
                                                });
-                        convert_associated_const(ccx, TraitContainer(local_def(it.id)),
+                        convert_associated_const(ccx, TraitContainer(DefId::local(it.id)),
                                                  trait_item.ident, trait_item.id,
                                                  ast::Public, ty, default.as_ref().map(|d| &**d));
                     }
@@ -938,7 +938,7 @@ fn convert_item(ccx: &CrateCtxt, it: &ast::Item) {
                             |ty| ccx.icx(&trait_predicates).to_ty(&ExplicitRscope, &ty)
                         });
 
-                        convert_associated_type(ccx, TraitContainer(local_def(it.id)),
+                        convert_associated_type(ccx, TraitContainer(DefId::local(it.id)),
                                                 trait_item.ident, trait_item.id, ast::Public,
                                                 typ);
                     }
@@ -956,7 +956,7 @@ fn convert_item(ccx: &CrateCtxt, it: &ast::Item) {
 
             // Run convert_methods on the trait methods.
             convert_methods(ccx,
-                            TraitContainer(local_def(it.id)),
+                            TraitContainer(DefId::local(it.id)),
                             methods,
                             tcx.mk_self_type(),
                             &trait_def.generics,
@@ -964,7 +964,7 @@ fn convert_item(ccx: &CrateCtxt, it: &ast::Item) {
 
             // Add an entry mapping
             let trait_item_def_ids = Rc::new(trait_items.iter().map(|trait_item| {
-                let def_id = local_def(trait_item.id);
+                let def_id = DefId::local(trait_item.id);
                 match trait_item.node {
                     ast::ConstTraitItem(..) => {
                         ty::ConstTraitItemId(def_id)
@@ -977,7 +977,7 @@ fn convert_item(ccx: &CrateCtxt, it: &ast::Item) {
                     }
                 }
             }).collect());
-            tcx.trait_item_def_ids.borrow_mut().insert(local_def(it.id), trait_item_def_ids);
+            tcx.trait_item_def_ids.borrow_mut().insert(DefId::local(it.id), trait_item_def_ids);
 
             // This must be done after `collect_trait_methods` so that
             // we have a method type stored for every method.
@@ -998,7 +998,7 @@ fn convert_item(ccx: &CrateCtxt, it: &ast::Item) {
             let (scheme, predicates) = convert_typed_item(ccx, it);
             write_ty_to_tcx(tcx, it.id, scheme.ty);
 
-            let variant = tcx.lookup_adt_def_master(local_def(it.id)).struct_variant();
+            let variant = tcx.lookup_adt_def_master(DefId::local(it.id)).struct_variant();
 
             for (f, ty_f) in struct_def.fields.iter().zip(variant.fields.iter()) {
                 convert_field(ccx, &scheme.generics, &predicates, f, ty_f)
@@ -1036,14 +1036,14 @@ fn convert_variant_ctor<'a, 'tcx>(tcx: &ty::ctxt<'tcx>,
                 .iter()
                 .map(|field| field.unsubst_ty())
                 .collect();
-            tcx.mk_ctor_fn(local_def(ctor_id),
+            tcx.mk_ctor_fn(DefId::local(ctor_id),
                            &inputs[..],
                            scheme.ty)
         }
     };
     write_ty_to_tcx(tcx, ctor_id, ctor_ty);
-    tcx.predicates.borrow_mut().insert(local_def(ctor_id), predicates);
-    tcx.register_item_type(local_def(ctor_id),
+    tcx.predicates.borrow_mut().insert(DefId::local(ctor_id), predicates);
+    tcx.register_item_type(DefId::local(ctor_id),
                            TypeScheme {
                                generics: scheme.generics,
                                ty: ctor_ty
@@ -1089,13 +1089,13 @@ fn convert_enum_variant_types<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
 }
 
 fn convert_struct_variant<'tcx>(tcx: &ty::ctxt<'tcx>,
-                                did: ast::DefId,
+                                did: DefId,
                                 name: ast::Name,
                                 disr_val: ty::Disr,
                                 def: &ast::StructDef) -> ty::VariantDefData<'tcx, 'tcx> {
     let mut seen_fields: FnvHashMap<ast::Name, Span> = FnvHashMap();
     let fields = def.fields.iter().map(|f| {
-        let fid = local_def(f.node.id);
+        let fid = DefId::local(f.node.id);
         match f.node.kind {
             ast::NamedField(ident, vis) => {
                 let dup_span = seen_fields.get(&ident.name).cloned();
@@ -1129,7 +1129,7 @@ fn convert_struct_def<'tcx>(tcx: &ty::ctxt<'tcx>,
                             -> ty::AdtDefMaster<'tcx>
 {
 
-    let did = local_def(it.id);
+    let did = DefId::local(it.id);
     tcx.intern_adt_def(
         did,
         ty::AdtKind::Struct,
@@ -1206,7 +1206,7 @@ fn convert_enum_def<'tcx>(tcx: &ty::ctxt<'tcx>,
                                   disr: ty::Disr)
                                   -> ty::VariantDefData<'tcx, 'tcx>
     {
-        let did = local_def(v.node.id);
+        let did = DefId::local(v.node.id);
         let name = v.node.name.name;
         match v.node.kind {
             ast::TupleVariantKind(ref va) => {
@@ -1216,7 +1216,7 @@ fn convert_enum_def<'tcx>(tcx: &ty::ctxt<'tcx>,
                     disr_val: disr,
                     fields: va.iter().map(|&ast::VariantArg { id, .. }| {
                         ty::FieldDefData::new(
-                            local_def(id),
+                            DefId::local(id),
                             special_idents::unnamed_field.name,
                             ast::Visibility::Public
                         )
@@ -1228,7 +1228,7 @@ fn convert_enum_def<'tcx>(tcx: &ty::ctxt<'tcx>,
             }
         }
     }
-    let did = local_def(it.id);
+    let did = DefId::local(it.id);
     let repr_hints = tcx.lookup_repr_hints(did);
     let (repr_type, repr_type_ty) = tcx.enum_repr_type(repr_hints.get(0));
     let mut prev_disr = None;
@@ -1242,7 +1242,7 @@ fn convert_enum_def<'tcx>(tcx: &ty::ctxt<'tcx>,
         prev_disr = Some(disr);
         v
     }).collect();
-    tcx.intern_adt_def(local_def(it.id), ty::AdtKind::Enum, variants)
+    tcx.intern_adt_def(DefId::local(it.id), ty::AdtKind::Enum, variants)
 }
 
 /// Ensures that the super-predicates of the trait with def-id
@@ -1253,14 +1253,14 @@ fn convert_enum_def<'tcx>(tcx: &ty::ctxt<'tcx>,
 /// well to guarantee that the transitive superpredicates are
 /// converted.
 fn ensure_super_predicates_step(ccx: &CrateCtxt,
-                                trait_def_id: ast::DefId)
-                                -> Vec<ast::DefId>
+                                trait_def_id: DefId)
+                                -> Vec<DefId>
 {
     let tcx = ccx.tcx;
 
     debug!("ensure_super_predicates_step(trait_def_id={:?})", trait_def_id);
 
-    if trait_def_id.krate != ast::LOCAL_CRATE {
+    if trait_def_id.krate != LOCAL_CRATE {
         // If this trait comes from an external crate, then all of the
         // supertraits it may depend on also must come from external
         // crates, and hence all of them already have their
@@ -1315,7 +1315,7 @@ fn ensure_super_predicates_step(ccx: &CrateCtxt,
             predicates: VecPerParamSpace::new(superbounds, vec![], vec![])
         };
         debug!("superpredicates for trait {:?} = {:?}",
-               local_def(item.id),
+               DefId::local(item.id),
                superpredicates);
 
         tcx.super_predicates.borrow_mut().insert(trait_def_id, superpredicates.clone());
@@ -1338,7 +1338,7 @@ fn trait_def_of_item<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                it: &ast::Item)
                                -> &'tcx ty::TraitDef<'tcx>
 {
-    let def_id = local_def(it.id);
+    let def_id = DefId::local(it.id);
     let tcx = ccx.tcx;
 
     if let Some(def) = tcx.trait_defs.borrow().get(&def_id) {
@@ -1452,7 +1452,7 @@ fn convert_trait_predicates<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>, it: &ast::Item)
     let tcx = ccx.tcx;
     let trait_def = trait_def_of_item(ccx, it);
 
-    let def_id = local_def(it.id);
+    let def_id = DefId::local(it.id);
 
     let (generics, items) = match it.node {
         ast::ItemTrait(_, ref generics, _, ref items) => (generics, items),
@@ -1523,10 +1523,10 @@ fn convert_trait_predicates<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>, it: &ast::Item)
 }
 
 fn type_scheme_of_def_id<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
-                                  def_id: ast::DefId)
+                                  def_id: DefId)
                                   -> ty::TypeScheme<'tcx>
 {
-    if def_id.krate != ast::LOCAL_CRATE {
+    if def_id.krate != LOCAL_CRATE {
         return ccx.tcx.lookup_item_type(def_id);
     }
 
@@ -1551,7 +1551,7 @@ fn type_scheme_of_item<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
                                 -> ty::TypeScheme<'tcx>
 {
     memoized(&ccx.tcx.tcache,
-             local_def(it.id),
+             DefId::local(it.id),
              |_| compute_type_scheme_of_item(ccx, it))
 }
 
@@ -1568,7 +1568,7 @@ fn compute_type_scheme_of_item<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
         ast::ItemFn(ref decl, unsafety, _, abi, ref generics, _) => {
             let ty_generics = ty_generics_for_fn(ccx, generics, &ty::Generics::empty());
             let tofd = astconv::ty_of_bare_fn(&ccx.icx(generics), unsafety, abi, &**decl);
-            let ty = tcx.mk_fn(Some(local_def(it.id)), tcx.mk_bare_fn(tofd));
+            let ty = tcx.mk_fn(Some(DefId::local(it.id)), tcx.mk_bare_fn(tofd));
             ty::TypeScheme { ty: ty, generics: ty_generics }
         }
         ast::ItemTy(ref t, ref generics) => {
@@ -1645,12 +1645,12 @@ fn convert_typed_item<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
         }
     };
 
-    let prev_predicates = tcx.predicates.borrow_mut().insert(local_def(it.id),
+    let prev_predicates = tcx.predicates.borrow_mut().insert(DefId::local(it.id),
                                                              predicates.clone());
     assert!(prev_predicates.is_none());
 
     // Debugging aid.
-    if tcx.has_attr(local_def(it.id), "rustc_object_lifetime_default") {
+    if tcx.has_attr(DefId::local(it.id), "rustc_object_lifetime_default") {
         let object_lifetime_default_reprs: String =
             scheme.generics.types.iter()
                                  .map(|t| match t.object_lifetime_default {
@@ -1673,7 +1673,7 @@ fn type_scheme_of_foreign_item<'a, 'tcx>(
     -> ty::TypeScheme<'tcx>
 {
     memoized(&ccx.tcx.tcache,
-             local_def(it.id),
+             DefId::local(it.id),
              |_| compute_type_scheme_of_foreign_item(ccx, it, abi))
 }
 
@@ -1718,7 +1718,7 @@ fn convert_foreign_item<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
         }
     };
 
-    let prev_predicates = tcx.predicates.borrow_mut().insert(local_def(it.id), predicates);
+    let prev_predicates = tcx.predicates.borrow_mut().insert(DefId::local(it.id), predicates);
     assert!(prev_predicates.is_none());
 }
 
@@ -1742,7 +1742,7 @@ fn ty_generics_for_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                    -> ty::Generics<'tcx>
 {
     debug!("ty_generics_for_trait(trait_id={:?}, substs={:?})",
-           local_def(trait_id), substs);
+           DefId::local(trait_id), substs);
 
     let mut generics = ty_generics_for_type_or_impl(ccx, ast_generics);
 
@@ -1758,8 +1758,8 @@ fn ty_generics_for_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
         space: SelfSpace,
         index: 0,
         name: special_idents::type_self.name,
-        def_id: local_def(param_id),
-        default_def_id: local_def(parent),
+        def_id: DefId::local(param_id),
+        default_def_id: DefId::local(parent),
         default: None,
         object_lifetime_default: ty::ObjectLifetimeDefault::BaseDefault,
     };
@@ -1966,7 +1966,7 @@ fn ty_generics<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
         let def = ty::RegionParameterDef { name: l.lifetime.name,
                                            space: space,
                                            index: i as u32,
-                                           def_id: local_def(l.lifetime.id),
+                                           def_id: DefId::local(l.lifetime.id),
                                            bounds: bounds };
         result.regions.push(space, def);
     }
@@ -2034,8 +2034,8 @@ fn get_or_create_type_parameter_def<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
         space: space,
         index: index,
         name: param.ident.name,
-        def_id: local_def(param.id),
-        default_def_id: local_def(parent),
+        def_id: DefId::local(param.id),
+        default_def_id: DefId::local(parent),
         default: default,
         object_lifetime_default: object_lifetime_default,
     };
@@ -2378,7 +2378,7 @@ fn check_method_self_type<'a, 'tcx, RS:RegionScope>(
         ty_fold::fold_regions(tcx, value, &mut false, |region, _| {
             match region {
                 ty::ReEarlyBound(data) => {
-                    let def_id = local_def(data.param_id);
+                    let def_id = DefId::local(data.param_id);
                     ty::ReFree(ty::FreeRegion { scope: scope,
                                                 bound_region: ty::BrNamed(def_id, data.name) })
                 }
@@ -2391,7 +2391,7 @@ fn check_method_self_type<'a, 'tcx, RS:RegionScope>(
 /// Checks that all the type parameters on an impl
 fn enforce_impl_params_are_constrained<'tcx>(tcx: &ty::ctxt<'tcx>,
                                              ast_generics: &ast::Generics,
-                                             impl_def_id: ast::DefId,
+                                             impl_def_id: DefId,
                                              impl_items: &[P<ast::ImplItem>])
 {
     let impl_scheme = tcx.lookup_item_type(impl_def_id);
@@ -2425,7 +2425,7 @@ fn enforce_impl_params_are_constrained<'tcx>(tcx: &ty::ctxt<'tcx>,
 
     let lifetimes_in_associated_types: HashSet<_> =
         impl_items.iter()
-                  .map(|item| tcx.impl_or_trait_item(local_def(item.id)))
+                  .map(|item| tcx.impl_or_trait_item(DefId::local(item.id)))
                   .filter_map(|item| match item {
                       ty::TypeTraitItem(ref assoc_ty) => assoc_ty.ty,
                       ty::ConstTraitItem(..) | ty::MethodTraitItem(..) => None

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -105,6 +105,7 @@ pub use rustc::session;
 pub use rustc::util;
 
 use middle::def;
+use middle::def_id::DefId;
 use middle::infer;
 use middle::subst;
 use middle::ty::{self, Ty, HasTypeFlags};
@@ -115,7 +116,6 @@ use util::common::time;
 use syntax::codemap::Span;
 use syntax::print::pprust::*;
 use syntax::{ast, abi};
-use syntax::ast_util::local_def;
 
 use std::cell::RefCell;
 
@@ -238,7 +238,7 @@ fn check_main_fn_ty(ccx: &CrateCtxt,
                 }
                 _ => ()
             }
-            let se_ty = tcx.mk_fn(Some(local_def(main_id)), tcx.mk_bare_fn(ty::BareFnTy {
+            let se_ty = tcx.mk_fn(Some(DefId::local(main_id)), tcx.mk_bare_fn(ty::BareFnTy {
                 unsafety: ast::Unsafety::Normal,
                 abi: abi::Rust,
                 sig: ty::Binder(ty::FnSig {
@@ -284,7 +284,7 @@ fn check_start_fn_ty(ccx: &CrateCtxt,
                 _ => ()
             }
 
-            let se_ty = tcx.mk_fn(Some(local_def(start_id)), tcx.mk_bare_fn(ty::BareFnTy {
+            let se_ty = tcx.mk_fn(Some(DefId::local(start_id)), tcx.mk_bare_fn(ty::BareFnTy {
                 unsafety: ast::Unsafety::Normal,
                 abi: abi::Rust,
                 sig: ty::Binder(ty::FnSig {

--- a/src/librustc_typeck/variance.rs
+++ b/src/librustc_typeck/variance.rs
@@ -404,7 +404,7 @@ fn lang_items(tcx: &ty::ctxt) -> Vec<(ast::NodeId,Vec<ty::Variance>)> {
 
     all.into_iter()
        .filter(|&(ref d,_)| d.is_some())
-       .filter(|&(ref d,_)| d.as_ref().unwrap().krate == LOCAL_CRATE)
+       .filter(|&(ref d,_)| d.as_ref().unwrap().is_local())
        .map(|(d, v)| (d.unwrap().node, v))
        .collect()
 }
@@ -740,7 +740,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
                          -> VarianceTermPtr<'a> {
         assert_eq!(param_def_id.krate, item_def_id.krate);
 
-        if param_def_id.krate == LOCAL_CRATE {
+        if param_def_id.is_local() {
             // Parameter on an item defined within current crate:
             // variance not yet inferred, so return a symbolic
             // variance.

--- a/src/librustdoc/clean/simplify.rs
+++ b/src/librustdoc/clean/simplify.rs
@@ -29,8 +29,8 @@
 use std::mem;
 use std::collections::HashMap;
 
+use rustc::middle::def_id::DefId;
 use rustc::middle::subst;
-use syntax::ast;
 
 use clean::PathParameters as PP;
 use clean::WherePredicate as WP;
@@ -148,8 +148,8 @@ fn ty_bounds(bounds: Vec<clean::TyParamBound>) -> Vec<clean::TyParamBound> {
     bounds
 }
 
-fn trait_is_same_or_supertrait(cx: &DocContext, child: ast::DefId,
-                               trait_: ast::DefId) -> bool {
+fn trait_is_same_or_supertrait(cx: &DocContext, child: DefId,
+                               trait_: DefId) -> bool {
     if child == trait_ {
         return true
     }

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -12,6 +12,7 @@ pub use self::MaybeTyped::*;
 use rustc_lint;
 use rustc_driver::{driver, target_features};
 use rustc::session::{self, config};
+use rustc::middle::def_id::DefId;
 use rustc::middle::{privacy, ty};
 use rustc::ast_map;
 use rustc::lint;
@@ -37,7 +38,7 @@ pub enum MaybeTyped<'a, 'tcx: 'a> {
     NotTyped(session::Session)
 }
 
-pub type ExternalPaths = RefCell<Option<HashMap<ast::DefId,
+pub type ExternalPaths = RefCell<Option<HashMap<DefId,
                                                 (Vec<String>, clean::TypeKind)>>>;
 
 pub struct DocContext<'a, 'tcx: 'a> {
@@ -45,11 +46,11 @@ pub struct DocContext<'a, 'tcx: 'a> {
     pub maybe_typed: MaybeTyped<'a, 'tcx>,
     pub input: Input,
     pub external_paths: ExternalPaths,
-    pub external_traits: RefCell<Option<HashMap<ast::DefId, clean::Trait>>>,
-    pub external_typarams: RefCell<Option<HashMap<ast::DefId, String>>>,
-    pub inlined: RefCell<Option<HashSet<ast::DefId>>>,
+    pub external_traits: RefCell<Option<HashMap<DefId, clean::Trait>>>,
+    pub external_typarams: RefCell<Option<HashMap<DefId, String>>>,
+    pub inlined: RefCell<Option<HashSet<DefId>>>,
     pub populated_crate_impls: RefCell<HashSet<ast::CrateNum>>,
-    pub deref_trait_did: Cell<Option<ast::DefId>>,
+    pub deref_trait_did: Cell<Option<DefId>>,
 }
 
 impl<'b, 'tcx> DocContext<'b, 'tcx> {
@@ -77,9 +78,9 @@ pub struct CrateAnalysis {
     pub exported_items: privacy::ExportedItems,
     pub public_items: privacy::PublicItems,
     pub external_paths: ExternalPaths,
-    pub external_typarams: RefCell<Option<HashMap<ast::DefId, String>>>,
-    pub inlined: RefCell<Option<HashSet<ast::DefId>>>,
-    pub deref_trait_did: Option<ast::DefId>,
+    pub external_typarams: RefCell<Option<HashMap<DefId, String>>>,
+    pub inlined: RefCell<Option<HashSet<DefId>>>,
+    pub deref_trait_did: Option<DefId>,
 }
 
 pub type Externs = HashMap<String, Vec<String>>;

--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -14,7 +14,6 @@ use std::cmp;
 use std::string::String;
 use std::usize;
 use syntax::ast;
-use syntax::ast_util;
 
 use clean;
 use clean::Item;
@@ -131,7 +130,7 @@ impl<'a> fold::DocFolder for Stripper<'a> {
             clean::TraitItem(..) | clean::FunctionItem(..) |
             clean::VariantItem(..) | clean::MethodItem(..) |
             clean::ForeignFunctionItem(..) | clean::ForeignStaticItem(..) => {
-                if ast_util::is_local(i.def_id) {
+                if i.def_id.is_local() {
                     if !self.exported_items.contains(&i.def_id.node) {
                         return None;
                     }
@@ -143,7 +142,7 @@ impl<'a> fold::DocFolder for Stripper<'a> {
             }
 
             clean::ConstantItem(..) => {
-                if ast_util::is_local(i.def_id) &&
+                if i.def_id.is_local() &&
                    !self.exported_items.contains(&i.def_id.node) {
                     return None;
                 }
@@ -171,7 +170,7 @@ impl<'a> fold::DocFolder for Stripper<'a> {
             clean::ImplItem(clean::Impl{
                 for_: clean::ResolvedPath{ did, .. }, ..
             }) => {
-                if ast_util::is_local(did) &&
+                if did.is_local() &&
                    !self.exported_items.contains(&did.node) {
                     return None;
                 }
@@ -238,7 +237,7 @@ impl<'a> fold::DocFolder for ImplStripper<'a> {
             match imp.trait_ {
                 Some(clean::ResolvedPath{ did, .. }) => {
                     let ImplStripper(s) = *self;
-                    if ast_util::is_local(did) && !s.contains(&did.node) {
+                    if did.is_local() && !s.contains(&did.node) {
                         return None;
                     }
                 }

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -16,12 +16,12 @@ use std::mem;
 
 use syntax::abi;
 use syntax::ast;
-use syntax::ast_util;
 use syntax::attr;
 use syntax::attr::AttrMetaMethods;
 use syntax::codemap::Span;
 
 use rustc::ast_map;
+use rustc::middle::def_id::DefId;
 use rustc::middle::stability;
 
 use core;
@@ -62,7 +62,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
 
     fn stability(&self, id: ast::NodeId) -> Option<attr::Stability> {
         self.cx.tcx_opt().and_then(
-            |tcx| stability::lookup(tcx, ast_util::local_def(id)).map(|x| x.clone()))
+            |tcx| stability::lookup(tcx, DefId::local(id)).map(|x| x.clone()))
     }
 
     pub fn visit(&mut self, krate: &ast::Crate) {
@@ -205,7 +205,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             None => return false
         };
         let def = tcx.def_map.borrow()[&id].def_id();
-        if !ast_util::is_local(def) { return false }
+        if !def.is_local() { return false }
         let analysis = match self.analysis {
             Some(analysis) => analysis, None => return false
         };

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -65,7 +65,6 @@ use parse::lexer::comments::{doc_comment_style, strip_doc_comment_decoration};
 use print::pprust;
 use ptr::P;
 
-use std::cell::Cell;
 use std::fmt;
 use std::rc::Rc;
 use serialize::{Encodable, Decodable, Encoder, Decoder};
@@ -371,37 +370,7 @@ pub type CrateNum = u32;
 
 pub type NodeId = u32;
 
-#[derive(Clone, Eq, Ord, PartialOrd, PartialEq, RustcEncodable,
-           RustcDecodable, Hash, Copy)]
-pub struct DefId {
-    pub krate: CrateNum,
-    pub node: NodeId,
-}
-
-fn default_def_id_debug(_: DefId, _: &mut fmt::Formatter) -> fmt::Result { Ok(()) }
-
-thread_local!(pub static DEF_ID_DEBUG: Cell<fn(DefId, &mut fmt::Formatter) -> fmt::Result> =
-                Cell::new(default_def_id_debug));
-
-impl fmt::Debug for DefId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "DefId {{ krate: {}, node: {} }}",
-                    self.krate, self.node));
-        DEF_ID_DEBUG.with(|def_id_debug| def_id_debug.get()(*self, f))
-    }
-}
-
-impl DefId {
-    /// Read the node id, asserting that this def-id is krate-local.
-    pub fn local_id(&self) -> NodeId {
-        assert_eq!(self.krate, LOCAL_CRATE);
-        self.node
-    }
-}
-
-/// Item definitions in the currently-compiled crate would have the CrateNum
-/// LOCAL_CRATE in their DefId.
-pub const LOCAL_CRATE: CrateNum = 0;
+/// Node id used to represent the root of the crate.
 pub const CRATE_NODE_ID: NodeId = 0;
 
 /// When parsing and doing expansions, we initially give all AST nodes this AST

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -28,12 +28,6 @@ pub fn path_name_i(idents: &[Ident]) -> String {
     idents.iter().map(|i| i.to_string()).collect::<Vec<String>>().join("::")
 }
 
-pub fn local_def(id: NodeId) -> DefId {
-    ast::DefId { krate: LOCAL_CRATE, node: id }
-}
-
-pub fn is_local(did: ast::DefId) -> bool { did.krate == LOCAL_CRATE }
-
 pub fn stmt_id(s: &Stmt) -> NodeId {
     match s.node {
       StmtDecl(_, id) => id,


### PR DESCRIPTION
It doesn't really make sense for DefId to be in libsyntax -- it is concerned with a single crate only. It is the compiler that understands the idea of many crates. (At some point, there might be a useful intermediate point here.) This is a refactoring in support of incr. compilation, which will be adjusting the notion of a DefId to make it more durable across compilations.

This will probably be a [breaking-change] for every plugin ever. You need to adjust things as follows:

```
use rustc::middle::def_id::{DefId, LOCAL_CRATE}; // two most common definitions
ast_util::is_local(def_id) => def_id.is_local()
ast_util::local_def(node_id) => DefId::local(node_id)
```
