### PR TITLE
Rename #[deprecated] to #[rustc_deprecated]

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -2327,7 +2327,7 @@ The currently implemented features of the reference compiler are:
 
 * `staged_api` - Allows usage of stability markers and `#![staged_api]` in a
                  crate. Stability markers are also attributes: `#[stable]`,
-                 `#[unstable]`, and `#[deprecated]` are the three levels.
+                 `#[unstable]`, and `#[rustc_deprecated]` are the three levels.
 
 * `start` - Allows use of the `#[start]` attribute, which changes the entry point
             into a Rust program. This capability, especially the signature for the

--- a/src/etc/featureck.py
+++ b/src/etc/featureck.py
@@ -206,7 +206,7 @@ for name in lib_feature_stats:
         lang_stable_since = language_feature_stats[name][4]
         lib_stable_since = lib_feature_stats[name][4]
 
-        if lang_status != lib_status and lib_status != "deprecated":
+        if lang_status != lib_status and lib_status != "rustc_deprecated":
             print("error: feature '%s' has lang status %s " +
                   "but lib status %s" % (name, lang_status, lib_status))
             errors = True

--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -385,7 +385,7 @@ impl<T: ?Sized> Deref for Arc<T> {
 impl<T: Clone> Arc<T> {
     #[unstable(feature = "arc_make_unique", reason = "renamed to Arc::make_mut",
                issue = "27718")]
-    #[deprecated(since = "1.4.0", reason = "renamed to Arc::make_mut")]
+    #[rustc_deprecated(since = "1.4.0", reason = "renamed to Arc::make_mut")]
     pub fn make_unique(this: &mut Self) -> &mut T {
         Arc::make_mut(this)
     }

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -74,6 +74,8 @@
 #![no_std]
 #![cfg_attr(not(stage0), needs_allocator)]
 
+#![cfg_attr(stage0, feature(rustc_attrs))]
+#![cfg_attr(stage0, allow(unused_attributes))]
 #![feature(allocator)]
 #![feature(box_syntax)]
 #![feature(coerce_unsized)]

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -362,7 +362,7 @@ impl<T: Clone> Rc<T> {
     #[inline]
     #[unstable(feature = "rc_make_unique", reason = "renamed to Rc::make_mut",
                issue = "27718")]
-    #[deprecated(since = "1.4.0", reason = "renamed to Rc::make_mut")]
+    #[rustc_deprecated(since = "1.4.0", reason = "renamed to Rc::make_mut")]
     pub fn make_unique(&mut self) -> &mut T {
         Rc::make_mut(self)
     }

--- a/src/libcollections/binary_heap.rs
+++ b/src/libcollections/binary_heap.rs
@@ -241,7 +241,7 @@ impl<T: Ord> BinaryHeap<T> {
     #[unstable(feature = "binary_heap_extras",
                reason = "needs to be audited",
                issue = "28147")]
-    #[deprecated(since = "1.5.0", reason = "use BinaryHeap::from instead")]
+    #[rustc_deprecated(since = "1.5.0", reason = "use BinaryHeap::from instead")]
     pub fn from_vec(vec: Vec<T>) -> BinaryHeap<T> {
         BinaryHeap::from(vec)
     }

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -161,7 +161,7 @@ impl<K: Ord, V> BTreeMap<K, V> {
     #[unstable(feature = "btree_b",
                reason = "probably want this to be on the type, eventually",
                issue = "27795")]
-    #[deprecated(since = "1.4.0", reason = "niche API")]
+    #[rustc_deprecated(since = "1.4.0", reason = "niche API")]
     pub fn with_b(b: usize) -> BTreeMap<K, V> {
         assert!(b > 1, "B must be greater than 1");
         BTreeMap {

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -105,7 +105,7 @@ impl<T: Ord> BTreeSet<T> {
     #[unstable(feature = "btree_b",
                reason = "probably want this to be on the type, eventually",
                issue = "27795")]
-    #[deprecated(since = "1.4.0", reason = "niche API")]
+    #[rustc_deprecated(since = "1.4.0", reason = "niche API")]
     #[allow(deprecated)]
     pub fn with_b(b: usize) -> BTreeSet<T> {
         BTreeSet { map: BTreeMap::with_b(b) }

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -37,6 +37,8 @@
 // SNAP 1af31d4
 #![allow(unused_attributes)]
 
+#![cfg_attr(stage0, feature(rustc_attrs))]
+#![cfg_attr(stage0, allow(unused_attributes))]
 #![feature(alloc)]
 #![feature(box_patterns)]
 #![feature(box_syntax)]

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -862,7 +862,7 @@ pub trait SliceConcatExt<T: ?Sized> {
     /// assert_eq!(["hello", "world"].connect(" "), "hello world");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[deprecated(since = "1.3.0", reason = "renamed to join")]
+    #[rustc_deprecated(since = "1.3.0", reason = "renamed to join")]
     fn connect(&self, sep: &T) -> Self::Output;
 }
 

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -665,7 +665,7 @@ impl str {
     /// assert_eq!(v, ["foo", "bar", "", "baz"]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[deprecated(since = "1.4.0", reason = "use lines() instead now")]
+    #[rustc_deprecated(since = "1.4.0", reason = "use lines() instead now")]
     #[inline]
     #[allow(deprecated)]
     pub fn lines_any(&self) -> LinesAny {

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -842,7 +842,7 @@ impl String {
     #[unstable(feature = "box_str2",
                reason = "recently added, matches RFC",
                issue = "27785")]
-    #[deprecated(since = "1.4.0", reason = "renamed to `into_boxed_str`")]
+    #[rustc_deprecated(since = "1.4.0", reason = "renamed to `into_boxed_str`")]
     pub fn into_boxed_slice(self) -> Box<str> {
         self.into_boxed_str()
     }

--- a/src/libcollections/vec_deque.rs
+++ b/src/libcollections/vec_deque.rs
@@ -1058,7 +1058,7 @@ impl<T> VecDeque<T> {
     #[unstable(feature = "deque_extras",
                reason = "the naming of this function may be altered",
                issue = "27788")]
-    #[deprecated(since = "1.5.0", reason = "renamed to swap_remove_back")]
+    #[rustc_deprecated(since = "1.5.0", reason = "renamed to swap_remove_back")]
     pub fn swap_back_remove(&mut self, index: usize) -> Option<T> {
         self.swap_remove_back(index)
     }
@@ -1101,7 +1101,7 @@ impl<T> VecDeque<T> {
     #[unstable(feature = "deque_extras",
                reason = "the naming of this function may be altered",
                issue = "27788")]
-    #[deprecated(since = "1.5.0", reason = "renamed to swap_remove_front")]
+    #[rustc_deprecated(since = "1.5.0", reason = "renamed to swap_remove_front")]
     pub fn swap_front_remove(&mut self, index: usize) -> Option<T> {
         self.swap_remove_front(index)
     }

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -4303,7 +4303,7 @@ impl<A> Iterator for StepBy<A, RangeFrom<A>> where
 #[unstable(feature = "range_inclusive",
            reason = "likely to be replaced by range notation and adapters",
            issue = "27777")]
