### PR TITLE
Translate constructor arguments for zero-sized tuple structs

### DIFF
--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -1758,6 +1758,17 @@ pub fn trans_named_tuple_constructor<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
             }
             _ => ccx.sess().bug("expected expr as arguments for variant/struct tuple constructor")
         }
+    } else {
+        // Just eval all the expressions (if any). Since expressions in Rust can have arbitrary
+        // contents, there could be side-effects we need from them.
+        match args {
+            callee::ArgExprs(exprs) => {
+                for expr in exprs {
+                    bcx = expr::trans_into(bcx, expr, expr::Ignore);
+                }
+            }
+            _ => ()
+        }
     }
 
     // If the caller doesn't care about the result

--- a/src/test/run-pass/zero-sized-tuple-struct.rs
+++ b/src/test/run-pass/zero-sized-tuple-struct.rs
@@ -1,0 +1,21 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(unused_assignments)]
+
+// Make sure that the constructor args are translated for zero-sized tuple structs
+
+struct Foo(());
+
+fn main() {
+    let mut a = 1;
+    Foo({ a = 2 });
+    assert_eq!(a, 2);
+}


### PR DESCRIPTION
This was preventing any side-effects from the expressions from
happening.

Fixes #28114

cc @rust-lang/compiler 
