### PR TITLE
disable net::addr::to_socket_addr_str_bad test under openbsd

### DIFF
--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -495,9 +495,9 @@ mod tests {
         assert!(tsa("localhost:23924").unwrap().contains(&a));
     }
 
-    // FIXME: figure out why this fails on bitrig and fix it
+    // FIXME: figure out why this fails on openbsd and bitrig and fix it
     #[test]
-    #[cfg(not(any(windows, target_os = "bitrig")))]
+    #[cfg(not(any(windows, target_os = "openbsd", target_os = "bitrig")))]
     fn to_socket_addr_str_bad() {
         assert!(tsa("1200::AB00:1234::2552:7777:1313:34300").is_err());
     }


### PR DESCRIPTION
I don't reproduce it on severals hosts (virtual or real), so I can't
debug it. As Bitrig has disabled this test too, I will follow the same
here.

r? @alexcrichton 
