### PR TITLE
Remove some instances of `ok().expect()` from the docs

### DIFF
--- a/src/doc/trpl/traits.md
+++ b/src/doc/trpl/traits.md
@@ -247,7 +247,7 @@ won’t have its methods:
 [write]: ../std/io/trait.Write.html
 
 ```rust,ignore
-let mut f = std::fs::File::open("foo.txt").ok().expect("Couldn’t open foo.txt");
+let mut f = std::fs::File::open("foo.txt").expect("Couldn’t open foo.txt");
 let buf = b"whatever"; // byte string literal. buf: &[u8; 8]
 let result = f.write(buf);
 # result.unwrap(); // ignore the error
@@ -266,7 +266,7 @@ We need to `use` the `Write` trait first:
 ```rust,ignore
 use std::io::Write;
 
-let mut f = std::fs::File::open("foo.txt").ok().expect("Couldn’t open foo.txt");
+let mut f = std::fs::File::open("foo.txt").expect("Couldn’t open foo.txt");
 let buf = b"whatever";
 let result = f.write(buf);
 # result.unwrap(); // ignore the error

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -117,16 +117,15 @@
 //! warning (by default, controlled by the `unused_must_use` lint).
 //!
 //! You might instead, if you don't want to handle the error, simply
-//! panic, by converting to an `Option` with `ok`, then asserting
-//! success with `expect`. This will panic if the write fails, proving
-//! a marginally useful message indicating why:
+//! assert success with `expect`. This will panic if the
+//! write fails, providing a marginally useful message indicating why:
 //!
 //! ```{.no_run}
 //! use std::fs::File;
 //! use std::io::prelude::*;
 //!
 //! let mut file = File::create("valuable_data.txt").unwrap();
-//! file.write_all(b"important message").ok().expect("failed to write message");
+//! file.write_all(b"important message").expect("failed to write message");
 //! ```
 //!
 //! You might also simply assert success:


### PR DESCRIPTION
This fixes part of #29506
These instances of `ok().expect()` have no benefit over using `Result`'s `expect` directly.
