### PR TITLE
Do not use SIMD instructions on i686

### DIFF
--- a/src/librustc_back/target/i686_linux_android.rs
+++ b/src/librustc_back/target/i686_linux_android.rs
@@ -12,7 +12,7 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::android_base::opts();
-    base.cpu = "pentium4".to_string();
+    base.cpu = "i686".to_string();
 
     Target {
         llvm_target: "i686-linux-android".to_string(),

--- a/src/librustc_back/target/i686_pc_windows_gnu.rs
+++ b/src/librustc_back/target/i686_pc_windows_gnu.rs
@@ -12,7 +12,7 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::windows_base::opts();
-    base.cpu = "pentium4".to_string();
+    base.cpu = "i686".to_string();
 
     // Mark all dynamic libraries and executables as compatible with the larger 4GiB address
     // space available to x86 Windows binaries on x86_64.

--- a/src/librustc_back/target/i686_pc_windows_msvc.rs
+++ b/src/librustc_back/target/i686_pc_windows_msvc.rs
@@ -12,7 +12,7 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::windows_msvc_base::opts();
-    base.cpu = "pentium4".to_string();
+    base.cpu = "i686".to_string();
 
     Target {
         llvm_target: "i686-pc-windows-msvc".to_string(),

--- a/src/librustc_back/target/i686_unknown_dragonfly.rs
+++ b/src/librustc_back/target/i686_unknown_dragonfly.rs
@@ -12,7 +12,7 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::dragonfly_base::opts();
-    base.cpu = "pentium4".to_string();
+    base.cpu = "i686".to_string();
     base.pre_link_args.push("-m32".to_string());
 
     Target {

--- a/src/librustc_back/target/i686_unknown_freebsd.rs
+++ b/src/librustc_back/target/i686_unknown_freebsd.rs
@@ -12,7 +12,7 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::freebsd_base::opts();
-    base.cpu = "pentium4".to_string();
+    base.cpu = "i686".to_string();
     base.pre_link_args.push("-m32".to_string());
 
     Target {

--- a/src/librustc_back/target/i686_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/i686_unknown_linux_gnu.rs
@@ -12,7 +12,7 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::linux_base::opts();
-    base.cpu = "pentium4".to_string();
+    base.cpu = "i686".to_string();
     base.pre_link_args.push("-m32".to_string());
 
     Target {


### PR DESCRIPTION
SIMD instructions are not available on all of i686 processors and
cause programs to terminate on illegal instruction on older
processors.

Clang defaults to compiling for `pentium4` when targeting a generic 32 bits x86 architecture. This was used as a precedent for rustc, but I believe some details were missed when doing so:
- when compiled for the plain i686 target, Clang does not use any SIMD operation (it uses x87 FPU operations)
- when compiling for the plain i686 target, Clang does not emit any SIMD operation

I think we should ensure that it is actually possible to target plain i686 with rust.
I expect this to come up with distros which target i686.

This should fix #14441 (so far I only verified with objdump that SIMD instructions are not used).
