### PR TITLE
resolve: Fix #23880, a scoping bug

### DIFF
--- a/src/test/run-pass/lexical-scoping.rs
+++ b/src/test/run-pass/lexical-scoping.rs
@@ -1,0 +1,28 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests that items in subscopes can shadow type parameters and local variables (see issue #23880).
+
+#![allow(unused)]
+struct Foo<X> { x: Box<X> }
+impl<Bar> Foo<Bar> {
+    fn foo(&self) {
+        type Bar = i32;
+        let _: Bar = 42;
+    }
+}
+
+fn main() {
+    let f = 1;
+    {
+        fn f() {}
+        f();
+    }
+}


### PR DESCRIPTION
This fixes #23880, a scoping bug in which items in a block are shadowed by local variables and type parameters that are in scope.

After this PR, an item in a block will shadow any local variables or type parameters above the item in the scope hierarchy. Items in a block will continue to be shadowed by local variables in the same block (even if the item is defined after the local variable).

This is a [breaking-change]. For example, the following code breaks:

``` rust
fn foo() {
    let mut f = 1;
    {
        fn f() {}
        f += 1; // This will resolve to the function instead of the local variable
    }
}
```
