### PR TITLE
Add a numeric ID to threads

### DIFF
--- a/src/libstd/sys/common/thread.rs
+++ b/src/libstd/sys/common/thread.rs
@@ -14,11 +14,11 @@ use alloc::boxed::FnBox;
 use libc;
 use sys::stack_overflow;
 
-pub unsafe fn start_thread(main: *mut libc::c_void) {
+pub unsafe fn start_thread(main: *mut libc::c_void, id: u32) {
     // Next, set up our stack overflow handler which may get triggered if we run
     // out of stack.
     let _handler = stack_overflow::Handler::new();
 
     // Finally, let's run some code.
-    Box::from_raw(main as *mut Box<FnBox()>)()
+    Box::from_raw(main as *mut Box<FnBox(u32)>)(id)
 }

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -35,7 +35,7 @@ unsafe impl Send for Thread {}
 unsafe impl Sync for Thread {}
 
 impl Thread {
-    pub unsafe fn new<'a>(stack: usize, p: Box<FnBox() + 'a>)
+    pub unsafe fn new<'a>(stack: usize, p: Box<FnBox(u32) + 'a>)
                           -> io::Result<Thread> {
         let p = box p;
         let mut native: libc::pthread_t = mem::zeroed();
@@ -71,7 +71,7 @@ impl Thread {
         };
 
         extern fn thread_start(main: *mut libc::c_void) -> *mut libc::c_void {
-            unsafe { start_thread(main); }
+            unsafe { start_thread(main, pthread_self() as u32); }
             ptr::null_mut()
         }
     }

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -162,6 +162,10 @@ impl Thread {
             debug_assert_eq!(ret, 0);
         }
     }
+
+    pub fn id(&self) -> u32 {
+        self.id as u32
+    }
 }
 
 impl Drop for Thread {

--- a/src/libstd/sys/windows/thread.rs
+++ b/src/libstd/sys/windows/thread.rs
@@ -49,7 +49,7 @@ impl Thread {
         };
 
         extern "system" fn thread_start(main: *mut libc::c_void) -> DWORD {
-            unsafe { start_thread(main); }
+            unsafe { start_thread(main, 42); }
             0
         }
     }

--- a/src/libstd/sys/windows/thread.rs
+++ b/src/libstd/sys/windows/thread.rs
@@ -78,6 +78,10 @@ impl Thread {
             c::Sleep(super::dur2timeout(dur))
         }
     }
+
+    pub fn id(&self) -> u32 {
+        42 // TODO
+    }
 }
 
 pub mod guard {

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -495,6 +495,7 @@ struct Inner {
     name: Option<String>,
     lock: Mutex<bool>,          // true when there is a buffered unpark
     cvar: Condvar,
+    id: u32,
 }
 
 #[derive(Clone)]
@@ -512,6 +513,7 @@ impl Thread {
                 name: name,
                 lock: Mutex::new(false),
                 cvar: Condvar::new(),
+                id: 0,
             })
         }
     }
@@ -533,12 +535,20 @@ impl Thread {
     pub fn name(&self) -> Option<&str> {
         self.inner.name.as_ref().map(|s| &**s)
     }
+
+    /// Gets the thread's unique ID.
+    ///
+    /// This ID is unique across running threads, and a thread that has stopped
+    /// might see its ID reused.
+    pub fn id(&self) -> u32 {
+        self.inner.id
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Debug for Thread {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(&self.name(), f)
+        fmt::Debug::fmt(&self.name(), f)  // print ID?
     }
 }
 


### PR DESCRIPTION
See #21507

Because we only get an ID once the thread has been spawned, and at that point the Inner struct is referenced from both the thread (which is gonna store it in the threadlocal thread_info) and the parent (which returns it), it was much easier to add it to Thread than to Inner. It is a single u32 so I'm not sure the memory usage is an issue, but it is a little awkward to have id in Thread and name in Inner?

Let me know.
