### PR TITLE
resolve: Get rid of `try_define`

### DIFF
--- a/src/librustc/middle/def.rs
+++ b/src/librustc/middle/def.rs
@@ -14,6 +14,7 @@ use middle::subst::ParamSpace;
 use util::nodemap::NodeMap;
 use syntax::ast;
 use rustc_front::hir;
+use std::collections::HashSet;
 
 #[derive(Clone, Copy, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub enum Def {
@@ -99,9 +100,9 @@ impl PathResolution {
 pub type DefMap = NodeMap<PathResolution>;
 // This is the replacement export map. It maps a module to all of the exports
 // within.
-pub type ExportMap = NodeMap<Vec<Export>>;
+pub type ExportMap = NodeMap<HashSet<Export>>;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Export {
     pub name: ast::Name,    // The name of the target.
     pub def_id: DefId, // The definition of the target.

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -819,7 +819,7 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
             Some(def) => Export { name: name, def_id: def.def_id() },
             None => return,
         };
-        self.resolver.export_map.entry(node_id).or_insert(Vec::new()).push(export);
+        self.resolver.export_map.entry(node_id).or_insert(Default::default()).insert(export);
     }
 
     /// Checks that imported names and items don't have the same name.


### PR DESCRIPTION
This was an unresolved question during review of https://github.com/rust-lang/rust/pull/30843.
Module reexport sets were not deduplicated, so variant reexports ended up in pairs in these sets, and then in metadata, and then led to "duplicate definition" errors unless duplicate checking were turned off.

cc @jseyfried
r? @nikomatsakis 
