### PR TITLE
std: Stabilize/deprecate features for 1.4

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -137,7 +137,7 @@ impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Arc<U>> for Arc<T> {}
 /// Weak pointers will not keep the data inside of the `Arc` alive, and can be
 /// used to break cycles between `Arc` pointers.
 #[unsafe_no_drop_flag]
-#[unstable(feature = "arc_weak", reason = "needs FCP", issue = "27718")]
+#[stable(feature = "arc_weak", since = "1.4.0")]
 pub struct Weak<T: ?Sized> {
     // FIXME #12808: strange name to try to avoid interfering with
     // field accesses of the contained type via Deref
@@ -201,7 +201,6 @@ impl<T> Arc<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(arc_unique)]
     /// use std::sync::Arc;
     ///
     /// let x = Arc::new(3);
@@ -212,7 +211,7 @@ impl<T> Arc<T> {
     /// assert_eq!(Arc::try_unwrap(x), Err(Arc::new(4)));
     /// ```
     #[inline]
-    #[unstable(feature = "arc_unique", reason = "needs FCP", issue = "27718")]
+    #[stable(feature = "arc_unique", since = "1.4.0")]
     pub fn try_unwrap(this: Self) -> Result<T, Self> {
         // See `drop` for why all these atomics are like this
         if this.inner().strong.compare_and_swap(1, 0, Release) != 1 { return Err(this) }
@@ -238,14 +237,13 @@ impl<T: ?Sized> Arc<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(arc_weak)]
     /// use std::sync::Arc;
     ///
     /// let five = Arc::new(5);
     ///
     /// let weak_five = Arc::downgrade(&five);
     /// ```
-    #[unstable(feature = "arc_weak", reason = "needs FCP", issue = "27718")]
+    #[stable(feature = "arc_weak", since = "1.4.0")]
     pub fn downgrade(this: &Self) -> Weak<T> {
         loop {
             // This Relaxed is OK because we're checking the value in the CAS
@@ -270,14 +268,16 @@ impl<T: ?Sized> Arc<T> {
 
     /// Get the number of weak references to this value.
     #[inline]
-    #[unstable(feature = "arc_counts", reason = "not clearly useful, and racy", issue = "27718")]
+    #[unstable(feature = "arc_counts", reason = "not clearly useful, and racy",
+               issue = "28356")]
     pub fn weak_count(this: &Self) -> usize {
         this.inner().weak.load(SeqCst) - 1
     }
 
     /// Get the number of strong references to this value.
     #[inline]
-    #[unstable(feature = "arc_counts", reason = "not clearly useful, and racy", issue = "27718")]
+    #[unstable(feature = "arc_counts", reason = "not clearly useful, and racy",
+               issue = "28356")]
     pub fn strong_count(this: &Self) -> usize {
         this.inner().strong.load(SeqCst)
     }
@@ -366,7 +366,8 @@ impl<T: ?Sized> Deref for Arc<T> {
 }
 
 impl<T: Clone> Arc<T> {
-    #[unstable(feature = "arc_unique", reason = "renamed to Arc::make_mut", issue = "27718")]
+    #[unstable(feature = "arc_make_unique", reason = "renamed to Arc::make_mut",
+               issue = "27718")]
     #[deprecated(since = "1.4.0", reason = "renamed to Arc::make_mut")]
     pub fn make_unique(this: &mut Self) -> &mut T {
         Arc::make_mut(this)
@@ -381,7 +382,6 @@ impl<T: Clone> Arc<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(arc_unique)]
     /// use std::sync::Arc;
     ///
     /// let mut data = Arc::new(5);
