### PR TITLE
Add support for the crosstool-ng Raspberry Pi 2 toolchain

### DIFF
--- a/mk/cfg/armv7-unknown-linux-gnueabihf.mk
+++ b/mk/cfg/armv7-unknown-linux-gnueabihf.mk
@@ -1,0 +1,26 @@
+# armv7-unknown-linux-gnueabihf configuration
+CROSS_PREFIX_armv7-unknown-linux-gnueabihf=armv7-unknown-linux-gnueabihf-
+CC_armv7-unknown-linux-gnueabihf=gcc
+CXX_armv7-unknown-linux-gnueabihf=g++
+CPP_armv7-unknown-linux-gnueabihf=gcc -E
+AR_armv7-unknown-linux-gnueabihf=ar
+CFG_LIB_NAME_armv7-unknown-linux-gnueabihf=lib$(1).so
+CFG_STATIC_LIB_NAME_armv7-unknown-linux-gnueabihf=lib$(1).a
+CFG_LIB_GLOB_armv7-unknown-linux-gnueabihf=lib$(1)-*.so
+CFG_LIB_DSYM_GLOB_armv7-unknown-linux-gnueabihf=lib$(1)-*.dylib.dSYM
+CFG_JEMALLOC_CFLAGS_armv7-unknown-linux-gnueabihf := -D__arm__ $(CFLAGS)
+CFG_GCCISH_CFLAGS_armv7-unknown-linux-gnueabihf := -Wall -g -fPIC -D__arm__ $(CFLAGS)
+CFG_GCCISH_CXXFLAGS_armv7-unknown-linux-gnueabihf := -fno-rtti $(CXXFLAGS)
+CFG_GCCISH_LINK_FLAGS_armv7-unknown-linux-gnueabihf := -shared -fPIC -g
+CFG_GCCISH_DEF_FLAG_armv7-unknown-linux-gnueabihf := -Wl,--export-dynamic,--dynamic-list=
+CFG_LLC_FLAGS_armv7-unknown-linux-gnueabihf :=
+CFG_INSTALL_NAME_ar,-unknown-linux-gnueabihf =
+CFG_EXE_SUFFIX_armv7-unknown-linux-gnueabihf :=
+CFG_WINDOWSY_armv7-unknown-linux-gnueabihf :=
+CFG_UNIXY_armv7-unknown-linux-gnueabihf := 1
+CFG_LDPATH_armv7-unknown-linux-gnueabihf :=
+CFG_RUN_armv7-unknown-linux-gnueabihf=$(2)
+CFG_RUN_TARG_armv7-unknown-linux-gnueabihf=$(call CFG_RUN_armv7-unknown-linux-gnueabihf,,$(2))
+RUSTC_FLAGS_armv7-unknown-linux-gnueabihf := -C target-feature=+v7,+vfp2,+neon
+RUSTC_CROSS_FLAGS_armv7-unknown-linux-gnueabihf :=
+CFG_GNU_TRIPLE_armv7-unknown-linux-gnueabihf := armv7-unknown-linux-gnueabihf

--- a/src/librustc_back/target/armv7_unknown_linux_gnueabihf.rs
+++ b/src/librustc_back/target/armv7_unknown_linux_gnueabihf.rs
@@ -1,0 +1,31 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use target::{Target, TargetOptions};
+
+pub fn target() -> Target {
+    let base = super::linux_base::opts();
+    Target {
+        llvm_target: "armv7-unknown-linux-gnueabihf".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "32".to_string(),
+        arch: "arm".to_string(),
+        target_os: "linux".to_string(),
+        target_env: "gnueabihf".to_string(),
+        target_vendor: "unknown".to_string(),
+
+        options: TargetOptions {
+            features: "+v7,+vfp2,+neon".to_string(),
+            cpu: "cortex-a7".to_string(),
+            .. base
+        }
+    }
+}
+

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -417,6 +417,7 @@ impl Target {
             powerpc64le_unknown_linux_gnu,
             arm_unknown_linux_gnueabi,
             arm_unknown_linux_gnueabihf,
+            armv7_unknown_linux_gnueabihf,
             aarch64_unknown_linux_gnu,
             x86_64_unknown_linux_musl,
 


### PR DESCRIPTION
This adds support for the armv7 crosstool-ng toolchain for the Raspberry Pi 2.

Getting the toolchain ready:
Checkout crosstool-ng from https://github.com/crosstool-ng/crosstool-ng
Build crosstool-ng
Configure the rpi2 target with |ct-ng armv7-rpi2-linux-gnueabihf|
Build the toolchain with |ct-build| and add the path to $toolchain_install_dir/bin to your $PATH

Then, on the rust side:
configure --target=armv7-rpi2-linux-gnueabihf && make && make install

To cross compile for the rpi2, 
add $rust_install_path/lib to your $LD_LIBRARY_PATH, then use
rustc --target=armv7-rpi2-linux-gnueabihf -C linker=armv7-rpi2-linux-gnueabihf-g++ hello.rs
