### PR TITLE
Add dropck unsafe escape hatch (UGEH) to vec::IntoIter.

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1577,6 +1577,7 @@ impl<T> ExactSizeIterator for IntoIter<T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> Drop for IntoIter<T> {
+    #[unsafe_destructor_blind_to_params]
     fn drop(&mut self) {
         // destroy the remaining elements
         for _x in self {}

--- a/src/test/run-pass/issue-29166.rs
+++ b/src/test/run-pass/issue-29166.rs
@@ -1,0 +1,30 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This test ensures that vec.into_iter does not overconstrain element lifetime.
+
+pub fn main() {
+    original_report();
+    revision_1();
+    revision_2();
+}
+
+fn original_report() {
+    drop(vec![&()].into_iter())
+}
+
+fn revision_1() {
+    // below is what above `vec!` expands into at time of this writing.
+    drop(<[_]>::into_vec(::std::boxed::Box::new([&()])).into_iter())
+}
+
+fn revision_2() {
+    drop((match (Vec::new(), &()) { (mut v, b) => { v.push(b); v } }).into_iter())
+}


### PR DESCRIPTION
Add dropck unsafe escape hatch (UGEH) to vec::IntoIter.

Fix #29166 
