### PR TITLE
Fix link to Installing Rust section of the book

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ and documentation.
 
 Read ["Installing Rust"] from [The Book].
 
-["Installing Rust"]: https://doc.rust-lang.org/book/installing-rust.html
+["Installing Rust"]: https://doc.rust-lang.org/book/getting-started.html#installing-rust
 [The Book]: https://doc.rust-lang.org/book/index.html
 
 ## Building from Source


### PR DESCRIPTION
Perhaps, it makes more sense to link straight to [Installing on Linux or Mac](https://doc.rust-lang.org/book/getting-started.html#installing-on-linux-or-mac) and [Installing on Windows](https://doc.rust-lang.org/book/getting-started.html#installing-on-windows) sections. Platform Support section could be skipped in case of _quick_ start.
