### PR TITLE
Faster slice PartialOrd

### DIFF
--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -463,17 +463,35 @@ mod impls {
         }
     }
 
-    partial_ord_impl! { char usize u8 u16 u32 u64 isize i8 i16 i32 i64 f32 f64 }
+    partial_ord_impl! { f32 f64 }
 
     macro_rules! ord_impl {
         ($($t:ty)*) => ($(
             #[stable(feature = "rust1", since = "1.0.0")]
+            impl PartialOrd for $t {
+                #[inline]
+                fn partial_cmp(&self, other: &$t) -> Option<Ordering> {
+                    if *self == *other { Some(Equal) }
+                    else if *self < *other { Some(Less) }
+                    else { Some(Greater) }
+                }
+                #[inline]
+                fn lt(&self, other: &$t) -> bool { (*self) < (*other) }
+                #[inline]
+                fn le(&self, other: &$t) -> bool { (*self) <= (*other) }
+                #[inline]
+                fn ge(&self, other: &$t) -> bool { (*self) >= (*other) }
+                #[inline]
+                fn gt(&self, other: &$t) -> bool { (*self) > (*other) }
+            }
+
+            #[stable(feature = "rust1", since = "1.0.0")]
             impl Ord for $t {
                 #[inline]
                 fn cmp(&self, other: &$t) -> Ordering {
-                    if *self < *other { Less }
-                    else if *self > *other { Greater }
-                    else { Equal }
+                    if *self == *other { Equal }
+                    else if *self < *other { Less }
+                    else { Greater }
                 }
             }
         )*)

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -471,9 +471,7 @@ mod impls {
             impl PartialOrd for $t {
                 #[inline]
                 fn partial_cmp(&self, other: &$t) -> Option<Ordering> {
-                    if *self == *other { Some(Equal) }
-                    else if *self < *other { Some(Less) }
-                    else { Some(Greater) }
+                    Some(self.cmp(other))
                 }
                 #[inline]
                 fn lt(&self, other: &$t) -> bool { (*self) < (*other) }

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -1558,7 +1558,6 @@ impl<T: Eq> Eq for [T] {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Ord> Ord for [T] {
-    #[inline]
     fn cmp(&self, other: &[T]) -> Ordering {
         let l = cmp::min(self.len(), other.len());
         let lhs = &self[..l];
@@ -1577,7 +1576,6 @@ impl<T: Ord> Ord for [T] {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: PartialOrd> PartialOrd for [T] {
-    #[inline]
     fn partial_cmp(&self, other: &[T]) -> Option<Ordering> {
         let l = cmp::min(self.len(), other.len());
         let lhs = &self[..l];

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -1561,9 +1561,11 @@ impl<T: Ord> Ord for [T] {
     #[inline]
     fn cmp(&self, other: &[T]) -> Ordering {
         let l = cmp::min(self.len(), other.len());
+        let lhs = &self[..l];
+        let rhs = &other[..l];
 
         for i in 0..l {
-            match self[i].cmp(&other[i]) {
+            match lhs[i].cmp(&rhs[i]) {
                 Ordering::Equal => (),
                 non_eq => return non_eq,
             }
@@ -1578,9 +1580,11 @@ impl<T: PartialOrd> PartialOrd for [T] {
     #[inline]
     fn partial_cmp(&self, other: &[T]) -> Option<Ordering> {
         let l = cmp::min(self.len(), other.len());
+        let lhs = &self[..l];
+        let rhs = &other[..l];
 
         for i in 0..l {
-            match self[i].partial_cmp(&other[i]) {
+            match lhs[i].partial_cmp(&rhs[i]) {
                 Some(Ordering::Equal) => (),
                 non_eq => return non_eq,
             }

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -1558,8 +1558,18 @@ impl<T: Eq> Eq for [T] {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Ord> Ord for [T] {
+    #[inline]
     fn cmp(&self, other: &[T]) -> Ordering {
-        self.iter().cmp(other.iter())
+        let l = cmp::min(self.len(), other.len());
+
+        for i in 0..l {
+            match self[i].cmp(&other[i]) {
+                Ordering::Equal => (),
+                non_eq => return non_eq,
+            }
+        }
+
+        self.len().cmp(&other.len())
     }
 }
 
@@ -1567,22 +1577,15 @@ impl<T: Ord> Ord for [T] {
 impl<T: PartialOrd> PartialOrd for [T] {
     #[inline]
     fn partial_cmp(&self, other: &[T]) -> Option<Ordering> {
-        self.iter().partial_cmp(other.iter())
-    }
-    #[inline]
-    fn lt(&self, other: &[T]) -> bool {
-        self.iter().lt(other.iter())
-    }
-    #[inline]
-    fn le(&self, other: &[T]) -> bool {
-        self.iter().le(other.iter())
-    }
-    #[inline]
-    fn ge(&self, other: &[T]) -> bool {
-        self.iter().ge(other.iter())
-    }
-    #[inline]
-    fn gt(&self, other: &[T]) -> bool {
-        self.iter().gt(other.iter())
+        let l = cmp::min(self.len(), other.len());
+
+        for i in 0..l {
+            match self[i].partial_cmp(&other[i]) {
+                Some(Ordering::Equal) => (),
+                non_eq => return non_eq,
+            }
+        }
+
+        self.len().partial_cmp(&other.len())
     }
 }

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -1560,6 +1560,9 @@ impl<T: Eq> Eq for [T] {}
 impl<T: Ord> Ord for [T] {
     fn cmp(&self, other: &[T]) -> Ordering {
         let l = cmp::min(self.len(), other.len());
+
+        // Slice to the loop iteration range to enable bound check
+        // elimination in the compiler
         let lhs = &self[..l];
         let rhs = &other[..l];
 
@@ -1578,6 +1581,9 @@ impl<T: Ord> Ord for [T] {
 impl<T: PartialOrd> PartialOrd for [T] {
     fn partial_cmp(&self, other: &[T]) -> Option<Ordering> {
         let l = cmp::min(self.len(), other.len());
+
+        // Slice to the loop iteration range to enable bound check
+        // elimination in the compiler
         let lhs = &self[..l];
         let rhs = &other[..l];
 


### PR DESCRIPTION
This branch improves the performance of Ord and PartialOrd methods for slices compared to the iter-based implementation.
Based on the approach used in #26884.
