### PR TITLE
Save bitcode before LTO when -C save-temps is given

### DIFF
--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -496,7 +496,8 @@ unsafe fn optimize_and_codegen(cgcx: &CodegenContext,
         match cgcx.lto_ctxt {
             Some((sess, reachable)) if sess.lto() =>  {
                 time(sess.time_passes(), "all lto passes", ||
-                     lto::run(sess, llmod, tm, reachable, &config));
+                     lto::run(sess, llmod, tm, reachable, &config,
+                              &name_extra, &output_names));
 
                 if config.emit_lto_bc {
                     let name = format!("{}.lto.bc", name_extra);


### PR DESCRIPTION
This is useful for debugging LTO issues, #28066 for example.
