### PR TITLE
Replace `Ident`s with `Name`s in HIR (Part 1)

### DIFF
--- a/src/librustc/front/map/blocks.rs
+++ b/src/librustc/front/map/blocks.rs
@@ -189,13 +189,13 @@ impl<'a> FnLikeNode<'a> {
 
     pub fn kind(self) -> FnKind<'a> {
         let item = |p: ItemFnParts<'a>| -> FnKind<'a> {
-            FnKind::ItemFn(p.ident, p.generics, p.unsafety, p.constness, p.abi, p.vis)
+            FnKind::ItemFn(p.ident.name, p.generics, p.unsafety, p.constness, p.abi, p.vis)
         };
         let closure = |_: ClosureParts| {
             FnKind::Closure
         };
-        let method = |_, ident, sig: &'a ast::MethodSig, vis, _, _| {
-            FnKind::Method(ident, sig, vis)
+        let method = |_, ident: Ident, sig: &'a ast::MethodSig, vis, _, _| {
+            FnKind::Method(ident.name, sig, vis)
         };
         self.handle(item, method, closure)
     }

--- a/src/librustc/front/map/blocks.rs
+++ b/src/librustc/front/map/blocks.rs
@@ -26,7 +26,7 @@ pub use self::Code::*;
 use front::map::{self, Node};
 use syntax::abi;
 use rustc_front::hir::{Block, FnDecl};
-use syntax::ast::{NodeId, Ident};
+use syntax::ast::{Name, NodeId};
 use rustc_front::hir as ast;
 use syntax::codemap::Span;
 use rustc_front::visit::FnKind;
@@ -107,7 +107,7 @@ impl<'a> Code<'a> {
 /// These are all the components one can extract from a fn item for
 /// use when implementing FnLikeNode operations.
 struct ItemFnParts<'a> {
-    ident:    Ident,
+    name:     Name,
     decl:     &'a ast::FnDecl,
     unsafety: ast::Unsafety,
     constness: ast::Constness,
@@ -189,13 +189,13 @@ impl<'a> FnLikeNode<'a> {
 
     pub fn kind(self) -> FnKind<'a> {
         let item = |p: ItemFnParts<'a>| -> FnKind<'a> {
-            FnKind::ItemFn(p.ident.name, p.generics, p.unsafety, p.constness, p.abi, p.vis)
+            FnKind::ItemFn(p.name, p.generics, p.unsafety, p.constness, p.abi, p.vis)
         };
         let closure = |_: ClosureParts| {
             FnKind::Closure
         };
-        let method = |_, ident: Ident, sig: &'a ast::MethodSig, vis, _, _| {
-            FnKind::Method(ident.name, sig, vis)
+        let method = |_, name: Name, sig: &'a ast::MethodSig, vis, _, _| {
+            FnKind::Method(name, sig, vis)
         };
         self.handle(item, method, closure)
     }
