### PR TITLE
parser: require argument names in trait methods

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1203,10 +1203,7 @@ impl<'a> Parser<'a> {
                 let mut generics = try!(p.parse_generics());
 
                 let (explicit_self, d) = try!(p.parse_fn_decl_with_self(|p|{
-                    // This is somewhat dubious; We don't want to allow
-                    // argument names to be left off if there is a
-                    // definition...
-                    p.parse_arg_general(false)
+                    p.parse_arg_general(true)
                 }));
 
                 generics.where_clause = try!(p.parse_where_clause());


### PR DESCRIPTION
Rust currently allows omitting parameter names in trati methods, like this.

``` rust
trait T {
   fn foo(i32) {  }
}
```

In all other contexts, except for the fn types, parameter names are
mandatory. This makes argument names in trait methods also mandatory.

This is a breaking language change.

I'm not sure that this is a bug, so feel free to close. I haven't run the tests yet ( they are in progress :( ), so build will likelly fail.

Discussion on the users.rust-lang: https://users.rust-lang.org/t/question-why-does-rust-admit-anonymous-parameters-in-traits/3420
