### PR TITLE
Fix issue 30063 (reset codegen-units to 1 when necessary)

### DIFF
--- a/src/test/run-make/issue-30063/Makefile
+++ b/src/test/run-make/issue-30063/Makefile
@@ -1,0 +1,35 @@
+-include ../tools.mk
+
+all:
+	rm -f $(TMPDIR)/foo-output
+	$(RUSTC) -C codegen-units=4 -o $(TMPDIR)/foo-output foo.rs
+	rm $(TMPDIR)/foo-output
+
+	rm -f $(TMPDIR)/asm-output
+	$(RUSTC) -C codegen-units=4 --emit=asm -o $(TMPDIR)/asm-output foo.rs
+	rm $(TMPDIR)/asm-output
+
+	rm -f $(TMPDIR)/bc-output
+	$(RUSTC) -C codegen-units=4 --emit=llvm-bc -o $(TMPDIR)/bc-output foo.rs
+	rm $(TMPDIR)/bc-output
+
+	rm -f $(TMPDIR)/ir-output
+	$(RUSTC) -C codegen-units=4 --emit=llvm-ir -o $(TMPDIR)/ir-output foo.rs
+	rm $(TMPDIR)/ir-output
+
+	rm -f $(TMPDIR)/link-output
+	$(RUSTC) -C codegen-units=4 --emit=link -o $(TMPDIR)/link-output foo.rs
+	rm $(TMPDIR)/link-output
+
+	rm -f $(TMPDIR)/obj-output
+	$(RUSTC) -C codegen-units=4 --emit=obj -o $(TMPDIR)/obj-output foo.rs
+	rm $(TMPDIR)/obj-output
+
+	rm -f $(TMPDIR)/dep-output
+	$(RUSTC) -C codegen-units=4 --emit=dep-info -o $(TMPDIR)/dep-output foo.rs
+	rm $(TMPDIR)/dep-output
+
+#	# (This case doesn't work yet, and may be fundamentally wrong-headed anyway.)
+#	rm -f $(TMPDIR)/multi-output
+#	$(RUSTC) -C codegen-units=4 --emit=asm,obj -o $(TMPDIR)/multi-output foo.rs
+#	rm $(TMPDIR)/multi-output

--- a/src/test/run-make/issue-30063/foo.rs
+++ b/src/test/run-make/issue-30063/foo.rs
@@ -1,0 +1,11 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() { }


### PR DESCRIPTION
 When given `rustc -C codegen-units=4 --emit=obj`, reset units back to 1.

Fix #30063

Note: while this code is careful to handle the case of mutliple emit types (e.g. `--emit=asm,obj`) by reporting all the emit types that conflict with codegen units in its warnings, an invocation with multiple emit types _and_ `-o PATH` will continue to ignore the requested target path (with a warning), as it already does today, since the code that checks for that is further downstream.  (Multiple emit types without `-o PATH` will "work", though it will downgrade codegen-units to 1 just like all the other cases.)

r? @alexcrichton 
