### PR TITLE
refactored compiletest following clippy's suggestions

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -178,7 +178,7 @@ pub fn log_config(config: &Config) {
     logv(c, format!("filter: {}",
                     opt_str(&config.filter
                                    .as_ref()
-                                   .map(|re| re.to_string()))));
+                                   .map(|re| re.to_owned()))));
     logv(c, format!("runtool: {}", opt_str(&config.runtool)));
     logv(c, format!("host-rustcflags: {}",
                     opt_str(&config.host_rustcflags)));
@@ -205,19 +205,16 @@ pub fn opt_str<'a>(maybestr: &'a Option<String>) -> &'a str {
 
 pub fn opt_str2(maybestr: Option<String>) -> String {
     match maybestr {
-        None => "(none)".to_string(),
+        None => "(none)".to_owned(),
         Some(s) => s,
     }
 }
 
 pub fn run_tests(config: &Config) {
     if config.target.contains("android") {
-        match config.mode {
-            DebugInfoGdb => {
-                println!("{} debug-info test uses tcp 5039 port.\
-                         please reserve it", config.target);
-            }
-            _ =>{}
+        if let DebugInfoGdb = config.mode {
+            println!("{} debug-info test uses tcp 5039 port.\
+                     please reserve it", config.target);
         }
 
         // android debug-info test uses remote debugger
@@ -289,10 +286,10 @@ pub fn is_test(config: &Config, testfile: &Path) -> bool {
     // Pretty-printer does not work with .rc files yet
     let valid_extensions =
         match config.mode {
-          Pretty => vec!(".rs".to_string()),
-          _ => vec!(".rc".to_string(), ".rs".to_string())
+          Pretty => vec!(".rs".to_owned()),
+          _ => vec!(".rc".to_owned(), ".rs".to_owned())
         };
-    let invalid_prefixes = vec!(".".to_string(), "#".to_string(), "~".to_string());
+    let invalid_prefixes = vec!(".".to_owned(), "#".to_owned(), "~".to_owned());
     let name = testfile.file_name().unwrap().to_str().unwrap();
 
     let mut valid = false;
@@ -364,7 +361,7 @@ fn extract_gdb_version(full_version_line: Option<String>) -> Option<String> {
                    full_version_line.char_at(pos + 3).is_digit(10) {
                     continue
                 }
-                return Some(full_version_line[pos..pos+3].to_string());
+                return Some(full_version_line[pos..pos+3].to_owned());
             }
             println!("Could not extract GDB version from line '{}'",
                      full_version_line);
@@ -386,9 +383,8 @@ fn extract_lldb_version(full_version_line: Option<String>) -> Option<String> {
     // We are only interested in the major version number, so this function
     // will return `Some("179")` and `Some("300")` respectively.
 
-    match full_version_line {
-        Some(ref full_version_line)
-          if !full_version_line.trim().is_empty() => {
+    if let Some(ref full_version_line) = full_version_line {
+        if !full_version_line.trim().is_empty() {
             let full_version_line = full_version_line.trim();
 
             for (pos, l) in full_version_line.char_indices() {
@@ -410,8 +406,7 @@ fn extract_lldb_version(full_version_line: Option<String>) -> Option<String> {
             }
             println!("Could not extract LLDB version from line '{}'",
                      full_version_line);
-            None
-        },
-        _ => None
+        }
     }
+    None
 }

--- a/src/compiletest/errors.rs
+++ b/src/compiletest/errors.rs
@@ -76,7 +76,7 @@ fn parse_expected(last_nonfollow_error: Option<usize>,
     let letters = line[kind_start..].chars();
     let msg = letters.skip_while(|c| c.is_whitespace())
                      .skip_while(|c| !c.is_whitespace())
-                     .collect::<String>().trim().to_string();
+                     .collect::<String>().trim().to_owned();
 
     let (which, line) = if follow {
         assert!(adjusts == 0, "use either //~| or //~^, not both.");

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -67,10 +67,9 @@ pub fn load_props(testfile: &Path) -> TestProps {
     let mut pretty_compare_only = false;
     let mut forbid_output = Vec::new();
     iter_header(testfile, &mut |ln| {
-        match parse_error_pattern(ln) {
-          Some(ep) => error_patterns.push(ep),
-          None => ()
-        };
+        if let Some(ep) = parse_error_pattern(ln) {
+           error_patterns.push(ep);
+        }
 
         if compile_flags.is_none() {
             compile_flags = parse_compile_flags(ln);
@@ -108,24 +107,20 @@ pub fn load_props(testfile: &Path) -> TestProps {
             pretty_compare_only = parse_pretty_compare_only(ln);
         }
 
-        match parse_aux_build(ln) {
-            Some(ab) => { aux_builds.push(ab); }
-            None => {}
+        if let  Some(ab) = parse_aux_build(ln) {
+            aux_builds.push(ab);
         }
 
-        match parse_exec_env(ln) {
-            Some(ee) => { exec_env.push(ee); }
-            None => {}
+        if let Some(ee) = parse_exec_env(ln) {
+            exec_env.push(ee);
         }
 
-        match parse_check_line(ln) {
-            Some(cl) => check_lines.push(cl),
-            None => ()
-        };
+        if let Some(cl) =  parse_check_line(ln) {
+            check_lines.push(cl);
+        }
 
-        match parse_forbid_output(ln) {
-            Some(of) => forbid_output.push(of),
-            None => (),
+        if let Some(of) = parse_forbid_output(ln) {
+            forbid_output.push(of);
         }
 
         true
@@ -134,8 +129,8 @@ pub fn load_props(testfile: &Path) -> TestProps {
     for key in vec!["RUST_TEST_NOCAPTURE", "RUST_TEST_THREADS"] {
         match env::var(key) {
             Ok(val) =>
-                if exec_env.iter().find(|&&(ref x, _)| *x == key.to_string()).is_none() {
-                    exec_env.push((key.to_string(), val))
+                if exec_env.iter().find(|&&(ref x, _)| *x == key).is_none() {
+                    exec_env.push((key.to_owned(), val))
                 },
             Err(..) => {}
         }
@@ -153,7 +148,7 @@ pub fn load_props(testfile: &Path) -> TestProps {
         check_stdout: check_stdout,
         no_prefer_dynamic: no_prefer_dynamic,
         pretty_expanded: pretty_expanded,
-        pretty_mode: pretty_mode.unwrap_or("normal".to_string()),
+        pretty_mode: pretty_mode.unwrap_or("normal".to_owned()),
         pretty_compare_only: pretty_compare_only,
         forbid_output: forbid_output,
     }
@@ -182,22 +177,21 @@ pub fn is_test_ignored(config: &Config, testfile: &Path) -> bool {
             return true;
         }
 
-        match config.gdb_version {
-            Some(ref actual_version) => {
-                if line.contains("min-gdb-version") {
-                    let min_version = line.trim()
-                                          .split(' ')
-                                          .last()
-                                          .expect("Malformed GDB version directive");
-                    // Ignore if actual version is smaller the minimum required
-                    // version
-                    gdb_version_to_int(actual_version) <
-                        gdb_version_to_int(min_version)
-                } else {
-                    false
-                }
+        if let Some(ref actual_version) = config.gdb_version {
+            if line.contains("min-gdb-version") {
+                let min_version = line.trim()
+                                      .split(' ')
+                                      .last()
+                                      .expect("Malformed GDB version directive");
+                // Ignore if actual version is smaller the minimum required
+                // version
+                gdb_version_to_int(actual_version) <
+                    gdb_version_to_int(min_version)
+            } else {
+                false
             }
-            None => false
+        } else {
+            false
         }
     }
 
@@ -210,22 +204,21 @@ pub fn is_test_ignored(config: &Config, testfile: &Path) -> bool {
             return true;
         }
 
-        match config.lldb_version {
-            Some(ref actual_version) => {
-                if line.contains("min-lldb-version") {
-                    let min_version = line.trim()
-                                          .split(' ')
-                                          .last()
-                                          .expect("Malformed lldb version directive");
-                    // Ignore if actual version is smaller the minimum required
-                    // version
-                    lldb_version_to_int(actual_version) <
-                        lldb_version_to_int(min_version)
-                } else {
-                    false
-                }
+        if let Some(ref actual_version) = config.lldb_version {
+            if line.contains("min-lldb-version") {
+                let min_version = line.trim()
+                                      .split(' ')
+                                      .last()
+                                      .expect("Malformed lldb version directive");
+                // Ignore if actual version is smaller the minimum required
+                // version
+                lldb_version_to_int(actual_version) <
+                    lldb_version_to_int(min_version)
+            } else {
+                false
             }
-            None => false
+        } else {
+            false
         }
     }
 
@@ -316,11 +309,11 @@ fn parse_exec_env(line: &str) -> Option<(String, String)> {
         // nv is either FOO or FOO=BAR
         let mut strs: Vec<String> = nv
                                       .splitn(2, '=')
-                                      .map(|s| s.to_string())
+                                      .map(str::to_owned)
                                       .collect();
 
         match strs.len() {
-          1 => (strs.pop().unwrap(), "".to_string()),
+          1 => (strs.pop().unwrap(), "".to_owned()),
           2 => {
               let end = strs.pop().unwrap();
               (strs.pop().unwrap(), end)
@@ -331,33 +324,31 @@ fn parse_exec_env(line: &str) -> Option<(String, String)> {
 }
 
 fn parse_pp_exact(line: &str, testfile: &Path) -> Option<PathBuf> {
-    match parse_name_value_directive(line, "pp-exact") {
-      Some(s) => Some(PathBuf::from(&s)),
-      None => {
+    if let Some(s) = parse_name_value_directive(line, "pp-exact") {
+        Some(PathBuf::from(&s))
+    } else {
         if parse_name_directive(line, "pp-exact") {
-            testfile.file_name().map(|s| PathBuf::from(s))
+            testfile.file_name().map(PathBuf::from)
         } else {
             None
         }
-      }
     }
 }
 
 fn parse_name_directive(line: &str, directive: &str) -> bool {
     // This 'no-' rule is a quick hack to allow pretty-expanded and no-pretty-expanded to coexist
-    line.contains(directive) && !line.contains(&("no-".to_string() + directive))
+    line.contains(directive) && !line.contains(&("no-".to_owned() + directive))
 }
 
 pub fn parse_name_value_directive(line: &str, directive: &str)
                                   -> Option<String> {
     let keycolon = format!("{}:", directive);
-    match line.find(&keycolon) {
-        Some(colon) => {
-            let value = line[(colon + keycolon.len()) .. line.len()].to_string();
-            debug!("{}: {}", directive, value);
-            Some(value)
-        }
-        None => None
+    if let Some(colon) = line.find(&keycolon) {
+        let value = line[(colon + keycolon.len()) .. line.len()].to_owned();
+        debug!("{}: {}", directive, value);
+        Some(value)
+    } else {
+        None
     }
 }
 

--- a/src/compiletest/procsrv.rs
+++ b/src/compiletest/procsrv.rs
@@ -17,9 +17,8 @@ fn add_target_env(cmd: &mut Command, lib_path: &str, aux_path: Option<&str>) {
     // Need to be sure to put both the lib_path and the aux path in the dylib
     // search path for the child.
     let mut path = DynamicLibrary::search_path();
-    match aux_path {
-        Some(p) => path.insert(0, PathBuf::from(p)),
-        None => {}
+    if let Some(p) = aux_path {
+        path.insert(0, PathBuf::from(p))
     }
     path.insert(0, PathBuf::from(lib_path));
 

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -165,9 +165,9 @@ fn run_valgrind_test(config: &Config, props: &TestProps, testfile: &Path) {
 
 fn run_pretty_test(config: &Config, props: &TestProps, testfile: &Path) {
     if props.pp_exact.is_some() {
-        logv(config, "testing for exact pretty-printing".to_string());
+        logv(config, "testing for exact pretty-printing".to_owned());
     } else {
-        logv(config, "testing for converging pretty-printing".to_string());
+        logv(config, "testing for converging pretty-printing".to_owned());
     }
 
     let rounds =
@@ -183,7 +183,7 @@ fn run_pretty_test(config: &Config, props: &TestProps, testfile: &Path) {
         let proc_res = print_source(config,
                                     props,
                                     testfile,
-                                    srcs[round].to_string(),
+                                    srcs[round].to_owned(),
                                     &props.pretty_mode);
 
         if !proc_res.status.success() {
@@ -209,9 +209,9 @@ fn run_pretty_test(config: &Config, props: &TestProps, testfile: &Path) {
 
     if props.pp_exact.is_some() {
         // Now we have to care about line endings
-        let cr = "\r".to_string();
-        actual = actual.replace(&cr, "").to_string();
-        expected = expected.replace(&cr, "").to_string();
+        let cr = "\r".to_owned();
+        actual = actual.replace(&cr, "").to_owned();
+        expected = expected.replace(&cr, "").to_owned();
     }
 
     compare_source(&expected, &actual);
@@ -253,7 +253,7 @@ fn run_pretty_test(config: &Config, props: &TestProps, testfile: &Path) {
                         make_pp_args(config,
                                      props,
                                      testfile,
-                                     pretty_type.to_string()),
+                                     pretty_type.to_owned()),
                         props.exec_env.clone(),
                         &config.compile_lib_path,
                         Some(aux_dir.to_str().unwrap()),
@@ -266,17 +266,17 @@ fn run_pretty_test(config: &Config, props: &TestProps, testfile: &Path) {
                     pretty_type: String) -> ProcArgs {
         let aux_dir = aux_output_dir_name(config, testfile);
         // FIXME (#9639): This needs to handle non-utf8 paths
-        let mut args = vec!("-".to_string(),
-                            "-Zunstable-options".to_string(),
-                            "--pretty".to_string(),
+        let mut args = vec!("-".to_owned(),
+                            "-Zunstable-options".to_owned(),
+                            "--pretty".to_owned(),
                             pretty_type,
                             format!("--target={}", config.target),
-                            "-L".to_string(),
-                            aux_dir.to_str().unwrap().to_string());
+                            "-L".to_owned(),
+                            aux_dir.to_str().unwrap().to_owned());
         args.extend(split_maybe_args(&config.target_rustcflags));
         args.extend(split_maybe_args(&props.compile_flags));
         return ProcArgs {
-            prog: config.rustc_path.to_str().unwrap().to_string(),
+            prog: config.rustc_path.to_str().unwrap().to_owned(),
             args: args,
         };
     }
@@ -313,18 +313,18 @@ actual:\n\
             &*config.target
         };
         // FIXME (#9639): This needs to handle non-utf8 paths
-        let mut args = vec!("-".to_string(),
-                            "-Zno-trans".to_string(),
+        let mut args = vec!("-".to_owned(),
+                            "-Zno-trans".to_owned(),
                             format!("--target={}", target),
-                            "-L".to_string(),
-                            config.build_base.to_str().unwrap().to_string(),
-                            "-L".to_string(),
-                            aux_dir.to_str().unwrap().to_string());
+                            "-L".to_owned(),
+                            config.build_base.to_str().unwrap().to_owned(),
+                            "-L".to_owned(),
+                            aux_dir.to_str().unwrap().to_owned());
         args.extend(split_maybe_args(&config.target_rustcflags));
         args.extend(split_maybe_args(&props.compile_flags));
         // FIXME (#9639): This needs to handle non-utf8 paths
         return ProcArgs {
-            prog: config.rustc_path.to_str().unwrap().to_string(),
+            prog: config.rustc_path.to_str().unwrap().to_owned(),
             args: args,
         };
     }
@@ -387,24 +387,24 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
                          &config.adb_path,
                          None,
                          &[
-                            "push".to_string(),
-                            exe_file.to_str().unwrap().to_string(),
+                            "push".to_owned(),
+                            exe_file.to_str().unwrap().to_owned(),
                             config.adb_test_dir.clone()
                          ],
-                         vec!(("".to_string(), "".to_string())),
-                         Some("".to_string()))
+                         vec!(("".to_owned(), "".to_owned())),
+                         Some("".to_owned()))
                 .expect(&format!("failed to exec `{:?}`", config.adb_path));
 
             procsrv::run("",
                          &config.adb_path,
                          None,
                          &[
-                            "forward".to_string(),
-                            "tcp:5039".to_string(),
-                            "tcp:5039".to_string()
+                            "forward".to_owned(),
+                            "tcp:5039".to_owned(),
+                            "tcp:5039".to_owned()
                          ],
-                         vec!(("".to_string(), "".to_string())),
-                         Some("".to_string()))
+                         vec!(("".to_owned(), "".to_owned())),
+                         Some("".to_owned()))
                 .expect(&format!("failed to exec `{:?}`", config.adb_path));
 
             let adb_arg = format!("export LD_LIBRARY_PATH={}; \
@@ -421,12 +421,12 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
                                                             ,
                                                       None,
                                                       &[
-                                                        "shell".to_string(),
+                                                        "shell".to_owned(),
                                                         adb_arg.clone()
                                                       ],
-                                                      vec!(("".to_string(),
-                                                            "".to_string())),
-                                                      Some("".to_string()))
+                                                      vec!(("".to_owned(),
+                                                            "".to_owned())),
+                                                      Some("".to_owned()))
                 .expect(&format!("failed to exec `{:?}`", config.adb_path));
             loop {
                 //waiting 1 second for gdbserver start
@@ -437,16 +437,16 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
             }
 
             let tool_path = match config.android_cross_path.to_str() {
-                Some(x) => x.to_string(),
+                Some(x) => x.to_owned(),
                 None => fatal("cannot find android cross path")
             };
 
             let debugger_script = make_out_name(config, testfile, "debugger.script");
             // FIXME (#9639): This needs to handle non-utf8 paths
             let debugger_opts =
-                vec!("-quiet".to_string(),
-                     "-batch".to_string(),
-                     "-nx".to_string(),
+                vec!("-quiet".to_owned(),
+                     "-batch".to_owned(),
+                     "-nx".to_owned(),
                      format!("-command={}", debugger_script.to_str().unwrap()));
 
             let mut gdb_path = tool_path;
@@ -459,7 +459,7 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
                              &gdb_path,
                              None,
                              &debugger_opts,
-                             vec!(("".to_string(), "".to_string())),
+                             vec!(("".to_owned(), "".to_owned())),
                              None)
                 .expect(&format!("failed to exec `{:?}`", gdb_path));
             let cmdline = {
@@ -488,7 +488,7 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
             let rust_pp_module_abs_path = rust_src_root.join(rust_pp_module_rel_path)
                                                        .to_str()
                                                        .unwrap()
-                                                       .to_string();
+                                                       .to_owned();
             // write debugger script
             let mut script_str = String::with_capacity(2048);
             script_str.push_str(&format!("set charset {}\n", charset()));
@@ -554,17 +554,17 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
 
             // FIXME (#9639): This needs to handle non-utf8 paths
             let debugger_opts =
-                vec!("-quiet".to_string(),
-                     "-batch".to_string(),
-                     "-nx".to_string(),
+                vec!("-quiet".to_owned(),
+                     "-batch".to_owned(),
+                     "-nx".to_owned(),
                      format!("-command={}", debugger_script.to_str().unwrap()));
 
             let proc_args = ProcArgs {
-                prog: debugger().to_string(),
+                prog: debugger().to_owned(),
                 args: debugger_opts,
             };
 
-            let environment = vec![("PYTHONPATH".to_string(), rust_pp_module_abs_path)];
+            let environment = vec![("PYTHONPATH".to_owned(), rust_pp_module_abs_path)];
 
             debugger_run_result = compose_and_run(config,
                                                   testfile,
@@ -650,7 +650,7 @@ fn run_debuginfo_lldb_test(config: &Config, props: &TestProps, testfile: &Path) 
     let rust_pp_module_abs_path = rust_src_root.join(rust_pp_module_rel_path)
                                                .to_str()
                                                .unwrap()
-                                               .to_string();
+                                               .to_owned();
 
     script_str.push_str(&format!("command script import {}\n",
                                  &rust_pp_module_abs_path[..])[..]);
@@ -790,9 +790,9 @@ fn cleanup_debug_info_options(options: &Option<String>) -> Option<String> {
 
     // Remove options that are either unwanted (-O) or may lead to duplicates due to RUSTFLAGS.
     let options_to_remove = [
-        "-O".to_string(),
-        "-g".to_string(),
-        "--debuginfo".to_string()
+        "-O".to_owned(),
+        "-g".to_owned(),
+        "--debuginfo".to_owned()
     ];
     let new_options =
         split_maybe_args(options).into_iter()
@@ -812,7 +812,7 @@ fn check_debugger_output(debugger_run_result: &ProcRes, check_lines: &[String]) 
                 s
                  .trim()
                  .split("[...]")
-                 .map(|x| x.to_string())
+                 .map(str::to_owned)
                  .collect()
             }).collect();
         // check if each line in props.check_lines appears in the
@@ -1139,8 +1139,8 @@ fn compile_test(config: &Config, props: &TestProps,
                 testfile: &Path) -> ProcRes {
     let aux_dir = aux_output_dir_name(config, testfile);
     // FIXME (#9639): This needs to handle non-utf8 paths
-    let link_args = vec!("-L".to_string(),
-                         aux_dir.to_str().unwrap().to_string());
+    let link_args = vec!("-L".to_owned(),
+                         aux_dir.to_str().unwrap().to_owned());
     let args = make_compile_args(config,
                                  props,
                                  link_args,
@@ -1154,14 +1154,14 @@ fn document(config: &Config, props: &TestProps,
     let out_dir = output_base_name(config, testfile);
     let _ = fs::remove_dir_all(&out_dir);
     ensure_dir(&out_dir);
-    let mut args = vec!["-L".to_string(),
-                        aux_dir.to_str().unwrap().to_string(),
-                        "-o".to_string(),
-                        out_dir.to_str().unwrap().to_string(),
-                        testfile.to_str().unwrap().to_string()];
+    let mut args = vec!["-L".to_owned(),
+                        aux_dir.to_str().unwrap().to_owned(),
+                        "-o".to_owned(),
+                        out_dir.to_str().unwrap().to_owned(),
+                        testfile.to_str().unwrap().to_owned()];
     args.extend(split_maybe_args(&props.compile_flags));
     let args = ProcArgs {
-        prog: config.rustdoc_path.to_str().unwrap().to_string(),
+        prog: config.rustdoc_path.to_str().unwrap().to_owned(),
         args: args,
     };
     (compose_and_run_compiler(config, props, testfile, args, None), out_dir)
@@ -1200,8 +1200,8 @@ fn compose_and_run_compiler(config: &Config, props: &TestProps,
 
     let aux_dir = aux_output_dir_name(config, testfile);
     // FIXME (#9639): This needs to handle non-utf8 paths
-    let extra_link_args = vec!["-L".to_string(),
-                               aux_dir.to_str().unwrap().to_string()];
+    let extra_link_args = vec!["-L".to_owned(),
+                               aux_dir.to_str().unwrap().to_owned()];
 
     for rel_ab in &props.aux_builds {
         let abs_ab = config.aux_base.join(rel_ab);
@@ -1219,9 +1219,9 @@ fn compose_and_run_compiler(config: &Config, props: &TestProps,
             // however, that if the library is built with `force_host` then it's
             // ok to be a dylib as the host should always support dylibs.
             if config.target.contains("musl") && !aux_props.force_host {
-                vec!("--crate-type=lib".to_string())
+                vec!("--crate-type=lib".to_owned())
             } else {
-                vec!("--crate-type=dylib".to_string())
+                vec!("--crate-type=dylib".to_owned())
             }
         };
         crate_type.extend(extra_link_args.clone());
@@ -1301,26 +1301,26 @@ fn make_compile_args<F>(config: &Config,
         &*config.target
     };
     // FIXME (#9639): This needs to handle non-utf8 paths
-    let mut args = vec!(testfile.to_str().unwrap().to_string(),
-                        "-L".to_string(),
-                        config.build_base.to_str().unwrap().to_string(),
+    let mut args = vec!(testfile.to_str().unwrap().to_owned(),
+                        "-L".to_owned(),
+                        config.build_base.to_str().unwrap().to_owned(),
                         format!("--target={}", target));
     args.push_all(&extras);
     if !props.no_prefer_dynamic {
-        args.push("-C".to_string());
-        args.push("prefer-dynamic".to_string());
+        args.push("-C".to_owned());
+        args.push("prefer-dynamic".to_owned());
     }
     let path = match xform_file {
         TargetLocation::ThisFile(path) => {
-            args.push("-o".to_string());
+            args.push("-o".to_owned());
             path
         }
         TargetLocation::ThisDirectory(path) => {
-            args.push("--out-dir".to_string());
+            args.push("--out-dir".to_owned());
             path
         }
     };
-    args.push(path.to_str().unwrap().to_string());
+    args.push(path.to_str().unwrap().to_owned());
     if props.force_host {
         args.extend(split_maybe_args(&config.host_rustcflags));
     } else {
@@ -1328,7 +1328,7 @@ fn make_compile_args<F>(config: &Config,
     }
     args.extend(split_maybe_args(&props.compile_flags));
     return ProcArgs {
-        prog: config.rustc_path.to_str().unwrap().to_string(),
+        prog: config.rustc_path.to_str().unwrap().to_owned(),
         args: args,
     };
 }
@@ -1358,7 +1358,7 @@ fn make_run_args(config: &Config, props: &TestProps, testfile: &Path)
     let exe_file = make_exe_name(config, testfile);
 
     // FIXME (#9639): This needs to handle non-utf8 paths
-    args.push(exe_file.to_str().unwrap().to_string());
+    args.push(exe_file.to_str().unwrap().to_owned());
 
     // Add the arguments in the run_flags directive
     args.extend(split_maybe_args(&props.run_flags));
@@ -1379,7 +1379,7 @@ fn split_maybe_args(argstr: &Option<String>) -> Vec<String> {
                  if s.chars().all(|c| c.is_whitespace()) {
                      None
                  } else {
-                     Some(s.to_string())
+                     Some(s.to_owned())
                  }
              }).collect()
         }
@@ -1514,7 +1514,7 @@ fn _arm_exec_compiled_test(config: &Config,
     // get bare program string
     let mut tvec: Vec<String> = args.prog
                                     .split('/')
-                                    .map(|ts| ts.to_string())
+                                    .map(str::to_owned)
                                     .collect();
     let prog_short = tvec.pop().unwrap();
 
@@ -1523,12 +1523,12 @@ fn _arm_exec_compiled_test(config: &Config,
                                    &config.adb_path,
                                    None,
                                    &[
-                                    "push".to_string(),
+                                    "push".to_owned(),
                                     args.prog.clone(),
                                     config.adb_test_dir.clone()
                                    ],
-                                   vec!(("".to_string(), "".to_string())),
-                                   Some("".to_string()))
+                                   vec!(("".to_owned(), "".to_owned())),
+                                   Some("".to_owned()))
         .expect(&format!("failed to exec `{}`", config.adb_path));
 
     if config.verbose {
@@ -1544,7 +1544,7 @@ fn _arm_exec_compiled_test(config: &Config,
     let mut runargs = Vec::new();
 
     // run test via adb_run_wrapper
-    runargs.push("shell".to_string());
+    runargs.push("shell".to_owned());
     for (key, val) in env {
         runargs.push(format!("{}={}", key, val));
     }
@@ -1553,19 +1553,19 @@ fn _arm_exec_compiled_test(config: &Config,
     runargs.push(format!("{}", prog_short));
 
     for tv in &args.args {
-        runargs.push(tv.to_string());
+        runargs.push(tv.to_owned());
     }
     procsrv::run("",
                  &config.adb_path,
                  None,
                  &runargs,
-                 vec!(("".to_string(), "".to_string())), Some("".to_string()))
+                 vec!(("".to_owned(), "".to_owned())), Some("".to_owned()))
         .expect(&format!("failed to exec `{}`", config.adb_path));
 
     // get exitcode of result
     runargs = Vec::new();
-    runargs.push("shell".to_string());
-    runargs.push("cat".to_string());
+    runargs.push("shell".to_owned());
+    runargs.push("cat".to_owned());
     runargs.push(format!("{}/{}.exitcode", config.adb_test_dir, prog_short));
 
     let procsrv::Result{ out: exitcode_out, err: _, status: _ } =
@@ -1573,8 +1573,8 @@ fn _arm_exec_compiled_test(config: &Config,
                      &config.adb_path,
                      None,
                      &runargs,
-                     vec!(("".to_string(), "".to_string())),
-                     Some("".to_string()))
+                     vec!(("".to_owned(), "".to_owned())),
+                     Some("".to_owned()))
         .expect(&format!("failed to exec `{}`", config.adb_path));
 
     let mut exitcode: i32 = 0;
@@ -1588,8 +1588,8 @@ fn _arm_exec_compiled_test(config: &Config,
 
     // get stdout of result
     runargs = Vec::new();
-    runargs.push("shell".to_string());
-    runargs.push("cat".to_string());
+    runargs.push("shell".to_owned());
+    runargs.push("cat".to_owned());
     runargs.push(format!("{}/{}.stdout", config.adb_test_dir, prog_short));
 
     let procsrv::Result{ out: stdout_out, err: _, status: _ } =
@@ -1597,14 +1597,14 @@ fn _arm_exec_compiled_test(config: &Config,
                      &config.adb_path,
                      None,
                      &runargs,
-                     vec!(("".to_string(), "".to_string())),
-                     Some("".to_string()))
+                     vec!(("".to_owned(), "".to_owned())),
+                     Some("".to_owned()))
         .expect(&format!("failed to exec `{}`", config.adb_path));
 
     // get stderr of result
     runargs = Vec::new();
-    runargs.push("shell".to_string());
-    runargs.push("cat".to_string());
+    runargs.push("shell".to_owned());
+    runargs.push("cat".to_owned());
     runargs.push(format!("{}/{}.stderr", config.adb_test_dir, prog_short));
 
     let procsrv::Result{ out: stderr_out, err: _, status: _ } =
@@ -1612,8 +1612,8 @@ fn _arm_exec_compiled_test(config: &Config,
                      &config.adb_path,
                      None,
                      &runargs,
-                     vec!(("".to_string(), "".to_string())),
-                     Some("".to_string()))
+                     vec!(("".to_owned(), "".to_owned())),
+                     Some("".to_owned()))
         .expect(&format!("failed to exec `{}`", config.adb_path));
 
     dump_output(config,
@@ -1641,15 +1641,15 @@ fn _arm_push_aux_shared_library(config: &Config, testfile: &Path) {
                                            &config.adb_path,
                                            None,
                                            &[
-                                            "push".to_string(),
+                                            "push".to_owned(),
                                             file.to_str()
                                                 .unwrap()
-                                                .to_string(),
-                                            config.adb_test_dir.to_string(),
+                                                .to_owned(),
+                                            config.adb_test_dir.to_owned(),
                                            ],
-                                           vec!(("".to_string(),
-                                                 "".to_string())),
-                                           Some("".to_string()))
+                                           vec!(("".to_owned(),
+                                                 "".to_owned())),
+                                           Some("".to_owned()))
                 .expect(&format!("failed to exec `{}`", config.adb_path));
 
             if config.verbose {
@@ -1667,10 +1667,10 @@ fn compile_test_and_save_ir(config: &Config, props: &TestProps,
                                  testfile: &Path) -> ProcRes {
     let aux_dir = aux_output_dir_name(config, testfile);
     // FIXME (#9639): This needs to handle non-utf8 paths
-    let mut link_args = vec!("-L".to_string(),
-                             aux_dir.to_str().unwrap().to_string());
-    let llvm_args = vec!("--emit=llvm-ir".to_string(),
-                         "--crate-type=lib".to_string());
+    let mut link_args = vec!("-L".to_owned(),
+                             aux_dir.to_str().unwrap().to_owned());
+    let llvm_args = vec!("--emit=llvm-ir".to_owned(),
+                         "--crate-type=lib".to_owned());
     link_args.extend(llvm_args);
     let args = make_compile_args(config,
                                  props,
@@ -1687,9 +1687,9 @@ fn check_ir_with_filecheck(config: &Config, testfile: &Path) -> ProcRes {
     let prog = config.llvm_bin_path.as_ref().unwrap().join("FileCheck");
     let proc_args = ProcArgs {
         // FIXME (#9639): This needs to handle non-utf8 paths
-        prog: prog.to_str().unwrap().to_string(),
+        prog: prog.to_str().unwrap().to_owned(),
         args: vec!(format!("-input-file={}", irfile.to_str().unwrap()),
-                   testfile.to_str().unwrap().to_string())
+                   testfile.to_str().unwrap().to_owned())
     };
     compose_and_run(config, testfile, proc_args, Vec::new(), "", None, None)
 }

--- a/src/compiletest/util.rs
+++ b/src/compiletest/util.rs
@@ -73,7 +73,7 @@ pub fn make_new_path(path: &str) -> String {
         Ok(curr) => {
             format!("{}{}{}", path, path_div(), curr)
         }
-        Err(..) => path.to_string()
+        Err(..) => path.to_owned()
     }
 }
 


### PR DESCRIPTION
This changes a lot of `.to_string()` to `.to_owned()`, removes a few redundant closures, and changes some `match`es to `if let`s.

I'm currently in the process of trying out clippy and acting on its suggestions. I started with compiletest, because we use it to test clippy, too. If this finds positive reception, I may continue refactoring other parts of the rust codebase.
