### PR TITLE
Implement `CoerceUnsized` for `Unique`

### DIFF
--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -532,6 +532,10 @@ impl<T: ?Sized> Unique<T> {
     }
 }
 
+#[cfg(not(stage0))] // remove cfg after new snapshot
+#[unstable(feature = "unique", issue = "27730")]
+impl<T: ?Sized, U: ?Sized> CoerceUnsized<Unique<U>> for Unique<T> where T: Unsize<U> { }
+
 #[unstable(feature = "unique", issue= "27730")]
 impl<T:?Sized> Deref for Unique<T> {
     type Target = *mut T;


### PR DESCRIPTION
Closes rust-lang/rfcs#1343.
