### PR TITLE
Drop upper bounds on net timeout tests

### DIFF
--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -954,7 +954,6 @@ mod tests {
             assert!(kind == ErrorKind::WouldBlock || kind == ErrorKind::TimedOut);
         });
         assert!(wait > Duration::from_millis(400));
-        assert!(wait < Duration::from_millis(1600));
     }
 
     #[test]
@@ -977,6 +976,5 @@ mod tests {
             assert!(kind == ErrorKind::WouldBlock || kind == ErrorKind::TimedOut);
         });
         assert!(wait > Duration::from_millis(400));
-        assert!(wait < Duration::from_millis(1600));
     }
 }

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -379,7 +379,6 @@ mod tests {
             assert!(kind == ErrorKind::WouldBlock || kind == ErrorKind::TimedOut);
         });
         assert!(wait > Duration::from_millis(400));
-        assert!(wait < Duration::from_millis(1600));
     }
 
     #[test]
@@ -400,6 +399,5 @@ mod tests {
             assert!(kind == ErrorKind::WouldBlock || kind == ErrorKind::TimedOut);
         });
         assert!(wait > Duration::from_millis(400));
-        assert!(wait < Duration::from_millis(1600));
     }
 }


### PR DESCRIPTION
Windows's scheduler apparently has "problems" unblocking calls in the
asked for time period.
