### PR TITLE
Avoid FCA loads and extractvalue when copying fat pointers

### DIFF
--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -1223,6 +1223,9 @@ pub fn memcpy_ty<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, dst: ValueRef, src: ValueRe
         let llsz = llsize_of(ccx, llty);
         let llalign = type_of::align_of(ccx, t);
         call_memcpy(bcx, dst, src, llsz, llalign as u32);
+    } else if common::type_is_fat_ptr(bcx.tcx(), t) {
+        let (data, extra) = load_fat_ptr(bcx, src, t);
+        store_fat_ptr(bcx, data, extra, dst, t);
     } else {
         store_ty(bcx, load_ty(bcx, src, t), dst, t);
     }

--- a/src/test/codegen/fatptr.rs
+++ b/src/test/codegen/fatptr.rs
@@ -1,0 +1,22 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -C no-prepopulate-passes
+
+#![crate_type = "lib"]
+
+pub trait T {}
+
+// CHECK-LABEL: @copy_fat_ptr
+#[no_mangle]
+pub fn copy_fat_ptr(x: &T) {
+// CHECK-NOT: extractvalue
+    let x2 = x;
+}


### PR DESCRIPTION
Since fat pointers do not qualify as structural types, they got copied
using load_ty and store_ty, which means that we load an FCA and use
extractvalue to get the components of the fat pointer. This breaks
certain optimizations in LLVM.

Found via apasel422/ref_count#13
