### PR TITLE
Make unreachable_code lint warn on diverging call arguments as well

### DIFF
--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -678,9 +678,9 @@ impl<'a> ExtCtxt<'a> {
     pub fn bt_push(&mut self, ei: ExpnInfo) {
         self.recursion_count += 1;
         if self.recursion_count > self.ecfg.recursion_limit {
-            panic!(self.span_fatal(ei.call_site,
+            self.span_fatal(ei.call_site,
                             &format!("recursion limit reached while expanding the macro `{}`",
-                                    ei.callee.name())));
+                                    ei.callee.name()));
         }
 
         let mut call_site = ei.call_site;

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -209,12 +209,12 @@ fn generic_extension<'cx>(cx: &'cx ExtCtxt,
                 best_fail_msg = (*msg).clone();
             },
             Error(err_sp, ref msg) => {
-                panic!(cx.span_fatal(err_sp.substitute_dummy(sp), &msg[..]))
+                cx.span_fatal(err_sp.substitute_dummy(sp), &msg[..])
             }
         }
     }
 
-    panic!(cx.span_fatal(best_fail_spot.substitute_dummy(sp), &best_fail_msg[..]));
+     cx.span_fatal(best_fail_spot.substitute_dummy(sp), &best_fail_msg[..]);
 }
 
 // Note that macro-by-example's input is also matched against a token tree:

--- a/src/test/compile-fail/unreachable-in-call.rs
+++ b/src/test/compile-fail/unreachable-in-call.rs
@@ -8,11 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Test that the unboxed closure sugar can be used with an arbitrary
-// struct type and that it is equivalent to the same syntax using
-// angle brackets. This test covers only simple types and in
-// particular doesn't test bound regions.
-
 #![allow(dead_code)]
 #![deny(unreachable_code)]
 

--- a/src/test/compile-fail/unreachable-in-call.rs
+++ b/src/test/compile-fail/unreachable-in-call.rs
@@ -1,0 +1,37 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that the unboxed closure sugar can be used with an arbitrary
+// struct type and that it is equivalent to the same syntax using
+// angle brackets. This test covers only simple types and in
+// particular doesn't test bound regions.
+
+#![allow(dead_code)]
+#![deny(unreachable_code)]
+
+fn diverge() -> ! { panic!() }
+
+fn get_u8() -> u8 {
+    1
+}
+fn call(_: u8, _: u8) {
+
+}
+fn diverge_first() {
+    call(diverge(),
+         get_u8()); //~ ERROR unreachable expression
+}
+fn diverge_second() {
+    call( //~ ERROR unreachable call
+        get_u8(),
+        diverge());
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #1889
