### PR TITLE
Add notes for missing PartialEq and PartialOrd, closes #28837

### DIFF
--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -209,8 +209,7 @@ fn check_overloaded_binop<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
 
                     if let Some(missing_trait) = missing_trait {
                         span_note!(fcx.tcx().sess, lhs_expr.span,
-                                   "an implementation of `{}` might be missing for `{}` \
-                                    or one of its type arguments",
+                                   "an implementation of `{}` might be missing for `{}`",
                                     missing_trait, lhs_ty);
                     }
                 }

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -191,6 +191,20 @@ fn check_overloaded_binop<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                               "binary operation `{}` cannot be applied to type `{}`",
                               hir_util::binop_to_string(op.node),
                               lhs_ty);
+                    match op.node {
+                        hir::BiEq =>
+                            span_note!(fcx.tcx().sess, lhs_expr.span,
+                                       "an implementation of `std::cmp::PartialEq` might be \
+                                        missing for `{}` or one of its type paramters",
+                                        lhs_ty),
+                        hir::BiLt | hir::BiLe | hir::BiGt | hir::BiGe =>
+                            span_note!(fcx.tcx().sess, lhs_expr.span,
+                                       "an implementation of `std::cmp::PartialOrd` might be \
+                                        missing for `{}` or one of its type paramters",
+                                        lhs_ty),
+                        _ => ()
+
+                    };
                 }
             }
             fcx.tcx().types.err

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -191,20 +191,28 @@ fn check_overloaded_binop<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                               "binary operation `{}` cannot be applied to type `{}`",
                               hir_util::binop_to_string(op.node),
                               lhs_ty);
-                    match op.node {
-                        hir::BiEq =>
-                            span_note!(fcx.tcx().sess, lhs_expr.span,
-                                       "an implementation of `std::cmp::PartialEq` might be \
-                                        missing for `{}` or one of its type paramters",
-                                        lhs_ty),
+                    let missing_trait = match op.node {
+                        hir::BiAdd    => Some("std::ops::Add"),
+                        hir::BiSub    => Some("std::ops::Sub"),
+                        hir::BiMul    => Some("std::ops::Mul"),
+                        hir::BiDiv    => Some("std::ops::Div"),
+                        hir::BiRem    => Some("std::ops::Rem"),
+                        hir::BiBitAnd => Some("std::ops::BitAnd"),
+                        hir::BiBitOr  => Some("std::ops::BitOr"),
+                        hir::BiShl    => Some("std::ops::Shl"),
+                        hir::BiShr    => Some("std::ops::Shr"),
+                        hir::BiEq | hir::BiNe => Some("std::cmp::PartialEq"),
                         hir::BiLt | hir::BiLe | hir::BiGt | hir::BiGe =>
-                            span_note!(fcx.tcx().sess, lhs_expr.span,
-                                       "an implementation of `std::cmp::PartialOrd` might be \
-                                        missing for `{}` or one of its type paramters",
-                                        lhs_ty),
-                        _ => ()
-
+                            Some("std::cmp::PartialOrd"),
+                        _             => None
                     };
+
+                    if let Some(missing_trait) = missing_trait {
+                        span_note!(fcx.tcx().sess, lhs_expr.span,
+                                   "an implementation of `{}` might be missing for `{}` \
+                                    or one of its type arguments",
+                                    missing_trait, lhs_ty);
+                    }
                 }
             }
             fcx.tcx().types.err

