### PR TITLE
Correct type definition of HANDLE.

### DIFF
--- a/src/test/run-pass/x86stdcall2.rs
+++ b/src/test/run-pass/x86stdcall2.rs
@@ -10,7 +10,7 @@
 
 #![feature(std_misc)]
 
-pub type HANDLE = u32;
+pub type HANDLE = usize;
 pub type DWORD = u32;
 pub type SIZE_T = u32;
 pub type LPVOID = usize;


### PR DESCRIPTION
Type `HANDLE` is defined on Windows as `PVOID`. Test `run-pass/x86stdcall2` defined it as `u32` that caused access violation in `catch_panic` routine at the line:

```
try!(unwind::try(move || *result = Some(f())))
```

The original failure is as follows:

```
---- [run-pass] run-pass/x86stdcall2.rs stdout ----

error: test run failed!
status: exit code: -1073741819
command: PATH="x86_64-pc-windows-msvc/stage2/bin/rustlib/x86_64-pc-windows-msvc/lib;D:\Sources\Rust\x86_64-pc-windows-msvc\stage2\bin;C:\MSYS2\mingw64\bin;C:\MSYS2\usr\local\bin;C:\MSYS2\usr\bin;C:\MSYS2\usr\bin;C:\Program Files\Python 3;C:\Program Files\Python 3\Scripts;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0;C:\Program Files (x86)\Windows Kits\8.1\Windows Performance Toolkit;C:\Program Files\SlikSvn\bin;C:\Program Files\System Tools;C:\Program Files (x86)\System Tools;C:\Program Files\Vim\vim74;C:\Program Files\Rust\bin;C:\Program Files\Microsoft\Web Platform Installer;C:\Program Files\MiKTeX\miktex\bin\x64;C:\Program Files (x86)\Pandoc;C:\Program Files\LLVM\bin;C:\Program Files\KDiff3;C:\Program Files\Git\cmd;C:\Users\Vitali\AppData\Local\atom\bin;C:\MSYS2\usr\bin\site_perl;C:\MSYS2\usr\bin\vendor_perl;C:\MSYS2\usr\bin\core_perl" x86_64-pc-windows-msvc/test/run-pass\x86stdcall2.stage2-x86_64-pc-windows-msvc.exe
stdout:
------------------------------------------

------------------------------------------
stderr:
------------------------------------------

------------------------------------------

thread '[run-pass] run-pass/x86stdcall2.rs' panicked at 'explicit panic', D:/Sources/Rust/src/compiletest\runtest.rs:1501
```

P.S. I compiled rust for `x86_64-pc-windows-msvc`.
