### PR TITLE
Remove Visibility field from enum variants

### DIFF
--- a/src/librustc_front/fold.rs
+++ b/src/librustc_front/fold.rs
@@ -415,7 +415,7 @@ pub fn noop_fold_foreign_mod<T: Folder>(ForeignMod {abi, items}: ForeignMod,
 }
 
 pub fn noop_fold_variant<T: Folder>(v: P<Variant>, fld: &mut T) -> P<Variant> {
-    v.map(|Spanned {node: Variant_ {id, name, attrs, kind, disr_expr, vis}, span}| Spanned {
+    v.map(|Spanned {node: Variant_ {id, name, attrs, kind, disr_expr}, span}| Spanned {
         node: Variant_ {
             id: fld.new_id(id),
             name: name,
@@ -430,7 +430,6 @@ pub fn noop_fold_variant<T: Folder>(v: P<Variant>, fld: &mut T) -> P<Variant> {
                 }
             },
             disr_expr: disr_expr.map(|e| fld.fold_expr(e)),
-            vis: vis,
         },
         span: fld.new_span(span),
     })

--- a/src/librustc_front/hir.rs
+++ b/src/librustc_front/hir.rs
@@ -1055,7 +1055,6 @@ pub struct Variant_ {
     pub id: NodeId,
     /// Explicit discriminant, eg `Foo = 1`
     pub disr_expr: Option<P<Expr>>,
-    pub vis: Visibility,
 }
 
 pub type Variant = Spanned<Variant_>;

--- a/src/librustc_front/lowering.rs
+++ b/src/librustc_front/lowering.rs
@@ -147,7 +147,6 @@ pub fn lower_variant(v: &Variant) -> P<hir::Variant> {
                 }
             },
             disr_expr: v.node.disr_expr.as_ref().map(|e| lower_expr(e)),
-            vis: lower_visibility(v.node.vis),
         },
         span: v.span,
     })

