### PR TITLE
Tag feature gates with issues

### DIFF
--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -51,53 +51,59 @@ const KNOWN_FEATURES: &'static [(&'static str, &'static str, Option<u32>, Status
     ("globs", "1.0.0", None, Accepted),
     ("macro_rules", "1.0.0", None, Accepted),
     ("struct_variant", "1.0.0", None, Accepted),
-    ("asm", "1.0.0", None, Active),
+    ("asm", "1.0.0", Some(29722), Active),
     ("managed_boxes", "1.0.0", None, Removed),
-    ("non_ascii_idents", "1.0.0", None, Active),
-    ("thread_local", "1.0.0", None, Active),
-    ("link_args", "1.0.0", None, Active),
-    ("plugin_registrar", "1.0.0", None, Active),
-    ("log_syntax", "1.0.0", None, Active),
-    ("trace_macros", "1.0.0", None, Active),
-    ("concat_idents", "1.0.0", None, Active),
+    ("non_ascii_idents", "1.0.0", Some(28979), Active),
+    ("thread_local", "1.0.0", Some(29594), Active),
+    ("link_args", "1.0.0", Some(29596), Active),
+    ("plugin_registrar", "1.0.0", Some(29597), Active),
+    ("log_syntax", "1.0.0", Some(29598), Active),
+    ("trace_macros", "1.0.0", Some(29598), Active),
+    ("concat_idents", "1.0.0", Some(29599), Active),
+
+    // rustc internal, for now:
     ("intrinsics", "1.0.0", None, Active),
     ("lang_items", "1.0.0", None, Active),
 
     ("simd", "1.0.0", Some(27731), Active),
     ("default_type_params", "1.0.0", None, Accepted),
-    ("quote", "1.0.0", None, Active),
-    ("link_llvm_intrinsics", "1.0.0", None, Active),
-    ("linkage", "1.0.0", None, Active),
+    ("quote", "1.0.0", Some(29601), Active),
+    ("link_llvm_intrinsics", "1.0.0", Some(29602), Active),
+    ("linkage", "1.0.0", Some(29603), Active),
     ("struct_inherit", "1.0.0", None, Removed),
 
     ("quad_precision_float", "1.0.0", None, Removed),
 
+    // rustc internal
     ("rustc_diagnostic_macros", "1.0.0", None, Active),
-    ("unboxed_closures", "1.0.0", None, Active),
-    ("reflect", "1.0.0", None, Active),
+    ("unboxed_closures", "1.0.0", Some(29625), Active),
+    ("reflect", "1.0.0", Some(27749), Active),
     ("import_shadowing", "1.0.0", None, Removed),
-    ("advanced_slice_patterns", "1.0.0", None, Active),
+    ("advanced_slice_patterns", "1.0.0", Some(23121), Active),
     ("tuple_indexing", "1.0.0", None, Accepted),
     ("associated_types", "1.0.0", None, Accepted),
-    ("visible_private_types", "1.0.0", None, Active),
+    ("visible_private_types", "1.0.0", Some(29627), Active),
     ("slicing_syntax", "1.0.0", None, Accepted),
     ("box_syntax", "1.0.0", Some(27779), Active),
     ("placement_in_syntax", "1.0.0", Some(27779), Active),
+
+    // rustc internal.
     ("pushpop_unsafe", "1.2.0", None, Active),
-    ("on_unimplemented", "1.0.0", None, Active),
-    ("simd_ffi", "1.0.0", None, Active),
-    ("allocator", "1.0.0", None, Active),
-    ("needs_allocator", "1.4.0", None, Active),
-    ("linked_from", "1.3.0", None, Active),
+
+    ("on_unimplemented", "1.0.0", Some(29628), Active),
+    ("simd_ffi", "1.0.0", Some(27731), Active),
+    ("allocator", "1.0.0", Some(27389), Active),
+    ("needs_allocator", "1.4.0", Some(27389), Active),
+    ("linked_from", "1.3.0", Some(29629), Active),
 
     ("if_let", "1.0.0", None, Accepted),
     ("while_let", "1.0.0", None, Accepted),
 
-    ("plugin", "1.0.0", None, Active),
-    ("start", "1.0.0", None, Active),
-    ("main", "1.0.0", None, Active),
+    ("plugin", "1.0.0", Some(29597), Active),
+    ("start", "1.0.0", Some(29633), Active),
+    ("main", "1.0.0", Some(29634), Active),
 
-    ("fundamental", "1.0.0", None, Active),
+    ("fundamental", "1.0.0", Some(29635), Active),
 
     // A temporary feature gate used to enable parser extensions needed
     // to bootstrap fix for #5723.
@@ -107,10 +113,10 @@ const KNOWN_FEATURES: &'static [(&'static str, &'static str, Option<u32>, Status
     ("opt_out_copy", "1.0.0", None, Removed),
 
     // OIBIT specific features
-    ("optin_builtin_traits", "1.0.0", None, Active),
+    ("optin_builtin_traits", "1.0.0", Some(13231), Active),
 
     // macro reexport needs more discussion and stabilization
-    ("macro_reexport", "1.0.0", None, Active),
+    ("macro_reexport", "1.0.0", Some(29638), Active),
 
     // These are used to test this portion of the compiler, they don't actually
     // mean anything
@@ -118,19 +124,21 @@ const KNOWN_FEATURES: &'static [(&'static str, &'static str, Option<u32>, Status
     ("test_removed_feature", "1.0.0", None, Removed),
 
     // Allows use of #[staged_api]
