### PR TITLE
add support for mips(el)-unknown-linux-musl

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,5 +16,4 @@
 	url = https://github.com/rust-lang/rust-installer.git
 [submodule "src/liblibc"]
 	path = src/liblibc
-	url = https://github.com/japaric/libc.git
-	branch = mips-musl
+	url = https://github.com/rust-lang-nursery/libc.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,4 +16,5 @@
 	url = https://github.com/rust-lang/rust-installer.git
 [submodule "src/liblibc"]
 	path = src/liblibc
-	url = https://github.com/rust-lang-nursery/libc.git
+	url = https://github.com/japaric/libc.git
+	branch = mips-musl

--- a/configure
+++ b/configure
@@ -1178,7 +1178,7 @@ do
             ;;
 
 
-        *-musl)
+        x86_64-*-musl)
             if [ ! -f $CFG_MUSL_ROOT/lib/libc.a ]
             then
                 err "musl libc $CFG_MUSL_ROOT/lib/libc.a not found"

--- a/mk/cfg/mips-unknown-linux-musl.mk
+++ b/mk/cfg/mips-unknown-linux-musl.mk
@@ -1,0 +1,24 @@
+# mips-unknown-linux-musl configuration
+CC_mips-unknown-linux-musl=mips-openwrt-linux-gcc
+CXX_mips-unknown-linux-musl=mips-openwrt-linux-g++
+CPP_mips-unknown-linux-musl=mips-openwrt-linux-gcc -E
+AR_mips-unknown-linux-musl=mips-openwrt-linux-ar
+CFG_LIB_NAME_mips-unknown-linux-musl=lib$(1).so
+CFG_STATIC_LIB_NAME_mips-unknown-linux-musl=lib$(1).a
+CFG_LIB_GLOB_mips-unknown-linux-musl=lib$(1)-*.so
+CFG_LIB_DSYM_GLOB_mips-unknown-linux-musl=lib$(1)-*.dylib.dSYM
+CFG_JEMALLOC_CFLAGS_mips-unknown-linux-musl := -mips32r2 -msoft-float -mabi=32 $(CFLAGS)
+CFG_GCCISH_CFLAGS_mips-unknown-linux-musl := -Wall -g -fPIC -mips32r2 -msoft-float -mabi=32 $(CFLAGS)
+CFG_GCCISH_CXXFLAGS_mips-unknown-linux-musl := -fno-rtti $(CXXFLAGS)
+CFG_GCCISH_LINK_FLAGS_mips-unknown-linux-musl := -shared -fPIC -g -mips32r2 -msoft-float -mabi=32
+CFG_GCCISH_DEF_FLAG_mips-unknown-linux-musl := -Wl,--export-dynamic,--dynamic-list=
+CFG_LLC_FLAGS_mips-unknown-linux-musl :=
+CFG_INSTALL_NAME_mips-unknown-linux-musl =
+CFG_EXE_SUFFIX_mips-unknown-linux-musl =
+CFG_WINDOWSY_mips-unknown-linux-musl :=
+CFG_UNIXY_mips-unknown-linux-musl := 1
+CFG_LDPATH_mips-unknown-linux-musl :=
+CFG_RUN_mips-unknown-linux-musl=
+CFG_RUN_TARG_mips-unknown-linux-musl=
+RUSTC_FLAGS_mips-unknown-linux-musl := -C target-cpu=mips32r2 -C target-feature="+mips32r2" -C soft-float
+CFG_GNU_TRIPLE_mips-unknown-linux-musl := mips-unknown-linux-musl

--- a/mk/cfg/mips-unknown-linux-musl.mk
+++ b/mk/cfg/mips-unknown-linux-musl.mk
@@ -20,5 +20,5 @@ CFG_UNIXY_mips-unknown-linux-musl := 1
 CFG_LDPATH_mips-unknown-linux-musl :=
 CFG_RUN_mips-unknown-linux-musl=
 CFG_RUN_TARG_mips-unknown-linux-musl=
-RUSTC_FLAGS_mips-unknown-linux-musl := -C target-cpu=mips32r2 -C target-feature="+mips32r2" -C soft-float
+RUSTC_FLAGS_mips-unknown-linux-musl :=
 CFG_GNU_TRIPLE_mips-unknown-linux-musl := mips-unknown-linux-musl

--- a/mk/cfg/mips-unknown-linux-musl.mk
+++ b/mk/cfg/mips-unknown-linux-musl.mk
@@ -1,8 +1,8 @@
 # mips-unknown-linux-musl configuration
-CC_mips-unknown-linux-musl=mips-openwrt-linux-gcc
-CXX_mips-unknown-linux-musl=mips-openwrt-linux-g++
-CPP_mips-unknown-linux-musl=mips-openwrt-linux-gcc -E
-AR_mips-unknown-linux-musl=mips-openwrt-linux-ar
+CC_mips-unknown-linux-musl=mips-linux-musl-gcc
+CXX_mips-unknown-linux-musl=mips-linux-musl-g++
+CPP_mips-unknown-linux-musl=mips-linux-musl-gcc -E
+AR_mips-unknown-linux-musl=mips-linux-musl-ar
 CFG_LIB_NAME_mips-unknown-linux-musl=lib$(1).so
 CFG_STATIC_LIB_NAME_mips-unknown-linux-musl=lib$(1).a
 CFG_LIB_GLOB_mips-unknown-linux-musl=lib$(1)-*.so

