### PR TITLE
Implement RFC 1234: Ignore PhantomData when checking CoerceUnsized implementations

### DIFF
--- a/src/librustc/middle/ty/sty.rs
+++ b/src/librustc/middle/ty/sty.rs
@@ -899,6 +899,14 @@ impl<'tcx> TyS<'tcx> {
         }
     }
 
+    pub fn is_phantom_data(&self) -> bool {
+        if let TyStruct(def, _) = self.sty {
+            def.is_phantom_data()
+        } else {
+            false
+        }
+    }
+
     pub fn is_bool(&self) -> bool { self.sty == TyBool }
 
     pub fn is_param(&self, space: subst::ParamSpace, index: u32) -> bool {

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -533,7 +533,7 @@ fn coerce_unsized<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                               Rvalue::new(ByRef)));
                 } else {
                     // Otherwise, simply copy the data from the source.
-                    assert_eq!(src_ty, target_ty);
+                    assert!(src_ty.is_phantom_data() || src_ty == target_ty);
                     memcpy_ty(bcx, ll_target, ll_source, src_ty);
                 }
             }

--- a/src/test/compile-fail/issue-26905.rs
+++ b/src/test/compile-fail/issue-26905.rs
@@ -1,0 +1,34 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(unsize, coerce_unsized)]
+
+// Verfies that non-PhantomData ZSTs still cause coercions to fail.
+// They might have additional semantics that we don't want to bulldoze.
+
+use std::marker::{Unsize, PhantomData};
+use std::ops::CoerceUnsized;
+
+struct NotPhantomData<T: ?Sized>(PhantomData<T>);
+
+struct MyRc<T: ?Sized> {
+    _ptr: *const T,
+    _boo: NotPhantomData<T>,
+}
+
+impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<MyRc<U>> for MyRc<T>{ } //~ERROR
+
+fn main() {
+    let data = [1, 2, 3];
+    let iter = data.iter();
+    let x = MyRc { _ptr: &iter, _boo: NotPhantomData(PhantomData) };
+    let _y: MyRc<Iterator<Item=&u32>> = x;
+}
+

--- a/src/test/run-pass/issue-26905.rs
+++ b/src/test/run-pass/issue-26905.rs
@@ -1,0 +1,31 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(unsize, coerce_unsized)]
+
+// Verfies that PhantomData is ignored for DST coercions
+
+use std::marker::{Unsize, PhantomData};
+use std::ops::CoerceUnsized;
+
+struct MyRc<T: ?Sized> {
+    _ptr: *const T,
+    _boo: PhantomData<T>,
+}
+
+impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<MyRc<U>> for MyRc<T>{ }
+
+fn main() {
+    let data = [1, 2, 3];
+    let iter = data.iter();
+    let x = MyRc { _ptr: &iter, _boo: PhantomData };
+    let _y: MyRc<Iterator<Item=&u32>> = x;
+}
+


### PR DESCRIPTION
#27483 redux at Gankro's request.

Fixes #26905, Closes #28239

r? @nrc
