### PR TITLE
Fix off-by-one in String::remove

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -1029,8 +1029,8 @@ impl String {
     ///
     /// # Panics
     ///
-    /// Panics if `idx` is larger than the `String`'s length, or if it does not
-    /// lie on a [`char`] boundary.
+    /// Panics if `idx` is larger than or equal to the `String`'s length,
+    /// or if it does not lie on a [`char`] boundary.
     ///
     /// [`char`]: ../primitive.char.html
     ///
@@ -1049,7 +1049,7 @@ impl String {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn remove(&mut self, idx: usize) -> char {
         let len = self.len();
-        assert!(idx <= len);
+        assert!(idx < len);
 
         let ch = self.char_at(idx);
         let next = idx + ch.len_utf8();


### PR DESCRIPTION
Obviously we can't remove the character one past the end of the String. And we can't today either - we'll just panic at char_at() instead - but if we're going to keep that assertion, we should at least have a correct assertion.
