### PR TITLE
pass at least one argument to execve

### DIFF
--- a/src/test/run-pass/env-funky-keys.rs
+++ b/src/test/run-pass/env-funky-keys.rs
@@ -26,7 +26,7 @@ use std::ffi::OsStr;
 use std::ptr;
 
 fn main() {
-    if env::args_os().next().is_none() {
+    if env::args_os().count() == 2 {
         for (key, value) in env::vars_os() {
             panic!("found env value {:?} {:?}", key, value);
         }
@@ -36,7 +36,7 @@ fn main() {
     let current_exe = env::current_exe().unwrap().into_os_string().to_cstring().unwrap();
     let new_env_var = OsStr::new("FOOBAR").to_cstring().unwrap();
     let filename: *const c_char = current_exe.as_ptr();
-    let argv: &[*const c_char] = &[ptr::null()];
+    let argv: &[*const c_char] = &[filename, filename, ptr::null()];
     let envp: &[*const c_char] = &[new_env_var.as_ptr(), ptr::null()];
     unsafe {
         execve(filename, &argv[0], &envp[0]);


### PR DESCRIPTION
under OpenBSD and Bitrig, it is an error to pass an empty argv
argument to execve(2). It results the test fail as execve(2) don't exec
and set errno to EINVAL.

instead, make argv with two arguments (in order to differenciate the
initial call, from the execve call).

r? @alexcrichton 