@@ -398,7 +398,7 @@ impl<T: Clone> Arc<T> {
     ///
     /// ```
     #[inline]
-    #[unstable(feature = "arc_unique", reason = "needs FCP", issue = "27718")]
+    #[stable(feature = "arc_unique", since = "1.4.0")]
     pub fn make_mut(this: &mut Self) -> &mut T {
         // Note that we hold both a strong reference and a weak reference.
         // Thus, releasing our strong reference only will not, by itself, cause
@@ -460,7 +460,6 @@ impl<T: ?Sized> Arc<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(arc_unique)]
     /// use std::sync::Arc;
     ///
     /// let mut x = Arc::new(3);
@@ -471,7 +470,7 @@ impl<T: ?Sized> Arc<T> {
     /// assert!(Arc::get_mut(&mut x).is_none());
     /// ```
     #[inline]
-    #[unstable(feature = "arc_unique", reason = "needs FCP", issue = "27718")]
+    #[stable(feature = "arc_unique", since = "1.4.0")]
     pub fn get_mut(this: &mut Self) -> Option<&mut T> {
         if this.is_unique() {
             // This unsafety is ok because we're guaranteed that the pointer
@@ -595,7 +594,6 @@ impl<T: ?Sized> Weak<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(arc_weak)]
     /// use std::sync::Arc;
     ///
     /// let five = Arc::new(5);
@@ -604,7 +602,7 @@ impl<T: ?Sized> Weak<T> {
     ///
     /// let strong_five: Option<Arc<_>> = weak_five.upgrade();
     /// ```
-    #[unstable(feature = "arc_weak", reason = "needs FCP", issue = "27718")]
+    #[stable(feature = "arc_weak", since = "1.4.0")]
     pub fn upgrade(&self) -> Option<Arc<T>> {
         // We use a CAS loop to increment the strong count instead of a
         // fetch_add because once the count hits 0 it must never be above 0.
@@ -630,7 +628,7 @@ impl<T: ?Sized> Weak<T> {
     }
 }
 
-#[unstable(feature = "arc_weak", reason = "needs FCP", issue = "27718")]
+#[stable(feature = "arc_weak", since = "1.4.0")]
 impl<T: ?Sized> Clone for Weak<T> {
     /// Makes a clone of the `Weak<T>`.
     ///
@@ -639,7 +637,6 @@ impl<T: ?Sized> Clone for Weak<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(arc_weak)]
     /// use std::sync::Arc;
     ///
     /// let weak_five = Arc::downgrade(&Arc::new(5));
@@ -672,7 +669,6 @@ impl<T: ?Sized> Drop for Weak<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(arc_weak)]
     /// use std::sync::Arc;
     ///
     /// {

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -226,11 +226,8 @@ impl<T : ?Sized> Box<T> {
     /// Function is unsafe, because improper use of this function may
     /// lead to memory problems like double-free, for example if the
     /// function is called twice on the same raw pointer.
-    #[unstable(feature = "box_raw",
-               reason = "may be renamed or moved out of Box scope",
-               issue = "27768")]
+    #[stable(feature = "box_raw", since = "1.4.0")]
     #[inline]
-    // NB: may want to be called from_ptr, see comments on CStr::from_ptr
     pub unsafe fn from_raw(raw: *mut T) -> Self {
         mem::transmute(raw)
     }
@@ -244,17 +241,14 @@ impl<T : ?Sized> Box<T> {
     /// `Box` does not specify, how memory is allocated.
     ///
     /// # Examples
-    /// ```
-    /// #![feature(box_raw)]
     ///
+    /// ```
     /// let seventeen = Box::new(17u32);
     /// let raw = Box::into_raw(seventeen);
     /// let boxed_again = unsafe { Box::from_raw(raw) };
     /// ```
-    #[unstable(feature = "box_raw", reason = "may be renamed",
-               issue = "27768")]
+    #[stable(feature = "box_raw", since = "1.4.0")]
     #[inline]
-    // NB: may want to be called into_ptr, see comments on CStr::from_ptr
     pub fn into_raw(b: Box<T>) -> *mut T {
         unsafe { mem::transmute(b) }
     }
@@ -289,8 +283,6 @@ impl<T: Clone> Clone for Box<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(box_raw)]
-    ///
     /// let x = Box::new(5);
     /// let mut y = Box::new(10);
     ///

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -100,7 +100,7 @@
 #![cfg_attr(stage0, feature(alloc_system))]
 #![cfg_attr(not(stage0), feature(needs_allocator))]
 
-#![cfg_attr(test, feature(test, rustc_private, box_raw))]
+#![cfg_attr(test, feature(test, rustc_private))]
 
 #[cfg(stage0)]
 extern crate alloc_system;

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// FIXME(27718): rc_counts stuff is useful internally, but was previously public
 #![allow(deprecated)]
 
 //! Thread-local reference-counted boxes (the `Rc<T>` type).
@@ -94,8 +93,6 @@
 //! documentation for more details on interior mutability.
 //!
 //! ```rust
-//! #![feature(rc_weak)]
-//!
 //! use std::rc::Rc;
 //! use std::rc::Weak;
 //! use std::cell::RefCell;
@@ -242,7 +239,7 @@ impl<T> Rc<T> {
     /// assert_eq!(Rc::try_unwrap(x), Err(Rc::new(4)));
     /// ```
     #[inline]
-    #[unstable(feature = "rc_unique", reason=  "needs FCP", issue = "27718")]
+    #[stable(feature = "rc_unique", since = "1.4.0")]
     pub fn try_unwrap(this: Self) -> Result<T, Self> {
         if Rc::would_unwrap(&this) {
             unsafe {
@@ -263,8 +260,9 @@ impl<T> Rc<T> {
     }
 
     /// Checks if `Rc::try_unwrap` would return `Ok`.
-    #[unstable(feature = "rc_would_unwrap", reason = "just added for niche usecase",
-               issue = "27718")]
+    #[unstable(feature = "rc_would_unwrap",
+               reason = "just added for niche usecase",
+               issue = "28356")]
     pub fn would_unwrap(this: &Self) -> bool {
         Rc::strong_count(&this) == 1
     }
@@ -276,15 +274,13 @@ impl<T: ?Sized> Rc<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(rc_weak)]
-    ///
     /// use std::rc::Rc;
     ///
     /// let five = Rc::new(5);
     ///
     /// let weak_five = Rc::downgrade(&five);
     /// ```
-    #[unstable(feature = "rc_weak", reason = "needs FCP", issue = "27718")]
+    #[stable(feature = "rc_weak", since = "1.4.0")]
     pub fn downgrade(this: &Self) -> Weak<T> {
         this.inc_weak();
         Weak { _ptr: this._ptr }
@@ -292,12 +288,14 @@ impl<T: ?Sized> Rc<T> {
 
     /// Get the number of weak references to this value.
     #[inline]
-    #[unstable(feature = "rc_counts", reason = "not clearly useful", issue = "27718")]
+    #[unstable(feature = "rc_counts", reason = "not clearly useful",
+               issue = "28356")]
     pub fn weak_count(this: &Self) -> usize { this.weak() - 1 }
 
     /// Get the number of strong references to this value.
     #[inline]
-    #[unstable(feature = "rc_counts", reason = "not clearly useful", issue = "27718")]
+    #[unstable(feature = "rc_counts", reason = "not clearly useful",
+               issue = "28356")]
     pub fn strong_count(this: &Self) -> usize { this.strong() }
 
     /// Returns true if there are no other `Rc` or `Weak<T>` values that share
