### PR TITLE
Use MultiSpan for unused imports

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -57,7 +57,7 @@ pub struct Session {
     pub local_crate_source_file: Option<PathBuf>,
     pub working_dir: PathBuf,
     pub lint_store: RefCell<lint::LintStore>,
-    pub lints: RefCell<NodeMap<Vec<(lint::LintId, Span, String)>>>,
+    pub lints: RefCell<NodeMap<Vec<(lint::LintId, MultiSpan, String)>>>,
     pub plugin_llvm_passes: RefCell<Vec<String>>,
     pub plugin_attributes: RefCell<Vec<(String, AttributeType)>>,
     pub crate_types: RefCell<Vec<config::CrateType>>,
@@ -236,18 +236,18 @@ impl Session {
     pub fn unimpl(&self, msg: &str) -> ! {
         self.diagnostic().unimpl(msg)
     }
-    pub fn add_lint(&self,
+    pub fn add_lint<S: Into<MultiSpan>>(&self,
                     lint: &'static lint::Lint,
                     id: ast::NodeId,
-                    sp: Span,
+                    sp: S,
                     msg: String) {
         let lint_id = lint::LintId::of(lint);
         let mut lints = self.lints.borrow_mut();
         match lints.get_mut(&id) {
-            Some(arr) => { arr.push((lint_id, sp, msg)); return; }
+            Some(arr) => { arr.push((lint_id, sp.into(), msg)); return; }
             None => {}
         }
-        lints.insert(id, vec!((lint_id, sp, msg)));
+        lints.insert(id, vec!((lint_id, sp.into(), msg)));
     }
     pub fn reserve_node_ids(&self, count: ast::NodeId) -> ast::NodeId {
         let id = self.next_node_id.get();

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -364,6 +364,14 @@ impl MultiSpan {
     }
 }
 
+impl fmt::Debug for MultiSpan {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f,
+               "MultiSpan ({})",
+               self.spans.iter().map(|s| format!("{:?}", s)).collect::<Vec<_>>().join(", "))
+    }
+}
+
 impl From<Span> for MultiSpan {
     fn from(span: Span) -> MultiSpan {
         MultiSpan { spans: vec![span] }


### PR DESCRIPTION
This is an initial PR that uses `MultiSpan` introduced by @mitaa to make the unused imports lint less nosiy (#16132).

However there are still a few open questions about how the lint system should use MultiSpans. At the moment each lint added by  `add_lint` is tied to a single AST node. If we want to use a multispan to bundle a few spans together for a lint , we would probably want to call `add_lint` with a MultiSpan. But when we bundle multipe lint messages together, there also are multiple AST ids.

The unused imports lint should illustrate the problem quite well.  Consider the exmaple from the issue. Ideally we would use a multispan to highlight all unused imports in a single line. This could be done by grouping the lint spans and passing a MultiSpan to `add_lint`. But as the lint system works at the moment, lints are tied to a single AST node they originated from. What I do in the initial version of the PR is just picking the AST id of the first node, but that's not good.

```
#![crate_type = "lib"]

use foo::{Foo, Bar, Baz, Qux};

mod foo {
    pub struct Foo;
    pub struct Bar;
    pub struct Baz;
    pub struct Qux;
}
```

It also breaks down when you use `#[allow()]` attributes on imports, like

```
#[allow(unused_imports)]
use foo::{Foo, Bar}; use foo::{Baz, Qux};
```

It seems like we would have to have use the allow information when grouping spans, but this is currently done when the lint is emitted, not when it's added. Pushing the grouping to the stage where the lints are emitted would have quite an impact on the code, because we would have first collect all instances of a lint that should be emitted, and then group them if it makes sense.

Any ideas/preferences? I think @nrc handled the PR that added MultiSpan, so I hope r? @nrc makes sense.
