### PR TITLE
Use BufWriter in fasta-redux for a nice speedup

### DIFF
--- a/src/test/bench/shootout-fasta-redux.rs
+++ b/src/test/bench/shootout-fasta-redux.rs
@@ -41,6 +41,7 @@
 use std::cmp::min;
 use std::env;
 use std::io;
+use std::io::BufWriter;
 use std::io::prelude::*;
 
 const LINE_LEN: usize = 60;
@@ -214,7 +215,7 @@ fn main() {
     };
 
     let stdout = io::stdout();
-    let mut out = stdout.lock();
+    let mut out = BufWriter::new(stdout.lock());
 
     out.write_all(b">ONE Homo sapiens alu\n").unwrap();
     {


### PR DESCRIPTION
Since 1.3.0 the BufWriter has seen tremendous speedups. So when I use it in the shootout benchmarks, I see some nice speedup (which up to 1.2.0 was nixed by the pessimizations during initialization).
