### PR TITLE
Change overflowing_(add|sub|mul) to be non generic

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -579,13 +579,6 @@ extern "rust-intrinsic" {
     /// Performs checked `u64` multiplication.
     pub fn u64_mul_with_overflow(x: u64, y: u64) -> (u64, bool);
 
-    /// Returns (a + b) mod 2^N, where N is the width of N in bits.
-    pub fn overflowing_add<T>(a: T, b: T) -> T;
-    /// Returns (a - b) mod 2^N, where N is the width of N in bits.
-    pub fn overflowing_sub<T>(a: T, b: T) -> T;
-    /// Returns (a * b) mod 2^N, where N is the width of N in bits.
-    pub fn overflowing_mul<T>(a: T, b: T) -> T;
-
     /// Performs an unchecked signed division, which results in undefined behavior,
     /// in cases where y == 0, or x == isize::MIN and y == -1
     pub fn unchecked_sdiv<T>(x: T, y: T) -> T;
@@ -608,4 +601,68 @@ extern "rust-intrinsic" {
     /// the data pointer `data`, returning the exception payload if an exception
     /// is thrown (aka the thread panics).
     pub fn try(f: fn(*mut u8), data: *mut u8) -> *mut u8;
+}
+
+#[cfg(stage0)]
+extern "rust-intrinsic" {
+    /// Returns (a + b) mod 2^N, where N is the width of N in bits.
+    pub fn overflowing_add<T>(a: T, b: T) -> T;
+    /// Returns (a - b) mod 2^N, where N is the width of N in bits.
+    pub fn overflowing_sub<T>(a: T, b: T) -> T;
+    /// Returns (a * b) mod 2^N, where N is the width of N in bits.
+    pub fn overflowing_mul<T>(a: T, b: T) -> T;
+}
+
+#[cfg(not(stage0))]
+extern "rust-intrinsic" {
+    /// Returns (a + b) mod 2^N, where N is the width of N in bits.
+    pub fn u8_wrapping_add(a: u8, b: u8) -> u8;
+    /// Returns (a + b) mod 2^N, where N is the width of N in bits.
+    pub fn u16_wrapping_add(a: u16, b: u16) -> u16;
+    /// Returns (a + b) mod 2^N, where N is the width of N in bits.
+    pub fn u32_wrapping_add(a: u32, b: u32) -> u32;
+    /// Returns (a + b) mod 2^N, where N is the width of N in bits.
+    pub fn u64_wrapping_add(a: u64, b: u64) -> u64;
+    /// Returns (a + b) mod 2^N, where N is the width of N in bits.
+    pub fn i8_wrapping_add(a: i8, b: i8) -> i8;
+    /// Returns (a + b) mod 2^N, where N is the width of N in bits.
+    pub fn i16_wrapping_add(a: i16, b: i16) -> i16;
+    /// Returns (a + b) mod 2^N, where N is the width of N in bits.
+    pub fn i32_wrapping_add(a: i32, b: i32) -> i32;
+    /// Returns (a + b) mod 2^N, where N is the width of N in bits.
+    pub fn i64_wrapping_add(a: i64, b: i64) -> i64;
+
+    /// Returns (a - b) mod 2^N, where N is the width of N in bits.
+    pub fn u8_wrapping_sub(a: u8, b: u8) -> u8;
+    /// Returns (a - b) mod 2^N, where N is the width of N in bits.
+    pub fn u16_wrapping_sub(a: u16, b: u16) -> u16;
+    /// Returns (a - b) mod 2^N, where N is the width of N in bits.
+    pub fn u32_wrapping_sub(a: u32, b: u32) -> u32;
+    /// Returns (a - b) mod 2^N, where N is the width of N in bits.
+    pub fn u64_wrapping_sub(a: u64, b: u64) -> u64;
+    /// Returns (a - b) mod 2^N, where N is the width of N in bits.
+    pub fn i8_wrapping_sub(a: i8, b: i8) -> i8;
+    /// Returns (a - b) mod 2^N, where N is the width of N in bits.
+    pub fn i16_wrapping_sub(a: i16, b: i16) -> i16;
+    /// Returns (a - b) mod 2^N, where N is the width of N in bits.
+    pub fn i32_wrapping_sub(a: i32, b: i32) -> i32;
+    /// Returns (a - b) mod 2^N, where N is the width of N in bits.
+    pub fn i64_wrapping_sub(a: i64, b: i64) -> i64;
+
+    /// Returns (a * b) mod 2^N, where N is the width of N in bits.
+    pub fn u8_wrapping_mul(a: u8, b: u8) -> u8;
+    /// Returns (a * b) mod 2^N, where N is the width of N in bits.
+    pub fn u16_wrapping_mul(a: u16, b: u16) -> u16;
+    /// Returns (a * b) mod 2^N, where N is the width of N in bits.
+    pub fn u32_wrapping_mul(a: u32, b: u32) -> u32;
+    /// Returns (a * b) mod 2^N, where N is the width of N in bits.
+    pub fn u64_wrapping_mul(a: u64, b: u64) -> u64;
+    /// Returns (a * b) mod 2^N, where N is the width of N in bits.
+    pub fn i8_wrapping_mul(a: i8, b: i8) -> i8;
+    /// Returns (a * b) mod 2^N, where N is the width of N in bits.
+    pub fn i16_wrapping_mul(a: i16, b: i16) -> i16;
+    /// Returns (a * b) mod 2^N, where N is the width of N in bits.
+    pub fn i32_wrapping_mul(a: i32, b: i32) -> i32;
+    /// Returns (a * b) mod 2^N, where N is the width of N in bits.
+    pub fn i64_wrapping_mul(a: i64, b: i64) -> i64;
 }

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -115,504 +115,1016 @@ macro_rules! checked_op {
 unsafe fn bswap8(x: u8) -> u8 { x }
 
 // `Int` + `SignedInt` implemented for signed integers
-macro_rules! int_impl {
-    ($ActualT:ty, $UnsignedT:ty, $BITS:expr,
-     $add_with_overflow:path,
-     $sub_with_overflow:path,
-     $mul_with_overflow:path) => {
-        /// Returns the smallest value that can be represented by this integer type.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn min_value() -> Self {
-            (-1 as Self) << ($BITS - 1)
-        }
-
-        /// Returns the largest value that can be represented by this integer type.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn max_value() -> Self {
-            let min = Self::min_value(); !min
-        }
-
-        /// Converts a string slice in a given base to an integer.
-        ///
-        /// Leading and trailing whitespace represent an error.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// assert_eq!(u32::from_str_radix("A", 16), Ok(10));
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        pub fn from_str_radix(src: &str, radix: u32) -> Result<Self, ParseIntError> {
-            from_str_radix(src, radix)
-        }
-
-        /// Returns the number of ones in the binary representation of `self`.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// let n = 0b01001100u8;
-        ///
-        /// assert_eq!(n.count_ones(), 3);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn count_ones(self) -> u32 { (self as $UnsignedT).count_ones() }
-
-        /// Returns the number of zeros in the binary representation of `self`.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// let n = 0b01001100u8;
-        ///
-        /// assert_eq!(n.count_zeros(), 5);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn count_zeros(self) -> u32 {
-            (!self).count_ones()
-        }
-
-        /// Returns the number of leading zeros in the binary representation
-        /// of `self`.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// let n = 0b0101000u16;
-        ///
-        /// assert_eq!(n.leading_zeros(), 10);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn leading_zeros(self) -> u32 {
-            (self as $UnsignedT).leading_zeros()
-        }
-
-        /// Returns the number of trailing zeros in the binary representation
-        /// of `self`.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// let n = 0b0101000u16;
-        ///
-        /// assert_eq!(n.trailing_zeros(), 3);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn trailing_zeros(self) -> u32 {
-            (self as $UnsignedT).trailing_zeros()
-        }
-
-        /// Shifts the bits to the left by a specified amount, `n`,
-        /// wrapping the truncated bits to the end of the resulting integer.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// let n = 0x0123456789ABCDEFu64;
-        /// let m = 0x3456789ABCDEF012u64;
-        ///
-        /// assert_eq!(n.rotate_left(12), m);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn rotate_left(self, n: u32) -> Self {
-            (self as $UnsignedT).rotate_left(n) as Self
-        }
-
-        /// Shifts the bits to the right by a specified amount, `n`,
-        /// wrapping the truncated bits to the beginning of the resulting
-        /// integer.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// let n = 0x0123456789ABCDEFu64;
-        /// let m = 0xDEF0123456789ABCu64;
-        ///
-        /// assert_eq!(n.rotate_right(12), m);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn rotate_right(self, n: u32) -> Self {
-            (self as $UnsignedT).rotate_right(n) as Self
-        }
-
-        /// Reverses the byte order of the integer.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// let n = 0x0123456789ABCDEFu64;
-        /// let m = 0xEFCDAB8967452301u64;
-        ///
-        /// assert_eq!(n.swap_bytes(), m);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn swap_bytes(self) -> Self {
-            (self as $UnsignedT).swap_bytes() as Self
-        }
-
-        /// Converts an integer from big endian to the target's endianness.
-        ///
-        /// On big endian this is a no-op. On little endian the bytes are
-        /// swapped.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// let n = 0x0123456789ABCDEFu64;
-        ///
-        /// if cfg!(target_endian = "big") {
-        ///     assert_eq!(u64::from_be(n), n)
-        /// } else {
-        ///     assert_eq!(u64::from_be(n), n.swap_bytes())
-        /// }
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn from_be(x: Self) -> Self {
-            if cfg!(target_endian = "big") { x } else { x.swap_bytes() }
-        }
-
-        /// Converts an integer from little endian to the target's endianness.
-        ///
-        /// On little endian this is a no-op. On big endian the bytes are
-        /// swapped.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// let n = 0x0123456789ABCDEFu64;
-        ///
-        /// if cfg!(target_endian = "little") {
-        ///     assert_eq!(u64::from_le(n), n)
-        /// } else {
-        ///     assert_eq!(u64::from_le(n), n.swap_bytes())
-        /// }
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn from_le(x: Self) -> Self {
-            if cfg!(target_endian = "little") { x } else { x.swap_bytes() }
-        }
-
-        /// Converts `self` to big endian from the target's endianness.
-        ///
-        /// On big endian this is a no-op. On little endian the bytes are
-        /// swapped.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// let n = 0x0123456789ABCDEFu64;
-        ///
-        /// if cfg!(target_endian = "big") {
-        ///     assert_eq!(n.to_be(), n)
-        /// } else {
-        ///     assert_eq!(n.to_be(), n.swap_bytes())
-        /// }
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn to_be(self) -> Self { // or not to be?
-            if cfg!(target_endian = "big") { self } else { self.swap_bytes() }
-        }
-
-        /// Converts `self` to little endian from the target's endianness.
-        ///
-        /// On little endian this is a no-op. On big endian the bytes are
-        /// swapped.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// let n = 0x0123456789ABCDEFu64;
-        ///
-        /// if cfg!(target_endian = "little") {
-        ///     assert_eq!(n.to_le(), n)
-        /// } else {
-        ///     assert_eq!(n.to_le(), n.swap_bytes())
-        /// }
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn to_le(self) -> Self {
-            if cfg!(target_endian = "little") { self } else { self.swap_bytes() }
-        }
-
-        /// Checked integer addition. Computes `self + other`, returning `None`
-        /// if overflow occurred.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// assert_eq!(5u16.checked_add(65530), Some(65535));
-        /// assert_eq!(6u16.checked_add(65530), None);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn checked_add(self, other: Self) -> Option<Self> {
-            checked_op!($ActualT, $add_with_overflow, self, other)
-        }
-
-        /// Checked integer subtraction. Computes `self - other`, returning
-        /// `None` if underflow occurred.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// assert_eq!((-127i8).checked_sub(1), Some(-128));
-        /// assert_eq!((-128i8).checked_sub(1), None);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn checked_sub(self, other: Self) -> Option<Self> {
-            checked_op!($ActualT, $sub_with_overflow, self, other)
-        }
-
-        /// Checked integer multiplication. Computes `self * other`, returning
-        /// `None` if underflow or overflow occurred.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// assert_eq!(5u8.checked_mul(51), Some(255));
-        /// assert_eq!(5u8.checked_mul(52), None);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn checked_mul(self, other: Self) -> Option<Self> {
-            checked_op!($ActualT, $mul_with_overflow, self, other)
-        }
-
-        /// Checked integer division. Computes `self / other`, returning `None`
-        /// if `other == 0` or the operation results in underflow or overflow.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// assert_eq!((-127i8).checked_div(-1), Some(127));
-        /// assert_eq!((-128i8).checked_div(-1), None);
-        /// assert_eq!((1i8).checked_div(0), None);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn checked_div(self, other: Self) -> Option<Self> {
-            match other {
-                0    => None,
-               -1 if self == Self::min_value()
-                     => None,
-               other => Some(self / other),
+#[cfg(not(stage0))]
+#[macro_use]
+mod int_macro {
+    macro_rules! int_impl {
+        ($ActualT:ty, $UnsignedT:ty, $BITS:expr,
+         $wrapping_add:path,
+         $wrapping_sub:path,
+         $wrapping_mul:path,
+         $add_with_overflow:path,
+         $sub_with_overflow:path,
+         $mul_with_overflow:path) => {
+            /// Returns the smallest value that can be represented by this integer type.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn min_value() -> Self {
+                (-1 as Self) << ($BITS - 1)
             }
-        }
 
-        /// Saturating integer addition. Computes `self + other`, saturating at
-        /// the numeric bounds instead of overflowing.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn saturating_add(self, other: Self) -> Self {
-            match self.checked_add(other) {
-                Some(x)                       => x,
-                None if other >= Self::zero() => Self::max_value(),
-                None => Self::min_value(),
+            /// Returns the largest value that can be represented by this integer type.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn max_value() -> Self {
+                let min = Self::min_value(); !min
             }
-        }
 
-        /// Saturating integer subtraction. Computes `self - other`, saturating
-        /// at the numeric bounds instead of overflowing.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn saturating_sub(self, other: Self) -> Self {
-            match self.checked_sub(other) {
-                Some(x)                      => x,
-                None if other >= Self::zero() => Self::min_value(),
-                None => Self::max_value(),
+            /// Converts a string slice in a given base to an integer.
+            ///
+            /// Leading and trailing whitespace represent an error.
+            ///
+            /// # Examples
+            ///
+            /// ```
+            /// assert_eq!(u32::from_str_radix("A", 16), Ok(10));
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            pub fn from_str_radix(src: &str, radix: u32) -> Result<Self, ParseIntError> {
+                from_str_radix(src, radix)
             }
-        }
 
-        /// Wrapping (modular) addition. Computes `self + other`,
-        /// wrapping around at the boundary of the type.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn wrapping_add(self, rhs: Self) -> Self {
-            unsafe {
-                intrinsics::overflowing_add(self, rhs)
+            /// Returns the number of ones in the binary representation of `self`.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0b01001100u8;
+            ///
+            /// assert_eq!(n.count_ones(), 3);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn count_ones(self) -> u32 { (self as $UnsignedT).count_ones() }
+
+            /// Returns the number of zeros in the binary representation of `self`.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0b01001100u8;
+            ///
+            /// assert_eq!(n.count_zeros(), 5);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn count_zeros(self) -> u32 {
+                (!self).count_ones()
             }
-        }
 
