### PR TITLE
Fix half of emscripten's failing tests

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -1229,11 +1229,13 @@ fn compose_and_run_compiler(config: &Config, props: &TestProps,
             // for the test suite (otherwise including libstd statically in all
             // executables takes up quite a bit of space).
             //
-            // For targets like MUSL, however, there is no support for dynamic
-            // libraries so we just go back to building a normal library. Note,
-            // however, that if the library is built with `force_host` then it's
-            // ok to be a dylib as the host should always support dylibs.
-            if config.target.contains("musl") && !aux_props.force_host {
+            // For targets like MUSL or Emscripten, however, there is no support for
+            // dynamic libraries so we just go back to building a normal library. Note,
+            // however, that for MUSL if the library is built with `force_host` then
+            // it's ok to be a dylib as the host should always support dylibs.
+            if (config.target.contains("musl") && !aux_props.force_host) ||
+                config.target.contains("emscripten")
+            {
                 vec!("--crate-type=lib".to_owned())
             } else {
                 vec!("--crate-type=dylib".to_owned())

--- a/src/libstd/sys/unix/fd.rs
+++ b/src/libstd/sys/unix/fd.rs
@@ -51,14 +51,14 @@ impl FileDesc {
         Ok(ret as usize)
     }
 
-    #[cfg(not(any(target_env = "newlib", target_os = "solaris")))]
+    #[cfg(not(any(target_env = "newlib", target_os = "solaris", target_os = "emscripten")))]
     pub fn set_cloexec(&self) {
         unsafe {
             let ret = libc::ioctl(self.fd, libc::FIOCLEX);
             debug_assert_eq!(ret, 0);
         }
     }
-    #[cfg(any(target_env = "newlib", target_os = "solaris"))]
+    #[cfg(any(target_env = "newlib", target_os = "solaris", target_os = "emscripten"))]
     pub fn set_cloexec(&self) {
         unsafe {
             let previous = libc::fcntl(self.fd, libc::F_GETFD);

--- a/src/test/run-pass/x86stdcall.rs
+++ b/src/test/run-pass/x86stdcall.rs
@@ -38,5 +38,6 @@ pub fn main() {
           target_os = "netbsd",
           target_os = "openbsd",
           target_os = "android",
-          target_os = "solaris"))]
+          target_os = "solaris",
+          target_os = "emscripten"))]
 pub fn main() { }


### PR DESCRIPTION
Before this PR:

> test result: FAILED. 2039 passed; 327 failed; 2 ignored; 0 measured

After:

> test result: FAILED. 2232 passed; 134 failed; 2 ignored; 0 measured

r? @brson 
