### PR TITLE
Store items out-of-line in the HIR

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -96,7 +96,7 @@ DEPS_rustc_driver := arena flate getopts graphviz libc rustc rustc_back rustc_bo
                      rustc_typeck rustc_mir rustc_resolve log syntax serialize rustc_llvm \
 		             rustc_trans rustc_privacy rustc_lint rustc_front
 
-DEPS_rustc_front := std syntax log serialize
+DEPS_rustc_front := std syntax log serialize rustc_data_structures
 DEPS_rustc_lint := rustc log syntax
 DEPS_rustc_llvm := native:rustllvm libc std rustc_bitflags
 DEPS_rustc_mir := rustc rustc_front syntax

--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -96,7 +96,7 @@ DEPS_rustc_driver := arena flate getopts graphviz libc rustc rustc_back rustc_bo
                      rustc_typeck rustc_mir rustc_resolve log syntax serialize rustc_llvm \
 		             rustc_trans rustc_privacy rustc_lint rustc_front
 
-DEPS_rustc_front := std syntax log serialize rustc_data_structures
+DEPS_rustc_front := std syntax log serialize
 DEPS_rustc_lint := rustc log syntax
 DEPS_rustc_llvm := native:rustllvm libc std rustc_bitflags
 DEPS_rustc_mir := rustc rustc_front syntax

--- a/src/librustc/front/map/blocks.rs
+++ b/src/librustc/front/map/blocks.rs
@@ -29,7 +29,7 @@ use rustc_front::hir::{Block, FnDecl};
 use syntax::ast::{Name, NodeId};
 use rustc_front::hir as ast;
 use syntax::codemap::Span;
-use rustc_front::visit::FnKind;
+use rustc_front::intravisit::FnKind;
 
 /// An FnLikeNode is a Node that is like a fn, in that it has a decl
 /// and a body (as well as a NodeId, a span, etc).

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -555,7 +555,6 @@ impl<'a> EarlyContext<'a> {
     {
         let mut v = ast_util::IdVisitor {
             operation: self,
-            pass_through_items: false,
             visited_outermost: false,
         };
         f(&mut v);
@@ -583,11 +582,7 @@ impl<'a, 'tcx> LateContext<'a, 'tcx> {
     fn visit_ids<F>(&mut self, f: F)
         where F: FnOnce(&mut util::IdVisitor<LateContext>)
     {
-        let mut v = util::IdVisitor {
-            operation: self,
-            pass_through_items: false,
-            visited_outermost: false,
-        };
+        let mut v = util::IdVisitor::new(self);
         f(&mut v);
     }
 }

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -44,7 +44,7 @@ use syntax::parse::token::InternedString;
 use syntax::ast;
 use rustc_front::hir;
 use rustc_front::util;
-use rustc_front::visit as hir_visit;
+use rustc_front::intravisit as hir_visit;
 use syntax::visit as ast_visit;
 use syntax::diagnostic;
 
@@ -606,10 +606,12 @@ impl<'a, 'tcx> LintContext for LateContext<'a, 'tcx> {
     }
 
     fn enter_attrs(&mut self, attrs: &[ast::Attribute]) {
+        debug!("late context: enter_attrs({:?})", attrs);
         run_lints!(self, enter_lint_attrs, late_passes, attrs);
     }
 
     fn exit_attrs(&mut self, attrs: &[ast::Attribute]) {
+        debug!("late context: exit_attrs({:?})", attrs);
         run_lints!(self, exit_lint_attrs, late_passes, attrs);
     }
 }
@@ -633,15 +635,24 @@ impl<'a> LintContext for EarlyContext<'a> {
     }
 
     fn enter_attrs(&mut self, attrs: &[ast::Attribute]) {
+        debug!("early context: exit_attrs({:?})", attrs);
         run_lints!(self, enter_lint_attrs, early_passes, attrs);
     }
 
     fn exit_attrs(&mut self, attrs: &[ast::Attribute]) {
+        debug!("early context: exit_attrs({:?})", attrs);
         run_lints!(self, exit_lint_attrs, early_passes, attrs);
     }
 }
 
 impl<'a, 'tcx, 'v> hir_visit::Visitor<'v> for LateContext<'a, 'tcx> {
+    /// Because lints are scoped lexically, we want to walk nested
+    /// items in the context of the outer item, so enable
+    /// deep-walking.
+    fn visit_nested_item(&mut self, item: hir::ItemId) {
+        self.visit_item(self.tcx.map.expect_item(item.id))
+    }
+
     fn visit_item(&mut self, it: &hir::Item) {
         self.with_lint_attrs(&it.attrs, |cx| {
             run_lints!(cx, check_item, late_passes, it);
@@ -947,6 +958,7 @@ impl<'a, 'tcx> IdVisitingOperation for LateContext<'a, 'tcx> {
         match self.sess().lints.borrow_mut().remove(&id) {
             None => {}
             Some(lints) => {
+                debug!("LateContext::visit_id: id={:?} lints={:?}", id, lints);
                 for (lint_id, span, msg) in lints {
                     self.span_lint(lint_id.lint, span, &msg[..])
                 }
@@ -1003,16 +1015,14 @@ impl LateLintPass for GatherNodeLevels {
 ///
 /// Consumes the `lint_store` field of the `Session`.
 pub fn check_crate(tcx: &ty::ctxt,
-                   krate: &hir::Crate,
                    exported_items: &ExportedItems) {
-
+    let krate = tcx.map.krate();
     let mut cx = LateContext::new(tcx, krate, exported_items);
 
     // Visit the whole crate.
     cx.with_lint_attrs(&krate.attrs, |cx| {
         cx.visit_id(ast::CRATE_NODE_ID);
         cx.visit_ids(|v| {
-            v.visited_outermost = true;
             hir_visit::walk_crate(v, krate);
         });
 

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -34,7 +34,7 @@ pub use self::LintSource::*;
 use std::hash;
 use std::ascii::AsciiExt;
 use syntax::codemap::Span;
-use rustc_front::visit::FnKind;
+use rustc_front::intravisit::FnKind;
 use syntax::visit as ast_visit;
 use syntax::ast;
 use rustc_front::hir;
@@ -218,7 +218,7 @@ pub type EarlyLintPassObject = Box<EarlyLintPass + 'static>;
 pub type LateLintPassObject = Box<LateLintPass + 'static>;
 
 /// Identifies a lint known to the compiler.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct LintId {
     // Identity is based on pointer equality of this field.
     lint: &'static Lint,

--- a/src/librustc/metadata/inline.rs
+++ b/src/librustc/metadata/inline.rs
@@ -48,11 +48,7 @@ impl InlinedItem {
     }
 
     pub fn visit_ids<O: IdVisitingOperation>(&self, operation: &mut O) {
-        let mut id_visitor = IdVisitor {
-            operation: operation,
-            pass_through_items: true,
-            visited_outermost: false,
-        };
+        let mut id_visitor = IdVisitor::new(operation);
         self.visit(&mut id_visitor);
     }
 

--- a/src/librustc/metadata/inline.rs
+++ b/src/librustc/metadata/inline.rs
@@ -13,7 +13,7 @@ use rustc_front::hir;
 use rustc_front::util::IdVisitor;
 use syntax::ast_util::{IdRange, IdRangeComputingVisitor, IdVisitingOperation};
 use syntax::ptr::P;
-use rustc_front::visit::Visitor;
+use rustc_front::intravisit::Visitor;
 use self::InlinedItem::*;
 
 /// The data we save and restore about an inlined item or method.  This is not

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -389,7 +389,7 @@ fn simplify_ast(ii: InlinedItemRef) -> InlinedItem {
     match ii {
         // HACK we're not dropping items.
         InlinedItemRef::Item(i) => {
-            InlinedItem::Item(fold::noop_fold_item(P(i.clone()), &mut fld))
+            InlinedItem::Item(P(fold::noop_fold_item(i.clone(), &mut fld)))
         }
         InlinedItemRef::TraitItem(d, ti) => {
             InlinedItem::TraitItem(d, fold::noop_fold_trait_item(P(ti.clone()), &mut fld))

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -1393,13 +1393,13 @@ fn mk_ctxt() -> parse::ParseSess {
 }
 
 #[cfg(test)]
-fn roundtrip(in_item: P<hir::Item>) {
+fn roundtrip(in_item: hir::Item) {
     let mut wr = Cursor::new(Vec::new());
-    encode_item_ast(&mut Encoder::new(&mut wr), &*in_item);
+    encode_item_ast(&mut Encoder::new(&mut wr), &in_item);
     let rbml_doc = rbml::Doc::new(wr.get_ref());
     let out_item = decode_item_ast(rbml_doc);
 
-    assert!(*in_item == out_item);
+    assert!(in_item == out_item);
 }
 
 #[test]
@@ -1449,11 +1449,11 @@ fn test_simplification() {
     let hir_item = lower_item(&lcx, &item);
     let item_in = InlinedItemRef::Item(&hir_item);
     let item_out = simplify_ast(item_in);
-    let item_exp = InlinedItem::Item(lower_item(&lcx, &quote_item!(&cx,
+    let item_exp = InlinedItem::Item(P(lower_item(&lcx, &quote_item!(&cx,
         fn new_int_alist<B>() -> alist<isize, B> {
             return alist {eq_fn: eq_int, data: Vec::new()};
         }
-    ).unwrap()));
+    ).unwrap())));
     match (item_out, item_exp) {
       (InlinedItem::Item(item_out), InlinedItem::Item(item_exp)) => {
         assert!(pprust::item_to_string(&*item_out) ==

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -485,11 +485,7 @@ impl<'a, 'tcx> Folder for StaticInliner<'a, 'tcx> {
                 renaming_map: renaming_map,
             };
 
-            let mut id_visitor = front_util::IdVisitor {
-                operation: &mut renaming_recorder,
-                pass_through_items: true,
-                visited_outermost: false,
-            };
+            let mut id_visitor = front_util::IdVisitor::new(&mut renaming_recorder);
 
             id_visitor.visit_expr(const_expr);
         }

--- a/src/librustc/middle/check_rvalues.rs
+++ b/src/librustc/middle/check_rvalues.rs
@@ -20,21 +20,21 @@ use middle::ty;
 use syntax::ast;
 use rustc_front::hir;
 use syntax::codemap::Span;
-use rustc_front::visit;
+use rustc_front::intravisit;
 
 pub fn check_crate(tcx: &ty::ctxt,
                    krate: &hir::Crate) {
     let mut rvcx = RvalueContext { tcx: tcx };
-    visit::walk_crate(&mut rvcx, krate);
+    krate.visit_all_items(&mut rvcx);
 }
 
 struct RvalueContext<'a, 'tcx: 'a> {
     tcx: &'a ty::ctxt<'tcx>,
 }
 
-impl<'a, 'tcx, 'v> visit::Visitor<'v> for RvalueContext<'a, 'tcx> {
+impl<'a, 'tcx, 'v> intravisit::Visitor<'v> for RvalueContext<'a, 'tcx> {
     fn visit_fn(&mut self,
-                fk: visit::FnKind<'v>,
+                fk: intravisit::FnKind<'v>,
                 fd: &'v hir::FnDecl,
                 b: &'v hir::Block,
                 s: Span,
@@ -50,7 +50,7 @@ impl<'a, 'tcx, 'v> visit::Visitor<'v> for RvalueContext<'a, 'tcx> {
             let mut euv = euv::ExprUseVisitor::new(&mut delegate, &infcx);
             euv.walk_fn(fd, b);
         }
-        visit::walk_fn(self, fk, fd, b, s)
+        intravisit::walk_fn(self, fk, fd, b, s)
     }
 }
 

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -29,7 +29,7 @@ use util::nodemap::NodeMap;
 use syntax::{ast, abi};
 use rustc_front::hir::Expr;
 use rustc_front::hir;
-use rustc_front::visit::FnKind;
+use rustc_front::intravisit::FnKind;
 use syntax::codemap::Span;
 use syntax::parse::token::InternedString;
 use syntax::ptr::P;

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -27,7 +27,7 @@ use syntax::print::pp;
 use syntax::print::pprust::PrintState;
 use util::nodemap::NodeMap;
 use rustc_front::hir;
-use rustc_front::visit;
+use rustc_front::intravisit;
 use rustc_front::print::pprust;
 
 
@@ -194,11 +194,11 @@ fn build_nodeid_to_index(decl: Option<&hir::FnDecl>,
             index: &'a mut NodeMap<Vec<CFGIndex>>,
         }
         let mut formals = Formals { entry: entry, index: index };
-        visit::walk_fn_decl(&mut formals, decl);
-        impl<'a, 'v> visit::Visitor<'v> for Formals<'a> {
+        intravisit::walk_fn_decl(&mut formals, decl);
+        impl<'a, 'v> intravisit::Visitor<'v> for Formals<'a> {
             fn visit_pat(&mut self, p: &hir::Pat) {
                 self.index.entry(p.id).or_insert(vec![]).push(self.entry);
-                visit::walk_pat(self, p)
+                intravisit::walk_pat(self, p)
             }
         }
     }
@@ -533,7 +533,7 @@ impl<'a, 'tcx, O:DataFlowOperator+Clone+'static> DataFlowContext<'a, 'tcx, O> {
 
     fn pretty_print_to<'b>(&self, wr: Box<io::Write + 'b>,
                            blk: &hir::Block) -> io::Result<()> {
-        let mut ps = pprust::rust_printer_annotated(wr, self);
+        let mut ps = pprust::rust_printer_annotated(wr, self, None);
         try!(ps.cbox(pprust::indent_unit));
         try!(ps.ibox(0));
         try!(ps.print_block(blk));

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -19,8 +19,8 @@ use middle::ty::MethodCall;
 use syntax::ast;
 use syntax::codemap::Span;
 use rustc_front::hir;
-use rustc_front::visit;
-use rustc_front::visit::{FnKind, Visitor};
+use rustc_front::intravisit;
+use rustc_front::intravisit::{FnKind, Visitor};
 
 #[derive(Copy, Clone)]
 struct UnsafeContext {
@@ -94,7 +94,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for EffectCheckVisitor<'a, 'tcx> {
             self.unsafe_context = UnsafeContext::new(SafeContext)
         }
 
-        visit::walk_fn(self, fn_kind, fn_decl, block, span);
+        intravisit::walk_fn(self, fn_kind, fn_decl, block, span);
 
         self.unsafe_context = old_unsafe_context
     }
@@ -133,7 +133,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for EffectCheckVisitor<'a, 'tcx> {
             hir::DefaultBlock | hir::PushUnstableBlock | hir:: PopUnstableBlock => {}
         }
 
-        visit::walk_block(self, block);
+        intravisit::walk_block(self, block);
 
         self.unsafe_context = old_unsafe_context
     }
@@ -177,7 +177,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for EffectCheckVisitor<'a, 'tcx> {
             _ => {}
         }
 
-        visit::walk_expr(self, expr);
+        intravisit::walk_expr(self, expr);
     }
 }
 
@@ -187,5 +187,5 @@ pub fn check_crate(tcx: &ty::ctxt) {
         unsafe_context: UnsafeContext::new(SafeContext),
     };
 
-    visit::walk_crate(&mut visitor, tcx.map.krate());
+    tcx.map.krate().visit_all_items(&mut visitor);
 }

--- a/src/librustc/middle/intrinsicck.rs
+++ b/src/librustc/middle/intrinsicck.rs
@@ -19,7 +19,7 @@ use std::fmt;
 use syntax::abi::RustIntrinsic;
 use syntax::ast;
 use syntax::codemap::Span;
-use rustc_front::visit::{self, Visitor, FnKind};
+use rustc_front::intravisit::{self, Visitor, FnKind};
 use rustc_front::hir;
 
 pub fn check_crate(tcx: &ctxt) {
@@ -29,7 +29,7 @@ pub fn check_crate(tcx: &ctxt) {
         dummy_sized_ty: tcx.types.isize,
         dummy_unsized_ty: tcx.mk_slice(tcx.types.isize),
     };
-    visit::walk_crate(&mut visitor, tcx.map.krate());
+    tcx.map.krate().visit_all_items(&mut visitor);
 }
 
 struct IntrinsicCheckingVisitor<'a, 'tcx: 'a> {
@@ -222,11 +222,11 @@ impl<'a, 'tcx, 'v> Visitor<'v> for IntrinsicCheckingVisitor<'a, 'tcx> {
             FnKind::ItemFn(..) | FnKind::Method(..) => {
                 let param_env = ty::ParameterEnvironment::for_item(self.tcx, id);
                 self.param_envs.push(param_env);
-                visit::walk_fn(self, fk, fd, b, s);
+                intravisit::walk_fn(self, fk, fd, b, s);
                 self.param_envs.pop();
             }
             FnKind::Closure(..) => {
-                visit::walk_fn(self, fk, fd, b, s);
+                intravisit::walk_fn(self, fk, fd, b, s);
             }
         }
 
@@ -255,7 +255,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for IntrinsicCheckingVisitor<'a, 'tcx> {
             }
         }
 
-        visit::walk_expr(self, expr);
+        intravisit::walk_expr(self, expr);
     }
 }
 

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -33,8 +33,7 @@ use syntax::ast;
 use syntax::attr::AttrMetaMethods;
 use syntax::codemap::{DUMMY_SP, Span};
 use syntax::parse::token::InternedString;
-use rustc_front::visit::Visitor;
-use rustc_front::visit;
+use rustc_front::intravisit::Visitor;
 use rustc_front::hir;
 
 use std::iter::Enumerate;
@@ -164,8 +163,6 @@ impl<'a, 'v, 'tcx> Visitor<'v> for LanguageItemCollector<'a, 'tcx> {
                 self.collect_item(item_index, self.ast_map.local_def_id(item.id), item.span)
             }
         }
-
-        visit::walk_item(self, item);
     }
 }
 
@@ -202,7 +199,7 @@ impl<'a, 'tcx> LanguageItemCollector<'a, 'tcx> {
     }
 
     pub fn collect_local_language_items(&mut self, krate: &hir::Crate) {
-        visit::walk_crate(self, krate);
+        krate.visit_all_items(self);
     }
 
     pub fn collect_external_language_items(&mut self) {

--- a/src/librustc/middle/weak_lang_items.rs
+++ b/src/librustc/middle/weak_lang_items.rs
@@ -18,8 +18,8 @@ use middle::lang_items;
 use syntax::ast;
 use syntax::codemap::Span;
 use syntax::parse::token::InternedString;
-use rustc_front::visit::Visitor;
-use rustc_front::visit;
+use rustc_front::intravisit::Visitor;
+use rustc_front::intravisit;
 use rustc_front::hir;
 
 use std::collections::HashSet;
@@ -50,7 +50,7 @@ pub fn check_crate(krate: &hir::Crate,
 
     {
         let mut cx = Context { sess: sess, items: items };
-        visit::walk_crate(&mut cx, krate);
+        krate.visit_all_items(&mut cx);
     }
     verify(sess, items);
 }
@@ -114,7 +114,7 @@ impl<'a, 'v> Visitor<'v> for Context<'a> {
             None => {}
             Some(lang_item) => self.register(&lang_item, i.span),
         }
-        visit::walk_foreign_item(self, i)
+        intravisit::walk_foreign_item(self, i)
     }
 }
 

--- a/src/librustc/plugin/build.rs
+++ b/src/librustc/plugin/build.rs
@@ -14,8 +14,7 @@ use syntax::ast;
 use syntax::attr;
 use syntax::codemap::Span;
 use syntax::diagnostic;
-use rustc_front::visit;
-use rustc_front::visit::Visitor;
+use rustc_front::intravisit::Visitor;
 use rustc_front::hir;
 
 struct RegistrarFinder {
@@ -30,8 +29,6 @@ impl<'v> Visitor<'v> for RegistrarFinder {
                 self.registrars.push((item.id, item.span));
             }
         }
-
-        visit::walk_item(self, item);
     }
 }
 
@@ -40,7 +37,7 @@ pub fn find_plugin_registrar(diagnostic: &diagnostic::SpanHandler,
                              krate: &hir::Crate)
                              -> Option<ast::NodeId> {
     let mut finder = RegistrarFinder { registrars: Vec::new() };
-    visit::walk_crate(&mut finder, krate);
+    krate.visit_all_items(&mut finder);
 
     match finder.registrars.len() {
         0 => None,

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -21,8 +21,8 @@ use std::path::Path;
 use std::time::Duration;
 
 use rustc_front::hir;
-use rustc_front::visit;
-use rustc_front::visit::Visitor;
+use rustc_front::intravisit;
+use rustc_front::intravisit::Visitor;
 
 // The name of the associated type for `Fn` return types
 pub const FN_OUTPUT_NAME: &'static str = "Output";
@@ -169,7 +169,7 @@ impl<'v, P> Visitor<'v> for LoopQueryVisitor<P> where P: FnMut(&hir::Expr_) -> b
           // Skip inner loops, since a break in the inner loop isn't a
           // break inside the outer loop
           hir::ExprLoop(..) | hir::ExprWhile(..) => {}
-          _ => visit::walk_expr(self, e)
+          _ => intravisit::walk_expr(self, e)
         }
     }
 }
@@ -181,7 +181,7 @@ pub fn loop_query<P>(b: &hir::Block, p: P) -> bool where P: FnMut(&hir::Expr_) -
         p: p,
         flag: false,
     };
-    visit::walk_block(&mut v, b);
+    intravisit::walk_block(&mut v, b);
     return v.flag;
 }
 
@@ -193,7 +193,7 @@ struct BlockQueryVisitor<P> where P: FnMut(&hir::Expr) -> bool {
 impl<'v, P> Visitor<'v> for BlockQueryVisitor<P> where P: FnMut(&hir::Expr) -> bool {
     fn visit_expr(&mut self, e: &hir::Expr) {
         self.flag |= (self.p)(e);
-        visit::walk_expr(self, e)
+        intravisit::walk_expr(self, e)
     }
 }
 
@@ -204,7 +204,7 @@ pub fn block_query<P>(b: &hir::Block, p: P) -> bool where P: FnMut(&hir::Expr) -
         p: p,
         flag: false,
     };
-    visit::walk_block(&mut v, &*b);
+    intravisit::walk_block(&mut v, &*b);
     return v.flag;
 }
 

--- a/src/librustc_back/svh.rs
+++ b/src/librustc_back/svh.rs
@@ -49,7 +49,7 @@
 use std::fmt;
 use std::hash::{Hash, SipHasher, Hasher};
 use rustc_front::hir;
-use rustc_front::visit;
+use rustc_front::intravisit as visit;
 
 #[derive(Clone, PartialEq, Debug)]
 pub struct Svh {
@@ -83,7 +83,7 @@ impl Svh {
         }
 
         {
-            let mut visit = svh_visitor::make(&mut state);
+            let mut visit = svh_visitor::make(&mut state, krate);
             visit::walk_crate(&mut visit, krate);
         }
 
@@ -134,19 +134,20 @@ mod svh_visitor {
     use syntax::ast::{self, Name, NodeId};
     use syntax::codemap::Span;
     use syntax::parse::token;
-    use rustc_front::visit;
-    use rustc_front::visit::{Visitor, FnKind};
+    use rustc_front::intravisit as visit;
+    use rustc_front::intravisit::{Visitor, FnKind};
     use rustc_front::hir::*;
     use rustc_front::hir;
 
     use std::hash::{Hash, SipHasher};
 
     pub struct StrictVersionHashVisitor<'a> {
+        pub krate: &'a Crate,
         pub st: &'a mut SipHasher,
     }
 
-    pub fn make<'a>(st: &'a mut SipHasher) -> StrictVersionHashVisitor<'a> {
-        StrictVersionHashVisitor { st: st }
+    pub fn make<'a>(st: &'a mut SipHasher, krate: &'a Crate) -> StrictVersionHashVisitor<'a> {
+        StrictVersionHashVisitor { st: st, krate: krate }
     }
 
     // To off-load the bulk of the hash-computation on #[derive(Hash)],
@@ -300,15 +301,19 @@ mod svh_visitor {
         }
     }
 
