### PR TITLE
Rework stability annotation pass

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -130,10 +130,13 @@ pub struct Arc<T: ?Sized> {
     _ptr: Shared<ArcInner<T>>,
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: ?Sized + Sync + Send> Send for Arc<T> { }
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: ?Sized + Sync + Send> Sync for Arc<T> { }
 
 #[cfg(not(stage0))] // remove cfg after new snapshot
+#[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Arc<U>> for Arc<T> {}
 
 /// A weak pointer to an `Arc`.
@@ -148,10 +151,13 @@ pub struct Weak<T: ?Sized> {
     _ptr: Shared<ArcInner<T>>,
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: ?Sized + Sync + Send> Send for Weak<T> { }
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: ?Sized + Sync + Send> Sync for Weak<T> { }
 
 #[cfg(not(stage0))] // remove cfg after new snapshot
+#[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Weak<U>> for Weak<T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1157,6 +1163,7 @@ mod tests {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> borrow::Borrow<T> for Arc<T> {
     fn borrow(&self) -> &T {
         &**self

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -136,6 +136,9 @@ pub struct IntermediateBox<T: ?Sized> {
     marker: marker::PhantomData<*mut T>,
 }
 
+#[unstable(feature = "placement_in",
+           reason = "placement box design is still being worked out.",
+           issue = "27779")]
 impl<T> Place<T> for IntermediateBox<T> {
     fn pointer(&mut self) -> *mut T {
         self.ptr as *mut T
@@ -170,12 +173,18 @@ fn make_place<T>() -> IntermediateBox<T> {
     }
 }
 
+#[unstable(feature = "placement_in",
+           reason = "placement box design is still being worked out.",
+           issue = "27779")]
 impl<T> BoxPlace<T> for IntermediateBox<T> {
     fn make_place() -> IntermediateBox<T> {
         make_place()
     }
 }
 
+#[unstable(feature = "placement_in",
+           reason = "placement box design is still being worked out.",
+           issue = "27779")]
 impl<T> InPlace<T> for IntermediateBox<T> {
     type Owner = Box<T>;
     unsafe fn finalize(self) -> Box<T> {
@@ -183,6 +192,7 @@ impl<T> InPlace<T> for IntermediateBox<T> {
     }
 }
 
+#[unstable(feature = "placement_new_protocol", issue = "27779")]
 impl<T> Boxed for Box<T> {
     type Data = T;
     type Place = IntermediateBox<T>;
@@ -191,6 +201,9 @@ impl<T> Boxed for Box<T> {
     }
 }
 
+#[unstable(feature = "placement_in",
+           reason = "placement box design is still being worked out.",
+           issue = "27779")]
 impl<T> Placer<T> for ExchangeHeapSingleton {
     type Place = IntermediateBox<T>;
 
@@ -199,6 +212,9 @@ impl<T> Placer<T> for ExchangeHeapSingleton {
     }
 }
 
