### PR TITLE
Re-enable testing the book

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -163,8 +163,8 @@ endef
 
 $(foreach doc,$(DOCS), \
   $(eval $(call DOCTEST,md-$(doc),$(S)src/doc/$(doc).md)))
-$(foreach file,$(wildcard $(S)src/doc/trpl/*.md), \
-  $(eval $(call DOCTEST,$(file:$(S)src/doc/trpl/%.md=trpl-%),$(file))))
+$(foreach file,$(wildcard $(S)src/doc/book/*.md), \
+  $(eval $(call DOCTEST,$(file:$(S)src/doc/book/%.md=book-%),$(file))))
 $(foreach file,$(wildcard $(S)src/doc/nomicon/*.md), \
   $(eval $(call DOCTEST,$(file:$(S)src/doc/nomicon/%.md=nomicon-%),$(file))))
 ######################################################################


### PR DESCRIPTION
In #29932, I moved the location of TRPL, but I missed making the changes
in mk/tests.mk. This led to #30088 landing with a broken example.

As such, #30113 will need to land before this.
