### PR TITLE
Rename _nopanic methods to remove the suffix.

### DIFF
--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -79,7 +79,7 @@ pub fn expand_asm<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
                     cx.span_err(sp, "malformed inline assembly");
                     return DummyResult::expr(sp);
                 }
-                let (s, style) = match expr_to_string(cx, panictry!(p.parse_expr_nopanic()),
+                let (s, style) = match expr_to_string(cx, panictry!(p.parse_expr()),
                                                    "inline assembly must be a string literal") {
                     Some((s, st)) => (s, st),
                     // let compilation continue
@@ -102,7 +102,7 @@ pub fn expand_asm<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
                     let span = p.last_span;
 
                     panictry!(p.expect(&token::OpenDelim(token::Paren)));
-                    let out = panictry!(p.parse_expr_nopanic());
+                    let out = panictry!(p.parse_expr());
                     panictry!(p.expect(&token::CloseDelim(token::Paren)));
 
                     // Expands a read+write operand into two operands.
@@ -146,7 +146,7 @@ pub fn expand_asm<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
                     }
 
                     panictry!(p.expect(&token::OpenDelim(token::Paren)));
-                    let input = panictry!(p.parse_expr_nopanic());
+                    let input = panictry!(p.parse_expr());
                     panictry!(p.expect(&token::CloseDelim(token::Paren)));
 
                     inputs.push((constraint, input));

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -809,7 +809,7 @@ pub fn get_single_str_from_tts(cx: &mut ExtCtxt,
         cx.span_err(sp, &format!("{} takes 1 argument", name));
         return None
     }
-    let ret = cx.expander().fold_expr(panictry!(p.parse_expr_nopanic()));
+    let ret = cx.expander().fold_expr(panictry!(p.parse_expr()));
     if p.token != token::Eof {
         cx.span_err(sp, &format!("{} takes 1 argument", name));
     }
@@ -826,7 +826,7 @@ pub fn get_exprs_from_tts(cx: &mut ExtCtxt,
     let mut p = cx.new_parser_from_tts(tts);
     let mut es = Vec::new();
     while p.token != token::Eof {
-        es.push(cx.expander().fold_expr(panictry!(p.parse_expr_nopanic())));
+        es.push(cx.expander().fold_expr(panictry!(p.parse_expr())));
         if panictry!(p.eat(&token::Comma)){
             continue;
         }

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -93,7 +93,7 @@ fn parse_args(ecx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
         ecx.span_err(sp, "requires at least a format string argument");
         return None;
     }
-    let fmtstr = panictry!(p.parse_expr_nopanic());
+    let fmtstr = panictry!(p.parse_expr());
     let mut named = false;
     while p.token != token::Eof {
         if !panictry!(p.eat(&token::Comma)) {
@@ -124,7 +124,7 @@ fn parse_args(ecx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
             let name: &str = &ident.name.as_str();
 
             panictry!(p.expect(&token::Eq));
-            let e = panictry!(p.parse_expr_nopanic());
+            let e = panictry!(p.parse_expr());
             match names.get(name) {
                 None => {}
                 Some(prev) => {
@@ -138,7 +138,7 @@ fn parse_args(ecx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
             order.push(name.to_string());
             names.insert(name.to_string(), e);
         } else {
-            args.push(panictry!(p.parse_expr_nopanic()));
+            args.push(panictry!(p.parse_expr()));
         }
     }
     Some((fmtstr, args, order, names))

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -701,7 +701,7 @@ fn parse_arguments_to_quote(cx: &ExtCtxt, tts: &[TokenTree])
     let mut p = cx.new_parser_from_tts(tts);
     p.quote_depth += 1;
 
-    let cx_expr = panictry!(p.parse_expr_nopanic());
+    let cx_expr = panictry!(p.parse_expr());
     if !panictry!(p.eat(&token::Comma)) {
         panic!(p.fatal("expected token `,`"));
     }

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -109,13 +109,13 @@ pub fn expand_include<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree
     }
     impl<'a> base::MacResult for ExpandResult<'a> {
         fn make_expr(mut self: Box<ExpandResult<'a>>) -> Option<P<ast::Expr>> {
-            Some(panictry!(self.p.parse_expr_nopanic()))
+            Some(panictry!(self.p.parse_expr()))
         }
         fn make_items(mut self: Box<ExpandResult<'a>>)
                       -> Option<SmallVector<P<ast::Item>>> {
             let mut ret = SmallVector::zero();
             while self.p.token != token::Eof {
-                match panictry!(self.p.parse_item_nopanic()) {
+                match panictry!(self.p.parse_item()) {
                     Some(item) => ret.push(item),
                     None => panic!(self.p.span_fatal(
                         self.p.span,

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -501,18 +501,18 @@ pub fn parse_nt(p: &mut Parser, sp: Span, name: &str) -> Nonterminal {
     // check at the beginning and the parser checks after each bump
     panictry!(p.check_unknown_macro_variable());
     match name {
-        "item" => match panictry!(p.parse_item_nopanic()) {
+        "item" => match panictry!(p.parse_item()) {
             Some(i) => token::NtItem(i),
             None => panic!(p.fatal("expected an item keyword"))
         },
         "block" => token::NtBlock(panictry!(p.parse_block())),
-        "stmt" => match panictry!(p.parse_stmt_nopanic()) {
+        "stmt" => match panictry!(p.parse_stmt()) {
             Some(s) => token::NtStmt(s),
             None => panic!(p.fatal("expected a statement"))
         },
-        "pat" => token::NtPat(panictry!(p.parse_pat_nopanic())),
-        "expr" => token::NtExpr(panictry!(p.parse_expr_nopanic())),
-        "ty" => token::NtTy(panictry!(p.parse_ty_nopanic())),
+        "pat" => token::NtPat(panictry!(p.parse_pat())),
+        "expr" => token::NtExpr(panictry!(p.parse_expr())),
+        "ty" => token::NtTy(panictry!(p.parse_ty())),
         // this could be handled like a token, since it is one
         "ident" => match p.token {
             token::Ident(sn,b) => { panictry!(p.bump()); token::NtIdent(Box::new(sn),b) }

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -67,18 +67,18 @@ impl<'a> ParserAnyMacro<'a> {
 
 impl<'a> MacResult for ParserAnyMacro<'a> {
     fn make_expr(self: Box<ParserAnyMacro<'a>>) -> Option<P<ast::Expr>> {
-        let ret = panictry!(self.parser.borrow_mut().parse_expr_nopanic());
+        let ret = panictry!(self.parser.borrow_mut().parse_expr());
         self.ensure_complete_parse(true);
         Some(ret)
     }
     fn make_pat(self: Box<ParserAnyMacro<'a>>) -> Option<P<ast::Pat>> {
-        let ret = panictry!(self.parser.borrow_mut().parse_pat_nopanic());
+        let ret = panictry!(self.parser.borrow_mut().parse_pat());
         self.ensure_complete_parse(false);
         Some(ret)
     }
     fn make_items(self: Box<ParserAnyMacro<'a>>) -> Option<SmallVector<P<ast::Item>>> {
         let mut ret = SmallVector::zero();
-        while let Some(item) = panictry!(self.parser.borrow_mut().parse_item_nopanic()) {
+        while let Some(item) = panictry!(self.parser.borrow_mut().parse_item()) {
             ret.push(item);
         }
         self.ensure_complete_parse(false);
@@ -106,7 +106,7 @@ impl<'a> MacResult for ParserAnyMacro<'a> {
             let mut parser = self.parser.borrow_mut();
             match parser.token {
                 token::Eof => break,
-                _ => match parser.parse_stmt_nopanic() {
+                _ => match parser.parse_stmt() {
                     Ok(maybe_stmt) => match maybe_stmt {
                         Some(stmt) => ret.push(stmt),
                         None => (),
@@ -120,7 +120,7 @@ impl<'a> MacResult for ParserAnyMacro<'a> {
     }
 
     fn make_ty(self: Box<ParserAnyMacro<'a>>) -> Option<P<ast::Ty>> {
-        let ret = panictry!(self.parser.borrow_mut().parse_ty_nopanic());
+        let ret = panictry!(self.parser.borrow_mut().parse_ty());
         self.ensure_complete_parse(true);
         Some(ret)
     }

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -116,7 +116,7 @@ pub fn parse_expr_from_source_str(name: String,
                                   sess: &ParseSess)
                                   -> P<ast::Expr> {
     let mut p = new_parser_from_source_str(sess, cfg, name, source);
-    maybe_aborted(panictry!(p.parse_expr_nopanic()), p)
+    maybe_aborted(panictry!(p.parse_expr()), p)
 }
 
 pub fn parse_item_from_source_str(name: String,
@@ -125,7 +125,7 @@ pub fn parse_item_from_source_str(name: String,
                                   sess: &ParseSess)
                                   -> Option<P<ast::Item>> {
     let mut p = new_parser_from_source_str(sess, cfg, name, source);
-    maybe_aborted(panictry!(p.parse_item_nopanic()), p)
+    maybe_aborted(panictry!(p.parse_item()), p)
 }
 
 pub fn parse_meta_from_source_str(name: String,
@@ -148,7 +148,7 @@ pub fn parse_stmt_from_source_str(name: String,
         name,
         source
     );
-    maybe_aborted(panictry!(p.parse_stmt_nopanic()), p)
+    maybe_aborted(panictry!(p.parse_stmt()), p)
 }
 
 // Warning: This parses with quote_depth > 0, which is not the default.
@@ -882,7 +882,7 @@ mod tests {
     #[test] fn parse_ident_pat () {
         let sess = ParseSess::new();
         let mut parser = string_to_parser(&sess, "b".to_string());
-        assert!(panictry!(parser.parse_pat_nopanic())
+        assert!(panictry!(parser.parse_pat())
                 == P(ast::Pat{
                 id: ast::DUMMY_NODE_ID,
                 node: ast::PatIdent(ast::BindByValue(ast::MutImmutable),

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -366,27 +366,27 @@ impl<'a> Parser<'a> {
     // These functions are used by the quote_*!() syntax extensions, but shouldn't
     // be used otherwise.
     pub fn parse_expr_panic(&mut self) -> P<Expr> {
-        panictry!(self.parse_expr_nopanic())
+        panictry!(self.parse_expr())
     }
 
     pub fn parse_item_panic(&mut self) -> Option<P<Item>> {
-        panictry!(self.parse_item_nopanic())
+        panictry!(self.parse_item())
     }
 
     pub fn parse_pat_panic(&mut self) -> P<Pat> {
-        panictry!(self.parse_pat_nopanic())
+        panictry!(self.parse_pat())
     }
 
     pub fn parse_arm_panic(&mut self) -> Arm {
-        panictry!(self.parse_arm_nopanic())
+        panictry!(self.parse_arm())
     }
 
     pub fn parse_ty_panic(&mut self) -> P<Ty> {
-        panictry!(self.parse_ty_nopanic())
+        panictry!(self.parse_ty())
     }
 
     pub fn parse_stmt_panic(&mut self) -> Option<P<Stmt>> {
-        panictry!(self.parse_stmt_nopanic())
+        panictry!(self.parse_stmt())
     }
 
     pub fn parse_attribute_panic(&mut self, permit_inner: bool) -> ast::Attribute {
@@ -1197,7 +1197,7 @@ impl<'a> Parser<'a> {
                 let ty = try!(p.parse_ty_sum());
                 let default = if p.check(&token::Eq) {
                     try!(p.bump());
-                    let expr = try!(p.parse_expr_nopanic());
+                    let expr = try!(p.parse_expr());
                     try!(p.commit_expr_expecting(&expr, token::Semi));
                     Some(expr)
                 } else {
@@ -1264,7 +1264,7 @@ impl<'a> Parser<'a> {
     /// Parse a possibly mutable type
     pub fn parse_mt(&mut self) -> PResult<MutTy> {
         let mutbl = try!(self.parse_mutability());
-        let t = try!(self.parse_ty_nopanic());
+        let t = try!(self.parse_ty());
         Ok(MutTy { ty: t, mutbl: mutbl })
     }
 
@@ -1274,7 +1274,7 @@ impl<'a> Parser<'a> {
             if try!(self.eat(&token::Not) ){
                 Ok(NoReturn(self.last_span))
             } else {
-                Ok(Return(try!(self.parse_ty_nopanic())))
+                Ok(Return(try!(self.parse_ty())))
             }
         } else {
             let pos = self.span.lo;
@@ -1285,7 +1285,7 @@ impl<'a> Parser<'a> {
     /// Parse a type in a context where `T1+T2` is allowed.
     pub fn parse_ty_sum(&mut self) -> PResult<P<Ty>> {
         let lo = self.span.lo;
-        let lhs = try!(self.parse_ty_nopanic());
+        let lhs = try!(self.parse_ty());
 
         if !try!(self.eat(&token::BinOp(token::Plus)) ){
             return Ok(lhs);
@@ -1308,7 +1308,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse a type.
-    pub fn parse_ty_nopanic(&mut self) -> PResult<P<Ty>> {
+    pub fn parse_ty(&mut self) -> PResult<P<Ty>> {
         maybe_whole!(no_clone self, NtTy);
 
         let lo = self.span.lo;
@@ -1369,7 +1369,7 @@ impl<'a> Parser<'a> {
             // TYPEOF
             // In order to not be ambiguous, the type must be surrounded by parens.
             try!(self.expect(&token::OpenDelim(token::Paren)));
-            let e = try!(self.parse_expr_nopanic());
+            let e = try!(self.parse_expr());
             try!(self.expect(&token::CloseDelim(token::Paren)));
             TyTypeof(e)
         } else if try!(self.eat_lt()) {
@@ -1429,7 +1429,7 @@ impl<'a> Parser<'a> {
                            known as `*const T`");
             MutImmutable
         };
-        let t = try!(self.parse_ty_nopanic());
+        let t = try!(self.parse_ty());
         Ok(MutTy { ty: t, mutbl: mutbl })
     }
 
@@ -1458,7 +1458,7 @@ impl<'a> Parser<'a> {
         let pat = if require_name || self.is_named_argument() {
             debug!("parse_arg_general parse_pat (require_name:{})",
                    require_name);
-            let pat = try!(self.parse_pat_nopanic());
+            let pat = try!(self.parse_pat());
 
             try!(self.expect(&token::Colon));
             pat
@@ -1485,7 +1485,7 @@ impl<'a> Parser<'a> {
 
     /// Parse an argument in a lambda header e.g. |arg, arg|
     pub fn parse_fn_block_arg(&mut self) -> PResult<Arg> {
-        let pat = try!(self.parse_pat_nopanic());
+        let pat = try!(self.parse_pat());
         let t = if try!(self.eat(&token::Colon) ){
             try!(self.parse_ty_sum())
         } else {
@@ -1505,7 +1505,7 @@ impl<'a> Parser<'a> {
     pub fn maybe_parse_fixed_length_of_vec(&mut self) -> PResult<Option<P<ast::Expr>>> {
         if self.check(&token::Semi) {
             try!(self.bump());
-            Ok(Some(try!(self.parse_expr_nopanic())))
+            Ok(Some(try!(self.parse_expr())))
         } else {
             Ok(None)
         }
@@ -1730,7 +1730,7 @@ impl<'a> Parser<'a> {
                     |p| p.parse_ty_sum()));
 
                 let output_ty = if try!(self.eat(&token::RArrow) ){
-                    Some(try!(self.parse_ty_nopanic()))
+                    Some(try!(self.parse_ty()))
                 } else {
                     None
                 };
@@ -1935,7 +1935,7 @@ impl<'a> Parser<'a> {
         let i = try!(self.parse_ident());
         let hi = self.last_span.hi;
         try!(self.expect(&token::Colon));
-        let e = try!(self.parse_expr_nopanic());
+        let e = try!(self.parse_expr());
         Ok(ast::Field {
             ident: spanned(lo, hi, i),
             span: mk_sp(lo, e.span.hi),
@@ -2049,7 +2049,7 @@ impl<'a> Parser<'a> {
                 let mut es = vec![];
                 let mut trailing_comma = false;
                 while self.token != token::CloseDelim(token::Paren) {
-                    es.push(try!(self.parse_expr_nopanic()));
+                    es.push(try!(self.parse_expr()));
                     try!(self.commit_expr(&**es.last().unwrap(), &[],
                                      &[token::Comma, token::CloseDelim(token::Paren)]));
                     if self.check(&token::Comma) {
@@ -2095,11 +2095,11 @@ impl<'a> Parser<'a> {
                     ex = ExprVec(Vec::new());
                 } else {
                     // Nonempty vector.
-                    let first_expr = try!(self.parse_expr_nopanic());
+                    let first_expr = try!(self.parse_expr());
                     if self.check(&token::Semi) {
                         // Repeating array syntax: [ 0; 512 ]
                         try!(self.bump());
-                        let count = try!(self.parse_expr_nopanic());
+                        let count = try!(self.parse_expr());
                         try!(self.expect(&token::CloseDelim(token::Bracket)));
                         ex = ExprRepeat(first_expr, count);
                     } else if self.check(&token::Comma) {
@@ -2108,7 +2108,7 @@ impl<'a> Parser<'a> {
                         let remaining_exprs = try!(self.parse_seq_to_end(
                             &token::CloseDelim(token::Bracket),
                             seq_sep_trailing_allowed(token::Comma),
-                            |p| Ok(try!(p.parse_expr_nopanic()))
+                            |p| Ok(try!(p.parse_expr()))
                                 ));
                         let mut exprs = vec!(first_expr);
                         exprs.extend(remaining_exprs);
@@ -2187,7 +2187,7 @@ impl<'a> Parser<'a> {
                 }
                 if try!(self.eat_keyword(keywords::Return) ){
                     if self.token.can_begin_expr() {
-                        let e = try!(self.parse_expr_nopanic());
+                        let e = try!(self.parse_expr());
                         hi = e.span.hi;
                         ex = ExprRet(Some(e));
                     } else {
@@ -2241,7 +2241,7 @@ impl<'a> Parser<'a> {
 
                             while self.token != token::CloseDelim(token::Brace) {
                                 if try!(self.eat(&token::DotDot) ){
-                                    base = Some(try!(self.parse_expr_nopanic()));
+                                    base = Some(try!(self.parse_expr()));
                                     break;
                                 }
 
@@ -2317,7 +2317,7 @@ impl<'a> Parser<'a> {
                                 &token::OpenDelim(token::Paren),
                                 &token::CloseDelim(token::Paren),
                                 seq_sep_trailing_allowed(token::Comma),
-                                |p| Ok(try!(p.parse_expr_nopanic()))
+                                |p| Ok(try!(p.parse_expr()))
                             ));
                             hi = self.last_span.hi;
 
@@ -2394,7 +2394,7 @@ impl<'a> Parser<'a> {
                     &token::OpenDelim(token::Paren),
                     &token::CloseDelim(token::Paren),
                     seq_sep_trailing_allowed(token::Comma),
-                    |p| Ok(try!(p.parse_expr_nopanic()))
+                    |p| Ok(try!(p.parse_expr()))
                 ));
                 hi = self.last_span.hi;
 
@@ -2406,7 +2406,7 @@ impl<'a> Parser<'a> {
               // Could be either an index expression or a slicing expression.
               token::OpenDelim(token::Bracket) => {
                 try!(self.bump());
-                let ix = try!(self.parse_expr_nopanic());
+                let ix = try!(self.parse_expr());
                 hi = self.span.hi;
                 try!(self.commit_expr_expecting(&*ix, token::CloseDelim(token::Bracket)));
                 let index = self.mk_index(e, ix);
@@ -2698,7 +2698,7 @@ impl<'a> Parser<'a> {
             }
             // Special cases:
             if op == AssocOp::As {
-                let rhs = try!(self.parse_ty_nopanic());
+                let rhs = try!(self.parse_ty());
                 lhs = self.mk_expr(lhs.span.lo, rhs.span.hi, ExprCast(lhs, rhs));
                 continue
             } else if op == AssocOp::DotDot {
@@ -2851,7 +2851,7 @@ impl<'a> Parser<'a> {
     pub fn parse_if_let_expr(&mut self) -> PResult<P<Expr>> {
         let lo = self.last_span.lo;
         try!(self.expect_keyword(keywords::Let));
-        let pat = try!(self.parse_pat_nopanic());
+        let pat = try!(self.parse_pat());
         try!(self.expect(&token::Eq));
         let expr = try!(self.parse_expr_res(Restrictions::RESTRICTION_NO_STRUCT_LITERAL));
         let thn = try!(self.parse_block());
@@ -2873,7 +2873,7 @@ impl<'a> Parser<'a> {
             DefaultReturn(_) => {
                 // If no explicit return type is given, parse any
                 // expr and wrap it up in a dummy block:
-                let body_expr = try!(self.parse_expr_nopanic());
+                let body_expr = try!(self.parse_expr());
                 P(ast::Block {
                     id: ast::DUMMY_NODE_ID,
                     stmts: vec![],
@@ -2909,7 +2909,7 @@ impl<'a> Parser<'a> {
                           span_lo: BytePos) -> PResult<P<Expr>> {
         // Parse: `for <src_pat> in <src_expr> <src_loop_block>`
 
-        let pat = try!(self.parse_pat_nopanic());
+        let pat = try!(self.parse_pat());
         try!(self.expect_keyword(keywords::In));
         let expr = try!(self.parse_expr_res(Restrictions::RESTRICTION_NO_STRUCT_LITERAL));
         let loop_block = try!(self.parse_block());
@@ -2934,7 +2934,7 @@ impl<'a> Parser<'a> {
     pub fn parse_while_let_expr(&mut self, opt_ident: Option<ast::Ident>,
                                 span_lo: BytePos) -> PResult<P<Expr>> {
         try!(self.expect_keyword(keywords::Let));
-        let pat = try!(self.parse_pat_nopanic());
+        let pat = try!(self.parse_pat());
         try!(self.expect(&token::Eq));
         let expr = try!(self.parse_expr_res(Restrictions::RESTRICTION_NO_STRUCT_LITERAL));
         let body = try!(self.parse_block());
@@ -2961,21 +2961,21 @@ impl<'a> Parser<'a> {
         }
         let mut arms: Vec<Arm> = Vec::new();
         while self.token != token::CloseDelim(token::Brace) {
-            arms.push(try!(self.parse_arm_nopanic()));
+            arms.push(try!(self.parse_arm()));
         }
         let hi = self.span.hi;
         try!(self.bump());
         return Ok(self.mk_expr(lo, hi, ExprMatch(discriminant, arms)));
     }
 
-    pub fn parse_arm_nopanic(&mut self) -> PResult<Arm> {
+    pub fn parse_arm(&mut self) -> PResult<Arm> {
         maybe_whole!(no_clone self, NtArm);
 
         let attrs = try!(self.parse_outer_attributes());
         let pats = try!(self.parse_pats());
         let mut guard = None;
         if try!(self.eat_keyword(keywords::If) ){
-            guard = Some(try!(self.parse_expr_nopanic()));
+            guard = Some(try!(self.parse_expr()));
         }
         try!(self.expect(&token::FatArrow));
         let expr = try!(self.parse_expr_res(Restrictions::RESTRICTION_STMT_EXPR));
@@ -2999,7 +2999,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse an expression
-    pub fn parse_expr_nopanic(&mut self) -> PResult<P<Expr>> {
+    pub fn parse_expr(&mut self) -> PResult<P<Expr>> {
         self.parse_expr_res(Restrictions::empty())
     }
 
@@ -3025,7 +3025,7 @@ impl<'a> Parser<'a> {
     fn parse_initializer(&mut self) -> PResult<Option<P<Expr>>> {
         if self.check(&token::Eq) {
             try!(self.bump());
-            Ok(Some(try!(self.parse_expr_nopanic())))
+            Ok(Some(try!(self.parse_expr())))
         } else {
             Ok(None)
         }
@@ -3035,7 +3035,7 @@ impl<'a> Parser<'a> {
     fn parse_pats(&mut self) -> PResult<Vec<P<Pat>>> {
         let mut pats = Vec::new();
         loop {
-            pats.push(try!(self.parse_pat_nopanic()));
+            pats.push(try!(self.parse_pat()));
             if self.check(&token::BinOp(token::Or)) { try!(self.bump());}
             else { return Ok(pats); }
         };
@@ -3044,11 +3044,11 @@ impl<'a> Parser<'a> {
     fn parse_pat_tuple_elements(&mut self) -> PResult<Vec<P<Pat>>> {
         let mut fields = vec![];
         if !self.check(&token::CloseDelim(token::Paren)) {
-            fields.push(try!(self.parse_pat_nopanic()));
+            fields.push(try!(self.parse_pat()));
             if self.look_ahead(1, |t| *t != token::CloseDelim(token::Paren)) {
                 while try!(self.eat(&token::Comma)) &&
                       !self.check(&token::CloseDelim(token::Paren)) {
-                    fields.push(try!(self.parse_pat_nopanic()));
+                    fields.push(try!(self.parse_pat()));
                 }
             }
             if fields.len() == 1 {
@@ -3096,7 +3096,7 @@ impl<'a> Parser<'a> {
                 }
             }
 
-            let subpat = try!(self.parse_pat_nopanic());
+            let subpat = try!(self.parse_pat());
             if before_slice && self.check(&token::DotDot) {
                 try!(self.bump());
                 slice = Some(subpat);
@@ -3144,7 +3144,7 @@ impl<'a> Parser<'a> {
                 // Parsing a pattern of the form "fieldname: pat"
                 let fieldname = try!(self.parse_ident());
                 try!(self.bump());
-                let pat = try!(self.parse_pat_nopanic());
+                let pat = try!(self.parse_pat());
                 hi = pat.span.hi;
                 (pat, fieldname, false)
             } else {
@@ -3215,7 +3215,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse a pattern.
-    pub fn parse_pat_nopanic(&mut self) -> PResult<P<Pat>> {
+    pub fn parse_pat(&mut self) -> PResult<P<Pat>> {
         maybe_whole!(self, NtPat);
 
         let lo = self.span.lo;
@@ -3234,7 +3234,7 @@ impl<'a> Parser<'a> {
                 return Err(self.fatal(&format!("unexpected lifetime `{}` in pattern", ident)));
             }
 
-            let subpat = try!(self.parse_pat_nopanic());
+            let subpat = try!(self.parse_pat());
             pat = PatRegion(subpat, mutbl);
           }
           token::OpenDelim(token::Paren) => {
@@ -3262,7 +3262,7 @@ impl<'a> Parser<'a> {
                 pat = try!(self.parse_pat_ident(BindByRef(mutbl)));
             } else if try!(self.eat_keyword(keywords::Box)) {
                 // Parse box pat
-                let subpat = try!(self.parse_pat_nopanic());
+                let subpat = try!(self.parse_pat());
                 pat = PatBox(subpat);
             } else if self.is_path_start() {
                 // Parse pattern starting with a path
@@ -3334,7 +3334,7 @@ impl<'a> Parser<'a> {
                                     &token::OpenDelim(token::Paren),
                                     &token::CloseDelim(token::Paren),
                                     seq_sep_trailing_allowed(token::Comma),
-                                    |p| p.parse_pat_nopanic()));
+                                    |p| p.parse_pat()));
                             pat = PatEnum(path, Some(args));
                         }
                       }
@@ -3385,7 +3385,7 @@ impl<'a> Parser<'a> {
         let last_span = self.last_span;
         let name = codemap::Spanned{span: last_span, node: ident};
         let sub = if try!(self.eat(&token::At) ){
-            Some(try!(self.parse_pat_nopanic()))
+            Some(try!(self.parse_pat()))
         } else {
             None
         };
@@ -3409,7 +3409,7 @@ impl<'a> Parser<'a> {
     /// Parse a local variable declaration
     fn parse_local(&mut self) -> PResult<P<Local>> {
         let lo = self.span.lo;
-        let pat = try!(self.parse_pat_nopanic());
+        let pat = try!(self.parse_pat());
 
         let mut ty = None;
         if try!(self.eat(&token::Colon) ){
@@ -3466,7 +3466,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse a statement. may include decl.
-    pub fn parse_stmt_nopanic(&mut self) -> PResult<Option<P<Stmt>>> {
+    pub fn parse_stmt(&mut self) -> PResult<Option<P<Stmt>>> {
         Ok(try!(self.parse_stmt_()).map(P))
     }
 
@@ -3897,7 +3897,7 @@ impl<'a> Parser<'a> {
             self.span_err(self.span, &msg);
 
             let span_hi = self.span.hi;
-            let span_hi = if self.parse_ty_nopanic().is_ok() {
+            let span_hi = if self.parse_ty().is_ok() {
                 self.span.hi
             } else {
                 span_hi
@@ -3941,7 +3941,7 @@ impl<'a> Parser<'a> {
                     let span = p.span;
                     p.span_warn(span, "whoops, no =?");
                 }
-                let ty = try!(p.parse_ty_nopanic());
+                let ty = try!(p.parse_ty());
                 let hi = ty.span.hi;
                 let span = mk_sp(lo, hi);
                 return Ok(P(TypeBinding{id: ast::DUMMY_NODE_ID,
@@ -4022,7 +4022,7 @@ impl<'a> Parser<'a> {
                         vec![]
                     };
 
-                    let bounded_ty = try!(self.parse_ty_nopanic());
+                    let bounded_ty = try!(self.parse_ty());
 
                     if try!(self.eat(&token::Colon) ){
                         let bounds = try!(self.parse_ty_param_bounds(BoundParsingMode::Bare));
@@ -4045,7 +4045,7 @@ impl<'a> Parser<'a> {
 
                         parsed_something = true;
                     } else if try!(self.eat(&token::Eq) ){
-                        // let ty = try!(self.parse_ty_nopanic());
+                        // let ty = try!(self.parse_ty());
                         let hi = self.last_span.hi;
                         let span = mk_sp(lo, hi);
                         // where_clause.predicates.push(
@@ -4461,7 +4461,7 @@ impl<'a> Parser<'a> {
             try!(self.expect(&token::Colon));
             let typ = try!(self.parse_ty_sum());
             try!(self.expect(&token::Eq));
-            let expr = try!(self.parse_expr_nopanic());
+            let expr = try!(self.parse_expr());
             try!(self.commit_expr_expecting(&expr, token::Semi));
             (name, ConstImplItem(typ, expr))
         } else {
@@ -4813,7 +4813,7 @@ impl<'a> Parser<'a> {
     /// Given a termination token, parse all of the items in a module
     fn parse_mod_items(&mut self, term: &token::Token, inner_lo: BytePos) -> PResult<Mod> {
         let mut items = vec![];
-        while let Some(item) = try!(self.parse_item_nopanic()) {
+        while let Some(item) = try!(self.parse_item()) {
             items.push(item);
         }
 
@@ -4839,7 +4839,7 @@ impl<'a> Parser<'a> {
         try!(self.expect(&token::Colon));
         let ty = try!(self.parse_ty_sum());
         try!(self.expect(&token::Eq));
-        let e = try!(self.parse_expr_nopanic());
+        let e = try!(self.parse_expr());
         try!(self.commit_expr_expecting(&*e, token::Semi));
         let item = match m {
             Some(m) => ItemStatic(ty, m, e),
@@ -5169,7 +5169,7 @@ impl<'a> Parser<'a> {
                 struct_def = VariantData::Tuple(try!(self.parse_tuple_struct_body(ParsePub::No)),
                                                 ast::DUMMY_NODE_ID);
             } else if try!(self.eat(&token::Eq) ){
-                disr_expr = Some(try!(self.parse_expr_nopanic()));
+                disr_expr = Some(try!(self.parse_expr()));
                 any_disr = disr_expr.as_ref().map(|expr| expr.span);
                 struct_def = VariantData::Unit(ast::DUMMY_NODE_ID);
             } else {
@@ -5601,7 +5601,7 @@ impl<'a> Parser<'a> {
         Ok(None)
     }
 
-    pub fn parse_item_nopanic(&mut self) -> PResult<Option<P<Item>>> {
+    pub fn parse_item(&mut self) -> PResult<Option<P<Item>>> {
         let attrs = try!(self.parse_outer_attributes());
         self.parse_item_(attrs, true)
     }

--- a/src/libsyntax/util/parser_testing.rs
+++ b/src/libsyntax/util/parser_testing.rs
@@ -50,21 +50,21 @@ pub fn string_to_crate (source_str : String) -> ast::Crate {
 /// Parse a string, return an expr
 pub fn string_to_expr (source_str : String) -> P<ast::Expr> {
     with_error_checking_parse(source_str, |p| {
-        p.parse_expr_nopanic()
+        p.parse_expr()
     })
 }
 
 /// Parse a string, return an item
 pub fn string_to_item (source_str : String) -> Option<P<ast::Item>> {
     with_error_checking_parse(source_str, |p| {
-        p.parse_item_nopanic()
+        p.parse_item()
     })
 }
 
 /// Parse a string, return a stmt
 pub fn string_to_stmt(source_str : String) -> Option<P<ast::Stmt>> {
     with_error_checking_parse(source_str, |p| {
-        p.parse_stmt_nopanic()
+        p.parse_stmt()
     })
 }
 
@@ -72,7 +72,7 @@ pub fn string_to_stmt(source_str : String) -> Option<P<ast::Stmt>> {
 /// (currently) affect parsing.
 pub fn string_to_pat(source_str: String) -> P<ast::Pat> {
     with_error_checking_parse(source_str, |p| {
-        p.parse_pat_nopanic()
+        p.parse_pat()
     })
 }
 


### PR DESCRIPTION
Just `sed s/_nopanic//g`.  Hopefully makes libsyntax a bit more
readable.
