### PR TITLE
Some minor docs improvements for TRPL

### DIFF
--- a/src/doc/book/README.md
+++ b/src/doc/book/README.md
@@ -14,7 +14,7 @@ Even then, Rust still allows precise control like a low-level language would.
 
 [rust]: https://www.rust-lang.org
 
-“The Rust Programming Language” is split into sections. This introduction
+“The Rust Programming Language” is split into chapters. This introduction
 is the first. After this:
 
 * [Getting started][gs] - Set up your computer for Rust development.

--- a/src/doc/book/closures.md
+++ b/src/doc/book/closures.md
@@ -208,7 +208,7 @@ different.
 
 Rust’s implementation of closures is a bit different than other languages. They
 are effectively syntax sugar for traits. You’ll want to make sure to have read
-the [traits chapter][traits] before this one, as well as the chapter on [trait
+the [traits][traits] section before this one, as well as the section on [trait
 objects][trait-objects].
 
 [traits]: traits.html

--- a/src/doc/book/effective-rust.md
+++ b/src/doc/book/effective-rust.md
@@ -3,6 +3,6 @@
 So you’ve learned how to write some Rust code. But there’s a difference between
 writing *any* Rust code and writing *good* Rust code.
 
-This section consists of relatively independent tutorials which show you how to
+This chapter consists of relatively independent tutorials which show you how to
 take your Rust to the next level. Common patterns and standard library features
 will be introduced. Read these sections in any order of your choosing.

--- a/src/doc/book/error-handling.md
+++ b/src/doc/book/error-handling.md
@@ -5,18 +5,18 @@ errors in a particular way. Generally speaking, error handling is divided into
 two broad categories: exceptions and return values. Rust opts for return
 values.
 
-In this chapter, we intend to provide a comprehensive treatment of how to deal
+In this section, we intend to provide a comprehensive treatment of how to deal
 with errors in Rust. More than that, we will attempt to introduce error handling
 one piece at a time so that you'll come away with a solid working knowledge of
 how everything fits together.
 
 When done naïvely, error handling in Rust can be verbose and annoying. This
-chapter will explore those stumbling blocks and demonstrate how to use the
+section will explore those stumbling blocks and demonstrate how to use the
 standard library to make error handling concise and ergonomic.
 
 # Table of Contents
 
-This chapter is very long, mostly because we start at the very beginning with
+This section is very long, mostly because we start at the very beginning with
 sum types and combinators, and try to motivate the way Rust does error handling
 incrementally. As such, programmers with experience in other expressive type
 systems may want to jump around.
@@ -636,7 +636,7 @@ Thus far, we've looked at error handling where everything was either an
 `Option` and a `Result`? Or what if you have a `Result<T, Error1>` and a
 `Result<T, Error2>`? Handling *composition of distinct error types* is the next
 challenge in front of us, and it will be the major theme throughout the rest of
-this chapter.
+this section.
 
 ## Composing `Option` and `Result`
 
@@ -648,7 +648,7 @@ Of course, in real code, things aren't always as clean. Sometimes you have a
 mix of `Option` and `Result` types. Must we resort to explicit case analysis,
 or can we continue using combinators?
 
-For now, let's revisit one of the first examples in this chapter:
+For now, let's revisit one of the first examples in this section:
 
 ```rust,should_panic
 use std::env;
@@ -1319,7 +1319,7 @@ and [`cause`](../std/error/trait.Error.html#method.cause), but the
 limitation remains: `Box<Error>` is opaque. (N.B. This isn't entirely
 true because Rust does have runtime reflection, which is useful in
 some scenarios that are [beyond the scope of this
-chapter](https://crates.io/crates/error).)
+section](https://crates.io/crates/error).)
 
 It's time to revisit our custom `CliError` type and tie everything together.
 
@@ -1486,7 +1486,7 @@ and [`fmt::Result`](../std/fmt/type.Result.html).
 
 # Case study: A program to read population data
 
-This chapter was long, and depending on your background, it might be
+This section was long, and depending on your background, it might be
 rather dense. While there is plenty of example code to go along with
 the prose, most of it was specifically designed to be pedagogical. So,
 we're going to do something new: a case study.
@@ -1512,7 +1512,7 @@ and [`rustc-serialize`](https://crates.io/crates/rustc-serialize) crates.
 
 We're not going to spend a lot of time on setting up a project with
 Cargo because it is already covered well in [the Cargo
-chapter](../book/hello-cargo.html) and [Cargo's documentation][14].
+section](../book/hello-cargo.html) and [Cargo's documentation][14].
 
 To get started from scratch, run `cargo new --bin city-pop` and make sure your
 `Cargo.toml` looks something like this:
@@ -2108,7 +2108,7 @@ handling.
 
 # The Short Story
 
-Since this chapter is long, it is useful to have a quick summary for error
+Since this section is long, it is useful to have a quick summary for error
 handling in Rust. These are some good “rules of thumb." They are emphatically
 *not* commandments. There are probably good reasons to break every one of these
 heuristics!

--- a/src/doc/book/getting-started.md
+++ b/src/doc/book/getting-started.md
@@ -1,13 +1,13 @@
 % Getting Started
 
-This first section of the book will get us going with Rust and its tooling.
+This first chapter of the book will get us going with Rust and its tooling.
 First, we’ll install Rust. Then, the classic ‘Hello World’ program. Finally,
 we’ll talk about Cargo, Rust’s build system and package manager.
 
 # Installing Rust
 
 The first step to using Rust is to install it. Generally speaking, you’ll need
-an Internet connection to run the commands in this chapter, as we’ll be
+an Internet connection to run the commands in this section, as we’ll be
 downloading Rust from the internet.
 
 We’ll be showing off a number of commands using a terminal, and those lines all

--- a/src/doc/book/guessing-game.md
+++ b/src/doc/book/guessing-game.md
@@ -7,7 +7,7 @@ prompt us to enter a guess. Upon entering our guess, it will tell us if we’re
 too low or too high. Once we guess correctly, it will congratulate us. Sounds
 good?
 
-Along the way, we’ll learn a little bit about Rust. The next section, ‘Syntax
+Along the way, we’ll learn a little bit about Rust. The next chapter, ‘Syntax
 and Semantics’, will dive deeper into each part.
 
 # Set up

--- a/src/doc/book/learn-rust.md
+++ b/src/doc/book/learn-rust.md
@@ -1,6 +1,6 @@
 % Learn Rust
 
-Welcome! This section has a few tutorials that teach you Rust through building
+Welcome! This chapter has a few tutorials that teach you Rust through building
 projects. You’ll get a high-level overview, but we’ll skim over the details.
 
 If you’d prefer a more ‘from the ground up’-style experience, check

--- a/src/doc/book/ownership.md
+++ b/src/doc/book/ownership.md
@@ -51,21 +51,21 @@ fn foo() {
 }
 ```
 
-When `v` comes into scope, a new [vector][] is created, and it allocates space
-on the heap for each of its elements. When `v` goes out of scope at the end of
-`foo()`, Rust will clean up everything related to the vector, even the
+When `v` comes into scope, a new [vector] is created, and it allocates space on
+[the heap][heap] for each of its elements. When `v` goes out of scope at the
+end of `foo()`, Rust will clean up everything related to the vector, even the
 heap-allocated memory. This happens deterministically, at the end of the scope.
 
-We'll cover [vectors][vector] in detail later in this chapter; we only use them
+We'll cover [vectors] in detail later in this chapter; we only use them
 here as an example of a type that allocates space on the heap at runtime. They
-behave like [arrays][], except their size may change by `push()`ing more
+behave like [arrays], except their size may change by `push()`ing more
 elements onto them.
 
 Vectors have a [generic type][generics] `Vec<T>`, so in this example `v` will have type
 `Vec<i32>`. We'll cover generics in detail later in this chapter.
 
 [arrays]: primitive-types.html#arrays
-[vector]: vectors.html
+[vectors]: vectors.html
 [heap]: the-stack-and-the-heap.html
 [bindings]: variable-bindings.html
 [generics]: generics.html

--- a/src/doc/book/ownership.md
+++ b/src/doc/book/ownership.md
@@ -51,15 +51,24 @@ fn foo() {
 }
 ```
 
-When `v` comes into scope, a new [`Vec<T>`][vect] is created. In this case, the
-vector also allocates space on [the heap][heap], for the three elements. When
-`v` goes out of scope at the end of `foo()`, Rust will clean up everything
-related to the vector, even the heap-allocated memory. This happens
-deterministically, at the end of the scope.
+When `v` comes into scope, a new [vector][] is created, and it allocates space
+on the heap for each of its elements. When `v` goes out of scope at the end of
+`foo()`, Rust will clean up everything related to the vector, even the
+heap-allocated memory. This happens deterministically, at the end of the scope.
 
-[vect]: ../std/vec/struct.Vec.html
+We'll cover [vectors][vector] in detail later in this chapter; we only use them
+here as an example of a type that allocates space on the heap at runtime. They
+behave like [arrays][], except their size may change by `push()`ing more
+elements onto them.
+
+Vectors have a [generic type][generics] `Vec<T>`, so in this example `v` will have type
+`Vec<i32>`. We'll cover generics in detail later in this chapter.
+
+[arrays]: primitive-types.html#arrays
+[vector]: vectors.html
 [heap]: the-stack-and-the-heap.html
 [bindings]: variable-bindings.html
+[generics]: generics.html
 
 # Move semantics
 

--- a/src/doc/book/primitive-types.md
+++ b/src/doc/book/primitive-types.md
@@ -167,8 +167,11 @@ variable binding. Slices have a defined length, can be mutable or immutable.
 ## Slicing syntax
 
 You can use a combo of `&` and `[]` to create a slice from various things. The
-`&` indicates that slices are similar to references, and the `[]`s, with a
-range, let you define the length of the slice:
+`&` indicates that slices are similar to [references][], which we will cover in
+detail later in this section. The `[]`s, with a range, let you define the
+length of the slice:
+
+[references]: references-and-borrowing.html
 
 ```rust
 let a = [0, 1, 2, 3, 4];

--- a/src/doc/book/primitive-types.md
+++ b/src/doc/book/primitive-types.md
@@ -167,7 +167,7 @@ variable binding. Slices have a defined length, can be mutable or immutable.
 ## Slicing syntax
 
 You can use a combo of `&` and `[]` to create a slice from various things. The
-`&` indicates that slices are similar to [references][], which we will cover in
+`&` indicates that slices are similar to [references], which we will cover in
 detail later in this section. The `[]`s, with a range, let you define the
 length of the slice:
 
@@ -194,7 +194,7 @@ documentation][slice].
 Rust’s `str` type is the most primitive string type. As an [unsized type][dst],
 it’s not very useful by itself, but becomes useful when placed behind a
 reference, like `&str`. We'll elaborate further when we cover
