### PR TITLE
doc: Add descriptions to links in the index

### DIFF
--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -10,12 +10,28 @@ This is an index of the documentation included with the Rust
 compiler. For more comprehensive documentation see [the
 website](https://www.rust-lang.org).
 
-[**The Rust Programming Language**](book/index.html)
+[**The Rust Programming Language**][book]. Also known as "The Book",
+The Rust Programming Language is the most comprehensive resource for
+all topics related to Rust, and is the primary official document of
+the language.
 
-[**The Rust Reference**](reference.html)
+[**The Rust Reference**][ref]. While Rust does not have a
+specification, the reference tries to describe its working in
+detail. It tends to be out of date.
 
-[**The Standard Library API Reference**](std/index.html)
+[**Standard Library API Reference**][api]. Documentation for the
+standard library.
 
-[**The Rustonomicon**](nomicon/index.html)
+[**The Rustonomicon**][nomicon]. An entire book dedicated to
+explaining how to write unsafe Rust code. It is for advanced Rust
+programmers.
 
-[**The Compiler Error Index**](error-index.html)
+[**Compiler Error Index**][err]. Extended explanations of
+the errors produced by the Rust compiler.
+
+[book]: book/index.html
+[ref]: reference.html
+[api]: std/index.html
+[nomicon]: nomicon/index.html
+[err]: error-index.html
+


### PR DESCRIPTION
These are the same descriptions as on the website.

re https://www.reddit.com/r/rust/comments/409nlo/i_just_noticed_the_docs_nightly_all_docs_got_more/cytc4ab

r? @steveklabnik 
