### PR TITLE
Documented caveat of the remove_dir_all

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1046,8 +1046,11 @@ pub fn remove_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// Removes a directory at this path, after removing all its contents. Use
 /// carefully!
 ///
-/// This function does **not** follow symbolic links and it will simply remove the
-/// symbolic link itself.
+/// This function does **not** follow symbolic links **inside** the
+/// directory and it will simply remove the symbolic link itself.
+/// But if a directory is **itself** a symbolic link to a directory
+/// it will first clean the target directory, then fail with the
+/// "Not a directory" error. 
 ///
 /// # Errors
 ///


### PR DESCRIPTION
I'm not sure the wording is great.

Maybe it's just a bug that is going to be fixed because the current behavior is probably useless. But if it is, it's a backwards-incompatible change.
