### PR TITLE
Pass --enable-new-dtags to GNU ld

### DIFF
--- a/src/librustc_back/rpath.rs
+++ b/src/librustc_back/rpath.rs
@@ -19,6 +19,7 @@ pub struct RPathConfig<'a> {
     pub out_filename: PathBuf,
     pub is_like_osx: bool,
     pub has_rpath: bool,
+    pub linker_is_gnu: bool,
     pub get_install_prefix_lib_path: &'a mut FnMut() -> PathBuf,
 }
 
@@ -36,6 +37,12 @@ pub fn get_rpath_flags(config: &mut RPathConfig) -> Vec<String> {
     let libs = libs.into_iter().filter_map(|(_, l)| l).collect::<Vec<_>>();
     let rpaths = get_rpaths(config, &libs[..]);
     flags.extend_from_slice(&rpaths_to_flags(&rpaths[..]));
+
+    // Use DT_RUNPATH instead of DT_RPATH if available
+    if config.linker_is_gnu {
+        flags.push("-Wl,--enable-new-dtags".to_string());
+    }
+
     flags
 }
 
@@ -228,6 +235,7 @@ mod tests {
                 used_crates: Vec::new(),
                 has_rpath: true,
                 is_like_osx: true,
+                linker_is_gnu: false,
                 out_filename: PathBuf::from("bin/rustc"),
                 get_install_prefix_lib_path: &mut || panic!(),
             };
@@ -241,6 +249,7 @@ mod tests {
                 get_install_prefix_lib_path: &mut || panic!(),
                 has_rpath: true,
                 is_like_osx: false,
+                linker_is_gnu: true,
             };
             let res = get_rpath_relative_to_output(config,
                                                    Path::new("lib/libstd.so"));

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -1054,6 +1054,7 @@ fn link_args(cmd: &mut Linker,
             out_filename: out_filename.to_path_buf(),
             has_rpath: sess.target.target.options.has_rpath,
             is_like_osx: sess.target.target.options.is_like_osx,
+            linker_is_gnu: sess.target.target.options.linker_is_gnu,
             get_install_prefix_lib_path: &mut get_install_prefix_lib_path,
         };
         cmd.args(&rpath::get_rpath_flags(&mut rpath_config));


### PR DESCRIPTION
This causes the linker to emit DT_RUNPATH instead of DT_RPATH, which fixes #30378. See that bug for rationale.
