### PR TITLE
doc: Change Google link to generic top level domain

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,7 +238,7 @@ are:
 * Don't be afraid to ask! The Rust community is friendly and helpful.
 
 [gdfrustc]: http://manishearth.github.io/rust-internals-docs/rustc/
-[gsearchdocs]: https://www.google.de/search?q=site:doc.rust-lang.org+your+query+here
+[gsearchdocs]: https://www.google.com/search?q=site:doc.rust-lang.org+your+query+here
 [rif]: http://internals.rust-lang.org
 [rr]: https://doc.rust-lang.org/book/README.html
 [tlgba]: http://tomlee.co/2014/04/03/a-more-detailed-tour-of-the-rust-compiler/


### PR DESCRIPTION
Country-code top level domain names are tied to a specific country (for example .de for Germany).

r? @steveklabnik
