### PR TITLE
Convert errors in libcore’s try! macro too.

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -154,16 +154,15 @@ macro_rules! debug_assert_eq {
 }
 
 /// Short circuiting evaluation on Err
-///
-/// `libstd` contains a more general `try!` macro that uses `From<E>`.
 #[macro_export]
 macro_rules! try {
     ($e:expr) => ({
         use $crate::result::Result::{Ok, Err};
+        use $crate::convert::From;
 
         match $e {
             Ok(e) => e,
-            Err(e) => return Err(e),
+            Err(e) => return Err(From::from(e)),
         }
     })
 }

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -223,6 +223,8 @@
 //! }
 //! ```
 //!
+//! (The real `try!` macro uses `From<E>` to convert between error types automatically.)
+//!
 //! `try!` is imported by the prelude and is available everywhere, but it can only
 //! be used in functions that return `Result` because of the early return of
 //! `Err` that it provides.


### PR DESCRIPTION
It is still a separate definition from libstd’s so that `$crate` expands to `std::` in the latter, not `core::`.

See discussion at https://github.com/rust-lang/rust/issues/27701. There is an expectation that `core::foo` is the same as `std::foo`. We should not have two things with the same name but subtly different behavior.

r? @aturon 
