### PR TITLE
Fix configure for LLVM 3.8

### DIFF
--- a/configure
+++ b/configure
@@ -1030,7 +1030,7 @@ then
             esac
         else
             case $CFG_CLANG_VERSION in
-                (3.2* | 3.3* | 3.4* | 3.5* | 3.6* | 3.7*)
+                (3.2* | 3.3* | 3.4* | 3.5* | 3.6* | 3.7* | 3.8*)
                 step_msg "found ok version of CLANG: $CFG_CLANG_VERSION"
                 ;;
                 (*)

--- a/configure
+++ b/configure
@@ -956,7 +956,7 @@ then
     LLVM_VERSION=$($LLVM_CONFIG --version)
 
     case $LLVM_VERSION in
-        (3.[5-7]*)
+        (3.[5-8]*)
             msg "found ok version of LLVM: $LLVM_VERSION"
             ;;
         (*)


### PR DESCRIPTION
Fix the following error when running configure with llvm 3.8svn:

configure: error: bad LLVM version: 3.8.0svn, need >=3.5
