### PR TITLE
[MIR] use mir::repr::Constant in ExprKind::Repeat, close #29789

### DIFF
--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -683,7 +683,7 @@ pub enum Rvalue<'tcx> {
     Use(Operand<'tcx>),
 
     // [x; 32]
-    Repeat(Operand<'tcx>, Constant<'tcx>),
+    Repeat(Operand<'tcx>, TypedConstVal<'tcx>),
 
     // &x or &mut x
     Ref(Region, BorrowKind, Lvalue<'tcx>),
@@ -889,6 +889,13 @@ pub struct Constant<'tcx> {
     pub span: Span,
     pub ty: Ty<'tcx>,
     pub literal: Literal<'tcx>,
+}
+
+#[derive(Clone, Debug, RustcEncodable, RustcDecodable)]
+pub struct TypedConstVal<'tcx> {
+    pub ty: Ty<'tcx>,
+    pub span: Span,
+    pub value: ConstVal
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, RustcEncodable, RustcDecodable)]

--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -891,11 +891,18 @@ pub struct Constant<'tcx> {
     pub literal: Literal<'tcx>,
 }
 
-#[derive(Clone, Debug, RustcEncodable, RustcDecodable)]
+#[derive(Clone, RustcEncodable, RustcDecodable)]
 pub struct TypedConstVal<'tcx> {
     pub ty: Ty<'tcx>,
     pub span: Span,
     pub value: ConstVal
