### PR TITLE
MIR unified ADTs

### DIFF
--- a/src/test/run-pass/mir_adt_construction.rs
+++ b/src/test/run-pass/mir_adt_construction.rs
@@ -1,0 +1,77 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_attrs)]
+
+#[repr(C, u32)]
+enum CEnum {
+    Hello = 30,
+    World = 60
+}
+
+#[rustc_mir]
+fn test1(c: CEnum) -> i32 {
+  let c2 = CEnum::Hello;
+  match (c, c2) {
+    (CEnum::Hello, CEnum::Hello) => 42,
+    (CEnum::World, CEnum::Hello) => 0,
+    _ => 1
+  }
+}
+
+#[repr(packed)]
+#[derive(PartialEq, Debug)]
+struct Pakd {
+    a: u64,
+    b: u32,
+    c: u16,
+    d: u8,
+    e: ()
+}
+
+impl Drop for Pakd {
+    fn drop(&mut self) {}
+}
+
+#[rustc_mir]
+fn test2() -> Pakd {
+    Pakd { a: 42, b: 42, c: 42, d: 42, e: () }
+}
+
+#[derive(PartialEq, Debug)]
+struct TupleLike(u64, u32);
+
+#[rustc_mir]
+fn test3() -> TupleLike {
+    TupleLike(42, 42)
+}
+
+#[rustc_mir]
+fn test4(x: fn(u64, u32) -> TupleLike) -> (TupleLike, TupleLike) {
+    let y = TupleLike;
+    (x(42, 84), y(42, 84))
+}
+
+#[rustc_mir]
+fn test5(x: fn(u32) -> Option<u32>) -> (Option<u32>, Option<u32>) {
+    let y = Some;
+    (x(42), y(42))
+}
+
+fn main() {
+  assert_eq!(test1(CEnum::Hello), 42);
+  assert_eq!(test1(CEnum::World), 0);
+  assert_eq!(test2(), Pakd { a: 42, b: 42, c: 42, d: 42, e: () });
+  assert_eq!(test3(), TupleLike(42, 42));
+  let t4 = test4(TupleLike);
+  assert_eq!(t4.0, t4.1);
+  let t5 = test5(Some);
+  assert_eq!(t5.0, t5.1);
+}

--- a/src/test/run-pass/mir_build_match_comparisons.rs
+++ b/src/test/run-pass/mir_build_match_comparisons.rs
@@ -11,7 +11,7 @@
 #![feature(rustc_attrs)]
 
 #[rustc_mir]
-pub fn test1(x: i8) -> i32 {
+fn test1(x: i8) -> i32 {
   match x {
     1...10 => 0,
     _ => 1,
@@ -22,7 +22,7 @@ const U: Option<i8> = Some(10);
 const S: &'static str = "hello";
 
 #[rustc_mir]
-pub fn test2(x: i8) -> i32 {
+fn test2(x: i8) -> i32 {
   match Some(x) {
     U => 0,
     _ => 1,
@@ -30,12 +30,27 @@ pub fn test2(x: i8) -> i32 {
 }
 
 #[rustc_mir]
-pub fn test3(x: &'static str) -> i32 {
+fn test3(x: &'static str) -> i32 {
   match x {
     S => 0,
     _ => 1,
   }
 }
+
+enum Opt<T> {
+    Some { v: T },
+    None
+}
+
+#[rustc_mir]
+fn test4(x: u64) -> i32 {
+  let opt = Opt::Some{ v: x };
+  match opt {
+    Opt::Some { v: 10 } => 0,
+    _ => 1,
+  }
+}
+
 
 fn main() {
   assert_eq!(test1(0), 1);
@@ -52,4 +67,7 @@ fn main() {
   assert_eq!(test3("hello"), 0);
   assert_eq!(test3(""), 1);
   assert_eq!(test3("world"), 1);
+  assert_eq!(test4(10), 0);
+  assert_eq!(test4(0), 1);
+  assert_eq!(test4(20), 1);
 }


### PR DESCRIPTION
This PR changes translation of tuple-like ADTs from being calls to being proper aggregates. This change is done in hope to make code generation better. Namely, now we can avoid:
1. Call overhead;
2. Generating landingpads in presence of cleanups (we know for sure constructing ADTs can’t panic);
3. And probably much more, gaining better MIR introspectablilty.

Along with that a few serious deficiencies with translation of ADTs and switches have been fixed as well (commits 2 and 3).

r? @nikomatsakis 
cc @tsion
