### PR TITLE
Improve error message for char literals

### DIFF
--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1081,11 +1081,12 @@ impl<'a> StringReader<'a> {
             if !self.curr_is('\'') {
                 let last_bpos = self.last_pos;
                 panic!(self.fatal_span_verbose(
-                                   // Byte offsetting here is okay because the
-                                   // character before position `start` is an
-                                   // ascii single quote.
-                                   start - BytePos(1), last_bpos,
-                                   "unterminated character constant".to_string()));
+                        // Byte offsetting here is okay because the
+                        // character before position `start` is an
+                        // ascii single quote.
+                        start - BytePos(1), last_bpos,
+
+                        String::from("character literal may only contain one codepoint")));
             }
             let id = if valid { self.name_from(start) } else { token::intern("0") };
             self.bump(); // advance curr past token

--- a/src/test/parse-fail/lex-bad-char-literals.rs
+++ b/src/test/parse-fail/lex-bad-char-literals.rs
@@ -25,8 +25,8 @@ static s: &'static str =
     "\●" //~ ERROR: unknown character escape
 ;
 
-// THIS MUST BE LAST, since unterminated character constants kill the lexer
+// THIS MUST BE LAST, since it kills the lexer
 
 static c: char =
-    '●  //~ ERROR: unterminated character constant
+    '●  //~ ERROR: character literal may only contain one codepoint
 ;


### PR DESCRIPTION
If you try to put something that's bigger than a char into a char
literal, you get an error:

```
fn main() {
    let c = 'ஶ்ரீ';
}

error: unterminated character constant:
```

This is a very compiler-centric message. Yes, it's technically
'unterminated', but that's not what you, the user did wrong.

Instead, this commit changes it to

```
error: character literal that's larger than a char:
```

As this actually tells you what went wrong.

Fixes #28851
