### PR TITLE
[RFCish] Hack in intrinsics into [MIR]

### DIFF
--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -909,8 +909,14 @@ impl<'tcx> Debug for TypedConstVal<'tcx> {
 pub enum ItemKind {
     Constant,
     /// This is any sort of callable (usually those that have a type of `fn(…) -> …`). This
-    /// includes functions, constructors, but not methods which have their own ItemKind.
+    /// includes functions, constructors, but not methods or intrinsics which have their own
+    /// ItemKind.
     Function,
+    /// An intrinsic.
+    Intrinsic,
+    // Translation of this kind of items differ considerably from Function to warrant their own
+    // kind.
+    /// A method.
     Method,
 }
 

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -678,7 +678,7 @@ impl LateLintPass for ImproperCTypes {
         }
 
         if let hir::ItemForeignMod(ref nmod) = it.node {
-            if nmod.abi != abi::RustIntrinsic && nmod.abi != abi::PlatformIntrinsic {
+            if !nmod.abi.is_intrinsic() {
                 for ni in &nmod.items {
                     match ni.node {
                         hir::ForeignItemFn(ref decl, _) => check_foreign_fn(cx, &**decl),

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -778,7 +778,7 @@ impl<'a, 'b> LocalCrateReader<'a, 'b> {
     }
 
     fn process_foreign_mod(&mut self, i: &hir::Item, fm: &hir::ForeignMod) {
-        if fm.abi == abi::Rust || fm.abi == abi::RustIntrinsic || fm.abi == abi::PlatformIntrinsic {
+        if fm.abi == abi::Rust || fm.abi.is_intrinsic() {
             return;
         }
 

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -1392,7 +1392,7 @@ fn encode_info_for_foreign_item<'a, 'tcx>(ecx: &EncodeContext<'a, 'tcx>,
         encode_family(rbml_w, FN_FAMILY);
         encode_bounds_and_type_for_item(rbml_w, ecx, index, nitem.id);
         encode_name(rbml_w, nitem.name);
-        if abi == abi::RustIntrinsic || abi == abi::PlatformIntrinsic {
+        if abi.is_intrinsic() {
             encode_inlined_item(ecx, rbml_w, InlinedItemRef::Foreign(nitem));
         }
         encode_attributes(rbml_w, &*nitem.attrs);

--- a/src/librustc_trans/trans/foreign.rs
+++ b/src/librustc_trans/trans/foreign.rs
@@ -626,7 +626,7 @@ pub fn trans_rust_fn_with_foreign_abi<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
         // normal Rust function. This will be the type of the wrappee fn.
         match t.sty {
             ty::TyBareFn(_, ref f) => {
-                assert!(f.abi != Rust && f.abi != RustIntrinsic && f.abi != PlatformIntrinsic);
+                assert!(f.abi != Rust && !f.abi.is_intrinsic());
             }
             _ => {
                 ccx.sess().bug(&format!("build_rust_fn: extern fn {} has ty {:?}, \

--- a/src/librustc_trans/trans/mir/constant.rs
+++ b/src/librustc_trans/trans/mir/constant.rs
@@ -86,7 +86,7 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
         match constant.literal {
             mir::Literal::Item { def_id, kind, substs } => {
                 let substs = bcx.tcx().mk_substs(bcx.monomorphize(&substs));
-                self.trans_item_ref(bcx, ty, kind, substs, def_id)
+                self.trans_item_ref(bcx, ty, constant.span, kind, substs, def_id)
             }
             mir::Literal::Value { ref value } => {
                 self.trans_constval(bcx, value, ty)

--- a/src/librustc_trans/trans/mir/mod.rs
+++ b/src/librustc_trans/trans/mir/mod.rs
@@ -191,8 +191,8 @@ fn arg_value_refs<'bcx, 'tcx>(bcx: Block<'bcx, 'tcx>,
 mod analyze;
 mod block;
 mod constant;
-mod lvalue;
-mod rvalue;
-mod operand;
-mod statement;
 mod did;
+mod lvalue;
+mod operand;
+mod rvalue;
+mod statement;

--- a/src/librustc_trans/trans/monomorphize.rs
+++ b/src/librustc_trans/trans/monomorphize.rs
@@ -96,7 +96,7 @@ pub fn monomorphic_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
 
     if let hir_map::NodeForeignItem(_) = map_node {
         let abi = ccx.tcx().map.get_foreign_abi(fn_node_id);
-        if abi != abi::RustIntrinsic && abi != abi::PlatformIntrinsic {
+        if !abi.is_intrinsic() {
             // Foreign externs don't have to be monomorphized.
             return (get_item_val(ccx, fn_node_id), mono_ty, true);
         }

--- a/src/libsyntax/abi.rs
+++ b/src/libsyntax/abi.rs
@@ -125,6 +125,10 @@ impl Abi {
     pub fn name(&self) -> &'static str {
         self.data().name
     }
+
+    pub fn is_intrinsic(self) -> bool {
+        self == Abi::RustIntrinsic || self == Abi::PlatformIntrinsic
+    }
 }
 
 impl fmt::Display for Abi {

--- a/src/test/run-pass/mir_intrinsics.rs
+++ b/src/test/run-pass/mir_intrinsics.rs
@@ -1,0 +1,30 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_attrs, core_intrinsics)]
+
+#[rustc_mir]
+fn zeroed() -> [u64; 5] {
+    unsafe {
+    ::std::intrinsics::init()
+    }
+}
+
+#[rustc_mir]
+fn bswappd() -> u16 {
+    unsafe {
+    ::std::intrinsics::bswap(0xABCD)
+    }
+}
+
+fn main() {
+  assert_eq!(zeroed(), [0, 0, 0, 0, 0]);
+  assert_eq!(bswappd(), 0xCDAB);
+}


### PR DESCRIPTION
`trans_intrinsic_call` is very heavily specialised for the old trans and is hard to reuse. I attempted to change it just enough so it could be usable in MIR, so I woudln’t have to rewrite the whole code dealing with intrinsics for now (though, it seems eventually it’ll have to be done to get satisfactory code quality).

With this, MIR now can translate some simpler intrinsics (i.e. not the `transmute`/`move_val_init`/`try`).
