### PR TITLE
Move some ast_util functions into methods

### DIFF
--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -24,7 +24,7 @@ use middle::ty::{self, TypeAndMut, Ty, HasTypeFlags};
 use middle::ty::fold::TypeFoldable;
 
 use std::fmt;
-use syntax::{abi, ast_util};
+use syntax::{abi};
 use syntax::parse::token;
 use syntax::ast::CRATE_NODE_ID;
 use rustc_front::hir;
@@ -778,9 +778,9 @@ impl<'tcx> fmt::Display for ty::TypeVariants<'tcx> {
         match *self {
             TyBool => write!(f, "bool"),
             TyChar => write!(f, "char"),
-            TyInt(t) => write!(f, "{}", ast_util::int_ty_to_string(t)),
-            TyUint(t) => write!(f, "{}", ast_util::uint_ty_to_string(t)),
-            TyFloat(t) => write!(f, "{}", ast_util::float_ty_to_string(t)),
+            TyInt(t) => write!(f, "{}", t.ty_to_string()),
+            TyUint(t) => write!(f, "{}", t.ty_to_string()),
+            TyFloat(t) => write!(f, "{}", t.ty_to_string()),
             TyBox(typ) => write!(f, "Box<{}>",  typ),
             TyRawPtr(ref tm) => {
                 write!(f, "*{} {}", match tm.mutbl {

--- a/src/librustc_trans/trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/trans/debuginfo/metadata.rs
@@ -46,7 +46,7 @@ use std::rc::Rc;
 use syntax;
 use syntax::util::interner::Interner;
 use syntax::codemap::Span;
-use syntax::{ast, ast_util, codemap};
+use syntax::{ast, codemap};
 use syntax::parse::token;
 
 
@@ -936,13 +936,13 @@ fn basic_type_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
         ty::TyBool => ("bool", DW_ATE_boolean),
         ty::TyChar => ("char", DW_ATE_unsigned_char),
         ty::TyInt(int_ty) => {
-            (ast_util::int_ty_to_string(int_ty), DW_ATE_signed)
+            (int_ty.ty_to_string(), DW_ATE_signed)
         },
         ty::TyUint(uint_ty) => {
-            (ast_util::uint_ty_to_string(uint_ty), DW_ATE_unsigned)
+            (uint_ty.ty_to_string(), DW_ATE_unsigned)
         },
         ty::TyFloat(float_ty) => {
-            (ast_util::float_ty_to_string(float_ty), DW_ATE_float)
+            (float_ty.ty_to_string(), DW_ATE_float)
         },
         _ => cx.sess().bug("debuginfo::basic_type_metadata - t is invalid type")
     };

--- a/src/librustc_trans/trans/debuginfo/type_names.rs
+++ b/src/librustc_trans/trans/debuginfo/type_names.rs
@@ -19,7 +19,6 @@ use middle::subst::{self, Substs};
 use middle::ty::{self, Ty};
 
 use rustc_front::hir;
-use syntax::ast_util;
 
 // Compute the name of the type as it should be stored in debuginfo. Does not do
 // any caching, i.e. calling the function twice with the same type will also do
@@ -44,9 +43,9 @@ pub fn push_debuginfo_type_name<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
         ty::TyBool => output.push_str("bool"),
         ty::TyChar => output.push_str("char"),
         ty::TyStr => output.push_str("str"),
-        ty::TyInt(int_ty) => output.push_str(ast_util::int_ty_to_string(int_ty)),
-        ty::TyUint(uint_ty) => output.push_str(ast_util::uint_ty_to_string(uint_ty)),
-        ty::TyFloat(float_ty) => output.push_str(ast_util::float_ty_to_string(float_ty)),
+        ty::TyInt(int_ty) => output.push_str(int_ty.ty_to_string()),
+        ty::TyUint(uint_ty) => output.push_str(uint_ty.ty_to_string()),
+        ty::TyFloat(float_ty) => output.push_str(float_ty.ty_to_string()),
         ty::TyStruct(def, substs) |
         ty::TyEnum(def, substs) => {
             push_item_name(cx, def.did, qualified, output);

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -83,7 +83,7 @@ use trans::type_::Type;
 use rustc_front;
 use rustc_front::hir;
 
-use syntax::{ast, ast_util, codemap};
+use syntax::{ast, codemap};
 use syntax::parse::token::InternedString;
 use syntax::ptr::P;
 use syntax::parse::token;
@@ -2622,7 +2622,7 @@ fn expr_kind(tcx: &ty::ctxt, expr: &hir::Expr) -> ExprKind {
             ExprKind::RvalueDps
         }
 
-        hir::ExprLit(ref lit) if ast_util::lit_is_str(&**lit) => {
+        hir::ExprLit(ref lit) if lit.node.is_str() => {
             ExprKind::RvalueDps
         }
 

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -11,7 +11,6 @@
 use abi;
 use ast::{Ident, Generics, Expr};
 use ast;
-use ast_util;
 use attr;
 use codemap::{Span, respan, Spanned, DUMMY_SP, Pos};
 use ext::base::ExtCtxt;
@@ -991,7 +990,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             name,
             inputs,
             output,
-            ast_util::empty_generics(),
+            Generics::default(),
             body)
     }
 
@@ -1029,7 +1028,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     fn item_enum(&self, span: Span, name: Ident,
                  enum_definition: ast::EnumDef) -> P<ast::Item> {
         self.item_enum_poly(span, name, enum_definition,
-                            ast_util::empty_generics())
+                            Generics::default())
     }
 
     fn item_struct(&self, span: Span, name: Ident,
@@ -1038,7 +1037,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             span,
             name,
             struct_def,
-            ast_util::empty_generics()
+            Generics::default()
         )
     }
 
@@ -1086,7 +1085,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     }
 
     fn item_ty(&self, span: Span, name: Ident, ty: P<ast::Ty>) -> P<ast::Item> {
-        self.item_ty_poly(span, name, ty, ast_util::empty_generics())
+        self.item_ty_poly(span, name, ty, Generics::default())
     }
 
     fn attribute(&self, sp: Span, mi: P<ast::MetaItem>) -> ast::Attribute {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2872,7 +2872,7 @@ impl<'a> Parser<'a> {
     fn check_no_chained_comparison(&mut self, lhs: &Expr, outer_op: &AssocOp) {
         debug_assert!(outer_op.is_comparison());
         match lhs.node {
-            ExprBinary(op, _, _) if ast_util::is_comparison_binop(op.node) => {
+            ExprBinary(op, _, _) if op.node.is_comparison() => {
                 // respan to include both operators
                 let op_span = mk_sp(op.span.lo, self.span.hi);
                 self.span_err(op_span,
@@ -4000,7 +4000,7 @@ impl<'a> Parser<'a> {
                 }
             })
         } else {
-            Ok(ast_util::empty_generics())
+            Ok(ast::Generics::default())
         }
     }
 

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -500,7 +500,7 @@ fn mk_main(cx: &mut TestCtxt) -> P<ast::Item> {
     let main = ast::ItemFn(ecx.fn_decl(vec![], main_ret_ty),
                            ast::Unsafety::Normal,
                            ast::Constness::NotConst,
-                           ::abi::Rust, empty_generics(), main_body);
+                           ::abi::Rust, ast::Generics::default(), main_body);
     let main = P(ast::Item {
         ident: token::str_to_ident("main"),
         attrs: vec![main_attr],


### PR DESCRIPTION
Issue: #30058
Updated for:
- Stmt
- BinOp_
- UnOp
- UintTy, IntTy and FloatTy
- Lit
- Generics

A possible inconsistancy?
The `Stmt` methods are on the spanned varient:

``` rust
pub type Stmt = Spanned<Stmt_>;

impl Stmt {
    pub fn id(s: &Stmt) -> Option<NodeId> {
        match s.node {
          StmtDecl(_, id) => Some(id),
          StmtExpr(_, id) => Some(id),
          StmtSemi(_, id) => Some(id),
          StmtMac(..) => None,
      }
  }
}
```

Whilst the methods for BinOp are on the non spanned version.

``` rust
impl BinOp_ {
    pub fn to_string(op: BinOp_) -> &'static str { ... }
    pub fn lazy(b: BinOp_) -> bool { ... }

    pub fn is_shift(b: BinOp_) -> bool { ... }
    pub fn is_comparison(b: BinOp_) -> bool { ... }
    /// Returns `true` if the binary operator takes its arguments by value
    pub fn is_by_value(b: BinOp_) -> bool { ... }

}
pub type BinOp = Spanned<BinOp_>;
```

r? @Manishearth
