### PR TITLE
Fix some typos in SSE-AVX intrinsics

### DIFF
--- a/src/etc/platform-intrinsics/x86/sse2.json
+++ b/src/etc/platform-intrinsics/x86/sse2.json
@@ -19,8 +19,8 @@
             "intrinsic": "_madd_epi16",
             "width": [128],
             "llvm": "pmadd.wd",
-            "ret": "s16",
-            "args": ["0", "0"]
+            "ret": "s32",
+            "args": ["s16", "s16"]
         },
         {
             "intrinsic": "_max_{0.data_type}",
@@ -68,11 +68,11 @@
             "intrinsic": "_mul_epu32",
             "width": [128],
             "llvm": "pmulu.dq",
-            "ret": "s64",
+            "ret": "u64",
             "args": ["0dn", "0dn"]
         },
         {
-            "intrinsic": "_mulhi_ep{0.kind}16",
+            "intrinsic": "_mulhi_{0.data_type}",
             "width": [128],
             "llvm": "pmulh{0.kind_short}.w",
             "ret": "i16",

--- a/src/etc/platform-intrinsics/x86/sse41.json
+++ b/src/etc/platform-intrinsics/x86/sse41.json
@@ -39,7 +39,7 @@
         {
             "intrinsic": "_mul_epi32",
             "width": [128],
-            "llvm": "muldq",
+            "llvm": "pmuldq",
             "ret": "s64",
             "args": ["s32", "s32"]
         },
@@ -58,9 +58,9 @@
             "args": ["u64", "u64"]
         },
         {
-            "intrinsic": "_testncz_si128",
+            "intrinsic": "_testnzc_si128",
             "width": [128],
-            "llvm": "ptest.nzc",
+            "llvm": "ptestnzc",
             "ret": "S32",
             "args": ["u64", "u64"]
         },

--- a/src/etc/platform-intrinsics/x86/ssse3.json
+++ b/src/etc/platform-intrinsics/x86/ssse3.json
@@ -4,7 +4,7 @@
         {
             "intrinsic": "_abs_{0.data_type}",
             "width": [128],
-            "llvm": "pabs.{0.data_type_short}",
+            "llvm": "pabs.{0.data_type_short}.128",
             "ret": "s(8-32)",
             "args": ["0"]
         },
@@ -41,7 +41,7 @@
             "width": [128],
             "llvm": "pmadd.ub.sw.128",
             "ret": "s16",
-            "args": ["s8", "s8"]
+            "args": ["u8", "s8"]
         },
         {
             "intrinsic": "_mulhrs_epi16",
@@ -61,7 +61,7 @@
             "intrinsic": "_sign_{0.data_type}",
             "width": [128],
             "llvm": "psign.{0.data_type_short}.128",
-            "ret": "s(8-16)",
+            "ret": "s(8-32)",
             "args": ["0", "0"]
         }
     ]

--- a/src/librustc_platform_intrinsics/x86.rs
+++ b/src/librustc_platform_intrinsics/x86.rs
@@ -82,7 +82,7 @@ pub fn find<'tcx>(_tcx: &ty::ctxt<'tcx>, name: &str) -> Option<Intrinsic> {
         },
         "_madd_epi16" => Intrinsic {
             inputs: vec![v(i(16), 8), v(i(16), 8)],
-            output: v(i(16), 8),
+            output: v(i(32), 4),
             definition: Named("llvm.x86.sse2.pmadd.wd")
         },
         "_max_epi16" => Intrinsic {
@@ -126,11 +126,11 @@ pub fn find<'tcx>(_tcx: &ty::ctxt<'tcx>, name: &str) -> Option<Intrinsic> {
             definition: Named("llvm.x86.sse2.pmovmskb.128")
         },
         "_mul_epu32" => Intrinsic {
-            inputs: vec![v(i(32), 4), v(i(32), 4)],
-            output: v(i(64), 2),
+            inputs: vec![v(u(32), 4), v(u(32), 4)],
+            output: v(u(64), 2),
             definition: Named("llvm.x86.sse2.pmulu.dq")
         },
