### PR TITLE
fix condition for clang

### DIFF
--- a/configure
+++ b/configure
@@ -1051,7 +1051,7 @@ then
             esac
         else
             case $CFG_CLANG_VERSION in
-                (3.2* | 3.3* | 3.4* | 3.5* | 3.6* | 3.7* | 3.8*)
+                (3.2* | 3.3* | 3.4* | 3.5* | 3.6* | 3.7* | 3.8* | 3.9*)
                 step_msg "found ok version of CLANG: $CFG_CLANG_VERSION"
                 ;;
                 (*)


### PR DESCRIPTION
Version of Clang in repository is 3.9

So, error is caused by 

```
./configure --enable-dist-host-only --enable-clang
```

Then, I got

```
configure: error: bad CLANG version: 3.9.0 (http://llvm.org/git/clang.git 3d5d4c39659f11dfbe8e11c857cadf5c449b559b) (http://llvm.org/git/llvm.git, need >=3.0svn
```

I fixed this issue by appending 3.9\* in the if sentence.
Thanks.
