### PR TITLE
Generate stability attributes for derived impls

### DIFF
--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -417,7 +417,7 @@ impl<'a> TraitDef<'a> {
                 let mut attrs = newitem.attrs.clone();
                 attrs.extend(item.attrs.iter().filter(|a| {
                     match &a.name()[..] {
-                        "allow" | "warn" | "deny" | "forbid" => true,
+                        "allow" | "warn" | "deny" | "forbid" | "stable" | "unstable" => true,
                         _ => false,
                     }
                 }).cloned());


### PR DESCRIPTION
The attributes are copied from the item for which the trait impl is derived

I think now we can close these two issues:
https://github.com/rust-lang/rust/issues/13054 - `allow`, `deny` etc. were already copied, now `stable` and `unstable` are copied as well.
https://github.com/rust-lang/rust/issues/18969 - I'm not sure this is needed, insta-stability were good enough so far, copied stability will be better. Nonetheless, it can be subsumed by some more general mechanism for supplying arbitrary not necessarily stability related attributes (for example `inline`) to derived impls and their methods (I haven't found an open issue for such mechanism).

r? @alexcrichton 
