### PR TITLE
Fix note about B-prefixed issue labels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,7 +174,7 @@ labels to triage issues:
 * Yellow, **A**-prefixed labels state which **area** of the project an issue
   relates to.
 
-* Magenta, **B**-prefixed labels identify bugs which **belong** elsewhere.
+* Magenta, **B**-prefixed labels identify bugs which are **blockers**.
 
 * Green, **E**-prefixed labels explain the level of **experience** necessary
   to fix the issue.


### PR DESCRIPTION
'B' labels are for blockers, not issues which belong elsewhere.

Prompted by this comment on Reddit:
https://www.reddit.com/r/rust/comments/40nzkd/contributing_to_the_rust_compiler_a_short_guide/cyxcjtd
