### PR TITLE
MIN_ALIGN is definitely 8 on 32-bit x86, at least on Windows.

### DIFF
--- a/src/liballoc_system/lib.rs
+++ b/src/liballoc_system/lib.rs
@@ -29,13 +29,13 @@ extern crate libc;
 // The minimum alignment guaranteed by the architecture. This value is used to
 // add fast paths for low alignment values. In practice, the alignment is a
 // constant at the call site and the branch will be optimized out.
-#[cfg(all(any(target_arch = "arm",
+#[cfg(all(any(target_arch = "x86",
+              target_arch = "arm",
               target_arch = "mips",
               target_arch = "mipsel",
               target_arch = "powerpc")))]
 const MIN_ALIGN: usize = 8;
-#[cfg(all(any(target_arch = "x86",
-              target_arch = "x86_64",
+#[cfg(all(any(target_arch = "x86_64",
               target_arch = "aarch64")))]
 const MIN_ALIGN: usize = 16;
 


### PR DESCRIPTION
This fixes it so the Rust allocator on Windows 32-bit doesn't think the system allocator is aligned to 16 when it is really only aligned to 8.
