### PR TITLE
Add note when item accessed from module via `m.i` rather than `m::i`. 

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -202,9 +202,18 @@ pub enum ResolutionError<'a> {
     AttemptToUseNonConstantValueInConstant,
 }
 
+/// Context of where `ResolutionError::UnresolvedName` arose.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum UnresolvedNameContext {
+    /// `PathIsMod(id)` indicates that a given path, used in
+    /// expression context, actually resolved to a module rather than
+    /// a value. The `id` attached to the variant is the node id of
+    /// the erroneous path expression.
     PathIsMod(ast::NodeId),
+
+    /// `Other` means we have no extra information about the context
+    /// of the unresolved name error. (Maybe we could eliminate all
+    /// such cases; but for now, this is an information-free default.)
     Other,
 }
 

--- a/src/test/compile-fail/suggest-path-instead-of-mod-dot-item.rs
+++ b/src/test/compile-fail/suggest-path-instead-of-mod-dot-item.rs
@@ -1,0 +1,60 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Beginners write `mod.item` when they should write `mod::item`.
+// This tests that we suggest the latter when we encounter the former.
+
+pub mod a {
+    pub const I: i32 = 1;
+
+    pub fn f() -> i32 { 2 }
+
+    pub mod b {
+        pub const J: i32 = 3;
+
+        pub fn g() -> i32 { 4 }
+    }
+}
+
+fn h1() -> i32 {
+    a.I
+        //~^ ERROR E0425
+        //~| HELP To reference an item from the `a` module, use `a::I`
+}
+
+fn h2() -> i32 {
+    a.g()
+        //~^ ERROR E0425
+        //~| HELP To call a function from the `a` module, use `a::g(..)`
+}
+
+fn h3() -> i32 {
+    a.b.J
+        //~^ ERROR E0425
+        //~| HELP To reference an item from the `a` module, use `a::b`
+}
+
+fn h4() -> i32 {
+    a::b.J
+        //~^ ERROR E0425
+        //~| HELP To reference an item from the `a::b` module, use `a::b::J`
+}
+
+fn h5() -> i32 {
+    a.b.f()
+        //~^ ERROR E0425
+        //~| HELP To reference an item from the `a` module, use `a::b`
+}
+
+fn h6() -> i32 {
+    a::b.f()
+        //~^ ERROR E0425
+        //~| HELP To call a function from the `a::b` module, use `a::b::f(..)`
+}


### PR DESCRIPTION
Add note when item accessed from module via `m.i` rather than `m::i`.

(I tried to make this somewhat future-proofed, in that the `UnresolvedNameContext` could be expanded in the future with other cases besides paths that are known to be modules.)

This supersedes PR #30356 ; since I'm responsible for a bunch of new code here, someone else should review it. :)
