### PR TITLE
Reject "+" and "-" when parsing floats.

### DIFF
--- a/src/libcore/num/dec2flt/parse.rs
+++ b/src/libcore/num/dec2flt/parse.rs
@@ -59,7 +59,12 @@ pub fn parse_decimal(s: &str) -> ParseResult {
     let s = s.as_bytes();
     let (integral, s) = eat_digits(s);
     match s.first() {
-        None => Valid(Decimal::new(integral, b"", 0)),
+        None => {
+            if integral.is_empty() {
+                return Invalid; // No digits at all
+            }
+            Valid(Decimal::new(integral, b"", 0))
+        }
         Some(&b'e') | Some(&b'E') => {
             if integral.is_empty() {
                 return Invalid; // No digits before 'e'

--- a/src/libcoretest/num/dec2flt/mod.rs
+++ b/src/libcoretest/num/dec2flt/mod.rs
@@ -102,6 +102,18 @@ fn lonely_dot() {
 }
 
 #[test]
+fn lonely_sign() {
+    assert!("+".parse::<f32>().is_err());
+    assert!("-".parse::<f64>().is_err());
+}
+
+#[test]
+fn whitespace() {
+    assert!(" 1.0".parse::<f32>().is_err());
+    assert!("1.0 ".parse::<f64>().is_err());
+}
+
+#[test]
 fn nan() {
     assert!("NaN".parse::<f32>().unwrap().is_nan());
     assert!("NaN".parse::<f64>().unwrap().is_nan());


### PR DESCRIPTION
Fixes #29042
