### PR TITLE
Implement basic NetBSD/amd64 support

### DIFF
--- a/mk/cfg/x86_64-unknown-netbsd.mk
+++ b/mk/cfg/x86_64-unknown-netbsd.mk
@@ -1,4 +1,5 @@
 # x86_64-unknown-netbsd configuration
+CROSS_PREFIX_x86_64-unknown-netbsd=x86_64-unknown-netbsd-
 CC_x86_64-unknown-netbsd=$(CC)
 CXX_x86_64-unknown-netbsd=$(CXX)
 CPP_x86_64-unknown-netbsd=$(CPP)

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -1450,7 +1450,23 @@ pub mod types {
                     pub __unused7: *mut c_void,
                 }
 
-                #[cfg(any(target_os = "netbsd", target_os="openbsd"))]
+                #[cfg(target_os = "netbsd")]
+                #[repr(C)]
+                #[derive(Copy, Clone)] pub struct glob_t {
+                    pub gl_pathc:  size_t,
+                    pub gl_matchc: size_t,
+                    pub gl_offs:   size_t,
+                    pub gl_flags:  c_int,
+                    pub gl_pathv:  *mut *mut c_char,
+                    pub __unused1: *mut c_void,
+                    pub __unused2: *mut c_void,
+                    pub __unused3: *mut c_void,
+                    pub __unused4: *mut c_void,
+                    pub __unused5: *mut c_void,
+                    pub __unused6: *mut c_void,
+                }
+
+                #[cfg(target_os = "openbsd")]
                 #[repr(C)]
                 #[derive(Copy, Clone)] pub struct glob_t {
                     pub gl_pathc:  c_int,
@@ -1578,6 +1594,7 @@ pub mod types {
                     pub ipv6mr_multiaddr: in6_addr,
                     pub ipv6mr_interface: c_uint,
                 }
+                #[cfg(not(target_os = "netbsd"))]
                 #[repr(C)]
                 #[derive(Copy, Clone)] pub struct addrinfo {
                     pub ai_flags: c_int,
@@ -1587,6 +1604,18 @@ pub mod types {
                     pub ai_addrlen: socklen_t,
                     pub ai_addr: *mut sockaddr,
                     pub ai_canonname: *mut c_char,
+                    pub ai_next: *mut addrinfo,
+                }
+                #[cfg(target_os = "netbsd")]
+                #[repr(C)]
+                #[derive(Copy, Clone)] pub struct addrinfo {
+                    pub ai_flags: c_int,
+                    pub ai_family: c_int,
+                    pub ai_socktype: c_int,
+                    pub ai_protocol: c_int,
+                    pub ai_addrlen: socklen_t,
+                    pub ai_canonname: *mut c_char,
+                    pub ai_addr: *mut sockaddr,
                     pub ai_next: *mut addrinfo,
                 }
                 #[repr(C)]
@@ -1654,7 +1683,7 @@ pub mod types {
             pub mod posix01 {
                 use types::common::c95::{c_void};
                 use types::common::c99::{uint32_t, uint64_t};
-                use types::os::arch::c95::{c_long, time_t};
+                use types::os::arch::c95::{c_int, c_uint, c_long, time_t};
                 use types::os::arch::posix88::{dev_t, gid_t};
                 use types::os::arch::posix88::{mode_t, off_t};
                 use types::os::arch::posix88::{uid_t};
@@ -1665,6 +1694,7 @@ pub mod types {
                 pub type blkcnt_t = i64;
                 pub type fflags_t = u32; // type not declared, but struct stat have u_int32_t
 
+                #[cfg(not(target_os = "netbsd"))]
                 #[repr(C)]
                 #[derive(Copy, Clone)] pub struct stat {
                     pub st_mode: mode_t,
@@ -1688,13 +1718,47 @@ pub mod types {
                     pub st_birthtime: time_t,
                     pub st_birthtime_nsec: c_long,
                 }
+                #[cfg(target_os = "netbsd")]
+                #[repr(C)]
+                #[derive(Copy, Clone)] pub struct stat {
+                    pub st_mode: mode_t,
+                    pub st_dev: dev_t,
+                    pub st_ino: ino_t,
+                    pub st_nlink: nlink_t,
+                    pub st_uid: uid_t,
+                    pub st_gid: gid_t,
+                    pub st_rdev: dev_t,
+                    pub st_atime: time_t,
+                    pub st_atime_nsec: c_long,
+                    pub st_mtime: time_t,
+                    pub st_mtime_nsec: c_long,
+                    pub st_ctime: time_t,
+                    pub st_ctime_nsec: c_long,
+                    pub st_birthtime: time_t,
+                    pub st_birthtime_nsec: c_long,
+                    pub st_size: off_t,
+                    pub st_blocks: blkcnt_t,
+                    pub st_blksize: blksize_t,
+                    pub st_flags: fflags_t,
+                    pub st_gen: uint32_t,
+                    st_spare: [uint32_t; 2],
+                }
+
                 #[repr(C)]
                 #[derive(Copy, Clone)] pub struct utimbuf {
                     pub actime: time_t,
                     pub modtime: time_t,
                 }
 
+                #[cfg(not(target_os = "netbsd"))]
                 pub type pthread_attr_t = *mut c_void;
+                #[cfg(target_os = "netbsd")]
+                #[repr(C)]
+                #[derive(Copy, Clone)] pub struct pthread_attr_t {
+                    pta_magic: c_uint,
+                    pta_flags: c_int,
+                    pta_private: *mut c_void,
+                }
             }
             pub mod posix08 {
             }
@@ -4450,7 +4514,7 @@ pub mod consts {
         }
     }
 
