### PR TITLE
Explicitly disable stack execution on linux and bsd

### DIFF
--- a/src/librustc_back/target/dragonfly_base.rs
+++ b/src/librustc_back/target/dragonfly_base.rs
@@ -24,6 +24,9 @@ pub fn opts() -> TargetOptions {
             // libraries which follow this flag.  Thus, use it before
             // specifying libraries to link to.
             "-Wl,--as-needed".to_string(),
+
+            // Always enable NX protection when it is available
+            "-Wl,-z,noexecstack".to_string(),
         ),
         position_independent_executables: true,
         archive_format: "gnu".to_string(),

--- a/src/librustc_back/target/freebsd_base.rs
+++ b/src/librustc_back/target/freebsd_base.rs
@@ -17,6 +17,19 @@ pub fn opts() -> TargetOptions {
         dynamic_linking: true,
         executables: true,
         has_rpath: true,
+        pre_link_args: vec![
+            // We want to be able to strip as much executable code as possible
+            // from the linker command line, and this flag indicates to the
+            // linker that it can avoid linking in dynamic libraries that don't
+            // actually satisfy any symbols up to that point (as with many other
+            // resolutions the linker does). This option only applies to all
+            // following libraries so we're sure to pass it as one of the first
+            // arguments.
+            "-Wl,--as-needed".to_string(),
+
+            // Always enable NX protection when it is available
+            "-Wl,-z,noexecstack".to_string(),
+        ],
         archive_format: "gnu".to_string(),
         exe_allocation_crate: super::maybe_jemalloc(),
 

--- a/src/librustc_back/target/freebsd_base.rs
+++ b/src/librustc_back/target/freebsd_base.rs
@@ -18,15 +18,6 @@ pub fn opts() -> TargetOptions {
         executables: true,
         has_rpath: true,
         pre_link_args: vec![
-            // We want to be able to strip as much executable code as possible
-            // from the linker command line, and this flag indicates to the
-            // linker that it can avoid linking in dynamic libraries that don't
-            // actually satisfy any symbols up to that point (as with many other
-            // resolutions the linker does). This option only applies to all
-            // following libraries so we're sure to pass it as one of the first
-            // arguments.
-            "-Wl,--as-needed".to_string(),
-
             // Always enable NX protection when it is available
             "-Wl,-z,noexecstack".to_string(),
         ],

--- a/src/librustc_back/target/linux_base.rs
+++ b/src/librustc_back/target/linux_base.rs
@@ -26,6 +26,9 @@ pub fn opts() -> TargetOptions {
             // following libraries so we're sure to pass it as one of the first
             // arguments.
             "-Wl,--as-needed".to_string(),
+
+            // Always enable NX protection when it is available
+            "-Wl,-z,noexecstack".to_string(),
         ],
         position_independent_executables: true,
         archive_format: "gnu".to_string(),

--- a/src/librustc_back/target/netbsd_base.rs
+++ b/src/librustc_back/target/netbsd_base.rs
@@ -24,6 +24,9 @@ pub fn opts() -> TargetOptions {
             // libraries which follow this flag.  Thus, use it before
             // specifying libraries to link to.
             "-Wl,--as-needed".to_string(),
+
+            // Always enable NX protection when it is available
+            "-Wl,-z,noexecstack".to_string(),
         ),
         position_independent_executables: true,
         archive_format: "gnu".to_string(),

--- a/src/librustc_back/target/openbsd_base.rs
+++ b/src/librustc_back/target/openbsd_base.rs
@@ -24,6 +24,9 @@ pub fn opts() -> TargetOptions {
             // libraries which follow this flag.  Thus, use it before
             // specifying libraries to link to.
             "-Wl,--as-needed".to_string(),
+
+            // Always enable NX protection when it is available
+            "-Wl,-z,noexecstack".to_string(),
         ),
         position_independent_executables: true,
         archive_format: "gnu".to_string(),


### PR DESCRIPTION
This explicitly adds an option telling the linker on these platforms to make the stack and heap non-executable (should already be the case for Windows, and likely OS X).

Without this option there is some risk of accidentally losing NX protection, as the linker will not enable NX if any of the binary's constituent objects don't contain the .note.GNU-stack header.

We're not aware of any users who would want a binary with executable stack or heap, but in future this could be made possible by passing a flag to disable the protection, which would also help document the fact to the crate's users.

Edit: older discussion of previous quickfix to add a .note.GNU-stack header to libunwind's assembly:

Short term solution for issue #30824 to ensure that object files generated from assembler contain the .note.GNU-stack header.

When this header is not present in any constituent object files, the linker refrains from making the stack NX in the final executable.

Further actions:

I'll try to get this change merged in with upstream too, and then update these instructions to just compile the fixed version.

It seems a good idea to use issue #30824 or some other issue to add a test that similar security regressions can be automatically caught in future.
