### PR TITLE
Make the Metadata struct Clone

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -60,6 +60,7 @@ pub struct File {
 /// represents known metadata about a file such as its permissions, size,
 /// modification times, etc.
 #[stable(feature = "rust1", since = "1.0.0")]
+#[derive(Clone)]
 pub struct Metadata(fs_imp::FileAttr);
 
 /// Iterator over the entries in a directory.

--- a/src/libstd/os/android/raw.rs
+++ b/src/libstd/os/android/raw.rs
@@ -39,6 +39,7 @@ mod arch {
     pub type time_t = i32;
 
     #[repr(C)]
+    #[derive(Clone)]
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
         #[stable(feature = "raw_ext", since = "1.1.0")]
@@ -108,6 +109,7 @@ mod arch {
     pub type time_t = i64;
 
     #[repr(C)]
+    #[derive(Clone)]
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
         #[stable(feature = "raw_ext", since = "1.1.0")]

--- a/src/libstd/os/bitrig/raw.rs
+++ b/src/libstd/os/bitrig/raw.rs
@@ -26,6 +26,7 @@ use os::unix::raw::{uid_t, gid_t};
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
 #[repr(C)]
+#[derive(Clone)]
 #[stable(feature = "raw_ext", since = "1.1.0")]
 pub struct stat {
     #[stable(feature = "raw_ext", since = "1.1.0")]

--- a/src/libstd/os/dragonfly/raw.rs
+++ b/src/libstd/os/dragonfly/raw.rs
@@ -26,6 +26,7 @@ use os::unix::raw::{uid_t, gid_t};
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
 #[repr(C)]
+#[derive(Clone)]
 #[stable(feature = "raw_ext", since = "1.1.0")]
 pub struct stat {
     #[stable(feature = "raw_ext", since = "1.1.0")]

--- a/src/libstd/os/freebsd/raw.rs
+++ b/src/libstd/os/freebsd/raw.rs
@@ -33,6 +33,7 @@ mod arch {
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i32;
 
     #[repr(C)]
+    #[derive(Clone)]
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
         #[stable(feature = "raw_ext", since = "1.1.0")]
@@ -91,6 +92,7 @@ mod arch {
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
     #[repr(C)]
+    #[derive(Clone)]
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
         #[stable(feature = "raw_ext", since = "1.1.0")]

--- a/src/libstd/os/ios/raw.rs
+++ b/src/libstd/os/ios/raw.rs
@@ -25,6 +25,7 @@ use os::unix::raw::{uid_t, gid_t};
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = c_long;
 
 #[repr(C)]
+#[derive(Clone)]
 #[stable(feature = "raw_ext", since = "1.1.0")]
 pub struct stat {
     #[stable(feature = "raw_ext", since = "1.1.0")]

--- a/src/libstd/os/linux/raw.rs
+++ b/src/libstd/os/linux/raw.rs
@@ -35,6 +35,7 @@ mod arch {
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i32;
 
     #[repr(C)]
+    #[derive(Clone)]
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
         #[stable(feature = "raw_ext", since = "1.1.0")]
@@ -95,6 +96,7 @@ mod arch {
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i32;
 
     #[repr(C)]
+    #[derive(Clone)]
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
         #[stable(feature = "raw_ext", since = "1.1.0")]
@@ -154,6 +156,7 @@ mod arch {
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
     #[repr(C)]
+    #[derive(Clone)]
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
         #[stable(feature = "raw_ext", since = "1.1.0")]
@@ -211,6 +214,7 @@ mod arch {
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
     #[repr(C)]
+    #[derive(Clone)]
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
         #[stable(feature = "raw_ext", since = "1.1.0")]

--- a/src/libstd/os/macos/raw.rs
+++ b/src/libstd/os/macos/raw.rs
@@ -25,6 +25,7 @@ use os::unix::raw::{uid_t, gid_t};
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = c_long;
 
 #[repr(C)]
+#[derive(Clone)]
 #[stable(feature = "raw_ext", since = "1.1.0")]
 pub struct stat {
     #[stable(feature = "raw_ext", since = "1.1.0")]

--- a/src/libstd/os/nacl/raw.rs
+++ b/src/libstd/os/nacl/raw.rs
@@ -34,6 +34,7 @@ mod arch {
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i32;
 
     #[repr(C)]
+    #[derive(Clone)]
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
         #[stable(feature = "raw_ext", since = "1.1.0")]
@@ -94,6 +95,7 @@ mod arch {
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i32;
 
     #[repr(C)]
+    #[derive(Clone)]
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
         #[stable(feature = "raw_ext", since = "1.1.0")]
@@ -153,6 +155,7 @@ mod arch {
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
     #[repr(C)]
+    #[derive(Clone)]
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
         #[stable(feature = "raw_ext", since = "1.1.0")]
@@ -210,6 +213,7 @@ mod arch {
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
     #[repr(C)]
+    #[derive(Clone)]
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
         #[stable(feature = "raw_ext", since = "1.1.0")]

--- a/src/libstd/os/netbsd/raw.rs
+++ b/src/libstd/os/netbsd/raw.rs
@@ -26,6 +26,7 @@ use os::unix::raw::{uid_t, gid_t};
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
 #[repr(C)]
+#[derive(Clone)]
 #[stable(feature = "raw_ext", since = "1.1.0")]
 pub struct stat {
     #[stable(feature = "raw_ext", since = "1.1.0")]

--- a/src/libstd/os/openbsd/raw.rs
+++ b/src/libstd/os/openbsd/raw.rs
@@ -26,6 +26,7 @@ use os::unix::raw::{uid_t, gid_t};
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
 #[repr(C)]
+#[derive(Clone)]
 #[stable(feature = "raw_ext", since = "1.1.0")]
 pub struct stat {
     #[stable(feature = "raw_ext", since = "1.1.0")]

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -27,6 +27,7 @@ use vec::Vec;
 
 pub struct File(FileDesc);
 
+#[derive(Clone)]
 pub struct FileAttr {
     stat: raw::stat,
 }

--- a/src/libstd/sys/windows/c.rs
+++ b/src/libstd/sys/windows/c.rs
@@ -182,6 +182,7 @@ pub struct CONSOLE_SCREEN_BUFFER_INFO {
 pub type PCONSOLE_SCREEN_BUFFER_INFO = *mut CONSOLE_SCREEN_BUFFER_INFO;
 
 #[repr(C)]
+#[derive(Clone)]
 pub struct WIN32_FILE_ATTRIBUTE_DATA {
     pub dwFileAttributes: libc::DWORD,
     pub ftCreationTime: libc::FILETIME,

--- a/src/libstd/sys/windows/fs.rs
+++ b/src/libstd/sys/windows/fs.rs
@@ -27,6 +27,7 @@ use vec::Vec;
 
 pub struct File { handle: Handle }
 
+#[derive(Clone)]
 pub struct FileAttr {
     data: c::WIN32_FILE_ATTRIBUTE_DATA,
     reparse_tag: libc::DWORD,


### PR DESCRIPTION
This commit adds `#[derive(Clone)]` to `std::fs::Metadata`, making that struct cloneable. Although the exact contents of that struct differ between OSes, they all have it contain only value types, meaning that the data can be re-used without repercussions.

It also adds `#[derive(Clone)]` to every type used by that struct across all OSes, including the various Unix `stat` structs and Windows's `WIN32_FILE_ATTRIBUTE_DATA`.

This stems from my comment here: https://github.com/rust-lang/rfcs/issues/939#issuecomment-140524439
