### PR TITLE
trans: Inform LLVM we want CodeView on MSVC

### DIFF
--- a/src/librustc_trans/trans/debuginfo/mod.rs
+++ b/src/librustc_trans/trans/debuginfo/mod.rs
@@ -200,6 +200,13 @@ pub fn finalize(cx: &CrateContext) {
                                         2)
         }
 
+        // Indicate that we want CodeView debug information on MSVC
+        if cx.sess().target.target.options.is_like_msvc {
+            llvm::LLVMRustAddModuleFlag(cx.llmod(),
+                                        "CodeView\0".as_ptr() as *const _,
+                                        1)
+        }
+
         // Prevent bitcode readers from deleting the debug info.
         let ptr = "Debug Info Version\0".as_ptr();
         llvm::LLVMRustAddModuleFlag(cx.llmod(), ptr as *const _,


### PR DESCRIPTION
This mirrors the behavior of `clang-cl.exe` by adding a `CodeView` global
variable when emitting debug information. This should in turn help stack traces
that are generated when code is compiled with debuginfo enabled.

Closes #28133
