### PR TITLE
Improve the detailed error message for E0432

### DIFF
--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -806,6 +806,15 @@ mod something {
     pub struct Foo;
 }
 ```
+
+Or, if you tried to use a module from an external crate, you may have missed
+the `extern crate` declaration:
+
+```
+extern crate homura; // Required to use the `homura` crate
+
+use homura::Madoka;
+```
 "##,
 
 E0433: r##"


### PR DESCRIPTION
The command-line error message for E0432 does mention the possibility of missing the `extern crate` declaration, but the detailed error message for it doesn't.

Fixes #29517.
