### PR TITLE
compiletest/raise_fd_limit: use libc instead of custom impl

### DIFF
--- a/src/compiletest/raise_fd_limit.rs
+++ b/src/compiletest/raise_fd_limit.rs
@@ -23,25 +23,8 @@ pub unsafe fn raise_fd_limit() {
     use std::mem::size_of_val;
     use std::ptr::null_mut;
 
-    type rlim_t = libc::uint64_t;
-
-    #[repr(C)]
-    struct rlimit {
-        rlim_cur: rlim_t,
-        rlim_max: rlim_t
-    }
-    extern {
-        // name probably doesn't need to be mut, but the C function doesn't
-        // specify const
-        fn sysctl(name: *mut libc::c_int, namelen: libc::c_uint,
-                  oldp: *mut libc::c_void, oldlenp: *mut libc::size_t,
-                  newp: *mut libc::c_void, newlen: libc::size_t) -> libc::c_int;
-        fn getrlimit(resource: libc::c_int, rlp: *mut rlimit) -> libc::c_int;
-        fn setrlimit(resource: libc::c_int, rlp: *const rlimit) -> libc::c_int;
-    }
     static CTL_KERN: libc::c_int = 1;
     static KERN_MAXFILESPERPROC: libc::c_int = 29;
-    static RLIMIT_NOFILE: libc::c_int = 8;
 
     // The strategy here is to fetch the current resource limits, read the
     // kern.maxfilesperproc sysctl value, and bump the soft resource limit for
@@ -51,25 +34,25 @@ pub unsafe fn raise_fd_limit() {
     let mut mib: [libc::c_int; 2] = [CTL_KERN, KERN_MAXFILESPERPROC];
     let mut maxfiles: libc::c_int = 0;
     let mut size: libc::size_t = size_of_val(&maxfiles) as libc::size_t;
-    if sysctl(&mut mib[0], 2, &mut maxfiles as *mut _ as *mut _, &mut size,
+    if libc::sysctl(&mut mib[0], 2, &mut maxfiles as *mut _ as *mut _, &mut size,
               null_mut(), 0) != 0 {
         let err = io::Error::last_os_error();
         panic!("raise_fd_limit: error calling sysctl: {}", err);
     }
 
     // Fetch the current resource limits
-    let mut rlim = rlimit{rlim_cur: 0, rlim_max: 0};
-    if getrlimit(RLIMIT_NOFILE, &mut rlim) != 0 {
+    let mut rlim = libc::rlimit{rlim_cur: 0, rlim_max: 0};
+    if libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) != 0 {
         let err = io::Error::last_os_error();
         panic!("raise_fd_limit: error calling getrlimit: {}", err);
     }
 
     // Bump the soft limit to the smaller of kern.maxfilesperproc and the hard
     // limit
-    rlim.rlim_cur = cmp::min(maxfiles as rlim_t, rlim.rlim_max);
+    rlim.rlim_cur = cmp::min(maxfiles as libc::rlim_t, rlim.rlim_max);
 
     // Set our newly-increased resource limit
-    if setrlimit(RLIMIT_NOFILE, &rlim) != 0 {
+    if libc::setrlimit(libc::RLIMIT_NOFILE, &rlim) != 0 {
         let err = io::Error::last_os_error();
         panic!("raise_fd_limit: error calling setrlimit: {}", err);
     }


### PR DESCRIPTION
Fixes #29751.
