### PR TITLE
kill the fake provided method stubs

### DIFF
--- a/src/librustc/metadata/common.rs
+++ b/src/librustc/metadata/common.rs
@@ -180,7 +180,7 @@ pub const tag_mod_child: usize = 0x7b;
 pub const tag_misc_info: usize = 0x108; // top-level only
 pub const tag_misc_info_crate_items: usize = 0x7c;
 
-pub const tag_item_method_provided_source: usize = 0x7d;
+// GAP 0x7d
 pub const tag_item_impl_vtables: usize = 0x7e;
 
 pub const tag_impls: usize = 0x109; // top-level only

--- a/src/librustc/middle/ty/context.rs
+++ b/src/librustc/middle/ty/context.rs
@@ -235,8 +235,6 @@ pub struct ctxt<'tcx> {
     pub ty_param_defs: RefCell<NodeMap<ty::TypeParameterDef<'tcx>>>,
     pub normalized_cache: RefCell<FnvHashMap<Ty<'tcx>, Ty<'tcx>>>,
     pub lang_items: middle::lang_items::LanguageItems,
-    /// A mapping of fake provided method def_ids to the default implementation
-    pub provided_method_sources: RefCell<DefIdMap<DefId>>,
 
     /// Maps from def-id of a type or region parameter to its
     /// (inferred) variance.
@@ -471,7 +469,6 @@ impl<'tcx> ctxt<'tcx> {
             ty_param_defs: RefCell::new(NodeMap()),
             normalized_cache: RefCell::new(FnvHashMap()),
             lang_items: lang_items,
-            provided_method_sources: RefCell::new(DefIdMap()),
             inherent_impls: RefCell::new(DefIdMap()),
             impl_items: RefCell::new(DefIdMap()),
             used_unsafe: RefCell::new(NodeSet()),

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -725,19 +725,6 @@ impl<'a, 'tcx> PrivacyVisitor<'a, 'tcx> {
                            span: Span,
                            method_id: DefId,
                            name: ast::Name) {
-        // If the method is a default method, we need to use the def_id of
-        // the default implementation.
-        let method_id = match self.tcx.impl_or_trait_item(method_id) {
-            ty::MethodTraitItem(method_type) => {
-                method_type.provided_source.unwrap_or(method_id)
-            }
-            _ => {
-                self.tcx.sess
-                    .span_bug(span,
-                              "got non-method item in check_static_method")
-            }
-        };
-
         self.report_error(self.ensure_public(span,
                                              method_id,
                                              None,

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -250,10 +250,10 @@ pub fn trans_static_method_callee<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
                                                      impl_self,
                                                      rcvr_method));
 
-            let mth_id = method_with_name(ccx, impl_did, mname);
-            trans_fn_ref_with_substs(ccx, mth_id, ExprId(expr_id),
+            let mth = tcx.get_impl_method(impl_did, callee_substs, mname);
+            trans_fn_ref_with_substs(ccx, mth.method.def_id, ExprId(expr_id),
                                      param_substs,
-                                     callee_substs)
+                                     mth.substs)
         }
         traits::VtableObject(ref data) => {
             let idx = traits::get_vtable_index_of_object_method(tcx, data, method_id);
@@ -267,28 +267,6 @@ pub fn trans_static_method_callee<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
                                  vtbl));
         }
     }
-}
-
-fn method_with_name(ccx: &CrateContext, impl_id: DefId, name: ast::Name)
-                    -> DefId {
-    match ccx.impl_method_cache().borrow().get(&(impl_id, name)).cloned() {
-        Some(m) => return m,
-        None => {}
-    }
-
-    let impl_items = ccx.tcx().impl_items.borrow();
-    let impl_items =
-        impl_items.get(&impl_id)
-                  .expect("could not find impl while translating");
-    let meth_did = impl_items.iter()
-                             .find(|&did| {
-                                ccx.tcx().impl_or_trait_item(did.def_id()).name() == name
-                             }).expect("could not find method while \
-                                        translating");
-
-    ccx.impl_method_cache().borrow_mut().insert((impl_id, name),
-                                              meth_did.def_id());
-    meth_did.def_id()
 }
 
 fn trans_monomorphized_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
@@ -312,20 +290,19 @@ fn trans_monomorphized_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                         item")
                 }
             };
-            let mth_id = method_with_name(bcx.ccx(), impl_did, mname);
-
             // create a concatenated set of substitutions which includes
             // those from the impl and those from the method:
             let callee_substs =
                 combine_impl_and_methods_tps(
                     bcx, MethodCallKey(method_call), vtable_impl.substs);
 
+            let mth = bcx.tcx().get_impl_method(impl_did, callee_substs, mname);
             // translate the function
             let datum = trans_fn_ref_with_substs(bcx.ccx(),
-                                                 mth_id,
+                                                 mth.method.def_id,
                                                  MethodCallKey(method_call),
                                                  bcx.fcx.param_substs,
-                                                 callee_substs);
+                                                 mth.substs);
 
             Callee { bcx: bcx, data: Fn(datum.val), ty: datum.ty }
         }
