### PR TITLE
run-make: search libstdc++ in /usr/local/lib too

### DIFF
--- a/src/test/run-make/tools.mk
+++ b/src/test/run-make/tools.mk
@@ -85,6 +85,11 @@ ifeq ($(UNAME),Bitrig)
 else
 ifeq ($(UNAME),OpenBSD)
 	EXTRACFLAGS := -lm -lpthread
+	# extend search lib for found estdc++ if build using gcc from
+	# ports under OpenBSD. This is needed for:
+	#  - run-make/execution-engine
+	#  - run-make/issue-19371
+	RUSTC := $(RUSTC) -L/usr/local/lib
 else
 	EXTRACFLAGS := -lm -lrt -ldl -lpthread
 	EXTRACXXFLAGS := -lstdc++


### PR DESCRIPTION
extend the search path of libraries to /usr/local/lib in `run-make`
testsuite. It should permit to find libstdc++.so on usual directory.

r? @alexcrichton 
