### PR TITLE
Fix typo

### DIFF
--- a/src/doc/book/loops.md
+++ b/src/doc/book/loops.md
@@ -80,7 +80,7 @@ for var in expression {
 }
 ```
 
-The expression is an item can can be converted into an [iterator] using
+The expression is an item that can be converted into an [iterator] using
 [`IntoIterator`]. The iterator gives back a series of elements. Each element is
 one iteration of the loop. That value is then bound to the name `var`, which is
 valid for the loop body. Once the body is over, the next value is fetched from


### PR DESCRIPTION
This fixes a double word typo, 'can'.
