### PR TITLE
Rename is_positive argument in fmt::Formatter::pad_integral

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -852,7 +852,7 @@ impl<'a> Formatter<'a> {
     ///
     /// # Arguments
     ///
-    /// * is_positive - whether the original integer was positive or not.
+    /// * is_nonnegative - whether the original integer was either positive or zero.
     /// * prefix - if the '#' character (Alternate) is provided, this
     ///   is the prefix to put in front of the number.
     /// * buf - the byte array that the number has been formatted into
@@ -861,7 +861,7 @@ impl<'a> Formatter<'a> {
     /// the minimum width. It will not take precision into account.
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn pad_integral(&mut self,
-                        is_positive: bool,
+                        is_nonnegative: bool,
                         prefix: &str,
                         buf: &str)
                         -> Result {
@@ -870,7 +870,7 @@ impl<'a> Formatter<'a> {
         let mut width = buf.len();
 
         let mut sign = None;
-        if !is_positive {
+        if !is_nonnegative {
             sign = Some('-'); width += 1;
         } else if self.sign_plus() {
             sign = Some('+'); width += 1;

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -60,11 +60,11 @@ trait GenericRadix {
         // The radix can be as low as 2, so we need a buffer of at least 64
         // characters for a base 2 number.
         let zero = T::zero();
-        let is_positive = x >= zero;
+        let is_nonnegative = x >= zero;
         let mut buf = [0; 64];
         let mut curr = buf.len();
         let base = T::from_u8(self.base());
-        if is_positive {
+        if is_nonnegative {
             // Accumulate each digit of the number from the least significant
             // to the most significant figure.
             for byte in buf.iter_mut().rev() {
@@ -91,7 +91,7 @@ trait GenericRadix {
             }
         }
         let buf = unsafe { str::from_utf8_unchecked(&buf[curr..]) };
-        f.pad_integral(is_positive, self.prefix(), buf)
+        f.pad_integral(is_nonnegative, self.prefix(), buf)
     }
 }
 
@@ -268,8 +268,8 @@ macro_rules! impl_Display {
     impl fmt::Display for $t {
         #[allow(unused_comparisons)]
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            let is_positive = *self >= 0;
-            let mut n = if is_positive {
+            let is_nonnegative = *self >= 0;
+            let mut n = if is_nonnegative {
                 self.$conv_fn()
             } else {
                 // convert the negative num to positive by summing 1 to it's 2 complement
@@ -321,7 +321,7 @@ macro_rules! impl_Display {
                 str::from_utf8_unchecked(
                     slice::from_raw_parts(buf_ptr.offset(curr), buf.len() - curr as usize))
             };
-            f.pad_integral(is_positive, "", buf_slice)
+            f.pad_integral(is_nonnegative, "", buf_slice)
         }
     })*);
 }


### PR DESCRIPTION
The function expects a value of true for zero but zero is not positive.
