### PR TITLE
Document that BTreeMap iteration is in order

### DIFF
--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -1194,7 +1194,7 @@ unsafe fn unwrap_unchecked<T>(val: Option<T>) -> T {
 }
 
 impl<K, V> BTreeMap<K, V> {
-    /// Gets an iterator over the entries of the map.
+    /// Gets an iterator over the entries of the map, sorted by key.
     ///
     /// # Examples
     ///
@@ -1202,9 +1202,9 @@ impl<K, V> BTreeMap<K, V> {
     /// use std::collections::BTreeMap;
     ///
     /// let mut map = BTreeMap::new();
-    /// map.insert(1, "a");
-    /// map.insert(2, "b");
     /// map.insert(3, "c");
+    /// map.insert(2, "b");
+    /// map.insert(1, "a");
     ///
     /// for (key, value) in map.iter() {
     ///     println!("{}: {}", key, value);
@@ -1224,7 +1224,7 @@ impl<K, V> BTreeMap<K, V> {
         }
     }
 
-    /// Gets a mutable iterator over the entries of the map.
+    /// Gets a mutable iterator over the entries of the map, sorted by key.
     ///
     /// # Examples
     ///
@@ -1257,7 +1257,7 @@ impl<K, V> BTreeMap<K, V> {
         }
     }
 
-    /// Gets an iterator over the keys of the map.
+    /// Gets an iterator over the keys of the map, in sorted order.
     ///
     /// # Examples
     ///
@@ -1265,8 +1265,8 @@ impl<K, V> BTreeMap<K, V> {
     /// use std::collections::BTreeMap;
     ///
     /// let mut a = BTreeMap::new();
-    /// a.insert(1, "a");
     /// a.insert(2, "b");
+    /// a.insert(1, "a");
     ///
     /// let keys: Vec<_> = a.keys().cloned().collect();
     /// assert_eq!(keys, [1, 2]);
@@ -1276,7 +1276,7 @@ impl<K, V> BTreeMap<K, V> {
         Keys { inner: self.iter() }
     }
 
-    /// Gets an iterator over the values of the map.
+    /// Gets an iterator over the values of the map, in order by key.
     ///
     /// # Examples
     ///
@@ -1284,11 +1284,11 @@ impl<K, V> BTreeMap<K, V> {
     /// use std::collections::BTreeMap;
     ///
     /// let mut a = BTreeMap::new();
-    /// a.insert(1, "a");
-    /// a.insert(2, "b");
+    /// a.insert(1, "hello");
+    /// a.insert(2, "goodbye");
     ///
     /// let values: Vec<&str> = a.values().cloned().collect();
-    /// assert_eq!(values, ["a", "b"]);
+    /// assert_eq!(values, ["hello", "goodbye"]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn values<'a>(&'a self) -> Values<'a, K, V> {


### PR DESCRIPTION
Also change the examples to make this more obvious. Fixes #31129.