@@ -315,7 +313,8 @@ impl<T: ?Sized> Rc<T> {
     /// assert!(Rc::is_unique(&five));
     /// ```
     #[inline]
-    #[unstable(feature = "rc_counts", reason = "uniqueness has unclear meaning", issue = "27718")]
+    #[unstable(feature = "rc_counts", reason = "uniqueness has unclear meaning",
+               issue = "28356")]
     pub fn is_unique(this: &Self) -> bool {
         Rc::weak_count(this) == 0 && Rc::strong_count(this) == 1
     }
@@ -328,8 +327,6 @@ impl<T: ?Sized> Rc<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(rc_unique)]
-    ///
     /// use std::rc::Rc;
     ///
     /// let mut x = Rc::new(3);
@@ -340,7 +337,7 @@ impl<T: ?Sized> Rc<T> {
     /// assert!(Rc::get_mut(&mut x).is_none());
     /// ```
     #[inline]
-    #[unstable(feature = "rc_unique", reason = "needs FCP", issue = "27718")]
+    #[stable(feature = "rc_unique", since = "1.4.0")]
     pub fn get_mut(this: &mut Self) -> Option<&mut T> {
         if Rc::is_unique(this) {
             let inner = unsafe { &mut **this._ptr };
@@ -353,7 +350,8 @@ impl<T: ?Sized> Rc<T> {
 
 impl<T: Clone> Rc<T> {
     #[inline]
-    #[unstable(feature = "rc_unique", reason = "renamed to Rc::make_mut", issue = "27718")]
+    #[unstable(feature = "rc_make_unique", reason = "renamed to Rc::make_mut",
+               issue = "27718")]
     #[deprecated(since = "1.4.0", reason = "renamed to Rc::make_mut")]
     pub fn make_unique(&mut self) -> &mut T {
         Rc::make_mut(self)
@@ -385,7 +383,7 @@ impl<T: Clone> Rc<T> {
     ///
     /// ```
     #[inline]
-    #[unstable(feature = "rc_unique", reason = "needs FCP", issue = "27718")]
+    #[stable(feature = "rc_unique", since = "1.4.0")]
     pub fn make_mut(this: &mut Self) -> &mut T {
         if Rc::strong_count(this) != 1 {
             // Gotta clone the data, there are other Rcs
@@ -693,7 +691,7 @@ impl<T> fmt::Pointer for Rc<T> {
 ///
 /// See the [module level documentation](./index.html) for more.
 #[unsafe_no_drop_flag]
-#[unstable(feature = "rc_weak", reason = "needs FCP", issue = "27718")]
+#[stable(feature = "rc_weak", since = "1.4.0")]
 pub struct Weak<T: ?Sized> {
     // FIXME #12808: strange names to try to avoid interfering with
     // field accesses of the contained type via Deref
@@ -716,8 +714,6 @@ impl<T: ?Sized> Weak<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(rc_weak)]
-    ///
     /// use std::rc::Rc;
     ///
     /// let five = Rc::new(5);
@@ -726,7 +722,7 @@ impl<T: ?Sized> Weak<T> {
     ///
     /// let strong_five: Option<Rc<_>> = weak_five.upgrade();
     /// ```
-    #[unstable(feature = "rc_weak", reason = "needs FCP", issue = "27718")]
+    #[stable(feature = "rc_weak", since = "1.4.0")]
     pub fn upgrade(&self) -> Option<Rc<T>> {
         if self.strong() == 0 {
             None
@@ -746,8 +742,6 @@ impl<T: ?Sized> Drop for Weak<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(rc_weak)]
-    ///
     /// use std::rc::Rc;
     ///
     /// {
@@ -783,7 +777,7 @@ impl<T: ?Sized> Drop for Weak<T> {
     }
 }
 
-#[unstable(feature = "rc_weak", reason = "needs FCP", issue = "27718")]
+#[stable(feature = "rc_weak", since = "1.4.0")]
 impl<T: ?Sized> Clone for Weak<T> {
 
     /// Makes a clone of the `Weak<T>`.
@@ -793,8 +787,6 @@ impl<T: ?Sized> Clone for Weak<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(rc_weak)]
-    ///
     /// use std::rc::Rc;
     ///
     /// let weak_five = Rc::downgrade(&Rc::new(5));

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -149,6 +149,7 @@ pub struct OccupiedEntry<'a, K:'a, V:'a> {
 impl<K: Ord, V> BTreeMap<K, V> {
     /// Makes a new empty BTreeMap with a reasonable choice for B.
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[allow(deprecated)]
     pub fn new() -> BTreeMap<K, V> {
         //FIXME(Gankro): Tune this as a function of size_of<K/V>?
         BTreeMap::with_b(6)
@@ -160,6 +161,7 @@ impl<K: Ord, V> BTreeMap<K, V> {
     #[unstable(feature = "btree_b",
                reason = "probably want this to be on the type, eventually",
                issue = "27795")]
+    #[deprecated(since = "1.4.0", reason = "niche API")]
     pub fn with_b(b: usize) -> BTreeMap<K, V> {
         assert!(b > 1, "B must be greater than 1");
         BTreeMap {
@@ -183,6 +185,7 @@ impl<K: Ord, V> BTreeMap<K, V> {
     /// assert!(a.is_empty());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[allow(deprecated)]
     pub fn clear(&mut self) {
         let b = self.b;
         // avoid recursive destructors by manually traversing the tree

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -104,6 +104,8 @@ impl<T: Ord> BTreeSet<T> {
     #[unstable(feature = "btree_b",
                reason = "probably want this to be on the type, eventually",
                issue = "27795")]
+    #[deprecated(since = "1.4.0", reason = "niche API")]
+    #[allow(deprecated)]
     pub fn with_b(b: usize) -> BTreeSet<T> {
         BTreeSet { map: BTreeMap::with_b(b) }
     }

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -515,16 +515,14 @@ impl str {
     /// assert_eq!(b, " 老虎 Léopard");
     /// ```
     #[inline]
-    #[unstable(feature = "str_split_at", reason = "recently added",
-               issue = "27792")]
+    #[stable(feature = "str_split_at", since = "1.4.0")]
     pub fn split_at(&self, mid: usize) -> (&str, &str) {
         core_str::StrExt::split_at(self, mid)
     }
 
     /// Divide one mutable string slice into two at an index.
     #[inline]
-    #[unstable(feature = "str_split_at", reason = "recently added",
-               issue = "27792")]
+    #[stable(feature = "str_split_at", since = "1.4.0")]
     pub fn split_at_mut(&mut self, mid: usize) -> (&mut str, &mut str) {
         core_str::StrExt::split_at_mut(self, mid)
     }
@@ -1505,9 +1503,7 @@ impl str {
     }
 
     /// Converts the `Box<str>` into a `String` without copying or allocating.
-    #[unstable(feature = "box_str",
-               reason = "recently added, matches RFC",
-               issue = "27785")]
+    #[stable(feature = "box_str", since = "1.4.0")]
     pub fn into_string(self: Box<str>) -> String {
         unsafe {
             let slice = mem::transmute::<Box<str>, Box<[u8]>>(self);

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -722,9 +722,7 @@ impl String {
     /// Converts the string into `Box<str>`.
     ///
     /// Note that this will drop any excess capacity.
-    #[unstable(feature = "box_str",
-               reason = "recently added, matches RFC",
-               issue = "27785")]
+    #[stable(feature = "box_str", since = "1.4.0")]
     pub fn into_boxed_str(self) -> Box<str> {
         let slice = self.vec.into_boxed_slice();
         unsafe { mem::transmute::<Box<[u8]>, Box<str>>(slice) }
@@ -733,7 +731,7 @@ impl String {
     /// Converts the string into `Box<str>`.
     ///
     /// Note that this will drop any excess capacity.
-    #[unstable(feature = "box_str",
+    #[unstable(feature = "box_str2",
                reason = "recently added, matches RFC",
                issue = "27785")]
     #[deprecated(since = "1.4.0", reason = "renamed to `into_boxed_str`")]

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -614,8 +614,6 @@ impl<T> Vec<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(append)]
-    ///
     /// let mut vec = vec![1, 2, 3];
     /// let mut vec2 = vec![4, 5, 6];
     /// vec.append(&mut vec2);
@@ -623,9 +621,7 @@ impl<T> Vec<T> {
     /// assert_eq!(vec2, []);
     /// ```
     #[inline]
-    #[unstable(feature = "append",
-               reason = "new API, waiting for dust to settle",
-               issue = "27765")]
+    #[stable(feature = "append", since = "1.4.0")]
     pub fn append(&mut self, other: &mut Self) {
         self.reserve(other.len());
         let len = self.len();
@@ -765,9 +761,7 @@ impl<T> Vec<T> {
     /// assert_eq!(vec2, [2, 3]);
     /// ```
     #[inline]
-    #[unstable(feature = "split_off",
-               reason = "new API, waiting for dust to settle",
-               issue = "27766")]
+    #[stable(feature = "split_off", since = "1.4.0")]
     pub fn split_off(&mut self, at: usize) -> Self {
         assert!(at <= self.len(), "`at` out of bounds");
 

--- a/src/libcollections/vec_deque.rs
+++ b/src/libcollections/vec_deque.rs
@@ -1322,9 +1322,7 @@ impl<T> VecDeque<T> {
     /// assert_eq!(buf2.len(), 2);
     /// ```
     #[inline]
-    #[unstable(feature = "split_off",
-               reason = "new API, waiting for dust to settle",
-               issue = "27766")]
+    #[stable(feature = "split_off", since = "1.4.0")]
     pub fn split_off(&mut self, at: usize) -> Self {
         let len = self.len();
         assert!(at <= len, "`at` out of bounds");
@@ -1376,8 +1374,6 @@ impl<T> VecDeque<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(append)]
-    ///
     /// use std::collections::VecDeque;
     ///
     /// let mut buf: VecDeque<_> = vec![1, 2, 3].into_iter().collect();
@@ -1387,9 +1383,7 @@ impl<T> VecDeque<T> {
     /// assert_eq!(buf2.len(), 0);
     /// ```
     #[inline]
-    #[unstable(feature = "append",
-               reason = "new API, waiting for dust to settle",
-               issue = "27765")]
+    #[stable(feature = "append", since = "1.4.0")]
     pub fn append(&mut self, other: &mut Self) {
         // naive impl
         self.extend(other.drain());
@@ -1415,9 +1409,7 @@ impl<T> VecDeque<T> {
     /// let v: Vec<_> = buf.into_iter().collect();
     /// assert_eq!(&v[..], &[2, 4]);
     /// ```
-    #[unstable(feature = "vec_deque_retain",
-               reason = "new API, waiting for dust to settle",
-               issue = "27767")]
+    #[stable(feature = "vec_deque_retain", since = "1.4.0")]
     pub fn retain<F>(&mut self, mut f: F) where F: FnMut(&T) -> bool {
         let len = self.len();
         let mut del = 0;

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -289,6 +289,7 @@ impl<T> Option<T> {
     #[unstable(feature = "as_slice",
                reason = "waiting for mut conventions",
                issue = "27776")]
+    #[deprecated(since = "1.4.0", reason = "niche API, unclear of usefulness")]
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         match *self {
             Some(ref mut x) => {
@@ -690,8 +691,9 @@ impl<T> Option<T> {
 
     /// Converts from `Option<T>` to `&[T]` (without copying)
     #[inline]
-    #[unstable(feature = "as_slice", since = "unsure of the utility here",
+    #[unstable(feature = "as_slice", reason = "unsure of the utility here",
                issue = "27776")]
+    #[deprecated(since = "1.4.0", reason = "niche API, unclear of usefulness")]
     pub fn as_slice(&self) -> &[T] {
         match *self {
             Some(ref x) => slice::ref_slice(x),

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -405,8 +405,9 @@ impl<T, E> Result<T, E> {
 
     /// Converts from `Result<T, E>` to `&[T]` (without copying)
     #[inline]
-    #[unstable(feature = "as_slice", since = "unsure of the utility here",
+    #[unstable(feature = "as_slice", reason = "unsure of the utility here",
                issue = "27776")]
+    #[deprecated(since = "1.4.0", reason = "niche API, unclear of usefulness")]
     pub fn as_slice(&self) -> &[T] {
         match *self {
             Ok(ref x) => slice::ref_slice(x),
@@ -439,6 +440,7 @@ impl<T, E> Result<T, E> {
     #[unstable(feature = "as_slice",
                reason = "waiting for mut conventions",
                issue = "27776")]
+    #[deprecated(since = "1.4.0", reason = "niche API, unclear of usefulness")]
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         match *self {
             Ok(ref mut x) => slice::mut_ref_slice(x),
@@ -742,12 +744,11 @@ impl<T, E: fmt::Debug> Result<T, E> {
     ///
     /// # Examples
     /// ```{.should_panic}
-    /// #![feature(result_expect)]
     /// let x: Result<u32, &str> = Err("emergency failure");
     /// x.expect("Testing expect"); // panics with `Testing expect: emergency failure`
     /// ```
     #[inline]
-    #[unstable(feature = "result_expect", reason = "newly introduced", issue = "27277")]
+    #[stable(feature = "result_expect", since = "1.4.0")]
     pub fn expect(self, msg: &str) -> T {
         match self {
             Ok(t) => t,

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -800,7 +800,7 @@ impl<'a, T> Iter<'a, T> {
     ///
     /// This has the same lifetime as the original slice, and so the
     /// iterator can continue to be used while this exists.
-    #[unstable(feature = "iter_to_slice", issue = "27775")]
+    #[stable(feature = "iter_to_slice", since = "1.4.0")]
     pub fn as_slice(&self) -> &'a [T] {
         make_slice!(self.ptr, self.end)
     }
@@ -848,7 +848,7 @@ impl<'a, T> IterMut<'a, T> {
     /// to consume the iterator. Consider using the `Slice` and
     /// `SliceMut` implementations for obtaining slices with more
     /// restricted lifetimes that do not consume the iterator.
-    #[unstable(feature = "iter_to_slice", issue = "27775")]
+    #[stable(feature = "iter_to_slice", since = "1.4.0")]
     pub fn into_slice(self) -> &'a mut [T] {
         make_mut_slice!(self.ptr, self.end)
     }

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -297,7 +297,7 @@ impl<'a> Chars<'a> {
     ///
     /// This has the same lifetime as the original slice, and so the
     /// iterator can continue to be used while this exists.
-    #[unstable(feature = "iter_to_slice", issue = "27775")]
+    #[stable(feature = "iter_to_slice", since = "1.4.0")]
     #[inline]
     pub fn as_str(&self) -> &'a str {
         unsafe { from_utf8_unchecked(self.iter.as_slice()) }
@@ -356,7 +356,7 @@ impl<'a> CharIndices<'a> {
     ///
     /// This has the same lifetime as the original slice, and so the
     /// iterator can continue to be used while this exists.
-    #[unstable(feature = "iter_to_slice", issue = "27775")]
+    #[stable(feature = "iter_to_slice", since = "1.4.0")]
     #[inline]
     pub fn as_str(&self) -> &'a str {
         self.iter.as_str()

--- a/src/libcoretest/lib.rs
+++ b/src/libcoretest/lib.rs
@@ -33,7 +33,6 @@
 #![feature(rand)]
 #![feature(range_inclusive)]
 #![feature(raw)]
-#![feature(result_expect)]
 #![feature(slice_bytes)]
 #![feature(slice_patterns)]
 #![feature(step_by)]

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -170,7 +170,6 @@
        html_playground_url = "https://play.rust-lang.org/")]
 #![deny(missing_docs)]
 
-#![feature(box_raw)]
 #![feature(box_syntax)]
 #![feature(const_fn)]
 #![feature(iter_cmp)]

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -25,7 +25,6 @@
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
       html_root_url = "https://doc.rust-lang.org/nightly/")]
 
-#![feature(append)]
 #![feature(associated_consts)]
 #![feature(box_patterns)]
 #![feature(box_syntax)]

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -25,7 +25,6 @@
 #![feature(rustc_private)]
 #![feature(slice_splits)]
 #![feature(staged_api)]
-#![feature(rc_weak)]
 
 #[macro_use] extern crate log;
 #[macro_use] extern crate syntax;

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -42,7 +42,6 @@
 #![feature(unicode)]
 #![feature(unicode)]
 #![feature(vec_push_all)]
-#![feature(rc_weak)]
 
 #![allow(trivial_casts)]
 

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -75,7 +75,6 @@ This API is completely unstable and subject to change.
 
 #![allow(non_camel_case_types)]
 
-#![feature(append)]
 #![feature(box_patterns)]
 #![feature(box_syntax)]
 #![feature(drain)]

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -119,7 +119,7 @@ pub struct CString {
 /// Converting a foreign C string into a Rust `String`
 ///
 /// ```no_run
-/// # #![feature(libc,cstr_to_str)]
+/// # #![feature(libc)]
 /// extern crate libc;
 /// use std::ffi::CStr;
 ///
@@ -205,7 +205,7 @@ impl CString {
     /// The only appropriate argument is a pointer obtained by calling
     /// `into_ptr`. The length of the string will be recalculated
     /// using the pointer.
-    #[unstable(feature = "cstr_memory", reason = "recently added",
+    #[unstable(feature = "cstr_memory2", reason = "recently added",
                issue = "27769")]
     #[deprecated(since = "1.4.0", reason = "renamed to from_raw")]
     pub unsafe fn from_ptr(ptr: *const libc::c_char) -> CString {
@@ -217,8 +217,7 @@ impl CString {
     /// The only appropriate argument is a pointer obtained by calling
     /// `into_raw`. The length of the string will be recalculated
     /// using the pointer.
-    #[unstable(feature = "cstr_memory", reason = "recently added",
-               issue = "27769")]
+    #[stable(feature = "cstr_memory", since = "1.4.0")]
     pub unsafe fn from_raw(ptr: *mut libc::c_char) -> CString {
         let len = libc::strlen(ptr) + 1; // Including the NUL byte
         let slice = slice::from_raw_parts(ptr, len as usize);
@@ -233,7 +232,7 @@ impl CString {
     /// this string.
     ///
     /// Failure to call `from_raw` will lead to a memory leak.
-    #[unstable(feature = "cstr_memory", reason = "recently added",
+    #[unstable(feature = "cstr_memory2", reason = "recently added",
                issue = "27769")]
     #[deprecated(since = "1.4.0", reason = "renamed to into_raw")]
     pub fn into_ptr(self) -> *const libc::c_char {
@@ -248,8 +247,7 @@ impl CString {
     /// this string.
     ///
     /// Failure to call `from_ptr` will lead to a memory leak.
-    #[unstable(feature = "cstr_memory", reason = "recently added",
-               issue = "27769")]
+    #[stable(feature = "cstr_memory", since = "1.4.0")]
     pub fn into_raw(self) -> *mut libc::c_char {
         Box::into_raw(self.inner) as *mut libc::c_char
     }
@@ -429,8 +427,7 @@ impl CStr {
     /// > after a 0-cost cast, but it is planned to alter its definition in the
     /// > future to perform the length calculation in addition to the UTF-8
     /// > check whenever this method is called.
-    #[unstable(feature = "cstr_to_str", reason = "recently added",
-               issue = "27764")]
+    #[stable(feature = "cstr_to_str", since = "1.4.0")]
     pub fn to_str(&self) -> Result<&str, str::Utf8Error> {
         // NB: When CStr is changed to perform the length check in .to_bytes()
         // instead of in from_ptr(), it may be worth considering if this should
@@ -450,8 +447,7 @@ impl CStr {
     /// > after a 0-cost cast, but it is planned to alter its definition in the
     /// > future to perform the length calculation in addition to the UTF-8
     /// > check whenever this method is called.
-    #[unstable(feature = "cstr_to_str", reason = "recently added",
-               issue = "27764")]
+    #[stable(feature = "cstr_to_str", since = "1.4.0")]
     pub fn to_string_lossy(&self) -> Cow<str> {
         String::from_utf8_lossy(self.to_bytes())
     }

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -203,7 +203,6 @@
 #![feature(allow_internal_unstable)]
 #![feature(associated_consts)]
 #![feature(borrow_state)]
-#![feature(box_raw)]
 #![feature(box_syntax)]
 #![feature(char_from_unchecked)]
 #![feature(char_internals)]

--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -130,8 +130,13 @@ impl TcpStream {
     /// If the value specified is `None`, then `read` calls will block
     /// indefinitely. It is an error to pass the zero `Duration` to this
     /// method.
-    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added",
-               issue = "27773")]
+    ///
+    /// # Note
+    ///
+    /// Platforms may return a different error code whenever a read times out as
+    /// a result of setting this option. For example Unix typically returns an
+    /// error of the kind `WouldBlock`, but Windows may return `TimedOut`.
+    #[stable(feature = "socket_timeout", since = "1.4.0")]
     pub fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
         self.0.set_read_timeout(dur)
     }
@@ -141,8 +146,13 @@ impl TcpStream {
     /// If the value specified is `None`, then `write` calls will block
     /// indefinitely. It is an error to pass the zero `Duration` to this
     /// method.
-    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added",
-               issue = "27773")]
+    ///
+    /// # Note
+    ///
+    /// Platforms may return a different error code whenever a write times out
+    /// as a result of setting this option. For example Unix typically returns
+    /// an error of the kind `WouldBlock`, but Windows may return `TimedOut`.
+    #[stable(feature = "socket_timeout", since = "1.4.0")]
     pub fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
         self.0.set_write_timeout(dur)
     }
@@ -154,8 +164,7 @@ impl TcpStream {
     /// # Note
     ///
     /// Some platforms do not provide access to the current timeout.
-    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added",
-               issue = "27773")]
+    #[stable(feature = "socket_timeout", since = "1.4.0")]
     pub fn read_timeout(&self) -> io::Result<Option<Duration>> {
         self.0.read_timeout()
     }
@@ -167,8 +176,7 @@ impl TcpStream {
     /// # Note
     ///
     /// Some platforms do not provide access to the current timeout.
-    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added",
-               issue = "27773")]
+    #[stable(feature = "socket_timeout", since = "1.4.0")]
     pub fn write_timeout(&self) -> io::Result<Option<Duration>> {
         self.0.write_timeout()
     }

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -97,8 +97,13 @@ impl UdpSocket {
     /// If the value specified is `None`, then `read` calls will block
     /// indefinitely. It is an error to pass the zero `Duration` to this
     /// method.
-    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added",
-               issue = "27773")]
+    ///
+    /// # Note
+    ///
+    /// Platforms may return a different error code whenever a read times out as
+    /// a result of setting this option. For example Unix typically returns an
+    /// error of the kind `WouldBlock`, but Windows may return `TimedOut`.
+    #[stable(feature = "socket_timeout", since = "1.4.0")]
     pub fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
         self.0.set_read_timeout(dur)
     }
@@ -108,8 +113,13 @@ impl UdpSocket {
     /// If the value specified is `None`, then `write` calls will block
     /// indefinitely. It is an error to pass the zero `Duration` to this
     /// method.
-    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added",
-               issue = "27773")]
+    ///
+    /// # Note
+    ///
+    /// Platforms may return a different error code whenever a write times out
+    /// as a result of setting this option. For example Unix typically returns
+    /// an error of the kind `WouldBlock`, but Windows may return `TimedOut`.
+    #[stable(feature = "socket_timeout", since = "1.4.0")]
     pub fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
         self.0.set_write_timeout(dur)
     }
