### PR TITLE
Remove hir::TyParen

### DIFF
--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -1444,7 +1444,6 @@ impl<'a, 'tcx> Rebuilder<'a, 'tcx> {
                     hir::TyTup(tys) => {
                         hir::TyTup(tys.into_iter().map(|ty| build_to(ty, to)).collect())
                     }
-                    hir::TyParen(typ) => hir::TyParen(build_to(typ, to)),
                     other => other
                 };
                 hir::Ty { id: id, node: new_node, span: span }

--- a/src/librustc_front/fold.rs
+++ b/src/librustc_front/fold.rs
@@ -382,7 +382,6 @@ pub fn noop_fold_ty<T: Folder>(t: P<Ty>, fld: &mut T) -> P<Ty> {
                     }))
                 }
                 TyTup(tys) => TyTup(tys.move_map(|ty| fld.fold_ty(ty))),
-                TyParen(ty) => TyParen(fld.fold_ty(ty)),
                 TyPath(qself, path) => {
                     let qself = qself.map(|QSelf { ty, position }| {
                         QSelf {

--- a/src/librustc_front/hir.rs
+++ b/src/librustc_front/hir.rs
@@ -848,8 +848,6 @@ pub enum Ty_ {
     TyObjectSum(P<Ty>, TyParamBounds),
     /// A type like `for<'a> Foo<&'a Bar>`
     TyPolyTraitRef(TyParamBounds),
-    /// No-op; kept solely so that we can pretty-print faithfully
-    TyParen(P<Ty>),
     /// Unused for now
     TyTypeof(P<Expr>),
     /// TyInfer means the type should be inferred instead of it having been

--- a/src/librustc_front/lowering.rs
+++ b/src/librustc_front/lowering.rs
@@ -225,7 +225,9 @@ pub fn lower_ty(_lctx: &LoweringContext, t: &Ty) -> P<hir::Ty> {
                 }))
             }
             TyTup(ref tys) => hir::TyTup(tys.iter().map(|ty| lower_ty(_lctx, ty)).collect()),
-            TyParen(ref ty) => hir::TyParen(lower_ty(_lctx, ty)),
+            TyParen(ref ty) => {
+                return lower_ty(_lctx, ty);
+            }
             TyPath(ref qself, ref path) => {
                 let qself = qself.as_ref().map(|&QSelf { ref ty, position }| {
                     hir::QSelf {

--- a/src/librustc_front/print/pprust.rs
+++ b/src/librustc_front/print/pprust.rs
@@ -506,11 +506,6 @@ impl<'a> State<'a> {
                 }
                 try!(self.pclose());
             }
-            hir::TyParen(ref typ) => {
-                try!(self.popen());
-                try!(self.print_type(&**typ));
-                try!(self.pclose());
-            }
             hir::TyBareFn(ref f) => {
                 let generics = hir::Generics {
                     lifetimes: f.lifetimes.clone(),

--- a/src/librustc_front/visit.rs
+++ b/src/librustc_front/visit.rs
@@ -349,7 +349,7 @@ pub fn walk_variant<'v, V: Visitor<'v>>(visitor: &mut V,
 
 pub fn walk_ty<'v, V: Visitor<'v>>(visitor: &mut V, typ: &'v Ty) {
     match typ.node {
-        TyVec(ref ty) | TyParen(ref ty) => {
+        TyVec(ref ty) => {
             visitor.visit_ty(ty)
         }
         TyPtr(ref mutable_type) => {

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1624,7 +1624,6 @@ pub fn ast_ty_to_ty<'tcx>(this: &AstConv<'tcx>,
                              .collect();
             tcx.mk_tup(flds)
         }
-        hir::TyParen(ref typ) => ast_ty_to_ty(this, rscope, &**typ),
         hir::TyBareFn(ref bf) => {
             require_c_abi_if_variadic(tcx, &bf.decl, bf.abi, ast_ty.span);
             let bare_fn = ty_of_bare_fn(this, bf.unsafety, bf.abi, &*bf.decl);

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1606,7 +1606,6 @@ impl Clean<Type> for hir::Ty {
                 }
             }
             TyBareFn(ref barefn) => BareFunction(box barefn.clean(cx)),
-            TyParen(ref ty) => ty.clean(cx),
             TyPolyTraitRef(ref bounds) => {
                 PolyTraitRef(bounds.clean(cx))
             },


### PR DESCRIPTION
Like https://github.com/nrc/rust/commit/d21bfff78cd949ce72be57d3528c4f6985190feb, but for the type grammar.

r? @nrc 
