### PR TITLE
Clarify reference about main returning unit

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -649,8 +649,8 @@ apply to the crate as a whole.
 ```
 
 A crate that contains a `main` function can be compiled to an executable. If a
-`main` function is present, its return type must be [`unit`](#tuple-types)
-and it must take no arguments.
+`main` function is present, its return type must be `()`
+("[unit](#tuple-types)") and it must take no arguments.
 
 # Items and attributes
 


### PR DESCRIPTION
`unit` was in code formatting, which is wrong, since it's not actual code. The correct code is `()`.
