### PR TITLE
rustc: add a `--print targets` command

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -164,6 +164,7 @@ pub enum PrintRequest {
     Sysroot,
     CrateName,
     Cfg,
+    TargetList,
 }
 
 pub enum Input {
@@ -844,7 +845,7 @@ pub fn rustc_short_optgroups() -> Vec<RustcOptGroup> {
                  "[asm|llvm-bc|llvm-ir|obj|link|dep-info]"),
         opt::multi("", "print", "Comma separated list of compiler information to \
                                print on stdout",
-                 "[crate-name|file-names|sysroot]"),
+                 "[crate-name|file-names|sysroot|target-list]"),
         opt::flagmulti("g",  "",  "Equivalent to -C debuginfo=2"),
         opt::flagmulti("O", "", "Equivalent to -C opt-level=2"),
         opt::opt("o", "", "Write output to <filename>", "FILENAME"),
@@ -1109,6 +1110,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
             "file-names" => PrintRequest::FileNames,
             "sysroot" => PrintRequest::Sysroot,
             "cfg" => PrintRequest::Cfg,
+            "target-list" => PrintRequest::TargetList,
             req => {
                 early_error(error_format, &format!("unknown print request `{}`", req))
             }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -532,6 +532,11 @@ impl RustcDefaultCalls {
         let attrs = input.map(|input| parse_crate_attrs(sess, input));
         for req in &sess.opts.prints {
             match *req {
+                PrintRequest::TargetList => {
+                    let mut targets = rustc_back::target::TARGETS.to_vec();
+                    targets.sort();
+                    println!("{}", targets.join("\n"));
+                },
                 PrintRequest::Sysroot => println!("{}", sess.sysroot().display()),
                 PrintRequest::FileNames |
                 PrintRequest::CrateName => {

--- a/src/test/run-make/print-target-list/Makefile
+++ b/src/test/run-make/print-target-list/Makefile
@@ -1,0 +1,15 @@
+-include ../tools.mk
+
+# Checks that all the targets returned by `rustc --print target-list` are valid
+# target specifications
+# TODO remove the '*ios*' case when rust-lang/rust#29812 is fixed
+all:
+	for target in $(shell $(BARE_RUSTC) --print target-list); do \
+		case $$target in \
+			*ios*) \
+				;; \
+			*) \
+				$(BARE_RUSTC) --target $$target --print sysroot \
+				;; \
+			esac \
+	done


### PR DESCRIPTION
that prints a list of all the triples supported by the `--target` flag

r? @alexcrichton 
