### PR TITLE
MIR: Support closure up-vars in LvalueTy::projection_ty()

### DIFF
--- a/src/librustc_mir/tcx/mod.rs
+++ b/src/librustc_mir/tcx/mod.rs
@@ -78,6 +78,8 @@ impl<'tcx> LvalueTy<'tcx> {
                             adt_def.struct_variant().fields[field.index()].ty(tcx, substs),
                         ty::TyTuple(ref tys) =>
                             tys[field.index()],
+                        ty::TyClosure(_, ref closure_substs) =>
+                            closure_substs.upvar_tys[field.index()],
                         _ =>
                             tcx.sess.bug(&format!("cannot get field of type: `{:?}`", ty)),
                     },


### PR DESCRIPTION
Add a missing case in LvalueTy::projection_ty() that popped up earlier today.

cc @rust-lang/compiler @nikomatsakis 
