### PR TITLE
target_family configuration

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -610,22 +610,28 @@ pub fn default_configuration(sess: &Session) -> ast::CrateConfig {
     let env = &sess.target.target.target_env;
     let vendor = &sess.target.target.target_vendor;
 
-    let fam = match sess.target.target.options.is_like_windows {
-        true  => InternedString::new("windows"),
-        false => InternedString::new("unix")
+    let fam = if let Some(ref fam) = sess.target.target.options.target_family {
+        intern(fam)
+    } else if sess.target.target.options.is_like_windows {
+        InternedString::new("windows")
+    } else {
+        InternedString::new("unix")
     };
 
     let mk = attr::mk_name_value_item_str;
     let mut ret = vec![ // Target bindings.
-         attr::mk_word_item(fam.clone()),
-         mk(InternedString::new("target_os"), intern(os)),
-         mk(InternedString::new("target_family"), fam),
-         mk(InternedString::new("target_arch"), intern(arch)),
-         mk(InternedString::new("target_endian"), intern(end)),
-         mk(InternedString::new("target_pointer_width"), intern(wordsz)),
-         mk(InternedString::new("target_env"), intern(env)),
-         mk(InternedString::new("target_vendor"), intern(vendor)),
+        mk(InternedString::new("target_os"), intern(os)),
+        mk(InternedString::new("target_family"), fam.clone()),
+        mk(InternedString::new("target_arch"), intern(arch)),
+        mk(InternedString::new("target_endian"), intern(end)),
+        mk(InternedString::new("target_pointer_width"), intern(wordsz)),
+        mk(InternedString::new("target_env"), intern(env)),
+        mk(InternedString::new("target_vendor"), intern(vendor)),
     ];
+    match &fam[..] {
+        "windows" | "unix" => ret.push(attr::mk_word_item(fam)),
+        _ => (),
+    }
     if sess.opts.debug_assertions {
         ret.push(attr::mk_word_item(InternedString::new("debug_assertions")));
     }

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -150,6 +150,8 @@ pub struct TargetOptions {
     pub staticlib_prefix: String,
     /// String to append to the name of every static library. Defaults to ".a".
     pub staticlib_suffix: String,
+    /// OS family to use for conditional compilation. Valid options: "unix", "windows".
+    pub target_family: Option<String>,
     /// Whether the target toolchain is like OSX's. Only useful for compiling against iOS/OS X, in
     /// particular running dsymutil and some other stuff like `-dead_strip`. Defaults to false.
     pub is_like_osx: bool,
@@ -219,6 +221,7 @@ impl Default for TargetOptions {
             exe_suffix: "".to_string(),
             staticlib_prefix: "lib".to_string(),
             staticlib_suffix: ".a".to_string(),
+            target_family: None,
             is_like_osx: false,
             is_like_windows: false,
             is_like_android: false,
@@ -339,6 +342,7 @@ impl Target {
         key!(disable_redzone, bool);
         key!(eliminate_frame_pointer, bool);
         key!(function_sections, bool);
+        key!(target_family, optional);
         key!(is_like_osx, bool);
         key!(is_like_windows, bool);
         key!(linker_is_gnu, bool);


### PR DESCRIPTION
Allow the changing of `target_family` through flexible configuration. The whole computing world isn't just a binary of *nix and Windows! Makes porting `libstd` and co to new platforms a lot less painful.
