### PR TITLE
Two optimizations to metadata hashing

### DIFF
--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -73,7 +73,7 @@ fn lookup_hash<'a, F>(d: rbml::Doc<'a>, mut eq_fn: F, hash: u64) -> Option<rbml:
 {
     let index = reader::get_doc(d, tag_index);
     let table = reader::get_doc(index, tag_index_table);
-    let hash_pos = table.start + (hash % 256 * 4) as usize;
+    let hash_pos = table.start + (hash % 4096 * 4) as usize;
     let pos = u32_from_be_bytes(&d.data[hash_pos..]) as usize;
     let tagged_doc = reader::doc_at(d.data, pos).unwrap();
 

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -31,11 +31,11 @@ use middle::lang_items;
 use middle::subst;
 use middle::ty::{ImplContainer, TraitContainer};
 use middle::ty::{self, RegionEscape, Ty};
-use util::nodemap::FnvHashMap;
+use util::nodemap::{FnvHashMap, FnvHasher};
 
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
-use std::hash::{Hash, SipHasher, Hasher};
+use std::hash::{Hash, Hasher};
 use std::io::prelude::*;
 use std::io;
 use std::rc::Rc;
@@ -90,7 +90,7 @@ pub fn maybe_find_item<'a>(item_id: ast::NodeId,
     fn eq_item(bytes: &[u8], item_id: ast::NodeId) -> bool {
         u32_from_be_bytes(bytes) == item_id
     }
-    let mut s = SipHasher::new_with_keys(0, 0);
+    let mut s = FnvHasher::default();
     (item_id as i64).hash(&mut s);
     lookup_hash(items, |a| eq_item(a, item_id), s.finish())
 }

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1624,12 +1624,12 @@ fn encode_index<T, F>(rbml_w: &mut Encoder, index: Vec<entry<T>>, mut write_fn: 
     F: FnMut(&mut Cursor<Vec<u8>>, &T),
     T: Hash,
 {
-    let mut buckets: Vec<Vec<entry<T>>> = (0..256u16).map(|_| Vec::new()).collect();
+    let mut buckets: Vec<Vec<entry<T>>> = (0..4096u16).map(|_| Vec::new()).collect();
     for elt in index {
         let mut s = SipHasher::new();
         elt.val.hash(&mut s);
         let h = s.finish() as usize;
-        (&mut buckets[h % 256]).push(elt);
+        (&mut buckets[h % 4096]).push(elt);
     }
 
     rbml_w.start_tag(tag_index);

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -25,11 +25,11 @@ use metadata::tyencode;
 use middle::def;
 use middle::ty::{self, Ty};
 use middle::stability;
-use util::nodemap::{FnvHashMap, NodeMap, NodeSet};
+use util::nodemap::{FnvHashMap, NodeMap, NodeSet, FnvHasher};
 
 use serialize::Encodable;
 use std::cell::RefCell;
-use std::hash::{Hash, Hasher, SipHasher};
+use std::hash::{Hash, Hasher};
 use std::io::prelude::*;
 use std::io::{Cursor, SeekFrom};
 use syntax::abi;
@@ -1626,7 +1626,7 @@ fn encode_index<T, F>(rbml_w: &mut Encoder, index: Vec<entry<T>>, mut write_fn: 
 {
     let mut buckets: Vec<Vec<entry<T>>> = (0..4096u16).map(|_| Vec::new()).collect();
     for elt in index {
-        let mut s = SipHasher::new();
+        let mut s = FnvHasher::default();
         elt.val.hash(&mut s);
         let h = s.finish() as usize;
         (&mut buckets[h % 4096]).push(elt);


### PR DESCRIPTION
I've been sitting on these for a week because I can't verify they produce real wins, but they are in theory more efficient.

One patch expands the number of buckets in the metadata index's hash table from 256 to 4096. I observed that in Servo these buckets were always very full, imposing lots of linear scanning on every lookup.

The second patch uses FnvHasher instead of SipHasher to generate the indexes, which should be lots faster for these short keys.

I wasn't going to post this because I can't prove it's better, but @pcwalton inspired me that microoptimizations can add up (ala SQLite's recent work).
