### PR TITLE
Make Windows directory layout uniform with everything else

### DIFF
--- a/configure
+++ b/configure
@@ -632,18 +632,9 @@ putvar CFG_BUILD # Yes, this creates a duplicate entry, but the last one wins.
 CFG_HOST=$(to_llvm_triple $CFG_HOST)
 CFG_TARGET=$(to_llvm_triple $CFG_TARGET)
 
-# On windows we just store the libraries in the bin directory because
-# there's no rpath. This is where the build system itself puts libraries;
-# --libdir is used to configure the installation directory.
-# FIXME: This needs to parameterized over target triples. Do it in platform.mk
-if [ "$CFG_OSTYPE" = "pc-windows-gnu" ] || [ "$CFG_OSTYPE" = "pc-windows-msvc" ]
-then
-    CFG_LIBDIR_RELATIVE=bin
-else
-    CFG_LIBDIR_RELATIVE=lib
-fi
-
-valopt libdir "${CFG_PREFIX}/${CFG_LIBDIR_RELATIVE}" "install libraries (do not set it on windows platform)"
+# On Windows this determines root of the subtree for target libraries.
+# Host runtime libs always go to 'bin'.
+valopt libdir "${CFG_PREFIX}/lib" "install libraries"
 
 case "$CFG_LIBDIR" in
     "$CFG_PREFIX"/*) CAT_INC=2;;
@@ -653,11 +644,6 @@ case "$CFG_LIBDIR" in
 esac
 
 CFG_LIBDIR_RELATIVE=`echo ${CFG_LIBDIR} | cut -c$((${#CFG_PREFIX}+${CAT_INC}))-`
-
-if ( [ "$CFG_OSTYPE" = "pc-windows-gnu" ] || [ "$CFG_OSTYPE" = "pc-windows-msvc" ] ) \
-	&& [ "$CFG_LIBDIR_RELATIVE" != "bin" ]; then
-    err "libdir on windows should be set to 'bin'"
-fi
 
 if [ $HELP -eq 1 ]
 then

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -376,18 +376,29 @@ define SREQ
 # Destinations of artifacts for the host compiler
 HROOT$(1)_H_$(3) = $(3)/stage$(1)
 HBIN$(1)_H_$(3) = $$(HROOT$(1)_H_$(3))/bin
+
 ifeq ($$(CFG_WINDOWSY_$(3)),1)
-HLIB$(1)_H_$(3) = $$(HROOT$(1)_H_$(3))/$$(CFG_LIBDIR_RELATIVE)
+# On Windows we always store host runtime libraries in the 'bin' directory because
+# there's no rpath. Target libraries go under $CFG_LIBDIR_RELATIVE (usually 'lib').
+HLIB$(1)_H_$(3) = $$(HROOT$(1)_H_$(3))/bin
+TROOT$(1)_T_$(2)_H_$(3) = $$(HROOT$(1)_H_$(3))/$$(CFG_LIBDIR_RELATIVE)/rustlib/$(2)
+# Remove the next 3 lines after a snapshot
+ifeq ($(1),0)
+RUSTFLAGS_STAGE0 += -L $$(TROOT$(1)_T_$(2)_H_$(3))/lib
+endif
+
 else
+
 ifeq ($(1),0)
 HLIB$(1)_H_$(3) = $$(HROOT$(1)_H_$(3))/lib
 else
 HLIB$(1)_H_$(3) = $$(HROOT$(1)_H_$(3))/$$(CFG_LIBDIR_RELATIVE)
 endif
+TROOT$(1)_T_$(2)_H_$(3) = $$(HLIB$(1)_H_$(3))/rustlib/$(2)
+
 endif
 
 # Destinations of artifacts for target architectures
-TROOT$(1)_T_$(2)_H_$(3) = $$(HLIB$(1)_H_$(3))/rustlib/$(2)
 TBIN$(1)_T_$(2)_H_$(3) = $$(TROOT$(1)_T_$(2)_H_$(3))/bin
 TLIB$(1)_T_$(2)_H_$(3) = $$(TROOT$(1)_T_$(2)_H_$(3))/lib
 

--- a/src/etc/make-win-dist.py
+++ b/src/etc/make-win-dist.py
@@ -33,7 +33,11 @@ def find_files(files, path):
     return found
 
 
-def make_win_dist(rust_root, gcc_root, target_triple):
+# rust_root - root directory of the host binaries image
+# plat_root - root directory of the target platform tools and libs image
+#             (the two get overlayed on top of each other during installation)
+# target_triple - triple of the target image being layed out
+def make_win_dist(rust_root, plat_root, target_triple):
     # Ask gcc where it keeps its stuff
     gcc_out = subprocess.check_output(["gcc.exe", "-print-search-dirs"])
     bin_path = os.environ["PATH"].split(os.pathsep)
@@ -107,14 +111,14 @@ def make_win_dist(rust_root, gcc_root, target_triple):
         shutil.copy(src, dist_bin_dir)
 
     # Copy platform tools to platform-specific bin directory
-    target_bin_dir = os.path.join(gcc_root, "bin", "rustlib", target_triple, "bin")
+    target_bin_dir = os.path.join(plat_root, "lib", "rustlib", target_triple, "bin")
     if not os.path.exists(target_bin_dir):
         os.makedirs(target_bin_dir)
     for src in target_tools:
         shutil.copy(src, target_bin_dir)
 
     # Copy platform libs to platform-specific lib directory
-    target_lib_dir = os.path.join(gcc_root, "bin", "rustlib", target_triple, "lib")
+    target_lib_dir = os.path.join(plat_root, "lib", "rustlib", target_triple, "lib")
     if not os.path.exists(target_lib_dir):
         os.makedirs(target_lib_dir)
     for src in target_libs:

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -258,7 +258,6 @@ pub fn rust_path() -> Vec<PathBuf> {
 }
 
 // The name of the directory rustc expects libraries to be located.
-// On Unix should be "lib", on windows "bin"
 #[cfg(unix)]
 fn find_libdir(sysroot: &Path) -> String {
     // FIXME: This is a quick hack to make the rustc binary able to locate
@@ -295,7 +294,7 @@ fn find_libdir(sysroot: &Path) -> String {
 
 #[cfg(windows)]
 fn find_libdir(_sysroot: &Path) -> String {
-    "bin".to_string()
+    "lib".to_string()
 }
 
 // The name of rustc's own place to organize libraries.

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -258,7 +258,6 @@ pub fn rust_path() -> Vec<PathBuf> {
 }
 
 // The name of the directory rustc expects libraries to be located.
-#[cfg(unix)]
 fn find_libdir(sysroot: &Path) -> String {
     // FIXME: This is a quick hack to make the rustc binary able to locate
     // Rust libraries in Linux environments where libraries might be installed
@@ -290,11 +289,6 @@ fn find_libdir(sysroot: &Path) -> String {
     fn secondary_libdir_name() -> String {
         "lib".to_string()
     }
-}
-
-#[cfg(windows)]
-fn find_libdir(_sysroot: &Path) -> String {
-    "lib".to_string()
 }
 
 // The name of rustc's own place to organize libraries.


### PR DESCRIPTION
According to a recent [discussion on IRC](https://botbot.me/mozilla/rust-tools/2015-10-27/?msg=52887517&page=2), there's no good reason for Windows builds to store target libraries under `bin`, when on every other platform they are under `lib`.

This might be a [breaking-change] for some users.  I am pretty sure VisualRust has that path hard-coded somewhere.

r? @brson 
