### PR TITLE
Provides an alternative print and println macro that don't panic.

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -98,6 +98,41 @@ macro_rules! print {
     ($($arg:tt)*) => ($crate::io::_print(format_args!($($arg)*)));
 }
 
+/// Macro for printing to the standard output.
+///
+/// Equivalent to the `print!` macro except it does not panic if it fails to
+/// write to stdout.
+///
+/// Note that stdout is frequently line-buffered by default so it may be
+/// necessary to use `io::stdout().flush()` to ensure the output is emitted
+/// immediately.
+///
+///
+/// # Examples
+///
+/// ```
+/// use std::io::{self, Write};
+///
+/// try_print!("this ").unwrap();
+/// try_print!("will ").unwrap();
+/// try_print!("be ").unwrap();
+/// try_print!("on ").unwrap();
+/// try_print!("the ").unwrap();
+/// try_print!("same ").unwrap();
+/// try_print!("line ").unwrap();
+///
+/// io::stdout().flush().unwrap();
+///
+/// try_print!("this string has a newline, why not choose println! instead?\n").unwrap();
+///
+/// io::stdout().flush().unwrap();
+/// ```
+#[macro_export]
+#[allow_internal_unstable]
+macro_rules! try_print {
+    ($($arg:tt)*) => ($crate::io::_try_print(format_args!($($arg)*)));
+}
+
 /// Macro for printing to the standard output, with a newline.
 ///
 /// Use the `format!` syntax to write data to the standard output.
@@ -118,6 +153,23 @@ macro_rules! print {
 macro_rules! println {
     ($fmt:expr) => (print!(concat!($fmt, "\n")));
     ($fmt:expr, $($arg:tt)*) => (print!(concat!($fmt, "\n"), $($arg)*));
+}
+
+/// Macro for printing to the standard output, with a newline.
+///
+/// Use the `format!` syntax to write data to the standard output.
+/// See `std::fmt` for more information.
+///
+/// # Examples
+///
+/// ```
+/// try_println!("hello there!").unwrap();
+/// try_println!("format {} arguments", "some").unwrap();
+/// ```
+#[macro_export]
+macro_rules! try_println {
+    ($fmt:expr) => (try_print!(concat!($fmt, "\n")));
+    ($fmt:expr, $($arg:tt)*) => (try_print!(concat!($fmt, "\n"), $($arg)*));
 }
 
 /// Helper macro for unwrapping `Result` values while returning early with an


### PR DESCRIPTION
The `println` and `print` macros provides a simple interface to output
content on the stdout of a program. The macros panic when writing to
stdout, and the failure condition could happen on external conditions.

Take the following rust code:

``` rust
fn main() {
  for _ in 0..10000 {
    println!("line") {
  }
}
```

Piping the program output to other utilities could cause the program to
panic, when the pipe is closed.

``` bash
produce_logs | head
line
line
line
line
line
line
line
line
line
line
thread '<main>' panicked at 'failed printing to stdout: Broken pipe (os error 32)', ../src/libstd/io/stdio.rs:588
```

Instead of panicking, it would be interesting to allow the developer to
decide what to do with the error result, either ignoring it or panicking
on it's own. This commit implements `try_println` and `try_print` as an
alternative non-panicking macros.

The following code will not panic anymore when the pipe is closed.

``` rust
fn main() {
  for _ in 0..10000 {
    if let Err(_) = try_println!("line") {
      std::process::exit(0);
    }
  }
}
```
