### PR TITLE
Fix path to TRPL in doc README

### DIFF
--- a/src/doc/README.md
+++ b/src/doc/README.md
@@ -29,4 +29,4 @@ rustdoc reference.md
 An overview of how to use the `rustdoc` command is available [in the docs][1].
 Further details are available from the command line by with `rustdoc --help`.
 
-[1]: https://github.com/rust-lang/rust/blob/master/src/doc/trpl/documentation.md
+[1]: https://github.com/rust-lang/rust/blob/master/src/doc/book/documentation.md


### PR DESCRIPTION
Along with https://github.com/rust-lang/rust/pull/30121, this should fix the last fallout from https://github.com/rust-lang/rust/pull/29932