-[Strings][strings] and [references][].
+[Strings][strings] and [references].
 
 [dst]: unsized-types.html
 [strings]: strings.html

--- a/src/doc/book/primitive-types.md
+++ b/src/doc/book/primitive-types.md
@@ -192,11 +192,13 @@ documentation][slice].
 # `str`
 
 Rust’s `str` type is the most primitive string type. As an [unsized type][dst],
-it’s not very useful by itself, but becomes useful when placed behind a reference,
-like [`&str`][strings]. As such, we’ll just leave it at that.
+it’s not very useful by itself, but becomes useful when placed behind a
+reference, like `&str`. We'll elaborate further when we cover
+[Strings][strings] and [references][].
 
 [dst]: unsized-types.html
 [strings]: strings.html
+[references]: references-and-borrowing.html
 
 You can find more documentation for `str` [in the standard library
 documentation][str].

--- a/src/doc/book/syntax-and-semantics.md
+++ b/src/doc/book/syntax-and-semantics.md
@@ -1,6 +1,6 @@
 % Syntax and Semantics
 
-This section breaks Rust down into small chunks, one for each concept.
+This chapter breaks Rust down into small chunks, one for each concept.
 
 If you’d like to learn Rust from the bottom up, reading this in order is a
 great way to do that.


### PR DESCRIPTION
I'm working my way through TRPL beginning at "Syntax and Semantics" as was recommended in a previous version.

I'm expecting the chapter to incrementally build up my knowledge of the language section by section, assuming no prior Rust experience. So it was a bit of a speed-bump to encounter references and the vector type in a code example long before they had been defined and explained.

Another commit in this PR tries to make consistent what is a "chapter" of TRPL versus a "section." Just a nit-pick, but not thinking about that stuff keeps my focus on the important material.

My background: Python programmer since ~2000, with moderate exposure to C, C++, assembly, operating systems, and system architecture in university several years ago.

For your kind consideration, feel welcome to use or drop or rework any part of this.
