### PR TITLE
[Documentation] trivial typo fix:  from_utrf8 should be from_utf8

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -381,7 +381,7 @@ impl String {
     /// Converts a vector of bytes to a `String` without checking that the
     /// string contains valid UTF-8.
     ///
-    /// See the safe version, [`from_utrf8()`][fromutf8], for more.
+    /// See the safe version, [`from_utf8()`][fromutf8], for more.
     ///
     /// [fromutf8]: struct.String.html#method.from_utf8
     ///

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -243,7 +243,7 @@ pub fn from_utf8(v: &[u8]) -> Result<&str, Utf8Error> {
 /// Converts a slice of bytes to a string slice without checking
 /// that the string contains valid UTF-8.
 ///
-/// See the safe version, [`from_utrf8()`][fromutf8], for more.
+/// See the safe version, [`from_utf8()`][fromutf8], for more.
 ///
 /// [fromutf8]: fn.from_utf8.html
 ///


### PR DESCRIPTION
r? @steveklabnik
