### PR TITLE
require a method callee's type to outlive the call

### DIFF
--- a/src/librustc/front/map/mod.rs
+++ b/src/librustc/front/map/mod.rs
@@ -527,6 +527,10 @@ impl<'ast> Map<'ast> {
             NodeTraitItem(ti) => PathName(ti.name),
             NodeVariant(v) => PathName(v.node.name),
             NodeLifetime(lt) => PathName(lt.name),
+            NodeTyParam(tp) => PathName(tp.name),
+            NodeLocal(&Pat { node: PatIdent(_,l,_), .. }) => {
+                PathName(l.node.name)
+            },
             _ => panic!("no path elem for {:?}", node)
         }
     }
@@ -987,4 +991,3 @@ fn node_id_to_string(map: &Map, id: NodeId, include_id: bool) -> String {
         }
     }
 }
-

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -592,6 +592,8 @@ fn visit_expr(rcx: &mut Rcx, expr: &hir::Expr) {
         };
 
         substs_wf_in_scope(rcx, origin, &callee.substs, expr.span, expr_region);
+        type_must_outlive(rcx, infer::ExprTypeIsNotInScope(callee.ty, expr.span),
+                          callee.ty, expr_region);
     }
 
     // Check any autoderefs or autorefs that appear.
@@ -664,6 +666,8 @@ fn visit_expr(rcx: &mut Rcx, expr: &hir::Expr) {
         }
     }
 
+    debug!("regionck::visit_expr(e={:?}, repeating_scope={}) - visiting subexprs",
+           expr, rcx.repeating_scope);
     match expr.node {
         hir::ExprPath(..) => {
             rcx.fcx.opt_node_ty_substs(expr.id, |item_substs| {

--- a/src/test/run-pass/issue-28999.rs
+++ b/src/test/run-pass/issue-28999.rs
@@ -1,0 +1,20 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub struct Xyz<'a, V> {
+    pub v: (V, &'a u32),
+}
+
+pub fn eq<'a, 's, 't, V>(this: &'s Xyz<'a, V>, other: &'t Xyz<'a, V>) -> bool
+        where V: PartialEq {
+    this.v == other.v
+}
+
+fn main() {}


### PR DESCRIPTION
This rather crucial requirement was not checked. In most cases, that
didn't cause any trouble because the argument types are required to
outlive the call and are subtypes of a subformula of the callee type.

However, binary ops are taken by ref only indirectly, without it being
marked in the argument types, which led to the argument types not being
constrained anywhere causing spurious errors (as these are basically
unconstrainable, I don't think this change can break code). Of course,
the old way was also incorrent with contravariance, but that is still
unsound for other reasons.

This also improves rustc::front to get RUST_LOG to _somewhat_ work.

Fixes #28999. That issue is one of the several regression introduced by #28669.

r? @pnkfelix 
