### PR TITLE
Handle gateage of built-in attributes seperately

### DIFF
--- a/src/librustc/plugin/registry.rs
+++ b/src/librustc/plugin/registry.rs
@@ -145,11 +145,6 @@ impl<'a> Registry<'a> {
     /// `Whitelisted` attributes will additionally not trigger the `unused_attribute`
     /// lint. `CrateLevel` attributes will not be allowed on anything other than a crate.
     pub fn register_attribute(&mut self, name: String, ty: AttributeType) {
-        if let AttributeType::Gated(..) = ty {
-            self.sess.span_err(self.krate_span, "plugin tried to register a gated \
-                                                 attribute. Only `Normal`, `Whitelisted`, \
-                                                 and `CrateLevel` attributes are allowed");
-        }
         self.attributes.push((name, ty));
     }
 }

--- a/src/test/compile-fail/invalid-plugin-attr.rs
+++ b/src/test/compile-fail/invalid-plugin-attr.rs
@@ -1,0 +1,17 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(unused_attributes)]
+#![feature(plugin)]
+
+#[plugin(bla)]  //~ ERROR unused attribute
+                //~^ ERROR should be an inner attribute
+
+fn main() {}


### PR DESCRIPTION
This allows marking attributes as whitelisted/crate-only independent of
their feature gate status.

Closes #24213
