### PR TITLE
Make `{Default, From, FromIterator, One, Zero}` well-formed

### DIFF
--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -95,7 +95,7 @@ pub trait Into<T>: Sized {
 /// assert_eq!(string, other_string);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait From<T> {
+pub trait From<T>: Sized {
     /// Performs the conversion.
     #[stable(feature = "rust1", since = "1.0.0")]
     fn from(T) -> Self;

--- a/src/libcore/default.rs
+++ b/src/libcore/default.rs
@@ -78,6 +78,8 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+use marker::Sized;
+
 /// A trait for giving a type a useful default value.
 ///
 /// A struct can derive default implementations of `Default` for basic types using
@@ -93,7 +95,7 @@
 /// }
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait Default {
+pub trait Default: Sized {
     /// Returns the "default value" for a type.
     ///
     /// Default values are often some kind of initial value, identity value, or anything else that

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -1490,7 +1490,7 @@ impl<'a, I: Iterator + ?Sized> Iterator for &'a mut I {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_on_unimplemented="a collection of type `{Self}` cannot be \
                           built from an iterator over elements of type `{A}`"]
-pub trait FromIterator<A> {
+pub trait FromIterator<A>: Sized {
     /// Builds a container with elements from something iterable.
     ///
     /// # Examples

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -58,7 +58,7 @@ pub mod diy_float;
 #[unstable(feature = "zero_one",
            reason = "unsure of placement, wants to use associated constants",
            issue = "27739")]
-pub trait Zero {
+pub trait Zero: Sized {
     /// The "zero" (usually, additive identity) for this type.
     fn zero() -> Self;
 }
@@ -70,7 +70,7 @@ pub trait Zero {
 #[unstable(feature = "zero_one",
            reason = "unsure of placement, wants to use associated constants",
            issue = "27739")]
-pub trait One {
+pub trait One: Sized {
     /// The "one" (usually, multiplicative identity) for this type.
     fn one() -> Self;
 }


### PR DESCRIPTION
Using these traits in an object context previously resulted in an RFC 1214 warning.
