### PR TITLE
[MIR] Store MIR in crate metadata

### DIFF
--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -242,7 +242,7 @@ pub fn lookup_const_fn_by_id<'tcx>(tcx: &ty::ctxt<'tcx>, def_id: DefId)
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, RustcEncodable, RustcDecodable)]
 pub enum ConstVal {
     Float(f64),
     Int(i64),

--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -21,6 +21,7 @@ use std::fmt::{Debug, Formatter, Error};
 use std::u32;
 
 /// Lowered representation of a single function.
+#[derive(RustcEncodable, RustcDecodable)]
 pub struct Mir<'tcx> {
     /// List of basic blocks. References to basic block use a newtyped index type `BasicBlock`
     /// that indexes into this vector.
@@ -71,13 +72,13 @@ impl<'tcx> Mir<'tcx> {
 ///////////////////////////////////////////////////////////////////////////
 // Mutability and borrow kinds
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, RustcEncodable, RustcDecodable)]
 pub enum Mutability {
     Mut,
     Not,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, RustcEncodable, RustcDecodable)]
 pub enum BorrowKind {
     /// Data must be immutable and is aliasable.
     Shared,
@@ -128,6 +129,7 @@ pub enum BorrowKind {
 
 // A "variable" is a binding declared by the user as part of the fn
 // decl, a let, etc.
+#[derive(RustcEncodable, RustcDecodable)]
 pub struct VarDecl<'tcx> {
     pub mutability: Mutability,
     pub name: Name,
@@ -136,6 +138,7 @@ pub struct VarDecl<'tcx> {
 
 // A "temp" is a temporary that we place on the stack. They are
 // anonymous, always mutable, and have only a type.
+#[derive(RustcEncodable, RustcDecodable)]
 pub struct TempDecl<'tcx> {
     pub ty: Ty<'tcx>,
 }
@@ -151,6 +154,7 @@ pub struct TempDecl<'tcx> {
 //
 // there is only one argument, of type `(i32, u32)`, but two bindings
 // (`x` and `y`).
+#[derive(RustcEncodable, RustcDecodable)]
 pub struct ArgDecl<'tcx> {
     pub ty: Ty<'tcx>,
 }
@@ -162,7 +166,7 @@ pub struct ArgDecl<'tcx> {
 /// list of the `Mir`.
 ///
 /// (We use a `u32` internally just to save memory.)
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, RustcEncodable, RustcDecodable)]
 pub struct BasicBlock(u32);
 
 impl BasicBlock {
@@ -186,12 +190,13 @@ impl Debug for BasicBlock {
 ///////////////////////////////////////////////////////////////////////////
 // BasicBlock and Terminator
 
-#[derive(Debug)]
+#[derive(Debug, RustcEncodable, RustcDecodable)]
 pub struct BasicBlockData<'tcx> {
     pub statements: Vec<Statement<'tcx>>,
     pub terminator: Terminator<'tcx>,
 }
 
+#[derive(RustcEncodable, RustcDecodable)]
 pub enum Terminator<'tcx> {
     /// block should have one successor in the graph; we jump there
     Goto {
@@ -289,7 +294,7 @@ impl<'tcx> Terminator<'tcx> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, RustcEncodable, RustcDecodable)]
 pub struct CallData<'tcx> {
     /// where the return value is written to
     pub destination: Lvalue<'tcx>,
