### PR TITLE
Add `naked` attribute

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -1847,6 +1847,8 @@ type int8_t = i8;
 - `should_panic` - indicates that this test function should panic, inverting the success condition.
 - `cold` - The function is unlikely to be executed, so optimize it (and calls
   to it) differently.
+- `naked` - The function utilizes a custom ABI or custom inline ASM that requires
+  the normal stack frame and return to be left out.
 
 ### Static-only attributes
 

--- a/src/librustc_trans/trans/attributes.rs
+++ b/src/librustc_trans/trans/attributes.rs
@@ -43,6 +43,21 @@ pub fn inline(val: ValueRef, inline: InlineAttr) {
     };
 }
 
+/// Tell LLVM whether the function should be naked.
+#[inline]
+pub fn naked(val: ValueRef, naked: bool) {
+    if naked {
+        llvm::SetFunctionAttribute(val, llvm::Attribute::Naked);
+    } else {
+        unsafe {
+            llvm::LLVMRemoveFunctionAttr(
+                val,
+                llvm::Attribute::Naked.bits() as c_ulonglong,
+            );
+        }
+    }
+}
+
 /// Tell LLVM to emit or not emit the information necessary to unwind the stack for the function.
 #[inline]
 pub fn emit_uwtable(val: ValueRef, emit: bool) {
@@ -116,6 +131,8 @@ pub fn from_fn_attrs(ccx: &CrateContext, attrs: &[ast::Attribute], llfn: ValueRe
                                                llvm::FunctionIndex as c_uint,
                                                llvm::ColdAttribute as u64)
             }
+        }else if attr.check_name("naked") {
+            naked(llfn, true);
         } else if attr.check_name("allocator") {
             llvm::Attribute::NoAlias.apply_llfn(llvm::ReturnIndex as c_uint, llfn);
         } else if attr.check_name("unwind") {

--- a/src/librustc_trans/trans/attributes.rs
+++ b/src/librustc_trans/trans/attributes.rs
@@ -131,7 +131,7 @@ pub fn from_fn_attrs(ccx: &CrateContext, attrs: &[ast::Attribute], llfn: ValueRe
                                                llvm::FunctionIndex as c_uint,
                                                llvm::ColdAttribute as u64)
             }
-        }else if attr.check_name("naked") {
+        } else if attr.check_name("naked") {
             naked(llfn, true);
         } else if attr.check_name("allocator") {
             llvm::Attribute::NoAlias.apply_llfn(llvm::ReturnIndex as c_uint, llfn);

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -328,7 +328,7 @@ pub const KNOWN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeGat
     ("cold", Whitelisted, Ungated),
     ("naked", Whitelisted, Gated("naked",
                                     "the `#[naked]` attribute \
-                                     is an experimental feature"))),
+                                     is an experimental feature")),
     ("export_name", Whitelisted, Ungated),
     ("inline", Whitelisted, Ungated),
     ("link", Whitelisted, Ungated),

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -326,6 +326,7 @@ pub const KNOWN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeGat
     // FIXME: #14406 these are processed in trans, which happens after the
     // lint pass
     ("cold", Whitelisted, Ungated),
+    ("naked", Whitelisted, Ungated),
     ("export_name", Whitelisted, Ungated),
     ("inline", Whitelisted, Ungated),
     ("link", Whitelisted, Ungated),

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -193,6 +193,9 @@ const KNOWN_FEATURES: &'static [(&'static str, &'static str, Option<u32>, Status
     // allow `extern "platform-intrinsic" { ... }`
     ("platform_intrinsics", "1.4.0", Some(27731), Active),
 
+    // allow `#[naked]`
+    ("naked_attributes", "1.5.0", None, Active),
+
     // allow `#[unwind]`
     ("unwind_attributes", "1.4.0", None, Active),
 
@@ -326,7 +329,7 @@ pub const KNOWN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeGat
     // FIXME: #14406 these are processed in trans, which happens after the
     // lint pass
     ("cold", Whitelisted, Ungated),
-    ("naked", Whitelisted, Gated("naked",
+    ("naked", Whitelisted, Gated("naked_attributes",
                                     "the `#[naked]` attribute \
                                      is an experimental feature")),
     ("export_name", Whitelisted, Ungated),

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -326,7 +326,9 @@ pub const KNOWN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeGat
     // FIXME: #14406 these are processed in trans, which happens after the
     // lint pass
     ("cold", Whitelisted, Ungated),
-    ("naked", Whitelisted, Ungated),
+    ("naked", Whitelisted, Gated("naked",
+                                    "the `#[naked]` attribute \
+                                     is an experimental feature"))),
     ("export_name", Whitelisted, Ungated),
     ("inline", Whitelisted, Ungated),
     ("link", Whitelisted, Ungated),


### PR DESCRIPTION
**Description:**
The naked attribute allows functions to be defined that do not have standard wrappers, like stack frames, local variables, or a function return.

This change exposes the LLVM Naked function attribute by using the #[naked] attribute on a Rust function.

Because it is unsafe to use, it is feature gated behind #![feature(naked)]. I have already verified that Rust builds correctly with this change.

**Rationale:**
The current rustc provides no mechanism for defining these functions _correctly_, which is why this change is required for operating systems development in Rust, such as the development of Redox.

This is highly important when designing operating systems, due to requirements for interrupt handlers and context switching, or other functions like green threads, virtual machines, and emulators. These require predictable assembly output, without any wrapping instructions. This has limited some features to only being possible in external assembly or C.

http://wiki.osdev.org/Interrupt_Service_Routines#Naked_Functions

**Example:**
A very simple example of use, inside an interrupt handler:

``` rust
#![feature(naked)]

#[naked]
#[cfg(target_arch = "x86")]
fn interrupt_handler(){
    asm!("iretd");
}
```

Which will generate:

``` asm
interrupt_handler:
   iretd
```

This is more correct than the current operation:

``` rust
#[cfg(target_arch = "x86")]
fn interrupt_handler(){
    asm!("iretd");
}
```

Which will generate something similar to:

``` asm
interrupt_handler:
   push ebp
   mov ebp, esp
   iretd
   ret
```
