### PR TITLE
Rustdoc - display `since` version for stable items

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -339,6 +339,14 @@ impl Item {
             _ => String::new(),
         }
     }
+
+    pub fn stable_since(&self) -> Option<&str> {
+        if let Some(ref s) = self.stability {
+            return Some(&s.since[..]);
+        }
+
+        None
+    }
 }
 
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug)]

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -498,6 +498,21 @@ em.stab p {
     opacity: 0.65;
 }
 
+span.since {
+    float: right;
+    font-weight: normal;
+    font-size: initial;
+    color: grey;
+}
+
+.variants_table {
+    width: 100%;
+}
+
+.variants_table tbody tr td:first-child {
+    width: 1%; /* make the variant name as small as possible */
+}
+
 td.summary-column {
     width: 100%;
 }


### PR DESCRIPTION
Here's some screenshots after this change:

![screen shot 2016-01-03 at 11 38 30 am](https://cloud.githubusercontent.com/assets/831192/12079661/23da4e38-b20f-11e5-8c84-ba51d7a59c3f.png)
![screen shot 2016-01-03 at 11 40 39 am](https://cloud.githubusercontent.com/assets/831192/12079663/23e00012-b20f-11e5-9f01-408cc8d43687.png)
![screen shot 2016-01-03 at 11 42 17 am](https://cloud.githubusercontent.com/assets/831192/12079662/23dfe6c2-b20f-11e5-9998-53abc643e2ef.png)

I tried to click through the `std` docs and make sure everything that can have stability attributes has it rendered but I'm probably missing some. I'd also appreciate any feedback on the css changes. I had difficulty getting the `since` labels aligning correctly for enum variants. If anyone has a better idea for that, I'd be glad to implement it.

Fixes #27607
