### PR TITLE
rustc: Improve the dep-info experience

### DIFF
--- a/man/rustc.1
+++ b/man/rustc.1
@@ -53,7 +53,9 @@ Comma separated list of types of crates for the compiler to emit.
 Specify the name of the crate being built.
 .TP
 \fB\-\-emit\fR [asm|llvm\-bc|llvm\-ir|obj|link|dep\-info]
-Configure the output that \fBrustc\fR will produce.
+Configure the output that \fBrustc\fR will produce. Each option may also be of
+the form KIND=PATH to specify the explicit output location for that particular
+emission kind.
 .TP
 \fB\-\-print\fR [crate\-name|file\-names|sysroot]
 Comma separated list of compiler information to print on stdout.
@@ -66,7 +68,8 @@ Equivalent to \fI\-C\ opt\-level=2\fR.
 .TP
 \fB\-o\fR \fIFILENAME\fR
 Write output to \fIFILENAME\fR.
-Ignored if multiple \fI\-\-emit\fR outputs are specified.
+Ignored if multiple \fI\-\-emit\fR outputs are specified which don't have an
+explicit path otherwise.
 .TP
 \fB\-\-out\-dir\fR \fIDIR\fR
 Write output to compiler\[hy]chosen filename in \fIDIR\fR.

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -881,8 +881,15 @@ fn write_out_deps(sess: &Session, outputs: &OutputFilenames, id: &str) {
                                    .collect();
         let mut file = try!(fs::File::create(&deps_filename));
         for path in &out_filenames {
-            try!(write!(&mut file,
+            try!(write!(file,
                         "{}: {}\n\n", path.display(), files.join(" ")));
+        }
+
+        // Emit a fake target for each input file to the compilation. This
+        // prevents `make` from spitting out an error if a file is later
+        // deleted. For more info see #28735
+        for path in files {
+            try!(writeln!(file, "{}:", path));
         }
         Ok(())
     })();

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -63,7 +63,7 @@ use rustc_resolve as resolve;
 use rustc_trans::back::link;
 use rustc_trans::save;
 use rustc::session::{config, Session, build_session};
-use rustc::session::config::{Input, PrintRequest};
+use rustc::session::config::{Input, PrintRequest, OutputType};
 use rustc::lint::Lint;
 use rustc::lint;
 use rustc::metadata;
@@ -382,7 +382,7 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
             control.after_analysis.stop = Compilation::Stop;
         }
 
