### PR TITLE
mk: fix undefined variable warnings

### DIFF
--- a/mk/cfg/aarch64-linux-android.mk
+++ b/mk/cfg/aarch64-linux-android.mk
@@ -1,5 +1,4 @@
 # aarch64-linux-android configuration
-# CROSS_PREFIX_aarch64-linux-android-
 CC_aarch64-linux-android=$(CFG_AARCH64_LINUX_ANDROID_NDK)/bin/aarch64-linux-android-gcc
 CXX_aarch64-linux-android=$(CFG_AARCH64_LINUX_ANDROID_NDK)/bin/aarch64-linux-android-g++
 CPP_aarch64-linux-android=$(CFG_AARCH64_LINUX_ANDROID_NDK)/bin/aarch64-linux-android-gcc -E

--- a/mk/cfg/x86_64-apple-ios.mk
+++ b/mk/cfg/x86_64-apple-ios.mk
@@ -29,4 +29,4 @@ CFG_UNIXY_x86_64-apple-ios := 1
 CFG_LDPATH_x86_64-apple-ios :=
 CFG_RUN_x86_64-apple-ios = $(2)
 CFG_RUN_TARG_x86_64-apple-ios = $(call CFG_RUN_x86_64-apple-ios,,$(2))
-CFG_GNU_TRIPLE_i386-apple-ios := x86_64-apple-ios
+CFG_GNU_TRIPLE_x86_64-apple-ios := x86_64-apple-ios

--- a/mk/cfg/x86_64-unknown-bitrig.mk
+++ b/mk/cfg/x86_64-unknown-bitrig.mk
@@ -9,7 +9,7 @@ CFG_LIB_GLOB_x86_64-unknown-bitrig=lib$(1)-*.so
 CFG_LIB_DSYM_GLOB_x86_64-unknown-bitrig=$(1)-*.dylib.dSYM
 CFG_JEMALLOC_CFLAGS_x86_64-unknown-bitrig := -m64 -I/usr/include $(CFLAGS)
 CFG_GCCISH_CFLAGS_x86_64-unknown-bitrig := -Wall -Werror -fPIE -fPIC -m64 -I/usr/include $(CFLAGS)
-CFG_GCCISH_LINK_FLAGS_x86_64-unknown-bitrig := -shared -pic -pthread -m64 $(LDFLAGS)
+CFG_GCCISH_LINK_FLAGS_x86_64-unknown-bitrig := -shared -pic -pthread -m64
 CFG_GCCISH_DEF_FLAG_x86_64-unknown-bitrig := -Wl,--export-dynamic,--dynamic-list=
 CFG_LLC_FLAGS_x86_64-unknown-bitrig :=
 CFG_INSTALL_NAME_x86_64-unknown-bitrig =

--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -139,13 +139,13 @@ ONLY_RLIB_alloc_system := 1
 # Documented-by-default crates
 DOC_CRATES := std alloc collections core libc rustc_unicode
 
-ifeq ($(CFG_DISABLE_JEMALLOC),)
+ifdef CFG_DISABLE_JEMALLOC
+RUSTFLAGS_rustc_back := --cfg disable_jemalloc
+else
 TARGET_CRATES += alloc_jemalloc
 DEPS_std += alloc_jemalloc
 DEPS_alloc_jemalloc := core libc native:jemalloc
 ONLY_RLIB_alloc_jemalloc := 1
-else
-RUSTFLAGS_rustc_back := --cfg disable_jemalloc
 endif
 
 ################################################################################

--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -71,7 +71,7 @@ DOC_L10N_TARGETS :=
 
 # If NO_REBUILD is set then break the dependencies on rustdoc so we
 # build the documentation without having to rebuild rustdoc.
-ifeq ($(NO_REBUILD),)
+ifndef NO_REBUILD
 HTML_DEPS := $(RUSTDOC_EXE)
 else
 HTML_DEPS :=
