### PR TITLE
Redo the README intro again

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,9 @@
 # The Rust Programming Language
 
-Rust is a fast systems programming language that guarantees
-memory safety and offers painless concurrency ([no data races]).
-It does not employ a garbage collector and has minimal runtime overhead.
+This is the main source code repository for [Rust]. It contains the compiler, standard library,
+and documentation.
 
-This repo contains the code for the compiler (`rustc`), as well
-as standard libraries, tools and documentation for Rust.
-
-[no data races]: http://blog.rust-lang.org/2015/04/10/Fearless-Concurrency.html
+[Rust]: https://www.rust-lang.org
 
 ## Quick Start
 


### PR DESCRIPTION
r? @steveklabnik 

This completely abdicates any responsibility to explain what Rust is, instead linking to the website.

My main motivation is that I am still not happy with it, and every time I try to fix it I just write a slightly longer sales pitch than what's on the website.

One thing this paragraph could do is direct people to more information about what is in the repo, or more technical information about the implementation.
