### PR TITLE
Fix unpredictable ordering of sidebar boxes in rustdoc

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -137,7 +137,7 @@ r##"<!DOCTYPE html>
     <script src="{root_path}jquery.js"></script>
     <script src="{root_path}main.js"></script>
     {play_js}
-    <script async src="{root_path}search-index.js"></script>
+    <script defer src="{root_path}search-index.js"></script>
 </body>
 </html>"##,
     content   = *t,


### PR DESCRIPTION
A race condition in Javascript was causing unpredictable ordering
of the sidebar boxes when loading documentation generated by
rustdoc, due to the script that adds the Crates box being executed
asynchronously. Disabling the asynchronous execution and deferring
this script should ensure that the Crates box always appears last
in the sidebox (this seemed to be the more common ordering prior
to this change).

Fixes #29698
