### PR TITLE
properly short circuit const eval of && and ||

### DIFF
--- a/src/librustc_trans/trans/consts.rs
+++ b/src/librustc_trans/trans/consts.rs
@@ -591,6 +591,21 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             let is_float = ty.is_fp();
             let signed = ty.is_signed();
 
+            if ty.is_bool() && (b.node == hir::BiOr || b.node == hir::BiAnd) {
+              match eval_const_expr_partial(cx.tcx(),
+                                            &e1,
+                                            ExprTypeChecked,
+                                            None) {
+                Ok(ConstVal::Bool(false)) if b.node == hir::BiAnd => {
+                  return Ok(te1)
+                }
+                Ok(ConstVal::Bool(true)) if b.node == hir::BiOr => {
+                  return Ok(te1)
+                }
+                _ => ()
+              }
+            }
+
             let (te2, _) = try!(const_expr(cx, &**e2, param_substs, fn_args, trueconst));
 
             try!(check_binary_expr_validity(cx, e, ty, te1, te2, trueconst));

--- a/src/test/run-pass/issue-29608.rs
+++ b/src/test/run-pass/issue-29608.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Testcase provided by oli-obk
+
+const X: bool = false && ((1u8 - 5u8) == 42);
+
+fn main() {
+println!("{}", X);
+}


### PR DESCRIPTION
As described in #29608, the rhs of a logical expression is evaluated
even if evaluation of the lhs means no such evaluation should take
place if that evaluation happens in a const context.
