### PR TITLE
Do not .UR in man

### DIFF
--- a/man/rustc.1
+++ b/man/rustc.1
@@ -6,9 +6,7 @@ rustc \- The Rust compiler
 [\fIOPTIONS\fR] \fIINPUT\fR
 
 .SH DESCRIPTION
-This program is a compiler for the Rust language, available at
-.UR https://www.rust\-lang.org
-.UE .
+This program is a compiler for the Rust language, available at https://www.rust\-lang.org.
 
 .SH OPTIONS
 
@@ -298,10 +296,7 @@ To build an executable with debug info:
 .BR rustdoc (1)
 
 .SH "BUGS"
-See
-.UR https://github.com/rust\-lang/rust/issues
-.UE
-for issues.
+See https://github.com/rust\-lang/rust/issues for issues.
 
 .SH "AUTHOR"
 See \fIAUTHORS.txt\fR in the Rust source distribution.


### PR DESCRIPTION
seems to not work on OS X (or requires label, which would make link repeat twice on non-OS X)

Fixes https://github.com/rust-lang/rust/issues/31432
