### PR TITLE
Disable the null check elimination pass

### DIFF
--- a/src/rustllvm/llvm-auto-clean-trigger
+++ b/src/rustllvm/llvm-auto-clean-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be forcibly cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2015-10-18
+2015-12-02

--- a/src/test/run-pass/issue-30081.rs
+++ b/src/test/run-pass/issue-30081.rs
@@ -1,0 +1,24 @@
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This used to segfault #30081
+
+pub enum Instruction {
+    Increment(i8),
+    Loop(Box<Box<()>>),
+}
+
+fn main() {
+    let instrs: Option<(u8, Box<Instruction>)> = None;
+    instrs.into_iter()
+        .map(|(_, instr)| instr)
+        .map(|instr| match *instr { _other => {} })
+        .last();
+}


### PR DESCRIPTION
This pass causes mis-optimizations in some cases and is probably no
longer really important for us, so let's disable it for now.

Fixes #30081
