### PR TITLE
turn on MIR construction unconditionally

### DIFF
--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -242,7 +242,7 @@ pub fn lookup_const_fn_by_id<'tcx>(tcx: &ty::ctxt<'tcx>, def_id: DefId)
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ConstVal {
     Float(f64),
     Int(i64),

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -38,6 +38,7 @@ use std::borrow::{Cow, IntoCow};
 use std::num::wrapping::OverflowingOps;
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry::Vacant;
+use std::mem::transmute;
 use std::{i8, i16, i32, i64, u8, u16, u32, u64};
 use std::rc::Rc;
 
@@ -242,7 +243,7 @@ pub fn lookup_const_fn_by_id<'tcx>(tcx: &ty::ctxt<'tcx>, def_id: DefId)
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub enum ConstVal {
     Float(f64),
     Int(i64),
@@ -252,6 +253,27 @@ pub enum ConstVal {
     Bool(bool),
     Struct(ast::NodeId),
     Tuple(ast::NodeId),
+}
+
+/// Note that equality for `ConstVal` means that the it is the same
+/// constant, not that the rust values are equal. In particular, `NaN
+/// == NaN` (at least if it's the same NaN; distinct encodings for NaN
+/// are considering unequal).
+impl PartialEq for ConstVal {
+    #[stable(feature = "rust1", since = "1.0.0")]
+    fn eq(&self, other: &ConstVal) -> bool {
+        match (self, other) {
+            (&Float(a), &Float(b)) => unsafe{transmute::<_,u64>(a) == transmute::<_,u64>(b)},
+            (&Int(a), &Int(b)) => a == b,
+            (&Uint(a), &Uint(b)) => a == b,
+            (&Str(ref a), &Str(ref b)) => a == b,
+            (&ByteStr(ref a), &ByteStr(ref b)) => a == b,
+            (&Bool(a), &Bool(b)) => a == b,
+            (&Struct(a), &Struct(b)) => a == b,
+            (&Tuple(a), &Tuple(b)) => a == b,
+            _ => false,
+        }
+    }
 }
 
 impl ConstVal {

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -718,9 +718,6 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: Session,
         // passes are timed inside typeck
         typeck::check_crate(tcx, trait_map);
 
-        time(time_passes, "MIR dump", ||
-             mir::dump::dump_crate(tcx));
-
         time(time_passes, "const checking", ||
             middle::check_const::check_crate(tcx));
 
@@ -740,6 +737,9 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: Session,
 
         time(time_passes, "match checking", ||
             middle::check_match::check_crate(tcx));
+
+        time(time_passes, "MIR dump", ||
+             mir::dump::dump_crate(tcx));
 
         time(time_passes, "liveness checking", ||
             middle::liveness::check_crate(tcx));

--- a/src/librustc_mir/build/expr/as_constant.rs
+++ b/src/librustc_mir/build/expr/as_constant.rs
@@ -10,8 +10,6 @@
 
 //! See docs in build/expr/mod.rs
 
-use rustc_data_structures::fnv::FnvHashMap;
-
 use build::{Builder};
 use hair::*;
 use repr::*;
@@ -28,93 +26,16 @@ impl<H:Hair> Builder<H> {
 
     fn expr_as_constant(&mut self, expr: Expr<H>) -> Constant<H> {
         let this = self;
-        let Expr { ty: _, temp_lifetime: _, span, kind } = expr;
-        let kind = match kind {
-            ExprKind::Scope { extent: _, value } => {
-                return this.as_constant(value);
-            }
-            ExprKind::Literal { literal } => {
-                ConstantKind::Literal(literal)
-            }
-            ExprKind::Vec { fields } => {
-                let fields = this.as_constants(fields);
-                ConstantKind::Aggregate(AggregateKind::Vec, fields)
-            }
-            ExprKind::Tuple { fields } => {
-                let fields = this.as_constants(fields);
-                ConstantKind::Aggregate(AggregateKind::Tuple, fields)
-            }
-            ExprKind::Adt { adt_def, variant_index, substs, fields, base: None } => {
-                let field_names = this.hir.fields(adt_def, variant_index);
-                let fields = this.named_field_constants(field_names, fields);
-                ConstantKind::Aggregate(AggregateKind::Adt(adt_def, variant_index, substs), fields)
-            }
-            ExprKind::Repeat { value, count } => {
-                let value = Box::new(this.as_constant(value));
-                let count = Box::new(this.as_constant(count));
-                ConstantKind::Repeat(value, count)
-            }
-            ExprKind::Binary { op, lhs, rhs } => {
-                let lhs = Box::new(this.as_constant(lhs));
-                let rhs = Box::new(this.as_constant(rhs));
-                ConstantKind::BinaryOp(op, lhs, rhs)
-            }
-            ExprKind::Unary { op, arg } => {
-                let arg = Box::new(this.as_constant(arg));
-                ConstantKind::UnaryOp(op, arg)
-            }
-            ExprKind::Field { lhs, name } => {
-                let lhs = this.as_constant(lhs);
-                ConstantKind::Projection(
-                    Box::new(ConstantProjection {
-                        base: lhs,
-                        elem: ProjectionElem::Field(name),
-                    }))
-            }
-            ExprKind::Deref { arg } => {
-                let arg = this.as_constant(arg);
-                ConstantKind::Projection(
-                    Box::new(ConstantProjection {
-                        base: arg,
-                        elem: ProjectionElem::Deref,
-                    }))
-            }
-            ExprKind::Call { fun, args } => {
-                let fun = this.as_constant(fun);
-                let args = this.as_constants(args);
-                ConstantKind::Call(Box::new(fun), args)
-            }
-            _ => {
+        let Expr { ty, temp_lifetime: _, span, kind } = expr;
+        match kind {
+            ExprKind::Scope { extent: _, value } =>
+                this.as_constant(value),
+            ExprKind::Literal { literal } =>
+                Constant { span: span, ty: ty, literal: literal },
+            _ =>
                 this.hir.span_bug(
                     span,
-                    &format!("expression is not a valid constant {:?}", kind));
-            }
-        };
-        Constant { span: span, kind: kind }
-    }
-
-    fn as_constants(&mut self,
-                    exprs: Vec<ExprRef<H>>)
-                    -> Vec<Constant<H>>
-    {
-        exprs.into_iter().map(|expr| self.as_constant(expr)).collect()
-    }
-
-    fn named_field_constants(&mut self,
-                             field_names: Vec<Field<H>>,
-                             field_exprs: Vec<FieldExprRef<H>>)
-                             -> Vec<Constant<H>>
-    {
-        let fields_map: FnvHashMap<_, _> =
-            field_exprs.into_iter()
-                       .map(|f| (f.name, self.as_constant(f.expr)))
-                       .collect();
-
-        let fields: Vec<_> =
-            field_names.into_iter()
-                       .map(|n| fields_map[&n].clone())
-                       .collect();
-
-        fields
+                    &format!("expression is not a valid constant {:?}", kind)),
+        }
     }
 }

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -99,14 +99,16 @@ impl<H:Hair> Builder<H> {
                     true_block, expr_span, destination,
                     Constant {
                         span: expr_span,
-                        kind: ConstantKind::Literal(Literal::Bool { value: true }),
+                        ty: this.hir.bool_ty(),
+                        literal: this.hir.true_literal(),
                     });
 
                 this.cfg.push_assign_constant(
                     false_block, expr_span, destination,
                     Constant {
                         span: expr_span,
-                        kind: ConstantKind::Literal(Literal::Bool { value: false }),
+                        ty: this.hir.bool_ty(),
+                        literal: this.hir.false_literal(),
                     });
 
                 this.cfg.terminate(true_block, Terminator::Goto { target: join_block });

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -221,10 +221,10 @@ enum TestKind<H:Hair> {
     Switch { adt_def: H::AdtDef },
 
     // test for equality
-    Eq { value: Constant<H>, ty: H::Ty },
+    Eq { value: Literal<H>, ty: H::Ty },
 
     // test whether the value falls within an inclusive range
-    Range { lo: Constant<H>, hi: Constant<H>, ty: H::Ty },
+    Range { lo: Literal<H>, hi: Literal<H>, ty: H::Ty },
 
     // test length of the slice is equal to len
     Len { len: usize, op: BinOp },
@@ -267,9 +267,12 @@ impl<H:Hair> Builder<H> {
             // If so, apply any bindings, test the guard (if any), and
             // branch to the arm.
             let candidate = candidates.pop().unwrap();
-            match self.bind_and_guard_matched_candidate(block, var_extent, candidate) {
-                None => { return; }
-                Some(b) => { block = b; }
+            if let Some(b) = self.bind_and_guard_matched_candidate(block, var_extent, candidate) {
+                block = b;
+            } else {
+                // if None is returned, then any remaining candidates
+                // are unreachable (at least not through this path).
+                return;
             }
         }
 

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -33,20 +33,20 @@ impl<H:Hair> Builder<H> {
                 }
             }
 
-            PatternKind::Constant { ref expr } => {
-                let expr = self.as_constant(expr.clone());
+            PatternKind::Constant { ref value } => {
                 Test {
                     span: match_pair.pattern.span,
-                    kind: TestKind::Eq { value: expr, ty: match_pair.pattern.ty.clone() },
+                    kind: TestKind::Eq { value: value.clone(),
+                                         ty: match_pair.pattern.ty.clone() },
                 }
             }
 
             PatternKind::Range { ref lo, ref hi } => {
-                let lo = self.as_constant(lo.clone());
-                let hi = self.as_constant(hi.clone());
                 Test {
                     span: match_pair.pattern.span,
-                    kind: TestKind::Range { lo: lo, hi: hi, ty: match_pair.pattern.ty.clone() },
+                    kind: TestKind::Range { lo: lo.clone(),
+                                            hi: hi.clone(),
+                                            ty: match_pair.pattern.ty.clone() },
                 }
             }
 
@@ -90,15 +90,15 @@ impl<H:Hair> Builder<H> {
 
             TestKind::Eq { value, ty } => {
                 // call PartialEq::eq(discrim, constant)
-                let constant = self.push_constant(block, test.span, ty.clone(), value);
+                let constant = self.push_literal(block, test.span, ty.clone(), value);
                 let item_ref = self.hir.partial_eq(ty);
                 self.call_comparison_fn(block, test.span, item_ref, lvalue.clone(), constant)
             }
 
             TestKind::Range { lo, hi, ty } => {
                 // Test `v` by computing `PartialOrd::le(lo, v) && PartialOrd::le(v, hi)`.
-                let lo = self.push_constant(block, test.span, ty.clone(), lo);
-                let hi = self.push_constant(block, test.span, ty.clone(), hi);
+                let lo = self.push_literal(block, test.span, ty.clone(), lo);
+                let hi = self.push_literal(block, test.span, ty.clone(), hi);
                 let item_ref = self.hir.partial_le(ty);
 
                 let lo_blocks =

--- a/src/librustc_mir/build/misc.rs
+++ b/src/librustc_mir/build/misc.rs
@@ -33,13 +33,14 @@ impl<H:Hair> Builder<H> {
         lvalue
     }
 
-    pub fn push_constant(&mut self,
-                         block: BasicBlock,
-                         span: H::Span,
-                         ty: H::Ty,
-                         constant: Constant<H>)
-                         -> Lvalue<H> {
-        let temp = self.temp(ty);
+    pub fn push_literal(&mut self,
+                        block: BasicBlock,
+                        span: H::Span,
+                        ty: H::Ty,
+                        literal: Literal<H>)
+                        -> Lvalue<H> {
+        let temp = self.temp(ty.clone());
+        let constant = Constant { span: span, ty: ty, literal: literal };
         self.cfg.push_assign_constant(block, span, &temp, constant);
         temp
     }
@@ -55,8 +56,8 @@ impl<H:Hair> Builder<H> {
             block, span, &temp,
             Constant {
                 span: span,
-                kind: ConstantKind::Literal(Literal::Uint { bits: IntegralBits::BSize,
-                                                            value: value as u64 }),
+                ty: self.hir.usize_ty(),
+                literal: self.hir.usize_literal(value),
             });
         temp
     }
@@ -66,13 +67,7 @@ impl<H:Hair> Builder<H> {
                          span: H::Span,
                          item_ref: ItemRef<H>)
                          -> Lvalue<H> {
-        let constant = Constant {
-            span: span,
-            kind: ConstantKind::Literal(Literal::Item {
-                def_id: item_ref.def_id,
-                substs: item_ref.substs
-            })
-        };
-        self.push_constant(block, span, item_ref.ty, constant)
+        let literal = Literal::Item { def_id: item_ref.def_id, substs: item_ref.substs };
+        self.push_literal(block, span, item_ref.ty, literal)
     }
 }

--- a/src/librustc_mir/build/stmt.rs
+++ b/src/librustc_mir/build/stmt.rs
@@ -40,7 +40,7 @@ impl<H:Hair> Builder<H> {
             StmtKind::Let { remainder_scope, init_scope, pattern, initializer: None, stmts } => {
                 this.in_scope(remainder_scope, block, |this| {
                     unpack!(block = this.in_scope(init_scope, block, |this| {
-                        this.declare_uninitialized_variables(remainder_scope, pattern);
+                        this.declare_bindings(remainder_scope, pattern);
                         block.unit()
                     }));
                     this.stmts(block, stmts)

--- a/src/librustc_mir/dump.rs
+++ b/src/librustc_mir/dump.rs
@@ -62,7 +62,7 @@ impl<'a, 'tcx> OuterDump<'a, 'tcx> {
             }
         }
 
-        let always_build_mir = self.tcx.sess.opts.always_build_mir;
+        let always_build_mir = true;
         if !built_mir && always_build_mir {
             let mut closure_dump = InnerDump { tcx: self.tcx, attr: None };
             walk_op(&mut closure_dump);

--- a/src/librustc_mir/hair.rs
+++ b/src/librustc_mir/hair.rs
@@ -38,6 +38,7 @@ pub trait Hair: Sized+Debug+Clone+Eq+Hash { // (*)
     type Ty: Clone+Debug+Eq;                                     // e.g., ty::Ty<'tcx>
     type Region: Copy+Debug;                                     // e.g., ty::Region
     type CodeExtent: Copy+Debug+Hash+Eq;                         // e.g., region::CodeExtent
+    type ConstVal: Clone+Debug+PartialEq;                        // e.g., ConstVal
     type Pattern: Clone+Debug+Mirror<Self,Output=Pattern<Self>>; // e.g., &P<ast::Pat>
     type Expr: Clone+Debug+Mirror<Self,Output=Expr<Self>>;       // e.g., &P<ast::Expr>
     type Stmt: Clone+Debug+Mirror<Self,Output=Stmt<Self>>;       // e.g., &P<ast::Stmt>
@@ -55,8 +56,17 @@ pub trait Hair: Sized+Debug+Clone+Eq+Hash { // (*)
     /// Returns the type `usize`.
     fn usize_ty(&mut self) -> Self::Ty;
 
+    /// Returns the literal for `true`
+    fn usize_literal(&mut self, value: usize) -> Literal<Self>;
+
     /// Returns the type `bool`.
     fn bool_ty(&mut self) -> Self::Ty;
+
+    /// Returns the literal for `true`
+    fn true_literal(&mut self) -> Literal<Self>;
+
+    /// Returns the literal for `true`
+    fn false_literal(&mut self) -> Literal<Self>;
 
     /// Returns a reference to `PartialEq::<T,T>::eq`
     fn partial_eq(&mut self, ty: Self::Ty) -> ItemRef<Self>;
@@ -261,9 +271,9 @@ pub enum PatternKind<H:Hair> {
 
     Deref { subpattern: PatternRef<H> }, // box P, &P, &mut P, etc
 
-    Constant { expr: ExprRef<H> },
+    Constant { value: Literal<H> },
 
-    Range { lo: ExprRef<H>, hi: ExprRef<H> },
+    Range { lo: Literal<H>, hi: Literal<H> },
 
     // matches against a slice, checking the length and extracting elements
     Slice { prefix: Vec<PatternRef<H>>,

--- a/src/librustc_mir/repr.rs
+++ b/src/librustc_mir/repr.rs
@@ -646,44 +646,12 @@ impl<H:Hair> Debug for Rvalue<H> {
 #[derive(Clone, Debug, PartialEq)]
 pub struct Constant<H:Hair> {
     pub span: H::Span,
-    pub kind: ConstantKind<H>
+    pub ty: H::Ty,
+    pub literal: Literal<H>
 }
-
-#[derive(Clone, Debug, PartialEq)]
-pub enum ConstantKind<H:Hair> {
-    Literal(Literal<H>),
-    Aggregate(AggregateKind<H>, Vec<Constant<H>>),
-    Call(Box<Constant<H>>, Vec<Constant<H>>),
-    Cast(Box<Constant<H>>, H::Ty),
-    Repeat(Box<Constant<H>>, Box<Constant<H>>),
-    Ref(BorrowKind, Box<Constant<H>>),
-    BinaryOp(BinOp, Box<Constant<H>>, Box<Constant<H>>),
-    UnaryOp(UnOp, Box<Constant<H>>),
-    Projection(Box<ConstantProjection<H>>)
-}
-
-pub type ConstantProjection<H> =
-    Projection<H,Constant<H>,Constant<H>>;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Literal<H:Hair> {
     Item { def_id: H::DefId, substs: H::Substs },
-    Projection { projection: H::Projection },
-    Int { bits: IntegralBits, value: i64 },
-    Uint { bits: IntegralBits, value: u64 },
-    Float { bits: FloatBits, value: f64 },
-    Char { c: char },
-    Bool { value: bool },
-    Bytes { value: H::Bytes },
-    String { value: H::InternedString },
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
-pub enum IntegralBits {
-    B8, B16, B32, B64, BSize
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
-pub enum FloatBits {
-    F32, F64
+    Value { value: H::ConstVal },
 }

--- a/src/librustc_mir/repr.rs
+++ b/src/librustc_mir/repr.rs
@@ -642,6 +642,10 @@ impl<H:Hair> Debug for Rvalue<H> {
 
 ///////////////////////////////////////////////////////////////////////////
 // Constants
+//
+// Two constants are equal if they are the same constant. Note that
+// this does not necessarily mean that they are "==" in Rust -- in
+// particular one must be wary of `NaN`!
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Constant<H:Hair> {
@@ -655,3 +659,4 @@ pub enum Literal<H:Hair> {
     Item { def_id: H::DefId, substs: H::Substs },
     Value { value: H::ConstVal },
 }
+

--- a/src/librustc_mir/tcx/mod.rs
+++ b/src/librustc_mir/tcx/mod.rs
@@ -14,6 +14,7 @@ use std::fmt::{Debug, Formatter, Error};
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
 
+use self::rustc::middle::const_eval::ConstVal;
 use self::rustc::middle::def_id::DefId;
 use self::rustc::middle::infer::InferCtxt;
 use self::rustc::middle::region::CodeExtent;
@@ -56,6 +57,7 @@ impl<'a,'tcx:'a> Hair for Cx<'a, 'tcx> {
     type Ty = Ty<'tcx>;
     type Region = ty::Region;
     type CodeExtent = CodeExtent;
+    type ConstVal = ConstVal;
     type Pattern = PatNode<'tcx>;
     type Expr = &'tcx hir::Expr;
     type Stmt = &'tcx hir::Stmt;
@@ -70,8 +72,20 @@ impl<'a,'tcx:'a> Hair for Cx<'a, 'tcx> {
         self.tcx.types.usize
     }
 
+    fn usize_literal(&mut self, value: usize) -> Literal<Self> {
+        Literal::Value { value: ConstVal::Uint(value as u64) }
+    }
+
     fn bool_ty(&mut self) -> Ty<'tcx> {
         self.tcx.types.bool
+    }
+
+    fn true_literal(&mut self) -> Literal<Self> {
+        Literal::Value { value: ConstVal::Bool(true) }
+    }
+
+    fn false_literal(&mut self) -> Literal<Self> {
+        Literal::Value { value: ConstVal::Bool(false) }
     }
 
     fn partial_eq(&mut self, ty: Ty<'tcx>) -> ItemRef<Self> {


### PR DESCRIPTION
I had to fix a few things. Notable changes:
1. I removed the MIR support for constants, instead falling back to the existing `ConstVal`. I still think we ought to reform how we handle constants, but it's not clear to me that the approach I was taking is correct, and anyway I think we ought to do it separately.
2. I adjusted how we handle bindings in matches: we now _declare_ all the bindings up front, rather than doing it as we encounter them. This is not only simpler, since we don't have to check if a binding has already been declared, it avoids ICEs if any of the arms turn out to be unreachable.
3. I do MIR construction _after_ `check_match`, because it detects various broken cases. I'd like for `check_match` to be subsumed by MIR construction, but we can do that as a separate PR (if indeed it makes sense).

I did a crater run and found no regressions in the wild: https://gist.github.com/nikomatsakis/0038f90e10c8ad00f2f8
