### PR TITLE
Open code the __failfast intrinsic for rtabort! on windows

### DIFF
--- a/src/libstd/sys/common/util.rs
+++ b/src/libstd/sys/common/util.rs
@@ -10,7 +10,6 @@
 
 use env;
 use fmt;
-use intrinsics;
 use io::prelude::*;
 use sync::atomic::{self, Ordering};
 use sys::stdio::Stderr;
@@ -34,7 +33,16 @@ pub fn dumb_print(args: fmt::Arguments) {
     let _ = Stderr::new().map(|mut stderr| stderr.write_fmt(args));
 }
 
+#[cfg(unix)]
 pub fn abort(args: fmt::Arguments) -> ! {
+    use libc;
+    dumb_print(format_args!("fatal runtime error: {}\n", args));
+    unsafe { libc::abort(); }
+}
+
+#[cfg(not(unix))]
+pub fn abort(args: fmt::Arguments) -> ! {
+    use intrinsics;
     dumb_print(format_args!("fatal runtime error: {}\n", args));
     unsafe { intrinsics::abort(); }
 }

--- a/src/libstd/sys/common/util.rs
+++ b/src/libstd/sys/common/util.rs
@@ -40,11 +40,24 @@ pub fn abort(args: fmt::Arguments) -> ! {
     unsafe { libc::abort(); }
 }
 
-#[cfg(not(unix))]
+// On windows, use the processor-specific __fastfail mechanism
+// https://msdn.microsoft.com/en-us/library/dn774154.aspx
+#[cfg(all(windows, target_arch = "x86"))]
 pub fn abort(args: fmt::Arguments) -> ! {
-    use intrinsics;
     dumb_print(format_args!("fatal runtime error: {}\n", args));
-    unsafe { intrinsics::abort(); }
+    unsafe {
+        asm!("int $$0x29" :: "{ecx}"(7) ::: volatile); // 7 is FAST_FAIL_FATAL_APP_EXIT
+        ::intrinsics::unreachable();
+    }
+}
+
+#[cfg(all(windows, target_arch = "x86_64"))]
+pub fn abort(args: fmt::Arguments) -> ! {
+    dumb_print(format_args!("fatal runtime error: {}\n", args));
+    unsafe {
+        asm!("int $$0x29" :: "{rcx}"(7) ::: volatile); // 7 is FAST_FAIL_FATAL_APP_EXIT
+        ::intrinsics::unreachable();
+    }
 }
 
 #[allow(dead_code)] // stack overflow detection not enabled on all platforms

--- a/src/test/run-pass/out-of-stack.rs
+++ b/src/test/run-pass/out-of-stack.rs
@@ -46,8 +46,7 @@ fn check_status(status: std::process::ExitStatus)
     use std::os::unix::process::ExitStatusExt;
 
     assert!(!status.success());
-    assert!(status.signal() != Some(libc::SIGSEGV)
-            && status.signal() != Some(libc::SIGBUS));
+    assert_eq!(status.signal(), Some(libc::SIGABRT));
 }
 
 #[cfg(not(unix))]


### PR DESCRIPTION
Open code the __failfast intrinsic for rtabort! on windows

Based on https://github.com/rust-lang/rust/pull/31457

As described https://msdn.microsoft.com/en-us/library/dn774154.aspx

This is a Windows 8+ mechanism for terminating the process quickly,
which degrades to either an access violation or bugcheck in older versions.

I'm not sure this is better the the current mechanism of terminating
with an illegal instruction, but we recently converted unix to
terminate more correctly with SIGABORT, and this _seems_ more correct
for windows.

I'm not convinced this is the right thing to do, since it will make it harder to detect runtime aborts on windows - presumably the different exit modes for different windows versions produce different exit codes. Since this is a breaking change we really only want to do it once.

r? @alexcrichton 
cc @retep998 
