### PR TITLE
AsRawHandle IntoRawHandle and JoinHandleExt for JoinHandle

### DIFF
--- a/src/libstd/os/android/raw.rs
+++ b/src/libstd/os/android/raw.rs
@@ -12,6 +12,10 @@
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
+use os::raw::c_long;
+
+#[unstable(feature = "pthread_t", issue = "29791")] pub type pthread_t = c_long;
+
 #[doc(inline)]
 #[stable(feature = "raw_ext", since = "1.1.0")]
 pub use self::arch::{dev_t, mode_t, blkcnt_t, blksize_t, ino_t, nlink_t, off_t, stat, time_t};

--- a/src/libstd/os/bitrig/raw.rs
+++ b/src/libstd/os/bitrig/raw.rs
@@ -25,6 +25,8 @@ use os::unix::raw::{uid_t, gid_t};
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
+#[unstable(feature = "pthread_t", issue = "29791")] pub type pthread_t = usize;
+
 #[repr(C)]
 #[derive(Clone)]
 #[stable(feature = "raw_ext", since = "1.1.0")]

--- a/src/libstd/os/dragonfly/raw.rs
+++ b/src/libstd/os/dragonfly/raw.rs
@@ -25,6 +25,8 @@ use os::unix::raw::{uid_t, gid_t};
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
+#[unstable(feature = "pthread_t", issue = "29791")] pub type pthread_t = usize;
+
 #[repr(C)]
 #[derive(Clone)]
 #[stable(feature = "raw_ext", since = "1.1.0")]

--- a/src/libstd/os/freebsd/raw.rs
+++ b/src/libstd/os/freebsd/raw.rs
@@ -21,6 +21,8 @@
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type fflags_t = u32;
 
+#[unstable(feature = "pthread_t", issue = "29791")] pub type pthread_t = usize;
+
 #[doc(inline)]
 #[stable(feature = "raw_ext", since = "1.1.0")]
 pub use self::arch::{stat, time_t};

--- a/src/libstd/os/ios/raw.rs
+++ b/src/libstd/os/ios/raw.rs
@@ -24,6 +24,8 @@ use os::unix::raw::{uid_t, gid_t};
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = c_long;
 
+#[unstable(feature = "pthread_t", issue = "29791")] pub type pthread_t = usize;
+
 #[repr(C)]
 #[derive(Clone)]
 #[stable(feature = "raw_ext", since = "1.1.0")]

--- a/src/libstd/os/linux/raw.rs
+++ b/src/libstd/os/linux/raw.rs
@@ -12,8 +12,12 @@
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
+use os::raw::c_ulong;
+
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
+
+#[unstable(feature = "pthread_t", issue = "29791")] pub type pthread_t = c_ulong;
 
 #[doc(inline)]
 #[stable(feature = "raw_ext", since = "1.1.0")]

--- a/src/libstd/os/macos/raw.rs
+++ b/src/libstd/os/macos/raw.rs
@@ -24,6 +24,8 @@ use os::unix::raw::{uid_t, gid_t};
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = c_long;
 
+#[unstable(feature = "pthread_t", issue = "29791")] pub type pthread_t = usize;
+
 #[repr(C)]
 #[derive(Clone)]
 #[stable(feature = "raw_ext", since = "1.1.0")]

--- a/src/libstd/os/nacl/raw.rs
+++ b/src/libstd/os/nacl/raw.rs
@@ -24,6 +24,8 @@
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i32;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i32;
 
+#[unstable(feature = "pthread_t", issue = "29791")] pub type pthread_t = usize;
+
 #[repr(C)]
 #[derive(Copy, Clone)]
 #[stable(feature = "raw_ext", since = "1.1.0")]

--- a/src/libstd/os/netbsd/raw.rs
+++ b/src/libstd/os/netbsd/raw.rs
@@ -25,6 +25,8 @@ use os::unix::raw::{uid_t, gid_t};
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
+#[unstable(feature = "pthread_t", issue = "29791")] pub type pthread_t = usize;
+
 #[repr(C)]
 #[derive(Clone)]
 #[stable(feature = "raw_ext", since = "1.1.0")]

--- a/src/libstd/os/openbsd/raw.rs
+++ b/src/libstd/os/openbsd/raw.rs
@@ -25,6 +25,8 @@ use os::unix::raw::{uid_t, gid_t};
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
+#[unstable(feature = "pthread_t", issue = "29791")] pub type pthread_t = usize;
+
 #[repr(C)]
 #[derive(Clone)]
 #[stable(feature = "raw_ext", since = "1.1.0")]

--- a/src/libstd/sys/unix/ext/mod.rs
+++ b/src/libstd/sys/unix/ext/mod.rs
@@ -34,6 +34,7 @@ pub mod ffi;
 pub mod fs;
 pub mod process;
 pub mod raw;
+pub mod thread;
 
 /// A prelude for conveniently writing platform-specific code.
 ///

--- a/src/libstd/sys/unix/ext/raw.rs
+++ b/src/libstd/sys/unix/ext/raw.rs
@@ -17,6 +17,9 @@
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type pid_t = i32;
 
 #[doc(inline)]