-    #[cfg(any(target_os = "bitrig", target_os = "netbsd", target_os = "openbsd"))]
+    #[cfg(any(target_os = "bitrig", target_os = "openbsd"))]
     pub mod os {
         pub mod c95 {
             use types::os::arch::c95::{c_int, c_uint};
@@ -4737,17 +4801,10 @@ pub mod consts {
             pub const RUSAGE_CHILDREN: c_int = -1;
             pub const RUSAGE_THREAD: c_int = 1;
         }
-        #[cfg(any(target_os = "bitrig", target_os = "openbsd"))]
         pub mod posix08 {
             use types::os::arch::c95::c_int;
             pub const O_CLOEXEC: c_int = 0x10000;
             pub const F_DUPFD_CLOEXEC: c_int = 10;
-        }
-        #[cfg(target_os = "netbsd")]
-        pub mod posix08 {
-            use types::os::arch::c95::c_int;
-            pub const O_CLOEXEC: c_int = 0x400000;
-            pub const F_DUPFD_CLOEXEC: c_int = 12;
         }
         pub mod bsd44 {
             use types::os::arch::c95::c_int;
@@ -4886,6 +4943,410 @@ pub mod consts {
 
             pub const _PC_NAME_MAX: c_int = 4;
             pub const _PC_PATH_MAX: c_int = 5;
+        }
+    }
+
+    #[cfg(target_os = "netbsd")]
+    pub mod os {
+        pub mod c95 {
+            use types::os::arch::c95::{c_int, c_uint};
+
+            pub const EXIT_FAILURE : c_int = 1;
+            pub const EXIT_SUCCESS : c_int = 0;
+            pub const RAND_MAX : c_int = 2147483647;
+            pub const EOF : c_int = -1;
+            pub const SEEK_SET : c_int = 0;
+            pub const SEEK_CUR : c_int = 1;
+            pub const SEEK_END : c_int = 2;
+            pub const _IOFBF : c_int = 0;
+            pub const _IONBF : c_int = 2;
+            pub const _IOLBF : c_int = 1;
+            pub const BUFSIZ : c_uint = 1024;
+            pub const FOPEN_MAX : c_uint = 20;
+            pub const FILENAME_MAX : c_uint = 1024;
+            pub const L_tmpnam : c_uint = 1024;
+            pub const TMP_MAX : c_uint = 308915776;
+        }
+        pub mod c99 {
+        }
+        pub mod posix88 {
+            use types::common::c95::c_void;
+            use types::os::arch::c95::c_int;
+            use types::os::arch::posix88::mode_t;
+
+            pub const O_RDONLY : c_int = 0;
+            pub const O_WRONLY : c_int = 1;
+            pub const O_RDWR : c_int = 2;
+            pub const O_APPEND : c_int = 8;
+            pub const O_CREAT : c_int = 512;
+            pub const O_EXCL : c_int = 2048;
+            pub const O_NOCTTY : c_int = 32768;
+            pub const O_TRUNC : c_int = 1024;
+            pub const S_IFIFO : mode_t = 4096;
+            pub const S_IFCHR : mode_t = 8192;
+            pub const S_IFBLK : mode_t = 24576;
+            pub const S_IFDIR : mode_t = 16384;
+            pub const S_IFREG : mode_t = 32768;
+            pub const S_IFLNK : mode_t = 40960;
+            pub const S_IFSOCK : mode_t = 49152;
+            pub const S_IFMT : mode_t = 61440;
+            pub const S_IEXEC : mode_t = 64;
+            pub const S_IWRITE : mode_t = 128;
+            pub const S_IREAD : mode_t = 256;
+            pub const S_IRWXU : mode_t = 448;
+            pub const S_IXUSR : mode_t = 64;
+            pub const S_IWUSR : mode_t = 128;
+            pub const S_IRUSR : mode_t = 256;
+            pub const S_IRWXG : mode_t = 56;
+            pub const S_IXGRP : mode_t = 8;
+            pub const S_IWGRP : mode_t = 16;
+            pub const S_IRGRP : mode_t = 32;
+            pub const S_IRWXO : mode_t = 7;
+            pub const S_IXOTH : mode_t = 1;
+            pub const S_IWOTH : mode_t = 2;
+            pub const S_IROTH : mode_t = 4;
+            pub const F_OK : c_int = 0;
+            pub const R_OK : c_int = 4;
+            pub const W_OK : c_int = 2;
+            pub const X_OK : c_int = 1;
+            pub const STDIN_FILENO : c_int = 0;
+            pub const STDOUT_FILENO : c_int = 1;
+            pub const STDERR_FILENO : c_int = 2;
+            pub const F_LOCK : c_int = 1;
+            pub const F_TEST : c_int = 3;
+            pub const F_TLOCK : c_int = 2;
+            pub const F_ULOCK : c_int = 0;
+            pub const SIGHUP : c_int = 1;
+            pub const SIGINT : c_int = 2;
+            pub const SIGQUIT : c_int = 3;
+            pub const SIGILL : c_int = 4;
+            pub const SIGABRT : c_int = 6;
+            pub const SIGFPE : c_int = 8;
+            pub const SIGKILL : c_int = 9;
+            pub const SIGSEGV : c_int = 11;
+            pub const SIGPIPE : c_int = 13;
+            pub const SIGALRM : c_int = 14;
+            pub const SIGTERM : c_int = 15;
+
+            pub const PROT_NONE : c_int = 0;
+            pub const PROT_READ : c_int = 1;
+            pub const PROT_WRITE : c_int = 2;
+            pub const PROT_EXEC : c_int = 4;
+
+            pub const MAP_FILE : c_int = 0;
+            pub const MAP_SHARED : c_int = 1;
+            pub const MAP_PRIVATE : c_int = 2;
+            pub const MAP_FIXED : c_int = 16;
+            pub const MAP_ANON : c_int = 4096;
+
+            pub const MAP_FAILED : *mut c_void = !0 as *mut c_void;
+
+            pub const MCL_CURRENT : c_int = 1;
+            pub const MCL_FUTURE : c_int = 2;
+
+            pub const MS_ASYNC : c_int = 1;
+            pub const MS_SYNC : c_int = 4;
+            pub const MS_INVALIDATE : c_int = 2;
+
+            pub const EPERM : c_int = 1;
+            pub const ENOENT : c_int = 2;
+            pub const ESRCH : c_int = 3;
+            pub const EINTR : c_int = 4;
+            pub const EIO : c_int = 5;
+            pub const ENXIO : c_int = 6;
+            pub const E2BIG : c_int = 7;
+            pub const ENOEXEC : c_int = 8;
+            pub const EBADF : c_int = 9;
+            pub const ECHILD : c_int = 10;
+            pub const EDEADLK : c_int = 11;
+            pub const ENOMEM : c_int = 12;
+            pub const EACCES : c_int = 13;
+            pub const EFAULT : c_int = 14;
+            pub const ENOTBLK : c_int = 15;
+            pub const EBUSY : c_int = 16;
+            pub const EEXIST : c_int = 17;
+            pub const EXDEV : c_int = 18;
+            pub const ENODEV : c_int = 19;
+            pub const ENOTDIR : c_int = 20;
+            pub const EISDIR : c_int = 21;
+            pub const EINVAL : c_int = 22;
+            pub const ENFILE : c_int = 23;
+            pub const EMFILE : c_int = 24;
+            pub const ENOTTY : c_int = 25;
+            pub const ETXTBSY : c_int = 26;
+            pub const EFBIG : c_int = 27;
+            pub const ENOSPC : c_int = 28;
+            pub const ESPIPE : c_int = 29;
+            pub const EROFS : c_int = 30;
+            pub const EMLINK : c_int = 31;
+            pub const EPIPE : c_int = 32;
+            pub const EDOM : c_int = 33;
+            pub const ERANGE : c_int = 34;
+            pub const EAGAIN : c_int = 35;
+            pub const EWOULDBLOCK : c_int = 35;
+            pub const EINPROGRESS : c_int = 36;
+            pub const EALREADY : c_int = 37;
+            pub const ENOTSOCK : c_int = 38;
+            pub const EDESTADDRREQ : c_int = 39;
+            pub const EMSGSIZE : c_int = 40;
+            pub const EPROTOTYPE : c_int = 41;
+            pub const ENOPROTOOPT : c_int = 42;
+            pub const EPROTONOSUPPORT : c_int = 43;
+            pub const ESOCKTNOSUPPORT : c_int = 44;
+            pub const EOPNOTSUPP : c_int = 45;
+            pub const EPFNOSUPPORT : c_int = 46;
+            pub const EAFNOSUPPORT : c_int = 47;
+            pub const EADDRINUSE : c_int = 48;
+            pub const EADDRNOTAVAIL : c_int = 49;
+            pub const ENETDOWN : c_int = 50;
+            pub const ENETUNREACH : c_int = 51;
+            pub const ENETRESET : c_int = 52;
+            pub const ECONNABORTED : c_int = 53;
+            pub const ECONNRESET : c_int = 54;
+            pub const ENOBUFS : c_int = 55;
+            pub const EISCONN : c_int = 56;
+            pub const ENOTCONN : c_int = 57;
+            pub const ESHUTDOWN : c_int = 58;
+            pub const ETOOMANYREFS : c_int = 59;
+            pub const ETIMEDOUT : c_int = 60;
+            pub const ECONNREFUSED : c_int = 61;
+            pub const ELOOP : c_int = 62;
+            pub const ENAMETOOLONG : c_int = 63;
+            pub const EHOSTDOWN : c_int = 64;
+            pub const EHOSTUNREACH : c_int = 65;
+            pub const ENOTEMPTY : c_int = 66;
+            pub const EPROCLIM : c_int = 67;
+            pub const EUSERS : c_int = 68;
+            pub const EDQUOT : c_int = 69;
+            pub const ESTALE : c_int = 70;
+            pub const EREMOTE : c_int = 71;
+            pub const EBADRPC : c_int = 72;
+            pub const ERPCMISMATCH : c_int = 73;
+            pub const EPROGUNAVAIL : c_int = 74;
+            pub const EPROGMISMATCH : c_int = 75;
+            pub const EPROCUNAVAIL : c_int = 76;
+            pub const ENOLCK : c_int = 77;
+            pub const ENOSYS : c_int = 78;
+            pub const EFTYPE : c_int = 79;
+            pub const EAUTH : c_int = 80;
+            pub const ENEEDAUTH : c_int = 81;
+            pub const ENOATTR : c_int = 93;
+            pub const EILSEQ : c_int = 85;
+            pub const EOVERFLOW : c_int = 84;
+            pub const ECANCELED : c_int = 87;
+            pub const EIDRM : c_int = 82;
+            pub const ENOMSG : c_int = 83;
+            pub const ENOTSUP : c_int = 86;
+            pub const ELAST : c_int = 96;
+        }
+        pub mod posix01 {
+            use types::os::arch::c95::{c_int, size_t};
+            use types::os::common::posix01::rlim_t;
+
+            pub const F_DUPFD : c_int = 0;
+            pub const F_GETFD : c_int = 1;
+            pub const F_SETFD : c_int = 2;
+            pub const F_GETFL : c_int = 3;
+            pub const F_SETFL : c_int = 4;
+            pub const F_GETOWN : c_int = 5;
+            pub const F_SETOWN : c_int = 6;
+            pub const F_GETLK : c_int = 7;
+            pub const F_SETLK : c_int = 8;
+            pub const F_SETLKW : c_int = 9;
+
+            pub const SIGTRAP : c_int = 5;
+            pub const SIG_IGN : size_t = 1;
+
+            pub const GLOB_APPEND : c_int = 1;
+            pub const GLOB_DOOFFS : c_int = 2;
+            pub const GLOB_ERR : c_int = 4;
+            pub const GLOB_MARK : c_int = 8;
+            pub const GLOB_NOCHECK : c_int = 16;
+            pub const GLOB_NOSORT : c_int = 32;
+            pub const GLOB_NOESCAPE : c_int = 4096;
+
+            pub const GLOB_NOSPACE : c_int = -1;
+            pub const GLOB_ABORTED : c_int = -2;
+            pub const GLOB_NOMATCH : c_int = -3;
+            pub const GLOB_NOSYS : c_int = -4;
+
+            pub const POSIX_MADV_NORMAL : c_int = 0;
+            pub const POSIX_MADV_RANDOM : c_int = 1;
+            pub const POSIX_MADV_SEQUENTIAL : c_int = 2;
+            pub const POSIX_MADV_WILLNEED : c_int = 3;
+            pub const POSIX_MADV_DONTNEED : c_int = 4;
+
+            pub const _SC_IOV_MAX : c_int = 32;
+            pub const _SC_GETGR_R_SIZE_MAX : c_int = 47;
+            pub const _SC_GETPW_R_SIZE_MAX : c_int = 48;
+            pub const _SC_LOGIN_NAME_MAX : c_int = 37;
+            pub const _SC_MQ_PRIO_MAX : c_int = 55;
+            pub const _SC_THREAD_ATTR_STACKADDR : c_int = 61;
+            pub const _SC_THREAD_ATTR_STACKSIZE : c_int = 62;
+            pub const _SC_THREAD_DESTRUCTOR_ITERATIONS : c_int = 57;
+            pub const _SC_THREAD_KEYS_MAX : c_int = 58;
+            pub const _SC_THREAD_PRIO_INHERIT : c_int = 64;
+            pub const _SC_THREAD_PRIO_PROTECT : c_int = 65;
+            pub const _SC_THREAD_PRIORITY_SCHEDULING : c_int = 63;
+            pub const _SC_THREAD_PROCESS_SHARED : c_int = 66;
+            pub const _SC_THREAD_SAFE_FUNCTIONS : c_int = 67;
+            pub const _SC_THREAD_STACK_MIN : c_int = 59;
+            pub const _SC_THREAD_THREADS_MAX : c_int = 60;
+            pub const _SC_THREADS : c_int = 41;
+            pub const _SC_TTY_NAME_MAX : c_int = 68;
+            pub const _SC_ATEXIT_MAX : c_int = 40;
+            pub const _SC_XOPEN_SHM : c_int = 30;
+
+            pub const PTHREAD_CREATE_JOINABLE : c_int = 0;
+            pub const PTHREAD_CREATE_DETACHED : c_int = 1;
+            pub const PTHREAD_STACK_MIN : size_t = 2048;
+
+            pub const CLOCK_REALTIME : c_int = 0;
+            pub const CLOCK_MONOTONIC : c_int = 3;
+
+            pub const RLIMIT_CPU : c_int = 0;
+            pub const RLIMIT_FSIZE : c_int = 1;
+            pub const RLIMIT_DATA : c_int = 2;
+            pub const RLIMIT_STACK : c_int = 3;
+            pub const RLIMIT_CORE : c_int = 4;
+            pub const RLIMIT_RSS : c_int = 5;
+            pub const RLIMIT_MEMLOCK : c_int = 6;
+            pub const RLIMIT_NPROC : c_int = 7;
+            pub const RLIMIT_NOFILE : c_int = 8;
+            pub const RLIM_NLIMITS : c_int = 9;
+
+            pub const RLIM_INFINITY : rlim_t = 0x7fff_ffff_ffff_ffff;
+            pub const RLIM_SAVED_MAX : rlim_t = RLIM_INFINITY;
+            pub const RLIM_SAVED_CUR : rlim_t = RLIM_INFINITY;
+
+            pub const RUSAGE_SELF : c_int = 0;
+            pub const RUSAGE_CHILDREN : c_int = -1;
+            pub const RUSAGE_THREAD : c_int = 1;
+        }
+        pub mod posix08 {
+            use types::os::arch::c95::c_int;
+            pub const O_CLOEXEC: c_int = 0x400000;
+            pub const F_DUPFD_CLOEXEC: c_int = 12;
+        }
+        pub mod bsd44 {
+            use types::os::arch::c95::c_int;
+
+            pub const MADV_NORMAL : c_int = 0;
+            pub const MADV_RANDOM : c_int = 1;
+            pub const MADV_SEQUENTIAL : c_int = 2;
+            pub const MADV_WILLNEED : c_int = 3;
+            pub const MADV_DONTNEED : c_int = 4;
+            pub const MADV_FREE : c_int = 6;
+
+            pub const AF_UNIX : c_int = 1;
+            pub const AF_INET : c_int = 2;
+            pub const AF_INET6 : c_int = 24;
+            pub const SOCK_STREAM : c_int = 1;
+            pub const SOCK_DGRAM : c_int = 2;
+            pub const SOCK_RAW : c_int = 3;
+            pub const IPPROTO_TCP : c_int = 6;
+            pub const IPPROTO_IP : c_int = 0;
+            pub const IPPROTO_IPV6 : c_int = 41;
+            pub const IP_MULTICAST_TTL : c_int = 10;
+            pub const IP_MULTICAST_LOOP : c_int = 11;
+            pub const IP_TTL : c_int = 4;
+            pub const IP_HDRINCL : c_int = 2;
+            pub const IP_ADD_MEMBERSHIP : c_int = 12;
+            pub const IP_DROP_MEMBERSHIP : c_int = 13;
+
+            pub const TCP_NODELAY : c_int = 1;
+            pub const SOL_SOCKET : c_int = 65535;
+            pub const SO_DEBUG : c_int = 1;
+            pub const SO_ACCEPTCONN : c_int = 2;
+            pub const SO_REUSEADDR : c_int = 4;
+            pub const SO_KEEPALIVE : c_int = 8;
+            pub const SO_DONTROUTE : c_int = 16;
+            pub const SO_BROADCAST : c_int = 32;
+            pub const SO_USELOOPBACK : c_int = 64;
+            pub const SO_LINGER : c_int = 128;
+            pub const SO_OOBINLINE : c_int = 256;
+            pub const SO_REUSEPORT : c_int = 512;
+            pub const SO_SNDBUF : c_int = 4097;
+            pub const SO_RCVBUF : c_int = 4098;
+            pub const SO_SNDLOWAT : c_int = 4099;
+            pub const SO_RCVLOWAT : c_int = 4100;
+            pub const SO_SNDTIMEO : c_int = 4107;
+            pub const SO_RCVTIMEO : c_int = 4108;
+            pub const SO_ERROR : c_int = 4103;
+            pub const SO_TYPE : c_int = 4104;
+
+            pub const IFF_LOOPBACK : c_int = 0x8;
+
+            pub const SHUT_RD : c_int = 0;
+            pub const SHUT_WR : c_int = 1;
+            pub const SHUT_RDWR : c_int = 2;
+
+            pub const LOCK_SH : c_int = 1;
+            pub const LOCK_EX : c_int = 2;
+            pub const LOCK_NB : c_int = 4;
+            pub const LOCK_UN : c_int = 8;
+        }
+        pub mod extra {
+            use types::os::arch::c95::c_int;
+
+
+            pub const MAP_RENAME : c_int = 32;
+            pub const MAP_NORESERVE : c_int = 64;
+            pub const MAP_HASSEMAPHORE : c_int = 512;
+
+            pub const IPPROTO_RAW : c_int = 255;
+
+            pub const PATH_MAX : c_int = 1024;
+        }
+        pub mod sysconf {
+            use types::os::arch::c95::c_int;
+
+            pub const _SC_ARG_MAX : c_int = 1;
+            pub const _SC_CHILD_MAX : c_int = 2;
+            pub const _SC_CLK_TCK : c_int = 39;
+            pub const _SC_NGROUPS_MAX : c_int = 4;
+            pub const _SC_OPEN_MAX : c_int = 5;
+            pub const _SC_JOB_CONTROL : c_int = 6;
+            pub const _SC_SAVED_IDS : c_int = 7;
+            pub const _SC_VERSION : c_int = 8;
+            pub const _SC_BC_BASE_MAX : c_int = 9;
+            pub const _SC_BC_DIM_MAX : c_int = 10;
+            pub const _SC_BC_SCALE_MAX : c_int = 11;
+            pub const _SC_BC_STRING_MAX : c_int = 12;
+            pub const _SC_COLL_WEIGHTS_MAX : c_int = 13;
+            pub const _SC_EXPR_NEST_MAX : c_int = 14;
+            pub const _SC_LINE_MAX : c_int = 15;
+            pub const _SC_RE_DUP_MAX : c_int = 16;
+            pub const _SC_2_VERSION : c_int = 17;
+            pub const _SC_2_C_BIND : c_int = 18;
+            pub const _SC_2_C_DEV : c_int = 19;
+            pub const _SC_2_CHAR_TERM : c_int = 20;
+            pub const _SC_2_FORT_DEV : c_int = 21;
+            pub const _SC_2_FORT_RUN : c_int = 22;
+            pub const _SC_2_LOCALEDEF : c_int = 23;
+            pub const _SC_2_SW_DEV : c_int = 24;
+            pub const _SC_2_UPE : c_int = 25;
+            pub const _SC_STREAM_MAX : c_int = 26;
+            pub const _SC_TZNAME_MAX : c_int = 27;
+            pub const _SC_PAGESIZE : c_int = 28;
+            pub const _SC_FSYNC : c_int = 29;
+            pub const _SC_AIO_LISTIO_MAX : c_int = 51;
+            pub const _SC_AIO_MAX : c_int = 52;
+            pub const _SC_ASYNCHRONOUS_IO : c_int = 50;
+            pub const _SC_MAPPED_FILES : c_int = 33;
+            pub const _SC_MEMLOCK : c_int = 34;
+            pub const _SC_MEMLOCK_RANGE : c_int = 35;
+            pub const _SC_MEMORY_PROTECTION : c_int = 36;
+            pub const _SC_MESSAGE_PASSING : c_int = 53;
+            pub const _SC_MQ_OPEN_MAX : c_int = 54;
+            pub const _SC_PRIORITY_SCHEDULING : c_int = 56;
+            pub const _SC_SEMAPHORES : c_int = 42;
+            pub const _SC_SHARED_MEMORY_OBJECTS : c_int = 87;
+            pub const _SC_SYNCHRONIZED_IO : c_int = 31;
+            pub const _SC_TIMERS : c_int = 44;
+
+            pub const _PC_NAME_MAX : c_int = 4;
+            pub const _PC_PATH_MAX : c_int = 5;
         }
     }
 
@@ -5733,38 +6194,16 @@ pub mod funcs {
                 pub fn chmod(path: *const c_char, mode: mode_t) -> c_int;
                 pub fn fchmod(fd: c_int, mode: mode_t) -> c_int;
 
-                #[cfg(any(target_os = "linux",
-                          target_os = "freebsd",
-                          target_os = "dragonfly",
-                          target_os = "bitrig",
-                          target_os = "netbsd",
-                          target_os = "openbsd",
-                          target_os = "android",
-                          target_os = "ios",
-                          target_os = "nacl"))]
-                pub fn fstat(fildes: c_int, buf: *mut stat) -> c_int;
-
-                #[cfg(target_os = "macos")]
-                #[link_name = "fstat64"]
+                #[cfg_attr(target_os = "macos", link_name = "fstat64")]
+                #[cfg_attr(target_os = "netbsd", link_name = "__fstat50")]
                 pub fn fstat(fildes: c_int, buf: *mut stat) -> c_int;
 
                 pub fn mkdir(path: *const c_char, mode: mode_t) -> c_int;
                 #[cfg(not(target_os = "nacl"))]
                 pub fn mkfifo(path: *const c_char, mode: mode_t) -> c_int;
 
