### PR TITLE
Stop a private method on `SipHasher` from shadowing `Hasher::write`

### DIFF
--- a/src/libcore/hash/sip.rs
+++ b/src/libcore/hash/sip.rs
@@ -138,7 +138,10 @@ impl SipHasher {
         self.v3 = self.k1 ^ 0x7465646279746573;
         self.ntail = 0;
     }
+}
 
+#[stable(feature = "rust1", since = "1.0.0")]
+impl Hasher for SipHasher {
     #[inline]
     fn write(&mut self, msg: &[u8]) {
         let length = msg.len();
@@ -182,14 +185,6 @@ impl SipHasher {
 
         self.tail = u8to64_le!(msg, i, left);
         self.ntail = left;
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl Hasher for SipHasher {
-    #[inline]
-    fn write(&mut self, msg: &[u8]) {
-        self.write(msg)
     }
 
     #[inline]


### PR DESCRIPTION
Closes #28374
