### PR TITLE
Add snapshotting to ObligationForest

### DIFF
--- a/src/librustc_data_structures/obligation_forest/README.md
+++ b/src/librustc_data_structures/obligation_forest/README.md
@@ -60,11 +60,9 @@ which includes three bits of information:
   
 #### Snapshots
 
-The `ObligationForest` supports a limited form of snapshots; see
-`start_snapshot`; `commit_snapshot`; and `rollback_snapshot`. In
-particular, you can use a snapshot to roll back new root
-obligations. However, it is an error to attempt to
-`process_obligations` during a snapshot.
+The `ObligationForest` supports snapshots; see
+`start_snapshot`; `commit_snapshot`; and `rollback_snapshot`. Snapshots roll
+back all externally visible state.
 
 ### Implementation details
 
@@ -74,7 +72,8 @@ the forest is stored in a vector. Each element of the vector is a node
 in some tree. Each node in the vector has the index of an (optional)
 parent and (for convenience) its root (which may be itself). It also
 has a current state, described by `NodeState`. After each
-processing step, we compress the vector to remove completed and error
-nodes, which aren't needed anymore.
+processing step, we compress the vector to remove completed and error nodes (or
+mark as 'popped' if we can't remove due to snapshotting), which aren't needed
+anymore.
 
   

--- a/src/librustc_data_structures/obligation_forest/mod.rs
+++ b/src/librustc_data_structures/obligation_forest/mod.rs
@@ -15,6 +15,7 @@
 //! in the first place). See README.md for a general overview of how
 //! to use this class.
 
+use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::mem;
 
@@ -23,6 +24,7 @@ mod node_index;
 #[cfg(test)]
 mod test;
 
+#[derive(Debug)]
 pub struct ObligationForest<O> {
     /// The list of obligations. In between calls to
     /// `process_obligations`, this list only contains nodes in the
@@ -30,27 +32,63 @@ pub struct ObligationForest<O> {
     /// incomplete children). During processing, some of those nodes
     /// may be changed to the error state, or we may find that they
     /// are completed (That is, `num_incomplete_children` drops to 0).
-    /// At the end of processing, those nodes will be removed by a
-    /// call to `compress`.
+    /// At the end of processing, those nodes will be removed (or
+    /// marked as removed if used in earlier snapshots) by a call to
+    /// `compress`.
     ///
     /// At all times we maintain the invariant that every node appears
     /// at a higher index than its parent. This is needed by the
     /// backtrace iterator (which uses `split_at`).
     nodes: Vec<Node<O>>,
-    snapshots: Vec<usize>
+    snapshots: Vec<Snapshot>
 }
 
-pub struct Snapshot {
-    len: usize,
-}
+// We could implement Copy here, but that tastes weird.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Snapshot(usize);
 
 pub use self::node_index::NodeIndex;
 
-struct Node<O> {
+/// Snapshotted state of a node. The snapshot is the one in which the node state *applies*, not the
+/// one upon which the node state *was applied*.
+#[derive(Debug)]
+struct NodeStateSnapshot<O> {
+    snapshot: Snapshot,
     state: NodeState<O>,
+}
+impl<O> NodeStateSnapshot<O> {
+    fn new(snapshot: Snapshot, state: NodeState<O>) -> NodeStateSnapshot<O> {
+        NodeStateSnapshot {
+            snapshot: snapshot,
+            state: state,
+        }
+    }
+}
+
+/// Stack of node state snapshots. Has implicit stack structure from the total ordering of the
+/// Snapshot structure and its closure under Snapshot::next(): every stack has an implicit value
+/// for every possible snapshot, with the most recent state at or below any given snapshot being
+/// the applicable state.
+///
+/// The stack is split into a Base and a Stack variant to take advantage of the per-node
+/// snapshotting performed by ObligationForest and to thus avoid allocating space for snapshots
+/// when it isn't necessary.
+#[derive(Debug)]
+enum NodeStateSnapshots<O> {
+    Base(NodeStateSnapshot<O>),
+    Stack(Vec<NodeStateSnapshot<O>>),
+}
+
+#[derive(Debug)]
+struct Node<O> {
+    snapshots: NodeStateSnapshots<O>,
     parent: Option<NodeIndex>,
     root: NodeIndex, // points to the root, which may be the current node
 }
+
+// FIXME make the `obligation` member a `Cow<O>` instead of an `O` to avoid cloning so much (or,
+// maybe don't? Maybe the extra byte for the discriminant isn't worth the usually inexpensive
+// clone?). Maybe move the Obligation into the Node instead?
 
 /// The state of one node in some tree within the forest. This
 /// represents the current state of processing for the obligation (of
@@ -67,12 +105,22 @@ enum NodeState<O> {
     /// there is pending work somewhere in the subtree of the child.)
     ///
     /// Once all children have completed, success nodes are removed
-    /// from the vector by the compression step.
+    /// from the vector by the compression step if they have no
+    /// underlying snapshots that are still alive. Else, they're set
+    /// to 'Popped'.
     Success { obligation: O, num_incomplete_children: usize },
 
     /// This obligation was resolved to an error. Error nodes are
-    /// removed from the vector by the compression step.
+    /// removed from the vector by the compression step if they have
+    /// no underlying snapshots that are still alive. Else, they're
+    /// set to 'Popped'.
     Error,
+
+    /// Obligation is dead in the latest snapshot, but still being
+    /// used by earlier snapshots. Note that this state may occur
+    /// even if there are no earlier snapshots if a node became
+    /// Popped then was committed to a lower snapshot.
+    Popped,
 }
 
 #[derive(Debug)]
@@ -99,11 +147,11 @@ pub struct Error<O,E> {
     pub backtrace: Vec<O>,
 }
 
-impl<O: Debug> ObligationForest<O> {
+impl<O: Debug + Clone> ObligationForest<O> {
     pub fn new() -> ObligationForest<O> {
         ObligationForest {
             nodes: vec![],
-            snapshots: vec![]
+            snapshots: vec![Snapshot::new_base()]
         }
     }
 
@@ -113,35 +161,40 @@ impl<O: Debug> ObligationForest<O> {
         self.nodes.len()
     }
 
+    fn current_snapshot(&self) -> Snapshot {
+        self.snapshots.last().unwrap().clone()
+    }
+
     pub fn start_snapshot(&mut self) -> Snapshot {
-        self.snapshots.push(self.nodes.len());
-        Snapshot { len: self.snapshots.len() }
+        let next_snapshot = self.snapshots.last().unwrap().next();
+        self.snapshots.push(next_snapshot.clone());
+        next_snapshot
     }
 
     pub fn commit_snapshot(&mut self, snapshot: Snapshot) {
-        assert_eq!(snapshot.len, self.snapshots.len());
-        let nodes_len = self.snapshots.pop().unwrap();
-        assert!(self.nodes.len() >= nodes_len);
+        assert_eq!(*self.snapshots.last().unwrap(), snapshot);
+        let prev_snapshot = snapshot.prev();
+        for node in &mut self.nodes {
+            node.snapshots.commit(snapshot.clone(), prev_snapshot.clone());
+        }
+        self.snapshots.pop();
     }
 
     pub fn rollback_snapshot(&mut self, snapshot: Snapshot) {
-        // Check that we are obeying stack discipline.
-        assert_eq!(snapshot.len, self.snapshots.len());
-        let nodes_len = self.snapshots.pop().unwrap();
-
-        // The only action permitted while in a snapshot is to push
-        // new root obligations. Because no processing will have been
-        // done, those roots should still be in the pending state.
-        debug_assert!(self.nodes[nodes_len..].iter().all(|n| match n.state {
-            NodeState::Pending { .. } => true,
-            _ => false,
-        }));
-
-        self.nodes.truncate(nodes_len);
+        assert_eq!(*self.snapshots.last().unwrap(), snapshot);
+        for node in &mut self.nodes {
+            node.snapshots.pop(snapshot.clone());
+        }
+        // Compress before popping the snapshot to ensure that the
+        // snapshot seen while popping is the one that corresponds
+        // to snapshotted Popped states.
+        self.compress();
+        self.snapshots.pop();
+        assert!(!self.snapshots.is_empty(), "rolled back into non-existence");
     }
 
     pub fn in_snapshot(&self) -> bool {
-        !self.snapshots.is_empty()
+        self.snapshots.len() != 1
     }
 
     /// Adds a new tree to the forest.
@@ -149,19 +202,17 @@ impl<O: Debug> ObligationForest<O> {
     /// This CAN be done during a snapshot.
     pub fn push_root(&mut self, obligation: O) {
         let index = NodeIndex::new(self.nodes.len());
-        self.nodes.push(Node::new(index, None, obligation));
+        let current_snapshot = self.current_snapshot();
+        self.nodes.push(Node::new(current_snapshot, index, None, obligation));
     }
 
     /// Convert all remaining obligations to the given error.
-    ///
-    /// This cannot be done during a snapshot.
     pub fn to_errors<E:Clone>(&mut self, error: E) -> Vec<Error<O,E>> {
-        assert!(!self.in_snapshot());
         let mut errors = vec![];
         for index in 0..self.nodes.len() {
-            debug_assert!(!self.nodes[index].is_popped());
+            debug_assert!(!self.nodes[index].is_popped_at(self.current_snapshot()));
             self.inherit_error(index);
-            if let NodeState::Pending { .. } = self.nodes[index].state {
+            if let &NodeState::Pending { .. } = self.nodes[index].snapshots.top() {
                 let backtrace = self.backtrace(index);
                 errors.push(Error { error: error.clone(), backtrace: backtrace });
             }
@@ -174,8 +225,8 @@ impl<O: Debug> ObligationForest<O> {
     /// Returns the set of obligations that are in a pending state.
     pub fn pending_obligations(&self) -> Vec<O> where O: Clone {
         self.nodes.iter()
-                  .filter_map(|n| match n.state {
-                      NodeState::Pending { ref obligation } => Some(obligation),
+                  .filter_map(|n| match n.snapshots.top() {
+                      &NodeState::Pending { ref obligation } => Some(obligation),
                       _ => None,
                   })
                   .cloned()
@@ -183,13 +234,10 @@ impl<O: Debug> ObligationForest<O> {
     }
 
     /// Process the obligations.
-    ///
-    /// This CANNOT be unrolled (presently, at least).
     pub fn process_obligations<E,F>(&mut self, mut action: F) -> Outcome<O,E>
         where E: Debug, F: FnMut(&mut O, Backtrace<O>) -> Result<Option<Vec<O>>, E>
     {
         debug!("process_obligations(len={})", self.nodes.len());
-        assert!(!self.in_snapshot()); // cannot unroll this action
 
         let mut errors = vec![];
         let mut stalled = true;
@@ -203,21 +251,28 @@ impl<O: Debug> ObligationForest<O> {
         // encountered an error.
 
         for index in 0..self.nodes.len() {
-            debug_assert!(!self.nodes[index].is_popped());
+            if self.nodes[index].is_popped_at(self.current_snapshot()) {
+                // FIXME have compression move nodes that are popped at the current snapshot to the
+                // end of the nodes array, s.t. if we started keeping track of the total number of
+                // nodes alive in this snapshot, we could always skip the popped ones instead of
+                // explicitly checking.
+                continue;
+            }
             self.inherit_error(index);
 
             debug!("process_obligations: node {} == {:?}",
-                   index, self.nodes[index].state);
+                   index, self.nodes[index].snapshots.top());
 
             let result = {
                 let parent = self.nodes[index].parent;
                 let (prefix, suffix) = self.nodes.split_at_mut(index);
                 let backtrace = Backtrace::new(prefix, parent);
-                match suffix[0].state {
-                    NodeState::Error |
-                    NodeState::Success { .. } =>
+                match suffix[0].snapshots.top_mut() {
+                    &mut NodeState::Popped |
+                    &mut NodeState::Error |
+                    &mut NodeState::Success { .. } =>
                         continue,
-                    NodeState::Pending { ref mut obligation } =>
+                    &mut NodeState::Pending { ref mut obligation } =>
                         action(obligation, backtrace),
                 }
             };
@@ -262,6 +317,7 @@ impl<O: Debug> ObligationForest<O> {
         debug!("success(index={}, children={:?})", index, children);
 
         let num_incomplete_children = children.len();
+        let current_snapshot = self.current_snapshot();
 
         if num_incomplete_children == 0 {
             // if there is no work left to be done, decrement parent's ref count
@@ -272,37 +328,49 @@ impl<O: Debug> ObligationForest<O> {
             let node_index = NodeIndex::new(index);
             self.nodes.extend(
                 children.into_iter()
-                        .map(|o| Node::new(root_index, Some(node_index), o)));
+                        .map(|o| Node::new(current_snapshot.clone(),
+                                           root_index,
+                                           Some(node_index),
+                                           o)));
         }
 
-        // change state from `Pending` to `Success`, temporarily swapping in `Error`
-        let state = mem::replace(&mut self.nodes[index].state, NodeState::Error);
-        self.nodes[index].state = match state {
-            NodeState::Pending { obligation } =>
-                NodeState::Success { obligation: obligation,
-                                     num_incomplete_children: num_incomplete_children },
-            NodeState::Success { .. } |
-            NodeState::Error =>
+        // change state from `Pending` to `Success`
+        self.nodes[index].snapshots.update_with(current_snapshot.clone(), |_, state| match state {
+            &NodeState::Pending { ref obligation } =>
+                Some(NodeState::Success { obligation: obligation.clone(),
+                                          num_incomplete_children: num_incomplete_children }),
+            &NodeState::Success { .. } |
+            &NodeState::Error |
+            &NodeState::Popped =>
                 unreachable!()
-        };
+        });
     }
 
     /// Decrements the ref count on the parent of `child`; if the
     /// parent's ref count then reaches zero, proceeds recursively.
     fn update_parent(&mut self, child: usize) {
         debug!("update_parent(child={})", child);
+        let current_snapshot = self.current_snapshot();
         if let Some(parent) = self.nodes[child].parent {
             let parent = parent.get();
-            match self.nodes[parent].state {
-                NodeState::Success { ref mut num_incomplete_children, .. } => {
-                    *num_incomplete_children -= 1;
-                    if *num_incomplete_children > 0 {
-                        return;
+            let mut skip_update_parent = false;
+            self.nodes[parent].snapshots.update_with(
+                current_snapshot,
+                |_, state| match state {
+                    &NodeState::Success { ref num_incomplete_children, ref obligation } => {
+                        if *num_incomplete_children > 1 {
+                            skip_update_parent = true;
+                        }
+                        Some(NodeState::Success {
+                            num_incomplete_children: num_incomplete_children - 1,
+                            obligation: obligation.clone()
+                        })
                     }
-                }
-                _ => unreachable!(),
+                    _ => unreachable!(),
+                });
+            if !skip_update_parent {
+                self.update_parent(parent);
             }
-            self.update_parent(parent);
         }
     }
 
@@ -311,9 +379,10 @@ impl<O: Debug> ObligationForest<O> {
     /// skip the remaining obligations from a tree once some other
     /// node in the tree is found to be in error.
     fn inherit_error(&mut self, child: usize) {
+        let current_snapshot = self.current_snapshot();
         let root = self.nodes[child].root.get();
-        if let NodeState::Error = self.nodes[root].state {
-            self.nodes[child].state = NodeState::Error;
+        if let NodeState::Error = *self.nodes[root].snapshots.top() {
+            self.nodes[child].snapshots.update(current_snapshot, NodeState::Error);
         }
     }
 
@@ -324,21 +393,31 @@ impl<O: Debug> ObligationForest<O> {
     /// remainder of the tree.
     fn backtrace(&mut self, mut p: usize) -> Vec<O> {
         let mut trace = vec![];
+        let current_snapshot = self.current_snapshot();
         loop {
-            let state = mem::replace(&mut self.nodes[p].state, NodeState::Error);
-            match state {
-                NodeState::Pending { obligation } |
-                NodeState::Success { obligation, .. } => {
-                    trace.push(obligation);
+            self.nodes[p].snapshots.update_with(current_snapshot.clone(), |_, state| {
+                match state {
+                    &NodeState::Pending { ref obligation } |
+                    &NodeState::Success { ref obligation, .. } => {
+                        trace.push(obligation.clone());
+                    }
+                    &NodeState::Error => {
+                        // we should not encounter an error, because if
+                        // there was an error in the ancestors, it should
+                        // have been propagated down and we should never
+                        // have tried to process this obligation
+                        panic!("encountered error in node {:?} when collecting stack trace", p);
+                    }
+                    &NodeState::Popped => {
+                        // We should not encounter a popped node, because if there was a popped
+                        // node in the ancestors, it would mean that it was done being used, but
+                        // we're backtracing from a still-in-use node so all parent nodes must be
+                        // aware of this and be in use.
+                        panic!("encountered dead node {:?} when collecting stack trace", p);
+                    }
                 }
-                NodeState::Error => {
-                    // we should not encounter an error, because if
-                    // there was an error in the ancestors, it should
-                    // have been propagated down and we should never
-                    // have tried to process this obligation
-                    panic!("encountered error in node {:?} when collecting stack trace", p);
-                }
-            }
+                Some(NodeState::Error)
+            });
 
             // loop to the parent
             match self.nodes[p].parent {
@@ -350,10 +429,15 @@ impl<O: Debug> ObligationForest<O> {
 
     /// Compresses the vector, removing all popped nodes. This adjusts
     /// the indices and hence invalidates any outstanding
-    /// indices. Cannot be used during a transaction.
+    /// indices.
     fn compress(&mut self) -> Vec<O> {
-        assert!(!self.in_snapshot()); // didn't write code to unroll this action
+        // FIXME have compression move nodes that are popped at the current snapshot to the
+        // end of the nodes array but *before the dead nodes*, s.t. if we started keeping track of
+        // the total number of nodes alive in this snapshot, we could always skip the popped ones.
+        // Or maybe the boatload of swapping is more expensive than just sifting through? I'unno.
+
         let mut rewrites: Vec<_> = (0..self.nodes.len()).collect();
+        let current_snapshot = self.current_snapshot();
 
         // Finish propagating error state. Note that in this case we
         // only have to check immediate parents, rather than all
@@ -361,18 +445,21 @@ impl<O: Debug> ObligationForest<O> {
         // are going to occur.
         let nodes_len = self.nodes.len();
         for i in 0..nodes_len {
-            if !self.nodes[i].is_popped() {
+            if !self.nodes[i].is_popped_at(current_snapshot.clone()) {
                 self.inherit_error(i);
             }
         }
 
         // Now go through and move all nodes that are either
-        // successful or which have an error over into to the end of
-        // the list, preserving the relative order of the survivors
+        // successful or which have an error over to the end of the
+        // list, preserving the relative order of the survivors
         // (which is important for the `inherit_error` logic).
+        //
+        // Note that even in the presence of snapshots this maintains
+        // the pre-ordering of the nodes.
         let mut dead = 0;
         for i in 0..nodes_len {
-            if self.nodes[i].is_popped() {
+            if self.nodes[i].is_dead(current_snapshot.clone()) {
                 dead += 1;
             } else if dead > 0 {
                 self.nodes.swap(i, i - dead);
@@ -382,17 +469,47 @@ impl<O: Debug> ObligationForest<O> {
 
         // Pop off all the nodes we killed and extract the success
         // stories.
-        let successful =
+        let successful_dead: Vec<_> =
             (0 .. dead).map(|_| self.nodes.pop().unwrap())
-                       .flat_map(|node| match node.state {
-                           NodeState::Error => None,
-                           NodeState::Pending { .. } => unreachable!(),
-                           NodeState::Success { obligation, num_incomplete_children } => {
+                       .flat_map(|node| match node.snapshots.top() {
+                           &NodeState::Pending { .. } => unreachable!(),
+                           &NodeState::Popped |
+                           &NodeState::Error => None,
+                           &NodeState::Success { ref obligation, num_incomplete_children } => {
                                assert_eq!(num_incomplete_children, 0);
-                               Some(obligation)
+                               // FIXME introduce a way of just moving the obligation out of the
+                               // top snapshot without triggering a panic.
+                               Some(obligation.clone())
                            }
                        })
                        .collect();
+        // Go through the still-alive successful and error nodes and extract the success stories;
+        // they are then marked in the current snapshot as 'Popped' so that they won't be
+        // reported again.
+        let mut successful: Vec<_> =
+            self.nodes.iter_mut()
+                      .flat_map(|node| {
+                          let mut is_popped = false;
+                          let result = match node.snapshots.top() {
+                              &NodeState::Pending { .. } => None,
+                              &NodeState::Error => { is_popped = true; None },
+                              &NodeState::Success { ref obligation, num_incomplete_children } => {
+                                  if num_incomplete_children == 0 {
+                                      is_popped = true;
+                                      Some(obligation.clone())
+                                  } else {
+                                      None
+                                  }
+                              },
+                              &NodeState::Popped => None,
+                          };
+                          if is_popped {
+                              node.snapshots.update(current_snapshot.clone(), NodeState::Popped);
+                          }
+                          result
+                      })
+                      .collect();
+        successful.extend(successful_dead);
 
         // Adjust the parent indices, since we compressed things.
         for node in &mut self.nodes {
@@ -401,7 +518,6 @@ impl<O: Debug> ObligationForest<O> {
                 debug_assert!(new_index < (nodes_len - dead));
                 *index = NodeIndex::new(new_index);
             }
-
             node.root = NodeIndex::new(rewrites[node.root.get()]);
         }
 
@@ -409,23 +525,219 @@ impl<O: Debug> ObligationForest<O> {
     }
 }
 
+impl Snapshot {
+    fn new_base() -> Snapshot { Snapshot(0) }
+    fn next(&self) -> Snapshot { Snapshot(self.0 + 1) }
+    fn prev(&self) -> Snapshot { assert!(self.0 > 0); Snapshot(self.0 - 1) }
+}
+
+impl<O> NodeStateSnapshots<O> {
+    fn new(snapshot: Snapshot, state: NodeState<O>) -> NodeStateSnapshots<O> {
+        NodeStateSnapshots::Base(NodeStateSnapshot::new(snapshot, state))
+    }
+
+    fn top_snapshot(&self) -> Snapshot {
+        match self {
+            &NodeStateSnapshots::Base(ref base) => base.snapshot.clone(),
+            &NodeStateSnapshots::Stack(ref stack) => stack.last().unwrap().snapshot.clone()
+        }
+    }
+    fn top(&self) -> &NodeState<O> {
+        match self {
+            &NodeStateSnapshots::Base(ref base) => &base.state,
+            &NodeStateSnapshots::Stack(ref stack) => &stack.last().unwrap().state
+        }
+    }
+    fn top_mut(&mut self) -> &mut NodeState<O> {
+        match self {
+            &mut NodeStateSnapshots::Base(ref mut base) => &mut base.state,
+            &mut NodeStateSnapshots::Stack(ref mut stack) => &mut stack.last_mut().unwrap().state
+        }
+    }
+    fn len(&self) -> usize {
+        match self {
+            &NodeStateSnapshots::Base(_) => 1,
+            &NodeStateSnapshots::Stack(ref stack) => stack.len()
+        }
+    }
+
+    /// Pops the given snapshot off of the top of the stack. If the snapshot we have at the top is
+    /// from earlier than the snapshot passed to us, we ignore the pop. If the snapshot we have is
+    /// greater than the snapshot passed to us, we were somehow skipped in the rest of this code
+    /// and we panic.
+    fn pop(&mut self, snapshot: Snapshot) -> Option<NodeState<O>> {
+        match self {
+            &mut NodeStateSnapshots::Stack(ref mut stack) => {
+                match stack.last().unwrap().snapshot.cmp(&snapshot) {
+                    Ordering::Equal => {
+                        let NodeStateSnapshot {snapshot: node_snapshot, state: node_state} =
+                            stack.pop().unwrap();
+                        if stack.is_empty() {
+                            stack.push(NodeStateSnapshot::new(node_snapshot, NodeState::Popped));
+                        }
+                        Some(node_state)
+                    },
+                    Ordering::Less => None,
+                    Ordering::Greater => panic!("failure to maintain stack discipline")
+                }
+            },
+            &mut NodeStateSnapshots::Base(ref mut base) =>
+                match base.snapshot.cmp(&snapshot) {
+                    Ordering::Equal => Some(mem::replace(&mut base.state, NodeState::Popped)),
+                    Ordering::Less => None,
+                    Ordering::Greater => panic!("failure to maintain stack discipline")
+                }
+        }
+    }
+
+    /// Commits from the `from` snapshot down into the `into` snapshot. If the snapshot we have at
+    /// the top is at or earlier than the `into` snapshot passed to us, we don't do anything. If
+    /// the snapshot we have at the top is later than the `from` snapshot passed to us, we were
+    /// somehow skipped in the rest of this code and we panic. Else, we overwrite any snapshot at
+    /// the into_snapshot with the from_snapshot state (or make such a state if it doesn't exist by
+    /// rewriting only the snapshot at the top of the stack).
+    fn commit(&mut self, from_snapshot: Snapshot, into_snapshot: Snapshot) {
+        assert!(from_snapshot.prev() == into_snapshot, "failure to maintain stack discipline");
+        if self.top_snapshot() <= into_snapshot {
+            return;
+        }
+        if self.top_snapshot() > from_snapshot {
+            panic!("failure to maintain stack discipline");
+        }
+        match self {
+            &mut NodeStateSnapshots::Stack(ref mut stack) => {
+                let mut to_commit = stack.pop().unwrap();
+                if stack.is_empty() {
+                } else {
+                    let mut do_push = false;
+                    {
+                        let potential_overwrite = stack.last_mut().unwrap();
+                        if potential_overwrite.snapshot == into_snapshot {
+                            potential_overwrite.state = mem::replace(&mut to_commit.state,
+                                                                     NodeState::Popped);
+                        } else {
+                            do_push = true;
+                        }
+                    }
+                    if do_push {
+                        stack.push(NodeStateSnapshot::new(
+                                into_snapshot,
+                                mem::replace(&mut to_commit.state, NodeState::Popped)));
+                    }
+                }
+            },
+            &mut NodeStateSnapshots::Base(ref mut base) => {
+                base.snapshot = into_snapshot;
+            }
+        }
+    }
+
+    /// Optionally updates the given snapshot at the top of the stack. If the snapshot we have at
+    /// the top is from earlier than the snapshot passed to us, we push the new state. If the
+    /// snapshot we have is from later than the snapshot passed to us, we were somehow skipped in
+    /// the rest of this code and we panic.
+    ///
+    /// The new_state_fn accepts a clone of the latest snapshot on the stack and that snapshot's
+    /// state. It returns Some() if the state at the snapshot passed into `update_with` is to be
+    /// updated, or None if it need not be updated (e.g. to avoid unnecessarily duplicating node
+    /// states and allocations).
+    fn update_with<F>(&mut self, snapshot: Snapshot, new_state_fn: F) -> Option<NodeState<O>>
+        where F: FnOnce(Snapshot, &NodeState<O>) -> Option<NodeState<O>>
+    {
+        let mut old_state = None;
+        let mut rebase = None;
+        match self {
+            &mut NodeStateSnapshots::Stack(ref mut stack) => {
+                let snapshot_cmp = stack.last().unwrap().snapshot.cmp(&snapshot);
+                let new_state = {
+                    let state_snapshot = stack.last_mut().unwrap();
+                    new_state_fn(state_snapshot.snapshot.clone(),
+                                 &state_snapshot.state)
+                };
+                if new_state.is_none() {
+                    // we have nothing to do here
+                    return None;
+                }
+                match snapshot_cmp {
+                    Ordering::Equal => {
+                        old_state = Some(
+                            mem::replace(
+                                stack.last_mut().unwrap(),
+                                NodeStateSnapshot::new(snapshot.clone(),
+                                                       new_state.unwrap())).state);
+                    },
+                    Ordering::Less => {
+                        stack.push(NodeStateSnapshot::new(snapshot.clone(), new_state.unwrap()));
+                    },
+                    Ordering::Greater => panic!("failure to maintain stack discipline")
+                }
+            },
+            &mut NodeStateSnapshots::Base(ref mut base) => {
+                let new_state = new_state_fn(base.snapshot.clone(), &base.state);
+                if new_state.is_none() {
+                    // we have nothing to do here
+                    return None;
+                }
+                match base.snapshot.cmp(&snapshot) {
+                    Ordering::Equal => {
+                        old_state = Some(mem::replace(&mut base.state, new_state.unwrap()));
+                    },
+                    Ordering::Less => {
+                        rebase = Some((mem::replace(base, unsafe { mem::uninitialized() }),
+                                       new_state.unwrap()));
+                    },
+                    Ordering::Greater => panic!("failure to maintain stack discipline")
+                }
+            },
+        }
+        if let Some((base, new_state)) = rebase {
+            let new_self = NodeStateSnapshots::Stack(
+                vec![base, NodeStateSnapshot::new(snapshot.clone(), new_state)]);
+            mem::forget(mem::replace(self, new_self));
+        }
+        old_state
+    }
+    fn update(&mut self, snapshot: Snapshot, new_state: NodeState<O>) -> Option<NodeState<O>> {
+        self.update_with(snapshot, move |_, _| Some(new_state))
+    }
+}
+
 impl<O> Node<O> {
-    fn new(root: NodeIndex, parent: Option<NodeIndex>, obligation: O) -> Node<O> {
+    fn new(snapshot: Snapshot, root: NodeIndex, parent: Option<NodeIndex>, obligation: O)
+        -> Node<O>
+    {
         Node {
             parent: parent,
-            state: NodeState::Pending { obligation: obligation },
+            snapshots: NodeStateSnapshots::new(snapshot,
+                                               NodeState::Pending { obligation: obligation }),
             root: root
         }
     }
 
-    fn is_popped(&self) -> bool {
-        match self.state {
-            NodeState::Pending { .. } => false,
-            NodeState::Success { num_incomplete_children, .. } => num_incomplete_children == 0,
-            NodeState::Error => true,
+    /// Whether or not this node is popped in all snapshots and is not being used by prior
+    /// snapshots.
+    fn is_dead(&self, snapshot: Snapshot) -> bool {
+        assert!(self.snapshots.top_snapshot() <= snapshot, "failure to maintain stack discpline");
+        if self.snapshots.len() > 1 {
+            false
+        } else {
+            self.is_popped_at(snapshot)
+        }
+    }
+
+    /// Whether or not we're done using this node at the given snapshot and it is popped or is
+    /// about to be popped.
+    fn is_popped_at(&self, snapshot: Snapshot) -> bool {
+        assert!(self.snapshots.top_snapshot() <= snapshot, "failure to maintain stack discipline");
+        match self.snapshots.top() {
+            &NodeState::Pending { .. } => false,
+            &NodeState::Success { num_incomplete_children, .. } => num_incomplete_children == 0,
+            &NodeState::Error => true,
+            &NodeState::Popped => true,
         }
     }
 }
+
 
 #[derive(Clone)]
 pub struct Backtrace<'b, O: 'b> {
@@ -446,13 +758,16 @@ impl<'b, O> Iterator for Backtrace<'b, O> {
         debug!("Backtrace: self.pointer = {:?}", self.pointer);
         if let Some(p) = self.pointer {
             self.pointer = self.nodes[p.get()].parent;
-            match self.nodes[p.get()].state {
-                NodeState::Pending { ref obligation } |
-                NodeState::Success { ref obligation, .. } => {
+            match self.nodes[p.get()].snapshots.top() {
+                &NodeState::Pending { ref obligation } |
+                &NodeState::Success { ref obligation, .. } => {
                     Some(obligation)
                 }
-                NodeState::Error => {
+                &NodeState::Error => {
                     panic!("Backtrace encountered an error.");
+                }
+                &NodeState::Popped => {
+                    panic!("Backtrace encountered a popped node.");
                 }
             }
         } else {

--- a/src/librustc_data_structures/obligation_forest/mod.rs
+++ b/src/librustc_data_structures/obligation_forest/mod.rs
@@ -46,7 +46,8 @@ pub struct ObligationForest<O> {
 // once.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Snapshot {
-    len: usize
+    id: usize,
+    len: usize,
 }
 
 pub use self::node_index::NodeIndex;
@@ -150,7 +151,7 @@ impl<O: Debug + Clone> ObligationForest<O> {
     pub fn new() -> ObligationForest<O> {
         ObligationForest {
             nodes: vec![],
-            snapshots: vec![Snapshot::new(0)]
+            snapshots: vec![Snapshot::new(0, 0)]
         }
     }
 
@@ -167,8 +168,7 @@ impl<O: Debug + Clone> ObligationForest<O> {
     /// Get the current snapshot, initiating a new snapshot on top of it.
     pub fn start_snapshot(&mut self) -> Snapshot {
         let current_snapshot = self.current_snapshot();
-        let next_snapshot = Snapshot::new(self.nodes.len());
-        assert!(next_snapshot != current_snapshot);
+        let next_snapshot = current_snapshot.next(self.nodes.len());
         self.snapshots.push(next_snapshot.clone());
         current_snapshot
     }
@@ -744,6 +744,7 @@ impl Default for NodeScratch {
     }
 }
 impl Snapshot {
-    fn new(len: usize) -> Self { Snapshot { len: len } }
+    fn new(id: usize, len: usize) -> Self { Snapshot { id: id, len: len } }
+    fn next(&self, len: usize) -> Self { Snapshot { id: self.id + 1, len: len } }
 }
 

--- a/src/librustc_data_structures/obligation_forest/node_index.rs
+++ b/src/librustc_data_structures/obligation_forest/node_index.rs
@@ -11,7 +11,7 @@
 use core::nonzero::NonZero;
 use std::u32;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NodeIndex {
     index: NonZero<u32>
 }

--- a/src/librustc_data_structures/obligation_forest/test.rs
+++ b/src/librustc_data_structures/obligation_forest/test.rs
@@ -204,3 +204,367 @@ fn backtrace() {
     assert_eq!(ok.len(), 0);
     assert!(err.is_empty());
 }
+
+#[test]
+fn snapshots_0() {
+    let mut forest: ObligationForest<&'static str> = ObligationForest::new();
+    forest.push_root("A");
+    let snap = forest.start_snapshot();
+    let Outcome { completed: ok_snap, errors: err_snap, .. } =
+        forest.process_obligations::<(),_>(|obligation, _| {
+            match *obligation {
+                "A" => Ok(Some(vec![])),
+                _ => unreachable!()
+            }
+        });
+    assert_eq!(ok_snap, vec!["A"]);
+    assert_eq!(err_snap, vec![]);
+
+    forest.rollback_snapshot(snap);
+    let Outcome { completed: ok, errors: err, .. } =
+        forest.process_obligations::<(),_>(|obligation, _| {
+            match *obligation {
+                "A" => Ok(Some(vec![])),
+                _ => unreachable!()
+            }
+        });
+    assert_eq!(ok, vec!["A"]);
+    assert_eq!(err, vec![]);
+}
+
+// Like push_pop, but with snapshots taken in various places without rollbacks until the very end.
+#[test]
+fn snapshots_1() {
+    let mut forest = ObligationForest::new();
+    let mut snapshots = Vec::new();
+    forest.push_root("A");
+    forest.push_root("B");
+    snapshots.push(forest.start_snapshot());
+    forest.push_root("C");
+
+    // first round, B errors out, A has subtasks, and C completes, creating this:
+    //      A |-> A.1
+    //        |-> A.2
+    //        |-> A.3
+    let Outcome { completed: ok, errors: err, .. } = forest.process_obligations(|obligation, _| {
+        match *obligation {
+            "A" => Ok(Some(vec!["A.1", "A.2", "A.3"])),
+            "B" => Err("B is for broken"),
+            "C" => Ok(Some(vec![])),
+            _ => unreachable!(),
+        }
+    });
+    assert_eq!(ok, vec!["C"]);
+    assert_eq!(err, vec![Error {error: "B is for broken",
+                                backtrace: vec!["B"]}]);
+    snapshots.push(forest.start_snapshot());
+
+    // second round: two delays, one success, creating an uneven set of subtasks:
+    //      A |-> A.1
+    //        |-> A.2
+    //        |-> A.3 |-> A.3.i
+    //      D |-> D.1
+    //        |-> D.2
+    forest.push_root("D");
+    snapshots.push(forest.start_snapshot());
+    let Outcome { completed: ok, errors: err, .. }: Outcome<&'static str, ()> =
+        forest.process_obligations(|obligation, _| {
+            match *obligation {
+                "A.1" => Ok(None),
+                "A.2" => Ok(None),
+                "A.3" => Ok(Some(vec!["A.3.i"])),
+                "D" => Ok(Some(vec!["D.1", "D.2"])),
+                _ => unreachable!(),
+            }
+        });
+    assert_eq!(ok, Vec::<&'static str>::new());
+    assert_eq!(err, Vec::new());
+
+
+    // third round: ok in A.1 but trigger an error in A.2. Check that it
+    // propagates to A.3.i, but not D.1 or D.2.
+    //      D |-> D.1 |-> D.1.i
+    //        |-> D.2 |-> D.2.i
+    let Outcome { completed: ok, errors: err, .. } = forest.process_obligations(|obligation, _| {
+        match *obligation {
+            "A.1" => Ok(Some(vec![])),
+            "A.2" => Err("A is for apple"),
+            "D.1" => Ok(Some(vec!["D.1.i"])),
+            "D.2" => Ok(Some(vec!["D.2.i"])),
+            _ => unreachable!(),
+        }
+    });
+    assert_eq!(ok, vec!["A.1"]);
+    assert_eq!(err, vec![Error { error: "A is for apple",
+                                 backtrace: vec!["A.2", "A"] }]);
+    snapshots.push(forest.start_snapshot());
+
+    // fourth round: error in D.1.i that should propagate to D.2.i
+    let Outcome { completed: ok, errors: err, .. } = forest.process_obligations(|obligation, _| {
+        match *obligation {
+            "D.1.i" => Err("D is for dumb"),
+            _ => panic!("unexpected obligation {:?}", obligation),
+        }
+    });
+    assert_eq!(ok, Vec::<&'static str>::new());
+    assert_eq!(err, vec![Error { error: "D is for dumb",
+                                 backtrace: vec!["D.1.i", "D.1", "D"] }]);
+    while let Some(snapshot) = snapshots.pop() {
+        forest.rollback_snapshot(snapshot);
+    }
+    // All we should be left with are the two roots "A" and "B" as Pending.
+    let Outcome { completed: ok, errors: err, .. } = forest.process_obligations(|obligation, _| {
+        match *obligation {
+            "A" => Ok(Some(vec![])),
+            "B" => Err("B is for broken"),
+            _ => unreachable!(),
+        }
+    });
+    assert_eq!(ok, vec!["A"]);
+    assert_eq!(err, vec![Error { error: "B is for broken",
+                                 backtrace: vec!["B"] }]);
+}
+
+// Like push_pop, but with snapshots, rollbacks, and commits interspersed throughout.
+#[test]
+fn snapshots_2() {
+    let mut forest: ObligationForest<&'static str> = ObligationForest::new();
+    let mut snapshots = Vec::new();
+    // Snapshots: |
+    forest.push_root("A");
+    forest.push_root("B");
+    // Snapshots: | -> |
+    snapshots.push(forest.start_snapshot());
+    forest.push_root("C");
+    // Snapshots: |
+    forest.rollback_snapshot(snapshots.pop().unwrap());
+
+    // Snapshots: | -> |
+    snapshots.push(forest.start_snapshot());
+
+    // first round, B errors out, A has subtasks, and C completes, creating this:
+    //      A |-> A.1
+    //        |-> A.2
+    //        |-> A.3
+    let Outcome { completed: ok, errors: err, .. } = forest.process_obligations(|obligation, _| {
+        match *obligation {
+            "A" => Ok(Some(vec!["A.1", "A.2", "A.3"])),
+            "B" => Err("B is for broken"),
+            "C" => panic!("C shouldn't exist after being rolled back"),
+            _ => unreachable!(),
+        }
+    });
+    assert!(ok.is_empty());
+    assert_eq!(err, vec![Error {error: "B is for broken",
+                                backtrace: vec!["B"]}]);
+
+    forest.push_root("C");
+
+    // Snapshots: | -> | -> |
+    snapshots.push(forest.start_snapshot());
+
+    // second round: two delays, one success, creating an uneven set of subtasks:
+    //      A |-> A.1
+    //        |-> A.2
+    //        |-> A.3 |-> A.3.i
+    //      D |-> D.1
+    //        |-> D.2
+    forest.push_root("D");
+    // Snapshots: | -> | -> | -> |
+    snapshots.push(forest.start_snapshot());
+    let Outcome { completed: ok, errors: err, .. }: Outcome<&'static str, ()> =
+        forest.process_obligations(|obligation, _| {
+            match *obligation {
+                "A.1" => Ok(None),
+                "A.2" => Ok(None),
+                "A.3" => Ok(Some(vec!["A.3.i"])),
+                "C" => Ok(Some(vec![])),
+                "D" => Ok(Some(vec!["D.1", "D.2"])),
+                _ => unreachable!(),
+            }
+        });
+    assert_eq!(ok, vec!["C"]);
+    assert_eq!(err, Vec::new());
+
+    // Undo the entire previous action with uneven subtasks, then do it again
+    // Snapshots: | -> | -> |
+    forest.rollback_snapshot(snapshots.pop().unwrap());
+
+    // Snapshots: | -> | -> | -> |
+    snapshots.push(forest.start_snapshot());
+    let Outcome { completed: ok, errors: err, .. }: Outcome<&'static str, ()> =
+        forest.process_obligations(|obligation, _| {
+            match *obligation {
+                "A.1" => Ok(None),
+                "A.2" => Ok(None),
+                "A.3" => Ok(Some(vec!["A.3.i"])),
+                "C" => Ok(Some(vec![])),
+                "D" => Ok(Some(vec!["D.1", "D.2"])),
+                _ => unreachable!(),
+            }
+        });
+    assert_eq!(ok, vec!["C"]);
+    assert_eq!(err, Vec::new());
+
+    // Snapshots: | -> | -> |
+    forest.commit_snapshot(snapshots.pop().unwrap());
+
+    // third round: ok in A.1 but trigger an error in A.2. Check that it
+    // propagates to A.3.i, but not D.1 or D.2.
+    //      D |-> D.1 |-> D.1.i
+    //        |-> D.2 |-> D.2.i
+    let Outcome { completed: ok, errors: err, .. } = forest.process_obligations(|obligation, _| {
+        match *obligation {
+            "A.1" => Ok(Some(vec![])),
+            "A.2" => Err("A is for apple"),
+            "D.1" => Ok(Some(vec!["D.1.i"])),
+            "D.2" => Ok(Some(vec!["D.2.i"])),
+            _ => unreachable!(),
+        }
+    });
+    assert_eq!(ok, vec!["A.1"]);
+    assert_eq!(err, vec![Error { error: "A is for apple",
+                                 backtrace: vec!["A.2", "A"] }]);
+
+    // fourth round: error in D.1.i that should propagate to D.2.i
+    let Outcome { completed: ok, errors: err, .. } = forest.process_obligations(|obligation, _| {
+        match *obligation {
+            "D.1.i" => Err("D is for dumb"),
+            _ => panic!("unexpected obligation {:?}", obligation),
+        }
+    });
+    assert_eq!(ok, Vec::<&'static str>::new());
+    assert_eq!(err, vec![Error { error: "D is for dumb",
+                                 backtrace: vec!["D.1.i", "D.1", "D"] }]);
+    while let Some(snapshot) = snapshots.pop() {
+        forest.rollback_snapshot(snapshot);
+    }
+
+    // All we should be left with are the two roots "A" and "B" as Pending.
+    let Outcome { completed: ok, errors: err, .. } = forest.process_obligations(|obligation, _| {
+        match *obligation {
+            "A" => Ok(Some(vec![])),
+            "B" => Err("B is for broken"),
+            _ => unreachable!(),
+        }
+    });
+    assert_eq!(ok, vec!["A"]);
+    assert_eq!(err, vec![Error { error: "B is for broken",
+                                 backtrace: vec!["B"] }]);
+}
+
+// Like to_errors_no_throw, but with snapshots taken and rolled back.
+#[test]
+fn snapshots_3() {
+    // check that converting multiple children with common parent (A)
+    // only yields one of them (and does not panic, in particular).
+    let mut forest = ObligationForest::new();
+    let mut snapshots = Vec::new();
+    forest.push_root("A");
+    snapshots.push(forest.start_snapshot());
+    let Outcome { completed: ok, errors: err, .. } =
+        forest.process_obligations::<(),_>(|obligation, _| {
+            match *obligation {
+                "A" => Ok(Some(vec!["A.1", "A.2", "A.3"])),
+                _ => unreachable!(),
+            }
+        });
+    assert_eq!(ok.len(), 0);
+    assert_eq!(err.len(), 0);
+    let errors = forest.to_errors(());
+    assert_eq!(errors.len(), 1);
+    forest.rollback_snapshot(snapshots.pop().unwrap());
+    let Outcome { completed: ok, errors: err, .. } =
+        forest.process_obligations::<(),_>(|obligation, _| {
+            match *obligation {
+                "A" => Ok(Some(vec!["A.1", "A.2", "A.3"])),
+                _ => unreachable!(),
+            }
+        });
+    assert_eq!(ok.len(), 0);
+    assert_eq!(err.len(), 0);
+    let errors = forest.to_errors(());
+    assert_eq!(errors.len(), 1);
+}
+
+// Like backtrace, but with snapshots taken and rolled back.
+#[test]
+fn snapshots_4() {
+    // check that converting multiple children with common parent (A)
+    // only yields one of them (and does not panic, in particular).
+    let mut forest: ObligationForest<&'static str> = ObligationForest::new();
+    let mut snapshots = Vec::new();
+    forest.push_root("A");
+    snapshots.push(forest.start_snapshot());
+    let Outcome { completed: ok, errors: err, .. } =
+        forest.process_obligations::<(),_>(|obligation, mut backtrace| {
+            assert!(backtrace.next().is_none());
+            match *obligation {
+                "A" => Ok(Some(vec!["A.1"])),
+                _ => unreachable!(),
+            }
+        });
+    assert!(ok.is_empty());
+    assert!(err.is_empty());
+    let Outcome { completed: ok, errors: err, .. } =
+        forest.process_obligations::<(),_>(|obligation, mut backtrace| {
+            assert!(backtrace.next().unwrap() == &"A");
+            assert!(backtrace.next().is_none());
+            match *obligation {
+                "A.1" => Ok(Some(vec!["A.1.i"])),
+                _ => unreachable!(),
+            }
+        });
+    assert!(ok.is_empty());
+    assert!(err.is_empty());
+    snapshots.push(forest.start_snapshot());
+    let Outcome { completed: ok, errors: err, .. } =
+        forest.process_obligations::<(),_>(|obligation, mut backtrace| {
+            assert!(backtrace.next().unwrap() == &"A.1");
+            assert!(backtrace.next().unwrap() == &"A");
+            assert!(backtrace.next().is_none());
+            match *obligation {
+                "A.1.i" => Ok(None),
+                _ => unreachable!(),
+            }
+        });
+    assert_eq!(ok.len(), 0);
+    assert!(err.is_empty());
+    forest.commit_snapshot(snapshots.pop().unwrap());
+    forest.rollback_snapshot(snapshots.pop().unwrap());
+    // We should be back to just having "A" as the only pending root.
+    let Outcome { completed: ok, errors: err, .. } =
+        forest.process_obligations::<(),_>(|obligation, mut backtrace| {
+            assert!(backtrace.next().is_none());
+            match *obligation {
+                "A" => Ok(Some(vec!["A.1"])),
+                _ => unreachable!(),
+            }
+        });
+    assert!(ok.is_empty());
+    assert!(err.is_empty());
+    let Outcome { completed: ok, errors: err, .. } =
+        forest.process_obligations::<(),_>(|obligation, mut backtrace| {
+            assert!(backtrace.next().unwrap() == &"A");
+            assert!(backtrace.next().is_none());
+            match *obligation {
+                "A.1" => Ok(Some(vec!["A.1.i"])),
+                _ => unreachable!(),
+            }
+        });
+    assert!(ok.is_empty());
+    assert!(err.is_empty());
+    let Outcome { completed: ok, errors: err, .. } =
+        forest.process_obligations::<(),_>(|obligation, mut backtrace| {
+            assert!(backtrace.next().unwrap() == &"A.1");
+            assert!(backtrace.next().unwrap() == &"A");
+            assert!(backtrace.next().is_none());
+            match *obligation {
+                "A.1.i" => Ok(None),
+                _ => unreachable!(),
+            }
+        });
+    assert_eq!(ok.len(), 0);
+    assert!(err.is_empty());
+}
+


### PR DESCRIPTION
Adds snapshotting to `ObligationForest`. The choice of using per-node vecs instead of additional tables or duplication was made under the assumption that if some node was getting hit with a snapshot+rollback, it'd probably get hit with another snapshot in the near future, and that we'd rather branch on superfluous nodes than (re)allocate some number of times at each snapshot. I haven't actually written the alternatives to test the potential performance difference though.

I think I recall a <1% drop in runtime performance with this on top of the previous incarnation of `ObligationForest` on `libsyntax` at cursory glance. Can check again if desired.

There are several FIXMEs sprinkled around. Mostly miscellaneous opportunities to perhaps optimize a bit.

r? @nikomatsakis (I think?)
cc @jroesch 

EDIT: Needs tidying.
