### PR TITLE
[MIR] Make sure candidates are reversed before `match_candidates`.

### DIFF
--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -512,7 +512,10 @@ impl<'a,'tcx> Builder<'a,'tcx> {
         let otherwise: Vec<_> =
             target_blocks.into_iter()
                          .zip(target_candidates)
-                         .flat_map(|(target_block, target_candidates)| {
+                         .flat_map(|(target_block, mut target_candidates)| {
+                             // We need to preserve the fact that the candidates
+                             // are in the reversed order compared to the source.
+                             target_candidates.reverse();
                              self.match_candidates(span,
                                                    arm_blocks,
                                                    target_candidates,

--- a/src/test/run-pass/mir_match_arm_guard.rs
+++ b/src/test/run-pass/mir_match_arm_guard.rs
@@ -1,0 +1,28 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// #30527 - We were not generating arms with guards in certain cases.
+
+#![feature(rustc_attrs)]
+
+#[rustc_mir]
+fn match_with_guard(x: Option<i8>) -> i8 {
+    match x {
+        Some(xyz) if xyz > 100 => 0,
+        Some(_) => -1,
+        None => -2
+    }
+}
+
+fn main() {
+    assert_eq!(match_with_guard(Some(111)), 0);
+    assert_eq!(match_with_guard(Some(2)), -1);
+    assert_eq!(match_with_guard(None), -2);
+}


### PR DESCRIPTION
Fixes #30527.

``` Rust
#![feature(rustc_attrs)]

#[rustc_mir(graphviz="match.dot")]
fn main() {
    let _abc = match Some(101i8) {
        Some(xyz) if xyz > 100 => xyz,
        Some(_) => -1,
        None => -2
    };
}
```

Resulting MIR now includes the `Some(xyz)` arm, guard and all:
![match.dot](https://cloud.githubusercontent.com/assets/287063/11999413/066f7610-aa8b-11e5-927b-24215af57fc4.png)

~~Not quite sure how to write a test for this.~~ Thinking too hard, just tested the end result.

r? @nikomatsakis 
