### PR TITLE
Don't force system LLVM libs to be linked staticly

### DIFF
--- a/mk/llvm.mk
+++ b/mk/llvm.mk
@@ -83,7 +83,7 @@ endif
 LLVM_LINKAGE_PATH_$(1):=$$(abspath $$(RT_OUTPUT_DIR_$(1))/llvmdeps.rs)
 $$(LLVM_LINKAGE_PATH_$(1)): $(S)src/etc/mklldeps.py $$(LLVM_CONFIG_$(1))
 	$(Q)$(CFG_PYTHON) "$$<" "$$@" "$$(LLVM_COMPONENTS)" "$$(CFG_ENABLE_LLVM_STATIC_STDCPP)" \
-		$$(LLVM_CONFIG_$(1))
+		"$$(CFG_LLVM_ROOT)" $$(LLVM_CONFIG_$(1))
 endef
 
 $(foreach host,$(CFG_HOST), \

--- a/src/etc/mklldeps.py
+++ b/src/etc/mklldeps.py
@@ -16,7 +16,8 @@ f = open(sys.argv[1], 'wb')
 
 components = sys.argv[2].split() # splits on whitespace
 enable_static = sys.argv[3]
-llvm_config = sys.argv[4]
+llvm_root = sys.argv[4]
+llvm_config = sys.argv[5]
 
 f.write("""// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
@@ -63,7 +64,7 @@ for lib in out.strip().replace("\n", ' ').split(' '):
         lib = lib.strip()[1:]
     f.write("#[link(name = \"" + lib + "\"")
     # LLVM libraries are all static libraries
-    if 'LLVM' in lib:
+    if llvm_root == '' and 'LLVM' in lib:
         f.write(", kind = \"static\"")
     f.write(")]\n")
 


### PR DESCRIPTION
This allows building against an external LLVM installation that only includes dynamic libraries.  When linking against bundled LLVM we still force static linking so the bundled LLVM libraries don't have to be installed.
