### PR TITLE
librustdoc: don't override ctrl-s and other browser shortcuts

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -101,6 +101,10 @@
         if (document.activeElement.tagName == "INPUT")
             return;
 
+        // Don't interfere with browser shortcuts
+        if (ev.ctrlKey || ev.altKey || ev.metaKey)
+            return;
+
         switch (getVirtualKey(ev)) {
         case "Escape":
             if (!$("#help").hasClass("hidden")) {


### PR DESCRIPTION
Rustdoc pages with a search box inadvertently override `ctrl-s` in addition to the intended `s` and `S` keys.  You can test this in at least Firefox and Chrome (tested: Windows): press `ctrl-s` on http://doc.rust-lang.org/std/.  The search box is focused when instead the browser's save feature should be activated.  This PR fixes `ctrl-s` and possibly other browser shortcuts.
