### PR TITLE
librustc: dont warn for inside of items when the parent is dead

### DIFF
--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -539,19 +539,18 @@ impl<'a, 'tcx, 'v> Visitor<'v> for DeadVisitor<'a, 'tcx> {
                 item.node.descriptive_variant()
             );
         } else {
-            match item.node {
-                hir::ItemEnum(ref enum_def, _) => {
-                    for variant in &enum_def.variants {
-                        if self.should_warn_about_variant(&variant.node) {
-                            self.warn_dead_code(variant.node.data.id(), variant.span,
-                                                variant.node.name, "variant");
-                        }
-                    }
-                },
-                _ => ()
-            }
+            // Only continue if we didn't warn
+            visit::walk_item(self, item);
         }
-        visit::walk_item(self, item);
+    }
+
+    fn visit_variant(&mut self, variant: &hir::Variant, g: &hir::Generics, id: ast::NodeId) {
+        if self.should_warn_about_variant(&variant.node) {
+            self.warn_dead_code(variant.node.data.id(), variant.span,
+                                variant.node.name, "variant");
+        } else {
+            visit::walk_variant(self, variant, g, id);
+        }
     }
 
     fn visit_foreign_item(&mut self, fi: &hir::ForeignItem) {

--- a/src/test/compile-fail/lint-dead-code-3.rs
+++ b/src/test/compile-fail/lint-dead-code-3.rs
@@ -30,7 +30,7 @@ impl Foo {
 }
 
 fn bar() { //~ ERROR: function is never used
-    fn baz() {} //~ ERROR: function is never used
+    fn baz() {}
 
     Foo.foo();
     baz();

--- a/src/test/compile-fail/lint-dead-code-4.rs
+++ b/src/test/compile-fail/lint-dead-code-4.rs
@@ -25,10 +25,39 @@ enum XYZ {
     X, //~ ERROR variant is never used
     Y { //~ ERROR variant is never used
         a: String,
-        b: i32, //~ ERROR: struct field is never used
-        c: i32, //~ ERROR: struct field is never used
+        b: i32,
+        c: i32,
     },
     Z
+}
+
+enum ABC { //~ ERROR enum is never used
+    A,
+    B {
+        a: String,
+        b: i32,
+        c: i32,
+    },
+    C
+}
+
+// ensure struct variants get warning for their fields
+enum IJK {
+    I, //~ ERROR variant is never used
+    J {
+        a: String,
+        b: i32, //~ ERROR struct field is never used
+        c: i32, //~ ERROR struct field is never used
+    },
+    K //~ ERROR variant is never used
+
+}
+
+fn struct_variant_partial_use(b: IJK) -> String {
+    match b {
+        IJK::J { a, b: _, .. } => a,
+        _ => "".to_string()
+    }
 }
 
 fn field_match_in_patterns(b: XYZ) -> String {
@@ -58,6 +87,7 @@ fn field_match_in_let(f: Bar) -> bool {
 fn main() {
     field_read(Foo { x: 1, b: false });
     field_match_in_patterns(XYZ::Z);
+    struct_variant_partial_use(IJK::J { a: "".into(), b: 1, c: -1 });
     field_match_in_let(Bar { x: 42, b: true, c: false, _guard: () });
     let _ = Baz { x: 0 };
 }


### PR DESCRIPTION
This standardises the current behavior to match `enum` variants, hopefully leading to less warning spam for users!

For example the code below will have 2 warnings (for `Foo` and `Bar`) rather than 7:

``` rust
enum Foo {
    A,
    B { a: String, b: isize },
    C
}

struct Bar {
    a: i32,
    b: String,
    c: ()
}

fn main() {
    println!("Hi")
}
```

http://is.gd/zAztKW