--- a/mk/cfg/mipsel-unknown-linux-musl.mk
+++ b/mk/cfg/mipsel-unknown-linux-musl.mk
@@ -1,8 +1,8 @@
 # mipsel-unknown-linux-musl configuration
-CC_mipsel-unknown-linux-musl=mipsel-openwrt-linux-gcc
-CXX_mipsel-unknown-linux-musl=mipsel-openwrt-linux-g++
-CPP_mipsel-unknown-linux-musl=mipsel-openwrt-linux-gcc
-AR_mipsel-unknown-linux-musl=mipsel-openwrt-linux-ar
+CC_mipsel-unknown-linux-musl=mipsel-linux-musl-gcc
+CXX_mipsel-unknown-linux-musl=mipsel-linux-musl-g++
+CPP_mipsel-unknown-linux-musl=mipsel-linux-musl-gcc
+AR_mipsel-unknown-linux-musl=mipsel-linux-musl-ar
 CFG_LIB_NAME_mipsel-unknown-linux-musl=lib$(1).so
 CFG_STATIC_LIB_NAME_mipsel-unknown-linux-musl=lib$(1).a
 CFG_LIB_GLOB_mipsel-unknown-linux-musl=lib$(1)-*.so

--- a/mk/cfg/mipsel-unknown-linux-musl.mk
+++ b/mk/cfg/mipsel-unknown-linux-musl.mk
@@ -1,0 +1,24 @@
+# mipsel-unknown-linux-musl configuration
+CC_mipsel-unknown-linux-musl=mipsel-openwrt-linux-gcc
+CXX_mipsel-unknown-linux-musl=mipsel-openwrt-linux-g++
+CPP_mipsel-unknown-linux-musl=mipsel-openwrt-linux-gcc
+AR_mipsel-unknown-linux-musl=mipsel-openwrt-linux-ar
+CFG_LIB_NAME_mipsel-unknown-linux-musl=lib$(1).so
+CFG_STATIC_LIB_NAME_mipsel-unknown-linux-musl=lib$(1).a
+CFG_LIB_GLOB_mipsel-unknown-linux-musl=lib$(1)-*.so
+CFG_LIB_DSYM_GLOB_mipsel-unknown-linux-musl=lib$(1)-*.dylib.dSYM
+CFG_JEMALLOC_CFLAGS_mipsel-unknown-linux-musl := -mips32 -mabi=32 $(CFLAGS)
+CFG_GCCISH_CFLAGS_mipsel-unknown-linux-musl := -Wall -g -fPIC -mips32 -mabi=32 $(CFLAGS)
+CFG_GCCISH_CXXFLAGS_mipsel-unknown-linux-musl := -fno-rtti $(CXXFLAGS)
+CFG_GCCISH_LINK_FLAGS_mipsel-unknown-linux-musl := -shared -fPIC -g -mips32
+CFG_GCCISH_DEF_FLAG_mipsel-unknown-linux-musl := -Wl,--export-dynamic,--dynamic-list=
+CFG_LLC_FLAGS_mipsel-unknown-linux-musl :=
+CFG_INSTALL_NAME_mipsel-unknown-linux-musl =
+CFG_EXE_SUFFIX_mipsel-unknown-linux-musl :=
+CFG_WINDOWSY_mipsel-unknown-linux-musl :=
+CFG_UNIXY_mipsel-unknown-linux-musl := 1
+CFG_LDPATH_mipsel-unknown-linux-musl :=
+CFG_RUN_mipsel-unknown-linux-musl=
+CFG_RUN_TARG_mipsel-unknown-linux-musl=
+RUSTC_FLAGS_mipsel-unknown-linux-musl := -C target-cpu=mips32 -C target-feature="+mips32"
+CFG_GNU_TRIPLE_mipsel-unknown-linux-musl := mipsel-unknown-linux-musl

--- a/mk/cfg/mipsel-unknown-linux-musl.mk
+++ b/mk/cfg/mipsel-unknown-linux-musl.mk
@@ -20,5 +20,5 @@ CFG_UNIXY_mipsel-unknown-linux-musl := 1
 CFG_LDPATH_mipsel-unknown-linux-musl :=
 CFG_RUN_mipsel-unknown-linux-musl=
 CFG_RUN_TARG_mipsel-unknown-linux-musl=
-RUSTC_FLAGS_mipsel-unknown-linux-musl := -C target-cpu=mips32 -C target-feature="+mips32"
+RUSTC_FLAGS_mipsel-unknown-linux-musl :=
 CFG_GNU_TRIPLE_mipsel-unknown-linux-musl := mipsel-unknown-linux-musl

