### PR TITLE
rustc: Set MIPS cpu/features in the compiler

### DIFF
--- a/mk/cfg/mips-unknown-linux-gnu.mk
+++ b/mk/cfg/mips-unknown-linux-gnu.mk
@@ -20,5 +20,5 @@ CFG_UNIXY_mips-unknown-linux-gnu := 1
 CFG_LDPATH_mips-unknown-linux-gnu :=
 CFG_RUN_mips-unknown-linux-gnu=
 CFG_RUN_TARG_mips-unknown-linux-gnu=
-RUSTC_FLAGS_mips-unknown-linux-gnu := -C target-cpu=mips32r2 -C target-feature="+mips32r2" -C soft-float
+RUSTC_FLAGS_mips-unknown-linux-gnu :=
 CFG_GNU_TRIPLE_mips-unknown-linux-gnu := mips-unknown-linux-gnu

--- a/mk/cfg/mipsel-unknown-linux-gnu.mk
+++ b/mk/cfg/mipsel-unknown-linux-gnu.mk
@@ -20,5 +20,5 @@ CFG_UNIXY_mipsel-unknown-linux-gnu := 1
 CFG_LDPATH_mipsel-unknown-linux-gnu :=
 CFG_RUN_mipsel-unknown-linux-gnu=
 CFG_RUN_TARG_mipsel-unknown-linux-gnu=
-RUSTC_FLAGS_mipsel-unknown-linux-gnu := -C target-cpu=mips32 -C target-feature="+mips32"
+RUSTC_FLAGS_mipsel-unknown-linux-gnu :=
 CFG_GNU_TRIPLE_mipsel-unknown-linux-gnu := mipsel-unknown-linux-gnu

--- a/src/librustc_back/target/mips_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/mips_unknown_linux_gnu.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use target::Target;
+use target::{Target, TargetOptions};
 
 pub fn target() -> Target {
     Target {
@@ -19,6 +19,10 @@ pub fn target() -> Target {
         target_os: "linux".to_string(),
         target_env: "gnu".to_string(),
         target_vendor: "unknown".to_string(),
-        options: super::linux_base::opts()
+        options: TargetOptions {
+            cpu: "mips32r2".to_string(),
+            features: "+mips32r2,+soft-float".to_string(),
+            ..super::linux_base::opts()
+        },
     }
 }

--- a/src/librustc_back/target/mipsel_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/mipsel_unknown_linux_gnu.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use target::Target;
+use target::{Target, TargetOptions};
 
 pub fn target() -> Target {
     Target {
@@ -20,6 +20,10 @@ pub fn target() -> Target {
         target_env: "gnu".to_string(),
         target_vendor: "unknown".to_string(),
 
-        options: super::linux_base::opts()
+        options: TargetOptions {
+            cpu: "mips32".to_string(),
+            features: "+mips32".to_string(),
+            ..super::linux_base::opts()
+        },
     }
 }


### PR DESCRIPTION
Currently any compilation to MIPS spits out the warning:

```
'generic' is not a recognized processor for this target (ignoring processor)
```

Doesn't make for a great user experience! We don't encounter this in the normal
bootstrap because the cpu/feature set are set by the makefiles. Instead let's
just propagate these to the defaults for the entire target all the time (still
overridable from the command line) and prevent warnings from being emitted by
default.
