### PR TITLE
Removed .UR from rustdoc man page

### DIFF
--- a/man/rustdoc.1
+++ b/man/rustdoc.1
@@ -8,10 +8,8 @@ rustdoc \- generate documentation from Rust source code
 .SH DESCRIPTION
 This tool generates API reference documentation by extracting comments from
 source code written in the Rust language, available at
-.UR https://www.rust\-lang.org
-.UE .
-It accepts several input formats and provides several output formats
-for the generated documentation.
+<\fBhttps://www.rust-lang.org\fR>. It accepts several input formats and
+provides several output formats for the generated documentation.
 
 .SH OPTIONS
 
@@ -131,9 +129,7 @@ The generated HTML can be viewed with any standard web browser.
 .BR rustc (1)
 
 .SH "BUGS"
-See
-.UR https://github.com/rust\-lang/rust/issues
-.UE
+See <\fBhttps://github.com/rust\-lang/rust/issues\fR>
 for issues.
 
 .SH "AUTHOR"


### PR DESCRIPTION
Similar to https://github.com/rust-lang/rust/issues/31432. Links do not show in OS X for the `rustdoc` man page.
