### PR TITLE
Have std::convert::AsMut require AsRef

### DIFF
--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -54,7 +54,7 @@ pub trait AsRef<T: ?Sized> {
 
 /// A cheap, mutable reference-to-mutable reference conversion.
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait AsMut<T: ?Sized> {
+pub trait AsMut<T: ?Sized>: AsRef<T> {
     /// Performs the conversion.
     #[stable(feature = "rust1", since = "1.0.0")]
     fn as_mut(&mut self) -> &mut T;


### PR DESCRIPTION
I’m writing a generic type that uses `AsMut`, but I find myself writing `where T: AsRef<[u8]> + AsMut<[u8]>` everywhere so that it can have methods that take `&self`.

All implementations of `AsMut` in std have corresponding `AsRef` implementations, and I can’t think of a reason to have the former without the latter. This change makes it required, so that types like mind can write just one bound.

This is a [breaking-change], but I don’t know how much real code it affects.

Can we run this on Crater? Is it a terrible idea regardless?
