### PR TITLE
Fix "the the" typo + split a run-on sentence in rust book section 5.14

### DIFF
--- a/src/doc/trpl/patterns.md
+++ b/src/doc/trpl/patterns.md
@@ -299,7 +299,7 @@ match x {
 ```
 
 This prints `no`, because the `if` applies to the whole of `4 | 5`, and not to
-just the `5`, In other words, the the precedence of `if` behaves like this:
+just the `5`. In other words, the precedence of `if` behaves like this:
 
 ```text
 (4 | 5) if y => ...


### PR DESCRIPTION
The diff can hopefully speak for itself. Regardless: this chapter of the book contained a sentence where "the" was mistakenly repeated twice. In this same section, there was a comma separating two sentences where a period should have been. This PR fixes both issues.
