### PR TITLE
fix docs for compiler builtin macros

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -472,8 +472,8 @@ pub mod builtin {
     /// boolean expression evaluation of configuration flags. This frequently
     /// leads to less duplicated code.
     ///
-    /// The syntax given to this macro is the same syntax as the `cfg`
-    /// attribute (so `$cfg:meta` is not _exactly_ correct).
+    /// The syntax given to this macro is the same syntax as [the `cfg`
+    /// attribute](../reference.html#conditional-compilation).
     ///
     /// # Examples
     ///
@@ -486,7 +486,7 @@ pub mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[macro_export]
-    macro_rules! cfg { ($cfg:meta) => ({ /* compiler built-in */ }) }
+    macro_rules! cfg { ($($cfg:tt)*) => ({ /* compiler built-in */ }) }
 
     /// Parse the current given file as an expression.
     ///

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -473,7 +473,7 @@ pub mod builtin {
     /// leads to less duplicated code.
     ///
     /// The syntax given to this macro is the same syntax as the `cfg`
-    /// attribute.
+    /// attribute (so `$cfg:meta` is not _exactly_ correct).
     ///
     /// # Examples
     ///
@@ -486,7 +486,7 @@ pub mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[macro_export]
-    macro_rules! cfg { ($cfg:tt) => ({ /* compiler built-in */ }) }
+    macro_rules! cfg { ($cfg:meta) => ({ /* compiler built-in */ }) }
 
     /// Parse the current given file as an expression.
     ///
@@ -501,5 +501,5 @@ pub mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[macro_export]
-    macro_rules! include { ($cfg:tt) => ({ /* compiler built-in */ }) }
+    macro_rules! include { ($file:expr) => ({ /* compiler built-in */ }) }
 }


### PR DESCRIPTION
Fixes #30073. The input to `cfg!` is a meta attribute, but not _any_ meta attribute (e.g. `cfg!(allow(dead_code))` doesn't compile). But the macro_rules syntax can't quite express this, so I added a note to the doc.
