### PR TITLE
E0210: Add a warning about type aliases

### DIFF
--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -2269,6 +2269,8 @@ struct MyType<T>(T);
 impl<T> ForeignTrait for MyType<T> { ... } // Ok
 ```
 
+Please note that a type alias is not sufficient.
+
 For another example of an error, suppose there's another trait defined in `foo`
 named `ForeignTrait2` that takes two type parameters. Then this `impl` results
 in the same rule violation:


### PR DESCRIPTION
E0210 explains about orphan rules and suggests using a local type as a workaround. It wasn't obvious to me that I couldn't use a type alias, so I added a note.
