### PR TITLE
Abort configure if source path contains spaces, #18477

### DIFF
--- a/configure
+++ b/configure
@@ -541,6 +541,16 @@ CFG_BUILD_DIR="$(pwd)/"
 CFG_SELF="$0"
 CFG_CONFIGURE_ARGS="$@"
 
+
+case "${CFG_SRC_DIR}" in  
+    *\ * )
+        err "The path to the rust source directory contains spaces, which is not supported"
+        ;;
+    *)
+        ;;
+esac
+
+
 OPTIONS=""
 HELP=0
 if [ "$1" = "--help" ]


### PR DESCRIPTION
The Rust build scripts do work if the source directory contains spaces. I tried to make it work with spaces. I managed to get the Rust's and LLVM's configure scripts to work with spaces in the path, but I could not figure out how to get the Rust makefiles working.

So for now, this PR updates Rust's `configure` to abort if the source path contains spaces. I also added a note about spaces in the source path to the README. 

I think this should close #18477 for now.
