### PR TITLE
hide docs for private `collections::btree::Recover` trait

### DIFF
--- a/src/libcollections/btree/mod.rs
+++ b/src/libcollections/btree/mod.rs
@@ -12,6 +12,7 @@ mod node;
 pub mod map;
 pub mod set;
 
+#[doc(hidden)]
 trait Recover<Q: ?Sized> {
     type Key;
 


### PR DESCRIPTION
closes #28093
