### PR TITLE
special-case #[derive(Copy, Clone)] with a shallow clone

### DIFF
--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -75,6 +75,17 @@ pub trait Clone : Sized {
     }
 }
 
+// FIXME(aburka): this method is used solely by #[derive] to
+// assert that every component of a type implements Clone.
+//
+// This should never be called by user code.
+#[doc(hidden)]
+#[inline(always)]
+#[unstable(feature = "derive_clone_copy",
+           reason = "deriving hack, should not be public",
+           issue = "0")]
+pub fn assert_receiver_is_clone<T: Clone + ?Sized>(_: &T) {}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T: ?Sized> Clone for &'a T {
     /// Returns a shallow copy of the reference.

--- a/src/libsyntax_ext/deriving/decodable.rs
+++ b/src/libsyntax_ext/deriving/decodable.rs
@@ -74,7 +74,7 @@ fn expand_deriving_decodable_imp(cx: &mut ExtCtxt,
                 },
                 explicit_self: None,
                 args: vec!(Ptr(Box::new(Literal(Path::new_local(typaram))),
-                            Borrowed(None, Mutability::Mutable))),
+                           Borrowed(None, Mutability::Mutable))),
                 ret_ty: Literal(Path::new_(
                     pathvec_std!(cx, core::result::Result),
                     None,

--- a/src/libsyntax_ext/deriving/encodable.rs
+++ b/src/libsyntax_ext/deriving/encodable.rs
@@ -150,7 +150,7 @@ fn expand_deriving_encodable_imp(cx: &mut ExtCtxt,
                 },
                 explicit_self: borrowed_explicit_self(),
                 args: vec!(Ptr(Box::new(Literal(Path::new_local(typaram))),
-                            Borrowed(None, Mutability::Mutable))),
+                           Borrowed(None, Mutability::Mutable))),
                 ret_ty: Literal(Path::new_(
                     pathvec_std!(cx, core::result::Result),
                     None,

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -858,6 +858,7 @@ impl<'a> MethodDef<'a> {
                      explicit_self: ast::ExplicitSelf,
                      arg_types: Vec<(Ident, P<ast::Ty>)> ,
                      body: P<Expr>) -> ast::ImplItem {
+
         // create the generics that aren't for Self
         let fn_generics = self.generics.to_generics(cx, trait_.span, type_ident, generics);
 
@@ -991,6 +992,7 @@ impl<'a> MethodDef<'a> {
             body = cx.expr_match(trait_.span, arg_expr.clone(),
                                      vec!( cx.arm(trait_.span, vec!(pat.clone()), body) ))
         }
+
         body
     }
 

--- a/src/test/compile-fail/deriving-copyclone.rs
+++ b/src/test/compile-fail/deriving-copyclone.rs
@@ -1,0 +1,48 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// this will get a no-op Clone impl
+#[derive(Copy, Clone)]
+struct A {
+    a: i32,
+    b: i64
+}
+
+// this will get a deep Clone impl
+#[derive(Copy, Clone)]
+struct B<T> {
+    a: i32,
+    b: T
+}
+
+struct C; // not Copy or Clone
+#[derive(Clone)] struct D; // Clone but not Copy
+
+fn is_copy<T: Copy>(_: T) {}
+fn is_clone<T: Clone>(_: T) {}
+
+fn main() {
+    // A can be copied and cloned
+    is_copy(A { a: 1, b: 2 });
+    is_clone(A { a: 1, b: 2 });
+
+    // B<i32> can be copied and cloned
+    is_copy(B { a: 1, b: 2 });
+    is_clone(B { a: 1, b: 2 });
+
+    // B<C> cannot be copied or cloned
+    is_copy(B { a: 1, b: C }); //~ERROR Copy
+    is_clone(B { a: 1, b: C }); //~ERROR Clone
+
+    // B<D> can be cloned but not copied
+    is_copy(B { a: 1, b: D }); //~ERROR Copy
+    is_clone(B { a: 1, b: D });
+}
+

--- a/src/test/run-pass/copy-out-of-array-1.rs
+++ b/src/test/run-pass/copy-out-of-array-1.rs
@@ -12,8 +12,6 @@
 //
 // (Compare with compile-fail/move-out-of-array-1.rs)
 
-// pretty-expanded FIXME #23616
-
 #[derive(Copy, Clone)]
 struct C { _x: u8 }
 

--- a/src/test/run-pass/deriving-copyclone.rs
+++ b/src/test/run-pass/deriving-copyclone.rs
@@ -1,0 +1,48 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Test that #[derive(Copy, Clone)] produces a shallow copy
+//! even when a member violates RFC 1521
+
+use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT, Ordering};
+
+/// A struct that pretends to be Copy, but actually does something
+/// in its Clone impl
+#[derive(Copy)]
+struct Liar;
+
+/// Static cooperating with the rogue Clone impl
+static CLONED: AtomicBool = ATOMIC_BOOL_INIT;
+
+impl Clone for Liar {
+    fn clone(&self) -> Self {
+        // this makes Clone vs Copy observable
+        CLONED.store(true, Ordering::SeqCst);
+
+        *self
+    }
+}
+
+/// This struct is actually Copy... at least, it thinks it is!
+#[derive(Copy, Clone)]
+struct Innocent(Liar);
+
+impl Innocent {
+    fn new() -> Self {
+        Innocent(Liar)
+    }
+}
+
+fn main() {
+    let _ = Innocent::new().clone();
+    // if Innocent was byte-for-byte copied, CLONED will still be false
+    assert!(!CLONED.load(Ordering::SeqCst));
+}
+

--- a/src/test/run-pass/hrtb-opt-in-copy.rs
+++ b/src/test/run-pass/hrtb-opt-in-copy.rs
@@ -16,8 +16,6 @@
 // did not consider that a match (something I would like to revise in
 // a later PR).
 
-// pretty-expanded FIXME #23616
-
 #![allow(dead_code)]
 
 use std::marker::PhantomData;

--- a/src/test/run-pass/issue-13264.rs
+++ b/src/test/run-pass/issue-13264.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
-
 use std::ops::Deref;
 
 struct Root {

--- a/src/test/run-pass/issue-3121.rs
+++ b/src/test/run-pass/issue-3121.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
-
 #![allow(unknown_features)]
 #![feature(box_syntax)]
 


### PR DESCRIPTION
If a type is Copy then its Clone implementation can be a no-op. Currently `#[derive(Clone)]` generates a deep clone anyway. This can lead to lots of code bloat.

This PR detects the case where Copy and Clone are both being derived (the general case of "is this type Copy" can't be determined by a syntax extension) and generates the shallow Clone impl. Right now this can only be done if there are no type parameters (see https://github.com/rust-lang/rust/issues/31085#issuecomment-178988663), but this restriction can be removed after specialization.

Fixes #31085.