@@ -117,8 +127,7 @@ impl UdpSocket {
     /// Returns the read timeout of this socket.
     ///
     /// If the timeout is `None`, then `read` calls will block indefinitely.
-    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added",
-               issue = "27773")]
+    #[stable(feature = "socket_timeout", since = "1.4.0")]
     pub fn read_timeout(&self) -> io::Result<Option<Duration>> {
         self.0.read_timeout()
     }
@@ -126,8 +135,7 @@ impl UdpSocket {
     /// Returns the write timeout of this socket.
     ///
     /// If the timeout is `None`, then `write` calls will block indefinitely.
-    #[unstable(feature = "socket_timeout", reason = "RFC 1047 - recently added",
-               issue = "27773")]
+    #[stable(feature = "socket_timeout", since = "1.4.0")]
     pub fn write_timeout(&self) -> io::Result<Option<Duration>> {
         self.0.write_timeout()
     }

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -125,6 +125,8 @@ impl f32 {
     /// Parses a float as with a given radix
     #[unstable(feature = "float_from_str_radix", reason = "recently moved API",
                issue = "27736")]
+    #[deprecated(since = "1.4.0",
+                 reason = "unclear how useful or correct this is")]
     pub fn from_str_radix(s: &str, radix: u32) -> Result<f32, ParseFloatError> {
         num::Float::from_str_radix(s, radix)
     }

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -82,6 +82,8 @@ impl f64 {
     /// Parses a float as with a given radix
     #[unstable(feature = "float_from_str_radix", reason = "recently moved API",
                issue = "27736")]
