### PR TITLE
Downgrade unit struct match via S(..) warnings to errors

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -133,6 +133,12 @@ declare_lint! {
     "type parameter default erroneously allowed in invalid location"
 }
 
+declare_lint! {
+    pub MATCH_OF_UNIT_VARIANT_VIA_PAREN_DOTDOT,
+    Warn,
+    "unit struct or enum variant erroneously allowed to match via path::ident(..)"
+}
+
 /// Does nothing as a lint pass, but registers some `Lint`s
 /// which are used by other parts of the compiler.
 #[derive(Copy, Clone)]
@@ -159,6 +165,7 @@ impl LintPass for HardwiredLints {
             TRIVIAL_NUMERIC_CASTS,
             PRIVATE_IN_PUBLIC,
             INVALID_TYPE_PARAM_DEFAULT,
+            MATCH_OF_UNIT_VARIANT_VIA_PAREN_DOTDOT,
             CONST_ERR
         )
     }

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -144,7 +144,8 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
                     UNUSED_UNSAFE, PATH_STATEMENTS, UNUSED_ATTRIBUTES);
 
     add_lint_group!(sess, FUTURE_INCOMPATIBLE,
-                    PRIVATE_IN_PUBLIC, INVALID_TYPE_PARAM_DEFAULT);
+                    PRIVATE_IN_PUBLIC, INVALID_TYPE_PARAM_DEFAULT,
+                    MATCH_OF_UNIT_VARIANT_VIA_PAREN_DOTDOT);
 
     // We have one lint pass defined specially
     store.register_late_pass(sess, false, box lint::GatherNodeLevels);

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -659,6 +659,12 @@ pub fn check_pat_enum<'a, 'tcx>(pcx: &pat_ctxt<'a, 'tcx>,
     let report_bad_struct_kind = |is_warning| {
         bad_struct_kind_err(tcx.sess, pat.span, path, is_warning);
         if is_warning {
+            // Boo! Too painful to attach this to the actual warning,
+            // it should go away at some point though.
+            tcx.sess.span_note_without_error(
+                pat.span,
+                "this warning will become a HARD ERROR in a future release. \
+                 See RFC 218 for details.");
             return;
         }
 
@@ -699,12 +705,6 @@ pub fn check_pat_enum<'a, 'tcx>(pcx: &pat_ctxt<'a, 'tcx>,
                 report_bad_struct_kind(is_special_case);
                 if !is_special_case {
                     return
-                } else {
-                    // Boo! Too painful to attach this to the actual warning,
-                    // it should go away at some point though.
-                    tcx.sess.span_note_without_error(pat.span,
-                        "this warning will become a HARD ERROR in a future release. \
-                        See RFC 218 for details.");
                 }
             }
             (variant.fields
@@ -718,7 +718,10 @@ pub fn check_pat_enum<'a, 'tcx>(pcx: &pat_ctxt<'a, 'tcx>,
         ty::TyStruct(struct_def, expected_substs) => {
             let variant = struct_def.struct_variant();
             if is_tuple_struct_pat && variant.kind() != ty::VariantKind::Tuple {
-                report_bad_struct_kind(false);
+                // Matching unit structs with tuple variant patterns (`UnitVariant(..)`)
+                // is allowed for backward compatibility.
+                let is_special_case = variant.kind() == ty::VariantKind::Unit;
+                report_bad_struct_kind(is_special_case);
                 return;
             }
             (variant.fields

--- a/src/test/compile-fail/empty-struct-unit-pat.rs
+++ b/src/test/compile-fail/empty-struct-unit-pat.rs
@@ -10,6 +10,8 @@
 
 // Can't use unit struct as enum pattern
 
+#![feature(rustc_attrs)]
+// remove prior feature after warning cycle and promoting warnings to errors
 #![feature(braced_empty_structs)]
 
 struct Empty1;
@@ -18,7 +20,9 @@ enum E {
     Empty2
 }
 
-fn main() {
+// remove attribute after warning cycle and promoting warnings to errors
+#[rustc_error]
+fn main() { //~ ERROR: compilation successful
     let e1 = Empty1;
     let e2 = E::Empty2;
 
@@ -27,7 +31,7 @@ fn main() {
     //     Empty1() => () // ERROR `Empty1` does not name a tuple variant or a tuple struct
     // }
     match e1 {
-        Empty1(..) => () //~ ERROR `Empty1` does not name a tuple variant or a tuple struct
+        Empty1(..) => () //~ WARN `Empty1` does not name a tuple variant or a tuple struct
     }
     // Rejected by parser as yet
     // match e2 {

--- a/src/test/compile-fail/match-pattern-field-mismatch-2.rs
+++ b/src/test/compile-fail/match-pattern-field-mismatch-2.rs
@@ -21,7 +21,6 @@ fn main() {
           color::cmyk(_, _, _, _) => { }
           color::no_color(_) => { }
           //~^ ERROR this pattern has 1 field, but the corresponding variant has no fields
-          //~^^ WARN `color::no_color` does not name a tuple variant or a tuple struct
         }
     }
 }

--- a/src/test/compile-fail/pattern-error-continue.rs
+++ b/src/test/compile-fail/pattern-error-continue.rs
@@ -26,7 +26,6 @@ fn main() {
     match A::B(1, 2) {
         A::B(_, _, _) => (), //~ ERROR this pattern has 3 fields, but
         A::D(_) => (),       //~ ERROR this pattern has 1 field, but
-        //~^ WARN `A::D` does not name a tuple variant or a tuple struct
         _ => ()
     }
     match 'c' {


### PR DESCRIPTION
Downgrade unit struct match via S(..) warnings to errors

The error signalling was introduced in #29383

It was noted as a warning-cycle-less regression in #30379

Fix #30379 
