### PR TITLE
Allow clang 7.x in configuration

### DIFF
--- a/configure
+++ b/configure
@@ -1035,7 +1035,7 @@ then
         if [ -n "$CFG_OSX_CLANG_VERSION" ]
         then
             case $CFG_OSX_CLANG_VERSION in
-                (7.0*)
+                (7.*)
                 step_msg "found ok version of APPLE CLANG: $CFG_OSX_CLANG_VERSION"
                 ;;
                 (*)

--- a/configure
+++ b/configure
@@ -1035,7 +1035,7 @@ then
         if [ -n "$CFG_OSX_CLANG_VERSION" ]
         then
             case $CFG_OSX_CLANG_VERSION in
-                (7.*)
+                (7.0* | 7.1* | 7.2*)
                 step_msg "found ok version of APPLE CLANG: $CFG_OSX_CLANG_VERSION"
                 ;;
                 (*)


### PR DESCRIPTION
I'm using clang 7.2 which works just fine to compile Rust with, but was disallowed.