+#[unstable(feature = "placement_in",
+           reason = "placement box design is still being worked out.",
+           issue = "27779")]
 impl<T: ?Sized> Drop for IntermediateBox<T> {
     fn drop(&mut self) {
         if self.size > 0 {
@@ -518,6 +534,7 @@ pub trait FnBox<A> {
     fn call_box(self: Box<Self>, args: A) -> Self::Output;
 }
 
+#[unstable(feature = "fnbox", reason = "Newly introduced", issue = "0")]
 impl<A,F> FnBox<A> for F
     where F: FnOnce<A>
 {
@@ -528,6 +545,7 @@ impl<A,F> FnBox<A> for F
     }
 }
 
+#[unstable(feature = "fnbox", reason = "Newly introduced", issue = "0")]
 impl<'a,A,R> FnOnce<A> for Box<FnBox<A,Output=R>+'a> {
     type Output = R;
 
@@ -536,6 +554,7 @@ impl<'a,A,R> FnOnce<A> for Box<FnBox<A,Output=R>+'a> {
     }
 }
 
+#[unstable(feature = "fnbox", reason = "Newly introduced", issue = "0")]
 impl<'a,A,R> FnOnce<A> for Box<FnBox<A,Output=R>+Send+'a> {
     type Output = R;
 
@@ -544,6 +563,7 @@ impl<'a,A,R> FnOnce<A> for Box<FnBox<A,Output=R>+Send+'a> {
     }
 }
 
+#[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<Box<U>> for Box<T> {}
 
 #[stable(feature = "box_slice_clone", since = "1.3.0")]
@@ -597,12 +617,14 @@ impl<T: Clone> Clone for Box<[T]> {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> borrow::Borrow<T> for Box<T> {
     fn borrow(&self) -> &T {
         &**self
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> borrow::BorrowMut<T> for Box<T> {
     fn borrow_mut(&mut self) -> &mut T {
         &mut **self

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -191,10 +191,13 @@ pub struct Rc<T: ?Sized> {
     _ptr: Shared<RcBox<T>>,
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> !marker::Send for Rc<T> {}
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> !marker::Sync for Rc<T> {}
 
 #[cfg(not(stage0))] // remove cfg after new snapshot
+#[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<Rc<U>> for Rc<T> {}
 
 impl<T> Rc<T> {
@@ -723,10 +726,13 @@ pub struct Weak<T: ?Sized> {
     _ptr: Shared<RcBox<T>>,
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> !marker::Send for Weak<T> {}
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> !marker::Sync for Weak<T> {}
 
 #[cfg(not(stage0))] // remove cfg after new snapshot
+#[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<Weak<U>> for Weak<T> {}
 
 impl<T: ?Sized> Weak<T> {
@@ -1126,6 +1132,7 @@ mod tests {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> borrow::Borrow<T> for Rc<T> {
     fn borrow(&self) -> &T {
         &**self

--- a/src/libcollections/binary_heap.rs
+++ b/src/libcollections/binary_heap.rs
@@ -731,6 +731,7 @@ impl<'a, T: 'a> DoubleEndedIterator for Drain<'a, T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T: 'a> ExactSizeIterator for Drain<'a, T> {}
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Ord> From<Vec<T>> for BinaryHeap<T> {
     fn from(vec: Vec<T>) -> BinaryHeap<T> {
         let mut heap = BinaryHeap { data: vec };
@@ -743,6 +744,7 @@ impl<T: Ord> From<Vec<T>> for BinaryHeap<T> {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T> From<BinaryHeap<T>> for Vec<T> {
     fn from(heap: BinaryHeap<T>) -> Vec<T> {
         heap.data

--- a/src/libcollections/borrow.rs
+++ b/src/libcollections/borrow.rs
@@ -24,6 +24,7 @@ use fmt;
 
 use self::Cow::*;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::borrow::{Borrow, BorrowMut};
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcollections/btree/node.rs
+++ b/src/libcollections/btree/node.rs
@@ -451,7 +451,6 @@ impl<K, V> Node<K, V> {
 }
 
 // FIXME(gereeter) Write an efficient clone_from
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<K: Clone, V: Clone> Clone for Node<K, V> {
     fn clone(&self) -> Node<K, V> {
         let mut ret = if self.is_leaf() {

--- a/src/libcollections/fmt.rs
+++ b/src/libcollections/fmt.rs
@@ -475,8 +475,10 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+#[unstable(feature = "fmt_internals", issue = "0")]
+pub use core::fmt::rt;
 #[stable(feature = "rust1", since = "1.0.0")]
-pub use core::fmt::{Formatter, Result, Write, rt};
+pub use core::fmt::{Formatter, Result, Write};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{Octal, Binary};
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcollections/fmt.rs
+++ b/src/libcollections/fmt.rs
@@ -475,13 +475,21 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{Formatter, Result, Write, rt};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{Octal, Binary};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{Display, Debug};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{LowerHex, UpperHex, Pointer};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{LowerExp, UpperExp};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::Error;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{ArgumentV1, Arguments, write, radix, Radix, RadixFmt};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{DebugList, DebugMap, DebugSet, DebugStruct, DebugTuple};
 
 use string;

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -107,11 +107,13 @@ pub mod vec_deque;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod btree_map {
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub use btree::map::*;
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod btree_set {
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub use btree::set::*;
 }
 

--- a/src/libcollections/linked_list.rs
+++ b/src/libcollections/linked_list.rs
@@ -857,6 +857,7 @@ impl<A> DoubleEndedIterator for IntoIter<A> {
     fn next_back(&mut self) -> Option<A> { self.list.pop_back() }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<A> ExactSizeIterator for IntoIter<A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -890,6 +891,7 @@ impl<'a, T> IntoIterator for &'a LinkedList<T> {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> IntoIterator for &'a mut LinkedList<T> {
     type Item = &'a mut T;
     type IntoIter = IterMut<'a, T>;

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -102,12 +102,18 @@ use core::slice as core_slice;
 use borrow::{Borrow, BorrowMut, ToOwned};
 use vec::Vec;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::slice::{Chunks, Windows};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::slice::{Iter, IterMut};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::slice::{SplitMut, ChunksMut, Split};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::slice::{SplitN, RSplitN, SplitNMut, RSplitNMut};
+#[unstable(feature = "ref_slice", issue = "27774")]
 #[allow(deprecated)]
 pub use core::slice::{bytes, mut_ref_slice, ref_slice};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::slice::{from_raw_parts, from_raw_parts_mut};
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -860,6 +866,9 @@ pub trait SliceConcatExt<T: ?Sized> {
     fn connect(&self, sep: &T) -> Self::Output;
 }
 
+#[unstable(feature = "slice_concat_ext",
+           reason = "trait should not have to exist",
+           issue = "27747")]
 impl<T: Clone, V: Borrow<[T]>> SliceConcatExt<T> for [V] {
     type Output = Vec<T>;
 

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -37,19 +37,33 @@ use vec::Vec;
 use slice::SliceConcatExt;
 use boxed::Box;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::{FromStr, Utf8Error};
 #[allow(deprecated)]
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::{Lines, LinesAny, CharRange};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::{Split, RSplit};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::{SplitN, RSplitN};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::{SplitTerminator, RSplitTerminator};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::{Matches, RMatches};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::{MatchIndices, RMatchIndices};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::{from_utf8, Chars, CharIndices, Bytes};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::{from_utf8_unchecked, ParseBoolError};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use rustc_unicode::str::{SplitWhitespace};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::pattern;
 
+#[unstable(feature = "slice_concat_ext",
+           reason = "trait should not have to exist",
+           issue = "27747")]
 impl<S: Borrow<str>> SliceConcatExt<str> for [S] {
     type Output = String;
 

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -949,6 +949,9 @@ impl Extend<String> for String {
 }
 
 /// A convenience impl that delegates to the impl for `&str`
+#[unstable(feature = "pattern",
+           reason = "API not fully fleshed out and ready to be stabilized",
+           issue = "27721")]
 impl<'a, 'b> Pattern<'a> for &'b String {
     type Searcher = <&'b str as Pattern<'a>>::Searcher;
 
@@ -1143,24 +1146,28 @@ impl FromStr for String {
     }
 }
 
+#[stable(feature = "str_parse_error", since = "1.5.0")]
 impl Clone for ParseError {
     fn clone(&self) -> ParseError {
         match *self {}
     }
 }
 
+#[stable(feature = "str_parse_error", since = "1.5.0")]
 impl fmt::Debug for ParseError {
     fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
         match *self {}
     }
 }
 
+#[stable(feature = "str_parse_error", since = "1.5.0")]
 impl PartialEq for ParseError {
     fn eq(&self, _: &ParseError) -> bool {
         match *self {}
     }
 }
 
+#[stable(feature = "str_parse_error", since = "1.5.0")]
 impl Eq for ParseError {}
 
 /// A generic trait for converting a value to a string
@@ -1287,7 +1294,9 @@ pub struct Drain<'a> {
     iter: Chars<'a>,
 }
 
+#[unstable(feature = "drain", reason = "recently added", issue = "27711")]
 unsafe impl<'a> Sync for Drain<'a> {}
+#[unstable(feature = "drain", reason = "recently added", issue = "27711")]
 unsafe impl<'a> Send for Drain<'a> {}
 
 #[unstable(feature = "drain", reason = "recently added", issue = "27711")]

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1471,12 +1471,14 @@ impl<'a, T> FromIterator<T> for Cow<'a, [T]> where T: Clone {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T: 'a> IntoCow<'a, [T]> for Vec<T> where T: Clone {
     fn into_cow(self) -> Cow<'a, [T]> {
         Cow::Owned(self)
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> IntoCow<'a, [T]> for &'a [T] where T: Clone {
     fn into_cow(self) -> Cow<'a, [T]> {
         Cow::Borrowed(self)
@@ -1495,7 +1497,9 @@ pub struct IntoIter<T> {
     end: *const T
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Send> Send for IntoIter<T> { }
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Sync> Sync for IntoIter<T> { }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1590,7 +1594,9 @@ pub struct Drain<'a, T: 'a> {
     vec: *mut Vec<T>,
 }
 
+#[unstable(feature = "drain", reason = "recently added", issue = "27711")]
 unsafe impl<'a, T: Sync> Sync for Drain<'a, T> {}
+#[unstable(feature = "drain", reason = "recently added", issue = "27711")]
 unsafe impl<'a, T: Send> Send for Drain<'a, T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcollections/vec_deque.rs
+++ b/src/libcollections/vec_deque.rs
@@ -1662,6 +1662,7 @@ pub struct Iter<'a, T:'a> {
 }
 
 // FIXME(#19839) Remove in favor of `#[derive(Clone)]`
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> Clone for Iter<'a, T> {
     fn clone(&self) -> Iter<'a, T> {
         Iter {
@@ -1805,7 +1806,9 @@ pub struct Drain<'a, T: 'a> {
     deque: *mut VecDeque<T>,
 }
 
+#[unstable(feature = "drain", issue = "27711")]
 unsafe impl<'a, T: Sync> Sync for Drain<'a, T> {}
+#[unstable(feature = "drain", issue = "27711")]
 unsafe impl<'a, T: Send> Send for Drain<'a, T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -97,6 +97,7 @@ pub trait Any: Reflect + 'static {
     fn get_type_id(&self) -> TypeId;
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Reflect + 'static> Any for T {
     fn get_type_id(&self) -> TypeId { TypeId::of::<T>() }
 }

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -791,6 +791,7 @@ pub struct UnsafeCell<T: ?Sized> {
     value: T,
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> !Sync for UnsafeCell<T> {}
 
 impl<T> UnsafeCell<T> {

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -152,6 +152,9 @@ pub trait CharExt {
     fn encode_utf16(self, dst: &mut [u16]) -> Option<usize>;
 }
 
+#[unstable(feature = "core_char_ext",
+           reason = "the stable interface is `impl char` in later crate",
+           issue = "27701")]
 impl CharExt for char {
     #[inline]
     fn is_digit(self, radix: u32) -> bool {

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -24,10 +24,13 @@ use slice;
 use str;
 use self::rt::v1::Alignment;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::num::radix;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::num::Radix;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::num::RadixFmt;
-
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::builders::{DebugStruct, DebugTuple, DebugSet, DebugList, DebugMap};
 
 mod num;
@@ -170,6 +173,8 @@ pub struct ArgumentV1<'a> {
     formatter: fn(&Void, &mut Formatter) -> Result,
 }
 
+#[unstable(feature = "fmt_internals", reason = "internal to format_args!",
+           issue = "0")]
 impl<'a> Clone for ArgumentV1<'a> {
     fn clone(&self) -> ArgumentV1<'a> {
         *self
@@ -1568,6 +1573,7 @@ impl Debug for () {
         f.pad("()")
     }
 }
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T> Debug for PhantomData<T> {
     fn fmt(&self, f: &mut Formatter) -> Result {
         f.pad("PhantomData")

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -24,13 +24,13 @@ use slice;
 use str;
 use self::rt::v1::Alignment;
 
-#[stable(feature = "rust1", since = "1.0.0")]
+#[unstable(feature = "fmt_radix", issue = "27728")]
 pub use self::num::radix;
-#[stable(feature = "rust1", since = "1.0.0")]
+#[unstable(feature = "fmt_radix", issue = "27728")]
 pub use self::num::Radix;
-#[stable(feature = "rust1", since = "1.0.0")]
+#[unstable(feature = "fmt_radix", issue = "27728")]
 pub use self::num::RadixFmt;
-#[stable(feature = "rust1", since = "1.0.0")]
+#[stable(feature = "debug_builders", since = "1.2.0")]
 pub use self::builders::{DebugStruct, DebugTuple, DebugSet, DebugList, DebugMap};
 
 mod num;

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -264,6 +264,7 @@ const DEC_DIGITS_LUT: &'static[u8] =
 
 macro_rules! impl_Display {
     ($($t:ident),*: $conv_fn:ident) => ($(
+    #[stable(feature = "rust1", since = "1.0.0")]
     impl fmt::Display for $t {
         #[allow(unused_comparisons)]
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -75,6 +75,7 @@ use prelude::v1::*;
 
 use mem;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::sip::SipHasher;
 
 mod sip;

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -3488,6 +3488,7 @@ impl<I: Iterator> Peekable<I> {
     ///
     /// assert_eq!(iter.is_empty(), true);
     /// ```
+    #[unstable(feature = "core", issue = "27701")]
     #[inline]
     pub fn is_empty(&mut self) -> bool {
         self.peek().is_none()
@@ -3991,6 +3992,9 @@ pub trait Step: PartialOrd + Sized {
 
 macro_rules! step_impl_unsigned {
     ($($t:ty)*) => ($(
+        #[unstable(feature = "step_trait",
+                   reason = "likely to be replaced by finer-grained traits",
+                   issue = "27741")]
         impl Step for $t {
             #[inline]
             fn step(&self, by: &$t) -> Option<$t> {
@@ -4018,6 +4022,9 @@ macro_rules! step_impl_unsigned {
 }
 macro_rules! step_impl_signed {
     ($($t:ty)*) => ($(
+        #[unstable(feature = "step_trait",
+                   reason = "likely to be replaced by finer-grained traits",
+                   issue = "27741")]
         impl Step for $t {
             #[inline]
             fn step(&self, by: &$t) -> Option<$t> {
@@ -4057,6 +4064,9 @@ macro_rules! step_impl_signed {
 
 macro_rules! step_impl_no_between {
     ($($t:ty)*) => ($(
+        #[unstable(feature = "step_trait",
+                   reason = "likely to be replaced by finer-grained traits",
+                   issue = "27741")]
         impl Step for $t {
             #[inline]
             fn step(&self, by: &$t) -> Option<$t> {

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -31,9 +31,12 @@ pub unsafe trait Send {
     // empty.
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl Send for .. { }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T> !Send for *const T { }
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T> !Send for *mut T { }
 
 /// Types with a constant size known at compile-time.
@@ -223,48 +226,59 @@ pub unsafe trait Sync {
     // Empty
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl Sync for .. { }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T> !Sync for *const T { }
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T> !Sync for *mut T { }
 
 macro_rules! impls{
     ($t: ident) => (
+        #[stable(feature = "rust1", since = "1.0.0")]
         impl<T:?Sized> Hash for $t<T> {
             #[inline]
             fn hash<H: Hasher>(&self, _: &mut H) {
             }
         }
 
+        #[stable(feature = "rust1", since = "1.0.0")]
         impl<T:?Sized> cmp::PartialEq for $t<T> {
             fn eq(&self, _other: &$t<T>) -> bool {
                 true
             }
         }
 
+        #[stable(feature = "rust1", since = "1.0.0")]
         impl<T:?Sized> cmp::Eq for $t<T> {
         }
 
+        #[stable(feature = "rust1", since = "1.0.0")]
         impl<T:?Sized> cmp::PartialOrd for $t<T> {
             fn partial_cmp(&self, _other: &$t<T>) -> Option<cmp::Ordering> {
                 Option::Some(cmp::Ordering::Equal)
             }
         }
 
+        #[stable(feature = "rust1", since = "1.0.0")]
         impl<T:?Sized> cmp::Ord for $t<T> {
             fn cmp(&self, _other: &$t<T>) -> cmp::Ordering {
                 cmp::Ordering::Equal
             }
         }
 
+        #[stable(feature = "rust1", since = "1.0.0")]
         impl<T:?Sized> Copy for $t<T> { }
 
+        #[stable(feature = "rust1", since = "1.0.0")]
         impl<T:?Sized> Clone for $t<T> {
             fn clone(&self) -> $t<T> {
                 $t
             }
         }
 
+        #[stable(feature = "rust1", since = "1.0.0")]
         impl<T:?Sized> Default for $t<T> {
             fn default() -> $t<T> {
                 $t
@@ -387,7 +401,9 @@ impls! { PhantomData }
 mod impls {
     use super::{Send, Sync, Sized};
 
+    #[stable(feature = "rust1", since = "1.0.0")]
     unsafe impl<'a, T: Sync + ?Sized> Send for &'a T {}
+    #[stable(feature = "rust1", since = "1.0.0")]
     unsafe impl<'a, T: Send + ?Sized> Send for &'a mut T {}
 }
 
@@ -433,4 +449,7 @@ mod impls {
                             ensure all type parameters are bounded by `Any`"]
 pub trait Reflect {}
 
+#[unstable(feature = "reflect_marker",
+           reason = "requires RFC and more experience",
+           issue = "27749")]
 impl Reflect for .. { }

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -141,6 +141,9 @@ pub mod consts {
     pub const LN_10: f32 = 2.30258509299404568401799145468436421_f32;
 }
 
+#[unstable(feature = "core_float",
+           reason = "stable interface is via `impl f{32,64}` in later crates",
+           issue = "27702")]
 impl Float for f32 {
     #[inline]
     fn nan() -> f32 { NAN }

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -141,6 +141,9 @@ pub mod consts {
     pub const LN_10: f64 = 2.30258509299404568401799145468436421_f64;
 }
 
+#[unstable(feature = "core_float",
+           reason = "stable interface is via `impl f{32,64}` in later crates",
+           issue = "27702")]
 impl Float for f64 {
     #[inline]
     fn nan() -> f64 { NAN }

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -77,10 +77,16 @@ pub trait One: Sized {
 
 macro_rules! zero_one_impl {
     ($($t:ty)*) => ($(
+        #[unstable(feature = "zero_one",
+                   reason = "unsure of placement, wants to use associated constants",
+                   issue = "27739")]
         impl Zero for $t {
             #[inline]
             fn zero() -> Self { 0 }
         }
+        #[unstable(feature = "zero_one",
+                   reason = "unsure of placement, wants to use associated constants",
+                   issue = "27739")]
         impl One for $t {
             #[inline]
             fn one() -> Self { 1 }
@@ -91,10 +97,16 @@ zero_one_impl! { u8 u16 u32 u64 usize i8 i16 i32 i64 isize }
 
 macro_rules! zero_one_impl_float {
     ($($t:ty)*) => ($(
+        #[unstable(feature = "zero_one",
+                   reason = "unsure of placement, wants to use associated constants",
+                   issue = "27739")]
         impl Zero for $t {
             #[inline]
             fn zero() -> Self { 0.0 }
         }
+        #[unstable(feature = "zero_one",
+                   reason = "unsure of placement, wants to use associated constants",
+                   issue = "27739")]
         impl One for $t {
             #[inline]
             fn one() -> Self { 1.0 }
@@ -1938,6 +1950,7 @@ impl fmt::Display for ParseIntError {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use num::dec2flt::ParseFloatError;
 
 // Conversion traits for primitive integer and float types

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -894,6 +894,7 @@ pub trait Shr<RHS> {
 
 macro_rules! shr_impl {
     ($t:ty, $f:ty) => (
+        #[stable(feature = "rust1", since = "1.0.0")]
         impl Shr<$f> for $t {
             type Output = $t;
 
@@ -1731,6 +1732,7 @@ impl<'a, T: ?Sized> DerefMut for &'a mut T {
 #[fundamental] // so that regex can rely that `&str: !FnMut`
 pub trait Fn<Args> : FnMut<Args> {
     /// This is called when the call operator is used.
+    #[unstable(feature = "core", issue = "27701")]
     extern "rust-call" fn call(&self, args: Args) -> Self::Output;
 }
 
@@ -1741,6 +1743,7 @@ pub trait Fn<Args> : FnMut<Args> {
 #[fundamental] // so that regex can rely that `&str: !FnMut`
 pub trait FnMut<Args> : FnOnce<Args> {
     /// This is called when the call operator is used.
+    #[unstable(feature = "core", issue = "27701")]
     extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output;
 }
 
@@ -1751,9 +1754,11 @@ pub trait FnMut<Args> : FnOnce<Args> {
 #[fundamental] // so that regex can rely that `&str: !FnMut`
 pub trait FnOnce<Args> {
     /// The returned type after the call operator is used.
+    #[unstable(feature = "core", issue = "27701")]
     type Output;
 
     /// This is called when the call operator is used.
+    #[unstable(feature = "core", issue = "27701")]
     extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
 }
 
@@ -1761,6 +1766,7 @@ mod impls {
     use marker::Sized;
     use super::{Fn, FnMut, FnOnce};
 
+    #[stable(feature = "rust1", since = "1.0.0")]
     impl<'a,A,F:?Sized> Fn<A> for &'a F
         where F : Fn<A>
     {
@@ -1769,6 +1775,7 @@ mod impls {
         }
     }
 
+    #[stable(feature = "rust1", since = "1.0.0")]
     impl<'a,A,F:?Sized> FnMut<A> for &'a F
         where F : Fn<A>
     {
@@ -1777,6 +1784,7 @@ mod impls {
         }
     }
 
+    #[stable(feature = "rust1", since = "1.0.0")]
     impl<'a,A,F:?Sized> FnOnce<A> for &'a F
         where F : Fn<A>
     {
@@ -1787,6 +1795,7 @@ mod impls {
         }
     }
 
+    #[stable(feature = "rust1", since = "1.0.0")]
     impl<'a,A,F:?Sized> FnMut<A> for &'a mut F
         where F : FnMut<A>
     {
@@ -1795,6 +1804,7 @@ mod impls {
         }
     }
 
+    #[stable(feature = "rust1", since = "1.0.0")]
     impl<'a,A,F:?Sized> FnOnce<A> for &'a mut F
         where F : FnMut<A>
     {
@@ -1814,25 +1824,34 @@ pub trait CoerceUnsized<T> {
 }
 
 // &mut T -> &mut U
+#[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<'a, T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<&'a mut U> for &'a mut T {}
 // &mut T -> &U
+#[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<'a, 'b: 'a, T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<&'a U> for &'b mut T {}
 // &mut T -> *mut U
+#[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<'a, T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<*mut U> for &'a mut T {}
 // &mut T -> *const U
+#[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<'a, T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for &'a mut T {}
 
 // &T -> &U
+#[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<'a, 'b: 'a, T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<&'a U> for &'b T {}
 // &T -> *const U
+#[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<'a, T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for &'a T {}
 
 // *mut T -> *mut U
+#[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<*mut U> for *mut T {}
 // *mut T -> *const U
+#[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for *mut T {}
 
 // *const T -> *const U
+#[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for *const T {}
 
 /// Both `in (PLACE) EXPR` and `box EXPR` desugar into expressions

--- a/src/libcore/prelude/v1.rs
+++ b/src/libcore/prelude/v1.rs
@@ -17,23 +17,37 @@
 #![stable(feature = "core_prelude", since = "1.4.0")]
 
 // Reexported core operators
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use marker::{Copy, Send, Sized, Sync};
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use ops::{Drop, Fn, FnMut, FnOnce};
 
 // Reexported functions
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use mem::drop;
 
 // Reexported types and traits
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use clone::Clone;
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use cmp::{PartialEq, PartialOrd, Eq, Ord};
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use convert::{AsRef, AsMut, Into, From};
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use default::Default;
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use iter::{Iterator, Extend, IntoIterator};
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use iter::{DoubleEndedIterator, ExactSizeIterator};
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use option::Option::{self, Some, None};
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use result::Result::{self, Ok, Err};
 
 // Reexported extension traits for primitive types
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use slice::SliceExt;
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use str::StrExt;
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use char::CharExt;

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -40,6 +40,7 @@ pub use intrinsics::copy;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use intrinsics::write_bytes;
 
+#[unstable(feature = "drop_in_place", reason = "just exposed, needs FCP", issue = "27908")]
 pub use intrinsics::drop_in_place;
 
 /// Creates a null raw pointer.

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -870,6 +870,7 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> ExactSizeIterator for Iter<'a, T> {}
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> Clone for Iter<'a, T> {
     fn clone(&self) -> Iter<'a, T> { Iter { inner: self.inner } }
 }

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -154,6 +154,9 @@ macro_rules! slice_ref {
     }};
 }
 
+#[unstable(feature = "core_slice_ext",
+           reason = "stable interface provided by `impl [T]` in later crates",
+           issue = "27701")]
 impl<T> SliceExt for [T] {
     type Item = T;
 
@@ -796,7 +799,9 @@ pub struct Iter<'a, T: 'a> {
     _marker: marker::PhantomData<&'a T>,
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<'a, T: Sync> Sync for Iter<'a, T> {}
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<'a, T: Sync> Send for Iter<'a, T> {}
 
 impl<'a, T> Iter<'a, T> {
@@ -842,7 +847,9 @@ pub struct IterMut<'a, T: 'a> {
     _marker: marker::PhantomData<&'a mut T>,
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<'a, T: Sync> Sync for IterMut<'a, T> {}
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<'a, T: Send> Send for IterMut<'a, T> {}
 
 impl<'a, T> IterMut<'a, T> {

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -1440,6 +1440,9 @@ fn slice_error_fail(s: &str, begin: usize, end: usize) -> ! {
           begin, end, s);
 }
 
+#[unstable(feature = "core_str_ext",
+           reason = "stable interface provided by `impl str` in later crates",
+           issue = "27701")]
 impl StrExt for str {
     #[inline]
     fn contains<'a, P: Pattern<'a>>(&'a self, pat: P) -> bool {

--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -86,6 +86,7 @@ pub struct AtomicBool {
     v: UnsafeCell<usize>,
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl Default for AtomicBool {
     fn default() -> Self {
         Self::new(Default::default())
@@ -93,6 +94,7 @@ impl Default for AtomicBool {
 }
 
 // Send is implicitly implemented for AtomicBool.
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl Sync for AtomicBool {}
 
 /// A signed integer type which can be safely shared between threads.
@@ -101,6 +103,7 @@ pub struct AtomicIsize {
     v: UnsafeCell<isize>,
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl Default for AtomicIsize {
     fn default() -> Self {
         Self::new(Default::default())
@@ -108,6 +111,7 @@ impl Default for AtomicIsize {
 }
 
 // Send is implicitly implemented for AtomicIsize.
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl Sync for AtomicIsize {}
 
 /// An unsigned integer type which can be safely shared between threads.
@@ -116,6 +120,7 @@ pub struct AtomicUsize {
     v: UnsafeCell<usize>,
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl Default for AtomicUsize {
     fn default() -> Self {
         Self::new(Default::default())
@@ -123,6 +128,7 @@ impl Default for AtomicUsize {
 }
 
 // Send is implicitly implemented for AtomicUsize.
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl Sync for AtomicUsize {}
 
 /// A raw pointer type which can be safely shared between threads.
@@ -131,13 +137,16 @@ pub struct AtomicPtr<T> {
     p: UnsafeCell<*mut T>,
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T> Default for AtomicPtr<T> {
     fn default() -> AtomicPtr<T> {
         AtomicPtr::new(::ptr::null_mut())
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T> Send for AtomicPtr<T> {}
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T> Sync for AtomicPtr<T> {}
 
 /// Atomic memory orderings

--- a/src/libcore/tuple.rs
+++ b/src/libcore/tuple.rs
@@ -27,8 +27,6 @@
 //! * `Ord`
 //! * `Default`
 
-#![stable(feature = "rust1", since = "1.0.0")]
-
 use clone::Clone;
 use cmp::*;
 use cmp::Ordering::*;

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -12,6 +12,7 @@
 //! propagating default levels lexically from parent to children ast nodes.
 
 pub use self::StabilityLevel::*;
+use self::AnnotationKind::*;
 
 use session::Session;
 use lint;
@@ -30,8 +31,8 @@ use syntax::attr::{self, Stability, AttrMetaMethods};
 use util::nodemap::{DefIdMap, FnvHashSet, FnvHashMap};
 
 use rustc_front::hir;
-use rustc_front::hir::{FnDecl, Block, Crate, Item, Generics, StructField, Variant};
-use rustc_front::visit::{self, FnKind, Visitor};
+use rustc_front::hir::{Block, Crate, Item, Generics, StructField, Variant};
+use rustc_front::visit::{self, Visitor};
 
 use std::mem::replace;
 use std::cmp::Ordering;
@@ -46,6 +47,16 @@ impl StabilityLevel {
     pub fn from_attr_level(level: &attr::StabilityLevel) -> Self {
         if level.is_stable() { Stable } else { Unstable }
     }
+}
+
+#[derive(PartialEq)]
+enum AnnotationKind {
+    // Annotation is required if not inherited from unstable parents
+    AnnRequired,
+    // Annotation is useless, reject it
+    AnnProhibited,
+    // Annotation itself is useless, but it can be propagated to children
+    AnnContainer,
 }
 
 /// A stability index, giving the stability level for items and methods.
@@ -64,174 +75,180 @@ struct Annotator<'a, 'tcx: 'a> {
     index: &'a mut Index<'tcx>,
     parent: Option<&'tcx Stability>,
     export_map: &'a PublicItems,
+    in_trait_impl: bool,
+    in_enum: bool,
 }
 
 impl<'a, 'tcx: 'a> Annotator<'a, 'tcx> {
     // Determine the stability for a node based on its attributes and inherited
     // stability. The stability is recorded in the index and used as the parent.
-    fn annotate<F>(&mut self, id: NodeId, use_parent: bool,
-                   attrs: &Vec<Attribute>, item_sp: Span, f: F, required: bool) where
-        F: FnOnce(&mut Annotator),
+    fn annotate<F>(&mut self, id: NodeId, attrs: &Vec<Attribute>,
+                   item_sp: Span, kind: AnnotationKind, visit_children: F)
+        where F: FnOnce(&mut Annotator)
     {
         if self.index.staged_api[&LOCAL_CRATE] {
             debug!("annotate(id = {:?}, attrs = {:?})", id, attrs);
-            match attr::find_stability(self.tcx.sess.diagnostic(), attrs, item_sp) {
-                Some(mut stab) => {
-                    debug!("annotate: found {:?}", stab);
-                    // if parent is deprecated and we're not, inherit this by merging
-                    // deprecated_since and its reason.
-                    if let Some(parent_stab) = self.parent {
-                        if parent_stab.depr.is_some()
-                        && stab.depr.is_none() {
-                            stab.depr = parent_stab.depr.clone()
+            if let Some(mut stab) = attr::find_stability(self.tcx.sess.diagnostic(),
+                                                         attrs, item_sp) {
+                // Error if prohibited, or can't inherit anything from a container
+                if kind == AnnProhibited ||
+                   kind == AnnContainer && stab.level.is_stable() && stab.depr.is_none() {
+                    self.tcx.sess.span_err(item_sp, "This stability annotation is useless");
+                }
+
+                debug!("annotate: found {:?}", stab);
+                // If parent is deprecated and we're not, inherit this by merging
+                // deprecated_since and its reason.
+                if let Some(parent_stab) = self.parent {
+                    if parent_stab.depr.is_some() && stab.depr.is_none() {
+                        stab.depr = parent_stab.depr.clone()
+                    }
+                }
+
+                let stab = self.tcx.intern_stability(stab);
+
+                // Check if deprecated_since < stable_since. If it is,
+                // this is *almost surely* an accident.
+                if let (&Some(attr::Deprecation {since: ref dep_since, ..}),
+                        &attr::Stable {since: ref stab_since}) = (&stab.depr, &stab.level) {
+                    // Explicit version of iter::order::lt to handle parse errors properly
+                    for (dep_v, stab_v) in dep_since.split(".").zip(stab_since.split(".")) {
+                        if let (Ok(dep_v), Ok(stab_v)) = (dep_v.parse::<u64>(), stab_v.parse()) {
+                            match dep_v.cmp(&stab_v) {
+                                Ordering::Less => {
+                                    self.tcx.sess.span_err(item_sp, "An API can't be stabilized \
+                                                                     after it is deprecated");
+                                    break
+                                }
+                                Ordering::Equal => continue,
+                                Ordering::Greater => break,
+                            }
+                        } else {
+                            // Act like it isn't less because the question is now nonsensical,
+                            // and this makes us not do anything else interesting.
+                            self.tcx.sess.span_err(item_sp, "Invalid stability or deprecation \
+                                                             version found");
+                            break
                         }
                     }
+                }
 
-                    let stab = self.tcx.intern_stability(stab);
+                let def_id = self.tcx.map.local_def_id(id);
+                self.index.map.insert(def_id, Some(stab));
 
-                    // Check if deprecated_since < stable_since. If it is,
-                    // this is *almost surely* an accident.
-                    let deprecated_predates_stable = match (&stab.depr, &stab.level) {
-                        (&Some(attr::Deprecation {since: ref dep_since, ..}),
-                               &attr::Stable {since: ref stab_since}) => {
-                            // explicit version of iter::order::lt to handle parse errors properly
-                            let mut is_less = false;
-                            for (dep_v, stab_v) in dep_since.split(".").zip(stab_since.split(".")) {
-                                match (dep_v.parse::<u64>(), stab_v.parse::<u64>()) {
-                                    (Ok(dep_v), Ok(stab_v)) => match dep_v.cmp(&stab_v) {
-                                        Ordering::Less => {
-                                            is_less = true;
-                                            break;
-                                        }
-                                        Ordering::Equal => { continue; }
-                                        Ordering::Greater => { break; }
-                                    },
-                                    _ => {
-                                        self.tcx.sess.span_err(item_sp,
-                                            "Invalid stability or deprecation version found");
-                                        // act like it isn't less because the question is now
-                                        // nonsensical, and this makes us not do anything else
-                                        // interesting.
-                                        break;
-                                    }
-                                }
-                            }
-                            is_less
-                        },
-                        _ => false,
-                    };
-
-                    if deprecated_predates_stable {
-                        self.tcx.sess.span_err(item_sp,
-                            "An API can't be stabilized after it is deprecated");
-                    }
-
-                    let def_id = self.tcx.map.local_def_id(id);
-                    self.index.map.insert(def_id, Some(stab));
-
-                    // Don't inherit #[stable(feature = "rust1", since = "1.0.0")]
-                    if !stab.level.is_stable() {
-                        let parent = replace(&mut self.parent, Some(stab));
-                        f(self);
-                        self.parent = parent;
-                    } else {
-                        f(self);
+                let parent = replace(&mut self.parent, Some(stab));
+                visit_children(self);
+                self.parent = parent;
+            } else {
+                debug!("annotate: not found, parent = {:?}", self.parent);
+                let mut is_error = kind == AnnRequired &&
+                                   self.export_map.contains(&id) &&
+                                   !self.tcx.sess.opts.test;
+                if let Some(stab) = self.parent {
+                    if stab.level.is_unstable() {
+                        let def_id = self.tcx.map.local_def_id(id);
+                        self.index.map.insert(def_id, Some(stab));
+                        is_error = false;
                     }
                 }
-                None => {
-                    debug!("annotate: not found, use_parent = {:?}, parent = {:?}",
-                           use_parent, self.parent);
-                    if use_parent {
-                        if let Some(stab) = self.parent {
-                            let def_id = self.tcx.map.local_def_id(id);
-                            self.index.map.insert(def_id, Some(stab));
-                        } else if self.index.staged_api[&LOCAL_CRATE] && required
-                            && self.export_map.contains(&id)
-                            && !self.tcx.sess.opts.test {
-                                self.tcx.sess.span_err(item_sp,
-                                                       "This node does not \
-                                                        have a stability attribute");
-                            }
-                    }
-                    f(self);
+                if is_error {
+                    self.tcx.sess.span_err(item_sp, "This node does not have \
+                                                     a stability attribute");
                 }
+                visit_children(self);
             }
         } else {
-            // Emit warnings for non-staged-api crates. These should be errors.
+            // Emit errors for non-staged-api crates.
             for attr in attrs {
                 let tag = attr.name();
                 if tag == "unstable" || tag == "stable" || tag == "deprecated" {
                     attr::mark_used(attr);
-                    self.tcx.sess.span_err(attr.span(),
-                                       "stability attributes may not be used outside \
-                                        of the standard library");
+                    self.tcx.sess.span_err(attr.span(), "stability attributes may not be used \
+                                                         outside of the standard library");
                 }
             }
-            f(self);
+            visit_children(self);
         }
     }
 }
 
 impl<'a, 'tcx, 'v> Visitor<'v> for Annotator<'a, 'tcx> {
     fn visit_item(&mut self, i: &Item) {
-        // FIXME (#18969): the following is a hack around the fact
-        // that we cannot currently annotate the stability of
-        // `deriving`.  Basically, we do *not* allow stability
-        // inheritance on trait implementations, so that derived
-        // implementations appear to be unannotated. This then allows
-        // derived implementations to be automatically tagged with the
-        // stability of the trait. This is WRONG, but expedient to get
-        // libstd stabilized for the 1.0 release.
-        let use_parent = match i.node {
-            hir::ItemImpl(_, _, _, Some(_), _, _) => false,
-            _ => true,
-        };
-
-        // In case of a `pub use <mod>;`, we should not error since the stability
-        // is inherited from the module itself
-        let required = match i.node {
-            hir::ItemUse(_) => i.vis != hir::Public,
-            _ => true
-        };
-
-        self.annotate(i.id, use_parent, &i.attrs, i.span,
-                      |v| visit::walk_item(v, i), required);
-
-        if let hir::ItemStruct(ref sd, _) = i.node {
-            if !sd.is_struct() {
-                self.annotate(sd.id(), true, &i.attrs, i.span, |_| {}, true)
+        let orig_in_trait_impl = self.in_trait_impl;
+        let orig_in_enum = self.in_enum;
+        let mut kind = AnnRequired;
+        match i.node {
+            // Inherent impls and foreign modules serve only as containers for other items,
+            // they don't have their own stability. They still can be annotated as unstable
+            // and propagate this unstability to children, but this annotation is completely
+            // optional. They inherit stability from their parents when unannotated.
+            hir::ItemImpl(_, _, _, None, _, _) | hir::ItemForeignMod(..) => {
+                self.in_trait_impl = false;
+                kind = AnnContainer;
             }
+            hir::ItemImpl(_, _, _, Some(_), _, _) => {
+                self.in_trait_impl = true;
+            }
+            hir::ItemStruct(ref sd, _) => {
+                self.in_enum = false;
+                if !sd.is_struct() {
+                    self.annotate(sd.id(), &i.attrs, i.span, AnnRequired, |_| {})
+                }
+            }
+            hir::ItemEnum(..) => {
+                self.in_enum = true;
+            }
+            _ => {}
         }
-    }
 
-    fn visit_fn(&mut self, _: FnKind<'v>, _: &'v FnDecl,
-                _: &'v Block, _: Span, _: NodeId) {
-        // Items defined in a function body have no reason to have
-        // a stability attribute, so we don't recurse.
+        self.annotate(i.id, &i.attrs, i.span, kind, |v| {
+            visit::walk_item(v, i)
+        });
+        self.in_trait_impl = orig_in_trait_impl;
+        self.in_enum = orig_in_enum;
     }
 
     fn visit_trait_item(&mut self, ti: &hir::TraitItem) {
-        self.annotate(ti.id, true, &ti.attrs, ti.span,
-                      |v| visit::walk_trait_item(v, ti), true);
+        self.annotate(ti.id, &ti.attrs, ti.span, AnnRequired, |v| {
+            visit::walk_trait_item(v, ti);
+        });
     }
 
     fn visit_impl_item(&mut self, ii: &hir::ImplItem) {
-        self.annotate(ii.id, true, &ii.attrs, ii.span,
-                      |v| visit::walk_impl_item(v, ii), false);
+        let kind = if self.in_trait_impl { AnnProhibited } else { AnnRequired };
+        self.annotate(ii.id, &ii.attrs, ii.span, kind, |v| {
+            visit::walk_impl_item(v, ii);
+        });
     }
 
     fn visit_variant(&mut self, var: &Variant, g: &'v Generics, item_id: NodeId) {
-        self.annotate(var.node.data.id(), true, &var.node.attrs, var.span,
-                      |v| visit::walk_variant(v, var, g, item_id), true)
+        self.annotate(var.node.data.id(), &var.node.attrs, var.span, AnnRequired, |v| {
+            visit::walk_variant(v, var, g, item_id);
+        })
     }
 
     fn visit_struct_field(&mut self, s: &StructField) {
-        self.annotate(s.node.id, true, &s.node.attrs, s.span,
-                      |v| visit::walk_struct_field(v, s), !s.node.kind.is_unnamed());
+        // FIXME: This is temporary, can't use attributes with tuple variant fields until snapshot
+        let kind = if self.in_enum && s.node.kind.is_unnamed() {
+            AnnProhibited
+        } else {
+            AnnRequired
+        };
+        self.annotate(s.node.id, &s.node.attrs, s.span, kind, |v| {
+            visit::walk_struct_field(v, s);
+        });
     }
 
     fn visit_foreign_item(&mut self, i: &hir::ForeignItem) {
-        self.annotate(i.id, true, &i.attrs, i.span, |_| {}, true);
+        self.annotate(i.id, &i.attrs, i.span, AnnRequired, |v| {
+            visit::walk_foreign_item(v, i);
+        });
+    }
+
+    fn visit_macro_def(&mut self, md: &'v hir::MacroDef) {
+        if md.imported_from.is_none() {
+            self.annotate(md.id, &md.attrs, md.span, AnnRequired, |_| {});
+        }
     }
 }
 
@@ -243,21 +260,21 @@ impl<'tcx> Index<'tcx> {
             index: self,
             parent: None,
             export_map: export_map,
+            in_trait_impl: false,
+            in_enum: false,
         };
-        annotator.annotate(ast::CRATE_NODE_ID, true, &krate.attrs, krate.span,
-                           |v| visit::walk_crate(v, krate), true);
+        annotator.annotate(ast::CRATE_NODE_ID, &krate.attrs, krate.span, AnnRequired,
+                           |v| visit::walk_crate(v, krate));
     }
 
     pub fn new(krate: &Crate) -> Index {
         let mut is_staged_api = false;
         for attr in &krate.attrs {
-            if &attr.name()[..] == "staged_api" {
-                match attr.node.value.node {
-                    ast::MetaWord(_) => {
-                        attr::mark_used(attr);
-                        is_staged_api = true;
-                    }
-                    _ => (/*pass*/)
+            if attr.name() == "staged_api" {
+                if let ast::MetaWord(_) = attr.node.value.node {
+                    attr::mark_used(attr);
+                    is_staged_api = true;
+                    break
                 }
             }
         }

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -739,7 +739,6 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
                                lang_items,
                                stability::Index::new(krate),
                                |tcx| {
-
                                    // passes are timed inside typeck
                                    typeck::check_crate(tcx, trait_map);
 
@@ -756,7 +755,7 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
 
                                    // Do not move this check past lint
                                    time(time_passes, "stability index", || {
-                                       tcx.stability.borrow_mut().build(tcx, krate, &public_items)
+                                       tcx.stability.borrow_mut().build(tcx, krate, &exported_items)
                                    });
 
                                    time(time_passes,

--- a/src/librustc_unicode/char.rs
+++ b/src/librustc_unicode/char.rs
@@ -35,9 +35,11 @@ use core::iter::Iterator;
 use tables::{derived_property, property, general_category, conversions};
 
 // stable reexports
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::char::{MAX, from_u32, from_u32_unchecked, from_digit, EscapeUnicode, EscapeDefault};
 
 // unstable reexports
+#[unstable(feature = "unicode", issue = "27783")]
 pub use tables::UNICODE_VERSION;
 
 /// An iterator over the lowercase mapping of a given character, returned from

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1215,6 +1215,7 @@ fn search_entry_hashed<'a, K: Eq, V>(table: &'a mut RawTable<K,V>, hash: SafeHas
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<K, V, S> PartialEq for HashMap<K, V, S>
     where K: Eq + Hash, V: PartialEq, S: HashState
 {
@@ -1272,6 +1273,7 @@ pub struct Iter<'a, K: 'a, V: 'a> {
 }
 
 // FIXME(#19839) Remove in favor of `#[derive(Clone)]`
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, K, V> Clone for Iter<'a, K, V> {
     fn clone(&self) -> Iter<'a, K, V> {
         Iter {
@@ -1299,6 +1301,7 @@ pub struct Keys<'a, K: 'a, V: 'a> {
 }
 
 // FIXME(#19839) Remove in favor of `#[derive(Clone)]`
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, K, V> Clone for Keys<'a, K, V> {
     fn clone(&self) -> Keys<'a, K, V> {
         Keys {
@@ -1314,6 +1317,7 @@ pub struct Values<'a, K: 'a, V: 'a> {
 }
 
 // FIXME(#19839) Remove in favor of `#[derive(Clone)]`
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, K, V> Clone for Values<'a, K, V> {
     fn clone(&self) -> Values<'a, K, V> {
         Values {

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -901,6 +901,7 @@ impl<T, S> IntoIterator for HashSet<T, S>
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, K> Clone for Iter<'a, K> {
     fn clone(&self) -> Iter<'a, K> { Iter { iter: self.iter.clone() } }
 }
@@ -940,6 +941,7 @@ impl<'a, K> ExactSizeIterator for Drain<'a, K> {
     fn len(&self) -> usize { self.iter.len() }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T, S> Clone for Intersection<'a, T, S> {
     fn clone(&self) -> Intersection<'a, T, S> {
         Intersection { iter: self.iter.clone(), ..*self }
@@ -969,6 +971,7 @@ impl<'a, T, S> Iterator for Intersection<'a, T, S>
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T, S> Clone for Difference<'a, T, S> {
     fn clone(&self) -> Difference<'a, T, S> {
         Difference { iter: self.iter.clone(), ..*self }
@@ -998,6 +1001,7 @@ impl<'a, T, S> Iterator for Difference<'a, T, S>
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T, S> Clone for SymmetricDifference<'a, T, S> {
     fn clone(&self) -> SymmetricDifference<'a, T, S> {
         SymmetricDifference { iter: self.iter.clone() }
@@ -1014,6 +1018,7 @@ impl<'a, T, S> Iterator for SymmetricDifference<'a, T, S>
     fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T, S> Clone for Union<'a, T, S> {
     fn clone(&self) -> Union<'a, T, S> { Union { iter: self.iter.clone() } }
 }

--- a/src/libstd/collections/mod.rs
+++ b/src/libstd/collections/mod.rs
@@ -408,14 +408,20 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::Bound;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::{BinaryHeap, BTreeMap, BTreeSet};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::{LinkedList, VecDeque};
-
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::{binary_heap, btree_map, btree_set};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::{linked_list, vec_deque};
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::hash_map::HashMap;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::hash_set::HashSet;
 
 mod hash;
@@ -423,12 +429,14 @@ mod hash;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod hash_map {
     //! A hashmap
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::hash::map::*;
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod hash_set {
     //! A hashset
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::hash::set::*;
 }
 

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -324,6 +324,7 @@ impl IntoInner<fs_imp::File> for File {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Debug for File {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.inner.fmt(f)
@@ -1230,6 +1231,7 @@ pub trait PathExt {
 }
 
 #[allow(deprecated)]
+#[unstable(feature = "path_ext_deprecated", issue = "27725")]
 impl PathExt for Path {
     fn metadata(&self) -> io::Result<Metadata> { metadata(self) }
     fn symlink_metadata(&self) -> io::Result<Metadata> { symlink_metadata(self) }

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -485,6 +485,7 @@ impl<W: Write + Seek> Seek for BufWriter<W> {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<W: Write> Drop for BufWriter<W> {
     fn drop(&mut self) {
         if self.inner.is_some() {

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -255,13 +255,21 @@ use string::String;
 use str;
 use vec::Vec;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::buffered::{BufReader, BufWriter, LineWriter};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::buffered::IntoInnerError;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::cursor::Cursor;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::error::{Result, Error, ErrorKind};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::util::{copy, sink, Sink, empty, Empty, repeat, Repeat};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::stdio::{stdin, stdout, stderr, _print, Stdin, Stdout, Stderr};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::stdio::{StdoutLock, StderrLock, StdinLock};
+#[unstable(feature = "libstd_io_internals", issue = "0")]
 #[doc(no_inline, hidden)]
 pub use self::stdio::{set_panic, set_print};
 

--- a/src/libstd/io/prelude.rs
+++ b/src/libstd/io/prelude.rs
@@ -20,6 +20,8 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use super::{Read, Write, BufRead, Seek};
 #[allow(deprecated)]
+#[unstable(feature = "path_ext_deprecated", issue = "27725")]
 pub use fs::PathExt;

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -303,36 +303,63 @@ extern crate libc;
 
 // NB: These reexports are in the order they should be listed in rustdoc
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::any;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::cell;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::clone;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::cmp;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::convert;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::default;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::hash;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::intrinsics;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::iter;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::marker;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::mem;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::ops;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::ptr;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::raw;
+#[stable(feature = "rust1", since = "1.0.0")]
 #[allow(deprecated)]
 pub use core::simd;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::result;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::option;
+
 pub mod error;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use alloc::boxed;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use alloc::rc;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::borrow;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::fmt;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::slice;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::str;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::string;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::vec;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use rustc_unicode::char;
 
 /* Exported macros */
@@ -353,16 +380,26 @@ pub mod prelude;
 // doc pages are inlined from the public re-exports of core_collections::{slice,
 // str} above.
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::isize;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::i8;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::i16;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::i32;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::i64;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::usize;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::u8;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::u16;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::u32;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::u64;
 
 #[path = "num/f32.rs"]   pub mod f32;

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -259,6 +259,7 @@ pub mod builtin {
     /// assert_eq!(s, format!("hello {}", "world"));
     ///
     /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[macro_export]
     macro_rules! format_args { ($fmt:expr, $($args:tt)*) => ({
         /* compiler built-in */
@@ -279,6 +280,7 @@ pub mod builtin {
     /// let path: &'static str = env!("PATH");
     /// println!("the $PATH variable at the time of compiling was: {}", path);
     /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[macro_export]
     macro_rules! env { ($name:expr) => ({ /* compiler built-in */ }) }
 
@@ -298,6 +300,7 @@ pub mod builtin {
     /// let key: Option<&'static str> = option_env!("SECRET_KEY");
     /// println!("the secret key might be: {:?}", key);
     /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[macro_export]
     macro_rules! option_env { ($name:expr) => ({ /* compiler built-in */ }) }
 
@@ -322,6 +325,7 @@ pub mod builtin {
     /// println!("{}", f());
     /// # }
     /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[macro_export]
     macro_rules! concat_idents {
         ($($e:ident),*) => ({ /* compiler built-in */ })
@@ -342,6 +346,7 @@ pub mod builtin {
     /// let s = concat!("test", 10, 'b', true);
     /// assert_eq!(s, "test10btrue");
     /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[macro_export]
     macro_rules! concat { ($($e:expr),*) => ({ /* compiler built-in */ }) }
 
@@ -357,6 +362,7 @@ pub mod builtin {
     /// let current_line = line!();
     /// println!("defined on line: {}", current_line);
     /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[macro_export]
     macro_rules! line { () => ({ /* compiler built-in */ }) }
 
@@ -372,6 +378,7 @@ pub mod builtin {
     /// let current_col = column!();
     /// println!("defined on column: {}", current_col);
     /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[macro_export]
     macro_rules! column { () => ({ /* compiler built-in */ }) }
 
@@ -388,6 +395,7 @@ pub mod builtin {
     /// let this_file = file!();
     /// println!("defined in file: {}", this_file);
     /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[macro_export]
     macro_rules! file { () => ({ /* compiler built-in */ }) }
 
@@ -403,6 +411,7 @@ pub mod builtin {
     /// let one_plus_one = stringify!(1 + 1);
     /// assert_eq!(one_plus_one, "1 + 1");
     /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[macro_export]
     macro_rules! stringify { ($t:tt) => ({ /* compiler built-in */ }) }
 
@@ -417,6 +426,7 @@ pub mod builtin {
     /// ```rust,ignore
     /// let secret_key = include_str!("secret-key.ascii");
     /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[macro_export]
     macro_rules! include_str { ($file:expr) => ({ /* compiler built-in */ }) }
 
@@ -431,6 +441,7 @@ pub mod builtin {
     /// ```rust,ignore
     /// let secret_key = include_bytes!("secret-key.bin");
     /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[macro_export]
     macro_rules! include_bytes { ($file:expr) => ({ /* compiler built-in */ }) }
 
@@ -451,6 +462,7 @@ pub mod builtin {
     ///
     /// test::foo();
     /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[macro_export]
     macro_rules! module_path { () => ({ /* compiler built-in */ }) }
 
@@ -472,6 +484,7 @@ pub mod builtin {
     ///     "unix-directory"
     /// };
     /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[macro_export]
     macro_rules! cfg { ($cfg:tt) => ({ /* compiler built-in */ }) }
 
@@ -486,6 +499,7 @@ pub mod builtin {
     ///     include!("/path/to/a/file")
     /// }
     /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[macro_export]
     macro_rules! include { ($cfg:tt) => ({ /* compiler built-in */ }) }
 }

--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -448,6 +448,7 @@ impl ToSocketAddrs for str {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T: ToSocketAddrs + ?Sized> ToSocketAddrs for &'a T {
     type Iter = T::Iter;
     fn to_socket_addrs(&self) -> io::Result<T::Iter> {

--- a/src/libstd/net/mod.rs
+++ b/src/libstd/net/mod.rs
@@ -17,10 +17,15 @@ use prelude::v1::*;
 use io::{self, Error, ErrorKind};
 use sys_common::net as net_imp;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::ip::{IpAddr, Ipv4Addr, Ipv6Addr, Ipv6MulticastScope};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::addr::{SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::tcp::{TcpStream, TcpListener, Incoming};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::udp::UdpSocket;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::parser::AddrParseError;
 
 mod ip;

--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -219,6 +219,7 @@ impl IntoInner<net_imp::TcpStream> for TcpStream {
     fn into_inner(self) -> net_imp::TcpStream { self.0 }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Debug for TcpStream {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
@@ -301,6 +302,7 @@ impl IntoInner<net_imp::TcpListener> for TcpListener {
     fn into_inner(self) -> net_imp::TcpListener { self.0 }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Debug for TcpListener {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -153,6 +153,7 @@ impl IntoInner<net_imp::UdpSocket> for UdpSocket {
     fn into_inner(self) -> net_imp::UdpSocket { self.0 }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Debug for UdpSocket {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -20,10 +20,15 @@ use intrinsics;
 use libc::c_int;
 use num::{FpCategory, ParseFloatError};
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::f32::{RADIX, MANTISSA_DIGITS, DIGITS, EPSILON};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::f32::{MIN_EXP, MAX_EXP, MIN_10_EXP};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::f32::{MAX_10_EXP, NAN, INFINITY, NEG_INFINITY};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::f32::{MIN, MIN_POSITIVE, MAX};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::f32::consts;
 
 #[allow(dead_code)]

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -20,10 +20,15 @@ use intrinsics;
 use libc::c_int;
 use num::{FpCategory, ParseFloatError};
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::f64::{RADIX, MANTISSA_DIGITS, DIGITS, EPSILON};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::f64::{MIN_EXP, MAX_EXP, MIN_10_EXP};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::f64::{MAX_10_EXP, NAN, INFINITY, NEG_INFINITY};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::f64::{MIN, MIN_POSITIVE, MAX};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::f64::consts;
 
 #[allow(dead_code)]

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -16,8 +16,11 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 #![allow(missing_docs)]
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::num::{Zero, One};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::num::{FpCategory, ParseIntError, ParseFloatError};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::num::{wrapping, Wrapping};
 
 #[cfg(test)] use cmp::PartialEq;

--- a/src/libstd/os/android/mod.rs
+++ b/src/libstd/os/android/mod.rs
@@ -14,7 +14,8 @@
 
 pub mod raw;
 
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub mod fs {
-    #![stable(feature = "raw_ext", since = "1.1.0")]
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub use sys::fs::MetadataExt;
 }

--- a/src/libstd/os/android/raw.rs
+++ b/src/libstd/os/android/raw.rs
@@ -13,6 +13,7 @@
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
 #[doc(inline)]
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub use self::arch::{dev_t, mode_t, blkcnt_t, blksize_t, ino_t, nlink_t, off_t, stat, time_t};
 
 #[cfg(any(target_arch = "arm", target_arch = "x86"))]

--- a/src/libstd/os/bitrig/mod.rs
+++ b/src/libstd/os/bitrig/mod.rs
@@ -14,7 +14,8 @@
 
 pub mod raw;
 
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub mod fs {
-    #![stable(feature = "raw_ext", since = "1.1.0")]
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub use sys::fs::MetadataExt;
 }

--- a/src/libstd/os/dragonfly/mod.rs
+++ b/src/libstd/os/dragonfly/mod.rs
@@ -14,7 +14,8 @@
 
 pub mod raw;
 
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub mod fs {
-    #![stable(feature = "raw_ext", since = "1.1.0")]
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub use sys::fs::MetadataExt;
 }

--- a/src/libstd/os/freebsd/mod.rs
+++ b/src/libstd/os/freebsd/mod.rs
@@ -14,7 +14,8 @@
 
 pub mod raw;
 
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub mod fs {
-    #![stable(feature = "raw_ext", since = "1.1.0")]
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub use sys::fs::MetadataExt;
 }

--- a/src/libstd/os/freebsd/raw.rs
+++ b/src/libstd/os/freebsd/raw.rs
@@ -22,6 +22,7 @@
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type fflags_t = u32;
 
 #[doc(inline)]
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub use self::arch::{stat, time_t};
 
 #[cfg(target_arch = "x86")]

--- a/src/libstd/os/ios/mod.rs
+++ b/src/libstd/os/ios/mod.rs
@@ -14,7 +14,8 @@
 
 pub mod raw;
 
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub mod fs {
-    #![stable(feature = "raw_ext", since = "1.1.0")]
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub use sys::fs::MetadataExt;
 }

--- a/src/libstd/os/linux/mod.rs
+++ b/src/libstd/os/linux/mod.rs
@@ -14,7 +14,8 @@
 
 pub mod raw;
 
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub mod fs {
-    #![stable(feature = "raw_ext", since = "1.1.0")]
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub use sys::fs::MetadataExt;
 }

--- a/src/libstd/os/linux/raw.rs
+++ b/src/libstd/os/linux/raw.rs
@@ -16,6 +16,7 @@
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
 
 #[doc(inline)]
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub use self::arch::{off_t, ino_t, nlink_t, blksize_t, blkcnt_t, stat, time_t};
 
 #[cfg(any(target_arch = "x86",

--- a/src/libstd/os/macos/mod.rs
+++ b/src/libstd/os/macos/mod.rs
@@ -14,7 +14,8 @@
 
 pub mod raw;
 
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub mod fs {
-    #![stable(feature = "raw_ext", since = "1.1.0")]
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub use sys::fs::MetadataExt;
 }

--- a/src/libstd/os/mod.rs
+++ b/src/libstd/os/mod.rs
@@ -13,8 +13,12 @@
 #![stable(feature = "os", since = "1.0.0")]
 #![allow(missing_docs, bad_style)]
 
-#[cfg(unix)]    pub use sys::ext as unix;
-#[cfg(windows)] pub use sys::ext as windows;
+#[cfg(unix)]
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use sys::ext as unix;
+#[cfg(windows)]
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use sys::ext as windows;
 
 #[cfg(target_os = "android")]   pub mod android;
 #[cfg(target_os = "bitrig")]    pub mod bitrig;

--- a/src/libstd/os/nacl/mod.rs
+++ b/src/libstd/os/nacl/mod.rs
@@ -14,7 +14,8 @@
 
 pub mod raw;
 
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub mod fs {
-    #![stable(feature = "raw_ext", since = "1.1.0")]
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub use sys::fs::MetadataExt;
 }

--- a/src/libstd/os/netbsd/mod.rs
+++ b/src/libstd/os/netbsd/mod.rs
@@ -14,7 +14,8 @@
 
 pub mod raw;
 
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub mod fs {
-    #![stable(feature = "raw_ext", since = "1.1.0")]
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub use sys::fs::MetadataExt;
 }

--- a/src/libstd/os/openbsd/mod.rs
+++ b/src/libstd/os/openbsd/mod.rs
@@ -14,7 +14,8 @@
 
 pub mod raw;
 
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub mod fs {
-    #![stable(feature = "raw_ext", since = "1.1.0")]
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub use sys::fs::MetadataExt;
 }

--- a/src/libstd/sync/barrier.rs
+++ b/src/libstd/sync/barrier.rs
@@ -46,6 +46,7 @@ struct BarrierState {
 ///
 /// Currently this opaque structure only has one method, `.is_leader()`. Only
 /// one thread will receive a result that will return `true` from this function.
+#[stable(feature = "rust1", since = "1.0.0")]
 pub struct BarrierWaitResult(bool);
 
 impl Barrier {

--- a/src/libstd/sync/mod.rs
+++ b/src/libstd/sync/mod.rs
@@ -17,17 +17,28 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use alloc::arc::{Arc, Weak};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::sync::atomic;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::barrier::{Barrier, BarrierWaitResult};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::condvar::{Condvar, StaticCondvar, WaitTimeoutResult, CONDVAR_INIT};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::mutex::MUTEX_INIT;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::mutex::{Mutex, MutexGuard, StaticMutex};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::once::{Once, ONCE_INIT};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use sys_common::poison::{PoisonError, TryLockError, TryLockResult, LockResult};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::rwlock::{RwLockReadGuard, RwLockWriteGuard};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::rwlock::{RwLock, StaticRwLock, RW_LOCK_INIT};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::semaphore::{Semaphore, SemaphoreGuard};
 
 pub mod mpsc;

--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -272,6 +272,7 @@ use mem;
 use cell::UnsafeCell;
 use marker::Reflect;
 
+#[unstable(feature = "mpsc_select", issue = "27800")]
 pub use self::select::{Select, Handle};
 use self::select::StartResult;
 use self::select::StartResult::*;
@@ -295,6 +296,7 @@ pub struct Receiver<T> {
 
 // The receiver port can be sent from place to place, so long as it
 // is not used to receive non-sendable things.
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Send> Send for Receiver<T> { }
 
 /// An iterator over messages on a receiver, this iterator will block
@@ -322,6 +324,7 @@ pub struct Sender<T> {
 
 // The send port can be sent from place to place, so long as it
 // is not used to send non-sendable things.
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Send> Send for Sender<T> { }
 
 /// The sending-half of Rust's synchronous channel type. This half can only be
@@ -331,8 +334,10 @@ pub struct SyncSender<T> {
     inner: Arc<UnsafeCell<sync::Packet<T>>>,
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Send> Send for SyncSender<T> {}
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T> !Sync for SyncSender<T> {}
 
 /// An error returned from the `send` function on channels.
@@ -954,6 +959,7 @@ impl<'a, T> IntoIterator for &'a Receiver<T> {
     fn into_iter(self) -> Iter<'a, T> { self.iter() }
 }
 
+#[stable(feature = "receiver_into_iter", since = "1.1.0")]
 impl<T> Iterator for IntoIter<T> {
     type Item = T;
     fn next(&mut self) -> Option<T> { self.rx.recv().ok() }

--- a/src/libstd/sync/mpsc/mpsc_queue.rs
+++ b/src/libstd/sync/mpsc/mpsc_queue.rs
@@ -133,7 +133,6 @@ impl<T> Queue<T> {
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<T> Drop for Queue<T> {
     fn drop(&mut self) {
         unsafe {

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -125,8 +125,9 @@ pub struct Mutex<T: ?Sized> {
 
 // these are the only places where `T: Send` matters; all other
 // functionality works fine on a single thread.
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: ?Sized + Send> Send for Mutex<T> { }
-
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: ?Sized + Send> Sync for Mutex<T> { }
 
 /// The static mutex type is provided to allow for static allocation of mutexes.
@@ -175,6 +176,7 @@ pub struct MutexGuard<'a, T: ?Sized + 'a> {
     __poison: poison::Guard,
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T: ?Sized> !marker::Send for MutexGuard<'a, T> {}
 
 /// Static initialization of a mutex. This constant can be used to initialize

--- a/src/libstd/sync/rwlock.rs
+++ b/src/libstd/sync/rwlock.rs
@@ -71,7 +71,9 @@ pub struct RwLock<T: ?Sized> {
     data: UnsafeCell<T>,
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: ?Sized + Send + Sync> Send for RwLock<T> {}
+#[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: ?Sized + Send + Sync> Sync for RwLock<T> {}
 
 /// Structure representing a statically allocated RwLock.
@@ -122,6 +124,7 @@ pub struct RwLockReadGuard<'a, T: ?Sized + 'a> {
     __data: &'a UnsafeCell<T>,
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T: ?Sized> !marker::Send for RwLockReadGuard<'a, T> {}
 
 /// RAII structure used to release the exclusive write access of a lock when
@@ -134,6 +137,7 @@ pub struct RwLockWriteGuard<'a, T: ?Sized + 'a> {
     __poison: poison::Guard,
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T: ?Sized> !marker::Send for RwLockWriteGuard<'a, T> {}
 
 impl<T> RwLock<T> {

--- a/src/libstd/sys/common/poison.rs
+++ b/src/libstd/sys/common/poison.rs
@@ -110,6 +110,7 @@ impl<T> fmt::Display for PoisonError<T> {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Send + Reflect> Error for PoisonError<T> {
     fn description(&self) -> &str {
         "poisoned lock: another task failed inside"
@@ -139,6 +140,7 @@ impl<T> PoisonError<T> {
     pub fn get_mut(&mut self) -> &mut T { &mut self.guard }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T> From<PoisonError<T>> for TryLockError<T> {
     fn from(err: PoisonError<T>) -> TryLockError<T> {
         TryLockError::Poisoned(err)
@@ -162,6 +164,7 @@ impl<T: Send + Reflect> fmt::Display for TryLockError<T> {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Send + Reflect> Error for TryLockError<T> {
     fn description(&self) -> &str {
         match *self {

--- a/src/libstd/sys/common/unwind/gcc.rs
+++ b/src/libstd/sys/common/unwind/gcc.rs
@@ -253,12 +253,14 @@ pub mod eh_frame_registry {
     }
     #[cfg(not(test))]
     #[no_mangle]
+    #[unstable(feature = "libstd_sys_internals", issue = "0")]
     pub unsafe extern fn rust_eh_register_frames(eh_frame_begin: *const u8,
                                                  object: *mut u8) {
         __register_frame_info(eh_frame_begin, object);
     }
     #[cfg(not(test))]
     #[no_mangle]
+    #[unstable(feature = "libstd_sys_internals", issue = "0")]
     pub  unsafe extern fn rust_eh_unregister_frames(eh_frame_begin: *const u8,
                                                    object: *mut u8) {
         __deregister_frame_info(eh_frame_begin, object);

--- a/src/libstd/sys/common/unwind/mod.rs
+++ b/src/libstd/sys/common/unwind/mod.rs
@@ -203,6 +203,9 @@ pub extern fn rust_begin_unwind(msg: fmt::Arguments,
 /// site as much as possible (so that `panic!()` has as low an impact
 /// on (e.g.) the inlining of other functions as possible), by moving
 /// the actual formatting into this shared place.
+#[unstable(feature = "libstd_sys_internals",
+           reason = "used by the panic! macro",
+           issue = "0")]
 #[inline(never)] #[cold]
 pub fn begin_unwind_fmt(msg: fmt::Arguments, file_line: &(&'static str, u32)) -> ! {
     use fmt::Write;
@@ -218,6 +221,9 @@ pub fn begin_unwind_fmt(msg: fmt::Arguments, file_line: &(&'static str, u32)) ->
 }
 
 /// This is the entry point of unwinding for panic!() and assert!().
+#[unstable(feature = "libstd_sys_internals",
+           reason = "used by the panic! macro",
+           issue = "0")]
 #[inline(never)] #[cold] // avoid code bloat at the call sites as much as possible
 pub fn begin_unwind<M: Any + Send>(msg: M, file_line: &(&'static str, u32)) -> ! {
     // Note that this should be the only allocation performed in this code path.

--- a/src/libstd/sys/common/wtf8.rs
+++ b/src/libstd/sys/common/wtf8.rs
@@ -715,6 +715,7 @@ impl<'a> Iterator for Wtf8CodePoints<'a> {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Clone)]
 pub struct EncodeWide<'a> {
     code_points: Wtf8CodePoints<'a>,
@@ -722,6 +723,7 @@ pub struct EncodeWide<'a> {
 }
 
 // Copied from libunicode/u_str.rs
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> Iterator for EncodeWide<'a> {
     type Item = u16;
 

--- a/src/libstd/sys/unix/ext/fs.rs
+++ b/src/libstd/sys/unix/ext/fs.rs
@@ -153,6 +153,7 @@ pub trait MetadataExt {
     fn blocks(&self) -> raw::blkcnt_t;
 }
 
+#[stable(feature = "metadata_ext", since = "1.1.0")]
 impl MetadataExt for fs::Metadata {
     fn dev(&self) -> raw::dev_t { self.as_raw_stat().st_dev as raw::dev_t }
     fn ino(&self) -> raw::ino_t { self.as_raw_stat().st_ino as raw::ino_t }
@@ -211,6 +212,7 @@ pub trait DirEntryExt {
     fn ino(&self) -> raw::ino_t;
 }
 
+#[stable(feature = "dir_entry_ext", since = "1.1.0")]
 impl DirEntryExt for fs::DirEntry {
     fn ino(&self) -> raw::ino_t { self.as_inner().ino() }
 }
@@ -253,6 +255,8 @@ pub trait DirBuilderExt {
     fn mode(&mut self, mode: raw::mode_t) -> &mut Self;
 }
 
+#[unstable(feature = "dir_builder", reason = "recently added API",
+           issue = "27710")]
 impl DirBuilderExt for fs::DirBuilder {
     fn mode(&mut self, mode: raw::mode_t) -> &mut fs::DirBuilder {
         self.as_inner_mut().set_mode(mode);

--- a/src/libstd/sys/unix/ext/mod.rs
+++ b/src/libstd/sys/unix/ext/mod.rs
@@ -40,13 +40,13 @@ pub mod raw;
 /// Includes all extension traits, and some important type definitions.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod prelude {
-    #[doc(no_inline)]
+    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::io::{RawFd, AsRawFd, FromRawFd, IntoRawFd};
     #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::ffi::{OsStrExt, OsStringExt};
-    #[doc(no_inline)]
+    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::fs::{PermissionsExt, OpenOptionsExt, MetadataExt, FileTypeExt};
-    #[doc(no_inline)]
+    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::fs::{DirEntryExt};
     #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::process::{CommandExt, ExitStatusExt};

--- a/src/libstd/sys/unix/ext/process.rs
+++ b/src/libstd/sys/unix/ext/process.rs
@@ -107,18 +107,21 @@ impl AsRawFd for process::ChildStderr {
     }
 }
 
+#[stable(feature = "process_extensions", since = "1.2.0")]
 impl IntoRawFd for process::ChildStdin {
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_fd().into_raw()
     }
 }
 
+#[stable(feature = "process_extensions", since = "1.2.0")]
 impl IntoRawFd for process::ChildStdout {
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_fd().into_raw()
     }
 }
 
+#[stable(feature = "process_extensions", since = "1.2.0")]
 impl IntoRawFd for process::ChildStderr {
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_fd().into_raw()

--- a/src/libstd/sys/unix/ext/raw.rs
+++ b/src/libstd/sys/unix/ext/raw.rs
@@ -17,6 +17,8 @@
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type pid_t = i32;
 
 #[doc(inline)]
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub use sys::platform::raw::{dev_t, ino_t, mode_t, nlink_t, off_t, blksize_t};
 #[doc(inline)]
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub use sys::platform::raw::{blkcnt_t, time_t};

--- a/src/libstd/sys/unix/time.rs
+++ b/src/libstd/sys/unix/time.rs
@@ -47,6 +47,7 @@ mod inner {
         }
     }
 
+    #[unstable(feature = "libstd_sys_internals", issue = "0")]
     impl<'a> Sub for &'a SteadyTime {
         type Output = Duration;
 

--- a/src/libstd/sys/unix/time.rs
+++ b/src/libstd/sys/unix/time.rs
@@ -98,6 +98,7 @@ mod inner {
         }
     }
 
+    #[unstable(feature = "libstd_sys_internals", issue = "0")]
     impl<'a> Sub for &'a SteadyTime {
         type Output = Duration;
 

--- a/src/libstd/sys/windows/ext/ffi.rs
+++ b/src/libstd/sys/windows/ext/ffi.rs
@@ -17,6 +17,7 @@ use sys::os_str::Buf;
 use sys_common::wtf8::Wtf8Buf;
 use sys_common::{FromInner, AsInner};
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use sys_common::wtf8::EncodeWide;
 
 /// Windows-specific extensions to `OsString`.

--- a/src/libstd/sys/windows/ext/fs.rs
+++ b/src/libstd/sys/windows/ext/fs.rs
@@ -49,6 +49,9 @@ pub trait OpenOptionsExt {
     fn share_mode(&mut self, val: u32) -> &mut Self;
 }
 
+#[unstable(feature = "open_options_ext",
+           reason = "may require more thought/methods",
+           issue = "27720")]
 impl OpenOptionsExt for OpenOptions {
     fn desired_access(&mut self, access: u32) -> &mut OpenOptions {
         self.as_inner_mut().desired_access(access); self

--- a/src/libstd/sys/windows/ext/mod.rs
+++ b/src/libstd/sys/windows/ext/mod.rs
@@ -27,12 +27,12 @@ pub mod process;
 /// Includes all extension traits, and some important type definitions.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod prelude {
-    #[doc(no_inline)]
+    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::io::{RawSocket, RawHandle, AsRawSocket, AsRawHandle};
-    #[doc(no_inline)]
+    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::io::{FromRawSocket, FromRawHandle, IntoRawSocket, IntoRawHandle};
     #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::ffi::{OsStrExt, OsStringExt};
-    #[doc(no_inline)]
+    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::fs::{OpenOptionsExt, MetadataExt};
 }

--- a/src/libstd/sys/windows/ext/process.rs
+++ b/src/libstd/sys/windows/ext/process.rs
@@ -32,6 +32,7 @@ impl AsRawHandle for process::Child {
     }
 }
 
+#[stable(feature = "process_extensions", since = "1.2.0")]
 impl IntoRawHandle for process::Child {
     fn into_raw_handle(self) -> RawHandle {
         self.into_inner().into_handle().into_raw() as *mut _
@@ -59,18 +60,21 @@ impl AsRawHandle for process::ChildStderr {
     }
 }
 
+#[stable(feature = "process_extensions", since = "1.2.0")]
 impl IntoRawHandle for process::ChildStdin {
     fn into_raw_handle(self) -> RawHandle {
         self.into_inner().into_handle().into_raw() as *mut _
     }
 }
 
+#[stable(feature = "process_extensions", since = "1.2.0")]
 impl IntoRawHandle for process::ChildStdout {
     fn into_raw_handle(self) -> RawHandle {
         self.into_inner().into_handle().into_raw() as *mut _
     }
 }
 
+#[stable(feature = "process_extensions", since = "1.2.0")]
 impl IntoRawHandle for process::ChildStderr {
     fn into_raw_handle(self) -> RawHandle {
         self.into_inner().into_handle().into_raw() as *mut _

--- a/src/libstd/sys/windows/time.rs
+++ b/src/libstd/sys/windows/time.rs
@@ -39,6 +39,7 @@ fn frequency() -> c::LARGE_INTEGER {
     }
 }
 
+#[unstable(feature = "libstd_sys_internals", issue = "0")]
 impl<'a> Sub for &'a SteadyTime {
     type Output = Duration;
 

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -189,7 +189,9 @@ pub use self::local::{LocalKey, LocalKeyState};
            issue = "27715")]
 pub use self::scoped_tls::ScopedKey;
 
+#[unstable(feature = "libstd_thread_internals", issue = "0")]
 #[doc(hidden)] pub use self::local::__KeyInner as __LocalKeyInner;
+#[unstable(feature = "libstd_thread_internals", issue = "0")]
 #[doc(hidden)] pub use self::scoped_tls::__KeyInner as __ScopedKeyInner;
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/libstd/thread/scoped_tls.rs
+++ b/src/libstd/thread/scoped_tls.rs
@@ -65,6 +65,9 @@ pub struct ScopedKey<T:'static> { inner: fn() -> &'static imp::KeyInner<T> }
 ///
 /// See [ScopedKey documentation](thread/struct.ScopedKey.html) for more
 /// information.
+#[unstable(feature = "thread_local_internals",
+           reason = "should not be necessary",
+           issue = "0")]
 #[macro_export]
 #[allow_internal_unstable]
 macro_rules! scoped_thread_local {
@@ -80,7 +83,8 @@ macro_rules! scoped_thread_local {
 
 #[doc(hidden)]
 #[unstable(feature = "thread_local_internals",
-           reason = "should not be necessary")]
+           reason = "should not be necessary",
+           issue = "0")]
 #[macro_export]
 #[allow_internal_unstable]
 #[cfg(no_elf_tls)]
@@ -95,7 +99,8 @@ macro_rules! __scoped_thread_local_inner {
 
 #[doc(hidden)]
 #[unstable(feature = "thread_local_internals",
-           reason = "should not be necessary")]
+           reason = "should not be necessary",
+           issue = "0")]
 #[macro_export]
 #[allow_internal_unstable]
 #[cfg(not(no_elf_tls))]

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -102,6 +102,7 @@ impl Duration {
     pub fn subsec_nanos(&self) -> u32 { self.nanos }
 }
 
+#[stable(feature = "duration", since = "1.3.0")]
 impl Add for Duration {
     type Output = Duration;
 
@@ -118,6 +119,7 @@ impl Add for Duration {
     }
 }
 
+#[stable(feature = "duration", since = "1.3.0")]
 impl Sub for Duration {
     type Output = Duration;
 
@@ -136,6 +138,7 @@ impl Sub for Duration {
     }
 }
 
+#[stable(feature = "duration", since = "1.3.0")]
 impl Mul<u32> for Duration {
     type Output = Duration;
 
@@ -152,6 +155,7 @@ impl Mul<u32> for Duration {
     }
 }
 
+#[stable(feature = "duration", since = "1.3.0")]
 impl Div<u32> for Duration {
     type Output = Duration;
 

--- a/src/libstd/time/mod.rs
+++ b/src/libstd/time/mod.rs
@@ -12,6 +12,7 @@
 
 #![stable(feature = "time", since = "1.3.0")]
 
+#[stable(feature = "time", since = "1.3.0")]
 pub use self::duration::Duration;
 
 mod duration;

--- a/src/test/auxiliary/inherited_stability.rs
+++ b/src/test/auxiliary/inherited_stability.rs
@@ -20,6 +20,7 @@ pub fn stable() {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod stable_mod {
+    #[unstable(feature = "test_feature", issue = "0")]
     pub fn unstable() {}
 
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -37,6 +38,7 @@ pub mod unstable_mod {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Stable {
+    #[unstable(feature = "test_feature", issue = "0")]
     fn unstable(&self);
 
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/test/auxiliary/internal_unstable.rs
+++ b/src/test/auxiliary/internal_unstable.rs
@@ -33,12 +33,14 @@ pub struct Bar {
     pub x: u8
 }
 
+#[stable(feature = "stable", since = "1.0.0")]
 #[allow_internal_unstable]
 #[macro_export]
 macro_rules! call_unstable_allow {
     () => { $crate::unstable() }
 }
 
+#[stable(feature = "stable", since = "1.0.0")]
 #[allow_internal_unstable]
 #[macro_export]
 macro_rules! construct_unstable_allow {
@@ -47,29 +49,34 @@ macro_rules! construct_unstable_allow {
     }
 }
 
+#[stable(feature = "stable", since = "1.0.0")]
 #[allow_internal_unstable]
 #[macro_export]
 macro_rules! call_method_allow {
     ($e: expr) => { $e.method() }
 }
 
+#[stable(feature = "stable", since = "1.0.0")]
 #[allow_internal_unstable]
 #[macro_export]
 macro_rules! access_field_allow {
     ($e: expr) => { $e.x }
 }
 
+#[stable(feature = "stable", since = "1.0.0")]
 #[allow_internal_unstable]
 #[macro_export]
 macro_rules! pass_through_allow {
     ($e: expr) => { $e }
 }
 
+#[stable(feature = "stable", since = "1.0.0")]
 #[macro_export]
 macro_rules! call_unstable_noallow {
     () => { $crate::unstable() }
 }
 
+#[stable(feature = "stable", since = "1.0.0")]
 #[macro_export]
 macro_rules! construct_unstable_noallow {
     ($e: expr) => {
@@ -77,16 +84,19 @@ macro_rules! construct_unstable_noallow {
     }
 }
 
+#[stable(feature = "stable", since = "1.0.0")]
 #[macro_export]
 macro_rules! call_method_noallow {
     ($e: expr) => { $e.method() }
 }
 
+#[stable(feature = "stable", since = "1.0.0")]
 #[macro_export]
 macro_rules! access_field_noallow {
     ($e: expr) => { $e.x }
 }
 
+#[stable(feature = "stable", since = "1.0.0")]
 #[macro_export]
 macro_rules! pass_through_noallow {
     ($e: expr) => { $e }

--- a/src/test/auxiliary/lint_stability.rs
+++ b/src/test/auxiliary/lint_stability.rs
@@ -93,6 +93,7 @@ pub trait Trait {
     fn trait_stable_text(&self) {}
 }
 
+#[stable(feature = "test_feature", since = "1.0.0")]
 impl Trait for MethodTester {}
 
 #[unstable(feature = "test_feature", issue = "0")]
@@ -154,16 +155,19 @@ pub struct UnstableTupleStruct(#[stable(feature = "rust1", since = "1.0.0")] pub
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct StableTupleStruct(#[stable(feature = "rust1", since = "1.0.0")] pub isize);
 
+#[stable(feature = "test_feature", since = "1.0.0")]
 #[macro_export]
 macro_rules! macro_test {
     () => (deprecated());
 }
 
+#[stable(feature = "test_feature", since = "1.0.0")]
 #[macro_export]
 macro_rules! macro_test_arg {
     ($func:expr) => ($func);
 }
 
+#[stable(feature = "test_feature", since = "1.0.0")]
 #[macro_export]
 macro_rules! macro_test_arg_nested {
     ($func:ident) => (macro_test_arg!($func()));

--- a/src/test/compile-fail/issue-17337.rs
+++ b/src/test/compile-fail/issue-17337.rs
@@ -12,6 +12,8 @@
 #![staged_api]
 #![deny(deprecated)]
 
+#![unstable(feature = "test_feature", issue = "0")]
+
 struct Foo;
 
 impl Foo {

--- a/src/test/compile-fail/lint-stability-fields.rs
+++ b/src/test/compile-fail/lint-stability-fields.rs
@@ -14,6 +14,8 @@
 #![feature(staged_api)]
 #![staged_api]
 
+#![stable(feature = "rust1", since = "1.0.0")]
+
 mod cross_crate {
     extern crate lint_stability_fields;
 

--- a/src/test/compile-fail/lint-stability.rs
+++ b/src/test/compile-fail/lint-stability.rs
@@ -18,6 +18,8 @@
 #![feature(staged_api)]
 #![staged_api]
 
+#![stable(feature = "rust1", since = "1.0.0")]
+
 #[macro_use]
 extern crate lint_stability;
 
@@ -127,7 +129,9 @@ mod cross_crate {
         <Foo>::trait_stable_text(&foo);
         <Foo as Trait>::trait_stable_text(&foo);
 
-        let _ = DeprecatedStruct { i: 0 }; //~ ERROR use of deprecated item
+        let _ = DeprecatedStruct { //~ ERROR use of deprecated item
+            i: 0 //~ ERROR use of deprecated item
+        };
         let _ = DeprecatedUnstableStruct {
             //~^ ERROR use of deprecated item
             //~^^ ERROR use of unstable library feature
@@ -475,7 +479,7 @@ mod this_crate {
     #[deprecated(since = "1.0.0", reason = "text")]
     fn test_fn_body() {
         fn fn_in_body() {}
-        fn_in_body();
+        fn_in_body(); //~ ERROR use of deprecated item: text
     }
 
     impl MethodTester {
@@ -483,7 +487,7 @@ mod this_crate {
         #[deprecated(since = "1.0.0", reason = "text")]
         fn test_method_body(&self) {
             fn fn_in_body() {}
-            fn_in_body();
+            fn_in_body(); //~ ERROR use of deprecated item: text
         }
     }
 

--- a/src/test/compile-fail/missing-stability.rs
+++ b/src/test/compile-fail/missing-stability.rs
@@ -14,6 +14,8 @@
 #![feature(staged_api)]
 #![staged_api]
 
+#![stable(feature = "test_feature", since = "1.0.0")]
+
 pub fn unmarked() {
     //~^ ERROR This node does not have a stability attribute
     ()

--- a/src/test/compile-fail/stability-attribute-sanity-2.rs
+++ b/src/test/compile-fail/stability-attribute-sanity-2.rs
@@ -13,6 +13,8 @@
 #![feature(staged_api)]
 #![staged_api]
 
+#![stable(feature = "test_feature", since = "1.0.0")]
+
 #[stable(feature = "a", feature = "b", since = "1.0.0")] //~ ERROR multiple 'feature' items
 fn f1() { }
 
@@ -21,5 +23,10 @@ fn f2() { }
 
 #[unstable(feature = "a", issue = "no")] //~ ERROR incorrect 'issue'
 fn f3() { }
+
+#[macro_export]
+macro_rules! mac { //~ ERROR This node does not have a stability attribute
+    () => ()
+}
 
 fn main() { }

--- a/src/test/compile-fail/stability-attribute-sanity.rs
+++ b/src/test/compile-fail/stability-attribute-sanity.rs
@@ -13,6 +13,8 @@
 #![feature(staged_api)]
 #![staged_api]
 
+#![stable(feature = "rust1", since = "1.0.0")]
+
 mod bogus_attribute_types_1 {
     #[stable(feature = "a", since = "a", reason)] //~ ERROR unknown meta item 'reason'
     fn f1() { }

--- a/src/test/rustdoc/issue-18199.rs
+++ b/src/test/rustdoc/issue-18199.rs
@@ -14,6 +14,7 @@
 
 /// ```
 /// #![staged_api]
+/// #![unstable(feature="test", issue="18199")]
 /// fn main() {}
 /// ```
 pub fn foo() {}

--- a/src/test/rustdoc/issue-27759.rs
+++ b/src/test/rustdoc/issue-27759.rs
@@ -12,6 +12,8 @@
 #![staged_api]
 #![doc(issue_tracker_base_url = "http://issue_url/")]
 
+#![unstable(feature="test", issue="27759")]
+
 // @has issue_27759/unstable/index.html
 // @has - '<code>test</code>'
 // @has - '<a href="http://issue_url/27759">#27759</a>'


### PR DESCRIPTION
What this patch does:
- Stability annotations are now based on "exported items" supplied by rustc_privacy and not "public items". Exported items are as accessible for external crates as directly public items and should be annotated with stability attributes.
- Trait impls require annotations now.
- Reexports require annotations now.
- Crates themselves didn't require annotations, now they do.
- Exported macros are annotated now, but these annotations are not used yet.
- Some useless annotations are detected and result in errors
- Finally, some small bugs are fixed - deprecation propagates from stable deprecated parents, items in blocks are traversed correctly (fixes https://github.com/rust-lang/rust/issues/29034) + some code cleanup.
