### PR TITLE
Add missing word to TRPL's 'The Heap' section

### DIFF
--- a/src/doc/trpl/the-stack-and-the-heap.md
+++ b/src/doc/trpl/the-stack-and-the-heap.md
@@ -224,7 +224,7 @@ like this:
 | 1                    | y    | 42                     |
 | 0                    | x    | → (2<sup>30</sup>) - 1 |
 
-We have (2<sup>30</sup>) - 1 in our hypothetical computer with 1GB of RAM. And since
+We have (2<sup>30</sup>) - 1 addresses in our hypothetical computer with 1GB of RAM. And since
 our stack grows from zero, the easiest place to allocate memory is from the
 other end. So our first value is at the highest place in memory. And the value
 of the struct at `x` has a [raw pointer][rawpointer] to the place we’ve


### PR DESCRIPTION
I somehow missed a word behind the numbers while going through this section, don't know what the best approach would be though since "**available** addresses" sounds good to me, too".
