### PR TITLE
Fixes #31229 fixes up BSD type mismatch errors and updates libc dependency part deux

### DIFF
--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -224,7 +224,7 @@ impl DirEntry {
     fn name_bytes(&self) -> &[u8] {
         unsafe {
             ::slice::from_raw_parts(self.entry.d_name.as_ptr() as *const u8,
-                                    self.entry.d_namelen as usize)
+                                    self.entry.d_namlen as usize)
         }
     }
     #[cfg(any(target_os = "android",

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -211,14 +211,8 @@ impl DirEntry {
     #[cfg(any(target_os = "macos",
               target_os = "ios",
               target_os = "netbsd",
-              target_os = "openbsd"))]
-    fn name_bytes(&self) -> &[u8] {
-        unsafe {
-            ::slice::from_raw_parts(self.entry.d_name.as_ptr() as *const u8,
-                                    self.entry.d_namlen as usize)
-        }
-    }
-    #[cfg(any(target_os = "freebsd",
+              target_os = "openbsd",
+              target_os = "freebsd",
               target_os = "dragonfly",
               target_os = "bitrig"))]
     fn name_bytes(&self) -> &[u8] {

--- a/src/libstd/sys/unix/stack_overflow.rs
+++ b/src/libstd/sys/unix/stack_overflow.rs
@@ -135,12 +135,7 @@ mod imp {
         Handler { _data: MAIN_ALTSTACK };
     }
 
-    #[cfg(any(target_os = "linux",
-              target_os = "macos",
-              target_os = "bitrig",
-              target_os = "netbsd",
-              target_os = "openbsd"))]
-    unsafe fn get_stack() -> libc::stack_t {
+    unsafe fn get_stack() -> *mut i8 {
         let stackp = mmap(ptr::null_mut(),
                           SIGSTKSZ,
                           PROT_READ | PROT_WRITE,
@@ -150,27 +145,11 @@ mod imp {
         if stackp == MAP_FAILED {
             panic!("failed to allocate an alternative stack");
         }
-        libc::stack_t { ss_sp: stackp, ss_flags: 0, ss_size: SIGSTKSZ }
+        stackp as *mut i8
     }
-
-    #[cfg(any(target_os = "dragonfly",
-              target_os = "freebsd"))]
-    unsafe fn get_stack() -> libc::stack_t {
-        let stackp = mmap(ptr::null_mut(),
-                          SIGSTKSZ,
-                          PROT_READ | PROT_WRITE,
-                          MAP_PRIVATE | MAP_ANON,
-                          -1,
-                          0);
-        if stackp == MAP_FAILED {
-            panic!("failed to allocate an alternative stack");
-        }
-        libc::stack_t { ss_sp: stackp as *mut i8, ss_flags: 0, ss_size: SIGSTKSZ }
-    }
-
 
     pub unsafe fn make_handler() -> Handler {
-        let stack = get_stack();
+        let stack = libc::stack_t { ss_sp: get_stack(), ss_flags: 0, ss_size: SIGSTKSZ }
         sigaltstack(&stack, ptr::null_mut());
         Handler { _data: stack.ss_sp as *mut libc::c_void }
     }

--- a/src/libstd/sys/unix/stack_overflow.rs
+++ b/src/libstd/sys/unix/stack_overflow.rs
@@ -140,46 +140,39 @@ mod imp {
               target_os = "bitrig",
               target_os = "netbsd",
               target_os = "openbsd"))]
-    unsafe fn get_stack() -> *mut libc::c_void {
-        let stack = mmap(ptr::null_mut(),
-                         SIGSTKSZ,
-                         PROT_READ | PROT_WRITE,
-                         MAP_PRIVATE | MAP_ANON,
-                         -1,
-                         0);
-        if stack == MAP_FAILED {
+    unsafe fn get_stack() -> libc::stack_t {
+        let stackp = mmap(ptr::null_mut(),
+                          SIGSTKSZ,
+                          PROT_READ | PROT_WRITE,
+                          MAP_PRIVATE | MAP_ANON,
+                          -1,
+                          0);
+        if stackp == MAP_FAILED {
             panic!("failed to allocate an alternative stack");
         }
-        stack
+        libc::stack_t { ss_sp: stackp, ss_flags: 0, ss_size: SIGSTKSZ }
     }
 
     #[cfg(any(target_os = "dragonfly",
               target_os = "freebsd"))]
-    unsafe fn get_stack() -> *mut i8 {
-        let stack = mmap(ptr::null_mut(),
-                         SIGSTKSZ,
-                         PROT_READ | PROT_WRITE,
-                         MAP_PRIVATE | MAP_ANON,
-                         -1,
-                         0);
-        if stack == MAP_FAILED {
+    unsafe fn get_stack() -> libc::stack_t {
+        let stackp = mmap(ptr::null_mut(),
+                          SIGSTKSZ,
+                          PROT_READ | PROT_WRITE,
+                          MAP_PRIVATE | MAP_ANON,
+                          -1,
+                          0);
+        if stackp == MAP_FAILED {
             panic!("failed to allocate an alternative stack");
         }
-        stack as *mut i8
+        libc::stack_t { ss_sp: stackp as *mut i8, ss_flags: 0, ss_size: SIGSTKSZ }
     }
 
 
     pub unsafe fn make_handler() -> Handler {
-        let alt_stack = get_stack();
-        let mut stack: libc::stack_t = mem::zeroed();
-
-        stack.ss_sp = alt_stack;
-        stack.ss_flags = 0;
-        stack.ss_size = SIGSTKSZ;
-
+        let stack = get_stack();
         sigaltstack(&stack, ptr::null_mut());
-
-        Handler { _data: alt_stack as *mut libc::c_void }
+        Handler { _data: stack.ss_sp as *mut libc::c_void }
     }
 
     pub unsafe fn drop_handler(handler: &mut Handler) {

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -939,18 +939,12 @@ fn get_concurrency() -> usize {
     fn num_cpus() -> usize {
         let mut cpus: libc::c_uint = 0;
         let mut cpus_size = std::mem::size_of_val(&cpus);
-        let mut mib = [libc::CTL_HW, libc::HW_AVAILCPU, 0, 0];
 
         unsafe {
-            libc::sysctl(mib.as_mut_ptr(),
-                         2,
-                         &mut cpus as *mut _ as *mut _,
-                         &mut cpus_size as *mut _ as *mut _,
-                         0 as *mut _,
-                         0);
+            cpus = libc::sysconf(libc::_SC_NPROCESSORS_ONLN) as libc::c_uint;
         }
         if cpus < 1 {
-            mib[1] = libc::HW_NCPU;
+            let mut mib = [libc::CTL_HW, libc::HW_NCPU, 0, 0];
             unsafe {
                 libc::sysctl(mib.as_mut_ptr(),
                              2,


### PR DESCRIPTION
Something went haywire with github last night and the old PR https://github.com/rust-lang/rust/pull/31230 got closed somehow.  This new PR is to replace the old one.  This incorporates all of the feedback from the other PR.

@alexcrichton I incorporated the suggestion from @semarie and the result is cleaner and clearer.  I think this is ready to go.
