### PR TITLE
Improve OwnedSlice and use it in HIR

### DIFF
--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -93,6 +93,7 @@ use syntax::ast;
 use syntax::codemap::{self, Pos, Span};
 use syntax::parse::token;
 use syntax::ptr::P;
+use syntax::util::MoveMap;
 
 impl<'tcx> ty::ctxt<'tcx> {
     pub fn note_and_explain_region(&self,
@@ -1153,19 +1154,19 @@ impl<'a, 'tcx> Rebuilder<'a, 'tcx> {
     }
 
     fn rebuild_ty_params(&self,
-                         ty_params: P<[hir::TyParam]>,
+                         ty_params: hir::HirVec<hir::TyParam>,
                          lifetime: hir::Lifetime,
                          region_names: &HashSet<ast::Name>)
-                         -> P<[hir::TyParam]> {
-        ty_params.map(|ty_param| {
-            let bounds = self.rebuild_ty_param_bounds(ty_param.bounds.clone(),
+                         -> hir::HirVec<hir::TyParam> {
+        ty_params.move_map(|ty_param| {
+            let bounds = self.rebuild_ty_param_bounds(ty_param.bounds,
                                                       lifetime,
                                                       region_names);
             hir::TyParam {
                 name: ty_param.name,
                 id: ty_param.id,
                 bounds: bounds,
-                default: ty_param.default.clone(),
+                default: ty_param.default,
                 span: ty_param.span,
             }
         })
@@ -1176,15 +1177,15 @@ impl<'a, 'tcx> Rebuilder<'a, 'tcx> {
                                lifetime: hir::Lifetime,
                                region_names: &HashSet<ast::Name>)
                                -> hir::TyParamBounds {
-        ty_param_bounds.map(|tpb| {
+        ty_param_bounds.move_map(|tpb| {
             match tpb {
-                &hir::RegionTyParamBound(lt) => {
+                hir::RegionTyParamBound(lt) => {
                     // FIXME -- it's unclear whether I'm supposed to
                     // substitute lifetime here. I suspect we need to
                     // be passing down a map.
                     hir::RegionTyParamBound(lt)
                 }
-                &hir::TraitTyParamBound(ref poly_tr, modifier) => {
+                hir::TraitTyParamBound(ref poly_tr, modifier) => {
                     let tr = &poly_tr.trait_ref;
                     let last_seg = tr.path.segments.last().unwrap();
                     let mut insert = Vec::new();
@@ -1248,7 +1249,7 @@ impl<'a, 'tcx> Rebuilder<'a, 'tcx> {
                         add: &Vec<hir::Lifetime>,
                         keep: &HashSet<ast::Name>,
                         remove: &HashSet<ast::Name>,
-                        ty_params: P<[hir::TyParam]>,
+                        ty_params: hir::HirVec<hir::TyParam>,
                         where_clause: hir::WhereClause)
                         -> hir::Generics {
         let mut lifetimes = Vec::new();
@@ -1498,10 +1499,10 @@ impl<'a, 'tcx> Rebuilder<'a, 'tcx> {
                         }
                     }
                 }
-                let new_types = data.types.map(|t| {
+                let new_types = data.types.iter().map(|t| {
                     self.rebuild_arg_ty_or_output(&**t, lifetime, anon_nums, region_names)
-                });
-                let new_bindings = data.bindings.map(|b| {
+                }).collect();
+                let new_bindings = data.bindings.iter().map(|b| {
                     hir::TypeBinding {
                         id: b.id,
                         name: b.name,
@@ -1511,7 +1512,7 @@ impl<'a, 'tcx> Rebuilder<'a, 'tcx> {
                                                           region_names),
                         span: b.span
                     }
-                });
+                }).collect();
                 hir::AngleBracketedParameters(hir::AngleBracketedParameterData {
                     lifetimes: new_lts.into(),
                     types: new_types,

--- a/src/librustc_front/fold.rs
+++ b/src/librustc_front/fold.rs
@@ -19,7 +19,7 @@ use hir;
 use syntax::codemap::{respan, Span, Spanned};
 use syntax::ptr::P;
 use syntax::parse::token;
-use syntax::util::move_map::MoveMap;
+use syntax::util::{MoveMap, MoveFlatMap};
 
 pub trait Folder : Sized {
     // Any additions to this trait should happen in form
@@ -210,7 +210,7 @@ pub trait Folder : Sized {
         noop_fold_ty_param(tp, self)
     }
 
-    fn fold_ty_params(&mut self, tps: P<[TyParam]>) -> P<[TyParam]> {
+    fn fold_ty_params(&mut self, tps: HirVec<TyParam>) -> HirVec<TyParam> {
         noop_fold_ty_params(tps, self)
     }
 
@@ -575,9 +575,9 @@ pub fn noop_fold_ty_param<T: Folder>(tp: TyParam, fld: &mut T) -> TyParam {
     }
 }
 
-pub fn noop_fold_ty_params<T: Folder>(tps: P<[TyParam]>,
+pub fn noop_fold_ty_params<T: Folder>(tps: HirVec<TyParam>,
                                       fld: &mut T)
-                                      -> P<[TyParam]> {
+                                      -> HirVec<TyParam> {
     tps.move_map(|tp| fld.fold_ty_param(tp))
 }
 

--- a/src/librustc_front/hir.rs
+++ b/src/librustc_front/hir.rs
@@ -208,8 +208,8 @@ impl PathParameters {
     pub fn none() -> PathParameters {
         AngleBracketedParameters(AngleBracketedParameterData {
             lifetimes: HirVec::new(),
-            types: P::empty(),
-            bindings: P::empty(),
+            types: HirVec::new(),
+            bindings: HirVec::new(),
         })
     }
 
@@ -282,10 +282,10 @@ pub struct AngleBracketedParameterData {
     /// The lifetime parameters for this path segment.
     pub lifetimes: HirVec<Lifetime>,
     /// The type parameters for this path segment, if present.
-    pub types: P<[P<Ty>]>,
+    pub types: HirVec<P<Ty>>,
     /// Bindings (equality constraints) on associated types, if present.
     /// E.g., `Foo<A=Bar>`.
-    pub bindings: P<[TypeBinding]>,
+    pub bindings: HirVec<TypeBinding>,
 }
 
 impl AngleBracketedParameterData {
@@ -325,7 +325,7 @@ pub enum TraitBoundModifier {
     Maybe,
 }
 
-pub type TyParamBounds = P<[TyParamBound]>;
+pub type TyParamBounds = HirVec<TyParamBound>;
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct TyParam {
@@ -341,7 +341,7 @@ pub struct TyParam {
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct Generics {
     pub lifetimes: HirVec<LifetimeDef>,
-    pub ty_params: P<[TyParam]>,
+    pub ty_params: HirVec<TyParam>,
     pub where_clause: WhereClause,
 }
 

--- a/src/librustc_front/lowering.rs
+++ b/src/librustc_front/lowering.rs
@@ -433,8 +433,8 @@ pub fn lower_ty_param(lctx: &LoweringContext, tp: &TyParam) -> hir::TyParam {
 }
 
 pub fn lower_ty_params(lctx: &LoweringContext,
-                       tps: &P<[TyParam]>)
-                       -> P<[hir::TyParam]> {
+                       tps: &[TyParam])
+                       -> hir::HirVec<hir::TyParam> {
     tps.iter().map(|tp| lower_ty_param(lctx, tp)).collect()
 }
 
@@ -1771,19 +1771,19 @@ fn path_ident(span: Span, id: hir::Ident) -> hir::Path {
 }
 
 fn path(span: Span, strs: Vec<hir::Ident>) -> hir::Path {
-    path_all(span, false, strs, hir::HirVec::new(), Vec::new(), Vec::new())
+    path_all(span, false, strs, hir::HirVec::new(), hir::HirVec::new(), hir::HirVec::new())
 }
 
 fn path_global(span: Span, strs: Vec<hir::Ident>) -> hir::Path {
-    path_all(span, true, strs, hir::HirVec::new(), Vec::new(), Vec::new())
+    path_all(span, true, strs, hir::HirVec::new(), hir::HirVec::new(), hir::HirVec::new())
 }
 
 fn path_all(sp: Span,
             global: bool,
             mut idents: Vec<hir::Ident>,
             lifetimes: hir::HirVec<hir::Lifetime>,
-            types: Vec<P<hir::Ty>>,
-            bindings: Vec<hir::TypeBinding>)
+            types: hir::HirVec<P<hir::Ty>>,
+            bindings: hir::HirVec<hir::TypeBinding>)
             -> hir::Path {
     let last_identifier = idents.pop().unwrap();
     let mut segments: Vec<hir::PathSegment> = idents.into_iter()
@@ -1798,8 +1798,8 @@ fn path_all(sp: Span,
         identifier: last_identifier,
         parameters: hir::AngleBracketedParameters(hir::AngleBracketedParameterData {
             lifetimes: lifetimes,
-            types: P::from_vec(types),
-            bindings: P::from_vec(bindings),
+            types: types.into(),
+            bindings: bindings.into(),
         }),
     });
     hir::Path {

--- a/src/librustc_front/print/pprust.rs
+++ b/src/librustc_front/print/pprust.rs
@@ -518,7 +518,7 @@ impl<'a> State<'a> {
             hir::TyBareFn(ref f) => {
                 let generics = hir::Generics {
                     lifetimes: f.lifetimes.clone(),
-                    ty_params: P::empty(),
+                    ty_params: hir::HirVec::new(),
                     where_clause: hir::WhereClause {
                         id: ast::DUMMY_NODE_ID,
                         predicates: hir::HirVec::new(),
@@ -2257,7 +2257,7 @@ impl<'a> State<'a> {
         }
         let generics = hir::Generics {
             lifetimes: hir::HirVec::new(),
-            ty_params: P::empty(),
+            ty_params: hir::HirVec::new(),
             where_clause: hir::WhereClause {
                 id: ast::DUMMY_NODE_ID,
                 predicates: hir::HirVec::new(),

--- a/src/librustc_front/util.rs
+++ b/src/librustc_front/util.rs
@@ -335,7 +335,7 @@ pub fn is_path(e: P<Expr>) -> bool {
 pub fn empty_generics() -> Generics {
     Generics {
         lifetimes: HirVec::new(),
-        ty_params: P::empty(),
+        ty_params: HirVec::new(),
         where_clause: WhereClause {
             id: DUMMY_NODE_ID,
             predicates: HirVec::new(),
@@ -353,8 +353,8 @@ pub fn ident_to_path(s: Span, ident: Ident) -> Path {
             identifier: ident,
             parameters: hir::AngleBracketedParameters(hir::AngleBracketedParameterData {
                 lifetimes: HirVec::new(),
-                types: P::empty(),
-                bindings: P::empty(),
+                types: HirVec::new(),
+                bindings: HirVec::new(),
             }),
         }],
     }

--- a/src/librustc_mir/hair/cx/to_ref.rs
+++ b/src/librustc_mir/hair/cx/to_ref.rs
@@ -61,3 +61,13 @@ impl<'a,'tcx:'a,T,U> ToRef for &'tcx Vec<T>
         self.iter().map(|expr| expr.to_ref()).collect()
     }
 }
+
+impl<'a,'tcx:'a,T,U> ToRef for &'tcx P<[T]>
+    where &'tcx T: ToRef<Output=U>
+{
+    type Output = Vec<U>;
+
+    fn to_ref(self) -> Vec<U> {
+        self.iter().map(|expr| expr.to_ref()).collect()
+    }
+}

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4906,7 +4906,7 @@ pub fn may_break(cx: &ty::ctxt, id: ast::NodeId, b: &hir::Block) -> bool {
 }
 
 pub fn check_bounds_are_used<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
-                                       tps: &P<[hir::TyParam]>,
+                                       tps: &[hir::TyParam],
                                        ty: Ty<'tcx>) {
     debug!("check_bounds_are_used(n_tps={}, ty={:?})",
            tps.len(),  ty);

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -260,8 +260,8 @@ impl PathParameters {
     pub fn none() -> PathParameters {
         AngleBracketedParameters(AngleBracketedParameterData {
             lifetimes: Vec::new(),
-            types: P::empty(),
-            bindings: P::empty(),
+            types: P::new(),
+            bindings: P::new(),
         })
     }
 
@@ -429,7 +429,7 @@ impl Default for Generics {
     fn default() ->  Generics {
         Generics {
             lifetimes: Vec::new(),
-            ty_params: P::empty(),
+            ty_params: P::new(),
             where_clause: WhereClause {
                 id: DUMMY_NODE_ID,
                 predicates: Vec::new(),

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -42,8 +42,8 @@ pub fn ident_to_path(s: Span, identifier: Ident) -> Path {
                 identifier: identifier,
                 parameters: ast::AngleBracketedParameters(ast::AngleBracketedParameterData {
                     lifetimes: Vec::new(),
-                    types: P::empty(),
-                    bindings: P::empty(),
+                    types: P::new(),
+                    bindings: P::new(),
                 })
             }
         ),

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -69,8 +69,8 @@ pub trait AstBuilder {
     fn ty_option(&self, ty: P<ast::Ty>) -> P<ast::Ty>;
     fn ty_infer(&self, sp: Span) -> P<ast::Ty>;
 
-    fn ty_vars(&self, ty_params: &P<[ast::TyParam]>) -> Vec<P<ast::Ty>> ;
-    fn ty_vars_global(&self, ty_params: &P<[ast::TyParam]>) -> Vec<P<ast::Ty>> ;
+    fn ty_vars(&self, ty_params: &[ast::TyParam]) -> Vec<P<ast::Ty>> ;
+    fn ty_vars_global(&self, ty_params: &[ast::TyParam]) -> Vec<P<ast::Ty>> ;
 
     fn typaram(&self,
                span: Span,
@@ -330,8 +330,8 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             identifier: last_identifier,
             parameters: ast::AngleBracketedParameters(ast::AngleBracketedParameterData {
                 lifetimes: lifetimes,
-                types: P::from_vec(types),
-                bindings: P::from_vec(bindings),
+                types: P::from(types),
+                bindings: P::from(bindings),
             })
         });
         ast::Path {
@@ -368,8 +368,8 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             identifier: ident,
             parameters: ast::AngleBracketedParameters(ast::AngleBracketedParameterData {
                 lifetimes: lifetimes,
-                types: P::from_vec(types),
-                bindings: P::from_vec(bindings),
+                types: P::from(types),
+                bindings: P::from(bindings),
             })
         });
 
@@ -461,11 +461,11 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     // these are strange, and probably shouldn't be used outside of
     // pipes. Specifically, the global version possible generates
     // incorrect code.
-    fn ty_vars(&self, ty_params: &P<[ast::TyParam]>) -> Vec<P<ast::Ty>> {
+    fn ty_vars(&self, ty_params: &[ast::TyParam]) -> Vec<P<ast::Ty>> {
         ty_params.iter().map(|p| self.ty_ident(DUMMY_SP, p.ident)).collect()
     }
 
-    fn ty_vars_global(&self, ty_params: &P<[ast::TyParam]>) -> Vec<P<ast::Ty>> {
+    fn ty_vars_global(&self, ty_params: &[ast::TyParam]) -> Vec<P<ast::Ty>> {
         ty_params
             .iter()
             .map(|p| self.ty_path(self.path_global(DUMMY_SP, vec!(p.ident))))

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -24,7 +24,6 @@ use ext::base::*;
 use feature_gate::{self, Features};
 use fold;
 use fold::*;
-use util::move_map::MoveMap;
 use parse;
 use parse::token::{fresh_mark, fresh_name, intern};
 use ptr::P;
@@ -32,6 +31,7 @@ use util::small_vector::SmallVector;
 use visit;
 use visit::Visitor;
 use std_inject;
+use util::MoveMap;
 
 use std::collections::HashSet;
 

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -25,8 +25,8 @@ use ast_util;
 use codemap::{respan, Span, Spanned};
 use parse::token;
 use ptr::P;
+use util::{MoveMap, MoveFlatMap};
 use util::small_vector::SmallVector;
-use util::move_map::MoveMap;
 
 use std::rc::Rc;
 

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -61,14 +61,16 @@ macro_rules! panictry {
 }
 
 pub mod util {
+    pub use self::move_map::{MoveMap, MoveFlatMap};
+
     pub mod interner;
     pub mod lev_distance;
+    pub mod move_map;
     pub mod node_count;
     pub mod parser;
     #[cfg(test)]
     pub mod parser_testing;
     pub mod small_vector;
-    pub mod move_map;
 }
 
 pub mod diagnostics {

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -946,7 +946,7 @@ mod tests {
                                     abi::Rust,
                                     ast::Generics{ // no idea on either of these:
                                         lifetimes: Vec::new(),
-                                        ty_params: P::empty(),
+                                        ty_params: P::new(),
                                         where_clause: ast::WhereClause {
                                             id: ast::DUMMY_NODE_ID,
                                             predicates: Vec::new(),

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -771,7 +771,7 @@ impl<'a> Parser<'a> {
             if i % 2 == 0 {
                 match try!(f(self)) {
                     Some(result) => v.push(result),
-                    None => return Ok((P::from_vec(v), true))
+                    None => return Ok((P::from(v), true))
                 }
             } else {
                 if let Some(t) = sep.as_ref() {
@@ -780,7 +780,7 @@ impl<'a> Parser<'a> {
 
             }
         }
-        return Ok((P::from_vec(v), false));
+        return Ok((P::from(v), false));
     }
 
     /// Parse a sequence bracketed by '<' and '>', stopping
@@ -1075,11 +1075,11 @@ impl<'a> Parser<'a> {
             let other_bounds = if try!(self.eat(&token::BinOp(token::Plus)) ){
                 try!(self.parse_ty_param_bounds(BoundParsingMode::Bare))
             } else {
-                P::empty()
+                P::new()
             };
             let all_bounds =
                 Some(TraitTyParamBound(poly_trait_ref, TraitBoundModifier::None)).into_iter()
-                .chain(other_bounds.into_vec())
+                .chain(other_bounds.into_iter())
                 .collect();
             Ok(ast::TyPolyTraitRef(all_bounds))
         }
@@ -1708,8 +1708,8 @@ impl<'a> Parser<'a> {
 
                 ast::AngleBracketedParameters(ast::AngleBracketedParameterData {
                     lifetimes: lifetimes,
-                    types: P::from_vec(types),
-                    bindings: P::from_vec(bindings),
+                    types: P::from(types),
+                    bindings: P::from(bindings),
                 })
             } else if try!(self.eat(&token::OpenDelim(token::Paren)) ){
                 let lo = self.last_span.lo;
@@ -1772,8 +1772,8 @@ impl<'a> Parser<'a> {
                     identifier: identifier,
                     parameters: ast::AngleBracketedParameters(ast::AngleBracketedParameterData {
                         lifetimes: lifetimes,
-                        types: P::from_vec(types),
-                        bindings: P::from_vec(bindings),
+                        types: P::from(types),
+                        bindings: P::from(bindings),
                     }),
                 });
 
@@ -3884,7 +3884,7 @@ impl<'a> Parser<'a> {
                                         -> PResult<TyParamBounds>
     {
         if !try!(self.eat(&token::Colon) ){
-            Ok(P::empty())
+            Ok(P::new())
         } else {
             self.parse_ty_param_bounds(mode)
         }
@@ -3938,7 +3938,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        return Ok(P::from_vec(result));
+        return Ok(P::from(result));
     }
 
     /// Matches typaram = IDENT (`?` unbound)? optbounds ( EQ ty )?
@@ -4051,7 +4051,7 @@ impl<'a> Parser<'a> {
 
         // If we found the `>`, don't continue.
         if !returned {
-            return Ok((lifetimes, types.into_vec(), Vec::new()));
+            return Ok((lifetimes, types.into(), Vec::new()));
         }
 
         // Then parse type bindings.
@@ -4076,7 +4076,7 @@ impl<'a> Parser<'a> {
                 }));
             }
         ));
-        Ok((lifetimes, types.into_vec(), bindings.into_vec()))
+        Ok((lifetimes, types.into(), bindings.into()))
     }
 
     fn forbid_lifetime(&mut self) -> PResult<()> {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1000,7 +1000,7 @@ impl<'a> State<'a> {
             ast::TyBareFn(ref f) => {
                 let generics = ast::Generics {
                     lifetimes: f.lifetimes.clone(),
-                    ty_params: P::empty(),
+                    ty_params: P::new(),
                     where_clause: ast::WhereClause {
                         id: ast::DUMMY_NODE_ID,
                         predicates: Vec::new(),
@@ -3023,7 +3023,7 @@ impl<'a> State<'a> {
         }
         let generics = ast::Generics {
             lifetimes: Vec::new(),
-            ty_params: P::empty(),
+            ty_params: P::new(),
             where_clause: ast::WhereClause {
                 id: ast::DUMMY_NODE_ID,
                 predicates: Vec::new(),

--- a/src/libsyntax/ptr.rs
+++ b/src/libsyntax/ptr.rs
@@ -36,18 +36,39 @@
 //!   implementation changes (using a special thread-local heap, for example).
 //!   Moreover, a switch to, e.g. `P<'a, T>` would be easy and mostly automated.
 
-use std::fmt::{self, Display, Debug};
+use std::fmt;
 use std::iter::FromIterator;
 use std::ops::Deref;
-use std::{ptr, slice, vec};
-
+use std::ptr;
+use std::slice;
+use std::vec;
 use serialize::{Encodable, Decodable, Encoder, Decoder};
 
 /// An owned smart pointer.
-#[derive(Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(PartialEq, Eq, Hash)]
 pub struct P<T: ?Sized> {
     ptr: Box<T>
 }
+
+// ----------------------------------------------------------------------------
+// Common impls
+
+impl<T: ?Sized> Deref for P<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.ptr
+    }
+}
+
+impl<T: ?Sized + fmt::Debug> fmt::Debug for P<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.ptr, fmt)
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Impls for one boxed element `P<T>`
 
 #[allow(non_snake_case)]
 /// Construct a `P<T>` from a `T` value.
@@ -79,28 +100,15 @@ impl<T: 'static> P<T> {
     }
 }
 
-impl<T> Deref for P<T> {
-    type Target = T;
-
-    fn deref<'a>(&'a self) -> &'a T {
-        &*self.ptr
-    }
-}
-
 impl<T: 'static + Clone> Clone for P<T> {
     fn clone(&self) -> P<T> {
         P((**self).clone())
     }
 }
 
-impl<T: Debug> Debug for P<T> {
+impl<T: fmt::Display> fmt::Display for P<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        Debug::fmt(&**self, f)
-    }
-}
-impl<T: Display> Display for P<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        Display::fmt(&**self, f)
+        fmt::Display::fmt(&**self, f)
     }
 }
 
@@ -122,64 +130,81 @@ impl<T: Encodable> Encodable for P<T> {
     }
 }
 
-
-impl<T:fmt::Debug> fmt::Debug for P<[T]> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        self.ptr.fmt(fmt)
-    }
-}
+// ----------------------------------------------------------------------------
+// Impls for boxed array `P<[T]>` (ex-`OwnedSlice`)
 
 impl<T> P<[T]> {
-    pub fn empty() -> P<[T]> {
-        P { ptr: Default::default() }
+    pub fn new() -> Self {
+        P { ptr: Box::new([]) as Box<[T]> }
     }
 
-    #[inline(never)]
+    #[unstable(feature = "rustc_private", issue = "0")]
+    #[rustc_deprecated(since = "1.6.0", reason = "use `P::new` instead")]
+    pub fn empty() -> P<[T]> {
+        P { ptr: Box::new([]) as Box<[T]> }
+    }
+
+    #[unstable(feature = "rustc_private", issue = "0")]
+    #[rustc_deprecated(since = "1.6.0", reason = "use `P::from` instead")]
     pub fn from_vec(v: Vec<T>) -> P<[T]> {
         P { ptr: v.into_boxed_slice() }
     }
 
-    #[inline(never)]
+    #[unstable(feature = "rustc_private", issue = "0")]
+    #[rustc_deprecated(since = "1.6.0", reason = "use `P::into` instead")]
     pub fn into_vec(self) -> Vec<T> {
         self.ptr.into_vec()
     }
 
+    #[unstable(feature = "rustc_private", issue = "0")]
+    #[rustc_deprecated(since = "1.6.0", reason = "use `&owned_slice[..]` instead")]
     pub fn as_slice<'a>(&'a self) -> &'a [T] {
         &*self.ptr
     }
 
+    #[unstable(feature = "rustc_private", issue = "0")]
+    #[rustc_deprecated(since = "1.6.0", reason = "use `P::into_iter` instead")]
     pub fn move_iter(self) -> vec::IntoIter<T> {
-        self.into_vec().into_iter()
+        self.ptr.into_vec().into_iter()
     }
 
+    #[unstable(feature = "rustc_private", issue = "0")]
+    #[rustc_deprecated(since = "1.6.0", reason = "use `iter().map(f).collect()` instead")]
     pub fn map<U, F: FnMut(&T) -> U>(&self, f: F) -> P<[U]> {
         self.iter().map(f).collect()
     }
 }
 
-impl<T> Deref for P<[T]> {
-    type Target = [T];
-
-    fn deref(&self) -> &[T] {
-        self.as_slice()
-    }
-}
-
-impl<T> Default for P<[T]> {
-    fn default() -> P<[T]> {
-        P::empty()
-    }
-}
-
 impl<T: Clone> Clone for P<[T]> {
-    fn clone(&self) -> P<[T]> {
-        P::from_vec(self.to_vec())
+    fn clone(&self) -> Self {
+        P { ptr: self.ptr.clone() }
+    }
+}
+
+impl<T> From<Vec<T>> for P<[T]> {
+    fn from(v: Vec<T>) -> Self {
+        P { ptr: v.into_boxed_slice() }
+    }
+}
+
+impl<T> Into<Vec<T>> for P<[T]> {
+    fn into(self) -> Vec<T> {
+        self.ptr.into_vec()
     }
 }
 
 impl<T> FromIterator<T> for P<[T]> {
-    fn from_iter<I: IntoIterator<Item=T>>(iter: I) -> P<[T]> {
-        P::from_vec(iter.into_iter().collect())
+    fn from_iter<I: IntoIterator<Item=T>>(iter: I) -> Self {
+        P::from(iter.into_iter().collect::<Vec<_>>())
+    }
+}
+
+impl<T> IntoIterator for P<[T]> {
+    type Item = T;
+    type IntoIter = vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.ptr.into_vec().into_iter()
     }
 }
 
@@ -187,21 +212,26 @@ impl<'a, T> IntoIterator for &'a P<[T]> {
     type Item = &'a T;
     type IntoIter = slice::Iter<'a, T>;
     fn into_iter(self) -> Self::IntoIter {
-        self.ptr.into_iter()
+        self.ptr.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut P<[T]> {
+    type Item = &'a mut T;
+    type IntoIter = slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.ptr.iter_mut()
     }
 }
 
 impl<T: Encodable> Encodable for P<[T]> {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-        Encodable::encode(&**self, s)
+    fn encode<E: Encoder>(&self, s: &mut E) -> Result<(), E::Error> {
+        Encodable::encode(&self.ptr, s)
     }
 }
 
 impl<T: Decodable> Decodable for P<[T]> {
-    fn decode<D: Decoder>(d: &mut D) -> Result<P<[T]>, D::Error> {
-        Ok(P::from_vec(match Decodable::decode(d) {
-            Ok(t) => t,
-            Err(e) => return Err(e)
-        }))
+    fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
+        Ok(P { ptr: try!(Decodable::decode(d)) })
     }
 }

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -30,7 +30,6 @@ use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::expand::ExpansionConfig;
 use fold::Folder;
-use util::move_map::MoveMap;
 use fold;
 use parse::token::{intern, InternedString};
 use parse::{token, ParseSess};

--- a/src/libsyntax/util/move_map.rs
+++ b/src/libsyntax/util/move_map.rs
@@ -10,17 +10,36 @@
 
 use std::ptr;
 
-pub trait MoveMap<T>: Sized {
-    fn move_map<F>(self, mut f: F) -> Self where F: FnMut(T) -> T {
-        self.move_flat_map(|e| Some(f(e)))
-    }
-
-    fn move_flat_map<F, I>(self, f: F) -> Self
-        where F: FnMut(T) -> I,
-              I: IntoIterator<Item=T>;
+pub trait MoveMap {
+    type Item;
+    fn move_map<F>(self, f: F) -> Self
+        where F: FnMut(Self::Item) -> Self::Item;
 }
 
-impl<T> MoveMap<T> for Vec<T> {
+pub trait MoveFlatMap {
+    type Item;
+    fn move_flat_map<F, I>(self, f: F) -> Self
+        where F: FnMut(Self::Item) -> I,
+              I: IntoIterator<Item = Self::Item>;
+}
+
+impl<Container, T> MoveMap for Container
+    where for<'a> &'a mut Container: IntoIterator<Item = &'a mut T>
+{
+    type Item = T;
+    fn move_map<F>(mut self, mut f: F) -> Container where F: FnMut(T) -> T {
+        for p in &mut self {
+            unsafe {
+                // FIXME(#5016) this shouldn't need to zero to be safe.
+                ptr::write(p, f(ptr::read_and_drop(p)));
+            }
+        }
+        self
+    }
+}
+
+impl<T> MoveFlatMap for Vec<T> {
+    type Item = T;
     fn move_flat_map<F, I>(mut self, mut f: F) -> Self
         where F: FnMut(T) -> I,
               I: IntoIterator<Item=T>
@@ -67,11 +86,13 @@ impl<T> MoveMap<T> for Vec<T> {
     }
 }
 
-impl<T> MoveMap<T> for ::ptr::P<[T]> {
+impl<T> MoveFlatMap for ::ptr::P<[T]> {
+    type Item = T;
     fn move_flat_map<F, I>(self, f: F) -> Self
         where F: FnMut(T) -> I,
               I: IntoIterator<Item=T>
     {
-        ::ptr::P::from_vec(self.into_vec().move_flat_map(f))
+        let v: Vec<_> = self.into();
+        v.move_flat_map(f).into()
     }
 }

--- a/src/libsyntax/util/small_vector.rs
+++ b/src/libsyntax/util/small_vector.rs
@@ -16,8 +16,6 @@ use std::mem;
 use std::slice;
 use std::vec;
 
-use util::move_map::MoveMap;
-
 /// A vector type optimized for cases where the size is almost always 0 or 1
 pub struct SmallVector<T> {
     repr: SmallVectorRepr<T>,
@@ -34,6 +32,14 @@ impl<T> FromIterator<T> for SmallVector<T> {
         let mut v = SmallVector::zero();
         v.extend(iter);
         v
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut SmallVector<T> {
+    type Item = &'a mut T;
+    type IntoIter = slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.as_slice_mut().iter_mut()
     }
 }
 
@@ -68,6 +74,18 @@ impl<T> SmallVector<T> {
                 unsafe { slice::from_raw_parts(v, 1) }
             }
             Many(ref vs) => vs
+        }
+    }
+
+    pub fn as_slice_mut(&mut self) -> &mut [T] {
+        match self.repr {
+            Zero => {
+                &mut []
+            }
+            One(ref mut v) => {
+                unsafe { slice::from_raw_parts_mut(v, 1) }
+            }
+            Many(ref mut vs) => vs
         }
     }
 
@@ -184,19 +202,6 @@ impl<T> Iterator for IntoIter<T> {
             ZeroIterator => (0, Some(0)),
             OneIterator(..) => (1, Some(1)),
             ManyIterator(ref inner) => inner.size_hint()
-        }
-    }
-}
-
-impl<T> MoveMap<T> for SmallVector<T> {
-    fn move_flat_map<F, I>(self, mut f: F) -> Self
-        where F: FnMut(T) -> I,
-              I: IntoIterator<Item=T>
-    {
-        match self.repr {
-            Zero => Self::zero(),
-            One(v) => f(v).into_iter().collect(),
-            Many(vs) => SmallVector { repr: Many(vs.move_flat_map(f)) },
         }
     }
 }

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -489,7 +489,7 @@ impl<'a> TraitDef<'a> {
 
         let Generics { mut lifetimes, ty_params, mut where_clause } =
             self.generics.to_generics(cx, self.span, type_ident, generics);
-        let mut ty_params = ty_params.into_vec();
+        let mut ty_params: Vec<_> = ty_params.into();
 
         // Copy the lifetimes
         lifetimes.extend(generics.lifetimes.iter().cloned());
@@ -515,7 +515,7 @@ impl<'a> TraitDef<'a> {
 
             cx.typaram(self.span,
                        ty_param.ident,
-                       P::from_vec(bounds),
+                       P::from(bounds),
                        None)
         }));
 
@@ -527,7 +527,7 @@ impl<'a> TraitDef<'a> {
                         span: self.span,
                         bound_lifetimes: wb.bound_lifetimes.clone(),
                         bounded_ty: wb.bounded_ty.clone(),
-                        bounds: P::from_vec(wb.bounds.iter().cloned().collect())
+                        bounds: wb.bounds.iter().cloned().collect()
                     })
                 }
                 ast::WherePredicate::RegionPredicate(ref rb) => {
@@ -578,7 +578,7 @@ impl<'a> TraitDef<'a> {
                         span: self.span,
                         bound_lifetimes: vec![],
                         bounded_ty: ty,
-                        bounds: P::from_vec(bounds),
+                        bounds: P::from(bounds),
                     };
 
                     let predicate = ast::WherePredicate::BoundPredicate(predicate);
@@ -589,7 +589,7 @@ impl<'a> TraitDef<'a> {
 
         let trait_generics = Generics {
             lifetimes: lifetimes,
-            ty_params: P::from_vec(ty_params),
+            ty_params: P::from(ty_params),
             where_clause: where_clause
         };
 
@@ -597,9 +597,9 @@ impl<'a> TraitDef<'a> {
         let trait_ref = cx.trait_ref(trait_path);
 
         // Create the type parameters on the `self` path.
-        let self_ty_params = generics.ty_params.map(|ty_param| {
+        let self_ty_params = generics.ty_params.iter().map(|ty_param| {
             cx.ty_ident(self.span, ty_param.ident)
-        });
+        }).collect();
 
         let self_lifetimes: Vec<ast::Lifetime> =
             generics.lifetimes
@@ -610,7 +610,7 @@ impl<'a> TraitDef<'a> {
         // Create the type of `self`.
         let self_type = cx.ty_path(
             cx.path_all(self.span, false, vec!( type_ident ), self_lifetimes,
-                        self_ty_params.into_vec(), Vec::new()));
+                        self_ty_params, Vec::new()));
 
         let attr = cx.attribute(
             self.span,

--- a/src/libsyntax_ext/deriving/generic/ty.rs
+++ b/src/libsyntax_ext/deriving/generic/ty.rs
@@ -169,15 +169,15 @@ impl<'a> Ty<'a> {
                    -> ast::Path {
         match *self {
             Self_ => {
-                let self_params = self_generics.ty_params.map(|ty_param| {
+                let self_params = self_generics.ty_params.iter().map(|ty_param| {
                     cx.ty_ident(span, ty_param.ident)
-                });
+                }).collect();
                 let lifetimes = self_generics.lifetimes.iter()
                                                        .map(|d| d.lifetime)
                                                        .collect();
 
                 cx.path_all(span, false, vec!(self_ty), lifetimes,
-                            self_params.into_vec(), Vec::new())
+                            self_params, Vec::new())
             }
             Literal(ref p) => {
                 p.to_path(cx, span, self_ty, self_generics)
@@ -208,7 +208,7 @@ fn mk_generics(lifetimes: Vec<ast::LifetimeDef>, ty_params: Vec<ast::TyParam>)
                -> Generics {
     Generics {
         lifetimes: lifetimes,
-        ty_params: P::from_vec(ty_params),
+        ty_params: P::from(ty_params),
         where_clause: ast::WhereClause {
             id: ast::DUMMY_NODE_ID,
             predicates: Vec::new(),


### PR DESCRIPTION
Most of the changes are to support switching between vector-like containers in HIR and beefing up `OwnedSlice`'s interface.
The actual change from `Vec` to `OwnedSlice` is [one line](https://github.com/petrochenkov/rust/blob/365e34c30ba5fb6c04684bd48ad90315f5918464/src/librustc_front/hir.rs#L54), and it can be changed back if necessary.

Memory consumption for librustc, libcore and libstd is below under the spoilers - the changes are small, but consistent.
libcore is the most noticeable, 5.7% less memory immediately after lowering to HIR, 4% less memory during type checking.

<details> 
  <summary>

Before:</summary>



```
rustc: x86_64-pc-windows-gnu/stage1/lib/rustlib/x86_64-pc-windows-gnu/lib/librustc
time: 0.149; rss: 61MB  parsing
time: 0.050; rss: 61MB  configuration 1
time: 0.000; rss: 61MB  recursion limit
time: 0.004; rss: 61MB  gated macro checking
time: 0.000; rss: 61MB  crate injection
time: 0.019; rss: 64MB  macro loading
time: 0.000; rss: 64MB  plugin loading
time: 0.000; rss: 64MB  plugin registration
time: 0.655; rss: 99MB  expansion
time: 0.026; rss: 99MB  complete gated feature checking 1
time: 0.111; rss: 99MB  configuration 2
time: 0.000; rss: 99MB  gated configuration checking
time: 0.059; rss: 100MB maybe building test harness
time: 0.054; rss: 100MB prelude injection
time: 0.013; rss: 100MB checking that all macro invocations are gone
time: 0.000; rss: 100MB checking for inline asm in case the target doesn't support it
time: 0.027; rss: 100MB complete gated feature checking 2
time: 0.058; rss: 100MB assigning node ids
time: 0.094; rss: 151MB lowering ast -> hir
time: 0.048; rss: 167MB indexing hir
time: 0.000; rss: 167MB attribute checking
time: 0.035; rss: 167MB early lint checks
time: 0.011; rss: 183MB external crate/lib resolution
time: 0.010; rss: 183MB language item collection
time: 0.219; rss: 233MB resolution
time: 0.019; rss: 233MB lifetime resolution
time: 0.000; rss: 233MB looking for entry point
time: 0.000; rss: 233MB looking for plugin registrar
time: 0.071; rss: 252MB region resolution
time: 0.010; rss: 252MB loop checking
time: 0.012; rss: 252MB static item recursion checking
time: 0.069; rss: 261MB type collecting
time: 0.002; rss: 261MB variance inference
time: 0.059; rss: 283MB coherence checking
time: 0.103; rss: 288MB wf checking (old)
time: 0.166; rss: 290MB item-types checking
time: 5.307; rss: 402MB item-bodies checking
time: 0.000; rss: 402MB drop-impl checking
time: 0.270; rss: 402MB wf checking (new)
time: 0.586; rss: 419MB const checking
time: 0.117; rss: 420MB privacy checking
time: 0.018; rss: 420MB stability index
time: 0.034; rss: 420MB intrinsic checking
time: 0.023; rss: 420MB effect checking
time: 0.093; rss: 420MB match checking
time: 0.430; rss: 486MB MIR dump
time: 0.068; rss: 487MB liveness checking
time: 0.613; rss: 488MB borrow checking
time: 0.327; rss: 489MB rvalue checking
time: 0.024; rss: 489MB reachability checking
time: 0.076; rss: 490MB death checking
time: 0.066; rss: 492MB stability checking
time: 0.000; rss: 492MB unused lib feature checking
time: 0.281; rss: 492MB lint checking
time: 0.001; rss: 492MB resolving dependency formats
time: 0.070; rss: 497MB erasing regions from MIR
time: 7.883; rss: 1028MB        translation
  time: 1.817; rss: 549MB       llvm function passes [0]
  time: 32.515; rss: 667MB      llvm module passes [0]
  time: 10.598; rss: 685MB      codegen passes [0]
  time: 0.004; rss: 166MB       codegen passes [0]
time: 45.969; rss: 161MB        LLVM passes
  time: 0.612; rss: 161MB       running linker
time: 1.105; rss: 164MB linking
rustc: x86_64-pc-windows-gnu/stage2/lib/rustlib/x86_64-pc-windows-gnu/lib/libcore
time: 0.089; rss: 41MB  parsing
time: 0.024; rss: 43MB  configuration 1
time: 0.000; rss: 43MB  recursion limit
time: 0.002; rss: 43MB  gated macro checking
time: 0.000; rss: 43MB  crate injection
time: 0.001; rss: 43MB  macro loading
time: 0.000; rss: 43MB  plugin loading
time: 0.000; rss: 43MB  plugin registration
time: 0.428; rss: 71MB  expansion
time: 0.012; rss: 71MB  complete gated feature checking 1
time: 0.090; rss: 71MB  configuration 2
time: 0.000; rss: 71MB  gated configuration checking
time: 0.047; rss: 71MB  maybe building test harness
time: 0.000; rss: 71MB  prelude injection
time: 0.005; rss: 71MB  checking that all macro invocations are gone
time: 0.000; rss: 71MB  checking for inline asm in case the target doesn't support it
time: 0.012; rss: 71MB  complete gated feature checking 2
time: 0.046; rss: 71MB  assigning node ids
time: 0.039; rss: 105MB lowering ast -> hir
time: 0.085; rss: 122MB indexing hir
time: 0.000; rss: 122MB attribute checking
time: 0.019; rss: 122MB early lint checks
time: 0.000; rss: 122MB external crate/lib resolution
time: 0.004; rss: 122MB language item collection
time: 0.076; rss: 139MB resolution
time: 0.011; rss: 139MB lifetime resolution
time: 0.000; rss: 139MB looking for entry point
time: 0.000; rss: 139MB looking for plugin registrar
time: 0.028; rss: 146MB region resolution
time: 0.003; rss: 146MB loop checking
time: 0.004; rss: 146MB static item recursion checking
time: 0.070; rss: 156MB type collecting
time: 0.001; rss: 156MB variance inference
time: 0.311; rss: 157MB coherence checking
time: 0.380; rss: 160MB wf checking (old)
time: 0.514; rss: 165MB item-types checking
time: 3.256; rss: 195MB item-bodies checking
time: 0.000; rss: 195MB drop-impl checking
time: 0.685; rss: 196MB wf checking (new)
time: 0.144; rss: 197MB const checking
time: 0.057; rss: 197MB privacy checking
time: 0.009; rss: 197MB stability index
time: 0.033; rss: 197MB intrinsic checking
time: 0.011; rss: 197MB effect checking
time: 0.052; rss: 197MB match checking
time: 0.178; rss: 218MB MIR dump
time: 0.024; rss: 219MB liveness checking
time: 0.285; rss: 219MB borrow checking
time: 0.146; rss: 219MB rvalue checking
time: 0.073; rss: 220MB reachability checking
time: 0.035; rss: 220MB death checking
time: 0.032; rss: 221MB stability checking
time: 0.000; rss: 221MB unused lib feature checking
time: 0.434; rss: 221MB lint checking
time: 0.000; rss: 221MB resolving dependency formats
time: 0.022; rss: 222MB erasing regions from MIR
time: 1.182; rss: 292MB translation
  time: 0.157; rss: 171MB       llvm function passes [0]
  time: 1.464; rss: 180MB       llvm module passes [0]
  time: 1.217; rss: 183MB       codegen passes [0]
  time: 0.004; rss: 148MB       codegen passes [0]
time: 2.897; rss: 143MB LLVM passes
time: 0.051; rss: 143MB linking
rustc: x86_64-pc-windows-gnu/stage2/lib/rustlib/x86_64-pc-windows-gnu/lib/libstd
time: 0.143; rss: 60MB  parsing
time: 0.041; rss: 62MB  configuration 1
time: 0.000; rss: 62MB  recursion limit
time: 0.002; rss: 62MB  gated macro checking
time: 0.000; rss: 62MB  crate injection
time: 0.006; rss: 63MB  macro loading
time: 0.000; rss: 63MB  plugin loading
time: 0.000; rss: 63MB  plugin registration
time: 0.165; rss: 64MB  expansion
time: 0.007; rss: 64MB  complete gated feature checking 1
time: 0.039; rss: 64MB  configuration 2
time: 0.000; rss: 64MB  gated configuration checking
time: 0.020; rss: 64MB  maybe building test harness
time: 0.019; rss: 64MB  prelude injection
time: 0.003; rss: 64MB  checking that all macro invocations are gone
time: 0.000; rss: 64MB  checking for inline asm in case the target doesn't support it
time: 0.007; rss: 64MB  complete gated feature checking 2
time: 0.020; rss: 64MB  assigning node ids
time: 0.021; rss: 72MB  lowering ast -> hir
time: 0.012; rss: 80MB  indexing hir
time: 0.000; rss: 80MB  attribute checking
time: 0.010; rss: 80MB  early lint checks
time: 0.003; rss: 80MB  external crate/lib resolution
time: 0.002; rss: 80MB  language item collection
time: 0.057; rss: 106MB resolution
time: 0.004; rss: 106MB lifetime resolution
time: 0.000; rss: 106MB looking for entry point
time: 0.000; rss: 106MB looking for plugin registrar
time: 0.014; rss: 111MB region resolution
time: 0.002; rss: 111MB loop checking
time: 0.002; rss: 111MB static item recursion checking
time: 0.025; rss: 112MB type collecting
time: 0.001; rss: 112MB variance inference
time: 0.035; rss: 122MB coherence checking
time: 0.043; rss: 123MB wf checking (old)
time: 0.065; rss: 126MB item-types checking
time: 1.068; rss: 153MB item-bodies checking
time: 0.000; rss: 153MB drop-impl checking
time: 0.111; rss: 153MB wf checking (new)
time: 0.109; rss: 154MB const checking
time: 0.026; rss: 155MB privacy checking
time: 0.004; rss: 155MB stability index
time: 0.010; rss: 155MB intrinsic checking
time: 0.005; rss: 155MB effect checking
time: 0.026; rss: 155MB match checking
time: 0.117; rss: 171MB MIR dump
time: 0.014; rss: 172MB liveness checking
time: 0.185; rss: 172MB borrow checking
time: 0.127; rss: 172MB rvalue checking
time: 0.009; rss: 172MB reachability checking
time: 0.016; rss: 172MB death checking
time: 0.016; rss: 173MB stability checking
time: 0.000; rss: 173MB unused lib feature checking
time: 0.096; rss: 173MB lint checking
time: 0.000; rss: 173MB resolving dependency formats
time: 0.015; rss: 175MB erasing regions from MIR
time: 0.987; rss: 267MB translation
  time: 0.202; rss: 213MB       llvm function passes [0]
  time: 3.011; rss: 228MB       llvm module passes [0]
  time: 1.258; rss: 233MB       codegen passes [0]
  time: 0.004; rss: 178MB       codegen passes [0]
time: 4.568; rss: 175MB LLVM passes
  time: 0.003; rss: 175MB       altering collections-71b07a99.rlib
  time: 0.001; rss: 175MB       altering alloc-71b07a99.rlib
  time: 0.009; rss: 175MB       altering rustc_unicode-71b07a99.rlib
  time: 0.003; rss: 175MB       altering alloc_jemalloc-71b07a99.rlib
  time: 0.001; rss: 175MB       altering libc-71b07a99.rlib
  time: 0.003; rss: 175MB       altering rand-71b07a99.rlib
  time: 0.004; rss: 175MB       altering core-71b07a99.rlib
  time: 0.249; rss: 176MB       running linker
time: 0.343; rss: 176MB linking
```

</details>
<details> 
  <summary>

After:</summary>



```
rustc: x86_64-pc-windows-gnu/stage1/lib/rustlib/x86_64-pc-windows-gnu/lib/librustc
time: 0.148; rss: 61MB  parsing
time: 0.050; rss: 61MB  configuration 1
time: 0.000; rss: 61MB  recursion limit
time: 0.005; rss: 62MB  gated macro checking
time: 0.000; rss: 62MB  crate injection
time: 0.018; rss: 64MB  macro loading
time: 0.000; rss: 64MB  plugin loading
time: 0.000; rss: 64MB  plugin registration
time: 0.668; rss: 100MB expansion
time: 0.026; rss: 100MB complete gated feature checking 1
time: 0.112; rss: 100MB configuration 2
time: 0.000; rss: 100MB gated configuration checking
time: 0.059; rss: 100MB maybe building test harness
time: 0.054; rss: 100MB prelude injection
time: 0.013; rss: 100MB checking that all macro invocations are gone
time: 0.000; rss: 100MB checking for inline asm in case the target doesn't support it
time: 0.028; rss: 100MB complete gated feature checking 2
time: 0.057; rss: 100MB assigning node ids
time: 0.080; rss: 148MB lowering ast -> hir
time: 0.045; rss: 164MB indexing hir
time: 0.000; rss: 164MB attribute checking
time: 0.035; rss: 164MB early lint checks
time: 0.011; rss: 180MB external crate/lib resolution
time: 0.010; rss: 180MB language item collection
time: 0.211; rss: 231MB resolution
time: 0.017; rss: 231MB lifetime resolution
time: 0.000; rss: 231MB looking for entry point
time: 0.000; rss: 231MB looking for plugin registrar
time: 0.066; rss: 249MB region resolution
time: 0.008; rss: 249MB loop checking
time: 0.009; rss: 249MB static item recursion checking
time: 0.066; rss: 257MB type collecting
time: 0.002; rss: 257MB variance inference
time: 0.058; rss: 281MB coherence checking
time: 0.100; rss: 286MB wf checking (old)
time: 0.164; rss: 288MB item-types checking
time: 5.349; rss: 399MB item-bodies checking
time: 0.000; rss: 399MB drop-impl checking
time: 0.274; rss: 400MB wf checking (new)
time: 0.387; rss: 417MB const checking
time: 0.115; rss: 417MB privacy checking
time: 0.016; rss: 417MB stability index
time: 0.036; rss: 417MB intrinsic checking
time: 0.026; rss: 417MB effect checking
time: 0.093; rss: 417MB match checking
time: 0.430; rss: 483MB MIR dump
time: 0.065; rss: 484MB liveness checking
time: 0.619; rss: 485MB borrow checking
time: 0.341; rss: 486MB rvalue checking
time: 0.023; rss: 486MB reachability checking
time: 0.075; rss: 487MB death checking
time: 0.068; rss: 489MB stability checking
time: 0.000; rss: 489MB unused lib feature checking
time: 0.282; rss: 489MB lint checking
time: 0.002; rss: 489MB resolving dependency formats
time: 0.071; rss: 493MB erasing regions from MIR
time: 7.926; rss: 1014MB        translation
  time: 1.861; rss: 549MB       llvm function passes [0]
  time: 32.975; rss: 665MB      llvm module passes [0]
  time: 10.806; rss: 667MB      codegen passes [0]
  time: 0.004; rss: 166MB       codegen passes [0]
time: 46.722; rss: 160MB        LLVM passes
  time: 0.626; rss: 160MB       running linker
time: 1.142; rss: 163MB linking
rustc: x86_64-pc-windows-gnu/stage2/lib/rustlib/x86_64-pc-windows-gnu/lib/libcore
time: 0.072; rss: 42MB  parsing
time: 0.026; rss: 43MB  configuration 1
time: 0.000; rss: 43MB  recursion limit
time: 0.002; rss: 43MB  gated macro checking
time: 0.000; rss: 43MB  crate injection
time: 0.001; rss: 43MB  macro loading
time: 0.000; rss: 43MB  plugin loading
time: 0.000; rss: 43MB  plugin registration
time: 0.435; rss: 71MB  expansion
time: 0.010; rss: 71MB  complete gated feature checking 1
time: 0.093; rss: 71MB  configuration 2
time: 0.000; rss: 71MB  gated configuration checking
time: 0.045; rss: 71MB  maybe building test harness
time: 0.000; rss: 71MB  prelude injection
time: 0.005; rss: 71MB  checking that all macro invocations are gone
time: 0.000; rss: 71MB  checking for inline asm in case the target doesn't support it
time: 0.013; rss: 71MB  complete gated feature checking 2
time: 0.046; rss: 71MB  assigning node ids
time: 0.036; rss: 99MB  lowering ast -> hir
time: 0.084; rss: 116MB indexing hir
time: 0.000; rss: 116MB attribute checking
time: 0.018; rss: 116MB early lint checks
time: 0.000; rss: 116MB external crate/lib resolution
time: 0.003; rss: 116MB language item collection
time: 0.076; rss: 131MB resolution
time: 0.010; rss: 131MB lifetime resolution
time: 0.000; rss: 131MB looking for entry point
time: 0.000; rss: 131MB looking for plugin registrar
time: 0.029; rss: 141MB region resolution
time: 0.003; rss: 141MB loop checking
time: 0.003; rss: 141MB static item recursion checking
time: 0.068; rss: 149MB type collecting
time: 0.001; rss: 150MB variance inference
time: 0.313; rss: 151MB coherence checking
time: 0.403; rss: 154MB wf checking (old)
time: 0.543; rss: 158MB item-types checking
time: 3.340; rss: 187MB item-bodies checking
time: 0.000; rss: 187MB drop-impl checking
time: 0.689; rss: 188MB wf checking (new)
time: 0.144; rss: 189MB const checking
time: 0.055; rss: 189MB privacy checking
time: 0.008; rss: 189MB stability index
time: 0.032; rss: 189MB intrinsic checking
time: 0.010; rss: 189MB effect checking
time: 0.051; rss: 189MB match checking
time: 0.178; rss: 212MB MIR dump
time: 0.024; rss: 213MB liveness checking
time: 0.284; rss: 213MB borrow checking
time: 0.147; rss: 213MB rvalue checking
time: 0.073; rss: 214MB reachability checking
time: 0.033; rss: 214MB death checking
time: 0.032; rss: 215MB stability checking
time: 0.000; rss: 215MB unused lib feature checking
time: 0.436; rss: 215MB lint checking
time: 0.000; rss: 215MB resolving dependency formats
time: 0.023; rss: 217MB erasing regions from MIR
time: 1.166; rss: 288MB translation
  time: 0.148; rss: 176MB       llvm function passes [0]
  time: 1.406; rss: 185MB       llvm module passes [0]
  time: 1.199; rss: 187MB       codegen passes [0]
  time: 0.005; rss: 151MB       codegen passes [0]
time: 2.814; rss: 147MB LLVM passes
time: 0.048; rss: 147MB linking
rustc: x86_64-pc-windows-gnu/stage2/lib/rustlib/x86_64-pc-windows-gnu/lib/libstd
time: 0.152; rss: 60MB  parsing
time: 0.043; rss: 62MB  configuration 1
time: 0.000; rss: 62MB  recursion limit
time: 0.002; rss: 62MB  gated macro checking
time: 0.000; rss: 62MB  crate injection
time: 0.006; rss: 63MB  macro loading
time: 0.000; rss: 63MB  plugin loading
time: 0.000; rss: 63MB  plugin registration
time: 0.179; rss: 64MB  expansion
time: 0.007; rss: 64MB  complete gated feature checking 1
time: 0.039; rss: 64MB  configuration 2
time: 0.000; rss: 64MB  gated configuration checking
time: 0.020; rss: 64MB  maybe building test harness
time: 0.019; rss: 64MB  prelude injection
time: 0.003; rss: 64MB  checking that all macro invocations are gone
time: 0.000; rss: 64MB  checking for inline asm in case the target doesn't support it
time: 0.008; rss: 64MB  complete gated feature checking 2
time: 0.020; rss: 64MB  assigning node ids
time: 0.024; rss: 69MB  lowering ast -> hir
time: 0.012; rss: 76MB  indexing hir
time: 0.000; rss: 76MB  attribute checking
time: 0.012; rss: 76MB  early lint checks
time: 0.003; rss: 77MB  external crate/lib resolution
time: 0.002; rss: 77MB  language item collection
time: 0.057; rss: 103MB resolution
time: 0.004; rss: 103MB lifetime resolution
time: 0.000; rss: 103MB looking for entry point
time: 0.000; rss: 103MB looking for plugin registrar
time: 0.013; rss: 107MB region resolution
time: 0.002; rss: 107MB loop checking
time: 0.002; rss: 107MB static item recursion checking
time: 0.024; rss: 108MB type collecting
time: 0.001; rss: 108MB variance inference
time: 0.033; rss: 119MB coherence checking
time: 0.044; rss: 120MB wf checking (old)
time: 0.065; rss: 122MB item-types checking
time: 1.113; rss: 151MB item-bodies checking
time: 0.000; rss: 151MB drop-impl checking
time: 0.120; rss: 151MB wf checking (new)
time: 0.106; rss: 153MB const checking
time: 0.023; rss: 153MB privacy checking
time: 0.003; rss: 153MB stability index
time: 0.010; rss: 153MB intrinsic checking
time: 0.005; rss: 153MB effect checking
time: 0.025; rss: 153MB match checking
time: 0.122; rss: 169MB MIR dump
time: 0.013; rss: 170MB liveness checking
time: 0.211; rss: 170MB borrow checking
time: 0.127; rss: 170MB rvalue checking
time: 0.007; rss: 170MB reachability checking
time: 0.017; rss: 170MB death checking
time: 0.016; rss: 171MB stability checking
time: 0.000; rss: 171MB unused lib feature checking
time: 0.087; rss: 171MB lint checking
time: 0.000; rss: 171MB resolving dependency formats
time: 0.017; rss: 172MB erasing regions from MIR
time: 1.039; rss: 264MB translation
  time: 0.212; rss: 214MB       llvm function passes [0]
  time: 3.120; rss: 227MB       llvm module passes [0]
  time: 1.344; rss: 233MB       codegen passes [0]
  time: 0.003; rss: 178MB       codegen passes [0]
time: 4.772; rss: 175MB LLVM passes
  time: 0.003; rss: 175MB       altering collections-71b07a99.rlib
  time: 0.001; rss: 175MB       altering alloc-71b07a99.rlib
  time: 0.006; rss: 175MB       altering rustc_unicode-71b07a99.rlib
  time: 0.003; rss: 175MB       altering alloc_jemalloc-71b07a99.rlib
  time: 0.001; rss: 175MB       altering libc-71b07a99.rlib
  time: 0.002; rss: 175MB       altering rand-71b07a99.rlib
  time: 0.003; rss: 175MB       altering core-71b07a99.rlib
  time: 0.260; rss: 175MB       running linker
time: 0.346; rss: 175MB linking
```

</details>

r? @nrc or @eddyb 
