### PR TITLE
Remove some unnecessary indirection from AST/HIR structures

### DIFF
--- a/src/librustc/front/map/collector.rs
+++ b/src/librustc/front/map/collector.rs
@@ -140,7 +140,7 @@ impl<'ast> Visitor<'ast> for NodeCollector<'ast> {
                 for v in &enum_definition.variants {
                     let variant_def_index =
                         self.insert_def(v.node.data.id(),
-                                        NodeVariant(&**v),
+                                        NodeVariant(v),
                                         DefPathData::EnumVariant(v.node.name));
 
                     for field in v.node.data.fields() {

--- a/src/librustc/front/map/mod.rs
+++ b/src/librustc/front/map/mod.rs
@@ -852,13 +852,13 @@ pub fn map_decoded_item<'ast, F: FoldOps>(map: &Map<'ast>,
         II::Item(i) => II::Item(i.map(|i| fld.fold_item(i))),
         II::TraitItem(d, ti) => {
             II::TraitItem(fld.fold_ops.new_def_id(d),
-                          fld.fold_trait_item(ti))
+                          ti.map(|ti| fld.fold_trait_item(ti)))
         }
         II::ImplItem(d, ii) => {
             II::ImplItem(fld.fold_ops.new_def_id(d),
-                         fld.fold_impl_item(ii))
+                         ii.map(|ii| fld.fold_impl_item(ii)))
         }
