### PR TITLE
openbsd: probe CFG_GCC egcc

### DIFF
--- a/configure
+++ b/configure
@@ -885,6 +885,25 @@ then
     CFG_DISABLE_JEMALLOC=1
 fi
 
+# default gcc version under OpenBSD maybe too old, try using egcc, which is a
+# gcc version from ports
+if [ $CFG_OSTYPE = unknown-openbsd ]
+then
+    if [ $("$CFG_GCC" --version 2>&1 | grep -c ' 4\.[0-6]') -ne 0 ]; then
+        step_msg "older GCC found, try with egcc instead"
+
+        # probe again but using egcc
+        probe CFG_GCC egcc
+
+        # and use egcc/eg++ for CC/CXX too if it was found
+        # (but user setting has priority)
+        if [ -n "$CFG_GCC" ]; then
+            CC="${CC:-egcc}"
+            CXX="${CXX:-eg++}"
+        fi
+    fi    
+fi
+
 # OS X 10.9, gcc is actually clang. This can cause some confusion in the build
 # system, so if we find that gcc is clang, we should just use clang directly.
 if [ $CFG_OSTYPE = apple-darwin -a -z "$CFG_ENABLE_CLANG" ]

--- a/configure
+++ b/configure
@@ -901,7 +901,10 @@ then
             CC="${CC:-egcc}"
             CXX="${CXX:-eg++}"
         fi
-    fi    
+    fi
+
+    step_msg "on OpenBSD, disabling jemalloc"
+    CFG_DISABLE_JEMALLOC=1
 fi
 
 # OS X 10.9, gcc is actually clang. This can cause some confusion in the build


### PR DESCRIPTION
under OpenBSD, it could be have present multiples versions of gcc compiler:
- gcc-4.2 (with patchs) : c/c++ compiler present in `/usr/bin`. It is unusable to build recent LLVM (so rustc too).
- gcc/g++ -4.9 : c/c++ compiler, installed as third-party with "ports" mechanism. The compiler is installed in `/usr/local` as `egcc` (and `eg++`).

this PR adds probing for `egcc` for `CFG_GCC`, if the first probed `gcc` is too old. It will set `CC` and `CXX` too, in order to pass the variables to LLVM configure if builded.

please note this PR is a first step in order to build rustc under OpenBSD with unpatched tree.

r? @alexcrichton

cc @brson @dhuseby 
