### PR TITLE
Diagnostic change: crate features -> crate root

### DIFF
--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -131,7 +131,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
                                 "overloaded augmented assignments are not stable");
                             fileline_help!(
                                 tcx.sess, e.span,
-                                "add #![feature(augmented_assignments)] to the crate features \
+                                "add #![feature(augmented_assignments)] to the crate root \
                                  to enable");
                         }
                     }

--- a/src/test/compile-fail/augmented-assignments-feature-gate-cross.rs
+++ b/src/test/compile-fail/augmented-assignments-feature-gate-cross.rs
@@ -21,5 +21,5 @@ fn main() {
     let mut x = Int(0);
     x += 1;
     //~^ error: overloaded augmented assignments are not stable
-    // | help: add #![feature(augmented_assignments)] to the crate features to enable
+    // | help: add #![feature(augmented_assignments)] to the crate root to enable
 }

--- a/src/test/compile-fail/augmented-assignments-feature-gate.rs
+++ b/src/test/compile-fail/augmented-assignments-feature-gate.rs
@@ -22,5 +22,5 @@ fn main() {
     let mut x = Int(0);
     x += 1;
     //~^ error: overloaded augmented assignments are not stable
-    // | help: add #![feature(augmented_assignments)] to the crate features to enable
+    // | help: add #![feature(augmented_assignments)] to the crate root to enable
 }


### PR DESCRIPTION
"Crate features" isn't a thing in Rust, but you do need to add this line
to your crate root.

Fixes #28944
