### PR TITLE
Turn constants in modules core::[i/u][8/16/32/64/size] into associated constants

### DIFF
--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -15,7 +15,6 @@ use heap;
 use super::oom;
 use super::boxed::Box;
 use core::ops::Drop;
-use core;
 
 /// A low-level utility for more ergonomically allocating, reallocating, and deallocating a
 /// a buffer of memory on the heap without having to worry about all the corner cases
@@ -472,8 +471,7 @@ impl<T> Drop for RawVec<T> {
 
 #[inline]
 fn alloc_guard(alloc_size: usize) {
-    if core::usize::BITS < 64 {
-        assert!(alloc_size <= ::core::isize::MAX as usize,
-                "capacity overflow");
+    if usize::BITS < 64 {
+        assert!(alloc_size <= isize::MAX as usize, "capacity overflow");
     }
 }

--- a/src/libcollections/enum_set.rs
+++ b/src/libcollections/enum_set.rs
@@ -89,7 +89,6 @@ pub trait CLike {
 }
 
 fn bit<E:CLike>(e: &E) -> usize {
-    use core::usize;
     let value = e.to_usize();
     assert!(value < usize::BITS,
             "EnumSet only supports up to {} variants.", usize::BITS - 1);

--- a/src/libcollections/vec_deque.rs
+++ b/src/libcollections/vec_deque.rs
@@ -25,7 +25,6 @@ use core::mem;
 use core::ops::{Index, IndexMut};
 use core::ptr;
 use core::slice;
-use core::usize;
 
 use core::hash::{Hash, Hasher};
 use core::cmp;

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1387,7 +1387,7 @@ impl<T> Pointer for *const T {
             f.flags |= 1 << (FlagV1::SignAwareZeroPad as u32);
 
             if let None = f.width {
-                f.width = Some((::usize::BITS/4) + 2);
+                f.width = Some((usize::BITS/4) + 2);
             }
         }
         f.flags |= 1 << (FlagV1::Alternate as u32);

--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -192,7 +192,7 @@ mod impls {
                 fn hash_slice<H: Hasher>(data: &[$ty], state: &mut H) {
                     // FIXME(#23542) Replace with type ascription.
                     #![allow(trivial_casts)]
-                    let newlen = data.len() * ::$ty::BYTES;
+                    let newlen = data.len() * $ty::BYTES;
                     let ptr = data.as_ptr() as *const u8;
                     state.write(unsafe { slice::from_raw_parts(ptr, newlen) })
                 }

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -67,6 +67,7 @@
 #![deny(missing_docs)]
 
 #![feature(allow_internal_unstable)]
+#![feature(associated_consts)]
 #![feature(associated_type_defaults)]
 #![feature(concat_idents)]
 #![feature(const_fn)]

--- a/src/libcore/num/int_macros.rs
+++ b/src/libcore/num/int_macros.rs
@@ -13,25 +13,10 @@
 macro_rules! int_module { ($T:ty, $bits:expr) => (
 
 // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
-// calling the `mem::size_of` function.
-#[unstable(feature = "num_bits_bytes",
-           reason = "may want to be an associated function",
-           issue = "27753")]
-#[allow(missing_docs)]
-pub const BITS : usize = $bits;
-// FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
-// calling the `mem::size_of` function.
-#[unstable(feature = "num_bits_bytes",
-           reason = "may want to be an associated function",
-           issue = "27753")]
-#[allow(missing_docs)]
-pub const BYTES : usize = ($bits / 8);
-
-// FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
 // calling the `Bounded::min_value` function.
 #[stable(feature = "rust1", since = "1.0.0")]
 #[allow(missing_docs)]
-pub const MIN: $T = (-1 as $T) << (BITS - 1);
+pub const MIN: $T = (-1 as $T) << ($bits - 1);
 // FIXME(#9837): Compute MIN like this so the high bits that shouldn't exist are 0.
 // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
 // calling the `Bounded::max_value` function.

--- a/src/libcore/num/int_macros.rs
+++ b/src/libcore/num/int_macros.rs
@@ -13,6 +13,21 @@
 macro_rules! int_module { ($T:ty, $bits:expr) => (
 
 // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
+// calling the `mem::size_of` function.
+#[unstable(feature = "num_bits_bytes",
+           reason = "may want to be an associated function",
+           issue = "27753")]
+#[allow(missing_docs)]
+pub const BITS : usize = $bits;
+// FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
+// calling the `mem::size_of` function.
+#[unstable(feature = "num_bits_bytes",
+           reason = "may want to be an associated function",
+           issue = "27753")]
+#[allow(missing_docs)]
+pub const BYTES : usize = ($bits / 8);
+
+// FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
 // calling the `Bounded::min_value` function.
 #[stable(feature = "rust1", since = "1.0.0")]
 #[allow(missing_docs)]

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -115,7 +115,7 @@ unsafe fn bswap8(x: u8) -> u8 { x }
 
 // `Int` + `SignedInt` implemented for signed integers
 macro_rules! int_impl {
-    ($ActualT:ty, $UnsignedT:ty, $BITS:expr,
+    ($SelfT:ty, $ActualT:ty, $UnsignedT:ty, $BITS:expr,
      $add_with_overflow:path,
      $sub_with_overflow:path,
      $mul_with_overflow:path) => {
@@ -139,13 +139,13 @@ macro_rules! int_impl {
         // calling the `Bounded::min_value` function.
         #[stable(feature = "rust1", since = "1.0.0")]
         #[allow(missing_docs)]
-        pub const MIN: $ActualT = (-1 as $ActualT) << ($BITS - 1);
+        pub const MIN: $SelfT = (-1 as $SelfT) << ($BITS - 1);
         // FIXME(#9837): Compute MIN like this so the high bits that shouldn't exist are 0.
         // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
         // calling the `Bounded::max_value` function.
         #[stable(feature = "rust1", since = "1.0.0")]
         #[allow(missing_docs)]
-        pub const MAX: $ActualT = !<$ActualT>::MIN;
+        pub const MAX: $SelfT = !<$SelfT>::MIN;
 
         /// Returns the smallest value that can be represented by this integer type.
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -639,7 +639,7 @@ macro_rules! int_impl {
 
 #[lang = "i8"]
 impl i8 {
-    int_impl! { i8, u8, 8,
+    int_impl! { i8, i8, u8, 8,
         intrinsics::i8_add_with_overflow,
         intrinsics::i8_sub_with_overflow,
         intrinsics::i8_mul_with_overflow }
@@ -647,7 +647,7 @@ impl i8 {
 
 #[lang = "i16"]
 impl i16 {
-    int_impl! { i16, u16, 16,
+    int_impl! { i16, i16, u16, 16,
         intrinsics::i16_add_with_overflow,
         intrinsics::i16_sub_with_overflow,
         intrinsics::i16_mul_with_overflow }
@@ -655,7 +655,7 @@ impl i16 {
 
 #[lang = "i32"]
 impl i32 {
-    int_impl! { i32, u32, 32,
+    int_impl! { i32, i32, u32, 32,
         intrinsics::i32_add_with_overflow,
         intrinsics::i32_sub_with_overflow,
         intrinsics::i32_mul_with_overflow }
@@ -663,7 +663,7 @@ impl i32 {
 
 #[lang = "i64"]
 impl i64 {
-    int_impl! { i64, u64, 64,
+    int_impl! { i64, i64, u64, 64,
         intrinsics::i64_add_with_overflow,
         intrinsics::i64_sub_with_overflow,
         intrinsics::i64_mul_with_overflow }
@@ -672,7 +672,7 @@ impl i64 {
 #[cfg(target_pointer_width = "32")]
 #[lang = "isize"]
 impl isize {
-    int_impl! { i32, u32, 32,
+    int_impl! { isize, i32, u32, 32,
         intrinsics::i32_add_with_overflow,
         intrinsics::i32_sub_with_overflow,
         intrinsics::i32_mul_with_overflow }
@@ -681,7 +681,7 @@ impl isize {
 #[cfg(target_pointer_width = "64")]
 #[lang = "isize"]
 impl isize {
-    int_impl! { i64, u64, 64,
+    int_impl! { isize, i64, u64, 64,
         intrinsics::i64_add_with_overflow,
         intrinsics::i64_sub_with_overflow,
         intrinsics::i64_mul_with_overflow }
@@ -689,7 +689,7 @@ impl isize {
 
 // `Int` + `UnsignedInt` implemented for signed integers
 macro_rules! uint_impl {
-    ($ActualT:ty, $BITS:expr,
+    ($SelfT:ty, $ActualT:ty, $BITS:expr,
      $ctpop:path,
      $ctlz:path,
      $cttz:path,
@@ -711,10 +711,10 @@ macro_rules! uint_impl {
 
         #[stable(feature = "rust1", since = "1.0.0")]
         #[allow(missing_docs)]
-        pub const MIN: $ActualT = 0 as $ActualT;
+        pub const MIN: $SelfT = 0 as $SelfT;
         #[stable(feature = "rust1", since = "1.0.0")]
         #[allow(missing_docs)]
-        pub const MAX: $ActualT = !0 as $ActualT;
+        pub const MAX: $SelfT = !0 as $SelfT;
 
         /// Returns the smallest value that can be represented by this integer type.
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -1210,7 +1210,7 @@ macro_rules! uint_impl {
 
 #[lang = "u8"]
 impl u8 {
-    uint_impl! { u8, 8,
+    uint_impl! { u8, u8, 8,
         intrinsics::ctpop8,
         intrinsics::ctlz8,
         intrinsics::cttz8,
@@ -1222,7 +1222,7 @@ impl u8 {
 
 #[lang = "u16"]
 impl u16 {
-    uint_impl! { u16, 16,
+    uint_impl! { u16, u16, 16,
         intrinsics::ctpop16,
         intrinsics::ctlz16,
         intrinsics::cttz16,
@@ -1234,7 +1234,7 @@ impl u16 {
 
 #[lang = "u32"]
 impl u32 {
-    uint_impl! { u32, 32,
+    uint_impl! { u32, u32, 32,
         intrinsics::ctpop32,
         intrinsics::ctlz32,
         intrinsics::cttz32,
@@ -1247,7 +1247,7 @@ impl u32 {
 
 #[lang = "u64"]
 impl u64 {
-    uint_impl! { u64, 64,
+    uint_impl! { u64, u64, 64,
         intrinsics::ctpop64,
         intrinsics::ctlz64,
         intrinsics::cttz64,
@@ -1260,7 +1260,7 @@ impl u64 {
 #[cfg(target_pointer_width = "32")]
 #[lang = "usize"]
 impl usize {
-    uint_impl! { u32, 32,
+    uint_impl! { usize, u32, 32,
         intrinsics::ctpop32,
         intrinsics::ctlz32,
         intrinsics::cttz32,
@@ -1273,7 +1273,7 @@ impl usize {
 #[cfg(target_pointer_width = "64")]
 #[lang = "usize"]
 impl usize {
-    uint_impl! { u64, 64,
+    uint_impl! { usize, u64, 64,
         intrinsics::ctpop64,
         intrinsics::ctlz64,
         intrinsics::cttz64,

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -119,6 +119,34 @@ macro_rules! int_impl {
      $add_with_overflow:path,
      $sub_with_overflow:path,
      $mul_with_overflow:path) => {
+
+        // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
+        // calling the `mem::size_of` function.
+        #[unstable(feature = "num_bits_bytes",
+                   reason = "may want to be an associated function",
+                   issue = "27753")]
+        #[allow(missing_docs)]
+        pub const BITS : usize = $BITS;
+        // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
+        // calling the `mem::size_of` function.
+        #[unstable(feature = "num_bits_bytes",
+                   reason = "may want to be an associated function",
+                   issue = "27753")]
+        #[allow(missing_docs)]
+        pub const BYTES : usize = ($BITS / 8);
+
+        // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
+        // calling the `Bounded::min_value` function.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        #[allow(missing_docs)]
+        pub const MIN: $ActualT = (-1 as $ActualT) << ($BITS - 1);
+        // FIXME(#9837): Compute MIN like this so the high bits that shouldn't exist are 0.
+        // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
+        // calling the `Bounded::max_value` function.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        #[allow(missing_docs)]
+        pub const MAX: $ActualT = !<$ActualT>::MIN;
+
         /// Returns the smallest value that can be represented by this integer type.
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
@@ -669,6 +697,25 @@ macro_rules! uint_impl {
      $add_with_overflow:path,
      $sub_with_overflow:path,
      $mul_with_overflow:path) => {
+
+        #[unstable(feature = "num_bits_bytes",
+                   reason = "may want to be an associated function",
+                   issue = "27753")]
+        #[allow(missing_docs)]
+        pub const BITS : usize = $BITS;
+        #[unstable(feature = "num_bits_bytes",
+                   reason = "may want to be an associated function",
+                   issue = "27753")]
+        #[allow(missing_docs)]
+        pub const BYTES : usize = ($BITS / 8);
+
+        #[stable(feature = "rust1", since = "1.0.0")]
+        #[allow(missing_docs)]
+        pub const MIN: $ActualT = 0 as $ActualT;
+        #[stable(feature = "rust1", since = "1.0.0")]
+        #[allow(missing_docs)]
+        pub const MAX: $ActualT = !0 as $ActualT;
+
         /// Returns the smallest value that can be represented by this integer type.
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]

--- a/src/libcore/num/uint_macros.rs
+++ b/src/libcore/num/uint_macros.rs
@@ -12,6 +12,17 @@
 
 macro_rules! uint_module { ($T:ty, $T_SIGNED:ty, $bits:expr) => (
 
+#[unstable(feature = "num_bits_bytes",
+           reason = "may want to be an associated function",
+           issue = "27753")]
+#[allow(missing_docs)]
+pub const BITS : usize = $bits;
+#[unstable(feature = "num_bits_bytes",
+           reason = "may want to be an associated function",
+           issue = "27753")]
+#[allow(missing_docs)]
+pub const BYTES : usize = ($bits / 8);
+
 #[stable(feature = "rust1", since = "1.0.0")]
 #[allow(missing_docs)]
 pub const MIN: $T = 0 as $T;

--- a/src/libcore/num/uint_macros.rs
+++ b/src/libcore/num/uint_macros.rs
@@ -12,17 +12,6 @@
 
 macro_rules! uint_module { ($T:ty, $T_SIGNED:ty, $bits:expr) => (
 
-#[unstable(feature = "num_bits_bytes",
-           reason = "may want to be an associated function",
-           issue = "27753")]
-#[allow(missing_docs)]
-pub const BITS : usize = $bits;
-#[unstable(feature = "num_bits_bytes",
-           reason = "may want to be an associated function",
-           issue = "27753")]
-#[allow(missing_docs)]
-pub const BYTES : usize = ($bits / 8);
-
 #[stable(feature = "rust1", since = "1.0.0")]
 #[allow(missing_docs)]
 pub const MIN: $T = 0 as $T;

--- a/src/libcore/num/usize.rs
+++ b/src/libcore/num/usize.rs
@@ -14,4 +14,4 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-uint_module! { usize, isize, ::isize::BITS }
+uint_module! { usize, isize, isize::BITS }

--- a/src/libcoretest/num/int_macros.rs
+++ b/src/libcoretest/num/int_macros.rs
@@ -18,9 +18,9 @@ mod tests {
 
     #[test]
     fn test_overflows() {
-        assert!(MAX > 0);
-        assert!(MIN <= 0);
-        assert!(MIN + MAX + 1 == 0);
+        assert!($T::MAX > 0);
+        assert!($T::MIN <= 0);
+        assert!($T::MIN + $T::MAX + 1 == 0);
     }
 
     #[test]
@@ -85,9 +85,9 @@ mod tests {
 
     #[test]
     fn test_count_zeros() {
-        assert!(A.count_zeros() == BITS as u32 - 3);
-        assert!(B.count_zeros() == BITS as u32 - 2);
-        assert!(C.count_zeros() == BITS as u32 - 5);
+        assert!(A.count_zeros() == $T::BITS as u32 - 3);
+        assert!(B.count_zeros() == $T::BITS as u32 - 2);
+        assert!(C.count_zeros() == $T::BITS as u32 - 5);
     }
 
     #[test]

--- a/src/libcoretest/num/uint_macros.rs
+++ b/src/libcoretest/num/uint_macros.rs
@@ -18,9 +18,9 @@ mod tests {
 
     #[test]
     fn test_overflows() {
-        assert!(MAX > 0);
-        assert!(MIN <= 0);
-        assert!((MIN + MAX).wrapping_add(1) == 0);
+        assert!($T::MAX > 0);
+        assert!($T::MIN <= 0);
+        assert!(($T::MIN + $T::MAX).wrapping_add(1) == 0);
     }
 
     #[test]
@@ -54,9 +54,9 @@ mod tests {
 
     #[test]
     fn test_count_zeros() {
-        assert!(A.count_zeros() == BITS as u32 - 3);
-        assert!(B.count_zeros() == BITS as u32 - 2);
-        assert!(C.count_zeros() == BITS as u32 - 5);
+        assert!(A.count_zeros() == $T::BITS as u32 - 3);
+        assert!(B.count_zeros() == $T::BITS as u32 - 2);
+        assert!(C.count_zeros() == $T::BITS as u32 - 5);
     }
 
     #[test]

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -20,7 +20,6 @@ use middle::cfg;
 use middle::cfg::CFGIndex;
 use middle::ty;
 use std::io;
-use std::usize;
 use syntax::ast;
 use syntax::ast_util::IdRange;
 use syntax::print::pp;

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -19,7 +19,7 @@ use lint::{LateContext, LintContext, LintArray};
 use lint::{LintPass, LateLintPass};
 
 use std::cmp;
-use std::{i8, i16, i32, i64, u8, u16, u32, u64, f32, f64};
+use std::{f32, f64};
 
 use syntax::{abi, ast};
 use syntax::attr::{self, AttrMetaMethods};

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -533,12 +533,13 @@ fn build_index(krate: &clean::Crate, cache: &mut Cache) -> io::Result<String> {
     try!(write!(&mut w, r#"],"paths":["#));
 
     for (i, &did) in pathid_to_nodeid.iter().enumerate() {
-        let &(ref fqp, short) = cache.paths.get(&did).unwrap();
-        if i > 0 {
-            try!(write!(&mut w, ","));
+        if let Some(&(ref fqp, short)) = cache.paths.get(&did) {
+            if i > 0 {
+                try!(write!(&mut w, ","));
+            }
+            try!(write!(&mut w, r#"[{},"{}"]"#,
+                        short as usize, *fqp.last().unwrap()));
         }
-        try!(write!(&mut w, r#"[{},"{}"]"#,
-                    short as usize, *fqp.last().unwrap()));
     }
 
     try!(write!(&mut w, "]}};"));

--- a/src/libserialize/collection_impls.rs
+++ b/src/libserialize/collection_impls.rs
@@ -10,7 +10,6 @@
 
 //! Implementations of serialization for structures found in libcollections
 
-use std::usize;
 use std::default::Default;
 use std::hash::Hash;
 use std::collections::hash_state::HashState;

--- a/src/test/compile-fail/lint-exceeding-bitshifts.rs
+++ b/src/test/compile-fail/lint-exceeding-bitshifts.rs
@@ -57,8 +57,8 @@ fn main() {
       let n = 1u8 << (4+3);
       let n = 1u8 << (4+4); //~ ERROR: bitshift exceeds the type's number of bits
 
-      let n = 1_isize << std::isize::BITS; //~ ERROR: bitshift exceeds the type's number of bits
-      let n = 1_usize << std::usize::BITS; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1_isize << isize::BITS; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1_usize << usize::BITS; //~ ERROR: bitshift exceeds the type's number of bits
 
 
       let n = 1i8<<(1isize+-1);

--- a/src/test/run-pass/vector-sort-panic-safe.rs
+++ b/src/test/run-pass/vector-sort-panic-safe.rs
@@ -46,7 +46,7 @@ impl Drop for DropCounter {
 }
 
 pub fn main() {
-    assert!(MAX_LEN <= std::usize::BITS);
+    assert!(MAX_LEN <= usize::BITS);
     // len can't go above 64.
     for len in 2..MAX_LEN {
         for _ in 0..REPEATS {


### PR DESCRIPTION
Module versions of the constants are left in place for both stability reasons and as an escape hatch for https://github.com/rust-lang/rust/issues/28586

After this change (and after the resolution of https://github.com/rust-lang/rust/issues/28586) primitive types `[i/u][8/16/32/64/size]` and `bool` can be put into the prelude and not treated specially in resolve (the same can't be done backward-compatibly with `f[32/64]`, `char` and `str`, unfortunately).
