### PR TITLE
[MIR] Fix setting discriminant for unit enums

### DIFF
--- a/src/librustc_trans/trans/mir/rvalue.rs
+++ b/src/librustc_trans/trans/mir/rvalue.rs
@@ -102,7 +102,8 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                     mir::AggregateKind::Adt(adt_def, index, _)
                     if adt_def.variants[index].kind() == ty::VariantKind::Unit => {
                         let repr = adt::represent_type(bcx.ccx(), dest.ty.to_ty(bcx.tcx()));
-                        adt::trans_set_discr(bcx, &*repr, dest.llval, 0);
+                        let disr = adt_def.variants[index].disr_val;
+                        adt::trans_set_discr(bcx, &*repr, dest.llval, disr);
                     },
                     _ => {
                         for (i, operand) in operands.iter().enumerate() {

--- a/src/test/run-pass/mir_refs_correct.rs
+++ b/src/test/run-pass/mir_refs_correct.rs
@@ -59,6 +59,12 @@ enum E {
     U(u8)
 }
 
+#[derive(PartialEq, Debug, Eq)]
+enum CEnum {
+    A = 0x321,
+    B = 0x123
+}
+
 const C: u8 = 84;
 const C2: [u8; 5] = [42; 5];
 const C3: [u8; 3] = [42, 41, 40];
@@ -187,6 +193,11 @@ fn t22() -> Option<u8> {
     None
 }
 
+#[rustc_mir]
+fn t23() -> (CEnum, CEnum) {
+    (CEnum::A, CEnum::B)
+}
+
 fn main(){
     unsafe {
         assert_eq!(t1()(), regular());
@@ -228,5 +239,6 @@ fn main(){
         assert_eq!(t20()(123u64, 38u32), <u32 as T<_, _>>::staticmeth(123, 38));
         assert_eq!(t21(), Unit);
         assert_eq!(t22(), None);
+        assert_eq!(t23(), (CEnum::A, CEnum::B));
     }
 }


### PR DESCRIPTION
A dumb mistake on my part from previous PR fixing unit enums in MIR.
