### PR TITLE
Ensure borrows of fn/closure params do not outlive invocations

### DIFF
--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -148,6 +148,9 @@ impl<'tcx> ty::ctxt<'tcx> {
                 };
                 let scope_decorated_tag = match self.region_maps.code_extent_data(scope) {
                     region::CodeExtentData::Misc(_) => tag,
+                    region::CodeExtentData::CallSiteScope { .. } => {
+                        "scope of call-site for function"
+                    }
                     region::CodeExtentData::ParameterScope { .. } => {
                         "scope of parameters for function"
                     }

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1466,10 +1466,11 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
                  entry_ln: LiveNode,
                  body: &hir::Block)
     {
-        // within the fn body, late-bound regions are liberated:
+        // within the fn body, late-bound regions are liberated
+        // and must outlive the *call-site* of the function.
         let fn_ret =
             self.ir.tcx.liberate_late_bound_regions(
-                self.ir.tcx.region_maps.item_extent(body.id),
+                self.ir.tcx.region_maps.call_site_extent(id, body.id),
                 &self.fn_ret(id));
 
         match fn_ret {

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -42,7 +42,7 @@ pub enum DefRegion {
                         /* lifetime decl */ ast::NodeId),
     DefLateBoundRegion(ty::DebruijnIndex,
                        /* lifetime decl */ ast::NodeId),
-    DefFreeRegion(/* block scope */ region::DestructionScopeData,
+    DefFreeRegion(region::CallSiteScopeData,
                   /* lifetime decl */ ast::NodeId),
 }
 
@@ -83,9 +83,9 @@ enum ScopeChain<'a> {
     /// LateScope(['a, 'b, ...], s) extends s with late-bound
     /// lifetimes introduced by the declaration binder_id.
     LateScope(&'a Vec<hir::LifetimeDef>, Scope<'a>),
-    /// lifetimes introduced by items within a code block are scoped
-    /// to that block.
-    BlockScope(region::DestructionScopeData, Scope<'a>),
+
+    /// lifetimes introduced by a fn are scoped to the call-site for that fn.
+    FnScope { fn_id: ast::NodeId, body_id: ast::NodeId, s: Scope<'a> },
     RootScope
 }
 
@@ -172,20 +172,20 @@ impl<'a, 'v> Visitor<'v> for LifetimeContext<'a> {
     }
 
     fn visit_fn(&mut self, fk: FnKind<'v>, fd: &'v hir::FnDecl,
-                b: &'v hir::Block, s: Span, _: ast::NodeId) {
+                b: &'v hir::Block, s: Span, fn_id: ast::NodeId) {
         match fk {
             FnKind::ItemFn(_, generics, _, _, _, _) => {
                 self.visit_early_late(subst::FnSpace, generics, |this| {
-                    this.walk_fn(fk, fd, b, s)
+                    this.add_scope_and_walk_fn(fk, fd, b, s, fn_id)
                 })
             }
             FnKind::Method(_, sig, _) => {
                 self.visit_early_late(subst::FnSpace, &sig.generics, |this| {
-                    this.walk_fn(fk, fd, b, s)
+                    this.add_scope_and_walk_fn(fk, fd, b, s, fn_id)
                 })
             }
             FnKind::Closure => {
-                self.walk_fn(fk, fd, b, s)
+                self.add_scope_and_walk_fn(fk, fd, b, s, fn_id)
             }
         }
     }
@@ -234,12 +234,6 @@ impl<'a, 'v> Visitor<'v> for LifetimeContext<'a> {
         }
 
         replace(&mut self.labels_in_fn, saved);
-    }
-
-    fn visit_block(&mut self, b: &hir::Block) {
-        self.with(BlockScope(region::DestructionScopeData::new(b.id),
-                             self.scope),
-                  |_, this| intravisit::walk_block(this, b));
     }
 
     fn visit_lifetime(&mut self, lifetime_ref: &hir::Lifetime) {
@@ -437,7 +431,7 @@ fn extract_labels<'v, 'a>(ctxt: &mut LifetimeContext<'a>, b: &'v hir::Block) {
                                            label_span: Span) {
         loop {
             match *scope {
-                BlockScope(_, s) => { scope = s; }
+                FnScope { s, .. } => { scope = s; }
                 RootScope => { return; }
 
                 EarlyScope(_, lifetimes, s) |
@@ -461,14 +455,13 @@ fn extract_labels<'v, 'a>(ctxt: &mut LifetimeContext<'a>, b: &'v hir::Block) {
 }
 
 impl<'a> LifetimeContext<'a> {
-    // This is just like intravisit::walk_fn, except that it extracts the
-    // labels of the function body and swaps them in before visiting
-    // the function body itself.
-    fn walk_fn<'b>(&mut self,
-                   fk: FnKind,
-                   fd: &hir::FnDecl,
-                   fb: &'b hir::Block,
-                   _span: Span) {
+    fn add_scope_and_walk_fn<'b>(&mut self,
+                                 fk: FnKind,
+                                 fd: &hir::FnDecl,
+                                 fb: &'b hir::Block,
+                                 _span: Span,
+                                 fn_id: ast::NodeId) {
+
         match fk {
             FnKind::ItemFn(_, generics, _, _, _, _) => {
                 intravisit::walk_fn_decl(self, fd);
@@ -488,7 +481,8 @@ impl<'a> LifetimeContext<'a> {
         // `self.labels_in_fn`.
         extract_labels(self, fb);
 
-        self.visit_block(fb);
+        self.with(FnScope { fn_id: fn_id, body_id: fb.id, s: self.scope },
+                  |_old_scope, this| this.visit_block(fb))
     }
 
     fn with<F>(&mut self, wrap_scope: ScopeChain, f: F) where
@@ -559,8 +553,11 @@ impl<'a> LifetimeContext<'a> {
         let mut scope = self.scope;
         loop {
             match *scope {
-                BlockScope(blk_scope, s) => {
-                    return self.resolve_free_lifetime_ref(blk_scope, lifetime_ref, s);
+                FnScope {fn_id, body_id, s } => {
+                    return self.resolve_free_lifetime_ref(
+                        region::CallSiteScopeData { fn_id: fn_id, body_id: body_id },
+                        lifetime_ref,
+                        s);
                 }
 
                 RootScope => {
@@ -604,7 +601,7 @@ impl<'a> LifetimeContext<'a> {
     }
 
     fn resolve_free_lifetime_ref(&mut self,
-                                 scope_data: region::DestructionScopeData,
+                                 scope_data: region::CallSiteScopeData,
                                  lifetime_ref: &hir::Lifetime,
                                  scope: Scope) {
         debug!("resolve_free_lifetime_ref \
@@ -622,8 +619,10 @@ impl<'a> LifetimeContext<'a> {
                     scope_data: {:?} scope: {:?} search_result: {:?}",
                    scope_data, scope, search_result);
             match *scope {
-                BlockScope(blk_scope_data, s) => {
-                    scope_data = blk_scope_data;
+                FnScope { fn_id, body_id, s } => {
+                    scope_data = region::CallSiteScopeData {
+                        fn_id: fn_id, body_id: body_id
+                    };
                     scope = s;
                 }
 
@@ -711,7 +710,7 @@ impl<'a> LifetimeContext<'a> {
 
         loop {
             match *old_scope {
-                BlockScope(_, s) => {
+                FnScope { s, .. } => {
                     old_scope = s;
                 }
 
@@ -864,7 +863,7 @@ impl<'a> fmt::Debug for ScopeChain<'a> {
         match *self {
             EarlyScope(space, defs, _) => write!(fmt, "EarlyScope({:?}, {:?})", space, defs),
             LateScope(defs, _) => write!(fmt, "LateScope({:?})", defs),
-            BlockScope(id, _) => write!(fmt, "BlockScope({:?})", id),
+            FnScope { fn_id, body_id, s: _ } => write!(fmt, "FnScope({:?}, {:?})", fn_id, body_id),
             RootScope => write!(fmt, "RootScope"),
         }
     }

--- a/src/librustc/middle/traits/object_safety.rs
+++ b/src/librustc/middle/traits/object_safety.rs
@@ -192,7 +192,8 @@ fn generics_require_sized_self<'tcx>(tcx: &ty::ctxt<'tcx>,
     };
 
     // Search for a predicate like `Self : Sized` amongst the trait bounds.
-    let free_substs = tcx.construct_free_substs(generics, ast::DUMMY_NODE_ID);
+    let free_substs = tcx.construct_free_substs(generics,
+                                                tcx.region_maps.node_extent(ast::DUMMY_NODE_ID));
     let predicates = predicates.instantiate(tcx, &free_substs).predicates.into_vec();
     elaborate_predicates(tcx, predicates)
         .any(|predicate| {

--- a/src/librustc/middle/ty/structural_impls.rs
+++ b/src/librustc/middle/ty/structural_impls.rs
@@ -823,7 +823,7 @@ impl<'a, 'tcx> TypeFoldable<'tcx> for ty::ParameterEnvironment<'a, 'tcx> where '
             caller_bounds: self.caller_bounds.fold_with(folder),
             selection_cache: traits::SelectionCache::new(),
             evaluation_cache: traits::EvaluationCache::new(),
-            free_id: self.free_id,
+            free_id_outlive: self.free_id_outlive,
         }
     }
 }

--- a/src/librustc_metadata/tydecode.rs
+++ b/src/librustc_metadata/tydecode.rs
@@ -233,6 +233,17 @@ impl<'a,'tcx> TyDecoder<'a,'tcx> {
             // doesn't care about regions.
             //
             // May still be worth fixing though.
+            'C' => {
+                assert_eq!(self.next(), '[');
+                let fn_id = self.parse_uint() as ast::NodeId;
+                assert_eq!(self.next(), '|');
+                let body_id = self.parse_uint() as ast::NodeId;
+                assert_eq!(self.next(), ']');
+                region::CodeExtentData::CallSiteScope {
+                    fn_id: fn_id, body_id: body_id
+                }
+            }
+            // This creates scopes with the wrong NodeId. (See note above.)
             'P' => {
                 assert_eq!(self.next(), '[');
                 let fn_id = self.parse_uint() as ast::NodeId;

--- a/src/librustc_metadata/tyencode.rs
+++ b/src/librustc_metadata/tyencode.rs
@@ -286,6 +286,8 @@ pub fn enc_region(w: &mut Encoder, cx: &ctxt, r: ty::Region) {
 
 fn enc_scope(w: &mut Encoder, cx: &ctxt, scope: region::CodeExtent) {
     match cx.tcx.region_maps.code_extent_data(scope) {
+        region::CodeExtentData::CallSiteScope {
+            fn_id, body_id } => mywrite!(w, "C[{}|{}]", fn_id, body_id),
         region::CodeExtentData::ParameterScope {
             fn_id, body_id } => mywrite!(w, "P[{}|{}]", fn_id, body_id),
         region::CodeExtentData::Misc(node_id) => mywrite!(w, "M{}", node_id),

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -181,7 +181,7 @@ pub fn ast_region_to_region(tcx: &ty::ctxt, lifetime: &hir::Lifetime)
 
         Some(&rl::DefFreeRegion(scope, id)) => {
             ty::ReFree(ty::FreeRegion {
-                    scope: tcx.region_maps.item_extent(scope.node_id),
+                    scope: scope.to_code_extent(&tcx.region_maps),
                     bound_region: ty::BrNamed(tcx.map.local_def_id(id),
                                               lifetime.name)
                 })

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -75,7 +75,7 @@ fn check_closure<'a,'tcx>(fcx: &FnCtxt<'a,'tcx>,
     fcx.write_ty(expr.id, closure_type);
 
     let fn_sig = fcx.tcx().liberate_late_bound_regions(
-        fcx.tcx().region_maps.item_extent(body.id), &fn_ty.sig);
+        fcx.tcx().region_maps.call_site_extent(expr.id, body.id), &fn_ty.sig);
 
     check_fn(fcx.ccx,
              hir::Unsafety::Normal,

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -456,7 +456,7 @@ fn check_bare_fn<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
             let inh = Inherited::new(ccx.tcx, &tables, param_env);
 
             // Compute the fty from point of view of inside fn.
-            let fn_scope = ccx.tcx.region_maps.item_extent(body.id);
+            let fn_scope = ccx.tcx.region_maps.call_site_extent(fn_id, body.id);
             let fn_sig =
                 fn_ty.sig.subst(ccx.tcx, &inh.infcx.parameter_environment.free_substs);
             let fn_sig =

--- a/src/librustc_typeck/check/wf.rs
+++ b/src/librustc_typeck/check/wf.rs
@@ -137,10 +137,11 @@ impl<'ccx, 'tcx> CheckTypeWellFormedVisitor<'ccx, 'tcx> {
         let type_scheme = ccx.tcx.lookup_item_type(item_def_id);
         let type_predicates = ccx.tcx.lookup_predicates(item_def_id);
         reject_non_type_param_bounds(ccx.tcx, item.span, &type_predicates);
+        let free_id_outlive = ccx.tcx.region_maps.item_extent(item.id);
         let param_env = ccx.tcx.construct_parameter_environment(item.span,
                                                                 &type_scheme.generics,
                                                                 &type_predicates,
-                                                                item.id);
+                                                                free_id_outlive);
         let tables = RefCell::new(ty::Tables::empty());
         let inh = Inherited::new(ccx.tcx, &tables, param_env);
         let fcx = blank_fn_ctxt(ccx, &inh, ty::FnConverging(type_scheme.ty), item.id);

--- a/src/test/compile-fail/region-borrow-params-issue-29793-big.rs
+++ b/src/test/compile-fail/region-borrow-params-issue-29793-big.rs
@@ -1,0 +1,84 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #29793, big regression test: do not let borrows of
+// parameters to ever be returned (expanded with exploration of
+// variations).
+//
+// This is the version of the test that actually exposed unsound
+// behavior (because the improperly accepted closure was actually
+// able to be invoked).
+
+struct WrapA<F>(Option<F>);
+
+impl<F> WrapA<F> {
+    fn new() -> WrapA<F> {
+        WrapA(None)
+    }
+    fn set(mut self, f: F) -> Self {
+        self.0 = Some(f);
+        self
+    }
+}
+
+struct WrapB<F>(Option<F>);
+
+impl<F> WrapB<F> {
+    fn new() -> WrapB<F> {
+        WrapB(None)
+    }
+    fn set(mut self, f: F) -> Self {
+        self.0 = Some(f);
+        self
+    }
+}
+
+trait DoStuff : Sized {
+    fn handle(self);
+}
+
+impl<F, T> DoStuff for WrapA<F>
+    where F: FnMut(usize, usize) -> T, T: DoStuff {
+        fn handle(mut self) {
+            if let Some(ref mut f) = self.0 {
+                let x = f(1, 2);
+                let _foo = [0usize; 16];
+                x.handle();
+            }
+        }
+    }
+
+impl<F> DoStuff for WrapB<F> where F: FnMut(bool) -> usize {
+    fn handle(mut self) {
+        if let Some(ref mut f) = self.0 {
+            println!("{}", f(true));
+        }
+    }
+}
+
+impl<F, T> WrapA<F>
+    where F: FnMut(usize, usize) -> T, T: DoStuff {
+        fn handle_ref(&mut self) {
+            if let Some(ref mut f) = self.0 {
+                let x = f(1, 2);
+            }
+        }
+    }
+
+fn main() {
+    let mut w = WrapA::new().set(|x: usize, y: usize| {
+        WrapB::new().set(|t: bool| if t { x } else { y }) // (separate errors for `x` vs `y`)
+            //~^ ERROR `x` does not live long enough
+            //~| ERROR `y` does not live long enough
+    });
+
+    w.handle(); // This works
+    // w.handle_ref(); // This doesn't
+}

--- a/src/test/compile-fail/region-borrow-params-issue-29793-small.rs
+++ b/src/test/compile-fail/region-borrow-params-issue-29793-small.rs
@@ -1,0 +1,223 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #29793, small regression tests: do not let borrows of
+// parameters to ever be returned (expanded with exploration of
+// variations).
+
+// CLOSURES
+
+fn escaping_borrow_of_closure_params_1() {
+    let g = |x: usize, y:usize| {
+        let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+        //~^ ERROR `x` does not live long enough
+        //~| ERROR `y` does not live long enough
+        return f;
+    };
+
+    // We delberately do not call `g`; this small version of the test,
+    // after adding such a call, was (properly) rejected even when the
+    // system still suffered from issue #29793.
+
+    // g(10, 20)(true);
+}
+
+fn escaping_borrow_of_closure_params_2() {
+    let g = |x: usize, y:usize| {
+        let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+        //~^ ERROR `x` does not live long enough
+        //~| ERROR `y` does not live long enough
+        f
+    };
+
+    // (we don't call `g`; see above)
+}
+
+fn move_of_closure_params() {
+    let g = |x: usize, y:usize| {
+        let f = move |t: bool| if t { x } else { y };
+        f;
+    };
+    // (this code is fine, so lets go ahead and ensure rustc accepts call of `g`)
+    (g(1,2));
+}
+
+fn ok_borrow_of_fn_params(a: usize, b:usize) {
+    let g = |x: usize, y:usize| {
+        let f = |t: bool| if t { a } else { b };
+        return f;
+    };
+    // (this code is fine, so lets go ahead and ensure rustc accepts call of `g`)
+    (g(1,2))(true);
+}
+
+// TOP-LEVEL FN'S
+
+fn escaping_borrow_of_fn_params_1() {
+    fn g<'a>(x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+        let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+        //~^ ERROR E0373
+        //~| ERROR E0373
+        return Box::new(f);
+    };
+
+    // (we don't call `g`; see above)
+}
+
+fn escaping_borrow_of_fn_params_2() {
+    fn g<'a>(x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+        let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+        //~^ ERROR E0373
+        //~| ERROR E0373
+        Box::new(f)
+    };
+
+    // (we don't call `g`; see above)
+}
+
+fn move_of_fn_params() {
+    fn g<'a>(x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+        let f = move |t: bool| if t { x } else { y };
+        return Box::new(f);
+    };
+    // (this code is fine, so lets go ahead and ensure rustc accepts call of `g`)
+    (g(1,2))(true);
+}
+
+// INHERENT METHODS
+
+fn escaping_borrow_of_method_params_1() {
+    struct S;
+    impl S {
+        fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+            let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+            //~^ ERROR E0373
+            //~| ERROR E0373
+            return Box::new(f);
+        }
+    }
+
+    // (we don't call `g`; see above)
+}
+
+fn escaping_borrow_of_method_params_2() {
+    struct S;
+    impl S {
+        fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+            let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+            //~^ ERROR E0373
+            //~| ERROR E0373
+            Box::new(f)
+        }
+    }
+    // (we don't call `g`; see above)
+}
+
+fn move_of_method_params() {
+    struct S;
+    impl S {
+        fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+            let f = move |t: bool| if t { x } else { y };
+            return Box::new(f);
+        }
+    }
+    // (this code is fine, so lets go ahead and ensure rustc accepts call of `g`)
+    (S.g(1,2))(true);
+}
+
+// TRAIT IMPL METHODS
+
+fn escaping_borrow_of_trait_impl_params_1() {
+    trait T { fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a>; }
+    struct S;
+    impl T for S {
+        fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+            let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+            //~^ ERROR E0373
+            //~| ERROR E0373
+            return Box::new(f);
+        }
+    }
+
+    // (we don't call `g`; see above)
+}
+
+fn escaping_borrow_of_trait_impl_params_2() {
+    trait T { fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a>; }
+    struct S;
+    impl T for S {
+        fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+            let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+            //~^ ERROR E0373
+            //~| ERROR E0373
+            Box::new(f)
+        }
+    }
+    // (we don't call `g`; see above)
+}
+
+fn move_of_trait_impl_params() {
+    trait T { fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a>; }
+    struct S;
+    impl T for S {
+        fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+            let f = move |t: bool| if t { x } else { y };
+            return Box::new(f);
+        }
+    }
+    // (this code is fine, so lets go ahead and ensure rustc accepts call of `g`)
+    (S.g(1,2))(true);
+}
+
+// TRAIT DEFAULT METHODS
+
+fn escaping_borrow_of_trait_default_params_1() {
+    struct S;
+    trait T {
+        fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+            let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+            //~^ ERROR E0373
+            //~| ERROR E0373
+            return Box::new(f);
+        }
+    }
+    impl T for S {}
+    // (we don't call `g`; see above)
+}
+
+fn escaping_borrow_of_trait_default_params_2() {
+    struct S;
+    trait T {
+        fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+            let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
+            //~^ ERROR E0373
+            //~| ERROR E0373
+            Box::new(f)
+        }
+    }
+    impl T for S {}
+    // (we don't call `g`; see above)
+}
+
+fn move_of_trait_default_params() {
+    struct S;
+    trait T {
+        fn g<'a>(&self, x: usize, y:usize) -> Box<Fn(bool) -> usize + 'a> {
+            let f = move |t: bool| if t { x } else { y };
+            return Box::new(f);
+        }
+    }
+    impl T for S {}
+    // (this code is fine, so lets go ahead and ensure rustc accepts call of `g`)
+    (S.g(1,2))(true);
+}
+
+fn main() { }
+


### PR DESCRIPTION
Ensure borrows of fn/closure params do not outlive invocations.

Does this by adding a new CallSiteScope to the region (or rather code extent) hierarchy, which outlives even the ParameterScope (which in turn outlives the DestructionScope of a fn/closure's body).

Fix #29793 

r? @nikomatsakis 
