### PR TITLE
reference grammar: remove duplicate else_tail rule

### DIFF
--- a/src/doc/grammar.md
+++ b/src/doc/grammar.md
@@ -688,7 +688,6 @@ match_pat : pat [ '|' pat ] * [ "if" expr ] ? ;
 ```antlr
 if_let_expr : "if" "let" pat '=' expr '{' block '}'
                else_tail ? ;
-else_tail : "else" [ if_expr | if_let_expr | '{' block '}' ] ;
 ```
 
 ### While let loops


### PR DESCRIPTION
The rule `else_tail` was duplicated in `if` and `if_let` sections. I guess that this is a mistake.

r? @steveklabnik
