### PR TITLE
Speed up operations on scopes

### DIFF
--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -225,7 +225,7 @@ impl<'a,'tcx> TyDecoder<'a,'tcx> {
             }
             'f' => {
                 assert_eq!(self.next(), '[');
-                let scope = self.parse_destruction_scope_data();
+                let scope = self.parse_scope();
                 assert_eq!(self.next(), '|');
                 let br = self.parse_bound_region();
                 assert_eq!(self.next(), ']');
@@ -282,11 +282,6 @@ impl<'a,'tcx> TyDecoder<'a,'tcx> {
             }
             _ => panic!("parse_scope: bad input")
         })
-    }
-
-    fn parse_destruction_scope_data(&mut self) -> region::DestructionScopeData {
-        let node_id = self.parse_uint() as ast::NodeId;
-        region::DestructionScopeData::new(node_id)
     }
 
     fn parse_opt<T, F>(&mut self, f: F) -> Option<T>

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -207,8 +207,10 @@ impl<'a,'tcx> TyDecoder<'a,'tcx> {
             }
             'B' => {
                 assert_eq!(self.next(), '[');
-                // this is totally wrong, but nobody relevant cares about
-                // this field - it will die soon(TM).
+                // this is the wrong NodeId, but `param_id` is only accessed
+                // by the receiver-matching code in collect, which won't
+                // be going down this code path, and anyway I will kill it
+                // the moment wfcheck becomes the standard.
                 let node_id = self.parse_uint() as ast::NodeId;
                 assert_eq!(self.next(), '|');
                 let space = self.parse_param_space();
@@ -249,8 +251,12 @@ impl<'a,'tcx> TyDecoder<'a,'tcx> {
 
     fn parse_scope(&mut self) -> region::CodeExtent {
         self.tcx.region_maps.bogus_code_extent(match self.next() {
-            // the scopes created here are totally bogus with their
-            // NodeIDs
+            // This creates scopes with the wrong NodeId. This isn't
+            // actually a problem because scopes only exist *within*
+            // functions, and functions aren't loaded until trans which
+            // doesn't care about regions.
+            //
+            // May still be worth fixing though.
             'P' => {
                 assert_eq!(self.next(), '[');
                 let fn_id = self.parse_uint() as ast::NodeId;

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -269,7 +269,7 @@ impl<'a,'tcx> TyDecoder<'a,'tcx> {
                 assert_eq!(self.next(), '[');
                 let node_id = self.parse_uint() as ast::NodeId;
                 assert_eq!(self.next(), '|');
-                let first_stmt_index = self.parse_uint();
+                let first_stmt_index = self.parse_u32();
                 assert_eq!(self.next(), ']');
                 let block_remainder = region::BlockRemainder {
                     block: node_id, first_statement_index: first_stmt_index,
@@ -717,4 +717,3 @@ fn parse_unsafety(c: char) -> ast::Unsafety {
         _ => panic!("parse_unsafety: bad unsafety {}", c)
     }
 }
-

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -255,7 +255,7 @@ pub fn enc_region(w: &mut Encoder, cx: &ctxt, r: ty::Region) {
         }
         ty::ReFree(ref fr) => {
             mywrite!(w, "f[");
-            enc_destruction_scope_data(w, fr.scope);
+            enc_scope(w, cx, fr.scope);
             mywrite!(w, "|");
             enc_bound_region(w, cx, fr.bound_region);
             mywrite!(w, "]");
@@ -287,11 +287,6 @@ fn enc_scope(w: &mut Encoder, cx: &ctxt, scope: region::CodeExtent) {
             block: b, first_statement_index: i }) => mywrite!(w, "B[{}|{}]", b, i),
         region::CodeExtentData::DestructionScope(node_id) => mywrite!(w, "D{}", node_id),
     }
-}
-
-fn enc_destruction_scope_data(w: &mut Encoder,
-                              d: region::DestructionScopeData) {
-    mywrite!(w, "{}", d.node_id);
 }
 
 fn enc_bound_region(w: &mut Encoder, cx: &ctxt, br: ty::BoundRegion) {

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -271,7 +271,7 @@ pub fn enc_region(w: &mut Encoder, cx: &ctxt, r: ty::Region) {
         ty::ReEmpty => {
             mywrite!(w, "e");
         }
-        ty::ReInfer(_) => {
+        ty::ReVar(_) | ty::ReSkolemized(..) => {
             // these should not crop up after typeck
             cx.diag.handler().bug("cannot encode region variables");
         }

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -498,7 +498,7 @@ impl tr for ty::Region {
             ty::ReScope(scope) => {
                 ty::ReScope(scope.tr(dcx))
             }
-            ty::ReEmpty | ty::ReStatic | ty::ReInfer(..) => {
+            ty::ReEmpty | ty::ReStatic | ty::ReVar(..) | ty::ReSkolemized(..) => {
                 *self
             }
             ty::ReFree(ref fr) => {

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -1365,7 +1365,7 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
     /// the crate numbers back to the original source crate.
     ///
     /// Scopes will end up as being totally bogus. This can actually
-    /// be fixed through.
+    /// be fixed though.
     ///
     /// Unboxed closures are cloned along with the function being
     /// inlined, and all side tables use interned node IDs, so we

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -479,67 +479,6 @@ impl tr for def::Def {
 }
 
 // ______________________________________________________________________
-// Encoding and decoding of ancillary information
-
-impl tr for ty::Region {
-    fn tr(&self, dcx: &DecodeContext) -> ty::Region {
-        match *self {
-            ty::ReLateBound(debruijn, br) => {
-                ty::ReLateBound(debruijn, br.tr(dcx))
-            }
-            ty::ReEarlyBound(data) => {
-                ty::ReEarlyBound(ty::EarlyBoundRegion {
-                    param_id: dcx.tr_id(data.param_id),
-                    space: data.space,
-                    index: data.index,
-                    name: data.name,
-                })
-            }
-            ty::ReScope(scope) => {
-                ty::ReScope(scope.tr(dcx))
-            }
-            ty::ReEmpty | ty::ReStatic | ty::ReVar(..) | ty::ReSkolemized(..) => {
-                *self
-            }
-            ty::ReFree(ref fr) => {
-                ty::ReFree(fr.tr(dcx))
-            }
-        }
-    }
-}
-
-impl tr for ty::FreeRegion {
-    fn tr(&self, dcx: &DecodeContext) -> ty::FreeRegion {
-        ty::FreeRegion { scope: self.scope.tr(dcx),
-                         bound_region: self.bound_region.tr(dcx) }
-    }
-}
-
-impl tr for region::CodeExtent {
-    fn tr(&self, dcx: &DecodeContext) -> region::CodeExtent {
-        self.map_id(|id| dcx.tr_id(id))
-    }
-}
-
-impl tr for region::DestructionScopeData {
-    fn tr(&self, dcx: &DecodeContext) -> region::DestructionScopeData {
-        region::DestructionScopeData { node_id: dcx.tr_id(self.node_id) }
-    }
-}
-
-impl tr for ty::BoundRegion {
-    fn tr(&self, dcx: &DecodeContext) -> ty::BoundRegion {
-        match *self {
-            ty::BrAnon(_) |
-            ty::BrFresh(_) |
-            ty::BrEnv => *self,
-            ty::BrNamed(id, ident) => ty::BrNamed(dcx.tr_def_id(id),
-                                                    ident),
-        }
-    }
-}
-
-// ______________________________________________________________________
 // Encoding and decoding of freevar information
 
 fn encode_freevar_entry(rbml_w: &mut Encoder, fv: &ty::Freevar) {
@@ -570,24 +509,6 @@ impl tr for ty::Freevar {
         ty::Freevar {
             def: self.def.tr(dcx),
             span: self.span.tr(dcx),
-        }
-    }
-}
-
-impl tr for ty::UpvarBorrow {
-    fn tr(&self, dcx: &DecodeContext) -> ty::UpvarBorrow {
-        ty::UpvarBorrow {
-            kind: self.kind,
-            region: self.region.tr(dcx)
-        }
-    }
-}
-
-impl tr for ty::UpvarCapture {
-    fn tr(&self, dcx: &DecodeContext) -> ty::UpvarCapture {
-        match *self {
-            ty::UpvarCapture::ByValue => ty::UpvarCapture::ByValue,
-            ty::UpvarCapture::ByRef(ref data) => ty::UpvarCapture::ByRef(data.tr(dcx)),
         }
     }
 }
@@ -703,10 +624,13 @@ impl<'a, 'tcx> get_ty_str_ctxt<'tcx> for e::EncodeContext<'a, 'tcx> {
 trait rbml_writer_helpers<'tcx> {
     fn emit_closure_type<'a>(&mut self, ecx: &e::EncodeContext<'a, 'tcx>,
                              closure_type: &ty::ClosureTy<'tcx>);
+    fn emit_region(&mut self, ecx: &e::EncodeContext, r: ty::Region);
     fn emit_ty<'a>(&mut self, ecx: &e::EncodeContext<'a, 'tcx>, ty: Ty<'tcx>);
     fn emit_tys<'a>(&mut self, ecx: &e::EncodeContext<'a, 'tcx>, tys: &[Ty<'tcx>]);
     fn emit_type_param_def<'a>(&mut self, ecx: &e::EncodeContext<'a, 'tcx>,
                                type_param_def: &ty::TypeParameterDef<'tcx>);
+    fn emit_region_param_def(&mut self, ecx: &e::EncodeContext,
+                             region_param_def: &ty::RegionParameterDef);
     fn emit_predicate<'a>(&mut self, ecx: &e::EncodeContext<'a, 'tcx>,
                           predicate: &ty::Predicate<'tcx>);
     fn emit_trait_ref<'a>(&mut self, ecx: &e::EncodeContext<'a, 'tcx>,
@@ -718,9 +642,11 @@ trait rbml_writer_helpers<'tcx> {
     fn emit_existential_bounds<'b>(&mut self, ecx: &e::EncodeContext<'b,'tcx>,
                                    bounds: &ty::ExistentialBounds<'tcx>);
     fn emit_builtin_bounds(&mut self, ecx: &e::EncodeContext, bounds: &ty::BuiltinBounds);
+    fn emit_upvar_capture(&mut self, ecx: &e::EncodeContext, capture: &ty::UpvarCapture);
     fn emit_auto_adjustment<'a>(&mut self, ecx: &e::EncodeContext<'a, 'tcx>,
                                 adj: &ty::AutoAdjustment<'tcx>);
-    fn emit_autoref<'a>(&mut self, autoref: &ty::AutoRef<'tcx>);
+    fn emit_autoref<'a>(&mut self, ecx: &e::EncodeContext<'a, 'tcx>,
+                        autoref: &ty::AutoRef<'tcx>);
     fn emit_auto_deref_ref<'a>(&mut self, ecx: &e::EncodeContext<'a, 'tcx>,
                                auto_deref_ref: &ty::AutoDerefRef<'tcx>);
 }
@@ -732,6 +658,10 @@ impl<'a, 'tcx> rbml_writer_helpers<'tcx> for Encoder<'a> {
         self.emit_opaque(|this| {
             Ok(e::write_closure_type(ecx, this, closure_type))
         });
+    }
+
+    fn emit_region(&mut self, ecx: &e::EncodeContext, r: ty::Region) {
+        self.emit_opaque(|this| Ok(e::write_region(ecx, this, r)));
     }
 
     fn emit_ty<'b>(&mut self, ecx: &e::EncodeContext<'b, 'tcx>, ty: Ty<'tcx>) {
@@ -755,7 +685,14 @@ impl<'a, 'tcx> rbml_writer_helpers<'tcx> for Encoder<'a> {
                                          type_param_def))
         });
     }
-
+    fn emit_region_param_def(&mut self, ecx: &e::EncodeContext,
+                             region_param_def: &ty::RegionParameterDef) {
+        self.emit_opaque(|this| {
+            Ok(tyencode::enc_region_param_def(this,
+                                              &ecx.ty_str_ctxt(),
+                                              region_param_def))
+        });
+    }
     fn emit_predicate<'b>(&mut self, ecx: &e::EncodeContext<'b, 'tcx>,
                           predicate: &ty::Predicate<'tcx>) {
         self.emit_opaque(|this| {
@@ -781,7 +718,7 @@ impl<'a, 'tcx> rbml_writer_helpers<'tcx> for Encoder<'a> {
                     this.emit_struct_field("regions", 1, |this| {
                         Ok(encode_vec_per_param_space(
                             this, &type_scheme.generics.regions,
-                            |this, def| def.encode(this).unwrap()))
+                            |this, def| this.emit_region_param_def(ecx, def)))
                     })
                 })
             });
