### PR TITLE
Fixup some inconsistent whitespace

### DIFF
--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -1390,8 +1390,7 @@ enum Bar { A(u8), B(&bool), }        // error
 enum Bar<'a> { A(u8), B(&'a bool), } // correct
 
 type MyStr = &str;        // error
-type MyStr<'a> = &'a str; //correct
-
+type MyStr<'a> = &'a str; // correct
 ```
 
 Lifetime elision is a special, limited kind of inference for lifetimes in


### PR DESCRIPTION
This is a pretty trivial change. My eye caught some inconsistent whitespace while perusing compiler errors tonight. Specifically, I changed `//correct` to `// correct`, and got rid of some trailing whitespace that isn't seen in other code snippets.
