### PR TITLE
default flexible targets path to /etc/rustc/

### DIFF
--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -467,7 +467,7 @@ impl Target {
         };
 
         let target_path = env::var_os("RUST_TARGET_PATH")
-                              .unwrap_or(OsString::new());
+                              .unwrap_or(OsString::from("/etc/rustc/"));
 
         // FIXME 16351: add a sane default search path?
 


### PR DESCRIPTION
In RFC 131, the default RUST_TARGET_PATH if one is not set should be
/etc/rustc/ however the existing behavior does not match the RFC.

Signed-off-by: Doug Goldstein cardoe@cardoe.com
