### PR TITLE
Improve pretty-printing for `ConstVal` in MIR.

### DIFF
--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -496,13 +496,11 @@ pub enum ProjectionElem<'tcx, V> {
 
 /// Alias for projections as they appear in lvalues, where the base is an lvalue
 /// and the index is an operand.
-pub type LvalueProjection<'tcx> =
-    Projection<'tcx,Lvalue<'tcx>,Operand<'tcx>>;
+pub type LvalueProjection<'tcx> = Projection<'tcx, Lvalue<'tcx>, Operand<'tcx>>;
 
 /// Alias for projections as they appear in lvalues, where the base is an lvalue
 /// and the index is an operand.
-pub type LvalueElem<'tcx> =
-    ProjectionElem<'tcx,Operand<'tcx>>;
+pub type LvalueElem<'tcx> = ProjectionElem<'tcx, Operand<'tcx>>;
 
 /// Index into the list of fields found in a `VariantDef`
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, RustcEncodable, RustcDecodable)]
@@ -546,11 +544,11 @@ impl<'tcx> Debug for Lvalue<'tcx> {
 
         match *self {
             Var(id) =>
-                write!(fmt,"var{:?}", id),
+                write!(fmt, "var{:?}", id),
             Arg(id) =>
-                write!(fmt,"arg{:?}", id),
+                write!(fmt, "arg{:?}", id),
             Temp(id) =>
-                write!(fmt,"tmp{:?}", id),
+                write!(fmt, "tmp{:?}", id),
             Static(def_id) =>
                 write!(fmt, "{}", ty::tls::with(|tcx| tcx.item_path_str(def_id))),
             ReturnPointer =>

--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -15,8 +15,9 @@ use middle::ty::{self, AdtDef, ClosureSubsts, FnOutput, Region, Ty};
 use rustc_back::slice;
 use rustc_data_structures::tuple_slice::TupleSlice;
 use rustc_front::hir::InlineAsm;
-use syntax::ast::Name;
+use syntax::ast::{self, Name};
 use syntax::codemap::Span;
+use std::ascii;
 use std::borrow::{Cow, IntoCow};
 use std::fmt::{self, Debug, Formatter, Write};
 use std::{iter, u32};
@@ -844,26 +845,41 @@ impl<'tcx> Debug for Literal<'tcx> {
         use self::Literal::*;
         match *self {
             Item { def_id, .. } =>
-                write!(fmt, "{}", ty::tls::with(|tcx| tcx.item_path_str(def_id))),
-            Value { ref value } => fmt_const_val(fmt, value),
+                write!(fmt, "{}", item_path_str(def_id)),
+            Value { ref value } => {
+                try!(write!(fmt, "const "));
+                fmt_const_val(fmt, value)
+            }
         }
     }
 }
 
 /// Write a `ConstVal` in a way closer to the original source code than the `Debug` output.
-pub fn fmt_const_val<W: Write>(fmt: &mut W, const_val: &ConstVal) -> fmt::Result {
+fn fmt_const_val<W: Write>(fmt: &mut W, const_val: &ConstVal) -> fmt::Result {
     use middle::const_eval::ConstVal::*;
     match *const_val {
         Float(f) => write!(fmt, "{:?}", f),
         Int(n) => write!(fmt, "{:?}", n),
         Uint(n) => write!(fmt, "{:?}", n),
-        Str(ref s) => write!(fmt, "Str({:?})", s),
-        ByteStr(ref bytes) => write!(fmt, "ByteStr{:?}", bytes),
+        Str(ref s) => write!(fmt, "{:?}", s),
+        ByteStr(ref bytes) => {
+            let escaped: String = bytes
+                .iter()
+                .flat_map(|&ch| ascii::escape_default(ch).map(|c| c as char))
+                .collect();
+            write!(fmt, "b\"{}\"", escaped)
+        }
         Bool(b) => write!(fmt, "{:?}", b),
-        Struct(id) => write!(fmt, "Struct({:?})", id),
-        Tuple(id) => write!(fmt, "Tuple({:?})", id),
-        Function(def_id) => write!(fmt, "Function({:?})", def_id),
-        Array(id, n) => write!(fmt, "Array({:?}, {:?})", id, n),
-        Repeat(id, n) => write!(fmt, "Repeat({:?}, {:?})", id, n),
+        Function(def_id) => write!(fmt, "{}", item_path_str(def_id)),
+        Struct(node_id) | Tuple(node_id) | Array(node_id, _) | Repeat(node_id, _) =>
+            write!(fmt, "{}", node_to_string(node_id)),
     }
+}
+
+fn node_to_string(node_id: ast::NodeId) -> String {
+    ty::tls::with(|tcx| tcx.map.node_to_user_string(node_id))
+}
+
+fn item_path_str(def_id: DefId) -> String {
+    ty::tls::with(|tcx| tcx.item_path_str(def_id))
 }


### PR DESCRIPTION
- Put `const` in front of every `ConstVal`.
- Pretty-print bytestrings as they appear in Rust source.
- Pretty-print `ConstVal::{Struct, Tuple, Array, Repeat}` by pretty-printing the `ast::NodeId`. This is a temporary measure, and probably not perfect, but I'm avoiding anything more complex since I hear the const evaluator might not be AST-based in the near future.
##### consts.rs

``` rust
#![feature(rustc_attrs)]

struct Point {
    x: i32,
    y: i32,
}

#[rustc_mir(pretty = "consts.mir")]
fn consts() {
    let _float = 3.14159;
    let _non_const_int = -42;
    const INT: i32 = -42;
    let _int = INT;
    let _uint = 42u32;
    let _str = "a string";
    let _bytestr = b"a bytes\xFF\n\ttri\'\"\\ng";
    let _bool = true;
    const STRUCT: Point = Point { x: 42, y: 42 };
    let _struct = STRUCT;
    const EXTERNAL_STRUCT: std::sync::atomic::AtomicUsize = std::sync::atomic::ATOMIC_USIZE_INIT;
    let _external_struct = EXTERNAL_STRUCT;
    const TUPLE: (i32, &'static str, &'static [u8; 5]) = (1, "two", b"three");
    let _tuple = TUPLE;
    const FUNC: fn() = consts;
    let _function = FUNC;
    let _non_const_function = consts;
    const ARRAY: [&'static str; 3] = ["a", "b", "c"];
    let _array = ARRAY;
    const REPEAT: [&'static [u8; 3]; 10] = [b"foo"; 10];
    let _repeat = REPEAT;
}
```
##### consts.mir diff

``` diff
--- consts-old.mir  2016-01-05 23:23:14.163807017 -0600
+++ consts-new.mir  2016-01-05 23:04:51.121386151 -0600
@@ -1,45 +1,45 @@
 fn() -> () {
     let var0: f64; // _float
     let var1: i32; // _non_const_int
     let var2: i32; // _int
     let var3: u32; // _uint
     let var4: &str; // _str
     let var5: &[u8; 18]; // _bytestr
     let var6: bool; // _bool
     let var7: Point; // _struct
     let var8: core::sync::atomic::AtomicUsize; // _external_struct
     let var9: (i32, &str, &[u8; 5]); // _tuple
     let var10: fn(); // _function
     let var11: fn() {consts}; // _non_const_function
     let var12: [&str; 3]; // _array
     let var13: [&[u8; 3]; 10]; // _repeat
     let mut tmp0: ();

     bb0: {
-        var0 = 3.14159;
-        var1 = Neg(42);
-        var2 = -42;
-        var3 = 42;
-        var4 = Str("a string");
-        var5 = ByteStr[97, 32, 98, 121, 116, 101, 115, 255, 10, 9, 116, 114, 105, 39, 34, 92, 110, 103];
-        var6 = true;
-        var7 = Struct(51);
+        var0 = const 3.14159;
+        var1 = Neg(const 42);
+        var2 = const -42;
+        var3 = const 42;
+        var4 = const "a string";
+        var5 = const b"a bytes\xff\n\ttri\'\"\\ng";
+        var6 = const true;
+        var7 = const expr Point{x: 42, y: 42,};
         var8 = consts::EXTERNAL_STRUCT;
-        var9 = Tuple(78);
-        var10 = Function(DefId { krate: 0, node: DefIndex(7) => consts });
+        var9 = const expr (1, "two", b"three");
+        var10 = const consts;
         var11 = consts;
-        var12 = Array(105, 3);
-        var13 = Repeat(122, 10);
+        var12 = const expr ["a", "b", "c"];
+        var13 = const expr [b"foo"; 10];
         drop var8;
         drop var7;
         goto -> bb1;
     }

     bb1: {
         return;
     }

     bb2: {
         diverge;
     }
 }
```