--- a/src/test/compile-fail/issue-28837.rs
+++ b/src/test/compile-fail/issue-28837.rs
@@ -1,20 +1,60 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 struct A;
 
 fn main() {
     let a = A;
 
-    if a == a {} //~ ERROR binary operation `==` cannot be applied to type `A`
-        //^~ NOTE an implementation of `std::cmp::PartialEq` might be missing for `A` or one of
+    a + a; //~ ERROR binary operation `+` cannot be applied to type `A` 
+    //~^ NOTE an implementation of `std::ops::Add` might be missing for `A` or
 
-    if a < a {} //~ ERROR binary operation `<` cannot be applied to type `A`
-        //^~ NOTE an implementation of `std::cmp::PartialOrd` might be missing for `A` or one of
+    a - a; //~ ERROR binary operation `-` cannot be applied to type `A`
+    //~^ NOTE an implementation of `std::ops::Sub` might be missing for `A` or one of
 
-    if a <= a {} //~ ERROR binary operation `<=` cannot be applied to type `A`
-        //^~ NOTE an implementation of `std::cmp::PartialOrd` might be missing for `A` or one of
+    a * a; //~ ERROR binary operation `*` cannot be applied to type `A`
+    //~^ NOTE an implementation of `std::ops::Mul` might be missing for `A` or one of
 
-    if a > a {} //~ ERROR binary operation `>` cannot be applied to type `A`
-        //^~ NOTE an implementation of `std::cmp::PartialOrd` might be missing for `A` or one of
+    a / a; //~ ERROR binary operation `/` cannot be applied to type `A`
+    //~^ NOTE an implementation of `std::ops::Div` might be missing for `A` or one of
 
-    if a >= a {} //~ ERROR binary operation `>=` cannot be applied to type `A`
-        //^~ NOTE an implementation of `std::cmp::PartialOrd` might be missing for `A` or one of
+    a % a; //~ ERROR binary operation `%` cannot be applied to type `A`
+    //~^ NOTE an implementation of `std::ops::Rem` might be missing for `A` or one of
+
+    a & a; //~ ERROR binary operation `&` cannot be applied to type `A`
+    //~^ NOTE an implementation of `std::ops::BitAnd` might be missing for `A` or one of
+
+    a | a; //~ ERROR binary operation `|` cannot be applied to type `A`
+    //~^ NOTE an implementation of `std::ops::BitOr` might be missing for `A` or one of
+
+    a << a; //~ ERROR binary operation `<<` cannot be applied to type `A`
+    //~^ NOTE an implementation of `std::ops::Shl` might be missing for `A` or one of
+
+    a >> a; //~ ERROR binary operation `>>` cannot be applied to type `A`
+    //~^ NOTE an implementation of `std::ops::Shr` might be missing for `A` or one of
+
+    a == a; //~ ERROR binary operation `==` cannot be applied to type `A`
+    //~^ NOTE an implementation of `std::cmp::PartialEq` might be missing for `A` or one of
+
+    a != a; //~ ERROR binary operation `!=` cannot be applied to type `A`
+    //~^ NOTE an implementation of `std::cmp::PartialEq` might be missing for `A` or one of
+
+    a < a; //~ ERROR binary operation `<` cannot be applied to type `A`
+    //~^ NOTE an implementation of `std::cmp::PartialOrd` might be missing for `A` or one of
+
+    a <= a; //~ ERROR binary operation `<=` cannot be applied to type `A`
+    //~^ NOTE an implementation of `std::cmp::PartialOrd` might be missing for `A` or one of
+
+    a > a; //~ ERROR binary operation `>` cannot be applied to type `A`
+    //~^ NOTE an implementation of `std::cmp::PartialOrd` might be missing for `A` or one of
+
+    a >= a; //~ ERROR binary operation `>=` cannot be applied to type `A`
+    //~^ NOTE an implementation of `std::cmp::PartialOrd` might be missing for `A` or one of
 }

--- a/src/test/compile-fail/issue-28837.rs
+++ b/src/test/compile-fail/issue-28837.rs
@@ -1,0 +1,20 @@
+struct A;
+
+fn main() {
+    let a = A;
+
+    if a == a {} //~ ERROR binary operation `==` cannot be applied to type `A`
+        //^~ NOTE an implementation of `std::cmp::PartialEq` might be missing for `A` or one of
+
+    if a < a {} //~ ERROR binary operation `<` cannot be applied to type `A`
+        //^~ NOTE an implementation of `std::cmp::PartialOrd` might be missing for `A` or one of
+
+    if a <= a {} //~ ERROR binary operation `<=` cannot be applied to type `A`
+        //^~ NOTE an implementation of `std::cmp::PartialOrd` might be missing for `A` or one of
+
+    if a > a {} //~ ERROR binary operation `>` cannot be applied to type `A`
+        //^~ NOTE an implementation of `std::cmp::PartialOrd` might be missing for `A` or one of
+
+    if a >= a {} //~ ERROR binary operation `>=` cannot be applied to type `A`
+        //^~ NOTE an implementation of `std::cmp::PartialOrd` might be missing for `A` or one of
+}

