### PR TITLE
Add example for installing git in MSYS2

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Read ["Installing Rust"] from [The Book].
    $ pacman -S mingw-w64-i686-toolchain
    $ pacman -S mingw-w64-x86_64-toolchain
 
+   # Make git available in MSYS2 (if not already available on path)
+   $ pacman -S git
+
    $ pacman -S base-devel
    ```
 
@@ -98,7 +101,7 @@ Building the documentation requires building the compiler, so the above
 details will apply. Once you have the compiler built, you can
 
 ```sh
-$ make docs NO_REBUILD=1 
+$ make docs NO_REBUILD=1
 ```
 
 To make sure you don’t re-build the compiler because you made a change


### PR DESCRIPTION
Adds the pacman git command to the high level Windows installation instructions. As the MSYS2 installation may not include Windows git on the path by default (based on the path settings of Windows users), I figured this could be a helpful inclusion.
