### PR TITLE
Unsafety -> Safety in doc headings

### DIFF
--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -254,7 +254,7 @@ impl str {
     ///
     /// Returns the substring from [`begin`..`end`).
     ///
-    /// # Unsafety
+    /// # Safety
     ///
     /// Caller must check both UTF-8 sequence boundaries and the boundaries
     /// of the entire slice as well.

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -361,7 +361,7 @@ impl String {
 
     /// Creates a new `String` from a length, capacity, and pointer.
     ///
-    /// # Unsafety
+    /// # Safety
     ///
     /// This is _very_ unsafe because:
     ///
@@ -385,7 +385,7 @@ impl String {
     ///
     /// [fromutf8]: struct.String.html#method.from_utf8
     ///
-    /// # Unsafety
+    /// # Safety
     ///
     /// This function is unsafe because it does not check that the bytes passed to
     /// it are valid UTF-8. If this constraint is violated, undefined behavior

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -284,7 +284,7 @@ impl<T> Vec<T> {
 
     /// Creates a `Vec<T>` directly from the raw components of another vector.
     ///
-    /// # Unsafety
+    /// # Safety
     ///
     /// This is highly unsafe, due to the number of invariants that aren't
     /// checked:

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -214,7 +214,7 @@ impl<T:Copy> Cell<T> {
 
     /// Returns a reference to the underlying `UnsafeCell`.
     ///
-    /// # Unsafety
+    /// # Safety
     ///
     /// This function is `unsafe` because `UnsafeCell`'s field is public.
     ///
@@ -813,7 +813,7 @@ impl<T> UnsafeCell<T> {
 
     /// Unwraps the value.
     ///
-    /// # Unsafety
+    /// # Safety
     ///
     /// This function is unsafe because this thread or another thread may currently be
     /// inspecting the inner value.

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -1430,7 +1430,7 @@ pub fn mut_ref_slice<A>(s: &mut A) -> &mut [A] {
 ///
 /// The `len` argument is the number of **elements**, not the number of bytes.
 ///
-/// # Unsafety
+/// # Safety
 ///
 /// This function is unsafe as there is no guarantee that the given pointer is
 /// valid for `len` elements, nor whether the lifetime inferred is a suitable

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -247,7 +247,7 @@ pub fn from_utf8(v: &[u8]) -> Result<&str, Utf8Error> {
 ///
 /// [fromutf8]: fn.from_utf8.html
 ///
-/// # Unsafety
+/// # Safety
 ///
 /// This function is unsafe because it does not check that the bytes passed to
 /// it are valid UTF-8. If this constraint is violated, undefined behavior

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -6163,7 +6163,7 @@ pub mod funcs {
 
                 /// Exits the running program in a possibly dangerous manner.
                 ///
-                /// # Unsafety
+                /// # Safety
                 ///
                 /// While this forces your program to exit, it does so in a way that has
                 /// consequences. This will skip all unwinding code, which means that anything


### PR DESCRIPTION
Follow https://doc.rust-lang.org/book/documentation.html#special-sections
