### PR TITLE
WIP: Hash and Hasher update for faster common case hashing

### DIFF
--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -118,6 +118,13 @@ pub trait Hasher {
     #[stable(feature = "rust1", since = "1.0.0")]
     fn write(&mut self, bytes: &[u8]);
 
+    /// Emit a delimiter for data of length `len`
+    #[inline]
+    #[unstable(feature = "hash_delimit", since = "1.4.0", issue="0")]
+    fn delimit(&mut self, len: usize) {
+        self.write_usize(len);
+    }
+
     /// Write a single `u8` into this hasher
     #[inline]
     #[stable(feature = "hasher_write", since = "1.3.0")]
@@ -230,8 +237,9 @@ mod impls {
     #[stable(feature = "rust1", since = "1.0.0")]
     impl Hash for str {
         fn hash<H: Hasher>(&self, state: &mut H) {
+            // See `[T]` impl for why we write the u8
+            state.delimit(self.len());
             state.write(self.as_bytes());
-            state.write_u8(0xff)
         }
     }
 
@@ -272,7 +280,7 @@ mod impls {
     #[stable(feature = "rust1", since = "1.0.0")]
     impl<T: Hash> Hash for [T] {
         fn hash<H: Hasher>(&self, state: &mut H) {
-            self.len().hash(state);
+            state.delimit(self.len());
             Hash::hash_slice(self, state)
         }
     }

--- a/src/libcore/hash/sip.rs
+++ b/src/libcore/hash/sip.rs
@@ -193,6 +193,14 @@ impl Hasher for SipHasher {
     }
 
     #[inline]
+    fn delimit(&mut self, len: usize) {
+        // skip the first delimiter
+        if self.length > 0 {
+            self.write_usize(len);
+        }
+    }
+
+    #[inline]
     fn finish(&self) -> u64 {
         let mut v0 = self.v0;
         let mut v1 = self.v1;

--- a/src/libcoretest/hash/mod.rs
+++ b/src/libcoretest/hash/mod.rs
@@ -61,7 +61,7 @@ fn test_writer_hasher() {
     assert_eq!(hash(&'a'), 97);
 
     let s: &str = "a";
-    assert_eq!(hash(& s), 97 + 0xFF);
+    assert_eq!(hash(&s), 1 + 97);
     // FIXME (#18283) Enable test
     //let s: Box<str> = box "a";
     //assert_eq!(hasher.hash(& s), 97 + 0xFF);

--- a/src/libcoretest/hash/sip.rs
+++ b/src/libcoretest/hash/sip.rs
@@ -239,7 +239,7 @@ fn test_hash_no_concat_alias() {
 fn bench_str_under_8_bytes(b: &mut Bencher) {
     let s = "foo";
     b.iter(|| {
-        assert_eq!(hash(&s), 16262950014981195938);
+        hash(&s)
     })
 }
 
@@ -247,7 +247,7 @@ fn bench_str_under_8_bytes(b: &mut Bencher) {
 fn bench_str_of_8_bytes(b: &mut Bencher) {
     let s = "foobar78";
     b.iter(|| {
-        assert_eq!(hash(&s), 4898293253460910787);
+        hash(&s)
     })
 }
 
@@ -255,7 +255,7 @@ fn bench_str_of_8_bytes(b: &mut Bencher) {
 fn bench_str_over_8_bytes(b: &mut Bencher) {
     let s = "foobarbaz0";
     b.iter(|| {
-        assert_eq!(hash(&s), 10581415515220175264);
+        hash(&s)
     })
 }
 
@@ -268,7 +268,7 @@ irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nul
 pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui \
 officia deserunt mollit anim id est laborum.";
     b.iter(|| {
-        assert_eq!(hash(&s), 17717065544121360093);
+        hash(&s)
     })
 }
 

--- a/src/libstd/sys/common/wtf8.rs
+++ b/src/libstd/sys/common/wtf8.rs
@@ -124,7 +124,7 @@ impl CodePoint {
 ///
 /// Similar to `String`, but can additionally contain surrogate code points
 /// if they’re not in a surrogate pair.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Hash)]
 pub struct Wtf8Buf {
     bytes: Vec<u8>
 }
@@ -382,6 +382,7 @@ impl Extend<CodePoint> for Wtf8Buf {
 ///
 /// Similar to `&str`, but can additionally contain surrogate code points
 /// if they’re not in a surrogate pair.
+#[derive(Hash)]
 pub struct Wtf8 {
     bytes: [u8]
 }
@@ -793,22 +794,6 @@ impl Hash for CodePoint {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.value.hash(state)
-    }
-}
-
-impl Hash for Wtf8Buf {
-    #[inline]
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        state.write(&self.bytes);
-        0xfeu8.hash(state)
-    }
-}
-
-impl Hash for Wtf8 {
-    #[inline]
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        state.write(&self.bytes);
-        0xfeu8.hash(state)
     }
 }
 


### PR DESCRIPTION
Add method `fn delimit(&mut self, len: usize)` to Hasher.
- str now emits a delimiter of its own length
- str and [u8] hash the same, and `Wtf8` does too.
- `Hasher::delimiter` customizes how a delimiter is handled

The Hasher impl decides how to implement the delimiter. By default it
emits the whole `usize` as data to the hashing stream.

SipHash will ignore the first delimiter and hash the others as `usize`.

For the next example, take something like farmhash that is not designed
for streaming hashing. It could be implemented like this:
- Every call to `Hasher::write` runs the whole hashing algorithm.
  Previous hash is a seed to the next hash invocation.
- Delimiters are ignored, since the length of each chunk to write is
  already hashed in.

It follows a sketch of how siphash and farmhash could work with this change:

When hashing `a: &[u8]`
- SipHash: `write(a); finish();`
- Farmhash: `hash = write(a); hash`

Both SipHash and Farmhash will hash just the bytes of the slice in
a single Hasher::write and a single Hasher::finish.

When hashing `(a: &[u8], b: [u8])`:
- SipHash: `write(a); write(b.len()); write(b); finish();`
- Farmhash: `hash = write(a); hash ^= write(b); hash`
