### PR TITLE
driver: Disallow predicates in --cfg specs

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -348,10 +348,24 @@ fn handle_explain(code: &str,
     }
 }
 
+fn check_cfg(sopts: &config::Options,
+             output: ErrorOutputType) {
+    fn is_meta_list(item: &ast::MetaItem) -> bool {
+        match item.node {
+            ast::MetaItem_::MetaList(..) => true,
+            _ => false,
+        }
+    }
+
+    if sopts.cfg.iter().any(|item| is_meta_list(&*item)) {
+        early_error(output, "predicates are not allowed in --cfg");
+    }
+}
+
 impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
     fn early_callback(&mut self,
                       matches: &getopts::Matches,
-                      _sopts: &config::Options,
+                      sopts: &config::Options,
                       descriptions: &diagnostics::registry::Registry,
                       output: ErrorOutputType)
                       -> Compilation {
@@ -360,6 +374,7 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
             return Compilation::Stop;
         }
 
+        check_cfg(sopts, output);
         Compilation::Continue
     }
 

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -164,7 +164,11 @@ pub fn run_compiler<'a>(args: &[String],
 
     let descriptions = diagnostics_registry();
 
-    do_or_return!(callbacks.early_callback(&matches, &descriptions, sopts.error_format), None);
+    do_or_return!(callbacks.early_callback(&matches,
+                                           &sopts,
+                                           &descriptions,
+                                           sopts.error_format),
+                                           None);
 
     let (odir, ofile) = make_output(&matches);
     let (input, input_file_path) = match make_input(&matches.free) {
@@ -251,6 +255,7 @@ pub trait CompilerCalls<'a> {
     // else (e.g., selecting input and output).
     fn early_callback(&mut self,
                       _: &getopts::Matches,
+                      _: &config::Options,
                       _: &diagnostics::registry::Registry,
                       _: ErrorOutputType)
                       -> Compilation {
@@ -327,6 +332,7 @@ pub struct RustcDefaultCalls;
 impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
     fn early_callback(&mut self,
                       matches: &getopts::Matches,
+                      _sopts: &config::Options,
                       descriptions: &diagnostics::registry::Registry,
                       output: ErrorOutputType)
                       -> Compilation {

--- a/src/test/compile-fail/cfg-attr-invalid-predicate.rs
+++ b/src/test/compile-fail/cfg-attr-invalid-predicate.rs
@@ -1,0 +1,12 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[cfg(foo(bar))] //~ ERROR invalid predicate `foo`
+fn main() {}

--- a/src/test/compile-fail/issue-31495.rs
+++ b/src/test/compile-fail/issue-31495.rs
@@ -1,0 +1,13 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --cfg foo(bar)
+// error-pattern: predicates are not allowed in --cfg
+fn main() {}

--- a/src/test/compile-fail/issue-31495.rs
+++ b/src/test/compile-fail/issue-31495.rs
@@ -9,5 +9,5 @@
 // except according to those terms.
 
 // compile-flags: --cfg foo(bar)
-// error-pattern: predicates are not allowed in --cfg
+// error-pattern: invalid predicate in --cfg command line argument: `foo`
 fn main() {}

--- a/src/test/run-pass-fulldeps/compiler-calls.rs
+++ b/src/test/run-pass-fulldeps/compiler-calls.rs
@@ -34,6 +34,7 @@ struct TestCalls {
 impl<'a> CompilerCalls<'a> for TestCalls {
     fn early_callback(&mut self,
                       _: &getopts::Matches,
+                      _: &config::Options,
                       _: &diagnostics::registry::Registry,
                       _: config::ErrorOutputType)
                       -> Compilation {


### PR DESCRIPTION
A spec like `#[cfg(foo(bar))]` is not allowed as an attribute. This
makes the same spec be rejected by the compiler if passed in as a
`--cfg` argument.

Fixes #31495
