### PR TITLE
rustc_privacy: Fix bugs in SanePrivacyVisitor

### DIFF
--- a/src/doc/trpl/associated-constants.md
+++ b/src/doc/trpl/associated-constants.md
@@ -74,6 +74,6 @@ for a `struct` or an `enum` works fine too:
 struct Foo;
 
 impl Foo {
-    pub const FOO: u32 = 3;
+    const FOO: u32 = 3;
 }
 ```

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -1094,7 +1094,10 @@ impl<'a, 'tcx> SanePrivacyVisitor<'a, 'tcx> {
                 check_inherited(item.span, item.vis,
                                 "place qualifiers on individual functions instead");
             }
-            _ => {}
+            hir::ItemStruct(..) | hir::ItemEnum(..) | hir::ItemTrait(..) |
+            hir::ItemConst(..) | hir::ItemStatic(..) | hir::ItemFn(..) |
+            hir::ItemMod(..) | hir::ItemExternCrate(..) |
+            hir::ItemUse(..) | hir::ItemTy(..) => {}
         }
     }
 
@@ -1125,7 +1128,10 @@ impl<'a, 'tcx> SanePrivacyVisitor<'a, 'tcx> {
                     check_inherited(f.span, f.node.kind.visibility());
                 }
             }
-            _ => {}
+            hir::ItemDefaultImpl(..) | hir::ItemEnum(..) | hir::ItemTrait(..) |
+            hir::ItemConst(..) | hir::ItemStatic(..) | hir::ItemFn(..) |
+            hir::ItemMod(..) | hir::ItemExternCrate(..) |
+            hir::ItemUse(..) | hir::ItemTy(..) => {}
         }
     }
 }

--- a/src/test/compile-fail/privacy-sanity.rs
+++ b/src/test/compile-fail/privacy-sanity.rs
@@ -1,0 +1,113 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(associated_consts)]
+#![feature(optin_builtin_traits)]
+
+trait MarkerTr {}
+pub trait Tr {
+    fn f();
+    const C: u8;
+    type T;
+}
+pub struct S {
+    pub a: u8
+}
+struct Ts(pub u8);
+
+pub impl MarkerTr for .. {} //~ ERROR unnecessary visibility qualifier
+pub impl Tr for S {  //~ ERROR unnecessary visibility qualifier
+    pub fn f() {} //~ ERROR unnecessary visibility qualifier
+    pub const C: u8 = 0; //~ ERROR unnecessary visibility qualifier
+    pub type T = u8; //~ ERROR unnecessary visibility qualifier
+}
+pub impl S { //~ ERROR unnecessary visibility qualifier
+    pub fn f() {}
+    pub const C: u8 = 0;
+    // pub type T = u8;
+}
+pub extern "C" { //~ ERROR unnecessary visibility qualifier
+    pub fn f();
+    pub static St: u8;
+}
+
+const MAIN: u8 = {
+    trait MarkerTr {}
+    pub trait Tr { //~ ERROR visibility has no effect inside functions or block
+        fn f();
+        const C: u8;
+        type T;
+    }
+    pub struct S { //~ ERROR visibility has no effect inside functions or block
+        pub a: u8 //~ ERROR visibility has no effect inside functions or block
+    }
+    struct Ts(pub u8); //~ ERROR visibility has no effect inside functions or block
+
+    pub impl MarkerTr for .. {} //~ ERROR unnecessary visibility qualifier
+    //~^ ERROR visibility has no effect inside functions or block
+    pub impl Tr for S {  //~ ERROR unnecessary visibility qualifier
+    //~^ ERROR visibility has no effect inside functions or block
+        pub fn f() {} //~ ERROR unnecessary visibility qualifier
+        //~^ ERROR visibility has no effect inside functions or block
+        pub const C: u8 = 0; //~ ERROR unnecessary visibility qualifier
+        //~^ ERROR visibility has no effect inside functions or block
+        pub type T = u8; //~ ERROR unnecessary visibility qualifier
+        //~^ ERROR visibility has no effect inside functions or block
+    }
+    pub impl S { //~ ERROR unnecessary visibility qualifier
+    //~^ ERROR visibility has no effect inside functions or block
+        pub fn f() {} //~ ERROR visibility has no effect inside functions or block
+        pub const C: u8 = 0; //~ ERROR visibility has no effect inside functions or block
+        // pub type T = u8; // ERROR visibility has no effect inside functions or block
+    }
+    pub extern "C" { //~ ERROR unnecessary visibility qualifier
+    //~^ ERROR visibility has no effect inside functions or block
+        pub fn f(); //~ ERROR visibility has no effect inside functions or block
+        pub static St: u8; //~ ERROR visibility has no effect inside functions or block
+    }
+
+    0
+};
+
+fn main() {
+    trait MarkerTr {}
+    pub trait Tr { //~ ERROR visibility has no effect inside functions or block
+        fn f();
+        const C: u8;
+        type T;
+    }
+    pub struct S { //~ ERROR visibility has no effect inside functions or block
+        pub a: u8 //~ ERROR visibility has no effect inside functions or block
+    }
+    struct Ts(pub u8); //~ ERROR visibility has no effect inside functions or block
+
+    pub impl MarkerTr for .. {} //~ ERROR unnecessary visibility qualifier
+    //~^ ERROR visibility has no effect inside functions or block
+    pub impl Tr for S {  //~ ERROR unnecessary visibility qualifier
+    //~^ ERROR visibility has no effect inside functions or block
+        pub fn f() {} //~ ERROR unnecessary visibility qualifier
+        //~^ ERROR visibility has no effect inside functions or block
+        pub const C: u8 = 0; //~ ERROR unnecessary visibility qualifier
+        //~^ ERROR visibility has no effect inside functions or block
+        pub type T = u8; //~ ERROR unnecessary visibility qualifier
+        //~^ ERROR visibility has no effect inside functions or block
+    }
+    pub impl S { //~ ERROR unnecessary visibility qualifier
+    //~^ ERROR visibility has no effect inside functions or block
+        pub fn f() {} //~ ERROR visibility has no effect inside functions or block
+        pub const C: u8 = 0; //~ ERROR visibility has no effect inside functions or block
+        // pub type T = u8; // ERROR visibility has no effect inside functions or block
+    }
+    pub extern "C" { //~ ERROR unnecessary visibility qualifier
+    //~^ ERROR visibility has no effect inside functions or block
+        pub fn f(); //~ ERROR visibility has no effect inside functions or block
+        pub static St: u8; //~ ERROR visibility has no effect inside functions or block
+    }
+}

--- a/src/test/run-pass/const-block-item.rs
+++ b/src/test/run-pass/const-block-item.rs
@@ -20,11 +20,6 @@ static BLOCK_USE: usize = {
     100
 };
 
-static BLOCK_PUB_USE: usize = {
-    pub use foo::Value;
-    200
-};
-
 static BLOCK_STRUCT_DEF: usize = {
     struct Foo {
         a: usize
@@ -48,7 +43,6 @@ static BLOCK_MACRO_RULES: usize = {
 
 pub fn main() {
     assert_eq!(BLOCK_USE, 100);
-    assert_eq!(BLOCK_PUB_USE, 200);
     assert_eq!(BLOCK_STRUCT_DEF, 300);
     assert_eq!(BLOCK_FN_DEF(390), 400);
     assert_eq!(BLOCK_MACRO_RULES, 412);


### PR DESCRIPTION
- Check privacy sanity in all blocks, not only function bodies
- Check all fields, not only named
- Check all impl items, not only methods
- Check default impls
- Move the sanity check in the beginning of privacy checking, so others could rely on it

Technically it's a [breaking-change], but I expect no breakage because, well, it's _sane_ privacy visitor, if code is broken it must be insane by definition!
