### PR TITLE
Move test to the right directory and make it pass

### DIFF
--- a/src/test/compile-fail/borrowck-loan-of-static-data-issue-27616.rs
+++ b/src/test/compile-fail/borrowck-loan-of-static-data-issue-27616.rs
@@ -23,7 +23,7 @@ fn evil(mut s: &'static mut String)
     let alias: &'static mut String = s;
     let inner: &str = &alias;
     // free value
-    *s = String::new(); //~ ERROR cannot assign
+    *s = String::new(); //~ ERROR use of moved value
     let _spray = "0wned".to_owned();
     // ... and then use it
     println!("{}", inner);


### PR DESCRIPTION
I assume the expected error changed during the development of pull
request #28321 and that wasn't noticed because the test was
accidentally not running.

r? @nikomatsakis
