### PR TITLE
std::sync::mpsc: Add fmt::Debug stubs

### DIFF
--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -635,6 +635,13 @@ impl<T> Drop for Sender<T> {
     }
 }
 
+#[stable(feature = "mpsc_debug", since = "1.7.0")]
+impl<T> fmt::Debug for Sender<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Sender {{ .. }}")
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // SyncSender
 ////////////////////////////////////////////////////////////////////////////////
@@ -690,6 +697,13 @@ impl<T> Clone for SyncSender<T> {
 impl<T> Drop for SyncSender<T> {
     fn drop(&mut self) {
         unsafe { (*self.inner.get()).drop_chan(); }
+    }
+}
+
+#[stable(feature = "mpsc_debug", since = "1.7.0")]
+impl<T> fmt::Debug for SyncSender<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "SyncSender {{ .. }}")
     }
 }
 
@@ -984,6 +998,13 @@ impl<T> Drop for Receiver<T> {
             Flavor::Shared(ref mut p) => unsafe { (*p.get()).drop_port(); },
             Flavor::Sync(ref mut p) => unsafe { (*p.get()).drop_port(); },
         }
+    }
+}
+
+#[stable(feature = "mpsc_debug", since = "1.7.0")]
+impl<T> fmt::Debug for Receiver<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Receiver {{ .. }}")
     }
 }
 
@@ -2198,5 +2219,23 @@ mod sync_tests {
         for _ in 0..100 {
             repro()
         }
+    }
+
+    #[test]
+    fn fmt_debug_sender() {
+        let (tx, _) = channel::<i32>();
+        assert_eq!(format!("{:?}", tx), "Sender { .. }");
+    }
+
+    #[test]
+    fn fmt_debug_recv() {
+        let (_, rx) = channel::<i32>();
+        assert_eq!(format!("{:?}", rx), "Receiver { .. }");
+    }
+
+    #[test]
+    fn fmt_debug_sync_sender() {
+        let (tx, _) = sync_channel::<i32>(1);
+        assert_eq!(format!("{:?}", tx), "SyncSender { .. }");
     }
 }

--- a/src/libstd/sync/mpsc/select.rs
+++ b/src/libstd/sync/mpsc/select.rs
@@ -58,6 +58,8 @@
             issue = "27800")]
 
 
+use fmt;
+
 use core::cell::{Cell, UnsafeCell};
 use core::marker;
 use core::ptr;
@@ -347,6 +349,20 @@ impl Iterator for Packets {
             unsafe { self.cur = (*self.cur).next; }
             ret
         }
+    }
+}
+
+#[stable(feature = "mpsc_debug", since = "1.7.0")]
+impl fmt::Debug for Select {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Select {{ .. }}")
+    }
+}
+
+#[stable(feature = "mpsc_debug", since = "1.7.0")]
+impl<'rx, T:Send+'rx> fmt::Debug for Handle<'rx, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Handle {{ .. }}")
     }
 }
 
@@ -761,5 +777,19 @@ mod tests {
                 assert_eq!(rx1.recv().unwrap(), 1);
             }
         }
+    }
+
+    #[test]
+    fn fmt_debug_select() {
+        let sel = Select::new();
+        assert_eq!(format!("{:?}", sel), "Select { .. }");
+    }
+
+    #[test]
+    fn fmt_debug_handle() {
+        let (_, rx) = channel::<i32>();
+        let sel = Select::new();
+        let mut handle = sel.handle(&rx);
+        assert_eq!(format!("{:?}", handle), "Handle { .. }");
     }
 }


### PR DESCRIPTION
Minimal fix for https://github.com/rust-lang/rust/issues/30563

This covers all the public structs I think; except for Iter and
IntoIter, which I don't know if or how they should be handled.
