### PR TITLE
doc: Address issue of crates not being explained when introduced.

### DIFF
--- a/src/doc/book/crates-and-modules.md
+++ b/src/doc/book/crates-and-modules.md
@@ -2,7 +2,7 @@
 
 When a project starts getting large, it’s considered good software
 engineering practice to split it up into a bunch of smaller pieces, and then
-fit them together. It’s also important to have a well-defined interface, so
+fit them together. It is also important to have a well-defined interface, so
 that some of your functionality is private, and some is public. To facilitate
 these kinds of things, Rust has a module system.
 

--- a/src/doc/book/getting-started.md
+++ b/src/doc/book/getting-started.md
@@ -505,9 +505,11 @@ Cargo checks to see if any of your project’s files have been modified, and onl
 rebuilds your project if they’ve changed since the last time you built it.
 
 With simple projects, Cargo doesn't bring a whole lot over just using `rustc`,
-but it will become useful in future. With complex projects composed of multiple
-crates, it’s much easier to let Cargo coordinate the build. With Cargo, you can
-run `cargo build`, and it should work the right way.
+but it will become useful in future. This is especially true when you start
+using crates; these are synonymous with a ‘library’ or ‘package’ in other
+programming languages. For complex projects composed of multiple crates, it’s
+much easier to let Cargo coordinate the build. Using Cargo, you can run `cargo
+build`, and it should work the right way.
 
 ## Building for Release
 


### PR DESCRIPTION
Ref issue [30825](https://github.com/rust-lang/rust/issues/30825)

This commit should suffice to add a concise introduction to the concept of crates. 
My only worry, is that it is maybe too concise; but, the book seems to be written with the understanding that the new Rust user is coming from another language, and so will understand what a Library or Code Package is.
