### PR TITLE
Move Duration to libcore (and remove deprecated Duration::span)

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -140,6 +140,7 @@ pub mod iter;
 pub mod option;
 pub mod raw;
 pub mod result;
+pub mod time;
 
 pub mod slice;
 pub mod str;

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -8,6 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! Temporal quantification.
+
+#![stable(feature = "time", since = "1.3.0")]
+
 use ops::{Add, Sub, Mul, Div};
 
 const NANOS_PER_SEC: u32 = 1_000_000_000;
@@ -152,83 +156,5 @@ impl Div<u32> for Duration {
         let nanos = self.nanos / rhs + (extra_nanos as u32);
         debug_assert!(nanos < NANOS_PER_SEC);
         Duration { secs: secs, nanos: nanos }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::Duration;
-
-    #[test]
-    fn creation() {
-        assert!(Duration::from_secs(1) != Duration::from_secs(0));
-        assert_eq!(Duration::from_secs(1) + Duration::from_secs(2),
-                   Duration::from_secs(3));
-        assert_eq!(Duration::from_millis(10) + Duration::from_secs(4),
-                   Duration::new(4, 10 * 1_000_000));
-        assert_eq!(Duration::from_millis(4000), Duration::new(4, 0));
-    }
-
-    #[test]
-    fn secs() {
-        assert_eq!(Duration::new(0, 0).as_secs(), 0);
-        assert_eq!(Duration::from_secs(1).as_secs(), 1);
-        assert_eq!(Duration::from_millis(999).as_secs(), 0);
-        assert_eq!(Duration::from_millis(1001).as_secs(), 1);
-    }
-
-    #[test]
-    fn nanos() {
-        assert_eq!(Duration::new(0, 0).subsec_nanos(), 0);
-        assert_eq!(Duration::new(0, 5).subsec_nanos(), 5);
-        assert_eq!(Duration::new(0, 1_000_000_001).subsec_nanos(), 1);
-        assert_eq!(Duration::from_secs(1).subsec_nanos(), 0);
-        assert_eq!(Duration::from_millis(999).subsec_nanos(), 999 * 1_000_000);
-        assert_eq!(Duration::from_millis(1001).subsec_nanos(), 1 * 1_000_000);
-    }
-
-    #[test]
-    fn add() {
-        assert_eq!(Duration::new(0, 0) + Duration::new(0, 1),
-                   Duration::new(0, 1));
-        assert_eq!(Duration::new(0, 500_000_000) + Duration::new(0, 500_000_001),
-                   Duration::new(1, 1));
-    }
-
-    #[test]
-    fn sub() {
-        assert_eq!(Duration::new(0, 1) - Duration::new(0, 0),
-                   Duration::new(0, 1));
-        assert_eq!(Duration::new(0, 500_000_001) - Duration::new(0, 500_000_000),
-                   Duration::new(0, 1));
-        assert_eq!(Duration::new(1, 0) - Duration::new(0, 1),
-                   Duration::new(0, 999_999_999));
-    }
-
-    #[test] #[should_panic]
-    fn sub_bad1() {
-        Duration::new(0, 0) - Duration::new(0, 1);
-    }
-
-    #[test] #[should_panic]
-    fn sub_bad2() {
-        Duration::new(0, 0) - Duration::new(1, 0);
-    }
-
-    #[test]
-    fn mul() {
-        assert_eq!(Duration::new(0, 1) * 2, Duration::new(0, 2));
-        assert_eq!(Duration::new(1, 1) * 3, Duration::new(3, 3));
-        assert_eq!(Duration::new(0, 500_000_001) * 4, Duration::new(2, 4));
-        assert_eq!(Duration::new(0, 500_000_001) * 4000,
-                   Duration::new(2000, 4000));
-    }
-
-    #[test]
-    fn div() {
-        assert_eq!(Duration::new(0, 1) / 2, Duration::new(0, 0));
-        assert_eq!(Duration::new(1, 1) / 3, Duration::new(0, 333_333_333));
-        assert_eq!(Duration::new(99, 999_999_000) / 100,
-                   Duration::new(0, 999_999_990));
     }
 }

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -10,7 +10,8 @@
 
 //! Temporal quantification.
 
-#![stable(feature = "time", since = "1.3.0")]
+#![unstable(feature = "time", reason = "recently moved to libcore",
+            issue = "0")]  // FIXME: file tracking issue if this lands
 
 use ops::{Add, Sub, Mul, Div};
 

