### PR TITLE
Add to Testing docs to make more clear

### DIFF
--- a/src/doc/trpl/testing.md
+++ b/src/doc/trpl/testing.md
@@ -504,3 +504,5 @@ you add more examples.
 
 We haven’t covered all of the details with writing documentation tests. For more,
 please see the [Documentation chapter](documentation.html)
+
+One final note: Tests *cannot* be run on the binary (main) file. To see more on file arrangement see the [Crates and Modules](https://doc.rust-lang.org/stable/book/crates-and-modules.html) Section

--- a/src/doc/trpl/testing.md
+++ b/src/doc/trpl/testing.md
@@ -505,4 +505,5 @@ you add more examples.
 We haven’t covered all of the details with writing documentation tests. For more,
 please see the [Documentation chapter](documentation.html)
 
-One final note: Tests *cannot* be run on the binary (main) file. To see more on file arrangement see the [Crates and Modules](https://doc.rust-lang.org/stable/book/crates-and-modules.html) Section
+One final note: Tests *cannot* be run on a binary file. To see more on file arrangement see the [Crates and Modules](crates-and-modules.html) section.
+


### PR DESCRIPTION
When going through the docs, it is not clear that binary files cannot be tested. Additionally, it is hard to find the proper structure of a Rust crate and it took me several hours of looking through the docs to find the crates and modules section. I think we can link to it from here and it will be beneficial to those who are coming to the language.
