### PR TITLE
Implement `nth`, `count`, and `last` for `EscapeUnicode`

### DIFF
--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -299,14 +299,16 @@ impl CharExt for char {
 
     #[inline]
     fn escape_unicode(self) -> EscapeUnicode {
-        let mut n = 0;
-        while (self as u32) >> (4 * (n + 1)) != 0 {
-            n += 1;
-        }
+        let c = self as u32;
+        // or-ing 1 ensures that for c==0 the code computes that one
+        // digit should be printed and (which is the same) avoids the
+        // (31 - 32) underflow
+        let msb = 31 - (c | 1).leading_zeros();
+        let msdigit = msb / 4;
         EscapeUnicode {
             c: self,
             state: EscapeUnicodeState::Backslash,
-            offset: n,
+            offset: msdigit as usize,
         }
     }
 

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -491,6 +491,11 @@ impl Iterator for EscapeUnicode {
         let n = n + self.offset;
         (n, Some(n))
     }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.len()
+    }
 }
 
 #[stable(feature = "rust1", since = "1.7.0")]
@@ -545,13 +550,9 @@ impl Iterator for EscapeDefault {
         }
     }
 
+    #[inline]
     fn count(self) -> usize {
-        match self.state {
-            EscapeDefaultState::Char(_) => 1,
-            EscapeDefaultState::Unicode(iter) => iter.count(),
-            EscapeDefaultState::Done => 0,
-            EscapeDefaultState::Backslash(_) => 2,
-        }
+        self.len()
     }
 
     fn nth(&mut self, n: usize) -> Option<char> {

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -466,6 +466,23 @@ impl Iterator for EscapeUnicode {
         self.len()
     }
 
+    fn nth(&mut self, n: usize) -> Option<char> {
+        let remaining = self.len().saturating_sub(n);
+
+        // offset = (number of hex digits still to be emitted) - 1
+        // It can be computed from the remaining number of items by keeping
+        // into account that:
+        // - offset can never increase
+        // - the last 2 items (last hex digit, '}') are not counted in offset
+        let offset = ::cmp::min(self.offset, remaining.saturating_sub(2));
+
+        // state = number of items to be emitted for the state (as per state_len())
+        // It can be computed because (remaining number of items) = state + offset
+        let state = remaining - offset;
+
+        self.step(state, offset)
+    }
+
     fn last(self) -> Option<char> {
         match self.state {
             EscapeUnicodeState::Done => None,

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -571,7 +571,7 @@ pub struct EscapeDefault {
 
 #[derive(Clone)]
 enum EscapeDefaultState {
-    Done,
+    Done(char),
     Char(char),
     Backslash(char),
     Unicode(EscapeUnicode),
@@ -588,10 +588,10 @@ impl Iterator for EscapeDefault {
                 Some('\\')
             }
             EscapeDefaultState::Char(c) => {
-                self.state = EscapeDefaultState::Done;
+                self.state = EscapeDefaultState::Done(c);
                 Some(c)
             }
-            EscapeDefaultState::Done => None,
+            EscapeDefaultState::Done(_) => None,
             EscapeDefaultState::Unicode(ref mut iter) => iter.next(),
         }
     }
@@ -614,15 +614,15 @@ impl Iterator for EscapeDefault {
                 Some('\\')
             },
             EscapeDefaultState::Backslash(c) if n == 1 => {
-                self.state = EscapeDefaultState::Done;
+                self.state = EscapeDefaultState::Done(c);
                 Some(c)
             },
-            EscapeDefaultState::Backslash(_) => {
-                self.state = EscapeDefaultState::Done;
+            EscapeDefaultState::Backslash(c) => {
+                self.state = EscapeDefaultState::Done(c);
                 None
             },
             EscapeDefaultState::Char(c) => {
-                self.state = EscapeDefaultState::Done;
+                self.state = EscapeDefaultState::Done(c);
 
                 if n == 0 {
                     Some(c)
@@ -630,7 +630,7 @@ impl Iterator for EscapeDefault {
                     None
                 }
             },
-            EscapeDefaultState::Done => return None,
+            EscapeDefaultState::Done(_) => return None,
             EscapeDefaultState::Unicode(ref mut i) => return i.nth(n),
         }
     }
@@ -638,7 +638,7 @@ impl Iterator for EscapeDefault {
     fn last(self) -> Option<char> {
         match self.state {
             EscapeDefaultState::Unicode(iter) => iter.last(),
-            EscapeDefaultState::Done => None,
+            EscapeDefaultState::Done(_) => None,
             EscapeDefaultState::Backslash(c) | EscapeDefaultState::Char(c) => Some(c),
         }
     }
@@ -648,7 +648,7 @@ impl Iterator for EscapeDefault {
 impl ExactSizeIterator for EscapeDefault {
     fn len(&self) -> usize {
         match self.state {
-            EscapeDefaultState::Done => 0,
+            EscapeDefaultState::Done(_) => 0,
             EscapeDefaultState::Char(_) => 1,
             EscapeDefaultState::Backslash(_) => 2,
             EscapeDefaultState::Unicode(ref iter) => iter.len(),

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -15,7 +15,7 @@
 #![allow(non_snake_case)]
 #![stable(feature = "core_char", since = "1.2.0")]
 
-use iter::Iterator;
+use iter::{Iterator, ExactSizeIterator};
 use mem::transmute;
 use option::Option::{None, Some};
 use option::Option;
@@ -493,6 +493,9 @@ impl Iterator for EscapeUnicode {
     }
 }
 
+#[stable(feature = "rust1", since = "1.7.0")]
+impl ExactSizeIterator for EscapeUnicode { }
+
 /// An iterator that yields the literal escape code of a `char`.
 ///
 /// This `struct` is created by the [`escape_default()`] method on [`char`]. See
@@ -587,3 +590,6 @@ impl Iterator for EscapeDefault {
         }
     }
 }
+
+#[stable(feature = "rust1", since = "1.7.0")]
+impl ExactSizeIterator for EscapeDefault { }

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -449,34 +449,10 @@ impl Iterator for EscapeUnicode {
     type Item = char;
 
     fn next(&mut self) -> Option<char> {
-        match self.state {
-            EscapeUnicodeState::Backslash => {
-                self.state = EscapeUnicodeState::Type;
-                Some('\\')
-            }
-            EscapeUnicodeState::Type => {
-                self.state = EscapeUnicodeState::LeftBrace;
-                Some('u')
-            }
-            EscapeUnicodeState::LeftBrace => {
-                self.state = EscapeUnicodeState::Value;
-                Some('{')
-            }
-            EscapeUnicodeState::Value => {
-                let c = from_digit(((self.c as u32) >> (self.offset * 4)) & 0xf, 16).unwrap();
-                if self.offset == 0 {
-                    self.state = EscapeUnicodeState::RightBrace;
-                } else {
-                    self.offset -= 1;
-                }
-                Some(c)
-            }
-            EscapeUnicodeState::RightBrace => {
-                self.state = EscapeUnicodeState::Done;
-                Some('}')
-            }
-            EscapeUnicodeState::Done => None,
-        }
+        let state = self.state_len();
+        let offset = self.offset;
+
+        self.step(state, offset)
     }
 
     #[inline]
@@ -507,14 +483,58 @@ impl Iterator for EscapeUnicode {
 impl ExactSizeIterator for EscapeUnicode {
     #[inline]
     fn len(&self) -> usize {
+        self.offset + self.state_len()
+    }
+}
+
+impl EscapeUnicode {
+    #[inline]
+    fn state_len(&self) -> usize {
         // The match is a single memory access with no branching
-        self.offset + self.state {
+        match self.state {
             EscapeUnicodeState::Done => 0,
             EscapeUnicodeState::RightBrace => 1,
             EscapeUnicodeState::Value => 2,
             EscapeUnicodeState::LeftBrace => 3,
             EscapeUnicodeState::Type => 4,
             EscapeUnicodeState::Backslash => 5,
+        }
+    }
+
+    #[inline]
+    fn step(&mut self, state: usize, offset: usize) -> Option<char> {
+        self.offset = offset;
+
+        match state {
+            5 => {
+                self.state = EscapeUnicodeState::Type;
+                Some('\\')
+            }
+            4 => {
+                self.state = EscapeUnicodeState::LeftBrace;
+                Some('u')
+            }
+            3 => {
+                self.state = EscapeUnicodeState::LeftBrace;
+                Some('{')
+            }
+            2 => {
+                self.state = if offset == 0 {
+                    EscapeUnicodeState::RightBrace
+                } else {
+                    self.offset -= 1;
+                    EscapeUnicodeState::Value
+                };
+                from_digit(((self.c as u32) >> (offset * 4)) & 0xf, 16)
+            }
+            1 => {
+                self.state = EscapeUnicodeState::Done;
+                Some('}')
+            }
+            _ => {
+                self.state = EscapeUnicodeState::Done;
+                None
+            }
         }
     }
 }

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -496,6 +496,18 @@ impl Iterator for EscapeUnicode {
     fn count(self) -> usize {
         self.len()
     }
+
+    fn last(self) -> Option<char> {
+        match self.state {
+            EscapeUnicodeState::Done => None,
+
+            EscapeUnicodeState::RightBrace |
+            EscapeUnicodeState::Value |
+            EscapeUnicodeState::LeftBrace |
+            EscapeUnicodeState::Type |
+            EscapeUnicodeState::Backslash => Some('}'),
+        }
+    }
 }
 
 #[stable(feature = "rust1", since = "1.7.0")]


### PR DESCRIPTION
and align the implementations in `EscapeUnicode` and `EscapeDefault`

Part of #24214.

EDIT: corrected reference to issue.
