### PR TITLE
Fix example for the Debug trait so it matches the given output

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -328,7 +328,7 @@ impl<'a> Display for Arguments<'a> {
 ///
 /// impl fmt::Debug for Point {
 ///     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-///         write!(f, "({}, {})", self.x, self.y)
+///         write!(f, "Point {{ x: {}, y: {} }}", self.x, self.y)
 ///     }
 /// }
 ///


### PR DESCRIPTION
The example given for the manual implementation of the core::fmt::Debug trait doesn't match the output after the code sample. This updates it so it matches.