-        /// Wrapping (modular) subtraction. Computes `self - other`,
-        /// wrapping around at the boundary of the type.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn wrapping_sub(self, rhs: Self) -> Self {
-            unsafe {
-                intrinsics::overflowing_sub(self, rhs)
+            /// Returns the number of leading zeros in the binary representation
+            /// of `self`.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0b0101000u16;
+            ///
+            /// assert_eq!(n.leading_zeros(), 10);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn leading_zeros(self) -> u32 {
+                (self as $UnsignedT).leading_zeros()
             }
-        }
 
-        /// Wrapping (modular) multiplication. Computes `self *
-        /// other`, wrapping around at the boundary of the type.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn wrapping_mul(self, rhs: Self) -> Self {
-            unsafe {
-                intrinsics::overflowing_mul(self, rhs)
+            /// Returns the number of trailing zeros in the binary representation
+            /// of `self`.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0b0101000u16;
+            ///
+            /// assert_eq!(n.trailing_zeros(), 3);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn trailing_zeros(self) -> u32 {
+                (self as $UnsignedT).trailing_zeros()
             }
-        }
 
-        /// Wrapping (modular) division. Computes `self / other`,
-        /// wrapping around at the boundary of the type.
-        ///
-        /// The only case where such wrapping can occur is when one
-        /// divides `MIN / -1` on a signed type (where `MIN` is the
-        /// negative minimal value for the type); this is equivalent
-        /// to `-MIN`, a positive value that is too large to represent
-        /// in the type. In such a case, this function returns `MIN`
-        /// itself.
-        #[stable(feature = "num_wrapping", since = "1.2.0")]
-        #[inline(always)]
-        pub fn wrapping_div(self, rhs: Self) -> Self {
-            self.overflowing_div(rhs).0
-        }
+            /// Shifts the bits to the left by a specified amount, `n`,
+            /// wrapping the truncated bits to the end of the resulting integer.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            /// let m = 0x3456789ABCDEF012u64;
+            ///
+            /// assert_eq!(n.rotate_left(12), m);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn rotate_left(self, n: u32) -> Self {
+                (self as $UnsignedT).rotate_left(n) as Self
+            }
 
-        /// Wrapping (modular) remainder. Computes `self % other`,
-        /// wrapping around at the boundary of the type.
-        ///
-        /// Such wrap-around never actually occurs mathematically;
-        /// implementation artifacts make `x % y` invalid for `MIN /
-        /// -1` on a signed type (where `MIN` is the negative
-        /// minimal value). In such a case, this function returns `0`.
-        #[stable(feature = "num_wrapping", since = "1.2.0")]
-        #[inline(always)]
-        pub fn wrapping_rem(self, rhs: Self) -> Self {
-            self.overflowing_rem(rhs).0
-        }
+            /// Shifts the bits to the right by a specified amount, `n`,
+            /// wrapping the truncated bits to the beginning of the resulting
+            /// integer.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            /// let m = 0xDEF0123456789ABCu64;
+            ///
+            /// assert_eq!(n.rotate_right(12), m);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn rotate_right(self, n: u32) -> Self {
+                (self as $UnsignedT).rotate_right(n) as Self
+            }
 
-        /// Wrapping (modular) negation. Computes `-self`,
-        /// wrapping around at the boundary of the type.
-        ///
-        /// The only case where such wrapping can occur is when one
-        /// negates `MIN` on a signed type (where `MIN` is the
-        /// negative minimal value for the type); this is a positive
-        /// value that is too large to represent in the type. In such
-        /// a case, this function returns `MIN` itself.
-        #[stable(feature = "num_wrapping", since = "1.2.0")]
-        #[inline(always)]
-        pub fn wrapping_neg(self) -> Self {
-            self.overflowing_neg().0
-        }
+            /// Reverses the byte order of the integer.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            /// let m = 0xEFCDAB8967452301u64;
+            ///
+            /// assert_eq!(n.swap_bytes(), m);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn swap_bytes(self) -> Self {
+                (self as $UnsignedT).swap_bytes() as Self
+            }
 
-        /// Panic-free bitwise shift-left; yields `self << mask(rhs)`,
-        /// where `mask` removes any high-order bits of `rhs` that
-        /// would cause the shift to exceed the bitwidth of the type.
-        #[stable(feature = "num_wrapping", since = "1.2.0")]
-        #[inline(always)]
-        pub fn wrapping_shl(self, rhs: u32) -> Self {
-            self.overflowing_shl(rhs).0
-        }
+            /// Converts an integer from big endian to the target's endianness.
+            ///
+            /// On big endian this is a no-op. On little endian the bytes are
+            /// swapped.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            ///
+            /// if cfg!(target_endian = "big") {
+            ///     assert_eq!(u64::from_be(n), n)
+            /// } else {
+            ///     assert_eq!(u64::from_be(n), n.swap_bytes())
+            /// }
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn from_be(x: Self) -> Self {
+                if cfg!(target_endian = "big") { x } else { x.swap_bytes() }
+            }
 
-        /// Panic-free bitwise shift-left; yields `self >> mask(rhs)`,
-        /// where `mask` removes any high-order bits of `rhs` that
-        /// would cause the shift to exceed the bitwidth of the type.
-        #[stable(feature = "num_wrapping", since = "1.2.0")]
-        #[inline(always)]
-        pub fn wrapping_shr(self, rhs: u32) -> Self {
-            self.overflowing_shr(rhs).0
-        }
+            /// Converts an integer from little endian to the target's endianness.
+            ///
+            /// On little endian this is a no-op. On big endian the bytes are
+            /// swapped.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            ///
+            /// if cfg!(target_endian = "little") {
+            ///     assert_eq!(u64::from_le(n), n)
+            /// } else {
+            ///     assert_eq!(u64::from_le(n), n.swap_bytes())
+            /// }
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn from_le(x: Self) -> Self {
+                if cfg!(target_endian = "little") { x } else { x.swap_bytes() }
+            }
 
-        /// Raises self to the power of `exp`, using exponentiation by squaring.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// let x: i32 = 2; // or any other integer type
-        ///
-        /// assert_eq!(x.pow(4), 16);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn pow(self, mut exp: u32) -> Self {
-            let mut base = self;
-            let mut acc = Self::one();
+            /// Converts `self` to big endian from the target's endianness.
+            ///
+            /// On big endian this is a no-op. On little endian the bytes are
+            /// swapped.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            ///
+            /// if cfg!(target_endian = "big") {
+            ///     assert_eq!(n.to_be(), n)
+            /// } else {
+            ///     assert_eq!(n.to_be(), n.swap_bytes())
+            /// }
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn to_be(self) -> Self { // or not to be?
+                if cfg!(target_endian = "big") { self } else { self.swap_bytes() }
+            }
 
