### PR TITLE
Emscripten support take 2 (with bonus i686-unknown-linux-musl).

### DIFF
--- a/configure
+++ b/configure
@@ -1305,6 +1305,12 @@ $ pacman -R cmake && pacman -S mingw-w64-x86_64-cmake
             putvar CFG_DISABLE_JEMALLOC
             ;;
 
+        *-emscripten)
+            step_msg "targeting emscripten, disabling jemalloc"
+            CFG_DISABLE_JEMALLOC=1
+            putvar CFG_DISABLE_JEMALLOC
+            ;;
+
         *)
             ;;
     esac

--- a/mk/cfg/asmjs-unknown-emscripten.mk
+++ b/mk/cfg/asmjs-unknown-emscripten.mk
@@ -1,0 +1,23 @@
+# asmjs-unknown-emscripten configuration
+CC_asmjs-unknown-emscripten=emcc
+CXX_asmjs-unknown-emscripten=em++
+CPP_asmjs-unknown-emscripten=$(CPP)
+AR_asmjs-unknown-emscripten=emar
+CFG_LIB_NAME_asmjs-unknown-emscripten=lib$(1).so
+CFG_STATIC_LIB_NAME_asmjs-unknown-emscripten=lib$(1).a
+CFG_LIB_GLOB_asmjs-unknown-emscripten=lib$(1)-*.so
+CFG_LIB_DSYM_GLOB_asmjs-unknown-emscripten=lib$(1)-*.dylib.dSYM
+CFG_JEMALLOC_CFLAGS_asmjs-unknown-emscripten := -m32 $(CFLAGS)
+CFG_GCCISH_CFLAGS_asmjs-unknown-emscripten := -Wall -Werror -g -fPIC -m32 $(CFLAGS)
+CFG_GCCISH_CXXFLAGS_asmjs-unknown-emscripten := -fno-rtti $(CXXFLAGS)
+CFG_GCCISH_LINK_FLAGS_asmjs-unknown-emscripten := -shared -fPIC -ldl -pthread  -lrt -g -m32
+CFG_GCCISH_DEF_FLAG_asmjs-unknown-emscripten := -Wl,--export-dynamic,--dynamic-list=
+CFG_LLC_FLAGS_asmjs-unknown-emscripten :=
+CFG_INSTALL_NAME_asmjs-unknown-emscripten =
+CFG_EXE_SUFFIX_asmjs-unknown-emscripten =
+CFG_WINDOWSY_asmjs-unknown-emscripten :=
+CFG_UNIXY_asmjs-unknown-emscripten := 1
+CFG_LDPATH_asmjs-unknown-emscripten :=
+CFG_RUN_asmjs-unknown-emscripten=$(2)
+CFG_RUN_TARG_asmjs-unknown-emscripten=$(call CFG_RUN_asmjs-unknown-emscripten,,$(2))
+CFG_GNU_TRIPLE_asmjs-unknown-emscripten := asmjs-unknown-emscripten

