### PR TITLE
Resolve: allow non-imported items to shadow glob imports

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -90,6 +90,9 @@ impl ImportDirective {
         if self.shadowable == Shadowable::Always {
             modifiers = modifiers | DefModifiers::PRELUDE;
         }
+        if binding.defined_with(DefModifiers::LINKED_NAMESPACES) {
+            modifiers = modifiers | DefModifiers::LINKED_NAMESPACES;
+        }
 
         NameBinding {
             kind: NameBindingKind::Import { binding: binding, id: self.id },
@@ -136,11 +139,9 @@ impl<'a> NameResolution<'a> {
             _ => { self.binding = Some(binding); return Ok(()); }
         };
 
-        // FIXME #31337: We currently allow items to shadow glob-imported re-exports.
+        // We currently allow items to shadow glob-imports.
         if !old_binding.is_import() && binding.defined_with(DefModifiers::GLOB_IMPORTED) {
-            if let NameBindingKind::Import { binding, .. } = binding.kind {
-                if binding.is_import() { return Ok(()); }
-            }
+            return Ok(());
         }
 
         Err(old_binding)

--- a/src/test/compile-fail/shadowed-glob-import.rs
+++ b/src/test/compile-fail/shadowed-glob-import.rs
@@ -1,0 +1,38 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+mod foo {
+    pub struct Bar;
+
+    pub enum E { V }
+    pub use self::E::V;
+
+    pub fn baz() -> bool {}
+    pub mod baz { pub fn f() {} }
+}
+
+use foo::*;
+fn Bar() {}
+struct V { x: i32 }
+fn baz() {}
+
+fn main() {
+    // The function `Bar` shadows the imported struct `Bar` in both namespaces
+    Bar();
+    let x: Bar = unimplemented!(); //~ ERROR use of undeclared type name `Bar`
+
+    // The struct `V` shadows the imported variant `V` in both namespaces
+    let _ = V { x: 0 };
+    let _ = V; //~ ERROR `V` is the name of a struct
+
+    // The function `baz` only shadows the imported name `baz` in the value namespace
+    let _: () = baz();
+    let _ = baz::f();
+}

--- a/src/test/compile-fail/variant-namespacing.rs
+++ b/src/test/compile-fail/variant-namespacing.rs
@@ -11,14 +11,14 @@
 // aux-build:variant-namespacing.rs
 
 extern crate variant_namespacing;
-pub use variant_namespacing::XE::*;
+pub use variant_namespacing::XE::{XStruct, XTuple, XUnit};
 //~^ ERROR import `XStruct` conflicts with type in this module
 //~| ERROR import `XStruct` conflicts with value in this module
 //~| ERROR import `XTuple` conflicts with type in this module
 //~| ERROR import `XTuple` conflicts with value in this module
 //~| ERROR import `XUnit` conflicts with type in this module
 //~| ERROR import `XUnit` conflicts with value in this module
-pub use E::*;
+pub use E::{Struct, Tuple, Unit};
 //~^ ERROR import `Struct` conflicts with type in this module
 //~| ERROR import `Struct` conflicts with value in this module
 //~| ERROR import `Tuple` conflicts with type in this module


### PR DESCRIPTION
This PR lets non-imported items shadow glob imported items (fixes #31337).
More precisely, a glob imported item will be shadowed (in all of the namespaces it defines) if any namespace it defines is already defined by a non-imported item.

Previously, it was possible to shadow only one namespace of a glob-imported re-export that defined both namespaces, so this is a [breaking-chage]. For example,

``` rust
mod foo {
    mod bar { pub struct Bar; }
    pub use self::bar::Bar;
}

pub use foo::*; // This imports the item `foo::bar::Bar`.

// The following used to only shadow `Bar` in the value namespace,
// leaving `foo::bar::Bar` only partially accessible.
// Now, it shadows `Bar` in both namespaces.
pub fn Bar() {}

fn f() -> Bar { foo::Bar } // This breaks
```

The breakage can be fixed by importing the shadowed item again as a fresh name or by renaming the item that shadows it.
r? @nrc 
