### PR TITLE
save-analysis: normalise node ids before emitting.

### DIFF
--- a/src/librustc_trans/save/dump_csv.rs
+++ b/src/librustc_trans/save/dump_csv.rs
@@ -69,7 +69,7 @@ pub struct DumpCsvVisitor<'l, 'tcx: 'l> {
     analysis: &'l ty::CrateAnalysis,
 
     span: SpanUtils<'l>,
-    fmt: FmtStrs<'l>,
+    fmt: FmtStrs<'l, 'tcx>,
 
     cur_scope: NodeId,
 }
@@ -91,7 +91,8 @@ impl <'l, 'tcx> DumpCsvVisitor<'l, 'tcx> {
                                   out: output_file,
                                   dump_spans: false,
                               },
-                              span_utils),
+                              span_utils,
+                              tcx),
             cur_scope: 0,
         }
     }


### PR DESCRIPTION
With this change, normalised node ids correspond to def id indices where they exist, or are made disjoint from def ids otherwise.

r? @nikomatsakis 
