### PR TITLE
Fixes #29946 (missing drop in FnOnce adapter for closures)

### DIFF
--- a/src/librustc_trans/trans/closure.rs
+++ b/src/librustc_trans/trans/closure.rs
@@ -421,7 +421,7 @@ fn trans_fn_once_adapter_shim<'a, 'tcx>(
         }
     }, ArgVals(&llargs[(self_idx + 1)..]), dest).bcx;
 
-    fcx.pop_custom_cleanup_scope(self_scope);
+    fcx.pop_and_trans_custom_cleanup_scope(bcx, self_scope);
 
     finish_fn(&fcx, bcx, sig.output, DebugLoc::None);
 

--- a/src/test/run-pass/issue-29948.rs
+++ b/src/test/run-pass/issue-29948.rs
@@ -1,0 +1,32 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo<'a>(&'a mut bool);
+
+impl<'a> Drop for Foo<'a> {
+    fn drop(&mut self) {
+        *self.0 = true;
+    }
+}
+
+fn f<T: FnOnce()>(t: T) {
+    t()
+}
+
+fn main() {
+    let mut ran_drop = false;
+    {
+        let x = Foo(&mut ran_drop);
+        let x = move || { let _ = x; };
+        f(x);
+    }
+    assert!(ran_drop);
+}
+


### PR DESCRIPTION
Generates drop calls at the end of the Fn/FnMut -> FnOnce closure shim

Fix #29946
