### PR TITLE
Update jemalloc to 4.0.0 and LLVM to 3.7

### DIFF
--- a/src/rustllvm/llvm-auto-clean-trigger
+++ b/src/rustllvm/llvm-auto-clean-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be forcibly cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2015-06-30
+2015-09-02


### PR DESCRIPTION
This updates the jemalloc and LLVM submodules to the recently released 4.0.0 and 3.7 versions. There's no breakage on the LLVM side of things because we had already been tracking the 3.7 release branch for awhile and no breakage was introduced, and jemalloc apparently is stable enough that nothing broke!
