### PR TITLE
Fix Lifetime Elision link in lifetimes.md

### DIFF
--- a/src/doc/trpl/lifetimes.md
+++ b/src/doc/trpl/lifetimes.md
@@ -74,7 +74,7 @@ associated with it, but the compiler lets you elide (i.e. omit, see
 ["Lifetime Elision"][lifetime-elision] below) them in common cases.
 Before we get to that, though, let’s break the explicit example down:
 
-[lifetime-elision]: #user-content-lifetime-elision
+[lifetime-elision]: #lifetime-elision
 
 ```rust,ignore
 fn bar<'a>(...)


### PR DESCRIPTION
This link was added in #28842 but doesn't work at https://doc.rust-lang.org/nightly/book/lifetimes.html. What works in my markdown preview doesn't work live, and vice versa.
