### PR TITLE
Docs: Removes duplicate output from FFI example

### DIFF
--- a/src/doc/trpl/rust-inside-other-languages.md
+++ b/src/doc/trpl/rust-inside-other-languages.md
@@ -119,7 +119,6 @@ fn process() {
         println!("Thread finished with count={}",
 	    h.join().map_err(|_| "Could not join a thread!").unwrap());
     }
-    println!("done!");
 }
 ```
 


### PR DESCRIPTION
"Rust Inside Other Languages" in the Rust book includes a library example. The reference specifies printing "done!" when the code finishes running, and the language examples (Ruby, Python, JS) all do this in their code. 

However, the Rust library example code _also_ does this, so that the examples as written would output "done!" twice.

This commit removes the "done!" from the Rust example code to tidy up the output to match expectations.
