### PR TITLE
Stricter doctests for corelibs

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -25,7 +25,7 @@ $(eval $(call RUST_CRATE,collectionstest))
 TEST_TARGET_CRATES = $(filter-out core rustc_unicode alloc_system libc \
 		     		  alloc_jemalloc,$(TARGET_CRATES)) \
 			collectionstest coretest
-TEST_DOC_CRATES = $(DOC_CRATES)
+TEST_DOC_CRATES = $(DOC_CRATES) arena
 TEST_HOST_CRATES = $(filter-out rustc_typeck rustc_borrowck rustc_resolve \
 		   		rustc_trans rustc_lint,\
                      $(HOST_CRATES))

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -26,7 +26,7 @@ TEST_TARGET_CRATES = $(filter-out core rustc_unicode alloc_system libc \
 		     		  alloc_jemalloc,$(TARGET_CRATES)) \
 			collectionstest coretest
 TEST_DOC_CRATES = $(DOC_CRATES) arena flate fmt_macros getopts graphviz \
-                log rand rbml
+                log rand rbml serialize
 TEST_HOST_CRATES = $(filter-out rustc_typeck rustc_borrowck rustc_resolve \
 		   		rustc_trans rustc_lint,\
                      $(HOST_CRATES))

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -26,7 +26,7 @@ TEST_TARGET_CRATES = $(filter-out core rustc_unicode alloc_system libc \
 		     		  alloc_jemalloc,$(TARGET_CRATES)) \
 			collectionstest coretest
 TEST_DOC_CRATES = $(DOC_CRATES) arena flate fmt_macros getopts graphviz \
-                log rand rbml serialize
+                log rand rbml serialize syntax
 TEST_HOST_CRATES = $(filter-out rustc_typeck rustc_borrowck rustc_resolve \
 		   		rustc_trans rustc_lint,\
                      $(HOST_CRATES))

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -25,7 +25,8 @@ $(eval $(call RUST_CRATE,collectionstest))
 TEST_TARGET_CRATES = $(filter-out core rustc_unicode alloc_system libc \
 		     		  alloc_jemalloc,$(TARGET_CRATES)) \
 			collectionstest coretest
-TEST_DOC_CRATES = $(DOC_CRATES) arena flate fmt_macros getopts graphviz
+TEST_DOC_CRATES = $(DOC_CRATES) arena flate fmt_macros getopts graphviz \
+                log
 TEST_HOST_CRATES = $(filter-out rustc_typeck rustc_borrowck rustc_resolve \
 		   		rustc_trans rustc_lint,\
                      $(HOST_CRATES))

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -26,7 +26,7 @@ TEST_TARGET_CRATES = $(filter-out core rustc_unicode alloc_system libc \
 		     		  alloc_jemalloc,$(TARGET_CRATES)) \
 			collectionstest coretest
 TEST_DOC_CRATES = $(DOC_CRATES) arena flate fmt_macros getopts graphviz \
-                log rand
+                log rand rbml
 TEST_HOST_CRATES = $(filter-out rustc_typeck rustc_borrowck rustc_resolve \
 		   		rustc_trans rustc_lint,\
                      $(HOST_CRATES))

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -25,7 +25,7 @@ $(eval $(call RUST_CRATE,collectionstest))
 TEST_TARGET_CRATES = $(filter-out core rustc_unicode alloc_system libc \
 		     		  alloc_jemalloc,$(TARGET_CRATES)) \
 			collectionstest coretest
-TEST_DOC_CRATES = $(DOC_CRATES) arena flate fmt_macros
+TEST_DOC_CRATES = $(DOC_CRATES) arena flate fmt_macros getopts
 TEST_HOST_CRATES = $(filter-out rustc_typeck rustc_borrowck rustc_resolve \
 		   		rustc_trans rustc_lint,\
                      $(HOST_CRATES))

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -25,7 +25,7 @@ $(eval $(call RUST_CRATE,collectionstest))
 TEST_TARGET_CRATES = $(filter-out core rustc_unicode alloc_system libc \
 		     		  alloc_jemalloc,$(TARGET_CRATES)) \
 			collectionstest coretest
-TEST_DOC_CRATES = $(DOC_CRATES) arena
+TEST_DOC_CRATES = $(DOC_CRATES) arena flate
 TEST_HOST_CRATES = $(filter-out rustc_typeck rustc_borrowck rustc_resolve \
 		   		rustc_trans rustc_lint,\
                      $(HOST_CRATES))

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -26,7 +26,7 @@ TEST_TARGET_CRATES = $(filter-out core rustc_unicode alloc_system libc \
 		     		  alloc_jemalloc,$(TARGET_CRATES)) \
 			collectionstest coretest
 TEST_DOC_CRATES = $(DOC_CRATES) arena flate fmt_macros getopts graphviz \
-                log rand rbml serialize syntax term
+                log rand rbml serialize syntax term test
 TEST_HOST_CRATES = $(filter-out rustc_typeck rustc_borrowck rustc_resolve \
 		   		rustc_trans rustc_lint,\
                      $(HOST_CRATES))

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -25,7 +25,7 @@ $(eval $(call RUST_CRATE,collectionstest))
 TEST_TARGET_CRATES = $(filter-out core rustc_unicode alloc_system libc \
 		     		  alloc_jemalloc,$(TARGET_CRATES)) \
 			collectionstest coretest