--- a/src/libcoretest/lib.rs
+++ b/src/libcoretest/lib.rs
@@ -71,4 +71,5 @@ mod ptr;
 mod result;
 mod slice;
 mod str;
+mod time;
 mod tuple;

--- a/src/libcoretest/time.rs
+++ b/src/libcoretest/time.rs
@@ -1,0 +1,84 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use core::time::Duration;
+
+#[test]
+fn creation() {
+    assert!(Duration::from_secs(1) != Duration::from_secs(0));
+    assert_eq!(Duration::from_secs(1) + Duration::from_secs(2),
+               Duration::from_secs(3));
+    assert_eq!(Duration::from_millis(10) + Duration::from_secs(4),
+               Duration::new(4, 10 * 1_000_000));
+    assert_eq!(Duration::from_millis(4000), Duration::new(4, 0));
+}
+
+#[test]
+fn secs() {
+    assert_eq!(Duration::new(0, 0).as_secs(), 0);
+    assert_eq!(Duration::from_secs(1).as_secs(), 1);
+    assert_eq!(Duration::from_millis(999).as_secs(), 0);
+    assert_eq!(Duration::from_millis(1001).as_secs(), 1);
+}
+
+#[test]
+fn nanos() {
+    assert_eq!(Duration::new(0, 0).subsec_nanos(), 0);
+    assert_eq!(Duration::new(0, 5).subsec_nanos(), 5);
+    assert_eq!(Duration::new(0, 1_000_000_001).subsec_nanos(), 1);
+    assert_eq!(Duration::from_secs(1).subsec_nanos(), 0);
+    assert_eq!(Duration::from_millis(999).subsec_nanos(), 999 * 1_000_000);
+    assert_eq!(Duration::from_millis(1001).subsec_nanos(), 1 * 1_000_000);
+}
+
+#[test]
+fn add() {
+    assert_eq!(Duration::new(0, 0) + Duration::new(0, 1),
+               Duration::new(0, 1));
+    assert_eq!(Duration::new(0, 500_000_000) + Duration::new(0, 500_000_001),
+               Duration::new(1, 1));
+}
+
+#[test]
+fn sub() {
+    assert_eq!(Duration::new(0, 1) - Duration::new(0, 0),
+               Duration::new(0, 1));
+    assert_eq!(Duration::new(0, 500_000_001) - Duration::new(0, 500_000_000),
+               Duration::new(0, 1));
+    assert_eq!(Duration::new(1, 0) - Duration::new(0, 1),
+               Duration::new(0, 999_999_999));
+}
+
+#[test] #[should_panic]
+fn sub_bad1() {
+    Duration::new(0, 0) - Duration::new(0, 1);
+}
+
+#[test] #[should_panic]
+fn sub_bad2() {
+    Duration::new(0, 0) - Duration::new(1, 0);
+}
+
+#[test]
+fn mul() {
+    assert_eq!(Duration::new(0, 1) * 2, Duration::new(0, 2));
+    assert_eq!(Duration::new(1, 1) * 3, Duration::new(3, 3));
+    assert_eq!(Duration::new(0, 500_000_001) * 4, Duration::new(2, 4));
+    assert_eq!(Duration::new(0, 500_000_001) * 4000,
+               Duration::new(2000, 4000));
+}
+
+#[test]
+fn div() {
+    assert_eq!(Duration::new(0, 1) / 2, Duration::new(0, 0));
+    assert_eq!(Duration::new(1, 1) / 3, Duration::new(0, 333_333_333));
+    assert_eq!(Duration::new(99, 999_999_000) / 100,
+               Duration::new(0, 999_999_990));
+}

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 use ops::{Add, Sub, Mul, Div};
-use time::Instant;
 
 const NANOS_PER_SEC: u32 = 1_000_000_000;
 const NANOS_PER_MILLI: u32 = 1_000_000;
@@ -57,21 +56,6 @@ impl Duration {
         let secs = secs + (nanos / NANOS_PER_SEC) as u64;
         let nanos = nanos % NANOS_PER_SEC;
         Duration { secs: secs, nanos: nanos }
-    }
-
-    /// Runs a closure, returning the duration of time it took to run the
-    /// closure.
-    #[unstable(feature = "duration_span",
-               reason = "unsure if this is the right API or whether it should \
-                         wait for a more general \"moment in time\" \
-                         abstraction",
-               issue = "27799")]
-    #[rustc_deprecated(reason = "use std::time::Instant instead",
-                       since = "1.6.0")]
-    pub fn span<F>(f: F) -> Duration where F: FnOnce() {
-        let start = Instant::now();
-        f();
-        start.elapsed()
     }
 
     /// Creates a new `Duration` from the specified number of seconds.