-            while exp > 1 {
-                if (exp & 1) == 1 {
+            /// Converts `self` to little endian from the target's endianness.
+            ///
+            /// On little endian this is a no-op. On big endian the bytes are
+            /// swapped.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            ///
+            /// if cfg!(target_endian = "little") {
+            ///     assert_eq!(n.to_le(), n)
+            /// } else {
+            ///     assert_eq!(n.to_le(), n.swap_bytes())
+            /// }
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn to_le(self) -> Self {
+                if cfg!(target_endian = "little") { self } else { self.swap_bytes() }
+            }
+
+            /// Checked integer addition. Computes `self + other`, returning `None`
+            /// if overflow occurred.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// assert_eq!(5u16.checked_add(65530), Some(65535));
+            /// assert_eq!(6u16.checked_add(65530), None);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn checked_add(self, other: Self) -> Option<Self> {
+                checked_op!($ActualT, $add_with_overflow, self, other)
+            }
+
+            /// Checked integer subtraction. Computes `self - other`, returning
+            /// `None` if underflow occurred.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// assert_eq!((-127i8).checked_sub(1), Some(-128));
+            /// assert_eq!((-128i8).checked_sub(1), None);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn checked_sub(self, other: Self) -> Option<Self> {
+                checked_op!($ActualT, $sub_with_overflow, self, other)
+            }
+
+            /// Checked integer multiplication. Computes `self * other`, returning
+            /// `None` if underflow or overflow occurred.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// assert_eq!(5u8.checked_mul(51), Some(255));
+            /// assert_eq!(5u8.checked_mul(52), None);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn checked_mul(self, other: Self) -> Option<Self> {
+                checked_op!($ActualT, $mul_with_overflow, self, other)
+            }
+
+            /// Checked integer division. Computes `self / other`, returning `None`
+            /// if `other == 0` or the operation results in underflow or overflow.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// assert_eq!((-127i8).checked_div(-1), Some(127));
+            /// assert_eq!((-128i8).checked_div(-1), None);
+            /// assert_eq!((1i8).checked_div(0), None);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn checked_div(self, other: Self) -> Option<Self> {
+                match other {
+                    0    => None,
+                   -1 if self == Self::min_value()
+                         => None,
+                   other => Some(self / other),
+                }
+            }
+
+            /// Saturating integer addition. Computes `self + other`, saturating at
+            /// the numeric bounds instead of overflowing.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn saturating_add(self, other: Self) -> Self {
+                match self.checked_add(other) {
+                    Some(x)                       => x,
+                    None if other >= Self::zero() => Self::max_value(),
+                    None => Self::min_value(),
+                }
+            }
+
+            /// Saturating integer subtraction. Computes `self - other`, saturating
+            /// at the numeric bounds instead of overflowing.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn saturating_sub(self, other: Self) -> Self {
+                match self.checked_sub(other) {
+                    Some(x)                      => x,
+                    None if other >= Self::zero() => Self::min_value(),
+                    None => Self::max_value(),
+                }
+            }
+
+            /// Wrapping (modular) addition. Computes `self + other`,
+            /// wrapping around at the boundary of the type.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn wrapping_add(self, rhs: Self) -> Self {
+                unsafe {
+                    $wrapping_add(self as $ActualT, rhs as $ActualT) as Self
+                }
+            }
+
+            /// Wrapping (modular) subtraction. Computes `self - other`,
+            /// wrapping around at the boundary of the type.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn wrapping_sub(self, rhs: Self) -> Self {
+                unsafe {
+                    $wrapping_sub(self as $ActualT, rhs as $ActualT) as Self
+                }
+            }
+
+            /// Wrapping (modular) multiplication. Computes `self *
+            /// other`, wrapping around at the boundary of the type.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn wrapping_mul(self, rhs: Self) -> Self {
+                unsafe {
+                    $wrapping_mul(self as $ActualT, rhs as $ActualT) as Self
+                }
+            }
+
+            /// Wrapping (modular) division. Computes `self / other`,
+            /// wrapping around at the boundary of the type.
+            ///
+            /// The only case where such wrapping can occur is when one
+            /// divides `MIN / -1` on a signed type (where `MIN` is the
+            /// negative minimal value for the type); this is equivalent
+            /// to `-MIN`, a positive value that is too large to represent
+            /// in the type. In such a case, this function returns `MIN`
+            /// itself.
+            #[stable(feature = "num_wrapping", since = "1.2.0")]
+            #[inline(always)]
+            pub fn wrapping_div(self, rhs: Self) -> Self {
+                self.overflowing_div(rhs).0
+            }
+
+            /// Wrapping (modular) remainder. Computes `self % other`,
+            /// wrapping around at the boundary of the type.
+            ///
+            /// Such wrap-around never actually occurs mathematically;
+            /// implementation artifacts make `x % y` invalid for `MIN /
+            /// -1` on a signed type (where `MIN` is the negative
+            /// minimal value). In such a case, this function returns `0`.
+            #[stable(feature = "num_wrapping", since = "1.2.0")]
+            #[inline(always)]
+            pub fn wrapping_rem(self, rhs: Self) -> Self {
+                self.overflowing_rem(rhs).0
+            }
+
+            /// Wrapping (modular) negation. Computes `-self`,
+            /// wrapping around at the boundary of the type.
+            ///
+            /// The only case where such wrapping can occur is when one
+            /// negates `MIN` on a signed type (where `MIN` is the
+            /// negative minimal value for the type); this is a positive
+            /// value that is too large to represent in the type. In such
+            /// a case, this function returns `MIN` itself.
+            #[stable(feature = "num_wrapping", since = "1.2.0")]
+            #[inline(always)]
+            pub fn wrapping_neg(self) -> Self {
+                self.overflowing_neg().0
+            }
+
+            /// Panic-free bitwise shift-left; yields `self << mask(rhs)`,
+            /// where `mask` removes any high-order bits of `rhs` that
+            /// would cause the shift to exceed the bitwidth of the type.
+            #[stable(feature = "num_wrapping", since = "1.2.0")]
+            #[inline(always)]
+            pub fn wrapping_shl(self, rhs: u32) -> Self {
+                self.overflowing_shl(rhs).0
+            }
+
+            /// Panic-free bitwise shift-left; yields `self >> mask(rhs)`,
+            /// where `mask` removes any high-order bits of `rhs` that
+            /// would cause the shift to exceed the bitwidth of the type.
+            #[stable(feature = "num_wrapping", since = "1.2.0")]
+            #[inline(always)]
+            pub fn wrapping_shr(self, rhs: u32) -> Self {
+                self.overflowing_shr(rhs).0
+            }
+
+            /// Raises self to the power of `exp`, using exponentiation by squaring.
+            ///
+            /// # Examples
+            ///
+            /// ```
+            /// let x: i32 = 2; // or any other integer type
+            ///
+            /// assert_eq!(x.pow(4), 16);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn pow(self, mut exp: u32) -> Self {
+                let mut base = self;
+                let mut acc = Self::one();
+
+                while exp > 1 {
+                    if (exp & 1) == 1 {
+                        acc = acc * base;
+                    }
+                    exp /= 2;
+                    base = base * base;
+                }
+
+                // Deal with the final bit of the exponent separately, since
+                // squaring the base afterwards is not necessary and may cause a
+                // needless overflow.
+                if exp == 1 {
                     acc = acc * base;
                 }
-                exp /= 2;
-                base = base * base;
+
+                acc
             }
 
-            // Deal with the final bit of the exponent separately, since
-            // squaring the base afterwards is not necessary and may cause a
-            // needless overflow.
-            if exp == 1 {
-                acc = acc * base;
+            /// Computes the absolute value of `self`.
+            ///
+            /// # Overflow behavior
+            ///
+            /// The absolute value of `i32::min_value()` cannot be represented as an
+            /// `i32`, and attempting to calculate it will cause an overflow. This
+            /// means that code in debug mode will trigger a panic on this case and
+            /// optimized code will return `i32::min_value()` without a panic.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn abs(self) -> Self {
+                if self.is_negative() {
+                    // Note that the #[inline] above means that the overflow
+                    // semantics of this negation depend on the crate we're being
+                    // inlined into.
+                    -self
+                } else {
+                    self
+                }
             }
 
-            acc
+            /// Returns a number representing sign of `self`.
+            ///
+            /// - `0` if the number is zero
+            /// - `1` if the number is positive
+            /// - `-1` if the number is negative
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn signum(self) -> Self {
+                match self {
+                    n if n > 0 =>  1,
+                    0          =>  0,
+                    _          => -1,
+                }
+            }
+
+            /// Returns `true` if `self` is positive and `false` if the number
+            /// is zero or negative.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn is_positive(self) -> bool { self > 0 }
+
+            /// Returns `true` if `self` is negative and `false` if the number
+            /// is zero or positive.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn is_negative(self) -> bool { self < 0 }
         }
+    }
+}
 
