### PR TITLE
Fix module links in std::fmt and the Rust book's documentation chapter.

### DIFF
--- a/src/doc/trpl/documentation.md
+++ b/src/doc/trpl/documentation.md
@@ -45,7 +45,7 @@ Rust keeps track of these comments, and uses them when generating
 documentation. This is important when documenting things like enums:
 
 ```rust
-/// The `Option` type. See [the module level documentation](../) for more.
+/// The `Option` type. See [the module level documentation](index.html) for more.
 enum Option<T> {
     /// No value
     None,
@@ -57,7 +57,7 @@ enum Option<T> {
 The above works, but this does not:
 
 ```rust,ignore
-/// The `Option` type. See [the module level documentation](../) for more.
+/// The `Option` type. See [the module level documentation](index.html) for more.
 enum Option<T> {
     None, /// No value
     Some(T), /// Some value `T`

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -298,7 +298,7 @@ impl<'a> Display for Arguments<'a> {
 ///
 /// For more information on formatters, see [the module-level documentation][module].
 ///
-/// [module]: ../index.html
+/// [module]: index.html
 ///
 /// # Examples
 ///
@@ -393,7 +393,7 @@ pub trait Debug {
 ///
 /// For more information on formatters, see [the module-level documentation][module].
 ///
-/// [module]: ../index.html
+/// [module]: index.html
 ///
 /// # Examples
 ///
@@ -435,7 +435,7 @@ pub trait Display {
 ///
 /// For more information on formatters, see [the module-level documentation][module].
 ///
-/// [module]: ../index.html
+/// [module]: index.html
 ///
 /// # Examples
 ///
@@ -482,7 +482,7 @@ pub trait Octal {
 ///
 /// For more information on formatters, see [the module-level documentation][module].
 ///
-/// [module]: ../index.html
+/// [module]: index.html
 ///
 /// # Examples
 ///
@@ -530,7 +530,7 @@ pub trait Binary {
 ///
 /// For more information on formatters, see [the module-level documentation][module].
 ///
-/// [module]: ../index.html
+/// [module]: index.html
 ///
 /// # Examples
 ///
@@ -578,7 +578,7 @@ pub trait LowerHex {
 ///
 /// For more information on formatters, see [the module-level documentation][module].
 ///
-/// [module]: ../index.html
+/// [module]: index.html
 ///
 /// # Examples
 ///
@@ -624,7 +624,7 @@ pub trait UpperHex {
 ///
 /// For more information on formatters, see [the module-level documentation][module].
 ///
-/// [module]: ../index.html
+/// [module]: index.html
 ///
 /// # Examples
 ///
@@ -668,7 +668,7 @@ pub trait Pointer {
 ///
 /// For more information on formatters, see [the module-level documentation][module].
 ///
-/// [module]: ../index.html
+/// [module]: index.html
 ///
 /// # Examples
 ///
@@ -711,7 +711,7 @@ pub trait LowerExp {
 ///
 /// For more information on formatters, see [the module-level documentation][module].
 ///
-/// [module]: ../index.html
+/// [module]: index.html
 ///
 /// # Examples
 ///

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -298,7 +298,7 @@ impl<'a> Display for Arguments<'a> {
 ///
 /// For more information on formatters, see [the module-level documentation][module].
 ///
-/// [module]: index.html
+/// [module]: ../../std/fmt/index.html
 ///
 /// # Examples
 ///
@@ -393,7 +393,7 @@ pub trait Debug {
 ///
 /// For more information on formatters, see [the module-level documentation][module].
 ///
-/// [module]: index.html
+/// [module]: ../../std/fmt/index.html
 ///
 /// # Examples
 ///
@@ -435,7 +435,7 @@ pub trait Display {
 ///
 /// For more information on formatters, see [the module-level documentation][module].
 ///
-/// [module]: index.html
+/// [module]: ../../std/fmt/index.html
 ///
 /// # Examples
 ///
@@ -482,7 +482,7 @@ pub trait Octal {
 ///
 /// For more information on formatters, see [the module-level documentation][module].
 ///
-/// [module]: index.html
+/// [module]: ../../std/fmt/index.html
 ///
 /// # Examples
 ///
@@ -530,7 +530,7 @@ pub trait Binary {
 ///
 /// For more information on formatters, see [the module-level documentation][module].
 ///
-/// [module]: index.html
+/// [module]: ../../std/fmt/index.html
 ///
 /// # Examples
 ///
@@ -578,7 +578,7 @@ pub trait LowerHex {
 ///
 /// For more information on formatters, see [the module-level documentation][module].
 ///
-/// [module]: index.html
+/// [module]: ../../std/fmt/index.html
 ///
 /// # Examples
 ///
@@ -624,7 +624,7 @@ pub trait UpperHex {
 ///
 /// For more information on formatters, see [the module-level documentation][module].
 ///
-/// [module]: index.html
+/// [module]: ../../std/fmt/index.html
 ///
 /// # Examples
 ///
@@ -668,7 +668,7 @@ pub trait Pointer {
 ///
 /// For more information on formatters, see [the module-level documentation][module].
 ///
-/// [module]: index.html
+/// [module]: ../../std/fmt/index.html
 ///
 /// # Examples
 ///
@@ -711,7 +711,7 @@ pub trait LowerExp {
 ///
 /// For more information on formatters, see [the module-level documentation][module].
 ///
-/// [module]: index.html
+/// [module]: ../../std/fmt/index.html
 ///
 /// # Examples
 ///


### PR DESCRIPTION
The links in the rustdoc for several places in fmt were trying to link to
the std::fmt module but actually linking to std, which was confusing.
While trying to figure out why I noticed that the documentation chapter of
the Rust book has examples that show this same bug (although it doesn't seem
widespread in practice).

r? @steveklabnik 
