### PR TITLE
Expect all help/note messages are specified in a cfail test

### DIFF
--- a/src/test/compile-fail/changing-crates.rs
+++ b/src/test/compile-fail/changing-crates.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-msvc FIXME #31306
+
 // note that these aux-build directives must be in this order
 // aux-build:changing-crates-a1.rs
 // aux-build:changing-crates-b.rs

--- a/src/test/compile-fail/changing-crates.rs
+++ b/src/test/compile-fail/changing-crates.rs
@@ -15,6 +15,8 @@
 
 extern crate a;
 extern crate b; //~ ERROR: found possibly newer version of crate `a` which `b` depends on
-//~^ NOTE: perhaps this crate needs to be recompiled
+//~| NOTE: perhaps this crate needs to be recompiled
+//~| NOTE: crate `a` path #1:
+//~| NOTE: crate `b` path #1:
 
 fn main() {}

--- a/src/test/compile-fail/default_ty_param_conflict_cross_crate.rs
+++ b/src/test/compile-fail/default_ty_param_conflict_cross_crate.rs
@@ -26,4 +26,5 @@ fn main() {
     meh(foo);
     //~^ ERROR: mismatched types:
     //~| NOTE: conflicting type parameter defaults `bool` and `char`
+    //~| NOTE:  ...that was applied to an unconstrained type variable here
 }

