### PR TITLE
Fix MIR text output for terminators since they were wrapped in Option.

### DIFF
--- a/src/librustc_mir/pretty.rs
+++ b/src/librustc_mir/pretty.rs
@@ -39,7 +39,7 @@ fn write_basic_block<W: Write>(block: BasicBlock, mir: &Mir, w: &mut W) -> io::R
     }
 
     // Terminator at the bottom.
-    try!(writeln!(w, "{0}{0}{1:?};", INDENT, data.terminator));
+    try!(writeln!(w, "{0}{0}{1:?};", INDENT, data.terminator()));
 
     writeln!(w, "{}}}", INDENT)
 }


### PR DESCRIPTION
This just removes the `Some()` that appeared around terminators in MIR text output after https://github.com/rust-lang/rust/pull/30481 (cc @nagisa). The graphviz is already fixed.

r? @eddyb 
