### PR TITLE
Change the typo 'that' to 'than' in the book error-handling chapter

### DIFF
--- a/src/doc/book/error-handling.md
+++ b/src/doc/book/error-handling.md
@@ -887,7 +887,7 @@ fn main() {
 }
 ```
 
-Reasonable people can disagree over whether this code is better that the code
+Reasonable people can disagree over whether this code is better than the code
 that uses combinators, but if you aren't familiar with the combinator approach,
 this code looks simpler to read to me. It uses explicit case analysis with
 `match` and `if let`. If an error occurs, it simply stops executing the


### PR DESCRIPTION
Didn't build/test the change, but if that one-character fix isn't correct, I'll eat my hat.  :-)  Found this reading the book over the last week or two since Mozlando -- much enjoying the book so far.
