### PR TITLE
Specialise count, last and nth for Cloned and Map iterators

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -1421,6 +1421,18 @@ impl<'a, I, T: 'a> Iterator for Cloned<I>
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.it.size_hint()
     }
+
+    fn count(self) -> usize {
+        self.it.count()
+    }
+
+    fn last(self) -> Option<T> {
+        self.it.last().cloned()
+    }
+
+    fn nth(&mut self, n: usize) -> Option<T> {
+        self.it.nth(n).cloned()
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
Map/Cloned does not call the mapping/cloning function unnecessarily anymore for `count`, `last` and `nth`, which has a serious benefit to performance, especially with expensive mapping functions.

For example 

``` rust
(1..10).map(|x| {
    for y in 1..50 { black_box(y); }
    black_box(x)
}).last()
```

runs in 25 ns/iter (+/- 9) compared to 238 ns/iter (+/- 21) with nightly.
