### PR TITLE
fixes #28696

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -716,11 +716,13 @@
 
         function startSearch() {
 
-            if ($('.search-input').val().length === 0) {
-                window.history.pushState("", "std - Rust", "?search=");
-                $('#main.content').removeClass('hidden');
-                $('#search.content').addClass('hidden');
-            }
+            $(".search-input").on("keyup",function() {
+                if ($(this).val().length === 0) {
+                    window.history.replaceState("", "std - Rust", "?search=");
+                    $('#main.content').removeClass('hidden');
+                    $('#search.content').addClass('hidden');
+                }
+            });
 
             var keyUpTimeout;
             $('.do-search').on('click', search);
@@ -896,14 +898,6 @@
         // note that this text is also set in the HTML template in render.rs
         return "\u2212"; // "\u2212" is '−' minus sign
     }
-
-    $(".search-input").on("keyup",function() {
-        if ($(this).val().length === 0) {
-            window.history.replaceState("", "std - Rust", "?search=");
-            $('#main.content').removeClass('hidden');
-            $('#search.content').addClass('hidden');
-        }
-    });
 
     $("#toggle-all-docs").on("click", function() {
         var toggle = $("#toggle-all-docs");

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -890,6 +890,22 @@
         return "\u2212"; // "\u2212" is '−' minus sign
     }
 
+    $(".search-input").on("keyup",function() {
+        if ($(this).val().length === 0) {
+            window.history.pushState("", "std - Rust", "?search=");
+            $('#main.content').removeClass('hidden');
+            $('#search.content').addClass('hidden');
+        }
+    });
+
+    $('.search-input').on('search', function () {
+        if ($(this).val().length === 0) {
+            window.history.pushState("", "std - Rust", "?search=");
+            $('#main.content').removeClass('hidden');
+            $('#search.content').addClass('hidden');
+        }
+    });
+
     $("#toggle-all-docs").on("click", function() {
         var toggle = $("#toggle-all-docs");
         if (toggle.hasClass("will-expand")) {

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -715,6 +715,13 @@
         }
 
         function startSearch() {
+
+            if ($('.search-input').val().length === 0) {
+                window.history.pushState("", "std - Rust", "?search=");
+                $('#main.content').removeClass('hidden');
+                $('#search.content').addClass('hidden');
+            }
+
             var keyUpTimeout;
             $('.do-search').on('click', search);
             $('.search-input').on('keyup', function() {
@@ -892,15 +899,7 @@
 
     $(".search-input").on("keyup",function() {
         if ($(this).val().length === 0) {
-            window.history.pushState("", "std - Rust", "?search=");
-            $('#main.content').removeClass('hidden');
-            $('#search.content').addClass('hidden');
-        }
-    });
-
-    $('.search-input').on('search', function () {
-        if ($(this).val().length === 0) {
-            window.history.pushState("", "std - Rust", "?search=");
+            window.history.replaceState("", "std - Rust", "?search=");
             $('#main.content').removeClass('hidden');
             $('#search.content').addClass('hidden');
         }


### PR DESCRIPTION
Return to the default content when .search-input is empty
- Add a validation when input search is empty on top of "startSearch()"
