### PR TITLE
doc: improve clarity by introducing a pause

### DIFF
--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -1616,7 +1616,7 @@ impl<Idx: fmt::Debug> fmt::Debug for RangeTo<Idx> {
 }
 
 /// The `Deref` trait is used to specify the functionality of dereferencing
-/// operations like `*v`.
+/// operations, like `*v`.
 ///
 /// `Deref` also enables ['`Deref` coercions'][coercions].
 ///


### PR DESCRIPTION
The comma removes the ambiguity
