### PR TITLE
libsyntax: Add more quasiquoting macros

### DIFF
--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -512,6 +512,18 @@ fn initial_syntax_expander_table<'feat>(ecfg: &expand::ExpansionConfig<'feat>)
         syntax_expanders.insert(intern("quote_attr"),
                            builtin_normal_expander(
                                 ext::quote::expand_quote_attr));
+        syntax_expanders.insert(intern("quote_arg"),
+                           builtin_normal_expander(
+                                ext::quote::expand_quote_arg));
+        syntax_expanders.insert(intern("quote_block"),
+                           builtin_normal_expander(
+                                ext::quote::expand_quote_block));
+        syntax_expanders.insert(intern("quote_meta_item"),
+                           builtin_normal_expander(
+                                ext::quote::expand_quote_meta_item));
+        syntax_expanders.insert(intern("quote_path"),
+                           builtin_normal_expander(
+                                ext::quote::expand_quote_path));
     }
 
     syntax_expanders.insert(intern("line"),

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -684,6 +684,7 @@ pub fn noop_fold_interpolated<T: Folder>(nt: token::Nonterminal, fld: &mut T)
         token::NtGenerics(generics) => token::NtGenerics(fld.fold_generics(generics)),
         token::NtWhereClause(where_clause) =>
             token::NtWhereClause(fld.fold_where_clause(where_clause)),
+        token::NtArg(arg) => token::NtArg(fld.fold_arg(arg)),
     }
 }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -393,6 +393,22 @@ impl<'a> Parser<'a> {
         panictry!(self.parse_attribute(permit_inner))
     }
 