--- a/mk/cfg/i686-unknown-linux-musl.mk
+++ b/mk/cfg/i686-unknown-linux-musl.mk
@@ -1,0 +1,28 @@
+# i686-unknown-linux-musl configuration
+CC_i686-unknown-linux-musl=$(CFG_MUSL_ROOT)/bin/musl-gcc
+CXX_i686-unknown-linux-musl=notaprogram
+CPP_i686-unknown-linux-musl=$(CFG_MUSL_ROOT)/bin/musl-gcc -E
+AR_i686-unknown-linux-musl=$(AR)
+CFG_INSTALL_ONLY_RLIB_i686-unknown-linux-musl = 1
+CFG_LIB_NAME_i686-unknown-linux-musl=lib$(1).so
+CFG_STATIC_LIB_NAME_i686-unknown-linux-musl=lib$(1).a
+CFG_LIB_GLOB_i686-unknown-linux-musl=lib$(1)-*.so
+CFG_JEMALLOC_CFLAGS_i686-unknown-linux-musl := -m32 -Wl,-melf_i386
+CFG_GCCISH_CFLAGS_i686-unknown-linux-musl := -Wall -Werror -g -fPIC -m32 -Wl,-melf_i386
+CFG_GCCISH_CXXFLAGS_i686-unknown-linux-musl :=
+CFG_GCCISH_LINK_FLAGS_i686-unknown-linux-musl :=
+CFG_GCCISH_DEF_FLAG_i686-unknown-linux-musl :=
+CFG_LLC_FLAGS_i686-unknown-linux-musl :=
+CFG_INSTALL_NAME_i686-unknown-linux-musl =
+CFG_EXE_SUFFIX_i686-unknown-linux-musl =
+CFG_WINDOWSY_i686-unknown-linux-musl :=
+CFG_UNIXY_i686-unknown-linux-musl := 1
+CFG_LDPATH_i686-unknown-linux-musl :=
+CFG_RUN_i686-unknown-linux-musl=$(2)
+CFG_RUN_TARG_i686-unknown-linux-musl=$(call CFG_RUN_i686-unknown-linux-musl,,$(2))
+CFG_GNU_TRIPLE_i686-unknown-linux-musl := i686-unknown-linux-musl
+CFG_THIRD_PARTY_OBJECTS_i686-unknown-linux-musl := crt1.o crti.o crtn.o
+CFG_INSTALLED_OBJECTS_i686-unknown-linux-musl := crt1.o crti.o crtn.o
+
+NATIVE_DEPS_libc_T_i686-unknown-linux-musl += libc.a
+NATIVE_DEPS_std_T_i686-unknown-linux-musl += libunwind.a crt1.o crti.o crtn.o

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -361,6 +361,9 @@ export CFG_DISABLE_UNSTABLE_FEATURES
 export RUSTC_BOOTSTRAP_KEY:=$(CFG_BOOTSTRAP_KEY)
 endif
 export CFG_BOOTSTRAP_KEY
+ifdef CFG_MUSL_ROOT
+export CFG_MUSL_ROOT
+endif
 
 ######################################################################
 # Per-stage targets and runner

--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -254,6 +254,15 @@ ifeq ($$(findstring freebsd,$(1)),freebsd)
 	COMPRT_CFLAGS_$(1) += -I/usr/include/c++/v1
 endif
 
+ifeq ($$(findstring emscripten,$(1)),emscripten)
+
+# FIXME: emscripten doesn't use compiler-rt and can't build it without
+# further hacks
+$$(COMPRT_LIB_$(1)):
+	touch $$@
+
+else
+
 $$(COMPRT_LIB_$(1)): $$(COMPRT_DEPS) $$(MKFILE_DEPS)
 	@$$(call E, make: compiler-rt)
 	$$(Q)$$(MAKE) -C "$(S)src/compiler-rt" \
@@ -266,7 +275,10 @@ $$(COMPRT_LIB_$(1)): $$(COMPRT_DEPS) $$(MKFILE_DEPS)
 		TargetTriple=$(1) \
 		triple-builtins
 	$$(Q)cp $$(COMPRT_BUILD_DIR_$(1))/triple/builtins/libcompiler_rt.a $$@
+
+endif # if emscripten
 endif
+
 ################################################################################
 # libbacktrace
 #
@@ -297,6 +309,12 @@ else
 
 ifeq ($$(findstring msvc,$(1)),msvc)
 # See comment above
+$$(BACKTRACE_LIB_$(1)):
+	touch $$@
+else
+
+ifeq ($$(findstring emscripten,$(1)),emscripten)
+# FIXME: libbacktrace doesn't understand the emscripten triple
 $$(BACKTRACE_LIB_$(1)):
 	touch $$@
 else
