### PR TITLE
some more clippy-based improvements

### DIFF
--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -220,7 +220,7 @@ impl<'longer_than_self> Arena<'longer_than_self> {
         *self.copy_head.borrow_mut() =
             chunk((new_min_chunk_size + 1).next_power_of_two(), true);
 
-        return self.alloc_copy_inner(n_bytes, align);
+        self.alloc_copy_inner(n_bytes, align)
     }
 
     #[inline]
@@ -247,7 +247,7 @@ impl<'longer_than_self> Arena<'longer_than_self> {
                                             mem::align_of::<T>());
             let ptr = ptr as *mut T;
             ptr::write(&mut (*ptr), op());
-            return &mut *ptr;
+            &mut *ptr
         }
     }
 
@@ -261,7 +261,7 @@ impl<'longer_than_self> Arena<'longer_than_self> {
         *self.head.borrow_mut() =
             chunk((new_min_chunk_size + 1).next_power_of_two(), false);
 
-        return self.alloc_noncopy_inner(n_bytes, align);
+        self.alloc_noncopy_inner(n_bytes, align)
     }
 
     #[inline]
@@ -290,7 +290,7 @@ impl<'longer_than_self> Arena<'longer_than_self> {
 
         unsafe {
             let buf = head.as_ptr();
-            return (buf.offset(tydesc_start as isize), buf.offset(start as isize));
+            (buf.offset(tydesc_start as isize), buf.offset(start as isize))
         }
     }
 
@@ -312,7 +312,7 @@ impl<'longer_than_self> Arena<'longer_than_self> {
             // the object is there.
             *ty_ptr = bitpack_tydesc_ptr(tydesc, true);
 
-            return &mut *ptr;
+            &mut *ptr
         }
     }
 
@@ -486,14 +486,12 @@ impl<T> TypedArena<T> {
             self.grow()
         }
 
-        let ptr: &mut T = unsafe {
+        unsafe {
             let ptr: &mut T = &mut *(self.ptr.get() as *mut T);
             ptr::write(ptr, object);
             self.ptr.set(self.ptr.get().offset(1));
             ptr
-        };
-
-        ptr
+        }
     }
 
     /// Grows the arena.

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -1558,10 +1558,10 @@ impl StrExt for str {
             if w > 2 { val = utf8_acc_cont_byte(val, s.as_bytes()[i + 2]); }
             if w > 3 { val = utf8_acc_cont_byte(val, s.as_bytes()[i + 3]); }
 
-            return CharRange {ch: unsafe { char::from_u32_unchecked(val) }, next: i};
+            CharRange {ch: unsafe { char::from_u32_unchecked(val) }, next: i}
         }
 
-        return multibyte_char_range_at_reverse(self, prev);
+        multibyte_char_range_at_reverse(self, prev)
     }
 
     #[inline]
@@ -1683,7 +1683,7 @@ fn char_range_at_raw(bytes: &[u8], i: usize) -> (u32, usize) {
         if w > 2 { val = utf8_acc_cont_byte(val, bytes[i + 2]); }
         if w > 3 { val = utf8_acc_cont_byte(val, bytes[i + 3]); }
 
-        return (val, i + w as usize);
+        (val, i + w as usize)
     }
 
     multibyte_char_range_at(bytes, i)

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -229,14 +229,14 @@ impl Name {
         if nm.len() == 1 {
             Short(nm.char_at(0))
         } else {
-            Long(nm.to_string())
+            Long(nm.to_owned())
         }
     }
 
     fn to_string(&self) -> String {
         match *self {
             Short(ch) => ch.to_string(),
-            Long(ref s) => s.to_string()
+            Long(ref s) => s.to_owned()
         }
     }
 }
@@ -375,7 +375,7 @@ impl Matches {
         } else {
             match vals[0] {
                 Val(ref s) => Some((*s).clone()),
-                _ => Some(def.to_string())
+                _ => Some(def.to_owned())
             }
         }
     }
@@ -414,10 +414,10 @@ pub fn reqopt(short_name: &str, long_name: &str, desc: &str, hint: &str) -> OptG
     let len = short_name.len();
     assert!(len == 1 || len == 0);
     OptGroup {
-        short_name: short_name.to_string(),
-        long_name: long_name.to_string(),
-        hint: hint.to_string(),
-        desc: desc.to_string(),
+        short_name: short_name.to_owned(),
+        long_name: long_name.to_owned(),
+        hint: hint.to_owned(),
+        desc: desc.to_owned(),
         hasarg: Yes,
         occur: Req
     }
@@ -434,10 +434,10 @@ pub fn optopt(short_name: &str, long_name: &str, desc: &str, hint: &str) -> OptG
     let len = short_name.len();
     assert!(len == 1 || len == 0);
     OptGroup {
-        short_name: short_name.to_string(),
-        long_name: long_name.to_string(),
-        hint: hint.to_string(),
-        desc: desc.to_string(),
+        short_name: short_name.to_owned(),
+        long_name: long_name.to_owned(),
+        hint: hint.to_owned(),
+        desc: desc.to_owned(),
         hasarg: Yes,
         occur: Optional
     }
