### PR TITLE
configure cleanup on windows

### DIFF
--- a/configure
+++ b/configure
@@ -1169,12 +1169,21 @@ do
             #
             # Consequently here we try to detect when that happens and print an
             # error if it does.
-            if $CFG_PYTHON -c 'import sys; print sys.argv[1]' `pwd` | grep '^/'
+            if $CFG_PYTHON -c 'import sys; print sys.argv[1]' `pwd` | grep '^/' > /dev/null
             then
-                err "python is silently translating windows paths to MSYS paths \
-                     and the build will fail if this python is used.\n\n \
-                     Either an official python install must be used or an \
-                     alternative python package in MinGW must be used."
+                err "
+
+python is silently translating windows paths to MSYS paths \
+and the build will fail if this python is used.
+
+Either an official python install must be used or an \
+alternative python package in MinGW must be used.
+
+If you are building under msys2 try installing the mingw-w64-x86_64-python2 \
+package instead of python2:
+
+$ pacman -R python2 && pacman -S mingw-w64-x86_64-python2
+"
             fi
 
             # MSVC requires cmake because that's how we're going to build LLVM
@@ -1185,10 +1194,19 @@ do
             # detect that here and error.
             if ! "$CFG_CMAKE" --help | sed -n '/^Generators/,$p' | grep 'Visual Studio' > /dev/null
             then
-                err "cmake does not support Visual Studio generators.\n\n \
-                     This is likely due to it being an msys/cygwin build of cmake, \
-                     rather than the required windows version, built using MinGW \
-                     or Visual Studio."
+                err "
+
+cmake does not support Visual Studio generators.
+
+This is likely due to it being an msys/cygwin build of cmake, \
+rather than the required windows version, built using MinGW \
+or Visual Studio.
+
+If you are building under msys2 try installing the mingw-w64-x86_64-cmake \
+package instead of cmake:
+
+$ pacman -R cmake && pacman -S mingw-w64-x86_64-cmake
+"
             fi
 
             # Use the REG program to figure out where VS is installed


### PR DESCRIPTION
Redirect stdout on the python bogosity detector. This is printing
pwd to the terminal currently.

Reformat the bogus python/cmake messages so they format correctly.
echo does not always escape newlines (it doesn't here), and multiline
strings don't whitespace munch.

r? @alexcrichton 
