### PR TITLE
Implement From<[T; ..]> for (T, ..) and From<(T, ..)> for [T; ..]

### DIFF
--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -22,7 +22,7 @@
 use borrow::{Borrow, BorrowMut};
 use clone::Clone;
 use cmp::{PartialEq, Eq, PartialOrd, Ord, Ordering};
-use convert::{AsRef, AsMut};
+use convert::{AsRef, AsMut, From};
 use default::Default;
 use fmt;
 use hash::{Hash, self};
@@ -220,25 +220,43 @@ array_impls! {
     30 31 32
 }
 
-// The Default impls cannot be generated using the array_impls! macro because
+// Some impls cannot be generated using the array_impls! macro because
 // they require array literals.
 
-macro_rules! array_impl_default {
-    {$n:expr, $t:ident $($ts:ident)*} => {
+macro_rules! array_impl_variadic {
+    {$n:expr, $i:ident: $t:ident $(, $is:ident: $ts:ident)*} => {
         #[stable(since = "1.4.0", feature = "array_default")]
         impl<T> Default for [T; $n] where T: Default {
             fn default() -> [T; $n] {
                 [$t::default(), $($ts::default()),*]
             }
         }
-        array_impl_default!{($n - 1), $($ts)*}
+
+        #[unstable(feature = "array_from_tuple", reason = "recently added", issue = "0")]
+        impl<T> From<($t, $($ts),*)> for [T; $n] {
+            #[inline]
+            fn from(val: ($t, $($ts),*)) -> [T; $n] {
+                let ($i, $($is),*) = val;
+                [$i, $($is),*]
+            }
+        }
+
+        array_impl_variadic!{($n - 1), $($is: $ts),*}
     };
     {$n:expr,} => {
         #[stable(since = "1.4.0", feature = "array_default")]
         impl<T> Default for [T; $n] {
             fn default() -> [T; $n] { [] }
         }
+
+        #[unstable(feature = "array_from_tuple", reason = "recently added", issue = "0")]
+        impl<T> From<()> for [T; $n] {
+            #[inline]
+            fn from(_: ()) -> [T; $n] { [] }
+        }
     };
 }
 
-array_impl_default!{32, T T T T T T T T T T T T T T T T T T T T T T T T T T T T T T T T}
+array_impl_variadic!{32, a: T, b: T, c: T, d: T, e: T, f: T, g: T, h: T, i: T, j: T, k: T, l: T,
+                         m: T, n: T, o: T, p: T, q: T, r: T, s: T, t: T, u: T, v: T, w: T, x: T,
+                         y: T, z: T, aa: T, ab: T, ac: T, ad: T, ae: T, af: T}

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -71,6 +71,7 @@
 #![feature(reflect)]
 #![feature(unwind_attributes)]
 #![feature(repr_simd, platform_intrinsics)]
+#![feature(slice_patterns)]
 #![feature(staged_api)]
 #![feature(unboxed_closures)]
 

--- a/src/libcore/tuple.rs
+++ b/src/libcore/tuple.rs
@@ -30,6 +30,7 @@
 use clone::Clone;
 use cmp::*;
 use cmp::Ordering::*;
+use convert::From;
 use default::Default;
 use option::Option;
 use option::Option::Some;
@@ -110,6 +111,28 @@ macro_rules! tuple_impls {
             }
         )+
     }
+}
+
+// macro for implementing `From<[T; N]` on tuples
+macro_rules! tuple_impl_variadic {
+    {$n:expr, $i:ident: $t:ident $(,$is:ident: $ts:ident)*} => {
+        #[unstable(feature = "tuple_from_array", reason = "recently added", issue = "0")]
+        impl<T> From<[T; $n]> for ($t, $($ts),*) {
+            #[inline]
+            fn from([$i, $($is,)*]: [T; $n]) -> ($t, $($ts,)*) {
+                ($i, $($is,)*)
+            }
+        }
+
+        tuple_impl_variadic!{($n - 1), $($is: $ts),*}
+    };
+    {$n:expr,} => {
+        #[unstable(feature = "tuple_from_array", reason = "recently added", issue = "0")]
+        impl<T> From<[T; $n]> for () {
+            #[inline]
+            fn from(_: [T; $n]) -> () { () }
+        }
+    };
 }
 
 // Constructs an expression that performs a lexical ordering using method $rel.
@@ -248,3 +271,6 @@ tuple_impls! {
         (11) -> L
     }
 }
+
+tuple_impl_variadic! { 12, l: T, k: T, j: T, i: T, h: T, g: T,
+                           f: T, e: T, d: T, c: T, b: T, a: T }

--- a/src/libcoretest/array.rs
+++ b/src/libcoretest/array.rs
@@ -26,3 +26,14 @@ fn fixed_size_array() {
     assert_eq!(FixedSizeArray::as_mut_slice(&mut empty_array).len(), 0);
     assert_eq!(FixedSizeArray::as_mut_slice(&mut empty_zero_sized).len(), 0);
 }
+
+#[test]
+fn from_tuple() {
+    let a: [u8; 3] = From::from((1, 2, 3));
+    assert_eq!(a, [1, 2, 3]);
+
+    let a: [u16; 5] = From::from((5, 6, 7, 8, 9));
+    assert_eq!(a, [5, 6, 7, 8, 9]);
+
+    let _: [bool; 0] = From::from(());
+}

--- a/src/libcoretest/tuple.rs
+++ b/src/libcoretest/tuple.rs
@@ -66,3 +66,15 @@ fn test_show() {
     let s = format!("{:?}", (1, "hi", true));
     assert_eq!(s, "(1, \"hi\", true)");
 }
+
+#[test]
+fn test_from_array() {
+    let a: (u8, u8, u8) = From::from([1, 2, 3]);
+    assert_eq!(a, (1, 2, 3));
+
+    let a: (u16, u16, u16, u16, u16) = From::from([5, 6, 7, 8, 9]);
+    assert_eq!(a, (5, 6, 7, 8, 9));
+
+    let a: [u8; 0] = [];
+    let _: () = From::from(a);
+}


### PR DESCRIPTION
This adds:

``` rust
impl<T> From<[T; 3]> for (T, T, T) { .. }
impl<T> From<(T, T, T)> for [T; 3] { .. }
```

And same for all other arrays and tuples dimensions, up to 32 elements for tuple->array and up to 12 elements for array->tuple (similar to the other trait implementations on arrays and tuples).

~~Note that the first one requires `Clone`, because [otherwise I couldn't manage to make it compile](http://is.gd/ZN6ihO).~~ Fixed.

If the changes are good, this still needs ~~some tests and~~ an issue number.
