### PR TITLE
rustc_resolve: refactor NameBindings and fix issue #4952

### DIFF
--- a/src/librustc_resolve/record_exports.rs
+++ b/src/librustc_resolve/record_exports.rs
@@ -79,7 +79,7 @@ impl<'a, 'b, 'tcx> ExportRecorder<'a, 'b, 'tcx> {
         build_reduced_graph::populate_module_if_necessary(self.resolver, &module_);
 
         for (_, child_name_bindings) in module_.children.borrow().iter() {
-            match child_name_bindings.get_module_if_available() {
+            match child_name_bindings.type_ns.module() {
                 None => {
                     // Nothing to do.
                 }
@@ -149,6 +149,6 @@ impl<'a, 'b, 'tcx> ExportRecorder<'a, 'b, 'tcx> {
 
 pub fn record(resolver: &mut Resolver) {
     let mut recorder = ExportRecorder { resolver: resolver };
-    let root_module = recorder.graph_root.get_module();
+    let root_module = recorder.graph_root.clone();
     recorder.record_exports_for_module_subtree(root_module);
 }

--- a/src/librustc_resolve/record_exports.rs
+++ b/src/librustc_resolve/record_exports.rs
@@ -18,8 +18,8 @@
 // Then this operation can simply be performed as part of item (or import)
 // processing.
 
-use {Module, NameBindings, Resolver};
-use Namespace::{self, TypeNS, ValueNS};
+use {Module, NameBinding, Resolver};
+use Namespace::{TypeNS, ValueNS};
 
 use build_reduced_graph;
 use module_to_string;
@@ -108,12 +108,11 @@ impl<'a, 'b, 'tcx> ExportRecorder<'a, 'b, 'tcx> {
         }
     }
 
-    fn add_exports_of_namebindings(&mut self,
-                                   exports: &mut Vec<Export>,
-                                   name: ast::Name,
-                                   namebindings: &NameBindings,
-                                   ns: Namespace) {
-        match namebindings.def_for_namespace(ns) {
+    fn add_export_of_namebinding(&mut self,
+                                 exports: &mut Vec<Export>,
+                                 name: ast::Name,
+                                 namebinding: &NameBinding) {
+        match namebinding.def() {
             Some(d) => {
                 debug!("(computing exports) YES: export '{}' => {:?}",
                        name,
@@ -139,7 +138,7 @@ impl<'a, 'b, 'tcx> ExportRecorder<'a, 'b, 'tcx> {
                 match import_resolution.target_for_namespace(ns) {
                     Some(target) => {
                         debug!("(computing exports) maybe export '{}'", name);
-                        self.add_exports_of_namebindings(exports, *name, &*target.bindings, ns)
+                        self.add_export_of_namebinding(exports, *name, &target.binding)
                     }
                     _ => (),
                 }

--- a/src/librustc_resolve/record_exports.rs
+++ b/src/librustc_resolve/record_exports.rs
@@ -54,7 +54,7 @@ impl<'a, 'b, 'tcx> ExportRecorder<'a, 'b, 'tcx> {
         // If this isn't a local krate, then bail out. We don't need to record
         // exports for nonlocal crates.
 
-        match module_.def_id.get() {
+        match module_.def_id() {
             Some(def_id) if def_id.is_local() => {
                 // OK. Continue.
                 debug!("(recording exports for module subtree) recording exports for local \
@@ -98,7 +98,7 @@ impl<'a, 'b, 'tcx> ExportRecorder<'a, 'b, 'tcx> {
         let mut exports = Vec::new();
 
         self.add_exports_for_module(&mut exports, module_);
-        match module_.def_id.get() {
+        match module_.def_id() {
             Some(def_id) => {
                 let node_id = self.ast_map.as_local_node_id(def_id).unwrap();
                 self.export_map.insert(node_id, exports);

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -209,7 +209,7 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
                    i,
                    self.resolver.unresolved_imports);
 
-            let module_root = self.resolver.graph_root.get_module();
+            let module_root = self.resolver.graph_root.clone();
             let errors = self.resolve_imports_for_module_subtree(module_root.clone());
 
             if self.resolver.unresolved_imports == 0 {
@@ -254,7 +254,7 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
 
         build_reduced_graph::populate_module_if_necessary(self.resolver, &module_);
         for (_, child_node) in module_.children.borrow().iter() {
-            match child_node.get_module_if_available() {
+            match child_node.type_ns.module() {
                 None => {
                     // Nothing to do.
                 }
@@ -337,7 +337,7 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
         // First, resolve the module path for the directive, if necessary.
         let container = if module_path.is_empty() {
             // Use the crate root.
-            Some((self.resolver.graph_root.get_module(), LastMod(AllPublic)))
+            Some((self.resolver.graph_root.clone(), LastMod(AllPublic)))
         } else {
             match self.resolver.resolve_module_path(module_.clone(),
                                                     &module_path[..],

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -1039,7 +1039,7 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
         match import_resolution.type_target {
             Some(ref target) if target.shadowable != Shadowable::Always => {
                 if let Some(ref ty) = *name_bindings.type_ns.borrow() {
-                    let (what, note) = match ty.module.clone() {
+                    let (what, note) = match ty.module() {
                         Some(ref module) if module.is_normal() =>
                             ("existing submodule", "note conflicting module here"),
                         Some(ref module) if module.is_trait() =>

--- a/src/test/compile-fail/enum-and-module-in-same-scope.rs
+++ b/src/test/compile-fail/enum-and-module-in-same-scope.rs
@@ -13,7 +13,7 @@ mod Foo {
 }
 
 enum Foo {  //~ ERROR duplicate definition of type or module `Foo`
-    X //~ ERROR duplicate definition of value `X`
+    X
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-21546.rs
+++ b/src/test/compile-fail/issue-21546.rs
@@ -16,7 +16,7 @@ mod Foo { }
 
 #[allow(dead_code)]
 struct Foo;
-//~^ WARNING duplicate definition of type or module `Foo`
+//~^ ERROR duplicate definition of type or module `Foo`
 
 
 #[allow(non_snake_case)]
@@ -25,7 +25,7 @@ mod Bar { }
 
 #[allow(dead_code)]
 struct Bar(i32);
-//~^ WARNING duplicate definition of type or module `Bar`
+//~^ ERROR duplicate definition of type or module `Bar`
 
 
 #[allow(dead_code)]
@@ -34,7 +34,7 @@ struct Baz(i32);
 
 #[allow(non_snake_case)]
 mod Baz { }
-//~^ WARNING duplicate definition of type or module `Baz`
+//~^ ERROR duplicate definition of type or module `Baz`
 
 
 #[allow(dead_code)]
@@ -43,7 +43,7 @@ struct Qux { x: bool }
 
 #[allow(non_snake_case)]
 mod Qux { }
-//~^ WARNING duplicate definition of type or module `Qux`
+//~^ ERROR duplicate definition of type or module `Qux`
 
 
 #[allow(dead_code)]
@@ -52,7 +52,7 @@ struct Quux;
 
 #[allow(non_snake_case)]
 mod Quux { }
-//~^ WARNING duplicate definition of type or module `Quux`
+//~^ ERROR duplicate definition of type or module `Quux`
 
 
 #[allow(dead_code)]


### PR DESCRIPTION
Replace `TypeNsDef` and `ValueNsDef` with a more general type `NsDef`.

Define a newtype `NameBinding` for `Rc<RefCell<Option<NsDef>>>` and refactor `NameBindings` to be a `NameBinding` for each namespace.

Replace uses of `NameBindings` with `NameBinding` where only one binding is being used (in `NamespaceResult`, `Target,` etc).

Refactor away `resolve_definition_of_name_in_module` and `NameDefinition`, fixing issue #4952.