-                #[cfg(any(target_os = "linux",
-                          target_os = "freebsd",
-                          target_os = "dragonfly",
-                          target_os = "bitrig",
-                          target_os = "netbsd",
-                          target_os = "openbsd",
-                          target_os = "android",
-                          target_os = "ios",
-                          target_os = "nacl"))]
-                pub fn stat(path: *const c_char, buf: *mut stat) -> c_int;
-
-                #[cfg(target_os = "macos")]
-                #[link_name = "stat64"]
+                #[cfg_attr(target_os = "macos", link_name = "stat64")]
+                #[cfg_attr(target_os = "netbsd", link_name = "__stat50")]
                 pub fn stat(path: *const c_char, buf: *mut stat) -> c_int;
             }
         }
@@ -5908,6 +6347,7 @@ pub mod funcs {
                 pub fn setuid(uid: uid_t) -> c_int;
                 pub fn sleep(secs: c_uint) -> c_uint;
                 pub fn usleep(secs: c_uint) -> c_int;
+                #[cfg_attr(target_os = "netbsd", link_name = "__nanosleep50")]
                 pub fn nanosleep(rqtp: *const timespec,
                                  rmtp: *mut timespec) -> c_int;
                 pub fn sysconf(name: c_int) -> c_long;
@@ -5923,6 +6363,7 @@ pub mod funcs {
                              offset: off_t) -> ssize_t;
                 pub fn pwrite(fd: c_int, buf: *const c_void, count: size_t,
                               offset: off_t) -> ssize_t;
+                #[cfg_attr(target_os = "netbsd", link_name = "__utime50")]
                 pub fn utime(file: *const c_char, buf: *const utimbuf) -> c_int;
             }
             #[cfg(target_os = "nacl")]
