### PR TITLE
Use Unicode line drawing characters for spans

### DIFF
--- a/man/rustc.1
+++ b/man/rustc.1
@@ -139,6 +139,9 @@ always colorize output;
 .B never
 never colorize output.
 .RE
+.TP
+\fB\-\-drawing\fR
+Use drawing characters in diagnostic output
 
 .SH CODEGEN OPTIONS
 

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -36,6 +36,7 @@ use util::nodemap::FnvHashMap;
 
 use std::cell::RefCell;
 use std::cmp;
+use std::default;
 use std::mem;
 use syntax::ast_util::{self, IdVisitingOperation};
 use syntax::attr::{self, AttrMetaMethods};
@@ -46,7 +47,6 @@ use rustc_front::hir;
 use rustc_front::util;
 use rustc_front::visit as hir_visit;
 use syntax::visit as ast_visit;
-use syntax::diagnostic;
 
 /// Information about the registered lints.
 ///
@@ -166,7 +166,7 @@ impl LintStore {
                 match (sess, from_plugin) {
                     // We load builtin lints first, so a duplicate is a compiler bug.
                     // Use early_error when handling -W help with no crate.
-                    (None, _) => early_error(diagnostic::ColorConfig::Auto, &msg[..]),
+                    (None, _) => early_error(default::Default::default(), &msg[..]),
                     (Some(sess), false) => sess.bug(&msg[..]),
 
                     // A duplicate name from a plugin is a user error.
@@ -190,7 +190,7 @@ impl LintStore {
             match (sess, from_plugin) {
                 // We load builtin lints first, so a duplicate is a compiler bug.
                 // Use early_error when handling -W help with no crate.
-                (None, _) => early_error(diagnostic::ColorConfig::Auto, &msg[..]),
+                (None, _) => early_error(default::Default::default(), &msg[..]),
                 (Some(sess), false) => sess.bug(&msg[..]),
 
                 // A duplicate name from a plugin is a user error.

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -166,7 +166,7 @@ impl LintStore {
                 match (sess, from_plugin) {
                     // We load builtin lints first, so a duplicate is a compiler bug.
                     // Use early_error when handling -W help with no crate.
-                    (None, _) => early_error(diagnostic::Auto, &msg[..]),
+                    (None, _) => early_error(diagnostic::ColorConfig::Auto, &msg[..]),
                     (Some(sess), false) => sess.bug(&msg[..]),
 
                     // A duplicate name from a plugin is a user error.
@@ -190,7 +190,7 @@ impl LintStore {
             match (sess, from_plugin) {
                 // We load builtin lints first, so a duplicate is a compiler bug.
                 // Use early_error when handling -W help with no crate.
-                (None, _) => early_error(diagnostic::Auto, &msg[..]),
+                (None, _) => early_error(diagnostic::ColorConfig::Auto, &msg[..]),
                 (Some(sess), false) => sess.bug(&msg[..]),
 
                 // A duplicate name from a plugin is a user error.

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -27,7 +27,7 @@ use metadata::cstore;
 use syntax::ast::{self, IntTy, UintTy};
 use syntax::attr;
 use syntax::attr::AttrMetaMethods;
-use syntax::diagnostic::{ColorConfig, Auto, Always, Never, SpanHandler};
+use syntax::diagnostic::{ColorConfig, SpanHandler};
 use syntax::parse;
 use syntax::parse::token::InternedString;
 use syntax::feature_gate::UnstableFeatures;
@@ -216,7 +216,7 @@ pub fn basic_options() -> Options {
         debugging_opts: basic_debugging_options(),
         prints: Vec::new(),
         cg: basic_codegen_options(),
-        color: Auto,
+        color: ColorConfig::Auto,
         show_span: None,
         externs: HashMap::new(),
         crate_name: None,
@@ -854,16 +854,17 @@ pub fn parse_cfgspecs(cfgspecs: Vec<String> ) -> ast::CrateConfig {
 
 pub fn build_session_options(matches: &getopts::Matches) -> Options {
     let color = match matches.opt_str("color").as_ref().map(|s| &s[..]) {
-        Some("auto")   => Auto,
-        Some("always") => Always,
-        Some("never")  => Never,
+        Some("auto")   => ColorConfig::Auto,
+        Some("always") => ColorConfig::Always,
+        Some("never")  => ColorConfig::Never,
 
-        None => Auto,
+        None => ColorConfig::Auto,
 
         Some(arg) => {
-            early_error(Auto, &format!("argument for --color must be auto, always \
-                                        or never (instead was `{}`)",
-                                       arg))
+            early_error(ColorConfig::Auto,
+                        &format!("argument for --color must be auto, always \
+                                  or never (instead was `{}`)",
+                                 arg))
         }
     };
 

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -394,7 +394,7 @@ pub fn build_session(sopts: config::Options,
 
     let codemap = codemap::CodeMap::new();
     let diagnostic_handler =
-        diagnostic::Handler::new(sopts.color, Some(registry), can_print_warnings);
+        diagnostic::Handler::new(sopts.emit_cfg, Some(registry), can_print_warnings);
     let span_diagnostic_handler =
         diagnostic::SpanHandler::new(diagnostic_handler, codemap);
 
@@ -473,13 +473,13 @@ pub fn expect<T, M>(sess: &Session, opt: Option<T>, msg: M) -> T where
     diagnostic::expect(sess.diagnostic(), opt, msg)
 }
 
-pub fn early_error(color: diagnostic::ColorConfig, msg: &str) -> ! {
-    let mut emitter = diagnostic::EmitterWriter::stderr(color, None);
+pub fn early_error(cfg: diagnostic::EmitterConfig, msg: &str) -> ! {
+    let mut emitter = diagnostic::EmitterWriter::stderr(cfg, None);
     emitter.emit(None, msg, None, diagnostic::Fatal);
     panic!(diagnostic::FatalError);
 }
 
-pub fn early_warn(color: diagnostic::ColorConfig, msg: &str) {
-    let mut emitter = diagnostic::EmitterWriter::stderr(color, None);
+pub fn early_warn(cfg: diagnostic::EmitterConfig, msg: &str) {
+    let mut emitter = diagnostic::EmitterWriter::stderr(cfg, None);
     emitter.emit(None, msg, None, diagnostic::Warning);
 }

--- a/src/librustc/session/search_paths.rs
+++ b/src/librustc/session/search_paths.rs
@@ -38,7 +38,7 @@ impl SearchPaths {
         SearchPaths { paths: Vec::new() }
     }
 
-    pub fn add_path(&mut self, path: &str, color: diagnostic::ColorConfig) {
+    pub fn add_path(&mut self, path: &str, cfg: diagnostic::EmitterConfig) {
         let (kind, path) = if path.starts_with("native=") {
             (PathKind::Native, &path["native=".len()..])
         } else if path.starts_with("crate=") {
@@ -53,7 +53,7 @@ impl SearchPaths {
             (PathKind::All, path)
         };
         if path.is_empty() {
-            early_error(color, "empty search path given via `-L`");
+            early_error(cfg, "empty search path given via `-L`");
         }
         self.paths.push((kind, PathBuf::from(path)));
     }

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -250,7 +250,7 @@ impl Target {
         // this is 1. ugly, 2. error prone.
 
 
-        let handler = diagnostic::Handler::new(diagnostic::ColorConfig::Auto, None, true);
+        let handler = diagnostic::Handler::new(Default::default(), None, true);
 
         let get_req_field = |name: &str| {
             match obj.find(name)

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -250,7 +250,7 @@ impl Target {
         // this is 1. ugly, 2. error prone.
 
 
-        let handler = diagnostic::Handler::new(diagnostic::Auto, None, true);
+        let handler = diagnostic::Handler::new(diagnostic::ColorConfig::Auto, None, true);
 
         let get_req_field = |name: &str| {
             match obj.find(name)

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -706,15 +706,16 @@ pub fn handle_options(mut args: Vec<String>) -> Option<getopts::Matches> {
                             &opt.opt_group.short_name
                         };
                         if m.opt_present(opt_name) {
-                            early_error(diagnostic::Auto, &format!("use of unstable option '{}' \
-                                                                    requires -Z unstable-options",
-                                                                   opt_name));
+                            early_error(diagnostic::ColorConfig::Auto,
+                                        &format!("use of unstable option '{}' \
+                                                  requires -Z unstable-options",
+                                                 opt_name));
                         }
                     }
                 }
                 m
             }
-            Err(f) => early_error(diagnostic::Auto, &f.to_string())
+            Err(f) => early_error(diagnostic::ColorConfig::Auto, &f.to_string())
         }
     }
 
@@ -819,7 +820,8 @@ pub fn monitor<F:FnOnce()+Send+'static>(f: F) {
         Err(value) => {
             // Thread panicked without emitting a fatal diagnostic
             if !value.is::<diagnostic::FatalError>() {
-                let mut emitter = diagnostic::EmitterWriter::stderr(diagnostic::Auto, None);
+                let mut emitter = diagnostic::EmitterWriter::stderr(
+                    diagnostic::ColorConfig::Auto, None);
 
                 // a .span_bug or .bug call has already printed what
                 // it wants to print.

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -26,6 +26,7 @@ use syntax::feature_gate::UnstableFeatures;
 
 use std::cell::{RefCell, Cell};
 use std::collections::{HashMap, HashSet};
+use std::default::Default;
 
 use visit_ast::RustdocVisitor;
 use clean;
@@ -114,7 +115,7 @@ pub fn run_core(search_paths: SearchPaths, cfgs: Vec<String>, externs: Externs,
     };
 
     let codemap = codemap::CodeMap::new();
-    let diagnostic_handler = diagnostic::Handler::new(diagnostic::Auto, None, true);
+    let diagnostic_handler = diagnostic::Handler::new(Default::default(), None, true);
     let span_diagnostic_handler =
         diagnostic::SpanHandler::new(diagnostic_handler, codemap);
 

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -19,6 +19,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::str;
 use std::sync::{Arc, Mutex};
+use std::default::Default;
 
 use testing;
 use rustc_lint;
@@ -67,7 +68,7 @@ pub fn run(input: &str,
     };
 
     let codemap = CodeMap::new();
-    let diagnostic_handler = diagnostic::Handler::new(diagnostic::Auto, None, true);
+    let diagnostic_handler = diagnostic::Handler::new(Default::default(), None, true);
     let span_diagnostic_handler =
     diagnostic::SpanHandler::new(diagnostic_handler, codemap);
 

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -105,9 +105,9 @@ impl EmitterConfig {
             },
             true => SpanFormat {
                 single: '\u{25B2}', // BLACK UP-POINTING TRIANGLE
-                begin:  '\u{2517}', // BOX DRAWINGS HEAVY UP AND RIGHT
-                middle: '\u{2501}', // BOX DRAWINGS HEAVY HORIZONTAL
-                end:    '\u{251B}', // BOX DRAWINGS HEAVY UP AND LEFT
+                begin:  '\u{2514}', // BOX DRAWINGS LIGHT UP AND RIGHT
+                middle: '\u{2500}', // BOX DRAWINGS LIGHT HORIZONTAL
+                end:    '\u{2518}', // BOX DRAWINGS LIGHT UP AND LEFT
             },
         }
     }

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -10,7 +10,6 @@
 
 pub use self::Level::*;
 pub use self::RenderSpan::*;
-pub use self::ColorConfig::*;
 use self::Destination::*;
 
 use codemap::{self, COMMAND_LINE_SP, COMMAND_LINE_EXPN, Pos, Span};
@@ -342,9 +341,9 @@ impl EmitterWriter {
         let stderr = io::stderr();
 
         let use_color = match color_config {
-            Always => true,
-            Never  => false,
-            Auto   => stderr_isatty(),
+            ColorConfig::Always => true,
+            ColorConfig::Never  => false,
+            ColorConfig::Auto   => stderr_isatty()
         };
 
         if use_color {

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -16,6 +16,7 @@ use codemap::{self, COMMAND_LINE_SP, COMMAND_LINE_EXPN, Pos, Span};
 use diagnostics;
 
 use std::cell::{RefCell, Cell};
+use std::default::Default;
 use std::{cmp, error, fmt};
 use std::io::prelude::*;
 use std::io;
@@ -67,6 +68,49 @@ pub enum ColorConfig {
     Auto,
     Always,
     Never
+}
+
+#[derive(Clone, Copy)]
+pub struct EmitterConfig {
+    pub color: ColorConfig,
+    pub drawing: bool,
+}
+
+impl Default for EmitterConfig {
+    fn default() -> EmitterConfig {
+        EmitterConfig {
+            color: ColorConfig::Auto,
+            drawing: false,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct SpanFormat {
+    single: char,
+    begin:  char,
+    middle: char,
+    end:    char,
+}
+
+impl EmitterConfig {
+    #[inline]
+    fn span_format(&self) -> SpanFormat {
+        match self.drawing {
+            false => SpanFormat {
+                single: '^',
+                begin:  '^',
+                middle: '~',
+                end:    '~',
+            },
+            true => SpanFormat {
+                single: '\u{25B2}', // BLACK UP-POINTING TRIANGLE
+                begin:  '\u{2517}', // BOX DRAWINGS HEAVY UP AND RIGHT
+                middle: '\u{2501}', // BOX DRAWINGS HEAVY HORIZONTAL
+                end:    '\u{251B}', // BOX DRAWINGS HEAVY UP AND LEFT
+            },
+        }
+    }
 }
 
 pub trait Emitter {
@@ -192,10 +236,10 @@ pub struct Handler {
 }
 
 impl Handler {
-    pub fn new(color_config: ColorConfig,
+    pub fn new(emitter_config: EmitterConfig,
                registry: Option<diagnostics::registry::Registry>,
                can_emit_warnings: bool) -> Handler {
-        let emitter = Box::new(EmitterWriter::stderr(color_config, registry));
+        let emitter = Box::new(EmitterWriter::stderr(emitter_config, registry));
         Handler::with_emitter(can_emit_warnings, emitter)
     }
     pub fn with_emitter(can_emit_warnings: bool, e: Box<Emitter + Send>) -> Handler {
@@ -313,7 +357,8 @@ impl Level {
 
 pub struct EmitterWriter {
     dst: Destination,
-    registry: Option<diagnostics::registry::Registry>
+    registry: Option<diagnostics::registry::Registry>,
+    cfg: EmitterConfig,
 }
 
 enum Destination {
@@ -336,11 +381,11 @@ macro_rules! println_maybe_styled {
 }
 
 impl EmitterWriter {
-    pub fn stderr(color_config: ColorConfig,
+    pub fn stderr(cfg: EmitterConfig,
                   registry: Option<diagnostics::registry::Registry>) -> EmitterWriter {
         let stderr = io::stderr();
 
-        let use_color = match color_config {
+        let use_color = match cfg.color {
             ColorConfig::Always => true,
             ColorConfig::Never  => false,
             ColorConfig::Auto   => stderr_isatty()
@@ -351,15 +396,15 @@ impl EmitterWriter {
                 Some(t) => Terminal(t),
                 None    => Raw(Box::new(stderr)),
             };
-            EmitterWriter { dst: dst, registry: registry }
+            EmitterWriter { dst: dst, registry: registry, cfg: cfg }
         } else {
-            EmitterWriter { dst: Raw(Box::new(stderr)), registry: registry }
+            EmitterWriter { dst: Raw(Box::new(stderr)), registry: registry, cfg: cfg }
         }
     }
 
     pub fn new(dst: Box<Write + Send>,
                registry: Option<diagnostics::registry::Registry>) -> EmitterWriter {
-        EmitterWriter { dst: Raw(dst), registry: registry }
+        EmitterWriter { dst: Raw(dst), registry: registry, cfg: Default::default() }
     }
 
     fn print_maybe_styled(&mut self,
@@ -618,14 +663,16 @@ impl EmitterWriter {
                 }
 
                 try!(write!(&mut self.dst, "{}", s));
-                let mut s = String::from("^");
+                let mut s = String::new();
+                let fmt = self.cfg.span_format();
                 let count = match lastc {
                     // Most terminals have a tab stop every eight columns by default
                     '\t' => 8 - col%8,
                     _ => 1,
                 };
                 col += count;
-                s.extend(::std::iter::repeat('~').take(count));
+                s.push(fmt.begin);
+                s.extend(::std::iter::repeat(fmt.middle).take(count));
 
                 let hi = cm.lookup_char_pos(sp.hi);
                 if hi.col != lo.col {
@@ -636,13 +683,20 @@ impl EmitterWriter {
                             _ => 1,
                         };
                         col += count;
-                        s.extend(::std::iter::repeat('~').take(count));
+                        s.extend(::std::iter::repeat(fmt.middle).take(count));
                     }
                 }
 
                 if s.len() > 1 {
                     // One extra squiggly is replaced by a "^"
                     s.pop();
+                }
+
+                s.pop();
+                if s.is_empty() {
+                    s.push(fmt.single);
+                } else {
+                    s.push(fmt.end);
                 }
 
                 try!(println_maybe_styled!(self, term::attr::ForegroundColor(lvl.color()),
@@ -717,7 +771,7 @@ impl EmitterWriter {
                 }
             }
         }
-        s.push('^');
+        s.push(self.cfg.span_format().single);
         println_maybe_styled!(self, term::attr::ForegroundColor(lvl.color()),
                               "{}", s)
     }

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -12,7 +12,7 @@
 
 use ast;
 use codemap::{self, Span, CodeMap, FileMap};
-use diagnostic::{SpanHandler, Handler, ColorConfig, FatalError};
+use diagnostic::{SpanHandler, Handler, FatalError};
 use parse::attr::ParserAttr;
 use parse::parser::Parser;
 use parse::token::InternedString;
@@ -24,6 +24,7 @@ use std::io::Read;
 use std::iter;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
+use std::default::Default;
 use std::str;
 
 pub type PResult<T> = Result<T, FatalError>;
@@ -48,7 +49,7 @@ pub struct ParseSess {
 
 impl ParseSess {
     pub fn new() -> ParseSess {
-        let handler = SpanHandler::new(Handler::new(ColorConfig::Auto, None, true), CodeMap::new());
+        let handler = SpanHandler::new(Handler::new(Default::default(), None, true), CodeMap::new());
         ParseSess::with_span_handler(handler)
     }
 

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -12,7 +12,7 @@
 
 use ast;
 use codemap::{self, Span, CodeMap, FileMap};
-use diagnostic::{SpanHandler, Handler, Auto, FatalError};
+use diagnostic::{SpanHandler, Handler, ColorConfig, FatalError};
 use parse::attr::ParserAttr;
 use parse::parser::Parser;
 use parse::token::InternedString;
@@ -48,7 +48,7 @@ pub struct ParseSess {
 
 impl ParseSess {
     pub fn new() -> ParseSess {
-        let handler = SpanHandler::new(Handler::new(Auto, None, true), CodeMap::new());
+        let handler = SpanHandler::new(Handler::new(ColorConfig::Auto, None, true), CodeMap::new());
         ParseSess::with_span_handler(handler)
     }
 

--- a/src/test/compile-fail/drawing-spans-one-char.rs
+++ b/src/test/compile-fail/drawing-spans-one-char.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:--drawing
+// error-pattern: ▲
+
+#![deny(warnings)]
+
+fn main() {
+    let x = 3;
+}

--- a/src/test/compile-fail/drawing-spans.rs
+++ b/src/test/compile-fail/drawing-spans.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:--drawing
+// error-pattern: ┗━━━━┛
+
+#![deny(warnings)]
+
+fn main() {
+    let foobar = 3;
+}


### PR DESCRIPTION
See #24387. 

This is a port of the first PR (#21406) to the current master branch. I also added a commit to change the characters to use WGL4 instead, as suggested in the comment thread of the original PR, since those are more widely supported.

The proposal that was more or less accepted was to remove the `--color` and `--drawing` options and replace them with environment variables and a single `--output-plain-ascii` option. The problem is that `--color` still exists, and a stable option. I left `--drawing` for now, for consistency with `--color` but there are maybe better options.

This PR is not yet ready to be merged but I wanted to post it to have feedback on this issue. The proposal also included auto-enabling Unicode output when writing to a terminal and LC_CTYPE ends with `.UTF-8`. I'll implement this if there is still agreement that this should be done.

cc @Manishearth.

(PS: I did not change the author of the commits since I did not implement the Unicode outputting itself, but the commits from the original PR needed a lot of fixes to build on the current master branch, maybe I should have. Let me know if I should. Doing a separate commit was also possible but generated a huge diff of duplicate modifications.)
