### PR TITLE
rust-gdb/rust-lldb: Trim output of vec/slice/array 

### DIFF
--- a/src/etc/gdb_rust_pretty_printing.py
+++ b/src/etc/gdb_rust_pretty_printing.py
@@ -209,15 +209,12 @@ class RustSlicePrinter:
                 ("(len: %i)" % length))
 
     def children(self):
-        cs = []
         (length, data_ptr) = rustpp.extract_length_and_ptr_from_slice(self.__val)
+
         assert data_ptr.type.get_dwarf_type_kind() == rustpp.DWARF_TYPE_CODE_PTR
         raw_ptr = data_ptr.get_wrapped_value()
 
-        for index in range(0, length):
-            cs.append((str(index), (raw_ptr + index).dereference()))
-
-        return cs
+        return iter_children_pointer(raw_ptr, length)
 
 
 class RustStringSlicePrinter:
@@ -243,12 +240,9 @@ class RustStdVecPrinter:
                 ("(len: %i, cap: %i)" % (length, cap)))
 
     def children(self):
-        cs = []
         (length, data_ptr, cap) = rustpp.extract_length_ptr_and_cap_from_std_vec(self.__val)
-        gdb_ptr = data_ptr.get_wrapped_value()
-        for index in range(0, length):
-            cs.append((str(index), (gdb_ptr + index).dereference()))
-        return cs
+        raw_ptr = data_ptr.get_wrapped_value()
+        return iter_children_pointer(raw_ptr, length)
 
 
 class RustStdStringPrinter:
@@ -286,3 +280,7 @@ def get_field_at_index(gdb_val, index):
             return field
         i += 1
     return None
+
+def iter_children_pointer(raw_ptr, length):
+    for index in range(0, length):
+        yield str(index), (raw_ptr + index).dereference()

--- a/src/etc/lldb_rust_formatters.py
+++ b/src/etc/lldb_rust_formatters.py
@@ -12,6 +12,9 @@ import lldb
 import re
 import debugger_pretty_printers_common as rustpp
 
+# Maximal amount of array/vec/slice items to print before trimming
+MAX_CHILDREN = 100
+
 #===============================================================================
 # LLDB Pretty Printing Module for Rust
 #===============================================================================
@@ -311,7 +314,18 @@ def print_array_of_values(array_name, data_ptr_val, length, internal_dict):
                                                        element_type)
         return print_val(element_val, internal_dict)
 
-    return ', '.join([render_element(i) for i in range(length)])
+    overflow = length > MAX_CHILDREN
+    if overflow:
+        length = MAX_CHILDREN
+
+    def render_all():
+        for i in range(length):
+            yield render_element(i)
+
+        if overflow:
+            yield ".."
+
+    return ', '.join(render_all())
 
 
 def read_utf8_string(ptr_val, byte_count):

--- a/src/test/debuginfo/huge-vec.rs
+++ b/src/test/debuginfo/huge-vec.rs
@@ -1,0 +1,33 @@
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// min-lldb-version: 310
+// ignore-tidy-linelength
+
+// compile-flags:-g
+
+// gdb-command:set print elements 10
+// gdb-command:run
+// gdb-command:print a
+// gdb-check:$1 = Vec<i32>(len: 200, cap: 200) = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1...}
+
+// === LLDB TESTS ==================================================================================
+
+// lldb-command:run
+// lldb-command:print a
+// lldb-check:[...]$0 = vec![1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ..]
+
+#![allow(unused_variables)]
+
+fn main() {
+    let a = vec![1; 200];
+
+    () // #break
+}


### PR DESCRIPTION
Fix #29467

I have tested this with rust-gdb, but rust-lldb is completely untested.

It prints "cannot access memory" for the example in #29467 instead of hanging
up.
