### PR TITLE
Fix type parameter default error to mention type and trait definitions

### DIFF
--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1922,8 +1922,8 @@ fn get_or_create_type_parameter_def<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
                 lint::builtin::INVALID_TYPE_PARAM_DEFAULT,
                 param.id,
                 param.span,
-                format!("defaults for type parameters are only allowed on type definitions, \
-                         like `struct` or `enum`"));
+                format!("defaults for type parameters are only allowed in `struct`, \
+                         `enum`, `type`, or `trait` definitions."));
         }
     }
 


### PR DESCRIPTION
Fix type parameter default error to mention type and trait definitions

Introduced in PR #30724, needs to mention that type parameter defaults
are legal in trait and type definitions too.
