### PR TITLE
rename ImplItem_::*ImplItem to ImplItem_::*

### DIFF
--- a/src/librustc/front/map/blocks.rs
+++ b/src/librustc/front/map/blocks.rs
@@ -236,7 +236,7 @@ impl<'a> FnLikeNode<'a> {
             },
             map::NodeImplItem(ii) => {
                 match ii.node {
-                    ast::MethodImplItem(ref sig, ref body) => {
+                    ast::ImplItem_::Method(ref sig, ref body) => {
                         method(ii.id, ii.name, sig, Some(ii.vis), body, ii.span)
                     }
                     _ => {

--- a/src/librustc/front/map/blocks.rs
+++ b/src/librustc/front/map/blocks.rs
@@ -236,7 +236,7 @@ impl<'a> FnLikeNode<'a> {
             },
             map::NodeImplItem(ii) => {
                 match ii.node {
-                    ast::ImplItem_::Method(ref sig, ref body) => {
+                    ast::ImplItemKind::Method(ref sig, ref body) => {
                         method(ii.id, ii.name, sig, Some(ii.vis), body, ii.span)
                     }
                     _ => {

--- a/src/librustc/front/map/collector.rs
+++ b/src/librustc/front/map/collector.rs
@@ -224,8 +224,8 @@ impl<'ast> Visitor<'ast> for NodeCollector<'ast> {
 
     fn visit_impl_item(&mut self, ii: &'ast ImplItem) {
         let def_data = match ii.node {
-            MethodImplItem(..) | ConstImplItem(..) => DefPathData::Value(ii.name),
-            TypeImplItem(..) => DefPathData::Type(ii.name),
+            ImplItem_::Method(..) | ImplItem_::Const(..) => DefPathData::Value(ii.name),
+            ImplItem_::Type(..) => DefPathData::Type(ii.name),
         };
 
         self.insert_def(ii.id, NodeImplItem(ii), def_data);
@@ -234,7 +234,7 @@ impl<'ast> Visitor<'ast> for NodeCollector<'ast> {
         self.parent_node = ii.id;
 
         match ii.node {
-            ConstImplItem(_, ref expr) => {
+            ImplItem_::Const(_, ref expr) => {
                 self.create_def(expr.id, DefPathData::Initializer);
             }
             _ => { }
@@ -313,4 +313,3 @@ impl<'ast> Visitor<'ast> for NodeCollector<'ast> {
         self.create_def(macro_def.id, DefPathData::MacroDef(macro_def.name));
     }
 }
-

--- a/src/librustc/front/map/collector.rs
+++ b/src/librustc/front/map/collector.rs
@@ -224,8 +224,8 @@ impl<'ast> Visitor<'ast> for NodeCollector<'ast> {
 
     fn visit_impl_item(&mut self, ii: &'ast ImplItem) {
         let def_data = match ii.node {
-            ImplItem_::Method(..) | ImplItem_::Const(..) => DefPathData::Value(ii.name),
-            ImplItem_::Type(..) => DefPathData::Type(ii.name),
+            ImplItemKind::Method(..) | ImplItemKind::Const(..) => DefPathData::Value(ii.name),
+            ImplItemKind::Type(..) => DefPathData::Type(ii.name),
         };
 
         self.insert_def(ii.id, NodeImplItem(ii), def_data);
@@ -234,7 +234,7 @@ impl<'ast> Visitor<'ast> for NodeCollector<'ast> {
         self.parent_node = ii.id;
 
         match ii.node {
-            ImplItem_::Const(_, ref expr) => {
+            ImplItemKind::Const(_, ref expr) => {
                 self.create_def(expr.id, DefPathData::Initializer);
             }
             _ => { }

--- a/src/librustc/front/map/mod.rs
+++ b/src/librustc/front/map/mod.rs
@@ -937,18 +937,18 @@ fn node_id_to_string(map: &Map, id: NodeId, include_id: bool) -> String {
         }
         Some(NodeImplItem(ii)) => {
             match ii.node {
-                ImplItem_::Const(..) => {
+                ImplItemKind::Const(..) => {
                     format!("assoc const {} in {}{}",
                             ii.name,
                             map.path_to_string(id),
                             id_str)
                 }
-                ImplItem_::Method(..) => {
+                ImplItemKind::Method(..) => {
                     format!("method {} in {}{}",
                             ii.name,
                             map.path_to_string(id), id_str)
                 }
-                ImplItem_::Type(_) => {
+                ImplItemKind::Type(_) => {
                     format!("assoc type {} in {}{}",
                             ii.name,
                             map.path_to_string(id),

--- a/src/librustc/front/map/mod.rs
+++ b/src/librustc/front/map/mod.rs
@@ -937,18 +937,18 @@ fn node_id_to_string(map: &Map, id: NodeId, include_id: bool) -> String {
         }
         Some(NodeImplItem(ii)) => {
             match ii.node {
-                ConstImplItem(..) => {
+                ImplItem_::Const(..) => {
                     format!("assoc const {} in {}{}",
                             ii.name,
                             map.path_to_string(id),
                             id_str)
                 }
-                MethodImplItem(..) => {
+                ImplItem_::Method(..) => {
                     format!("method {} in {}{}",
                             ii.name,
                             map.path_to_string(id), id_str)
                 }
-                TypeImplItem(_) => {
+                ImplItem_::Type(_) => {
                     format!("assoc type {} in {}{}",
                             ii.name,
                             map.path_to_string(id),

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -739,7 +739,7 @@ fn encode_info_for_method<'a, 'tcx>(ecx: &EncodeContext<'a, 'tcx>,
     let elem = ast_map::PathName(m.name);
     encode_path(rbml_w, impl_path.chain(Some(elem)));
     if let Some(impl_item) = impl_item_opt {
-        if let hir::ImplItem_::Method(ref sig, _) = impl_item.node {
+        if let hir::ImplItemKind::Method(ref sig, _) = impl_item.node {
             encode_attributes(rbml_w, &impl_item.attrs);
             let scheme = ecx.tcx.lookup_item_type(m.def_id);
             let any_types = !scheme.generics.types.is_empty();

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -739,7 +739,7 @@ fn encode_info_for_method<'a, 'tcx>(ecx: &EncodeContext<'a, 'tcx>,
     let elem = ast_map::PathName(m.name);
     encode_path(rbml_w, impl_path.chain(Some(elem)));
     if let Some(impl_item) = impl_item_opt {
-        if let hir::MethodImplItem(ref sig, _) = impl_item.node {
+        if let hir::ImplItem_::Method(ref sig, _) = impl_item.node {
             encode_attributes(rbml_w, &impl_item.attrs);
             let scheme = ecx.tcx.lookup_item_type(m.def_id);
             let any_types = !scheme.generics.types.is_empty();

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -348,7 +348,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for CheckCrateVisitor<'a, 'tcx> {
 
     fn visit_impl_item(&mut self, i: &'v hir::ImplItem) {
         match i.node {
-            hir::ImplItem_::Const(_, ref expr) => {
+            hir::ImplItemKind::Const(_, ref expr) => {
                 self.global_expr(Mode::Const, &*expr);
             }
             _ => self.with_mode(Mode::Var, |v| visit::walk_impl_item(v, i)),

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -348,7 +348,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for CheckCrateVisitor<'a, 'tcx> {
 
     fn visit_impl_item(&mut self, i: &'v hir::ImplItem) {
         match i.node {
-            hir::ConstImplItem(_, ref expr) => {
+            hir::ImplItem_::Const(_, ref expr) => {
                 self.global_expr(Mode::Const, &*expr);
             }
             _ => self.with_mode(Mode::Var, |v| visit::walk_impl_item(v, i)),

--- a/src/librustc/middle/check_static_recursion.rs
+++ b/src/librustc/middle/check_static_recursion.rs
@@ -79,7 +79,7 @@ impl<'a, 'ast: 'a> Visitor<'ast> for CheckCrateVisitor<'a, 'ast> {
 
     fn visit_impl_item(&mut self, ii: &'ast hir::ImplItem) {
         match ii.node {
-            hir::ConstImplItem(..) => {
+            hir::ImplItem_::Const(..) => {
                 let mut recursion_visitor =
                     CheckItemRecursionVisitor::new(self, &ii.span);
                 recursion_visitor.visit_impl_item(ii);

--- a/src/librustc/middle/check_static_recursion.rs
+++ b/src/librustc/middle/check_static_recursion.rs
@@ -79,7 +79,7 @@ impl<'a, 'ast: 'a> Visitor<'ast> for CheckCrateVisitor<'a, 'ast> {
 
     fn visit_impl_item(&mut self, ii: &'ast hir::ImplItem) {
         match ii.node {
-            hir::ImplItem_::Const(..) => {
+            hir::ImplItemKind::Const(..) => {
                 let mut recursion_visitor =
                     CheckItemRecursionVisitor::new(self, &ii.span);
                 recursion_visitor.visit_impl_item(ii);

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -129,7 +129,7 @@ pub fn lookup_const_by_id<'a, 'tcx: 'a>(tcx: &'a ty::ctxt<'tcx>,
                 _ => None
             },
             Some(ast_map::NodeImplItem(ii)) => match ii.node {
-                hir::ConstImplItem(_, ref expr) => {
+                hir::ImplItem_::Const(_, ref expr) => {
                     Some(&*expr)
                 }
                 _ => None
@@ -171,7 +171,7 @@ pub fn lookup_const_by_id<'a, 'tcx: 'a>(tcx: &'a ty::ctxt<'tcx>,
                 _ => None
             },
             csearch::FoundAst::Found(&InlinedItem::ImplItem(_, ref ii)) => match ii.node {
-                hir::ConstImplItem(_, ref expr) => Some(expr.id),
+                hir::ImplItem_::Const(_, ref expr) => Some(expr.id),
                 _ => None
             },
             _ => None
@@ -996,7 +996,7 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
                           },
                           ty::ImplContainer(_) => match tcx.map.find(node_id) {
                               Some(ast_map::NodeImplItem(ii)) => match ii.node {
-                                  hir::ConstImplItem(ref ty, ref expr) => {
+                                  hir::ImplItem_::Const(ref ty, ref expr) => {
                                       (Some(&**expr), Some(&**ty))
                                   }
                                   _ => (None, None)

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -129,7 +129,7 @@ pub fn lookup_const_by_id<'a, 'tcx: 'a>(tcx: &'a ty::ctxt<'tcx>,
                 _ => None
             },
             Some(ast_map::NodeImplItem(ii)) => match ii.node {
-                hir::ImplItem_::Const(_, ref expr) => {
+                hir::ImplItemKind::Const(_, ref expr) => {
                     Some(&*expr)
                 }
                 _ => None
@@ -171,7 +171,7 @@ pub fn lookup_const_by_id<'a, 'tcx: 'a>(tcx: &'a ty::ctxt<'tcx>,
                 _ => None
             },
             csearch::FoundAst::Found(&InlinedItem::ImplItem(_, ref ii)) => match ii.node {
-                hir::ImplItem_::Const(_, ref expr) => Some(expr.id),
+                hir::ImplItemKind::Const(_, ref expr) => Some(expr.id),
                 _ => None
             },
             _ => None
@@ -996,7 +996,7 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
                           },
                           ty::ImplContainer(_) => match tcx.map.find(node_id) {
                               Some(ast_map::NodeImplItem(ii)) => match ii.node {
-                                  hir::ImplItem_::Const(ref ty, ref expr) => {
+                                  hir::ImplItemKind::Const(ref ty, ref expr) => {
                                       (Some(&**expr), Some(&**ty))
                                   }
                                   _ => (None, None)

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -358,14 +358,14 @@ impl<'v> Visitor<'v> for LifeSeeder {
             hir::ItemImpl(_, _, _, ref opt_trait, _, ref impl_items) => {
                 for impl_item in impl_items {
                     match impl_item.node {
-                        hir::ImplItem_::Const(..) |
-                        hir::ImplItem_::Method(..) => {
+                        hir::ImplItemKind::Const(..) |
+                        hir::ImplItemKind::Method(..) => {
                             if opt_trait.is_some() ||
                                     has_allow_dead_code_or_lang_attr(&impl_item.attrs) {
                                 self.worklist.push(impl_item.id);
                             }
                         }
-                        hir::ImplItem_::Type(_) => {}
+                        hir::ImplItemKind::Type(_) => {}
                     }
                 }
             }
@@ -571,21 +571,21 @@ impl<'a, 'tcx, 'v> Visitor<'v> for DeadVisitor<'a, 'tcx> {
 
     fn visit_impl_item(&mut self, impl_item: &hir::ImplItem) {
         match impl_item.node {
-            hir::ImplItem_::Const(_, ref expr) => {
+            hir::ImplItemKind::Const(_, ref expr) => {
                 if !self.symbol_is_live(impl_item.id, None) {
                     self.warn_dead_code(impl_item.id, impl_item.span,
                                         impl_item.name, "associated const");
                 }
                 visit::walk_expr(self, expr)
             }
-            hir::ImplItem_::Method(_, ref body) => {
+            hir::ImplItemKind::Method(_, ref body) => {
                 if !self.symbol_is_live(impl_item.id, None) {
                     self.warn_dead_code(impl_item.id, impl_item.span,
                                         impl_item.name, "method");
                 }
                 visit::walk_block(self, body)
             }
-            hir::ImplItem_::Type(..) => {}
+            hir::ImplItemKind::Type(..) => {}
         }
     }
 

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -358,14 +358,14 @@ impl<'v> Visitor<'v> for LifeSeeder {
             hir::ItemImpl(_, _, _, ref opt_trait, _, ref impl_items) => {
                 for impl_item in impl_items {
                     match impl_item.node {
-                        hir::ConstImplItem(..) |
-                        hir::MethodImplItem(..) => {
+                        hir::ImplItem_::Const(..) |
+                        hir::ImplItem_::Method(..) => {
                             if opt_trait.is_some() ||
                                     has_allow_dead_code_or_lang_attr(&impl_item.attrs) {
                                 self.worklist.push(impl_item.id);
                             }
                         }
-                        hir::TypeImplItem(_) => {}
+                        hir::ImplItem_::Type(_) => {}
                     }
                 }
             }
@@ -571,21 +571,21 @@ impl<'a, 'tcx, 'v> Visitor<'v> for DeadVisitor<'a, 'tcx> {
 
     fn visit_impl_item(&mut self, impl_item: &hir::ImplItem) {
         match impl_item.node {
-            hir::ConstImplItem(_, ref expr) => {
+            hir::ImplItem_::Const(_, ref expr) => {
                 if !self.symbol_is_live(impl_item.id, None) {
                     self.warn_dead_code(impl_item.id, impl_item.span,
                                         impl_item.name, "associated const");
                 }
                 visit::walk_expr(self, expr)
             }
-            hir::MethodImplItem(_, ref body) => {
+            hir::ImplItem_::Method(_, ref body) => {
                 if !self.symbol_is_live(impl_item.id, None) {
                     self.warn_dead_code(impl_item.id, impl_item.span,
                                         impl_item.name, "method");
                 }
                 visit::walk_block(self, body)
             }
-            hir::TypeImplItem(..) => {}
+            hir::ImplItem_::Type(..) => {}
         }
     }
 

--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -948,7 +948,7 @@ impl<'a, 'tcx> ErrorReporting<'tcx> for InferCtxt<'a, 'tcx> {
                 }
                 ast_map::NodeImplItem(item) => {
                     match item.node {
-                        hir::ImplItem_::Method(ref sig, _) => {
+                        hir::ImplItemKind::Method(ref sig, _) => {
                             Some((&sig.decl,
                                   &sig.generics,
                                   sig.unsafety,
@@ -1839,7 +1839,7 @@ fn lifetimes_in_scope(tcx: &ty::ctxt,
             },
             ast_map::NodeImplItem(ii) => {
                 match ii.node {
-                    hir::ImplItem_::Method(ref sig, _) => {
+                    hir::ImplItemKind::Method(ref sig, _) => {
                         taken.push_all(&sig.generics.lifetimes);
                         Some(ii.id)
                     }

--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -948,7 +948,7 @@ impl<'a, 'tcx> ErrorReporting<'tcx> for InferCtxt<'a, 'tcx> {
                 }
                 ast_map::NodeImplItem(item) => {
                     match item.node {
-                        hir::MethodImplItem(ref sig, _) => {
+                        hir::ImplItem_::Method(ref sig, _) => {
                             Some((&sig.decl,
                                   &sig.generics,
                                   sig.unsafety,
@@ -1839,7 +1839,7 @@ fn lifetimes_in_scope(tcx: &ty::ctxt,
             },
             ast_map::NodeImplItem(ii) => {
                 match ii.node {
-                    hir::MethodImplItem(ref sig, _) => {
+                    hir::ImplItem_::Method(ref sig, _) => {
                         taken.push_all(&sig.generics.lifetimes);
                         Some(ii.id)
                     }

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -185,8 +185,8 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
             }
             Some(ast_map::NodeImplItem(impl_item)) => {
                 match impl_item.node {
-                    hir::ConstImplItem(..) => true,
-                    hir::MethodImplItem(ref sig, _) => {
+                    hir::ImplItem_::Const(..) => true,
+                    hir::ImplItem_::Method(ref sig, _) => {
                         if generics_require_inlining(&sig.generics) ||
                                 attr::requests_inline(&impl_item.attrs) {
                             true
@@ -206,7 +206,7 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
                             }
                         }
                     }
-                    hir::TypeImplItem(_) => false,
+                    hir::ImplItem_::Type(_) => false,
                 }
             }
             Some(_) => false,
@@ -299,16 +299,16 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
             }
             ast_map::NodeImplItem(impl_item) => {
                 match impl_item.node {
-                    hir::ConstImplItem(_, ref expr) => {
+                    hir::ImplItem_::Const(_, ref expr) => {
                         self.visit_expr(&*expr);
                     }
-                    hir::MethodImplItem(ref sig, ref body) => {
+                    hir::ImplItem_::Method(ref sig, ref body) => {
                         let did = self.tcx.map.get_parent_did(search_item);
                         if method_might_be_inlined(self.tcx, sig, impl_item, did) {
                             visit::walk_block(self, body)
                         }
                     }
-                    hir::TypeImplItem(_) => {}
+                    hir::ImplItem_::Type(_) => {}
                 }
             }
             // Nothing to recurse on for these

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -185,8 +185,8 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
             }
             Some(ast_map::NodeImplItem(impl_item)) => {
                 match impl_item.node {
-                    hir::ImplItem_::Const(..) => true,
-                    hir::ImplItem_::Method(ref sig, _) => {
+                    hir::ImplItemKind::Const(..) => true,
+                    hir::ImplItemKind::Method(ref sig, _) => {
                         if generics_require_inlining(&sig.generics) ||
                                 attr::requests_inline(&impl_item.attrs) {
                             true
@@ -206,7 +206,7 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
                             }
                         }
                     }
-                    hir::ImplItem_::Type(_) => false,
+                    hir::ImplItemKind::Type(_) => false,
                 }
             }
             Some(_) => false,
@@ -299,16 +299,16 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
             }
             ast_map::NodeImplItem(impl_item) => {
                 match impl_item.node {
-                    hir::ImplItem_::Const(_, ref expr) => {
+                    hir::ImplItemKind::Const(_, ref expr) => {
                         self.visit_expr(&*expr);
                     }
-                    hir::ImplItem_::Method(ref sig, ref body) => {
+                    hir::ImplItemKind::Method(ref sig, ref body) => {
                         let did = self.tcx.map.get_parent_did(search_item);
                         if method_might_be_inlined(self.tcx, sig, impl_item, did) {
                             visit::walk_block(self, body)
                         }
                     }
-                    hir::ImplItem_::Type(_) => {}
+                    hir::ImplItemKind::Type(_) => {}
                 }
             }
             // Nothing to recurse on for these

--- a/src/librustc/middle/ty/mod.rs
+++ b/src/librustc/middle/ty/mod.rs
@@ -1124,7 +1124,7 @@ impl<'a, 'tcx> ParameterEnvironment<'a, 'tcx> {
         match cx.map.find(id) {
             Some(ast_map::NodeImplItem(ref impl_item)) => {
                 match impl_item.node {
-                    hir::ImplItem_::Type(_) => {
+                    hir::ImplItemKind::Type(_) => {
                         // associated types don't have their own entry (for some reason),
                         // so for now just grab environment for the impl
                         let impl_id = cx.map.get_parent(id);
@@ -1136,7 +1136,7 @@ impl<'a, 'tcx> ParameterEnvironment<'a, 'tcx> {
                                                            &predicates,
                                                            id)
                     }
-                    hir::ImplItem_::Const(_, _) => {
+                    hir::ImplItemKind::Const(_, _) => {
                         let def_id = cx.map.local_def_id(id);
                         let scheme = cx.lookup_item_type(def_id);
                         let predicates = cx.lookup_predicates(def_id);
@@ -1145,7 +1145,7 @@ impl<'a, 'tcx> ParameterEnvironment<'a, 'tcx> {
                                                            &predicates,
                                                            id)
                     }
-                    hir::ImplItem_::Method(_, ref body) => {
+                    hir::ImplItemKind::Method(_, ref body) => {
                         let method_def_id = cx.map.local_def_id(id);
                         match cx.impl_or_trait_item(method_def_id) {
                             MethodTraitItem(ref method_ty) => {
@@ -2158,7 +2158,7 @@ impl<'tcx> ctxt<'tcx> {
                 }
                 ItemImpl(_, _, _, _, _, ref iis) => {
                     iis.iter().filter_map(|ii| {
-                        if let hir::ImplItem_::Const(_, _) = ii.node {
+                        if let hir::ImplItemKind::Const(_, _) = ii.node {
                             match self.impl_or_trait_item(self.map.local_def_id(ii.id)) {
                                 ConstTraitItem(ac) => Some(ac),
                                 _ => {

--- a/src/librustc/middle/ty/mod.rs
+++ b/src/librustc/middle/ty/mod.rs
@@ -1124,7 +1124,7 @@ impl<'a, 'tcx> ParameterEnvironment<'a, 'tcx> {
         match cx.map.find(id) {
             Some(ast_map::NodeImplItem(ref impl_item)) => {
                 match impl_item.node {
-                    hir::TypeImplItem(_) => {
+                    hir::ImplItem_::Type(_) => {
                         // associated types don't have their own entry (for some reason),
                         // so for now just grab environment for the impl
                         let impl_id = cx.map.get_parent(id);
@@ -1136,7 +1136,7 @@ impl<'a, 'tcx> ParameterEnvironment<'a, 'tcx> {
                                                            &predicates,
                                                            id)
                     }
-                    hir::ConstImplItem(_, _) => {
+                    hir::ImplItem_::Const(_, _) => {
                         let def_id = cx.map.local_def_id(id);
                         let scheme = cx.lookup_item_type(def_id);
                         let predicates = cx.lookup_predicates(def_id);
@@ -1145,7 +1145,7 @@ impl<'a, 'tcx> ParameterEnvironment<'a, 'tcx> {
                                                            &predicates,
                                                            id)
                     }
-                    hir::MethodImplItem(_, ref body) => {
+                    hir::ImplItem_::Method(_, ref body) => {
                         let method_def_id = cx.map.local_def_id(id);
                         match cx.impl_or_trait_item(method_def_id) {
                             MethodTraitItem(ref method_ty) => {
@@ -2158,7 +2158,7 @@ impl<'tcx> ctxt<'tcx> {
                 }
                 ItemImpl(_, _, _, _, _, ref iis) => {
                     iis.iter().filter_map(|ii| {
-                        if let hir::ConstImplItem(_, _) = ii.node {
+                        if let hir::ImplItem_::Const(_, _) = ii.node {
                             match self.impl_or_trait_item(self.map.local_def_id(ii.id)) {
                                 ConstTraitItem(ac) => Some(ac),
                                 _ => {

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -89,7 +89,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for BorrowckCtxt<'a, 'tcx> {
     }
 
     fn visit_impl_item(&mut self, ii: &hir::ImplItem) {
-        if let hir::ImplItem_::Const(_, ref expr) = ii.node {
+        if let hir::ImplItemKind::Const(_, ref expr) = ii.node {
             gather_loans::gather_loans_in_static_initializer(self, &*expr);
         }
         visit::walk_impl_item(self, ii);

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -89,7 +89,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for BorrowckCtxt<'a, 'tcx> {
     }
 
     fn visit_impl_item(&mut self, ii: &hir::ImplItem) {
-        if let hir::ConstImplItem(_, ref expr) = ii.node {
+        if let hir::ImplItem_::Const(_, ref expr) = ii.node {
             gather_loans::gather_loans_in_static_initializer(self, &*expr);
         }
         visit::walk_impl_item(self, ii);

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -623,7 +623,7 @@ impl fold::Folder for ReplaceBodyWithLoop {
 
     fn fold_impl_item(&mut self, i: P<ast::ImplItem>) -> SmallVector<P<ast::ImplItem>> {
         match i.node {
-            ast::ConstImplItem(..) => {
+            ast::ImplItemKind::Const(..) => {
                 self.within_static_or_const = true;
                 let ret = fold::noop_fold_impl_item(i, self);
                 self.within_static_or_const = false;

--- a/src/librustc_front/fold.rs
+++ b/src/librustc_front/fold.rs
@@ -867,13 +867,13 @@ pub fn noop_fold_impl_item<T: Folder>(i: P<ImplItem>, folder: &mut T) -> P<ImplI
             attrs: fold_attrs(attrs, folder),
             vis: vis,
             node: match node {
-                ImplItem_::Const(ty, expr) => {
-                    ImplItem_::Const(folder.fold_ty(ty), folder.fold_expr(expr))
+                ImplItemKind::Const(ty, expr) => {
+                    ImplItemKind::Const(folder.fold_ty(ty), folder.fold_expr(expr))
                 }
-                ImplItem_::Method(sig, body) => {
-                    ImplItem_::Method(noop_fold_method_sig(sig, folder), folder.fold_block(body))
+                ImplItemKind::Method(sig, body) => {
+                    ImplItemKind::Method(noop_fold_method_sig(sig, folder), folder.fold_block(body))
                 }
-                ImplItem_::Type(ty) => ImplItem_::Type(folder.fold_ty(ty)),
+                ImplItemKind::Type(ty) => ImplItemKind::Type(folder.fold_ty(ty)),
             },
             span: folder.new_span(span),
         }

--- a/src/librustc_front/fold.rs
+++ b/src/librustc_front/fold.rs
@@ -867,13 +867,13 @@ pub fn noop_fold_impl_item<T: Folder>(i: P<ImplItem>, folder: &mut T) -> P<ImplI
             attrs: fold_attrs(attrs, folder),
             vis: vis,
             node: match node {
-                ConstImplItem(ty, expr) => {
-                    ConstImplItem(folder.fold_ty(ty), folder.fold_expr(expr))
+                ImplItem_::Const(ty, expr) => {
+                    ImplItem_::Const(folder.fold_ty(ty), folder.fold_expr(expr))
                 }
-                MethodImplItem(sig, body) => {
-                    MethodImplItem(noop_fold_method_sig(sig, folder), folder.fold_block(body))
+                ImplItem_::Method(sig, body) => {
+                    ImplItem_::Method(noop_fold_method_sig(sig, folder), folder.fold_block(body))
                 }
-                TypeImplItem(ty) => TypeImplItem(folder.fold_ty(ty)),
+                ImplItem_::Type(ty) => ImplItem_::Type(folder.fold_ty(ty)),
             },
             span: folder.new_span(span),
         }

--- a/src/librustc_front/hir.rs
+++ b/src/librustc_front/hir.rs
@@ -770,12 +770,12 @@ pub struct ImplItem {
     pub name: Name,
     pub vis: Visibility,
     pub attrs: Vec<Attribute>,
-    pub node: ImplItem_,
+    pub node: ImplItemKind,
     pub span: Span,
 }
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
-pub enum ImplItem_ {
+pub enum ImplItemKind {
     Const(P<Ty>, P<Expr>),
     Method(MethodSig, P<Block>),
     Type(P<Ty>),

--- a/src/librustc_front/hir.rs
+++ b/src/librustc_front/hir.rs
@@ -19,7 +19,6 @@ pub use self::ExplicitSelf_::*;
 pub use self::Expr_::*;
 pub use self::FunctionRetTy::*;
 pub use self::ForeignItem_::*;
-pub use self::ImplItem_::*;
 pub use self::Item_::*;
 pub use self::Mutability::*;
 pub use self::Pat_::*;
@@ -777,9 +776,9 @@ pub struct ImplItem {
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub enum ImplItem_ {
-    ConstImplItem(P<Ty>, P<Expr>),
-    MethodImplItem(MethodSig, P<Block>),
-    TypeImplItem(P<Ty>),
+    Const(P<Ty>, P<Expr>),
+    Method(MethodSig, P<Block>),
+    Type(P<Ty>),
 }
 
 // Bind a type to an associated type: `A=Foo`.

--- a/src/librustc_front/lowering.rs
+++ b/src/librustc_front/lowering.rs
@@ -676,12 +676,12 @@ pub fn lower_impl_item(_lctx: &LoweringContext, i: &ImplItem) -> P<hir::ImplItem
         vis: lower_visibility(_lctx, i.vis),
         node: match i.node {
             ConstImplItem(ref ty, ref expr) => {
-                hir::ImplItem_::Const(lower_ty(_lctx, ty), lower_expr(_lctx, expr))
+                hir::ImplItemKind::Const(lower_ty(_lctx, ty), lower_expr(_lctx, expr))
             }
             MethodImplItem(ref sig, ref body) => {
-                hir::ImplItem_::Method(lower_method_sig(_lctx, sig), lower_block(_lctx, body))
+                hir::ImplItemKind::Method(lower_method_sig(_lctx, sig), lower_block(_lctx, body))
             }
-            TypeImplItem(ref ty) => hir::ImplItem_::Type(lower_ty(_lctx, ty)),
+            TypeImplItem(ref ty) => hir::ImplItemKind::Type(lower_ty(_lctx, ty)),
             MacImplItem(..) => panic!("Shouldn't exist any more"),
         },
         span: i.span,

--- a/src/librustc_front/lowering.rs
+++ b/src/librustc_front/lowering.rs
@@ -675,14 +675,14 @@ pub fn lower_impl_item(_lctx: &LoweringContext, i: &ImplItem) -> P<hir::ImplItem
         attrs: i.attrs.clone(),
         vis: lower_visibility(_lctx, i.vis),
         node: match i.node {
-            ConstImplItem(ref ty, ref expr) => {
+            ImplItemKind::Const(ref ty, ref expr) => {
                 hir::ImplItemKind::Const(lower_ty(_lctx, ty), lower_expr(_lctx, expr))
             }
-            MethodImplItem(ref sig, ref body) => {
+            ImplItemKind::Method(ref sig, ref body) => {
                 hir::ImplItemKind::Method(lower_method_sig(_lctx, sig), lower_block(_lctx, body))
             }
-            TypeImplItem(ref ty) => hir::ImplItemKind::Type(lower_ty(_lctx, ty)),
-            MacImplItem(..) => panic!("Shouldn't exist any more"),
+            ImplItemKind::Type(ref ty) => hir::ImplItemKind::Type(lower_ty(_lctx, ty)),
+            ImplItemKind::Macro(..) => panic!("Shouldn't exist any more"),
         },
         span: i.span,
     })

--- a/src/librustc_front/lowering.rs
+++ b/src/librustc_front/lowering.rs
@@ -676,12 +676,12 @@ pub fn lower_impl_item(_lctx: &LoweringContext, i: &ImplItem) -> P<hir::ImplItem
         vis: lower_visibility(_lctx, i.vis),
         node: match i.node {
             ConstImplItem(ref ty, ref expr) => {
-                hir::ConstImplItem(lower_ty(_lctx, ty), lower_expr(_lctx, expr))
+                hir::ImplItem_::Const(lower_ty(_lctx, ty), lower_expr(_lctx, expr))
             }
             MethodImplItem(ref sig, ref body) => {
-                hir::MethodImplItem(lower_method_sig(_lctx, sig), lower_block(_lctx, body))
+                hir::ImplItem_::Method(lower_method_sig(_lctx, sig), lower_block(_lctx, body))
             }
-            TypeImplItem(ref ty) => hir::TypeImplItem(lower_ty(_lctx, ty)),
+            TypeImplItem(ref ty) => hir::ImplItem_::Type(lower_ty(_lctx, ty)),
             MacImplItem(..) => panic!("Shouldn't exist any more"),
         },
         span: i.span,

--- a/src/librustc_front/print/pprust.rs
+++ b/src/librustc_front/print/pprust.rs
@@ -1011,16 +1011,16 @@ impl<'a> State<'a> {
         try!(self.maybe_print_comment(ii.span.lo));
         try!(self.print_outer_attributes(&ii.attrs));
         match ii.node {
-            hir::ConstImplItem(ref ty, ref expr) => {
+            hir::ImplItem_::Const(ref ty, ref expr) => {
                 try!(self.print_associated_const(ii.name, &ty, Some(&expr), ii.vis));
             }
-            hir::MethodImplItem(ref sig, ref body) => {
+            hir::ImplItem_::Method(ref sig, ref body) => {
                 try!(self.head(""));
                 try!(self.print_method_sig(ii.name, sig, ii.vis));
                 try!(self.nbsp());
                 try!(self.print_block_with_attrs(body, &ii.attrs));
             }
-            hir::TypeImplItem(ref ty) => {
+            hir::ImplItem_::Type(ref ty) => {
                 try!(self.print_associated_type(ii.name, None, Some(ty)));
             }
         }

--- a/src/librustc_front/print/pprust.rs
+++ b/src/librustc_front/print/pprust.rs
@@ -1011,16 +1011,16 @@ impl<'a> State<'a> {
         try!(self.maybe_print_comment(ii.span.lo));
         try!(self.print_outer_attributes(&ii.attrs));
         match ii.node {
-            hir::ImplItem_::Const(ref ty, ref expr) => {
+            hir::ImplItemKind::Const(ref ty, ref expr) => {
                 try!(self.print_associated_const(ii.name, &ty, Some(&expr), ii.vis));
             }
-            hir::ImplItem_::Method(ref sig, ref body) => {
+            hir::ImplItemKind::Method(ref sig, ref body) => {
                 try!(self.head(""));
                 try!(self.print_method_sig(ii.name, sig, ii.vis));
                 try!(self.nbsp());
                 try!(self.print_block_with_attrs(body, &ii.attrs));
             }
-            hir::ImplItem_::Type(ref ty) => {
+            hir::ImplItemKind::Type(ref ty) => {
                 try!(self.print_associated_type(ii.name, None, Some(ty)));
             }
         }

--- a/src/librustc_front/visit.rs
+++ b/src/librustc_front/visit.rs
@@ -614,18 +614,18 @@ pub fn walk_impl_item<'v, V: Visitor<'v>>(visitor: &mut V, impl_item: &'v ImplIt
     visitor.visit_name(impl_item.span, impl_item.name);
     walk_list!(visitor, visit_attribute, &impl_item.attrs);
     match impl_item.node {
-        ImplItem_::Const(ref ty, ref expr) => {
+        ImplItemKind::Const(ref ty, ref expr) => {
             visitor.visit_ty(ty);
             visitor.visit_expr(expr);
         }
-        ImplItem_::Method(ref sig, ref body) => {
+        ImplItemKind::Method(ref sig, ref body) => {
             visitor.visit_fn(FnKind::Method(impl_item.name, sig, Some(impl_item.vis)),
                              &sig.decl,
                              body,
                              impl_item.span,
                              impl_item.id);
         }
-        ImplItem_::Type(ref ty) => {
+        ImplItemKind::Type(ref ty) => {
             visitor.visit_ty(ty);
         }
     }

--- a/src/librustc_front/visit.rs
+++ b/src/librustc_front/visit.rs
@@ -614,18 +614,18 @@ pub fn walk_impl_item<'v, V: Visitor<'v>>(visitor: &mut V, impl_item: &'v ImplIt
     visitor.visit_name(impl_item.span, impl_item.name);
     walk_list!(visitor, visit_attribute, &impl_item.attrs);
     match impl_item.node {
-        ConstImplItem(ref ty, ref expr) => {
+        ImplItem_::Const(ref ty, ref expr) => {
             visitor.visit_ty(ty);
             visitor.visit_expr(expr);
         }
-        MethodImplItem(ref sig, ref body) => {
+        ImplItem_::Method(ref sig, ref body) => {
             visitor.visit_fn(FnKind::Method(impl_item.name, sig, Some(impl_item.vis)),
                              &sig.decl,
                              body,
                              impl_item.span,
                              impl_item.id);
         }
-        TypeImplItem(ref ty) => {
+        ImplItem_::Type(ref ty) => {
             visitor.visit_ty(ty);
         }
     }

--- a/src/librustc_lint/bad_style.rs
+++ b/src/librustc_lint/bad_style.rs
@@ -351,7 +351,7 @@ impl LateLintPass for NonUpperCaseGlobals {
 
     fn check_impl_item(&mut self, cx: &LateContext, ii: &hir::ImplItem) {
         match ii.node {
-            hir::ImplItem_::Const(..) => {
+            hir::ImplItemKind::Const(..) => {
                 NonUpperCaseGlobals::check_upper_case(cx, "associated constant",
                                                       ii.name, ii.span);
             }

--- a/src/librustc_lint/bad_style.rs
+++ b/src/librustc_lint/bad_style.rs
@@ -351,7 +351,7 @@ impl LateLintPass for NonUpperCaseGlobals {
 
     fn check_impl_item(&mut self, cx: &LateContext, ii: &hir::ImplItem) {
         match ii.node {
-            hir::ConstImplItem(..) => {
+            hir::ImplItem_::Const(..) => {
                 NonUpperCaseGlobals::check_upper_case(cx, "associated constant",
                                                       ii.name, ii.span);
             }

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -505,9 +505,9 @@ impl LateLintPass for MissingDoc {
         }
 
         let desc = match impl_item.node {
-            hir::ImplItem_::Const(..) => "an associated constant",
-            hir::ImplItem_::Method(..) => "a method",
-            hir::ImplItem_::Type(_) => "an associated type",
+            hir::ImplItemKind::Const(..) => "an associated constant",
+            hir::ImplItemKind::Method(..) => "a method",
+            hir::ImplItemKind::Type(_) => "an associated type",
         };
         self.check_missing_docs_attrs(cx, Some(impl_item.id),
                                       &impl_item.attrs,

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -505,9 +505,9 @@ impl LateLintPass for MissingDoc {
         }
 
         let desc = match impl_item.node {
-            hir::ConstImplItem(..) => "an associated constant",
-            hir::MethodImplItem(..) => "a method",
-            hir::TypeImplItem(_) => "an associated type",
+            hir::ImplItem_::Const(..) => "an associated constant",
+            hir::ImplItem_::Method(..) => "a method",
+            hir::ImplItem_::Type(_) => "an associated type",
         };
         self.check_missing_docs_attrs(cx, Some(impl_item.id),
                                       &impl_item.attrs,

--- a/src/librustc_mir/mir_map.rs
+++ b/src/librustc_mir/mir_map.rs
@@ -99,10 +99,10 @@ impl<'a, 'tcx> visit::Visitor<'tcx> for OuterDump<'a, 'tcx> {
 
     fn visit_impl_item(&mut self, impl_item: &'tcx hir::ImplItem) {
         match impl_item.node {
-            hir::MethodImplItem(..) => {
+            hir::ImplItem_::Method(..) => {
                 self.visit_mir(&impl_item.attrs, |c| visit::walk_impl_item(c, impl_item));
             }
-            hir::ConstImplItem(..) | hir::TypeImplItem(..) => {}
+            hir::ImplItem_::Const(..) | hir::ImplItem_::Type(..) => {}
         }
         visit::walk_impl_item(self, impl_item);
     }

--- a/src/librustc_mir/mir_map.rs
+++ b/src/librustc_mir/mir_map.rs
@@ -99,10 +99,10 @@ impl<'a, 'tcx> visit::Visitor<'tcx> for OuterDump<'a, 'tcx> {
 
     fn visit_impl_item(&mut self, impl_item: &'tcx hir::ImplItem) {
         match impl_item.node {
-            hir::ImplItem_::Method(..) => {
+            hir::ImplItemKind::Method(..) => {
                 self.visit_mir(&impl_item.attrs, |c| visit::walk_impl_item(c, impl_item));
             }
-            hir::ImplItem_::Const(..) | hir::ImplItem_::Type(..) => {}
+            hir::ImplItemKind::Const(..) | hir::ImplItemKind::Type(..) => {}
         }
         visit::walk_impl_item(self, impl_item);
     }

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -553,8 +553,8 @@ impl<'a, 'tcx> PrivacyVisitor<'a, 'tcx> {
                 //               where the method was defined?
                 Some(ast_map::NodeImplItem(ii)) => {
                     match ii.node {
-                        hir::ConstImplItem(..) |
-                        hir::MethodImplItem(..) => {
+                        hir::ImplItem_::Const(..) |
+                        hir::ImplItem_::Method(..) => {
                             let imp = self.tcx.map
                                           .get_parent_did(closest_private_id);
                             match self.tcx.impl_trait_ref(imp) {
@@ -565,7 +565,7 @@ impl<'a, 'tcx> PrivacyVisitor<'a, 'tcx> {
                                 _ => ii.vis
                             }
                         }
-                        hir::TypeImplItem(_) => return Allowable,
+                        hir::ImplItem_::Type(_) => return Allowable,
                     }
                 }
                 Some(ast_map::NodeTraitItem(_)) => {
@@ -1293,11 +1293,11 @@ impl<'a, 'tcx, 'v> Visitor<'v> for VisiblePrivateTypesVisitor<'a, 'tcx> {
                     impl_items.iter()
                               .any(|impl_item| {
                                   match impl_item.node {
-                                      hir::ConstImplItem(..) |
-                                      hir::MethodImplItem(..) => {
+                                      hir::ImplItem_::Const(..) |
+                                      hir::ImplItem_::Method(..) => {
                                           self.exported_items.contains(&impl_item.id)
                                       }
-                                      hir::TypeImplItem(_) => false,
+                                      hir::ImplItem_::Type(_) => false,
                                   }
                               });
 
@@ -1316,13 +1316,13 @@ impl<'a, 'tcx, 'v> Visitor<'v> for VisiblePrivateTypesVisitor<'a, 'tcx> {
                                 // don't erroneously report errors for private
                                 // types in private items.
                                 match impl_item.node {
-                                    hir::ConstImplItem(..) |
-                                    hir::MethodImplItem(..)
+                                    hir::ImplItem_::Const(..) |
+                                    hir::ImplItem_::Method(..)
                                         if self.item_is_public(&impl_item.id, impl_item.vis) =>
                                     {
                                         visit::walk_impl_item(self, impl_item)
                                     }
-                                    hir::TypeImplItem(..) => {
+                                    hir::ImplItem_::Type(..) => {
                                         visit::walk_impl_item(self, impl_item)
                                     }
                                     _ => {}
@@ -1347,7 +1347,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for VisiblePrivateTypesVisitor<'a, 'tcx> {
 
                             // Those in 3. are warned with this call.
                             for impl_item in impl_items {
-                                if let hir::TypeImplItem(ref ty) = impl_item.node {
+                                if let hir::ImplItem_::Type(ref ty) = impl_item.node {
                                     self.visit_ty(ty);
                                 }
                             }
@@ -1359,13 +1359,13 @@ impl<'a, 'tcx, 'v> Visitor<'v> for VisiblePrivateTypesVisitor<'a, 'tcx> {
                     let mut found_pub_static = false;
                     for impl_item in impl_items {
                         match impl_item.node {
-                            hir::ConstImplItem(..) => {
+                            hir::ImplItem_::Const(..) => {
                                 if self.item_is_public(&impl_item.id, impl_item.vis) {
                                     found_pub_static = true;
                                     visit::walk_impl_item(self, impl_item);
                                 }
                             }
-                            hir::MethodImplItem(ref sig, _) => {
+                            hir::ImplItem_::Method(ref sig, _) => {
                                 if sig.explicit_self.node == hir::SelfStatic &&
                                       self.item_is_public(&impl_item.id, impl_item.vis) {
                                     found_pub_static = true;

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -553,8 +553,8 @@ impl<'a, 'tcx> PrivacyVisitor<'a, 'tcx> {
                 //               where the method was defined?
                 Some(ast_map::NodeImplItem(ii)) => {
                     match ii.node {
-                        hir::ImplItem_::Const(..) |
-                        hir::ImplItem_::Method(..) => {
+                        hir::ImplItemKind::Const(..) |
+                        hir::ImplItemKind::Method(..) => {
                             let imp = self.tcx.map
                                           .get_parent_did(closest_private_id);
                             match self.tcx.impl_trait_ref(imp) {
@@ -565,7 +565,7 @@ impl<'a, 'tcx> PrivacyVisitor<'a, 'tcx> {
                                 _ => ii.vis
                             }
                         }
-                        hir::ImplItem_::Type(_) => return Allowable,
+                        hir::ImplItemKind::Type(_) => return Allowable,
                     }
                 }
                 Some(ast_map::NodeTraitItem(_)) => {
@@ -1293,11 +1293,11 @@ impl<'a, 'tcx, 'v> Visitor<'v> for VisiblePrivateTypesVisitor<'a, 'tcx> {
                     impl_items.iter()
                               .any(|impl_item| {
                                   match impl_item.node {
-                                      hir::ImplItem_::Const(..) |
-                                      hir::ImplItem_::Method(..) => {
+                                      hir::ImplItemKind::Const(..) |
+                                      hir::ImplItemKind::Method(..) => {
                                           self.exported_items.contains(&impl_item.id)
                                       }
-                                      hir::ImplItem_::Type(_) => false,
+                                      hir::ImplItemKind::Type(_) => false,
                                   }
                               });
 
@@ -1316,13 +1316,13 @@ impl<'a, 'tcx, 'v> Visitor<'v> for VisiblePrivateTypesVisitor<'a, 'tcx> {
                                 // don't erroneously report errors for private
                                 // types in private items.
                                 match impl_item.node {
-                                    hir::ImplItem_::Const(..) |
-                                    hir::ImplItem_::Method(..)
+                                    hir::ImplItemKind::Const(..) |
+                                    hir::ImplItemKind::Method(..)
                                         if self.item_is_public(&impl_item.id, impl_item.vis) =>
                                     {
                                         visit::walk_impl_item(self, impl_item)
                                     }
-                                    hir::ImplItem_::Type(..) => {
+                                    hir::ImplItemKind::Type(..) => {
                                         visit::walk_impl_item(self, impl_item)
                                     }
                                     _ => {}
@@ -1347,7 +1347,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for VisiblePrivateTypesVisitor<'a, 'tcx> {
 
                             // Those in 3. are warned with this call.
                             for impl_item in impl_items {
-                                if let hir::ImplItem_::Type(ref ty) = impl_item.node {
+                                if let hir::ImplItemKind::Type(ref ty) = impl_item.node {
                                     self.visit_ty(ty);
                                 }
                             }
@@ -1359,13 +1359,13 @@ impl<'a, 'tcx, 'v> Visitor<'v> for VisiblePrivateTypesVisitor<'a, 'tcx> {
                     let mut found_pub_static = false;
                     for impl_item in impl_items {
                         match impl_item.node {
-                            hir::ImplItem_::Const(..) => {
+                            hir::ImplItemKind::Const(..) => {
                                 if self.item_is_public(&impl_item.id, impl_item.vis) {
                                     found_pub_static = true;
                                     visit::walk_impl_item(self, impl_item);
                                 }
                             }
-                            hir::ImplItem_::Method(ref sig, _) => {
+                            hir::ImplItemKind::Method(ref sig, _) => {
                                 if sig.explicit_self.node == hir::SelfStatic &&
                                       self.item_is_public(&impl_item.id, impl_item.vis) {
                                     found_pub_static = true;

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2420,7 +2420,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                     this.with_current_self_type(self_type, |this| {
                         for impl_item in impl_items {
                             match impl_item.node {
-                                hir::ImplItem_::Const(..) => {
+                                hir::ImplItemKind::Const(..) => {
                                     // If this is a trait impl, ensure the const
                                     // exists in trait
                                     this.check_trait_item(impl_item.name,
@@ -2430,7 +2430,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                         visit::walk_impl_item(this, impl_item);
                                     });
                                 }
-                                hir::ImplItem_::Method(ref sig, _) => {
+                                hir::ImplItemKind::Method(ref sig, _) => {
                                     // If this is a trait impl, ensure the method
                                     // exists in trait
                                     this.check_trait_item(impl_item.name,
@@ -2447,7 +2447,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                         visit::walk_impl_item(this, impl_item);
                                     });
                                 }
-                                hir::ImplItem_::Type(ref ty) => {
+                                hir::ImplItemKind::Type(ref ty) => {
                                     // If this is a trait impl, ensure the type
                                     // exists in trait
                                     this.check_trait_item(impl_item.name,
@@ -3544,7 +3544,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                         _ => return false,
                     },
                     hir_map::NodeImplItem(impl_item) => match impl_item.node {
-                        hir::ImplItem_::Method(ref sig, _) => sig,
+                        hir::ImplItemKind::Method(ref sig, _) => sig,
                         _ => return false,
                     },
                     _ => return false,

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -79,7 +79,7 @@ use syntax::codemap::{self, Span, Pos};
 use rustc_front::visit::{self, FnKind, Visitor};
 use rustc_front::hir;
 use rustc_front::hir::{Arm, BindByRef, BindByValue, BindingMode, Block};
-use rustc_front::hir::{ConstImplItem, Crate};
+use rustc_front::hir::Crate;
 use rustc_front::hir::{Expr, ExprAgain, ExprBreak, ExprField};
 use rustc_front::hir::{ExprLoop, ExprWhile, ExprMethodCall};
 use rustc_front::hir::{ExprPath, ExprStruct, FnDecl};
@@ -87,12 +87,11 @@ use rustc_front::hir::{ForeignItemFn, ForeignItemStatic, Generics};
 use rustc_front::hir::{ImplItem, Item, ItemConst, ItemEnum, ItemExternCrate};
 use rustc_front::hir::{ItemFn, ItemForeignMod, ItemImpl, ItemMod, ItemStatic, ItemDefaultImpl};
 use rustc_front::hir::{ItemStruct, ItemTrait, ItemTy, ItemUse};
-use rustc_front::hir::{Local, MethodImplItem};
+use rustc_front::hir::Local;
 use rustc_front::hir::{Pat, PatEnum, PatIdent, PatLit, PatQPath};
 use rustc_front::hir::{PatRange, PatStruct, Path, PrimTy};
 use rustc_front::hir::{TraitRef, Ty, TyBool, TyChar, TyFloat, TyInt};
 use rustc_front::hir::{TyRptr, TyStr, TyUint, TyPath, TyPtr};
-use rustc_front::hir::TypeImplItem;
 use rustc_front::util::walk_pat;
 
 use std::collections::{HashMap, HashSet};
@@ -2421,7 +2420,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                     this.with_current_self_type(self_type, |this| {
                         for impl_item in impl_items {
                             match impl_item.node {
-                                ConstImplItem(..) => {
+                                hir::ImplItem_::Const(..) => {
                                     // If this is a trait impl, ensure the const
                                     // exists in trait
                                     this.check_trait_item(impl_item.name,
@@ -2431,7 +2430,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                         visit::walk_impl_item(this, impl_item);
                                     });
                                 }
-                                MethodImplItem(ref sig, _) => {
+                                hir::ImplItem_::Method(ref sig, _) => {
                                     // If this is a trait impl, ensure the method
                                     // exists in trait
                                     this.check_trait_item(impl_item.name,
@@ -2448,7 +2447,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                         visit::walk_impl_item(this, impl_item);
                                     });
                                 }
-                                TypeImplItem(ref ty) => {
+                                hir::ImplItem_::Type(ref ty) => {
                                     // If this is a trait impl, ensure the type
                                     // exists in trait
                                     this.check_trait_item(impl_item.name,
@@ -3545,7 +3544,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                         _ => return false,
                     },
                     hir_map::NodeImplItem(impl_item) => match impl_item.node {
-                        hir::MethodImplItem(ref sig, _) => sig,
+                        hir::ImplItem_::Method(ref sig, _) => sig,
                         _ => return false,
                     },
                     _ => return false,

--- a/src/librustc_trans/save/dump_csv.rs
+++ b/src/librustc_trans/save/dump_csv.rs
@@ -992,22 +992,22 @@ impl<'l, 'tcx, 'v> Visitor<'v> for DumpCsvVisitor<'l, 'tcx> {
 
     fn visit_impl_item(&mut self, impl_item: &ast::ImplItem) {
         match impl_item.node {
-            ast::ConstImplItem(ref ty, ref expr) => {
+            ast::ImplItemKind::Const(ref ty, ref expr) => {
                 self.process_const(impl_item.id,
                                    impl_item.ident.name,
                                    impl_item.span,
                                    &ty,
                                    &expr);
             }
-            ast::MethodImplItem(ref sig, ref body) => {
+            ast::ImplItemKind::Method(ref sig, ref body) => {
                 self.process_method(sig,
                                     Some(body),
                                     impl_item.id,
                                     impl_item.ident.name,
                                     impl_item.span);
             }
-            ast::TypeImplItem(_) |
-            ast::MacImplItem(_) => {}
+            ast::ImplItemKind::Type(_) |
+            ast::ImplItemKind::Macro(_) => {}
         }
     }
 

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -1326,7 +1326,7 @@ fn build_cfg(tcx: &ty::ctxt, id: ast::NodeId) -> (ast::NodeId, Option<cfg::CFG>)
         }
         Some(hir_map::NodeImplItem(impl_item)) => {
             match impl_item.node {
-                hir::MethodImplItem(_, ref body) => body,
+                hir::ImplItem_::Method(_, ref body) => body,
                 _ => {
                     tcx.sess.bug("unexpected variant: non-method impl item in \
                                   has_nested_returns")
@@ -2614,7 +2614,7 @@ pub fn get_item_val(ccx: &CrateContext, id: ast::NodeId) -> ValueRef {
 
         hir_map::NodeImplItem(impl_item) => {
             match impl_item.node {
-                hir::MethodImplItem(..) => {
+                hir::ImplItem_::Method(..) => {
                     register_method(ccx, id, &impl_item.attrs, impl_item.span)
                 }
                 _ => {

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -1326,7 +1326,7 @@ fn build_cfg(tcx: &ty::ctxt, id: ast::NodeId) -> (ast::NodeId, Option<cfg::CFG>)
         }
         Some(hir_map::NodeImplItem(impl_item)) => {
             match impl_item.node {
-                hir::ImplItem_::Method(_, ref body) => body,
+                hir::ImplItemKind::Method(_, ref body) => body,
                 _ => {
                     tcx.sess.bug("unexpected variant: non-method impl item in \
                                   has_nested_returns")
@@ -2614,7 +2614,7 @@ pub fn get_item_val(ccx: &CrateContext, id: ast::NodeId) -> ValueRef {
 
         hir_map::NodeImplItem(impl_item) => {
             match impl_item.node {
-                hir::ImplItem_::Method(..) => {
+                hir::ImplItemKind::Method(..) => {
                     register_method(ccx, id, &impl_item.attrs, impl_item.span)
                 }
                 _ => {

--- a/src/librustc_trans/trans/debuginfo/mod.rs
+++ b/src/librustc_trans/trans/debuginfo/mod.rs
@@ -253,7 +253,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
         }
         hir_map::NodeImplItem(impl_item) => {
             match impl_item.node {
-                hir::ImplItem_::Method(ref sig, ref body) => {
+                hir::ImplItemKind::Method(ref sig, ref body) => {
                     if contains_nodebug_attribute(&impl_item.attrs) {
                         return FunctionDebugContext::FunctionWithoutDebugInfo;
                     }

--- a/src/librustc_trans/trans/debuginfo/mod.rs
+++ b/src/librustc_trans/trans/debuginfo/mod.rs
@@ -253,7 +253,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
         }
         hir_map::NodeImplItem(impl_item) => {
             match impl_item.node {
-                hir::MethodImplItem(ref sig, ref body) => {
+                hir::ImplItem_::Method(ref sig, ref body) => {
                     if contains_nodebug_attribute(&impl_item.attrs) {
                         return FunctionDebugContext::FunctionWithoutDebugInfo;
                     }

--- a/src/librustc_trans/trans/inline.rs
+++ b/src/librustc_trans/trans/inline.rs
@@ -160,7 +160,7 @@ fn instantiate_inline(ccx: &CrateContext, fn_id: DefId)
             ccx.stats().n_inlines.set(ccx.stats().n_inlines.get() + 1);
 
             // Translate monomorphic impl methods immediately.
-            if let hir::MethodImplItem(ref sig, ref body) = impl_item.node {
+            if let hir::ImplItem_::Method(ref sig, ref body) = impl_item.node {
                 let impl_tpt = ccx.tcx().lookup_item_type(impl_did);
                 if impl_tpt.generics.types.is_empty() &&
                         sig.generics.ty_params.is_empty() {

--- a/src/librustc_trans/trans/inline.rs
+++ b/src/librustc_trans/trans/inline.rs
@@ -160,7 +160,7 @@ fn instantiate_inline(ccx: &CrateContext, fn_id: DefId)
             ccx.stats().n_inlines.set(ccx.stats().n_inlines.get() + 1);
 
             // Translate monomorphic impl methods immediately.
-            if let hir::ImplItem_::Method(ref sig, ref body) = impl_item.node {
+            if let hir::ImplItemKind::Method(ref sig, ref body) = impl_item.node {
                 let impl_tpt = ccx.tcx().lookup_item_type(impl_did);
                 if impl_tpt.generics.types.is_empty() &&
                         sig.generics.ty_params.is_empty() {

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -70,7 +70,7 @@ pub fn trans_impl(ccx: &CrateContext,
     if !generics.ty_params.is_empty() {
         for impl_item in impl_items {
             match impl_item.node {
-                hir::ImplItem_::Method(..) => {
+                hir::ImplItemKind::Method(..) => {
                     visit::walk_impl_item(&mut v, impl_item);
                 }
                 _ => {}
@@ -80,7 +80,7 @@ pub fn trans_impl(ccx: &CrateContext,
     }
     for impl_item in impl_items {
         match impl_item.node {
-            hir::ImplItem_::Method(ref sig, ref body) => {
+            hir::ImplItemKind::Method(ref sig, ref body) => {
                 if sig.generics.ty_params.is_empty() {
                     let trans_everywhere = attr::requests_inline(&impl_item.attrs);
                     for (ref ccx, is_origin) in ccx.maybe_iter(trans_everywhere) {

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -70,7 +70,7 @@ pub fn trans_impl(ccx: &CrateContext,
     if !generics.ty_params.is_empty() {
         for impl_item in impl_items {
             match impl_item.node {
-                hir::MethodImplItem(..) => {
+                hir::ImplItem_::Method(..) => {
                     visit::walk_impl_item(&mut v, impl_item);
                 }
                 _ => {}
@@ -80,7 +80,7 @@ pub fn trans_impl(ccx: &CrateContext,
     }
     for impl_item in impl_items {
         match impl_item.node {
-            hir::MethodImplItem(ref sig, ref body) => {
+            hir::ImplItem_::Method(ref sig, ref body) => {
                 if sig.generics.ty_params.is_empty() {
                     let trans_everywhere = attr::requests_inline(&impl_item.attrs);
                     for (ref ccx, is_origin) in ccx.maybe_iter(trans_everywhere) {

--- a/src/librustc_trans/trans/monomorphize.rs
+++ b/src/librustc_trans/trans/monomorphize.rs
@@ -206,7 +206,7 @@ pub fn monomorphic_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
         }
         hir_map::NodeImplItem(impl_item) => {
             match impl_item.node {
-                hir::MethodImplItem(ref sig, ref body) => {
+                hir::ImplItem_::Method(ref sig, ref body) => {
                     let d = mk_lldecl(abi::Rust);
                     let needs_body = setup_lldecl(d, &impl_item.attrs);
                     if needs_body {

--- a/src/librustc_trans/trans/monomorphize.rs
+++ b/src/librustc_trans/trans/monomorphize.rs
@@ -206,7 +206,7 @@ pub fn monomorphic_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
         }
         hir_map::NodeImplItem(impl_item) => {
             match impl_item.node {
-                hir::ImplItem_::Method(ref sig, ref body) => {
+                hir::ImplItemKind::Method(ref sig, ref body) => {
                     let d = mk_lldecl(abi::Rust);
                     let needs_body = setup_lldecl(d, &impl_item.attrs);
                     if needs_body {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -764,14 +764,14 @@ pub fn check_item_body<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx hir::Item) {
 
         for impl_item in impl_items {
             match impl_item.node {
-                hir::ConstImplItem(_, ref expr) => {
+                hir::ImplItem_::Const(_, ref expr) => {
                     check_const(ccx, impl_item.span, &*expr, impl_item.id)
                 }
-                hir::MethodImplItem(ref sig, ref body) => {
+                hir::ImplItem_::Method(ref sig, ref body) => {
                     check_method_body(ccx, &impl_pty.generics, sig, body,
                                       impl_item.id, impl_item.span);
                 }
-                hir::TypeImplItem(_) => {
+                hir::ImplItem_::Type(_) => {
                     // Nothing to do here.
                 }
             }
@@ -908,7 +908,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                            impl_trait_ref));
             });
         match impl_item.node {
-            hir::ConstImplItem(..) => {
+            hir::ImplItem_::Const(..) => {
                 let impl_const = match ty_impl_item {
                     ty::ConstTraitItem(ref cti) => cti,
                     _ => tcx.sess.span_bug(impl_item.span, "non-const impl-item for const")
@@ -929,7 +929,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                               impl_trait_ref)
                 }
             }
-            hir::MethodImplItem(ref sig, ref body) => {
+            hir::ImplItem_::Method(ref sig, ref body) => {
                 check_trait_fn_not_const(ccx, impl_item.span, sig.constness);
 
                 let impl_method = match ty_impl_item {
@@ -952,7 +952,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                               impl_trait_ref)
                 }
             }
-            hir::TypeImplItem(_) => {
+            hir::ImplItem_::Type(_) => {
                 let impl_type = match ty_impl_item {
                     ty::TypeTraitItem(ref tti) => tti,
                     _ => tcx.sess.span_bug(impl_item.span, "non-type impl-item for type")
@@ -983,7 +983,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
             ty::ConstTraitItem(ref associated_const) => {
                 let is_implemented = impl_items.iter().any(|ii| {
                     match ii.node {
-                        hir::ConstImplItem(..) => {
+                        hir::ImplItem_::Const(..) => {
                             ii.name == associated_const.name
                         }
                         _ => false,
@@ -1003,7 +1003,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                 let is_implemented =
                     impl_items.iter().any(|ii| {
                         match ii.node {
-                            hir::MethodImplItem(..) => {
+                            hir::ImplItem_::Method(..) => {
                                 ii.name == trait_method.name
                             }
                             _ => false,
@@ -1022,7 +1022,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
             ty::TypeTraitItem(ref associated_type) => {
                 let is_implemented = impl_items.iter().any(|ii| {
                     match ii.node {
-                        hir::TypeImplItem(_) => {
+                        hir::ImplItem_::Type(_) => {
                             ii.name == associated_type.name
                         }
                         _ => false,

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -764,14 +764,14 @@ pub fn check_item_body<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx hir::Item) {
 
         for impl_item in impl_items {
             match impl_item.node {
-                hir::ImplItem_::Const(_, ref expr) => {
+                hir::ImplItemKind::Const(_, ref expr) => {
                     check_const(ccx, impl_item.span, &*expr, impl_item.id)
                 }
-                hir::ImplItem_::Method(ref sig, ref body) => {
+                hir::ImplItemKind::Method(ref sig, ref body) => {
                     check_method_body(ccx, &impl_pty.generics, sig, body,
                                       impl_item.id, impl_item.span);
                 }
-                hir::ImplItem_::Type(_) => {
+                hir::ImplItemKind::Type(_) => {
                     // Nothing to do here.
                 }
             }
@@ -908,7 +908,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                            impl_trait_ref));
             });
         match impl_item.node {
-            hir::ImplItem_::Const(..) => {
+            hir::ImplItemKind::Const(..) => {
                 let impl_const = match ty_impl_item {
                     ty::ConstTraitItem(ref cti) => cti,
                     _ => tcx.sess.span_bug(impl_item.span, "non-const impl-item for const")
@@ -929,7 +929,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                               impl_trait_ref)
                 }
             }
-            hir::ImplItem_::Method(ref sig, ref body) => {
+            hir::ImplItemKind::Method(ref sig, ref body) => {
                 check_trait_fn_not_const(ccx, impl_item.span, sig.constness);
 
                 let impl_method = match ty_impl_item {
@@ -952,7 +952,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                               impl_trait_ref)
                 }
             }
-            hir::ImplItem_::Type(_) => {
+            hir::ImplItemKind::Type(_) => {
                 let impl_type = match ty_impl_item {
                     ty::TypeTraitItem(ref tti) => tti,
                     _ => tcx.sess.span_bug(impl_item.span, "non-type impl-item for type")
@@ -983,7 +983,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
             ty::ConstTraitItem(ref associated_const) => {
                 let is_implemented = impl_items.iter().any(|ii| {
                     match ii.node {
-                        hir::ImplItem_::Const(..) => {
+                        hir::ImplItemKind::Const(..) => {
                             ii.name == associated_const.name
                         }
                         _ => false,
@@ -1003,7 +1003,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                 let is_implemented =
                     impl_items.iter().any(|ii| {
                         match ii.node {
-                            hir::ImplItem_::Method(..) => {
+                            hir::ImplItemKind::Method(..) => {
                                 ii.name == trait_method.name
                             }
                             _ => false,
@@ -1022,7 +1022,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
             ty::TypeTraitItem(ref associated_type) => {
                 let is_implemented = impl_items.iter().any(|ii| {
                     match ii.node {
-                        hir::ImplItem_::Type(_) => {
+                        hir::ImplItemKind::Type(_) => {
                             ii.name == associated_type.name
                         }
                         _ => false,

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -196,13 +196,13 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
                 impl_items.iter().map(|impl_item| {
                     let impl_def_id = self.crate_context.tcx.map.local_def_id(impl_item.id);
                     match impl_item.node {
-                        hir::ConstImplItem(..) => {
+                        hir::ImplItem_::Const(..) => {
                             ConstTraitItemId(impl_def_id)
                         }
-                        hir::MethodImplItem(..) => {
+                        hir::ImplItem_::Method(..) => {
                             MethodTraitItemId(impl_def_id)
                         }
-                        hir::TypeImplItem(_) => {
+                        hir::ImplItem_::Type(_) => {
                             TypeTraitItemId(impl_def_id)
                         }
                     }

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -196,13 +196,13 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
                 impl_items.iter().map(|impl_item| {
                     let impl_def_id = self.crate_context.tcx.map.local_def_id(impl_item.id);
                     match impl_item.node {
-                        hir::ImplItem_::Const(..) => {
+                        hir::ImplItemKind::Const(..) => {
                             ConstTraitItemId(impl_def_id)
                         }
-                        hir::ImplItem_::Method(..) => {
+                        hir::ImplItemKind::Method(..) => {
                             MethodTraitItemId(impl_def_id)
                         }
-                        hir::ImplItem_::Type(_) => {
+                        hir::ImplItemKind::Type(_) => {
                             TypeTraitItemId(impl_def_id)
                         }
                     }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -821,14 +821,14 @@ fn convert_item(ccx: &CrateCtxt, it: &hir::Item) {
 
             for impl_item in impl_items {
                 let seen_items = match impl_item.node {
-                    hir::TypeImplItem(_) => &mut seen_type_items,
+                    hir::ImplItem_::Type(_) => &mut seen_type_items,
                     _                    => &mut seen_value_items,
                 };
                 if !seen_items.insert(impl_item.name) {
                     let desc = match impl_item.node {
-                        hir::ConstImplItem(_, _) => "associated constant",
-                        hir::TypeImplItem(_) => "associated type",
-                        hir::MethodImplItem(ref sig, _) =>
+                        hir::ImplItem_::Const(_, _) => "associated constant",
+                        hir::ImplItem_::Type(_) => "associated type",
+                        hir::ImplItem_::Method(ref sig, _) =>
                             match sig.explicit_self.node {
                                 hir::SelfStatic => "associated function",
                                 _ => "method",
@@ -838,7 +838,7 @@ fn convert_item(ccx: &CrateCtxt, it: &hir::Item) {
                     span_err!(tcx.sess, impl_item.span, E0201, "duplicate {}", desc);
                 }
 
-                if let hir::ConstImplItem(ref ty, _) = impl_item.node {
+                if let hir::ImplItem_::Const(ref ty, _) = impl_item.node {
                     let ty = ccx.icx(&ty_predicates)
                                 .to_ty(&ExplicitRscope, &*ty);
                     tcx.register_item_type(ccx.tcx.map.local_def_id(impl_item.id),
@@ -855,7 +855,7 @@ fn convert_item(ccx: &CrateCtxt, it: &hir::Item) {
 
             // Convert all the associated types.
             for impl_item in impl_items {
-                if let hir::TypeImplItem(ref ty) = impl_item.node {
+                if let hir::ImplItem_::Type(ref ty) = impl_item.node {
                     if opt_trait_ref.is_none() {
                         span_err!(tcx.sess, impl_item.span, E0202,
                                   "associated types are not allowed in inherent impls");
@@ -870,7 +870,7 @@ fn convert_item(ccx: &CrateCtxt, it: &hir::Item) {
             }
 
             let methods = impl_items.iter().filter_map(|ii| {
-                if let hir::MethodImplItem(ref sig, _) = ii.node {
+                if let hir::ImplItem_::Method(ref sig, _) = ii.node {
                     // if the method specifies a visibility, use that, otherwise
                     // inherit the visibility from the impl (so `foo` in `pub impl
                     // { fn foo(); }` is public, but private in `impl { fn
@@ -889,7 +889,7 @@ fn convert_item(ccx: &CrateCtxt, it: &hir::Item) {
                             &ty_predicates);
 
             for impl_item in impl_items {
-                if let hir::MethodImplItem(ref sig, ref body) = impl_item.node {
+                if let hir::ImplItem_::Method(ref sig, ref body) = impl_item.node {
                     let body_id = body.id;
                     check_method_self_type(ccx,
                                            &BindingRscope::new(),

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -821,14 +821,14 @@ fn convert_item(ccx: &CrateCtxt, it: &hir::Item) {
 
             for impl_item in impl_items {
                 let seen_items = match impl_item.node {
-                    hir::ImplItem_::Type(_) => &mut seen_type_items,
+                    hir::ImplItemKind::Type(_) => &mut seen_type_items,
                     _                    => &mut seen_value_items,
                 };
                 if !seen_items.insert(impl_item.name) {
                     let desc = match impl_item.node {
-                        hir::ImplItem_::Const(_, _) => "associated constant",
-                        hir::ImplItem_::Type(_) => "associated type",
-                        hir::ImplItem_::Method(ref sig, _) =>
+                        hir::ImplItemKind::Const(_, _) => "associated constant",
+                        hir::ImplItemKind::Type(_) => "associated type",
+                        hir::ImplItemKind::Method(ref sig, _) =>
                             match sig.explicit_self.node {
                                 hir::SelfStatic => "associated function",
                                 _ => "method",
@@ -838,7 +838,7 @@ fn convert_item(ccx: &CrateCtxt, it: &hir::Item) {
                     span_err!(tcx.sess, impl_item.span, E0201, "duplicate {}", desc);
                 }
 
-                if let hir::ImplItem_::Const(ref ty, _) = impl_item.node {
+                if let hir::ImplItemKind::Const(ref ty, _) = impl_item.node {
                     let ty = ccx.icx(&ty_predicates)
                                 .to_ty(&ExplicitRscope, &*ty);
                     tcx.register_item_type(ccx.tcx.map.local_def_id(impl_item.id),
@@ -855,7 +855,7 @@ fn convert_item(ccx: &CrateCtxt, it: &hir::Item) {
 
             // Convert all the associated types.
             for impl_item in impl_items {
-                if let hir::ImplItem_::Type(ref ty) = impl_item.node {
+                if let hir::ImplItemKind::Type(ref ty) = impl_item.node {
                     if opt_trait_ref.is_none() {
                         span_err!(tcx.sess, impl_item.span, E0202,
                                   "associated types are not allowed in inherent impls");
@@ -870,7 +870,7 @@ fn convert_item(ccx: &CrateCtxt, it: &hir::Item) {
             }
 
             let methods = impl_items.iter().filter_map(|ii| {
-                if let hir::ImplItem_::Method(ref sig, _) = ii.node {
+                if let hir::ImplItemKind::Method(ref sig, _) = ii.node {
                     // if the method specifies a visibility, use that, otherwise
                     // inherit the visibility from the impl (so `foo` in `pub impl
                     // { fn foo(); }` is public, but private in `impl { fn
@@ -889,7 +889,7 @@ fn convert_item(ccx: &CrateCtxt, it: &hir::Item) {
                             &ty_predicates);
 
             for impl_item in impl_items {
-                if let hir::ImplItem_::Method(ref sig, ref body) = impl_item.node {
+                if let hir::ImplItemKind::Method(ref sig, ref body) = impl_item.node {
                     let body_id = body.id;
                     check_method_self_type(ccx,
                                            &BindingRscope::new(),

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1271,16 +1271,16 @@ impl Clean<Item> for hir::TraitItem {
 impl Clean<Item> for hir::ImplItem {
     fn clean(&self, cx: &DocContext) -> Item {
         let inner = match self.node {
-            hir::ConstImplItem(ref ty, ref expr) => {
+            hir::ImplItem_::Const(ref ty, ref expr) => {
                 ConstantItem(Constant{
                     type_: ty.clean(cx),
                     expr: expr.span.to_src(cx),
                 })
             }
-            hir::MethodImplItem(ref sig, _) => {
+            hir::ImplItem_::Method(ref sig, _) => {
                 MethodItem(sig.clean(cx))
             }
-            hir::TypeImplItem(ref ty) => TypedefItem(Typedef {
+            hir::ImplItem_::Type(ref ty) => TypedefItem(Typedef {
                 type_: ty.clean(cx),
                 generics: Generics {
                     lifetimes: Vec::new(),

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1271,16 +1271,16 @@ impl Clean<Item> for hir::TraitItem {
 impl Clean<Item> for hir::ImplItem {
     fn clean(&self, cx: &DocContext) -> Item {
         let inner = match self.node {
-            hir::ImplItem_::Const(ref ty, ref expr) => {
+            hir::ImplItemKind::Const(ref ty, ref expr) => {
                 ConstantItem(Constant{
                     type_: ty.clean(cx),
                     expr: expr.span.to_src(cx),
                 })
             }
-            hir::ImplItem_::Method(ref sig, _) => {
+            hir::ImplItemKind::Method(ref sig, _) => {
                 MethodItem(sig.clean(cx))
             }
-            hir::ImplItem_::Type(ref ty) => TypedefItem(Typedef {
+            hir::ImplItemKind::Type(ref ty) => TypedefItem(Typedef {
                 type_: ty.clean(cx),
                 generics: Generics {
                     lifetimes: Vec::new(),

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -20,7 +20,6 @@ pub use self::Expr_::*;
 pub use self::FloatTy::*;
 pub use self::FunctionRetTy::*;
 pub use self::ForeignItem_::*;
-pub use self::ImplItem_::*;
 pub use self::IntTy::*;
 pub use self::Item_::*;
 pub use self::KleeneOp::*;
@@ -1230,16 +1229,16 @@ pub struct ImplItem {
     pub ident: Ident,
     pub vis: Visibility,
     pub attrs: Vec<Attribute>,
-    pub node: ImplItem_,
+    pub node: ImplItemKind,
     pub span: Span,
 }
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
-pub enum ImplItem_ {
-    ConstImplItem(P<Ty>, P<Expr>),
-    MethodImplItem(MethodSig, P<Block>),
-    TypeImplItem(P<Ty>),
-    MacImplItem(Mac),
+pub enum ImplItemKind {
+    Const(P<Ty>, P<Expr>),
+    Method(MethodSig, P<Block>),
+    Type(P<Ty>),
+    Macro(Mac),
 }
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Copy)]

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -480,7 +480,7 @@ impl<'a> TraitDef<'a> {
                 ident: ident,
                 vis: ast::Inherited,
                 attrs: Vec::new(),
-                node: ast::TypeImplItem(type_def.to_ty(cx,
+                node: ast::ImplItemKind::Type(type_def.to_ty(cx,
                     self.span,
                     type_ident,
                     generics
@@ -895,7 +895,7 @@ impl<'a> MethodDef<'a> {
             span: trait_.span,
             vis: ast::Inherited,
             ident: method_ident,
-            node: ast::MethodImplItem(ast::MethodSig {
+            node: ast::ImplItemKind::Method(ast::MethodSig {
                 generics: fn_generics,
                 abi: abi,
                 explicit_self: explicit_self,

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1030,23 +1030,23 @@ fn expand_item_multi_modifier(mut it: Annotatable,
 fn expand_impl_item(ii: P<ast::ImplItem>, fld: &mut MacroExpander)
                  -> SmallVector<P<ast::ImplItem>> {
     match ii.node {
-        ast::MethodImplItem(..) => SmallVector::one(ii.map(|ii| ast::ImplItem {
+        ast::ImplItemKind::Method(..) => SmallVector::one(ii.map(|ii| ast::ImplItem {
             id: ii.id,
             ident: ii.ident,
             attrs: ii.attrs,
             vis: ii.vis,
             node: match ii.node  {
-                ast::MethodImplItem(sig, body) => {
+                ast::ImplItemKind::Method(sig, body) => {
                     let (sig, body) = expand_and_rename_method(sig, body, fld);
-                    ast::MethodImplItem(sig, body)
+                    ast::ImplItemKind::Method(sig, body)
                 }
                 _ => unreachable!()
             },
             span: fld.new_span(ii.span)
         })),
-        ast::MacImplItem(_) => {
+        ast::ImplItemKind::Macro(_) => {
             let (span, mac) = ii.and_then(|ii| match ii.node {
-                ast::MacImplItem(mac) => (ii.span, mac),
+                ast::ImplItemKind::Macro(mac) => (ii.span, mac),
                 _ => unreachable!()
             });
             let maybe_new_items =

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -998,12 +998,12 @@ impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
 
     fn visit_impl_item(&mut self, ii: &'v ast::ImplItem) {
         match ii.node {
-            ast::ConstImplItem(..) => {
+            ast::ImplItemKind::Const(..) => {
                 self.gate_feature("associated_consts",
                                   ii.span,
                                   "associated constants are experimental")
             }
-            ast::MethodImplItem(ref sig, _) => {
+            ast::ImplItemKind::Method(ref sig, _) => {
                 if sig.constness == ast::Constness::Const {
                     self.gate_feature("const_fn", ii.span, "const fn is unstable");
                 }

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -1001,15 +1001,15 @@ pub fn noop_fold_impl_item<T: Folder>(i: P<ImplItem>, folder: &mut T)
         attrs: fold_attrs(attrs, folder),
         vis: vis,
         node: match node  {
-            ConstImplItem(ty, expr) => {
-                ConstImplItem(folder.fold_ty(ty), folder.fold_expr(expr))
+            ast::ImplItemKind::Const(ty, expr) => {
+                ast::ImplItemKind::Const(folder.fold_ty(ty), folder.fold_expr(expr))
             }
-            MethodImplItem(sig, body) => {
-                MethodImplItem(noop_fold_method_sig(sig, folder),
+            ast::ImplItemKind::Method(sig, body) => {
+                ast::ImplItemKind::Method(noop_fold_method_sig(sig, folder),
                                folder.fold_block(body))
             }
-            TypeImplItem(ty) => TypeImplItem(folder.fold_ty(ty)),
-            MacImplItem(mac) => MacImplItem(folder.fold_mac(mac))
+            ast::ImplItemKind::Type(ty) => ast::ImplItemKind::Type(folder.fold_ty(ty)),
+            ast::ImplItemKind::Macro(mac) => ast::ImplItemKind::Macro(folder.fold_mac(mac))
         },
         span: folder.new_span(span)
     }))

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -17,7 +17,7 @@ use ast::{Public, Unsafety};
 use ast::{Mod, BiAdd, Arg, Arm, Attribute, BindByRef, BindByValue};
 use ast::{BiBitAnd, BiBitOr, BiBitXor, BiRem, BiLt, Block};
 use ast::{BlockCheckMode, CaptureByRef, CaptureByValue, CaptureClause};
-use ast::{Constness, ConstImplItem, ConstTraitItem, Crate, CrateConfig};
+use ast::{Constness, ConstTraitItem, Crate, CrateConfig};
 use ast::{Decl, DeclItem, DeclLocal, DefaultBlock, DefaultReturn};
 use ast::{UnDeref, BiDiv, EMPTY_CTXT, EnumDef, ExplicitSelf};
 use ast::{Expr, Expr_, ExprAddrOf, ExprMatch, ExprAgain};
@@ -39,7 +39,7 @@ use ast::{LitStr, LitInt, Local};
 use ast::{MacStmtWithBraces, MacStmtWithSemicolon, MacStmtWithoutBraces};
 use ast::{MutImmutable, MutMutable, Mac_};
 use ast::{MutTy, BiMul, Mutability};
-use ast::{MethodImplItem, NamedField, UnNeg, NoReturn, UnNot};
+use ast::{NamedField, UnNeg, NoReturn, UnNot};
 use ast::{Pat, PatBox, PatEnum, PatIdent, PatLit, PatQPath, PatMac, PatRange};
 use ast::{PatRegion, PatStruct, PatTup, PatVec, PatWild};
 use ast::{PolyTraitRef, QSelf};
@@ -52,7 +52,7 @@ use ast::{Ty, Ty_, TypeBinding, TyMac};
 use ast::{TyFixedLengthVec, TyBareFn, TyTypeof, TyInfer};
 use ast::{TyParam, TyParamBound, TyParen, TyPath, TyPolyTraitRef, TyPtr};
 use ast::{TyRptr, TyTup, TyU32, TyVec};
-use ast::{TypeImplItem, TypeTraitItem};
+use ast::TypeTraitItem;
 use ast::{UnnamedField, UnsafeBlock};
 use ast::{ViewPath, ViewPathGlob, ViewPathList, ViewPathSimple};
 use ast::{Visibility, WhereClause};
@@ -4425,7 +4425,7 @@ impl<'a> Parser<'a> {
             try!(self.expect(&token::Eq));
             let typ = try!(self.parse_ty_sum());
             try!(self.expect(&token::Semi));
-            (name, TypeImplItem(typ))
+            (name, ast::ImplItemKind::Type(typ))
         } else if self.is_const_item() {
             try!(self.expect_keyword(keywords::Const));
             let name = try!(self.parse_ident());
@@ -4434,7 +4434,7 @@ impl<'a> Parser<'a> {
             try!(self.expect(&token::Eq));
             let expr = try!(self.parse_expr());
             try!(self.commit_expr_expecting(&expr, token::Semi));
-            (name, ConstImplItem(typ, expr))
+            (name, ast::ImplItemKind::Const(typ, expr))
         } else {
             let (name, inner_attrs, node) = try!(self.parse_impl_method(vis));
             attrs.extend(inner_attrs);
@@ -4464,7 +4464,7 @@ impl<'a> Parser<'a> {
 
     /// Parse a method or a macro invocation in a trait impl.
     fn parse_impl_method(&mut self, vis: Visibility)
-                         -> PResult<(Ident, Vec<ast::Attribute>, ast::ImplItem_)> {
+                         -> PResult<(Ident, Vec<ast::Attribute>, ast::ImplItemKind)> {
         // code copied from parse_macro_use_or_failure... abstraction!
         if !self.token.is_any_keyword()
             && self.look_ahead(1, |t| *t == token::Not)
@@ -4490,7 +4490,7 @@ impl<'a> Parser<'a> {
             if delim != token::Brace {
                 try!(self.expect(&token::Semi))
             }
-            Ok((token::special_idents::invalid, vec![], ast::MacImplItem(m)))
+            Ok((token::special_idents::invalid, vec![], ast::ImplItemKind::Macro(m)))
         } else {
             let (constness, unsafety, abi) = try!(self.parse_fn_front_matter());
             let ident = try!(self.parse_ident());
@@ -4500,7 +4500,7 @@ impl<'a> Parser<'a> {
                 }));
             generics.where_clause = try!(self.parse_where_clause());
             let (inner_attrs, body) = try!(self.parse_inner_attrs_and_block());
-            Ok((ident, inner_attrs, MethodImplItem(ast::MethodSig {
+            Ok((ident, inner_attrs, ast::ImplItemKind::Method(ast::MethodSig {
                 generics: generics,
                 abi: abi,
                 explicit_self: explicit_self,

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1576,19 +1576,19 @@ impl<'a> State<'a> {
         try!(self.maybe_print_comment(ii.span.lo));
         try!(self.print_outer_attributes(&ii.attrs));
         match ii.node {
-            ast::ConstImplItem(ref ty, ref expr) => {
+            ast::ImplItemKind::Const(ref ty, ref expr) => {
                 try!(self.print_associated_const(ii.ident, &ty, Some(&expr), ii.vis));
             }
-            ast::MethodImplItem(ref sig, ref body) => {
+            ast::ImplItemKind::Method(ref sig, ref body) => {
                 try!(self.head(""));
                 try!(self.print_method_sig(ii.ident, sig, ii.vis));
                 try!(self.nbsp());
                 try!(self.print_block_with_attrs(body, &ii.attrs));
             }
-            ast::TypeImplItem(ref ty) => {
+            ast::ImplItemKind::Type(ref ty) => {
                 try!(self.print_associated_type(ii.ident, None, Some(ty)));
             }
-            ast::MacImplItem(codemap::Spanned { ref node, .. }) => {
+            ast::ImplItemKind::Macro(codemap::Spanned { ref node, .. }) => {
                 // code copied from ItemMac:
                 try!(self.print_path(&node.path, false, 0));
                 try!(word(&mut self.s, "! "));

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -588,18 +588,18 @@ pub fn walk_impl_item<'v, V: Visitor<'v>>(visitor: &mut V, impl_item: &'v ImplIt
     visitor.visit_ident(impl_item.span, impl_item.ident);
     walk_list!(visitor, visit_attribute, &impl_item.attrs);
     match impl_item.node {
-        ConstImplItem(ref ty, ref expr) => {
+        ImplItemKind::Const(ref ty, ref expr) => {
             visitor.visit_ty(ty);
             visitor.visit_expr(expr);
         }
-        MethodImplItem(ref sig, ref body) => {
+        ImplItemKind::Method(ref sig, ref body) => {
             visitor.visit_fn(FnKind::Method(impl_item.ident, sig, Some(impl_item.vis)), &sig.decl,
                              body, impl_item.span, impl_item.id);
         }
-        TypeImplItem(ref ty) => {
+        ImplItemKind::Type(ref ty) => {
             visitor.visit_ty(ty);
         }
-        MacImplItem(ref mac) => {
+        ImplItemKind::Macro(ref mac) => {
             visitor.visit_mac(mac);
         }
     }


### PR DESCRIPTION
[breaking change]

I'm not sure if those renames are ok. [TokenType::Tt\* to TokenType::*](https://github.com/rust-lang/rust/pull/29582) was obvious, but for all those Item-enums it's less obvious to me what the right way forward is due to the underscore.
