### PR TITLE
llvm: Add support for vectorcall (X86_VectorCall) convention

### DIFF
--- a/src/doc/book/ffi.md
+++ b/src/doc/book/ffi.md
@@ -478,6 +478,7 @@ are:
 * `aapcs`
 * `cdecl`
 * `fastcall`
+* `vectorcall`
 * `Rust`
 * `rust-intrinsic`
 * `system`

--- a/src/doc/book/ffi.md
+++ b/src/doc/book/ffi.md
@@ -479,6 +479,7 @@ are:
 * `cdecl`
 * `fastcall`
 * `vectorcall`
+This is currently hidden behind the `abi_vectorcall` gate and is subject to change.
 * `Rust`
 * `rust-intrinsic`
 * `system`

--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -2390,6 +2390,9 @@ The currently implemented features of the reference compiler are:
 
 * - `type_ascription` - Allows type ascription expressions `expr: Type`.
 
+* - `abi_vectorcall` - Allows the usage of the vectorcall calling convention
+                             (e.g. `extern "vectorcall" func fn_();`)
+
 If a feature is promoted to a language feature, then all existing programs will
 start to receive compilation warnings about `#![feature]` directives which enabled
 the new feature (because the directive is no longer necessary). However, if a

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -85,6 +85,7 @@ pub enum CallConv {
     X86StdcallCallConv = 64,
     X86FastcallCallConv = 65,
     X86_64_Win64 = 79,
+    X86_VectorCall = 80
 }
 
 #[derive(Copy, Clone)]

--- a/src/librustc_trans/trans/foreign.rs
+++ b/src/librustc_trans/trans/foreign.rs
@@ -35,7 +35,8 @@ use std::cmp;
 use std::iter::once;
 use libc::c_uint;
 use syntax::abi::{Cdecl, Aapcs, C, Win64, Abi};
-use syntax::abi::{PlatformIntrinsic, RustIntrinsic, Rust, RustCall, Stdcall, Fastcall, System};
+use syntax::abi::{PlatformIntrinsic, RustIntrinsic, Rust, RustCall, Stdcall};
+use syntax::abi::{Fastcall, Vectorcall, System};
 use syntax::attr;
 use syntax::codemap::Span;
 use syntax::parse::token::{InternedString, special_idents};
@@ -104,6 +105,7 @@ pub fn llvm_calling_convention(ccx: &CrateContext,
 
         Stdcall => llvm::X86StdcallCallConv,
         Fastcall => llvm::X86FastcallCallConv,
+        Vectorcall => llvm::X86_VectorCall,
         C => llvm::CCallConv,
         Win64 => llvm::X86_64_Win64,
 

--- a/src/libsyntax/abi.rs
+++ b/src/libsyntax/abi.rs
@@ -39,6 +39,7 @@ pub enum Abi {
     Cdecl,
     Stdcall,
     Fastcall,
+    Vectorcall,
     Aapcs,
     Win64,
 
@@ -85,6 +86,7 @@ const AbiDatas: &'static [AbiData] = &[
     AbiData {abi: Cdecl, name: "cdecl" },
     AbiData {abi: Stdcall, name: "stdcall" },
     AbiData {abi: Fastcall, name: "fastcall" },
+    AbiData {abi: Vectorcall, name: "vectorcall"},
     AbiData {abi: Aapcs, name: "aapcs" },
     AbiData {abi: Win64, name: "win64" },
 

--- a/src/test/compile-fail/feature-gate-abi-vectorcall.rs
+++ b/src/test/compile-fail/feature-gate-abi-vectorcall.rs
@@ -1,0 +1,19 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern "vectorcall" {   //~ ERROR vectorcall is experimental and subject to change
+    fn bar();
+}
+
+extern "vectorcall" fn baz() {  //~ ERROR vectorcall is experimental and subject to change
+}
+
+fn main() {
+}

--- a/src/test/run-pass/extern-vectorcall.rs
+++ b/src/test/run-pass/extern-vectorcall.rs
@@ -1,0 +1,32 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(abi_vectorcall)]
+
+trait A {
+    extern "vectorcall" fn test1(i: i32);
+}
+
+struct S;
+
+impl A for S {
+    extern "vectorcall" fn test1(i: i32) {
+        assert_eq!(i, 1);
+    }
+}
+
+extern "vectorcall" fn test2(i: i32) {
+    assert_eq!(i, 2);
+}
+
+fn main() {
+    <S as A>::test1(1);
+    test2(2);
+}


### PR DESCRIPTION
Add support to use functions exported using vectorcall.
This essentially only allows to pass a new LLVM calling convention
from rust to LLVM.

``` rust
extern "vectorcall" fn abc(param: c_void);
```
## references

http://llvm.org/docs/doxygen/html/CallingConv_8h_source.html
https://msdn.microsoft.com/en-us/library/dn375768.aspx
