### PR TITLE
Clarify how Rust treats backslashes at end of line in string literals

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -208,10 +208,10 @@ A _string literal_ is a sequence of any Unicode characters enclosed within two
 which must be _escaped_ by a preceding `U+005C` character (`\`).
 
 Line-break characters are allowed in string literals. Normally they represent
-themselves (i.e. no translation), but as a special exception, when a `U+005C`
-character (`\`) occurs immediately before the newline, the `U+005C` character,
-the newline, and all whitespace at the beginning of the next line are ignored.
-Thus `a` and `b` are equal:
+themselves (i.e. no translation), but as a special exception, when an unescaped
+`U+005C` character (`\`) occurs immediately before the newline (`U+000A`), the
+`U+005C` character, the newline, and all whitespace at the beginning of the
+next line are ignored. Thus `a` and `b` are equal:
 
 ```rust
 let a = "foobar";


### PR DESCRIPTION
Rust differs in that behavior from C: In C, the newline escapes are resolved
before anything else, and in Rust this depends on whether the backslash is
escaped itself.

A difference can be observed in the following two programs:

``` c
#include <stdio.h>
int main()
{
    printf("\\
n\n");
    return 0;
}
```

``` rust
fn main() {
    println!("\\
n");
}
```

The first program prints two newlines, the second one prints a backslash, a
newline, the latin character n and a final newline.
