### PR TITLE
mk: Add rtstartup to dist

### DIFF
--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -59,6 +59,7 @@ PKG_FILES := \
       libcoretest                              \
       libbacktrace                             \
       rt                                       \
+      rtstartup                                \
       rustllvm                                 \
       snapshots.txt                            \
       rust-installer                           \


### PR DESCRIPTION
Needed for distcheck to pass and to have a working tarball.
