### PR TITLE
Fix variance of BTreeMap and its companion structs.

### DIFF
--- a/src/libcollectionstest/btree/map.rs
+++ b/src/libcollectionstest/btree/map.rs
@@ -378,6 +378,22 @@ fn test_clone() {
     }
 }
 
+#[test]
+fn test_variance() {
+    use std::collections::btree_map::{Iter, IntoIter, Range, Keys, Values};
+
+    fn map_key<'new>(v: BTreeMap<&'static str, ()>) -> BTreeMap<&'new str, ()> { v }
+    fn map_val<'new>(v: BTreeMap<(), &'static str>) -> BTreeMap<(), &'new str> { v }
+    fn iter_key<'a, 'new>(v: Iter<'a, &'static str, ()>) -> Iter<'a, &'new str, ()> { v }
+    fn iter_val<'a, 'new>(v: Iter<'a, (), &'static str>) -> Iter<'a, (), &'new str> { v }
+    fn into_iter_key<'new>(v: IntoIter<&'static str, ()>) -> IntoIter<&'new str, ()> { v }
+    fn into_iter_val<'new>(v: IntoIter<(), &'static str>) -> IntoIter<(), &'new str> { v }
+    fn range_key<'a, 'new>(v: Range<'a, &'static str, ()>) -> Range<'a, &'new str, ()> { v }
+    fn range_val<'a, 'new>(v: Range<'a, (), &'static str>) -> Range<'a, (), &'new str> { v }
+    fn keys<'a, 'new>(v: Keys<'a, &'static str, ()>) -> Keys<'a, &'new str, ()> { v }
+    fn vals<'a, 'new>(v: Values<'a, (), &'static str>) -> Values<'a, (), &'new str> { v }
+}
+
 mod bench {
     use std::collections::BTreeMap;
     use std::__rand::{Rng, thread_rng};

--- a/src/test/compile-fail/variance-btree-invariant-types.rs
+++ b/src/test/compile-fail/variance-btree-invariant-types.rs
@@ -1,0 +1,56 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_attrs)]
+
+use std::collections::btree_map::{IterMut, OccupiedEntry, VacantEntry};
+
+macro_rules! test_invariant {
+    { $m:ident $t:ident } => {
+        mod $m {
+            use std::collections::btree_map::{IterMut, OccupiedEntry, VacantEntry};
+
+            fn not_covariant_key<'a, 'min,'max>(v: $t<'a, &'max (), ()>)
+                                                -> $t<'a, &'min (), ()>
+                where 'max : 'min
+            {
+                v //~ ERROR mismatched types
+            }
+
+            fn not_contravariant_key<'a, 'min,'max>(v: $t<'a, &'min (), ()>)
+                                                    -> $t<'a, &'max (), ()>
+                where 'max : 'min
+            {
+                v //~ ERROR mismatched types
+            }
+
+            fn not_covariant_val<'a, 'min,'max>(v: $t<'a, (), &'max ()>)
+                                                -> $t<'a, (), &'min ()>
+                where 'max : 'min
+            {
+                v //~ ERROR mismatched types
+            }
+
+            fn not_contravariant_val<'a, 'min,'max>(v: $t<'a, (), &'min ()>)
+                                                    -> $t<'a, (), &'max ()>
+                where 'max : 'min
+            {
+                v //~ ERROR mismatched types
+            }
+        }
+    }
+}
+
+test_invariant! { foo IterMut }
+test_invariant! { bar OccupiedEntry }
+test_invariant! { baz VacantEntry }
+
+#[rustc_error]
+fn main() { }

--- a/src/test/compile-fail/variance-btree-invariant-types.rs
+++ b/src/test/compile-fail/variance-btree-invariant-types.rs
@@ -12,45 +12,52 @@
 
 use std::collections::btree_map::{IterMut, OccupiedEntry, VacantEntry};
 