+    #[deprecated(since = "1.4.0",
+                 reason = "unclear how useful or correct this is")]
     pub fn from_str_radix(s: &str, radix: u32) -> Result<f64, ParseFloatError> {
         num::Float::from_str_radix(s, radix)
     }

--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -111,8 +111,6 @@ mod prim_unit { }
 /// the raw pointer. It doesn't destroy `T` or deallocate any memory.
 ///
 /// ```
-/// #![feature(box_raw)]
-///
 /// let my_speed: Box<i32> = Box::new(88);
 /// let my_speed: *mut i32 = Box::into_raw(my_speed);
 ///

--- a/src/libstd/sys/unix/ext/io.rs
+++ b/src/libstd/sys/unix/ext/io.rs
@@ -61,14 +61,14 @@ pub trait FromRawFd {
 
 /// A trait to express the ability to consume an object and acquire ownership of
 /// its raw file descriptor.
-#[unstable(feature = "into_raw_os", reason = "recently added API",
-           issue = "27797")]
+#[stable(feature = "into_raw_os", since = "1.4.0")]
 pub trait IntoRawFd {
     /// Consumes this object, returning the raw underlying file descriptor.
     ///
     /// This function **transfers ownership** of the underlying file descriptor
     /// to the caller. Callers are then the unique owners of the file descriptor
     /// and must close the descriptor once it's no longer needed.
+    #[stable(feature = "into_raw_os", since = "1.4.0")]
     fn into_raw_fd(self) -> RawFd;
 }
 
