### PR TITLE
Unhide some code from the Traits section

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -1435,11 +1435,11 @@ struct Foo;
 
 trait Shape { fn area(&self) -> f64; }
 trait Circle : Shape { fn radius(&self) -> f64; }
-# impl Shape for Foo {
-#     fn area(&self) -> f64 {
-#         0.0
-#     }
-# }
+impl Shape for Foo {
+    fn area(&self) -> f64 {
+        0.0
+    }
+}
 impl Circle for Foo {
     fn radius(&self) -> f64 {
         println!("calling area: {}", self.area());


### PR DESCRIPTION
Having this code section hidden is misleading because it makes it look like implementing Circle for Foo automatically makes Foo implement Shape.
