### PR TITLE
change link on book front page trpl -> book

### DIFF
--- a/src/doc/book/README.md
+++ b/src/doc/book/README.md
@@ -42,7 +42,6 @@ Copious cross-linking connects these parts together.
 ### Contributing
 
 The source files from which this book is generated can be found on
-[GitHub][trpl].
+[GitHub][book].
 
-[trpl]: https://github.com/rust-lang/rust/tree/master/src/doc/trpl
-
+[book]: https://github.com/rust-lang/rust/tree/master/src/doc/book


### PR DESCRIPTION
This commit changes the location of the rust docs.
https://github.com/rust-lang/rust/commit/024aa9a345e92aa1926517c4d9b16bd83e74c10d
Clicking the contribution link on the front page therefore becomes a 'not found' error.
