### PR TITLE
simplify HIR folder so that it only maps 1 item to 1 item

### DIFF
--- a/src/librustc/front/map/mod.rs
+++ b/src/librustc/front/map/mod.rs
@@ -847,14 +847,14 @@ pub fn map_decoded_item<'ast, F: FoldOps>(map: &Map<'ast>,
                                           -> &'ast InlinedItem {
     let mut fld = IdAndSpanUpdater { fold_ops: fold_ops };
     let ii = match ii {
-        II::Item(i) => II::Item(fld.fold_item(i).expect_one("expected one item")),
+        II::Item(i) => II::Item(fld.fold_item(i)),
         II::TraitItem(d, ti) => {
             II::TraitItem(fld.fold_ops.new_def_id(d),
-                        fld.fold_trait_item(ti).expect_one("expected one trait item"))
+                          fld.fold_trait_item(ti))
         }
         II::ImplItem(d, ii) => {
             II::ImplItem(fld.fold_ops.new_def_id(d),
-                       fld.fold_impl_item(ii).expect_one("expected one impl item"))
+                         fld.fold_impl_item(ii))
         }
         II::Foreign(i) => II::Foreign(fld.fold_foreign_item(i))
     };

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -389,20 +389,13 @@ fn simplify_ast(ii: InlinedItemRef) -> InlinedItem {
     match ii {
         // HACK we're not dropping items.
         InlinedItemRef::Item(i) => {
-            InlinedItem::Item(fold::noop_fold_item(P(i.clone()), &mut fld)
-                            .expect_one("expected one item"))
+            InlinedItem::Item(fold::noop_fold_item(P(i.clone()), &mut fld))
         }
         InlinedItemRef::TraitItem(d, ti) => {
-            InlinedItem::TraitItem(d,
-                fold::noop_fold_trait_item(P(ti.clone()), &mut fld)
-                    .expect_one("noop_fold_trait_item must produce \
-                                 exactly one trait item"))
+            InlinedItem::TraitItem(d, fold::noop_fold_trait_item(P(ti.clone()), &mut fld))
         }
         InlinedItemRef::ImplItem(d, ii) => {
-            InlinedItem::ImplItem(d,
-                fold::noop_fold_impl_item(P(ii.clone()), &mut fld)
-                    .expect_one("noop_fold_impl_item must produce \
-                                 exactly one impl item"))
+            InlinedItem::ImplItem(d, fold::noop_fold_impl_item(P(ii.clone()), &mut fld))
         }
         InlinedItemRef::Foreign(i) => {
             InlinedItem::Foreign(fold::noop_fold_foreign_item(P(i.clone()), &mut fld))


### PR DESCRIPTION
Simplify HIR folder so that it only maps 1 item to 1 item, removing a bunch of asserts. This is a small refactoring on the way to my larger branch for moving items out of line in the tree and isolating attempts to access them.

r? @nrc 