@@ -6005,8 +6446,10 @@ pub mod funcs {
                 pub fn mprotect(addr: *mut c_void, len: size_t, prot: c_int)
                                 -> c_int;
 
+                #[cfg_attr(target_os = "netbsd", link_name = "__msync13")]
                 pub fn msync(addr: *mut c_void, len: size_t, flags: c_int)
                              -> c_int;
+
                 pub fn shm_open(name: *const c_char, oflag: c_int, mode: mode_t)
                                 -> c_int;
                 pub fn shm_unlink(name: *const c_char) -> c_int;
@@ -6051,19 +6494,8 @@ pub mod funcs {
             use types::os::arch::posix01::stat;
 
             extern {
-                #[cfg(any(target_os = "linux",
-                          target_os = "freebsd",
-                          target_os = "dragonfly",
-                          target_os = "bitrig",
-                          target_os = "netbsd",
-                          target_os = "openbsd",
-                          target_os = "android",
-                          target_os = "ios",
-                          target_os = "nacl"))]
-                pub fn lstat(path: *const c_char, buf: *mut stat) -> c_int;
-
-                #[cfg(target_os = "macos")]
-                #[link_name = "lstat64"]
+                #[cfg_attr(target_os = "macos", link_name = "lstat64")]
+                #[cfg_attr(target_os = "netbsd", link_name = "__lstat50")]
                 pub fn lstat(path: *const c_char, buf: *mut stat) -> c_int;
             }
         }
