### PR TITLE
Fix various bugs around empty structs and patterns

### DIFF
--- a/src/librustc/middle/intrinsicck.rs
+++ b/src/librustc/middle/intrinsicck.rs
@@ -225,11 +225,10 @@ impl<'a, 'tcx, 'v> Visitor<'v> for IntrinsicCheckingVisitor<'a, 'tcx> {
                 intravisit::walk_fn(self, fk, fd, b, s);
                 self.param_envs.pop();
             }
-            FnKind::Closure(..) => {
+            FnKind::Closure => {
                 intravisit::walk_fn(self, fk, fd, b, s);
             }
         }
-
     }
 
     fn visit_expr(&mut self, expr: &hir::Expr) {

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -1424,7 +1424,7 @@ impl<'tcx> cmt_<'tcx> {
                 NonAliasable
             }
 
-            Categorization::StaticItem(..) => {
+            Categorization::StaticItem => {
                 if self.mutbl.is_mutable() {
                     FreelyAliasable(AliasableStaticMut)
                 } else {

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -184,7 +184,7 @@ impl<'a, 'v> Visitor<'v> for LifetimeContext<'a> {
                     this.walk_fn(fk, fd, b, s)
                 })
             }
-            FnKind::Closure(..) => {
+            FnKind::Closure => {
                 self.walk_fn(fk, fd, b, s)
             }
         }
@@ -479,7 +479,7 @@ impl<'a> LifetimeContext<'a> {
                 self.visit_generics(&sig.generics);
                 self.visit_explicit_self(&sig.explicit_self);
             }
-            FnKind::Closure(..) => {
+            FnKind::Closure => {
                 intravisit::walk_fn_decl(self, fd);
             }
         }

--- a/src/librustc/middle/traits/coherence.rs
+++ b/src/librustc/middle/traits/coherence.rs
@@ -301,7 +301,7 @@ fn ty_is_local_constructor<'tcx>(tcx: &ty::ctxt<'tcx>,
         ty::TyInt(..) |
         ty::TyUint(..) |
         ty::TyFloat(..) |
-        ty::TyStr(..) |
+        ty::TyStr |
         ty::TyBareFn(..) |
         ty::TyArray(..) |
         ty::TySlice(..) |

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1563,7 +1563,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         }
 
         match other {
-            &ObjectCandidate(..) |
+            &ObjectCandidate |
             &ParamCandidate(_) | &ProjectionCandidate => match victim {
                 &DefaultImplCandidate(..) => {
                     self.tcx().sess.bug(
@@ -1572,16 +1572,16 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 }
                 &ImplCandidate(..) |
                 &ClosureCandidate(..) |
-                &FnPointerCandidate(..) |
-                &BuiltinObjectCandidate(..) |
-                &BuiltinUnsizeCandidate(..) |
+                &FnPointerCandidate |
+                &BuiltinObjectCandidate |
+                &BuiltinUnsizeCandidate |
                 &DefaultImplObjectCandidate(..) |
                 &BuiltinCandidate(..) => {
                     // We have a where-clause so don't go around looking
                     // for impls.
                     true
                 }
-                &ObjectCandidate(..) |
+                &ObjectCandidate |
                 &ProjectionCandidate => {
                     // Arbitrarily give param candidates priority
                     // over projection and object candidates.

--- a/src/librustc/middle/ty/outlives.rs
+++ b/src/librustc/middle/ty/outlives.rs
@@ -188,21 +188,21 @@ fn compute_components<'a,'tcx>(infcx: &InferCtxt<'a,'tcx>,
         // the type and then visits the types that are lexically
         // contained within. (The comments refer to relevant rules
         // from RFC1214.)
-        ty::TyBool(..) |        // OutlivesScalar
-        ty::TyChar(..) |        // OutlivesScalar
+        ty::TyBool |            // OutlivesScalar
+        ty::TyChar |            // OutlivesScalar
         ty::TyInt(..) |         // OutlivesScalar
         ty::TyUint(..) |        // OutlivesScalar
         ty::TyFloat(..) |       // OutlivesScalar
         ty::TyEnum(..) |        // OutlivesNominalType
         ty::TyStruct(..) |      // OutlivesNominalType
         ty::TyBox(..) |         // OutlivesNominalType (ish)
-        ty::TyStr(..) |         // OutlivesScalar (ish)
+        ty::TyStr |             // OutlivesScalar (ish)
         ty::TyArray(..) |       // ...
         ty::TySlice(..) |       // ...
         ty::TyRawPtr(..) |      // ...
         ty::TyRef(..) |         // OutlivesReference
         ty::TyTuple(..) |       // ...
-        ty::TyError(..) => {
+        ty::TyError => {
             push_region_constraints(out, ty.regions());
             for subty in ty.walk_shallow() {
                 compute_components(infcx, subty, out);

--- a/src/librustc_borrowck/borrowck/check_loans.rs
+++ b/src/librustc_borrowck/borrowck/check_loans.rs
@@ -540,14 +540,14 @@ impl<'a, 'tcx> CheckLoanCtxt<'a, 'tcx> {
                             ol, old_loan_msg)
                 }
 
-                euv::OverloadedOperator(..) |
-                euv::AddrOf(..) |
-                euv::AutoRef(..) |
-                euv::AutoUnsafe(..) |
-                euv::ClosureInvocation(..) |
-                euv::ForLoop(..) |
-                euv::RefBinding(..) |
-                euv::MatchDiscriminant(..) => {
+                euv::OverloadedOperator |
+                euv::AddrOf |
+                euv::AutoRef |
+                euv::AutoUnsafe |
+                euv::ClosureInvocation |
+                euv::ForLoop |
+                euv::RefBinding |
+                euv::MatchDiscriminant => {
                     format!("previous borrow of `{}` occurs here{}",
                             ol, old_loan_msg)
                 }

--- a/src/librustc_borrowck/borrowck/gather_loans/restrictions.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/restrictions.rs
@@ -101,7 +101,7 @@ impl<'a, 'tcx> RestrictionsContext<'a, 'tcx> {
                 self.extend(result, &cmt, LpInterior(i.cleaned()))
             }
 
-            Categorization::StaticItem(..) => {
+            Categorization::StaticItem => {
                 Safe
             }
 

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -942,8 +942,8 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                            "consider changing this closure to take self by mutable reference");
                 }
             }
-            mc::AliasableStatic(..) |
-            mc::AliasableStaticMut(..) => {
+            mc::AliasableStatic |
+            mc::AliasableStaticMut => {
                 span_err!(
                     self.tcx.sess, span, E0388,
                     "{} in a static location", prefix);
@@ -998,7 +998,7 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
     pub fn note_and_explain_bckerr(&self, err: BckError<'tcx>) {
         let code = err.code;
         match code {
-            err_mutbl(..) => {
+            err_mutbl => {
                 match err.cmt.note {
                     mc::NoteClosureEnv(upvar_id) | mc::NoteUpvarRef(upvar_id) => {
                         // If this is an `Fn` closure, it simply can't mutate upvars.

--- a/src/librustc_mir/build/matches/simplify.rs
+++ b/src/librustc_mir/build/matches/simplify.rs
@@ -66,7 +66,7 @@ impl<'a,'tcx> Builder<'a,'tcx> {
                                  candidate: &mut Candidate<'pat, 'tcx>)
                                  -> Result<BasicBlock, MatchPair<'pat, 'tcx>> {
         match *match_pair.pattern.kind {
-            PatternKind::Wild(..) => {
+            PatternKind::Wild => {
                 // nothing left to do
                 Ok(block)
             }

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -178,7 +178,7 @@ impl<'tcx> Mirror<'tcx> for &'tcx hir::Expr {
                     }
                     ty::TyEnum(adt, substs) => {
                         match cx.tcx.def_map.borrow()[&self.id].full_def() {
-                            def::DefVariant(enum_id, variant_id, true) => {
+                            def::DefVariant(enum_id, variant_id, _) => {
                                 debug_assert!(adt.did == enum_id);
                                 let index = adt.variant_index_with_id(variant_id);
                                 let field_refs = field_refs(&adt.variants[index], fields);

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -625,7 +625,7 @@ impl<'a, 'v, 'tcx> Visitor<'v> for Resolver<'a, 'tcx> {
                 self.visit_explicit_self(&sig.explicit_self);
                 MethodRibKind
             }
-            FnKind::Closure(..) => ClosureRibKind(node_id),
+            FnKind::Closure => ClosureRibKind(node_id),
         };
         self.resolve_function(rib_kind, declaration, block);
     }

--- a/src/librustc_trans/trans/type_of.rs
+++ b/src/librustc_trans/trans/type_of.rs
@@ -247,7 +247,7 @@ pub fn sizing_type_of<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>) -> Typ
             }
         }
 
-        ty::TyProjection(..) | ty::TyInfer(..) | ty::TyParam(..) | ty::TyError(..) => {
+        ty::TyProjection(..) | ty::TyInfer(..) | ty::TyParam(..) | ty::TyError => {
             cx.sess().bug(&format!("fictitious type {:?} in sizing_type_of()",
                                    t))
         }
@@ -451,7 +451,7 @@ pub fn in_memory_type_of<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>) -> 
       ty::TyInfer(..) => cx.sess().bug("type_of with TyInfer"),
       ty::TyProjection(..) => cx.sess().bug("type_of with TyProjection"),
       ty::TyParam(..) => cx.sess().bug("type_of with ty_param"),
-      ty::TyError(..) => cx.sess().bug("type_of with TyError"),
+      ty::TyError => cx.sess().bug("type_of with TyError"),
     };
 
     debug!("--> mapped t={:?} to llty={}",

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -674,6 +674,10 @@ pub fn check_pat_enum<'a, 'tcx>(pcx: &pat_ctxt<'a, 'tcx>,
                 report_bad_struct_kind(is_special_case);
                 if !is_special_case {
                     return
+                } else {
+                    span_note!(tcx.sess, pat.span,
+                        "this warning will become a HARD ERROR in a future release. \
+                        See RFC 218 for details.");
                 }
             }
             (variant.fields

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -1052,7 +1052,7 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
                     (impl_def_id, substs, ref_obligations)
                 }
 
-                ObjectCandidate(..) |
+                ObjectCandidate |
                 TraitCandidate |
                 WhereClauseCandidate(..) => {
                     // These have no additional conditions to check.

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1446,7 +1446,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                               -> Option<(ty::AdtDef<'tcx>, ty::VariantDef<'tcx>)>
     {
         let (adt, variant) = match def {
-            def::DefVariant(enum_id, variant_id, true) => {
+            def::DefVariant(enum_id, variant_id, _) => {
                 let adt = self.tcx().lookup_adt_def(enum_id);
                 (adt, adt.variant_with_id(variant_id))
             }

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -69,7 +69,7 @@ fn get_base_type_def_id<'a, 'tcx>(inference_context: &InferCtxt<'a, 'tcx>,
         }
 
         TyBool | TyChar | TyInt(..) | TyUint(..) | TyFloat(..) |
-        TyStr(..) | TyArray(..) | TySlice(..) | TyBareFn(..) | TyTuple(..) |
+        TyStr | TyArray(..) | TySlice(..) | TyBareFn(..) | TyTuple(..) |
         TyParam(..) | TyError |
         TyRawPtr(_) | TyRef(_, _) | TyProjection(..) => {
             None

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -776,7 +776,7 @@ impl Clean<Option<Lifetime>> for ty::Region {
             ty::ReScope(..) |
             ty::ReVar(..) |
             ty::ReSkolemized(..) |
-            ty::ReEmpty(..) => None
+            ty::ReEmpty => None
         }
     }
 }
@@ -1609,7 +1609,7 @@ impl Clean<Type> for hir::Ty {
             TyPolyTraitRef(ref bounds) => {
                 PolyTraitRef(bounds.clean(cx))
             },
-            TyInfer(..) => {
+            TyInfer => {
                 Infer
             },
             TyTypeof(..) => {

--- a/src/test/compile-fail/empty-struct-braces-gate-2.rs
+++ b/src/test/compile-fail/empty-struct-braces-gate-2.rs
@@ -20,8 +20,7 @@ enum E {
 fn main() {
     let e2: Empty2 = Empty2 {}; //~ ERROR empty structs and enum variants with braces are unstable
     let e2: Empty2 = Empty2;
-    // Issue #28692
-    // let e5: E = E::Empty5 {}; // ERROR empty structs and enum variants with braces are unstable
+    let e5: E = E::Empty5 {}; //~ ERROR empty structs and enum variants with braces are unstable
     let e5: E = E::Empty5;
 
     match e2 {
@@ -33,17 +32,15 @@ fn main() {
     match e2 {
         Empty2 { .. } => {} //~ ERROR empty structs and enum variants with braces are unstable
     }
-    // Issue #28692
-    // match e5 {
-    //     E::Empty5 {} => {} // ERROR empty structs and enum variants with braces are unstable
-    // }
+    match e5 {
+        E::Empty5 {} => {} //~ ERROR empty structs and enum variants with braces are unstable
+    }
     match e5 {
         E::Empty5 => {}
     }
-    // Issue #28692
-    // match e5 {
-    //     E::Empty5 { .. } => {} // ERROR empty structs and enum variants with braces are unstable
-    // }
+    match e5 {
+        E::Empty5 { .. } => {} //~ ERROR empty structs and enum variants with braces are unstable
+    }
 
     let e22 = Empty2 { ..e2 }; //~ ERROR empty structs and enum variants with braces are unstable
 }

--- a/src/test/compile-fail/empty-struct-braces-pat-2.rs
+++ b/src/test/compile-fail/empty-struct-braces-pat-2.rs
@@ -14,13 +14,8 @@
 
 struct Empty1 {}
 
-enum E {
-    Empty2 {}
-}
-
 fn main() {
     let e1 = Empty1 {};
-    let e2 = E::Empty2 {};
 
     // Rejected by parser as yet
     // match e1 {
@@ -29,11 +24,4 @@ fn main() {
     match e1 {
         Empty1(..) => () //~ ERROR unresolved enum variant, struct or const `Empty1`
     }
-    // Issue #28692
-    // match e2 {
-    //     E::Empty2() => () // ERROR unresolved enum variant, struct or const `Empty2`
-    // }
-    // match e2 {
-    //     E::Empty2(..) => () // ERROR unresolved enum variant, struct or const `Empty2`
-    // }
 }

--- a/src/test/compile-fail/empty-struct-braces-pat-3.rs
+++ b/src/test/compile-fail/empty-struct-braces-pat-3.rs
@@ -8,24 +8,22 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Can't use empty braced struct as constant pattern
+// Can't use empty braced struct as enum pattern
 
 #![feature(braced_empty_structs)]
-
-struct Empty1 {}
 
 enum E {
     Empty2 {}
 }
 
 fn main() {
-    let e1 = Empty1 {};
     let e2 = E::Empty2 {};
 
-    match e1 {
-        Empty1 => () // Not an error, `Empty1` is interpreted as a new binding
-    }
+    // Rejected by parser as yet
+    // match e2 {
+    //     E::Empty2() => () // ERROR `E::Empty2` does not name a tuple variant or a tuple struct
+    // }
     match e2 {
-        E::Empty2 => () //~ ERROR `E::Empty2` does not name a tuple variant or a tuple struct
+        E::Empty2(..) => () //~ ERROR `E::Empty2` does not name a tuple variant or a tuple struct
     }
 }

--- a/src/test/compile-fail/empty-struct-unit-pat.rs
+++ b/src/test/compile-fail/empty-struct-unit-pat.rs
@@ -12,8 +12,6 @@
 
 #![feature(braced_empty_structs)]
 
-FIXME //~ ERROR expected item, found `FIXME`
-
 struct Empty1;
 
 enum E {
@@ -24,17 +22,18 @@ fn main() {
     let e1 = Empty1;
     let e2 = E::Empty2;
 
-    // Issue #28692
+    // Rejected by parser as yet
     // match e1 {
-    //     Empty1() => () // ERROR variable `Empty1` should have a snake case name
+    //     Empty1() => () // ERROR `Empty1` does not name a tuple variant or a tuple struct
     // }
-    // match e1 {
-    //     Empty1(..) => () // ERROR variable `Empty1` should have a snake case name
-    // }
+    match e1 {
+        Empty1(..) => () //~ ERROR `Empty1` does not name a tuple variant or a tuple struct
+    }
+    // Rejected by parser as yet
     // match e2 {
-    //     E::Empty2() => () // ERROR variable `Empty2` should have a snake case name
+    //     E::Empty2() => () // ERROR `E::Empty2` does not name a tuple variant or a tuple struct
     // }
-    // match e2 {
-    //     E::Empty2(..) => () // ERROR variable `Empty2` should have a snake case name
-    // }
+    match e2 {
+        E::Empty2(..) => () //~ ERROR `E::Empty2` does not name a tuple variant or a tuple struct
+    }
 }

--- a/src/test/compile-fail/empty-struct-unit-pat.rs
+++ b/src/test/compile-fail/empty-struct-unit-pat.rs
@@ -34,6 +34,6 @@ fn main() {
     //     E::Empty2() => () // ERROR `E::Empty2` does not name a tuple variant or a tuple struct
     // }
     match e2 {
-        E::Empty2(..) => () //~ ERROR `E::Empty2` does not name a tuple variant or a tuple struct
+        E::Empty2(..) => () //~ WARN `E::Empty2` does not name a tuple variant or a tuple struct
     }
 }

--- a/src/test/compile-fail/issue-27831.rs
+++ b/src/test/compile-fail/issue-27831.rs
@@ -26,7 +26,7 @@ fn main() {
     let Bar { .. } = x; //~ ERROR empty structs and enum variants with braces are unstable
 
     match Enum::Bar {
-        Enum::Bar { .. } //~ ERROR `Enum::Bar` does not name a struct
+        Enum::Bar { .. } //~ ERROR empty structs and enum variants with braces are unstable
            => {}
         Enum::Foo { .. } //~ ERROR `Enum::Foo` does not name a struct
            => {}

--- a/src/test/compile-fail/issue-28992-empty.rs
+++ b/src/test/compile-fail/issue-28992-empty.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,16 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use Foo::FooB;
+// Can't use constants as tuple struct patterns
 
-enum Foo {
-    FooB { x: i32, y: i32 }
+#![feature(associated_consts)]
+
+const C1: i32 = 0;
+
+struct S;
+
+impl S {
+    const C2: i32 = 0;
 }
 
 fn main() {
-    let f = FooB { x: 3, y: 4 };
-    match f {
-        FooB(a, b) => println!("{} {}", a, b),
-//~^ ERROR `FooB` does not name a tuple variant or a tuple struct
-    }
+    if let C1(..) = 0 {} //~ ERROR `C1` does not name a tuple variant or a tuple struct
+    if let S::C2(..) = 0 {} //~ ERROR `S::C2` does not name a tuple variant or a tuple struct
 }

--- a/src/test/compile-fail/match-pattern-field-mismatch-2.rs
+++ b/src/test/compile-fail/match-pattern-field-mismatch-2.rs
@@ -20,7 +20,7 @@ fn main() {
           color::rgb(_, _, _) => { }
           color::cmyk(_, _, _, _) => { }
           color::no_color(_) => { }
-          //~^ ERROR this pattern has 1 field, but the corresponding variant has no fields
+          //~^ ERROR `color::no_color` does not name a tuple variant or a tuple struct
         }
     }
 }

--- a/src/test/compile-fail/match-pattern-field-mismatch-2.rs
+++ b/src/test/compile-fail/match-pattern-field-mismatch-2.rs
@@ -20,7 +20,8 @@ fn main() {
           color::rgb(_, _, _) => { }
           color::cmyk(_, _, _, _) => { }
           color::no_color(_) => { }
-          //~^ ERROR `color::no_color` does not name a tuple variant or a tuple struct
+          //~^ ERROR this pattern has 1 field, but the corresponding variant has no fields
+          //~^^ WARN `color::no_color` does not name a tuple variant or a tuple struct
         }
     }
 }

--- a/src/test/compile-fail/move-fragments-2.rs
+++ b/src/test/compile-fail/move-fragments-2.rs
@@ -32,7 +32,7 @@ pub fn test_match_partial(p: Lonely<D, D>) {
     //~^ ERROR                 parent_of_fragments: `$(local p)`
     //~| ERROR                  assigned_leaf_path: `($(local p) as Lonely::Zero)`
     match p {
-        Zero(..) => {}
+        Zero => {}
         _ => {}
     }
 }
@@ -44,7 +44,7 @@ pub fn test_match_full(p: Lonely<D, D>) {
     //~| ERROR                  assigned_leaf_path: `($(local p) as Lonely::One)`
     //~| ERROR                  assigned_leaf_path: `($(local p) as Lonely::Two)`
     match p {
-        Zero(..) => {}
+        Zero => {}
         One(..) => {}
         Two(..) => {}
     }
@@ -59,7 +59,7 @@ pub fn test_match_bind_one(p: Lonely<D, D>) {
     //~| ERROR                  assigned_leaf_path: `($(local p) as Lonely::Two)`
     //~| ERROR                  assigned_leaf_path: `$(local data)`
     match p {
-        Zero(..) => {}
+        Zero => {}
         One(data) => {}
         Two(..) => {}
     }
@@ -78,7 +78,7 @@ pub fn test_match_bind_many(p: Lonely<D, D>) {
     //~| ERROR                  assigned_leaf_path: `$(local left)`
     //~| ERROR                  assigned_leaf_path: `$(local right)`
     match p {
-        Zero(..) => {}
+        Zero => {}
         One(data) => {}
         Two(left, right) => {}
     }

--- a/src/test/compile-fail/move-fragments-3.rs
+++ b/src/test/compile-fail/move-fragments-3.rs
@@ -38,7 +38,7 @@ pub fn test_match_bind_and_underscore(p: Lonely<D, D>) {
     //~| ERROR                  assigned_leaf_path: `$(local left)`
 
     match p {
-        Zero(..) => {}
+        Zero => {}
 
         One(_) => {}       // <-- does not fragment `($(local p) as One)` ...
 

--- a/src/test/compile-fail/pattern-error-continue.rs
+++ b/src/test/compile-fail/pattern-error-continue.rs
@@ -25,7 +25,7 @@ fn f(_c: char) {}
 fn main() {
     match A::B(1, 2) {
         A::B(_, _, _) => (), //~ ERROR this pattern has 3 fields, but
-        A::D(_) => (),       //~ ERROR this pattern has 1 field, but
+        A::D(_) => (),       //~ ERROR `A::D` does not name a tuple variant or a tuple struct
         _ => ()
     }
     match 'c' {

--- a/src/test/compile-fail/pattern-error-continue.rs
+++ b/src/test/compile-fail/pattern-error-continue.rs
@@ -25,7 +25,8 @@ fn f(_c: char) {}
 fn main() {
     match A::B(1, 2) {
         A::B(_, _, _) => (), //~ ERROR this pattern has 3 fields, but
-        A::D(_) => (),       //~ ERROR `A::D` does not name a tuple variant or a tuple struct
+        A::D(_) => (),       //~ ERROR this pattern has 1 field, but
+        //~^ WARN `A::D` does not name a tuple variant or a tuple struct
         _ => ()
     }
     match 'c' {

--- a/src/test/run-pass/empty-struct-braces.rs
+++ b/src/test/run-pass/empty-struct-braces.rs
@@ -30,7 +30,7 @@ fn main() {
     let e3: Empty3 = Empty3 {};
     let e3: Empty3 = Empty3;
     let e4: E = E::Empty4 {};
-    // let e5: E = E::Empty5 {}; // Issue #28692
+    let e5: E = E::Empty5 {};
     let e5: E = E::Empty5;
 
     match e1 {
@@ -46,11 +46,10 @@ fn main() {
         E::Empty4 {} => {}
         _ => {}
     }
-    // Issue #28692
-    // match e5 {
-    //     E::Empty5 {} => {}
-    //     _ => {}
-    // }
+    match e5 {
+        E::Empty5 {} => {}
+        _ => {}
+    }
 
     match e1 {
         Empty1 { .. } => {}
@@ -65,11 +64,10 @@ fn main() {
         E::Empty4 { .. } => {}
         _ => {}
     }
-    // Issue #28692
-    // match e5 {
-    //     E::Empty5 { .. } => {}
-    //     _ => {}
-    // }
+    match e5 {
+        E::Empty5 { .. } => {}
+        _ => {}
+    }
 
     match e2 {
         Empty2 => {}

--- a/src/test/run-pass/issue-14308.rs
+++ b/src/test/run-pass/issue-14308.rs
@@ -10,7 +10,6 @@
 
 
 struct A(isize);
-struct B;
 
 fn main() {
     let x = match A(3) {
@@ -22,12 +21,4 @@ fn main() {
         A(..) => 2
     };
     assert_eq!(x, 2);
-
-    // This next test uses a (..) wildcard match on a nullary struct.
-    // There's no particularly good reason to support this, but it's currently allowed,
-    // and this makes sure it doesn't ICE or break LLVM.
-    let x = match B {
-        B(..) => 3
-    };
-    assert_eq!(x, 3);
 }

--- a/src/test/run-pass/issue-1701.rs
+++ b/src/test/run-pass/issue-1701.rs
@@ -20,7 +20,7 @@ fn noise(a: animal) -> Option<String> {
       animal::cat(..)    => { Some("meow".to_string()) }
       animal::dog(..)    => { Some("woof".to_string()) }
       animal::rabbit(..) => { None }
-      animal::tiger(..)  => { Some("roar".to_string()) }
+      animal::tiger  => { Some("roar".to_string()) }
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/28692
Fixes https://github.com/rust-lang/rust/issues/28992
Fixes some other similar issues (see the tests)

[breaking-change], needs crater run (cc @brson or @alexcrichton )

The pattern with parens `UnitVariant(..)` for unit variants seems to be popular in rustc (see the second commit), but mostly used by one person (@nikomatsakis), according to git blame. If it causes breakage on crates.io I'll add an exceptional case for it.
