### PR TITLE
Implement Any for unsized types

### DIFF
--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -99,7 +99,7 @@ pub trait Any: Reflect + 'static {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Reflect + 'static> Any for T {
+impl<T: Reflect + 'static + ?Sized > Any for T {
     fn get_type_id(&self) -> TypeId { TypeId::of::<T>() }
 }
 

--- a/src/libcoretest/any.rs
+++ b/src/libcoretest/any.rs
@@ -119,6 +119,11 @@ fn any_fixed_vec() {
     assert!(!test.is::<[usize; 10]>());
 }
 
+#[test]
+fn any_unsized() {
+    fn is_any<T: Any + ?Sized>() {}
+    is_any::<[i32]>();
+}
 
 #[bench]
 fn bench_downcast_ref(b: &mut Bencher) {


### PR DESCRIPTION
This is a bit weird since unsized types can't be used in trait objects,
but Any is _also_ used as pure marker trait since Reflect isn't stable.
There are many cases (e.g. TypeMap) where all you need is a TypeId.

r? @aturon
