### PR TITLE
mk: Move from `-D warnings` to `#![deny(warnings)]`

### DIFF
--- a/mk/target.mk
+++ b/mk/target.mk
@@ -17,14 +17,6 @@ export CFG_COMPILER_HOST_TRIPLE
 export CFG_DEFAULT_LINKER
 export CFG_DEFAULT_AR
 
-# The standard libraries should be held up to a higher standard than any old
-# code, make sure that these common warnings are denied by default. These can
-# be overridden during development temporarily. For stage0, we allow warnings
-# which may be bugs in stage0 (should be fixed in stage1+)
-RUST_LIB_FLAGS_ST0 += -W warnings
-RUST_LIB_FLAGS_ST1 += -D warnings
-RUST_LIB_FLAGS_ST2 += -D warnings
-
 # Macro that generates the full list of dependencies for a crate at a particular
 # stage/target/host tuple.
 #

--- a/src/liballoc/boxed_test.rs
+++ b/src/liballoc/boxed_test.rs
@@ -15,7 +15,6 @@ use core::ops::Deref;
 use core::result::Result::{Ok, Err};
 use core::clone::Clone;
 
-use std::boxed;
 use std::boxed::Box;
 
 #[test]

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -75,31 +75,28 @@
 #![feature(allocator)]
 #![feature(box_syntax)]
 #![feature(coerce_unsized)]
+#![feature(const_fn)]
 #![feature(core_intrinsics)]
 #![feature(custom_attribute)]
+#![feature(drop_in_place)]
+#![feature(dropck_parametricity)]
 #![feature(fundamental)]
 #![feature(lang_items)]
+#![feature(needs_allocator)]
 #![feature(optin_builtin_traits)]
 #![feature(placement_in_syntax)]
-#![feature(placement_new_protocol)]
-#![feature(raw)]
 #![feature(shared)]
 #![feature(staged_api)]
 #![feature(unboxed_closures)]
 #![feature(unique)]
 #![feature(unsafe_no_drop_flag, filling_drop)]
-#![feature(dropck_parametricity)]
 #![feature(unsize)]
-#![feature(drop_in_place)]
-#![feature(fn_traits)]
-#![feature(const_fn)]
-
-#![feature(needs_allocator)]
 
 // Issue# 30592: Systematically use alloc_system during stage0 since jemalloc
 // might be unavailable or disabled
 #![cfg_attr(stage0, feature(alloc_system))]
 
+#![cfg_attr(not(test), feature(raw, fn_traits, placement_new_protocol))]
 #![cfg_attr(test, feature(test, rustc_private, box_heap))]
 
 #[cfg(stage0)]

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -70,6 +70,7 @@
        test(no_crate_inject, attr(allow(unused_variables), deny(warnings))))]
 #![no_std]
 #![needs_allocator]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(allocator)]
 #![feature(box_syntax)]

--- a/src/liballoc_jemalloc/lib.rs
+++ b/src/liballoc_jemalloc/lib.rs
@@ -16,6 +16,7 @@
             reason = "this library is unlikely to be stabilized in its current \
                       form or name",
             issue = "27783")]
+#![cfg_attr(not(stage0), deny(warnings))]
 #![feature(allocator)]
 #![feature(libc)]
 #![feature(staged_api)]

--- a/src/liballoc_system/lib.rs
+++ b/src/liballoc_system/lib.rs
@@ -12,6 +12,7 @@
 #![crate_type = "rlib"]
 #![no_std]
 #![allocator]
+#![cfg_attr(not(stage0), deny(warnings))]
 #![unstable(feature = "alloc_system",
             reason = "this library is unlikely to be stabilized in its current \
                       form or name",

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -27,6 +27,7 @@
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/",
        test(no_crate_inject, attr(deny(warnings))))]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(alloc)]
 #![feature(core_intrinsics)]

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -56,7 +56,7 @@
 #![feature(unicode)]
 #![feature(unique)]
 #![feature(unsafe_no_drop_flag)]
