### PR TITLE
librustc/middle/dataflow.rs: Debug to STDERR

### DIFF
--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -527,8 +527,7 @@ impl<'a, 'tcx, O:DataFlowOperator+Clone+'static> DataFlowContext<'a, 'tcx, O> {
         debug!("{}", {
             let mut v = Vec::new();
             self.pretty_print_to(box &mut v, blk).unwrap();
-            println!("{}", String::from_utf8(v).unwrap());
-            ""
+            String::from_utf8(v).unwrap()
         });
     }
 


### PR DESCRIPTION
In 95d904625b4d45af80b4e40d51a3a0fde1abaa8a output was accidentally moved
from STDERR to STDOUT.

This commit also changes the order of debug output. Previously, it was:

```
/* id 22: … */ {
  …
}
DEBUG:rustc::middle::dataflow:
```

Now, it is:

```
DEBUG:rustc::middle::dataflow: /* id 22: … */ {
  …
}
```
