### PR TITLE
Ignore malformed environment variables on Windows too

### DIFF
--- a/src/libstd/sys/windows/os.rs
+++ b/src/libstd/sys/windows/os.rs
@@ -97,7 +97,7 @@ impl Iterator for Env {
                 let pos = match s[1..].iter().position(|&u| u == b'=' as u16).map(|p| p + 1) {
                     Some(p) => p,
                     None => continue,
-                }
+                };
                 return Some((
                     OsStringExt::from_wide(&s[..pos]),
                     OsStringExt::from_wide(&s[pos+1..]),

--- a/src/test/run-pass/env-vars.rs
+++ b/src/test/run-pass/env-vars.rs
@@ -14,10 +14,7 @@ use std::env::*;
 fn main() {
     for (k, v) in vars_os() {
         let v2 = var_os(&k);
-        // MingW seems to set some funky environment variables like
-        // "=C:=C:\MinGW\msys\1.0\bin" and "!::=::\" that are returned
-        // from vars() but not visible from var().
-        assert!(v2.is_none() || v2.as_ref().map(|s| &**s) == Some(&*v),
+        assert!(v2.as_ref().map(|s| &**s) == Some(&*v),
                 "bad vars->var transition: {:?} {:?} {:?}", k, v, v2);
     }
 }


### PR DESCRIPTION
See also #29297.
