### PR TITLE
Introduce 'make doc' -> 'make docs'

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -191,6 +191,7 @@ ifdef CFG_DISABLE_DOCS
 endif
 
 docs: $(DOC_TARGETS)
+doc: docs
 compiler-docs: $(COMPILER_DOC_TARGETS)
 
 trpl: doc/book/index.html


### PR DESCRIPTION
Because 'doc' is a directory, when running `make doc`, you'll see
this:

```
make: Nothing to be done for `doc'.
```

By adding a target for `doc` to build `docs`, both work.

Fixes #14705
