### PR TITLE
book: Add missing punctuation

### DIFF
--- a/src/doc/book/testing.md
+++ b/src/doc/book/testing.md
@@ -503,7 +503,7 @@ for the function test. These will auto increment with names like `add_two_1` as
 you add more examples.
 
 We haven’t covered all of the details with writing documentation tests. For more,
-please see the [Documentation chapter](documentation.html)
+please see the [Documentation chapter](documentation.html).
 
 One final note: documentation tests *cannot* be run on binary crates.
 To see more on file arrangement see the [Crates and


### PR DESCRIPTION
Missing period at the end of a sentence.
