### PR TITLE
Nomicon: Vec ZST a few code fixes

### DIFF
--- a/src/doc/nomicon/vec-final.md
+++ b/src/doc/nomicon/vec-final.md
@@ -226,7 +226,11 @@ impl<T> Iterator for RawValIter<T> {
         } else {
             unsafe {
                 let result = ptr::read(self.start);
-                self.start = self.start.offset(1);
+                self.start = if mem::size_of::<T>() == 0 {
+					(self.start as usize + 1) as *const _
+				} else {
+					self.start.offset(1)
+				};
                 Some(result)
             }
         }
@@ -246,7 +250,11 @@ impl<T> DoubleEndedIterator for RawValIter<T> {
             None
         } else {
             unsafe {
-                self.end = self.end.offset(-1);
+                self.end = if mem::size_of::<T>() == 0 {
+					(self.end as usize - 1) as *const _
+				} else {
+					self.end.offset(-1)
+				};
                 Some(ptr::read(self.end))
             }
         }

--- a/src/doc/nomicon/vec-final.md
+++ b/src/doc/nomicon/vec-final.md
@@ -227,10 +227,10 @@ impl<T> Iterator for RawValIter<T> {
             unsafe {
                 let result = ptr::read(self.start);
                 self.start = if mem::size_of::<T>() == 0 {
-					(self.start as usize + 1) as *const _
-				} else {
-					self.start.offset(1)
-				};
+                    (self.start as usize + 1) as *const _
+                } else {
+                    self.start.offset(1)
+                };
                 Some(result)
             }
         }
@@ -251,10 +251,10 @@ impl<T> DoubleEndedIterator for RawValIter<T> {
         } else {
             unsafe {
                 self.end = if mem::size_of::<T>() == 0 {
-					(self.end as usize - 1) as *const _
-				} else {
-					self.end.offset(-1)
-				};
+                    (self.end as usize - 1) as *const _
+                } else {
+                    self.end.offset(-1)
+                };
                 Some(ptr::read(self.end))
             }
         }

--- a/src/doc/nomicon/vec-zsts.md
+++ b/src/doc/nomicon/vec-zsts.md
@@ -140,8 +140,8 @@ impl<T> Iterator for RawValIter<T> {
                 self.start = if mem::size_of::<T>() == 0 {
                     (self.start as usize + 1) as *const _
                 } else {
-                    self.start.offset(1);
-                }
+                    self.start.offset(1)
+                };
                 Some(result)
             }
         }
@@ -164,8 +164,8 @@ impl<T> DoubleEndedIterator for RawValIter<T> {
                 self.end = if mem::size_of::<T>() == 0 {
                     (self.end as usize - 1) as *const _
                 } else {
-                    self.end.offset(-1);
-                }
+                    self.end.offset(-1)
+                };
                 Some(ptr::read(self.end))
             }
         }


### PR DESCRIPTION
- Moved semicolon to the right place in the `let` statement in the ZST section.
- Fixed the missing ZST additions for `RawValIter<T>` from this section in the final code section.
