### PR TITLE
Finish atomically setting CLOEXEC for fds created on Unix

### DIFF
--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -27,6 +27,9 @@ use ops::Neg;
 #[cfg(target_os = "openbsd")]   pub use os::openbsd as platform;
 #[cfg(target_os = "solaris")]   pub use os::solaris as platform;
 
+#[macro_use]
+pub mod weak;
+
 pub mod backtrace;
 pub mod condvar;
 pub mod ext;

--- a/src/libstd/sys/unix/net.rs
+++ b/src/libstd/sys/unix/net.rs
@@ -12,7 +12,7 @@ use prelude::v1::*;
 
 use ffi::CStr;
 use io;
-use libc::{self, c_int, size_t};
+use libc::{self, c_int, size_t, sockaddr, socklen_t};
 use net::{SocketAddr, Shutdown};
 use str;
 use sys::fd::FileDesc;
@@ -78,8 +78,28 @@ impl Socket {
         }
     }
 
-    pub fn accept(&self, storage: *mut libc::sockaddr,
-                  len: *mut libc::socklen_t) -> io::Result<Socket> {
+    pub fn accept(&self, storage: *mut sockaddr, len: *mut socklen_t)
+                  -> io::Result<Socket> {
+        // Unfortunately the only known way right now to accept a socket and
+        // atomically set the CLOEXEC flag is to use the `accept4` syscall on
+        // Linux. This was added in 2.6.28, however, and because we support
+        // 2.6.18 we must detect this support dynamically.
+        if cfg!(target_os = "linux") {
+            weak! {
+                fn accept4(c_int, *mut sockaddr, *mut socklen_t, c_int) -> c_int
+            }
+            if let Some(accept) = accept4.get() {
+                let res = cvt_r(|| unsafe {
+                    accept(self.0.raw(), storage, len, SOCK_CLOEXEC)
+                });
+                match res {
+                    Ok(fd) => return Ok(Socket(FileDesc::new(fd))),
+                    Err(ref e) if e.raw_os_error() == Some(libc::ENOSYS) => {}
+                    Err(e) => return Err(e),
+                }
+            }
+        }
+
         let fd = try!(cvt_r(|| unsafe {
             libc::accept(self.0.raw(), storage, len)
         }));

--- a/src/libstd/sys/unix/weak.rs
+++ b/src/libstd/sys/unix/weak.rs
@@ -1,0 +1,81 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Support for "weak linkage" to symbols on Unix
+//!
+//! Some I/O operations we do in libstd require newer versions of OSes but we
+//! need to maintain binary compatibility with older releases for now. In order
+//! to use the new functionality when available we use this module for
+//! detection.
+//!
+//! One option to use here is weak linkage, but that is unfortunately only
+//! really workable on Linux. Hence, use dlsym to get the symbol value at
+//! runtime. This is also done for compatibility with older versions of glibc,
+//! and to avoid creating dependencies on GLIBC_PRIVATE symbols. It assumes that
+//! we've been dynamically linked to the library the symbol comes from, but that
+//! is currently always the case for things like libpthread/libc.
+//!
+//! A long time ago this used weak linkage for the __pthread_get_minstack
+//! symbol, but that caused Debian to detect an unnecessarily strict versioned
+//! dependency on libc6 (#23628).
+
+use libc;
+
+use ffi::CString;
+use marker;
+use mem;
+use sync::atomic::{AtomicUsize, Ordering};
+
+macro_rules! weak {
+    (fn $name:ident($($t:ty),*) -> $ret:ty) => (
+        static $name: ::sys::weak::Weak<unsafe extern fn($($t),*) -> $ret> =
+            ::sys::weak::Weak::new(stringify!($name));
+    )
+}
+
+pub struct Weak<F> {
+    name: &'static str,
+    addr: AtomicUsize,
+    _marker: marker::PhantomData<F>,
+}
+
+impl<F> Weak<F> {
+    pub const fn new(name: &'static str) -> Weak<F> {
+        Weak {
+            name: name,
+            addr: AtomicUsize::new(1),
+            _marker: marker::PhantomData,
+        }
+    }
+
+    pub fn get(&self) -> Option<&F> {
+        assert_eq!(mem::size_of::<F>(), mem::size_of::<usize>());
+        unsafe {
+            if self.addr.load(Ordering::SeqCst) == 1 {
+                self.addr.store(fetch(self.name), Ordering::SeqCst);
+            }
+            mem::transmute::<&AtomicUsize, Option<&F>>(&self.addr)
+        }
+    }
+}
+
+unsafe fn fetch(name: &str) -> usize {
+    let name = match CString::new(name) {
+        Ok(cstr) => cstr,
+        Err(..) => return 0,
+    };
+    let lib = libc::dlopen(0 as *const _, libc::RTLD_LAZY);
+    if lib.is_null() {
+        return 0
+    }
+    let ret = libc::dlsym(lib, name.as_ptr()) as usize;
+    libc::dlclose(lib);
+    return ret
+}

--- a/src/libstd/sys/unix/weak.rs
+++ b/src/libstd/sys/unix/weak.rs
@@ -61,7 +61,11 @@ impl<F> Weak<F> {
             if self.addr.load(Ordering::SeqCst) == 1 {
                 self.addr.store(fetch(self.name), Ordering::SeqCst);
             }
-            mem::transmute::<&AtomicUsize, Option<&F>>(&self.addr)
+            if self.addr.load(Ordering::SeqCst) == 0 {
+                None
+            } else {
+                mem::transmute::<&AtomicUsize, Option<&F>>(&self.addr)
+            }
         }
     }
 }

