### PR TITLE
Revert "PR #30130 Implement `Clone` for more arrays"

### DIFF
--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -27,7 +27,7 @@ use default::Default;
 use fmt;
 use hash::{Hash, self};
 use iter::IntoIterator;
-use marker::{Sized, Unsize};
+use marker::{Copy, Sized, Unsize};
 use option::Option;
 use slice::{Iter, IterMut, SliceExt};
 
@@ -123,6 +123,13 @@ macro_rules! array_impls {
             impl<T> BorrowMut<[T]> for [T; $N] {
                 fn borrow_mut(&mut self) -> &mut [T] {
                     self
+                }
+            }
+
+            #[stable(feature = "rust1", since = "1.0.0")]
+            impl<T:Copy> Clone for [T; $N] {
+                fn clone(&self) -> [T; $N] {
+                    *self
                 }
             }
 
@@ -235,30 +242,3 @@ macro_rules! array_impl_default {
 }
 
 array_impl_default!{32, T T T T T T T T T T T T T T T T T T T T T T T T T T T T T T T T}
-
-macro_rules! array_impl_clone {
-    {$n:expr, $i:expr, $($idx:expr,)*} => {
-        #[stable(feature = "rust1", since = "1.0.0")]
-        impl<T: Clone> Clone for [T; $n] {
-            fn clone(&self) -> [T; $n] {
-                [self[$i-$i].clone(), $(self[$i-$idx].clone()),*]
-            }
-        }
-        array_impl_clone!{$i, $($idx,)*}
-    };
-    {$n:expr,} => {
-        #[stable(feature = "rust1", since = "1.0.0")]
-        impl<T: Clone> Clone for [T; 0] {
-            fn clone(&self) -> [T; 0] {
-                []
-            }
-        }
-    };
-}
-
-array_impl_clone! {
-                                32, 31, 30,
-    29, 28, 27, 26, 25, 24, 23, 22, 21, 20,
-    19, 18, 17, 16, 15, 14, 13, 12, 11, 10,
-     9,  8,  7,  6,  5,  4,  3,  2,  1,  0,
-}

--- a/src/test/run-pass/deriving-clone-array.rs
+++ b/src/test/run-pass/deriving-clone-array.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// test for issue #30244
+
+#[derive(Copy, Clone)]
+struct Array {
+    arr: [[u8; 256]; 4]
+}
+
+pub fn main() {}


### PR DESCRIPTION
Revert "PR #30130 Implement `Clone` for more arrays"

This reverts commit e22a64e8d8d4da46c74f878ce1c23ad1c88982e8.

This caused a regression such that types like `[[u8; 256]; 4]`
no longer implemented Clone. This previously worked due to Clone
for `[T; N]` (N in 0 to 32) being implemented for T: Copy.

Due to fixed size arrays not implementing Clone for sizes above 32,
the new implementation requiring T: Clone would not allow
`[[u8; 256]; 4]` to be Clone.

Fixes #30244

Due to changing back, this is technically a [breaking-change],
albeit for a behavior that existed for a very short time.