-        /// Computes the absolute value of `self`.
-        ///
-        /// # Overflow behavior
-        ///
-        /// The absolute value of `i32::min_value()` cannot be represented as an
-        /// `i32`, and attempting to calculate it will cause an overflow. This
-        /// means that code in debug mode will trigger a panic on this case and
-        /// optimized code will return `i32::min_value()` without a panic.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn abs(self) -> Self {
-            if self.is_negative() {
-                // Note that the #[inline] above means that the overflow
-                // semantics of this negation depend on the crate we're being
-                // inlined into.
-                -self
-            } else {
-                self
+#[cfg(stage0)]
+#[macro_use]
+mod int_macro {
+    macro_rules! int_impl {
+        ($ActualT:ty, $UnsignedT:ty, $BITS:expr,
+         $wrapping_add:path,
+         $wrapping_sub:path,
+         $wrapping_mul:path,
+         $add_with_overflow:path,
+         $sub_with_overflow:path,
+         $mul_with_overflow:path) => {
+            /// Returns the smallest value that can be represented by this integer type.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn min_value() -> Self {
+                (-1 as Self) << ($BITS - 1)
             }
-        }
 
-        /// Returns a number representing sign of `self`.
-        ///
-        /// - `0` if the number is zero
-        /// - `1` if the number is positive
-        /// - `-1` if the number is negative
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn signum(self) -> Self {
-            match self {
-                n if n > 0 =>  1,
-                0          =>  0,
-                _          => -1,
+            /// Returns the largest value that can be represented by this integer type.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn max_value() -> Self {
+                let min = Self::min_value(); !min
             }
+
+            /// Converts a string slice in a given base to an integer.
+            ///
+            /// Leading and trailing whitespace represent an error.
+            ///
+            /// # Examples
+            ///
+            /// ```
+            /// assert_eq!(u32::from_str_radix("A", 16), Ok(10));
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            pub fn from_str_radix(src: &str, radix: u32) -> Result<Self, ParseIntError> {
+                from_str_radix(src, radix)
+            }
+
+            /// Returns the number of ones in the binary representation of `self`.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0b01001100u8;
+            ///
+            /// assert_eq!(n.count_ones(), 3);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn count_ones(self) -> u32 { (self as $UnsignedT).count_ones() }
+
+            /// Returns the number of zeros in the binary representation of `self`.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0b01001100u8;
+            ///
+            /// assert_eq!(n.count_zeros(), 5);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn count_zeros(self) -> u32 {
+                (!self).count_ones()
+            }
+
+            /// Returns the number of leading zeros in the binary representation
+            /// of `self`.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0b0101000u16;
+            ///
+            /// assert_eq!(n.leading_zeros(), 10);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn leading_zeros(self) -> u32 {
+                (self as $UnsignedT).leading_zeros()
+            }
+
+            /// Returns the number of trailing zeros in the binary representation
+            /// of `self`.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0b0101000u16;
+            ///
+            /// assert_eq!(n.trailing_zeros(), 3);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn trailing_zeros(self) -> u32 {
+                (self as $UnsignedT).trailing_zeros()
+            }
+
+            /// Shifts the bits to the left by a specified amount, `n`,
+            /// wrapping the truncated bits to the end of the resulting integer.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            /// let m = 0x3456789ABCDEF012u64;
+            ///
+            /// assert_eq!(n.rotate_left(12), m);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn rotate_left(self, n: u32) -> Self {
+                (self as $UnsignedT).rotate_left(n) as Self
+            }
+
+            /// Shifts the bits to the right by a specified amount, `n`,
+            /// wrapping the truncated bits to the beginning of the resulting
+            /// integer.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            /// let m = 0xDEF0123456789ABCu64;
+            ///
+            /// assert_eq!(n.rotate_right(12), m);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn rotate_right(self, n: u32) -> Self {
+                (self as $UnsignedT).rotate_right(n) as Self
+            }
+
+            /// Reverses the byte order of the integer.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            /// let m = 0xEFCDAB8967452301u64;
+            ///
+            /// assert_eq!(n.swap_bytes(), m);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn swap_bytes(self) -> Self {
+                (self as $UnsignedT).swap_bytes() as Self
+            }
+
+            /// Converts an integer from big endian to the target's endianness.
+            ///
+            /// On big endian this is a no-op. On little endian the bytes are
+            /// swapped.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            ///
+            /// if cfg!(target_endian = "big") {
+            ///     assert_eq!(u64::from_be(n), n)
+            /// } else {
+            ///     assert_eq!(u64::from_be(n), n.swap_bytes())
+            /// }
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn from_be(x: Self) -> Self {
+                if cfg!(target_endian = "big") { x } else { x.swap_bytes() }
+            }
+
+            /// Converts an integer from little endian to the target's endianness.
+            ///
+            /// On little endian this is a no-op. On big endian the bytes are
+            /// swapped.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            ///
+            /// if cfg!(target_endian = "little") {
+            ///     assert_eq!(u64::from_le(n), n)
+            /// } else {
+            ///     assert_eq!(u64::from_le(n), n.swap_bytes())
+            /// }
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn from_le(x: Self) -> Self {
+                if cfg!(target_endian = "little") { x } else { x.swap_bytes() }
+            }
+
+            /// Converts `self` to big endian from the target's endianness.
+            ///
+            /// On big endian this is a no-op. On little endian the bytes are
+            /// swapped.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            ///
+            /// if cfg!(target_endian = "big") {
+            ///     assert_eq!(n.to_be(), n)
+            /// } else {
+            ///     assert_eq!(n.to_be(), n.swap_bytes())
+            /// }
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn to_be(self) -> Self { // or not to be?
+                if cfg!(target_endian = "big") { self } else { self.swap_bytes() }
+            }
+
+            /// Converts `self` to little endian from the target's endianness.
+            ///
+            /// On little endian this is a no-op. On big endian the bytes are
+            /// swapped.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            ///
+            /// if cfg!(target_endian = "little") {
+            ///     assert_eq!(n.to_le(), n)
+            /// } else {
+            ///     assert_eq!(n.to_le(), n.swap_bytes())
+            /// }
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn to_le(self) -> Self {
+                if cfg!(target_endian = "little") { self } else { self.swap_bytes() }
+            }
+
+            /// Checked integer addition. Computes `self + other`, returning `None`
+            /// if overflow occurred.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// assert_eq!(5u16.checked_add(65530), Some(65535));
+            /// assert_eq!(6u16.checked_add(65530), None);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn checked_add(self, other: Self) -> Option<Self> {
+                checked_op!($ActualT, $add_with_overflow, self, other)
+            }
+
+            /// Checked integer subtraction. Computes `self - other`, returning
+            /// `None` if underflow occurred.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// assert_eq!((-127i8).checked_sub(1), Some(-128));
+            /// assert_eq!((-128i8).checked_sub(1), None);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn checked_sub(self, other: Self) -> Option<Self> {
+                checked_op!($ActualT, $sub_with_overflow, self, other)
+            }
+
+            /// Checked integer multiplication. Computes `self * other`, returning
+            /// `None` if underflow or overflow occurred.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// assert_eq!(5u8.checked_mul(51), Some(255));
+            /// assert_eq!(5u8.checked_mul(52), None);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn checked_mul(self, other: Self) -> Option<Self> {
+                checked_op!($ActualT, $mul_with_overflow, self, other)
+            }
+
+            /// Checked integer division. Computes `self / other`, returning `None`
+            /// if `other == 0` or the operation results in underflow or overflow.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// assert_eq!((-127i8).checked_div(-1), Some(127));
+            /// assert_eq!((-128i8).checked_div(-1), None);
+            /// assert_eq!((1i8).checked_div(0), None);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn checked_div(self, other: Self) -> Option<Self> {
+                match other {
+                    0    => None,
+                   -1 if self == Self::min_value()
+                         => None,
+                   other => Some(self / other),
+                }
+            }
+
+            /// Saturating integer addition. Computes `self + other`, saturating at
+            /// the numeric bounds instead of overflowing.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn saturating_add(self, other: Self) -> Self {
+                match self.checked_add(other) {
+                    Some(x)                       => x,
+                    None if other >= Self::zero() => Self::max_value(),
+                    None => Self::min_value(),
+                }
+            }
+
+            /// Saturating integer subtraction. Computes `self - other`, saturating
+            /// at the numeric bounds instead of overflowing.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn saturating_sub(self, other: Self) -> Self {
+                match self.checked_sub(other) {
+                    Some(x)                      => x,
+                    None if other >= Self::zero() => Self::min_value(),
+                    None => Self::max_value(),
+                }
+            }
+
+            /// Wrapping (modular) addition. Computes `self + other`,
+            /// wrapping around at the boundary of the type.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn wrapping_add(self, rhs: Self) -> Self {
+                unsafe {
+                    intrinsics::overflowing_add(self, rhs)
+                }
+            }
+
+            /// Wrapping (modular) subtraction. Computes `self - other`,
+            /// wrapping around at the boundary of the type.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn wrapping_sub(self, rhs: Self) -> Self {
+                unsafe {
+                    intrinsics::overflowing_sub(self, rhs)
+                }
+            }
+
+            /// Wrapping (modular) multiplication. Computes `self *
+            /// other`, wrapping around at the boundary of the type.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn wrapping_mul(self, rhs: Self) -> Self {
+                unsafe {
+                    intrinsics::overflowing_mul(self, rhs)
+                }
+            }
+
+            /// Wrapping (modular) division. Computes `self / other`,
+            /// wrapping around at the boundary of the type.
+            ///
+            /// The only case where such wrapping can occur is when one
+            /// divides `MIN / -1` on a signed type (where `MIN` is the
+            /// negative minimal value for the type); this is equivalent
+            /// to `-MIN`, a positive value that is too large to represent
+            /// in the type. In such a case, this function returns `MIN`
+            /// itself.
+            #[stable(feature = "num_wrapping", since = "1.2.0")]
+            #[inline(always)]
+            pub fn wrapping_div(self, rhs: Self) -> Self {
+                self.overflowing_div(rhs).0
+            }
+
+            /// Wrapping (modular) remainder. Computes `self % other`,
+            /// wrapping around at the boundary of the type.
+            ///
+            /// Such wrap-around never actually occurs mathematically;
+            /// implementation artifacts make `x % y` invalid for `MIN /
+            /// -1` on a signed type (where `MIN` is the negative
+            /// minimal value). In such a case, this function returns `0`.
+            #[stable(feature = "num_wrapping", since = "1.2.0")]
+            #[inline(always)]
+            pub fn wrapping_rem(self, rhs: Self) -> Self {
+                self.overflowing_rem(rhs).0
+            }
+
+            /// Wrapping (modular) negation. Computes `-self`,
+            /// wrapping around at the boundary of the type.
+            ///
+            /// The only case where such wrapping can occur is when one
+            /// negates `MIN` on a signed type (where `MIN` is the
+            /// negative minimal value for the type); this is a positive
+            /// value that is too large to represent in the type. In such
+            /// a case, this function returns `MIN` itself.
+            #[stable(feature = "num_wrapping", since = "1.2.0")]
+            #[inline(always)]
+            pub fn wrapping_neg(self) -> Self {
+                self.overflowing_neg().0
+            }
+
+            /// Panic-free bitwise shift-left; yields `self << mask(rhs)`,
+            /// where `mask` removes any high-order bits of `rhs` that
+            /// would cause the shift to exceed the bitwidth of the type.
+            #[stable(feature = "num_wrapping", since = "1.2.0")]
+            #[inline(always)]
+            pub fn wrapping_shl(self, rhs: u32) -> Self {
+                self.overflowing_shl(rhs).0
+            }
+
+            /// Panic-free bitwise shift-left; yields `self >> mask(rhs)`,
+            /// where `mask` removes any high-order bits of `rhs` that
+            /// would cause the shift to exceed the bitwidth of the type.
+            #[stable(feature = "num_wrapping", since = "1.2.0")]
+            #[inline(always)]
+            pub fn wrapping_shr(self, rhs: u32) -> Self {
+                self.overflowing_shr(rhs).0
+            }
+
+            /// Raises self to the power of `exp`, using exponentiation by squaring.
+            ///
+            /// # Examples
+            ///
+            /// ```
+            /// let x: i32 = 2; // or any other integer type
+            ///
+            /// assert_eq!(x.pow(4), 16);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn pow(self, mut exp: u32) -> Self {
+                let mut base = self;
+                let mut acc = Self::one();
+
+                while exp > 1 {
+                    if (exp & 1) == 1 {
+                        acc = acc * base;
+                    }
+                    exp /= 2;
+                    base = base * base;
+                }
+
+                // Deal with the final bit of the exponent separately, since
+                // squaring the base afterwards is not necessary and may cause a
+                // needless overflow.
+                if exp == 1 {
+                    acc = acc * base;
+                }
+
+                acc
+            }
+
+            /// Computes the absolute value of `self`.
+            ///
+            /// # Overflow behavior
+            ///
+            /// The absolute value of `i32::min_value()` cannot be represented as an
+            /// `i32`, and attempting to calculate it will cause an overflow. This
+            /// means that code in debug mode will trigger a panic on this case and
+            /// optimized code will return `i32::min_value()` without a panic.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn abs(self) -> Self {
+                if self.is_negative() {
+                    // Note that the #[inline] above means that the overflow
+                    // semantics of this negation depend on the crate we're being
+                    // inlined into.
+                    -self
+                } else {
+                    self
+                }
+            }
+
+            /// Returns a number representing sign of `self`.
+            ///
+            /// - `0` if the number is zero
+            /// - `1` if the number is positive
+            /// - `-1` if the number is negative
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn signum(self) -> Self {
+                match self {
+                    n if n > 0 =>  1,
+                    0          =>  0,
+                    _          => -1,
+                }
+            }
+
+            /// Returns `true` if `self` is positive and `false` if the number
+            /// is zero or negative.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn is_positive(self) -> bool { self > 0 }
+
+            /// Returns `true` if `self` is negative and `false` if the number
+            /// is zero or positive.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn is_negative(self) -> bool { self < 0 }
         }
