### PR TITLE
Replace no_elf_tls with target_thread_local

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -175,9 +175,5 @@ endef
 
 $(foreach crate,$(TOOLS),$(eval $(call RUST_TOOL,$(crate))))
 
-ifdef CFG_DISABLE_ELF_TLS
-RUSTFLAGS_std := --cfg no_elf_tls
-endif
-
 CRATEFILE_libc := $(SREL)src/liblibc/src/lib.rs
 RUSTFLAGS_libc := --cfg stdbuild

--- a/src/librustc_back/target/aarch64_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/aarch64_unknown_linux_gnu.rs
@@ -11,8 +11,7 @@
 use target::Target;
 
 pub fn target() -> Target {
-    let mut base = super::linux_base::opts();
-    base.has_elf_tls = false;
+    let base = super::linux_base::opts();
     Target {
         llvm_target: "aarch64-unknown-linux-gnu".to_string(),
         target_endian: "little".to_string(),

--- a/src/librustc_back/target/android_base.rs
+++ b/src/librustc_back/target/android_base.rs
@@ -17,5 +17,6 @@ pub fn opts() -> TargetOptions {
     base.pre_link_args.push("-Wl,--allow-multiple-definition".to_string());
     base.is_like_android = true;
     base.position_independent_executables = true;
+    base.has_elf_tls = false;
     base
 }

--- a/src/librustc_back/target/arm_linux_androideabi.rs
+++ b/src/librustc_back/target/arm_linux_androideabi.rs
@@ -13,7 +13,6 @@ use target::Target;
 pub fn target() -> Target {
     let mut base = super::android_base::opts();
     base.features = "+v7".to_string();
-    base.has_elf_tls = false;
 
     Target {
         llvm_target: "arm-linux-androideabi".to_string(),

--- a/src/libstd/thread/scoped_tls.rs
+++ b/src/libstd/thread/scoped_tls.rs
@@ -87,32 +87,9 @@ macro_rules! scoped_thread_local {
            issue = "0")]
 #[macro_export]
 #[allow_internal_unstable]
-#[cfg(no_elf_tls)]
 macro_rules! __scoped_thread_local_inner {
     ($t:ty) => {{
-        static _KEY: $crate::thread::__ScopedKeyInner<$t> =
-            $crate::thread::__ScopedKeyInner::new();
-        fn _getit() -> &'static $crate::thread::__ScopedKeyInner<$t> { &_KEY }
-        $crate::thread::ScopedKey::new(_getit)
-    }}
-}
-
-#[doc(hidden)]
-#[unstable(feature = "thread_local_internals",
-           reason = "should not be necessary",
-           issue = "0")]
-#[macro_export]
-#[allow_internal_unstable]
-#[cfg(not(no_elf_tls))]
-macro_rules! __scoped_thread_local_inner {
-    ($t:ty) => {{
-        #[cfg_attr(not(any(windows,
-                           target_os = "android",
-                           target_os = "ios",
-                           target_os = "netbsd",
-                           target_os = "openbsd",
-                           target_arch = "aarch64")),
-                   thread_local)]
+        #[cfg_attr(target_thread_local, thread_local)]
         static _KEY: $crate::thread::__ScopedKeyInner<$t> =
             $crate::thread::__ScopedKeyInner::new();
         fn _getit() -> &'static $crate::thread::__ScopedKeyInner<$t> { &_KEY }
@@ -221,13 +198,7 @@ impl<T> ScopedKey<T> {
     }
 }
 
-#[cfg(not(any(windows,
-              target_os = "android",
-              target_os = "ios",
-              target_os = "netbsd",
-              target_os = "openbsd",
-              target_arch = "aarch64",
-              no_elf_tls)))]
+#[cfg(target_thread_local)]
 #[doc(hidden)]
 mod imp {
     use cell::Cell;
@@ -246,13 +217,7 @@ mod imp {
     }
 }
 
-#[cfg(any(windows,
-          target_os = "android",
-          target_os = "ios",
-          target_os = "netbsd",
-          target_os = "openbsd",
-          target_arch = "aarch64",
-          no_elf_tls))]
+#[cfg(not(target_thread_local))]
 #[doc(hidden)]
 mod imp {
     use cell::Cell;


### PR DESCRIPTION
#30417 replaced the `--disable-elf-tls` configure option with a `cfg(target_thread_local)` target attribute for `thread_local!`, but `scoped_thread_local!` still used the old `cfg(no_elf_tls)` option. This PR changes `scoped_thread_local!` to use `cfg(target_thread_local)` to determine whether the `#[thread_local]` attribute is available. It also removes the `--disable-elf-tls` configure option since it is no longer used.

I also re-enabled the use of `#[thread_local]` on AArch64. It was originally disabled in the PR that introduced AArch64 (#19790), but the reasons for this were not explained. `#[thread_local]` seems to work fine in my tests on AArch64, so I don't think this should be an issue.

cc @alexcrichton @akiss77
