### PR TITLE
Safety docs about process::Child going out of scope

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -48,13 +48,15 @@ use thread::{self, JoinHandle};
 /// assert!(ecode.success());
 /// ```
 ///
-/// # Safety
+/// # Note
 ///
 /// Take note that there is no implementation of
 /// [`Drop`](../../core/ops/trait.Drop.html) for child processes, so if you
-/// not ensure the `Child` has exited (through `kill`, `wait`, or
-/// `wait_with_output`) then it will continue to run even after the `Child`
-/// handle to it has gone out of scope.
+/// do not ensure the `Child` has exited then it will continue to run, even
+/// after the `Child` handle to the child process has gone out of scope.
+///
+/// Calling `wait` (or other functions that wrap around it) will make the
+/// parent process wait until the child has actually exited before continuing.
 #[stable(feature = "process", since = "1.0.0")]
 pub struct Child {
     handle: imp::Process,

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -47,6 +47,14 @@ use thread::{self, JoinHandle};
 ///
 /// assert!(ecode.success());
 /// ```
+///
+/// # Safety
+///
+/// Take note that there is no implementation of
+/// [`Drop`](../../core/ops/trait.Drop.html) for child processes, so if you
+/// not ensure the `Child` has exited (through `kill`, `wait`, or
+/// `wait_with_output`) then it will continue to run even after the `Child`
+/// handle to it has gone out of scope.
 #[stable(feature = "process", since = "1.0.0")]
 pub struct Child {
     handle: imp::Process,


### PR DESCRIPTION
`Drop` is not implemented for `Child`, so if it goes out of scope in Rust-land and gets deallocated the child process will continue to exist and execute. If users want a guarantee that the process has finished running and exited they must manually use `kill`, `wait`, or `wait_with_output`.

Fixes #31289.

r? @steveklabnik
