### PR TITLE
Make short string hashing 30% faster by splitting Hash::hash_end from Hash::hash

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -892,6 +892,10 @@ impl<T: ?Sized + Hash> Hash for Arc<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         (**self).hash(state)
     }
+
+    fn hash_end<H: Hasher>(&self, state: &mut H) {
+        (**self).hash_end(state)
+    }
 }
 
 #[cfg(test)]

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -373,6 +373,10 @@ impl<T: ?Sized + Hash> Hash for Box<T> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         (**self).hash(state);
     }
+
+    fn hash_end<H: hash::Hasher>(&self, state: &mut H) {
+        (**self).hash_end(state);
+    }
 }
 
 impl Box<Any> {

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -82,6 +82,7 @@
 #![feature(core_slice_ext)]
 #![feature(custom_attribute)]
 #![feature(fundamental)]
+// #![feature(hash_end)]
 #![feature(lang_items)]
 #![feature(no_std)]
 #![feature(nonzero)]

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -678,6 +678,10 @@ impl<T: ?Sized+Hash> Hash for Rc<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         (**self).hash(state);
     }
+
+    fn hash_end<H: Hasher>(&self, state: &mut H) {
+        (**self).hash_end(state);
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcollections/borrow.rs
+++ b/src/libcollections/borrow.rs
@@ -232,6 +232,11 @@ impl<'a, B: ?Sized> Hash for Cow<'a, B> where B: Hash + ToOwned
     fn hash<H: Hasher>(&self, state: &mut H) {
         Hash::hash(&**self, state)
     }
+
+    #[inline]
+    fn hash_end<H: Hasher>(&self, state: &mut H) {
+        Hash::hash_end(&**self, state)
+    }
 }
 
 /// Trait for moving into a `Cow`.

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -889,6 +889,11 @@ impl<'a, K: Ord + Copy, V: Copy> Extend<(&'a K, &'a V)> for BTreeMap<K, V> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<K: Hash, V: Hash> Hash for BTreeMap<K, V> {
     fn hash<H: Hasher>(&self, state: &mut H) {
+        self.len().hash(state);
+        self.hash_end(state);
+    }
+
+    fn hash_end<H: Hasher>(&self, state: &mut H) {
         for elt in self {
             elt.hash(state);
         }

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -45,6 +45,7 @@
 #![feature(core_str_ext)]
 #![feature(fmt_internals)]
 #![feature(fmt_radix)]
+// #![feature(hash_end)]
 #![feature(heap_api)]
 #![feature(iter_order)]
 #![feature(iter_arith)]

--- a/src/libcollections/linked_list.rs
+++ b/src/libcollections/linked_list.rs
@@ -963,6 +963,10 @@ impl<A: fmt::Debug> fmt::Debug for LinkedList<A> {
 impl<A: Hash> Hash for LinkedList<A> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.len().hash(state);
+        self.hash_end(state);
+    }
+
+    fn hash_end<H: Hasher>(&self, state: &mut H) {
         for elt in self {
             elt.hash(state);
         }

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -1033,6 +1033,11 @@ impl hash::Hash for String {
     fn hash<H: hash::Hasher>(&self, hasher: &mut H) {
         (**self).hash(hasher)
     }
+
+    #[inline]
+    fn hash_end<H: hash::Hasher>(&self, hasher: &mut H) {
+        (**self).hash_end(hasher)
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1098,6 +1098,11 @@ impl<T: Hash> Hash for Vec<T> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         Hash::hash(&**self, state)
     }
+
+    #[inline]
+    fn hash_end<H: hash::Hasher>(&self, state: &mut H) {
+        Hash::hash_end(&**self, state)
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcollections/vec_deque.rs
+++ b/src/libcollections/vec_deque.rs
@@ -1696,6 +1696,10 @@ impl<A: Ord> Ord for VecDeque<A> {
 impl<A: Hash> Hash for VecDeque<A> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.len().hash(state);
+        self.hash_end(state);
+    }
+
+    fn hash_end<H: Hasher>(&self, state: &mut H) {
         for elt in self {
             elt.hash(state);
         }

--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -106,6 +106,10 @@ macro_rules! array_impls {
                 fn hash<H: hash::Hasher>(&self, state: &mut H) {
                     Hash::hash(&self[..], state)
                 }
+
+                fn hash_end<H: hash::Hasher>(&self, state: &mut H) {
+                    Hash::hash_end(&self[..], state)
+                }
             }
 
             #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcoretest/hash/mod.rs
+++ b/src/libcoretest/hash/mod.rs
@@ -41,6 +41,12 @@ fn test_writer_hasher() {
         s.finish()
     }
 
+    fn hash_end<T: Hash>(t: &T) -> u64 {
+        let mut s = MyHasher { hash: 0 };
+        t.hash_end(&mut s);
+        s.finish()
+    }
+
     assert_eq!(hash(&()), 0);
 
     assert_eq!(hash(&5_u8), 5);
@@ -78,6 +84,13 @@ fn test_writer_hasher() {
 
     let ptr = 5_usize as *mut i32;
     assert_eq!(hash(&ptr), 5);
+
+    assert_eq!(hash_end(&5_u32), 5);
+    assert_eq!(hash_end(&s), 97);
+    assert_eq!(hash_end(&("a", "b")), 97 + 98 + 0xFF);
+    assert_eq!(hash_end(&(42u8, "a")), 42 + 97);
+    assert_eq!(hash_end(&("a", 42u8)), 97 + 0xFF + 42);
+    assert_eq!(hash_end(&&s), 97);
 }
 
 struct Custom { hash: u64 }

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -36,6 +36,7 @@
 #![feature(dynamic_lib)]
 #![feature(enumset)]
 #![feature(fs_canonicalize)]
+// #![feature(hash_end)]
 #![feature(hashmap_hasher)]
 #![feature(into_cow)]
 #![feature(iter_cmp)]

--- a/src/librustc/middle/ty/context.rs
+++ b/src/librustc/middle/ty/context.rs
@@ -692,6 +692,10 @@ impl<'tcx> Hash for InternedTy<'tcx> {
     fn hash<H: Hasher>(&self, s: &mut H) {
         self.ty.sty.hash(s)
     }
+
+    fn hash_end<H: Hasher>(&self, s: &mut H) {
+        self.ty.sty.hash_end(s)
+    }
 }
 
 impl<'tcx> Borrow<TypeVariants<'tcx>> for InternedTy<'tcx> {

--- a/src/libstd/collections/hash/table.rs
+++ b/src/libstd/collections/hash/table.rs
@@ -148,7 +148,7 @@ pub fn make_hash<T: ?Sized, S>(hash_state: &S, t: &T) -> SafeHash
     where T: Hash, S: HashState
 {
     let mut state = hash_state.hasher();
-    t.hash(&mut state);
+    t.hash_end(&mut state);
     // We need to avoid 0 in order to prevent collisions with
     // EMPTY_HASH. We can maintain our precious uniform distribution
     // of initial indexes by unconditionally setting the MSB,

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -211,6 +211,11 @@ impl Hash for OsString {
     fn hash<H: Hasher>(&self, state: &mut H) {
         (&**self).hash(state)
     }
+
+    #[inline]
+    fn hash_end<H: Hasher>(&self, state: &mut H) {
+        (&**self).hash_end(state)
+    }
 }
 
 impl OsStr {
@@ -346,6 +351,11 @@ impl Ord for OsStr {
 impl Hash for OsStr {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
+        self.bytes().hash(state)
+    }
+
+    #[inline]
+    fn hash_end<H: Hasher>(&self, state: &mut H) {
         self.bytes().hash(state)
     }
 }

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -222,6 +222,7 @@
 #![feature(core_simd)]
 #![feature(drain)]
 #![feature(fnbox)]
+// #![feature(hash_end)]
 #![feature(heap_api)]
 #![feature(int_error_internals)]
 #![feature(into_cow)]

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -28,6 +28,7 @@
 #![feature(associated_consts)]
 #![feature(drain)]
 #![feature(filling_drop)]
+// #![feature(hash_end)]
 #![feature(libc)]
 #![feature(ref_slice)]
 #![feature(rustc_private)]

--- a/src/libsyntax/util/interner.rs
+++ b/src/libsyntax/util/interner.rs
@@ -19,7 +19,7 @@ use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
-use std::hash::Hash;
+use std::hash::{Hash,Hasher};
 use std::ops::Deref;
 use std::rc::Rc;
 
@@ -92,9 +92,19 @@ impl<T: Eq + Hash + Clone + 'static> Interner<T> {
     }
 }
 
-#[derive(Clone, PartialEq, Hash, PartialOrd)]
+#[derive(Clone, PartialEq, PartialOrd)]
 pub struct RcStr {
     string: Rc<String>,
+}
+
+impl Hash for RcStr {
+    fn hash<H: Hasher>(&self, s: &mut H) {
+        self.string.hash(s);
+    }
+
+    fn hash_end<H: Hasher>(&self, s: &mut H) {
+        self.string.hash_end(s);
+    }
 }
 
 impl RcStr {


### PR DESCRIPTION
# Why?

Since hash functions are already designed to prevent collisions between a string and its prefixes, it's somewhat inelegant that we append a sentinel byte to strings for hashing.  I was looking at #25237 a few days ago and realized that if we distinguish hashing contexts which are at the end of the key from those that aren't, we can suppress the sentinel byte (and also vector lengths) in the cases where they aren't needed; in addition to saving a byte of hashing, it saves a call to update and associated buffer-management overhead.

This attacks the same problem as #28044.
# How?

This adds a new method `hash_end` to the `Hash` trait, which behaves exactly as `hash` _except_ that it need not produce a prefix-free encoding.  It is always legal for `hash_end` to be the same as `hash`, and as such this is the default implementation.  There are specialized implementations for strings and slices which remove the end/length markers.
# How much?

Here's a small benchmark script:

``` rust
use std::hash::{Hasher,Hash,SipHasher};
use std::env;

fn main() {
    let args : Vec<String> = env::args().collect();
    let mut acc = 0u64;
    match &*args[1] {
        "0" => {
            for i in 1 .. 10_000_000 {
                acc += format!("{}", i).len() as u64; // not doing hashing
            }
        },
        "1" => {
            for i in 1 .. 10_000_000 {
                let mut _h = SipHasher::new();
                format!("{}", i).hash_end(&mut _h);
                acc += _h.finish();
            }
        },
        "2" => {
            for i in 1 .. 10_000_000 {
                let mut _h = SipHasher::new();
                format!("{}", i).hash(&mut _h);
                acc += _h.finish();
            }
        },
        "3" => {
            let mut s = std::collections::HashSet::new();
            for i in 1 .. 10_000_000 {
                s.insert(format!("{}", i));
            }
            acc = s.len() as u64;
        },
        "4" => {
            let mut s = std::collections::HashSet::new();
            for i in 1 .. 100_000 {
                s.insert(format!("{}", i));
            }
            for i in 1 .. 10_000_000 {
                if s.contains(&format!("{}", i)) { acc += 1; }
            }
        }
        _ => {},
    }
    println!("{}", acc);
}
```

I ran it in each mode on the patched and baseline rust compilers (with `-O`, on x86_64 OSX), median of 27 runs each time, for the following timings:

```
            (0)   (1)   (2)   (3)   (4)
PATCHED   0.864 1.133 1.276 5.564 1.619
BASELINE  0.852 ----- 1.298 5.654 1.736
```

Subtracting out the baseline (0) case which just allocates and frees strings, it looks like a 34% improvement on short string hashing, 13% on hashset queries, and 2% on hashset insertions.  Uncertainty for the medians seems to be around 10ms.
# What's the catch?
- Naturally this changes hash values.  It's not clear how big a deal that is, especially in re semver.
- More importantly: anybody who needs two types to have the same hash values (in particular `Borrow` implementers) can no longer generally do so by forwarding the `hash` method; `hash_end` must be forwarded as well.  This situation exists exactly once in the compiler.  `#[derive(Hash)]` has been modified to forward `hash_end`, so newtype-ish wrappers will just work (outside of the compiler; the compiler needs to implement `hash_end` itself when it's needed for `Borrow`, because we can't rely on the stage0 to do it.)
# Wait!

`hash_end` should probably be feature gated.  It's not in this version of the patch, because when I tried feature gating it deriving broke; I'm not sure how to tell rustc to ignore feature gates in deriving-generated code.

I'm not sure whether this belongs as an RFC.
