### PR TITLE
std: add Duration::as_millis

### DIFF
--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -93,6 +93,16 @@ impl Duration {
     #[stable(feature = "duration", since = "1.3.0")]
     pub fn as_secs(&self) -> u64 { self.secs }
 
+    /// Returns the number of whole milliseconds represented by this duration.
+    ///
+    /// Returns `None` if the operation would overflow.
+    #[unstable(feature = "duration_as_millis", reason = "newly added")]
+    pub fn as_millis(&self) -> Option<u64> {
+        self.secs.checked_mul(MILLIS_PER_SEC).and_then(|millis| {
+            millis.checked_add((self.nanos / NANOS_PER_MILLI) as u64)
+        })
+    }
+
     /// Returns the nanosecond precision represented by this duration.
     ///
     /// This method does **not** return the length of the duration when
@@ -186,6 +196,15 @@ mod tests {
         assert_eq!(Duration::from_secs(1).as_secs(), 1);
         assert_eq!(Duration::from_millis(999).as_secs(), 0);
         assert_eq!(Duration::from_millis(1001).as_secs(), 1);
+    }
+
+    #[test]
+    fn millis() {
+        assert_eq!(Duration::new(0, 0).as_millis(), Some(0));
+        assert_eq!(Duration::new(0, 5).as_millis(), Some(0));
+        assert_eq!(Duration::from_secs(1).as_millis(), Some(1_000));
+        assert_eq!(Duration::from_millis(999).as_millis(), Some(999));
+        assert_eq!(Duration::from_millis(1001).as_millis(), Some(1001));
     }
 
     #[test]


### PR DESCRIPTION
Following ["do whatever is easiest"](https://github.com/rust-lang/rfcs/pull/1224/files#diff-309db29ef1ed0eca4e0e38fd34406ac9R47), this was about the same amount of work to implement vs write up an RFC.

Motivation: there already exists a `Duration::from_millis` function, but no mirror `Duration::as_millis`. Milliseconds are commonly desired in programming, and the lack of `as_millis` feels unbalanced.
