### PR TITLE
Fix makefile rules for generated llvmdeps.rs file

### DIFF
--- a/mk/clean.mk
+++ b/mk/clean.mk
@@ -65,7 +65,7 @@ clean-generic-$(2)-$(1):
          -name '*.def' -o \
          -name '*.py' -o \
          -name '*.pyc' -o \
-         -name '*.bc' \
+         -name '*.bc' -o \
          -name '*.rs' \
          \) \
          | xargs rm -f

--- a/mk/clean.mk
+++ b/mk/clean.mk
@@ -66,6 +66,7 @@ clean-generic-$(2)-$(1):
          -name '*.py' -o \
          -name '*.pyc' -o \
          -name '*.bc' \
+         -name '*.rs' \
          \) \
          | xargs rm -f
 	$(Q)find $(1) \

--- a/mk/llvm.mk
+++ b/mk/llvm.mk
@@ -81,7 +81,7 @@ endif
 
 # LLVM linkage:
 LLVM_LINKAGE_PATH_$(1):=$$(abspath $$(RT_OUTPUT_DIR_$(1))/llvmdeps.rs)
-$$(LLVM_LINKAGE_PATH_$(1)): $(S)src/etc/mklldeps.py $$(LLVM_CONFIG_$(1))
+$$(LLVM_LINKAGE_PATH_$(1)): $(S)src/etc/mklldeps.py $(S)src/llvm $(S)src/rustllvm $$(LLVM_CONFIG_$(1))
 	$(Q)$(CFG_PYTHON) "$$<" "$$@" "$$(LLVM_COMPONENTS)" "$$(CFG_ENABLE_LLVM_STATIC_STDCPP)" \
 		$$(LLVM_CONFIG_$(1)) "$(CFG_STDCPP_NAME)"
 endef

--- a/mk/llvm.mk
+++ b/mk/llvm.mk
@@ -81,7 +81,7 @@ endif
 
 # LLVM linkage:
 LLVM_LINKAGE_PATH_$(1):=$$(abspath $$(RT_OUTPUT_DIR_$(1))/llvmdeps.rs)
-$$(LLVM_LINKAGE_PATH_$(1)): $(S)src/etc/mklldeps.py $(S)src/llvm $(S)src/rustllvm $$(LLVM_CONFIG_$(1))
+$$(LLVM_LINKAGE_PATH_$(1)): $(S)src/etc/mklldeps.py $$(LLVM_CONFIG_$(1))
 	$(Q)$(CFG_PYTHON) "$$<" "$$@" "$$(LLVM_COMPONENTS)" "$$(CFG_ENABLE_LLVM_STATIC_STDCPP)" \
 		$$(LLVM_CONFIG_$(1)) "$(CFG_STDCPP_NAME)"
 endef


### PR DESCRIPTION
Previously the file was not regenrated upon modification of `src/rustllvm` or others.

Now it will be rebuilt if `src/llvm` or `src/rustllvm` is touched.

Also added *.rs rule to 'clean' rule so that it is removed upon 'make
clean'.

Fixes #28614.
