### PR TITLE
libcxxabi is no longer necessary for libunwind

### DIFF
--- a/src/doc/trpl/advanced-linking.md
+++ b/src/doc/trpl/advanced-linking.md
@@ -94,8 +94,6 @@ $ # Build libunwind.a
 $ curl -O http://llvm.org/releases/3.7.0/llvm-3.7.0.src.tar.xz
 $ tar xf llvm-3.7.0.src.tar.xz
 $ cd llvm-3.7.0.src/projects/
-llvm-3.7.0.src/projects $ curl http://llvm.org/releases/3.7.0/libcxxabi-3.7.0.src.tar.xz | tar xJf -
-llvm-3.7.0.src/projects $ mv libcxxabi-3.7.0.src libcxxabi
 llvm-3.7.0.src/projects $ curl http://llvm.org/releases/3.7.0/libunwind-3.7.0.src.tar.xz | tar xJf -
 llvm-3.7.0.src/projects $ mv libunwind-3.7.0.src libunwind
 llvm-3.7.0.src/projects $ mkdir libunwind/build


### PR DESCRIPTION
On reading https://github.com/alexcrichton/port-of-rust/blob/master/musl/Dockerfile I was surprised to see no libcxxabi. I experimented, and it does seem to be unnecessary.

I guess it's a remnant from the 3.6 build.

r? @alexcrichton 