-#[deprecated(since = "1.5.0", reason = "replaced with ... syntax")]
+#[rustc_deprecated(since = "1.5.0", reason = "replaced with ... syntax")]
 #[allow(deprecated)]
 pub struct RangeInclusive<A> {
     range: ops::Range<A>,
@@ -4315,7 +4315,7 @@ pub struct RangeInclusive<A> {
 #[unstable(feature = "range_inclusive",
            reason = "likely to be replaced by range notation and adapters",
            issue = "27777")]
-#[deprecated(since = "1.5.0", reason = "replaced with ... syntax")]
+#[rustc_deprecated(since = "1.5.0", reason = "replaced with ... syntax")]
 #[allow(deprecated)]
 pub fn range_inclusive<A>(start: A, stop: A) -> RangeInclusive<A>
     where A: Step + One + Clone
@@ -4329,7 +4329,7 @@ pub fn range_inclusive<A>(start: A, stop: A) -> RangeInclusive<A>
 #[unstable(feature = "range_inclusive",
            reason = "likely to be replaced by range notation and adapters",
            issue = "27777")]
-#[deprecated(since = "1.5.0", reason = "replaced with ... syntax")]
+#[rustc_deprecated(since = "1.5.0", reason = "replaced with ... syntax")]
 #[allow(deprecated)]
 impl<A> Iterator for RangeInclusive<A> where
     A: PartialEq + Step + One + Clone,
@@ -4365,7 +4365,7 @@ impl<A> Iterator for RangeInclusive<A> where
 #[unstable(feature = "range_inclusive",
            reason = "likely to be replaced by range notation and adapters",
            issue = "27777")]
-#[deprecated(since = "1.5.0", reason = "replaced with ... syntax")]
+#[rustc_deprecated(since = "1.5.0", reason = "replaced with ... syntax")]
 #[allow(deprecated)]
 impl<A> DoubleEndedIterator for RangeInclusive<A> where
     A: PartialEq + Step + One + Clone,
@@ -4743,7 +4743,7 @@ pub fn once<T>(value: T) -> Once<T> {
 ///
 /// If two sequences are equal up until the point where one ends,
 /// the shorter sequence compares less.
-#[deprecated(since = "1.4.0", reason = "use the equivalent methods on `Iterator` instead")]
+#[rustc_deprecated(since = "1.4.0", reason = "use the equivalent methods on `Iterator` instead")]
 #[unstable(feature = "iter_order_deprecated", reason = "needs review and revision",
            issue = "27737")]
 pub mod order {

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -68,6 +68,8 @@
 #![no_core]
 #![deny(missing_docs)]
 
+#![cfg_attr(stage0, feature(rustc_attrs))]
+#![cfg_attr(stage0, allow(unused_attributes))]
 #![feature(allow_internal_unstable)]
 #![feature(associated_type_defaults)]
 #![feature(concat_idents)]
@@ -80,7 +82,6 @@
 #![feature(on_unimplemented)]
 #![feature(optin_builtin_traits)]
 #![feature(reflect)]
-#![feature(rustc_attrs)]
 #![feature(unwind_attributes)]
 #![cfg_attr(stage0, feature(simd))]
 #![cfg_attr(not(stage0), feature(repr_simd, platform_intrinsics))]

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -159,7 +159,7 @@ pub fn size_of_val<T: ?Sized>(val: &T) -> usize {
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(reason = "use `align_of` instead", since = "1.2.0")]
+#[rustc_deprecated(reason = "use `align_of` instead", since = "1.2.0")]
 pub fn min_align_of<T>() -> usize {
     unsafe { intrinsics::min_align_of::<T>() }
 }
@@ -176,7 +176,7 @@ pub fn min_align_of<T>() -> usize {
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(reason = "use `align_of_val` instead", since = "1.2.0")]
+#[rustc_deprecated(reason = "use `align_of_val` instead", since = "1.2.0")]
 pub fn min_align_of_val<T: ?Sized>(val: &T) -> usize {
     unsafe { intrinsics::min_align_of_val(val) }
 }

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -290,7 +290,7 @@ impl<T> Option<T> {
     #[unstable(feature = "as_slice",
                reason = "waiting for mut conventions",
                issue = "27776")]
-    #[deprecated(since = "1.4.0", reason = "niche API, unclear of usefulness")]
+    #[rustc_deprecated(since = "1.4.0", reason = "niche API, unclear of usefulness")]
     #[allow(deprecated)]
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         match *self {
@@ -695,7 +695,7 @@ impl<T> Option<T> {
     #[inline]
     #[unstable(feature = "as_slice", reason = "unsure of the utility here",
                issue = "27776")]
