### PR TITLE
Fix emitting asm and object file output at the same time

### DIFF
--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -2066,6 +2066,7 @@ extern {
                                    PM: PassManagerRef,
                                    M: ModuleRef,
                                    Output: *const c_char,
+                                   skip_codegen: bool,
                                    FileType: FileType) -> bool;
     pub fn LLVMRustPrintModule(PM: PassManagerRef,
                                M: ModuleRef,

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -56,11 +56,12 @@ pub fn write_output_file(
         pm: llvm::PassManagerRef,
         m: ModuleRef,
         output: &Path,
+        skip_codegen: bool,
         file_type: llvm::FileType) {
     unsafe {
         let output_c = path2cstr(output);
         let result = llvm::LLVMRustWriteOutputFile(
-                target, pm, m, output_c.as_ptr(), file_type);
+                target, pm, m, output_c.as_ptr(), skip_codegen, file_type);
         if !result {
             llvm_err(handler, format!("could not write output to {}", output.display()));
         }
@@ -543,15 +544,19 @@ unsafe fn optimize_and_codegen(cgcx: &CodegenContext,
         if config.emit_asm {
             let path = output_names.with_extension(&format!("{}.s", name_extra));
             with_codegen(tm, llmod, config.no_builtins, |cpm| {
-                write_output_file(cgcx.handler, tm, cpm, llmod, &path,
+                write_output_file(cgcx.handler, tm, cpm, llmod, &path, false,
                                   llvm::AssemblyFileType);
             });
         }
 
         if config.emit_obj {
+            // If we already emitted asm code, the codegen has already been done for this module,
+            // so don't do it again. See LLVMRustWriteOutputFile for details.
+            let skip_codegen = config.emit_asm;
             let path = output_names.with_extension(&format!("{}.o", name_extra));
             with_codegen(tm, llmod, config.no_builtins, |cpm| {
-                write_output_file(cgcx.handler, tm, cpm, llmod, &path, llvm::ObjectFileType);
+                write_output_file(cgcx.handler, tm, cpm, llmod, &path, skip_codegen,
+                                  llvm::ObjectFileType);
             });
         }
     });

--- a/src/test/run-make/emit/Makefile
+++ b/src/test/run-make/emit/Makefile
@@ -1,0 +1,7 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) -Copt-level=0 --emit=llvm-bc,llvm-ir,asm,obj,link test.rs
+	$(RUSTC) -Copt-level=1 --emit=llvm-bc,llvm-ir,asm,obj,link test.rs
+	$(RUSTC) -Copt-level=2 --emit=llvm-bc,llvm-ir,asm,obj,link test.rs
+	$(RUSTC) -Copt-level=3 --emit=llvm-bc,llvm-ir,asm,obj,link test.rs

--- a/src/test/run-make/emit/test.rs
+++ b/src/test/run-make/emit/test.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Checks for issue #24876
+
+fn main() {
+    let mut v = 0;
+    for i in 0..0 {
+        v += i;
+    }
+    println!("{}", v)
+}


### PR DESCRIPTION
The LLVM function to output file types that involve codegen can
invalidate the IR while lowering. That means that the second time the IR
is fed to those passes, it's invalid and the LLVM verifier complains. To
workaround this, we can tell the function to skip the codegen passes the
second time around. To do this, we tell it to start adding passes only
after it has seen a pass that doesn't exist at all. Quite the hack, I
know...

Fixes #24876