-#![cfg_attr(test, feature(clone_from_slice, rand, test))]
+#![cfg_attr(test, feature(rand, test))]
 
 #![no_std]
 

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -28,6 +28,7 @@
 
 #![allow(trivial_casts)]
 #![cfg_attr(test, allow(deprecated))] // rand
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(alloc)]
 #![feature(box_patterns)]

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -83,20 +83,14 @@
 
 // Many of the usings in this module are only used in the test configuration.
 // It's cleaner to just turn off the unused_imports warning than to fix them.
-#![allow(unused_imports)]
+#![cfg_attr(test, allow(unused_imports, dead_code))]
 
 use alloc::boxed::Box;
-use core::clone::Clone;
 use core::cmp::Ordering::{self, Greater, Less};
-use core::cmp::{self, Ord, PartialEq};
-use core::iter::Iterator;
-use core::marker::Sized;
+use core::cmp;
 use core::mem::size_of;
 use core::mem;
-use core::ops::FnMut;
-use core::option::Option::{self, Some, None};
 use core::ptr;
-use core::result::Result;
 use core::slice as core_slice;
 
 use borrow::{Borrow, BorrowMut, ToOwned};
@@ -136,12 +130,7 @@ pub use self::hack::to_vec;
 // `test_permutations` test
 mod hack {
     use alloc::boxed::Box;
-    use core::clone::Clone;
-    #[cfg(test)]
-    use core::iter::Iterator;
     use core::mem;
-    #[cfg(test)]
-    use core::option::Option::{Some, None};
 
     #[cfg(test)]
     use string::ToString;

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -19,10 +19,6 @@
 // It's cleaner to just turn off the unused_imports warning than to fix them.
 #![allow(unused_imports)]
 
-use core::clone::Clone;
-use core::iter::{Iterator, Extend};
-use core::option::Option::{self, Some, None};
-use core::result::Result;
 use core::str as core_str;
 use core::str::pattern::Pattern;
 use core::str::pattern::{Searcher, ReverseSearcher, DoubleEndedSearcher};

--- a/src/libcollectionstest/slice.rs
+++ b/src/libcollectionstest/slice.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 use std::cmp::Ordering::{Equal, Greater, Less};
-use std::default::Default;
 use std::mem;
 use std::__rand::{Rng, thread_rng};
 use std::rc::Rc;

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -56,6 +56,7 @@
 
 #![no_core]
 #![deny(missing_docs)]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(allow_internal_unstable)]
 #![feature(associated_type_defaults)]

--- a/src/libflate/lib.rs
+++ b/src/libflate/lib.rs
@@ -22,6 +22,7 @@
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/",
        test(attr(deny(warnings))))]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(libc)]
 #![feature(staged_api)]

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -23,6 +23,7 @@
        html_root_url = "https://doc.rust-lang.org/nightly/",
        html_playground_url = "https://play.rust-lang.org/",
        test(attr(deny(warnings))))]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(staged_api)]
 #![feature(unicode)]

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -280,6 +280,7 @@
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/",
        test(attr(allow(unused_variables), deny(warnings))))]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(str_escape)]
 

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -168,6 +168,7 @@
        html_playground_url = "https://play.rust-lang.org/",
        test(attr(deny(warnings))))]
 #![deny(missing_docs)]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(box_syntax)]
 #![feature(const_fn)]

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -36,7 +36,7 @@
 #![feature(custom_attribute)]
 #![allow(unused_attributes)]
 
-#![cfg_attr(test, feature(test, rand, rustc_private, iter_order_deprecated))]
+#![cfg_attr(test, feature(test, rand, rustc_private))]
 
 #![allow(deprecated)]
 

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -23,6 +23,7 @@
        html_root_url = "https://doc.rust-lang.org/nightly/",
        html_playground_url = "https://play.rust-lang.org/",
        test(attr(deny(warnings))))]
+#![cfg_attr(not(stage0), deny(warnings))]
 #![no_std]
 #![unstable(feature = "rand",
             reason = "use `rand` from crates.io",

--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -120,6 +120,7 @@
        html_root_url = "https://doc.rust-lang.org/nightly/",
        html_playground_url = "https://play.rust-lang.org/",
        test(attr(deny(warnings))))]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(rustc_private)]
 #![feature(staged_api)]

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -19,8 +19,9 @@
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-      html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
+       html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(associated_consts)]
 #![feature(box_patterns)]

