### PR TITLE
Remove unneeded `#[derive(Copy)]`

### DIFF
--- a/src/librustc_llvm/diagnostic.rs
+++ b/src/librustc_llvm/diagnostic.rs
@@ -37,7 +37,6 @@ impl OptimizationDiagnosticKind {
     }
 }
 
-#[derive(Copy, Clone)]
 pub struct OptimizationDiagnostic {
     pub kind: OptimizationDiagnosticKind,
     pub pass_name: *const c_char,
@@ -94,7 +93,6 @@ impl InlineAsmDiagnostic {
     }
 }
 
-#[derive(Copy, Clone)]
 pub enum Diagnostic {
     Optimization(OptimizationDiagnostic),
     InlineAsm(InlineAsmDiagnostic),


### PR DESCRIPTION
It was introduced with the change that made copy opt-in. The
implementation gives a warning, because the struct contains a raw
pointer.
