### PR TITLE
Semi-fix --libdir installs

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -380,7 +380,7 @@ HBIN$(1)_H_$(3) = $$(HROOT$(1)_H_$(3))/bin
 ifeq ($$(CFG_WINDOWSY_$(3)),1)
 # On Windows we always store host runtime libraries in the 'bin' directory because
 # there's no rpath. Target libraries go under $CFG_LIBDIR_RELATIVE (usually 'lib').
-HLIB$(1)_H_$(3) = $$(HROOT$(1)_H_$(3))/bin
+HLIB_RELATIVE$(1)_H_$(3) = bin
 TROOT$(1)_T_$(2)_H_$(3) = $$(HROOT$(1)_H_$(3))/$$(CFG_LIBDIR_RELATIVE)/rustlib/$(2)
 # Remove the next 3 lines after a snapshot
 ifeq ($(1),0)
@@ -390,13 +390,14 @@ endif
 else
 
 ifeq ($(1),0)
-HLIB$(1)_H_$(3) = $$(HROOT$(1)_H_$(3))/lib
+HLIB_RELATIVE$(1)_H_$(3) = lib
 else
-HLIB$(1)_H_$(3) = $$(HROOT$(1)_H_$(3))/$$(CFG_LIBDIR_RELATIVE)
+HLIB_RELATIVE$(1)_H_$(3) = $$(CFG_LIBDIR_RELATIVE)
 endif
 TROOT$(1)_T_$(2)_H_$(3) = $$(HLIB$(1)_H_$(3))/rustlib/$(2)
 
 endif
+HLIB$(1)_H_$(3) = $$(HROOT$(1)_H_$(3))/$$(HLIB_RELATIVE$(1)_H_$(3))
 
 # Destinations of artifacts for target architectures
 TBIN$(1)_T_$(2)_H_$(3) = $$(TROOT$(1)_T_$(2)_H_$(3))/bin

--- a/mk/prepare.mk
+++ b/mk/prepare.mk
@@ -115,7 +115,7 @@ define DEF_PREPARE_HOST_LIB
 prepare-host-lib-$(1)-$(2)-$(3)-$(4): \
 	PREPARE_WORKING_SOURCE_LIB_DIR=$$(HLIB$(2)_H_$(3))
 prepare-host-lib-$(1)-$(2)-$(3)-$(4): \
-	PREPARE_WORKING_DEST_LIB_DIR=$$(PREPARE_DEST_DIR)/$$(notdir $$(HLIB$(2)_H_$(3)))
+	PREPARE_WORKING_DEST_LIB_DIR=$$(PREPARE_DEST_DIR)/$$(HLIB_RELATIVE$(2)_H_$(3))
 prepare-host-lib-$(1)-$(2)-$(3)-$(4): prepare-maybe-clean-$(4) \
                                  $$(foreach dep,$$(RUST_DEPS_$(1)),prepare-host-lib-$$(dep)-$(2)-$(3)-$(4)) \
                                  $$(HLIB$(2)_H_$(3))/stamp.$(1) \


### PR DESCRIPTION
This should get `--libdir` working as well as it was a couple of weeks ago.  (That is, it still rewrites paths incorrectly but it no longer fails during `make install`.)

Fixes gentoo/gentoo-rust#28 and gentoo/gentoo-rust#29.
