### PR TITLE
Remove stability annotations from trait impl items

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -881,7 +881,6 @@ impl<T> fmt::Pointer for Arc<T> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Default> Default for Arc<T> {
-    #[stable(feature = "rust1", since = "1.0.0")]
     fn default() -> Arc<T> {
         Arc::new(Default::default())
     }

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -264,7 +264,6 @@ impl<T : ?Sized> Box<T> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Default> Default for Box<T> {
-    #[stable(feature = "rust1", since = "1.0.0")]
     fn default() -> Box<T> {
         box Default::default()
     }
@@ -272,7 +271,6 @@ impl<T: Default> Default for Box<T> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> Default for Box<[T]> {
-    #[stable(feature = "rust1", since = "1.0.0")]
     fn default() -> Box<[T]> {
         Box::<[T; 0]>::new([])
     }

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -508,7 +508,6 @@ impl<T: Default> Default for Rc<T> {
     /// let x: Rc<i32> = Default::default();
     /// ```
     #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
     fn default() -> Rc<T> {
         Rc::new(Default::default())
     }

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -903,7 +903,6 @@ impl<K: Hash, V: Hash> Hash for BTreeMap<K, V> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<K: Ord, V> Default for BTreeMap<K, V> {
-    #[stable(feature = "rust1", since = "1.0.0")]
     fn default() -> BTreeMap<K, V> {
         BTreeMap::new()
     }

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -559,7 +559,6 @@ impl<'a, T: 'a + Ord + Copy> Extend<&'a T> for BTreeSet<T> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Ord> Default for BTreeSet<T> {
-    #[stable(feature = "rust1", since = "1.0.0")]
     fn default() -> BTreeSet<T> {
         BTreeSet::new()
     }

--- a/src/libcollections/linked_list.rs
+++ b/src/libcollections/linked_list.rs
@@ -230,7 +230,6 @@ impl<T> LinkedList<T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> Default for LinkedList<T> {
     #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
     fn default() -> LinkedList<T> { LinkedList::new() }
 }
 

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -160,7 +160,6 @@ mod hack {
 /// Allocating extension methods for slices.
 #[lang = "slice"]
 #[cfg(not(test))]
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<T> [T] {
     /// Returns the number of elements in the slice.
     ///

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -153,7 +153,6 @@ impl ToOwned for str {
 /// Any string that can be represented as a slice.
 #[lang = "str"]
 #[cfg(not(test))]
-#[stable(feature = "rust1", since = "1.0.0")]
 impl str {
     /// Returns the length of `self` in bytes.
     ///

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -990,7 +990,6 @@ impl_eq! { Cow<'a, str>, String }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Default for String {
     #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
     fn default() -> String {
         String::new()
     }

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1405,7 +1405,6 @@ impl<T> Drop for Vec<T> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> Default for Vec<T> {
-    #[stable(feature = "rust1", since = "1.0.0")]
     fn default() -> Vec<T> {
         Vec::new()
     }

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -249,7 +249,6 @@ impl<T:Copy> Clone for Cell<T> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T:Default + Copy> Default for Cell<T> {
-    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     fn default() -> Cell<T> {
         Cell::new(Default::default())
@@ -468,7 +467,6 @@ impl<T: Clone> Clone for RefCell<T> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T:Default> Default for RefCell<T> {
-    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     fn default() -> RefCell<T> {
         RefCell::new(Default::default())

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -199,7 +199,6 @@ impl Eq for Ordering {}
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Ord for Ordering {
     #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
     fn cmp(&self, other: &Ordering) -> Ordering {
         (*self as i32).cmp(&(*other as i32))
     }
@@ -208,7 +207,6 @@ impl Ord for Ordering {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl PartialOrd for Ordering {
     #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
     fn partial_cmp(&self, other: &Ordering) -> Option<Ordering> {
         (*self as i32).partial_cmp(&(*other as i32))
     }

--- a/src/libcore/default.rs
+++ b/src/libcore/default.rs
@@ -133,7 +133,6 @@ macro_rules! default_impl {
         #[stable(feature = "rust1", since = "1.0.0")]
         impl Default for $t {
             #[inline]
-            #[stable(feature = "rust1", since = "1.0.0")]
             fn default() -> $t { $v }
         }
     }

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -3378,7 +3378,6 @@ impl<I: Iterator> Iterator for Peekable<I> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<I: ExactSizeIterator> ExactSizeIterator for Peekable<I> {}
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<I: Iterator> Peekable<I> {
     /// Returns a reference to the next() value without advancing the iterator.
     ///

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1636,7 +1636,6 @@ macro_rules! impl_from {
     ($Small: ty, $Large: ty) => {
         #[stable(feature = "lossless_prim_conv", since = "1.5.0")]
         impl From<$Small> for $Large {
-            #[stable(feature = "lossless_prim_conv", since = "1.5.0")]
             #[inline]
             fn from(small: $Small) -> $Large {
                 small as $Large

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -542,11 +542,9 @@ macro_rules! neg_impl_core {
     ($id:ident => $body:expr, $($t:ty)*) => ($(
         #[stable(feature = "rust1", since = "1.0.0")]
         impl Neg for $t {
-            #[stable(feature = "rust1", since = "1.0.0")]
             type Output = $t;
 
             #[inline]
-            #[stable(feature = "rust1", since = "1.0.0")]
             fn neg(self) -> $t { let $id = self; $body }
         }
 

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -756,7 +756,6 @@ impl<T: Default> Option<T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> Default for Option<T> {
     #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
     fn default() -> Option<T> { None }
 }
 
@@ -940,7 +939,6 @@ impl<A, V: FromIterator<A>> FromIterator<Option<A>> for Option<V> {
     /// assert!(res == Some(vec!(2, 3)));
     /// ```
     #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
     fn from_iter<I: IntoIterator<Item=Option<A>>>(iter: I) -> Option<V> {
         // FIXME(#11084): This could be replaced with Iterator::scan when this
         // performance bug is closed.

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -161,7 +161,6 @@ pub unsafe fn write<T>(dst: *mut T, src: T) {
     intrinsics::move_val_init(&mut *dst, src)
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 #[lang = "const_ptr"]
 impl<T: ?Sized> *const T {
     /// Returns true if the pointer is null.
@@ -210,7 +209,6 @@ impl<T: ?Sized> *const T {
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 #[lang = "mut_ptr"]
 impl<T: ?Sized> *mut T {
     /// Returns true if the pointer is null.

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -257,7 +257,6 @@ pub enum Result<T, E> {
 // Type implementation
 /////////////////////////////////////////////////////////////////////////////
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<T, E> Result<T, E> {
     /////////////////////////////////////////////////////////////////////////
     // Querying the contained values
@@ -708,7 +707,6 @@ impl<T, E> Result<T, E> {
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<T, E: fmt::Debug> Result<T, E> {
     /// Unwraps a result, yielding the content of an `Ok`.
     ///
@@ -758,7 +756,6 @@ impl<T, E: fmt::Debug> Result<T, E> {
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<T: fmt::Debug, E> Result<T, E> {
     /// Unwraps a result, yielding the content of an `Err`.
     ///

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -651,7 +651,6 @@ impl<T> ops::IndexMut<RangeFull> for [T] {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> Default for &'a [T] {
-    #[stable(feature = "rust1", since = "1.0.0")]
     fn default() -> &'a [T] { &[] }
 }
 

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -1826,6 +1826,5 @@ fn char_range_at_raw(bytes: &[u8], i: usize) -> (u32, usize) {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> Default for &'a str {
-    #[stable(feature = "rust1", since = "1.0.0")]
     fn default() -> &'a str { "" }
 }

--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -438,7 +438,6 @@ impl AtomicBool {
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl AtomicIsize {
     /// Creates a new `AtomicIsize`.
     ///
@@ -631,7 +630,6 @@ impl AtomicIsize {
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl AtomicUsize {
     /// Creates a new `AtomicUsize`.
     ///

--- a/src/libcore/tuple.rs
+++ b/src/libcore/tuple.rs
@@ -105,7 +105,6 @@ macro_rules! tuple_impls {
 
             #[stable(feature = "rust1", since = "1.0.0")]
             impl<$($T:Default),+> Default for ($($T,)+) {
-                #[stable(feature = "rust1", since = "1.0.0")]
                 #[inline]
                 fn default() -> ($($T,)+) {
                     ($({ let x: $T = Default::default(); x},)+)

--- a/src/librand/reseeding.rs
+++ b/src/librand/reseeding.rs
@@ -113,7 +113,6 @@ impl<R: Rng + Default> Reseeder<R> for ReseedWithDefault {
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Default for ReseedWithDefault {
-    #[stable(feature = "rust1", since = "1.0.0")]
     fn default() -> ReseedWithDefault {
         ReseedWithDefault
     }

--- a/src/librustc_unicode/char.rs
+++ b/src/librustc_unicode/char.rs
@@ -111,7 +111,6 @@ impl Iterator for CaseMappingIter {
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 #[lang = "char"]
 impl char {
     /// Checks if a `char` is a digit in the given radix.

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -675,7 +675,6 @@ impl<T, S> Default for HashSet<T, S>
     where T: Eq + Hash,
           S: HashState + Default,
 {
-    #[stable(feature = "rust1", since = "1.0.0")]
     fn default() -> HashSet<T, S> {
         HashSet::with_hash_state(Default::default())
     }

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -677,7 +677,6 @@ impl Iterator for ReadDir {
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl DirEntry {
     /// Returns the full path to the file that this entry represents.
     ///

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1534,7 +1534,6 @@ pub struct Take<T> {
     limit: u64,
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<T> Take<T> {
     /// Returns the number of bytes that can be read before this instance will
     /// return EOF.

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -120,7 +120,6 @@ mod cmath {
 
 #[cfg(not(test))]
 #[lang = "f32"]
-#[stable(feature = "rust1", since = "1.0.0")]
 impl f32 {
     /// Parses a float as with a given radix
     #[unstable(feature = "float_from_str_radix", reason = "recently moved API",

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -77,7 +77,6 @@ mod cmath {
 
 #[cfg(not(test))]
 #[lang = "f64"]
-#[stable(feature = "rust1", since = "1.0.0")]
 impl f64 {
     /// Parses a float as with a given radix
     #[unstable(feature = "float_from_str_radix", reason = "recently moved API",


### PR DESCRIPTION
Also remove `stable` stability annotations from inherent impls

(There will be a warning for useless stability annotations soon.)

r? @Gankro 
