### PR TITLE
Fix SocketAddrV6::flowinfo docs

### DIFF
--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -140,13 +140,13 @@ impl SocketAddrV6 {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn port(&self) -> u16 { ntoh(self.inner.sin6_port) }
 
-    /// Returns scope ID associated with this address, corresponding to the
-    /// `sin6_flowinfo` field in C.
+    /// Returns the flow information associated with this address,
+    /// corresponding to the `sin6_flowinfo` field in C.
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn flowinfo(&self) -> u32 { ntoh(self.inner.sin6_flowinfo) }
 
-    /// Returns scope ID associated with this address, corresponding to the
-    /// `sin6_scope_id` field in C.
+    /// Returns the scope ID associated with this address,
+    /// corresponding to the `sin6_scope_id` field in C.
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn scope_id(&self) -> u32 { ntoh(self.inner.sin6_scope_id) }
 }


### PR DESCRIPTION
I don’t understand what the "flow information" of an IPv6 address is, but it looks separate from the scope ID. This was probably a copy/paste error.
