### PR TITLE
Do not drop_in_place elements of Vec<T> if T doesn't need dropping

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -65,7 +65,7 @@ use alloc::heap::EMPTY;
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{self, Hash};
-use core::intrinsics::{arith_offset, assume, drop_in_place};
+use core::intrinsics::{arith_offset, assume, drop_in_place, needs_drop};
 use core::iter::FromIterator;
 use core::mem;
 use core::ops::{Index, IndexMut, Deref};
@@ -1322,8 +1322,10 @@ impl<T> Drop for Vec<T> {
         // OK because exactly when this stops being a valid assumption, we
         // don't need unsafe_no_drop_flag shenanigans anymore.
         if self.buf.unsafe_no_drop_flag_needs_drop() {
-            for x in self.iter_mut() {
-                unsafe { drop_in_place(x); }
+            if unsafe { needs_drop::<T>() } {
+                for x in self.iter_mut() {
+                    unsafe { drop_in_place(x); }
+                }
             }
         }
         // RawVec handles deallocation

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1322,9 +1322,11 @@ impl<T> Drop for Vec<T> {
         // OK because exactly when this stops being a valid assumption, we
         // don't need unsafe_no_drop_flag shenanigans anymore.
         if self.buf.unsafe_no_drop_flag_needs_drop() {
-            if unsafe { needs_drop::<T>() } {
-                for x in self.iter_mut() {
-                    unsafe { drop_in_place(x); }
+            unsafe {
+                if needs_drop::<T>() {
+                    for x in self.iter_mut() {
+                        drop_in_place(x);
+                    }
                 }
             }
         }

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1323,6 +1323,8 @@ impl<T> Drop for Vec<T> {
         // don't need unsafe_no_drop_flag shenanigans anymore.
         if self.buf.unsafe_no_drop_flag_needs_drop() {
             unsafe {
+                // The branch on needs_drop() is an -O1 performance optimization.
+                // Without the branch, dropping Vec<u8> takes linear time.
                 if needs_drop::<T>() {
                     for x in self.iter_mut() {
                         drop_in_place(x);


### PR DESCRIPTION
With -O2, LLVM's inliner can remove this code, but this does not happen
with -O1 and lower. As a result, dropping Vec<u8> was linear with length,
resulting in abysmal performance for large buffers.

See issue #24280.
