### PR TITLE
mk: Fix compiling powerpc64/armv7

### DIFF
--- a/mk/cfg/armv7-unknown-linux-gnueabihf.mk
+++ b/mk/cfg/armv7-unknown-linux-gnueabihf.mk
@@ -1,5 +1,5 @@
 # armv7-unknown-linux-gnueabihf configuration
-CROSS_PREFIX_armv7-unknown-linux-gnueabihf=armv7-unknown-linux-gnueabihf-
+CROSS_PREFIX_armv7-unknown-linux-gnueabihf=arm-linux-gnueabihf-
 CC_armv7-unknown-linux-gnueabihf=gcc
 CXX_armv7-unknown-linux-gnueabihf=g++
 CPP_armv7-unknown-linux-gnueabihf=gcc -E
@@ -8,8 +8,8 @@ CFG_LIB_NAME_armv7-unknown-linux-gnueabihf=lib$(1).so
 CFG_STATIC_LIB_NAME_armv7-unknown-linux-gnueabihf=lib$(1).a
 CFG_LIB_GLOB_armv7-unknown-linux-gnueabihf=lib$(1)-*.so
 CFG_LIB_DSYM_GLOB_armv7-unknown-linux-gnueabihf=lib$(1)-*.dylib.dSYM
-CFG_JEMALLOC_CFLAGS_armv7-unknown-linux-gnueabihf := -D__arm__ $(CFLAGS)
-CFG_GCCISH_CFLAGS_armv7-unknown-linux-gnueabihf := -Wall -g -fPIC -D__arm__ $(CFLAGS)
+CFG_JEMALLOC_CFLAGS_armv7-unknown-linux-gnueabihf := -D__arm__ $(CFLAGS) -march=armv7
+CFG_GCCISH_CFLAGS_armv7-unknown-linux-gnueabihf := -Wall -g -fPIC -D__arm__ $(CFLAGS) -march=armv7
 CFG_GCCISH_CXXFLAGS_armv7-unknown-linux-gnueabihf := -fno-rtti $(CXXFLAGS)
 CFG_GCCISH_LINK_FLAGS_armv7-unknown-linux-gnueabihf := -shared -fPIC -g
 CFG_GCCISH_DEF_FLAG_armv7-unknown-linux-gnueabihf := -Wl,--export-dynamic,--dynamic-list=

--- a/mk/cfg/powerpc64-unknown-linux-gnu.mk
+++ b/mk/cfg/powerpc64-unknown-linux-gnu.mk
@@ -8,6 +8,7 @@ CFG_LIB_NAME_powerpc64-unknown-linux-gnu=lib$(1).so
 CFG_STATIC_LIB_NAME_powerpc64-unknown-linux-gnu=lib$(1).a
 CFG_LIB_GLOB_powerpc64-unknown-linux-gnu=lib$(1)-*.so
 CFG_LIB_DSYM_GLOB_powerpc64-unknown-linux-gnu=lib$(1)-*.dylib.dSYM
+CFG_JEMALLOC_CFLAGS_powerpc64-unknown-linux-gnu := -m64
 CFG_CFLAGS_powerpc64-unknown-linux-gnu := -m64 $(CFLAGS)
 CFG_GCCISH_CFLAGS_powerpc64-unknown-linux-gnu := -Wall -Werror -g -fPIC -m64 $(CFLAGS)
 CFG_GCCISH_CXXFLAGS_powerpc64-unknown-linux-gnu := -fno-rtti $(CXXFLAGS)


### PR DESCRIPTION
We forgot to pass down the `-m64` flag to gcc, so we were actually compiling
powerpc code which would then later fail to link!
