### PR TITLE
liballoc: implement From for Box, Rc, Arc

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -902,16 +902,8 @@ impl<T> From<T> for Arc<T> {
     }
 }
 
-#[stable(feature = "rust1", since = "1.6.0")]
-impl<T> From<Box<T>> for Arc<T> {
-    fn from(t: Box<T>) -> Self {
-        Arc::new(*t)
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use std::boxed::Box;
     use std::clone::Clone;
     use std::sync::mpsc::channel;
     use std::mem::drop;
@@ -1159,13 +1151,6 @@ mod tests {
     fn test_from_owned() {
         let foo = 123;
         let foo_arc = Arc::from(foo);
-        assert!(123 == *foo_arc);
-    }
-
-    #[test]
-    fn test_from_box() {
-        let foo_box = Box::new(123);
-        let foo_arc = Arc::from(foo_box);
         assert!(123 == *foo_arc);
     }
 }

--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -895,7 +895,7 @@ impl<T: ?Sized + Hash> Hash for Arc<T> {
     }
 }
 
-#[stable(feature = "rust1", since = "1.6.0")]
+#[stable(feature = "from_for_ptrs", since = "1.6.0")]
 impl<T> From<T> for Arc<T> {
     fn from(t: T) -> Self {
         Arc::new(t)

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -376,7 +376,7 @@ impl<T: ?Sized + Hash> Hash for Box<T> {
     }
 }
 
-#[stable(feature = "rust1", since = "1.6.0")]
+#[stable(feature = "from_for_ptrs", since = "1.6.0")]
 impl<T> From<T> for Box<T> {
     fn from(t: T) -> Self {
         Box::new(t)

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -67,6 +67,7 @@ use core::ops::{CoerceUnsized, Deref, DerefMut};
 use core::ops::{Placer, Boxed, Place, InPlace, BoxPlace};
 use core::ptr::{self, Unique};
 use core::raw::TraitObject;
+use core::convert::From;
 
 /// A value that represents the heap. This is the default place that the `box`
 /// keyword allocates into when no place is supplied.
@@ -372,6 +373,13 @@ impl<T: ?Sized + Eq> Eq for Box<T> {}
 impl<T: ?Sized + Hash> Hash for Box<T> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         (**self).hash(state);
+    }
+}
+
+#[stable(feature = "rust1", since = "1.6.0")]
+impl<T> From<T> for Box<T> {
+    fn from(t: T) -> Self {
+        Box::new(t)
     }
 }
 

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -699,7 +699,7 @@ impl<T> fmt::Pointer for Rc<T> {
     }
 }
 
-#[stable(feature = "rust1", since = "1.6.0")]
+#[stable(feature = "from_for_ptrs", since = "1.6.0")]
 impl<T> From<T> for Rc<T> {
     fn from(t: T) -> Self {
         Rc::new(t)

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -165,6 +165,7 @@ use core::marker::{self, Unsize};
 use core::mem::{self, align_of_val, size_of_val, forget};
 use core::ops::{CoerceUnsized, Deref};
 use core::ptr::{self, Shared};
+use core::convert::From;
 
 use heap::deallocate;
 
@@ -698,6 +699,20 @@ impl<T> fmt::Pointer for Rc<T> {
     }
 }
 
+#[stable(feature = "rust1", since = "1.6.0")]
+impl<T> From<T> for Rc<T> {
+    fn from(t: T) -> Self {
+        Rc::new(t)
+    }
+}
+
+#[stable(feature = "rust1", since = "1.6.0")]
+impl<T> From<Box<T>> for Rc<T> {
+    fn from(t: Box<T>) -> Self {
+        Rc::new(*t)
+    }
+}
+
 /// A weak version of `Rc<T>`.
 ///
 /// Weak references do not count when determining if the inner value should be
@@ -903,6 +918,7 @@ mod tests {
     use std::result::Result::{Err, Ok};
     use std::mem::drop;
     use std::clone::Clone;
+    use std::convert::From;
 
     #[test]
     fn test_clone() {
@@ -1104,6 +1120,20 @@ mod tests {
     fn test_unsized() {
         let foo: Rc<[i32]> = Rc::new([1, 2, 3]);
         assert_eq!(foo, foo.clone());
+    }
+
+    #[test]
+    fn test_from_owned() {
+        let foo = 123;
+        let foo_rc = Rc::from(foo);
+        assert!(123 == *foo_rc);
+    }
+
+    #[test]
+    fn test_from_box() {
+        let foo_box = Box::new(123);
+        let foo_rc = Rc::from(foo_box);
+        assert!(123 == *foo_rc);
     }
 }
 

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -706,13 +706,6 @@ impl<T> From<T> for Rc<T> {
     }
 }
 
-#[stable(feature = "rust1", since = "1.6.0")]
-impl<T> From<Box<T>> for Rc<T> {
-    fn from(t: Box<T>) -> Self {
-        Rc::new(*t)
-    }
-}
-
 /// A weak version of `Rc<T>`.
 ///
 /// Weak references do not count when determining if the inner value should be
@@ -1126,13 +1119,6 @@ mod tests {
     fn test_from_owned() {
         let foo = 123;
         let foo_rc = Rc::from(foo);
-        assert!(123 == *foo_rc);
-    }
-
-    #[test]
-    fn test_from_box() {
-        let foo_box = Box::new(123);
-        let foo_rc = Rc::from(foo_box);
         assert!(123 == *foo_rc);
     }
 }


### PR DESCRIPTION
Sometimes when writing generic code you want to abstract over
owning/pointer type so that calling code isn't restricted by one
concrete owning/pointer type. This commit makes possible such code:

``` rust
fn i_will_work_with_arc<T: Into<Arc<MyTy>>>(t: T) {
    let the_arc = t.into();
    // Do something
}

i_will_work_with_arc(MyTy::new());

i_will_work_with_arc(Box::new(MyTy::new()));

let arc_that_i_already_have = Arc::new(MyTy::new());
i_will_work_with_arc(arc_that_i_already_have);
```

Please note that this patch doesn't work with DSTs.
Also to mention, I made those impls stable, and I don't know whether they should be actually stable from the beginning. Please tell me if this should be feature-gated.
