### PR TITLE
Don't show `const` in docs when it's not available

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -657,9 +657,6 @@ impl fmt::Display for UnsafetySpace {
 
 impl fmt::Display for ConstnessSpace {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if option_env!("CFG_DISABLE_UNSTABLE_FEATURES").is_some() {
-            return Ok(());
-        }
         match self.get() {
             hir::Constness::Const => write!(f, "const "),
             hir::Constness::NotConst => Ok(())

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -657,6 +657,9 @@ impl fmt::Display for UnsafetySpace {
 
 impl fmt::Display for ConstnessSpace {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if option_env!("CFG_DISABLE_UNSTABLE_FEATURES").is_some() {
+            return Ok(());
+        }
         match self.get() {
             hir::Constness::Const => write!(f, "const "),
             hir::Constness::NotConst => Ok(())


### PR DESCRIPTION
Fixes #31098 

AFAICT this is the only place where rustdoc explicitly checks if we are on stable before emitting content, so I can't tell if this is the sane way to handle this, or if anything else should be done to make sure that nobody forgets to remove this check when `const` is stabilized.
