### PR TITLE
unbreak openbsd code

### DIFF
--- a/src/libstd/rand/os.rs
+++ b/src/libstd/rand/os.rs
@@ -182,8 +182,8 @@ mod imp {
 #[cfg(target_os = "openbsd")]
 mod imp {
     use io;
+    use libc;
     use mem;
-    use libc::c_long;
     use sys::os::errno;
     use rand::Rng;
 


### PR DESCRIPTION
- upgrades libc to version with `si_addr` support in openbsd
- declares libc use for getentropy
- remove now unused use

r? @alexcrichton 
