### PR TITLE
Color primitives and aliases in rustdoc

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -378,7 +378,7 @@ fn primitive_link(f: &mut fmt::Formatter,
         Some(&LOCAL_CRATE) => {
             let len = CURRENT_LOCATION_KEY.with(|s| s.borrow().len());
             let len = if len == 0 {0} else {len - 1};
-            try!(write!(f, "<a href='{}primitive.{}.html'>",
+            try!(write!(f, "<a class='primitive' href='{}primitive.{}.html'>",
                         repeat("../").take(len).collect::<String>(),
                         prim.to_url_str()));
             needs_termination = true;
@@ -398,7 +398,7 @@ fn primitive_link(f: &mut fmt::Formatter,
             };
             match loc {
                 Some(root) => {
-                    try!(write!(f, "<a href='{}{}/primitive.{}.html'>",
+                    try!(write!(f, "<a class='primitive' href='{}{}/primitive.{}.html'>",
                                 root,
                                 path.0.first().unwrap(),
                                 prim.to_url_str()));

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -415,9 +415,9 @@ a {
 .content span.mod, .content a.mod, block a.current.mod { color: #4d76ae; }
 .content span.enum, .content a.enum, .block a.current.enum { color: #5e9766; }
 .content span.struct, .content a.struct, .block a.current.struct { color: #e53700; }
-.content span.fn, .content a.fn, .block a.current.fn { color: #8c6067; }
-.content span.method, .content a.method, .block a.current.method { color: #8c6067; }
-.content span.tymethod, .content a.tymethod, .block a.current.tymethod { color: #8c6067; }
+.content span.fn, .content a.fn, .block a.current.fn,
+.content span.method, .content a.method, .block a.current.method,
+.content span.tymethod, .content a.tymethod, .block a.current.tymethod,
 .content .fnname { color: #8c6067; }
 .block a.current.crate { font-weight: 500; }
 

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -415,6 +415,9 @@ a {
 .content span.mod, .content a.mod, block a.current.mod { color: #4d76ae; }
 .content span.enum, .content a.enum, .block a.current.enum { color: #5e9766; }
 .content span.struct, .content a.struct, .block a.current.struct { color: #e53700; }
+.content a.primitive { color: #39a7bf; }
+.content a.type { color: #e57300; }
+.content a.macro { color: #068000; }
 .content span.fn, .content a.fn, .block a.current.fn,
 .content span.method, .content a.method, .block a.current.method,
 .content span.tymethod, .content a.tymethod, .block a.current.tymethod,


### PR DESCRIPTION
This is an alternative to https://github.com/rust-lang/rust/pull/29240 which fixes #15307 by adding colors to primitives and aliases instead of underlining.

Try to keep the discussion in https://github.com/rust-lang/rust/pull/29240 for now though so it can be kept track of.

A sample rendering is [here](http://mdinger.github.io/rust_std_colored/std/index.html)