@@ -452,10 +452,10 @@ pub fn optflag(short_name: &str, long_name: &str, desc: &str) -> OptGroup {
     let len = short_name.len();
     assert!(len == 1 || len == 0);
     OptGroup {
-        short_name: short_name.to_string(),
-        long_name: long_name.to_string(),
-        hint: "".to_string(),
-        desc: desc.to_string(),
+        short_name: short_name.to_owned(),
+        long_name: long_name.to_owned(),
+        hint: "".to_owned(),
+        desc: desc.to_owned(),
         hasarg: No,
         occur: Optional
     }
@@ -471,10 +471,10 @@ pub fn optflagmulti(short_name: &str, long_name: &str, desc: &str) -> OptGroup {
     let len = short_name.len();
     assert!(len == 1 || len == 0);
     OptGroup {
-        short_name: short_name.to_string(),
-        long_name: long_name.to_string(),
-        hint: "".to_string(),
-        desc: desc.to_string(),
+        short_name: short_name.to_owned(),
+        long_name: long_name.to_owned(),
+        hint: "".to_owned(),
+        desc: desc.to_owned(),
         hasarg: No,
         occur: Multi
     }
@@ -491,10 +491,10 @@ pub fn optflagopt(short_name: &str, long_name: &str, desc: &str, hint: &str) -> 
     let len = short_name.len();
     assert!(len == 1 || len == 0);
     OptGroup {
-        short_name: short_name.to_string(),
-        long_name: long_name.to_string(),
-        hint: hint.to_string(),
-        desc: desc.to_string(),
+        short_name: short_name.to_owned(),
+        long_name: long_name.to_owned(),
+        hint: hint.to_owned(),
+        desc: desc.to_owned(),
         hasarg: Maybe,
         occur: Optional
     }
@@ -512,10 +512,10 @@ pub fn optmulti(short_name: &str, long_name: &str, desc: &str, hint: &str) -> Op
     let len = short_name.len();
     assert!(len == 1 || len == 0);
     OptGroup {
-        short_name: short_name.to_string(),
-        long_name: long_name.to_string(),
-        hint: hint.to_string(),
-        desc: desc.to_string(),
+        short_name: short_name.to_owned(),
+        long_name: long_name.to_owned(),
+        hint: hint.to_owned(),
+        desc: desc.to_owned(),
         hasarg: Yes,
         occur: Multi
     }
@@ -531,10 +531,10 @@ pub fn opt(short_name: &str,
     let len = short_name.len();
     assert!(len == 1 || len == 0);
     OptGroup {
-        short_name: short_name.to_string(),
-        long_name: long_name.to_string(),
-        hint: hint.to_string(),
-        desc: desc.to_string(),
+        short_name: short_name.to_owned(),
+        long_name: long_name.to_owned(),
+        hint: hint.to_owned(),
+        desc: desc.to_owned(),
         hasarg: hasarg,
         occur: occur
     }
@@ -574,7 +574,7 @@ pub fn getopts(args: &[String], optgrps: &[OptGroup]) -> Result {
     let opts: Vec<Opt> = optgrps.iter().map(|x| x.long_to_short()).collect();
     let n_opts = opts.len();
 
-    fn f(_x: usize) -> Vec<Optval> { return Vec::new(); }
+    fn f(_x: usize) -> Vec<Optval> { Vec::new() }
 
     let mut vals: Vec<_> = (0..n_opts).map(f).collect();
     let mut free: Vec<String> = Vec::new();
@@ -596,11 +596,11 @@ pub fn getopts(args: &[String], optgrps: &[OptGroup]) -> Result {
                 let tail = &cur[2..curlen];
                 let tail_eq: Vec<&str> = tail.split('=').collect();
                 if tail_eq.len() <= 1 {
-                    names = vec!(Long(tail.to_string()));
+                    names = vec!(Long(tail.to_owned()));
                 } else {
                     names =
-                        vec!(Long(tail_eq[0].to_string()));
-                    i_arg = Some(tail_eq[1].to_string());
+                        vec!(Long(tail_eq[0].to_owned()));
+                    i_arg = Some(tail_eq[1].to_owned());
                 }
             } else {
                 let mut j = 1;
@@ -630,7 +630,7 @@ pub fn getopts(args: &[String], optgrps: &[OptGroup]) -> Result {
 
                     let next = j + ch.len_utf8();
                     if arg_follows && next < curlen {
-                        i_arg = Some((&cur[next..curlen]).to_string());
+                        i_arg = Some((&cur[next..curlen]).to_owned());
                         break;
                     }
 
@@ -769,7 +769,7 @@ pub fn usage(brief: &str, opts: &[OptGroup]) -> String {
         // FIXME: #5516 should be graphemes not codepoints
         let mut desc_rows = Vec::new();
         each_split_within(&desc_normalized_whitespace[..], 54, |substr| {
-            desc_rows.push(substr.to_string());
+            desc_rows.push(substr.to_owned());
             true
         });
 
@@ -936,7 +936,7 @@ fn each_split_within<F>(ss: &str, lim: usize, mut it: F) -> bool where
         machine(&mut cont, (fake_i, ' '));
         fake_i += 1;
     }
-    return cont;
+    cont
 }
 
 #[test]

--- a/src/liblog/directive.rs
+++ b/src/liblog/directive.rs
@@ -74,12 +74,12 @@ pub fn parse_logging_spec(spec: &str) -> (Vec<LogDirective>, Option<String>) {
             }
         };
         dirs.push(LogDirective {
-            name: name.map(|s| s.to_string()),
+            name: name.map(str::to_owned),
             level: log_level,
         });
     }});
 
-    (dirs, filter.map(|s| s.to_string()))
+    (dirs, filter.map(str::to_owned))
 }
 
 #[cfg(test)]
