### PR TITLE
librustdoc: improve testnames for doctests

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2568,8 +2568,18 @@ fn resolve_type(cx: &DocContext,
     debug!("resolve_type({:?},{:?})", path, id);
     let tcx = match cx.tcx_opt() {
         Some(tcx) => tcx,
-        // If we're extracting tests, this return value doesn't matter.
-        None => return Primitive(Bool),
+        // If we're extracting tests, this return value's accuracy is not
+        // important, all we want is a string representation to help people
+        // figure out what doctests are failing.
+        None => {
+            let did = DefId::local(DefIndex::from_u32(0));
+            return ResolvedPath {
+                path: path,
+                typarams: None,
+                did: did,
+                is_generic: false
+            };
+        }
     };
     let def = match tcx.def_map.borrow().get(&id) {
         Some(k) => k.full_def(),


### PR DESCRIPTION
Old doctest names

``` bash
test sync::atomic::load_0 ... ok
test sync::atomic::load_0 ... ok
test sync::atomic::load_0 ... ok
test sync::atomic::load_0 ... ok
```

New doctest names

``` bash
test sync::atomic::AtomicBool::load_0 ... ok
test sync::atomic::AtomicIsize::load_0 ... ok
test sync::atomic::AtomicPtr<T>::load_0 ... ok
test sync::atomic::AtomicUsize::load_0 ... ok
```
