### PR TITLE
Fix docattr to match surrounding text

### DIFF
--- a/src/doc/trpl/documentation.md
+++ b/src/doc/trpl/documentation.md
@@ -518,7 +518,7 @@ are the same, as are these:
 ```rust
 //! this
 
-#![doc="/// this"]
+#![doc="this"]
 ```
 
 You won't often see this attribute used for writing documentation, but it


### PR DESCRIPTION
As is, this attr would lead to the "///" prefix being in the output text.
