### PR TITLE
Avoid loading the whole gdb debug scripts section.

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -1669,8 +1669,7 @@ fn compile_test_and_save_ir(config: &Config, props: &TestProps,
     // FIXME (#9639): This needs to handle non-utf8 paths
     let mut link_args = vec!("-L".to_owned(),
                              aux_dir.to_str().unwrap().to_owned());
-    let llvm_args = vec!("--emit=llvm-ir".to_owned(),
-                         "--crate-type=lib".to_owned());
+    let llvm_args = vec!("--emit=llvm-ir".to_owned(),);
     link_args.extend(llvm_args);
     let args = make_compile_args(config,
                                  props,

--- a/src/test/codegen/adjustments.rs
+++ b/src/test/codegen/adjustments.rs
@@ -10,6 +10,8 @@
 
 // compile-flags: -C no-prepopulate-passes
 
+#![crate_type = "lib"]
+
 // Hack to get the correct size for the length part in slices
 // CHECK: @helper([[USIZE:i[0-9]+]])
 #[no_mangle]

--- a/src/test/codegen/extern-functions.rs
+++ b/src/test/codegen/extern-functions.rs
@@ -10,6 +10,7 @@
 
 // compile-flags: -C no-prepopulate-passes
 
+#![crate_type = "lib"]
 #![feature(unwind_attributes)]
 
 extern {

--- a/src/test/codegen/function-arguments.rs
+++ b/src/test/codegen/function-arguments.rs
@@ -10,6 +10,7 @@
 
 // compile-flags: -C no-prepopulate-passes
 
+#![crate_type = "lib"]
 #![feature(allocator)]
 
 pub struct S {

--- a/src/test/codegen/gdb_debug_script_load.rs
+++ b/src/test/codegen/gdb_debug_script_load.rs
@@ -8,22 +8,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -C no-prepopulate-passes
+// ignore-tidy-linelength
+// ignore-windows
+// ignore-macos
 
-#![crate_type = "lib"]
+// compile-flags: -g -C no-prepopulate-passes
 
-static X: i32 = 5;
+#![feature(start)]
 
-// CHECK-LABEL: @raw_ptr_to_raw_ptr_noop
-// CHECK-NOT: alloca
-#[no_mangle]
-pub fn raw_ptr_to_raw_ptr_noop() -> *const i32{
-    &X as *const i32
-}
+// CHECK-LABEL: @main
+// CHECK: load volatile i8, i8* getelementptr inbounds ([[B:\[[0-9]* x i8\]]], [[B]]* @__rustc_debug_gdb_scripts_section__, i32 0, i32 0), align 1
 
-// CHECK-LABEL: @reference_to_raw_ptr_noop
-// CHECK-NOT: alloca
-#[no_mangle]
-pub fn reference_to_raw_ptr_noop() -> *const i32 {
-    &X
+#[start]
+fn start(_: isize, _: *const *const u8) -> isize {
+    return 0;
 }

--- a/src/test/codegen/link_section.rs
+++ b/src/test/codegen/link_section.rs
@@ -10,6 +10,8 @@
 
 // compile-flags: -C no-prepopulate-passes
 
+#![crate_type = "lib"]
+
 // CHECK: @VAR1 = constant i32 1, section ".test_one"
 #[no_mangle]
 #[link_section = ".test_one"]

--- a/src/test/codegen/loads.rs
+++ b/src/test/codegen/loads.rs
@@ -10,6 +10,8 @@
 
 // compile-flags: -C no-prepopulate-passes
 
+#![crate_type = "lib"]
+
 pub struct Bytes {
   a: u8,
   b: u8,

--- a/src/test/codegen/stores.rs
+++ b/src/test/codegen/stores.rs
@@ -10,6 +10,8 @@
 
 // compile-flags: -C no-prepopulate-passes
 
+#![crate_type = "lib"]
+
 pub struct Bytes {
   a: u8,
   b: u8,


### PR DESCRIPTION
This is so LLVM isn't forced to load every byte of it. Also sets the alignment of
the load. Adds a test for the debug script section.

r? @alexcrichton 
