### PR TITLE
use a newtype for the variant discriminant in trans instead of u64

### DIFF
--- a/src/librustc_trans/trans/build.rs
+++ b/src/librustc_trans/trans/build.rs
@@ -21,6 +21,7 @@ use syntax::codemap::Span;
 use trans::builder::Builder;
 use trans::type_::Type;
 use trans::debuginfo::DebugLoc;
+use trans::Disr;
 
 use libc::{c_uint, c_char};
 
@@ -577,8 +578,8 @@ pub fn AtomicLoad(cx: Block, pointer_val: ValueRef, order: AtomicOrdering) -> Va
 }
 
 
-pub fn LoadRangeAssert(cx: Block, pointer_val: ValueRef, lo: u64,
-                       hi: u64, signed: llvm::Bool) -> ValueRef {
+pub fn LoadRangeAssert(cx: Block, pointer_val: ValueRef, lo: Disr,
+                       hi: Disr, signed: llvm::Bool) -> ValueRef {
     if cx.unreachable.get() {
         let ccx = cx.fcx.ccx;
         let ty = val_ty(pointer_val);
@@ -591,7 +592,7 @@ pub fn LoadRangeAssert(cx: Block, pointer_val: ValueRef, lo: u64,
             llvm::LLVMGetUndef(eltty.to_ref())
         }
     } else {
-        B(cx).load_range_assert(pointer_val, lo, hi, signed)
+        B(cx).load_range_assert(pointer_val, lo.0, hi.0, signed)
     }
 }
 

--- a/src/librustc_trans/trans/callee.rs
+++ b/src/librustc_trans/trans/callee.rs
@@ -50,6 +50,7 @@ use trans::meth;
 use trans::monomorphize;
 use trans::type_::Type;
 use trans::type_of;
+use trans::Disr;
 use middle::ty::{self, Ty, TypeFoldable};
 use middle::ty::MethodCall;
 use rustc_front::hir;
@@ -68,7 +69,7 @@ pub struct MethodData {
 pub enum CalleeData<'tcx> {
     // Constructor for enum variant/tuple-like-struct
     // i.e. Some, Ok
-    NamedTupleConstructor(ty::Disr),
+    NamedTupleConstructor(Disr),
 
     // Represents a (possibly monomorphized) top-level fn item or method
     // item. Note that this is just the fn-ptr and is not a Rust closure
@@ -151,7 +152,7 @@ fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, expr: &hir::Expr)
             } => {
                 Callee {
                     bcx: bcx,
-                    data: NamedTupleConstructor(0),
+                    data: NamedTupleConstructor(Disr(0)),
                     ty: expr_ty
                 }
             }
@@ -195,14 +196,14 @@ fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, expr: &hir::Expr)
 
                 Callee {
                     bcx: bcx,
-                    data: NamedTupleConstructor(vinfo.disr_val),
+                    data: NamedTupleConstructor(Disr::from(vinfo.disr_val)),
                     ty: expr_ty
                 }
             }
             def::DefStruct(_) => {
                 Callee {
                     bcx: bcx,
-                    data: NamedTupleConstructor(0),
+                    data: NamedTupleConstructor(Disr(0)),
                     ty: expr_ty
                 }
             }
