### PR TITLE
doc: this is more easy to read, and less prone mis-interpretation

### DIFF
--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -130,7 +130,7 @@ pub fn size_of<T>() -> usize {
     unsafe { intrinsics::size_of::<T>() }
 }
 
-/// Returns the size of the type that `val` points to in bytes.
+/// Returns the size of the given value in bytes.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
This function returns the size on the stack, not that of the value
that may be allocated on the heap.
