### PR TITLE
don't revisit modules while finding traits in suggest

### DIFF
--- a/src/test/auxiliary/issue-29181.rs
+++ b/src/test/auxiliary/issue-29181.rs
@@ -1,0 +1,15 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type="lib"]
+
+pub mod foo {
+    pub use super::*;
+}

--- a/src/test/compile-fail/issue-29181.rs
+++ b/src/test/compile-fail/issue-29181.rs
@@ -1,0 +1,17 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-29181.rs
+
+extern crate issue_29181 as foo;
+
+fn main() {
+    0.homura(); //~ ERROR no method named `homura` found
+}


### PR DESCRIPTION
This prevents a stack-overflow when the module graph was cyclic.

Fixes #29181 

r? @eddyb 
