### PR TITLE
type_of: use `sizing_type_of` to check the size of arrays

### DIFF
--- a/src/librustc_trans/trans/type_of.rs
+++ b/src/librustc_trans/trans/type_of.rs
@@ -395,8 +395,12 @@ pub fn in_memory_type_of<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>) -> 
 
       ty::TyArray(ty, size) => {
           let size = size as u64;
+          // we must use `sizing_type_of` here as the type may
+          // not be fully initialized.
+          let szty = sizing_type_of(cx, ty);
+          ensure_array_fits_in_address_space(cx, szty, size, t);
+
           let llty = in_memory_type_of(cx, ty);
-          ensure_array_fits_in_address_space(cx, llty, size, t);
           Type::array(&llty, size)
       }
 

--- a/src/test/run-pass/issue-19001.rs
+++ b/src/test/run-pass/issue-19001.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// check that we handle recursive arrays correctly in `type_of`
+
+struct Loopy {
+    ptr: *mut [Loopy; 1]
+}
+
+fn main() {
+    let _t = Loopy { ptr: 0 as *mut _ };
+}


### PR DESCRIPTION
when evaluating a recursive type, the `type_of` of the interior could be
still in progress, so trying to get its size would cause an ICE.

Fixes #19001

r? @eddyb 
