### PR TITLE
Improve computation of offset in `EscapeUnicode`

### DIFF
--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -470,7 +470,8 @@ impl Iterator for EscapeUnicode {
                 Some('{')
             }
             EscapeUnicodeState::Value => {
-                let c = from_digit(((self.c as u32) >> (self.hex_digit_idx * 4)) & 0xf, 16).unwrap();
+                let hex_digit = ((self.c as u32) >> (self.hex_digit_idx * 4)) & 0xf;
+                let c = from_digit(hex_digit, 16).unwrap();
                 if self.hex_digit_idx == 0 {
                     self.state = EscapeUnicodeState::RightBrace;
                 } else {

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -299,14 +299,16 @@ impl CharExt for char {
 
     #[inline]
     fn escape_unicode(self) -> EscapeUnicode {
-        let mut n = 0;
-        while (self as u32) >> (4 * (n + 1)) != 0 {
-            n += 1;
-        }
+        let c = self as u32;
+        // or-ing 1 ensures that for c==0 the code computes that one
+        // digit should be printed and (which is the same) avoids the
+        // (31 - 32) underflow
+        let msb = 31 - (c | 1).leading_zeros();
+        let msdigit = msb / 4;
         EscapeUnicode {
             c: self,
             state: EscapeUnicodeState::Backslash,
-            offset: n,
+            offset: msdigit as usize,
         }
     }
 


### PR DESCRIPTION
Unify the computation of `offset` and use `leading_zeros` instead of manually scanning the bits.
This PR removes some duplicated code and makes it a little simpler .
The computation of `offset` is also faster, but it is unlikely to have an impact on actual code.

(split from #31049)