--- a/src/librustc_back/lib.rs
+++ b/src/librustc_back/lib.rs
@@ -28,6 +28,7 @@
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
       html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(box_syntax)]
 #![feature(libc)]

--- a/src/librustc_bitflags/lib.rs
+++ b/src/librustc_bitflags/lib.rs
@@ -15,6 +15,7 @@
 #![crate_type = "rlib"]
 #![no_std]
 #![unstable(feature = "rustc_private", issue = "27812")]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 //! A typesafe bitmask flag generator.
 

--- a/src/librustc_borrowck/lib.rs
+++ b/src/librustc_borrowck/lib.rs
@@ -15,6 +15,7 @@
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
       html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![allow(non_camel_case_types)]
 

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -23,6 +23,7 @@
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://www.rust-lang.org/favicon.ico",
       html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(hashmap_hasher)]
 #![feature(nonzero)]

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -21,6 +21,7 @@
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
       html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(box_syntax)]
 #![feature(libc)]

--- a/src/librustc_front/lib.rs
+++ b/src/librustc_front/lib.rs
@@ -19,8 +19,9 @@
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-      html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "http://doc.rust-lang.org/nightly/")]
+       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
+       html_root_url = "http://doc.rust-lang.org/nightly/")]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(associated_consts)]
 #![feature(box_patterns)]

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -26,6 +26,7 @@
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
       html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![cfg_attr(test, feature(test))]
 #![feature(box_patterns)]

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -21,6 +21,7 @@
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(associated_consts)]
 #![feature(box_syntax)]

--- a/src/librustc_metadata/lib.rs
+++ b/src/librustc_metadata/lib.rs
@@ -13,8 +13,9 @@
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-      html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
+       html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(box_patterns)]
 #![feature(enumset)]

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -17,6 +17,7 @@ Rust MIR: a lowered representation of Rust. Also: an experiment!
 #![crate_name = "rustc_mir"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(rustc_private)]
 

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -18,8 +18,10 @@ Rust MIR: a lowered representation of Rust. Also: an experiment!
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![cfg_attr(not(stage0), deny(warnings))]
+#![unstable(feature = "rustc_private", issue = "27812")]
 
 #![feature(rustc_private)]
+#![feature(staged_api)]
 
 #[macro_use] extern crate log;
 extern crate graphviz as dot;

--- a/src/librustc_passes/lib.rs
+++ b/src/librustc_passes/lib.rs
@@ -19,8 +19,9 @@
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-      html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
+       html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(rustc_diagnostic_macros)]
 #![feature(staged_api)]

--- a/src/librustc_platform_intrinsics/lib.rs
+++ b/src/librustc_platform_intrinsics/lib.rs
@@ -13,6 +13,7 @@
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 #![feature(staged_api, rustc_private)]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 extern crate rustc_llvm as llvm;
 extern crate rustc;

--- a/src/librustc_plugin/lib.rs
+++ b/src/librustc_plugin/lib.rs
@@ -55,8 +55,9 @@
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-      html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
+       html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(dynamic_lib)]
 #![feature(staged_api)]

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -15,6 +15,7 @@
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
       html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(rustc_diagnostic_macros)]
 #![feature(rustc_private)]

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -15,6 +15,7 @@
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
       html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(associated_consts)]
 #![feature(borrow_state)]

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -21,6 +21,7 @@
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
       html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(box_patterns)]
 #![feature(box_syntax)]

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -70,6 +70,7 @@ This API is completely unstable and subject to change.
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
       html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![allow(non_camel_case_types)]
 

--- a/src/librustc_unicode/lib.rs
+++ b/src/librustc_unicode/lib.rs
@@ -29,6 +29,7 @@
        html_playground_url = "https://play.rust-lang.org/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
        test(no_crate_inject, attr(allow(unused_variables), deny(warnings))))]
