### PR TITLE
Preserve public static items across LTO

### DIFF
--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -344,6 +344,11 @@ pub fn is_const_fn(cstore: &cstore::CStore, did: DefId) -> bool {
     decoder::is_const_fn(&*cdata, did.index)
 }
 
+pub fn is_static(cstore: &cstore::CStore, did: DefId) -> bool {
+    let cdata = cstore.get_crate_data(did.krate);
+    decoder::is_static(&*cdata, did.index)
+}
+
 pub fn is_impl(cstore: &cstore::CStore, did: DefId) -> bool {
     let cdata = cstore.get_crate_data(did.krate);
     decoder::is_impl(&*cdata, did.index)

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1425,6 +1425,14 @@ pub fn is_const_fn(cdata: Cmd, id: DefIndex) -> bool {
     }
 }
 
+pub fn is_static(cdata: Cmd, id: DefIndex) -> bool {
+    let item_doc = cdata.lookup_item(id);
+    match item_family(item_doc) {
+        ImmStatic | MutStatic => true,
+        _ => false,
+    }
+}
+
 pub fn is_impl(cdata: Cmd, id: DefIndex) -> bool {
     let item_doc = cdata.lookup_item(id);
     match item_family(item_doc) {

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -2875,7 +2875,8 @@ pub fn trans_crate<'tcx>(tcx: &ty::ctxt<'tcx>,
         sess.cstore.iter_crate_data(|cnum, _| {
             let syms = csearch::get_reachable_ids(&sess.cstore, cnum);
             reachable_symbols.extend(syms.into_iter().filter(|did| {
-                csearch::is_extern_fn(&sess.cstore, *did, shared_ccx.tcx())
+                csearch::is_extern_fn(&sess.cstore, *did, shared_ccx.tcx()) ||
+                csearch::is_static(&sess.cstore, *did)
             }).map(|did| {
                 csearch::get_symbol(&sess.cstore, did)
             }));

--- a/src/test/run-make/issue-14500/foo.c
+++ b/src/test/run-make/issue-14500/foo.c
@@ -9,8 +9,9 @@
 // except according to those terms.
 
 extern void foo();
+extern char FOO_STATIC;
 
 int main() {
     foo();
-    return 0;
+    return (int)FOO_STATIC;
 }

--- a/src/test/run-make/issue-14500/foo.rs
+++ b/src/test/run-make/issue-14500/foo.rs
@@ -10,3 +10,6 @@
 
 #[no_mangle]
 pub extern fn foo() {}
+
+#[no_mangle]
+pub static FOO_STATIC: u8 = 0;


### PR DESCRIPTION
This is currently done for functions but not public static symbols.
