### PR TITLE
Recognize #[thread_local] attr on extern static. Fixes #30795.

### DIFF
--- a/src/test/auxiliary/thread-local-extern-static.rs
+++ b/src/test/auxiliary/thread-local-extern-static.rs
@@ -1,0 +1,2 @@
+#[thread_local]
+pub static FOO: u32 = 3;

--- a/src/test/auxiliary/thread-local-extern-static.rs
+++ b/src/test/auxiliary/thread-local-extern-static.rs
@@ -1,2 +1,14 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(thread_local)]
+
 #[thread_local]
 pub static FOO: u32 = 3;

--- a/src/test/auxiliary/thread-local-extern-static.rs
+++ b/src/test/auxiliary/thread-local-extern-static.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 #![feature(thread_local)]
+#![crate_type = "lib"]
 
+#[no_mangle]
 #[thread_local]
 pub static FOO: u32 = 3;

--- a/src/test/auxiliary/thread-local-extern-static.rs
+++ b/src/test/auxiliary/thread-local-extern-static.rs
@@ -9,8 +9,9 @@
 // except according to those terms.
 
 #![feature(thread_local)]
+#![feature(cfg_target_thread_local)]
 #![crate_type = "lib"]
 
 #[no_mangle]
-#[thread_local]
+#[cfg_attr(target_thread_local, thread_local)]
 pub static FOO: u32 = 3;

--- a/src/test/run-pass/thread-local-extern-static.rs
+++ b/src/test/run-pass/thread-local-extern-static.rs
@@ -1,0 +1,10 @@
+extern crate thread_local_extern_static;
+
+extern {
+    #[thread_local]
+    static FOO: u32;
+}
+
+fn main() {
+    assert_eq!(FOO, 3);
+}

--- a/src/test/run-pass/thread-local-extern-static.rs
+++ b/src/test/run-pass/thread-local-extern-static.rs
@@ -1,3 +1,15 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(thread_local)]
+
 extern crate thread_local_extern_static;
 
 extern {

--- a/src/test/run-pass/thread-local-extern-static.rs
+++ b/src/test/run-pass/thread-local-extern-static.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows
 // aux-build:thread-local-extern-static.rs
 
 #![feature(thread_local)]

--- a/src/test/run-pass/thread-local-extern-static.rs
+++ b/src/test/run-pass/thread-local-extern-static.rs
@@ -11,11 +11,12 @@
 // aux-build:thread-local-extern-static.rs
 
 #![feature(thread_local)]
+#![feature(cfg_target_thread_local)]
 
 extern crate thread_local_extern_static;
 
 extern {
-    #[thread_local]
+    #[cfg_attr(target_thread_local, thread_local)]
     static FOO: u32;
 }
 

--- a/src/test/run-pass/thread-local-extern-static.rs
+++ b/src/test/run-pass/thread-local-extern-static.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// aux-build:thread-local-extern-static.rs
+
 #![feature(thread_local)]
 
 extern crate thread_local_extern_static;


### PR DESCRIPTION
This will correctly add the thread_local attribute to the external static variable `errno`:

``` rust
extern {
     #[thread_local]
     static errno: c_int;
}
```

Before this commit, the thread_local attribute is ignored. Fixes #30795.

Thanks @alexcrichton for pointing out the solution.
