### PR TITLE
Make iter::order functions into methods on Iterator

### DIFF
--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -22,7 +22,7 @@ use core::fmt::Debug;
 use core::hash::{Hash, Hasher};
 use core::iter::{Map, FromIterator};
 use core::ops::Index;
-use core::{iter, fmt, mem, usize};
+use core::{fmt, mem, usize};
 use Bound::{self, Included, Excluded, Unbounded};
 
 use borrow::Borrow;
@@ -915,7 +915,7 @@ impl<K: Eq, V: Eq> Eq for BTreeMap<K, V> {}
 impl<K: PartialOrd, V: PartialOrd> PartialOrd for BTreeMap<K, V> {
     #[inline]
     fn partial_cmp(&self, other: &BTreeMap<K, V>) -> Option<Ordering> {
-        iter::order::partial_cmp(self.iter(), other.iter())
+        self.iter().partial_cmp(other.iter())
     }
 }
 
@@ -923,7 +923,7 @@ impl<K: PartialOrd, V: PartialOrd> PartialOrd for BTreeMap<K, V> {
 impl<K: Ord, V: Ord> Ord for BTreeMap<K, V> {
     #[inline]
     fn cmp(&self, other: &BTreeMap<K, V>) -> Ordering {
-        iter::order::cmp(self.iter(), other.iter())
+        self.iter().cmp(other.iter())
     }
 }
 

--- a/src/libcollections/linked_list.rs
+++ b/src/libcollections/linked_list.rs
@@ -25,7 +25,7 @@ use alloc::boxed::Box;
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{Hasher, Hash};
-use core::iter::{self, FromIterator};
+use core::iter::FromIterator;
 use core::mem;
 use core::ptr;
 
@@ -917,12 +917,12 @@ impl<'a, T: 'a + Copy> Extend<&'a T> for LinkedList<T> {
 impl<A: PartialEq> PartialEq for LinkedList<A> {
     fn eq(&self, other: &LinkedList<A>) -> bool {
         self.len() == other.len() &&
-            iter::order::eq(self.iter(), other.iter())
+            self.iter().eq(other.iter())
     }
 
     fn ne(&self, other: &LinkedList<A>) -> bool {
         self.len() != other.len() ||
-            iter::order::ne(self.iter(), other.iter())
+            self.iter().ne(other.iter())
     }
 }
 
@@ -932,7 +932,7 @@ impl<A: Eq> Eq for LinkedList<A> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A: PartialOrd> PartialOrd for LinkedList<A> {
     fn partial_cmp(&self, other: &LinkedList<A>) -> Option<Ordering> {
-        iter::order::partial_cmp(self.iter(), other.iter())
+        self.iter().partial_cmp(other.iter())
     }
 }
 
@@ -940,7 +940,7 @@ impl<A: PartialOrd> PartialOrd for LinkedList<A> {
 impl<A: Ord> Ord for LinkedList<A> {
     #[inline]
     fn cmp(&self, other: &LinkedList<A>) -> Ordering {
-        iter::order::cmp(self.iter(), other.iter())
+        self.iter().cmp(other.iter())
     }
 }
 

--- a/src/libcollections/vec_deque.rs
+++ b/src/libcollections/vec_deque.rs
@@ -20,7 +20,7 @@
 
 use core::cmp::Ordering;
 use core::fmt;
-use core::iter::{self, repeat, FromIterator};
+use core::iter::{repeat, FromIterator};
 use core::ops::{Index, IndexMut};
 use core::ptr;
 use core::slice;
@@ -1676,7 +1676,7 @@ impl<A: Eq> Eq for VecDeque<A> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A: PartialOrd> PartialOrd for VecDeque<A> {
     fn partial_cmp(&self, other: &VecDeque<A>) -> Option<Ordering> {
-        iter::order::partial_cmp(self.iter(), other.iter())
+        self.iter().partial_cmp(other.iter())
     }
 }
 
@@ -1684,7 +1684,7 @@ impl<A: PartialOrd> PartialOrd for VecDeque<A> {
 impl<A: Ord> Ord for VecDeque<A> {
     #[inline]
     fn cmp(&self, other: &VecDeque<A>) -> Ordering {
-        iter::order::cmp(self.iter(), other.iter())
+        self.iter().cmp(other.iter())
     }
 }
 

--- a/src/libcore/num/flt2dec/bignum.rs
+++ b/src/libcore/num/flt2dec/bignum.rs
@@ -448,12 +448,10 @@ macro_rules! define_bignum {
         impl ::cmp::Ord for $name {
             fn cmp(&self, other: &$name) -> ::cmp::Ordering {
                 use cmp::max;
-                use iter::order;
-
                 let sz = max(self.size, other.size);
                 let lhs = self.base[..sz].iter().cloned().rev();
                 let rhs = other.base[..sz].iter().cloned().rev();
-                order::cmp(lhs, rhs)
+                lhs.cmp(rhs)
             }
         }
 

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -1557,7 +1557,7 @@ impl<T: Eq> Eq for [T] {}
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Ord> Ord for [T] {
     fn cmp(&self, other: &[T]) -> Ordering {
-        order::cmp(self.iter(), other.iter())
+        self.iter().cmp(other.iter())
     }
 }
 
@@ -1565,22 +1565,22 @@ impl<T: Ord> Ord for [T] {
 impl<T: PartialOrd> PartialOrd for [T] {
     #[inline]
     fn partial_cmp(&self, other: &[T]) -> Option<Ordering> {
-        order::partial_cmp(self.iter(), other.iter())
+        self.iter().partial_cmp(other.iter())
     }
     #[inline]
     fn lt(&self, other: &[T]) -> bool {
-        order::lt(self.iter(), other.iter())
+        self.iter().lt(other.iter())
     }
     #[inline]
     fn le(&self, other: &[T]) -> bool {
-        order::le(self.iter(), other.iter())
+        self.iter().le(other.iter())
     }
     #[inline]
     fn ge(&self, other: &[T]) -> bool {
-        order::ge(self.iter(), other.iter())
+        self.iter().ge(other.iter())
     }
     #[inline]
     fn gt(&self, other: &[T]) -> bool {
-        order::gt(self.iter(), other.iter())
+        self.iter().gt(other.iter())
     }
 }

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -882,7 +882,7 @@ impl<'a> DoubleEndedIterator for Components<'a> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> cmp::PartialEq for Components<'a> {
     fn eq(&self, other: &Components<'a>) -> bool {
-        iter::order::eq(self.clone(), other.clone())
+        Iterator::eq(self.clone(), other.clone())
     }
 }
 
@@ -892,14 +892,14 @@ impl<'a> cmp::Eq for Components<'a> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> cmp::PartialOrd for Components<'a> {
     fn partial_cmp(&self, other: &Components<'a>) -> Option<cmp::Ordering> {
-        iter::order::partial_cmp(self.clone(), other.clone())
+        Iterator::partial_cmp(self.clone(), other.clone())
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> cmp::Ord for Components<'a> {
     fn cmp(&self, other: &Components<'a>) -> cmp::Ordering {
-        iter::order::cmp(self.clone(), other.clone())
+        Iterator::cmp(self.clone(), other.clone())
     }
 }
 
@@ -1162,14 +1162,14 @@ impl cmp::Eq for PathBuf {}
 #[stable(feature = "rust1", since = "1.0.0")]
 impl cmp::PartialOrd for PathBuf {
     fn partial_cmp(&self, other: &PathBuf) -> Option<cmp::Ordering> {
-        self.components().partial_cmp(&other.components())
+        self.components().partial_cmp(other.components())
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl cmp::Ord for PathBuf {
     fn cmp(&self, other: &PathBuf) -> cmp::Ordering {
-        self.components().cmp(&other.components())
+        self.components().cmp(other.components())
     }
 }
 
@@ -1691,7 +1691,7 @@ impl<'a> fmt::Display for Display<'a> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl cmp::PartialEq for Path {
     fn eq(&self, other: &Path) -> bool {
-        iter::order::eq(self.components(), other.components())
+        self.components().eq(other.components())
     }
 }
 
@@ -1701,14 +1701,14 @@ impl cmp::Eq for Path {}
 #[stable(feature = "rust1", since = "1.0.0")]
 impl cmp::PartialOrd for Path {
     fn partial_cmp(&self, other: &Path) -> Option<cmp::Ordering> {
-        self.components().partial_cmp(&other.components())
+        self.components().partial_cmp(other.components())
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl cmp::Ord for Path {
     fn cmp(&self, other: &Path) -> cmp::Ordering {
-        self.components().cmp(&other.components())
+        self.components().cmp(other.components())
     }
 }
 


### PR DESCRIPTION
This does cause some breakage due to deficiencies in resolve -
`path::Components` is both an `Iterator` and implements `Eq`, `Ord`,
etc. If one calls e.g. `partial_cmp` on a `Components` and passes a
`&Components` intending to target the `PartialOrd` impl, the compiler
will select the `partial_cmp` from `Iterator` and then error out. I
doubt anyone will run into breakage from `Components` specifically, but
we should see if there are third party types that will run into issues.

`iter::order::equals` wasn't moved to `Iterator` since it's exactly the
same as `iter::order::eq` but with an `Eq` instead of `PartialEq` bound,
which doensn't seem very useful.

I also updated `le`, `gt`, etc to use `partial_cmp` which lets us drop
the extra `PartialEq` bound.

cc #27737 

r? @alexcrichton 
