### PR TITLE
use historical philosophers in dining philosophers example

### DIFF
--- a/src/doc/trpl/dining-philosophers.md
+++ b/src/doc/trpl/dining-philosophers.md
@@ -62,11 +62,11 @@ impl Philosopher {
 }
 
 fn main() {
-    let p1 = Philosopher::new("Judith Butler");
-    let p2 = Philosopher::new("Gilles Deleuze");
+    let p1 = Philosopher::new("Hypatia");
+    let p2 = Philosopher::new("Uddalaka Aruni");
     let p3 = Philosopher::new("Karl Marx");
-    let p4 = Philosopher::new("Emma Goldman");
-    let p5 = Philosopher::new("Michel Foucault");
+    let p4 = Philosopher::new("Laura Bassi");
+    let p5 = Philosopher::new("Mencius");
 }
 ```
 


### PR DESCRIPTION
As I was working through the Rust book, I found the choice of philosophers here distracting; I definitely felt like I was being told that Rust learners are supposed to recognize and like a particular kind of philosophy, and by extension, belong to a particular culture. In the version adapted from [here](http://www.usingcsp.com/cspbook.pdf), Hoare uses PHIL0 through PHIL4, which is a bit boring and formal but very good at being neutral and inclusive.

I thought a good compromise between these two cases would be to use exclusively historical philosophers from diverse times and places.

First PR, do let me know if I'm doing something wrong.

r? @steveklabnik
