### PR TITLE
Add underline hints to the docs. Exclude obvious things.

### DIFF
--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -172,6 +172,28 @@ nav.sub {
 
 /* Everything else */
 
+#main a {
+    border-bottom: dashed 1px #aaa;
+}
+#main a:hover {
+    border-bottom: dashed 1px black;
+}
+
+#main h1 a,
+#main h2 a,
+#main .collapse-toggle,
+#main .docblock a,
+#main .stability a {
+    border-bottom: none;
+}
+#main h1 a:hover,
+#main h2 a:hover,
+#main .collapse-toggle:hover,
+#main .docblock a:hover,
+#main .stability a:hover {
+    border-bottom: none;
+}
+
 .js-only, .hidden { display: none !important; }
 
 .sidebar {


### PR DESCRIPTION
Links:

[solid underline](http://mdinger.github.io/rust_std_underline/std/index.html)
[dashed underline](http://mdinger.github.io/rust_std_dashed_underline/std/index.html)
[colored primitives and aliases](http://mdinger.github.io/rust_std_colored/std/index.html)

---

Original post:

Here's a PR which fixes https://github.com/rust-lang/rust/issues/15307

I hosted a version ([`std::vec`](http://mdinger.github.io/rust_std_dashed_underline/std/vec/index.html)) but I must have messed something up because they don't work perfectly (but you can still see how the line styling looks fine). I don't think jquery loaded properly but I'm not sure why.

Note: I don't particularly like this as it is. Many of the links already kinda look like links. It's mainly the primitives which don't look like links because they're black.

For example, below you can probably tell the functions and the structs are links but `usize`, who knows without the underlining. The underlining also basically ignores the coloring that already exists and kinda feels inconsistent.

![small](https://cloud.githubusercontent.com/assets/4156987/10679889/6c76c482-78e9-11e5-9665-f1d542e92656.png)

---

As an alternative, I'd consider trying something else. If you look at this picture, the first 5 colors are the colors currently used for link highlighting (I think). I'd consider trying something like number 6 for primitives to see if it makes this issue much better as an alternative to this PR.

![highlight](https://cloud.githubusercontent.com/assets/4156987/10679826/16492906-78e9-11e5-901f-5f0a396cf22b.png)

Note: If I could figure out how to tell rustdoc to add a `class='primitive'` to each primitive element, this would be easy to test out but I haven't figured that out yet.
