### PR TITLE
Improve safety & usability of |size_t| and |ssize_t|.

### DIFF
--- a/src/liballoc_jemalloc/lib.rs
+++ b/src/liballoc_jemalloc/lib.rs
@@ -77,7 +77,7 @@ fn align_to_flags(align: usize) -> c_int {
 #[no_mangle]
 pub extern "C" fn __rust_allocate(size: usize, align: usize) -> *mut u8 {
     let flags = align_to_flags(align);
-    unsafe { je_mallocx(size as size_t, flags) as *mut u8 }
+    unsafe { je_mallocx(size, flags) as *mut u8 }
 }
 
 #[no_mangle]
@@ -87,7 +87,7 @@ pub extern "C" fn __rust_reallocate(ptr: *mut u8,
                                     align: usize)
                                     -> *mut u8 {
     let flags = align_to_flags(align);
-    unsafe { je_rallocx(ptr as *mut c_void, size as size_t, flags) as *mut u8 }
+    unsafe { je_rallocx(ptr as *mut c_void, size, flags) as *mut u8 }
 }
 
 #[no_mangle]
@@ -97,17 +97,17 @@ pub extern "C" fn __rust_reallocate_inplace(ptr: *mut u8,
                                             align: usize)
                                             -> usize {
     let flags = align_to_flags(align);
-    unsafe { je_xallocx(ptr as *mut c_void, size as size_t, 0, flags) as usize }
+    unsafe { je_xallocx(ptr as *mut c_void, size, 0, flags) as usize }
 }
 
 #[no_mangle]
 pub extern "C" fn __rust_deallocate(ptr: *mut u8, old_size: usize, align: usize) {
     let flags = align_to_flags(align);
-    unsafe { je_sdallocx(ptr as *mut c_void, old_size as size_t, flags) }
+    unsafe { je_sdallocx(ptr as *mut c_void, old_size, flags) }
 }
 
 #[no_mangle]
 pub extern "C" fn __rust_usable_size(size: usize, align: usize) -> usize {
     let flags = align_to_flags(align);
-    unsafe { je_nallocx(size as size_t, flags) as usize }
+    unsafe { je_nallocx(size, flags) as usize }
 }

--- a/src/liballoc_jemalloc/lib.rs
+++ b/src/liballoc_jemalloc/lib.rs
@@ -97,7 +97,7 @@ pub extern "C" fn __rust_reallocate_inplace(ptr: *mut u8,
                                             align: usize)
                                             -> usize {
     let flags = align_to_flags(align);
-    unsafe { je_xallocx(ptr as *mut c_void, size, 0, flags) as usize }
+    unsafe { je_xallocx(ptr as *mut c_void, size, 0, flags) }
 }
 
 #[no_mangle]
@@ -109,5 +109,5 @@ pub extern "C" fn __rust_deallocate(ptr: *mut u8, old_size: usize, align: usize)
 #[no_mangle]
 pub extern "C" fn __rust_usable_size(size: usize, align: usize) -> usize {
     let flags = align_to_flags(align);
-    unsafe { je_nallocx(size, flags) as usize }
+    unsafe { je_nallocx(size, flags) }
 }

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1473,9 +1473,12 @@ impl fmt::Display for ParseIntError {
 
 pub use num::dec2flt::ParseFloatError;
 
-// Conversion traits for primitive integer types
-// Conversions T -> T are covered by a blanket impl and therefore excluded
-// Some conversions from and to usize/isize are not implemented due to portability concerns
+// Conversion traits for primitive integer types (only) where the conversion is
+// guaranteed to be lossless on all platforms. Conversions T -> T are covered
+// by a blanket impl and therefore excluded. Conversions from `usize` and
+// `isize` to other types are not implemented because there are no primitive
+// integer types that are defined to be at least as large as them on all
+// architectures.
 macro_rules! impl_from {
     ($Small: ty, $Large: ty) => {
         #[stable(feature = "lossless_int_conv", since = "1.5.0")]
@@ -1496,6 +1499,7 @@ impl_from! { u8, u64 }
 impl_from! { u8, usize }
 impl_from! { u16, u32 }
 impl_from! { u16, u64 }
+impl_from! { u16, usize }
 impl_from! { u32, u64 }
 
 // Signed -> Signed
@@ -1505,12 +1509,14 @@ impl_from! { i8, i64 }
 impl_from! { i8, isize }
 impl_from! { i16, i32 }
 impl_from! { i16, i64 }
+impl_from! { i16, isize }
 impl_from! { i32, i64 }
 
 // Unsigned -> Signed
 impl_from! { u8, i16 }
 impl_from! { u8, i32 }
 impl_from! { u8, i64 }
+impl_from! { u8, isize }
 impl_from! { u16, i32 }
 impl_from! { u16, i64 }
 impl_from! { u32, i64 }

--- a/src/libflate/lib.rs
+++ b/src/libflate/lib.rs
@@ -103,10 +103,8 @@ const TDEFL_WRITE_ZLIB_HEADER: c_int = 0x01000; // write zlib header and adler32
 fn deflate_bytes_internal(bytes: &[u8], flags: c_int) -> Bytes {
     unsafe {
         let mut outsz: size_t = 0;
-        let res = tdefl_compress_mem_to_heap(bytes.as_ptr() as *const _,
-                                             bytes.len() as size_t,
-                                             &mut outsz,
-                                             flags);
+        let res = tdefl_compress_mem_to_heap(bytes.as_ptr() as *const _, bytes.len(),
+                                             &mut outsz, flags);
         assert!(!res.is_null());
         Bytes {
             ptr: Unique::new(res as *mut u8),
@@ -129,9 +127,7 @@ fn inflate_bytes_internal(bytes: &[u8], flags: c_int) -> Result<Bytes, Error> {
     unsafe {
         let mut outsz: size_t = 0;
         let res = tinfl_decompress_mem_to_heap(bytes.as_ptr() as *const _,
-                                               bytes.len() as size_t,
-                                               &mut outsz,
-                                               flags);
+                                               bytes.len(), &mut outsz, flags);
         if !res.is_null() {
             Ok(Bytes {
                 ptr: Unique::new(res as *mut u8),

--- a/src/librustc_trans/back/archive.rs
+++ b/src/librustc_trans/back/archive.rs
@@ -21,7 +21,6 @@ use std::process::{Command, Output, Stdio};
 use std::ptr;
 use std::str;
 
-use libc;
 use llvm::archive_ro::{ArchiveRO, Child};
 use llvm::{self, ArchiveKind};
 use rustc::metadata::loader::METADATA_FILENAME;
@@ -489,8 +488,7 @@ impl<'a> ArchiveBuilder<'a> {
 
             let dst = self.config.dst.to_str().unwrap().as_bytes();
             let dst = try!(CString::new(dst));
-            let r = llvm::LLVMRustWriteArchive(dst.as_ptr(),
-                                               members.len() as libc::size_t,
+            let r = llvm::LLVMRustWriteArchive(dst.as_ptr(), members.len(),
                                                members.as_ptr(),
                                                self.should_update_symbols,
                                                kind);

--- a/src/librustc_trans/back/lto.rs
+++ b/src/librustc_trans/back/lto.rs
@@ -100,7 +100,7 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
             time(sess.time_passes(), &format!("ll link {}", name), || unsafe {
                 if !llvm::LLVMRustLinkInExternalBitcode(llmod,
                                                         ptr as *const libc::c_char,
-                                                        bc_decoded.len() as libc::size_t) {
+                                                        bc_decoded.len()) {
                     write::llvm_err(sess.diagnostic().handler(),
                                     format!("failed to load bc of `{}`",
                                             &name[..]));
@@ -118,7 +118,7 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
     unsafe {
         llvm::LLVMRustRunRestrictionPass(llmod,
                                          ptr as *const *const libc::c_char,
-                                         arr.len() as libc::size_t);
+                                         arr.len());
     }
 
     if sess.no_landing_pads() {

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -371,8 +371,7 @@ pub fn render(w: &mut fmt::Formatter, s: &str, print_toc: bool) -> fmt::Result {
         (*renderer).codespan = Some(codespan);
 
         let document = hoedown_document_new(renderer, HOEDOWN_EXTENSIONS, 16);
-        hoedown_document_render(document, ob, s.as_ptr(),
-                                s.len() as libc::size_t);
+        hoedown_document_render(document, ob, s.as_ptr(), s.len());
         hoedown_document_free(document);
 
         hoedown_html_renderer_free(renderer);
@@ -444,8 +443,7 @@ pub fn find_testable_code(doc: &str, tests: &mut ::test::Collector) {
                 = tests as *mut _ as *mut libc::c_void;
 
         let document = hoedown_document_new(renderer, HOEDOWN_EXTENSIONS, 16);
-        hoedown_document_render(document, ob, doc.as_ptr(),
-                                doc.len() as libc::size_t);
+        hoedown_document_render(document, ob, doc.as_ptr(), doc.len());
         hoedown_document_free(document);
 
         hoedown_html_renderer_free(renderer);
@@ -565,8 +563,7 @@ pub fn plain_summary_line(md: &str) -> String {
         (*renderer).normal_text = Some(normal_text);
 
         let document = hoedown_document_new(renderer, HOEDOWN_EXTENSIONS, 16);
-        hoedown_document_render(document, ob, md.as_ptr(),
-                                md.len() as libc::size_t);
+        hoedown_document_render(document, ob, md.as_ptr(), md.len());
         hoedown_document_free(document);
         let plain_slice = (*ob).as_bytes();
         let plain = str::from_utf8(plain_slice).unwrap_or("").to_owned();

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -232,7 +232,7 @@ impl CString {
     #[stable(feature = "cstr_memory", since = "1.4.0")]
     pub unsafe fn from_raw(ptr: *mut libc::c_char) -> CString {
         let len = libc::strlen(ptr) + 1; // Including the NUL byte
-        let slice = slice::from_raw_parts(ptr, len as usize);
+        let slice = slice::from_raw_parts(ptr, len);
         CString { inner: mem::transmute(slice) }
     }
 
@@ -447,7 +447,7 @@ impl CStr {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub unsafe fn from_ptr<'a>(ptr: *const libc::c_char) -> &'a CStr {
         let len = libc::strlen(ptr);
-        mem::transmute(slice::from_raw_parts(ptr, len as usize + 1))
+        mem::transmute(slice::from_raw_parts(ptr, len + 1))
     }
 
     /// Returns the inner pointer to this C string.

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1642,8 +1642,8 @@ mod tests {
             let stem = f.file_stem().unwrap().to_str().unwrap();
             let root = stem.as_bytes()[0] - b'0';
             let name = stem.as_bytes()[1] - b'0';
-            assert!(cur[root as usize] < name);
-            cur[root as usize] = name;
+            assert!(cur[root] < name);
+            cur[root] = name;
         }
 
         check!(fs::remove_dir_all(dir));

--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -405,6 +405,8 @@ mod prim_u64 { }
 //
 /// The pointer-sized signed integer type.
 ///
+/// `isize` is guaranteed to at least as large as `i16`.
+///
 /// *[See also the `std::isize` module](isize/index.html).*
 ///
 mod prim_isize { }
@@ -412,6 +414,8 @@ mod prim_isize { }
 #[doc(primitive = "usize")]
 //
 /// The pointer-sized unsigned integer type.
+///
+/// `usize` is guaranteed to be at least as large as `u16`.
 ///
 /// *[See also the `std::usize` module](usize/index.html).*
 ///

--- a/src/libstd/rand/os.rs
+++ b/src/libstd/rand/os.rs
@@ -236,8 +236,7 @@ mod imp {
         }
         fn fill_bytes(&mut self, v: &mut [u8]) {
             let ret = unsafe {
-                SecRandomCopyBytes(kSecRandomDefault, v.len() as size_t,
-                                   v.as_mut_ptr())
+                SecRandomCopyBytes(kSecRandomDefault, v.len(), v.as_mut_ptr())
             };
             if ret == -1 {
                 panic!("couldn't generate random bytes: {}",

--- a/src/libstd/sys/common/net.rs
+++ b/src/libstd/sys/common/net.rs
@@ -143,7 +143,7 @@ extern "system" {
                    flags: c_int) -> c_int;
 }
 
-const NI_MAXHOST: usize = 1025;
+const NI_MAXHOST: libc::size_t = 1025;
 
 pub fn lookup_addr(addr: &IpAddr) -> io::Result<String> {
     init();
@@ -154,7 +154,7 @@ pub fn lookup_addr(addr: &IpAddr) -> io::Result<String> {
 
     let data = unsafe {
         try!(cvt_gai(getnameinfo(inner, len,
-                                 hostbuf.as_mut_ptr(), NI_MAXHOST as libc::size_t,
+                                 hostbuf.as_mut_ptr(), NI_MAXHOST,
                                  ptr::null_mut(), 0, 0)));
 
         CStr::from_ptr(hostbuf.as_ptr())

--- a/src/libstd/sys/unix/fd.rs
+++ b/src/libstd/sys/unix/fd.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use io;
-use libc::{self, c_int, size_t, c_void};
+use libc::{self, c_int, c_void};
 use mem;
 use sys::c;
 use sys::cvt;
@@ -35,18 +35,14 @@ impl FileDesc {
 
     pub fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
         let ret = try!(cvt(unsafe {
-            libc::read(self.fd,
-                       buf.as_mut_ptr() as *mut c_void,
-                       buf.len() as size_t)
+            libc::read(self.fd, buf.as_mut_ptr() as *mut c_void, buf.len())
         }));
         Ok(ret as usize)
     }
 
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
         let ret = try!(cvt(unsafe {
-            libc::write(self.fd,
-                        buf.as_ptr() as *const c_void,
-                        buf.len() as size_t)
+            libc::write(self.fd, buf.as_ptr() as *const c_void, buf.len())
         }));
         Ok(ret as usize)
     }

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -388,7 +388,7 @@ impl fmt::Debug for File {
                 return None;
             }
             let l = buf.iter().position(|&c| c == 0).unwrap();
-            buf.truncate(l as usize);
+            buf.truncate(l);
             buf.shrink_to_fit();
             Some(PathBuf::from(OsString::from_vec(buf)))
         }

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -14,7 +14,7 @@ use os::unix::prelude::*;
 use ffi::{CString, CStr, OsString, OsStr};
 use fmt;
 use io::{self, Error, ErrorKind, SeekFrom};
-use libc::{self, c_int, size_t, off_t, c_char, mode_t};
+use libc::{self, c_int, off_t, c_char, mode_t};
 use mem;
 use path::{Path, PathBuf};
 use ptr;
@@ -478,7 +478,7 @@ pub fn readlink(p: &Path) -> io::Result<PathBuf> {
 
     loop {
         let buf_read = try!(cvt(unsafe {
-            libc::readlink(p, buf.as_mut_ptr() as *mut _, buf.capacity() as libc::size_t)
+            libc::readlink(p, buf.as_mut_ptr() as *mut _, buf.capacity())
         })) as usize;
 
         unsafe { buf.set_len(buf_read); }

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -83,7 +83,7 @@ pub fn error_string(errno: i32) -> String {
 
     let p = buf.as_mut_ptr();
     unsafe {
-        if strerror_r(errno as c_int, p, buf.len() as libc::size_t) < 0 {
+        if strerror_r(errno as c_int, p, buf.len()) < 0 {
             panic!("strerror_r failure");
         }
 
@@ -97,7 +97,7 @@ pub fn getcwd() -> io::Result<PathBuf> {
     loop {
         unsafe {
             let ptr = buf.as_mut_ptr() as *mut libc::c_char;
-            if !libc::getcwd(ptr, buf.capacity() as libc::size_t).is_null() {
+            if !libc::getcwd(ptr, buf.capacity()).is_null() {
                 let len = CStr::from_ptr(buf.as_ptr() as *const libc::c_char).to_bytes().len();
                 buf.set_len(len);
                 buf.shrink_to_fit();
@@ -488,8 +488,7 @@ pub fn home_dir() -> Option<PathBuf> {
             let mut passwd: c::passwd = mem::zeroed();
             let mut result = ptr::null_mut();
             match c::getpwuid_r(me, &mut passwd, buf.as_mut_ptr(),
-                                buf.capacity() as libc::size_t,
-                                &mut result) {
+                                buf.capacity(), &mut result) {
                 0 if !result.is_null() => {}
                 _ => return None
             }

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -197,13 +197,13 @@ pub fn current_exe() -> io::Result<PathBuf> {
                          0 as libc::size_t);
         if err != 0 { return Err(io::Error::last_os_error()); }
         if sz == 0 { return Err(io::Error::last_os_error()); }
-        let mut v: Vec<u8> = Vec::with_capacity(sz as usize);
+        let mut v: Vec<u8> = Vec::with_capacity(sz);
         let err = sysctl(mib.as_mut_ptr(), mib.len() as ::libc::c_uint,
                          v.as_mut_ptr() as *mut libc::c_void, &mut sz,
                          ptr::null_mut(), 0 as libc::size_t);
         if err != 0 { return Err(io::Error::last_os_error()); }
         if sz == 0 { return Err(io::Error::last_os_error()); }
-        v.set_len(sz as usize - 1); // chop off trailing NUL
+        v.set_len(sz - 1); // chop off trailing NUL
         Ok(PathBuf::from(OsString::from_vec(v)))
     }
 }
@@ -252,10 +252,10 @@ pub fn current_exe() -> io::Result<PathBuf> {
         let mut sz: u32 = 0;
         _NSGetExecutablePath(ptr::null_mut(), &mut sz);
         if sz == 0 { return Err(io::Error::last_os_error()); }
-        let mut v: Vec<u8> = Vec::with_capacity(sz as usize);
+        let mut v: Vec<u8> = Vec::with_capacity(sz);
         let err = _NSGetExecutablePath(v.as_mut_ptr() as *mut i8, &mut sz);
         if err != 0 { return Err(io::Error::last_os_error()); }
-        v.set_len(sz as usize - 1); // chop off trailing NUL
+        v.set_len(sz - 1); // chop off trailing NUL
         Ok(PathBuf::from(OsString::from_vec(v)))
     }
 }
@@ -479,7 +479,7 @@ pub fn home_dir() -> Option<PathBuf> {
                   target_os = "ios")))]
     unsafe fn fallback() -> Option<OsString> {
         let amt = match libc::sysconf(c::_SC_GETPW_R_SIZE_MAX) {
-            n if n < 0 => 512 as usize,
+            n if n < 0 => 512usize,
             n => n as usize,
         };
         let me = libc::getuid();

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -43,7 +43,7 @@ impl Thread {
         assert_eq!(pthread_attr_init(&mut attr), 0);
 
         let stack_size = cmp::max(stack, min_stack_size(&attr));
-        match pthread_attr_setstacksize(&mut attr, stack_size as libc::size_t) {
+        match pthread_attr_setstacksize(&mut attr, stack_size) {
             0 => {}
             n => {
                 assert_eq!(n, libc::EINVAL);
@@ -54,7 +54,7 @@ impl Thread {
                 let page_size = os::page_size();
                 let stack_size = (stack_size + page_size - 1) &
                                  (-(page_size as isize - 1) as usize - 1);
-                let stack_size = stack_size as libc::size_t;
+                let stack_size = stack_size;
                 assert_eq!(pthread_attr_setstacksize(&mut attr, stack_size), 0);
             }
         };
@@ -251,7 +251,7 @@ pub mod guard {
         // This ensures SIGBUS will be raised on
         // stack overflow.
         let result = mmap(stackaddr,
-                          psize as libc::size_t,
+                          psize,
                           PROT_NONE,
                           MAP_PRIVATE | MAP_ANON | MAP_FIXED,
                           -1,
@@ -272,7 +272,7 @@ pub mod guard {
             fn pthread_get_stackaddr_np(thread: pthread_t) -> *mut libc::c_void;
             fn pthread_get_stacksize_np(thread: pthread_t) -> libc::size_t;
         }
-        Some((pthread_get_stackaddr_np(pthread_self()) as libc::size_t -
+        Some((pthread_get_stackaddr_np(pthread_self()) -
               pthread_get_stacksize_np(pthread_self())) as usize)
     }
 

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -377,8 +377,8 @@ fn min_stack_size(attr: *const libc::pthread_attr_t) -> usize {
     });
 
     match unsafe { __pthread_get_minstack } {
-        None => PTHREAD_STACK_MIN as usize,
-        Some(f) => unsafe { f(attr) as usize },
+        None => PTHREAD_STACK_MIN,
+        Some(f) => unsafe { f(attr) },
     }
 }
 
@@ -386,7 +386,7 @@ fn min_stack_size(attr: *const libc::pthread_attr_t) -> usize {
 // platforms.
 #[cfg(not(target_os = "linux"))]
 fn min_stack_size(_: *const libc::pthread_attr_t) -> usize {
-    PTHREAD_STACK_MIN as usize
+    PTHREAD_STACK_MIN
 }
 
 extern {

--- a/src/libstd/sys/windows/thread.rs
+++ b/src/libstd/sys/windows/thread.rs
@@ -37,9 +37,9 @@ impl Thread {
         // Round up to the next 64 kB because that's what the NT kernel does,
         // might as well make it explicit.
         let stack_size = (stack + 0xfffe) & (!0xfffe);
-        let ret = c::CreateThread(ptr::null_mut(), stack_size as libc::size_t,
-                                  thread_start, &*p as *const _ as *mut _,
-                                  0, ptr::null_mut());
+        let ret = c::CreateThread(ptr::null_mut(), stack_size, thread_start,
+                                  &*p as *const _ as *mut _, 0,
+                                  ptr::null_mut());
 
         return if ret as usize == 0 {
             Err(io::Error::last_os_error())

--- a/src/test/auxiliary/allocator-dummy.rs
+++ b/src/test/auxiliary/allocator-dummy.rs
@@ -23,7 +23,7 @@ pub static mut HITS: usize = 0;
 pub extern fn __rust_allocate(size: usize, align: usize) -> *mut u8 {
     unsafe {
         HITS += 1;
-        libc::malloc(size as libc::size_t) as *mut u8
+        libc::malloc(size) as *mut u8
     }
 }
 
@@ -39,7 +39,7 @@ pub extern fn __rust_deallocate(ptr: *mut u8, old_size: usize, align: usize) {
 pub extern fn __rust_reallocate(ptr: *mut u8, old_size: usize, size: usize,
                                 align: usize) -> *mut u8 {
     unsafe {
-        libc::realloc(ptr as *mut _, size as libc::size_t) as *mut u8
+        libc::realloc(ptr as *mut _, size) as *mut u8
     }
 }
 

--- a/src/test/bench/shootout-reverse-complement.rs
+++ b/src/test/bench/shootout-reverse-complement.rs
@@ -103,9 +103,9 @@ impl Tables {
 
 /// Finds the first position at which `b` occurs in `s`.
 fn memchr(h: &[u8], n: u8) -> Option<usize> {
-    use libc::{c_void, c_int, size_t};
+    use libc::{c_void, c_int};
     let res = unsafe {
-        libc::memchr(h.as_ptr() as *const c_void, n as c_int, h.len() as size_t)
+        libc::memchr(h.as_ptr() as *const c_void, n as c_int, h.len())
     };
     if res.is_null() {
         None

--- a/src/test/run-pass/regions-mock-trans.rs
+++ b/src/test/run-pass/regions-mock-trans.rs
@@ -32,8 +32,7 @@ struct Ccx {
 
 fn alloc<'a>(_bcx : &'a arena) -> &'a Bcx<'a> {
     unsafe {
-        mem::transmute(libc::malloc(mem::size_of::<Bcx<'a>>()
-            as libc::size_t))
+        mem::transmute(libc::malloc(mem::size_of::<Bcx<'a>>()))
     }
 }
 


### PR DESCRIPTION
This has been rebased on top of https://github.com/rust-lang/rust/pull/28779 and https://github.com/rust-lang/rust/pull/29220. It is intended to address the `usize`/`isize` related aspects of [RFC 1291](https://github.com/rust-lang/rfcs/pull/1291/).

Note in particular that one of these changesets removes casts that would actually result in unsafe memory usage on any platform where `libc::size_t` is smaller than `usize`.

r? @alexcrichton
