### PR TITLE
libsyntax: improve error message when a statement is prefixed with a match keyword

### DIFF
--- a/src/test/parse-fail/match-refactor-to-expr.rs
+++ b/src/test/parse-fail/match-refactor-to-expr.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let foo =
+        match //~ NOTE did you mean to remove this `match` keyword?
+        Some(4).unwrap_or_else(5)
+        ; //~ ERROR expected one of `.`, `{`, or an operator, found `;`
+
+    println!("{}", foo)
+}


### PR DESCRIPTION
This helps for the case where a match, such as below:

``` rust
let foo = match foo {
    Some(x) => x,
    None => 0
};
```

gets refactored to no longer need the match, but the match keyword has been left accidentally: 

``` rust
let foo = match foo.unwrap_or(0);
```

This can be hard to spot as the expression grows more complex.

r? @alexcrichton 
