### PR TITLE
std: Refactor process exit code handling slightly

### DIFF
--- a/src/libstd/sys/unix/ext/process.rs
+++ b/src/libstd/sys/unix/ext/process.rs
@@ -75,10 +75,7 @@ pub trait ExitStatusExt {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl ExitStatusExt for process::ExitStatus {
     fn signal(&self) -> Option<i32> {
-        match *self.as_inner() {
-            sys::process::ExitStatus::Signal(s) => Some(s),
-            _ => None
-        }
+        self.as_inner().signal()
     }
 }
 

--- a/src/test/run-pass/weird-exit-code.rs
+++ b/src/test/run-pass/weird-exit-code.rs
@@ -1,0 +1,37 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// On Windows the GetExitCodeProcess API is used to get the exit code of a
+// process, but it's easy to mistake a process exiting with the code 259 as
+// "still running" because this is the value of the STILL_ACTIVE constant. Make
+// sure we handle this case in the standard library and correctly report the
+// status.
+//
+// Note that this is disabled on unix as processes exiting with 259 will have
+// their exit status truncated to 3 (only the lower 8 bits are used).
+
+use std::process::{self, Command};
+use std::env;
+
+fn main() {
+    if !cfg!(windows) {
+        return
+    }
+
+    if env::args().len() == 1 {
+        let status = Command::new(env::current_exe().unwrap())
+                             .arg("foo")
+                             .status()
+                             .unwrap();
+        assert_eq!(status.code(), Some(259));
+    } else {
+        process::exit(259);
+    }
+}


### PR DESCRIPTION
- Store the native representation directly in the `ExitStatus` structure instead
  of a "parsed version" (mostly for Unix).
- On Windows, be more robust against processes exiting with the status of 259.
  Unfortunately this exit code corresponds to `STILL_ACTIVE`, causing libstd to
  think the process was still alive, causing an infinite loop. Instead the loop
  is removed altogether and `WaitForSingleObject` is used to wait for the
  process to exit.
