### PR TITLE
Fix undefined behavior in f64::sqrt

### DIFF
--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -454,7 +454,11 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn sqrt(self) -> f64 {
-        unsafe { intrinsics::sqrtf64(self) }
+        if self < 0.0 {
+            NAN
+        } else {
+            unsafe { intrinsics::sqrtf64(self) }
+        }
     }
 
     /// Returns `e^(self)`, (the exponential function).


### PR DESCRIPTION
This fixes a reappearance of bug #9987 introduced in
1ddee8070d3cb83609b1f71c29e3deda3d30fd51, which caused
f64::tests::test_sqrt_domain to fail (at least on some systems).
