### PR TITLE
Library changes in rustc_trans

### DIFF
--- a/src/librustc_trans/save/mod.rs
+++ b/src/librustc_trans/save/mod.rs
@@ -30,11 +30,10 @@ use syntax::print::pprust::ty_to_string;
 
 use self::span_utils::SpanUtils;
 
+pub mod dump_csv;
 #[macro_use]
 pub mod span_utils;
 pub mod recorder;
-
-mod dump_csv;
 
 pub struct SaveContext<'l, 'tcx: 'l> {
     tcx: &'l ty::ctxt<'tcx>,
@@ -764,7 +763,7 @@ pub fn process_crate<'l, 'tcx>(tcx: &'l ty::ctxt<'tcx>,
     out_name.push_str(&tcx.sess.opts.cg.extra_filename);
     out_name.push_str(".csv");
     root_path.push(&out_name);
-    let output_file = match File::create(&root_path) {
+    let mut output_file = match File::create(&root_path) {
         Ok(f) => box f,
         Err(e) => {
             let disp = root_path.display();
@@ -773,7 +772,7 @@ pub fn process_crate<'l, 'tcx>(tcx: &'l ty::ctxt<'tcx>,
     };
     root_path.pop();
 
-    let mut visitor = dump_csv::DumpCsvVisitor::new(tcx, lcx, analysis, output_file);
+    let mut visitor = dump_csv::DumpCsvVisitor::new(tcx, lcx, analysis, &mut output_file);
 
     visitor.dump_crate_info(cratename, krate);
     visit::walk_crate(&mut visitor, krate);

--- a/src/librustc_trans/save/recorder.rs
+++ b/src/librustc_trans/save/recorder.rs
@@ -28,13 +28,13 @@ const CRATE_ROOT_DEF_ID: DefId = DefId {
     index: CRATE_DEF_INDEX,
 };
 
-pub struct Recorder {
+pub struct Recorder<'a> {
     // output file
-    pub out: Box<Write + 'static>,
+    pub out: &'a mut (Write + 'a),
     pub dump_spans: bool,
 }
 
-impl Recorder {
+impl<'a> Recorder<'a> {
     pub fn record(&mut self, info: &str) {
         match write!(self.out, "{}", info) {
             Err(_) => error!("Error writing output '{}'", info),
@@ -52,8 +52,8 @@ impl Recorder {
     }
 }
 
-pub struct FmtStrs<'a, 'tcx: 'a> {
-    pub recorder: Box<Recorder>,
+pub struct FmtStrs<'a, 'tcx: 'a, 'output> {
+    pub recorder: Box<Recorder<'output>>,
     span: SpanUtils<'a>,
     tcx: &'a ty::ctxt<'tcx>,
 }
@@ -98,11 +98,11 @@ pub enum Row {
     FnRef,
 }
 
-impl<'a, 'tcx: 'a> FmtStrs<'a, 'tcx> {
-    pub fn new(rec: Box<Recorder>,
+impl<'a, 'tcx: 'a, 'r> FmtStrs<'a, 'tcx, 'r> {
+    pub fn new(rec: Box<Recorder<'r>>,
                span: SpanUtils<'a>,
                tcx: &'a ty::ctxt<'tcx>)
-               -> FmtStrs<'a, 'tcx> {
+               -> FmtStrs<'a, 'tcx, 'r> {
         FmtStrs {
             recorder: rec,
             span: span,


### PR DESCRIPTION
These changes allow users of `rustc_trans` to generate csv data to memory
instead of directly to a file. It also makes the `dump_csv` module public,
in order to make the functionality accessible.

r? @nrc 
