### PR TITLE
Fix MIN, MAX links in std docs

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -76,7 +76,7 @@
 //! `i32`](primitive.i32.html) that lists all the methods that can be called on
 //! 32-bit integers (very useful), and there is a [page for the module
 //! `std::i32`](i32/index.html) that documents the constant values [`MIN`] and
-//! [`MAX`](i32/constant.MAX.html) (rarely useful).
+//! [`MAX`] (rarely useful).
 //!
 //! Note the documentation for the primitives [`str`] and [`[T]`][slice] (also
 //! called 'slice'). Many method calls on [`String`] and [`Vec<T>`] are actually
@@ -152,7 +152,8 @@
 //! [`mpsc`], which contains the channel types for message passing.
 //!
 //! [I/O]: io/index.html
-//! [MIN]: i32/constant.MIN.html
+//! [`MIN`]: i32/constant.MIN.html
+//! [`MAX`]: i32/constant.MAX.html
 //! [TCP]: net/struct.TcpStream.html
 //! [The Rust Prelude]: prelude/index.html
 //! [UDP]: net/struct.UdpSocket.html


### PR DESCRIPTION
The `MIN` link was broken. Reverts #29624.
