### PR TITLE
Add TRACE to the known log levels

### DIFF
--- a/src/liblog/directive.rs
+++ b/src/liblog/directive.rs
@@ -17,7 +17,7 @@ pub struct LogDirective {
     pub level: u32,
 }
 
-pub const LOG_LEVEL_NAMES: [&'static str; 4] = ["ERROR", "WARN", "INFO", "DEBUG"];
+pub const LOG_LEVEL_NAMES: [&'static str; 5] = ["ERROR", "WARN", "INFO", "DEBUG", "TRACE"];
 
 /// Parse an individual log level that is either a number or a symbolic log level
 fn parse_log_level(level: &str) -> Option<u32> {


### PR DESCRIPTION
The `log` crate on crates.io already knows `TRACE`, but the internal liblog doesn't, which causes it to spew errors when a `TRACE` level is defined. I made `TRACE` behave like `DEBUG`.
