### PR TITLE
Improve safety & usability of |size_t| and |ssize_t|.

### DIFF
--- a/src/compiletest/raise_fd_limit.rs
+++ b/src/compiletest/raise_fd_limit.rs
@@ -50,7 +50,7 @@ pub unsafe fn raise_fd_limit() {
     // Fetch the kern.maxfilesperproc value
     let mut mib: [libc::c_int; 2] = [CTL_KERN, KERN_MAXFILESPERPROC];
     let mut maxfiles: libc::c_int = 0;
-    let mut size: libc::size_t = size_of_val(&maxfiles) as libc::size_t;
+    let mut size = size_of_val(&maxfiles);
     if sysctl(&mut mib[0], 2, &mut maxfiles as *mut _ as *mut _, &mut size,
               null_mut(), 0) != 0 {
         let err = io::Error::last_os_error();

--- a/src/liballoc_jemalloc/lib.rs
+++ b/src/liballoc_jemalloc/lib.rs
@@ -81,7 +81,7 @@ pub extern fn __rust_reallocate(ptr: *mut u8, _old_size: usize, size: usize,
 pub extern fn __rust_reallocate_inplace(ptr: *mut u8, _old_size: usize,
                                         size: usize, align: usize) -> usize {
     let flags = align_to_flags(align);
-    unsafe { je_xallocx(ptr as *mut c_void, size, 0, flags) as usize }
+    unsafe { je_xallocx(ptr as *mut c_void, size, 0, flags) }
 }
 
 #[no_mangle]
@@ -93,5 +93,5 @@ pub extern fn __rust_deallocate(ptr: *mut u8, old_size: usize, align: usize) {
 #[no_mangle]
 pub extern fn __rust_usable_size(size: usize, align: usize) -> usize {
     let flags = align_to_flags(align);
-    unsafe { je_nallocx(size, flags) as usize }
+    unsafe { je_nallocx(size, flags) }
 }

--- a/src/liballoc_jemalloc/lib.rs
+++ b/src/liballoc_jemalloc/lib.rs
@@ -67,31 +67,31 @@ fn align_to_flags(align: usize) -> c_int {
 #[no_mangle]
 pub extern fn __rust_allocate(size: usize, align: usize) -> *mut u8 {
     let flags = align_to_flags(align);
-    unsafe { je_mallocx(size as size_t, flags) as *mut u8 }
+    unsafe { je_mallocx(size, flags) as *mut u8 }
 }
 
 #[no_mangle]
 pub extern fn __rust_reallocate(ptr: *mut u8, _old_size: usize, size: usize,
                                 align: usize) -> *mut u8 {
     let flags = align_to_flags(align);
-    unsafe { je_rallocx(ptr as *mut c_void, size as size_t, flags) as *mut u8 }
+    unsafe { je_rallocx(ptr as *mut c_void, size, flags) as *mut u8 }
 }
 
 #[no_mangle]
 pub extern fn __rust_reallocate_inplace(ptr: *mut u8, _old_size: usize,
                                         size: usize, align: usize) -> usize {
     let flags = align_to_flags(align);
-    unsafe { je_xallocx(ptr as *mut c_void, size as size_t, 0, flags) as usize }
+    unsafe { je_xallocx(ptr as *mut c_void, size, 0, flags) as usize }
 }
 
 #[no_mangle]
 pub extern fn __rust_deallocate(ptr: *mut u8, old_size: usize, align: usize) {
     let flags = align_to_flags(align);
-    unsafe { je_sdallocx(ptr as *mut c_void, old_size as size_t, flags) }
+    unsafe { je_sdallocx(ptr as *mut c_void, old_size, flags) }
 }
 
 #[no_mangle]
 pub extern fn __rust_usable_size(size: usize, align: usize) -> usize {
     let flags = align_to_flags(align);
-    unsafe { je_nallocx(size as size_t, flags) as usize }
+    unsafe { je_nallocx(size, flags) as usize }
 }

--- a/src/liballoc_system/lib.rs
+++ b/src/liballoc_system/lib.rs
@@ -85,18 +85,16 @@ mod imp {
 
     pub unsafe fn allocate(size: usize, align: usize) -> *mut u8 {
         if align <= MIN_ALIGN {
-            libc::malloc(size as libc::size_t) as *mut u8
+            libc::malloc(size) as *mut u8
         } else {
             #[cfg(target_os = "android")]
             unsafe fn more_aligned_malloc(size: usize, align: usize) -> *mut u8 {
-                memalign(align as libc::size_t, size as libc::size_t) as *mut u8
+                memalign(align, size) as *mut u8
             }
             #[cfg(not(target_os = "android"))]
             unsafe fn more_aligned_malloc(size: usize, align: usize) -> *mut u8 {
                 let mut out = ptr::null_mut();
-                let ret = posix_memalign(&mut out,
-                                         align as libc::size_t,
-                                         size as libc::size_t);
+                let ret = posix_memalign(&mut out, align, size);
                 if ret != 0 {
                     ptr::null_mut()
                 } else {
@@ -110,7 +108,7 @@ mod imp {
     pub unsafe fn reallocate(ptr: *mut u8, old_size: usize, size: usize,
                              align: usize) -> *mut u8 {
         if align <= MIN_ALIGN {
-            libc::realloc(ptr as *mut libc::c_void, size as libc::size_t) as *mut u8
+            libc::realloc(ptr as *mut libc::c_void, size) as *mut u8
         } else {
             let new_ptr = allocate(size, align);
             ptr::copy(ptr, new_ptr, cmp::min(size, old_size));

--- a/src/libflate/lib.rs
+++ b/src/libflate/lib.rs
@@ -102,9 +102,7 @@ fn deflate_bytes_internal(bytes: &[u8], flags: c_int) -> Bytes {
     unsafe {
         let mut outsz: size_t = 0;
         let res = tdefl_compress_mem_to_heap(bytes.as_ptr() as *const _,
-                                             bytes.len() as size_t,
-                                             &mut outsz,
-                                             flags);
+                                             bytes.len(), &mut outsz, flags);
         assert!(!res.is_null());
         Bytes {
             ptr: Unique::new(res as *mut u8),
@@ -127,9 +125,7 @@ fn inflate_bytes_internal(bytes: &[u8], flags: c_int) -> Result<Bytes,Error> {
     unsafe {
         let mut outsz: size_t = 0;
         let res = tinfl_decompress_mem_to_heap(bytes.as_ptr() as *const _,
-                                               bytes.len() as size_t,
-                                               &mut outsz,
-                                               flags);
+                                               bytes.len(), &mut outsz, flags);
         if !res.is_null() {
             Ok(Bytes {
                 ptr: Unique::new(res as *mut u8),

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -4749,7 +4749,7 @@ pub mod consts {
 
             pub const PTHREAD_CREATE_JOINABLE : c_int = 0;
             pub const PTHREAD_CREATE_DETACHED : c_int = 1;
-            pub const PTHREAD_STACK_MIN : size_t = 2048;
+            pub const PTHREAD_STACK_MIN: size_t = 2048;
 
             pub const CLOCK_REALTIME : c_int = 0;
             pub const CLOCK_MONOTONIC : c_int = 3;

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -228,6 +228,50 @@ pub mod types {
     }
 
     // Standard types that are scalar but vary by OS and arch.
+    //
+    // ISO C's `size_t` is defined to be the type of the result of the
+    // `sizeof` operator and the type of the size parameter to `malloc`. That
+    // is, C's `size_t` is only required to hold the size of the largest object
+    // that can be allocated. In particular, it is legal for a C implementation
+    // to have a maximum object size smaller than the entire address space. For
+    // example, a C implementation may have an maximum object size of 2^32
+    // bytes with a 64-bit address space, and typedef `size_t` as `uint32_t` so
+    // that `sizeof(size_t) == 4` and `sizeof(void*) == 8`.
+    //
+    // Rust's `usize`, on the other hand, is defined to always be the same size
+    // as a pointer. This means that it is possible, in theory, to have a
+    // platform where `usize` can represent values that `size_t` cannot
+    // represent. However, on the vast majority of systems, `usize` and
+    // `size_t` are represented the same way. If it were required to explicitly
+    // cast `usize` to `size_t` on common platforms, then many programmers
+    // would habitually write expressions such as
+    // `my_slice.len() as libc::size_t` expecting this to always work and be
+    // safe. But such a cast is *not* safe on the uncommon platforms where
+    // `mem::sizeof(libc::size_t) < mem::size_t(usize)`. Consequently, to
+    // reduce the chances of programmers becoming habituated to such casts that
+    // would be unsafe on unusual platforms, we have adopted the following
+    // convention:
+    //
+    // * On common platforms where
+    //   `mem::sizeof(libc::size_t) == mem::sizeof(usize)`, `libc::size_t` must
+    //   be a type alias of `usize`, and `libc::ssize_t` must be a type alias
+    //   of `isize`.
+    //
+    // * On uncommon platforms where
+    //   `mem::sizeof(libc::size_t) != mem::sizeof(usize)`, `libc::size_t` and
+    //   `libc::ssize_t` must be defined as types other than `usize` and
+    //   `isize`.
+    //
+    // * Code that was written without consideration for the uncommon platforms
+    //   should not do any explicit casting between `libc::size_t` and `usize`
+    //   or `libc::ssize_t` and `isize`. Such code will fail to compile on the
+    //   uncommon platforms; this is better than executing with unsafe
+    //   truncations.
+    //
+    // * Code that was written with full consideration of the uncommon
+    //   platforms should have explicit casts using `num::cast` or other
+    //   methods that avoid unintended truncation. Such code will then work on
+    //   all platforms.
 
     #[cfg(any(target_os = "linux", target_os = "android", target_os = "nacl"))]
     pub mod os {
@@ -429,7 +473,7 @@ pub mod types {
                 pub type c_ulong = u32;
                 pub type c_float = f32;
                 pub type c_double = f64;
-                pub type size_t = u32;
+                pub type size_t = usize;
                 pub type ptrdiff_t = i32;
                 pub type clock_t = i32;
                 pub type time_t = i32;
@@ -459,7 +503,7 @@ pub mod types {
                 pub type gid_t = u32;
                 pub type useconds_t = u32;
                 pub type mode_t = u32;
-                pub type ssize_t = i32;
+                pub type ssize_t = isize;
             }
             #[cfg(all(any(target_arch = "arm", target_arch = "x86"),
                       target_os = "android"))]
@@ -474,7 +518,7 @@ pub mod types {
                 pub type useconds_t = u32;
 
                 pub type mode_t = u16;
-                pub type ssize_t = i32;
+                pub type ssize_t = isize;
             }
             #[cfg(any(all(any(target_arch = "arm", target_arch = "x86"),
                           not(target_os = "android")),
@@ -655,7 +699,7 @@ pub mod types {
                 pub type c_ulong = u64;
                 pub type c_float = f32;
                 pub type c_double = f64;
-                pub type size_t = u64;
+                pub type size_t = usize;
                 pub type ptrdiff_t = i64;
                 pub type clock_t = i64;
                 pub type time_t = i64;
@@ -682,7 +726,7 @@ pub mod types {
                 pub type gid_t = u32;
                 pub type useconds_t = u32;
                 pub type mode_t = u32;
-                pub type ssize_t = i64;
+                pub type ssize_t = isize;
             }
             #[cfg(not(target_arch = "aarch64"))]
             pub mod posix01 {
@@ -980,7 +1024,7 @@ pub mod types {
                 pub type c_ulong = u32;
                 pub type c_float = f32;
                 pub type c_double = f64;
-                pub type size_t = u32;
+                pub type size_t = usize;
                 pub type ptrdiff_t = i32;
                 pub type clock_t = i32;
                 pub type time_t = i32;
@@ -1004,7 +1048,7 @@ pub mod types {
                 pub type gid_t = u32;
                 pub type useconds_t = u32;
                 pub type mode_t = u16;
-                pub type ssize_t = i32;
+                pub type ssize_t = isize;
             }
             pub mod posix01 {
                 use types::common::c95::{c_void};
@@ -1074,7 +1118,7 @@ pub mod types {
                 pub type c_ulong = u64;
                 pub type c_float = f32;
                 pub type c_double = f64;
-                pub type size_t = u64;
+                pub type size_t = usize;
                 pub type ptrdiff_t = i64;
                 pub type clock_t = i32;
                 pub type time_t = i64;
@@ -1098,7 +1142,7 @@ pub mod types {
                 pub type gid_t = u32;
                 pub type useconds_t = u32;
                 pub type mode_t = u16;
-                pub type ssize_t = i64;
+                pub type ssize_t = isize;
             }
             pub mod posix01 {
                 use types::common::c95::{c_void};
@@ -1340,7 +1384,7 @@ pub mod types {
                 pub type c_ulong = u64;
                 pub type c_float = f32;
                 pub type c_double = f64;
-                pub type size_t = u64;
+                pub type size_t = usize;
                 pub type ptrdiff_t = i64;
                 pub type clock_t = i32;
                 pub type time_t = i64;
@@ -1363,7 +1407,7 @@ pub mod types {
                 pub type gid_t = u32;
                 pub type useconds_t = u32;
                 pub type mode_t = u16;
-                pub type ssize_t = i64;
+                pub type ssize_t = isize;
             }
             pub mod posix01 {
                 use types::common::c95::{c_void};
@@ -1625,7 +1669,7 @@ pub mod types {
                 pub type c_ulong = u64;
                 pub type c_float = f32;
                 pub type c_double = f64;
-                pub type size_t = u64;
+                pub type size_t = usize;
                 pub type ptrdiff_t = i64;
                 pub type clock_t = i64;
                 pub type time_t = i64;
@@ -1649,7 +1693,7 @@ pub mod types {
                 pub type gid_t = u32;
                 pub type useconds_t = u32;
                 pub type mode_t = u32;
-                pub type ssize_t = c_long;
+                pub type ssize_t = isize;
             }
             pub mod posix01 {
                 use types::common::c95::{c_void};
@@ -1845,10 +1889,7 @@ pub mod types {
                 pub type c_float = f32;
                 pub type c_double = f64;
 
-                #[cfg(target_arch = "x86")]
-                pub type size_t = u32;
-                #[cfg(target_arch = "x86_64")]
-                pub type size_t = u64;
+                pub type size_t = usize;
 
                 #[cfg(target_arch = "x86")]
                 pub type ptrdiff_t = i32;
@@ -1898,10 +1939,7 @@ pub mod types {
                 pub type useconds_t = u32;
                 pub type mode_t = u16;
 
-                #[cfg(target_arch = "x86")]
-                pub type ssize_t = i32;
-                #[cfg(target_arch = "x86_64")]
-                pub type ssize_t = i64;
+                pub type ssize_t = isize;
             }
 
             pub mod posix01 {
@@ -2345,7 +2383,7 @@ pub mod types {
                 pub type gid_t = u32;
                 pub type useconds_t = u32;
                 pub type mode_t = u16;
-                pub type ssize_t = c_long;
+                pub type ssize_t = isize;
             }
             pub mod posix01 {
                 use types::common::c99::{int32_t, int64_t, uint32_t};
@@ -2453,7 +2491,7 @@ pub mod types {
                 pub type gid_t = u32;
                 pub type useconds_t = u32;
                 pub type mode_t = u16;
-                pub type ssize_t = c_long;
+                pub type ssize_t = isize;
             }
             pub mod posix01 {
                 use types::common::c99::{int32_t, int64_t};

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -550,14 +550,9 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                 FfiSafe
             }
 
-            ty::TyInt(ast::TyIs) => {
-                FfiUnsafe("found Rust type `isize` in foreign module, while \
-                          `libc::c_int` or `libc::c_long` should be used")
-            }
-            ty::TyUint(ast::TyUs) => {
-                FfiUnsafe("found Rust type `usize` in foreign module, while \
-                          `libc::c_uint` or `libc::c_ulong` should be used")
-            }
+            // FIXME: We should warn about `usize`/`isize`/ if (and only if)
+            // `size_t`/'ssize_t' are not defined as aliases for them.
+
             ty::TyChar => {
                 FfiUnsafe("found Rust type `char` in foreign module, while \
                            `u32` or `libc::wchar_t` should be used")

--- a/src/librustc_trans/back/archive.rs
+++ b/src/librustc_trans/back/archive.rs
@@ -20,7 +20,6 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::str;
 
-use libc;
 use llvm::archive_ro::{ArchiveRO, Child};
 use llvm::{self, ArchiveKind};
 use rustc::metadata::loader::METADATA_FILENAME;
@@ -485,8 +484,7 @@ impl<'a> ArchiveBuilder<'a> {
 
             let dst = self.config.dst.to_str().unwrap().as_bytes();
             let dst = try!(CString::new(dst));
-            let r = llvm::LLVMRustWriteArchive(dst.as_ptr(),
-                                               members.len() as libc::size_t,
+            let r = llvm::LLVMRustWriteArchive(dst.as_ptr(), members.len(),
                                                members.as_ptr(),
                                                self.should_update_symbols,
                                                kind);

--- a/src/librustc_trans/back/lto.rs
+++ b/src/librustc_trans/back/lto.rs
@@ -97,7 +97,7 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
             time(sess.time_passes(), &format!("ll link {}", name), || unsafe {
                 if !llvm::LLVMRustLinkInExternalBitcode(llmod,
                                                         ptr as *const libc::c_char,
-                                                        bc_decoded.len() as libc::size_t) {
+                                                        bc_decoded.len()) {
                     write::llvm_err(sess.diagnostic().handler(),
                                     format!("failed to load bc of `{}`",
                                             &name[..]));
@@ -115,7 +115,7 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
     unsafe {
         llvm::LLVMRustRunRestrictionPass(llmod,
                                          ptr as *const *const libc::c_char,
-                                         arr.len() as libc::size_t);
+                                         arr.len());
     }
 
     if sess.no_landing_pads() {

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -361,8 +361,7 @@ pub fn render(w: &mut fmt::Formatter, s: &str, print_toc: bool) -> fmt::Result {
         (*renderer).codespan = Some(codespan);
 
         let document = hoedown_document_new(renderer, HOEDOWN_EXTENSIONS, 16);
-        hoedown_document_render(document, ob, s.as_ptr(),
-                                s.len() as libc::size_t);
+        hoedown_document_render(document, ob, s.as_ptr(), s.len());
         hoedown_document_free(document);
 
         hoedown_html_renderer_free(renderer);
@@ -435,8 +434,7 @@ pub fn find_testable_code(doc: &str, tests: &mut ::test::Collector) {
                 = tests as *mut _ as *mut libc::c_void;
 
         let document = hoedown_document_new(renderer, HOEDOWN_EXTENSIONS, 16);
-        hoedown_document_render(document, ob, doc.as_ptr(),
-                                doc.len() as libc::size_t);
+        hoedown_document_render(document, ob, doc.as_ptr(), doc.len());
         hoedown_document_free(document);
 
         hoedown_html_renderer_free(renderer);
@@ -556,8 +554,7 @@ pub fn plain_summary_line(md: &str) -> String {
         (*renderer).normal_text = Some(normal_text);
 
         let document = hoedown_document_new(renderer, HOEDOWN_EXTENSIONS, 16);
-        hoedown_document_render(document, ob, md.as_ptr(),
-                                md.len() as libc::size_t);
+        hoedown_document_render(document, ob, md.as_ptr(), md.len());
         hoedown_document_free(document);
         let plain_slice = (*ob).as_bytes();
         let plain = match str::from_utf8(plain_slice) {

--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -136,7 +136,7 @@ mod prim_unit { }
 ///
 /// fn main() {
 ///     unsafe {
-///         let my_num: *mut i32 = libc::malloc(mem::size_of::<i32>() as libc::size_t) as *mut i32;
+///         let my_num: *mut i32 = libc::malloc(mem::size_of::<i32>()) as *mut i32;
 ///         if my_num.is_null() {
 ///             panic!("failed to allocate memory");
 ///         }

--- a/src/libstd/rand/os.rs
+++ b/src/libstd/rand/os.rs
@@ -235,8 +235,7 @@ mod imp {
         }
         fn fill_bytes(&mut self, v: &mut [u8]) {
             let ret = unsafe {
-                SecRandomCopyBytes(kSecRandomDefault, v.len() as size_t,
-                                   v.as_mut_ptr())
+                SecRandomCopyBytes(kSecRandomDefault, v.len(), v.as_mut_ptr())
             };
             if ret == -1 {
                 panic!("couldn't generate random bytes: {}",

--- a/src/libstd/sys/common/net.rs
+++ b/src/libstd/sys/common/net.rs
@@ -153,8 +153,8 @@ pub fn lookup_addr(addr: &IpAddr) -> io::Result<String> {
 
     let data = unsafe {
         try!(cvt_gai(getnameinfo(inner, len,
-                                 hostbuf.as_mut_ptr(), NI_MAXHOST as libc::size_t,
-                                 0 as *mut _, 0, 0)));
+                                 hostbuf.as_mut_ptr(), NI_MAXHOST, 0 as *mut _,
+                                 0, 0)));
 
         CStr::from_ptr(hostbuf.as_ptr())
     };

--- a/src/libstd/sys/unix/fd.rs
+++ b/src/libstd/sys/unix/fd.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use io;
-use libc::{self, c_int, size_t, c_void};
+use libc::{self, c_int, c_void};
 use mem;
 use sys::c;
 use sys::cvt;
@@ -35,18 +35,14 @@ impl FileDesc {
 
     pub fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
         let ret = try!(cvt(unsafe {
-            libc::read(self.fd,
-                       buf.as_mut_ptr() as *mut c_void,
-                       buf.len() as size_t)
+            libc::read(self.fd, buf.as_mut_ptr() as *mut c_void, buf.len())
         }));
         Ok(ret as usize)
     }
 
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
         let ret = try!(cvt(unsafe {
-            libc::write(self.fd,
-                        buf.as_ptr() as *const c_void,
-                        buf.len() as size_t)
+            libc::write(self.fd, buf.as_ptr() as *const c_void, buf.len())
         }));
         Ok(ret as usize)
     }

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -14,7 +14,7 @@ use os::unix::prelude::*;
 use ffi::{CString, CStr, OsString, OsStr};
 use fmt;
 use io::{self, Error, ErrorKind, SeekFrom};
-use libc::{self, c_int, size_t, off_t, c_char, mode_t};
+use libc::{self, c_int, off_t, c_char, mode_t};
 use mem;
 use path::{Path, PathBuf};
 use ptr;
@@ -477,7 +477,7 @@ pub fn readlink(p: &Path) -> io::Result<PathBuf> {
 
     loop {
         let buf_read = try!(cvt(unsafe {
-            libc::readlink(p, buf.as_mut_ptr() as *mut _, buf.capacity() as libc::size_t)
+            libc::readlink(p, buf.as_mut_ptr() as *mut _, buf.capacity())
         })) as usize;
 
         unsafe { buf.set_len(buf_read); }

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -196,13 +196,13 @@ pub fn current_exe() -> io::Result<PathBuf> {
                          ptr::null_mut(), &mut sz, ptr::null_mut(), 0);
         if err != 0 { return Err(io::Error::last_os_error()); }
         if sz == 0 { return Err(io::Error::last_os_error()); }
-        let mut v: Vec<u8> = Vec::with_capacity(sz as usize);
+        let mut v: Vec<u8> = Vec::with_capacity(sz);
         let err = sysctl(mib.as_mut_ptr(), mib.len() as ::libc::c_uint,
                          v.as_mut_ptr() as *mut libc::c_void, &mut sz,
                          ptr::null_mut(), 0);
         if err != 0 { return Err(io::Error::last_os_error()); }
         if sz == 0 { return Err(io::Error::last_os_error()); }
-        v.set_len(sz as usize - 1); // chop off trailing NUL
+        v.set_len(sz - 1); // chop off trailing NUL
         Ok(PathBuf::from(OsString::from_vec(v)))
     }
 }
@@ -246,10 +246,10 @@ pub fn current_exe() -> io::Result<PathBuf> {
         let mut sz: u32 = 0;
         _NSGetExecutablePath(ptr::null_mut(), &mut sz);
         if sz == 0 { return Err(io::Error::last_os_error()); }
-        let mut v: Vec<u8> = Vec::with_capacity(sz as usize);
+        let mut v: Vec<u8> = Vec::with_capacity(sz);
         let err = _NSGetExecutablePath(v.as_mut_ptr() as *mut i8, &mut sz);
         if err != 0 { return Err(io::Error::last_os_error()); }
-        v.set_len(sz as usize - 1); // chop off trailing NUL
+        v.set_len(sz - 1); // chop off trailing NUL
         Ok(PathBuf::from(OsString::from_vec(v)))
     }
 }

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -83,7 +83,7 @@ pub fn error_string(errno: i32) -> String {
 
     let p = buf.as_mut_ptr();
     unsafe {
-        if strerror_r(errno as c_int, p, buf.len() as libc::size_t) < 0 {
+        if strerror_r(errno as c_int, p, buf.len()) < 0 {
             panic!("strerror_r failure");
         }
 
@@ -97,7 +97,7 @@ pub fn getcwd() -> io::Result<PathBuf> {
     loop {
         unsafe {
             let ptr = buf.as_mut_ptr() as *mut libc::c_char;
-            if !libc::getcwd(ptr, buf.capacity() as libc::size_t).is_null() {
+            if !libc::getcwd(ptr, buf.capacity()).is_null() {
                 let len = CStr::from_ptr(buf.as_ptr() as *const libc::c_char).to_bytes().len();
                 buf.set_len(len);
                 buf.shrink_to_fit();
@@ -193,14 +193,13 @@ pub fn current_exe() -> io::Result<PathBuf> {
                            -1 as c_int];
         let mut sz: libc::size_t = 0;
         let err = sysctl(mib.as_mut_ptr(), mib.len() as ::libc::c_uint,
-                         ptr::null_mut(), &mut sz, ptr::null_mut(),
-                         0 as libc::size_t);
+                         ptr::null_mut(), &mut sz, ptr::null_mut(), 0);
         if err != 0 { return Err(io::Error::last_os_error()); }
         if sz == 0 { return Err(io::Error::last_os_error()); }
         let mut v: Vec<u8> = Vec::with_capacity(sz as usize);
         let err = sysctl(mib.as_mut_ptr(), mib.len() as ::libc::c_uint,
                          v.as_mut_ptr() as *mut libc::c_void, &mut sz,
-                         ptr::null_mut(), 0 as libc::size_t);
+                         ptr::null_mut(), 0);
         if err != 0 { return Err(io::Error::last_os_error()); }
         if sz == 0 { return Err(io::Error::last_os_error()); }
         v.set_len(sz as usize - 1); // chop off trailing NUL
@@ -483,8 +482,7 @@ pub fn home_dir() -> Option<PathBuf> {
             let mut passwd: c::passwd = mem::zeroed();
             let mut result = 0 as *mut _;
             match c::getpwuid_r(me, &mut passwd, buf.as_mut_ptr(),
-                                buf.capacity() as libc::size_t,
-                                &mut result) {
+                                buf.capacity(), &mut result) {
                 0 if !result.is_null() => {}
                 _ => return None
             }

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -360,8 +360,8 @@ fn min_stack_size(attr: *const libc::pthread_attr_t) -> usize {
     });
 
     match unsafe { __pthread_get_minstack } {
-        None => PTHREAD_STACK_MIN as usize,
-        Some(f) => unsafe { f(attr) as usize },
+        None => PTHREAD_STACK_MIN,
+        Some(f) => unsafe { f(attr) },
     }
 }
 
@@ -369,7 +369,7 @@ fn min_stack_size(attr: *const libc::pthread_attr_t) -> usize {
 // platforms.
 #[cfg(not(target_os = "linux"))]
 fn min_stack_size(_: *const libc::pthread_attr_t) -> usize {
-    PTHREAD_STACK_MIN as usize
+    PTHREAD_STACK_MIN
 }
 
 extern {

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -43,7 +43,7 @@ impl Thread {
         assert_eq!(pthread_attr_init(&mut attr), 0);
 
         let stack_size = cmp::max(stack, min_stack_size(&attr));
-        match pthread_attr_setstacksize(&mut attr, stack_size as libc::size_t) {
+        match pthread_attr_setstacksize(&mut attr, stack_size) {
             0 => {}
             n => {
                 assert_eq!(n, libc::EINVAL);
@@ -54,7 +54,7 @@ impl Thread {
                 let page_size = os::page_size();
                 let stack_size = (stack_size + page_size - 1) &
                                  (-(page_size as isize - 1) as usize - 1);
-                let stack_size = stack_size as libc::size_t;
+                let stack_size = stack_size;
                 assert_eq!(pthread_attr_setstacksize(&mut attr, stack_size), 0);
             }
         };
@@ -238,7 +238,7 @@ pub mod guard {
         // This ensures SIGBUS will be raised on
         // stack overflow.
         let result = mmap(stackaddr,
-                          psize as libc::size_t,
+                          psize,
                           PROT_NONE,
                           MAP_PRIVATE | MAP_ANON | MAP_FIXED,
                           -1,
@@ -259,7 +259,7 @@ pub mod guard {
             fn pthread_get_stackaddr_np(thread: pthread_t) -> *mut libc::c_void;
             fn pthread_get_stacksize_np(thread: pthread_t) -> libc::size_t;
         }
-        Some((pthread_get_stackaddr_np(pthread_self()) as libc::size_t -
+        Some((pthread_get_stackaddr_np(pthread_self()) -
               pthread_get_stacksize_np(pthread_self())) as usize)
     }
 

--- a/src/libstd/sys/windows/thread.rs
+++ b/src/libstd/sys/windows/thread.rs
@@ -37,9 +37,9 @@ impl Thread {
         // Round up to the next 64 kB because that's what the NT kernel does,
         // might as well make it explicit.
         let stack_size = (stack + 0xfffe) & (!0xfffe);
-        let ret = c::CreateThread(ptr::null_mut(), stack_size as libc::size_t,
-                                  thread_start, &*p as *const _ as *mut _,
-                                  0, ptr::null_mut());
+        let ret = c::CreateThread(ptr::null_mut(), stack_size, thread_start,
+                                  &*p as *const _ as *mut _, 0,
+                                  ptr::null_mut());
 
         return if ret as usize == 0 {
             Err(io::Error::last_os_error())

--- a/src/test/auxiliary/allocator-dummy.rs
+++ b/src/test/auxiliary/allocator-dummy.rs
@@ -23,7 +23,7 @@ pub static mut HITS: usize = 0;
 pub extern fn __rust_allocate(size: usize, align: usize) -> *mut u8 {
     unsafe {
         HITS += 1;
-        libc::malloc(size as libc::size_t) as *mut u8
+        libc::malloc(size) as *mut u8
     }
 }
 
@@ -39,7 +39,7 @@ pub extern fn __rust_deallocate(ptr: *mut u8, old_size: usize, align: usize) {
 pub extern fn __rust_reallocate(ptr: *mut u8, old_size: usize, size: usize,
                                 align: usize) -> *mut u8 {
     unsafe {
-        libc::realloc(ptr as *mut _, size as libc::size_t) as *mut u8
+        libc::realloc(ptr as *mut _, size) as *mut u8
     }
 }
 

--- a/src/test/bench/shootout-reverse-complement.rs
+++ b/src/test/bench/shootout-reverse-complement.rs
@@ -103,9 +103,9 @@ impl Tables {
 
 /// Finds the first position at which `b` occurs in `s`.
 fn memchr(h: &[u8], n: u8) -> Option<usize> {
-    use libc::{c_void, c_int, size_t};
+    use libc::{c_void, c_int};
     let res = unsafe {
-        libc::memchr(h.as_ptr() as *const c_void, n as c_int, h.len() as size_t)
+        libc::memchr(h.as_ptr() as *const c_void, n as c_int, h.len())
     };
     if res.is_null() {
         None

--- a/src/test/compile-fail/warn-foreign-int-types.rs
+++ b/src/test/compile-fail/warn-foreign-int-types.rs
@@ -13,9 +13,11 @@
 
 mod xx {
     extern {
-        pub fn strlen(str: *const u8) -> usize; //~ ERROR found Rust type `usize`
-        pub fn foo(x: isize, y: usize); //~ ERROR found Rust type `isize`
-        //~^ ERROR found Rust type `usize`
+        pub fn strlen_good(str: *const u8) -> usize; // `usize` is OK.
+        pub fn strlen_bad(str: *const char) -> usize; //~ ERROR found Rust type `char`
+        pub fn foo(x: isize, y: usize); // `isize` is OK.
+        pub fn bar(x: &[u8]); //~ ERROR found Rust slice type
+        //~^ ERROR found Rust type `char`
     }
 }
 

--- a/src/test/run-pass/regions-mock-trans.rs
+++ b/src/test/run-pass/regions-mock-trans.rs
@@ -32,8 +32,7 @@ struct Ccx {
 
 fn alloc<'a>(_bcx : &'a arena) -> &'a Bcx<'a> {
     unsafe {
-        mem::transmute(libc::malloc(mem::size_of::<Bcx<'a>>()
-            as libc::size_t))
+        mem::transmute(libc::malloc(mem::size_of::<Bcx<'a>>()))
     }
 }
 


### PR DESCRIPTION
I mostly just want to get feedback on this change before I do any of the additional work that should be done:
- Fix any compiler errors caused by changing the definitions of these types.
- Remove any now-redundant (and potentially unsafe) casting in the repository.
