### PR TITLE
openbsd: use specific linker instead of cc

### DIFF
--- a/mk/cfg/x86_64-unknown-openbsd.mk
+++ b/mk/cfg/x86_64-unknown-openbsd.mk
@@ -20,3 +20,4 @@ CFG_LDPATH_x86_64-unknown-openbsd :=
 CFG_RUN_x86_64-unknown-openbsd=$(2)
 CFG_RUN_TARG_x86_64-unknown-openbsd=$(call CFG_RUN_x86_64-unknown-openbsd,,$(2))
 CFG_GNU_TRIPLE_x86_64-unknown-openbsd := x86_64-unknown-openbsd
+RUSTC_FLAGS_x86_64-unknown-openbsd=-C linker=$(call FIND_COMPILER,$(CC))

--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -215,16 +215,6 @@ define CFG_MAKE_TOOLCHAIN
 
   ifeq ($$(findstring $(HOST_$(1)),arm aarch64 mips mipsel powerpc),)
 
-  # On OpenBSD, we need to pass the path of libstdc++.so to the linker
-  # (use path of libstdc++.a which is a known name for the same path)
-  ifeq ($(OSTYPE_$(1)),unknown-openbsd)
-    STDCPP_LIBDIR_RUSTFLAGS_$(1)= \
-        -L "$$(dir $$(shell $$(CC_$(1)) $$(CFG_GCCISH_CFLAGS_$(1)) \
-        -print-file-name=lib$(CFG_STDCPP_NAME).a))"
-  else
-    STDCPP_LIBDIR_RUSTFLAGS_$(1)=
-  endif
-
   # On Bitrig, we need the relocation model to be PIC for everything
   ifeq (,$(filter $(OSTYPE_$(1)),bitrig))
     LLVM_MC_RELOCATION_MODEL="pic"

--- a/mk/target.mk
+++ b/mk/target.mk
@@ -95,7 +95,6 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$(4): \
 		$$(RUSTFLAGS_$(4)) \
 		$$(RUSTFLAGS$(1)_$(4)) \
 		$$(RUSTFLAGS$(1)_$(4)_T_$(2)) \
-		$$(STDCPP_LIBDIR_RUSTFLAGS_$(2)) \
 		--out-dir $$(@D) \
 		-C extra-filename=-$$(CFG_FILENAME_EXTRA) \
 		$$<
@@ -130,7 +129,6 @@ $$(TBIN$(1)_T_$(2)_H_$(3))/$(4)$$(X_$(2)): \
 		| $$(TBIN$(1)_T_$(2)_H_$(3))/
 	@$$(call E, rustc: $$@)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) \
-		$$(STDCPP_LIBDIR_RUSTFLAGS_$(2)) \
 		$$(LLVM_LIBDIR_RUSTFLAGS_$(2)) \
 		-o $$@ $$< --cfg $(4)
 

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -393,8 +393,7 @@ $(3)/stage$(1)/test/$(4)test-$(2)$$(X_$(2)): \
 	    $$(subst @,,$$(STAGE$(1)_T_$(2)_H_$(3))) -o $$@ $$< --test \
 		-L "$$(RT_OUTPUT_DIR_$(2))" \
 		$$(LLVM_LIBDIR_RUSTFLAGS_$(2)) \
-		$$(RUSTFLAGS_$(4)) \
-		$$(STDCPP_LIBDIR_RUSTFLAGS_$(2))
+		$$(RUSTFLAGS_$(4))
 
 endef
 
@@ -664,9 +663,9 @@ CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3) := \
         --android-cross-path=$(CFG_ANDROID_CROSS_PATH) \
         --adb-path=$(CFG_ADB) \
         --adb-test-dir=$(CFG_ADB_TEST_DIR) \
-        --host-rustcflags "$(RUSTC_FLAGS_$(3)) $$(CTEST_RUSTC_FLAGS) -L $$(RT_OUTPUT_DIR_$(3)) $$(STDCPP_LIBDIR_RUSTFLAGS_$(3))" \
+        --host-rustcflags "$(RUSTC_FLAGS_$(3)) $$(CTEST_RUSTC_FLAGS) -L $$(RT_OUTPUT_DIR_$(3))" \
         --lldb-python-dir=$(CFG_LLDB_PYTHON_DIR) \
-        --target-rustcflags "$(RUSTC_FLAGS_$(2)) $$(CTEST_RUSTC_FLAGS) -L $$(RT_OUTPUT_DIR_$(2)) $$(STDCPP_LIBDIR_RUSTFLAGS_$(2))" \
+        --target-rustcflags "$(RUSTC_FLAGS_$(2)) $$(CTEST_RUSTC_FLAGS) -L $$(RT_OUTPUT_DIR_$(2))" \
         $$(CTEST_TESTARGS)
 
 ifdef CFG_VALGRIND_RPASS

--- a/src/test/run-make/tools.mk
+++ b/src/test/run-make/tools.mk
@@ -85,11 +85,6 @@ ifeq ($(UNAME),Bitrig)
 else
 ifeq ($(UNAME),OpenBSD)
 	EXTRACFLAGS := -lm -lpthread
-	# extend search lib for found estdc++ if build using gcc from
-	# ports under OpenBSD. This is needed for:
-	#  - run-make/execution-engine
-	#  - run-make/issue-19371
-	RUSTC := $(RUSTC) -L/usr/local/lib
 else
 	EXTRACFLAGS := -lm -lrt -ldl -lpthread
 	EXTRACXXFLAGS := -lstdc++

--- a/src/test/run-make/tools.mk
+++ b/src/test/run-make/tools.mk
@@ -85,6 +85,7 @@ ifeq ($(UNAME),Bitrig)
 else
 ifeq ($(UNAME),OpenBSD)
 	EXTRACFLAGS := -lm -lpthread
+	RUSTC := $(RUSTC) -C linker="$(word 1,$(CC:ccache=))"
 else
 	EXTRACFLAGS := -lm -lrt -ldl -lpthread
 	EXTRACXXFLAGS := -lstdc++


### PR DESCRIPTION
this PR reverts previous ones, that tried to make `cc` to found `estdc++` in `/usr/local/lib`. It causes more trouble than it resolvs things: rustc become unbuildable if another version already exists in `/usr/local` (for example, `libstd-xxxx.so` is found in `/usr/local/lib` and in builddir).

so this PR tries another way to achieve build, but using the good linker for building. By default, rustc use `cc` for linking. But under OpenBSD, `cc` is gcc 4.2.1 from base, whereas we build with gcc 4.9 from ports. By linking using the compiler found at compile-time, we ensure that the compiler will found his own stdc++ library without trouble.

r? @alexcrichton 
