### PR TITLE
A collection of minor cleanups in dec2flt

### DIFF
--- a/src/libcore/num/dec2flt/mod.rs
+++ b/src/libcore/num/dec2flt/mod.rs
@@ -109,7 +109,7 @@ pub mod rawfp;
 pub mod parse;
 
 macro_rules! from_str_float_impl {
-    ($t:ty, $func:ident) => {
+    ($t:ty) => {
         #[stable(feature = "rust1", since = "1.0.0")]
         impl FromStr for $t {
             type Err = ParseFloatError;
@@ -146,8 +146,8 @@ macro_rules! from_str_float_impl {
         }
     }
 }
-from_str_float_impl!(f32, to_f32);
-from_str_float_impl!(f64, to_f64);
+from_str_float_impl!(f32);
+from_str_float_impl!(f64);
 
 /// An error which can be returned when parsing a float.
 #[derive(Debug, Clone, PartialEq)]

--- a/src/libcore/num/dec2flt/mod.rs
+++ b/src/libcore/num/dec2flt/mod.rs
@@ -97,7 +97,7 @@ use fmt;
 use str::FromStr;
 
 use self::parse::{parse_decimal, Decimal, Sign};
-use self::parse::ParseResult::{self, Valid, ShortcutToInf, ShortcutToZero};
+use self::parse::ParseResult::{Valid, Invalid, ShortcutToInf, ShortcutToZero};
 use self::num::digits_to_big;
 use self::rawfp::RawFloat;
 
@@ -183,11 +183,11 @@ impl fmt::Display for ParseFloatError {
     }
 }
 
-pub fn pfe_empty() -> ParseFloatError {
+fn pfe_empty() -> ParseFloatError {
     ParseFloatError { kind: FloatErrorKind::Empty }
 }
 
-pub fn pfe_invalid() -> ParseFloatError {
+fn pfe_invalid() -> ParseFloatError {
     ParseFloatError { kind: FloatErrorKind::Invalid }
 }
 
@@ -211,7 +211,7 @@ fn dec2flt<T: RawFloat>(s: &str) -> Result<T, ParseFloatError> {
         Valid(decimal) => try!(convert(decimal)),
         ShortcutToInf => T::infinity(),
         ShortcutToZero => T::zero(),
-        ParseResult::Invalid => match s {
+        Invalid => match s {
             "inf" => T::infinity(),
             "NaN" => T::nan(),
             _ => { return Err(pfe_invalid()); }

--- a/src/libcore/num/dec2flt/rawfp.rs
+++ b/src/libcore/num/dec2flt/rawfp.rs
@@ -288,7 +288,7 @@ pub fn encode_normal<T: RawFloat>(x: Unpacked) -> T {
 /// Construct the subnormal. A mantissa of 0 is allowed and constructs zero.
 pub fn encode_subnormal<T: RawFloat>(significand: u64) -> T {
     assert!(significand < T::min_sig(), "encode_subnormal: not actually subnormal");
-    // Êncoded exponent is 0, the sign bit is 0, so we just have to reinterpret the bits.
+    // Encoded exponent is 0, the sign bit is 0, so we just have to reinterpret the bits.
     T::from_bits(significand)
 }
 


### PR DESCRIPTION
The landing of #30182, specifically the removal of float `from_str_radix`, allowed the refactoring in the middle commit. While I was at it, I also crossed two other nits off my TODO list.
