### PR TITLE
Remove some remains of virtual structs from the parser

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -2367,9 +2367,6 @@ The currently implemented features of the reference compiler are:
             into a Rust program. This capability, especially the signature for the
             annotated function, is subject to change.
 
-* `struct_inherit` - Allows using struct inheritance, which is barely
-                     implemented and will probably be removed. Don't use this.
-
 * `struct_variant` - Structural enum variants (those with named fields). It is
                      currently unknown whether this style of enum variant is as
                      fully supported as the tuple-forms, and it's not certain

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4692,11 +4692,6 @@ impl<'a> Parser<'a> {
         let class_name = try!(self.parse_ident());
         let mut generics = try!(self.parse_generics());
 
-        if try!(self.eat(&token::Colon) ){
-            let ty = try!(self.parse_ty_sum());
-            self.span_err(ty.span, "`virtual` structs have been removed from the language");
-        }
-
         // There is a special case worth noting here, as reported in issue #17904.
         // If we are parsing a tuple struct it is the case that the where clause
         // should follow the field list. Like so:
@@ -5381,11 +5376,6 @@ impl<'a> Parser<'a> {
             }
 
             try!(self.expect_one_of(&[], &[]));
-        }
-
-        if try!(self.eat_keyword_noexpect(keywords::Virtual) ){
-            let span = self.span;
-            self.span_err(span, "`virtual` structs have been removed from the language");
         }
 
         if try!(self.eat_keyword(keywords::Static) ){

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -575,13 +575,13 @@ declare_special_idents_and_keywords! {
         (36,                         Type,       "type");
         (37,                         Unsafe,     "unsafe");
         (38,                         Use,        "use");
-        (39,                         Virtual,    "virtual");
-        (40,                         While,      "while");
-        (41,                         Continue,   "continue");
-        (42,                         Box,        "box");
-        (43,                         Const,      "const");
-        (44,                         Where,      "where");
+        (39,                         While,      "while");
+        (40,                         Continue,   "continue");
+        (41,                         Box,        "box");
+        (42,                         Const,      "const");
+        (43,                         Where,      "where");
         'reserved:
+        (44,                         Virtual,    "virtual");
         (45,                         Proc,       "proc");
         (46,                         Alignof,    "alignof");
         (47,                         Become,     "become");

--- a/src/test/parse-fail/virtual-structs.rs
+++ b/src/test/parse-fail/virtual-structs.rs
@@ -11,12 +11,11 @@
 // compile-flags: -Z parse-only
 
 // Test diagnostics for the removed struct inheritance feature.
-#![feature(struct_inherit)]
 
-virtual struct SuperStruct { //~ ERROR `virtual` structs have been removed from the language
+virtual struct SuperStruct { //~ ERROR expected item, found `virtual`
     f1: isize,
 }
 
-struct Struct : SuperStruct; //~ ERROR `virtual` structs have been removed from the language
+struct Struct : SuperStruct;
 
 pub fn main() {}


### PR DESCRIPTION
Noticed these yesterday while reading libsyntax