-        II::Foreign(i) => II::Foreign(fld.fold_foreign_item(i))
+        II::Foreign(i) => II::Foreign(i.map(|i| fld.fold_foreign_item(i)))
     };
 
     let ii_parent = map.forest.inlined_items.alloc(InlinedParent {

--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -62,7 +62,7 @@ impl<'a, 'tcx> CFGBuilder<'a, 'tcx> {
     fn block(&mut self, blk: &hir::Block, pred: CFGIndex) -> CFGIndex {
         let mut stmts_exit = pred;
         for stmt in &blk.stmts {
-            stmts_exit = self.stmt(&**stmt, stmts_exit);
+            stmts_exit = self.stmt(stmt, stmts_exit);
         }
 
         let expr_exit = self.opt_expr(&blk.expr, stmts_exit);

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -61,7 +61,7 @@ fn lookup_variant_by_id<'a>(tcx: &'a ty::ctxt,
                             enum_def: DefId,
                             variant_def: DefId)
                             -> Option<&'a Expr> {
-    fn variant_expr<'a>(variants: &'a [P<hir::Variant>], id: ast::NodeId)
+    fn variant_expr<'a>(variants: &'a [hir::Variant], id: ast::NodeId)
                         -> Option<&'a Expr> {
         for variant in variants {
             if variant.node.data.id() == id {
@@ -77,7 +77,7 @@ fn lookup_variant_by_id<'a>(tcx: &'a ty::ctxt,
             None => None,
             Some(ast_map::NodeItem(it)) => match it.node {
                 hir::ItemEnum(hir::EnumDef { ref variants }, _) => {
-                    variant_expr(&variants[..], variant_node_id)
+                    variant_expr(variants, variant_node_id)
                 }
                 _ => None
             },

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -637,7 +637,7 @@ impl<'d,'t,'a,'tcx> ExprUseVisitor<'d,'t,'a,'tcx> {
         debug!("walk_block(blk.id={})", blk.id);
 
         for stmt in &blk.stmts {
-            self.walk_stmt(&**stmt);
+            self.walk_stmt(stmt);
         }
 
         if let Some(ref tail_expr) = blk.expr {

--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -1501,7 +1501,7 @@ impl<'a, 'tcx> Rebuilder<'a, 'tcx> {
                     self.rebuild_arg_ty_or_output(&**t, lifetime, anon_nums, region_names)
                 });
                 let new_bindings = data.bindings.map(|b| {
-                    P(hir::TypeBinding {
+                    hir::TypeBinding {
                         id: b.id,
                         name: b.name,
                         ty: self.rebuild_arg_ty_or_output(&*b.ty,
@@ -1509,7 +1509,7 @@ impl<'a, 'tcx> Rebuilder<'a, 'tcx> {
                                                           anon_nums,
                                                           region_names),
                         span: b.span
-                    })
+                    }
                 });
                 hir::AngleBracketedParameters(hir::AngleBracketedParameterData {
                     lifetimes: new_lts,

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -866,7 +866,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
                                -> LiveNode {
         let succ = self.propagate_through_opt_expr(blk.expr.as_ref().map(|e| &**e), succ);
         blk.stmts.iter().rev().fold(succ, |succ, stmt| {
-            self.propagate_through_stmt(&**stmt, succ)
+            self.propagate_through_stmt(stmt, succ)
         })
     }
 

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -720,7 +720,7 @@ fn resolve_block(visitor: &mut RegionResolutionVisitor, blk: &hir::Block) {
                     parent: stmt_extent,
                 };
             }
-            visitor.visit_stmt(&**statement)
+            visitor.visit_stmt(statement)
         }
         walk_list!(visitor, visit_expr, &blk.expr);
     }

--- a/src/librustc_front/hir.rs
+++ b/src/librustc_front/hir.rs
@@ -183,7 +183,7 @@ impl PathParameters {
         }
     }
 
-    pub fn bindings(&self) -> Vec<&P<TypeBinding>> {
+    pub fn bindings(&self) -> Vec<&TypeBinding> {
         match *self {
             AngleBracketedParameters(ref data) => {
                 data.bindings.iter().collect()
@@ -204,7 +204,7 @@ pub struct AngleBracketedParameterData {
     pub types: OwnedSlice<P<Ty>>,
     /// Bindings (equality constraints) on associated types, if present.
     /// E.g., `Foo<A=Bar>`.
-    pub bindings: OwnedSlice<P<TypeBinding>>,
+    pub bindings: OwnedSlice<TypeBinding>,
 }
 
 impl AngleBracketedParameterData {
@@ -379,7 +379,7 @@ pub struct MacroDef {
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct Block {
     /// Statements in a block
-    pub stmts: Vec<P<Stmt>>,
+    pub stmts: Vec<Stmt>,
     /// An expression at the end of the block
     /// without a semicolon, if any
     pub expr: Option<P<Expr>>,
@@ -1031,12 +1031,12 @@ pub struct Mod {
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct ForeignMod {
     pub abi: Abi,
-    pub items: Vec<P<ForeignItem>>,
+    pub items: Vec<ForeignItem>,
 }
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct EnumDef {
-    pub variants: Vec<P<Variant>>,
+    pub variants: Vec<Variant>,
 }
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
@@ -1287,7 +1287,7 @@ pub enum Item_ {
     /// A struct definition, e.g. `struct Foo<A> {x: A}`
     ItemStruct(VariantData, Generics),
     /// Represents a Trait Declaration
-    ItemTrait(Unsafety, Generics, TyParamBounds, Vec<P<TraitItem>>),
+    ItemTrait(Unsafety, Generics, TyParamBounds, Vec<TraitItem>),
 
     // Default trait implementations
     ///
@@ -1299,7 +1299,7 @@ pub enum Item_ {
              Generics,
              Option<TraitRef>, // (optional) trait this impl implements
              P<Ty>, // self
-             Vec<P<ImplItem>>),
+             Vec<ImplItem>),
 }
 
 impl Item_ {

--- a/src/librustc_front/lowering.rs
+++ b/src/librustc_front/lowering.rs
@@ -199,13 +199,13 @@ pub fn lower_decl(lctx: &LoweringContext, d: &Decl) -> P<hir::Decl> {
     }
 }
 
-pub fn lower_ty_binding(lctx: &LoweringContext, b: &TypeBinding) -> P<hir::TypeBinding> {
-    P(hir::TypeBinding {
+pub fn lower_ty_binding(lctx: &LoweringContext, b: &TypeBinding) -> hir::TypeBinding {
+    hir::TypeBinding {
         id: b.id,
         name: b.ident.name,
         ty: lower_ty(lctx, &b.ty),
         span: b.span,
-    })
+    }
 }
 
 pub fn lower_ty(lctx: &LoweringContext, t: &Ty) -> P<hir::Ty> {
@@ -264,8 +264,8 @@ pub fn lower_foreign_mod(lctx: &LoweringContext, fm: &ForeignMod) -> hir::Foreig
     }
 }
 
-pub fn lower_variant(lctx: &LoweringContext, v: &Variant) -> P<hir::Variant> {
-    P(Spanned {
+pub fn lower_variant(lctx: &LoweringContext, v: &Variant) -> hir::Variant {
+    Spanned {
         node: hir::Variant_ {
             name: v.node.name.name,
             attrs: v.node.attrs.clone(),
@@ -273,7 +273,7 @@ pub fn lower_variant(lctx: &LoweringContext, v: &Variant) -> P<hir::Variant> {
             disr_expr: v.node.disr_expr.as_ref().map(|e| lower_expr(lctx, e)),
         },
         span: v.span,
-    })
+    }
 }
 
 pub fn lower_path(lctx: &LoweringContext, p: &Path) -> hir::Path {
@@ -650,8 +650,8 @@ pub fn lower_item_underscore(lctx: &LoweringContext, i: &Item_) -> hir::Item_ {
     }
 }
 
-pub fn lower_trait_item(lctx: &LoweringContext, i: &TraitItem) -> P<hir::TraitItem> {
-    P(hir::TraitItem {
+pub fn lower_trait_item(lctx: &LoweringContext, i: &TraitItem) -> hir::TraitItem {
+    hir::TraitItem {
         id: i.id,
         name: i.ident.name,
         attrs: i.attrs.clone(),
@@ -670,11 +670,11 @@ pub fn lower_trait_item(lctx: &LoweringContext, i: &TraitItem) -> P<hir::TraitIt
             }
         },
         span: i.span,
-    })
+    }
 }
 
-pub fn lower_impl_item(lctx: &LoweringContext, i: &ImplItem) -> P<hir::ImplItem> {
-    P(hir::ImplItem {
+pub fn lower_impl_item(lctx: &LoweringContext, i: &ImplItem) -> hir::ImplItem {
+    hir::ImplItem {
         id: i.id,
         name: i.ident.name,
         attrs: i.attrs.clone(),
@@ -690,7 +690,7 @@ pub fn lower_impl_item(lctx: &LoweringContext, i: &ImplItem) -> P<hir::ImplItem>
             ImplItemKind::Macro(..) => panic!("Shouldn't exist any more"),
         },
         span: i.span,
-    })
+    }
 }
 
 pub fn lower_mod(lctx: &LoweringContext, m: &Mod) -> hir::Mod {
@@ -760,8 +760,8 @@ pub fn lower_item(lctx: &LoweringContext, i: &Item) -> hir::Item {
     }
 }
 
-pub fn lower_foreign_item(lctx: &LoweringContext, i: &ForeignItem) -> P<hir::ForeignItem> {
-    P(hir::ForeignItem {
+pub fn lower_foreign_item(lctx: &LoweringContext, i: &ForeignItem) -> hir::ForeignItem {
+    hir::ForeignItem {
         id: i.id,
         name: i.ident.name,
         attrs: i.attrs.clone(),
@@ -775,7 +775,7 @@ pub fn lower_foreign_item(lctx: &LoweringContext, i: &ForeignItem) -> P<hir::For
         },
         vis: lower_visibility(lctx, i.vis),
         span: i.span,
-    })
+    }
 }
 
 pub fn lower_method_sig(lctx: &LoweringContext, sig: &MethodSig) -> hir::MethodSig {
@@ -1054,7 +1054,7 @@ pub fn lower_expr(lctx: &LoweringContext, e: &Expr) -> P<hir::Expr> {
                         let place = expr_ident(lctx, e.span, place_ident, None);
                         let call = make_call(lctx, &inplace_finalize, vec![place]);
                         signal_block_expr(lctx,
-                                          vec![P(call_move_val_init)],
+                                          vec![call_move_val_init],
                                           call,
                                           e.span,
                                           hir::PushUnsafeBlock(hir::CompilerGenerated), None)
@@ -1484,25 +1484,25 @@ pub fn lower_expr(lctx: &LoweringContext, e: &Expr) -> P<hir::Expr> {
     })
 }
 
-pub fn lower_stmt(lctx: &LoweringContext, s: &Stmt) -> P<hir::Stmt> {
+pub fn lower_stmt(lctx: &LoweringContext, s: &Stmt) -> hir::Stmt {
     match s.node {
         StmtDecl(ref d, id) => {
-            P(Spanned {
+            Spanned {
                 node: hir::StmtDecl(lower_decl(lctx, d), id),
                 span: s.span,
-            })
+            }
         }
         StmtExpr(ref e, id) => {
-            P(Spanned {
+            Spanned {
                 node: hir::StmtExpr(lower_expr(lctx, e), id),
                 span: s.span,
-            })
+            }
         }
         StmtSemi(ref e, id) => {
-            P(Spanned {
+            Spanned {
                 node: hir::StmtSemi(lower_expr(lctx, e), id),
                 span: s.span,
-            })
+            }
         }
         StmtMac(..) => panic!("Shouldn't exist here"),
     }
@@ -1644,7 +1644,7 @@ fn stmt_let(lctx: &LoweringContext,
             ident: Ident,
             ex: P<hir::Expr>,
             attrs: ThinAttributes)
-            -> P<hir::Stmt> {
+            -> hir::Stmt {
     let pat = if mutbl {
         pat_ident_binding_mode(lctx, sp, ident, hir::BindByValue(hir::MutMutable))
     } else {
@@ -1659,7 +1659,7 @@ fn stmt_let(lctx: &LoweringContext,
         attrs: attrs,
     });
     let decl = respan(sp, hir::DeclLocal(local));
-    P(respan(sp, hir::StmtDecl(P(decl), lctx.next_id())))
+    respan(sp, hir::StmtDecl(P(decl), lctx.next_id()))
 }
 
 fn block_expr(lctx: &LoweringContext, expr: P<hir::Expr>) -> P<hir::Block> {
@@ -1668,7 +1668,7 @@ fn block_expr(lctx: &LoweringContext, expr: P<hir::Expr>) -> P<hir::Block> {
 
 fn block_all(lctx: &LoweringContext,
              span: Span,
-             stmts: Vec<P<hir::Stmt>>,
+             stmts: Vec<hir::Stmt>,
              expr: Option<P<hir::Expr>>)
              -> P<hir::Block> {
     P(hir::Block {
@@ -1748,7 +1748,7 @@ fn path_all(sp: Span,
             mut idents: Vec<Ident>,
             lifetimes: Vec<hir::Lifetime>,
             types: Vec<P<hir::Ty>>,
-            bindings: Vec<P<hir::TypeBinding>>)
+            bindings: Vec<hir::TypeBinding>)
             -> hir::Path {
     let last_identifier = idents.pop().unwrap();
     let mut segments: Vec<hir::PathSegment> = idents.into_iter()
@@ -1791,7 +1791,7 @@ fn core_path(lctx: &LoweringContext, span: Span, components: &[&str]) -> hir::Pa
 }
 
 fn signal_block_expr(lctx: &LoweringContext,
-                     stmts: Vec<P<hir::Stmt>>,
+                     stmts: Vec<hir::Stmt>,
                      expr: P<hir::Expr>,
                      span: Span,
                      rule: hir::BlockCheckMode,

--- a/src/librustc_front/print/pprust.rs
+++ b/src/librustc_front/print/pprust.rs
@@ -473,7 +473,7 @@ impl<'a> State<'a> {
                              -> io::Result<()> {
         try!(self.print_inner_attributes(attrs));
         for item in &nmod.items {
-            try!(self.print_foreign_item(&**item));
+            try!(self.print_foreign_item(item));
         }
         Ok(())
     }
@@ -878,7 +878,7 @@ impl<'a> State<'a> {
     }
 
     pub fn print_variants(&mut self,
-                          variants: &[P<hir::Variant>],
+                          variants: &[hir::Variant],
                           span: codemap::Span)
                           -> io::Result<()> {
         try!(self.bopen());
@@ -887,7 +887,7 @@ impl<'a> State<'a> {
             try!(self.maybe_print_comment(v.span.lo));
             try!(self.print_outer_attributes(&v.node.attrs));
             try!(self.ibox(indent_unit));
-            try!(self.print_variant(&**v));
+            try!(self.print_variant(v));
             try!(word(&mut self.s, ","));
             try!(self.end());
             try!(self.maybe_print_trailing_comment(v.span, None));
@@ -1107,7 +1107,7 @@ impl<'a> State<'a> {
         try!(self.print_inner_attributes(attrs));
 
         for st in &blk.stmts {
-            try!(self.print_stmt(&**st));
+            try!(self.print_stmt(st));
         }
         match blk.expr {
             Some(ref expr) => {

--- a/src/librustc_metadata/astencode.rs
+++ b/src/librustc_metadata/astencode.rs
@@ -394,13 +394,13 @@ fn simplify_ast(ii: InlinedItemRef) -> InlinedItem {
             InlinedItem::Item(P(fold::noop_fold_item(i.clone(), &mut fld)))
         }
         InlinedItemRef::TraitItem(d, ti) => {
-            InlinedItem::TraitItem(d, fold::noop_fold_trait_item(P(ti.clone()), &mut fld))
+            InlinedItem::TraitItem(d, P(fold::noop_fold_trait_item(ti.clone(), &mut fld)))
         }
         InlinedItemRef::ImplItem(d, ii) => {
-            InlinedItem::ImplItem(d, fold::noop_fold_impl_item(P(ii.clone()), &mut fld))
+            InlinedItem::ImplItem(d, P(fold::noop_fold_impl_item(ii.clone(), &mut fld)))
         }
         InlinedItemRef::Foreign(i) => {
-            InlinedItem::Foreign(fold::noop_fold_foreign_item(P(i.clone()), &mut fld))
+            InlinedItem::Foreign(P(fold::noop_fold_foreign_item(i.clone(), &mut fld)))
         }
     }
 }

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -1156,7 +1156,7 @@ fn encode_info_for_item<'a, 'tcx>(ecx: &EncodeContext<'a, 'tcx>,
         let num_implemented_methods = ast_items.len();
         for (i, &trait_item_def_id) in items.iter().enumerate() {
             let ast_item = if i < num_implemented_methods {
-                Some(&*ast_items[i])
+                Some(&ast_items[i])
             } else {
                 None
             };
@@ -1321,7 +1321,7 @@ fn encode_info_for_item<'a, 'tcx>(ecx: &EncodeContext<'a, 'tcx>,
                 }
             }
 
-            let trait_item = &*ms[i];
+            let trait_item = &ms[i];
             encode_attributes(rbml_w, &trait_item.attrs);
             match trait_item.node {
                 hir::ConstTraitItem(_, ref default) => {

--- a/src/librustc_mir/hair/cx/block.rs
+++ b/src/librustc_mir/hair/cx/block.rs
@@ -14,7 +14,6 @@ use hair::cx::to_ref::ToRef;
 use rustc::middle::region::{BlockRemainder, CodeExtentData};
 use rustc_front::hir;
 use syntax::ast;
-use syntax::ptr::P;
 
 impl<'tcx> Mirror<'tcx> for &'tcx hir::Block {
     type Output = Block<'tcx>;
@@ -36,7 +35,7 @@ fn mirror_stmts<'a,'tcx:'a,STMTS>(cx: &mut Cx<'a,'tcx>,
                                   block_id: ast::NodeId,
                                   mut stmts: STMTS)
                                   -> Vec<StmtRef<'tcx>>
-    where STMTS: Iterator<Item=(usize, &'tcx P<hir::Stmt>)>
+    where STMTS: Iterator<Item=(usize, &'tcx hir::Stmt)>
 {
     let mut result = vec![];
     while let Some((index, stmt)) = stmts.next() {

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -392,7 +392,7 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
 
                 for variant in &(*enum_definition).variants {
                     let item_def_id = self.ast_map.local_def_id(item.id);
-                    self.build_reduced_graph_for_variant(&**variant, item_def_id, &module);
+                    self.build_reduced_graph_for_variant(variant, item_def_id, &module);
                 }
                 parent.clone()
             }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -69,7 +69,6 @@ use syntax::ast::{TyUs, TyU8, TyU16, TyU32, TyU64, TyF64, TyF32};
 use syntax::attr::AttrMetaMethods;
 use syntax::ext::mtwt;
 use syntax::parse::token::{self, special_names, special_idents};
-use syntax::ptr::P;
 use syntax::codemap::{self, Span, Pos};
 use syntax::util::lev_distance::{lev_distance, max_suggestion_distance};
 
@@ -1907,7 +1906,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                             opt_trait_ref,
                                             &**self_type,
                                             item.id,
-                                            &impl_items[..]);
+                                            impl_items);
             }
 
             ItemTrait(_, ref generics, ref bounds, ref trait_items) => {
@@ -2223,7 +2222,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                               opt_trait_reference: &Option<TraitRef>,
                               self_type: &Ty,
                               item_id: NodeId,
-                              impl_items: &[P<ImplItem>]) {
+                              impl_items: &[ImplItem]) {
         // If applicable, create a rib for the type parameters.
         self.with_type_parameter_rib(HasTypeParameters(generics,
                                                        TypeSpace,

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -2378,7 +2378,7 @@ pub fn trans_item(ccx: &CrateContext, item: &hir::Item) {
             }
         }
         hir::ItemImpl(_, _, ref generics, _, _, ref impl_items) => {
-            meth::trans_impl(ccx, item.name, &impl_items[..], generics, item.id);
+            meth::trans_impl(ccx, item.name, impl_items, generics, item.id);
         }
         hir::ItemMod(_) => {
             // modules have no equivalent at runtime, they just affect

--- a/src/librustc_trans/trans/controlflow.rs
+++ b/src/librustc_trans/trans/controlflow.rs
@@ -110,7 +110,7 @@ pub fn trans_block<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     fcx.push_ast_cleanup_scope(cleanup_debug_loc);
 
     for s in &b.stmts {
-        bcx = trans_stmt(bcx, &**s);
+        bcx = trans_stmt(bcx, s);
     }
 
     if dest != expr::Ignore {

--- a/src/librustc_trans/trans/debuginfo/create_scope_map.rs
+++ b/src/librustc_trans/trans/debuginfo/create_scope_map.rs
@@ -117,7 +117,7 @@ fn walk_block(cx: &CrateContext,
 
     // The interesting things here are statements and the concluding expression.
     for statement in &block.stmts {
-        scope_map.insert(rustc_front::util::stmt_id(&**statement),
+        scope_map.insert(rustc_front::util::stmt_id(statement),
                          scope_stack.last().unwrap().scope_metadata);
 
         match statement.node {

--- a/src/librustc_trans/trans/foreign.rs
+++ b/src/librustc_trans/trans/foreign.rs
@@ -481,7 +481,7 @@ fn gate_simd_ffi(tcx: &ty::ctxt, decl: &hir::FnDecl, ty: &ty::BareFnTy) {
 pub fn trans_foreign_mod(ccx: &CrateContext, foreign_mod: &hir::ForeignMod) {
     let _icx = push_ctxt("foreign::trans_foreign_mod");
     for foreign_item in &foreign_mod.items {
-        let lname = link_name(&**foreign_item);
+        let lname = link_name(foreign_item);
 
         if let hir::ForeignItemFn(ref decl, _) = foreign_item.node {
             match foreign_mod.abi {

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -41,7 +41,6 @@ use middle::ty::MethodCall;
 use syntax::ast;
 use syntax::attr;
 use syntax::codemap::DUMMY_SP;
-use syntax::ptr::P;
 
 use rustc_front::hir;
 
@@ -54,7 +53,7 @@ const VTABLE_OFFSET: usize = 3;
 /// see `trans::base::lval_static_fn()` or `trans::base::monomorphic_fn()`.
 pub fn trans_impl(ccx: &CrateContext,
                   name: ast::Name,
-                  impl_items: &[P<hir::ImplItem>],
+                  impl_items: &[hir::ImplItem],
                   generics: &hir::Generics,
                   id: ast::NodeId) {
     let _icx = push_ctxt("meth::trans_impl");

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -711,11 +711,11 @@ pub fn check_item_type<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx hir::Item) {
       hir::ItemForeignMod(ref m) => {
         if m.abi == abi::RustIntrinsic {
             for item in &m.items {
-                intrinsic::check_intrinsic_type(ccx, &**item);
+                intrinsic::check_intrinsic_type(ccx, item);
             }
         } else if m.abi == abi::PlatformIntrinsic {
             for item in &m.items {
-                intrinsic::check_platform_intrinsic_type(ccx, &**item);
+                intrinsic::check_platform_intrinsic_type(ccx, item);
             }
         } else {
             for item in &m.items {
@@ -880,7 +880,7 @@ fn check_method_body<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
 fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                             impl_span: Span,
                                             impl_trait_ref: &ty::TraitRef<'tcx>,
-                                            impl_items: &[P<hir::ImplItem>]) {
+                                            impl_items: &[hir::ImplItem]) {
     // Locate trait methods
     let tcx = ccx.tcx;
     let trait_items = tcx.trait_items(impl_trait_ref.def_id);
@@ -4024,8 +4024,8 @@ fn check_block_with_expected<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
     let mut any_diverges = false;
     let mut any_err = false;
     for s in &blk.stmts {
-        check_stmt(fcx, &**s);
-        let s_id = ::rustc_front::util::stmt_id(&**s);
+        check_stmt(fcx, s);
+        let s_id = ::rustc_front::util::stmt_id(s);
         let s_ty = fcx.node_ty(s_id);
         if any_diverges && !warned && match s.node {
             hir::StmtDecl(ref decl, _) => {
@@ -4193,7 +4193,7 @@ pub fn check_simd(tcx: &ty::ctxt, sp: Span, id: ast::NodeId) {
 
 pub fn check_enum_variants<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
                                     sp: Span,
-                                    vs: &'tcx [P<hir::Variant>],
+                                    vs: &'tcx [hir::Variant],
                                     id: ast::NodeId) {
 
     fn disr_in_range(ccx: &CrateCtxt,
@@ -4224,7 +4224,7 @@ pub fn check_enum_variants<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
     }
 
     fn do_check<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
-                          vs: &'tcx [P<hir::Variant>],
+                          vs: &'tcx [hir::Variant],
                           id: ast::NodeId,
                           hint: attr::ReprAttr) {
         #![allow(trivial_numeric_casts)]

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -24,7 +24,6 @@ use std::rc::Rc;
 use syntax::ast;
 use syntax::codemap::{Span};
 use syntax::parse::token::{special_idents};
-use syntax::ptr::P;
 use rustc_front::intravisit::{self, Visitor};
 use rustc_front::hir;
 
@@ -225,7 +224,7 @@ impl<'ccx, 'tcx> CheckTypeWellFormedVisitor<'ccx, 'tcx> {
 
     fn check_trait(&mut self,
                    item: &hir::Item,
-                   items: &[P<hir::TraitItem>])
+                   items: &[hir::TraitItem])
     {
         let trait_def_id = self.tcx().map.local_def_id(item.id);
 

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1061,7 +1061,7 @@ fn convert_enum_variant_types<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                         def: ty::AdtDefMaster<'tcx>,
                                         scheme: ty::TypeScheme<'tcx>,
                                         predicates: ty::GenericPredicates<'tcx>,
-                                        variants: &[P<hir::Variant>]) {
+                                        variants: &[hir::Variant]) {
     // fill the field types
     for (variant, ty_variant) in variants.iter().zip(def.variants.iter()) {
         for (f, ty_f) in variant.node.data.fields().iter().zip(ty_variant.fields.iter()) {
@@ -1479,7 +1479,7 @@ fn convert_trait_predicates<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>, it: &hir::Item)
                                                  ast_generics: &hir::Generics,
                                                  trait_predicates: &ty::GenericPredicates<'tcx>,
                                                  self_trait_ref: ty::TraitRef<'tcx>,
-                                                 trait_items: &[P<hir::TraitItem>])
+                                                 trait_items: &[hir::TraitItem])
                                                  -> Vec<ty::Predicate<'tcx>>
     {
         trait_items.iter().flat_map(|trait_item| {
@@ -2410,7 +2410,7 @@ fn enforce_impl_params_are_constrained<'tcx>(tcx: &ty::ctxt<'tcx>,
 fn enforce_impl_lifetimes_are_constrained<'tcx>(tcx: &ty::ctxt<'tcx>,
                                                 ast_generics: &hir::Generics,
                                                 impl_def_id: DefId,
-                                                impl_items: &[P<hir::ImplItem>])
+                                                impl_items: &[hir::ImplItem])
 {
     // Every lifetime used in an associated type must be constrained.
     let impl_scheme = tcx.lookup_item_type(impl_def_id);

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -176,7 +176,7 @@ pub struct Constant {
 pub struct Trait {
     pub unsafety: hir::Unsafety,
     pub name: Name,
-    pub items: Vec<P<hir::TraitItem>>, //should be TraitItem
+    pub items: Vec<hir::TraitItem>,
     pub generics: hir::Generics,
     pub bounds: Vec<hir::TyParamBound>,
     pub attrs: Vec<ast::Attribute>,
@@ -192,7 +192,7 @@ pub struct Impl {
     pub generics: hir::Generics,
     pub trait_: Option<hir::TraitRef>,
     pub for_: P<hir::Ty>,
-    pub items: Vec<P<hir::ImplItem>>,
+    pub items: Vec<hir::ImplItem>,
     pub attrs: Vec<ast::Attribute>,
     pub whence: Span,
     pub vis: hir::Visibility,


### PR DESCRIPTION
I've measured the time/memory consumption before and after - the difference is lost in statistical noise, so it's mostly a code simplification.
Sizes of `enum`s are not affected.

r? @nrc 

I wonder if AST/HIR visitors could run faster if `P`s are systematically removed (except for cases where they control `enum` sizes). Theoretically they should.
Remaining unnecessary `P`s can't be easily removed because many folders accept `P<X>`s as arguments, but these folders can be converted to accept `X`s instead without loss of efficiency.
When I have a mood for some mindless refactoring again, I'll probably try to convert the folders, remove remaining `P`s and measure again.
