### PR TITLE
Minor makefile fixes

### DIFF
--- a/mk/llvm.mk
+++ b/mk/llvm.mk
@@ -64,10 +64,10 @@ $$(LLVM_AR_$(1)): $$(LLVM_CONFIG_$(1))
 # when we changed something not otherwise captured by builtin
 # dependencies. In these cases, commit a change that touches
 # the stamp in the source dir.
-$$(LLVM_STAMP_$(1)): $(S)src/rustllvm/llvm-auto-clean-trigger
+$$(LLVM_STAMP_$(1)): $$(S)src/rustllvm/llvm-auto-clean-trigger
 	@$$(call E, make: cleaning llvm)
-	$(Q)touch $$@.start_time
-	$(Q)$(MAKE) clean-llvm$(1)
+	$$(Q)touch $$@.start_time
+	$$(Q)$$(MAKE) clean-llvm$(1)
 	@$$(call E, make: done cleaning llvm)
 	touch -r $$@.start_time $$@ && rm $$@.start_time
 

--- a/mk/snap.mk
+++ b/mk/snap.mk
@@ -18,8 +18,8 @@ snap-stage$(1)-H-$(2): $$(HSREQ$(1)_H_$(2))
 endef
 
 $(foreach host,$(CFG_HOST), \
- $(eval $(foreach stage,1 2 3, \
-  $(eval $(call DEF_SNAP_FOR_STAGE_H,$(stage),$(host))))))
+ $(foreach stage,1 2 3, \
+  $(eval $(call DEF_SNAP_FOR_STAGE_H,$(stage),$(host)))))
 
 snap-stage1: snap-stage1-H-$(CFG_BUILD)
 

--- a/mk/target.mk
+++ b/mk/target.mk
@@ -204,5 +204,5 @@ $(foreach host,$(CFG_HOST), \
 $(foreach host,$(CFG_HOST), \
  $(foreach target,$(CFG_TARGET), \
   $(foreach stage,$(STAGES), \
-  	$(foreach obj,rsbegin rsend, \
-   	  $(eval $(call TARGET_RUSTRT_STARTUP_OBJ,$(stage),$(target),$(host),$(obj)))))))
+   $(foreach obj,rsbegin rsend, \
+    $(eval $(call TARGET_RUSTRT_STARTUP_OBJ,$(stage),$(target),$(host),$(obj)))))))


### PR DESCRIPTION
The first commit fixes the "jobserver unavailable" warning reported at gentoo/gentoo-rust#29.  I don't think the warning is related to the compilation failure shown there.

The remaining commits are minor fixes I noticed while investigating the jobserver warning.
