### PR TITLE
std: Add into_raw_os traits to the OS preludes

### DIFF
--- a/src/libstd/sys/unix/ext/mod.rs
+++ b/src/libstd/sys/unix/ext/mod.rs
@@ -41,7 +41,7 @@ pub mod raw;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod prelude {
     #[doc(no_inline)]
-    pub use super::io::{RawFd, AsRawFd, FromRawFd};
+    pub use super::io::{RawFd, AsRawFd, FromRawFd, IntoRawFd};
     #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::ffi::{OsStrExt, OsStringExt};
     #[doc(no_inline)]

--- a/src/libstd/sys/windows/ext/mod.rs
+++ b/src/libstd/sys/windows/ext/mod.rs
@@ -30,7 +30,7 @@ pub mod prelude {
     #[doc(no_inline)]
     pub use super::io::{RawSocket, RawHandle, AsRawSocket, AsRawHandle};
     #[doc(no_inline)]
-    pub use super::io::{FromRawSocket, FromRawHandle};
+    pub use super::io::{FromRawSocket, FromRawHandle, IntoRawSocket, IntoRawHandle};
     #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::ffi::{OsStrExt, OsStringExt};
     #[doc(no_inline)]


### PR DESCRIPTION
These traits were mistakenly left out of the OS-specific prelude modules when
they were added.
