### PR TITLE
Fix race condition in fs::create_dir_all

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1312,11 +1312,20 @@ impl DirBuilder {
     }
 
     fn create_dir_all(&self, path: &Path) -> io::Result<()> {
+        use io::{ErrorKind};
         if path == Path::new("") || path.is_dir() { return Ok(()) }
         if let Some(p) = path.parent() {
             try!(self.create_dir_all(p))
         }
-        self.inner.mkdir(path)
+        match self.inner.mkdir(path) {
+            Err(ref e) if e.kind() == ErrorKind::AlreadyExists
+                && path.is_dir() => {
+                    // It looks like the directory was created after
+                    // we checked, so this is not an error after all.
+                    Ok(())
+                },
+            r => r,
+        }
     }
 }
 


### PR DESCRIPTION
The code would crash if the directory was created after create_dir_all
checked whether the directory already existed.  This was contrary to
the documentation which claimed to create the directory if it doesn't
exist, implying (but not stating) that there would not be a failure
due to the directory existing.
