### PR TITLE
Include type name in symbol for methods

### DIFF
--- a/src/librustc/front/map/collector.rs
+++ b/src/librustc/front/map/collector.rs
@@ -122,7 +122,7 @@ impl<'ast> Visitor<'ast> for NodeCollector<'ast> {
         // Pick the def data. This need not be unique, but the more
         // information we encapsulate into
         let def_data = match i.node {
-            ItemDefaultImpl(..) | ItemImpl(..) => DefPathData::Impl,
+            ItemDefaultImpl(..) | ItemImpl(..) => DefPathData::Impl(i.name),
             ItemEnum(..) | ItemStruct(..) | ItemTrait(..) => DefPathData::Type(i.name),
             ItemExternCrate(..) | ItemMod(..) => DefPathData::Mod(i.name),
             ItemStatic(..) | ItemConst(..) | ItemFn(..) => DefPathData::Value(i.name),

--- a/src/librustc/front/map/definitions.rs
+++ b/src/librustc/front/map/definitions.rs
@@ -73,7 +73,7 @@ pub enum DefPathData {
     Misc,
 
     // Different kinds of items and item-like things:
-    Impl,
+    Impl(ast::Name),
     Type(ast::Name),
     Mod(ast::Name),
     Value(ast::Name),
@@ -177,6 +177,7 @@ impl DefPathData {
     pub fn as_interned_str(&self) -> InternedString {
         use self::DefPathData::*;
         match *self {
+            Impl(name) |
             Type(name) |
             Mod(name) |
             Value(name) |
@@ -210,10 +211,6 @@ impl DefPathData {
 
             Misc => {
                 InternedString::new("?")
-            }
-
-            Impl => {
-                InternedString::new("<impl>")
             }
 
             ClosureExpr => {

--- a/src/test/run-make/symbols-include-type-name/Makefile
+++ b/src/test/run-make/symbols-include-type-name/Makefile
@@ -1,0 +1,9 @@
+-include ../tools.mk
+
+# Check that symbol names for methods include type names, instead of <impl>.
+
+OUT=$(TMPDIR)/lib.s
+
+all:
+	$(RUSTC) --crate-type staticlib --emit asm lib.rs
+	grep Def $(OUT)

--- a/src/test/run-make/symbols-include-type-name/lib.rs
+++ b/src/test/run-make/symbols-include-type-name/lib.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub struct Def {
+    pub id: i32,
+}
+
+impl Def {
+    pub fn new(id: i32) -> Def {
+        Def { id: id }
+    }
+}


### PR DESCRIPTION
Fix #30260.
