### PR TITLE
Fill in some missing parts in the default AST and HIR visitors

### DIFF
--- a/src/librustc/front/map/mod.rs
+++ b/src/librustc/front/map/mod.rs
@@ -912,12 +912,12 @@ impl<'ast> Visitor<'ast> for NodeCollector<'ast> {
         self.parent_node = parent_node;
     }
 
-    fn visit_lifetime_ref(&mut self, lifetime: &'ast Lifetime) {
+    fn visit_lifetime(&mut self, lifetime: &'ast Lifetime) {
         self.insert(lifetime.id, NodeLifetime(lifetime));
     }
 
     fn visit_lifetime_def(&mut self, def: &'ast LifetimeDef) {
-        self.visit_lifetime_ref(&def.lifetime);
+        self.visit_lifetime(&def.lifetime);
     }
 }
 

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -898,12 +898,8 @@ impl<'a, 'v> ast_visit::Visitor<'v> for EarlyContext<'a> {
         });
     }
 
-    fn visit_opt_lifetime_ref(&mut self, sp: Span, lt: &Option<ast::Lifetime>) {
-        run_lints!(self, check_opt_lifetime_ref, early_passes, sp, lt);
-    }
-
-    fn visit_lifetime_ref(&mut self, lt: &ast::Lifetime) {
-        run_lints!(self, check_lifetime_ref, early_passes, lt);
+    fn visit_lifetime(&mut self, lt: &ast::Lifetime) {
+        run_lints!(self, check_lifetime, early_passes, lt);
     }
 
     fn visit_lifetime_def(&mut self, lt: &ast::LifetimeDef) {

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -745,12 +745,8 @@ impl<'a, 'tcx, 'v> hir_visit::Visitor<'v> for LateContext<'a, 'tcx> {
         });
     }
 
