### PR TITLE
improper_ctypes: also check extern fn's

### DIFF
--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -658,7 +658,7 @@ fn check_foreign_fn(cx: &LateContext, decl: &hir::FnDecl) {
 }
 
 fn should_check_abi(abi: abi::Abi) -> bool {
-    ![abi::RustIntrinsic, abi::PlatformIntrinsic].contains(&abi)
+    ![abi::RustIntrinsic, abi::PlatformIntrinsic, abi::Rust, abi::RustCall].contains(&abi)
 }
 
 impl LateLintPass for ImproperCTypes {

--- a/src/libstd/sys/common/unwind/mod.rs
+++ b/src/libstd/sys/common/unwind/mod.rs
@@ -192,6 +192,7 @@ fn rust_panic(cause: Box<Any + Send + 'static>) -> ! {
 /// Entry point of panic from the libcore crate.
 #[lang = "panic_fmt"]
 #[unwind]
+#[allow(improper_ctypes)]
 pub extern fn rust_begin_unwind(msg: fmt::Arguments,
                                 file: &'static str, line: u32) -> ! {
     begin_unwind_fmt(msg, &(file, line))

--- a/src/test/compile-fail/lint-ctypes.rs
+++ b/src/test/compile-fail/lint-ctypes.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_variables)]
 #![deny(improper_ctypes)]
 #![feature(libc)]
 
@@ -61,6 +62,38 @@ extern {
     pub fn good10() -> CVoidRet;
     pub fn good11(size: isize);
     pub fn good12(size: usize);
+}
+
+pub mod extern_fn {
+    use libc;
+    use types::*;
+
+    pub extern fn ptr_type1(size: *const Foo) {} //~ ERROR: found struct without
+    pub extern fn ptr_type2(size: *const Foo) {} //~ ERROR: found struct without
+    pub extern fn slice_type(p: &[u32]) {} //~ ERROR: found Rust slice type
+    pub extern fn str_type(p: &str) {} //~ ERROR: found Rust type
+    pub extern fn box_type(p: Box<u32>) {} //~ ERROR found Rust type
+    pub extern fn char_type(p: char) {} //~ ERROR found Rust type
+    pub extern fn trait_type(p: &Bar) {} //~ ERROR found Rust trait type
+    pub extern fn tuple_type(p: (i32, i32)) {} //~ ERROR found Rust tuple type
+    pub extern fn tuple_type2(p: I32Pair) {} //~ ERROR found Rust tuple type
+    pub extern fn zero_size(p: ZeroSize) {} //~ ERROR found zero-size struct
+    pub extern fn fn_type(p: RustFn) {} //~ ERROR found function pointer with Rust
+    pub extern fn fn_type2(p: fn()) {} //~ ERROR found function pointer with Rust
+    pub extern fn fn_contained(p: RustBadRet) {} //~ ERROR: found Rust type
+
+    pub extern fn good1(size: *const libc::c_int) {}
+    pub extern fn good2(size: *const libc::c_uint) {}
+    pub extern fn good3(fptr: Option<extern fn()>) {}
+    pub extern fn good4(aptr: &[u8; 4 as usize]) {}
+    pub extern fn good5(s: StructWithProjection) {}
+    pub extern fn good6(s: StructWithProjectionAndLifetime) {}
+    pub extern fn good7(fptr: extern fn() -> ()) {}
+    pub extern fn good8(fptr: extern fn() -> !) {}
+    pub extern fn good9() -> () {}
+    pub extern fn good10() -> CVoidRet {}
+    pub extern fn good11(size: isize) {}
+    pub extern fn good12(size: usize) {}
 }
 
 fn main() {

--- a/src/test/compile-fail/lint-ctypes.rs
+++ b/src/test/compile-fail/lint-ctypes.rs
@@ -11,24 +11,28 @@
 #![deny(improper_ctypes)]
 #![feature(libc)]
 
+use types::*;
+
 extern crate libc;
 
-trait Mirror { type It; }
-impl<T> Mirror for T { type It = Self; }
-#[repr(C)]
-pub struct StructWithProjection(*mut <StructWithProjection as Mirror>::It);
-#[repr(C)]
-pub struct StructWithProjectionAndLifetime<'a>(
-    &'a mut <StructWithProjectionAndLifetime<'a> as Mirror>::It
-);
-pub type I32Pair = (i32, i32);
-#[repr(C)]
-pub struct ZeroSize;
-pub type RustFn = fn();
-pub type RustBadRet = extern fn() -> Box<u32>;
-pub type CVoidRet = ();
-pub struct Foo;
-pub trait Bar {}
+pub mod types {
+    pub trait Mirror { type It; }
+    impl<T> Mirror for T { type It = Self; }
+    #[repr(C)]
+    pub struct StructWithProjection(*mut <StructWithProjection as Mirror>::It);
+    #[repr(C)]
+    pub struct StructWithProjectionAndLifetime<'a>(
+        &'a mut <StructWithProjectionAndLifetime<'a> as Mirror>::It
+    );
+    pub type I32Pair = (i32, i32);
+    #[repr(C)]
+    pub struct ZeroSize;
+    pub type RustFn = fn();
+    pub type RustBadRet = extern fn() -> Box<u32>;
+    pub type CVoidRet = ();
+    pub struct Foo;
+    pub trait Bar {}
+}
 
 extern {
     pub fn ptr_type1(size: *const Foo); //~ ERROR: found struct without

--- a/src/test/compile-fail/lint-ctypes.rs
+++ b/src/test/compile-fail/lint-ctypes.rs
@@ -28,6 +28,7 @@ pub type RustFn = fn();
 pub type RustBadRet = extern fn() -> Box<u32>;
 pub type CVoidRet = ();
 pub struct Foo;
+pub trait Bar {}
 
 extern {
     pub fn ptr_type1(size: *const Foo); //~ ERROR: found struct without
@@ -36,7 +37,7 @@ extern {
     pub fn str_type(p: &str); //~ ERROR: found Rust type
     pub fn box_type(p: Box<u32>); //~ ERROR found Rust type
     pub fn char_type(p: char); //~ ERROR found Rust type
-    pub fn trait_type(p: &Clone); //~ ERROR found Rust trait type
+    pub fn trait_type(p: &Bar); //~ ERROR found Rust trait type
     pub fn tuple_type(p: (i32, i32)); //~ ERROR found Rust tuple type
     pub fn tuple_type2(p: I32Pair); //~ ERROR found Rust tuple type
     pub fn zero_size(p: ZeroSize); //~ ERROR found zero-size struct


### PR DESCRIPTION
The improper ctypes lint currently only checks functions inside of `extern` blocks. This changes the lint so that it also checks all functions with an `extern` calling convention.

Closes #19834.

This probably need a crater run.

**Edit:** I just realised that there's still some stuff to be tested: generics and methods, I will add those soon.