+    // rustc internal
     ("staged_api", "1.0.0", None, Active),
 
     // Allows using items which are missing stability attributes
+    // rustc internal
     ("unmarked_api", "1.0.0", None, Active),
 
     // Allows using #![no_std]
-    ("no_std", "1.0.0", None, Active),
+    ("no_std", "1.0.0", Some(27701), Active),
 
     // Allows using #![no_core]
-    ("no_core", "1.3.0", None, Active),
+    ("no_core", "1.3.0", Some(29639), Active),
 
     // Allows using `box` in patterns; RFC 469
-    ("box_patterns", "1.0.0", None, Active),
+    ("box_patterns", "1.0.0", Some(29641), Active),
 
     // Allows using the unsafe_no_drop_flag attribute (unlikely to
     // switch to Accepted; see RFC 320)
@@ -141,75 +149,81 @@ const KNOWN_FEATURES: &'static [(&'static str, &'static str, Option<u32>, Status
     ("dropck_parametricity", "1.3.0", Some(28498), Active),
 
     // Allows the use of custom attributes; RFC 572
-    ("custom_attribute", "1.0.0", None, Active),
+    ("custom_attribute", "1.0.0", Some(29642), Active),
 
     // Allows the use of #[derive(Anything)] as sugar for
     // #[derive_Anything].
-    ("custom_derive", "1.0.0", None, Active),
+    ("custom_derive", "1.0.0", Some(29644), Active),
 
     // Allows the use of rustc_* attributes; RFC 572
-    ("rustc_attrs", "1.0.0", None, Active),
+    ("rustc_attrs", "1.0.0", Some(29642), Active),
 
     // Allows the use of #[allow_internal_unstable]. This is an
     // attribute on macro_rules! and can't use the attribute handling
     // below (it has to be checked before expansion possibly makes
     // macros disappear).
+    //
+    // rustc internal
     ("allow_internal_unstable", "1.0.0", None, Active),
 
     // #23121. Array patterns have some hazards yet.
-    ("slice_patterns", "1.0.0", None, Active),
+    ("slice_patterns", "1.0.0", Some(23121), Active),
 
     // Allows use of unary negate on unsigned integers, e.g. -e for e: u8
-    ("negate_unsigned", "1.0.0", None, Active),
+    ("negate_unsigned", "1.0.0", Some(29645), Active),
 
     // Allows the definition of associated constants in `trait` or `impl`
     // blocks.
-    ("associated_consts", "1.0.0", None, Active),
+    ("associated_consts", "1.0.0", Some(29646), Active),
 
     // Allows the definition of `const fn` functions.
-    ("const_fn", "1.2.0", None, Active),
+    ("const_fn", "1.2.0", Some(24111), Active),
 
     // Allows using #[prelude_import] on glob `use` items.
+    //
+    // rustc internal
     ("prelude_import", "1.2.0", None, Active),
 
     // Allows the definition recursive static items.
-    ("static_recursion", "1.3.0", None, Active),
+    ("static_recursion", "1.3.0", Some(29719), Active),
 
     // Allows default type parameters to influence type inference.
-    ("default_type_parameter_fallback", "1.3.0", None, Active),
+    ("default_type_parameter_fallback", "1.3.0", Some(27336), Active),
 
     // Allows associated type defaults
-    ("associated_type_defaults", "1.2.0", None, Active),
-    // Allows macros to appear in the type position.
+    ("associated_type_defaults", "1.2.0", Some(29661), Active),
 
+    // Allows macros to appear in the type position.
     ("type_macros", "1.3.0", Some(27336), Active),
 
     // allow `repr(simd)`, and importing the various simd intrinsics
     ("repr_simd", "1.4.0", Some(27731), Active),
 
     // Allows cfg(target_feature = "...").
-    ("cfg_target_feature", "1.4.0", None, Active),
+    ("cfg_target_feature", "1.4.0", Some(29717), Active),
 
     // allow `extern "platform-intrinsic" { ... }`
     ("platform_intrinsics", "1.4.0", Some(27731), Active),
 
     // allow `#[unwind]`
+    // rust runtime internal
     ("unwind_attributes", "1.4.0", None, Active),
 
     // allow empty structs and enum variants with braces
-    ("braced_empty_structs", "1.5.0", None, Active),
+    ("braced_empty_structs", "1.5.0", Some(29720), Active),
 
     // allow overloading augmented assignment operations like `a += b`
-    ("augmented_assignments", "1.5.0", None, Active),
+    ("augmented_assignments", "1.5.0", Some(28235), Active),
 
     // allow `#[no_debug]`
-    ("no_debug", "1.5.0", None, Active),
+    ("no_debug", "1.5.0", Some(29721), Active),
 
     // allow `#[omit_gdb_pretty_printer_section]`
+    // rustc internal.
     ("omit_gdb_pretty_printer_section", "1.5.0", None, Active),
 
     // Allows cfg(target_vendor = "...").
-    ("cfg_target_vendor", "1.5.0", None, Active),
+    ("cfg_target_vendor", "1.5.0", Some(29718), Active),
 ];
 // (changing above list without updating src/doc/reference.md makes @cmr sad)
 


### PR DESCRIPTION
This commit adds issue numbers to the vast majority of active feature
gates. The few that are left without issues are rustc/runtime-internal
features that are essentially private APIs.

Closes #28244

r? @huonw 
