### PR TITLE
Fix keyboard scrolling in the book

### DIFF
--- a/src/rustbook/static/rustbook.css
+++ b/src/rustbook/static/rustbook.css
@@ -44,7 +44,6 @@ h1, h2, h3, h4, h5, h6 {
 
     #page-wrapper {
         position: absolute;
-        overflow-y: auto;
         left: 310px;
         right: 0px;
         top: 0px;

--- a/src/rustbook/static/rustbook.css
+++ b/src/rustbook/static/rustbook.css
@@ -27,7 +27,7 @@ h1, h2, h3, h4, h5, h6 {
 
 @media only screen {
     #toc {
-        position: absolute;
+        position: fixed;
         left: 0px;
         top: 0px;
         bottom: 0px;
@@ -48,7 +48,6 @@ h1, h2, h3, h4, h5, h6 {
         left: 310px;
         right: 0px;
         top: 0px;
-        bottom: 0px;
         box-sizing: border-box;
         background: none repeat scroll 0% 0% #FFF;
         -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
As of now, when you open a page in the Rust book and other books made with `rustbook`, you cannot scroll with your keyboard, whether using spacebar or arrow keys, unless you explicitly focus on the content div by clicking.

This PR fixes the issue by removing the bound on the content div size and by sticking the TOC with `position: fixed` rather than restricting the content to the window height.

r? @steveklabnik