-    #[deprecated(since = "1.4.0", reason = "niche API, unclear of usefulness")]
+    #[rustc_deprecated(since = "1.4.0", reason = "niche API, unclear of usefulness")]
     #[allow(deprecated)]
     pub fn as_slice(&self) -> &[T] {
         match *self {

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -410,7 +410,7 @@ impl<T, E> Result<T, E> {
     #[inline]
     #[unstable(feature = "as_slice", reason = "unsure of the utility here",
                issue = "27776")]
-    #[deprecated(since = "1.4.0", reason = "niche API, unclear of usefulness")]
+    #[rustc_deprecated(since = "1.4.0", reason = "niche API, unclear of usefulness")]
     #[allow(deprecated)]
     pub fn as_slice(&self) -> &[T] {
         match *self {
@@ -445,7 +445,7 @@ impl<T, E> Result<T, E> {
     #[unstable(feature = "as_slice",
                reason = "waiting for mut conventions",
                issue = "27776")]
-    #[deprecated(since = "1.4.0", reason = "niche API, unclear of usefulness")]
+    #[rustc_deprecated(since = "1.4.0", reason = "niche API, unclear of usefulness")]
     #[allow(deprecated)]
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         match *self {

--- a/src/libcore/simd.rs
+++ b/src/libcore/simd.rs
@@ -24,7 +24,7 @@
 #![unstable(feature = "core_simd",
             reason = "needs an RFC to flesh out the design",
             issue = "27731")]
-#![deprecated(since = "1.3.0",
+#![rustc_deprecated(since = "1.3.0",
               reason = "use the external `simd` crate instead")]
 
 #![allow(non_camel_case_types)]

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -1423,7 +1423,7 @@ impl<'a, T> ExactSizeIterator for ChunksMut<'a, T> {}
 
 /// Converts a reference to A into a slice of length 1 (without copying).
 #[unstable(feature = "ref_slice", issue = "27774")]
-#[deprecated(since = "1.5.0", reason = "unclear whether belongs in libstd")]
+#[rustc_deprecated(since = "1.5.0", reason = "unclear whether belongs in libstd")]
 pub fn ref_slice<A>(s: &A) -> &[A] {
     unsafe {
         from_raw_parts(s, 1)
@@ -1432,7 +1432,7 @@ pub fn ref_slice<A>(s: &A) -> &[A] {
 
 /// Converts a reference to A into a slice of length 1 (without copying).
 #[unstable(feature = "ref_slice", issue = "27774")]
-#[deprecated(since = "1.5.0", reason = "unclear whether belongs in libstd")]
+#[rustc_deprecated(since = "1.5.0", reason = "unclear whether belongs in libstd")]
 pub fn mut_ref_slice<A>(s: &mut A) -> &mut [A] {
     unsafe {
         from_raw_parts_mut(s, 1)

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -955,7 +955,7 @@ impl<'a> DoubleEndedIterator for Lines<'a> {
 
 /// Created with the method `.lines_any()`.
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "1.4.0", reason = "use lines()/Lines instead now")]
+#[rustc_deprecated(since = "1.4.0", reason = "use lines()/Lines instead now")]
 #[derive(Clone)]
 #[allow(deprecated)]
 pub struct LinesAny<'a>(Lines<'a>);

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -162,7 +162,7 @@ impl<'a, 'tcx: 'a> Annotator<'a, 'tcx> {
             // Emit errors for non-staged-api crates.
             for attr in attrs {
                 let tag = attr.name();
-                if tag == "unstable" || tag == "stable" || tag == "deprecated" {
+                if tag == "unstable" || tag == "stable" || tag == "rustc_deprecated" {
                     attr::mark_used(attr);
                     self.tcx.sess.span_err(attr.span(), "stability attributes may not be used \
                                                          outside of the standard library");

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -577,10 +577,10 @@ impl LateLintPass for MissingDebugImplementations {
 declare_lint! {
     DEPRECATED,
     Warn,
-    "detects use of #[deprecated] items"
+    "detects use of #[rustc_deprecated] items"
 }
 
-/// Checks for use of items with `#[deprecated]` attributes
+/// Checks for use of items with `#[rustc_deprecated]` attributes
 #[derive(Copy, Clone)]
 pub struct Stability;
 

--- a/src/librustc_unicode/lib.rs
+++ b/src/librustc_unicode/lib.rs
@@ -34,6 +34,8 @@
        test(no_crate_inject, attr(allow(unused_variables), deny(warnings))))]
 #![no_std]
 
+#![cfg_attr(stage0, feature(rustc_attrs))]
+#![cfg_attr(stage0, allow(unused_attributes))]
 #![feature(core_char_ext)]
 #![feature(core_slice_ext)]
 #![feature(core_str_ext)]

--- a/src/librustc_unicode/u_str.rs
+++ b/src/librustc_unicode/u_str.rs
@@ -129,7 +129,7 @@ pub fn is_utf16(v: &[u16]) -> bool {
 
 /// An iterator that decodes UTF-16 encoded codepoints from a vector
 /// of `u16`s.
-#[deprecated(since = "1.4.0", reason = "renamed to `char::DecodeUtf16`")]
+#[rustc_deprecated(since = "1.4.0", reason = "renamed to `char::DecodeUtf16`")]
 #[unstable(feature = "decode_utf16", reason = "not exposed in std", issue = "27830")]
 #[allow(deprecated)]
 #[derive(Clone)]
@@ -138,7 +138,8 @@ pub struct Utf16Items<'a> {
 }
 
 /// The possibilities for values decoded from a `u16` stream.
-#[deprecated(since = "1.4.0", reason = "`char::DecodeUtf16` uses `Result<char, u16>` instead")]
+#[rustc_deprecated(since = "1.4.0",
+                   reason = "`char::DecodeUtf16` uses `Result<char, u16>` instead")]
 #[unstable(feature = "decode_utf16", reason = "not exposed in std", issue = "27830")]
 #[allow(deprecated)]
 #[derive(Copy, PartialEq, Eq, Clone, Debug)]
@@ -162,7 +163,7 @@ impl Utf16Item {
     }
 }
 
-#[deprecated(since = "1.4.0", reason = "use `char::DecodeUtf16` instead")]
+#[rustc_deprecated(since = "1.4.0", reason = "use `char::DecodeUtf16` instead")]
 #[unstable(feature = "decode_utf16", reason = "not exposed in std", issue = "27830")]
 #[allow(deprecated)]
 impl<'a> Iterator for Utf16Items<'a> {
@@ -210,7 +211,7 @@ impl<'a> Iterator for Utf16Items<'a> {
 ///                     LoneSurrogate(0xD834)]);
 /// }
 /// ```
-#[deprecated(since = "1.4.0", reason = "renamed to `char::decode_utf16`")]
+#[rustc_deprecated(since = "1.4.0", reason = "renamed to `char::decode_utf16`")]
 #[unstable(feature = "decode_utf16", reason = "not exposed in std", issue = "27830")]
 #[allow(deprecated)]
 pub fn utf16_items<'a>(v: &'a [u16]) -> Utf16Items<'a> {

--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -16,7 +16,7 @@
             reason = "API has not been scrutinized and is highly likely to \
                       either disappear or change",
             issue = "27810")]
-#![deprecated(since = "1.5.0", reason = "replaced with crates.io crates")]
+#![rustc_deprecated(since = "1.5.0", reason = "replaced with crates.io crates")]
 #![allow(missing_docs)]
 #![allow(deprecated)]
 

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -213,7 +213,7 @@ impl CString {
     /// using the pointer.
     #[unstable(feature = "cstr_memory2", reason = "recently added",
                issue = "27769")]
