### PR TITLE
DOC: Remove repetition in Seek::seek() doc

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1060,9 +1060,6 @@ pub trait Seek {
     /// A seek beyond the end of a stream is allowed, but implementation
     /// defined.
     ///
-    /// The behavior when seeking past the end of the stream is implementation
-    /// defined.
-    ///
     /// If the seek operation completed successfully,
     /// this method returns the new position from the start of the stream.
     /// That position can be used later with `SeekFrom::Start`.


### PR DESCRIPTION
"Don't seek past end of stream" is mentioned twice in a row. This happened because seeking before offset 0 was previously mentioned there, and was moved to the "errors" section afterwards.

Somehow made it through [#26924](https://github.com/rust-lang/rust/pull/26924/files#diff-668f8f358d4a93474b396dcb3727399eR825).
