### PR TITLE
doc(lib.rs): fix #L79 with inline link syntax

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -76,7 +76,7 @@
 //! `i32`](primitive.i32.html) that lists all the methods that can be called on
 //! 32-bit integers (very useful), and there is a [page for the module
 //! `std::i32`](i32/index.html) that documents the constant values [`MIN`] and
-//! [`MAX`] (rarely useful).
+//! [`MAX`](i32/constant.MAX.html) (rarely useful).
 //!
 //! Note the documentation for the primitives [`str`] and [`[T]`][slice] (also
 //! called 'slice'). Many method calls on [`String`] and [`Vec<T>`] are actually
@@ -153,7 +153,6 @@
 //!
 //! [I/O]: io/index.html
 //! [MIN]: i32/constant.MIN.html
-//! [MAX]: i32/constant.MAX.html
 //! [TCP]: net/struct.TcpStream.html
 //! [The Rust Prelude]: prelude/index.html
 //! [UDP]: net/struct.UdpSocket.html


### PR DESCRIPTION
Thanks.
r? @steveklabnik
