### PR TITLE
Mention [T]::sort is stable in docs

### DIFF
--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -732,6 +732,8 @@ impl<T> [T] {
     ///
     /// This is equivalent to `self.sort_by(|a, b| a.cmp(b))`.
     ///
+    /// This is a stable sort.
+    ///
     /// # Examples
     ///
     /// ```rust


### PR DESCRIPTION
Fixes #27322
