### PR TITLE
Don't throw away item attributes before trans_fn() for generic functions and others.

### DIFF
--- a/src/librustc_trans/trans/closure.rs
+++ b/src/librustc_trans/trans/closure.rs
@@ -31,6 +31,7 @@ use session::config::FullDebugInfo;
 
 use syntax::abi::RustCall;
 use syntax::ast;
+use syntax::attr::{ThinAttributes, ThinAttributesExt};
 
 use rustc_front::hir;
 
@@ -176,7 +177,8 @@ pub fn trans_closure_expr<'a, 'tcx>(dest: Dest<'a, 'tcx>,
                                     body: &hir::Block,
                                     id: ast::NodeId,
                                     closure_def_id: DefId, // (*)
-                                    closure_substs: &'tcx ty::ClosureSubsts<'tcx>)
+                                    closure_substs: &'tcx ty::ClosureSubsts<'tcx>,
+                                    closure_expr_attrs: &ThinAttributes)
                                     -> Option<Block<'a, 'tcx>>
 {
     // (*) Note that in the case of inlined functions, the `closure_def_id` will be the
@@ -218,7 +220,7 @@ pub fn trans_closure_expr<'a, 'tcx>(dest: Dest<'a, 'tcx>,
                   llfn,
                   param_substs,
                   id,
-                  &[],
+                  closure_expr_attrs.as_attr_slice(),
                   sig.output,
                   function_type.abi,
                   ClosureEnv::Closure(closure_def_id, &freevars));

--- a/src/librustc_trans/trans/consts.rs
+++ b/src/librustc_trans/trans/consts.rs
@@ -1019,8 +1019,13 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
         hir::ExprClosure(_, ref decl, ref body) => {
             match ety.sty {
                 ty::TyClosure(def_id, ref substs) => {
-                    closure::trans_closure_expr(closure::Dest::Ignore(cx), decl,
-                                                body, e.id, def_id, substs);
+                    closure::trans_closure_expr(closure::Dest::Ignore(cx),
+                                                decl,
+                                                body,
+                                                e.id,
+                                                def_id,
+                                                substs,
+                                                &e.attrs);
                 }
                 _ =>
                     cx.sess().span_bug(

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -1196,7 +1196,13 @@ fn trans_rvalue_dps_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                         &format!("closure expr without closure type: {:?}", t)),
             };
 
-            closure::trans_closure_expr(dest, decl, body, expr.id, def_id, substs).unwrap_or(bcx)
+            closure::trans_closure_expr(dest,
+                                        decl,
+                                        body,
+                                        expr.id,
+                                        def_id,
+                                        substs,
+                                        &expr.attrs).unwrap_or(bcx)
         }
         hir::ExprCall(ref f, ref args) => {
             if bcx.tcx().is_method_call(expr.id) {

--- a/src/librustc_trans/trans/foreign.rs
+++ b/src/librustc_trans/trans/foreign.rs
@@ -639,7 +639,7 @@ pub fn trans_rust_fn_with_foreign_abi<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
 
         let llfn = declare::define_internal_rust_fn(ccx, &ps, t);
         attributes::from_fn_attrs(ccx, attrs, llfn);
-        base::trans_fn(ccx, decl, body, llfn, param_substs, id, &[]);
+        base::trans_fn(ccx, decl, body, llfn, param_substs, id, attrs);
         llfn
     }
 

--- a/src/librustc_trans/trans/inline.rs
+++ b/src/librustc_trans/trans/inline.rs
@@ -165,7 +165,7 @@ fn instantiate_inline(ccx: &CrateContext, fn_id: DefId)
                              llfn,
                              empty_substs,
                              impl_item.id,
-                             &[]);
+                             &impl_item.attrs);
                     // See linkage comments on items.
                     if ccx.sess().opts.cg.codegen_units == 1 {
                         SetLinkage(llfn, InternalLinkage);

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -74,8 +74,13 @@ pub fn trans_impl(ccx: &CrateContext,
                     for (ref ccx, is_origin) in ccx.maybe_iter(trans_everywhere) {
                         let llfn = get_item_val(ccx, impl_item.id);
                         let empty_substs = tcx.mk_substs(Substs::trans_empty());
-                        trans_fn(ccx, &sig.decl, body, llfn,
-                                 empty_substs, impl_item.id, &[]);
+                        trans_fn(ccx,
+                                 &sig.decl,
+                                 body,
+                                 llfn,
+                                 empty_substs,
+                                 impl_item.id,
+                                 &impl_item.attrs);
                         update_linkage(ccx,
                                        llfn,
                                        Some(impl_item.id),

--- a/src/librustc_trans/trans/monomorphize.rs
+++ b/src/librustc_trans/trans/monomorphize.rs
@@ -185,7 +185,13 @@ pub fn monomorphic_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
                               ccx, &**decl, &**body, &[], d, psubsts, fn_node_id,
                               Some(&hash[..]));
                       } else {
-                          trans_fn(ccx, &**decl, &**body, d, psubsts, fn_node_id, &[]);
+                          trans_fn(ccx,
+                                   &**decl,
+                                   &**body,
+                                   d,
+                                   psubsts,
+                                   fn_node_id,
+                                   &i.attrs);
                       }
                   }
 
@@ -216,7 +222,7 @@ pub fn monomorphic_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
                                  d,
                                  psubsts,
                                  impl_item.id,
-                                 &[]);
+                                 &impl_item.attrs);
                     }
                     d
                 }
