### PR TITLE
Check for mmap failure with MAP_FAILED, not NULL

### DIFF
--- a/src/libbacktrace/mmap.c
+++ b/src/libbacktrace/mmap.c
@@ -139,7 +139,7 @@ backtrace_alloc (struct backtrace_state *state,
       asksize = (size + pagesize - 1) & ~ (pagesize - 1);
       page = mmap (NULL, asksize, PROT_READ | PROT_WRITE,
 		   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-      if (page == NULL)
+      if (page == MAP_FAILED)
 	error_callback (data, "mmap", errno);
       else
 	{


### PR DESCRIPTION
From upstream. Here's the commit:

https://github.com/gcc-mirror/gcc/commit/37bab844414c75d11ae46f45196562993de6ae6a

And the associated PR:

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67457
