### PR TITLE
Document that Ordering::Relaxed is Monotonic

### DIFF
--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -153,7 +153,8 @@ unsafe impl<T> Sync for AtomicPtr<T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Copy, Clone)]
 pub enum Ordering {
-    /// No ordering constraints, only atomic operations.
+    /// No ordering constraints, only atomic operations. Corresponds to LLVM's
+    /// `Monotonic` ordering.
     #[stable(feature = "rust1", since = "1.0.0")]
     Relaxed,
     /// When coupled with a store, all previous writes become visible


### PR DESCRIPTION
I wasn't sure whether `Ordering::Relaxed` meant `Monotonic` or `Unordered`, so I checked the compiler sources and found https://github.com/rust-lang/rust/blob/206af38e74ce7fa4b0e781ece7f1067c018c580e/src/librustc_trans/trans/intrinsic.rs#L846 which appears conclusive.  Adding this answer to the documentation.
