### PR TITLE
Add -C inline-threshold

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -513,6 +513,8 @@ options! {CodegenOptions, CodegenSetter, basic_codegen_options,
         "optimize with possible levels 0-3"),
     debug_assertions: Option<bool> = (None, parse_opt_bool,
         "explicitly enable the cfg(debug_assertions) directive"),
+    inline_threshold: Option<usize> = (None, parse_opt_uint,
+        "set the inlining threshold for"),
 }
 
 


### PR DESCRIPTION
Corresponds directly to llvm's inline-threshold.

I want this so I can experiment out-of-tree with tweaking optimization settings, and this is the most important value that isn't exposed. I can't get it to work either via `-C llvm-args`.

cc @rust-lang/compiler
