### PR TITLE
book: Change raw pointer conversion example

### DIFF
--- a/src/doc/trpl/raw-pointers.md
+++ b/src/doc/trpl/raw-pointers.md
@@ -98,16 +98,15 @@ these properties are true for any references, no matter how they are created,
 and so any conversion from raw pointers is asserting that they hold. The
 programmer *must* guarantee this.
 
-The recommended method for the conversion is
+The recommended method for the conversion is:
 
 ```rust
-let i: u32 = 1;
-
 // explicit cast
+let i: u32 = 1;
 let p_imm: *const u32 = &i as *const u32;
-let mut m: u32 = 2;
 
 // implicit coercion
+let mut m: u32 = 2;
 let p_mut: *mut u32 = &mut m;
 
 unsafe {


### PR DESCRIPTION
Change the spacing/order of lines in the final pointer conversion example to make it more clear.

Very small change, can be rolled up.
