### PR TITLE
Do MTWT resolution during lowering to HIR

### DIFF
--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -247,7 +247,7 @@ fn check_for_bindings_named_the_same_as_variants(cx: &MatchCheckCtxt, pat: &Pat)
                     let def = cx.tcx.def_map.borrow().get(&p.id).map(|d| d.full_def());
                     if let Some(DefLocal(..)) = def {
                         if edef.variants.iter().any(|variant|
-                            variant.name == ident.node.name
+                            variant.name == ident.node.unhygienic_name
                                 && variant.kind() == VariantKind::Unit
                         ) {
                             span_warn!(cx.tcx.sess, p.span, E0170,

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1596,7 +1596,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
                     self.ir.tcx.sess.add_lint(lint::builtin::UNUSED_VARIABLES, id, sp,
                         format!("variable `{}` is assigned to, but never used",
                                 name));
-                } else {
+                } else if name != "self" {
                     self.ir.tcx.sess.add_lint(lint::builtin::UNUSED_VARIABLES, id, sp,
                         format!("unused variable: `{}`", name));
                 }

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -426,7 +426,7 @@ fn extract_labels<'v, 'a>(ctxt: &mut LifetimeContext<'a>, b: &'v hir::Block) {
     fn expression_label(ex: &hir::Expr) -> Option<ast::Name> {
         match ex.node {
             hir::ExprWhile(_, _, Some(label)) |
-            hir::ExprLoop(_, Some(label)) => Some(label.name),
+            hir::ExprLoop(_, Some(label)) => Some(label.unhygienic_name),
             _ => None,
         }
     }

--- a/src/librustc_front/fold.rs
+++ b/src/librustc_front/fold.rs
@@ -12,7 +12,7 @@
 //! and returns a piece of the same type.
 
 use hir::*;
-use syntax::ast::{Ident, Name, NodeId, DUMMY_NODE_ID, Attribute, Attribute_, MetaItem};
+use syntax::ast::{Name, NodeId, DUMMY_NODE_ID, Attribute, Attribute_, MetaItem};
 use syntax::ast::{MetaWord, MetaList, MetaNameValue};
 use syntax::attr::ThinAttributesExt;
 use hir;

--- a/src/librustc_front/intravisit.rs
+++ b/src/librustc_front/intravisit.rs
@@ -26,7 +26,7 @@
 //! property.
 
 use syntax::abi::Abi;
-use syntax::ast::{Ident, NodeId, CRATE_NODE_ID, Name, Attribute};
+use syntax::ast::{NodeId, CRATE_NODE_ID, Name, Attribute};
 use syntax::codemap::Span;
 use hir::*;
 

--- a/src/librustc_front/lowering.rs
+++ b/src/librustc_front/lowering.rs
@@ -67,10 +67,11 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use syntax::ast::*;
 use syntax::attr::{ThinAttributes, ThinAttributesExt};
+use syntax::ext::mtwt;
 use syntax::ptr::P;
 use syntax::codemap::{respan, Spanned, Span};
 use syntax::owned_slice::OwnedSlice;
-use syntax::parse::token::{self, str_to_ident};
+use syntax::parse::token;
 use syntax::std_inject;
 use syntax::visit::{self, Visitor};
 
@@ -86,7 +87,7 @@ pub struct LoweringContext<'a> {
     // incrementing.
     cached_id: Cell<u32>,
     // Keep track of gensym'ed idents.
-    gensym_cache: RefCell<HashMap<(NodeId, &'static str), Ident>>,
+    gensym_cache: RefCell<HashMap<(NodeId, &'static str), hir::Ident>>,
     // A copy of cached_id, but is also set to an id while it is being cached.
     gensym_key: Cell<u32>,
 }
@@ -123,20 +124,27 @@ impl<'a, 'hir> LoweringContext<'a> {
         cached
     }
 
-    fn str_to_ident(&self, s: &'static str) -> Ident {
+    fn str_to_ident(&self, s: &'static str) -> hir::Ident {
         let cached_id = self.gensym_key.get();
         if cached_id == 0 {
-            return token::gensym_ident(s);
+            return hir::Ident::from_name(token::gensym(s));
         }
 
         let cached = self.gensym_cache.borrow().contains_key(&(cached_id, s));
         if cached {
             self.gensym_cache.borrow()[&(cached_id, s)]
         } else {
-            let result = token::gensym_ident(s);
+            let result = hir::Ident::from_name(token::gensym(s));
             self.gensym_cache.borrow_mut().insert((cached_id, s), result);
             result
         }
+    }
+}
+
+pub fn lower_ident(_lctx: &LoweringContext, ident: Ident) -> hir::Ident {
+    hir::Ident {
+        name: mtwt::resolve(ident),
+        unhygienic_name: ident.name,
     }
 }
 
@@ -276,20 +284,32 @@ pub fn lower_variant(lctx: &LoweringContext, v: &Variant) -> P<hir::Variant> {
     })
 }
 
-pub fn lower_path(lctx: &LoweringContext, p: &Path) -> hir::Path {
+// Path segments are usually unhygienic, hygienic path segments can occur only in
+// identifier-like paths originating from `ExprPath`.
+// Make life simpler for rustc_resolve by renaming only such segments.
+pub fn lower_path_full(lctx: &LoweringContext, p: &Path, maybe_hygienic: bool) -> hir::Path {
+    let maybe_hygienic = maybe_hygienic && !p.global && p.segments.len() == 1;
     hir::Path {
         global: p.global,
         segments: p.segments
                    .iter()
                    .map(|&PathSegment { identifier, ref parameters }| {
                        hir::PathSegment {
-                           identifier: identifier,
+                           identifier: if maybe_hygienic {
+                               lower_ident(lctx, identifier)
+                           } else {
+                               hir::Ident::from_name(identifier.name)
+                           },
                            parameters: lower_path_parameters(lctx, parameters),
                        }
                    })
                    .collect(),
         span: p.span,
     }
+}
+
+pub fn lower_path(lctx: &LoweringContext, p: &Path) -> hir::Path {
+    lower_path_full(lctx, p, false)
 }
 
 pub fn lower_path_parameters(lctx: &LoweringContext,
@@ -844,7 +864,7 @@ pub fn lower_pat(lctx: &LoweringContext, p: &Pat) -> P<hir::Pat> {
             PatWild => hir::PatWild,
             PatIdent(ref binding_mode, pth1, ref sub) => {
                 hir::PatIdent(lower_binding_mode(lctx, binding_mode),
-                              pth1,
+                              respan(pth1.span, lower_ident(lctx, pth1.node)),
                               sub.as_ref().map(|x| lower_pat(lctx, x)))
             }
             PatLit(ref e) => hir::PatLit(lower_expr(lctx, e)),
@@ -1138,10 +1158,12 @@ pub fn lower_expr(lctx: &LoweringContext, e: &Expr) -> P<hir::Expr> {
                 hir::ExprIf(lower_expr(lctx, cond), lower_block(lctx, blk), else_opt)
             }
             ExprWhile(ref cond, ref body, opt_ident) => {
-                hir::ExprWhile(lower_expr(lctx, cond), lower_block(lctx, body), opt_ident)
+                hir::ExprWhile(lower_expr(lctx, cond), lower_block(lctx, body),
+                               opt_ident.map(|ident| lower_ident(lctx, ident)))
             }
             ExprLoop(ref body, opt_ident) => {
-                hir::ExprLoop(lower_block(lctx, body), opt_ident)
+                hir::ExprLoop(lower_block(lctx, body),
+                              opt_ident.map(|ident| lower_ident(lctx, ident)))
             }
             ExprMatch(ref expr, ref arms) => {
                 hir::ExprMatch(lower_expr(lctx, expr),
@@ -1176,16 +1198,20 @@ pub fn lower_expr(lctx: &LoweringContext, e: &Expr) -> P<hir::Expr> {
                                e2.as_ref().map(|x| lower_expr(lctx, x)))
             }
             ExprPath(ref qself, ref path) => {
-                let qself = qself.as_ref().map(|&QSelf { ref ty, position }| {
+                let hir_qself = qself.as_ref().map(|&QSelf { ref ty, position }| {
                     hir::QSelf {
                         ty: lower_ty(lctx, ty),
                         position: position,
                     }
                 });
-                hir::ExprPath(qself, lower_path(lctx, path))
+                hir::ExprPath(hir_qself, lower_path_full(lctx, path, qself.is_none()))
             }
-            ExprBreak(opt_ident) => hir::ExprBreak(opt_ident),
-            ExprAgain(opt_ident) => hir::ExprAgain(opt_ident),
+            ExprBreak(opt_ident) => hir::ExprBreak(opt_ident.map(|sp_ident| {
+                respan(sp_ident.span, lower_ident(lctx, sp_ident.node))
+            })),
+            ExprAgain(opt_ident) => hir::ExprAgain(opt_ident.map(|sp_ident| {
+                respan(sp_ident.span, lower_ident(lctx, sp_ident.node))
+            })),
             ExprRet(ref e) => hir::ExprRet(e.as_ref().map(|x| lower_expr(lctx, x))),
             ExprInlineAsm(InlineAsm {
                     ref inputs,
@@ -1356,8 +1382,10 @@ pub fn lower_expr(lctx: &LoweringContext, e: &Expr) -> P<hir::Expr> {
 
                     // `[opt_ident]: loop { ... }`
                     let loop_block = block_expr(lctx, match_expr);
+                    let loop_expr = hir::ExprLoop(loop_block,
+                                                  opt_ident.map(|ident| lower_ident(lctx, ident)));
                     // add attributes to the outer returned expr node
-                    expr(lctx, e.span, hir::ExprLoop(loop_block, opt_ident), e.attrs.clone())
+                    expr(lctx, e.span, loop_expr, e.attrs.clone())
                 });
             }
 
@@ -1434,10 +1462,9 @@ pub fn lower_expr(lctx: &LoweringContext, e: &Expr) -> P<hir::Expr> {
 
                     // `[opt_ident]: loop { ... }`
                     let loop_block = block_expr(lctx, match_expr);
-                    let loop_expr = expr(lctx,
-                                         e.span,
-                                         hir::ExprLoop(loop_block, opt_ident),
-                                         None);
+                    let loop_expr = hir::ExprLoop(loop_block,
+                                                  opt_ident.map(|ident| lower_ident(lctx, ident)));
+                    let loop_expr = expr(lctx, e.span, loop_expr, None);
 
                     // `mut iter => { ... }`
                     let iter_arm = {
@@ -1593,7 +1620,7 @@ fn expr_call(lctx: &LoweringContext,
     expr(lctx, span, hir::ExprCall(e, args), attrs)
 }
 
-fn expr_ident(lctx: &LoweringContext, span: Span, id: Ident,
+fn expr_ident(lctx: &LoweringContext, span: Span, id: hir::Ident,
               attrs: ThinAttributes) -> P<hir::Expr> {
     expr_path(lctx, path_ident(span, id), attrs)
 }
@@ -1641,7 +1668,7 @@ fn expr(lctx: &LoweringContext, span: Span, node: hir::Expr_,
 fn stmt_let(lctx: &LoweringContext,
             sp: Span,
             mutbl: bool,
-            ident: Ident,
+            ident: hir::Ident,
             ex: P<hir::Expr>,
             attrs: ThinAttributes)
             -> P<hir::Stmt> {
@@ -1701,13 +1728,13 @@ fn pat_enum(lctx: &LoweringContext,
     pat(lctx, span, pt)
 }
 
-fn pat_ident(lctx: &LoweringContext, span: Span, ident: Ident) -> P<hir::Pat> {
+fn pat_ident(lctx: &LoweringContext, span: Span, ident: hir::Ident) -> P<hir::Pat> {
     pat_ident_binding_mode(lctx, span, ident, hir::BindByValue(hir::MutImmutable))
 }
 
 fn pat_ident_binding_mode(lctx: &LoweringContext,
                           span: Span,
-                          ident: Ident,
+                          ident: hir::Ident,
                           bm: hir::BindingMode)
                           -> P<hir::Pat> {
     let pat_ident = hir::PatIdent(bm,
@@ -1731,21 +1758,21 @@ fn pat(lctx: &LoweringContext, span: Span, pat: hir::Pat_) -> P<hir::Pat> {
     })
 }
 
-fn path_ident(span: Span, id: Ident) -> hir::Path {
+fn path_ident(span: Span, id: hir::Ident) -> hir::Path {
     path(span, vec![id])
 }
 
-fn path(span: Span, strs: Vec<Ident>) -> hir::Path {
+fn path(span: Span, strs: Vec<hir::Ident>) -> hir::Path {
     path_all(span, false, strs, Vec::new(), Vec::new(), Vec::new())
 }
 
-fn path_global(span: Span, strs: Vec<Ident>) -> hir::Path {
+fn path_global(span: Span, strs: Vec<hir::Ident>) -> hir::Path {
     path_all(span, true, strs, Vec::new(), Vec::new(), Vec::new())
 }
 
 fn path_all(sp: Span,
             global: bool,
-            mut idents: Vec<Ident>,
+            mut idents: Vec<hir::Ident>,
             lifetimes: Vec<hir::Lifetime>,
             types: Vec<P<hir::Ty>>,
             bindings: Vec<P<hir::TypeBinding>>)
@@ -1774,12 +1801,12 @@ fn path_all(sp: Span,
     }
 }
 
-fn std_path(lctx: &LoweringContext, components: &[&str]) -> Vec<Ident> {
+fn std_path(lctx: &LoweringContext, components: &[&str]) -> Vec<hir::Ident> {
     let mut v = Vec::new();
     if let Some(s) = lctx.crate_root {
-        v.push(str_to_ident(s));
+        v.push(hir::Ident::from_name(token::intern(s)));
     }
-    v.extend(components.iter().map(|s| str_to_ident(s)));
+    v.extend(components.iter().map(|s| hir::Ident::from_name(token::intern(s))));
     return v;
 }
 

--- a/src/librustc_front/util.rs
+++ b/src/librustc_front/util.rs
@@ -12,7 +12,7 @@ use hir;
 use hir::*;
 use intravisit::{self, Visitor, FnKind};
 use syntax::ast_util;
-use syntax::ast::{Ident, Name, NodeId, DUMMY_NODE_ID};
+use syntax::ast::{Name, NodeId, DUMMY_NODE_ID};
 use syntax::codemap::Span;
 use syntax::ptr::P;
 use syntax::owned_slice::OwnedSlice;

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -170,9 +170,7 @@ impl LateLintPass for NonShorthandFieldPatterns {
             });
             for fieldpat in field_pats {
                 if let hir::PatIdent(_, ident, None) = fieldpat.node.pat.node {
-                    if ident.node.name == fieldpat.node.name {
-                        // FIXME: should this comparison really be done on the name?
-                        // doing it on the ident will fail during compilation of libcore
+                    if ident.node.unhygienic_name == fieldpat.node.name {
                         cx.span_lint(NON_SHORTHAND_FIELD_PATTERNS, fieldpat.span,
                                      &format!("the `{}:` in this pattern is redundant and can \
                                               be removed", ident.node))

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -21,7 +21,6 @@ use rustc::middle::ty::{self, VariantDef, Ty};
 use rustc::mir::repr::*;
 use rustc_front::hir;
 use rustc_front::util as hir_util;
-use syntax::ext::mtwt;
 use syntax::parse::token;
 use syntax::ptr::P;
 
@@ -500,8 +499,8 @@ fn convert_arm<'a, 'tcx: 'a>(cx: &mut Cx<'a, 'tcx>, arm: &'tcx hir::Arm) -> Arm<
         None
     } else {
         map = FnvHashMap();
-        pat_util::pat_bindings_hygienic(&cx.tcx.def_map, &arm.pats[0], |_, p_id, _, path| {
-            map.insert(mtwt::resolve(path.node), p_id);
+        pat_util::pat_bindings(&cx.tcx.def_map, &arm.pats[0], |_, p_id, _, path| {
+            map.insert(path.node, p_id);
         });
         Some(&map)
     };

--- a/src/librustc_mir/hair/cx/pattern.rs
+++ b/src/librustc_mir/hair/cx/pattern.rs
@@ -19,7 +19,6 @@ use rustc::middle::ty::{self, Ty};
 use rustc::mir::repr::*;
 use rustc_front::hir;
 use syntax::ast;
-use syntax::ext::mtwt;
 use syntax::ptr::P;
 
 /// When there are multiple patterns in a single arm, each one has its
@@ -162,7 +161,7 @@ impl<'patcx, 'cx, 'tcx> PatCx<'patcx, 'cx, 'tcx> {
             {
                 let id = match self.binding_map {
                     None => pat.id,
-                    Some(ref map) => map[&mtwt::resolve(ident.node)],
+                    Some(ref map) => map[&ident.node.name],
                 };
                 let var_ty = self.cx.tcx.node_id_to_type(pat.id);
                 let region = match var_ty.sty {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -57,7 +57,7 @@ use rustc::lint;
 use rustc::middle::cstore::{CrateStore, DefLike, DlDef};
 use rustc::middle::def::*;
 use rustc::middle::def_id::DefId;
-use rustc::middle::pat_util::pat_bindings_hygienic;
+use rustc::middle::pat_util::pat_bindings;
 use rustc::middle::privacy::*;
 use rustc::middle::subst::{ParamSpace, FnSpace, TypeSpace};
 use rustc::middle::ty::{Freevar, FreevarMap, TraitMap, GlobMap};
@@ -67,7 +67,6 @@ use syntax::ast;
 use syntax::ast::{CRATE_NODE_ID, Ident, Name, NodeId, CrateNum, TyIs, TyI8, TyI16, TyI32, TyI64};
 use syntax::ast::{TyUs, TyU8, TyU16, TyU32, TyU64, TyF64, TyF32};
 use syntax::attr::AttrMetaMethods;
-use syntax::ext::mtwt;
 use syntax::parse::token::{self, special_names, special_idents};
 use syntax::ptr::P;
 use syntax::codemap::{self, Span, Pos};
@@ -2315,8 +2314,8 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
     // user and one 'x' came from the macro.
     fn binding_mode_map(&mut self, pat: &Pat) -> BindingMap {
         let mut result = HashMap::new();
-        pat_bindings_hygienic(&self.def_map, pat, |binding_mode, _id, sp, path1| {
-            let name = mtwt::resolve(path1.node);
+        pat_bindings(&self.def_map, pat, |binding_mode, _id, sp, path1| {
+            let name = path1.node;
             result.insert(name,
                           BindingInfo {
                               span: sp,
@@ -2520,9 +2519,10 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                     let const_ok = mode == RefutableMode && at_rhs.is_none();
 
                     let ident = path1.node;
-                    let renamed = mtwt::resolve(ident);
+                    let renamed = ident.name;
 
-                    match self.resolve_bare_identifier_pattern(ident.name, pattern.span) {
+                    match self.resolve_bare_identifier_pattern(ident.unhygienic_name,
+                                                               pattern.span) {
                         FoundStructOrEnumVariant(def, lp) if const_ok => {
                             debug!("(resolving pattern) resolving `{}` to struct or enum variant",
                                    renamed);
@@ -2911,7 +2911,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
     // Resolve a single identifier
     fn resolve_identifier(&mut self,
-                          identifier: Ident,
+                          identifier: hir::Ident,
                           namespace: Namespace,
                           check_ribs: bool)
                           -> Option<LocalDef> {
@@ -2919,7 +2919,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         if namespace == TypeNS {
             if let Some(&prim_ty) = self.primitive_type_table
                                         .primitive_types
-                                        .get(&identifier.name) {
+                                        .get(&identifier.unhygienic_name) {
                 return Some(LocalDef::from_def(DefPrimTy(prim_ty)));
             }
         }
@@ -2930,7 +2930,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             }
         }
 
-        self.resolve_item_by_name_in_lexical_scope(identifier.name, namespace)
+        self.resolve_item_by_name_in_lexical_scope(identifier.unhygienic_name, namespace)
             .map(LocalDef::from_def)
     }
 
@@ -3144,13 +3144,13 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
     }
 
     fn resolve_identifier_in_local_ribs(&mut self,
-                                        ident: Ident,
+                                        ident: hir::Ident,
                                         namespace: Namespace)
                                         -> Option<LocalDef> {
         // Check the local set of ribs.
         let (name, ribs) = match namespace {
-            ValueNS => (mtwt::resolve(ident), &self.value_ribs),
-            TypeNS => (ident.name, &self.type_ribs),
+            ValueNS => (ident.name, &self.value_ribs),
+            TypeNS => (ident.unhygienic_name, &self.type_ribs),
         };
 
         for (i, rib) in ribs.iter().enumerate().rev() {
@@ -3551,8 +3551,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
                     {
                         let rib = this.label_ribs.last_mut().unwrap();
-                        let renamed = mtwt::resolve(label);
-                        rib.bindings.insert(renamed, def_like);
+                        rib.bindings.insert(label.name, def_like);
                     }
 
                     intravisit::walk_expr(this, expr);
@@ -3560,8 +3559,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             }
 
             ExprBreak(Some(label)) | ExprAgain(Some(label)) => {
-                let renamed = mtwt::resolve(label.node);
-                match self.search_label(renamed) {
+                match self.search_label(label.node.name) {
                     None => {
                         resolve_error(self,
                                       label.span,

--- a/src/librustc_trans/trans/debuginfo/create_scope_map.rs
+++ b/src/librustc_trans/trans/debuginfo/create_scope_map.rs
@@ -47,9 +47,9 @@ pub fn create_scope_map(cx: &CrateContext,
     // Push argument identifiers onto the stack so arguments integrate nicely
     // with variable shadowing.
     for arg in args {
-        pat_util::pat_bindings(def_map, &*arg.pat, |_, node_id, _, path1| {
+        pat_util::pat_bindings_ident(def_map, &*arg.pat, |_, node_id, _, path1| {
             scope_stack.push(ScopeStackEntry { scope_metadata: fn_metadata,
-                                               name: Some(path1.node) });
+                                               name: Some(path1.node.unhygienic_name) });
             scope_map.insert(node_id, fn_metadata);
         })
     }
@@ -169,7 +169,7 @@ fn walk_pattern(cx: &CrateContext,
             // scope stack and maybe introduce an artificial scope
             if pat_util::pat_is_binding(&def_map.borrow(), &*pat) {
 
-                let name = path1.node.name;
+                let name = path1.node.unhygienic_name;
 
                 // LLVM does not properly generate 'DW_AT_start_scope' fields
                 // for variable DIEs. For this reason we have to introduce

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -26,7 +26,6 @@ use session::Session;
 use std::cmp;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use syntax::ast;
-use syntax::ext::mtwt;
 use syntax::codemap::{Span, Spanned};
 use syntax::ptr::P;
 
@@ -187,7 +186,7 @@ pub fn check_pat<'a, 'tcx>(pcx: &pat_ctxt<'a, 'tcx>,
 
             // if there are multiple arms, make sure they all agree on
             // what the type of the binding `x` ought to be
-            let canon_id = *pcx.map.get(&mtwt::resolve(path.node)).unwrap();
+            let canon_id = *pcx.map.get(&path.node.name).unwrap();
             if canon_id != pat.id {
                 let ct = fcx.local_ty(pat.span, canon_id);
                 demand::eqtype(fcx, pat.span, ct, typ);


### PR DESCRIPTION
Instead of `ast::Ident`, bindings, paths and labels in HIR now keep a new structure called `hir::Ident` containing mtwt-renamed `name` and the original not-renamed `unhygienic_name`. `name` is supposed to be used by default, `unhygienic_name` is rarely used.

This is not ideal, but better than the status quo for two reasons:
- MTWT tables can be cleared immediately after lowering to HIR
- This is less bug-prone, because it is impossible now to forget applying `mtwt::resolve` to a name. It is still possible to use `name` instead of `unhygienic_name` by mistake, but `unhygienic_name`s are used only in few very special circumstances, so it shouldn't be a problem.

Besides name resolution `unhygienic_name` is used in some lints and debuginfo. `unhygienic_name` can be very well approximated by "reverse renaming" `token::intern(name.as_str())` or even plain string `name.as_str()`, except that it would break gensyms like `iter` in desugared `for` loops. This approximation is likely good enough for lints and debuginfo, but not for name resolution, unfortunately (see https://github.com/rust-lang/rust/issues/27639), so `unhygienic_name` has to be kept.

cc https://github.com/rust-lang/rust/issues/29782

r? @nrc 
