### PR TITLE
doc: Clarify supported platforms and tiers

### DIFF
--- a/src/doc/trpl/installing-rust.md
+++ b/src/doc/trpl/installing-rust.md
@@ -61,21 +61,90 @@ binary downloads][install-page].
 
 ## Platform support
 
-Oh, we should also mention the officially supported platforms:
+The Rust compiler runs on, and compiles to, a great number of platforms, though
+not all platforms are equally supported. Rust's support levels are organized
+into three tiers, each with a different set of guarantees.
 
-* Windows (7 or later, Server 2008 R2)
-* Linux (2.6.18 or later, various distributions), x86 and x86-64
-* OSX 10.7 (Lion) or later, x86 and x86-64
+Platforms are identified by their "target triple" which is the string to inform
+the compiler what kind of output should be produced. The columns below indicate
+whether the corresponding component works on the specified platform.
 
-We extensively test Rust on these platforms, and a few others, too, like
-Android. But these are the ones most likely to work, as they have the most
-testing.
+### Tier 1
 
-Finally, a comment about Windows. Rust considers Windows to be a first-class
-platform upon release, but if we're honest, the Windows experience isn't as
-integrated as the Linux/OS X experience is. We're working on it! If anything
-doesn't work, it is a bug. Please let us know if that happens. Each and every
-commit is tested against Windows just like any other platform.
+Tier 1 platforms can be thought of as "guaranteed to build and work".
+Specifically they will each satisfy the following requirements:
+
+* Automated testing is set up to run tests for the platform.
+* Landing changes to the `rust-lang/rust` repository's master branch is gated on
+  tests passing.
+* Official release artifacts are provided for the platform.
+* Documentation for how to use and how to build the platform is available.
+
+|  Target                       | std |rustc|cargo| notes                      |
+|-------------------------------|-----|-----|-----|----------------------------|
+| `x86_64-pc-windows-msvc`      |  ✓  |  ✓  |  ✓  | 64-bit MSVC (Windows 7+)   |
+| `i686-pc-windows-gnu`         |  ✓  |  ✓  |  ✓  | 32-bit MinGW (Windows 7+)  |
+| `x86_64-pc-windows-gnu`       |  ✓  |  ✓  |  ✓  | 64-bit MinGW (Windows 7+)  |
+| `i686-apple-darwin`           |  ✓  |  ✓  |  ✓  | 32-bit OSX (10.7+, Lion+)  |
+| `x86_64-apple-darwin`         |  ✓  |  ✓  |  ✓  | 64-bit OSX (10.7+, Lion+)  |
+| `i686-unknown-linux-gnu`      |  ✓  |  ✓  |  ✓  | 32-bit Linux (2.6.18+)     |
+| `x86_64-unknown-linux-gnu`    |  ✓  |  ✓  |  ✓  | 64-bit Linux (2.6.18+)     |
+
+### Tier 2
+
+Tier 2 platforms can be thought of as "guaranteed to build". Automated tests are
+not run so it's not guaranteed to produce a working build, but platforms often
+work to quite a good degree and patches are always welcome! Specifically, these
+platforms are required to have each of the following:
+
+* Automated building is set up, but may not be running tests.
+* Landing changes to the `rust-lang/rust` repository's master branch is gated on
+  platforms **building**. Note that this means for some platforms just the
+  standard library is compiled, but for others the full bootstrap is run.
+* Official release artifacts are provided for the platform.
+
+|  Target                       | std |rustc|cargo| notes                      |
+|-------------------------------|-----|-----|-----|----------------------------|
+| `i686-pc-windows-msvc`        |  ✓  |  ✓  |  ✓  | 32-bit MSVC (Windows 7+)   |
+
+### Tier 3
+
+Tier 3 platforms are those which Rust has support for, but landing changes is
+not gated on the platform either building or passing tests. Working builds for
+these platforms may be spotty as their reliability is often defined in terms of
+community contributions. Additionally, release artifacts and installers are not
+provided, but there may be community infrastructure producing these in
+unofficial locations.
+
+|  Target                       | std |rustc|cargo| notes                      |
+|-------------------------------|-----|-----|-----|----------------------------|
+| `x86_64-unknown-linux-musl`   |  ✓  |     |     | 64-bit Linux with MUSL     |
+| `arm-linux-androideabi`       |  ✓  |     |     | ARM Android                |
+| `i686-linux-android`          |  ✓  |     |     | 32-bit x86 Android         |
+| `aarch64-linux-android`       |  ✓  |     |     | ARM64 Android              |
+| `arm-unknown-linux-gnueabi`   |  ✓  |  ✓  |     | ARM Linux (2.6.18+)        |
+| `arm-unknown-linux-gnueabihf` |  ✓  |  ✓  |     | ARM Linux (2.6.18+)        |
+| `aarch64-unknown-linux-gnu`   |  ✓  |     |     | ARM64 Linux (2.6.18+)      |
+| `mips-unknown-linux-gnu`      |  ✓  |     |     | MIPS Linux (2.6.18+)       |
+| `mipsel-unknown-linux-gnu`    |  ✓  |     |     | MIPS (LE) Linux (2.6.18+)  |
+| `powerpc-unknown-linux-gnu`   |  ✓  |     |     | PowerPC Linux (2.6.18+)    |
+| `i386-apple-ios`              |  ✓  |     |     | 32-bit x86 iOS             |
+| `x86_64-apple-ios`            |  ✓  |     |     | 64-bit x86 iOS             |
+| `armv7-apple-ios`             |  ✓  |     |     | ARM iOS                    |
+| `armv7s-apple-ios`            |  ✓  |     |     | ARM iOS                    |
+| `aarch64-apple-ios`           |  ✓  |     |     | ARM64 iOS                  |
+| `i686-unknown-freebsd`        |  ✓  |  ✓  |     | 32-bit FreeBSD             |
+| `x86_64-unknown-freebsd`      |  ✓  |  ✓  |     | 64-bit FreeBSD             |
+| `x86_64-unknown-openbsd`      |  ✓  |  ✓  |     | 64-bit OpenBSD             |
+| `x86_64-unknown-netbsd`       |  ✓  |  ✓  |     | 64-bit NetBSD              |
+| `x86_64-unknown-bitrig`       |  ✓  |  ✓  |     | 64-bit Bitrig              |
+| `x86_64-unknown-dragonfly`    |  ✓  |  ✓  |     | 64-bit DragonFlyBSD        |
+| `x86_64-rumprun-netbsd`       |  ✓  |     |     | 64-bit NetBSD Rump Kernel  |
+| `i686-pc-windows-msvc` (XP)   |  ✓  |     |     | Windows XP support         |
+| `x86_64-pc-windows-msvc` (XP) |  ✓  |     |     | Windows XP support         |
+
+Note that this table can be expanded over time, this isn't the exhaustive set of
+tier 3 platforms that will ever be!
 
 ## After installation
 


### PR DESCRIPTION
This commit expands the "supported platforms" section of the book to include
documentation on the tiers that Rust currently has as well as organizing all
supported platforms into these various tiers. Infrastructure improvements over
the next few months are likely to change the location of may of these platforms
over, but for now this should faithfully represent what we've got today!