-    #[deprecated(since = "1.4.0", reason = "renamed to from_raw")]
+    #[rustc_deprecated(since = "1.4.0", reason = "renamed to from_raw")]
     pub unsafe fn from_ptr(ptr: *const c_char) -> CString {
         CString::from_raw(ptr as *mut _)
     }
@@ -240,7 +240,7 @@ impl CString {
     /// Failure to call `from_raw` will lead to a memory leak.
     #[unstable(feature = "cstr_memory2", reason = "recently added",
                issue = "27769")]
-    #[deprecated(since = "1.4.0", reason = "renamed to into_raw")]
+    #[rustc_deprecated(since = "1.4.0", reason = "renamed to into_raw")]
     pub fn into_ptr(self) -> *const c_char {
         self.into_raw() as *const _
     }

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -922,7 +922,7 @@ pub fn hard_link<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<(
 /// # Ok(())
 /// # }
 /// ```
-#[deprecated(since = "1.1.0",
+#[rustc_deprecated(since = "1.1.0",
              reason = "replaced with std::os::unix::fs::symlink and \
                        std::os::windows::fs::{symlink_file, symlink_dir}")]
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1176,7 +1176,7 @@ impl Iterator for WalkDir {
                      change and some methods may be removed.  For stable code, \
                      see the std::fs::metadata function.",
            issue = "27725")]
-#[deprecated(since = "1.5.0", reason = "replaced with inherent methods")]
+#[rustc_deprecated(since = "1.5.0", reason = "replaced with inherent methods")]
 pub trait PathExt {
     /// Gets information on the file, directory, etc at this path.
     ///

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -216,6 +216,8 @@
 #![cfg_attr(stage0, allow(unused_attributes))]
 #![cfg_attr(stage0, allow(improper_ctypes))]
 
+#![cfg_attr(stage0, feature(rustc_attrs))]
+#![cfg_attr(stage0, allow(unused_attributes))]
 #![feature(alloc)]
 #![feature(allow_internal_unstable)]
 #![feature(asm)]

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -129,7 +129,7 @@ impl f32 {
     /// Parses a float as with a given radix
     #[unstable(feature = "float_from_str_radix", reason = "recently moved API",
                issue = "27736")]
-    #[deprecated(since = "1.4.0",
+    #[rustc_deprecated(since = "1.4.0",
                  reason = "unclear how useful or correct this is")]
     pub fn from_str_radix(s: &str, radix: u32) -> Result<f32, ParseFloatError> {
         num::Float::from_str_radix(s, radix)

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -86,7 +86,7 @@ impl f64 {
     /// Parses a float as with a given radix
     #[unstable(feature = "float_from_str_radix", reason = "recently moved API",
                issue = "27736")]
