### PR TITLE
select: treat ErrorCandidate as a real error

### DIFF
--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -628,9 +628,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         }
 
         match self.candidate_from_obligation(stack) {
-            Ok(Some(c)) => self.evaluate_candidate(stack, &c),
+            Err(..) | Ok(Some(ErrorCandidate)) => EvaluatedToErr,
             Ok(None) => EvaluatedToAmbig,
-            Err(..) => EvaluatedToErr
+            Ok(Some(c)) => self.evaluate_candidate(stack, &c),
         }
     }
 
@@ -754,7 +754,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                                               stack: &TraitObligationStack<'o, 'tcx>)
                                               -> SelectionResult<'tcx, SelectionCandidate<'tcx>>
     {
-        if stack.obligation.predicate.0.self_ty().references_error() {
+        if stack.obligation.predicate.references_error() {
             return Ok(Some(ErrorCandidate));
         }
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3507,9 +3507,10 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
         let t_cast = structurally_resolved_type(fcx, expr.span, t_cast);
         check_expr_with_expectation(fcx, e, ExpectCastableToType(t_cast));
         let t_expr = fcx.expr_ty(e);
+        let t_cast = fcx.infcx().resolve_type_vars_if_possible(&t_cast);
 
         // Eagerly check for some obvious errors.
-        if t_expr.references_error() {
+        if t_expr.references_error() || t_cast.references_error() {
             fcx.write_error(id);
         } else if !fcx.type_is_known_to_be_sized(t_cast, expr.span) {
             report_cast_to_unsized_type(fcx, expr.span, t.span, e.span, t_cast, t_expr, id);

--- a/src/test/run-pass/issue-29857.rs
+++ b/src/test/run-pass/issue-29857.rs
@@ -1,0 +1,25 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// check that we don't go mad when there are errors in trait evaluation
+
+use std::marker::PhantomData;
+
+pub trait Foo { type Output: 'static; }
+pub trait Bar<P> {}
+pub trait Baz<P> {}
+pub struct Qux<T>(PhantomData<*mut T>);
+
+impl<P, T: Baz<P>> Bar<P> for Option<T> {}
+impl<T> Bar<*mut T> for Option<Qux<T>> {}
+
+impl<T: 'static, W: Foo<Output=T>> Baz<*mut T> for W {}
+
+fn main() {}


### PR DESCRIPTION
Otherwise, projection can result in type errors that are unified
into the trait inputs. We should probably refactor the
`normalize_to_error` mess.

We could instead change `ctp::identify_constrained_type_params` to put a projection's desugar selection before the projection. Would you like that better?

Fixes #29857.

r? @nikomatsakis 