-TEST_DOC_CRATES = $(DOC_CRATES) arena flate
+TEST_DOC_CRATES = $(DOC_CRATES) arena flate fmt_macros
 TEST_HOST_CRATES = $(filter-out rustc_typeck rustc_borrowck rustc_resolve \
 		   		rustc_trans rustc_lint,\
                      $(HOST_CRATES))

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -26,7 +26,7 @@ TEST_TARGET_CRATES = $(filter-out core rustc_unicode alloc_system libc \
 		     		  alloc_jemalloc,$(TARGET_CRATES)) \
 			collectionstest coretest
 TEST_DOC_CRATES = $(DOC_CRATES) arena flate fmt_macros getopts graphviz \
-                log rand rbml serialize syntax
+                log rand rbml serialize syntax term
 TEST_HOST_CRATES = $(filter-out rustc_typeck rustc_borrowck rustc_resolve \
 		   		rustc_trans rustc_lint,\
                      $(HOST_CRATES))

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -25,7 +25,7 @@ $(eval $(call RUST_CRATE,collectionstest))
 TEST_TARGET_CRATES = $(filter-out core rustc_unicode alloc_system libc \
 		     		  alloc_jemalloc,$(TARGET_CRATES)) \
 			collectionstest coretest
-TEST_DOC_CRATES = $(DOC_CRATES) arena flate fmt_macros getopts
+TEST_DOC_CRATES = $(DOC_CRATES) arena flate fmt_macros getopts graphviz
 TEST_HOST_CRATES = $(filter-out rustc_typeck rustc_borrowck rustc_resolve \
 		   		rustc_trans rustc_lint,\
                      $(HOST_CRATES))

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -26,7 +26,7 @@ TEST_TARGET_CRATES = $(filter-out core rustc_unicode alloc_system libc \
 		     		  alloc_jemalloc,$(TARGET_CRATES)) \
 			collectionstest coretest
 TEST_DOC_CRATES = $(DOC_CRATES) arena flate fmt_macros getopts graphviz \
-                log
+                log rand
 TEST_HOST_CRATES = $(filter-out rustc_typeck rustc_borrowck rustc_resolve \
 		   		rustc_trans rustc_lint,\
                      $(HOST_CRATES))

--- a/src/doc/trpl/documentation.md
+++ b/src/doc/trpl/documentation.md
@@ -620,6 +620,18 @@ You can control a few aspects of the HTML that `rustdoc` generates through the
 
 This sets a few different options, with a logo, favicon, and a root URL.
 
+### Configuring documentation tests
+
+You can also configure the way that `rustdoc` tests your documentation examples
+through the `#![doc(test(..))]` attribute.
+
+```rust
+#![doc(test(attr(allow(unused_variables), deny(warnings))))]
+```
+
+This allows unused variables within the examples, but will fail the test for any
+other lint warning thrown.
+
 ## Generation options
 
 `rustdoc` also contains a few other options on the command line, for further customization:

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -70,7 +70,7 @@
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
-       test(no_crate_inject))]
+       test(no_crate_inject, attr(allow(unused_variables), deny(warnings))))]
 #![no_std]
 #![cfg_attr(not(stage0), needs_allocator)]
 

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -28,7 +28,8 @@
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/")]
+       html_root_url = "https://doc.rust-lang.org/nightly/",
+       test(no_crate_inject, attr(deny(warnings))))]
 
 #![feature(alloc)]
 #![feature(box_syntax)]