-
-        /// Returns `true` if `self` is positive and `false` if the number
-        /// is zero or negative.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn is_positive(self) -> bool { self > 0 }
-
-        /// Returns `true` if `self` is negative and `false` if the number
-        /// is zero or positive.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn is_negative(self) -> bool { self < 0 }
     }
 }
 
 #[lang = "i8"]
 impl i8 {
     int_impl! { i8, u8, 8,
+        intrinsics::i8_wrapping_add,
+        intrinsics::i8_wrapping_sub,
+        intrinsics::i8_wrapping_mul,
         intrinsics::i8_add_with_overflow,
         intrinsics::i8_sub_with_overflow,
         intrinsics::i8_mul_with_overflow }
@@ -621,6 +1133,9 @@ impl i8 {
 #[lang = "i16"]
 impl i16 {
     int_impl! { i16, u16, 16,
+        intrinsics::i16_wrapping_add,
+        intrinsics::i16_wrapping_sub,
+        intrinsics::i16_wrapping_mul,
         intrinsics::i16_add_with_overflow,
         intrinsics::i16_sub_with_overflow,
         intrinsics::i16_mul_with_overflow }
@@ -629,6 +1144,9 @@ impl i16 {
 #[lang = "i32"]
 impl i32 {
     int_impl! { i32, u32, 32,
+        intrinsics::i32_wrapping_add,
+        intrinsics::i32_wrapping_sub,
+        intrinsics::i32_wrapping_mul,
         intrinsics::i32_add_with_overflow,
         intrinsics::i32_sub_with_overflow,
         intrinsics::i32_mul_with_overflow }
@@ -637,6 +1155,9 @@ impl i32 {
 #[lang = "i64"]
 impl i64 {
     int_impl! { i64, u64, 64,
+        intrinsics::i64_wrapping_add,
+        intrinsics::i64_wrapping_sub,
+        intrinsics::i64_wrapping_mul,
         intrinsics::i64_add_with_overflow,
         intrinsics::i64_sub_with_overflow,
         intrinsics::i64_mul_with_overflow }
@@ -646,6 +1167,9 @@ impl i64 {
 #[lang = "isize"]
 impl isize {
     int_impl! { i32, u32, 32,
+        intrinsics::i32_wrapping_add,
+        intrinsics::i32_wrapping_sub,
+        intrinsics::i32_wrapping_mul,
         intrinsics::i32_add_with_overflow,
         intrinsics::i32_sub_with_overflow,
         intrinsics::i32_mul_with_overflow }
@@ -655,508 +1179,1026 @@ impl isize {
 #[lang = "isize"]
 impl isize {
     int_impl! { i64, u64, 64,
+        intrinsics::i64_wrapping_add,
+        intrinsics::i64_wrapping_sub,
+        intrinsics::i64_wrapping_mul,
         intrinsics::i64_add_with_overflow,
         intrinsics::i64_sub_with_overflow,
         intrinsics::i64_mul_with_overflow }
 }
 
 // `Int` + `UnsignedInt` implemented for signed integers
-macro_rules! uint_impl {
-    ($ActualT:ty, $BITS:expr,
-     $ctpop:path,
-     $ctlz:path,
-     $cttz:path,
-     $bswap:path,
-     $add_with_overflow:path,
-     $sub_with_overflow:path,
-     $mul_with_overflow:path) => {
-        /// Returns the smallest value that can be represented by this integer type.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn min_value() -> Self { 0 }
+#[cfg(not(stage0))]
+#[macro_use]
+mod uint_macro {
+    macro_rules! uint_impl {
+        ($ActualT:ty, $BITS:expr,
+         $ctpop:path,
+         $ctlz:path,
+         $cttz:path,
+         $bswap:path,
+         $wrapping_add:path,
+         $wrapping_sub:path,
+         $wrapping_mul:path,
+         $add_with_overflow:path,
+         $sub_with_overflow:path,
+         $mul_with_overflow:path) => {
+            /// Returns the smallest value that can be represented by this integer type.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn min_value() -> Self { 0 }
 
-        /// Returns the largest value that can be represented by this integer type.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn max_value() -> Self { !0 }
+            /// Returns the largest value that can be represented by this integer type.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn max_value() -> Self { !0 }
 
-        /// Converts a string slice in a given base to an integer.
-        ///
-        /// Leading and trailing whitespace represent an error.
-        ///
-        /// # Arguments
-        ///
-        /// * src - A string slice
-        /// * radix - The base to use. Must lie in the range [2 .. 36]
-        ///
-        /// # Return value
-        ///
-        /// `Err(ParseIntError)` if the string did not represent a valid number.
-        /// Otherwise, `Ok(n)` where `n` is the integer represented by `src`.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        pub fn from_str_radix(src: &str, radix: u32) -> Result<Self, ParseIntError> {
-            from_str_radix(src, radix)
-        }
-
-        /// Returns the number of ones in the binary representation of `self`.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// let n = 0b01001100u8;
-        ///
-        /// assert_eq!(n.count_ones(), 3);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn count_ones(self) -> u32 {
-            unsafe { $ctpop(self as $ActualT) as u32 }
-        }
-
-        /// Returns the number of zeros in the binary representation of `self`.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// let n = 0b01001100u8;
-        ///
-        /// assert_eq!(n.count_zeros(), 5);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn count_zeros(self) -> u32 {
-            (!self).count_ones()
-        }
-
-        /// Returns the number of leading zeros in the binary representation
-        /// of `self`.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// let n = 0b0101000u16;
-        ///
-        /// assert_eq!(n.leading_zeros(), 10);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn leading_zeros(self) -> u32 {
-            unsafe { $ctlz(self as $ActualT) as u32 }
-        }
-
-        /// Returns the number of trailing zeros in the binary representation
-        /// of `self`.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// let n = 0b0101000u16;
-        ///
-        /// assert_eq!(n.trailing_zeros(), 3);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn trailing_zeros(self) -> u32 {
-            // As of LLVM 3.6 the codegen for the zero-safe cttz8 intrinsic
-            // emits two conditional moves on x86_64. By promoting the value to
-            // u16 and setting bit 8, we get better code without any conditional
-            // operations.
-            // FIXME: There's a LLVM patch (http://reviews.llvm.org/D9284)
-            // pending, remove this workaround once LLVM generates better code
-            // for cttz8.
-            unsafe {
-                if $BITS == 8 {
-                    intrinsics::cttz16(self as u16 | 0x100) as u32
-                } else {
-                    $cttz(self as $ActualT) as u32
-                }
+            /// Converts a string slice in a given base to an integer.
+            ///
+            /// Leading and trailing whitespace represent an error.
+            ///
+            /// # Arguments
+            ///
+            /// * src - A string slice
+            /// * radix - The base to use. Must lie in the range [2 .. 36]
+            ///
+            /// # Return value
+            ///
+            /// `Err(ParseIntError)` if the string did not represent a valid number.
+            /// Otherwise, `Ok(n)` where `n` is the integer represented by `src`.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            pub fn from_str_radix(src: &str, radix: u32) -> Result<Self, ParseIntError> {
+                from_str_radix(src, radix)
             }
-        }
 
-        /// Shifts the bits to the left by a specified amount, `n`,
-        /// wrapping the truncated bits to the end of the resulting integer.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// let n = 0x0123456789ABCDEFu64;
-        /// let m = 0x3456789ABCDEF012u64;
-        ///
-        /// assert_eq!(n.rotate_left(12), m);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn rotate_left(self, n: u32) -> Self {
-            // Protect against undefined behaviour for over-long bit shifts
-            let n = n % $BITS;
-            (self << n) | (self >> (($BITS - n) % $BITS))
-        }
-
-        /// Shifts the bits to the right by a specified amount, `n`,
-        /// wrapping the truncated bits to the beginning of the resulting
-        /// integer.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// let n = 0x0123456789ABCDEFu64;
-        /// let m = 0xDEF0123456789ABCu64;
-        ///
-        /// assert_eq!(n.rotate_right(12), m);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn rotate_right(self, n: u32) -> Self {
-            // Protect against undefined behaviour for over-long bit shifts
-            let n = n % $BITS;
-            (self >> n) | (self << (($BITS - n) % $BITS))
-        }
-
-        /// Reverses the byte order of the integer.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// let n = 0x0123456789ABCDEFu64;
-        /// let m = 0xEFCDAB8967452301u64;
-        ///
-        /// assert_eq!(n.swap_bytes(), m);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn swap_bytes(self) -> Self {
-            unsafe { $bswap(self as $ActualT) as Self }
-        }
-
-        /// Converts an integer from big endian to the target's endianness.
-        ///
-        /// On big endian this is a no-op. On little endian the bytes are
-        /// swapped.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// let n = 0x0123456789ABCDEFu64;
-        ///
-        /// if cfg!(target_endian = "big") {
-        ///     assert_eq!(u64::from_be(n), n)
-        /// } else {
-        ///     assert_eq!(u64::from_be(n), n.swap_bytes())
-        /// }
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn from_be(x: Self) -> Self {
-            if cfg!(target_endian = "big") { x } else { x.swap_bytes() }
-        }
-
-        /// Converts an integer from little endian to the target's endianness.
-        ///
-        /// On little endian this is a no-op. On big endian the bytes are
-        /// swapped.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// let n = 0x0123456789ABCDEFu64;
-        ///
-        /// if cfg!(target_endian = "little") {
-        ///     assert_eq!(u64::from_le(n), n)
-        /// } else {
-        ///     assert_eq!(u64::from_le(n), n.swap_bytes())
-        /// }
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn from_le(x: Self) -> Self {
-            if cfg!(target_endian = "little") { x } else { x.swap_bytes() }
-        }
-
-        /// Converts `self` to big endian from the target's endianness.
-        ///
-        /// On big endian this is a no-op. On little endian the bytes are
-        /// swapped.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// let n = 0x0123456789ABCDEFu64;
-        ///
-        /// if cfg!(target_endian = "big") {
-        ///     assert_eq!(n.to_be(), n)
-        /// } else {
-        ///     assert_eq!(n.to_be(), n.swap_bytes())
-        /// }
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn to_be(self) -> Self { // or not to be?
-            if cfg!(target_endian = "big") { self } else { self.swap_bytes() }
-        }
-
-        /// Converts `self` to little endian from the target's endianness.
-        ///
-        /// On little endian this is a no-op. On big endian the bytes are
-        /// swapped.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// let n = 0x0123456789ABCDEFu64;
-        ///
-        /// if cfg!(target_endian = "little") {
-        ///     assert_eq!(n.to_le(), n)
-        /// } else {
-        ///     assert_eq!(n.to_le(), n.swap_bytes())
-        /// }
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn to_le(self) -> Self {
-            if cfg!(target_endian = "little") { self } else { self.swap_bytes() }
-        }
-
-        /// Checked integer addition. Computes `self + other`, returning `None`
-        /// if overflow occurred.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// assert_eq!(5u16.checked_add(65530), Some(65535));
-        /// assert_eq!(6u16.checked_add(65530), None);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn checked_add(self, other: Self) -> Option<Self> {
-            checked_op!($ActualT, $add_with_overflow, self, other)
-        }
-
-        /// Checked integer subtraction. Computes `self - other`, returning
-        /// `None` if underflow occurred.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// assert_eq!((-127i8).checked_sub(1), Some(-128));
-        /// assert_eq!((-128i8).checked_sub(1), None);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn checked_sub(self, other: Self) -> Option<Self> {
-            checked_op!($ActualT, $sub_with_overflow, self, other)
-        }
-
-        /// Checked integer multiplication. Computes `self * other`, returning
-        /// `None` if underflow or overflow occurred.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// assert_eq!(5u8.checked_mul(51), Some(255));
-        /// assert_eq!(5u8.checked_mul(52), None);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn checked_mul(self, other: Self) -> Option<Self> {
-            checked_op!($ActualT, $mul_with_overflow, self, other)
-        }
-
-        /// Checked integer division. Computes `self / other`, returning `None`
-        /// if `other == 0` or the operation results in underflow or overflow.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// assert_eq!((-127i8).checked_div(-1), Some(127));
-        /// assert_eq!((-128i8).checked_div(-1), None);
-        /// assert_eq!((1i8).checked_div(0), None);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn checked_div(self, other: Self) -> Option<Self> {
-            match other {
-                0 => None,
-                other => Some(self / other),
+            /// Returns the number of ones in the binary representation of `self`.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0b01001100u8;
+            ///
+            /// assert_eq!(n.count_ones(), 3);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn count_ones(self) -> u32 {
+                unsafe { $ctpop(self as $ActualT) as u32 }
             }
-        }
 
-        /// Saturating integer addition. Computes `self + other`, saturating at
-        /// the numeric bounds instead of overflowing.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn saturating_add(self, other: Self) -> Self {
-            match self.checked_add(other) {
-                Some(x)                       => x,
-                None if other >= Self::zero() => Self::max_value(),
-                None => Self::min_value(),
+            /// Returns the number of zeros in the binary representation of `self`.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0b01001100u8;
+            ///
+            /// assert_eq!(n.count_zeros(), 5);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn count_zeros(self) -> u32 {
+                (!self).count_ones()
             }
-        }
 
-        /// Saturating integer subtraction. Computes `self - other`, saturating
-        /// at the numeric bounds instead of overflowing.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn saturating_sub(self, other: Self) -> Self {
-            match self.checked_sub(other) {
-                Some(x)                       => x,
-                None if other >= Self::zero() => Self::min_value(),
-                None => Self::max_value(),
+            /// Returns the number of leading zeros in the binary representation
+            /// of `self`.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0b0101000u16;
+            ///
+            /// assert_eq!(n.leading_zeros(), 10);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn leading_zeros(self) -> u32 {
+                unsafe { $ctlz(self as $ActualT) as u32 }
             }
-        }
 
-        /// Wrapping (modular) addition. Computes `self + other`,
-        /// wrapping around at the boundary of the type.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn wrapping_add(self, rhs: Self) -> Self {
-            unsafe {
-                intrinsics::overflowing_add(self, rhs)
-            }
-        }
-
-        /// Wrapping (modular) subtraction. Computes `self - other`,
-        /// wrapping around at the boundary of the type.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn wrapping_sub(self, rhs: Self) -> Self {
-            unsafe {
-                intrinsics::overflowing_sub(self, rhs)
-            }
-        }
-
-        /// Wrapping (modular) multiplication. Computes `self *
-        /// other`, wrapping around at the boundary of the type.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn wrapping_mul(self, rhs: Self) -> Self {
-            unsafe {
-                intrinsics::overflowing_mul(self, rhs)
-            }
-        }
-
-        /// Wrapping (modular) division. Computes `self / other`,
-        /// wrapping around at the boundary of the type.
-        ///
-        /// The only case where such wrapping can occur is when one
-        /// divides `MIN / -1` on a signed type (where `MIN` is the
-        /// negative minimal value for the type); this is equivalent
-        /// to `-MIN`, a positive value that is too large to represent
-        /// in the type. In such a case, this function returns `MIN`
-        /// itself.
-        #[stable(feature = "num_wrapping", since = "1.2.0")]
-        #[inline(always)]
-        pub fn wrapping_div(self, rhs: Self) -> Self {
-            self.overflowing_div(rhs).0
-        }
-
-        /// Wrapping (modular) remainder. Computes `self % other`,
-        /// wrapping around at the boundary of the type.
-        ///
-        /// Such wrap-around never actually occurs mathematically;
-        /// implementation artifacts make `x % y` invalid for `MIN /
-        /// -1` on a signed type (where `MIN` is the negative
-        /// minimal value). In such a case, this function returns `0`.
-        #[stable(feature = "num_wrapping", since = "1.2.0")]
-        #[inline(always)]
-        pub fn wrapping_rem(self, rhs: Self) -> Self {
-            self.overflowing_rem(rhs).0
-        }
-
-        /// Wrapping (modular) negation. Computes `-self`,
-        /// wrapping around at the boundary of the type.
-        ///
-        /// The only case where such wrapping can occur is when one
-        /// negates `MIN` on a signed type (where `MIN` is the
-        /// negative minimal value for the type); this is a positive
-        /// value that is too large to represent in the type. In such
-        /// a case, this function returns `MIN` itself.
-        #[stable(feature = "num_wrapping", since = "1.2.0")]
-        #[inline(always)]
-        pub fn wrapping_neg(self) -> Self {
-            self.overflowing_neg().0
-        }
-
-        /// Panic-free bitwise shift-left; yields `self << mask(rhs)`,
-        /// where `mask` removes any high-order bits of `rhs` that
-        /// would cause the shift to exceed the bitwidth of the type.
-        #[stable(feature = "num_wrapping", since = "1.2.0")]
-        #[inline(always)]
-        pub fn wrapping_shl(self, rhs: u32) -> Self {
-            self.overflowing_shl(rhs).0
-        }
-
-        /// Panic-free bitwise shift-left; yields `self >> mask(rhs)`,
-        /// where `mask` removes any high-order bits of `rhs` that
-        /// would cause the shift to exceed the bitwidth of the type.
-        #[stable(feature = "num_wrapping", since = "1.2.0")]
-        #[inline(always)]
-        pub fn wrapping_shr(self, rhs: u32) -> Self {
-            self.overflowing_shr(rhs).0
-        }
-
-        /// Raises self to the power of `exp`, using exponentiation by squaring.
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// assert_eq!(2i32.pow(4), 16);
-        /// ```
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn pow(self, mut exp: u32) -> Self {
-            let mut base = self;
-            let mut acc = Self::one();
-
-            let mut prev_base = self;
-            let mut base_oflo = false;
-            while exp > 0 {
-                if (exp & 1) == 1 {
-                    if base_oflo {
-                        // ensure overflow occurs in the same manner it
-                        // would have otherwise (i.e. signal any exception
-                        // it would have otherwise).
-                        acc = acc * (prev_base * prev_base);
+            /// Returns the number of trailing zeros in the binary representation
+            /// of `self`.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0b0101000u16;
+            ///
+            /// assert_eq!(n.trailing_zeros(), 3);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn trailing_zeros(self) -> u32 {
+                // As of LLVM 3.6 the codegen for the zero-safe cttz8 intrinsic
+                // emits two conditional moves on x86_64. By promoting the value to
+                // u16 and setting bit 8, we get better code without any conditional
+                // operations.
+                // FIXME: There's a LLVM patch (http://reviews.llvm.org/D9284)
+                // pending, remove this workaround once LLVM generates better code
+                // for cttz8.
+                unsafe {
+                    if $BITS == 8 {
+                        intrinsics::cttz16(self as u16 | 0x100) as u32
                     } else {
-                        acc = acc * base;
+                        $cttz(self as $ActualT) as u32
                     }
                 }
-                prev_base = base;
-                let (new_base, new_base_oflo) = base.overflowing_mul(base);
-                base = new_base;
-                base_oflo = new_base_oflo;
-                exp /= 2;
             }
-            acc
-        }
 
-        /// Returns `true` if and only if `self == 2^k` for some `k`.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn is_power_of_two(self) -> bool {
-            (self.wrapping_sub(Self::one())) & self == Self::zero() &&
-                !(self == Self::zero())
-        }
+            /// Shifts the bits to the left by a specified amount, `n`,
+            /// wrapping the truncated bits to the end of the resulting integer.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            /// let m = 0x3456789ABCDEF012u64;
+            ///
+            /// assert_eq!(n.rotate_left(12), m);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn rotate_left(self, n: u32) -> Self {
+                // Protect against undefined behaviour for over-long bit shifts
+                let n = n % $BITS;
+                (self << n) | (self >> (($BITS - n) % $BITS))
+            }
 
