### PR TITLE
Support configure for illumos or solaris (including SmartOS)

### DIFF
--- a/configure
+++ b/configure
@@ -66,7 +66,7 @@ move_if_changed() {
 }
 
 putvar() {
-    local T
+    T=
     eval T=\$$1
     eval TLEN=\${#$1}
     if [ $TLEN -gt 35 ]
@@ -79,7 +79,7 @@ putvar() {
 }
 
 putpathvar() {
-    local T
+    T=
     eval T=\$$1
     eval TLEN=\${#$1}
     if [ $TLEN -gt 35 ]
@@ -97,10 +97,10 @@ putpathvar() {
 }
 
 probe() {
-    local V=$1
+    V=$1
     shift
-    local P
-    local T
+    P=
+    T=
     for P
     do
         T=$(command -v $P 2>&1)
@@ -125,7 +125,7 @@ probe() {
 }
 
 probe_need() {
-    local V=$1
+    V=$1
     probe $*
     eval VV=\$$V
     if [ -z "$VV" ]
@@ -183,18 +183,18 @@ validate_opt () {
 valopt_core() {
     VAL_OPTIONS="$VAL_OPTIONS $2"
 
-    local SAVE=$1
-    local OP=$2
-    local DEFAULT=$3
+    SAVE=$1
+    OP=$2
+    DEFAULT=$3
     shift
     shift
     shift
-    local DOC="$*"
+    DOC="$*"
     if [ $HELP -eq 0 ]
     then
-        local UOP=$(echo $OP | tr '[:lower:]' '[:upper:]' | tr '\-' '\_')
-        local V="CFG_${UOP}"
-        local V_PROVIDED="${V}_PROVIDED"
+        UOP=$(echo $OP | tr '[:lower:]' '[:upper:]' | tr '\-' '\_')
+        V="CFG_${UOP}"
+        V_PROVIDED="${V}_PROVIDED"
         eval $V="$DEFAULT"
         for arg in $CFG_CONFIGURE_ARGS
         do
@@ -239,14 +239,14 @@ valopt() {
 opt_core() {
     BOOL_OPTIONS="$BOOL_OPTIONS $2"
 
-    local SAVE=$1
-    local OP=$2
-    local DEFAULT=$3
+    SAVE=$1
+    OP=$2
+    DEFAULT=$3
     shift
     shift
     shift
-    local DOC="$*"
-    local FLAG=""
+    DOC="$*"
+    FLAG=""
 
     if [ $DEFAULT -eq 0 ]
     then
@@ -266,8 +266,8 @@ opt_core() {
             then
                 OP=$(echo $OP | tr 'a-z-' 'A-Z_')
                 FLAG=$(echo $FLAG | tr 'a-z' 'A-Z')
-                local V="CFG_${FLAG}_${OP}"
-                local V_PROVIDED="CFG_${FLAG}_${OP}_PROVIDED"
+                V="CFG_${FLAG}_${OP}"
+                V_PROVIDED="CFG_${FLAG}_${OP}_PROVIDED"
                 eval $V=1
                 eval $V_PROVIDED=1
                 if [ "$SAVE" = "save" ]
@@ -278,7 +278,7 @@ opt_core() {
             then
                 OP=$(echo $OP | tr 'a-z-' 'A-Z_')
                 DEFAULT_FLAG=$(echo $DEFAULT_FLAG | tr 'a-z' 'A-Z')
-                local V_PROVIDED="CFG_${DEFAULT_FLAG}_${OP}_PROVIDED"
+                V_PROVIDED="CFG_${DEFAULT_FLAG}_${OP}_PROVIDED"
                 eval $V_PROVIDED=1
             fi
         done
@@ -300,8 +300,8 @@ opt() {
 }
 
 envopt() {
-    local NAME=$1
-    local V="CFG_${NAME}"
+    NAME=$1
+    V="CFG_${NAME}"
     eval VV=\$$V
 
     # If configure didn't set a value already, then check environment.
@@ -324,10 +324,10 @@ envopt() {
 }
 
 enable_if_not_disabled() {
-    local OP=$1
-    local UOP=$(echo $OP | tr '[:lower:]' '[:upper:]' | tr '\-' '\_')
-    local ENAB_V="CFG_ENABLE_$UOP"
-    local EXPLICITLY_DISABLED="CFG_DISABLE_${UOP}_PROVIDED"
+    OP=$1
+    UOP=$(echo $OP | tr '[:lower:]' '[:upper:]' | tr '\-' '\_')
+    ENAB_V="CFG_ENABLE_$UOP"
+    EXPLICITLY_DISABLED="CFG_DISABLE_${UOP}_PROVIDED"
     eval VV=\$$EXPLICITLY_DISABLED
     if [ -z "$VV" ]; then
         eval $ENAB_V=1
@@ -352,7 +352,7 @@ to_gnu_triple() {
 
 # Prints the absolute path of a directory to stdout
 abs_path() {
-    local _path="$1"
+    _path="$1"
     # Unset CDPATH because it causes havok: it makes the destination unpredictable
     # and triggers 'cd' to print the path to stdout. Route `cd`'s output to /dev/null
     # for good measure.

--- a/configure
+++ b/configure
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+# /bin/sh on Solaris is not a POSIX compatible shell, but /usr/bin/ksh is.
+if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
+    POSIX_SHELL="true"
+    export POSIX_SHELL
+    exec /usr/bin/ksh $0 "$@"
+fi
+unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
+
 msg() {
     echo "configure: $*"
 }
@@ -422,6 +430,11 @@ case $CFG_OSTYPE in
 
     Darwin)
         CFG_OSTYPE=apple-darwin
+        ;;
+
+    SunOS)
+        CFG_OSTYPE=sun-solaris
+        CFG_CPUTYPE=$(isainfo -n)
         ;;
 
     MINGW*)

--- a/mk/cfg/x86_64-sun-solaris.mk
+++ b/mk/cfg/x86_64-sun-solaris.mk
@@ -1,0 +1,22 @@
+# x86_64-sun-solaris configuration
+CC_x86_64-sun-solaris=$(CC)
+CXX_x86_64-sun-solaris=$(CXX)
+CPP_x86_64-sun-solaris=$(CPP)
+AR_x86_64-sun-solaris=$(AR)
+CFG_LIB_NAME_x86_64-sun-solaris=lib$(1).so
+CFG_STATIC_LIB_NAME_x86_64-sun-solaris=lib$(1).a
+CFG_LIB_GLOB_x86_64-sun-solaris=lib$(1)-*.so
+CFG_LIB_DSYM_GLOB_x86_64-sun-solaris=$(1)-*.dylib.dSYM
+CFG_JEMALLOC_CFLAGS_x86_64-sun-solaris := -I/usr/local/include $(CFLAGS)
+CFG_GCCISH_CFLAGS_x86_64-sun-solaris := -Wall -Werror -g -fPIC -I/usr/local/include $(CFLAGS)
+CFG_GCCISH_LINK_FLAGS_x86_64-sun-solaris := -shared -fPIC -g -pthread  -lrt
+CFG_GCCISH_DEF_FLAG_x86_64-sun-solaris := -Wl,--export-dynamic,--dynamic-list=
+CFG_LLC_FLAGS_x86_64-sun-solaris :=
+CFG_INSTALL_NAME_x86_64-sun-solaris =
+CFG_EXE_SUFFIX_x86_64-sun-solaris :=
+CFG_WINDOWSY_x86_64-sun-solaris :=
+CFG_UNIXY_x86_64-sun-solaris := 1
+CFG_LDPATH_x86_64-sun-solaris :=
+CFG_RUN_x86_64-sun-solaris=$(2)
+CFG_RUN_TARG_x86_64-sun-solaris=$(call CFG_RUN_x86_64-sun-solaris,,$(2))
+CFG_GNU_TRIPLE_x86_64-sun-solaris := x86_64-sun-solaris


### PR DESCRIPTION
This pull request removes some non-POSIX bashisms found in the configure script (namely [`local` scope variables](http://mywiki.wooledge.org/Bashism#Builtins)) and adds the `x86_64-sun-solaris` build triple so that configure can successfully run on Solaris based operating systems (like SmartOS).

The configure script also behaves as a shell wrapper for `/usr/bin/ksh` if it detects that `/bin/sh` (or any other non-POSIX shell) is being used on SunOS.  The problem is that the `/bin/sh` built into SunOS _is not_ POSIX compliant, rather than there being an POSIX compliance issue with the configure script itself.  Dash explicitly supports local scope variables as a non-POSIX extension, which may be why that specific bashism has remained unnoticed.  I wonder how many more times I can fit the word POSIX into this already POSIX filled paragraph?

See also #21000, #25845, #25846, and #25889.

Question about next steps for building on SmartOS:

I still have yet to successfully build rust on SmartOS, although these changes to the configure process have gotten me a little further down the building road.  What would be the next steps for getting a stage0 snapshot built for SmartOS?  That's about as far down the compilation process as I've been able to go.
