### PR TITLE
[MIR] Refine representation and translation of calls

### DIFF
--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -265,7 +265,7 @@ pub enum Terminator<'tcx> {
     }
 }
 
-#[derive(RustcEncodable, RustcDecodable)]
+#[derive(Clone, Copy, RustcEncodable, RustcDecodable)]
 pub enum CallTargets {
     /// The only target that should be entered when function returns normally.
     Return(BasicBlock),

--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -192,6 +192,7 @@ impl Debug for BasicBlock {
 pub struct BasicBlockData<'tcx> {
     pub statements: Vec<Statement<'tcx>>,
     pub terminator: Option<Terminator<'tcx>>,
+    pub is_cleanup: bool,
 }
 
 #[derive(RustcEncodable, RustcDecodable)]
@@ -341,6 +342,7 @@ impl<'tcx> BasicBlockData<'tcx> {
         BasicBlockData {
             statements: vec![],
             terminator: terminator,
+            is_cleanup: false,
         }
     }
 

--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -204,12 +204,6 @@ pub enum Terminator<'tcx> {
         target: BasicBlock,
     },
 
-    /// block should initiate unwinding; should be one successor
-    /// that does cleanup and branches to DIVERGE_BLOCK
-    Panic {
-        target: BasicBlock,
-    },
-
     /// jump to branch 0 if this lvalue evaluates to true
     If {
         cond: Operand<'tcx>,
@@ -320,7 +314,6 @@ impl<'tcx> Terminator<'tcx> {
         use self::Terminator::*;
         match *self {
             Goto { target: ref b } => slice::ref_slice(b),
-            Panic { target: ref b } => slice::ref_slice(b),
             If { targets: ref b, .. } => b.as_slice(),
             Switch { targets: ref b, .. } => b,
             SwitchInt { targets: ref b, .. } => b,
@@ -340,7 +333,6 @@ impl<'tcx> Terminator<'tcx> {
         use self::Terminator::*;
         match *self {
             Goto { target: ref mut b } => slice::mut_ref_slice(b),
-            Panic { target: ref mut b } => slice::mut_ref_slice(b),
             If { targets: ref mut b, .. } => b.as_mut_slice(),
             Switch { targets: ref mut b, .. } => b,
             SwitchInt { targets: ref mut b, .. } => b,
@@ -401,7 +393,6 @@ impl<'tcx> Terminator<'tcx> {
         use self::Terminator::*;
         match *self {
             Goto { .. } => write!(fmt, "goto"),
-            Panic { .. } => write!(fmt, "panic"),
             If { cond: ref lv, .. } => write!(fmt, "if({:?})", lv),
             Switch { discr: ref lv, .. } => write!(fmt, "switch({:?})", lv),
             SwitchInt { discr: ref lv, .. } => write!(fmt, "switchInt({:?})", lv),
@@ -424,7 +415,7 @@ impl<'tcx> Terminator<'tcx> {
         use self::Terminator::*;
         match *self {
             Diverge | Return | Resume => vec![],
-            Goto { .. } | Panic { .. } => vec!["".into_cow()],
+            Goto { .. } => vec!["".into_cow()],
             If { .. } => vec!["true".into_cow(), "false".into_cow()],
             Call { .. } => vec!["return".into_cow(), "unwind".into_cow()],
             DivergingCall { .. } => vec!["unwind".into_cow()],

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -84,7 +84,7 @@ pub trait Visitor<'tcx> {
         for statement in &data.statements {
             self.visit_statement(block, statement);
         }
-        self.visit_terminator(block, &data.terminator);
+        data.terminator.as_ref().map(|r| self.visit_terminator(block, r));
     }
 
     fn super_statement(&mut self, block: BasicBlock, statement: &Statement<'tcx>) {
@@ -132,7 +132,6 @@ pub trait Visitor<'tcx> {
                 }
             }
 
-            Terminator::Diverge |
             Terminator::Resume |
             Terminator::Return => {
             }
@@ -374,7 +373,7 @@ pub trait MutVisitor<'tcx> {
         for statement in &mut data.statements {
             self.visit_statement(block, statement);
         }
-        self.visit_terminator(block, &mut data.terminator);
+        data.terminator.as_mut().map(|r| self.visit_terminator(block, r));
     }
 
     fn super_statement(&mut self,
@@ -429,7 +428,6 @@ pub trait MutVisitor<'tcx> {
                 }
             }
 
-            Terminator::Diverge |
             Terminator::Resume |
             Terminator::Return => {
             }

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -136,23 +136,15 @@ pub trait Visitor<'tcx> {
             Terminator::Return => {
             }
 
-            Terminator::Call { ref func, ref args, ref destination, ref targets } => {
-                self.visit_lvalue(destination, LvalueContext::Store);
+            Terminator::Call { ref func, ref args, ref kind } => {
+                if let Some(ref destination) = kind.destination() {
+                    self.visit_lvalue(destination, LvalueContext::Store);
+                }
                 self.visit_operand(func);
                 for arg in args {
                     self.visit_operand(arg);
                 }
-                for &target in targets.as_slice() {
-                    self.visit_branch(block, target);
-                }
-            }
-
-            Terminator::DivergingCall { ref func, ref args, ref cleanup } => {
-                self.visit_operand(func);
-                for arg in args {
-                    self.visit_operand(arg);
-                }
-                for &target in cleanup.as_ref() {
+                for &target in kind.successors() {
                     self.visit_branch(block, target);
                 }
             }
@@ -432,26 +424,15 @@ pub trait MutVisitor<'tcx> {
             Terminator::Return => {
             }
 
-            Terminator::Call { ref mut func,
-                               ref mut args,
-                               ref mut destination,
-                               ref mut targets } => {
-                self.visit_lvalue(destination, LvalueContext::Store);
+            Terminator::Call { ref mut func, ref mut args, ref mut kind } => {
+                if let Some(ref mut destination) = kind.destination() {
+                    self.visit_lvalue(destination, LvalueContext::Store);
+                }
                 self.visit_operand(func);
                 for arg in args {
                     self.visit_operand(arg);
                 }
-                for &target in targets.as_slice() {
-                    self.visit_branch(block, target);
-                }
-            }
-
-            Terminator::DivergingCall { ref mut func, ref mut args, ref mut cleanup } => {
-                self.visit_operand(func);
-                for arg in args {
-                    self.visit_operand(arg);
-                }
-                for &target in cleanup.as_ref() {
+                for &target in kind.successors() {
                     self.visit_branch(block, target);
                 }
             }

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -134,6 +134,7 @@ pub trait Visitor<'tcx> {
             }
 
             Terminator::Diverge |
+            Terminator::Resume |
             Terminator::Return => {
             }
 
@@ -431,6 +432,7 @@ pub trait MutVisitor<'tcx> {
             }
 
             Terminator::Diverge |
+            Terminator::Resume |
             Terminator::Return => {
             }
 

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -107,8 +107,7 @@ pub trait Visitor<'tcx> {
 
     fn super_terminator(&mut self, block: BasicBlock, terminator: &Terminator<'tcx>) {
         match *terminator {
-            Terminator::Goto { target } |
-            Terminator::Panic { target } => {
+            Terminator::Goto { target } => {
                 self.visit_branch(block, target);
             }
 
@@ -405,8 +404,7 @@ pub trait MutVisitor<'tcx> {
                         block: BasicBlock,
                         terminator: &mut Terminator<'tcx>) {
         match *terminator {
-            Terminator::Goto { target } |
-            Terminator::Panic { target } => {
+            Terminator::Goto { target } => {
                 self.visit_branch(block, target);
             }
 

--- a/src/librustc_mir/build/cfg.rs
+++ b/src/librustc_mir/build/cfg.rs
@@ -28,7 +28,7 @@ impl<'tcx> CFG<'tcx> {
 
     pub fn start_new_block(&mut self) -> BasicBlock {
         let node_index = self.basic_blocks.len();
-        self.basic_blocks.push(BasicBlockData::new(Terminator::Diverge));
+        self.basic_blocks.push(BasicBlockData::new(None));
         BasicBlock::new(node_index)
     }
 
@@ -67,15 +67,9 @@ impl<'tcx> CFG<'tcx> {
     pub fn terminate(&mut self,
                      block: BasicBlock,
                      terminator: Terminator<'tcx>) {
-        // Check whether this block has already been terminated. For
-        // this, we rely on the fact that the initial state is to have
-        // a Diverge terminator and an empty list of targets (which
-        // is not a valid state).
-        debug_assert!(match self.block_data(block).terminator { Terminator::Diverge => true,
-                                                                _ => false },
+        debug_assert!(self.block_data(block).terminator.is_none(),
                       "terminate: block {:?} already has a terminator set", block);
-
-        self.block_data_mut(block).terminator = terminator;
+        self.block_data_mut(block).terminator = Some(terminator);
     }
 }
 

--- a/src/librustc_mir/build/expr/as_lvalue.rs
+++ b/src/librustc_mir/build/expr/as_lvalue.rs
@@ -71,7 +71,7 @@ impl<'a,'tcx> Builder<'a,'tcx> {
                                        cond: Operand::Consume(lt),
                                        targets: (success, failure),
                                    });
-                this.panic_bound_check(failure, idx.clone(), Operand::Consume(len), expr_span);
+                this.panic_bounds_check(failure, idx.clone(), Operand::Consume(len), expr_span);
                 success.and(slice.index(idx))
             }
             ExprKind::SelfRef => {

--- a/src/librustc_mir/build/expr/as_lvalue.rs
+++ b/src/librustc_mir/build/expr/as_lvalue.rs
@@ -63,7 +63,7 @@ impl<'a,'tcx> Builder<'a,'tcx> {
                 this.cfg.push_assign(block, expr_span, // lt = idx < len
                                      &lt, Rvalue::BinaryOp(BinOp::Lt,
                                                            idx.clone(),
-                                                           Operand::Consume(len)));
+                                                           Operand::Consume(len.clone())));
 
                 let (success, failure) = (this.cfg.start_new_block(), this.cfg.start_new_block());
                 this.cfg.terminate(block,
@@ -71,7 +71,7 @@ impl<'a,'tcx> Builder<'a,'tcx> {
                                        cond: Operand::Consume(lt),
                                        targets: (success, failure),
                                    });
-                this.panic(failure);
+                this.panic_bound_check(failure, idx.clone(), Operand::Consume(len), expr_span);
                 success.and(slice.index(idx))
             }
             ExprKind::SelfRef => {

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -225,13 +225,13 @@ impl<'a,'tcx> Builder<'a,'tcx> {
                 let success = this.cfg.start_new_block();
                 let cleanup = this.diverge_cleanup();
                 let term = if diverges {
-                    Terminator::DivergingCall { func: fun, args: args, cleanup: Some(cleanup) }
+                    Terminator::DivergingCall { func: fun, args: args, cleanup: cleanup }
                 } else {
                     Terminator::Call {
                         func: fun,
                         args: args,
                         destination: destination.clone(),
-                        targets: CallTargets::WithCleanup((success, cleanup))
+                        targets: CallTargets::new(success, cleanup)
                     }
                 };
                 this.cfg.terminate(block, term);

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -218,14 +218,13 @@ impl<'a,'tcx> Builder<'a,'tcx> {
                         .collect();
                 let success = this.cfg.start_new_block();
                 let panic = this.diverge_cleanup();
+                let targets = CallTargets::WithCleanup((success, panic));
                 this.cfg.terminate(block,
                                    Terminator::Call {
-                                       data: CallData {
-                                           destination: destination.clone(),
-                                           func: fun,
-                                           args: args,
-                                       },
-                                       targets: (success, panic),
+                                       func: fun,
+                                       args: args,
+                                       destination: destination.clone(),
+                                       targets: targets
                                    });
                 success.unit()
             }

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -89,7 +89,7 @@ impl<'a,'tcx> Builder<'a,'tcx> {
         // not entirely precise
         if !otherwise.is_empty() {
             let join_block = self.join_otherwise_blocks(otherwise);
-            self.panic(join_block);
+            self.panic(join_block, "something about matches algorithm not being precise", span);
         }
 
         // all the arm blocks will rejoin here

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -107,7 +107,6 @@ pub fn construct<'a,'tcx>(mut hir: Cx<'a,'tcx>,
 
     assert_eq!(builder.cfg.start_new_block(), START_BLOCK);
     assert_eq!(builder.cfg.start_new_block(), END_BLOCK);
-    assert_eq!(builder.cfg.start_new_block(), DIVERGE_BLOCK);
 
     let mut block = START_BLOCK;
     let arg_decls = unpack!(block = builder.args_and_body(block,

--- a/src/librustc_mir/build/scope.rs
+++ b/src/librustc_mir/build/scope.rs
@@ -251,6 +251,7 @@ impl<'a,'tcx> Builder<'a,'tcx> {
                 continue;
             } else {
                 let new_block = self.cfg.start_new_block();
+                self.cfg.block_data_mut(new_block).is_cleanup = true;
                 self.cfg.terminate(new_block, terminator);
                 terminator = Terminator::Goto { target: new_block };
                 for &(kind, span, ref lvalue) in scope.drops.iter().rev() {

--- a/src/librustc_mir/graphviz.rs
+++ b/src/librustc_mir/graphviz.rs
@@ -62,7 +62,7 @@ fn write_node<W: Write>(block: BasicBlock, mir: &Mir, w: &mut W) -> io::Result<(
     // Terminator head at the bottom, not including the list of successor blocks. Those will be
     // displayed as labels on the edges between blocks.
     let mut terminator_head = String::new();
-    data.terminator.fmt_head(&mut terminator_head).unwrap();
+    data.terminator().fmt_head(&mut terminator_head).unwrap();
     try!(write!(w, r#"<tr><td align="left">{}</td></tr>"#, dot::escape_html(&terminator_head)));
 
     // Close the table, node label, and the node itself.
@@ -71,7 +71,7 @@ fn write_node<W: Write>(block: BasicBlock, mir: &Mir, w: &mut W) -> io::Result<(
 
 /// Write graphviz DOT edges with labels between the given basic block and all of its successors.
 fn write_edges<W: Write>(source: BasicBlock, mir: &Mir, w: &mut W) -> io::Result<()> {
-    let terminator = &mir.basic_block_data(source).terminator;
+    let terminator = &mir.basic_block_data(source).terminator();
     let labels = terminator.fmt_successor_labels();
 
     for (&target, label) in terminator.successors().iter().zip(labels) {

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -41,6 +41,7 @@ impl<'tcx> Mirror<'tcx> for &'tcx hir::Expr {
                                .map(|e| e.to_ref())
                                .collect();
                 ExprKind::Call {
+                    ty: expr.ty,
                     fun: expr.to_ref(),
                     args: args,
                 }
@@ -58,11 +59,17 @@ impl<'tcx> Mirror<'tcx> for &'tcx hir::Expr {
                     argrefs.extend(args.iter().map(|a| a.to_ref()));
 
                     ExprKind::Call {
+                        ty: method.ty,
                         fun: method.to_ref(),
                         args: argrefs,
                     }
                 } else {
-                    ExprKind::Call { fun: fun.to_ref(), args: args.to_ref() }
+                    ExprKind::Call {
+                        ty: &cx.tcx.node_id_to_type(fun.id),
+                        fun: fun.to_ref(),
+                        args: args.to_ref(),
+                    }
+
                 }
             }
 
@@ -802,6 +809,7 @@ fn overloaded_operator<'a, 'tcx: 'a>(cx: &mut Cx<'a, 'tcx>,
     // now create the call itself
     let fun = method_callee(cx, expr, method_call);
     ExprKind::Call {
+        ty: fun.ty,
         fun: fun.to_ref(),
         args: argrefs,
     }

--- a/src/librustc_mir/hair/cx/mod.rs
+++ b/src/librustc_mir/hair/cx/mod.rs
@@ -22,6 +22,7 @@ use rustc::middle::const_eval::{self, ConstVal};
 use rustc::middle::infer::InferCtxt;
 use rustc::middle::ty::{self, Ty};
 use syntax::codemap::Span;
+use syntax::parse::token;
 use rustc_front::hir;
 
 #[derive(Copy, Clone)]
@@ -59,6 +60,10 @@ impl<'a,'tcx:'a> Cx<'a, 'tcx> {
 
     pub fn bool_ty(&mut self) -> Ty<'tcx> {
         self.tcx.types.bool
+    }
+
+    pub fn str_literal(&mut self, value: token::InternedString) -> Literal<'tcx> {
+        Literal::Value { value: ConstVal::Str(value) }
     }
 
     pub fn true_literal(&mut self) -> Literal<'tcx> {

--- a/src/librustc_mir/hair/mod.rs
+++ b/src/librustc_mir/hair/mod.rs
@@ -19,7 +19,7 @@ use rustc::middle::const_eval::ConstVal;
 use rustc::middle::def_id::DefId;
 use rustc::middle::region::CodeExtent;
 use rustc::middle::subst::Substs;
-use rustc::middle::ty::{AdtDef, ClosureSubsts, Region, Ty};
+use rustc::middle::ty::{self, AdtDef, ClosureSubsts, Region, Ty};
 use rustc_front::hir;
 use syntax::ast;
 use syntax::codemap::Span;
@@ -124,6 +124,7 @@ pub enum ExprKind<'tcx> {
         value: ExprRef<'tcx>,
     },
     Call {
+        ty: ty::Ty<'tcx>,
         fun: ExprRef<'tcx>,
         args: Vec<ExprRef<'tcx>>,
     },

--- a/src/librustc_mir/transform/erase_regions.rs
+++ b/src/librustc_mir/transform/erase_regions.rs
@@ -90,23 +90,18 @@ impl<'a, 'tcx> EraseRegions<'a, 'tcx> {
             Terminator::Switch { ref mut discr, .. } => {
                 self.erase_regions_lvalue(discr);
             }
-            Terminator::SwitchInt {
-                ref mut discr,
-                ref mut switch_ty,
-                ..
-            } => {
+            Terminator::SwitchInt { ref mut discr, ref mut switch_ty, .. } => {
                 self.erase_regions_lvalue(discr);
                 *switch_ty = self.tcx.erase_regions(switch_ty);
             },
-            Terminator::Call {
-                data: CallData {
-                    ref mut destination,
-                    ref mut func,
-                    ref mut args
-                },
-                ..
-            } => {
+            Terminator::Call { ref mut destination, ref mut func, ref mut args, .. } => {
                 self.erase_regions_lvalue(destination);
+                self.erase_regions_operand(func);
+                for arg in &mut *args {
+                    self.erase_regions_operand(arg);
+                }
+            }
+            Terminator::DivergingCall { ref mut func, ref mut args, .. } => {
                 self.erase_regions_operand(func);
                 for arg in &mut *args {
                     self.erase_regions_operand(arg);

--- a/src/librustc_mir/transform/erase_regions.rs
+++ b/src/librustc_mir/transform/erase_regions.rs
@@ -80,6 +80,7 @@ impl<'a, 'tcx> EraseRegions<'a, 'tcx> {
         match *terminator {
             Terminator::Goto { .. } |
             Terminator::Diverge |
+            Terminator::Resume |
             Terminator::Return |
             Terminator::Panic { .. } => {
                 /* nothing to do */

--- a/src/librustc_mir/transform/erase_regions.rs
+++ b/src/librustc_mir/transform/erase_regions.rs
@@ -81,8 +81,7 @@ impl<'a, 'tcx> EraseRegions<'a, 'tcx> {
             Terminator::Goto { .. } |
             Terminator::Diverge |
             Terminator::Resume |
-            Terminator::Return |
-            Terminator::Panic { .. } => {
+            Terminator::Return => {
                 /* nothing to do */
             }
             Terminator::If { ref mut cond, .. } => {

--- a/src/librustc_mir/transform/erase_regions.rs
+++ b/src/librustc_mir/transform/erase_regions.rs
@@ -59,7 +59,7 @@ impl<'a, 'tcx> EraseRegions<'a, 'tcx> {
             self.erase_regions_statement(statement);
         }
 
-        self.erase_regions_terminator(&mut basic_block.terminator);
+        self.erase_regions_terminator(basic_block.terminator_mut());
     }
 
     fn erase_regions_statement(&mut self,
@@ -79,7 +79,6 @@ impl<'a, 'tcx> EraseRegions<'a, 'tcx> {
                                 terminator: &mut Terminator<'tcx>) {
         match *terminator {
             Terminator::Goto { .. } |
-            Terminator::Diverge |
             Terminator::Resume |
             Terminator::Return => {
                 /* nothing to do */

--- a/src/librustc_mir/transform/erase_regions.rs
+++ b/src/librustc_mir/transform/erase_regions.rs
@@ -93,14 +93,10 @@ impl<'a, 'tcx> EraseRegions<'a, 'tcx> {
                 self.erase_regions_lvalue(discr);
                 *switch_ty = self.tcx.erase_regions(switch_ty);
             },
-            Terminator::Call { ref mut destination, ref mut func, ref mut args, .. } => {
-                self.erase_regions_lvalue(destination);
-                self.erase_regions_operand(func);
-                for arg in &mut *args {
-                    self.erase_regions_operand(arg);
+            Terminator::Call { ref mut func, ref mut args, ref mut kind } => {
+                if let Some(ref mut destination) = kind.destination() {
+                    self.erase_regions_lvalue(destination);
                 }
-            }
-            Terminator::DivergingCall { ref mut func, ref mut args, .. } => {
                 self.erase_regions_operand(func);
                 for arg in &mut *args {
                     self.erase_regions_operand(arg);

--- a/src/librustc_mir/transform/util.rs
+++ b/src/librustc_mir/transform/util.rs
@@ -15,7 +15,7 @@ use rustc::mir::repr::*;
 /// in a single pass
 pub fn update_basic_block_ids(mir: &mut Mir, replacements: &[BasicBlock]) {
     for bb in mir.all_basic_blocks() {
-        for target in mir.basic_block_data_mut(bb).terminator.successors_mut() {
+        for target in mir.basic_block_data_mut(bb).terminator_mut().successors_mut() {
             *target = replacements[target.index()];
         }
     }

--- a/src/librustc_trans/trans/mir/block.rs
+++ b/src/librustc_trans/trans/mir/block.rs
@@ -40,10 +40,6 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                 build::Br(bcx, self.llblock(target), DebugLoc::None)
             }
 
-            mir::Terminator::Panic { .. } => {
-                unimplemented!()
-            }
-
             mir::Terminator::If { ref cond, targets: (true_bb, false_bb) } => {
                 let cond = self.trans_operand(bcx, cond);
                 let lltrue = self.llblock(true_bb);

--- a/src/librustc_trans/trans/mir/block.rs
+++ b/src/librustc_trans/trans/mir/block.rs
@@ -33,9 +33,9 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
             bcx = self.trans_statement(bcx, statement);
         }
 
-        debug!("trans_block: terminator: {:?}", data.terminator);
+        debug!("trans_block: terminator: {:?}", data.terminator());
 
-        match data.terminator {
+        match *data.terminator() {
             mir::Terminator::Goto { target } => {
                 build::Br(bcx, self.llblock(target), DebugLoc::None)
             }
@@ -80,10 +80,6 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                     let llbb = self.llblock(*target);
                     build::AddCase(switch, llval, llbb)
                 }
-            }
-
-            mir::Terminator::Diverge => {
-                build::Unreachable(bcx);
             }
 
             mir::Terminator::Resume => {

--- a/src/librustc_trans/trans/mir/block.rs
+++ b/src/librustc_trans/trans/mir/block.rs
@@ -164,6 +164,10 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                 }
 
                 build::Br(bcx, self.llblock(targets.0), DebugLoc::None)
+            },
+
+            mir::Terminator::DivergingCall { .. } => {
+                unimplemented!()
             }
         }
     }

--- a/src/librustc_trans/trans/mir/block.rs
+++ b/src/librustc_trans/trans/mir/block.rs
@@ -87,16 +87,16 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
             }
 
             mir::Terminator::Diverge => {
+                build::Unreachable(bcx);
+            }
+
+            mir::Terminator::Resume => {
                 if let Some(llpersonalityslot) = self.llpersonalityslot {
                     let lp = build::Load(bcx, llpersonalityslot);
                     // FIXME(lifetime) base::call_lifetime_end(bcx, self.personality);
                     build::Resume(bcx, lp);
                 } else {
-                    // This fn never encountered anything fallible, so
-                    // a Diverge cannot actually happen. Note that we
-                    // do a total hack to ensure that we visit the
-                    // DIVERGE block last.
-                    build::Unreachable(bcx);
+                    panic!("resume terminator without personality slot")
                 }
             }
 

--- a/src/librustc_trans/trans/mir/mod.rs
+++ b/src/librustc_trans/trans/mir/mod.rs
@@ -125,16 +125,11 @@ pub fn trans_mir<'bcx, 'tcx>(bcx: Block<'bcx, 'tcx>) {
 
     // Translate the body of each block
     for &bb in &mir_blocks {
-        if bb != mir::DIVERGE_BLOCK {
-            mircx.trans_block(bb);
-        }
+        // NB that we do not handle the Resume terminator specially, because a block containing
+        // that terminator will have a higher block number than a function call which should take
+        // care of filling in that information.
+        mircx.trans_block(bb);
     }
-
-    // Total hack: translate DIVERGE_BLOCK last. This is so that any
-    // panics which the fn may do can initialize the
-    // `llpersonalityslot` cell. We don't do this up front because the
-    // LLVM type of it is (frankly) annoying to compute.
-    mircx.trans_block(mir::DIVERGE_BLOCK);
 }
 
 /// Produce, for each argument, a `ValueRef` pointing at the

--- a/src/librustc_trans/trans/mir/mod.rs
+++ b/src/librustc_trans/trans/mir/mod.rs
@@ -28,6 +28,9 @@ use self::operand::OperandRef;
 pub struct MirContext<'bcx, 'tcx:'bcx> {
     mir: &'bcx mir::Mir<'tcx>,
 
+    /// Function context
+    fcx: &'bcx common::FunctionContext<'bcx, 'tcx>,
+
     /// When unwinding is initiated, we have to store this personality
     /// value somewhere so that we can load it and re-use it in the
     /// resume instruction. The personality is (afaik) some kind of
@@ -39,6 +42,9 @@ pub struct MirContext<'bcx, 'tcx:'bcx> {
 
     /// A `Block` for each MIR `BasicBlock`
     blocks: Vec<Block<'bcx, 'tcx>>,
+
+    /// Cached unreachable block
+    unreachable_block: Option<Block<'bcx, 'tcx>>,
 
     /// An LLVM alloca for each MIR `VarDecl`
     vars: Vec<LvalueRef<'tcx>>,
@@ -116,8 +122,10 @@ pub fn trans_mir<'bcx, 'tcx>(bcx: Block<'bcx, 'tcx>) {
 
     let mut mircx = MirContext {
         mir: mir,
+        fcx: fcx,
         llpersonalityslot: None,
         blocks: block_bcxs,
+        unreachable_block: None,
         vars: vars,
         temps: temps,
         args: args,

--- a/src/librustc_trans/trans/mir/mod.rs
+++ b/src/librustc_trans/trans/mir/mod.rs
@@ -136,9 +136,6 @@ pub fn trans_mir<'bcx, 'tcx>(bcx: Block<'bcx, 'tcx>) {
 
     // Translate the body of each block
     for &bb in &mir_blocks {
-        // NB that we do not handle the Resume terminator specially, because a block containing
-        // that terminator will have a higher block number than a function call which should take
-        // care of filling in that information.
         mircx.trans_block(bb);
     }
 }

--- a/src/librustc_trans/trans/mir/mod.rs
+++ b/src/librustc_trans/trans/mir/mod.rs
@@ -113,7 +113,10 @@ pub fn trans_mir<'bcx, 'tcx>(bcx: Block<'bcx, 'tcx>) {
     // Allocate a `Block` for every basic block
     let block_bcxs: Vec<Block<'bcx,'tcx>> =
         mir_blocks.iter()
-                  .map(|&bb| fcx.new_block(false, &format!("{:?}", bb), None))
+                  .map(|&bb|{
+                      let is_cleanup = mir.basic_block_data(bb).is_cleanup;
+                      fcx.new_block(is_cleanup, &format!("{:?}", bb), None)
+                  })
                   .collect();
 
     // Branch to the START block

--- a/src/test/run-fail/mir_indexing_oob_1.rs
+++ b/src/test/run-fail/mir_indexing_oob_1.rs
@@ -1,0 +1,23 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:index out of bounds: the len is 5 but the index is 10
+#![feature(rustc_attrs)]
+
+const C: [u32; 5] = [0; 5];
+
+#[rustc_mir]
+fn test() -> u32 {
+    C[10]
+}
+
+fn main() {
+    test();
+}

--- a/src/test/run-fail/mir_indexing_oob_2.rs
+++ b/src/test/run-fail/mir_indexing_oob_2.rs
@@ -1,0 +1,23 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:index out of bounds: the len is 5 but the index is 10
+#![feature(rustc_attrs)]
+
+const C: &'static [u8; 5] = b"hello";
+
+#[rustc_mir]
+fn test() -> u8 {
+    C[10]
+}
+
+fn main() {
+    test();
+}

--- a/src/test/run-fail/mir_indexing_oob_3.rs
+++ b/src/test/run-fail/mir_indexing_oob_3.rs
@@ -1,0 +1,23 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:index out of bounds: the len is 5 but the index is 10
+#![feature(rustc_attrs)]
+
+const C: &'static [u8; 5] = b"hello";
+
+#[rustc_mir]
+fn mir() -> u8 {
+    C[10]
+}
+
+fn main() {
+    mir();
+}

--- a/src/test/run-fail/mir_trans_calls_converging_drops.rs
+++ b/src/test/run-fail/mir_trans_calls_converging_drops.rs
@@ -1,0 +1,37 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![feature(rustc_attrs)]
+// error-pattern:converging_fn called
+// error-pattern:0 dropped
+// error-pattern:exit
+
+use std::io::{self, Write};
+
+struct Droppable(u8);
+impl Drop for Droppable {
+    fn drop(&mut self) {
+        write!(io::stderr(), "{} dropped\n", self.0);
+    }
+}
+
+fn converging_fn() {
+    write!(io::stderr(), "converging_fn called\n");
+}
+
+#[rustc_mir]
+fn mir(d: Droppable) {
+    converging_fn();
+}
+
+fn main() {
+    let d = Droppable(0);
+    mir(d);
+    panic!("exit");
+}

--- a/src/test/run-fail/mir_trans_calls_converging_drops_2.rs
+++ b/src/test/run-fail/mir_trans_calls_converging_drops_2.rs
@@ -1,0 +1,41 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![feature(rustc_attrs)]
+// error-pattern:complex called
+// error-pattern:dropped
+// error-pattern:exit
+
+use std::io::{self, Write};
+
+struct Droppable;
+impl Drop for Droppable {
+    fn drop(&mut self) {
+        write!(io::stderr(), "dropped\n");
+    }
+}
+
+// return value of this function is copied into the return slot
+fn complex() -> u64 {
+    write!(io::stderr(), "complex called\n");
+    42
+}
+
+
+#[rustc_mir]
+fn mir() -> u64 {
+    let x = Droppable;
+    return complex();
+    drop(x);
+}
+
+pub fn main() {
+    assert_eq!(mir(), 42);
+    panic!("exit");
+}

--- a/src/test/run-fail/mir_trans_calls_diverging.rs
+++ b/src/test/run-fail/mir_trans_calls_diverging.rs
@@ -1,0 +1,24 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![feature(rustc_attrs)]
+// error-pattern:diverging_fn called
+
+fn diverging_fn() -> ! {
+    panic!("diverging_fn called")
+}
+
+#[rustc_mir]
+fn mir() {
+    diverging_fn();
+}
+
+fn main() {
+    mir();
+}

--- a/src/test/run-fail/mir_trans_calls_diverging_drops.rs
+++ b/src/test/run-fail/mir_trans_calls_diverging_drops.rs
@@ -1,0 +1,34 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![feature(rustc_attrs)]
+// error-pattern:diverging_fn called
+// error-pattern:0 dropped
+use std::io::{self, Write};
+
+struct Droppable(u8);
+impl Drop for Droppable {
+    fn drop(&mut self) {
+        write!(io::stderr(), "{} dropped", self.0);
+    }
+}
+
+fn diverging_fn() -> ! {
+    panic!("diverging_fn called")
+}
+
+#[rustc_mir]
+fn mir(d: Droppable) {
+    diverging_fn();
+}
+
+fn main() {
+    let d = Droppable(0);
+    mir(d);
+}

--- a/src/test/run-fail/mir_trans_no_landing_pads.rs
+++ b/src/test/run-fail/mir_trans_no_landing_pads.rs
@@ -1,0 +1,36 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![feature(rustc_attrs)]
+// compile-flags: -Z no-landing-pads
+// error-pattern:converging_fn called
+use std::io::{self, Write};
+
+struct Droppable;
+impl Drop for Droppable {
+    fn drop(&mut self) {
+        ::std::process::exit(1)
+    }
+}
+
+fn converging_fn() {
+    panic!("converging_fn called")
+}
+
+#[rustc_mir]
+fn mir(d: Droppable) {
+    let x = Droppable;
+    converging_fn();
+    drop(x);
+    drop(d);
+}
+
+fn main() {
+    mir(Droppable);
+}

--- a/src/test/run-fail/mir_trans_no_landing_pads_diverging.rs
+++ b/src/test/run-fail/mir_trans_no_landing_pads_diverging.rs
@@ -1,0 +1,36 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![feature(rustc_attrs)]
+// compile-flags: -Z no-landing-pads
+// error-pattern:diverging_fn called
+use std::io::{self, Write};
+
+struct Droppable;
+impl Drop for Droppable {
+    fn drop(&mut self) {
+        ::std::process::exit(1)
+    }
+}
+
+fn diverging_fn() -> ! {
+    panic!("diverging_fn called")
+}
+
+#[rustc_mir]
+fn mir(d: Droppable) {
+    let x = Droppable;
+    diverging_fn();
+    drop(x);
+    drop(d);
+}
+
+fn main() {
+    mir(Droppable);
+}

--- a/src/test/run-pass/mir_trans_call_converging.rs
+++ b/src/test/run-pass/mir_trans_call_converging.rs
@@ -1,0 +1,28 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![feature(rustc_attrs)]
+
+fn converging_fn() -> u64 {
+    43
+}
+
+#[rustc_mir]
+fn mir() -> u64 {
+    let x;
+    loop {
+        x = converging_fn();
+        break;
+    }
+    x
+}
+
+fn main() {
+    assert_eq!(mir(), 43);
+}

--- a/src/test/run-pass/mir_void_return.rs
+++ b/src/test/run-pass/mir_void_return.rs
@@ -1,0 +1,24 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_attrs)]
+
+#[rustc_mir]
+fn mir() -> (){
+    let x = 1;
+    let mut y = 0;
+    while  y < x {
+        y += 1
+    }
+}
+
+pub fn main() {
+    mir();
+}

--- a/src/test/run-pass/mir_void_return_2.rs
+++ b/src/test/run-pass/mir_void_return_2.rs
@@ -1,0 +1,22 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_attrs)]
+
+fn nil() {}
+
+#[rustc_mir]
+fn mir(){
+    nil()
+}
+
+pub fn main() {
+    mir();
+}


### PR DESCRIPTION
r? @nikomatsakis 

This is a pretty big PR conflating changes to a few different block terminators (Call, DivergingCall, Panic, Resume, Diverge), because they are somewhat closely related.

Each commit has a pretty good description on what is being changed in each commit. The end result is greatly simplified CFG and translation for calls (no success branch if the function is diverging, no cleanup branch if there’s nothing to cleanup etc).

Fixes https://github.com/rust-lang/rust/issues/30480
Fixes https://github.com/rust-lang/rust/issues/29767
Partialy solves https://github.com/rust-lang/rust/issues/29575
Fixes https://github.com/rust-lang/rust/issues/29573
