### PR TITLE
Reduce the reliance on `PATH_MAX`

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -3920,6 +3920,8 @@ pub mod consts {
             pub const _SC_XBS5_ILP32_OFFBIG : c_int = 126;
             pub const _SC_XBS5_LPBIG_OFFBIG : c_int = 128;
 
+            pub const _PC_NAME_MAX: c_int = 3;
+            pub const _PC_PATH_MAX: c_int = 4;
         }
         #[cfg(target_os = "nacl")]
         pub mod sysconf {
@@ -3928,6 +3930,9 @@ pub mod consts {
             pub static _SC_SENDMSG_MAX_SIZE : c_int = 0;
             pub static _SC_NPROCESSORS_ONLN : c_int = 1;
             pub static _SC_PAGESIZE : c_int = 2;
+
+            pub const _PC_NAME_MAX: c_int = 3;
+            pub const _PC_PATH_MAX: c_int = 4;
         }
 
         #[cfg(target_os = "android")]
@@ -3963,6 +3968,9 @@ pub mod consts {
             pub const _SC_STREAM_MAX : c_int = 27;
             pub const _SC_TZNAME_MAX : c_int = 28;
             pub const _SC_PAGESIZE : c_int = 39;
+
+            pub const _PC_NAME_MAX: c_int = 4;
+            pub const _PC_PATH_MAX: c_int = 5;
         }
     }
 
@@ -4433,6 +4441,9 @@ pub mod consts {
             pub const _SC_SEM_VALUE_MAX : c_int = 50;
             pub const _SC_SIGQUEUE_MAX : c_int = 51;
             pub const _SC_TIMER_MAX : c_int = 52;
+
+            pub const _PC_NAME_MAX: c_int = 4;
+            pub const _PC_PATH_MAX: c_int = 5;
         }
     }
 
@@ -4868,6 +4879,9 @@ pub mod consts {
             pub const _SC_SYNCHRONIZED_IO : c_int = 75;
             pub const _SC_TIMER_MAX : c_int = 93;
             pub const _SC_TIMERS : c_int = 94;
+
+            pub const _PC_NAME_MAX: c_int = 4;
+            pub const _PC_PATH_MAX: c_int = 5;
         }
     }
 
@@ -5379,6 +5393,9 @@ pub mod consts {
             pub const _SC_TRACE_SYS_MAX : c_int = 129;
             pub const _SC_TRACE_USER_EVENT_MAX : c_int = 130;
             pub const _SC_PASS_MAX : c_int = 131;
+
+            pub const _PC_NAME_MAX: c_int = 4;
+            pub const _PC_PATH_MAX: c_int = 5;
         }
     }
 }
@@ -5834,8 +5851,6 @@ pub mod funcs {
             use types::os::arch::posix01::utimbuf;
             use types::os::arch::posix88::{gid_t, off_t, pid_t};
             use types::os::arch::posix88::{ssize_t, uid_t};
-
-            pub const _PC_NAME_MAX: c_int = 4;
 
             #[cfg(not(target_os = "nacl"))]
             extern {

--- a/src/rt/rust_builtin.c
+++ b/src/rt/rust_builtin.c
@@ -341,7 +341,11 @@ const char * rust_current_exe()
   char **paths;
   size_t sz;
   int i;
-  char buf[2*PATH_MAX], exe[2*PATH_MAX];
+  /* If `PATH_MAX` is defined on the platform, `realpath` will truncate the
+   * resolved path up to `PATH_MAX`. While this can make the resolution fail if
+   * the executable is placed in a deep path, the usage of a buffer whose
+   * length depends on `PATH_MAX` is still memory safe. */
+  char buf[2*PATH_MAX], exe[PATH_MAX];
 
   if (self != NULL)
     return self;


### PR DESCRIPTION
This PR rewrites the code that previously relied on `PATH_MAX`.

On my tests, even though the user gives the buffer length explicitly, both Linux's glibc and OS X's libc seems to obey the hard limit of `PATH_MAX` internally. So, to truly remove the limitation of `PATH_MAX`, the related system calls should be rewritten from scratch in Rust, which this PR does not try to do.

However, eliminating the need of `PATH_MAX` is still a good idea for various reasons, such as: (1) they might change the implementation in the future, and (2) some platforms don't have a hard-coded `PATH_MAX`, such as GNU Hurd.

More details are in the commit messages.

Fixes #27454.

r? @alexcrichton
