### PR TITLE
std: Bump time margin in std::time tests

### DIFF
--- a/src/libstd/time/mod.rs
+++ b/src/libstd/time/mod.rs
@@ -235,7 +235,7 @@ mod tests {
             let (a, b) = ($a, $b);
             if a != b {
                 let (a, b) = if a > b {(a, b)} else {(b, a)};
-                assert!(a - Duration::new(0, 1) <= b);
+                assert!(a - Duration::new(0, 100) <= b);
             }
         })
     }


### PR DESCRIPTION
I believe that because Windows' unit of resolution is 100ns that this unit of
time will ensure that the assertions will hold true as it's representable in the
native format.

cc #29970
