### PR TITLE
Small fixes for 1.6 docs

### DIFF
--- a/src/librustc_unicode/char.rs
+++ b/src/librustc_unicode/char.rs
@@ -386,9 +386,10 @@ impl char {
     /// Returns the number of 16-bit code units this `char` would need if
     /// encoded in UTF-16.
     ///
-    /// See the documentation for [`len_utf8()`][len_utf8] for more explanation
-    /// of this concept. This function is a mirror, but for UTF-16 instead of
-    /// UTF-8.
+    /// See the documentation for [`len_utf8()`] for more explanation of this
+    /// concept. This function is a mirror, but for UTF-16 instead of UTF-8.
+    ///
+    /// [`len_utf8()`]: #method.len_utf8
     ///
     /// # Examples
     ///

--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -350,7 +350,7 @@ mod prim_slice { }
 /// ```
 ///
 /// [`.as_ptr()`]: #method.as_ptr
-/// [`len()`]: # method.len
+/// [`len()`]: #method.len
 mod prim_str { }
 
 #[doc(primitive = "tuple")]


### PR DESCRIPTION
I meant to double check the work in https://github.com/rust-lang/rust/issues/29429, but due to Mozlando, forgot. Here are two small fixes.

r? @brson I would like to get this backported to beta as well, sorry :( I don't generally want doc backports, but feel this is exceptional and worth it.
