### PR TITLE
Remove reference to `hello_world.rs` in TRPL §2.2

### DIFF
--- a/src/doc/trpl/hello-world.md
+++ b/src/doc/trpl/hello-world.md
@@ -37,8 +37,9 @@ If we’re on Windows and not using PowerShell, the `~` may not work. Consult th
 documentation for our shell for more details.
 
 Let’s make a new source file next. We’ll call our file `main.rs`. Rust files
-always end in a `.rs` extension. If we’re using more than one word in our
-filename, use an underscore: `hello_world.rs` rather than `helloworld.rs`.
+always end in a `.rs` extension, and if we’re using more than one word in a
+Rust filename, we use an underscore: for example, `linked_list.rs`, not
+`linkedlist.rs` or `LinkedList.rs`.
 
 Now that we’ve got our file open, type this in:
 


### PR DESCRIPTION
When reading this paragraph, the beginning Rust programmer is starting
to write a Hello World program.  We have just told her to name the file
`main.rs`, and immediately afterward, a `hello_world.rs` is mentioned.
I changed this to an unrelated filename (incidentally one that appears
in this repository) to make it clear that this is just an example.
Also, wording it as a declarative sentence rather than an imperative one
further separates it from the Hello World instructions in this section.

r? @steveklabnik 

(Let me know if I'm sending too many PRs -- I can batch up TRPL edits, say, per chapter, if that works better. Or I can just refrain from editing TRPL as I read through it, if these are not sufficiently useful.)
