### PR TITLE
Implement Weak::new_downgraded() (#30425)

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -924,19 +924,18 @@ impl<T> Weak<T> {
     ///
     /// use std::sync::Arc;
     ///
-    /// let five = Arc::new(5);
+    /// let empty: Weak<i64> = Weak::new();
     /// ```
     #[unstable(feature = "downgraded_weak",
                reason = "recently added",
                issue = "30425")]
     pub fn new() -> Weak<T> {
         unsafe {
-            let x: Box<_> = box ArcInner {
+            Weak { _ptr: Shared::new(Box::into_raw(box ArcInner {
                 strong: atomic::AtomicUsize::new(0),
                 weak: atomic::AtomicUsize::new(1),
                 data: uninitialized(),
-            };
-            Weak { _ptr: Shared::new(Box::into_raw(x)) }
+            }))}
         }
     }
 }

--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -922,7 +922,7 @@ impl<T> Weak<T> {
     /// ```
     /// #![feature(downgraded_weak)]
     ///
-    /// use std::sync::Arc;
+    /// use std::sync::Weak;
     ///
     /// let empty: Weak<i64> = Weak::new();
     /// ```

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -160,11 +160,11 @@ use core::cell::Cell;
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{Hasher, Hash};
-use core::intrinsics::{assume, abort, uninit};
+use core::intrinsics::{assume, abort};
 use core::marker;
 #[cfg(not(stage0))]
 use core::marker::Unsize;
-use core::mem::{self, align_of_val, size_of_val, forget};
+use core::mem::{self, align_of_val, size_of_val, forget, uninitialized};
 use core::ops::Deref;
 #[cfg(not(stage0))]
 use core::ops::CoerceUnsized;
@@ -855,7 +855,7 @@ impl<T> Weak<T> {
                 _ptr: Shared::new(Box::into_raw(box RcBox {
                     strong: Cell::new(0),
                     weak: Cell::new(1),
-                    value: uninit(),
+                    value: uninitialized(),
                 })),
             }
         }

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -843,9 +843,8 @@ impl<T> Weak<T> {
     ///
     /// use std::rc::Weak;
     ///
-    /// let empty:Weak<i64> = Weak::new();
+    /// let empty: Weak<i64> = Weak::new();
     /// ```
-
     #[unstable(feature = "downgraded_weak",
                reason = "recently added",
                issue="30425")]

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -843,13 +843,13 @@ impl<T> Weak<T> {
     ///
     /// use std::rc::Weak;
     ///
-    /// let empty:Weak<i64> = Weak::new_downgraded();
+    /// let empty:Weak<i64> = Weak::new();
     /// ```
 
     #[unstable(feature = "downgraded_weak",
                reason = "recently added",
                issue="30425")]
-    pub fn new_downgraded() -> Weak<T> {
+    pub fn new() -> Weak<T> {
         unsafe {
             Weak {
                 _ptr: Shared::new(Box::into_raw(box RcBox {
@@ -1156,8 +1156,8 @@ mod tests {
     }
 
     #[test]
-    fn test_new_downgraded() {
-        let foo: Weak<usize> = Weak::new_downgraded();
+    fn test_new_weak() {
+        let foo: Weak<usize> = Weak::new();
         assert!(foo.upgrade().is_none());
     }
 }

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -839,9 +839,11 @@ impl<T> Weak<T> {
     /// # Examples
     ///
     /// ```
+    /// #![feature(downgraded_weak)]
+    ///
     /// use std::rc::Weak;
     ///
-    /// let five = Weak::new_downgraded();
+    /// let empty:Weak<i64> = Weak::new_downgraded();
     /// ```
 
     #[unstable(feature = "downgraded_weak",


### PR DESCRIPTION
This adds a constructor for a Weak that can never be upgraded. These are
mostly useless, but for example are required when deserializing.
