### PR TITLE
Fix unclear make_mut description

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -380,9 +380,9 @@ impl<T: ?Sized> Deref for Arc<T> {
 }
 
 impl<T: Clone> Arc<T> {
-    /// Make a mutable reference into the given `Arc<T>` by cloning the inner
-    /// data if the `Arc<T>` doesn't have one strong reference and no weak
-    /// references.
+    /// Make a mutable reference into the given `Arc<T>`.
+    /// If the `Arc<T>` has more than one strong reference, or any weak
+    /// references, the inner data is cloned.
     ///
     /// This is also referred to as a copy-on-write.
     ///


### PR DESCRIPTION
The documentation for the `make_mut` function on `Arc<T>` contains a somewhat impenetrable double-negative that I was only able to fully grasp by looking at the implementation. Here's a quick rewrite that reads a lot better.

The sentence "doesn't have one strong reference and no weak references." is a
hard to understand, and it can be much more easily explained. In particular, such a double-negative
could give English as a Second Language users even more trouble than native speakers.

r? @steveklabnik
