### PR TITLE
alloc: make RawVec round up allocation sizes to next power-of-two

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -148,7 +148,7 @@ use boxed::Box;
 /// let len = story.len();
 /// let capacity = story.capacity();
 ///
-/// // story has thirteen bytes
+/// // story has nineteen bytes
 /// assert_eq!(19, len);
 ///
 /// // Now that we have our parts, we throw the story away.
@@ -191,6 +191,9 @@ use boxed::Box;
 /// 40
 /// ```
 ///
+/// Please note that the actual output may be higher than stated as the
+/// allocator may reserve more space to avoid frequent reallocations.
+///
 /// At first, we have no memory allocated at all, but as we append to the
 /// string, it increases its capacity appropriately. If we instead use the
 /// [`with_capacity()`] method to allocate the correct capacity initially:
@@ -219,7 +222,9 @@ use boxed::Box;
 /// 25
 /// ```
 ///
-/// Here, there's no need to allocate more memory inside the loop.
+/// Here, there's no need to allocate more memory inside the loop. As above,
+/// the actual numbers may differ as the allocator may reserve more space to
+/// avoid frequent reallocations.
 #[derive(PartialOrd, Eq, Ord)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct String {

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -763,7 +763,11 @@ impl String {
         self.vec.reserve_exact(additional)
     }
 
-    /// Shrinks the capacity of this string buffer to match its length.
+    /// Shrinks the capacity of this string buffer to match its length as much
+    /// as possible.
+    ///
+    /// It will drop down as close as possible to the length but the allocator
+    /// may still inform the string that there is space for a few more bytes.
     ///
     /// # Examples
     ///
@@ -772,7 +776,7 @@ impl String {
     /// s.reserve(100);
     /// assert!(s.capacity() >= 100);
     /// s.shrink_to_fit();
-    /// assert_eq!(s.capacity(), 3);
+    /// assert!(s.capacity() >= 3);
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -207,9 +207,9 @@ use super::range::RangeArgument;
 /// strategy is used will of course guarantee `O(1)` amortized `push`.
 ///
 /// `vec![x; n]`, `vec![a, b, c, d]`, and `Vec::with_capacity(n)`, will all
-/// produce a Vec with exactly the requested capacity. If `len() == capacity()`,
-/// (as is the case for the `vec!` macro), then a `Vec<T>` can be converted
-/// to and from a `Box<[T]>` without reallocating or moving the elements.
+/// produce a Vec with at least the requested capacity.
+/// If `len() == capacity()`, then a `Vec<T>` can be converted to and from a
+/// `Box<[T]>` without reallocating or moving the elements.
 ///
 /// Vec will not specifically overwrite any data that is removed from it,
 /// but also won't specifically preserve it. Its uninitialized memory is

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -273,9 +273,12 @@ impl<T> Vec<T> {
     /// assert_eq!(vec.len(), 0);
     ///
     /// // These are all done without reallocating...
+    /// let cap = vec.capacity();
     /// for i in 0..10 {
     ///     vec.push(i);
     /// }
+    ///
+    /// assert_eq!(vec.capacity(), cap);
     ///
     /// // ...but this may make the vector reallocate
     /// vec.push(11);
@@ -349,7 +352,7 @@ impl<T> Vec<T> {
     ///
     /// ```
     /// let vec: Vec<i32> = Vec::with_capacity(10);
-    /// assert_eq!(vec.capacity(), 10);
+    /// assert!(vec.capacity() >= 10);
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -411,7 +414,7 @@ impl<T> Vec<T> {
     /// ```
     /// let mut vec = Vec::with_capacity(10);
     /// vec.extend([1, 2, 3].iter().cloned());
-    /// assert_eq!(vec.capacity(), 10);
+    /// assert!(vec.capacity() >= 10);
     /// vec.shrink_to_fit();
     /// assert!(vec.capacity() >= 3);
     /// ```

--- a/src/test/auxiliary/allocator-dummy.rs
+++ b/src/test/auxiliary/allocator-dummy.rs
@@ -51,5 +51,5 @@ pub extern fn __rust_reallocate_inplace(ptr: *mut u8, old_size: usize,
 
 #[no_mangle]
 pub extern fn __rust_usable_size(size: usize, align: usize) -> usize {
-    unsafe { core::intrinsics::abort() }
+    size
 }


### PR DESCRIPTION
The system allocator may give more memory than requested, usually rounding up to the next power-of-two.
This PR uses a similar logic inside RawVec to be able to make use of this excess memory.

NB: this is _not_ used for `with_capacity` and `shrink_to_fit` pending discussion in #29931 

r? @Gankro 
