### PR TITLE
[MIR] Handle overloaded call expressions during HIR -> HAIR translation.

### DIFF
--- a/src/librustc_trans/trans/mir/constant.rs
+++ b/src/librustc_trans/trans/mir/constant.rs
@@ -89,8 +89,10 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
     {
         let ty = bcx.monomorphize(&constant.ty);
         match constant.literal {
-            mir::Literal::Item { def_id, kind, substs } =>
-                self.trans_item_ref(bcx, ty, kind, substs, def_id),
+            mir::Literal::Item { def_id, kind, substs } => {
+                let substs = bcx.tcx().mk_substs(bcx.monomorphize(&substs));
+                self.trans_item_ref(bcx, ty, kind, substs, def_id)
+            }
             mir::Literal::Value { ref value } => {
                 self.trans_constval(bcx, value, ty)
             }

--- a/src/test/run-pass/mir_trans_calls.rs
+++ b/src/test/run-pass/mir_trans_calls.rs
@@ -93,6 +93,19 @@ fn test8() -> isize {
     Two::two()
 }
 
+#[rustc_mir]
+fn test_fn_impl(f: &&Fn(i32, i32) -> i32, x: i32, y: i32) -> i32 {
+    // This call goes through the Fn implementation for &Fn provided in
+    // core::ops::impls. It expands to a static Fn::call() that calls the
+    // Fn::call() implemenation of the object shim underneath.
+    f(x, y)
+}
+
+#[rustc_mir]
+fn test_fn_object(f: &Fn(i32, i32) -> i32, x: i32, y: i32) -> i32 {
+    f(x, y)
+}
+
 fn main() {
     assert_eq!(test1(1, (2, 3), &[4, 5, 6]), (1, (2, 3), &[4, 5, 6][..]));
     assert_eq!(test2(98), 98);
@@ -103,4 +116,8 @@ fn main() {
     // assert_eq!(test6(&Foo, 12367), 12367);
     assert_eq!(test7(), 1);
     assert_eq!(test8(), 2);
+
+    let function_object = (&|x: i32, y: i32| { x + y }) as &Fn(i32, i32) -> i32;
+    assert_eq!(test_fn_object(function_object, 100, 1), 101);
+    assert_eq!(test_fn_impl(&function_object, 100, 2), 102);
 }


### PR DESCRIPTION
So far, calls going through `Fn::call`, `FnMut::call_mut`, or `FnOnce::call_once` have not been translated properly into MIR:
The call `f(a, b, c)` where `f: Fn(T1, T2, T3)` would end up in MIR as:

```
call `f` with arguments  `a`, `b`, `c`
```

What we really want is:

```
call `Fn::call` with arguments  `f`, `a`, `b`, `c`
```

This PR transforms these kinds of overloaded calls during `HIR -> HAIR` translation.

What's still a bit funky is that the `Fn` traits expect arguments to be tupled but due to special handling type-checking and trans, we do not actually tuple arguments and everything still checks out fine. So, after this PR we end up with MIR containing calls where function signature and arguments seemingly don't match:

```
call Fn::call(&self, args: (T1, T2, T3)) with arguments `f`, `a`, `b`, `c`
```

instead of

```
call Fn::call(&self, args: (T1, T2, T3)) with arguments `f`, (`a`, `b`, `c`)  //  <- args tupled!
```

It would be nice if the call traits could go without special handling in MIR and later on.
