### PR TITLE
Fix the armv7 linux target

### DIFF
--- a/mk/cfg/armv7-unknown-linux-gnueabihf.mk
+++ b/mk/cfg/armv7-unknown-linux-gnueabihf.mk
@@ -8,8 +8,8 @@ CFG_LIB_NAME_armv7-unknown-linux-gnueabihf=lib$(1).so
 CFG_STATIC_LIB_NAME_armv7-unknown-linux-gnueabihf=lib$(1).a
 CFG_LIB_GLOB_armv7-unknown-linux-gnueabihf=lib$(1)-*.so
 CFG_LIB_DSYM_GLOB_armv7-unknown-linux-gnueabihf=lib$(1)-*.dylib.dSYM
-CFG_JEMALLOC_CFLAGS_armv7-unknown-linux-gnueabihf := -D__arm__ $(CFLAGS) -march=armv7
-CFG_GCCISH_CFLAGS_armv7-unknown-linux-gnueabihf := -Wall -g -fPIC -D__arm__ $(CFLAGS) -march=armv7
+CFG_JEMALLOC_CFLAGS_armv7-unknown-linux-gnueabihf := -D__arm__ $(CFLAGS) -march=armv7-a
+CFG_GCCISH_CFLAGS_armv7-unknown-linux-gnueabihf := -Wall -g -fPIC -D__arm__ $(CFLAGS) -march=armv7-a
 CFG_GCCISH_CXXFLAGS_armv7-unknown-linux-gnueabihf := -fno-rtti $(CXXFLAGS)
 CFG_GCCISH_LINK_FLAGS_armv7-unknown-linux-gnueabihf := -shared -fPIC -g
 CFG_GCCISH_DEF_FLAG_armv7-unknown-linux-gnueabihf := -Wl,--export-dynamic,--dynamic-list=

--- a/src/librustc_back/target/armv7_unknown_linux_gnueabihf.rs
+++ b/src/librustc_back/target/armv7_unknown_linux_gnueabihf.rs
@@ -23,7 +23,7 @@ pub fn target() -> Target {
 
         options: TargetOptions {
             features: "+v7,+vfp2,+neon".to_string(),
-            cpu: "cortex-a7".to_string(),
+            cpu: "cortex-a8".to_string(),
             .. base
         }
     }


### PR DESCRIPTION
The target was meant as a modern generic `armv7` option, therefore a few changes were necessary:
- gcc's `-march=armv7` was causing compilation failures on modern linux systems 
- rust codegen defaulted to `cortex-a7` causing illegal instruction crashes on previous `armv7-a` processors (e.g, cortex-a5, cortex-a8) due to unsupported hardware division.
