### PR TITLE
(take 2) libsyntax: note that `let a = (let b = something)` is invalid 

### DIFF
--- a/src/libsyntax/errors/emitter.rs
+++ b/src/libsyntax/errors/emitter.rs
@@ -10,7 +10,7 @@
 
 use self::Destination::*;
 
-use codemap::{self, COMMAND_LINE_SP, COMMAND_LINE_EXPN, Pos, Span};
+use codemap::{self, COMMAND_LINE_SP, COMMAND_LINE_EXPN, DUMMY_SP, Pos, Span};
 use diagnostics;
 
 use errors::{Level, RenderSpan, DiagnosticBuilder};
@@ -109,8 +109,8 @@ impl Emitter for EmitterWriter {
             lvl: Level) {
         let error = match sp {
             Some(COMMAND_LINE_SP) => self.emit_(FileLine(COMMAND_LINE_SP), msg, code, lvl),
+            Some(DUMMY_SP) | None => print_diagnostic(&mut self.dst, "", lvl, msg, code),
             Some(sp) => self.emit_(FullSpan(sp), msg, code, lvl),
-            None => print_diagnostic(&mut self.dst, "", lvl, msg, code),
         };
 
         if let Err(e) = error {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2156,12 +2156,6 @@ impl<'a> Parser<'a> {
                     let lo = self.last_span.lo;
                     return self.parse_while_expr(None, lo, attrs);
                 }
-                if self.token.is_keyword(keywords::Let) {
-                    // Catch this syntax error here, instead of in `check_strict_keywords`, so
-                    // that we can explicitly mention that let is not to be used as an expression
-                    let msg = "`let` is not an expression, so it cannot be used in this way";
-                    self.span_err(self.span, msg);
-                }
                 if self.token.is_lifetime() {
                     let lifetime = self.get_lifetime();
                     let lo = self.span.lo;
@@ -2224,6 +2218,11 @@ impl<'a> Parser<'a> {
                         ex = ExprBreak(None);
                     }
                     hi = self.last_span.hi;
+                } else if self.token.is_keyword(keywords::Let) {
+                    // Catch this syntax error here, instead of in `check_strict_keywords`, so
+                    // that we can explicitly mention that let is not to be used as an expression
+                    let msg = "`let` is not an expression, so it cannot be used in this way";
+                    return Err(self.fatal(&msg));
                 } else if self.check(&token::ModSep) ||
                         self.token.is_ident() &&
                         !self.check_keyword(keywords::True) &&

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2199,6 +2199,12 @@ impl<'a> Parser<'a> {
                         UnsafeBlock(ast::UserProvided),
                         attrs);
                 }
+                if self.eat_keyword(keywords::Let) {
+                    return Err(self.span_fatal(self.span,
+                                               "`let` is not an expression, so it cannot \
+                                                be used in this way"))
+
+                }
                 if self.eat_keyword(keywords::Return) {
                     if self.token.can_begin_expr() {
                         let e = try!(self.parse_expr());

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2134,6 +2134,12 @@ impl<'a> Parser<'a> {
                 }
                 hi = self.last_span.hi;
             }
+            _ if self.token.is_keyword(keywords::Let) => {
+                // Catch this syntax error here, instead of in `check_strict_keywords`, so that
+                // we can explicitly mention that let is not to be used as an expression
+                let msg = "`let` is not an expression, so it cannot be used in this way";
+                return Err(self.diagnostic().struct_span_err(self.span, &msg));
+            },
             _ => {
                 if self.eat_lt() {
                     let (qself, path) =
@@ -2198,12 +2204,6 @@ impl<'a> Parser<'a> {
                         lo,
                         UnsafeBlock(ast::UserProvided),
                         attrs);
-                }
-                if self.eat_keyword(keywords::Let) {
-                    return Err(self.span_fatal(self.span,
-                                               "`let` is not an expression, so it cannot \
-                                                be used in this way"))
-
                 }
                 if self.eat_keyword(keywords::Return) {
                     if self.token.can_begin_expr() {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2134,12 +2134,6 @@ impl<'a> Parser<'a> {
                 }
                 hi = self.last_span.hi;
             }
-            _ if self.token.is_keyword(keywords::Let) => {
-                // Catch this syntax error here, instead of in `check_strict_keywords`, so that
-                // we can explicitly mention that let is not to be used as an expression
-                let msg = "`let` is not an expression, so it cannot be used in this way";
-                return Err(self.diagnostic().struct_span_err(self.span, &msg));
-            },
             _ => {
                 if self.eat_lt() {
                     let (qself, path) =
@@ -2161,6 +2155,12 @@ impl<'a> Parser<'a> {
                 if self.eat_keyword(keywords::While) {
                     let lo = self.last_span.lo;
                     return self.parse_while_expr(None, lo, attrs);
+                }
+                if self.token.is_keyword(keywords::Let) {
+                    // Catch this syntax error here, instead of in `check_strict_keywords`, so
+                    // that we can explicitly mention that let is not to be used as an expression
+                    let msg = "`let` is not an expression, so it cannot be used in this way";
+                    self.span_err(self.span, msg);
                 }
                 if self.token.is_lifetime() {
                     let lifetime = self.get_lifetime();

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2221,8 +2221,9 @@ impl<'a> Parser<'a> {
                 } else if self.token.is_keyword(keywords::Let) {
                     // Catch this syntax error here, instead of in `check_strict_keywords`, so
                     // that we can explicitly mention that let is not to be used as an expression
-                    let msg = "`let` is not an expression, so it cannot be used in this way";
-                    return Err(self.fatal(&msg));
+                    let mut db = self.fatal("expected expression, found statement (`let`)");
+                    db.note("variable declaration using `let` is a statement");
+                    return Err(db);
                 } else if self.check(&token::ModSep) ||
                         self.token.is_ident() &&
                         !self.check_keyword(keywords::True) &&

--- a/src/test/run-fail-fulldeps/qquote.rs
+++ b/src/test/run-fail-fulldeps/qquote.rs
@@ -10,7 +10,7 @@
 
 // ignore-cross-compile
 
-// error-pattern:expected identifier, found keyword `let`
+// error-pattern:`let` is not an expression, so it cannot be used in this way
 
 #![feature(quote, rustc_private)]
 

--- a/src/test/run-fail-fulldeps/qquote.rs
+++ b/src/test/run-fail-fulldeps/qquote.rs
@@ -10,7 +10,7 @@
 
 // ignore-cross-compile
 
-// error-pattern:`let` is not an expression, so it cannot be used in this way
+// error-pattern:expected expression, found statement (`let`)
 
 #![feature(quote, rustc_private)]
 


### PR DESCRIPTION
#30765 with fixes

fixes #30440

r? @eddyb or @nrc
