### PR TITLE
book: mention the existence of block comments in passing

### DIFF
--- a/src/doc/trpl/comments.md
+++ b/src/doc/trpl/comments.md
@@ -15,6 +15,11 @@ let x = 5; // this is also a line comment.
 // If you have a long explanation for something, you can put line comments next
 // to each other. Put a space between the // and your comment so that it’s
 // more readable.
+
+/*
+ * (Block comments delimited by `/*` and `*/` are also available, but this
+ * style is generally discouraged.)
+ */
 ```
 
 The other kind of comment is a doc comment. Doc comments use `///` instead of


### PR DESCRIPTION
While the style guide does say to [avoid block comments](https://doc.rust-lang.org/stable/style/style/comments.html#avoid-block-comments.), they should perhaps be briefly mentioned in the "Comments" section of the book, to avoid leaving readers with the false belief that they don't exist.

r? @steveklabnik