@@ -348,6 +366,7 @@ $$(BACKTRACE_LIB_$(1)): $$(BACKTRACE_BUILD_DIR_$(1))/Makefile $$(MKFILE_DEPS)
 		INCDIR=$(S)src/libbacktrace
 	$$(Q)cp $$(BACKTRACE_BUILD_DIR_$(1))/.libs/libbacktrace.a $$@
 
+endif # endif for emscripten
 endif # endif for msvc
 endif # endif for ios
 endif # endif for darwin

--- a/src/compiletest/util.rs
+++ b/src/compiletest/util.rs
@@ -26,6 +26,7 @@ const OS_TABLE: &'static [(&'static str, &'static str)] = &[
     ("win32", "windows"),
     ("windows", "windows"),
     ("solaris", "solaris"),
+    ("emscripten", "emscripten"),
 ];
 
 const ARCH_TABLE: &'static [(&'static str, &'static str)] = &[
@@ -44,6 +45,7 @@ const ARCH_TABLE: &'static [(&'static str, &'static str)] = &[
     ("sparc", "sparc"),
     ("x86_64", "x86_64"),
     ("xcore", "xcore"),
+    ("asmjs", "asmjs"),
 ];
 
 pub fn get_os(triple: &str) -> &'static str {

--- a/src/liballoc_system/lib.rs
+++ b/src/liballoc_system/lib.rs
@@ -30,7 +30,8 @@ extern crate libc;
               target_arch = "arm",
               target_arch = "mips",
               target_arch = "powerpc",
-              target_arch = "powerpc64")))]
+              target_arch = "powerpc64",
+              target_arch = "asmjs")))]
 const MIN_ALIGN: usize = 8;
 #[cfg(all(any(target_arch = "x86_64",
               target_arch = "aarch64")))]

