### PR TITLE
Update openbsd libc

### DIFF
--- a/src/libstd/rand/os.rs
+++ b/src/libstd/rand/os.rs
@@ -222,7 +222,7 @@ mod imp {
             // getentropy(2) permits a maximum buffer size of 256 bytes
             for s in v.chunks_mut(256) {
                 let ret = unsafe {
-                    libc::syscall(libc::NR_GETENTROPY, s.as_mut_ptr(), s.len())
+                    libc::getentropy(s.as_mut_ptr() as *mut libc::c_void, s.len())
                 };
                 if ret == -1 {
                     panic!("unexpected getentropy error: {}", errno());

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -204,7 +204,8 @@ impl DirEntry {
 
     #[cfg(any(target_os = "macos",
               target_os = "ios",
-              target_os = "netbsd"))]
+              target_os = "netbsd",
+              target_os = "openbsd"))]
     fn name_bytes(&self) -> &[u8] {
         unsafe {
             ::slice::from_raw_parts(self.entry.d_name.as_ptr() as *const u8,
@@ -213,8 +214,7 @@ impl DirEntry {
     }
     #[cfg(any(target_os = "freebsd",
               target_os = "dragonfly",
-              target_os = "bitrig",
-              target_os = "openbsd"))]
+              target_os = "bitrig"))]
     fn name_bytes(&self) -> &[u8] {
         unsafe {
             ::slice::from_raw_parts(self.entry.d_name.as_ptr() as *const u8,

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -919,7 +919,6 @@ fn get_concurrency() -> usize {
     #[cfg(any(target_os = "freebsd",
               target_os = "dragonfly",
               target_os = "bitrig",
-              target_os = "openbsd",
               target_os = "netbsd"))]
     fn num_cpus() -> usize {
         let mut cpus: libc::c_uint = 0;
@@ -943,6 +942,24 @@ fn get_concurrency() -> usize {
             if cpus < 1 {
                 cpus = 1;
             }
+        }
+        cpus as usize
+    }
+
+    #[cfg(target_os = "openbsd")]
+    fn num_cpus() -> usize {
+        let mut cpus: libc::c_uint = 0;
+        let mut cpus_size = std::mem::size_of_val(&cpus);
+        let mut mib = [libc::CTL_HW, libc::HW_NCPU, 0, 0];
+
+        unsafe {
+            libc::sysctl(mib.as_mut_ptr(), 2,
+                         &mut cpus as *mut _ as *mut _,
+                         &mut cpus_size as *mut _ as *mut _,
+                         0 as *mut _, 0);
+        }
+        if cpus < 1 {
+            cpus = 1;
         }
         cpus as usize
     }


### PR DESCRIPTION
The following PR updates libc version to latest commits for correctly support openbsd.
It corrects several points in rustc to be compatible with libc changes.

r? @alexcrichton
