### PR TITLE
Remove a needless memset() from the runtime

### DIFF
--- a/src/rt/rust_builtin.c
+++ b/src/rt/rust_builtin.c
@@ -328,7 +328,6 @@ int rust_get_argv_zero(void* p, size_t* sz)
     return -1;
   }
 
-  memset(p, 0, len);
   memcpy(p, argv[0], len);
   free(argv);
   return 0;


### PR DESCRIPTION
It's okay that we don't append NUL because len is actually one more than the length of argv[0]. However, this is precarious and should probably be replaced with more robust logic.
