### PR TITLE
Add configure flag to build stage1 with landing pads.

### DIFF
--- a/configure
+++ b/configure
@@ -578,6 +578,7 @@ opt ccache 0 "invoke gcc/clang via ccache to reuse object files between builds"
 opt local-rust 0 "use an installed rustc rather than downloading a snapshot"
 opt llvm-static-stdcpp 0 "statically link to libstdc++ for LLVM"
 opt rpath 0 "build rpaths into rustc itself"
+opt stage1-landing-pads 0 "compile stage1 with landing pads enabled"
 # This is used by the automation to produce single-target nightlies
 opt dist-host-only 0 "only install bins for the host architecture"
 opt inject-std-version 1 "inject the current compiler version of libstd into programs"

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -170,7 +170,9 @@ RUST_LIB_FLAGS_ST3 += -C prefer-dynamic
 
 # Landing pads require a lot of codegen. We can get through bootstrapping faster
 # by not emitting them.
-RUSTFLAGS_STAGE0 += -Z no-landing-pads
+ifndef CFG_ENABLE_STAGE1_LANDING_PADS
+  RUSTFLAGS_STAGE0 += -Z no-landing-pads
+endif
 
 # Enable MIR to "always build" for crates where this works. This is
 # just temporary while MIR is being actively built up -- it's just a


### PR DESCRIPTION
This adds a new configure flag, `--enable-stage1-landing-pads`.

It allows the use of `make check-stage1` which is broken when
`-Z no-landing-pads` is used to build stage1. The downside is that bootstrapping
will be slower with this flag is enabled, but some developers already manually do this to speed up their
testing cycle.

The default is to build with `-Z no-landing-pads` as before, so this commit has
no effect except when someone uses `./configure --enable-stage1-landing-pads`.
