### PR TITLE
Fix minor error in Arc docs

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -93,7 +93,7 @@ const MAX_REFCOUNT: usize = (isize::MAX) as usize;
 ///
 /// # Examples
 ///
-/// In this example, a large vector of floats is shared between several threads.
+/// In this example, a large vector is shared between several threads.
 /// With simple pipes, without `Arc`, a copy would have to be made for each
 /// thread.
 ///


### PR DESCRIPTION
The text says it's a vector of floats, but the code actually uses a vector of integers.  The type of the Vec doesn't really matter, so I just cut it from the text.
