### PR TITLE
Elide lifetime in Deref doc example

### DIFF
--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -1628,7 +1628,7 @@ impl<Idx: fmt::Debug> fmt::Debug for RangeTo<Idx> {
 /// impl<T> Deref for DerefExample<T> {
 ///     type Target = T;
 ///
-///     fn deref<'a>(&'a self) -> &'a T {
+///     fn deref(&self) -> &T {
 ///         &self.value
 ///     }
 /// }


### PR DESCRIPTION
The lifetime can be elided here, and I think eliding it makes the example slightly simpler.
