### PR TITLE
doc: fix swapped docs for intro_ptr and intro_raw of CString

### DIFF
--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -206,7 +206,7 @@ impl CString {
     /// Retakes ownership of a CString that was transferred to C.
     ///
     /// The only appropriate argument is a pointer obtained by calling
-    /// `into_ptr`. The length of the string will be recalculated
+    /// `into_raw`. The length of the string will be recalculated
     /// using the pointer.
     #[unstable(feature = "cstr_memory2", reason = "recently added",
                issue = "27769")]
@@ -230,11 +230,11 @@ impl CString {
     /// Transfers ownership of the string to a C caller.
     ///
     /// The pointer must be returned to Rust and reconstituted using
-    /// `from_ptr` to be properly deallocated. Specifically, one
+    /// `from_raw` to be properly deallocated. Specifically, one
     /// should *not* use the standard C `free` function to deallocate
     /// this string.
     ///
-    /// Failure to call `from_ptr` will lead to a memory leak.
+    /// Failure to call `from_raw` will lead to a memory leak.
     #[unstable(feature = "cstr_memory2", reason = "recently added",
                issue = "27769")]
     #[deprecated(since = "1.4.0", reason = "renamed to into_raw")]

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -230,11 +230,11 @@ impl CString {
     /// Transfers ownership of the string to a C caller.
     ///
     /// The pointer must be returned to Rust and reconstituted using
-    /// `from_raw` to be properly deallocated. Specifically, one
+    /// `from_ptr` to be properly deallocated. Specifically, one
     /// should *not* use the standard C `free` function to deallocate
     /// this string.
     ///
-    /// Failure to call `from_raw` will lead to a memory leak.
+    /// Failure to call `from_ptr` will lead to a memory leak.
     #[unstable(feature = "cstr_memory2", reason = "recently added",
                issue = "27769")]
     #[deprecated(since = "1.4.0", reason = "renamed to into_raw")]
@@ -245,11 +245,11 @@ impl CString {
     /// Transfers ownership of the string to a C caller.
     ///
     /// The pointer must be returned to Rust and reconstituted using
-    /// `from_ptr` to be properly deallocated. Specifically, one
+    /// `from_raw` to be properly deallocated. Specifically, one
     /// should *not* use the standard C `free` function to deallocate
     /// this string.
     ///
-    /// Failure to call `from_ptr` will lead to a memory leak.
+    /// Failure to call `from_raw` will lead to a memory leak.
     #[stable(feature = "cstr_memory", since = "1.4.0")]
     pub fn into_raw(self) -> *mut libc::c_char {
         Box::into_raw(self.inner) as *mut libc::c_char


### PR DESCRIPTION
Please correct me if I confused something but the documentation for `into_ptr` and `into_raw` of `CString` seem to be swapped as the docs for `into_ptr` mentions `into_raw` and vice versa.

Update: I actually meant `into_ptr` and `into_raw` NOT `from_*`
