### PR TITLE
Remove irrelevant comment

### DIFF
--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -495,9 +495,6 @@ macro_rules! declare_special_idents_and_keywords {(
     }
 
     fn mk_fresh_ident_interner() -> IdentInterner {
-        // The indices here must correspond to the numbers in
-        // special_idents, in Keyword to_name(), and in static
-        // constants below.
         let mut init_vec = Vec::new();
         $(init_vec.push($si_str);)*
         $(init_vec.push($sk_str);)*


### PR DESCRIPTION
The fundamental problem of duplication was fixed in https://github.com/rust-lang/rust/pull/10891, but the comment was preserved. Closes https://github.com/rust-lang/rust/issues/9762.
