### PR TITLE
Issue 28157 bad semicolon

### DIFF
--- a/src/doc/grammar.md
+++ b/src/doc/grammar.md
@@ -436,7 +436,7 @@ meta_seq : meta_item [ ',' meta_seq ] ? ;
 ## Statements
 
 ```antlr
-stmt : decl_stmt | expr_stmt ;
+stmt : decl_stmt | expr_stmt | ';' ;
 ```
 
 ### Declaration statements

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -207,7 +207,7 @@ impl CStore {
                 visit(cstore, dep, ordering);
             }
             ordering.push(cnum);
-        };
+        }
         for (&num, _) in self.metas.borrow().iter() {
             visit(self, num, &mut ordering);
         }

--- a/src/librustc_trans/save/dump_csv.rs
+++ b/src/librustc_trans/save/dump_csv.rs
@@ -58,7 +58,7 @@ macro_rules! down_cast_data {
             data
         } else {
             $this.sess.span_bug($sp, &format!("unexpected data kind: {:?}", $id));
-        };
+        }
     };
 }
 

--- a/src/librustc_trans/trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/trans/debuginfo/metadata.rs
@@ -480,7 +480,7 @@ macro_rules! return_if_metadata_created_in_meantime {
                                 .find_metadata_for_unique_id($unique_type_id) {
             Some(metadata) => return MetadataCreationResult::new(metadata, true),
             None => { /* proceed normally */ }
-        };
+        }
     )
 }
 

--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -28,7 +28,7 @@ pub fn strip_hidden(krate: clean::Crate) -> plugins::PluginResult {
     let krate = {
         struct Stripper<'a> {
             stripped: &'a mut DefIdSet
-        };
+        }
         impl<'a> fold::DocFolder for Stripper<'a> {
             fn fold_item(&mut self, i: Item) -> Option<Item> {
                 if i.is_hidden_from_doc() {
@@ -60,7 +60,7 @@ pub fn strip_hidden(krate: clean::Crate) -> plugins::PluginResult {
     let krate = {
         struct ImplStripper<'a> {
             stripped: &'a mut DefIdSet
-        };
+        }
         impl<'a> fold::DocFolder for ImplStripper<'a> {
             fn fold_item(&mut self, i: Item) -> Option<Item> {
                 if let clean::ImplItem(clean::Impl{

--- a/src/libstd/sys/common/wtf8.rs
+++ b/src/libstd/sys/common/wtf8.rs
@@ -1019,7 +1019,7 @@ mod tests {
     fn wtf8buf_from_iterator() {
         fn f(values: &[u32]) -> Wtf8Buf {
             values.iter().map(|&c| CodePoint::from_u32(c).unwrap()).collect::<Wtf8Buf>()
-        };
+        }
         assert_eq!(f(&[0x61, 0xE9, 0x20, 0x1F4A9]).bytes, b"a\xC3\xA9 \xF0\x9F\x92\xA9");
 
         assert_eq!(f(&[0xD83D, 0xDCA9]).bytes, b"\xF0\x9F\x92\xA9");  // Magic!
@@ -1038,7 +1038,7 @@ mod tests {
             let mut string = initial.iter().map(c).collect::<Wtf8Buf>();
             string.extend(extended.iter().map(c));
             string
-        };
+        }
 
         assert_eq!(e(&[0x61, 0xE9], &[0x20, 0x1F4A9]).bytes,
                    b"a\xC3\xA9 \xF0\x9F\x92\xA9");

--- a/src/libterm/terminfo/searcher.rs
+++ b/src/libterm/terminfo/searcher.rs
@@ -102,7 +102,7 @@ fn test_get_dbpath_for_term() {
     fn x(t: &str) -> String {
         let p = get_dbpath_for_term(t).expect("no terminfo entry found");
         p.to_str().unwrap().to_string()
-    };
+    }
     assert!(x("screen") == "/usr/share/terminfo/s/screen");
     assert!(get_dbpath_for_term("") == None);
     env::set_var("TERMINFO_DIRS", ":");

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -924,7 +924,7 @@ pub fn filter_tests(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> Vec<TestDescA
             } else {
                 None
             }
-        };
+        }
         filtered.into_iter().filter_map(filter).collect()
     };
 


### PR DESCRIPTION
PR for #28157. At the moment, `rustc` emits a warning when a bare semicolon is encountered (could also be a fail, but I think this is a backwards incompatible change).

Also I am not sure where the best place for a test for that warning would be. Seems run-pass tests do not check warnings.
