### PR TITLE
Fix ICE for lifetimes with semicolons

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4046,10 +4046,12 @@ impl<'a> Parser<'a> {
             let mut err = self.diagnostic().struct_span_err(self.span, &msg);
 
             let span_hi = self.span.hi;
-            let span_hi = if self.parse_ty().is_ok() {
-                self.span.hi
-            } else {
-                span_hi
+            let span_hi = match self.parse_ty() {
+                Ok(..) => self.span.hi,
+                Err(ref mut err) => {
+                    err.cancel();
+                    span_hi
+                }
             };
 
             let msg = format!("did you mean a single argument type &'a Type, \

--- a/src/test/parse-fail/lifetime-semicolon.rs
+++ b/src/test/parse-fail/lifetime-semicolon.rs
@@ -1,0 +1,19 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z parse-only
+
+struct Foo<'a, 'b> {
+    a: &'a &'b i32
+}
+
+fn foo<'a, 'b>(x: &mut Foo<'a; 'b>) {}
+//~^ ERROR expected `,` or `>` after lifetime name, found `;`
+//~^^ NOTE did you mean a single argument type &'a Type, or did you mean the comma-separated


### PR DESCRIPTION
This PR fixes an ICE due to an DiagnosticsBuilder not being canceld or emitted.

Ideally it would use `Handler::cancel`, but I did not manage to get a `&mut` reference to the diagnostics handler.
