### PR TITLE
Ignore malformed environment strings like glibc does

### DIFF
--- a/src/test/run-pass/env-funky-keys.rs
+++ b/src/test/run-pass/env-funky-keys.rs
@@ -1,0 +1,45 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Ignore this test on Android, because it segfaults there.
+
+// ignore-android
+// ignore-windows
+// no-prefer-dynamic
+
+#![feature(convert)]
+#![feature(libc)]
+
+extern crate libc;
+
+use libc::c_char;
+use libc::execve;
+use std::env;
+use std::ffi::OsStr;
+use std::ptr;
+
+fn main() {
+    if env::args_os().next().is_none() {
+        for (key, value) in env::vars_os() {
+            panic!("found env value {:?} {:?}", key, value);
+        }
+        return;
+    }
+
+    let current_exe = env::current_exe().unwrap().into_os_string().to_cstring().unwrap();
+    let new_env_var = OsStr::new("FOOBAR").to_cstring().unwrap();
+    let filename: *const c_char = current_exe.as_ptr();
+    let argv: &[*const c_char] = &[ptr::null()];
+    let envp: &[*const c_char] = &[new_env_var.as_ptr(), ptr::null()];
+    unsafe {
+        execve(filename, &argv[0], &envp[0]);
+    }
+    panic!("execve failed");
+}

--- a/src/test/run-pass/env-vars.rs
+++ b/src/test/run-pass/env-vars.rs
@@ -14,10 +14,7 @@ use std::env::*;
 fn main() {
     for (k, v) in vars_os() {
         let v2 = var_os(&k);
-        // MingW seems to set some funky environment variables like
-        // "=C:=C:\MinGW\msys\1.0\bin" and "!::=::\" that are returned
-        // from vars() but not visible from var().
-        assert!(v2.is_none() || v2.as_ref().map(|s| &**s) == Some(&*v),
+        assert!(v2.as_ref().map(|s| &**s) == Some(&*v),
                 "bad vars->var transition: {:?} {:?} {:?}", k, v, v2);
     }
 }


### PR DESCRIPTION
Otherwise, the iterator and the functions for getting specific
environment variables might disagree, for environments like

```
FOOBAR
```
