### PR TITLE
Elaborate predicates on associated types' associated types (and so on)

### DIFF
--- a/src/librustc/middle/traits/mod.rs
+++ b/src/librustc/middle/traits/mod.rs
@@ -49,7 +49,7 @@ pub use self::select::SelectionContext;
 pub use self::select::SelectionCache;
 pub use self::select::{MethodMatchResult, MethodMatched, MethodAmbiguous, MethodDidNotMatch};
 pub use self::select::{MethodMatchedData}; // intentionally don't export variants
-pub use self::util::elaborate_predicates;
+pub use self::util::{elaborate_predicates, elaborate_super_predicates};
 pub use self::util::get_vtable_index_of_object_method;
 pub use self::util::trait_ref_for_builtin_bound;
 pub use self::util::predicate_for_trait_def;
@@ -416,7 +416,7 @@ pub fn normalize_param_env_or_error<'a,'tcx>(unnormalized_env: ty::ParameterEnvi
            unnormalized_env);
 
     let predicates: Vec<_> =
-        util::elaborate_predicates(tcx, unnormalized_env.caller_bounds.clone())
+        util::elaborate_super_predicates(tcx, unnormalized_env.caller_bounds.clone())
         .filter(|p| !p.is_global()) // (*)
         .collect();
 

--- a/src/librustc/middle/traits/object_safety.rs
+++ b/src/librustc/middle/traits/object_safety.rs
@@ -18,7 +18,7 @@
 //!   - not have generic type parameters
 
 use super::supertraits;
-use super::elaborate_predicates;
+use super::elaborate_super_predicates;
 
 use middle::def_id::DefId;
 use middle::subst::{self, SelfSpace, TypeSpace};
@@ -195,7 +195,7 @@ fn generics_require_sized_self<'tcx>(tcx: &ty::ctxt<'tcx>,
     let free_substs = tcx.construct_free_substs(generics,
                                                 tcx.region_maps.node_extent(ast::DUMMY_NODE_ID));
     let predicates = predicates.instantiate(tcx, &free_substs).predicates.into_vec();
-    elaborate_predicates(tcx, predicates)
+    elaborate_super_predicates(tcx, predicates)
         .any(|predicate| {
             match predicate {
                 ty::Predicate::Trait(ref trait_pred) if trait_pred.def_id() == sized_def_id => {

--- a/src/librustc/middle/ty/context.rs
+++ b/src/librustc/middle/ty/context.rs
@@ -257,6 +257,8 @@ pub struct ctxt<'tcx> {
     pub trait_defs: RefCell<DefIdMap<&'tcx ty::TraitDef<'tcx>>>,
     pub adt_defs: RefCell<DefIdMap<ty::AdtDefMaster<'tcx>>>,
 
+    pub collection_finished: RefCell<bool>, // cruft
+
     /// Maps from the def-id of an item (trait/struct/enum/fn) to its
     /// associated predicates.
     pub predicates: RefCell<DefIdMap<GenericPredicates<'tcx>>>,
@@ -485,6 +487,7 @@ impl<'tcx> ctxt<'tcx> {
         let common_types = CommonTypes::new(&arenas.type_, &interner);
 
         tls::enter(ctxt {
+            collection_finished: RefCell::new(false), // cruft
             arenas: arenas,
             interner: interner,
             substs_interner: RefCell::new(FnvHashMap()),

--- a/src/librustc/middle/ty/sty.rs
+++ b/src/librustc/middle/ty/sty.rs
@@ -438,6 +438,19 @@ impl<'tcx> ProjectionTy<'tcx> {
     pub fn sort_key(&self) -> (DefId, Name) {
         (self.trait_ref.def_id, self.item_name)
     }
+    // FIXME @reviewer: This feels weird. I have no idea if it should feel weird or not, though.
+    pub fn parent_trait_refs(&self) -> Vec<ty::TraitRef<'tcx>> {
+        let mut trait_refs = Vec::new();
+        let mut current = self.trait_ref;
+        loop {
+            trait_refs.push(current);
+            match current.self_ty().sty {
+                TyProjection(ref data) => { current = data.trait_ref },
+                _ => break
+            }
+        }
+        trait_refs
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]

--- a/src/librustc/middle/ty/util.rs
+++ b/src/librustc/middle/ty/util.rs
@@ -392,7 +392,7 @@ impl<'tcx> ty::ctxt<'tcx> {
 
         assert!(!erased_self_ty.has_escaping_regions());
 
-        traits::elaborate_predicates(self, predicates)
+        traits::elaborate_super_predicates(self, predicates)
             .filter_map(|predicate| {
                 match predicate {
                     ty::Predicate::Projection(..) |

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -109,6 +109,8 @@ pub fn collect_item_types(tcx: &ty::ctxt) {
 
     let mut visitor = CollectItemTypesVisitor{ ccx: ccx };
     ccx.tcx.map.krate().visit_all_items(&mut visitor);
+
+    *tcx.collection_finished.borrow_mut() = true;
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/test/run-pass/elaborate_self_projection_projection.rs
+++ b/src/test/run-pass/elaborate_self_projection_projection.rs
@@ -1,0 +1,39 @@
+trait D {}
+
+trait C {
+    type D;
+}
+
+trait B {
+    type C: Default;
+    fn c(&self) -> Self::C { Default::default() }
+}
+
+trait A
+    where <Self::B as B>::C: C, <<Self::B as B>::C as C>::D: D
+{
+    type B: B + Default;
+    fn b(&self) -> Self::B { Default::default() }
+}
+
+
+trait QQ: A {}
+
+
+impl D for () {}
+impl C for i8 { type D = (); }
+impl B for i16 { type C = i8; }
+impl A for i32 { type B = i16; }
+impl QQ for i32 {}
+
+fn accept_a<T: A>(a: T) {
+    let _ = a.b().c();
+}
+fn accept_qq<T: QQ>(a: T) {
+    let _ = a.b().c();
+}
+
+pub fn main() {
+    accept_a(0);
+    accept_qq(0);
+}


### PR DESCRIPTION
This elaborates predicates of the form `<<<Self as S>::A as X>::B as Y>: Z` for traits with supertrait `S` (and naturally the chain of projections can go on to the recursion limit).

I don't know if the overall way I wrote this is koscher or not, so I've not tidied up yet. I've left a few comments in the code directed at reviewers (those will of course be cleaned up).

I would have liked to tackle predicates of the form `<Self as Super>::A: X` for traits with supertraits that are subtraits (wc?) of `Super`, but after playing around with it I couldn't see how to do it.

Specifically, given the following (where `-->` is the usual implication):

```
<Self as B> --> <Self as A>
<Self as B> --> <<Self as A>::T as U>
```

I couldn't figure out how to prove `<<Self as A>::T as U>` whenever `<Self as B>`, because it looks like obligations passed into `librustc/middle/traits/select.rs` code only keep track of one notion of `Self` (so when proving `<<Self as A>::T as U>`: `<Self as A>` is known and accessible but `<Self as B>` is not accessible despite being known somewhere in the aether). I'd love for someone to tell me that I'm horribly wrong. :-D

All tests appear to be passing on my local machine, save for some `run-pass-valgrind` ones and one `run-pass` dealing with LTO, but those never passed on my machine to begin with so meh.

cc #20671 