@@ -802,6 +739,26 @@ impl<'a, 'tcx> rbml_writer_helpers<'tcx> for Encoder<'a> {
         self.emit_opaque(|this| Ok(tyencode::enc_builtin_bounds(this,
                                                                 &ecx.ty_str_ctxt(),
                                                                 bounds)));
+    }
+
+    fn emit_upvar_capture(&mut self, ecx: &e::EncodeContext, capture: &ty::UpvarCapture) {
+        use serialize::Encoder;
+
+        self.emit_enum("UpvarCapture", |this| {
+            match *capture {
+                ty::UpvarCapture::ByValue => {
+                    this.emit_enum_variant("ByValue", 1, 0, |_| Ok(()))
+                }
+                ty::UpvarCapture::ByRef(ty::UpvarBorrow { kind, region }) => {
+                    this.emit_enum_variant("ByRef", 2, 0, |this| {
+                        this.emit_enum_variant_arg(0,
+                            |this| kind.encode(this));
+                        this.emit_enum_variant_arg(1,
+                            |this| Ok(this.emit_region(ecx, region)))
+                    })
+                }
+            }
+        }).unwrap()
     }
 
     fn emit_substs<'b>(&mut self, ecx: &e::EncodeContext<'b, 'tcx>,
@@ -837,14 +794,16 @@ impl<'a, 'tcx> rbml_writer_helpers<'tcx> for Encoder<'a> {
         });
     }
 
-    fn emit_autoref<'b>(&mut self, autoref: &ty::AutoRef<'tcx>) {
+    fn emit_autoref<'b>(&mut self, ecx: &e::EncodeContext<'b, 'tcx>,
+                        autoref: &ty::AutoRef<'tcx>) {
         use serialize::Encoder;
 
         self.emit_enum("AutoRef", |this| {
             match autoref {
                 &ty::AutoPtr(r, m) => {
                     this.emit_enum_variant("AutoPtr", 0, 2, |this| {
-                        this.emit_enum_variant_arg(0, |this| r.encode(this));
+                        this.emit_enum_variant_arg(0,
+                            |this| Ok(this.emit_region(ecx, *r)));
                         this.emit_enum_variant_arg(1, |this| m.encode(this))
                     })
                 }
@@ -868,7 +827,7 @@ impl<'a, 'tcx> rbml_writer_helpers<'tcx> for Encoder<'a> {
                 this.emit_option(|this| {
                     match auto_deref_ref.autoref {
                         None => this.emit_option_none(),
-                        Some(ref a) => this.emit_option_some(|this| Ok(this.emit_autoref(a))),
+                        Some(ref a) => this.emit_option_some(|this| Ok(this.emit_autoref(ecx, a))),
                     }
                 })
             });
@@ -983,7 +942,7 @@ fn encode_side_tables_for_id(ecx: &e::EncodeContext,
                                        .unwrap()
                                        .clone();
                 var_id.encode(rbml_w);
-                upvar_capture.encode(rbml_w);
+                rbml_w.emit_upvar_capture(ecx, &upvar_capture);
             })
         }
     }
