### PR TITLE
Change EraseRegions pass to use MutVisitor

### DIFF
--- a/src/librustc_mir/mir_map.rs
+++ b/src/librustc_mir/mir_map.rs
@@ -23,7 +23,7 @@ extern crate rustc_front;
 use build;
 use graphviz;
 use pretty;
-use transform::*;
+use transform::{simplify_cfg, MirPass};
 use rustc::dep_graph::DepNode;
 use rustc::mir::repr::Mir;
 use hair::cx::Cx;


### PR DESCRIPTION
Having a `MirPass` provides literally no benefits over `MutVisitor`. Moreover using `MirPass` for
`EraseRegions` basically makes the programmer to fix breakage from changing repr twice – in the
visitor and eraseregions. Since `MutVisitor` implements all the “walking” inside the trait, that can
be reused for `EraseRegions` too, basically resulting in less code duplication.
