### PR TITLE
remove excess string allocation

### DIFF
--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -225,7 +225,7 @@ impl<'a, 'tcx> CheckCrateVisitor<'a, 'tcx> {
             {
                 self.tcx.sess.span_err(
                     expr.span,
-                    &format!("const fns are an unstable feature"));
+                    "const fns are an unstable feature");
                 fileline_help!(
                     self.tcx.sess,
                     expr.span,

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -1213,7 +1213,7 @@ fn resolve_trait_associated_const<'a, 'tcx: 'a>(tcx: &'a ty::ctxt<'tcx>,
         _ => {
             tcx.sess.span_bug(
                 ti.span,
-                &format!("resolve_trait_associated_const: unexpected vtable type"))
+                "resolve_trait_associated_const: unexpected vtable type")
         }
     }
 }

--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -1751,7 +1751,7 @@ impl<'a, 'tcx> ErrorReportingHelpers<'tcx> for InferCtxt<'a, 'tcx> {
             infer::ParameterInScope(_, span) => {
                 self.tcx.sess.span_note(
                     span,
-                    &format!("...so that a type/lifetime parameter is in scope here"));
+                    "...so that a type/lifetime parameter is in scope here");
             }
             infer::DataBorrowed(ty, span) => {
                 self.tcx.sess.span_note(

--- a/src/librustc/middle/infer/mod.rs
+++ b/src/librustc/middle/infer/mod.rs
@@ -1130,7 +1130,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         match self.tables.borrow().node_types.get(&ex.id) {
             Some(&t) => t,
             None => {
-                self.tcx.sess.bug(&format!("no type for expr in fcx"));
+                self.tcx.sess.bug("no type for expr in fcx");
             }
         }
     }

--- a/src/librustc/middle/traits/error_reporting.rs
+++ b/src/librustc/middle/traits/error_reporting.rs
@@ -498,7 +498,7 @@ fn note_obligation_cause_code<'a, 'tcx, T>(infcx: &InferCtxt<'a, 'tcx>,
         ObligationCauseCode::SliceOrArrayElem => {
             tcx.sess.fileline_note(
                 cause_span,
-                &format!("slice and array elements must have `Sized` type"));
+                "slice and array elements must have `Sized` type");
         }
         ObligationCauseCode::ProjectionWf(data) => {
             tcx.sess.fileline_note(

--- a/src/librustc/middle/ty/error.rs
+++ b/src/librustc/middle/ty/error.rs
@@ -288,10 +288,9 @@ impl<'tcx> ty::ctxt<'tcx> {
                 let found_str = values.found.sort_string(self);
                 if expected_str == found_str && expected_str == "closure" {
                     self.sess.span_note(sp,
-                        &format!("no two closures, even if identical, have the same type"));
+                        "no two closures, even if identical, have the same type");
                     self.sess.span_help(sp,
-                        &format!("consider boxing your closure and/or \
-                                  using it as a trait object"));
+                        "consider boxing your closure and/or using it as a trait object");
                 }
             },
             TyParamDefaultMismatch(values) => {
@@ -307,8 +306,7 @@ impl<'tcx> ty::ctxt<'tcx> {
                             .and_then(|node_id| self.map.opt_span(node_id))
                 {
                     Some(span) => {
-                        self.sess.span_note(span,
-                                            &format!("a default was defined here..."));
+                        self.sess.span_note(span, "a default was defined here...");
                     }
                     None => {
                         self.sess.note(
@@ -319,15 +317,14 @@ impl<'tcx> ty::ctxt<'tcx> {
 
                 self.sess.span_note(
                     expected.origin_span,
-                    &format!("...that was applied to an unconstrained type variable here"));
+                    "...that was applied to an unconstrained type variable here");
 
                 match
                     self.map.as_local_node_id(found.def_id)
                             .and_then(|node_id| self.map.opt_span(node_id))
                 {
                     Some(span) => {
-                        self.sess.span_note(span,
-                                            &format!("a second default was defined here..."));
+                        self.sess.span_note(span, "a second default was defined here...");
                     }
                     None => {
                         self.sess.note(
@@ -338,7 +335,7 @@ impl<'tcx> ty::ctxt<'tcx> {
 
                 self.sess.span_note(
                     found.origin_span,
-                    &format!("...that also applies to the same type variable here"));
+                    "...that also applies to the same type variable here");
             }
             _ => {}
         }

--- a/src/librustc_mir/build/expr/as_temp.rs
+++ b/src/librustc_mir/build/expr/as_temp.rs
@@ -38,7 +38,7 @@ impl<'a,'tcx> Builder<'a,'tcx> {
         let temp_lifetime = match expr.temp_lifetime {
             Some(t) => t,
             None => {
-                this.hir.span_bug(expr.span, &format!("no temp_lifetime for expr"));
+                this.hir.span_bug(expr.span, "no temp_lifetime for expr");
             }
         };
         this.schedule_drop(expr.span, temp_lifetime, DropKind::Deep, &temp, expr_ty);

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -236,7 +236,7 @@ impl<'tcx> Mirror<'tcx> for &'tcx hir::Expr {
                 let (adt_def, substs) = match range_ty.sty {
                     ty::TyStruct(adt_def, substs) => (adt_def, substs),
                     _ => {
-                        cx.tcx.sess.span_bug(self.span, &format!("unexpanded ast"));
+                        cx.tcx.sess.span_bug(self.span, "unexpanded ast");
                     }
                 };
 
@@ -555,14 +555,12 @@ fn convert_var<'a, 'tcx: 'a>(cx: &mut Cx<'a, 'tcx>,
                     match expr.node {
                         hir::ExprClosure(_, _, ref body) => body.id,
                         _ => {
-                            cx.tcx.sess.span_bug(expr.span,
-                                              &format!("closure expr is not a closure expr"));
+                            cx.tcx.sess.span_bug(expr.span, "closure expr is not a closure expr");
                         }
                     }
                 }
                 _ => {
-                    cx.tcx.sess.span_bug(expr.span,
-                                      &format!("ast-map has garbage for closure expr"));
+                    cx.tcx.sess.span_bug(expr.span, "ast-map has garbage for closure expr");
                 }
             };
 

--- a/src/librustc_mir/mir_map.rs
+++ b/src/librustc_mir/mir_map.rs
@@ -173,7 +173,7 @@ impl<'a, 'm, 'tcx> visit::Visitor<'tcx> for InnerDump<'a,'m,'tcx> {
                             None => {
                                 self.tcx.sess.span_err(
                                     item.span,
-                                    &format!("graphviz attribute requires a path"));
+                                    "graphviz attribute requires a path");
                             }
                         }
                     }

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -458,14 +458,12 @@ fn match_intrinsic_type_to_type<'tcx, 'a>(
                     match_intrinsic_type_to_type(tcx, position, span, structural_to_nominal,
                                                  inner_expected, ty)
                 }
-                _ => simple_error(&format!("`{}`", t),
-                                  &format!("raw pointer")),
+                _ => simple_error(&format!("`{}`", t), "raw pointer"),
             }
         }
         Vector(ref inner_expected, ref _llvm_type, len) => {
             if !t.is_simd() {
-                simple_error(&format!("non-simd type `{}`", t),
-                             "simd type");
+                simple_error(&format!("non-simd type `{}`", t), "simd type");
                 return;
             }
             let t_len = t.simd_size(tcx);

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1732,7 +1732,7 @@ mod tests {
         let tmpdir = tmpdir();
 
         let mut dirpath = tmpdir.path().to_path_buf();
-        dirpath.push(&format!("test-가一ー你好"));
+        dirpath.push("test-가一ー你好");
         check!(fs::create_dir(&dirpath));
         assert!(dirpath.is_dir());
 

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -400,9 +400,7 @@ pub fn expand_item_mac(it: P<ast::Item>,
                 }
                 MacroRulesTT => {
                     if ident.name == parse::token::special_idents::invalid.name {
-                        fld.cx.span_err(path_span,
-                                        &format!("macro_rules! expects an ident argument")
-                                        );
+                        fld.cx.span_err(path_span, "macro_rules! expects an ident argument");
                         return SmallVector::zero();
                     }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1843,7 +1843,7 @@ impl<'a> Parser<'a> {
                 });
             }
             _ => {
-                return Err(self.fatal(&format!("expected a lifetime name")));
+                return Err(self.fatal("expected a lifetime name"));
             }
         }
     }

