### PR TITLE
Remove "powerpc64le" and "mipsel" target_arch

### DIFF
--- a/src/compiletest/util.rs
+++ b/src/compiletest/util.rs
@@ -39,7 +39,6 @@ const ARCH_TABLE: &'static [(&'static str, &'static str)] = &[
     ("msp430", "msp430"),
     ("powerpc", "powerpc"),
     ("powerpc64", "powerpc64"),
-    ("powerpc64le", "powerpc64le"),
     ("s390x", "systemz"),
     ("sparc", "sparc"),
     ("x86_64", "x86_64"),

--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -2044,7 +2044,7 @@ The following configurations must be defined by the implementation:
   production.  For example, it controls the behavior of the standard library's
   `debug_assert!` macro.
 * `target_arch = "..."` - Target CPU architecture, such as `"x86"`, `"x86_64"`
-  `"mips"`, `"powerpc"`, `"powerpc64"`, `"powerpc64le"`, `"arm"`, or `"aarch64"`.
+  `"mips"`, `"powerpc"`, `"powerpc64"`, `"arm"`, or `"aarch64"`.
 * `target_endian = "..."` - Endianness of the target CPU, either `"little"` or
   `"big"`.
 * `target_env = ".."` - An option provided by the compiler by default

--- a/src/liballoc_jemalloc/lib.rs
+++ b/src/liballoc_jemalloc/lib.rs
@@ -51,7 +51,6 @@ extern "C" {
 // constant at the call site and the branch will be optimized out.
 #[cfg(all(any(target_arch = "arm",
               target_arch = "mips",
-              target_arch = "mipsel",
               target_arch = "powerpc")))]
 const MIN_ALIGN: usize = 8;
 #[cfg(all(any(target_arch = "x86",

--- a/src/liballoc_system/lib.rs
+++ b/src/liballoc_system/lib.rs
@@ -29,10 +29,8 @@ extern crate libc;
 #[cfg(all(any(target_arch = "x86",
               target_arch = "arm",
               target_arch = "mips",
-              target_arch = "mipsel",
               target_arch = "powerpc",
-              target_arch = "powerpc64",
-              target_arch = "powerpc64le")))]
+              target_arch = "powerpc64")))]
 const MIN_ALIGN: usize = 8;
 #[cfg(all(any(target_arch = "x86_64",
               target_arch = "aarch64")))]

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -79,8 +79,8 @@ pub struct Target {
     pub target_env: String,
     /// Vendor name to use for conditional compilation.
     pub target_vendor: String,
-    /// Architecture to use for ABI considerations. Valid options: "x86", "x86_64", "arm",
-    /// "aarch64", "mips", "powerpc", "powerpc64" and "powerpc64le". "mips" includes "mipsel".
+    /// Architecture to use for ABI considerations. Valid options: "x86",
+    /// "x86_64", "arm", "aarch64", "mips", "powerpc", and "powerpc64".
     pub arch: String,
     /// Optional settings with defaults.
     pub options: TargetOptions,

--- a/src/librustc_back/target/powerpc64le_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/powerpc64le_unknown_linux_gnu.rs
@@ -19,7 +19,7 @@ pub fn target() -> Target {
         llvm_target: "powerpc64le-unknown-linux-gnu".to_string(),
         target_endian: "little".to_string(),
         target_pointer_width: "64".to_string(),
-        arch: "powerpc64le".to_string(),
+        arch: "powerpc64".to_string(),
         target_os: "linux".to_string(),
         target_env: "gnu".to_string(),
         target_vendor: "unknown".to_string(),

--- a/src/librustc_trans/trans/cabi.rs
+++ b/src/librustc_trans/trans/cabi.rs
@@ -128,7 +128,7 @@ pub fn compute_abi_info(ccx: &CrateContext,
         },
         "mips" => cabi_mips::compute_abi_info(ccx, atys, rty, ret_def),
         "powerpc" => cabi_powerpc::compute_abi_info(ccx, atys, rty, ret_def),
-        "powerpc64" | "powerpc64le" => cabi_powerpc64::compute_abi_info(ccx, atys, rty, ret_def),
+        "powerpc64" => cabi_powerpc64::compute_abi_info(ccx, atys, rty, ret_def),
         a => ccx.sess().fatal(&format!("unrecognized arch \"{}\" in target specification", a)
                               ),
     }

--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -613,10 +613,8 @@ pub mod consts {
     /// - arm
     /// - aarch64
     /// - mips
-    /// - mipsel
     /// - powerpc
     /// - powerpc64
-    /// - powerpc64le
     #[stable(feature = "env", since = "1.0.0")]
     pub const ARCH: &'static str = super::arch::ARCH;
 
@@ -859,11 +857,6 @@ mod arch {
     pub const ARCH: &'static str = "mips";
 }
 
-#[cfg(target_arch = "mipsel")]
-mod arch {
-    pub const ARCH: &'static str = "mipsel";
-}
-
 #[cfg(target_arch = "powerpc")]
 mod arch {
     pub const ARCH: &'static str = "powerpc";
@@ -872,11 +865,6 @@ mod arch {
 #[cfg(target_arch = "powerpc64")]
 mod arch {
     pub const ARCH: &'static str = "powerpc64";
-}
-
-#[cfg(target_arch = "powerpc64le")]
-mod arch {
-    pub const ARCH: &'static str = "powerpc64le";
 }
 
 #[cfg(target_arch = "le32")]

--- a/src/libstd/os/linux/raw.rs
+++ b/src/libstd/os/linux/raw.rs
@@ -86,8 +86,7 @@ mod arch {
     }
 }
 
-#[cfg(any(target_arch = "mips",
-          target_arch = "mipsel"))]
+#[cfg(target_arch = "mips")]
 mod arch {
     use super::mode_t;
     use os::raw::{c_long, c_ulong};
@@ -205,8 +204,7 @@ mod arch {
     }
 }
 
