### PR TITLE
Enable or disable colored output according to CLICOLOR(_FORCE)

### DIFF
--- a/src/libsyntax/errors/emitter.rs
+++ b/src/libsyntax/errors/emitter.rs
@@ -55,7 +55,8 @@ impl ColorConfig {
         match *self {
             ColorConfig::Always => true,
             ColorConfig::Never  => false,
-            ColorConfig::Auto   => stderr_isatty(),
+            ColorConfig::Auto   => env::var("CLICOLOR_FORCE").unwrap_or("0".to_string()) != "0" ||
+                      (stderr_isatty() && env::var("CLICOLOR").unwrap_or("1".to_string()) != "0"),
         }
     }
 }

--- a/src/libsyntax/errors/emitter.rs
+++ b/src/libsyntax/errors/emitter.rs
@@ -17,7 +17,7 @@ use errors::{Level, RenderSpan, DiagnosticBuilder};
 use errors::RenderSpan::*;
 use errors::Level::*;
 
-use std::{cmp, fmt};
+use std::{cmp, fmt, env};
 use std::io::prelude::*;
 use std::io;
 use std::rc::Rc;

--- a/src/libterm/terminfo/parser/compiled.rs
+++ b/src/libterm/terminfo/parser/compiled.rs
@@ -323,8 +323,9 @@ pub fn parse(file: &mut io::Read, longnames: bool) -> Result<TermInfo, String> {
     })
 }
 
-/// Create a dummy TermInfo struct for msys terminals
-pub fn msys_terminfo() -> TermInfo {
+/// Create a dummy TermInfo struct which only supports ISO 6429 (ANSI) color sequences. This is
+/// used for msys and when CLICOLOR(_FORCE) is set.
+pub fn ansi_terminfo() -> TermInfo {
     let mut strings = HashMap::new();
     strings.insert("sgr0".to_string(), b"\x1B[0m".to_vec());
     strings.insert("bold".to_string(), b"\x1B[1m".to_vec());


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/27867)*
<!-- homu-ignore:end -->

While rust-lang/rust#14040 already enabled a command line flag to enable or disable colored output, this uses the environment variables `CLICOLOR` and `CLICOLOR_FORCE`. `CLICOLOR=0` would be `--color=never` and `CLICOLOR_FORCE=1` `--color=always`.

Why environment variables when there is already a command line switch? When working with build systems, editors or continuous integration servers output almost always gets piped or buffered, so a switch to force colored output is needed. When we agree upon a standard for this, the only thing one would need to do in such a situation is to define `CLICOLOR_FORCE=1`. I've also created a page with a summary: http://bixense.com/clicolors/ Please tell me what you think :)
