### PR TITLE
fix link on std::result::Result

### DIFF
--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -17,9 +17,8 @@ use option::Option::{self, Some, None};
 use result;
 use sys;
 
-/// A specialized [`Result`][result] type for I/O operations.
-///
-/// [result]: ../result/enum.Result.html
+/// A specialized [`Result`](../result/enum.Result.html) type for I/O 
+/// operations.
 ///
 /// This type is broadly used across `std::io` for any operation which may
 /// produce an error.


### PR DESCRIPTION
r? @steveklabnik

The link is broken here: https://doc.rust-lang.org/std/io/#types.

Looks like crate documentation generator uses only first paragraph of the module documentation and 
so doesn't resolve the link defined below.

Probably this behaviour of the documentation generator should be considered as a bug and should be reported.
