### PR TITLE
[MIR] implement zero-on-move

### DIFF
--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -1298,21 +1298,28 @@ pub fn init_zero_mem<'blk, 'tcx>(cx: Block<'blk, 'tcx>, llptr: ValueRef, t: Ty<'
 fn memfill<'a, 'tcx>(b: &Builder<'a, 'tcx>, llptr: ValueRef, ty: Ty<'tcx>, byte: u8) {
     let _icx = push_ctxt("memfill");
     let ccx = b.ccx;
-
     let llty = type_of::type_of(ccx, ty);
-    let ptr_width = &ccx.sess().target.target.target_pointer_width[..];
-    let intrinsic_key = format!("llvm.memset.p0i8.i{}", ptr_width);
-
-    let llintrinsicfn = ccx.get_intrinsic(&intrinsic_key);
     let llptr = b.pointercast(llptr, Type::i8(ccx).ptr_to());
     let llzeroval = C_u8(ccx, byte);
     let size = machine::llsize_of(ccx, llty);
     let align = C_i32(ccx, type_of::align_of(ccx, ty) as i32);
-    let volatile = C_bool(ccx, false);
-    b.call(llintrinsicfn,
-           &[llptr, llzeroval, size, align, volatile],
-           None, None);
+    call_memset(b, llptr, llzeroval, size, align, false);
 }
+
+pub fn call_memset<'bcx, 'tcx>(b: &Builder<'bcx, 'tcx>,
+                               ptr: ValueRef,
+                               fill_byte: ValueRef,
+                               size: ValueRef,
+                               align: ValueRef,
+                               volatile: bool) {
+    let ccx = b.ccx;
+    let ptr_width = &ccx.sess().target.target.target_pointer_width[..];
+    let intrinsic_key = format!("llvm.memset.p0i8.i{}", ptr_width);
+    let llintrinsicfn = ccx.get_intrinsic(&intrinsic_key);
+    let volatile = C_bool(ccx, volatile);
+    b.call(llintrinsicfn, &[ptr, fill_byte, size, align, volatile], None, None);
+}
+
 
 /// In general, when we create an scratch value in an alloca, the
 /// creator may not know if the block (that initializes the scratch

--- a/src/librustc_trans/trans/mir/drop.rs
+++ b/src/librustc_trans/trans/mir/drop.rs
@@ -1,0 +1,81 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use llvm::ValueRef;
+use rustc::middle::ty::Ty;
+use rustc::mir::repr as mir;
+use trans::adt;
+use trans::base;
+use trans::build;
+use trans::common::{self, Block};
+use trans::debuginfo::DebugLoc;
+use trans::glue;
+use trans::machine;
+use trans::type_of;
+use trans::type_::Type;
+
+use super::MirContext;
+
+impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
+    pub fn trans_drop(&mut self,
+                      bcx: Block<'bcx, 'tcx>,
+                      value: &mir::Lvalue<'tcx>,
+                      target: mir::BasicBlock,
+                      unwind: Option<mir::BasicBlock>) {
+        let lvalue = self.trans_lvalue(bcx, value);
+        let ty = lvalue.ty.to_ty(bcx.tcx());
+        // Double check for necessity to drop
+        if !glue::type_needs_drop(bcx.tcx(), ty) {
+            build::Br(bcx, self.llblock(target), DebugLoc::None);
+            return;
+        }
+        let drop_fn = glue::get_drop_glue(bcx.ccx(), ty);
+        let drop_ty = glue::get_drop_glue_type(bcx.ccx(), ty);
+        let llvalue = if drop_ty != ty {
+            build::PointerCast(bcx, lvalue.llval,
+                               type_of::type_of(bcx.ccx(), drop_ty).ptr_to())
+        } else {
+            lvalue.llval
+        };
+        if let Some(unwind) = unwind {
+            // block cannot be cleanup in this case, so a regular block is fine
+            let intermediate_bcx = bcx.fcx.new_block("", None);
+            let uwbcx = self.bcx(unwind);
+            let unwind = self.make_landing_pad(uwbcx);
+            // FIXME: it could be possible to do zeroing before invoking here if the drop glue
+            // didn’t code in the checks inside itself.
+            build::Invoke(bcx,
+                          drop_fn,
+                          &[llvalue],
+                          intermediate_bcx.llbb,
+                          unwind.llbb,
+                          None,
+                          DebugLoc::None);
+            // FIXME: perhaps we also should fill inside failed branch? We do not want to re-drop a
+            // failed drop again by mistake. (conflicts with MSVC SEH if we don’t want to introduce
+            // a heap of hacks)
+            self.drop_fill(intermediate_bcx, lvalue.llval, ty);
+            build::Br(intermediate_bcx, self.llblock(target), DebugLoc::None);
+        } else {
+            build::Call(bcx, drop_fn, &[llvalue], None, DebugLoc::None);
+            self.drop_fill(bcx, lvalue.llval, ty);
+            build::Br(bcx, self.llblock(target), DebugLoc::None);
+        }
+    }
+
+    pub fn drop_fill(&mut self, bcx: Block<'bcx, 'tcx>, value: ValueRef, ty: Ty<'tcx>) {
+        let llty = type_of::type_of(bcx.ccx(), ty);
+        let llptr = build::PointerCast(bcx, value, Type::i8(bcx.ccx()).ptr_to());
+        let filling = common::C_u8(bcx.ccx(), adt::DTOR_DONE);
+        let size = machine::llsize_of(bcx.ccx(), llty);
+        let align = common::C_u32(bcx.ccx(), machine::llalign_of_min(bcx.ccx(), llty));
+        base::call_memset(&build::B(bcx), llptr, filling, size, align, false);
+    }
+}

