### PR TITLE
Add feature gate test for #[fundamental] attribute

### DIFF
--- a/src/test/compile-fail/feature-gate-fundamental.rs
+++ b/src/test/compile-fail/feature-gate-fundamental.rs
@@ -1,0 +1,14 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[fundamental] //~ ERROR the `#[fundamental]` attribute is an experimental feature
+struct Fundamental;
+
+fn main() { }


### PR DESCRIPTION
Fundamental attribute was missing a feature gate test.
