### PR TITLE
Log the error we get when we fail to load metadata from a library.

### DIFF
--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -542,8 +542,8 @@ impl<'a> Context<'a> {
                         continue
                     }
                 }
-                Err(_) => {
-                    info!("no metadata found");
+                Err(err) => {
+                    info!("no metadata found: {}", err);
                     continue
                 }
             };


### PR DESCRIPTION
Discarding errors is bad, m'kay?
