### PR TITLE
Print missing semicolon warning for type-inferred ints

### DIFF
--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1487,9 +1487,9 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
                                         // Type inference causes unsuffixed integer literals
                                         // to be evaluated as i32 values. We still want to
                                         // inform the user of a semicolon in this case.
-                                        (&ty::TyInt(ast::TyI32),&ty::TyInt(..)) => true,
-                                        (&ty::TyInt(ast::TyI32),&ty::TyUint(..)) => true,
-                                        (a,b) => (a == b),
+                                        (&ty::TyInt(ast::TyI32), &ty::TyInt(..)) => true,
+                                        (&ty::TyInt(ast::TyI32), &ty::TyUint(..)) => true,
+                                        (a, b) => (a == b),
                                     }
                                 },
                                 _ => false

--- a/src/test/compile-fail/missing-semicolon.rs
+++ b/src/test/compile-fail/missing-semicolon.rs
@@ -1,0 +1,17 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:consider removing this semicolon
+
+fn foo() -> u16 {
+    1234;
+}
+
+fn main() { }


### PR DESCRIPTION
We only printed the extra semicolon warning if the type of the last
statement was the same as the return type of the function.

If a semicolon was appended, then the code

``` rust
fn foo() -> u16 {
    1234;
}
```

Would not print the extra semicolon warning, because without knowing
that `1234` is the return value, the inference engine would take `1234` to
be an `i32`.

This adds extra logic to recognize this case.

Fixes issue #29307.
