### PR TITLE
[MIR-trans] Small fixes for the initial trans support

### DIFF
--- a/src/librustc_trans/trans/mir/mod.rs
+++ b/src/librustc_trans/trans/mir/mod.rs
@@ -177,7 +177,7 @@ fn arg_value_refs<'bcx, 'tcx>(bcx: Block<'bcx, 'tcx>,
                let llarg = llvm::get_param(fcx.llfn, idx);
                idx += 1;
                let lltemp = base::alloc_ty(bcx, arg_ty, &format!("arg{}", arg_index));
-               build::Store(bcx, llarg, lltemp);
+               base::store_ty(bcx, llarg, lltemp, arg_ty);
                lltemp
            };
            LvalueRef::new(llval, LvalueTy::from_ty(arg_ty))

--- a/src/librustc_trans/trans/mir/mod.rs
+++ b/src/librustc_trans/trans/mir/mod.rs
@@ -169,7 +169,7 @@ fn arg_value_refs<'bcx, 'tcx>(bcx: Block<'bcx, 'tcx>,
                idx += 2;
                let lltemp = base::alloc_ty(bcx, arg_ty, &format!("arg{}", arg_index));
                build::Store(bcx, lldata, expr::get_dataptr(bcx, lltemp));
-               build::Store(bcx, llextra, expr::get_dataptr(bcx, lltemp));
+               build::Store(bcx, llextra, expr::get_meta(bcx, lltemp));
                lltemp
            } else {
                // otherwise, arg is passed by value, so make a

--- a/src/test/run-pass/mir_small_agg_arg.rs
+++ b/src/test/run-pass/mir_small_agg_arg.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_attrs)]
+
+#[rustc_mir]
+fn foo((x, y): (i8, i8)) {
+}
+
+fn main() {
+    foo((0, 1));
+}


### PR DESCRIPTION
Fix handling of small aggregate function arguments and assignments of temporaries to lvalues.