--- a/src/libcollections/binary_heap.rs
+++ b/src/libcollections/binary_heap.rs
@@ -233,6 +233,7 @@ impl<T: Ord> BinaryHeap<T> {
     ///
     /// ```
     /// #![feature(binary_heap_extras)]
+    /// # #![allow(deprecated)]
     ///
     /// use std::collections::BinaryHeap;
     /// let heap = BinaryHeap::from_vec(vec![9, 1, 2, 7, 3, 2]);

--- a/src/libcollections/borrow.rs
+++ b/src/libcollections/borrow.rs
@@ -72,6 +72,7 @@ impl<T> ToOwned for T where T: Clone {
 /// ```
 /// use std::borrow::Cow;
 ///
+/// # #[allow(dead_code)]
 /// fn abs_all(input: &mut Cow<[i32]>) {
 ///     for i in 0..input.len() {
 ///         let v = input[i];

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -89,6 +89,7 @@ impl<T: Ord> BTreeSet<T> {
     /// # Examples
     ///
     /// ```
+    /// # #![allow(unused_mut)]
     /// use std::collections::BTreeSet;
     ///
     /// let mut set: BTreeSet<i32> = BTreeSet::new();

--- a/src/libcollections/fmt.rs
+++ b/src/libcollections/fmt.rs
@@ -150,6 +150,7 @@
 //! implement a method of the signature:
 //!
 //! ```
+//! # #![allow(dead_code)]
 //! # use std::fmt;
 //! # struct Foo; // our custom type
 //! # impl fmt::Display for Foo {
@@ -174,7 +175,6 @@
 //! like:
 //!
 //! ```
-//! #![feature(fmt_flags)]
 //! use std::fmt;
 //!
 //! #[derive(Debug)]
@@ -288,6 +288,7 @@
 //! off, some example usage is:
 //!
 //! ```
+//! # #![allow(unused_must_use)]
 //! use std::fmt;
 //! use std::io::{self, Write};
 //!

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -27,7 +27,7 @@
        html_root_url = "https://doc.rust-lang.org/nightly/",
        html_playground_url = "https://play.rust-lang.org/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
-       test(no_crate_inject))]
+       test(no_crate_inject, attr(allow(unused_variables), deny(warnings))))]
 
 #![allow(trivial_casts)]
 #![cfg_attr(test, allow(deprecated))] // rand

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -852,6 +852,7 @@ pub trait SliceConcatExt<T: ?Sized> {
     /// # Examples
     ///
     /// ```
+    /// # #![allow(deprecated)]
     /// assert_eq!(["hello", "world"].connect(" "), "hello world");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -298,7 +298,7 @@ impl str {
     /// done by `.chars()` or `.char_indices()`.
     ///
     /// ```
-    /// #![feature(str_char, core)]
+    /// #![feature(str_char)]
     ///
     /// use std::str::CharRange;
     ///
@@ -358,7 +358,7 @@ impl str {
     /// done by `.chars().rev()` or `.char_indices()`.
     ///
     /// ```
-    /// #![feature(str_char, core)]
+    /// #![feature(str_char)]
     ///
     /// use std::str::CharRange;
     ///
@@ -634,6 +634,7 @@ impl str {
     /// # Examples
     ///
     /// ```
+    /// # #![allow(deprecated)]
     /// let four_lines = "foo\r\nbar\n\r\nbaz";
     /// let v: Vec<&str> = four_lines.lines_any().collect();
     ///
@@ -643,6 +644,7 @@ impl str {
     /// Leaving off the trailing character:
     ///
     /// ```
+    /// # #![allow(deprecated)]
     /// let four_lines = "foo\r\nbar\n\r\nbaz\n";
     /// let v: Vec<&str> = four_lines.lines_any().collect();
     ///
@@ -1179,8 +1181,6 @@ impl str {
     /// # Examples
     ///
     /// ```
-    /// #![feature(str_match_indices)]
-    ///
     /// let v: Vec<_> = "abcXXXabcYYYabc".match_indices("abc").collect();
     /// assert_eq!(v, [(0, "abc"), (6, "abc"), (12, "abc")]);
     ///
@@ -1216,8 +1216,6 @@ impl str {
     /// # Examples
     ///
     /// ```
-    /// #![feature(str_match_indices)]
-    ///
     /// let v: Vec<_> = "abcXXXabcYYYabc".rmatch_indices("abc").collect();
     /// assert_eq!(v, [(12, "abc"), (6, "abc"), (0, "abc")]);
     ///

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -55,6 +55,7 @@ impl String {
     /// # Examples
     ///
     /// ```
+    /// # #![allow(unused_mut)]
     /// let mut s = String::new();
     /// ```
     #[inline]
@@ -73,6 +74,20 @@ impl String {
     ///
     /// ```
     /// let mut s = String::with_capacity(10);
+    ///
+    /// // The String contains no chars, even though it has capacity for more
+    /// assert_eq!(s.len(), 0);
+    ///
+    /// // These are all done without reallocating...
+    /// let cap = s.capacity();
+    /// for i in 0..10 {
+    ///     s.push('a');
+    /// }
+    ///
+    /// assert_eq!(s.capacity(), cap);
+    ///
+    /// // ...but this may make the vector reallocate
+    /// s.push('a');
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -242,6 +242,7 @@ impl<T> Vec<T> {
     /// # Examples
     ///
     /// ```
+    /// # #![allow(unused_mut)]
     /// let mut vec: Vec<i32> = Vec::new();
     /// ```
     #[inline]

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -76,6 +76,7 @@
 //! a trait method that was originally defined to take `&self`.
 //!
 //! ```
+//! # #![allow(dead_code)]
 //! use std::cell::RefCell;
 //!
 //! struct Graph {
@@ -125,6 +126,7 @@
 //! }
 //!
 //! struct RcBox<T> {
+//! # #[allow(dead_code)]
 //!     value: T,
 //!     refcount: Cell<usize>
 //! }
@@ -776,6 +778,7 @@ impl<'b, T: ?Sized> DerefMut for RefMut<'b, T> {
 /// use std::cell::UnsafeCell;
 /// use std::marker::Sync;
 ///
+/// # #[allow(dead_code)]
 /// struct NotThreadSafe<T> {
 ///     value: UnsafeCell<T>,
 /// }

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -140,8 +140,6 @@ impl Ordering {
     /// This method can be used to reverse a comparison:
     ///
     /// ```
-    /// use std::cmp::Ordering;
-    ///
     /// let mut data: &mut [_] = &mut [2, 10, 5, 8];
     ///
     /// // sort the array from largest to smallest.
@@ -263,8 +261,6 @@ pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
     /// # Examples
     ///
     /// ```
-    /// use std::cmp::Ordering;
-    ///
     /// let result = 1.0 < 2.0;
     /// assert_eq!(result, true);
     ///

--- a/src/libcore/default.rs
+++ b/src/libcore/default.rs
@@ -15,6 +15,7 @@
 //! that define a set of options:
 //!
 //! ```
+//! # #[allow(dead_code)]
 //! struct SomeOptions {
 //!     foo: i32,
 //!     bar: f32,
@@ -24,6 +25,7 @@
 //! How can we define some default values? You can use `Default`:
 //!
 //! ```
+//! # #[allow(dead_code)]
 //! #[derive(Default)]
 //! struct SomeOptions {
 //!     foo: i32,
@@ -40,6 +42,7 @@
 //! If you have your own type, you need to implement `Default` yourself:
 //!
 //! ```
+//! # #![allow(dead_code)]
 //! enum Kind {
 //!     A,
 //!     B,
@@ -66,6 +69,7 @@
 //! If you want to override a particular option, but still retain the other defaults:
 //!
 //! ```
+//! # #[allow(dead_code)]
 //! # #[derive(Default)]
 //! # struct SomeOptions {
 //! #     foo: i32,
@@ -88,6 +92,7 @@ use marker::Sized;
 /// # Examples
 ///
 /// ```
+/// # #[allow(dead_code)]
 /// #[derive(Default)]
 /// struct SomeOptions {
 ///     foo: i32,
@@ -114,6 +119,7 @@ pub trait Default: Sized {
     /// Making your own:
     ///
     /// ```
+    /// # #[allow(dead_code)]
     /// enum Kind {
     ///     A,
     ///     B,

--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -45,6 +45,7 @@
 //!
 //! struct Person {
 //!     id: u32,
+//! # #[allow(dead_code)]
 //!     name: String,
 //!     phone: u64,
 //! }

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -334,6 +334,7 @@ extern "rust-intrinsic" {
     /// use std::mem;
     /// use std::ptr;
     ///
+    /// # #[allow(dead_code)]
     /// fn swap<T>(x: &mut T, y: &mut T) {
     ///     unsafe {
     ///         // Give ourselves some scratch space to work with
@@ -372,6 +373,7 @@ extern "rust-intrinsic" {
     /// ```
     /// use std::ptr;
     ///
+    /// # #[allow(dead_code)]
     /// unsafe fn from_buf_raw<T>(ptr: *const T, elts: usize) -> Vec<T> {
     ///     let mut dst = Vec::with_capacity(elts);
     ///     dst.set_len(elts);

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -241,6 +241,7 @@
 //! method calls a closure on each element it iterates over:
 //!
 //! ```
+//! # #![allow(unused_must_use)]
 //! let v = vec![1, 2, 3, 4, 5];
 //! v.iter().map(|x| println!("{}", x));
 //! ```
@@ -419,7 +420,7 @@ pub trait Iterator {
     ///
     /// ```
     /// // an infinite iterator has no upper bound
-    /// let iter = (0..);
+    /// let iter = 0..;
     ///
     /// assert_eq!((0, None), iter.size_hint());
     /// ```
@@ -709,6 +710,7 @@ pub trait Iterator {
     /// If you're doing some sort of side effect, prefer [`for`] to `map()`:
     ///
     /// ```
+    /// # #![allow(unused_must_use)]
     /// // don't do this:
     /// (0..5).map(|x| println!("{}", x));
     ///
@@ -2695,7 +2697,7 @@ impl<'a, I: DoubleEndedIterator + ?Sized> DoubleEndedIterator for &'a mut I {
 ///
 /// ```
 /// // a finite range knows exactly how many times it will iterate
-/// let five = (0..5);
+/// let five = 0..5;
 ///
 /// assert_eq!(5, five.len());
 /// ```
@@ -2761,7 +2763,7 @@ pub trait ExactSizeIterator: Iterator {
     ///
     /// ```
     /// // a finite range knows exactly how many times it will iterate
-    /// let five = (0..5);
+    /// let five = 0..5;
     ///
     /// assert_eq!(5, five.len());
     /// ```

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -60,7 +60,7 @@
        html_root_url = "https://doc.rust-lang.org/nightly/",
        html_playground_url = "https://play.rust-lang.org/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/")]
-#![doc(test(no_crate_inject))]
+#![doc(test(no_crate_inject, attr(allow(unused_variables), deny(warnings))))]
 
 #![no_core]
 #![allow(raw_pointer_derive)]

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -247,6 +247,7 @@ macro_rules! writeln {
 /// Match arms:
 ///
 /// ```
+/// # #[allow(dead_code)]
 /// fn foo(x: Option<i32>) {
 ///     match x {
 ///         Some(n) if n >= 0 => println!("Some(Non-negative)"),
@@ -260,6 +261,7 @@ macro_rules! writeln {
 /// Iterators:
 ///
 /// ```
+/// # #[allow(dead_code)]
 /// fn divide_by_three(x: u32) -> u32 { // one of the poorest implementations of x/3
 ///     for i in 0.. {
 ///         if 3*i < i { panic!("u32 overflow"); }

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -42,6 +42,7 @@ impl<T> !Send for *mut T { }
 /// `?Sized` can be used to remove this bound if it is not appropriate.
 ///
 /// ```
+/// # #![allow(dead_code)]
 /// struct Foo<T>(T);
 /// struct Bar<T: ?Sized>(T);
 ///
@@ -106,6 +107,7 @@ pub trait Unsize<T: ?Sized> {
 /// `struct` can be `Copy`:
 ///
 /// ```
+/// # #[allow(dead_code)]
 /// struct Point {
 ///    x: i32,
 ///    y: i32,
@@ -115,6 +117,7 @@ pub trait Unsize<T: ?Sized> {
 /// A `struct` can be `Copy`, and `i32` is `Copy`, so therefore, `Point` is eligible to be `Copy`.
 ///
 /// ```
+/// # #![allow(dead_code)]
 /// # struct Point;
 /// struct PointList {
 ///     points: Vec<Point>,
@@ -303,6 +306,7 @@ macro_rules! impls{
 /// ```
 /// use std::marker::PhantomData;
 ///
+/// # #[allow(dead_code)]
 /// struct Slice<'a, T:'a> {
 ///     start: *const T,
 ///     end: *const T,
@@ -323,6 +327,7 @@ macro_rules! impls{
 /// mismatches by enforcing types in the method implementations:
 ///
 /// ```
+/// # #![allow(dead_code)]
 /// # trait ResType { fn foo(&self); }
 /// # struct ParamType;
 /// # mod foreign_lib {
@@ -393,6 +398,8 @@ mod impls {
 /// #![feature(reflect_marker)]
 /// use std::marker::Reflect;
 /// use std::any::Any;
+///
+/// # #[allow(dead_code)]
 /// fn foo<T:Reflect+'static>(x: &T) {
 ///     let any: &Any = x;
 ///     if any.is::<u32>() { println!("u32"); }

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -92,6 +92,7 @@ pub use intrinsics::transmute;
 /// use std::mem;
 /// use std::ptr;
 ///
+/// # #[allow(dead_code)]
 /// fn swap<T>(x: &mut T, y: &mut T) {
 ///     unsafe {
 ///         // Give ourselves some scratch space to work with
@@ -151,6 +152,7 @@ pub fn size_of_val<T: ?Sized>(val: &T) -> usize {
 /// # Examples
 ///
 /// ```
+/// # #![allow(deprecated)]
 /// use std::mem;
 ///
 /// assert_eq!(4, mem::min_align_of::<i32>());
@@ -167,6 +169,7 @@ pub fn min_align_of<T>() -> usize {
 /// # Examples
 ///
 /// ```
+/// # #![allow(deprecated)]
 /// use std::mem;
 ///
 /// assert_eq!(4, mem::min_align_of_val(&5i32));
@@ -414,6 +417,7 @@ pub fn swap<T>(x: &mut T, y: &mut T) {
 /// `self`, allowing it to be returned:
 ///
 /// ```
+/// # #![allow(dead_code)]
 /// use std::mem;
 /// # struct Buffer<T> { buf: Vec<T> }
 /// impl<T> Buffer<T> {

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -947,6 +947,7 @@ shr_impl_all! { u8 u16 u32 u64 usize i8 i16 i32 i64 isize }
 ///     }
 /// }
 ///
+/// # #[allow(unused_assignments)]
 /// fn main() {
 ///     let mut foo = Foo;
 ///     foo += Foo;
@@ -996,6 +997,7 @@ add_assign_impl! { usize u8 u16 u32 u64 isize i8 i16 i32 i64 f32 f64 }
 ///     }
 /// }
 ///
+/// # #[allow(unused_assignments)]
 /// fn main() {
 ///     let mut foo = Foo;
 ///     foo -= Foo;
@@ -1045,6 +1047,7 @@ sub_assign_impl! { usize u8 u16 u32 u64 isize i8 i16 i32 i64 f32 f64 }
 ///     }
 /// }
 ///
+/// # #[allow(unused_assignments)]
 /// fn main() {
 ///     let mut foo = Foo;
 ///     foo *= Foo;
@@ -1094,6 +1097,7 @@ mul_assign_impl! { usize u8 u16 u32 u64 isize i8 i16 i32 i64 f32 f64 }
 ///     }
 /// }
 ///
+/// # #[allow(unused_assignments)]
 /// fn main() {
 ///     let mut foo = Foo;
 ///     foo /= Foo;
@@ -1143,6 +1147,7 @@ div_assign_impl! { usize u8 u16 u32 u64 isize i8 i16 i32 i64 f32 f64 }
 ///     }
 /// }
 ///
+/// # #[allow(unused_assignments)]
 /// fn main() {
 ///     let mut foo = Foo;
 ///     foo %= Foo;
@@ -1192,6 +1197,7 @@ rem_assign_impl! { usize u8 u16 u32 u64 isize i8 i16 i32 i64 f32 f64 }
 ///     }
 /// }
 ///
+/// # #[allow(unused_assignments)]
 /// fn main() {
 ///     let mut foo = Foo;
 ///     foo &= Foo;
@@ -1241,6 +1247,7 @@ bitand_assign_impl! { bool usize u8 u16 u32 u64 isize i8 i16 i32 i64 }
 ///     }
 /// }
 ///
+/// # #[allow(unused_assignments)]
 /// fn main() {
 ///     let mut foo = Foo;
 ///     foo |= Foo;
@@ -1290,6 +1297,7 @@ bitor_assign_impl! { bool usize u8 u16 u32 u64 isize i8 i16 i32 i64 }
 ///     }
 /// }
 ///
+/// # #[allow(unused_assignments)]
 /// fn main() {
 ///     let mut foo = Foo;
 ///     foo ^= Foo;
@@ -1339,6 +1347,7 @@ bitxor_assign_impl! { bool usize u8 u16 u32 u64 isize i8 i16 i32 i64 }
 ///     }
 /// }
 ///
+/// # #[allow(unused_assignments)]
 /// fn main() {
 ///     let mut foo = Foo;
 ///     foo <<= Foo;
@@ -1407,6 +1416,7 @@ shl_assign_impl_all! { u8 u16 u32 u64 usize i8 i16 i32 i64 isize }
 ///     }
 /// }
 ///
+/// # #[allow(unused_assignments)]
 /// fn main() {
 ///     let mut foo = Foo;
 ///     foo >>= Foo;

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -275,6 +275,7 @@ impl<T> Option<T> {
     ///
     /// ```
     /// #![feature(as_slice)]
+    /// # #![allow(deprecated)]
     ///
     /// let mut x = Some("Diamonds");
     /// {

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -16,6 +16,7 @@
 //! and containing an error value.
 //!
 //! ```
+//! # #[allow(dead_code)]
 //! enum Result<T, E> {
 //!    Ok(T),
 //!    Err(E)
@@ -104,6 +105,7 @@
 //! something like this:
 //!
 //! ```no_run
+//! # #![allow(unused_must_use)] // \o/
 //! use std::fs::File;
 //! use std::io::prelude::*;
 //!
@@ -143,6 +145,7 @@
 //! # use std::fs::File;
 //! # use std::io::prelude::*;
 //! # use std::io;
+//! # #[allow(dead_code)]
 //! fn write_message() -> io::Result<()> {
 //!     let mut file = try!(File::create("valuable_data.txt"));
 //!     try!(file.write_all(b"important message"));
@@ -160,6 +163,7 @@
 //! It replaces this:
 //!
 //! ```
+//! # #![allow(dead_code)]
 //! use std::fs::File;
 //! use std::io::prelude::*;
 //! use std::io;
@@ -189,6 +193,7 @@
 //! With this:
 //!
 //! ```
+//! # #![allow(dead_code)]
 //! use std::fs::File;
 //! use std::io::prelude::*;
 //! use std::io;
@@ -422,6 +427,7 @@ impl<T, E> Result<T, E> {
     ///
     /// ```
     /// #![feature(as_slice)]
+    /// # #![allow(deprecated)]
     ///
     /// let mut x: Result<&str, u32> = Ok("Gold");
     /// {

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -142,8 +142,6 @@ impl Utf8Error {
     /// Basic usage:
     ///
     /// ```
-    /// #![feature(utf8_error)]
-    ///
     /// use std::str;
     ///
     /// // some invalid bytes, in a vector

--- a/src/libflate/lib.rs
+++ b/src/libflate/lib.rs
@@ -23,7 +23,8 @@
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/")]
+       html_root_url = "https://doc.rust-lang.org/nightly/",
+       test(attr(deny(warnings))))]
 
 #![feature(libc)]
 #![feature(staged_api)]

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -24,7 +24,8 @@
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/",
-       html_playground_url = "https://play.rust-lang.org/")]
+       html_playground_url = "https://play.rust-lang.org/",
+       test(attr(deny(warnings))))]
 
 #![feature(staged_api)]
 #![feature(unicode)]

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -30,9 +30,11 @@
 //! file name following `-o`, and accepts both `-h` and `--help` as optional flags.
 //!
 //! ```{.rust}
+//! #![feature(rustc_private)]
+//!
 //! extern crate getopts;
 //! use getopts::{optopt,optflag,getopts,OptGroup,usage};
-//! use std::os;
+//! use std::env;
 //!
 //! fn do_work(inp: &str, out: Option<String>) {
 //!     println!("{}", inp);
@@ -44,11 +46,11 @@
 //!
 //! fn print_usage(program: &str, opts: &[OptGroup]) {
 //!     let brief = format!("Usage: {} [options]", program);
-//!     print!("{}", usage(brief, opts));
+//!     print!("{}", usage(&brief, opts));
 //! }
 //!
 //! fn main() {
-//!     let args: Vec<String> = os::args();
+//!     let args: Vec<String> = env::args().collect();
 //!
 //!     let program = args[0].clone();
 //!
@@ -56,22 +58,22 @@
 //!         optopt("o", "", "set output file name", "NAME"),
 //!         optflag("h", "help", "print this help menu")
 //!     ];
-//!     let matches = match getopts(args[1..], opts) {
+//!     let matches = match getopts(&args[1..], opts) {
 //!         Ok(m) => { m }
 //!         Err(f) => { panic!(f.to_string()) }
 //!     };
 //!     if matches.opt_present("h") {
-//!         print_usage(program, opts);
+//!         print_usage(&program, opts);
 //!         return;
 //!     }
 //!     let output = matches.opt_str("o");
 //!     let input = if !matches.free.is_empty() {
 //!         matches.free[0].clone()
 //!     } else {
-//!         print_usage(program, opts);
+//!         print_usage(&program, opts);
 //!         return;
 //!     };
-//!     do_work(input, output);
+//!     do_work(&input, output);
 //! }
 //! ```
 
@@ -88,7 +90,8 @@
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/",
-       html_playground_url = "https://play.rust-lang.org/")]
+       html_playground_url = "https://play.rust-lang.org/",
+       test(attr(deny(warnings))))]
 
 #![deny(missing_docs)]
 #![feature(staged_api)]

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -47,7 +47,7 @@
 //! which is cyclic.
 //!
 //! ```rust
-//! #![feature(rustc_private, core, into_cow)]
+//! #![feature(rustc_private, into_cow)]
 //!
 //! use std::borrow::IntoCow;
 //! use std::io::Write;
@@ -150,9 +150,8 @@
 //! entity `&sube`).
 //!
 //! ```rust
-//! #![feature(rustc_private, core, into_cow)]
+//! #![feature(rustc_private)]
 //!
-//! use std::borrow::IntoCow;
 //! use std::io::Write;
 //! use graphviz as dot;
 //!
@@ -174,10 +173,10 @@
 //!         dot::Id::new(format!("N{}", n)).unwrap()
 //!     }
 //!     fn node_label<'b>(&'b self, n: &Nd) -> dot::LabelText<'b> {
-//!         dot::LabelText::LabelStr(self.nodes[*n].as_slice().into_cow())
+//!         dot::LabelText::LabelStr(self.nodes[*n].into())
 //!     }
 //!     fn edge_label<'b>(&'b self, _: &Ed) -> dot::LabelText<'b> {
-//!         dot::LabelText::LabelStr("&sube;".into_cow())
+//!         dot::LabelText::LabelStr("&sube;".into())
 //!     }
 //! }
 //!
@@ -209,9 +208,8 @@
 //! Hasse-diagram for the subsets of the set `{x, y}`.
 //!
 //! ```rust
-//! #![feature(rustc_private, core, into_cow)]
+//! #![feature(rustc_private)]
 //!
-//! use std::borrow::IntoCow;
 //! use std::io::Write;
 //! use graphviz as dot;
 //!
@@ -234,10 +232,10 @@
 //!     }
 //!     fn node_label<'b>(&'b self, n: &Nd<'b>) -> dot::LabelText<'b> {
 //!         let &(i, _) = n;
-//!         dot::LabelText::LabelStr(self.nodes[i].into_cow())
+//!         dot::LabelText::LabelStr(self.nodes[i].into())
 //!     }
 //!     fn edge_label<'b>(&'b self, _: &Ed<'b>) -> dot::LabelText<'b> {
-//!         dot::LabelText::LabelStr("&sube;".into_cow())
+//!         dot::LabelText::LabelStr("&sube;".into())
 //!     }
 //! }
 //!
@@ -283,7 +281,8 @@
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/")]
+       html_root_url = "https://doc.rust-lang.org/nightly/",
+       test(attr(allow(unused_variables), deny(warnings))))]
 
 #![feature(into_cow)]
 #![feature(str_escape)]

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -13,6 +13,7 @@
 //! # Examples
 //!
 //! ```
+//! # #![feature(rustc_private)]
 //! #[macro_use] extern crate log;
 //!
 //! fn main() {
@@ -167,7 +168,8 @@
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/",
-       html_playground_url = "https://play.rust-lang.org/")]
+       html_playground_url = "https://play.rust-lang.org/",
+       test(attr(deny(warnings))))]
 #![deny(missing_docs)]
 
 #![feature(box_syntax)]

--- a/src/liblog/macros.rs
+++ b/src/liblog/macros.rs
@@ -19,6 +19,7 @@
 /// # Examples
 ///
 /// ```
+/// # #![feature(rustc_private)]
 /// #[macro_use] extern crate log;
 ///
 /// fn main() {
@@ -67,6 +68,7 @@ macro_rules! log {
 /// # Examples
 ///
 /// ```
+/// # #![feature(rustc_private)]
 /// #[macro_use] extern crate log;
 ///
 /// fn main() {
@@ -92,6 +94,7 @@ macro_rules! error {
 /// # Examples
 ///
 /// ```
+/// # #![feature(rustc_private)]
 /// #[macro_use] extern crate log;
 ///
 /// fn main() {
@@ -116,6 +119,7 @@ macro_rules! warn {
 /// # Examples
 ///
 /// ```
+/// # #![feature(rustc_private)]
 /// #[macro_use] extern crate log;
 ///
 /// fn main() {
@@ -142,6 +146,7 @@ macro_rules! info {
 /// # Examples
 ///
 /// ```
+/// # #![feature(rustc_private)]
 /// #[macro_use] extern crate log;
 ///
 /// fn main() {
@@ -165,9 +170,10 @@ macro_rules! debug {
 /// # Examples
 ///
 /// ```
+/// # #![feature(rustc_private)]
 /// #[macro_use] extern crate log;
 ///
-/// struct Point { x: int, y: int }
+/// struct Point { x: i32, y: i32 }
 /// fn some_expensive_computation() -> Point { Point { x: 1, y: 2 } }
 ///
 /// fn main() {

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -23,7 +23,8 @@
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/",
-       html_playground_url = "https://play.rust-lang.org/")]
+       html_playground_url = "https://play.rust-lang.org/",
+       test(attr(deny(warnings))))]
 #![no_std]
 #![staged_api]
 #![unstable(feature = "rand",

--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -121,7 +121,8 @@
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/",
-       html_playground_url = "https://play.rust-lang.org/")]
+       html_playground_url = "https://play.rust-lang.org/",
+       test(attr(deny(warnings))))]
 
 #![feature(rustc_private)]
 #![feature(staged_api)]

--- a/src/librustc_unicode/lib.rs
+++ b/src/librustc_unicode/lib.rs
@@ -31,7 +31,7 @@
        html_root_url = "https://doc.rust-lang.org/nightly/",
        html_playground_url = "https://play.rust-lang.org/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
-       test(no_crate_inject))]
+       test(no_crate_inject, attr(allow(unused_variables), deny(warnings))))]
 #![no_std]
 
 #![feature(core_char_ext)]

--- a/src/librustc_unicode/u_str.rs
+++ b/src/librustc_unicode/u_str.rs
@@ -190,6 +190,7 @@ impl<'a> Iterator for Utf16Items<'a> {
 ///
 /// ```
 /// #![feature(unicode, decode_utf16)]
+/// # #![allow(deprecated)]
 ///
 /// extern crate rustc_unicode;
 ///

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -77,8 +77,9 @@
 //! serialization API, using the derived serialization code.
 //!
 //! ```rust
-//! extern crate serialize;
-//! use serialize::json;
+//! # #![feature(rustc_private)]
+//! extern crate serialize as rustc_serialize; // for the deriving below
+//! use rustc_serialize::json;
 //!
 //! // Automatically generate `Decodable` and `Encodable` trait implementations
 //! #[derive(RustcDecodable, RustcEncodable)]
@@ -111,6 +112,7 @@
 //! ### Simple example of `ToJson` usage
 //!
 //! ```rust
+//! # #![feature(rustc_private)]
 //! extern crate serialize;
 //! use serialize::json::{self, ToJson, Json};
 //!
@@ -150,6 +152,7 @@
 //! ### Verbose example of `ToJson` usage
 //!
 //! ```rust
+//! # #![feature(rustc_private)]
 //! extern crate serialize;
 //! use std::collections::BTreeMap;
 //! use serialize::json::{self, Json, ToJson};
@@ -185,7 +188,7 @@
 //!     let json_str: String = json_obj.to_string();
 //!
 //!     // Deserialize like before
-//!     let decoded: TestStruct = json::decode(json_str)).unwrap();
+//!     let decoded: TestStruct = json::decode(&json_str).unwrap();
 //! }
 //! ```
 

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -26,7 +26,8 @@ Core encoding and decoding interfaces.
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/",
-       html_playground_url = "https://play.rust-lang.org/")]
+       html_playground_url = "https://play.rust-lang.org/",
+       test(attr(allow(unused_variables), deny(warnings))))]
 
 #![feature(box_syntax)]
 #![feature(collections)]

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -908,13 +908,15 @@ pub enum Expr_ {
 /// separately. `position` represents the index of the associated
 /// item qualified with this Self type.
 ///
-///     <Vec<T> as a::b::Trait>::AssociatedItem
-///      ^~~~~     ~~~~~~~~~~~~~~^
-///      ty        position = 3
+/// ```ignore
+/// <Vec<T> as a::b::Trait>::AssociatedItem
+///  ^~~~~     ~~~~~~~~~~~~~~^
+///  ty        position = 3
 ///
-///     <Vec<T>>::AssociatedItem
-///      ^~~~~    ^
-///      ty       position = 0
+/// <Vec<T>>::AssociatedItem
+///  ^~~~~    ^
+///  ty       position = 0
+/// ```
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct QSelf {
     pub ty: P<Ty>,

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -54,6 +54,7 @@
 //! following snippet
 //!
 //! ```rust
+//! # #![allow(dead_code)]
 //! struct A { x : i32 }
 //!
 //! struct B(i32);
@@ -88,7 +89,7 @@
 //!
 //! ```rust
 //! trait PartialEq {
-//!     fn eq(&self, other: &Self);
+//!     fn eq(&self, other: &Self) -> bool;
 //! }
 //! impl PartialEq for i32 {
 //!     fn eq(&self, other: &i32) -> bool {
@@ -905,7 +906,7 @@ impl<'a> MethodDef<'a> {
         })
     }
 
-    /// ```
+    /// ```ignore
     /// #[derive(PartialEq)]
     /// struct A { x: i32, y: i32 }
     ///
@@ -1010,7 +1011,7 @@ impl<'a> MethodDef<'a> {
                                       &StaticStruct(struct_def, summary))
     }
 
-    /// ```
+    /// ```ignore
     /// #[derive(PartialEq)]
     /// enum A {
     ///     A1,
@@ -1596,7 +1597,7 @@ pub fn cs_fold<F>(use_foldl: bool,
 /// Call the method that is being derived on all the fields, and then
 /// process the collected results. i.e.
 ///
-/// ```
+/// ```ignore
 /// f(cx, span, vec![self_1.method(__arg_1_1, __arg_2_1),
 ///                  self_2.method(__arg_1_2, __arg_2_2)])
 /// ```

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -77,9 +77,10 @@ struct Context<'a, 'b:'a> {
 /// expressions.
 ///
 /// If parsing succeeds, the return value is:
-///
-///     Some((fmtstr, unnamed arguments, ordering of named arguments,
-///           named arguments))
+/// ```ignore
+/// Some((fmtstr, unnamed arguments, ordering of named arguments,
+///       named arguments))
+/// ```
 fn parse_args(ecx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
               -> Option<(P<ast::Expr>, Vec<P<ast::Expr>>, Vec<String>,
                          HashMap<String, P<ast::Expr>>)> {

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -23,7 +23,8 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/")]
+       html_root_url = "https://doc.rust-lang.org/nightly/",
+       test(attr(deny(warnings))))]
 
 #![feature(associated_consts)]
 #![feature(drain)]

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3965,7 +3965,7 @@ impl<'a> Parser<'a> {
 
     /// Parses an optional `where` clause and places it in `generics`.
     ///
-    /// ```
+    /// ```ignore
     /// where T : Trait<U, V> + 'b, 'a : 'b
     /// ```
     pub fn parse_where_clause(&mut self) -> PResult<ast::WhereClause> {

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -11,8 +11,10 @@
 //! This pretty-printer is a direct reimplementation of Philip Karlton's
 //! Mesa pretty-printer, as described in appendix A of
 //!
-//!     STAN-CS-79-770: "Pretty Printing", by Derek C. Oppen.
-//!     Stanford Department of Computer Science, 1979.
+//! ````ignore
+//! STAN-CS-79-770: "Pretty Printing", by Derek C. Oppen.
+//! Stanford Department of Computer Science, 1979.
+//! ````
 //!
 //! The algorithm's aim is to break a stream into as few lines as possible
 //! while respecting the indentation-consistency requirements of the enclosing

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -53,7 +53,8 @@
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/",
-       html_playground_url = "https://play.rust-lang.org/")]
+       html_playground_url = "https://play.rust-lang.org/",
+       test(attr(deny(warnings))))]
 #![deny(missing_docs)]
 
 #![feature(box_syntax)]

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -32,7 +32,8 @@
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/")]
+       html_root_url = "https://doc.rust-lang.org/nightly/",
+       test(attr(deny(warnings))))]
 
 #![feature(asm)]
 #![feature(box_syntax)]


### PR DESCRIPTION
Did this alphabetically, so I didn't see [how `std` was doing things](https://dxr.mozilla.org/rust/source/src/libstd/lib.rs#215) till I was nearly finished. If you prefer to add crate-level-whitelists like std instead of test-level, I can rebase with that strategy.

A number of these commits can probably be dropped as the crates don't have much to test, and are deprecated. Let me know which if any to drop! (can also squash after review if desired)

r? @steveklabnik 
