### PR TITLE
win64/msvc: large or oddly-sized types pass by-ref

### DIFF
--- a/src/librustc_trans/trans/cabi_x86_win64.rs
+++ b/src/librustc_trans/trans/cabi_x86_win64.rs
@@ -46,7 +46,7 @@ pub fn compute_abi_info(ccx: &CrateContext,
                     2 => ArgType::direct(t, Some(Type::i16(ccx)), None, None),
                     4 => ArgType::direct(t, Some(Type::i32(ccx)), None, None),
                     8 => ArgType::direct(t, Some(Type::i64(ccx)), None, None),
-                    _ => ArgType::indirect(t, Some(Attribute::ByVal))
+                    _ => ArgType::indirect(t, None)
                 }
             }
             _ => {

--- a/src/rt/rust_test_helpers.c
+++ b/src/rt/rust_test_helpers.c
@@ -218,3 +218,7 @@ uint64_t get_y(struct S s) {
 uint64_t get_z(struct S s) {
     return s.z;
 }
+
+uint64_t get_c_many_params(void *a, void *b, void *c, void *d, struct quad f) {
+    return f.c;
+}

--- a/src/test/run-pass/issue-28676.rs
+++ b/src/test/run-pass/issue-28676.rs
@@ -1,0 +1,40 @@
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+
+#[derive(Copy, Clone)]
+pub struct Quad { a: u64, b: u64, c: u64, d: u64 }
+
+mod rustrt {
+    use super::Quad;
+
+    #[link(name = "rust_test_helpers")]
+    extern {
+        pub fn get_c_many_params(_: *const (), _: *const (),
+                                 _: *const (), _: *const (), f: Quad) -> u64;
+    }
+}
+
+fn test() {
+    unsafe {
+        let null = std::ptr::null();
+        let q = Quad {
+            a: 1,
+            b: 2,
+            c: 3,
+            d: 4
+        };
+        assert_eq!(rustrt::get_c_many_params(null, null, null, null, q), q.c);
+    }
+}
+
+pub fn main() {
+    test();
+}


### PR DESCRIPTION
Fixes #28676.

There doesn't seem to be a good way to add a test for this, but I tested the repro in #28676 and confirmed it now yields the correct result.
