### PR TITLE
Revert compiler-rt updates from #29233

### DIFF
--- a/configure
+++ b/configure
@@ -1498,9 +1498,25 @@ do
         done
     fi
 
-    # We need the generator later on for compiler-rt even if LLVM's not built
-    if [ ${is_msvc} -ne 0 ]
+    if [ ${do_reconfigure} -ne 0 ] && [ ${is_msvc} -ne 0 ]
     then
+        msg "configuring LLVM for $t with cmake"
+
+        CMAKE_ARGS="-DLLVM_INCLUDE_TESTS=OFF"
+        if [ -n "$CFG_DISABLE_OPTIMIZE_LLVM" ]; then
+            CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_BUILD_TYPE=Debug"
+        else
+            CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release"
+        fi
+        if [ -z "$CFG_ENABLE_LLVM_ASSERTIONS" ]
+        then
+            CMAKE_ARGS="$CMAKE_ARGS -DLLVM_ENABLE_ASSERTIONS=OFF"
+        else
+            CMAKE_ARGS="$CMAKE_ARGS -DLLVM_ENABLE_ASSERTIONS=ON"
+        fi
+
+        msg "configuring LLVM with:"
+        msg "$CMAKE_ARGS"
         case "$CFG_MSVC_ROOT" in
             *14.0*)
                 generator="Visual Studio 14 2015"
@@ -1522,32 +1538,8 @@ do
                 err "can only build LLVM for x86 platforms"
                 ;;
         esac
-        CFG_CMAKE_GENERATOR=$generator
-        putvar CFG_CMAKE_GENERATOR
-    fi
-
-    if [ ${do_reconfigure} -ne 0 ] && [ ${is_msvc} -ne 0 ]
-    then
-        msg "configuring LLVM for $t with cmake"
-
-        CMAKE_ARGS="-DLLVM_INCLUDE_TESTS=OFF"
-        if [ -n "$CFG_DISABLE_OPTIMIZE_LLVM" ]; then
-            CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_BUILD_TYPE=Debug"
-        else
-            CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release"
-        fi
-        if [ -z "$CFG_ENABLE_LLVM_ASSERTIONS" ]
-        then
-            CMAKE_ARGS="$CMAKE_ARGS -DLLVM_ENABLE_ASSERTIONS=OFF"
-        else
-            CMAKE_ARGS="$CMAKE_ARGS -DLLVM_ENABLE_ASSERTIONS=ON"
-        fi
-
-        msg "configuring LLVM with:"
-        msg "$CMAKE_ARGS"
-
         (cd $LLVM_BUILD_DIR && "$CFG_CMAKE" $CFG_LLVM_SRC_DIR \
-                                            -G "$CFG_CMAKE_GENERATOR" \
+                                            -G "$generator" \
                                             $CMAKE_ARGS)
         need_ok "LLVM cmake configure failed"
     fi

--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -216,31 +216,22 @@ COMPRT_NAME_$(1) := $$(call CFG_STATIC_LIB_NAME_$(1),compiler-rt)
 COMPRT_LIB_$(1) := $$(RT_OUTPUT_DIR_$(1))/$$(COMPRT_NAME_$(1))
 COMPRT_BUILD_DIR_$(1) := $$(RT_OUTPUT_DIR_$(1))/compiler-rt
 
