### PR TITLE
libsyntax: remove dead code from parser.rs

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4726,9 +4726,13 @@ impl<'a> Parser<'a> {
             let fields = try!(self.parse_record_struct_body(&class_name));
             (fields, None)
         // Tuple-style struct definition with optional where-clause.
-        } else {
+        } else if self.token == token::OpenDelim(token::Paren) {
             let fields = try!(self.parse_tuple_struct_body(&class_name, &mut generics));
             (fields, Some(ast::DUMMY_NODE_ID))
+        } else {
+            let token_str = self.this_token_to_string();
+            return Err(self.fatal(&format!("expected `where`, `{}`, `(`, or `;` after struct \
+                                            name, found `{}`", "{", token_str)))
         };
 
         Ok((class_name,

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4731,8 +4731,8 @@ impl<'a> Parser<'a> {
             (fields, Some(ast::DUMMY_NODE_ID))
         } else {
             let token_str = self.this_token_to_string();
-            return Err(self.fatal(&format!("expected `where`, `{}`, `(`, or `;` after struct \
-                                            name, found `{}`", "{", token_str)))
+            return Err(self.fatal(&format!("expected `where`, `{{`, `(`, or `;` after struct \
+                                            name, found `{}`", token_str)))
         };
 
         Ok((class_name,
@@ -4760,8 +4760,8 @@ impl<'a> Parser<'a> {
             try!(self.bump());
         } else {
             let token_str = self.this_token_to_string();
-            return Err(self.fatal(&format!("expected `where`, or `{}` after struct \
-                                name, found `{}`", "{",
+            return Err(self.fatal(&format!("expected `where`, or `{{` after struct \
+                                name, found `{}`",
                                 token_str)));
         }
 


### PR DESCRIPTION
There is a dead code in libsyntax/parser/parse.rs, when parsing structs.

Two functions are involved:
- [parse_item_struct](https://github.com/rust-lang/rust/blob/cd9c9f048f6aa0be091cd9835771ba0712bead4e/src/libsyntax/parse/parser.rs#L4691)
- [parse_tuple_struct_body](https://github.com/rust-lang/rust/blob/cd9c9f048f6aa0be091cd9835771ba0712bead4e/src/libsyntax/parse/parser.rs#L4769)

The problem is that both functions handle the case with unit structs. But because
`parse_tuple_struct_body` is called from `parse_item_struct`, it never faces
this case.

This PR removes unit struct case from `parse_tuple_struct_body` function. I tested with `make -j8 check-statge1`.
