### PR TITLE
Downgrade bundled jemalloc version

### DIFF
--- a/configure
+++ b/configure
@@ -550,7 +550,7 @@ CFG_SELF="$0"
 CFG_CONFIGURE_ARGS="$@"
 
 
-case "${CFG_SRC_DIR}" in  
+case "${CFG_SRC_DIR}" in
     *\ * )
         err "The path to the rust source directory contains spaces, which is not supported"
         ;;
@@ -889,6 +889,13 @@ then
     fi
 
     step_msg "on OpenBSD, disabling jemalloc"
+    CFG_DISABLE_JEMALLOC=1
+fi
+
+if [ $CFG_OSTYPE = pc-windows-gnu ]
+then
+    # FIXME(#31030) - there's not a great reason to disable jemalloc here
+    step_msg "on Windows, disabling jemalloc"
     CFG_DISABLE_JEMALLOC=1
 fi
 

--- a/src/test/compile-fail/allocator-dylib-is-system.rs
+++ b/src/test/compile-fail/allocator-dylib-is-system.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-msvc everything is the system allocator on msvc
+// ignore-windows everything is the system allocator on windows
 // ignore-musl no dylibs on musl yet
 // ignore-bitrig no jemalloc on bitrig
 // ignore-openbsd no jemalloc on openbsd

--- a/src/test/compile-fail/allocator-rust-dylib-is-jemalloc.rs
+++ b/src/test/compile-fail/allocator-rust-dylib-is-jemalloc.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-msvc everything is the system allocator on msvc
+// ignore-windows everything is the system allocator on windows
 // ignore-musl no dylibs on musl right now
 // ignore-bitrig no jemalloc on bitrig
 // ignore-openbsd no jemalloc on openbsd

--- a/src/test/run-pass/allocator-default.rs
+++ b/src/test/run-pass/allocator-default.rs
@@ -10,9 +10,9 @@
 
 #![feature(alloc_jemalloc, alloc_system)]
 
-#[cfg(not(any(target_env = "msvc", target_os = "bitrig", target_os = "openbsd")))]
+#[cfg(not(any(windows, target_os = "bitrig", target_os = "openbsd")))]
 extern crate alloc_jemalloc;
-#[cfg(any(target_env = "msvc", target_os = "bitrig", target_os = "openbsd"))]
+#[cfg(any(windows, target_os = "bitrig", target_os = "openbsd"))]
 extern crate alloc_system;
 
 fn main() {

--- a/src/test/run-pass/allocator-jemalloc.rs
+++ b/src/test/run-pass/allocator-jemalloc.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // no-prefer-dynamic
-// ignore-msvc no jemalloc on msvc
+// ignore-windows no jemalloc on windows
 // ignore-bitrig no jemalloc on bitrig
 // ignore-openbsd no jemalloc on openbsd
 


### PR DESCRIPTION
We've been seeing a lot of timeouts in tests on the bots and investigation ended
pointing to jemalloc/jemalloc#315 as the culprit. Unfortunately it looks like
that doesn't seem to have a fix on the way soon, so let's temporarily downgrade
back to the previous version of jemalloc we were using (where #30434 was the
most recent upgrade)
