### PR TITLE
Change OSX version req wording to match Linux.

### DIFF
--- a/src/doc/trpl/installing-rust.md
+++ b/src/doc/trpl/installing-rust.md
@@ -64,7 +64,7 @@ Oh, we should also mention the officially supported platforms:
 
 * Windows (7, 8, Server 2008 R2)
 * Linux (2.6.18 or later, various distributions), x86 and x86-64
-* OSX 10.7 (Lion) or greater, x86 and x86-64
+* OSX 10.7 (Lion) or later, x86 and x86-64
 
 We extensively test Rust on these platforms, and a few others, too, like
 Android. But these are the ones most likely to work, as they have the most


### PR DESCRIPTION
Using "later" in this context makes more sense than "greater" so it's been changed to match the Linux requirement above it rather than the other way around.
