### PR TITLE
Respect `--color` when printing early errors

### DIFF
--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -43,6 +43,7 @@ use syntax::codemap::Span;
 use syntax::visit::{Visitor, FnKind};
 use syntax::parse::token::InternedString;
 use syntax::{ast, ast_util, visit};
+use syntax::diagnostic;
 
 /// Information about the registered lints.
 ///
@@ -141,7 +142,7 @@ impl LintStore {
                 match (sess, from_plugin) {
                     // We load builtin lints first, so a duplicate is a compiler bug.
                     // Use early_error when handling -W help with no crate.
-                    (None, _) => early_error(&msg[..]),
+                    (None, _) => early_error(diagnostic::Auto, &msg[..]),
                     (Some(sess), false) => sess.bug(&msg[..]),
 
                     // A duplicate name from a plugin is a user error.
@@ -166,7 +167,7 @@ impl LintStore {
             match (sess, from_plugin) {
                 // We load builtin lints first, so a duplicate is a compiler bug.
                 // Use early_error when handling -W help with no crate.
-                (None, _) => early_error(&msg[..]),
+                (None, _) => early_error(diagnostic::Auto, &msg[..]),
                 (Some(sess), false) => sess.bug(&msg[..]),
 
                 // A duplicate name from a plugin is a user error.

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -473,13 +473,13 @@ pub fn expect<T, M>(sess: &Session, opt: Option<T>, msg: M) -> T where
     diagnostic::expect(sess.diagnostic(), opt, msg)
 }
 
-pub fn early_error(msg: &str) -> ! {
-    let mut emitter = diagnostic::EmitterWriter::stderr(diagnostic::Auto, None);
+pub fn early_error(color: diagnostic::ColorConfig, msg: &str) -> ! {
+    let mut emitter = diagnostic::EmitterWriter::stderr(color, None);
     emitter.emit(None, msg, None, diagnostic::Fatal);
     panic!(diagnostic::FatalError);
 }
 
-pub fn early_warn(msg: &str) {
-    let mut emitter = diagnostic::EmitterWriter::stderr(diagnostic::Auto, None);
+pub fn early_warn(color: diagnostic::ColorConfig, msg: &str) {
+    let mut emitter = diagnostic::EmitterWriter::stderr(color, None);
     emitter.emit(None, msg, None, diagnostic::Warning);
 }

--- a/src/librustc/session/search_paths.rs
+++ b/src/librustc/session/search_paths.rs
@@ -11,6 +11,7 @@
 use std::slice;
 use std::path::{Path, PathBuf};
 use session::early_error;
+use syntax::diagnostic;
 
 #[derive(Clone, Debug)]
 pub struct SearchPaths {
@@ -37,7 +38,7 @@ impl SearchPaths {
         SearchPaths { paths: Vec::new() }
     }
 
-    pub fn add_path(&mut self, path: &str) {
+    pub fn add_path(&mut self, path: &str, color: diagnostic::ColorConfig) {
         let (kind, path) = if path.starts_with("native=") {
             (PathKind::Native, &path["native=".len()..])
         } else if path.starts_with("crate=") {
@@ -52,7 +53,7 @@ impl SearchPaths {
             (PathKind::All, path)
         };
         if path.is_empty() {
-            early_error("empty search path given via `-L`");
+            early_error(color, "empty search path given via `-L`");
         }
         self.paths.push((kind, PathBuf::from(path)));
     }

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -65,6 +65,7 @@ use externalfiles::ExternalHtml;
 use serialize::Decodable;
 use serialize::json::{self, Json};
 use rustc::session::search_paths::SearchPaths;
+use syntax::diagnostic;
 
 // reexported from `clean` so it can be easily updated with the mod itself
 pub use clean::SCHEMA_VERSION;
@@ -227,7 +228,7 @@ pub fn main_args(args: &[String]) -> isize {
 
     let mut libs = SearchPaths::new();
     for s in &matches.opt_strs("L") {
-        libs.add_path(s);
+        libs.add_path(s, diagnostic::Auto);
     }
     let externs = match parse_externs(&matches) {
         Ok(ex) => ex,
@@ -362,7 +363,7 @@ fn rust_input(cratefile: &str, externs: core::Externs, matches: &getopts::Matche
     // First, parse the crate and extract all relevant information.
     let mut paths = SearchPaths::new();
     for s in &matches.opt_strs("L") {
-        paths.add_path(s);
+        paths.add_path(s, diagnostic::Auto);
     }
     let cfgs = matches.opt_strs("cfg");
     let triple = matches.opt_str("target");

--- a/src/test/run-pass-fulldeps/compiler-calls.rs
+++ b/src/test/run-pass-fulldeps/compiler-calls.rs
@@ -23,7 +23,7 @@ extern crate syntax;
 use rustc::session::Session;
 use rustc::session::config::{self, Input};
 use rustc_driver::{driver, CompilerCalls, Compilation};
-use syntax::diagnostics;
+use syntax::{diagnostics, diagnostic};
 
 use std::path::PathBuf;
 
@@ -34,7 +34,8 @@ struct TestCalls {
 impl<'a> CompilerCalls<'a> for TestCalls {
     fn early_callback(&mut self,
                       _: &getopts::Matches,
-                      _: &diagnostics::registry::Registry)
+                      _: &diagnostics::registry::Registry,
+                      _: diagnostic::ColorConfig)
                       -> Compilation {
         self.count *= 2;
         Compilation::Continue


### PR DESCRIPTION
Currently, `early_error` and `early_warn` in `librustc::session` always use `ColorConfig::Auto`. Modify them to follow the color configuration set by the `--color` option.

As colored output is also printed during the early stage, parsing the `--color` option should be done as early as possible. However, there are still some cases when the output needs to be colored before knowing the exact color settings. In these cases, it will be defaulted to `ColorConfig::Auto`, which is the same as before.

Fixes #27879.
