### PR TITLE
Resolve: improve detection of unused imports and other miscellaneous improvements

### DIFF
--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -20,7 +20,7 @@ use front::map as ast_map;
 use session::Session;
 use util::nodemap::{FnvHashMap, NodeMap, NodeSet};
 use middle::cstore::InlinedItem;
-use middle::ty::{self, Ty};
+use middle::ty;
 
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -26,7 +26,6 @@ use std::{i8, i16, i32, i64, u8, u16, u32, u64, f32, f64};
 use syntax::{abi, ast};
 use syntax::attr::{self, AttrMetaMethods};
 use syntax::codemap::{self, Span};
-use syntax::ast::{TyIs, TyUs, TyI8, TyU8, TyI16, TyU16, TyI32, TyU32, TyI64, TyU64};
 
 use rustc_front::hir;
 use rustc_front::intravisit::{self, Visitor};

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -297,7 +297,7 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
                     let external_module = self.new_extern_crate_module(parent_link, def);
                     self.define(parent, name, TypeNS, (external_module, sp));
 
-                    self.build_reduced_graph_for_external_crate(&external_module);
+                    self.build_reduced_graph_for_external_crate(external_module);
                 }
                 parent
             }
@@ -353,7 +353,7 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
                 for variant in &(*enum_definition).variants {
                     let item_def_id = self.ast_map.local_def_id(item.id);
                     self.build_reduced_graph_for_variant(variant, item_def_id,
-                                                         &module, variant_modifiers);
+                                                         module, variant_modifiers);
                 }
                 parent
             }
@@ -409,7 +409,7 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
                     };
 
                     let modifiers = DefModifiers::PUBLIC; // NB: not DefModifiers::IMPORTABLE
