### PR TITLE
Tweak Travis to use GCE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,22 @@
-# ccache support is disabled unless your language is a C-derivative. However
-# `language: C` unconditionally sets `CC=compiler`. If we just set it in our
-# `env` it will be overwritten by the default (gcc 4.6).
 language: c
-compiler: /usr/bin/gcc-4.7
-cache: ccache
-sudo: false
+sudo: required
+services:
+  - docker
 
-# The test suite is in general way too stressful for travis, especially in
-# terms of time limit and reliability. In the past we've tried to scale things
-# back to only build the stage1 compiler and run a subset of tests, but this
-# didn't end up panning out very well.
-#
-# As a result, we're just using travis to run `make tidy` and *only* build
-# stage1 but *not* test it for now (a strict subset of the bootstrap). This will
-# catch "obvious" errors like style or not even compiling.
-#
-# We need gcc4.7 or higher to build LLVM, and travis (well, Ubuntu 12.04)
-# currently ships with 4.6. Gotta download our own.
-before_script:
-  - ./configure --enable-ccache
+# LLVM takes awhile to check out and otherwise we'll manage the submodules in
+# our configure script, so disable auto submodule management.
+git:
+  submodules: false
+
+before_install:
+  - docker build -t rust -f src/etc/Dockerfile src/etc
 script:
-  - make tidy && make check -j4
-
-env:
-  - CXX=/usr/bin/g++-4.7
-
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - gcc-4.7
-    - g++-4.7
+  - docker run --privileged -tv `pwd`:/build rust
+    sh -c "
+      ./configure --llvm-root=/usr/lib/llvm-3.7 &&
+      make tidy &&
+      make check -j4
+    "
 
 # Real testing happens on http://buildbot.rust-lang.org/
 #

--- a/src/etc/Dockerfile
+++ b/src/etc/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:latest
+
+RUN echo 'deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.7 main' | \
+        sudo tee -a /etc/apt/sources.list
+RUN echo 'deb-src http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.7 main' | \
+        sudo tee -a /etc/apt/sources.list
+RUN apt-get update
+RUN apt-get -y install curl make g++ python2.7 git zlib1g-dev libedit-dev
+RUN apt-get -y --force-yes install llvm-3.7-tools
+
+RUN mkdir /build
+WORKDIR /build

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -185,14 +185,13 @@ mod tests {
         }
     }
 
-    // FIXME #11530 this fails on android because tests are run as root
-    #[cfg_attr(any(windows, target_os = "android"), ignore)]
     #[test]
     fn bind_error() {
-        let addr = SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 1);
-        match UdpSocket::bind(&addr) {
+        match UdpSocket::bind("1.1.1.1:9999") {
             Ok(..) => panic!(),
-            Err(e) => assert_eq!(e.kind(), ErrorKind::PermissionDenied),
+            Err(e) => {
+                assert_eq!(e.kind(), ErrorKind::AddrNotAvailable)
+            }
         }
     }
 

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -625,17 +625,20 @@ mod tests {
         drop(p.wait());
     }
 
+    #[cfg(unix)]
     #[cfg(all(unix, not(target_os="android")))]
-    #[test]
     fn signal_reported_right() {
         use os::unix::process::ExitStatusExt;
 
-        let p = Command::new("/bin/sh").arg("-c").arg("kill -9 $$").spawn();
-        assert!(p.is_ok());
-        let mut p = p.unwrap();
+        let mut p = Command::new("/bin/sh")
+                            .arg("-c").arg("read a")
+                            .stdin(Stdio::piped())
+                            .spawn().unwrap();
+        p.kill().unwrap();
         match p.wait().unwrap().signal() {
             Some(9) => {},
-            result => panic!("not terminated by signal 9 (instead, {:?})", result),
+            result => panic!("not terminated by signal 9 (instead, {:?})",
+                             result),
         }
     }
 