-    #[deprecated(since = "1.4.0",
+    #[rustc_deprecated(since = "1.4.0",
                  reason = "unclear how useful or correct this is")]
     pub fn from_str_radix(s: &str, radix: u32) -> Result<f64, ParseFloatError> {
         num::Float::from_str_radix(s, radix)
@@ -355,7 +355,7 @@ impl f64 {
     pub fn is_sign_positive(self) -> bool { num::Float::is_positive(self) }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[deprecated(since = "1.0.0", reason = "renamed to is_sign_positive")]
+    #[rustc_deprecated(since = "1.0.0", reason = "renamed to is_sign_positive")]
     #[inline]
     pub fn is_positive(self) -> bool { num::Float::is_positive(self) }
 
@@ -380,7 +380,7 @@ impl f64 {
     pub fn is_sign_negative(self) -> bool { num::Float::is_negative(self) }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[deprecated(since = "1.0.0", reason = "renamed to is_sign_negative")]
+    #[rustc_deprecated(since = "1.0.0", reason = "renamed to is_sign_negative")]
     #[inline]
     pub fn is_negative(self) -> bool { num::Float::is_negative(self) }
 

--- a/src/libstd/sync/condvar.rs
+++ b/src/libstd/sync/condvar.rs
@@ -166,7 +166,7 @@ impl Condvar {
     /// Like `wait`, the lock specified will be re-acquired when this function
     /// returns, regardless of whether the timeout elapsed or not.
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[deprecated(since = "1.6.0", reason = "replaced by `std::sync::Condvar::wait_timeout`")]
+    #[rustc_deprecated(since = "1.6.0", reason = "replaced by `std::sync::Condvar::wait_timeout`")]
     #[allow(deprecated)]
     pub fn wait_timeout_ms<'a, T>(&self, guard: MutexGuard<'a, T>, ms: u32)
                                   -> LockResult<(MutexGuard<'a, T>, bool)> {
@@ -290,7 +290,8 @@ impl StaticCondvar {
     #[unstable(feature = "static_condvar",
                reason = "may be merged with Condvar in the future",
                issue = "27717")]
-    #[deprecated(since = "1.6.0", reason = "replaced by `std::sync::StaticCondvar::wait_timeout`")]
+    #[rustc_deprecated(since = "1.6.0",
+                       reason = "replaced by `std::sync::StaticCondvar::wait_timeout`")]
     pub fn wait_timeout_ms<'a, T>(&'static self, guard: MutexGuard<'a, T>, ms: u32)
                                   -> LockResult<(MutexGuard<'a, T>, bool)> {
         match self.wait_timeout(guard, Duration::from_millis(ms as u64)) {

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -392,7 +392,7 @@ pub fn catch_panic<F, R>(f: F) -> Result<R>
 /// this function will not return early due to a signal being received or a
 /// spurious wakeup.
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "1.6.0", reason = "replaced by `std::thread::sleep`")]
+#[rustc_deprecated(since = "1.6.0", reason = "replaced by `std::thread::sleep`")]
 pub fn sleep_ms(ms: u32) {
     sleep(Duration::from_millis(ms as u64))
 }
@@ -459,7 +459,7 @@ pub fn park() {
 ///
 /// See the module doc for more detail.
 #[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(since = "1.6.0", reason = "replaced by `std::thread::park_timeout`")]
+#[rustc_deprecated(since = "1.6.0", reason = "replaced by `std::thread::park_timeout`")]
 pub fn park_timeout_ms(ms: u32) {
     park_timeout(Duration::from_millis(ms as u64))
 }

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -381,7 +381,7 @@ pub fn cfg_matches(diagnostic: &SpanHandler, cfgs: &[P<MetaItem>], cfg: &ast::Me
     }
 }
 
-/// Represents the #[stable], #[unstable] and #[deprecated] attributes.
+/// Represents the #[stable], #[unstable] and #[rustc_deprecated] attributes.
 #[derive(RustcEncodable, RustcDecodable, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Stability {
     pub level: StabilityLevel,
@@ -420,7 +420,7 @@ fn find_stability_generic<'a, I>(diagnostic: &SpanHandler,
     'outer: for attr in attrs_iter {
         let tag = attr.name();
         let tag = &*tag;
-        if tag != "deprecated" && tag != "unstable" && tag != "stable" {
+        if tag != "rustc_deprecated" && tag != "unstable" && tag != "stable" {
             continue // not a stability level
         }
 
@@ -443,9 +443,9 @@ fn find_stability_generic<'a, I>(diagnostic: &SpanHandler,
             };
 
             match tag {
-                "deprecated" => {
+                "rustc_deprecated" => {
                     if depr.is_some() {
-                        diagnostic.span_err(item_sp, "multiple deprecated attributes");
+                        diagnostic.span_err(item_sp, "multiple rustc_deprecated attributes");
                         break
                     }
 
@@ -586,7 +586,7 @@ fn find_stability_generic<'a, I>(diagnostic: &SpanHandler,
             }
             stab.depr = Some(depr);
         } else {
-            diagnostic.span_err(item_sp, "deprecated attribute must be paired with \
+            diagnostic.span_err(item_sp, "rustc_deprecated attribute must be paired with \
                                           either stable or unstable attribute");
         }
     }

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -600,7 +600,7 @@ impl<'a> ExtCtxt<'a> {
     }
 
     #[unstable(feature = "rustc_private", issue = "0")]
-    #[deprecated(since = "1.0.0",
+    #[rustc_deprecated(since = "1.0.0",
                  reason = "Replaced with `expander().fold_expr()`")]
     pub fn expand_expr(&mut self, e: P<ast::Expr>) -> P<ast::Expr> {
         self.expander().fold_expr(e)

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -370,7 +370,7 @@ pub const KNOWN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeGat
 
     // FIXME: #14407 these are only looked at on-demand so we can't
     // guarantee they'll have already been checked
-    ("deprecated", Whitelisted, Ungated),
+    ("rustc_deprecated", Whitelisted, Ungated),
     ("must_use", Whitelisted, Ungated),
     ("stable", Whitelisted, Ungated),
     ("unstable", Whitelisted, Ungated),

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -26,6 +26,8 @@
        html_root_url = "https://doc.rust-lang.org/nightly/",
        test(attr(deny(warnings))))]
 
+#![cfg_attr(stage0, feature(rustc_attrs))]
+#![cfg_attr(stage0, allow(unused_attributes))]
 #![feature(associated_consts)]
 #![feature(drain)]
 #![feature(filling_drop)]

