### PR TITLE
Fix mistake in trait.md

### DIFF
--- a/src/doc/trpl/traits.md
+++ b/src/doc/trpl/traits.md
@@ -390,7 +390,7 @@ fn normal<T: ConvertTo<i64>>(x: &T) -> i64 {
 
 // can be called with T == i64
 fn inverse<T>() -> T
-        // this is using ConvertTo as if it were "ConvertFrom<i32>"
+        // this is using ConvertTo as if it were "ConvertTo<i64>"
         where i32: ConvertTo<T> {
     42.convert()
 }


### PR DESCRIPTION
Originally in an example it reads as follows:

``` rust
fn inverse<T>() -> T
        // this is using ConvertTo as if it were "ConvertFrom<i32>"
         where i32: ConvertTo<T> {
     42.convert()
 }
```

There was no mention of `ConvertFrom` elsewhere in the page other than in this comment. Is this supposed to be `ConvertTo<i64>` ?
I'm confused by this example.
