### PR TITLE
resolve: don't speculatively create freevars when resolving

### DIFF
--- a/src/test/run-pass/issue-29522.rs
+++ b/src/test/run-pass/issue-29522.rs
@@ -1,0 +1,25 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// check that we don't accidentally capture upvars just because their name
+// occurs in a path
+
+fn assert_static<T: 'static>(_t: T) {}
+
+mod foo {
+    pub fn scope() {}
+}
+
+fn main() {
+    let scope = &mut 0;
+    assert_static(|| {
+       foo::scope();
+    });
+}

--- a/src/test/run-pass/resolve-pseudo-shadowing.rs
+++ b/src/test/run-pass/resolve-pseudo-shadowing.rs
@@ -1,0 +1,20 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// check that type parameters can't "shadow" qualified paths.
+
+fn check<Clone>(_c: Clone) {
+    fn check2() {
+        <() as std::clone::Clone>::clone(&());
+    }
+    check2();
+}
+
+fn main() { check(()); }


### PR DESCRIPTION
`resolve_identifier` used to mark a variable as an upvar when used within a closure. However, the function is also used for the "unnecessary qualification" lint, which would mark paths whose last component had the same name as a local as upvars.

Fixes #29522 

r? @eddyb 
