### PR TITLE
PowerPC64 fixes after removal of powerpc64le target_arch

### DIFF
--- a/src/liballoc_jemalloc/lib.rs
+++ b/src/liballoc_jemalloc/lib.rs
@@ -56,8 +56,7 @@ const MIN_ALIGN: usize = 8;
 #[cfg(all(any(target_arch = "x86",
               target_arch = "x86_64",
               target_arch = "aarch64",
-              target_arch = "powerpc64",
-              target_arch = "powerpc64le")))]
+              target_arch = "powerpc64")))]
 const MIN_ALIGN: usize = 16;
 
 // MALLOCX_ALIGN(a) macro

--- a/src/librustc_trans/trans/cabi_powerpc64.rs
+++ b/src/librustc_trans/trans/cabi_powerpc64.rs
@@ -158,7 +158,7 @@ fn classify_ret_ty(ccx: &CrateContext, ty: Type) -> ArgType {
     }
 
     // The PowerPC64 big endian ABI doesn't return aggregates in registers
-    if ccx.sess().target.target.arch == "powerpc64" {
+    if ccx.sess().target.target.target_endian == "big" {
         return ArgType::indirect(ty, Some(Attribute::StructRet))
     }
 


### PR DESCRIPTION
We no longer have a separate powerpc64 and powerpc64le target_arch, and instead use target_endian to select between the two. These patches fix a couple of remaining issues.
