### PR TITLE
Make `--explain` Handle Partial Error Codes

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -285,7 +285,12 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
                       -> Compilation {
         match matches.opt_str("explain") {
             Some(ref code) => {
-                match descriptions.find_description(&code[..]) {
+                let normalised = if !code.starts_with("E") {
+                    format!("E{0:0>4}", code)
+                } else {
+                    code.to_string()
+                };
+                match descriptions.find_description(&normalised) {
                     Some(ref description) => {
                         // Slice off the leading newline and print.
                         print!("{}", &description[1..]);


### PR DESCRIPTION
Currently the explain command line flag requires full error codes, complete with
the leading zeros and the E at the beginning. This commit changes that,
if you don't supply a full error code then the error number is padded
out to the required size and the E is added to the beginning.

This means that where previously you would need to write E0001, you can
now write 0001, 001, 01 or just 1 to refer to the same error.