--- a/src/librustc_front/print/pprust.rs
+++ b/src/librustc_front/print/pprust.rs
@@ -944,7 +944,6 @@ impl<'a> State<'a> {
     }
 
     pub fn print_variant(&mut self, v: &hir::Variant) -> io::Result<()> {
-        try!(self.print_visibility(v.node.vis));
         match v.node.kind {
             hir::TupleVariantKind(ref args) => {
                 try!(self.print_ident(v.node.name));

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -1075,20 +1075,7 @@ impl<'a, 'tcx> SanePrivacyVisitor<'a, 'tcx> {
                                  instead");
             }
 
-            hir::ItemEnum(ref def, _) => {
-                for v in &def.variants {
-                    match v.node.vis {
-                        hir::Public => {
-                            if item.vis == hir::Public {
-                                span_err!(tcx.sess, v.span, E0448,
-                                          "unnecessary `pub` visibility");
-                            }
-                        }
-                        hir::Inherited => {}
-                    }
-                }
-            }
-
+            hir::ItemEnum(..) |
             hir::ItemTrait(..) | hir::ItemDefaultImpl(..) |
             hir::ItemConst(..) | hir::ItemStatic(..) | hir::ItemStruct(..) |
             hir::ItemFn(..) | hir::ItemMod(..) | hir::ItemTy(..) |
@@ -1131,14 +1118,10 @@ impl<'a, 'tcx> SanePrivacyVisitor<'a, 'tcx> {
                     check_inherited(tcx, i.span, i.vis);
                 }
             }
-            hir::ItemEnum(ref def, _) => {
-                for v in &def.variants {
-                    check_inherited(tcx, v.span, v.node.vis);
-                }
-            }
 
             hir::ItemStruct(ref def, _) => check_struct(&**def),
 
+            hir::ItemEnum(..) |
             hir::ItemExternCrate(_) | hir::ItemUse(_) |
             hir::ItemTrait(..) | hir::ItemDefaultImpl(..) |
             hir::ItemStatic(..) | hir::ItemConst(..) |

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1850,7 +1850,7 @@ impl Clean<Item> for doctree::Variant {
             name: Some(self.name.clean(cx)),
             attrs: self.attrs.clean(cx),
             source: self.whence.clean(cx),
-            visibility: self.vis.clean(cx),
+            visibility: None,
             stability: self.stab.clean(cx),
             def_id: DefId::local(self.id),
             inner: VariantItem(Variant {

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -121,7 +121,6 @@ pub struct Variant {
     pub attrs: Vec<ast::Attribute>,
     pub kind: hir::VariantKind,
     pub id: ast::NodeId,
-    pub vis: hir::Visibility,
     pub stab: Option<attr::Stability>,
     pub whence: Span,
 }

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -109,7 +109,6 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             variants: def.variants.iter().map(|v| Variant {
                 name: v.node.name,
                 attrs: v.node.attrs.clone(),
-                vis: v.node.vis,
                 stab: self.stability(v.node.id),
                 id: v.node.id,
                 kind: v.node.kind.clone(),

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1614,7 +1614,6 @@ pub struct Variant_ {
     pub id: NodeId,
     /// Explicit discriminant, eg `Foo = 1`
     pub disr_expr: Option<P<Expr>>,
-    pub vis: Visibility,
 }
 
 pub type Variant = Spanned<Variant_>;

--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -141,7 +141,7 @@ fn fold_item_underscore<F>(cx: &mut Context<F>, item: ast::Item_) -> ast::Item_ 
                     None
                 } else {
                     Some(v.map(|Spanned {node: ast::Variant_ {id, name, attrs, kind,
-                                                              disr_expr, vis}, span}| {
+                                                              disr_expr}, span}| {
                         Spanned {
                             node: ast::Variant_ {
                                 id: id,
@@ -154,7 +154,6 @@ fn fold_item_underscore<F>(cx: &mut Context<F>, item: ast::Item_) -> ast::Item_ 
                                     }
                                 },
                                 disr_expr: disr_expr,
-                                vis: vis
                             },
                             span: span
                         }

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -1013,7 +1013,6 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                    kind: ast::TupleVariantKind(args),
                    id: ast::DUMMY_NODE_ID,
                    disr_expr: None,
-                   vis: ast::Public
                })
     }
 

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -450,7 +450,7 @@ pub fn noop_fold_foreign_mod<T: Folder>(ForeignMod {abi, items}: ForeignMod,
 }
 
 pub fn noop_fold_variant<T: Folder>(v: P<Variant>, fld: &mut T) -> P<Variant> {
-    v.map(|Spanned {node: Variant_ {id, name, attrs, kind, disr_expr, vis}, span}| Spanned {
+    v.map(|Spanned {node: Variant_ {id, name, attrs, kind, disr_expr}, span}| Spanned {
         node: Variant_ {
             id: fld.new_id(id),
             name: name,
@@ -465,7 +465,6 @@ pub fn noop_fold_variant<T: Folder>(v: P<Variant>, fld: &mut T) -> P<Variant> {
                 }
             },
             disr_expr: disr_expr.map(|e| fld.fold_expr(e)),
-            vis: vis,
         },
         span: fld.new_span(span),
     })

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -5200,13 +5200,10 @@ impl<'a> Parser<'a> {
             let variant_attrs = self.parse_outer_attributes();
             let vlo = self.span.lo;
 
-            let vis = try!(self.parse_visibility());
-
-            let ident;
             let kind;
             let mut args = Vec::new();
             let mut disr_expr = None;
-            ident = try!(self.parse_ident());
+            let ident = try!(self.parse_ident());
             if try!(self.eat(&token::OpenDelim(token::Brace)) ){
                 // Parse a struct variant.
                 all_nullary = false;
@@ -5248,7 +5245,7 @@ impl<'a> Parser<'a> {
                 kind: kind,
                 id: ast::DUMMY_NODE_ID,
                 disr_expr: disr_expr,
-                vis: vis,
+                vis: Inherited,
             };
             variants.push(P(spanned(vlo, self.last_span.hi, vr)));
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -5245,7 +5245,6 @@ impl<'a> Parser<'a> {
                 kind: kind,
                 id: ast::DUMMY_NODE_ID,
                 disr_expr: disr_expr,
-                vis: Inherited,
             };
             variants.push(P(spanned(vlo, self.last_span.hi, vr)));
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1507,7 +1507,6 @@ impl<'a> State<'a> {
     }
 
     pub fn print_variant(&mut self, v: &ast::Variant) -> io::Result<()> {
-        try!(self.print_visibility(v.node.vis));
         match v.node.kind {
             ast::TupleVariantKind(ref args) => {
                 try!(self.print_ident(v.node.name));
@@ -3139,11 +3138,10 @@ mod tests {
             kind: ast::TupleVariantKind(Vec::new()),
             id: 0,
             disr_expr: None,
-            vis: ast::Public,
         });
 
         let varstr = variant_to_string(&var);
-        assert_eq!(varstr, "pub principal_skinner");
+        assert_eq!(varstr, "principal_skinner");
     }
 
     #[test]

--- a/src/test/compile-fail/issue-28433.rs
+++ b/src/test/compile-fail/issue-28433.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,15 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct A { pub i: isize }
-pub enum C { pub Variant }      //~ ERROR: unnecessary `pub`
-
-pub trait E {
-    fn foo(&self);
+enum bird {
+    pub duck, //~ ERROR: expected identifier, found keyword `pub`
+    goose
 }
 
-impl E for A {
-    pub fn foo(&self) {}             //~ ERROR: unnecessary visibility
-}
 
-fn main() {}
+fn main() {
+    let y = bird::goose;
+}

--- a/src/test/compile-fail/issue-28433.rs
+++ b/src/test/compile-fail/issue-28433.rs
@@ -9,7 +9,9 @@
 // except according to those terms.
 
 enum bird {
-    pub duck, //~ ERROR: expected identifier, found keyword `pub`
+    pub duck,
+    //~^ ERROR: expected identifier, found keyword `pub`
+    //~^^ ERROR: expected
     goose
 }
 

--- a/src/test/compile-fail/useless-pub.rs
+++ b/src/test/compile-fail/useless-pub.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,16 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use zoo::bird::{duck, goose};
+struct A { pub i: isize }
 
-mod zoo {
-    pub enum bird {
-        pub duck, //~ ERROR: unnecessary `pub` visibility
-        goose
-    }
+pub trait E {
+    fn foo(&self);
 }
 
-
-fn main() {
-    let y = goose;
+impl E for A {
+    pub fn foo(&self) {}             //~ ERROR: unnecessary visibility
 }
+
+fn main() {}


### PR DESCRIPTION
Followup on #28440 

Do not merge before the referenced PR is merged. I will fix the PR once that is merged (or close if it is not)
