### PR TITLE
Fix LLVM default CPU on powerpc64 and powerpc64le

### DIFF
--- a/src/librustc_back/target/powerpc64_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/powerpc64_unknown_linux_gnu.rs
@@ -12,6 +12,7 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::linux_base::opts();
+    base.cpu = "ppc64".to_string();
     base.pre_link_args.push("-m64".to_string());
 
     Target {

--- a/src/librustc_back/target/powerpc64le_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/powerpc64le_unknown_linux_gnu.rs
@@ -12,6 +12,7 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::linux_base::opts();
+    base.cpu = "ppc64le".to_string();
     base.pre_link_args.push("-m64".to_string());
 
     Target {


### PR DESCRIPTION
We currently pass generic as the CPU to LLVM. This results in worse
than required code generation. On little endian, which is only POWER8,
we avoid many POWER4 and newer instructions.

Pass ppc64 and ppc64le instead.
