### PR TITLE
Resolved warnings about unused result in concurrency.md

### DIFF
--- a/src/doc/book/concurrency.md
+++ b/src/doc/book/concurrency.md
@@ -295,12 +295,12 @@ fn main() {
             let mut data = data.lock().unwrap();
             *data += 1;
 
-            tx.send(());
+            let _ = tx.send(());
         });
     }
 
     for _ in 0..10 {
-        rx.recv();
+        let _ = rx.recv();
     }
 }
 ```
@@ -324,7 +324,7 @@ fn main() {
         thread::spawn(move || {
             let answer = i * i;
 
-            tx.send(answer);
+            let _ = tx.send(answer);
         });
     }
 

--- a/src/doc/book/concurrency.md
+++ b/src/doc/book/concurrency.md
@@ -295,12 +295,12 @@ fn main() {
             let mut data = data.lock().unwrap();
             *data += 1;
 
-            let _ = tx.send(());
+            tx.send(()).unwrap();
         });
     }
 
     for _ in 0..10 {
-        let _ = rx.recv();
+        rx.recv().unwrap();
     }
 }
 ```
@@ -324,7 +324,7 @@ fn main() {
         thread::spawn(move || {
             let answer = i * i;
 
-            let _ = tx.send(answer);
+            tx.send(answer).unwrap();
         });
     }
 


### PR DESCRIPTION
The example code in the Channels subsection of the rust book give warnings about 

```
unused result which must be used, #[warn(unused_must_use)] on by default
```

Added a small pattern match to resolve those warnings.
