### PR TITLE
Fix tests that used `// | help:` annotations

### DIFF
--- a/src/test/compile-fail/augmented-assignments-feature-gate-cross.rs
+++ b/src/test/compile-fail/augmented-assignments-feature-gate-cross.rs
@@ -21,5 +21,5 @@ fn main() {
     let mut x = Int(0);
     x += 1;
     //~^ error: overloaded augmented assignments are not stable
-    // | help: add #![feature(augmented_assignments)] to the crate root to enable
+    //~| help: add #![feature(augmented_assignments)] to the crate root to enable
 }

--- a/src/test/compile-fail/augmented-assignments-feature-gate.rs
+++ b/src/test/compile-fail/augmented-assignments-feature-gate.rs
@@ -22,5 +22,5 @@ fn main() {
     let mut x = Int(0);
     x += 1;
     //~^ error: overloaded augmented assignments are not stable
-    // | help: add #![feature(augmented_assignments)] to the crate root to enable
+    //~| help: add #![feature(augmented_assignments)] to the crate root to enable
 }

--- a/src/test/compile-fail/issue-21659-show-relevant-trait-impls-1.rs
+++ b/src/test/compile-fail/issue-21659-show-relevant-trait-impls-1.rs
@@ -33,7 +33,8 @@ fn main() {
 
     f1.foo(1usize);
     //~^ error: the trait `Foo<usize>` is not implemented for the type `Bar`
-    // | help: the following implementations were found:
-    // | help: implementation 1: `Foo<i32>`
-    // | help: implementation 2: `Foo<u8>`
+    //~| help: the following implementations were found:
+    //~| help:   <Bar as Foo<i32>>
+    //~| help:   <Bar as Foo<u8>>
+    //~| help: run `rustc --explain E0277`
 }

--- a/src/test/compile-fail/issue-21659-show-relevant-trait-impls-2.rs
+++ b/src/test/compile-fail/issue-21659-show-relevant-trait-impls-2.rs
@@ -37,10 +37,11 @@ fn main() {
 
     f1.foo(1usize);
     //~^ error: the trait `Foo<usize>` is not implemented for the type `Bar`
-    // | help: the following implementations were found:
-    // | help:   Foo<i8>
-    // | help:   Foo<i16>
-    // | help:   Foo<i32>
-    // | help:   Foo<u8>
-    // | help: and 2 others
+    //~| help: the following implementations were found:
+    //~| help:   <Bar as Foo<i8>>
+    //~| help:   <Bar as Foo<i16>>
+    //~| help:   <Bar as Foo<i32>>
+    //~| help:   <Bar as Foo<u8>>
+    //~| help: and 2 others
+    //~| help: run `rustc --explain E0277`
 }


### PR DESCRIPTION
In my PR for #21659 I accidentally used `// | help` as test annotation. This PR updates it to `//~| help`. I also found and updated 2 other tests with the same issue.
