### PR TITLE
mk: Re-add libgcc_s_seh-1.dll to windows dist

### DIFF
--- a/src/etc/make-win-dist.py
+++ b/src/etc/make-win-dist.py
@@ -50,6 +50,8 @@ def make_win_dist(rust_root, gcc_root, target_triple):
     rustc_dlls = ["libstdc++-6.dll"]
     if target_triple.startswith("i686-"):
         rustc_dlls.append("libgcc_s_dw2-1.dll")
+    else:
+        rustc_dlls.append("libgcc_s_seh-1.dll")
 
     target_libs = [ # MinGW libs
                     "crtbegin.o",


### PR DESCRIPTION
Although the compiler itself does not depend on this DLL the `libstdc++-6.dll`
that we're shipping does, so we still need to include it.
