### PR TITLE
fix missing Panics tag and missing period (doc)

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -309,7 +309,7 @@ impl<T> Option<T> {
     // Getting to contained values
     /////////////////////////////////////////////////////////////////////////
 
-    /// Unwraps an option, yielding the content of a `Some`
+    /// Unwraps an option, yielding the content of a `Some`.
     ///
     /// # Panics
     ///

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -744,6 +744,8 @@ impl<T, E: fmt::Debug> Result<T, E> {
 
     /// Unwraps a result, yielding the content of an `Ok`.
     ///
+    /// # Panics
+    ///
     /// Panics if the value is an `Err`, with a panic message including the
     /// passed message, and the content of the `Err`.
     ///


### PR DESCRIPTION
Missing Panics tag and missing period in the documentation of `fn expect(…)` for `Option` and `Result`.
