### PR TITLE
Add LLVM ModulePass regression test using run-make.

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -1048,7 +1048,8 @@ $(3)/test/run-make/%-$(1)-T-$(2)-H-$(3).ok: \
 	    $$(S) \
 	    $(3) \
 	    "$$(LLVM_LIBDIR_RUSTFLAGS_$(3))" \
-	    "$$(LLVM_ALL_COMPONENTS_$(3))"
+	    "$$(LLVM_ALL_COMPONENTS_$(3))" \
+	    "$$(LLVM_CXXFLAGS_$(3))"
 	@touch -r $$@.start_time $$@ && rm $$@.start_time
 else
 # FIXME #11094 - The above rule doesn't work right for multiple targets

--- a/src/etc/maketest.py
+++ b/src/etc/maketest.py
@@ -46,6 +46,7 @@ make = sys.argv[2]
 putenv('RUSTC', os.path.abspath(sys.argv[3]))
 putenv('TMPDIR', os.path.abspath(sys.argv[4]))
 putenv('CC', sys.argv[5] + ' ' + sys.argv[6])
+putenv('CFLAGS', sys.argv[6])
 putenv('RUSTDOC', os.path.abspath(sys.argv[7]))
 filt = sys.argv[8]
 putenv('LD_LIB_PATH_ENVVAR', sys.argv[9])
@@ -55,6 +56,7 @@ putenv('RUST_BUILD_STAGE', sys.argv[12])
 putenv('S', os.path.abspath(sys.argv[13]))
 putenv('RUSTFLAGS', sys.argv[15])
 putenv('LLVM_COMPONENTS', sys.argv[16])
+putenv('LLVM_CXXFLAGS', sys.argv[17])
 putenv('PYTHON', sys.executable)
 os.putenv('TARGET', target_triple)
 

--- a/src/test/run-make/llvm-module-pass/Makefile
+++ b/src/test/run-make/llvm-module-pass/Makefile
@@ -1,0 +1,14 @@
+-include ../tools.mk
+
+# Windows doesn't correctly handle include statements with escaping paths,
+# so this test will not get run on Windows.
+ifdef IS_WINDOWS
+all:
+else
+all: $(call NATIVE_STATICLIB,llvm-pass)
+	$(RUSTC) plugin.rs -C prefer-dynamic
+	$(RUSTC) main.rs
+
+$(TMPDIR)/libllvm-pass.o:
+	$(CXX) $(CFLAGS) $(LLVM_CXXFLAGS) -c llvm-pass.so.cc -o $(TMPDIR)/libllvm-pass.o
+endif

--- a/src/test/run-make/llvm-module-pass/llvm-pass.so.cc
+++ b/src/test/run-make/llvm-module-pass/llvm-pass.so.cc
@@ -1,0 +1,55 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "llvm/IR/Module.h"
+
+using namespace llvm;
+
+namespace {
+
+  class TestLLVMPass : public ModulePass {
+
+  public:
+
+    static char ID;
+    TestLLVMPass() : ModulePass(ID) { }
+
+    bool runOnModule(Module &M) override;
+
+    const char *getPassName() const override {
+      return "Some LLVM pass";
+    }
+
+  };
+
+}
+
+bool TestLLVMPass::runOnModule(Module &M) {
+  // A couple examples of operations that previously caused segmentation faults
+  // https://github.com/rust-lang/rust/issues/31067
+
+  for (auto F = M.begin(); F != M.end(); ++F) {
+    /* code */
+  }
+
+  LLVMContext &C = M.getContext();
+  IntegerType *Int8Ty  = IntegerType::getInt8Ty(C);
+  PointerType::get(Int8Ty, 0);
+  return true;
+}
+
+char TestLLVMPass::ID = 0;
+
+static RegisterPass<TestLLVMPass> RegisterAFLPass(
+  "some-llvm-pass", "Some LLVM pass");

--- a/src/test/run-make/llvm-module-pass/main.rs
+++ b/src/test/run-make/llvm-module-pass/main.rs
@@ -1,0 +1,14 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(plugin)]
+#![plugin(some_plugin)]
+
+fn main() {}

--- a/src/test/run-make/llvm-module-pass/plugin.rs
+++ b/src/test/run-make/llvm-module-pass/plugin.rs
@@ -1,0 +1,26 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(plugin_registrar, rustc_private)]
+#![crate_type = "dylib"]
+#![crate_name = "some_plugin"]
+
+extern crate rustc;
+extern crate rustc_plugin;
+
+#[link(name = "llvm-pass", kind = "static")]
+extern {}
+
+use rustc_plugin::registry::Registry;
+
+#[plugin_registrar]
+pub fn plugin_registrar(reg: &mut Registry) {
+    reg.register_llvm_pass("some-llvm-pass");
+}


### PR DESCRIPTION
Part of #31185