@@ -863,7 +864,7 @@ fn trans_args_under_call_abi<'blk, 'tcx>(
                     bcx,
                     field_type,
                     |srcval| {
-                        adt::trans_field_ptr(bcx, repr_ptr, srcval, 0, i)
+                        adt::trans_field_ptr(bcx, repr_ptr, srcval, Disr(0), i)
                     }).to_expr_datum();
                 bcx = trans_arg_datum(bcx,
                                       field_type,

--- a/src/librustc_trans/trans/closure.rs
+++ b/src/librustc_trans/trans/closure.rs
@@ -26,6 +26,7 @@ use trans::declare;
 use trans::expr;
 use trans::monomorphize::{MonoId};
 use trans::type_of::*;
+use trans::Disr;
 use middle::ty;
 use session::config::FullDebugInfo;
 
@@ -242,7 +243,7 @@ pub fn trans_closure_expr<'a, 'tcx>(dest: Dest<'a, 'tcx>,
     for (i, freevar) in freevars.iter().enumerate() {
         let datum = expr::trans_local_var(bcx, freevar.def);
         let upvar_slot_dest = adt::trans_field_ptr(
-            bcx, &*repr, adt::MaybeSizedValue::sized(dest_addr), 0, i);
+            bcx, &*repr, adt::MaybeSizedValue::sized(dest_addr), Disr(0), i);
         let upvar_id = ty::UpvarId { var_id: freevar.def.var_id(),
                                      closure_expr_id: id };
         match tcx.upvar_capture(upvar_id).unwrap() {
@@ -254,7 +255,7 @@ pub fn trans_closure_expr<'a, 'tcx>(dest: Dest<'a, 'tcx>,
             }
         }
     }
-    adt::trans_set_discr(bcx, &*repr, dest_addr, 0);
+    adt::trans_set_discr(bcx, &*repr, dest_addr, Disr(0));
 
     Some(bcx)
 }

--- a/src/librustc_trans/trans/common.rs
+++ b/src/librustc_trans/trans/common.rs
@@ -161,6 +161,8 @@ pub fn gensym_name(name: &str) -> ast::Name {
 *
 */
 
+use trans::Disr;
+
 #[derive(Copy, Clone)]
 pub struct NodeIdAndSpan {
     pub id: ast::NodeId,
@@ -177,7 +179,7 @@ pub struct Field<'tcx>(pub ast::Name, pub Ty<'tcx>);
 
 /// The concrete version of ty::VariantDef
 pub struct VariantInfo<'tcx> {
-    pub discr: ty::Disr,
+    pub discr: Disr,
     pub fields: Vec<Field<'tcx>>
 }
 
