### PR TITLE
Copyright year set to initial

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -6,7 +6,7 @@ terms.
 
 Longer version:
 
-The Rust Project is copyright 2016, The Rust Project
+The Rust Project is copyright 2010, The Rust Project
 Developers.
 
 Licensed under the Apache License, Version 2.0

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2016 The Rust Project Developers
+Copyright (c) 2010 The Rust Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
According to http://www.copyright.gov/circs/circ01.pdf (See screenshot of relevant section below) , listing the first year of publication in the copyright is enough

![selection_008](https://cloud.githubusercontent.com/assets/829526/12409934/7021c3a6-be95-11e5-8d1a-18f6948571e0.png)

The commits d5c8f626a8e4c5166833 and f979f91ae20b2da9b24140334 have changed the copyright years

This commit reverts back those changes, so that license year is again 2014 (As it was, when this license was first introduced in commit 90ba013bde2396f200196  )

---

Edit 1: Added screenshot 
