### PR TITLE
Change TraitRef subtyping checks to equality

### DIFF
--- a/src/librustc/middle/infer/mod.rs
+++ b/src/librustc/middle/infer/mod.rs
@@ -474,14 +474,26 @@ pub fn mk_eqty<'a, 'tcx>(cx: &InferCtxt<'a, 'tcx>,
     cx.commit_if_ok(|_| cx.eq_types(a_is_expected, origin, a, b))
 }
 
-pub fn mk_sub_poly_trait_refs<'a, 'tcx>(cx: &InferCtxt<'a, 'tcx>,
+pub fn mk_eq_trait_refs<'a, 'tcx>(cx: &InferCtxt<'a, 'tcx>,
                                    a_is_expected: bool,
                                    origin: TypeOrigin,
-                                   a: ty::PolyTraitRef<'tcx>,
-                                   b: ty::PolyTraitRef<'tcx>)
+                                   a: ty::TraitRef<'tcx>,
+                                   b: ty::TraitRef<'tcx>)
                                    -> UnitResult<'tcx>
 {
-    debug!("mk_sub_trait_refs({:?} <: {:?})",
+    debug!("mk_eq_trait_refs({:?} <: {:?})",
+           a, b);
+    cx.commit_if_ok(|_| cx.eq_trait_refs(a_is_expected, origin, a.clone(), b.clone()))
+}
+
+pub fn mk_sub_poly_trait_refs<'a, 'tcx>(cx: &InferCtxt<'a, 'tcx>,
+                                        a_is_expected: bool,
+                                        origin: TypeOrigin,
+                                        a: ty::PolyTraitRef<'tcx>,
+                                        b: ty::PolyTraitRef<'tcx>)
+                                        -> UnitResult<'tcx>
+{
+    debug!("mk_sub_poly_trait_refs({:?} <: {:?})",
            a, b);
     cx.commit_if_ok(|_| cx.sub_poly_trait_refs(a_is_expected, origin, a.clone(), b.clone()))
 }
@@ -857,14 +869,14 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         })
     }
 
-    pub fn sub_trait_refs(&self,
+    pub fn eq_trait_refs(&self,
                           a_is_expected: bool,
                           origin: TypeOrigin,
                           a: ty::TraitRef<'tcx>,
                           b: ty::TraitRef<'tcx>)
                           -> UnitResult<'tcx>
     {
-        debug!("sub_trait_refs({:?} <: {:?})",
+        debug!("eq_trait_refs({:?} <: {:?})",
                a,
                b);
         self.commit_if_ok(|_| {
@@ -872,7 +884,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 origin: origin,
                 values: TraitRefs(expected_found(a_is_expected, a.clone(), b.clone()))
             };
-            self.sub(a_is_expected, trace).relate(&a, &b).map(|_| ())
+            self.equate(a_is_expected, trace).relate(&a, &b).map(|_| ())
         })
     }
 

--- a/src/librustc/middle/traits/project.rs
+++ b/src/librustc/middle/traits/project.rs
@@ -902,10 +902,10 @@ fn confirm_param_env_candidate<'cx,'tcx>(
                obligation.predicate.item_name);
 
     let origin = infer::RelateOutputImplTypes(obligation.cause.span);
-    match infcx.sub_trait_refs(false,
-                               origin,
-                               obligation.predicate.trait_ref.clone(),
-                               projection.projection_ty.trait_ref.clone()) {
+    match infcx.eq_trait_refs(false,
+                              origin,
+                              obligation.predicate.trait_ref.clone(),
+                              projection.projection_ty.trait_ref.clone()) {
         Ok(()) => { }
         Err(e) => {
             selcx.tcx().sess.span_bug(

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -2695,11 +2695,11 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                skol_obligation_trait_ref);
 
         let origin = infer::RelateOutputImplTypes(obligation.cause.span);
-        if let Err(e) = self.infcx.sub_trait_refs(false,
-                                                  origin,
-                                                  impl_trait_ref.value.clone(),
-                                                  skol_obligation_trait_ref) {
-            debug!("match_impl: failed sub_trait_refs due to `{}`", e);
+        if let Err(e) = self.infcx.eq_trait_refs(false,
+                                                 origin,
+                                                 impl_trait_ref.value.clone(),
+                                                 skol_obligation_trait_ref) {
+            debug!("match_impl: failed eq_trait_refs due to `{}`", e);
             return Err(());
         }
 


### PR DESCRIPTION
Trait references are always invariant, so all uses of subtyping between
them are equivalent to using equality.

Moreover, the overlap check was previously performed twice per impl
pair, once in each direction. It is now performed only once, and
internally uses the equality check.

On glium, a crate that spends some time in coherence, this change sped
up coherence checking by a few percent (not very significant).

r? @nikomatsakis 
