### PR TITLE
implement RFC 1229

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -17,6 +17,12 @@
 use lint::{LintPass, LateLintPass, LintArray};
 
 declare_lint! {
+    pub CONST_ERR,
+    Warn,
+    "constant evaluation detected erroneous expression"
+}
+
+declare_lint! {
     pub UNUSED_IMPORTS,
     Warn,
     "imports that are never used"
@@ -134,7 +140,8 @@ impl LintPass for HardwiredLints {
             VARIANT_SIZE_DIFFERENCES,
             FAT_PTR_TRANSMUTES,
             TRIVIAL_CASTS,
-            TRIVIAL_NUMERIC_CASTS
+            TRIVIAL_NUMERIC_CASTS,
+            CONST_ERR
         )
     }
 }

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -176,8 +176,8 @@ impl<'a, 'tcx> CheckCrateVisitor<'a, 'tcx> {
         if mode == Mode::ConstFn {
             for arg in &fd.inputs {
                 match arg.pat.node {
-                    hir::PatIdent(hir::BindByValue(hir::MutImmutable), _, None) => {}
                     hir::PatWild(_) => {}
+                    hir::PatIdent(hir::BindByValue(hir::MutImmutable), _, None) => {}
                     _ => {
                         span_err!(self.tcx.sess, arg.pat.span, E0022,
                                   "arguments of constant functions can only \
@@ -476,9 +476,9 @@ impl<'a, 'tcx, 'v> Visitor<'v> for CheckCrateVisitor<'a, 'tcx> {
                                     self.tcx, ex, ExprTypeChecked) {
                                 Ok(_) => {}
                                 Err(msg) => {
-                                    span_err!(self.tcx.sess, msg.span, E0020,
-                                              "{} in a constant expression",
-                                              msg.description())
+                                    self.tcx.sess.add_lint(::lint::builtin::CONST_ERR, ex.id,
+                                                           msg.span,
+                                                           msg.description().into_owned())
                                 }
                             }
                         }

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -2125,7 +2125,10 @@ pub fn trans_item(ccx: &CrateContext, item: &hir::Item) {
           let mut v = TransItemVisitor{ ccx: ccx };
           v.visit_expr(&**expr);
 
-          let g = consts::trans_static(ccx, m, expr, item.id, &item.attrs);
+          let g = match consts::trans_static(ccx, m, expr, item.id, &item.attrs) {
+              Ok(g) => g,
+              Err(err) => ccx.tcx().sess.span_fatal(expr.span, &err.description()),
+          };
           set_global_section(ccx, g, item);
           update_linkage(ccx, g, Some(item.id), OriginalTranslation);
       },

--- a/src/test/compile-fail/const-err.rs
+++ b/src/test/compile-fail/const-err.rs
@@ -1,0 +1,36 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[allow(exceeding_bitshifts)]
+#[deny(const_err)]
+
+fn black_box<T>(_: T) {
+    unimplemented!()
+}
+
+const BLA: u8 = 200u8 + 200u8;
+//~^ ERROR attempted to add with overflow
+
+fn main() {
+    let a = -std::i8::MIN;
+    //~^ WARN attempted to negate with overflow
+    let b = 200u8 + 200u8 + 200u8;
+    //~^ WARN attempted to add with overflow
+    //~^^ WARN attempted to add with overflow
+    let c = 200u8 * 4;
+    //~^ WARN attempted to mul with overflow
+    let d = 42u8 - (42u8 + 1);
+    //~^ WARN attempted to sub with overflow
+    let _e = BLA;
+    black_box(a);
+    black_box(b);
+    black_box(c);
+    black_box(d);
+}

--- a/src/test/compile-fail/const-eval-overflow.rs
+++ b/src/test/compile-fail/const-eval-overflow.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(negate_unsigned)]
-
 #![allow(unused_imports)]
 #![feature(negate_unsigned)]
 

--- a/src/test/compile-fail/issue-8460-const.rs
+++ b/src/test/compile-fail/issue-8460-const.rs
@@ -8,48 +8,50 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![deny(const_err)]
+
 use std::{isize, i8, i16, i32, i64};
 use std::thread;
 
 fn main() {
     assert!(thread::spawn(move|| { isize::MIN / -1; }).join().is_err());
-    //~^ ERROR attempted to divide with overflow in a constant expression
+    //~^ ERROR attempted to divide with overflow
     assert!(thread::spawn(move|| { i8::MIN / -1; }).join().is_err());
-    //~^ ERROR attempted to divide with overflow in a constant expression
+    //~^ ERROR attempted to divide with overflow
     assert!(thread::spawn(move|| { i16::MIN / -1; }).join().is_err());
-    //~^ ERROR attempted to divide with overflow in a constant expression
+    //~^ ERROR attempted to divide with overflow
     assert!(thread::spawn(move|| { i32::MIN / -1; }).join().is_err());
-    //~^ ERROR attempted to divide with overflow in a constant expression
+    //~^ ERROR attempted to divide with overflow
     assert!(thread::spawn(move|| { i64::MIN / -1; }).join().is_err());
-    //~^ ERROR attempted to divide with overflow in a constant expression
+    //~^ ERROR attempted to divide with overflow
     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
-    //~^ ERROR attempted to divide by zero in a constant expression
+    //~^ ERROR attempted to divide by zero
     assert!(thread::spawn(move|| { 1i8 / 0; }).join().is_err());
-    //~^ ERROR attempted to divide by zero in a constant expression
+    //~^ ERROR attempted to divide by zero
     assert!(thread::spawn(move|| { 1i16 / 0; }).join().is_err());
-    //~^ ERROR attempted to divide by zero in a constant expression
+    //~^ ERROR attempted to divide by zero
     assert!(thread::spawn(move|| { 1i32 / 0; }).join().is_err());
-    //~^ ERROR attempted to divide by zero in a constant expression
+    //~^ ERROR attempted to divide by zero
     assert!(thread::spawn(move|| { 1i64 / 0; }).join().is_err());
-    //~^ ERROR attempted to divide by zero in a constant expression
+    //~^ ERROR attempted to divide by zero
     assert!(thread::spawn(move|| { isize::MIN % -1; }).join().is_err());
-    //~^ ERROR attempted remainder with overflow in a constant expression
+    //~^ ERROR attempted remainder with overflow
     assert!(thread::spawn(move|| { i8::MIN % -1; }).join().is_err());
-    //~^ ERROR attempted remainder with overflow in a constant expression
+    //~^ ERROR attempted remainder with overflow
     assert!(thread::spawn(move|| { i16::MIN % -1; }).join().is_err());
-    //~^ ERROR attempted remainder with overflow in a constant expression
+    //~^ ERROR attempted remainder with overflow
     assert!(thread::spawn(move|| { i32::MIN % -1; }).join().is_err());
-    //~^ ERROR attempted remainder with overflow in a constant expression
+    //~^ ERROR attempted remainder with overflow
     assert!(thread::spawn(move|| { i64::MIN % -1; }).join().is_err());
-    //~^ ERROR attempted remainder with overflow in a constant expression
+    //~^ ERROR attempted remainder with overflow
     assert!(thread::spawn(move|| { 1isize % 0; }).join().is_err());
-    //~^ ERROR attempted remainder with a divisor of zero in a constant expression
+    //~^ ERROR attempted remainder with a divisor of zero
     assert!(thread::spawn(move|| { 1i8 % 0; }).join().is_err());
-    //~^ ERROR attempted remainder with a divisor of zero in a constant expression
+    //~^ ERROR attempted remainder with a divisor of zero
     assert!(thread::spawn(move|| { 1i16 % 0; }).join().is_err());
-    //~^ ERROR attempted remainder with a divisor of zero in a constant expression
+    //~^ ERROR attempted remainder with a divisor of zero
     assert!(thread::spawn(move|| { 1i32 % 0; }).join().is_err());
-    //~^ ERROR attempted remainder with a divisor of zero in a constant expression
+    //~^ ERROR attempted remainder with a divisor of zero
     assert!(thread::spawn(move|| { 1i64 % 0; }).join().is_err());
-    //~^ ERROR attempted remainder with a divisor of zero in a constant expression
+    //~^ ERROR attempted remainder with a divisor of zero
 }

--- a/src/test/run-fail/overflowing-add.rs
+++ b/src/test/run-fail/overflowing-add.rs
@@ -11,9 +11,7 @@
 // error-pattern:thread '<main>' panicked at 'arithmetic operation overflowed'
 // compile-flags: -C debug-assertions
 
-// (Work around constant-evaluation)
-fn value() -> u8 { 200 }
 
 fn main() {
-    let _x = value() + value() + value();
+    let _x = 200u8 + 200u8 + 200u8;
 }

--- a/src/test/run-fail/overflowing-lsh-1.rs
+++ b/src/test/run-fail/overflowing-lsh-1.rs
@@ -11,9 +11,8 @@
 // error-pattern:thread '<main>' panicked at 'shift operation overflowed'
 // compile-flags: -C debug-assertions
 
-// (Work around constant-evaluation)
-fn id<T>(x: T) -> T { x }
+#![warn(exceeding_bitshifts)]
 
 fn main() {
-    let _x = 1_i32 << id(32);
+    let _x = 1_i32 << 32;
 }

--- a/src/test/run-fail/overflowing-lsh-2.rs
+++ b/src/test/run-fail/overflowing-lsh-2.rs
@@ -11,9 +11,8 @@
 // error-pattern:thread '<main>' panicked at 'shift operation overflowed'
 // compile-flags: -C debug-assertions
 
-// (Work around constant-evaluation)
-fn id<T>(x: T) -> T { x }
+#![warn(exceeding_bitshifts)]
 
 fn main() {
-    let _x = 1 << id(-1);
+    let _x = 1 << -1;
 }

--- a/src/test/run-fail/overflowing-lsh-3.rs
+++ b/src/test/run-fail/overflowing-lsh-3.rs
@@ -11,9 +11,8 @@
 // error-pattern:thread '<main>' panicked at 'shift operation overflowed'
 // compile-flags: -C debug-assertions
 
-// (Work around constant-evaluation)
-fn id<T>(x: T) -> T { x }
+#![warn(exceeding_bitshifts)]
 
 fn main() {
-    let _x = 1_u64 << id(64);
+    let _x = 1_u64 << 64;
 }

--- a/src/test/run-fail/overflowing-lsh-4.rs
+++ b/src/test/run-fail/overflowing-lsh-4.rs
@@ -14,12 +14,11 @@
 // This function is checking that our automatic truncation does not
 // sidestep the overflow checking.
 
-// (Work around constant-evaluation)
-fn id<T>(x: T) -> T { x }
+#![warn(exceeding_bitshifts)]
 
 fn main() {
     // this signals overflow when checking is on
-    let x = 1_i8 << id(17);
+    let x = 1_i8 << 17;
 
     // ... but when checking is off, the fallback will truncate the
     // input to its lower three bits (= 1). Note that this is *not*

--- a/src/test/run-fail/overflowing-mul.rs
+++ b/src/test/run-fail/overflowing-mul.rs
@@ -11,9 +11,6 @@
 // error-pattern:thread '<main>' panicked at 'arithmetic operation overflowed'
 // compile-flags: -C debug-assertions
 
-// (Work around constant-evaluation)
-fn value() -> u8 { 200 }
-
 fn main() {
-    let x = value() * 4;
+    let x = 200u8 * 4;
 }

--- a/src/test/run-fail/overflowing-neg.rs
+++ b/src/test/run-fail/overflowing-neg.rs
@@ -11,9 +11,6 @@
 // error-pattern:thread '<main>' panicked at 'attempted to negate with overflow'
 // compile-flags: -C debug-assertions
 
-// (Work around constant-evaluation)
-fn value() -> i8 { std::i8::MIN }
-
 fn main() {
-    let _x = -value();
+    let _x = -std::i8::MIN;
 }

--- a/src/test/run-fail/overflowing-rsh-1.rs
+++ b/src/test/run-fail/overflowing-rsh-1.rs
@@ -11,9 +11,8 @@
 // error-pattern:thread '<main>' panicked at 'shift operation overflowed'
 // compile-flags: -C debug-assertions
 
-// (Work around constant-evaluation)
-fn id<T>(x: T) -> T { x }
+#![warn(exceeding_bitshifts)]
 
 fn main() {
-    let _x = -1_i32 >> id(32);
+    let _x = -1_i32 >> 32;
 }

--- a/src/test/run-fail/overflowing-rsh-2.rs
+++ b/src/test/run-fail/overflowing-rsh-2.rs
@@ -11,9 +11,8 @@
 // error-pattern:thread '<main>' panicked at 'shift operation overflowed'
 // compile-flags: -C debug-assertions
 
-// (Work around constant-evaluation)
-fn id<T>(x: T) -> T { x }
+#![warn(exceeding_bitshifts)]
 
 fn main() {
-    let _x = -1_i32 >> id(-1);
+    let _x = -1_i32 >> -1;
 }

--- a/src/test/run-fail/overflowing-rsh-3.rs
+++ b/src/test/run-fail/overflowing-rsh-3.rs
@@ -11,9 +11,8 @@
 // error-pattern:thread '<main>' panicked at 'shift operation overflowed'
 // compile-flags: -C debug-assertions
 
-// (Work around constant-evaluation)
-fn id<T>(x: T) -> T { x }
+#![warn(exceeding_bitshifts)]
 
 fn main() {
-    let _x = -1_i64 >> id(64);
+    let _x = -1_i64 >> 64;
 }

--- a/src/test/run-fail/overflowing-rsh-4.rs
+++ b/src/test/run-fail/overflowing-rsh-4.rs
@@ -14,12 +14,11 @@
 // This function is checking that our (type-based) automatic
 // truncation does not sidestep the overflow checking.
 
-// (Work around constant-evaluation)
-fn id<T>(x: T) -> T { x }
+#![warn(exceeding_bitshifts)]
 
 fn main() {
     // this signals overflow when checking is on
-    let x = 2_i8 >> id(17);
+    let x = 2_i8 >> 17;
 
     // ... but when checking is off, the fallback will truncate the
     // input to its lower three bits (= 1). Note that this is *not*

--- a/src/test/run-fail/overflowing-sub.rs
+++ b/src/test/run-fail/overflowing-sub.rs
@@ -11,9 +11,6 @@
 // error-pattern:thread '<main>' panicked at 'arithmetic operation overflowed'
 // compile-flags: -C debug-assertions
 
-// (Work around constant-evaluation)
-fn value() -> u8 { 42 }
-
 fn main() {
-    let _x = value() - (value() + 1);
+    let _x = 42u8 - (42u8 + 1);
 }

--- a/src/test/run-pass/wrapping-int-api.rs
+++ b/src/test/run-pass/wrapping-int-api.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(num_wrapping)]
-
 // Test inherent wrapping_* methods for {i,u}{size,8,16,32,64}.
 
 use std::{i8, i16, i32, i64, isize};


### PR DESCRIPTION
This PR turns statically known erroneous code (e.g. numeric overflow) into a warning and continues normal code-generation to emit the same code that would have been generated without `check_const` detecting that the result can be computed at compile-time.

<del>It's not done yet, as I don't know how to properly emit a lint from trans. I can't seem to extract the real lint level of the item the erroneous expression is in.</del> It's an unconditional warning now.

r? @pnkfelix 

cc @nikomatsakis 
- [RFC 1229 text](https://github.com/rust-lang/rfcs/blob/master/text/1229-compile-time-asserts.md)
- RFC PR: rust-lang/rfcs#1229
- tracking issue: https://github.com/rust-lang/rust/issues/28238