--- a/src/librustc_back/target/asmjs_unknown_emscripten.rs
+++ b/src/librustc_back/target/asmjs_unknown_emscripten.rs
@@ -22,6 +22,7 @@ pub fn target() -> Target {
         linker_is_gnu: true,
         allow_asm: false,
         archive_format: "gnu".to_string(),
+        obj_is_bitcode: true,
         .. Default::default()
     };
     Target {

--- a/src/librustc_back/target/asmjs_unknown_emscripten.rs
+++ b/src/librustc_back/target/asmjs_unknown_emscripten.rs
@@ -1,0 +1,37 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use super::{Target, TargetOptions};
+
+pub fn target() -> Target {
+    let opts = TargetOptions {
+        linker: "emcc".to_string(),
+        ar: "emar".to_string(),
+
+        dynamic_linking: false,
+        executables: true,
+        exe_suffix: ".js".to_string(),
+        no_compiler_rt: true,
+        linker_is_gnu: true,
+        allow_asm: false,
+        archive_format: "gnu".to_string(),
+        .. Default::default()
+    };
+    Target {
+        llvm_target: "asmjs-unknown-emscripten".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "32".to_string(),
+        target_os: "emscripten".to_string(),
+        target_env: "".to_string(),
+        target_vendor: "unknown".to_string(),
+        arch: "asmjs".to_string(),
+        options: opts,
+    }
+}

--- a/src/librustc_back/target/i686_unknown_linux_musl.rs
+++ b/src/librustc_back/target/i686_unknown_linux_musl.rs
@@ -1,0 +1,46 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// See x86_64_unknown_linux_musl for explanation of arguments
+
+use target::Target;
+
+pub fn target() -> Target {
+    let mut base = super::linux_base::opts();
+    base.cpu = "pentium4".to_string();
+    base.pre_link_args.push("-m32".to_string());
+    base.pre_link_args.push("-Wl,-melf_i386".to_string());
+
+    base.pre_link_args.push("-nostdlib".to_string());
+    base.pre_link_args.push("-static".to_string());
+    base.pre_link_args.push("-Wl,--eh-frame-hdr".to_string());
+
+    base.pre_link_args.push("-Wl,-(".to_string());
+    base.post_link_args.push("-Wl,-)".to_string());
+
+    base.pre_link_objects_exe.push("crt1.o".to_string());
+    base.pre_link_objects_exe.push("crti.o".to_string());
+    base.post_link_objects.push("crtn.o".to_string());
+
+    base.dynamic_linking = false;
+    base.has_rpath = false;
+    base.position_independent_executables = false;
+
+    Target {
+        llvm_target: "i686-unknown-linux-musl".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "32".to_string(),
+        arch: "x86".to_string(),
+        target_os: "linux".to_string(),
+        target_env: "musl".to_string(),
+        target_vendor: "unknown".to_string(),
+        options: base,
+    }
+}

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -461,7 +461,8 @@ impl Target {
             x86_64_pc_windows_msvc,
             i686_pc_windows_msvc,
 
-            le32_unknown_nacl
+            le32_unknown_nacl,
+            asmjs_unknown_emscripten
         );
 
 

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -204,6 +204,10 @@ pub struct TargetOptions {
     /// Flag indicating whether ELF TLS (e.g. #[thread_local]) is available for
     /// this target.
     pub has_elf_tls: bool,
+    // This is mainly for easy compatibility with emscripten.
+    // If we give emcc .o files that are actually .bc files it
+    // will 'just work'.
+    pub obj_is_bitcode: bool,
 }
 
 impl Default for TargetOptions {
@@ -251,6 +255,7 @@ impl Default for TargetOptions {
             exe_allocation_crate: "alloc_system".to_string(),
             allow_asm: true,
             has_elf_tls: false,
+            obj_is_bitcode: false,
         }
     }
 }

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -431,6 +431,7 @@ impl Target {
             armv7_unknown_linux_gnueabihf,
             aarch64_unknown_linux_gnu,
             x86_64_unknown_linux_musl,
+            i686_unknown_linux_musl,
             mips_unknown_linux_musl,
             mipsel_unknown_linux_musl,
 

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -244,7 +244,6 @@ pub struct ModuleConfig {
     emit_ir: bool,
     emit_asm: bool,
     emit_obj: bool,
-
     // Miscellaneous flags.  These are mostly copied from command-line
     // options.
     no_verify: bool,
@@ -254,7 +253,11 @@ pub struct ModuleConfig {
     vectorize_loop: bool,
     vectorize_slp: bool,
     merge_functions: bool,
-    inline_threshold: Option<usize>
+    inline_threshold: Option<usize>,
+    // Instead of creating an object file by doing LLVM codegen, just
+    // make the object file bitcode. Provides easy compatibility with
+    // emscripten's ecc compiler, when used as the linker.
+    obj_is_bitcode: bool,
 }
 
 unsafe impl Send for ModuleConfig { }
@@ -272,6 +275,7 @@ impl ModuleConfig {
             emit_ir: false,
             emit_asm: false,
             emit_obj: false,
+            obj_is_bitcode: false,
 
             no_verify: false,
             no_prepopulate_passes: false,
@@ -290,6 +294,7 @@ impl ModuleConfig {
         self.no_builtins = trans.no_builtins;
         self.time_passes = sess.time_passes();
         self.inline_threshold = sess.opts.cg.inline_threshold;
+        self.obj_is_bitcode = sess.target.target.options.obj_is_bitcode;
 
         // Copy what clang does by turning on loop vectorization at O2 and
         // slp vectorization at O3. Otherwise configure other optimization aspects
@@ -530,11 +535,21 @@ unsafe fn optimize_and_codegen(cgcx: &CodegenContext,
         f(cpm);
     }
 
-    if config.emit_bc {
-        let ext = format!("{}.bc", name_extra);
-        let out = output_names.with_extension(&ext);
-        let out = path2cstr(&out);
-        llvm::LLVMWriteBitcodeToFile(llmod, out.as_ptr());
+    // Change what we write and cleanup based on whether obj files are
+    // just llvm bitcode. In that case write bitcode, and possibly
+    // delete the bitcode if it wasn't requested. Don't generate the
+    // machine code, instead copy the .o file from the .bc
+    let write_bc = config.emit_bc || config.obj_is_bitcode;
+    let rm_bc = !config.emit_bc && config.obj_is_bitcode;
+    let write_obj = config.emit_obj && !config.obj_is_bitcode;
+    let copy_bc_to_obj = config.emit_obj && config.obj_is_bitcode;
+
+    let bc_out = output_names.with_extension(&format!("{}.bc", name_extra));
+    let obj_out = output_names.with_extension(&format!("{}.o", name_extra));
+
+    if write_bc {
+        let bc_out_c = path2cstr(&bc_out);
+        llvm::LLVMWriteBitcodeToFile(llmod, bc_out_c.as_ptr());
     }
 
     time(config.time_passes, &format!("codegen passes [{}]", cgcx.worker), || {
@@ -568,13 +583,26 @@ unsafe fn optimize_and_codegen(cgcx: &CodegenContext,
             }
         }
 
-        if config.emit_obj {
-            let path = output_names.with_extension(&format!("{}.o", name_extra));
+        if write_obj {
             with_codegen(tm, llmod, config.no_builtins, |cpm| {
-                write_output_file(cgcx.handler, tm, cpm, llmod, &path, llvm::ObjectFileType);
+                write_output_file(cgcx.handler, tm, cpm, llmod, &obj_out, llvm::ObjectFileType);
             });
         }
     });
+
+    if copy_bc_to_obj {
+        debug!("copying bitcode {:?} to obj {:?}", bc_out, obj_out);
+        if let Err(e) = fs::copy(&bc_out, &obj_out) {
+            cgcx.handler.err(&format!("failed to copy bitcode to object file: {}", e));
+        }
+    }
+
+    if rm_bc {
+        debug!("removing_bitcode {:?}", bc_out);
+        if let Err(e) = fs::remove_file(&bc_out) {
+            cgcx.handler.err(&format!("failed to remove bitcode: {}", e));
+        }
+    }
 
     llvm::LLVMDisposeModule(llmod);
     llvm::LLVMContextDispose(llcx);

--- a/src/librustc_trans/trans/cabi.rs
+++ b/src/librustc_trans/trans/cabi.rs
@@ -21,6 +21,7 @@ use trans::cabi_aarch64;
 use trans::cabi_powerpc;
 use trans::cabi_powerpc64;
 use trans::cabi_mips;
+use trans::cabi_asmjs;
 use trans::type_::Type;
 
 #[derive(Clone, Copy, PartialEq)]
@@ -129,6 +130,7 @@ pub fn compute_abi_info(ccx: &CrateContext,
         "mips" => cabi_mips::compute_abi_info(ccx, atys, rty, ret_def),
         "powerpc" => cabi_powerpc::compute_abi_info(ccx, atys, rty, ret_def),
         "powerpc64" => cabi_powerpc64::compute_abi_info(ccx, atys, rty, ret_def),
+        "asmjs" => cabi_asmjs::compute_abi_info(ccx, atys, rty, ret_def),
         a => ccx.sess().fatal(&format!("unrecognized arch \"{}\" in target specification", a)
                               ),
     }

--- a/src/librustc_trans/trans/cabi_asmjs.rs
+++ b/src/librustc_trans/trans/cabi_asmjs.rs
@@ -1,0 +1,22 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use trans::cabi::FnType;
+use trans::cabi_arm;
+use trans::context::CrateContext;
+use trans::type_::Type;
+
+pub fn compute_abi_info(ccx: &CrateContext,
+                        atys: &[Type],
+                        rty: Type,
+                        ret_def: bool) -> FnType {
+    cabi_arm::compute_abi_info(ccx, atys, rty, ret_def,
+                               cabi_arm::Flavor::General)
+}

--- a/src/librustc_trans/trans/mod.rs
+++ b/src/librustc_trans/trans/mod.rs
@@ -30,6 +30,7 @@ mod builder;
 mod cabi;
 mod cabi_aarch64;
 mod cabi_arm;
+mod cabi_asmjs;
 mod cabi_mips;
 mod cabi_powerpc;
 mod cabi_powerpc64;

--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -197,7 +197,8 @@ mod tests {
           target_os = "bitrig",
           target_os = "netbsd",
           target_os = "openbsd",
-          target_os = "solaris"))]
+          target_os = "solaris",
+          target_os = "emscripten"))]
 mod dl {
     use prelude::v1::*;
 

--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -844,6 +844,17 @@ mod os {
     pub const EXE_EXTENSION: &'static str = "pexe";
 }
 
+#[cfg(target_os = "emscripten")]
+mod os {
+    pub const FAMILY: &'static str = "unix";
+    pub const OS: &'static str = "emscripten";
+    pub const DLL_PREFIX: &'static str = "lib";
+    pub const DLL_SUFFIX: &'static str = ".so";
+    pub const DLL_EXTENSION: &'static str = "so";
+    pub const EXE_SUFFIX: &'static str = ".js";
+    pub const EXE_EXTENSION: &'static str = "js";
+}
+
 #[cfg(target_arch = "x86")]
 mod arch {
     pub const ARCH: &'static str = "x86";
@@ -882,6 +893,11 @@ mod arch {
 #[cfg(target_arch = "le32")]
 mod arch {
     pub const ARCH: &'static str = "le32";
+}
+
+#[cfg(target_arch = "asmjs")]
+mod arch {
+    pub const ARCH: &'static str = "asmjs";
 }
 
 #[cfg(test)]

--- a/src/libstd/os/linux/raw.rs
+++ b/src/libstd/os/linux/raw.rs
@@ -26,7 +26,8 @@ pub use self::arch::{off_t, ino_t, nlink_t, blksize_t, blkcnt_t, stat, time_t};
 #[cfg(any(target_arch = "x86",
           target_arch = "le32",
           target_arch = "powerpc",
-          target_arch = "arm"))]
+          target_arch = "arm",
+          target_arch = "asmjs"))]
 mod arch {
     use super::{dev_t, mode_t};
     use os::raw::{c_long, c_short};
@@ -34,7 +35,14 @@ mod arch {
 
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i32;
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i32;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u32;
+
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    #[cfg(not(any(target_env = "musl", target_arch = "asmjs")))]
+    pub type ino_t = u32;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    #[cfg(any(target_env = "musl", target_arch = "asmjs"))]
+    pub type ino_t = u64;
+
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u32;
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i32;
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i32;

--- a/src/libstd/os/mod.rs
+++ b/src/libstd/os/mod.rs
@@ -32,4 +32,9 @@ pub use sys::ext as windows;
 #[cfg(target_os = "openbsd")]   pub mod openbsd;
 #[cfg(target_os = "solaris")]   pub mod solaris;
 
+// Emscripten is just like linux
+#[cfg(target_os = "emscripten")]
+#[path = "linux/mod.rs"]
+pub mod emscripten;
+
 pub mod raw;

--- a/src/libstd/os/raw.rs
+++ b/src/libstd/os/raw.rs
@@ -13,12 +13,14 @@
 #![stable(feature = "raw_os", since = "1.1.0")]
 
 #[cfg(any(target_os = "android",
+          target_os = "emscripten",
           all(target_os = "linux", any(target_arch = "aarch64",
                                        target_arch = "arm",
                                        target_arch = "powerpc",
                                        target_arch = "powerpc64"))))]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_char = u8;
 #[cfg(not(any(target_os = "android",
