### PR TITLE
Fix -windows-gnu installer

### DIFF
--- a/mk/cfg/i686-pc-windows-gnu.mk
+++ b/mk/cfg/i686-pc-windows-gnu.mk
@@ -22,4 +22,5 @@ CFG_LDPATH_i686-pc-windows-gnu :=
 CFG_RUN_i686-pc-windows-gnu=$(2)
 CFG_RUN_TARG_i686-pc-windows-gnu=$(call CFG_RUN_i686-pc-windows-gnu,,$(2))
 CFG_GNU_TRIPLE_i686-pc-windows-gnu := i686-w64-mingw32
-CFG_LIBC_STARTUP_OBJECTS_i686-pc-windows-gnu := crt2.o dllcrt2.o
+CFG_THIRD_PARTY_OBJECTS_i686-pc-windows-gnu := crt2.o dllcrt2.o
+CFG_INSTALLED_OBJECTS_i686-pc-windows-gnu := crt2.o dllcrt2.o rsbegin.o rsend.o

--- a/mk/cfg/x86_64-pc-windows-gnu.mk
+++ b/mk/cfg/x86_64-pc-windows-gnu.mk
@@ -22,4 +22,5 @@ CFG_LDPATH_x86_64-pc-windows-gnu :=
 CFG_RUN_x86_64-pc-windows-gnu=$(2)
 CFG_RUN_TARG_x86_64-pc-windows-gnu=$(call CFG_RUN_x86_64-pc-windows-gnu,,$(2))
 CFG_GNU_TRIPLE_x86_64-pc-windows-gnu := x86_64-w64-mingw32
-CFG_LIBC_STARTUP_OBJECTS_x86_64-pc-windows-gnu := crt2.o dllcrt2.o
+CFG_THIRD_PARTY_OBJECTS_x86_64-pc-windows-gnu := crt2.o dllcrt2.o
+CFG_INSTALLED_OBJECTS_x86_64-pc-windows-gnu := crt2.o dllcrt2.o rsbegin.o rsend.o

--- a/mk/cfg/x86_64-unknown-linux-musl.mk
+++ b/mk/cfg/x86_64-unknown-linux-musl.mk
@@ -21,8 +21,8 @@ CFG_LDPATH_x86_64-unknown-linux-musl :=
 CFG_RUN_x86_64-unknown-linux-musl=$(2)
 CFG_RUN_TARG_x86_64-unknown-linux-musl=$(call CFG_RUN_x86_64-unknown-linux-musl,,$(2))
 CFG_GNU_TRIPLE_x86_64-unknown-linux-musl := x86_64-unknown-linux-musl
+CFG_THIRD_PARTY_OBJECTS_x86_64-unknown-linux-musl := crt1.o crti.o crtn.o
+CFG_INSTALLED_OBJECTS_x86_64-unknown-linux-musl := crt1.o crti.o crtn.o
 
 NATIVE_DEPS_libc_T_x86_64-unknown-linux-musl += libc.a
-NATIVE_DEPS_std_T_x86_64-unknown-linux-musl += libunwind.a \
-	crt1.o crti.o crtn.o
-INSTALLED_OBJECTS_x86_64-unknown-linux-musl += crt1.o crti.o crtn.o
+NATIVE_DEPS_std_T_x86_64-unknown-linux-musl += libunwind.a crt1.o crti.o crtn.o

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -415,7 +415,7 @@ endif
 # Prerequisites for using the stageN compiler to build target artifacts
 TSREQ$(1)_T_$(2)_H_$(3) = \
 	$$(HSREQ$(1)_H_$(3)) \
-	$$(foreach obj,$$(INSTALLED_OBJECTS_$(2)),\
+	$$(foreach obj,$$(REQUIRED_OBJECTS_$(2)),\
 		$$(TLIB$(1)_T_$(2)_H_$(3))/$$(obj))
 
 # Prerequisites for a working stageN compiler and libraries, for a specific

--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -113,7 +113,10 @@ CFG_RLIB_GLOB=lib$(1)-*.rlib
 include $(wildcard $(CFG_SRC_DIR)mk/cfg/*.mk)
 
 define ADD_INSTALLED_OBJECTS
+  INSTALLED_OBJECTS_$(1) += $$(CFG_INSTALLED_OBJECTS_$(1))
+  REQUIRED_OBJECTS_$(1) += $$(CFG_THIRD_PARTY_OBJECTS_$(1))
   INSTALLED_OBJECTS_$(1) += $$(call CFG_STATIC_LIB_NAME_$(1),compiler-rt)
+  REQUIRED_OBJECTS_$(1) += $$(call CFG_STATIC_LIB_NAME_$(1),compiler-rt)
 endef
 
 $(foreach target,$(CFG_TARGET), \

--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -352,6 +352,10 @@ endif # endif for darwin
 ifeq ($$(findstring musl,$(1)),musl)
 $$(RT_OUTPUT_DIR_$(1))/%: $$(CFG_MUSL_ROOT)/lib/%
 	cp $$^ $$@
+else
+# Ask gcc where it is
+$$(RT_OUTPUT_DIR_$(1))/%:
+	cp $$(shell $$(CC_$(1)) -print-file-name=$$(@F)) $$@
 endif
 
 endef

--- a/src/etc/make-win-dist.py
+++ b/src/etc/make-win-dist.py
@@ -58,10 +58,6 @@ def make_win_dist(rust_root, plat_root, target_triple):
         rustc_dlls.append("libgcc_s_seh-1.dll")
 
     target_libs = [ # MinGW libs
-                    "crtbegin.o",
-                    "crtend.o",
-                    "crt2.o",
-                    "dllcrt2.o",
                     "libgcc.a",
                     "libgcc_eh.a",
                     "libgcc_s.a",


### PR DESCRIPTION
Resolves  #29672.   This happened because rust runtime startup objects, rsbegin.o and rsend.o, were not included in the target libraries package for -windows-gnu.

r? @alexcrichton 
