### PR TITLE
Run tidy by itself on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ sudo: false
 before_script:
   - ./configure --enable-ccache
 script:
-  - make tidy check -j4
+  - make tidy && make check -j4
 
 env:
   - CXX=/usr/bin/g++-4.7


### PR DESCRIPTION
It is very difficult to find tidy problems in the midst of the output of
the LLVM/jemalloc/etc. build, and travis is great for the former, so
lets remove that problem.
