### PR TITLE
Atomically set CLOEXEC on duplicated sockets

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -3614,6 +3614,7 @@ pub mod consts {
         pub mod posix08 {
             use types::os::arch::c95::c_int;
             pub const O_CLOEXEC: c_int = 0x80000;
+            pub const F_DUPFD_CLOEXEC: c_int = 1030;
         }
         #[cfg(any(target_arch = "arm",
                   target_arch = "aarch64",
@@ -4285,11 +4286,13 @@ pub mod consts {
         pub mod posix08 {
             use types::os::arch::c95::c_int;
             pub const O_CLOEXEC: c_int = 0x100000;
+            pub const F_DUPFD_CLOEXEC: c_int = 17;
         }
         #[cfg(target_os = "dragonfly")]
         pub mod posix08 {
             use types::os::arch::c95::c_int;
             pub const O_CLOEXEC: c_int = 0x20000;
+            pub const F_DUPFD_CLOEXEC: c_int = 17;
         }
         pub mod bsd44 {
             use types::os::arch::c95::c_int;
@@ -4657,7 +4660,6 @@ pub mod consts {
             pub const F_GETLK : c_int = 7;
             pub const F_SETLK : c_int = 8;
             pub const F_SETLKW : c_int = 9;
-            pub const F_DUPFD_CLOEXEC : c_int = 10;
 
             pub const SIGTRAP : c_int = 5;
             pub const SIG_IGN: size_t = 1;
@@ -4739,11 +4741,13 @@ pub mod consts {
         pub mod posix08 {
             use types::os::arch::c95::c_int;
             pub const O_CLOEXEC: c_int = 0x10000;
+            pub const F_DUPFD_CLOEXEC: c_int = 10;
         }
         #[cfg(target_os = "netbsd")]
         pub mod posix08 {
             use types::os::arch::c95::c_int;
             pub const O_CLOEXEC: c_int = 0x400000;
+            pub const F_DUPFD_CLOEXEC: c_int = 12;
         }
         pub mod bsd44 {
             use types::os::arch::c95::c_int;
@@ -5186,6 +5190,7 @@ pub mod consts {
         pub mod posix08 {
             use types::os::arch::c95::c_int;
             pub const O_CLOEXEC: c_int = 0x1000000;
+            pub const F_DUPFD_CLOEXEC: c_int = 67;
         }
         pub mod bsd44 {
             use types::os::arch::c95::c_int;


### PR DESCRIPTION
Still needs values of F_DUPFD_CLOEXEC on other OSs.

For Bitrig, NetBSD and OpenBSD the constant was incorrectly in posix01, when
it's actually posix08. In order to maintain backwards-compatiblity, the
constant was only copied, not moved.

cc #24237
