### PR TITLE
Update the playpen link for code in the rust book to agree with rustdoc's new style

### DIFF
--- a/src/doc/rust.css
+++ b/src/doc/rust.css
@@ -338,14 +338,17 @@ table th {
 
 .rusttest { display: none; }
 pre.rust { position: relative; }
-.test-arrow {
+a.test-arrow {
     display: inline-block;
     position: absolute;
-    top: 0;
-    right: 10px;
-    font-size: 150%;
-    -webkit-transform: scaleX(-1);
-    transform: scaleX(-1);
+
+    background-color: #4e8bca;
+    color: #f5f5f5;
+    padding: 5px 10px 5px 10px;
+    border-radius: 5px;
+    font-size: 130%;
+    top: 5px;
+    right: 5px;
 }
 
 .unstable-feature {


### PR DESCRIPTION
Makes rustbook code playpen links follow the style set in https://github.com/rust-lang/rust/pull/28963. This is basically cut and paste from the other one. The link looks better and still works so I assume it's good.

![rustbook](https://cloud.githubusercontent.com/assets/4156987/10717631/7a74f8ae-7b34-11e5-8870-35b5fc2526a4.png)

Fixes https://github.com/rust-lang/rust/issues/29308

r? @steveklabnik 
