### PR TITLE
fix MIR's `box`

### DIFF
--- a/src/librustc_mir/build/expr/as_rvalue.rs
+++ b/src/librustc_mir/build/expr/as_rvalue.rs
@@ -61,16 +61,15 @@ impl<'a,'tcx> Builder<'a,'tcx> {
             }
             ExprKind::Box { value } => {
                 let value = this.hir.mirror(value);
-                let value_ty = value.ty.clone();
-                let result = this.temp(value_ty.clone());
+                let result = this.temp(expr.ty);
 
                 // to start, malloc some memory of suitable type (thus far, uninitialized):
-                let rvalue = Rvalue::Box(value.ty.clone());
+                let rvalue = Rvalue::Box(value.ty);
                 this.cfg.push_assign(block, expr_span, &result, rvalue);
 
                 // schedule a shallow free of that memory, lest we unwind:
                 let extent = this.extent_of_innermost_scope();
-                this.schedule_drop(expr_span, extent, DropKind::Free, &result, value_ty);
+                this.schedule_drop(expr_span, extent, DropKind::Free, &result, value.ty);
 
                 // initialize the box contents:
                 let contents = result.clone().deref();

--- a/src/test/run-pass/mir_boxing.rs
+++ b/src/test/run-pass/mir_boxing.rs
@@ -1,0 +1,20 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_attrs, box_syntax)]
+
+#[rustc_mir]
+fn test() -> Box<i32> {
+    box 42
+}
+
+fn main() {
+    assert_eq!(*test(), 42);
+}


### PR DESCRIPTION
the previous code generated a temporary of the inner type and assigned the box-memory to it. So if you did `let x: Box<usize> = box 5;` you got a

``` rust
let var0: Box<usize>; // x
let mut tmp0: Box<usize>;
let mut tmp1: usize;
...
tmp1 = Box(usize);
(*tmp1) = const 5;
tmp0 = tmp1;
var0 = tmp0;
```

r? @nagisa 
