### PR TITLE
syntax: Use `let _` in #[derive(Debug)]

### DIFF
--- a/src/test/run-pass/issue-29710.rs
+++ b/src/test/run-pass/issue-29710.rs
@@ -1,0 +1,20 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(unused_results)]
+#![allow(dead_code)]
+
+#[derive(Debug)]
+struct A(usize);
+
+#[derive(Debug)]
+struct B { a: usize }
+
+fn main() {}


### PR DESCRIPTION
This should help avoid triggering the unused_results lint which can frequently
be turned on.

Closes #29710
