### PR TITLE
Fix pretty_printer to print omitted type `_` marker

### DIFF
--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -425,7 +425,7 @@ pub fn variant_to_string(var: &ast::Variant) -> String {
 }
 
 pub fn arg_to_string(arg: &ast::Arg) -> String {
-    to_string(|s| s.print_arg(arg))
+    to_string(|s| s.print_arg(arg, false))
 }
 
 pub fn mac_to_string(arg: &ast::Mac) -> String {
@@ -2672,8 +2672,8 @@ impl<'a> State<'a> {
     }
 
     pub fn print_fn_args(&mut self, decl: &ast::FnDecl,
-                         opt_explicit_self: Option<&ast::ExplicitSelf_>)
-        -> io::Result<()> {
+                         opt_explicit_self: Option<&ast::ExplicitSelf_>,
+                         is_closure: bool) -> io::Result<()> {
         // It is unfortunate to duplicate the commasep logic, but we want the
         // self type and the args all in the same box.
         try!(self.rbox(0, Inconsistent));
@@ -2698,7 +2698,7 @@ impl<'a> State<'a> {
 
         for arg in args {
             if first { first = false; } else { try!(self.word_space(",")); }
-            try!(self.print_arg(arg));
+            try!(self.print_arg(arg, is_closure));
         }
 
         self.end()
@@ -2708,7 +2708,7 @@ impl<'a> State<'a> {
                                  opt_explicit_self: Option<&ast::ExplicitSelf_>)
         -> io::Result<()> {
         try!(self.popen());
-        try!(self.print_fn_args(decl, opt_explicit_self));
+        try!(self.print_fn_args(decl, opt_explicit_self, false));
         if decl.variadic {
             try!(word(&mut self.s, ", ..."));
         }
@@ -2722,7 +2722,7 @@ impl<'a> State<'a> {
             decl: &ast::FnDecl)
             -> io::Result<()> {
         try!(word(&mut self.s, "|"));
-        try!(self.print_fn_args(decl, None));
+        try!(self.print_fn_args(decl, None, true));
         try!(word(&mut self.s, "|"));
 
         if let ast::DefaultReturn(..) = decl.output {
@@ -2967,10 +2967,10 @@ impl<'a> State<'a> {
         self.print_type(&*mt.ty)
     }
 
-    pub fn print_arg(&mut self, input: &ast::Arg) -> io::Result<()> {
+    pub fn print_arg(&mut self, input: &ast::Arg, is_closure: bool) -> io::Result<()> {
         try!(self.ibox(INDENT_UNIT));
         match input.ty.node {
-            ast::TyInfer => try!(self.print_pat(&*input.pat)),
+            ast::TyInfer if is_closure => try!(self.print_pat(&*input.pat)),
             _ => {
                 match input.pat.node {
                     ast::PatIdent(_, ref path1, _) if

--- a/src/test/pretty/issue-31073.pp
+++ b/src/test/pretty/issue-31073.pp
@@ -1,0 +1,17 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// pp-exact:issue-31073.pp
+
+fn main() {
+    fn f1(x: i32, y: i32) -> i32 { y }
+    let f: fn(_, i32) -> i32 = f1;
+    f(1, 2);
+}

--- a/src/test/pretty/issue-31073.rs
+++ b/src/test/pretty/issue-31073.rs
@@ -1,0 +1,17 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// pp-exact:issue-31073.pp
+
+fn main() {
+    fn f1(x: i32, y: i32) -> i32 { y }
+    let f: fn(_, i32) -> i32 = f1;
+    f(1, 2);
+}


### PR DESCRIPTION
Fixes #31073 
r? @eddyb 