+#![cfg_attr(not(stage0), deny(warnings))]
 #![no_std]
 
 #![feature(core_char_ext)]

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -16,6 +16,7 @@
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/",
        html_playground_url = "https://play.rust-lang.org/")]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(box_patterns)]
 #![feature(box_syntax)]

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -2606,7 +2606,6 @@ impl FromStr for Json {
 mod tests {
     extern crate test;
     use self::Animal::*;
-    use self::DecodeEnum::*;
     use self::test::Bencher;
     use {Encodable, Decodable};
     use super::Json::*;

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -25,6 +25,7 @@ Core encoding and decoding interfaces.
        html_root_url = "https://doc.rust-lang.org/nightly/",
        html_playground_url = "https://play.rust-lang.org/",
        test(attr(allow(unused_variables), deny(warnings))))]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(box_syntax)]
 #![feature(collections)]

--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -16,7 +16,6 @@
             reason = "API has not been scrutinized and is highly likely to \
                       either disappear or change",
             issue = "27810")]
-#![rustc_deprecated(since = "1.5.0", reason = "replaced with 'dylib' on crates.io")]
 #![allow(missing_docs)]
 #![allow(deprecated)]
 
@@ -26,6 +25,11 @@ use env;
 use ffi::{CString, OsString};
 use path::{Path, PathBuf};
 
+#[unstable(feature = "dynamic_lib",
+           reason = "API has not been scrutinized and is highly likely to \
+                     either disappear or change",
+           issue = "27810")]
+#[rustc_deprecated(since = "1.5.0", reason = "replaced with 'dylib' on crates.io")]
 pub struct DynamicLibrary {
     handle: *mut u8
 }
@@ -43,6 +47,11 @@ impl Drop for DynamicLibrary {
     }
 }
 
+#[unstable(feature = "dynamic_lib",
+           reason = "API has not been scrutinized and is highly likely to \
+                     either disappear or change",
+           issue = "27810")]
+#[rustc_deprecated(since = "1.5.0", reason = "replaced with 'dylib' on crates.io")]
 impl DynamicLibrary {
     /// Lazily open a dynamic library. When passed None it gives a
     /// handle to the calling process
@@ -126,7 +135,6 @@ mod tests {
     use prelude::v1::*;
     use libc;
     use mem;
-    use path::Path;
 
     #[test]
     #[cfg_attr(any(windows,
@@ -167,6 +175,8 @@ mod tests {
               target_os = "openbsd"))]
     #[allow(deprecated)]
     fn test_errors_do_not_crash() {
+        use path::Path;
+
         // Open /dev/null as a library to get an error, and make sure
         // that only causes an error, and not a crash.
         let path = Path::new("/dev/null");

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -1095,8 +1095,8 @@ mod tests {
 
         thread::spawn(|| {
             let mut writer = BufWriter::new(PanicWriter);
-            writer.write(b"hello world");
-            writer.flush();
+            let _ = writer.write(b"hello world");
+            let _ = writer.flush();
         }).join().err().unwrap();
 
         assert_eq!(WRITES.load(Ordering::SeqCst), 1);

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -273,6 +273,7 @@
 
 #![deny(missing_docs)]
 #![allow(unused_features)] // std may use features in a platform-specific way
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #[cfg(test)] extern crate test;
 #[cfg(test)] #[macro_use] extern crate log;

--- a/src/libstd/os/raw.rs
+++ b/src/libstd/os/raw.rs
@@ -68,6 +68,7 @@ pub enum c_void {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
     use any::TypeId;
     use libc;

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -3326,11 +3326,13 @@ mod tests {
                          "{:?}.ends_with({:?}), expected {:?}, got {:?}", $path1, $path2,
                          $ends_with, ends_with);
 
-                 let relative_from = path1.relative_from(path2).map(|p| p.to_str().unwrap());
+                 let relative_from = path1.strip_prefix(path2)
+                                          .map(|p| p.to_str().unwrap())
+                                          .ok();
                  let exp: Option<&str> = $relative_from;
                  assert!(relative_from == exp,
-                         "{:?}.relative_from({:?}), expected {:?}, got {:?}", $path1, $path2,
-                         exp, relative_from);
+                         "{:?}.strip_prefix({:?}), expected {:?}, got {:?}",
+                         $path1, $path2, exp, relative_from);
             });
         );
 