-#[cfg(any(target_arch = "x86_64", target_arch = "powerpc64",
-          target_arch = "powerpc64le"))]
+#[cfg(any(target_arch = "x86_64", target_arch = "powerpc64"))]
 mod arch {
     use super::{dev_t, mode_t};
     use os::raw::{c_long, c_int};

--- a/src/libstd/os/raw.rs
+++ b/src/libstd/os/raw.rs
@@ -16,15 +16,13 @@
           all(target_os = "linux", any(target_arch = "aarch64",
                                        target_arch = "arm",
                                        target_arch = "powerpc",
-                                       target_arch = "powerpc64",
-                                       target_arch = "powerpc64le"))))]
+                                       target_arch = "powerpc64"))))]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_char = u8;
 #[cfg(not(any(target_os = "android",
               all(target_os = "linux", any(target_arch = "aarch64",
                                            target_arch = "arm",
                                            target_arch = "powerpc",
-                                           target_arch = "powerpc64",
-                                           target_arch = "powerpc64le")))))]
+                                           target_arch = "powerpc64")))))]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_char = i8;
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_schar = i8;
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_uchar = u8;

--- a/src/libstd/rand/os.rs
+++ b/src/libstd/rand/os.rs
@@ -31,8 +31,7 @@ mod imp {
                   target_arch = "arm",
                   target_arch = "aarch64",
                   target_arch = "powerpc",
-                  target_arch = "powerpc64",
-                  target_arch = "powerpc64le")))]
+                  target_arch = "powerpc64")))]
     fn getrandom(buf: &mut [u8]) -> libc::c_long {
         #[cfg(target_arch = "x86_64")]
         const NR_GETRANDOM: libc::c_long = 318;
@@ -40,8 +39,7 @@ mod imp {
         const NR_GETRANDOM: libc::c_long = 355;
         #[cfg(target_arch = "arm")]
         const NR_GETRANDOM: libc::c_long = 384;
-        #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64",
-                  target_arch = "powerpc64le"))]
+        #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
         const NR_GETRANDOM: libc::c_long = 359;
         #[cfg(target_arch = "aarch64")]
         const NR_GETRANDOM: libc::c_long = 278;
@@ -57,8 +55,7 @@ mod imp {
                       target_arch = "arm",
                       target_arch = "aarch64",
                       target_arch = "powerpc",
-                      target_arch = "powerpc64",
-                      target_arch = "powerpc64le"))))]
+                      target_arch = "powerpc64"))))]
     fn getrandom(_buf: &mut [u8]) -> libc::c_long { -1 }
 
     fn getrandom_fill_bytes(v: &mut [u8]) {
@@ -96,8 +93,7 @@ mod imp {
                   target_arch = "arm",
                   target_arch = "aarch64",
                   target_arch = "powerpc",
-                  target_arch = "powerpc64",
-                  target_arch = "powerpc64le")))]
+                  target_arch = "powerpc64")))]
     fn is_getrandom_available() -> bool {
         use sync::atomic::{AtomicBool, Ordering};
         use sync::Once;
@@ -126,8 +122,7 @@ mod imp {
                       target_arch = "arm",
                       target_arch = "aarch64",
                       target_arch = "powerpc",
-                      target_arch = "powerpc64",
-                      target_arch = "powerpc64le"))))]
+                      target_arch = "powerpc64"))))]
     fn is_getrandom_available() -> bool { false }
 
     /// A random number generator that retrieves randomness straight from

--- a/src/libstd/sys/common/libunwind.rs
+++ b/src/libstd/sys/common/libunwind.rs
@@ -80,11 +80,10 @@ pub const unwinder_private_data_size: usize = 5;
 #[cfg(target_arch = "aarch64")]
 pub const unwinder_private_data_size: usize = 2;
 
-#[cfg(any(target_arch = "mips", target_arch = "mipsel"))]
+#[cfg(target_arch = "mips")]
 pub const unwinder_private_data_size: usize = 2;
 
-#[cfg(any(target_arch = "powerpc", target_arch = "powerpc64",
-          target_arch = "powerpc64le"))]
+#[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
 pub const unwinder_private_data_size: usize = 2;
 
 #[repr(C)]

--- a/src/test/run-pass/conditional-compile-arch.rs
+++ b/src/test/run-pass/conditional-compile-arch.rs
@@ -24,6 +24,3 @@ pub fn main() { }
 
 #[cfg(target_arch = "powerpc64")]
 pub fn main() { }
-
-#[cfg(target_arch = "powerpc64le")]
-pub fn main() { }


### PR DESCRIPTION
Currently the `mipsel-unknown-linux-gnu` target doesn't actually set the
`target_arch` value to `mipsel` but it rather uses `mips`. Alternatively the
`powerpc64le` target does indeed set the `target_arch` as `powerpc64le`,
causing a bit of inconsistency between theset two.

As these are just the same instance of one instruction set, let's use
`target_endian` to switch between them and only set the `target_arch` as one
value. This should cut down on the number of `#[cfg]` annotations necessary and
all around be a little more ergonomic.
