### PR TITLE
std: Run TLS destructors in a statically linked binary

### DIFF
--- a/src/test/run-pass/tls-dtors-are-run-in-a-static-binary.rs
+++ b/src/test/run-pass/tls-dtors-are-run-in-a-static-binary.rs
@@ -8,36 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-thread_local!(static FOO: Foo = Foo);
-thread_local!(static BAR: Bar = Bar(1));
-thread_local!(static BAZ: Baz = Baz);
+// no-prefer-dynamic
 
 static mut HIT: bool = false;
 
 struct Foo;
-struct Bar(i32);
-struct Baz;
 
 impl Drop for Foo {
-    fn drop(&mut self) {
-        BAR.with(|_| {});
-    }
-}
-
-impl Drop for Bar {
-    fn drop(&mut self) {
-        assert_eq!(self.0, 1);
-        self.0 = 2;
-        BAZ.with(|_| {});
-        assert_eq!(self.0, 2);
-    }
-}
-
-impl Drop for Baz {
     fn drop(&mut self) {
         unsafe { HIT = true; }
     }
 }
+
+thread_local!(static FOO: Foo = Foo);
 
 fn main() {
     std::thread::spawn(|| {


### PR DESCRIPTION
Running TLS destructors for a MSVC Windows binary requires the linker doesn't
elide the `_tls_used` or `__tls_used` symbols (depending on the architecture).
This is currently achieved via a `#[link_args]` hack but this only works for
dynamically linked binaries because the link arguments aren't propagated to
statically linked binaries.

This commit alters the strategy to instead emit a volatile load from those
symbols so LLVM can't elide it, forcing the reference to the symbol to stay
alive as long as the callback function stays alive (which we've made sure of
with the `#[linkage]` attribute).

Closes #28111