@@ -90,13 +90,13 @@ mod tests {
     fn parse_logging_spec_valid() {
         let (dirs, filter) = parse_logging_spec("crate1::mod1=1,crate1::mod2,crate2=4");
         assert_eq!(dirs.len(), 3);
-        assert_eq!(dirs[0].name, Some("crate1::mod1".to_string()));
+        assert_eq!(dirs[0].name, Some("crate1::mod1".to_owned()));
         assert_eq!(dirs[0].level, 1);
 
-        assert_eq!(dirs[1].name, Some("crate1::mod2".to_string()));
+        assert_eq!(dirs[1].name, Some("crate1::mod2".to_owned()));
         assert_eq!(dirs[1].level, ::MAX_LOG_LEVEL);
 
-        assert_eq!(dirs[2].name, Some("crate2".to_string()));
+        assert_eq!(dirs[2].name, Some("crate2".to_owned()));
         assert_eq!(dirs[2].level, 4);
         assert!(filter.is_none());
     }
@@ -106,7 +106,7 @@ mod tests {
         // test parse_logging_spec with multiple = in specification
         let (dirs, filter) = parse_logging_spec("crate1::mod1=1=2,crate2=4");
         assert_eq!(dirs.len(), 1);
-        assert_eq!(dirs[0].name, Some("crate2".to_string()));
+        assert_eq!(dirs[0].name, Some("crate2".to_owned()));
         assert_eq!(dirs[0].level, 4);
         assert!(filter.is_none());
     }
@@ -116,7 +116,7 @@ mod tests {
         // test parse_logging_spec with 'noNumber' as log level
         let (dirs, filter) = parse_logging_spec("crate1::mod1=noNumber,crate2=4");
         assert_eq!(dirs.len(), 1);
-        assert_eq!(dirs[0].name, Some("crate2".to_string()));
+        assert_eq!(dirs[0].name, Some("crate2".to_owned()));
         assert_eq!(dirs[0].level, 4);
         assert!(filter.is_none());
     }
@@ -126,7 +126,7 @@ mod tests {
         // test parse_logging_spec with 'warn' as log level
         let (dirs, filter) = parse_logging_spec("crate1::mod1=wrong,crate2=warn");
         assert_eq!(dirs.len(), 1);
-        assert_eq!(dirs[0].name, Some("crate2".to_string()));
+        assert_eq!(dirs[0].name, Some("crate2".to_owned()));
         assert_eq!(dirs[0].level, ::WARN);
         assert!(filter.is_none());
     }
@@ -136,7 +136,7 @@ mod tests {
         // test parse_logging_spec with '' as log level
         let (dirs, filter) = parse_logging_spec("crate1::mod1=wrong,crate2=");
         assert_eq!(dirs.len(), 1);
-        assert_eq!(dirs[0].name, Some("crate2".to_string()));
+        assert_eq!(dirs[0].name, Some("crate2".to_owned()));
         assert_eq!(dirs[0].level, ::MAX_LOG_LEVEL);
         assert!(filter.is_none());
     }
@@ -148,7 +148,7 @@ mod tests {
         assert_eq!(dirs.len(), 2);
         assert_eq!(dirs[0].name, None);
         assert_eq!(dirs[0].level, 2);
-        assert_eq!(dirs[1].name, Some("crate2".to_string()));
+        assert_eq!(dirs[1].name, Some("crate2".to_owned()));
         assert_eq!(dirs[1].level, 4);
         assert!(filter.is_none());
     }
@@ -157,32 +157,32 @@ mod tests {
     fn parse_logging_spec_valid_filter() {
         let (dirs, filter) = parse_logging_spec("crate1::mod1=1,crate1::mod2,crate2=4/abc");
         assert_eq!(dirs.len(), 3);
-        assert_eq!(dirs[0].name, Some("crate1::mod1".to_string()));
+        assert_eq!(dirs[0].name, Some("crate1::mod1".to_owned()));
         assert_eq!(dirs[0].level, 1);
 
-        assert_eq!(dirs[1].name, Some("crate1::mod2".to_string()));
+        assert_eq!(dirs[1].name, Some("crate1::mod2".to_owned()));
         assert_eq!(dirs[1].level, ::MAX_LOG_LEVEL);
 
-        assert_eq!(dirs[2].name, Some("crate2".to_string()));
+        assert_eq!(dirs[2].name, Some("crate2".to_owned()));
         assert_eq!(dirs[2].level, 4);
-        assert!(filter.is_some() && filter.unwrap().to_string() == "abc");
+        assert!(filter.is_some() && filter.unwrap().to_owned() == "abc");
     }
 
     #[test]
     fn parse_logging_spec_invalid_crate_filter() {
         let (dirs, filter) = parse_logging_spec("crate1::mod1=1=2,crate2=4/a.c");
         assert_eq!(dirs.len(), 1);
-        assert_eq!(dirs[0].name, Some("crate2".to_string()));
+        assert_eq!(dirs[0].name, Some("crate2".to_owned()));
         assert_eq!(dirs[0].level, 4);
-        assert!(filter.is_some() && filter.unwrap().to_string() == "a.c");
+        assert!(filter.is_some() && filter.unwrap().to_owned() == "a.c");
     }
 
     #[test]
     fn parse_logging_spec_empty_with_filter() {
         let (dirs, filter) = parse_logging_spec("crate1/a*c");
         assert_eq!(dirs.len(), 1);
-        assert_eq!(dirs[0].name, Some("crate1".to_string()));
+        assert_eq!(dirs[0].name, Some("crate1".to_owned()));
         assert_eq!(dirs[0].level, ::MAX_LOG_LEVEL);
-        assert!(filter.is_some() && filter.unwrap().to_string() == "a*c");
+        assert!(filter.is_some() && filter.unwrap().to_owned() == "a*c");
     }
 }

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -1324,7 +1324,7 @@ impl Stack {
     pub fn is_equal_to(&self, rhs: &[StackElement]) -> bool {
         if self.stack.len() != rhs.len() { return false; }
         for (i, r) in rhs.iter().enumerate() {
-            if &self.get(i) != r { return false; }
+            if self.get(i) != *r { return false; }
         }
         true
     }
@@ -1334,7 +1334,7 @@ impl Stack {
     pub fn starts_with(&self, rhs: &[StackElement]) -> bool {
         if self.stack.len() < rhs.len() { return false; }
         for (i, r) in rhs.iter().enumerate() {
-            if &self.get(i) != r { return false; }
+            if self.get(i) != *r { return false; }
         }
         true
     }
@@ -1345,7 +1345,7 @@ impl Stack {
         if self.stack.len() < rhs.len() { return false; }
         let offset = self.stack.len() - rhs.len();
         for (i, r) in rhs.iter().enumerate() {
-            if &self.get(i + offset) != r { return false; }
+            if self.get(i + offset) != *r { return false; }
         }
         true
     }

--- a/src/libserialize/serialize.rs
+++ b/src/libserialize/serialize.rs
@@ -515,7 +515,7 @@ macro_rules! tuple {
                                                        |d| -> Result<$name,D::Error> {
                         Decodable::decode(d)
                     })),)*);
-                    return Ok(ret);
+                    Ok(ret)
                 })
             }
         }

--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -231,7 +231,7 @@ mod dl {
                 Ok(result)
             } else {
                 let s = CStr::from_ptr(last_error).to_bytes();
-                Err(str::from_utf8(s).unwrap().to_string())
+                Err(str::from_utf8(s).unwrap().to_owned())
             };
 
             ret

--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -277,11 +277,11 @@ impl Error {
 
 impl fmt::Debug for Repr {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            &Repr::Os(ref code) =>
+        match *self {
+            Repr::Os(ref code) =>
                 fmt.debug_struct("Os").field("code", code)
                    .field("message", &sys::os::error_string(*code)).finish(),
-            &Repr::Custom(ref c) => fmt.debug_tuple("Custom").field(c).finish(),
+            Repr::Custom(ref c) => fmt.debug_tuple("Custom").field(c).finish(),
         }
     }
 }

--- a/src/libstd/io/lazy.rs
+++ b/src/libstd/io/lazy.rs
@@ -62,6 +62,6 @@ impl<T: Send + Sync + 'static> Lazy<T> {
         if registered.is_ok() {
             self.ptr.set(Box::into_raw(Box::new(ret.clone())));
         }
-        return ret
+        ret
     }
 }

--- a/src/libstd/net/parser.rs
+++ b/src/libstd/net/parser.rs
@@ -262,8 +262,8 @@ impl<'a> Parser<'a> {
     }
 
     fn read_ip_addr(&mut self) -> Option<IpAddr> {
-        let ipv4_addr = |p: &mut Parser| p.read_ipv4_addr().map(|v4| IpAddr::V4(v4));
-        let ipv6_addr = |p: &mut Parser| p.read_ipv6_addr().map(|v6| IpAddr::V6(v6));
+        let ipv4_addr = |p: &mut Parser| p.read_ipv4_addr().map(IpAddr::V4);
+        let ipv6_addr = |p: &mut Parser| p.read_ipv6_addr().map(IpAddr::V6);
         self.read_or(&mut [Box::new(ipv4_addr), Box::new(ipv6_addr)])
     }
 

