### PR TITLE
rustc: Don't use jemalloc when crossing to MSVC

### DIFF
--- a/src/librustc_back/target/apple_base.rs
+++ b/src/librustc_back/target/apple_base.rs
@@ -24,7 +24,7 @@ pub fn opts() -> TargetOptions {
         dll_suffix: ".dylib".to_string(),
         archive_format: "bsd".to_string(),
         pre_link_args: Vec::new(),
-        exe_allocation_crate: super::best_allocator(),
+        exe_allocation_crate: super::maybe_jemalloc(),
         .. Default::default()
     }
 }

--- a/src/librustc_back/target/bitrig_base.rs
+++ b/src/librustc_back/target/bitrig_base.rs
@@ -20,7 +20,7 @@ pub fn opts() -> TargetOptions {
         has_rpath: true,
         position_independent_executables: true,
         archive_format: "gnu".to_string(),
-        exe_allocation_crate: super::best_allocator(),
+        exe_allocation_crate: "alloc_system".to_string(),
 
         .. Default::default()
     }

--- a/src/librustc_back/target/dragonfly_base.rs
+++ b/src/librustc_back/target/dragonfly_base.rs
@@ -27,7 +27,7 @@ pub fn opts() -> TargetOptions {
         ),
         position_independent_executables: true,
         archive_format: "gnu".to_string(),
-        exe_allocation_crate: super::best_allocator(),
+        exe_allocation_crate: super::maybe_jemalloc(),
         .. Default::default()
     }
 }

--- a/src/librustc_back/target/freebsd_base.rs
+++ b/src/librustc_back/target/freebsd_base.rs
@@ -18,7 +18,7 @@ pub fn opts() -> TargetOptions {
         executables: true,
         has_rpath: true,
         archive_format: "gnu".to_string(),
-        exe_allocation_crate: super::best_allocator(),
+        exe_allocation_crate: super::maybe_jemalloc(),
 
         .. Default::default()
     }

--- a/src/librustc_back/target/linux_base.rs
+++ b/src/librustc_back/target/linux_base.rs
@@ -29,7 +29,7 @@ pub fn opts() -> TargetOptions {
         ],
         position_independent_executables: true,
         archive_format: "gnu".to_string(),
-        exe_allocation_crate: super::best_allocator(),
+        exe_allocation_crate: super::maybe_jemalloc(),
         .. Default::default()
     }
 }

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -449,7 +449,7 @@ impl Target {
     }
 }
 
-fn best_allocator() -> String {
+fn maybe_jemalloc() -> String {
     if cfg!(disable_jemalloc) {
         "alloc_system".to_string()
     } else {

--- a/src/librustc_back/target/openbsd_base.rs
+++ b/src/librustc_back/target/openbsd_base.rs
@@ -27,7 +27,7 @@ pub fn opts() -> TargetOptions {
         ),
         position_independent_executables: true,
         archive_format: "gnu".to_string(),
-        exe_allocation_crate: super::best_allocator(),
+        exe_allocation_crate: "alloc_system".to_string(),
         .. Default::default()
     }
 }

--- a/src/librustc_back/target/windows_base.rs
+++ b/src/librustc_back/target/windows_base.rs
@@ -64,7 +64,7 @@ pub fn opts() -> TargetOptions {
             // Always enable DEP (NX bit) when it is available
             "-Wl,--nxcompat".to_string(),
         ),
-        exe_allocation_crate: super::best_allocator(),
+        exe_allocation_crate: super::maybe_jemalloc(),
 
         .. Default::default()
     }

--- a/src/librustc_back/target/windows_msvc_base.rs
+++ b/src/librustc_back/target/windows_msvc_base.rs
@@ -60,7 +60,7 @@ pub fn opts() -> TargetOptions {
             "/NXCOMPAT".to_string(),
         ],
         archive_format: "gnu".to_string(),
-        exe_allocation_crate: super::best_allocator(),
+        exe_allocation_crate: "alloc_system".to_string(),
 
         .. Default::default()
     }


### PR DESCRIPTION
This commit updates the compiler to not attempt to use jemalloc for platforms
where jemalloc is never enabled. Currently the compiler attempts to link in
jemalloc based on whether `--disable-jemalloc` was specified at build time for
the compiler itself, but this is only the right decision for the host target,
not for other targets.

This still leaves a hole open where a set of target libraries are downloaded
which were built with `--disable-jemalloc` and the compiler is unaware of that,
but this is a pretty rare case so it can always be fixed later.
