### PR TITLE
Remove rampant infestation of `String` from ExpnInfo

### DIFF
--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -29,6 +29,8 @@ use std::io::{self, Read};
 
 use serialize::{Encodable, Decodable, Encoder, Decoder};
 
+use parse::token::intern;
+use ast::Name;
 
 // _____________________________________________________________________________
 // Pos, BytePos, CharPos
@@ -260,9 +262,9 @@ pub struct FileMapAndBytePos { pub fm: Rc<FileMap>, pub pos: BytePos }
 #[derive(Clone, Hash, Debug, PartialEq, Eq)]
 pub enum ExpnFormat {
     /// e.g. #[derive(...)] <item>
-    MacroAttribute(String),
+    MacroAttribute(Name),
     /// e.g. `format!()`
-    MacroBang(String),
+    MacroBang(Name),
     /// Syntax sugar expansion performed by the compiler (libsyntax::expand).
     CompilerExpansion(CompilerExpansionFormat),
 }
@@ -302,13 +304,13 @@ pub struct NameAndSpan {
 }
 
 impl NameAndSpan {
-    pub fn name(&self) -> &str{
+    pub fn name(&self) -> Name {
         match self.format {
-            ExpnFormat::MacroAttribute(ref s) => &s,
-            ExpnFormat::MacroBang(ref s) => &s,
-            ExpnFormat::CompilerExpansion(ce) => ce.name(),
+            ExpnFormat::MacroAttribute(s) => s,
+            ExpnFormat::MacroBang(s) => s,
+            ExpnFormat::CompilerExpansion(ce) => intern(ce.name()),
         }
-    } 
+    }
 }
 
 /// Extra information for tracking spans of macro and syntax sugar expansion

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -733,14 +733,14 @@ impl EmitterWriter {
                     let ss = ei.callee.span.map_or(String::new(),
                                                    |span| cm.span_to_string(span));
                     let (pre, post) = match ei.callee.format {
-                        codemap::MacroAttribute => ("#[", "]"),
-                        codemap::MacroBang => ("", "!"),
-                        codemap::CompilerExpansion => ("", ""),
+                        codemap::MacroAttribute(..) => ("#[", "]"),
+                        codemap::MacroBang(..) => ("", "!"),
+                        codemap::CompilerExpansion(..) => ("", ""),
                     };
                     try!(self.print_diagnostic(&ss, Note,
                                                &format!("in expansion of {}{}{}",
                                                         pre,
-                                                        ei.callee.name,
+                                                        ei.callee.name(),
                                                         post),
                                                None));
                     let ss = cm.span_to_string(ei.call_site);

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -211,8 +211,7 @@ pub fn expand_asm<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
     let expn_id = cx.codemap().record_expansion(codemap::ExpnInfo {
         call_site: sp,
         callee: codemap::NameAndSpan {
-            name: "asm".to_string(),
-            format: codemap::MacroBang,
+            format: codemap::MacroBang("asm".to_string()),
             span: None,
             allow_internal_unstable: false,
         },

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -19,7 +19,7 @@ use codemap::Span;
 use ext::base;
 use ext::base::*;
 use feature_gate;
-use parse::token::InternedString;
+use parse::token::{intern, InternedString};
 use parse::token;
 use ptr::P;
 
@@ -211,7 +211,7 @@ pub fn expand_asm<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
     let expn_id = cx.codemap().record_expansion(codemap::ExpnInfo {
         call_site: sp,
         callee: codemap::NameAndSpan {
-            format: codemap::MacroBang("asm".to_string()),
+            format: codemap::MacroBang(intern("asm")),
             span: None,
             allow_internal_unstable: false,
         },

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -714,13 +714,14 @@ impl<'a> ExtCtxt<'a> {
         loop {
             if self.codemap().with_expn_info(expn_id, |info| {
                 info.map_or(None, |i| {
-                    if i.callee.name == "include" {
+                    if i.callee.name() == "include" {
                         // Stop going up the backtrace once include! is encountered
                         return None;
                     }
                     expn_id = i.call_site.expn_id;
-                    if i.callee.format != CompilerExpansion {
-                        last_macro = Some(i.call_site)
+                    match i.callee.format {
+                        CompilerExpansion(..) => (),
+                        _ => last_macro = Some(i.call_site),
                     }
                     return Some(());
                 })
@@ -744,7 +745,7 @@ impl<'a> ExtCtxt<'a> {
         if self.recursion_count > self.ecfg.recursion_limit {
             panic!(self.span_fatal(ei.call_site,
                             &format!("recursion limit reached while expanding the macro `{}`",
-                                    ei.callee.name)));
+                                    ei.callee.name())));
         }
 
         let mut call_site = ei.call_site;

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -205,7 +205,7 @@ use codemap::Span;
 use diagnostic::SpanHandler;
 use fold::MoveMap;
 use owned_slice::OwnedSlice;
-use parse::token::InternedString;
+use parse::token::{intern, InternedString};
 use parse::token::special_idents;
 use ptr::P;
 
@@ -1436,7 +1436,7 @@ impl<'a> TraitDef<'a> {
         to_set.expn_id = cx.codemap().record_expansion(codemap::ExpnInfo {
             call_site: to_set,
             callee: codemap::NameAndSpan {
-                format: codemap::MacroAttribute(format!("derive({})", trait_name)),
+                format: codemap::MacroAttribute(intern(&format!("derive({})", trait_name))),
                 span: Some(self.span),
                 allow_internal_unstable: false,
             }

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -1436,8 +1436,7 @@ impl<'a> TraitDef<'a> {
         to_set.expn_id = cx.codemap().record_expansion(codemap::ExpnInfo {
             call_site: to_set,
             callee: codemap::NameAndSpan {
-                name: format!("derive({})", trait_name),
-                format: codemap::MacroAttribute,
+                format: codemap::MacroAttribute(format!("derive({})", trait_name)),
                 span: Some(self.span),
                 allow_internal_unstable: false,
             }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -19,7 +19,8 @@ use ext::build::AstBuilder;
 use attr;
 use attr::AttrMetaMethods;
 use codemap;
-use codemap::{Span, Spanned, ExpnInfo, NameAndSpan, MacroBang, MacroAttribute, CompilerExpansion};
+use codemap::{Span, Spanned, ExpnInfo, NameAndSpan, MacroBang, MacroAttribute};
+use codemap::{CompilerExpansion, CompilerExpansionFormat};
 use ext::base::*;
 use feature_gate::{self, Features, GatedCfg};
 use fold;
@@ -43,12 +44,12 @@ fn mk_core_path(fld: &mut MacroExpander,
 }
 
 pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
-    fn push_compiler_expansion(fld: &mut MacroExpander, span: Span, expansion_desc: &str) {
+    fn push_compiler_expansion(fld: &mut MacroExpander, span: Span,
+                               expansion_type: CompilerExpansionFormat) {
         fld.cx.bt_push(ExpnInfo {
             call_site: span,
             callee: NameAndSpan {
-                name: expansion_desc.to_string(),
-                format: CompilerExpansion,
+                format: CompilerExpansion(expansion_type),
 
                 // This does *not* mean code generated after
                 // `push_compiler_expansion` is automatically exempt
@@ -111,7 +112,7 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
                 &fld.cx.parse_sess.span_diagnostic,
                 expr_span);
 
-            push_compiler_expansion(fld, expr_span, "placement-in expansion");
+            push_compiler_expansion(fld, expr_span, CompilerExpansionFormat::PlacementIn);
 
             let value_span = value_expr.span;
             let placer_span = placer.span;
@@ -223,7 +224,7 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
             //     }
             //   }
 
-            push_compiler_expansion(fld, span, "while let expansion");
+            push_compiler_expansion(fld, span, CompilerExpansionFormat::WhileLet);
 
             // `<pat> => <body>`
             let pat_arm = {
@@ -262,7 +263,7 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
             //     _ => [<elseopt> | ()]
             //   }
 
-            push_compiler_expansion(fld, span, "if let expansion");
+            push_compiler_expansion(fld, span, CompilerExpansionFormat::IfLet);
 
             // `<pat> => <body>`
             let pat_arm = {
@@ -334,7 +335,7 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
         ast::ExprIf(cond, blk, elseopt) => {
             let elseopt = elseopt.map(|els| els.and_then(|els| match els.node {
                 ast::ExprIfLet(..) => {
-                    push_compiler_expansion(fld, span, "if let expansion");
+                    push_compiler_expansion(fld, span, CompilerExpansionFormat::IfLet);
                     // wrap the if-let expr in a block
                     let span = els.span;
                     let blk = P(ast::Block {
@@ -378,7 +379,7 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
             //     result
             //   }
 
-            push_compiler_expansion(fld, span, "for loop expansion");
+            push_compiler_expansion(fld, span, CompilerExpansionFormat::ForLoop);
 
             let span = fld.new_span(span);
 
@@ -458,7 +459,7 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
         }
 
         ast::ExprClosure(capture_clause, fn_decl, block) => {
-            push_compiler_expansion(fld, span, "closure expansion");
+            push_compiler_expansion(fld, span, CompilerExpansionFormat::Closure);
             let (rewritten_fn_decl, rewritten_block)
                 = expand_and_rename_fn_decl_and_block(fn_decl, block, fld);
             let new_node = ast::ExprClosure(capture_clause,
@@ -542,8 +543,7 @@ fn expand_mac_invoc<T, F, G>(mac: ast::Mac,
                         fld.cx.bt_push(ExpnInfo {
                                 call_site: span,
                                 callee: NameAndSpan {
-                                    name: extname.to_string(),
-                                    format: MacroBang,
+                                    format: MacroBang(extname.to_string()),
                                     span: exp_span,
                                     allow_internal_unstable: allow_internal_unstable,
                                 },
@@ -721,8 +721,7 @@ pub fn expand_item_mac(it: P<ast::Item>,
                     fld.cx.bt_push(ExpnInfo {
                         call_site: it.span,
                         callee: NameAndSpan {
-                            name: extname.to_string(),
-                            format: MacroBang,
+                            format: MacroBang(extname.to_string()),
                             span: span,
                             allow_internal_unstable: allow_internal_unstable,
                         }
@@ -741,8 +740,7 @@ pub fn expand_item_mac(it: P<ast::Item>,
                     fld.cx.bt_push(ExpnInfo {
                         call_site: it.span,
                         callee: NameAndSpan {
-                            name: extname.to_string(),
-                            format: MacroBang,
+                            format: MacroBang(extname.to_string()),
                             span: span,
                             allow_internal_unstable: allow_internal_unstable,
                         }
@@ -762,8 +760,7 @@ pub fn expand_item_mac(it: P<ast::Item>,
                     fld.cx.bt_push(ExpnInfo {
                         call_site: it.span,
                         callee: NameAndSpan {
-                            name: extname.to_string(),
-                            format: MacroBang,
+                            format: MacroBang(extname.to_string()),
                             span: None,
                             // `macro_rules!` doesn't directly allow
                             // unstable (this is orthogonal to whether
@@ -1090,8 +1087,7 @@ fn expand_pat(p: P<ast::Pat>, fld: &mut MacroExpander) -> P<ast::Pat> {
                     fld.cx.bt_push(ExpnInfo {
                         call_site: span,
                         callee: NameAndSpan {
-                            name: extname.to_string(),
-                            format: MacroBang,
+                            format: MacroBang(extname.to_string()),
                             span: tt_span,
                             allow_internal_unstable: allow_internal_unstable,
                         }
@@ -1302,8 +1298,7 @@ fn expand_decorators(a: Annotatable,
                     fld.cx.bt_push(ExpnInfo {
                         call_site: attr.span,
                         callee: NameAndSpan {
-                            name: mname.to_string(),
-                            format: MacroAttribute,
+                            format: MacroAttribute(mname.to_string()),
                             span: Some(attr.span),
                             // attributes can do whatever they like,
                             // for now.
@@ -1330,8 +1325,7 @@ fn expand_decorators(a: Annotatable,
                     fld.cx.bt_push(ExpnInfo {
                         call_site: attr.span,
                         callee: NameAndSpan {
-                            name: mname.to_string(),
-                            format: MacroAttribute,
+                            format: MacroAttribute(mname.to_string()),
                             span: Some(attr.span),
                             // attributes can do whatever they like,
                             // for now.
@@ -1381,8 +1375,7 @@ fn expand_item_multi_modifier(mut it: Annotatable,
                     fld.cx.bt_push(ExpnInfo {
                         call_site: attr.span,
                         callee: NameAndSpan {
-                            name: mname.to_string(),
-                            format: MacroAttribute,
+                            format: MacroAttribute(mname.to_string()),
                             span: Some(attr.span),
                             // attributes can do whatever they like,
                             // for now
@@ -1430,8 +1423,7 @@ fn expand_item_modifiers(mut it: P<ast::Item>,
                     fld.cx.bt_push(ExpnInfo {
                         call_site: attr.span,
                         callee: NameAndSpan {
-                            name: mname.to_string(),
-                            format: MacroAttribute,
+                            format: MacroAttribute(mname.to_string()),
                             span: Some(attr.span),
                             // attributes can do whatever they like,
                             // for now

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -543,7 +543,7 @@ fn expand_mac_invoc<T, F, G>(mac: ast::Mac,
                         fld.cx.bt_push(ExpnInfo {
                                 call_site: span,
                                 callee: NameAndSpan {
-                                    format: MacroBang(extname.to_string()),
+                                    format: MacroBang(extname),
                                     span: exp_span,
                                     allow_internal_unstable: allow_internal_unstable,
                                 },
@@ -721,7 +721,7 @@ pub fn expand_item_mac(it: P<ast::Item>,
                     fld.cx.bt_push(ExpnInfo {
                         call_site: it.span,
                         callee: NameAndSpan {
-                            format: MacroBang(extname.to_string()),
+                            format: MacroBang(extname),
                             span: span,
                             allow_internal_unstable: allow_internal_unstable,
                         }
@@ -740,7 +740,7 @@ pub fn expand_item_mac(it: P<ast::Item>,
                     fld.cx.bt_push(ExpnInfo {
                         call_site: it.span,
                         callee: NameAndSpan {
-                            format: MacroBang(extname.to_string()),
+                            format: MacroBang(extname),
                             span: span,
                             allow_internal_unstable: allow_internal_unstable,
                         }
@@ -760,7 +760,7 @@ pub fn expand_item_mac(it: P<ast::Item>,
                     fld.cx.bt_push(ExpnInfo {
                         call_site: it.span,
                         callee: NameAndSpan {
-                            format: MacroBang(extname.to_string()),
+                            format: MacroBang(extname),
                             span: None,
                             // `macro_rules!` doesn't directly allow
                             // unstable (this is orthogonal to whether
@@ -1087,7 +1087,7 @@ fn expand_pat(p: P<ast::Pat>, fld: &mut MacroExpander) -> P<ast::Pat> {
                     fld.cx.bt_push(ExpnInfo {
                         call_site: span,
                         callee: NameAndSpan {
-                            format: MacroBang(extname.to_string()),
+                            format: MacroBang(extname),
                             span: tt_span,
                             allow_internal_unstable: allow_internal_unstable,
                         }
@@ -1289,8 +1289,8 @@ fn expand_decorators(a: Annotatable,
                      new_attrs: &mut Vec<ast::Attribute>)
 {
     for attr in a.attrs() {
-        let mname = attr.name();
-        match fld.cx.syntax_env.find(&intern(&mname)) {
+        let mname = intern(&attr.name());
+        match fld.cx.syntax_env.find(&mname) {
             Some(rc) => match *rc {
                 Decorator(ref dec) => {
                     attr::mark_used(&attr);
@@ -1298,7 +1298,7 @@ fn expand_decorators(a: Annotatable,
                     fld.cx.bt_push(ExpnInfo {
                         call_site: attr.span,
                         callee: NameAndSpan {
-                            format: MacroAttribute(mname.to_string()),
+                            format: MacroAttribute(mname),
                             span: Some(attr.span),
                             // attributes can do whatever they like,
                             // for now.
@@ -1325,7 +1325,7 @@ fn expand_decorators(a: Annotatable,
                     fld.cx.bt_push(ExpnInfo {
                         call_site: attr.span,
                         callee: NameAndSpan {
-                            format: MacroAttribute(mname.to_string()),
+                            format: MacroAttribute(mname),
                             span: Some(attr.span),
                             // attributes can do whatever they like,
                             // for now.
@@ -1366,16 +1366,16 @@ fn expand_item_multi_modifier(mut it: Annotatable,
     }
 
     for attr in &modifiers {
-        let mname = attr.name();
+        let mname = intern(&attr.name());
 
-        match fld.cx.syntax_env.find(&intern(&mname)) {
+        match fld.cx.syntax_env.find(&mname) {
             Some(rc) => match *rc {
                 MultiModifier(ref mac) => {
                     attr::mark_used(attr);
                     fld.cx.bt_push(ExpnInfo {
                         call_site: attr.span,
                         callee: NameAndSpan {
-                            format: MacroAttribute(mname.to_string()),
+                            format: MacroAttribute(mname),
                             span: Some(attr.span),
                             // attributes can do whatever they like,
                             // for now
@@ -1414,16 +1414,16 @@ fn expand_item_modifiers(mut it: P<ast::Item>,
     }
 
     for attr in &modifiers {
-        let mname = attr.name();
+        let mname = intern(&attr.name());
 
-        match fld.cx.syntax_env.find(&intern(&mname)) {
+        match fld.cx.syntax_env.find(&mname) {
             Some(rc) => match *rc {
                 Modifier(ref mac) => {
                     attr::mark_used(attr);
                     fld.cx.bt_push(ExpnInfo {
                         call_site: attr.span,
                         callee: NameAndSpan {
-                            format: MacroAttribute(mname.to_string()),
+                            format: MacroAttribute(mname),
                             span: Some(attr.span),
                             // attributes can do whatever they like,
                             // for now

--- a/src/libsyntax/std_inject.rs
+++ b/src/libsyntax/std_inject.rs
@@ -27,8 +27,7 @@ fn ignored_span(sess: &ParseSess, sp: Span) -> Span {
     let info = ExpnInfo {
         call_site: DUMMY_SP,
         callee: NameAndSpan {
-            name: "std_inject".to_string(),
-            format: MacroAttribute,
+            format: MacroAttribute("std_inject".to_string()),
             span: None,
             allow_internal_unstable: true,
         }

--- a/src/libsyntax/std_inject.rs
+++ b/src/libsyntax/std_inject.rs
@@ -14,8 +14,7 @@ use codemap::{DUMMY_SP, Span, ExpnInfo, NameAndSpan, MacroAttribute};
 use codemap;
 use fold::Folder;
 use fold;
-use parse::token::InternedString;
-use parse::token::special_idents;
+use parse::token::{intern, InternedString, special_idents};
 use parse::{token, ParseSess};
 use ptr::P;
 use util::small_vector::SmallVector;
@@ -27,7 +26,7 @@ fn ignored_span(sess: &ParseSess, sp: Span) -> Span {
     let info = ExpnInfo {
         call_site: DUMMY_SP,
         callee: NameAndSpan {
-            format: MacroAttribute("std_inject".to_string()),
+            format: MacroAttribute(intern("std_inject")),
             span: None,
             allow_internal_unstable: true,
         }

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -30,7 +30,7 @@ use ext::expand::ExpansionConfig;
 use fold::{Folder, MoveMap};
 use fold;
 use owned_slice::OwnedSlice;
-use parse::token::InternedString;
+use parse::token::{intern, InternedString};
 use parse::{token, ParseSess};
 use print::pprust;
 use {ast, ast_util};
@@ -265,7 +265,7 @@ fn generate_test_harness(sess: &ParseSess,
     cx.ext_cx.bt_push(ExpnInfo {
         call_site: DUMMY_SP,
         callee: NameAndSpan {
-            format: MacroAttribute("test".to_string()),
+            format: MacroAttribute(intern("test")),
             span: None,
             allow_internal_unstable: false,
         }
@@ -297,7 +297,7 @@ fn ignored_span(cx: &TestCtxt, sp: Span) -> Span {
     let info = ExpnInfo {
         call_site: DUMMY_SP,
         callee: NameAndSpan {
-            format: MacroAttribute("test".to_string()),
+            format: MacroAttribute(intern("test")),
             span: None,
             allow_internal_unstable: true,
         }

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -265,8 +265,7 @@ fn generate_test_harness(sess: &ParseSess,
     cx.ext_cx.bt_push(ExpnInfo {
         call_site: DUMMY_SP,
         callee: NameAndSpan {
-            name: "test".to_string(),
-            format: MacroAttribute,
+            format: MacroAttribute("test".to_string()),
             span: None,
             allow_internal_unstable: false,
         }
@@ -298,8 +297,7 @@ fn ignored_span(cx: &TestCtxt, sp: Span) -> Span {
     let info = ExpnInfo {
         call_site: DUMMY_SP,
         callee: NameAndSpan {
-            name: "test".to_string(),
-            format: MacroAttribute,
+            format: MacroAttribute("test".to_string()),
             span: None,
             allow_internal_unstable: true,
         }

--- a/src/test/compile-fail-fulldeps/qquote.rs
+++ b/src/test/compile-fail-fulldeps/qquote.rs
@@ -27,8 +27,7 @@ fn main() {
     cx.bt_push(syntax::codemap::ExpnInfo {
         call_site: DUMMY_SP,
         callee: syntax::codemap::NameAndSpan {
-            name: "".to_string(),
-            format: syntax::codemap::MacroBang,
+            format: syntax::codemap::MacroBang(parse::token::intern("")),
             allow_internal_unstable: false,
             span: None,
         }

--- a/src/test/run-fail-fulldeps/qquote.rs
+++ b/src/test/run-fail-fulldeps/qquote.rs
@@ -31,8 +31,7 @@ fn main() {
     cx.bt_push(syntax::codemap::ExpnInfo {
         call_site: DUMMY_SP,
         callee: syntax::codemap::NameAndSpan {
-            name: "".to_string(),
-            format: syntax::codemap::MacroBang,
+            format: syntax::codemap::MacroBang(parse::token::intern("")),
             allow_internal_unstable: false,
             span: None,
         }

--- a/src/test/run-pass-fulldeps/qquote.rs
+++ b/src/test/run-pass-fulldeps/qquote.rs
@@ -16,6 +16,7 @@ extern crate syntax;
 
 use syntax::codemap::DUMMY_SP;
 use syntax::print::pprust::*;
+use syntax::parse::token::intern;
 
 fn main() {
     let ps = syntax::parse::ParseSess::new();
@@ -27,8 +28,7 @@ fn main() {
     cx.bt_push(syntax::codemap::ExpnInfo {
         call_site: DUMMY_SP,
         callee: syntax::codemap::NameAndSpan {
-            name: "".to_string(),
-            format: syntax::codemap::MacroBang,
+            format: syntax::codemap::MacroBang(intern("")),
             allow_internal_unstable: false,
             span: None,
         }


### PR DESCRIPTION
We were using them for every expansion, instead of using `Name`.

Also converted `CompilerExpansion` into an enum so its nicer to use and takes up less space.

Will profile later, but this should be a small improvement in memory usage.

r? @eddyb
