### PR TITLE
store the rustc version in metadata and check it

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -2074,4 +2074,5 @@ register_diagnostics! {
     E0495, // cannot infer an appropriate lifetime due to conflicting requirements
     E0496, // .. name `..` shadows a .. name that is already in scope
     E0498, // malformed plugin attribute
+    E0514, // metadata version mismatch
 }

--- a/src/librustc/metadata/common.rs
+++ b/src/librustc/metadata/common.rs
@@ -259,3 +259,11 @@ pub const tag_defaulted_trait: usize = 0xa4;
 pub const tag_impl_coerce_unsized_kind: usize = 0xa5;
 
 pub const tag_items_data_item_constness: usize = 0xa6;
+
+pub const tag_rustc_version: usize = 0x10f;
+pub fn rustc_version() -> String {
+    format!(
+        "rustc {}",
+        option_env!("CFG_VERSION").unwrap_or("unknown version")
+    )
+}

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -77,6 +77,11 @@ pub fn load_index(data: &[u8]) -> index::Index {
     index::Index::from_buf(index.data, index.start, index.end)
 }
 
+pub fn crate_rustc_version(data: &[u8]) -> Option<String> {
+    let doc = rbml::Doc::new(data);
+    reader::maybe_get_doc(doc, tag_rustc_version).map(|s| s.as_str())
+}
+
 #[derive(Debug, PartialEq)]
 enum Family {
     ImmStatic,             // c

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1923,6 +1923,10 @@ fn encode_hash(rbml_w: &mut Encoder, hash: &Svh) {
     rbml_w.wr_tagged_str(tag_crate_hash, hash.as_str());
 }
 
+fn encode_rustc_version(rbml_w: &mut Encoder) {
+    rbml_w.wr_tagged_str(tag_rustc_version, &rustc_version());
+}
+
 fn encode_crate_name(rbml_w: &mut Encoder, crate_name: &str) {
     rbml_w.wr_tagged_str(tag_crate_crate_name, crate_name);
 }
@@ -2051,6 +2055,7 @@ fn encode_metadata_inner(wr: &mut Cursor<Vec<u8>>,
 
     let mut rbml_w = Encoder::new(wr);
 
+    encode_rustc_version(&mut rbml_w);
     encode_crate_name(&mut rbml_w, &ecx.link_meta.crate_name);
     encode_crate_triple(&mut rbml_w, &tcx.sess.opts.target_triple);
     encode_hash(&mut rbml_w, &ecx.link_meta.crate_hash);

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -244,7 +244,7 @@ impl OverloadedCallType {
 // can just use the tcx as the typer.
 //
 // FIXME(stage0): the :'t here is probably only important for stage0
-pub struct ExprUseVisitor<'d, 't, 'a: 't, 'tcx:'a+'d+'t> {
+pub struct ExprUseVisitor<'d, 't, 'a: 't, 'tcx:'a+'d> {
     typer: &'t infer::InferCtxt<'a, 'tcx>,
     mc: mc::MemCategorizationContext<'t, 'a, 'tcx>,
     delegate: &'d mut Delegate<'tcx>,
@@ -278,7 +278,7 @@ enum PassArgs {
 impl<'d,'t,'a,'tcx> ExprUseVisitor<'d,'t,'a,'tcx> {
     pub fn new(delegate: &'d mut Delegate<'tcx>,
                typer: &'t infer::InferCtxt<'a, 'tcx>)
-               -> ExprUseVisitor<'d,'t,'a,'tcx>
+               -> ExprUseVisitor<'d,'t,'a,'tcx> where 'tcx:'a
     {
         ExprUseVisitor {
             typer: typer,


### PR DESCRIPTION
This prevents ICEs when old crates are used with a new version of
rustc. Currently, the linking of crates compiled with different
versions of rustc is completely unsupported.

Fixes #28700

r? @nrc 
