### PR TITLE
[wip] [need help] Improve unused mut lint to check for arguments

### DIFF
--- a/src/libcollections/btree/node.rs
+++ b/src/libcollections/btree/node.rs
@@ -407,7 +407,7 @@ impl<K, V> Node<K, V> {
             unsafe {
                 let data = match self.edges {
                     None => heap::EMPTY as *mut Node<K, V>,
-                    Some(ref mut p) => **p as *mut Node<K, V>,
+                    Some(ref p) => **p as *mut Node<K, V>,
                 };
                 slice::from_raw_parts_mut(data, len + 1)
             }

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -45,13 +45,18 @@ impl UnusedMut {
         for p in pats {
             pat_util::pat_bindings(&cx.tcx.def_map, p, |mode, id, _, path1| {
                 let name = path1.node;
-                if let hir::BindByValue(hir::MutMutable) = mode {
-                    if !name.as_str().starts_with("_") {
-                        match mutables.entry(name.0 as usize) {
-                            Vacant(entry) => { entry.insert(vec![id]); },
-                            Occupied(mut entry) => { entry.get_mut().push(id); },
+
+                match mode {
+                    hir::BindByValue(hir::MutMutable) |
+                    hir::BindByRef(hir::MutMutable) => {
+                        if !name.as_str().starts_with("_") {
+                            match mutables.entry(name.0 as usize) {
+                                Vacant(entry) => { entry.insert(vec![id]); },
+                                Occupied(mut entry) => { entry.get_mut().push(id); },
+                            }
                         }
-                    }
+                    },
+                    _ => {},
                 }
             });
         }

--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -627,9 +627,9 @@ impl<T> Clone for Sender<T> {
 impl<T> Drop for Sender<T> {
     fn drop(&mut self) {
         match *unsafe { self.inner_mut() } {
-            Flavor::Oneshot(ref mut p) => unsafe { (*p.get()).drop_chan(); },
-            Flavor::Stream(ref mut p) => unsafe { (*p.get()).drop_chan(); },
-            Flavor::Shared(ref mut p) => unsafe { (*p.get()).drop_chan(); },
+            Flavor::Oneshot(ref p) => unsafe { (*p.get()).drop_chan(); },
+            Flavor::Stream(ref p) => unsafe { (*p.get()).drop_chan(); },
+            Flavor::Shared(ref p) => unsafe { (*p.get()).drop_chan(); },
             Flavor::Sync(..) => unreachable!(),
         }
     }
@@ -979,10 +979,10 @@ impl <T> IntoIterator for Receiver<T> {
 impl<T> Drop for Receiver<T> {
     fn drop(&mut self) {
         match *unsafe { self.inner_mut() } {
-            Flavor::Oneshot(ref mut p) => unsafe { (*p.get()).drop_port(); },
-            Flavor::Stream(ref mut p) => unsafe { (*p.get()).drop_port(); },
-            Flavor::Shared(ref mut p) => unsafe { (*p.get()).drop_port(); },
-            Flavor::Sync(ref mut p) => unsafe { (*p.get()).drop_port(); },
+            Flavor::Oneshot(ref p) => unsafe { (*p.get()).drop_port(); },
+            Flavor::Stream(ref p) => unsafe { (*p.get()).drop_port(); },
+            Flavor::Shared(ref p) => unsafe { (*p.get()).drop_port(); },
+            Flavor::Sync(ref p) => unsafe { (*p.get()).drop_port(); },
         }
     }
 }

--- a/src/test/compile-fail/lint-unused-mut-ref.rs
+++ b/src/test/compile-fail/lint-unused-mut-ref.rs
@@ -1,0 +1,38 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(unused_assignments)]
+#![allow(unused_variables)]
+#![allow(dead_code)]
+#![deny(unused_mut)]
+
+fn foo(any: &mut i32) {} //~ ERROR: variable does not need to be mutable
+
+fn bar(_any: &mut i32) {}
+
+fn main() {
+    let mut x = 42;
+    foo(&mut x);
+
+    let mut something = Some(43);
+
+    match something {
+        Some(ref mut i) => {}, //~ ERROR: variable does not need to be mutable
+        None => {},
+    }
+
+    // Positive cases
+    bar(&mut x);
+
+    match something {
+        Some(ref mut _i) => {},
+        None => {},
+    }
+}

--- a/src/test/compile-fail/lint-unused-mut-ref.rs
+++ b/src/test/compile-fail/lint-unused-mut-ref.rs
@@ -16,6 +16,9 @@
 fn foo(any: &mut i32) {} //~ ERROR: variable does not need to be mutable
 
 fn bar(_any: &mut i32) {}
+fn baz(something: &mut i32) {
+    *something += 1;
+}
 
 fn main() {
     let mut x = 42;
@@ -30,9 +33,14 @@ fn main() {
 
     // Positive cases
     bar(&mut x);
+    baz(&mut x);
 
     match something {
         Some(ref mut _i) => {},
         None => {},
+    }
+
+    if let Some(ref mut i) = something {
+        *i += 1;
     }
 }


### PR DESCRIPTION
I was trying to address #30280 improving the lint.

At first I thought it'd be simple enough to check for binding by reference too.

I realised it didn't catch mutable references as arguments, so I added a simple override for that.

However, this fails to bootstrap rustc due to two errors, one in `liballoc` and one in `librand`:

```
src/liballoc/rc.rs:348:20: 348:24 error: variable does not need to be mutable, #[deny(unused_mut)] on by default
src/liballoc/rc.rs:348     pub fn get_mut(this: &mut Self) -> Option<&mut T> {
                                          ^~~~
error: aborting due to previous error
/home/emilio/projects/moz/rust/mk/target.mk:194: recipe for target 'x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-gnu/lib/stamp.alloc' failed
make: *** [x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-gnu/lib/stamp.alloc] Error 101
make: *** Waiting for unfinished jobs....
src/librand/lib.rs:189:30: 189:34 error: variable does not need to be mutable, #[deny(unused_mut)] on by default
src/librand/lib.rs:189     fn fill_bytes(&mut self, dest: &mut [u8]) {
```

Those are **not** legit failures, and I suspect the `used_mut_nodes` field is not being properly updated in those situations, or that I've misunderstood it.

I also understand that a `&mut self` reference may also be interesting even though when not modifying anything, but that's another discussion.

I'd like to get some help on this, since it's my very first contribution to rustc and I don't know where to follow.

Thanks in advance.
