### PR TITLE
Add snapshotting to ObligationForest, take 2

### DIFF
--- a/src/librustc/middle/traits/fulfill.rs
+++ b/src/librustc/middle/traits/fulfill.rs
@@ -42,7 +42,7 @@ pub struct GlobalFulfilledPredicates<'tcx> {
     dep_graph: DepGraph,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct LocalFulfilledPredicates<'tcx> {
     set: FnvHashSet<ty::Predicate<'tcx>>,
     log: Option<(Rc<RefCell<ObligationForestUndoLog<'tcx>>>, usize)>,

--- a/src/librustc/middle/traits/fulfill.rs
+++ b/src/librustc/middle/traits/fulfill.rs
@@ -11,8 +11,11 @@
 use dep_graph::DepGraph;
 use middle::infer::InferCtxt;
 use middle::ty::{self, Ty, TypeFoldable};
-use rustc_data_structures::obligation_forest::{Backtrace, ObligationForest, Error};
+use rustc_data_structures::obligation_forest::{Backtrace, ObligationForest, UndoLog, Error};
+use rustc_data_structures::undoable::{Undoable, UndoableTracker, Undoer};
+use std::cell::RefCell;
 use std::iter;
+use std::rc::Rc;
 use syntax::ast;
 use util::common::ErrorReported;
 use util::nodemap::{FnvHashMap, FnvHashSet, NodeMap};
@@ -31,14 +34,18 @@ use super::select::SelectionContext;
 use super::Unimplemented;
 use super::util::predicate_for_builtin_bound;
 
+pub type ObligationForestUndoLog<'tcx> = UndoLog<PendingPredicateObligation<'tcx>,
+                                                 LocalFulfilledPredicates<'tcx>>;
+
 pub struct GlobalFulfilledPredicates<'tcx> {
     set: FnvHashSet<ty::PolyTraitPredicate<'tcx>>,
     dep_graph: DepGraph,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LocalFulfilledPredicates<'tcx> {
-    set: FnvHashSet<ty::Predicate<'tcx>>
+    set: FnvHashSet<ty::Predicate<'tcx>>,
+    log: Option<(Rc<RefCell<ObligationForestUndoLog<'tcx>>>, usize)>,
 }
 
 /// The fulfillment context is used to drive trait resolution.  It
@@ -109,6 +116,12 @@ pub struct PendingPredicateObligation<'tcx> {
     pub obligation: PredicateObligation<'tcx>,
     pub stalled_on: Vec<Ty<'tcx>>,
 }