+              target_os = "emscripten",
               all(target_os = "linux", any(target_arch = "aarch64",
                                            target_arch = "arm",
                                            target_arch = "powerpc",

--- a/src/libstd/sys/common/args.rs
+++ b/src/libstd/sys/common/args.rs
@@ -39,7 +39,8 @@ pub fn clone() -> Option<Vec<Vec<u8>>> { imp::clone() }
           target_os = "bitrig",
           target_os = "netbsd",
           target_os = "openbsd",
-          target_os = "solaris"))]
+          target_os = "solaris",
+          target_os = "emscripten"))]
 mod imp {
     use prelude::v1::*;
 

--- a/src/libstd/sys/common/libunwind.rs
+++ b/src/libstd/sys/common/libunwind.rs
@@ -86,6 +86,10 @@ pub const unwinder_private_data_size: usize = 2;
 #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
 pub const unwinder_private_data_size: usize = 2;
 
+#[cfg(target_arch = "asmjs")]
+// FIXME: Copied from arm. Need to confirm.
+pub const unwinder_private_data_size: usize = 20;
+
 #[repr(C)]
 pub struct _Unwind_Exception {
     pub exception_class: _Unwind_Exception_Class,

--- a/src/libstd/sys/common/mod.rs
+++ b/src/libstd/sys/common/mod.rs
@@ -45,7 +45,7 @@ pub mod unwind;
 pub mod util;
 pub mod wtf8;
 
-#[cfg(any(all(unix, not(any(target_os = "macos", target_os = "ios"))),
+#[cfg(any(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "emscripten"))),
           all(windows, target_env = "gnu")))]
 pub mod gnu;
 

