### PR TITLE
Various cleanups to doc index

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -22,14 +22,14 @@
 # L10N_LANGS are the languages for which the docs have been
 # translated.
 ######################################################################
-DOCS := index intro tutorial \
+DOCS := index \
     complement-lang-faq complement-design-faq complement-project-faq \
     rustdoc reference grammar
 
 # Legacy guides, preserved for a while to reduce the number of 404s
 DOCS += guide-crates guide-error-handling guide-ffi guide-macros guide \
     guide-ownership guide-plugins guide-pointers guide-strings guide-tasks \
-    guide-testing
+    guide-testing tutorial intro
 
 
 RUSTDOC_DEPS_reference := doc/full-toc.inc

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -31,6 +31,13 @@ library](std/index.html). There's a list of crates on the left with more
 specific sections, or you can use the search bar at the top to search for
 something if you know its name.
 
+# The Rustonomicon
+
+[The Rustonomicon] is an entire book dedicated dedicated to explaining
+how to write `unsafe` Rust code. It is for advanced Rust programmers.
+
+[The Rustonomicon]: nomicon/index.html
+
 # Tools
 
 [Cargo](https://crates.io) is the Rust's package manager providing access to libraries

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -39,37 +39,6 @@ beyond the standard one, and its website contains lots of good documentation.
 [`rustdoc`](book/documentation.html) is the Rust's documentation generator, a tool converting
 annotated source code into HTML docs.
 
-# Community & Getting Help
-
-If you need help with something, or just want to talk about Rust with others,
-there are a few places you can do that:
-
-The Rust IRC channels on [irc.mozilla.org](irc://irc.mozilla.org/) are the
-fastest way to get help.
-[`#rust`](http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust) is
-the general discussion channel, and you'll find people willing to help you with
-any questions you may have.
-
-There are also three specialty channels:
-[`#rust-gamedev`](http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-gamedev)
-and
-[`#rust-osdev`](http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-osdev)
-are for game development and operating system development, respectively.
-There's also
-[`#rust-internals`](http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-internals), which is for discussion of the development of Rust itself.
-
-You can also get help on [Stack
-Overflow](https://stackoverflow.com/questions/tagged/rust). Searching for your
-problem might reveal someone who has asked it before!
-
-There is an active [subreddit](https://reddit.com/r/rust) with lots of
-discussion and news about Rust.
-
-There is also a [user forum](https://users.rust-lang.org), for all
-user-oriented discussion, and a [developer
-forum](https://internals.rust-lang.org/), where the development of Rust
-itself is discussed.
-
 # FAQs
 
 There are questions that are asked quite often, so we've made FAQs for them:

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -33,14 +33,14 @@ something if you know its name.
 
 # The Rustonomicon
 
-[The Rustonomicon] is an entire book dedicated dedicated to explaining
+[The Rustonomicon] is an entire book dedicated to explaining
 how to write `unsafe` Rust code. It is for advanced Rust programmers.
 
 [The Rustonomicon]: nomicon/index.html
 
 # Tools
 
-[Cargo](http://doc.crates.io/index.html) is the Rust's package manager providing access to libraries
+[Cargo](http://doc.crates.io/index.html) is the Rust package manager providing access to libraries
 beyond the standard one, and its website contains lots of good documentation.
 
 [`rustdoc`](book/documentation.html) is the Rust's documentation generator, a tool converting

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -14,9 +14,8 @@ concepts. Upon completing the book, you'll be an intermediate Rust
 developer, and will have a good grasp of the fundamental ideas behind
 Rust.
 
-[Rust By Example][rbe] was originally a community resource, but was then
-donated to the Rust project. As the name implies, it teaches you Rust through a
-series of small examples.
+[Rust By Example][rbe] teaches you Rust through a series of small
+examples.
 
 [rbe]: http://rustbyexample.com/
 

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -40,7 +40,7 @@ how to write `unsafe` Rust code. It is for advanced Rust programmers.
 
 # Tools
 
-[Cargo](https://crates.io) is the Rust's package manager providing access to libraries
+[Cargo](http://doc.crates.io/index.html) is the Rust's package manager providing access to libraries
 beyond the standard one, and its website contains lots of good documentation.
 
 [`rustdoc`](book/documentation.html) is the Rust's documentation generator, a tool converting

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -39,10 +39,6 @@ beyond the standard one, and its website contains lots of good documentation.
 [`rustdoc`](book/documentation.html) is the Rust's documentation generator, a tool converting
 annotated source code into HTML docs.
 
-A bunch of non-official tools are available, such as [Racer](https://github.com/phildawes/racer)
-(code completion engine), or [rustfmt](https://github.com/nrc/rustfmt) (source code formatter),
-or text editor plugins.
-
 # Community & Getting Help
 
 If you need help with something, or just want to talk about Rust with others,


### PR DESCRIPTION
I noticed the nomicon was not listed!

I also removed links to racer and rustfmt since they were not _doc-specific_ links, just links to tools, as well as pointed the cargo link directly at the docs.

Removed all the community stuff. There are lots of other places to find this now, including the website.

With pending website changes this page will continue to be pared back, reflecting only what's in-tree, not general Rust docs.

r? @steveklabnik 
