### PR TITLE
test: Increase resolution of MB/s stat for bench runs close to 1 second

### DIFF
--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -1258,8 +1258,7 @@ pub mod bench {
         let ns_iter_summ = bs.auto_bench(f);
 
         let ns_iter = cmp::max(ns_iter_summ.median as u64, 1);
-        let iter_s = 1_000_000_000 / ns_iter;
-        let mb_s = (bs.bytes * iter_s) / 1_000_000;
+        let mb_s = bs.bytes * 1000 / ns_iter;
 
         BenchSamples {
             ns_iter_summ: ns_iter_summ,


### PR DESCRIPTION
test: Increase resolution of MB/s stat for bench runs close to 1 second

MB/s was based on the number of iterations performed in a second, when
the iteration duration nears 1 second (1e9 ns), the resolution of the
MB/s stat decreases.
