### PR TITLE
doc: "x" is used as variable name on this API, so avoid using it here

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -227,7 +227,7 @@ impl<T> Box<T> {
     /// # Examples
     ///
     /// ```
-    /// let x = Box::new(5);
+    /// let five = Box::new(5);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline(always)]


### PR DESCRIPTION
For a moment, I got confused by thinking the summary was referring to the same `x`