@@ -738,22 +715,17 @@ fn emit_vtable_methods<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
 
             // The substitutions we have are on the impl, so we grab
             // the method type from the impl to substitute into.
-            let impl_method_def_id = method_with_name(ccx, impl_id, name);
-            let impl_method_type = match tcx.impl_or_trait_item(impl_method_def_id) {
-                ty::MethodTraitItem(m) => m,
-                _ => ccx.sess().bug("should be a method, not other assoc item"),
-            };
+            let mth = tcx.get_impl_method(impl_id, substs.clone(), name);
 
-            debug!("emit_vtable_methods: impl_method_type={:?}",
-                   impl_method_type);
+            debug!("emit_vtable_methods: mth={:?}", mth);
 
             // If this is a default method, it's possible that it
             // relies on where clauses that do not hold for this
             // particular set of type parameters. Note that this
             // method could then never be called, so we do not want to
             // try and trans it, in that case. Issue #23435.
-            if tcx.provided_source(impl_method_def_id).is_some() {
-                let predicates = impl_method_type.predicates.predicates.subst(tcx, &substs);
+            if mth.is_provided {
+                let predicates = mth.method.predicates.predicates.subst(tcx, &mth.substs);
                 if !normalize_and_test_predicates(ccx, predicates.into_vec()) {
                     debug!("emit_vtable_methods: predicates do not hold");
                     return nullptr;
@@ -761,10 +733,10 @@ fn emit_vtable_methods<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
             }
 
             trans_fn_ref_with_substs(ccx,
-                                     impl_method_def_id,
+                                     mth.method.def_id,
                                      ExprId(0),
                                      param_substs,
-                                     substs.clone()).val
+                                     mth.substs).val
         })
         .collect()
 }

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -182,7 +182,14 @@ pub fn report_error<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                 CandidateSource::ImplSource(impl_did) => {
                     // Provide the best span we can. Use the item, if local to crate, else
                     // the impl, if local to crate (item may be defaulted), else the call site.
-                    let item = impl_item(fcx.tcx(), impl_did, item_name).unwrap();
+                    let item = impl_item(fcx.tcx(), impl_did, item_name)
+                        .or_else(|| {
+                            trait_item(
+                                fcx.tcx(),
+                                fcx.tcx().impl_trait_ref(impl_did).unwrap().def_id,
+                                item_name
+                            )
+                        }).unwrap();
                     let impl_span = fcx.tcx().map.def_id_span(impl_did, span);
                     let item_span = fcx.tcx().map.def_id_span(item.def_id(), impl_span);
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -989,7 +989,6 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
 
     // Check for missing items from trait
     let provided_methods = tcx.provided_trait_methods(impl_trait_ref.def_id);
-    let associated_consts = tcx.associated_consts(impl_trait_ref.def_id);
     let mut missing_items = Vec::new();
     let mut invalidated_items = Vec::new();
     let associated_type_overridden = overridden_associated_type.is_some();
@@ -1004,9 +1003,8 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                         _ => false,
                     }
                 });
-                let is_provided =
-                    associated_consts.iter().any(|ac| ac.default.is_some() &&
-                                                 ac.name == associated_const.name);
+                let is_provided = associated_const.has_value;
+
                 if !is_implemented {
                     if !is_provided {
                         missing_items.push(associated_const.name);

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -317,10 +317,11 @@ pub fn build_impl(cx: &DocContext,
             ty::ConstTraitItem(ref assoc_const) => {
                 let did = assoc_const.def_id;
                 let type_scheme = tcx.lookup_item_type(did);
-                let default = match assoc_const.default {
-                    Some(_) => Some(const_eval::lookup_const_by_id(tcx, did, None)
-                                               .unwrap().span.to_src(cx)),
-                    None => None,
+                let default = if assoc_const.has_value {
+                    Some(const_eval::lookup_const_by_id(tcx, did, None)
+                         .unwrap().span.to_src(cx))
+                } else {
+                    None
                 };
                 Some(clean::Item {
                     name: Some(assoc_const.name.clean(cx)),
@@ -337,9 +338,6 @@ pub fn build_impl(cx: &DocContext,
             }
             ty::MethodTraitItem(method) => {
                 if method.vis != hir::Public && associated_trait.is_none() {
-                    return None
-                }
-                if method.provided_source.is_some() {
                     return None
                 }
                 let mut item = method.clean(cx);


### PR DESCRIPTION
this simplifies the code while reducing the size of libcore.rlib by
3.3 MiB (~1M of which is bloat a separate patch of mine removes
too), while reducing rustc memory usage on small crates by 18MiB.

This also simplifies the code considerably.

I have measured a small, but possibly insignificant, bootstrap performance improvement, and the memory savings grow to about 30M for larger crates (but that is still less as a percentage).

r? @eddyb 
