### PR TITLE
Owned conversions for CString

### DIFF
--- a/src/libstd/ffi/mod.rs
+++ b/src/libstd/ffi/mod.rs
@@ -13,7 +13,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 #[stable(feature = "rust1", since = "1.0.0")]
-pub use self::c_str::{CString, CStr, NulError};
+pub use self::c_str::{CString, CStr, NulError, IntoStringError};
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::os_str::{OsString, OsStr};


### PR DESCRIPTION
`OsString` has these sorts of conversions, while `CString` has been missing them. I'm iffy on `into_string` simply because the return type would be better off as `FromUtf8Error<CString>`, which of course isn't generic :cry:

Also should a different/new feature gate be used?
