### PR TITLE
Allow #[repr(i32)] for univariant enum

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4250,14 +4250,9 @@ pub fn check_enum_variants<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
     let def_id = ccx.tcx.map.local_def_id(id);
     let hint = *ccx.tcx.lookup_repr_hints(def_id).get(0).unwrap_or(&attr::ReprAny);
 
-    if hint != attr::ReprAny && vs.len() <= 1 {
-        if vs.len() == 1 {
-            span_err!(ccx.tcx.sess, sp, E0083,
-                "unsupported representation for univariant enum");
-        } else {
-            span_err!(ccx.tcx.sess, sp, E0084,
-                "unsupported representation for zero-variant enum");
-        };
+    if hint != attr::ReprAny && vs.is_empty() {
+        span_err!(ccx.tcx.sess, sp, E0084,
+            "unsupported representation for zero-variant enum");
     }
 
     do_check(ccx, vs, id, hint);

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -1062,13 +1062,6 @@ Note also that without a representation manually defined, the compiler will
 optimize by using the smallest integer type possible.
 "##,
 
-E0083: r##"
-At present, it's not possible to define a custom representation for an enum with
-a single variant. As a workaround you can add a `Dummy` variant.
-
-See: https://github.com/rust-lang/rust/issues/10292
-"##,
-
 E0084: r##"
 It is impossible to define an integer type to be used to represent zero-variant
 enum values because there are no zero-variant enum values. There is no way to

--- a/src/test/run-pass/enum-univariant-repr.rs
+++ b/src/test/run-pass/enum-univariant-repr.rs
@@ -1,0 +1,47 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+use std::mem;
+
+// Univariant C-like enum
+#[repr(i32)]
+enum Univariant {
+    X = 17
+}
+
+#[repr(u16)]
+enum UnivariantWithoutDescr {
+    Y
+}
+
+pub fn main() {
+    {
+        assert_eq!(4, mem::size_of::<Univariant>());
+        assert_eq!(17, Univariant::X as i32);
+
+        let enums: &[Univariant] =
+            &[Univariant::X, Univariant::X, Univariant::X];
+        let ints: &[i32] = unsafe { mem::transmute(enums) };
+        // check it has the same memory layout as i32
+        assert_eq!(&[17, 17, 17], ints);
+    }
+
+    {
+        assert_eq!(2, mem::size_of::<UnivariantWithoutDescr>());
+        let descr = UnivariantWithoutDescr::Y as u16;
+
+        let enums: &[UnivariantWithoutDescr] =
+            &[UnivariantWithoutDescr::Y, UnivariantWithoutDescr::Y, UnivariantWithoutDescr::Y];
+        let ints: &[u16] = unsafe { mem::transmute(enums) };
+        // check it has the same memory layout as u16
+        assert_eq!(&[descr, descr, descr], ints);
+    }
+}


### PR DESCRIPTION
```
#[repr(i32)]
enum Univariant {
    X = 17
}
```

Fixes #10292
