### PR TITLE
remove #![feature(rc_unique)] from Rc docs

### DIFF
--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -227,8 +227,6 @@ impl<T> Rc<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(rc_unique)]
-    ///
     /// use std::rc::Rc;
     ///
     /// let x = Rc::new(3);
@@ -370,7 +368,6 @@ impl<T: Clone> Rc<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(rc_unique)]
     /// use std::rc::Rc;
     ///
     /// let mut data = Rc::new(5);


### PR DESCRIPTION
`Rc::try_unwrap` and `Rc::make_mut` are stable since 1.4.0, but the example code still has `#![feature(rc_unique)]`. Ideally the stable and beta docs would be updated, but I don't think that's possible :(
