### PR TITLE
Change the first line of the println macro doc

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -98,7 +98,7 @@ macro_rules! print {
     ($($arg:tt)*) => ($crate::io::_print(format_args!($($arg)*)));
 }
 
-/// Macro for printing to the standard output.
+/// Macro for printing to the standard output, with a newline.
 ///
 /// Use the `format!` syntax to write data to the standard output.
 /// See `std::fmt` for more information.


### PR DESCRIPTION
This was discovered by maggyero on #rust.

In the [documentation for the macros in libstd](https://doc.rust-lang.org/stable/std/#macros), the first lines for `print!` and `println!` were exactly the same, with no mention of how one of them also emits a newline:

<img width="622" alt="screen shot 2015-09-25 at 12 11 52" src="https://cloud.githubusercontent.com/assets/503760/10099409/465d509a-6381-11e5-9eb9-766f21a08c50.png">

This commit makes the first lines of those two macros different.
