### PR TITLE
Correct formatting use of tab instead of spaces

### DIFF
--- a/src/doc/book/error-handling.md
+++ b/src/doc/book/error-handling.md
@@ -1573,11 +1573,11 @@ fn main() {
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m)  => { m }
-	Err(e) => { panic!(e.to_string()) }
+        Err(e) => { panic!(e.to_string()) }
     };
     if matches.opt_present("h") {
         print_usage(&program, opts);
-	return;
+        return;
     }
     let data_path = args[1].clone();
     let city = args[2].clone();


### PR DESCRIPTION
I noticed the alignment was off in the error handling part of the book.  This was caused because two tabs had crept into the file.  I have changed these for spaces.
