### PR TITLE
Update readme to reflect #28260 and a workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Read ["Installing Rust"] from [The Book].
 > resulting in a segmentation fault when building Rust. In order to avoid this
 > it may be necessary to obtain an earlier version of gcc such as 4.9.x.
 > Installers for earlier Windows builds of gcc are available at the
-> [Mingw-Builds] project.
+> [Mingw-Builds] project. For more information on this see issue #28260.
 
 [Mingw-Builds]: http://sourceforge.net/projects/mingw-w64/
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ Read ["Installing Rust"] from [The Book].
    $ ./configure
    $ make && make install
    ```
+> ***Note:*** gcc versions >= 5 currently have issues building LLVM on Windows
+> resulting in a segmentation fault when building Rust. In order to avoid this
+> it may be necessary to obtain an earlier version of gcc such as 4.9.x.
+> Installers for earlier Windows builds of gcc are available at the
+> [Mingw-Builds] project.
+
+[Mingw-Builds]: http://sourceforge.net/projects/mingw-w64/
 
 ## Building Documentation
 


### PR DESCRIPTION
This PR adds a note to the end of the Windows build instructions to reflect the issues detailed in #28260, as well as a work around using older versions of gcc. I've avoided going into detail as I did not wish to bloat the README, and so that the changes are easy to yank once the issue is resolved.