--- a/src/librustc_trans/trans/mir/mod.rs
+++ b/src/librustc_trans/trans/mir/mod.rs
@@ -196,6 +196,7 @@ mod analyze;
 mod block;
 mod constant;
 mod did;
+mod drop;
 mod lvalue;
 mod operand;
 mod rvalue;

--- a/src/librustc_trans/trans/mir/operand.rs
+++ b/src/librustc_trans/trans/mir/operand.rs
@@ -147,22 +147,6 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
         }
     }
 
-    pub fn trans_operand_into(&mut self,
-                              bcx: Block<'bcx, 'tcx>,
-                              lldest: ValueRef,
-                              operand: &mir::Operand<'tcx>)
-    {
-        debug!("trans_operand_into(lldest={}, operand={:?})",
-               bcx.val_to_string(lldest),
-               operand);
-
-        // FIXME: consider not copying constants through the
-        // stack.
-
-        let o = self.trans_operand(bcx, operand);
-        self.store_operand(bcx, lldest, o);
-    }
-
     pub fn store_operand(&mut self,
                          bcx: Block<'bcx, 'tcx>,
                          lldest: ValueRef,

--- a/src/librustc_trans/trans/mir/rvalue.rs
+++ b/src/librustc_trans/trans/mir/rvalue.rs
@@ -43,11 +43,6 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                rvalue);
 
         match *rvalue {
-            mir::Rvalue::Use(ref operand) => {
-                self.trans_operand_into(bcx, dest.llval, operand);
-                bcx
-            }
-
             mir::Rvalue::Cast(mir::CastKind::Unsize, ref operand, cast_ty) => {
                 if common::type_is_fat_ptr(bcx.tcx(), cast_ty) {
                     // into-coerce of a thin pointer to a fat pointer - just
@@ -168,6 +163,8 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
 
         match *rvalue {
             mir::Rvalue::Use(ref operand) => {
+                // FIXME: consider not copying constants through stack. (fixable by translating
+                // constants into OperandValue::Ref, why don’t we do that yet if we don’t?)
                 let operand = self.trans_operand(bcx, operand);
                 (bcx, operand)
             }

--- a/src/test/run-fail/mir_dynamic_drops_1.rs
+++ b/src/test/run-fail/mir_dynamic_drops_1.rs
@@ -1,0 +1,41 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![feature(rustc_attrs)]
+// error-pattern:drop 1
+// error-pattern:drop 2
+use std::io::{self, Write};
+
+
+/// Structure which will not allow to be dropped twice.
+struct Droppable(bool, u32);
+impl Drop for Droppable {
+    fn drop(&mut self) {
+        if self.0 {
+            writeln!(io::stderr(), "{} dropped twice", self.1);
+            ::std::process::exit(1);
+        }
+        writeln!(io::stderr(), "drop {}", self.1);
+        self.0 = true;
+    }
+}
+
+#[rustc_mir]
+fn mir(){
+    let x = Droppable(false, 1);
+    let y = Droppable(false, 2);
+    let mut z = x;
+    let k = y;
+    z = k;
+}
+
+fn main() {
+    mir();
+    panic!();
+}

--- a/src/test/run-fail/mir_dynamic_drops_1.rs
+++ b/src/test/run-fail/mir_dynamic_drops_1.rs
@@ -14,22 +14,24 @@ use std::io::{self, Write};
 
 
 /// Structure which will not allow to be dropped twice.
-struct Droppable(bool, u32);
-impl Drop for Droppable {
+struct Droppable<'a>(&'a mut bool, u32);
+impl<'a> Drop for Droppable<'a> {
     fn drop(&mut self) {
-        if self.0 {
+        if *self.0 {
             writeln!(io::stderr(), "{} dropped twice", self.1);
             ::std::process::exit(1);
         }
         writeln!(io::stderr(), "drop {}", self.1);
-        self.0 = true;
+        *self.0 = true;
     }
 }
 
 #[rustc_mir]
 fn mir(){
-    let x = Droppable(false, 1);
-    let y = Droppable(false, 2);
+    let mut b1 = false;
+    let mut b2 = false;
+    let x = Droppable(&mut b1, 1);
+    let y = Droppable(&mut b2, 2);
     let mut z = x;
     let k = y;
     z = k;

--- a/src/test/run-fail/mir_dynamic_drops_2.rs
+++ b/src/test/run-fail/mir_dynamic_drops_2.rs
@@ -1,0 +1,39 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![feature(rustc_attrs)]
+// error-pattern:drop 1
+use std::io::{self, Write};
+
+
+/// Structure which will not allow to be dropped twice.
+struct Droppable(bool, u32);
+impl Drop for Droppable {
+    fn drop(&mut self) {
+        if self.0 {
+            writeln!(io::stderr(), "{} dropped twice", self.1);
+            ::std::process::exit(1);
+        }
+        writeln!(io::stderr(), "drop {}", self.1);
+        self.0 = true;
+    }
+}
+
+#[rustc_mir]
+fn mir(d: Droppable){
+    loop {
+        let x = d;
+        break;
+    }
+}
+
+fn main() {
+    mir(Droppable(false, 1));
+    panic!();
+}

--- a/src/test/run-fail/mir_dynamic_drops_2.rs
+++ b/src/test/run-fail/mir_dynamic_drops_2.rs
@@ -13,15 +13,15 @@ use std::io::{self, Write};
 
 
 /// Structure which will not allow to be dropped twice.
-struct Droppable(bool, u32);
-impl Drop for Droppable {
+struct Droppable<'a>(&'a mut bool, u32);
+impl<'a> Drop for Droppable<'a> {
     fn drop(&mut self) {
-        if self.0 {
+        if *self.0 {
             writeln!(io::stderr(), "{} dropped twice", self.1);
             ::std::process::exit(1);
         }
         writeln!(io::stderr(), "drop {}", self.1);
-        self.0 = true;
+        *self.0 = true;
     }
 }
 
@@ -34,6 +34,7 @@ fn mir(d: Droppable){
 }
 
 fn main() {
-    mir(Droppable(false, 1));
+    let mut d1 = false;
+    mir(Droppable(&mut d1, 1));
     panic!();
 }

--- a/src/test/run-fail/mir_dynamic_drops_3.rs
+++ b/src/test/run-fail/mir_dynamic_drops_3.rs
@@ -1,0 +1,43 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![feature(rustc_attrs)]
+// error-pattern:unwind happens
+// error-pattern:drop 3
+// error-pattern:drop 2
+// error-pattern:drop 1
+use std::io::{self, Write};
+
+
+/// Structure which will not allow to be dropped twice.
+struct Droppable(bool, u32);
+impl Drop for Droppable {
+    fn drop(&mut self) {
+        if self.0 {
+            writeln!(io::stderr(), "{} dropped twice", self.1);
+            ::std::process::exit(1);
+        }
+        writeln!(io::stderr(), "drop {}", self.1);
+        self.0 = true;
+    }
+}
+
+fn may_panic() -> Droppable {
+    panic!("unwind happens");
+}
+
+#[rustc_mir]
+fn mir(d: Droppable){
+    let y = Droppable(false, 2);
+    let x = [Droppable(false, 1), y, d, may_panic()];
+}
+
+fn main() {
+    mir(Droppable(false, 3));
+}

--- a/src/test/run-fail/mir_dynamic_drops_3.rs
+++ b/src/test/run-fail/mir_dynamic_drops_3.rs
@@ -16,28 +16,31 @@ use std::io::{self, Write};
 
 
 /// Structure which will not allow to be dropped twice.
-struct Droppable(bool, u32);
-impl Drop for Droppable {
+struct Droppable<'a>(&'a mut bool, u32);
+impl<'a> Drop for Droppable<'a> {
     fn drop(&mut self) {
-        if self.0 {
+        if *self.0 {
             writeln!(io::stderr(), "{} dropped twice", self.1);
             ::std::process::exit(1);
         }
         writeln!(io::stderr(), "drop {}", self.1);
-        self.0 = true;
+        *self.0 = true;
     }
 }
 
-fn may_panic() -> Droppable {
+fn may_panic<'a>() -> Droppable<'a> {
     panic!("unwind happens");
 }
 
 #[rustc_mir]
 fn mir(d: Droppable){
-    let y = Droppable(false, 2);
-    let x = [Droppable(false, 1), y, d, may_panic()];
+    let mut d1 = false;
+    let mut d2 = false;
+    let y = Droppable(&mut d2, 2);
+    let x = [Droppable(&mut d1, 1), y, d, may_panic()];
 }
 
 fn main() {
-    mir(Droppable(false, 3));
+    let mut d3 = false;
+    mir(Droppable(&mut d3, 3));
 }


### PR DESCRIPTION
This is, we think, is the last piece necessary for the fully functional implementation of dynamic dropping in MIR.
