### PR TITLE
Allow none Sized types in assert_eq!

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -89,7 +89,7 @@ macro_rules! assert_eq {
             (left_val, right_val) => {
                 if !(*left_val == *right_val) {
                     panic!("assertion failed: `(left == right)` \
-                           (left: `{:?}`, right: `{:?}`)", *left_val, *right_val)
+                           (left: `{:?}`, right: `{:?}`)", left_val, right_val)
                 }
             }
         }

--- a/src/test/run-pass/assert-eq-macro-unsized.rs
+++ b/src/test/run-pass/assert-eq-macro-unsized.rs
@@ -1,0 +1,13 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {
+    assert_eq!([1, 2, 3][..], vec![1, 2, 3][..]);
+}


### PR DESCRIPTION
`format_args!` doesn't support none Sized types so we should just pass it the references to `left_val` and `right_val`.

The following works:

``` rust
assert!([1, 2, 3][..] == vec![1, 2, 3][..])
```

So I would expect this to as well:

``` rust
assert_eq!([1, 2, 3][..], vec![1, 2, 3][..])
```

But it fails with "error: the trait `core::marker::Sized` is not implemented for the type `[_]` [E0277]"
I don't know if this change will have any nasty side effects I don't understand.
