### PR TITLE
openbsd: pass stdc++ library path after LVVM library path

### DIFF
--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -214,9 +214,11 @@ define CFG_MAKE_TOOLCHAIN
   # On OpenBSD, we need to pass the path of libstdc++.so to the linker
   # (use path of libstdc++.a which is a known name for the same path)
   ifeq ($(OSTYPE_$(1)),unknown-openbsd)
-    RUSTC_FLAGS_$(1)=-L "$$(dir $$(shell $$(CC_$(1)) $$(CFG_GCCISH_CFLAGS_$(1)) \
-        -print-file-name=lib$(CFG_STDCPP_NAME).a))" \
-        $(RUSTC_FLAGS_$(1))
+    STDCPP_LIBDIR_RUSTFLAGS_$(1)= \
+        -L "$$(dir $$(shell $$(CC_$(1)) $$(CFG_GCCISH_CFLAGS_$(1)) \
+        -print-file-name=lib$(CFG_STDCPP_NAME).a))"
+  else
+    STDCPP_LIBDIR_RUSTFLAGS_$(1)=
   endif
 
   # On Bitrig, we need the relocation model to be PIC for everything

--- a/mk/target.mk
+++ b/mk/target.mk
@@ -95,6 +95,7 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$(4): \
 		$$(RUSTFLAGS_$(4)) \
 		$$(RUSTFLAGS$(1)_$(4)) \
 		$$(RUSTFLAGS$(1)_$(4)_T_$(2)) \
+		$$(STDCPP_LIBDIR_RUSTFLAGS_$(2)) \
 		--out-dir $$(@D) \
 		-C extra-filename=-$$(CFG_FILENAME_EXTRA) \
 		$$<
@@ -128,7 +129,9 @@ $$(TBIN$(1)_T_$(2)_H_$(3))/$(4)$$(X_$(2)): \
 		$$(TSREQ$(1)_T_$(2)_H_$(3)) \
 		| $$(TBIN$(1)_T_$(2)_H_$(3))/
 	@$$(call E, rustc: $$@)
-	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< --cfg $(4)
+	$$(STAGE$(1)_T_$(2)_H_$(3)) \
+		$$(STDCPP_LIBDIR_RUSTFLAGS_$(2)) \
+		-o $$@ $$< --cfg $(4)
 
 endef
 

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -392,7 +392,8 @@ $(3)/stage$(1)/test/$(4)test-$(2)$$(X_$(2)): \
 	    $$(subst @,,$$(STAGE$(1)_T_$(2)_H_$(3))) -o $$@ $$< --test \
 		-L "$$(RT_OUTPUT_DIR_$(2))" \
 		$$(LLVM_LIBDIR_RUSTFLAGS_$(2)) \
-		$$(RUSTFLAGS_$(4))
+		$$(RUSTFLAGS_$(4)) \
+		$$(STDCPP_LIBDIR_RUSTFLAGS_$(2))
 
 endef
 
@@ -662,9 +663,9 @@ CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3) := \
         --android-cross-path=$(CFG_ANDROID_CROSS_PATH) \
         --adb-path=$(CFG_ADB) \
         --adb-test-dir=$(CFG_ADB_TEST_DIR) \
-        --host-rustcflags "$(RUSTC_FLAGS_$(3)) $$(CTEST_RUSTC_FLAGS) -L $$(RT_OUTPUT_DIR_$(3))" \
+        --host-rustcflags "$(RUSTC_FLAGS_$(3)) $$(CTEST_RUSTC_FLAGS) -L $$(RT_OUTPUT_DIR_$(3)) $$(STDCPP_LIBDIR_RUSTFLAGS_$(3))" \
         --lldb-python-dir=$(CFG_LLDB_PYTHON_DIR) \
-        --target-rustcflags "$(RUSTC_FLAGS_$(2)) $$(CTEST_RUSTC_FLAGS) -L $$(RT_OUTPUT_DIR_$(2))" \
+        --target-rustcflags "$(RUSTC_FLAGS_$(2)) $$(CTEST_RUSTC_FLAGS) -L $$(RT_OUTPUT_DIR_$(2)) $$(STDCPP_LIBDIR_RUSTFLAGS_$(2))" \
         $$(CTEST_TESTARGS)
 
 ifdef CFG_VALGRIND_RPASS


### PR DESCRIPTION
under openbsd, the library path of libstdc++ need to be explicit (due
to the fact the default linker `cc` is gcc-4.2, and not gcc-4.9).

but when a recent LLVM is installed, rustc compilation pikes the bad
LLVM version (which live in /usr/local/lib, which is same directory of
libestdc++.so for gcc-4.9).

this patch move the libstdc++ path from RUST_FLAGS_<target> to special
variable, and use it _after_ LLVM_LIBDIR_RUSTFLAGS_<target> in
arguments.

r? @alexcrichton