--- a/src/libstd/rt/at_exit_imp.rs
+++ b/src/libstd/rt/at_exit_imp.rs
@@ -42,7 +42,7 @@ unsafe fn init() -> bool {
         return false
     }
 
-    return true
+    true
 }
 
 pub fn cleanup() {
@@ -78,5 +78,5 @@ pub fn push(f: Box<FnBox()>) -> bool {
         }
         LOCK.unlock();
     }
-    return ret
+    ret
 }

--- a/src/libstd/rt/dwarf/eh.rs
+++ b/src/libstd/rt/dwarf/eh.rs
@@ -104,7 +104,7 @@ pub unsafe fn find_landing_pad(lsda: *const u8, context: &EHContext)
     // IP range not found: gcc's C++ personality calls terminate() here,
     // however the rest of the languages treat this the same as cs_lpad == 0.
     // We follow this suit.
-    return None;
+    None
 }
 
 #[inline]

--- a/src/libstd/rt/mod.rs
+++ b/src/libstd/rt/mod.rs
@@ -73,7 +73,7 @@ fn lang_start(main: *const u8, argc: isize, argv: *const *const u8) -> isize {
         // created. Note that this isn't necessary in general for new threads,
         // but we just do this to name the main thread and to give it correct
         // info about the stack bounds.
-        let thread: Thread = NewThread::new(Some("<main>".to_string()));
+        let thread: Thread = NewThread::new(Some("<main>".to_owned()));
         thread_info::set(main_guard, thread);
 
         // By default, some platforms will send a *signal* when a EPIPE error

--- a/src/libstd/rt/util.rs
+++ b/src/libstd/rt/util.rs
@@ -27,7 +27,7 @@ pub fn min_stack() -> usize {
     // 0 is our sentinel value, so ensure that we'll never see 0 after
     // initialization has run
     MIN.store(amt + 1, Ordering::SeqCst);
-    return amt;
+    amt
 }
 
 // Indicates whether we should perform expensive sanity checks, including rtassert!

--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -397,7 +397,7 @@ enum Flavor<T> {
 
 #[doc(hidden)]
 trait UnsafeFlavor<T> {
-    fn inner_unsafe<'a>(&'a self) -> &'a UnsafeCell<Flavor<T>>;
+    fn inner_unsafe(&self) -> &UnsafeCell<Flavor<T>>;
     unsafe fn inner_mut<'a>(&'a self) -> &'a mut Flavor<T> {
         &mut *self.inner_unsafe().get()
     }
@@ -406,12 +406,12 @@ trait UnsafeFlavor<T> {
     }
 }
 impl<T> UnsafeFlavor<T> for Sender<T> {
-    fn inner_unsafe<'a>(&'a self) -> &'a UnsafeCell<Flavor<T>> {
+    fn inner_unsafe(&self) -> &UnsafeCell<Flavor<T>> {
         &self.inner
     }
 }
 impl<T> UnsafeFlavor<T> for Receiver<T> {
-    fn inner_unsafe<'a>(&'a self) -> &'a UnsafeCell<Flavor<T>> {
+    fn inner_unsafe(&self) -> &UnsafeCell<Flavor<T>> {
         &self.inner
     }
 }
@@ -677,7 +677,7 @@ impl<T> SyncSender<T> {
 impl<T> Clone for SyncSender<T> {
     fn clone(&self) -> SyncSender<T> {
         unsafe { (*self.inner.get()).clone_chan(); }
-        return SyncSender::new(self.inner.clone());
+        SyncSender::new(self.inner.clone())
     }
 }
 

--- a/src/libstd/sync/mpsc/spsc_queue.rs
+++ b/src/libstd/sync/mpsc/spsc_queue.rs
@@ -196,7 +196,7 @@ impl<T> Queue<T> {
                     let _: Box<Node<T>> = Box::from_raw(tail);
                 }
             }
-            return ret;
+            ret
         }
     }
 
@@ -207,14 +207,13 @@ impl<T> Queue<T> {
     /// The reference returned is invalid if it is not used before the consumer
     /// pops the value off the queue. If the producer then pushes another value
     /// onto the queue, it will overwrite the value pointed to by the reference.
-    pub fn peek<'a>(&'a self) -> Option<&'a mut T> {
+    pub fn peek(&self) -> Option<&mut T> {
         // This is essentially the same as above with all the popping bits
         // stripped out.
         unsafe {
             let tail = *self.tail.get();
             let next = (*tail).next.load(Ordering::Acquire);
-            if next.is_null() { return None }
-            return (*next).value.as_mut();
+            if next.is_null() { None } else { (*next).value.as_mut() }
         }
     }
 }

--- a/src/libstd/sync/mpsc/stream.rs
+++ b/src/libstd/sync/mpsc/stream.rs
@@ -307,12 +307,7 @@ impl<T> Packet<T> {
                             steals, DISCONNECTED, Ordering::SeqCst);
             cnt != DISCONNECTED && cnt != steals
         } {
-            loop {
-                match self.queue.pop() {
-                    Some(..) => { steals += 1; }
-                    None => break
-                }
-            }
+            while let Some(_) = self.queue.pop() { steals += 1; }
         }
 
         // At this point in time, we have gated all future senders from sending,
@@ -378,7 +373,7 @@ impl<T> Packet<T> {
                 // previous value is positive because we're not going to sleep
                 let prev = self.bump(1);
                 assert!(prev == DISCONNECTED || prev >= 0);
-                return ret;
+                ret
             }
         }
     }

--- a/src/libstd/sync/mpsc/sync.rs
+++ b/src/libstd/sync/mpsc/sync.rs
@@ -254,7 +254,7 @@ impl<T> Packet<T> {
         assert!(guard.buf.size() > 0);
         let ret = guard.buf.dequeue();
         self.wakeup_senders(waited, guard);
-        return Ok(ret);
+        Ok(ret)
     }
 
     pub fn try_recv(&self) -> Result<T, Failure> {
@@ -267,8 +267,7 @@ impl<T> Packet<T> {
         // Be sure to wake up neighbors
         let ret = Ok(guard.buf.dequeue());
         self.wakeup_senders(false, guard);
-
-        return ret;
+        ret
     }
 
     // Wake up pending senders after some data has been received
@@ -356,12 +355,7 @@ impl<T> Packet<T> {
         };
         mem::drop(guard);
 
-        loop {
-            match queue.dequeue() {
-                Some(token) => { token.signal(); }
-                None => break,
-            }
-        }
+        while let Some(token) = queue.dequeue() { token.signal(); }
         waiter.map(|t| t.signal());
     }
 

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -334,13 +334,14 @@ impl<'mutex, T: ?Sized> MutexGuard<'mutex, T> {
 impl<'mutex, T: ?Sized> Deref for MutexGuard<'mutex, T> {
     type Target = T;
 
-    fn deref<'a>(&'a self) -> &'a T {
+    fn deref(&self) -> &T {
         unsafe { &*self.__data.get() }
     }
 }
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'mutex, T: ?Sized> DerefMut for MutexGuard<'mutex, T> {
-    fn deref_mut<'a>(&'a mut self) -> &'a mut T {
+    fn deref_mut(&mut self) -> &mut T {
         unsafe { &mut *self.__data.get() }
     }
 }

