### PR TITLE
docs: split a run-on sentence

### DIFF
--- a/src/doc/trpl/references-and-borrowing.md
+++ b/src/doc/trpl/references-and-borrowing.md
@@ -122,8 +122,8 @@ println!("{}", x);
 ```
 
 This will print `6`. We make `y` a mutable reference to `x`, then add one to
-the thing `y` points at. You’ll notice that `x` had to be marked `mut` as well,
-if it wasn’t, we couldn’t take a mutable borrow to an immutable value.
+the thing `y` points at. You’ll notice that `x` had to be marked `mut` as well.
+If it wasn’t, we couldn’t take a mutable borrow to an immutable value.
 
 You'll also notice we added an asterisk (`*`) in front of `y`, making it `*y`,
 this is because `y` is an `&mut` reference. You'll also need to use them for


### PR DESCRIPTION
This is two sentences that have been comma spliced, and should
be split with a full stop.  (This error made me stop and re-read,
and I submit this as an actual improvement to readability, not
as a grammar weird-o!)
