### PR TITLE
libsyntax: forbid visibility modifiers for enum variants

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -5210,13 +5210,10 @@ impl<'a> Parser<'a> {
             let variant_attrs = self.parse_outer_attributes();
             let vlo = self.span.lo;
 
-            let vis = try!(self.parse_visibility());
-
-            let ident;
             let kind;
             let mut args = Vec::new();
             let mut disr_expr = None;
-            ident = try!(self.parse_ident());
+            let ident = try!(self.parse_ident());
             if try!(self.eat(&token::OpenDelim(token::Brace)) ){
                 // Parse a struct variant.
                 all_nullary = false;
@@ -5258,7 +5255,7 @@ impl<'a> Parser<'a> {
                 kind: kind,
                 id: ast::DUMMY_NODE_ID,
                 disr_expr: disr_expr,
-                vis: vis,
+                vis: Inherited,
             };
             variants.push(P(spanned(vlo, self.last_span.hi, vr)));
 

--- a/src/test/compile-fail/issue-28433.rs
+++ b/src/test/compile-fail/issue-28433.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,15 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct A { pub i: isize }
-pub enum C { pub Variant }      //~ ERROR: unnecessary `pub`
-
-pub trait E {
-    fn foo(&self);
+enum bird {
+    pub duck, //~ ERROR: expected identifier, found keyword `pub`
+    goose
 }
 
-impl E for A {
-    pub fn foo(&self) {}             //~ ERROR: unnecessary visibility
-}
 
-fn main() {}
+fn main() {
+    let y = bird::goose;
+}

--- a/src/test/compile-fail/useless-pub.rs
+++ b/src/test/compile-fail/useless-pub.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,16 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use zoo::bird::{duck, goose};
+struct A { pub i: isize }
 
-mod zoo {
-    pub enum bird {
-        pub duck, //~ ERROR: unnecessary `pub` visibility
-        goose
-    }
+pub trait E {
+    fn foo(&self);
 }
 
-
-fn main() {
-    let y = goose;
+impl E for A {
+    pub fn foo(&self) {}             //~ ERROR: unnecessary visibility
 }
+
+fn main() {}


### PR DESCRIPTION
fixes #28433 

This just removes visibility parsing from the parser. No custom error message is provided: I guess default "expected identifier, found keyword `pub`" is already good. 

So the `ast::Variant_` `vis` is always `Inherited`. I guess it would be possible to get rid of this field now, but I'm not sure that it is in scope of this PR. 

The tests are changed as follows:
- issue-3993-2.rs is removed (it is not relevant any more)
- issue-28433.rs is added (it's basically simplified issue-3993-2.rs)
- nothing is done to issue-3993. It does not seem relevant to #3993 git hub issue
- useless-priv.rs is renamed to useless-pub.rs and a case about enum is dropped
