### PR TITLE
Don't add unnamed address attributes to intrinsics.

### DIFF
--- a/src/librustc_trans/trans/context.rs
+++ b/src/librustc_trans/trans/context.rs
@@ -798,6 +798,7 @@ fn declare_intrinsic(ccx: &CrateContext, key: &str) -> Option<ValueRef> {
             if key == $name {
                 let f = declare::declare_cfn(ccx, $name, Type::func(&[], &$ret),
                                              ccx.tcx().mk_nil());
+                llvm::SetUnnamedAddr(f, false);
                 ccx.intrinsics().borrow_mut().insert($name, f.clone());
                 return Some(f);
             }
@@ -806,6 +807,7 @@ fn declare_intrinsic(ccx: &CrateContext, key: &str) -> Option<ValueRef> {
             if key == $name {
                 let f = declare::declare_cfn(ccx, $name, Type::func(&[$($arg),*], &$ret),
                                              ccx.tcx().mk_nil());
+                llvm::SetUnnamedAddr(f, false);
                 ccx.intrinsics().borrow_mut().insert($name, f.clone());
                 return Some(f);
             }

--- a/src/test/codegen/intrinsic-no-unnamed-attr.rs
+++ b/src/test/codegen/intrinsic-no-unnamed-attr.rs
@@ -1,0 +1,22 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -C no-prepopulate-passes
+
+#![feature(intrinsics)]
+
+extern "rust-intrinsic" {
+    fn sqrtf32(x: f32) -> f32;
+}
+// CHECK: @llvm.sqrt.f32(float) #{{[0-9]*}}
+
+fn main() {
+    unsafe { sqrtf32(0.0f32); }
+}


### PR DESCRIPTION
Intrinsics never have an address, so it doesn't make sense to say that their
address is unnamed.
