### PR TITLE
Stabilise f32::to_{degrees,radians} to match f64

### DIFF
--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -676,8 +676,6 @@ impl f32 {
     /// Converts radians to degrees.
     ///
     /// ```
-    /// #![feature(float_extras)]
-    ///
     /// use std::f32::{self, consts};
     ///
     /// let angle = consts::PI;
@@ -686,16 +684,13 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[unstable(feature = "float_extras", reason = "desirability is unclear",
-               issue = "27752")]
+    #[stable(feature = "f32_deg_rad_conversions", since="1.7.0")]
     #[inline]
     pub fn to_degrees(self) -> f32 { num::Float::to_degrees(self) }
 
     /// Converts degrees to radians.
     ///
     /// ```
-    /// #![feature(float_extras)]
-    ///
     /// use std::f32::{self, consts};
     ///
     /// let angle = 180.0f32;
@@ -704,8 +699,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[unstable(feature = "float_extras", reason = "desirability is unclear",
-               issue = "27752")]
+    #[stable(feature = "f32_deg_rad_conversions", since="1.7.0")]
     #[inline]
     pub fn to_radians(self) -> f32 { num::Float::to_radians(self) }
 


### PR DESCRIPTION
f64 methods have been stable since rust 1.0, but f32 never got stabilised.

I suggest backporting this to beta as well (needs changing stablilisation version then).

r? @aturon 

Fixes https://github.com/rust-lang/rfcs/issues/1438
