### PR TITLE
Don't emit memcpy's for zero-sized types

### DIFF
--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -956,6 +956,11 @@ pub fn memcpy_ty<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                              t: Ty<'tcx>) {
     let _icx = push_ctxt("memcpy_ty");
     let ccx = bcx.ccx();
+
+    if type_is_zero_size(ccx, t) {
+        return;
+    }
+
     if t.is_structural() {
         let llty = type_of::type_of(ccx, t);
         let llsz = llsize_of(ccx, llty);


### PR DESCRIPTION
r? @eddyb 