-        /// Returns the smallest power of two greater than or equal to `self`.
-        /// Unspecified behavior on overflow.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        #[inline]
-        pub fn next_power_of_two(self) -> Self {
-            let bits = size_of::<Self>() * 8;
-            let one: Self = Self::one();
-            one << ((bits - self.wrapping_sub(one).leading_zeros() as usize) % bits)
-        }
+            /// Shifts the bits to the right by a specified amount, `n`,
+            /// wrapping the truncated bits to the beginning of the resulting
+            /// integer.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            /// let m = 0xDEF0123456789ABCu64;
+            ///
+            /// assert_eq!(n.rotate_right(12), m);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn rotate_right(self, n: u32) -> Self {
+                // Protect against undefined behaviour for over-long bit shifts
+                let n = n % $BITS;
+                (self >> n) | (self << (($BITS - n) % $BITS))
+            }
 
-        /// Returns the smallest power of two greater than or equal to `n`. If
-        /// the next power of two is greater than the type's maximum value,
-        /// `None` is returned, otherwise the power of two is wrapped in `Some`.
-        #[stable(feature = "rust1", since = "1.0.0")]
-        pub fn checked_next_power_of_two(self) -> Option<Self> {
-            let npot = self.next_power_of_two();
-            if npot >= self {
-                Some(npot)
-            } else {
-                None
+            /// Reverses the byte order of the integer.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            /// let m = 0xEFCDAB8967452301u64;
+            ///
+            /// assert_eq!(n.swap_bytes(), m);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn swap_bytes(self) -> Self {
+                unsafe { $bswap(self as $ActualT) as Self }
+            }
+
+            /// Converts an integer from big endian to the target's endianness.
+            ///
+            /// On big endian this is a no-op. On little endian the bytes are
+            /// swapped.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            ///
+            /// if cfg!(target_endian = "big") {
+            ///     assert_eq!(u64::from_be(n), n)
+            /// } else {
+            ///     assert_eq!(u64::from_be(n), n.swap_bytes())
+            /// }
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn from_be(x: Self) -> Self {
+                if cfg!(target_endian = "big") { x } else { x.swap_bytes() }
+            }
+
+            /// Converts an integer from little endian to the target's endianness.
+            ///
+            /// On little endian this is a no-op. On big endian the bytes are
+            /// swapped.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            ///
+            /// if cfg!(target_endian = "little") {
+            ///     assert_eq!(u64::from_le(n), n)
+            /// } else {
+            ///     assert_eq!(u64::from_le(n), n.swap_bytes())
+            /// }
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn from_le(x: Self) -> Self {
+                if cfg!(target_endian = "little") { x } else { x.swap_bytes() }
+            }
+
+            /// Converts `self` to big endian from the target's endianness.
+            ///
+            /// On big endian this is a no-op. On little endian the bytes are
+            /// swapped.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            ///
+            /// if cfg!(target_endian = "big") {
+            ///     assert_eq!(n.to_be(), n)
+            /// } else {
+            ///     assert_eq!(n.to_be(), n.swap_bytes())
+            /// }
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn to_be(self) -> Self { // or not to be?
+                if cfg!(target_endian = "big") { self } else { self.swap_bytes() }
+            }
+
+            /// Converts `self` to little endian from the target's endianness.
+            ///
+            /// On little endian this is a no-op. On big endian the bytes are
+            /// swapped.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            ///
+            /// if cfg!(target_endian = "little") {
+            ///     assert_eq!(n.to_le(), n)
+            /// } else {
+            ///     assert_eq!(n.to_le(), n.swap_bytes())
+            /// }
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn to_le(self) -> Self {
+                if cfg!(target_endian = "little") { self } else { self.swap_bytes() }
+            }
+
+            /// Checked integer addition. Computes `self + other`, returning `None`
+            /// if overflow occurred.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// assert_eq!(5u16.checked_add(65530), Some(65535));
+            /// assert_eq!(6u16.checked_add(65530), None);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn checked_add(self, other: Self) -> Option<Self> {
+                checked_op!($ActualT, $add_with_overflow, self, other)
+            }
+
+            /// Checked integer subtraction. Computes `self - other`, returning
+            /// `None` if underflow occurred.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// assert_eq!((-127i8).checked_sub(1), Some(-128));
+            /// assert_eq!((-128i8).checked_sub(1), None);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn checked_sub(self, other: Self) -> Option<Self> {
+                checked_op!($ActualT, $sub_with_overflow, self, other)
+            }
+
+            /// Checked integer multiplication. Computes `self * other`, returning
+            /// `None` if underflow or overflow occurred.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// assert_eq!(5u8.checked_mul(51), Some(255));
+            /// assert_eq!(5u8.checked_mul(52), None);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn checked_mul(self, other: Self) -> Option<Self> {
+                checked_op!($ActualT, $mul_with_overflow, self, other)
+            }
+
+            /// Checked integer division. Computes `self / other`, returning `None`
+            /// if `other == 0` or the operation results in underflow or overflow.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// assert_eq!((-127i8).checked_div(-1), Some(127));
+            /// assert_eq!((-128i8).checked_div(-1), None);
+            /// assert_eq!((1i8).checked_div(0), None);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn checked_div(self, other: Self) -> Option<Self> {
+                match other {
+                    0 => None,
+                    other => Some(self / other),
+                }
+            }
+
+            /// Saturating integer addition. Computes `self + other`, saturating at
+            /// the numeric bounds instead of overflowing.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn saturating_add(self, other: Self) -> Self {
+                match self.checked_add(other) {
+                    Some(x)                       => x,
+                    None if other >= Self::zero() => Self::max_value(),
+                    None => Self::min_value(),
+                }
+            }
+
+            /// Saturating integer subtraction. Computes `self - other`, saturating
+            /// at the numeric bounds instead of overflowing.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn saturating_sub(self, other: Self) -> Self {
+                match self.checked_sub(other) {
+                    Some(x)                       => x,
+                    None if other >= Self::zero() => Self::min_value(),
+                    None => Self::max_value(),
+                }
+            }
+
+            /// Wrapping (modular) addition. Computes `self + other`,
+            /// wrapping around at the boundary of the type.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn wrapping_add(self, rhs: Self) -> Self {
+                unsafe {
+                    $wrapping_add(self as $ActualT, rhs as $ActualT) as Self
+                }
+            }
+
+            /// Wrapping (modular) subtraction. Computes `self - other`,
+            /// wrapping around at the boundary of the type.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn wrapping_sub(self, rhs: Self) -> Self {
+                unsafe {
+                    $wrapping_sub(self as $ActualT, rhs as $ActualT) as Self
+                }
+            }
+
+            /// Wrapping (modular) multiplication. Computes `self *
+            /// other`, wrapping around at the boundary of the type.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn wrapping_mul(self, rhs: Self) -> Self {
+                unsafe {
+                    $wrapping_mul(self as $ActualT, rhs as $ActualT) as Self
+                }
+            }
+
+            /// Wrapping (modular) division. Computes `self / other`,
+            /// wrapping around at the boundary of the type.
+            ///
+            /// The only case where such wrapping can occur is when one
+            /// divides `MIN / -1` on a signed type (where `MIN` is the
+            /// negative minimal value for the type); this is equivalent
+            /// to `-MIN`, a positive value that is too large to represent
+            /// in the type. In such a case, this function returns `MIN`
+            /// itself.
+            #[stable(feature = "num_wrapping", since = "1.2.0")]
+            #[inline(always)]
+            pub fn wrapping_div(self, rhs: Self) -> Self {
+                self.overflowing_div(rhs).0
+            }
+
+            /// Wrapping (modular) remainder. Computes `self % other`,
+            /// wrapping around at the boundary of the type.
+            ///
+            /// Such wrap-around never actually occurs mathematically;
+            /// implementation artifacts make `x % y` invalid for `MIN /
+            /// -1` on a signed type (where `MIN` is the negative
+            /// minimal value). In such a case, this function returns `0`.
+            #[stable(feature = "num_wrapping", since = "1.2.0")]
+            #[inline(always)]
+            pub fn wrapping_rem(self, rhs: Self) -> Self {
+                self.overflowing_rem(rhs).0
+            }
+
+            /// Wrapping (modular) negation. Computes `-self`,
+            /// wrapping around at the boundary of the type.
+            ///
+            /// The only case where such wrapping can occur is when one
+            /// negates `MIN` on a signed type (where `MIN` is the
+            /// negative minimal value for the type); this is a positive
+            /// value that is too large to represent in the type. In such
+            /// a case, this function returns `MIN` itself.
+            #[stable(feature = "num_wrapping", since = "1.2.0")]
+            #[inline(always)]
+            pub fn wrapping_neg(self) -> Self {
+                self.overflowing_neg().0
+            }
+
+            /// Panic-free bitwise shift-left; yields `self << mask(rhs)`,
+            /// where `mask` removes any high-order bits of `rhs` that
+            /// would cause the shift to exceed the bitwidth of the type.
+            #[stable(feature = "num_wrapping", since = "1.2.0")]
+            #[inline(always)]
+            pub fn wrapping_shl(self, rhs: u32) -> Self {
+                self.overflowing_shl(rhs).0
+            }
+
+            /// Panic-free bitwise shift-left; yields `self >> mask(rhs)`,
+            /// where `mask` removes any high-order bits of `rhs` that
+            /// would cause the shift to exceed the bitwidth of the type.
+            #[stable(feature = "num_wrapping", since = "1.2.0")]
+            #[inline(always)]
+            pub fn wrapping_shr(self, rhs: u32) -> Self {
+                self.overflowing_shr(rhs).0
+            }
+
+            /// Raises self to the power of `exp`, using exponentiation by squaring.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// assert_eq!(2i32.pow(4), 16);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn pow(self, mut exp: u32) -> Self {
+                let mut base = self;
+                let mut acc = Self::one();
+
+                let mut prev_base = self;
+                let mut base_oflo = false;
+                while exp > 0 {
+                    if (exp & 1) == 1 {
+                        if base_oflo {
+                            // ensure overflow occurs in the same manner it
+                            // would have otherwise (i.e. signal any exception
+                            // it would have otherwise).
+                            acc = acc * (prev_base * prev_base);
+                        } else {
+                            acc = acc * base;
+                        }
+                    }
+                    prev_base = base;
+                    let (new_base, new_base_oflo) = base.overflowing_mul(base);
+                    base = new_base;
+                    base_oflo = new_base_oflo;
+                    exp /= 2;
+                }
+                acc
+            }
+
+            /// Returns `true` if and only if `self == 2^k` for some `k`.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn is_power_of_two(self) -> bool {
+                (self.wrapping_sub(Self::one())) & self == Self::zero() &&
+                    !(self == Self::zero())
+            }
+
+            /// Returns the smallest power of two greater than or equal to `self`.
+            /// Unspecified behavior on overflow.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn next_power_of_two(self) -> Self {
+                let bits = size_of::<Self>() * 8;
+                let one: Self = Self::one();
+                one << ((bits - self.wrapping_sub(one).leading_zeros() as usize) % bits)
+            }
+
+            /// Returns the smallest power of two greater than or equal to `n`. If
+            /// the next power of two is greater than the type's maximum value,
+            /// `None` is returned, otherwise the power of two is wrapped in `Some`.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            pub fn checked_next_power_of_two(self) -> Option<Self> {
+                let npot = self.next_power_of_two();
+                if npot >= self {
+                    Some(npot)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}
+
+#[cfg(stage0)]
+#[macro_use]
+mod uint_macro {
+    macro_rules! uint_impl {
+        ($ActualT:ty, $BITS:expr,
+         $ctpop:path,
+         $ctlz:path,
+         $cttz:path,
+         $bswap:path,
+         $wrapping_add:path,
+         $wrapping_sub:path,
+         $wrapping_mul:path,
+         $add_with_overflow:path,
+         $sub_with_overflow:path,
+         $mul_with_overflow:path) => {
+            /// Returns the smallest value that can be represented by this integer type.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn min_value() -> Self { 0 }
+
+            /// Returns the largest value that can be represented by this integer type.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn max_value() -> Self { !0 }
+
+            /// Converts a string slice in a given base to an integer.
+            ///
+            /// Leading and trailing whitespace represent an error.
+            ///
+            /// # Arguments
+            ///
+            /// * src - A string slice
+            /// * radix - The base to use. Must lie in the range [2 .. 36]
+            ///
+            /// # Return value
+            ///
+            /// `Err(ParseIntError)` if the string did not represent a valid number.
+            /// Otherwise, `Ok(n)` where `n` is the integer represented by `src`.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            pub fn from_str_radix(src: &str, radix: u32) -> Result<Self, ParseIntError> {
+                from_str_radix(src, radix)
+            }
+
+            /// Returns the number of ones in the binary representation of `self`.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0b01001100u8;
+            ///
+            /// assert_eq!(n.count_ones(), 3);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn count_ones(self) -> u32 {
+                unsafe { $ctpop(self as $ActualT) as u32 }
+            }
+
+            /// Returns the number of zeros in the binary representation of `self`.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0b01001100u8;
+            ///
+            /// assert_eq!(n.count_zeros(), 5);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn count_zeros(self) -> u32 {
+                (!self).count_ones()
+            }
+
+            /// Returns the number of leading zeros in the binary representation
+            /// of `self`.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0b0101000u16;
+            ///
+            /// assert_eq!(n.leading_zeros(), 10);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn leading_zeros(self) -> u32 {
+                unsafe { $ctlz(self as $ActualT) as u32 }
+            }
+
+            /// Returns the number of trailing zeros in the binary representation
+            /// of `self`.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0b0101000u16;
+            ///
+            /// assert_eq!(n.trailing_zeros(), 3);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn trailing_zeros(self) -> u32 {
+                // As of LLVM 3.6 the codegen for the zero-safe cttz8 intrinsic
+                // emits two conditional moves on x86_64. By promoting the value to
+                // u16 and setting bit 8, we get better code without any conditional
+                // operations.
+                // FIXME: There's a LLVM patch (http://reviews.llvm.org/D9284)
+                // pending, remove this workaround once LLVM generates better code
+                // for cttz8.
+                unsafe {
+                    if $BITS == 8 {
+                        intrinsics::cttz16(self as u16 | 0x100) as u32
+                    } else {
+                        $cttz(self as $ActualT) as u32
+                    }
+                }
+            }
+
+            /// Shifts the bits to the left by a specified amount, `n`,
+            /// wrapping the truncated bits to the end of the resulting integer.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            /// let m = 0x3456789ABCDEF012u64;
+            ///
+            /// assert_eq!(n.rotate_left(12), m);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn rotate_left(self, n: u32) -> Self {
+                // Protect against undefined behaviour for over-long bit shifts
+                let n = n % $BITS;
+                (self << n) | (self >> (($BITS - n) % $BITS))
+            }
+
+            /// Shifts the bits to the right by a specified amount, `n`,
+            /// wrapping the truncated bits to the beginning of the resulting
+            /// integer.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            /// let m = 0xDEF0123456789ABCu64;
+            ///
+            /// assert_eq!(n.rotate_right(12), m);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn rotate_right(self, n: u32) -> Self {
+                // Protect against undefined behaviour for over-long bit shifts
+                let n = n % $BITS;
+                (self >> n) | (self << (($BITS - n) % $BITS))
+            }
+
+            /// Reverses the byte order of the integer.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            /// let m = 0xEFCDAB8967452301u64;
+            ///
+            /// assert_eq!(n.swap_bytes(), m);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn swap_bytes(self) -> Self {
+                unsafe { $bswap(self as $ActualT) as Self }
+            }
+
+            /// Converts an integer from big endian to the target's endianness.
+            ///
+            /// On big endian this is a no-op. On little endian the bytes are
+            /// swapped.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            ///
+            /// if cfg!(target_endian = "big") {
+            ///     assert_eq!(u64::from_be(n), n)
+            /// } else {
+            ///     assert_eq!(u64::from_be(n), n.swap_bytes())
+            /// }
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn from_be(x: Self) -> Self {
+                if cfg!(target_endian = "big") { x } else { x.swap_bytes() }
+            }
+
+            /// Converts an integer from little endian to the target's endianness.
+            ///
+            /// On little endian this is a no-op. On big endian the bytes are
+            /// swapped.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            ///
+            /// if cfg!(target_endian = "little") {
+            ///     assert_eq!(u64::from_le(n), n)
+            /// } else {
+            ///     assert_eq!(u64::from_le(n), n.swap_bytes())
+            /// }
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn from_le(x: Self) -> Self {
+                if cfg!(target_endian = "little") { x } else { x.swap_bytes() }
+            }
+
+            /// Converts `self` to big endian from the target's endianness.
+            ///
+            /// On big endian this is a no-op. On little endian the bytes are
+            /// swapped.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            ///
+            /// if cfg!(target_endian = "big") {
+            ///     assert_eq!(n.to_be(), n)
+            /// } else {
+            ///     assert_eq!(n.to_be(), n.swap_bytes())
+            /// }
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn to_be(self) -> Self { // or not to be?
+                if cfg!(target_endian = "big") { self } else { self.swap_bytes() }
+            }
+
+            /// Converts `self` to little endian from the target's endianness.
+            ///
+            /// On little endian this is a no-op. On big endian the bytes are
+            /// swapped.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// let n = 0x0123456789ABCDEFu64;
+            ///
+            /// if cfg!(target_endian = "little") {
+            ///     assert_eq!(n.to_le(), n)
+            /// } else {
+            ///     assert_eq!(n.to_le(), n.swap_bytes())
+            /// }
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn to_le(self) -> Self {
+                if cfg!(target_endian = "little") { self } else { self.swap_bytes() }
+            }
+
+            /// Checked integer addition. Computes `self + other`, returning `None`
+            /// if overflow occurred.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// assert_eq!(5u16.checked_add(65530), Some(65535));
+            /// assert_eq!(6u16.checked_add(65530), None);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn checked_add(self, other: Self) -> Option<Self> {
+                checked_op!($ActualT, $add_with_overflow, self, other)
+            }
+
+            /// Checked integer subtraction. Computes `self - other`, returning
+            /// `None` if underflow occurred.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// assert_eq!((-127i8).checked_sub(1), Some(-128));
+            /// assert_eq!((-128i8).checked_sub(1), None);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn checked_sub(self, other: Self) -> Option<Self> {
+                checked_op!($ActualT, $sub_with_overflow, self, other)
+            }
+
+            /// Checked integer multiplication. Computes `self * other`, returning
+            /// `None` if underflow or overflow occurred.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// assert_eq!(5u8.checked_mul(51), Some(255));
+            /// assert_eq!(5u8.checked_mul(52), None);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn checked_mul(self, other: Self) -> Option<Self> {
+                checked_op!($ActualT, $mul_with_overflow, self, other)
+            }
+
+            /// Checked integer division. Computes `self / other`, returning `None`
+            /// if `other == 0` or the operation results in underflow or overflow.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// assert_eq!((-127i8).checked_div(-1), Some(127));
+            /// assert_eq!((-128i8).checked_div(-1), None);
+            /// assert_eq!((1i8).checked_div(0), None);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn checked_div(self, other: Self) -> Option<Self> {
+                match other {
+                    0 => None,
+                    other => Some(self / other),
+                }
+            }
+
+            /// Saturating integer addition. Computes `self + other`, saturating at
+            /// the numeric bounds instead of overflowing.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn saturating_add(self, other: Self) -> Self {
+                match self.checked_add(other) {
+                    Some(x)                       => x,
+                    None if other >= Self::zero() => Self::max_value(),
+                    None => Self::min_value(),
+                }
+            }
+
+            /// Saturating integer subtraction. Computes `self - other`, saturating
+            /// at the numeric bounds instead of overflowing.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn saturating_sub(self, other: Self) -> Self {
+                match self.checked_sub(other) {
+                    Some(x)                       => x,
+                    None if other >= Self::zero() => Self::min_value(),
+                    None => Self::max_value(),
+                }
+            }
+
+            /// Wrapping (modular) addition. Computes `self + other`,
+            /// wrapping around at the boundary of the type.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn wrapping_add(self, rhs: Self) -> Self {
+                unsafe {
+                    intrinsics::overflowing_add(self, rhs)
+                }
+            }
+
+            /// Wrapping (modular) subtraction. Computes `self - other`,
+            /// wrapping around at the boundary of the type.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn wrapping_sub(self, rhs: Self) -> Self {
+                unsafe {
+                    intrinsics::overflowing_sub(self, rhs)
+                }
+            }
+
+            /// Wrapping (modular) multiplication. Computes `self *
+            /// other`, wrapping around at the boundary of the type.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn wrapping_mul(self, rhs: Self) -> Self {
+                unsafe {
+                    intrinsics::overflowing_mul(self, rhs)
+                }
+            }
+
+            /// Wrapping (modular) division. Computes `self / other`,
+            /// wrapping around at the boundary of the type.
+            ///
+            /// The only case where such wrapping can occur is when one
+            /// divides `MIN / -1` on a signed type (where `MIN` is the
+            /// negative minimal value for the type); this is equivalent
+            /// to `-MIN`, a positive value that is too large to represent
+            /// in the type. In such a case, this function returns `MIN`
+            /// itself.
+            #[stable(feature = "num_wrapping", since = "1.2.0")]
+            #[inline(always)]
+            pub fn wrapping_div(self, rhs: Self) -> Self {
+                self.overflowing_div(rhs).0
+            }
+
+            /// Wrapping (modular) remainder. Computes `self % other`,
+            /// wrapping around at the boundary of the type.
+            ///
+            /// Such wrap-around never actually occurs mathematically;
+            /// implementation artifacts make `x % y` invalid for `MIN /
+            /// -1` on a signed type (where `MIN` is the negative
+            /// minimal value). In such a case, this function returns `0`.
+            #[stable(feature = "num_wrapping", since = "1.2.0")]
+            #[inline(always)]
+            pub fn wrapping_rem(self, rhs: Self) -> Self {
+                self.overflowing_rem(rhs).0
+            }
+
+            /// Wrapping (modular) negation. Computes `-self`,
+            /// wrapping around at the boundary of the type.
+            ///
+            /// The only case where such wrapping can occur is when one
+            /// negates `MIN` on a signed type (where `MIN` is the
+            /// negative minimal value for the type); this is a positive
+            /// value that is too large to represent in the type. In such
+            /// a case, this function returns `MIN` itself.
+            #[stable(feature = "num_wrapping", since = "1.2.0")]
+            #[inline(always)]
+            pub fn wrapping_neg(self) -> Self {
+                self.overflowing_neg().0
+            }
+
+            /// Panic-free bitwise shift-left; yields `self << mask(rhs)`,
+            /// where `mask` removes any high-order bits of `rhs` that
+            /// would cause the shift to exceed the bitwidth of the type.
+            #[stable(feature = "num_wrapping", since = "1.2.0")]
+            #[inline(always)]
+            pub fn wrapping_shl(self, rhs: u32) -> Self {
+                self.overflowing_shl(rhs).0
+            }
+
+            /// Panic-free bitwise shift-left; yields `self >> mask(rhs)`,
+            /// where `mask` removes any high-order bits of `rhs` that
+            /// would cause the shift to exceed the bitwidth of the type.
+            #[stable(feature = "num_wrapping", since = "1.2.0")]
+            #[inline(always)]
+            pub fn wrapping_shr(self, rhs: u32) -> Self {
+                self.overflowing_shr(rhs).0
+            }
+
+            /// Raises self to the power of `exp`, using exponentiation by squaring.
+            ///
+            /// # Examples
+            ///
+            /// ```rust
+            /// assert_eq!(2i32.pow(4), 16);
+            /// ```
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn pow(self, mut exp: u32) -> Self {
+                let mut base = self;
+                let mut acc = Self::one();
+
+                let mut prev_base = self;
+                let mut base_oflo = false;
+                while exp > 0 {
+                    if (exp & 1) == 1 {
+                        if base_oflo {
+                            // ensure overflow occurs in the same manner it
+                            // would have otherwise (i.e. signal any exception
+                            // it would have otherwise).
+                            acc = acc * (prev_base * prev_base);
+                        } else {
+                            acc = acc * base;
+                        }
+                    }
+                    prev_base = base;
+                    let (new_base, new_base_oflo) = base.overflowing_mul(base);
+                    base = new_base;
+                    base_oflo = new_base_oflo;
+                    exp /= 2;
+                }
+                acc
+            }
+
+            /// Returns `true` if and only if `self == 2^k` for some `k`.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn is_power_of_two(self) -> bool {
+                (self.wrapping_sub(Self::one())) & self == Self::zero() &&
+                    !(self == Self::zero())
+            }
+
+            /// Returns the smallest power of two greater than or equal to `self`.
+            /// Unspecified behavior on overflow.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[inline]
+            pub fn next_power_of_two(self) -> Self {
+                let bits = size_of::<Self>() * 8;
+                let one: Self = Self::one();
+                one << ((bits - self.wrapping_sub(one).leading_zeros() as usize) % bits)
+            }
+
+            /// Returns the smallest power of two greater than or equal to `n`. If
+            /// the next power of two is greater than the type's maximum value,
+            /// `None` is returned, otherwise the power of two is wrapped in `Some`.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            pub fn checked_next_power_of_two(self) -> Option<Self> {
+                let npot = self.next_power_of_two();
+                if npot >= self {
+                    Some(npot)
+                } else {
+                    None
+                }
             }
         }
     }
