### PR TITLE
Fix truncated drop pattern on 32bit -> 64bit cross compilation

### DIFF
--- a/src/librustc_trans/trans/adt.rs
+++ b/src/librustc_trans/trans/adt.rs
@@ -229,28 +229,12 @@ pub const DTOR_NEEDED_HINT: u8 = 0x3d;
 pub const DTOR_MOVED_HINT: u8 = 0x2d;
 
 pub const DTOR_NEEDED: u8 = 0xd4;
-pub const DTOR_NEEDED_U32: u32 = repeat_u8_as_u32(DTOR_NEEDED);
-pub const DTOR_NEEDED_U64: u64 = repeat_u8_as_u64(DTOR_NEEDED);
 #[allow(dead_code)]
-pub fn dtor_needed_usize(ccx: &CrateContext) -> usize {
-    match &ccx.tcx().sess.target.target.target_pointer_width[..] {
-        "32" => DTOR_NEEDED_U32 as usize,
-        "64" => DTOR_NEEDED_U64 as usize,
-        tws => panic!("Unsupported target word size for int: {}", tws),
-    }
-}
+pub const DTOR_NEEDED_U64: u64 = repeat_u8_as_u64(DTOR_NEEDED);
 
 pub const DTOR_DONE: u8 = 0x1d;
-pub const DTOR_DONE_U32: u32 = repeat_u8_as_u32(DTOR_DONE);
-pub const DTOR_DONE_U64: u64 = repeat_u8_as_u64(DTOR_DONE);
 #[allow(dead_code)]
-pub fn dtor_done_usize(ccx: &CrateContext) -> usize {
-    match &ccx.tcx().sess.target.target.target_pointer_width[..] {
-        "32" => DTOR_DONE_U32 as usize,
-        "64" => DTOR_DONE_U64 as usize,
-        tws => panic!("Unsupported target word size for int: {}", tws),
-    }
-}
+pub const DTOR_DONE_U64: u64 = repeat_u8_as_u64(DTOR_DONE);
 
 fn dtor_to_init_u8(dtor: bool) -> u8 {
     if dtor { DTOR_NEEDED } else { 0 }

--- a/src/librustc_trans/trans/glue.rs
+++ b/src/librustc_trans/trans/glue.rs
@@ -514,7 +514,7 @@ fn make_drop_glue<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, v0: ValueRef, g: DropGlueK
     // the special dtor markings.
 
     let inttype = Type::int(bcx.ccx());
-    let dropped_pattern = C_integral(inttype, adt::dtor_done_usize(bcx.fcx.ccx) as u64, false);
+    let dropped_pattern = C_integral(inttype, adt::DTOR_DONE_U64, false);
 
     match t.sty {
         ty::TyBox(content_ty) => {


### PR DESCRIPTION
When cross compiling for a target that has a larger usize type than the
host system, we use a truncated value to mark data as dropped,
eventually leading to drop calls on already dropped data. To properly
handle this, the drop pattern needs to be of type u64.

Since C_integral truncates its given value to the requested size anyway,
we can also drop the function that chose between the u32 and u64 values,
and always use the u64 constant.

Fixes #31139 

r? @pnkfelix 