+#[unstable(feature = "pthread_t", issue = "29791")]
+pub use sys::platform::raw::pthread_t;
+#[doc(inline)]
 #[stable(feature = "raw_ext", since = "1.1.0")]
 pub use sys::platform::raw::{dev_t, ino_t, mode_t, nlink_t, off_t, blksize_t};
 #[doc(inline)]

--- a/src/libstd/sys/unix/ext/thread.rs
+++ b/src/libstd/sys/unix/ext/thread.rs
@@ -1,0 +1,43 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Unix-specific extensions to primitives in the `std::process` module.
+
+#![unstable(feature = "thread_extensions", issue = "29791")]
+
+use os::unix::raw::{pthread_t};
+use sys_common::{AsInner, IntoInner};
+use thread::{JoinHandle};
+
+#[unstable(feature = "thread_extensions", issue = "29791")]
+pub type RawPthread = pthread_t;
+
+/// Unix-specific extensions to `std::thread::JoinHandle`
+#[unstable(feature = "thread_extensions", issue = "29791")]
+pub trait JoinHandleExt {
+    /// Extracts the raw pthread_t without taking ownership
+    fn as_pthread_t(&self) -> RawPthread;
+    /// Consumes the thread, returning the raw pthread_t
+    ///
+    /// This function **transfers ownership** of the underlying pthread_t to
+    /// the caller. Callers are then the unique owners of the pthread_t and
+    /// must either detech or join the pthread_t once it's no longer needed.
+    fn into_pthread_t(self) -> RawPthread;
+}
+
+#[unstable(feature = "thread_extensions", issue = "29791")]
+impl<T> JoinHandleExt for JoinHandle<T> {
+    fn as_pthread_t(&self) -> RawPthread {
+        self.as_inner().id() as RawPthread
+    }
+    fn into_pthread_t(self) -> RawPthread {
+        self.into_inner().into_id() as RawPthread
+    }
+}

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -152,6 +152,14 @@ impl Thread {
             debug_assert_eq!(ret, 0);
         }
     }
+
+    pub fn id(&self) -> libc::pthread_t { self.id }
+
+    pub fn into_id(self) -> libc::pthread_t {
+        let id = self.id;
+        mem::forget(self);
+        id
+    }
 }
 
 impl Drop for Thread {

--- a/src/libstd/sys/windows/ext/mod.rs
+++ b/src/libstd/sys/windows/ext/mod.rs
@@ -21,6 +21,7 @@ pub mod fs;
 pub mod io;
 pub mod raw;
 pub mod process;
+pub mod thread;
 
 /// A prelude for conveniently writing platform-specific code.
 ///

--- a/src/libstd/sys/windows/ext/thread.rs
+++ b/src/libstd/sys/windows/ext/thread.rs
@@ -1,0 +1,29 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Extensions to `std::thread` for Windows.
+
+#![unstable(feature = "thread_extensions", issue = "29791")]
+
+use os::windows::io::{RawHandle, AsRawHandle, IntoRawHandle};
+use thread;
+use sys_common::{AsInner, IntoInner};
+
+impl<T> AsRawHandle for thread::JoinHandle<T> {
+    fn as_raw_handle(&self) -> RawHandle {
+        self.as_inner().handle().raw() as *mut _
+    }
+}
+
+impl<T> IntoRawHandle for thread::JoinHandle<T>  {
+    fn into_raw_handle(self) -> RawHandle {
+        self.into_inner().into_handle().into_raw() as *mut _
+    }
+}

--- a/src/libstd/sys/windows/thread.rs
+++ b/src/libstd/sys/windows/thread.rs
@@ -77,6 +77,10 @@ impl Thread {
             c::Sleep(super::dur2timeout(dur))
         }
     }
+
+    pub fn handle(&self) -> &Handle { &self.handle }
+
+    pub fn into_handle(self) -> Handle { self.handle }
 }
 
 pub mod guard {

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -171,6 +171,7 @@ use sys::thread as imp;
 use sys_common::thread_info;
 use sys_common::unwind;
 use sys_common::util;
+use sys_common::{AsInner, IntoInner};
 use time::Duration;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -619,6 +620,14 @@ impl<T> JoinHandle<T> {
     pub fn join(mut self) -> Result<T> {
         self.0.join()
     }
+}
+
+impl<T> AsInner<imp::Thread> for JoinHandle<T> {
+    fn as_inner(&self) -> &imp::Thread { self.0.native.as_ref().unwrap() }
+}
+
+impl<T> IntoInner<imp::Thread> for JoinHandle<T> {
+    fn into_inner(self) -> imp::Thread { self.0.native.unwrap() }
 }
 
 fn _assert_sync_and_send() {


### PR DESCRIPTION
Allows a `HANDLE` to be extracted from a `JoinHandle` on Windows.
Allows a `pthread_t` to be extracted from a `JoinHandle` everywhere else.

Because https://github.com/rust-lang/rust/pull/29461 was closed.

r? @alexcrichton 