--- a/src/libsyntax/util/small_vector.rs
+++ b/src/libsyntax/util/small_vector.rs
@@ -129,7 +129,7 @@ impl<T> SmallVector<T> {
 
     /// Deprecated: use `into_iter`.
     #[unstable(feature = "rustc_private", issue = "0")]
-    #[deprecated(since = "1.0.0", reason = "use into_iter")]
+    #[rustc_deprecated(since = "1.0.0", reason = "use into_iter")]
     pub fn move_iter(self) -> IntoIter<T> {
         self.into_iter()
     }

--- a/src/test/auxiliary/inherited_stability.rs
+++ b/src/test/auxiliary/inherited_stability.rs
@@ -30,7 +30,7 @@ pub mod stable_mod {
 #[unstable(feature = "test_feature", issue = "0")]
 pub mod unstable_mod {
     #[stable(feature = "test_feature", since = "1.0.0")]
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub fn deprecated() {}
 
     pub fn unstable() {}

--- a/src/test/auxiliary/lint_output_format.rs
+++ b/src/test/auxiliary/lint_output_format.rs
@@ -15,7 +15,7 @@
 #![unstable(feature = "test_feature", issue = "0")]
 
 #[stable(feature = "test_feature", since = "1.0.0")]
-#[deprecated(since = "1.0.0", reason = "text")]
+#[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub fn foo() -> usize {
     20
 }

--- a/src/test/auxiliary/lint_stability.rs
+++ b/src/test/auxiliary/lint_stability.rs
@@ -14,17 +14,17 @@
 #![stable(feature = "lint_stability", since = "1.0.0")]
 
 #[stable(feature = "test_feature", since = "1.0.0")]
-#[deprecated(since = "1.0.0", reason = "text")]
+#[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub fn deprecated() {}
 #[stable(feature = "test_feature", since = "1.0.0")]
-#[deprecated(since = "1.0.0", reason = "text")]
+#[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub fn deprecated_text() {}
 
 #[unstable(feature = "test_feature", issue = "0")]
-#[deprecated(since = "1.0.0", reason = "text")]
+#[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub fn deprecated_unstable() {}
 #[unstable(feature = "test_feature", issue = "0")]
-#[deprecated(since = "1.0.0", reason = "text")]
+#[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub fn deprecated_unstable_text() {}
 
 #[unstable(feature = "test_feature", issue = "0")]
@@ -42,17 +42,17 @@ pub struct MethodTester;
 
 impl MethodTester {
     #[stable(feature = "test_feature", since = "1.0.0")]
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub fn method_deprecated(&self) {}
     #[stable(feature = "test_feature", since = "1.0.0")]
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub fn method_deprecated_text(&self) {}
 
     #[unstable(feature = "test_feature", issue = "0")]
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub fn method_deprecated_unstable(&self) {}
     #[unstable(feature = "test_feature", issue = "0")]
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub fn method_deprecated_unstable_text(&self) {}
 
     #[unstable(feature = "test_feature", issue = "0")]
@@ -69,17 +69,17 @@ impl MethodTester {
 #[stable(feature = "test_feature", since = "1.0.0")]
 pub trait Trait {
     #[stable(feature = "test_feature", since = "1.0.0")]
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     fn trait_deprecated(&self) {}
     #[stable(feature = "test_feature", since = "1.0.0")]
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     fn trait_deprecated_text(&self) {}
 
     #[unstable(feature = "test_feature", issue = "0")]
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     fn trait_deprecated_unstable(&self) {}
     #[unstable(feature = "test_feature", issue = "0")]
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     fn trait_deprecated_unstable_text(&self) {}
 
     #[unstable(feature = "test_feature", issue = "0")]
@@ -100,12 +100,12 @@ impl Trait for MethodTester {}
 pub trait UnstableTrait { fn dummy(&self) { } }
 
 #[stable(feature = "test_feature", since = "1.0.0")]
-#[deprecated(since = "1.0.0", reason = "text")]
+#[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub struct DeprecatedStruct {
     #[stable(feature = "test_feature", since = "1.0.0")] pub i: isize
 }
 #[unstable(feature = "test_feature", issue = "0")]
-#[deprecated(since = "1.0.0", reason = "text")]
+#[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub struct DeprecatedUnstableStruct {
     #[stable(feature = "test_feature", since = "1.0.0")] pub i: isize
 }
@@ -119,10 +119,10 @@ pub struct StableStruct {
 }
 
 #[stable(feature = "test_feature", since = "1.0.0")]
-#[deprecated(since = "1.0.0", reason = "text")]
+#[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub struct DeprecatedUnitStruct;
 #[unstable(feature = "test_feature", issue = "0")]
-#[deprecated(since = "1.0.0", reason = "text")]
+#[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub struct DeprecatedUnstableUnitStruct;
 #[unstable(feature = "test_feature", issue = "0")]
 pub struct UnstableUnitStruct;
@@ -132,10 +132,10 @@ pub struct StableUnitStruct;
 #[stable(feature = "test_feature", since = "1.0.0")]
 pub enum Enum {
     #[stable(feature = "test_feature", since = "1.0.0")]
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     DeprecatedVariant,
     #[unstable(feature = "test_feature", issue = "0")]
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     DeprecatedUnstableVariant,
     #[unstable(feature = "test_feature", issue = "0")]
     UnstableVariant,
@@ -145,10 +145,10 @@ pub enum Enum {
 }
 
 #[stable(feature = "test_feature", since = "1.0.0")]
-#[deprecated(since = "1.0.0", reason = "text")]
+#[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub struct DeprecatedTupleStruct(#[stable(feature = "rust1", since = "1.0.0")] pub isize);
 #[unstable(feature = "test_feature", issue = "0")]
-#[deprecated(since = "1.0.0", reason = "text")]
+#[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub struct DeprecatedUnstableTupleStruct(#[stable(feature = "rust1", since = "1.0.0")] pub isize);
 #[unstable(feature = "test_feature", issue = "0")]
 pub struct UnstableTupleStruct(#[stable(feature = "rust1", since = "1.0.0")] pub isize);

--- a/src/test/auxiliary/lint_stability_fields.rs
+++ b/src/test/auxiliary/lint_stability_fields.rs
@@ -18,7 +18,7 @@ pub struct Stable {
     pub inherit: u8, // it's a lie (stable doesn't inherit)
     #[unstable(feature = "test_feature", issue = "0")]
     pub override1: u8,
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     #[unstable(feature = "test_feature", issue = "0")]
     pub override2: u8,
 }
@@ -27,14 +27,14 @@ pub struct Stable {
 pub struct Stable2(#[stable(feature = "rust1", since = "1.0.0")] pub u8,
                    #[unstable(feature = "test_feature", issue = "0")] pub u8,
                    #[unstable(feature = "test_feature", issue = "0")]
-                   #[deprecated(since = "1.0.0", reason = "text")] pub u8);
+                   #[rustc_deprecated(since = "1.0.0", reason = "text")] pub u8);
 
 #[unstable(feature = "test_feature", issue = "0")]
 pub struct Unstable {
     pub inherit: u8,
     #[stable(feature = "rust1", since = "1.0.0")]
     pub override1: u8,
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     #[unstable(feature = "test_feature", issue = "0")]
     pub override2: u8,
 }
@@ -43,10 +43,10 @@ pub struct Unstable {
 pub struct Unstable2(pub u8,
                      #[stable(feature = "rust1", since = "1.0.0")] pub u8,
                      #[unstable(feature = "test_feature", issue = "0")]
-                     #[deprecated(since = "1.0.0", reason = "text")] pub u8);
+                     #[rustc_deprecated(since = "1.0.0", reason = "text")] pub u8);
 
 #[unstable(feature = "test_feature", issue = "0")]
-#[deprecated(since = "1.0.0", reason = "text")]
+#[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub struct Deprecated {
     pub inherit: u8,
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -56,7 +56,7 @@ pub struct Deprecated {
 }
 
 #[unstable(feature = "test_feature", issue = "0")]
-#[deprecated(since = "1.0.0", reason = "text")]
+#[rustc_deprecated(since = "1.0.0", reason = "text")]
 pub struct Deprecated2(pub u8,
                        #[stable(feature = "rust1", since = "1.0.0")] pub u8,
                        #[unstable(feature = "test_feature", issue = "0")] pub u8);

--- a/src/test/compile-fail/issue-17337.rs
+++ b/src/test/compile-fail/issue-17337.rs
@@ -18,7 +18,7 @@ struct Foo;
 
 impl Foo {
     #[unstable(feature = "test_feature", issue = "0")]
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     fn foo(self) {}
 }
 

--- a/src/test/compile-fail/lint-stability-fields.rs
+++ b/src/test/compile-fail/lint-stability-fields.rs
@@ -191,7 +191,7 @@ mod this_crate {
         inherit: u8,
         #[unstable(feature = "test_feature", issue = "0")]
         override1: u8,
-        #[deprecated(since = "1.0.0", reason = "text")]
+        #[rustc_deprecated(since = "1.0.0", reason = "text")]
         #[unstable(feature = "test_feature", issue = "0")]
         override2: u8,
     }
@@ -200,14 +200,14 @@ mod this_crate {
     struct Stable2(u8,
                    #[stable(feature = "rust1", since = "1.0.0")] u8,
                    #[unstable(feature = "test_feature", issue = "0")]
-                   #[deprecated(since = "1.0.0", reason = "text")] u8);
+                   #[rustc_deprecated(since = "1.0.0", reason = "text")] u8);
 
     #[unstable(feature = "test_feature", issue = "0")]
     struct Unstable {
         inherit: u8,
         #[stable(feature = "rust1", since = "1.0.0")]
         override1: u8,
-        #[deprecated(since = "1.0.0", reason = "text")]
+        #[rustc_deprecated(since = "1.0.0", reason = "text")]
         #[unstable(feature = "test_feature", issue = "0")]
         override2: u8,
     }
@@ -216,10 +216,10 @@ mod this_crate {
     struct Unstable2(u8,
                      #[stable(feature = "rust1", since = "1.0.0")] u8,
                      #[unstable(feature = "test_feature", issue = "0")]
-                     #[deprecated(since = "1.0.0", reason = "text")] u8);
+                     #[rustc_deprecated(since = "1.0.0", reason = "text")] u8);
 
     #[unstable(feature = "test_feature", issue = "0")]
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     struct Deprecated {
         inherit: u8,
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -229,7 +229,7 @@ mod this_crate {
     }
 
     #[unstable(feature = "test_feature", issue = "0")]
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     struct Deprecated2(u8,
                        #[stable(feature = "rust1", since = "1.0.0")] u8,
                        #[unstable(feature = "test_feature", issue = "0")] u8);

--- a/src/test/compile-fail/lint-stability.rs
+++ b/src/test/compile-fail/lint-stability.rs
@@ -262,10 +262,10 @@ mod inheritance {
 
 mod this_crate {
     #[unstable(feature = "test_feature", issue = "0")]
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub fn deprecated() {}
     #[unstable(feature = "test_feature", issue = "0")]
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub fn deprecated_text() {}
 
     #[unstable(feature = "test_feature", issue = "0")]
@@ -283,10 +283,10 @@ mod this_crate {
 
     impl MethodTester {
         #[unstable(feature = "test_feature", issue = "0")]
-        #[deprecated(since = "1.0.0", reason = "text")]
+        #[rustc_deprecated(since = "1.0.0", reason = "text")]
         pub fn method_deprecated(&self) {}
         #[unstable(feature = "test_feature", issue = "0")]
-        #[deprecated(since = "1.0.0", reason = "text")]
+        #[rustc_deprecated(since = "1.0.0", reason = "text")]
         pub fn method_deprecated_text(&self) {}
 
         #[unstable(feature = "test_feature", issue = "0")]
@@ -302,10 +302,10 @@ mod this_crate {
 
     pub trait Trait {
         #[unstable(feature = "test_feature", issue = "0")]
-        #[deprecated(since = "1.0.0", reason = "text")]
+        #[rustc_deprecated(since = "1.0.0", reason = "text")]
         fn trait_deprecated(&self) {}
         #[unstable(feature = "test_feature", issue = "0")]
-        #[deprecated(since = "1.0.0", reason = "text")]
+        #[rustc_deprecated(since = "1.0.0", reason = "text")]
         fn trait_deprecated_text(&self) {}
 
         #[unstable(feature = "test_feature", issue = "0")]
@@ -322,7 +322,7 @@ mod this_crate {
     impl Trait for MethodTester {}
 
     #[unstable(feature = "test_feature", issue = "0")]
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub struct DeprecatedStruct {
         #[stable(feature = "test_feature", since = "1.0.0")] i: isize
     }
@@ -336,7 +336,7 @@ mod this_crate {
     }
 
     #[unstable(feature = "test_feature", issue = "0")]
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub struct DeprecatedUnitStruct;
     #[unstable(feature = "test_feature", issue = "0")]
     pub struct UnstableUnitStruct;
@@ -345,7 +345,7 @@ mod this_crate {
 
     pub enum Enum {
         #[unstable(feature = "test_feature", issue = "0")]
-        #[deprecated(since = "1.0.0", reason = "text")]
+        #[rustc_deprecated(since = "1.0.0", reason = "text")]
         DeprecatedVariant,
         #[unstable(feature = "test_feature", issue = "0")]
         UnstableVariant,
@@ -355,7 +355,7 @@ mod this_crate {
     }
 
     #[unstable(feature = "test_feature", issue = "0")]
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub struct DeprecatedTupleStruct(isize);
     #[unstable(feature = "test_feature", issue = "0")]
     pub struct UnstableTupleStruct(isize);
@@ -476,7 +476,7 @@ mod this_crate {
     }
 
     #[unstable(feature = "test_feature", issue = "0")]
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     fn test_fn_body() {
         fn fn_in_body() {}
         fn_in_body(); //~ ERROR use of deprecated item: text
@@ -484,7 +484,7 @@ mod this_crate {
 
     impl MethodTester {
         #[unstable(feature = "test_feature", issue = "0")]
-        #[deprecated(since = "1.0.0", reason = "text")]
+        #[rustc_deprecated(since = "1.0.0", reason = "text")]
         fn test_method_body(&self) {
             fn fn_in_body() {}
             fn_in_body(); //~ ERROR use of deprecated item: text
@@ -492,7 +492,7 @@ mod this_crate {
     }
 
     #[unstable(feature = "test_feature", issue = "0")]
-    #[deprecated(since = "1.0.0", reason = "text")]
+    #[rustc_deprecated(since = "1.0.0", reason = "text")]
     pub trait DeprecatedTrait {
         fn dummy(&self) { }
     }

--- a/src/test/compile-fail/stability-attribute-non-staged.rs
+++ b/src/test/compile-fail/stability-attribute-non-staged.rs
@@ -10,5 +10,5 @@
 
 #[unstable] //~ ERROR: stability attributes may not be used
 #[stable] //~ ERROR: stability attributes may not be used
-#[deprecated] //~ ERROR: stability attributes may not be used
+#[rustc_deprecated] //~ ERROR: stability attributes may not be used
 fn main() { }

--- a/src/test/compile-fail/stability-attribute-sanity.rs
+++ b/src/test/compile-fail/stability-attribute-sanity.rs
@@ -46,11 +46,11 @@ mod bogus_attribute_types_2 {
     fn f4() { }
 
     #[stable(feature = "a", since = "b")]
-    #[deprecated] //~ ERROR incorrect stability attribute type
+    #[rustc_deprecated] //~ ERROR incorrect stability attribute type
     fn f5() { }
 
     #[stable(feature = "a", since = "b")]
-    #[deprecated = "a"] //~ ERROR incorrect stability attribute type
+    #[rustc_deprecated = "a"] //~ ERROR incorrect stability attribute type
     fn f6() { }
 }
 
@@ -70,7 +70,7 @@ mod missing_version {
     fn f1() { }
 
     #[stable(feature = "a", since = "b")]
-    #[deprecated(reason = "a")] //~ ERROR missing 'since'
+    #[rustc_deprecated(reason = "a")] //~ ERROR missing 'since'
     fn f2() { }
 }
 
@@ -87,12 +87,12 @@ fn multiple2() { } //~ ERROR multiple stability levels
 fn multiple3() { } //~ ERROR multiple stability levels
 
 #[stable(feature = "a", since = "b")]
-#[deprecated(since = "b", reason = "text")]
-#[deprecated(since = "b", reason = "text")]
-fn multiple4() { } //~ ERROR multiple deprecated attributes
+#[rustc_deprecated(since = "b", reason = "text")]
+#[rustc_deprecated(since = "b", reason = "text")]
+fn multiple4() { } //~ ERROR multiple rustc_deprecated attributes
 //~^ ERROR Invalid stability or deprecation version found
 
-#[deprecated(since = "a", reason = "text")]
-fn deprecated_without_unstable_or_stable() { } //~ ERROR deprecated attribute must be paired
+#[rustc_deprecated(since = "a", reason = "text")]
+fn deprecated_without_unstable_or_stable() { } //~ ERROR rustc_deprecated attribute must be paired
 
 fn main() { }


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/29935

The deprecation lint is still called "deprecated", so people can continue using `#[allow(deprecated)]` and similar things.
