### PR TITLE
[RFC-ish][MIR] Add a pass manager

### DIFF
--- a/src/librustc/dep_graph/mod.rs
+++ b/src/librustc/dep_graph/mod.rs
@@ -70,6 +70,7 @@ pub enum DepNode {
     IntrinsicCheck(DefId),
     MatchCheck(DefId),
     MirMapConstruction(DefId),
+    MirPrintPass,
     BorrowCheck(DefId),
     RvalueCheck(DefId),
     Reachability,

--- a/src/librustc/mir/mir_map.rs
+++ b/src/librustc/mir/mir_map.rs
@@ -10,19 +10,7 @@
 
 use util::nodemap::NodeMap;
 use mir::repr::Mir;
-use mir::transform::MirPass;
-use middle::ty;
 
 pub struct MirMap<'tcx> {
     pub map: NodeMap<Mir<'tcx>>,
-}
-
-impl<'tcx> MirMap<'tcx> {
-    pub fn run_passes(&mut self, passes: &mut [Box<MirPass>], tcx: &ty::ctxt<'tcx>) {
-        for (_, ref mut mir) in &mut self.map {
-            for pass in &mut *passes {
-                pass.run_on_mir(mir, tcx)
-            }
-        }
-    }
 }

--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -204,7 +204,7 @@ impl Debug for BasicBlock {
 }
 
 ///////////////////////////////////////////////////////////////////////////
-// BasicBlock and Terminator
+// BasicBlockData and Terminator
 
 #[derive(Clone, Debug, RustcEncodable, RustcDecodable)]
 pub struct BasicBlockData<'tcx> {

--- a/src/librustc/mir/transform.rs
+++ b/src/librustc/mir/transform.rs
@@ -8,9 +8,79 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use mir::repr::Mir;
+use mir::repr::{Mir, BasicBlockData, BasicBlock};
+use mir::mir_map::MirMap;
 use middle::ty::ctxt;
 
-pub trait MirPass {
-    fn run_on_mir<'tcx>(&mut self, mir: &mut Mir<'tcx>, tcx: &ctxt<'tcx>);
+/// Contains various metadata about the pass.
+pub trait Pass {
+    /// Ordering of the pass. Lower value runs the pass earlier.
+    fn priority(&self) -> usize;
+    // Possibly also `fn name()` and `fn should_run(Session)` etc.
+}
+
+/// Pass which inspects the whole MirMap.
+pub trait MirMapPass: Pass {
+    fn run_pass<'tcx>(&mut self, tcx: &ctxt<'tcx>, map: &mut MirMap<'tcx>);
+}
+
+/// Pass which only inspects MIR of distinct functions.
+pub trait MirPass: Pass {
+    fn run_pass<'tcx>(&mut self, tcx: &ctxt<'tcx>, mir: &mut Mir<'tcx>);
+}
+
+/// Pass which only inspects basic blocks in MIR.
+///
+/// Invariant: The blocks are considered to be fully self-contained for the purposes of this pass –
+/// the pass may not change the list of successors of the block or apply any transformations to
+/// blocks based on the information collected during earlier runs of the pass.
+pub trait MirBlockPass: Pass {
+    fn run_pass<'tcx>(&mut self, tcx: &ctxt<'tcx>, bb: BasicBlock, data: &mut BasicBlockData<'tcx>);
+}
+
+impl<T: MirBlockPass> MirPass for T {
+    fn run_pass<'tcx>(&mut self, tcx: &ctxt<'tcx>, mir: &mut Mir<'tcx>) {
+        for (i, basic_block) in mir.basic_blocks.iter_mut().enumerate() {
+            MirBlockPass::run_pass(self, tcx, BasicBlock::new(i), basic_block);
+        }
+    }
+}
+
+impl<T: MirPass> MirMapPass for T {
+    fn run_pass<'tcx>(&mut self, tcx: &ctxt<'tcx>, map: &mut MirMap<'tcx>) {
+        for (_, mir) in &mut map.map {
+            MirPass::run_pass(self, tcx, mir);
+        }
+    }
+}
+
+/// A manager for MIR passes.
+pub struct Passes {
+    passes: Vec<Box<MirMapPass>>
+}
+
+impl Passes {
+    pub fn new() -> Passes {
+        let passes = Passes {
+            passes: Vec::new()
+        };
+        passes
+    }
+
+    pub fn run_passes<'tcx>(&mut self, tcx: &ctxt<'tcx>, map: &mut MirMap<'tcx>) {
+        self.passes.sort_by_key(|e| e.priority());
+        for pass in &mut self.passes {
+            pass.run_pass(tcx, map);
+        }
+    }
+
+    pub fn push_pass(&mut self, pass: Box<MirMapPass>) {
+        self.passes.push(pass);
+    }
+}
+
+impl ::std::iter::Extend<Box<MirMapPass>> for Passes {
+    fn extend<I: IntoIterator<Item=Box<MirMapPass>>>(&mut self, it: I) {
+        self.passes.extend(it);
+    }
 }

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -13,7 +13,7 @@ use middle::cstore::CrateStore;
 use middle::dependency_format;
 use session::search_paths::PathKind;
 use util::nodemap::{NodeMap, FnvHashMap};
