### PR TITLE
reference grammar: fix item definition

### DIFF
--- a/src/doc/grammar.md
+++ b/src/doc/grammar.md
@@ -306,7 +306,7 @@ transcriber : '(' transcriber * ')' | '[' transcriber * ']'
 
 ```antlr
 item : vis ? mod_item | fn_item | type_item | struct_item | enum_item
-     | const_item | static_item | trait_item | impl_item | extern_block ;
+     | const_item | static_item | trait_item | impl_item | extern_block_item ;
 ```
 
 ### Type Parameters


### PR DESCRIPTION
extern_block should be extern_block_item.

extern_block_item is `extern { bunch of fns }`, extern_block is just `bunch of fns`

r? @steveklabnik
