### PR TITLE
Fix doc comment typo

### DIFF
--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -47,7 +47,7 @@ pub struct Duration {
 }
 
 impl Duration {
-    /// Crates a new `Duration` from the specified number of seconds and
+    /// Creates a new `Duration` from the specified number of seconds and
     /// additional nanosecond precision.
     ///
     /// If the nanoseconds is greater than 1 billion (the number of nanoseconds


### PR DESCRIPTION
Added a single character to fix a typo in a doc comment.
