### PR TITLE
Add an error message for using `typeof` instead of an ICE

### DIFF
--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1703,7 +1703,9 @@ pub fn ast_ty_to_ty<'tcx>(this: &AstConv<'tcx>,
             }
         }
         hir::TyTypeof(ref _e) => {
-            tcx.sess.span_bug(ast_ty.span, "typeof is reserved but unimplemented");
+            span_err!(tcx.sess, ast_ty.span, E0516,
+                  "`typeof` is a reserved keyword but unimplemented");
+            tcx.types.err
         }
         hir::TyInfer => {
             // TyInfer also appears as the type of arguments or return

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -3331,6 +3331,25 @@ extern "platform-intrinsic" {
 ```
 "##,
 
+E0516: r##"
+The `typeof` keyword is currently reserved but unimplemented.
+Erroneous code example:
+
+```
+fn main() {
+    let x: typeof(92) = 92;
+}
+```
+
+Try using type inference instead. Example:
+
+```
+fn main() {
+    let x = 92;
+}
+```
+"##,
+
 }
 
 register_diagnostics! {

--- a/src/test/compile-fail/issue-29184.rs
+++ b/src/test/compile-fail/issue-29184.rs
@@ -1,0 +1,13 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let x: typeof(92) = 92; //~ ERROR `typeof` is a reserved keyword
+}


### PR DESCRIPTION
Fixes #29184 

This adds an error message for the use of the reserved `typeof` keyword, instead of reporting an ICE.
Also adds a `compile-fail` test.

I chose to add a `span_err` instead of removing to parser code, as to preserve the reservation of `typeof`.
