### PR TITLE
std: Add more entries to stdtest base_port

### DIFF
--- a/src/libstd/net/test.rs
+++ b/src/libstd/net/test.rs
@@ -47,7 +47,9 @@ pub fn tsa<A: ToSocketAddrs>(a: A) -> Result<Vec<SocketAddr>, String> {
 // it is running in and assigns a port range based on it.
 fn base_port() -> u16 {
     let cwd = env::current_dir().unwrap();
-    let dirs = ["32-opt", "32-nopt", "64-opt", "64-nopt", "64-opt-vg",
+    let dirs = ["32-opt", "32-nopt",
+                "musl-64-opt", "cross-opt",
+                "64-opt", "64-nopt", "64-opt-vg", "64-debug-opt",
                 "all-opt", "snap3", "dist"];
     dirs.iter().enumerate().find(|&(_, dir)| {
         cwd.to_str().unwrap().contains(dir)


### PR DESCRIPTION
The new bots we have may conflict with one another on base ports, causing tests
to fail. For example the linux-musl-64-opt and linux-64-opt bots are using the
same base port right now, causing some spurious failures every now and then.
