### PR TITLE
docs: remove extern crate collections from example code

### DIFF
--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -288,7 +288,8 @@ pub fn maketest(s: &str, cratename: Option<&str>, dont_insert_main: bool,
 
     // Don't inject `extern crate std` because it's already injected by the
     // compiler.
-    if !s.contains("extern crate") && !opts.no_crate_inject && cratename != Some("std") {
+    if !s.contains("extern crate") && !opts.no_crate_inject && cratename != Some("std") &&
+       cratename != Some("collections") {
         match cratename {
             Some(cratename) => {
                 if s.contains(cratename) {


### PR DESCRIPTION
All code examples from the collections crate are currently adding `extern crate collections` causing the following error when trying to run in the playground

```
<anon>:3:1: 3:26 error: use of unstable library feature 'collections': library is unlikely to be stabilized with the current layout and name, use std::collections instead (see issue #27783)
<anon>:3 extern crate collections;
         ^~~~~~~~~~~~~~~~~~~~~~~~~
```

This tiny PR simply removes the extern crate in favor of std::collections as suggested by the error description.

r? @steveklabnik
