### PR TITLE
[RFC issue 1468] make some common traits object-safe

### DIFF
--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -27,7 +27,7 @@ use marker::Sized;
 ///
 /// This trait can be used with `#[derive]`.
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait Clone : Sized {
+pub trait Clone {
     /// Returns a copy of the value.
     ///
     /// # Examples
@@ -38,7 +38,7 @@ pub trait Clone : Sized {
     /// assert_eq!("Hello", hello.clone());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn clone(&self) -> Self;
+    fn clone(&self) -> Self where Self: Sized;
 
     /// Performs copy-assignment from `source`.
     ///
@@ -47,7 +47,7 @@ pub trait Clone : Sized {
     /// allocations.
     #[inline(always)]
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn clone_from(&mut self, source: &Self) {
+    fn clone_from(&mut self, source: &Self) where Self: Sized {
         *self = source.clone()
     }
 }

--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -76,7 +76,7 @@ pub trait AsMut<T: ?Sized> {
 /// is_hello(s);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait Into<T>: Sized {
+pub trait Into<T> {
     /// Performs the conversion.
     #[stable(feature = "rust1", since = "1.0.0")]
     fn into(self) -> T;
@@ -95,10 +95,10 @@ pub trait Into<T>: Sized {
 /// assert_eq!(string, other_string);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait From<T>: Sized {
+pub trait From<T> {
     /// Performs the conversion.
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn from(T) -> Self;
+    fn from(T) -> Self where Self: Sized;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/libcore/default.rs
+++ b/src/libcore/default.rs
@@ -100,7 +100,7 @@ use marker::Sized;
 /// }
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait Default: Sized {
+pub trait Default {
     /// Returns the "default value" for a type.
     ///
     /// Default values are often some kind of initial value, identity value, or anything else that
@@ -131,7 +131,7 @@ pub trait Default: Sized {
     /// }
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn default() -> Self;
+    fn default() -> Self where Self: Sized;
 }
 
 macro_rules! default_impl {

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -25,8 +25,8 @@ use ptr;
 use mem;
 
 #[doc(hidden)]
-trait Int: Zero + PartialEq + PartialOrd + Div<Output=Self> + Rem<Output=Self> +
-           Sub<Output=Self> + Copy {
+trait Int: Sized + Zero + PartialEq + PartialOrd + Div<Output=Self> +
+           Rem<Output=Self> + Sub<Output=Self> + Copy {
     fn from_u8(u: u8) -> Self;
     fn to_u8(&self) -> u8;
     fn to_u32(&self) -> u32;

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -2296,9 +2296,9 @@ from_str_radix_int_impl! { isize i8 i16 i32 i64 usize u8 u16 u32 u64 }
 trait FromStrRadixHelper: PartialOrd + Copy {
     fn min_value() -> Self;
     fn from_u32(u: u32) -> Self;
-    fn checked_mul(&self, other: u32) -> Option<Self>;
-    fn checked_sub(&self, other: u32) -> Option<Self>;
-    fn checked_add(&self, other: u32) -> Option<Self>;
+    fn checked_mul(&self, other: u32) -> Option<Self> where Self: Sized;
+    fn checked_sub(&self, other: u32) -> Option<Self> where Self: Sized;
+    fn checked_add(&self, other: u32) -> Option<Self> where Self: Sized;
 }
 
 macro_rules! doit {

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -56,9 +56,9 @@ pub mod diy_float;
 #[unstable(feature = "zero_one",
            reason = "unsure of placement, wants to use associated constants",
            issue = "27739")]
-pub trait Zero: Sized {
+pub trait Zero {
     /// The "zero" (usually, additive identity) for this type.
-    fn zero() -> Self;
+    fn zero() -> Self where Self: Sized;
 }
 
 /// Types that have a "one" value.
@@ -68,9 +68,9 @@ pub trait Zero: Sized {
 #[unstable(feature = "zero_one",
            reason = "unsure of placement, wants to use associated constants",
            issue = "27739")]
-pub trait One: Sized {
+pub trait One {
     /// The "one" (usually, multiplicative identity) for this type.
-    fn one() -> Self;
+    fn one() -> Self where Self: Sized;
 }
 
 macro_rules! zero_one_impl {

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -45,7 +45,7 @@ pub mod pattern;
 /// [`str`]: ../primitive.str.html
 /// [`parse()`]: ../primitive.str.html#method.parse
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait FromStr: Sized {
+pub trait FromStr {
     /// The associated error which can be returned from parsing.
     #[stable(feature = "rust1", since = "1.0.0")]
     type Err;
@@ -71,7 +71,7 @@ pub trait FromStr: Sized {
     /// assert_eq!(5, x);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn from_str(s: &str) -> Result<Self, Self::Err>;
+    fn from_str(s: &str) -> Result<Self, Self::Err> where Self: Sized;
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/librustc/middle/ty/fold.rs
+++ b/src/librustc/middle/ty/fold.rs
@@ -49,7 +49,7 @@ use util::nodemap::{FnvHashMap, FnvHashSet};
 
 /// The TypeFoldable trait is implemented for every type that can be folded.
 /// Basically, every type that has a corresponding method in TypeFolder.
-pub trait TypeFoldable<'tcx>: fmt::Debug + Clone {
+pub trait TypeFoldable<'tcx>: Sized + fmt::Debug + Clone {
     fn super_fold_with<F: TypeFolder<'tcx>>(&self, folder: &mut F) -> Self;
     fn fold_with<F: TypeFolder<'tcx>>(&self, folder: &mut F) -> Self {
         self.super_fold_with(folder)

--- a/src/librustc_data_structures/unify/mod.rs
+++ b/src/librustc_data_structures/unify/mod.rs
@@ -27,7 +27,7 @@ mod tests;
 ///
 /// Clients are expected to provide implementations of this trait; you
 /// can see some examples in the `test` module.
-pub trait UnifyKey : Copy + Clone + Debug + PartialEq {
+pub trait UnifyKey : Sized + Copy + Clone + Debug + PartialEq {
     type Value: Clone + PartialEq + Debug;
 
     fn index(&self) -> u32;

--- a/src/test/auxiliary/trait_inheritance_overloading_xc.rs
+++ b/src/test/auxiliary/trait_inheritance_overloading_xc.rs
@@ -11,7 +11,8 @@
 use std::cmp::PartialEq;
 use std::ops::{Add, Sub, Mul};
 
-pub trait MyNum : Sized + Add<Output=Self> + Sub<Output=Self> + Mul<Output=Self> + PartialEq + Clone {
+pub trait MyNum : Sized + Add<Output=Self> + Sub<Output=Self> + Mul<Output=Self>
+                + PartialEq + Clone {
 }
 
 #[derive(Clone, Debug)]

--- a/src/test/auxiliary/trait_inheritance_overloading_xc.rs
+++ b/src/test/auxiliary/trait_inheritance_overloading_xc.rs
@@ -11,7 +11,7 @@
 use std::cmp::PartialEq;
 use std::ops::{Add, Sub, Mul};
 
-pub trait MyNum : Add<Output=Self> + Sub<Output=Self> + Mul<Output=Self> + PartialEq + Clone {
+pub trait MyNum : Sized + Add<Output=Self> + Sub<Output=Self> + Mul<Output=Self> + PartialEq + Clone {
 }
 
 #[derive(Clone, Debug)]

--- a/src/test/compile-fail/kindck-inherited-copy-bound.rs
+++ b/src/test/compile-fail/kindck-inherited-copy-bound.rs
@@ -32,8 +32,7 @@ fn b() {
     let x: Box<_> = box 3;
     let y = &x;
     let z = &x as &Foo;
-    //~^ ERROR E0038
-    //~| ERROR E0038
+    //~^ ERROR E0277
 }
 
 fn main() { }

--- a/src/test/compile-fail/type-params-in-different-spaces-1.rs
+++ b/src/test/compile-fail/type-params-in-different-spaces-1.rs
@@ -10,7 +10,7 @@
 
 use std::ops::Add;
 
-trait BrokenAdd: Copy + Add<Output=Self> {
+trait BrokenAdd: Sized + Copy + Add<Output=Self> {
     fn broken_add<T>(&self, rhs: T) -> Self {
         *self + rhs //~  ERROR mismatched types
                     //~| expected `Self`

--- a/src/test/run-pass/clone-object-safe.rs
+++ b/src/test/run-pass/clone-object-safe.rs
@@ -1,0 +1,30 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+// Test that Clone and other common traits are object-safe.
+
+#![feature(zero_one)]
+
+macro_rules! check {
+    ($($trate:path),*) => {
+        $(let _: Box<$trate>;)*
+    }
+}
+
+fn main() {
+    check!(Clone,
+           Default,
+           From<()>,
+           Into<()>,
+           std::str::FromStr<Err=()>,
+           std::num::One,
+           std::num::Zero);
+}
+

--- a/src/test/run-pass/issue-23485.rs
+++ b/src/test/run-pass/issue-23485.rs
@@ -13,12 +13,7 @@
 // problem occurred specifically because normalizing
 // `Self::Item::Target` was impossible in this case.
 
-use std::boxed::Box;
-use std::marker::Sized;
-use std::clone::Clone;
 use std::ops::Deref;
-use std::option::Option;
-use std::option::Option::{Some,None};
 
 trait Iterator {
     type Item;
@@ -28,7 +23,7 @@ trait Iterator {
     fn clone_first(mut self) -> Option<<Self::Item as Deref>::Target> where
         Self: Sized,
         Self::Item: Deref,
-        <Self::Item as Deref>::Target: Clone,
+        <Self::Item as Deref>::Target: Clone + Sized,
     {
         self.next().map(|x| x.clone())
     }

--- a/src/test/run-pass/trait-inheritance-overloading-simple.rs
+++ b/src/test/run-pass/trait-inheritance-overloading-simple.rs
@@ -32,4 +32,5 @@ pub fn main() {
     let (x, y, z) = (mi(3), mi(5), mi(3));
     assert!(x != y);
     assert_eq!(x, z);
+    assert!(!f(x, y));
 }

--- a/src/test/run-pass/trait-inheritance-overloading.rs
+++ b/src/test/run-pass/trait-inheritance-overloading.rs
@@ -11,7 +11,7 @@
 use std::cmp::PartialEq;
 use std::ops::{Add, Sub, Mul};
 
-trait MyNum : Add<Output=Self> + Sub<Output=Self> + Mul<Output=Self> + PartialEq + Clone { }
+trait MyNum : Sized + Add<Output=Self> + Sub<Output=Self> + Mul<Output=Self> + PartialEq + Clone { }
 
 #[derive(Clone, Debug)]
 struct MyInt { val: isize }


### PR DESCRIPTION
This is a very dubious change but @eddyb was curious about the fallout. @brson crater this too?

cc rust-lang/rfcs#1468
