### PR TITLE
Improve handling of lifetime intrinsics once more

### DIFF
--- a/src/librustc_trans/trans/_match.rs
+++ b/src/librustc_trans/trans/_match.rs
@@ -1196,8 +1196,7 @@ fn compile_submatch_continue<'a, 'p, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
                 let unsized_ty = def.struct_variant().fields.last().map(|field| {
                     monomorphize::field_ty(bcx.tcx(), substs, field)
                 }).unwrap();
-                let llty = type_of::type_of(bcx.ccx(), unsized_ty);
-                let scratch = alloca(bcx, llty, "__struct_field_fat_ptr");
+                let scratch = alloc_ty(bcx, unsized_ty, "__struct_field_fat_ptr");
                 let data = adt::trans_field_ptr(bcx, &*repr, struct_val, 0, arg_count);
                 let len = Load(bcx, expr::get_meta(bcx, val.val));
                 Store(bcx, data, expr::get_dataptr(bcx, scratch));

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -1025,12 +1025,6 @@ pub fn alloc_ty<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, t: Ty<'tcx>, name: &str) -> 
 }
 
 pub fn alloca(cx: Block, ty: Type, name: &str) -> ValueRef {
-    let p = alloca_no_lifetime(cx, ty, name);
-    call_lifetime_start(cx, p);
-    p
-}
-
-pub fn alloca_no_lifetime(cx: Block, ty: Type, name: &str) -> ValueRef {
     let _icx = push_ctxt("alloca");
     if cx.unreachable.get() {
         unsafe {
@@ -1742,7 +1736,9 @@ pub fn trans_named_tuple_constructor<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         expr::SaveIn(d) => d,
         expr::Ignore => {
             if !type_is_zero_size(ccx, result_ty) {
-                alloc_ty(bcx, result_ty, "constructor_result")
+                let llresult = alloc_ty(bcx, result_ty, "constructor_result");
+                call_lifetime_start(bcx, llresult);
+                llresult
             } else {
                 C_undef(type_of::type_of(ccx, result_ty).ptr_to())
             }

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -1020,8 +1020,7 @@ pub fn alloc_ty<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, t: Ty<'tcx>, name: &str) -> 
     let ccx = bcx.ccx();
     let ty = type_of::type_of(ccx, t);
     assert!(!t.has_param_types());
-    let val = alloca(bcx, ty, name);
-    return val;
+    alloca(bcx, ty, name)
 }
 
 pub fn alloca(cx: Block, ty: Type, name: &str) -> ValueRef {

--- a/src/librustc_trans/trans/callee.rs
+++ b/src/librustc_trans/trans/callee.rs
@@ -725,7 +725,9 @@ pub fn trans_call_inner<'a, 'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
                     let llty = type_of::type_of(ccx, ret_ty);
                     Some(common::C_undef(llty.ptr_to()))
                 } else {
-                    Some(alloc_ty(bcx, ret_ty, "__llret"))
+                    let llresult = alloc_ty(bcx, ret_ty, "__llret");
+                    call_lifetime_start(bcx, llresult);
+                    Some(llresult)
                 }
             } else {
                 None

--- a/src/librustc_trans/trans/cleanup.rs
+++ b/src/librustc_trans/trans/cleanup.rs
@@ -883,6 +883,7 @@ impl<'blk, 'tcx> CleanupHelperMethods<'blk, 'tcx> for FunctionContext<'blk, 'tcx
             }
             None => {
                 let addr = base::alloca(pad_bcx, common::val_ty(llretval), "");
+                base::call_lifetime_start(pad_bcx, addr);
                 self.personality.set(Some(addr));
                 build::Store(pad_bcx, llretval, addr);
             }

--- a/src/librustc_trans/trans/cleanup.rs
+++ b/src/librustc_trans/trans/cleanup.rs
@@ -730,8 +730,9 @@ impl<'blk, 'tcx> CleanupHelperMethods<'blk, 'tcx> for FunctionContext<'blk, 'tcx
                         let prev_bcx = self.new_block(true, "resume", None);
                         let personality = self.personality.get().expect(
                             "create_landing_pad() should have set this");
-                        build::Resume(prev_bcx,
-                                      build::Load(prev_bcx, personality));
+                        let lp = build::Load(prev_bcx, personality);
+                        base::call_lifetime_end(prev_bcx, personality);
+                        build::Resume(prev_bcx, lp);
                         prev_llbb = prev_bcx.llbb;
                         break;
                     }

--- a/src/librustc_trans/trans/common.rs
+++ b/src/librustc_trans/trans/common.rs
@@ -504,7 +504,7 @@ impl<'a, 'tcx> FunctionContext<'a, 'tcx> {
                         output: ty::FnOutput<'tcx>,
                         name: &str) -> ValueRef {
         if self.needs_ret_allocas {
-            base::alloca_no_lifetime(bcx, match output {
+            base::alloca(bcx, match output {
                 ty::FnConverging(output_type) => type_of::type_of(bcx.ccx(), output_type),
                 ty::FnDiverging => Type::void(bcx.ccx())
             }, name)

--- a/src/librustc_trans/trans/datum.rs
+++ b/src/librustc_trans/trans/datum.rs
@@ -306,6 +306,7 @@ pub fn lvalue_scratch_datum<'blk, 'tcx, A, F>(bcx: Block<'blk, 'tcx>,
     let scratch = alloca(bcx, llty, name);
 
     // Subtle. Populate the scratch memory *before* scheduling cleanup.
+    call_lifetime_start(bcx, scratch);
     let bcx = populate(arg, bcx, scratch);
     bcx.fcx.schedule_lifetime_end(scope, scratch);
     bcx.fcx.schedule_drop_mem(scope, scratch, ty, None);
@@ -324,6 +325,7 @@ pub fn rvalue_scratch_datum<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                         -> Datum<'tcx, Rvalue> {
     let llty = type_of::type_of(bcx.ccx(), ty);
     let scratch = alloca(bcx, llty, name);
+    call_lifetime_start(bcx, scratch);
     Datum::new(scratch, ty, Rvalue::new(ByRef))
 }
 

--- a/src/librustc_trans/trans/datum.rs
+++ b/src/librustc_trans/trans/datum.rs
@@ -101,7 +101,6 @@ use trans::cleanup;
 use trans::cleanup::{CleanupMethods, DropHintDatum, DropHintMethods};
 use trans::expr;
 use trans::tvec;
-use trans::type_of;
 use middle::ty::Ty;
 
 use std::fmt;
@@ -302,8 +301,7 @@ pub fn lvalue_scratch_datum<'blk, 'tcx, A, F>(bcx: Block<'blk, 'tcx>,
                                               -> DatumBlock<'blk, 'tcx, Lvalue> where
     F: FnOnce(A, Block<'blk, 'tcx>, ValueRef) -> Block<'blk, 'tcx>,
 {
-    let llty = type_of::type_of(bcx.ccx(), ty);
-    let scratch = alloca(bcx, llty, name);
+    let scratch = alloc_ty(bcx, ty, name);
 
     // Subtle. Populate the scratch memory *before* scheduling cleanup.
     call_lifetime_start(bcx, scratch);
@@ -323,8 +321,7 @@ pub fn rvalue_scratch_datum<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                         ty: Ty<'tcx>,
                                         name: &str)
                                         -> Datum<'tcx, Rvalue> {
-    let llty = type_of::type_of(bcx.ccx(), ty);
-    let scratch = alloca(bcx, llty, name);
+    let scratch = alloc_ty(bcx, ty, name);
     call_lifetime_start(bcx, scratch);
     Datum::new(scratch, ty, Rvalue::new(ByRef))
 }

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -246,8 +246,7 @@ pub fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             // Maybe just get the value directly, instead of loading it?
             immediate_rvalue(load_ty(bcx, global, const_ty), const_ty)
         } else {
-            let llty = type_of::type_of(bcx.ccx(), const_ty);
-            let scratch = alloca(bcx, llty, "const");
+            let scratch = alloc_ty(bcx, const_ty, "const");
             call_lifetime_start(bcx, scratch);
             let lldest = if !const_ty.is_structural() {
                 // Cast pointer to slot, because constants have different types.
@@ -410,9 +409,8 @@ fn apply_adjustments<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                     datum.to_rvalue_datum(bcx, "__coerce_source"));
 
                 let target = bcx.monomorphize(&target);
-                let llty = type_of::type_of(bcx.ccx(), target);
 
-                let scratch = alloca(bcx, llty, "__coerce_target");
+                let scratch = alloc_ty(bcx, target, "__coerce_target");
                 call_lifetime_start(bcx, scratch);
                 let target_datum = Datum::new(scratch, target,
                                               Rvalue::new(ByRef));

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -247,8 +247,7 @@ pub fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             immediate_rvalue(load_ty(bcx, global, const_ty), const_ty)
         } else {
             let llty = type_of::type_of(bcx.ccx(), const_ty);
-            // HACK(eddyb) get around issues with lifetime intrinsics.
-            let scratch = alloca_no_lifetime(bcx, llty, "const");
+            let scratch = alloca(bcx, llty, "const");
             let lldest = if !const_ty.is_structural() {
                 // Cast pointer to slot, because constants have different types.
                 PointerCast(bcx, scratch, val_ty(global))
@@ -412,8 +411,7 @@ fn apply_adjustments<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                 let target = bcx.monomorphize(&target);
                 let llty = type_of::type_of(bcx.ccx(), target);
 
-                // HACK(eddyb) get around issues with lifetime intrinsics.
-                let scratch = alloca_no_lifetime(bcx, llty, "__coerce_target");
+                let scratch = alloca(bcx, llty, "__coerce_target");
                 let target_datum = Datum::new(scratch, target,
                                               Rvalue::new(ByRef));
                 bcx = coerce_unsized(bcx, expr.span, source_datum, target_datum);

--- a/src/librustc_trans/trans/foreign.rs
+++ b/src/librustc_trans/trans/foreign.rs
@@ -432,6 +432,7 @@ pub fn trans_native_call<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             // - Truncating foreign type to correct integral type and then
             //   bitcasting to the struct type yields invalid cast errors.
             let llscratch = base::alloca(bcx, llforeign_ret_ty, "__cast");
+            base::call_lifetime_start(bcx, llscratch);
             Store(bcx, llforeign_retval, llscratch);
             let llscratch_i8 = BitCast(bcx, llscratch, Type::i8(ccx).ptr_to());
             let llretptr_i8 = BitCast(bcx, llretptr, Type::i8(ccx).ptr_to());
@@ -442,6 +443,7 @@ pub fn trans_native_call<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             debug!("llrust_size={}", llrust_size);
             base::call_memcpy(bcx, llretptr_i8, llscratch_i8,
                               C_uint(ccx, llrust_size), llalign as u32);
+            base::call_lifetime_end(bcx, llscratch);
         }
     }
 

--- a/src/librustc_trans/trans/foreign.rs
+++ b/src/librustc_trans/trans/foreign.rs
@@ -296,10 +296,7 @@ pub fn trans_native_call<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         // Ensure that we always have the Rust value indirectly,
         // because it makes bitcasting easier.
         if !rust_indirect {
-            let scratch =
-                base::alloca(bcx,
-                             type_of::type_of(ccx, passed_arg_tys[i]),
-                             "__arg");
+            let scratch = base::alloc_ty(bcx, passed_arg_tys[i], "__arg");
             if type_is_fat_ptr(ccx.tcx(), passed_arg_tys[i]) {
                 Store(bcx, llargs_rust[i + offset], expr::get_dataptr(bcx, scratch));
                 Store(bcx, llargs_rust[i + offset + 1], expr::get_meta(bcx, scratch));

--- a/src/librustc_trans/trans/glue.rs
+++ b/src/librustc_trans/trans/glue.rs
@@ -190,7 +190,9 @@ pub fn drop_ty_immediate<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let vp = alloca(bcx, type_of(bcx.ccx(), t), "");
     call_lifetime_start(bcx, vp);
     store_ty(bcx, v, vp, t);
-    drop_ty_core(bcx, vp, t, debug_loc, skip_dtor, None)
+    let bcx = drop_ty_core(bcx, vp, t, debug_loc, skip_dtor, None);
+    call_lifetime_end(bcx, vp);
+    bcx
 }
 
 pub fn get_drop_glue<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>) -> ValueRef {

--- a/src/librustc_trans/trans/glue.rs
+++ b/src/librustc_trans/trans/glue.rs
@@ -187,7 +187,7 @@ pub fn drop_ty_immediate<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                      skip_dtor: bool)
                                      -> Block<'blk, 'tcx> {
     let _icx = push_ctxt("drop_ty_immediate");
-    let vp = alloca(bcx, type_of(bcx.ccx(), t), "");
+    let vp = alloc_ty(bcx, t, "");
     call_lifetime_start(bcx, vp);
     store_ty(bcx, v, vp, t);
     let bcx = drop_ty_core(bcx, vp, t, debug_loc, skip_dtor, None);

--- a/src/librustc_trans/trans/glue.rs
+++ b/src/librustc_trans/trans/glue.rs
@@ -188,6 +188,7 @@ pub fn drop_ty_immediate<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                      -> Block<'blk, 'tcx> {
     let _icx = push_ctxt("drop_ty_immediate");
     let vp = alloca(bcx, type_of(bcx.ccx(), t), "");
+    call_lifetime_start(bcx, vp);
     store_ty(bcx, v, vp, t);
     drop_ty_core(bcx, vp, t, debug_loc, skip_dtor, None)
 }

--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -966,6 +966,7 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
     match dest {
         expr::Ignore => {
             bcx = glue::drop_ty(bcx, llresult, ret_ty, call_debug_location);
+            call_lifetime_end(bcx, llresult);
         }
         expr::SaveIn(_) => {}
     }

--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -393,7 +393,9 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         expr::SaveIn(d) => d,
         expr::Ignore => {
             if !type_is_zero_size(ccx, ret_ty) {
-                alloc_ty(bcx, ret_ty, "intrinsic_result")
+                let llresult = alloc_ty(bcx, ret_ty, "intrinsic_result");
+                call_lifetime_start(bcx, llresult);
+                llresult
             } else {
                 C_undef(llret_ty.ptr_to())
             }

--- a/src/librustc_trans/trans/tvec.rs
+++ b/src/librustc_trans/trans/tvec.rs
@@ -111,6 +111,7 @@ pub fn trans_slice_vec<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     // Always create an alloca even if zero-sized, to preserve
     // the non-null invariant of the inner slice ptr
     let llfixed = base::alloca(bcx, llfixed_ty, "");
+    call_lifetime_start(bcx, llfixed);
 
     if count > 0 {
         // Arrange for the backing array to be cleaned up.

--- a/src/librustc_trans/trans/tvec.rs
+++ b/src/librustc_trans/trans/tvec.rs
@@ -106,11 +106,10 @@ pub fn trans_slice_vec<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     debug!("    vt={}, count={}", vt.to_string(ccx), count);
 
     let fixed_ty = bcx.tcx().mk_array(vt.unit_ty, count);
-    let llfixed_ty = type_of::type_of(bcx.ccx(), fixed_ty);
 
     // Always create an alloca even if zero-sized, to preserve
     // the non-null invariant of the inner slice ptr
-    let llfixed = base::alloca(bcx, llfixed_ty, "");
+    let llfixed = base::alloc_ty(bcx, fixed_ty, "");
     call_lifetime_start(bcx, llfixed);
 
     if count > 0 {


### PR DESCRIPTION
The major change here is in the tiny commit at the end and makes it so that we no longer emit lifetime intrinsics for allocas for function arguments. They are live for the whole function anyway, so the intrinsics add no value. This makes the resulting IR more clear, and reduces the peak memory usage and LLVM times by about 1-4%, depending on the crate.

The remaining changes are just preparatory cleanups and fixes for missing lifetime intrinsics. 
