### PR TITLE
Fix C macro example

### DIFF
--- a/src/doc/book/macros.md
+++ b/src/doc/book/macros.md
@@ -285,9 +285,11 @@ This expands to
 
 ```text
 const char *state = "reticulating splines";
-int state = get_log_state();
-if (state > 0) {
-    printf("log(%d): %s\n", state, state);
+{
+    int state = get_log_state();
+    if (state > 0) {
+        printf("log(%d): %s\n", state, state);
+    }
 }
 ```
 


### PR DESCRIPTION
Sorry for nitpicking, but I think the example of the expanded macro should be wrapped inside a pair of curly braces to match the macro definition. Also the current example triggers a variable redefinition error. 
