### PR TITLE
Fix the Debug impl of PhantomData requiring Sized on T

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1569,7 +1569,7 @@ impl Debug for () {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> Debug for PhantomData<T> {
+impl<T: ?Sized> Debug for PhantomData<T> {
     fn fmt(&self, f: &mut Formatter) -> Result {
         f.pad("PhantomData")
     }


### PR DESCRIPTION
All the trait implementations of `PhantomData` use `impl<T: ?Sized>` except for `Debug`
https://doc.rust-lang.org/nightly/std/marker/struct.PhantomData.html#implementations

This PR fixes this.