-        "_mulhi_eps16" => Intrinsic {
+        "_mulhi_epi16" => Intrinsic {
             inputs: vec![v(i(16), 8), v(i(16), 8)],
             output: v(i(16), 8),
             definition: Named("llvm.x86.sse2.pmulh.w")
@@ -218,17 +218,17 @@ pub fn find<'tcx>(_tcx: &ty::ctxt<'tcx>, name: &str) -> Option<Intrinsic> {
         "_abs_epi8" => Intrinsic {
             inputs: vec![v(i(8), 16)],
             output: v(i(8), 16),
-            definition: Named("llvm.x86.ssse3.pabs.b")
+            definition: Named("llvm.x86.ssse3.pabs.b.128")
         },
         "_abs_epi16" => Intrinsic {
             inputs: vec![v(i(16), 8)],
             output: v(i(16), 8),
-            definition: Named("llvm.x86.ssse3.pabs.w")
+            definition: Named("llvm.x86.ssse3.pabs.w.128")
         },
         "_abs_epi32" => Intrinsic {
             inputs: vec![v(i(32), 4)],
             output: v(i(32), 4),
-            definition: Named("llvm.x86.ssse3.pabs.d")
+            definition: Named("llvm.x86.ssse3.pabs.d.128")
         },
         "_hadd_epi16" => Intrinsic {
             inputs: vec![v(i(16), 8), v(i(16), 8)],
@@ -261,7 +261,7 @@ pub fn find<'tcx>(_tcx: &ty::ctxt<'tcx>, name: &str) -> Option<Intrinsic> {
             definition: Named("llvm.x86.ssse3.phsub.sw.128")
         },
         "_maddubs_epi16" => Intrinsic {
-            inputs: vec![v(i(8), 16), v(i(8), 16)],
+            inputs: vec![v(u(8), 16), v(i(8), 16)],
             output: v(i(16), 8),
             definition: Named("llvm.x86.ssse3.pmadd.ub.sw.128")
         },
@@ -284,6 +284,11 @@ pub fn find<'tcx>(_tcx: &ty::ctxt<'tcx>, name: &str) -> Option<Intrinsic> {
             inputs: vec![v(i(16), 8), v(i(16), 8)],
             output: v(i(16), 8),
             definition: Named("llvm.x86.ssse3.psign.w.128")
+        },
+        "_sign_epi32" => Intrinsic {
+            inputs: vec![v(i(32), 4), v(i(32), 4)],
+            output: v(i(32), 4),
+            definition: Named("llvm.x86.ssse3.psign.d.128")
         },
         "_dp_ps" => Intrinsic {
             inputs: vec![v(f(32), 4), v(f(32), 4), i_(32, 8)],
@@ -348,7 +353,7 @@ pub fn find<'tcx>(_tcx: &ty::ctxt<'tcx>, name: &str) -> Option<Intrinsic> {
         "_mul_epi32" => Intrinsic {
             inputs: vec![v(i(32), 4), v(i(32), 4)],
             output: v(i(64), 2),
-            definition: Named("llvm.x86.sse41.muldq")
+            definition: Named("llvm.x86.sse41.pmuldq")
         },
         "_packus_epi32" => Intrinsic {
             inputs: vec![v(i(32), 4), v(i(32), 4)],
@@ -360,10 +365,10 @@ pub fn find<'tcx>(_tcx: &ty::ctxt<'tcx>, name: &str) -> Option<Intrinsic> {
             output: i(32),
             definition: Named("llvm.x86.sse41.ptestc")
         },
-        "_testncz_si128" => Intrinsic {
+        "_testnzc_si128" => Intrinsic {
             inputs: vec![v(u(64), 2), v(u(64), 2)],
             output: i(32),
-            definition: Named("llvm.x86.sse41.ptest.nzc")
+            definition: Named("llvm.x86.sse41.ptestnzc")
         },
         "_testz_si128" => Intrinsic {
             inputs: vec![v(u(64), 2), v(u(64), 2)],


### PR DESCRIPTION
I believe everything that doesn't take a constant integer up to SSE4.2
should now be correct (I don't have any reason to believe that those
that do take constant integers are wrong; they're just more complicated
and I just haven't tested them in detail).

(Also, takes out two unused code paths from trans.)
