### PR TITLE
fixes #28696 Return to the default content when .search-input is empt…

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -715,6 +715,15 @@
         }
 
         function startSearch() {
+
+            $(".search-input").on("keyup",function() {
+                if ($(this).val().length === 0) {
+                    window.history.replaceState("", "std - Rust", "?search=");
+                    $('#main.content').removeClass('hidden');
+                    $('#search.content').addClass('hidden');
+                }
+            });
+
             var keyUpTimeout;
             $('.do-search').on('click', search);
             $('.search-input').on('keyup', function() {


### PR DESCRIPTION
-Add a validation when input search is empty on top of 'startSearch()'