+
+#[derive(Debug)]
+pub enum LocalFulfilledPredicatesAction<'tcx> {
+    Add { key: ty::Predicate<'tcx> }
+}
+
 
 impl<'tcx> FulfillmentContext<'tcx> {
     /// Creates a new fulfillment context.
@@ -670,11 +683,19 @@ fn register_region_obligation<'tcx>(t_a: Ty<'tcx>,
 impl<'tcx> LocalFulfilledPredicates<'tcx> {
     pub fn new() -> LocalFulfilledPredicates<'tcx> {
         LocalFulfilledPredicates {
-            set: FnvHashSet()
+            set: FnvHashSet(),
+            log: None,
         }
     }
 
     fn is_duplicate_or_add(&mut self, key: &ty::Predicate<'tcx>) -> bool {
+        let insert_result = self.set.insert(key.clone());
+        if insert_result {
+            if let Some((ref log, id)) = self.log {
+                (*log).borrow_mut().push_action(
+                    id, LocalFulfilledPredicatesAction::Add { key: key.clone() });
+            }
+        }
         // For a `LocalFulfilledPredicates`, if we find a match, we
         // don't need to add a read edge to the dep-graph. This is
         // because it means that the predicate has already been
@@ -682,7 +703,26 @@ impl<'tcx> LocalFulfilledPredicates<'tcx> {
         // containing task will already have an edge. (Here we are
         // assuming each `FulfillmentContext` only gets used from one
         // task; but to do otherwise makes no sense)
-        !self.set.insert(key.clone())
+        !insert_result
+    }
+}
+
+impl<'tcx> Undoer for LocalFulfilledPredicatesAction<'tcx> {
+    type Undoable = LocalFulfilledPredicates<'tcx>;
+    fn undo(self, predicates: &mut LocalFulfilledPredicates<'tcx>) {
+        match self {
+            LocalFulfilledPredicatesAction::Add { key } => {
+                assert!(predicates.set.remove(&key));
+            }
+        }
+    }
+}
+
+impl<'tcx> Undoable for LocalFulfilledPredicates<'tcx> {
+    type Undoer = LocalFulfilledPredicatesAction<'tcx>;
+    type Tracker = ObligationForestUndoLog<'tcx>;
+    fn register_tracker(&mut self, log: Rc<RefCell<Self::Tracker>>, id: usize) {
+        self.log = Some((log, id));
     }
 }
 

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -44,6 +44,7 @@ pub mod transitive_relation;
 pub mod unify;
 pub mod fnv;
 pub mod tuple_slice;
+pub mod undoable;
 pub mod veccell;
 
 // See comments in src/librustc/lib.rs

--- a/src/librustc_data_structures/undoable.rs
+++ b/src/librustc_data_structures/undoable.rs
@@ -1,0 +1,35 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::cell::RefCell;
+use std::fmt::Debug;
+use std::rc::Rc;
+
+/// Tracks undoable actions.
+pub trait UndoableTracker {
+    type Undoable: ?Sized + Undoable;
+    fn push_action(&mut self, id: usize, undoer: <Self::Undoable as Undoable>::Undoer);
+}
+
+/// The 'undo' part of an undoable action that may be tracked by an UndoableTracker.
+pub trait Undoer {
+    type Undoable: ?Sized + Undoable;
+    fn undo(self, item: &mut Self::Undoable);
+}
+
+/// Type that is contractually obligated to push undoable actions onto any (single) registered
+/// tracker.
+pub trait Undoable {
+    type Undoer: Undoer<Undoable=Self> + Debug;
+    type Tracker: UndoableTracker<Undoable=Self>;
+    // We use an Rc here due to it being difficult to represent a reference-to-owner safely in the
+    // type system.
+    fn register_tracker(&mut self, tracker: Rc<RefCell<Self::Tracker>>, id: usize);
+}


### PR DESCRIPTION
Take 2 (3?) of adding snapshotting to `ObligationForest`, this time with a simpler undo-list approach (separate PR because the last one's commit deltas were nearly removed from history with these). Additionally adds snapshotting methods to `FulfillmentContext`.

Note: I tried adding the snapshotting of the `FulfillmentContext` to snapshotting calls in `InferCtxt` and hit `RefCell` borrow panics. The `action` callback in the `ObligationForest::process_obligations` call attempts to borrow the `FulfillmentContext` already in the middle of a `select_*` (specifically for a probe), and because we've already borrowed it in the earlier stack frame for calling `select_*` it falls on its face. If I understand the rest of the compiler correctly, the usual solution is to make everything a `RefCell`. We could do that in `ObligationForest` and in `FulfillmentContext`, but then that means every call to `process_obligations` would need to make a copy of `<self as ObligationForest>.nodes: Vec` to release all borrows surrounding the call to `action` in `ObligationForest::process_obligations`. Moreover, because `action`s may do more mutating things with the `ObligationForest`, the alternative of not making a copy via something unsafe could leave us with a dangling mutable reference if some `action` increases the size of `nodes`... which then leads to the alternative of using a stable vec (and other more complicated possibilities maintaining the required invariants). The rabbit hole goes down a ways...

Playing with some notion of a `StackCell` <sup>(wc?)</sup> (something that explicitly allows one mutable borrow per snapshot level) could be fruitful, at least to bless the needed patterns of unsafe code for partially persistent structures as discouraged yet idiomatic, or perhaps much better finding a way of guaranteeing the invariants of snapshotting.

r? @nikomatsakis
cc @jroesch (because I think you're doing something eventually with a snapshotting trait?)
