### PR TITLE
Source code style fixed: tab replaced with whitespaces.

### DIFF
--- a/src/doc/trpl/rust-inside-other-languages.md
+++ b/src/doc/trpl/rust-inside-other-languages.md
@@ -111,7 +111,7 @@ fn process() {
             for _ in (0..5_000_000) {
                 x += 1
             }
-	    x
+            x
         })
     }).collect();
 


### PR DESCRIPTION
Fixed x variable identation. How it was displayed in Firefox before: http://s16.postimg.org/c9448tn0k/Screenshot_from_2015_09_01_17_35_43.jpg
