### PR TITLE
Display better snippet for invalid char literal

### DIFF
--- a/src/test/parse-fail/lex-bad-char-literals-1.rs
+++ b/src/test/parse-fail/lex-bad-char-literals-1.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -25,8 +25,3 @@ static s: &'static str =
     "\●" //~ ERROR: unknown character escape
 ;
 
-// THIS MUST BE LAST, since it kills the lexer
-
-static c: char =
-    '●  //~ ERROR: character literal may only contain one codepoint
-;

--- a/src/test/parse-fail/lex-bad-char-literals-2.rs
+++ b/src/test/parse-fail/lex-bad-char-literals-2.rs
@@ -1,0 +1,17 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z parse-only
+
+// This test needs to the last one appearing in this file as it kills the parser
+static c: char =
+    'nope' //~ ERROR: character literal may only contain one codepoint: 'nope'
+;
+

--- a/src/test/parse-fail/lex-bad-char-literals-3.rs
+++ b/src/test/parse-fail/lex-bad-char-literals-3.rs
@@ -1,0 +1,16 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z parse-only
+
+// This test needs to the last one appearing in this file as it kills the parser
+static c: char =
+    '●●' //~ ERROR: character literal may only contain one codepoint: '●
+;

--- a/src/test/parse-fail/lex-bad-char-literals-4.rs
+++ b/src/test/parse-fail/lex-bad-char-literals-4.rs
@@ -1,0 +1,16 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z parse-only
+//
+// This test needs to the last one appearing in this file as it kills the parser
+static c: char =
+    '●  //~ ERROR: character literal may only contain one codepoint: '●
+;

--- a/src/test/parse-fail/lex-bad-char-literals-5.rs
+++ b/src/test/parse-fail/lex-bad-char-literals-5.rs
@@ -1,0 +1,16 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z parse-only
+//
+// This test needs to the last one appearing in this file as it kills the parser
+static c: char =
+    '\x10\x10'  //~ ERROR: character literal may only contain one codepoint: '\x10
+;


### PR DESCRIPTION
This is achieved by adding the scan_back method. This method looks back
through the source_text of the StringReader until it finds the target
char, returning it's offset in the source. We use this method to find
the offset of the opening single quote, and use that offset as the start
of the error.

Given this code:

``` rust
fn main() {
    let _ = 'abcd';
}
```

The compiler would give a message like:

```
error: character literal may only contain one codepoint: ';
let _ = 'abcd';
             ^~
```

With this change, the message now displays:

```
error: character literal may only contain one codepoint: 'abcd';
let _ = 'abcd';
        ^~~~~~~
```

Fixes #30033