-macro_rules! test_invariant {
-    { $m:ident $t:ident } => {
-        mod $m {
-            use std::collections::btree_map::{IterMut, OccupiedEntry, VacantEntry};
-
-            fn not_covariant_key<'a, 'min,'max>(v: $t<'a, &'max (), ()>)
-                                                -> $t<'a, &'min (), ()>
-                where 'max : 'min
-            {
-                v //~ ERROR mismatched types
-            }
-
-            fn not_contravariant_key<'a, 'min,'max>(v: $t<'a, &'min (), ()>)
-                                                    -> $t<'a, &'max (), ()>
-                where 'max : 'min
-            {
-                v //~ ERROR mismatched types
-            }
-
-            fn not_covariant_val<'a, 'min,'max>(v: $t<'a, (), &'max ()>)
-                                                -> $t<'a, (), &'min ()>
-                where 'max : 'min
-            {
-                v //~ ERROR mismatched types
-            }
-
-            fn not_contravariant_val<'a, 'min,'max>(v: $t<'a, (), &'min ()>)
-                                                    -> $t<'a, (), &'max ()>
-                where 'max : 'min
-            {
-                v //~ ERROR mismatched types
-            }
-        }
-    }
+fn iter_cov_key<'a, 'new>(v: IterMut<'a, &'static (), ()>) -> IterMut<'a, &'new (), ()> {
+    v //~ ERROR mismatched types
+}
+fn iter_cov_val<'a, 'new>(v: IterMut<'a, (), &'static ()>) -> IterMut<'a, (), &'new ()> {
+    v //~ ERROR mismatched types
+}
+fn iter_contra_key<'a, 'new>(v: IterMut<'a, &'new (), ()>) -> IterMut<'a, &'static (), ()> {
+    v //~ ERROR mismatched types
+}
+fn iter_contra_val<'a, 'new>(v: IterMut<'a, (), &'new ()>) -> IterMut<'a, (), &'static ()> {
+    v //~ ERROR mismatched types
 }
 
-test_invariant! { foo IterMut }
-test_invariant! { bar OccupiedEntry }
-test_invariant! { baz VacantEntry }
+fn occ_cov_key<'a, 'new>(v: OccupiedEntry<'a, &'static (), ()>)
+                         -> OccupiedEntry<'a, &'new (), ()> {
+    v //~ ERROR mismatched types
+}
+fn occ_cov_val<'a, 'new>(v: OccupiedEntry<'a, (), &'static ()>)
+                         -> OccupiedEntry<'a, (), &'new ()> {
+    v //~ ERROR mismatched types
+}
+fn occ_contra_key<'a, 'new>(v: OccupiedEntry<'a, &'new (), ()>)
+                            -> OccupiedEntry<'a, &'static (), ()> {
+    v //~ ERROR mismatched types
+}
+fn occ_contra_val<'a, 'new>(v: OccupiedEntry<'a, (), &'new ()>)
+                            -> OccupiedEntry<'a, (), &'static ()> {
+    v //~ ERROR mismatched types
+}
+
+fn vac_cov_key<'a, 'new>(v: VacantEntry<'a, &'static (), ()>)
+                         -> VacantEntry<'a, &'new (), ()> {
+    v //~ ERROR mismatched types
+}
+fn vac_cov_val<'a, 'new>(v: VacantEntry<'a, (), &'static ()>)
+                         -> VacantEntry<'a, (), &'new ()> {
+    v //~ ERROR mismatched types
+}
+fn vac_contra_key<'a, 'new>(v: VacantEntry<'a, &'new (), ()>)
+                            -> VacantEntry<'a, &'static (), ()> {
+    v //~ ERROR mismatched types
+}
+fn vac_contra_val<'a, 'new>(v: VacantEntry<'a, (), &'new ()>)
+                            -> VacantEntry<'a, (), &'static ()> {
+    v //~ ERROR mismatched types
+}
 
 #[rustc_error]
 fn main() { }


### PR DESCRIPTION
This takes the approach of making `NodeRef` universally covariant.

 Fixes #30979.