@@ -84,6 +84,7 @@ impl FromRawFd for fs::File {
         fs::File::from_inner(sys::fs::File::from_inner(fd))
     }
 }
+#[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawFd for fs::File {
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_fd().into_raw()
@@ -125,16 +126,19 @@ impl FromRawFd for net::UdpSocket {
     }
 }
 
+#[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawFd for net::TcpStream {
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_socket().into_inner()
     }
 }
+#[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawFd for net::TcpListener {
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_socket().into_inner()
     }
 }
+#[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawFd for net::UdpSocket {
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_socket().into_inner()

--- a/src/libstd/sys/windows/ext/io.rs
+++ b/src/libstd/sys/windows/ext/io.rs
@@ -52,14 +52,14 @@ pub trait FromRawHandle {
 
 /// A trait to express the ability to consume an object and acquire ownership of
 /// its raw `HANDLE`.
-#[unstable(feature = "into_raw_os", reason = "recently added API",
-           issue = "27797")]
+#[stable(feature = "into_raw_os", since = "1.4.0")]
 pub trait IntoRawHandle {
     /// Consumes this object, returning the raw underlying handle.
     ///
     /// This function **transfers ownership** of the underlying handle to the
     /// caller. Callers are then the unique owners of the handle and must close
     /// it once it's no longer needed.
+    #[stable(feature = "into_raw_os", since = "1.4.0")]
     fn into_raw_handle(self) -> RawHandle;
 }
 
