### PR TITLE
Preserve struct/variant kinds in metadata

### DIFF
--- a/src/librustc/middle/ty/mod.rs
+++ b/src/librustc/middle/ty/mod.rs
@@ -49,7 +49,7 @@ use std::collections::{HashMap, HashSet};
 use syntax::ast::{self, CrateNum, Name, NodeId};
 use syntax::attr::{self, AttrMetaMethods};
 use syntax::codemap::{DUMMY_SP, Span};
-use syntax::parse::token::{InternedString, special_idents};
+use syntax::parse::token::InternedString;
 
 use rustc_front::hir;
 use rustc_front::hir::{ItemImpl, ItemTrait};
@@ -1353,6 +1353,7 @@ pub struct VariantDefData<'tcx, 'container: 'tcx> {
     pub name: Name, // struct's name if this is a struct
     pub disr_val: Disr,
     pub fields: Vec<FieldDefData<'tcx, 'container>>,
+    pub kind: VariantKind,
 }
 
 pub struct FieldDefData<'tcx, 'container: 'tcx> {
@@ -1607,13 +1608,7 @@ impl<'tcx, 'container> VariantDefData<'tcx, 'container> {
     }
 
     pub fn kind(&self) -> VariantKind {
-        match self.fields.get(0) {
-            None => VariantKind::Unit,
-            Some(&FieldDefData { name, .. }) if name == special_idents::unnamed_field.name => {
-                VariantKind::Tuple
-            }
-            Some(_) => VariantKind::Struct
-        }
+        self.kind
     }
 
     pub fn is_tuple_struct(&self) -> bool {

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -285,8 +285,9 @@ fn encode_enum_variant_info<'a, 'tcx>(ecx: &EncodeContext<'a, 'tcx>,
         rbml_w.start_tag(tag_items_data_item);
         encode_def_id_and_key(ecx, rbml_w, vid);
         encode_family(rbml_w, match variant.kind() {
-            ty::VariantKind::Unit | ty::VariantKind::Tuple => 'v',
-            ty::VariantKind::Struct => 'V'
+            ty::VariantKind::Struct => 'V',
+            ty::VariantKind::Tuple => 'v',
+            ty::VariantKind::Unit => 'w',
         });
         encode_name(rbml_w, variant.name);
         encode_parent_item(rbml_w, ecx.tcx.map.local_def_id(id));
@@ -1043,7 +1044,11 @@ fn encode_info_for_item<'a, 'tcx>(ecx: &EncodeContext<'a, 'tcx>,
         /* Now, make an item for the class itself */
         rbml_w.start_tag(tag_items_data_item);
         encode_def_id_and_key(ecx, rbml_w, def_id);
-        encode_family(rbml_w, 'S');
+        encode_family(rbml_w, match *struct_def {
+            hir::VariantData::Struct(..) => 'S',
+            hir::VariantData::Tuple(..) => 's',
+            hir::VariantData::Unit(..) => 'u',
+        });
         encode_bounds_and_type_for_item(rbml_w, ecx, index, item.id);
 
         encode_item_variances(rbml_w, ecx, item.id);

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1006,7 +1006,12 @@ fn convert_struct_variant<'tcx>(tcx: &ty::ctxt<'tcx>,
         did: did,
         name: name,
         disr_val: disr_val,
-        fields: fields
+        fields: fields,
+        kind: match *def {
+            hir::VariantData::Struct(..) => ty::VariantKind::Struct,
+            hir::VariantData::Tuple(..) => ty::VariantKind::Tuple,
+            hir::VariantData::Unit(..) => ty::VariantKind::Unit,
+        }
     }
 }
 

--- a/src/test/auxiliary/empty-struct.rs
+++ b/src/test/auxiliary/empty-struct.rs
@@ -8,24 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Can't use unit struct as constructor function
-
-// aux-build:empty-struct.rs
-
 #![feature(braced_empty_structs)]
 
-extern crate empty_struct;
-use empty_struct::*;
+pub struct XEmpty1 {}
+pub struct XEmpty2;
 
-struct Empty2;
-
-enum E {
-    Empty4
-}
-
-fn main() {
-    let e2 = Empty2(); //~ ERROR expected function, found `Empty2`
-    let e4 = E::Empty4(); //~ ERROR expected function, found `E`
-    let xe2 = XEmpty2(); //~ ERROR expected function, found `empty_struct::XEmpty2`
-    let xe4 = XE::XEmpty4(); //~ ERROR  expected function, found `empty_struct::XE`
+pub enum XE {
+    XEmpty3 {},
+    XEmpty4,
 }

--- a/src/test/compile-fail/empty-struct-braces-expr.rs
+++ b/src/test/compile-fail/empty-struct-braces-expr.rs
@@ -10,17 +10,28 @@
 
 // Can't use empty braced struct as constant or constructor function
 
+// aux-build:empty-struct.rs
+
 #![feature(braced_empty_structs)]
+
+extern crate empty_struct;
+use empty_struct::*;
 
 struct Empty1 {}
 
 enum E {
-    Empty2 {}
+    Empty3 {}
 }
 
 fn main() {
     let e1 = Empty1; //~ ERROR `Empty1` is the name of a struct or struct variant
     let e1 = Empty1(); //~ ERROR `Empty1` is the name of a struct or struct variant
-    let e2 = E::Empty2; //~ ERROR `E::Empty2` is the name of a struct or struct variant
-    let e2 = E::Empty2(); //~ ERROR `E::Empty2` is the name of a struct or struct variant
+    let e3 = E::Empty3; //~ ERROR `E::Empty3` is the name of a struct or struct variant
+    let e3 = E::Empty3(); //~ ERROR `E::Empty3` is the name of a struct or struct variant
+
+    // FIXME: non-local struct kind should be known early (e.g. kept in `DefStruct`)
+    // let xe1 = XEmpty1; // ERROR `XEmpty1` is the name of a struct or struct variant
+    let xe1 = XEmpty1(); //~ ERROR expected function, found `empty_struct::XEmpty1`
+    let xe3 = XE::Empty3; //~ ERROR no associated item named `Empty3` found for type
+    let xe3 = XE::Empty3(); //~ ERROR no associated item named `Empty3` found for type
 }

--- a/src/test/compile-fail/empty-struct-braces-pat-1.rs
+++ b/src/test/compile-fail/empty-struct-braces-pat-1.rs
@@ -10,22 +10,35 @@
 
 // Can't use empty braced struct as constant pattern
 
+// aux-build:empty-struct.rs
+
 #![feature(braced_empty_structs)]
+
+extern crate empty_struct;
+use empty_struct::*;
 
 struct Empty1 {}
 
 enum E {
-    Empty2 {}
+    Empty3 {}
 }
 
 fn main() {
     let e1 = Empty1 {};
-    let e2 = E::Empty2 {};
+    let e3 = E::Empty3 {};
+    let xe1 = XEmpty1 {};
+    let xe3 = XE::XEmpty3 {};
 
     match e1 {
         Empty1 => () // Not an error, `Empty1` is interpreted as a new binding
     }
-    match e2 {
-        E::Empty2 => () //~ ERROR `E::Empty2` does not name a tuple variant or a tuple struct
+    match e3 {
+        E::Empty3 => () //~ ERROR `E::Empty3` does not name a tuple variant or a tuple struct
+    }
+    match xe1 {
+        XEmpty1 => () // Not an error, `XEmpty1` is interpreted as a new binding
+    }
+    match xe3 {
+        XE::XEmpty3 => () //~ ERROR no associated item named `XEmpty3` found for type
     }
 }

--- a/src/test/compile-fail/empty-struct-braces-pat-2.rs
+++ b/src/test/compile-fail/empty-struct-braces-pat-2.rs
@@ -10,18 +10,30 @@
 
 // Can't use empty braced struct as enum pattern
 
+// aux-build:empty-struct.rs
+
 #![feature(braced_empty_structs)]
+
+extern crate empty_struct;
+use empty_struct::*;
 
 struct Empty1 {}
 
 fn main() {
     let e1 = Empty1 {};
+    let xe1 = XEmpty1 {};
 
     // Rejected by parser as yet
     // match e1 {
     //     Empty1() => () // ERROR unresolved enum variant, struct or const `Empty1`
     // }
+    // match xe1 {
+    //     XEmpty1() => () // ERROR unresolved enum variant, struct or const `XEmpty1`
+    // }
     match e1 {
         Empty1(..) => () //~ ERROR unresolved enum variant, struct or const `Empty1`
+    }
+    match xe1 {
+        XEmpty1(..) => () //~ ERROR `XEmpty1` does not name a tuple variant or a tuple struct
     }
 }

--- a/src/test/compile-fail/empty-struct-braces-pat-3.rs
+++ b/src/test/compile-fail/empty-struct-braces-pat-3.rs
@@ -10,20 +10,32 @@
 
 // Can't use empty braced struct as enum pattern
 
+// aux-build:empty-struct.rs
+
 #![feature(braced_empty_structs)]
 
+extern crate empty_struct;
+use empty_struct::*;
+
 enum E {
-    Empty2 {}
+    Empty3 {}
 }
 
 fn main() {
-    let e2 = E::Empty2 {};
+    let e3 = E::Empty3 {};
+    let xe3 = XE::XEmpty3 {};
 
     // Rejected by parser as yet
-    // match e2 {
-    //     E::Empty2() => () // ERROR `E::Empty2` does not name a tuple variant or a tuple struct
+    // match e3 {
+    //     E::Empty3() => () // ERROR `E::Empty3` does not name a tuple variant or a tuple struct
     // }
-    match e2 {
-        E::Empty2(..) => () //~ ERROR `E::Empty2` does not name a tuple variant or a tuple struct
+    // match xe3 {
+    //     E::Empty3() => () // ERROR `XE::XEmpty3` does not name a tuple variant or a tuple struct
+    // }
+    match e3 {
+        E::Empty3(..) => () //~ ERROR `E::Empty3` does not name a tuple variant or a tuple struct
+    }
+    match xe3 {
+        XE::XEmpty3(..) => () //~ ERROR no associated item named `XEmpty3` found for type
     }
 }

--- a/src/test/compile-fail/empty-struct-unit-pat.rs
+++ b/src/test/compile-fail/empty-struct-unit-pat.rs
@@ -10,36 +10,59 @@
 
 // Can't use unit struct as enum pattern
 
+// aux-build:empty-struct.rs
+
 #![feature(rustc_attrs)]
 // remove prior feature after warning cycle and promoting warnings to errors
 #![feature(braced_empty_structs)]
 
-struct Empty1;
+extern crate empty_struct;
+use empty_struct::*;
+
+struct Empty2;
 
 enum E {
-    Empty2
+    Empty4
 }
 
 // remove attribute after warning cycle and promoting warnings to errors
 #[rustc_error]
 fn main() { //~ ERROR: compilation successful
-    let e1 = Empty1;
-    let e2 = E::Empty2;
+    let e2 = Empty2;
+    let e4 = E::Empty4;
+    let xe2 = XEmpty2;
+    let xe4 = XE::XEmpty4;
 
     // Rejected by parser as yet
-    // match e1 {
-    //     Empty1() => () // ERROR `Empty1` does not name a tuple variant or a tuple struct
+    // match e2 {
+    //     Empty2() => () // ERROR `Empty2` does not name a tuple variant or a tuple struct
     // }
-    match e1 {
-        Empty1(..) => () //~ WARN `Empty1` does not name a tuple variant or a tuple struct
+    // match xe2 {
+    //     XEmpty2() => () // ERROR `XEmpty2` does not name a tuple variant or a tuple struct
+    // }
+    match e2 {
+        Empty2(..) => () //~ WARN `Empty2` does not name a tuple variant or a tuple struct
+            //~^ WARN hard error
+    }
+    match xe2 {
+        XEmpty2(..) => () //~ WARN `XEmpty2` does not name a tuple variant or a tuple struct
             //~^ WARN hard error
     }
     // Rejected by parser as yet
-    // match e2 {
-    //     E::Empty2() => () // ERROR `E::Empty2` does not name a tuple variant or a tuple struct
+    // match e4 {
+    //     E::Empty4() => () // ERROR `E::Empty4` does not name a tuple variant or a tuple struct
     // }
-    match e2 {
-        E::Empty2(..) => () //~ WARN `E::Empty2` does not name a tuple variant or a tuple struct
+    // match xe4 {
+    //     XE::XEmpty4() => (), // ERROR `XE::XEmpty4` does not name a tuple variant or a tuple
+    //     _ => {},
+    // }
+    match e4 {
+        E::Empty4(..) => () //~ WARN `E::Empty4` does not name a tuple variant or a tuple struct
             //~^ WARN hard error
+    }
+    match xe4 {
+        XE::XEmpty4(..) => (), //~ WARN `XE::XEmpty4` does not name a tuple variant or a tuple
+            //~^ WARN hard error
+        _ => {},
     }
 }

--- a/src/test/run-pass/empty-struct-braces.rs
+++ b/src/test/run-pass/empty-struct-braces.rs
@@ -11,7 +11,12 @@
 // Empty struct defined with braces add names into type namespace
 // Empty struct defined without braces add names into both type and value namespaces
 
+// aux-build:empty-struct.rs
+
 #![feature(braced_empty_structs)]
+
+extern crate empty_struct;
+use empty_struct::*;
 
 struct Empty1 {}
 struct Empty2;
@@ -23,7 +28,7 @@ enum E {
     Empty5,
 }
 
-fn main() {
+fn local() {
     let e1: Empty1 = Empty1 {};
     let e2: Empty2 = Empty2 {};
     let e2: Empty2 = Empty2;
@@ -83,4 +88,60 @@ fn main() {
     let e11: Empty1 = Empty1 { ..e1 };
     let e22: Empty2 = Empty2 { ..e2 };
     let e33: Empty3 = Empty3 { ..e3 };
+}
+
+fn xcrate() {
+    let e1: XEmpty1 = XEmpty1 {};
+    let e2: XEmpty2 = XEmpty2 {};
+    let e2: XEmpty2 = XEmpty2;
+    let e3: XE = XE::XEmpty3 {};
+    // FIXME: Commented out tests are waiting for PR 30882 (fixes for variant namespaces)
+    // let e4: XE = XE::XEmpty4 {};
+    let e4: XE = XE::XEmpty4;
+
+    match e1 {
+        XEmpty1 {} => {}
+    }
+    match e2 {
+        XEmpty2 {} => {}
+    }
+    match e3 {
+        XE::XEmpty3 {} => {}
+        _ => {}
+    }
+    // match e4 {
+    //     XE::XEmpty4 {} => {}
+    //     _ => {}
+    // }
+
+    match e1 {
+        XEmpty1 { .. } => {}
+    }
+    match e2 {
+        XEmpty2 { .. } => {}
+    }
+    match e3 {
+        XE::XEmpty3 { .. } => {}
+        _ => {}
+    }
+    // match e4 {
+    //     XE::XEmpty4 { .. } => {}
+    //     _ => {}
+    // }
+
+    match e2 {
+        XEmpty2 => {}
+    }
+    // match e4 {
+    //     XE::XEmpty4 => {}
+    //     _ => {}
+    // }
+
+    let e11: XEmpty1 = XEmpty1 { ..e1 };
+    let e22: XEmpty2 = XEmpty2 { ..e2 };
+}
+
+fn main() {
+    local();
+    xcrate();
 }


### PR DESCRIPTION
Also add tests for use of empty structs in cross-crate scenarios

Some tests are commented out, they depend on fixes from  https://github.com/rust-lang/rust/pull/30882
