### PR TITLE
Add a hint when given --extern with an indeterminate type

### DIFF
--- a/src/librustc_metadata/loader.rs
+++ b/src/librustc_metadata/loader.rs
@@ -664,6 +664,8 @@ impl<'a> Context<'a> {
                 }
                 sess.err(&format!("extern location for {} is of an unknown type: {}",
                                  self.crate_name, loc.display()));
+                sess.help(&format!("file name should be lib*.rlib or {}*.{}",
+                                   dylibname.0, dylibname.1));
                 false
             });
 


### PR DESCRIPTION
@ubsan brought up this relatively poor error message. This adds a
help message hinting when the problem actually is, and how to fix
it.