+    pub fn parse_arg_panic(&mut self) -> Arg {
+        panictry!(self.parse_arg())
+    }
+
+    pub fn parse_block_panic(&mut self) -> P<Block> {
+        panictry!(self.parse_block())
+    }
+
+    pub fn parse_meta_item_panic(&mut self) -> P<ast::MetaItem> {
+        panictry!(self.parse_meta_item())
+    }
+
+    pub fn parse_path_panic(&mut self, mode: PathParsingMode) -> ast::Path {
+        panictry!(self.parse_path(mode))
+    }
+
     /// Convert a token to a string using self's reader
     pub fn token_to_string(token: &token::Token) -> String {
         pprust::token_to_string(token)
@@ -1455,6 +1471,8 @@ impl<'a> Parser<'a> {
     /// This version of parse arg doesn't necessarily require
     /// identifier names.
     pub fn parse_arg_general(&mut self, require_name: bool) -> PResult<Arg> {
+        maybe_whole!(no_clone self, NtArg);
+
         let pat = if require_name || self.is_named_argument() {
             debug!("parse_arg_general parse_pat (require_name:{})",
                    require_name);

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -381,12 +381,13 @@ pub enum Nonterminal {
     NtMeta(P<ast::MetaItem>),
     NtPath(Box<ast::Path>),
     NtTT(P<ast::TokenTree>), // needs P'ed to break a circularity
-    // These is not exposed to macros, but is used by quasiquote.
+    // These are not exposed to macros, but are used by quasiquote.
     NtArm(ast::Arm),
     NtImplItem(P<ast::ImplItem>),
     NtTraitItem(P<ast::TraitItem>),
     NtGenerics(ast::Generics),
     NtWhereClause(ast::WhereClause),
+    NtArg(ast::Arg),
 }
 
 impl fmt::Debug for Nonterminal {
@@ -407,6 +408,7 @@ impl fmt::Debug for Nonterminal {
             NtTraitItem(..) => f.pad("NtTraitItem(..)"),
             NtGenerics(..) => f.pad("NtGenerics(..)"),
             NtWhereClause(..) => f.pad("NtWhereClause(..)"),
+            NtArg(..) => f.pad("NtArg(..)"),
         }
     }
 }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -305,6 +305,7 @@ pub fn token_to_string(tok: &Token) -> String {
             token::NtTraitItem(ref e)   => trait_item_to_string(&**e),
             token::NtGenerics(ref e)    => generics_to_string(&*e),
             token::NtWhereClause(ref e) => where_clause_to_string(&*e),
+            token::NtArg(ref e)         => arg_to_string(&*e),
         }
     }
 }

--- a/src/test/compile-fail-fulldeps/gated-quote.rs
+++ b/src/test/compile-fail-fulldeps/gated-quote.rs
@@ -37,14 +37,18 @@ impl ParseSess {
 
 pub fn main() {
     let ecx = &ParseSess;
-    let x = quote_tokens!(ecx, 3);   //~ ERROR macro undefined: 'quote_tokens!'
-    let x = quote_expr!(ecx, 3);     //~ ERROR macro undefined: 'quote_expr!'
-    let x = quote_ty!(ecx, 3);       //~ ERROR macro undefined: 'quote_ty!'
-    let x = quote_method!(ecx, 3);   //~ ERROR macro undefined: 'quote_method!'
-    let x = quote_item!(ecx, 3);     //~ ERROR macro undefined: 'quote_item!'
-    let x = quote_pat!(ecx, 3);      //~ ERROR macro undefined: 'quote_pat!'
-    let x = quote_arm!(ecx, 3);      //~ ERROR macro undefined: 'quote_arm!'
-    let x = quote_stmt!(ecx, 3);     //~ ERROR macro undefined: 'quote_stmt!'
-    let x = quote_matcher!(ecx, 3);  //~ ERROR macro undefined: 'quote_matcher!'
-    let x = quote_attr!(ecx, 3);     //~ ERROR macro undefined: 'quote_attr!'
+    let x = quote_tokens!(ecx, 3);    //~ ERROR macro undefined: 'quote_tokens!'
+    let x = quote_expr!(ecx, 3);      //~ ERROR macro undefined: 'quote_expr!'
+    let x = quote_ty!(ecx, 3);        //~ ERROR macro undefined: 'quote_ty!'
+    let x = quote_method!(ecx, 3);    //~ ERROR macro undefined: 'quote_method!'
+    let x = quote_item!(ecx, 3);      //~ ERROR macro undefined: 'quote_item!'
+    let x = quote_pat!(ecx, 3);       //~ ERROR macro undefined: 'quote_pat!'
+    let x = quote_arm!(ecx, 3);       //~ ERROR macro undefined: 'quote_arm!'
+    let x = quote_stmt!(ecx, 3);      //~ ERROR macro undefined: 'quote_stmt!'
+    let x = quote_matcher!(ecx, 3);   //~ ERROR macro undefined: 'quote_matcher!'
+    let x = quote_attr!(ecx, 3);      //~ ERROR macro undefined: 'quote_attr!'
+    let x = quote_arg!(ecx, 3);       //~ ERROR macro undefined: 'quote_arg!'
+    let x = quote_block!(ecx, 3);     //~ ERROR macro undefined: 'quote_block!'
+    let x = quote_meta_item!(ecx, 3); //~ ERROR macro undefined: 'quote_meta_item!'
+    let x = quote_path!(ecx, 3);      //~ ERROR macro undefined: 'quote_path!'
 }

--- a/src/test/run-pass-fulldeps/qquote.rs
+++ b/src/test/run-pass-fulldeps/qquote.rs
@@ -63,4 +63,41 @@ fn main() {
 
     let attr = quote_attr!(cx, #![cfg(foo = "bar")]);
     check!(attribute_to_string, attr, quote_attr!(cx, $attr); r#"#![cfg(foo = "bar")]"#);
+
+    // quote_arg!
+
+    let arg = quote_arg!(cx, foo: i32);
+    check!(arg_to_string, arg, quote_arg!(cx, $arg); "foo: i32");
+
+    let function = quote_item!(cx, fn f($arg) { }).unwrap();
+    check!(item_to_string, function; "fn f(foo: i32) { }");
+
+    let args = vec![arg, quote_arg!(cx, bar: u32)];
+    let args = &args[..];
+    let function = quote_item!(cx, fn f($args) { }).unwrap();
+    check!(item_to_string, function; "fn f(foo: i32, bar: u32) { }");
+
+    // quote_block!
+
+    let block = quote_block!(cx, { $stmt let y = 40u32; });
+    check!(block_to_string, block, *quote_block!(cx, $block); "{ let x = 20u16; let y = 40u32; }");
+
+    let function = quote_item!(cx, fn f() $block).unwrap();
+    check!(item_to_string, function; "fn f() { let x = 20u16; let y = 40u32; }");
+
+    // quote_path!
+
+    let path = quote_path!(cx, ::syntax::ptr::P<MetaItem>);
+    check!(path_to_string, path, quote_path!(cx, $path); "::syntax::ptr::P<MetaItem>");
+
+    let ty = quote_ty!(cx, $path);
+    check!(ty_to_string, ty; "::syntax::ptr::P<MetaItem>");
+
+    // quote_meta_item!
+
+    let meta = quote_meta_item!(cx, cfg(foo = "bar"));
+    check!(meta_item_to_string, meta, *quote_meta_item!(cx, $meta); r#"cfg(foo = "bar")"#);
+
+    let attr = quote_attr!(cx, #![$meta]);
+    check!(attribute_to_string, attr; r#"#![cfg(foo = "bar")]"#);
 }


### PR DESCRIPTION
This is my first code contribution to Rust, so I'm sure there are some issues with the changes I've made.

I've added the `quote_arg!`, `quote_block!`, `quote_path!`, and `quote_meta_item!` quasiquoting macros. From my experience trying to build AST in compiler plugins, I would like to be able to build any AST piece with a quasiquoting macro (e.g., `quote_struct_field!` or `quote_variant!`) and then use those AST pieces in other quasiquoting macros, but this pull request just adds some of the low-hanging fruit.

I'm not sure if these additions are desirable, and I'm sure these macros can be implemented in an external crate if not.
