### PR TITLE
Remove reference to AUTHORS.txt file

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -7,7 +7,7 @@ terms.
 Longer version:
 
 The Rust Project is copyright 2016, The Rust Project
-Developers (given in the file AUTHORS.txt).
+Developers.
 
 Licensed under the Apache License, Version 2.0
 <LICENSE-APACHE or


### PR DESCRIPTION
The COPYRIGHT file should be updated to note that Rust no longer ships with AUTHORS.txt.

```
$ git log -1 -- AUTHORS.txt
commit 402749c539edcbc2d850ac3a782cace8661c68e6
Author: Brian Anderson <banderson@mozilla.com>
Date:   Wed Dec 2 22:16:08 2015 +0000

    Remove AUTHORS.txt and add-authors.sh

    Keeping this file up to date requires hours of work every release,
    even with the script. It is a fool's errand and we shall not do it
    any longer.
```
