### PR TITLE
reference: clarify impl

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -1520,11 +1520,11 @@ impl Shape for Circle {
 ```
 
 It is possible to define an implementation without referring to a trait. The
-methods in such an implementation can only be used as direct calls on the
-values of the type that the implementation targets. In such an implementation,
-the trait type and `for` after `impl` are omitted. Such implementations are
-limited to nominal types (enums, structs), and the implementation must appear
-in the same crate as the `self` type:
+methods in such an implementation can only be used as direct calls on the values
+of the type that the implementation targets. In such an implementation, the
+trait type and `for` after `impl` are omitted. Such implementations are limited
+to nominal types (enums, structs, trait objects), and the implementation must
+appear in the same crate as the `self` type:
 
 ```
 struct Point {x: i32, y: i32}


### PR DESCRIPTION
Rust reference is a bit confusing here, because it does not explicitly mention trait objects.

See an example of confusion here https://users.rust-lang.org/t/confusion-about-impls-without-for/3379/2 :)

r? @steveklabnik
