### PR TITLE
doc: fixing typos

### DIFF
--- a/src/doc/grammar.md
+++ b/src/doc/grammar.md
@@ -259,7 +259,7 @@ symbol : "::" | "->"
 ```
 
 Symbols are a general class of printable [tokens](#tokens) that play structural
-roles in a variety of grammar productions. They are catalogued here for
+roles in a variety of grammar productions. They are cataloged here for
 completeness as the set of remaining miscellaneous printable tokens that do not
 otherwise appear as [unary operators](#unary-operator-expressions), [binary
 operators](#binary-operator-expressions), or [keywords](#keywords).

--- a/src/doc/nomicon/concurrency.md
+++ b/src/doc/nomicon/concurrency.md
@@ -1,4 +1,4 @@
-% Concurrency and Paralellism
+% Concurrency and Parallelism
 
 Rust as a language doesn't *really* have an opinion on how to do concurrency or
 parallelism. The standard library exposes OS threads and blocking sys-calls

--- a/src/doc/nomicon/destructors.md
+++ b/src/doc/nomicon/destructors.md
@@ -53,7 +53,7 @@ impl<T> Drop for Box<T> {
 
 and this works fine because when Rust goes to drop the `ptr` field it just sees
 a [Unique] that has no actual `Drop` implementation. Similarly nothing can
-use-after-free the `ptr` because when drop exits, it becomes inacessible.
+use-after-free the `ptr` because when drop exits, it becomes inaccessible.
 
 However this wouldn't work:
 

--- a/src/doc/nomicon/lifetimes.md
+++ b/src/doc/nomicon/lifetimes.md
@@ -195,7 +195,7 @@ println!("{}", x);
 
 The problem here is is bit more subtle and interesting. We want Rust to
 reject this program for the following reason: We have a live shared reference `x`
-to a descendent of `data` when we try to take a mutable reference to `data`
+to a descendant of `data` when we try to take a mutable reference to `data`
 to `push`. This would create an aliased mutable reference, which would
 violate the *second* rule of references.
 

--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -419,7 +419,7 @@ The two values of the boolean type are written `true` and `false`.
 ### Symbols
 
 Symbols are a general class of printable [tokens](#tokens) that play structural
-roles in a variety of grammar productions. They are catalogued here for
+roles in a variety of grammar productions. They are cataloged here for
 completeness as the set of remaining miscellaneous printable tokens that do not
 otherwise appear as [unary operators](#unary-operator-expressions), [binary
 operators](#binary-operator-expressions), or [keywords][keywords].

--- a/src/doc/trpl/dining-philosophers.md
+++ b/src/doc/trpl/dining-philosophers.md
@@ -45,7 +45,7 @@ Now, let’s imagine this sequence of events:
 6. ... ? All the forks are taken, but nobody can eat!
 
 There are different ways to solve this problem. We’ll get to our solution in
-the tutorial itself. For now, let’s get started modelling the problem itself.
+the tutorial itself. For now, let’s get started modeling the problem itself.
 We’ll start with the philosophers:
 
 ```rust


### PR DESCRIPTION
Just a few typos found in the docs. Thanks!