--- a/src/libstd/sys/common/gnu/libbacktrace.rs
+++ b/src/libstd/sys/common/gnu/libbacktrace.rs
@@ -151,7 +151,7 @@ pub fn print(w: &mut Write, idx: isize, addr: *mut libc::c_void,
         };
         STATE = backtrace_create_state(filename, 0, error_cb,
                                        ptr::null_mut());
-        return STATE
+        STATE
     }
 
     ////////////////////////////////////////////////////////////////////////

--- a/src/libstd/sys/common/net.rs
+++ b/src/libstd/sys/common/net.rs
@@ -161,7 +161,7 @@ pub fn lookup_addr(addr: &IpAddr) -> io::Result<String> {
     };
 
     match from_utf8(data.to_bytes()) {
-        Ok(name) => Ok(name.to_string()),
+        Ok(name) => Ok(name.to_owned()),
         Err(_) => Err(io::Error::new(io::ErrorKind::Other,
                                      "failed to lookup address information"))
     }

--- a/src/libstd/sys/common/remutex.rs
+++ b/src/libstd/sys/common/remutex.rs
@@ -67,7 +67,7 @@ impl<T> ReentrantMutex<T> {
                 data: t,
             };
             mutex.inner.init();
-            return mutex
+            mutex
         }
     }
 
@@ -145,7 +145,7 @@ impl<'mutex, T> ReentrantMutexGuard<'mutex, T> {
 impl<'mutex, T> Deref for ReentrantMutexGuard<'mutex, T> {
     type Target = T;
 
-    fn deref<'a>(&'a self) -> &'a T {
+    fn deref(&self) -> &T {
         &self.__lock.data
     }
 }

--- a/src/libstd/sys/unix/backtrace/tracing/gcc_s.rs
+++ b/src/libstd/sys/unix/backtrace/tracing/gcc_s.rs
@@ -99,7 +99,7 @@ pub fn write(w: &mut Write) -> io::Result<()> {
         }
 
         // keep going
-        return uw::_URC_NO_REASON
+        uw::_URC_NO_REASON
     }
 }
 

--- a/src/libstd/sys/unix/net.rs
+++ b/src/libstd/sys/unix/net.rs
@@ -35,7 +35,7 @@ pub fn cvt_gai(err: c_int) -> io::Result<()> {
 
     let detail = unsafe {
         str::from_utf8(CStr::from_ptr(c::gai_strerror(err)).to_bytes()).unwrap()
-            .to_string()
+            .to_owned()
     };
     Err(io::Error::new(io::ErrorKind::Other,
                        &format!("failed to lookup address information: {}",

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -141,8 +141,7 @@ pub fn split_paths(unparsed: &OsStr) -> SplitPaths {
     fn is_colon(b: &u8) -> bool { *b == b':' }
     let unparsed = unparsed.as_bytes();
     SplitPaths {
-        iter: unparsed.split(is_colon as fn(&u8) -> bool)
-                      .map(bytes_to_path as fn(&[u8]) -> PathBuf)
+        iter: unparsed.split(is_colon).map(bytes_to_path)
     }
 }
 

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -142,7 +142,7 @@ pub fn split_paths(unparsed: &OsStr) -> SplitPaths {
     let unparsed = unparsed.as_bytes();
     SplitPaths {
         iter: unparsed.split(is_colon as fn(&u8) -> bool)
-                      .map(bytes_to_path as fn(&'a [u8]) -> PathBuf)
+                      .map(bytes_to_path as fn(&[u8]) -> PathBuf)
     }
 }
 

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -141,7 +141,8 @@ pub fn split_paths(unparsed: &OsStr) -> SplitPaths {
     fn is_colon(b: &u8) -> bool { *b == b':' }
     let unparsed = unparsed.as_bytes();
     SplitPaths {
-        iter: unparsed.split(is_colon).map(bytes_to_path)
+        iter: unparsed.split(is_colon as fn(&u8) -> bool)
+                      .map(bytes_to_path as fn(&'a [u8]) -> PathBuf)
     }
 }
 

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -88,7 +88,7 @@ pub fn error_string(errno: i32) -> String {
         }
 
         let p = p as *const _;
-        str::from_utf8(CStr::from_ptr(p).to_bytes()).unwrap().to_string()
+        str::from_utf8(CStr::from_ptr(p).to_bytes()).unwrap().to_owned()
     }
 }
 
@@ -134,7 +134,7 @@ pub struct SplitPaths<'a> {
                     fn(&'a [u8]) -> PathBuf>,
 }
 
-pub fn split_paths<'a>(unparsed: &'a OsStr) -> SplitPaths<'a> {
+pub fn split_paths(unparsed: &OsStr) -> SplitPaths {
     fn bytes_to_path(b: &[u8]) -> PathBuf {
         PathBuf::from(<OsStr as OsStrExt>::from_bytes(b))
     }
@@ -142,7 +142,7 @@ pub fn split_paths<'a>(unparsed: &'a OsStr) -> SplitPaths<'a> {
     let unparsed = unparsed.as_bytes();
     SplitPaths {
         iter: unparsed.split(is_colon as fn(&u8) -> bool)
-                      .map(bytes_to_path as fn(&'a [u8]) -> PathBuf)
+                      .map(bytes_to_path as fn(&[u8]) -> PathBuf)
     }
 }
 

--- a/src/libstd/sys/unix/stdio.rs
+++ b/src/libstd/sys/unix/stdio.rs
@@ -23,7 +23,7 @@ impl Stdin {
         let fd = FileDesc::new(libc::STDIN_FILENO);
         let ret = fd.read(data);
         fd.into_raw();
-        return ret;
+        ret
     }
 }
 
@@ -34,7 +34,7 @@ impl Stdout {
         let fd = FileDesc::new(libc::STDOUT_FILENO);
         let ret = fd.write(data);
         fd.into_raw();
-        return ret;
+        ret
     }
 }
 
@@ -45,7 +45,7 @@ impl Stderr {
         let fd = FileDesc::new(libc::STDERR_FILENO);
         let ret = fd.write(data);
         fd.into_raw();
-        return ret;
+        ret
     }
 }
 

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -310,7 +310,7 @@ pub mod guard {
             ret = Some(stackaddr as usize + guardsize as usize);
         }
         assert_eq!(pthread_attr_destroy(&mut attr), 0);
-        return ret
+        ret
     }
 
     #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/src/libstd/sys/unix/thread_local.rs
+++ b/src/libstd/sys/unix/thread_local.rs
@@ -18,7 +18,7 @@ pub type Key = pthread_key_t;
 pub unsafe fn create(dtor: Option<unsafe extern fn(*mut u8)>) -> Key {
     let mut key = 0;
     assert_eq!(pthread_key_create(&mut key, dtor), 0);
-    return key;
+    key
 }
 
 #[inline]

--- a/src/libterm/terminfo/mod.rs
+++ b/src/libterm/terminfo/mod.rs
@@ -151,7 +151,7 @@ impl<T: Write+Send+'static> Terminal<T> for TerminfoTerminal<T> {
                 cap = self.ti.strings.get("op");
             }
         }