--- a/src/libstd/sync/mpsc/select.rs
+++ b/src/libstd/sync/mpsc/select.rs
@@ -789,7 +789,7 @@ mod tests {
     fn fmt_debug_handle() {
         let (_, rx) = channel::<i32>();
         let sel = Select::new();
-        let mut handle = sel.handle(&rx);
+        let handle = sel.handle(&rx);
         assert_eq!(format!("{:?}", handle), "Handle { .. }");
     }
 }

--- a/src/libstd/sync/semaphore.rs
+++ b/src/libstd/sync/semaphore.rs
@@ -12,9 +12,6 @@
             reason = "the interaction between semaphores and the acquisition/release \
                       of resources is currently unclear",
             issue = "27798")]
-#![rustc_deprecated(since = "1.7.0",
-                    reason = "easily confused with system semaphores and not \
-                              used enough to pull its weight")]
 #![allow(deprecated)]
 
 use ops::Drop;
@@ -49,6 +46,13 @@ use sync::{Mutex, Condvar};
 /// // Release our initially acquired resource
 /// sem.release();
 /// ```
+#[rustc_deprecated(since = "1.7.0",
+                   reason = "easily confused with system semaphores and not \
+                             used enough to pull its weight")]
+#[unstable(feature = "semaphore",
+           reason = "the interaction between semaphores and the acquisition/release \
+                     of resources is currently unclear",
+           issue = "27798")]
 pub struct Semaphore {
     lock: Mutex<isize>,
     cvar: Condvar,
@@ -56,10 +60,24 @@ pub struct Semaphore {
 
 /// An RAII guard which will release a resource acquired from a semaphore when
 /// dropped.
+#[rustc_deprecated(since = "1.7.0",
+                   reason = "easily confused with system semaphores and not \
+                             used enough to pull its weight")]
+#[unstable(feature = "semaphore",
+           reason = "the interaction between semaphores and the acquisition/release \
+                     of resources is currently unclear",
+           issue = "27798")]
 pub struct SemaphoreGuard<'a> {
     sem: &'a Semaphore,
 }
 
+#[rustc_deprecated(since = "1.7.0",
+                   reason = "easily confused with system semaphores and not \
+                             used enough to pull its weight")]
+#[unstable(feature = "semaphore",
+           reason = "the interaction between semaphores and the acquisition/release \
+                     of resources is currently unclear",
+           issue = "27798")]
 impl Semaphore {
     /// Creates a new semaphore with the initial count specified.
     ///

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -8,14 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(missing_docs)]
-#![allow(non_camel_case_types)]
+#![allow(missing_docs, bad_style)]
 
 use io::{self, ErrorKind};
 use libc;
 use num::One;
 use ops::Neg;
-use alloc::oom;
 
 #[cfg(target_os = "android")]   pub use os::android as platform;
 #[cfg(target_os = "bitrig")]    pub use os::bitrig as platform;
@@ -46,25 +44,10 @@ pub mod thread_local;
 pub mod time;
 pub mod stdio;
 
