### PR TITLE
finish enabling -C rpath by default in rustc. See #30353.

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -149,7 +149,7 @@ endif
 ifdef TRACE
   CFG_RUSTC_FLAGS += -Z trace
 endif
-ifdef CFG_ENABLE_RPATH
+ifndef CFG_DISABLE_RPATH
 CFG_RUSTC_FLAGS += -C rpath
 endif
 


### PR DESCRIPTION
finish enabling `-C rpath` by default in rustc. See #30353.
