### PR TITLE
test: Don't panic if some tests failed

### DIFF
--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -250,7 +250,7 @@ pub fn test_main(args: &[String], tests: Vec<TestDescAndFn> ) {
         };
     match run_tests_console(&opts, tests) {
         Ok(true) => {}
-        Ok(false) => panic!("Some tests failed"),
+        Ok(false) => std::process::exit(101),
         Err(e) => panic!("io error when running tests: {:?}", e),
     }
 }


### PR DESCRIPTION
This commit removes the call to `panic!("Some tests failed")` at the end of all
tests run when running with libtest. The panic is replaced with
`std::process::exit` to have a nonzero error code, but this change both:
1. Makes the test runner no longer print out the extraneous panic message at the
   end of a failing test run that some tests failed. (this is already summarized
   in the output of the test run).
2. When running tests with `RUST_BACKTRACE` set it removes an extraneous
   backtrace from the output (only failing tests will have their backtraces in
   the output.
