### PR TITLE
Implement FromIterator for arrays up to [T; 32]

### DIFF
--- a/src/libcoretest/array.rs
+++ b/src/libcoretest/array.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 use core::array::FixedSizeArray;
+use core::iter::{empty, Iterator, repeat};
 
 #[test]
 fn fixed_size_array() {
@@ -25,4 +26,30 @@ fn fixed_size_array() {
     assert_eq!(FixedSizeArray::as_mut_slice(&mut zero_sized).len(), 64);
     assert_eq!(FixedSizeArray::as_mut_slice(&mut empty_array).len(), 0);
     assert_eq!(FixedSizeArray::as_mut_slice(&mut empty_zero_sized).len(), 0);
+}
+
+#[test]
+fn test_from_iter() {
+    assert_eq!((0..3).collect::<[u8; 3]>(), [0, 1, 2]);
+    assert_eq!((0..5).map(|x| x * x).collect::<[i32; 5]>(), [0, 1, 4, 9, 16]);
+    assert_eq!(repeat([0, 1, 2]).take(32).collect::<[[u64; 3]; 32]>(), [[0, 1, 2]; 32]);
+    assert_eq!(empty().collect::<[u8; 0]>(), []);
+}
+
+#[test]
+#[should_panic(expected = "iterator too short")]
+fn test_from_iter_too_short() {
+    (0..2).collect::<[i32; 3]>();
+}
+
+#[test]
+#[should_panic(expected = "iterator too long")]
+fn test_from_iter_too_long() {
+    (0..3).collect::<[i32; 2]>();
+}
+
+#[test]
+#[should_panic(expected = "iterator too long")]
+fn test_from_iter_too_long_empty() {
+    repeat(0).collect::<[i32; 0]>();
 }

--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -167,6 +167,7 @@ mod prim_pointer { }
 ///
 /// - `Clone` (only if `T: Copy`)
 /// - `Debug`
+/// - `FromIterator`
 /// - `IntoIterator` (implemented for `&[T; N]` and `&mut [T; N]`)
 /// - `PartialEq`, `PartialOrd`, `Ord`, `Eq`
 /// - `Hash`


### PR DESCRIPTION
I have used basically the same macro as for `Default`.
It will `panic!` if the iterator is not exactly the correct length.
This goes some way to solving rust-lang/rfcs#1109.

For example:

``` rust
fn from_iter<I: IntoIterator<Item=T>>(iterator: I) -> [T; 3] {
    let mut i = iterator.into_iter();
    let a = [
        i.next().expect("iterator too short"),
        i.next().expect("iterator too short"),
        i.next().expect("iterator too short"),
    ];
    assert!(i.next().is_none(), "iterator too long");
    a
}
```

This relies on the evaluation order within array expressions which I don't know is well defined yet. If it's not it will be easy to fix.
I have added some simple tests to `src/libcoretest/array.rs`.
