### PR TITLE
Fix warnings when compiling stdlib with --test

### DIFF
--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -132,6 +132,7 @@ mod tests {
     #[cfg_attr(any(windows,
                    target_os = "android",  // FIXME #10379
                    target_env = "musl"), ignore)]
+    #[allow(deprecated)]
     fn test_loading_cosine() {
         // The math library does not need to be loaded since it is already
         // statically linked in
@@ -164,6 +165,7 @@ mod tests {
               target_os = "bitrig",
               target_os = "netbsd",
               target_os = "openbsd"))]
+    #[allow(deprecated)]
     fn test_errors_do_not_crash() {
         // Open /dev/null as a library to get an error, and make sure
         // that only causes an error, and not a crash.

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1281,7 +1281,6 @@ mod tests {
     use io::{ErrorKind, SeekFrom};
     use path::PathBuf;
     use path::Path as Path2;
-    use os;
     use rand::{self, StdRng, Rng};
     use str;
 
@@ -1410,8 +1409,8 @@ mod tests {
         let message = "ten-four";
         let mut read_mem = [0; 4];
         let set_cursor = 4 as u64;
-        let mut tell_pos_pre_read;
-        let mut tell_pos_post_read;
+        let tell_pos_pre_read;
+        let tell_pos_post_read;
         let tmpdir = tmpdir();
         let filename = &tmpdir.join("file_rt_io_file_test_seeking.txt");
         {

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -791,7 +791,7 @@ impl<W: Read + Write> Read for InternalBufWriter<W> {
 mod tests {
     use prelude::v1::*;
     use io::prelude::*;
-    use io::{self, BufReader, BufWriter, Cursor, LineWriter, SeekFrom};
+    use io::{self, BufReader, BufWriter, LineWriter, SeekFrom};
     use test;
 
     /// A dummy reader intended at testing short-reads propagation.

--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -377,7 +377,7 @@ mod test {
         struct TestError;
 
         impl fmt::Display for TestError {
-            fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+            fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
                 Ok(())
             }
         }

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1983,7 +1983,7 @@ mod tests {
         b.iter(|| {
             let mut lr = repeat(1).take(10000000);
             let mut vec = Vec::with_capacity(1024);
-            super::read_to_end(&mut lr, &mut vec);
+            super::read_to_end(&mut lr, &mut vec)
         });
     }
 }

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -199,6 +199,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn tee() {
         let mut buf = [0; 10];
         {
@@ -209,6 +210,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn broadcast() {
         let mut buf1 = [0; 10];
         let mut buf2 = [0; 10];

--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -468,9 +468,7 @@ impl<'a, T: ToSocketAddrs + ?Sized> ToSocketAddrs for &'a T {
 #[cfg(test)]
 mod tests {
     use prelude::v1::*;
-    use io;
     use net::*;
-    use net::Ipv6MulticastScope::*;
     use net::test::{tsa, sa6, sa4};
 
     #[test]

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -527,7 +527,6 @@ impl FromInner<c::in6_addr> for Ipv6Addr {
 #[cfg(test)]
 mod tests {
     use prelude::v1::*;
-    use io;
     use net::*;
     use net::Ipv6MulticastScope::*;
     use net::test::{tsa, sa6, sa4};

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -15,10 +15,15 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 #![allow(missing_docs)]
 
+#[cfg(not(test))]
 use core::num;
+#[cfg(not(test))]
 use intrinsics;
+#[cfg(not(test))]
 use libc::c_int;
+#[cfg(not(test))]
 use num::FpCategory;
+
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::f32::{RADIX, MANTISSA_DIGITS, DIGITS, EPSILON};

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -15,9 +15,13 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 #![allow(missing_docs)]
 
+#[cfg(not(test))]
 use core::num;
+#[cfg(not(test))]
 use intrinsics;
+#[cfg(not(test))]
 use libc::c_int;
+#[cfg(not(test))]
 use num::FpCategory;
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -47,11 +47,6 @@ pub fn test_num<T>(ten: T, two: T) where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use i8;
-    use i16;
-    use i32;
-    use i64;
-    use isize;
     use u8;
     use u16;
     use u32;

--- a/src/libstd/os/raw.rs
+++ b/src/libstd/os/raw.rs
@@ -88,7 +88,8 @@ mod tests {
             c_longlong c_ulonglong c_float c_double);
     }
 
-    #[cfg(unix)]
+    #[cfg(all(unix, not(target_os = "android")))]
+    #[test]
     fn unix() {
         {
             use os::unix::raw;
@@ -101,6 +102,7 @@ mod tests {
     }
 
     #[cfg(windows)]
+    #[test]
     fn windows() {
         use os::windows::raw;
     }

--- a/src/libstd/rand/os.rs
+++ b/src/libstd/rand/os.rs
@@ -381,8 +381,6 @@ mod imp {
 
 #[cfg(test)]
 mod tests {
-    use prelude::v1::*;
-
     use sync::mpsc::channel;
     use rand::Rng;
     use super::OsRng;

--- a/src/libstd/rand/reader.rs
+++ b/src/libstd/rand/reader.rs
@@ -63,8 +63,6 @@ impl<R: Read> Rng for ReaderRng<R> {
 
 #[cfg(test)]
 mod tests {
-    use prelude::v1::*;
-
     use super::ReaderRng;
     use rand::Rng;
 

--- a/src/libstd/rt.rs
+++ b/src/libstd/rt.rs
@@ -22,13 +22,7 @@
             issue = "0")]
 #![doc(hidden)]
 
-use borrow::ToOwned;
-use mem;
-use panic;
-use sys;
-use sys_common::thread_info::{self, NewThread};
-use sys_common;
-use thread::Thread;
+
 
 // Reexport some of our utilities which are expected by other crates.
 pub use sys_common::unwind::{begin_unwind, begin_unwind_fmt};
@@ -41,6 +35,14 @@ pub use sys_common::unwind::imp::eh_frame_registry::*;
 #[cfg(not(test))]
 #[lang = "start"]
 fn lang_start(main: *const u8, argc: isize, argv: *const *const u8) -> isize {
+    use borrow::ToOwned;
+    use mem;
+    use panic;
+    use sys;
+    use sys_common;
+    use sys_common::thread_info::{self, NewThread};
+    use thread::Thread;
+
     sys::init();
 
     let failed = unsafe {

--- a/src/libstd/sync/condvar.rs
+++ b/src/libstd/sync/condvar.rs
@@ -510,15 +510,15 @@ mod tests {
         static M: StaticMutex = StaticMutex::new();
 
         let g = M.lock().unwrap();
-        let (g, _no_timeout) = C.wait_timeout_ms(g, 1).unwrap();
+        let (g, _no_timeout) = C.wait_timeout(g, Duration::from_millis(1)).unwrap();
         // spurious wakeups mean this isn't necessarily true
         // assert!(!no_timeout);
         let _t = thread::spawn(move || {
             let _g = M.lock().unwrap();
             C.notify_one();
         });
-        let (g, no_timeout) = C.wait_timeout_ms(g, u32::MAX).unwrap();
-        assert!(no_timeout);
+        let (g, timeout_res) = C.wait_timeout(g, Duration::from_millis(u32::MAX as u64)).unwrap();
+        assert!(!timeout_res.timed_out());
         drop(g);
         unsafe { C.destroy(); M.destroy(); }
     }

--- a/src/libstd/sys/common/io.rs
+++ b/src/libstd/sys/common/io.rs
@@ -133,7 +133,7 @@ mod tests {
         b.iter(|| {
             let mut lr = repeat(1).take(10000000);
             let mut vec = Vec::with_capacity(1024);
-            unsafe { read_to_end_uninitialized(&mut lr, &mut vec) };
+            unsafe { read_to_end_uninitialized(&mut lr, &mut vec) }
         });
     }
 }

--- a/src/libstd/sys/common/remutex.rs
+++ b/src/libstd/sys/common/remutex.rs
@@ -167,7 +167,6 @@ mod tests {
     use sys_common::remutex::{ReentrantMutex, ReentrantMutexGuard};
     use cell::RefCell;
     use sync::Arc;
-    use boxed;
     use thread;
 
     #[test]
@@ -208,13 +207,13 @@ mod tests {
     fn trylock_works() {
         let m = Arc::new(ReentrantMutex::new(()));
         let m2 = m.clone();
-        let lock = m.try_lock().unwrap();
-        let lock2 = m.try_lock().unwrap();
+        let _lock = m.try_lock().unwrap();
+        let _lock2 = m.try_lock().unwrap();
         thread::spawn(move || {
             let lock = m2.try_lock();
             assert!(lock.is_err());
         }).join().unwrap();
-        let lock3 = m.try_lock().unwrap();
+        let _lock3 = m.try_lock().unwrap();
     }
 
     pub struct Answer<'a>(pub ReentrantMutexGuard<'a, RefCell<u32>>);
@@ -233,9 +232,8 @@ mod tests {
             *lock.borrow_mut() = 1;
             let lock2 = mc.lock().unwrap();
             *lock.borrow_mut() = 2;
-            let answer = Answer(lock2);
+            let _answer = Answer(lock2);
             panic!("What the answer to my lifetimes dilemma is?");
-            drop(answer);
         }).join();
         assert!(result.is_err());
         let r = m.lock().err().unwrap().into_inner();

--- a/src/libstd/sys/common/wtf8.rs
+++ b/src/libstd/sys/common/wtf8.rs
@@ -1067,7 +1067,7 @@ mod tests {
     #[test]
     fn wtf8buf_show_str() {
         let text = "a\té 💩\r";
-        let mut string = Wtf8Buf::from_str(text);
+        let string = Wtf8Buf::from_str(text);
         assert_eq!(format!("{:?}", text), format!("{:?}", string));
     }
 

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -45,7 +45,7 @@ pub mod thread_local;
 pub mod time;
 pub mod stdio;
 
-#[cfg(not(target_os = "nacl"))]
+#[cfg(not(any(target_os = "nacl", test)))]
 pub fn init() {
     use libc::signal;
     // By default, some platforms will send a *signal* when an EPIPE error
@@ -59,7 +59,8 @@ pub fn init() {
         assert!(signal(libc::SIGPIPE, libc::SIG_IGN) != !0);
     }
 }
-#[cfg(target_os = "nacl")]
+
+#[cfg(all(target_os = "nacl", not(test)))]
 pub fn init() { }
 
 pub fn decode_error_kind(errno: i32) -> ErrorKind {

--- a/src/libstd/sys/unix/process.rs
+++ b/src/libstd/sys/unix/process.rs
@@ -462,8 +462,7 @@ mod tests {
     use mem;
     use ptr;
     use libc;
-    use slice;
-    use sys::{self, cvt, pipe};
+    use sys::{self, cvt};
 
     macro_rules! t {
         ($e:expr) => {
@@ -482,6 +481,8 @@ mod tests {
 
     #[cfg(target_os = "android")]
     unsafe fn sigaddset(set: *mut libc::sigset_t, signum: libc::c_int) -> libc::c_int {
+        use slice;
+
         let raw = slice::from_raw_parts_mut(set as *mut u8, mem::size_of::<libc::sigset_t>());
         let bit = (signum - 1) as usize;
         raw[bit / 8] |= 1 << (bit % 8);

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -830,14 +830,14 @@ mod tests {
     fn test_park_timeout_unpark_before() {
         for _ in 0..10 {
             thread::current().unpark();
-            thread::park_timeout_ms(u32::MAX);
+            thread::park_timeout(Duration::from_millis(u32::MAX as u64));
         }
     }
 
     #[test]
     fn test_park_timeout_unpark_not_called() {
         for _ in 0..10 {
-            thread::park_timeout_ms(10);
+            thread::park_timeout(Duration::from_millis(10));
         }
     }
 
@@ -847,17 +847,17 @@ mod tests {
             let th = thread::current();
 
             let _guard = thread::spawn(move || {
-                super::sleep_ms(50);
+                super::sleep(Duration::from_millis(50));
                 th.unpark();
             });
 
-            thread::park_timeout_ms(u32::MAX);
+            thread::park_timeout(Duration::from_millis(u32::MAX as u64));
         }
     }
 
     #[test]
     fn sleep_ms_smoke() {
-        thread::sleep_ms(2);
+        thread::sleep(Duration::from_millis(2));
     }
 
     // NOTE: the corresponding test for stderr is in run-pass/thread-stderr, due

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -173,7 +173,6 @@ impl Div<u32> for Duration {
 
 #[cfg(test)]
 mod tests {
-    use prelude::v1::*;
     use super::Duration;
 
     #[test]


### PR DESCRIPTION
This PR siliences some warnings when compiling stdlib with --test. Mostly remove some unused imports and added a few `#[allow(..)]`.

I also marked some signal handling functions with `#[cfg(not(test))]`, because they are only called through `rt::lang_start`, which is also marked as  `#[cfg(not(test))]`
