### PR TITLE
Ensure two `SystemTime`s are equal when nanos add to exactly 1B

### DIFF
--- a/src/libstd/sys/unix/time.rs
+++ b/src/libstd/sys/unix/time.rs
@@ -111,7 +111,7 @@ mod inner {
             // Nano calculations can't overflow because nanos are <1B which fit
             // in a u32.
             let mut usec = (other.subsec_nanos() / 1000) + self.t.tv_usec as u32;
-            if usec > USEC_PER_SEC as u32 {
+            if usec >= USEC_PER_SEC as u32 {
                 usec -= USEC_PER_SEC as u32;
                 secs = secs.checked_add(1).expect("overflow when adding \
                                                    duration to time");

--- a/src/libstd/sys/unix/time.rs
+++ b/src/libstd/sys/unix/time.rs
@@ -330,7 +330,7 @@ mod inner {
             // Nano calculations can't overflow because nanos are <1B which fit
             // in a u32.
             let mut nsec = other.subsec_nanos() + self.t.tv_nsec as u32;
-            if nsec > NSEC_PER_SEC as u32 {
+            if nsec >= NSEC_PER_SEC as u32 {
                 nsec -= NSEC_PER_SEC as u32;
                 secs = secs.checked_add(1).expect("overflow when adding \
                                                    duration to time");

--- a/src/libstd/time/mod.rs
+++ b/src/libstd/time/mod.rs
@@ -305,8 +305,8 @@ mod tests {
         assert_almost_eq!(a - (eighty_years * 10) + (eighty_years * 10), a);
 
         let one_second_from_epoch = UNIX_EPOCH + Duration::new(1, 0);
-        let one_second_from_epoch2 = UNIX_EPOCH + Duration::new(0, 999_999_999)
-            + Duration::new(0, 1);
+        let one_second_from_epoch2 = UNIX_EPOCH + Duration::new(0, 500_000_000)
+            + Duration::new(0, 500_000_000);
         assert_eq!(one_second_from_epoch, one_second_from_epoch2);
     }
 

--- a/src/libstd/time/mod.rs
+++ b/src/libstd/time/mod.rs
@@ -305,7 +305,8 @@ mod tests {
         assert_almost_eq!(a - (eighty_years * 10) + (eighty_years * 10), a);
 
         let one_second_from_epoch = UNIX_EPOCH + Duration::new(1, 0);
-        let one_second_from_epoch2 = UNIX_EPOCH + Duration::new(0, 999_999_999) + Duration::new(0, 1);
+        let one_second_from_epoch2 = UNIX_EPOCH + Duration::new(0, 999_999_999)
+            + Duration::new(0, 1);
         assert_eq!(one_second_from_epoch, one_second_from_epoch2);
     }
 

--- a/src/libstd/time/mod.rs
+++ b/src/libstd/time/mod.rs
@@ -303,6 +303,10 @@ mod tests {
         let eighty_years = second * 60 * 60 * 24 * 365 * 80;
         assert_almost_eq!(a - eighty_years + eighty_years, a);
         assert_almost_eq!(a - (eighty_years * 10) + (eighty_years * 10), a);
+
+        let one_second_from_epoch = UNIX_EPOCH + Duration::new(1, 0);
+        let one_second_from_epoch2 = UNIX_EPOCH + Duration::new(0, 999_999_999) + Duration::new(0, 1);
+        assert_eq!(one_second_from_epoch, one_second_from_epoch2);
     }
 
     #[test]


### PR DESCRIPTION
Currently if you add a duration which should lead to 0 nanos and 1
additional second, we end up with no additional seconds, and 1000000000
nanos.
