### PR TITLE
rustc: Don't lint about isize/usize in FFI

### DIFF
--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -497,14 +497,6 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                 FfiSafe
             }
 
-            ty::TyInt(ast::TyIs) => {
-                FfiUnsafe("found Rust type `isize` in foreign module, while \
-                          `libc::c_int` or `libc::c_long` should be used")
-            }
-            ty::TyUint(ast::TyUs) => {
-                FfiUnsafe("found Rust type `usize` in foreign module, while \
-                          `libc::c_uint` or `libc::c_ulong` should be used")
-            }
             ty::TyChar => {
                 FfiUnsafe("found Rust type `char` in foreign module, while \
                            `u32` or `libc::wchar_t` should be used")

--- a/src/test/compile-fail/issue-16250.rs
+++ b/src/test/compile-fail/issue-16250.rs
@@ -10,8 +10,10 @@
 
 #![deny(warnings)]
 
+pub struct Foo;
+
 extern {
-    pub fn foo(x: (isize)); //~ ERROR found Rust type `isize` in foreign module
+    pub fn foo(x: (Foo)); //~ ERROR found struct without
 }
 
 fn main() {

--- a/src/test/compile-fail/lint-ctypes.rs
+++ b/src/test/compile-fail/lint-ctypes.rs
@@ -27,12 +27,11 @@ pub struct ZeroSize;
 pub type RustFn = fn();
 pub type RustBadRet = extern fn() -> Box<u32>;
 pub type CVoidRet = ();
+pub struct Foo;
 
 extern {
-    pub fn bare_type1(size: isize); //~ ERROR: found Rust type
-    pub fn bare_type2(size: usize); //~ ERROR: found Rust type
-    pub fn ptr_type1(size: *const isize); //~ ERROR: found Rust type
-    pub fn ptr_type2(size: *const usize); //~ ERROR: found Rust type
+    pub fn ptr_type1(size: *const Foo); //~ ERROR: found struct without
+    pub fn ptr_type2(size: *const Foo); //~ ERROR: found struct without
     pub fn slice_type(p: &[u32]); //~ ERROR: found Rust slice type
     pub fn str_type(p: &str); //~ ERROR: found Rust type
     pub fn box_type(p: Box<u32>); //~ ERROR found Rust type
@@ -55,6 +54,8 @@ extern {
     pub fn good8(fptr: extern fn() -> !);
     pub fn good9() -> ();
     pub fn good10() -> CVoidRet;
+    pub fn good11(size: isize);
+    pub fn good12(size: usize);
 }
 
 fn main() {

--- a/src/test/run-pass/foreign-int-types.rs
+++ b/src/test/run-pass/foreign-int-types.rs
@@ -13,9 +13,8 @@
 
 mod xx {
     extern {
-        pub fn strlen(str: *const u8) -> usize; //~ ERROR found Rust type `usize`
-        pub fn foo(x: isize, y: usize); //~ ERROR found Rust type `isize`
-        //~^ ERROR found Rust type `usize`
+        pub fn strlen(str: *const u8) -> usize;
+        pub fn foo(x: isize, y: usize);
     }
 }
 


### PR DESCRIPTION
This lint warning was originally intended to help against misuse of the old Rust
`int` and `uint` types in FFI bindings where the Rust `int` was not equal to the
C `int`. This confusion no longer exists (as Rust's types are now `isize` and
`usize`), and as a result the need for this lint has become much less over time.

Additionally, starting with [the RFC for libc](https://github.com/rust-lang/rfcs/pull/1291) it's likely that `isize` and
`usize` will be quite common in FFI bindings (e.g. they're the definition of
`size_t` and `ssize_t` on many platforms).

This commit disables these lints to instead consider `isize` and `usize` valid
types to have in FFI signatures.
