### PR TITLE
reference grammar: remove procedure_type

### DIFF
--- a/src/doc/grammar.md
+++ b/src/doc/grammar.md
@@ -754,8 +754,6 @@ return_expr : "return" expr ? ;
 ```antlr
 closure_type := [ 'unsafe' ] [ '<' lifetime-list '>' ] '|' arg-list '|'
                 [ ':' bound-list ] [ '->' type ]
-procedure_type := 'proc' [ '<' lifetime-list '>' ] '(' arg-list ')'
-                  [ ':' bound-list ] [ '->' type ]
 lifetime-list := lifetime | lifetime ',' lifetime-list
 arg-list := ident ':' type | ident ':' type ',' arg-list
 bound-list := bound | bound '+' bound-list


### PR DESCRIPTION
As I understand, there are no proc closures in Rust any more. So this pr removes `procedure_type` production. It isn't used anywhere. The `proc` is still a keyword.

r? @steveklabnik
@bors: r+ rollup
