### PR TITLE
Rustdoc: Use the extern item-path for documentation links

### DIFF
--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -34,6 +34,8 @@ pub struct TestProps {
     pub exec_env: Vec<(String,String)> ,
     // Lines to check if they appear in the expected debugger output
     pub check_lines: Vec<String> ,
+    // Build documentation for all specified aux-builds as well
+    pub build_aux_docs: bool,
     // Flag to force a crate to be built with the host architecture
     pub force_host: bool,
     // Check stdout for error-pattern output as well as stderr
@@ -59,6 +61,7 @@ pub fn load_props(testfile: &Path) -> TestProps {
     let mut run_flags = None;
     let mut pp_exact = None;
     let mut check_lines = Vec::new();
+    let mut build_aux_docs = false;
     let mut force_host = false;
     let mut check_stdout = false;
     let mut no_prefer_dynamic = false;
@@ -81,6 +84,10 @@ pub fn load_props(testfile: &Path) -> TestProps {
 
         if pp_exact.is_none() {
             pp_exact = parse_pp_exact(ln, testfile);
+        }
+
+        if !build_aux_docs {
+            build_aux_docs = parse_build_aux_docs(ln);
         }
 
         if !force_host {
@@ -144,6 +151,7 @@ pub fn load_props(testfile: &Path) -> TestProps {
         aux_builds: aux_builds,
         exec_env: exec_env,
         check_lines: check_lines,
+        build_aux_docs: build_aux_docs,
         force_host: force_host,
         check_stdout: check_stdout,
         no_prefer_dynamic: no_prefer_dynamic,
@@ -282,6 +290,10 @@ fn parse_check_line(line: &str) -> Option<String> {
 
 fn parse_force_host(line: &str) -> bool {
     parse_name_directive(line, "force-host")
+}
+
+fn parse_build_aux_docs(line: &str) -> bool {
+    parse_name_directive(line, "build-aux-docs")
 }
 
 fn parse_check_stdout(line: &str) -> bool {

--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -142,6 +142,7 @@ pub trait CrateStore<'tcx> : Any {
     fn item_type(&self, tcx: &ty::ctxt<'tcx>, def: DefId)
                  -> ty::TypeScheme<'tcx>;
     fn item_path(&self, def: DefId) -> Vec<hir_map::PathElem>;
+    fn extern_item_path(&self, def: DefId) -> Vec<hir_map::PathElem>;
     fn item_name(&self, def: DefId) -> ast::Name;
     fn item_predicates(&self, tcx: &ty::ctxt<'tcx>, def: DefId)
                        -> ty::GenericPredicates<'tcx>;
@@ -295,6 +296,7 @@ impl<'tcx> CrateStore<'tcx> for DummyCrateStore {
     fn item_type(&self, tcx: &ty::ctxt<'tcx>, def: DefId)
                  -> ty::TypeScheme<'tcx> { unimplemented!() }
     fn item_path(&self, def: DefId) -> Vec<hir_map::PathElem> { unimplemented!() }
+    fn extern_item_path(&self, def: DefId) -> Vec<hir_map::PathElem> { unimplemented!() }
     fn item_name(&self, def: DefId) -> ast::Name { unimplemented!() }
     fn item_predicates(&self, tcx: &ty::ctxt<'tcx>, def: DefId)
                        -> ty::GenericPredicates<'tcx> { unimplemented!() }

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -138,7 +138,7 @@ pub fn load_attrs(cx: &DocContext, tcx: &ty::ctxt,
 pub fn record_extern_fqn(cx: &DocContext, did: DefId, kind: clean::TypeKind) {
     match cx.tcx_opt() {
         Some(tcx) => {
-            let fqn = tcx.sess.cstore.item_path(did);
+            let fqn = tcx.sess.cstore.extern_item_path(did);
             let fqn = fqn.into_iter().map(|i| i.to_string()).collect();
             cx.external_paths.borrow_mut().as_mut().unwrap().insert(did, (fqn, kind));
         }

--- a/src/test/auxiliary/issue-30109-1.rs
+++ b/src/test/auxiliary/issue-30109-1.rs
@@ -1,0 +1,11 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub struct Bar;

--- a/src/test/rustdoc/issue-30109.rs
+++ b/src/test/rustdoc/issue-30109.rs
@@ -1,0 +1,24 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// build-aux-docs
+// aux-build:issue-30109-1.rs
+// ignore-cross-compile
+
+pub mod quux {
+    extern crate issue_30109_1 as bar;
+    use self::bar::Bar;
+
+    pub trait Foo {}
+
+    // @has issue_30109/quux/trait.Foo.html \
+    //          '//a/@href' '../issue_30109_1/struct.Bar.html'
+    impl Foo for Bar {}
+}


### PR DESCRIPTION
Fixes #30109 
