### PR TITLE
Move the core MIR datastructures to librustc.

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -136,6 +136,11 @@ pub mod middle {
     pub mod weak_lang_items;
 }
 
+pub mod mir {
+    pub mod repr;
+    pub mod tcx;
+}
+
 pub mod session;
 
 pub mod lint;

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -139,6 +139,7 @@ pub mod middle {
 pub mod mir {
     pub mod repr;
     pub mod tcx;
+    pub mod visit;
 }
 
 pub mod session;

--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -8,10 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use rustc::middle::const_eval::ConstVal;
-use rustc::middle::def_id::DefId;
-use rustc::middle::subst::Substs;
-use rustc::middle::ty::{AdtDef, ClosureSubsts, FnOutput, Region, Ty};
+use middle::const_eval::ConstVal;
+use middle::def_id::DefId;
+use middle::subst::Substs;
+use middle::ty::{AdtDef, ClosureSubsts, FnOutput, Region, Ty};
 use rustc_back::slice;
 use rustc_front::hir::InlineAsm;
 use syntax::ast::Name;

--- a/src/librustc/mir/tcx.rs
+++ b/src/librustc/mir/tcx.rs
@@ -13,9 +13,9 @@
  * building is complete.
  */
 
-use repr::*;
-use rustc::middle::subst::Substs;
-use rustc::middle::ty::{self, AdtDef, Ty};
+use mir::repr::*;
+use middle::subst::Substs;
+use middle::ty::{self, AdtDef, Ty};
 use rustc_front::hir;
 
 #[derive(Copy, Clone, Debug)]

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use rustc::middle::ty::Region;
-use rustc::mir::repr::*;
+use middle::ty::Region;
+use mir::repr::*;
 
 pub trait Visitor<'tcx> {
     // Override these, and call `self.super_xxx` to revert back to the

--- a/src/librustc_mir/build/block.rs
+++ b/src/librustc_mir/build/block.rs
@@ -10,7 +10,7 @@
 
 use build::{BlockAnd, Builder};
 use hair::*;
-use repr::*;
+use rustc::mir::repr::*;
 use rustc_front::hir;
 
 impl<'a,'tcx> Builder<'a,'tcx> {

--- a/src/librustc_mir/build/cfg.rs
+++ b/src/librustc_mir/build/cfg.rs
@@ -14,7 +14,7 @@
 //! Routines for manipulating the control-flow graph.
 
 use build::CFG;
-use repr::*;
+use rustc::mir::repr::*;
 use syntax::codemap::Span;
 
 impl<'tcx> CFG<'tcx> {

--- a/src/librustc_mir/build/expr/as_constant.rs
+++ b/src/librustc_mir/build/expr/as_constant.rs
@@ -12,7 +12,7 @@
 
 use build::Builder;
 use hair::*;
-use repr::*;
+use rustc::mir::repr::*;
 
 impl<'a,'tcx> Builder<'a,'tcx> {
     /// Compile `expr`, yielding a compile-time constant. Assumes that

--- a/src/librustc_mir/build/expr/as_lvalue.rs
+++ b/src/librustc_mir/build/expr/as_lvalue.rs
@@ -10,10 +10,10 @@
 
 //! See docs in build/expr/mod.rs
 
-use build::{BlockAnd, Builder};
+use build::{BlockAnd, BlockAndExtension, Builder};
 use build::expr::category::Category;
 use hair::*;
-use repr::*;
+use rustc::mir::repr::*;
 
 impl<'a,'tcx> Builder<'a,'tcx> {
     /// Compile `expr`, yielding an lvalue that we can move from etc.

--- a/src/librustc_mir/build/expr/as_operand.rs
+++ b/src/librustc_mir/build/expr/as_operand.rs
@@ -10,10 +10,10 @@
 
 //! See docs in build/expr/mod.rs
 
-use build::{BlockAnd, Builder};
+use build::{BlockAnd, BlockAndExtension, Builder};
 use build::expr::category::Category;
 use hair::*;
-use repr::*;
+use rustc::mir::repr::*;
 
 impl<'a,'tcx> Builder<'a,'tcx> {
     /// Compile `expr` into a value that can be used as an operand.

--- a/src/librustc_mir/build/expr/as_rvalue.rs
+++ b/src/librustc_mir/build/expr/as_rvalue.rs
@@ -12,10 +12,10 @@
 
 use rustc_data_structures::fnv::FnvHashMap;
 
-use build::{BlockAnd, Builder};
+use build::{BlockAnd, BlockAndExtension, Builder};
 use build::expr::category::{Category, RvalueFunc};
 use hair::*;
-use repr::*;
+use rustc::mir::repr::*;
 
 impl<'a,'tcx> Builder<'a,'tcx> {
     /// Compile `expr`, yielding an rvalue.

--- a/src/librustc_mir/build/expr/as_temp.rs
+++ b/src/librustc_mir/build/expr/as_temp.rs
@@ -10,10 +10,10 @@
 
 //! See docs in build/expr/mod.rs
 
-use build::{BlockAnd, Builder};
+use build::{BlockAnd, BlockAndExtension, Builder};
 use build::expr::category::Category;
 use hair::*;
-use repr::*;
+use rustc::mir::repr::*;
 
 impl<'a,'tcx> Builder<'a,'tcx> {
     /// Compile `expr` into a fresh temporary. This is used when building

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -10,12 +10,12 @@
 
 //! See docs in build/expr/mod.rs
 
-use build::{BlockAnd, Builder};
+use build::{BlockAnd, BlockAndExtension, Builder};
 use build::expr::category::{Category, RvalueFunc};
 use build::scope::LoopScope;
 use hair::*;
-use repr::*;
 use rustc::middle::region::CodeExtent;
+use rustc::mir::repr::*;
 use syntax::codemap::Span;
 
 impl<'a,'tcx> Builder<'a,'tcx> {

--- a/src/librustc_mir/build/into.rs
+++ b/src/librustc_mir/build/into.rs
@@ -14,9 +14,9 @@
 //! wrapped up as expressions (e.g. blocks). To make this ergonomic, we use this
 //! latter `EvalInto` trait.
 
-use build::{BlockAnd, Builder};
+use build::{BlockAnd, BlockAndExtension, Builder};
 use hair::*;
-use repr::*;
+use rustc::mir::repr::*;
 
 pub trait EvalInto<'tcx> {
     fn eval_into<'a>(self,

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -13,12 +13,12 @@
 //! includes the high-level algorithm, the submodules contain the
 //! details.
 
-use build::{BlockAnd, Builder};
-use repr::*;
+use build::{BlockAnd, BlockAndExtension, Builder};
 use rustc_data_structures::fnv::FnvHashMap;
 use rustc::middle::const_eval::ConstVal;
 use rustc::middle::region::CodeExtent;
 use rustc::middle::ty::{AdtDef, Ty};
+use rustc::mir::repr::*;
 use hair::*;
 use syntax::ast::{Name, NodeId};
 use syntax::codemap::Span;

--- a/src/librustc_mir/build/matches/simplify.rs
+++ b/src/librustc_mir/build/matches/simplify.rs
@@ -22,10 +22,10 @@
 //! sort of test: for example, testing which variant an enum is, or
 //! testing a value against a constant.
 
-use build::{BlockAnd, Builder};
+use build::{BlockAnd, BlockAndExtension, Builder};
 use build::matches::{Binding, MatchPair, Candidate};
 use hair::*;
-use repr::*;
+use rustc::mir::repr::*;
 
 use std::mem;
 

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -18,10 +18,10 @@
 use build::Builder;
 use build::matches::{Candidate, MatchPair, Test, TestKind};
 use hair::*;
-use repr::*;
 use rustc_data_structures::fnv::FnvHashMap;
 use rustc::middle::const_eval::ConstVal;
 use rustc::middle::ty::{self, Ty};
+use rustc::mir::repr::*;
 use syntax::codemap::Span;
 
 impl<'a,'tcx> Builder<'a,'tcx> {

--- a/src/librustc_mir/build/matches/util.rs
+++ b/src/librustc_mir/build/matches/util.rs
@@ -8,10 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use build::{BlockAnd, Builder};
+use build::{BlockAnd, BlockAndExtension, Builder};
 use build::matches::MatchPair;
 use hair::*;
-use repr::*;
+use rustc::mir::repr::*;
 use std::u32;
 
 impl<'a,'tcx> Builder<'a,'tcx> {

--- a/src/librustc_mir/build/misc.rs
+++ b/src/librustc_mir/build/misc.rs
@@ -13,8 +13,8 @@
 
 use build::Builder;
 use hair::*;
-use repr::*;
 use rustc::middle::ty::Ty;
+use rustc::mir::repr::*;
 use std::u32;
 use syntax::codemap::Span;
 

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -11,9 +11,10 @@
 use hair::cx::Cx;
 use rustc::middle::region::CodeExtent;
 use rustc::middle::ty::{FnOutput, Ty};
+use rustc::mir::repr::*;
 use rustc_data_structures::fnv::FnvHashMap;
 use rustc_front::hir;
-use repr::*;
+
 use syntax::ast;
 use syntax::codemap::Span;
 
@@ -41,7 +42,12 @@ struct CFG<'tcx> {
 #[must_use] // if you don't use one of these results, you're leaving a dangling edge
 struct BlockAnd<T>(BasicBlock, T);
 
-impl BasicBlock {
+trait BlockAndExtension {
+    fn and<T>(self, v: T) -> BlockAnd<T>;
+    fn unit(self) -> BlockAnd<()>;
+}
+
+impl BlockAndExtension for BasicBlock {
     fn and<T>(self, v: T) -> BlockAnd<T> {
         BlockAnd(self, v)
     }

--- a/src/librustc_mir/build/scope.rs
+++ b/src/librustc_mir/build/scope.rs
@@ -86,10 +86,10 @@ should go to.
 
 */
 
-use build::{BlockAnd, Builder, CFG};
-use repr::*;
+use build::{BlockAnd, BlockAndExtension, Builder, CFG};
 use rustc::middle::region::CodeExtent;
 use rustc::middle::ty::Ty;
+use rustc::mir::repr::*;
 use syntax::codemap::Span;
 
 pub struct Scope<'tcx> {

--- a/src/librustc_mir/build/stmt.rs
+++ b/src/librustc_mir/build/stmt.rs
@@ -8,9 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use build::{BlockAnd, Builder};
+use build::{BlockAnd, BlockAndExtension, Builder};
 use hair::*;
-use repr::*;
+use rustc::mir::repr::*;
 
 impl<'a,'tcx> Builder<'a,'tcx> {
     pub fn stmts(&mut self, mut block: BasicBlock, stmts: Vec<StmtRef<'tcx>>) -> BlockAnd<()> {

--- a/src/librustc_mir/graphviz/mod.rs
+++ b/src/librustc_mir/graphviz/mod.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use dot;
-use repr::*;
+use rustc::mir::repr::*;
 use std::borrow::IntoCow;
 
 #[derive(Copy, Clone, PartialEq, Eq)]

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 use hair::*;
-use repr::*;
 use rustc_data_structures::fnv::FnvHashMap;
 use hair::cx::Cx;
 use hair::cx::block;
@@ -19,6 +18,7 @@ use rustc::middle::def;
 use rustc::middle::region::CodeExtent;
 use rustc::middle::pat_util;
 use rustc::middle::ty::{self, VariantDef, Ty};
+use rustc::mir::repr::*;
 use rustc_front::hir;
 use rustc_front::util as hir_util;
 use syntax::ext::mtwt;

--- a/src/librustc_mir/hair/cx/mod.rs
+++ b/src/librustc_mir/hair/cx/mod.rs
@@ -16,7 +16,7 @@
  */
 
 use hair::*;
-use repr::*;
+use rustc::mir::repr::*;
 
 use rustc::middle::const_eval::{self, ConstVal};
 use rustc::middle::def_id::DefId;

--- a/src/librustc_mir/hair/cx/pattern.rs
+++ b/src/librustc_mir/hair/cx/pattern.rs
@@ -10,13 +10,13 @@
 
 use hair::*;
 use hair::cx::Cx;
-use repr::*;
 use rustc_data_structures::fnv::FnvHashMap;
 use rustc::middle::const_eval;
 use rustc::middle::def;
 use rustc::middle::pat_util::{pat_is_resolved_const, pat_is_binding};
 use rustc::middle::subst::Substs;
 use rustc::middle::ty::{self, Ty};
+use rustc::mir::repr::*;
 use rustc_front::hir;
 use syntax::ast;
 use syntax::ext::mtwt;

--- a/src/librustc_mir/hair/mod.rs
+++ b/src/librustc_mir/hair/mod.rs
@@ -14,7 +14,7 @@
 //! unit-tested and separated from the Rust source and compiler data
 //! structures.
 
-use repr::{BinOp, BorrowKind, Field, Literal, Mutability, UnOp};
+use rustc::mir::repr::{BinOp, BorrowKind, Field, Literal, Mutability, UnOp};
 use rustc::middle::def_id::DefId;
 use rustc::middle::region::CodeExtent;
 use rustc::middle::subst::Substs;

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -34,5 +34,4 @@ pub mod mir_map;
 mod hair;
 mod graphviz;
 pub mod transform;
-pub mod visit;
 

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -32,9 +32,7 @@ extern crate syntax;
 pub mod build;
 pub mod mir_map;
 mod hair;
-pub mod repr;
 mod graphviz;
 pub mod transform;
-pub mod tcx;
 pub mod visit;
 

--- a/src/librustc_mir/mir_map.rs
+++ b/src/librustc_mir/mir_map.rs
@@ -23,7 +23,7 @@ extern crate rustc_front;
 use build;
 use dot;
 use transform::*;
-use repr::Mir;
+use rustc::mir::repr::Mir;
 use hair::cx::Cx;
 use std::fs::File;
 

--- a/src/librustc_mir/transform/erase_regions.rs
+++ b/src/librustc_mir/transform/erase_regions.rs
@@ -12,8 +12,8 @@
 //! We want to do this once just before trans, so trans does not have to take
 //! care erasing regions all over the place.
 
-use repr::*;
 use rustc::middle::ty;
+use rustc::mir::repr::*;
 use transform::MirPass;
 use mir_map::MirMap;
 

--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -12,7 +12,7 @@ pub mod simplify_cfg;
 pub mod erase_regions;
 mod util;
 
-use repr::Mir;
+use rustc::mir::repr::Mir;
 
 pub trait MirPass<'tcx> {
     fn run_on_mir(&mut self, mir: &mut Mir<'tcx>);

--- a/src/librustc_mir/transform/simplify_cfg.rs
+++ b/src/librustc_mir/transform/simplify_cfg.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use repr::*;
 use rustc::middle::const_eval::ConstVal;
+use rustc::mir::repr::*;
 use std::mem;
 use transform::util;
 use transform::MirPass;

--- a/src/librustc_mir/transform/util.rs
+++ b/src/librustc_mir/transform/util.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use repr::*;
+use rustc::mir::repr::*;
 
 /// Update basic block ids in all terminators using the given replacements,
 /// useful e.g. after removal of several basic blocks to update all terminators

--- a/src/librustc_mir/visit.rs
+++ b/src/librustc_mir/visit.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use rustc::middle::ty::Region;
-use repr::*;
+use rustc::mir::repr::*;
 
 pub trait Visitor<'tcx> {
     // Override these, and call `self.super_xxx` to revert back to the

--- a/src/librustc_trans/trans/common.rs
+++ b/src/librustc_trans/trans/common.rs
@@ -40,7 +40,7 @@ use middle::traits;
 use middle::ty::{self, HasTypeFlags, Ty};
 use middle::ty::fold::{TypeFolder, TypeFoldable};
 use rustc_front::hir;
-use rustc_mir::repr::Mir;
+use rustc::mir::repr::Mir;
 use util::nodemap::{FnvHashMap, NodeMap};
 
 use arena::TypedArena;

--- a/src/librustc_trans/trans/mir/analyze.rs
+++ b/src/librustc_trans/trans/mir/analyze.rs
@@ -13,7 +13,7 @@
 
 use rustc_data_structures::fnv::FnvHashSet;
 use rustc::mir::repr as mir;
-use rustc_mir::visit::{Visitor, LvalueContext};
+use rustc::mir::visit::{Visitor, LvalueContext};
 use trans::common::{self, Block};
 use super::rvalue;
 

--- a/src/librustc_trans/trans/mir/analyze.rs
+++ b/src/librustc_trans/trans/mir/analyze.rs
@@ -12,7 +12,7 @@
 //! which do not.
 
 use rustc_data_structures::fnv::FnvHashSet;
-use rustc_mir::repr as mir;
+use rustc::mir::repr as mir;
 use rustc_mir::visit::{Visitor, LvalueContext};
 use trans::common::{self, Block};
 use super::rvalue;

--- a/src/librustc_trans/trans/mir/block.rs
+++ b/src/librustc_trans/trans/mir/block.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use llvm::BasicBlockRef;
-use rustc_mir::repr as mir;
+use rustc::mir::repr as mir;
 use trans::base;
 use trans::build;
 use trans::common::Block;

--- a/src/librustc_trans/trans/mir/constant.rs
+++ b/src/librustc_trans/trans/mir/constant.rs
@@ -10,7 +10,7 @@
 
 use middle::ty::{Ty, HasTypeFlags};
 use rustc::middle::const_eval::ConstVal;
-use rustc_mir::repr as mir;
+use rustc::mir::repr as mir;
 use trans::consts::{self, TrueConst};
 use trans::common::{self, Block};
 use trans::common::{C_bool, C_bytes, C_floating_f64, C_integral, C_str_slice};

--- a/src/librustc_trans/trans/mir/lvalue.rs
+++ b/src/librustc_trans/trans/mir/lvalue.rs
@@ -10,8 +10,8 @@
 
 use llvm::ValueRef;
 use rustc::middle::ty::{self, Ty, HasTypeFlags};
-use rustc_mir::repr as mir;
-use rustc_mir::tcx::LvalueTy;
+use rustc::mir::repr as mir;
+use rustc::mir::tcx::LvalueTy;
 use trans::adt;
 use trans::base;
 use trans::build;

--- a/src/librustc_trans/trans/mir/mod.rs
+++ b/src/librustc_trans/trans/mir/mod.rs
@@ -10,8 +10,8 @@
 
 use libc::c_uint;
 use llvm::{self, ValueRef};
-use rustc_mir::repr as mir;
-use rustc_mir::tcx::LvalueTy;
+use rustc::mir::repr as mir;
+use rustc::mir::tcx::LvalueTy;
 use trans::base;
 use trans::build;
 use trans::common::{self, Block};

--- a/src/librustc_trans/trans/mir/operand.rs
+++ b/src/librustc_trans/trans/mir/operand.rs
@@ -10,7 +10,7 @@
 
 use llvm::ValueRef;
 use rustc::middle::ty::{Ty, HasTypeFlags};
-use rustc_mir::repr as mir;
+use rustc::mir::repr as mir;
 use trans::base;
 use trans::common::{self, Block};
 use trans::datum;

--- a/src/librustc_trans/trans/mir/rvalue.rs
+++ b/src/librustc_trans/trans/mir/rvalue.rs
@@ -10,7 +10,7 @@
 
 use llvm::ValueRef;
 use rustc::middle::ty::{self, Ty};
-use rustc_mir::repr as mir;
+use rustc::mir::repr as mir;
 
 use trans::asm;
 use trans::base;

--- a/src/librustc_trans/trans/mir/statement.rs
+++ b/src/librustc_trans/trans/mir/statement.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use rustc::middle::ty::LvaluePreference;
-use rustc_mir::repr as mir;
+use rustc::mir::repr as mir;
 use trans::common::Block;
 use trans::debuginfo::DebugLoc;
 use trans::glue;


### PR DESCRIPTION
This is done mostly so that we can refer to MIR types in csearch and other metadata related area.

Heads up, @rust-lang/compiler!

r? @nikomatsakis 
