### PR TITLE
Fix getopts for issue 30204

### DIFF
--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -598,7 +598,7 @@ pub fn getopts(args: &[String], optgrps: &[OptGroup]) -> Result {
             let mut i_arg = None;
             if cur.as_bytes()[1] == b'-' {
                 let tail = &cur[2..curlen];
-                let tail_eq: Vec<&str> = tail.split('=').collect();
+                let tail_eq: Vec<&str> = tail.splitn(2, '=').collect();
                 if tail_eq.len() <= 1 {
                     names = vec![Long(tail.to_owned())];
                 } else {
@@ -1625,5 +1625,19 @@ Options:
         debug!("expected: <<{}>>", expected);
         debug!("generated: <<{}>>", generated_usage);
         assert_eq!(generated_usage, expected);
+    }
+
+    #[test]
+    fn test_args_with_equals() {
+        let args = vec!("--one".to_string(), "A=B".to_string(),
+                        "--two=C=D".to_string());
+        let opts = vec![optopt("o", "one", "One", "INFO"),
+                        optopt("t", "two", "Two", "INFO")];
+        let matches = &match getopts(&args, &opts) {
+            result::Result::Ok(m) => m,
+            result::Result::Err(e) => panic!("{}", e)
+        };
+        assert_eq!(matches.opts_str(&["o".to_string()]).unwrap(), "A=B");
+        assert_eq!(matches.opts_str(&["t".to_string()]).unwrap(), "C=D");
     }
 }

--- a/src/test/run-make/output-type-permutations/Makefile
+++ b/src/test/run-make/output-type-permutations/Makefile
@@ -27,11 +27,15 @@ all:
 	rm $(TMPDIR)/foo
 	$(RUSTC) foo.rs --emit asm=$(TMPDIR)/foo
 	rm $(TMPDIR)/foo
+	$(RUSTC) foo.rs --emit=asm=$(TMPDIR)/foo
+	rm $(TMPDIR)/foo
 	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
 
 	$(RUSTC) foo.rs --emit llvm-bc -o $(TMPDIR)/foo
 	rm $(TMPDIR)/foo
 	$(RUSTC) foo.rs --emit llvm-bc=$(TMPDIR)/foo
+	rm $(TMPDIR)/foo
+	$(RUSTC) foo.rs --emit=llvm-bc=$(TMPDIR)/foo
 	rm $(TMPDIR)/foo
 	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
 
@@ -39,17 +43,23 @@ all:
 	rm $(TMPDIR)/foo
 	$(RUSTC) foo.rs --emit llvm-ir=$(TMPDIR)/foo
 	rm $(TMPDIR)/foo
+	$(RUSTC) foo.rs --emit=llvm-ir=$(TMPDIR)/foo
+	rm $(TMPDIR)/foo
 	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
 
 	$(RUSTC) foo.rs --emit obj -o $(TMPDIR)/foo
 	rm $(TMPDIR)/foo
 	$(RUSTC) foo.rs --emit obj=$(TMPDIR)/foo
 	rm $(TMPDIR)/foo
+	$(RUSTC) foo.rs --emit=obj=$(TMPDIR)/foo
+	rm $(TMPDIR)/foo
 	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
 
 	$(RUSTC) foo.rs --emit link -o $(TMPDIR)/$(call BIN,foo)
 	rm $(TMPDIR)/$(call BIN,foo)
 	$(RUSTC) foo.rs --emit link=$(TMPDIR)/$(call BIN,foo)
+	rm $(TMPDIR)/$(call BIN,foo)
+	$(RUSTC) foo.rs --emit=link=$(TMPDIR)/$(call BIN,foo)
 	rm $(TMPDIR)/$(call BIN,foo)
 	rm -f $(TMPDIR)/foo.pdb
 	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
@@ -58,11 +68,15 @@ all:
 	rm $(TMPDIR)/foo
 	$(RUSTC) foo.rs --crate-type=rlib --emit link=$(TMPDIR)/foo
 	rm $(TMPDIR)/foo
+	$(RUSTC) foo.rs --crate-type=rlib --emit=link=$(TMPDIR)/foo
+	rm $(TMPDIR)/foo
 	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
 
 	$(RUSTC) foo.rs --crate-type=dylib -o $(TMPDIR)/$(call BIN,foo)
 	rm $(TMPDIR)/$(call BIN,foo)
 	$(RUSTC) foo.rs --crate-type=dylib --emit link=$(TMPDIR)/$(call BIN,foo)
+	rm $(TMPDIR)/$(call BIN,foo)
+	$(RUSTC) foo.rs --crate-type=dylib --emit=link=$(TMPDIR)/$(call BIN,foo)
 	rm $(TMPDIR)/$(call BIN,foo)
 	rm -f $(TMPDIR)/foo.{exp,lib,pdb}
 	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
@@ -71,11 +85,15 @@ all:
 	rm $(TMPDIR)/foo
 	$(RUSTC) foo.rs --crate-type=staticlib --emit link=$(TMPDIR)/foo
 	rm $(TMPDIR)/foo
+	$(RUSTC) foo.rs --crate-type=staticlib --emit=link=$(TMPDIR)/foo
+	rm $(TMPDIR)/foo
 	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
 
 	$(RUSTC) foo.rs --crate-type=bin -o $(TMPDIR)/$(call BIN,foo)
 	rm $(TMPDIR)/$(call BIN,foo)
 	$(RUSTC) foo.rs --crate-type=bin --emit link=$(TMPDIR)/$(call BIN,foo)
+	rm $(TMPDIR)/$(call BIN,foo)
+	$(RUSTC) foo.rs --crate-type=bin --emit=link=$(TMPDIR)/$(call BIN,foo)
 	rm $(TMPDIR)/$(call BIN,foo)
 	rm -f $(TMPDIR)/foo.pdb
 	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
@@ -92,6 +110,17 @@ all:
 			--emit llvm-bc=$(TMPDIR)/bc \
 		        --emit obj=$(TMPDIR)/obj \
 			--emit link=$(TMPDIR)/link \
+			--crate-type=staticlib
+	rm $(TMPDIR)/asm
+	rm $(TMPDIR)/ir
+	rm $(TMPDIR)/bc
+	rm $(TMPDIR)/obj
+	rm $(TMPDIR)/link
+	$(RUSTC) foo.rs --emit=asm=$(TMPDIR)/asm \
+			--emit llvm-ir=$(TMPDIR)/ir \
+			--emit=llvm-bc=$(TMPDIR)/bc \
+		        --emit obj=$(TMPDIR)/obj \
+			--emit=link=$(TMPDIR)/link \
 			--crate-type=staticlib
 	rm $(TMPDIR)/asm
 	rm $(TMPDIR)/ir


### PR DESCRIPTION
Fix internal `getopts` so `--a=b=c` acts like `--a b=c` rather than `--a b`.

Fix #30204
