### PR TITLE
Reduce the size of the clone for people who just build rustc from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Read ["Installing Rust"] from [The Book].
 2. Clone the [source] with `git`:
 
    ```sh
-   $ git clone https://github.com/rust-lang/rust.git
+   $ git clone --depth=1 https://github.com/rust-lang/rust.git
    $ cd rust
    ```
 


### PR DESCRIPTION
This speeds up the download process for the user.

Tested on armhf and amd64.
