### PR TITLE
std: Fix endianness in Ord for IP addresses

### DIFF
--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -235,7 +235,7 @@ impl PartialOrd for Ipv4Addr {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Ord for Ipv4Addr {
     fn cmp(&self, other: &Ipv4Addr) -> Ordering {
-        self.inner.s_addr.cmp(&other.inner.s_addr)
+        self.octets().cmp(&other.octets())
     }
 }
 
@@ -498,7 +498,7 @@ impl PartialOrd for Ipv6Addr {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Ord for Ipv6Addr {
     fn cmp(&self, other: &Ipv6Addr) -> Ordering {
-        self.inner.s6_addr.cmp(&other.inner.s6_addr)
+        self.segments().cmp(&other.segments())
     }
 }
 
@@ -785,5 +785,12 @@ mod tests {
     fn test_int_to_ipv4() {
         let a = Ipv4Addr::new(127, 0, 0, 1);
         assert_eq!(Ipv4Addr::from(2130706433), a);
+    }
+
+    #[test]
+    fn ord() {
+        assert!(Ipv4Addr::new(100, 64, 3, 3) < Ipv4Addr::new(192, 0, 2, 2));
+        assert!("2001:db8:f00::1002".parse::<Ipv6Addr>().unwrap() <
+                "2001:db8:f00::2001".parse::<Ipv6Addr>().unwrap());
     }
 }


### PR DESCRIPTION
The comparison of IP addresses should happen not always in network endianness
but rather in the host endianness format, so be sure to convert to that before
comparing addresses.

There are still locations where the endianness will factor into visible
properties, such as the hash, but these are not important to be independent of
the endianness in play (as hash values are pretty undefined anyway.

Closes #29691