@@ -1080,6 +1039,7 @@ trait rbml_decoder_decoder_helpers<'tcx> {
                                      f: F) -> R
         where F: for<'x> FnOnce(&mut tydecode::TyDecoder<'x, 'tcx>) -> R;
 
+    fn read_region(&mut self, dcx: &DecodeContext) -> ty::Region;
     fn read_ty<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>) -> Ty<'tcx>;
     fn read_tys<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>) -> Vec<Ty<'tcx>>;
     fn read_trait_ref<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>)
@@ -1088,6 +1048,8 @@ trait rbml_decoder_decoder_helpers<'tcx> {
                                    -> ty::PolyTraitRef<'tcx>;
     fn read_type_param_def<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>)
                                    -> ty::TypeParameterDef<'tcx>;
+    fn read_region_param_def(&mut self, dcx: &DecodeContext)
+                             -> ty::RegionParameterDef;
     fn read_predicate<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>)
                               -> ty::Predicate<'tcx>;
     fn read_type_scheme<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>)
@@ -1096,6 +1058,8 @@ trait rbml_decoder_decoder_helpers<'tcx> {
                                        -> ty::ExistentialBounds<'tcx>;
     fn read_substs<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>)
                            -> subst::Substs<'tcx>;
+    fn read_upvar_capture(&mut self, dcx: &DecodeContext)
+                          -> ty::UpvarCapture;
     fn read_auto_adjustment<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>)
                                     -> ty::AutoAdjustment<'tcx>;
     fn read_cast_kind<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>)
@@ -1180,13 +1144,14 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
             str
         }
     }
-
-    fn read_ty<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>) -> Ty<'tcx> {
+    fn read_region(&mut self, dcx: &DecodeContext) -> ty::Region {
         // Note: regions types embed local node ids.  In principle, we
         // should translate these node ids into the new decode
         // context.  However, we do not bother, because region types
-        // are not used during trans.
-
+        // are not used during trans. This also applies to read_ty.
+        return self.read_ty_encoded(dcx, |decoder| decoder.parse_region());
+    }
+    fn read_ty<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>) -> Ty<'tcx> {
         return self.read_ty_encoded(dcx, |decoder| decoder.parse_ty());
     }
 
@@ -1209,7 +1174,10 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
                                    -> ty::TypeParameterDef<'tcx> {
         self.read_ty_encoded(dcx, |decoder| decoder.parse_type_param_def())
     }
-
+    fn read_region_param_def(&mut self, dcx: &DecodeContext)
+                             -> ty::RegionParameterDef {
+        self.read_ty_encoded(dcx, |decoder| decoder.parse_region_param_def())
+    }
     fn read_predicate<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>)
                               -> ty::Predicate<'tcx>
     {
@@ -1232,7 +1200,7 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
                             regions:
                             this.read_struct_field("regions", 1, |this| {
                                 Ok(this.read_vec_per_param_space(
-                                    |this| Decodable::decode(this).unwrap()))
+                                    |this| this.read_region_param_def(dcx)))
                             }).unwrap(),
                         })
                     })
@@ -1258,7 +1226,23 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
                .parse_substs())
         }).unwrap()
     }
