### PR TITLE
Introduce a `SwitchInt` construct to MIR

### DIFF
--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -378,7 +378,7 @@ impl<'a,'tcx> Builder<'a,'tcx> {
                     // Did not do an integer equality test (which is always a SwitchInt).
                     // So we learned nothing relevant to this match-pair.
                     //
-                    // TODO we could use TestKind::Range to rule
+                    // FIXME(#29623) we could use TestKind::Range to rule
                     // things out here, in some cases.
                     _ => false,
                 }
@@ -391,7 +391,7 @@ impl<'a,'tcx> Builder<'a,'tcx> {
                 if pattern_test.kind == *test_kind {
                     true
                 } else {
-                    // TODO in all 3 cases, we could sometimes do
+                    // FIXME(#29623) in all 3 cases, we could sometimes do
                     // better here. For example, if we are checking
                     // whether the value is equal to X, and we find
                     // that it is, that (may) imply value is not equal

--- a/src/librustc_mir/visit.rs
+++ b/src/librustc_mir/visit.rs
@@ -109,6 +109,13 @@ pub trait Visitor<'tcx> {
                 }
             }
 
+            Terminator::SwitchInt { ref discr, switch_ty: _, values: _, ref targets } => {
+                self.visit_lvalue(discr, LvalueContext::Inspect);
+                for &target in targets {
+                    self.visit_branch(block, target);
+                }
+            }
+
             Terminator::Diverge |
             Terminator::Return => {
             }

--- a/src/librustc_trans/trans/mir/block.rs
+++ b/src/librustc_trans/trans/mir/block.rs
@@ -50,6 +50,10 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                 unimplemented!()
             }
 
+            mir::Terminator::SwitchInt { .. } => {
+                unimplemented!()
+            }
+
             mir::Terminator::Diverge => {
                 if let Some(llpersonalityslot) = self.llpersonalityslot {
                     let lp = build::Load(bcx, llpersonalityslot);


### PR DESCRIPTION
Introduce a `SwitchInt` and restructure pattern matching to collect integers and characters into one master switch. This is aimed at #29227, but is not a complete fix. Whereas before we generated an if-else-if chain and, at least on my machine, just failed to compile, we now spend ~9sec compiling `rustc_abuse`. AFAICT this is basically just due to a need for more micro-optimization of the matching process: perf shows a fair amount of time just spent iterating over the candidate list. Still, it seemed worth opening a PR with this step alone, since it's a big step forward.
