### PR TITLE
Add missing stability annotations on reexports

### DIFF
--- a/src/libcollections/borrow.rs
+++ b/src/libcollections/borrow.rs
@@ -24,6 +24,7 @@ use fmt;
 
 use self::Cow::*;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::borrow::{Borrow, BorrowMut};
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcollections/fmt.rs
+++ b/src/libcollections/fmt.rs
@@ -474,13 +474,21 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{Formatter, Result, Write, rt};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{Octal, Binary};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{Display, Debug};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{LowerHex, UpperHex, Pointer};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{LowerExp, UpperExp};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::Error;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{ArgumentV1, Arguments, write, radix, Radix, RadixFmt};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{DebugList, DebugMap, DebugSet, DebugStruct, DebugTuple};
 
 use string;

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -107,11 +107,13 @@ pub mod vec_deque;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod btree_map {
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub use btree::map::*;
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod btree_set {
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub use btree::set::*;
 }
 

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -102,12 +102,18 @@ use core::slice as core_slice;
 use borrow::{Borrow, BorrowMut, ToOwned};
 use vec::Vec;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::slice::{Chunks, Windows};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::slice::{Iter, IterMut};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::slice::{SplitMut, ChunksMut, Split};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::slice::{SplitN, RSplitN, SplitNMut, RSplitNMut};
+#[unstable(feature = "ref_slice", issue = "27774")]
 #[allow(deprecated)]
 pub use core::slice::{bytes, mut_ref_slice, ref_slice};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::slice::{from_raw_parts, from_raw_parts_mut};
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -160,7 +166,6 @@ mod hack {
 /// Allocating extension methods for slices.
 #[lang = "slice"]
 #[cfg(not(test))]
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<T> [T] {
     /// Returns the number of elements in the slice.
     ///

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -37,17 +37,28 @@ use vec::Vec;
 use slice::SliceConcatExt;
 use boxed::Box;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::{FromStr, Utf8Error};
 #[allow(deprecated)]
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::{Lines, LinesAny, CharRange};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::{Split, RSplit};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::{SplitN, RSplitN};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::{SplitTerminator, RSplitTerminator};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::{Matches, RMatches};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::{MatchIndices, RMatchIndices};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::{from_utf8, Chars, CharIndices, Bytes};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::{from_utf8_unchecked, ParseBoolError};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use rustc_unicode::str::{SplitWhitespace};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::pattern;
 
 impl<S: Borrow<str>> SliceConcatExt<str> for [S] {
@@ -153,7 +164,6 @@ impl ToOwned for str {
 /// Any string that can be represented as a slice.
 #[lang = "str"]
 #[cfg(not(test))]
-#[stable(feature = "rust1", since = "1.0.0")]
 impl str {
     /// Returns the length of `self` in bytes.
     ///

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -24,10 +24,13 @@ use slice;
 use str;
 use self::rt::v1::Alignment;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::num::radix;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::num::Radix;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::num::RadixFmt;
-
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::builders::{DebugStruct, DebugTuple, DebugSet, DebugList, DebugMap};
 
 mod num;

--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -74,6 +74,7 @@ use prelude::v1::*;
 
 use mem;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::sip::SipHasher;
 
 mod sip;

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1627,6 +1627,7 @@ impl fmt::Display for ParseIntError {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use num::dec2flt::ParseFloatError;
 
 // Conversion traits for primitive integer and float types

--- a/src/libcore/prelude/v1.rs
+++ b/src/libcore/prelude/v1.rs
@@ -17,23 +17,37 @@
 #![stable(feature = "core_prelude", since = "1.4.0")]
 
 // Reexported core operators
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use marker::{Copy, Send, Sized, Sync};
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use ops::{Drop, Fn, FnMut, FnOnce};
 
 // Reexported functions
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use mem::drop;
 
 // Reexported types and traits
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use clone::Clone;
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use cmp::{PartialEq, PartialOrd, Eq, Ord};
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use convert::{AsRef, AsMut, Into, From};
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use default::Default;
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use iter::{Iterator, Extend, IntoIterator};
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use iter::{DoubleEndedIterator, ExactSizeIterator};
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use option::Option::{self, Some, None};
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use result::Result::{self, Ok, Err};
 
 // Reexported extension traits for primitive types
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use slice::SliceExt;
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use str::StrExt;
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use char::CharExt;

--- a/src/librustc_unicode/char.rs
+++ b/src/librustc_unicode/char.rs
@@ -35,9 +35,11 @@ use core::iter::Iterator;
 use tables::{derived_property, property, general_category, conversions};
 
 // stable reexports
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::char::{MAX, from_u32, from_u32_unchecked, from_digit, EscapeUnicode, EscapeDefault};
 
 // unstable reexports
+#[unstable(feature = "unicode", issue = "27783")]
 pub use tables::UNICODE_VERSION;
 
 /// An iterator over the lowercase mapping of a given character, returned from
@@ -111,7 +113,6 @@ impl Iterator for CaseMappingIter {
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 #[lang = "char"]
 impl char {
     /// Checks if a `char` is a digit in the given radix.

--- a/src/libstd/collections/mod.rs
+++ b/src/libstd/collections/mod.rs
@@ -408,14 +408,20 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::Bound;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::{BinaryHeap, BTreeMap, BTreeSet};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::{LinkedList, VecDeque};
-
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::{binary_heap, btree_map, btree_set};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::{linked_list, vec_deque};
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::hash_map::HashMap;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::hash_set::HashSet;
 
 mod hash;
@@ -423,12 +429,14 @@ mod hash;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod hash_map {
     //! A hashmap
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::hash::map::*;
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod hash_set {
     //! A hashset
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::hash::set::*;
 }
 

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -255,13 +255,21 @@ use string::String;
 use str;
 use vec::Vec;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::buffered::{BufReader, BufWriter, LineWriter};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::buffered::IntoInnerError;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::cursor::Cursor;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::error::{Result, Error, ErrorKind};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::util::{copy, sink, Sink, empty, Empty, repeat, Repeat};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::stdio::{stdin, stdout, stderr, _print, Stdin, Stdout, Stderr};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::stdio::{StdoutLock, StderrLock, StdinLock};
+#[unstable(feature = "libstd_io_internals", issue = "0")]
 #[doc(no_inline, hidden)]
 pub use self::stdio::{set_panic, set_print};
 
@@ -1534,7 +1542,6 @@ pub struct Take<T> {
     limit: u64,
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<T> Take<T> {
     /// Returns the number of bytes that can be read before this instance will
     /// return EOF.

--- a/src/libstd/io/prelude.rs
+++ b/src/libstd/io/prelude.rs
@@ -20,6 +20,8 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use super::{Read, Write, BufRead, Seek};
 #[allow(deprecated)]
+#[unstable(feature = "path_ext_deprecated", issue = "27725")]
 pub use fs::PathExt;

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -302,36 +302,63 @@ extern crate libc;
 
 // NB: These reexports are in the order they should be listed in rustdoc
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::any;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::cell;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::clone;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::cmp;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::convert;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::default;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::hash;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::intrinsics;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::iter;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::marker;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::mem;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::ops;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::ptr;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::raw;
+#[stable(feature = "rust1", since = "1.0.0")]
 #[allow(deprecated)]
 pub use core::simd;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::result;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::option;
+
 pub mod error;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use alloc::boxed;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use alloc::rc;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::borrow;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::fmt;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::slice;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::str;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::string;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::vec;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use rustc_unicode::char;
 
 /* Exported macros */
@@ -352,16 +379,26 @@ pub mod prelude;
 // doc pages are inlined from the public re-exports of core_collections::{slice,
 // str} above.
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::isize;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::i8;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::i16;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::i32;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::i64;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::usize;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::u8;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::u16;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::u32;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::u64;
 
 #[path = "num/f32.rs"]   pub mod f32;

--- a/src/libstd/net/mod.rs
+++ b/src/libstd/net/mod.rs
@@ -17,10 +17,15 @@ use prelude::v1::*;
 use io::{self, Error, ErrorKind};
 use sys_common::net as net_imp;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::ip::{IpAddr, Ipv4Addr, Ipv6Addr, Ipv6MulticastScope};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::addr::{SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::tcp::{TcpStream, TcpListener, Incoming};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::udp::UdpSocket;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::parser::AddrParseError;
 
 mod ip;

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -20,10 +20,15 @@ use intrinsics;
 use libc::c_int;
 use num::{FpCategory, ParseFloatError};
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::f32::{RADIX, MANTISSA_DIGITS, DIGITS, EPSILON};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::f32::{MIN_EXP, MAX_EXP, MIN_10_EXP};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::f32::{MAX_10_EXP, NAN, INFINITY, NEG_INFINITY};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::f32::{MIN, MIN_POSITIVE, MAX};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::f32::consts;
 
 #[allow(dead_code)]
@@ -120,7 +125,6 @@ mod cmath {
 
 #[cfg(not(test))]
 #[lang = "f32"]
-#[stable(feature = "rust1", since = "1.0.0")]
 impl f32 {
     /// Parses a float as with a given radix
     #[unstable(feature = "float_from_str_radix", reason = "recently moved API",

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -20,10 +20,15 @@ use intrinsics;
 use libc::c_int;
 use num::{FpCategory, ParseFloatError};
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::f64::{RADIX, MANTISSA_DIGITS, DIGITS, EPSILON};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::f64::{MIN_EXP, MAX_EXP, MIN_10_EXP};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::f64::{MAX_10_EXP, NAN, INFINITY, NEG_INFINITY};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::f64::{MIN, MIN_POSITIVE, MAX};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::f64::consts;
 
 #[allow(dead_code)]
@@ -77,7 +82,6 @@ mod cmath {
 
 #[cfg(not(test))]
 #[lang = "f64"]
-#[stable(feature = "rust1", since = "1.0.0")]
 impl f64 {
     /// Parses a float as with a given radix
     #[unstable(feature = "float_from_str_radix", reason = "recently moved API",

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -16,8 +16,11 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 #![allow(missing_docs)]
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::num::{Zero, One};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::num::{FpCategory, ParseIntError, ParseFloatError};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::num::{wrapping, Wrapping};
 
 #[cfg(test)] use cmp::PartialEq;

--- a/src/libstd/os/linux/mod.rs
+++ b/src/libstd/os/linux/mod.rs
@@ -14,7 +14,8 @@
 
 pub mod raw;
 
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub mod fs {
-    #![stable(feature = "raw_ext", since = "1.1.0")]
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub use sys::fs::MetadataExt;
 }

--- a/src/libstd/os/linux/raw.rs
+++ b/src/libstd/os/linux/raw.rs
@@ -16,6 +16,7 @@
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
 
 #[doc(inline)]
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub use self::arch::{off_t, ino_t, nlink_t, blksize_t, blkcnt_t, stat, time_t};
 
 #[cfg(any(target_arch = "x86",

--- a/src/libstd/os/mod.rs
+++ b/src/libstd/os/mod.rs
@@ -13,8 +13,12 @@
 #![stable(feature = "os", since = "1.0.0")]
 #![allow(missing_docs, bad_style)]
 
-#[cfg(unix)]    pub use sys::ext as unix;
-#[cfg(windows)] pub use sys::ext as windows;
+#[cfg(unix)]
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use sys::ext as unix;
+#[cfg(windows)]
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use sys::ext as windows;
 
 #[cfg(target_os = "android")]   pub mod android;
 #[cfg(target_os = "bitrig")]    pub mod bitrig;

--- a/src/libstd/sync/mod.rs
+++ b/src/libstd/sync/mod.rs
@@ -17,17 +17,28 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use alloc::arc::{Arc, Weak};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::sync::atomic;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::barrier::{Barrier, BarrierWaitResult};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::condvar::{Condvar, StaticCondvar, WaitTimeoutResult, CONDVAR_INIT};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::mutex::MUTEX_INIT;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::mutex::{Mutex, MutexGuard, StaticMutex};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::once::{Once, ONCE_INIT};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use sys_common::poison::{PoisonError, TryLockError, TryLockResult, LockResult};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::rwlock::{RwLockReadGuard, RwLockWriteGuard};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::rwlock::{RwLock, StaticRwLock, RW_LOCK_INIT};
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::semaphore::{Semaphore, SemaphoreGuard};
 
 pub mod mpsc;

--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -272,6 +272,7 @@ use mem;
 use cell::UnsafeCell;
 use marker::Reflect;
 
+#[unstable(feature = "mpsc_select", issue = "27800")]
 pub use self::select::{Select, Handle};
 use self::select::StartResult;
 use self::select::StartResult::*;

--- a/src/libstd/sys/unix/ext/mod.rs
+++ b/src/libstd/sys/unix/ext/mod.rs
@@ -40,13 +40,13 @@ pub mod raw;
 /// Includes all extension traits, and some important type definitions.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod prelude {
-    #[doc(no_inline)]
+    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::io::{RawFd, AsRawFd, FromRawFd, IntoRawFd};
     #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::ffi::{OsStrExt, OsStringExt};
-    #[doc(no_inline)]
+    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::fs::{PermissionsExt, OpenOptionsExt, MetadataExt, FileTypeExt};
-    #[doc(no_inline)]
+    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::fs::{DirEntryExt};
     #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::process::{CommandExt, ExitStatusExt};

--- a/src/libstd/sys/unix/ext/raw.rs
+++ b/src/libstd/sys/unix/ext/raw.rs
@@ -17,6 +17,8 @@
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type pid_t = i32;
 
 #[doc(inline)]
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub use sys::platform::raw::{dev_t, ino_t, mode_t, nlink_t, off_t, blksize_t};
 #[doc(inline)]
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub use sys::platform::raw::{blkcnt_t, time_t};

--- a/src/libstd/sys/windows/ext/ffi.rs
+++ b/src/libstd/sys/windows/ext/ffi.rs
@@ -17,6 +17,7 @@ use sys::os_str::Buf;
 use sys_common::wtf8::Wtf8Buf;
 use sys_common::{FromInner, AsInner};
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use sys_common::wtf8::EncodeWide;
 
 /// Windows-specific extensions to `OsString`.

--- a/src/libstd/sys/windows/ext/mod.rs
+++ b/src/libstd/sys/windows/ext/mod.rs
@@ -27,12 +27,12 @@ pub mod process;
 /// Includes all extension traits, and some important type definitions.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod prelude {
-    #[doc(no_inline)]
+    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::io::{RawSocket, RawHandle, AsRawSocket, AsRawHandle};
-    #[doc(no_inline)]
+    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::io::{FromRawSocket, FromRawHandle, IntoRawSocket, IntoRawHandle};
     #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::ffi::{OsStrExt, OsStringExt};
-    #[doc(no_inline)]
+    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::fs::{OpenOptionsExt, MetadataExt};
 }

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -189,7 +189,9 @@ pub use self::local::{LocalKey, LocalKeyState};
            issue = "27715")]
 pub use self::scoped_tls::ScopedKey;
 
+#[unstable(feature = "libstd_thread_internals", issue = "0")]
 #[doc(hidden)] pub use self::local::__KeyInner as __LocalKeyInner;
+#[unstable(feature = "libstd_thread_internals", issue = "0")]
 #[doc(hidden)] pub use self::scoped_tls::__KeyInner as __ScopedKeyInner;
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/libstd/time/mod.rs
+++ b/src/libstd/time/mod.rs
@@ -12,6 +12,7 @@
 
 #![stable(feature = "time", since = "1.3.0")]
 
+#[stable(feature = "time", since = "1.3.0")]
 pub use self::duration::Duration;
 
 mod duration;


### PR DESCRIPTION
Extracted from https://github.com/rust-lang/rust/pull/29083
I'll redo https://github.com/rust-lang/rust/pull/29083 in some time and it will be much smaller and easier to review without this part

r? @alexcrichton 
