### PR TITLE
Issue #30592: Restore build in --disable-jemalloc mode.

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -95,7 +95,14 @@
 
 #![feature(needs_allocator)]
 
+// Issue# 30592: Systematically use alloc_system during stage0 since jemalloc
+// might be unavailable or disabled
+#![cfg_attr(stage0, feature(alloc_system))]
+
 #![cfg_attr(test, feature(test, rustc_private, box_heap))]
+
+#[cfg(stage0)]
+extern crate alloc_system;
 
 // Allow testing this library
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/30592, a fallout of https://github.com/rust-lang/rust/commit/cd1848a1a60f40f25019e455b1050efd69707604
