### PR TITLE
Use built-in comparisons for range matching in MIR

### DIFF
--- a/src/librustc_mir/hair/cx/mod.rs
+++ b/src/librustc_mir/hair/cx/mod.rs
@@ -88,11 +88,6 @@ impl<'a,'tcx:'a> Cx<'a, 'tcx> {
         self.cmp_method_ref(eq_def_id, "eq", ty)
     }
 
-    pub fn partial_le(&mut self, ty: Ty<'tcx>) -> ItemRef<'tcx> {
-        let ord_def_id = self.tcx.lang_items.ord_trait().unwrap();
-        self.cmp_method_ref(ord_def_id, "le", ty)
-    }
-
     pub fn num_variants(&mut self, adt_def: ty::AdtDef<'tcx>) -> usize {
         adt_def.variants.len()
     }

--- a/src/test/run-pass/mir_trans_match_range.rs
+++ b/src/test/run-pass/mir_trans_match_range.rs
@@ -1,0 +1,30 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_attrs)]
+
+#[rustc_mir]
+pub fn foo(x: i8) -> i32 {
+  match x {
+    1...10 => 0,
+    _ => 1,
+  }
+}
+
+fn main() {
+  assert_eq!(foo(0), 1);
+  assert_eq!(foo(1), 0);
+  assert_eq!(foo(2), 0);
+  assert_eq!(foo(5), 0);
+  assert_eq!(foo(9), 0);
+  assert_eq!(foo(10), 0);
+  assert_eq!(foo(11), 1);
+  assert_eq!(foo(20), 1);
+}


### PR DESCRIPTION
The previous version using `PartialOrd::le` was broken since it passed `T` arguments where `&T` was expected.

It makes sense to use primitive comparisons since range patterns can only be used with chars and numeric types.

r? @eddyb
