### PR TITLE
mk: Use the right llvmdeps.rs file for cross build

### DIFF
--- a/mk/llvm.mk
+++ b/mk/llvm.mk
@@ -100,8 +100,8 @@ $(foreach host,$(CFG_HOST), \
 
 # This can't be done in target.mk because it's included before this file.
 define LLVM_LINKAGE_DEPS
-$$(TLIB$(1)_T_$(2)_H_$(3))/stamp.rustc_llvm: $$(LLVM_LINKAGE_PATH_$(3))
-RUSTFLAGS$(1)_rustc_llvm_T_$(3) += $$(shell echo $$(LLVM_ALL_COMPONENTS_$(3)) | tr '-' '_' |\
+$$(TLIB$(1)_T_$(2)_H_$(3))/stamp.rustc_llvm: $$(LLVM_LINKAGE_PATH_$(2))
+RUSTFLAGS$(1)_rustc_llvm_T_$(2) += $$(shell echo $$(LLVM_ALL_COMPONENTS_$(2)) | tr '-' '_' |\
 	sed -e 's/^ //;s/\([^ ]*\)/\-\-cfg have_component_\1/g')
 endef
 


### PR DESCRIPTION
It looks like #27937 accidentally switched the llvmdeps file from the target to
the host by accident, so be sure to use the right llvmdeps file which is built
for the target when building rustc_llvm