-        let s = cap.map_or(Err("can't find terminfo capability `sgr0`".to_string()), |op| {
+        let s = cap.map_or(Err("can't find terminfo capability `sgr0`".to_owned()), |op| {
             expand(op, &[], &mut Variables::new())
         });
         if s.is_ok() {
@@ -211,9 +211,9 @@ impl<T: Write+Send+'static> TerminfoTerminal<T> {
                      inf.numbers.get("colors").map_or(0, |&n| n)
                  } else { 0 };
 
-        return Some(box TerminfoTerminal {out: out,
-                                          ti: inf,
-                                          num_colors: nc});
+        Some(box TerminfoTerminal {out: out,
+                                   ti: inf,
+                                   num_colors: nc})
     }
 
     fn dim_if_necessary(&self, color: color::Color) -> color::Color {

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -133,9 +133,9 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                                     c as u8
                                 })
                             }
-                            _       => return Err("a non-char was used with %c".to_string())
+                            _       => return Err("a non-char was used with %c".to_owned())
                         }
-                    } else { return Err("stack is empty".to_string()) },
+                    } else { return Err("stack is empty".to_owned()) },
                     'p' => state = PushParam,
                     'P' => state = SetVar,
                     'g' => state = GetVar,
@@ -144,112 +144,112 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                     'l' => if !stack.is_empty() {
                         match stack.pop().unwrap() {
                             Words(s) => stack.push(Number(s.len() as isize)),
-                            _        => return Err("a non-str was used with %l".to_string())
+                            _        => return Err("a non-str was used with %l".to_owned())
                         }
-                    } else { return Err("stack is empty".to_string()) },
+                    } else { return Err("stack is empty".to_owned()) },
                     '+' => if stack.len() > 1 {
                         match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(y), Number(x)) => stack.push(Number(x + y)),
-                            _ => return Err("non-numbers on stack with +".to_string())
+                            _ => return Err("non-numbers on stack with +".to_owned())
                         }
-                    } else { return Err("stack is empty".to_string()) },
+                    } else { return Err("stack is empty".to_owned()) },
                     '-' => if stack.len() > 1 {
                         match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(y), Number(x)) => stack.push(Number(x - y)),
-                            _ => return Err("non-numbers on stack with -".to_string())
+                            _ => return Err("non-numbers on stack with -".to_owned())
                         }
-                    } else { return Err("stack is empty".to_string()) },
+                    } else { return Err("stack is empty".to_owned()) },
                     '*' => if stack.len() > 1 {
                         match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(y), Number(x)) => stack.push(Number(x * y)),
-                            _ => return Err("non-numbers on stack with *".to_string())
+                            _ => return Err("non-numbers on stack with *".to_owned())
                         }
-                    } else { return Err("stack is empty".to_string()) },
+                    } else { return Err("stack is empty".to_owned()) },
                     '/' => if stack.len() > 1 {
                         match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(y), Number(x)) => stack.push(Number(x / y)),
-                            _ => return Err("non-numbers on stack with /".to_string())
+                            _ => return Err("non-numbers on stack with /".to_owned())
                         }
-                    } else { return Err("stack is empty".to_string()) },
+                    } else { return Err("stack is empty".to_owned()) },
                     'm' => if stack.len() > 1 {
                         match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(y), Number(x)) => stack.push(Number(x % y)),
-                            _ => return Err("non-numbers on stack with %".to_string())
+                            _ => return Err("non-numbers on stack with %".to_owned())
                         }
-                    } else { return Err("stack is empty".to_string()) },
+                    } else { return Err("stack is empty".to_owned()) },
                     '&' => if stack.len() > 1 {
                         match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(y), Number(x)) => stack.push(Number(x & y)),
-                            _ => return Err("non-numbers on stack with &".to_string())
+                            _ => return Err("non-numbers on stack with &".to_owned())
                         }
-                    } else { return Err("stack is empty".to_string()) },
+                    } else { return Err("stack is empty".to_owned()) },
                     '|' => if stack.len() > 1 {
                         match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(y), Number(x)) => stack.push(Number(x | y)),
-                            _ => return Err("non-numbers on stack with |".to_string())
+                            _ => return Err("non-numbers on stack with |".to_owned())
                         }
-                    } else { return Err("stack is empty".to_string()) },
+                    } else { return Err("stack is empty".to_owned()) },
                     '^' => if stack.len() > 1 {
                         match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(y), Number(x)) => stack.push(Number(x ^ y)),
-                            _ => return Err("non-numbers on stack with ^".to_string())
+                            _ => return Err("non-numbers on stack with ^".to_owned())
                         }
-                    } else { return Err("stack is empty".to_string()) },
+                    } else { return Err("stack is empty".to_owned()) },
                     '=' => if stack.len() > 1 {
                         match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(y), Number(x)) => stack.push(Number(if x == y { 1 }
                                                                         else { 0 })),
-                            _ => return Err("non-numbers on stack with =".to_string())
+                            _ => return Err("non-numbers on stack with =".to_owned())
                         }
-                    } else { return Err("stack is empty".to_string()) },
+                    } else { return Err("stack is empty".to_owned()) },
                     '>' => if stack.len() > 1 {
                         match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(y), Number(x)) => stack.push(Number(if x > y { 1 }
                                                                         else { 0 })),
-                            _ => return Err("non-numbers on stack with >".to_string())
+                            _ => return Err("non-numbers on stack with >".to_owned())
                         }
-                    } else { return Err("stack is empty".to_string()) },
+                    } else { return Err("stack is empty".to_owned()) },
                     '<' => if stack.len() > 1 {
                         match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(y), Number(x)) => stack.push(Number(if x < y { 1 }
                                                                         else { 0 })),
