### PR TITLE
mk: Fix `make dist`

### DIFF
--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -42,7 +42,6 @@ PKG_FILES := \
     $(S)COPYRIGHT                              \
     $(S)LICENSE-APACHE                         \
     $(S)LICENSE-MIT                            \
-    $(S)AUTHORS.txt                            \
     $(S)CONTRIBUTING.md                        \
     $(S)README.md                              \
     $(S)RELEASES.md                            \


### PR DESCRIPTION
Now that AUTHORS.txt no longer exists we shouldn't try to package it.
