### PR TITLE
rustc: Implement a new `--print cfg` flag

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -163,6 +163,7 @@ pub enum PrintRequest {
     FileNames,
     Sysroot,
     CrateName,
+    Cfg,
 }
 
 pub enum Input {
@@ -1105,6 +1106,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
             "crate-name" => PrintRequest::CrateName,
             "file-names" => PrintRequest::FileNames,
             "sysroot" => PrintRequest::Sysroot,
+            "cfg" => PrintRequest::Cfg,
             req => {
                 early_error(error_format, &format!("unknown print request `{}`", req))
             }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -518,6 +518,25 @@ impl RustcDefaultCalls {
                                       .to_string_lossy());
                     }
                 }
+                PrintRequest::Cfg => {
+                    for cfg in config::build_configuration(sess) {
+                        match cfg.node {
+                            ast::MetaWord(ref word) => println!("{}", word),
+                            ast::MetaNameValue(ref name, ref value) => {
+                                println!("{}=\"{}\"", name, match value.node {
+                                    ast::LitStr(ref s, _) => s,
+                                    _ => continue,
+                                });
+                            }
+                            // Right now there are not and should not be any
+                            // MetaList items in the configuration returned by
+                            // `build_configuration`.
+                            ast::MetaList(..) => {
+                                panic!("MetaList encountered in default cfg")
+                            }
+                        }
+                    }
+                }
             }
         }
         return Compilation::Stop;

--- a/src/test/run-make/print-cfg/Makefile
+++ b/src/test/run-make/print-cfg/Makefile
@@ -1,0 +1,15 @@
+-include ../tools.mk
+
+all: default
+	$(RUSTC) --target x86_64-pc-windows-gnu --print cfg | grep windows
+	$(RUSTC) --target x86_64-pc-windows-gnu --print cfg | grep x86_64
+	$(RUSTC) --target i686-pc-windows-msvc --print cfg | grep msvc
+	$(RUSTC) --target i686-apple-darwin --print cfg | grep macos
+
+ifdef IS_WINDOWS
+default:
+	$(RUSTC) --print cfg | grep windows
+else
+default:
+	$(RUSTC) --print cfg | grep unix
+endif


### PR DESCRIPTION
This commit is an implementation of the new compiler flags required by [RFC
1361](https://github.com/rust-lang/rfcs/blob/master/text/1361-cargo-cfg-dependencies). This specifically adds a new `cfg` option to the `--print` flag to
the compiler. This new directive will print the defined `#[cfg]` directives by
the compiler for the target in question.