@@ -152,7 +152,7 @@ define DEF_LIB_DOC
 
 # If NO_REBUILD is set then break the dependencies on rustdoc so we
 # build crate documentation without having to rebuild rustdoc.
-ifeq ($(NO_REBUILD),)
+ifndef NO_REBUILD
 LIB_DOC_DEP_$(1) = \
 	$$(CRATEFILE_$(1)) \
 	$$(RSINPUTS_$(1)) \

--- a/mk/grammar.mk
+++ b/mk/grammar.mk
@@ -41,8 +41,8 @@ $(BG)RustLexer.class: $(BG) $(SG)RustLexer.g4
 
 check-build-lexer-verifier: $(BG)verify
 
-ifeq ($(NO_REBUILD),)
-VERIFY_DEPS :=  rustc-stage2-H-$(CFG_BUILD) $(LD)stamp.rustc
+ifndef NO_REBUILD
+VERIFY_DEPS := rustc-stage2-H-$(CFG_BUILD) $(LD)stamp.rustc
 else
 VERIFY_DEPS :=
 endif

--- a/mk/host.mk
+++ b/mk/host.mk
@@ -18,7 +18,7 @@
 # $(5) - the name of the crate being processed
 define CP_HOST_STAGE_N_CRATE
 
-ifeq ($$(ONLY_RLIB_$(5)),)
+ifndef ONLY_RLIB_$(5)
 $$(HLIB$(2)_H_$(4))/stamp.$(5): \
 	$$(TLIB$(1)_T_$(3)_H_$(4))/stamp.$(5) \
 	$$(RUST_DEPS_$(5):%=$$(HLIB$(2)_H_$(4))/stamp.%) \

