### PR TITLE
Switch to 'const unsafe fn' ordering (rust-lang/rust#29107)

### DIFF
--- a/src/libcore/nonzero.rs
+++ b/src/libcore/nonzero.rs
@@ -55,7 +55,7 @@ macro_rules! nonzero_new {
         /// Creates an instance of NonZero with the provided value.
         /// You must indeed ensure that the value is actually "non-zero".
         #[inline(always)]
-        pub unsafe const fn new(inner: T) -> NonZero<T> {
+        pub const unsafe fn new(inner: T) -> NonZero<T> {
             NonZero(inner)
         }
     )

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -511,7 +511,7 @@ macro_rules! unique_new {
 macro_rules! unique_new {
     () => (
         /// Creates a new `Unique`.
-        pub unsafe const fn new(ptr: *mut T) -> Unique<T> {
+        pub const unsafe fn new(ptr: *mut T) -> Unique<T> {
             Unique { pointer: NonZero::new(ptr), _marker: PhantomData }
         }
     )

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4382,7 +4382,8 @@ impl<'a> Parser<'a> {
     /// true if we are looking at `const ID`, false for things like `const fn` etc
     pub fn is_const_item(&mut self) -> bool {
         self.token.is_keyword(keywords::Const) &&
-            !self.look_ahead(1, |t| t.is_keyword(keywords::Fn))
+            !self.look_ahead(1, |t| t.is_keyword(keywords::Fn)) &&
+            !self.look_ahead(1, |t| t.is_keyword(keywords::Unsafe))
     }
 
     /// parses all the "front matter" for a `fn` declaration, up to
@@ -4390,11 +4391,12 @@ impl<'a> Parser<'a> {
     ///
     /// - `const fn`
     /// - `unsafe fn`
+    /// - `const unsafe fn`
     /// - `extern fn`
     /// - etc
     pub fn parse_fn_front_matter(&mut self) -> PResult<(ast::Constness, ast::Unsafety, abi::Abi)> {
-        let unsafety = try!(self.parse_unsafety());
         let is_const_fn = try!(self.eat_keyword(keywords::Const));
+        let unsafety = try!(self.parse_unsafety());
         let (constness, unsafety, abi) = if is_const_fn {
             (Constness::Const, unsafety, abi::Rust)
         } else {
@@ -5304,11 +5306,18 @@ impl<'a> Parser<'a> {
             return Ok(Some(item));
         }
         if try!(self.eat_keyword(keywords::Const) ){
-            if self.check_keyword(keywords::Fn) {
+            if self.check_keyword(keywords::Fn)
+                || (self.check_keyword(keywords::Unsafe)
+                    && self.look_ahead(1, |t| t.is_keyword(keywords::Fn))) {
                 // CONST FUNCTION ITEM
+                let unsafety = if try!(self.eat_keyword(keywords::Unsafe) ){
+                    Unsafety::Unsafe
+                } else {
+                    Unsafety::Normal
+                };
                 try!(self.bump());
                 let (ident, item_, extra_attrs) =
-                    try!(self.parse_item_fn(Unsafety::Normal, Constness::Const, abi::Rust));
+                    try!(self.parse_item_fn(unsafety, Constness::Const, abi::Rust));
                 let last_span = self.last_span;
                 let item = self.mk_item(lo,
                                         last_span.hi,
@@ -5391,14 +5400,9 @@ impl<'a> Parser<'a> {
             } else {
                 abi::Rust
             };
-            let constness = if abi == abi::Rust && try!(self.eat_keyword(keywords::Const) ){
-                Constness::Const
-            } else {
-                Constness::NotConst
-            };
             try!(self.expect_keyword(keywords::Fn));
             let (ident, item_, extra_attrs) =
-                try!(self.parse_item_fn(Unsafety::Unsafe, constness, abi));
+                try!(self.parse_item_fn(Unsafety::Unsafe, Constness::NotConst, abi));
             let last_span = self.last_span;
             let item = self.mk_item(lo,
                                     last_span.hi,

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -3071,12 +3071,13 @@ impl<'a> State<'a> {
                                 abi: abi::Abi,
                                 vis: ast::Visibility) -> io::Result<()> {
         try!(word(&mut self.s, &visibility_qualified(vis, "")));
-        try!(self.print_unsafety(unsafety));
 
         match constness {
             ast::Constness::NotConst => {}
             ast::Constness::Const => try!(self.word_nbsp("const"))
         }
+
+        try!(self.print_unsafety(unsafety));
 
         if abi != abi::Rust {
             try!(self.word_nbsp("extern"));

--- a/src/test/compile-fail/unsafe-const-fn.rs
+++ b/src/test/compile-fail/unsafe-const-fn.rs
@@ -12,7 +12,7 @@
 
 #![feature(const_fn)]
 
-unsafe const fn dummy(v: u32) -> u32 {
+const unsafe fn dummy(v: u32) -> u32 {
     !v
 }
 

--- a/src/test/run-pass/const-unsafe-fn.rs
+++ b/src/test/run-pass/const-unsafe-fn.rs
@@ -12,13 +12,13 @@
 
 #![feature(const_fn)]
 
-unsafe const fn dummy(v: u32) -> u32 {
+const unsafe fn dummy(v: u32) -> u32 {
     !v
 }
 
 struct Type;
 impl Type {
-    unsafe const fn new() -> Type {
+    const unsafe fn new() -> Type {
         Type
     }
 }


### PR DESCRIPTION
This PR switches the implemented ordering from `unsafe const fn` (as was in the original RFC) to `const unsafe fn` (which is what the lang team decided on)
