### PR TITLE
book: Change mention of unused `return` to `panic!`

### DIFF
--- a/src/doc/book/guessing-game.md
+++ b/src/doc/book/guessing-game.md
@@ -775,7 +775,7 @@ fn main() {
 ```
 
 And try it out. But wait, didn’t we just add an infinite loop? Yup. Remember
-our discussion about `parse()`? If we give a non-number answer, we’ll `return`
+our discussion about `parse()`? If we give a non-number answer, we’ll `panic!`
 and quit. Observe:
 
 ```bash


### PR DESCRIPTION
The text mentions `return`, but what's actually happening is a `panic!`.