-                            _ => return Err("non-numbers on stack with <".to_string())
+                            _ => return Err("non-numbers on stack with <".to_owned())
                         }
-                    } else { return Err("stack is empty".to_string()) },
+                    } else { return Err("stack is empty".to_owned()) },
                     'A' => if stack.len() > 1 {
                         match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(0), Number(_)) => stack.push(Number(0)),
                             (Number(_), Number(0)) => stack.push(Number(0)),
                             (Number(_), Number(_)) => stack.push(Number(1)),
-                            _ => return Err("non-numbers on stack with logical and".to_string())
+                            _ => return Err("non-numbers on stack with logical and".to_owned())
                         }
-                    } else { return Err("stack is empty".to_string()) },
+                    } else { return Err("stack is empty".to_owned()) },
                     'O' => if stack.len() > 1 {
                         match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(0), Number(0)) => stack.push(Number(0)),
                             (Number(_), Number(_)) => stack.push(Number(1)),
-                            _ => return Err("non-numbers on stack with logical or".to_string())
+                            _ => return Err("non-numbers on stack with logical or".to_owned())
                         }
-                    } else { return Err("stack is empty".to_string()) },
+                    } else { return Err("stack is empty".to_owned()) },
                     '!' => if !stack.is_empty() {
                         match stack.pop().unwrap() {
                             Number(0) => stack.push(Number(1)),
                             Number(_) => stack.push(Number(0)),
-                            _ => return Err("non-number on stack with logical not".to_string())
+                            _ => return Err("non-number on stack with logical not".to_owned())
                         }
-                    } else { return Err("stack is empty".to_string()) },
+                    } else { return Err("stack is empty".to_owned()) },
                     '~' => if !stack.is_empty() {
                         match stack.pop().unwrap() {
                             Number(x) => stack.push(Number(!x)),
-                            _         => return Err("non-number on stack with %~".to_string())
+                            _         => return Err("non-number on stack with %~".to_owned())
                         }
-                    } else { return Err("stack is empty".to_string()) },
+                    } else { return Err("stack is empty".to_owned()) },
                     'i' => match (mparams[0].clone(), mparams[1].clone()) {
                         (Number(x), Number(y)) => {
                             mparams[0] = Number(x+1);
                             mparams[1] = Number(y+1);
                         },
-                        (_, _) => return Err("first two params not numbers with %i".to_string())
+                        (_, _) => return Err("first two params not numbers with %i".to_owned())
                     },
 
                     // printf-style support for %doxXs
@@ -258,7 +258,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                         let res = format(stack.pop().unwrap(), FormatOp::from_char(cur), flags);
                         if res.is_err() { return res }
                         output.push_all(&res.unwrap())
-                    } else { return Err("stack is empty".to_string()) },
+                    } else { return Err("stack is empty".to_owned()) },
                     ':'|'#'|' '|'.'|'0'...'9' => {
                         let mut flags = Flags::new();
                         let mut fstate = FormatStateFlags;
@@ -283,9 +283,9 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                             Number(0) => state = SeekIfElse(0),
                             Number(_) => (),
                             _         => return Err("non-number on stack \
-                                                    with conditional".to_string())
+                                                    with conditional".to_owned())
                         }
-                    } else { return Err("stack is empty".to_string()) },
+                    } else { return Err("stack is empty".to_owned()) },
                     'e' => state = SeekIfEnd(0),
                     ';' => (),
 
@@ -298,7 +298,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                 // params are 1-indexed
                 stack.push(mparams[match cur.to_digit(10) {
                     Some(d) => d as usize - 1,
-                    None => return Err("bad param number".to_string())
+                    None => return Err("bad param number".to_owned())
                 }].clone());
             },
             SetVar => {
@@ -306,14 +306,14 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                     if !stack.is_empty() {
                         let idx = (cur as u8) - b'A';
                         vars.sta[idx as usize] = stack.pop().unwrap();
-                    } else { return Err("stack is empty".to_string()) }
+                    } else { return Err("stack is empty".to_owned()) }
                 } else if cur >= 'a' && cur <= 'z' {
                     if !stack.is_empty() {
                         let idx = (cur as u8) - b'a';
                         vars.dyn[idx as usize] = stack.pop().unwrap();
-                    } else { return Err("stack is empty".to_string()) }
+                    } else { return Err("stack is empty".to_owned()) }
                 } else {
-                    return Err("bad variable name in %P".to_string());
+                    return Err("bad variable name in %P".to_owned());
                 }
             },
             GetVar => {
@@ -324,7 +324,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                     let idx = (cur as u8) - b'a';
                     stack.push(vars.dyn[idx as usize].clone());
                 } else {
-                    return Err("bad variable name in %g".to_string());
+                    return Err("bad variable name in %g".to_owned());
                 }
             },
             CharConstant => {
@@ -333,7 +333,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
             },
             CharClose => {
                 if cur != '\'' {
-                    return Err("malformed character constant".to_string());
+                    return Err("malformed character constant".to_owned());
                 }
             },
             IntConstant(i) => {
@@ -346,7 +346,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                         state = IntConstant(i*10 + (cur as isize - '0' as isize));
                         old_state = Nothing;
                     }
-                    _ => return Err("bad isize constant".to_string())
+                    _ => return Err("bad isize constant".to_owned())
                 }
             }
             FormatPattern(ref mut flags, ref mut fstate) => {
@@ -358,7 +358,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                         output.push_all(&res.unwrap());
                         // will cause state to go to Nothing
                         old_state = FormatPattern(*flags, *fstate);
-                    } else { return Err("stack is empty".to_string()) },
+                    } else { return Err("stack is empty".to_owned()) },
                     (FormatStateFlags,'#') => {
                         flags.alternate = true;
                     }
@@ -381,7 +381,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                     (FormatStateWidth,'0'...'9') => {
                         let old = flags.width;
                         flags.width = flags.width * 10 + (cur as usize - '0' as usize);
-                        if flags.width < old { return Err("format width overflow".to_string()) }
+                        if flags.width < old { return Err("format width overflow".to_owned()) }
                     }
                     (FormatStateWidth,'.') => {
                         *fstate = FormatStatePrecision;
@@ -390,10 +390,10 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                         let old = flags.precision;
                         flags.precision = flags.precision * 10 + (cur as usize - '0' as usize);
                         if flags.precision < old {
-                            return Err("format precision overflow".to_string())
+                            return Err("format precision overflow".to_owned())
                         }
                     }
