### PR TITLE
std: Run at_exit cleanup on process::exit

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -582,6 +582,7 @@ impl Child {
 /// to run.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn exit(code: i32) -> ! {
+    ::rt::cleanup();
     ::sys::os::exit(code)
 }
 

--- a/src/libstd/rt/args.rs
+++ b/src/libstd/rt/args.rs
@@ -64,7 +64,6 @@ mod imp {
 
     pub unsafe fn cleanup() {
         take();
-        LOCK.destroy();
     }
 
     pub fn take() -> Option<Vec<Vec<u8>>> {

--- a/src/libstd/rt/at_exit_imp.rs
+++ b/src/libstd/rt/at_exit_imp.rs
@@ -12,10 +12,6 @@
 //!
 //! Documentation can be found on the `rt::at_exit` function.
 
-// FIXME: switch this to use atexit. Currently this
-// segfaults (the queue's memory is mysteriously gone), so
-// instead the cleanup is tied to the `std::rt` entry point.
-
 use alloc::boxed::FnBox;
 use boxed::Box;
 use sys_common::mutex::Mutex;

--- a/src/test/run-pass/exit-flushes.rs
+++ b/src/test/run-pass/exit-flushes.rs
@@ -1,0 +1,25 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::env;
+use std::process::{exit, Command};
+
+fn main() {
+    if env::args().len() > 1 {
+        print!("hello!");
+        exit(0);
+    } else {
+        let out = Command::new(env::args().next().unwrap()).arg("foo")
+                          .output().unwrap();
+        assert!(out.status.success());
+        assert_eq!(String::from_utf8(out.stdout).unwrap(), "hello!");
+        assert_eq!(String::from_utf8(out.stderr).unwrap(), "");
+    }
+}


### PR DESCRIPTION
This adds a call to `rt::cleanup` on `process::exit` to make sure we clean up
after ourselves on the way out from Rust.

Closes #28065
