### PR TITLE
Clarify that `include_bytes!` returns a reference to an array, not just a slice

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -412,9 +412,9 @@ pub mod builtin {
     #[macro_export]
     macro_rules! include_str { ($file:expr) => ({ /* compiler built-in */ }) }
 
-    /// Includes a file as a byte slice.
+    /// Includes a file as a reference to a byte array.
     ///
-    /// This macro will yield an expression of type `&'static [u8]` which is
+    /// This macro will yield an expression of type `&'static [u8; N]` which is
     /// the contents of the filename specified. The file is located relative to
     /// the current file (similarly to how modules are found),
     ///


### PR DESCRIPTION
This can be shown with the example code

``` rust
fn main() {
    let () = include_bytes!("/etc/hosts");
}

Which will have the error:

expected `&[u8; 195]`,
    found `()`
```
