### PR TITLE
Fix link to hygienic macros on Wikipedia

### DIFF
--- a/src/doc/trpl/macros.md
+++ b/src/doc/trpl/macros.md
@@ -313,7 +313,7 @@ fn main() {
 }
 ```
 
-This works because Rust has a [hygienic macro system][https://en.wikipedia.org/wiki/Hygienic_macro]. Each macro expansion
+This works because Rust has a [hygienic macro system]. Each macro expansion
 happens in a distinct ‘syntax context’, and each variable is tagged with the
 syntax context where it was introduced. It’s as though the variable `state`
 inside `main` is painted a different "color" from the variable `state` inside


### PR DESCRIPTION
The link address is defined below the paragraph so no need to have it inline.