@@ -1169,6 +2211,9 @@ impl u8 {
         intrinsics::ctlz8,
         intrinsics::cttz8,
         bswap8,
+        intrinsics::u8_wrapping_add,
+        intrinsics::u8_wrapping_sub,
+        intrinsics::u8_wrapping_mul,
         intrinsics::u8_add_with_overflow,
         intrinsics::u8_sub_with_overflow,
         intrinsics::u8_mul_with_overflow }
@@ -1181,6 +2226,9 @@ impl u16 {
         intrinsics::ctlz16,
         intrinsics::cttz16,
         intrinsics::bswap16,
+        intrinsics::u16_wrapping_add,
+        intrinsics::u16_wrapping_sub,
+        intrinsics::u16_wrapping_mul,
         intrinsics::u16_add_with_overflow,
         intrinsics::u16_sub_with_overflow,
         intrinsics::u16_mul_with_overflow }
@@ -1193,6 +2241,9 @@ impl u32 {
         intrinsics::ctlz32,
         intrinsics::cttz32,
         intrinsics::bswap32,
+        intrinsics::u32_wrapping_add,
+        intrinsics::u32_wrapping_sub,
+        intrinsics::u32_wrapping_mul,
         intrinsics::u32_add_with_overflow,
         intrinsics::u32_sub_with_overflow,
         intrinsics::u32_mul_with_overflow }
