### PR TITLE
Change "big ask" to "tall order" in Rustonomicon.

### DIFF
--- a/src/doc/nomicon/lifetimes.md
+++ b/src/doc/nomicon/lifetimes.md
@@ -107,8 +107,8 @@ This signature of `as_str` takes a reference to a u32 with *some* lifetime, and
 promises that it can produce a reference to a str that can live *just as long*.
 Already we can see why this signature might be trouble. That basically implies
 that we're going to find a str somewhere in the scope the reference
-to the u32 originated in, or somewhere *even earlier*. That's a bit of a big
-ask.
+to the u32 originated in, or somewhere *even earlier*. That's a bit of a tall
+order.
 
 We then proceed to compute the string `s`, and return a reference to it. Since
 the contract of our function says the reference must outlive `'a`, that's the


### PR DESCRIPTION
The Rustonomicon's Lifetimes chapter uses the idiom "big ask", which is obscure compared to "tall order" (check [Google ngrams](https://books.google.com/ngrams/graph?content=big+ask%2C+tall+order&year_start=1800)). Also, it's easily mistaken for a typo; either "a big task" or "a big thing to ask" could plausibly work there.

r? @steveklabnik
