### PR TITLE
Remove one level of indirection for slice-based PartialEq impls

### DIFF
--- a/src/libcore/cmp_macros.rs
+++ b/src/libcore/cmp_macros.rs
@@ -21,9 +21,9 @@ macro_rules! __impl_slice_eq1 {
         #[stable(feature = "rust1", since = "1.0.0")]
         impl<'a, 'b, A: $Bound, B> PartialEq<$Rhs> for $Lhs where A: PartialEq<B> {
             #[inline]
-            fn eq(&self, other: &$Rhs) -> bool { &self[..] == &other[..] }
+            fn eq(&self, other: &$Rhs) -> bool { self[..] == other[..] }
             #[inline]
-            fn ne(&self, other: &$Rhs) -> bool { &self[..] != &other[..] }
+            fn ne(&self, other: &$Rhs) -> bool { self[..] != other[..] }
         }
     }
 }
@@ -39,9 +39,9 @@ macro_rules! __impl_slice_eq2 {
         #[stable(feature = "rust1", since = "1.0.0")]
         impl<'a, 'b, A: $Bound, B> PartialEq<$Lhs> for $Rhs where B: PartialEq<A> {
             #[inline]
-            fn eq(&self, other: &$Lhs) -> bool { &self[..] == &other[..] }
+            fn eq(&self, other: &$Lhs) -> bool { self[..] == other[..] }
             #[inline]
-            fn ne(&self, other: &$Lhs) -> bool { &self[..] != &other[..] }
+            fn ne(&self, other: &$Lhs) -> bool { self[..] != other[..] }
         }
     }
 }


### PR DESCRIPTION
Using the comparison operators already refs the operands, so doing it
ourselves as well just adds an unnecessary level of indirection.
