### PR TITLE
Emit an error upon failing to create a temp dir instead of panicking

### DIFF
--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -543,7 +543,11 @@ fn link_binary_output(sess: &Session,
         }
     }
 
-    let tmpdir = TempDir::new("rustc").ok().expect("needs a temp dir");
+    let tmpdir = match TempDir::new("rustc") {
+        Ok(tmpdir) => tmpdir,
+        Err(err) => sess.fatal(&format!("couldn't create a temp dir: {}", err)),
+    };
+
     match crate_type {
         config::CrateTypeRlib => {
             link_rlib(sess, Some(trans), &objects, &out_filename,

--- a/src/test/run-make/issue-14698/Makefile
+++ b/src/test/run-make/issue-14698/Makefile
@@ -1,0 +1,4 @@
+-include ../tools.mk
+
+all:
+	TMP=fake TMPDIR=fake $(RUSTC) foo.rs 2>&1 | grep "couldn't create a temp dir:"

--- a/src/test/run-make/issue-14698/foo.rs
+++ b/src/test/run-make/issue-14698/foo.rs
@@ -1,0 +1,11 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {}


### PR DESCRIPTION
Emit an error upon failing to create a temp dir instead of panicking

Closes #14698.
