### PR TITLE
libsyntax: improve error message for lifetimes in patterns

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3304,13 +3304,13 @@ impl<'a> Parser<'a> {
                             pat = PatEnum(path, Some(args));
                         }
                       }
-                      _ if qself.is_some() => {
-                        // Parse qualified path
-                        pat = PatQPath(qself.unwrap(), path);
-                      }
                       _ => {
-                        // Parse nullary enum
-                        pat = PatEnum(path, Some(vec![]));
+                        pat = match qself {
+                            // Parse qualified path
+                            Some(qself) => PatQPath(qself, path),
+                            // Parse nullary enum
+                            None => PatEnum(path, Some(vec![]))
+                        };
                       }
                     }
                 }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3196,6 +3196,10 @@ impl<'a> Parser<'a> {
             // Parse &pat / &mut pat
             try!(self.expect_and());
             let mutbl = try!(self.parse_mutability());
+            if let token::Lifetime(ident) = self.token {
+                return Err(self.fatal(&format!("unexpected lifetime `{}` in pattern", ident)));
+            }
+
             let subpat = try!(self.parse_pat_nopanic());
             pat = PatRegion(subpat, mutbl);
           }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3276,12 +3276,9 @@ impl<'a> Parser<'a> {
                       }
                       token::OpenDelim(token::Brace) => {
                          if qself.is_some() {
-                            let span = self.span;
-                            self.span_err(span,
-                                          "unexpected `{` after qualified path");
-                            self.abort_if_errors();
+                            return Err(self.fatal("unexpected `{` after qualified path"));
                         }
-                       // Parse struct pattern
+                        // Parse struct pattern
                         try!(self.bump());
                         let (fields, etc) = try!(self.parse_pat_fields());
                         try!(self.bump());
@@ -3289,10 +3286,7 @@ impl<'a> Parser<'a> {
                       }
                       token::OpenDelim(token::Paren) => {
                         if qself.is_some() {
-                            let span = self.span;
-                            self.span_err(span,
-                                          "unexpected `(` after qualified path");
-                            self.abort_if_errors();
+                            return Err(self.fatal("unexpected `(` after qualified path"));
                         }
                         // Parse tuple struct or enum pattern
                         if self.look_ahead(1, |t| *t == token::DotDot) {

--- a/src/test/parse-fail/lifetime-in-pattern.rs
+++ b/src/test/parse-fail/lifetime-in-pattern.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn test(&'a str) {
+    //~^ ERROR unexpected lifetime `'a` in pattern
+}
+
+fn main() {
+}


### PR DESCRIPTION
Previously, if you copied a signature from a trait definition such as:

``` rust
fn foo<'a>(&'a Bar) -> bool {}
```

and moved it into an `impl`, there would be an error message:

"unexpected token `'a`"

Adding to the error message that a pattern is expected should help
users to find the actual problem with using a lifetime here.
