### PR TITLE
fix markdown in nomicon/dropck

### DIFF
--- a/src/doc/nomicon/dropck.md
+++ b/src/doc/nomicon/dropck.md
@@ -220,6 +220,7 @@ checking the implicit assertion that no potentially expired data
 It is sometimes obvious that no such access can occur, like the case above.
 However, when dealing with a generic type parameter, such access can
 occur indirectly. Examples of such indirect access are:
+
  * invoking a callback,
  * via a trait method call.
 


### PR DESCRIPTION
Yay, markdown isn't standardized and rustbook's parser has subtle incompatibilities with Github's! So in the Github preview you don't see that this list fails to separate from the previous paragraph. I think this should fix it, but I didn't check.
