### PR TITLE
Remove region variable leaks from higher_ranked_sub().

### DIFF
--- a/src/librustc/middle/infer/equate.rs
+++ b/src/librustc/middle/infer/equate.rs
@@ -17,6 +17,7 @@ use middle::ty::{self, Ty};
 use middle::ty::TyVar;
 use middle::ty_relate::{Relate, RelateResult, TypeRelation};
 
+/// Ensures `a` is made equal to `b`. Returns `a` on success.
 pub struct Equate<'a, 'tcx: 'a> {
     fields: CombineFields<'a, 'tcx>
 }

--- a/src/librustc/middle/infer/equate.rs
+++ b/src/librustc/middle/infer/equate.rs
@@ -68,7 +68,8 @@ impl<'a, 'tcx> TypeRelation<'a,'tcx> for Equate<'a, 'tcx> {
             }
 
             _ => {
-                combine::super_combine_tys(self.fields.infcx, self, a, b)
+                try!(combine::super_combine_tys(self.fields.infcx, self, a, b));
+                Ok(a)
             }
         }
     }

--- a/src/librustc/middle/infer/sub.rs
+++ b/src/librustc/middle/infer/sub.rs
@@ -18,7 +18,7 @@ use middle::ty::TyVar;
 use middle::ty_relate::{Cause, Relate, RelateResult, TypeRelation};
 use std::mem;
 
-/// "Greatest lower bound" (common subtype)
+/// Ensures `a` is made a subtype of `b`. Returns `a` on success.
 pub struct Sub<'a, 'tcx: 'a> {
     fields: CombineFields<'a, 'tcx>,
 }

--- a/src/librustc/middle/infer/sub.rs
+++ b/src/librustc/middle/infer/sub.rs
@@ -90,7 +90,8 @@ impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Sub<'a, 'tcx> {
             }
 
             _ => {
-                combine::super_combine_tys(self.fields.infcx, self, a, b)
+                try!(combine::super_combine_tys(self.fields.infcx, self, a, b));
+                Ok(a)
             }
         }
     }

--- a/src/test/run-pass/issue-28279.rs
+++ b/src/test/run-pass/issue-28279.rs
@@ -1,0 +1,30 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::rc::Rc;
+
+fn test1() -> Rc<for<'a> Fn(&'a usize) + 'static> {
+    if let Some(_) = Some(1) {
+        loop{}
+    } else {
+        loop{}
+    }
+}
+
+fn test2() -> *mut for<'a> Fn(&'a usize) + 'static {
+    if let Some(_) = Some(1) {
+        loop{}
+    } else {
+        loop{}
+    }
+}
+
+fn main() {}
+


### PR DESCRIPTION
Fixes #28279.

Currently

`common_supertype(*mut for<'a> Fn(&'a usize), *mut for<'a> Fn(&'a usize) + 'static)`

equals `*mut Fn(&usize)` which seems to be caused by `higher_ranked_sub()` allowing region variables to escape the comparison. This prevents inference from working properly with stuff like `Rc<Fn(&T)>`.

r? @nikomatsakis