@@ -1206,6 +2257,9 @@ impl u64 {
         intrinsics::ctlz64,
         intrinsics::cttz64,
         intrinsics::bswap64,
+        intrinsics::u64_wrapping_add,
+        intrinsics::u64_wrapping_sub,
+        intrinsics::u64_wrapping_mul,
         intrinsics::u64_add_with_overflow,
         intrinsics::u64_sub_with_overflow,
         intrinsics::u64_mul_with_overflow }
@@ -1219,6 +2273,9 @@ impl usize {
         intrinsics::ctlz32,
         intrinsics::cttz32,
         intrinsics::bswap32,
+        intrinsics::u32_wrapping_add,
+        intrinsics::u32_wrapping_sub,
+        intrinsics::u32_wrapping_mul,
         intrinsics::u32_add_with_overflow,
         intrinsics::u32_sub_with_overflow,
         intrinsics::u32_mul_with_overflow }
@@ -1232,6 +2289,9 @@ impl usize {
         intrinsics::ctlz64,
         intrinsics::cttz64,
         intrinsics::bswap64,
+        intrinsics::u64_wrapping_add,
+        intrinsics::u64_wrapping_sub,
+        intrinsics::u64_wrapping_mul,
         intrinsics::u64_add_with_overflow,
         intrinsics::u64_sub_with_overflow,
         intrinsics::u64_mul_with_overflow }

--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -797,9 +797,35 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         (_, "unchecked_urem") => URem(bcx, llargs[0], llargs[1], call_debug_location),
         (_, "unchecked_srem") => SRem(bcx, llargs[0], llargs[1], call_debug_location),
 
-        (_, "overflowing_add") => Add(bcx, llargs[0], llargs[1], call_debug_location),
-        (_, "overflowing_sub") => Sub(bcx, llargs[0], llargs[1], call_debug_location),
-        (_, "overflowing_mul") => Mul(bcx, llargs[0], llargs[1], call_debug_location),
+        (_, "u8_wrapping_add") => Add(bcx, llargs[0], llargs[1], call_debug_location),
+        (_, "u16_wrapping_add") => Add(bcx, llargs[0], llargs[1], call_debug_location),
+        (_, "u32_wrapping_add") => Add(bcx, llargs[0], llargs[1], call_debug_location),
+        (_, "u64_wrapping_add") => Add(bcx, llargs[0], llargs[1], call_debug_location),
+
+        (_, "i8_wrapping_add") => Add(bcx, llargs[0], llargs[1], call_debug_location),
+        (_, "i16_wrapping_add") => Add(bcx, llargs[0], llargs[1], call_debug_location),
+        (_, "i32_wrapping_add") => Add(bcx, llargs[0], llargs[1], call_debug_location),
+        (_, "i64_wrapping_add") => Add(bcx, llargs[0], llargs[1], call_debug_location),
+
+        (_, "u8_wrapping_sub") => Sub(bcx, llargs[0], llargs[1], call_debug_location),
+        (_, "u16_wrapping_sub") => Sub(bcx, llargs[0], llargs[1], call_debug_location),
+        (_, "u32_wrapping_sub") => Sub(bcx, llargs[0], llargs[1], call_debug_location),
+        (_, "u64_wrapping_sub") => Sub(bcx, llargs[0], llargs[1], call_debug_location),
+
+        (_, "i8_wrapping_sub") => Sub(bcx, llargs[0], llargs[1], call_debug_location),
+        (_, "i16_wrapping_sub") => Sub(bcx, llargs[0], llargs[1], call_debug_location),
+        (_, "i32_wrapping_sub") => Sub(bcx, llargs[0], llargs[1], call_debug_location),
+        (_, "i64_wrapping_sub") => Sub(bcx, llargs[0], llargs[1], call_debug_location),
+
+        (_, "u8_wrapping_mul") => Mul(bcx, llargs[0], llargs[1], call_debug_location),
+        (_, "u16_wrapping_mul") => Mul(bcx, llargs[0], llargs[1], call_debug_location),
+        (_, "u32_wrapping_mul") => Mul(bcx, llargs[0], llargs[1], call_debug_location),
+        (_, "u64_wrapping_mul") => Mul(bcx, llargs[0], llargs[1], call_debug_location),
+
+        (_, "i8_wrapping_mul") => Mul(bcx, llargs[0], llargs[1], call_debug_location),
+        (_, "i16_wrapping_mul") => Mul(bcx, llargs[0], llargs[1], call_debug_location),
+        (_, "i32_wrapping_mul") => Mul(bcx, llargs[0], llargs[1], call_debug_location),
+        (_, "i64_wrapping_mul") => Mul(bcx, llargs[0], llargs[1], call_debug_location),
 
         (_, "return_address") => {
             if !fcx.caller_expects_out_pointer {

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -310,8 +310,23 @@ pub fn check_intrinsic_type(ccx: &CrateCtxt, it: &hir::ForeignItem) {
             "unchecked_udiv" | "unchecked_sdiv" | "unchecked_urem" | "unchecked_srem" =>
                 (1, vec![param(ccx, 0), param(ccx, 0)], param(ccx, 0)),
 
-            "overflowing_add" | "overflowing_sub" | "overflowing_mul" =>
-                (1, vec![param(ccx, 0), param(ccx, 0)], param(ccx, 0)),
+            "u8_wrapping_add" | "u8_wrapping_sub" | "u8_wrapping_mul" =>
+                (0, vec![tcx.types.u8, tcx.types.u8], tcx.types.u8),
+            "u16_wrapping_add" | "u16_wrapping_sub" | "u16_wrapping_mul" =>
+                (0, vec![tcx.types.u16, tcx.types.u16], tcx.types.u16),
+            "u32_wrapping_add" | "u32_wrapping_sub" | "u32_wrapping_mul" =>
+                (0, vec![tcx.types.u32, tcx.types.u32], tcx.types.u32),
+            "u64_wrapping_add" | "u64_wrapping_sub" | "u64_wrapping_mul" =>
+                (0, vec![tcx.types.u64, tcx.types.u64], tcx.types.u64),
+
+            "i8_wrapping_add" | "i8_wrapping_sub" | "i8_wrapping_mul" =>
+                (0, vec![tcx.types.i8, tcx.types.i8], tcx.types.i8),
+            "i16_wrapping_add" | "i16_wrapping_sub" | "i16_wrapping_mul" =>
+                (0, vec![tcx.types.i16, tcx.types.i16], tcx.types.i16),
+            "i32_wrapping_add" | "i32_wrapping_sub" | "i32_wrapping_mul" =>
+                (0, vec![tcx.types.i32, tcx.types.i32], tcx.types.i32),
+            "i64_wrapping_add" | "i64_wrapping_sub" | "i64_wrapping_mul" =>
+                (0, vec![tcx.types.i64, tcx.types.i64], tcx.types.i64),
 
             "return_address" => (0, vec![], tcx.mk_imm_ptr(tcx.types.u8)),
 


### PR DESCRIPTION
And also rename them to T_wrapping_(add|sub|mul), in order to allay confusion
with (add|sub|mul)_with_overflow.
