### PR TITLE
libsyntax: note that `let a = (let b = something)` is invalid

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2127,12 +2127,6 @@ impl<'a> Parser<'a> {
                 }
                 hi = self.last_span.hi;
             }
-            _ if self.token.is_keyword(keywords::Let) => {
-                // Catch this syntax error here, instead of in `check_strict_keywords`, so that
-                // we can explicitly mention that let is not to be used as an expression
-                let msg = "`let` is not an expression, so it cannot be used in this way";
-                return Err(self.diagnostic().struct_span_err(self.span, &msg));
-            },
             _ => {
                 if try!(self.eat_lt()){
                     let (qself, path) =
@@ -2154,6 +2148,12 @@ impl<'a> Parser<'a> {
                 if try!(self.eat_keyword(keywords::While) ){
                     let lo = self.last_span.lo;
                     return self.parse_while_expr(None, lo, attrs);
+                }
+                if self.token.is_keyword(keywords::Let) {
+                    // Catch this syntax error here, instead of in `check_strict_keywords`, so
+                    // that we can explicitly mention that let is not to be used as an expression
+                    let msg = "`let` is not an expression, so it cannot be used in this way";
+                    self.span_err(self.span, msg);
                 }
                 if self.token.is_lifetime() {
                     let lifetime = self.get_lifetime();

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2127,6 +2127,12 @@ impl<'a> Parser<'a> {
                 }
                 hi = self.last_span.hi;
             }
+            _ if self.token.is_keyword(keywords::Let) => {
+                // Catch this syntax error here, instead of in `check_strict_keywords`, so that
+                // we can explicitly mention that let is not to be used as an expression
+                let msg = "`let` is not an expression, so it cannot be used in this way";
+                return Err(self.diagnostic().struct_span_err(self.span, &msg));
+            },
             _ => {
                 if try!(self.eat_lt()){
                     let (qself, path) =
@@ -2191,12 +2197,6 @@ impl<'a> Parser<'a> {
                         lo,
                         UnsafeBlock(ast::UserProvided),
                         attrs);
-                }
-                if try!(self.eat_keyword(keywords::Let) ) {
-                    return Err(self.span_fatal(self.span,
-                                               "`let` is not an expression, so it cannot \
-                                                be used in this way"))
-
                 }
                 if try!(self.eat_keyword(keywords::Return) ){
                     if self.token.can_begin_expr() {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2192,6 +2192,12 @@ impl<'a> Parser<'a> {
                         UnsafeBlock(ast::UserProvided),
                         attrs);
                 }
+                if try!(self.eat_keyword(keywords::Let) ) {
+                    return Err(self.span_fatal(self.span,
+                                               "`let` is not an expression, so it cannot \
+                                                be used in this way"))
+
+                }
                 if try!(self.eat_keyword(keywords::Return) ){
                     if self.token.can_begin_expr() {
                         let e = try!(self.parse_expr());

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2149,12 +2149,6 @@ impl<'a> Parser<'a> {
                     let lo = self.last_span.lo;
                     return self.parse_while_expr(None, lo, attrs);
                 }
-                if self.token.is_keyword(keywords::Let) {
-                    // Catch this syntax error here, instead of in `check_strict_keywords`, so
-                    // that we can explicitly mention that let is not to be used as an expression
-                    let msg = "`let` is not an expression, so it cannot be used in this way";
-                    self.span_err(self.span, msg);
-                }
                 if self.token.is_lifetime() {
                     let lifetime = self.get_lifetime();
                     let lo = self.span.lo;
@@ -2217,6 +2211,11 @@ impl<'a> Parser<'a> {
                         ex = ExprBreak(None);
                     }
                     hi = self.last_span.hi;
+                } else if self.token.is_keyword(keywords::Let) {
+                    // Catch this syntax error here, instead of in `check_strict_keywords`, so
+                    // that we can explicitly mention that let is not to be used as an expression
+                    let msg = "`let` is not an expression, so it cannot be used in this way";
+                    return Err(self.fatal(&msg));
                 } else if self.check(&token::ModSep) ||
                         self.token.is_ident() &&
                         !self.check_keyword(keywords::True) &&

--- a/src/test/run-fail-fulldeps/qquote.rs
+++ b/src/test/run-fail-fulldeps/qquote.rs
@@ -10,7 +10,7 @@
 
 // ignore-cross-compile
 
-// error-pattern:expected identifier, found keyword `let`
+// error-pattern:`let` is not an expression, so it cannot be used in this way
 
 #![feature(quote, rustc_private)]
 


### PR DESCRIPTION
This PR is in response to #30440.

Mention: @Manishearth, @Wafflespeanut 