--- a/src/libstd/sys/unix/backtrace/printing/mod.rs
+++ b/src/libstd/sys/unix/backtrace/printing/mod.rs
@@ -10,10 +10,12 @@
 
 pub use self::imp::print;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios",
+          target_os = "emscripten"))]
 #[path = "dladdr.rs"]
 mod imp;
 
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+#[cfg(not(any(target_os = "macos", target_os = "ios",
+              target_os = "emscripten")))]
 #[path = "gnu.rs"]
 mod imp;

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -293,7 +293,8 @@ impl DirEntry {
     #[cfg(any(target_os = "macos",
               target_os = "ios",
               target_os = "linux",
-              target_os = "solaris"))]
+              target_os = "solaris",
+              target_os = "emscripten"))]
     pub fn ino(&self) -> raw::ino_t {
         self.entry.d_ino
     }
@@ -326,7 +327,8 @@ impl DirEntry {
         }
     }
     #[cfg(any(target_os = "android",
-              target_os = "linux"))]
+              target_os = "linux",
+              target_os = "emscripten"))]
     fn name_bytes(&self) -> &[u8] {
         unsafe {
             CStr::from_ptr(self.entry.d_name.as_ptr()).to_bytes()

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -26,6 +26,7 @@ use ops::Neg;
 #[cfg(target_os = "netbsd")]    pub use os::netbsd as platform;
 #[cfg(target_os = "openbsd")]   pub use os::openbsd as platform;
 #[cfg(target_os = "solaris")]   pub use os::solaris as platform;
+#[cfg(target_os = "emscripten")] pub use os::emscripten as platform;
 
 pub mod backtrace;
 pub mod condvar;

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -38,7 +38,8 @@ static ENV_LOCK: StaticMutex = StaticMutex::new();
 /// Returns the platform-specific value of errno
 pub fn errno() -> i32 {
     extern {
-        #[cfg_attr(any(target_os = "linux"), link_name = "__errno_location")]
+        #[cfg_attr(any(target_os = "linux", target_os = "emscripten"),
+                   link_name = "__errno_location")]
         #[cfg_attr(any(target_os = "bitrig",
                        target_os = "netbsd",
                        target_os = "openbsd",
@@ -235,7 +236,7 @@ pub fn current_exe() -> io::Result<PathBuf> {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
 pub fn current_exe() -> io::Result<PathBuf> {
     ::fs::read_link("/proc/self/exe")
 }
@@ -385,7 +386,8 @@ pub fn args() -> Args {
           target_os = "netbsd",
           target_os = "openbsd",
           target_os = "solaris",
-          target_os = "nacl"))]
+          target_os = "nacl",
+          target_os = "emscripten"))]
 pub fn args() -> Args {
     use sys_common;
     let bytes = sys_common::args::clone().unwrap_or(Vec::new());

--- a/src/libstd/sys/unix/process.rs
+++ b/src/libstd/sys/unix/process.rs
@@ -131,7 +131,8 @@ impl fmt::Debug for Command {
 pub struct ExitStatus(c_int);
 
 #[cfg(any(target_os = "linux", target_os = "android",
-          target_os = "nacl", target_os = "solaris"))]
+          target_os = "nacl", target_os = "solaris",
+          target_os = "emscripten"))]
 mod status_imp {
     pub fn WIFEXITED(status: i32) -> bool { (status & 0xff) == 0 }
     pub fn WEXITSTATUS(status: i32) -> i32 { (status >> 8) & 0xff }

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -81,7 +81,9 @@ impl Thread {
         debug_assert_eq!(ret, 0);
     }
 
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(any(target_os = "linux",
+              target_os = "android",
+              target_os = "emscripten"))]
     pub fn set_name(name: &str) {
         const PR_SET_NAME: libc::c_int = 15;
         let cname = CString::new(name).unwrap_or_else(|_| {

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -168,7 +168,7 @@ impl Drop for Thread {
     }
 }
 
-#[cfg(all(not(target_os = "linux"),
+#[cfg(all(not(all(target_os = "linux", not(target_env = "musl"))),
           not(target_os = "macos"),
           not(target_os = "bitrig"),
           not(all(target_os = "netbsd", not(target_vendor = "rumprun"))),
@@ -181,7 +181,7 @@ pub mod guard {
 }
 
 
-#[cfg(any(target_os = "linux",
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")),
           target_os = "macos",
           target_os = "bitrig",
           all(target_os = "netbsd", not(target_vendor = "rumprun")),

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -928,7 +928,8 @@ fn get_concurrency() -> usize {
               target_os = "macos",
               target_os = "ios",
               target_os = "android",
-              target_os = "solaris"))]
+              target_os = "solaris",
+              target_os = "emscripten"))]
     fn num_cpus() -> usize {
         unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) as usize }
     }
