### PR TITLE
mk: actually run valgrind on x86_64-apple-darwin

### DIFF
--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -64,14 +64,18 @@ define DEF_GOOD_VALGRIND
   ifeq ($(OSTYPE_$(1)),unknown-linux-gnu)
     GOOD_VALGRIND_$(1) = 1
   endif
-  ifneq (,$(filter $(OSTYPE_$(1)),darwin freebsd))
-    ifeq (HOST_$(1),x86_64)
+  ifneq (,$(filter $(OSTYPE_$(1)),apple-darwin freebsd))
+    ifeq ($(HOST_$(1)),x86_64)
       GOOD_VALGRIND_$(1) = 1
     endif
   endif
+  ifdef GOOD_VALGRIND_$(t)
+    $$(info cfg: have good valgrind for $(t))
+  else
+    $$(info cfg: no good valgrind for $(t))
+  endif
 endef
 $(foreach t,$(CFG_TARGET),$(eval $(call DEF_GOOD_VALGRIND,$(t))))
-$(foreach t,$(CFG_TARGET),$(info cfg: good valgrind for $(t) is $(GOOD_VALGRIND_$(t))))
 
 ifneq ($(findstring linux,$(CFG_OSTYPE)),)
   ifdef CFG_PERF

--- a/src/etc/apple-darwin.supp
+++ b/src/etc/apple-darwin.supp
@@ -1,17 +1,11 @@
 {
    osx-frameworks.rs-fails-otherwise-1
    Memcheck:Leak
-   match-leak-kinds: possible
+   match-leak-kinds: definite,possible
    fun:malloc
    ...
    fun:__CFInitialize
-   fun:_ZN16ImageLoaderMachO11doImageInitERKN11ImageLoader11LinkContextE
-   fun:_ZN16ImageLoaderMachO16doInitializationERKN11ImageLoader11LinkContextE
-   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
-   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
-   fun:_ZN11ImageLoader19processInitializersERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
-   fun:_ZN11ImageLoader15runInitializersERKNS_11LinkContextERNS_21InitializerTimingListE
-   fun:_ZN4dyld24initializeMainExecutableEv
+   ...
 }
 
 {
@@ -22,10 +16,6 @@
    ...
    fun:__CFInitialize
    fun:_ZN16ImageLoaderMachO11doImageInitERKN11ImageLoader11LinkContextE
-   fun:_ZN16ImageLoaderMachO16doInitializationERKN11ImageLoader11LinkContextE
-   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
-   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
-   fun:_ZN11ImageLoader19processInitializersERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
 }
 
 {
@@ -33,12 +23,10 @@
    Memcheck:Leak
    match-leak-kinds: possible
    fun:realloc
-   fun:_ZL12realizeClassP10objc_class
-   fun:_ZL12realizeClassP10objc_class
-   fun:_ZN13list_array_ttIm15protocol_list_tE11attachListsEPKPS0_j
+   ...
    fun:_read_images
    fun:map_images_nolock
-   fun:map_2_images
+   ...
    fun:_ZN4dyldL18notifyBatchPartialE17dyld_image_statesbPFPKcS0_jPK15dyld_image_infoE
    fun:_ZN4dyld36registerImageStateBatchChangeHandlerE17dyld_image_statesPFPKcS0_jPK15dyld_image_infoE
    fun:dyld_register_image_state_change_handler
@@ -49,7 +37,7 @@
 {
    osx-frameworks.rs-fails-otherwise-4
    Memcheck:Leak
-   match-leak-kinds: possible
+   match-leak-kinds: definite,possible
    fun:calloc
    ...
    fun:__CFInitialize
@@ -61,45 +49,27 @@
 {
    osx-frameworks.rs-fails-otherwise-5
    Memcheck:Leak
-   match-leak-kinds: definite
-   fun:calloc
-   ...
-   fun:__CFInitialize
-   fun:_ZN16ImageLoaderMachO11doImageInitERKN11ImageLoader11LinkContextE
-   fun:_ZN16ImageLoaderMachO16doInitializationERKN11ImageLoader11LinkContextE
-   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
-}
-
-{
-   osx-frameworks.rs-fails-otherwise-6
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:strdup
-   fun:_CFProcessPath
-   fun:__CFInitialize
-   fun:_ZN16ImageLoaderMachO11doImageInitERKN11ImageLoader11LinkContextE
-   fun:_ZN16ImageLoaderMachO16doInitializationERKN11ImageLoader11LinkContextE
-   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
-   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
-   fun:_ZN11ImageLoader19processInitializersERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
-   fun:_ZN11ImageLoader15runInitializersERKNS_11LinkContextERNS_21InitializerTimingListE
-   fun:_ZN4dyld24initializeMainExecutableEv
-   fun:_ZN4dyld5_mainEPK12macho_headermiPPKcS5_S5_Pm
-}
-
-{
-   osx-frameworks.rs-fails-otherwise-7
-   Memcheck:Leak
-   match-leak-kinds: definite
+   match-leak-kinds: definite,possible
    fun:malloc_zone_malloc
    ...
    fun:__CFInitialize
-   fun:_ZN16ImageLoaderMachO11doImageInitERKN11ImageLoader11LinkContextE
-   fun:_ZN16ImageLoaderMachO16doInitializationERKN11ImageLoader11LinkContextE
-   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
-   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
-   fun:_ZN11ImageLoader19processInitializersERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
-   fun:_ZN11ImageLoader15runInitializersERKNS_11LinkContextERNS_21InitializerTimingListE
-   fun:_ZN4dyld24initializeMainExecutableEv
+   ...
+}
+
+{
+   fails-since-xcode-7.2
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_malloc
+   fun:_objc_copyClassNamesForImage
+   fun:_ZL9protocolsv
+   fun:_Z9readClassP10objc_classbb
+   fun:gc_init
+   fun:_ZL33objc_initializeClassPair_internalP10objc_classPKcS0_S0_
+   fun:layout_string_create
+   fun:_ZL12realizeClassP10objc_class
+   fun:_ZL22copySwiftV1MangledNamePKcb
+   fun:_ZL22copySwiftV1MangledNamePKcb
+   fun:_ZL22copySwiftV1MangledNamePKcb
+   fun:_ZL22copySwiftV1MangledNamePKcb
 }

--- a/src/etc/x86.supp
+++ b/src/etc/x86.supp
@@ -12,7 +12,7 @@
    fun:tlv_finalize
    fun:_pthread_tsd_cleanup
    fun:_pthread_exit
-   fun:_pthread_body
+   ...
    fun:_pthread_start
    fun:thread_start
 }
@@ -24,7 +24,7 @@
    fun:tlv_finalize
    fun:_pthread_tsd_cleanup
    fun:_pthread_exit
-   fun:_pthread_body
+   ...
    fun:_pthread_start
    fun:thread_start
 }
@@ -36,7 +36,7 @@
    fun:tlv_finalize
    fun:_pthread_tsd_cleanup
    fun:_pthread_exit
-   fun:_pthread_body
+   ...
    fun:_pthread_start
    fun:thread_start
 }
@@ -48,7 +48,7 @@
    fun:tlv_finalize
    fun:_pthread_tsd_cleanup
    fun:_pthread_exit
-   fun:_pthread_body
+   ...
    fun:_pthread_start
    fun:thread_start
 }

--- a/src/test/run-pass-valgrind/exit-flushes.rs
+++ b/src/test/run-pass-valgrind/exit-flushes.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-macos this needs valgrind 3.11 or higher; see
+// https://github.com/rust-lang/rust/pull/30365#issuecomment-165763679
+
 use std::env;
 use std::process::{exit, Command};
 


### PR DESCRIPTION
Since `darwin` is really `apple-darwin`, the valgrind-rpass tests were not actually being run with valgrind on mac before. Also, the `HOST` check was completely wrong.

r? @alexcrichton 
