### PR TITLE
Fix article in Result.map and Result.map_err documentation

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -456,7 +456,7 @@ impl<T, E> Result<T, E> {
     // Transforming contained values
     /////////////////////////////////////////////////////////////////////////
 
-    /// Maps a `Result<T, E>` to `Result<U, E>` by applying a function to an
+    /// Maps a `Result<T, E>` to `Result<U, E>` by applying a function to a
     /// contained `Ok` value, leaving an `Err` value untouched.
     ///
     /// This function can be used to compose the results of two functions.
@@ -484,7 +484,7 @@ impl<T, E> Result<T, E> {
         }
     }
 
-    /// Maps a `Result<T, E>` to `Result<T, F>` by applying a function to an
+    /// Maps a `Result<T, E>` to `Result<T, F>` by applying a function to a
     /// contained `Err` value, leaving an `Ok` value untouched.
     ///
     /// This function can be used to pass through a successful result while handling


### PR DESCRIPTION
Fix usage of wrong article in `Result` docs.

This is my first rust PR, if something about the process is wrong let me know.

As this is a documentation change, I believe the correct highfive line to use is the following:

r? @steveklabnik