-use mir::transform::MirPass;
+use mir;
 
 use syntax::ast::{NodeId, NodeIdAssigner, Name};
 use syntax::codemap::{Span, MultiSpan};
@@ -60,7 +60,7 @@ pub struct Session {
     pub lint_store: RefCell<lint::LintStore>,
     pub lints: RefCell<NodeMap<Vec<(lint::LintId, Span, String)>>>,
     pub plugin_llvm_passes: RefCell<Vec<String>>,
-    pub plugin_mir_passes: RefCell<Vec<Box<MirPass>>>,
+    pub mir_passes: RefCell<mir::transform::Passes>,
     pub plugin_attributes: RefCell<Vec<(String, AttributeType)>>,
     pub crate_types: RefCell<Vec<config::CrateType>>,
     pub dependency_formats: RefCell<dependency_format::Dependencies>,
@@ -477,7 +477,7 @@ pub fn build_session_(sopts: config::Options,
         lint_store: RefCell::new(lint::LintStore::new()),
         lints: RefCell::new(NodeMap()),
         plugin_llvm_passes: RefCell::new(Vec::new()),
-        plugin_mir_passes: RefCell::new(Vec::new()),
+        mir_passes: RefCell::new(mir::transform::Passes::new()),
         plugin_attributes: RefCell::new(Vec::new()),
         crate_types: RefCell::new(Vec::new()),
         dependency_formats: RefCell::new(FnvHashMap()),

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -856,6 +856,7 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
             // Push all the built-in passes.
             passes.push_pass(box transform::simplify_cfg::SimplifyCfg);
             passes.push_pass(box transform::erase_regions::EraseRegions);
+            passes.push_pass(box transform::simplify_cfg::CompactMir);
             // And run everything.
             passes.run_passes(tcx, &mut mir_map);
         });

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -856,6 +856,7 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
             // Push all the built-in passes.
             passes.push_pass(box transform::simplify_cfg::SimplifyCfg);
             passes.push_pass(box transform::erase_regions::EraseRegions);
+            passes.push_pass(box transform::print::MirPrint);
             passes.push_pass(box transform::simplify_cfg::CompactMir);
             // And run everything.
             passes.run_passes(tcx, &mut mir_map);

--- a/src/librustc_mir/mir_map.rs
+++ b/src/librustc_mir/mir_map.rs
@@ -22,13 +22,11 @@ extern crate rustc_front;
 use build;
 use graphviz;
 use pretty;
-use transform::{simplify_cfg, MirPass};
 use rustc::dep_graph::DepNode;
 use rustc::mir::repr::Mir;
 use hair::cx::Cx;
 use std::fs::File;
 
-use rustc::mir::transform::MirPass;
 use rustc::mir::mir_map::MirMap;
 use rustc::middle::infer;
 use rustc::middle::region::CodeExtentData;
