### PR TITLE
Resolve: stop letting items shadow reexported glob imports

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -12,7 +12,14 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use prelude::v1::*;
+use clone::Clone;
+use char::CharExt;
+use str::StrExt;
+use iter::Iterator;
+use slice::SliceExt;
+use marker::Sized;
+use option::Option::{self, Some, None};
+use result::Result::Ok;
 
 use cell::{Cell, RefCell, Ref, RefMut, BorrowState};
 use marker::PhantomData;
@@ -980,7 +987,7 @@ impl<'a> Formatter<'a> {
     /// afterwards depending on whether right or left alignment is requested.
     fn with_padding<F>(&mut self, padding: usize, default: Alignment,
                        f: F) -> Result
-        where F: FnOnce(&mut Formatter) -> Result,
+        where F: ::ops::FnOnce(&mut Formatter) -> Result,
     {
         use char::CharExt;
         let align = match self.align {
@@ -1576,7 +1583,7 @@ impl<T: ?Sized> Debug for PhantomData<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Copy + Debug> Debug for Cell<T> {
+impl<T: ::marker::Copy + Debug> Debug for Cell<T> {
     fn fmt(&self, f: &mut Formatter) -> Result {
         write!(f, "Cell {{ value: {:?} }}", self.get())
     }

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -136,13 +136,6 @@ impl<'a> NameResolution<'a> {
             _ => { self.binding = Some(binding); return Ok(()); }
         };
 
-        // FIXME #31337: We currently allow items to shadow glob-imported re-exports.
-        if !old_binding.is_import() && binding.defined_with(DefModifiers::GLOB_IMPORTED) {
-            if let NameBindingKind::Import { binding, .. } = binding.kind {
-                if binding.is_import() { return Ok(()); }
-            }
-        }
-
         Err(old_binding)
     }
 }

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -10,7 +10,8 @@
 
 use prelude::v1::*;
 use io::prelude::*;
-use os::unix::prelude::*;
+use os::unix::prelude::OsStrExt;
+use os::unix::prelude::OsStringExt;
 
 use ffi::{CString, CStr, OsString, OsStr};
 use fmt;

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -160,7 +160,8 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use prelude::v1::*;
+use string::String;
+use boxed::Box;
 
 use any::Any;
 use cell::UnsafeCell;

--- a/src/test/compile-fail/resolve-conflict-item-vs-import.rs
+++ b/src/test/compile-fail/resolve-conflict-item-vs-import.rs
@@ -13,5 +13,13 @@ use std::mem::transmute;
 
 fn transmute() {}
 
+mod foo {
+    pub fn baz() {}
+    pub use self::baz as bar;
+}
+
+use foo::*; //~ ERROR import `bar` conflicts with value in this module
+fn bar() {}
+
 fn main() {
 }

--- a/src/test/run-pass/issue-26873-onefile.rs
+++ b/src/test/run-pass/issue-26873-onefile.rs
@@ -22,7 +22,7 @@ mod A {
         pub struct T;
     }
 
-    pub use self::C::T;
+    pub use self::C::T as Q;
 }
 
 use A::*;

--- a/src/test/run-pass/issue_26873_multifile/A/mod.rs
+++ b/src/test/run-pass/issue_26873_multifile/A/mod.rs
@@ -11,5 +11,5 @@
 pub mod B;
 pub mod C;
 
-pub use self::C::T;
+pub use self::C::T as Q;
 


### PR DESCRIPTION
This PR stops non-import items from shadowing glob-imported re-exports (fixes #31337) and fixes the fallout in the standard libraries and tests.

Previously, it was possible to shadow a glob-imported re-export, so this a [breaking-chage]. For example,

``` rust
mod foo {
    pub fn g() {}
    pub use self::g as f;
}

use foo::*; // This breaks, since the imported re-export conflicts with the following item.
fn f() {}
```

The breakage can be fixed by renaming the non-import item or by using single imports in place of the glob import.
r? @nrc 
