### PR TITLE
rustc: Swap link order of native libs/rust deps

### DIFF
--- a/src/liballoc_jemalloc/lib.rs
+++ b/src/liballoc_jemalloc/lib.rs
@@ -27,7 +27,19 @@ extern crate libc;
 
 use libc::{c_int, c_void, size_t};
 
+// Linkage directives to pull in jemalloc and its dependencies.
+//
+// On some platforms we need to be sure to link in `pthread` which jemalloc
+// depends on, and specifically on android we need to also link to libgcc.
+// Currently jemalloc is compiled with gcc which will generate calls to
+// intrinsics that are libgcc specific (e.g. those intrinsics aren't present in
+// libcompiler-rt), so link that in to get that support.
 #[link(name = "jemalloc", kind = "static")]
+#[cfg_attr(target_os = "android", link(name = "gcc"))]
+#[cfg_attr(all(not(windows),
+               not(target_os = "android"),
+               not(target_env = "musl")),
+           link(name = "pthread"))]
 extern {
     fn je_mallocx(size: size_t, flags: c_int) -> *mut c_void;
     fn je_rallocx(ptr: *mut c_void, size: size_t, flags: c_int) -> *mut c_void;
@@ -36,13 +48,6 @@ extern {
     fn je_sdallocx(ptr: *mut c_void, size: size_t, flags: c_int);
     fn je_nallocx(size: size_t, flags: c_int) -> size_t;
 }
-
-// -lpthread needs to occur after -ljemalloc, the earlier argument isn't enough
-#[cfg(all(not(windows),
-          not(target_os = "android"),
-          not(target_env = "musl")))]
-#[link(name = "pthread")]
-extern {}
 
 // The minimum alignment guaranteed by the architecture. This value is used to
 // add fast paths for low alignment values. In practice, the alignment is a

--- a/src/test/run-make/issue-12446/Makefile
+++ b/src/test/run-make/issue-12446/Makefile
@@ -1,6 +1,0 @@
--include ../tools.mk
-
-all: $(call NATIVE_STATICLIB,foo)
-	$(RUSTC) foo.rs
-	$(RUSTC) bar.rs
-	$(call RUN,bar)

--- a/src/test/run-make/issue-12446/foo.c
+++ b/src/test/run-make/issue-12446/foo.c
@@ -1,2 +1,0 @@
-// ignore-license
-void some_c_symbol() {}

--- a/src/test/run-make/issue-28595/Makefile
+++ b/src/test/run-make/issue-28595/Makefile
@@ -1,0 +1,6 @@
+-include ../tools.mk
+
+all: $(call NATIVE_STATICLIB,a) $(call NATIVE_STATICLIB,b)
+	$(RUSTC) a.rs
+	$(RUSTC) b.rs
+	$(call RUN,b)

--- a/src/test/run-make/issue-28595/a.c
+++ b/src/test/run-make/issue-28595/a.c
@@ -1,0 +1,11 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+void a(void) {}

--- a/src/test/run-make/issue-28595/a.rs
+++ b/src/test/run-make/issue-28595/a.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,11 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate foo;
+#![crate_type = "rlib"]
 
-#[link(name = "foo")]
-extern {}
-
-fn main() {
-    foo::foo();
+#[link(name = "a", kind = "static")]
+extern {
+    pub fn a();
 }

--- a/src/test/run-make/issue-28595/b.c
+++ b/src/test/run-make/issue-28595/b.c
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern void a(void);
+
+void b(void) {
+    a();
+}
+

--- a/src/test/run-make/issue-28595/b.rs
+++ b/src/test/run-make/issue-28595/b.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![crate_type = "rlib"]
+extern crate a;
 
+#[link(name = "b", kind = "static")]
 extern {
-    fn some_c_symbol();
+    pub fn b();
 }
 
-pub fn foo() {
-    unsafe { some_c_symbol() }
+
+fn main() {
+    unsafe { b(); }
 }


### PR DESCRIPTION
This commit swaps the order of linking local native libraries and upstream
native libraries on the linker command line. Detail of bugs this can cause can
be found in #28595, and this change also invalidates the test case that was
added for #12446 which is now considered a bug because the downstream dependency
would need to declare that it depends on the native library somehow.

Closes #28595
[breaking-change]
