### PR TITLE
Implement error::Error and fmt::Display for string::ParseError

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -1692,6 +1692,13 @@ impl fmt::Debug for ParseError {
     }
 }
 
+#[stable(feature = "str_parse_error2", since = "1.8.0")]
+impl fmt::Display for ParseError {
+    fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        match *self {}
+    }
+}
+
 #[stable(feature = "str_parse_error", since = "1.5.0")]
 impl PartialEq for ParseError {
     fn eq(&self, _: &ParseError) -> bool {

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -182,6 +182,13 @@ impl Error for string::FromUtf16Error {
     }
 }
 
+#[stable(feature = "str_parse_error2", since = "1.8.0")]
+impl Error for string::ParseError {
+    fn description(&self) -> &str {
+        "parse error"
+    }
+}
+
 // copied from any.rs
 impl Error + 'static {
     /// Returns true if the boxed type is the same as `T`

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -185,7 +185,7 @@ impl Error for string::FromUtf16Error {
 #[stable(feature = "str_parse_error2", since = "1.8.0")]
 impl Error for string::ParseError {
     fn description(&self) -> &str {
-        "parse error"
+        match *self {}
     }
 }
 


### PR DESCRIPTION
Fixes #31106.
##### Couple of questions:
- [x] I wasn't sure of the correct `#[stable(...)]` definition to use here. Happy to fix it if it's incorrect.
- [x] `ParseError` is sort of an ephemeral non-error, but do let me know if the implementation of `error::Error` for it should return something more descriptive than "parse error".
