### PR TITLE
Make lexer tooling message more generic

### DIFF
--- a/mk/grammar.mk
+++ b/mk/grammar.mk
@@ -58,17 +58,17 @@ check-lexer: $(BG) $(BG)RustLexer.class check-build-lexer-verifier
 	$(Q)$(SG)check.sh $(S) "$(BG)" \
 		"$(CFG_GRUN)" "$(BG)verify" "$(BG)RustLexer.tokens"
 else
-$(info cfg: grun not available, skipping lexer test...)
+$(info cfg: lexer tooling not available, skipping lexer test...)
 check-lexer:
 
 endif
 else
-$(info cfg: antlr4 not available, skipping lexer test...)
+$(info cfg: lexer tooling not available, skipping lexer test...)
 check-lexer:
 
 endif
 else
-$(info cfg: javac not available, skipping lexer test...)
+$(info cfg: lexer tooling not available, skipping lexer test...)
 check-lexer:
 
 endif


### PR DESCRIPTION
We don't actually probe for javac in all circumstances, so if you have
javac installed, but don't have antlr4 installed, and you're on Mac OS
X, then you'll get a message that javac is missing, even though that's
wrong.

To fix this, let's just be a bit more generic in the message, so that
it's the same no matter what part of the lexer tests you're missing.

cc
https://www.reddit.com/r/rust/comments/3m199d/running_make_check_on_the_source_code_says_javac/