@@ -6085,7 +6517,9 @@ pub mod funcs {
 
                 pub fn setenv(name: *const c_char, val: *const c_char,
                               overwrite: c_int) -> c_int;
+                #[cfg_attr(target_os = "netbsd", link_name = "__unsetenv13")]
                 pub fn unsetenv(name: *const c_char) -> c_int;
+                #[cfg_attr(target_os = "netbsd", link_name = "__putenv50")]
                 pub fn putenv(string: *mut c_char) -> c_int;
 
                 pub fn symlink(path1: *const c_char,
@@ -6120,11 +6554,13 @@ pub mod funcs {
             use types::os::common::posix01::{glob_t};
 
             extern {
+                #[cfg_attr(target_os = "netbsd", link_name = "__glob30")]
                 pub fn glob(pattern: *const c_char,
                             flags: c_int,
                             errfunc: ::core::option::Option<extern "C" fn(epath: *const c_char,
                                                               errno: c_int) -> c_int>,
                             pglob: *mut glob_t);
+                #[cfg_attr(target_os = "netbsd", link_name = "__globfree30")]
                 pub fn globfree(pglob: *mut glob_t);
             }
         }
@@ -6149,8 +6585,8 @@ pub mod funcs {
             extern {
                 pub fn getrlimit(resource: c_int, rlim: *mut rlimit) -> c_int;
                 pub fn setrlimit(resource: c_int, rlim: *const rlimit) -> c_int;
+                #[cfg_attr(target_os = "netbsd", link_name = "__getrusage50")]
                 pub fn getrusage(resource: c_int, usage: *mut rusage) -> c_int;
-
             }
         }
     }
@@ -6198,7 +6634,9 @@ pub mod funcs {
         use types::os::arch::posix88::ssize_t;
 
         extern "system" {
+            #[cfg_attr(target_os = "netbsd", link_name = "__socket30")]
             pub fn socket(domain: c_int, ty: c_int, protocol: c_int) -> c_int;
+
             pub fn connect(socket: c_int, address: *const sockaddr,
                            len: socklen_t) -> c_int;
             pub fn bind(socket: c_int, address: *const sockaddr,

--- a/src/libstd/os/netbsd/raw.rs
+++ b/src/libstd/os/netbsd/raw.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! NetBSD/OpenBSD-specific raw type definitions
+//! NetBSD-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
@@ -17,7 +17,7 @@ use os::unix::raw::{uid_t, gid_t};
 
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = i32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type fflags_t = u32;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
@@ -55,6 +55,10 @@ pub struct stat {
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ctime_nsec: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_birthtime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_birthtime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_size: off_t,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_blocks: blkcnt_t,
@@ -64,8 +68,5 @@ pub struct stat {
     pub st_flags: fflags_t,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_gen: u32,
-    #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_birthtime: time_t,
-    #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_birthtime_nsec: c_long,
+    st_spare: [u32; 2],
 }

--- a/src/libstd/sys/unix/c.rs
+++ b/src/libstd/sys/unix/c.rs
@@ -61,9 +61,10 @@ pub const _SC_GETPW_R_SIZE_MAX: libc::c_int = 70;
           target_os = "dragonfly"))]
 pub const _SC_GETPW_R_SIZE_MAX: libc::c_int = 71;
 #[cfg(any(target_os = "bitrig",
-          target_os = "netbsd",
           target_os = "openbsd"))]
 pub const _SC_GETPW_R_SIZE_MAX: libc::c_int = 101;