@@ -147,9 +145,7 @@ impl<'a, 'm, 'tcx> Visitor<'tcx> for InnerDump<'a,'m,'tcx> {
         let infcx = infer::new_infer_ctxt(self.tcx, &self.tcx.tables, Some(param_env));
 
         match build_mir(Cx::new(&infcx), implicit_arg_tys, id, span, decl, body) {
-            Ok(mut mir) => {
-                simplify_cfg::SimplifyCfg::new().run_on_mir(&mut mir, self.tcx);
-
+            Ok(mir) => {
                 let meta_item_list = self.attr
                                          .iter()
                                          .flat_map(|a| a.meta_item_list())

--- a/src/librustc_mir/mir_map.rs
+++ b/src/librustc_mir/mir_map.rs
@@ -22,7 +22,7 @@ extern crate rustc_front;
 use build;
 use graphviz;
 use pretty;
-use transform::simplify_cfg;
+use transform::{simplify_cfg, MirPass};
 use rustc::dep_graph::DepNode;
 use rustc::mir::repr::Mir;
 use hair::cx::Cx;

--- a/src/librustc_mir/transform/erase_regions.rs
+++ b/src/librustc_mir/transform/erase_regions.rs
@@ -28,19 +28,14 @@ pub fn erase_regions<'tcx>(tcx: &ty::ctxt<'tcx>, mir_map: &mut MirMap<'tcx>) {
 
 pub struct EraseRegions;
 
-impl MirPass for EraseRegions {
-    fn run_pass<'tcx>(&mut self, tcx: &ty::ctxt<'tcx>, mir: &mut Mir<'tcx>) {
+impl<'tcx> MirPass<'tcx> for EraseRegions {
+    fn run_pass(&mut self, tcx: &ty::ctxt<'tcx>, mir: &mut Mir<'tcx>) {
         EraseRegionsVisitor::new(tcx).visit_mir(mir);
     }
 
 }
 
 impl Pass for EraseRegions {
-    fn priority(&self) -> usize {
-        // We want this pass to run as late as possible in transformation chain, so we give it a
-        // very high priority number.
-        !50
-    }
 }
 
 struct EraseRegionsVisitor<'a, 'tcx: 'a> {

--- a/src/librustc_mir/transform/erase_regions.rs
+++ b/src/librustc_mir/transform/erase_regions.rs
@@ -58,13 +58,13 @@ impl<'a, 'tcx> EraseRegionsVisitor<'a, 'tcx> {
     }
 }
 
-impl MirPass for EraseRegions {
-    fn run_on_mir<'tcx>(&mut self, mir: &mut Mir<'tcx>, tcx: &ty::ctxt<'tcx>) {
-        EraseRegionsVisitor::new(tcx).visit_mir(mir);
+impl<'a, 'tcx> MirPass<'tcx> for EraseRegions<'a, 'tcx> {
+    fn run_on_mir(&mut self, mir: &mut Mir<'tcx>) {
+        self.visit_mir(mir);
     }
 }
 
-impl<'a, 'tcx> MutVisitor<'tcx> for EraseRegionsVisitor<'a, 'tcx> {
+impl<'a, 'tcx> MutVisitor<'tcx> for EraseRegions<'a, 'tcx> {
     fn visit_mir(&mut self, mir: &mut Mir<'tcx>) {
         self.erase_regions_return_ty(&mut mir.return_ty);
         self.erase_regions_tys(mir.var_decls.iter_mut().map(|d| &mut d.ty));

--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -10,4 +10,5 @@
 
 pub mod simplify_cfg;
 pub mod erase_regions;
+pub mod print;
 mod util;

--- a/src/librustc_mir/transform/print.rs
+++ b/src/librustc_mir/transform/print.rs
@@ -1,0 +1,73 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! This pass handles the `#[rustc_mir(*)]` attributes and prints the contents.
+//!
+//! The attribute formats that are currently accepted are:
+//!
+//! - `#[rustc_mir(graphviz="file.gv")]`
+//! - `#[rustc_mir(pretty="file.mir")]`
+use graphviz;
+use pretty;
+
+use syntax::attr::AttrMetaMethods;
+use rustc::middle::ty;
+use rustc::dep_graph::DepNode;
+use rustc::mir::mir_map::MirMap;
+use rustc::mir::transform::{MirMapPass, Pass};
+
+use std::fs::File;
+
+pub struct MirPrint;
+
+impl Pass for MirPrint {
+    fn priority(&self) -> usize {
+        // This is a late pass, because we usually want to see the Mir post-passes.
+        !100
+    }
+}
+
+impl MirMapPass for MirPrint {
+    fn run_pass<'tcx>(&mut self, tcx: &ty::ctxt<'tcx>, map: &mut MirMap<'tcx>) {
+        let _task = tcx.map.dep_graph.in_task(DepNode::MirPrintPass);
+        for (node_id, mir) in &map.map {
+            for attr in tcx.map.attrs(*node_id) {
+                if !attr.check_name("rustc_mir") {
+                    continue
+                }
+                for arg in attr.meta_item_list().iter().flat_map(|e| *e) {
+                    if arg.check_name("graphviz") || arg.check_name("pretty") {
+                        let filename = if let Some(p) = arg.value_str() {
+                            p
+                        } else {
+                            tcx.sess.span_err(arg.span,
+                                &format!("{} attribute requires a path", arg.name())
+                            );
+                            continue
+                        };
+                        let result = File::create(&*filename).and_then(|ref mut output| {
+                            if arg.check_name("graphviz") {
+                                graphviz::write_mir_graphviz(&mir, output)
+                            } else {
+                                pretty::write_mir_pretty(&mir, output)
+                            }
+                        });
+
+                        if let Err(e) = result {
+                            tcx.sess.span_err(arg.span,
+                                &format!("Error writing MIR {} output to `{}`: {}",
+                                         arg.name(), filename, e));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/librustc_mir/transform/print.rs
+++ b/src/librustc_mir/transform/print.rs
@@ -28,14 +28,10 @@ use std::fs::File;
 pub struct MirPrint;
 
 impl Pass for MirPrint {
-    fn priority(&self) -> usize {
-        // This is a late pass, because we usually want to see the Mir post-passes.
-        !100
-    }
 }
 
-impl MirMapPass for MirPrint {
-    fn run_pass<'tcx>(&mut self, tcx: &ty::ctxt<'tcx>, map: &mut MirMap<'tcx>) {
+impl<'tcx> MirMapPass<'tcx> for MirPrint {
+    fn run_pass(&mut self, tcx: &ty::ctxt<'tcx>, map: &mut MirMap<'tcx>) {
         let _task = tcx.map.dep_graph.in_task(DepNode::MirPrintPass);
         for (node_id, mir) in &map.map {
             for attr in tcx.map.attrs(*node_id) {

--- a/src/librustc_mir/transform/simplify_cfg.rs
+++ b/src/librustc_mir/transform/simplify_cfg.rs
@@ -11,32 +11,31 @@
 use rustc::middle::const_eval::ConstVal;
 use rustc::middle::ty;
 use rustc::mir::repr::*;
+use rustc::mir::visit::MutVisitor;
 use transform::util;
 use rustc::mir::transform::{MirPass, Pass};
 
 pub struct SimplifyCfg;
 
-impl SimplifyCfg {
-    fn remove_dead_blocks(&self, mir: &mut Mir) {
-        let mut seen = vec![false; mir.basic_blocks.len()];
-
-        // These blocks are always required.
-        seen[START_BLOCK.index()] = true;
-        seen[END_BLOCK.index()] = true;
-
-        let mut worklist = vec![START_BLOCK];
-        while let Some(bb) = worklist.pop() {
-            for succ in mir.basic_block_data(bb).terminator().successors().iter() {
-                if !seen[succ.index()] {
-                    seen[succ.index()] = true;
-                    worklist.push(*succ);
-                }
-            }
-        }
-
-        util::retain_basic_blocks(mir, &seen);
+impl Pass for SimplifyCfg {
+    fn priority(&self) -> usize {
+        50
     }
+}
 
+impl MirPass for SimplifyCfg {
+    fn run_pass<'tcx>(&mut self, tcx: &ty::ctxt<'tcx>, mir: &mut Mir<'tcx>) {
+        let mut dbr_pass = DeadBlockRemoval::new(self);
+        let mut changed = true;
+        while changed {
+            changed = self.simplify_branches(mir);
+            changed |= self.remove_goto_chains(mir);
+            dbr_pass.run_pass(tcx, mir);
+        }
+    }
+}
+
+impl SimplifyCfg {
     fn remove_goto_chains(&self, mir: &mut Mir) -> bool {
 
         // Find the target at the end of the jump chain, return None if there is a loop
@@ -116,21 +115,94 @@ impl SimplifyCfg {
     }
 }
 
-impl MirPass for SimplifyCfg {
-    fn run_pass<'tcx>(&mut self, _: &ty::ctxt<'tcx>, mir: &mut Mir<'tcx>) {
-        let mut changed = true;
-        while changed {
-            changed = self.simplify_branches(mir);
-            changed |= self.remove_goto_chains(mir);
-            self.remove_dead_blocks(mir);
-        }
-        // FIXME: Should probably be moved into some kind of pass manager
-        mir.basic_blocks.shrink_to_fit();
+/// Remove all the unreachable blocks.
+///
+/// You want to schedule this pass just after any pass which might introduce unreachable blocks.
+/// This pass is very cheap and might improve the run-time of other not-so-cheap passes.
+pub struct DeadBlockRemoval(usize);
+
+impl DeadBlockRemoval {
+    fn new(run_after: &Pass) -> DeadBlockRemoval {
+        DeadBlockRemoval(run_after.priority() + 1)
     }
 }
 
-impl Pass for SimplifyCfg {
+impl Pass for DeadBlockRemoval {
     fn priority(&self) -> usize {
-        50
+        self.0
+    }
+}
+
+impl MirPass for DeadBlockRemoval {
+    fn run_pass<'tcx>(&mut self, _: &ty::ctxt<'tcx>, mir: &mut Mir<'tcx>) {
+        let mut seen = vec![false; mir.basic_blocks.len()];
+
+        // These blocks are always required.
+        seen[START_BLOCK.index()] = true;
+        seen[END_BLOCK.index()] = true;
+
+        let mut worklist = vec![START_BLOCK];
+        while let Some(bb) = worklist.pop() {
+            for succ in mir.basic_block_data(bb).terminator().successors().iter() {
+                if !seen[succ.index()] {
+                    seen[succ.index()] = true;
+                    worklist.push(*succ);
+                }
+            }
+        }
+
+        util::retain_basic_blocks(mir, &seen);
+    }
+}
+
+/// Reduce the memory allocated by a MIR graph.
+pub struct CompactMir;
+
+impl Pass for CompactMir {
+    fn priority(&self) -> usize {
+        // We want this pass to run very late, so we give it a very high priority number.
+        !10
+    }
+}
+
+impl MirPass for CompactMir {
+    fn run_pass<'tcx>(&mut self, _: &ty::ctxt<'tcx>, mir: &mut Mir<'tcx>) {
+        self.visit_mir(mir);
+    }
+}
+
+impl<'tcx> MutVisitor<'tcx> for CompactMir {
+    fn visit_mir(&mut self, mir: &mut Mir<'tcx>) {
+        mir.basic_blocks.shrink_to_fit();
+        mir.var_decls.shrink_to_fit();
+        mir.arg_decls.shrink_to_fit();
+        mir.temp_decls.shrink_to_fit();
+        self.super_mir(mir);
+    }
+
+    fn visit_basic_block_data(&mut self, b: BasicBlock, data: &mut BasicBlockData) {
+        data.statements.shrink_to_fit();
+        self.super_basic_block_data(b, data);
+    }
+
+    fn visit_terminator(&mut self, b: BasicBlock, terminator: &mut Terminator) {
+        match *terminator {
+            Terminator::Switch { ref mut targets, .. } => targets.shrink_to_fit(),
+            Terminator::SwitchInt { ref mut values, ref mut targets, .. } => {
+                values.shrink_to_fit();
+                targets.shrink_to_fit();
+            },
+            Terminator::Call { ref mut args, .. } => args.shrink_to_fit(),
+            _ => {/* nothing to do */}
+        }
+        self.super_terminator(b, terminator);
+    }
+
+    fn visit_rvalue(&mut self, rvalue: &mut Rvalue) {
+        match *rvalue {
+            Rvalue::Aggregate(_, ref mut operands) => operands.shrink_to_fit(),
+            _ => { /* nothing to do */ }
+        }
+        self.super_rvalue(rvalue);
     }
 }

--- a/src/librustc_mir/transform/simplify_cfg.rs
+++ b/src/librustc_mir/transform/simplify_cfg.rs
@@ -18,14 +18,11 @@ use rustc::mir::transform::{MirPass, Pass};
 pub struct SimplifyCfg;
 
 impl Pass for SimplifyCfg {
-    fn priority(&self) -> usize {
-        50
-    }
 }
 
-impl MirPass for SimplifyCfg {
-    fn run_pass<'tcx>(&mut self, tcx: &ty::ctxt<'tcx>, mir: &mut Mir<'tcx>) {
-        let mut dbr_pass = DeadBlockRemoval::new(self);
+impl<'tcx> MirPass<'tcx> for SimplifyCfg {
+    fn run_pass(&mut self, tcx: &ty::ctxt<'tcx>, mir: &mut Mir<'tcx>) {
+        let mut dbr_pass = DeadBlockRemoval;
         let mut changed = true;
         while changed {
             changed = self.simplify_branches(mir);
@@ -119,22 +116,13 @@ impl SimplifyCfg {
 ///
 /// You want to schedule this pass just after any pass which might introduce unreachable blocks.
 /// This pass is very cheap and might improve the run-time of other not-so-cheap passes.
-pub struct DeadBlockRemoval(usize);
-
-impl DeadBlockRemoval {
-    fn new(run_after: &Pass) -> DeadBlockRemoval {
-        DeadBlockRemoval(run_after.priority() + 1)
-    }
-}
+pub struct DeadBlockRemoval;
 
 impl Pass for DeadBlockRemoval {
-    fn priority(&self) -> usize {
-        self.0
-    }
 }
 
-impl MirPass for DeadBlockRemoval {
-    fn run_pass<'tcx>(&mut self, _: &ty::ctxt<'tcx>, mir: &mut Mir<'tcx>) {
+impl<'tcx> MirPass<'tcx> for DeadBlockRemoval {
+    fn run_pass(&mut self, _: &ty::ctxt<'tcx>, mir: &mut Mir<'tcx>) {
         let mut seen = vec![false; mir.basic_blocks.len()];
 
         // These blocks are always required.
@@ -159,14 +147,10 @@ impl MirPass for DeadBlockRemoval {
 pub struct CompactMir;
 
 impl Pass for CompactMir {
-    fn priority(&self) -> usize {
-        // We want this pass to run very late, so we give it a very high priority number.
-        !10
-    }
 }
 
-impl MirPass for CompactMir {
-    fn run_pass<'tcx>(&mut self, _: &ty::ctxt<'tcx>, mir: &mut Mir<'tcx>) {
+impl<'tcx> MirPass<'tcx> for CompactMir {
+    fn run_pass(&mut self, _: &ty::ctxt<'tcx>, mir: &mut Mir<'tcx>) {
         self.visit_mir(mir);
     }
 }

--- a/src/librustc_plugin/registry.rs
+++ b/src/librustc_plugin/registry.rs
@@ -13,7 +13,7 @@
 use rustc::lint::{EarlyLintPassObject, LateLintPassObject, LintId, Lint};
 use rustc::session::Session;
 
-use rustc::mir::transform::MirPass;
+use rustc::mir;
 
 use syntax::ext::base::{SyntaxExtension, NamedSyntaxExtension, NormalTT};
 use syntax::ext::base::{IdentTT, MultiModifier, MultiDecorator};
@@ -56,7 +56,7 @@ pub struct Registry<'a> {
     pub late_lint_passes: Vec<LateLintPassObject>,
 
     #[doc(hidden)]
-    pub mir_passes: Vec<Box<MirPass>>,
+    pub mir_passes: Vec<Box<mir::transform::MirMapPass>>,
 
     #[doc(hidden)]
     pub lint_groups: HashMap<&'static str, Vec<LintId>>,
@@ -141,7 +141,7 @@ impl<'a> Registry<'a> {
     }
 
     /// Register a MIR pass
-    pub fn register_mir_pass(&mut self, pass: Box<MirPass>) {
+    pub fn register_mir_pass(&mut self, pass: Box<mir::transform::MirMapPass>) {
         self.mir_passes.push(pass);
     }
 

--- a/src/librustc_plugin/registry.rs
+++ b/src/librustc_plugin/registry.rs
@@ -56,7 +56,7 @@ pub struct Registry<'a> {
     pub late_lint_passes: Vec<LateLintPassObject>,
 
     #[doc(hidden)]
-    pub mir_passes: Vec<Box<mir::transform::MirMapPass>>,
+    pub mir_passes: Vec<Box<for<'p> mir::transform::MirMapPass<'p>>>,
 
     #[doc(hidden)]
     pub lint_groups: HashMap<&'static str, Vec<LintId>>,
@@ -141,7 +141,7 @@ impl<'a> Registry<'a> {
     }
 
     /// Register a MIR pass
-    pub fn register_mir_pass(&mut self, pass: Box<mir::transform::MirMapPass>) {
+    pub fn register_mir_pass(&mut self, pass: Box<for<'p> mir::transform::MirMapPass<'p>>) {
         self.mir_passes.push(pass);
     }
 

--- a/src/test/auxiliary/dummy_mir_pass.rs
+++ b/src/test/auxiliary/dummy_mir_pass.rs
@@ -18,8 +18,8 @@ extern crate rustc_front;
 extern crate rustc_plugin;
 extern crate syntax;
 
-use rustc::mir::transform::MirPass;
-use rustc::mir::repr::{Mir, Literal};
+use rustc::mir::transform::{self, MirBlockPass};
+use rustc::mir::repr::{BasicBlock, BasicBlockData, Literal};
 use rustc::mir::visit::MutVisitor;
 use rustc::middle::ty;
 use rustc::middle::const_eval::ConstVal;
@@ -30,9 +30,15 @@ use syntax::attr;
 
 struct Pass;
 
-impl MirPass for Pass {
-    fn run_on_mir<'tcx>(&mut self, mir: &mut Mir<'tcx>, tcx: &ty::ctxt<'tcx>) {
-        Visitor.visit_mir(mir)
+impl transform::Pass for Pass {
+    fn priority(&self) -> usize {
+        1000
+    }
+}
+
+impl MirBlockPass for Pass {
+    fn run_pass<'tcx>(&mut self, tcx: &ty::ctxt<'tcx>, bb: BasicBlock, bbd: &mut BasicBlockData) {
+        Visitor.visit_basic_block_data(bb, bbd)
     }
 }
 


### PR DESCRIPTION
Previously we would run MIR passes in a very ad-hoc way by calling passses directly everywhere across the compiler. This PR adds a proper pass manager which will run all the passes in some order (decided by the `priority` method in `Pass`) right after the MIR is constructed. I believe the pass manager should be general enough to be able to accommodate passes as complex as MIR-based borrowck.

The next step here would be to add something like `-Z mir-opt-level=[0..]` defaulting to `1 + -C opt-level` and a `fn should_run(&Session)` so the passes could decide whether they want to run under a given optimisation level or not.

Depends on https://github.com/rust-lang/rust/pull/31425 landing first.

r? @nikomatsakis
