### PR TITLE
rustc: Fix `extern crate` being order dependent

### DIFF
--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -547,7 +547,12 @@ impl<'a> Context<'a> {
                     continue
                 }
             };
-            if ret.is_some() {
+            // If we've already found a candidate and we're not matching hashes,
+            // emit an error about duplicate candidates found. If we're matching
+            // based on a hash, however, then if we've gotten this far both
+            // candidates have the same hash, so they're not actually
+            // duplicates that we should warn about.
+            if ret.is_some() && self.hash.is_none() {
                 span_err!(self.sess, self.span, E0465,
                           "multiple {} candidates for `{}` found",
                           flavor, self.crate_name);

--- a/src/test/run-make/extern-multiple-copies/Makefile
+++ b/src/test/run-make/extern-multiple-copies/Makefile
@@ -1,0 +1,8 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) foo1.rs
+	$(RUSTC) foo2.rs
+	mkdir $(TMPDIR)/foo
+	cp $(TMPDIR)/libfoo1.rlib $(TMPDIR)/foo/libfoo1.rlib
+	$(RUSTC) bar.rs --extern foo1=$(TMPDIR)/libfoo1.rlib -L $(TMPDIR)/foo

--- a/src/test/run-make/extern-multiple-copies/bar.rs
+++ b/src/test/run-make/extern-multiple-copies/bar.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate foo2; // foo2 first to exhibit the bug
+extern crate foo1;
+
+fn main() {
+    /* ... */
+}

--- a/src/test/run-make/extern-multiple-copies/foo1.rs
+++ b/src/test/run-make/extern-multiple-copies/foo1.rs
@@ -1,0 +1,11 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rlib"]

--- a/src/test/run-make/extern-multiple-copies/foo2.rs
+++ b/src/test/run-make/extern-multiple-copies/foo2.rs
@@ -1,0 +1,11 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rlib"]


### PR DESCRIPTION
This commit fixes a bug where a crate could fail to compile depending on the
order of `extern crate` directives at the top of the crate. Specifically, if the
same crate is found at two locations, then if it's loaded first via `--extern`
it will not emit a duplicate warning, but if it's first loaded transitively
via a dep and _then_ via `--extern` an error will be emitted.

The loader was tweaked to catch this scenario and coalesce the loading of these
two crates to prevent errors from being emitted.
