### PR TITLE
std: Expose SystemTime accessors on fs::Metadata

### DIFF
--- a/src/libstd/sys/unix/time.rs
+++ b/src/libstd/sys/unix/time.rs
@@ -146,6 +146,12 @@ mod inner {
         }
     }
 
+    impl From<libc::timeval> for SystemTime {
+        fn from(t: libc::timeval) -> SystemTime {
+            SystemTime { t: t }
+        }
+    }
+
     impl PartialEq for SystemTime {
         fn eq(&self, other: &SystemTime) -> bool {
             self.t.tv_sec == other.t.tv_sec && self.t.tv_usec == other.t.tv_usec
@@ -279,6 +285,12 @@ mod inner {
 
         pub fn sub_duration(&self, other: &Duration) -> SystemTime {
             SystemTime { t: self.t.sub_duration(other) }
+        }
+    }
+
+    impl From<libc::timespec> for SystemTime {
+        fn from(t: libc::timespec) -> SystemTime {
+            SystemTime { t: Timespec { t: t } }
         }
     }
 

--- a/src/libstd/sys/windows/ext/fs.rs
+++ b/src/libstd/sys/windows/ext/fs.rs
@@ -196,9 +196,9 @@ pub trait MetadataExt {
 #[stable(feature = "metadata_ext", since = "1.1.0")]
 impl MetadataExt for Metadata {
     fn file_attributes(&self) -> u32 { self.as_inner().attrs() }
-    fn creation_time(&self) -> u64 { self.as_inner().created() }
-    fn last_access_time(&self) -> u64 { self.as_inner().accessed() }
-    fn last_write_time(&self) -> u64 { self.as_inner().modified() }
+    fn creation_time(&self) -> u64 { self.as_inner().created_u64() }
+    fn last_access_time(&self) -> u64 { self.as_inner().accessed_u64() }
+    fn last_write_time(&self) -> u64 { self.as_inner().modified_u64() }
     fn file_size(&self) -> u64 { self.as_inner().size() }
 }
 

--- a/src/libstd/sys/windows/time.rs
+++ b/src/libstd/sys/windows/time.rs
@@ -166,6 +166,12 @@ impl fmt::Debug for SystemTime {
     }
 }
 
+impl From<c::FILETIME> for SystemTime {
+    fn from(t: c::FILETIME) -> SystemTime {
+        SystemTime { t: t }
+    }
+}
+
 fn dur2intervals(d: &Duration) -> i64 {
     d.as_secs().checked_mul(INTERVALS_PER_SEC).and_then(|i| {
         i.checked_add(d.subsec_nanos() as u64 / 100)

--- a/src/libstd/time/mod.rs
+++ b/src/libstd/time/mod.rs
@@ -16,6 +16,7 @@ use error::Error;
 use fmt;
 use ops::{Add, Sub};
 use sys::time;
+use sys_common::FromInner;
 
 #[stable(feature = "time", since = "1.3.0")]
 pub use self::duration::Duration;
@@ -224,6 +225,12 @@ impl Error for SystemTimeError {
 impl fmt::Display for SystemTimeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "second time provided was later than self")
+    }
+}
+
+impl FromInner<time::SystemTime> for SystemTime {
+    fn from_inner(time: time::SystemTime) -> SystemTime {
+        SystemTime(time)
     }
 }
 


### PR DESCRIPTION
These accessors are used to get at the last modification, last access, and
creation time of the underlying file. Currently not all platforms provide the
creation time, so that currently returns `Option`.
