### PR TITLE
syntax/rustc_front: Simplify VariantData::fields

### DIFF
--- a/src/librustc/front/map/collector.rs
+++ b/src/librustc/front/map/collector.rs
@@ -152,7 +152,7 @@ impl<'ast> Visitor<'ast> for NodeCollector<'ast> {
                 // If this is a tuple-like struct, register the constructor.
                 if !struct_def.is_struct() {
                     self.insert_def(struct_def.id(),
-                                    NodeStructCtor(&**struct_def),
+                                    NodeStructCtor(struct_def),
                                     DefPathData::StructCtor);
                 }
 

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -219,7 +219,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for MarkSymbolVisitor<'a, 'tcx> {
                         _: &hir::Generics, _: ast::NodeId, _: codemap::Span) {
         let has_extern_repr = self.struct_has_extern_repr;
         let inherited_pub_visibility = self.inherited_pub_visibility;
-        let live_fields = def.fields().filter(|f| {
+        let live_fields = def.fields().iter().filter(|f| {
             has_extern_repr || inherited_pub_visibility || match f.node.kind {
                 hir::NamedField(_, hir::Public) => true,
                 _ => false

--- a/src/librustc_front/fold.rs
+++ b/src/librustc_front/fold.rs
@@ -223,8 +223,8 @@ pub trait Folder : Sized {
         noop_fold_poly_trait_ref(p, self)
     }
 
-    fn fold_variant_data(&mut self, struct_def: P<VariantData>) -> P<VariantData> {
-        noop_fold_struct_def(struct_def, self)
+    fn fold_variant_data(&mut self, vdata: VariantData) -> VariantData {
+        noop_fold_variant_data(vdata, self)
     }
 
     fn fold_lifetimes(&mut self, lts: Vec<Lifetime>) -> Vec<Lifetime> {
@@ -693,18 +693,16 @@ pub fn noop_fold_where_predicate<T: Folder>(pred: WherePredicate, fld: &mut T) -
     }
 }
 
-pub fn noop_fold_struct_def<T: Folder>(struct_def: P<VariantData>, fld: &mut T) -> P<VariantData> {
-    struct_def.map(|vdata| {
-        match vdata {
-            VariantData::Struct(fields, id) => {
-                VariantData::Struct(fields.move_map(|f| fld.fold_struct_field(f)), fld.new_id(id))
-            }
-            VariantData::Tuple(fields, id) => {
-                VariantData::Tuple(fields.move_map(|f| fld.fold_struct_field(f)), fld.new_id(id))
-            }
-            VariantData::Unit(id) => VariantData::Unit(fld.new_id(id))
+pub fn noop_fold_variant_data<T: Folder>(vdata: VariantData, fld: &mut T) -> VariantData {
+    match vdata {
+        VariantData::Struct(fields, id) => {
+            VariantData::Struct(fields.move_map(|f| fld.fold_struct_field(f)), fld.new_id(id))
         }
-    })
+        VariantData::Tuple(fields, id) => {
+            VariantData::Tuple(fields.move_map(|f| fld.fold_struct_field(f)), fld.new_id(id))
+        }
+        VariantData::Unit(id) => VariantData::Unit(fld.new_id(id))
+    }
 }
 
 pub fn noop_fold_trait_ref<T: Folder>(p: TraitRef, fld: &mut T) -> TraitRef {

--- a/src/librustc_front/lowering.rs
+++ b/src/librustc_front/lowering.rs
@@ -266,7 +266,7 @@ pub fn lower_variant(_lctx: &LoweringContext, v: &Variant) -> P<hir::Variant> {
         node: hir::Variant_ {
             name: v.node.name.name,
             attrs: v.node.attrs.clone(),
-            data: lower_struct_def(_lctx, &v.node.data),
+            data: lower_variant_data(_lctx, &v.node.data),
             disr_expr: v.node.disr_expr.as_ref().map(|e| lower_expr(_lctx, e)),
         },
         span: v.span,
@@ -498,8 +498,8 @@ pub fn lower_where_predicate(_lctx: &LoweringContext,
     }
 }
 
-pub fn lower_struct_def(_lctx: &LoweringContext, sd: &VariantData) -> P<hir::VariantData> {
-    P(match *sd {
+pub fn lower_variant_data(_lctx: &LoweringContext, vdata: &VariantData) -> hir::VariantData {
+    match *vdata {
         VariantData::Struct(ref fields, id) => {
             hir::VariantData::Struct(fields.iter()
                                            .map(|f| lower_struct_field(_lctx, f)).collect(), id)
@@ -509,7 +509,7 @@ pub fn lower_struct_def(_lctx: &LoweringContext, sd: &VariantData) -> P<hir::Var
                                           .map(|f| lower_struct_field(_lctx, f)).collect(), id)
         }
         VariantData::Unit(id) => hir::VariantData::Unit(id)
-    })
+    }
 }
 
 pub fn lower_trait_ref(_lctx: &LoweringContext, p: &TraitRef) -> hir::TraitRef {
@@ -611,7 +611,7 @@ pub fn lower_item_underscore(_lctx: &LoweringContext, i: &Item_) -> hir::Item_ {
                           lower_generics(_lctx, generics))
         }
         ItemStruct(ref struct_def, ref generics) => {
-            let struct_def = lower_struct_def(_lctx, struct_def);
+            let struct_def = lower_variant_data(_lctx, struct_def);
             hir::ItemStruct(struct_def, lower_generics(_lctx, generics))
         }
         ItemDefaultImpl(unsafety, ref trait_ref) => {

--- a/src/librustc_front/print/pprust.rs
+++ b/src/librustc_front/print/pprust.rs
@@ -734,7 +734,7 @@ impl<'a> State<'a> {
             }
             hir::ItemStruct(ref struct_def, ref generics) => {
                 try!(self.head(&visibility_qualified(item.vis, "struct")));
-                try!(self.print_struct(&**struct_def, generics, item.name, item.span, true));
+                try!(self.print_struct(struct_def, generics, item.name, item.span, true));
             }
 
             hir::ItemDefaultImpl(unsafety, ref trait_ref) => {
@@ -899,7 +899,7 @@ impl<'a> State<'a> {
         if !struct_def.is_struct() {
             if struct_def.is_tuple() {
                 try!(self.popen());
-                try!(self.commasep_iter(Inconsistent,
+                try!(self.commasep(Inconsistent,
                                    struct_def.fields(),
                                    |s, field| {
                                        match field.node.kind {

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -1114,7 +1114,7 @@ impl<'a, 'tcx> SanePrivacyVisitor<'a, 'tcx> {
                 }
             }
 
-            hir::ItemStruct(ref def, _) => check_struct(&**def),
+            hir::ItemStruct(ref def, _) => check_struct(def),
 
             hir::ItemEnum(..) |
             hir::ItemExternCrate(_) | hir::ItemUse(_) |

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -514,7 +514,7 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
                 }
 
                 // Record the def ID and fields of this struct.
-                let named_fields = struct_def.fields().filter_map(|f| {
+                let named_fields = struct_def.fields().iter().filter_map(|f| {
                     match f.node.kind {
                         NamedField(name, _) => Some(name),
                         UnnamedField(_) => None

--- a/src/librustc_trans/save/dump_csv.rs
+++ b/src/librustc_trans/save/dump_csv.rs
@@ -918,7 +918,7 @@ impl<'l, 'tcx, 'v> Visitor<'v> for DumpCsvVisitor<'l, 'tcx> {
                 self.process_static_or_const_item(item, typ, expr),
             ast::ItemConst(ref typ, ref expr) =>
                 self.process_static_or_const_item(item, &typ, &expr),
-            ast::ItemStruct(ref def, ref ty_params) => self.process_struct(item, &**def, ty_params),
+            ast::ItemStruct(ref def, ref ty_params) => self.process_struct(item, def, ty_params),
             ast::ItemEnum(ref def, ref ty_params) => self.process_enum(item, def, ty_params),
             ast::ItemImpl(_, _,
                           ref ty_params,

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -2435,7 +2435,7 @@ pub fn get_item_val(ccx: &CrateContext, id: ast::NodeId) -> ValueRef {
             } else {
                 v.node.data.fields()
             };
-            assert!(fields.count() != 0);
+            assert!(!fields.is_empty());
             let ty = ccx.tcx().node_id_to_type(id);
             let parent = ccx.tcx().map.get_parent(id);
             let enm = ccx.tcx().map.expect_item(parent);

--- a/src/librustc_typeck/check/wf.rs
+++ b/src/librustc_typeck/check/wf.rs
@@ -103,7 +103,7 @@ impl<'ccx, 'tcx> CheckTypeWellFormedVisitor<'ccx, 'tcx> {
             }
             hir::ItemStruct(ref struct_def, ref ast_generics) => {
                 self.check_type_defn(item, |fcx| {
-                    vec![struct_variant(fcx, &**struct_def)]
+                    vec![struct_variant(fcx, struct_def)]
                 });
 
                 self.check_variances_for_type_defn(item, ast_generics);
@@ -627,7 +627,7 @@ fn struct_variant<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                             struct_def: &hir::VariantData)
                             -> AdtVariant<'tcx> {
     let fields =
-        struct_def.fields()
+        struct_def.fields().iter()
         .map(|field| {
             let field_ty = fcx.tcx().node_id_to_type(field.node.id);
             let field_ty = fcx.instantiate_type_scheme(field.span,

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -112,7 +112,7 @@ impl<'ccx, 'tcx> CheckTypeWellFormedVisitor<'ccx, 'tcx> {
             }
             hir::ItemStruct(ref struct_def, ref ast_generics) => {
                 self.check_type_defn(item, |fcx| {
-                    vec![struct_variant(fcx, &**struct_def)]
+                    vec![struct_variant(fcx, struct_def)]
                 });
 
                 self.check_variances_for_type_defn(item, ast_generics);
@@ -524,7 +524,7 @@ fn struct_variant<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                             struct_def: &hir::VariantData)
                             -> AdtVariant<'tcx> {
     let fields =
-        struct_def.fields()
+        struct_def.fields().iter()
         .map(|field| {
             let field_ty = fcx.tcx().node_id_to_type(field.node.id);
             let field_ty = fcx.instantiate_type_scheme(field.span,

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1010,7 +1010,7 @@ fn convert_item(ccx: &CrateCtxt, it: &hir::Item) {
             let it_def_id = ccx.tcx.map.local_def_id(it.id);
             let variant = tcx.lookup_adt_def_master(it_def_id).struct_variant();
 
-            for (f, ty_f) in struct_def.fields().zip(variant.fields.iter()) {
+            for (f, ty_f) in struct_def.fields().iter().zip(variant.fields.iter()) {
                 convert_field(ccx, &scheme.generics, &predicates, f, ty_f)
             }
 
@@ -1067,7 +1067,7 @@ fn convert_enum_variant_types<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                         variants: &[P<hir::Variant>]) {
     // fill the field types
     for (variant, ty_variant) in variants.iter().zip(def.variants.iter()) {
-        for (f, ty_f) in variant.node.data.fields().zip(ty_variant.fields.iter()) {
+        for (f, ty_f) in variant.node.data.fields().iter().zip(ty_variant.fields.iter()) {
             convert_field(ccx, &scheme.generics, &predicates, f, ty_f)
         }
 
@@ -1089,7 +1089,7 @@ fn convert_struct_variant<'tcx>(tcx: &ty::ctxt<'tcx>,
                                 disr_val: ty::Disr,
                                 def: &hir::VariantData) -> ty::VariantDefData<'tcx, 'tcx> {
     let mut seen_fields: FnvHashMap<ast::Name, Span> = FnvHashMap();
-    let fields = def.fields().map(|f| {
+    let fields = def.fields().iter().map(|f| {
         let fid = tcx.map.local_def_id(f.node.id);
         match f.node.kind {
             hir::NamedField(name, vis) => {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1809,7 +1809,7 @@ impl Clean<VariantStruct> for ::rustc_front::hir::VariantData {
     fn clean(&self, cx: &DocContext) -> VariantStruct {
         VariantStruct {
             struct_type: doctree::struct_type_from_def(self),
-            fields: self.fields().map(|x| x.clean(cx)).collect(),
+            fields: self.fields().iter().map(|x| x.clean(cx)).collect(),
             fields_stripped: false,
         }
     }
@@ -1923,7 +1923,7 @@ fn struct_def_to_variant_kind(struct_def: &hir::VariantData, cx: &DocContext) ->
     } else if struct_def.is_unit() {
         CLikeVariant
     } else {
-        TupleVariant(struct_def.fields().map(|x| x.node.ty.clean(cx)).collect())
+        TupleVariant(struct_def.fields().iter().map(|x| x.node.ty.clean(cx)).collect())
     }
 }
 

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -119,7 +119,7 @@ pub struct Enum {
 pub struct Variant {
     pub name: Name,
     pub attrs: Vec<ast::Attribute>,
-    pub def: P<hir::VariantData>,
+    pub def: hir::VariantData,
     pub stab: Option<attr::Stability>,
     pub whence: Span,
 }
@@ -236,7 +236,7 @@ pub struct Import {
 pub fn struct_type_from_def(sd: &hir::VariantData) -> StructType {
     if !sd.is_struct() {
         // We are in a tuple-struct
-        match sd.fields().count() {
+        match sd.fields().len() {
             0 => Unit,
             1 => Newtype,
             _ => Tuple

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -97,7 +97,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             stab: self.stability(item.id),
             attrs: item.attrs.clone(),
             generics: generics.clone(),
-            fields: sd.fields().cloned().collect(),
+            fields: sd.fields().iter().cloned().collect(),
             whence: item.span
         }
     }
@@ -298,7 +298,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             hir::ItemEnum(ref ed, ref gen) =>
                 om.enums.push(self.visit_enum_def(item, name, ed, gen)),
             hir::ItemStruct(ref sd, ref gen) =>
-                om.structs.push(self.visit_variant_data(item, name, &**sd, gen)),
+                om.structs.push(self.visit_variant_data(item, name, sd, gen)),
             hir::ItemFn(ref fd, ref unsafety, constness, ref abi, ref gen, _) =>
                 om.fns.push(self.visit_fn(item, name, &**fd, unsafety,
                                           constness, abi, gen)),

--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -164,24 +164,22 @@ fn fold_item_underscore<F>(cx: &mut Context<F>, item: ast::Item_) -> ast::Item_ 
     fold::noop_fold_item_underscore(item, cx)
 }
 
-fn fold_struct<F>(cx: &mut Context<F>, def: P<ast::VariantData>) -> P<ast::VariantData> where
+fn fold_struct<F>(cx: &mut Context<F>, vdata: ast::VariantData) -> ast::VariantData where
     F: FnMut(&[ast::Attribute]) -> bool
 {
-    def.map(|vdata| {
-        match vdata {
-            ast::VariantData::Struct(fields, id) => {
-                ast::VariantData::Struct(fields.into_iter().filter(|m| {
-                    (cx.in_cfg)(&m.node.attrs)
-                }).collect(), id)
-            }
-            ast::VariantData::Tuple(fields, id) => {
-                ast::VariantData::Tuple(fields.into_iter().filter(|m| {
-                    (cx.in_cfg)(&m.node.attrs)
-                }).collect(), id)
-            }
-            ast::VariantData::Unit(id) => ast::VariantData::Unit(id)
+    match vdata {
+        ast::VariantData::Struct(fields, id) => {
+            ast::VariantData::Struct(fields.into_iter().filter(|m| {
+                (cx.in_cfg)(&m.node.attrs)
+            }).collect(), id)
         }
-    })
+        ast::VariantData::Tuple(fields, id) => {
+            ast::VariantData::Tuple(fields.into_iter().filter(|m| {
+                (cx.in_cfg)(&m.node.attrs)
+            }).collect(), id)
+        }
+        ast::VariantData::Unit(id) => ast::VariantData::Unit(id)
+    }
 }
 
 fn retain_stmt<F>(cx: &mut Context<F>, stmt: &ast::Stmt) -> bool where

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -1012,7 +1012,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                ast::Variant_ {
                    name: name,
                    attrs: Vec::new(),
-                   data: P(vdata),
+                   data: vdata,
                    disr_expr: None,
                })
     }
@@ -1041,7 +1041,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
 
     fn item_struct_poly(&self, span: Span, name: Ident,
         struct_def: ast::VariantData, generics: Generics) -> P<ast::Item> {
-        self.item(span, name, Vec::new(), ast::ItemStruct(P(struct_def), generics))
+        self.item(span, name, Vec::new(), ast::ItemStruct(struct_def, generics))
     }
 
     fn item_mod(&self, span: Span, inner_span: Span, name: Ident,

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -652,7 +652,7 @@ impl<'a> TraitDef<'a> {
                          struct_def: &'a VariantData,
                          type_ident: Ident,
                          generics: &Generics) -> P<ast::Item> {
-        let field_tys: Vec<P<ast::Ty>> = struct_def.fields()
+        let field_tys: Vec<P<ast::Ty>> = struct_def.fields().iter()
             .map(|field| field.node.ty.clone())
             .collect();
 
@@ -700,7 +700,7 @@ impl<'a> TraitDef<'a> {
         let mut field_tys = Vec::new();
 
         for variant in &enum_def.variants {
-            field_tys.extend(variant.node.data.fields()
+            field_tys.extend(variant.node.data.fields().iter()
                 .map(|field| field.node.ty.clone()));
         }
 
@@ -1483,7 +1483,7 @@ impl<'a> TraitDef<'a> {
                              -> (P<ast::Pat>, Vec<(Span, Option<Ident>,
                                                    P<Expr>,
                                                    &'a [ast::Attribute])>) {
-        if struct_def.fields().count() == 0 {
+        if struct_def.fields().is_empty() {
             return (cx.pat_enum(self.span, struct_path, vec![]), vec![]);
         }
 
@@ -1491,7 +1491,7 @@ impl<'a> TraitDef<'a> {
         let mut ident_expr = Vec::new();
         let mut struct_type = Unknown;
 
-        for (i, struct_field) in struct_def.fields().enumerate() {
+        for (i, struct_field) in struct_def.fields().iter().enumerate() {
             let sp = self.set_expn_info(cx, struct_field.span);
             let opt_id = match struct_field.node.kind {
                 ast::NamedField(ident, _) if (struct_type == Unknown ||

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -859,7 +859,7 @@ impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
 
     fn visit_variant_data(&mut self, s: &'v ast::VariantData, _: ast::Ident,
                         _: &'v ast::Generics, _: ast::NodeId, span: Span) {
-        if s.fields().count() == 0 {
+        if s.fields().is_empty() {
             if s.is_struct() {
                 self.gate_feature("braced_empty_structs", span,
                                   "empty structs and enum variants with braces are unstable");

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -231,8 +231,8 @@ pub trait Folder : Sized {
         noop_fold_poly_trait_ref(p, self)
     }
 
-    fn fold_variant_data(&mut self, struct_def: P<VariantData>) -> P<VariantData> {
-        noop_fold_struct_def(struct_def, self)
+    fn fold_variant_data(&mut self, vdata: VariantData) -> VariantData {
+        noop_fold_variant_data(vdata, self)
     }
 
     fn fold_lifetimes(&mut self, lts: Vec<Lifetime>) -> Vec<Lifetime> {
@@ -814,20 +814,18 @@ pub fn noop_fold_where_predicate<T: Folder>(
     }
 }
 
-pub fn noop_fold_struct_def<T: Folder>(struct_def: P<VariantData>, fld: &mut T) -> P<VariantData> {
-    struct_def.map(|vdata| {
-        match vdata {
-            ast::VariantData::Struct(fields, id) => {
-                ast::VariantData::Struct(fields.move_map(|f| fld.fold_struct_field(f)),
-                                         fld.new_id(id))
-            }
-            ast::VariantData::Tuple(fields, id) => {
-                ast::VariantData::Tuple(fields.move_map(|f| fld.fold_struct_field(f)),
-                                        fld.new_id(id))
-            }
-            ast::VariantData::Unit(id) => ast::VariantData::Unit(fld.new_id(id))
+pub fn noop_fold_variant_data<T: Folder>(vdata: VariantData, fld: &mut T) -> VariantData {
+    match vdata {
+        ast::VariantData::Struct(fields, id) => {
+            ast::VariantData::Struct(fields.move_map(|f| fld.fold_struct_field(f)),
+                                     fld.new_id(id))
         }
-    })
+        ast::VariantData::Tuple(fields, id) => {
+            ast::VariantData::Tuple(fields.move_map(|f| fld.fold_struct_field(f)),
+                                    fld.new_id(id))
+        }
+        ast::VariantData::Unit(id) => ast::VariantData::Unit(fld.new_id(id))
+    }
 }
 
 pub fn noop_fold_trait_ref<T: Folder>(p: TraitRef, fld: &mut T) -> TraitRef {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4678,9 +4678,7 @@ impl<'a> Parser<'a> {
                                             name, found `{}`", token_str)))
         };
 
-        Ok((class_name,
-            ItemStruct(P(vdata), generics),
-            None))
+        Ok((class_name, ItemStruct(vdata, generics), None))
     }
 
     pub fn parse_record_struct_body(&mut self) -> PResult<Vec<StructField>> {
@@ -5111,14 +5109,14 @@ impl<'a> Parser<'a> {
 
     /// Parse a structure-like enum variant definition
     /// this should probably be renamed or refactored...
-    fn parse_struct_def(&mut self) -> PResult<P<VariantData>> {
+    fn parse_struct_def(&mut self) -> PResult<VariantData> {
         let mut fields: Vec<StructField> = Vec::new();
         while self.token != token::CloseDelim(token::Brace) {
             fields.push(try!(self.parse_struct_decl_field(false)));
         }
         try!(self.bump());
 
-        Ok(P(VariantData::Struct(fields, ast::DUMMY_NODE_ID)))
+        Ok(VariantData::Struct(fields, ast::DUMMY_NODE_ID))
     }
 
     /// Parse the part of an "enum" decl following the '{'
@@ -5154,13 +5152,13 @@ impl<'a> Parser<'a> {
                         id: ast::DUMMY_NODE_ID,
                     }});
                 }
-                struct_def = P(ast::VariantData::Tuple(fields, ast::DUMMY_NODE_ID));
+                struct_def = ast::VariantData::Tuple(fields, ast::DUMMY_NODE_ID);
             } else if try!(self.eat(&token::Eq) ){
                 disr_expr = Some(try!(self.parse_expr_nopanic()));
                 any_disr = disr_expr.as_ref().map(|expr| expr.span);
-                struct_def = P(ast::VariantData::Unit(ast::DUMMY_NODE_ID));
+                struct_def = ast::VariantData::Unit(ast::DUMMY_NODE_ID);
             } else {
-                struct_def = P(ast::VariantData::Unit(ast::DUMMY_NODE_ID));
+                struct_def = ast::VariantData::Unit(ast::DUMMY_NODE_ID);
             }
 
             let vr = ast::Variant_ {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -520,19 +520,6 @@ pub trait PrintState<'a> {
         self.end()
     }
 
-    fn commasep_iter<'it, T: 'it, F, I>(&mut self, b: Breaks, elts: I, mut op: F) -> io::Result<()>
-        where F: FnMut(&mut Self, &T) -> io::Result<()>,
-              I: Iterator<Item=&'it T>,
-    {
-        try!(self.rbox(0, b));
-        let mut first = true;
-        for elt in elts {
-            if first { first = false; } else { try!(self.word_space(",")); }
-            try!(op(self, elt));
-        }
-        self.end()
-    }
-
     fn next_lit(&mut self, pos: BytePos) -> Option<comments::Literal> {
         let mut cur_lit = self.cur_cmnt_and_lit().cur_lit;
 
@@ -1407,7 +1394,7 @@ impl<'a> State<'a> {
         if !struct_def.is_struct() {
             if struct_def.is_tuple() {
                 try!(self.popen());
-                try!(self.commasep_iter(
+                try!(self.commasep(
                     Inconsistent, struct_def.fields(),
                     |s, field| {
                         match field.node.kind {
@@ -3104,7 +3091,6 @@ mod tests {
     use ast_util;
     use codemap;
     use parse::token;
-    use ptr::P;
 
     #[test]
     fn test_fun_to_string() {
@@ -3131,7 +3117,7 @@ mod tests {
             name: ident,
             attrs: Vec::new(),
             // making this up as I go.... ?
-            data: P(ast::VariantData::Unit(ast::DUMMY_NODE_ID)),
+            data: ast::VariantData::Unit(ast::DUMMY_NODE_ID),
             disr_expr: None,
         });
 


### PR DESCRIPTION
And use `VariantData` instead of `P<VariantData>` in `Item_` and `Variant_`

Improvements suggested by @eddyb in https://github.com/rust-lang/rust/pull/28816#discussion_r42483587 and https://github.com/rust-lang/rust/pull/28816#discussion_r42483648

plugin-[breaking-change]

r? @eddyb 
