### PR TITLE
DOCS: update reference about paths

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -509,6 +509,25 @@ fn bar() {
 # fn main() {}
 ```
 
+Additionally keyword `super` may be repeated several times after the first
+`super` or `self` to refer to ancestor modules.
+
+```rust
+mod a {
+    fn foo() {}
+
+    mod b {
+        mod c {
+            fn foo() {
+                super::super::foo(); // call a's foo function
+                self::super::super::foo(); // call a's foo function
+            }
+        }
+    }
+}
+# fn main() {}
+```
+
 # Syntax extensions
 
 A number of minor features of Rust are not central enough to have their own


### PR DESCRIPTION
Make clear that `super` may be included in the path several times.

r? @steveklabnik
