### PR TITLE
mk: Remove obsolete comment

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -276,7 +276,6 @@ endif
 # LLVM macros
 ######################################################################
 
-# FIXME: x86-ism
 LLVM_COMPONENTS=x86 arm aarch64 mips powerpc ipo bitreader bitwriter linker asmparser mcjit \
                 interpreter instrumentation
 


### PR DESCRIPTION
This dates from the stone-ages. We always configure LLVM with all
supported targets.
