### PR TITLE
Update Libflate Formatting

### DIFF
--- a/src/libflate/lib.rs
+++ b/src/libflate/lib.rs
@@ -30,7 +30,9 @@
 #![feature(unique)]
 #![cfg_attr(test, feature(rustc_private, rand, vec_push_all))]
 
-#[cfg(test)] #[macro_use] extern crate log;
+#[cfg(test)]
+#[macro_use]
+extern crate log;
 
 extern crate libc;
 
@@ -47,9 +49,7 @@ pub struct Error {
 
 impl Error {
     fn new() -> Error {
-        Error {
-            _unused: (),
-        }
+        Error { _unused: () }
     }
 }
 
@@ -73,7 +73,9 @@ impl Deref for Bytes {
 
 impl Drop for Bytes {
     fn drop(&mut self) {
-        unsafe { libc::free(*self.ptr as *mut _); }
+        unsafe {
+            libc::free(*self.ptr as *mut _);
+        }
     }
 }
 
@@ -123,7 +125,7 @@ pub fn deflate_bytes_zlib(bytes: &[u8]) -> Bytes {
     deflate_bytes_internal(bytes, LZ_NORM | TDEFL_WRITE_ZLIB_HEADER)
 }
 
-fn inflate_bytes_internal(bytes: &[u8], flags: c_int) -> Result<Bytes,Error> {
+fn inflate_bytes_internal(bytes: &[u8], flags: c_int) -> Result<Bytes, Error> {
     unsafe {
         let mut outsz: size_t = 0;
         let res = tinfl_decompress_mem_to_heap(bytes.as_ptr() as *const _,
@@ -142,12 +144,12 @@ fn inflate_bytes_internal(bytes: &[u8], flags: c_int) -> Result<Bytes,Error> {
 }
 
 /// Decompress a buffer, without parsing any sort of header on the input.
-pub fn inflate_bytes(bytes: &[u8]) -> Result<Bytes,Error> {
+pub fn inflate_bytes(bytes: &[u8]) -> Result<Bytes, Error> {
     inflate_bytes_internal(bytes, 0)
 }
 
 /// Decompress a buffer that starts with a zlib header.
-pub fn inflate_bytes_zlib(bytes: &[u8]) -> Result<Bytes,Error> {
+pub fn inflate_bytes_zlib(bytes: &[u8]) -> Result<Bytes, Error> {
     inflate_bytes_internal(bytes, TINFL_FLAG_PARSE_ZLIB_HEADER)
 }
 
@@ -176,7 +178,8 @@ mod tests {
             let cmp = deflate_bytes(&input);
             let out = inflate_bytes(&cmp).unwrap();
             debug!("{} bytes deflated to {} ({:.1}% size)",
-                   input.len(), cmp.len(),
+                   input.len(),
+                   cmp.len(),
                    100.0 * ((cmp.len() as f64) / (input.len() as f64)));
             assert_eq!(&*input, &*out);
         }


### PR DESCRIPTION
This commit updates the libflate crate with the formatting output of
`rustfmt`.

r? @nrc
