### PR TITLE
Implement conversion traits for primitive float types

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1515,6 +1515,10 @@ impl_from! { u16, i32 }
 impl_from! { u16, i64 }
 impl_from! { u32, i64 }
 
+// Note: integers can only be represented with full precision in a float if
+// they fit in the significand, which is 24 bits in f32 and 53 bits in f64.
+// Lossy float conversions are not implemented at this time.
+
 // Signed -> Float
 impl_from! { i8, f32 }
 impl_from! { i8, f64 }

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1473,14 +1473,14 @@ impl fmt::Display for ParseIntError {
 
 pub use num::dec2flt::ParseFloatError;
 
-// Conversion traits for primitive integer types
+// Conversion traits for primitive integer and float types
 // Conversions T -> T are covered by a blanket impl and therefore excluded
 // Some conversions from and to usize/isize are not implemented due to portability concerns
 macro_rules! impl_from {
     ($Small: ty, $Large: ty) => {
-        #[stable(feature = "lossless_int_conv", since = "1.5.0")]
+        #[stable(feature = "lossless_prim_conv", since = "1.5.0")]
         impl From<$Small> for $Large {
-            #[stable(feature = "lossless_int_conv", since = "1.5.0")]
+            #[stable(feature = "lossless_prim_conv", since = "1.5.0")]
             #[inline]
             fn from(small: $Small) -> $Large {
                 small as $Large
@@ -1514,3 +1514,20 @@ impl_from! { u8, i64 }
 impl_from! { u16, i32 }
 impl_from! { u16, i64 }
 impl_from! { u32, i64 }
+
+// Signed -> Float
+impl_from! { i8, f32 }
+impl_from! { i8, f64 }
+impl_from! { i16, f32 }
+impl_from! { i16, f64 }
+impl_from! { i32, f64 }
+
+// Unsigned -> Float
+impl_from! { u8, f32 }
+impl_from! { u8, f64 }
+impl_from! { u16, f32 }
+impl_from! { u16, f64 }
+impl_from! { u32, f64 }
+
+// Float -> Float
+impl_from! { f32, f64 }

--- a/src/libcoretest/num/mod.rs
+++ b/src/libcoretest/num/mod.rs
@@ -177,4 +177,61 @@ mod tests {
     test_impl_from! { test_u16i32, u16, i32 }
     test_impl_from! { test_u16i64, u16, i64 }
     test_impl_from! { test_u32i64, u32, i64 }
+
+    // Signed -> Float
+    test_impl_from! { test_i8f32, i8, f32 }
+    test_impl_from! { test_i8f64, i8, f64 }
+    test_impl_from! { test_i16f32, i16, f32 }
+    test_impl_from! { test_i16f64, i16, f64 }
+    test_impl_from! { test_i32f64, i32, f64 }
+
+    // Unsigned -> Float
+    test_impl_from! { test_u8f32, u8, f32 }
+    test_impl_from! { test_u8f64, u8, f64 }
+    test_impl_from! { test_u16f32, u16, f32 }
+    test_impl_from! { test_u16f64, u16, f64 }
+    test_impl_from! { test_u32f64, u32, f64 }
+
+    // Float -> Float
+    #[test]
+    fn test_f32f64() {
+        use core::f32;
+
+        let max: f64 = f32::MAX.into();
+        assert_eq!(max as f32, f32::MAX);
+        assert!(max.is_normal());
+
+        let min: f64 = f32::MIN.into();
+        assert_eq!(min as f32, f32::MIN);
+        assert!(min.is_normal());
+
+        let min_positive: f64 = f32::MIN_POSITIVE.into();
+        assert_eq!(min_positive as f32, f32::MIN_POSITIVE);
+        assert!(min_positive.is_normal());
+
+        let epsilon: f64 = f32::EPSILON.into();
+        assert_eq!(epsilon as f32, f32::EPSILON);
+        assert!(epsilon.is_normal());
+
+        let zero: f64 = (0.0f32).into();
+        assert_eq!(zero as f32, 0.0f32);
+        assert!(zero.is_sign_positive());
+
+        let neg_zero: f64 = (-0.0f32).into();
+        assert_eq!(neg_zero as f32, -0.0f32);
+        assert!(neg_zero.is_sign_negative());
+
+        let infinity: f64 = f32::INFINITY.into();
+        assert_eq!(infinity as f32, f32::INFINITY);
+        assert!(infinity.is_infinite());
+        assert!(infinity.is_sign_positive());
+
+        let neg_infinity: f64 = f32::NEG_INFINITY.into();
+        assert_eq!(neg_infinity as f32, f32::NEG_INFINITY);
+        assert!(neg_infinity.is_infinite());
+        assert!(neg_infinity.is_sign_negative());
+
+        let nan: f64 = f32::NAN.into();
+        assert!(nan.is_nan());
+    }
 }


### PR DESCRIPTION
This is a spiritual successor to #28921, completing the "upcast" idea from rust-num/num#97.
