### PR TITLE
rustc: Remove def::DefUse

### DIFF
--- a/src/librustc/middle/def.rs
+++ b/src/librustc/middle/def.rs
@@ -35,7 +35,6 @@ pub enum Def {
     DefTrait(DefId),
     DefPrimTy(hir::PrimTy),
     DefTyParam(ParamSpace, u32, DefId, ast::Name),
-    DefUse(DefId),
     DefUpvar(DefId,        // def id of closed over local
              ast::NodeId,  // node id of closed over local
              usize,        // index in the freevars list of the closure
@@ -123,7 +122,7 @@ impl Def {
 
             DefFn(..) | DefMod(..) | DefForeignMod(..) | DefStatic(..) |
             DefVariant(..) | DefTy(..) | DefAssociatedTy(..) |
-            DefTyParam(..) | DefUse(..) | DefStruct(..) | DefTrait(..) |
+            DefTyParam(..) | DefStruct(..) | DefTrait(..) |
             DefMethod(..) | DefConst(..) | DefAssociatedConst(..) |
             DefPrimTy(..) | DefLabel(..) | DefSelfTy(..) | DefErr => {
                 panic!("attempted .def_id() on invalid {:?}", self)
@@ -135,7 +134,7 @@ impl Def {
         match *self {
             DefFn(id, _) | DefMod(id) | DefForeignMod(id) | DefStatic(id, _) |
             DefVariant(_, id, _) | DefTy(id, _) | DefAssociatedTy(_, id) |
-            DefTyParam(_, _, id, _) | DefUse(id) | DefStruct(id) | DefTrait(id) |
+            DefTyParam(_, _, id, _) | DefStruct(id) | DefTrait(id) |
             DefMethod(id) | DefConst(id) | DefAssociatedConst(id) |
             DefLocal(id, _) | DefUpvar(id, _, _, _) => {
                 id

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -548,7 +548,7 @@ impl<'t, 'a,'tcx> MemCategorizationContext<'t, 'a, 'tcx> {
           def::DefAssociatedConst(..) | def::DefFn(..) | def::DefMethod(..) => {
                 Ok(self.cat_rvalue_node(id, span, expr_ty))
           }
-          def::DefMod(_) | def::DefForeignMod(_) | def::DefUse(_) |
+          def::DefMod(_) | def::DefForeignMod(_) |
           def::DefTrait(_) | def::DefTy(..) | def::DefPrimTy(_) |
           def::DefTyParam(..) |
           def::DefLabel(_) | def::DefSelfTy(..) |

--- a/src/librustc_metadata/astencode.rs
+++ b/src/librustc_metadata/astencode.rs
@@ -399,7 +399,6 @@ impl tr for def::Def {
               def::DefAssociatedTy(trait_did.tr(dcx), did.tr(dcx)),
           def::DefPrimTy(p) => def::DefPrimTy(p),
           def::DefTyParam(s, index, def_id, n) => def::DefTyParam(s, index, def_id.tr(dcx), n),
-          def::DefUse(did) => def::DefUse(did.tr(dcx)),
           def::DefUpvar(_, nid1, index, nid2) => {
               let nid1 = dcx.tr_id(nid1);
               let nid2 = dcx.tr_id(nid2);

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -706,7 +706,6 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
             DefLocal(..) |
             DefPrimTy(..) |
             DefTyParam(..) |
-            DefUse(..) |
             DefUpvar(..) |
             DefLabel(..) |
             DefSelfTy(..) |

--- a/src/librustc_trans/save/dump_csv.rs
+++ b/src/librustc_trans/save/dump_csv.rs
@@ -274,7 +274,6 @@ impl <'l, 'tcx> DumpCsvVisitor<'l, 'tcx> {
             def::DefSelfTy(..) |
             def::DefLabel(_) |
             def::DefTyParam(..) |
-            def::DefUse(_) |
             def::DefMethod(..) |
             def::DefPrimTy(_) |
             def::DefErr => {

--- a/src/librustc_trans/trans/callee.rs
+++ b/src/librustc_trans/trans/callee.rs
@@ -215,7 +215,7 @@ fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, expr: &hir::Expr)
             }
             def::DefMod(..) | def::DefForeignMod(..) | def::DefTrait(..) |
             def::DefTy(..) | def::DefPrimTy(..) | def::DefAssociatedTy(..) |
-            def::DefUse(..) | def::DefLabel(..) | def::DefTyParam(..) |
+            def::DefLabel(..) | def::DefTyParam(..) |
             def::DefSelfTy(..) | def::DefErr => {
                 bcx.tcx().sess.span_bug(
                     ref_expr.span,

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4327,7 +4327,6 @@ fn type_scheme_and_predicates_for_def<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
         def::DefTyParam(..) |
         def::DefMod(..) |
         def::DefForeignMod(..) |
-        def::DefUse(..) |
         def::DefLabel(..) |
         def::DefSelfTy(..) |
         def::DefErr => {
@@ -4498,7 +4497,6 @@ pub fn instantiate_path<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
         def::DefMod(..) |
         def::DefForeignMod(..) |
         def::DefLocal(..) |
-        def::DefUse(..) |
         def::DefLabel(..) |
         def::DefUpvar(..) |
         def::DefErr => {


### PR DESCRIPTION
A relic of some old resolution algorithm?
