### PR TITLE
core: Derive Default for Wrapping<T>

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -39,7 +39,7 @@ use slice::SliceExt;
 /// all standard arithmetic operations on the underlying value are
 /// intended to have wrapping semantics.
 #[stable(feature = "rust1", since = "1.0.0")]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug, Default)]
 pub struct Wrapping<T>(#[stable(feature = "rust1", since = "1.0.0")] pub T);
 
 pub mod wrapping;


### PR DESCRIPTION
It's not very common to store `Wrapping` values, but I kept wrapping and unwrapping a hash value when I taking it out of a struct to do operations on it. I couldn't store the hash as `Wrapping<u64>` because I wanted to be able to `#[derive(Default)]` for the struct.

At any rate, it feels to me that `Wrapping<T>` should implement pretty much everything `T` does. I left out `#[derive(Hash)]` since I'd be hard pressed to find a use case and wanted to avoid the extra generated code, but maybe I should add that too?
