### PR TITLE
tweak colors for a11y

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -383,7 +383,7 @@ a {
 }
 
 .content span.enum, .content a.enum, .block a.current.enum { color: #5e9766; }
-.content span.struct, .content a.struct, .block a.current.struct { color: #e53700; }
+.content span.struct, .content a.struct, .block a.current.struct { color: #df3600; }
 .content a.type { color: #e57300; }
 .content a.macro { color: #068000; }
 .block a.current.crate { font-weight: 500; }

--- a/src/librustdoc/html/static/styles/main.css
+++ b/src/librustdoc/html/static/styles/main.css
@@ -106,7 +106,7 @@ a {
 }
 
 .docblock a, .stability a {
-    color: #4e8bca;
+    color: #3873AD;
 }
 
 a.test-arrow {

--- a/src/librustdoc/html/static/styles/main.css
+++ b/src/librustdoc/html/static/styles/main.css
@@ -113,7 +113,7 @@ a.test-arrow {
     color: #f5f5f5;
 }
 
-.content span.trait, .content a.trait, .block a.current.trait { color: #8866ff; }
+.content span.trait, .content a.trait, .block a.current.trait { color: #7c5af3; }
 
 .search-input {
     color: #555;


### PR DESCRIPTION
I've been interested in the accessibility of Rustdoc's output, but never did anything about it. Today, I ran a tool, and it suggested adjusting some colors.

Here's some screen shots. Before:
![2016-01-20-114944_443x199_scrot](https://cloud.githubusercontent.com/assets/27786/12455979/d84d7ae8-bf6b-11e5-9aea-0602fb1a8cfa.png)

After: 

![2016-01-20-114516_453x204_scrot](https://cloud.githubusercontent.com/assets/27786/12455841/36a55d14-bf6b-11e5-8014-239594c12e46.png)

As you can see, the link text is just a _shade_ darker.

Browsable: http://www.steveklabnik.com/rust-a11y-doc-testing/doc/std/
