### PR TITLE
AsRef and related conversions for CString

### DIFF
--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -20,7 +20,7 @@ use iter::Iterator;
 use libc;
 use mem;
 use memchr;
-use ops::Deref;
+use ops;
 use option::Option::{self, Some, None};
 use os::raw::c_char;
 use result::Result::{self, Ok, Err};
@@ -282,7 +282,7 @@ impl CString {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl Deref for CString {
+impl ops::Deref for CString {
     type Target = CStr;
 
     fn deref(&self) -> &CStr {
@@ -519,6 +519,37 @@ impl ToOwned for CStr {
 
     fn to_owned(&self) -> CString {
         unsafe { CString::from_vec_unchecked(self.to_bytes().to_vec()) }
+    }
+}
+
+#[unstable(feature = "cstring_asref", reason = "recently added", issue = "0")]
+impl ops::Index<ops::RangeFull> for CString {
+    type Output = CStr;
+
+    #[inline]
+    fn index(&self, _index: ops::RangeFull) -> &CStr {
+        self
+    }
+}
+
+#[unstable(feature = "cstring_asref", reason = "recently added", issue = "0")]
+impl<'a, T: ?Sized + AsRef<CStr>> From<&'a T> for CString {
+    fn from(s: &'a T) -> CString {
+        s.as_ref().to_owned()
+    }
+}
+
+#[unstable(feature = "cstring_asref", reason = "recently added", issue = "0")]
+impl AsRef<CStr> for CStr {
+    fn as_ref(&self) -> &CStr {
+        self
+    }
+}
+
+#[unstable(feature = "cstring_asref", reason = "recently added", issue = "0")]
+impl AsRef<CStr> for CString {
+    fn as_ref(&self) -> &CStr {
+        self
     }
 }
 

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -522,14 +522,14 @@ impl ToOwned for CStr {
     }
 }
 
-#[unstable(feature = "cstring_asref", reason = "recently added", issue = "0")]
+#[stable(feature = "cstring_asref", since = "1.7.0")]
 impl<'a> From<&'a CStr> for CString {
     fn from(s: &'a CStr) -> CString {
         s.to_owned()
     }
 }
 
-#[unstable(feature = "cstring_asref", reason = "recently added", issue = "0")]
+#[stable(feature = "cstring_asref", since = "1.7.0")]
 impl ops::Index<ops::RangeFull> for CString {
     type Output = CStr;
 
@@ -539,14 +539,14 @@ impl ops::Index<ops::RangeFull> for CString {
     }
 }
 
-#[unstable(feature = "cstring_asref", reason = "recently added", issue = "0")]
+#[stable(feature = "cstring_asref", since = "1.7.0")]
 impl AsRef<CStr> for CStr {
     fn as_ref(&self) -> &CStr {
         self
     }
 }
 
-#[unstable(feature = "cstring_asref", reason = "recently added", issue = "0")]
+#[stable(feature = "cstring_asref", since = "1.7.0")]
 impl AsRef<CStr> for CString {
     fn as_ref(&self) -> &CStr {
         self

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -523,19 +523,19 @@ impl ToOwned for CStr {
 }
 
 #[unstable(feature = "cstring_asref", reason = "recently added", issue = "0")]
+impl<'a> From<&'a CStr> for CString {
+    fn from(s: &'a CStr) -> CString {
+        s.to_owned()
+    }
+}
+
+#[unstable(feature = "cstring_asref", reason = "recently added", issue = "0")]
 impl ops::Index<ops::RangeFull> for CString {
     type Output = CStr;
 
     #[inline]
     fn index(&self, _index: ops::RangeFull) -> &CStr {
         self
-    }
-}
-
-#[unstable(feature = "cstring_asref", reason = "recently added", issue = "0")]
-impl<'a, T: ?Sized + AsRef<CStr>> From<&'a T> for CString {
-    fn from(s: &'a T) -> CString {
-        s.as_ref().to_owned()
     }
 }
 


### PR DESCRIPTION
Are trait impls still insta-stable? Considering that this design has been around for a long time on `String` and `OsString` it probably doesn't matter much...

The `From` impl is a bit strange to me. It's stolen from `OsString` but I'm not really sure about it... `String` just impls `From<&str>` instead, would that make more sense?
