### PR TITLE
Split dummy-idx node to fix expand_givens DFS

### DIFF
--- a/src/test/compile-fail/issue-30438-a.rs
+++ b/src/test/compile-fail/issue-30438-a.rs
@@ -1,0 +1,33 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Original regression test for Issue #30438.
+
+use std::ops::Index;
+
+struct Test<'a> {
+    s: &'a String
+}
+
+impl <'a> Index<usize> for Test<'a> {
+    type Output = Test<'a>;
+    fn index(&self, _: usize) -> &Self::Output {
+        return &Test { s: &self.s};
+        //~^ ERROR: borrowed value does not live long enough
+    }
+}
+
+fn main() {
+    let s = "Hello World".to_string();
+    let test = Test{s: &s};
+    let r = &test[0];
+    println!("{}", test.s); // OK since test is valid
+    println!("{}", r.s); // Segfault since value pointed by r has already been dropped
+}

--- a/src/test/compile-fail/issue-30438-b.rs
+++ b/src/test/compile-fail/issue-30438-b.rs
@@ -1,0 +1,34 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Modified regression test for Issue #30438 that exposed an
+// independent issue (see discussion on ticket).
+
+use std::ops::Index;
+
+struct Test<'a> {
+    s: &'a String
+}
+
+impl <'a> Index<usize> for Test<'a> {
+    type Output = Test<'a>;
+    fn index(&self, _: usize) -> &Self::Output {
+        &Test { s: &self.s}
+        //~^ ERROR: borrowed value does not live long enough
+    }
+}
+
+fn main() {
+    let s = "Hello World".to_string();
+    let test = Test{s: &s};
+    let r = &test[0];
+    println!("{}", test.s); // OK since test is valid
+    println!("{}", r.s); // Segfault since value pointed by r has already been dropped
+}

--- a/src/test/compile-fail/issue-30438-c.rs
+++ b/src/test/compile-fail/issue-30438-c.rs
@@ -1,0 +1,30 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Simplfied regression test for #30438, inspired by arielb1.
+
+trait Trait { type Out; }
+
+struct Test<'a> { s: &'a str }
+
+fn silly<'y, 'z>(_s: &'y Test<'z>) -> &'y <Test<'z> as Trait>::Out where 'z: 'static {
+    let x = Test { s: "this cannot last" };
+    &x
+    //~^ ERROR: `x` does not live long enough
+}
+
+impl<'b> Trait for Test<'b> { type Out = Test<'b>; }
+
+fn main() {
+    let orig = Test { s: "Hello World" };
+    let r = silly(&orig);
+    println!("{}", orig.s); // OK since `orig` is valid
+    println!("{}", r.s); // Segfault (method does not return a sane value)
+}


### PR DESCRIPTION
Split dummy-idx node to fix expand_givens DFS

(Much more detail in commit comments.)

Fix #30438.