@@ -78,6 +78,7 @@ impl FromRawHandle for fs::File {
     }
 }
 
+#[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawHandle for fs::File {
     fn into_raw_handle(self) -> RawHandle {
         self.into_inner().into_handle().into_raw() as *mut _
@@ -111,14 +112,14 @@ pub trait FromRawSocket {
 
 /// A trait to express the ability to consume an object and acquire ownership of
 /// its raw `SOCKET`.
-#[unstable(feature = "into_raw_os", reason = "recently added API",
-           issue = "27797")]
+#[stable(feature = "into_raw_os", since = "1.4.0")]
 pub trait IntoRawSocket {
     /// Consumes this object, returning the raw underlying socket.
     ///
     /// This function **transfers ownership** of the underlying socket to the
     /// caller. Callers are then the unique owners of the socket and must close
     /// it once it's no longer needed.
+    #[stable(feature = "into_raw_os", since = "1.4.0")]
     fn into_raw_socket(self) -> RawSocket;
 }
 
@@ -163,18 +164,21 @@ impl FromRawSocket for net::UdpSocket {
     }
 }
 
+#[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawSocket for net::TcpStream {
     fn into_raw_socket(self) -> RawSocket {
         self.into_inner().into_socket().into_inner()
     }
 }
 
+#[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawSocket for net::TcpListener {
     fn into_raw_socket(self) -> RawSocket {
         self.into_inner().into_socket().into_inner()
     }
 }
 