-    fn visit_opt_lifetime_ref(&mut self, sp: Span, lt: &Option<hir::Lifetime>) {
-        run_lints!(self, check_opt_lifetime_ref, late_passes, sp, lt);
-    }
-
-    fn visit_lifetime_ref(&mut self, lt: &hir::Lifetime) {
-        run_lints!(self, check_lifetime_ref, late_passes, lt);
+    fn visit_lifetime(&mut self, lt: &hir::Lifetime) {
+        run_lints!(self, check_lifetime, late_passes, lt);
     }
 
     fn visit_lifetime_def(&mut self, lt: &hir::LifetimeDef) {

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -199,11 +199,7 @@ pub trait EarlyLintPass: LintPass {
     fn check_struct_field(&mut self, _: &EarlyContext, _: &ast::StructField) { }
     fn check_variant(&mut self, _: &EarlyContext, _: &ast::Variant, _: &ast::Generics) { }
     fn check_variant_post(&mut self, _: &EarlyContext, _: &ast::Variant, _: &ast::Generics) { }
-    fn check_opt_lifetime_ref(&mut self,
-                              _: &EarlyContext,
-                              _: Span,
-                              _: &Option<ast::Lifetime>) { }
-    fn check_lifetime_ref(&mut self, _: &EarlyContext, _: &ast::Lifetime) { }
+    fn check_lifetime(&mut self, _: &EarlyContext, _: &ast::Lifetime) { }
     fn check_lifetime_def(&mut self, _: &EarlyContext, _: &ast::LifetimeDef) { }
     fn check_explicit_self(&mut self, _: &EarlyContext, _: &ast::ExplicitSelf) { }
     fn check_path(&mut self, _: &EarlyContext, _: &ast::Path, _: ast::NodeId) { }

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -156,8 +156,7 @@ pub trait LateLintPass: LintPass {
     fn check_struct_field(&mut self, _: &LateContext, _: &hir::StructField) { }
     fn check_variant(&mut self, _: &LateContext, _: &hir::Variant, _: &hir::Generics) { }
     fn check_variant_post(&mut self, _: &LateContext, _: &hir::Variant, _: &hir::Generics) { }
-    fn check_opt_lifetime_ref(&mut self, _: &LateContext, _: Span, _: &Option<hir::Lifetime>) { }
-    fn check_lifetime_ref(&mut self, _: &LateContext, _: &hir::Lifetime) { }
+    fn check_lifetime(&mut self, _: &LateContext, _: &hir::Lifetime) { }
     fn check_lifetime_def(&mut self, _: &LateContext, _: &hir::LifetimeDef) { }
     fn check_explicit_self(&mut self, _: &LateContext, _: &hir::ExplicitSelf) { }
     fn check_path(&mut self, _: &LateContext, _: &hir::Path, _: ast::NodeId) { }

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -481,6 +481,12 @@ impl<'a> CrateReader<'a> {
                 };
                 let span = mk_sp(lo, p.last_span.hi);
                 p.abort_if_errors();
+
+                // Mark the attrs as used
+                for attr in &attrs {
+                    attr::mark_used(attr);
+                }
+
                 macros.push(ast::MacroDef {
                     ident: ast::Ident::with_empty_ctxt(name),
                     attrs: attrs,

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -705,7 +705,7 @@ fn resolve_block(visitor: &mut RegionResolutionVisitor, blk: &hir::Block) {
             }
             visitor.visit_stmt(&**statement)
         }
-        visit::walk_expr_opt(visitor, &blk.expr)
+        walk_list!(visitor, visit_expr, &blk.expr);
     }
 
     visitor.cx = prev_cx;

--- a/src/librustc_back/svh.rs
+++ b/src/librustc_back/svh.rs
@@ -177,7 +177,7 @@ mod svh_visitor {
         SawIdent(token::InternedString),
         SawStructDef(token::InternedString),
 
-        SawLifetimeRef(token::InternedString),
+        SawLifetime(token::InternedString),
         SawLifetimeDef(token::InternedString),
 
         SawMod,
@@ -193,7 +193,6 @@ mod svh_visitor {
         SawVariant,
         SawExplicitSelf,
         SawPath,
-        SawOptLifetimeRef,
         SawBlock,
         SawPat,
         SawLocal,
@@ -316,17 +315,6 @@ mod svh_visitor {
             visit::walk_variant(self, v, g)
         }
 
-        fn visit_opt_lifetime_ref(&mut self, _: Span, l: &Option<Lifetime>) {
-            SawOptLifetimeRef.hash(self.st);
-            // (This is a strange method in the visitor trait, in that
-            // it does not expose a walk function to do the subroutine
-            // calls.)
-            match *l {
-                Some(ref l) => self.visit_lifetime_ref(l),
-                None => ()
-            }
-        }
-
         // All of the remaining methods just record (in the hash
         // SipHasher) that the visitor saw that particular variant
         // (with its payload), and continue walking as the default
@@ -345,8 +333,8 @@ mod svh_visitor {
             SawIdent(name.as_str()).hash(self.st);
         }
 
-        fn visit_lifetime_ref(&mut self, l: &Lifetime) {
-            SawLifetimeRef(l.name.as_str()).hash(self.st);
+        fn visit_lifetime(&mut self, l: &Lifetime) {
+            SawLifetime(l.name.as_str()).hash(self.st);
         }
 
         fn visit_lifetime_def(&mut self, l: &LifetimeDef) {

--- a/src/librustc_front/hir.rs
+++ b/src/librustc_front/hir.rs
@@ -1054,6 +1054,13 @@ impl PathListItem_ {
         }
     }
 
+    pub fn name(&self) -> Option<Name> {
+        match *self {
+            PathListIdent { name, .. } => Some(name),
+            PathListMod { .. } => None,
+        }
+    }
+
     pub fn rename(&self) -> Option<Name> {
         match *self {
             PathListIdent { rename, .. } | PathListMod { rename, .. } => rename

--- a/src/librustc_front/util.rs
+++ b/src/librustc_front/util.rs
@@ -303,12 +303,12 @@ impl<'a, 'v, O: ast_util::IdVisitingOperation> Visitor<'v> for IdVisitor<'a, O> 
         visit::walk_impl_item(self, ii);
     }
 
-    fn visit_lifetime_ref(&mut self, lifetime: &Lifetime) {
+    fn visit_lifetime(&mut self, lifetime: &Lifetime) {
         self.operation.visit_id(lifetime.id);
     }
 
     fn visit_lifetime_def(&mut self, def: &LifetimeDef) {
-        self.visit_lifetime_ref(&def.lifetime);
+        self.visit_lifetime(&def.lifetime);
     }
 
     fn visit_trait_ref(&mut self, trait_ref: &TraitRef) {

--- a/src/librustc_front/visit.rs
+++ b/src/librustc_front/visit.rs
@@ -25,11 +25,8 @@
 
 use syntax::abi::Abi;
 use syntax::ast::{Ident, NodeId, CRATE_NODE_ID, Name, Attribute};
-use hir::*;
-use hir;
 use syntax::codemap::Span;
-use syntax::ptr::P;
-use syntax::owned_slice::OwnedSlice;
+use hir::*;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum FnKind<'a> {
@@ -39,8 +36,7 @@ pub enum FnKind<'a> {
     /// fn foo(&self)
     Method(Name, &'a MethodSig, Option<Visibility>),
 
-    /// |x, y| ...
-    /// proc(x, y) ...
+    /// |x, y| {}
     Closure,
 }
 
@@ -57,7 +53,9 @@ pub trait Visitor<'v> : Sized {
     fn visit_name(&mut self, _span: Span, _name: Name) {
         // Nothing to do.
     }
-    fn visit_ident(&mut self, span: Span, ident: Ident) { walk_ident(self, span, ident) }
+    fn visit_ident(&mut self, span: Span, ident: Ident) {
+        walk_ident(self, span, ident);
+    }
     fn visit_mod(&mut self, m: &'v Mod, _s: Span, _n: NodeId) { walk_mod(self, m) }
     fn visit_foreign_item(&mut self, i: &'v ForeignItem) { walk_foreign_item(self, i) }
     fn visit_item(&mut self, i: &'v Item) { walk_item(self, i) }
@@ -94,21 +92,8 @@ pub trait Visitor<'v> : Sized {
 
     fn visit_variant(&mut self, v: &'v Variant, g: &'v Generics) { walk_variant(self, v, g) }
 
-    /// Visits an optional reference to a lifetime. The `span` is the span of some surrounding
-    /// reference should opt_lifetime be None.
-    fn visit_opt_lifetime_ref(&mut self,
-                              _span: Span,
-                              opt_lifetime: &'v Option<Lifetime>) {
-        match *opt_lifetime {
-            Some(ref l) => self.visit_lifetime_ref(l),
-            None => ()
-        }
-    }
-    fn visit_lifetime_bound(&mut self, lifetime: &'v Lifetime) {
-        walk_lifetime_bound(self, lifetime)
-    }
-    fn visit_lifetime_ref(&mut self, lifetime: &'v Lifetime) {
-        walk_lifetime_ref(self, lifetime)
+    fn visit_lifetime(&mut self, lifetime: &'v Lifetime) {
+        walk_lifetime(self, lifetime)
     }
     fn visit_lifetime_def(&mut self, lifetime: &'v LifetimeDef) {
         walk_lifetime_def(self, lifetime)
@@ -132,6 +117,21 @@ pub trait Visitor<'v> : Sized {
         walk_assoc_type_binding(self, type_binding)
     }
     fn visit_attribute(&mut self, _attr: &'v Attribute) {}
+    fn visit_macro_def(&mut self, macro_def: &'v MacroDef) {
+        walk_macro_def(self, macro_def)
+    }
+}
+
+pub fn walk_opt_name<'v, V: Visitor<'v>>(visitor: &mut V, span: Span, opt_name: Option<Name>) {
+    for name in opt_name {
+        visitor.visit_name(span, name);
+    }
+}
+
+pub fn walk_opt_ident<'v, V: Visitor<'v>>(visitor: &mut V, span: Span, opt_ident: Option<Ident>) {
+    for ident in opt_ident {
+        visitor.visit_ident(span, ident);
+    }
 }
 
 pub fn walk_ident<'v, V: Visitor<'v>>(visitor: &mut V, span: Span, ident: Ident) {
@@ -140,49 +140,51 @@ pub fn walk_ident<'v, V: Visitor<'v>>(visitor: &mut V, span: Span, ident: Ident)
 
 pub fn walk_crate<'v, V: Visitor<'v>>(visitor: &mut V, krate: &'v Crate) {
     visitor.visit_mod(&krate.module, krate.span, CRATE_NODE_ID);
-    for attr in &krate.attrs {
-        visitor.visit_attribute(attr);
-    }
+    walk_list!(visitor, visit_attribute, &krate.attrs);
+    walk_list!(visitor, visit_macro_def, &krate.exported_macros);
+}
+
+pub fn walk_macro_def<'v, V: Visitor<'v>>(visitor: &mut V, macro_def: &'v MacroDef) {
+    visitor.visit_name(macro_def.span, macro_def.name);
+    walk_opt_name(visitor, macro_def.span, macro_def.imported_from);
+    walk_list!(visitor, visit_attribute, &macro_def.attrs);
 }
 
 pub fn walk_mod<'v, V: Visitor<'v>>(visitor: &mut V, module: &'v Mod) {
-    for item in &module.items {
-        visitor.visit_item(&**item)
-    }
+    walk_list!(visitor, visit_item, &module.items);
 }
 
 pub fn walk_local<'v, V: Visitor<'v>>(visitor: &mut V, local: &'v Local) {
-    visitor.visit_pat(&*local.pat);
-    walk_ty_opt(visitor, &local.ty);
-    walk_expr_opt(visitor, &local.init);
+    visitor.visit_pat(&local.pat);
+    walk_list!(visitor, visit_ty, &local.ty);
+    walk_list!(visitor, visit_expr, &local.init);
+}
+
+pub fn walk_lifetime<'v, V: Visitor<'v>>(visitor: &mut V, lifetime: &'v Lifetime) {
+    visitor.visit_name(lifetime.span, lifetime.name);
 }
 
 pub fn walk_lifetime_def<'v, V: Visitor<'v>>(visitor: &mut V,
                                               lifetime_def: &'v LifetimeDef) {
-    visitor.visit_name(lifetime_def.lifetime.span, lifetime_def.lifetime.name);
-    for bound in &lifetime_def.bounds {
-        visitor.visit_lifetime_bound(bound);
-    }
-}
-
-pub fn walk_lifetime_bound<'v, V: Visitor<'v>>(visitor: &mut V,
-                                               lifetime_ref: &'v Lifetime) {
-    visitor.visit_lifetime_ref(lifetime_ref)
-}
-
-pub fn walk_lifetime_ref<'v, V: Visitor<'v>>(visitor: &mut V,
-                                             lifetime_ref: &'v Lifetime) {
-    visitor.visit_name(lifetime_ref.span, lifetime_ref.name)
+    visitor.visit_lifetime(&lifetime_def.lifetime);
+    walk_list!(visitor, visit_lifetime, &lifetime_def.bounds);
 }
 
 pub fn walk_explicit_self<'v, V: Visitor<'v>>(visitor: &mut V,
                                               explicit_self: &'v ExplicitSelf) {
     match explicit_self.node {
-        SelfStatic | SelfValue(_) => {},
-        SelfRegion(ref lifetime, _, _) => {
-            visitor.visit_opt_lifetime_ref(explicit_self.span, lifetime)
+        SelfStatic => {},
+        SelfValue(name) => {
+            visitor.visit_name(explicit_self.span, name)
         }
-        SelfExplicit(ref typ, _) => visitor.visit_ty(&**typ),
+        SelfRegion(ref opt_lifetime, _, name) => {
+            visitor.visit_name(explicit_self.span, name);
+            walk_list!(visitor, visit_lifetime, opt_lifetime);
+        }
+        SelfExplicit(ref typ, name) => {
+            visitor.visit_name(explicit_self.span, name);
+            visitor.visit_ty(typ)
+        }
     }
 }
 
@@ -191,7 +193,7 @@ pub fn walk_poly_trait_ref<'v, V>(visitor: &mut V,
                                   _modifier: &'v TraitBoundModifier)
     where V: Visitor<'v>
 {
-    walk_lifetime_decls_helper(visitor, &trait_ref.bound_lifetimes);
+    walk_list!(visitor, visit_lifetime_def, &trait_ref.bound_lifetimes);
     visitor.visit_trait_ref(&trait_ref.trait_ref);
 }
 
@@ -205,7 +207,9 @@ pub fn walk_trait_ref<'v,V>(visitor: &mut V,
 pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
     visitor.visit_name(item.span, item.name);
     match item.node {
-        ItemExternCrate(..) => {}
+        ItemExternCrate(opt_name) => {
+            walk_opt_name(visitor, item.span, opt_name)
+        }
         ItemUse(ref vp) => {
             match vp.node {
                 ViewPathSimple(name, ref path) => {
@@ -228,14 +232,14 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
         }
         ItemStatic(ref typ, _, ref expr) |
         ItemConst(ref typ, ref expr) => {
-            visitor.visit_ty(&**typ);
-            visitor.visit_expr(&**expr);
+            visitor.visit_ty(typ);
+            visitor.visit_expr(expr);
         }
         ItemFn(ref declaration, unsafety, constness, abi, ref generics, ref body) => {
             visitor.visit_fn(FnKind::ItemFn(item.name, generics, unsafety,
                                             constness, abi, item.vis),
-                             &**declaration,
-                             &**body,
+                             declaration,
+                             body,
                              item.span,
                              item.id)
         }
@@ -243,12 +247,10 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
             visitor.visit_mod(module, item.span, item.id)
         }
         ItemForeignMod(ref foreign_module) => {
-            for foreign_item in &foreign_module.items {
-                visitor.visit_foreign_item(&**foreign_item)
-            }
+            walk_list!(visitor, visit_foreign_item, &foreign_module.items);
         }
         ItemTy(ref typ, ref type_parameters) => {
-            visitor.visit_ty(&**typ);
+            visitor.visit_ty(typ);
             visitor.visit_generics(type_parameters)
         }
         ItemEnum(ref enum_definition, ref type_parameters) => {
@@ -260,44 +262,35 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
         }
         ItemImpl(_, _,
                  ref type_parameters,
-                 ref trait_reference,
+                 ref opt_trait_reference,
                  ref typ,
                  ref impl_items) => {
             visitor.visit_generics(type_parameters);
-            match *trait_reference {
-                Some(ref trait_reference) => visitor.visit_trait_ref(trait_reference),
-                None => ()
-            }
-            visitor.visit_ty(&**typ);
-            for impl_item in impl_items {
-                visitor.visit_impl_item(impl_item);
-            }
+            walk_list!(visitor, visit_trait_ref, opt_trait_reference);
+            visitor.visit_ty(typ);
+            walk_list!(visitor, visit_impl_item, impl_items);
         }
         ItemStruct(ref struct_definition, ref generics) => {
             visitor.visit_generics(generics);
-            visitor.visit_struct_def(&**struct_definition,
+            visitor.visit_struct_def(struct_definition,
                                      item.name,
                                      generics,
                                      item.id)
         }
         ItemTrait(_, ref generics, ref bounds, ref methods) => {
             visitor.visit_generics(generics);
-            walk_ty_param_bounds_helper(visitor, bounds);
-            for method in methods {
-                visitor.visit_trait_item(method)
-            }
+            walk_list!(visitor, visit_ty_param_bound, bounds);
+            walk_list!(visitor, visit_trait_item, methods);
         }
     }
-    for attr in &item.attrs {
-        visitor.visit_attribute(attr);
-    }
+    walk_list!(visitor, visit_attribute, &item.attrs);
 }
 
 pub fn walk_enum_def<'v, V: Visitor<'v>>(visitor: &mut V,
                                          enum_definition: &'v EnumDef,
                                          generics: &'v Generics) {
     for variant in &enum_definition.variants {
-        visitor.visit_variant(&**variant, generics);
+        visitor.visit_variant(variant, generics);
     }
 }
 
@@ -309,88 +302,60 @@ pub fn walk_variant<'v, V: Visitor<'v>>(visitor: &mut V,
     match variant.node.kind {
         TupleVariantKind(ref variant_arguments) => {
             for variant_argument in variant_arguments {
-                visitor.visit_ty(&*variant_argument.ty)
+                visitor.visit_ty(&variant_argument.ty)
             }
         }
         StructVariantKind(ref struct_definition) => {
-            visitor.visit_struct_def(&**struct_definition,
+            visitor.visit_struct_def(struct_definition,
                                      variant.node.name,
                                      generics,
                                      variant.node.id)
         }
     }
-    match variant.node.disr_expr {
-        Some(ref expr) => visitor.visit_expr(&**expr),
-        None => ()
-    }
-    for attr in &variant.node.attrs {
-        visitor.visit_attribute(attr);
-    }
-}
-
-pub fn skip_ty<'v, V: Visitor<'v>>(_: &mut V, _: &'v Ty) {
-    // Empty!
-}
-
-pub fn walk_ty_opt<'v, V: Visitor<'v>>(visitor: &mut V, optional_type: &'v Option<P<Ty>>) {
-    match *optional_type {
-        Some(ref ty) => visitor.visit_ty(&**ty),
-        None => ()
-    }
+    walk_list!(visitor, visit_expr, &variant.node.disr_expr);
+    walk_list!(visitor, visit_attribute, &variant.node.attrs);
 }
 
 pub fn walk_ty<'v, V: Visitor<'v>>(visitor: &mut V, typ: &'v Ty) {
     match typ.node {
         TyVec(ref ty) | TyParen(ref ty) => {
-            visitor.visit_ty(&**ty)
+            visitor.visit_ty(ty)
         }
         TyPtr(ref mutable_type) => {
-            visitor.visit_ty(&*mutable_type.ty)
+            visitor.visit_ty(&mutable_type.ty)
         }
-        TyRptr(ref lifetime, ref mutable_type) => {
-            visitor.visit_opt_lifetime_ref(typ.span, lifetime);
-            visitor.visit_ty(&*mutable_type.ty)
+        TyRptr(ref opt_lifetime, ref mutable_type) => {
+            walk_list!(visitor, visit_lifetime, opt_lifetime);
+            visitor.visit_ty(&mutable_type.ty)
         }
         TyTup(ref tuple_element_types) => {
-            for tuple_element_type in tuple_element_types {
-                visitor.visit_ty(&**tuple_element_type)
-            }
+            walk_list!(visitor, visit_ty, tuple_element_types);
         }
         TyBareFn(ref function_declaration) => {
-            for argument in &function_declaration.decl.inputs {
-                visitor.visit_ty(&*argument.ty)
-            }
-            walk_fn_ret_ty(visitor, &function_declaration.decl.output);
-            walk_lifetime_decls_helper(visitor, &function_declaration.lifetimes);
+            walk_fn_decl(visitor, &function_declaration.decl);
+            walk_list!(visitor, visit_lifetime_def, &function_declaration.lifetimes);
         }
         TyPath(ref maybe_qself, ref path) => {
-            if let Some(ref qself) = *maybe_qself {
+            for qself in maybe_qself {
                 visitor.visit_ty(&qself.ty);
             }
             visitor.visit_path(path, typ.id);
         }
         TyObjectSum(ref ty, ref bounds) => {
-            visitor.visit_ty(&**ty);
-            walk_ty_param_bounds_helper(visitor, bounds);
+            visitor.visit_ty(ty);
+            walk_list!(visitor, visit_ty_param_bound, bounds);
         }
         TyFixedLengthVec(ref ty, ref expression) => {
-            visitor.visit_ty(&**ty);
-            visitor.visit_expr(&**expression)
+            visitor.visit_ty(ty);
+            visitor.visit_expr(expression)
         }
         TyPolyTraitRef(ref bounds) => {
-            walk_ty_param_bounds_helper(visitor, bounds)
+            walk_list!(visitor, visit_ty_param_bound, bounds);
         }
         TyTypeof(ref expression) => {
-            visitor.visit_expr(&**expression)
+            visitor.visit_expr(expression)
         }
         TyInfer => {}
-    }
-}
-
-pub fn walk_lifetime_decls_helper<'v, V: Visitor<'v>>(visitor: &mut V,
-                                                      lifetimes: &'v Vec<LifetimeDef>) {
-    for l in lifetimes {
-        visitor.visit_lifetime_def(l);
     }
 }
 
@@ -406,9 +371,8 @@ pub fn walk_path_list_item<'v, V: Visitor<'v>>(visitor: &mut V, prefix: &'v Path
         visitor.visit_path_segment(prefix.span, segment);
     }
 
-    if let PathListIdent { name, .. } = item.node {
-        visitor.visit_name(item.span, name);
-    }
+    walk_opt_name(visitor, item.span, item.node.name());
+    walk_opt_name(visitor, item.span, item.node.rename());
 }
 
 pub fn walk_path_segment<'v, V: Visitor<'v>>(visitor: &mut V,
@@ -422,24 +386,14 @@ pub fn walk_path_parameters<'v, V: Visitor<'v>>(visitor: &mut V,
                                                 _path_span: Span,
                                                 path_parameters: &'v PathParameters) {
     match *path_parameters {
-        hir::AngleBracketedParameters(ref data) => {
-            for typ in data.types.iter() {
-                visitor.visit_ty(&**typ);
-            }
-            for lifetime in &data.lifetimes {
-                visitor.visit_lifetime_ref(lifetime);
-            }
-            for binding in data.bindings.iter() {
-                visitor.visit_assoc_type_binding(&**binding);
-            }
+        AngleBracketedParameters(ref data) => {
+            walk_list!(visitor, visit_ty, &data.types);
+            walk_list!(visitor, visit_lifetime, &data.lifetimes);
+            walk_list!(visitor, visit_assoc_type_binding, &data.bindings);
         }
-        hir::ParenthesizedParameters(ref data) => {
-            for typ in &data.inputs {
-                visitor.visit_ty(&**typ);
-            }
-            if let Some(ref typ) = data.output {
-                visitor.visit_ty(&**typ);
-            }
+        ParenthesizedParameters(ref data) => {
+            walk_list!(visitor, visit_ty, &data.inputs);
+            walk_list!(visitor, visit_ty, &data.output);
         }
     }
 }
@@ -447,17 +401,15 @@ pub fn walk_path_parameters<'v, V: Visitor<'v>>(visitor: &mut V,
 pub fn walk_assoc_type_binding<'v, V: Visitor<'v>>(visitor: &mut V,
                                                    type_binding: &'v TypeBinding) {
     visitor.visit_name(type_binding.span, type_binding.name);
-    visitor.visit_ty(&*type_binding.ty);
+    visitor.visit_ty(&type_binding.ty);
 }
 
 pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat) {
     match pattern.node {
-        PatEnum(ref path, ref children) => {
+        PatEnum(ref path, ref opt_children) => {
             visitor.visit_path(path, pattern.id);
-            if let Some(ref children) = *children {
-                for child in children {
-                    visitor.visit_pat(&*child)
-                }
+            for children in opt_children {
+                walk_list!(visitor, visit_pat, children);
             }
         }
         PatQPath(ref qself, ref path) => {
@@ -467,41 +419,31 @@ pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat) {
         PatStruct(ref path, ref fields, _) => {
             visitor.visit_path(path, pattern.id);
             for field in fields {
-                visitor.visit_pat(&*field.node.pat)
+                visitor.visit_name(field.span, field.node.name);
+                visitor.visit_pat(&field.node.pat)
             }
         }
         PatTup(ref tuple_elements) => {
-            for tuple_element in tuple_elements {
-                visitor.visit_pat(&**tuple_element)
-            }
+            walk_list!(visitor, visit_pat, tuple_elements);
         }
         PatBox(ref subpattern) |
         PatRegion(ref subpattern, _) => {
-            visitor.visit_pat(&**subpattern)
+            visitor.visit_pat(subpattern)
         }
         PatIdent(_, ref pth1, ref optional_subpattern) => {
             visitor.visit_ident(pth1.span, pth1.node);
-            match *optional_subpattern {
-                None => {}
-                Some(ref subpattern) => visitor.visit_pat(&**subpattern),
-            }
+            walk_list!(visitor, visit_pat, optional_subpattern);
         }
-        PatLit(ref expression) => visitor.visit_expr(&**expression),
+        PatLit(ref expression) => visitor.visit_expr(expression),
         PatRange(ref lower_bound, ref upper_bound) => {
-            visitor.visit_expr(&**lower_bound);
-            visitor.visit_expr(&**upper_bound)
+            visitor.visit_expr(lower_bound);
+            visitor.visit_expr(upper_bound)
         }
         PatWild(_) => (),
-        PatVec(ref prepattern, ref slice_pattern, ref postpatterns) => {
-            for prepattern in prepattern {
-                visitor.visit_pat(&**prepattern)
-            }
-            if let Some(ref slice_pattern) = *slice_pattern {
-                visitor.visit_pat(&**slice_pattern)
-            }
-            for postpattern in postpatterns {
-                visitor.visit_pat(&**postpattern)
-            }
+        PatVec(ref prepatterns, ref slice_pattern, ref postpatterns) => {
+            walk_list!(visitor, visit_pat, prepatterns);
+            walk_list!(visitor, visit_pat, slice_pattern);
+            walk_list!(visitor, visit_pat, postpatterns);
         }
     }
 }
@@ -512,22 +454,13 @@ pub fn walk_foreign_item<'v, V: Visitor<'v>>(visitor: &mut V,
 
     match foreign_item.node {
         ForeignItemFn(ref function_declaration, ref generics) => {
-            walk_fn_decl(visitor, &**function_declaration);
+            walk_fn_decl(visitor, function_declaration);
             visitor.visit_generics(generics)
         }
-        ForeignItemStatic(ref typ, _) => visitor.visit_ty(&**typ),
+        ForeignItemStatic(ref typ, _) => visitor.visit_ty(typ),
     }
 
-    for attr in &foreign_item.attrs {
-        visitor.visit_attribute(attr);
-    }
-}
-
-pub fn walk_ty_param_bounds_helper<'v, V: Visitor<'v>>(visitor: &mut V,
-                                                       bounds: &'v OwnedSlice<TyParamBound>) {
-    for bound in bounds.iter() {
-        visitor.visit_ty_param_bound(bound)
-    }
+    walk_list!(visitor, visit_attribute, &foreign_item.attrs);
 }
 
 pub fn walk_ty_param_bound<'v, V: Visitor<'v>>(visitor: &mut V,
@@ -537,41 +470,40 @@ pub fn walk_ty_param_bound<'v, V: Visitor<'v>>(visitor: &mut V,
             visitor.visit_poly_trait_ref(typ, modifier);
         }
         RegionTyParamBound(ref lifetime) => {
-            visitor.visit_lifetime_bound(lifetime);
+            visitor.visit_lifetime(lifetime);
         }
     }
 }
 
 pub fn walk_generics<'v, V: Visitor<'v>>(visitor: &mut V, generics: &'v Generics) {
-    for param in generics.ty_params.iter() {
+    for param in &generics.ty_params {
         visitor.visit_name(param.span, param.name);
-        walk_ty_param_bounds_helper(visitor, &param.bounds);
-        walk_ty_opt(visitor, &param.default);
+        walk_list!(visitor, visit_ty_param_bound, &param.bounds);
+        walk_list!(visitor, visit_ty, &param.default);
     }
-    walk_lifetime_decls_helper(visitor, &generics.lifetimes);
+    walk_list!(visitor, visit_lifetime_def, &generics.lifetimes);
     for predicate in &generics.where_clause.predicates {
         match predicate {
-            &hir::WherePredicate::BoundPredicate(hir::WhereBoundPredicate{ref bounded_ty,
+            &WherePredicate::BoundPredicate(WhereBoundPredicate{ref bounded_ty,
                                                                           ref bounds,
+                                                                          ref bound_lifetimes,
                                                                           ..}) => {
-                visitor.visit_ty(&**bounded_ty);
-                walk_ty_param_bounds_helper(visitor, bounds);
+                visitor.visit_ty(bounded_ty);
+                walk_list!(visitor, visit_ty_param_bound, bounds);
+                walk_list!(visitor, visit_lifetime_def, bound_lifetimes);
             }
-            &hir::WherePredicate::RegionPredicate(hir::WhereRegionPredicate{ref lifetime,
+            &WherePredicate::RegionPredicate(WhereRegionPredicate{ref lifetime,
                                                                             ref bounds,
                                                                             ..}) => {
-                visitor.visit_lifetime_ref(lifetime);
-
-                for bound in bounds {
-                    visitor.visit_lifetime_ref(bound);
-                }
+                visitor.visit_lifetime(lifetime);
+                walk_list!(visitor, visit_lifetime, bounds);
             }
-            &hir::WherePredicate::EqPredicate(hir::WhereEqPredicate{id,
+            &WherePredicate::EqPredicate(WhereEqPredicate{id,
                                                                     ref path,
                                                                     ref ty,
                                                                     ..}) => {
                 visitor.visit_path(path, id);
-                visitor.visit_ty(&**ty);
+                visitor.visit_ty(ty);
             }
         }
     }
@@ -579,14 +511,21 @@ pub fn walk_generics<'v, V: Visitor<'v>>(visitor: &mut V, generics: &'v Generics
 
 pub fn walk_fn_ret_ty<'v, V: Visitor<'v>>(visitor: &mut V, ret_ty: &'v FunctionRetTy) {
     if let Return(ref output_ty) = *ret_ty {
-        visitor.visit_ty(&**output_ty)
+        visitor.visit_ty(output_ty)
     }
 }
 
 pub fn walk_fn_decl<'v, V: Visitor<'v>>(visitor: &mut V, function_declaration: &'v FnDecl) {
     for argument in &function_declaration.inputs {
-        visitor.visit_pat(&*argument.pat);
-        visitor.visit_ty(&*argument.ty)
+        visitor.visit_pat(&argument.pat);
+        visitor.visit_ty(&argument.ty)
+    }
+    walk_fn_ret_ty(visitor, &function_declaration.output)
+}
+
+pub fn walk_fn_decl_nopat<'v, V: Visitor<'v>>(visitor: &mut V, function_declaration: &'v FnDecl) {
+    for argument in &function_declaration.inputs {
+        visitor.visit_ty(&argument.ty)
     }
     walk_fn_ret_ty(visitor, &function_declaration.output)
 }
@@ -601,7 +540,7 @@ pub fn walk_fn_kind<'v, V: Visitor<'v>>(visitor: &mut V,
             visitor.visit_generics(&sig.generics);
             visitor.visit_explicit_self(&sig.explicit_self);
         }
-        FnKind::Closure(..) => {}
+        FnKind::Closure => {}
     }
 }
 
@@ -617,15 +556,11 @@ pub fn walk_fn<'v, V: Visitor<'v>>(visitor: &mut V,
 
 pub fn walk_trait_item<'v, V: Visitor<'v>>(visitor: &mut V, trait_item: &'v TraitItem) {
     visitor.visit_name(trait_item.span, trait_item.name);
-    for attr in &trait_item.attrs {
-        visitor.visit_attribute(attr);
-    }
+    walk_list!(visitor, visit_attribute, &trait_item.attrs);
     match trait_item.node {
         ConstTraitItem(ref ty, ref default) => {
             visitor.visit_ty(ty);
-            if let Some(ref expr) = *default {
-                visitor.visit_expr(expr);
-            }
+            walk_list!(visitor, visit_expr, default);
         }
         MethodTraitItem(ref sig, None) => {
             visitor.visit_explicit_self(&sig.explicit_self);
@@ -637,17 +572,15 @@ pub fn walk_trait_item<'v, V: Visitor<'v>>(visitor: &mut V, trait_item: &'v Trai
                              body, trait_item.span, trait_item.id);
         }
         TypeTraitItem(ref bounds, ref default) => {
-            walk_ty_param_bounds_helper(visitor, bounds);
-            walk_ty_opt(visitor, default);
+            walk_list!(visitor, visit_ty_param_bound, bounds);
+            walk_list!(visitor, visit_ty, default);
         }
     }
 }
 
 pub fn walk_impl_item<'v, V: Visitor<'v>>(visitor: &mut V, impl_item: &'v ImplItem) {
     visitor.visit_name(impl_item.span, impl_item.name);
-    for attr in &impl_item.attrs {
-        visitor.visit_attribute(attr);
-    }
+    walk_list!(visitor, visit_attribute, &impl_item.attrs);
     match impl_item.node {
         ConstImplItem(ref ty, ref expr) => {
             visitor.visit_ty(ty);
@@ -665,173 +598,150 @@ pub fn walk_impl_item<'v, V: Visitor<'v>>(visitor: &mut V, impl_item: &'v ImplIt
 
 pub fn walk_struct_def<'v, V: Visitor<'v>>(visitor: &mut V,
                                            struct_definition: &'v StructDef) {
-    for field in &struct_definition.fields {
-        visitor.visit_struct_field(field)
-    }
+    walk_list!(visitor, visit_struct_field, &struct_definition.fields);
 }
 
 pub fn walk_struct_field<'v, V: Visitor<'v>>(visitor: &mut V,
                                              struct_field: &'v StructField) {
-    if let NamedField(name, _) = struct_field.node.kind {
-        visitor.visit_name(struct_field.span, name);
-    }
-
-    visitor.visit_ty(&*struct_field.node.ty);
-
-    for attr in &struct_field.node.attrs {
-        visitor.visit_attribute(attr);
-    }
+    walk_opt_name(visitor, struct_field.span, struct_field.node.name());
+    visitor.visit_ty(&struct_field.node.ty);
+    walk_list!(visitor, visit_attribute, &struct_field.node.attrs);
 }
 
 pub fn walk_block<'v, V: Visitor<'v>>(visitor: &mut V, block: &'v Block) {
-    for statement in &block.stmts {
-        visitor.visit_stmt(&**statement)
-    }
-    walk_expr_opt(visitor, &block.expr)
+    walk_list!(visitor, visit_stmt, &block.stmts);
+    walk_list!(visitor, visit_expr, &block.expr);
 }
 
 pub fn walk_stmt<'v, V: Visitor<'v>>(visitor: &mut V, statement: &'v Stmt) {
     match statement.node {
-        StmtDecl(ref declaration, _) => visitor.visit_decl(&**declaration),
+        StmtDecl(ref declaration, _) => visitor.visit_decl(declaration),
         StmtExpr(ref expression, _) | StmtSemi(ref expression, _) => {
-            visitor.visit_expr(&**expression)
+            visitor.visit_expr(expression)
         }
     }
 }
 
 pub fn walk_decl<'v, V: Visitor<'v>>(visitor: &mut V, declaration: &'v Decl) {
     match declaration.node {
-        DeclLocal(ref local) => visitor.visit_local(&**local),
-        DeclItem(ref item) => visitor.visit_item(&**item),
-    }
-}
-
-pub fn walk_expr_opt<'v, V: Visitor<'v>>(visitor: &mut V,
-                                         optional_expression: &'v Option<P<Expr>>) {
-    match *optional_expression {
-        None => {}
-        Some(ref expression) => visitor.visit_expr(&**expression),
-    }
-}
-
-pub fn walk_exprs<'v, V: Visitor<'v>>(visitor: &mut V, expressions: &'v [P<Expr>]) {
-    for expression in expressions {
-        visitor.visit_expr(&**expression)
+        DeclLocal(ref local) => visitor.visit_local(local),
+        DeclItem(ref item) => visitor.visit_item(item),
     }
 }
 
 pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
     match expression.node {
         ExprBox(ref subexpression) => {
-            visitor.visit_expr(&**subexpression)
+            visitor.visit_expr(subexpression)
         }
         ExprVec(ref subexpressions) => {
-            walk_exprs(visitor, subexpressions)
+            walk_list!(visitor, visit_expr, subexpressions);
         }
         ExprRepeat(ref element, ref count) => {
-            visitor.visit_expr(&**element);
-            visitor.visit_expr(&**count)
+            visitor.visit_expr(element);
+            visitor.visit_expr(count)
         }
         ExprStruct(ref path, ref fields, ref optional_base) => {
             visitor.visit_path(path, expression.id);
             for field in fields {
-                visitor.visit_expr(&*field.expr)
+                visitor.visit_name(field.name.span, field.name.node);
+                visitor.visit_expr(&field.expr)
             }
-            walk_expr_opt(visitor, optional_base)
+            walk_list!(visitor, visit_expr, optional_base);
         }
         ExprTup(ref subexpressions) => {
-            for subexpression in subexpressions {
-                visitor.visit_expr(&**subexpression)
-            }
+            walk_list!(visitor, visit_expr, subexpressions);
         }
         ExprCall(ref callee_expression, ref arguments) => {
-            for argument in arguments {
-                visitor.visit_expr(&**argument)
-            }
-            visitor.visit_expr(&**callee_expression)
+            walk_list!(visitor, visit_expr, arguments);
+            visitor.visit_expr(callee_expression)
         }
-        ExprMethodCall(_, ref types, ref arguments) => {
-            walk_exprs(visitor, arguments);
-            for typ in types {
-                visitor.visit_ty(&**typ)
-            }
+        ExprMethodCall(ref name, ref types, ref arguments) => {
+            visitor.visit_name(name.span, name.node);
+            walk_list!(visitor, visit_expr, arguments);
+            walk_list!(visitor, visit_ty, types);
         }
         ExprBinary(_, ref left_expression, ref right_expression) => {
-            visitor.visit_expr(&**left_expression);
-            visitor.visit_expr(&**right_expression)
+            visitor.visit_expr(left_expression);
+            visitor.visit_expr(right_expression)
         }
         ExprAddrOf(_, ref subexpression) | ExprUnary(_, ref subexpression) => {
-            visitor.visit_expr(&**subexpression)
+            visitor.visit_expr(subexpression)
         }
         ExprLit(_) => {}
         ExprCast(ref subexpression, ref typ) => {
-            visitor.visit_expr(&**subexpression);
-            visitor.visit_ty(&**typ)
+            visitor.visit_expr(subexpression);
+            visitor.visit_ty(typ)
         }
         ExprIf(ref head_expression, ref if_block, ref optional_else) => {
-            visitor.visit_expr(&**head_expression);
-            visitor.visit_block(&**if_block);
-            walk_expr_opt(visitor, optional_else)
+            visitor.visit_expr(head_expression);
+            visitor.visit_block(if_block);
+            walk_list!(visitor, visit_expr, optional_else);
         }
-        ExprWhile(ref subexpression, ref block, _) => {
-            visitor.visit_expr(&**subexpression);
-            visitor.visit_block(&**block)
+        ExprWhile(ref subexpression, ref block, opt_ident) => {
+            visitor.visit_expr(subexpression);
+            visitor.visit_block(block);
+            walk_opt_ident(visitor, expression.span, opt_ident)
         }
-        ExprLoop(ref block, _) => visitor.visit_block(&**block),
+        ExprLoop(ref block, opt_ident) => {
+            visitor.visit_block(block);
+            walk_opt_ident(visitor, expression.span, opt_ident)
+        }
         ExprMatch(ref subexpression, ref arms, _) => {
-            visitor.visit_expr(&**subexpression);
-            for arm in arms {
-                visitor.visit_arm(arm)
-            }
+            visitor.visit_expr(subexpression);
+            walk_list!(visitor, visit_arm, arms);
         }
         ExprClosure(_, ref function_declaration, ref body) => {
             visitor.visit_fn(FnKind::Closure,
-                             &**function_declaration,
-                             &**body,
+                             function_declaration,
+                             body,
                              expression.span,
                              expression.id)
         }
-        ExprBlock(ref block) => visitor.visit_block(&**block),
+        ExprBlock(ref block) => visitor.visit_block(block),
         ExprAssign(ref left_hand_expression, ref right_hand_expression) => {
-            visitor.visit_expr(&**right_hand_expression);
-            visitor.visit_expr(&**left_hand_expression)
+            visitor.visit_expr(right_hand_expression);
+            visitor.visit_expr(left_hand_expression)
         }
         ExprAssignOp(_, ref left_expression, ref right_expression) => {
-            visitor.visit_expr(&**right_expression);
-            visitor.visit_expr(&**left_expression)
+            visitor.visit_expr(right_expression);
+            visitor.visit_expr(left_expression)
         }
-        ExprField(ref subexpression, _) => {
-            visitor.visit_expr(&**subexpression);
+        ExprField(ref subexpression, ref name) => {
+            visitor.visit_expr(subexpression);
+            visitor.visit_name(name.span, name.node);
         }
         ExprTupField(ref subexpression, _) => {
-            visitor.visit_expr(&**subexpression);
+            visitor.visit_expr(subexpression);
         }
         ExprIndex(ref main_expression, ref index_expression) => {
-            visitor.visit_expr(&**main_expression);
-            visitor.visit_expr(&**index_expression)
+            visitor.visit_expr(main_expression);
+            visitor.visit_expr(index_expression)
         }
         ExprRange(ref start, ref end) => {
-            walk_expr_opt(visitor, start);
-            walk_expr_opt(visitor, end)
+            walk_list!(visitor, visit_expr, start);
+            walk_list!(visitor, visit_expr, end);
         }
         ExprPath(ref maybe_qself, ref path) => {
-            if let Some(ref qself) = *maybe_qself {
+            for qself in maybe_qself {
                 visitor.visit_ty(&qself.ty);
             }
             visitor.visit_path(path, expression.id)
         }
-        ExprBreak(_) | ExprAgain(_) => {}
+        ExprBreak(ref opt_sp_ident) | ExprAgain(ref opt_sp_ident) => {
+            for sp_ident in opt_sp_ident {
+                visitor.visit_ident(sp_ident.span, sp_ident.node);
+            }
+        }
         ExprRet(ref optional_expression) => {
-            walk_expr_opt(visitor, optional_expression)
+            walk_list!(visitor, visit_expr, optional_expression);
         }
         ExprInlineAsm(ref ia) => {
-            for input in &ia.inputs {
-                let (_, ref input) = *input;
-                visitor.visit_expr(&**input)
+            for &(_, ref input) in &ia.inputs {
+                visitor.visit_expr(&input)
             }
-            for output in &ia.outputs {
-                let (_, ref output, _) = *output;
-                visitor.visit_expr(&**output)
+            for &(_, ref output, _) in &ia.outputs {
+                visitor.visit_expr(&output)
             }
         }
     }
@@ -840,12 +750,8 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
 }
 
 pub fn walk_arm<'v, V: Visitor<'v>>(visitor: &mut V, arm: &'v Arm) {
-    for pattern in &arm.pats {
-        visitor.visit_pat(&**pattern)
-    }
-    walk_expr_opt(visitor, &arm.guard);
-    visitor.visit_expr(&*arm.body);
-    for attr in &arm.attrs {
-        visitor.visit_attribute(attr);
-    }
+    walk_list!(visitor, visit_pat, &arm.pats);
+    walk_list!(visitor, visit_expr, &arm.guard);
+    visitor.visit_expr(&arm.body);
+    walk_list!(visitor, visit_attribute, &arm.attrs);
 }

--- a/src/librustc_front/visit.rs
+++ b/src/librustc_front/visit.rs
@@ -336,7 +336,7 @@ pub fn walk_ty<'v, V: Visitor<'v>>(visitor: &mut V, typ: &'v Ty) {
             walk_list!(visitor, visit_lifetime_def, &function_declaration.lifetimes);
         }
         TyPath(ref maybe_qself, ref path) => {
-            for qself in maybe_qself {
+            if let Some(ref qself) = *maybe_qself {
                 visitor.visit_ty(&qself.ty);
             }
             visitor.visit_path(path, typ.id);
@@ -408,7 +408,7 @@ pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat) {
     match pattern.node {
         PatEnum(ref path, ref opt_children) => {
             visitor.visit_path(path, pattern.id);
-            for children in opt_children {
+            if let Some(ref children) = *opt_children {
                 walk_list!(visitor, visit_pat, children);
             }
         }
@@ -723,7 +723,7 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
             walk_list!(visitor, visit_expr, end);
         }
         ExprPath(ref maybe_qself, ref path) => {
-            for qself in maybe_qself {
+            if let Some(ref qself) = *maybe_qself {
                 visitor.visit_ty(&qself.ty);
             }
             visitor.visit_path(path, expression.id)

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2158,7 +2158,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                              |this| {
                     this.with_self_rib(DefSelfTy(Some(DefId::local(item.id)), None), |this| {
                         this.visit_generics(generics);
-                        visit::walk_ty_param_bounds_helper(this, bounds);
+                        walk_list!(this, visit_ty_param_bound, bounds);
 
                         for trait_item in trait_items {
                             match trait_item.node {
@@ -2542,10 +2542,10 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
     fn resolve_local(&mut self, local: &Local) {
         // Resolve the type.
-        visit::walk_ty_opt(self, &local.ty);
+        walk_list!(self, visit_ty, &local.ty);
 
         // Resolve the initializer.
-        visit::walk_expr_opt(self, &local.init);
+        walk_list!(self, visit_expr, &local.init);
 
         // Resolve the pattern.
         self.resolve_pattern(&*local.pat,
@@ -2622,7 +2622,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         // pat_idents are variants
         self.check_consistent_bindings(arm);
 
-        visit::walk_expr_opt(self, &arm.guard);
+        walk_list!(self, visit_expr, &arm.guard);
         self.visit_expr(&*arm.body);
 
         if !self.resolved {

--- a/src/librustc_trans/save/dump_csv.rs
+++ b/src/librustc_trans/save/dump_csv.rs
@@ -771,7 +771,7 @@ impl <'l, 'tcx> DumpCsvVisitor<'l, 'tcx> {
             }
         }
 
-        visit::walk_expr_opt(self, base)
+        walk_list!(self, visit_expr, base);
     }
 
     fn process_method_call(&mut self, ex: &ast::Expr, args: &Vec<P<ast::Expr>>) {
@@ -785,7 +785,7 @@ impl <'l, 'tcx> DumpCsvVisitor<'l, 'tcx> {
         }
 
         // walk receiver and args
-        visit::walk_exprs(self, &args);
+        walk_list!(self, visit_expr, args);
     }
 
     fn process_pat(&mut self, p: &ast::Pat) {
@@ -1200,7 +1200,7 @@ impl<'l, 'tcx, 'v> Visitor<'v> for DumpCsvVisitor<'l, 'tcx> {
         for &(id, ref path, ref_kind) in &paths_to_process {
             self.process_path(id, path, ref_kind);
         }
-        visit::walk_expr_opt(self, &arm.guard);
+        walk_list!(self, visit_expr, &arm.guard);
         self.visit_expr(&arm.body);
     }
 
@@ -1246,7 +1246,7 @@ impl<'l, 'tcx, 'v> Visitor<'v> for DumpCsvVisitor<'l, 'tcx> {
         }
 
         // Just walk the initialiser and type (don't want to walk the pattern again).
-        visit::walk_ty_opt(self, &l.ty);
-        visit::walk_expr_opt(self, &l.init);
+        walk_list!(self, visit_ty, &l.ty);
+        walk_list!(self, visit_expr, &l.init);
     }
 }

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -1167,7 +1167,7 @@ fn has_nested_returns(tcx: &ty::ctxt, cfg: &cfg::CFG, blk_id: ast::NodeId) -> bo
             }
             Some(hir_map::NodeBlock(blk)) if blk.id == blk_id => {
                 let mut visitor = FindNestedReturn::new();
-                visit::walk_expr_opt(&mut visitor, &blk.expr);
+                walk_list!(&mut visitor, visit_expr, &blk.expr);
                 if visitor.found {
                     return true;
                 }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -376,6 +376,11 @@ impl<'a, 'tcx> Visitor<'tcx> for CheckItemTypesVisitor<'a, 'tcx> {
             hir::TyFixedLengthVec(_, ref expr) => {
                 check_const_in_type(self.ccx, &**expr, self.ccx.tcx.types.usize);
             }
+            hir::TyBareFn(ref function_declaration) => {
+                visit::walk_fn_decl_nopat(self, &function_declaration.decl);
+                walk_list!(self, visit_lifetime_def, &function_declaration.lifetimes);
+                return
+            }
             _ => {}
         }
 
@@ -559,6 +564,10 @@ impl<'a, 'tcx> Visitor<'tcx> for GatherLocalsVisitor<'a, 'tcx> {
             hir::TyFixedLengthVec(ref ty, ref count_expr) => {
                 self.visit_ty(&**ty);
                 check_expr_with_hint(self.fcx, &**count_expr, self.fcx.tcx().types.usize);
+            }
+            hir::TyBareFn(ref function_declaration) => {
+                visit::walk_fn_decl_nopat(self, &function_declaration.decl);
+                walk_list!(self, visit_lifetime_def, &function_declaration.lifetimes);
             }
             _ => visit::walk_ty(self, t)
         }

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -225,6 +225,10 @@ impl<'cx, 'tcx, 'v> Visitor<'v> for WritebackCx<'cx, 'tcx> {
                 self.visit_ty(&**ty);
                 write_ty_to_tcx(self.tcx(), count_expr.id, self.tcx().types.usize);
             }
+            hir::TyBareFn(ref function_declaration) => {
+                visit::walk_fn_decl_nopat(self, &function_declaration.decl);
+                walk_list!(self, visit_lifetime_def, &function_declaration.lifetimes);
+            }
             _ => visit::walk_ty(self, t)
         }
     }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1613,6 +1613,13 @@ impl PathListItem_ {
         }
     }
 
+    pub fn name(&self) -> Option<Ident> {
+        match *self {
+            PathListIdent { name, .. } => Some(name),
+            PathListMod { .. } => None,
+        }
+    }
+
     pub fn rename(&self) -> Option<Ident> {
         match *self {
             PathListIdent { rename, .. } | PathListMod { rename, .. } => rename

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -476,12 +476,12 @@ impl<'a, 'v, O: IdVisitingOperation> Visitor<'v> for IdVisitor<'a, O> {
         visit::walk_impl_item(self, ii);
     }
 
-    fn visit_lifetime_ref(&mut self, lifetime: &Lifetime) {
+    fn visit_lifetime(&mut self, lifetime: &Lifetime) {
         self.operation.visit_id(lifetime.id);
     }
 
     fn visit_lifetime_def(&mut self, def: &LifetimeDef) {
-        self.visit_lifetime_ref(&def.lifetime);
+        self.visit_lifetime(&def.lifetime);
     }
 
     fn visit_trait_ref(&mut self, trait_ref: &TraitRef) {

--- a/src/libsyntax/owned_slice.rs
+++ b/src/libsyntax/owned_slice.rs
@@ -12,6 +12,7 @@ use std::default::Default;
 use std::fmt;
 use std::iter::{IntoIterator, FromIterator};
 use std::ops::Deref;
+use std::slice;
 use std::vec;
 use serialize::{Encodable, Decodable, Encoder, Decoder};
 
@@ -79,6 +80,14 @@ impl<T: Clone> Clone for OwnedSlice<T> {
 impl<T> FromIterator<T> for OwnedSlice<T> {
     fn from_iter<I: IntoIterator<Item=T>>(iter: I) -> OwnedSlice<T> {
         OwnedSlice::from_vec(iter.into_iter().collect())
+    }
+}
+
+impl<'a, T> IntoIterator for &'a OwnedSlice<T> {
+    type Item = &'a T;
+    type IntoIter = slice::Iter<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.into_iter()
     }
 }
 

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -353,7 +353,7 @@ pub fn walk_ty<'v, V: Visitor<'v>>(visitor: &mut V, typ: &'v Ty) {
             walk_list!(visitor, visit_lifetime_def, &function_declaration.lifetimes);
         }
         TyPath(ref maybe_qself, ref path) => {
-            for qself in maybe_qself {
+            if let Some(ref qself) = *maybe_qself {
                 visitor.visit_ty(&qself.ty);
             }
             visitor.visit_path(path, typ.id);
@@ -428,7 +428,7 @@ pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat) {
     match pattern.node {
         PatEnum(ref path, ref opt_children) => {
             visitor.visit_path(path, pattern.id);
-            for children in opt_children {
+            if let Some(ref children) = *opt_children {
                 walk_list!(visitor, visit_pat, children);
             }
         }
@@ -767,7 +767,7 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
             walk_list!(visitor, visit_expr, end);
         }
         ExprPath(ref maybe_qself, ref path) => {
-            for qself in maybe_qself {
+            if let Some(ref qself) = *maybe_qself {
                 visitor.visit_ty(&qself.ty);
             }
             visitor.visit_path(path, expression.id)

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -25,10 +25,7 @@
 
 use abi::Abi;
 use ast::*;
-use ast;
 use codemap::Span;
-use ptr::P;
-use owned_slice::OwnedSlice;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum FnKind<'a> {
@@ -56,7 +53,7 @@ pub trait Visitor<'v> : Sized {
         // Nothing to do.
     }
     fn visit_ident(&mut self, span: Span, ident: Ident) {
-        self.visit_name(span, ident.name);
+        walk_ident(self, span, ident);
     }
     fn visit_mod(&mut self, m: &'v Mod, _s: Span, _n: NodeId) { walk_mod(self, m) }
     fn visit_foreign_item(&mut self, i: &'v ForeignItem) { walk_foreign_item(self, i) }
@@ -94,21 +91,8 @@ pub trait Visitor<'v> : Sized {
 
     fn visit_variant(&mut self, v: &'v Variant, g: &'v Generics) { walk_variant(self, v, g) }
 
-    /// Visits an optional reference to a lifetime. The `span` is the span of some surrounding
-    /// reference should opt_lifetime be None.
-    fn visit_opt_lifetime_ref(&mut self,
-                              _span: Span,
-                              opt_lifetime: &'v Option<Lifetime>) {
-        match *opt_lifetime {
-            Some(ref l) => self.visit_lifetime_ref(l),
-            None => ()
-        }
-    }
-    fn visit_lifetime_bound(&mut self, lifetime: &'v Lifetime) {
-        walk_lifetime_bound(self, lifetime)
-    }
-    fn visit_lifetime_ref(&mut self, lifetime: &'v Lifetime) {
-        walk_lifetime_ref(self, lifetime)
+    fn visit_lifetime(&mut self, lifetime: &'v Lifetime) {
+        walk_lifetime(self, lifetime)
     }
     fn visit_lifetime_def(&mut self, lifetime: &'v LifetimeDef) {
         walk_lifetime_def(self, lifetime)
@@ -124,7 +108,7 @@ pub trait Visitor<'v> : Sized {
         // definition in your trait impl:
         // visit::walk_mac(self, _mac)
     }
-    fn visit_path(&mut self, path: &'v Path, _id: ast::NodeId) {
+    fn visit_path(&mut self, path: &'v Path, _id: NodeId) {
         walk_path(self, path)
     }
     fn visit_path_list_item(&mut self, prefix: &'v Path, item: &'v PathListItem) {
@@ -140,53 +124,83 @@ pub trait Visitor<'v> : Sized {
         walk_assoc_type_binding(self, type_binding)
     }
     fn visit_attribute(&mut self, _attr: &'v Attribute) {}
+    fn visit_macro_def(&mut self, macro_def: &'v MacroDef) {
+        walk_macro_def(self, macro_def)
+    }
+}
+
+#[macro_export]
+macro_rules! walk_list {
+    ($visitor: ident, $method: ident, $list: expr) => {
+        for elem in $list {
+            $visitor.$method(elem)
+        }
+    }
+}
+
+pub fn walk_opt_name<'v, V: Visitor<'v>>(visitor: &mut V, span: Span, opt_name: Option<Name>) {
+    for name in opt_name {
+        visitor.visit_name(span, name);
+    }
+}
+
+pub fn walk_opt_ident<'v, V: Visitor<'v>>(visitor: &mut V, span: Span, opt_ident: Option<Ident>) {
+    for ident in opt_ident {
+        visitor.visit_ident(span, ident);
+    }
+}
+
+pub fn walk_ident<'v, V: Visitor<'v>>(visitor: &mut V, span: Span, ident: Ident) {
+    visitor.visit_name(span, ident.name);
 }
 
 pub fn walk_crate<'v, V: Visitor<'v>>(visitor: &mut V, krate: &'v Crate) {
     visitor.visit_mod(&krate.module, krate.span, CRATE_NODE_ID);
-    for attr in &krate.attrs {
-        visitor.visit_attribute(attr);
-    }
+    walk_list!(visitor, visit_attribute, &krate.attrs);
+    walk_list!(visitor, visit_macro_def, &krate.exported_macros);
+}
+
+pub fn walk_macro_def<'v, V: Visitor<'v>>(visitor: &mut V, macro_def: &'v MacroDef) {
+    visitor.visit_ident(macro_def.span, macro_def.ident);
+    walk_opt_ident(visitor, macro_def.span, macro_def.imported_from);
+    walk_list!(visitor, visit_attribute, &macro_def.attrs);
 }
 
 pub fn walk_mod<'v, V: Visitor<'v>>(visitor: &mut V, module: &'v Mod) {
-    for item in &module.items {
-        visitor.visit_item(&**item)
-    }
+    walk_list!(visitor, visit_item, &module.items);
 }
 
 pub fn walk_local<'v, V: Visitor<'v>>(visitor: &mut V, local: &'v Local) {
-    visitor.visit_pat(&*local.pat);
-    walk_ty_opt(visitor, &local.ty);
-    walk_expr_opt(visitor, &local.init);
+    visitor.visit_pat(&local.pat);
+    walk_list!(visitor, visit_ty, &local.ty);
+    walk_list!(visitor, visit_expr, &local.init);
+}
+
+pub fn walk_lifetime<'v, V: Visitor<'v>>(visitor: &mut V, lifetime: &'v Lifetime) {
+    visitor.visit_name(lifetime.span, lifetime.name);
 }
 
 pub fn walk_lifetime_def<'v, V: Visitor<'v>>(visitor: &mut V,
                                               lifetime_def: &'v LifetimeDef) {
-    visitor.visit_name(lifetime_def.lifetime.span, lifetime_def.lifetime.name);
-    for bound in &lifetime_def.bounds {
-        visitor.visit_lifetime_bound(bound);
-    }
-}
-
-pub fn walk_lifetime_bound<'v, V: Visitor<'v>>(visitor: &mut V,
-                                               lifetime_ref: &'v Lifetime) {
-    visitor.visit_lifetime_ref(lifetime_ref)
-}
-
-pub fn walk_lifetime_ref<'v, V: Visitor<'v>>(visitor: &mut V,
-                                             lifetime_ref: &'v Lifetime) {
-    visitor.visit_name(lifetime_ref.span, lifetime_ref.name)
+    visitor.visit_lifetime(&lifetime_def.lifetime);
+    walk_list!(visitor, visit_lifetime, &lifetime_def.bounds);
 }
 
 pub fn walk_explicit_self<'v, V: Visitor<'v>>(visitor: &mut V,
                                               explicit_self: &'v ExplicitSelf) {
     match explicit_self.node {
-        SelfStatic | SelfValue(_) => {},
-        SelfRegion(ref lifetime, _, _) => {
-            visitor.visit_opt_lifetime_ref(explicit_self.span, lifetime)
+        SelfStatic => {},
+        SelfValue(ident) => {
+            visitor.visit_ident(explicit_self.span, ident)
         }
-        SelfExplicit(ref typ, _) => visitor.visit_ty(&**typ),
+        SelfRegion(ref opt_lifetime, _, ident) => {
+            visitor.visit_ident(explicit_self.span, ident);
+            walk_list!(visitor, visit_lifetime, opt_lifetime);
+        }
+        SelfExplicit(ref typ, ident) => {
+            visitor.visit_ident(explicit_self.span, ident);
+            visitor.visit_ty(typ)
+        }
     }
 }
 
@@ -195,7 +209,7 @@ pub fn walk_poly_trait_ref<'v, V>(visitor: &mut V,
                                   _modifier: &'v TraitBoundModifier)
     where V: Visitor<'v>
 {
-    walk_lifetime_decls_helper(visitor, &trait_ref.bound_lifetimes);
+    walk_list!(visitor, visit_lifetime_def, &trait_ref.bound_lifetimes);
     visitor.visit_trait_ref(&trait_ref.trait_ref);
 }
 
@@ -209,10 +223,13 @@ pub fn walk_trait_ref<'v,V>(visitor: &mut V,
 pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
     visitor.visit_ident(item.span, item.ident);
     match item.node {
-        ItemExternCrate(..) => {}
+        ItemExternCrate(opt_name) => {
+            walk_opt_name(visitor, item.span, opt_name)
+        }
         ItemUse(ref vp) => {
             match vp.node {
-                ViewPathSimple(_ident, ref path) => {
+                ViewPathSimple(ident, ref path) => {
+                    visitor.visit_ident(vp.span, ident);
                     visitor.visit_path(path, item.id);
                 }
                 ViewPathGlob(ref path) => {
@@ -231,14 +248,14 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
         }
         ItemStatic(ref typ, _, ref expr) |
         ItemConst(ref typ, ref expr) => {
-            visitor.visit_ty(&**typ);
-            visitor.visit_expr(&**expr);
+            visitor.visit_ty(typ);
+            visitor.visit_expr(expr);
         }
         ItemFn(ref declaration, unsafety, constness, abi, ref generics, ref body) => {
             visitor.visit_fn(FnKind::ItemFn(item.ident, generics, unsafety,
                                             constness, abi, item.vis),
-                             &**declaration,
-                             &**body,
+                             declaration,
+                             body,
                              item.span,
                              item.id)
         }
@@ -246,12 +263,10 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
             visitor.visit_mod(module, item.span, item.id)
         }
         ItemForeignMod(ref foreign_module) => {
-            for foreign_item in &foreign_module.items {
-                visitor.visit_foreign_item(&**foreign_item)
-            }
+            walk_list!(visitor, visit_foreign_item, &foreign_module.items);
         }
         ItemTy(ref typ, ref type_parameters) => {
-            visitor.visit_ty(&**typ);
+            visitor.visit_ty(typ);
             visitor.visit_generics(type_parameters)
         }
         ItemEnum(ref enum_definition, ref type_parameters) => {
@@ -263,45 +278,36 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
         }
         ItemImpl(_, _,
                  ref type_parameters,
-                 ref trait_reference,
+                 ref opt_trait_reference,
                  ref typ,
                  ref impl_items) => {
             visitor.visit_generics(type_parameters);
-            match *trait_reference {
-                Some(ref trait_reference) => visitor.visit_trait_ref(trait_reference),
-                None => ()
-            }
-            visitor.visit_ty(&**typ);
-            for impl_item in impl_items {
-                visitor.visit_impl_item(impl_item);
-            }
+            walk_list!(visitor, visit_trait_ref, opt_trait_reference);
+            visitor.visit_ty(typ);
+            walk_list!(visitor, visit_impl_item, impl_items);
         }
         ItemStruct(ref struct_definition, ref generics) => {
             visitor.visit_generics(generics);
-            visitor.visit_struct_def(&**struct_definition,
+            visitor.visit_struct_def(struct_definition,
                                      item.ident,
                                      generics,
                                      item.id)
         }
         ItemTrait(_, ref generics, ref bounds, ref methods) => {
             visitor.visit_generics(generics);
-            walk_ty_param_bounds_helper(visitor, bounds);
-            for method in methods {
-                visitor.visit_trait_item(method)
-            }
+            walk_list!(visitor, visit_ty_param_bound, bounds);
+            walk_list!(visitor, visit_trait_item, methods);
         }
         ItemMac(ref mac) => visitor.visit_mac(mac),
     }
-    for attr in &item.attrs {
-        visitor.visit_attribute(attr);
-    }
+    walk_list!(visitor, visit_attribute, &item.attrs);
 }
 
 pub fn walk_enum_def<'v, V: Visitor<'v>>(visitor: &mut V,
                                          enum_definition: &'v EnumDef,
                                          generics: &'v Generics) {
     for variant in &enum_definition.variants {
-        visitor.visit_variant(&**variant, generics);
+        visitor.visit_variant(variant, generics);
     }
 }
 
@@ -313,91 +319,63 @@ pub fn walk_variant<'v, V: Visitor<'v>>(visitor: &mut V,
     match variant.node.kind {
         TupleVariantKind(ref variant_arguments) => {
             for variant_argument in variant_arguments {
-                visitor.visit_ty(&*variant_argument.ty)
+                visitor.visit_ty(&variant_argument.ty)
             }
         }
         StructVariantKind(ref struct_definition) => {
-            visitor.visit_struct_def(&**struct_definition,
+            visitor.visit_struct_def(struct_definition,
                                      variant.node.name,
                                      generics,
                                      variant.node.id)
         }
     }
-    match variant.node.disr_expr {
-        Some(ref expr) => visitor.visit_expr(&**expr),
-        None => ()
-    }
-    for attr in &variant.node.attrs {
-        visitor.visit_attribute(attr);
-    }
-}
-
-pub fn skip_ty<'v, V: Visitor<'v>>(_: &mut V, _: &'v Ty) {
-    // Empty!
-}
-
-pub fn walk_ty_opt<'v, V: Visitor<'v>>(visitor: &mut V, optional_type: &'v Option<P<Ty>>) {
-    match *optional_type {
-        Some(ref ty) => visitor.visit_ty(&**ty),
-        None => ()
-    }
+    walk_list!(visitor, visit_expr, &variant.node.disr_expr);
+    walk_list!(visitor, visit_attribute, &variant.node.attrs);
 }
 
 pub fn walk_ty<'v, V: Visitor<'v>>(visitor: &mut V, typ: &'v Ty) {
     match typ.node {
         TyVec(ref ty) | TyParen(ref ty) => {
-            visitor.visit_ty(&**ty)
+            visitor.visit_ty(ty)
         }
         TyPtr(ref mutable_type) => {
-            visitor.visit_ty(&*mutable_type.ty)
+            visitor.visit_ty(&mutable_type.ty)
         }
-        TyRptr(ref lifetime, ref mutable_type) => {
-            visitor.visit_opt_lifetime_ref(typ.span, lifetime);
-            visitor.visit_ty(&*mutable_type.ty)
+        TyRptr(ref opt_lifetime, ref mutable_type) => {
+            walk_list!(visitor, visit_lifetime, opt_lifetime);
+            visitor.visit_ty(&mutable_type.ty)
         }
         TyTup(ref tuple_element_types) => {
-            for tuple_element_type in tuple_element_types {
-                visitor.visit_ty(&**tuple_element_type)
-            }
+            walk_list!(visitor, visit_ty, tuple_element_types);
         }
         TyBareFn(ref function_declaration) => {
-            for argument in &function_declaration.decl.inputs {
-                visitor.visit_ty(&*argument.ty)
-            }
-            walk_fn_ret_ty(visitor, &function_declaration.decl.output);
-            walk_lifetime_decls_helper(visitor, &function_declaration.lifetimes);
+            walk_fn_decl(visitor, &function_declaration.decl);
+            walk_list!(visitor, visit_lifetime_def, &function_declaration.lifetimes);
         }
         TyPath(ref maybe_qself, ref path) => {
-            if let Some(ref qself) = *maybe_qself {
+            for qself in maybe_qself {
                 visitor.visit_ty(&qself.ty);
             }
             visitor.visit_path(path, typ.id);
         }
         TyObjectSum(ref ty, ref bounds) => {
-            visitor.visit_ty(&**ty);
-            walk_ty_param_bounds_helper(visitor, bounds);
+            visitor.visit_ty(ty);
+            walk_list!(visitor, visit_ty_param_bound, bounds);
         }
         TyFixedLengthVec(ref ty, ref expression) => {
-            visitor.visit_ty(&**ty);
-            visitor.visit_expr(&**expression)
+            visitor.visit_ty(ty);
+            visitor.visit_expr(expression)
         }
         TyPolyTraitRef(ref bounds) => {
-            walk_ty_param_bounds_helper(visitor, bounds)
+            walk_list!(visitor, visit_ty_param_bound, bounds);
         }
         TyTypeof(ref expression) => {
-            visitor.visit_expr(&**expression)
+            visitor.visit_expr(expression)
         }
         TyInfer => {}
         TyMac(ref mac) => {
             visitor.visit_mac(mac)
         }
-    }
-}
-
-pub fn walk_lifetime_decls_helper<'v, V: Visitor<'v>>(visitor: &mut V,
-                                                      lifetimes: &'v Vec<LifetimeDef>) {
-    for l in lifetimes {
-        visitor.visit_lifetime_def(l);
     }
 }
 
@@ -413,9 +391,8 @@ pub fn walk_path_list_item<'v, V: Visitor<'v>>(visitor: &mut V, prefix: &'v Path
         visitor.visit_path_segment(prefix.span, segment);
     }
 
-    if let PathListIdent { name, .. } = item.node {
-        visitor.visit_ident(item.span, name);
-    }
+    walk_opt_ident(visitor, item.span, item.node.name());
+    walk_opt_ident(visitor, item.span, item.node.rename());
 }
 
 pub fn walk_path_segment<'v, V: Visitor<'v>>(visitor: &mut V,
@@ -429,24 +406,14 @@ pub fn walk_path_parameters<'v, V: Visitor<'v>>(visitor: &mut V,
                                                 _path_span: Span,
                                                 path_parameters: &'v PathParameters) {
     match *path_parameters {
-        ast::AngleBracketedParameters(ref data) => {
-            for typ in data.types.iter() {
-                visitor.visit_ty(&**typ);
-            }
-            for lifetime in &data.lifetimes {
-                visitor.visit_lifetime_ref(lifetime);
-            }
-            for binding in data.bindings.iter() {
-                visitor.visit_assoc_type_binding(&**binding);
-            }
+        AngleBracketedParameters(ref data) => {
+            walk_list!(visitor, visit_ty, &data.types);
+            walk_list!(visitor, visit_lifetime, &data.lifetimes);
+            walk_list!(visitor, visit_assoc_type_binding, &data.bindings);
         }
-        ast::ParenthesizedParameters(ref data) => {
-            for typ in &data.inputs {
-                visitor.visit_ty(&**typ);
-            }
-            if let Some(ref typ) = data.output {
-                visitor.visit_ty(&**typ);
-            }
+        ParenthesizedParameters(ref data) => {
+            walk_list!(visitor, visit_ty, &data.inputs);
+            walk_list!(visitor, visit_ty, &data.output);
         }
     }
 }
@@ -454,17 +421,15 @@ pub fn walk_path_parameters<'v, V: Visitor<'v>>(visitor: &mut V,
 pub fn walk_assoc_type_binding<'v, V: Visitor<'v>>(visitor: &mut V,
                                                    type_binding: &'v TypeBinding) {
     visitor.visit_ident(type_binding.span, type_binding.ident);
-    visitor.visit_ty(&*type_binding.ty);
+    visitor.visit_ty(&type_binding.ty);
 }
 
 pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat) {
     match pattern.node {
-        PatEnum(ref path, ref children) => {
+        PatEnum(ref path, ref opt_children) => {
             visitor.visit_path(path, pattern.id);
-            if let Some(ref children) = *children {
-                for child in children {
-                    visitor.visit_pat(&*child)
-                }
+            for children in opt_children {
+                walk_list!(visitor, visit_pat, children);
             }
         }
         PatQPath(ref qself, ref path) => {
@@ -474,41 +439,31 @@ pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat) {
         PatStruct(ref path, ref fields, _) => {
             visitor.visit_path(path, pattern.id);
             for field in fields {
-                visitor.visit_pat(&*field.node.pat)
+                visitor.visit_ident(field.span, field.node.ident);
+                visitor.visit_pat(&field.node.pat)
             }
         }
         PatTup(ref tuple_elements) => {
-            for tuple_element in tuple_elements {
-                visitor.visit_pat(&**tuple_element)
-            }
+            walk_list!(visitor, visit_pat, tuple_elements);
         }
         PatBox(ref subpattern) |
         PatRegion(ref subpattern, _) => {
-            visitor.visit_pat(&**subpattern)
+            visitor.visit_pat(subpattern)
         }
         PatIdent(_, ref pth1, ref optional_subpattern) => {
             visitor.visit_ident(pth1.span, pth1.node);
-            match *optional_subpattern {
-                None => {}
-                Some(ref subpattern) => visitor.visit_pat(&**subpattern),
-            }
+            walk_list!(visitor, visit_pat, optional_subpattern);
         }
-        PatLit(ref expression) => visitor.visit_expr(&**expression),
+        PatLit(ref expression) => visitor.visit_expr(expression),
         PatRange(ref lower_bound, ref upper_bound) => {
-            visitor.visit_expr(&**lower_bound);
-            visitor.visit_expr(&**upper_bound)
+            visitor.visit_expr(lower_bound);
+            visitor.visit_expr(upper_bound)
         }
         PatWild(_) => (),
-        PatVec(ref prepattern, ref slice_pattern, ref postpatterns) => {
-            for prepattern in prepattern {
-                visitor.visit_pat(&**prepattern)
-            }
-            if let Some(ref slice_pattern) = *slice_pattern {
-                visitor.visit_pat(&**slice_pattern)
-            }
-            for postpattern in postpatterns {
-                visitor.visit_pat(&**postpattern)
-            }
+        PatVec(ref prepatterns, ref slice_pattern, ref postpatterns) => {
+            walk_list!(visitor, visit_pat, prepatterns);
+            walk_list!(visitor, visit_pat, slice_pattern);
+            walk_list!(visitor, visit_pat, postpatterns);
         }
         PatMac(ref mac) => visitor.visit_mac(mac),
     }
@@ -520,22 +475,13 @@ pub fn walk_foreign_item<'v, V: Visitor<'v>>(visitor: &mut V,
 
     match foreign_item.node {
         ForeignItemFn(ref function_declaration, ref generics) => {
-            walk_fn_decl(visitor, &**function_declaration);
+            walk_fn_decl(visitor, function_declaration);
             visitor.visit_generics(generics)
         }
-        ForeignItemStatic(ref typ, _) => visitor.visit_ty(&**typ),
+        ForeignItemStatic(ref typ, _) => visitor.visit_ty(typ),
     }
 
-    for attr in &foreign_item.attrs {
-        visitor.visit_attribute(attr);
-    }
-}
-
-pub fn walk_ty_param_bounds_helper<'v, V: Visitor<'v>>(visitor: &mut V,
-                                                       bounds: &'v OwnedSlice<TyParamBound>) {
-    for bound in bounds.iter() {
-        visitor.visit_ty_param_bound(bound)
-    }
+    walk_list!(visitor, visit_attribute, &foreign_item.attrs);
 }
 
 pub fn walk_ty_param_bound<'v, V: Visitor<'v>>(visitor: &mut V,
@@ -545,58 +491,53 @@ pub fn walk_ty_param_bound<'v, V: Visitor<'v>>(visitor: &mut V,
             visitor.visit_poly_trait_ref(typ, modifier);
         }
         RegionTyParamBound(ref lifetime) => {
-            visitor.visit_lifetime_bound(lifetime);
+            visitor.visit_lifetime(lifetime);
         }
     }
 }
 
 pub fn walk_generics<'v, V: Visitor<'v>>(visitor: &mut V, generics: &'v Generics) {
-    for param in generics.ty_params.iter() {
+    for param in &generics.ty_params {
         visitor.visit_ident(param.span, param.ident);
-        walk_ty_param_bounds_helper(visitor, &param.bounds);
-        walk_ty_opt(visitor, &param.default);
+        walk_list!(visitor, visit_ty_param_bound, &param.bounds);
+        walk_list!(visitor, visit_ty, &param.default);
     }
-    walk_lifetime_decls_helper(visitor, &generics.lifetimes);
+    walk_list!(visitor, visit_lifetime_def, &generics.lifetimes);
     for predicate in &generics.where_clause.predicates {
         match predicate {
-            &ast::WherePredicate::BoundPredicate(ast::WhereBoundPredicate{ref bounded_ty,
+            &WherePredicate::BoundPredicate(WhereBoundPredicate{ref bounded_ty,
                                                                           ref bounds,
+                                                                          ref bound_lifetimes,
                                                                           ..}) => {
-                visitor.visit_ty(&**bounded_ty);
-                walk_ty_param_bounds_helper(visitor, bounds);
+                visitor.visit_ty(bounded_ty);
+                walk_list!(visitor, visit_ty_param_bound, bounds);
+                walk_list!(visitor, visit_lifetime_def, bound_lifetimes);
             }
-            &ast::WherePredicate::RegionPredicate(ast::WhereRegionPredicate{ref lifetime,
+            &WherePredicate::RegionPredicate(WhereRegionPredicate{ref lifetime,
                                                                             ref bounds,
                                                                             ..}) => {
-                visitor.visit_lifetime_ref(lifetime);
-
-                for bound in bounds {
-                    visitor.visit_lifetime_ref(bound);
-                }
+                visitor.visit_lifetime(lifetime);
+                walk_list!(visitor, visit_lifetime, bounds);
             }
-            &ast::WherePredicate::EqPredicate(ast::WhereEqPredicate{id,
+            &WherePredicate::EqPredicate(WhereEqPredicate{id,
                                                                     ref path,
                                                                     ref ty,
                                                                     ..}) => {
                 visitor.visit_path(path, id);
-                visitor.visit_ty(&**ty);
+                visitor.visit_ty(ty);
             }
         }
     }
 }
 
-pub fn walk_fn_ret_ty<'v, V: Visitor<'v>>(visitor: &mut V, ret_ty: &'v FunctionRetTy) {
-    if let Return(ref output_ty) = *ret_ty {
-        visitor.visit_ty(&**output_ty)
-    }
-}
-
 pub fn walk_fn_decl<'v, V: Visitor<'v>>(visitor: &mut V, function_declaration: &'v FnDecl) {
     for argument in &function_declaration.inputs {
-        visitor.visit_pat(&*argument.pat);
-        visitor.visit_ty(&*argument.ty)
+        visitor.visit_pat(&argument.pat);
+        visitor.visit_ty(&argument.ty)
     }
-    walk_fn_ret_ty(visitor, &function_declaration.output)
+    if let Return(ref output_ty) = function_declaration.output {
+        visitor.visit_ty(output_ty)
+    }
 }
 
 pub fn walk_fn<'v, V: Visitor<'v>>(visitor: &mut V,
@@ -614,7 +555,7 @@ pub fn walk_fn<'v, V: Visitor<'v>>(visitor: &mut V,
             visitor.visit_generics(&sig.generics);
             visitor.visit_explicit_self(&sig.explicit_self);
         }
-        FnKind::Closure(..) => {}
+        FnKind::Closure => {}
     }
 
     visitor.visit_block(function_body)
@@ -622,15 +563,11 @@ pub fn walk_fn<'v, V: Visitor<'v>>(visitor: &mut V,
 
 pub fn walk_trait_item<'v, V: Visitor<'v>>(visitor: &mut V, trait_item: &'v TraitItem) {
     visitor.visit_ident(trait_item.span, trait_item.ident);
-    for attr in &trait_item.attrs {
-        visitor.visit_attribute(attr);
-    }
+    walk_list!(visitor, visit_attribute, &trait_item.attrs);
     match trait_item.node {
         ConstTraitItem(ref ty, ref default) => {
             visitor.visit_ty(ty);
-            if let Some(ref expr) = *default {
-                visitor.visit_expr(expr);
-            }
+            walk_list!(visitor, visit_expr, default);
         }
         MethodTraitItem(ref sig, None) => {
             visitor.visit_explicit_self(&sig.explicit_self);
@@ -642,17 +579,15 @@ pub fn walk_trait_item<'v, V: Visitor<'v>>(visitor: &mut V, trait_item: &'v Trai
                              body, trait_item.span, trait_item.id);
         }
         TypeTraitItem(ref bounds, ref default) => {
-            walk_ty_param_bounds_helper(visitor, bounds);
-            walk_ty_opt(visitor, default);
+            walk_list!(visitor, visit_ty_param_bound, bounds);
+            walk_list!(visitor, visit_ty, default);
         }
     }
 }
 
 pub fn walk_impl_item<'v, V: Visitor<'v>>(visitor: &mut V, impl_item: &'v ImplItem) {
     visitor.visit_ident(impl_item.span, impl_item.ident);
-    for attr in &impl_item.attrs {
-        visitor.visit_attribute(attr);
-    }
+    walk_list!(visitor, visit_attribute, &impl_item.attrs);
     match impl_item.node {
         ConstImplItem(ref ty, ref expr) => {
             visitor.visit_ty(ty);
@@ -673,59 +608,35 @@ pub fn walk_impl_item<'v, V: Visitor<'v>>(visitor: &mut V, impl_item: &'v ImplIt
 
 pub fn walk_struct_def<'v, V: Visitor<'v>>(visitor: &mut V,
                                            struct_definition: &'v StructDef) {
-    for field in &struct_definition.fields {
-        visitor.visit_struct_field(field)
-    }
+    walk_list!(visitor, visit_struct_field, &struct_definition.fields);
 }
 
 pub fn walk_struct_field<'v, V: Visitor<'v>>(visitor: &mut V,
                                              struct_field: &'v StructField) {
-    if let NamedField(name, _) = struct_field.node.kind {
-        visitor.visit_ident(struct_field.span, name);
-    }
-
-    visitor.visit_ty(&*struct_field.node.ty);
-
-    for attr in &struct_field.node.attrs {
-        visitor.visit_attribute(attr);
-    }
+    walk_opt_ident(visitor, struct_field.span, struct_field.node.ident());
+    visitor.visit_ty(&struct_field.node.ty);
+    walk_list!(visitor, visit_attribute, &struct_field.node.attrs);
 }
 
 pub fn walk_block<'v, V: Visitor<'v>>(visitor: &mut V, block: &'v Block) {
-    for statement in &block.stmts {
-        visitor.visit_stmt(&**statement)
-    }
-    walk_expr_opt(visitor, &block.expr)
+    walk_list!(visitor, visit_stmt, &block.stmts);
+    walk_list!(visitor, visit_expr, &block.expr);
 }
 
 pub fn walk_stmt<'v, V: Visitor<'v>>(visitor: &mut V, statement: &'v Stmt) {
     match statement.node {
-        StmtDecl(ref declaration, _) => visitor.visit_decl(&**declaration),
+        StmtDecl(ref declaration, _) => visitor.visit_decl(declaration),
         StmtExpr(ref expression, _) | StmtSemi(ref expression, _) => {
-            visitor.visit_expr(&**expression)
+            visitor.visit_expr(expression)
         }
-        StmtMac(ref mac, _) => visitor.visit_mac(&**mac),
+        StmtMac(ref mac, _) => visitor.visit_mac(mac),
     }
 }
 
 pub fn walk_decl<'v, V: Visitor<'v>>(visitor: &mut V, declaration: &'v Decl) {
     match declaration.node {
-        DeclLocal(ref local) => visitor.visit_local(&**local),
-        DeclItem(ref item) => visitor.visit_item(&**item),
-    }
-}
-
-pub fn walk_expr_opt<'v, V: Visitor<'v>>(visitor: &mut V,
-                                         optional_expression: &'v Option<P<Expr>>) {
-    match *optional_expression {
-        None => {}
-        Some(ref expression) => visitor.visit_expr(&**expression),
-    }
-}
-
-pub fn walk_exprs<'v, V: Visitor<'v>>(visitor: &mut V, expressions: &'v [P<Expr>]) {
-    for expression in expressions {
-        visitor.visit_expr(&**expression)
+        DeclLocal(ref local) => visitor.visit_local(local),
+        DeclItem(ref item) => visitor.visit_item(item),
     }
 }
 
@@ -736,139 +647,142 @@ pub fn walk_mac<'v, V: Visitor<'v>>(_: &mut V, _: &'v Mac) {
 pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
     match expression.node {
         ExprBox(ref subexpression) => {
-            visitor.visit_expr(&**subexpression)
+            visitor.visit_expr(subexpression)
         }
         ExprInPlace(ref place, ref subexpression) => {
-            visitor.visit_expr(&**place);
-            visitor.visit_expr(&**subexpression)
+            visitor.visit_expr(place);
+            visitor.visit_expr(subexpression)
         }
         ExprVec(ref subexpressions) => {
-            walk_exprs(visitor, subexpressions)
+            walk_list!(visitor, visit_expr, subexpressions);
         }
         ExprRepeat(ref element, ref count) => {
-            visitor.visit_expr(&**element);
-            visitor.visit_expr(&**count)
+            visitor.visit_expr(element);
+            visitor.visit_expr(count)
         }
         ExprStruct(ref path, ref fields, ref optional_base) => {
             visitor.visit_path(path, expression.id);
             for field in fields {
-                visitor.visit_expr(&*field.expr)
+                visitor.visit_ident(field.ident.span, field.ident.node);
+                visitor.visit_expr(&field.expr)
             }
-            walk_expr_opt(visitor, optional_base)
+            walk_list!(visitor, visit_expr, optional_base);
         }
         ExprTup(ref subexpressions) => {
-            for subexpression in subexpressions {
-                visitor.visit_expr(&**subexpression)
-            }
+            walk_list!(visitor, visit_expr, subexpressions);
         }
         ExprCall(ref callee_expression, ref arguments) => {
-            for argument in arguments {
-                visitor.visit_expr(&**argument)
-            }
-            visitor.visit_expr(&**callee_expression)
+            walk_list!(visitor, visit_expr, arguments);
+            visitor.visit_expr(callee_expression)
         }
-        ExprMethodCall(_, ref types, ref arguments) => {
-            walk_exprs(visitor, arguments);
-            for typ in types {
-                visitor.visit_ty(&**typ)
-            }
+        ExprMethodCall(ref ident, ref types, ref arguments) => {
+            visitor.visit_ident(ident.span, ident.node);
+            walk_list!(visitor, visit_expr, arguments);
+            walk_list!(visitor, visit_ty, types);
         }
         ExprBinary(_, ref left_expression, ref right_expression) => {
-            visitor.visit_expr(&**left_expression);
-            visitor.visit_expr(&**right_expression)
+            visitor.visit_expr(left_expression);
+            visitor.visit_expr(right_expression)
         }
         ExprAddrOf(_, ref subexpression) | ExprUnary(_, ref subexpression) => {
-            visitor.visit_expr(&**subexpression)
+            visitor.visit_expr(subexpression)
         }
         ExprLit(_) => {}
         ExprCast(ref subexpression, ref typ) => {
-            visitor.visit_expr(&**subexpression);
-            visitor.visit_ty(&**typ)
+            visitor.visit_expr(subexpression);
+            visitor.visit_ty(typ)
         }
         ExprIf(ref head_expression, ref if_block, ref optional_else) => {
-            visitor.visit_expr(&**head_expression);
-            visitor.visit_block(&**if_block);
-            walk_expr_opt(visitor, optional_else)
+            visitor.visit_expr(head_expression);
+            visitor.visit_block(if_block);
+            walk_list!(visitor, visit_expr, optional_else);
         }
-        ExprWhile(ref subexpression, ref block, _) => {
-            visitor.visit_expr(&**subexpression);
-            visitor.visit_block(&**block)
+        ExprWhile(ref subexpression, ref block, opt_ident) => {
+            visitor.visit_expr(subexpression);
+            visitor.visit_block(block);
+            walk_opt_ident(visitor, expression.span, opt_ident)
         }
         ExprIfLet(ref pattern, ref subexpression, ref if_block, ref optional_else) => {
-            visitor.visit_pat(&**pattern);
-            visitor.visit_expr(&**subexpression);
-            visitor.visit_block(&**if_block);
-            walk_expr_opt(visitor, optional_else);
+            visitor.visit_pat(pattern);
+            visitor.visit_expr(subexpression);
+            visitor.visit_block(if_block);
+            walk_list!(visitor, visit_expr, optional_else);
         }
-        ExprWhileLet(ref pattern, ref subexpression, ref block, _) => {
-            visitor.visit_pat(&**pattern);
-            visitor.visit_expr(&**subexpression);
-            visitor.visit_block(&**block);
+        ExprWhileLet(ref pattern, ref subexpression, ref block, opt_ident) => {
+            visitor.visit_pat(pattern);
+            visitor.visit_expr(subexpression);
+            visitor.visit_block(block);
+            walk_opt_ident(visitor, expression.span, opt_ident)
         }
-        ExprForLoop(ref pattern, ref subexpression, ref block, _) => {
-            visitor.visit_pat(&**pattern);
-            visitor.visit_expr(&**subexpression);
-            visitor.visit_block(&**block)
+        ExprForLoop(ref pattern, ref subexpression, ref block, opt_ident) => {
+            visitor.visit_pat(pattern);
+            visitor.visit_expr(subexpression);
+            visitor.visit_block(block);
+            walk_opt_ident(visitor, expression.span, opt_ident)
         }
-        ExprLoop(ref block, _) => visitor.visit_block(&**block),
+        ExprLoop(ref block, opt_ident) => {
+            visitor.visit_block(block);
+            walk_opt_ident(visitor, expression.span, opt_ident)
+        }
         ExprMatch(ref subexpression, ref arms, _) => {
-            visitor.visit_expr(&**subexpression);
-            for arm in arms {
-                visitor.visit_arm(arm)
-            }
+            visitor.visit_expr(subexpression);
+            walk_list!(visitor, visit_arm, arms);
         }
         ExprClosure(_, ref function_declaration, ref body) => {
             visitor.visit_fn(FnKind::Closure,
-                             &**function_declaration,
-                             &**body,
+                             function_declaration,
+                             body,
                              expression.span,
                              expression.id)
         }
-        ExprBlock(ref block) => visitor.visit_block(&**block),
+        ExprBlock(ref block) => visitor.visit_block(block),
         ExprAssign(ref left_hand_expression, ref right_hand_expression) => {
-            visitor.visit_expr(&**right_hand_expression);
-            visitor.visit_expr(&**left_hand_expression)
+            visitor.visit_expr(right_hand_expression);
+            visitor.visit_expr(left_hand_expression)
         }
         ExprAssignOp(_, ref left_expression, ref right_expression) => {
-            visitor.visit_expr(&**right_expression);
-            visitor.visit_expr(&**left_expression)
+            visitor.visit_expr(right_expression);
+            visitor.visit_expr(left_expression)
         }
-        ExprField(ref subexpression, _) => {
-            visitor.visit_expr(&**subexpression);
+        ExprField(ref subexpression, ref ident) => {
+            visitor.visit_expr(subexpression);
+            visitor.visit_ident(ident.span, ident.node);
         }
         ExprTupField(ref subexpression, _) => {
-            visitor.visit_expr(&**subexpression);
+            visitor.visit_expr(subexpression);
         }
         ExprIndex(ref main_expression, ref index_expression) => {
-            visitor.visit_expr(&**main_expression);
-            visitor.visit_expr(&**index_expression)
+            visitor.visit_expr(main_expression);
+            visitor.visit_expr(index_expression)
         }
         ExprRange(ref start, ref end) => {
-            walk_expr_opt(visitor, start);
-            walk_expr_opt(visitor, end)
+            walk_list!(visitor, visit_expr, start);
+            walk_list!(visitor, visit_expr, end);
         }
         ExprPath(ref maybe_qself, ref path) => {
-            if let Some(ref qself) = *maybe_qself {
+            for qself in maybe_qself {
                 visitor.visit_ty(&qself.ty);
             }
             visitor.visit_path(path, expression.id)
         }
-        ExprBreak(_) | ExprAgain(_) => {}
+        ExprBreak(ref opt_sp_ident) | ExprAgain(ref opt_sp_ident) => {
+            for sp_ident in opt_sp_ident {
+                visitor.visit_ident(sp_ident.span, sp_ident.node);
+            }
+        }
         ExprRet(ref optional_expression) => {
-            walk_expr_opt(visitor, optional_expression)
+            walk_list!(visitor, visit_expr, optional_expression);
         }
         ExprMac(ref mac) => visitor.visit_mac(mac),
         ExprParen(ref subexpression) => {
-            visitor.visit_expr(&**subexpression)
+            visitor.visit_expr(subexpression)
         }
         ExprInlineAsm(ref ia) => {
-            for input in &ia.inputs {
-                let (_, ref input) = *input;
-                visitor.visit_expr(&**input)
+            for &(_, ref input) in &ia.inputs {
+                visitor.visit_expr(&input)
             }
-            for output in &ia.outputs {
-                let (_, ref output, _) = *output;
-                visitor.visit_expr(&**output)
+            for &(_, ref output, _) in &ia.outputs {
+                visitor.visit_expr(&output)
             }
         }
     }
@@ -877,12 +791,8 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
 }
 
 pub fn walk_arm<'v, V: Visitor<'v>>(visitor: &mut V, arm: &'v Arm) {
-    for pattern in &arm.pats {
-        visitor.visit_pat(&**pattern)
-    }
-    walk_expr_opt(visitor, &arm.guard);
-    visitor.visit_expr(&*arm.body);
-    for attr in &arm.attrs {
-        visitor.visit_attribute(attr);
-    }
+    walk_list!(visitor, visit_pat, &arm.pats);
+    walk_list!(visitor, visit_expr, &arm.guard);
+    visitor.visit_expr(&arm.body);
+    walk_list!(visitor, visit_attribute, &arm.attrs);
 }


### PR DESCRIPTION
Some minor parts of AST and HIR were not visited by the `visit::walk_xxx` methods - some identifiers, lifetimes, loop labels, attributes of exported macros - but nothing as serious as in, for example, https://github.com/rust-lang/rust/pull/28364.
+ Added a convenience macro for visiting lists (including Options)
+ Removed some pre-Deref-coersions `&**` noise from visitors

r? @nrc 
