### PR TITLE
Prevent `/**/` from being parsed as a doc comment

### DIFF
--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1385,8 +1385,9 @@ pub fn is_doc_comment(s: &str) -> bool {
 }
 
 pub fn is_block_doc_comment(s: &str) -> bool {
-    let res = (s.starts_with("/**") && *s.as_bytes().get(3).unwrap_or(&b' ') != b'*')
-              || s.starts_with("/*!");
+    let res = ((s.starts_with("/**") && *s.as_bytes().get(3).unwrap_or(&b' ') != b'*')
+               || s.starts_with("/*!"))
+              && s.len() >= 5; // Prevent `/**/` from being parsed as a doc comment
     debug!("is {:?} a doc comment? {}", s, res);
     res
 }

--- a/src/test/compile-fail/empty-comment.rs
+++ b/src/test/compile-fail/empty-comment.rs
@@ -1,0 +1,17 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// `/**/` was previously regarded as a doc comment because it starts with `/**` and ends with `*/`.
+// This could break some internal logic that assumes the length of a doc comment is at least 5,
+// leading to an ICE.
+
+fn main() {
+    println!(/**/); //~ ERROR unexpected end
+}


### PR DESCRIPTION
Previously, `/**/` was incorrectly regarded as a doc comment because it starts with `/**` and ends with `*/`. However, this caused an ICE because some code assumed that the length of a doc comment is at least 5. This commit adds an additional check to `is_block_doc_comment` that tests the length of the input.

Fixes #28844.