-                    self.define(&module_parent, item.name, ns, (def, item.span, modifiers));
+                    self.define(module_parent, item.name, ns, (def, item.span, modifiers));
 
                     self.trait_item_map.insert((item.name, def_id), item_def_id);
                 }

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -142,29 +142,17 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
     }
 
     fn block_needs_anonymous_module(&mut self, block: &Block) -> bool {
-        // Check each statement.
-        for statement in &block.stmts {
-            match statement.node {
-                StmtDecl(ref declaration, _) => {
-                    match declaration.node {
-                        DeclItem(_) => {
-                            return true;
-                        }
-                        _ => {
-                            // Keep searching.
-                        }
-                    }
-                }
-                _ => {
-                    // Keep searching.
+        fn is_item(statement: &hir::Stmt) -> bool {
+            if let StmtDecl(ref declaration, _) = statement.node {
+                if let DeclItem(_) = declaration.node {
+                    return true;
                 }
             }
+            false
         }
 
-        // If we found no items, we don't need to create
-        // an anonymous module.
-
-        return false;
+        // If any statements are items, we need to create an anonymous module
+        block.stmts.iter().any(is_item)
     }
 
     /// Constructs the reduced graph for one item.

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1262,7 +1262,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                     let segment_name = name.as_str();
                     let module_name = module_to_string(search_module);
                     let mut span = span;
-                    let msg = if "???" == &module_name[..] {
+                    let msg = if "???" == &module_name {
                         span.hi = span.lo + Pos::from_usize(segment_name.len());
 
                         match search_parent_externals(name, &self.current_module) {
@@ -1568,7 +1568,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                module_to_string(&*module_));
 
         // First, check the direct children of the module.
-        build_reduced_graph::populate_module_if_necessary(self, &module_);
+        build_reduced_graph::populate_module_if_necessary(self, module_);
 
         if let Some(binding) = module_.get_child(name, namespace) {
             debug!("(resolving name in module) found node as child");
@@ -1609,7 +1609,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         }
 
         // Descend into children and anonymous children.
-        build_reduced_graph::populate_module_if_necessary(self, &module_);
+        build_reduced_graph::populate_module_if_necessary(self, module_);
 
         module_.for_each_local_child(|_, _, child_node| {
             match child_node.module() {
@@ -2947,7 +2947,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         let containing_module;
         let last_private;
         match self.resolve_module_path_from_root(root_module,
-                                                 &module_path[..],
+                                                 &module_path,
                                                  0,
                                                  span,
                                                  LastMod(AllPublic)) {
@@ -2956,7 +2956,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                     Some((span, msg)) => (span, msg),
                     None => {
                         let msg = format!("Use of undeclared module `::{}`",
-                                          names_to_string(&module_path[..]));
+                                          names_to_string(&module_path));
                         (span, msg)
                     }
                 };

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -790,7 +790,7 @@ enum ParentLink<'a> {
 /// One node in the tree of modules.
 pub struct ModuleS<'a> {
     parent_link: ParentLink<'a>,
-    def: Cell<Option<Def>>,
+    def: Option<Def>,
     is_public: bool,
     is_extern_crate: bool,
 
@@ -840,7 +840,7 @@ impl<'a> ModuleS<'a> {
     fn new(parent_link: ParentLink<'a>, def: Option<Def>, external: bool, is_public: bool) -> Self {
         ModuleS {
             parent_link: parent_link,
-            def: Cell::new(def),
+            def: def,
             is_public: is_public,
             is_extern_crate: false,
             children: RefCell::new(HashMap::new()),
@@ -878,18 +878,18 @@ impl<'a> ModuleS<'a> {
     }
 
     fn def_id(&self) -> Option<DefId> {
-        self.def.get().as_ref().map(Def::def_id)
+        self.def.as_ref().map(Def::def_id)
     }
 
     fn is_normal(&self) -> bool {
-        match self.def.get() {
+        match self.def {
             Some(Def::Mod(_)) | Some(Def::ForeignMod(_)) => true,
             _ => false,
         }
     }
 
     fn is_trait(&self) -> bool {
-        match self.def.get() {
+        match self.def {
             Some(Def::Trait(_)) => true,
             _ => false,
         }
@@ -988,7 +988,7 @@ impl<'a> NameBinding<'a> {
     fn def(&self) -> Option<Def> {
         match self.def_or_module {
             DefOrModule::Def(def) => Some(def),
-            DefOrModule::Module(ref module) => module.def.get(),
+            DefOrModule::Module(ref module) => module.def,
         }
     }
 

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -460,12 +460,7 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
 
                 let target = resolution.target.clone();
                 if let Some(Target { target_module, binding, shadowable: _ }) = target {
-                    // track used imports and extern crates as well
-                    self.resolver.used_imports.insert((resolution.id, ns));
-                    self.resolver.record_import_use(resolution.id, name);
-                    if let Some(DefId { krate, .. }) = target_module.def_id() {
-                        self.resolver.used_crates.insert(krate);
-                    }
+                    self.resolver.record_import_use(name, ns, &resolution);
                     (Success((target_module, binding)), true)
                 } else {
                     (Failed(None), false)

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -257,7 +257,7 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
         errors.extend(self.resolve_imports_for_module(module_));
         self.resolver.current_module = orig_module;
 
-        build_reduced_graph::populate_module_if_necessary(self.resolver, &module_);
+        build_reduced_graph::populate_module_if_necessary(self.resolver, module_);
         module_.for_each_local_child(|_, _, child_node| {
             match child_node.module() {
                 None => {
@@ -345,14 +345,14 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
                 // We found the module that the target is contained
                 // within. Attempt to resolve the import within it.
                 if let SingleImport(target, source) = import_directive.subclass {
-                    self.resolve_single_import(&module_,
+                    self.resolve_single_import(module_,
                                                containing_module,
                                                target,
                                                source,
                                                import_directive,
                                                lp)
                 } else {
-                    self.resolve_glob_import(&module_, containing_module, import_directive, lp)
+                    self.resolve_glob_import(module_, containing_module, import_directive, lp)
                 }
             })
             .and_then(|()| {
@@ -465,9 +465,9 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
 
         // We need to resolve both namespaces for this to succeed.
         let (value_result, value_used_reexport) =
-            self.resolve_name_in_module(&target_module, source, ValueNS, module_);
+            self.resolve_name_in_module(target_module, source, ValueNS, module_);
         let (type_result, type_used_reexport) =
-            self.resolve_name_in_module(&target_module, source, TypeNS, module_);
+            self.resolve_name_in_module(target_module, source, TypeNS, module_);
 
         match (&value_result, &type_result) {
             (&Success((_, ref name_binding)), _) if !value_used_reexport &&
@@ -585,7 +585,7 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
         if let (&Failed(_), &Failed(_)) = (&value_result, &type_result) {
             let msg = format!("There is no `{}` in `{}`{}",
                               source,
-                              module_to_string(&target_module), lev_suggestion);
+                              module_to_string(target_module), lev_suggestion);
             return Failed(Some((directive.span, msg)));
         }
 
@@ -711,7 +711,7 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
         }
 
         // Add all children from the containing module.
-        build_reduced_graph::populate_module_if_necessary(self.resolver, &target_module);
+        build_reduced_graph::populate_module_if_necessary(self.resolver, target_module);
 
         target_module.for_each_local_child(|name, ns, name_binding| {
             self.merge_import_resolution(module_,

--- a/src/librustc_trans/trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/trans/debuginfo/metadata.rs
@@ -26,7 +26,7 @@ use llvm::debuginfo::{DIType, DIFile, DIScope, DIDescriptor, DICompositeType};
 use middle::def_id::DefId;
 use middle::infer;
 use middle::pat_util;
-use middle::subst::{self, Substs};
+use middle::subst;
 use rustc::front::map as hir_map;
 use rustc_front::hir;
 use trans::{type_of, adt, machine, monomorphize};

--- a/src/librustc_trans/trans/debuginfo/type_names.rs
+++ b/src/librustc_trans/trans/debuginfo/type_names.rs
@@ -15,7 +15,7 @@ use super::namespace::crate_root_namespace;
 use trans::common::CrateContext;
 use middle::def_id::DefId;
 use middle::infer;
-use middle::subst::{self, Substs};
+use middle::subst;
 use middle::ty::{self, Ty};
 
 use rustc_front::hir;

--- a/src/librustc_typeck/check/cast.rs
+++ b/src/librustc_typeck/check/cast.rs
@@ -50,7 +50,6 @@ use middle::ty::cast::{CastKind, CastTy};
 use syntax::codemap::Span;
 use rustc_front::hir;
 use syntax::ast;
-use syntax::ast::UintTy::TyU8;
 
 
 /// Reifies a cast check to be checked once we have full type information for

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -17,7 +17,7 @@ use astconv::AstConv;
 use check::{self, FnCtxt};
 use front::map as hir_map;
 use middle::ty::{self, Ty, ToPolyTraitRef, ToPredicate, TypeFoldable};
-use middle::cstore::{self, CrateStore, DefLike};
+use middle::cstore::{self, CrateStore};
 use middle::def::Def;
 use middle::def_id::DefId;
 use middle::lang_items::FnOnceTraitLangItem;

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -92,7 +92,7 @@ use middle::infer;
 use middle::infer::{TypeOrigin, type_variable};
 use middle::pat_util::{self, pat_id_map};
 use middle::privacy::{AllPublic, LastMod};
-use middle::subst::{self, Subst, Substs, VecPerParamSpace, ParamSpace, TypeSpace};
+use middle::subst::{self, Subst, Substs, VecPerParamSpace, ParamSpace};
 use middle::traits::{self, report_fulfillment_errors};
 use middle::ty::{GenericPredicates, TypeScheme};
 use middle::ty::{Disr, ParamTy, ParameterEnvironment};

--- a/src/test/compile-fail/lint-unused-imports.rs
+++ b/src/test/compile-fail/lint-unused-imports.rs
@@ -56,7 +56,10 @@ mod bar {
         use foo::Point;
         use foo::Square; //~ ERROR unused import
         pub fn cc(_p: Point) -> super::Square {
-            super::Square
+            fn f() -> super::Square {
+                super::Square
+            }
+            f()
         }
     }
 


### PR DESCRIPTION
The first commit improves detection of unused imports -- it should have been part of #30325. Right now, the unused import in the changed test would not be reported.

The rest of the commits are miscellaneous, independent clean-ups in resolve that I didn't think warranted individual PRs.

r? @nrc 
