### PR TITLE
Prohibit renaming to primitive types' names in import lists

### DIFF
--- a/src/test/compile-fail/issue-20427.rs
+++ b/src/test/compile-fail/issue-20427.rs
@@ -47,6 +47,8 @@ mod char {
         //~^ ERROR user-defined types or type parameters cannot shadow the primitive types
         use super::bool_ as bool;
         //~^ ERROR user-defined types or type parameters cannot shadow the primitive types
+        use super::{bool_ as str};
+        //~^ ERROR user-defined types or type parameters cannot shadow the primitive types
         use super::char_ as char;
     }
 }


### PR DESCRIPTION
This was missing from https://github.com/rust-lang/rust/pull/27451

r? @eddyb 
