### PR TITLE
Update TRPL/Installing Rust to avoid concrete version numbers

### DIFF
--- a/src/doc/trpl/installing-rust.md
+++ b/src/doc/trpl/installing-rust.md
@@ -84,16 +84,11 @@ If you've got Rust installed, you can open up a shell, and type this:
 $ rustc --version
 ```
 
-You should see the version number, commit hash, and commit date. If you just
-installed version 1.2.0, you should see:
+You should see the version number, commit hash, and commit date.
 
-```bash
-rustc 1.2.0 (082e47636 2015-08-03)
-```
+If you do, Rust has been installed successfully! Congrats!
 
-If you did, Rust has been installed successfully! Congrats!
-
-If you didn't and you're on Windows, check that Rust is in your %PATH% system
+If you don't and you're on Windows, check that Rust is in your %PATH% system
 variable. If it isn't, run the installer again, select "Change" on the "Change,
 repair, or remove installation" page and ensure "Add to PATH" is installed on
 the local hard drive.


### PR DESCRIPTION
Update "Installing Rust" section @ TRPL so it references the last stable version, v1.3.0.
