### PR TITLE
Changes to data produced by privacy pass

### DIFF
--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -17,19 +17,53 @@ pub use self::ImportUse::*;
 pub use self::LastPrivate::*;
 
 use middle::def_id::DefId;
-use util::nodemap::{DefIdSet, NodeSet};
+use util::nodemap::{DefIdSet, FnvHashMap};
 
-/// A set of AST nodes exported by the crate.
-pub type ExportedItems = NodeSet;
+use std::hash::Hash;
+use syntax::ast::NodeId;
+
+// Accessibility levels, sorted in ascending order
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AccessLevel {
+    // Exported items + items participating in various kinds of public interfaces,
+    // but not directly nameable. For example, if function `fn f() -> T {...}` is
+    // public, then type `T` is exported. Its values can be obtained by other crates
+    // even if the type itseld is not nameable.
+    // FIXME: Mostly unimplemented. Only `type` aliases export items currently.
+    Reachable,
+    // Public items + items accessible to other crates with help of `pub use` reexports
+    Exported,
+    // Items accessible to other crates directly, without help of reexports
+    Public,
+}
+
+// Accessibility levels for reachable HIR nodes
+#[derive(Clone)]
+pub struct AccessLevels<Id = NodeId> {
+    pub map: FnvHashMap<Id, AccessLevel>
+}
+
+impl<Id: Hash + Eq> AccessLevels<Id> {
+    pub fn is_reachable(&self, id: Id) -> bool {
+        self.map.contains_key(&id)
+    }
+    pub fn is_exported(&self, id: Id) -> bool {
+        self.map.get(&id) >= Some(&AccessLevel::Exported)
+    }
+    pub fn is_public(&self, id: Id) -> bool {
+        self.map.get(&id) >= Some(&AccessLevel::Public)
+    }
+}
+
+impl<Id: Hash + Eq> Default for AccessLevels<Id> {
+    fn default() -> Self {
+        AccessLevels { map: Default::default() }
+    }
+}
 
 /// A set containing all exported definitions from external crates.
 /// The set does not contain any entries from local crates.
 pub type ExternalExports = DefIdSet;
-
-/// A set of AST nodes that are fully public in the crate. This map is used for
-/// documentation purposes (reexporting a private struct inlines the doc,
-/// reexporting a public struct doesn't inline the doc).
-pub type PublicItems = NodeSet;
 
 #[derive(Copy, Clone, Debug)]
 pub enum LastPrivate {

--- a/src/librustc/middle/ty/mod.rs
+++ b/src/librustc/middle/ty/mod.rs
@@ -104,13 +104,11 @@ pub const INITIAL_DISCRIMINANT_VALUE: Disr = 0;
 /// produced by the driver and fed to trans and later passes.
 pub struct CrateAnalysis<'a> {
     pub export_map: ExportMap,
-    pub exported_items: middle::privacy::ExportedItems,
-    pub public_items: middle::privacy::PublicItems,
+    pub access_levels: middle::privacy::AccessLevels,
     pub reachable: NodeSet,
     pub name: &'a str,
     pub glob_map: Option<GlobMap>,
 }
-
 
 #[derive(Copy, Clone)]
 pub enum DtorKind {

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -301,8 +301,8 @@ impl MissingDoc {
         // Only check publicly-visible items, using the result from the privacy pass.
         // It's an option so the crate root can also use this function (it doesn't
         // have a NodeId).
-        if let Some(ref id) = id {
-            if !cx.exported_items.contains(id) {
+        if let Some(id) = id {
+            if !cx.access_levels.is_exported(id) {
                 return;
             }
         }
@@ -470,7 +470,7 @@ impl LintPass for MissingCopyImplementations {
 
 impl LateLintPass for MissingCopyImplementations {
     fn check_item(&mut self, cx: &LateContext, item: &hir::Item) {
-        if !cx.exported_items.contains(&item.id) {
+        if !cx.access_levels.is_reachable(item.id) {
             return;
         }
         let (def, ty) = match item.node {
@@ -534,7 +534,7 @@ impl LintPass for MissingDebugImplementations {
 
 impl LateLintPass for MissingDebugImplementations {
     fn check_item(&mut self, cx: &LateContext, item: &hir::Item) {
-        if !cx.exported_items.contains(&item.id) {
+        if !cx.access_levels.is_reachable(item.id) {
             return;
         }
 
@@ -987,7 +987,7 @@ impl LateLintPass for InvalidNoMangleItems {
         match it.node {
             hir::ItemFn(..) => {
                 if attr::contains_name(&it.attrs, "no_mangle") &&
-                       !cx.exported_items.contains(&it.id) {
+                       !cx.access_levels.is_reachable(it.id) {
                     let msg = format!("function {} is marked #[no_mangle], but not exported",
                                       it.name);
                     cx.span_lint(PRIVATE_NO_MANGLE_FNS, it.span, &msg);
@@ -995,7 +995,7 @@ impl LateLintPass for InvalidNoMangleItems {
             },
             hir::ItemStatic(..) => {
                 if attr::contains_name(&it.attrs, "no_mangle") &&
-                       !cx.exported_items.contains(&it.id) {
+                       !cx.access_levels.is_reachable(it.id) {
                     let msg = format!("static {} is marked #[no_mangle], but not exported",
                                       it.name);
                     cx.span_lint(PRIVATE_NO_MANGLE_STATICS, it.span, &msg);

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -214,7 +214,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
         let analysis = match self.analysis {
             Some(analysis) => analysis, None => return false
         };
-        if !please_inline && analysis.public_items.contains(&def) {
+        if !please_inline && analysis.access_levels.is_public(def) {
             return false
         }
         if !self.view_item_stack.insert(def_node_id) { return false }


### PR DESCRIPTION
This patch implements the plan described in https://internals.rust-lang.org/t/privacy-and-its-interaction-with-docs-lints-and-stability/2880 with one deviation.

It turns out, that rustdoc needs the "directly public" set for its docs inlining logic, so the privacy pass have to produce three sets and not two. Three is arguably too many, so I merged them in one map:
`public_items/exported_items/reachable_items: NodeSet => access_levels: NodeMap<AccessLevel>`

r? @alexcrichton 