+#[cfg(target_os = "netbsd")]
+pub const _SC_GETPW_R_SIZE_MAX: libc::c_int = 48;
 #[cfg(target_os = "android")]
 pub const _SC_GETPW_R_SIZE_MAX: libc::c_int = 0x0048;
 
@@ -131,26 +132,31 @@ extern {
 
     pub fn raise(signum: libc::c_int) -> libc::c_int;
 
+    #[cfg_attr(target_os = "netbsd", link_name = "__sigaction14")]
     pub fn sigaction(signum: libc::c_int,
                      act: *const sigaction,
                      oldact: *mut sigaction) -> libc::c_int;
 
+    #[cfg_attr(target_os = "netbsd", link_name = "__sigaltstack14")]
     pub fn sigaltstack(ss: *const sigaltstack,
                        oss: *mut sigaltstack) -> libc::c_int;
 
     #[cfg(not(target_os = "android"))]
+    #[cfg_attr(target_os = "netbsd", link_name = "__sigemptyset14")]
     pub fn sigemptyset(set: *mut sigset_t) -> libc::c_int;
 
     pub fn pthread_sigmask(how: libc::c_int, set: *const sigset_t,
                            oldset: *mut sigset_t) -> libc::c_int;
 
     #[cfg(not(target_os = "ios"))]
+    #[cfg_attr(target_os = "netbsd", link_name = "__getpwuid_r50")]
     pub fn getpwuid_r(uid: libc::uid_t,
                       pwd: *mut passwd,
                       buf: *mut libc::c_char,
                       buflen: libc::size_t,
                       result: *mut *mut passwd) -> libc::c_int;
 
+    #[cfg_attr(target_os = "netbsd", link_name = "__utimes50")]
     pub fn utimes(filename: *const libc::c_char,
                   times: *const libc::timeval) -> libc::c_int;
     pub fn gai_strerror(errcode: libc::c_int) -> *const libc::c_char;
@@ -347,12 +353,12 @@ mod signal_os {
     #[cfg(any(target_os = "macos",
               target_os = "ios"))]
     pub type sigset_t = u32;
-    #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+    #[cfg(any(target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd"))]
     #[repr(C)]
     pub struct sigset_t {
         bits: [u32; 4],
     }
-    #[cfg(any(target_os = "bitrig", target_os = "netbsd", target_os = "openbsd"))]
+    #[cfg(any(target_os = "bitrig", target_os = "openbsd"))]
     pub type sigset_t = libc::c_uint;
 
     // This structure has more fields, but we're not all that interested in

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -213,7 +213,12 @@ pub fn current_exe() -> io::Result<PathBuf> {
     ::fs::read_link("/proc/curproc/file")
 }
 
