### PR TITLE
Rename FnKind variants and stop re-exporting them from the visit module.

### DIFF
--- a/src/librustc/ast_map/blocks.rs
+++ b/src/librustc/ast_map/blocks.rs
@@ -28,7 +28,7 @@ use syntax::abi;
 use syntax::ast::{Block, FnDecl, NodeId};
 use syntax::ast;
 use syntax::codemap::Span;
-use syntax::visit;
+use syntax::visit::FnKind;
 
 /// An FnLikeNode is a Node that is like a fn, in that it has a decl
 /// and a body (as well as a NodeId, a span, etc).
@@ -50,7 +50,7 @@ pub trait MaybeFnLike { fn is_fn_like(&self) -> bool; }
 pub struct FnParts<'a> {
     pub decl: &'a FnDecl,
     pub body: &'a Block,
-    pub kind: visit::FnKind<'a>,
+    pub kind: FnKind<'a>,
     pub span: Span,
     pub id:   NodeId,
 }
@@ -186,15 +186,15 @@ impl<'a> FnLikeNode<'a> {
                     |c: ClosureParts|    c.id)
     }
 
-    pub fn kind(self) -> visit::FnKind<'a> {
-        let item = |p: ItemFnParts<'a>| -> visit::FnKind<'a> {
-            visit::FkItemFn(p.ident, p.generics, p.unsafety, p.constness, p.abi, p.vis)
+    pub fn kind(self) -> FnKind<'a> {
+        let item = |p: ItemFnParts<'a>| -> FnKind<'a> {
+            FnKind::ItemFn(p.ident, p.generics, p.unsafety, p.constness, p.abi, p.vis)
         };
         let closure = |_: ClosureParts| {
-            visit::FkClosure
+            FnKind::Closure
         };
         let method = |_, ident, sig: &'a ast::MethodSig, vis, _, _| {
-            visit::FkMethod(ident, sig, vis)
+            FnKind::Method(ident, sig, vis)
         };
         self.handle(item, method, closure)
     }

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -38,7 +38,7 @@ use util::nodemap::NodeMap;
 
 use syntax::ast;
 use syntax::codemap::Span;
-use syntax::visit::{self, Visitor};
+use syntax::visit::{self, FnKind, Visitor};
 
 use std::collections::hash_map::Entry;
 use std::cmp::Ordering;
