### PR TITLE
Disable browser history API on file:/// URLs

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -54,7 +54,8 @@
     }
 
     function browserSupportsHistoryApi() {
-        return window.history && typeof window.history.pushState === "function";
+        return document.location.protocol != "file:" &&
+          window.history && typeof window.history.pushState === "function";
     }
 
     function highlightSourceLines(ev) {


### PR DESCRIPTION
history.pushState is defined, but not working whenever document.origin is "null"
(literally that string, not just the null object).
This is due to some security considerations and is unlikely to be ever working.

For now just disable the usage of the history API when the documentation
is accessed through a file:/// URL.

See https://code.google.com/p/chromium/issues/detail?id=301210 for a
Chrome-specific issue on the history API on file:/// URLs

Closes #25953
