### PR TITLE
add a --dep-file option

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -799,6 +799,8 @@ pub fn rustc_short_optgroups() -> Vec<RustcOptGroup> {
                               http://www.sourceware.org/autobook/
                               for details)",
                "TRIPLE"),
+        opt::opt("", "dep-file", "Write dep-info output to <filename>",
+                 "FILENAME"),
         opt::multi("W", "warn", "Set lint warnings", "OPT"),
         opt::multi("A", "allow", "Set lint allowed", "OPT"),
         opt::multi("D", "deny", "Set lint denied", "OPT"),
@@ -1004,7 +1006,9 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
 
     let cfg = parse_cfgspecs(matches.opt_strs("cfg"));
     let test = matches.opt_present("test");
-    let write_dependency_info = (output_types.contains(&OutputTypeDepInfo), None);
+    let dependency_info_file = matches.opt_str("dep-file").map(|f| { PathBuf::from(&f) });
+    let write_dependency_info = (output_types.contains(&OutputTypeDepInfo),
+                                 dependency_info_file);
 
     let prints = matches.opt_strs("print").into_iter().map(|s| {
         match &*s {


### PR DESCRIPTION
Some projects need/want finer-grained control over where dependency
information is generated, rather than accepting the rustc default.  For
those projects, add a --dep-file option which enables them to specify
the location of the dependency info file.  It looks like config::Options
had such support already, so all that needs to be done is adding the
appropriate option and stuffing the information into the options
structure.

Fixes #28716.