@@ -142,7 +142,7 @@ impl<'a, 'tcx> CheckCrateVisitor<'a, 'tcx> {
     }
 
     fn fn_like(&mut self,
-               fk: visit::FnKind,
+               fk: FnKind,
                fd: &ast::FnDecl,
                b: &ast::Block,
                s: Span,
@@ -157,10 +157,10 @@ impl<'a, 'tcx> CheckCrateVisitor<'a, 'tcx> {
         }
 
         let mode = match fk {
-            visit::FkItemFn(_, _, _, ast::Constness::Const, _, _) => {
+            FnKind::ItemFn(_, _, _, ast::Constness::Const, _, _) => {
                 Mode::ConstFn
             }
-            visit::FkMethod(_, m, _) => {
+            FnKind::Method(_, m, _) => {
                 if m.constness == ast::Constness::Const {
                     Mode::ConstFn
                 } else {
@@ -352,7 +352,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for CheckCrateVisitor<'a, 'tcx> {
     }
 
     fn visit_fn(&mut self,
-                fk: visit::FnKind<'v>,
+                fk: FnKind<'v>,
                 fd: &'v ast::FnDecl,
                 b: &'v ast::Block,
                 s: Span,

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -1007,7 +1007,7 @@ fn check_fn(cx: &mut MatchCheckCtxt,
             sp: Span,
             fn_id: NodeId) {
     match kind {
-        visit::FkClosure => {}
+        FnKind::Closure => {}
         _ => cx.param_env = ParameterEnvironment::for_item(cx.tcx, fn_id),
     }
 

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(non_camel_case_types)]
+//#![allow(non_camel_case_types)]
 
 use self::ConstVal::*;
 use self::ErrKind::*;
@@ -26,10 +26,10 @@ use middle::astconv_util::ast_ty_to_prim_ty;
 use util::num::ToPrimitive;
 
 use syntax::ast::{self, Expr};
-use syntax::codemap::Span;
+use syntax::codemap::{self, Span};
 use syntax::parse::token::InternedString;
 use syntax::ptr::P;
-use syntax::{codemap, visit};
+use syntax::visit::FnKind;
 
 use std::borrow::{Cow, IntoCow};
 use std::num::wrapping::OverflowingOps;
@@ -246,10 +246,10 @@ pub fn lookup_const_fn_by_id<'tcx>(tcx: &ty::ctxt<'tcx>, def_id: DefId)
     };
 
     match fn_like.kind() {
-        visit::FkItemFn(_, _, _, ast::Constness::Const, _, _) => {
+        FnKind::ItemFn(_, _, _, ast::Constness::Const, _, _) => {
             Some(fn_like)
         }
-        visit::FkMethod(_, m, _) => {
+        FnKind::Method(_, m, _) => {
             if m.constness == ast::Constness::Const {
                 Some(fn_like)
             } else {

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -19,7 +19,7 @@ use middle::ty::MethodCall;
 use syntax::ast;
 use syntax::codemap::Span;
 use syntax::visit;
-use syntax::visit::Visitor;
+use syntax::visit::{FnKind, Visitor};
 
 #[derive(Copy, Clone)]
 struct UnsafeContext {
@@ -75,13 +75,13 @@ impl<'a, 'tcx> EffectCheckVisitor<'a, 'tcx> {
 }
 
 impl<'a, 'tcx, 'v> Visitor<'v> for EffectCheckVisitor<'a, 'tcx> {
-    fn visit_fn(&mut self, fn_kind: visit::FnKind<'v>, fn_decl: &'v ast::FnDecl,
+    fn visit_fn(&mut self, fn_kind: FnKind<'v>, fn_decl: &'v ast::FnDecl,
                 block: &'v ast::Block, span: Span, _: ast::NodeId) {
 
         let (is_item_fn, is_unsafe_fn) = match fn_kind {
-            visit::FkItemFn(_, _, unsafety, _, _, _) =>
+            FnKind::ItemFn(_, _, unsafety, _, _, _) =>
                 (true, unsafety == ast::Unsafety::Unsafe),
-            visit::FkMethod(_, sig, _) =>
+            FnKind::Method(_, sig, _) =>
                 (true, sig.unsafety == ast::Unsafety::Unsafe),
             _ => (false, false),
         };

--- a/src/librustc/middle/intrinsicck.rs
+++ b/src/librustc/middle/intrinsicck.rs
@@ -19,7 +19,7 @@ use std::fmt;
 use syntax::abi::RustIntrinsic;
 use syntax::ast;
 use syntax::codemap::Span;
-use syntax::visit::Visitor;
+use syntax::visit::{FnKind, Visitor};
 use syntax::visit;
 
 pub fn check_crate(tcx: &ctxt) {
@@ -216,16 +216,16 @@ impl<'a, 'tcx> IntrinsicCheckingVisitor<'a, 'tcx> {
 }
 
 impl<'a, 'tcx, 'v> Visitor<'v> for IntrinsicCheckingVisitor<'a, 'tcx> {
-    fn visit_fn(&mut self, fk: visit::FnKind<'v>, fd: &'v ast::FnDecl,
+    fn visit_fn(&mut self, fk: FnKind<'v>, fd: &'v ast::FnDecl,
                 b: &'v ast::Block, s: Span, id: ast::NodeId) {
         match fk {
-            visit::FkItemFn(..) | visit::FkMethod(..) => {
+            FnKind::ItemFn(..) | FnKind::Method(..) => {
                 let param_env = ty::ParameterEnvironment::for_item(self.tcx, id);
                 self.param_envs.push(param_env);
                 visit::walk_fn(self, fk, fd, b, s);
                 self.param_envs.pop();
             }
-            visit::FkClosure(..) => {
+            FnKind::Closure(..) => {
                 visit::walk_fn(self, fk, fd, b, s);
             }
         }

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -59,8 +59,8 @@ impl<'a, 'tcx, 'v> Visitor<'v> for BorrowckCtxt<'a, 'tcx> {
     fn visit_fn(&mut self, fk: FnKind<'v>, fd: &'v FnDecl,
                 b: &'v Block, s: Span, id: ast::NodeId) {
         match fk {
-            visit::FkItemFn(..) |
-            visit::FkMethod(..) => {
+            FnKind::ItemFn(..) |
+            FnKind::Method(..) => {
                 let new_free_region_map = self.tcx.free_region_map(id);
                 let old_free_region_map =
                     mem::replace(&mut self.free_region_map, new_free_region_map);
@@ -68,7 +68,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for BorrowckCtxt<'a, 'tcx> {
                 self.free_region_map = old_free_region_map;
             }
 
-            visit::FkClosure => {
+            FnKind::Closure => {
                 borrowck_fn(self, fk, fd, b, s, id);
             }
         }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -88,7 +88,7 @@ use syntax::ext::mtwt;
 use syntax::parse::token::{self, special_names, special_idents};
 use syntax::ptr::P;
 use syntax::codemap::{self, Span, Pos};
-use syntax::visit::{self, Visitor};
+use syntax::visit::{self, FnKind, Visitor};
 
 use std::collections::{HashMap, HashSet};
 use std::collections::hash_map::Entry::{Occupied, Vacant};
@@ -527,22 +527,22 @@ impl<'a, 'v, 'tcx> Visitor<'v> for Resolver<'a, 'tcx> {
         });
     }
     fn visit_fn(&mut self,
-                function_kind: visit::FnKind<'v>,
+                function_kind: FnKind<'v>,
                 declaration: &'v FnDecl,
                 block: &'v Block,
                 _: Span,
                 node_id: NodeId) {
         let rib_kind = match function_kind {
-            visit::FkItemFn(_, generics, _, _, _, _) => {
+            FnKind::ItemFn(_, generics, _, _, _, _) => {
                 self.visit_generics(generics);
                 ItemRibKind
             }
-            visit::FkMethod(_, sig, _) => {
+            FnKind::Method(_, sig, _) => {
                 self.visit_generics(&sig.generics);
                 self.visit_explicit_self(&sig.explicit_self);
                 MethodRibKind
             }
-            visit::FkClosure(..) => ClosureRibKind(node_id)
+            FnKind::Closure(..) => ClosureRibKind(node_id)
         };
         self.resolve_function(rib_kind, declaration, block);
     }

--- a/src/librustc_typeck/check/wf.rs
+++ b/src/librustc_typeck/check/wf.rs
@@ -25,7 +25,7 @@ use syntax::ast;
 use syntax::codemap::{DUMMY_SP, Span};
 use syntax::parse::token::{special_idents};
 use syntax::visit;
-use syntax::visit::Visitor;
+use syntax::visit::{FnKind, Visitor};
 
 pub struct CheckTypeWellFormedVisitor<'ccx, 'tcx:'ccx> {
     ccx: &'ccx CrateCtxt<'ccx, 'tcx>,
@@ -425,11 +425,11 @@ impl<'ccx, 'tcx, 'v> Visitor<'v> for CheckTypeWellFormedVisitor<'ccx, 'tcx> {
     }
 
     fn visit_fn(&mut self,
-                fk: visit::FnKind<'v>, fd: &'v ast::FnDecl,
+                fk: FnKind<'v>, fd: &'v ast::FnDecl,
                 b: &'v ast::Block, span: Span, id: ast::NodeId) {
         match fk {
-            visit::FkClosure | visit::FkItemFn(..) => {}
-            visit::FkMethod(..) => {
+            FnKind::Closure | FnKind::ItemFn(..) => {}
+            FnKind::Method(..) => {
                 match self.tcx().impl_or_trait_item(DefId::local(id)) {
                     ty::ImplOrTraitItem::MethodTraitItem(ty_method) => {
                         reject_shadowing_type_parameters(self.tcx(), span, &ty_method.generics)

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -17,7 +17,7 @@ use owned_slice::OwnedSlice;
 use parse::token;
 use print::pprust;
 use ptr::P;
-use visit::Visitor;
+use visit::{FnKind, Visitor};
 use visit;
 
 use std::cmp;
@@ -423,8 +423,8 @@ impl<'a, 'v, O: IdVisitingOperation> Visitor<'v> for IdVisitor<'a, O> {
                 node_id: NodeId) {
         if !self.pass_through_items {
             match function_kind {
-                visit::FkMethod(..) if self.visited_outermost => return,
-                visit::FkMethod(..) => self.visited_outermost = true,
+                FnKind::Method(..) if self.visited_outermost => return,
+                FnKind::Method(..) => self.visited_outermost = true,
                 _ => {}
             }
         }
@@ -432,13 +432,13 @@ impl<'a, 'v, O: IdVisitingOperation> Visitor<'v> for IdVisitor<'a, O> {
         self.operation.visit_id(node_id);
 
         match function_kind {
-            visit::FkItemFn(_, generics, _, _, _, _) => {
+            FnKind::ItemFn(_, generics, _, _, _, _) => {
                 self.visit_generics_helper(generics)
             }
-            visit::FkMethod(_, sig, _) => {
+            FnKind::Method(_, sig, _) => {
                 self.visit_generics_helper(&sig.generics)
             }
-            visit::FkClosure => {}
+            FnKind::Closure => {}
         }
 
         for argument in &function_declaration.inputs {
@@ -452,7 +452,7 @@ impl<'a, 'v, O: IdVisitingOperation> Visitor<'v> for IdVisitor<'a, O> {
                        span);
 
         if !self.pass_through_items {
-            if let visit::FkMethod(..) = function_kind {
+            if let FnKind::Method(..) = function_kind {
                 self.visited_outermost = false;
             }
         }
@@ -518,7 +518,7 @@ impl IdVisitingOperation for IdRangeComputingVisitor {
 }
 
 /// Computes the id range for a single fn body, ignoring nested items.
-pub fn compute_id_range_for_fn_body(fk: visit::FnKind,
+pub fn compute_id_range_for_fn_body(fk: FnKind,
                                     decl: &FnDecl,
                                     body: &Block,
                                     sp: Span,

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -33,7 +33,7 @@ use attr::AttrMetaMethods;
 use codemap::{CodeMap, Span};
 use diagnostic::SpanHandler;
 use visit;
-use visit::Visitor;
+use visit::{FnKind, Visitor};
 use parse::token::{self, InternedString};
 
 use std::ascii::AsciiExt;
@@ -825,14 +825,14 @@ impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
     }
 
     fn visit_fn(&mut self,
-                fn_kind: visit::FnKind<'v>,
+                fn_kind: FnKind<'v>,
                 fn_decl: &'v ast::FnDecl,
                 block: &'v ast::Block,
                 span: Span,
                 _node_id: NodeId) {
         // check for const fn declarations
         match fn_kind {
-            visit::FkItemFn(_, _, _, ast::Constness::Const, _, _) => {
+            FnKind::ItemFn(_, _, _, ast::Constness::Const, _, _) => {
                 self.gate_feature("const_fn", span, "const fn is unstable");
             }
             _ => {
@@ -844,13 +844,13 @@ impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
         }
 
         match fn_kind {
-            visit::FkItemFn(_, _, _, _, abi, _) if abi == Abi::RustIntrinsic => {
+            FnKind::ItemFn(_, _, _, _, abi, _) if abi == Abi::RustIntrinsic => {
                 self.gate_feature("intrinsics",
                                   span,
                                   "intrinsics are subject to change")
             }
-            visit::FkItemFn(_, _, _, _, abi, _) |
-            visit::FkMethod(_, &ast::MethodSig { abi, .. }, _) if abi == Abi::RustCall => {
+            FnKind::ItemFn(_, _, _, _, abi, _) |
+            FnKind::Method(_, &ast::MethodSig { abi, .. }, _) if abi == Abi::RustCall => {
                 self.gate_feature("unboxed_closures",
                                   span,
                                   "rust-call ABI is subject to change")

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -23,8 +23,6 @@
 //! instance, a walker looking for item names in a module will miss all of
 //! those that are created by the expansion of a macro.
 
-pub use self::FnKind::*;
-
 use abi::Abi;
 use ast::*;
 use ast;
@@ -35,13 +33,13 @@ use owned_slice::OwnedSlice;
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum FnKind<'a> {
     /// fn foo() or extern "Abi" fn foo()
-    FkItemFn(Ident, &'a Generics, Unsafety, Constness, Abi, Visibility),
+    ItemFn(Ident, &'a Generics, Unsafety, Constness, Abi, Visibility),
 
     /// fn foo(&self)
-    FkMethod(Ident, &'a MethodSig, Option<Visibility>),
+    Method(Ident, &'a MethodSig, Option<Visibility>),
 
     /// |x, y| {}
-    FkClosure,
+    Closure,
 }
 
 /// Each method of the Visitor trait is a hook to be potentially
@@ -247,8 +245,8 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
             visitor.visit_expr(&**expr);
         }
         ItemFn(ref declaration, unsafety, constness, abi, ref generics, ref body) => {
-            visitor.visit_fn(FkItemFn(item.ident, generics, unsafety,
-                                      constness, abi, item.vis),
+            visitor.visit_fn(FnKind::ItemFn(item.ident, generics, unsafety,
+                                            constness, abi, item.vis),
                              &**declaration,
                              &**body,
                              item.span,
@@ -608,14 +606,14 @@ pub fn walk_fn<'v, V: Visitor<'v>>(visitor: &mut V,
     walk_fn_decl(visitor, function_declaration);
 
     match function_kind {
-        FkItemFn(_, generics, _, _, _, _) => {
+        FnKind::ItemFn(_, generics, _, _, _, _) => {
             visitor.visit_generics(generics);
         }
-        FkMethod(_, sig, _) => {
+        FnKind::Method(_, sig, _) => {
             visitor.visit_generics(&sig.generics);
             visitor.visit_explicit_self(&sig.explicit_self);
         }
-        FkClosure(..) => {}
+        FnKind::Closure(..) => {}
     }
 
     visitor.visit_block(function_body)
@@ -639,7 +637,7 @@ pub fn walk_trait_item<'v, V: Visitor<'v>>(visitor: &mut V, trait_item: &'v Trai
             walk_fn_decl(visitor, &sig.decl);
         }
         MethodTraitItem(ref sig, Some(ref body)) => {
-            visitor.visit_fn(FkMethod(trait_item.ident, sig, None), &sig.decl,
+            visitor.visit_fn(FnKind::Method(trait_item.ident, sig, None), &sig.decl,
                              body, trait_item.span, trait_item.id);
         }
         TypeTraitItem(ref bounds, ref default) => {
@@ -660,7 +658,7 @@ pub fn walk_impl_item<'v, V: Visitor<'v>>(visitor: &mut V, impl_item: &'v ImplIt
             visitor.visit_expr(expr);
         }
         MethodImplItem(ref sig, ref body) => {
-            visitor.visit_fn(FkMethod(impl_item.ident, sig, Some(impl_item.vis)), &sig.decl,
+            visitor.visit_fn(FnKind::Method(impl_item.ident, sig, Some(impl_item.vis)), &sig.decl,
                              body, impl_item.span, impl_item.id);
         }
         TypeImplItem(ref ty) => {
@@ -816,7 +814,7 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
             }
         }
         ExprClosure(_, ref function_declaration, ref body) => {
-            visitor.visit_fn(FkClosure,
+            visitor.visit_fn(FnKind::Closure,
                              &**function_declaration,
                              &**body,
                              expression.span,


### PR DESCRIPTION
There is no longer a need for that pattern, since enums are now qualified.
