### PR TITLE
Fix LLVM assertion on out-of-bounds const slice index.

### DIFF
--- a/src/librustc_trans/trans/consts.rs
+++ b/src/librustc_trans/trans/consts.rs
@@ -630,7 +630,7 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                 // pass. Reporting here is a bit late.
                 cx.sess().span_err(e.span,
                                    "const index-expr is out of bounds");
-                C_undef(type_of::type_of(cx, bt).element_type())
+                C_undef(val_ty(arr).element_type())
             } else {
                 const_get_elt(cx, arr, &[iv as c_uint])
             }

--- a/src/test/compile-fail/const-slice-oob.rs
+++ b/src/test/compile-fail/const-slice-oob.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+const FOO: &'static[u32] = &[1, 2, 3];
+const BAR: u32 = FOO[5]; //~ ERROR const index-expr is out of bounds
+
+fn main() {
+    let _ = BAR;
+}


### PR DESCRIPTION
This turned up as part of #3170.  When constructing an `undef` value to
return in the error case, we were trying to get the element type of the
Rust-level value being indexed instead of the underlying array; when
indexing a slice, that's not an array and the LLVM assertion failure
reflects this.

The regression test is a lightly altered copy of `const-array-oob.rs`.
