### PR TITLE
Puts capitals and dots in the comments of the rustonomicon.

### DIFF
--- a/src/doc/nomicon/atomics.md
+++ b/src/doc/nomicon/atomics.md
@@ -210,17 +210,17 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 
 fn main() {
-    let lock = Arc::new(AtomicBool::new(false)); // value answers "am I locked?"
+    let lock = Arc::new(AtomicBool::new(false)); // Value answers "am I locked?".
 
     // ... distribute lock to threads somehow ...
 
-    // Try to acquire the lock by setting it to true
+    // Try to acquire the lock by setting it to true.
     while lock.compare_and_swap(false, true, Ordering::Acquire) { }
-    // broke out of the loop, so we successfully acquired the lock!
+    // Broke out of the loop, so we successfully acquired the lock!
 
     // ... scary data accesses ...
 
-    // ok we're done, release the lock
+    // Ok we're done, release the lock.
     lock.store(false, Ordering::Release);
 }
 ```

--- a/src/doc/nomicon/checked-uninit.md
+++ b/src/doc/nomicon/checked-uninit.md
@@ -64,7 +64,7 @@ fn main() {
         println!("{}", x);
     }
     // Don't care that there are branches where it's not initialized
-    // since we don't use the value in those branches
+    // since we don't use the value in those branches.
 }
 ```
 
@@ -98,8 +98,8 @@ uninitialized if the type of the value isn't Copy. That is:
 fn main() {
     let x = 0;
     let y = Box::new(0);
-    let z1 = x; // x is still valid because i32 is Copy
-    let z2 = y; // y is now logically uninitialized because Box isn't Copy
+    let z1 = x; // x is still valid because i32 is Copy.
+    let z2 = y; // y is now logically uninitialized because Box isn't Copy.
 }
 ```
 
@@ -109,8 +109,8 @@ mutable, as a Safe Rust program could observe that the value of `y` changed:
 ```rust
 fn main() {
     let mut y = Box::new(0);
-    let z = y; // y is now logically uninitialized because Box isn't Copy
-    y = Box::new(1); // reinitialize y
+    let z = y; // y is now logically uninitialized because Box isn't Copy.
+    y = Box::new(1); // Reinitialize y.
 }
 ```
 

--- a/src/doc/nomicon/destructors.md
+++ b/src/doc/nomicon/destructors.md
@@ -87,7 +87,7 @@ impl<T> Drop for SuperBox<T> {
     fn drop(&mut self) {
         unsafe {
             // Hyper-optimized: deallocate the box's contents for it
-            // without `drop`ing the contents
+            // without `drop`ing the contents.
             heap::deallocate((*self.my_box.ptr) as *mut u8,
                              mem::size_of::<T>(),
                              mem::align_of::<T>());

--- a/src/doc/nomicon/drop-flags.md
+++ b/src/doc/nomicon/drop-flags.md
@@ -13,9 +13,9 @@ particular, assigning through a dereference unconditionally drops, and assigning
 in a `let` unconditionally doesn't drop:
 
 ```
-let mut x = Box::new(0); // let makes a fresh variable, so never need to drop
+let mut x = Box::new(0); // let makes a fresh variable, so never need to drop.
 let y = &mut x;
-*y = Box::new(1); // Deref assumes the referent is initialized, so always drops
+*y = Box::new(1); // Deref assumes the referent is initialized, so always drops.
 ```
 
 This is only a problem when overwriting a previously initialized variable or

--- a/src/doc/nomicon/dropck.md
+++ b/src/doc/nomicon/dropck.md
@@ -250,7 +250,7 @@ struct Inspector<T: fmt::Display>(T, &'static str);
 impl<T: fmt::Display> Drop for Inspector<T> {
     fn drop(&mut self) {
         // There is a hidden call to `<T as Display>::fmt` below, which
-        // could access a borrow e.g. if `T` is `&'a _`
+        // could access a borrow e.g. if `T` is `&'a _`.
         println!("Inspector({}, {}) unwittingly inspects expired data.",
                  self.0, self.1);
     }