--- a/src/libstd/sys/unix/process.rs
+++ b/src/libstd/sys/unix/process.rs
@@ -450,6 +450,15 @@ mod tests {
     use slice;
     use sys::{self, c, cvt, pipe};
 
+    macro_rules! t {
+        ($e:expr) => {
+            match $e {
+                Ok(t) => t,
+                Err(e) => panic!("received error for `{}`: {}", stringify!($e), e),
+            }
+        }
+    }
+
     #[cfg(not(target_os = "android"))]
     extern {
         #[cfg_attr(target_os = "netbsd", link_name = "__sigaddset14")]
@@ -473,24 +482,26 @@ mod tests {
         unsafe {
             // Test to make sure that a signal mask does not get inherited.
             let cmd = Command::new(OsStr::new("cat"));
-            let (stdin_read, stdin_write) = sys::pipe::anon_pipe().unwrap();
-            let (stdout_read, stdout_write) = sys::pipe::anon_pipe().unwrap();
+            let (stdin_read, stdin_write) = t!(sys::pipe::anon_pipe());
+            let (stdout_read, stdout_write) = t!(sys::pipe::anon_pipe());
 
             let mut set: c::sigset_t = mem::uninitialized();
             let mut old_set: c::sigset_t = mem::uninitialized();
-            cvt(c::sigemptyset(&mut set)).unwrap();
-            cvt(sigaddset(&mut set, libc::SIGINT)).unwrap();
-            cvt(c::pthread_sigmask(c::SIG_SETMASK, &set, &mut old_set)).unwrap();
+            t!(cvt(c::sigemptyset(&mut set)));
+            t!(cvt(sigaddset(&mut set, libc::SIGINT)));
+            t!(cvt(c::pthread_sigmask(c::SIG_SETMASK, &set, &mut old_set)));
 
-            let cat = Process::spawn(&cmd, Stdio::Raw(stdin_read.raw()),
-                                           Stdio::Raw(stdout_write.raw()),
-                                           Stdio::None).unwrap();
+            let cat = t!(Process::spawn(&cmd, Stdio::Raw(stdin_read.raw()),
+                                              Stdio::Raw(stdout_write.raw()),
+                                              Stdio::None));
             drop(stdin_read);
             drop(stdout_write);
 
-            cvt(c::pthread_sigmask(c::SIG_SETMASK, &old_set, ptr::null_mut())).unwrap();
+            t!(cvt(c::pthread_sigmask(c::SIG_SETMASK, &old_set,
+                                      ptr::null_mut())));
 
-            cvt(libc::funcs::posix88::signal::kill(cat.id() as libc::pid_t, libc::SIGINT)).unwrap();
+            t!(cvt(libc::funcs::posix88::signal::kill(cat.id() as libc::pid_t,
+                                                      libc::SIGINT)));
             // We need to wait until SIGINT is definitely delivered. The
             // easiest way is to write something to cat, and try to read it
             // back: if SIGINT is unmasked, it'll get delivered when cat is
@@ -504,7 +515,7 @@ mod tests {
                 assert!(ret == 0);
             }
 
-            cat.wait().unwrap();
+            t!(cat.wait());
         }
     }
 }

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -951,10 +951,5 @@ LLVMRustBuildLandingPad(LLVMBuilderRef Builder,
                         unsigned NumClauses,
                         const char* Name,
                         LLVMValueRef F) {
-#if LLVM_VERSION_MINOR >= 7
-    unwrap<Function>(F)->setPersonalityFn(unwrap<Constant>(PersFn));
-    return LLVMBuildLandingPad(Builder, Ty, NumClauses, Name);
-#else
     return LLVMBuildLandingPad(Builder, Ty, PersFn, NumClauses, Name);
-#endif
 }


### PR DESCRIPTION
Travis CI has new infrastructure using the Google Compute Engine which has both
faster CPUs and more memory, and we've been encouraged to switch as it should
help our build times! The only downside currently, however, is that IPv6 is
disabled, causing a number of standard library tests to fail.

Consequently this commit tweaks our travis config in a few ways:
- ccache is disabled as it's not working on GCE just yet
- Docker is used to run tests inside which reportedly will get IPv6 working
- A system LLVM installation is used instead of building LLVM itself. This is
  primarily done to reduce build times, but we want automation for this sort of
  behavior anyway and we can extend this in the future with building from source
  as well if needed.
- gcc-specific logic is removed as the docker image for Ubuntu gives us a
  recent-enough gcc by default.
