### PR TITLE
Properly support inline asm indirect output operands

### DIFF
--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -368,8 +368,7 @@ impl<'a, 'tcx> CFGBuilder<'a, 'tcx> {
                 }), pred);
                 let post_outputs = self.exprs(outputs.map(|a| {
                     debug!("cfg::construct InlineAsm id:{} output:{:?}", expr.id, a);
-                    let &(_, ref expr, _, _) = a;
-                    &**expr
+                    &*a.expr
                 }), post_inputs);
                 self.add_ast_node(expr.id, &[post_outputs])
             }

--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -368,7 +368,7 @@ impl<'a, 'tcx> CFGBuilder<'a, 'tcx> {
                 }), pred);
                 let post_outputs = self.exprs(outputs.map(|a| {
                     debug!("cfg::construct InlineAsm id:{} output:{:?}", expr.id, a);
-                    let &(_, ref expr, _) = a;
+                    let &(_, ref expr, _, _) = a;
                     &**expr
                 }), post_inputs);
                 self.add_ast_node(expr.id, &[post_outputs])

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -458,12 +458,12 @@ impl<'d,'t,'a,'tcx> ExprUseVisitor<'d,'t,'a,'tcx> {
                     self.consume_expr(&**input);
                 }
 
-                for &(_, ref output, is_rw, is_indirect) in &ia.outputs {
-                    if is_indirect {
-                        self.consume_expr(&**output);
+                for output in &ia.outputs {
+                    if output.is_indirect {
+                        self.consume_expr(&*output.expr);
                     } else {
-                        self.mutate_expr(expr, &**output,
-                                           if is_rw { WriteAndRead } else { JustWrite });
+                        self.mutate_expr(expr, &*output.expr,
+                                         if output.is_rw { WriteAndRead } else { JustWrite });
                     }
                 }
             }

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -458,9 +458,13 @@ impl<'d,'t,'a,'tcx> ExprUseVisitor<'d,'t,'a,'tcx> {
                     self.consume_expr(&**input);
                 }
 
-                for &(_, ref output, is_rw) in &ia.outputs {
-                    self.mutate_expr(expr, &**output,
+                for &(_, ref output, is_rw, is_indirect) in &ia.outputs {
+                    if is_indirect {
+                        self.consume_expr(&**output);
+                    } else {
+                        self.mutate_expr(expr, &**output,
                                            if is_rw { WriteAndRead } else { JustWrite });
+                    }
                 }
             }
 

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1167,13 +1167,14 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
           hir::ExprInlineAsm(ref ia) => {
 
             let succ = ia.outputs.iter().rev().fold(succ,
-                |succ, &(_, ref expr, _, is_indirect)| {
+                |succ, &(_, ref expr, is_rw, is_indirect)| {
                     // see comment on lvalues
                     // in propagate_through_lvalue_components()
                     if is_indirect {
                         self.propagate_through_expr(&**expr, succ)
                     } else {
-                        let succ = self.write_lvalue(&**expr, succ, ACC_WRITE);
+                        let acc = if is_rw { ACC_WRITE|ACC_READ } else { ACC_WRITE };
+                        let succ = self.write_lvalue(&**expr, succ, acc);
                         self.propagate_through_lvalue_components(&**expr, succ)
                     }
                 }

--- a/src/librustc_front/fold.rs
+++ b/src/librustc_front/fold.rs
@@ -1127,7 +1127,9 @@ pub fn noop_fold_expr<T: Folder>(Expr { id, node, span, attrs }: Expr, folder: &
                 expn_id,
             }) => ExprInlineAsm(InlineAsm {
                 inputs: inputs.move_map(|(c, input)| (c, folder.fold_expr(input))),
-                outputs: outputs.move_map(|(c, out, is_rw)| (c, folder.fold_expr(out), is_rw)),
+                outputs: outputs.move_map(|(c, out, is_rw, is_indirect)| {
+                    (c, folder.fold_expr(out), is_rw, is_indirect)
+                }),
                 asm: asm,
                 asm_str_style: asm_str_style,
                 clobbers: clobbers,

--- a/src/librustc_front/fold.rs
+++ b/src/librustc_front/fold.rs
@@ -1127,8 +1127,13 @@ pub fn noop_fold_expr<T: Folder>(Expr { id, node, span, attrs }: Expr, folder: &
                 expn_id,
             }) => ExprInlineAsm(InlineAsm {
                 inputs: inputs.move_map(|(c, input)| (c, folder.fold_expr(input))),
-                outputs: outputs.move_map(|(c, out, is_rw, is_indirect)| {
-                    (c, folder.fold_expr(out), is_rw, is_indirect)
+                outputs: outputs.move_map(|out| {
+                    InlineAsmOutput {
+                        constraint: out.constraint,
+                        expr: folder.fold_expr(out.expr),
+                        is_rw: out.is_rw,
+                        is_indirect: out.is_indirect,
+                    }
                 }),
                 asm: asm,
                 asm_str_style: asm_str_style,

--- a/src/librustc_front/hir.rs
+++ b/src/librustc_front/hir.rs
@@ -891,7 +891,7 @@ pub enum Ty_ {
 pub struct InlineAsm {
     pub asm: InternedString,
     pub asm_str_style: StrStyle,
-    pub outputs: Vec<(InternedString, P<Expr>, bool)>,
+    pub outputs: Vec<(InternedString, P<Expr>, bool, bool)>,
     pub inputs: Vec<(InternedString, P<Expr>)>,
     pub clobbers: Vec<InternedString>,
     pub volatile: bool,

--- a/src/librustc_front/hir.rs
+++ b/src/librustc_front/hir.rs
@@ -888,10 +888,18 @@ pub enum Ty_ {
 }
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct InlineAsmOutput {
+    pub constraint: InternedString,
+    pub expr: P<Expr>,
+    pub is_rw: bool,
+    pub is_indirect: bool,
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct InlineAsm {
     pub asm: InternedString,
     pub asm_str_style: StrStyle,
-    pub outputs: Vec<(InternedString, P<Expr>, bool, bool)>,
+    pub outputs: Vec<InlineAsmOutput>,
     pub inputs: Vec<(InternedString, P<Expr>)>,
     pub clobbers: Vec<InternedString>,
     pub volatile: bool,

--- a/src/librustc_front/intravisit.rs
+++ b/src/librustc_front/intravisit.rs
@@ -803,7 +803,7 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
             for &(_, ref input) in &ia.inputs {
                 visitor.visit_expr(&input)
             }
-            for &(_, ref output, _) in &ia.outputs {
+            for &(_, ref output, _, _) in &ia.outputs {
                 visitor.visit_expr(&output)
             }
         }

--- a/src/librustc_front/intravisit.rs
+++ b/src/librustc_front/intravisit.rs
@@ -803,8 +803,8 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
             for &(_, ref input) in &ia.inputs {
                 visitor.visit_expr(&input)
             }
-            for &(_, ref output, _, _) in &ia.outputs {
-                visitor.visit_expr(&output)
+            for output in &ia.outputs {
+                visitor.visit_expr(&output.expr)
             }
         }
     }

--- a/src/librustc_front/lowering.rs
+++ b/src/librustc_front/lowering.rs
@@ -1202,8 +1202,8 @@ pub fn lower_expr(lctx: &LoweringContext, e: &Expr) -> P<hir::Expr> {
                               .map(|&(ref c, ref input)| (c.clone(), lower_expr(lctx, input)))
                               .collect(),
                 outputs: outputs.iter()
-                                .map(|&(ref c, ref out, ref is_rw)| {
-                                    (c.clone(), lower_expr(lctx, out), *is_rw)
+                                .map(|&(ref c, ref out, is_rw, is_indirect)| {
+                                    (c.clone(), lower_expr(lctx, out), is_rw, is_indirect)
                                 })
                                 .collect(),
                 asm: asm.clone(),

--- a/src/librustc_front/lowering.rs
+++ b/src/librustc_front/lowering.rs
@@ -1202,8 +1202,13 @@ pub fn lower_expr(lctx: &LoweringContext, e: &Expr) -> P<hir::Expr> {
                               .map(|&(ref c, ref input)| (c.clone(), lower_expr(lctx, input)))
                               .collect(),
                 outputs: outputs.iter()
-                                .map(|&(ref c, ref out, is_rw, is_indirect)| {
-                                    (c.clone(), lower_expr(lctx, out), is_rw, is_indirect)
+                                .map(|out| {
+                                    hir::InlineAsmOutput {
+                                        constraint: out.constraint.clone(),
+                                        expr: lower_expr(lctx, &out.expr),
+                                        is_rw: out.is_rw,
+                                        is_indirect: out.is_indirect,
+                                    }
                                 })
                                 .collect(),
                 asm: asm.clone(),

--- a/src/librustc_front/print/pprust.rs
+++ b/src/librustc_front/print/pprust.rs
@@ -1502,15 +1502,15 @@ impl<'a> State<'a> {
                 try!(self.print_string(&a.asm, a.asm_str_style));
                 try!(self.word_space(":"));
 
-                try!(self.commasep(Inconsistent, &a.outputs, |s, &(ref co, ref o, is_rw, _)| {
-                    match co.slice_shift_char() {
-                        Some(('=', operand)) if is_rw => {
+                try!(self.commasep(Inconsistent, &a.outputs, |s, out| {
+                    match out.constraint.slice_shift_char() {
+                        Some(('=', operand)) if out.is_rw => {
                             try!(s.print_string(&format!("+{}", operand), ast::CookedStr))
                         }
-                        _ => try!(s.print_string(&co, ast::CookedStr)),
+                        _ => try!(s.print_string(&out.constraint, ast::CookedStr)),
                     }
                     try!(s.popen());
-                    try!(s.print_expr(&**o));
+                    try!(s.print_expr(&*out.expr));
                     try!(s.pclose());
                     Ok(())
                 }));

--- a/src/librustc_front/print/pprust.rs
+++ b/src/librustc_front/print/pprust.rs
@@ -1502,7 +1502,7 @@ impl<'a> State<'a> {
                 try!(self.print_string(&a.asm, a.asm_str_style));
                 try!(self.word_space(":"));
 
-                try!(self.commasep(Inconsistent, &a.outputs, |s, &(ref co, ref o, is_rw)| {
+                try!(self.commasep(Inconsistent, &a.outputs, |s, &(ref co, ref o, is_rw, _)| {
                     match co.slice_shift_char() {
                         Some(('=', operand)) if is_rw => {
                             try!(s.print_string(&format!("+{}", operand), ast::CookedStr))

--- a/src/librustc_trans/trans/asm.rs
+++ b/src/librustc_trans/trans/asm.rs
@@ -39,27 +39,39 @@ pub fn trans_inline_asm<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, ia: &ast::InlineAsm)
     let mut ext_constraints = Vec::new();
 
     // Prepare the output operands
-    let outputs = ia.outputs.iter().enumerate().map(|(i, &(ref c, ref out, is_rw))| {
+    let mut outputs = Vec::new();
+    let mut inputs = Vec::new();
+    for (i, &(ref c, ref out, is_rw, is_indirect)) in ia.outputs.iter().enumerate() {
         constraints.push((*c).clone());
 
         let out_datum = unpack_datum!(bcx, expr::trans(bcx, &**out));
-        output_types.push(type_of::type_of(bcx.ccx(), out_datum.ty));
-        let val = out_datum.val;
-        if is_rw {
+        if is_indirect {
             bcx = callee::trans_arg_datum(bcx,
                                           expr_ty(bcx, &**out),
                                           out_datum,
                                           cleanup::CustomScope(temp_scope),
                                           callee::DontAutorefArg,
-                                          &mut ext_inputs);
-            ext_constraints.push(i.to_string());
+                                          &mut inputs);
+            if is_rw {
+                ext_inputs.push(*inputs.last().unwrap());
+                ext_constraints.push(i.to_string());
+            }
+        } else {
+            output_types.push(type_of::type_of(bcx.ccx(), out_datum.ty));
+            outputs.push(out_datum.val);
+            if is_rw {
+                bcx = callee::trans_arg_datum(bcx,
+                                              expr_ty(bcx, &**out),
+                                              out_datum,
+                                              cleanup::CustomScope(temp_scope),
+                                              callee::DontAutorefArg,
+                                              &mut ext_inputs);
+                ext_constraints.push(i.to_string());
+            }
         }
-        val
-
-    }).collect::<Vec<_>>();
+    }
 
     // Now the input operands
-    let mut inputs = Vec::new();
     for &(ref c, ref input) in &ia.inputs {
         constraints.push((*c).clone());
 

--- a/src/librustc_trans/trans/asm.rs
+++ b/src/librustc_trans/trans/asm.rs
@@ -41,27 +41,27 @@ pub fn trans_inline_asm<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, ia: &ast::InlineAsm)
     // Prepare the output operands
     let mut outputs = Vec::new();
     let mut inputs = Vec::new();
-    for (i, &(ref c, ref out, is_rw, is_indirect)) in ia.outputs.iter().enumerate() {
-        constraints.push((*c).clone());
+    for (i, out) in ia.outputs.iter().enumerate() {
+        constraints.push(out.constraint.clone());
 
-        let out_datum = unpack_datum!(bcx, expr::trans(bcx, &**out));
-        if is_indirect {
+        let out_datum = unpack_datum!(bcx, expr::trans(bcx, &*out.expr));
+        if out.is_indirect {
             bcx = callee::trans_arg_datum(bcx,
-                                          expr_ty(bcx, &**out),
+                                          expr_ty(bcx, &*out.expr),
                                           out_datum,
                                           cleanup::CustomScope(temp_scope),
                                           callee::DontAutorefArg,
                                           &mut inputs);
-            if is_rw {
+            if out.is_rw {
                 ext_inputs.push(*inputs.last().unwrap());
                 ext_constraints.push(i.to_string());
             }
         } else {
             output_types.push(type_of::type_of(bcx.ccx(), out_datum.ty));
             outputs.push(out_datum.val);
-            if is_rw {
+            if out.is_rw {
                 bcx = callee::trans_arg_datum(bcx,
-                                              expr_ty(bcx, &**out),
+                                              expr_ty(bcx, &*out.expr),
                                               out_datum,
                                               cleanup::CustomScope(temp_scope),
                                               callee::DontAutorefArg,

--- a/src/librustc_trans/trans/debuginfo/create_scope_map.rs
+++ b/src/librustc_trans/trans/debuginfo/create_scope_map.rs
@@ -480,7 +480,7 @@ fn walk_expr(cx: &CrateContext,
                 walk_expr(cx, &**exp, scope_stack, scope_map);
             }
 
-            for &(_, ref exp, _) in outputs {
+            for &(_, ref exp, _, _) in outputs {
                 walk_expr(cx, &**exp, scope_stack, scope_map);
             }
         }

--- a/src/librustc_trans/trans/debuginfo/create_scope_map.rs
+++ b/src/librustc_trans/trans/debuginfo/create_scope_map.rs
@@ -480,8 +480,8 @@ fn walk_expr(cx: &CrateContext,
                 walk_expr(cx, &**exp, scope_stack, scope_map);
             }
 
-            for &(_, ref exp, _, _) in outputs {
-                walk_expr(cx, &**exp, scope_stack, scope_map);
+            for out in outputs {
+                walk_expr(cx, &*out.expr, scope_stack, scope_map);
             }
         }
     }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3393,7 +3393,7 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
           for &(_, ref input) in &ia.inputs {
               check_expr(fcx, &**input);
           }
-          for &(_, ref out, _) in &ia.outputs {
+          for &(_, ref out, _, _) in &ia.outputs {
               check_expr(fcx, &**out);
           }
           fcx.write_nil(id);

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3393,8 +3393,8 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
           for &(_, ref input) in &ia.inputs {
               check_expr(fcx, &**input);
           }
-          for &(_, ref out, _, _) in &ia.outputs {
-              check_expr(fcx, &**out);
+          for out in &ia.outputs {
+              check_expr(fcx, &*out.expr);
           }
           fcx.write_nil(id);
       }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1462,7 +1462,7 @@ pub enum AsmDialect {
 pub struct InlineAsm {
     pub asm: InternedString,
     pub asm_str_style: StrStyle,
-    pub outputs: Vec<(InternedString, P<Expr>, bool)>,
+    pub outputs: Vec<(InternedString, P<Expr>, bool, bool)>,
     pub inputs: Vec<(InternedString, P<Expr>)>,
     pub clobbers: Vec<InternedString>,
     pub volatile: bool,

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1459,10 +1459,18 @@ pub enum AsmDialect {
 }
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct InlineAsmOutput {
+    pub constraint: InternedString,
+    pub expr: P<Expr>,
+    pub is_rw: bool,
+    pub is_indirect: bool,
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct InlineAsm {
     pub asm: InternedString,
     pub asm_str_style: StrStyle,
-    pub outputs: Vec<(InternedString, P<Expr>, bool, bool)>,
+    pub outputs: Vec<InlineAsmOutput>,
     pub inputs: Vec<(InternedString, P<Expr>)>,
     pub clobbers: Vec<InternedString>,
     pub volatile: bool,

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -126,7 +126,12 @@ pub fn expand_asm<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
 
                     let is_rw = output.is_some();
                     let is_indirect = constraint.contains("*");
-                    outputs.push((output.unwrap_or(constraint), out, is_rw, is_indirect));
+                    outputs.push(ast::InlineAsmOutput {
+                        constraint: output.unwrap_or(constraint),
+                        expr: out,
+                        is_rw: is_rw,
+                        is_indirect: is_indirect,
+                    });
                 }
             }
             Inputs => {

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -125,7 +125,8 @@ pub fn expand_asm<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
                     };
 
                     let is_rw = output.is_some();
-                    outputs.push((output.unwrap_or(constraint), out, is_rw));
+                    let is_indirect = constraint.contains("*");
+                    outputs.push((output.unwrap_or(constraint), out, is_rw, is_indirect));
                 }
             }
             Inputs => {
@@ -139,9 +140,9 @@ pub fn expand_asm<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
 
                     let (constraint, _str_style) = panictry!(p.parse_str());
 
-                    if constraint.starts_with("=") && !constraint.contains("*") {
+                    if constraint.starts_with("=") {
                         cx.span_err(p.last_span, "input operand constraint contains '='");
-                    } else if constraint.starts_with("+") && !constraint.contains("*") {
+                    } else if constraint.starts_with("+") {
                         cx.span_err(p.last_span, "input operand constraint contains '+'");
                     }
 

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -1303,8 +1303,8 @@ pub fn noop_fold_expr<T: Folder>(Expr {id, node, span, attrs}: Expr, folder: &mu
                 inputs: inputs.move_map(|(c, input)| {
                     (c, folder.fold_expr(input))
                 }),
-                outputs: outputs.move_map(|(c, out, is_rw)| {
-                    (c, folder.fold_expr(out), is_rw)
+                outputs: outputs.move_map(|(c, out, is_rw, is_indirect)| {
+                    (c, folder.fold_expr(out), is_rw, is_indirect)
                 }),
                 asm: asm,
                 asm_str_style: asm_str_style,

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -1303,8 +1303,13 @@ pub fn noop_fold_expr<T: Folder>(Expr {id, node, span, attrs}: Expr, folder: &mu
                 inputs: inputs.move_map(|(c, input)| {
                     (c, folder.fold_expr(input))
                 }),
-                outputs: outputs.move_map(|(c, out, is_rw, is_indirect)| {
-                    (c, folder.fold_expr(out), is_rw, is_indirect)
+                outputs: outputs.move_map(|out| {
+                    InlineAsmOutput {
+                        constraint: out.constraint,
+                        expr: folder.fold_expr(out.expr),
+                        is_rw: out.is_rw,
+                        is_indirect: out.is_indirect,
+                    }
                 }),
                 asm: asm,
                 asm_str_style: asm_str_style,

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2221,16 +2221,16 @@ impl<'a> State<'a> {
                 try!(self.word_space(":"));
 
                 try!(self.commasep(Inconsistent, &a.outputs,
-                                   |s, &(ref co, ref o, is_rw, _)| {
-                    match co.slice_shift_char() {
-                        Some(('=', operand)) if is_rw => {
+                                   |s, out| {
+                    match out.constraint.slice_shift_char() {
+                        Some(('=', operand)) if out.is_rw => {
                             try!(s.print_string(&format!("+{}", operand),
                                                 ast::CookedStr))
                         }
-                        _ => try!(s.print_string(&co, ast::CookedStr))
+                        _ => try!(s.print_string(&out.constraint, ast::CookedStr))
                     }
                     try!(s.popen());
-                    try!(s.print_expr(&**o));
+                    try!(s.print_expr(&*out.expr));
                     try!(s.pclose());
                     Ok(())
                 }));

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2221,7 +2221,7 @@ impl<'a> State<'a> {
                 try!(self.word_space(":"));
 
                 try!(self.commasep(Inconsistent, &a.outputs,
-                                   |s, &(ref co, ref o, is_rw)| {
+                                   |s, &(ref co, ref o, is_rw, _)| {
                     match co.slice_shift_char() {
                         Some(('=', operand)) if is_rw => {
                             try!(s.print_string(&format!("+{}", operand),

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -786,7 +786,7 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
             for &(_, ref input) in &ia.inputs {
                 visitor.visit_expr(&input)
             }
-            for &(_, ref output, _) in &ia.outputs {
+            for &(_, ref output, _, _) in &ia.outputs {
                 visitor.visit_expr(&output)
             }
         }

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -786,8 +786,8 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
             for &(_, ref input) in &ia.inputs {
                 visitor.visit_expr(&input)
             }
-            for &(_, ref output, _, _) in &ia.outputs {
-                visitor.visit_expr(&output)
+            for output in &ia.outputs {
+                visitor.visit_expr(&output.expr)
             }
         }
     }

--- a/src/test/run-pass/asm-indirect-memory.rs
+++ b/src/test/run-pass/asm-indirect-memory.rs
@@ -22,17 +22,29 @@ fn read(ptr: &u32) -> u32 {
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn write(ptr: &mut u32, val: u32) {
     unsafe {
-        asm!("mov $1, $0" :: "=*m" (ptr), "r" (val));
+        asm!("mov $1, $0" : "=*m" (ptr) : "r" (val));
     }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn replace(ptr: &mut u32, val: u32) -> u32 {
+    let out: u32;
+    unsafe {
+        asm!("mov $0, $1; mov $2, $0" : "+*m" (ptr), "=&r" (out) : "r" (val));
+    }
+    out
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn main() {
     let a = 1;
-    let mut b = 2;
     assert_eq!(read(&a), 1);
+    let mut b = 2;
     write(&mut b, 3);
     assert_eq!(b, 3);
+    let mut c = 4;
+    assert_eq!(replace(&mut c, 5), 4);
+    assert_eq!(c, 5);
 }
 
 #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]


### PR DESCRIPTION
This PR reverts #29543 and instead implements proper support for "=_m" and "+_m" indirect output operands. This provides a framework on top of which support for plain memory operands ("m", "=m" and "+m") can be implemented.

This also fixes the liveness analysis pass not handling read/write operands correctly.
