### PR TITLE
Fix docs for TcpListener::bind

### DIFF
--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -234,7 +234,7 @@ impl TcpListener {
     ///
     /// Binding with a port number of 0 will request that the OS assigns a port
     /// to this listener. The port allocated can be queried via the
-    /// `socket_addr` function.
+    /// `local_addr` method.
     ///
     /// The address type can be any implementor of `ToSocketAddrs` trait. See
     /// its documentation for concrete examples.


### PR DESCRIPTION
`socket_addr` was renamed to `local_addr` in 1.0beta.

See: f798674b86382929ca17c88de422a6e2fdb27f2a

r? @steveklabnik 
