### PR TITLE
Use cold functions for panic formatting Option::expect, Result::unwra…

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -295,14 +295,8 @@ impl<T> Option<T> {
     pub fn expect(self, msg: &str) -> T {
         match self {
             Some(val) => val,
-            None => Self::expect_failed(msg),
+            None => expect_failed(msg),
         }
-    }
-
-    #[inline(never)]
-    #[cold]
-    fn expect_failed(msg: &str) -> ! {
-        panic!("{}", msg)
     }
 
     /// Moves the value `v` out of the `Option<T>` if it is `Some(v)`.
@@ -702,6 +696,14 @@ impl<T: Default> Option<T> {
         }
     }
 }
+
+// This is a separate function to reduce the code size of .expect() itself.
+#[inline(never)]
+#[cold]
+fn expect_failed(msg: &str) -> ! {
+    panic!("{}", msg)
+}
+
 
 /////////////////////////////////////////////////////////////////////////////
 // Trait implementations

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -295,8 +295,14 @@ impl<T> Option<T> {
     pub fn expect(self, msg: &str) -> T {
         match self {
             Some(val) => val,
-            None => panic!("{}", msg),
+            None => Self::expect_failed(msg),
         }
+    }
+
+    #[inline(never)]
+    #[cold]
+    fn expect_failed(msg: &str) -> ! {
+        panic!("{}", msg)
     }
 
     /// Moves the value `v` out of the `Option<T>` if it is `Some(v)`.

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -684,9 +684,14 @@ impl<T, E: fmt::Debug> Result<T, E> {
     pub fn unwrap(self) -> T {
         match self {
             Ok(t) => t,
-            Err(e) =>
-                panic!("called `Result::unwrap()` on an `Err` value: {:?}", e)
+            Err(e) => Self::unwrap_failed(e),
         }
+    }
+
+    #[inline(never)]
+    #[cold]
+    fn unwrap_failed(error: E) -> ! {
+        panic!("called `Result::unwrap()` on an `Err` value: {:?}", error)
     }
 
     /// Unwraps a result, yielding the content of an `Ok`.
@@ -706,8 +711,14 @@ impl<T, E: fmt::Debug> Result<T, E> {
     pub fn expect(self, msg: &str) -> T {
         match self {
             Ok(t) => t,
-            Err(e) => panic!("{}: {:?}", msg, e),
+            Err(e) => Self::expect_failed(msg, e),
         }
+    }
+
+    #[inline(never)]
+    #[cold]
+    fn expect_failed(msg: &str, error: E) -> ! {
+        panic!("{}: {:?}", msg, error)
     }
 }
 
@@ -734,11 +745,17 @@ impl<T: fmt::Debug, E> Result<T, E> {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn unwrap_err(self) -> E {
         match self {
-            Ok(t) =>
-                panic!("called `Result::unwrap_err()` on an `Ok` value: {:?}", t),
-            Err(e) => e
+            Ok(t) => Self::unwrap_err_failed(t),
+            Err(e) => e,
         }
     }
+
+    #[inline(never)]
+    #[cold]
+    fn unwrap_err_failed(t: T) -> ! {
+        panic!("called `Result::unwrap_err()` on an `Ok` value: {:?}", t)
+    }
+
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -684,14 +684,8 @@ impl<T, E: fmt::Debug> Result<T, E> {
     pub fn unwrap(self) -> T {
         match self {
             Ok(t) => t,
-            Err(e) => Self::unwrap_failed(e),
+            Err(e) => unwrap_failed("called `Result::unwrap()` on an `Err` value", e),
         }
-    }
-
-    #[inline(never)]
-    #[cold]
-    fn unwrap_failed(error: E) -> ! {
-        panic!("called `Result::unwrap()` on an `Err` value: {:?}", error)
     }
 
     /// Unwraps a result, yielding the content of an `Ok`.
@@ -711,14 +705,8 @@ impl<T, E: fmt::Debug> Result<T, E> {
     pub fn expect(self, msg: &str) -> T {
         match self {
             Ok(t) => t,
-            Err(e) => Self::expect_failed(msg, e),
+            Err(e) => unwrap_failed(msg, e),
         }
-    }
-
-    #[inline(never)]
-    #[cold]
-    fn expect_failed(msg: &str, error: E) -> ! {
-        panic!("{}: {:?}", msg, error)
     }
 }
 
@@ -745,17 +733,17 @@ impl<T: fmt::Debug, E> Result<T, E> {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn unwrap_err(self) -> E {
         match self {
-            Ok(t) => Self::unwrap_err_failed(t),
+            Ok(t) => unwrap_failed("called `Result::unwrap_err()` on an `Ok` value", t),
             Err(e) => e,
         }
     }
+}
 
-    #[inline(never)]
-    #[cold]
-    fn unwrap_err_failed(t: T) -> ! {
-        panic!("called `Result::unwrap_err()` on an `Ok` value: {:?}", t)
-    }
-
+// This is a separate function to reduce the code size of the methods
+#[inline(never)]
+#[cold]
+fn unwrap_failed<E: fmt::Debug>(msg: &str, error: E) -> ! {
+    panic!("{}: {:?}", msg, error)
 }
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Use cold functions for panic formatting Option::expect, Result::unwrap, expect

These methods are marked inline, but insert a big chunk of formatting
code, as well as other error path related code, such as
deallocating a std::io::Error if you have one.

We can explicitly separate out that code path into a function that is
never inline, since the panicking case should always be rare.