@@ -346,18 +351,19 @@ impl<'tcx> Debug for Terminator<'tcx> {
 ///////////////////////////////////////////////////////////////////////////
 // Statements
 
+#[derive(RustcEncodable, RustcDecodable)]
 pub struct Statement<'tcx> {
     pub span: Span,
     pub kind: StatementKind<'tcx>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, RustcEncodable, RustcDecodable)]
 pub enum StatementKind<'tcx> {
     Assign(Lvalue<'tcx>, Rvalue<'tcx>),
     Drop(DropKind, Lvalue<'tcx>),
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, RustcEncodable, RustcDecodable)]
 pub enum DropKind {
     Free, // free a partially constructed box, should go away eventually
     Deep
@@ -378,7 +384,7 @@ impl<'tcx> Debug for Statement<'tcx> {
 
 /// A path to a value; something that can be evaluated without
 /// changing or disturbing program state.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, RustcEncodable, RustcDecodable)]
 pub enum Lvalue<'tcx> {
     /// local variable declared by the user
     Var(u32),
@@ -404,13 +410,13 @@ pub enum Lvalue<'tcx> {
 /// or `*B` or `B[index]`. Note that it is parameterized because it is
 /// shared between `Constant` and `Lvalue`. See the aliases
 /// `LvalueProjection` etc below.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, RustcEncodable, RustcDecodable)]
 pub struct Projection<'tcx, B, V> {
     pub base: B,
     pub elem: ProjectionElem<'tcx, V>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, RustcEncodable, RustcDecodable)]
 pub enum ProjectionElem<'tcx, V> {
     Deref,
     Field(Field),
@@ -448,7 +454,7 @@ pub type LvalueElem<'tcx> =
     ProjectionElem<'tcx,Operand<'tcx>>;
 
 /// Index into the list of fields found in a `VariantDef`
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, RustcEncodable, RustcDecodable)]
 pub struct Field(u32);
 
 impl Field {
@@ -524,7 +530,7 @@ impl<'tcx> Debug for Lvalue<'tcx> {
 // lvalue). They are intentionally limited to prevent rvalues from
 // being nested in one another.
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, RustcEncodable, RustcDecodable)]
 pub enum Operand<'tcx> {
     Consume(Lvalue<'tcx>),
     Constant(Constant<'tcx>),
@@ -543,7 +549,7 @@ impl<'tcx> Debug for Operand<'tcx> {
 ///////////////////////////////////////////////////////////////////////////
 // Rvalues
 
-#[derive(Clone)]
+#[derive(Clone, RustcEncodable, RustcDecodable)]
 pub enum Rvalue<'tcx> {
     // x (either a move or copy, depending on type of x)
     Use(Operand<'tcx>),
@@ -587,7 +593,7 @@ pub enum Rvalue<'tcx> {
     InlineAsm(InlineAsm),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, RustcEncodable, RustcDecodable)]
 pub enum CastKind {
     Misc,
 
@@ -605,7 +611,7 @@ pub enum CastKind {
     Unsize,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, RustcEncodable, RustcDecodable)]
 pub enum AggregateKind<'tcx> {
     Vec,
     Tuple,
@@ -613,7 +619,7 @@ pub enum AggregateKind<'tcx> {
     Closure(DefId, &'tcx ClosureSubsts<'tcx>),
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, RustcEncodable, RustcDecodable)]
 pub enum BinOp {
     /// The `+` operator (addition)
     Add,
@@ -649,7 +655,7 @@ pub enum BinOp {
     Gt,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, RustcEncodable, RustcDecodable)]
 pub enum UnOp {
     /// The `!` operator for logical inversion
     Not,
@@ -685,14 +691,14 @@ impl<'tcx> Debug for Rvalue<'tcx> {
 // this does not necessarily mean that they are "==" in Rust -- in
 // particular one must be wary of `NaN`!
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, RustcEncodable, RustcDecodable)]
 pub struct Constant<'tcx> {
     pub span: Span,
     pub ty: Ty<'tcx>,
     pub literal: Literal<'tcx>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, RustcEncodable, RustcDecodable)]
 pub enum Literal<'tcx> {
     Item {
         def_id: DefId,

--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -584,7 +584,7 @@ pub enum Rvalue<'tcx> {
         from_end: usize,
     },
 
