### PR TITLE
Fix run-make/bare-outfile test

### DIFF
--- a/src/test/run-make/bare-outfile/Makefile
+++ b/src/test/run-make/bare-outfile/Makefile
@@ -1,4 +1,6 @@
 -include ../tools.mk
 
 all:
-	$(rustc) -o foo foo.rs
+	cp foo.rs $(TMPDIR)
+	cd $(TMPDIR) && $(RUSTC) -o foo foo.rs
+	$(call RUN,foo)


### PR DESCRIPTION
The reason this was not failing is fascinating.  The variable $(rustc)
is empty, so the make recipe was expanded as " -o foo foo.rs".  make
interpreted this as an instruction to run the command "o foo foo.rs"
and ignore any failure that occurred, because it uses a leading '-' on
a command to signal that behavior.