-#[cfg(any(target_os = "bitrig", target_os = "netbsd", target_os = "openbsd"))]
+#[cfg(target_os = "netbsd")]
+pub fn current_exe() -> io::Result<PathBuf> {
+    ::fs::read_link("/proc/curproc/exe")
+}
+
+#[cfg(any(target_os = "bitrig", target_os = "openbsd"))]
 pub fn current_exe() -> io::Result<PathBuf> {
     use sync::StaticMutex;
     static LOCK: StaticMutex = StaticMutex::new();

--- a/src/libstd/sys/unix/process.rs
+++ b/src/libstd/sys/unix/process.rs
@@ -452,6 +452,7 @@ mod tests {
 
     #[cfg(not(target_os = "android"))]
     extern {
+        #[cfg_attr(target_os = "netbsd", link_name = "__sigaddset14")]
         fn sigaddset(set: *mut c::sigset_t, signum: libc::c_int) -> libc::c_int;
     }
 

--- a/src/libstd/sys/unix/sync.rs
+++ b/src/libstd/sys/unix/sync.rs
@@ -254,53 +254,61 @@ mod os {
 mod os {
     use libc;
 
-    // size of the type minus width of the magic int field
+    // size of the type minus width of the magic and alignment field
     #[cfg(target_arch = "x86_64")]
-    const __PTHREAD_MUTEX_SIZE__: usize = 48 - 4;
+    const __PTHREAD_MUTEX_SIZE__: usize = 48 - 4 - 8;
 
     #[cfg(target_arch = "x86_64")]
-    const __PTHREAD_COND_SIZE__: usize = 40 - 4;
+    const __PTHREAD_MUTEXATTR_SIZE__: usize = 16 - 8; // no magic field
 
     #[cfg(target_arch = "x86_64")]
-    const __PTHREAD_RWLOCK_SIZE__: usize = 64 - 4;
+    const __PTHREAD_COND_SIZE__: usize = 40 - 4 - 8;
+
+    #[cfg(target_arch = "x86_64")]
+    const __PTHREAD_RWLOCK_SIZE__: usize = 64 - 4 - 8;
 
     const _PTHREAD_MUTEX_MAGIC_INIT: libc::c_uint = 0x33330003;
     const _PTHREAD_COND_MAGIC_INIT: libc::c_uint = 0x55550005;
     const _PTHREAD_RWLOCK_MAGIC_INIT: libc::c_uint = 0x99990009;
 
-    // note the actual structs are smaller
-
-    #[repr(C, packed)]
+    #[repr(C)]
     pub struct pthread_mutex_t {
         __magic: libc::c_uint,
         __opaque: [u8; __PTHREAD_MUTEX_SIZE__],
+        __align: libc::c_longlong,
     }
-    #[repr(C, packed)]
+    #[repr(C)]
     pub struct pthread_mutexattr_t {
-        __opaque: [u8; 16],
+        __opaque: [u8; __PTHREAD_MUTEXATTR_SIZE__],
+        __align: libc::c_longlong,
     }
-    #[repr(C, packed)]
+    #[repr(C)]
     pub struct pthread_cond_t {
         __magic: libc::c_uint,
         __opaque: [u8; __PTHREAD_COND_SIZE__],
+        __align: libc::c_longlong,
     }
-    #[repr(C, packed)]
+    #[repr(C)]
     pub struct pthread_rwlock_t {
         __magic: libc::c_uint,
         __opaque: [u8; __PTHREAD_RWLOCK_SIZE__],
+        __align: libc::c_longlong,
     }
 
     pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t {
         __magic: _PTHREAD_MUTEX_MAGIC_INIT,
         __opaque: [0; __PTHREAD_MUTEX_SIZE__],
+        __align: 0,
     };
     pub const PTHREAD_COND_INITIALIZER: pthread_cond_t = pthread_cond_t {
         __magic: _PTHREAD_COND_MAGIC_INIT,
         __opaque: [0; __PTHREAD_COND_SIZE__],
+        __align: 0,
     };
     pub const PTHREAD_RWLOCK_INITIALIZER: pthread_rwlock_t = pthread_rwlock_t {
         __magic: _PTHREAD_RWLOCK_MAGIC_INIT,
         __opaque: [0; __PTHREAD_RWLOCK_SIZE__],
+        __align: 0,
     };
 
     pub const PTHREAD_MUTEX_RECURSIVE: libc::c_int = 2;

--- a/src/libstd/sys/unix/sync.rs
+++ b/src/libstd/sys/unix/sync.rs
@@ -40,6 +40,7 @@ extern {
     pub fn pthread_cond_signal(cond: *mut pthread_cond_t) -> libc::c_int;
     pub fn pthread_cond_broadcast(cond: *mut pthread_cond_t) -> libc::c_int;
     pub fn pthread_cond_destroy(cond: *mut pthread_cond_t) -> libc::c_int;
+    #[cfg_attr(target_os = "netbsd", link_name = "__gettimeofday50")]
     pub fn gettimeofday(tp: *mut libc::timeval,
                         tz: *mut libc::c_void) -> libc::c_int;
 
@@ -55,7 +56,6 @@ extern {
 #[cfg(any(target_os = "freebsd",
           target_os = "dragonfly",
           target_os = "bitrig",
-          target_os = "netbsd",
           target_os = "openbsd"))]
 mod os {
     use libc;
@@ -248,4 +248,60 @@ mod os {
         reserved: [ptr::null_mut(); 4],
     };
     pub const PTHREAD_MUTEX_RECURSIVE: libc::c_int = 1;
+}
+
+#[cfg(target_os = "netbsd")]
+mod os {
+    use libc;
+
+    // size of the type minus width of the magic int field
+    #[cfg(target_arch = "x86_64")]
+    const __PTHREAD_MUTEX_SIZE__: usize = 48 - 4;
+
+    #[cfg(target_arch = "x86_64")]
+    const __PTHREAD_COND_SIZE__: usize = 40 - 4;
+
+    #[cfg(target_arch = "x86_64")]
+    const __PTHREAD_RWLOCK_SIZE__: usize = 64 - 4;
+
+    const _PTHREAD_MUTEX_MAGIC_INIT: libc::c_uint = 0x33330003;
+    const _PTHREAD_COND_MAGIC_INIT: libc::c_uint = 0x55550005;
+    const _PTHREAD_RWLOCK_MAGIC_INIT: libc::c_uint = 0x99990009;
+
+    // note the actual structs are smaller
+
+    #[repr(C, packed)]
+    pub struct pthread_mutex_t {
+        __magic: libc::c_uint,
+        __opaque: [u8; __PTHREAD_MUTEX_SIZE__],
+    }
+    #[repr(C, packed)]
+    pub struct pthread_mutexattr_t {
+        __opaque: [u8; 16],
+    }
+    #[repr(C, packed)]
+    pub struct pthread_cond_t {
+        __magic: libc::c_uint,
+        __opaque: [u8; __PTHREAD_COND_SIZE__],
+    }
+    #[repr(C, packed)]
+    pub struct pthread_rwlock_t {
+        __magic: libc::c_uint,
+        __opaque: [u8; __PTHREAD_RWLOCK_SIZE__],
+    }
+
+    pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t {
+        __magic: _PTHREAD_MUTEX_MAGIC_INIT,
+        __opaque: [0; __PTHREAD_MUTEX_SIZE__],
+    };
+    pub const PTHREAD_COND_INITIALIZER: pthread_cond_t = pthread_cond_t {
+        __magic: _PTHREAD_COND_MAGIC_INIT,
+        __opaque: [0; __PTHREAD_COND_SIZE__],
+    };
+    pub const PTHREAD_RWLOCK_INITIALIZER: pthread_rwlock_t = pthread_rwlock_t {
+        __magic: _PTHREAD_RWLOCK_MAGIC_INIT,
+        __opaque: [0; __PTHREAD_RWLOCK_SIZE__],
+    };
+
+    pub const PTHREAD_MUTEX_RECURSIVE: libc::c_int = 2;
 }

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -102,7 +102,6 @@ impl Thread {
     #[cfg(any(target_os = "freebsd",
               target_os = "dragonfly",
               target_os = "bitrig",
-              target_os = "netbsd",
               target_os = "openbsd"))]
     pub fn set_name(name: &str) {
         extern {
@@ -123,6 +122,21 @@ impl Thread {
         let cname = CString::new(name).unwrap();
         unsafe {
             pthread_setname_np(cname.as_ptr());
+        }
+    }
+
+    #[cfg(target_os = "netbsd")]
+    pub fn set_name(name: &str) {
+        extern {
+            fn pthread_setname_np(thread: libc::pthread_t,
+                                  name: *const libc::c_char,
+                                  arg: *mut libc::c_void) -> libc::c_int;
+        }
+        let cname = CString::new(&b"%s"[..]).unwrap();
+        let carg = CString::new(name).unwrap();
+        unsafe {
+            pthread_setname_np(pthread_self(), cname.as_ptr(),
+                               carg.as_ptr() as *mut libc::c_void);
         }
     }
 
@@ -191,13 +205,12 @@ pub mod guard {
 
     #[cfg(any(target_os = "macos",
               target_os = "bitrig",
-              target_os = "netbsd",
               target_os = "openbsd"))]
     unsafe fn get_stack_start() -> Option<*mut libc::c_void> {
         current().map(|s| s as *mut libc::c_void)
     }
 
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "netbsd"))]
     unsafe fn get_stack_start() -> Option<*mut libc::c_void> {
         use super::pthread_attr_init;
 
@@ -263,7 +276,7 @@ pub mod guard {
               pthread_get_stacksize_np(pthread_self())) as usize)
     }
 