--- a/src/libstd/time/mod.rs
+++ b/src/libstd/time/mod.rs
@@ -18,9 +18,7 @@ use ops::{Add, Sub};
 use sys::time;
 
 #[stable(feature = "time", since = "1.3.0")]
-pub use self::duration::Duration;
-
-mod duration;
+pub use core::time::Duration;
 
 /// A measurement of a monotonically increasing clock.
 ///

--- a/src/test/bench/core-map.rs
+++ b/src/test/bench/core-map.rs
@@ -8,15 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(std_misc, rand, duration, duration_span)]
+#![feature(std_misc, rand, time2)]
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env;
 use std::__rand::{Rng, thread_rng};
-use std::time::Duration;
+use std::time::Instant;
 
-fn timed<F>(label: &str, f: F) where F: FnMut() {
-    println!("  {}: {:?}", label, Duration::span(f));
+fn timed<F>(label: &str, mut f: F) where F: FnMut() {
+    let start = Instant::now();
+    f();
+    println!("  {}: {:?}", label, start.elapsed());
 }
 
 trait MutableMap {

--- a/src/test/bench/core-set.rs
+++ b/src/test/bench/core-set.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty very bad with line comments
 
-#![feature(unboxed_closures, rand, std_misc, collections, duration, duration_span)]
+#![feature(unboxed_closures, rand, std_misc, collections, time2)]
 #![feature(bitset)]
 
 extern crate collections;
@@ -20,7 +20,7 @@ use std::collections::BTreeSet;
 use std::collections::HashSet;
 use std::hash::Hash;
 use std::env;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 struct Results {
     sequential_ints: Duration,
@@ -33,7 +33,9 @@ struct Results {
 }
 
 fn timed<F>(result: &mut Duration, op: F) where F: FnOnce() {
-    *result = Duration::span(op);
+    let start = Instant::now();
+    op();
+    *result = start.elapsed();
 }
 
 trait MutableSet<T> {

--- a/src/test/bench/core-std.rs
+++ b/src/test/bench/core-std.rs
@@ -10,13 +10,13 @@
 
 // Microbenchmarks for various functions in std and extra
 
-#![feature(rand, vec_push_all, duration, duration_span)]
+#![feature(rand, vec_push_all, time2)]
 
 use std::mem::swap;
 use std::env;
 use std::__rand::{thread_rng, Rng};
 use std::str;
-use std::time::Duration;
+use std::time::Instant;
 
 fn main() {
     let argv: Vec<String> = env::args().collect();
@@ -49,7 +49,9 @@ fn maybe_run_test<F>(argv: &[String], name: String, test: F) where F: FnOnce() {
         return
     }
 
-    let dur = Duration::span(test);
+    let start = Instant::now();
+    test();
+    let dur = start.elapsed();
 
     println!("{}:\t\t{:?}", name, dur);
 }

--- a/src/test/bench/msgsend-pipes-shared.rs
+++ b/src/test/bench/msgsend-pipes-shared.rs
@@ -18,12 +18,12 @@
 // different scalability characteristics compared to the select
 // version.
 
-#![feature(duration, duration_span)]
+#![feature(time2)]
 
 use std::sync::mpsc::{channel, Sender, Receiver};
 use std::env;
 use std::thread;
-use std::time::Duration;
+use std::time::Instant;
 
 fn move_out<T>(_x: T) {}
 
@@ -60,7 +60,8 @@ fn run(args: &[String]) {
     let num_bytes = 100;
     let mut result = None;
     let mut p = Some((to_child, to_parent, from_parent));
-    let dur = Duration::span(|| {
+    let start = Instant::now();
+    {
         let (to_child, to_parent, from_parent) = p.take().unwrap();
         let mut worker_results = Vec::new();
         for _ in 0..workers {
@@ -85,7 +86,8 @@ fn run(args: &[String]) {
         to_child.send(request::stop).unwrap();
         move_out(to_child);
         result = Some(from_child.recv().unwrap());
-    });
+    }
+    let dur = start.elapsed();
     let result = result.unwrap();
     print!("Count is {}\n", result);
     print!("Test took {:?}\n", dur);

--- a/src/test/bench/msgsend-pipes.rs
+++ b/src/test/bench/msgsend-pipes.rs
@@ -14,12 +14,12 @@
 //
 // I *think* it's the same, more or less.
 
-#![feature(duration, duration_span)]
+#![feature(time2)]
 
 use std::sync::mpsc::{channel, Sender, Receiver};
 use std::env;
 use std::thread;
-use std::time::Duration;
+use std::time::Instant;
 
 enum request {
     get_count,
@@ -53,7 +53,8 @@ fn run(args: &[String]) {
     let num_bytes = 100;
     let mut result = None;
     let mut to_parent = Some(to_parent);
-    let dur = Duration::span(|| {
+    let start = Instant::now();
+    {
         let to_parent = to_parent.take().unwrap();
         let mut worker_results = Vec::new();
         let from_parent = if workers == 1 {
@@ -92,7 +93,8 @@ fn run(args: &[String]) {
         //to_child.send(stop);
         //move_out(to_child);
         result = Some(from_child.recv().unwrap());
-    });
+    }
+    let dur = start.elapsed();
     let result = result.unwrap();
     print!("Count is {}\n", result);
     print!("Test took {:?}\n", dur);

--- a/src/test/bench/msgsend-ring-mutex-arcs.rs
+++ b/src/test/bench/msgsend-ring-mutex-arcs.rs
@@ -17,11 +17,11 @@
 
 // no-pretty-expanded FIXME #15189
 
-#![feature(duration_span)]
+#![feature(time2)]
 
 use std::env;
 use std::sync::{Arc, Mutex, Condvar};
-use std::time::Duration;
+use std::time::Instant;
 use std::thread;
 
 // A poor man's pipe.
@@ -80,7 +80,8 @@ fn main() {
     let (num_chan, num_port) = init();
 
     let mut p = Some((num_chan, num_port));
-    let dur = Duration::span(|| {
+    let start = Instant::now();
+    {
         let (mut num_chan, num_port) = p.take().unwrap();
 
         // create the ring
@@ -104,7 +105,8 @@ fn main() {
         for f in futures {
             f.join().unwrap()
         }
-    });
+    }
+    let dur = start.elapsed();
 
     // all done, report stats.
     let num_msgs = num_tasks * msg_per_task;

--- a/src/test/bench/shootout-pfib.rs
+++ b/src/test/bench/shootout-pfib.rs
@@ -18,7 +18,7 @@
 
 */
 
-#![feature(duration, duration_span, rustc_private)]
+#![feature(time2, rustc_private)]
 
 extern crate getopts;
 
@@ -26,7 +26,7 @@ use std::sync::mpsc::{channel, Sender};
 use std::env;
 use std::result::Result::{Ok, Err};
 use std::thread;
-use std::time::Duration;
+use std::time::Instant;
 
 fn fib(n: isize) -> isize {
     fn pfib(tx: &Sender<isize>, n: isize) {
@@ -110,9 +110,9 @@ fn main() {
 
         for n in 1..max + 1 {
             for _ in 0..num_trials {
-                let mut fibn = None;
-                let dur = Duration::span(|| fibn = Some(fib(n)));
-                let fibn = fibn.unwrap();
+                let start = Instant::now();
+                let fibn = fib(n);
+                let dur = start.elapsed();
 
                 println!("{}\t{}\t{:?}", n, fibn, dur);
             }

--- a/src/test/bench/task-perf-alloc-unwind.rs
+++ b/src/test/bench/task-perf-alloc-unwind.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(box_syntax, duration, duration_span, vec_push_all)]
+#![feature(box_syntax, time2, vec_push_all)]
 
 use std::env;
 use std::thread;
-use std::time::Duration;
+use std::time::Instant;
 
 #[derive(Clone)]
 enum List<T> {
@@ -31,12 +31,11 @@ fn main() {
 
 fn run(repeat: isize, depth: isize) {
     for _ in 0..repeat {
-        let dur = Duration::span(|| {
-            let _ = thread::spawn(move|| {
-                recurse_or_panic(depth, None)
-            }).join();
-        });
-        println!("iter: {:?}", dur);
+        let start = Instant::now();
+        let _ = thread::spawn(move|| {
+            recurse_or_panic(depth, None)
+        }).join();
+        println!("iter: {:?}", start.elapsed());
     }
 }
 


### PR DESCRIPTION
The `Duration::span` removal will hit stable in 1.7 at the soonest, while 1.6 already has the deprecation warning.