@@ -195,7 +197,7 @@ impl<'tcx> VariantInfo<'tcx> {
                 };
 
                 VariantInfo {
-                    discr: variant.disr_val,
+                    discr: Disr::from(variant.disr_val),
                     fields: variant.fields.iter().map(|f| {
                         Field(f.name, monomorphize::field_ty(tcx, substs, f))
                     }).collect()
@@ -204,7 +206,7 @@ impl<'tcx> VariantInfo<'tcx> {
 
             ty::TyTuple(ref v) => {
                 VariantInfo {
-                    discr: 0,
+                    discr: Disr(0),
                     fields: v.iter().enumerate().map(|(i, &t)| {
                         Field(token::intern(&i.to_string()), t)
                     }).collect()

--- a/src/librustc_trans/trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/trans/debuginfo/metadata.rs
@@ -1341,7 +1341,7 @@ impl<'tcx> EnumMemberDescriptionFactory<'tcx> {
                 // DWARF representation of enums uniform.
 
                 // First create a description of the artificial wrapper struct:
-                let non_null_variant = &adt.variants[non_null_variant_index as usize];
+                let non_null_variant = &adt.variants[non_null_variant_index.0 as usize];
                 let non_null_variant_name = non_null_variant.name.as_str();
 
                 // The llvm type and metadata of the pointer
@@ -1389,7 +1389,7 @@ impl<'tcx> EnumMemberDescriptionFactory<'tcx> {
 
                 // Encode the information about the null variant in the union
                 // member's name.
-                let null_variant_index = (1 - non_null_variant_index) as usize;
+                let null_variant_index = (1 - non_null_variant_index.0) as usize;
                 let null_variant_name = adt.variants[null_variant_index].name;
                 let union_member_name = format!("RUST$ENCODED$ENUM${}${}",
                                                 0,
@@ -1415,7 +1415,7 @@ impl<'tcx> EnumMemberDescriptionFactory<'tcx> {
                     describe_enum_variant(cx,
                                           self.enum_type,
                                           struct_def,
-                                          &adt.variants[nndiscr as usize],
+                                          &adt.variants[nndiscr.0 as usize],
                                           OptimizedDiscriminant,
                                           self.containing_scope,
                                           self.span);
@@ -1430,7 +1430,7 @@ impl<'tcx> EnumMemberDescriptionFactory<'tcx> {
 
                 // Encode the information about the null variant in the union
                 // member's name.
-                let null_variant_index = (1 - nndiscr) as usize;
+                let null_variant_index = (1 - nndiscr.0) as usize;
                 let null_variant_name = adt.variants[null_variant_index].name;
                 let discrfield = discrfield.iter()
                                            .skip(1)

--- a/src/librustc_trans/trans/disr.rs
+++ b/src/librustc_trans/trans/disr.rs
@@ -1,0 +1,49 @@
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub struct Disr(pub u64);
+
+impl Disr {
+    pub fn wrapping_add(self, other: Self) -> Self {
+        Disr(self.0.wrapping_add(other.0))
+    }
+}
+
+impl ::std::ops::BitAnd for Disr {
+    type Output = Disr;
+    fn bitand(self, other: Self) -> Self {
+        Disr(self.0 & other.0)
+    }
+}
+
+impl From<::middle::ty::Disr> for Disr {
+    fn from(i: ::middle::ty::Disr) -> Disr {
+        Disr(i)
+    }
+}
+
+impl From<usize> for Disr {
+    fn from(i: usize) -> Disr {
+        Disr(i as u64)
+    }
+}
+
+impl PartialOrd for Disr {
+    fn partial_cmp(&self, other: &Disr) -> Option<::std::cmp::Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+impl Ord for Disr {
+    fn cmp(&self, other: &Disr) -> ::std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}

--- a/src/librustc_trans/trans/foreign.rs
+++ b/src/librustc_trans/trans/foreign.rs
@@ -27,6 +27,7 @@ use trans::monomorphize;
 use trans::type_::Type;
 use trans::type_of::*;
 use trans::type_of;
+use trans::Disr;
 use middle::infer;
 use middle::ty::{self, Ty};
 use middle::subst::Substs;
@@ -332,7 +333,7 @@ pub fn trans_native_call<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             llarg_rust
         } else {
             if passed_arg_tys[i].is_bool() {
-                let val = LoadRangeAssert(bcx, llarg_rust, 0, 2, llvm::False);
+                let val = LoadRangeAssert(bcx, llarg_rust, Disr(0), Disr(2), llvm::False);
                 Trunc(bcx, val, Type::i1(bcx.ccx()))
             } else {
                 Load(bcx, llarg_rust)

--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -36,6 +36,7 @@ use trans::type_of;
 use trans::machine;
 use trans::type_::Type;
 use middle::ty::{self, Ty, TypeFoldable};
+use trans::Disr;
 use middle::subst::Substs;
 use rustc::dep_graph::DepNode;
 use rustc_front::hir;
@@ -848,7 +849,7 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
                         let arg = adt::MaybeSizedValue::sized(llarg);
                         (0..contents.len())
                             .map(|i| {
-                                Load(bcx, adt::trans_field_ptr(bcx, repr_ptr, arg, 0, i))
+                                Load(bcx, adt::trans_field_ptr(bcx, repr_ptr, arg, Disr(0), i))
                             })
                             .collect()
                     }

--- a/src/librustc_trans/trans/mir/block.rs
+++ b/src/librustc_trans/trans/mir/block.rs
@@ -18,6 +18,7 @@ use trans::common::{self, Block};
 use trans::debuginfo::DebugLoc;
 use trans::type_of;
 use trans::type_::Type;
+use trans::Disr;
 
 use super::MirContext;
 use super::operand::OperandValue::{FatPtr, Immediate, Ref};
@@ -60,7 +61,7 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                 let switch = build::Switch(bcx, discr, unreachable_blk.llbb, targets.len());
                 assert_eq!(adt_def.variants.len(), targets.len());
                 for (adt_variant, target) in adt_def.variants.iter().zip(targets) {
-                    let llval = adt::trans_case(bcx, &*repr, adt_variant.disr_val);
+                    let llval = adt::trans_case(bcx, &*repr, Disr::from(adt_variant.disr_val));
                     let llbb = self.llblock(*target);
 
                     build::AddCase(switch, llval, llbb)

--- a/src/librustc_trans/trans/mir/lvalue.rs
+++ b/src/librustc_trans/trans/mir/lvalue.rs
@@ -20,6 +20,7 @@ use trans::debuginfo::DebugLoc;
 use trans::machine;
 use trans::type_of;
 use llvm;
+use trans::Disr;
 
 use std::ptr;
 
@@ -137,7 +138,7 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                         } else {
                             adt::MaybeSizedValue::unsized_(tr_base.llval, tr_base.llextra)
                         };
-                        (adt::trans_field_ptr(bcx, &base_repr, base, discr, field.index()),
+                        (adt::trans_field_ptr(bcx, &base_repr, base, Disr(discr), field.index()),
                          if is_sized {
                              ptr::null_mut()
                          } else {

--- a/src/librustc_trans/trans/mir/rvalue.rs
+++ b/src/librustc_trans/trans/mir/rvalue.rs
@@ -25,6 +25,7 @@ use trans::machine;
 use trans::type_::Type;
 use trans::type_of;
 use trans::tvec;
+use trans::Disr;
 
 use super::MirContext;
 use super::operand::{OperandRef, OperandValue};
@@ -100,8 +101,8 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                 match *kind {
                     mir::AggregateKind::Adt(adt_def, index, _) => {
                         let repr = adt::represent_type(bcx.ccx(), dest.ty.to_ty(bcx.tcx()));
-                        let disr = adt_def.variants[index].disr_val;
-                        adt::trans_set_discr(bcx, &*repr, dest.llval, disr);
+                        let disr = Disr::from(adt_def.variants[index].disr_val);
+                        adt::trans_set_discr(bcx, &*repr, dest.llval, Disr::from(disr));
                         for (i, operand) in operands.iter().enumerate() {
                             let op = self.trans_operand(bcx, operand);
                             // Do not generate stores and GEPis for zero-sized fields.

--- a/src/librustc_trans/trans/mod.rs
+++ b/src/librustc_trans/trans/mod.rs
@@ -14,6 +14,7 @@ use middle::cstore::LinkMeta;
 pub use self::base::trans_crate;
 pub use self::context::CrateContext;
 pub use self::common::gensym_name;
+pub use self::disr::Disr;
 
 #[macro_use]
 mod macros;
@@ -45,6 +46,7 @@ mod controlflow;
 mod datum;
 mod debuginfo;
 mod declare;
+mod disr;
 mod expr;
 mod foreign;
 mod glue;

--- a/src/librustc_trans/trans/monomorphize.rs
+++ b/src/librustc_trans/trans/monomorphize.rs
@@ -24,6 +24,7 @@ use trans::common::*;
 use trans::declare;
 use trans::foreign;
 use middle::ty::{self, Ty};
+use trans::Disr;
 use rustc::front::map as hir_map;
 
 use rustc_front::hir;
@@ -207,7 +208,7 @@ pub fn monomorphic_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
             assert_eq!(v.node.name, variant.name);
             let d = mk_lldecl(abi::Rust);
             attributes::inline(d, attributes::InlineAttr::Hint);
-            trans_enum_variant(ccx, fn_node_id, variant.disr_val, psubsts, d);
+            trans_enum_variant(ccx, fn_node_id, Disr::from(variant.disr_val), psubsts, d);
             d
         }
         hir_map::NodeImplItem(impl_item) => {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4178,7 +4178,7 @@ pub fn check_enum_variants<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
                                     sp: Span,
                                     vs: &'tcx [hir::Variant],
                                     id: ast::NodeId) {
-
+    // disr_in_range should be removed once we have forced type hints for consts
     fn disr_in_range(ccx: &CrateCtxt,
                      ty: attr::IntType,
                      disr: ty::Disr) -> bool {


### PR DESCRIPTION
This is groundwork for #30587 (typestrong constant integrals), but imo it's a change that in itself is good, too, since we don't just juggle `u64`s around anymore.

`ty::Disr` will be changed to a `ConstInt` in #30587 
