### PR TITLE
Made dynamic_lib migration path more explicit

### DIFF
--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -16,7 +16,7 @@
             reason = "API has not been scrutinized and is highly likely to \
                       either disappear or change",
             issue = "27810")]
-#![rustc_deprecated(since = "1.5.0", reason = "replaced with crates.io crates")]
+#![rustc_deprecated(since = "1.5.0", reason = "replaced with crates.io 'libloading'")]
 #![allow(missing_docs)]
 #![allow(deprecated)]
 

--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -16,7 +16,7 @@
             reason = "API has not been scrutinized and is highly likely to \
                       either disappear or change",
             issue = "27810")]
-#![rustc_deprecated(since = "1.5.0", reason = "replaced with crates.io 'libloading'")]
+#![rustc_deprecated(since = "1.5.0", reason = "replaced with 'dylib' on crates.io")]
 #![allow(missing_docs)]
 #![allow(deprecated)]
 


### PR DESCRIPTION
The `dynamic_lib` library has been deprecated in favor of contents on crates.io, but apparently `libloading` is a more specific direction that fits the need.
