### PR TITLE
Suggest `mut` for mutability errors

### DIFF
--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -1015,7 +1015,18 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                                  self by mutable reference");
                         }
                     }
-                    _ => {}
+                    _ => {
+                        if let Categorization::Local(local_id) = err.cmt.cat {
+                            let span = self.tcx.map.span(local_id);
+                            if let Ok(snippet) = self.tcx.sess.codemap().span_to_snippet(span) {
+                                self.tcx.sess.span_suggestion(
+                                    span,
+                                    &format!("to make the {} mutable, use `mut` as shown:",
+                                             self.cmt_to_string(&err.cmt)),
+                                    format!("mut {}", snippet));
+                            }
+                        }
+                    }
                 }
             }
 

--- a/src/test/compile-fail/mut-suggestion.rs
+++ b/src/test/compile-fail/mut-suggestion.rs
@@ -1,0 +1,30 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[derive(Copy, Clone)]
+struct S;
+
+impl S {
+    fn mutate(&mut self) {
+    }
+}
+
+fn func(arg: S) {
+    //~^ HELP use `mut` as shown
+    //~| SUGGESTION fn func(mut arg: S) {
+    arg.mutate(); //~ ERROR cannot borrow immutable argument
+}
+
+fn main() {
+    let local = S;
+    //~^ HELP use `mut` as shown
+    //~| SUGGESTION let mut local = S;
+    local.mutate(); //~ ERROR cannot borrow immutable local variable
+}


### PR DESCRIPTION
Fix #16410.
