### PR TITLE
Add name of initializer to missing field message, closes #30299

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3156,12 +3156,13 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
             !remaining_fields.is_empty()
         {
             span_err!(tcx.sess, span, E0063,
-                      "missing field{}: {}",
+                      "missing field{} {} in initializer of `{}`",
                       if remaining_fields.len() == 1 {""} else {"s"},
                       remaining_fields.keys()
                                       .map(|n| format!("`{}`", n))
                                       .collect::<Vec<_>>()
-                                      .join(", "));
+                                      .join(", "),
+                      adt_ty);
         }
 
     }

--- a/src/test/compile-fail/struct-fields-missing.rs
+++ b/src/test/compile-fail/struct-fields-missing.rs
@@ -15,7 +15,7 @@ struct BuildData {
 }
 
 fn main() {
-    let foo = BuildData { //~ ERROR missing field: `bar`
+    let foo = BuildData { //~ ERROR missing field `bar` in initializer of `BuildData`
         foo: 0
     };
 }


### PR DESCRIPTION
This PR for #30299 adds the name of the type where the field is missing. 

The span that's used for the error seems correct. What may be confusing is when the initializer with the missing field contains other intializers. These are then included in the span. For example, consider the following listing.

```
struct A {
    a1: i32,
    a2: B,
}

struct B {
    b1: i32,
    b2: i32
}

fn main() {
    let x = A {
        a2: B {
            b1: 1,
            b2: 1
        },
    };
}
```

It will display the following code snippet along with the message that field `a2` is missing:

```
    let x = A {
        a2: B {
            b1: 1,
            b2: 1
        },
    };
```

By adding the name of the type it's clearer where the field is missing.
