### PR TITLE
Remove old #[allow(trivial_casts)] annotations

### DIFF
--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -26,7 +26,6 @@
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
        test(no_crate_inject, attr(allow(unused_variables), deny(warnings))))]
 
-#![allow(trivial_casts)]
 #![cfg_attr(test, allow(deprecated))] // rand
 #![cfg_attr(not(stage0), deny(warnings))]
 

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1414,8 +1414,6 @@ impl<T> Pointer for *const T {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> Pointer for *mut T {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        // FIXME(#23542) Replace with type ascription.
-        #![allow(trivial_casts)]
         Pointer::fmt(&(*self as *const T), f)
     }
 }
@@ -1423,8 +1421,6 @@ impl<T> Pointer for *mut T {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> Pointer for &'a T {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        // FIXME(#23542) Replace with type ascription.
-        #![allow(trivial_casts)]
         Pointer::fmt(&(*self as *const T), f)
     }
 }
@@ -1432,8 +1428,6 @@ impl<'a, T> Pointer for &'a T {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> Pointer for &'a mut T {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        // FIXME(#23542) Replace with type ascription.
-        #![allow(trivial_casts)]
         Pointer::fmt(&(&**self as *const T), f)
     }
 }

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -578,7 +578,5 @@ pub const POST_DROP_USIZE: usize = POST_DROP_U64 as usize;
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn transmute_copy<T, U>(src: &T) -> U {
-    // FIXME(#23542) Replace with type ascription.
-    #![allow(trivial_casts)]
     ptr::read(src as *const T as *const U)
 }

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -43,8 +43,6 @@
 #![feature(time2)]
 #![cfg_attr(test, feature(test))]
 
-#![allow(trivial_casts)]
-
 extern crate arena;
 extern crate core;
 extern crate flate;

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -12,7 +12,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(dead_code)]
-#![allow(trivial_casts)]
 
 #![crate_name = "rustc_llvm"]
 #![unstable(feature = "rustc_private", issue = "27812")]

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -37,8 +37,6 @@
 #![feature(staged_api)]
 #![feature(unicode)]
 
-#![allow(trivial_casts)]
-
 extern crate arena;
 extern crate flate;
 extern crate getopts;


### PR DESCRIPTION
These were added a long time ago but we long since switched the lint back to
allow-by-default, so these annotations shouldn't be necessary.