+#[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawSocket for net::UdpSocket {
     fn into_raw_socket(self) -> RawSocket {
         self.into_inner().into_socket().into_inner()

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -410,8 +410,7 @@ pub fn sleep_ms(ms: u32) {
 /// signal being received or a spurious wakeup. Platforms which do not support
 /// nanosecond precision for sleeping will have `dur` rounded up to the nearest
 /// granularity of time they can sleep for.
-#[unstable(feature = "thread_sleep", reason = "waiting on Duration",
-           issue = "27771")]
+#[stable(feature = "thread_sleep", since = "1.4.0")]
 pub fn sleep(dur: Duration) {
     imp::Thread::sleep(dur)
 }
@@ -481,8 +480,7 @@ pub fn park_timeout_ms(ms: u32) {
 ///
 /// Platforms which do not support nanosecond precision for sleeping will have
 /// `dur` rounded up to the nearest granularity of time they can sleep for.
-#[unstable(feature = "park_timeout", reason = "waiting on Duration",
-           issue = "27771")]
+#[stable(feature = "park_timeout", since = "1.4.0")]
 pub fn park_timeout(dur: Duration) {
     let thread = current();
     let mut guard = thread.inner.lock.lock().unwrap();

--- a/src/test/run-pass/std-sync-right-kind-impls.rs
+++ b/src/test/run-pass/std-sync-right-kind-impls.rs
@@ -11,7 +11,7 @@
 // pretty-expanded FIXME #23616
 
 #![feature(static_mutex, static_rwlock, static_condvar)]
-#![feature(arc_weak, semaphore)]
+#![feature(semaphore)]
 
 use std::sync;
 


### PR DESCRIPTION
The FCP is coming to a close and 1.4 is coming out soon, so this brings in the
libs team decision for all library features this cycle.

Stabilized APIs:
- `<Box<str>>::into_string`
- `Arc::downgrade`
- `Arc::get_mut`
- `Arc::make_mut`
- `Arc::try_unwrap`
- `Box::from_raw`
- `Box::into_raw`
- `CStr::to_str`
- `CStr::to_string_lossy`
- `CString::from_raw`
- `CString::into_raw`
- `IntoRawFd::into_raw_fd`
- `IntoRawFd`
- `IntoRawHandle::into_raw_handle`
- `IntoRawHandle`
- `IntoRawSocket::into_raw_socket`
- `IntoRawSocket`
- `Rc::downgrade`
- `Rc::get_mut`
- `Rc::make_mut`
- `Rc::try_unwrap`
- `Result::expect`
- `String::into_boxed_slice`
- `TcpSocket::read_timeout`
- `TcpSocket::set_read_timeout`
- `TcpSocket::set_write_timeout`
- `TcpSocket::write_timeout`
- `UdpSocket::read_timeout`
- `UdpSocket::set_read_timeout`
- `UdpSocket::set_write_timeout`
- `UdpSocket::write_timeout`
- `Vec::append`
- `Vec::split_off`
- `VecDeque::append`
- `VecDeque::retain`
- `VecDeque::split_off`
- `rc::Weak::upgrade`
- `rc::Weak`
- `slice::Iter::as_slice`
- `slice::IterMut::into_slice`
- `str::CharIndices::as_str`
- `str::Chars::as_str`
- `str::split_at_mut`
- `str::split_at`
- `sync::Weak::upgrade`
- `sync::Weak`
- `thread::park_timeout`
- `thread::sleep`

Deprecated APIs
- `BTreeMap::with_b`
- `BTreeSet::with_b`
- `Option::as_mut_slice`
- `Option::as_slice`
- `Result::as_mut_slice`
- `Result::as_slice`
- `f32::from_str_radix`
- `f64::from_str_radix`

Closes #27277
Closes #27718
Closes #27736
Closes #27764
Closes #27765
Closes #27766
Closes #27767
Closes #27768
Closes #27769
Closes #27771
Closes #27773
Closes #27775
Closes #27776
Closes #27785
Closes #27792
Closes #27795
Closes #27797