--- a/src/librustc_back/target/mips_unknown_linux_musl.rs
+++ b/src/librustc_back/target/mips_unknown_linux_musl.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use target::Target;
+use target::{Target, TargetOptions};
 
 pub fn target() -> Target {
     Target {
@@ -19,6 +19,10 @@ pub fn target() -> Target {
         target_os: "linux".to_string(),
         target_env: "musl".to_string(),
         target_vendor: "unknown".to_string(),
-        options: super::linux_base::opts()
+        options: TargetOptions {
+            cpu: "mips32r2".to_string(),
+            features: "+mips32r2,+soft-float".to_string(),
+            ..super::linux_base::opts()
+        }
     }
 }

--- a/src/librustc_back/target/mips_unknown_linux_musl.rs
+++ b/src/librustc_back/target/mips_unknown_linux_musl.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use target::Target;
+
+pub fn target() -> Target {
+    Target {
+        llvm_target: "mips-unknown-linux-musl".to_string(),
+        target_endian: "big".to_string(),
+        target_pointer_width: "32".to_string(),
+        arch: "mips".to_string(),
+        target_os: "linux".to_string(),
+        target_env: "musl".to_string(),
+        target_vendor: "unknown".to_string(),
+        options: super::linux_base::opts()
+    }
+}

--- a/src/librustc_back/target/mipsel_unknown_linux_musl.rs
+++ b/src/librustc_back/target/mipsel_unknown_linux_musl.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use target::Target;
+use target::{Target, TargetOptions};
 
 pub fn target() -> Target {
     Target {
@@ -19,7 +19,10 @@ pub fn target() -> Target {
         target_os: "linux".to_string(),
         target_env: "musl".to_string(),
         target_vendor: "unknown".to_string(),
-
-        options: super::linux_base::opts()
+        options: TargetOptions {
+            cpu: "mips32".to_string(),
+            features: "+mips32".to_string(),
+            ..super::linux_base::opts()
+        }
     }
 }

--- a/src/librustc_back/target/mipsel_unknown_linux_musl.rs
+++ b/src/librustc_back/target/mipsel_unknown_linux_musl.rs
@@ -1,0 +1,25 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use target::Target;
+
+pub fn target() -> Target {
+    Target {
+        llvm_target: "mipsel-unknown-linux-musl".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "32".to_string(),
+        arch: "mips".to_string(),
+        target_os: "linux".to_string(),
+        target_env: "musl".to_string(),
+        target_vendor: "unknown".to_string(),
+
+        options: super::linux_base::opts()
+    }
+}

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -420,6 +420,8 @@ impl Target {
             armv7_unknown_linux_gnueabihf,
             aarch64_unknown_linux_gnu,
             x86_64_unknown_linux_musl,
+            mips_unknown_linux_musl,
+            mipsel_unknown_linux_musl,
 
             i686_linux_android,
             arm_linux_androideabi,

--- a/src/libstd/os/linux/raw.rs
+++ b/src/libstd/os/linux/raw.rs
@@ -93,11 +93,20 @@ mod arch {
     use os::raw::{c_long, c_ulong};
     use os::unix::raw::{gid_t, uid_t};
 
+    #[cfg(target_env = "musl")]
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
+    #[cfg(not(target_env = "musl"))]
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i32;
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i32;
+    #[cfg(target_env = "musl")]
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
+    #[cfg(not(target_env = "musl"))]
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u32;
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u32;
+    #[cfg(target_env = "musl")]
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i32;
+    #[cfg(not(target_env = "musl"))]
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i32;
 
     #[repr(C)]

--- a/src/libstd/sys/common/libunwind.rs
+++ b/src/libstd/sys/common/libunwind.rs
@@ -101,9 +101,10 @@ pub type _Unwind_Exception_Cleanup_Fn =
                       exception: *mut _Unwind_Exception);
 
 #[cfg_attr(any(all(target_os = "linux", not(target_env = "musl")),
-               target_os = "freebsd"),
+               target_os = "freebsd",
+               all(target_os = "linux", target_env = "musl", not(target_arch = "x86_64"))),
            link(name = "gcc_s"))]
-#[cfg_attr(all(target_os = "linux", target_env = "musl", not(test)),
+#[cfg_attr(all(target_os = "linux", target_env = "musl", target_arch = "x86_64", not(test)),
            link(name = "unwind", kind = "static"))]
 #[cfg_attr(any(target_os = "android", target_os = "openbsd"),
            link(name = "gcc"))]


### PR DESCRIPTION
This target covers MIPS devices that run the trunk version of OpenWRT.

The x86_64-unknown-linux-musl target always links statically to C libraries. For
the mips(el)-unknown-linux-musl target, we opt for dynamic linking (like most of
other targets do) to keep binary size down.

As for the C compiler flags used in the build system, we use the same flags used
for the mips(el)-unknown-linux-gnu target.

r? @alexcrichton 
