### PR TITLE
don't leak environment variables into test process

### DIFF
--- a/src/test/run-pass/multi-panic.rs
+++ b/src/test/run-pass/multi-panic.rs
@@ -17,7 +17,10 @@ fn main() {
 
         panic!();
     } else {
-        let test = std::process::Command::new(&args[0]).arg("run_test").output().unwrap();
+        let test = std::process::Command::new(&args[0]).arg("run_test")
+                                                       .env_remove("RUST_BACKTRACE")
+                                                       .output()
+                                                       .unwrap();
         assert!(!test.status.success());
         let err = String::from_utf8_lossy(&test.stderr);
         let mut it = err.lines();


### PR DESCRIPTION
if the tests were run with `RUST_BACKTRACE=1 make check` this test failed. If they were run without `RUST_BACKTRACE=1` it succeeded.
