### PR TITLE
Undo the backwards incompatable part of the fix for issue #30159 in PR #30294.

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -871,6 +871,9 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
                             is_public: is_public
                         };
                     }
+                } else {
+                    // FIXME #30159: This is required for backwards compatability.
+                    dest_import_resolution[namespace].is_public |= is_public;
                 }
             };
             merge_child_item(ValueNS);

--- a/src/test/compile-fail/shadowed-use-visibility.rs
+++ b/src/test/compile-fail/shadowed-use-visibility.rs
@@ -17,10 +17,6 @@ mod foo {
 
 mod bar {
     use foo::bar::f as g; //~ ERROR unresolved import
-
-    use foo as f;
-    pub use foo::*;
 }
 
-use bar::f::f; //~ ERROR unresolved import
 fn main() {}


### PR DESCRIPTION
r? @nrc 
Since PR #30294 unintentionally fixed issue #30159, it can cause breakage for a different reason than I originally stated in the PR (see #30159, I characterized the issue precisely there).

This commit limits the scope of the breakage to what I originally stated in the PR by "unfixing" the backwards incompatible part of #30159.

I think fixing #30159 has enough potential for breakage to warrant a crater run. If you disagree, I can cancel this PR, leaving it fixed.