--- a/src/test/compile-fail/lifetime-inference-give-expl-lifetime-param.rs
+++ b/src/test/compile-fail/lifetime-inference-give-expl-lifetime-param.rs
@@ -49,6 +49,7 @@ struct Baz<'x> {
 
 impl<'a> Baz<'a> {
     fn baz2<'b>(&self, x: &isize) -> (&'b isize, &'b isize) {
+         //~^ HELP: parameter as shown: fn baz2<'b>(&self, x: &'b isize) -> (&'a isize, &'a isize)
         // The lifetime that gets assigned to `x` seems somewhat random.
         // I have disabled this test for the time being. --pcwalton
         (self.bar, x) //~ ERROR: cannot infer

--- a/src/test/compile-fail/privacy1.rs
+++ b/src/test/compile-fail/privacy1.rs
@@ -129,12 +129,17 @@ mod foo {
         ::bar::baz::foo(); //~ ERROR: function `foo` is inaccessible
                            //~^ NOTE: module `baz` is private
         ::bar::baz::bar(); //~ ERROR: function `bar` is inaccessible
+                           //~^ NOTE: module `baz` is private
     }
 
     fn test2() {
         use bar::baz::{foo, bar};
         //~^ ERROR: function `foo` is inaccessible
-        //~^^ ERROR: function `bar` is inaccessible
+        //~| NOTE: module `baz` is private
+        //~| ERROR: function `bar` is inaccessible
+        //~| NOTE: module `baz` is private
+
+
         foo();
         bar();
     }

--- a/src/test/compile-fail/svh-change-lit.rs
+++ b/src/test/compile-fail/svh-change-lit.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-msvc FIXME #31306
+
 // note that these aux-build directives must be in this order
 // aux-build:svh-a-base.rs
 // aux-build:svh-b.rs

--- a/src/test/compile-fail/svh-change-lit.rs
+++ b/src/test/compile-fail/svh-change-lit.rs
@@ -15,7 +15,9 @@
 
 extern crate a;
 extern crate b; //~ ERROR: found possibly newer version of crate `a` which `b` depends on
-//~^ NOTE: perhaps this crate needs to be recompiled
+//~| NOTE: perhaps this crate needs to be recompiled
+//~| NOTE: crate `a` path #1:
+//~| NOTE: crate `b` path #1:
 
 fn main() {
     b::foo()

--- a/src/test/compile-fail/svh-change-significant-cfg.rs
+++ b/src/test/compile-fail/svh-change-significant-cfg.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-msvc FIXME #31306
+
 // note that these aux-build directives must be in this order
 // aux-build:svh-a-base.rs
 // aux-build:svh-b.rs

--- a/src/test/compile-fail/svh-change-significant-cfg.rs
+++ b/src/test/compile-fail/svh-change-significant-cfg.rs
@@ -15,7 +15,9 @@
 
 extern crate a;
 extern crate b; //~ ERROR: found possibly newer version of crate `a` which `b` depends on
-//~^ NOTE: perhaps this crate needs to be recompiled
+//~| NOTE: perhaps this crate needs to be recompiled
+//~| NOTE: crate `a` path #1:
+//~| NOTE: crate `b` path #1:
 
 fn main() {
     b::foo()

--- a/src/test/compile-fail/svh-change-trait-bound.rs
+++ b/src/test/compile-fail/svh-change-trait-bound.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-msvc FIXME #31306
+
 // note that these aux-build directives must be in this order
 // aux-build:svh-a-base.rs
 // aux-build:svh-b.rs

--- a/src/test/compile-fail/svh-change-trait-bound.rs
+++ b/src/test/compile-fail/svh-change-trait-bound.rs
@@ -15,7 +15,9 @@
 
 extern crate a;
 extern crate b; //~ ERROR: found possibly newer version of crate `a` which `b` depends on
-//~^ NOTE: perhaps this crate needs to be recompiled
+//~| NOTE: perhaps this crate needs to be recompiled
+//~| NOTE: crate `a` path #1:
+//~| NOTE: crate `b` path #1:
 
 fn main() {
     b::foo()

--- a/src/test/compile-fail/svh-change-type-arg.rs
+++ b/src/test/compile-fail/svh-change-type-arg.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-msvc FIXME #31306
+
 // note that these aux-build directives must be in this order
 // aux-build:svh-a-base.rs
 // aux-build:svh-b.rs

--- a/src/test/compile-fail/svh-change-type-arg.rs
+++ b/src/test/compile-fail/svh-change-type-arg.rs
@@ -15,7 +15,9 @@
 
 extern crate a;
 extern crate b; //~ ERROR: found possibly newer version of crate `a` which `b` depends on
-//~^ NOTE: perhaps this crate needs to be recompiled
+//~| NOTE: perhaps this crate needs to be recompiled
+//~| NOTE: crate `a` path #1:
+//~| NOTE: crate `b` path #1:
 
 fn main() {
     b::foo()

--- a/src/test/compile-fail/svh-change-type-ret.rs
+++ b/src/test/compile-fail/svh-change-type-ret.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-msvc FIXME #31306
+
 // note that these aux-build directives must be in this order
 // aux-build:svh-a-base.rs
 // aux-build:svh-b.rs

--- a/src/test/compile-fail/svh-change-type-ret.rs
+++ b/src/test/compile-fail/svh-change-type-ret.rs
@@ -15,7 +15,9 @@
 
 extern crate a;
 extern crate b; //~ ERROR: found possibly newer version of crate `a` which `b` depends on
-//~^ NOTE: perhaps this crate needs to be recompiled
+//~| NOTE: perhaps this crate needs to be recompiled
+//~| NOTE: crate `a` path #1:
+//~| NOTE: crate `b` path #1:
 
 fn main() {
     b::foo()

--- a/src/test/compile-fail/svh-change-type-static.rs
+++ b/src/test/compile-fail/svh-change-type-static.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-msvc FIXME #31306
+
 // note that these aux-build directives must be in this order
 // aux-build:svh-a-base.rs
 // aux-build:svh-b.rs

--- a/src/test/compile-fail/svh-change-type-static.rs
+++ b/src/test/compile-fail/svh-change-type-static.rs
@@ -15,7 +15,9 @@
 
 extern crate a;
 extern crate b; //~ ERROR: found possibly newer version of crate `a` which `b` depends on
-//~^ NOTE: perhaps this crate needs to be recompiled
+//~| NOTE: perhaps this crate needs to be recompiled
+//~| NOTE: crate `a` path #1:
+//~| NOTE: crate `b` path #1:
 
 fn main() {
     b::foo()

--- a/src/test/compile-fail/svh-use-trait.rs
+++ b/src/test/compile-fail/svh-use-trait.rs
@@ -20,7 +20,9 @@
 
 extern crate uta;
 extern crate utb; //~ ERROR: found possibly newer version of crate `uta` which `utb` depends
-//~^ NOTE: perhaps this crate needs to be recompiled
+//~| NOTE: perhaps this crate needs to be recompiled?
+//~| NOTE: crate `uta` path #1:
+//~| NOTE: crate `utb` path #1:
 
 fn main() {
     utb::foo()

--- a/src/test/compile-fail/svh-use-trait.rs
+++ b/src/test/compile-fail/svh-use-trait.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-msvc FIXME #31306
+
 // note that these aux-build directives must be in this order
 // aux-build:svh-uta-base.rs
 // aux-build:svh-utb.rs


### PR DESCRIPTION
This is a PR for #21195. It changes the way unspecified `help` and `ǹote` messages are handled in compile-fail tests as suggested by @oli-obk in the issue: if there are some `note` or `help` annotations, there must be annotations for all `help` or `note` messages of this test. Maybe it makes also sense to add an option to specify that the this test should fail if there are unspecified `help` or `note` messages.

With this change, the following tests fail:

```
[compile-fail] compile-fail/changing-crates.rs
[compile-fail] compile-fail/default_ty_param_conflict_cross_crate.rs
[compile-fail] compile-fail/lifetime-inference-give-expl-lifetime-param.rs
[compile-fail] compile-fail/privacy1.rs
[compile-fail] compile-fail/svh-change-lit.rs
[compile-fail] compile-fail/svh-change-significant-cfg.rs
[compile-fail] compile-fail/svh-change-trait-bound.rs
[compile-fail] compile-fail/svh-change-type-arg.rs
[compile-fail] compile-fail/svh-change-type-ret.rs
[compile-fail] compile-fail/svh-change-type-static.rs
[compile-fail] compile-fail/svh-use-trait.rs
```

I'll add the missing annotations if we decide to accept this change.
