### PR TITLE
Use the fallback impl for memrchr on non-linux

### DIFF
--- a/src/libstd/memchr.rs
+++ b/src/libstd/memchr.rs
@@ -98,7 +98,7 @@ pub fn memrchr(needle: u8, haystack: &[u8]) -> Option<usize> {
 
     #[cfg(not(target_os = "linux"))]
     fn memrchr_specific(needle: u8, haystack: &[u8]) -> Option<usize> {
-        haystack.iter().rposition(|&b| b == needle)
+        fallback::memrchr(needle, haystack)
     }
 
     memrchr_specific(needle, haystack)


### PR DESCRIPTION
Use the fallback impl for memrchr on non-linux

The memrchr code was never used(!). This brings the memrchr improvements to
non-linux platforms (LineWriter / buffered stdout benefits).

Previous PR #30381
