### PR TITLE
use the struct's ctor-id as its variant def-id

### DIFF
--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -388,7 +388,6 @@ pub fn get_adt_def<'tcx>(intr: &IdentInterner,
                 did: did,
                 name: item_name(intr, item),
                 fields: get_variant_fields(intr, cdata, item, tcx),
-                ctor_id: did,
                 disr_val: disr
             }
         }).collect()
@@ -417,13 +416,11 @@ pub fn get_adt_def<'tcx>(intr: &IdentInterner,
                                 cdata: Cmd,
                                 doc: rbml::Doc,
                                 did: DefId,
-                                ctor_id: DefId,
                                 tcx: &ty::ctxt<'tcx>) -> ty::VariantDefData<'tcx, 'tcx> {
         ty::VariantDefData {
             did: did,
             name: item_name(intr, doc),
             fields: get_variant_fields(intr, cdata, doc, tcx),
-            ctor_id: ctor_id,
             disr_val: 0
         }
     }
@@ -440,7 +437,7 @@ pub fn get_adt_def<'tcx>(intr: &IdentInterner,
                 reader::maybe_get_doc(doc, tag_items_data_item_struct_ctor).
                 map_or(did, |ctor_doc| translated_def_id(cdata, ctor_doc));
             (ty::AdtKind::Struct,
-             vec![get_struct_variant(intr, cdata, doc, did, ctor_did, tcx)])
+             vec![get_struct_variant(intr, cdata, doc, ctor_did, tcx)])
         }
         _ => tcx.sess.bug(
             &format!("get_adt_def called on a non-ADT {:?} - {:?}",

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -1312,14 +1312,17 @@ fn copy_item_types(dcx: &DecodeContext, ii: &InlinedItem, orig_did: DefId) {
                 for (i_variant, orig_variant) in
                     def.variants.iter().zip(orig_def.variants.iter())
                 {
+                    debug!("astencode: copying variant {:?} => {:?}",
+                           orig_variant.did, i_variant.node.id);
                     copy_item_type(dcx, i_variant.node.id, orig_variant.did);
                 }
             }
             hir::ItemStruct(ref def, _) => {
                 if let Some(ctor_id) = def.ctor_id {
                     let ctor_did = dcx.tcx.lookup_adt_def(orig_did)
-                        .struct_variant().ctor_id;
-                    debug!("copying ctor {:?}", ctor_did);
+                        .struct_variant().did;
+                    debug!("astencode: copying ctor {:?} => {:?}", ctor_did,
+                           ctor_id);
                     copy_item_type(dcx, ctor_id, ctor_did);
                 }
             }

--- a/src/librustc/middle/ty/mod.rs
+++ b/src/librustc/middle/ty/mod.rs
@@ -1470,13 +1470,12 @@ pub type VariantDefMaster<'tcx> = &'tcx VariantDefData<'tcx, 'tcx>;
 pub type FieldDefMaster<'tcx> = &'tcx FieldDefData<'tcx, 'tcx>;
 
 pub struct VariantDefData<'tcx, 'container: 'tcx> {
+    /// The variant's DefId. If this is a tuple-like struct,
+    /// this is the DefId of the struct's ctor.
     pub did: DefId,
     pub name: Name, // struct's name if this is a struct
     pub disr_val: Disr,
     pub fields: Vec<FieldDefData<'tcx, 'container>>,
-    /// The DefId of the variant's ctor (unless the variant is a
-    /// tuple-like struct variant, this is just the variant's def-id).
-    pub ctor_id: DefId
 }
 
 pub struct FieldDefData<'tcx, 'container: 'tcx> {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1102,8 +1102,7 @@ fn convert_struct_variant<'tcx>(tcx: &ty::ctxt<'tcx>,
                                 did: DefId,
                                 name: ast::Name,
                                 disr_val: ty::Disr,
-                                def: &hir::StructDef,
-                                ctor_id: DefId) -> ty::VariantDefData<'tcx, 'tcx> {
+                                def: &hir::StructDef) -> ty::VariantDefData<'tcx, 'tcx> {
     let mut seen_fields: FnvHashMap<ast::Name, Span> = FnvHashMap();
     let fields = def.fields.iter().map(|f| {
         let fid = tcx.map.local_def_id(f.node.id);
@@ -1130,8 +1129,7 @@ fn convert_struct_variant<'tcx>(tcx: &ty::ctxt<'tcx>,
         did: did,
         name: name,
         disr_val: disr_val,
-        fields: fields,
-        ctor_id: ctor_id
+        fields: fields
     }
 }
 
@@ -1147,7 +1145,7 @@ fn convert_struct_def<'tcx>(tcx: &ty::ctxt<'tcx>,
     tcx.intern_adt_def(
         did,
         ty::AdtKind::Struct,
-        vec![convert_struct_variant(tcx, did, it.name, 0, def, ctor_id)]
+        vec![convert_struct_variant(tcx, ctor_id, it.name, 0, def)]
     )
 }
 
@@ -1237,12 +1235,11 @@ fn convert_enum_def<'tcx>(tcx: &ty::ctxt<'tcx>,
                             special_idents::unnamed_field.name,
                             hir::Visibility::Public
                         )
-                    }).collect(),
-                    ctor_id: did
+                    }).collect()
                 }
             }
             hir::StructVariantKind(ref def) => {
-                convert_struct_variant(tcx, did, name, disr, &def, did)
+                convert_struct_variant(tcx, did, name, disr, &def)
             }
         }
     }


### PR DESCRIPTION
this makes the code cleaner, and is a complement to the cleanup on the
HIR side.

r? @eddyb 
