### PR TITLE
Contrib doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,11 @@ To find documentation-related issues, sort by the [A-docs label][adocs].
 
 [adocs]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-docs
 
+In many cases, you don't need a full `make doc`. You can use `rustdoc` directly
+to check small fixes. For example, `rustdoc src/doc/reference.md` will render
+reference to `doc/reference.html`. The CSS might be messed up, but you can
+verify that HTML is right.
+
 ## Issue Triage
 
 Sometimes, an issue will stay open, even though the bug has been fixed. And

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,7 @@ To save @bors some work, and to get small changes through more quickly, when
 the other rollup-eligible patches too, and they'll get tested and merged at
 the same time.
 
-To find documentation-related issues, sort by the [A-docs label][adocs]. 
+To find documentation-related issues, sort by the [A-docs label][adocs].
 
 [adocs]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-docs
 
@@ -164,30 +164,30 @@ Contributors with sufficient permissions on the Rust repo can help by adding
 labels to triage issues:
 
 * Yellow, **A**-prefixed labels state which **area** of the project an issue
-  relates to. 
+  relates to.
 
-* Magenta, **B**-prefixed labels identify bugs which **belong** elsewhere. 
+* Magenta, **B**-prefixed labels identify bugs which **belong** elsewhere.
 
 * Green, **E**-prefixed labels explain the level of **experience** necessary
   to fix the issue.
 
 * Red, **I**-prefixed labels indicate the **importance** of the issue. The
   [I-nominated][inom] label indicates that an issue has been nominated for
-  prioritizing at the next triage meeting. 
+  prioritizing at the next triage meeting.
 
 * Orange, **P**-prefixed labels indicate a bug's **priority**. These labels
   are only assigned during triage meetings, and replace the [I-nominated][inom]
-  label. 
+  label.
 
 * Blue, **T**-prefixed bugs denote which **team** the issue belongs to.
 
 * Dark blue, **beta-** labels track changes which need to be backported into
-  the beta branches. 
- 
-* The purple **metabug** label marks lists of bugs collected by other
-  categories.  
+  the beta branches.
 
-If you're looking for somewhere to start, check out the [E-easy][eeasy] tag. 
+* The purple **metabug** label marks lists of bugs collected by other
+  categories.
+
+If you're looking for somewhere to start, check out the [E-easy][eeasy] tag.
 
 [inom]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AI-nominated
 [eeasy]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy


### PR DESCRIPTION
This adds a paragraph on how to generate documentation without sloooow `make doc`. I'm not a native English speaker, so there might be some language related bugs (I wish English was as hard to get wrong, as Rust)

This also includes whitespace cleanup of contributing.md in a separate commit. Whiltespace is not significant in github flavored markdown, and my Emacs just cleans ws automatically :)

r? @steveklabnik