@@ -203,7 +203,7 @@ impl<'a> FnLikeNode<'a> {
     fn handle<A, I, M, C>(self, item_fn: I, method: M, closure: C) -> A where
         I: FnOnce(ItemFnParts<'a>) -> A,
         M: FnOnce(NodeId,
-                  Ident,
+                  Name,
                   &'a ast::MethodSig,
                   Option<ast::Visibility>,
                   &'a ast::Block,
@@ -216,7 +216,7 @@ impl<'a> FnLikeNode<'a> {
                 ast::ItemFn(ref decl, unsafety, constness, abi, ref generics, ref block) =>
                     item_fn(ItemFnParts {
                         id: i.id,
-                        ident: i.ident,
+                        name: i.name,
                         decl: &**decl,
                         unsafety: unsafety,
                         body: &**block,
@@ -230,14 +230,14 @@ impl<'a> FnLikeNode<'a> {
             },
             map::NodeTraitItem(ti) => match ti.node {
                 ast::MethodTraitItem(ref sig, Some(ref body)) => {
-                    method(ti.id, ti.ident, sig, None, body, ti.span)
+                    method(ti.id, ti.name, sig, None, body, ti.span)
                 }
                 _ => panic!("trait method FnLikeNode that is not fn-like"),
             },
             map::NodeImplItem(ii) => {
                 match ii.node {
                     ast::MethodImplItem(ref sig, ref body) => {
-                        method(ii.id, ii.ident, sig, Some(ii.vis), body, ii.span)
+                        method(ii.id, ii.name, sig, Some(ii.vis), body, ii.span)
                     }
                     _ => {
                         panic!("impl method FnLikeNode that is not fn-like")

--- a/src/librustc/front/map/mod.rs
+++ b/src/librustc/front/map/mod.rs
@@ -483,7 +483,7 @@ impl<'ast> Map<'ast> {
             NodeForeignItem(i) => PathName(i.name),
             NodeImplItem(ii) => PathName(ii.name),
             NodeTraitItem(ti) => PathName(ti.name),
-            NodeVariant(v) => PathName(v.node.name.name),
+            NodeVariant(v) => PathName(v.node.name),
             NodeLifetime(lt) => PathName(lt.name),
             _ => panic!("no path elem for {:?}", node)
         }
@@ -710,7 +710,7 @@ impl<T:Named> Named for Spanned<T> { fn name(&self) -> Name { self.node.name() }
 
 impl Named for Item { fn name(&self) -> Name { self.name } }
 impl Named for ForeignItem { fn name(&self) -> Name { self.name } }
-impl Named for Variant_ { fn name(&self) -> Name { self.name.name } }
+impl Named for Variant_ { fn name(&self) -> Name { self.name } }
 impl Named for TraitItem { fn name(&self) -> Name { self.name } }
 impl Named for ImplItem { fn name(&self) -> Name { self.name } }
 

--- a/src/librustc/front/map/mod.rs
+++ b/src/librustc/front/map/mod.rs
@@ -17,7 +17,7 @@ use metadata::inline::InlinedItem as II;
 use middle::def_id::DefId;
 
 use syntax::abi;
-use syntax::ast::{self, Name, NodeId, Ident, CRATE_NODE_ID, DUMMY_NODE_ID};
+use syntax::ast::{self, Name, NodeId, CRATE_NODE_ID, DUMMY_NODE_ID};
 use syntax::codemap::{Span, Spanned};
 use syntax::parse::token;
 
@@ -475,14 +475,14 @@ impl<'ast> Map<'ast> {
             NodeItem(item) => {
                 match item.node {
                     ItemMod(_) | ItemForeignMod(_) => {
-                        PathMod(item.ident.name)
+                        PathMod(item.name)
                     }
-                    _ => PathName(item.ident.name)
+                    _ => PathName(item.name)
                 }
             }
-            NodeForeignItem(i) => PathName(i.ident.name),
-            NodeImplItem(ii) => PathName(ii.ident.name),
-            NodeTraitItem(ti) => PathName(ti.ident.name),
+            NodeForeignItem(i) => PathName(i.name),
+            NodeImplItem(ii) => PathName(ii.name),
+            NodeTraitItem(ti) => PathName(ti.name),
             NodeVariant(v) => PathName(v.node.name.name),
             NodeLifetime(lt) => PathName(lt.name),
             _ => panic!("no path elem for {:?}", node)
@@ -499,9 +499,9 @@ impl<'ast> Map<'ast> {
         self.with_path(id, |path| path_to_string(path))
     }
 
-    fn path_to_str_with_ident(&self, id: NodeId, i: Ident) -> String {
+    fn path_to_str_with_name(&self, id: NodeId, name: Name) -> String {
         self.with_path(id, |path| {
-            path_to_string(path.chain(Some(PathName(i.name))))
+            path_to_string(path.chain(Some(PathName(name))))
         })
     }
 
@@ -652,7 +652,7 @@ impl<'a, 'ast> NodesMatchingSuffix<'a, 'ast> {
                 match map.find(id) {
                     None => return None,
                     Some(NodeItem(item)) if item_is_mod(&*item) =>
-                        return Some((id, item.ident.name)),
+                        return Some((id, item.name)),
                     _ => {}
                 }
                 let parent = map.get_parent(id);
@@ -708,11 +708,11 @@ trait Named {
 
 impl<T:Named> Named for Spanned<T> { fn name(&self) -> Name { self.node.name() } }
 
-impl Named for Item { fn name(&self) -> Name { self.ident.name } }
-impl Named for ForeignItem { fn name(&self) -> Name { self.ident.name } }
+impl Named for Item { fn name(&self) -> Name { self.name } }
+impl Named for ForeignItem { fn name(&self) -> Name { self.name } }
 impl Named for Variant_ { fn name(&self) -> Name { self.name.name } }
-impl Named for TraitItem { fn name(&self) -> Name { self.ident.name } }
-impl Named for ImplItem { fn name(&self) -> Name { self.ident.name } }
+impl Named for TraitItem { fn name(&self) -> Name { self.name } }
+impl Named for ImplItem { fn name(&self) -> Name { self.name } }
 
 pub trait FoldOps {
     fn new_id(&self, id: NodeId) -> NodeId {
@@ -1040,7 +1040,7 @@ fn node_id_to_string(map: &Map, id: NodeId, include_id: bool) -> String {
 
     match map.find(id) {
         Some(NodeItem(item)) => {
-            let path_str = map.path_to_str_with_ident(id, item.ident);
+            let path_str = map.path_to_str_with_name(id, item.name);
             let item_str = match item.node {
                 ItemExternCrate(..) => "extern crate",
                 ItemUse(..) => "use",
@@ -1059,25 +1059,25 @@ fn node_id_to_string(map: &Map, id: NodeId, include_id: bool) -> String {
             format!("{} {}{}", item_str, path_str, id_str)
         }
         Some(NodeForeignItem(item)) => {
-            let path_str = map.path_to_str_with_ident(id, item.ident);
+            let path_str = map.path_to_str_with_name(id, item.name);
             format!("foreign item {}{}", path_str, id_str)
         }
         Some(NodeImplItem(ii)) => {
             match ii.node {
                 ConstImplItem(..) => {
                     format!("assoc const {} in {}{}",
-                            ii.ident,
+                            ii.name,
                             map.path_to_string(id),
                             id_str)
                 }
                 MethodImplItem(..) => {
                     format!("method {} in {}{}",
-                            ii.ident,
+                            ii.name,
                             map.path_to_string(id), id_str)
                 }
                 TypeImplItem(_) => {
                     format!("assoc type {} in {}{}",
-                            ii.ident,
+                            ii.name,
                             map.path_to_string(id),
                             id_str)
                 }
@@ -1092,7 +1092,7 @@ fn node_id_to_string(map: &Map, id: NodeId, include_id: bool) -> String {
 
             format!("{} {} in {}{}",
                     kind,
-                    ti.ident,
+                    ti.name,
                     map.path_to_string(id),
                     id_str)
         }

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -663,12 +663,12 @@ impl<'a, 'tcx, 'v> hir_visit::Visitor<'v> for LateContext<'a, 'tcx> {
 
     fn visit_struct_def(&mut self,
                         s: &hir::StructDef,
-                        ident: ast::Ident,
+                        name: ast::Name,
                         g: &hir::Generics,
                         id: ast::NodeId) {
-        run_lints!(self, check_struct_def, late_passes, s, ident, g, id);
+        run_lints!(self, check_struct_def, late_passes, s, name, g, id);
         hir_visit::walk_struct_def(self, s);
-        run_lints!(self, check_struct_def_post, late_passes, s, ident, g, id);
+        run_lints!(self, check_struct_def_post, late_passes, s, name, g, id);
     }
 
     fn visit_struct_field(&mut self, s: &hir::StructField) {
@@ -691,8 +691,8 @@ impl<'a, 'tcx, 'v> hir_visit::Visitor<'v> for LateContext<'a, 'tcx> {
         hir_visit::walk_ty(self, t);
     }
 
-    fn visit_ident(&mut self, sp: Span, id: ast::Ident) {
-        run_lints!(self, check_ident, late_passes, sp, id);
+    fn visit_name(&mut self, sp: Span, name: ast::Name) {
+        run_lints!(self, check_name, late_passes, sp, name);
     }
 
     fn visit_mod(&mut self, m: &hir::Mod, s: Span, n: ast::NodeId) {

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -130,7 +130,7 @@ pub trait LintPass {
 // FIXME: eliminate the duplication with `Visitor`. But this also
 // contains a few lint-specific methods with no equivalent in `Visitor`.
 pub trait LateLintPass: LintPass {
-    fn check_ident(&mut self, _: &LateContext, _: Span, _: ast::Ident) { }
+    fn check_name(&mut self, _: &LateContext, _: Span, _: ast::Name) { }
     fn check_crate(&mut self, _: &LateContext, _: &hir::Crate) { }
     fn check_mod(&mut self, _: &LateContext, _: &hir::Mod, _: Span, _: ast::NodeId) { }
     fn check_foreign_item(&mut self, _: &LateContext, _: &hir::ForeignItem) { }
@@ -150,9 +150,9 @@ pub trait LateLintPass: LintPass {
     fn check_trait_item(&mut self, _: &LateContext, _: &hir::TraitItem) { }
     fn check_impl_item(&mut self, _: &LateContext, _: &hir::ImplItem) { }
     fn check_struct_def(&mut self, _: &LateContext,
-        _: &hir::StructDef, _: ast::Ident, _: &hir::Generics, _: ast::NodeId) { }
+        _: &hir::StructDef, _: ast::Name, _: &hir::Generics, _: ast::NodeId) { }
     fn check_struct_def_post(&mut self, _: &LateContext,
-        _: &hir::StructDef, _: ast::Ident, _: &hir::Generics, _: ast::NodeId) { }
+        _: &hir::StructDef, _: ast::Name, _: &hir::Generics, _: ast::NodeId) { }
     fn check_struct_field(&mut self, _: &LateContext, _: &hir::StructField) { }
     fn check_variant(&mut self, _: &LateContext, _: &hir::Variant, _: &hir::Generics) { }
     fn check_variant_post(&mut self, _: &LateContext, _: &hir::Variant, _: &hir::Generics) { }

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -201,17 +201,17 @@ impl<'a> CrateReader<'a> {
         match i.node {
             hir::ItemExternCrate(ref path_opt) => {
                 debug!("resolving extern crate stmt. ident: {} path_opt: {:?}",
-                       i.ident, path_opt);
+                       i.name, path_opt);
                 let name = match *path_opt {
                     Some(name) => {
                         validate_crate_name(Some(self.sess), &name.as_str(),
                                             Some(i.span));
                         name.to_string()
                     }
-                    None => i.ident.to_string(),
+                    None => i.name.to_string(),
                 };
                 Some(CrateInfo {
-                    ident: i.ident.to_string(),
+                    ident: i.name.to_string(),
                     name: name,
                     id: i.id,
                     should_link: should_link_hir(i),

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1787,7 +1787,7 @@ fn encode_macro_defs(rbml_w: &mut Encoder,
     for def in &krate.exported_macros {
         rbml_w.start_tag(tag_macro_def);
 
-        encode_name(rbml_w, def.ident.name);
+        encode_name(rbml_w, def.name);
         encode_attributes(rbml_w, &def.attrs);
 
         rbml_w.wr_tagged_str(tag_macro_def_body,

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -426,16 +426,16 @@ fn encode_reexported_static_methods(ecx: &EncodeContext,
         // encoded metadata for static methods relative to Bar,
         // but not yet for Foo.
         //
-        if path_differs || item.ident.name != exp.name {
+        if path_differs || item.name != exp.name {
             if !encode_reexported_static_base_methods(ecx, rbml_w, exp) {
                 if encode_reexported_static_trait_methods(ecx, rbml_w, exp) {
                     debug!("(encode reexported static methods) {} [trait]",
-                           item.ident.name);
+                           item.name);
                 }
             }
             else {
                 debug!("(encode reexported static methods) {} [base]",
-                       item.ident.name);
+                       item.name);
             }
         }
     }
@@ -520,7 +520,7 @@ fn encode_info_for_mod(ecx: &EncodeContext,
         });
 
         if let hir::ItemImpl(..) = item.node {
-            let (ident, did) = (item.ident, item.id);
+            let (ident, did) = (item.name, item.id);
             debug!("(encoding info for module) ... encoding impl {} ({}/{})",
                    ident,
                    did, ecx.tcx.map.node_to_string(did));
@@ -1014,7 +1014,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         }
         encode_bounds_and_type_for_item(rbml_w, ecx, item.id);
         encode_symbol(ecx, rbml_w, item.id);
-        encode_name(rbml_w, item.ident.name);
+        encode_name(rbml_w, item.name);
         encode_path(rbml_w, path);
         encode_visibility(rbml_w, vis);
         encode_stability(rbml_w, stab);
@@ -1027,7 +1027,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         encode_def_id(rbml_w, def_id);
         encode_family(rbml_w, 'C');
         encode_bounds_and_type_for_item(rbml_w, ecx, item.id);
-        encode_name(rbml_w, item.ident.name);
+        encode_name(rbml_w, item.name);
         encode_path(rbml_w, path);
         encode_attributes(rbml_w, &item.attrs);
         encode_inlined_item(ecx, rbml_w, InlinedItemRef::Item(item));
@@ -1042,7 +1042,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         encode_family(rbml_w, FN_FAMILY);
         let tps_len = generics.ty_params.len();
         encode_bounds_and_type_for_item(rbml_w, ecx, item.id);
-        encode_name(rbml_w, item.ident.name);
+        encode_name(rbml_w, item.name);
         encode_path(rbml_w, path);
         encode_attributes(rbml_w, &item.attrs);
         let needs_inline = tps_len > 0 || attr::requests_inline(&item.attrs);
@@ -1066,7 +1066,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
                             &item.attrs,
                             item.id,
                             path,
-                            item.ident.name,
+                            item.name,
                             item.vis);
       }
       hir::ItemForeignMod(ref fm) => {
@@ -1074,7 +1074,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         rbml_w.start_tag(tag_items_data_item);
         encode_def_id(rbml_w, def_id);
         encode_family(rbml_w, 'n');
-        encode_name(rbml_w, item.ident.name);
+        encode_name(rbml_w, item.name);
         encode_path(rbml_w, path);
 
         // Encode all the items in this module.
@@ -1092,7 +1092,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         encode_def_id(rbml_w, def_id);
         encode_family(rbml_w, 'y');
         encode_bounds_and_type_for_item(rbml_w, ecx, item.id);
-        encode_name(rbml_w, item.ident.name);
+        encode_name(rbml_w, item.name);
         encode_path(rbml_w, path);
         encode_visibility(rbml_w, vis);
         encode_stability(rbml_w, stab);
@@ -1106,7 +1106,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         encode_family(rbml_w, 't');
         encode_item_variances(rbml_w, ecx, item.id);
         encode_bounds_and_type_for_item(rbml_w, ecx, item.id);
-        encode_name(rbml_w, item.ident.name);
+        encode_name(rbml_w, item.name);
         encode_attributes(rbml_w, &item.attrs);
         encode_repr_attrs(rbml_w, ecx, &item.attrs);
         for v in &enum_definition.variants {
@@ -1146,7 +1146,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         encode_bounds_and_type_for_item(rbml_w, ecx, item.id);
 
         encode_item_variances(rbml_w, ecx, item.id);
-        encode_name(rbml_w, item.ident.name);
+        encode_name(rbml_w, item.name);
         encode_attributes(rbml_w, &item.attrs);
         encode_path(rbml_w, path.clone());
         encode_stability(rbml_w, stab);
@@ -1168,7 +1168,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         // If this is a tuple-like struct, encode the type of the constructor.
         match struct_def.ctor_id {
             Some(ctor_id) => {
-                encode_info_for_struct_ctor(ecx, rbml_w, item.ident.name,
+                encode_info_for_struct_ctor(ecx, rbml_w, item.name,
                                             ctor_id, index, def_id.node);
             }
             None => {}
@@ -1179,7 +1179,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
           rbml_w.start_tag(tag_items_data_item);
           encode_def_id(rbml_w, def_id);
           encode_family(rbml_w, 'd');
-          encode_name(rbml_w, item.ident.name);
+          encode_name(rbml_w, item.name);
           encode_unsafety(rbml_w, unsafety);
 
           let trait_ref = tcx.impl_trait_ref(DefId::local(item.id)).unwrap();
@@ -1197,7 +1197,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         encode_def_id(rbml_w, def_id);
         encode_family(rbml_w, 'i');
         encode_bounds_and_type_for_item(rbml_w, ecx, item.id);
-        encode_name(rbml_w, item.ident.name);
+        encode_name(rbml_w, item.name);
         encode_attributes(rbml_w, &item.attrs);
         encode_unsafety(rbml_w, unsafety);
         encode_polarity(rbml_w, polarity);
@@ -1306,7 +1306,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         encode_predicates(rbml_w, ecx, &tcx.lookup_super_predicates(def_id),
                           tag_item_super_predicates);
         encode_trait_ref(rbml_w, ecx, trait_def.trait_ref, tag_item_trait_ref);
-        encode_name(rbml_w, item.ident.name);
+        encode_name(rbml_w, item.name);
         encode_attributes(rbml_w, &item.attrs);
         encode_visibility(rbml_w, vis);
         encode_stability(rbml_w, stab);
@@ -1483,7 +1483,7 @@ fn encode_info_for_foreign_item(ecx: &EncodeContext,
       hir::ForeignItemFn(ref fndecl, _) => {
         encode_family(rbml_w, FN_FAMILY);
         encode_bounds_and_type_for_item(rbml_w, ecx, nitem.id);
-        encode_name(rbml_w, nitem.ident.name);
+        encode_name(rbml_w, nitem.name);
         if abi == abi::RustIntrinsic || abi == abi::PlatformIntrinsic {
             encode_inlined_item(ecx, rbml_w, InlinedItemRef::Foreign(nitem));
         }
@@ -1504,7 +1504,7 @@ fn encode_info_for_foreign_item(ecx: &EncodeContext,
         let stab = stability::lookup(ecx.tcx, DefId::local(nitem.id));
         encode_stability(rbml_w, stab);
         encode_symbol(ecx, rbml_w, nitem.id);
-        encode_name(rbml_w, nitem.ident.name);
+        encode_name(rbml_w, nitem.name);
       }
     }
     encode_path(rbml_w, path);
@@ -1528,7 +1528,7 @@ fn my_visit_foreign_item(ni: &hir::ForeignItem,
                          index: &mut Vec<IndexEntry>) {
     debug!("writing foreign item {}::{}",
             ecx.tcx.map.path_to_string(ni.id),
-            ni.ident);
+            ni.name);
 
     let abi = ecx.tcx.map.get_foreign_abi(ni.id);
     ecx.tcx.map.with_path(ni.id, |path| {

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -155,16 +155,16 @@ pub fn decode_inlined_item<'tcx>(cdata: &cstore::crate_metadata,
         let raw_ii = decode_ast(ast_doc);
         let ii = ast_map::map_decoded_item(&dcx.tcx.map, path, raw_ii, dcx);
 
-        let ident = match *ii {
-            InlinedItem::Item(ref i) => i.ident,
-            InlinedItem::Foreign(ref i) => i.ident,
-            InlinedItem::TraitItem(_, ref ti) => ti.ident,
-            InlinedItem::ImplItem(_, ref ii) => ii.ident
+        let name = match *ii {
+            InlinedItem::Item(ref i) => i.name,
+            InlinedItem::Foreign(ref i) => i.name,
+            InlinedItem::TraitItem(_, ref ti) => ti.name,
+            InlinedItem::ImplItem(_, ref ii) => ii.name
         };
-        debug!("Fn named: {}", ident);
+        debug!("Fn named: {}", name);
         debug!("< Decoded inlined fn: {}::{}",
                path_as_str.unwrap(),
-               ident);
+               name);
         region::resolve_inlined_item(&tcx.sess, &tcx.region_maps, ii);
         decode_side_tables(dcx, ast_doc);
         match *ii {

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -526,7 +526,7 @@ fn construct_witness<'a,'tcx>(cx: &MatchCheckCtxt<'a,'tcx>, ctor: &Constructor,
                     .map(|(field, pat)| Spanned {
                         span: DUMMY_SP,
                         node: hir::FieldPat {
-                            ident: ast::Ident::new(field.name),
+                            name: field.name,
                             pat: pat,
                             is_shorthand: false,
                         }
@@ -910,7 +910,7 @@ pub fn specialize<'a>(cx: &MatchCheckCtxt, r: &[&'a Pat],
             let def_variant = adt.variant_of_def(def);
             if variant.did == def_variant.did {
                 Some(variant.fields.iter().map(|sf| {
-                    match pattern_fields.iter().find(|f| f.node.ident.name == sf.name) {
+                    match pattern_fields.iter().find(|f| f.node.name == sf.name) {
                         Some(ref f) => &*f.node.pat,
                         _ => DUMMY_WILD_PAT
                     }

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -1109,7 +1109,7 @@ fn resolve_trait_associated_const<'a, 'tcx: 'a>(tcx: &'a ty::ctxt<'tcx>,
     match selection {
         traits::VtableImpl(ref impl_data) => {
             match tcx.associated_consts(impl_data.impl_def_id)
-                     .iter().find(|ic| ic.name == ti.ident.name) {
+                     .iter().find(|ic| ic.name == ti.name) {
                 Some(ic) => lookup_const_by_id(tcx, ic.def_id, None),
                 None => match ti.node {
                     hir::ConstTraitItem(_, Some(ref expr)) => Some(&*expr),

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -314,7 +314,7 @@ pub fn const_expr_to_pat(tcx: &ty::ctxt, expr: &Expr, span: Span) -> P<hir::Pat>
             let field_pats = fields.iter().map(|field| codemap::Spanned {
                 span: codemap::DUMMY_SP,
                 node: hir::FieldPat {
-                    ident: field.ident.node,
+                    ident: ast::Ident::new(field.name.node),
                     pat: const_expr_to_pat(tcx, &*field.expr, span),
                     is_shorthand: false,
                 },
@@ -1040,8 +1040,8 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
                 if let hir::ExprStruct(_, ref fields, _) = tcx.map.expect_expr(struct_id).node {
                     // Check that the given field exists and evaluate it
                     // if the idents are compared run-pass/issue-19244 fails
-                    if let Some(f) = fields.iter().find(|f| f.ident.node.name
-                                                         == field_name.node.name) {
+                    if let Some(f) = fields.iter().find(|f| f.name.node
+                                                         == field_name.node) {
                         return eval_const_expr_partial(tcx, &*f.expr, base_hint)
                     } else {
                         signal!(e, MissingStructField);

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -314,7 +314,7 @@ pub fn const_expr_to_pat(tcx: &ty::ctxt, expr: &Expr, span: Span) -> P<hir::Pat>
             let field_pats = fields.iter().map(|field| codemap::Spanned {
                 span: codemap::DUMMY_SP,
                 node: hir::FieldPat {
-                    ident: ast::Ident::new(field.name.node),
+                    name: field.name.node,
                     pat: const_expr_to_pat(tcx, &*field.expr, span),
                     is_shorthand: false,
                 },

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -137,7 +137,7 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
             if let hir::PatWild(hir::PatWildSingle) = pat.node.pat.node {
                 continue;
             }
-            self.live_symbols.insert(variant.field_named(pat.node.ident.name).did.node);
+            self.live_symbols.insert(variant.field_named(pat.node.name).did.node);
         }
     }
 
@@ -443,7 +443,7 @@ impl<'a, 'tcx> DeadVisitor<'a, 'tcx> {
     }
 
     fn should_warn_about_field(&mut self, node: &hir::StructField_) -> bool {
-        let is_named = node.ident().is_some();
+        let is_named = node.name().is_some();
         let field_type = self.tcx.node_id_to_type(node.id);
         let is_marker_field = match field_type.ty_to_def_id() {
             Some(def_id) => self.tcx.lang_items.items().any(|(_, item)| *item == Some(def_id)),
@@ -529,7 +529,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for DeadVisitor<'a, 'tcx> {
                     for variant in &enum_def.variants {
                         if self.should_warn_about_variant(&variant.node) {
                             self.warn_dead_code(variant.node.id, variant.span,
-                                                variant.node.name.name, "variant");
+                                                variant.node.name, "variant");
                         }
                     }
                 },
@@ -549,7 +549,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for DeadVisitor<'a, 'tcx> {
     fn visit_struct_field(&mut self, field: &hir::StructField) {
         if self.should_warn_about_field(&field.node) {
             self.warn_dead_code(field.node.id, field.span,
-                                field.node.ident().unwrap().name, "struct field");
+                                field.node.name().unwrap(), "struct field");
         }
 
         visit::walk_struct_field(self, field);

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -520,7 +520,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for DeadVisitor<'a, 'tcx> {
             self.warn_dead_code(
                 item.id,
                 item.span,
-                item.ident.name,
+                item.name,
                 item.node.descriptive_variant()
             );
         } else {
@@ -541,7 +541,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for DeadVisitor<'a, 'tcx> {
 
     fn visit_foreign_item(&mut self, fi: &hir::ForeignItem) {
         if !self.symbol_is_live(fi.id, None) {
-            self.warn_dead_code(fi.id, fi.span, fi.ident.name, fi.node.descriptive_variant());
+            self.warn_dead_code(fi.id, fi.span, fi.name, fi.node.descriptive_variant());
         }
         visit::walk_foreign_item(self, fi);
     }
@@ -560,14 +560,14 @@ impl<'a, 'tcx, 'v> Visitor<'v> for DeadVisitor<'a, 'tcx> {
             hir::ConstImplItem(_, ref expr) => {
                 if !self.symbol_is_live(impl_item.id, None) {
                     self.warn_dead_code(impl_item.id, impl_item.span,
-                                        impl_item.ident.name, "associated const");
+                                        impl_item.name, "associated const");
                 }
                 visit::walk_expr(self, expr)
             }
             hir::MethodImplItem(_, ref body) => {
                 if !self.symbol_is_live(impl_item.id, None) {
                     self.warn_dead_code(impl_item.id, impl_item.span,
-                                        impl_item.ident.name, "method");
+                                        impl_item.name, "method");
                 }
                 visit::walk_block(self, body)
             }

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -227,8 +227,8 @@ impl<'a, 'tcx, 'v> Visitor<'v> for MarkSymbolVisitor<'a, 'tcx> {
             hir::ExprMethodCall(..) => {
                 self.lookup_and_handle_method(expr.id);
             }
-            hir::ExprField(ref lhs, ref ident) => {
-                self.handle_field_access(&**lhs, ident.node.name);
+            hir::ExprField(ref lhs, ref name) => {
+                self.handle_field_access(&**lhs, name.node);
             }
             hir::ExprTupField(ref lhs, idx) => {
                 self.handle_tup_field_access(&**lhs, idx.node);

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -207,7 +207,7 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
 
 impl<'a, 'tcx, 'v> Visitor<'v> for MarkSymbolVisitor<'a, 'tcx> {
 
-    fn visit_struct_def(&mut self, def: &hir::StructDef, _: ast::Ident,
+    fn visit_struct_def(&mut self, def: &hir::StructDef, _: ast::Name,
                         _: &hir::Generics, _: ast::NodeId) {
         let has_extern_repr = self.struct_has_extern_repr;
         let inherited_pub_visibility = self.inherited_pub_visibility;

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -85,7 +85,7 @@ fn entry_point_type(item: &Item, depth: usize) -> EntryPointType {
                 EntryPointType::Start
             } else if attr::contains_name(&item.attrs, "main") {
                 EntryPointType::MainAttr
-            } else if item.ident.name == "main" {
+            } else if item.name == "main" {
                 if depth == 1 {
                     // This is a top-level function so can be 'main'
                     EntryPointType::MainNamed

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -710,7 +710,7 @@ impl<'d,'t,'a,'tcx> ExprUseVisitor<'d,'t,'a,'tcx> {
                                 -> bool
         {
             fields.iter().any(
-                |f| f.ident.node.name == field.name)
+                |f| f.name.node == field.name)
         }
     }
 

--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -284,7 +284,7 @@ trait ErrorReportingHelpers<'tcx> {
                                 decl: &hir::FnDecl,
                                 unsafety: hir::Unsafety,
                                 constness: hir::Constness,
-                                ident: ast::Ident,
+                                name: ast::Name,
                                 opt_explicit_self: Option<&hir::ExplicitSelf_>,
                                 generics: &hir::Generics,
                                 span: Span);
@@ -978,7 +978,7 @@ impl<'a, 'tcx> ErrorReporting<'tcx> for InferCtxt<'a, 'tcx> {
                     match item.node {
                         hir::ItemFn(ref fn_decl, unsafety, constness, _, ref gen, _) => {
                             Some((fn_decl, gen, unsafety, constness,
-                                  item.ident, None, item.span))
+                                  item.name, None, item.span))
                         },
                         _ => None
                     }
@@ -990,7 +990,7 @@ impl<'a, 'tcx> ErrorReporting<'tcx> for InferCtxt<'a, 'tcx> {
                                   &sig.generics,
                                   sig.unsafety,
                                   sig.constness,
-                                  item.ident,
+                                  item.name,
                                   Some(&sig.explicit_self.node),
                                   item.span))
                         }
@@ -1004,7 +1004,7 @@ impl<'a, 'tcx> ErrorReporting<'tcx> for InferCtxt<'a, 'tcx> {
                                   &sig.generics,
                                   sig.unsafety,
                                   sig.constness,
-                                  item.ident,
+                                  item.name,
                                   Some(&sig.explicit_self.node),
                                   item.span))
                         }
@@ -1576,11 +1576,11 @@ impl<'a, 'tcx> ErrorReportingHelpers<'tcx> for InferCtxt<'a, 'tcx> {
                                 decl: &hir::FnDecl,
                                 unsafety: hir::Unsafety,
                                 constness: hir::Constness,
-                                ident: ast::Ident,
+                                name: ast::Name,
                                 opt_explicit_self: Option<&hir::ExplicitSelf_>,
                                 generics: &hir::Generics,
                                 span: Span) {
-        let suggested_fn = pprust::fun_to_string(decl, unsafety, constness, ident,
+        let suggested_fn = pprust::fun_to_string(decl, unsafety, constness, name,
                                                  opt_explicit_self, generics);
         let msg = format!("consider using an explicit lifetime \
                            parameter as shown: {}", suggested_fn);

--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -1198,7 +1198,7 @@ impl<'a, 'tcx> Rebuilder<'a, 'tcx> {
                                                       lifetime,
                                                       region_names);
             hir::TyParam {
-                ident: ty_param.ident,
+                name: ty_param.name,
                 id: ty_param.id,
                 bounds: bounds,
                 default: ty_param.default.clone(),
@@ -1541,7 +1541,7 @@ impl<'a, 'tcx> Rebuilder<'a, 'tcx> {
                 let new_bindings = data.bindings.map(|b| {
                     P(hir::TypeBinding {
                         id: b.id,
-                        ident: b.ident,
+                        name: b.name,
                         ty: self.rebuild_arg_ty_or_output(&*b.ty,
                                                           lifetime,
                                                           anon_nums,

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -474,7 +474,7 @@ impl<'t, 'a,'tcx> MemCategorizationContext<'t, 'a, 'tcx> {
                    expr.id,
                    expr,
                    base_cmt);
-            Ok(self.cat_field(expr, base_cmt, f_name.node.name, expr_ty))
+            Ok(self.cat_field(expr, base_cmt, f_name.node, expr_ty))
           }
 
           hir::ExprTupField(ref base, idx) => {

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -1272,7 +1272,7 @@ impl<'t, 'a,'tcx> MemCategorizationContext<'t, 'a, 'tcx> {
             // {f1: p1, ..., fN: pN}
             for fp in field_pats {
                 let field_ty = try!(self.pat_ty(&*fp.node.pat)); // see (*2)
-                let cmt_field = self.cat_field(pat, cmt.clone(), fp.node.ident.name, field_ty);
+                let cmt_field = self.cat_field(pat, cmt.clone(), fp.node.name, field_ty);
                 try!(self.cat_pattern_(cmt_field, &*fp.node.pat, op));
             }
           }

--- a/src/librustc/middle/pat_util.rs
+++ b/src/librustc/middle/pat_util.rs
@@ -16,7 +16,7 @@ use util::nodemap::FnvHashMap;
 use syntax::ast;
 use rustc_front::hir;
 use rustc_front::util::walk_pat;
-use syntax::codemap::{Span, DUMMY_SP};
+use syntax::codemap::{Span, Spanned, DUMMY_SP};
 
 pub type PatIdMap = FnvHashMap<ast::Ident, ast::NodeId>;
 
@@ -109,7 +109,7 @@ pub fn pat_is_binding_or_wild(dm: &DefMap, pat: &hir::Pat) -> bool {
 /// Call `it` on every "binding" in a pattern, e.g., on `a` in
 /// `match foo() { Some(a) => (), None => () }`
 pub fn pat_bindings<I>(dm: &DefMap, pat: &hir::Pat, mut it: I) where
-    I: FnMut(hir::BindingMode, ast::NodeId, Span, &hir::SpannedIdent),
+    I: FnMut(hir::BindingMode, ast::NodeId, Span, &Spanned<ast::Ident>),
 {
     walk_pat(pat, |p| {
         match p.node {

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -418,7 +418,7 @@ pub fn check_expr(tcx: &ty::ctxt, e: &hir::Expr,
         hir::ExprField(ref base_e, ref field) => {
             span = field.span;
             match tcx.expr_ty_adjusted(base_e).sty {
-                ty::TyStruct(def, _) => def.struct_variant().field_named(field.node.name).did,
+                ty::TyStruct(def, _) => def.struct_variant().field_named(field.node).did,
                 _ => tcx.sess.span_bug(e.span,
                                        "stability::check_expr: named field access on non-struct")
             }
@@ -441,7 +441,7 @@ pub fn check_expr(tcx: &ty::ctxt, e: &hir::Expr,
                     // in the construction expression.
                     for field in expr_fields {
                         let did = def.struct_variant()
-                            .field_named(field.ident.node.name)
+                            .field_named(field.name.node)
                             .did;
                         maybe_do_stability_check(tcx, did, field.span, cb);
                     }

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -336,7 +336,7 @@ impl<'a, 'v, 'tcx> Visitor<'v> for Checker<'a, 'tcx> {
         // When compiling with --test we don't enforce stability on the
         // compiler-generated test module, demarcated with `DUMMY_SP` plus the
         // name `__test`
-        if item.span == DUMMY_SP && item.ident.name == "__test" { return }
+        if item.span == DUMMY_SP && item.name == "__test" { return }
 
         check_item(self.tcx, item, true,
                    &mut |id, sp, stab| self.check(id, sp, stab));
@@ -393,7 +393,7 @@ pub fn check_item(tcx: &ty::ctxt, item: &hir::Item, warn_about_defns: bool,
 
             for impl_item in impl_items {
                 let item = trait_items.iter().find(|item| {
-                    item.name() == impl_item.ident.name
+                    item.name() == impl_item.name
                 }).unwrap();
                 if warn_about_defns {
                     maybe_do_stability_check(tcx, item.def_id(), impl_item.span, cb);

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -513,7 +513,7 @@ pub fn check_pat(tcx: &ty::ctxt, pat: &hir::Pat,
         // Foo { a, b, c }
         hir::PatStruct(_, ref pat_fields, _) => {
             for field in pat_fields {
-                let did = v.field_named(field.node.ident.name).did;
+                let did = v.field_named(field.node.name).did;
                 maybe_do_stability_check(tcx, did, field.span, cb);
             }
         }

--- a/src/librustc_back/svh.rs
+++ b/src/librustc_back/svh.rs
@@ -270,7 +270,7 @@ mod svh_visitor {
             ExprBlock(..)            => SawExprBlock,
             ExprAssign(..)           => SawExprAssign,
             ExprAssignOp(op, _, _)   => SawExprAssignOp(op.node),
-            ExprField(_, id)         => SawExprField(id.node.name.as_str()),
+            ExprField(_, name)       => SawExprField(name.node.as_str()),
             ExprTupField(_, id)      => SawExprTupField(id.node),
             ExprIndex(..)            => SawExprIndex,
             ExprRange(..)            => SawExprRange,

--- a/src/librustc_back/svh.rs
+++ b/src/librustc_back/svh.rs
@@ -131,7 +131,7 @@ mod svh_visitor {
     pub use self::SawExprComponent::*;
     pub use self::SawStmtComponent::*;
     use self::SawAbiComponent::*;
-    use syntax::ast::{self, NodeId, Ident};
+    use syntax::ast::{self, Name, NodeId};
     use syntax::codemap::Span;
     use syntax::parse::token;
     use rustc_front::visit;
@@ -302,9 +302,9 @@ mod svh_visitor {
     }
 
     impl<'a, 'v> Visitor<'v> for StrictVersionHashVisitor<'a> {
-        fn visit_struct_def(&mut self, s: &StructDef, ident: Ident,
+        fn visit_struct_def(&mut self, s: &StructDef, name: Name,
                             g: &Generics, _: NodeId) {
-            SawStructDef(ident.name.as_str()).hash(self.st);
+            SawStructDef(name.as_str()).hash(self.st);
             visit::walk_generics(self, g);
             visit::walk_struct_def(self, s)
         }
@@ -341,8 +341,8 @@ mod svh_visitor {
         // (If you edit a method such that it deviates from the
         // pattern, please move that method up above this comment.)
 
-        fn visit_ident(&mut self, _: Span, ident: Ident) {
-            SawIdent(ident.name.as_str()).hash(self.st);
+        fn visit_name(&mut self, _: Span, name: Name) {
+            SawIdent(name.as_str()).hash(self.st);
         }
 
         fn visit_lifetime_ref(&mut self, l: &Lifetime) {

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -195,7 +195,7 @@ impl<'a, 'tcx> Env<'a, 'tcx> {
                       -> Option<ast::NodeId> {
             assert!(idx < names.len());
             for item in &m.items {
-                if item.ident.to_string() == names[idx] {
+                if item.name.to_string() == names[idx] {
                     return search(this, &**item, idx+1, names);
                 }
             }

--- a/src/librustc_front/fold.rs
+++ b/src/librustc_front/fold.rs
@@ -837,9 +837,9 @@ pub fn noop_fold_item_underscore<T: Folder>(i: Item_, folder: &mut T) -> Item_ {
 
 pub fn noop_fold_trait_item<T: Folder>(i: P<TraitItem>, folder: &mut T)
                                        -> SmallVector<P<TraitItem>> {
-    SmallVector::one(i.map(|TraitItem {id, ident, attrs, node, span}| TraitItem {
+    SmallVector::one(i.map(|TraitItem {id, name, attrs, node, span}| TraitItem {
         id: folder.new_id(id),
-        ident: fold_ident(folder, ident),
+        name: folder.fold_name(name),
         attrs: fold_attrs(attrs, folder),
         node: match node {
             ConstTraitItem(ty, default) => {
@@ -861,9 +861,9 @@ pub fn noop_fold_trait_item<T: Folder>(i: P<TraitItem>, folder: &mut T)
 
 pub fn noop_fold_impl_item<T: Folder>(i: P<ImplItem>, folder: &mut T)
                                       -> SmallVector<P<ImplItem>> {
-    SmallVector::one(i.map(|ImplItem {id, ident, attrs, node, vis, span}| ImplItem {
+    SmallVector::one(i.map(|ImplItem {id, name, attrs, node, vis, span}| ImplItem {
         id: folder.new_id(id),
-        ident: fold_ident(folder, ident),
+        name: folder.fold_name(name),
         attrs: fold_attrs(attrs, folder),
         vis: vis,
         node: match node  {
@@ -892,7 +892,7 @@ pub fn noop_fold_crate<T: Folder>(Crate {module, attrs, config, span, exported_m
     let config = folder.fold_meta_items(config);
 
     let mut items = folder.fold_item(P(hir::Item {
-        ident: token::special_idents::invalid,
+        name: token::special_idents::invalid.name,
         attrs: attrs,
         id: DUMMY_NODE_ID,
         vis: hir::Public,
@@ -932,7 +932,7 @@ pub fn noop_fold_item<T: Folder>(i: P<Item>, folder: &mut T) -> SmallVector<P<It
 }
 
 // fold one item into exactly one item
-pub fn noop_fold_item_simple<T: Folder>(Item {id, ident, attrs, node, vis, span}: Item,
+pub fn noop_fold_item_simple<T: Folder>(Item {id, name, attrs, node, vis, span}: Item,
                                         folder: &mut T) -> Item {
     let id = folder.new_id(id);
     let node = folder.fold_item_underscore(node);
@@ -947,7 +947,7 @@ pub fn noop_fold_item_simple<T: Folder>(Item {id, ident, attrs, node, vis, span}
 
     Item {
         id: id,
-        ident: fold_ident(folder, ident),
+        name: folder.fold_name(name),
         attrs: fold_attrs(attrs, folder),
         node: node,
         vis: vis,
@@ -956,9 +956,9 @@ pub fn noop_fold_item_simple<T: Folder>(Item {id, ident, attrs, node, vis, span}
 }
 
 pub fn noop_fold_foreign_item<T: Folder>(ni: P<ForeignItem>, folder: &mut T) -> P<ForeignItem> {
-    ni.map(|ForeignItem {id, ident, attrs, node, span, vis}| ForeignItem {
+    ni.map(|ForeignItem {id, name, attrs, node, span, vis}| ForeignItem {
         id: folder.new_id(id),
-        ident: fold_ident(folder, ident),
+        name: folder.fold_name(name),
         attrs: fold_attrs(attrs, folder),
         node: match node {
             ForeignItemFn(fdec, generics) => {

--- a/src/librustc_front/fold.rs
+++ b/src/librustc_front/fold.rs
@@ -355,9 +355,9 @@ pub fn noop_fold_decl<T: Folder>(d: P<Decl>, fld: &mut T) -> SmallVector<P<Decl>
 }
 
 pub fn noop_fold_ty_binding<T: Folder>(b: P<TypeBinding>, fld: &mut T) -> P<TypeBinding> {
-    b.map(|TypeBinding { id, ident, ty, span }| TypeBinding {
+    b.map(|TypeBinding { id, name, ty, span }| TypeBinding {
         id: fld.new_id(id),
-        ident: ident,
+        name: name,
         ty: fld.fold_ty(ty),
         span: fld.new_span(span),
     })
@@ -576,10 +576,10 @@ pub fn noop_fold_ty_param_bound<T>(tpb: TyParamBound, fld: &mut T)
 }
 
 pub fn noop_fold_ty_param<T: Folder>(tp: TyParam, fld: &mut T) -> TyParam {
-    let TyParam {id, ident, bounds, default, span} = tp;
+    let TyParam {id, name, bounds, default, span} = tp;
     TyParam {
         id: fld.new_id(id),
-        ident: ident,
+        name: name,
         bounds: fld.fold_bounds(bounds),
         default: default.map(|x| fld.fold_ty(x)),
         span: span
@@ -1009,7 +1009,7 @@ pub fn noop_fold_pat<T: Folder>(p: P<Pat>, folder: &mut T) -> P<Pat> {
                 let fs = fields.move_map(|f| {
                     Spanned { span: folder.new_span(f.span),
                               node: hir::FieldPat {
-                                  ident: f.node.ident,
+                                  name: f.node.name,
                                   pat: folder.fold_pat(f.node.pat),
                                   is_shorthand: f.node.is_shorthand,
                               }}

--- a/src/librustc_front/fold.rs
+++ b/src/librustc_front/fold.rs
@@ -721,9 +721,9 @@ pub fn noop_fold_struct_field<T: Folder>(f: StructField, fld: &mut T) -> StructF
     }
 }
 
-pub fn noop_fold_field<T: Folder>(Field {ident, expr, span}: Field, folder: &mut T) -> Field {
+pub fn noop_fold_field<T: Folder>(Field {name, expr, span}: Field, folder: &mut T) -> Field {
     Field {
-        ident: respan(ident.span, fold_ident(folder, ident.node)),
+        name: respan(folder.new_span(name.span), folder.fold_name(name.node)),
         expr: folder.fold_expr(expr),
         span: folder.new_span(span)
     }
@@ -1050,9 +1050,9 @@ pub fn noop_fold_expr<T: Folder>(Expr {id, node, span}: Expr, folder: &mut T) ->
                 ExprCall(folder.fold_expr(f),
                          args.move_map(|x| folder.fold_expr(x)))
             }
-            ExprMethodCall(i, tps, args) => {
+            ExprMethodCall(name, tps, args) => {
                 ExprMethodCall(
-                    respan(folder.new_span(i.span), fold_ident(folder, i.node)),
+                    respan(folder.new_span(name.span), folder.fold_name(name.node)),
                     tps.move_map(|x| folder.fold_ty(x)),
                     args.move_map(|x| folder.fold_expr(x)))
             }
@@ -1102,10 +1102,10 @@ pub fn noop_fold_expr<T: Folder>(Expr {id, node, span}: Expr, folder: &mut T) ->
                             folder.fold_expr(el),
                             folder.fold_expr(er))
             }
-            ExprField(el, ident) => {
+            ExprField(el, name) => {
                 ExprField(folder.fold_expr(el),
-                          respan(folder.new_span(ident.span),
-                                 fold_ident(folder, ident.node)))
+                          respan(folder.new_span(name.span),
+                                 folder.fold_name(name.node)))
             }
             ExprTupField(el, ident) => {
                 ExprTupField(folder.fold_expr(el),

--- a/src/librustc_front/hir.rs
+++ b/src/librustc_front/hir.rs
@@ -333,11 +333,11 @@ pub struct Crate {
 /// Not parsed directly, but created on macro import or `macro_rules!` expansion.
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct MacroDef {
-    pub ident: Ident,
+    pub name: Name,
     pub attrs: Vec<Attribute>,
     pub id: NodeId,
     pub span: Span,
-    pub imported_from: Option<Ident>,
+    pub imported_from: Option<Name>,
     pub export: bool,
     pub use_locally: bool,
     pub allow_internal_unstable: bool,
@@ -1039,14 +1039,14 @@ pub type Variant = Spanned<Variant_>;
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
 pub enum PathListItem_ {
     PathListIdent {
-        name: Ident,
+        name: Name,
         /// renamed in list, eg `use foo::{bar as baz};`
-        rename: Option<Ident>,
+        rename: Option<Name>,
         id: NodeId
     },
     PathListMod {
         /// renamed in list, eg `use foo::{self as baz};`
-        rename: Option<Ident>,
+        rename: Option<Name>,
         id: NodeId
     }
 }
@@ -1058,7 +1058,7 @@ impl PathListItem_ {
         }
     }
 
-    pub fn rename(&self) -> Option<Ident> {
+    pub fn rename(&self) -> Option<Name> {
         match *self {
             PathListIdent { rename, .. } | PathListMod { rename, .. } => rename
         }
@@ -1077,7 +1077,7 @@ pub enum ViewPath_ {
     /// or just
     ///
     /// `foo::bar::baz` (with `as baz` implicitly on the right)
-    ViewPathSimple(Ident, Path),
+    ViewPathSimple(Name, Path),
 
     /// `foo::bar::*`
     ViewPathGlob(Path),

--- a/src/librustc_front/hir.rs
+++ b/src/librustc_front/hir.rs
@@ -770,7 +770,7 @@ pub struct MethodSig {
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct TraitItem {
     pub id: NodeId,
-    pub ident: Ident,
+    pub name: Name,
     pub attrs: Vec<Attribute>,
     pub node: TraitItem_,
     pub span: Span,
@@ -786,7 +786,7 @@ pub enum TraitItem_ {
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct ImplItem {
     pub id: NodeId,
-    pub ident: Ident,
+    pub name: Name,
     pub vis: Visibility,
     pub attrs: Vec<Attribute>,
     pub node: ImplItem_,
@@ -1190,7 +1190,7 @@ pub struct StructDef {
 /// The name might be a dummy name in case of anonymous items
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct Item {
-    pub ident: Ident,
+    pub name: Name,
     pub attrs: Vec<Attribute>,
     pub id: NodeId,
     pub node: Item_,
@@ -1264,7 +1264,7 @@ impl Item_ {
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct ForeignItem {
-    pub ident: Ident,
+    pub name: Name,
     pub attrs: Vec<Attribute>,
     pub node: ForeignItem_,
     pub id: NodeId,

--- a/src/librustc_front/hir.rs
+++ b/src/librustc_front/hir.rs
@@ -52,10 +52,6 @@ use util;
 use std::fmt;
 use serialize::{Encodable, Encoder, Decoder};
 
-
-/// Function name (not all functions have names)
-pub type FnIdent = Option<Ident>;
-
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Copy)]
 pub struct Lifetime {
     pub id: NodeId,
@@ -416,7 +412,7 @@ pub enum Pat_ {
     /// which it is. The resolver determines this, and
     /// records this pattern's NodeId in an auxiliary
     /// set (of "PatIdents that refer to nullary enums")
-    PatIdent(BindingMode, SpannedIdent, Option<P<Pat>>),
+    PatIdent(BindingMode, Spanned<Ident>, Option<P<Pat>>),
 
     /// "None" means a * pattern where we don't bind the fields to names.
     PatEnum(Path, Option<Vec<P<Pat>>>),
@@ -564,12 +560,10 @@ pub struct Arm {
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct Field {
-    pub ident: SpannedIdent,
+    pub name: Spanned<Name>,
     pub expr: P<Expr>,
     pub span: Span,
 }
-
-pub type SpannedIdent = Spanned<Ident>;
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
 pub enum BlockCheckMode {
@@ -612,7 +606,7 @@ pub enum Expr_ {
     ExprCall(P<Expr>, Vec<P<Expr>>),
     /// A method call (`x.foo::<Bar, Baz>(a, b, c, d)`)
     ///
-    /// The `SpannedIdent` is the identifier for the method name.
+    /// The `Spanned<Name>` is the identifier for the method name.
     /// The vector of `Ty`s are the ascripted type parameters for the method
     /// (within the angle brackets).
     ///
@@ -622,7 +616,7 @@ pub enum Expr_ {
     ///
     /// Thus, `x.foo::<Bar, Baz>(a, b, c, d)` is represented as
     /// `ExprMethodCall(foo, [Bar, Baz], [x, a, b, c, d])`.
-    ExprMethodCall(SpannedIdent, Vec<P<Ty>>, Vec<P<Expr>>),
+    ExprMethodCall(Spanned<Name>, Vec<P<Ty>>, Vec<P<Expr>>),
     /// A tuple (`(a, b, c ,d)`)
     ExprTup(Vec<P<Expr>>),
     /// A binary operation (For example: `a + b`, `a * b`)
@@ -662,7 +656,7 @@ pub enum Expr_ {
     /// For example, `a += 1`.
     ExprAssignOp(BinOp, P<Expr>, P<Expr>),
     /// Access of a named struct field (`obj.foo`)
-    ExprField(P<Expr>, SpannedIdent),
+    ExprField(P<Expr>, Spanned<Name>),
     /// Access of an unnamed field of a struct or tuple-struct
     ///
     /// For example, `foo.0`.
@@ -682,9 +676,9 @@ pub enum Expr_ {
     /// A referencing operation (`&a` or `&mut a`)
     ExprAddrOf(Mutability, P<Expr>),
     /// A `break`, with an optional label to break
-    ExprBreak(Option<SpannedIdent>),
+    ExprBreak(Option<Spanned<Ident>>),
     /// A `continue`, with an optional label
-    ExprAgain(Option<SpannedIdent>),
+    ExprAgain(Option<Spanned<Ident>>),
     /// A `return`, with an optional value to be returned
     ExprRet(Option<P<Expr>>),
 
@@ -742,13 +736,6 @@ pub enum CaptureClause {
 pub struct MutTy {
     pub ty: P<Ty>,
     pub mutbl: Mutability,
-}
-
-#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
-pub struct TypeField {
-    pub ident: Ident,
-    pub mt: MutTy,
-    pub span: Span,
 }
 
 /// Represents a method's signature in a trait declaration,

--- a/src/librustc_front/hir.rs
+++ b/src/librustc_front/hir.rs
@@ -244,7 +244,7 @@ pub type TyParamBounds = OwnedSlice<TyParamBound>;
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct TyParam {
-    pub ident: Ident,
+    pub name: Name,
     pub id: NodeId,
     pub bounds: TyParamBounds,
     pub default: Option<P<Ty>>,
@@ -378,7 +378,7 @@ impl fmt::Debug for Pat {
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct FieldPat {
     /// The identifier for the field
-    pub ident: Ident,
+    pub name: Name,
     /// The pattern the field is destructured to
     pub pat: P<Pat>,
     pub is_shorthand: bool,
@@ -791,7 +791,7 @@ pub enum ImplItem_ {
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct TypeBinding {
     pub id: NodeId,
-    pub ident: Ident,
+    pub name: Name,
     pub ty: P<Ty>,
     pub span: Span,
 }
@@ -981,11 +981,11 @@ pub enum ExplicitSelf_ {
     /// No self
     SelfStatic,
     /// `self`
-    SelfValue(Ident),
+    SelfValue(Name),
     /// `&'lt self`, `&'lt mut self`
-    SelfRegion(Option<Lifetime>, Mutability, Ident),
+    SelfRegion(Option<Lifetime>, Mutability, Name),
     /// `self: TYPE`
-    SelfExplicit(P<Ty>, Ident),
+    SelfExplicit(P<Ty>, Name),
 }
 
 pub type ExplicitSelf = Spanned<ExplicitSelf_>;
@@ -1026,7 +1026,7 @@ pub struct EnumDef {
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct Variant_ {
-    pub name: Ident,
+    pub name: Name,
     pub attrs: Vec<Attribute>,
     pub kind: VariantKind,
     pub id: NodeId,
@@ -1133,9 +1133,9 @@ pub struct StructField_ {
 }
 
 impl StructField_ {
-    pub fn ident(&self) -> Option<Ident> {
+    pub fn name(&self) -> Option<Name> {
         match self.kind {
-            NamedField(ref ident, _) => Some(ident.clone()),
+            NamedField(name, _) => Some(name),
             UnnamedField(_) => None
         }
     }
@@ -1145,7 +1145,7 @@ pub type StructField = Spanned<StructField_>;
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
 pub enum StructFieldKind {
-    NamedField(Ident, Visibility),
+    NamedField(Name, Visibility),
     /// Element of a tuple-like struct
     UnnamedField(Visibility),
 }

--- a/src/librustc_front/lowering.rs
+++ b/src/librustc_front/lowering.rs
@@ -466,7 +466,7 @@ pub fn lower_item_underscore(i: &Item_) -> hir::Item_ {
 pub fn lower_trait_item(i: &TraitItem) -> P<hir::TraitItem> {
     P(hir::TraitItem {
             id: i.id,
-            ident: i.ident,
+            name: i.ident.name,
             attrs: i.attrs.clone(),
             node: match i.node {
             ConstTraitItem(ref ty, ref default) => {
@@ -489,7 +489,7 @@ pub fn lower_trait_item(i: &TraitItem) -> P<hir::TraitItem> {
 pub fn lower_impl_item(i: &ImplItem) -> P<hir::ImplItem> {
     P(hir::ImplItem {
             id: i.id,
-            ident: i.ident,
+            name: i.ident.name,
             attrs: i.attrs.clone(),
             vis: lower_visibility(i.vis),
             node: match i.node  {
@@ -546,7 +546,7 @@ pub fn lower_item_simple(i: &Item) -> hir::Item {
 
     hir::Item {
         id: i.id,
-        ident: i.ident,
+        name: i.ident.name,
         attrs: i.attrs.clone(),
         node: node,
         vis: lower_visibility(i.vis),
@@ -557,7 +557,7 @@ pub fn lower_item_simple(i: &Item) -> hir::Item {
 pub fn lower_foreign_item(i: &ForeignItem) -> P<hir::ForeignItem> {
     P(hir::ForeignItem {
             id: i.id,
-            ident: i.ident,
+            name: i.ident.name,
             attrs: i.attrs.clone(),
             node: match i.node {
             ForeignItemFn(ref fdec, ref generics) => {

--- a/src/librustc_front/lowering.rs
+++ b/src/librustc_front/lowering.rs
@@ -22,7 +22,7 @@ pub fn lower_view_path(view_path: &ViewPath) -> P<hir::ViewPath> {
     P(Spanned {
         node: match view_path.node {
             ViewPathSimple(ident, ref path) => {
-                hir::ViewPathSimple(ident, lower_path(path))
+                hir::ViewPathSimple(ident.name, lower_path(path))
             }
             ViewPathGlob(ref path) => {
                 hir::ViewPathGlob(lower_path(path))
@@ -35,11 +35,14 @@ pub fn lower_view_path(view_path: &ViewPath) -> P<hir::ViewPath> {
                                         PathListIdent { id, name, rename } =>
                                             hir::PathListIdent {
                                                 id: id,
-                                                name: name,
-                                                rename: rename.clone(),
+                                                name: name.name,
+                                                rename: rename.map(|x| x.name),
                                             },
                                         PathListMod { id, rename } =>
-                                            hir::PathListMod { id: id, rename: rename.clone() }
+                                            hir::PathListMod {
+                                                id: id,
+                                                rename: rename.map(|x| x.name)
+                                            }
                                     },
                                     span: path_list_ident.span
                                 }
@@ -526,11 +529,11 @@ pub fn lower_crate(c: &Crate) -> hir::Crate {
 
 pub fn lower_macro_def(m: &MacroDef) -> hir::MacroDef {
     hir::MacroDef {
-        ident: m.ident,
+        name: m.ident.name,
         attrs: m.attrs.clone(),
         id: m.id,
         span: m.span,
-        imported_from: m.imported_from,
+        imported_from: m.imported_from.map(|x| x.name),
         export: m.export,
         use_locally: m.use_locally,
         allow_internal_unstable: m.allow_internal_unstable,

--- a/src/librustc_front/lowering.rs
+++ b/src/librustc_front/lowering.rs
@@ -14,7 +14,7 @@ use hir;
 
 use syntax::ast::*;
 use syntax::ptr::P;
-use syntax::codemap::Spanned;
+use syntax::codemap::{respan, Spanned};
 use syntax::owned_slice::OwnedSlice;
 
 
@@ -370,7 +370,10 @@ pub fn lower_struct_field(f: &StructField) -> hir::StructField {
 }
 
 pub fn lower_field(f: &Field) -> hir::Field {
-    hir::Field { ident: f.ident, expr: lower_expr(&f.expr), span: f.span }
+    hir::Field {
+        name: respan(f.ident.span, f.ident.node.name),
+        expr: lower_expr(&f.expr), span: f.span
+    }
 }
 
 pub fn lower_mt(mt: &MutTy) -> hir::MutTy {
@@ -704,7 +707,7 @@ pub fn lower_expr(e: &Expr) -> P<hir::Expr> {
                 }
                 ExprMethodCall(i, ref tps, ref args) => {
                     hir::ExprMethodCall(
-                        i,
+                        respan(i.span, i.node.name),
                         tps.iter().map(|x| lower_ty(x)).collect(),
                         args.iter().map(|x| lower_expr(x)).collect())
                 }
@@ -755,7 +758,7 @@ pub fn lower_expr(e: &Expr) -> P<hir::Expr> {
                                 lower_expr(er))
                 }
                 ExprField(ref el, ident) => {
-                    hir::ExprField(lower_expr(el), ident)
+                    hir::ExprField(lower_expr(el), respan(ident.span, ident.node.name))
                 }
                 ExprTupField(ref el, ident) => {
                     hir::ExprTupField(lower_expr(el), ident)

--- a/src/librustc_front/lowering.rs
+++ b/src/librustc_front/lowering.rs
@@ -76,7 +76,7 @@ pub fn lower_decl(d: &Decl) -> P<hir::Decl> {
 }
 
 pub fn lower_ty_binding(b: &TypeBinding) -> P<hir::TypeBinding> {
-    P(hir::TypeBinding { id: b.id, ident: b.ident, ty: lower_ty(&b.ty), span: b.span })
+    P(hir::TypeBinding { id: b.id, name: b.ident.name, ty: lower_ty(&b.ty), span: b.span })
 }
 
 pub fn lower_ty(t: &Ty) -> P<hir::Ty> {
@@ -138,7 +138,7 @@ pub fn lower_variant(v: &Variant) -> P<hir::Variant> {
     P(Spanned {
         node: hir::Variant_ {
             id: v.node.id,
-            name: v.node.name,
+            name: v.node.name.name,
             attrs: v.node.attrs.clone(),
             kind: match v.node.kind {
                 TupleVariantKind(ref variant_args) => {
@@ -209,12 +209,12 @@ pub fn lower_local(l: &Local) -> P<hir::Local> {
 pub fn lower_explicit_self_underscore(es: &ExplicitSelf_) -> hir::ExplicitSelf_ {
     match *es {
         SelfStatic => hir::SelfStatic,
-        SelfValue(v) => hir::SelfValue(v),
+        SelfValue(v) => hir::SelfValue(v.name),
         SelfRegion(ref lifetime, m, ident) => {
-            hir::SelfRegion(lower_opt_lifetime(lifetime), lower_mutability(m), ident)
+            hir::SelfRegion(lower_opt_lifetime(lifetime), lower_mutability(m), ident.name)
         }
         SelfExplicit(ref typ, ident) => {
-            hir::SelfExplicit(lower_ty(typ), ident)
+            hir::SelfExplicit(lower_ty(typ), ident.name)
         }
     }
 }
@@ -258,7 +258,7 @@ pub fn lower_ty_param_bound(tpb: &TyParamBound) -> hir::TyParamBound {
 pub fn lower_ty_param(tp: &TyParam) -> hir::TyParam {
     hir::TyParam {
         id: tp.id,
-        ident: tp.ident,
+        name: tp.ident.name,
         bounds: lower_bounds(&tp.bounds),
         default: tp.default.as_ref().map(|x| lower_ty(x)),
         span: tp.span,
@@ -665,7 +665,7 @@ pub fn lower_pat(p: &Pat) -> P<hir::Pat> {
                 let fs = fields.iter().map(|f| {
                     Spanned { span: f.span,
                               node: hir::FieldPat {
-                                  ident: f.node.ident,
+                                  name: f.node.ident.name,
                                   pat: lower_pat(&f.node.pat),
                                   is_shorthand: f.node.is_shorthand,
                               }}
@@ -901,7 +901,7 @@ pub fn lower_binding_mode(b: &BindingMode) -> hir::BindingMode {
 
 pub fn lower_struct_field_kind(s: &StructFieldKind) -> hir::StructFieldKind {
     match *s {
-        NamedField(ident, vis) => hir::NamedField(ident, lower_visibility(vis)),
+        NamedField(ident, vis) => hir::NamedField(ident.name, lower_visibility(vis)),
         UnnamedField(vis) => hir::UnnamedField(lower_visibility(vis)),
     }
 }

--- a/src/librustc_front/print/pprust.rs
+++ b/src/librustc_front/print/pprust.rs
@@ -13,7 +13,7 @@ pub use self::AnnNode::*;
 use syntax::abi;
 use syntax::ast;
 use syntax::owned_slice::OwnedSlice;
-use syntax::codemap::{self, CodeMap, BytePos};
+use syntax::codemap::{self, CodeMap, BytePos, Spanned};
 use syntax::diagnostic;
 use syntax::parse::token::{self, BinOpToken};
 use syntax::parse::lexer::comments;
@@ -1223,7 +1223,7 @@ impl<'a> State<'a> {
             &fields[..],
             |s, field| {
                 try!(s.ibox(indent_unit));
-                try!(s.print_ident(field.ident.node));
+                try!(s.print_name(field.name.node));
                 try!(s.word_space(":"));
                 try!(s.print_expr(&*field.expr));
                 s.end()
@@ -1265,13 +1265,13 @@ impl<'a> State<'a> {
     }
 
     fn print_expr_method_call(&mut self,
-                              ident: hir::SpannedIdent,
+                              name: Spanned<ast::Name>,
                               tys: &[P<hir::Ty>],
                               args: &[P<hir::Expr>]) -> io::Result<()> {
         let base_args = &args[1..];
         try!(self.print_expr(&*args[0]));
         try!(word(&mut self.s, "."));
-        try!(self.print_ident(ident.node));
+        try!(self.print_name(name.node));
         if !tys.is_empty() {
             try!(word(&mut self.s, "::<"));
             try!(self.commasep(Inconsistent, tys,
@@ -1329,8 +1329,8 @@ impl<'a> State<'a> {
             hir::ExprCall(ref func, ref args) => {
                 try!(self.print_expr_call(&**func, &args[..]));
             }
-            hir::ExprMethodCall(ident, ref tys, ref args) => {
-                try!(self.print_expr_method_call(ident, &tys[..], &args[..]));
+            hir::ExprMethodCall(name, ref tys, ref args) => {
+                try!(self.print_expr_method_call(name, &tys[..], &args[..]));
             }
             hir::ExprBinary(op, ref lhs, ref rhs) => {
                 try!(self.print_expr_binary(op, &**lhs, &**rhs));
@@ -1435,10 +1435,10 @@ impl<'a> State<'a> {
                 try!(self.word_space("="));
                 try!(self.print_expr(&**rhs));
             }
-            hir::ExprField(ref expr, id) => {
+            hir::ExprField(ref expr, name) => {
                 try!(self.print_expr(&**expr));
                 try!(word(&mut self.s, "."));
-                try!(self.print_ident(id.node));
+                try!(self.print_name(name.node));
             }
             hir::ExprTupField(ref expr, id) => {
                 try!(self.print_expr(&**expr));

--- a/src/librustc_front/print/pprust.rs
+++ b/src/librustc_front/print/pprust.rs
@@ -2174,15 +2174,14 @@ impl<'a> State<'a> {
 
     pub fn print_view_path(&mut self, vp: &hir::ViewPath) -> io::Result<()> {
         match vp.node {
-            hir::ViewPathSimple(ident, ref path) => {
+            hir::ViewPathSimple(name, ref path) => {
                 try!(self.print_path(path, false, 0));
 
                 // FIXME(#6993) can't compare identifiers directly here
-                if path.segments.last().unwrap().identifier.name !=
-                        ident.name {
+                if path.segments.last().unwrap().identifier.name != name {
                     try!(space(&mut self.s));
                     try!(self.word_space("as"));
-                    try!(self.print_ident(ident));
+                    try!(self.print_name(name));
                 }
 
                 Ok(())
@@ -2203,7 +2202,7 @@ impl<'a> State<'a> {
                 try!(self.commasep(Inconsistent, &idents[..], |s, w| {
                     match w.node {
                         hir::PathListIdent { name, .. } => {
-                            s.print_ident(name)
+                            s.print_name(name)
                         },
                         hir::PathListMod { .. } => {
                             word(&mut s.s, "self")

--- a/src/librustc_front/print/pprust.rs
+++ b/src/librustc_front/print/pprust.rs
@@ -926,12 +926,12 @@ impl<'a> State<'a> {
             for field in &struct_def.fields {
                 match field.node.kind {
                     hir::UnnamedField(..) => panic!("unexpected unnamed field"),
-                    hir::NamedField(ident, visibility) => {
+                    hir::NamedField(name, visibility) => {
                         try!(self.hardbreak_if_not_bol());
                         try!(self.maybe_print_comment(field.span.lo));
                         try!(self.print_outer_attributes(&field.node.attrs));
                         try!(self.print_visibility(visibility));
-                        try!(self.print_ident(ident));
+                        try!(self.print_name(name));
                         try!(self.word_nbsp(":"));
                         try!(self.print_type(&*field.node.ty));
                         try!(word(&mut self.s, ","));
@@ -946,7 +946,7 @@ impl<'a> State<'a> {
     pub fn print_variant(&mut self, v: &hir::Variant) -> io::Result<()> {
         match v.node.kind {
             hir::TupleVariantKind(ref args) => {
-                try!(self.print_ident(v.node.name));
+                try!(self.print_name(v.node.name));
                 if !args.is_empty() {
                     try!(self.popen());
                     try!(self.commasep(Consistent,
@@ -958,7 +958,7 @@ impl<'a> State<'a> {
             hir::StructVariantKind(ref struct_def) => {
                 try!(self.head(""));
                 let generics = ::util::empty_generics();
-                try!(self.print_struct(&**struct_def, &generics, v.node.name.name, v.span));
+                try!(self.print_struct(&**struct_def, &generics, v.node.name, v.span));
             }
         }
         match v.node.disr_expr {
@@ -1699,7 +1699,7 @@ impl<'a> State<'a> {
                     if comma {
                         try!(self.word_space(","))
                     }
-                    try!(self.print_ident(binding.ident));
+                    try!(self.print_name(binding.name));
                     try!(space(&mut self.s));
                     try!(self.word_space("="));
                     try!(self.print_type(&*binding.ty));
@@ -1785,7 +1785,7 @@ impl<'a> State<'a> {
                     |s, f| {
                         try!(s.cbox(indent_unit));
                         if !f.node.is_shorthand {
-                            try!(s.print_ident(f.node.ident));
+                            try!(s.print_name(f.node.name));
                             try!(s.word_nbsp(":"));
                         }
                         try!(s.print_pat(&*f.node.pat));
@@ -2111,7 +2111,7 @@ impl<'a> State<'a> {
     }
 
     pub fn print_ty_param(&mut self, param: &hir::TyParam) -> io::Result<()> {
-        try!(self.print_ident(param.ident));
+        try!(self.print_name(param.name));
         try!(self.print_bounds(":", &param.bounds));
         match param.default {
             Some(ref default) => {

--- a/src/librustc_front/util.rs
+++ b/src/librustc_front/util.rs
@@ -12,7 +12,7 @@ use hir;
 use hir::*;
 use visit::{self, Visitor, FnKind};
 use syntax::ast_util;
-use syntax::ast::{Ident, NodeId, DUMMY_NODE_ID};
+use syntax::ast::{Ident, Name, NodeId, DUMMY_NODE_ID};
 use syntax::codemap::Span;
 use syntax::ptr::P;
 use syntax::owned_slice::OwnedSlice;
@@ -286,7 +286,7 @@ impl<'a, 'v, O: ast_util::IdVisitingOperation> Visitor<'v> for IdVisitor<'a, O> 
 
     fn visit_struct_def(&mut self,
                         struct_def: &StructDef,
-                        _: Ident,
+                        _: Name,
                         _: &hir::Generics,
                         id: NodeId) {
         self.operation.visit_id(id);

--- a/src/librustc_front/visit.rs
+++ b/src/librustc_front/visit.rs
@@ -24,7 +24,7 @@
 //! those that are created by the expansion of a macro.
 
 use syntax::abi::Abi;
-use syntax::ast::{Ident, NodeId, CRATE_NODE_ID, Name, Attribute};
+use syntax::ast::{NodeId, CRATE_NODE_ID, Name, Attribute};
 use hir::*;
 use hir;
 use syntax::codemap::Span;
@@ -34,10 +34,10 @@ use syntax::owned_slice::OwnedSlice;
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum FnKind<'a> {
     /// fn foo() or extern "Abi" fn foo()
-    ItemFn(Ident, &'a Generics, Unsafety, Constness, Abi, Visibility),
+    ItemFn(Name, &'a Generics, Unsafety, Constness, Abi, Visibility),
 
     /// fn foo(&self)
-    Method(Ident, &'a MethodSig, Option<Visibility>),
+    Method(Name, &'a MethodSig, Option<Visibility>),
 
     /// |x, y| ...
     /// proc(x, y) ...
@@ -56,9 +56,6 @@ pub enum FnKind<'a> {
 pub trait Visitor<'v> : Sized {
     fn visit_name(&mut self, _span: Span, _name: Name) {
         // Nothing to do.
-    }
-    fn visit_ident(&mut self, span: Span, ident: Ident) {
-        self.visit_name(span, ident.name);
     }
     fn visit_mod(&mut self, m: &'v Mod, _s: Span, _n: NodeId) { walk_mod(self, m) }
     fn visit_foreign_item(&mut self, i: &'v ForeignItem) { walk_foreign_item(self, i) }
@@ -85,7 +82,7 @@ pub trait Visitor<'v> : Sized {
     fn visit_poly_trait_ref(&mut self, t: &'v PolyTraitRef, m: &'v TraitBoundModifier) {
         walk_poly_trait_ref(self, t, m)
     }
-    fn visit_struct_def(&mut self, s: &'v StructDef, _: Ident, _: &'v Generics, _: NodeId) {
+    fn visit_struct_def(&mut self, s: &'v StructDef, _: Name, _: &'v Generics, _: NodeId) {
         walk_struct_def(self, s)
     }
     fn visit_struct_field(&mut self, s: &'v StructField) { walk_struct_field(self, s) }
@@ -201,12 +198,13 @@ pub fn walk_trait_ref<'v,V>(visitor: &mut V,
 }
 
 pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
-    visitor.visit_ident(item.span, item.ident);
+    visitor.visit_name(item.span, item.ident.name);
     match item.node {
         ItemExternCrate(..) => {}
         ItemUse(ref vp) => {
             match vp.node {
-                ViewPathSimple(_ident, ref path) => {
+                ViewPathSimple(name, ref path) => {
+                    visitor.visit_name(vp.span, name);
                     visitor.visit_path(path, item.id);
                 }
                 ViewPathGlob(ref path) => {
@@ -229,7 +227,7 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
             visitor.visit_expr(&**expr);
         }
         ItemFn(ref declaration, unsafety, constness, abi, ref generics, ref body) => {
-            visitor.visit_fn(FnKind::ItemFn(item.ident, generics, unsafety,
+            visitor.visit_fn(FnKind::ItemFn(item.ident.name, generics, unsafety,
                                             constness, abi, item.vis),
                              &**declaration,
                              &**body,
@@ -273,7 +271,7 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
         ItemStruct(ref struct_definition, ref generics) => {
             visitor.visit_generics(generics);
             visitor.visit_struct_def(&**struct_definition,
-                                     item.ident,
+                                     item.ident.name,
                                      generics,
                                      item.id)
         }
@@ -301,7 +299,7 @@ pub fn walk_enum_def<'v, V: Visitor<'v>>(visitor: &mut V,
 pub fn walk_variant<'v, V: Visitor<'v>>(visitor: &mut V,
                                         variant: &'v Variant,
                                         generics: &'v Generics) {
-    visitor.visit_ident(variant.span, variant.node.name);
+    visitor.visit_name(variant.span, variant.node.name.name);
 
     match variant.node.kind {
         TupleVariantKind(ref variant_arguments) => {
@@ -311,7 +309,7 @@ pub fn walk_variant<'v, V: Visitor<'v>>(visitor: &mut V,
         }
         StructVariantKind(ref struct_definition) => {
             visitor.visit_struct_def(&**struct_definition,
-                                     variant.node.name,
+                                     variant.node.name.name,
                                      generics,
                                      variant.node.id)
         }
@@ -411,7 +409,7 @@ pub fn walk_path_list_item<'v, V: Visitor<'v>>(visitor: &mut V, prefix: &'v Path
 pub fn walk_path_segment<'v, V: Visitor<'v>>(visitor: &mut V,
                                              path_span: Span,
                                              segment: &'v PathSegment) {
-    visitor.visit_ident(path_span, segment.identifier);
+    visitor.visit_name(path_span, segment.identifier.name);
     visitor.visit_path_parameters(path_span, &segment.parameters);
 }
 
@@ -443,7 +441,7 @@ pub fn walk_path_parameters<'v, V: Visitor<'v>>(visitor: &mut V,
 
 pub fn walk_assoc_type_binding<'v, V: Visitor<'v>>(visitor: &mut V,
                                                    type_binding: &'v TypeBinding) {
-    visitor.visit_ident(type_binding.span, type_binding.ident);
+    visitor.visit_name(type_binding.span, type_binding.ident.name);
     visitor.visit_ty(&*type_binding.ty);
 }
 
@@ -477,7 +475,7 @@ pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat) {
             visitor.visit_pat(&**subpattern)
         }
         PatIdent(_, ref pth1, ref optional_subpattern) => {
-            visitor.visit_ident(pth1.span, pth1.node);
+            visitor.visit_name(pth1.span, pth1.node.name);
             match *optional_subpattern {
                 None => {}
                 Some(ref subpattern) => visitor.visit_pat(&**subpattern),
@@ -505,7 +503,7 @@ pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat) {
 
 pub fn walk_foreign_item<'v, V: Visitor<'v>>(visitor: &mut V,
                                              foreign_item: &'v ForeignItem) {
-    visitor.visit_ident(foreign_item.span, foreign_item.ident);
+    visitor.visit_name(foreign_item.span, foreign_item.ident.name);
 
     match foreign_item.node {
         ForeignItemFn(ref function_declaration, ref generics) => {
@@ -541,7 +539,7 @@ pub fn walk_ty_param_bound<'v, V: Visitor<'v>>(visitor: &mut V,
 
 pub fn walk_generics<'v, V: Visitor<'v>>(visitor: &mut V, generics: &'v Generics) {
     for param in generics.ty_params.iter() {
-        visitor.visit_ident(param.span, param.ident);
+        visitor.visit_name(param.span, param.ident.name);
         walk_ty_param_bounds_helper(visitor, &param.bounds);
         walk_ty_opt(visitor, &param.default);
     }
@@ -613,7 +611,7 @@ pub fn walk_fn<'v, V: Visitor<'v>>(visitor: &mut V,
 }
 
 pub fn walk_trait_item<'v, V: Visitor<'v>>(visitor: &mut V, trait_item: &'v TraitItem) {
-    visitor.visit_ident(trait_item.span, trait_item.ident);
+    visitor.visit_name(trait_item.span, trait_item.ident.name);
     for attr in &trait_item.attrs {
         visitor.visit_attribute(attr);
     }
@@ -630,7 +628,7 @@ pub fn walk_trait_item<'v, V: Visitor<'v>>(visitor: &mut V, trait_item: &'v Trai
             walk_fn_decl(visitor, &sig.decl);
         }
         MethodTraitItem(ref sig, Some(ref body)) => {
-            visitor.visit_fn(FnKind::Method(trait_item.ident, sig, None), &sig.decl,
+            visitor.visit_fn(FnKind::Method(trait_item.ident.name, sig, None), &sig.decl,
                              body, trait_item.span, trait_item.id);
         }
         TypeTraitItem(ref bounds, ref default) => {
@@ -641,7 +639,7 @@ pub fn walk_trait_item<'v, V: Visitor<'v>>(visitor: &mut V, trait_item: &'v Trai
 }
 
 pub fn walk_impl_item<'v, V: Visitor<'v>>(visitor: &mut V, impl_item: &'v ImplItem) {
-    visitor.visit_ident(impl_item.span, impl_item.ident);
+    visitor.visit_name(impl_item.span, impl_item.ident.name);
     for attr in &impl_item.attrs {
         visitor.visit_attribute(attr);
     }
@@ -651,8 +649,8 @@ pub fn walk_impl_item<'v, V: Visitor<'v>>(visitor: &mut V, impl_item: &'v ImplIt
             visitor.visit_expr(expr);
         }
         MethodImplItem(ref sig, ref body) => {
-            visitor.visit_fn(FnKind::Method(impl_item.ident, sig, Some(impl_item.vis)), &sig.decl,
-                             body, impl_item.span, impl_item.id);
+            visitor.visit_fn(FnKind::Method(impl_item.ident.name, sig, Some(impl_item.vis)),
+                             &sig.decl, body, impl_item.span, impl_item.id);
         }
         TypeImplItem(ref ty) => {
             visitor.visit_ty(ty);
@@ -670,7 +668,7 @@ pub fn walk_struct_def<'v, V: Visitor<'v>>(visitor: &mut V,
 pub fn walk_struct_field<'v, V: Visitor<'v>>(visitor: &mut V,
                                              struct_field: &'v StructField) {
     if let NamedField(name, _) = struct_field.node.kind {
-        visitor.visit_ident(struct_field.span, name);
+        visitor.visit_name(struct_field.span, name.name);
     }
 
     visitor.visit_ty(&*struct_field.node.ty);

--- a/src/librustc_front/visit.rs
+++ b/src/librustc_front/visit.rs
@@ -407,7 +407,7 @@ pub fn walk_path_list_item<'v, V: Visitor<'v>>(visitor: &mut V, prefix: &'v Path
     }
 
     if let PathListIdent { name, .. } = item.node {
-        visitor.visit_ident(item.span, name);
+        visitor.visit_name(item.span, name);
     }
 }
 

--- a/src/librustc_front/visit.rs
+++ b/src/librustc_front/visit.rs
@@ -299,7 +299,7 @@ pub fn walk_enum_def<'v, V: Visitor<'v>>(visitor: &mut V,
 pub fn walk_variant<'v, V: Visitor<'v>>(visitor: &mut V,
                                         variant: &'v Variant,
                                         generics: &'v Generics) {
-    visitor.visit_name(variant.span, variant.node.name.name);
+    visitor.visit_name(variant.span, variant.node.name);
 
     match variant.node.kind {
         TupleVariantKind(ref variant_arguments) => {
@@ -309,7 +309,7 @@ pub fn walk_variant<'v, V: Visitor<'v>>(visitor: &mut V,
         }
         StructVariantKind(ref struct_definition) => {
             visitor.visit_struct_def(&**struct_definition,
-                                     variant.node.name.name,
+                                     variant.node.name,
                                      generics,
                                      variant.node.id)
         }
@@ -441,7 +441,7 @@ pub fn walk_path_parameters<'v, V: Visitor<'v>>(visitor: &mut V,
 
 pub fn walk_assoc_type_binding<'v, V: Visitor<'v>>(visitor: &mut V,
                                                    type_binding: &'v TypeBinding) {
-    visitor.visit_name(type_binding.span, type_binding.ident.name);
+    visitor.visit_name(type_binding.span, type_binding.name);
     visitor.visit_ty(&*type_binding.ty);
 }
 
@@ -539,7 +539,7 @@ pub fn walk_ty_param_bound<'v, V: Visitor<'v>>(visitor: &mut V,
 
 pub fn walk_generics<'v, V: Visitor<'v>>(visitor: &mut V, generics: &'v Generics) {
     for param in generics.ty_params.iter() {
-        visitor.visit_name(param.span, param.ident.name);
+        visitor.visit_name(param.span, param.name);
         walk_ty_param_bounds_helper(visitor, &param.bounds);
         walk_ty_opt(visitor, &param.default);
     }
@@ -668,7 +668,7 @@ pub fn walk_struct_def<'v, V: Visitor<'v>>(visitor: &mut V,
 pub fn walk_struct_field<'v, V: Visitor<'v>>(visitor: &mut V,
                                              struct_field: &'v StructField) {
     if let NamedField(name, _) = struct_field.node.kind {
-        visitor.visit_name(struct_field.span, name.name);
+        visitor.visit_name(struct_field.span, name);
     }
 
     visitor.visit_ty(&*struct_field.node.ty);

--- a/src/librustc_front/visit.rs
+++ b/src/librustc_front/visit.rs
@@ -198,7 +198,7 @@ pub fn walk_trait_ref<'v,V>(visitor: &mut V,
 }
 
 pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
-    visitor.visit_name(item.span, item.ident.name);
+    visitor.visit_name(item.span, item.name);
     match item.node {
         ItemExternCrate(..) => {}
         ItemUse(ref vp) => {
@@ -227,7 +227,7 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
             visitor.visit_expr(&**expr);
         }
         ItemFn(ref declaration, unsafety, constness, abi, ref generics, ref body) => {
-            visitor.visit_fn(FnKind::ItemFn(item.ident.name, generics, unsafety,
+            visitor.visit_fn(FnKind::ItemFn(item.name, generics, unsafety,
                                             constness, abi, item.vis),
                              &**declaration,
                              &**body,
@@ -271,7 +271,7 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
         ItemStruct(ref struct_definition, ref generics) => {
             visitor.visit_generics(generics);
             visitor.visit_struct_def(&**struct_definition,
-                                     item.ident.name,
+                                     item.name,
                                      generics,
                                      item.id)
         }
@@ -503,7 +503,7 @@ pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat) {
 
 pub fn walk_foreign_item<'v, V: Visitor<'v>>(visitor: &mut V,
                                              foreign_item: &'v ForeignItem) {
-    visitor.visit_name(foreign_item.span, foreign_item.ident.name);
+    visitor.visit_name(foreign_item.span, foreign_item.name);
 
     match foreign_item.node {
         ForeignItemFn(ref function_declaration, ref generics) => {
@@ -611,7 +611,7 @@ pub fn walk_fn<'v, V: Visitor<'v>>(visitor: &mut V,
 }
 
 pub fn walk_trait_item<'v, V: Visitor<'v>>(visitor: &mut V, trait_item: &'v TraitItem) {
-    visitor.visit_name(trait_item.span, trait_item.ident.name);
+    visitor.visit_name(trait_item.span, trait_item.name);
     for attr in &trait_item.attrs {
         visitor.visit_attribute(attr);
     }
@@ -628,7 +628,7 @@ pub fn walk_trait_item<'v, V: Visitor<'v>>(visitor: &mut V, trait_item: &'v Trai
             walk_fn_decl(visitor, &sig.decl);
         }
         MethodTraitItem(ref sig, Some(ref body)) => {
-            visitor.visit_fn(FnKind::Method(trait_item.ident.name, sig, None), &sig.decl,
+            visitor.visit_fn(FnKind::Method(trait_item.name, sig, None), &sig.decl,
                              body, trait_item.span, trait_item.id);
         }
         TypeTraitItem(ref bounds, ref default) => {
@@ -639,7 +639,7 @@ pub fn walk_trait_item<'v, V: Visitor<'v>>(visitor: &mut V, trait_item: &'v Trai
 }
 
 pub fn walk_impl_item<'v, V: Visitor<'v>>(visitor: &mut V, impl_item: &'v ImplItem) {
-    visitor.visit_name(impl_item.span, impl_item.ident.name);
+    visitor.visit_name(impl_item.span, impl_item.name);
     for attr in &impl_item.attrs {
         visitor.visit_attribute(attr);
     }
@@ -649,8 +649,8 @@ pub fn walk_impl_item<'v, V: Visitor<'v>>(visitor: &mut V, impl_item: &'v ImplIt
             visitor.visit_expr(expr);
         }
         MethodImplItem(ref sig, ref body) => {
-            visitor.visit_fn(FnKind::Method(impl_item.ident.name, sig, Some(impl_item.vis)),
-                             &sig.decl, body, impl_item.span, impl_item.id);
+            visitor.visit_fn(FnKind::Method(impl_item.name, sig, Some(impl_item.vis)), &sig.decl,
+                             body, impl_item.span, impl_item.id);
         }
         TypeImplItem(ref ty) => {
             visitor.visit_ty(ty);

--- a/src/librustc_lint/bad_style.rs
+++ b/src/librustc_lint/bad_style.rs
@@ -53,17 +53,17 @@ declare_lint! {
 pub struct NonCamelCaseTypes;
 
 impl NonCamelCaseTypes {
-    fn check_case(&self, cx: &LateContext, sort: &str, ident: ast::Ident, span: Span) {
-        fn is_camel_case(ident: ast::Ident) -> bool {
-            let ident = ident.name.as_str();
-            if ident.is_empty() {
+    fn check_case(&self, cx: &LateContext, sort: &str, name: ast::Name, span: Span) {
+        fn is_camel_case(name: ast::Name) -> bool {
+            let name = name.as_str();
+            if name.is_empty() {
                 return true;
             }
-            let ident = ident.trim_matches('_');
+            let name = name.trim_matches('_');
 
             // start with a non-lowercase letter rather than non-uppercase
             // ones (some scripts don't have a concept of upper/lowercase)
-            !ident.is_empty() && !ident.char_at(0).is_lowercase() && !ident.contains('_')
+            !name.is_empty() && !name.char_at(0).is_lowercase() && !name.contains('_')
         }
 
         fn to_camel_case(s: &str) -> String {
@@ -76,9 +76,9 @@ impl NonCamelCaseTypes {
             )).collect::<Vec<_>>().concat()
         }
 
-        let s = ident.name.as_str();
+        let s = name.as_str();
 
-        if !is_camel_case(ident) {
+        if !is_camel_case(name) {
             let c = to_camel_case(&s);
             let m = if c.is_empty() {
                 format!("{} `{}` should have a camel case name such as `CamelCase`", sort, s)
@@ -110,16 +110,16 @@ impl LateLintPass for NonCamelCaseTypes {
 
         match it.node {
             hir::ItemTy(..) | hir::ItemStruct(..) => {
-                self.check_case(cx, "type", it.ident, it.span)
+                self.check_case(cx, "type", it.name, it.span)
             }
             hir::ItemTrait(..) => {
-                self.check_case(cx, "trait", it.ident, it.span)
+                self.check_case(cx, "trait", it.name, it.span)
             }
             hir::ItemEnum(ref enum_definition, _) => {
                 if has_extern_repr {
                     return;
                 }
-                self.check_case(cx, "type", it.ident, it.span);
+                self.check_case(cx, "type", it.name, it.span);
                 for variant in &enum_definition.variants {
                     self.check_case(cx, "variant", variant.node.name, variant.span);
                 }
@@ -130,7 +130,7 @@ impl LateLintPass for NonCamelCaseTypes {
 
     fn check_generics(&mut self, cx: &LateContext, it: &hir::Generics) {
         for gen in it.ty_params.iter() {
-            self.check_case(cx, "type parameter", gen.ident, gen.span);
+            self.check_case(cx, "type parameter", gen.name, gen.span);
         }
     }
 }
@@ -237,17 +237,17 @@ impl LateLintPass for NonSnakeCase {
                 fk: FnKind, _: &hir::FnDecl,
                 _: &hir::Block, span: Span, id: ast::NodeId) {
         match fk {
-            FnKind::Method(ident, _, _) => match method_context(cx, id, span) {
+            FnKind::Method(name, _, _) => match method_context(cx, id, span) {
                 MethodLateContext::PlainImpl => {
-                    self.check_snake_case(cx, "method", &ident.name.as_str(), Some(span))
+                    self.check_snake_case(cx, "method", &name.as_str(), Some(span))
                 },
                 MethodLateContext::TraitDefaultImpl => {
-                    self.check_snake_case(cx, "trait method", &ident.name.as_str(), Some(span))
+                    self.check_snake_case(cx, "trait method", &name.as_str(), Some(span))
                 },
                 _ => (),
             },
-            FnKind::ItemFn(ident, _, _, _, _, _) => {
-                self.check_snake_case(cx, "function", &ident.name.as_str(), Some(span))
+            FnKind::ItemFn(name, _, _, _, _, _) => {
+                self.check_snake_case(cx, "function", &name.as_str(), Some(span))
             },
             _ => (),
         }
@@ -255,13 +255,13 @@ impl LateLintPass for NonSnakeCase {
 
     fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
         if let hir::ItemMod(_) = it.node {
-            self.check_snake_case(cx, "module", &it.ident.name.as_str(), Some(it.span));
+            self.check_snake_case(cx, "module", &it.name.as_str(), Some(it.span));
         }
     }
 
     fn check_trait_item(&mut self, cx: &LateContext, trait_item: &hir::TraitItem) {
         if let hir::MethodTraitItem(_, None) = trait_item.node {
-            self.check_snake_case(cx, "trait method", &trait_item.ident.name.as_str(),
+            self.check_snake_case(cx, "trait method", &trait_item.name.as_str(),
                                   Some(trait_item.span));
         }
     }
@@ -281,10 +281,10 @@ impl LateLintPass for NonSnakeCase {
     }
 
     fn check_struct_def(&mut self, cx: &LateContext, s: &hir::StructDef,
-                        _: ast::Ident, _: &hir::Generics, _: ast::NodeId) {
+                        _: ast::Name, _: &hir::Generics, _: ast::NodeId) {
         for sf in &s.fields {
-            if let hir::StructField_ { kind: hir::NamedField(ident, _), .. } = sf.node {
-                self.check_snake_case(cx, "structure field", &ident.name.as_str(),
+            if let hir::StructField_ { kind: hir::NamedField(name, _), .. } = sf.node {
+                self.check_snake_case(cx, "structure field", &name.as_str(),
                                       Some(sf.span));
             }
         }
@@ -301,8 +301,8 @@ declare_lint! {
 pub struct NonUpperCaseGlobals;
 
 impl NonUpperCaseGlobals {
-    fn check_upper_case(cx: &LateContext, sort: &str, ident: ast::Ident, span: Span) {
-        let s = ident.name.as_str();
+    fn check_upper_case(cx: &LateContext, sort: &str, name: ast::Name, span: Span) {
+        let s = name.as_str();
 
         if s.chars().any(|c| c.is_lowercase()) {
             let uc = NonSnakeCase::to_snake_case(&s).to_uppercase();
@@ -330,10 +330,10 @@ impl LateLintPass for NonUpperCaseGlobals {
         match it.node {
             // only check static constants
             hir::ItemStatic(_, hir::MutImmutable, _) => {
-                NonUpperCaseGlobals::check_upper_case(cx, "static constant", it.ident, it.span);
+                NonUpperCaseGlobals::check_upper_case(cx, "static constant", it.name, it.span);
             }
             hir::ItemConst(..) => {
-                NonUpperCaseGlobals::check_upper_case(cx, "constant", it.ident, it.span);
+                NonUpperCaseGlobals::check_upper_case(cx, "constant", it.name, it.span);
             }
             _ => {}
         }
@@ -343,7 +343,7 @@ impl LateLintPass for NonUpperCaseGlobals {
         match ti.node {
             hir::ConstTraitItem(..) => {
                 NonUpperCaseGlobals::check_upper_case(cx, "associated constant",
-                                                      ti.ident, ti.span);
+                                                      ti.name, ti.span);
             }
             _ => {}
         }
@@ -353,7 +353,7 @@ impl LateLintPass for NonUpperCaseGlobals {
         match ii.node {
             hir::ConstImplItem(..) => {
                 NonUpperCaseGlobals::check_upper_case(cx, "associated constant",
-                                                      ii.ident, ii.span);
+                                                      ii.name, ii.span);
             }
             _ => {}
         }
@@ -364,7 +364,7 @@ impl LateLintPass for NonUpperCaseGlobals {
         match (&p.node, cx.tcx.def_map.borrow().get(&p.id).map(|d| d.full_def())) {
             (&hir::PatIdent(_, ref path1, _), Some(def::DefConst(..))) => {
                 NonUpperCaseGlobals::check_upper_case(cx, "constant in pattern",
-                                                      path1.node, p.span);
+                                                      path1.node.name, p.span);
             }
             _ => {}
         }

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1081,12 +1081,12 @@ impl LateLintPass for MissingDoc {
     }
 
     fn check_struct_def(&mut self, _: &LateContext, _: &hir::StructDef,
-                        _: ast::Ident, _: &hir::Generics, id: ast::NodeId) {
+                        _: ast::Name, _: &hir::Generics, id: ast::NodeId) {
         self.struct_def_stack.push(id);
     }
 
     fn check_struct_def_post(&mut self, _: &LateContext, _: &hir::StructDef,
-                             _: ast::Ident, _: &hir::Generics, id: ast::NodeId) {
+                             _: ast::Name, _: &hir::Generics, id: ast::NodeId) {
         let popped = self.struct_def_stack.pop().expect("empty struct_def_stack");
         assert!(popped == id);
     }

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1731,7 +1731,7 @@ impl LateLintPass for InvalidNoMangleItems {
                 if attr::contains_name(&it.attrs, "no_mangle") &&
                        !cx.exported_items.contains(&it.id) {
                     let msg = format!("function {} is marked #[no_mangle], but not exported",
-                                      it.ident);
+                                      it.name);
                     cx.span_lint(PRIVATE_NO_MANGLE_FNS, it.span, &msg);
                 }
             },
@@ -1739,7 +1739,7 @@ impl LateLintPass for InvalidNoMangleItems {
                 if attr::contains_name(&it.attrs, "no_mangle") &&
                        !cx.exported_items.contains(&it.id) {
                     let msg = format!("static {} is marked #[no_mangle], but not exported",
-                                      it.ident);
+                                      it.name);
                     cx.span_lint(PRIVATE_NO_MANGLE_STATICS, it.span, &msg);
                 }
             },

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -909,7 +909,7 @@ impl LateLintPass for NonShorthandFieldPatterns {
             });
             for fieldpat in field_pats {
                 if let hir::PatIdent(_, ident, None) = fieldpat.node.pat.node {
-                    if ident.node.name == fieldpat.node.ident.name {
+                    if ident.node.name == fieldpat.node.name {
                         // FIXME: should this comparison really be done on the name?
                         // doing it on the ident will fail during compilation of libcore
                         cx.span_lint(NON_SHORTHAND_FIELD_PATTERNS, fieldpat.span,

--- a/src/librustc_mir/tcx/expr.rs
+++ b/src/librustc_mir/tcx/expr.rs
@@ -288,9 +288,9 @@ impl<'a,'tcx:'a> Mirror<Cx<'a,'tcx>> for &'tcx hir::Expr {
             hir::ExprLoop(ref body, _) =>
                 ExprKind::Loop { condition: None,
                                  body: block::to_expr_ref(cx, body) },
-            hir::ExprField(ref source, ident) =>
+            hir::ExprField(ref source, name) =>
                 ExprKind::Field { lhs: source.to_ref(),
-                                  name: Field::Named(ident.node.name) },
+                                  name: Field::Named(name.node) },
             hir::ExprTupField(ref source, ident) =>
                 ExprKind::Field { lhs: source.to_ref(),
                                   name: Field::Indexed(ident.node) },

--- a/src/librustc_mir/tcx/pattern.rs
+++ b/src/librustc_mir/tcx/pattern.rs
@@ -268,7 +268,7 @@ impl<'a,'tcx:'a> Mirror<Cx<'a,'tcx>> for PatNode<'tcx> {
                 let subpatterns =
                     fields.iter()
                           .map(|field| FieldPatternRef {
-                              field: Field::Named(field.node.ident.name),
+                              field: Field::Named(field.node.name),
                               pattern: self.pat_ref(&field.node.pat),
                           })
                           .collect();

--- a/src/librustc_mir/tcx/to_ref.rs
+++ b/src/librustc_mir/tcx/to_ref.rs
@@ -86,9 +86,8 @@ impl<'a,'tcx:'a> ToRef<Cx<'a,'tcx>> for &'tcx hir::Field {
 
     fn to_ref(self) -> FieldExprRef<Cx<'a,'tcx>> {
         FieldExprRef {
-            name: Field::Named(self.ident.node.name),
+            name: Field::Named(self.name.node),
             expr: self.expr.to_ref()
         }
     }
 }
-

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -941,7 +941,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for PrivacyVisitor<'a, 'tcx> {
                 let variant = adt.variant_of_def(def);
                 for field in fields {
                     self.check_field(pattern.span, adt, variant,
-                                     NamedField(field.node.ident.name));
+                                     NamedField(field.node.name));
                 }
             }
 

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -683,7 +683,7 @@ impl<'a, 'tcx> PrivacyVisitor<'a, 'tcx> {
             hir::ItemEnum(..) => "enum",
             _ => return Some((err_span, err_msg, None))
         };
-        let msg = format!("{} `{}` is private", desc, item.ident);
+        let msg = format!("{} `{}` is private", desc, item.name);
         Some((err_span, err_msg, Some((span, msg))))
     }
 

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -988,7 +988,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for PrivacyVisitor<'a, 'tcx> {
 
     fn visit_path_list_item(&mut self, prefix: &hir::Path, item: &hir::PathListItem) {
         let name = if let hir::PathListIdent { name, .. } = item.node {
-            name.name
+            name
         } else if !prefix.segments.is_empty() {
             prefix.segments.last().unwrap().identifier.name
         } else {

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -866,12 +866,12 @@ impl<'a, 'tcx, 'v> Visitor<'v> for PrivacyVisitor<'a, 'tcx> {
 
     fn visit_expr(&mut self, expr: &hir::Expr) {
         match expr.node {
-            hir::ExprField(ref base, ident) => {
+            hir::ExprField(ref base, name) => {
                 if let ty::TyStruct(def, _) = self.tcx.expr_ty_adjusted(&**base).sty {
                     self.check_field(expr.span,
                                      def,
                                      def.struct_variant(),
-                                     NamedField(ident.node.name));
+                                     NamedField(name.node));
                 }
             }
             hir::ExprTupField(ref base, idx) => {
@@ -882,11 +882,11 @@ impl<'a, 'tcx, 'v> Visitor<'v> for PrivacyVisitor<'a, 'tcx> {
                                      UnnamedField(idx.node));
                 }
             }
-            hir::ExprMethodCall(ident, _, _) => {
+            hir::ExprMethodCall(name, _, _) => {
                 let method_call = ty::MethodCall::expr(expr.id);
                 let method = self.tcx.tables.borrow().method_map[&method_call];
                 debug!("(privacy checking) checking impl method");
-                self.check_method(expr.span, method.def_id, ident.node.name);
+                self.check_method(expr.span, method.def_id, name.node);
             }
             hir::ExprStruct(..) => {
                 let adt = self.tcx.expr_ty(expr).ty_adt_def().unwrap();

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -128,7 +128,7 @@ impl<'v> Visitor<'v> for ParentVisitor {
         visit::walk_impl_item(self, ii);
     }
 
-    fn visit_struct_def(&mut self, s: &hir::StructDef, _: ast::Ident,
+    fn visit_struct_def(&mut self, s: &hir::StructDef, _: ast::Name,
                         _: &'v hir::Generics, n: ast::NodeId) {
         // Struct constructors are parented to their struct definitions because
         // they essentially are the struct definitions.

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -263,7 +263,7 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
 
     /// Constructs the reduced graph for one item.
     fn build_reduced_graph_for_item(&mut self, item: &Item, parent: &Rc<Module>) -> Rc<Module> {
-        let name = item.ident.name;
+        let name = item.name;
         let sp = item.span;
         let is_public = item.vis == hir::Public;
         let modifiers = if is_public {
@@ -539,7 +539,7 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
 
                 // Add the names of all the items to the trait info.
                 for trait_item in items {
-                    let name_bindings = self.add_child(trait_item.ident.name,
+                    let name_bindings = self.add_child(trait_item.name,
                                         &module_parent,
                                         ForbidDuplicateTypesAndValues,
                                         trait_item.span);
@@ -563,7 +563,7 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
                         }
                     }
 
-                    self.trait_item_map.insert((trait_item.ident.name, def_id),
+                    self.trait_item_map.insert((trait_item.name, def_id),
                                                DefId::local(trait_item.id));
                 }
 
@@ -606,7 +606,7 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
     fn build_reduced_graph_for_foreign_item(&mut self,
                                             foreign_item: &ForeignItem,
                                             parent: &Rc<Module>) {
-        let name = foreign_item.ident.name;
+        let name = foreign_item.name;
         let is_public = foreign_item.vis == hir::Public;
         let modifiers = if is_public {
             DefModifiers::PUBLIC

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -508,7 +508,7 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
                 // Record the def ID and fields of this struct.
                 let named_fields = struct_def.fields.iter().filter_map(|f| {
                     match f.node.kind {
-                        NamedField(ident, _) => Some(ident.name),
+                        NamedField(name, _) => Some(name),
                         UnnamedField(_) => None
                     }
                 }).collect();
@@ -578,7 +578,7 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
                                        variant: &Variant,
                                        item_id: DefId,
                                        parent: &Rc<Module>) {
-        let name = variant.node.name.name;
+        let name = variant.node.name;
         let is_exported = match variant.node.kind {
             TupleVariantKind(_) => false,
             StructVariantKind(_) => {

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -312,8 +312,7 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
                                           ResolutionError::SelfImportsOnlyAllowedWithin);
                         }
 
-                        let subclass = SingleImport(binding.name,
-                                                    source_name);
+                        let subclass = SingleImport(binding, source_name);
                         self.build_import_directive(&**parent,
                                                     module_path,
                                                     subclass,
@@ -343,7 +342,7 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
                         for source_item in source_items {
                             let (module_path, name, rename) = match source_item.node {
                                 PathListIdent { name, rename, .. } =>
-                                    (module_path.clone(), name.name, rename.unwrap_or(name).name),
+                                    (module_path.clone(), name, rename.unwrap_or(name)),
                                 PathListMod { rename, .. } => {
                                     let name = match module_path.last() {
                                         Some(name) => *name,
@@ -358,7 +357,7 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
                                         }
                                     };
                                     let module_path = module_path.split_last().unwrap().1;
-                                    let rename = rename.map(|n| n.name).unwrap_or(name);
+                                    let rename = rename.unwrap_or(name);
                                     (module_path.to_vec(), name, rename)
                                 }
                             };

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2210,23 +2210,23 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
             ItemUse(ref view_path) => {
                 // check for imports shadowing primitive types
-                let check_rename = |this: &Self, id, ident: Ident| {
+                let check_rename = |this: &Self, id, name| {
                     match this.def_map.borrow().get(&id).map(|d| d.full_def()) {
                         Some(DefTy(..)) | Some(DefStruct(..)) | Some(DefTrait(..)) | None => {
-                            this.check_if_primitive_type_name(ident.name, item.span);
+                            this.check_if_primitive_type_name(name, item.span);
                         }
                         _ => {}
                     }
                 };
 
                 match view_path.node {
-                    hir::ViewPathSimple(ident, _) => {
-                        check_rename(self, item.id, ident);
+                    hir::ViewPathSimple(name, _) => {
+                        check_rename(self, item.id, name);
                     }
                     hir::ViewPathList(ref prefix, ref items) => {
                         for item in items {
-                            if let Some(ident) = item.node.rename() {
-                                check_rename(self, item.node.id(), ident);
+                            if let Some(name) = item.node.rename() {
+                                check_rename(self, item.node.id(), name);
                             }
                         }
 

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1258,7 +1258,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
     fn get_trait_name(&self, did: DefId) -> Name {
         if did.is_local() {
-            self.ast_map.expect_item(did.node).ident.name
+            self.ast_map.expect_item(did.node).name
         } else {
             csearch::get_trait_name(&self.session.cstore, did)
         }
@@ -2109,7 +2109,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
     }
 
     fn resolve_item(&mut self, item: &Item) {
-        let name = item.ident.name;
+        let name = item.name;
 
         debug!("(resolving item) resolving {}",
                name);
@@ -2184,7 +2184,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                     });
                                 }
                                 hir::TypeTraitItem(..) => {
-                                    this.check_if_primitive_type_name(trait_item.ident.name,
+                                    this.check_if_primitive_type_name(trait_item.name,
                                                                       trait_item.span);
                                     this.with_type_parameter_rib(NoTypeParameters, |this| {
                                         visit::walk_trait_item(this, trait_item)
@@ -2486,7 +2486,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                 ConstImplItem(..) => {
                                     // If this is a trait impl, ensure the const
                                     // exists in trait
-                                    this.check_trait_item(impl_item.ident.name,
+                                    this.check_trait_item(impl_item.name,
                                                           impl_item.span,
                                         |n, s| ResolutionError::ConstNotMemberOfTrait(n, s));
                                     this.with_constant_rib(|this| {
@@ -2496,7 +2496,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                 MethodImplItem(ref sig, _) => {
                                     // If this is a trait impl, ensure the method
                                     // exists in trait
-                                    this.check_trait_item(impl_item.ident.name,
+                                    this.check_trait_item(impl_item.name,
                                                           impl_item.span,
                                         |n, s| ResolutionError::MethodNotMemberOfTrait(n, s));
 
@@ -2513,7 +2513,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                 TypeImplItem(ref ty) => {
                                     // If this is a trait impl, ensure the type
                                     // exists in trait
-                                    this.check_trait_item(impl_item.ident.name,
+                                    this.check_trait_item(impl_item.name,
                                                           impl_item.span,
                                         |n, s| ResolutionError::TypeNotMemberOfTrait(n, s));
 

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3817,19 +3817,19 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
     fn record_candidate_traits_for_expr_if_necessary(&mut self, expr: &Expr) {
         match expr.node {
-            ExprField(_, ident) => {
+            ExprField(_, name) => {
                 // FIXME(#6890): Even though you can't treat a method like a
                 // field, we need to add any trait methods we find that match
                 // the field name so that we can do some nice error reporting
                 // later on in typeck.
-                let traits = self.get_traits_containing_item(ident.node.name);
+                let traits = self.get_traits_containing_item(name.node);
                 self.trait_map.insert(expr.id, traits);
             }
-            ExprMethodCall(ident, _, _) => {
+            ExprMethodCall(name, _, _) => {
                 debug!("(recording candidate traits for expr) recording \
                         traits for {}",
                        expr.id);
-                let traits = self.get_traits_containing_item(ident.node.name);
+                let traits = self.get_traits_containing_item(name.node);
                 self.trait_map.insert(expr.id, traits);
             }
             _ => {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -509,7 +509,7 @@ impl<'a, 'v, 'tcx> Visitor<'v> for Resolver<'a, 'tcx> {
             }
             hir::StructVariantKind(ref struct_definition) => {
                 self.visit_struct_def(&**struct_definition,
-                                      variant.node.name.name,
+                                      variant.node.name,
                                       generics,
                                       variant.node.id);
             }
@@ -2264,7 +2264,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 let mut function_type_rib = Rib::new(rib_kind);
                 let mut seen_bindings = HashSet::new();
                 for (index, type_parameter) in generics.ty_params.iter().enumerate() {
-                    let name = type_parameter.ident.name;
+                    let name = type_parameter.name;
                     debug!("with_type_parameter_rib: {}", type_parameter.id);
 
                     if seen_bindings.contains(&name) {
@@ -2390,7 +2390,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
     fn resolve_generics(&mut self, generics: &Generics) {
         for type_parameter in generics.ty_params.iter() {
-            self.check_if_primitive_type_name(type_parameter.ident.name, type_parameter.span);
+            self.check_if_primitive_type_name(type_parameter.name, type_parameter.span);
         }
         for predicate in &generics.where_clause.predicates {
             match predicate {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -509,7 +509,7 @@ impl<'a, 'v, 'tcx> Visitor<'v> for Resolver<'a, 'tcx> {
             }
             hir::StructVariantKind(ref struct_definition) => {
                 self.visit_struct_def(&**struct_definition,
-                                      variant.node.name,
+                                      variant.node.name.name,
                                       generics,
                                       variant.node.id);
             }

--- a/src/librustc_trans/trans/_match.rs
+++ b/src/librustc_trans/trans/_match.rs
@@ -1436,7 +1436,7 @@ fn is_discr_reassigned(bcx: Block, discr: &hir::Expr, body: &hir::Expr) -> bool 
                 Some(def::DefLocal(vid)) | Some(def::DefUpvar(vid, _, _)) => vid,
                 _ => return false
             };
-            (vid, Some(mc::NamedField(field.node.name)))
+            (vid, Some(mc::NamedField(field.node)))
         },
         hir::ExprTupField(ref base, field) => {
             let vid = match bcx.tcx().def_map.borrow().get(&base.id).map(|d| d.full_def()) {

--- a/src/librustc_trans/trans/_match.rs
+++ b/src/librustc_trans/trans/_match.rs
@@ -1872,7 +1872,7 @@ pub fn bind_irrefutable_pat<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             let pat_repr = adt::represent_type(bcx.ccx(), pat_ty);
             let pat_v = VariantInfo::of_node(tcx, pat_ty, pat.id);
             for f in fields {
-                let name = f.node.ident.name;
+                let name = f.node.name;
                 let fldptr = adt::trans_field_ptr(
                     bcx,
                     &*pat_repr,

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -2099,7 +2099,7 @@ pub fn trans_item(ccx: &CrateContext, item: &hir::Item) {
       }
       hir::ItemImpl(_, _, ref generics, _, _, ref impl_items) => {
         meth::trans_impl(ccx,
-                         item.ident,
+                         item.name,
                          &impl_items[..],
                          generics,
                          item.id);

--- a/src/librustc_trans/trans/consts.rs
+++ b/src/librustc_trans/trans/consts.rs
@@ -574,7 +574,7 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             let (bv, bt) = const_expr(cx, &**base, param_substs, fn_args);
             let brepr = adt::represent_type(cx, bt);
             let vinfo = VariantInfo::from_ty(cx.tcx(), bt, None);
-            let ix = vinfo.field_index(field.node.name);
+            let ix = vinfo.field_index(field.node);
             adt::const_get_field(cx, &*brepr, bv, vinfo.discr, ix)
         },
         hir::ExprTupField(ref base, idx) => {
@@ -742,7 +742,7 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
 
             let VariantInfo { discr, fields } = VariantInfo::of_node(cx.tcx(), ety, e.id);
             let cs = fields.iter().enumerate().map(|(ix, &Field(f_name, _))| {
-                match (fs.iter().find(|f| f_name == f.ident.node.name), base_val) {
+                match (fs.iter().find(|f| f_name == f.name.node), base_val) {
                     (Some(ref f), _) => const_expr(cx, &*f.expr, param_substs, fn_args).0,
                     (_, Some((bv, _))) => adt::const_get_field(cx, &*repr, bv, discr, ix),
                     (_, None) => cx.sess().span_bug(e.span, "missing struct field"),

--- a/src/librustc_trans/trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/trans/debuginfo/metadata.rs
@@ -1858,8 +1858,8 @@ pub fn create_global_var_metadata(cx: &CrateContext,
     let (name, span) = match var_item {
         hir_map::NodeItem(item) => {
             match item.node {
-                hir::ItemStatic(..) => (item.ident.name, item.span),
-                hir::ItemConst(..) => (item.ident.name, item.span),
+                hir::ItemStatic(..) => (item.name, item.span),
+                hir::ItemConst(..) => (item.name, item.span),
                 _ => {
                     cx.sess()
                       .span_bug(item.span,

--- a/src/librustc_trans/trans/debuginfo/mod.rs
+++ b/src/librustc_trans/trans/debuginfo/mod.rs
@@ -520,7 +520,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
 
         // Handle other generic parameters
         let actual_types = param_substs.types.get_slice(subst::FnSpace);
-        for (index, &hir::TyParam{ ident, .. }) in generics.ty_params.iter().enumerate() {
+        for (index, &hir::TyParam{ name, .. }) in generics.ty_params.iter().enumerate() {
             let actual_type = actual_types[index];
             // Add actual type name to <...> clause of function name
             let actual_type_name = compute_debuginfo_type_name(cx,
@@ -535,7 +535,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             // Again, only create type information if full debuginfo is enabled
             if cx.sess().opts.debuginfo == FullDebugInfo {
                 let actual_type_metadata = type_metadata(cx, actual_type, codemap::DUMMY_SP);
-                let name = CString::new(ident.name.as_str().as_bytes()).unwrap();
+                let name = CString::new(name.as_str().as_bytes()).unwrap();
                 let param_metadata = unsafe {
                     llvm::LLVMDIBuilderCreateTemplateTypeParameter(
                         DIB(cx),

--- a/src/librustc_trans/trans/debuginfo/mod.rs
+++ b/src/librustc_trans/trans/debuginfo/mod.rs
@@ -242,7 +242,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
 
             match item.node {
                 hir::ItemFn(ref fn_decl, _, _, _, ref generics, ref top_level_block) => {
-                    (item.ident.name, fn_decl, generics, top_level_block, item.span, true)
+                    (item.name, fn_decl, generics, top_level_block, item.span, true)
                 }
                 _ => {
                     cx.sess().span_bug(item.span,
@@ -257,7 +257,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                         return FunctionDebugContext::FunctionWithoutDebugInfo;
                     }
 
-                    (impl_item.ident.name,
+                    (impl_item.name,
                      &sig.decl,
                      &sig.generics,
                      body,
@@ -296,7 +296,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                         return FunctionDebugContext::FunctionWithoutDebugInfo;
                     }
 
-                    (trait_item.ident.name,
+                    (trait_item.name,
                      &sig.decl,
                      &sig.generics,
                      body,

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -664,8 +664,8 @@ fn trans_datum_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         hir::ExprPath(..) => {
             trans_def(bcx, expr, bcx.def(expr.id))
         }
-        hir::ExprField(ref base, ident) => {
-            trans_rec_field(bcx, &**base, ident.node.name)
+        hir::ExprField(ref base, name) => {
+            trans_rec_field(bcx, &**base, name.node)
         }
         hir::ExprTupField(ref base, idx) => {
             trans_rec_tup_field(bcx, &**base, idx.node)
@@ -1114,7 +1114,7 @@ fn trans_rvalue_dps_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             // trans. Shudder.
             fn make_field(field_name: &str, expr: P<hir::Expr>) -> hir::Field {
                 hir::Field {
-                    ident: codemap::dummy_spanned(token::str_to_ident(field_name)),
+                    name: codemap::dummy_spanned(token::str_to_ident(field_name).name),
                     expr: expr,
                     span: codemap::DUMMY_SP,
                 }
@@ -1408,7 +1408,7 @@ fn trans_struct<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let mut need_base = vec![true; vinfo.fields.len()];
 
     let numbered_fields = fields.iter().map(|field| {
-        let pos = vinfo.field_index(field.ident.node.name);
+        let pos = vinfo.field_index(field.name.node);
         need_base[pos] = false;
         (pos, &*field.expr)
     }).collect::<Vec<_>>();

--- a/src/librustc_trans/trans/foreign.rs
+++ b/src/librustc_trans/trans/foreign.rs
@@ -908,7 +908,7 @@ pub fn link_name(i: &hir::ForeignItem) -> InternedString {
         Some(ln) => ln.clone(),
         None => match weak_lang_items::link_name(&i.attrs) {
             Some(name) => name,
-            None => i.ident.name.as_str(),
+            None => i.name.as_str(),
         }
     }
 }

--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -50,7 +50,7 @@ use syntax::codemap::Span;
 use std::cmp::Ordering;
 
 pub fn get_simple_intrinsic(ccx: &CrateContext, item: &hir::ForeignItem) -> Option<ValueRef> {
-    let name = match &*item.ident.name.as_str() {
+    let name = match &*item.name.as_str() {
         "sqrtf32" => "llvm.sqrt.f32",
         "sqrtf64" => "llvm.sqrt.f64",
         "powif32" => "llvm.powi.f32",
@@ -185,7 +185,7 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         _ => panic!("expected bare_fn in trans_intrinsic_call")
     };
     let foreign_item = tcx.map.expect_foreign_item(node);
-    let name = foreign_item.ident.name.as_str();
+    let name = foreign_item.name.as_str();
 
     // For `transmute` we can just trans the input expr directly into dest
     if name == "transmute" {
@@ -931,7 +931,8 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         (_, _) => {
             let intr = match Intrinsic::find(tcx, &name) {
                 Some(intr) => intr,
-                None => ccx.sess().span_bug(foreign_item.span, "unknown intrinsic"),
+                None => ccx.sess().span_bug(foreign_item.span,
+                                            &format!("unknown intrinsic '{}'", name)),
             };
             fn one<T>(x: Vec<T>) -> T {
                 assert_eq!(x.len(), 1);

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -53,7 +53,7 @@ const VTABLE_OFFSET: usize = 3;
 /// be generated once they are invoked with specific type parameters,
 /// see `trans::base::lval_static_fn()` or `trans::base::monomorphic_fn()`.
 pub fn trans_impl(ccx: &CrateContext,
-                  name: ast::Ident,
+                  name: ast::Name,
                   impl_items: &[P<hir::ImplItem>],
                   generics: &hir::Generics,
                   id: ast::NodeId) {

--- a/src/librustc_trans/trans/monomorphize.rs
+++ b/src/librustc_trans/trans/monomorphize.rs
@@ -194,7 +194,7 @@ pub fn monomorphic_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
         }
         hir_map::NodeVariant(v) => {
             let variant = inlined_variant_def(ccx, fn_id.node);
-            assert_eq!(v.node.name.name, variant.name);
+            assert_eq!(v.node.name, variant.name);
             let d = mk_lldecl(abi::Rust);
             attributes::inline(d, attributes::InlineAttr::Hint);
             trans_enum_variant(ccx, fn_id.node, variant.disr_val, psubsts, d);

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1313,7 +1313,7 @@ fn associated_path_def_to_ty<'tcx>(this: &AstConv<'tcx>,
         match tcx.map.expect_item(trait_did.node).node {
             hir::ItemTrait(_, _, _, ref trait_items) => {
                 let item = trait_items.iter()
-                                      .find(|i| i.ident.name == assoc_name)
+                                      .find(|i| i.name == assoc_name)
                                       .expect("missing associated type");
                 DefId::local(item.id)
             }

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -545,7 +545,7 @@ fn convert_angle_bracketed_parameters<'tcx>(this: &AstConv<'tcx>,
 
     let assoc_bindings: Vec<_> =
         data.bindings.iter()
-                     .map(|b| ConvertedBinding { item_name: b.ident.name,
+                     .map(|b| ConvertedBinding { item_name: b.name,
                                                  ty: ast_ty_to_ty(this, rscope, &*b.ty),
                                                  span: b.span })
                      .collect();

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -706,25 +706,25 @@ pub fn check_struct_pat_fields<'a, 'tcx>(pcx: &pat_ctxt<'a, 'tcx>,
 
     // Typecheck each field.
     for &Spanned { node: ref field, span } in fields {
-        let field_ty = match used_fields.entry(field.ident.name) {
+        let field_ty = match used_fields.entry(field.name) {
             Occupied(occupied) => {
                 span_err!(tcx.sess, span, E0025,
                     "field `{}` bound multiple times in the pattern",
-                    field.ident);
+                    field.name);
                 span_note!(tcx.sess, *occupied.get(),
                     "field `{}` previously bound here",
-                    field.ident);
+                    field.name);
                 tcx.types.err
             }
             Vacant(vacant) => {
                 vacant.insert(span);
-                field_map.get(&field.ident.name)
+                field_map.get(&field.name)
                     .map(|f| pcx.fcx.field_ty(span, f, substs))
                     .unwrap_or_else(|| {
                         span_err!(tcx.sess, span, E0026,
                             "struct `{}` does not have a field named `{}`",
                             tcx.item_path_str(variant.did),
-                            field.ident);
+                            field.name);
                         tcx.types.err
                     })
             }

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -73,7 +73,7 @@ pub fn check_intrinsic_type(ccx: &CrateCtxt, it: &hir::ForeignItem) {
     }
 
     let tcx = ccx.tcx;
-    let name = it.ident.name.as_str();
+    let name = it.name.as_str();
     let (n_tps, inputs, output) = if name.starts_with("atomic_") {
         let split : Vec<&str> = name.split('_').collect();
         assert!(split.len() >= 2, "Atomic intrinsic not correct format");
@@ -367,7 +367,7 @@ pub fn check_platform_intrinsic_type(ccx: &CrateCtxt,
     let tcx = ccx.tcx;
     let i_ty = tcx.lookup_item_type(DefId::local(it.id));
     let i_n_tps = i_ty.generics.types.len(subst::FnSpace);
-    let name = it.ident.name.as_str();
+    let name = it.name.as_str();
 
     let (n_tps, inputs, output) = match &*name {
         "simd_eq" | "simd_ne" | "simd_lt" | "simd_le" | "simd_gt" | "simd_ge" => {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -838,7 +838,7 @@ fn check_trait_on_unimplemented<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                         Position::ArgumentNamed(s) if s == "Self" => (),
                         // So is `{A}` if A is a type parameter
                         Position::ArgumentNamed(s) => match types.iter().find(|t| {
-                            t.ident.name == s
+                            t.name == s
                         }) {
                             Some(_) => (),
                             None => {
@@ -4938,7 +4938,7 @@ pub fn check_bounds_are_used<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
         if !*b {
             span_err!(ccx.tcx.sess, span, E0091,
                 "type parameter `{}` is unused",
-                tps[i].ident);
+                tps[i].name);
         }
     }
 }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -698,7 +698,7 @@ pub fn check_item_type<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx hir::Item) {
       }
       hir::ItemFn(..) => {} // entirely within check_item_body
       hir::ItemImpl(_, _, _, _, _, ref impl_items) => {
-          debug!("ItemImpl {} with id {}", it.ident, it.id);
+          debug!("ItemImpl {} with id {}", it.name, it.id);
           match ccx.tcx.impl_trait_ref(DefId::local(it.id)) {
               Some(impl_trait_ref) => {
                 check_impl_items_against_trait(ccx,
@@ -761,7 +761,7 @@ pub fn check_item_body<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx hir::Item) {
         check_bare_fn(ccx, &**decl, &**body, it.id, it.span, fn_pty.ty, param_env);
       }
       hir::ItemImpl(_, _, _, _, _, ref impl_items) => {
-        debug!("ItemImpl {} with id {}", it.ident, it.id);
+        debug!("ItemImpl {} with id {}", it.name, it.id);
 
         let impl_pty = ccx.tcx.lookup_item_type(DefId::local(it.id));
 
@@ -845,7 +845,7 @@ fn check_trait_on_unimplemented<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                 span_err!(ccx.tcx.sess, attr.span, E0230,
                                                  "there is no type parameter \
                                                           {} on trait {}",
-                                                           s, item.ident);
+                                                           s, item.name);
                             }
                         },
                         // `{:1}` and `{}` are not to be used
@@ -988,7 +988,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                 let is_implemented = impl_items.iter().any(|ii| {
                     match ii.node {
                         hir::ConstImplItem(..) => {
-                            ii.ident.name == associated_const.name
+                            ii.name == associated_const.name
                         }
                         _ => false,
                     }
@@ -1009,7 +1009,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                     impl_items.iter().any(|ii| {
                         match ii.node {
                             hir::MethodImplItem(..) => {
-                                ii.ident.name == trait_method.name
+                                ii.name == trait_method.name
                             }
                             _ => false,
                         }
@@ -1028,7 +1028,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                 let is_implemented = impl_items.iter().any(|ii| {
                     match ii.node {
                         hir::TypeImplItem(_) => {
-                            ii.ident.name == associated_type.name
+                            ii.name == associated_type.name
                         }
                         _ => false,
                     }
@@ -1058,7 +1058,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
         span_err!(tcx.sess, invalidator.span, E0399,
                   "the following trait items need to be reimplemented \
                    as `{}` was overridden: `{}`",
-                  invalidator.ident,
+                  invalidator.name,
                   invalidated_items.iter()
                                    .map(|name| name.to_string())
                                    .collect::<Vec<_>>().join("`, `"))

--- a/src/librustc_typeck/check/wf.rs
+++ b/src/librustc_typeck/check/wf.rs
@@ -324,7 +324,7 @@ impl<'ccx, 'tcx> CheckTypeWellFormedVisitor<'ccx, 'tcx> {
                 -> ty::ParamTy
     {
         let name = match space {
-            TypeSpace => ast_generics.ty_params[index].ident.name,
+            TypeSpace => ast_generics.ty_params[index].name,
             SelfSpace => special_idents::type_self.name,
             FnSpace => self.tcx().sess.bug("Fn space occupied?"),
         };

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -431,7 +431,7 @@ impl<'ccx, 'tcx> CheckTypeWellFormedVisitor<'ccx, 'tcx> {
                 -> ty::ParamTy
     {
         let name = match space {
-            TypeSpace => ast_generics.ty_params[index].ident.name,
+            TypeSpace => ast_generics.ty_params[index].name,
             SelfSpace => special_idents::type_self.name,
             FnSpace => self.tcx().sess.bug("Fn space occupied?"),
         };

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -149,7 +149,7 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
         if let Some(trait_ref) = self.crate_context.tcx.impl_trait_ref(impl_did) {
             debug!("(checking implementation) adding impl for trait '{:?}', item '{}'",
                    trait_ref,
-                   item.ident);
+                   item.name);
 
             enforce_trait_manually_implementable(self.crate_context.tcx,
                                                  item.span,

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1099,18 +1099,18 @@ fn convert_struct_variant<'tcx>(tcx: &ty::ctxt<'tcx>,
     let fields = def.fields.iter().map(|f| {
         let fid = DefId::local(f.node.id);
         match f.node.kind {
-            hir::NamedField(ident, vis) => {
-                let dup_span = seen_fields.get(&ident.name).cloned();
+            hir::NamedField(name, vis) => {
+                let dup_span = seen_fields.get(&name).cloned();
                 if let Some(prev_span) = dup_span {
                     span_err!(tcx.sess, f.span, E0124,
                               "field `{}` is already declared",
-                              ident.name);
+                              name);
                     span_note!(tcx.sess, prev_span, "previously declared here");
                 } else {
-                    seen_fields.insert(ident.name, f.span);
+                    seen_fields.insert(name, f.span);
                 }
 
-                ty::FieldDefData::new(fid, ident.name, vis)
+                ty::FieldDefData::new(fid, name, vis)
             },
             hir::UnnamedField(vis) => {
                 ty::FieldDefData::new(fid, special_idents::unnamed_field.name, vis)
@@ -1195,7 +1195,7 @@ fn convert_enum_def<'tcx>(tcx: &ty::ctxt<'tcx>,
         if let Some(prev_disr_val) = prev_disr_val {
             let result = repr_type.disr_incr(prev_disr_val);
             if let None = result {
-                report_discrim_overflow(tcx, v.span, &v.node.name.name.as_str(),
+                report_discrim_overflow(tcx, v.span, &v.node.name.as_str(),
                                              repr_type, prev_disr_val);
             }
             result
@@ -1209,7 +1209,7 @@ fn convert_enum_def<'tcx>(tcx: &ty::ctxt<'tcx>,
                                   -> ty::VariantDefData<'tcx, 'tcx>
     {
         let did = DefId::local(v.node.id);
-        let name = v.node.name.name;
+        let name = v.node.name;
         match v.node.kind {
             hir::TupleVariantKind(ref va) => {
                 ty::VariantDefData {
@@ -1417,7 +1417,7 @@ fn trait_def_of_item<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                     .iter()
                     .enumerate()
                     .map(|(i, def)| tcx.mk_param(TypeSpace,
-                                                 i as u32, def.ident.name))
+                                                 i as u32, def.name))
                     .collect();
 
         // ...and also create the `Self` parameter.
@@ -1862,7 +1862,7 @@ fn ty_generic_predicates<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
     // type parameter (e.g., `<T:Foo>`).
     for (index, param) in ast_generics.ty_params.iter().enumerate() {
         let index = index as u32;
-        let param_ty = ty::ParamTy::new(space, index, param.ident.name).to_ty(ccx.tcx);
+        let param_ty = ty::ParamTy::new(space, index, param.name).to_ty(ccx.tcx);
         let bounds = compute_bounds(&ccx.icx(&(base_predicates, ast_generics)),
                                     param_ty,
                                     &param.bounds,
@@ -2033,7 +2033,7 @@ fn get_or_create_type_parameter_def<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
     let def = ty::TypeParameterDef {
         space: space,
         index: index,
-        name: param.ident.name,
+        name: param.name,
         def_id: DefId::local(param.id),
         default_def_id: DefId::local(parent),
         default: default,
@@ -2415,7 +2415,7 @@ fn enforce_impl_params_are_constrained<'tcx>(tcx: &ty::ctxt<'tcx>,
     for (index, ty_param) in ast_generics.ty_params.iter().enumerate() {
         let param_ty = ty::ParamTy { space: TypeSpace,
                                      idx: index as u32,
-                                     name: ty_param.ident.name };
+                                     name: ty_param.name };
         if !input_parameters.contains(&ctp::Parameter::Type(param_ty)) {
             report_unused_parameter(tcx, ty_param.span, "type", &param_ty.to_string());
         }

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -43,7 +43,7 @@ use super::{Clean, ToSource};
 ///
 /// The returned value is `None` if the `id` could not be inlined, and `Some`
 /// of a vector of items if it was successfully expanded.
-pub fn try_inline(cx: &DocContext, id: ast::NodeId, into: Option<ast::Ident>)
+pub fn try_inline(cx: &DocContext, id: ast::NodeId, into: Option<ast::Name>)
                   -> Option<Vec<clean::Item>> {
     let tcx = match cx.tcx_opt() {
         Some(tcx) => tcx,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2386,14 +2386,14 @@ impl Clean<Vec<Item>> for doctree::Import {
                 (ret, ImportList(resolve_use_source(cx, p.clean(cx), self.id),
                                  remaining))
             }
-            hir::ViewPathSimple(i, ref p) => {
+            hir::ViewPathSimple(name, ref p) => {
                 if !denied {
-                    match inline::try_inline(cx, self.id, Some(i)) {
+                    match inline::try_inline(cx, self.id, Some(name)) {
                         Some(items) => return items,
                         None => {}
                     }
                 }
-                (vec![], SimpleImport(i.clean(cx),
+                (vec![], SimpleImport(name.clean(cx),
                                       resolve_use_source(cx, p.clean(cx), self.id)))
             }
         };

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1257,7 +1257,7 @@ impl Clean<Item> for hir::TraitItem {
             }
         };
         Item {
-            name: Some(self.ident.clean(cx)),
+            name: Some(self.name.clean(cx)),
             attrs: self.attrs.clean(cx),
             source: self.span.clean(cx),
             def_id: DefId::local(self.id),
@@ -1290,7 +1290,7 @@ impl Clean<Item> for hir::ImplItem {
             }, true),
         };
         Item {
-            name: Some(self.ident.clean(cx)),
+            name: Some(self.name.clean(cx)),
             source: self.span.clean(cx),
             attrs: self.attrs.clean(cx),
             def_id: DefId::local(self.id),
@@ -2484,7 +2484,7 @@ impl Clean<Item> for hir::ForeignItem {
             }
         };
         Item {
-            name: Some(self.ident.clean(cx)),
+            name: Some(self.name.clean(cx)),
             attrs: self.attrs.clean(cx),
             source: self.span.clean(cx),
             def_id: DefId::local(self.id),

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -494,7 +494,7 @@ pub struct TyParam {
 impl Clean<TyParam> for hir::TyParam {
     fn clean(&self, cx: &DocContext) -> TyParam {
         TyParam {
-            name: self.ident.clean(cx),
+            name: self.name.clean(cx),
             did: DefId { krate: LOCAL_CRATE, node: self.id },
             bounds: self.bounds.clean(cx),
             default: self.default.clean(cx),
@@ -2547,7 +2547,7 @@ fn name_from_pat(p: &hir::Pat) -> String {
         PatStruct(ref name, ref fields, etc) => {
             format!("{} {{ {}{} }}", path_to_string(name),
                 fields.iter().map(|&Spanned { node: ref fp, .. }|
-                                  format!("{}: {}", fp.ident, name_from_pat(&*fp.pat)))
+                                  format!("{}: {}", fp.name, name_from_pat(&*fp.pat)))
                              .collect::<Vec<String>>().join(", "),
                 if etc { ", ..." } else { "" }
             )
@@ -2840,7 +2840,7 @@ pub struct TypeBinding {
 impl Clean<TypeBinding> for hir::TypeBinding {
     fn clean(&self, cx: &DocContext) -> TypeBinding {
         TypeBinding {
-            name: self.ident.clean(cx),
+            name: self.name.clean(cx),
             ty: self.ty.clean(cx)
         }
     }

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -17,7 +17,7 @@ use syntax;
 use syntax::codemap::Span;
 use syntax::abi;
 use syntax::ast;
-use syntax::ast::{Ident, Name, NodeId};
+use syntax::ast::{Name, NodeId};
 use syntax::attr;
 use syntax::ptr::P;
 use rustc_front::hir;
@@ -117,7 +117,7 @@ pub struct Enum {
 }
 
 pub struct Variant {
-    pub name: Ident,
+    pub name: Name,
     pub attrs: Vec<ast::Attribute>,
     pub kind: hir::VariantKind,
     pub id: ast::NodeId,

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -17,13 +17,13 @@ use syntax;
 use syntax::codemap::Span;
 use syntax::abi;
 use syntax::ast;
-use syntax::ast::{Ident, NodeId};
+use syntax::ast::{Ident, Name, NodeId};
 use syntax::attr;
 use syntax::ptr::P;
 use rustc_front::hir;
 
 pub struct Module {
-    pub name: Option<Ident>,
+    pub name: Option<Name>,
     pub attrs: Vec<ast::Attribute>,
     pub where_outer: Span,
     pub where_inner: Span,
@@ -48,7 +48,7 @@ pub struct Module {
 }
 
 impl Module {
-    pub fn new(name: Option<Ident>) -> Module {
+    pub fn new(name: Option<Name>) -> Module {
         Module {
             name       : name,
             id: 0,
@@ -98,7 +98,7 @@ pub struct Struct {
     pub stab: Option<attr::Stability>,
     pub id: NodeId,
     pub struct_type: StructType,
-    pub name: Ident,
+    pub name: Name,
     pub generics: hir::Generics,
     pub attrs: Vec<ast::Attribute>,
     pub fields: Vec<hir::StructField>,
@@ -113,7 +113,7 @@ pub struct Enum {
     pub attrs: Vec<ast::Attribute>,
     pub id: NodeId,
     pub whence: Span,
-    pub name: Ident,
+    pub name: Name,
 }
 
 pub struct Variant {
@@ -129,7 +129,7 @@ pub struct Function {
     pub decl: hir::FnDecl,
     pub attrs: Vec<ast::Attribute>,
     pub id: NodeId,
-    pub name: Ident,
+    pub name: Name,
     pub vis: hir::Visibility,
     pub stab: Option<attr::Stability>,
     pub unsafety: hir::Unsafety,
@@ -142,7 +142,7 @@ pub struct Function {
 pub struct Typedef {
     pub ty: P<hir::Ty>,
     pub gen: hir::Generics,
-    pub name: Ident,
+    pub name: Name,
     pub id: ast::NodeId,
     pub attrs: Vec<ast::Attribute>,
     pub whence: Span,
@@ -155,7 +155,7 @@ pub struct Static {
     pub type_: P<hir::Ty>,
     pub mutability: hir::Mutability,
     pub expr: P<hir::Expr>,
-    pub name: Ident,
+    pub name: Name,
     pub attrs: Vec<ast::Attribute>,
     pub vis: hir::Visibility,
     pub stab: Option<attr::Stability>,
@@ -166,7 +166,7 @@ pub struct Static {
 pub struct Constant {
     pub type_: P<hir::Ty>,
     pub expr: P<hir::Expr>,
-    pub name: Ident,
+    pub name: Name,
     pub attrs: Vec<ast::Attribute>,
     pub vis: hir::Visibility,
     pub stab: Option<attr::Stability>,
@@ -176,7 +176,7 @@ pub struct Constant {
 
 pub struct Trait {
     pub unsafety: hir::Unsafety,
-    pub name: Ident,
+    pub name: Name,
     pub items: Vec<P<hir::TraitItem>>, //should be TraitItem
     pub generics: hir::Generics,
     pub bounds: Vec<hir::TyParamBound>,
@@ -219,7 +219,7 @@ pub struct Macro {
 }
 
 pub struct ExternCrate {
-    pub name: Ident,
+    pub name: Name,
     pub path: Option<String>,
     pub vis: hir::Visibility,
     pub attrs: Vec<ast::Attribute>,

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -210,12 +210,12 @@ pub struct DefaultImpl {
 }
 
 pub struct Macro {
-    pub name: Ident,
+    pub name: Name,
     pub id: ast::NodeId,
     pub attrs: Vec<ast::Attribute>,
     pub whence: Span,
     pub stab: Option<attr::Stability>,
-    pub imported_from: Option<Ident>,
+    pub imported_from: Option<Name>,
 }
 
 pub struct ExternCrate {

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -199,7 +199,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
 
     }
 
-    fn resolve_id(&mut self, id: ast::NodeId, renamed: Option<ast::Ident>,
+    fn resolve_id(&mut self, id: ast::NodeId, renamed: Option<ast::Name>,
                   glob: bool, om: &mut Module, please_inline: bool) -> bool {
         let tcx = match self.cx.tcx_opt() {
             Some(tcx) => tcx,
@@ -241,9 +241,9 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
     }
 
     pub fn visit_item(&mut self, item: &hir::Item,
-                      renamed: Option<ast::Ident>, om: &mut Module) {
+                      renamed: Option<ast::Name>, om: &mut Module) {
         debug!("Visiting item {:?}", item);
-        let name = renamed.map_or(item.name, |x| x.name);
+        let name = renamed.unwrap_or(item.name);
         match item.node {
             hir::ItemExternCrate(ref p) => {
                 let path = match *p {
@@ -398,7 +398,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
         Macro {
             id: def.id,
             attrs: def.attrs.clone(),
-            name: def.ident,
+            name: def.name,
             whence: def.span,
             stab: self.stability(def.id),
             imported_from: def.imported_from,

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -83,7 +83,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
     }
 
     pub fn visit_struct_def(&mut self, item: &hir::Item,
-                            name: ast::Ident, sd: &hir::StructDef,
+                            name: ast::Name, sd: &hir::StructDef,
                             generics: &hir::Generics) -> Struct {
         debug!("Visiting struct");
         let struct_type = struct_type_from_def(&*sd);
@@ -101,7 +101,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
     }
 
     pub fn visit_enum_def(&mut self, it: &hir::Item,
-                          name: ast::Ident, def: &hir::EnumDef,
+                          name: ast::Name, def: &hir::EnumDef,
                           params: &hir::Generics) -> Enum {
         debug!("Visiting enum");
         Enum {
@@ -124,7 +124,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
     }
 
     pub fn visit_fn(&mut self, item: &hir::Item,
-                    name: ast::Ident, fd: &hir::FnDecl,
+                    name: ast::Name, fd: &hir::FnDecl,
                     unsafety: &hir::Unsafety,
                     constness: hir::Constness,
                     abi: &abi::Abi,
@@ -148,7 +148,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
     pub fn visit_mod_contents(&mut self, span: Span, attrs: Vec<ast::Attribute> ,
                               vis: hir::Visibility, id: ast::NodeId,
                               m: &hir::Mod,
-                              name: Option<ast::Ident>) -> Module {
+                              name: Option<ast::Name>) -> Module {
         let mut om = Module::new(name);
         om.where_outer = span;
         om.where_inner = m.inner;
@@ -243,7 +243,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
     pub fn visit_item(&mut self, item: &hir::Item,
                       renamed: Option<ast::Ident>, om: &mut Module) {
         debug!("Visiting item {:?}", item);
-        let name = renamed.unwrap_or(item.ident);
+        let name = renamed.map_or(item.name, |x| x.name);
         match item.node {
             hir::ItemExternCrate(ref p) => {
                 let path = match *p {

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -151,8 +151,7 @@ pub const ILLEGAL_CTXT : SyntaxContext = 1;
 
 /// A name is a part of an identifier, representing a string or gensym. It's
 /// the result of interning.
-#[derive(Eq, Ord, PartialEq, PartialOrd, Hash,
-           RustcEncodable, RustcDecodable, Clone, Copy)]
+#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Clone, Copy)]
 pub struct Name(pub u32);
 
 impl<T: AsRef<str>> PartialEq<T> for Name {
@@ -178,6 +177,18 @@ impl Name {
 
 /// A mark represents a unique id associated with a macro expansion
 pub type Mrk = u32;
+
+impl Encodable for Name {
+    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
+        s.emit_str(&self.as_str())
+    }
+}
+
+impl Decodable for Name {
+    fn decode<D: Decoder>(d: &mut D) -> Result<Name, D::Error> {
+        Ok(token::intern(&try!(d.read_str())[..]))
+    }
+}
 
 impl Encodable for Ident {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {

--- a/src/test/auxiliary/lint_group_plugin_test.rs
+++ b/src/test/auxiliary/lint_group_plugin_test.rs
@@ -37,7 +37,7 @@ impl LintPass for Pass {
 
 impl LateLintPass for Pass {
     fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
-        match &*it.ident.name.as_str() {
+        match &*it.name.as_str() {
             "lintme" => cx.span_lint(TEST_LINT, it.span, "item is named 'lintme'"),
             "pleaselintme" => cx.span_lint(PLEASE_LINT, it.span, "item is named 'pleaselintme'"),
             _ => {}


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/6993

This patch replaces `Ident`s with `Name`s in data structures of HIR and updates the dependent crates to compile and pass `make check`.
Some HIR structures still use `Ident`s, namely `PathSegment`, `PatIdent`, `ExprWhile`, `ExprLoop`, `ExprBreak` and `ExprAgain`,  they need them for resolve (but `PathSegment` is special, see https://github.com/rust-lang/rust/issues/6993#issuecomment-141256292).

r? @nrc 
