### PR TITLE
Add a method to set the controlling tty of child processes (unix).

### DIFF
--- a/src/libstd/sys/unix/process.rs
+++ b/src/libstd/sys/unix/process.rs
@@ -37,6 +37,7 @@ pub struct Command {
     pub uid: Option<uid_t>,
     pub gid: Option<gid_t>,
     pub session_leader: bool,
+    pub tty: Option<RawFd>,
 }
 
 impl Command {
@@ -49,6 +50,7 @@ impl Command {
             uid: None,
             gid: None,
             session_leader: false,
+            tty: None,
         }
     }
 
@@ -307,7 +309,23 @@ impl Process {
             // process leader already. We just forked so it shouldn't return
             // error, but ignore it anyway.
             let _ = libc::setsid();
+
+            // Associate the tty file descriptor with the controlling terminal,
+            // then close it unless it is an stdio handle. Errors returned by
+            // close are ignored.
+            if let Some(tty) = cfg.tty {
+
+                const TIOCSCTTY: u64 = 0x540E;
+
+                if cvt_r(|| libc::funcs::bsd44::ioctl(tty, TIOCSCTTY)).is_err() {
+                    fail(&mut output);
+                } else if tty > 2 {
+                    let _ = libc::close(tty);
+                }
+
+            }
         }
+
         if !dirp.is_null() && libc::chdir(dirp) == -1 {
             fail(&mut output);
         }


### PR DESCRIPTION
On UNIX, processes may have a controlling terminal. Currently, there is no way to set the controlling terminal of a child process using the `std::process::Command` API. I am working on a library which abstracts over the tty subsystem; this method is needed to create a Rustic equivalent to fork_pty(3).

The proposed API works like this:
- Calling `Command::tty()` sets session_leader to true, regardless of whether or not session_leader() has been called. It prevents future calls to session_leader from having any impact.
- `Command::tty()` does not automatically cause the controlling terminal to be set as the stdio handles of the child process. To do that, one needs to call the appropriate methods with `Stdio::from_raw_fd(fd)` or the like. I made this decision to make the API more flexible (e.g. if you want to run a process that needs to have a controlling terminal set for some reason, but you don't want to communicate with it over that tty pair).
- During `Command::spawn()`, in the child process, after setting the process to be the leader of a new session, if an fd has been set to be the ctty for the child, this change is performed using the TIOCSCTTY ioctl.

I think this code is correct, but I feel a bit out of my depth with regard to a few things. In particular: is TIOCSCTTY supported, with the same ioctl number, on all relevant platforms? is closing the file descriptor in the child process the correct behavior in the context of Rust's RAII?
