### PR TITLE
Avoid triggering a pathological case in the LLVM inliner

### DIFF
--- a/src/librustc_platform_intrinsics/aarch64.rs
+++ b/src/librustc_platform_intrinsics/aarch64.rs
@@ -17,6 +17,7 @@ use {Intrinsic, i, i_, u, u_, f, v, v_, agg, p, void};
 use IntrinsicDef::Named;
 use rustc::middle::ty;
 
+#[inline(never)]
 pub fn find<'tcx>(_tcx: &ty::ctxt<'tcx>, name: &str) -> Option<Intrinsic> {
     if !name.starts_with("aarch64_v") { return None }
     Some(match &name["aarch64_v".len()..] {

--- a/src/librustc_platform_intrinsics/arm.rs
+++ b/src/librustc_platform_intrinsics/arm.rs
@@ -17,6 +17,7 @@ use {Intrinsic, i, i_, u, u_, f, v, agg, p};
 use IntrinsicDef::Named;
 use rustc::middle::ty;
 
+#[inline(never)]
 pub fn find<'tcx>(_tcx: &ty::ctxt<'tcx>, name: &str) -> Option<Intrinsic> {
     if !name.starts_with("arm_v") { return None }
     Some(match &name["arm_v".len()..] {

--- a/src/librustc_platform_intrinsics/x86.rs
+++ b/src/librustc_platform_intrinsics/x86.rs
@@ -17,6 +17,7 @@ use {Intrinsic, i, i_, u, u_, f, v, v_, agg, p, void};
 use IntrinsicDef::Named;
 use rustc::middle::ty;
 
+#[inline(never)]
 pub fn find<'tcx>(_tcx: &ty::ctxt<'tcx>, name: &str) -> Option<Intrinsic> {
     if !name.starts_with("x86_mm") { return None }
     Some(match &name["x86_mm".len()..] {


### PR DESCRIPTION
When the inliner has to decided if it wants to inline a function A into an
internal function B, it first checks whether it would be more profitable
to inline B into its callees instead. This means that it has to analyze
B, which involves checking the assumption cache. Building the assumption
cache requires scanning the whole function, and because inlining
currently clears the assumption cache, this scan happens again and
again, getting even slower as the function grows from inlining.

As inlining the huge find functions isn't really useful anyway, we can
mark them as noinline, which skips the cost analysis and reduces compile
times by as much as 70%.

cc #28273
