### PR TITLE
Simplify `String`’s `Extend<&str>` implementation

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -813,11 +813,7 @@ impl<'a> Extend<&'a char> for String {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> Extend<&'a str> for String {
     fn extend<I: IntoIterator<Item=&'a str>>(&mut self, iterable: I) {
-        let iterator = iterable.into_iter();
-        // A guess that at least one byte per iterator element will be needed.
-        let (lower_bound, _) = iterator.size_hint();
-        self.reserve(lower_bound);
-        for s in iterator {
+        for s in iterable {
             self.push_str(s)
         }
     }


### PR DESCRIPTION
Reserving lower_bound bytes was just silly. It’d be perfectly reasonable
to have empty strings in the iterator, which could cause superfluous
reallocation of the string, or to have more than one byte per string,
which could cause additional reallocation (in practice it’ll balance
out). The added complexity of this logic is simply pointless, adding
a little bloat with no demonstrable advantage and slight disadvantage.
