### PR TITLE
Avoid memory leaks when destroying TLS values on MacOS X

### DIFF
--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -389,7 +389,7 @@ mod imp {
         _tlv_atexit(dtor, t);
     }
 
-    pub unsafe extern fn destroy_value<T>(ptr: *mut u8) {
+    unsafe extern fn destroy_value<T>(ptr: *mut u8) {
         let ptr = ptr as *mut Key<T>;
         // Right before we run the user destructor be sure to flag the
         // destructor as running for this thread so calls to `get` will return
@@ -470,7 +470,7 @@ mod imp {
         }
     }
 
-    pub unsafe extern fn destroy_value<T: 'static>(ptr: *mut u8) {
+    unsafe extern fn destroy_value<T: 'static>(ptr: *mut u8) {
         // The OS TLS ensures that this key contains a NULL value when this
         // destructor starts to run. We set it back to a sentinel value of 1 to
         // ensure that any future calls to `get` for this thread will return


### PR DESCRIPTION
Depends on #28631.
Fixes the memory fault in #28129 (and makes the problem cause explicit: stdout is being initialised during the thread destruction).

Before this is merged I would like to investigate how the mac-specific hack in `destroy_value` is related to this (in particular if it is still needed).

Some guidance about what is the best way to use TLS variables in a robust way (in particular in drop implementations) would be very appreciated.
From the reference manual I infer that `state` should always be checked if the function can be called from a site in which the TLS destructor has already run.
At least in library code this might become very common, so I guess we might either have an idiomatic way to do it (and provide an example in the docs) or even have a `safe_with` method which provides an `Option`, so that the not-available (already destroyed/being destroyed) case always needs to be explicitly handled.