--- a/mk/install.mk
+++ b/mk/install.mk
@@ -121,7 +121,7 @@ install-runtime-target-$(1)-cleanup:
 endef
 
 $(foreach target,$(CFG_TARGET), \
- $(if $(findstring $(CFG_ADB_DEVICE_STATUS),"true"), \
+ $(if $(findstring $(CFG_ADB_DEVICE_STATUS),true), \
   $(eval $(call INSTALL_RUNTIME_TARGET_N,$(taget),$(CFG_BUILD))) \
   $(eval $(call INSTALL_RUNTIME_TARGET_CLEANUP_N,$(target))) \
   ))

--- a/mk/llvm.mk
+++ b/mk/llvm.mk
@@ -71,7 +71,7 @@ $$(LLVM_STAMP_$(1)): $$(S)src/rustllvm/llvm-auto-clean-trigger
 	@$$(call E, make: done cleaning llvm)
 	touch -r $$@.start_time $$@ && rm $$@.start_time
 
-ifeq ($$(CFG_ENABLE_LLVM_STATIC_STDCPP),1)
+ifdef CFG_ENABLE_LLVM_STATIC_STDCPP
 LLVM_STDCPP_RUSTFLAGS_$(1) = -L "$$(dir $$(shell $$(CC_$(1)) $$(CFG_GCCISH_CFLAGS_$(1)) \
 					-print-file-name=lib$(CFG_STDCPP_NAME).a))"
 else
@@ -94,9 +94,6 @@ endef
 
 $(foreach host,$(CFG_HOST), \
  $(eval $(call DEF_LLVM_RULES,$(host))))
-
-$(foreach host,$(CFG_HOST), \
- $(eval LLVM_CONFIGS := $(LLVM_CONFIGS) $(LLVM_CONFIG_$(host))))
 
 # This can't be done in target.mk because it's included before this file.
 define LLVM_LINKAGE_DEPS

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -86,13 +86,13 @@ CFG_INFO := $(info cfg: version $(CFG_VERSION))
 
 MKFILE_DEPS := config.stamp $(call rwildcard,$(CFG_SRC_DIR)mk/,*)
 MKFILES_FOR_TARBALL:=$(MKFILE_DEPS)
-ifneq ($(NO_MKFILE_DEPS),)
+ifdef NO_MKFILE_DEPS
 MKFILE_DEPS :=
 endif
 NON_BUILD_HOST = $(filter-out $(CFG_BUILD),$(CFG_HOST))
 NON_BUILD_TARGET = $(filter-out $(CFG_BUILD),$(CFG_TARGET))
 
-ifneq ($(MAKE_RESTARTS),)
+ifdef MAKE_RESTARTS
 CFG_INFO := $(info cfg: make restarts: $(MAKE_RESTARTS))
 endif
 
@@ -107,27 +107,39 @@ ifneq ($(wildcard $(NON_BUILD_TARGET)),)
 CFG_INFO := $(info cfg: non-build target triples $(NON_BUILD_TARGET))
 endif
 
-CFG_RUSTC_FLAGS := $(RUSTFLAGS)
+CFG_RUSTC_FLAGS :=
+ifdef RUSTFLAGS
+  CFG_RUSTC_FLAGS += $(RUSTFLAGS)
+endif
 CFG_GCCISH_CFLAGS :=
 CFG_GCCISH_LINK_FLAGS :=
 
 CFG_JEMALLOC_FLAGS :=
+ifdef JEMALLOC_FLAGS
+  CFG_JEMALLOC_FLAGS += $(JEMALLOC_FLAGS)
+endif
 
 ifdef CFG_DISABLE_OPTIMIZE
   $(info cfg: disabling rustc optimization (CFG_DISABLE_OPTIMIZE))
-  CFG_RUSTC_FLAGS +=
   CFG_JEMALLOC_FLAGS += --enable-debug
 else
   # The rtopt cfg turns off runtime sanity checks
   CFG_RUSTC_FLAGS += -O --cfg rtopt
 endif
 
-CFG_JEMALLOC_FLAGS += $(JEMALLOC_FLAGS)
-
 ifdef CFG_ENABLE_DEBUG_ASSERTIONS
   $(info cfg: enabling debug assertions (CFG_ENABLE_DEBUG_ASSERTIONS))
   CFG_RUSTC_FLAGS += -C debug-assertions=on
 endif
+
+define DEF_RUSTFLAGS_STAGE
+RUSTFLAGS_STAGE$(1) :=
+endef
+
+STAGES = 0 1 2 3
+
+$(foreach stage,$(STAGES), \
+  $(eval $(call DEF_RUSTFLAGS_STAGE,$(stage))))
 
 ifdef CFG_ENABLE_DEBUGINFO
   $(info cfg: enabling debuginfo (CFG_ENABLE_DEBUGINFO))
@@ -186,9 +198,9 @@ endif
 
 
 ifndef CFG_DISABLE_VALGRIND_RPASS
-  $(info cfg: enabling valgrind run-pass tests (CFG_ENABLE_VALGRIND_RPASS))
+  $(info cfg: enabling valgrind run-pass tests)
   $(info cfg: valgrind-rpass command set to $(CFG_VALGRIND))
-  CFG_VALGRIND_RPASS :=$(CFG_VALGRIND)
+  CFG_VALGRIND_RPASS := $(CFG_VALGRIND)
 else
   $(info cfg: disabling valgrind run-pass tests)
   CFG_VALGRIND_RPASS :=
@@ -371,8 +383,6 @@ export CFG_BOOTSTRAP_KEY
 # target triple. See debuggers.mk for more information.
 TRIPLE_TO_DEBUGGER_SCRIPT_SETTING=\
  $(if $(findstring windows,$(1)),none,$(if $(findstring darwin,$(1)),lldb,gdb))
-
-STAGES = 0 1 2 3
 
 define SREQ
 # $(1) is the stage number

--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -82,12 +82,11 @@ AR := ar
 define SET_FROM_CFG
   ifdef CFG_$(1)
     ifeq ($(origin $(1)),undefined)
-      $$(info cfg: using $(1)=$(CFG_$(1)) (CFG_$(1)))
-      $(1)=$(CFG_$(1))
-    endif
-    ifeq ($(origin $(1)),default)
-      $$(info cfg: using $(1)=$(CFG_$(1)) (CFG_$(1)))
-      $(1)=$(CFG_$(1))
+      $$(info cfg: using $(1)=$$(CFG_$(1)) (CFG_$(1)))
+      $(1)=$$(CFG_$(1))
+    else ifeq ($(origin $(1)),default)
+      $$(info cfg: using $(1)=$$(CFG_$(1)) (CFG_$(1)))
+      $(1)=$$(CFG_$(1))
     endif
   endif
 endef
@@ -101,7 +100,9 @@ include $(wildcard $(CFG_SRC_DIR)mk/cfg/*.mk)
 
 define ADD_INSTALLED_OBJECTS
   INSTALLED_OBJECTS_$(1) += $$(CFG_INSTALLED_OBJECTS_$(1))
-  REQUIRED_OBJECTS_$(1) += $$(CFG_THIRD_PARTY_OBJECTS_$(1))
+  ifdef CFG_THIRD_PARTY_OBJECTS_$(1)
+    REQUIRED_OBJECTS_$(1) += $$(CFG_THIRD_PARTY_OBJECTS_$(1))
+  endif
   INSTALLED_OBJECTS_$(1) += $$(call CFG_STATIC_LIB_NAME_$(1),compiler-rt)
   REQUIRED_OBJECTS_$(1) += $$(call CFG_STATIC_LIB_NAME_$(1),compiler-rt)
 endef
@@ -163,15 +164,15 @@ define CFG_MAKE_TOOLCHAIN
   # Prepend the tools with their prefix if cross compiling
   ifneq ($(CFG_BUILD),$(1))
     ifneq ($$(findstring msvc,$(1)),msvc)
-       CC_$(1)=$(CROSS_PREFIX_$(1))$(CC_$(1))
-       CXX_$(1)=$(CROSS_PREFIX_$(1))$(CXX_$(1))
-       CPP_$(1)=$(CROSS_PREFIX_$(1))$(CPP_$(1))
-       AR_$(1)=$(CROSS_PREFIX_$(1))$(AR_$(1))
-       LINK_$(1)=$(CROSS_PREFIX_$(1))$(LINK_$(1))
-       RUSTC_CROSS_FLAGS_$(1)=-C linker=$$(call FIND_COMPILER,$$(LINK_$(1))) \
-           -C ar=$$(call FIND_COMPILER,$$(AR_$(1))) $(RUSTC_CROSS_FLAGS_$(1))
+      CC_$(1)=$(CROSS_PREFIX_$(1))$(CC_$(1))
+      CXX_$(1)=$(CROSS_PREFIX_$(1))$(CXX_$(1))
+      CPP_$(1)=$(CROSS_PREFIX_$(1))$(CPP_$(1))
+      AR_$(1)=$(CROSS_PREFIX_$(1))$(AR_$(1))
+      LINK_$(1)=$(CROSS_PREFIX_$(1))$(LINK_$(1))
+      RUSTC_CROSS_FLAGS_$(1)=-C linker=$$(call FIND_COMPILER,$$(LINK_$(1))) \
+        -C ar=$$(call FIND_COMPILER,$$(AR_$(1))) $(RUSTC_CROSS_FLAGS_$(1))
 
-       RUSTC_FLAGS_$(1)=$$(RUSTC_CROSS_FLAGS_$(1)) $(RUSTC_FLAGS_$(1))
+      RUSTC_FLAGS_$(1)=$$(RUSTC_CROSS_FLAGS_$(1)) $(RUSTC_FLAGS_$(1))
     endif
   endif
 

--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -107,8 +107,6 @@ $$(RT_OUTPUT_DIR_$(1))/$$(NATIVE_$(2)_$(1)): $$(OBJS_$(2)_$(1))
 
 endef
 
-$(foreach target,$(CFG_TARGET), \
- $(eval $(call RUNTIME_RULES,$(target))))
 $(foreach lib,$(NATIVE_LIBS), \
  $(foreach target,$(CFG_TARGET), \
   $(eval $(call THIRD_PARTY_LIB,$(target),$(lib)))))
@@ -171,7 +169,7 @@ endif
 
 # See #17183 for details, this file is touched during the build process so we
 # don't want to consider it as a dependency.
-JEMALLOC_DEPS := $(filter-out $(S)src/jemalloc/VERSION,$(JEMALLOC_DEPS))
+JEMALLOC_DEPS := $(filter-out $(S)src/jemalloc/VERSION,$$(JEMALLOC_DEPS))
 
 JEMALLOC_NAME_$(1) := $$(call CFG_STATIC_LIB_NAME_$(1),jemalloc)
 ifeq ($$(CFG_WINDOWSY_$(1)),1)

--- a/mk/target.mk
+++ b/mk/target.mk
@@ -138,12 +138,12 @@ define TARGET_RUSTRT_STARTUP_OBJ
 $$(TLIB$(1)_T_$(2)_H_$(3))/$(4).o: \
 		$(S)src/rtstartup/$(4).rs \
 		$$(TLIB$(1)_T_$(2)_H_$(3))/stamp.core \
-		$$(HSREQ$(1)_T_$(2)_H_$(3)) \
+		$$(HSREQ$(1)_H_$(3)) \
 		| $$(TBIN$(1)_T_$(2)_H_$(3))/
 	@$$(call E, rustc: $$@)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) --emit=obj -o $$@ $$<
 
-ifeq ($$(CFG_RUSTRT_HAS_STARTUP_OBJS_$(2)), 1)
+ifdef CFG_RUSTRT_HAS_STARTUP_OBJS_$(2)
 # Add dependencies on Rust startup objects to all crates that depend on core.
 # This ensures that they are built after core (since they depend on it),
 # but before everything else (since they are needed for linking dylib crates).

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -36,6 +36,8 @@ TEST_CRATES = $(TEST_TARGET_CRATES) $(TEST_HOST_CRATES)
 # Environment configuration
 ######################################################################
 
+TESTARGS :=
+
 # The arguments to all test runners
 ifdef TESTNAME
   TESTARGS += $(TESTNAME)
@@ -48,6 +50,8 @@ endif
 # Arguments to the cfail/rfail/rpass tests
 ifdef CFG_VALGRIND
   CTEST_RUNTOOL = --runtool "$(CFG_VALGRIND)"
+else
+  CTEST_RUNTOOL =
 endif
 
 CTEST_TESTARGS := $(TESTARGS)
@@ -143,10 +147,11 @@ else
 CFG_ADB_TEST_DIR=
 endif
 
+DOC_NAMES :=
 # $(1) - name of doc test
 # $(2) - file of the test
 define DOCTEST
-DOC_NAMES := $$(DOC_NAMES) $(1)
+DOC_NAMES += $(1)
 DOCFILE_$(1) := $(2)
 endef
 
@@ -362,7 +367,7 @@ define TEST_RUNNER
 # If NO_REBUILD is set then break the dependencies on everything but
 # the source files so we can test crates without rebuilding any of the
 # parent crates.
-ifeq ($(NO_REBUILD),)
+ifndef NO_REBUILD
 TESTDEP_$(1)_$(2)_$(3)_$(4) = $$(SREQ$(1)_T_$(2)_H_$(3)) \
 			    $$(foreach crate,$$(TARGET_CRATES), \
 				$$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$$(crate)) \
@@ -447,7 +452,7 @@ $(foreach host,$(CFG_HOST), \
     $(if $(findstring $(target),$(CFG_BUILD)), \
      $(eval $(call DEF_TEST_CRATE_RULES,$(stage),$(target),$(host),$(crate))), \
      $(if $(findstring android, $(target)), \
-      $(if $(findstring $(CFG_ADB_DEVICE_STATUS),"true"), \
+      $(if $(findstring $(CFG_ADB_DEVICE_STATUS),true), \
        $(eval $(call DEF_TEST_CRATE_RULES_android,$(stage),$(target),$(host),$(crate))), \
        $(eval $(call DEF_TEST_CRATE_RULES_null,$(stage),$(target),$(host),$(crate))) \
       ), \
@@ -700,14 +705,14 @@ check-stage$(1)-T-$(2)-H-$(3)-$(4)-exec: $$(call TEST_OK_FILE,$(1),$(2),$(3),$(4
 # (Encoded as a separate variable because GNU make does not have a
 # good way to express OR on ifeq commands)
 
-ifneq ($$(CTEST_DISABLE_$(4)),)
+ifdef CTEST_DISABLE_$(4)
 # Test suite is disabled for all configured targets.
 CTEST_DONT_RUN_$(1)-T-$(2)-H-$(3)-$(4) := $$(CTEST_DISABLE_$(4))
 else
 # else, check if non-self-hosted target (i.e. target not-in hosts) ...
 ifeq ($$(findstring $(2),$$(CFG_HOST)),)
 # ... if so, then check if this test suite is disabled for non-selfhosts.
-ifneq ($$(CTEST_DISABLE_NONSELFHOST_$(4)),)
+ifdef CTEST_DISABLE_NONSELFHOST_$(4)
 # Test suite is disabled for this target.
 CTEST_DONT_RUN_$(1)-T-$(2)-H-$(3)-$(4) := $$(CTEST_DISABLE_NONSELFHOST_$(4))
 endif
@@ -715,7 +720,7 @@ endif
 # Neither DISABLE nor DISABLE_NONSELFHOST is set ==> okay, run the test.
 endif
 
-ifeq ($$(CTEST_DONT_RUN_$(1)-T-$(2)-H-$(3)-$(4)),)
+ifndef CTEST_DONT_RUN_$(1)-T-$(2)-H-$(3)-$(4)
 $$(call TEST_OK_FILE,$(1),$(2),$(3),$(4)): \
 		$$(TEST_SREQ$(1)_T_$(2)_H_$(3)) \
                 $$(CTEST_DEPS_$(4)_$(1)-T-$(2)-H-$(3))
@@ -824,7 +829,7 @@ check-stage$(1)-T-$(2)-H-$(3)-doc-$(4)-exec: $$(call TEST_OK_FILE,$(1),$(2),$(3)
 # If NO_REBUILD is set then break the dependencies on everything but
 # the source files so we can test documentation without rebuilding
 # rustdoc etc.
-ifeq ($(NO_REBUILD),)
+ifndef NO_REBUILD
 DOCTESTDEP_$(1)_$(2)_$(3)_$(4) = \
 	$$(DOCFILE_$(4)) \
 	$$(TEST_SREQ$(1)_T_$(2)_H_$(3)) \
@@ -859,7 +864,7 @@ define DEF_CRATE_DOC_TEST
 # If NO_REBUILD is set then break the dependencies on everything but
 # the source files so we can test crate documentation without
 # rebuilding any of the parent crates.
-ifeq ($(NO_REBUILD),)
+ifndef NO_REBUILD
 CRATEDOCTESTDEP_$(1)_$(2)_$(3)_$(4) = \
 	$$(TEST_SREQ$(1)_T_$(2)_H_$(3)) \
 	$$(CRATE_FULLDEPS_$(1)_T_$(2)_H_$(3)_$(4)) \
@@ -922,8 +927,7 @@ TEST_GROUPS = \
 	pretty-rpass-full \
 	pretty-rfail-full \
 	pretty-rfail \
-	pretty-pretty \
-	$(NULL)
+	pretty-pretty
 
 define DEF_CHECK_FOR_STAGE_AND_TARGET_AND_HOST
 check-stage$(1)-T-$(2)-H-$(3): check-stage$(1)-T-$(2)-H-$(3)-exec


### PR DESCRIPTION
Some of this is scary stuff. Probably time to lint against this.

Found with `make --warn-undefined-variables`.

r? @alexcrichton 
