### PR TITLE
Take method invocation semantics out of chapter on deref coercion.

### DIFF
--- a/src/doc/trpl/deref-coercions.md
+++ b/src/doc/trpl/deref-coercions.md
@@ -89,8 +89,8 @@ Vectors can `Deref` to a slice.
 
 ## Deref and method calls
 
-`Deref` will also kick in when calling a method. In other words, these are
-the same two things in Rust:
+`Deref` will also kick in when calling a method. Consider the following
+example.
 
 ```rust
 struct Foo;
@@ -99,13 +99,13 @@ impl Foo {
     fn foo(&self) { println!("Foo"); }
 }
 
-let f = Foo;
+let f = &&Foo;
 
 f.foo();
 ```
 
-Even though `f` isn’t a reference, and `foo` takes `&self`, this works.
-That’s because these things are the same:
+Even though `f` is a `&&Foo` and `foo` takes `&self`, this works. That’s
+because these things are the same:
 
 ```rust,ignore
 f.foo();


### PR DESCRIPTION
I have two issues with the section "Deref and method calls" of the book's chapter "Deref coercions".
- (Minor) It says "In other words, these are the same two things in Rust:", followed by a code block in which no two things seem similar, much less the same. Presumably this sentence made more sense in a previous revision.
- The next paragraph conflates two concepts which, imho, should kept separate. They are
  - deref coercion, i.e. inserting as many `*` as necessary and
  - implicitly referencing the receiver, i.e. inserting a single `&` to satisfy the method's `self` parameter type.

I appreciate that with the proposed changes the example becomes very contrived, even for a foo-bar-baz one. However, the current exmplanation is just wrong.
