### PR TITLE
Consistently normalize fn types after erasing lifetimes.

### DIFF
--- a/src/librustc_trans/trans/attributes.rs
+++ b/src/librustc_trans/trans/attributes.rs
@@ -142,6 +142,7 @@ pub fn from_fn_type<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, fn_type: ty::Ty<'tcx
     };
 
     let fn_sig = ccx.tcx().erase_late_bound_regions(fn_sig);
+    let fn_sig = infer::normalize_associated_type(ccx.tcx(), &fn_sig);
 
     let mut attrs = llvm::AttrBuilder::new();
     let ret_ty = fn_sig.output;

--- a/src/librustc_trans/trans/closure.rs
+++ b/src/librustc_trans/trans/closure.rs
@@ -210,6 +210,7 @@ pub fn trans_closure_expr<'a, 'tcx>(dest: Dest<'a, 'tcx>,
         tcx.with_freevars(id, |fv| fv.iter().cloned().collect());
 
     let sig = tcx.erase_late_bound_regions(&function_type.sig);
+    let sig = infer::normalize_associated_type(ccx.tcx(), &sig);
 
     trans_closure(ccx,
                   decl,
@@ -371,6 +372,8 @@ fn trans_fn_once_adapter_shim<'a, 'tcx>(
     let lloncefn = declare::define_internal_rust_fn(ccx, &function_name,
                                                     llonce_fn_ty);
     let sig = tcx.erase_late_bound_regions(&llonce_bare_fn_ty.sig);
+    let sig = infer::normalize_associated_type(ccx.tcx(), &sig);
+
     let (block_arena, fcx): (TypedArena<_>, FunctionContext);
     block_arena = TypedArena::new();
     fcx = new_fn_ctxt(ccx,

--- a/src/librustc_trans/trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/trans/debuginfo/metadata.rs
@@ -24,6 +24,7 @@ use llvm::{self, ValueRef};
 use llvm::debuginfo::{DIType, DIFile, DIScope, DIDescriptor, DICompositeType};
 
 use middle::def_id::DefId;
+use middle::infer;
 use middle::pat_util;
 use middle::subst::{self, Substs};
 use rustc::front::map as hir_map;
@@ -262,6 +263,7 @@ impl<'tcx> TypeMap<'tcx> {
                 unique_type_id.push_str(" fn(");
 
                 let sig = cx.tcx().erase_late_bound_regions(sig);
+                let sig = infer::normalize_associated_type(cx.tcx(), &sig);
 
                 for &parameter_type in &sig.inputs {
                     let parameter_type_id =

--- a/src/librustc_trans/trans/debuginfo/type_names.rs
+++ b/src/librustc_trans/trans/debuginfo/type_names.rs
@@ -14,6 +14,7 @@ use super::namespace::crate_root_namespace;
 
 use trans::common::CrateContext;
 use middle::def_id::DefId;
+use middle::infer;
 use middle::subst::{self, Substs};
 use middle::ty::{self, Ty};
 
@@ -124,6 +125,7 @@ pub fn push_debuginfo_type_name<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             output.push_str("fn(");
 
             let sig = cx.tcx().erase_late_bound_regions(sig);
+            let sig = infer::normalize_associated_type(cx.tcx(), &sig);
             if !sig.inputs.is_empty() {
                 for &parameter_type in &sig.inputs {
                     push_debuginfo_type_name(cx, parameter_type, true, output);

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -12,6 +12,7 @@ use arena::TypedArena;
 use back::link;
 use llvm::{ValueRef, get_params};
 use middle::def_id::DefId;
+use middle::infer;
 use middle::subst::{Subst, Substs};
 use middle::subst::VecPerParamSpace;
 use middle::subst;
@@ -522,6 +523,7 @@ fn trans_object_shim<'a, 'tcx>(
     let llfn = declare::define_internal_rust_fn(ccx, &function_name, shim_fn_ty);
 
     let sig = ccx.tcx().erase_late_bound_regions(&fty.sig);
+    let sig = infer::normalize_associated_type(ccx.tcx(), &sig);
 
     let empty_substs = tcx.mk_substs(Substs::trans_empty());
     let (block_arena, fcx): (TypedArena<_>, FunctionContext);

--- a/src/test/run-pass/issue-23406.rs
+++ b/src/test/run-pass/issue-23406.rs
@@ -1,0 +1,23 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Inner {
+    type T;
+}
+
+impl<'a> Inner for &'a i32 {
+    type T = i32;
+}
+
+fn f<'a>(x: &'a i32) -> <&'a i32 as Inner>::T {
+    *x
+}
+
+fn main() {}

--- a/src/test/run-pass/issue-23598.rs
+++ b/src/test/run-pass/issue-23598.rs
@@ -1,0 +1,22 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Collection where for<'a> &'a Self: IntoIterator {
+    fn my_iter(&self) -> <&Self as IntoIterator>::IntoIter {
+        self.into_iter()
+    }
+}
+
+impl<T> Collection for [T] { }
+
+fn main() {
+    let v = [0usize];
+    let _ = v.my_iter();
+}


### PR DESCRIPTION
Fixes #23406.
Fixes #23958.
Fixes #29832.

CC @arielb1 
