### PR TITLE
std: Stabilize custom hasher support in HashMap

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -29,7 +29,6 @@
 #![feature(collections)]
 #![feature(const_fn)]
 #![feature(enumset)]
-#![feature(hashmap_hasher)]
 #![feature(iter_arith)]
 #![feature(libc)]
 #![feature(nonzero)]

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -12,10 +12,9 @@
 
 use std::cell::{RefCell, Cell};
 use std::collections::HashMap;
-use std::collections::hash_state::HashState;
 use std::ffi::CString;
 use std::fmt::Debug;
-use std::hash::Hash;
+use std::hash::{Hash, BuildHasher};
 use std::iter::repeat;
 use std::path::Path;
 use std::time::Instant;
@@ -217,7 +216,7 @@ pub trait MemoizationMap {
 }
 
 impl<K, V, S> MemoizationMap for RefCell<HashMap<K,V,S>>
-    where K: Hash+Eq+Clone, V: Clone, S: HashState
+    where K: Hash+Eq+Clone, V: Clone, S: BuildHasher
 {
     type Key = K;
     type Value = V;

--- a/src/librustc_data_structures/fnv.rs
+++ b/src/librustc_data_structures/fnv.rs
@@ -9,21 +9,20 @@
 // except according to those terms.
 
 use std::collections::{HashMap, HashSet};
-use std::collections::hash_state::DefaultState;
 use std::default::Default;
-use std::hash::{Hasher, Hash};
+use std::hash::{Hasher, Hash, BuildHasherDefault};
 
-pub type FnvHashMap<K, V> = HashMap<K, V, DefaultState<FnvHasher>>;
-pub type FnvHashSet<V> = HashSet<V, DefaultState<FnvHasher>>;
+pub type FnvHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FnvHasher>>;
+pub type FnvHashSet<V> = HashSet<V, BuildHasherDefault<FnvHasher>>;
 
 #[allow(non_snake_case)]
 pub fn FnvHashMap<K: Hash + Eq, V>() -> FnvHashMap<K, V> {
-    Default::default()
+    HashMap::default()
 }
 
 #[allow(non_snake_case)]
 pub fn FnvHashSet<V: Hash + Eq>() -> FnvHashSet<V> {
-    Default::default()
+    HashSet::default()
 }
 
 /// A speedy hash algorithm for node ids and def ids. The hashmap in

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -24,7 +24,6 @@
       html_favicon_url = "https://www.rust-lang.org/favicon.ico",
       html_root_url = "https://doc.rust-lang.org/nightly/")]
 
-#![feature(hashmap_hasher)]
 #![feature(nonzero)]
 #![feature(rustc_private)]
 #![feature(staged_api)]

--- a/src/libserialize/collection_impls.rs
+++ b/src/libserialize/collection_impls.rs
@@ -10,8 +10,7 @@
 
 //! Implementations of serialization for structures found in libcollections
 
-use std::hash::Hash;
-use std::collections::hash_state::HashState;
+use std::hash::{Hash, BuildHasher};
 use std::mem;
 
 use {Decodable, Encodable, Decoder, Encoder};
@@ -159,7 +158,7 @@ impl<
 impl<K, V, S> Encodable for HashMap<K, V, S>
     where K: Encodable + Hash + Eq,
           V: Encodable,
