### PR TITLE
trpl: Rename 'academic research' to 'bibliography'. Add some new links.

### DIFF
--- a/src/doc/trpl/README.md
+++ b/src/doc/trpl/README.md
@@ -24,7 +24,7 @@ is the first. After this:
 * [Syntax and Semantics][ss] - Each bit of Rust, broken down into small chunks.
 * [Nightly Rust][nr] - Cutting-edge features that aren’t in stable builds yet.
 * [Glossary][gl] - A reference of terms used in the book.
-* [Academic Research][ar] - Literature that influenced Rust.
+* [Bibliography][bi] - Background on Rust's influences, papers about Rust.
 
 [gs]: getting-started.html
 [lr]: learn-rust.html
@@ -32,7 +32,7 @@ is the first. After this:
 [ss]: syntax-and-semantics.html
 [nr]: nightly-rust.html
 [gl]: glossary.html
-[ar]: academic-research.html
+[bi]: bibliography.html
 
 After reading this introduction, you’ll want to dive into either ‘Learn Rust’
 or ‘Syntax and Semantics’, depending on your preference: ‘Learn Rust’ if you

--- a/src/doc/trpl/SUMMARY.md
+++ b/src/doc/trpl/SUMMARY.md
@@ -69,4 +69,4 @@
     * [Slice Patterns](slice-patterns.md)
     * [Associated Constants](associated-constants.md)
 * [Glossary](glossary.md)
-* [Academic Research](academic-research.md)
+* [Bibliography](bibliography.md)

--- a/src/doc/trpl/bibliography.md
+++ b/src/doc/trpl/bibliography.md
@@ -1,8 +1,8 @@
-% Academic Research
+% Bibliography
 
-An incomplete list of papers that have had some influence in Rust.
-
-Recommended for inspiration and a better understanding of Rust's background.
+This is a reading list of material relevant to Rust. It includes prior
+research that has - at one time or another - influenced the design of
+Rust, as well as publications about Rust.
 
 ### Type system
 
@@ -33,6 +33,7 @@ Recommended for inspiration and a better understanding of Rust's background.
 * [Non-blocking steal-half work queues](http://www.cs.bgu.ac.il/%7Ehendlerd/papers/p280-hendler.pdf)
 * [Reagents: expressing and composing fine-grained concurrency](http://www.mpi-sws.org/~turon/reagents.pdf)
 * [Algorithms for scalable synchronization of shared-memory multiprocessors](https://www.cs.rochester.edu/u/scott/papers/1991_TOCS_synch.pdf)
+* [Epoc-based reclamation](https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-579.pdf).
 
 ### Others
 
@@ -71,3 +72,9 @@ Language](http://www.cs.indiana.edu/~eholk/papers/hips2013.pdf). Early GPU work 
 * [Code Refinement of Stencil
   Codes](http://compilers.cs.uni-saarland.de/papers/ppl14_web.pdf). Another
   paper using Impala.
+* [Parallelization in Rust with fork-join and
+  friends](http://publications.lib.chalmers.se/records/fulltext/219016/219016.pdf). Linus
+  Farnstrand's master's thesis.
+* [Session Types for
+  Rust](http://munksgaard.me/papers/laumann-munksgaard-larsen.pdf). Philip
+  Munksgaard's master's thesis. Research for Servo.


### PR DESCRIPTION
r? @steveklabnik 

The phrase 'academic research' rubs me the wrong way. I have some concern about the role of this page and think it could be expanded to more than just academic papers and cleaned up a lot.
