### PR TITLE
Add name bindings for bad imports

### DIFF
--- a/src/librustc/middle/def.rs
+++ b/src/librustc/middle/def.rs
@@ -120,7 +120,7 @@ impl Def {
             Def::TyParam(..) | Def::Struct(..) | Def::Trait(..) |
             Def::Method(..) | Def::Const(..) | Def::AssociatedConst(..) |
             Def::PrimTy(..) | Def::Label(..) | Def::SelfTy(..) | Def::Err => {
-                panic!("attempted .def_id() on invalid {:?}", self)
+                panic!("attempted .var_id() on invalid {:?}", self)
             }
         }
     }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1468,7 +1468,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             match search_module.parent_link {
                 NoParentLink => {
                     // No more parents. This module was unresolved.
-                    debug!("(resolving item in lexical scope) unresolved module");
+                    debug!("(resolving item in lexical scope) unresolved module: no parent module");
                     return Failed(None);
                 }
                 ModuleParentLink(parent_module_node, _) => {
@@ -3109,7 +3109,8 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             }
             Indeterminate => None,
             Failed(err) => {
-                debug!("(resolving item path by identifier in lexical scope) failed to resolve {}",
+                debug!("(resolving item path by identifier in lexical scope) failed to \
+                        resolve `{}`",
                        name);
 
                 if let Some((span, msg)) = err {

--- a/src/test/compile-fail/import-from-missing.rs
+++ b/src/test/compile-fail/import-from-missing.rs
@@ -15,5 +15,8 @@ mod spam {
     pub fn ham() { }
 }
 
-fn main() { ham(); eggs(); }
-//~^ ERROR unresolved name `eggs`
+fn main() {
+    ham();
+    // Expect eggs to pass because the compiler inserts a fake name for it
+    eggs();
+}

--- a/src/test/compile-fail/import2.rs
+++ b/src/test/compile-fail/import2.rs
@@ -11,10 +11,10 @@
 use baz::zed::bar;
 //~^ ERROR unresolved import `baz::zed::bar`. Could not find `zed` in `baz`
 
-
 mod baz {}
 mod zed {
     pub fn bar() { println!("bar3"); }
 }
-fn main() { bar(); }
-//~^ ERROR unresolved name `bar`
+fn main() {
+    bar();
+}

--- a/src/test/compile-fail/privacy3.rs
+++ b/src/test/compile-fail/privacy3.rs
@@ -27,8 +27,10 @@ pub fn foo() {}
 fn test1() {
     use bar::gpriv;
     //~^ ERROR unresolved import `bar::gpriv`. There is no `gpriv` in `bar`
+
+    // This should pass because the compiler will insert a fake name binding
+    // for `gpriv`
     gpriv();
-    //~^ ERROR unresolved name `gpriv`
 }
 
 #[start] fn main(_: isize, _: *const *const u8) -> isize { 3 }


### PR DESCRIPTION
WIP implementation of #31209.

The goal is to insert fake/dummy definitions for names that we failed to import so that later resolver stages won't complain about them.