-    #[cfg(any(target_os = "openbsd", target_os = "netbsd", target_os = "bitrig"))]
+    #[cfg(any(target_os = "openbsd", target_os = "bitrig"))]
     pub unsafe fn current() -> Option<usize> {
         #[repr(C)]
         struct stack_t {
@@ -290,7 +303,7 @@ pub mod guard {
         })
     }
 
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "netbsd"))]
     pub unsafe fn current() -> Option<usize> {
         use super::pthread_attr_init;
 
@@ -307,13 +320,17 @@ pub mod guard {
             let mut size = 0;
             assert_eq!(pthread_attr_getstack(&attr, &mut stackaddr, &mut size), 0);
 
-            ret = Some(stackaddr as usize + guardsize as usize);
+            ret = if cfg!(target_os = "netbsd") {
+                Some(stackaddr as usize)
+            } else {
+                Some(stackaddr as usize + guardsize as usize)
+            };
         }
         assert_eq!(pthread_attr_destroy(&mut attr), 0);
         ret
     }
 
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "netbsd"))]
     extern {
         fn pthread_getattr_np(native: libc::pthread_t,
                               attr: *mut libc::pthread_attr_t) -> libc::c_int;

--- a/src/libstd/sys/unix/time.rs
+++ b/src/libstd/sys/unix/time.rs
@@ -86,7 +86,9 @@ mod inner {
     #[link(name = "rt")]
     extern {}
 
+
     extern {
+        #[cfg_attr(target_os = "netbsd", link_name = "__clock_gettime50")]
         fn clock_gettime(clk_id: libc::c_int, tp: *mut libc::timespec) -> libc::c_int;
     }
 


### PR DESCRIPTION
These changes introduce the ability to cross-compile working binaries for NetBSD/amd64. Previous support added in PR #26682 shared all its code with the OpenBSD implementation, and was therefore never functional (e.g. linking against non-existing symbols and using wrong type definitions). Nonetheless, the previous patches were a great starting point and made my work significantly easier. :smiley: 

Because there are no stage0 snapshots for NetBSD (yet), I used a cross-compiler for NetBSD 7.0 RC3 and only tested some toy programs (threading and channels, stack guards, a small TCP/IP echo server and some other platform dependent bits). If someone could point me to documentation on how to generate a stage0 snapshot from a cross-compiler I'm happy to run the full test suite.

A few other notes regarding Rust on NetBSD/amd64:
- To preserve binary compatibility, NetBSD introduces new symbols for system call wrappers on breaking ABI changes and keeps the old (legacy) symbols around, see [this documentation](https://www.netbsd.org/docs/internals/en/chap-processes.html#syscalls_master) for some details. I went ahead and modified the `libc` and `std` crate to use the current (renamed) symbols instead of the legacy ones where I found them, but I might have missed some. Notably using the `sigaction` symbol (deprecated in 1998) instead of `__sigaction14` even triggers SIGSYS (bad syscall) on my amd64 setup. I also changed the type definitions to use the most recent version.
- NetBSD's gdb doesn't really support position independent executables, so you might want to turn that off for debugging, see [NetBSD Problem Report #48250](https://gnats.netbsd.org/48250).
- For binaries invoked using a relative path, NetBSD supports `$ORIGIN` only for short `rpath`s (~64 chars or so, I'm told). If running an executable fails with `execname not specified in AUX vector: No such file or directory`, consider invoking the binary using its full absolute path.
