### PR TITLE
Fix reference info about parent doc block comments

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -104,7 +104,7 @@ comments (`/** ... */`), are interpreted as a special syntax for `doc`
 `#[doc="..."]` around the body of the comment, i.e., `/// Foo` turns into
 `#[doc="Foo"]`.
 
-Line comments beginning with `//!` and block comments `/*! ... !*/` are
+Line comments beginning with `//!` and block comments `/*! ... */` are
 doc comments that apply to the parent of the comment, rather than the item
 that follows.  That is, they are equivalent to writing `#![doc="..."]` around
 the body of the comment. `//!` comments are usually used to document


### PR DESCRIPTION
Block comments don't have to be in the format `/*! ... !*/`
in order to be read as doc comments about the parent block.
The format `/*! ... */` is enough.