--- a/src/test/compile-fail/issue-28837.rs
+++ b/src/test/compile-fail/issue-28837.rs
@@ -13,48 +13,48 @@ struct A;
 fn main() {
     let a = A;
 
-    a + a; //~ ERROR binary operation `+` cannot be applied to type `A` 
-    //~^ NOTE an implementation of `std::ops::Add` might be missing for `A` or
+    a + a; //~ ERROR binary operation `+` cannot be applied to type `A`
+    //~^ NOTE an implementation of `std::ops::Add` might be missing for `A`
 
     a - a; //~ ERROR binary operation `-` cannot be applied to type `A`
-    //~^ NOTE an implementation of `std::ops::Sub` might be missing for `A` or one of
+    //~^ NOTE an implementation of `std::ops::Sub` might be missing for `A`
 
     a * a; //~ ERROR binary operation `*` cannot be applied to type `A`
-    //~^ NOTE an implementation of `std::ops::Mul` might be missing for `A` or one of
+    //~^ NOTE an implementation of `std::ops::Mul` might be missing for `A`
 
     a / a; //~ ERROR binary operation `/` cannot be applied to type `A`
-    //~^ NOTE an implementation of `std::ops::Div` might be missing for `A` or one of
+    //~^ NOTE an implementation of `std::ops::Div` might be missing for `A`
 
     a % a; //~ ERROR binary operation `%` cannot be applied to type `A`
-    //~^ NOTE an implementation of `std::ops::Rem` might be missing for `A` or one of
+    //~^ NOTE an implementation of `std::ops::Rem` might be missing for `A`
 
     a & a; //~ ERROR binary operation `&` cannot be applied to type `A`
-    //~^ NOTE an implementation of `std::ops::BitAnd` might be missing for `A` or one of
+    //~^ NOTE an implementation of `std::ops::BitAnd` might be missing for `A`
 
     a | a; //~ ERROR binary operation `|` cannot be applied to type `A`
-    //~^ NOTE an implementation of `std::ops::BitOr` might be missing for `A` or one of
+    //~^ NOTE an implementation of `std::ops::BitOr` might be missing for `A`
 
     a << a; //~ ERROR binary operation `<<` cannot be applied to type `A`
-    //~^ NOTE an implementation of `std::ops::Shl` might be missing for `A` or one of
+    //~^ NOTE an implementation of `std::ops::Shl` might be missing for `A`
 
     a >> a; //~ ERROR binary operation `>>` cannot be applied to type `A`
-    //~^ NOTE an implementation of `std::ops::Shr` might be missing for `A` or one of
+    //~^ NOTE an implementation of `std::ops::Shr` might be missing for `A`
 
     a == a; //~ ERROR binary operation `==` cannot be applied to type `A`
-    //~^ NOTE an implementation of `std::cmp::PartialEq` might be missing for `A` or one of
+    //~^ NOTE an implementation of `std::cmp::PartialEq` might be missing for `A`
 
     a != a; //~ ERROR binary operation `!=` cannot be applied to type `A`
-    //~^ NOTE an implementation of `std::cmp::PartialEq` might be missing for `A` or one of
+    //~^ NOTE an implementation of `std::cmp::PartialEq` might be missing for `A`
 
     a < a; //~ ERROR binary operation `<` cannot be applied to type `A`
-    //~^ NOTE an implementation of `std::cmp::PartialOrd` might be missing for `A` or one of
+    //~^ NOTE an implementation of `std::cmp::PartialOrd` might be missing for `A`
 
     a <= a; //~ ERROR binary operation `<=` cannot be applied to type `A`
-    //~^ NOTE an implementation of `std::cmp::PartialOrd` might be missing for `A` or one of
+    //~^ NOTE an implementation of `std::cmp::PartialOrd` might be missing for `A`
 
     a > a; //~ ERROR binary operation `>` cannot be applied to type `A`
-    //~^ NOTE an implementation of `std::cmp::PartialOrd` might be missing for `A` or one of
+    //~^ NOTE an implementation of `std::cmp::PartialOrd` might be missing for `A`
 
     a >= a; //~ ERROR binary operation `>=` cannot be applied to type `A`
-    //~^ NOTE an implementation of `std::cmp::PartialOrd` might be missing for `A` or one of
+    //~^ NOTE an implementation of `std::cmp::PartialOrd` might be missing for `A`
 }


### PR DESCRIPTION
this PR adds notes for missing `PartialEq` and `PartialOrd`. I've added a test case but it seems like `NOTE` is ignored by the test runner.
#28837
