### PR TITLE
rustdoc: Add missing trailing comma for single element tuples

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -460,7 +460,7 @@ impl fmt::Display for clean::Type {
                     [] => primitive_link(f, clean::PrimitiveTuple, "()"),
                     [ref one] => {
                         try!(primitive_link(f, clean::PrimitiveTuple, "("));
-                        try!(write!(f, "{}", one));
+                        try!(write!(f, "{},", one));
                         primitive_link(f, clean::PrimitiveTuple, ")")
                     }
                     many => {

--- a/src/test/rustdoc/tuples.rs
+++ b/src/test/rustdoc/tuples.rs
@@ -1,0 +1,18 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "foo"]
+
+// @has foo/fn.tuple0.html //pre 'pub fn tuple0(x: ())'
+pub fn tuple0(x: ()) -> () { x }
+// @has foo/fn.tuple1.html //pre 'pub fn tuple1(x: (i32,)) -> (i32,)'
+pub fn tuple1(x: (i32,)) -> (i32,) { x }
+// @has foo/fn.tuple2.html //pre 'pub fn tuple2(x: (i32, i32)) -> (i32, i32)'
+pub fn tuple2(x: (i32, i32)) -> (i32, i32) { x }


### PR DESCRIPTION
It got lost in #31121.
