### PR TITLE
Properly convert and translate unit structs into MIR

### DIFF
--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -701,9 +701,9 @@ pub struct Constant<'tcx> {
 #[derive(Clone, Copy, Debug, PartialEq, RustcEncodable, RustcDecodable)]
 pub enum ItemKind {
     Constant,
+    /// This is any sort of callable (usually those that have a type of `fn(…) -> …`). This
+    /// includes functions, constructors, but not methods which have their own ItemKind.
     Function,
-    Struct,
-    Variant,
     Method,
 }
 

--- a/src/librustc_trans/trans/mir/did.rs
+++ b/src/librustc_trans/trans/mir/did.rs
@@ -39,9 +39,7 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                           did: DefId)
                           -> OperandRef<'tcx> {
         match kind {
-            ItemKind::Function |
-            ItemKind::Struct |
-            ItemKind::Variant => self.trans_fn_ref(bcx, ty, substs, did),
+            ItemKind::Function => self.trans_fn_ref(bcx, ty, substs, did),
             ItemKind::Method => match bcx.tcx().impl_or_trait_item(did).container() {
                 ty::ImplContainer(_) => self.trans_fn_ref(bcx, ty, substs, did),
                 ty::TraitContainer(tdid) => self.trans_static_method(bcx, ty, did, tdid, substs)

--- a/src/librustc_trans/trans/mir/statement.rs
+++ b/src/librustc_trans/trans/mir/statement.rs
@@ -31,7 +31,7 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                         let index = index as usize;
                         match self.temps[index as usize] {
                             TempRef::Lvalue(tr_dest) => {
-                                self.trans_rvalue(bcx, tr_dest.llval, rvalue)
+                                self.trans_rvalue(bcx, tr_dest, rvalue)
                             }
                             TempRef::Operand(None) => {
                                 let (bcx, operand) = self.trans_rvalue_operand(bcx, rvalue);
@@ -47,7 +47,7 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                     }
                     _ => {
                         let tr_dest = self.trans_lvalue(bcx, lvalue);
-                        self.trans_rvalue(bcx, tr_dest.llval, rvalue)
+                        self.trans_rvalue(bcx, tr_dest, rvalue)
                     }
                 }
             }

--- a/src/test/run-pass/mir_refs_correct.rs
+++ b/src/test/run-pass/mir_refs_correct.rs
@@ -14,6 +14,8 @@
 extern crate mir_external_refs as ext;
 
 struct S(u8);
+#[derive(Debug, PartialEq, Eq)]
+struct Unit;
 
 impl S {
     fn hey() -> u8 { 42 }
@@ -175,6 +177,11 @@ fn t20() -> fn(u64, u32)->(u64, u32) {
     <u32 as T<_, _>>::staticmeth
 }
 
+#[rustc_mir]
+fn t21() -> Unit {
+    Unit
+}
+
 fn main(){
     unsafe {
         assert_eq!(t1()(), regular());
@@ -214,5 +221,6 @@ fn main(){
         assert_eq!(t18()(50u64, 5u64), F::f(50u64, 5u64));
         assert_eq!(t19()(322u64, 2u32), F::f(322u64, 2u32));
         assert_eq!(t20()(123u64, 38u32), <u32 as T<_, _>>::staticmeth(123, 38));
+        assert_eq!(t21(), Unit);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/30514

i also went ahead and removed the redundant `ItemKind`s.

r? @nikomatsakis (this is an easy one I guess)
