### PR TITLE
Impl Eq/PartialEq on FnKind, improve docs

### DIFF
--- a/src/librustc/ast_map/blocks.rs
+++ b/src/librustc/ast_map/blocks.rs
@@ -191,7 +191,7 @@ impl<'a> FnLikeNode<'a> {
             visit::FkItemFn(p.ident, p.generics, p.unsafety, p.constness, p.abi, p.vis)
         };
         let closure = |_: ClosureParts| {
-            visit::FkFnBlock
+            visit::FkClosure
         };
         let method = |_, ident, sig: &'a ast::MethodSig, vis, _, _| {
             visit::FkMethod(ident, sig, vis)

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -1006,7 +1006,7 @@ fn check_fn(cx: &mut MatchCheckCtxt,
             sp: Span,
             fn_id: NodeId) {
     match kind {
-        visit::FkFnBlock => {}
+        visit::FkClosure => {}
         _ => cx.param_env = ParameterEnvironment::for_item(cx.tcx, fn_id),
     }
 

--- a/src/librustc/middle/intrinsicck.rs
+++ b/src/librustc/middle/intrinsicck.rs
@@ -241,7 +241,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for IntrinsicCheckingVisitor<'a, 'tcx> {
                 visit::walk_fn(self, fk, fd, b, s);
                 self.param_envs.pop();
             }
-            visit::FkFnBlock(..) => {
+            visit::FkClosure(..) => {
                 visit::walk_fn(self, fk, fd, b, s);
             }
         }

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -186,7 +186,7 @@ impl<'a, 'v> Visitor<'v> for LifetimeContext<'a> {
                     this.walk_fn(fk, fd, b, s)
                 })
             }
-            visit::FkFnBlock(..) => {
+            visit::FkClosure(..) => {
                 self.walk_fn(fk, fd, b, s)
             }
         }
@@ -484,7 +484,7 @@ impl<'a> LifetimeContext<'a> {
                 self.visit_generics(&sig.generics);
                 self.visit_explicit_self(&sig.explicit_self);
             }
-            visit::FkFnBlock(..) => {
+            visit::FkClosure(..) => {
                 visit::walk_fn_decl(self, fd);
             }
         }

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -67,7 +67,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for BorrowckCtxt<'a, 'tcx> {
                 self.free_region_map = old_free_region_map;
             }
 
-            visit::FkFnBlock => {
+            visit::FkClosure => {
                 borrowck_fn(self, fk, fd, b, s, id);
             }
         }

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -2133,7 +2133,7 @@ impl LintPass for UnconditionalRecursion {
                 cx.tcx.impl_or_trait_item(local_def(id)).as_opt_method()
             }
             // closures can't recur, so they don't matter.
-            visit::FkFnBlock => return
+            visit::FkClosure => return
         };
 
         // Walk through this function (say `f`) looking to see if

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -524,7 +524,7 @@ impl<'a, 'v, 'tcx> Visitor<'v> for Resolver<'a, 'tcx> {
                 self.visit_explicit_self(&sig.explicit_self);
                 MethodRibKind
             }
-            visit::FkFnBlock(..) => ClosureRibKind(node_id)
+            visit::FkClosure(..) => ClosureRibKind(node_id)
         };
         self.resolve_function(rib_kind, declaration, block);
     }

--- a/src/librustc_typeck/check/wf.rs
+++ b/src/librustc_typeck/check/wf.rs
@@ -428,7 +428,7 @@ impl<'ccx, 'tcx, 'v> Visitor<'v> for CheckTypeWellFormedVisitor<'ccx, 'tcx> {
                 fk: visit::FnKind<'v>, fd: &'v ast::FnDecl,
                 b: &'v ast::Block, span: Span, id: ast::NodeId) {
         match fk {
-            visit::FkFnBlock | visit::FkItemFn(..) => {}
+            visit::FkClosure | visit::FkItemFn(..) => {}
             visit::FkMethod(..) => {
                 match self.tcx().impl_or_trait_item(local_def(id)) {
                     ty::ImplOrTraitItem::MethodTraitItem(ty_method) => {

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -444,7 +444,7 @@ impl<'a, 'v, O: IdVisitingOperation> Visitor<'v> for IdVisitor<'a, O> {
             visit::FkMethod(_, sig, _) => {
                 self.visit_generics_helper(&sig.generics)
             }
-            visit::FkFnBlock => {}
+            visit::FkClosure => {}
         }
 
         for argument in &function_declaration.inputs {

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -32,7 +32,7 @@ use codemap::Span;
 use ptr::P;
 use owned_slice::OwnedSlice;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum FnKind<'a> {
     /// fn foo() or extern "Abi" fn foo()
     FkItemFn(Ident, &'a Generics, Unsafety, Constness, Abi, Visibility),
@@ -40,8 +40,7 @@ pub enum FnKind<'a> {
     /// fn foo(&self)
     FkMethod(Ident, &'a MethodSig, Option<Visibility>),
 
-    /// |x, y| ...
-    /// proc(x, y) ...
+    /// Closures (|x, y| {})
     FkFnBlock,
 }
 

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -40,8 +40,8 @@ pub enum FnKind<'a> {
     /// fn foo(&self)
     FkMethod(Ident, &'a MethodSig, Option<Visibility>),
 
-    /// Closures (|x, y| {})
-    FkFnBlock,
+    /// |x, y| {}
+    FkClosure,
 }
 
 /// Each method of the Visitor trait is a hook to be potentially
@@ -615,7 +615,7 @@ pub fn walk_fn<'v, V: Visitor<'v>>(visitor: &mut V,
             visitor.visit_generics(&sig.generics);
             visitor.visit_explicit_self(&sig.explicit_self);
         }
-        FkFnBlock(..) => {}
+        FkClosure(..) => {}
     }
 
     visitor.visit_block(function_body)
@@ -816,7 +816,7 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
             }
         }
         ExprClosure(_, ref function_declaration, ref body) => {
-            visitor.visit_fn(FkFnBlock,
+            visitor.visit_fn(FkClosure,
                              &**function_declaration,
                              &**body,
                              expression.span,


### PR DESCRIPTION
Since enums are namespaced now, should we also remove the `Fk` prefixes from `FnKind` and remove the reexport? (The reexport must be removed because otherwise it clashes with glob imports containing `ItemFn`). IMO writing `FnKind::Method` is much clearer than `FkMethod`.
