### PR TITLE
libsyntax: stop early enough if keyword is found instead of ident

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -545,7 +545,7 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_ident(&mut self) -> PResult<ast::Ident> {
-        self.check_strict_keywords();
+        try!(self.check_strict_keywords());
         try!(self.check_reserved_keywords());
         match self.token {
             token::Ident(i, _) => {
@@ -640,13 +640,13 @@ impl<'a> Parser<'a> {
     }
 
     /// Signal an error if the given string is a strict keyword
-    pub fn check_strict_keywords(&mut self) {
+    pub fn check_strict_keywords(&mut self) -> PResult<()> {
         if self.token.is_strict_keyword() {
             let token_str = self.this_token_to_string();
-            let span = self.span;
-            self.span_err(span,
-                          &format!("expected identifier, found keyword `{}`",
-                                  token_str));
+            Err(self.fatal(&format!("expected identifier, found keyword `{}`",
+                                    token_str)))
+        } else {
+            Ok(())
         }
     }
 

--- a/src/test/parse-fail/associated-types-project-from-hrtb-explicit.rs
+++ b/src/test/parse-fail/associated-types-project-from-hrtb-explicit.rs
@@ -21,7 +21,6 @@ pub trait Foo<T> {
 
 fn foo2<I>(x: <I as for<'x> Foo<&'x isize>>::A)
     //~^ ERROR expected identifier, found keyword `for`
-    //~| ERROR expected one of `::` or `>`
 {
 }
 

--- a/src/test/parse-fail/keywords-followed-by-double-colon.rs
+++ b/src/test/parse-fail/keywords-followed-by-double-colon.rs
@@ -12,5 +12,4 @@
 
 fn main() {
     struct::foo();  //~ ERROR expected identifier
-    mut::baz(); //~ ERROR expected identifier
 }

--- a/src/test/parse-fail/removed-syntax-field-let.rs
+++ b/src/test/parse-fail/removed-syntax-field-let.rs
@@ -13,5 +13,4 @@
 struct s {
     let foo: (),
     //~^  ERROR expected identifier, found keyword `let`
-    //~^^ ERROR expected `:`, found `foo`
 }

--- a/src/test/parse-fail/removed-syntax-mut-vec-expr.rs
+++ b/src/test/parse-fail/removed-syntax-mut-vec-expr.rs
@@ -13,5 +13,4 @@
 fn f() {
     let v = [mut 1, 2, 3, 4];
     //~^  ERROR expected identifier, found keyword `mut`
-    //~^^ ERROR expected one of `!`, `,`, `.`, `::`, `;`, `]`, `{`, or an operator, found `1`
 }

--- a/src/test/parse-fail/removed-syntax-mut-vec-ty.rs
+++ b/src/test/parse-fail/removed-syntax-mut-vec-ty.rs
@@ -12,4 +12,3 @@
 
 type v = [mut isize];
     //~^  ERROR expected identifier, found keyword `mut`
-    //~^^ ERROR expected one of `!`, `(`, `+`, `::`, `;`, `<`, or `]`, found `isize`

--- a/src/test/parse-fail/removed-syntax-uniq-mut-expr.rs
+++ b/src/test/parse-fail/removed-syntax-uniq-mut-expr.rs
@@ -13,5 +13,4 @@
 fn f() {
     let a_box = box mut 42;
     //~^  ERROR expected identifier, found keyword `mut`
-    //~^^ ERROR expected one of `!`, `.`, `::`, `;`, `{`, or an operator, found `42`
 }

--- a/src/test/parse-fail/removed-syntax-uniq-mut-ty.rs
+++ b/src/test/parse-fail/removed-syntax-uniq-mut-ty.rs
@@ -12,4 +12,3 @@
 
 type mut_box = Box<mut isize>;
     //~^  ERROR expected identifier, found keyword `mut`
-    //~^^ ERROR expected one of `!`, `(`, `+`, `,`, `::`, `<`, or `>`, found `isize`

--- a/src/test/parse-fail/unsized2.rs
+++ b/src/test/parse-fail/unsized2.rs
@@ -17,6 +17,4 @@ fn f<X>() {}
 pub fn main() {
     f<type>();
     //~^ ERROR expected identifier, found keyword `type`
-    //~^^ ERROR: chained comparison
-    //~^^^ HELP: use `::<
 }

--- a/src/test/parse-fail/use-as-where-use-ends-with-mod-sep.rs
+++ b/src/test/parse-fail/use-as-where-use-ends-with-mod-sep.rs
@@ -11,4 +11,3 @@
 // compile-flags: -Z parse-only
 
 use std::any:: as foo; //~ ERROR expected identifier, found keyword `as`
-//~^ ERROR: expected one of `::`, `;`, or `as`, found `foo`


### PR DESCRIPTION
fixes #28439

The signature of public function `check_strict_keywords` is changed. This function is used only once in rustc in `parse_ident`.

This breaks 9 tests in `parse-fail` category, because they expect two messages instead of one. I think it's safe just to fix the tests expectations.
