### PR TITLE
resolve: Finish fixing #30159, a bug in import visibility

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -798,9 +798,6 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
                 dest_import_resolution.is_public = is_public;
                 self.add_export(module_, name, &dest_import_resolution);
             }
-        } else {
-            // FIXME #30159: This is required for backwards compatability.
-            dest_import_resolution.is_public |= is_public;
         }
 
         self.check_for_conflicts_between_imports_and_items(module_,

--- a/src/test/compile-fail/shadowed-use-visibility.rs
+++ b/src/test/compile-fail/shadowed-use-visibility.rs
@@ -17,6 +17,10 @@ mod foo {
 
 mod bar {
     use foo::bar::f as g; //~ ERROR unresolved import
+
+    use foo as f;
+    pub use foo::*;
 }
 
+use bar::f::f; //~ ERROR unresolved import
 fn main() {}


### PR DESCRIPTION
This reverts PR #30324, fixing bug #30159 in which a public a glob import makes public any preceding imports that share a name with an item in the module being glob imported from.

For example,

``` rust
pub fn f() {}
pub mod foo {
    fn f() {}
}

mod bar {
    use f;
    use f as g;
    pub use foo::*; // This makes the first import public but does not affect the second import.
}
```

This is a [breaking-change].