-
+    fn read_upvar_capture(&mut self, dcx: &DecodeContext) -> ty::UpvarCapture {
+        self.read_enum("UpvarCapture", |this| {
+            let variants = ["ByValue", "ByRef"];
+            this.read_enum_variant(&variants, |this, i| {
+                Ok(match i {
+                    1 => ty::UpvarCapture::ByValue,
+                    2 => ty::UpvarCapture::ByRef(ty::UpvarBorrow {
+                        kind: this.read_enum_variant_arg(0,
+                                  |this| Decodable::decode(this)).unwrap(),
+                        region: this.read_enum_variant_arg(1,
+                                    |this| Ok(this.read_region(dcx))).unwrap()
+                    }),
+                    _ => panic!("bad enum variant for ty::UpvarCapture")
+                })
+            })
+        }).unwrap()
+    }
     fn read_auto_adjustment<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>)
                                     -> ty::AutoAdjustment<'tcx> {
         self.read_enum("AutoAdjustment", |this| {
@@ -1317,11 +1301,15 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
                 Ok(match i {
                     0 => {
                         let r: ty::Region =
-                            this.read_enum_variant_arg(0, |this| Decodable::decode(this)).unwrap();
+                            this.read_enum_variant_arg(0, |this| {
+                                Ok(this.read_region(dcx))
+                            }).unwrap();
                         let m: ast::Mutability =
-                            this.read_enum_variant_arg(1, |this| Decodable::decode(this)).unwrap();
+                            this.read_enum_variant_arg(1, |this| {
+                                Decodable::decode(this)
+                            }).unwrap();
 
-                        ty::AutoPtr(dcx.tcx.mk_region(r.tr(dcx)), m)
+                        ty::AutoPtr(dcx.tcx.mk_region(r), m)
                     }
                     1 => {
                         let m: ast::Mutability =
@@ -1375,6 +1363,9 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
     /// at trans time, but it's good to keep them consistent just in
     /// case. We translate them with `tr_def_id()` which will map
     /// the crate numbers back to the original source crate.
+    ///
+    /// Scopes will end up as being totally bogus. This can actually
+    /// be fixed through.
     ///
     /// Unboxed closures are cloned along with the function being
     /// inlined, and all side tables use interned node IDs, so we
@@ -1453,8 +1444,8 @@ fn decode_side_tables(dcx: &DecodeContext,
                             var_id: dcx.tr_id(var_id),
                             closure_expr_id: id
                         };
-                        let ub: ty::UpvarCapture = Decodable::decode(val_dsr).unwrap();
-                        dcx.tcx.tables.borrow_mut().upvar_capture_map.insert(upvar_id, ub.tr(dcx));
+                        let ub = val_dsr.read_upvar_capture(dcx);
+                        dcx.tcx.tables.borrow_mut().upvar_capture_map.insert(upvar_id, ub);
                     }
                     c::tag_table_tcache => {
                         let type_scheme = val_dsr.read_type_scheme(dcx);

--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -12,7 +12,6 @@ use rustc_data_structures::graph;
 use middle::cfg::*;
 use middle::def;
 use middle::pat_util;
-use middle::region::CodeExtent;
 use middle::ty;
 use syntax::ast;
 use syntax::ast_util;
@@ -585,11 +584,10 @@ impl<'a, 'tcx> CFGBuilder<'a, 'tcx> {
                         to_loop: LoopScope,
                         to_index: CFGIndex) {
         let mut data = CFGEdgeData {exiting_scopes: vec!() };
-        let mut scope = CodeExtent::from_node_id(from_expr.id);
-        let target_scope = CodeExtent::from_node_id(to_loop.loop_id);
+        let mut scope = self.tcx.region_maps.node_extent(from_expr.id);
+        let target_scope = self.tcx.region_maps.node_extent(to_loop.loop_id);
         while scope != target_scope {
-
-            data.exiting_scopes.push(scope.node_id());
+            data.exiting_scopes.push(scope.node_id(&self.tcx.region_maps));
             scope = self.tcx.region_maps.encl_scope(scope);
         }
         self.graph.add_edge(from_index, to_index, data);

--- a/src/librustc/middle/free_region.rs
+++ b/src/librustc/middle/free_region.rs
@@ -135,8 +135,7 @@ impl FreeRegionMap {
                     tcx.region_maps.is_subscope_of(sub_scope, super_scope),
 
                 (ty::ReScope(sub_scope), ty::ReFree(fr)) =>
-                    tcx.region_maps.is_subscope_of(sub_scope,
-                                                   fr.scope.to_code_extent(&tcx.region_maps)) ||
+                    tcx.region_maps.is_subscope_of(sub_scope, fr.scope) ||
                     self.is_static(fr),
 
                 (ty::ReFree(sub_fr), ty::ReFree(super_fr)) =>

--- a/src/librustc/middle/free_region.rs
+++ b/src/librustc/middle/free_region.rs
@@ -135,7 +135,8 @@ impl FreeRegionMap {
                     tcx.region_maps.is_subscope_of(sub_scope, super_scope),
 
                 (ty::ReScope(sub_scope), ty::ReFree(fr)) =>
-                    tcx.region_maps.is_subscope_of(sub_scope, fr.scope.to_code_extent()) ||
+                    tcx.region_maps.is_subscope_of(sub_scope,
+                                                   fr.scope.to_code_extent(&tcx.region_maps)) ||
                     self.is_static(fr),
 
                 (ty::ReFree(sub_fr), ty::ReFree(super_fr)) =>
@@ -177,4 +178,3 @@ fn lub() {
     map.relate_free_regions(frs[1], frs[2]);
     assert_eq!(map.lub_free_regions(frs[0], frs[1]), ty::ReFree(frs[2]));
 }
-

--- a/src/librustc/middle/free_region.rs
+++ b/src/librustc/middle/free_region.rs
@@ -162,8 +162,8 @@ impl FreeRegionMap {
 
 #[cfg(test)]
 fn free_region(index: u32) -> FreeRegion {
-    use middle::region::DestructionScopeData;
-    FreeRegion { scope: DestructionScopeData::new(0),
+    use middle::region::DUMMY_CODE_EXTENT;
+    FreeRegion { scope: DUMMY_CODE_EXTENT,
                  bound_region: ty::BoundRegion::BrAnon(index) }
 }
 

--- a/src/librustc/middle/infer/combine.rs
+++ b/src/librustc/middle/infer/combine.rs
@@ -340,14 +340,14 @@ impl<'cx, 'tcx> ty_fold::TypeFolder<'tcx> for Generalizer<'cx, 'tcx> {
 
             // Always make a fresh region variable for skolemized regions;
             // the higher-ranked decision procedures rely on this.
-            ty::ReInfer(ty::ReSkolemized(..)) => { }
+            ty::ReSkolemized(..) => { }
 
             // For anything else, we make a region variable, unless we
             // are *equating*, in which case it's just wasteful.
             ty::ReEmpty |
             ty::ReStatic |
             ty::ReScope(..) |
-            ty::ReInfer(ty::ReVar(..)) |
+            ty::ReVar(..) |
             ty::ReFree(..) => {
                 if !self.make_region_vars {
                     return r;

--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -172,7 +172,7 @@ impl<'tcx> ty::ctxt<'tcx> {
                     }
                 };
 
-                match self.map.find(fr.scope.node_id) {
+                match self.map.find(fr.scope.node_id(&self.region_maps)) {
                     Some(ast_map::NodeBlock(ref blk)) => {
                         let (msg, opt_span) = explain_span(self, "block", blk.span);
                         (format!("{} {}", prefix, msg), opt_span)
@@ -183,7 +183,8 @@ impl<'tcx> ty::ctxt<'tcx> {
                         (format!("{} {}", prefix, msg), opt_span)
                     }
                     Some(_) | None => {
-                        // this really should not happen
+                        // this really should not happen, but it does:
+                        // FIXME(#27942)
                         (format!("{} unknown free region bounded by scope {:?}",
                                  prefix, fr.scope), None)
                     }
@@ -422,7 +423,7 @@ impl<'a, 'tcx> ErrorReporting<'tcx> for InferCtxt<'a, 'tcx> {
                         return None
                     }
                     assert!(fr1.scope == fr2.scope);
-                    (fr1.scope.node_id, fr1, fr2)
+                    (fr1.scope.node_id(&tcx.region_maps), fr1, fr2)
                 },
                 _ => return None
             };

--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -196,9 +196,12 @@ impl<'tcx> ty::ctxt<'tcx> {
 
             ty::ReEarlyBound(ref data) => (data.name.to_string(), None),
 
-            // I believe these cases should not occur (except when debugging,
-            // perhaps)
-            ty::ReInfer(_) | ty::ReLateBound(..) => {
+            // FIXME(#13998) ReSkolemized should probably print like
+            // ReFree rather than dumping Debug output on the user.
+            //
+            // We shouldn't really be having unification failures with ReVar
+            // and ReLateBound through.
+            ty::ReSkolemized(..) | ty::ReVar(_) | ty::ReLateBound(..) => {
                 (format!("lifetime {:?}", region), None)
             }
         };

--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -201,7 +201,7 @@ impl<'tcx> ty::ctxt<'tcx> {
             // ReFree rather than dumping Debug output on the user.
             //
             // We shouldn't really be having unification failures with ReVar
-            // and ReLateBound through.
+            // and ReLateBound though.
             ty::ReSkolemized(..) | ty::ReVar(_) | ty::ReLateBound(..) => {
                 (format!("lifetime {:?}", region), None)
             }

--- a/src/librustc/middle/infer/freshen.rs
+++ b/src/librustc/middle/infer/freshen.rs
@@ -95,7 +95,8 @@ impl<'a, 'tcx> TypeFolder<'tcx> for TypeFreshener<'a, 'tcx> {
             ty::ReStatic |
             ty::ReFree(_) |
             ty::ReScope(_) |
-            ty::ReInfer(_) |
+            ty::ReVar(_) |
+            ty::ReSkolemized(..) |
             ty::ReEmpty => {
                 // replace all free regions with 'static
                 ty::ReStatic

--- a/src/librustc/middle/infer/higher_ranked/mod.rs
+++ b/src/librustc/middle/infer/higher_ranked/mod.rs
@@ -335,7 +335,7 @@ fn var_ids<'a, 'tcx>(fields: &CombineFields<'a, 'tcx>,
                      -> Vec<ty::RegionVid> {
     map.iter()
        .map(|(_, r)| match *r {
-           ty::ReInfer(ty::ReVar(r)) => { r }
+           ty::ReVar(r) => { r }
            r => {
                fields.tcx().sess.span_bug(
                    fields.trace.origin.span(),
@@ -347,7 +347,7 @@ fn var_ids<'a, 'tcx>(fields: &CombineFields<'a, 'tcx>,
 
 fn is_var_in_set(new_vars: &[ty::RegionVid], r: ty::Region) -> bool {
     match r {
-        ty::ReInfer(ty::ReVar(ref v)) => new_vars.iter().any(|x| x == v),
+        ty::ReVar(ref v) => new_vars.iter().any(|x| x == v),
         _ => false
     }
 }
@@ -443,7 +443,7 @@ impl<'a,'tcx> InferCtxtExt for InferCtxt<'a,'tcx> {
         }
 
         region_vars.retain(|&region_vid| {
-            let r = ty::ReInfer(ty::ReVar(region_vid));
+            let r = ty::ReVar(region_vid);
             !escaping_region_vars.contains(&r)
         });
 
@@ -561,7 +561,7 @@ pub fn leak_check<'a,'tcx>(infcx: &InferCtxt<'a,'tcx>,
             // Each skolemized should only be relatable to itself
             // or new variables:
             match tainted_region {
-                ty::ReInfer(ty::ReVar(vid)) => {
+                ty::ReVar(vid) => {
                     if new_vars.iter().any(|&x| x == vid) { continue; }
                 }
                 _ => {

--- a/src/librustc/middle/infer/mod.rs
+++ b/src/librustc/middle/infer/mod.rs
@@ -1059,7 +1059,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     }
 
     pub fn next_region_var(&self, origin: RegionVariableOrigin) -> ty::Region {
-        ty::ReInfer(ty::ReVar(self.region_vars.new_region_var(origin)))
+        ty::ReVar(self.region_vars.new_region_var(origin))
     }
 
     pub fn region_vars_for_defs(&self,

--- a/src/librustc/middle/infer/region_inference/mod.rs
+++ b/src/librustc/middle/infer/region_inference/mod.rs
@@ -790,7 +790,7 @@ impl<'a, 'tcx> RegionVarBindings<'a, 'tcx> {
             // A "free" region can be interpreted as "some region
             // at least as big as the block fr.scope_id".  So, we can
             // reasonably compare free regions and scopes:
-            let fr_scope = fr.scope.to_code_extent();
+            let fr_scope = fr.scope.to_code_extent(&self.tcx.region_maps);
             let r_id = self.tcx.region_maps.nearest_common_ancestor(fr_scope, s_id);
 
             if r_id == fr_scope {
@@ -871,7 +871,7 @@ impl<'a, 'tcx> RegionVarBindings<'a, 'tcx> {
                 // than the scope `s_id`, then we can say that the GLB
                 // is the scope `s_id`.  Otherwise, as we do not know
                 // big the free region is precisely, the GLB is undefined.
-                let fr_scope = fr.scope.to_code_extent();
+                let fr_scope = fr.scope.to_code_extent(&self.tcx.region_maps);
                 if self.tcx.region_maps.nearest_common_ancestor(fr_scope, s_id) == fr_scope ||
                         free_regions.is_static(fr) {
                     Ok(s)
@@ -927,8 +927,8 @@ impl<'a, 'tcx> RegionVarBindings<'a, 'tcx> {
                 Ok(ty::ReFree(*b))
             } else {
                 this.intersect_scopes(ty::ReFree(*a), ty::ReFree(*b),
-                                      a.scope.to_code_extent(),
-                                      b.scope.to_code_extent())
+                                      a.scope.to_code_extent(&this.tcx.region_maps),
+                                      b.scope.to_code_extent(&this.tcx.region_maps))
             }
         }
     }

--- a/src/librustc/middle/infer/region_inference/mod.rs
+++ b/src/librustc/middle/infer/region_inference/mod.rs
@@ -790,10 +790,9 @@ impl<'a, 'tcx> RegionVarBindings<'a, 'tcx> {
             // A "free" region can be interpreted as "some region
             // at least as big as the block fr.scope_id".  So, we can
             // reasonably compare free regions and scopes:
-            let fr_scope = fr.scope.to_code_extent(&self.tcx.region_maps);
-            let r_id = self.tcx.region_maps.nearest_common_ancestor(fr_scope, s_id);
+            let r_id = self.tcx.region_maps.nearest_common_ancestor(fr.scope, s_id);
 
-            if r_id == fr_scope {
+            if r_id == fr.scope {
               // if the free region's scope `fr.scope_id` is bigger than
               // the scope region `s_id`, then the LUB is the free
               // region itself:
@@ -871,8 +870,7 @@ impl<'a, 'tcx> RegionVarBindings<'a, 'tcx> {
                 // than the scope `s_id`, then we can say that the GLB
                 // is the scope `s_id`.  Otherwise, as we do not know
                 // big the free region is precisely, the GLB is undefined.
-                let fr_scope = fr.scope.to_code_extent(&self.tcx.region_maps);
-                if self.tcx.region_maps.nearest_common_ancestor(fr_scope, s_id) == fr_scope ||
+                if self.tcx.region_maps.nearest_common_ancestor(fr.scope, s_id) == fr.scope ||
                         free_regions.is_static(fr) {
                     Ok(s)
                 } else {
@@ -927,8 +925,7 @@ impl<'a, 'tcx> RegionVarBindings<'a, 'tcx> {
                 Ok(ty::ReFree(*b))
             } else {
                 this.intersect_scopes(ty::ReFree(*a), ty::ReFree(*b),
-                                      a.scope.to_code_extent(&this.tcx.region_maps),
-                                      b.scope.to_code_extent(&this.tcx.region_maps))
+                                      a.scope, b.scope)
             }
         }
     }

--- a/src/librustc/middle/infer/resolve.rs
+++ b/src/librustc/middle/infer/resolve.rs
@@ -106,7 +106,7 @@ impl<'a, 'tcx> ty_fold::TypeFolder<'tcx> for FullTypeResolver<'a, 'tcx> {
 
     fn fold_region(&mut self, r: ty::Region) -> ty::Region {
         match r {
-          ty::ReInfer(ty::ReVar(rid)) => self.infcx.region_vars.resolve_var(rid),
+          ty::ReVar(rid) => self.infcx.region_vars.resolve_var(rid),
           _ => r,
         }
     }

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -111,7 +111,6 @@ use self::VarKind::*;
 
 use middle::def::*;
 use middle::pat_util;
-use middle::region;
 use middle::ty;
 use lint;
 use util::nodemap::NodeMap;
@@ -1509,7 +1508,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
         // within the fn body, late-bound regions are liberated:
         let fn_ret =
             self.ir.tcx.liberate_late_bound_regions(
-                region::DestructionScopeData::new(body.id),
+                self.ir.tcx.region_maps.item_extent(body.id),
                 &self.fn_ret(id));
 
         match fn_ret {

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -77,7 +77,6 @@ use middle::def_id::DefId;
 use middle::infer;
 use middle::check_const;
 use middle::def;
-use middle::region;
 use middle::ty::{self, Ty};
 
 use syntax::ast::{MutImmutable, MutMutable};
@@ -749,7 +748,7 @@ impl<'t, 'a,'tcx> MemCategorizationContext<'t, 'a, 'tcx> {
             // The environment of a closure is guaranteed to
             // outlive any bindings introduced in the body of the
             // closure itself.
-            scope: region::DestructionScopeData::new(fn_body_id),
+            scope: self.tcx().region_maps.item_extent(fn_body_id),
             bound_region: ty::BrEnv
         });
 

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -144,7 +144,7 @@ impl DestructionScopeData {
          RustcDecodable, Debug, Copy)]
 pub struct BlockRemainder {
     pub block: ast::NodeId,
-    pub first_statement_index: usize,
+    pub first_statement_index: u32,
 }
 
 impl CodeExtent {
@@ -207,7 +207,7 @@ impl CodeExtent {
                         //
                         // (This is the special case aluded to in the
                         // doc-comment for this method)
-                        let stmt_span = blk.stmts[r.first_statement_index].span;
+                        let stmt_span = blk.stmts[r.first_statement_index as usize].span;
                         Some(Span { lo: stmt_span.hi, ..blk.span })
                     }
                 }
@@ -310,7 +310,7 @@ impl InnermostDeclaringBlock {
 struct DeclaringStatementContext {
     stmt_id: ast::NodeId,
     block_id: ast::NodeId,
-    stmt_index: usize,
+    stmt_index: u32,
 }
 
 impl DeclaringStatementContext {
@@ -711,7 +711,7 @@ fn resolve_block(visitor: &mut RegionResolutionVisitor, blk: &ast::Block) {
                 let declaring = DeclaringStatementContext {
                     stmt_id: stmt_id,
                     block_id: blk.id,
-                    stmt_index: i,
+                    stmt_index: i as u32,
                 };
                 record_superlifetime(
                     visitor, declaring.to_code_extent(), statement.span);

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -309,6 +309,13 @@ impl RegionMaps {
     pub fn lookup_code_extent(&self, e: CodeExtentData) -> CodeExtent {
         self.code_extent_interner.borrow()[&e]
     }
+    pub fn node_extent(&self, n: ast::NodeId) -> CodeExtent {
+        self.lookup_code_extent(CodeExtentData::Misc(n))
+    }
+    // Returns the code extent for an item - the destruction scope.
+    pub fn item_extent(&self, n: ast::NodeId) -> CodeExtent {
+        self.lookup_code_extent(CodeExtentData::DestructionScope(n))
+    }
     pub fn intern_code_extent(&self,
                               e: CodeExtentData,
                               parent: CodeExtent) -> CodeExtent {
@@ -349,9 +356,6 @@ impl RegionMaps {
                        n: ast::NodeId,
                        parent: CodeExtent) -> CodeExtent {
         self.intern_code_extent(CodeExtentData::Misc(n), parent)
-    }
-    pub fn node_extent(&self, n: ast::NodeId) -> CodeExtent {
-        self.lookup_code_extent(CodeExtentData::Misc(n))
     }
     pub fn code_extent_data(&self, e: CodeExtent) -> CodeExtentData {
         self.code_extents.borrow()[e.0 as usize]

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1503,7 +1503,7 @@ pub struct DebruijnIndex {
 }
 
 /// Representation of regions:
-#[derive(Clone, PartialEq, Eq, Hash, RustcEncodable, RustcDecodable, Copy)]
+#[derive(Clone, PartialEq, Eq, Hash, Copy)]
 pub enum Region {
     // Region bound in a type or fn declaration which will be
     // substituted 'early' -- that is, at the same time when type
@@ -1609,7 +1609,7 @@ pub enum BorrowKind {
 
 /// Information describing the capture of an upvar. This is computed
 /// during `typeck`, specifically by `regionck`.
-#[derive(PartialEq, Clone, RustcEncodable, RustcDecodable, Debug, Copy)]
+#[derive(PartialEq, Clone, Debug, Copy)]
 pub enum UpvarCapture {
     /// Upvar is captured by value. This is always true when the
     /// closure is labeled `move`, but can also be true in other cases
@@ -1620,7 +1620,7 @@ pub enum UpvarCapture {
     ByRef(UpvarBorrow),
 }
 
-#[derive(PartialEq, Clone, RustcEncodable, RustcDecodable, Copy)]
+#[derive(PartialEq, Clone, Copy)]
 pub struct UpvarBorrow {
     /// The kind of borrow: by-ref upvars have access to shared
     /// immutable borrows, which are not part of the normal language
@@ -2271,7 +2271,7 @@ pub struct TypeParameterDef<'tcx> {
     pub object_lifetime_default: ObjectLifetimeDefault,
 }
 
-#[derive(RustcEncodable, RustcDecodable, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct RegionParameterDef {
     pub name: ast::Name,
     pub def_id: DefId,
@@ -6673,7 +6673,8 @@ impl<'tcx> ctxt<'tcx> {
         let unnormalized_env = ty::ParameterEnvironment {
             tcx: self,
             free_substs: free_substs,
-            implicit_region_bound: ty::ReScope(free_id_outlive.to_code_extent()),
+            implicit_region_bound: ty::ReScope(
+                free_id_outlive.to_code_extent(&self.region_maps)),
             caller_bounds: predicates,
             selection_cache: traits::SelectionCache::new(),
             free_id: free_id,

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -13,7 +13,7 @@ use middle::def_id::DefId;
 use middle::subst::{self, Subst};
 use middle::ty::{BoundRegion, BrAnon, BrNamed};
 use middle::ty::{ReEarlyBound, BrFresh, ctxt};
-use middle::ty::{ReFree, ReScope, ReInfer, ReStatic, Region, ReEmpty};
+use middle::ty::{ReFree, ReScope, ReStatic, Region, ReEmpty};
 use middle::ty::{ReSkolemized, ReVar, BrEnv};
 use middle::ty::{TyBool, TyChar, TyStruct, TyEnum};
 use middle::ty::{TyError, TyStr, TyArray, TySlice, TyFloat, TyBareFn};
@@ -413,11 +413,11 @@ impl fmt::Debug for ty::Region {
 
             ty::ReStatic => write!(f, "ReStatic"),
 
-            ty::ReInfer(ReVar(ref vid)) => {
+            ty::ReVar(ref vid) => {
                 write!(f, "{:?}", vid)
             }
 
-            ty::ReInfer(ReSkolemized(id, ref bound_region)) => {
+            ty::ReSkolemized(id, ref bound_region) => {
                 write!(f, "ReSkolemized({}, {:?})", id, bound_region)
             }
 
@@ -442,11 +442,11 @@ impl fmt::Display for ty::Region {
             }
             ty::ReLateBound(_, br) |
             ty::ReFree(ty::FreeRegion { bound_region: br, .. }) |
-            ty::ReInfer(ReSkolemized(_, br)) => {
+            ty::ReSkolemized(_, br) => {
                 write!(f, "{}", br)
             }
             ty::ReScope(_) |
-            ty::ReInfer(ReVar(_)) => Ok(()),
+            ty::ReVar(_) => Ok(()),
             ty::ReStatic => write!(f, "'static"),
             ty::ReEmpty => write!(f, "'<empty>"),
         }

--- a/src/librustc_borrowck/borrowck/gather_loans/mod.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/mod.rs
@@ -44,7 +44,7 @@ pub fn gather_loans_in_fn<'a, 'tcx>(bccx: &BorrowckCtxt<'a, 'tcx>,
     let mut glcx = GatherLoanCtxt {
         bccx: bccx,
         all_loans: Vec::new(),
-        item_ub: region::CodeExtent::from_node_id(body.id),
+        item_ub: bccx.tcx.region_maps.node_extent(body.id),
         move_data: MoveData::new(),
         move_error_collector: move_error::MoveErrorCollector::new(),
     };
@@ -360,7 +360,9 @@ impl<'a, 'tcx> GatherLoanCtxt<'a, 'tcx> {
                 let loan_scope = match loan_region {
                     ty::ReScope(scope) => scope,
 
-                    ty::ReFree(ref fr) => fr.scope.to_code_extent(),
+                    ty::ReFree(ref fr) => {
+                        fr.scope.to_code_extent(&self.tcx().region_maps)
+                    }
 
                     ty::ReStatic => {
                         // If we get here, an error must have been
@@ -387,7 +389,7 @@ impl<'a, 'tcx> GatherLoanCtxt<'a, 'tcx> {
                 };
                 debug!("loan_scope = {:?}", loan_scope);
 
-                let borrow_scope = region::CodeExtent::from_node_id(borrow_id);
+                let borrow_scope = self.tcx().region_maps.node_extent(borrow_id);
                 let gen_scope = self.compute_gen_scope(borrow_scope, loan_scope);
                 debug!("gen_scope = {:?}", gen_scope);
 

--- a/src/librustc_borrowck/borrowck/gather_loans/mod.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/mod.rs
@@ -360,9 +360,7 @@ impl<'a, 'tcx> GatherLoanCtxt<'a, 'tcx> {
                 let loan_scope = match loan_region {
                     ty::ReScope(scope) => scope,
 
-                    ty::ReFree(ref fr) => {
-                        fr.scope.to_code_extent(&self.tcx().region_maps)
-                    }
+                    ty::ReFree(ref fr) => fr.scope,
 
                     ty::ReStatic => {
                         // If we get here, an error must have been

--- a/src/librustc_borrowck/borrowck/gather_loans/mod.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/mod.rs
@@ -377,7 +377,8 @@ impl<'a, 'tcx> GatherLoanCtxt<'a, 'tcx> {
                     ty::ReEmpty |
                     ty::ReLateBound(..) |
                     ty::ReEarlyBound(..) |
-                    ty::ReInfer(..) => {
+                    ty::ReVar(..) |
+                    ty::ReSkolemized(..) => {
                         self.tcx().sess.span_bug(
                             cmt.span,
                             &format!("invalid borrow lifetime: {:?}",

--- a/src/librustc_borrowck/borrowck/move_data.rs
+++ b/src/librustc_borrowck/borrowck/move_data.rs
@@ -494,7 +494,7 @@ impl<'tcx> MoveData<'tcx> {
                 LpVar(..) | LpUpvar(..) | LpDowncast(..) => {
                     let kill_scope = path.loan_path.kill_scope(tcx);
                     let path = *self.path_map.borrow().get(&path.loan_path).unwrap();
-                    self.kill_moves(path, kill_scope.node_id(),
+                    self.kill_moves(path, kill_scope.node_id(&tcx.region_maps),
                                     KillFrom::ScopeEnd, dfcx_moves);
                 }
                 LpExtend(..) => {}
@@ -509,7 +509,7 @@ impl<'tcx> MoveData<'tcx> {
                 LpVar(..) | LpUpvar(..) | LpDowncast(..) => {
                     let kill_scope = lp.kill_scope(tcx);
                     dfcx_assign.add_kill(KillFrom::ScopeEnd,
-                                         kill_scope.node_id(),
+                                         kill_scope.node_id(&tcx.region_maps),
                                          assignment_index);
                 }
                 LpExtend(..) => {

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -17,7 +17,7 @@ use rustc_lint;
 use rustc_resolve as resolve;
 use rustc_typeck::middle::lang_items;
 use rustc_typeck::middle::free_region::FreeRegionMap;
-use rustc_typeck::middle::region::{self, CodeExtent, DestructionScopeData};
+use rustc_typeck::middle::region::{self, CodeExtent};
 use rustc_typeck::middle::region::CodeExtentData;
 use rustc_typeck::middle::resolve_lifetime;
 use rustc_typeck::middle::stability;
@@ -329,8 +329,10 @@ impl<'a, 'tcx> Env<'a, 'tcx> {
     }
 
     pub fn re_free(&self, nid: ast::NodeId, id: u32) -> ty::Region {
-        ty::ReFree(ty::FreeRegion { scope: DestructionScopeData::new(nid),
-                                    bound_region: ty::BrAnon(id)})
+        ty::ReFree(ty::FreeRegion {
+            scope: self.tcx().region_maps.item_extent(nid),
+            bound_region: ty::BrAnon(id)
+        })
     }
 
     pub fn t_rptr_free(&self, nid: ast::NodeId, id: u32) -> Ty<'tcx> {

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -179,7 +179,7 @@ pub fn ast_region_to_region(tcx: &ty::ctxt, lifetime: &ast::Lifetime)
 
         Some(&rl::DefFreeRegion(scope, id)) => {
             ty::ReFree(ty::FreeRegion {
-                    scope: scope,
+                    scope: tcx.region_maps.item_extent(scope.node_id),
                     bound_region: ty::BrNamed(DefId::local(id),
                                               lifetime.name)
                 })

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -14,7 +14,6 @@ use super::{check_fn, Expectation, FnCtxt};
 
 use astconv;
 use middle::def_id::DefId;
-use middle::region;
 use middle::subst;
 use middle::ty::{self, ToPolyTraitRef, Ty};
 use std::cmp;
@@ -77,7 +76,7 @@ fn check_closure<'a,'tcx>(fcx: &FnCtxt<'a,'tcx>,
     fcx.write_ty(expr.id, closure_type);
 
     let fn_sig = fcx.tcx().liberate_late_bound_regions(
-        region::DestructionScopeData::new(body.id), &fn_ty.sig);
+        fcx.tcx().region_maps.item_extent(body.id), &fn_ty.sig);
 
     check_fn(fcx.ccx,
              ast::Unsafety::Normal,

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -91,7 +91,6 @@ use middle::infer;
 use middle::infer::type_variable;
 use middle::pat_util::{self, pat_id_map};
 use middle::privacy::{AllPublic, LastMod};
-use middle::region::{self};
 use middle::subst::{self, Subst, Substs, VecPerParamSpace, ParamSpace, TypeSpace};
 use middle::traits::{self, report_fulfillment_errors};
 use middle::ty::{FnSig, GenericPredicates, TypeScheme};
@@ -455,11 +454,11 @@ fn check_bare_fn<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
             let inh = Inherited::new(ccx.tcx, &tables, param_env);
 
             // Compute the fty from point of view of inside fn.
+            let fn_scope = ccx.tcx.region_maps.item_extent(body.id);
             let fn_sig =
                 fn_ty.sig.subst(ccx.tcx, &inh.infcx.parameter_environment.free_substs);
             let fn_sig =
-                ccx.tcx.liberate_late_bound_regions(region::DestructionScopeData::new(body.id),
-                                                    &fn_sig);
+                ccx.tcx.liberate_late_bound_regions(fn_scope, &fn_sig);
             let fn_sig =
                 inh.normalize_associated_types_in(body.span,
                                                   body.id,

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -428,7 +428,7 @@ impl<'a, 'tcx> Rcx<'a, 'tcx> {
                 debug!("implication: {:?}", implication);
                 match implication {
                     ImpliedBound::RegionSubRegion(ty::ReFree(free_a),
-                                                  ty::ReInfer(ty::ReVar(vid_b))) => {
+                                                  ty::ReVar(vid_b)) => {
                         self.fcx.inh.infcx.add_given(free_a, vid_b);
                     }
                     ImpliedBound::RegionSubParam(r_a, param_b) => {

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -294,7 +294,9 @@ impl<'a, 'tcx> Rcx<'a, 'tcx> {
 
         let old_body_id = self.set_body_id(body.id);
         self.relate_free_regions(&fn_sig[..], body.id, span);
-        link_fn_args(self, CodeExtent::from_node_id(body.id), &fn_decl.inputs[..]);
+        link_fn_args(self,
+                     self.tcx().region_maps.node_extent(body.id),
+                     &fn_decl.inputs[..]);
         self.visit_block(body);
         self.visit_region_obligations(body.id);
 
@@ -564,16 +566,14 @@ fn visit_expr(rcx: &mut Rcx, expr: &ast::Expr) {
     // No matter what, the type of each expression must outlive the
     // scope of that expression. This also guarantees basic WF.
     let expr_ty = rcx.resolve_node_type(expr.id);
-
+    // the region corresponding to this expression
+    let expr_region = ty::ReScope(rcx.tcx().region_maps.node_extent(expr.id));
     type_must_outlive(rcx, infer::ExprTypeIsNotInScope(expr_ty, expr.span),
-                      expr_ty, ty::ReScope(CodeExtent::from_node_id(expr.id)));
+                      expr_ty, expr_region);
 
     let method_call = MethodCall::expr(expr.id);
     let opt_method_callee = rcx.fcx.inh.tables.borrow().method_map.get(&method_call).cloned();
     let has_method_map = opt_method_callee.is_some();
-
-    // the region corresponding to this expression
-    let expr_region = ty::ReScope(CodeExtent::from_node_id(expr.id));
 
     // If we are calling a method (either explicitly or via an
     // overloaded operator), check that all of the types provided as
@@ -609,7 +609,7 @@ fn visit_expr(rcx: &mut Rcx, expr: &ast::Expr) {
                     // FIXME(#6268) remove to support nested method calls
                     type_of_node_must_outlive(
                         rcx, infer::AutoBorrow(expr.span),
-                        expr.id, ty::ReScope(CodeExtent::from_node_id(expr.id)));
+                        expr.id, expr_region);
                 }
             }
             /*
@@ -726,7 +726,7 @@ fn visit_expr(rcx: &mut Rcx, expr: &ast::Expr) {
                 type_must_outlive(rcx,
                                   infer::Operand(expr.span),
                                   ty,
-                                  ty::ReScope(CodeExtent::from_node_id(expr.id)));
+                                  expr_region);
             }
             visit::walk_expr(rcx, expr);
         }
@@ -756,7 +756,7 @@ fn visit_expr(rcx: &mut Rcx, expr: &ast::Expr) {
             };
             if let ty::TyRef(r_ptr, _) = base_ty.sty {
                 mk_subregion_due_to_dereference(
-                    rcx, expr.span, ty::ReScope(CodeExtent::from_node_id(expr.id)), *r_ptr);
+                    rcx, expr.span, expr_region, *r_ptr);
             }
 
             visit::walk_expr(rcx, expr);
@@ -789,8 +789,7 @@ fn visit_expr(rcx: &mut Rcx, expr: &ast::Expr) {
             //
             // FIXME(#6268) nested method calls requires that this rule change
             let ty0 = rcx.resolve_node_type(expr.id);
-            type_must_outlive(rcx, infer::AddrOf(expr.span),
-                              ty0, ty::ReScope(CodeExtent::from_node_id(expr.id)));
+            type_must_outlive(rcx, infer::AddrOf(expr.span), ty0, expr_region);
             visit::walk_expr(rcx, expr);
         }
 
@@ -919,7 +918,7 @@ fn constrain_call<'a, I: Iterator<Item=&'a ast::Expr>>(rcx: &mut Rcx,
     // call occurs.
     //
     // FIXME(#6268) to support nested method calls, should be callee_id
-    let callee_scope = CodeExtent::from_node_id(call_expr.id);
+    let callee_scope = rcx.tcx().region_maps.node_extent(call_expr.id);
     let callee_region = ty::ReScope(callee_scope);
 
     debug!("callee_region={:?}", callee_region);
@@ -966,7 +965,8 @@ fn constrain_autoderefs<'a, 'tcx>(rcx: &mut Rcx<'a, 'tcx>,
            derefs,
            derefd_ty);
 
-    let r_deref_expr = ty::ReScope(CodeExtent::from_node_id(deref_expr.id));
+    let s_deref_expr = rcx.tcx().region_maps.node_extent(deref_expr.id);
+    let r_deref_expr = ty::ReScope(s_deref_expr);
     for i in 0..derefs {
         let method_call = MethodCall::autoderef(deref_expr.id, i as u32);
         debug!("constrain_autoderefs: method_call={:?} (of {:?} total)", method_call, derefs);
@@ -1083,7 +1083,7 @@ fn constrain_index<'a, 'tcx>(rcx: &mut Rcx<'a, 'tcx>,
     debug!("constrain_index(index_expr=?, indexed_ty={}",
            rcx.fcx.infcx().ty_to_string(indexed_ty));
 
-    let r_index_expr = ty::ReScope(CodeExtent::from_node_id(index_expr.id));
+    let r_index_expr = ty::ReScope(rcx.tcx().region_maps.node_extent(index_expr.id));
     if let ty::TyRef(r_ptr, mt) = indexed_ty.sty {
         match mt.ty.sty {
             ty::TySlice(_) | ty::TyStr => {
@@ -1234,7 +1234,7 @@ fn link_autoref(rcx: &Rcx,
         }
 
         ty::AutoUnsafe(m) => {
-            let r = ty::ReScope(CodeExtent::from_node_id(expr.id));
+            let r = ty::ReScope(rcx.tcx().region_maps.node_extent(expr.id));
             link_region(rcx, expr.span, &r, ty::BorrowKind::from_mutbl(m), expr_cmt);
         }
     }

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -13,7 +13,6 @@ use check::{FnCtxt, Inherited, blank_fn_ctxt, regionck};
 use constrained_type_params::{identify_constrained_type_params, Parameter};
 use CrateCtxt;
 use middle::def_id::DefId;
-use middle::region::DestructionScopeData;
 use middle::subst::{self, TypeSpace, FnSpace, ParamSpace, SelfSpace};
 use middle::traits;
 use middle::ty::{self, Ty};
@@ -362,7 +361,7 @@ impl<'ccx, 'tcx> CheckTypeWellFormedVisitor<'ccx, 'tcx> {
     {
         let free_substs = &fcx.inh.infcx.parameter_environment.free_substs;
         let fty = fcx.instantiate_type_scheme(span, free_substs, fty);
-        let free_id_outlive = DestructionScopeData::new(free_id);
+        let free_id_outlive = fcx.tcx().region_maps.item_extent(free_id);
         let sig = fcx.tcx().liberate_late_bound_regions(free_id_outlive, &fty.sig);
 
         for &input_ty in &sig.inputs {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2311,7 +2311,7 @@ fn check_method_self_type<'a, 'tcx, RS:RegionScope>(
             _ => typ,
         };
 
-        let body_scope = region::DestructionScopeData::new(body_id);
+        let body_scope = tcx.region_maps.item_extent(body_id);
 
         // "Required type" comes from the trait definition. It may
         // contain late-bound regions from the method, but not the
@@ -2363,7 +2363,7 @@ fn check_method_self_type<'a, 'tcx, RS:RegionScope>(
 
     fn liberate_early_bound_regions<'tcx,T>(
         tcx: &ty::ctxt<'tcx>,
-        scope: region::DestructionScopeData,
+        scope: region::CodeExtent,
         value: &T)
         -> T
         where T : TypeFoldable<'tcx>

--- a/src/librustc_typeck/variance.rs
+++ b/src/librustc_typeck/variance.rs
@@ -1025,8 +1025,8 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
                 // methods or in fn types.
             }
 
-            ty::ReFree(..) | ty::ReScope(..) | ty::ReInfer(..) |
-            ty::ReEmpty => {
+            ty::ReFree(..) | ty::ReScope(..) | ty::ReVar(..) |
+            ty::ReSkolemized(..) | ty::ReEmpty => {
                 // We don't expect to see anything but 'static or bound
                 // regions when visiting member types or method types.
                 self.tcx()

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -772,7 +772,8 @@ impl Clean<Option<Lifetime>> for ty::Region {
             ty::ReLateBound(..) |
             ty::ReFree(..) |
             ty::ReScope(..) |
-            ty::ReInfer(..) |
+            ty::ReVar(..) |
+            ty::ReSkolemized(..) |
             ty::ReEmpty(..) => None
         }
     }


### PR DESCRIPTION
This increases regionck performance greatly - type-checking on
librustc decreased from 9.1s to 8.1s. Because of Amdahl's law,
total performance is improved only by about 1.5% (LLVM wizards,
this is your opportunity to shine!).

before:
576.91user 4.26system 7:42.36elapsed 125%CPU (0avgtext+0avgdata 1142192maxresident)k
after:
566.50user 4.84system 7:36.84elapsed 125%CPU (0avgtext+0avgdata 1124304maxresident)k

I am somewhat worried really need to find out why we have this Red Queen's
Race going on here. Originally I suspected it may be a problem from RFC1214's
warnings, but it seems to be an effect from other changes.

However, the increase seems to be mostly in LLVM's time, so I guess
it's the LLVM wizards' problem.

r? @nikomatsakis 
