### PR TITLE
doc: error-handling.md: main case analysis for search

### DIFF
--- a/src/doc/trpl/error-handling.md
+++ b/src/doc/trpl/error-handling.md
@@ -1838,6 +1838,22 @@ impl<'a, 'b> From<&'b str> for Box<Error + Send + Sync + 'a>
 impl From<String> for Box<Error + Send + Sync>
 ```
 
+Since `search` now returns a `Result<T, E>`, `main` should use case analysis
+when calling `search`:
+
+```rust,ignore
+...
+match search(&data_file, &city) {
+    Ok(pops) => {
+        for pop in pops {
+            println!("{}, {}: {:?}", pop.city, pop.country, pop.count);
+        }
+    }
+    Err(err) => println!("{}", err)
+}
+...
+```
+
 Now that we've seen how to do proper error handling with `Box<Error>`, let's
 try a different approach with our own custom error type. But first, let's take
 a quick break from error handling and add support for reading from `stdin`.


### PR DESCRIPTION
In src/doc/trpl/error-handling.md, in this section:
## Error handling with Box<Error>

It mentions three steps, to "convert this to proper error handling", the last one being:
1. Handle the error in main.

However, it is not shown. This pull request adds a code example showing how `main`'s call to `search` should use case analysis. I am still very much new to learning Rust, so this may not be idiomatic. Happy to make changes with guidance.
