### PR TITLE
Store a valid name for the root module in metadata

### DIFF
--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1500,7 +1500,7 @@ fn encode_info_for_items<'a, 'tcx>(ecx: &EncodeContext<'a, 'tcx>,
                         &[],
                         CRATE_NODE_ID,
                         [].iter().cloned().chain(LinkedPath::empty()),
-                        syntax::parse::token::special_idents::invalid.name,
+                        syntax::parse::token::intern(&ecx.link_meta.crate_name),
                         hir::Public);
 
     visit::walk_crate(&mut EncodeVisitor {

--- a/src/test/auxiliary/issue-28927-1.rs
+++ b/src/test/auxiliary/issue-28927-1.rs
@@ -1,0 +1,12 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate issue_28927_2 as inner2;
+pub use inner2 as bar;

--- a/src/test/auxiliary/issue-28927-2.rs
+++ b/src/test/auxiliary/issue-28927-2.rs
@@ -1,0 +1,11 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub struct Baz;

--- a/src/test/rustdoc/issue-28927.rs
+++ b/src/test/rustdoc/issue-28927.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-28927-2.rs
+// aux-build:issue-28927-1.rs
+// ignore-cross-compile
+
+extern crate issue_28927_1 as inner1;
+pub use inner1 as foo;


### PR DESCRIPTION
f357d55 caused a regression by retrieving item names from metadata, while previously using the last element of its absolute path (which in the case of a root module is the prefixed crate name since the stored path in metadata is empty)

fixes #28927
