### PR TITLE
rustc_privacy: Do not export items needed solely for the reachability analysis

### DIFF
--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -125,6 +125,9 @@ impl<'a, 'tcx, 'v> Visitor<'v> for ReachableContext<'a, 'tcx> {
             hir::ExprMethodCall(..) => {
                 let method_call = ty::MethodCall::expr(expr.id);
                 let def_id = self.tcx.tables.borrow().method_map[&method_call].def_id;
+
+                // Mark the trait item (and, possibly, its default impl) as reachable
+                // Or mark inherent impl item as reachable
                 if let Some(node_id) = self.tcx.map.as_local_node_id(def_id) {
                     if self.def_id_represents_local_inlined_item(def_id) {
                         self.worklist.push(node_id)
@@ -322,56 +325,68 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
             }
         }
     }
+}
 
-    // Step 3: Mark all destructors as reachable.
-    //
-    // FIXME #10732: This is a conservative overapproximation, but fixing
-    // this properly would result in the necessity of computing *type*
-    // reachability, which might result in a compile time loss.
-    fn mark_destructors_reachable(&mut self) {
-        let drop_trait = match self.tcx.lang_items.drop_trait() {
-            Some(id) => self.tcx.lookup_trait_def(id), None => { return }
-        };
-        drop_trait.for_each_impl(self.tcx, |drop_impl| {
-            for destructor in &self.tcx.impl_items.borrow()[&drop_impl] {
-                let destructor_did = destructor.def_id();
-                if let Some(destructor_node_id) = self.tcx.map.as_local_node_id(destructor_did) {
-                    self.reachable_symbols.insert(destructor_node_id);
+// Some methods from non-exported (completely private) trait impls still have to be
+// reachable if they are called from inlinable code. Generally, it's not known until
+// monomorphization if a specific trait impl item can be reachable or not. So, we
+// conservatively mark all of them as reachable.
+// FIXME: One possible strategy for pruning the reachable set is to avoid marking impl
+// items of non-exported traits (or maybe all local traits?) unless their respective
+// trait items are used from inlinable code through method call syntax or UFCS, or their
+// trait is a lang item.
+struct CollectPrivateImplItemsVisitor<'a> {
+    exported_items: &'a privacy::ExportedItems,
+    worklist: &'a mut Vec<ast::NodeId>,
+}
+
+impl<'a, 'v> Visitor<'v> for CollectPrivateImplItemsVisitor<'a> {
+    fn visit_item(&mut self, item: &hir::Item) {
+        // We need only trait impls here, not inherent impls, and only non-exported ones
+        if let hir::ItemImpl(_, _, _, Some(_), _, ref impl_items) = item.node {
+            if !self.exported_items.contains(&item.id) {
+                for impl_item in impl_items {
+                    self.worklist.push(impl_item.id);
                 }
             }
-        })
+        }
+
+        visit::walk_item(self, item);
     }
 }
 
 pub fn find_reachable(tcx: &ty::ctxt,
                       exported_items: &privacy::ExportedItems)
                       -> NodeSet {
+
     let mut reachable_context = ReachableContext::new(tcx);
 
     // Step 1: Seed the worklist with all nodes which were found to be public as
-    //         a result of the privacy pass along with all local lang items. If
-    //         other crates link to us, they're going to expect to be able to
+    //         a result of the privacy pass along with all local lang items and impl items.
+    //         If other crates link to us, they're going to expect to be able to
     //         use the lang items, so we need to be sure to mark them as
     //         exported.
     for id in exported_items {
         reachable_context.worklist.push(*id);
     }
     for (_, item) in tcx.lang_items.items() {
-        match *item {
-            Some(did) => {
-                if let Some(node_id) = tcx.map.as_local_node_id(did) {
-                    reachable_context.worklist.push(node_id);
-                }
+        if let Some(did) = *item {
+            if let Some(node_id) = tcx.map.as_local_node_id(did) {
+                reachable_context.worklist.push(node_id);
             }
-            _ => {}
         }
+    }
+    {
+        let mut collect_private_impl_items = CollectPrivateImplItemsVisitor {
+            exported_items: exported_items,
+            worklist: &mut reachable_context.worklist,
+        };
+
+        visit::walk_crate(&mut collect_private_impl_items, tcx.map.krate());
     }
 
     // Step 2: Mark all symbols that the symbols on the worklist touch.
     reachable_context.propagate();
-
-    // Step 3: Mark all destructors as reachable.
-    reachable_context.mark_destructors_reachable();
 
     // Return the set of reachable symbols.
     reachable_context.reachable_symbols

--- a/src/test/auxiliary/issue-11225-1.rs
+++ b/src/test/auxiliary/issue-11225-1.rs
@@ -11,13 +11,18 @@
 mod inner {
     pub trait Trait {
         fn f(&self) { f(); }
+        fn f_ufcs(&self) { f_ufcs(); }
     }
 
     impl Trait for isize {}
 
     fn f() {}
+    fn f_ufcs() {}
 }
 
 pub fn foo<T: inner::Trait>(t: T) {
     t.f();
+}
+pub fn foo_ufcs<T: inner::Trait>(t: T) {
+    T::f_ufcs(&t);
 }

--- a/src/test/auxiliary/issue-11225-2.rs
+++ b/src/test/auxiliary/issue-11225-2.rs
@@ -14,19 +14,25 @@ mod inner {
     pub struct Foo;
     pub trait Trait {
         fn f(&self);
+        fn f_ufcs(&self);
     }
 
     impl Trait for Foo {
         fn f(&self) { }
+        fn f_ufcs(&self) { }
     }
 }
 
 pub trait Outer {
     fn foo<T: Trait>(&self, t: T) { t.f(); }
+    fn foo_ufcs<T: Trait>(&self, t: T) { T::f(&t); }
 }
 
 impl Outer for isize {}
 
 pub fn foo<T: Outer>(t: T) {
     t.foo(inner::Foo);
+}
+pub fn foo_ufcs<T: Outer>(t: T) {
+    T::foo_ufcs(&t, inner::Foo)
 }

--- a/src/test/auxiliary/issue-11225-3.rs
+++ b/src/test/auxiliary/issue-11225-3.rs
@@ -10,20 +10,29 @@
 
 trait PrivateTrait {
     fn private_trait_method(&self);
+    fn private_trait_method_ufcs(&self);
 }
 
 struct PrivateStruct;
 
 impl PrivateStruct {
     fn private_inherent_method(&self) { }
+    fn private_inherent_method_ufcs(&self) { }
 }
 
 impl PrivateTrait for PrivateStruct {
     fn private_trait_method(&self) { }
+    fn private_trait_method_ufcs(&self) { }
 }
 
 #[inline]
-pub fn public_generic_function() {
+pub fn public_inlinable_function() {
     PrivateStruct.private_trait_method();
     PrivateStruct.private_inherent_method();
+}
+
+#[inline]
+pub fn public_inlinable_function_ufcs() {
+    PrivateStruct::private_trait_method(&PrivateStruct);
+    PrivateStruct::private_inherent_method(&PrivateStruct);
 }

--- a/src/test/run-pass/issue-11225-1.rs
+++ b/src/test/run-pass/issue-11225-1.rs
@@ -16,4 +16,5 @@ extern crate issue_11225_1 as foo;
 
 pub fn main() {
     foo::foo(1);
+    foo::foo_ufcs(1);
 }

--- a/src/test/run-pass/issue-11225-2.rs
+++ b/src/test/run-pass/issue-11225-2.rs
@@ -16,4 +16,5 @@ extern crate issue_11225_2 as foo;
 
 pub fn main() {
     foo::foo(1);
+    foo::foo_ufcs(1);
 }

--- a/src/test/run-pass/issue-11225-3.rs
+++ b/src/test/run-pass/issue-11225-3.rs
@@ -15,5 +15,6 @@
 extern crate issue_11225_3;
 
 pub fn main() {
-    issue_11225_3::public_generic_function();
+    issue_11225_3::public_inlinable_function();
+    issue_11225_3::public_inlinable_function_ufcs();
 }


### PR DESCRIPTION
Handle them in `middle::reachable` instead (no optimizations so far, just drop all trait impl items into the reachable set, as before). Addresses the concerns from https://github.com/rust-lang/rust/pull/29291#discussion_r43672413
+ In `middle::reachable` don't treat impls of `Drop` specially, they are subsumed by the general impl treatment.
+ Add some tests checking reachability of trait methods written in UFCS form
+ Minor refactoring in the second commit

r? @alexcrichton 