--- a/src/test/run-pass/fds-are-cloexec.rs
+++ b/src/test/run-pass/fds-are-cloexec.rs
@@ -16,11 +16,11 @@
 extern crate libc;
 
 use std::env;
-use std::fs::{self, File};
+use std::fs::File;
 use std::io;
 use std::net::{TcpListener, TcpStream, UdpSocket};
 use std::os::unix::prelude::*;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::thread;
 
 fn main() {
@@ -45,6 +45,17 @@ fn parent() {
     let udp1 = UdpSocket::bind("127.0.0.1:0").unwrap();
     let udp2 = udp1.try_clone().unwrap();
 
+    let mut child = Command::new(env::args().next().unwrap())
+                            .arg("100")
+                            .stdout(Stdio::piped())
+                            .stdin(Stdio::piped())
+                            .stderr(Stdio::piped())
+                            .spawn().unwrap();
+    let pipe1 = child.stdin.take().unwrap();
+    let pipe2 = child.stdout.take().unwrap();
+    let pipe3 = child.stderr.take().unwrap();
+
+
     let status = Command::new(env::args().next().unwrap())
                         .arg(file.as_raw_fd().to_string())
                         .arg(tcp1.as_raw_fd().to_string())
@@ -55,9 +66,13 @@ fn parent() {
                         .arg(tcp6.as_raw_fd().to_string())
                         .arg(udp1.as_raw_fd().to_string())
                         .arg(udp2.as_raw_fd().to_string())
+                        .arg(pipe1.as_raw_fd().to_string())
+                        .arg(pipe2.as_raw_fd().to_string())
+                        .arg(pipe3.as_raw_fd().to_string())
                         .status()
                         .unwrap();
     assert!(status.success());
+    child.wait().unwrap();
 }
 
 fn child(args: &[String]) {


### PR DESCRIPTION
These commits finish up closing out https://github.com/rust-lang/rust/issues/24237 by filling out all locations we create new file descriptors with variants that atomically create the file descriptor and set CLOEXEC where possible. Previous support for doing this in `File::open` was added in #27971 and support for `try_clone` was added in #27980. This commit fills out:
- `Socket::new` now passes `SOCK_CLOEXEC`
- `Socket::accept` now uses `accept4`
- `pipe2` is used instead of `pipe`

Unfortunately most of this support is Linux-specific, and most of it is post-2.6.18 (our oldest supported version), so all of the detection here is done dynamically. It looks like OSX does not have equivalent variants for these functions, so there's nothing more we can do there. Support for BSDs can be added over time if they also have these functions.

Closes #24237