-          S: HashState,
+          S: BuildHasher,
 {
     fn encode<E: Encoder>(&self, e: &mut E) -> Result<(), E::Error> {
         e.emit_map(self.len(), |e| {
@@ -177,12 +176,12 @@ impl<K, V, S> Encodable for HashMap<K, V, S>
 impl<K, V, S> Decodable for HashMap<K, V, S>
     where K: Decodable + Hash + Eq,
           V: Decodable,
-          S: HashState + Default,
+          S: BuildHasher + Default,
 {
     fn decode<D: Decoder>(d: &mut D) -> Result<HashMap<K, V, S>, D::Error> {
         d.read_map(|d, len| {
             let state = Default::default();
-            let mut map = HashMap::with_capacity_and_hash_state(len, state);
+            let mut map = HashMap::with_capacity_and_hasher(len, state);
             for i in 0..len {
                 let key = try!(d.read_map_elt_key(i, |d| Decodable::decode(d)));
                 let val = try!(d.read_map_elt_val(i, |d| Decodable::decode(d)));
@@ -195,7 +194,7 @@ impl<K, V, S> Decodable for HashMap<K, V, S>
 
 impl<T, S> Encodable for HashSet<T, S>
     where T: Encodable + Hash + Eq,
-          S: HashState,
+          S: BuildHasher,
 {
     fn encode<E: Encoder>(&self, s: &mut E) -> Result<(), E::Error> {
         s.emit_seq(self.len(), |s| {
@@ -211,12 +210,12 @@ impl<T, S> Encodable for HashSet<T, S>
 
 impl<T, S> Decodable for HashSet<T, S>
     where T: Decodable + Hash + Eq,
-          S: HashState + Default,
+          S: BuildHasher + Default,
 {
     fn decode<D: Decoder>(d: &mut D) -> Result<HashSet<T, S>, D::Error> {
         d.read_seq(|d, len| {
             let state = Default::default();
-            let mut set = HashSet::with_capacity_and_hash_state(len, state);
+            let mut set = HashSet::with_capacity_and_hasher(len, state);
             for i in 0..len {
                 set.insert(try!(d.read_seq_elt(i, |d| Decodable::decode(d))));
             }

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -29,7 +29,6 @@ Core encoding and decoding interfaces.
 #![feature(box_syntax)]
 #![feature(collections)]
 #![feature(enumset)]
-#![feature(hashmap_hasher)]
 #![feature(rustc_private)]
 #![feature(staged_api)]
 #![feature(str_char)]

--- a/src/libstd/collections/hash/state.rs
+++ b/src/libstd/collections/hash/state.rs
@@ -10,31 +10,15 @@
 
 #![unstable(feature = "hashmap_hasher", reason = "hasher stuff is unclear",
             issue = "27713")]
+#![rustc_deprecated(since = "1.7.0", reason = "support moved to std::hash")]
+#![allow(deprecated)]
 
 use clone::Clone;
 use default::Default;
 use hash;
 use marker;
 
-/// A trait representing stateful hashes which can be used to hash keys in a
-/// `HashMap`.
-///
-/// A HashState is used as a factory for instances of `Hasher` which a `HashMap`
-/// can then use to hash keys independently. A `HashMap` by default uses a state
-/// which will create instances of a `SipHasher`, but a custom state factory can
-/// be provided to the `with_hash_state` function.
-///
-/// If a hashing algorithm has no initial state, then the `Hasher` type for that
-/// algorithm can implement the `Default` trait and create hash maps with the
-/// `DefaultState` structure. This state is 0-sized and will simply delegate
-/// to `Default` when asked to create a hasher.
-pub trait HashState {
-    /// Type of the hasher that will be created.
-    type Hasher: hash::Hasher;
-
-    /// Creates a new hasher based on the given state of this object.
-    fn hasher(&self) -> Self::Hasher;
-}
+pub use hash::HashState;
 
 /// A structure which is a factory for instances of `Hasher` which implement the
 /// default trait.

--- a/src/libstd/collections/hash/table.rs
+++ b/src/libstd/collections/hash/table.rs
@@ -11,13 +11,12 @@
 use alloc::heap::{allocate, deallocate, EMPTY};
 
 use cmp;
-use hash::{Hash, Hasher};
+use hash::{Hash, Hasher, BuildHasher};
 use marker;
 use mem::{align_of, size_of};
 use mem;
 use ops::{Deref, DerefMut};
 use ptr::{self, Unique};
-use collections::hash_state::HashState;
 
 use self::BucketState::*;
 
@@ -144,9 +143,9 @@ impl SafeHash {
 /// This function wraps up `hash_keyed` to be the only way outside this
 /// module to generate a SafeHash.
 pub fn make_hash<T: ?Sized, S>(hash_state: &S, t: &T) -> SafeHash
-    where T: Hash, S: HashState
+    where T: Hash, S: BuildHasher
 {
-    let mut state = hash_state.hasher();
+    let mut state = hash_state.build_hasher();
     t.hash(&mut state);
     // We need to avoid 0 in order to prevent collisions with
     // EMPTY_HASH. We can maintain our precious uniform distribution

--- a/src/libstd/collections/mod.rs
+++ b/src/libstd/collections/mod.rs
@@ -444,6 +444,8 @@ pub mod hash_set {
 /// HashSet.
 #[unstable(feature = "hashmap_hasher", reason = "module was recently added",
            issue = "27713")]
+#[rustc_deprecated(since = "1.7.0", reason = "support moved to std::hash")]
+#[allow(deprecated)]
 pub mod hash_state {
     pub use super::hash::state::*;
 }

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -231,6 +231,7 @@
 #![feature(float_from_str_radix)]
 #![feature(fnbox)]
 #![feature(heap_api)]
+#![feature(hashmap_hasher)]
 #![feature(int_error_internals)]
 #![feature(into_cow)]
 #![feature(lang_items)]


### PR DESCRIPTION
This commit implements the stabilization of the custom hasher support intended
for 1.7 but left out due to some last-minute questions that needed some
decisions. A summary of the actions done in this PR are:

Stable
- `std::hash::BuildHasher`
- `BuildHasher::Hasher`
- `BuildHasher::build_hasher`
- `std::hash::BuildHasherDefault`
- `HashMap::with_hasher`
- `HashMap::with_capacity_and_hasher`
- `HashSet::with_hasher`
- `HashSet::with_capacity_and_hasher`
- `std::collections::hash_map::RandomState`
- `RandomState::new`

Deprecated
- `std::collections::hash_state`
- `std::collections::hash_state::HashState` - this trait was also moved into
  `std::hash` with a reexport here to ensure that we can have a blanket impl to
  prevent immediate breakage on nightly. Note that this is unstable in both
  location.
- `HashMap::with_hash_state` - renamed
- `HashMap::with_capacity_and_hash_state` - renamed
- `HashSet::with_hash_state` - renamed
- `HashSet::with_capacity_and_hash_state` - renamed

Closes #27713
