### PR TITLE
Add an example of constructing a unit-like struct.

### DIFF
--- a/src/doc/trpl/structs.md
+++ b/src/doc/trpl/structs.md
@@ -184,6 +184,8 @@ You can define a `struct` with no members at all:
 
 ```rust
 struct Electron;
+
+let x = Electron;
 ```
 
 Such a `struct` is called ‘unit-like’ because it resembles the empty


### PR DESCRIPTION
This was non-obvious to me: with no example, I assumed `Electron {}` and
didn't know what else to try when it didn't work.  The correct form is
weird because it looks like you're assigning the struct name rather than
an instance of the struct.

r? @steveklabnik 
