### PR TITLE
Use unsafe more idiomatically

### DIFF
--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -303,8 +303,10 @@ impl<T> SliceExt for [T] {
     fn split_at_mut(&mut self, mid: usize) -> (&mut [T], &mut [T]) {
         let len = self.len();
         let ptr = self.as_mut_ptr();
-        assert!(mid <= len);
+
         unsafe {
+            assert!(mid <= len);
+
             (from_raw_parts_mut(ptr, mid),
              from_raw_parts_mut(ptr.offset(mid as isize), len - mid))
         }


### PR DESCRIPTION
Generally, including everything that makes an unsafe block safe in the
block is good style. Since the assert! is what makes this safe, it
should go inside the block. I also added a few bits of whitespace.

This is of course, a little style thing, so no worries if we don't want this patch.
