### PR TITLE
Fix pretty-printing for empty tuples in MIR.

### DIFF
--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -804,10 +804,10 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                     Vec => write!(fmt, "{:?}", lvs),
 
                     Tuple => {
-                        if lvs.len() == 1 {
-                            write!(fmt, "({:?},)", lvs[0])
-                        } else {
-                            fmt_tuple(fmt, "", lvs)
+                        match lvs.len() {
+                            0 => write!(fmt, "()"),
+                            1 => write!(fmt, "({:?},)", lvs[0]),
+                            _ => fmt_tuple(fmt, "", lvs),
                         }
                     }
 


### PR DESCRIPTION
r? @nikomatsakis 

(Related issue about `debug_tuple` at https://github.com/rust-lang/rfcs/issues/1448.)

``` rust
#![feature(rustc_attrs)]

#[rustc_mir(pretty = "empty_tuple.mir")]
fn main() {
    let _x = ();
}
```

``` diff
--- empty_tuple-old.mir 2016-01-06 16:04:24.206409186 -0600
+++ empty_tuple-new.mir 2016-01-06 14:26:17.324888585 -0600
@@ -1,13 +1,13 @@
 fn() -> () {
     let var0: (); // _x
     let mut tmp0: ();

     bb0: {
-        var0 = ;
+        var0 = ();
         Some(goto -> bb1);
     }

     bb1: {
         Some(return);
     }
 }
```
