### PR TITLE
Do not build master branch on Travis either

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ notifications:
   email: false
 
 branches:
-  only:
-    - master
+  except:
+    - /^.*$/


### PR DESCRIPTION
As seen in https://travis-ci.org/rust-lang/rust/builds, travis will build each and every landed PR (AGAIN, no less!) that has already went through our own buildbots and maybe Travis as well. This is simply a waste of resources travis could be using to build other things.
