### PR TITLE
Revert "Convert negate_unsigned feature gate to a warning"

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -49,7 +49,7 @@ use std::{i8, i16, i32, i64, u8, u16, u32, u64, f32, f64};
 use syntax::{abi, ast};
 use syntax::attr::{self, AttrMetaMethods};
 use syntax::codemap::{self, Span};
-use syntax::feature_gate::{KNOWN_ATTRIBUTES, AttributeType};
+use syntax::feature_gate::{KNOWN_ATTRIBUTES, AttributeType, emit_feature_err, GateIssue};
 use syntax::ast::{TyIs, TyUs, TyI8, TyU8, TyI16, TyU16, TyI32, TyU32, TyI64, TyU64};
 use syntax::ptr::P;
 
@@ -381,13 +381,12 @@ impl LateLintPass for TypeLimits {
 
         fn check_unsigned_negation_feature(cx: &LateContext, span: Span) {
             if !cx.sess().features.borrow().negate_unsigned {
-                // FIXME(#27141): change this to syntax::feature_gate::emit_feature_err…
-                cx.sess().span_warn(span,
-                    "unary negation of unsigned integers will be feature gated in the future");
-                // …and remove following two expressions.
-                if option_env!("CFG_DISABLE_UNSTABLE_FEATURES").is_some() { return; }
-                cx.sess().fileline_help(span, "add #![feature(negate_unsigned)] to the \
-                                               crate attributes to enable the gate in advance");
+                emit_feature_err(
+                    &cx.sess().parse_sess.span_diagnostic,
+                    "negate_unsigned",
+                    span,
+                    GateIssue::Language,
+                    "unary negation of unsigned integers may be removed in the future");
             }
         }
     }

--- a/src/test/bench/shootout-mandelbrot.rs
+++ b/src/test/bench/shootout-mandelbrot.rs
@@ -192,7 +192,7 @@ fn write_line(init_i: f64, vec_init_r: &[f64], res: &mut Vec<u8>) {
             i += 2;
         }
 
-        res.push(cur_byte^-1);
+        res.push(cur_byte^!0);
     }
 }
 

--- a/src/test/compile-fail/feature-gate-negate-unsigned.rs
+++ b/src/test/compile-fail/feature-gate-negate-unsigned.rs
@@ -18,21 +18,21 @@ impl std::ops::Neg for S {
 }
 
 const _MAX: usize = -1;
-//~^ WARN unary negation of unsigned integers will be feature gated in the future
+//~^ ERROR unary negation of unsigned integers may be removed in the future
 
 fn main() {
     let a = -1;
-    //~^ WARN unary negation of unsigned integers will be feature gated in the future
+    //~^ ERROR unary negation of unsigned integers may be removed in the future
     let _b : u8 = a; // for infering variable a to u8.
 
     -a;
-    //~^ WARN unary negation of unsigned integers will be feature gated in the future
+    //~^ ERROR unary negation of unsigned integers may be removed in the future
 
     let _d = -1u8;
-    //~^ WARN unary negation of unsigned integers will be feature gated in the future
+    //~^ ERROR unary negation of unsigned integers may be removed in the future
 
     for _ in -10..10u8 {}
-    //~^ WARN unary negation of unsigned integers will be feature gated in the future
+    //~^ ERROR unary negation of unsigned integers may be removed in the future
 
     -S; // should not trigger the gate; issue 26840
 }

--- a/src/test/run-pass/unary-minus-suffix-inference.rs
+++ b/src/test/run-pass/unary-minus-suffix-inference.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(negate_unsigned)]
+
 pub fn main() {
     let a = 1;
     let a_neg: i8 = -a;


### PR DESCRIPTION
This reverts commit 0ca8e4994ee43ba9dfbded6e129b30ff5fe7a994.

Fixes #27141
