### PR TITLE
Add compiler option to keep mtwt tables

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -601,6 +601,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
           "For every macro invocation, print its name and arguments"),
     enable_nonzeroing_move_hints: bool = (false, parse_bool,
           "Force nonzeroing move optimization on"),
+    keep_mtwt_tables: bool = (false, parse_bool,
+          "Don't clear the resolution tables after analysis"),
 }
 
 pub fn default_lib_output() -> CrateType {

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -671,7 +671,9 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: Session,
              || resolve::resolve_crate(&sess, &ast_map, make_glob_map));
 
     // Discard MTWT tables that aren't required past resolution.
-    syntax::ext::mtwt::clear_tables();
+    if !sess.opts.debugging_opts.keep_mtwt_tables {
+        syntax::ext::mtwt::clear_tables();
+    }
 
     let named_region_map = time(time_passes, "lifetime resolution",
                                 || middle::resolve_lifetime::krate(&sess, krate, &def_map));


### PR DESCRIPTION
This is so that the resolution results can be used after analysis, potentially for tool support
