### PR TITLE
Error when paths contain NUL characters

### DIFF
--- a/src/libstd/sys/windows/fs.rs
+++ b/src/libstd/sys/windows/fs.rs
@@ -22,7 +22,8 @@ use sync::Arc;
 use sys::handle::Handle;
 use sys::{c, cvt};
 use sys_common::FromInner;
-use vec::Vec;
+
+use super::to_u16s;
 
 pub struct File { handle: Handle }
 
@@ -377,15 +378,6 @@ impl fmt::Debug for File {
     }
 }
 
-pub fn to_u16s(s: &Path) -> io::Result<Vec<u16>> {
-    let mut maybe_result = s.as_os_str().encode_wide().collect();
-    if maybe_result.iter().any(|&u| u == 0) {
-        return Err(io::Error::new(io::ErrorKind::InvalidInput, "paths cannot contain NULs"));
-    }
-    maybe_result.push(0);
-    Ok(maybe_result)
-}
-
 impl FileAttr {
     pub fn size(&self) -> u64 {
         ((self.data.nFileSizeHigh as u64) << 32) | (self.data.nFileSizeLow as u64)
@@ -622,6 +614,7 @@ fn directory_junctions_are_directories() {
     use ffi::OsStr;
     use env;
     use rand::{self, StdRng, Rng};
+    use vec::Vec;
 
     macro_rules! t {
         ($e:expr) => (match $e {

--- a/src/libstd/sys/windows/mod.rs
+++ b/src/libstd/sys/windows/mod.rs
@@ -72,10 +72,17 @@ pub fn decode_error_kind(errno: i32) -> ErrorKind {
     }
 }
 
-fn to_utf16_os(s: &OsStr) -> Vec<u16> {
-    let mut v: Vec<_> = s.encode_wide().collect();
-    v.push(0);
-    v
+pub fn to_u16s<S: AsRef<OsStr>>(s: S) -> io::Result<Vec<u16>> {
+    fn inner(s: &OsStr) -> io::Result<Vec<u16>> {
+        let mut maybe_result: Vec<u16> = s.encode_wide().collect();
+        if maybe_result.iter().any(|&u| u == 0) {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput,
+                                      "strings passed to WinAPI cannot contain NULs"));
+        }
+        maybe_result.push(0);
+        Ok(maybe_result)
+    }
+    inner(s.as_ref())
 }
 
 // Many Windows APIs follow a pattern of where we hand a buffer and then they

--- a/src/libstd/sys/windows/os.rs
+++ b/src/libstd/sys/windows/os.rs
@@ -28,6 +28,8 @@ use slice;
 use sys::{c, cvt};
 use sys::handle::Handle;
 
+use super::to_u16s;
+
 pub fn errno() -> i32 {
     unsafe { c::GetLastError() as i32 }
 }
@@ -228,7 +230,7 @@ pub fn chdir(p: &path::Path) -> io::Result<()> {
 }
 
 pub fn getenv(k: &OsStr) -> io::Result<Option<OsString>> {
-    let k = super::to_utf16_os(k);
+    let k = try!(to_u16s(k));
     let res = super::fill_utf16_buf(|buf, sz| unsafe {
         c::GetEnvironmentVariableW(k.as_ptr(), buf, sz)
     }, |buf| {
@@ -247,8 +249,8 @@ pub fn getenv(k: &OsStr) -> io::Result<Option<OsString>> {
 }
 
 pub fn setenv(k: &OsStr, v: &OsStr) -> io::Result<()> {
-    let k = super::to_utf16_os(k);
-    let v = super::to_utf16_os(v);
+    let k = try!(to_u16s(k));
+    let v = try!(to_u16s(v));
 
     cvt(unsafe {
         c::SetEnvironmentVariableW(k.as_ptr(), v.as_ptr())
@@ -256,7 +258,7 @@ pub fn setenv(k: &OsStr, v: &OsStr) -> io::Result<()> {
 }
 
 pub fn unsetenv(n: &OsStr) -> io::Result<()> {
-    let v = super::to_utf16_os(n);
+    let v = try!(to_u16s(n));
     cvt(unsafe {
         c::SetEnvironmentVariableW(v.as_ptr(), ptr::null())
     }).map(|_| ())

--- a/src/test/run-pass/paths-containing-nul.rs
+++ b/src/test/run-pass/paths-containing-nul.rs
@@ -1,0 +1,48 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::fs;
+use std::io;
+
+fn assert_invalid_input<T>(on: &str, result: io::Result<T>) {
+    fn inner(on: &str, result: io::Result<()>) {
+        match result {
+            Ok(()) => panic!("{} didn't return an error on a path with NUL", on),
+            Err(e) => assert!(e.kind() == io::ErrorKind::InvalidInput,
+                              "{} returned a strange {:?} on a path with NUL", on, e.kind()),
+        }
+    }
+    inner(on, result.map(|_| ()))
+}
+
+fn main() {
+    assert_invalid_input("File::open", fs::File::open("\0"));
+    assert_invalid_input("File::create", fs::File::create("\0"));
+    assert_invalid_input("remove_file", fs::remove_file("\0"));
+    assert_invalid_input("metadata", fs::metadata("\0"));
+    assert_invalid_input("symlink_metadata", fs::symlink_metadata("\0"));
+    assert_invalid_input("rename1", fs::rename("\0", "a"));
+    assert_invalid_input("rename2", fs::rename("a", "\0"));
+    assert_invalid_input("copy1", fs::copy("\0", "a"));
+    assert_invalid_input("copy2", fs::copy("a", "\0"));
+    assert_invalid_input("hard_link1", fs::hard_link("\0", "a"));
+    assert_invalid_input("hard_link2", fs::hard_link("a", "\0"));
+    assert_invalid_input("soft_link1", fs::soft_link("\0", "a"));
+    assert_invalid_input("soft_link2", fs::soft_link("a", "\0"));
+    assert_invalid_input("read_link", fs::read_link("\0"));
+    assert_invalid_input("canonicalize", fs::canonicalize("\0"));
+    assert_invalid_input("create_dir", fs::create_dir("\0"));
+    assert_invalid_input("create_dir_all", fs::create_dir_all("\0"));
+    assert_invalid_input("remove_dir", fs::remove_dir("\0"));
+    assert_invalid_input("remove_dir_all", fs::remove_dir_all("\0"));
+    assert_invalid_input("read_dir", fs::read_dir("\0"));
+    assert_invalid_input("set_permissions",
+                         fs::set_permissions("\0", fs::metadata(".").unwrap().permissions()));
+}


### PR DESCRIPTION
On Windows: Previously these paths were silently truncated at these NUL
characters, now they fail with `ErrorKind::InvalidInput`.