-                    _ => return Err("invalid format specifier".to_string())
+                    _ => return Err("invalid format specifier".to_owned())
                 }
             }
             SeekIfElse(level) => {
@@ -502,7 +502,7 @@ fn format(val: Param, op: FormatOp, flags: Flags) -> Result<Vec<u8> ,String> {
                 (FormatHex, _)       => format!("{:x}", d).into_bytes(),
                 (FormatHEX, _)       => format!("{:X}", d).into_bytes(),
                 (FormatString, _)    => {
-                    return Err("non-number on stack with %s".to_string())
+                    return Err("non-number on stack with %s".to_owned())
                 }
             };
             let mut s: Vec<u8> = s.into_iter().collect();
@@ -692,7 +692,7 @@ mod tests {
                             Words("f".to_string()),
                             Words("foo".to_string())], vars),
                    Ok("foofoo ffo".bytes().collect::<Vec<_>>()));
-        assert_eq!(expand(b"%p1%:-4.2s", &[Words("foo".to_string())], vars),
+        assert_eq!(expand(b"%p1%:-4.2s", &[Words("foo".to_owned())], vars),
                    Ok("fo  ".bytes().collect::<Vec<_>>()));
 
         assert_eq!(expand(b"%p1%d%p1%.3d%p1%5d%p1%:+d", &[Number(1)], vars),

--- a/src/libterm/terminfo/parser/compiled.rs
+++ b/src/libterm/terminfo/parser/compiled.rs
@@ -205,28 +205,28 @@ pub fn parse(file: &mut Read, longnames: bool)
 
     if (bools_bytes as usize) > boolnames.len() {
         return Err("incompatible file: more booleans than \
-                    expected".to_string());
+                    expected".to_owned());
     }
 
     if (numbers_count as usize) > numnames.len() {
         return Err("incompatible file: more numbers than \
-                    expected".to_string());
+                    expected".to_owned());
     }
 
     if (string_offsets_count as usize) > stringnames.len() {
         return Err("incompatible file: more string offsets than \
-                    expected".to_string());
+                    expected".to_owned());
     }
 
     // don't read NUL
     let bytes = try!(read_exact(file, names_bytes as usize - 1));
     let names_str = match String::from_utf8(bytes) {
         Ok(s)  => s,
-        Err(_) => return Err("input not utf-8".to_string()),
+        Err(_) => return Err("input not utf-8".to_owned()),
     };
 
     let term_names: Vec<String> = names_str.split('|')
-                                           .map(|s| s.to_string())
+                                           .map(str::to_owned)
                                            .collect();
 
     try!(read_byte(file)); // consume NUL
@@ -236,7 +236,7 @@ pub fn parse(file: &mut Read, longnames: bool)
         for i in 0..bools_bytes {
             let b = try!(read_byte(file));
             if b == 1 {
-                bools_map.insert(bnames[i as usize].to_string(), true);
+                bools_map.insert(bnames[i as usize].to_owned(), true);
             }
         }
     }
@@ -250,7 +250,7 @@ pub fn parse(file: &mut Read, longnames: bool)
         for i in 0..numbers_count {
             let n = try!(read_le_u16(file));
             if n != 0xFFFF {
-                numbers_map.insert(nnames[i as usize].to_string(), n);
+                numbers_map.insert(nnames[i as usize].to_owned(), n);
             }
         }
     }
@@ -267,7 +267,7 @@ pub fn parse(file: &mut Read, longnames: bool)
 
         if string_table.len() != string_table_bytes as usize {
             return Err("error: hit EOF before end of string \
-                        table".to_string());
+                        table".to_owned());
         }
 
         for (i, v) in string_offsets.iter().enumerate() {
@@ -285,7 +285,7 @@ pub fn parse(file: &mut Read, longnames: bool)
             if offset == 0xFFFE {
                 // undocumented: FFFE indicates cap@, which means the capability is not present
                 // unsure if the handling for this is correct
-                string_map.insert(name.to_string(), Vec::new());
+                string_map.insert(name.to_owned(), Vec::new());
                 continue;
             }
 
@@ -301,7 +301,7 @@ pub fn parse(file: &mut Read, longnames: bool)
                 },
                 None => {
                     return Err("invalid file: missing NUL in \
-                                string_table".to_string());
+                                string_table".to_owned());
                 }
             };
         }
@@ -338,12 +338,12 @@ fn read_exact<R: Read + ?Sized>(r: &mut R, sz: usize) -> io::Result<Vec<u8>> {
 /// Create a dummy TermInfo struct for msys terminals
 pub fn msys_terminfo() -> Box<TermInfo> {
     let mut strings = HashMap::new();
-    strings.insert("sgr0".to_string(), b"\x1B[0m".to_vec());
-    strings.insert("bold".to_string(), b"\x1B[1m".to_vec());
-    strings.insert("setaf".to_string(), b"\x1B[3%p1%dm".to_vec());
-    strings.insert("setab".to_string(), b"\x1B[4%p1%dm".to_vec());
+    strings.insert("sgr0".to_owned(), b"\x1B[0m".to_vec());
+    strings.insert("bold".to_owned(), b"\x1B[1m".to_vec());
+    strings.insert("setaf".to_owned(), b"\x1B[3%p1%dm".to_vec());
+    strings.insert("setab".to_owned(), b"\x1B[4%p1%dm".to_vec());
     box TermInfo {
-        names: vec!("cygwin".to_string()), // msys is a fork of an older cygwin version
+        names: vec!("cygwin".to_owned()), // msys is a fork of an older cygwin version
         bools: HashMap::new(),
         numbers: HashMap::new(),
         strings: strings

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -169,7 +169,6 @@ impl Stats for [f64] {
             // This inner loop applies `hi`/`lo` summation to each
             // partial so that the list of partial sums remains exact.
             for mut y in &mut partials {
-                let mut y: f64 = partials[i];
                 if x.abs() < y.abs() {
                     mem::swap(&mut x, &mut y);
                 }

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -168,7 +168,8 @@ impl Stats for [f64] {
             let mut j = 0;
             // This inner loop applies `hi`/`lo` summation to each
             // partial so that the list of partial sums remains exact.
-            for mut y in &mut partials {
+            for i in 0..partials.len() {
+                let mut y: f64 = partials[i];
                 if x.abs() < y.abs() {
                     mem::swap(&mut x, &mut y);
                 }

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -168,7 +168,7 @@ impl Stats for [f64] {
             let mut j = 0;
             // This inner loop applies `hi`/`lo` summation to each
             // partial so that the list of partial sums remains exact.
-            for i in 0..partials.len() {
+            for mut y in &mut partials {
                 let mut y: f64 = partials[i];
                 if x.abs() < y.abs() {
                     mem::swap(&mut x, &mut y);


### PR DESCRIPTION
It's a large number of small improvements to the code, mostly readability-related, but removing closures and replacing `str::to_string()` with `.to_owned()` should also positively affect performance.

r? @Manishearth (once it compiles, of course :smile:)
