### PR TITLE
sort the existential bounds list in tydecode

### DIFF
--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -680,9 +680,8 @@ impl<'a,'tcx> TyDecoder<'a,'tcx> {
             }
         }
 
-        return ty::ExistentialBounds { region_bound: region_bound,
-                                       builtin_bounds: builtin_bounds,
-                                       projection_bounds: projection_bounds };
+        ty::ExistentialBounds::new(
+            region_bound, builtin_bounds, projection_bounds)
     }
 
     fn parse_builtin_bounds(&mut self) -> ty::BuiltinBounds {

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2137,6 +2137,21 @@ pub struct ExistentialBounds<'tcx> {
     pub projection_bounds: Vec<PolyProjectionPredicate<'tcx>>,
 }
 
+impl<'tcx> ExistentialBounds<'tcx> {
+    pub fn new(region_bound: ty::Region,
+               builtin_bounds: BuiltinBounds,
+               projection_bounds: Vec<PolyProjectionPredicate<'tcx>>)
+               -> Self {
+        let mut projection_bounds = projection_bounds;
+        ty::sort_bounds_list(&mut projection_bounds);
+        ExistentialBounds {
+            region_bound: region_bound,
+            builtin_bounds: builtin_bounds,
+            projection_bounds: projection_bounds
+        }
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct BuiltinBounds(EnumSet<BuiltinBound>);
 

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -2019,7 +2019,7 @@ pub fn conv_existential_bounds_from_partitioned_bounds<'tcx>(
     rscope: &RegionScope,
     span: Span,
     principal_trait_ref: ty::PolyTraitRef<'tcx>,
-    mut projection_bounds: Vec<ty::PolyProjectionPredicate<'tcx>>, // Empty for boxed closures
+    projection_bounds: Vec<ty::PolyProjectionPredicate<'tcx>>, // Empty for boxed closures
     partitioned_bounds: PartitionedBounds)
     -> ty::ExistentialBounds<'tcx>
 {
@@ -2058,13 +2058,7 @@ pub fn conv_existential_bounds_from_partitioned_bounds<'tcx>(
 
     debug!("region_bound: {:?}", region_bound);
 
-    ty::sort_bounds_list(&mut projection_bounds);
-
-    ty::ExistentialBounds {
-        region_bound: region_bound,
-        builtin_bounds: builtin_bounds,
-        projection_bounds: projection_bounds,
-    }
+    ty::ExistentialBounds::new(region_bound, builtin_bounds, projection_bounds)
 }
 
 /// Given the bounds on an object, determines what single region bound

--- a/src/test/auxiliary/issue-25467.rs
+++ b/src/test/auxiliary/issue-25467.rs
@@ -1,0 +1,20 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type="lib"]
+
+pub trait Trait {
+    // the issue is sensitive to interning order - so use names
+    // unlikely to appear in libstd.
+    type Issue25467FooT;
+    type Issue25467BarT;
+}
+
+pub type Object = Option<Box<Trait<Issue25467FooT=(),Issue25467BarT=()>>>;

--- a/src/test/run-pass/issue-25467.rs
+++ b/src/test/run-pass/issue-25467.rs
@@ -1,0 +1,20 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-25467.rs
+
+pub type Issue25467BarT = ();
+pub type Issue25467FooT = ();
+
+extern crate issue_25467 as aux;
+
+fn main() {
+    let o: aux::Object = None;
+}


### PR DESCRIPTION
The sort key is a (DefId, Name), which is _not_ stable between
runs, so we must re-sort when loading.

Fixes #24063
Fixes #25467
Fixes #27222
Fixes #28377

r? @eddyb 
