### PR TITLE
test: Deny warnings in {core,collections}test

### DIFF
--- a/src/libcollectionstest/btree/map.rs
+++ b/src/libcollectionstest/btree/map.rs
@@ -379,6 +379,7 @@ fn test_clone() {
 }
 
 #[test]
+#[allow(dead_code)]
 fn test_variance() {
     use std::collections::btree_map::{Iter, IntoIter, Range, Keys, Values};
 

--- a/src/libcollectionstest/btree/set.rs
+++ b/src/libcollectionstest/btree/set.rs
@@ -256,6 +256,7 @@ fn test_recovery() {
 }
 
 #[test]
+#[allow(dead_code)]
 fn test_variance() {
     use std::collections::btree_set::{IntoIter, Iter, Range};
 

--- a/src/libcollectionstest/lib.rs
+++ b/src/libcollectionstest/lib.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![deny(warnings)]
+
 #![feature(ascii)]
 #![feature(binary_heap_extras)]
 #![feature(box_syntax)]
@@ -16,27 +18,20 @@
 #![feature(collections_bound)]
 #![feature(const_fn)]
 #![feature(fn_traits)]
-#![feature(deque_extras)]
-#![feature(drain)]
 #![feature(enumset)]
-#![feature(into_cow)]
 #![feature(iter_arith)]
 #![feature(pattern)]
 #![feature(rand)]
-#![feature(range_inclusive)]
 #![feature(rustc_private)]
 #![feature(set_recovery)]
 #![feature(slice_bytes)]
-#![feature(slice_splits)]
 #![feature(step_by)]
 #![feature(str_char)]
 #![feature(str_escape)]
-#![feature(str_match_indices)]
 #![feature(str_utf16)]
 #![feature(test)]
 #![feature(unboxed_closures)]
 #![feature(unicode)]
-#![feature(vec_push_all)]
 
 #[macro_use] extern crate log;
 

--- a/src/libcollectionstest/slice.rs
+++ b/src/libcollectionstest/slice.rs
@@ -866,6 +866,7 @@ fn test_vec_default() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_bytes_set_memory() {
     use std::slice::bytes::MutableByteVector;
 

--- a/src/libcollectionstest/string.rs
+++ b/src/libcollectionstest/string.rs
@@ -8,10 +8,26 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::borrow::{IntoCow, Cow};
+use std::borrow::Cow;
 use std::iter::repeat;
 
 use test::Bencher;
+
+pub trait IntoCow<'a, B: ?Sized> where B: ToOwned {
+    fn into_cow(self) -> Cow<'a, B>;
+}
+
+impl<'a> IntoCow<'a, str> for String {
+    fn into_cow(self) -> Cow<'a, str> {
+        Cow::Owned(self)
+    }
+}
+
+impl<'a> IntoCow<'a, str> for &'a str {
+    fn into_cow(self) -> Cow<'a, str> {
+        Cow::Borrowed(self)
+    }
+}
 
 #[test]
 fn test_from_str() {
@@ -175,7 +191,7 @@ fn test_push_bytes() {
     let mut s = String::from("ABC");
     unsafe {
         let mv = s.as_mut_vec();
-        mv.push_all(&[b'D']);
+        mv.extend_from_slice(&[b'D']);
     }
     assert_eq!(s, "ABCD");
 }

--- a/src/libcollectionstest/vec.rs
+++ b/src/libcollectionstest/vec.rs
@@ -686,7 +686,7 @@ fn do_bench_push_all(b: &mut Bencher, dst_len: usize, src_len: usize) {
 
     b.iter(|| {
         let mut dst = dst.clone();
-        dst.push_all(&src);
+        dst.extend_from_slice(&src);
         assert_eq!(dst.len(), dst_len + src_len);
         assert!(dst.iter().enumerate().all(|(i, x)| i == *x));
     });

--- a/src/libcoretest/fmt/num.rs
+++ b/src/libcoretest/fmt/num.rs
@@ -7,7 +7,6 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use core::fmt::radix;
 
 #[test]
 fn test_format_int() {
@@ -153,17 +152,22 @@ fn test_format_int_twos_complement() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_format_radix() {
+    use core::fmt::radix;
     assert!(format!("{:04}", radix(3, 2)) == "0011");
     assert!(format!("{}", radix(55, 36)) == "1j");
 }
 
 #[test]
 #[should_panic]
+#[allow(deprecated)]
 fn test_radix_base_too_large() {
+    use core::fmt::radix;
     let _ = radix(55, 37);
 }
 
+#[allow(deprecated)]
 mod u32 {
     use test::Bencher;
     use core::fmt::radix;
@@ -207,6 +211,7 @@ mod u32 {
     }
 }
 
+#[allow(deprecated)]
 mod i32 {
     use test::Bencher;
     use core::fmt::radix;

--- a/src/libcoretest/iter.rs
+++ b/src/libcoretest/iter.rs
@@ -607,15 +607,15 @@ fn test_count() {
 }
 
 #[test]
-fn test_max_by() {
+fn test_max_by_key() {
     let xs: &[isize] = &[-3, 0, 1, 5, -10];
-    assert_eq!(*xs.iter().max_by(|x| x.abs()).unwrap(), -10);
+    assert_eq!(*xs.iter().max_by_key(|x| x.abs()).unwrap(), -10);
 }
 
 #[test]
-fn test_min_by() {
+fn test_min_by_key() {
     let xs: &[isize] = &[-3, 0, 1, 5, -10];
-    assert_eq!(*xs.iter().min_by(|x| x.abs()).unwrap(), 0);
+    assert_eq!(*xs.iter().min_by_key(|x| x.abs()).unwrap(), 0);
 }
 
 #[test]
@@ -961,18 +961,18 @@ fn bench_multiple_take(b: &mut Bencher) {
 fn scatter(x: i32) -> i32 { (x * 31) % 127 }
 
 #[bench]
-fn bench_max_by(b: &mut Bencher) {
+fn bench_max_by_key(b: &mut Bencher) {
     b.iter(|| {
         let it = 0..100;
-        it.max_by(|&x| scatter(x))
+        it.max_by_key(|&x| scatter(x))
     })
 }
 
 // http://www.reddit.com/r/rust/comments/31syce/using_iterators_to_find_the_index_of_the_min_or/
 #[bench]
-fn bench_max_by2(b: &mut Bencher) {
+fn bench_max_by_key2(b: &mut Bencher) {
     fn max_index_iter(array: &[i32]) -> usize {
-        array.iter().enumerate().max_by(|&(_, item)| item).unwrap().0
+        array.iter().enumerate().max_by_key(|&(_, item)| item).unwrap().0
     }
 
     let mut data = vec![0i32; 1638];

--- a/src/libcoretest/lib.rs
+++ b/src/libcoretest/lib.rs
@@ -8,12 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![deny(warnings)]
+
 #![feature(as_unsafe_cell)]
 #![feature(borrow_state)]
 #![feature(box_syntax)]
 #![feature(cell_extras)]
 #![feature(const_fn)]
-#![feature(core)]
 #![feature(core_float)]
 #![feature(core_private_bignum)]
 #![feature(core_private_diy_float)]
@@ -21,29 +22,22 @@
 #![feature(decode_utf16)]
 #![feature(fixed_size_array)]
 #![feature(float_extras)]
-#![feature(float_from_str_radix)]
 #![feature(flt2dec)]
 #![feature(fmt_radix)]
 #![feature(iter_arith)]
 #![feature(iter_arith)]
-#![feature(iter_cmp)]
-#![feature(iter_order)]
 #![feature(libc)]
 #![feature(nonzero)]
-#![feature(num_bits_bytes)]
 #![feature(peekable_is_empty)]
 #![feature(ptr_as_ref)]
 #![feature(rand)]
-#![feature(range_inclusive)]
 #![feature(raw)]
-#![feature(slice_bytes)]
 #![feature(slice_patterns)]
 #![feature(step_by)]
 #![feature(test)]
 #![feature(unboxed_closures)]
 #![feature(unicode)]
 #![feature(unique)]
-#![feature(clone_from_slice)]
 
 extern crate core;
 extern crate test;

--- a/src/libcoretest/num/int_macros.rs
+++ b/src/libcoretest/num/int_macros.rs
@@ -14,6 +14,8 @@ mod tests {
     use core::$T_i::*;
     use core::isize;
     use core::ops::{Shl, Shr, Not, BitXor, BitAnd, BitOr};
+    use core::mem;
+
     use num;
 
     #[test]
@@ -85,9 +87,10 @@ mod tests {
 
     #[test]
     fn test_count_zeros() {
-        assert!(A.count_zeros() == BITS as u32 - 3);
-        assert!(B.count_zeros() == BITS as u32 - 2);
-        assert!(C.count_zeros() == BITS as u32 - 5);
+        let bits = mem::size_of::<$T>() * 8;
+        assert!(A.count_zeros() == bits as u32 - 3);
+        assert!(B.count_zeros() == bits as u32 - 2);
+        assert!(C.count_zeros() == bits as u32 - 5);
     }
 
     #[test]

--- a/src/libcoretest/num/uint_macros.rs
+++ b/src/libcoretest/num/uint_macros.rs
@@ -15,6 +15,7 @@ mod tests {
     use num;
     use core::ops::{BitOr, BitAnd, BitXor, Shl, Shr, Not};
     use std::str::FromStr;
+    use std::mem;
 
     #[test]
     fn test_overflows() {
@@ -54,9 +55,10 @@ mod tests {
 
     #[test]
     fn test_count_zeros() {
-        assert!(A.count_zeros() == BITS as u32 - 3);
-        assert!(B.count_zeros() == BITS as u32 - 2);
-        assert!(C.count_zeros() == BITS as u32 - 5);
+        let bits = mem::size_of::<$T>() * 8;
+        assert!(A.count_zeros() == bits as u32 - 3);
+        assert!(B.count_zeros() == bits as u32 - 2);
+        assert!(C.count_zeros() == bits as u32 - 5);
     }
 
     #[test]


### PR DESCRIPTION
Help cleans up our build a bit and stays in line with the rest of our crates
denying warnings traditionally.
