### PR TITLE
Fix docs for HashSet::insert

### DIFF
--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -544,10 +544,7 @@ impl<T, S> HashSet<T, S>
     ///
     /// If the set did not have a value present, `true` is returned.
     ///
-    /// If the set did have this key present, that value is returned, and the
-    /// entry is not updated. See the [module-level documentation] for more.
-    ///
-    /// [module-level documentation]: index.html#insert-and-complex-keys
+    /// If the set did have this key present, `false` is returned.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
insert() returns bool, but it was wrongly stated that if the set had the
key already present, that key would be returned (this was probably
copied from the HashMap docs). Also remove a reference to the
module-level documentation, which doesn't make sense as it doesn't give
any more context.

r? @steveklabnik
