### PR TITLE
Book on slices: Mention internal representation

### DIFF
--- a/src/doc/book/primitive-types.md
+++ b/src/doc/book/primitive-types.md
@@ -164,6 +164,9 @@ copying. For example, you might want to reference just one line of a file read
 into memory. By nature, a slice is not created directly, but from an existing
 variable binding. Slices have a defined length, can be mutable or immutable.
 
+Internally, slices are represented as a pointer to the beginning of the data 
+and a length.
+
 ## Slicing syntax
 
 You can use a combo of `&` and `[]` to create a slice from various things. The


### PR DESCRIPTION
When I read the book, the following sentence of the reference documentation helped me greatly to understand slices:

"Slices are a view into a block of memory represented as a pointer and a length."

In this commit, I tried to integrate the gist of that into the slice section inside of "primitive-types.md". I am not a native speaker, so feel very free to improve the wording.

r? @steveklabnik
