### PR TITLE
mk: Fix cross prefix for powerpc64

### DIFF
--- a/mk/cfg/powerpc64-unknown-linux-gnu.mk
+++ b/mk/cfg/powerpc64-unknown-linux-gnu.mk
@@ -1,5 +1,5 @@
 # powerpc64-unknown-linux-gnu configuration
-CROSS_PREFIX_powerpc64-unknown-linux-gnu=powerpc64-linux-gnu-
+CROSS_PREFIX_powerpc64-unknown-linux-gnu=powerpc-linux-gnu-
 CC_powerpc64-unknown-linux-gnu=$(CC)
 CXX_powerpc64-unknown-linux-gnu=$(CXX)
 CPP_powerpc64-unknown-linux-gnu=$(CPP)


### PR DESCRIPTION
Looks like the way to create these executables is to use the standard
`powerpc-linux-gnu-gcc` compiler but with the `-m64` option.
