### PR TITLE
Update expression span when transcribing macro args

### DIFF
--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -300,13 +300,13 @@ pub fn tt_next_token(r: &mut TtReader) -> TokenAndSpan {
                             // (a) idents can be in lots of places, so it'd be a pain
                             // (b) we actually can, since it's a token.
                             MatchedNonterminal(NtIdent(ref sn, b)) => {
-                                r.cur_span = sp;
+                                r.cur_span = sn.span;
                                 r.cur_tok = token::Ident(sn.node, b);
                                 return ret_val;
                             }
                             MatchedNonterminal(NtExpr(ref expr)) => {
                                 let mut expr = (**expr).clone();
-                                update_span(sp, &mut expr);
+                                //update_span(sp, &mut expr);
                                 // FIXME(pcwalton): Bad copy.
                                 r.cur_span = sp;
                                 r.cur_tok = token::Interpolated(NtExpr(ptr::P(expr)));

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -10,13 +10,12 @@
 use self::LockstepIterSize::*;
 
 use ast;
-use ptr;
 use ast::{TokenTree, Ident, Name};
 use codemap::{Span, DUMMY_SP};
 use errors::Handler;
 use ext::tt::macro_parser::{NamedMatch, MatchedSeq, MatchedNonterminal};
 use parse::token::{DocComment, MatchNt, SubstNt};
-use parse::token::{Token, NtIdent, NtExpr, SpecialMacroVar};
+use parse::token::{Token, NtIdent, SpecialMacroVar};
 use parse::token;
 use parse::lexer::TokenAndSpan;
 
@@ -174,11 +173,6 @@ fn lockstep_iter_size(t: &TokenTree, r: &TtReader) -> LockstepIterSize {
     }
 }
 
-fn update_span(base: Span, expr: &mut ast::Expr) {
-    expr.span.lo = base.lo;
-    expr.span.hi = base.hi;
-}
-
 /// Return the next token from the TtReader.
 /// EFFECT: advances the reader's token field
 pub fn tt_next_token(r: &mut TtReader) -> TokenAndSpan {
@@ -285,7 +279,6 @@ pub fn tt_next_token(r: &mut TtReader) -> TokenAndSpan {
             }
             // FIXME #2887: think about span stuff here
             TokenTree::Token(sp, SubstNt(ident, namep)) => {
-                //println!("SubstNt {:?} {:?}", ident, sp);
                 r.stack.last_mut().unwrap().idx += 1;
                 match lookup_cur_matched(r, ident) {
                     None => {
@@ -302,14 +295,6 @@ pub fn tt_next_token(r: &mut TtReader) -> TokenAndSpan {
                             MatchedNonterminal(NtIdent(ref sn, b)) => {
                                 r.cur_span = sn.span;
                                 r.cur_tok = token::Ident(sn.node, b);
-                                return ret_val;
-                            }
-                            MatchedNonterminal(NtExpr(ref expr)) => {
-                                let mut expr = (**expr).clone();
-                                //update_span(sp, &mut expr);
-                                // FIXME(pcwalton): Bad copy.
-                                r.cur_span = sp;
-                                r.cur_tok = token::Interpolated(NtExpr(ptr::P(expr)));
                                 return ret_val;
                             }
                             MatchedNonterminal(ref other_whole_nt) => {

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -223,6 +223,14 @@ impl Token {
         }
     }
 
+    /// Returns `true` if the token is interpolated.
+    pub fn is_interpolated(&self) -> bool {
+        match *self {
+            Interpolated(..) => true,
+            _                => false,
+        }
+    }
+
     /// Returns `true` if the token is an interpolated path.
     pub fn is_path(&self) -> bool {
         match *self {

--- a/src/test/compile-fail/issue-25385.rs
+++ b/src/test/compile-fail/issue-25385.rs
@@ -19,5 +19,5 @@ fn main() {
     foo!(a);
 
     foo!(1i32.foo());
-    //~^ ERROR attempted access of field `i32` on type `_`, but no field with that name was found
+    //~^ ERROR no method named `foo` found for type `i32` in the current scope
 }

--- a/src/test/compile-fail/issue-25385.rs
+++ b/src/test/compile-fail/issue-25385.rs
@@ -17,6 +17,7 @@ macro_rules! foo {
 fn main() {
     let a = 1i32;
     foo!(a);
+    //~^ NOTE in this expansion of foo!
 
     foo!(1i32.foo());
     //~^ ERROR no method named `foo` found for type `i32` in the current scope

--- a/src/test/compile-fail/issue-25385.rs
+++ b/src/test/compile-fail/issue-25385.rs
@@ -1,0 +1,23 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+macro_rules! foo {
+    ($e:expr) => { $e.foo() }
+    //~^ ERROR no method named `foo` found for type `i32` in the current scope
+}
+
+fn main() {
+    let a = 1i32;
+    foo!(a);
+
+    foo!(1.i32.foo());
+    //~^ ERROR attempted access of field `i32` on type `_`, but no field with that name was found
+}

--- a/src/test/compile-fail/issue-25385.rs
+++ b/src/test/compile-fail/issue-25385.rs
@@ -18,6 +18,6 @@ fn main() {
     let a = 1i32;
     foo!(a);
 
-    foo!(1.i32.foo());
+    foo!(1i32.foo());
     //~^ ERROR attempted access of field `i32` on type `_`, but no field with that name was found
 }

--- a/src/test/compile-fail/issue-25386.rs
+++ b/src/test/compile-fail/issue-25386.rs
@@ -1,0 +1,38 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+mod stuff {
+    pub struct Item {
+        c_object: Box<CObj>,
+    }
+    pub struct CObj {
+        name: Option<String>,
+    }
+    impl Item {
+        pub fn new() -> Item {
+            Item {
+                c_object: Box::new(CObj { name: None }),
+            }
+        }
+    }
+}
+
+macro_rules! check_ptr_exist {
+    ($var:expr, $member:ident) => (
+        (*$var.c_object).$member.is_some()
+        //~^ ERROR field `name` of struct `stuff::CObj` is private
+        //~^^ ERROR field `c_object` of struct `stuff::Item` is private
+    );
+}
+
+fn main() {
+    let item = stuff::Item::new();
+    println!("{}", check_ptr_exist!(item, name));
+}

--- a/src/test/compile-fail/issue-25386.rs
+++ b/src/test/compile-fail/issue-25386.rs
@@ -35,4 +35,6 @@ macro_rules! check_ptr_exist {
 fn main() {
     let item = stuff::Item::new();
     println!("{}", check_ptr_exist!(item, name));
+    //~^ NOTE in this expansion of check_ptr_exist!
+    //~^^ NOTE in this expansion of check_ptr_exist!
 }

--- a/src/test/compile-fail/issue-25793.rs
+++ b/src/test/compile-fail/issue-25793.rs
@@ -26,9 +26,8 @@ impl HasInfo {
 
     fn get_other(&mut self) -> usize {
         self.get_size(width!(self))
+        //~^ NOTE in this expansion of width!
     }
 }
 
-fn main() {
-    println!("hello?");
-}
+fn main() {}

--- a/src/test/compile-fail/issue-25793.rs
+++ b/src/test/compile-fail/issue-25793.rs
@@ -1,0 +1,34 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! width(
+    ($this:expr) => {
+        $this.width.unwrap()
+        //~^ ERROR cannot use `self.width` because it was mutably borrowed
+    }
+);
+
+struct HasInfo {
+    width: Option<usize>
+}
+
+impl HasInfo {
+    fn get_size(&mut self, n: usize) -> usize {
+        n
+    }
+
+    fn get_other(&mut self) -> usize {
+        self.get_size(width!(self))
+    }
+}
+
+fn main() {
+    println!("hello?");
+}

--- a/src/test/compile-fail/issue-26093.rs
+++ b/src/test/compile-fail/issue-26093.rs
@@ -1,0 +1,20 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! not_an_lvalue {
+    ($thing:expr) => {
+        $thing = 42;
+        //~^ ERROR invalid left-hand side expression
+    }
+}
+
+fn main() {
+    not_an_lvalue!(99);
+}

--- a/src/test/compile-fail/issue-26093.rs
+++ b/src/test/compile-fail/issue-26093.rs
@@ -16,7 +16,5 @@ macro_rules! not_an_lvalue {
 }
 
 fn main() {
-
-    0 = 42;
     not_an_lvalue!(99);
 }

--- a/src/test/compile-fail/issue-26093.rs
+++ b/src/test/compile-fail/issue-26093.rs
@@ -16,5 +16,7 @@ macro_rules! not_an_lvalue {
 }
 
 fn main() {
+
+    0 = 42;
     not_an_lvalue!(99);
 }

--- a/src/test/compile-fail/issue-26093.rs
+++ b/src/test/compile-fail/issue-26093.rs
@@ -17,4 +17,5 @@ macro_rules! not_an_lvalue {
 
 fn main() {
     not_an_lvalue!(99);
+    //~^ NOTE in this expansion of not_an_lvalue!
 }

--- a/src/test/compile-fail/issue-26094.rs
+++ b/src/test/compile-fail/issue-26094.rs
@@ -15,9 +15,9 @@ macro_rules! some_macro {
     })
 }
 
-fn some_function() {
-}
+fn some_function() {}
 
 fn main() {
     some_macro!(some_function);
+    //~^ in this expansion of some_macro!
 }

--- a/src/test/compile-fail/issue-26094.rs
+++ b/src/test/compile-fail/issue-26094.rs
@@ -1,0 +1,23 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! some_macro {
+    ($other: expr) => ({
+        $other(None)
+        //~^ this function takes 0 parameters but 1 parameter was supplied
+    })
+}
+
+fn some_function() {
+}
+
+fn main() {
+    some_macro!(some_function);
+}

--- a/src/test/compile-fail/issue-26237.rs
+++ b/src/test/compile-fail/issue-26237.rs
@@ -19,4 +19,5 @@ fn main() {
     let mut value_a = 0;
     let mut value_b = 0;
     macro_panic!(value_a, value_b);
+    //~^ in this expansion of macro_panic!
 }

--- a/src/test/compile-fail/issue-26237.rs
+++ b/src/test/compile-fail/issue-26237.rs
@@ -1,0 +1,22 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! macro_panic {
+    ($not_a_function:expr, $some_argument:ident) => {
+        $not_a_function($some_argument)
+        //~^ ERROR expected function, found `_`
+    }
+}
+
+fn main() {
+    let mut value_a = 0;
+    let mut value_b = 0;
+    macro_panic!(value_a, value_b);
+}

--- a/src/test/compile-fail/issue-26480.rs
+++ b/src/test/compile-fail/issue-26480.rs
@@ -24,7 +24,7 @@ macro_rules! write {
         unsafe {
             write(stdout, $arr.as_ptr() as *const i8,
                   $arr.len() * size_of($arr[0]));
-            //~^ ERROR mismatched types: expected `u64`, found `usize`
+            //~^ ERROR mismatched types
         }
     }}
 }

--- a/src/test/compile-fail/issue-26480.rs
+++ b/src/test/compile-fail/issue-26480.rs
@@ -37,6 +37,8 @@ macro_rules! cast {
 fn main() {
     let hello = ['H', 'e', 'y'];
     write!(hello);
+    //~^ NOTE in this expansion of write!
 
     cast!(2);
+    //~^ NOTE in this expansion of cast!
 }

--- a/src/test/compile-fail/issue-26480.rs
+++ b/src/test/compile-fail/issue-26480.rs
@@ -1,0 +1,42 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern {
+    fn write(fildes: i32, buf: *const i8, nbyte: u64) -> i64;
+}
+
+#[inline(always)]
+fn size_of<T>(_: T) -> usize {
+    ::std::mem::size_of::<T>()
+}
+
+macro_rules! write {
+    ($arr:expr) => {{
+        #[allow(non_upper_case_globals)]
+        const stdout: i32 = 1;
+        unsafe {
+            write(stdout, $arr.as_ptr() as *const i8,
+                  $arr.len() * size_of($arr[0]));
+            //~^ ERROR mismatched types: expected `u64`, found `usize`
+        }
+    }}
+}
+
+macro_rules! cast {
+    ($x:expr) => ($x as ())
+    //~^ ERROR non-scalar cast: `i32` as `()`
+}
+
+fn main() {
+    let hello = ['H', 'e', 'y'];
+    write!(hello);
+
+    cast!(2);
+}

--- a/src/test/compile-fail/issue-28308.rs
+++ b/src/test/compile-fail/issue-28308.rs
@@ -8,7 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// this error is dispayed in `<std macros>`
+// error-pattern:cannot apply unary operator `!` to type `&'static str`
+
 fn main() {
     assert!("foo");
-    //~^ ERROR cannot apply unary operator `!` to type `&'static str`
 }

--- a/src/test/compile-fail/issue-28308.rs
+++ b/src/test/compile-fail/issue-28308.rs
@@ -10,5 +10,5 @@
 
 fn main() {
     assert!("foo");
-    //~^ ERROR cannot apply unary operator `!` to type `&'static str`'`
+    //~^ ERROR cannot apply unary operator `!` to type `&'static str`
 }

--- a/src/test/compile-fail/issue-28308.rs
+++ b/src/test/compile-fail/issue-28308.rs
@@ -10,6 +10,7 @@
 
 // this error is dispayed in `<std macros>`
 // error-pattern:cannot apply unary operator `!` to type `&'static str`
+// error-pattern:in this expansion of assert!
 
 fn main() {
     assert!("foo");

--- a/src/test/compile-fail/issue-28308.rs
+++ b/src/test/compile-fail/issue-28308.rs
@@ -1,0 +1,14 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    assert!("foo");
+    //~^ ERROR cannot apply unary operator `!` to type `&'static str`'`
+}

--- a/src/test/compile-fail/issue-29084.rs
+++ b/src/test/compile-fail/issue-29084.rs
@@ -18,4 +18,5 @@ macro_rules! foo {
 
 fn main() {
     foo!(0u8);
+    //~^ NOTE in this expansion of foo!
 }

--- a/src/test/compile-fail/issue-29084.rs
+++ b/src/test/compile-fail/issue-29084.rs
@@ -12,7 +12,7 @@ macro_rules! foo {
     ($d:expr) => {{
         fn bar(d: u8) { }
         bar(&mut $d);
-        //~^ ERROR mismatched types: expected `u8`, found `&mut u8`
+        //~^ ERROR mismatched types
     }}
 }
 

--- a/src/test/compile-fail/issue-29084.rs
+++ b/src/test/compile-fail/issue-29084.rs
@@ -1,0 +1,21 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! foo {
+    ($d:expr) => {{
+        fn bar(d: u8) { }
+        bar(&mut $d);
+        //~^ ERROR mismatched types: expected `u8`, found `&mut u8`
+    }}
+}
+
+fn main() {
+    foo!(0u8);
+}

--- a/src/test/compile-fail/issue-31011.rs
+++ b/src/test/compile-fail/issue-31011.rs
@@ -1,0 +1,38 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! log {
+    ( $ctx:expr, $( $args:expr),* ) => {
+        if $ctx.trace {
+        //~^ attempted access of field `trace` on type `&T`, but no field with that name was found
+            println!( $( $args, )* );
+        }
+    }
+}
+
+// Create a structure.
+struct Foo {
+  trace: bool,
+}
+
+// Generic wrapper calls log! with a structure.
+fn wrap<T>(context: &T) -> ()
+{
+    log!(context, "entered wrapper");
+}
+
+fn main() {
+    // Create a structure.
+    let x = Foo { trace: true };
+    log!(x, "run started");
+    // Apply a closure which accesses internal fields.
+    wrap(&x);
+    log!(x, "run finished");
+}

--- a/src/test/compile-fail/issue-31011.rs
+++ b/src/test/compile-fail/issue-31011.rs
@@ -26,6 +26,7 @@ struct Foo {
 fn wrap<T>(context: &T) -> ()
 {
     log!(context, "entered wrapper");
+    //~^ in this expansion of log!
 }
 
 fn main() {

--- a/src/test/compile-fail/issue-31011.rs
+++ b/src/test/compile-fail/issue-31011.rs
@@ -11,7 +11,7 @@
 macro_rules! log {
     ( $ctx:expr, $( $args:expr),* ) => {
         if $ctx.trace {
-        //~^ attempted access of field `trace` on type `&T`, but no field with that name was found
+        //~^ ERROR attempted access of field `trace` on type `&T`, but no field with that name
             println!( $( $args, )* );
         }
     }


### PR DESCRIPTION
This is a  work in progress PR that potentially should fix #29084, #28308, #25385, #28288, #31011. I think this may also adresse parts of  #2887.

The problem in this issues seems to be that when transcribing macro arguments, we just clone the argument Nonterminal, which still has to original spans. This leads to the unprintable spans. One solution would be to update the spans of the inserted argument to match the argument in the macro definition. So for [this testcase](https://github.com/rust-lang/rust/compare/master...fhahn:macro-ice?expand=1#diff-f7def7420c51621640707b6337726876R2) the error message would be displayed in the macro definition:

```
src/test/compile-fail/issue-31011.rs:4:12: 4:22 error: attempted access of field `trace` on type `&T`, but no field with that name was found
src/test/compile-fail/issue-31011.rs:4         if $ctx.trace {
```

Currently I've added a very simple `update_span` function, which updates the span of the outer-most expression of a `NtExpr`, but this `update_span` function should be updated to handle all Nonterminals. But I'm pretty new to the macro system and would like to check if this approach makes sense, before doing that.
