### PR TITLE
Remove redundant uses of Iterator::by_ref()

### DIFF
--- a/src/libcollections/btree/node.rs
+++ b/src/libcollections/btree/node.rs
@@ -271,7 +271,7 @@ impl<T> DoubleEndedIterator for RawItems<T> {
 
 impl<T> Drop for RawItems<T> {
     fn drop(&mut self) {
-        for _ in self.by_ref() {}
+        for _ in self {}
     }
 }
 

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1489,7 +1489,7 @@ impl<T> ExactSizeIterator for IntoIter<T> {}
 impl<T> Drop for IntoIter<T> {
     fn drop(&mut self) {
         // destroy the remaining elements
-        for _x in self.by_ref() {}
+        for _x in self {}
 
         // RawVec handles deallocation
     }

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -165,7 +165,7 @@ pub trait Iterator {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn nth(&mut self, mut n: usize) -> Option<Self::Item> where Self: Sized {
-        for x in self.by_ref() {
+        for x in self {
             if n == 0 { return Some(x) }
             n -= 1;
         }
@@ -637,7 +637,7 @@ pub trait Iterator {
     fn all<F>(&mut self, mut f: F) -> bool where
         Self: Sized, F: FnMut(Self::Item) -> bool
     {
-        for x in self.by_ref() {
+        for x in self {
             if !f(x) {
                 return false;
             }
@@ -664,7 +664,7 @@ pub trait Iterator {
         Self: Sized,
         F: FnMut(Self::Item) -> bool
     {
-        for x in self.by_ref() {
+        for x in self {
             if f(x) {
                 return true;
             }
@@ -689,7 +689,7 @@ pub trait Iterator {
         Self: Sized,
         P: FnMut(&Self::Item) -> bool,
     {
-        for x in self.by_ref() {
+        for x in self {
             if predicate(&x) { return Some(x) }
         }
         None
@@ -725,7 +725,7 @@ pub trait Iterator {
         P: FnMut(Self::Item) -> bool,
     {
         // `enumerate` might overflow.
-        for (i, x) in self.by_ref().enumerate() {
+        for (i, x) in self.enumerate() {
             if predicate(x) {
                 return Some(i);
             }

--- a/src/libstd/collections/hash/table.rs
+++ b/src/libstd/collections/hash/table.rs
@@ -958,7 +958,7 @@ impl<'a, K, V> ExactSizeIterator for Drain<'a, K, V> {
 
 impl<'a, K: 'a, V: 'a> Drop for Drain<'a, K, V> {
     fn drop(&mut self) {
-        for _ in self.by_ref() {}
+        for _ in self {}
     }
 }
 


### PR DESCRIPTION
Remove redundant uses of Iterator::by_ref()