+}
+
+impl<'tcx> Debug for TypedConstVal<'tcx> {
+    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
+        try!(write!(fmt, "const "));
+        fmt_const_val(fmt, &self.value)
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, RustcEncodable, RustcDecodable)]

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -213,9 +213,8 @@ macro_rules! make_mir_visitor {
                     }
 
                     Rvalue::Repeat(ref $($mutability)* value,
-                                   ref $($mutability)* len) => {
+                                   _) => {
                         self.visit_operand(value);
-                        self.visit_constant(len);
                     }
 
                     Rvalue::Ref(r, bk, ref $($mutability)* path) => {

--- a/src/librustc_mir/build/expr/as_rvalue.rs
+++ b/src/librustc_mir/build/expr/as_rvalue.rs
@@ -44,7 +44,6 @@ impl<'a,'tcx> Builder<'a,'tcx> {
             }
             ExprKind::Repeat { value, count } => {
                 let value_operand = unpack!(block = this.as_operand(block, value));
-                let count = this.as_constant(count);
                 block.and(Rvalue::Repeat(value_operand, count))
             }
             ExprKind::Borrow { region, borrow_kind, arg } => {

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -15,6 +15,7 @@ use hair::cx::block;
 use hair::cx::to_ref::ToRef;
 use rustc::front::map;
 use rustc::middle::def::Def;
+use rustc::middle::const_eval;
 use rustc::middle::region::CodeExtent;
 use rustc::middle::pat_util;
 use rustc::middle::ty::{self, VariantDef, Ty};
@@ -325,10 +326,10 @@ impl<'tcx> Mirror<'tcx> for &'tcx hir::Expr {
 
             hir::ExprRepeat(ref v, ref c) => ExprKind::Repeat {
                 value: v.to_ref(),
-                count: Constant {
+                count: TypedConstVal {
                     ty: cx.tcx.expr_ty(c),
                     span: c.span,
-                    literal: cx.const_eval_literal(c)
+                    value: const_eval::eval_const_expr(cx.tcx, c)
                 }
             },
             hir::ExprRet(ref v) =>

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -325,14 +325,11 @@ impl<'tcx> Mirror<'tcx> for &'tcx hir::Expr {
 
             hir::ExprRepeat(ref v, ref c) => ExprKind::Repeat {
                 value: v.to_ref(),
-                count: Expr {
+                count: Constant {
                     ty: cx.tcx.expr_ty(c),
-                    temp_lifetime: None,
                     span: c.span,
-                    kind: ExprKind::Literal {
-                        literal: cx.const_eval_literal(c)
-                    }
-                }.to_ref()
+                    literal: cx.const_eval_literal(c)
+                }
             },
             hir::ExprRet(ref v) =>
                 ExprKind::Return { value: v.to_ref() },

--- a/src/librustc_mir/hair/mod.rs
+++ b/src/librustc_mir/hair/mod.rs
@@ -14,7 +14,7 @@
 //! unit-tested and separated from the Rust source and compiler data
 //! structures.
 
-use rustc::mir::repr::{BinOp, BorrowKind, Field, Literal, Mutability, UnOp, ItemKind};
+use rustc::mir::repr::{Constant, BinOp, BorrowKind, Field, Literal, Mutability, UnOp, ItemKind};
 use rustc::middle::const_eval::ConstVal;
 use rustc::middle::def_id::DefId;
 use rustc::middle::region::CodeExtent;
@@ -213,10 +213,7 @@ pub enum ExprKind<'tcx> {
     },
     Repeat {
         value: ExprRef<'tcx>,
-        // FIXME(#29789): Add a separate hair::Constant<'tcx> so this could be more explicit about
-        // its contained data. Currently this should only contain expression of ExprKind::Literal
-        // kind.
-        count: ExprRef<'tcx>,
+        count: Constant<'tcx>,
     },
     Vec {
         fields: Vec<ExprRef<'tcx>>,
@@ -341,7 +338,6 @@ pub struct FieldPattern<'tcx> {
     pub field: Field,
     pub pattern: Pattern<'tcx>,
 }
-
 ///////////////////////////////////////////////////////////////////////////
 // The Mirror trait
 

--- a/src/librustc_mir/hair/mod.rs
+++ b/src/librustc_mir/hair/mod.rs
@@ -14,7 +14,8 @@
 //! unit-tested and separated from the Rust source and compiler data
 //! structures.
 
-use rustc::mir::repr::{Constant, BinOp, BorrowKind, Field, Literal, Mutability, UnOp, ItemKind};
+use rustc::mir::repr::{BinOp, BorrowKind, Field, Literal, Mutability, UnOp, ItemKind,
+    TypedConstVal};
 use rustc::middle::const_eval::ConstVal;
 use rustc::middle::def_id::DefId;
 use rustc::middle::region::CodeExtent;
@@ -213,7 +214,7 @@ pub enum ExprKind<'tcx> {
     },
     Repeat {
         value: ExprRef<'tcx>,
-        count: Constant<'tcx>,
+        count: TypedConstVal<'tcx>,
     },
     Vec {
         fields: Vec<ExprRef<'tcx>>,
@@ -338,6 +339,7 @@ pub struct FieldPattern<'tcx> {
     pub field: Field,
     pub pattern: Pattern<'tcx>,
 }
+
 ///////////////////////////////////////////////////////////////////////////
 // The Mirror trait
 

--- a/src/librustc_mir/transform/erase_regions.rs
+++ b/src/librustc_mir/transform/erase_regions.rs
@@ -143,9 +143,8 @@ impl<'a, 'tcx> EraseRegions<'a, 'tcx> {
             Rvalue::Use(ref mut operand) => {
                 self.erase_regions_operand(operand)
             }
-            Rvalue::Repeat(ref mut operand, ref mut constant) => {
+            Rvalue::Repeat(ref mut operand, _) => {
                 self.erase_regions_operand(operand);
-                self.erase_regions_constant(constant);
             }
             Rvalue::Ref(ref mut region, _, ref mut lvalue) => {
                 *region = ty::ReStatic;

--- a/src/librustc_mir/transform/erase_regions.rs
+++ b/src/librustc_mir/transform/erase_regions.rs
@@ -143,8 +143,9 @@ impl<'a, 'tcx> EraseRegions<'a, 'tcx> {
             Rvalue::Use(ref mut operand) => {
                 self.erase_regions_operand(operand)
             }
-            Rvalue::Repeat(ref mut operand, _) => {
+            Rvalue::Repeat(ref mut operand, ref mut value) => {
                 self.erase_regions_operand(operand);
+                value.ty = self.tcx.erase_regions(&value.ty);
             }
             Rvalue::Ref(ref mut region, _, ref mut lvalue) => {
                 *region = ty::ReStatic;

--- a/src/librustc_trans/trans/mir/rvalue.rs
+++ b/src/librustc_trans/trans/mir/rvalue.rs
@@ -89,7 +89,7 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
 
             mir::Rvalue::Repeat(ref elem, ref count) => {
                 let elem = self.trans_operand(bcx, elem);
-                let size = self.trans_constant(bcx, count).immediate();
+                let size = self.trans_constval(bcx, &count.value, count.ty).immediate();
                 let base = expr::get_dataptr(bcx, dest.llval);
                 tvec::iter_vec_raw(bcx, base, elem.ty, size, |bcx, llslot, _| {
                     self.store_operand(bcx, llslot, elem);


### PR DESCRIPTION
This PR for  #29789 uses `rustc::repr::mir::Constant` in `ExprKind::Repeat`, which seems to fit quite nicely. Is there a reason for not re-using that type?