-// A nicer handler for out-of-memory situations than the default one. This one
-// prints a message to stderr before aborting. It is critical that this code
-// does not allocate any memory since we are in an OOM situation. Any errors are
-// ignored while printing since there's nothing we can do about them and we are
-// about to exit anyways.
-fn oom_handler() -> ! {
-    use intrinsics;
-    let msg = "fatal runtime error: out of memory\n";
-    unsafe {
-        libc::write(libc::STDERR_FILENO,
-                    msg.as_ptr() as *const libc::c_void,
-                    msg.len() as libc::size_t);
-        intrinsics::abort();
-    }
-}
-
-#[cfg(not(any(target_os = "nacl", test)))]
+#[cfg(not(test))]
 pub fn init() {
-    use libc::signal;
+    use alloc::oom;
+
     // By default, some platforms will send a *signal* when an EPIPE error
     // would otherwise be delivered. This runtime doesn't install a SIGPIPE
     // handler, causing it to kill the program, which isn't exactly what we
@@ -73,15 +56,33 @@ pub fn init() {
     // Hence, we set SIGPIPE to ignore when the program starts up in order
     // to prevent this problem.
     unsafe {
-        assert!(signal(libc::SIGPIPE, libc::SIG_IGN) != !0);
+        reset_sigpipe();
     }
 
     oom::set_oom_handler(oom_handler);
-}
 
-#[cfg(all(target_os = "nacl", not(test)))]
-pub fn init() {
-    oom::set_oom_handler(oom_handler);
+    // A nicer handler for out-of-memory situations than the default one. This
+    // one prints a message to stderr before aborting. It is critical that this
+    // code does not allocate any memory since we are in an OOM situation. Any
+    // errors are ignored while printing since there's nothing we can do about
+    // them and we are about to exit anyways.
+    fn oom_handler() -> ! {
+        use intrinsics;
+        let msg = "fatal runtime error: out of memory\n";
+        unsafe {
+            libc::write(libc::STDERR_FILENO,
+                        msg.as_ptr() as *const libc::c_void,
+                        msg.len() as libc::size_t);
+            intrinsics::abort();
+        }
+    }
+
+    #[cfg(not(target_os = "nacl"))]
+    unsafe fn reset_sigpipe() {
+        assert!(libc::signal(libc::SIGPIPE, libc::SIG_IGN) != !0);
+    }
+    #[cfg(target_os = "nacl")]
+    unsafe fn reset_sigpipe() {}
 }
 
 pub fn decode_error_kind(errno: i32) -> ErrorKind {

--- a/src/libstd/sys/unix/stack_overflow.rs
+++ b/src/libstd/sys/unix/stack_overflow.rs
@@ -7,6 +7,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
 #![cfg_attr(test, allow(dead_code))]
 
 use libc;

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(dead_code)]
-
 use prelude::v1::*;
 
 use alloc::boxed::FnBox;
@@ -174,6 +172,7 @@ impl Drop for Thread {
           not(target_os = "bitrig"),
           not(all(target_os = "netbsd", not(target_vendor = "rumprun"))),
           not(target_os = "openbsd")))]
+#[cfg_attr(test, allow(dead_code))]
 pub mod guard {
     pub unsafe fn current() -> Option<usize> { None }
     pub unsafe fn init() -> Option<usize> { None }
@@ -185,15 +184,13 @@ pub mod guard {
           target_os = "bitrig",
           all(target_os = "netbsd", not(target_vendor = "rumprun")),
           target_os = "openbsd"))]
