### PR TITLE
Make the rustdoc example links more noticable

### DIFF
--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -559,14 +559,17 @@ pre.rust .lifetime { color: #B76514; }
 
 .rusttest { display: none; }
 pre.rust { position: relative; }
-.test-arrow {
+a.test-arrow {
     display: inline-block;
     position: absolute;
-    top: 0;
-    right: 10px;
-    font-size: 150%;
-    -webkit-transform: scaleX(-1);
-    transform: scaleX(-1);
+
+    background-color: #4e8bca;
+    color: #f5f5f5;
+    padding: 5px 10px 5px 10px;
+    border-radius: 5px;
+    font-size: 130%;
+    top: 5px;
+    right: 5px;
 }
 
 .methods .section-header {

--- a/src/librustdoc/html/static/playpen.js
+++ b/src/librustdoc/html/static/playpen.js
@@ -28,8 +28,8 @@ document.addEventListener('DOMContentLoaded', function() {
             }
 
             var a = document.createElement('a');
-            a.textContent = '⇱';
             a.setAttribute('class', 'test-arrow');
+            a.textContent = 'Run';
 
             var code = el.previousElementSibling.textContent;
 


### PR DESCRIPTION
This is to make the link more prominent so hopefully people will actually see it. The new icon is partially because I wasn't sure how easy it would be to apply the previous transformations only to the last character of the string. As it is, I wasn't sure at first but I think the look is growing on me.

A minor nitpick is that the space after `Runnable` is underlined and I tried to fix that but it wasn't working for me right now. I tried switching a link with subelements to a div with subelements but I missed something because it wasn't working correctly.

---

Unselected:

![arrow](https://cloud.githubusercontent.com/assets/4156987/10414475/b1730ab2-6fa4-11e5-9062-15bc0c7c8b96.png)

---

Selected:

![arrow_selected](https://cloud.githubusercontent.com/assets/4156987/10414483/4a78088e-6fa5-11e5-864e-c83f354769b1.png)

Fixes https://github.com/rust-lang/rust/issues/28958
