### PR TITLE
Bash output fix to match real 'ruby embed.rb' call r? @steveklabnik

### DIFF
--- a/src/doc/trpl/rust-inside-other-languages.md
+++ b/src/doc/trpl/rust-inside-other-languages.md
@@ -217,6 +217,17 @@ And finally, we can try running it:
 
 ```bash
 $ ruby embed.rb
+Thread finished with count=5000000
+Thread finished with count=5000000
+Thread finished with count=5000000
+Thread finished with count=5000000
+Thread finished with count=5000000
+Thread finished with count=5000000
+Thread finished with count=5000000
+Thread finished with count=5000000
+Thread finished with count=5000000
+Thread finished with count=5000000
+done!
 done!
 $
 ```


### PR DESCRIPTION
The embed rust file that we compile prints out 'Thread finished..' messages along with a 'done!' r? @steveklabnik
