### PR TITLE
fallback to CFG_PREFIX as default sysroot

### DIFF
--- a/src/librustc/session/filesearch.rs
+++ b/src/librustc/session/filesearch.rs
@@ -162,7 +162,10 @@ pub fn get_or_default_sysroot() -> PathBuf {
 
     match canonicalize(env::current_exe().ok()) {
         Some(mut p) => { p.pop(); p.pop(); p }
-        None => panic!("can't determine value for sysroot")
+        None => match option_env!("CFG_PREFIX") {
+            Some(dir) => PathBuf::from(dir),
+            None => panic!("can't determine value for sysroot")
+        }
     }
 }
 


### PR DESCRIPTION
Some targets (OpenBSD in mind) don't have reliable way to get
env::current_exe() value. But for determining the sysroot value, this
function is used.

Instead of panicing, use `CFG_PREFIX' as fallback sysroot value.