@@ -1174,14 +1175,16 @@ impl MetricMap {
 /// elimination.
 ///
 /// This function is a no-op, and does not even read from `dummy`.
-#[cfg(not(all(target_os = "nacl", target_arch = "le32")))]
+#[cfg(not(any(all(target_os = "nacl", target_arch = "le32"),
+              target_arch = "asmjs")))]
 pub fn black_box<T>(dummy: T) -> T {
     // we need to "use" the argument in some way LLVM can't
     // introspect.
     unsafe { asm!("" : : "r"(&dummy)) }
     dummy
 }
-#[cfg(all(target_os = "nacl", target_arch = "le32"))]
+#[cfg(any(all(target_os = "nacl", target_arch = "le32"),
+          target_arch = "asmjs"))]
 #[inline(never)]
 pub fn black_box<T>(dummy: T) -> T {
     dummy


### PR DESCRIPTION
Here's another go at adding emscripten support. This needs to wait again on new [libc definitions](https://github.com/rust-lang-nursery/libc/pull/122) landing. To get the libc definitions right I had to add support for i686-unknown-linux-musl, which are very similar to emscripten's, which are derived from arm/musl.

This branch additionally removes the makefile dependency on the `EMSCRIPTEN` environment variable by not building the unused compiler-rt.

Again, this is not sufficient for actually compiling to asmjs since it needs additional LLVM patches.

r? @alexcrichton 
