### PR TITLE
Make `null()` and `null_mut()` const functions

### DIFF
--- a/src/libcollections/btree/node.rs
+++ b/src/libcollections/btree/node.rs
@@ -296,7 +296,7 @@ impl<K, V> Drop for Node<K, V> {
             self.destroy();
         }
 
-        self.keys = unsafe { Unique::new(0 as *mut K) };
+        self.keys = unsafe { Unique::new(ptr::null_mut()) };
     }
 }
 

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1135,7 +1135,7 @@ impl<T> ops::Deref for Vec<T> {
     fn deref(&self) -> &[T] {
         unsafe {
             let p = self.buf.ptr();
-            assume(p != 0 as *mut T);
+            assume(!p.is_null());
             slice::from_raw_parts(p, self.len)
         }
     }

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -51,7 +51,7 @@ pub use intrinsics::write_bytes;
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn null<T>() -> *const T { 0 as *const T }
+pub const fn null<T>() -> *const T { 0 as *const T }
 
 /// Creates a null mutable raw pointer.
 ///
@@ -65,7 +65,7 @@ pub fn null<T>() -> *const T { 0 as *const T }
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn null_mut<T>() -> *mut T { 0 as *mut T }
+pub const fn null_mut<T>() -> *mut T { 0 as *mut T }
 
 /// Swaps the values at two mutable locations of the same type, without
 /// deinitialising either. They may overlap, unlike `mem::swap` which is
@@ -163,7 +163,7 @@ impl<T: ?Sized> *const T {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn is_null(self) -> bool where T: Sized {
-        self == 0 as *const T
+        self == null()
     }
 
     /// Returns `None` if the pointer is null, or else returns a reference to
@@ -212,7 +212,7 @@ impl<T: ?Sized> *mut T {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn is_null(self) -> bool where T: Sized {
-        self == 0 as *mut T
+        self == null_mut()
     }
 
     /// Returns `None` if the pointer is null, or else returns a reference to

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -184,6 +184,7 @@ use std::io::{self, Stderr};
 use std::io::prelude::*;
 use std::mem;
 use std::env;
+use std::ptr;
 use std::rt;
 use std::slice;
 use std::sync::{Once, StaticMutex};
@@ -209,11 +210,10 @@ static LOCK: StaticMutex = StaticMutex::new();
 /// logging statement should be run.
 static mut LOG_LEVEL: u32 = MAX_LOG_LEVEL;
 
-static mut DIRECTIVES: *mut Vec<directive::LogDirective> =
-    0 as *mut Vec<directive::LogDirective>;
+static mut DIRECTIVES: *mut Vec<directive::LogDirective> = ptr::null_mut();
 
 /// Optional filter.
-static mut FILTER: *mut String = 0 as *mut _;
+static mut FILTER: *mut String = ptr::null_mut();
 
 /// Debug log level
 pub const DEBUG: u32 = 4;

--- a/src/librustc_trans/back/archive.rs
+++ b/src/librustc_trans/back/archive.rs
@@ -18,6 +18,7 @@ use std::io;
 use std::mem;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
+use std::ptr;
 use std::str;
 
 use libc;
@@ -449,7 +450,7 @@ impl<'a> ArchiveBuilder<'a> {
                     }
 
                     let name = try!(CString::new(child_name));
-                    members.push(llvm::LLVMRustArchiveMemberNew(0 as *const _,
+                    members.push(llvm::LLVMRustArchiveMemberNew(ptr::null(),
                                                                 name.as_ptr(),
                                                                 child.raw()));
                     strings.push(name);
@@ -462,7 +463,7 @@ impl<'a> ArchiveBuilder<'a> {
                         let name = try!(CString::new(name_in_archive));
                         members.push(llvm::LLVMRustArchiveMemberNew(path.as_ptr(),
                                                                     name.as_ptr(),
-                                                                    0 as *mut _));
+                                                                    ptr::null_mut()));
                         strings.push(path);
                         strings.push(name);
                     }
@@ -472,7 +473,7 @@ impl<'a> ArchiveBuilder<'a> {
                             if skip(child_name) { continue }
 
                             let name = try!(CString::new(child_name));
-                            let m = llvm::LLVMRustArchiveMemberNew(0 as *const _,
+                            let m = llvm::LLVMRustArchiveMemberNew(ptr::null(),
                                                                    name.as_ptr(),
                                                                    child.raw());
                             members.push(m);

--- a/src/librustc_trans/back/msvc/registry.rs
+++ b/src/librustc_trans/back/msvc/registry.rs
@@ -12,6 +12,7 @@ use std::io;
 use std::ffi::{OsString, OsStr};
 use std::os::windows::prelude::*;
 use std::ops::RangeFrom;
+use std::ptr;
 use libc::{DWORD, LPCWSTR, LONG, LPDWORD, LPBYTE, ERROR_SUCCESS};
 use libc::c_void;
 
@@ -88,7 +89,7 @@ impl RegistryKey {
 
     pub fn open(&self, key: &OsStr) -> io::Result<RegistryKey> {
         let key = key.encode_wide().chain(Some(0)).collect::<Vec<_>>();
-        let mut ret = 0 as *mut _;
+        let mut ret = ptr::null_mut();
         let err = unsafe {
             RegOpenKeyExW(self.raw(), key.as_ptr(), 0,
                           KEY_READ | KEY_WOW64_32KEY, &mut ret)
@@ -110,8 +111,8 @@ impl RegistryKey {
         let mut len = 0;
         let mut kind = 0;
         unsafe {
-            let err = RegQueryValueExW(self.raw(), name.as_ptr(), 0 as *mut _,
-                                       &mut kind, 0 as *mut _, &mut len);
+            let err = RegQueryValueExW(self.raw(), name.as_ptr(), ptr::null_mut(),
+                                       &mut kind, ptr::null_mut(), &mut len);
             if err != ERROR_SUCCESS {
                 return Err(io::Error::from_raw_os_error(err as i32))
             }
@@ -124,8 +125,8 @@ impl RegistryKey {
             // characters so we need to be sure to halve it for the capacity
             // passed in.
             let mut v = Vec::with_capacity(len as usize / 2);
-            let err = RegQueryValueExW(self.raw(), name.as_ptr(), 0 as *mut _,
-                                       0 as *mut _, v.as_mut_ptr() as *mut _,
+            let err = RegQueryValueExW(self.raw(), name.as_ptr(), ptr::null_mut(),
+                                       ptr::null_mut(), v.as_mut_ptr() as *mut _,
                                        &mut len);
             if err != ERROR_SUCCESS {
                 return Err(io::Error::from_raw_os_error(err as i32))
@@ -156,8 +157,8 @@ impl<'a> Iterator for Iter<'a> {
             let mut v = Vec::with_capacity(256);
             let mut len = v.capacity() as DWORD;
             let ret = RegEnumKeyExW(self.key.raw(), i, v.as_mut_ptr(), &mut len,
-                                    0 as *mut _, 0 as *mut _, 0 as *mut _,
-                                    0 as *mut _);
+                                    ptr::null_mut(), ptr::null_mut(), ptr::null_mut(),
+                                    ptr::null_mut());
             if ret == ERROR_NO_MORE_ITEMS as LONG {
                 None
             } else if ret != ERROR_SUCCESS {

--- a/src/libstd/io/lazy.rs
+++ b/src/libstd/io/lazy.rs
@@ -11,6 +11,7 @@
 use prelude::v1::*;
 
 use cell::Cell;
+use ptr;
 use rt;
 use sync::{StaticMutex, Arc};
 
@@ -26,7 +27,7 @@ impl<T: Send + Sync + 'static> Lazy<T> {
     pub const fn new(init: fn() -> Arc<T>) -> Lazy<T> {
         Lazy {
             lock: StaticMutex::new(),
-            ptr: Cell::new(0 as *mut _),
+            ptr: Cell::new(ptr::null_mut()),
             init: init
         }
     }

--- a/src/libstd/rand/os.rs
+++ b/src/libstd/rand/os.rs
@@ -185,6 +185,7 @@ mod imp {
 
     use io;
     use mem;
+    use ptr;
     use rand::Rng;
     use libc::{c_int, size_t};
 
@@ -207,7 +208,7 @@ mod imp {
     enum SecRandom {}
 
     #[allow(non_upper_case_globals)]
-    const kSecRandomDefault: *const SecRandom = 0 as *const SecRandom;
+    const kSecRandomDefault: *const SecRandom = ptr::null();
 
     #[link(name = "Security", kind = "framework")]
     extern "C" {

--- a/src/libstd/rt/at_exit_imp.rs
+++ b/src/libstd/rt/at_exit_imp.rs
@@ -18,6 +18,7 @@
 
 use alloc::boxed::FnBox;
 use boxed::Box;
+use ptr;
 use sys_common::mutex::Mutex;
 use vec::Vec;
 
@@ -28,7 +29,7 @@ type Queue = Vec<Box<FnBox()>>;
 // the thread infrastructure to be in place (useful on the borders of
 // initialization/destruction).
 static LOCK: Mutex = Mutex::new();
-static mut QUEUE: *mut Queue = 0 as *mut Queue;
+static mut QUEUE: *mut Queue = ptr::null_mut();
 
 // The maximum number of times the cleanup routines will be run. While running
 // the at_exit closures new ones may be registered, and this count is the number

--- a/src/libstd/rt/unwind/seh.rs
+++ b/src/libstd/rt/unwind/seh.rs
@@ -53,6 +53,7 @@ use prelude::v1::*;
 
 use any::Any;
 use libc::{c_ulong, DWORD, c_void};
+use ptr;
 use sys_common::thread_local::StaticKey;
 
 //                        0x R U S T
@@ -98,7 +99,7 @@ pub unsafe fn panic(data: Box<Any + Send + 'static>) -> ! {
     rtassert!(PANIC_DATA.get().is_null());
     PANIC_DATA.set(Box::into_raw(exception) as *mut u8);
 
-    RaiseException(RUST_PANIC, 0, 0, 0 as *const _);
+    RaiseException(RUST_PANIC, 0, 0, ptr::null());
     rtabort!("could not unwind stack");
 }
 
@@ -108,7 +109,7 @@ pub unsafe fn cleanup(ptr: *mut u8) -> Box<Any + Send + 'static> {
     rtassert!(ptr as DWORD == RUST_PANIC);
 
     let data = PANIC_DATA.get() as *mut Box<Any + Send + 'static>;
-    PANIC_DATA.set(0 as *mut u8);
+    PANIC_DATA.set(ptr::null_mut());
     rtassert!(!data.is_null());
 
     *Box::from_raw(data)

--- a/src/libstd/sys/common/net.rs
+++ b/src/libstd/sys/common/net.rs
@@ -16,6 +16,7 @@ use io::{self, Error, ErrorKind};
 use libc::{self, c_int, c_char, c_void, socklen_t};
 use mem;
 use net::{SocketAddr, Shutdown, IpAddr};
+use ptr;
 use str::from_utf8;
 use sys::c;
 use sys::net::{cvt, cvt_r, cvt_gai, Socket, init, wrlen_t};
@@ -123,9 +124,9 @@ pub fn lookup_host(host: &str) -> io::Result<LookupHost> {
     init();
 
     let c_host = try!(CString::new(host));
-    let mut res = 0 as *mut _;
+    let mut res = ptr::null_mut();
     unsafe {
-        try!(cvt_gai(getaddrinfo(c_host.as_ptr(), 0 as *const _, 0 as *const _,
+        try!(cvt_gai(getaddrinfo(c_host.as_ptr(), ptr::null(), ptr::null(),
                                  &mut res)));
         Ok(LookupHost { original: res, cur: res })
     }
@@ -154,7 +155,7 @@ pub fn lookup_addr(addr: &IpAddr) -> io::Result<String> {
     let data = unsafe {
         try!(cvt_gai(getnameinfo(inner, len,
                                  hostbuf.as_mut_ptr(), NI_MAXHOST as libc::size_t,
-                                 0 as *mut _, 0, 0)));
+                                 ptr::null_mut(), 0, 0)));
 
         CStr::from_ptr(hostbuf.as_ptr())
     };

--- a/src/libstd/sys/unix/backtrace/printing/libbacktrace.rs
+++ b/src/libstd/sys/unix/backtrace/printing/libbacktrace.rs
@@ -123,7 +123,7 @@ pub fn print(w: &mut Write, idx: isize, addr: *mut libc::c_void,
     // FIXME: We also call self_exe_name() on DragonFly BSD. I haven't
     //        tested if this is required or not.
     unsafe fn init_state() -> *mut backtrace_state {
-        static mut STATE: *mut backtrace_state = 0 as *mut backtrace_state;
+        static mut STATE: *mut backtrace_state = ptr::null_mut();
         static mut LAST_FILENAME: [libc::c_char; 256] = [0; 256];
         if !STATE.is_null() { return STATE }
         let selfname = if cfg!(target_os = "freebsd") ||

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -291,7 +291,7 @@ pub fn args() -> Args {
     };
     Args {
         iter: vec.into_iter(),
-        _dont_send_or_sync_me: 0 as *mut (),
+        _dont_send_or_sync_me: ptr::null_mut(),
     }
 }
 
@@ -347,7 +347,7 @@ pub fn args() -> Args {
         }
     }
 
-    Args { iter: res.into_iter(), _dont_send_or_sync_me: 0 as *mut _ }
+    Args { iter: res.into_iter(), _dont_send_or_sync_me: ptr::null_mut() }
 }
 
 #[cfg(any(target_os = "linux",
@@ -363,7 +363,7 @@ pub fn args() -> Args {
     let v: Vec<OsString> = bytes.into_iter().map(|v| {
         OsStringExt::from_vec(v)
     }).collect();
-    Args { iter: v.into_iter(), _dont_send_or_sync_me: 0 as *mut _ }
+    Args { iter: v.into_iter(), _dont_send_or_sync_me: ptr::null_mut() }
 }
 
 pub struct Env {
@@ -403,7 +403,7 @@ pub fn env() -> Env {
             result.push(parse(CStr::from_ptr(*environ).to_bytes()));
             environ = environ.offset(1);
         }
-        Env { iter: result.into_iter(), _dont_send_or_sync_me: 0 as *mut _ }
+        Env { iter: result.into_iter(), _dont_send_or_sync_me: ptr::null_mut() }
     };
 
     fn parse(input: &[u8]) -> (OsString, OsString) {
@@ -481,7 +481,7 @@ pub fn home_dir() -> Option<PathBuf> {
         loop {
             let mut buf = Vec::with_capacity(amt);
             let mut passwd: c::passwd = mem::zeroed();
-            let mut result = 0 as *mut _;
+            let mut result = ptr::null_mut();
             match c::getpwuid_r(me, &mut passwd, buf.as_mut_ptr(),
                                 buf.capacity() as libc::size_t,
                                 &mut result) {

--- a/src/libstd/sys/unix/process.rs
+++ b/src/libstd/sys/unix/process.rs
@@ -405,7 +405,7 @@ fn make_envp(env: Option<&HashMap<OsString, OsString>>)
 
         (ptrs.as_ptr() as *const _, tmps, ptrs)
     } else {
-        (0 as *const _, Vec::new(), Vec::new())
+        (ptr::null(), Vec::new(), Vec::new())
     }
 }
 

--- a/src/libstd/sys/unix/stack_overflow.rs
+++ b/src/libstd/sys/unix/stack_overflow.rs
@@ -93,7 +93,7 @@ mod imp {
         // See comment above for why this function returns.
     }
 
-    static mut MAIN_ALTSTACK: *mut libc::c_void = 0 as *mut libc::c_void;
+    static mut MAIN_ALTSTACK: *mut libc::c_void = ptr::null_mut();
 
     pub unsafe fn init() {
         PAGE_SIZE = ::sys::os::page_size();
@@ -155,7 +155,7 @@ mod imp {
     }
 
     pub unsafe fn make_handler() -> super::Handler {
-        super::Handler { _data: 0 as *mut libc::c_void }
+        super::Handler { _data: ptr::null_mut() }
     }
 
     pub unsafe fn drop_handler(_handler: &mut super::Handler) {

--- a/src/libstd/sys/unix/sync.rs
+++ b/src/libstd/sys/unix/sync.rs
@@ -59,15 +59,16 @@ extern {
           target_os = "openbsd"))]
 mod os {
     use libc;
+    use ptr;
 
     pub type pthread_mutex_t = *mut libc::c_void;
     pub type pthread_mutexattr_t = *mut libc::c_void;
     pub type pthread_cond_t = *mut libc::c_void;
     pub type pthread_rwlock_t = *mut libc::c_void;
 
-    pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = 0 as *mut _;
-    pub const PTHREAD_COND_INITIALIZER: pthread_cond_t = 0 as *mut _;
-    pub const PTHREAD_RWLOCK_INITIALIZER: pthread_rwlock_t = 0 as *mut _;
+    pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = ptr::null_mut();
+    pub const PTHREAD_COND_INITIALIZER: pthread_cond_t = ptr::null_mut();
+    pub const PTHREAD_RWLOCK_INITIALIZER: pthread_rwlock_t = ptr::null_mut();
     pub const PTHREAD_MUTEX_RECURSIVE: libc::c_int = 2;
 }
 
@@ -213,6 +214,7 @@ mod os {
 #[cfg(target_os = "android")]
 mod os {
     use libc;
+    use ptr;
 
     #[repr(C)]
     pub struct pthread_mutex_t { value: libc::c_int }
@@ -243,7 +245,7 @@ mod os {
         writerThreadId: 0,
         pendingReaders: 0,
         pendingWriters: 0,
-        reserved: [0 as *mut _; 4],
+        reserved: [ptr::null_mut(); 4],
     };
     pub const PTHREAD_MUTEX_RECURSIVE: libc::c_int = 1;
 }

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -72,7 +72,7 @@ impl Thread {
 
         extern fn thread_start(main: *mut libc::c_void) -> *mut libc::c_void {
             unsafe { start_thread(main); }
-            0 as *mut _
+            ptr::null_mut()
         }
     }
 

--- a/src/libstd/sys/windows/c.rs
+++ b/src/libstd/sys/windows/c.rs
@@ -16,6 +16,7 @@ use libc;
 use libc::{c_uint, c_ulong};
 use libc::{DWORD, BOOL, BOOLEAN, ERROR_CALL_NOT_IMPLEMENTED, LPVOID, HANDLE};
 use libc::{LPCWSTR, LONG};
+use ptr;
 
 pub use self::GET_FILEEX_INFO_LEVELS::*;
 pub use self::FILE_INFO_BY_HANDLE_CLASS::*;
@@ -294,9 +295,9 @@ pub struct CRITICAL_SECTION {
 }
 
 pub const CONDITION_VARIABLE_INIT: CONDITION_VARIABLE = CONDITION_VARIABLE {
-    ptr: 0 as *mut _,
+    ptr: ptr::null_mut(),
 };
-pub const SRWLOCK_INIT: SRWLOCK = SRWLOCK { ptr: 0 as *mut _ };
+pub const SRWLOCK_INIT: SRWLOCK = SRWLOCK { ptr: ptr::null_mut() };
 
 #[repr(C)]
 pub struct LUID {

--- a/src/libstd/sys/windows/fs.rs
+++ b/src/libstd/sys/windows/fs.rs
@@ -328,12 +328,12 @@ impl File {
             try!(cvt({
                 c::DeviceIoControl(self.handle.raw(),
                                    c::FSCTL_GET_REPARSE_POINT,
-                                   0 as *mut _,
+                                   ptr::null_mut(),
                                    0,
                                    space.as_mut_ptr() as *mut _,
                                    space.len() as libc::DWORD,
                                    &mut bytes,
-                                   0 as *mut _)
+                                   ptr::null_mut())
             }));
             Ok((bytes, &*(space.as_ptr() as *const c::REPARSE_DATA_BUFFER)))
         }
@@ -680,15 +680,15 @@ fn directory_junctions_are_directories() {
                                    c::FSCTL_SET_REPARSE_POINT,
                                    data.as_ptr() as *mut _,
                                    (*db).ReparseDataLength + 8,
-                                   0 as *mut _, 0,
+                                   ptr::null_mut(), 0,
                                    &mut ret,
-                                   0 as *mut _)).map(|_| ())
+                                   ptr::null_mut())).map(|_| ())
         }
     }
 
     fn opendir(p: &Path, write: bool) -> io::Result<File> {
         unsafe {
-            let mut token = 0 as *mut _;
+            let mut token = ptr::null_mut();
             let mut tp: c::TOKEN_PRIVILEGES = mem::zeroed();
             try!(cvt(c::OpenProcessToken(c::GetCurrentProcess(),
                                          c::TOKEN_ADJUST_PRIVILEGES,
@@ -699,14 +699,14 @@ fn directory_junctions_are_directories() {
                 "SeBackupPrivilege".as_ref()
             };
             let name = name.encode_wide().chain(Some(0)).collect::<Vec<_>>();
-            try!(cvt(c::LookupPrivilegeValueW(0 as *const _,
+            try!(cvt(c::LookupPrivilegeValueW(ptr::null(),
                                               name.as_ptr(),
                                               &mut tp.Privileges[0].Luid)));
             tp.PrivilegeCount = 1;
             tp.Privileges[0].Attributes = c::SE_PRIVILEGE_ENABLED;
             let size = mem::size_of::<c::TOKEN_PRIVILEGES>() as libc::DWORD;
             try!(cvt(c::AdjustTokenPrivileges(token, libc::FALSE, &mut tp, size,
-                                              0 as *mut _, 0 as *mut _)));
+                                              ptr::null_mut(), ptr::null_mut())));
             try!(cvt(libc::CloseHandle(token)));
 
             File::open_reparse_point(p, write)
@@ -726,9 +726,9 @@ fn directory_junctions_are_directories() {
                                    c::FSCTL_DELETE_REPARSE_POINT,
                                    data.as_ptr() as *mut _,
                                    (*db).ReparseDataLength + 8,
-                                   0 as *mut _, 0,
+                                   ptr::null_mut(), 0,
                                    &mut bytes,
-                                   0 as *mut _)).map(|_| ())
+                                   ptr::null_mut())).map(|_| ())
         }
     }
 }

--- a/src/libstd/sys/windows/net.rs
+++ b/src/libstd/sys/windows/net.rs
@@ -15,6 +15,7 @@ use mem;
 use net::SocketAddr;
 use num::One;
 use ops::Neg;
+use ptr;
 use rt;
 use sync::Once;
 use sys;
@@ -80,7 +81,7 @@ impl Socket {
             SocketAddr::V6(..) => libc::AF_INET6,
         };
         let socket = try!(unsafe {
-            match c::WSASocketW(fam, ty, 0, 0 as *mut _, 0,
+            match c::WSASocketW(fam, ty, 0, ptr::null_mut(), 0,
                                 c::WSA_FLAG_OVERLAPPED) {
                 INVALID_SOCKET => Err(last_error()),
                 n => Ok(Socket(n)),

--- a/src/libstd/sys/windows/pipe.rs
+++ b/src/libstd/sys/windows/pipe.rs
@@ -10,6 +10,7 @@
 
 use io;
 use libc;
+use ptr;
 use sys::cvt;
 use sys::c;
 use sys::handle::Handle;
@@ -26,7 +27,7 @@ pub fn anon_pipe() -> io::Result<(AnonPipe, AnonPipe)> {
     let mut reader = libc::INVALID_HANDLE_VALUE;
     let mut writer = libc::INVALID_HANDLE_VALUE;
     try!(cvt(unsafe {
-        c::CreatePipe(&mut reader, &mut writer, 0 as *mut _, 0)
+        c::CreatePipe(&mut reader, &mut writer, ptr::null_mut(), 0)
     }));
     let reader = Handle::new(reader);
     let writer = Handle::new(writer);

--- a/src/libstd/sys/windows/thread_local.rs
+++ b/src/libstd/sys/windows/thread_local.rs
@@ -58,7 +58,7 @@ pub type Dtor = unsafe extern fn(*mut u8);
 // the thread infrastructure to be in place (useful on the borders of
 // initialization/destruction).
 static DTOR_LOCK: Mutex = Mutex::new();
-static mut DTORS: *mut Vec<(Key, Dtor)> = 0 as *mut _;
+static mut DTORS: *mut Vec<(Key, Dtor)> = ptr::null_mut();
 
 // -------------------------------------------------------------------------
 // Native bindings

--- a/src/libstd/thread/scoped_tls.rs
+++ b/src/libstd/thread/scoped_tls.rs
@@ -226,6 +226,7 @@ impl<T> ScopedKey<T> {
 #[doc(hidden)]
 mod imp {
     use cell::Cell;
+    use ptr;
 
     pub struct KeyInner<T> { inner: Cell<*mut T> }
 
@@ -233,7 +234,7 @@ mod imp {
 
     impl<T> KeyInner<T> {
         pub const fn new() -> KeyInner<T> {
-            KeyInner { inner: Cell::new(0 as *mut _) }
+            KeyInner { inner: Cell::new(ptr::null_mut()) }
         }
         pub unsafe fn set(&self, ptr: *mut T) { self.inner.set(ptr); }
         pub unsafe fn get(&self) -> *mut T { self.inner.get() }


### PR DESCRIPTION
And replace more `0 as *const T`/`0 as *mut T`s with `null()`/`null_mut()`s

I'm not sure what is the general policy about making simple functions `const`, but `null()` and `null_mut()` seem to be good candidates.
