### PR TITLE
Provide overlapping types for coherence errors

### DIFF
--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -1569,8 +1569,8 @@ struct Foo {
     value: usize
 }
 
-impl MyTrait for Foo { // error: conflicting implementations for trait
-                       //        `MyTrait`
+impl MyTrait for Foo { // error: conflicting implementations of trait
+                       //        `MyTrait` for type `Foo`
     fn get(&self) -> usize { self.value }
 }
 ```

--- a/src/test/compile-fail/coherence-conflicting-negative-trait-impl.rs
+++ b/src/test/compile-fail/coherence-conflicting-negative-trait-impl.rs
@@ -15,14 +15,14 @@ trait MyTrait {}
 struct TestType<T>(::std::marker::PhantomData<T>);
 
 unsafe impl<T: MyTrait+'static> Send for TestType<T> {}
-//~^ ERROR conflicting implementations for trait `core::marker::Send`
-//~^^ ERROR conflicting implementations for trait `core::marker::Send`
+//~^ ERROR conflicting implementations of trait `core::marker::Send`
+//~^^ ERROR conflicting implementations of trait `core::marker::Send`
 
 impl<T: MyTrait> !Send for TestType<T> {}
-//~^ ERROR conflicting implementations for trait `core::marker::Send`
+//~^ ERROR conflicting implementations of trait `core::marker::Send`
 
 unsafe impl<T:'static> Send for TestType<T> {}
-//~^ ERROR error: conflicting implementations for trait `core::marker::Send`
+//~^ ERROR error: conflicting implementations of trait `core::marker::Send`
 
 impl !Send for TestType<i32> {}
 

--- a/src/test/compile-fail/coherence-default-trait-impl.rs
+++ b/src/test/compile-fail/coherence-default-trait-impl.rs
@@ -15,7 +15,7 @@ trait MyTrait {}
 impl MyTrait for .. {}
 
 impl MyTrait for .. {}
-//~^ ERROR conflicting implementations for trait `MyTrait`
+//~^ ERROR conflicting implementations of trait `MyTrait`
 
 trait MySafeTrait {}
 

--- a/src/test/compile-fail/coherence-overlap-messages.rs
+++ b/src/test/compile-fail/coherence-overlap-messages.rs
@@ -1,0 +1,42 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Foo {}
+
+impl<T> Foo for T {} //~ ERROR conflicting implementations of trait `Foo`:
+impl<U> Foo for U {}
+
+trait Bar {}
+
+impl<T> Bar for T {} //~ ERROR conflicting implementations of trait `Bar` for type `u8`:
+impl Bar for u8 {}
+
+trait Baz<T> {}
+
+impl<T, U> Baz<U> for T {} //~ ERROR conflicting implementations of trait `Baz<_>` for type `u8`:
+impl<T> Baz<T> for u8 {}
+
+trait Quux<T> {}
+
+impl<T, U> Quux<U> for T {} //~ ERROR conflicting implementations of trait `Quux<_>`:
+impl<T> Quux<T> for T {}
+
+trait Qaar<T> {}
+
+impl<T, U> Qaar<U> for T {} //~ ERROR conflicting implementations of trait `Qaar<u8>`:
+impl<T> Qaar<u8> for T {}
+
+trait Qaax<T> {}
+
+impl<T, U> Qaax<U> for T {}
+//~^ ERROR conflicting implementations of trait `Qaax<u8>` for type `u32`:
+impl Qaax<u8> for u32 {}
+
+fn main() {}

--- a/src/test/compile-fail/issue-28568.rs
+++ b/src/test/compile-fail/issue-28568.rs
@@ -11,12 +11,12 @@
 struct MyStruct;
 
 impl Drop for MyStruct {
-//~^ ERROR conflicting implementations for trait
+//~^ ERROR conflicting implementations of trait
     fn drop(&mut self) { }
 }
 
 impl Drop for MyStruct {
-//~^ NOTE conflicting implementation here
+//~^ NOTE conflicting implementation is here
     fn drop(&mut self) { }
 }
 


### PR DESCRIPTION
Currently, a coherence error based on overlapping impls simply mentions
the trait, and points to the two conflicting impls:

```
error: conflicting implementations for trait `Foo`
```

With this commit, the error will include all input types to the
trait (including the `Self` type) after unification between the
overlapping impls. In other words, the error message will provide
feedback with full type details, like:

```
error: conflicting implementations of trait `Foo<u32>` for type `u8`:
```

When the `Self` type for the two impls unify to an inference variable,
it is elided in the output, since "for type `_`" is just noise in that
case.

Closes #23980

r? @nikomatsakis 