-    InlineAsm(&'tcx InlineAsm),
+    InlineAsm(InlineAsm),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -10,6 +10,7 @@
 
 use middle::ty::Region;
 use mir::repr::*;
+use rustc_data_structures::tuple_slice::TupleSlice;
 
 pub trait Visitor<'tcx> {
     // Override these, and call `self.super_xxx` to revert back to the
@@ -97,7 +98,7 @@ pub trait Visitor<'tcx> {
 
             Terminator::If { ref cond, ref targets } => {
                 self.visit_operand(cond);
-                for &target in &targets[..] {
+                for &target in targets.as_slice() {
                     self.visit_branch(block, target);
                 }
             }
@@ -126,7 +127,7 @@ pub trait Visitor<'tcx> {
                 for arg in &data.args {
                     self.visit_operand(arg);
                 }
-                for &target in &targets[..] {
+                for &target in targets.as_slice() {
                     self.visit_branch(block, target);
                 }
             }

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -42,6 +42,7 @@ pub mod snapshot_vec;
 pub mod transitive_relation;
 pub mod unify;
 pub mod fnv;
+pub mod tuple_slice;
 
 // See comments in src/librustc/lib.rs
 #[doc(hidden)]

--- a/src/librustc_data_structures/tuple_slice.rs
+++ b/src/librustc_data_structures/tuple_slice.rs
@@ -1,0 +1,60 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::slice;
+
+/// Allows to view uniform tuples as slices
+pub trait TupleSlice<T> {
+    fn as_slice(&self) -> &[T];
+    fn as_mut_slice(&mut self) -> &mut [T];
+}
+
+macro_rules! impl_tuple_slice {
+    ($tuple_type:ty, $size:expr) => {
+        impl<T> TupleSlice<T> for $tuple_type {
+            fn as_slice(&self) -> &[T] {
+                unsafe {
+                    let ptr = &self.0 as *const T;
+                    slice::from_raw_parts(ptr, $size)
+                }
+            }
+
+            fn as_mut_slice(&mut self) -> &mut [T] {
+                unsafe {
+                    let ptr = &mut self.0 as *mut T;
+                    slice::from_raw_parts_mut(ptr, $size)
+                }
+            }
+        }
+    }
+}
+
+impl_tuple_slice!((T,T), 2);
+impl_tuple_slice!((T,T,T), 3);
+impl_tuple_slice!((T,T,T,T), 4);
+impl_tuple_slice!((T,T,T,T,T), 5);
+impl_tuple_slice!((T,T,T,T,T,T), 6);
+impl_tuple_slice!((T,T,T,T,T,T,T), 7);
+impl_tuple_slice!((T,T,T,T,T,T,T,T), 8);
+
+#[test]
+fn test_sliced_tuples() {
+    let t2 = (100i32, 101i32);
+    assert_eq!(t2.as_slice(), &[100i32, 101i32]);
+
+    let t3 = (102i32, 103i32, 104i32);
+    assert_eq!(t3.as_slice(), &[102i32, 103i32, 104i32]);
+
+    let t4 = (105i32, 106i32, 107i32, 108i32);
+    assert_eq!(t4.as_slice(), &[105i32, 106i32, 107i32, 108i32]);
+
+    let t5 = (109i32, 110i32, 111i32, 112i32, 113i32);
+    assert_eq!(t5.as_slice(), &[109i32, 110i32, 111i32, 112i32, 113i32]);
+}

--- a/src/librustc_metadata/common.rs
+++ b/src/librustc_metadata/common.rs
@@ -120,7 +120,8 @@ enum_from_u32! {
 
         tag_tree = 0x51,
 
-        // GAP 0x52
+        tag_mir = 0x52,
+
         tag_table = 0x53,
         // GAP 0x54, 0x55
         tag_table_def = 0x56,

--- a/src/librustc_metadata/csearch.rs
+++ b/src/librustc_metadata/csearch.rs
@@ -22,6 +22,7 @@ use middle::ty::{self, Ty};
 use middle::def_id::{DefId, DefIndex};
 
 use rustc::front::map as hir_map;
+use rustc::mir::repr::Mir;
 use rustc::util::nodemap::{FnvHashMap, NodeMap, NodeSet};
 
 use std::cell::RefCell;
@@ -421,6 +422,12 @@ impl<'tcx> CrateStore<'tcx> for cstore::CStore {
         decoder::maybe_get_item_ast(&*cdata, tcx, def.index, decode_inlined_item)
     }
 
+    fn maybe_get_item_mir(&self, tcx: &ty::ctxt<'tcx>, def: DefId)
+                          -> Option<Mir<'tcx>> {
+        let cdata = self.get_crate_data(def.krate);
+        decoder::maybe_get_item_mir(&*cdata, tcx, def.index)
+    }
+
     fn crates(&self) -> Vec<ast::CrateNum>
     {
         let mut result = vec![];
@@ -473,6 +480,7 @@ impl<'tcx> CrateStore<'tcx> for cstore::CStore {
                        item_symbols: &RefCell<NodeMap<String>>,
                        link_meta: &LinkMeta,
                        reachable: &NodeSet,
+                       mir_map: &NodeMap<Mir<'tcx>>,
                        krate: &hir::Crate) -> Vec<u8>
     {
         let encode_inlined_item: encoder::EncodeInlinedItem =
@@ -486,7 +494,8 @@ impl<'tcx> CrateStore<'tcx> for cstore::CStore {
             link_meta: link_meta,
             cstore: self,
             encode_inlined_item: encode_inlined_item,
-            reachable: reachable
+            reachable: reachable,
+            mir_map: mir_map,
         };
         encoder::encode_metadata(encode_params, krate)
 

--- a/src/librustc_mir/build/expr/as_lvalue.rs
+++ b/src/librustc_mir/build/expr/as_lvalue.rs
@@ -69,7 +69,7 @@ impl<'a,'tcx> Builder<'a,'tcx> {
                 this.cfg.terminate(block,
                                    Terminator::If {
                                        cond: Operand::Consume(lt),
-                                       targets: [success, failure],
+                                       targets: (success, failure),
                                    });
                 this.panic(failure);
                 success.and(slice.index(idx))

--- a/src/librustc_mir/build/expr/as_rvalue.rs
+++ b/src/librustc_mir/build/expr/as_rvalue.rs
@@ -40,7 +40,7 @@ impl<'a,'tcx> Builder<'a,'tcx> {
                 this.in_scope(extent, block, |this| this.as_rvalue(block, value))
             }
             ExprKind::InlineAsm { asm } => {
-                block.and(Rvalue::InlineAsm(asm))
+                block.and(Rvalue::InlineAsm(asm.clone()))
             }
             ExprKind::Repeat { value, count } => {
                 let value_operand = unpack!(block = this.as_operand(block, value));

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -53,7 +53,7 @@ impl<'a,'tcx> Builder<'a,'tcx> {
                 let mut else_block = this.cfg.start_new_block();
                 this.cfg.terminate(block, Terminator::If {
                     cond: operand,
-                    targets: [then_block, else_block]
+                    targets: (then_block, else_block)
                 });
 
                 unpack!(then_block = this.into(destination, then_block, then_expr));
@@ -84,15 +84,15 @@ impl<'a,'tcx> Builder<'a,'tcx> {
 
                 let lhs = unpack!(block = this.as_operand(block, lhs));
                 let blocks = match op {
-                    LogicalOp::And => [else_block, false_block],
-                    LogicalOp::Or => [true_block, else_block],
+                    LogicalOp::And => (else_block, false_block),
+                    LogicalOp::Or => (true_block, else_block),
                 };
                 this.cfg.terminate(block, Terminator::If { cond: lhs, targets: blocks });
 
                 let rhs = unpack!(else_block = this.as_operand(else_block, rhs));
                 this.cfg.terminate(else_block, Terminator::If {
                     cond: rhs,
-                    targets: [true_block, false_block]
+                    targets: (true_block, false_block)
                 });
 
                 this.cfg.push_assign_constant(
@@ -149,7 +149,7 @@ impl<'a,'tcx> Builder<'a,'tcx> {
                         this.cfg.terminate(loop_block_end,
                                            Terminator::If {
                                                cond: cond,
-                                               targets: [body_block, exit_block]
+                                               targets: (body_block, exit_block)
                                            });
                     } else {
                         body_block = loop_block;
@@ -225,7 +225,7 @@ impl<'a,'tcx> Builder<'a,'tcx> {
                                            func: fun,
                                            args: args,
                                        },
-                                       targets: [success, panic],
+                                       targets: (success, panic),
                                    });
                 success.unit()
             }

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -555,7 +555,7 @@ impl<'a,'tcx> Builder<'a,'tcx> {
             let cond = unpack!(block = self.as_operand(block, guard));
             let otherwise = self.cfg.start_new_block();
             self.cfg.terminate(block, Terminator::If { cond: cond,
-                                                       targets: [arm_block, otherwise]});
+                                                       targets: (arm_block, otherwise)});
             Some(otherwise)
         } else {
             self.cfg.terminate(block, Terminator::Goto { target: arm_block });

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -232,7 +232,7 @@ impl<'a,'tcx> Builder<'a,'tcx> {
                                                  self.cfg.start_new_block()];
                 self.cfg.terminate(block, Terminator::If {
                     cond: Operand::Consume(result),
-                    targets: [target_blocks[0], target_blocks[1]]
+                    targets: (target_blocks[0], target_blocks[1])
                 });
 
                 target_blocks
@@ -252,7 +252,7 @@ impl<'a,'tcx> Builder<'a,'tcx> {
         let bool_ty = self.hir.bool_ty();
         let eq_result = self.temp(bool_ty);
         let func = self.item_ref_operand(span, item_ref);
-        let call_blocks = [self.cfg.start_new_block(), self.diverge_cleanup()];
+        let call_blocks = (self.cfg.start_new_block(), self.diverge_cleanup());
         self.cfg.terminate(block,
                            Terminator::Call {
                                data: CallData {
@@ -264,10 +264,10 @@ impl<'a,'tcx> Builder<'a,'tcx> {
                            });
 
         // check the result
-        self.cfg.terminate(call_blocks[0],
+        self.cfg.terminate(call_blocks.0,
                            Terminator::If {
                                cond: Operand::Consume(eq_result),
-                               targets: [target_blocks[0], target_blocks[1]],
+                               targets: (target_blocks[0], target_blocks[1]),
                            });
 
         target_blocks

--- a/src/librustc_mir/transform/simplify_cfg.rs
+++ b/src/librustc_mir/transform/simplify_cfg.rs
@@ -96,9 +96,9 @@ impl SimplifyCfg {
             mem::swap(&mut terminator, &mut mir.basic_block_data_mut(bb).terminator);
 
             mir.basic_block_data_mut(bb).terminator = match terminator {
-                Terminator::If { ref targets, .. } if targets[0] == targets[1] => {
+                Terminator::If { ref targets, .. } if targets.0 == targets.1 => {
                     changed = true;
-                    Terminator::Goto { target: targets[0] }
+                    Terminator::Goto { target: targets.0 }
                 }
                 Terminator::If { ref targets, cond: Operand::Constant(Constant {
                     literal: Literal::Value {
@@ -106,8 +106,11 @@ impl SimplifyCfg {
                     }, ..
                 }) } => {
                     changed = true;
-                    let target_idx = if cond { 0 } else { 1 };
-                    Terminator::Goto { target: targets[target_idx] }
+                    if cond {
+                        Terminator::Goto { target: targets.0 }
+                    } else {
+                        Terminator::Goto { target: targets.1 }
+                    }
                 }
                 Terminator::SwitchInt { ref targets, .. }  if targets.len() == 1 => {
                     Terminator::Goto { target: targets[0] }

--- a/src/librustc_trans/trans/mir/block.rs
+++ b/src/librustc_trans/trans/mir/block.rs
@@ -39,7 +39,7 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                 unimplemented!()
             }
 
-            mir::Terminator::If { ref cond, targets: [true_bb, false_bb] } => {
+            mir::Terminator::If { ref cond, targets: (true_bb, false_bb) } => {
                 let cond = self.trans_operand(bcx, cond);
                 let lltrue = self.llblock(true_bb);
                 let llfalse = self.llblock(false_bb);

--- a/src/librustc_trans/trans/mir/rvalue.rs
+++ b/src/librustc_trans/trans/mir/rvalue.rs
@@ -120,7 +120,7 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                 bcx
             }
 
-            mir::Rvalue::InlineAsm(inline_asm) => {
+            mir::Rvalue::InlineAsm(ref inline_asm) => {
                 asm::trans_inline_asm(bcx, inline_asm)
             }
 


### PR DESCRIPTION
This PR makes `Mir` `RustcEncodable` and `RustcDecodable` and stores it in crate metadata for inlinable items. 

Some other things in here:
- `mir::visit::Visitor` is extended to also visit `Literals`, `Spans` and `DefIds`.
- It also adds `mir::visit::MutVisitor` which allows to mutate the visited `Mir` structure in place.
- Some numbers on how big MIR is in metadata (total metadata size in bytes):

|  | w/ MIR | w/o MIR | Rel. Size |
| --- | --: | --: | :-: |
| libcore | 17,695,473 | 14,263,377 | 124% |
| liblibc | 411,440 | 404,382 | 102% |
| libcollections | 4,537,975 | 3,526,933 | 129% |
| libserialize | 2,574,769 | 2,060,798 | 125% |
| libsyntax | 15,262,894 | 12,075,574 | 126% |
| librustc | 16,984,537 | 13,692,168 | 124% |

So, adding MIR to metadata makes it about 25% bigger. It could be worse, considering that it still uses the inefficient RBML encoding. Still, the question is whether we should put MIR emission behind a `-Z` flag.