@@ -232,8 +238,13 @@ pub fn monomorphic_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
                     let d = mk_lldecl(abi::Rust);
                     let needs_body = setup_lldecl(d, &trait_item.attrs);
                     if needs_body {
-                        trans_fn(ccx, &sig.decl, body, d,
-                                 psubsts, trait_item.id, &[]);
+                        trans_fn(ccx,
+                                 &sig.decl,
+                                 body,
+                                 d,
+                                 psubsts,
+                                 trait_item.id,
+                                 &trait_item.attrs);
                     }
                     d
                 }

--- a/src/test/run-pass/mir_trans_calls.rs
+++ b/src/test/run-pass/mir_trans_calls.rs
@@ -58,11 +58,16 @@ fn test5(x: &Bar, a: isize) -> isize {
     x.extension_method(a)
 }
 
-#[rustc_mir]
-fn test6<T: Bar>(x: &T, a: isize) -> isize {
-    // Test calling extension method on generic callee
-    x.extension_method(a)
-}
+// FIXME #30661: Although this function has the #[rustc_mir] attribute it never
+//               was translated via the MIR implementation because attributes
+//               where not passed along to trans::base::trans_fn() for generic
+//               functions.
+//               Uncomment this test once the thing it tests is fixed.
+// #[rustc_mir]
+// fn test6<T: Bar>(x: &T, a: isize) -> isize {
+//     // Test calling extension method on generic callee
+//     x.extension_method(a)
+// }
 
 trait One<T = Self> {
     fn one() -> T;
@@ -94,7 +99,8 @@ fn main() {
     assert_eq!(test3(&Foo, 42), 42);
     assert_eq!(test4(&Foo, 970), 970);
     assert_eq!(test5(&Foo, 8576), 8576);
-    assert_eq!(test6(&Foo, 12367), 12367);
+    // see definition of test6() above
+    // assert_eq!(test6(&Foo, 12367), 12367);
     assert_eq!(test7(), 1);
     assert_eq!(test8(), 2);
 }


### PR DESCRIPTION
So far `librustc::trans::base::trans_fn()` and `trans_closure()` have been passed the list of attributes on the function being translated _only_ if the function was local and non-generic. For generic functions, functions inlined from other crates, functions with foreign ABI and for closures, only an empty list of attributes was ever passed to `trans_fn()`.
This led to the case that generic functions marked with `#[rustc_mir]` where not actually translated via MIR but via the legacy translation path.

This PR makes function/closure attributes always be passed to `trans_fn()` and disables the one test where this makes a difference.

If there is an actual reason why attributes were not passed along in these cases, let me know.

cc @rust-lang/compiler 
cc @luqmana regarding the test case