-#[allow(unused_imports)]
+#[cfg_attr(test, allow(dead_code))]
 pub mod guard {
     use prelude::v1::*;
 
-    use libc::{self, pthread_t};
+    use libc;
     use libc::mmap;
     use libc::{PROT_NONE, MAP_PRIVATE, MAP_ANON, MAP_FAILED, MAP_FIXED};
-    use mem;
-    use ptr;
     use sys::os;
 
     #[cfg(any(target_os = "macos",
@@ -206,10 +203,10 @@ pub mod guard {
     #[cfg(any(target_os = "linux", target_os = "android", target_os = "netbsd"))]
     unsafe fn get_stack_start() -> Option<*mut libc::c_void> {
         let mut ret = None;
-        let mut attr: libc::pthread_attr_t = mem::zeroed();
+        let mut attr: libc::pthread_attr_t = ::mem::zeroed();
         assert_eq!(libc::pthread_attr_init(&mut attr), 0);
         if libc::pthread_getattr_np(libc::pthread_self(), &mut attr) == 0 {
-            let mut stackaddr = ptr::null_mut();
+            let mut stackaddr = ::ptr::null_mut();
             let mut stacksize = 0;
             assert_eq!(libc::pthread_attr_getstack(&attr, &mut stackaddr,
                                                    &mut stacksize), 0);
@@ -265,7 +262,7 @@ pub mod guard {
 
     #[cfg(any(target_os = "openbsd", target_os = "bitrig"))]
     pub unsafe fn current() -> Option<usize> {
-        let mut current_stack: libc::stack_t = mem::zeroed();
+        let mut current_stack: libc::stack_t = ::mem::zeroed();
         assert_eq!(libc::pthread_stackseg_np(libc::pthread_self(),
                                              &mut current_stack), 0);
 
@@ -282,7 +279,7 @@ pub mod guard {
     #[cfg(any(target_os = "linux", target_os = "android", target_os = "netbsd"))]
     pub unsafe fn current() -> Option<usize> {
         let mut ret = None;
-        let mut attr: libc::pthread_attr_t = mem::zeroed();
+        let mut attr: libc::pthread_attr_t = ::mem::zeroed();
         assert_eq!(libc::pthread_attr_init(&mut attr), 0);
         if libc::pthread_getattr_np(libc::pthread_self(), &mut attr) == 0 {
             let mut guardsize = 0;
@@ -290,7 +287,7 @@ pub mod guard {
             if guardsize == 0 {
                 panic!("there is no guard page");
             }
-            let mut stackaddr = ptr::null_mut();
+            let mut stackaddr = ::ptr::null_mut();
             let mut size = 0;
             assert_eq!(libc::pthread_attr_getstack(&attr, &mut stackaddr,
                                                    &mut size), 0);

--- a/src/libstd/sys/windows/fs.rs
+++ b/src/libstd/sys/windows/fs.rs
@@ -639,7 +639,7 @@ pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
 fn directory_junctions_are_directories() {
     use ffi::OsStr;
     use env;
-    use rand::{self, StdRng, Rng};
+    use rand::{self, Rng};
     use vec::Vec;
 
     macro_rules! t {
@@ -683,7 +683,7 @@ fn directory_junctions_are_directories() {
             let mut data = [0u8; c::MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
             let mut db = data.as_mut_ptr()
                             as *mut c::REPARSE_MOUNTPOINT_DATA_BUFFER;
-            let mut buf = &mut (*db).ReparseTarget as *mut _;
+            let buf = &mut (*db).ReparseTarget as *mut _;
             let mut i = 0;
             let v = br"\??\";
             let v = v.iter().map(|x| *x as u16);

--- a/src/libstd/sys/windows/process.rs
+++ b/src/libstd/sys/windows/process.rs
@@ -386,7 +386,6 @@ impl Stdio {
 #[cfg(test)]
 mod tests {
     use prelude::v1::*;
-    use str;
     use ffi::{OsStr, OsString};
     use super::make_command_line;
 

--- a/src/libstd/sys/windows/stack_overflow.rs
+++ b/src/libstd/sys/windows/stack_overflow.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![cfg_attr(test, allow(dead_code))]
+
 use sys_common::util::report_overflow;
 use sys::c;
 

--- a/src/libstd/sys/windows/thread.rs
+++ b/src/libstd/sys/windows/thread.rs
@@ -83,6 +83,7 @@ impl Thread {
     pub fn into_handle(self) -> Handle { self.handle }
 }
 
+#[cfg_attr(test, allow(dead_code))]
 pub mod guard {
     pub unsafe fn current() -> Option<usize> { None }
     pub unsafe fn init() -> Option<usize> { None }

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -22,6 +22,7 @@
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/",
        test(attr(deny(warnings))))]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(associated_consts)]
 #![feature(filling_drop)]

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -3149,7 +3149,6 @@ mod tests {
     use super::*;
 
     use ast;
-    use ast_util;
     use codemap;
     use parse::token;
 

--- a/src/libsyntax_ext/lib.rs
+++ b/src/libsyntax_ext/lib.rs
@@ -11,13 +11,13 @@
 //! Syntax extensions in the Rust compiler.
 
 #![crate_name = "syntax_ext"]
+#![unstable(feature = "rustc_private", issue = "27812")]
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/")]
-
-#![unstable(feature = "rustc_private", issue = "27812")]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(rustc_private)]
 #![feature(staged_api)]

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -52,6 +52,7 @@
        html_playground_url = "https://play.rust-lang.org/",
        test(attr(deny(warnings))))]
 #![deny(missing_docs)]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(box_syntax)]
 #![feature(staged_api)]

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -31,6 +31,7 @@
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/nightly/",
        test(attr(deny(warnings))))]
+#![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(asm)]
 #![feature(box_syntax)]


### PR DESCRIPTION
This commit removes the `-D warnings` flag being passed through the makefiles to
all crates to instead be a crate attribute. We want these attributes always
applied for all our standard builds, and this is more amenable to Cargo-based
builds as well.

Note that all `deny(warnings)` attributes are gated with a `cfg(stage0)`
attribute currently to match the same semantics we have today
