### PR TITLE
Document block doc comments better

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -99,13 +99,12 @@ Comments in Rust code follow the general C++ style of line (`//`) and
 block (`/* ... */`) comment forms. Nested block comments are supported.
 
 Line comments beginning with exactly _three_ slashes (`///`), and block
-comments beginning with exactly one repeated asterisk in the block-open
-sequence (`/**`), are interpreted as a special syntax for `doc`
+comments (`/** ... */`), are interpreted as a special syntax for `doc`
 [attributes](#attributes). That is, they are equivalent to writing
 `#[doc="..."]` around the body of the comment, i.e., `/// Foo` turns into
 `#[doc="Foo"]`.
 
-Line comments beginning with `//!` and block comments beginning with `/*!` are
+Line comments beginning with `//!` and block comments `/*! ... !*/` are
 doc comments that apply to the parent of the comment, rather than the item
 that follows.  That is, they are equivalent to writing `#![doc="..."]` around
 the body of the comment. `//!` comments are usually used to document


### PR DESCRIPTION
These really aren't documented well at all. The fact that doc comments end on a `*/` is really weird. I'm not sure if this is a mistake or not though.

None of the block comments are even mentioned in the [book nightly](http://doc.rust-lang.org/nightly/book/comments.html). Probably should be fixed.