-ifeq ($$(findstring msvc,$(1)),msvc)
-$$(COMPRT_LIB_$(1)): $$(COMPRT_DEPS) $$(MKFILE_DEPS) $$(LLVM_CONFIG_$(1))
-	@$$(call E, cmake: compiler-rt)
-	$$(Q)cd "$$(COMPRT_BUILD_DIR_$(1))"; $$(CFG_CMAKE) "$(S)src/compiler-rt" \
-		-DCMAKE_BUILD_TYPE=$$(LLVM_BUILD_CONFIG_MODE) \
-		-DLLVM_CONFIG_PATH=$$(LLVM_CONFIG_$(1)) \
-		-G"$$(CFG_CMAKE_GENERATOR)"
-	$$(Q)$$(CFG_CMAKE) --build "$$(COMPRT_BUILD_DIR_$(1))" \
-		--target lib/builtins/builtins \
-		--config $$(LLVM_BUILD_CONFIG_MODE) \
-		-- //v:m //nologo
-	$$(Q)cp $$(COMPRT_BUILD_DIR_$(1))/lib/windows/$$(LLVM_BUILD_CONFIG_MODE)/clang_rt.builtins-$$(HOST_$(1)).lib $$@
-else
+# Note that on MSVC-targeting builds we hardwire CC/AR to gcc/ar even though
+# we're targeting MSVC. This is because although compiler-rt has a CMake build
+# config I can't actually figure out how to use it, so I'm not sure how to use
+# cl.exe to build the objects. Additionally, the compiler-rt library when built
+# with gcc has the same ABI as cl.exe, so they're largely compatible
 COMPRT_CC_$(1) := $$(CC_$(1))
 COMPRT_AR_$(1) := $$(AR_$(1))
-# We chomp -Werror here because GCC warns about the type signature of
-# builtins not matching its own and the build fails. It's a bit hacky,
-# but what can we do, we're building libclang-rt using GCC ......
-COMPRT_CFLAGS_$(1) := $$(subst -Werror,,$$(CFG_GCCISH_CFLAGS_$(1))) -std=c99
-
-# FreeBSD Clang's packaging is problematic; it doesn't copy unwind.h to
-# the standard include directory. This should really be in our changes to
-# compiler-rt, but we override the CFLAGS here so there isn't much choice
-ifeq ($$(findstring freebsd,$(1)),freebsd)
-	COMPRT_CFLAGS_$(1) += -I/usr/include/c++/v1
+COMPRT_CFLAGS_$(1) := $$(CFG_GCCISH_CFLAGS_$(1))
+ifeq ($$(findstring msvc,$(1)),msvc)
+COMPRT_CC_$(1) := gcc
+COMPRT_AR_$(1) := ar
+ifeq ($$(findstring i686,$(1)),i686)
+COMPRT_CFLAGS_$(1) := $$(CFG_GCCISH_CFLAGS_$(1)) -m32
+else
+COMPRT_CFLAGS_$(1) := $$(CFG_GCCISH_CFLAGS_$(1)) -m64
+endif
 endif
 
 $$(COMPRT_LIB_$(1)): $$(COMPRT_DEPS) $$(MKFILE_DEPS)
@@ -255,7 +246,7 @@ $$(COMPRT_LIB_$(1)): $$(COMPRT_DEPS) $$(MKFILE_DEPS)
 		TargetTriple=$(1) \
 		triple-builtins
 	$$(Q)cp $$(COMPRT_BUILD_DIR_$(1))/triple/builtins/libcompiler_rt.a $$@
-endif
+
 ################################################################################
 # libbacktrace
 #


### PR DESCRIPTION
This ended up causing regressions in a few builds I've seen:
- MinGW -- [64-bit](https://ci.appveyor.com/project/alexcrichton/gcc-rs/build/1.0.338/job/2c4pkxgxa2dvqs25) and [32-bit](https://ci.appveyor.com/project/alexcrichton/gcc-rs/build/1.0.338/job/d0n7kml3k5el9gla)
- MSVC - [64-bit with VS 12.0](https://ci.appveyor.com/project/alexcrichton/gcc-rs/build/job/ugldcage9ydoy1k6) and [32-bit with VS 12.0](https://ci.appveyor.com/project/alexcrichton/gcc-rs/build/job/pn59p4rhnj8gybei).

I suspect the problems are along the lines of:
- The emutls support needs to be disabled on Windows, it currently always used pthreads which isn't available
- The objects in compiler-rt either need to be built without a CRT or not specifically against the static one.
