### PR TITLE
rustbook: Fix relative links on the Introduction page

### DIFF
--- a/src/rustbook/book.rs
+++ b/src/rustbook/book.rs
@@ -102,7 +102,7 @@ pub fn parse_summary(input: &mut Read, src: &Path) -> Result<Book, Vec<String>> 
     top_items.push(BookItem {
         title: "Introduction".to_string(),
         path: PathBuf::from("README.md"),
-        path_to_root: PathBuf::from("."),
+        path_to_root: PathBuf::from(""),
         children: vec!(),
     });
 

--- a/src/rustbook/build.rs
+++ b/src/rustbook/build.rs
@@ -52,16 +52,16 @@ fn write_toc(book: &Book, current_page: &BookItem, out: &mut Write) -> io::Resul
                  current_page: &BookItem,
                  out: &mut Write) -> io::Result<()> {
         let class_string = if item.path == current_page.path {
-          "class='active'"
+            "class='active'"
         } else {
-        ""
+            ""
         };
 
         try!(writeln!(out, "<li><a {} href='{}'><b>{}</b> {}</a>",
-                 class_string,
-                 current_page.path_to_root.join(&item.path).with_extension("html").display(),
-                 section,
-                 item.title));
+                      class_string,
+                      current_page.path_to_root.join(&item.path).with_extension("html").display(),
+                      section,
+                      item.title));
         if !item.children.is_empty() {
             try!(writeln!(out, "<ul class='section'>"));
             let _ = walk_items(&item.children[..], section, current_page, out);


### PR DESCRIPTION
The Introduction page generated by rustbook used weird relative links
like "./getting-started.html" instead of just "getting-started.html"
like on the other pages. This adversely affected Windows builds the
worst, since it generated links like ".\getting-started.html" (note the
backslash). If you then try to upload the generated book to a webserver,
you end up with 404's. See this example of what is going on with the
Introduction page links and why this PR should fix it:
http://is.gd/fRUTXk

Compare the links on these two pages, for instance:
https://doc.rust-lang.org/nightly/book/
https://doc.rust-lang.org/nightly/book/getting-started.html

Also, fix a few whitespace issues in build.rs.
