### PR TITLE
Resolve: stop requiring `use` and `extern crate` declarations to precede statements in blocks

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2508,29 +2508,6 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             }
         }
 
-        // Check for imports appearing after non-item statements.
-        let mut found_non_item = false;
-        for statement in &block.stmts {
-            if let hir::StmtDecl(ref declaration, _) = statement.node {
-                if let hir::DeclItem(i) = declaration.node {
-                    let i = self.ast_map.expect_item(i.id);
-                    match i.node {
-                        ItemExternCrate(_) | ItemUse(_) if found_non_item => {
-                            span_err!(self.session,
-                                      i.span,
-                                      E0154,
-                                      "imports are not allowed after non-item statements");
-                        }
-                        _ => {}
-                    }
-                } else {
-                    found_non_item = true
-                }
-            } else {
-                found_non_item = true;
-            }
-        }
-
         // Descend into the block.
         intravisit::walk_block(self, block);
 

--- a/src/test/compile-fail/blind-item-block-middle.rs
+++ b/src/test/compile-fail/blind-item-block-middle.rs
@@ -14,5 +14,4 @@ fn main() {
     let bar = 5;
     //~^ ERROR declaration of `bar` shadows an enum variant or unit-like struct in scope
     use foo::bar;
-    //~^ ERROR imports are not allowed after non-item statements
 }

--- a/src/test/run-pass/blind-item-local-shadow.rs
+++ b/src/test/run-pass/blind-item-local-shadow.rs
@@ -15,6 +15,5 @@ mod bar {
 fn main() {
     let foo = || false;
     use bar::foo;
-    //~^ ERROR imports are not allowed after non-item statements
     assert_eq!(foo(), false);
 }


### PR DESCRIPTION
We no longer require `use` and `extern crate` items to precede other items in modules thanks to [RFC #385](https://github.com/rust-lang/rfcs/pull/385), but we still require `use` and `extern crate` items to precede statements in blocks (other items can appear anywhere in a block).

I think that this is a needless distinction between imports and other items that contradicts the intent of the RFC.