--- a/src/test/run-pass/issue-23338-ensure-param-drop-order.rs
+++ b/src/test/run-pass/issue-23338-ensure-param-drop-order.rs
@@ -19,7 +19,7 @@ use self::d::D;
 
 pub fn main() {
     let log = RefCell::new(vec![]);
-    d::println(&format!("created empty log"));
+    d::println("created empty log");
     test(&log);
 
     assert_eq!(&log.borrow()[..],
@@ -59,19 +59,19 @@ pub fn main() {
 fn test<'a>(log: d::Log<'a>) {
     let da = D::new("da", 0, log);
     let de = D::new("de", 1, log);
-    d::println(&format!("calling foo"));
+    d::println("calling foo");
     let result = foo(da, de);
     d::println(&format!("result {}", result));
 }
 
 fn foo<'a>(da0: D<'a>, de1: D<'a>) -> D<'a> {
-    d::println(&format!("entered foo"));
+    d::println("entered foo");
     let de2 = de1.incr();      // creates D(de_2, 2)
     let de4 = {
         let _da1 = da0.incr(); // creates D(da_1, 3)
         de2.incr().incr()      // creates D(de_3, 4) and D(de_4, 5)
     };
-    d::println(&format!("eval tail of foo"));
+    d::println("eval tail of foo");
     de4.incr().incr()          // creates D(de_5, 6) and D(de_6, 7)
 }
 

--- a/src/test/run-pass/issue-23611-enum-swap-in-drop.rs
+++ b/src/test/run-pass/issue-23611-enum-swap-in-drop.rs
@@ -20,7 +20,7 @@ use self::d::D;
 
 pub fn main() {
     let log = RefCell::new(vec![]);
-    d::println(&format!("created empty log"));
+    d::println("created empty log");
     test(&log);
 
     // println!("log: {:?}", &log.borrow()[..]);


### PR DESCRIPTION
&format!("...") is the same as "" if we're not doing any interpolation,
and doesn't allocate an intermediate String.
