### PR TITLE
Make runtime function return size_t

### DIFF
--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -127,7 +127,7 @@ impl Iterator for ReadDir {
 
     fn next(&mut self) -> Option<io::Result<DirEntry>> {
         extern {
-            fn rust_dirent_t_size() -> size_t;
+            fn rust_dirent_t_size() -> libc::size_t;
         }
 
         let mut buf: Vec<u8> = Vec::with_capacity(unsafe {

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -127,11 +127,11 @@ impl Iterator for ReadDir {
 
     fn next(&mut self) -> Option<io::Result<DirEntry>> {
         extern {
-            fn rust_dirent_t_size() -> c_int;
+            fn rust_dirent_t_size() -> size_t;
         }
 
         let mut buf: Vec<u8> = Vec::with_capacity(unsafe {
-            rust_dirent_t_size() as usize
+            rust_dirent_t_size()
         });
         let ptr = buf.as_mut_ptr() as *mut libc::dirent;
 

--- a/src/rt/rust_builtin.c
+++ b/src/rt/rust_builtin.c
@@ -77,7 +77,7 @@ rust_readdir_r(DIR *dirp, struct dirent *entry, struct dirent **result) {
     return readdir_r(dirp, entry, result);
 }
 
-int
+size_t
 rust_dirent_t_size() {
     return sizeof(struct dirent);
 }


### PR DESCRIPTION
It returns sizeof(dirent_t), so I'm not sure why its return type is int.
It's only used once, and that usage immediately casts it to usize.
