### PR TITLE
Resolve unused_parens compilation warning

### DIFF
--- a/src/doc/trpl/rust-inside-other-languages.md
+++ b/src/doc/trpl/rust-inside-other-languages.md
@@ -108,7 +108,7 @@ fn process() {
     let handles: Vec<_> = (0..10).map(|_| {
         thread::spawn(|| {
             let mut x = 0;
-            for _ in (0..5_000_000) {
+            for _ in 0..5_000_000 {
                 x += 1
             }
             x


### PR DESCRIPTION
Before this commit, the first "A Rust library" code sample produced
the following compilation warning:

```
test.rs:7:22: 7:36 warning: unnecessary parentheses around `for` head
expression, #[warn(unused_parens)] on by default
test.rs:7             for _ in (0..5_000_000) {
```

This commit just removes the parens around the range 0..5_000_000 thereby removing the compilation warning.
