### PR TITLE
Make the fulldeps modes independent of their respective non-fulldeps mode.

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -516,17 +516,17 @@ CTEST_RUNTOOL_rpass-valgrind = $(CTEST_RUNTOOL)
 
 CTEST_SRC_BASE_rpass-full = run-pass-fulldeps
 CTEST_BUILD_BASE_rpass-full = run-pass-fulldeps
-CTEST_MODE_rpass-full = run-pass
+CTEST_MODE_rpass-full = run-pass-fulldeps
 CTEST_RUNTOOL_rpass-full = $(CTEST_RUNTOOL)
 
 CTEST_SRC_BASE_rfail-full = run-fail-fulldeps
 CTEST_BUILD_BASE_rfail-full = run-fail-fulldeps
-CTEST_MODE_rfail-full = run-fail
+CTEST_MODE_rfail-full = run-fail-fulldeps
 CTEST_RUNTOOL_rfail-full = $(CTEST_RUNTOOL)
 
 CTEST_SRC_BASE_cfail-full = compile-fail-fulldeps
 CTEST_BUILD_BASE_cfail-full = compile-fail-fulldeps
-CTEST_MODE_cfail-full = compile-fail
+CTEST_MODE_cfail-full = compile-fail-fulldeps
 CTEST_RUNTOOL_cfail-full = $(CTEST_RUNTOOL)
 
 CTEST_SRC_BASE_rfail = run-fail

--- a/src/compiletest/common.rs
+++ b/src/compiletest/common.rs
@@ -15,10 +15,10 @@ use std::path::PathBuf;
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum Mode {
-    CompileFail,
+    CompileFail { fulldeps: bool },
     ParseFail,
-    RunFail,
-    RunPass,
+    RunFail { fulldeps: bool },
+    RunPass { fulldeps: bool },
     RunPassValgrind,
     Pretty,
     DebugInfoGdb,
@@ -31,10 +31,13 @@ impl FromStr for Mode {
     type Err = ();
     fn from_str(s: &str) -> Result<Mode, ()> {
         match s {
-          "compile-fail" => Ok(CompileFail),
+          "compile-fail" => Ok(CompileFail { fulldeps: false }),
+          "compile-fail-fulldeps" => Ok(CompileFail { fulldeps: true }),
           "parse-fail" => Ok(ParseFail),
-          "run-fail" => Ok(RunFail),
-          "run-pass" => Ok(RunPass),
+          "run-fail" => Ok(RunFail { fulldeps: false, }),
+          "run-fail-fulldeps" => Ok(RunFail { fulldeps: true, }),
+          "run-pass" => Ok(RunPass { fulldeps: false, }),
+          "run-pass-fulldeps" => Ok(RunPass { fulldeps: true, }),
           "run-pass-valgrind" => Ok(RunPassValgrind),
           "pretty" => Ok(Pretty),
           "debuginfo-lldb" => Ok(DebugInfoLldb),
@@ -49,10 +52,13 @@ impl FromStr for Mode {
 impl fmt::Display for Mode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(match *self {
-            CompileFail => "compile-fail",
+            CompileFail { fulldeps: false } => "compile-fail",
+            CompileFail { fulldeps: true } => "compile-fail-fulldeps",
             ParseFail => "parse-fail",
-            RunFail => "run-fail",
-            RunPass => "run-pass",
+            RunFail { fulldeps: false, } => "run-fail",
+            RunFail { fulldeps: true, } => "run-fail-fulldeps",
+            RunPass { fulldeps: false, } => "run-pass",
+            RunPass { fulldeps: true, } => "run-pass-fulldeps",
             RunPassValgrind => "run-pass-valgrind",
             Pretty => "pretty",
             DebugInfoGdb => "debuginfo-gdb",

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -48,10 +48,10 @@ pub fn run(config: Config, testfile: &Path) {
     let props = header::load_props(&testfile);
     debug!("loaded props");
     match config.mode {
-        CompileFail => run_cfail_test(&config, &props, &testfile),
+        CompileFail { .. } => run_cfail_test(&config, &props, &testfile),
         ParseFail => run_cfail_test(&config, &props, &testfile),
-        RunFail => run_rfail_test(&config, &props, &testfile),
-        RunPass => run_rpass_test(&config, &props, &testfile),
+        RunFail { .. } => run_rfail_test(&config, &props, &testfile),
+        RunPass { .. } => run_rpass_test(&config, &props, &testfile),
         RunPassValgrind => run_valgrind_test(&config, &props, &testfile),
         Pretty => run_pretty_test(&config, &props, &testfile),
         DebugInfoGdb => run_debuginfo_gdb_test(&config, &props, &testfile),


### PR DESCRIPTION
This is a change needed for #27937, so that `-L $(llvm-config --libdir)` is only
added to RUSTFLAGS for fulldeps based compiletest modes.