--- a/src/doc/nomicon/exception-safety.md
+++ b/src/doc/nomicon/exception-safety.md
@@ -44,7 +44,7 @@ impl<T: Clone> Vec<T> {
     fn push_all(&mut self, to_push: &[T]) {
         self.reserve(to_push.len());
         unsafe {
-            // can't overflow because we just reserved this
+            // Can't overflow because we just reserved this.
             self.set_len(self.len() + to_push.len());
 
             for (i, x) in to_push.iter().enumerate() {
@@ -191,7 +191,7 @@ impl<'a, T> Hole<'a, T> {
 
 impl<'a, T> Drop for Hole<'a, T> {
     fn drop(&mut self) {
-        // fill the hole again
+        // Fill the hole again.
         unsafe {
             let pos = self.pos;
             ptr::write(&mut self.data[pos], self.elt.take().unwrap());

--- a/src/doc/nomicon/exotic-sizes.md
+++ b/src/doc/nomicon/exotic-sizes.md
@@ -32,7 +32,7 @@ Structs can actually store a single DST directly as their last field, but this
 makes them a DST as well:
 
 ```rust
-// Can't be stored on the stack directly
+// Can't be stored on the stack directly.
 struct Foo {
     info: u32,
     data: [u8],
@@ -51,13 +51,13 @@ a variable position based on its alignment][dst-issue].**
 Rust actually allows types to be specified that occupy no space:
 
 ```rust
-struct Foo; // No fields = no size
+struct Foo; // No fields = no size.
 
-// All fields have no size = no size
+// All fields have no size = no size.
 struct Baz {
     foo: Foo,
-    qux: (),      // empty tuple has no size
-    baz: [u8; 0], // empty array has no size
+    qux: (),      // Empty tuple has no size.
+    baz: [u8; 0], // Empty array has no size.
 }
 ```
 
@@ -99,7 +99,7 @@ types can only be talked about at the type level, and never at the value level.
 Empty types can be declared by specifying an enum with no variants:
 
 ```rust
-enum Void {} // No variants = EMPTY
+enum Void {} // No variants = EMPTY.
 ```
 
 Empty types are even more marginal than ZSTs. The primary motivating example for

--- a/src/doc/nomicon/leaking.md
+++ b/src/doc/nomicon/leaking.md
@@ -75,14 +75,14 @@ Now consider the following:
 let mut vec = vec![Box::new(0); 4];
 
 {
-    // start draining, vec can no longer be accessed
+    // Start draining, vec can no longer be accessed.
     let mut drainer = vec.drain(..);
 
-    // pull out two elements and immediately drop them
+    // Pull out two elements and immediately drop them.
     drainer.next();
     drainer.next();
 
-    // get rid of drainer, but don't call its destructor
+    // Get rid of drainer, but don't call its destructor.
     mem::forget(drainer);
 }
 
@@ -157,7 +157,7 @@ impl<T> Drop for Rc<T> {
         unsafe {
             (*self.ptr).ref_count -= 1;
             if (*self.ptr).ref_count == 0 {
-                // drop the data and then free it
+                // Drop the data and then free it.
                 ptr::read(self.ptr);
                 heap::deallocate(self.ptr);
             }
@@ -218,7 +218,7 @@ let mut data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         let guard = thread::scoped(move || {
             *x *= 2;
         });
-        // store the thread's guard for later
+        // Store the thread's guard for later.
         guards.push(guard);
     }
     // All guards are dropped here, forcing the threads to join
@@ -226,7 +226,7 @@ let mut data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     // Once the threads join, the borrow expires and the data becomes
     // accessible again in this thread.
 }
-// data is definitely mutated here.
+// Data is definitely mutated here.
 ```
 
 In principle, this totally works! Rust's ownership system perfectly ensures it!

--- a/src/doc/nomicon/lifetime-elision.md
+++ b/src/doc/nomicon/lifetime-elision.md
@@ -39,26 +39,26 @@ Elision rules are as follows:
 Examples:
 
 ```rust,ignore
-fn print(s: &str);                                      // elided
-fn print<'a>(s: &'a str);                               // expanded
+fn print(s: &str);                                      // Elided.
+fn print<'a>(s: &'a str);                               // Expanded.
 
-fn debug(lvl: uint, s: &str);                           // elided
-fn debug<'a>(lvl: uint, s: &'a str);                    // expanded
+fn debug(lvl: uint, s: &str);                           // Elided.
+fn debug<'a>(lvl: uint, s: &'a str);                    // Expanded.
 
-fn substr(s: &str, until: uint) -> &str;                // elided
-fn substr<'a>(s: &'a str, until: uint) -> &'a str;      // expanded
+fn substr(s: &str, until: uint) -> &str;                // Elided.
+fn substr<'a>(s: &'a str, until: uint) -> &'a str;      // Expanded.
 
-fn get_str() -> &str;                                   // ILLEGAL
+fn get_str() -> &str;                                   // ILLEGAL.
 
-fn frob(s: &str, t: &str) -> &str;                      // ILLEGAL
+fn frob(s: &str, t: &str) -> &str;                      // ILLEGAL.
 
-fn get_mut(&mut self) -> &mut T;                        // elided
-fn get_mut<'a>(&'a mut self) -> &'a mut T;              // expanded
+fn get_mut(&mut self) -> &mut T;                        // Elided.
+fn get_mut<'a>(&'a mut self) -> &'a mut T;              // Expanded.
 
-fn args<T:ToCStr>(&mut self, args: &[T]) -> &mut Command                  // elided
-fn args<'a, 'b, T:ToCStr>(&'a mut self, args: &'b [T]) -> &'a mut Command // expanded
+fn args<T:ToCStr>(&mut self, args: &[T]) -> &mut Command                  // Elided.
+fn args<'a, 'b, T:ToCStr>(&'a mut self, args: &'b [T]) -> &'a mut Command // Expanded.
 
-fn new(buf: &mut [u8]) -> BufWriter;                    // elided
-fn new<'a>(buf: &'a mut [u8]) -> BufWriter<'a>          // expanded
+fn new(buf: &mut [u8]) -> BufWriter;                    // Elided.
+fn new<'a>(buf: &'a mut [u8]) -> BufWriter<'a>          // Expanded.
 
 ```

--- a/src/doc/nomicon/lifetimes.md
+++ b/src/doc/nomicon/lifetimes.md
@@ -42,10 +42,10 @@ likely desugar to the following:
 'a: {
     let x: i32 = 0;
     'b: {
-        // lifetime used is 'b because that's good enough.
+        // Lifetime used is 'b because that's good enough.
         let y: &'b i32 = &'b x;
         'c: {
-            // ditto on 'c
+            // Ditto on 'c.
             let z: &'c &'b i32 = &'c y;
         }
     }
@@ -181,7 +181,7 @@ println!("{}", x);
     let mut data: Vec<i32> = vec![1, 2, 3];
     'b: {
         // 'b is as big as we need this borrow to be
-        // (just need to get to `println!`)
+        // (just need to get to `println!`).
         let x: &'b i32 = Index::index::<'b>(&'b data, 0);
         'c: {
             // Temporary scope because we don't need the

--- a/src/doc/nomicon/ownership.md
+++ b/src/doc/nomicon/ownership.md
@@ -19,10 +19,10 @@ language have made at one point:
 
 ```rust,ignore
 fn as_str(data: &u32) -> &str {
-    // compute the string
+    // Compute the string.
     let s = format!("{}", data);
 
-    // OH NO! We returned a reference to something that
+    // OH NOES! We returned a reference to something that
     // exists only in this function!
     // Dangling pointer! Use after free! Alas!
     // (this does not compile in Rust)
@@ -48,10 +48,10 @@ For instance in this code,
 
 ```rust,ignore
 let mut data = vec![1, 2, 3];
-// get an internal reference
+// Get an internal reference.
 let x = &data[0];
 
-// OH NO! `push` causes the backing storage of `data` to be reallocated.
+// OH NOES! `push` causes the backing storage of `data` to be reallocated.
 // Dangling pointer! User after free! Alas!
 // (this does not compile in Rust)
 data.push(4);

--- a/src/doc/nomicon/races.md
+++ b/src/doc/nomicon/races.md
@@ -40,7 +40,7 @@ let data = vec![1, 2, 3, 4];
 let idx = Arc::new(AtomicUsize::new(0));
 let other_idx = idx.clone();
 
-// `move` captures other_idx by-value, moving it into this thread
+// `move` captures other_idx by-value, moving it into this thread.
 thread::spawn(move || {
     // It's ok to mutate idx because this value
     // is an atomic, so it can't cause a Data Race.
@@ -68,7 +68,7 @@ let data = vec![1, 2, 3, 4];
 let idx = Arc::new(AtomicUsize::new(0));
 let other_idx = idx.clone();
 
-// `move` captures other_idx by-value, moving it into this thread
+// `move` captures other_idx by-value, moving it into this thread.
 thread::spawn(move || {
     // It's ok to mutate idx because this value
     // is an atomic, so it can't cause a Data Race.

--- a/src/doc/nomicon/references.md
+++ b/src/doc/nomicon/references.md
@@ -102,12 +102,12 @@ reborrowed to point to a field of its referent:
 ```rust
 let x = &mut (1, 2);
 {
-    // reborrow x to a subfield
+    // Reborrow x to a subfield.
     let y = &mut x.0;
-    // y is now live, but x isn't
+    // y is now live, but x isn't.
     *y = 3;
 }
-// y goes out of scope, so x is live again
+// y goes out of scope, so x is live again.
 *x = (5, 7);
 ```
 
@@ -119,15 +119,15 @@ disjointness can be statically proven:
 ```rust
 let x = &mut (1, 2);
 {
-    // reborrow x to two disjoint subfields
+    // Reborrow x to two disjoint subfields.
     let y = &mut x.0;
     let z = &mut x.1;
 
-    // y and z are now live, but x isn't
+    // y and z are now live, but x isn't.
     *y = 3;
     *z = 4;
 }
-// y and z go out of scope, so x is live again
+// y and z go out of scope, so x is live again.
 *x = (5, 7);
 ```
 

--- a/src/doc/nomicon/repr-rust.md
+++ b/src/doc/nomicon/repr-rust.md
@@ -43,10 +43,10 @@ of 32-bits. It will potentially become:
 ```rust
 struct A {
     a: u8,
-    _pad1: [u8; 3], // to align `b`
+    _pad1: [u8; 3], // To align `b`.
     b: u32,
     c: u16,
-    _pad2: [u8; 2], // to make overall size multiple of 4
+    _pad2: [u8; 2], // To make overall size multiple of 4.
 }
 ```
 
@@ -127,7 +127,7 @@ would be laid out as:
 
 ```rust
 struct FooRepr {
-    data: u64, // this is either a u64, u32, or u8 based on `tag`
+    data: u64, // This is either a u64, u32, or u8 based on `tag`.
     tag: u8,   // 0 = A, 1 = B, 2 = C
 }
 ```

--- a/src/doc/nomicon/subtyping.md
+++ b/src/doc/nomicon/subtyping.md
@@ -86,7 +86,7 @@ fn main() {
         let string = String::from("world");
         overwrite(&mut forever_str, &mut &*string);
     }
-    // Oops, printing free'd memory
+    // Oops, printing free'd memory.
     println!("{}", forever_str);
 }
 ```
@@ -127,7 +127,7 @@ that, yes, you can use subtyping when passing by-value. That is, this works:
 
 ```rust
 fn get_box<'a>(str: &'a str) -> Box<&'a str> {
-    // string literals are `&'static str`s
+    // string literals are `&'static str`s.
     Box::new("hello")
 }
 ```
@@ -146,7 +146,7 @@ cells must be invariant to avoid lifetime smuggling.
 signature:
 
 ```rust,ignore
-// 'a is derived from some parent scope
+// 'a is derived from some parent scope.
 fn foo(&'a str) -> usize;
 ```
 
@@ -168,7 +168,7 @@ To see why `Fn(T) -> U` should be variant over U, consider the following
 function signature:
 
 ```rust,ignore
-// 'a is derived from some parent scope
+// 'a is derived from some parent scope.
 fn foo(usize) -> &'a str;
 ```
 
@@ -199,14 +199,14 @@ in multiple fields.
 use std::cell::Cell;
 
 struct Foo<'a, 'b, A: 'a, B: 'b, C, D, E, F, G, H> {
-    a: &'a A,     // variant over 'a and A
-    b: &'b mut B, // invariant over 'b and B
-    c: *const C,  // variant over C
-    d: *mut D,    // invariant over D
-    e: Vec<E>,    // variant over E
-    f: Cell<F>,   // invariant over F
-    g: G,         // variant over G
-    h1: H,        // would also be variant over H except...
-    h2: Cell<H>,  // invariant over H, because invariance wins
+    a: &'a A,     // Variant over 'a and A.
+    b: &'b mut B, // Invariant over 'b and B.
+    c: *const C,  // Variant over C.
+    d: *mut D,    // Invariant over D.
+    e: Vec<E>,    // Variant over E.
+    f: Cell<F>,   // Invariant over F.
+    g: G,         // Variant over G.
+    h1: H,        // Would also be variant over H except...
+    h2: Cell<H>,  // Invariant over H, because invariance wins.
 }
 ```

--- a/src/doc/nomicon/unchecked-uninit.md
+++ b/src/doc/nomicon/unchecked-uninit.md
@@ -49,18 +49,18 @@ Putting this all together, we get the following:
 use std::mem;
 use std::ptr;
 
-// size of the array is hard-coded but easy to change. This means we can't
+// Size of the array is hard-coded but easy to change. This means we can't
 // use [a, b, c] syntax to initialize the array, though!
 const SIZE: usize = 10;
 
 let mut x: [Box<u32>; SIZE];
 
 unsafe {
-	// convince Rust that x is Totally Initialized
+	// Convince Rust that x is Totally Initialized.
 	x = mem::uninitialized();
 	for i in 0..SIZE {
-		// very carefully overwrite each index without reading it
-		// NOTE: exception safety is not a concern; Box can't panic
+		// Very carefully overwrite each index without reading it.
+		// NOTE: exception safety is not a concern; Box can't panic.
 		ptr::write(&mut x[i], Box::new(i as u32));
 	}
 }

--- a/src/doc/nomicon/vec-alloc.md
+++ b/src/doc/nomicon/vec-alloc.md
@@ -30,7 +30,7 @@ impl<T> Vec<T> {
     fn new() -> Self {
         assert!(mem::size_of::<T>() != 0, "We're not ready to handle ZSTs");
         unsafe {
-            // need to cast EMPTY to the actual ptr type we want, let
+            // Need to cast EMPTY to the actual ptr type we want, let
             // inference handle it.
             Vec { ptr: Unique::new(heap::EMPTY as *mut _), len: 0, cap: 0 }
         }
@@ -176,9 +176,9 @@ Ok with all the nonsense out of the way, let's actually allocate some memory:
 
 ```rust,ignore
 fn grow(&mut self) {
-    // this is all pretty delicate, so let's say it's all unsafe
+    // This is all pretty delicate, so let's say it's all unsafe.
     unsafe {
-        // current API requires us to specify size and alignment manually.
+        // Current API requires us to specify size and alignment manually.
         let align = mem::align_of::<T>();
         let elem_size = mem::size_of::<T>();
 
@@ -186,13 +186,13 @@ fn grow(&mut self) {
             let ptr = heap::allocate(elem_size, align);
             (1, ptr)
         } else {
-            // as an invariant, we can assume that `self.cap < isize::MAX`,
+            // As an invariant, we can assume that `self.cap < isize::MAX`,
             // so this doesn't need to be checked.
             let new_cap = self.cap * 2;
-            // Similarly this can't overflow due to previously allocating this
+            // Similarly this can't overflow due to previously allocating this.
             let old_num_bytes = self.cap * elem_size;
 
-            // check that the new allocation doesn't exceed `isize::MAX` at all
+            // Check that the new allocation doesn't exceed `isize::MAX` at all
             // regardless of the actual size of the capacity. This combines the
             // `new_cap <= isize::MAX` and `new_num_bytes <= usize::MAX` checks
             // we need to make. We lose the ability to allocate e.g. 2/3rds of
@@ -209,7 +209,7 @@ fn grow(&mut self) {
             (new_cap, ptr)
         };
 
-        // If allocate or reallocate fail, we'll get `null` back
+        // If allocate or reallocate fail, we'll get `null` back.
         if ptr.is_null() { oom(); }
 
         self.ptr = Unique::new(ptr as *mut _);

--- a/src/doc/nomicon/vec-drain.md
+++ b/src/doc/nomicon/vec-drain.md
@@ -33,7 +33,7 @@ struct RawValIter<T> {
 }
 
 impl<T> RawValIter<T> {
-    // unsafe to construct because it has no associated lifetimes.
+    // Unsafe to construct because it has no associated lifetimes.
     // This is necessary to store a RawValIter in the same struct as
     // its actual allocation. OK since it's a private implementation
     // detail.
@@ -59,7 +59,7 @@ And IntoIter becomes the following:
 
 ```rust,ignore
 pub struct IntoIter<T> {
-    _buf: RawVec<T>, // we don't actually care about this. Just need it to live.
+    _buf: RawVec<T>, // We don't actually care about this, just need it to live.
     iter: RawValIter<T>,
 }
 
@@ -132,7 +132,7 @@ impl<T> Vec<T> {
         unsafe {
             let iter = RawValIter::new(&self);
 
-            // this is a mem::forget safety thing. If Drain is forgotten, we just
+            // This is a mem::forget safety thing. If Drain is forgotten, we just
             // leak the whole Vec's contents. Also we need to do this *eventually*
             // anyway, so why not do it now?
             self.len = 0;

--- a/src/doc/nomicon/vec-final.md
+++ b/src/doc/nomicon/vec-final.md
@@ -24,7 +24,7 @@ impl<T> RawVec<T> {
             // !0 is usize::MAX. This branch should be stripped at compile time.
             let cap = if mem::size_of::<T>() == 0 { !0 } else { 0 };
 
-            // heap::EMPTY doubles as "unallocated" and "zero-sized allocation"
+            // heap::EMPTY doubles as "unallocated" and "zero-sized allocation".
             RawVec { ptr: Unique::new(heap::EMPTY as *mut T), cap: cap }
         }
     }
@@ -33,7 +33,7 @@ impl<T> RawVec<T> {
         unsafe {
             let elem_size = mem::size_of::<T>();
 
-            // since we set the capacity to usize::MAX when elem_size is
+            // Since we set the capacity to usize::MAX when elem_size is
             // 0, getting to here necessarily means the Vec is overfull.
             assert!(elem_size != 0, "capacity overflow");
 
@@ -51,7 +51,7 @@ impl<T> RawVec<T> {
                 (new_cap, ptr)
             };
 
-            // If allocate or reallocate fail, we'll get `null` back
+            // If allocate or reallocate fail, we'll get `null` back.
             if ptr.is_null() { oom() }
 
             self.ptr = Unique::new(ptr as *mut _);
@@ -157,7 +157,7 @@ impl<T> Vec<T> {
         unsafe {
             let iter = RawValIter::new(&self);
 
-            // this is a mem::forget safety thing. If Drain is forgotten, we just
+            // This is a mem::forget safety thing. If Drain is forgotten, we just
             // leak the whole Vec's contents. Also we need to do this *eventually*
             // anyway, so why not do it now?
             self.len = 0;
@@ -173,7 +173,7 @@ impl<T> Vec<T> {
 impl<T> Drop for Vec<T> {
     fn drop(&mut self) {
         while let Some(_) = self.pop() {}
-        // allocation is handled by RawVec
+        // Allocation is handled by RawVec.
     }
 }
 
@@ -257,7 +257,7 @@ impl<T> DoubleEndedIterator for RawValIter<T> {
 
 
 pub struct IntoIter<T> {
-    _buf: RawVec<T>, // we don't actually care about this. Just need it to live.
+    _buf: RawVec<T>, // We don't actually care about this, just need it to live.
     iter: RawValIter<T>,
 }
 
@@ -297,14 +297,14 @@ impl<'a, T> DoubleEndedIterator for Drain<'a, T> {
 
 impl<'a, T> Drop for Drain<'a, T> {
     fn drop(&mut self) {
-        // pre-drain the iter
+        // Pre-drain the iter.
         for _ in &mut self.iter {}
     }
 }
 
 /// Abort the process, we're out of memory!
 ///
-/// In practice this is probably dead code on most OSes
+/// In practice this is probably dead code on most OSes.
 fn oom() {
     ::std::process::exit(-9999);
 }

--- a/src/doc/nomicon/vec-insert-remove.md
+++ b/src/doc/nomicon/vec-insert-remove.md
@@ -21,7 +21,7 @@ pub fn insert(&mut self, index: usize, elem: T) {
 
     unsafe {
         if index < self.len {
-            // ptr::copy(src, dest, len): "copy from source to dest len elems"
+            // ptr::copy(src, dest, len): "copy from source to dest len elems".
             ptr::copy(self.ptr.offset(index as isize),
                       self.ptr.offset(index as isize + 1),
                       len - index);
@@ -37,7 +37,7 @@ Remove behaves in the opposite manner. We need to shift all the elements from
 
 ```rust,ignore
 pub fn remove(&mut self, index: usize) -> T {
-    // Note: `<` because it's *not* valid to remove after everything
+    // Note: `<` because it's *not* valid to remove after everything.
     assert!(index < self.len, "index out of bounds");
     unsafe {
         self.len -= 1;

--- a/src/doc/nomicon/vec-into-iter.md
+++ b/src/doc/nomicon/vec-into-iter.md
@@ -56,12 +56,12 @@ And this is what we end up with for initialization:
 ```rust,ignore
 impl<T> Vec<T> {
     fn into_iter(self) -> IntoIter<T> {
-        // Can't destructure Vec since it's Drop
+        // Can't destructure Vec since it's Drop.
         let ptr = self.ptr;
         let cap = self.cap;
         let len = self.len;
 
-        // Make sure not to drop Vec since that will free the buffer
+        // Make sure not to drop Vec since that will free the buffer.
         mem::forget(self);
 
         unsafe {
@@ -70,7 +70,7 @@ impl<T> Vec<T> {
                 cap: cap,
                 start: *ptr,
                 end: if cap == 0 {
-                    // can't offset off this pointer, it's not allocated!
+                    // Can't offset off this pointer, it's not allocated!
                     *ptr
                 } else {
                     ptr.offset(len as isize)
@@ -132,7 +132,7 @@ contains that weren't yielded.
 impl<T> Drop for IntoIter<T> {
     fn drop(&mut self) {
         if self.cap != 0 {
-            // drop any remaining elements
+            // Drop any remaining elements.
             for _ in &mut *self {}
 
             let align = mem::align_of::<T>();

--- a/src/doc/nomicon/vec-layout.md
+++ b/src/doc/nomicon/vec-layout.md
@@ -44,8 +44,8 @@ use std::ops::Deref;
 use std::mem;
 
 struct Unique<T> {
-    ptr: *const T,              // *const for variance
-    _marker: PhantomData<T>,    // For the drop checker
+    ptr: *const T,              // *const for variance.
+    _marker: PhantomData<T>,    // For the drop checker.
 }
 
 // Deriving Send and Sync is safe because we are the Unique owners

--- a/src/doc/nomicon/vec-raw.md
+++ b/src/doc/nomicon/vec-raw.md
@@ -22,7 +22,7 @@ impl<T> RawVec<T> {
         }
     }
 
-    // unchanged from Vec
+    // Unchanged from Vec.
     fn grow(&mut self) {
         unsafe {
             let align = mem::align_of::<T>();
@@ -40,7 +40,7 @@ impl<T> RawVec<T> {
                 (new_cap, ptr)
             };
 
-            // If allocate or reallocate fail, we'll get `null` back
+            // If allocate or reallocate fail, we'll get `null` back.
             if ptr.is_null() { oom() }
 
             self.ptr = Unique::new(ptr as *mut _);
@@ -84,13 +84,13 @@ impl<T> Vec<T> {
     // push/pop/insert/remove largely unchanged:
     // * `self.ptr -> self.ptr()`
     // * `self.cap -> self.cap()`
-    // * `self.grow -> self.buf.grow()`
+    // * `self.grow() -> self.buf.grow()`
 }
 
 impl<T> Drop for Vec<T> {
     fn drop(&mut self) {
         while let Some(_) = self.pop() {}
-        // deallocation is handled by RawVec
+        // Deallocation is handled by RawVec.
     }
 }
 ```
@@ -99,7 +99,7 @@ And finally we can really simplify IntoIter:
 
 ```rust,ignore
 struct IntoIter<T> {
-    _buf: RawVec<T>, // we don't actually care about this. Just need it to live.
+    _buf: RawVec<T>, // We don't actually care about thi, just need it to live.
     start: *const T,
     end: *const T,
 }
@@ -108,7 +108,7 @@ struct IntoIter<T> {
 
 impl<T> Drop for IntoIter<T> {
     fn drop(&mut self) {
-        // only need to ensure all our elements are read;
+        // Only need to ensure all of our elements are read;
         // buffer will clean itself up afterwards.
         for _ in &mut *self {}
     }
@@ -117,7 +117,7 @@ impl<T> Drop for IntoIter<T> {
 impl<T> Vec<T> {
     pub fn into_iter(self) -> IntoIter<T> {
         unsafe {
-            // need to use ptr::read to unsafely move the buf out since it's
+            // Need to use ptr::read to unsafely move the buf out since it's
             // not Copy, and Vec implements Drop (so we can't destructure it).
             let buf = ptr::read(&self.buf);
             let len = self.len;

--- a/src/doc/nomicon/vec-zsts.md
+++ b/src/doc/nomicon/vec-zsts.md
@@ -39,7 +39,7 @@ impl<T> RawVec<T> {
             // !0 is usize::MAX. This branch should be stripped at compile time.
             let cap = if mem::size_of::<T>() == 0 { !0 } else { 0 };
 
-            // heap::EMPTY doubles as "unallocated" and "zero-sized allocation"
+            // heap::EMPTY doubles as "unallocated" and "zero-sized allocation".
             RawVec { ptr: Unique::new(heap::EMPTY as *mut T), cap: cap }
         }
     }
@@ -48,7 +48,7 @@ impl<T> RawVec<T> {
         unsafe {
             let elem_size = mem::size_of::<T>();
 
-            // since we set the capacity to usize::MAX when elem_size is
+            // Since we set the capacity to usize::MAX when elem_size is
             // 0, getting to here necessarily means the Vec is overfull.
             assert!(elem_size != 0, "capacity overflow");
 
@@ -66,7 +66,7 @@ impl<T> RawVec<T> {
                 (new_cap, ptr)
             };
 
-            // If allocate or reallocate fail, we'll get `null` back
+            // If allocate or reallocate fail, we'll get `null` back.
             if ptr.is_null() { oom() }
 
             self.ptr = Unique::new(ptr as *mut _);
@@ -79,7 +79,7 @@ impl<T> Drop for RawVec<T> {
     fn drop(&mut self) {
         let elem_size = mem::size_of::<T>();
 
-        // don't free zero-sized allocations, as they were never allocated.
+        // Don't free zero-sized allocations, as they were never allocated.
         if self.cap != 0 && elem_size != 0 {
             let align = mem::align_of::<T>();
 

--- a/src/doc/nomicon/working-with-unsafe.md
+++ b/src/doc/nomicon/working-with-unsafe.md
@@ -64,7 +64,7 @@ pub struct Vec<T> {
 impl<T> Vec<T> {
     pub fn push(&mut self, elem: T) {
         if self.len == self.cap {
-            // not important for this example
+            // Not important for this example.
             self.reallocate();
         }
         unsafe {
@@ -84,7 +84,7 @@ adding the following method:
 
 ```rust,ignore
 fn make_room(&mut self) {
-    // grow the capacity
+    // Grow the capacity.
     self.cap += 1;
 }
 ```


### PR DESCRIPTION
This is a bit silly but it bothered me much more than it should have
when reading the rustonomicon (great read by the way!).
