### PR TITLE
Minimize the implementation of `Rem` in libcore

### DIFF
--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -423,7 +423,7 @@ pub trait Rem<RHS=Self> {
     fn rem(self, rhs: RHS) -> Self::Output;
 }
 
-macro_rules! rem_impl {
+macro_rules! rem_impl_integer {
     ($($t:ty)*) => ($(
         /// This operation satisfies `n % d == n - (n / d) * d`.  The
         /// result has the same sign as the left operand.
@@ -439,42 +439,23 @@ macro_rules! rem_impl {
     )*)
 }
 
-rem_impl! { usize u8 u16 u32 u64 isize i8 i16 i32 i64 }
+rem_impl_integer! { usize u8 u16 u32 u64 isize i8 i16 i32 i64 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
-impl Rem for f32 {
-    type Output = f32;
+macro_rules! rem_impl_float {
+    ($($t:ty)*) => ($(
+        #[stable(feature = "rust1", since = "1.0.0")]
+        impl Rem for $t {
+            type Output = $t;
 
-    // The builtin f32 rem operator is broken when targeting
-    // MSVC; see comment in std::f32::floor.
-    // FIXME: See also #27859.
-    #[inline]
-    #[cfg(target_env = "msvc")]
-    fn rem(self, other: f32) -> f32 {
-        (self as f64).rem(other as f64) as f32
-    }
+            #[inline]
+            fn rem(self, other: $t) -> $t { self % other }
+        }
 
-    #[inline]
-    #[cfg(not(target_env = "msvc"))]
-    fn rem(self, other: f32) -> f32 {
-        extern { fn fmodf(a: f32, b: f32) -> f32; }
-        unsafe { fmodf(self, other) }
-    }
+        forward_ref_binop! { impl Rem, rem for $t, $t }
+    )*)
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
-impl Rem for f64 {
-    type Output = f64;
-
-    #[inline]
-    fn rem(self, other: f64) -> f64 {
-        extern { fn fmod(a: f64, b: f64) -> f64; }
-        unsafe { fmod(self, other) }
-    }
-}
-
-forward_ref_binop! { impl Rem, rem for f64, f64 }
-forward_ref_binop! { impl Rem, rem for f32, f32 }
+rem_impl_float! { f32 f64 }
 
 /// The `Neg` trait is used to specify the functionality of unary `-`.
 ///


### PR DESCRIPTION
The implementation of the remainder operation belongs to
librustc_trans, but it is also stubbed out in libcore in order to
expose it as a trait on primitive types. Instead of exposing some
implementation details (like the upcast to `f64` in MSVC), use a
minimal implementation just like that of the `Div` trait.