-        if !sess.opts.output_types.iter().any(|&i| i == config::OutputTypeExe) {
+        if !sess.opts.output_types.keys().any(|&i| i == OutputType::Exe) {
             control.after_llvm.stop = Compilation::Stop;
         }
 

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -12,7 +12,7 @@ use back::lto;
 use back::link::{get_linker, remove};
 use session::config::{OutputFilenames, Passes, SomePasses, AllPasses};
 use session::Session;
-use session::config;
+use session::config::{self, OutputType};
 use llvm;
 use llvm::{ModuleRef, TargetMachineRef, PassManagerRef, DiagnosticInfoRef, ContextRef};
 use llvm::SMDiagnosticRef;
@@ -23,24 +23,16 @@ use syntax::codemap;
 use syntax::diagnostic;
 use syntax::diagnostic::{Emitter, Handler, Level};
 
+use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::ptr;
 use std::str;
 use std::sync::{Arc, Mutex};
 use std::sync::mpsc::channel;
 use std::thread;
 use libc::{self, c_uint, c_int, c_void};
-
-#[derive(Clone, Copy, PartialEq, PartialOrd, Ord, Eq)]
-pub enum OutputType {
-    OutputTypeBitcode,
-    OutputTypeAssembly,
-    OutputTypeLlvmAssembly,
-    OutputTypeObject,
-    OutputTypeExe,
-}
 
 pub fn llvm_err(handler: &diagnostic::Handler, msg: String) -> ! {
     unsafe {
@@ -571,7 +563,7 @@ unsafe fn optimize_and_codegen(cgcx: &CodegenContext,
 
 pub fn run_passes(sess: &Session,
                   trans: &CrateTranslation,
-                  output_types: &[config::OutputType],
+                  output_types: &HashMap<OutputType, Option<PathBuf>>,
                   crate_output: &OutputFilenames) {
     // It's possible that we have `codegen_units > 1` but only one item in
     // `trans.modules`.  We could theoretically proceed and do LTO in that
@@ -611,32 +603,32 @@ pub fn run_passes(sess: &Session,
     // archive in order to allow LTO against it.
     let needs_crate_bitcode =
             sess.crate_types.borrow().contains(&config::CrateTypeRlib) &&
-            sess.opts.output_types.contains(&config::OutputTypeExe);
+            sess.opts.output_types.contains_key(&OutputType::Exe);
     let needs_crate_object =
-            sess.opts.output_types.contains(&config::OutputTypeExe);
+            sess.opts.output_types.contains_key(&OutputType::Exe);
     if needs_crate_bitcode {
         modules_config.emit_bc = true;
     }
 
-    for output_type in output_types {
+    for output_type in output_types.keys() {
         match *output_type {
-            config::OutputTypeBitcode => { modules_config.emit_bc = true; },
-            config::OutputTypeLlvmAssembly => { modules_config.emit_ir = true; },
-            config::OutputTypeAssembly => {
+            OutputType::Bitcode => { modules_config.emit_bc = true; },
+            OutputType::LlvmAssembly => { modules_config.emit_ir = true; },
+            OutputType::Assembly => {
                 modules_config.emit_asm = true;
                 // If we're not using the LLVM assembler, this function
                 // could be invoked specially with output_type_assembly, so
                 // in this case we still want the metadata object file.
-                if !sess.opts.output_types.contains(&config::OutputTypeAssembly) {
+                if !sess.opts.output_types.contains_key(&OutputType::Assembly) {
                     metadata_config.emit_obj = true;
                 }
             },
-            config::OutputTypeObject => { modules_config.emit_obj = true; },
-            config::OutputTypeExe => {
+            OutputType::Object => { modules_config.emit_obj = true; },
+            OutputType::Exe => {
                 modules_config.emit_obj = true;
                 metadata_config.emit_obj = true;
             },
-            config::OutputTypeDepInfo => {}
+            OutputType::DepInfo => {}
         }
     }
 
@@ -686,8 +678,9 @@ pub fn run_passes(sess: &Session,
         }
     };
 
-    let copy_if_one_unit = |ext: &str, output_type: config::OutputType, keep_numbered: bool| {
-        // Three cases:
+    let copy_if_one_unit = |ext: &str,
+                            output_type: OutputType,
+                            keep_numbered: bool| {
         if sess.opts.cg.codegen_units == 1 {
             // 1) Only one codegen unit.  In this case it's no difficulty
             //    to copy `foo.0.x` to `foo.x`.
@@ -697,17 +690,20 @@ pub fn run_passes(sess: &Session,
                 // The user just wants `foo.x`, not `foo.0.x`.
                 remove(sess, &crate_output.with_extension(ext));
             }
+        } else if crate_output.outputs.contains_key(&output_type) {
+            // 2) Multiple codegen units, with `--emit foo=some_name`.  We have
+            //    no good solution for this case, so warn the user.
+            sess.warn(&format!("ignoring emit path because multiple .{} files \
+                                were produced", ext));
+        } else if crate_output.single_output_file.is_some() {
+            // 3) Multiple codegen units, with `-o some_name`.  We have
+            //    no good solution for this case, so warn the user.
+            sess.warn(&format!("ignoring -o because multiple .{} files \
+                                were produced", ext));
         } else {
-            if crate_output.single_output_file.is_some() {
-                // 2) Multiple codegen units, with `-o some_name`.  We have
-                //    no good solution for this case, so warn the user.
-                sess.warn(&format!("ignoring -o because multiple .{} files were produced",
-                                  ext));
-            } else {
-                // 3) Multiple codegen units, but no `-o some_name`.  We
-                //    just leave the `foo.0.x` files in place.
-                // (We don't have to do any work in this case.)
-            }
+            // 4) Multiple codegen units, but no explicit name.  We
+            //    just leave the `foo.0.x` files in place.
+            // (We don't have to do any work in this case.)
         }
     };
 
@@ -716,27 +712,27 @@ pub fn run_passes(sess: &Session,
     // to get rid of it.
     let mut user_wants_bitcode = false;
     let mut user_wants_objects = false;
-    for output_type in output_types {
+    for output_type in output_types.keys() {
         match *output_type {
-            config::OutputTypeBitcode => {
+            OutputType::Bitcode => {
                 user_wants_bitcode = true;
                 // Copy to .bc, but always keep the .0.bc.  There is a later
                 // check to figure out if we should delete .0.bc files, or keep
                 // them for making an rlib.
-                copy_if_one_unit("0.bc", config::OutputTypeBitcode, true);
+                copy_if_one_unit("0.bc", OutputType::Bitcode, true);
             }
-            config::OutputTypeLlvmAssembly => {
-                copy_if_one_unit("0.ll", config::OutputTypeLlvmAssembly, false);
+            OutputType::LlvmAssembly => {
+                copy_if_one_unit("0.ll", OutputType::LlvmAssembly, false);
             }
-            config::OutputTypeAssembly => {
-                copy_if_one_unit("0.s", config::OutputTypeAssembly, false);
+            OutputType::Assembly => {
+                copy_if_one_unit("0.s", OutputType::Assembly, false);
             }
-            config::OutputTypeObject => {
+            OutputType::Object => {
                 user_wants_objects = true;
-                copy_if_one_unit("0.o", config::OutputTypeObject, true);
+                copy_if_one_unit("0.o", OutputType::Object, true);
             }
-            config::OutputTypeExe |
-            config::OutputTypeDepInfo => {}
+            OutputType::Exe |
+            OutputType::DepInfo => {}
         }
     }
     let user_wants_bitcode = user_wants_bitcode;
@@ -913,8 +909,8 @@ fn run_work_multithreaded(sess: &Session,
 pub fn run_assembler(sess: &Session, outputs: &OutputFilenames) {
     let (pname, mut cmd) = get_linker(sess);
 
-    cmd.arg("-c").arg("-o").arg(&outputs.path(config::OutputTypeObject))
-                           .arg(&outputs.temp_path(config::OutputTypeAssembly));
+    cmd.arg("-c").arg("-o").arg(&outputs.path(OutputType::Object))
+                           .arg(&outputs.temp_path(OutputType::Assembly));
     debug!("{:?}", cmd);
 
     match cmd.output() {

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -23,7 +23,7 @@ use std::sync::{Arc, Mutex};
 use testing;
 use rustc_lint;
 use rustc::session::{self, config};
-use rustc::session::config::get_unstable_features_setting;
+use rustc::session::config::{get_unstable_features_setting, OutputType};
 use rustc::session::search_paths::{SearchPaths, PathKind};
 use rustc_front::lowering::lower_crate;
 use rustc_back::tempdir::TempDir;
@@ -163,13 +163,15 @@ fn runtest(test: &str, cratename: &str, libs: SearchPaths,
     // never wrap the test in `fn main() { ... }`
     let test = maketest(test, Some(cratename), as_test_harness, opts);
     let input = config::Input::Str(test.to_string());
+    let mut outputs = HashMap::new();
+    outputs.insert(OutputType::Exe, None);
 
     let sessopts = config::Options {
         maybe_sysroot: Some(env::current_exe().unwrap().parent().unwrap()
                                               .parent().unwrap().to_path_buf()),
         search_paths: libs,
         crate_types: vec!(config::CrateTypeExecutable),
-        output_types: vec!(config::OutputTypeExe),
+        output_types: outputs,
         externs: externs,
         cg: config::CodegenOptions {
             prefer_dynamic: true,

--- a/src/test/run-make/dep-info/Makefile
+++ b/src/test/run-make/dep-info/Makefile
@@ -7,9 +7,10 @@
 ifneq ($(shell uname),FreeBSD)
 ifndef IS_WINDOWS
 all:
-	$(RUSTC) --emit dep-info,link --crate-type=lib lib.rs
+	cp *.rs $(TMPDIR)
+	$(RUSTC) --emit dep-info,link --crate-type=lib $(TMPDIR)/lib.rs
 	sleep 2
-	touch foo.rs
+	touch $(TMPDIR)/foo.rs
 	-rm -f $(TMPDIR)/done
 	$(MAKE) -drf Makefile.foo
 	sleep 2
@@ -17,6 +18,11 @@ all:
 	pwd
 	$(MAKE) -drf Makefile.foo
 	rm $(TMPDIR)/done && exit 1 || exit 0
+
+	# When a source file is deleted `make` should still work
+	rm $(TMPDIR)/bar.rs
+	cp $(TMPDIR)/lib2.rs $(TMPDIR)/lib.rs
+	$(MAKE) -drf Makefile.foo
 else
 all:
 

--- a/src/test/run-make/dep-info/lib2.rs
+++ b/src/test/run-make/dep-info/lib2.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "foo"]
+
+pub mod foo;

--- a/src/test/run-make/issue-19371/foo.rs
+++ b/src/test/run-make/issue-19371/foo.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(rustc_private, path, convert)]
+#![feature(rustc_private)]
 
 extern crate rustc;
 extern crate rustc_driver;
@@ -16,7 +16,7 @@ extern crate rustc_lint;
 extern crate syntax;
 
 use rustc::session::{build_session, Session};
-use rustc::session::config::{basic_options, build_configuration, Input, OutputTypeExe};
+use rustc::session::config::{basic_options, build_configuration, Input, OutputType};
 use rustc_driver::driver::{compile_input, CompileController};
 use syntax::diagnostics::registry::Registry;
 
@@ -46,7 +46,7 @@ fn main() {
 
 fn basic_sess(sysroot: PathBuf) -> Session {
     let mut opts = basic_options();
-    opts.output_types = vec![OutputTypeExe];
+    opts.output_types.insert(OutputType::Exe, None);
     opts.maybe_sysroot = Some(sysroot);
 
     let descriptions = Registry::new(&rustc::DIAGNOSTICS);

--- a/src/test/run-make/output-type-permutations/Makefile
+++ b/src/test/run-make/output-type-permutations/Makefile
@@ -23,43 +23,81 @@ all:
 	rm -f $(TMPDIR)/bar.pdb
 	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
 
-	$(RUSTC) foo.rs --emit=asm -o $(TMPDIR)/foo
+	$(RUSTC) foo.rs --emit asm -o $(TMPDIR)/foo
+	rm $(TMPDIR)/foo
+	$(RUSTC) foo.rs --emit asm=$(TMPDIR)/foo
 	rm $(TMPDIR)/foo
 	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
 
-	$(RUSTC) foo.rs --emit=llvm-bc -o $(TMPDIR)/foo
+	$(RUSTC) foo.rs --emit llvm-bc -o $(TMPDIR)/foo
+	rm $(TMPDIR)/foo
+	$(RUSTC) foo.rs --emit llvm-bc=$(TMPDIR)/foo
 	rm $(TMPDIR)/foo
 	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
 
-	$(RUSTC) foo.rs --emit=llvm-ir -o $(TMPDIR)/foo
+	$(RUSTC) foo.rs --emit llvm-ir -o $(TMPDIR)/foo
+	rm $(TMPDIR)/foo
+	$(RUSTC) foo.rs --emit llvm-ir=$(TMPDIR)/foo
 	rm $(TMPDIR)/foo
 	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
 
-	$(RUSTC) foo.rs --emit=obj -o $(TMPDIR)/foo
+	$(RUSTC) foo.rs --emit obj -o $(TMPDIR)/foo
+	rm $(TMPDIR)/foo
+	$(RUSTC) foo.rs --emit obj=$(TMPDIR)/foo
 	rm $(TMPDIR)/foo
 	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
 
-	$(RUSTC) foo.rs --emit=link -o $(TMPDIR)/$(call BIN,foo)
+	$(RUSTC) foo.rs --emit link -o $(TMPDIR)/$(call BIN,foo)
+	rm $(TMPDIR)/$(call BIN,foo)
+	$(RUSTC) foo.rs --emit link=$(TMPDIR)/$(call BIN,foo)
 	rm $(TMPDIR)/$(call BIN,foo)
 	rm -f $(TMPDIR)/foo.pdb
 	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
 
 	$(RUSTC) foo.rs --crate-type=rlib -o $(TMPDIR)/foo
 	rm $(TMPDIR)/foo
+	$(RUSTC) foo.rs --crate-type=rlib --emit link=$(TMPDIR)/foo
+	rm $(TMPDIR)/foo
 	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
 
 	$(RUSTC) foo.rs --crate-type=dylib -o $(TMPDIR)/$(call BIN,foo)
+	rm $(TMPDIR)/$(call BIN,foo)
+	$(RUSTC) foo.rs --crate-type=dylib --emit link=$(TMPDIR)/$(call BIN,foo)
 	rm $(TMPDIR)/$(call BIN,foo)
 	rm -f $(TMPDIR)/foo.{exp,lib,pdb}
 	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
 
 	$(RUSTC) foo.rs --crate-type=staticlib -o $(TMPDIR)/foo
 	rm $(TMPDIR)/foo
+	$(RUSTC) foo.rs --crate-type=staticlib --emit link=$(TMPDIR)/foo
+	rm $(TMPDIR)/foo
 	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
 
 	$(RUSTC) foo.rs --crate-type=bin -o $(TMPDIR)/$(call BIN,foo)
 	rm $(TMPDIR)/$(call BIN,foo)
+	$(RUSTC) foo.rs --crate-type=bin --emit link=$(TMPDIR)/$(call BIN,foo)
+	rm $(TMPDIR)/$(call BIN,foo)
 	rm -f $(TMPDIR)/foo.pdb
+	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
+
+	$(RUSTC) foo.rs --emit llvm-ir=$(TMPDIR)/ir \
+			--emit link \
+			--crate-type=rlib
+	rm $(TMPDIR)/ir
+	rm $(TMPDIR)/libbar.rlib
+	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
+
+	$(RUSTC) foo.rs --emit asm=$(TMPDIR)/asm \
+			--emit llvm-ir=$(TMPDIR)/ir \
+			--emit llvm-bc=$(TMPDIR)/bc \
+		        --emit obj=$(TMPDIR)/obj \
+			--emit link=$(TMPDIR)/link \
+			--crate-type=staticlib
+	rm $(TMPDIR)/asm
+	rm $(TMPDIR)/ir
+	rm $(TMPDIR)/bc
+	rm $(TMPDIR)/obj
+	rm $(TMPDIR)/link
 	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
 
 	$(RUSTC) foo.rs --emit=asm,llvm-ir,llvm-bc,obj,link --crate-type=staticlib


### PR DESCRIPTION
This PR closes out #28716 and #28735 by making two changes to the compiler:
1. The `--emit` flag to the compiler now supports the ability to specify the output file name of a partuclar emit type. For example `--emit dep-info=bar.d,asm=foo.s,link` is now accepted.
2. The dep-info emission now emits a dummy target for all input file names to protect against deleted files.
