### PR TITLE
Improve --test interaction with entry points

### DIFF
--- a/src/libsyntax/entry.rs
+++ b/src/libsyntax/entry.rs
@@ -1,0 +1,42 @@
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use attr;
+use ast::{Item, ItemFn};
+
+pub enum EntryPointType {
+    None,
+    MainNamed,
+    MainAttr,
+    Start,
+    OtherMain, // Not an entry point, but some other function named main
+}
+
+pub fn entry_point_type(item: &Item, depth: usize) -> EntryPointType {
+    match item.node {
+        ItemFn(..) => {
+            if attr::contains_name(&item.attrs, "start") {
+                EntryPointType::Start
+            } else if attr::contains_name(&item.attrs, "main") {
+                EntryPointType::MainAttr
+            } else if item.ident.name == "main" {
+                if depth == 1 {
+                    // This is a top-level function so can be 'main'
+                    EntryPointType::MainNamed
+                } else {
+                    EntryPointType::OtherMain
+                }
+            } else {
+                EntryPointType::None
+            }
+        }
+        _ => EntryPointType::None,
+    }
+}

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -90,6 +90,7 @@ pub mod attr;
 pub mod codemap;
 pub mod config;
 pub mod diagnostic;
+pub mod entry;
 pub mod feature_gate;
 pub mod fold;
 pub mod owned_slice;

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -175,45 +175,6 @@ impl<'a> fold::Folder for TestHarnessGenerator<'a> {
         let tests = mem::replace(&mut self.tests, tests);
         let tested_submods = mem::replace(&mut self.tested_submods, tested_submods);
 
-        // Remove any #[main] from the AST so it doesn't clash with
-        // the one we're going to add. Only if compiling an executable.
-
-        mod_folded.items = mem::replace(&mut mod_folded.items, vec![]).move_map(|item| {
-            match entry::entry_point_type(&item, self.cx.path.len() + 1) {
-                EntryPointType::MainNamed |
-                EntryPointType::MainAttr |
-                EntryPointType::Start =>
-                    item.map(|ast::Item {id, ident, attrs, node, vis, span}| {
-                        let allow_str = InternedString::new("allow");
-                        let dead_code_str = InternedString::new("dead_code");
-                        let allow_dead_code_item =
-                            attr::mk_list_item(allow_str,
-                                               vec![attr::mk_word_item(dead_code_str)]);
-                        let allow_dead_code = attr::mk_attr_outer(attr::mk_attr_id(),
-                                                                  allow_dead_code_item);
-
-                        ast::Item {
-                            id: id,
-                            ident: ident,
-                            attrs: attrs.into_iter().filter_map(|attr| {
-                                if !attr.check_name("main") {
-                                    Some(attr)
-                                } else {
-                                    None
-                                }
-                            })
-                                .chain(iter::once(allow_dead_code))
-                                .collect(),
-                            node: node,
-                            vis: vis,
-                            span: span
-                        }
-                    }),
-                EntryPointType::None |
-                EntryPointType::OtherMain => item,
-            }
-        });
-
         if !tests.is_empty() || !tested_submods.is_empty() {
             let (it, sym) = mk_reexport_mod(&mut self.cx, tests, tested_submods);
             mod_folded.items.push(it);
@@ -227,6 +188,58 @@ impl<'a> fold::Folder for TestHarnessGenerator<'a> {
         }
 
         mod_folded
+    }
+}
+
+struct EntryPointCleaner {
+    // Current depth in the ast
+    depth: usize,
+}
+
+impl fold::Folder for EntryPointCleaner {
+    fn fold_item(&mut self, i: P<ast::Item>) -> SmallVector<P<ast::Item>> {
+        self.depth += 1;
+        let folded = fold::noop_fold_item(i, self).expect_one("noop did something");
+        self.depth -= 1;
+
+        // Remove any #[main] from the AST so it doesn't clash with
+        // the one we're going to add, but mark it as
+        // #[allow(dead_code)] to avoid printing warnings.
+        let folded = match entry::entry_point_type(&*folded, self.depth) {
+            EntryPointType::MainNamed |
+            EntryPointType::MainAttr |
+            EntryPointType::Start =>
+                folded.map(|ast::Item {id, ident, attrs, node, vis, span}| {
+                    let allow_str = InternedString::new("allow");
+                    let dead_code_str = InternedString::new("dead_code");
+                    let allow_dead_code_item =
+                        attr::mk_list_item(allow_str,
+                                           vec![attr::mk_word_item(dead_code_str)]);
+                    let allow_dead_code = attr::mk_attr_outer(attr::mk_attr_id(),
+                                                              allow_dead_code_item);
+
+                    ast::Item {
+                        id: id,
+                        ident: ident,
+                        attrs: attrs.into_iter().filter_map(|attr| {
+                            if !attr.check_name("main") {
+                                Some(attr)
+                            } else {
+                                None
+                            }
+                        })
+                            .chain(iter::once(allow_dead_code))
+                            .collect(),
+                        node: node,
+                        vis: vis,
+                        span: span
+                    }
+                }),
+            EntryPointType::None |
+            EntryPointType::OtherMain => folded,
+        };
+
+        SmallVector::one(folded)
     }
 }
 
@@ -265,6 +278,10 @@ fn generate_test_harness(sess: &ParseSess,
                          krate: ast::Crate,
                          cfg: &ast::CrateConfig,
                          sd: &diagnostic::SpanHandler) -> ast::Crate {
+    // Remove the entry points
+    let mut cleaner = EntryPointCleaner { depth: 0 };
+    let krate = cleaner.fold_crate(krate);
+
     let mut feature_gated_cfgs = vec![];
     let mut cx: TestCtxt = TestCtxt {
         sess: sess,

--- a/src/test/compile-fail/test-warns-dead-code.rs
+++ b/src/test/compile-fail/test-warns-dead-code.rs
@@ -1,0 +1,17 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --test
+
+#![deny(dead_code)]
+
+fn dead() {} //~ error: function is never used: `dead`
+
+fn main() {}

--- a/src/test/run-pass/test-main-not-dead-attr.rs
+++ b/src/test/run-pass/test-main-not-dead-attr.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --test
+
+#![feature(main)]
+
+#![deny(dead_code)]
+
+#[main]
+fn foo() { panic!(); }

--- a/src/test/run-pass/test-main-not-dead.rs
+++ b/src/test/run-pass/test-main-not-dead.rs
@@ -1,0 +1,15 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --test
+
+#![deny(dead_code)]
+
+fn main() { panic!(); }

--- a/src/test/run-pass/test-runner-hides-buried-main.rs
+++ b/src/test/run-pass/test-runner-hides-buried-main.rs
@@ -1,0 +1,24 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --test
+
+#![feature(main)]
+
+#![allow(dead_code)]
+
+mod a {
+    fn b() {
+        || {
+            #[main]
+            fn c() { panic!(); }
+        };
+    }
+}

--- a/src/test/run-pass/test-runner-hides-start.rs
+++ b/src/test/run-pass/test-runner-hides-start.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --test
+
+#![feature(start)]
+
+#[start]
+fn start(_: isize, _: *const *const u8) -> isize { panic!(); }


### PR DESCRIPTION
- Suppresses warnings that main is unused when testing (Closes #12327)
- Makes `--test` work with explicit `#[start]` (Closes #11766)
- Fixes some cases where the normal main would not be disabled by `--test`, resulting in compilation failures.
