### PR TITLE
rustc: Use llvm-ar for custom targets by default

### DIFF
--- a/src/librustc_back/target/asmjs_unknown_emscripten.rs
+++ b/src/librustc_back/target/asmjs_unknown_emscripten.rs
@@ -21,7 +21,6 @@ pub fn target() -> Target {
         no_compiler_rt: true,
         linker_is_gnu: true,
         allow_asm: false,
-        archive_format: "gnu".to_string(),
         obj_is_bitcode: true,
         .. Default::default()
     };

--- a/src/librustc_back/target/bitrig_base.rs
+++ b/src/librustc_back/target/bitrig_base.rs
@@ -19,7 +19,6 @@ pub fn opts() -> TargetOptions {
         linker_is_gnu: true,
         has_rpath: true,
         position_independent_executables: true,
-        archive_format: "gnu".to_string(),
         exe_allocation_crate: "alloc_system".to_string(),
 
         .. Default::default()

--- a/src/librustc_back/target/dragonfly_base.rs
+++ b/src/librustc_back/target/dragonfly_base.rs
@@ -29,7 +29,6 @@ pub fn opts() -> TargetOptions {
             "-Wl,-z,noexecstack".to_string(),
         ),
         position_independent_executables: true,
-        archive_format: "gnu".to_string(),
         exe_allocation_crate: super::maybe_jemalloc(),
         .. Default::default()
     }

--- a/src/librustc_back/target/freebsd_base.rs
+++ b/src/librustc_back/target/freebsd_base.rs
@@ -21,7 +21,6 @@ pub fn opts() -> TargetOptions {
             // Always enable NX protection when it is available
             "-Wl,-z,noexecstack".to_string(),
         ],
-        archive_format: "gnu".to_string(),
         exe_allocation_crate: super::maybe_jemalloc(),
 
         .. Default::default()

--- a/src/librustc_back/target/le32_unknown_nacl.rs
+++ b/src/librustc_back/target/le32_unknown_nacl.rs
@@ -25,7 +25,6 @@ pub fn target() -> Target {
         no_compiler_rt: false,
         linker_is_gnu: true,
         allow_asm: false,
-        archive_format: "gnu".to_string(),
         .. Default::default()
     };
     Target {

--- a/src/librustc_back/target/linux_base.rs
+++ b/src/librustc_back/target/linux_base.rs
@@ -31,7 +31,6 @@ pub fn opts() -> TargetOptions {
             "-Wl,-z,noexecstack".to_string(),
         ],
         position_independent_executables: true,
-        archive_format: "gnu".to_string(),
         exe_allocation_crate: super::maybe_jemalloc(),
         has_elf_tls: true,
         .. Default::default()

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -249,7 +249,7 @@ impl Default for TargetOptions {
             pre_link_objects_dll: Vec::new(),
             post_link_objects: Vec::new(),
             late_link_args: Vec::new(),
-            archive_format: String::new(),
+            archive_format: "gnu".to_string(),
             custom_unwind_resume: false,
             lib_allocation_crate: "alloc_system".to_string(),
             exe_allocation_crate: "alloc_system".to_string(),

--- a/src/librustc_back/target/netbsd_base.rs
+++ b/src/librustc_back/target/netbsd_base.rs
@@ -29,7 +29,6 @@ pub fn opts() -> TargetOptions {
             "-Wl,-z,noexecstack".to_string(),
         ),
         position_independent_executables: true,
-        archive_format: "gnu".to_string(),
         .. Default::default()
     }
 }

--- a/src/librustc_back/target/openbsd_base.rs
+++ b/src/librustc_back/target/openbsd_base.rs
@@ -29,7 +29,6 @@ pub fn opts() -> TargetOptions {
             "-Wl,-z,noexecstack".to_string(),
         ),
         position_independent_executables: true,
-        archive_format: "gnu".to_string(),
         exe_allocation_crate: "alloc_system".to_string(),
         .. Default::default()
     }

--- a/src/librustc_back/target/solaris_base.rs
+++ b/src/librustc_back/target/solaris_base.rs
@@ -18,7 +18,6 @@ pub fn opts() -> TargetOptions {
         executables: true,
         has_rpath: true,
         is_like_solaris: true,
-        archive_format: "gnu".to_string(),
         exe_allocation_crate: super::maybe_jemalloc(),
 
         .. Default::default()

--- a/src/librustc_back/target/windows_base.rs
+++ b/src/librustc_back/target/windows_base.rs
@@ -25,7 +25,6 @@ pub fn opts() -> TargetOptions {
         staticlib_suffix: ".lib".to_string(),
         no_default_libraries: true,
         is_like_windows: true,
-        archive_format: "gnu".to_string(),
         pre_link_args: vec!(
             // And here, we see obscure linker flags #45. On windows, it has been
             // found to be necessary to have this flag to compile liblibc.

--- a/src/librustc_back/target/windows_msvc_base.rs
+++ b/src/librustc_back/target/windows_msvc_base.rs
@@ -59,7 +59,6 @@ pub fn opts() -> TargetOptions {
             "/NOLOGO".to_string(),
             "/NXCOMPAT".to_string(),
         ],
-        archive_format: "gnu".to_string(),
         exe_allocation_crate: "alloc_system".to_string(),
 
         .. Default::default()


### PR DESCRIPTION
The compiler currently vendors its own version of "llvm-ar" (not literally the
binary but rather the library support) and uses it for all major targets by
default (e.g. everything defined in `src/librustc_back/target`). All custom
target specs, however, still search for an `ar` tool by default. This commit
changes this default behavior to using the internally bundled llvm-ar with the
GNU format.

Currently all targets use the GNU format except for OSX which uses the BSD
format (surely makes sense, right?), and custom targets can change the format
via the `archive-format` key in custom target specs.

I suspect that we can outright remove support for invoking an external `ar`
utility, but I figure for now there may be some crazy target relying on that so
we should leave support in for now.
