### PR TITLE
Use handle.join() the same way in similarly structured examples

### DIFF
--- a/src/doc/trpl/concurrency.md
+++ b/src/doc/trpl/concurrency.md
@@ -343,12 +343,14 @@ threads as a simple isolation mechanism:
 ```rust
 use std::thread;
 
-let result = thread::spawn(move || {
+let handle = thread::spawn(move || {
     panic!("oops!");
-}).join();
+});
+
+let result = handle.join();
 
 assert!(result.is_err());
 ```
 
-Our `Thread` gives us a `Result` back, which allows us to check if the thread
+`Thread.join()` gives us a `Result` back, which allows us to check if the thread
 has panicked or not.


### PR DESCRIPTION
The chapter on concurrency has two examples that both start with:

```
 let something = thread::spawn(…
```

but the returned values have different types, because the second example has `.join()` at the end of the expression.

I haven't noticed that join at first, and was wondering how is that possible that the result can have `.is_err()` and `.join()` methods.

I've changed the second example to have the same structure as the first, so they're easy to compare.