-    impl<'a, 'v> Visitor<'v> for StrictVersionHashVisitor<'a> {
-        fn visit_variant_data(&mut self, s: &VariantData, name: Name,
-                            g: &Generics, _: NodeId, _: Span) {
+    impl<'a> Visitor<'a> for StrictVersionHashVisitor<'a> {
+        fn visit_nested_item(&mut self, item: ItemId) {
+            self.visit_item(self.krate.item(item.id))
+        }
+
+        fn visit_variant_data(&mut self, s: &'a VariantData, name: Name,
+                              g: &'a Generics, _: NodeId, _: Span) {
             SawStructDef(name.as_str()).hash(self.st);
             visit::walk_generics(self, g);
             visit::walk_struct_def(self, s)
         }
 
-        fn visit_variant(&mut self, v: &Variant, g: &Generics, item_id: NodeId) {
+        fn visit_variant(&mut self, v: &'a Variant, g: &'a Generics, item_id: NodeId) {
             SawVariant.hash(self.st);
             // walk_variant does not call walk_generics, so do it here.
             visit::walk_generics(self, g);
@@ -333,11 +338,11 @@ mod svh_visitor {
             SawIdent(name.as_str()).hash(self.st);
         }
 
-        fn visit_lifetime(&mut self, l: &Lifetime) {
+        fn visit_lifetime(&mut self, l: &'a Lifetime) {
             SawLifetime(l.name.as_str()).hash(self.st);
         }
 
-        fn visit_lifetime_def(&mut self, l: &LifetimeDef) {
+        fn visit_lifetime_def(&mut self, l: &'a LifetimeDef) {
             SawLifetimeDef(l.lifetime.name.as_str()).hash(self.st);
         }
 
@@ -346,15 +351,15 @@ mod svh_visitor {
         // monomorphization and cross-crate inlining generally implies
         // that a change to a crate body will require downstream
         // crates to be recompiled.
-        fn visit_expr(&mut self, ex: &Expr) {
+        fn visit_expr(&mut self, ex: &'a Expr) {
             SawExpr(saw_expr(&ex.node)).hash(self.st); visit::walk_expr(self, ex)
         }
 
-        fn visit_stmt(&mut self, s: &Stmt) {
+        fn visit_stmt(&mut self, s: &'a Stmt) {
             SawStmt(saw_stmt(&s.node)).hash(self.st); visit::walk_stmt(self, s)
         }
 
-        fn visit_foreign_item(&mut self, i: &ForeignItem) {
+        fn visit_foreign_item(&mut self, i: &'a ForeignItem) {
             // FIXME (#14132) ideally we would incorporate privacy (or
             // perhaps reachability) somewhere here, so foreign items
             // that do not leak into downstream crates would not be
@@ -362,7 +367,7 @@ mod svh_visitor {
             SawForeignItem.hash(self.st); visit::walk_foreign_item(self, i)
         }
 
-        fn visit_item(&mut self, i: &Item) {
+        fn visit_item(&mut self, i: &'a Item) {
             // FIXME (#14132) ideally would incorporate reachability
             // analysis somewhere here, so items that never leak into
             // downstream crates (e.g. via monomorphisation or
@@ -370,64 +375,64 @@ mod svh_visitor {
             SawItem.hash(self.st); visit::walk_item(self, i)
         }
 
-        fn visit_mod(&mut self, m: &Mod, _s: Span, _n: NodeId) {
+        fn visit_mod(&mut self, m: &'a Mod, _s: Span, _n: NodeId) {
             SawMod.hash(self.st); visit::walk_mod(self, m)
         }
 
-        fn visit_decl(&mut self, d: &Decl) {
+        fn visit_decl(&mut self, d: &'a Decl) {
             SawDecl.hash(self.st); visit::walk_decl(self, d)
         }
 
-        fn visit_ty(&mut self, t: &Ty) {
+        fn visit_ty(&mut self, t: &'a Ty) {
             SawTy.hash(self.st); visit::walk_ty(self, t)
         }
 
-        fn visit_generics(&mut self, g: &Generics) {
+        fn visit_generics(&mut self, g: &'a Generics) {
             SawGenerics.hash(self.st); visit::walk_generics(self, g)
         }
 
-        fn visit_fn(&mut self, fk: FnKind<'v>, fd: &'v FnDecl,
-                    b: &'v Block, s: Span, _: NodeId) {
+        fn visit_fn(&mut self, fk: FnKind<'a>, fd: &'a FnDecl,
+                    b: &'a Block, s: Span, _: NodeId) {
             SawFn.hash(self.st); visit::walk_fn(self, fk, fd, b, s)
         }
 
-        fn visit_trait_item(&mut self, ti: &TraitItem) {
+        fn visit_trait_item(&mut self, ti: &'a TraitItem) {
             SawTraitItem.hash(self.st); visit::walk_trait_item(self, ti)
         }
 
-        fn visit_impl_item(&mut self, ii: &ImplItem) {
+        fn visit_impl_item(&mut self, ii: &'a ImplItem) {
             SawImplItem.hash(self.st); visit::walk_impl_item(self, ii)
         }
 
-        fn visit_struct_field(&mut self, s: &StructField) {
+        fn visit_struct_field(&mut self, s: &'a StructField) {
             SawStructField.hash(self.st); visit::walk_struct_field(self, s)
         }
 
-        fn visit_explicit_self(&mut self, es: &ExplicitSelf) {
+        fn visit_explicit_self(&mut self, es: &'a ExplicitSelf) {
             SawExplicitSelf.hash(self.st); visit::walk_explicit_self(self, es)
         }
 
-        fn visit_path(&mut self, path: &Path, _: ast::NodeId) {
+        fn visit_path(&mut self, path: &'a Path, _: ast::NodeId) {
             SawPath.hash(self.st); visit::walk_path(self, path)
         }
 
-        fn visit_path_list_item(&mut self, prefix: &Path, item: &'v PathListItem) {
+        fn visit_path_list_item(&mut self, prefix: &'a Path, item: &'a PathListItem) {
             SawPath.hash(self.st); visit::walk_path_list_item(self, prefix, item)
         }
 
-        fn visit_block(&mut self, b: &Block) {
+        fn visit_block(&mut self, b: &'a Block) {
             SawBlock.hash(self.st); visit::walk_block(self, b)
         }
 
-        fn visit_pat(&mut self, p: &Pat) {
+        fn visit_pat(&mut self, p: &'a Pat) {
             SawPat.hash(self.st); visit::walk_pat(self, p)
         }
 
-        fn visit_local(&mut self, l: &Local) {
+        fn visit_local(&mut self, l: &'a Local) {
             SawLocal.hash(self.st); visit::walk_local(self, l)
         }
 
-        fn visit_arm(&mut self, a: &Arm) {
+        fn visit_arm(&mut self, a: &'a Arm) {
             SawArm.hash(self.st); visit::walk_arm(self, a)
         }
     }

--- a/src/librustc_borrowck/borrowck/gather_loans/mod.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/mod.rs
@@ -30,8 +30,8 @@ use syntax::codemap::Span;
 use syntax::ast::NodeId;
 use rustc_front::hir;
 use rustc_front::hir::{Expr, FnDecl, Block, Pat};
-use rustc_front::visit;
-use rustc_front::visit::Visitor;
+use rustc_front::intravisit;
+use rustc_front::intravisit::Visitor;
 
 mod lifetime;
 mod restrictions;
@@ -533,7 +533,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for StaticInitializerCtxt<'a, 'tcx> {
             }
         }
 
-        visit::walk_expr(self, ex);
+        intravisit::walk_expr(self, ex);
     }
 }
 

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -827,7 +827,7 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
 
                                    time(time_passes,
                                         "lint checking",
-                                        || lint::check_crate(tcx, krate, &exported_items));
+                                        || lint::check_crate(tcx, &exported_items));
 
                                    // The above three passes generate errors w/o aborting
                                    tcx.sess.abort_if_errors();

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -777,7 +777,8 @@ pub fn pretty_print_input(sess: Session,
                                                       &mut rdr,
                                                       box out,
                                                       annotation.pp_ann(),
-                                                      true);
+                                                      true,
+                                                      Some(ast_map.krate()));
                 for node_id in uii.all_matching_node_ids(ast_map) {
                     let node = ast_map.get(node_id);
                     try!(pp_state.print_node(&node));

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -189,9 +189,10 @@ impl<'a, 'tcx> Env<'a, 'tcx> {
                       names: &[String])
                       -> Option<ast::NodeId> {
             assert!(idx < names.len());
-            for item in &m.items {
+            for item in &m.item_ids {
+                let item = this.infcx.tcx.map.expect_item(item.id);
                 if item.name.to_string() == names[idx] {
-                    return search(this, &**item, idx + 1, names);
+                    return search(this, item, idx + 1, names);
                 }
             }
             return None;

--- a/src/librustc_front/intravisit.rs
+++ b/src/librustc_front/intravisit.rs
@@ -13,15 +13,17 @@
 //! call `visit::walk_*` to apply the default traversal algorithm, or prevent
 //! deeper traversal by doing nothing.
 //!
-//! Note: it is an important invariant that the default visitor walks the body
-//! of a function in "execution order" (more concretely, reverse post-order
-//! with respect to the CFG implied by the AST), meaning that if AST node A may
-//! execute before AST node B, then A is visited first.  The borrow checker in
-//! particular relies on this property.
+//! When visiting the HIR, the contents of nested items are NOT visited
+//! by default. This is different from the AST visitor, which does a deep walk.
+//! Hence this module is called `intravisit`; see the method `visit_nested_item`
+//! for more details.
 //!
-//! Note: walking an AST before macro expansion is probably a bad idea. For
-//! instance, a walker looking for item names in a module will miss all of
-//! those that are created by the expansion of a macro.
+//! Note: it is an important invariant that the default visitor walks
+//! the body of a function in "execution order" (more concretely,
+//! reverse post-order with respect to the CFG implied by the AST),
+//! meaning that if AST node A may execute before AST node B, then A
+//! is visited first.  The borrow checker in particular relies on this
+//! property.
 
 use syntax::abi::Abi;
 use syntax::ast::{Ident, NodeId, CRATE_NODE_ID, Name, Attribute};
@@ -45,8 +47,10 @@ pub enum FnKind<'a> {
 /// the substructure of the input via the corresponding `walk` method;
 /// e.g. the `visit_mod` method by default calls `visit::walk_mod`.
 ///
-/// Note that this visitor does NOT visit nested items by default. If
-/// you simply want to visit all items in the crate in some order, you
+/// Note that this visitor does NOT visit nested items by default
+/// (this is why the module is called `intravisit`, to distinguish it
+/// from the AST's `visit` module, which acts differently). If you
+/// simply want to visit all items in the crate in some order, you
 /// should call `Crate::visit_all_items`. Otherwise, see the comment
 /// on `visit_nested_item` for details on how to visit nested items.
 ///

--- a/src/librustc_front/intravisit.rs
+++ b/src/librustc_front/intravisit.rs
@@ -45,11 +45,37 @@ pub enum FnKind<'a> {
 /// the substructure of the input via the corresponding `walk` method;
 /// e.g. the `visit_mod` method by default calls `visit::walk_mod`.
 ///
+/// Note that this visitor does NOT visit nested items by default. If
+/// you simply want to visit all items in the crate in some order, you
+/// should call `Crate::visit_all_items`. Otherwise, see the comment
+/// on `visit_nested_item` for details on how to visit nested items.
+///
 /// If you want to ensure that your code handles every variant
 /// explicitly, you need to override each method.  (And you also need
 /// to monitor future changes to `Visitor` in case a new method with a
 /// new default implementation gets introduced.)
 pub trait Visitor<'v> : Sized {
+    ///////////////////////////////////////////////////////////////////////////
+    // Nested items.
+
+    /// Invoked when a nested item is encountered. By default, does
+    /// nothing. If you want a deep walk, you need to override to
+    /// fetch the item contents. But most of the time, it is easier
+    /// (and better) to invoke `Crate::visit_all_items`, which visits
+    /// all items in the crate in some order (but doesn't respect
+    /// nesting).
+    #[allow(unused_variables)]
+    fn visit_nested_item(&mut self, id: ItemId) {
+    }
+
+    /// Visit the top-level item and (optionally) nested items. See
+    /// `visit_nested_item` for details.
+    fn visit_item(&mut self, i: &'v Item) {
+        walk_item(self, i)
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+
     fn visit_name(&mut self, _span: Span, _name: Name) {
         // Nothing to do.
     }
@@ -61,9 +87,6 @@ pub trait Visitor<'v> : Sized {
     }
     fn visit_foreign_item(&mut self, i: &'v ForeignItem) {
         walk_foreign_item(self, i)
-    }
-    fn visit_item(&mut self, i: &'v Item) {
-        walk_item(self, i)
     }
     fn visit_local(&mut self, l: &'v Local) {
         walk_local(self, l)
@@ -180,6 +203,7 @@ pub fn walk_ident<'v, V: Visitor<'v>>(visitor: &mut V, span: Span, ident: Ident)
     visitor.visit_name(span, ident.name);
 }
 
+/// Walks the contents of a crate. See also `Crate::visit_all_items`.
 pub fn walk_crate<'v, V: Visitor<'v>>(visitor: &mut V, krate: &'v Crate) {
     visitor.visit_mod(&krate.module, krate.span, CRATE_NODE_ID);
     walk_list!(visitor, visit_attribute, &krate.attrs);
@@ -193,7 +217,9 @@ pub fn walk_macro_def<'v, V: Visitor<'v>>(visitor: &mut V, macro_def: &'v MacroD
 }
 
 pub fn walk_mod<'v, V: Visitor<'v>>(visitor: &mut V, module: &'v Mod) {
-    walk_list!(visitor, visit_item, &module.items);
+    for &item_id in &module.item_ids {
+        visitor.visit_nested_item(item_id);
+    }
 }
 
 pub fn walk_local<'v, V: Visitor<'v>>(visitor: &mut V, local: &'v Local) {
@@ -658,7 +684,7 @@ pub fn walk_stmt<'v, V: Visitor<'v>>(visitor: &mut V, statement: &'v Stmt) {
 pub fn walk_decl<'v, V: Visitor<'v>>(visitor: &mut V, declaration: &'v Decl) {
     match declaration.node {
         DeclLocal(ref local) => visitor.visit_local(local),
-        DeclItem(ref item) => visitor.visit_item(item),
+        DeclItem(item) => visitor.visit_nested_item(item),
     }
 }
 

--- a/src/librustc_front/lib.rs
+++ b/src/librustc_front/lib.rs
@@ -45,13 +45,14 @@ extern crate syntax;
 #[macro_use]
 #[no_link]
 extern crate rustc_bitflags;
+extern crate rustc_data_structures;
 
 extern crate serialize as rustc_serialize; // used by deriving
 
 pub mod hir;
 pub mod lowering;
 pub mod fold;
-pub mod visit;
+pub mod intravisit;
 pub mod util;
 
 pub mod print {

--- a/src/librustc_front/lib.rs
+++ b/src/librustc_front/lib.rs
@@ -45,7 +45,6 @@ extern crate syntax;
 #[macro_use]
 #[no_link]
 extern crate rustc_bitflags;
-extern crate rustc_data_structures;
 
 extern crate serialize as rustc_serialize; // used by deriving
 

--- a/src/librustc_front/lowering.rs
+++ b/src/librustc_front/lowering.rs
@@ -138,17 +138,17 @@ impl<'a, 'hir> LoweringContext<'a> {
     }
 }
 
-pub fn lower_view_path(_lctx: &LoweringContext, view_path: &ViewPath) -> P<hir::ViewPath> {
+pub fn lower_view_path(lctx: &LoweringContext, view_path: &ViewPath) -> P<hir::ViewPath> {
     P(Spanned {
         node: match view_path.node {
             ViewPathSimple(ident, ref path) => {
-                hir::ViewPathSimple(ident.name, lower_path(_lctx, path))
+                hir::ViewPathSimple(ident.name, lower_path(lctx, path))
             }
             ViewPathGlob(ref path) => {
-                hir::ViewPathGlob(lower_path(_lctx, path))
+                hir::ViewPathGlob(lower_path(lctx, path))
             }
             ViewPathList(ref path, ref path_list_idents) => {
-                hir::ViewPathList(lower_path(_lctx, path),
+                hir::ViewPathList(lower_path(lctx, path),
                                   path_list_idents.iter()
                                                   .map(|path_list_ident| {
                                                       Spanned {
@@ -175,79 +175,79 @@ pub fn lower_view_path(_lctx: &LoweringContext, view_path: &ViewPath) -> P<hir::
     })
 }
 
-pub fn lower_arm(_lctx: &LoweringContext, arm: &Arm) -> hir::Arm {
+pub fn lower_arm(lctx: &LoweringContext, arm: &Arm) -> hir::Arm {
     hir::Arm {
         attrs: arm.attrs.clone(),
-        pats: arm.pats.iter().map(|x| lower_pat(_lctx, x)).collect(),
-        guard: arm.guard.as_ref().map(|ref x| lower_expr(_lctx, x)),
-        body: lower_expr(_lctx, &arm.body),
+        pats: arm.pats.iter().map(|x| lower_pat(lctx, x)).collect(),
+        guard: arm.guard.as_ref().map(|ref x| lower_expr(lctx, x)),
+        body: lower_expr(lctx, &arm.body),
     }
 }
 
-pub fn lower_decl(_lctx: &LoweringContext, d: &Decl) -> P<hir::Decl> {
+pub fn lower_decl(lctx: &LoweringContext, d: &Decl) -> P<hir::Decl> {
     match d.node {
         DeclLocal(ref l) => P(Spanned {
-            node: hir::DeclLocal(lower_local(_lctx, l)),
+            node: hir::DeclLocal(lower_local(lctx, l)),
             span: d.span,
         }),
         DeclItem(ref it) => P(Spanned {
-            node: hir::DeclItem(lower_item(_lctx, it)),
+            node: hir::DeclItem(lower_item(lctx, it)),
             span: d.span,
         }),
     }
 }
 
-pub fn lower_ty_binding(_lctx: &LoweringContext, b: &TypeBinding) -> P<hir::TypeBinding> {
+pub fn lower_ty_binding(lctx: &LoweringContext, b: &TypeBinding) -> P<hir::TypeBinding> {
     P(hir::TypeBinding {
         id: b.id,
         name: b.ident.name,
-        ty: lower_ty(_lctx, &b.ty),
+        ty: lower_ty(lctx, &b.ty),
         span: b.span,
     })
 }
 
-pub fn lower_ty(_lctx: &LoweringContext, t: &Ty) -> P<hir::Ty> {
+pub fn lower_ty(lctx: &LoweringContext, t: &Ty) -> P<hir::Ty> {
     P(hir::Ty {
         id: t.id,
         node: match t.node {
             TyInfer => hir::TyInfer,
-            TyVec(ref ty) => hir::TyVec(lower_ty(_lctx, ty)),
-            TyPtr(ref mt) => hir::TyPtr(lower_mt(_lctx, mt)),
+            TyVec(ref ty) => hir::TyVec(lower_ty(lctx, ty)),
+            TyPtr(ref mt) => hir::TyPtr(lower_mt(lctx, mt)),
             TyRptr(ref region, ref mt) => {
-                hir::TyRptr(lower_opt_lifetime(_lctx, region), lower_mt(_lctx, mt))
+                hir::TyRptr(lower_opt_lifetime(lctx, region), lower_mt(lctx, mt))
             }
             TyBareFn(ref f) => {
                 hir::TyBareFn(P(hir::BareFnTy {
-                    lifetimes: lower_lifetime_defs(_lctx, &f.lifetimes),
-                    unsafety: lower_unsafety(_lctx, f.unsafety),
+                    lifetimes: lower_lifetime_defs(lctx, &f.lifetimes),
+                    unsafety: lower_unsafety(lctx, f.unsafety),
                     abi: f.abi,
-                    decl: lower_fn_decl(_lctx, &f.decl),
+                    decl: lower_fn_decl(lctx, &f.decl),
                 }))
             }
-            TyTup(ref tys) => hir::TyTup(tys.iter().map(|ty| lower_ty(_lctx, ty)).collect()),
+            TyTup(ref tys) => hir::TyTup(tys.iter().map(|ty| lower_ty(lctx, ty)).collect()),
             TyParen(ref ty) => {
-                return lower_ty(_lctx, ty);
+                return lower_ty(lctx, ty);
             }
             TyPath(ref qself, ref path) => {
                 let qself = qself.as_ref().map(|&QSelf { ref ty, position }| {
                     hir::QSelf {
-                        ty: lower_ty(_lctx, ty),
+                        ty: lower_ty(lctx, ty),
                         position: position,
                     }
                 });
-                hir::TyPath(qself, lower_path(_lctx, path))
+                hir::TyPath(qself, lower_path(lctx, path))
             }
             TyObjectSum(ref ty, ref bounds) => {
-                hir::TyObjectSum(lower_ty(_lctx, ty), lower_bounds(_lctx, bounds))
+                hir::TyObjectSum(lower_ty(lctx, ty), lower_bounds(lctx, bounds))
             }
             TyFixedLengthVec(ref ty, ref e) => {
-                hir::TyFixedLengthVec(lower_ty(_lctx, ty), lower_expr(_lctx, e))
+                hir::TyFixedLengthVec(lower_ty(lctx, ty), lower_expr(lctx, e))
             }
             TyTypeof(ref expr) => {
-                hir::TyTypeof(lower_expr(_lctx, expr))
+                hir::TyTypeof(lower_expr(lctx, expr))
             }
             TyPolyTraitRef(ref bounds) => {
-                hir::TyPolyTraitRef(bounds.iter().map(|b| lower_ty_param_bound(_lctx, b)).collect())
+                hir::TyPolyTraitRef(bounds.iter().map(|b| lower_ty_param_bound(lctx, b)).collect())
             }
             TyMac(_) => panic!("TyMac should have been expanded by now."),
         },
@@ -255,26 +255,26 @@ pub fn lower_ty(_lctx: &LoweringContext, t: &Ty) -> P<hir::Ty> {
     })
 }
 
-pub fn lower_foreign_mod(_lctx: &LoweringContext, fm: &ForeignMod) -> hir::ForeignMod {
+pub fn lower_foreign_mod(lctx: &LoweringContext, fm: &ForeignMod) -> hir::ForeignMod {
     hir::ForeignMod {
         abi: fm.abi,
-        items: fm.items.iter().map(|x| lower_foreign_item(_lctx, x)).collect(),
+        items: fm.items.iter().map(|x| lower_foreign_item(lctx, x)).collect(),
     }
 }
 
-pub fn lower_variant(_lctx: &LoweringContext, v: &Variant) -> P<hir::Variant> {
+pub fn lower_variant(lctx: &LoweringContext, v: &Variant) -> P<hir::Variant> {
     P(Spanned {
         node: hir::Variant_ {
             name: v.node.name.name,
             attrs: v.node.attrs.clone(),
-            data: lower_variant_data(_lctx, &v.node.data),
-            disr_expr: v.node.disr_expr.as_ref().map(|e| lower_expr(_lctx, e)),
+            data: lower_variant_data(lctx, &v.node.data),
+            disr_expr: v.node.disr_expr.as_ref().map(|e| lower_expr(lctx, e)),
         },
         span: v.span,
     })
 }
 
-pub fn lower_path(_lctx: &LoweringContext, p: &Path) -> hir::Path {
+pub fn lower_path(lctx: &LoweringContext, p: &Path) -> hir::Path {
     hir::Path {
         global: p.global,
         segments: p.segments
@@ -282,7 +282,7 @@ pub fn lower_path(_lctx: &LoweringContext, p: &Path) -> hir::Path {
                    .map(|&PathSegment { identifier, ref parameters }| {
                        hir::PathSegment {
                            identifier: identifier,
-                           parameters: lower_path_parameters(_lctx, parameters),
+                           parameters: lower_path_parameters(lctx, parameters),
                        }
                    })
                    .collect(),
@@ -290,62 +290,62 @@ pub fn lower_path(_lctx: &LoweringContext, p: &Path) -> hir::Path {
     }
 }
 
-pub fn lower_path_parameters(_lctx: &LoweringContext,
+pub fn lower_path_parameters(lctx: &LoweringContext,
                              path_parameters: &PathParameters)
                              -> hir::PathParameters {
     match *path_parameters {
         AngleBracketedParameters(ref data) =>
-            hir::AngleBracketedParameters(lower_angle_bracketed_parameter_data(_lctx, data)),
+            hir::AngleBracketedParameters(lower_angle_bracketed_parameter_data(lctx, data)),
         ParenthesizedParameters(ref data) =>
-            hir::ParenthesizedParameters(lower_parenthesized_parameter_data(_lctx, data)),
+            hir::ParenthesizedParameters(lower_parenthesized_parameter_data(lctx, data)),
     }
 }
 
-pub fn lower_angle_bracketed_parameter_data(_lctx: &LoweringContext,
+pub fn lower_angle_bracketed_parameter_data(lctx: &LoweringContext,
                                             data: &AngleBracketedParameterData)
                                             -> hir::AngleBracketedParameterData {
     let &AngleBracketedParameterData { ref lifetimes, ref types, ref bindings } = data;
     hir::AngleBracketedParameterData {
-        lifetimes: lower_lifetimes(_lctx, lifetimes),
-        types: types.iter().map(|ty| lower_ty(_lctx, ty)).collect(),
-        bindings: bindings.iter().map(|b| lower_ty_binding(_lctx, b)).collect(),
+        lifetimes: lower_lifetimes(lctx, lifetimes),
+        types: types.iter().map(|ty| lower_ty(lctx, ty)).collect(),
+        bindings: bindings.iter().map(|b| lower_ty_binding(lctx, b)).collect(),
     }
 }
 
-pub fn lower_parenthesized_parameter_data(_lctx: &LoweringContext,
+pub fn lower_parenthesized_parameter_data(lctx: &LoweringContext,
                                           data: &ParenthesizedParameterData)
                                           -> hir::ParenthesizedParameterData {
     let &ParenthesizedParameterData { ref inputs, ref output, span } = data;
     hir::ParenthesizedParameterData {
-        inputs: inputs.iter().map(|ty| lower_ty(_lctx, ty)).collect(),
-        output: output.as_ref().map(|ty| lower_ty(_lctx, ty)),
+        inputs: inputs.iter().map(|ty| lower_ty(lctx, ty)).collect(),
+        output: output.as_ref().map(|ty| lower_ty(lctx, ty)),
         span: span,
     }
 }
 
-pub fn lower_local(_lctx: &LoweringContext, l: &Local) -> P<hir::Local> {
+pub fn lower_local(lctx: &LoweringContext, l: &Local) -> P<hir::Local> {
     P(hir::Local {
         id: l.id,
-        ty: l.ty.as_ref().map(|t| lower_ty(_lctx, t)),
-        pat: lower_pat(_lctx, &l.pat),
-        init: l.init.as_ref().map(|e| lower_expr(_lctx, e)),
+        ty: l.ty.as_ref().map(|t| lower_ty(lctx, t)),
+        pat: lower_pat(lctx, &l.pat),
+        init: l.init.as_ref().map(|e| lower_expr(lctx, e)),
         span: l.span,
     })
 }
 
-pub fn lower_explicit_self_underscore(_lctx: &LoweringContext,
+pub fn lower_explicit_self_underscore(lctx: &LoweringContext,
                                       es: &ExplicitSelf_)
                                       -> hir::ExplicitSelf_ {
     match *es {
         SelfStatic => hir::SelfStatic,
         SelfValue(v) => hir::SelfValue(v.name),
         SelfRegion(ref lifetime, m, ident) => {
-            hir::SelfRegion(lower_opt_lifetime(_lctx, lifetime),
-                            lower_mutability(_lctx, m),
+            hir::SelfRegion(lower_opt_lifetime(lctx, lifetime),
+                            lower_mutability(lctx, m),
                             ident.name)
         }
         SelfExplicit(ref typ, ident) => {
-            hir::SelfExplicit(lower_ty(_lctx, typ), ident.name)
+            hir::SelfExplicit(lower_ty(lctx, typ), ident.name)
         }
     }
 }
@@ -357,26 +357,26 @@ pub fn lower_mutability(_lctx: &LoweringContext, m: Mutability) -> hir::Mutabili
     }
 }
 
-pub fn lower_explicit_self(_lctx: &LoweringContext, s: &ExplicitSelf) -> hir::ExplicitSelf {
+pub fn lower_explicit_self(lctx: &LoweringContext, s: &ExplicitSelf) -> hir::ExplicitSelf {
     Spanned {
-        node: lower_explicit_self_underscore(_lctx, &s.node),
+        node: lower_explicit_self_underscore(lctx, &s.node),
         span: s.span,
     }
 }
 
-pub fn lower_arg(_lctx: &LoweringContext, arg: &Arg) -> hir::Arg {
+pub fn lower_arg(lctx: &LoweringContext, arg: &Arg) -> hir::Arg {
     hir::Arg {
         id: arg.id,
-        pat: lower_pat(_lctx, &arg.pat),
-        ty: lower_ty(_lctx, &arg.ty),
+        pat: lower_pat(lctx, &arg.pat),
+        ty: lower_ty(lctx, &arg.ty),
     }
 }
 
-pub fn lower_fn_decl(_lctx: &LoweringContext, decl: &FnDecl) -> P<hir::FnDecl> {
+pub fn lower_fn_decl(lctx: &LoweringContext, decl: &FnDecl) -> P<hir::FnDecl> {
     P(hir::FnDecl {
-        inputs: decl.inputs.iter().map(|x| lower_arg(_lctx, x)).collect(),
+        inputs: decl.inputs.iter().map(|x| lower_arg(lctx, x)).collect(),
         output: match decl.output {
-            Return(ref ty) => hir::Return(lower_ty(_lctx, ty)),
+            Return(ref ty) => hir::Return(lower_ty(lctx, ty)),
             DefaultReturn(span) => hir::DefaultReturn(span),
             NoReturn(span) => hir::NoReturn(span),
         },
@@ -384,32 +384,32 @@ pub fn lower_fn_decl(_lctx: &LoweringContext, decl: &FnDecl) -> P<hir::FnDecl> {
     })
 }
 
-pub fn lower_ty_param_bound(_lctx: &LoweringContext, tpb: &TyParamBound) -> hir::TyParamBound {
+pub fn lower_ty_param_bound(lctx: &LoweringContext, tpb: &TyParamBound) -> hir::TyParamBound {
     match *tpb {
         TraitTyParamBound(ref ty, modifier) => {
-            hir::TraitTyParamBound(lower_poly_trait_ref(_lctx, ty),
-                                   lower_trait_bound_modifier(_lctx, modifier))
+            hir::TraitTyParamBound(lower_poly_trait_ref(lctx, ty),
+                                   lower_trait_bound_modifier(lctx, modifier))
         }
         RegionTyParamBound(ref lifetime) => {
-            hir::RegionTyParamBound(lower_lifetime(_lctx, lifetime))
+            hir::RegionTyParamBound(lower_lifetime(lctx, lifetime))
         }
     }
 }
 
-pub fn lower_ty_param(_lctx: &LoweringContext, tp: &TyParam) -> hir::TyParam {
+pub fn lower_ty_param(lctx: &LoweringContext, tp: &TyParam) -> hir::TyParam {
     hir::TyParam {
         id: tp.id,
         name: tp.ident.name,
-        bounds: lower_bounds(_lctx, &tp.bounds),
-        default: tp.default.as_ref().map(|x| lower_ty(_lctx, x)),
+        bounds: lower_bounds(lctx, &tp.bounds),
+        default: tp.default.as_ref().map(|x| lower_ty(lctx, x)),
         span: tp.span,
     }
 }
 
-pub fn lower_ty_params(_lctx: &LoweringContext,
+pub fn lower_ty_params(lctx: &LoweringContext,
                        tps: &OwnedSlice<TyParam>)
                        -> OwnedSlice<hir::TyParam> {
-    tps.iter().map(|tp| lower_ty_param(_lctx, tp)).collect()
+    tps.iter().map(|tp| lower_ty_param(lctx, tp)).collect()
 }
 
 pub fn lower_lifetime(_lctx: &LoweringContext, l: &Lifetime) -> hir::Lifetime {
@@ -420,48 +420,48 @@ pub fn lower_lifetime(_lctx: &LoweringContext, l: &Lifetime) -> hir::Lifetime {
     }
 }
 
-pub fn lower_lifetime_def(_lctx: &LoweringContext, l: &LifetimeDef) -> hir::LifetimeDef {
+pub fn lower_lifetime_def(lctx: &LoweringContext, l: &LifetimeDef) -> hir::LifetimeDef {
     hir::LifetimeDef {
-        lifetime: lower_lifetime(_lctx, &l.lifetime),
-        bounds: lower_lifetimes(_lctx, &l.bounds),
+        lifetime: lower_lifetime(lctx, &l.lifetime),
+        bounds: lower_lifetimes(lctx, &l.bounds),
     }
 }
 
-pub fn lower_lifetimes(_lctx: &LoweringContext, lts: &Vec<Lifetime>) -> Vec<hir::Lifetime> {
-    lts.iter().map(|l| lower_lifetime(_lctx, l)).collect()
+pub fn lower_lifetimes(lctx: &LoweringContext, lts: &Vec<Lifetime>) -> Vec<hir::Lifetime> {
+    lts.iter().map(|l| lower_lifetime(lctx, l)).collect()
 }
 
-pub fn lower_lifetime_defs(_lctx: &LoweringContext,
+pub fn lower_lifetime_defs(lctx: &LoweringContext,
                            lts: &Vec<LifetimeDef>)
                            -> Vec<hir::LifetimeDef> {
-    lts.iter().map(|l| lower_lifetime_def(_lctx, l)).collect()
+    lts.iter().map(|l| lower_lifetime_def(lctx, l)).collect()
 }
 
-pub fn lower_opt_lifetime(_lctx: &LoweringContext,
+pub fn lower_opt_lifetime(lctx: &LoweringContext,
                           o_lt: &Option<Lifetime>)
                           -> Option<hir::Lifetime> {
-    o_lt.as_ref().map(|lt| lower_lifetime(_lctx, lt))
+    o_lt.as_ref().map(|lt| lower_lifetime(lctx, lt))
 }
 
-pub fn lower_generics(_lctx: &LoweringContext, g: &Generics) -> hir::Generics {
+pub fn lower_generics(lctx: &LoweringContext, g: &Generics) -> hir::Generics {
     hir::Generics {
-        ty_params: lower_ty_params(_lctx, &g.ty_params),
-        lifetimes: lower_lifetime_defs(_lctx, &g.lifetimes),
-        where_clause: lower_where_clause(_lctx, &g.where_clause),
+        ty_params: lower_ty_params(lctx, &g.ty_params),
+        lifetimes: lower_lifetime_defs(lctx, &g.lifetimes),
+        where_clause: lower_where_clause(lctx, &g.where_clause),
     }
 }
 
-pub fn lower_where_clause(_lctx: &LoweringContext, wc: &WhereClause) -> hir::WhereClause {
+pub fn lower_where_clause(lctx: &LoweringContext, wc: &WhereClause) -> hir::WhereClause {
     hir::WhereClause {
         id: wc.id,
         predicates: wc.predicates
                       .iter()
-                      .map(|predicate| lower_where_predicate(_lctx, predicate))
+                      .map(|predicate| lower_where_predicate(lctx, predicate))
                       .collect(),
     }
 }
 
-pub fn lower_where_predicate(_lctx: &LoweringContext,
+pub fn lower_where_predicate(lctx: &LoweringContext,
                              pred: &WherePredicate)
                              -> hir::WherePredicate {
     match *pred {
@@ -470,9 +470,9 @@ pub fn lower_where_predicate(_lctx: &LoweringContext,
                                                             ref bounds,
                                                             span}) => {
             hir::WherePredicate::BoundPredicate(hir::WhereBoundPredicate {
-                bound_lifetimes: lower_lifetime_defs(_lctx, bound_lifetimes),
-                bounded_ty: lower_ty(_lctx, bounded_ty),
-                bounds: bounds.iter().map(|x| lower_ty_param_bound(_lctx, x)).collect(),
+                bound_lifetimes: lower_lifetime_defs(lctx, bound_lifetimes),
+                bounded_ty: lower_ty(lctx, bounded_ty),
+                bounds: bounds.iter().map(|x| lower_ty_param_bound(lctx, x)).collect(),
                 span: span,
             })
         }
@@ -481,8 +481,8 @@ pub fn lower_where_predicate(_lctx: &LoweringContext,
                                                               span}) => {
             hir::WherePredicate::RegionPredicate(hir::WhereRegionPredicate {
                 span: span,
-                lifetime: lower_lifetime(_lctx, lifetime),
-                bounds: bounds.iter().map(|bound| lower_lifetime(_lctx, bound)).collect(),
+                lifetime: lower_lifetime(lctx, lifetime),
+                bounds: bounds.iter().map(|bound| lower_lifetime(lctx, bound)).collect(),
             })
         }
         WherePredicate::EqPredicate(WhereEqPredicate{ id,
@@ -491,25 +491,25 @@ pub fn lower_where_predicate(_lctx: &LoweringContext,
                                                       span}) => {
             hir::WherePredicate::EqPredicate(hir::WhereEqPredicate {
                 id: id,
-                path: lower_path(_lctx, path),
-                ty: lower_ty(_lctx, ty),
+                path: lower_path(lctx, path),
+                ty: lower_ty(lctx, ty),
                 span: span,
             })
         }
     }
 }
 
-pub fn lower_variant_data(_lctx: &LoweringContext, vdata: &VariantData) -> hir::VariantData {
+pub fn lower_variant_data(lctx: &LoweringContext, vdata: &VariantData) -> hir::VariantData {
     match *vdata {
         VariantData::Struct(ref fields, id) => {
             hir::VariantData::Struct(fields.iter()
-                                           .map(|f| lower_struct_field(_lctx, f))
+                                           .map(|f| lower_struct_field(lctx, f))
                                            .collect(),
                                      id)
         }
         VariantData::Tuple(ref fields, id) => {
             hir::VariantData::Tuple(fields.iter()
-                                          .map(|f| lower_struct_field(_lctx, f))
+                                          .map(|f| lower_struct_field(lctx, f))
                                           .collect(),
                                     id)
         }
@@ -517,129 +517,129 @@ pub fn lower_variant_data(_lctx: &LoweringContext, vdata: &VariantData) -> hir::
     }
 }
 
-pub fn lower_trait_ref(_lctx: &LoweringContext, p: &TraitRef) -> hir::TraitRef {
+pub fn lower_trait_ref(lctx: &LoweringContext, p: &TraitRef) -> hir::TraitRef {
     hir::TraitRef {
-        path: lower_path(_lctx, &p.path),
+        path: lower_path(lctx, &p.path),
         ref_id: p.ref_id,
     }
 }
 
-pub fn lower_poly_trait_ref(_lctx: &LoweringContext, p: &PolyTraitRef) -> hir::PolyTraitRef {
+pub fn lower_poly_trait_ref(lctx: &LoweringContext, p: &PolyTraitRef) -> hir::PolyTraitRef {
     hir::PolyTraitRef {
-        bound_lifetimes: lower_lifetime_defs(_lctx, &p.bound_lifetimes),
-        trait_ref: lower_trait_ref(_lctx, &p.trait_ref),
+        bound_lifetimes: lower_lifetime_defs(lctx, &p.bound_lifetimes),
+        trait_ref: lower_trait_ref(lctx, &p.trait_ref),
         span: p.span,
     }
 }
 
-pub fn lower_struct_field(_lctx: &LoweringContext, f: &StructField) -> hir::StructField {
+pub fn lower_struct_field(lctx: &LoweringContext, f: &StructField) -> hir::StructField {
     Spanned {
         node: hir::StructField_ {
             id: f.node.id,
-            kind: lower_struct_field_kind(_lctx, &f.node.kind),
-            ty: lower_ty(_lctx, &f.node.ty),
+            kind: lower_struct_field_kind(lctx, &f.node.kind),
+            ty: lower_ty(lctx, &f.node.ty),
             attrs: f.node.attrs.clone(),
         },
         span: f.span,
     }
 }
 
-pub fn lower_field(_lctx: &LoweringContext, f: &Field) -> hir::Field {
+pub fn lower_field(lctx: &LoweringContext, f: &Field) -> hir::Field {
     hir::Field {
         name: respan(f.ident.span, f.ident.node.name),
-        expr: lower_expr(_lctx, &f.expr),
+        expr: lower_expr(lctx, &f.expr),
         span: f.span,
     }
 }
 
-pub fn lower_mt(_lctx: &LoweringContext, mt: &MutTy) -> hir::MutTy {
+pub fn lower_mt(lctx: &LoweringContext, mt: &MutTy) -> hir::MutTy {
     hir::MutTy {
-        ty: lower_ty(_lctx, &mt.ty),
-        mutbl: lower_mutability(_lctx, mt.mutbl),
+        ty: lower_ty(lctx, &mt.ty),
+        mutbl: lower_mutability(lctx, mt.mutbl),
     }
 }
 
-pub fn lower_opt_bounds(_lctx: &LoweringContext,
+pub fn lower_opt_bounds(lctx: &LoweringContext,
                         b: &Option<OwnedSlice<TyParamBound>>)
                         -> Option<OwnedSlice<hir::TyParamBound>> {
-    b.as_ref().map(|ref bounds| lower_bounds(_lctx, bounds))
+    b.as_ref().map(|ref bounds| lower_bounds(lctx, bounds))
 }
 
-fn lower_bounds(_lctx: &LoweringContext, bounds: &TyParamBounds) -> hir::TyParamBounds {
-    bounds.iter().map(|bound| lower_ty_param_bound(_lctx, bound)).collect()
+fn lower_bounds(lctx: &LoweringContext, bounds: &TyParamBounds) -> hir::TyParamBounds {
+    bounds.iter().map(|bound| lower_ty_param_bound(lctx, bound)).collect()
 }
 
-pub fn lower_block(_lctx: &LoweringContext, b: &Block) -> P<hir::Block> {
+pub fn lower_block(lctx: &LoweringContext, b: &Block) -> P<hir::Block> {
     P(hir::Block {
         id: b.id,
-        stmts: b.stmts.iter().map(|s| lower_stmt(_lctx, s)).collect(),
-        expr: b.expr.as_ref().map(|ref x| lower_expr(_lctx, x)),
-        rules: lower_block_check_mode(_lctx, &b.rules),
+        stmts: b.stmts.iter().map(|s| lower_stmt(lctx, s)).collect(),
+        expr: b.expr.as_ref().map(|ref x| lower_expr(lctx, x)),
+        rules: lower_block_check_mode(lctx, &b.rules),
         span: b.span,
     })
 }
 
-pub fn lower_item_underscore(_lctx: &LoweringContext, i: &Item_) -> hir::Item_ {
+pub fn lower_item_underscore(lctx: &LoweringContext, i: &Item_) -> hir::Item_ {
     match *i {
         ItemExternCrate(string) => hir::ItemExternCrate(string),
         ItemUse(ref view_path) => {
-            hir::ItemUse(lower_view_path(_lctx, view_path))
+            hir::ItemUse(lower_view_path(lctx, view_path))
         }
         ItemStatic(ref t, m, ref e) => {
-            hir::ItemStatic(lower_ty(_lctx, t),
-                            lower_mutability(_lctx, m),
-                            lower_expr(_lctx, e))
+            hir::ItemStatic(lower_ty(lctx, t),
+                            lower_mutability(lctx, m),
+                            lower_expr(lctx, e))
         }
         ItemConst(ref t, ref e) => {
-            hir::ItemConst(lower_ty(_lctx, t), lower_expr(_lctx, e))
+            hir::ItemConst(lower_ty(lctx, t), lower_expr(lctx, e))
         }
         ItemFn(ref decl, unsafety, constness, abi, ref generics, ref body) => {
-            hir::ItemFn(lower_fn_decl(_lctx, decl),
-                        lower_unsafety(_lctx, unsafety),
-                        lower_constness(_lctx, constness),
+            hir::ItemFn(lower_fn_decl(lctx, decl),
+                        lower_unsafety(lctx, unsafety),
+                        lower_constness(lctx, constness),
                         abi,
-                        lower_generics(_lctx, generics),
-                        lower_block(_lctx, body))
+                        lower_generics(lctx, generics),
+                        lower_block(lctx, body))
         }
-        ItemMod(ref m) => hir::ItemMod(lower_mod(_lctx, m)),
-        ItemForeignMod(ref nm) => hir::ItemForeignMod(lower_foreign_mod(_lctx, nm)),
+        ItemMod(ref m) => hir::ItemMod(lower_mod(lctx, m)),
+        ItemForeignMod(ref nm) => hir::ItemForeignMod(lower_foreign_mod(lctx, nm)),
         ItemTy(ref t, ref generics) => {
-            hir::ItemTy(lower_ty(_lctx, t), lower_generics(_lctx, generics))
+            hir::ItemTy(lower_ty(lctx, t), lower_generics(lctx, generics))
         }
         ItemEnum(ref enum_definition, ref generics) => {
             hir::ItemEnum(hir::EnumDef {
                               variants: enum_definition.variants
                                                        .iter()
-                                                       .map(|x| lower_variant(_lctx, x))
+                                                       .map(|x| lower_variant(lctx, x))
                                                        .collect(),
                           },
-                          lower_generics(_lctx, generics))
+                          lower_generics(lctx, generics))
         }
         ItemStruct(ref struct_def, ref generics) => {
-            let struct_def = lower_variant_data(_lctx, struct_def);
-            hir::ItemStruct(struct_def, lower_generics(_lctx, generics))
+            let struct_def = lower_variant_data(lctx, struct_def);
+            hir::ItemStruct(struct_def, lower_generics(lctx, generics))
         }
         ItemDefaultImpl(unsafety, ref trait_ref) => {
-            hir::ItemDefaultImpl(lower_unsafety(_lctx, unsafety),
-                                 lower_trait_ref(_lctx, trait_ref))
+            hir::ItemDefaultImpl(lower_unsafety(lctx, unsafety),
+                                 lower_trait_ref(lctx, trait_ref))
         }
         ItemImpl(unsafety, polarity, ref generics, ref ifce, ref ty, ref impl_items) => {
             let new_impl_items = impl_items.iter()
-                                           .map(|item| lower_impl_item(_lctx, item))
+                                           .map(|item| lower_impl_item(lctx, item))
                                            .collect();
-            let ifce = ifce.as_ref().map(|trait_ref| lower_trait_ref(_lctx, trait_ref));
-            hir::ItemImpl(lower_unsafety(_lctx, unsafety),
-                          lower_impl_polarity(_lctx, polarity),
-                          lower_generics(_lctx, generics),
+            let ifce = ifce.as_ref().map(|trait_ref| lower_trait_ref(lctx, trait_ref));
+            hir::ItemImpl(lower_unsafety(lctx, unsafety),
+                          lower_impl_polarity(lctx, polarity),
+                          lower_generics(lctx, generics),
                           ifce,
-                          lower_ty(_lctx, ty),
+                          lower_ty(lctx, ty),
                           new_impl_items)
         }
         ItemTrait(unsafety, ref generics, ref bounds, ref items) => {
-            let bounds = lower_bounds(_lctx, bounds);
-            let items = items.iter().map(|item| lower_trait_item(_lctx, item)).collect();
-            hir::ItemTrait(lower_unsafety(_lctx, unsafety),
-                           lower_generics(_lctx, generics),
+            let bounds = lower_bounds(lctx, bounds);
+            let items = items.iter().map(|item| lower_trait_item(lctx, item)).collect();
+            hir::ItemTrait(lower_unsafety(lctx, unsafety),
+                           lower_generics(lctx, generics),
                            bounds,
                            items)
         }
@@ -647,63 +647,63 @@ pub fn lower_item_underscore(_lctx: &LoweringContext, i: &Item_) -> hir::Item_ {
     }
 }
 
-pub fn lower_trait_item(_lctx: &LoweringContext, i: &TraitItem) -> P<hir::TraitItem> {
+pub fn lower_trait_item(lctx: &LoweringContext, i: &TraitItem) -> P<hir::TraitItem> {
     P(hir::TraitItem {
         id: i.id,
         name: i.ident.name,
         attrs: i.attrs.clone(),
         node: match i.node {
             ConstTraitItem(ref ty, ref default) => {
-                hir::ConstTraitItem(lower_ty(_lctx, ty),
-                                    default.as_ref().map(|x| lower_expr(_lctx, x)))
+                hir::ConstTraitItem(lower_ty(lctx, ty),
+                                    default.as_ref().map(|x| lower_expr(lctx, x)))
             }
             MethodTraitItem(ref sig, ref body) => {
-                hir::MethodTraitItem(lower_method_sig(_lctx, sig),
-                                     body.as_ref().map(|x| lower_block(_lctx, x)))
+                hir::MethodTraitItem(lower_method_sig(lctx, sig),
+                                     body.as_ref().map(|x| lower_block(lctx, x)))
             }
             TypeTraitItem(ref bounds, ref default) => {
-                hir::TypeTraitItem(lower_bounds(_lctx, bounds),
-                                   default.as_ref().map(|x| lower_ty(_lctx, x)))
+                hir::TypeTraitItem(lower_bounds(lctx, bounds),
+                                   default.as_ref().map(|x| lower_ty(lctx, x)))
             }
         },
         span: i.span,
     })
 }
 
-pub fn lower_impl_item(_lctx: &LoweringContext, i: &ImplItem) -> P<hir::ImplItem> {
+pub fn lower_impl_item(lctx: &LoweringContext, i: &ImplItem) -> P<hir::ImplItem> {
     P(hir::ImplItem {
         id: i.id,
         name: i.ident.name,
         attrs: i.attrs.clone(),
-        vis: lower_visibility(_lctx, i.vis),
+        vis: lower_visibility(lctx, i.vis),
         node: match i.node {
             ImplItemKind::Const(ref ty, ref expr) => {
-                hir::ImplItemKind::Const(lower_ty(_lctx, ty), lower_expr(_lctx, expr))
+                hir::ImplItemKind::Const(lower_ty(lctx, ty), lower_expr(lctx, expr))
             }
             ImplItemKind::Method(ref sig, ref body) => {
-                hir::ImplItemKind::Method(lower_method_sig(_lctx, sig), lower_block(_lctx, body))
+                hir::ImplItemKind::Method(lower_method_sig(lctx, sig), lower_block(lctx, body))
             }
-            ImplItemKind::Type(ref ty) => hir::ImplItemKind::Type(lower_ty(_lctx, ty)),
+            ImplItemKind::Type(ref ty) => hir::ImplItemKind::Type(lower_ty(lctx, ty)),
             ImplItemKind::Macro(..) => panic!("Shouldn't exist any more"),
         },
         span: i.span,
     })
 }
 
-pub fn lower_mod(_lctx: &LoweringContext, m: &Mod) -> hir::Mod {
+pub fn lower_mod(lctx: &LoweringContext, m: &Mod) -> hir::Mod {
     hir::Mod {
         inner: m.inner,
-        items: m.items.iter().map(|x| lower_item(_lctx, x)).collect(),
+        items: m.items.iter().map(|x| lower_item(lctx, x)).collect(),
     }
 }
 
-pub fn lower_crate(_lctx: &LoweringContext, c: &Crate) -> hir::Crate {
+pub fn lower_crate(lctx: &LoweringContext, c: &Crate) -> hir::Crate {
     hir::Crate {
-        module: lower_mod(_lctx, &c.module),
+        module: lower_mod(lctx, &c.module),
         attrs: c.attrs.clone(),
         config: c.config.clone(),
         span: c.span,
-        exported_macros: c.exported_macros.iter().map(|m| lower_macro_def(_lctx, m)).collect(),
+        exported_macros: c.exported_macros.iter().map(|m| lower_macro_def(lctx, m)).collect(),
     }
 }
 
@@ -722,50 +722,50 @@ pub fn lower_macro_def(_lctx: &LoweringContext, m: &MacroDef) -> hir::MacroDef {
 }
 
 // fold one item into possibly many items
-pub fn lower_item(_lctx: &LoweringContext, i: &Item) -> P<hir::Item> {
-    P(lower_item_simple(_lctx, i))
+pub fn lower_item(lctx: &LoweringContext, i: &Item) -> P<hir::Item> {
+    P(lower_item_simple(lctx, i))
 }
 
 // fold one item into exactly one item
-pub fn lower_item_simple(_lctx: &LoweringContext, i: &Item) -> hir::Item {
-    let node = lower_item_underscore(_lctx, &i.node);
+pub fn lower_item_simple(lctx: &LoweringContext, i: &Item) -> hir::Item {
+    let node = lower_item_underscore(lctx, &i.node);
 
     hir::Item {
         id: i.id,
         name: i.ident.name,
         attrs: i.attrs.clone(),
         node: node,
-        vis: lower_visibility(_lctx, i.vis),
+        vis: lower_visibility(lctx, i.vis),
         span: i.span,
     }
 }
 
-pub fn lower_foreign_item(_lctx: &LoweringContext, i: &ForeignItem) -> P<hir::ForeignItem> {
+pub fn lower_foreign_item(lctx: &LoweringContext, i: &ForeignItem) -> P<hir::ForeignItem> {
     P(hir::ForeignItem {
         id: i.id,
         name: i.ident.name,
         attrs: i.attrs.clone(),
         node: match i.node {
             ForeignItemFn(ref fdec, ref generics) => {
-                hir::ForeignItemFn(lower_fn_decl(_lctx, fdec), lower_generics(_lctx, generics))
+                hir::ForeignItemFn(lower_fn_decl(lctx, fdec), lower_generics(lctx, generics))
             }
             ForeignItemStatic(ref t, m) => {
-                hir::ForeignItemStatic(lower_ty(_lctx, t), m)
+                hir::ForeignItemStatic(lower_ty(lctx, t), m)
             }
         },
-        vis: lower_visibility(_lctx, i.vis),
+        vis: lower_visibility(lctx, i.vis),
         span: i.span,
     })
 }
 
-pub fn lower_method_sig(_lctx: &LoweringContext, sig: &MethodSig) -> hir::MethodSig {
+pub fn lower_method_sig(lctx: &LoweringContext, sig: &MethodSig) -> hir::MethodSig {
     hir::MethodSig {
-        generics: lower_generics(_lctx, &sig.generics),
+        generics: lower_generics(lctx, &sig.generics),
         abi: sig.abi,
-        explicit_self: lower_explicit_self(_lctx, &sig.explicit_self),
-        unsafety: lower_unsafety(_lctx, sig.unsafety),
-        constness: lower_constness(_lctx, sig.constness),
-        decl: lower_fn_decl(_lctx, &sig.decl),
+        explicit_self: lower_explicit_self(lctx, &sig.explicit_self),
+        unsafety: lower_unsafety(lctx, sig.unsafety),
+        constness: lower_constness(lctx, sig.constness),
+        decl: lower_fn_decl(lctx, &sig.decl),
     }
 }
 
@@ -817,38 +817,38 @@ pub fn lower_binop(_lctx: &LoweringContext, b: BinOp) -> hir::BinOp {
     }
 }
 
-pub fn lower_pat(_lctx: &LoweringContext, p: &Pat) -> P<hir::Pat> {
+pub fn lower_pat(lctx: &LoweringContext, p: &Pat) -> P<hir::Pat> {
     P(hir::Pat {
         id: p.id,
         node: match p.node {
             PatWild => hir::PatWild,
             PatIdent(ref binding_mode, pth1, ref sub) => {
-                hir::PatIdent(lower_binding_mode(_lctx, binding_mode),
+                hir::PatIdent(lower_binding_mode(lctx, binding_mode),
                               pth1,
-                              sub.as_ref().map(|x| lower_pat(_lctx, x)))
+                              sub.as_ref().map(|x| lower_pat(lctx, x)))
             }
-            PatLit(ref e) => hir::PatLit(lower_expr(_lctx, e)),
+            PatLit(ref e) => hir::PatLit(lower_expr(lctx, e)),
             PatEnum(ref pth, ref pats) => {
-                hir::PatEnum(lower_path(_lctx, pth),
+                hir::PatEnum(lower_path(lctx, pth),
                              pats.as_ref()
-                                 .map(|pats| pats.iter().map(|x| lower_pat(_lctx, x)).collect()))
+                                 .map(|pats| pats.iter().map(|x| lower_pat(lctx, x)).collect()))
             }
             PatQPath(ref qself, ref pth) => {
                 let qself = hir::QSelf {
-                    ty: lower_ty(_lctx, &qself.ty),
+                    ty: lower_ty(lctx, &qself.ty),
                     position: qself.position,
                 };
-                hir::PatQPath(qself, lower_path(_lctx, pth))
+                hir::PatQPath(qself, lower_path(lctx, pth))
             }
             PatStruct(ref pth, ref fields, etc) => {
-                let pth = lower_path(_lctx, pth);
+                let pth = lower_path(lctx, pth);
                 let fs = fields.iter()
                                .map(|f| {
                                    Spanned {
                                        span: f.span,
                                        node: hir::FieldPat {
                                            name: f.node.ident.name,
-                                           pat: lower_pat(_lctx, &f.node.pat),
+                                           pat: lower_pat(lctx, &f.node.pat),
                                            is_shorthand: f.node.is_shorthand,
                                        },
                                    }
@@ -856,18 +856,18 @@ pub fn lower_pat(_lctx: &LoweringContext, p: &Pat) -> P<hir::Pat> {
                                .collect();
                 hir::PatStruct(pth, fs, etc)
             }
-            PatTup(ref elts) => hir::PatTup(elts.iter().map(|x| lower_pat(_lctx, x)).collect()),
-            PatBox(ref inner) => hir::PatBox(lower_pat(_lctx, inner)),
+            PatTup(ref elts) => hir::PatTup(elts.iter().map(|x| lower_pat(lctx, x)).collect()),
+            PatBox(ref inner) => hir::PatBox(lower_pat(lctx, inner)),
             PatRegion(ref inner, mutbl) => {
-                hir::PatRegion(lower_pat(_lctx, inner), lower_mutability(_lctx, mutbl))
+                hir::PatRegion(lower_pat(lctx, inner), lower_mutability(lctx, mutbl))
             }
             PatRange(ref e1, ref e2) => {
-                hir::PatRange(lower_expr(_lctx, e1), lower_expr(_lctx, e2))
+                hir::PatRange(lower_expr(lctx, e1), lower_expr(lctx, e2))
             }
             PatVec(ref before, ref slice, ref after) => {
-                hir::PatVec(before.iter().map(|x| lower_pat(_lctx, x)).collect(),
-                            slice.as_ref().map(|x| lower_pat(_lctx, x)),
-                            after.iter().map(|x| lower_pat(_lctx, x)).collect())
+                hir::PatVec(before.iter().map(|x| lower_pat(lctx, x)).collect(),
+                            slice.as_ref().map(|x| lower_pat(lctx, x)),
+                            after.iter().map(|x| lower_pat(lctx, x)).collect())
             }
             PatMac(_) => panic!("Shouldn't exist here"),
         },
@@ -1434,23 +1434,23 @@ pub fn lower_expr(lctx: &LoweringContext, e: &Expr) -> P<hir::Expr> {
     })
 }
 
-pub fn lower_stmt(_lctx: &LoweringContext, s: &Stmt) -> P<hir::Stmt> {
+pub fn lower_stmt(lctx: &LoweringContext, s: &Stmt) -> P<hir::Stmt> {
     match s.node {
         StmtDecl(ref d, id) => {
             P(Spanned {
-                node: hir::StmtDecl(lower_decl(_lctx, d), id),
+                node: hir::StmtDecl(lower_decl(lctx, d), id),
                 span: s.span,
             })
         }
         StmtExpr(ref e, id) => {
             P(Spanned {
-                node: hir::StmtExpr(lower_expr(_lctx, e), id),
+                node: hir::StmtExpr(lower_expr(lctx, e), id),
                 span: s.span,
             })
         }
         StmtSemi(ref e, id) => {
             P(Spanned {
-                node: hir::StmtSemi(lower_expr(_lctx, e), id),
+                node: hir::StmtSemi(lower_expr(lctx, e), id),
                 span: s.span,
             })
         }
@@ -1472,26 +1472,26 @@ pub fn lower_visibility(_lctx: &LoweringContext, v: Visibility) -> hir::Visibili
     }
 }
 
-pub fn lower_block_check_mode(_lctx: &LoweringContext, b: &BlockCheckMode) -> hir::BlockCheckMode {
+pub fn lower_block_check_mode(lctx: &LoweringContext, b: &BlockCheckMode) -> hir::BlockCheckMode {
     match *b {
         DefaultBlock => hir::DefaultBlock,
-        UnsafeBlock(u) => hir::UnsafeBlock(lower_unsafe_source(_lctx, u)),
+        UnsafeBlock(u) => hir::UnsafeBlock(lower_unsafe_source(lctx, u)),
     }
 }
 
-pub fn lower_binding_mode(_lctx: &LoweringContext, b: &BindingMode) -> hir::BindingMode {
+pub fn lower_binding_mode(lctx: &LoweringContext, b: &BindingMode) -> hir::BindingMode {
     match *b {
-        BindByRef(m) => hir::BindByRef(lower_mutability(_lctx, m)),
-        BindByValue(m) => hir::BindByValue(lower_mutability(_lctx, m)),
+        BindByRef(m) => hir::BindByRef(lower_mutability(lctx, m)),
+        BindByValue(m) => hir::BindByValue(lower_mutability(lctx, m)),
     }
 }
 
-pub fn lower_struct_field_kind(_lctx: &LoweringContext,
+pub fn lower_struct_field_kind(lctx: &LoweringContext,
                                s: &StructFieldKind)
                                -> hir::StructFieldKind {
     match *s {
-        NamedField(ident, vis) => hir::NamedField(ident.name, lower_visibility(_lctx, vis)),
-        UnnamedField(vis) => hir::UnnamedField(lower_visibility(_lctx, vis)),
+        NamedField(ident, vis) => hir::NamedField(ident.name, lower_visibility(lctx, vis)),
+        UnnamedField(vis) => hir::UnnamedField(lower_visibility(lctx, vis)),
     }
 }
 
@@ -1734,11 +1734,12 @@ fn signal_block_expr(lctx: &LoweringContext,
                      span: Span,
                      rule: hir::BlockCheckMode)
                      -> P<hir::Expr> {
+    let id = lctx.next_id();
     expr_block(lctx,
                P(hir::Block {
                    rules: rule,
                    span: span,
-                   id: lctx.next_id(),
+                   id: id,
                    stmts: stmts,
                    expr: Some(expr),
                }))

--- a/src/librustc_front/lowering.rs
+++ b/src/librustc_front/lowering.rs
@@ -63,8 +63,8 @@
 
 use hir;
 
+use std::collections::BTreeMap;
 use std::collections::HashMap;
-
 use syntax::ast::*;
 use syntax::ptr::P;
 use syntax::codemap::{respan, Spanned, Span};
@@ -72,7 +72,6 @@ use syntax::owned_slice::OwnedSlice;
 use syntax::parse::token::{self, str_to_ident};
 use syntax::std_inject;
 use syntax::visit::{self, Visitor};
-use rustc_data_structures::fnv::FnvHashMap;
 
 use std::cell::{Cell, RefCell};
 
@@ -700,7 +699,7 @@ pub fn lower_mod(lctx: &LoweringContext, m: &Mod) -> hir::Mod {
 }
 
 struct ItemLowerer<'lcx, 'interner: 'lcx> {
-    items: FnvHashMap<NodeId, hir::Item>,
+    items: BTreeMap<NodeId, hir::Item>,
     lctx: &'lcx LoweringContext<'interner>,
 }
 
@@ -713,7 +712,7 @@ impl<'lcx, 'interner> Visitor<'lcx> for ItemLowerer<'lcx, 'interner> {
 
 pub fn lower_crate(lctx: &LoweringContext, c: &Crate) -> hir::Crate {
     let items = {
-        let mut item_lowerer = ItemLowerer { items: FnvHashMap(), lctx: lctx };
+        let mut item_lowerer = ItemLowerer { items: BTreeMap::new(), lctx: lctx };
         visit::walk_crate(&mut item_lowerer, c);
         item_lowerer.items
     };

--- a/src/librustc_front/print/pprust.rs
+++ b/src/librustc_front/print/pprust.rs
@@ -91,7 +91,10 @@ pub fn rust_printer<'a>(writer: Box<Write + 'a>, krate: Option<&'a Crate>) -> St
     rust_printer_annotated(writer, &NO_ANN, krate)
 }
 
-pub fn rust_printer_annotated<'a>(writer: Box<Write + 'a>, ann: &'a PpAnn, krate: Option<&'a Crate>) -> State<'a> {
+pub fn rust_printer_annotated<'a>(writer: Box<Write + 'a>,
+                                  ann: &'a PpAnn,
+                                  krate: Option<&'a Crate>)
+                                  -> State<'a> {
     State {
         krate: krate,
         s: pp::mk_printer(writer, default_columns),
@@ -126,7 +129,8 @@ pub fn print_crate<'a>(cm: &'a CodeMap,
                        ann: &'a PpAnn,
                        is_expanded: bool)
                        -> io::Result<()> {
-    let mut s = State::new_from_input(cm, span_diagnostic, filename, input, out, ann, is_expanded, Some(krate));
+    let mut s = State::new_from_input(cm, span_diagnostic, filename, input,
+                                      out, ann, is_expanded, Some(krate));
 
     // When printing the AST, we sometimes need to inject `#[no_std]` here.
     // Since you can't compile the HIR, it's not necessary.

--- a/src/librustc_front/print/pprust.rs
+++ b/src/librustc_front/print/pprust.rs
@@ -25,7 +25,7 @@ use syntax::print::pprust::{self as ast_pp, PrintState};
 use syntax::ptr::P;
 
 use hir;
-use hir::{RegionTyParamBound, TraitTyParamBound, TraitBoundModifier};
+use hir::{Crate, RegionTyParamBound, TraitTyParamBound, TraitBoundModifier};
 
 use std::io::{self, Write, Read};
 
@@ -54,6 +54,7 @@ impl PpAnn for NoAnn {}
 
 
 pub struct State<'a> {
+    krate: Option<&'a Crate>,
     pub s: pp::Printer<'a>,
     cm: Option<&'a CodeMap>,
     comments: Option<Vec<comments::Comment>>,
@@ -85,13 +86,14 @@ impl<'a> PrintState<'a> for State<'a> {
     }
 }
 
-pub fn rust_printer<'a>(writer: Box<Write + 'a>) -> State<'a> {
+pub fn rust_printer<'a>(writer: Box<Write + 'a>, krate: Option<&'a Crate>) -> State<'a> {
     static NO_ANN: NoAnn = NoAnn;
-    rust_printer_annotated(writer, &NO_ANN)
+    rust_printer_annotated(writer, &NO_ANN, krate)
 }
 
-pub fn rust_printer_annotated<'a>(writer: Box<Write + 'a>, ann: &'a PpAnn) -> State<'a> {
+pub fn rust_printer_annotated<'a>(writer: Box<Write + 'a>, ann: &'a PpAnn, krate: Option<&'a Crate>) -> State<'a> {
     State {
+        krate: krate,
         s: pp::mk_printer(writer, default_columns),
         cm: None,
         comments: None,
@@ -124,7 +126,7 @@ pub fn print_crate<'a>(cm: &'a CodeMap,
                        ann: &'a PpAnn,
                        is_expanded: bool)
                        -> io::Result<()> {
-    let mut s = State::new_from_input(cm, span_diagnostic, filename, input, out, ann, is_expanded);
+    let mut s = State::new_from_input(cm, span_diagnostic, filename, input, out, ann, is_expanded, Some(krate));
 
     // When printing the AST, we sometimes need to inject `#[no_std]` here.
     // Since you can't compile the HIR, it's not necessary.
@@ -141,7 +143,8 @@ impl<'a> State<'a> {
                           input: &mut Read,
                           out: Box<Write + 'a>,
                           ann: &'a PpAnn,
-                          is_expanded: bool)
+                          is_expanded: bool,
+                          krate: Option<&'a Crate>)
                           -> State<'a> {
         let (cmnts, lits) = comments::gather_comments_and_literals(span_diagnostic,
                                                                    filename,
@@ -158,16 +161,19 @@ impl<'a> State<'a> {
                        None
                    } else {
                        Some(lits)
-                   })
+                   },
+                   krate)
     }
 
     pub fn new(cm: &'a CodeMap,
                out: Box<Write + 'a>,
                ann: &'a PpAnn,
                comments: Option<Vec<comments::Comment>>,
-               literals: Option<Vec<comments::Literal>>)
+               literals: Option<Vec<comments::Literal>>,
+               krate: Option<&'a Crate>)
                -> State<'a> {
         State {
+            krate: krate,
             s: pp::mk_printer(out, default_columns),
             cm: Some(cm),
             comments: comments.clone(),
@@ -187,7 +193,7 @@ pub fn to_string<F>(f: F) -> String
 {
     let mut wr = Vec::new();
     {
-        let mut printer = rust_printer(Box::new(&mut wr));
+        let mut printer = rust_printer(Box::new(&mut wr), None);
         f(&mut printer).unwrap();
         eof(&mut printer.s).unwrap();
     }
@@ -451,8 +457,8 @@ impl<'a> State<'a> {
 
     pub fn print_mod(&mut self, _mod: &hir::Mod, attrs: &[ast::Attribute]) -> io::Result<()> {
         try!(self.print_inner_attributes(attrs));
-        for item in &_mod.items {
-            try!(self.print_item(&**item));
+        for item_id in &_mod.item_ids {
+            try!(self.print_item_id(item_id));
         }
         Ok(())
     }
@@ -618,6 +624,16 @@ impl<'a> State<'a> {
             try!(self.print_type(ty));
         }
         word(&mut self.s, ";")
+    }
+
+    pub fn print_item_id(&mut self, item_id: &hir::ItemId) -> io::Result<()> {
+        if let Some(krate) = self.krate {
+            // skip nested items if krate context was not provided
+            let item = &krate.items[&item_id.id];
+            self.print_item(item)
+        } else {
+            Ok(())
+        }
     }
 
     /// Pretty-print an item
@@ -1566,7 +1582,9 @@ impl<'a> State<'a> {
                 }
                 self.end()
             }
-            hir::DeclItem(ref item) => self.print_item(&**item),
+            hir::DeclItem(ref item) => {
+                self.print_item_id(item)
+            }
         }
     }
 

--- a/src/librustc_lint/bad_style.rs
+++ b/src/librustc_lint/bad_style.rs
@@ -18,7 +18,7 @@ use syntax::attr::{self, AttrMetaMethods};
 use syntax::codemap::Span;
 
 use rustc_front::hir;
-use rustc_front::visit::FnKind;
+use rustc_front::intravisit::FnKind;
 
 #[derive(PartialEq)]
 pub enum MethodLateContext {

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -46,7 +46,7 @@ use syntax::attr::{self, AttrMetaMethods};
 use syntax::codemap::{self, Span};
 
 use rustc_front::hir;
-use rustc_front::visit::FnKind;
+use rustc_front::intravisit::FnKind;
 
 use bad_style::{MethodLateContext, method_context};
 

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -28,7 +28,7 @@ use syntax::feature_gate::{emit_feature_err, GateIssue};
 use syntax::ast::{TyIs, TyUs, TyI8, TyU8, TyI16, TyU16, TyI32, TyU32, TyI64, TyU64};
 
 use rustc_front::hir;
-use rustc_front::visit::{self, Visitor};
+use rustc_front::intravisit::{self, Visitor};
 use rustc_front::util::is_shift_binop;
 
 declare_lint! {
@@ -626,7 +626,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for ImproperCTypesVisitor<'a, 'tcx> {
                     "found Rust tuple type in foreign module; \
                      consider using a struct instead`")
             }
-            _ => visit::walk_ty(self, ty)
+            _ => intravisit::walk_ty(self, ty)
         }
     }
 }

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -27,7 +27,7 @@ use syntax::ptr::P;
 
 use rustc_back::slice;
 use rustc_front::hir;
-use rustc_front::visit::FnKind;
+use rustc_front::intravisit::FnKind;
 
 declare_lint! {
     pub UNUSED_MUT,

--- a/src/librustc_resolve/check_unused.rs
+++ b/src/librustc_resolve/check_unused.rs
@@ -29,7 +29,7 @@ use syntax::codemap::{Span, DUMMY_SP};
 
 use rustc_front::hir;
 use rustc_front::hir::{ViewPathGlob, ViewPathList, ViewPathSimple};
-use rustc_front::visit::{self, Visitor};
+use rustc_front::intravisit::Visitor;
 
 struct UnusedImportCheckVisitor<'a, 'b: 'a, 'tcx: 'b> {
     resolver: &'a mut Resolver<'b, 'tcx>,
@@ -118,7 +118,6 @@ impl<'a, 'b, 'v, 'tcx> Visitor<'v> for UnusedImportCheckVisitor<'a, 'b, 'tcx> {
         // because this means that they were generated in some fashion by the
         // compiler and we don't need to consider them.
         if item.vis == hir::Public || item.span == DUMMY_SP {
-            visit::walk_item(self, item);
             return;
         }
 
@@ -158,12 +157,10 @@ impl<'a, 'b, 'v, 'tcx> Visitor<'v> for UnusedImportCheckVisitor<'a, 'b, 'tcx> {
             }
             _ => {}
         }
-
-        visit::walk_item(self, item);
     }
 }
 
 pub fn check_crate(resolver: &mut Resolver, krate: &hir::Crate) {
     let mut visitor = UnusedImportCheckVisitor { resolver: resolver };
-    visit::walk_crate(&mut visitor, krate);
+    krate.visit_all_items(&mut visitor);
 }

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -100,8 +100,7 @@ use syntax::parse::token::InternedString;
 use syntax::attr::AttrMetaMethods;
 use syntax::attr;
 use rustc_front;
-use rustc_front::visit::Visitor;
-use rustc_front::visit;
+use rustc_front::intravisit::{self, Visitor};
 use rustc_front::hir;
 use syntax::ast;
 
@@ -1300,7 +1299,7 @@ impl<'v> Visitor<'v> for FindNestedReturn {
             hir::ExprRet(..) => {
                 self.found = true;
             }
-            _ => visit::walk_expr(self, e)
+            _ => intravisit::walk_expr(self, e)
         }
     }
 }
@@ -1369,7 +1368,7 @@ fn has_nested_returns(tcx: &ty::ctxt, cfg: &cfg::CFG, blk_id: ast::NodeId) -> bo
             Some(hir_map::NodeExpr(ex)) => {
                 if let hir::ExprRet(Some(ref ret_expr)) = ex.node {
                     let mut visitor = FindNestedReturn::new();
-                    visit::walk_expr(&mut visitor, &**ret_expr);
+                    intravisit::walk_expr(&mut visitor, &**ret_expr);
                     if visitor.found {
                         return true;
                     }
@@ -2302,11 +2301,6 @@ pub fn trans_item(ccx: &CrateContext, item: &hir::Item) {
                 }
             }
         }
-
-        // Be sure to travel more than just one layer deep to catch nested
-        // items in blocks and such.
-        let mut v = TransItemVisitor{ ccx: ccx };
-        v.visit_block(&**body);
       }
       hir::ItemImpl(_, _, ref generics, _, _, ref impl_items) => {
         meth::trans_impl(ccx,
@@ -2315,8 +2309,9 @@ pub fn trans_item(ccx: &CrateContext, item: &hir::Item) {
                          generics,
                          item.id);
       }
-      hir::ItemMod(ref m) => {
-        trans_mod(&ccx.rotate(), m);
+      hir::ItemMod(_) => {
+          // modules have no equivalent at runtime, they just affect
+          // the mangled names of things contained within
       }
       hir::ItemEnum(ref enum_definition, ref gens) => {
         if gens.ty_params.is_empty() {
@@ -2325,16 +2320,9 @@ pub fn trans_item(ccx: &CrateContext, item: &hir::Item) {
             enum_variant_size_lint(ccx, enum_definition, item.span, item.id);
         }
       }
-      hir::ItemConst(_, ref expr) => {
-          // Recurse on the expression to catch items in blocks
-          let mut v = TransItemVisitor{ ccx: ccx };
-          v.visit_expr(&**expr);
+      hir::ItemConst(..) => {
       }
       hir::ItemStatic(_, m, ref expr) => {
-          // Recurse on the expression to catch items in blocks
-          let mut v = TransItemVisitor{ ccx: ccx };
-          v.visit_expr(&**expr);
-
           let g = match consts::trans_static(ccx, m, expr, item.id, &item.attrs) {
               Ok(g) => g,
               Err(err) => ccx.tcx().sess.span_fatal(expr.span, &err.description()),
@@ -2346,29 +2334,10 @@ pub fn trans_item(ccx: &CrateContext, item: &hir::Item) {
         foreign::trans_foreign_mod(ccx, foreign_mod);
       }
       hir::ItemTrait(..) => {
-        // Inside of this trait definition, we won't be actually translating any
-        // functions, but the trait still needs to be walked. Otherwise default
-        // methods with items will not get translated and will cause ICE's when
-        // metadata time comes around.
-        let mut v = TransItemVisitor{ ccx: ccx };
-        visit::walk_item(&mut v, item);
       }
       _ => {/* fall through */ }
     }
 }
-
-// Translate a module. Doing this amounts to translating the items in the
-// module; there ends up being no artifact (aside from linkage names) of
-// separate modules in the compiled program.  That's because modules exist
-// only as a convenience for humans working with the code, to organize names
-// and control visibility.
-pub fn trans_mod(ccx: &CrateContext, m: &hir::Mod) {
-    let _icx = push_ctxt("trans_mod");
-    for item in &m.items {
-        trans_item(ccx, &**item);
-    }
-}
-
 
 // only use this for foreign function ABIs and glue, use `register_fn` for Rust functions
 pub fn register_fn_llvmty(ccx: &CrateContext,
@@ -2994,10 +2963,10 @@ pub fn trans_crate<'tcx>(tcx: &ty::ctxt<'tcx>,
         // First, verify intrinsics.
         intrinsic::check_intrinsics(&ccx);
 
-        // Next, translate the module.
+        // Next, translate all items.
         {
             let _icx = push_ctxt("text");
-            trans_mod(&ccx, &krate.module);
+            krate.visit_all_items(&mut TransItemVisitor { ccx: &ccx });
         }
     }
 

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -43,7 +43,6 @@ use syntax::attr;
 use syntax::codemap::DUMMY_SP;
 use syntax::ptr::P;
 
-use rustc_front::visit;
 use rustc_front::hir;
 
 // drop_glue pointer, size, align.
@@ -63,21 +62,12 @@ pub fn trans_impl(ccx: &CrateContext,
 
     debug!("trans_impl(name={}, id={})", name, id);
 
-    let mut v = TransItemVisitor { ccx: ccx };
-
     // Both here and below with generic methods, be sure to recurse and look for
     // items that we need to translate.
     if !generics.ty_params.is_empty() {
-        for impl_item in impl_items {
-            match impl_item.node {
-                hir::ImplItemKind::Method(..) => {
-                    visit::walk_impl_item(&mut v, impl_item);
-                }
-                _ => {}
-            }
-        }
         return;
     }
+
     for impl_item in impl_items {
         match impl_item.node {
             hir::ImplItemKind::Method(ref sig, ref body) => {
@@ -94,7 +84,6 @@ pub fn trans_impl(ccx: &CrateContext,
                                        if is_origin { OriginalTranslation } else { InlinedCopy });
                     }
                 }
-                visit::walk_impl_item(&mut v, impl_item);
             }
             _ => {}
         }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -371,11 +371,6 @@ impl<'a, 'tcx> Visitor<'tcx> for CheckItemTypesVisitor<'a, 'tcx> {
             hir::TyFixedLengthVec(_, ref expr) => {
                 check_const_in_type(self.ccx, &**expr, self.ccx.tcx.types.usize);
             }
-            hir::TyBareFn(ref function_declaration) => {
-                visit::walk_fn_decl_nopat(self, &function_declaration.decl);
-                walk_list!(self, visit_lifetime_def, &function_declaration.lifetimes);
-                return
-            }
             _ => {}
         }
 

--- a/src/librustc_typeck/check/upvar.rs
+++ b/src/librustc_typeck/check/upvar.rs
@@ -52,7 +52,7 @@ use std::collections::HashSet;
 use syntax::ast;
 use syntax::codemap::Span;
 use rustc_front::hir;
-use rustc_front::visit::{self, Visitor};
+use rustc_front::intravisit::{self, Visitor};
 
 ///////////////////////////////////////////////////////////////////////////
 // PUBLIC ENTRY POINTS
@@ -105,11 +105,8 @@ impl<'a, 'tcx, 'v> Visitor<'v> for SeedBorrowKind<'a, 'tcx> {
             _ => { }
         }
 
-        visit::walk_expr(self, expr);
+        intravisit::walk_expr(self, expr);
     }
-
-    // Skip all items; they aren't in the same context.
-    fn visit_item(&mut self, _: &'v hir::Item) { }
 }
 
 impl<'a,'tcx> SeedBorrowKind<'a,'tcx> {
@@ -510,18 +507,15 @@ impl<'a,'tcx> AdjustBorrowKind<'a,'tcx> {
 
 impl<'a, 'tcx, 'v> Visitor<'v> for AdjustBorrowKind<'a, 'tcx> {
     fn visit_fn(&mut self,
-                fn_kind: visit::FnKind<'v>,
+                fn_kind: intravisit::FnKind<'v>,
                 decl: &'v hir::FnDecl,
                 body: &'v hir::Block,
                 span: Span,
                 id: ast::NodeId)
     {
-        visit::walk_fn(self, fn_kind, decl, body, span);
+        intravisit::walk_fn(self, fn_kind, decl, body, span);
         self.analyze_closure(id, span, decl, body);
     }
-
-    // Skip all items; they aren't in the same context.
-    fn visit_item(&mut self, _: &'v hir::Item) { }
 }
 
 impl<'a,'tcx> euv::Delegate<'tcx> for AdjustBorrowKind<'a,'tcx> {

--- a/src/librustc_typeck/check/wf.rs
+++ b/src/librustc_typeck/check/wf.rs
@@ -24,7 +24,7 @@ use syntax::ast;
 use syntax::codemap::{DUMMY_SP, Span};
 use syntax::parse::token::special_idents;
 
-use rustc_front::visit::{self, Visitor, FnKind};
+use rustc_front::intravisit::{self, Visitor, FnKind};
 use rustc_front::hir;
 
 pub struct CheckTypeWellFormedVisitor<'ccx, 'tcx:'ccx> {
@@ -423,7 +423,7 @@ fn reject_shadowing_type_parameters<'tcx>(tcx: &ty::ctxt<'tcx>,
 impl<'ccx, 'tcx, 'v> Visitor<'v> for CheckTypeWellFormedVisitor<'ccx, 'tcx> {
     fn visit_item(&mut self, i: &hir::Item) {
         self.check_item_well_formed(i);
-        visit::walk_item(self, i);
+        intravisit::walk_item(self, i);
     }
 
     fn visit_fn(&mut self,
@@ -440,7 +440,7 @@ impl<'ccx, 'tcx, 'v> Visitor<'v> for CheckTypeWellFormedVisitor<'ccx, 'tcx> {
                 }
             }
         }
-        visit::walk_fn(self, fk, fd, b, span)
+        intravisit::walk_fn(self, fk, fd, b, span)
     }
 
     fn visit_trait_item(&mut self, trait_item: &'v hir::TraitItem) {
@@ -460,7 +460,7 @@ impl<'ccx, 'tcx, 'v> Visitor<'v> for CheckTypeWellFormedVisitor<'ccx, 'tcx> {
             }
         }
 
-        visit::walk_trait_item(self, trait_item)
+        intravisit::walk_trait_item(self, trait_item)
     }
 }
 

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -25,8 +25,7 @@ use syntax::ast;
 use syntax::codemap::{Span};
 use syntax::parse::token::{special_idents};
 use syntax::ptr::P;
-use rustc_front::visit;
-use rustc_front::visit::Visitor;
+use rustc_front::intravisit::{self, Visitor};
 use rustc_front::hir;
 
 pub struct CheckTypeWellFormedVisitor<'ccx, 'tcx:'ccx> {
@@ -492,19 +491,19 @@ impl<'ccx, 'tcx, 'v> Visitor<'v> for CheckTypeWellFormedVisitor<'ccx, 'tcx> {
     fn visit_item(&mut self, i: &hir::Item) {
         debug!("visit_item: {:?}", i);
         self.check_item_well_formed(i);
-        visit::walk_item(self, i);
+        intravisit::walk_item(self, i);
     }
 
     fn visit_trait_item(&mut self, trait_item: &'v hir::TraitItem) {
         debug!("visit_trait_item: {:?}", trait_item);
         self.check_trait_or_impl_item(trait_item.id, trait_item.span);
-        visit::walk_trait_item(self, trait_item)
+        intravisit::walk_trait_item(self, trait_item)
     }
 
     fn visit_impl_item(&mut self, impl_item: &'v hir::ImplItem) {
         debug!("visit_impl_item: {:?}", impl_item);
         self.check_trait_or_impl_item(impl_item.id, impl_item.span);
-        visit::walk_impl_item(self, impl_item)
+        intravisit::walk_impl_item(self, impl_item)
     }
 }
 

--- a/src/librustc_typeck/coherence/orphan.rs
+++ b/src/librustc_typeck/coherence/orphan.rs
@@ -17,13 +17,13 @@ use middle::traits;
 use middle::ty;
 use syntax::ast;
 use syntax::codemap::Span;
-use rustc_front::visit;
+use rustc_front::intravisit;
 use rustc_front::hir;
 use rustc_front::hir::{Item, ItemImpl};
 
 pub fn check(tcx: &ty::ctxt) {
     let mut orphan = OrphanChecker { tcx: tcx };
-    visit::walk_crate(&mut orphan, tcx.map.krate());
+    tcx.map.krate().visit_all_items(&mut orphan);
 }
 
 struct OrphanChecker<'cx, 'tcx:'cx> {
@@ -354,9 +354,8 @@ impl<'cx, 'tcx> OrphanChecker<'cx, 'tcx> {
     }
 }
 
-impl<'cx, 'tcx,'v> visit::Visitor<'v> for OrphanChecker<'cx, 'tcx> {
+impl<'cx, 'tcx,'v> intravisit::Visitor<'v> for OrphanChecker<'cx, 'tcx> {
     fn visit_item(&mut self, item: &hir::Item) {
         self.check_item(item);
-        visit::walk_item(self, item);
     }
 }

--- a/src/librustc_typeck/coherence/overlap.rs
+++ b/src/librustc_typeck/coherence/overlap.rs
@@ -19,7 +19,7 @@ use middle::infer::{self, new_infer_ctxt};
 use syntax::ast;
 use syntax::codemap::Span;
 use rustc_front::hir;
-use rustc_front::visit;
+use rustc_front::intravisit;
 use util::nodemap::DefIdMap;
 
 pub fn check(tcx: &ty::ctxt) {
@@ -28,7 +28,7 @@ pub fn check(tcx: &ty::ctxt) {
 
     // this secondary walk specifically checks for some other cases,
     // like defaulted traits, for which additional overlap rules exist
-    visit::walk_crate(&mut overlap, tcx.map.krate());
+    tcx.map.krate().visit_all_items(&mut overlap);
 }
 
 struct OverlapChecker<'cx, 'tcx:'cx> {
@@ -169,7 +169,7 @@ impl<'cx, 'tcx> OverlapChecker<'cx, 'tcx> {
 }
 
 
-impl<'cx, 'tcx,'v> visit::Visitor<'v> for OverlapChecker<'cx, 'tcx> {
+impl<'cx, 'tcx,'v> intravisit::Visitor<'v> for OverlapChecker<'cx, 'tcx> {
     fn visit_item(&mut self, item: &'v hir::Item) {
         match item.node {
             hir::ItemDefaultImpl(_, _) => {
@@ -226,6 +226,5 @@ impl<'cx, 'tcx,'v> visit::Visitor<'v> for OverlapChecker<'cx, 'tcx> {
             _ => {
             }
         }
-        visit::walk_item(self, item);
     }
 }

--- a/src/librustc_typeck/coherence/unsafety.rs
+++ b/src/librustc_typeck/coherence/unsafety.rs
@@ -12,13 +12,13 @@
 //! crate or pertains to a type defined in this crate.
 
 use middle::ty;
-use rustc_front::visit;
+use rustc_front::intravisit;
 use rustc_front::hir;
 use rustc_front::hir::{Item, ItemImpl};
 
 pub fn check(tcx: &ty::ctxt) {
     let mut orphan = UnsafetyChecker { tcx: tcx };
-    visit::walk_crate(&mut orphan, tcx.map.krate());
+    tcx.map.krate().visit_all_items(&mut orphan);
 }
 
 struct UnsafetyChecker<'cx, 'tcx:'cx> {
@@ -76,7 +76,7 @@ impl<'cx, 'tcx, 'v> UnsafetyChecker<'cx, 'tcx> {
     }
 }
 
-impl<'cx, 'tcx,'v> visit::Visitor<'v> for UnsafetyChecker<'cx, 'tcx> {
+impl<'cx, 'tcx,'v> intravisit::Visitor<'v> for UnsafetyChecker<'cx, 'tcx> {
     fn visit_item(&mut self, item: &'v hir::Item) {
         match item.node {
             hir::ItemDefaultImpl(unsafety, _) => {
@@ -87,7 +87,5 @@ impl<'cx, 'tcx,'v> visit::Visitor<'v> for UnsafetyChecker<'cx, 'tcx> {
             }
             _ => { }
         }
-
-        visit::walk_item(self, item);
     }
 }

--- a/src/librustc_typeck/variance.rs
+++ b/src/librustc_typeck/variance.rs
@@ -276,8 +276,7 @@ use std::fmt;
 use std::rc::Rc;
 use syntax::ast;
 use rustc_front::hir;
-use rustc_front::visit;
-use rustc_front::visit::Visitor;
+use rustc_front::intravisit::Visitor;
 use util::nodemap::NodeMap;
 
 pub fn infer_variance(tcx: &ty::ctxt) {
@@ -383,7 +382,7 @@ fn determine_parameters_to_be_inferred<'a, 'tcx>(tcx: &'a ty::ctxt<'tcx>,
         })
     };
 
-    visit::walk_crate(&mut terms_cx, krate);
+    krate.visit_all_items(&mut terms_cx);
 
     terms_cx
 }
@@ -531,7 +530,6 @@ impl<'a, 'tcx, 'v> Visitor<'v> for TermsContext<'a, 'tcx> {
                 // constrained to be invariant. See `visit_item` in
                 // the impl for `ConstraintContext` below.
                 self.add_inferreds_for_item(item.id, true, generics);
-                visit::walk_item(self, item);
             }
 
             hir::ItemExternCrate(_) |
@@ -544,7 +542,6 @@ impl<'a, 'tcx, 'v> Visitor<'v> for TermsContext<'a, 'tcx> {
             hir::ItemMod(..) |
             hir::ItemForeignMod(..) |
             hir::ItemTy(..) => {
-                visit::walk_item(self, item);
             }
         }
     }
@@ -591,7 +588,7 @@ fn add_constraints_from_crate<'a, 'tcx>(terms_cx: TermsContext<'a, 'tcx>,
         bivariant: bivariant,
         constraints: Vec::new(),
     };
-    visit::walk_crate(&mut constraint_cx, krate);
+    krate.visit_all_items(&mut constraint_cx);
     constraint_cx
 }
 
@@ -637,8 +634,6 @@ impl<'a, 'tcx, 'v> Visitor<'v> for ConstraintContext<'a, 'tcx> {
             hir::ItemDefaultImpl(..) => {
             }
         }
-
-        visit::walk_item(self, item);
     }
 }
 

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -157,8 +157,9 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
         om.vis = vis;
         om.stab = self.stability(id);
         om.id = id;
-        for i in &m.items {
-            self.visit_item(&**i, None, &mut om);
+        for i in &m.item_ids {
+            let item = self.cx.map.expect_item(i.id);
+            self.visit_item(item, None, &mut om);
         }
         om
     }
@@ -224,8 +225,9 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                     let prev = mem::replace(&mut self.inlining_from_glob, true);
                     match it.node {
                         hir::ItemMod(ref m) => {
-                            for i in &m.items {
-                                self.visit_item(&**i, None, om);
+                            for i in &m.item_ids {
+                                let i = self.cx.map.expect_item(i.id);
+                                self.visit_item(i, None, om);
                             }
                         }
                         hir::ItemEnum(..) => {}

--- a/src/test/compile-fail/issue-22638.rs
+++ b/src/test/compile-fail/issue-22638.rs
@@ -10,6 +10,8 @@
 
 #![allow(unused)]
 
+#![recursion_limit = "32"]
+
 #[derive(Clone)]
 struct A (B);
 

--- a/src/test/run-make/graphviz-flowgraph/f18.dot-expected.dot
+++ b/src/test/run-make/graphviz-flowgraph/f18.dot-expected.dot
@@ -1,14 +1,14 @@
 digraph block {
     N0[label="entry"];
     N1[label="exit"];
-    N2[label="stmt fn inner(x: isize) -> isize { x + x }"];
+    N2[label="stmt "];
     N3[label="expr inner"];
     N4[label="expr inner"];
     N5[label="expr 18"];
     N6[label="expr inner(18)"];
     N7[label="expr inner(inner(18))"];
     N8[label="stmt inner(inner(18));"];
-    N9[label="block {\l    fn inner(x: isize) -> isize { x + x }\l    inner(inner(18));\l}\l"];
+    N9[label="block { inner(inner(18)); }"];
     N0 -> N2;
     N2 -> N3;
     N3 -> N4;

--- a/src/test/run-make/graphviz-flowgraph/f19.dot-expected.dot
+++ b/src/test/run-make/graphviz-flowgraph/f19.dot-expected.dot
@@ -1,8 +1,8 @@
 digraph block {
     N0[label="entry"];
     N1[label="exit"];
-    N2[label="stmt struct S19 {\l    x: isize,\l}\l"];
-    N3[label="stmt impl S19 {\l    fn inner(self) -> S19 { S19{x: self.x + self.x,} }\l}\l"];
+    N2[label="stmt "];
+    N3[label="stmt "];
     N4[label="expr 19"];
     N5[label="expr S19{x: 19,}"];
     N6[label="local s"];
@@ -11,7 +11,7 @@ digraph block {
     N9[label="expr s.inner()"];
     N10[label="expr s.inner().inner()"];
     N11[label="stmt s.inner().inner();"];
-    N12[label="block {\l    struct S19 {\l        x: isize,\l    }\l    impl S19 {\l        fn inner(self) -> S19 { S19{x: self.x + self.x,} }\l    }\l    let s = S19{x: 19,};\l    s.inner().inner();\l}\l"];
+    N12[label="block { let s = S19{x: 19,}; s.inner().inner(); }"];
     N0 -> N2;
     N2 -> N3;
     N3 -> N4;


### PR DESCRIPTION
This PR moves items into a separate map stored in the krate, rather than storing them inline in the HIR. The HIR visitor is also modified to skip visiting nested items by default. The goal here is to ensure that if you get access to the HIR for one item, you don't automatically get access to a bunch of other items, for better dependency tracking.

r? @nrc 
cc @eddyb 
