### PR TITLE
Do not ignore the test on MSVC

### DIFF
--- a/src/test/run-pass/variadic-ffi.rs
+++ b/src/test/run-pass/variadic-ffi.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-msvc -- sprintf isn't a symbol in msvcrt? maybe a #define?
-
 #![feature(libc, std_misc)]
 
 extern crate libc;
@@ -17,8 +15,9 @@ extern crate libc;
 use std::ffi::{CStr, CString};
 use libc::{c_char, c_int};
 
-
+#[cfg_attr(windows, link(name = "user32"))]
 extern {
+    #[cfg_attr(windows, link_name="wsprintfA")]
     fn sprintf(s: *mut c_char, format: *const c_char, ...) -> c_int;
 }
 


### PR DESCRIPTION
The `sprintf` is indeed not a proper function in VS 2015, but there’s a equivalent [`wsprintfA`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms647550%28v=vs.85%29.aspx) function in the user32, which can be used.

I’m primarily submitting this PR to see what happens on the 64bit MSVC buildbot, so I have less things to check once I summon a Windows machine for failures on https://github.com/rust-lang/rust/pull/30845. If this PR fails to land, then we possibly mistranslate variadic functions for MSVC target. If this PR passes, I can be sure the issue there is restricted to MIR translator and reduce my debugging workload considerably.

r? @alexcrichton 
