### PR TITLE
Add additional automatic conversions to usize/isize.

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1473,9 +1473,12 @@ impl fmt::Display for ParseIntError {
 
 pub use num::dec2flt::ParseFloatError;
 
-// Conversion traits for primitive integer types
-// Conversions T -> T are covered by a blanket impl and therefore excluded
-// Some conversions from and to usize/isize are not implemented due to portability concerns
+// Conversion traits for primitive integer types (only) where the conversion is
+// guaranteed to be lossless on all platforms. Conversions T -> T are covered
+// by a blanket impl and therefore excluded. Conversions from `usize` and
+// `isize` to other types are not implemented because there are no primitive
+// integer types that are defined to be at least as large as them on all
+// architectures.
 macro_rules! impl_from {
     ($Small: ty, $Large: ty) => {
         #[stable(feature = "lossless_int_conv", since = "1.5.0")]
@@ -1496,6 +1499,7 @@ impl_from! { u8, u64 }
 impl_from! { u8, usize }
 impl_from! { u16, u32 }
 impl_from! { u16, u64 }
+impl_from! { u16, usize }
 impl_from! { u32, u64 }
 
 // Signed -> Signed
@@ -1505,12 +1509,14 @@ impl_from! { i8, i64 }
 impl_from! { i8, isize }
 impl_from! { i16, i32 }
 impl_from! { i16, i64 }
+impl_from! { i16, isize }
 impl_from! { i32, i64 }
 
 // Unsigned -> Signed
 impl_from! { u8, i16 }
 impl_from! { u8, i32 }
 impl_from! { u8, i64 }
+impl_from! { u8, isize }
 impl_from! { u16, i32 }
 impl_from! { u16, i64 }
 impl_from! { u32, i64 }

--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -405,6 +405,8 @@ mod prim_u64 { }
 //
 /// The pointer-sized signed integer type.
 ///
+/// `isize` is guaranteed to at least as large as `i16`.
+///
 /// *[See also the `std::isize` module](isize/index.html).*
 ///
 mod prim_isize { }
@@ -412,6 +414,8 @@ mod prim_isize { }
 #[doc(primitive = "usize")]
 //
 /// The pointer-sized unsigned integer type.
+///
+/// `usize` is guaranteed to be at least as large as `u16`.
 ///
 /// *[See also the `std::usize` module](usize/index.html).*
 ///


### PR DESCRIPTION
Also, improve the documentation related to the range of usize and isize.

See https://github.com/rust-lang/rfcs/pull/1218#issuecomment-146615171 and https://github.com/rust-lang/rust/pull/28921#issuecomment-149427316.

I decided to be conservative and assume that 16-bit platform support might be added in the future, because C99 supports platforms with 16-bit `size_t`. In particular, C99 specifies that the range of `size_t` is at least [0, 65535]; i.e. `SIZE_MAX` must be at least `65,535` and so `sizeof(size_t) >= 2`.
