### PR TITLE
astconv: don't use as_local_node_id for ids in a Def

### DIFF
--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1513,7 +1513,7 @@ fn base_def_to_ty<'tcx>(this: &AstConv<'tcx>,
                         &base_segments[base_segments.len()-2],
                         base_segments.last().unwrap())
         }
-        Def::Mod(id) => {
+        Def::Mod(..) => {
             // Used as sentinel by callers to indicate the `<T>::A::B::C` form.
             // FIXME(#22519) This part of the resolution logic should be
             // avoided entirely for that form, once we stop needed a Def
@@ -1522,15 +1522,7 @@ fn base_def_to_ty<'tcx>(this: &AstConv<'tcx>,
             // resolve Self::Foo, at the moment we can't resolve the former because
             // we don't have the trait information around, which is just sad.
 
-            if !base_segments.is_empty() {
-                let id_node = tcx.map.as_local_node_id(id).unwrap();
-                span_err!(tcx.sess,
-                          span,
-                          E0247,
-                          "found module name used as a type: {}",
-                          tcx.map.node_to_user_string(id_node));
-                return this.tcx().types.err;
-            }
+            assert!(base_segments.is_empty());
 
             opt_self_ty.expect("missing T in <T>::a::b::c")
         }
@@ -1541,10 +1533,9 @@ fn base_def_to_ty<'tcx>(this: &AstConv<'tcx>,
             return this.tcx().types.err;
         }
         _ => {
-            let id_node = tcx.map.as_local_node_id(def.def_id()).unwrap();
             span_err!(tcx.sess, span, E0248,
                       "found value `{}` used as a type",
-                      tcx.map.path_to_string(id_node));
+                      tcx.item_path_str(def.def_id()));
             return this.tcx().types.err;
         }
     }

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -2565,24 +2565,6 @@ struct Bar<S, T> { x: Foo<S, T> }
 ```
 "##,
 
-//NB: not currently reachable
-E0247: r##"
-This error indicates an attempt to use a module name where a type is expected.
-For example:
-
-```
-mod MyMod {
-    mod MySubMod { }
-}
-
-fn do_something(x: MyMod::MySubMod) { }
-```
-
-In this example, we're attempting to take a parameter of type `MyMod::MySubMod`
-in the do_something function. This is not legal: `MyMod::MySubMod` is a module
-name, not a type.
-"##,
-
 E0248: r##"
 This error indicates an attempt to use a value where a type is expected. For
 example:
@@ -3438,6 +3420,7 @@ register_diagnostics! {
     E0242, // internal error looking up a definition
     E0245, // not a trait
 //  E0246, // invalid recursive type
+//  E0247,
 //  E0319, // trait impls for defaulted traits allowed just for structs/enums
     E0320, // recursive overflow during dropck
     E0328, // cannot implement Unsize explicitly

--- a/src/test/auxiliary/issue-30535.rs
+++ b/src/test/auxiliary/issue-30535.rs
@@ -1,0 +1,15 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type="lib"]
+
+pub enum Foo {
+    FooV { data: () }
+}

--- a/src/test/compile-fail/issue-30535.rs
+++ b/src/test/compile-fail/issue-30535.rs
@@ -1,0 +1,19 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-30535.rs
+
+extern crate issue_30535 as foo;
+
+fn bar(
+    _: foo::Foo::FooV //~ ERROR value `foo::Foo::FooV` used as a type
+) {}
+
+fn main() {}


### PR DESCRIPTION
Also removed an unused and similarly buggy error path.

Fixes #30535

r? @eddyb
