### PR TITLE
[MIR] Fix translation of ConstVal::{Struct, Tuple}

### DIFF
--- a/src/librustc_trans/trans/mir/constant.rs
+++ b/src/librustc_trans/trans/mir/constant.rs
@@ -15,12 +15,13 @@ use middle::ty::{Ty, HasTypeFlags};
 use rustc::middle::const_eval::ConstVal;
 use rustc::mir::repr as mir;
 use trans::common::{self, Block, C_bool, C_bytes, C_floating_f64, C_integral, C_str_slice};
-use trans::consts::{self, TrueConst};
-use trans::{type_of, expr};
-
+use trans::consts;
+use trans::expr;
+use trans::type_of;
 
 use super::operand::{OperandRef, OperandValue};
 use super::MirContext;
+
 
 impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
     pub fn trans_constval(&mut self,
@@ -66,13 +67,7 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
             ConstVal::Uint(v) => C_integral(llty, v, false),
             ConstVal::Str(ref v) => C_str_slice(ccx, v.clone()),
             ConstVal::ByteStr(ref v) => consts::addr_of(ccx, C_bytes(ccx, v), 1, "byte_str"),
-            ConstVal::Struct(id) | ConstVal::Tuple(id) => {
-                let expr = bcx.tcx().map.expect_expr(id);
-                match consts::const_expr(ccx, expr, param_substs, None, TrueConst::Yes) {
-                    Ok((val, _)) => val,
-                    Err(e) => panic!("const eval failure: {}", e.description()),
-                }
-            },
+            ConstVal::Struct(id) | ConstVal::Tuple(id) |
             ConstVal::Array(id, _) | ConstVal::Repeat(id, _) => {
                 let expr = bcx.tcx().map.expect_expr(id);
                 expr::trans(bcx, expr).datum.val

--- a/src/test/run-pass/mir_constval_adts.rs
+++ b/src/test/run-pass/mir_constval_adts.rs
@@ -1,0 +1,32 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![feature(rustc_attrs)]
+
+#[derive(PartialEq, Debug)]
+struct Point {
+    _x: i32,
+    _y: i32,
+}
+const STRUCT: Point = Point { _x: 42, _y: 42 };
+const TUPLE1: (i32, i32) = (42, 42);
+const TUPLE2: (&'static str, &'static str) = ("hello","world");
+
+#[rustc_mir]
+fn mir() -> (Point, (i32, i32), (&'static str, &'static str)){
+    let struct1 = STRUCT;
+    let tuple1 = TUPLE1;
+    let tuple2 = TUPLE2;
+    (struct1, tuple1, tuple2)
+}
+
+fn main(){
+    assert_eq!(mir(), (STRUCT, TUPLE1, TUPLE2));
+}
+


### PR DESCRIPTION
Fixes #30772 

We used to have a untested special case which didn’t really work anyway, because of lacking casts. This PR removes the case in question.
