### PR TITLE
std: Deprecate all std::os::*::raw types

### DIFF
--- a/src/libstd/os/android/fs.rs
+++ b/src/libstd/os/android/fs.rs
@@ -1,0 +1,129 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![stable(feature = "metadata_ext", since = "1.1.0")]
+
+use libc;
+
+use fs::Metadata;
+use sys_common::AsInner;
+
+#[allow(deprecated)]
+use os::android::raw;
+
+/// OS-specific extension methods for `fs::Metadata`
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+pub trait MetadataExt {
+    /// Gain a reference to the underlying `stat` structure which contains
+    /// the raw information returned by the OS.
+    ///
+    /// The contents of the returned `stat` are **not** consistent across
+    /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
+    /// cross-Unix abstractions contained within the raw stat.
+    #[stable(feature = "metadata_ext", since = "1.1.0")]
+    #[rustc_deprecated(since = "1.8.0",
+                       reason = "deprecated in favor of the accessor \
+                                 methods of this trait")]
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat;
+
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_dev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ino(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mode(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_nlink(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_uid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_gid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_rdev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_size(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blksize(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blocks(&self) -> u64;
+}
+
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+impl MetadataExt for Metadata {
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat {
+        unsafe {
+            &*(self.as_inner().as_inner() as *const libc::stat
+                                          as *const raw::stat)
+        }
+    }
+    fn st_dev(&self) -> u64 {
+        self.as_inner().as_inner().st_dev as u64
+    }
+    fn st_ino(&self) -> u64 {
+        self.as_inner().as_inner().st_ino as u64
+    }
+    fn st_mode(&self) -> u32 {
+        self.as_inner().as_inner().st_mode as u32
+    }
+    fn st_nlink(&self) -> u64 {
+        self.as_inner().as_inner().st_nlink as u64
+    }
+    fn st_uid(&self) -> u32 {
+        self.as_inner().as_inner().st_uid as u32
+    }
+    fn st_gid(&self) -> u32 {
+        self.as_inner().as_inner().st_gid as u32
+    }
+    fn st_rdev(&self) -> u64 {
+        self.as_inner().as_inner().st_rdev as u64
+    }
+    fn st_size(&self) -> u64 {
+        self.as_inner().as_inner().st_size as u64
+    }
+    fn st_atime(&self) -> i64 {
+        self.as_inner().as_inner().st_atime as i64
+    }
+    fn st_atime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_atime_nsec as i64
+    }
+    fn st_mtime(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime as i64
+    }
+    fn st_mtime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime_nsec as i64
+    }
+    fn st_ctime(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime as i64
+    }
+    fn st_ctime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime_nsec as i64
+    }
+    fn st_blksize(&self) -> u64 {
+        self.as_inner().as_inner().st_blksize as u64
+    }
+    fn st_blocks(&self) -> u64 {
+        self.as_inner().as_inner().st_blocks as u64
+    }
+}
+

--- a/src/libstd/os/android/mod.rs
+++ b/src/libstd/os/android/mod.rs
@@ -13,9 +13,4 @@
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod raw;
-
-#[stable(feature = "raw_ext", since = "1.1.0")]
-pub mod fs {
-    #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub use sys::fs::MetadataExt;
-}
+pub mod fs;

--- a/src/libstd/os/android/raw.rs
+++ b/src/libstd/os/android/raw.rs
@@ -11,6 +11,12 @@
 //! Android-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
+#![rustc_deprecated(since = "1.8.0",
+                    reason = "these type aliases are no longer supported by \
+                              the standard library, the `libc` crate on \
+                              crates.io should be used instead for the correct \
+                              definitions")]
+#![allow(deprecated)]
 
 use os::raw::c_long;
 
@@ -26,22 +32,22 @@ mod arch {
     use os::unix::raw::{uid_t, gid_t};
 
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub type dev_t = u32;
+    pub type dev_t = u64;
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub type mode_t = u16;
+    pub type mode_t = u32;
 
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub type blkcnt_t = u32;
+    pub type blkcnt_t = u64;
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub type blksize_t = u32;
+    pub type blksize_t = u64;
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub type ino_t = u32;
+    pub type ino_t = u64;
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub type nlink_t = u16;
+    pub type nlink_t = u64;
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub type off_t = i32;
+    pub type off_t = u64;
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub type time_t = i32;
+    pub type time_t = i64;
 
     #[repr(C)]
     #[derive(Clone)]
@@ -52,7 +58,7 @@ mod arch {
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __pad0: [c_uchar; 4],
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub __st_ino: ino_t,
+        pub __st_ino: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mode: c_uint,
         #[stable(feature = "raw_ext", since = "1.1.0")]
@@ -68,19 +74,19 @@ mod arch {
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_size: c_longlong,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_blksize: blksize_t,
+        pub st_blksize: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_blocks: c_ulonglong,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_atime: time_t,
+        pub st_atime: c_ulong,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime_nsec: c_ulong,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_mtime: time_t,
+        pub st_mtime: c_ulong,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime_nsec: c_ulong,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_ctime: time_t,
+        pub st_ctime: c_ulong,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime_nsec: c_ulong,
         #[stable(feature = "raw_ext", since = "1.1.0")]
@@ -103,13 +109,13 @@ mod arch {
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type blkcnt_t = u64;
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub type blksize_t = u32;
+    pub type blksize_t = u64;
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type ino_t = u64;
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub type nlink_t = u32;
+    pub type nlink_t = u64;
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub type off_t = i64;
+    pub type off_t = u64;
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type time_t = i64;
 

--- a/src/libstd/os/bitrig/fs.rs
+++ b/src/libstd/os/bitrig/fs.rs
@@ -1,0 +1,149 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![stable(feature = "metadata_ext", since = "1.1.0")]
+
+use libc;
+
+use fs::Metadata;
+use sys_common::AsInner;
+
+#[allow(deprecated)]
+use os::bitrig::raw;
+
+/// OS-specific extension methods for `fs::Metadata`
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+pub trait MetadataExt {
+    /// Gain a reference to the underlying `stat` structure which contains
+    /// the raw information returned by the OS.
+    ///
+    /// The contents of the returned `stat` are **not** consistent across
+    /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
+    /// cross-Unix abstractions contained within the raw stat.
+    #[stable(feature = "metadata_ext", since = "1.1.0")]
+    #[rustc_deprecated(since = "1.8.0",
+                       reason = "deprecated in favor of the accessor \
+                                 methods of this trait")]
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat;
+
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_dev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ino(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mode(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_nlink(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_uid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_gid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_rdev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_size(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_birthtime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_birthtime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blksize(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blocks(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_flags(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_gen(&self) -> u32;
+}
+
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+impl MetadataExt for Metadata {
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat {
+        unsafe {
+            &*(self.as_inner().as_inner() as *const libc::stat
+                                          as *const raw::stat)
+        }
+    }
+    fn st_dev(&self) -> u64 {
+        self.as_inner().as_inner().st_dev as u64
+    }
+    fn st_ino(&self) -> u64 {
+        self.as_inner().as_inner().st_ino as u64
+    }
+    fn st_mode(&self) -> u32 {
+        self.as_inner().as_inner().st_mode as u32
+    }
+    fn st_nlink(&self) -> u64 {
+        self.as_inner().as_inner().st_nlink as u64
+    }
+    fn st_uid(&self) -> u32 {
+        self.as_inner().as_inner().st_uid as u32
+    }
+    fn st_gid(&self) -> u32 {
+        self.as_inner().as_inner().st_gid as u32
+    }
+    fn st_rdev(&self) -> u64 {
+        self.as_inner().as_inner().st_rdev as u64
+    }
+    fn st_size(&self) -> u64 {
+        self.as_inner().as_inner().st_size as u64
+    }
+    fn st_atime(&self) -> i64 {
+        self.as_inner().as_inner().st_atime as i64
+    }
+    fn st_atime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_atime_nsec as i64
+    }
+    fn st_mtime(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime as i64
+    }
+    fn st_mtime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime_nsec as i64
+    }
+    fn st_ctime(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime as i64
+    }
+    fn st_ctime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime_nsec as i64
+    }
+    fn st_birthtime(&self) -> i64 {
+        self.as_inner().as_inner().st_birthtime as i64
+    }
+    fn st_birthtime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_birthtime_nsec as i64
+    }
+    fn st_blksize(&self) -> u64 {
+        self.as_inner().as_inner().st_blksize as u64
+    }
+    fn st_blocks(&self) -> u64 {
+        self.as_inner().as_inner().st_blocks as u64
+    }
+    fn st_gen(&self) -> u32 {
+        self.as_inner().as_inner().st_gen as u32
+    }
+    fn st_flags(&self) -> u32 {
+        self.as_inner().as_inner().st_flags as u32
+    }
+}
+

--- a/src/libstd/os/bitrig/mod.rs
+++ b/src/libstd/os/bitrig/mod.rs
@@ -13,9 +13,4 @@
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod raw;
-
-#[stable(feature = "raw_ext", since = "1.1.0")]
-pub mod fs {
-    #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub use sys::fs::MetadataExt;
-}
+pub mod fs;

--- a/src/libstd/os/bitrig/raw.rs
+++ b/src/libstd/os/bitrig/raw.rs
@@ -11,18 +11,24 @@
 //! Bitrig-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
+#![rustc_deprecated(since = "1.8.0",
+                    reason = "these type aliases are no longer supported by \
+                              the standard library, the `libc` crate on \
+                              crates.io should be used instead for the correct \
+                              definitions")]
+#![allow(deprecated)]
 
 use os::raw::c_long;
 use os::unix::raw::{uid_t, gid_t};
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = i32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type fflags_t = u32;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
 #[unstable(feature = "pthread_t", issue = "29791")] pub type pthread_t = usize;
@@ -32,43 +38,43 @@ use os::unix::raw::{uid_t, gid_t};
 #[stable(feature = "raw_ext", since = "1.1.0")]
 pub struct stat {
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_mode: mode_t,
+    pub st_mode: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_dev: dev_t,
+    pub st_dev: i32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_ino: ino_t,
+    pub st_ino: u64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_nlink: nlink_t,
+    pub st_nlink: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_uid: uid_t,
+    pub st_uid: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_gid: gid_t,
+    pub st_gid: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_rdev: dev_t,
+    pub st_rdev: i32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_atime: time_t,
+    pub st_atime: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_atime_nsec: c_long,
+    pub st_atime_nsec: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_mtime: time_t,
+    pub st_mtime: u64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_mtime_nsec: c_long,
+    pub st_mtime_nsec: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_ctime: time_t,
+    pub st_ctime: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_ctime_nsec: c_long,
+    pub st_ctime_nsec: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_size: off_t,
+    pub st_size: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_blocks: blkcnt_t,
+    pub st_blocks: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_blksize: blksize_t,
+    pub st_blksize: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_flags: fflags_t,
+    pub st_flags: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_gen: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_birthtime: time_t,
+    pub st_birthtime: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_birthtime_nsec: c_long,
+    pub st_birthtime_nsec: i64,
 }

--- a/src/libstd/os/dragonfly/fs.rs
+++ b/src/libstd/os/dragonfly/fs.rs
@@ -1,0 +1,154 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![stable(feature = "metadata_ext", since = "1.1.0")]
+
+use libc;
+
+use fs::Metadata;
+use sys_common::AsInner;
+
+#[allow(deprecated)]
+use os::dragonfly::raw;
+
+/// OS-specific extension methods for `fs::Metadata`
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+pub trait MetadataExt {
+    /// Gain a reference to the underlying `stat` structure which contains
+    /// the raw information returned by the OS.
+    ///
+    /// The contents of the returned `stat` are **not** consistent across
+    /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
+    /// cross-Unix abstractions contained within the raw stat.
+    #[stable(feature = "metadata_ext", since = "1.1.0")]
+    #[rustc_deprecated(since = "1.8.0",
+                       reason = "deprecated in favor of the accessor \
+                                 methods of this trait")]
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat;
+
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_dev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ino(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mode(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_nlink(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_uid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_gid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_rdev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_size(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_birthtime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_birthtime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blksize(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blocks(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_flags(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_gen(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_lspare(&self) -> u32;
+}
+
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+impl MetadataExt for Metadata {
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat {
+        unsafe {
+            &*(self.as_inner().as_inner() as *const libc::stat
+                                          as *const raw::stat)
+        }
+    }
+    fn st_dev(&self) -> u64 {
+        self.as_inner().as_inner().st_dev as u64
+    }
+    fn st_ino(&self) -> u64 {
+        self.as_inner().as_inner().st_ino as u64
+    }
+    fn st_mode(&self) -> u32 {
+        self.as_inner().as_inner().st_mode as u32
+    }
+    fn st_nlink(&self) -> u64 {
+        self.as_inner().as_inner().st_nlink as u64
+    }
+    fn st_uid(&self) -> u32 {
+        self.as_inner().as_inner().st_uid as u32
+    }
+    fn st_gid(&self) -> u32 {
+        self.as_inner().as_inner().st_gid as u32
+    }
+    fn st_rdev(&self) -> u64 {
+        self.as_inner().as_inner().st_rdev as u64
+    }
+    fn st_size(&self) -> u64 {
+        self.as_inner().as_inner().st_size as u64
+    }
+    fn st_atime(&self) -> i64 {
+        self.as_inner().as_inner().st_atime as i64
+    }
+    fn st_atime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_atime_nsec as i64
+    }
+    fn st_mtime(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime as i64
+    }
+    fn st_mtime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime_nsec as i64
+    }
+    fn st_ctime(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime as i64
+    }
+    fn st_ctime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime_nsec as i64
+    }
+    fn st_birthtime(&self) -> i64 {
+        self.as_inner().as_inner().st_birthtime as i64
+    }
+    fn st_birthtime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_birthtime_nsec as i64
+    }
+    fn st_blksize(&self) -> u64 {
+        self.as_inner().as_inner().st_blksize as u64
+    }
+    fn st_blocks(&self) -> u64 {
+        self.as_inner().as_inner().st_blocks as u64
+    }
+    fn st_gen(&self) -> u32 {
+        self.as_inner().as_inner().st_gen as u32
+    }
+    fn st_flags(&self) -> u32 {
+        self.as_inner().as_inner().st_flags as u32
+    }
+    fn st_lspare(&self) -> u32 {
+        self.as_inner().as_inner().st_lspare as u32
+    }
+}
+

--- a/src/libstd/os/dragonfly/mod.rs
+++ b/src/libstd/os/dragonfly/mod.rs
@@ -13,9 +13,4 @@
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod raw;
-
-#[stable(feature = "raw_ext", since = "1.1.0")]
-pub mod fs {
-    #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub use sys::fs::MetadataExt;
-}
+pub mod fs;

--- a/src/libstd/os/dragonfly/raw.rs
+++ b/src/libstd/os/dragonfly/raw.rs
@@ -11,18 +11,24 @@
 //! Dragonfly-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
+#![rustc_deprecated(since = "1.8.0",
+                    reason = "these type aliases are no longer supported by \
+                              the standard library, the `libc` crate on \
+                              crates.io should be used instead for the correct \
+                              definitions")]
+#![allow(deprecated)]
 
 use os::raw::c_long;
 use os::unix::raw::{uid_t, gid_t};
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type fflags_t = u32;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u16;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u16;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
 #[unstable(feature = "pthread_t", issue = "29791")] pub type pthread_t = usize;
@@ -32,47 +38,45 @@ use os::unix::raw::{uid_t, gid_t};
 #[stable(feature = "raw_ext", since = "1.1.0")]
 pub struct stat {
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_ino: ino_t,
+    pub st_dev: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_nlink: nlink_t,
+    pub st_ino: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_dev: dev_t,
+    pub st_mode: u16,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_mode: mode_t,
+    pub st_nlink: u16,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_padding1: u16,
+    pub st_uid: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_uid: uid_t,
+    pub st_gid: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_gid: gid_t,
+    pub st_rdev: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_rdev: dev_t,
+    pub st_atime: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_atime: time_t,
+    pub st_atime_nsec: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_atime_nsec: c_long,
+    pub st_mtime: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_mtime: time_t,
+    pub st_mtime_nsec: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_mtime_nsec: c_long,
+    pub st_ctime: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_ctime: time_t,
+    pub st_ctime_nsec: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_ctime_nsec: c_long,
+    pub st_size: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_size: off_t,
+    pub st_blocks: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_blocks: blkcnt_t,
+    pub st_blksize: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_blksize: blksize_t,
-    #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_flags: fflags_t,
+    pub st_flags: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_gen: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_lspare: i32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_qspare1: i64,
+    pub st_birthtime: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_qspare2: i64,
+    pub st_birthtime_nsec: i64,
 }

--- a/src/libstd/os/freebsd/fs.rs
+++ b/src/libstd/os/freebsd/fs.rs
@@ -1,0 +1,154 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![stable(feature = "metadata_ext", since = "1.1.0")]
+
+use libc;
+
+use fs::Metadata;
+use sys_common::AsInner;
+
+#[allow(deprecated)]
+use os::freebsd::raw;
+
+/// OS-specific extension methods for `fs::Metadata`
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+pub trait MetadataExt {
+    /// Gain a reference to the underlying `stat` structure which contains
+    /// the raw information returned by the OS.
+    ///
+    /// The contents of the returned `stat` are **not** consistent across
+    /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
+    /// cross-Unix abstractions contained within the raw stat.
+    #[stable(feature = "metadata_ext", since = "1.1.0")]
+    #[rustc_deprecated(since = "1.8.0",
+                       reason = "deprecated in favor of the accessor \
+                                 methods of this trait")]
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat;
+
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_dev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ino(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mode(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_nlink(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_uid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_gid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_rdev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_size(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_birthtime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_birthtime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blksize(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blocks(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_flags(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_gen(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_lspare(&self) -> u32;
+}
+
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+impl MetadataExt for Metadata {
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat {
+        unsafe {
+            &*(self.as_inner().as_inner() as *const libc::stat
+                                          as *const raw::stat)
+        }
+    }
+    fn st_dev(&self) -> u64 {
+        self.as_inner().as_inner().st_dev as u64
+    }
+    fn st_ino(&self) -> u64 {
+        self.as_inner().as_inner().st_ino as u64
+    }
+    fn st_mode(&self) -> u32 {
+        self.as_inner().as_inner().st_mode as u32
+    }
+    fn st_nlink(&self) -> u64 {
+        self.as_inner().as_inner().st_nlink as u64
+    }
+    fn st_uid(&self) -> u32 {
+        self.as_inner().as_inner().st_uid as u32
+    }
+    fn st_gid(&self) -> u32 {
+        self.as_inner().as_inner().st_gid as u32
+    }
+    fn st_rdev(&self) -> u64 {
+        self.as_inner().as_inner().st_rdev as u64
+    }
+    fn st_size(&self) -> u64 {
+        self.as_inner().as_inner().st_size as u64
+    }
+    fn st_atime(&self) -> i64 {
+        self.as_inner().as_inner().st_atime as i64
+    }
+    fn st_atime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_atime_nsec as i64
+    }
+    fn st_mtime(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime as i64
+    }
+    fn st_mtime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime_nsec as i64
+    }
+    fn st_ctime(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime as i64
+    }
+    fn st_ctime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime_nsec as i64
+    }
+    fn st_birthtime(&self) -> i64 {
+        self.as_inner().as_inner().st_birthtime as i64
+    }
+    fn st_birthtime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_birthtime_nsec as i64
+    }
+    fn st_blksize(&self) -> u64 {
+        self.as_inner().as_inner().st_blksize as u64
+    }
+    fn st_blocks(&self) -> u64 {
+        self.as_inner().as_inner().st_blocks as u64
+    }
+    fn st_gen(&self) -> u32 {
+        self.as_inner().as_inner().st_gen as u32
+    }
+    fn st_flags(&self) -> u32 {
+        self.as_inner().as_inner().st_flags as u32
+    }
+    fn st_lspare(&self) -> u32 {
+        self.as_inner().as_inner().st_lspare as u32
+    }
+}
+

--- a/src/libstd/os/freebsd/mod.rs
+++ b/src/libstd/os/freebsd/mod.rs
@@ -13,9 +13,4 @@
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod raw;
-
-#[stable(feature = "raw_ext", since = "1.1.0")]
-pub mod fs {
-    #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub use sys::fs::MetadataExt;
-}
+pub mod fs;

--- a/src/libstd/os/freebsd/raw.rs
+++ b/src/libstd/os/freebsd/raw.rs
@@ -11,14 +11,20 @@
 //! FreeBSD-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
+#![rustc_deprecated(since = "1.8.0",
+                    reason = "these type aliases are no longer supported by \
+                              the standard library, the `libc` crate on \
+                              crates.io should be used instead for the correct \
+                              definitions")]
+#![allow(deprecated)]
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u16;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u16;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type fflags_t = u32;
 
 #[unstable(feature = "pthread_t", issue = "29791")] pub type pthread_t = usize;
@@ -33,7 +39,7 @@ mod arch {
     use os::raw::c_long;
     use os::unix::raw::{uid_t, gid_t};
 
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
     #[repr(C)]
     #[derive(Clone)]
@@ -99,47 +105,47 @@ mod arch {
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_dev: dev_t,
+        pub st_dev: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_ino: ino_t,
+        pub st_ino: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_mode: mode_t,
+        pub st_mode: u16,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_nlink: nlink_t,
+        pub st_nlink: u16,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_uid: uid_t,
+        pub st_uid: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_gid: gid_t,
+        pub st_gid: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_rdev: dev_t,
+        pub st_rdev: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_atime: time_t,
+        pub st_atime: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_atime_nsec: c_long,
+        pub st_atime_nsec: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_mtime: time_t,
+        pub st_mtime: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_mtime_nsec: c_long,
+        pub st_mtime_nsec: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_ctime: time_t,
+        pub st_ctime: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_ctime_nsec: c_long,
+        pub st_ctime_nsec: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_size: off_t,
+        pub st_size: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_blocks: blkcnt_t,
+        pub st_blocks: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_blksize: blksize_t,
+        pub st_blksize: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_flags: fflags_t,
+        pub st_flags: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_gen: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_lspare: i32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_birthtime: time_t,
+        pub st_birthtime: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_birthtime_nsec: c_long,
+        pub st_birthtime_nsec: i64,
     }
 }
 

--- a/src/libstd/os/ios/fs.rs
+++ b/src/libstd/os/ios/fs.rs
@@ -1,0 +1,154 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![stable(feature = "metadata_ext", since = "1.1.0")]
+
+use libc;
+
+use fs::Metadata;
+use sys_common::AsInner;
+
+#[allow(deprecated)]
+use os::ios::raw;
+
+/// OS-specific extension methods for `fs::Metadata`
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+pub trait MetadataExt {
+    /// Gain a reference to the underlying `stat` structure which contains
+    /// the raw information returned by the OS.
+    ///
+    /// The contents of the returned `stat` are **not** consistent across
+    /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
+    /// cross-Unix abstractions contained within the raw stat.
+    #[stable(feature = "metadata_ext", since = "1.1.0")]
+    #[rustc_deprecated(since = "1.8.0",
+                       reason = "deprecated in favor of the accessor \
+                                 methods of this trait")]
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat;
+
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_dev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ino(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mode(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_nlink(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_uid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_gid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_rdev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_size(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_birthtime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_birthtime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blksize(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blocks(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_flags(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_gen(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_lspare(&self) -> u32;
+}
+
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+impl MetadataExt for Metadata {
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat {
+        unsafe {
+            &*(self.as_inner().as_inner() as *const libc::stat
+                                          as *const raw::stat)
+        }
+    }
+    fn st_dev(&self) -> u64 {
+        self.as_inner().as_inner().st_dev as u64
+    }
+    fn st_ino(&self) -> u64 {
+        self.as_inner().as_inner().st_ino as u64
+    }
+    fn st_mode(&self) -> u32 {
+        self.as_inner().as_inner().st_mode as u32
+    }
+    fn st_nlink(&self) -> u64 {
+        self.as_inner().as_inner().st_nlink as u64
+    }
+    fn st_uid(&self) -> u32 {
+        self.as_inner().as_inner().st_uid as u32
+    }
+    fn st_gid(&self) -> u32 {
+        self.as_inner().as_inner().st_gid as u32
+    }
+    fn st_rdev(&self) -> u64 {
+        self.as_inner().as_inner().st_rdev as u64
+    }
+    fn st_size(&self) -> u64 {
+        self.as_inner().as_inner().st_size as u64
+    }
+    fn st_atime(&self) -> i64 {
+        self.as_inner().as_inner().st_atime as i64
+    }
+    fn st_atime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_atime_nsec as i64
+    }
+    fn st_mtime(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime as i64
+    }
+    fn st_mtime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime_nsec as i64
+    }
+    fn st_ctime(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime as i64
+    }
+    fn st_ctime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime_nsec as i64
+    }
+    fn st_birthtime(&self) -> i64 {
+        self.as_inner().as_inner().st_birthtime as i64
+    }
+    fn st_birthtime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_birthtime_nsec as i64
+    }
+    fn st_blksize(&self) -> u64 {
+        self.as_inner().as_inner().st_blksize as u64
+    }
+    fn st_blocks(&self) -> u64 {
+        self.as_inner().as_inner().st_blocks as u64
+    }
+    fn st_gen(&self) -> u32 {
+        self.as_inner().as_inner().st_gen as u32
+    }
+    fn st_flags(&self) -> u32 {
+        self.as_inner().as_inner().st_flags as u32
+    }
+    fn st_lspare(&self) -> u32 {
+        self.as_inner().as_inner().st_lspare as u32
+    }
+}
+

--- a/src/libstd/os/ios/mod.rs
+++ b/src/libstd/os/ios/mod.rs
@@ -13,9 +13,4 @@
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod raw;
-
-#[stable(feature = "raw_ext", since = "1.1.0")]
-pub mod fs {
-    #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub use sys::fs::MetadataExt;
-}
+pub mod fs;

--- a/src/libstd/os/ios/raw.rs
+++ b/src/libstd/os/ios/raw.rs
@@ -11,18 +11,23 @@
 //! iOS-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
+#![rustc_deprecated(since = "1.8.0",
+                    reason = "these type aliases are no longer supported by \
+                              the standard library, the `libc` crate on \
+                              crates.io should be used instead for the correct \
+                              definitions")]
+#![allow(deprecated)]
 
 use os::raw::c_long;
-use os::unix::raw::{uid_t, gid_t};
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = i32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u16;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u16;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = c_long;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
 #[unstable(feature = "pthread_t", issue = "29791")] pub type pthread_t = usize;
 
@@ -31,41 +36,41 @@ use os::unix::raw::{uid_t, gid_t};
 #[stable(feature = "raw_ext", since = "1.1.0")]
 pub struct stat {
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_dev: dev_t,
+    pub st_dev: i32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_mode: mode_t,
+    pub st_mode: u16,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_nlink: nlink_t,
+    pub st_nlink: u16,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_ino: ino_t,
+    pub st_ino: u64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_uid: uid_t,
+    pub st_uid: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_gid: gid_t,
+    pub st_gid: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_rdev: dev_t,
+    pub st_rdev: i32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_atime: time_t,
+    pub st_atime: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_atime_nsec: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_mtime: time_t,
+    pub st_mtime: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_mtime_nsec: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_ctime: time_t,
+    pub st_ctime: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ctime_nsec: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_birthtime: time_t,
+    pub st_birthtime: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_birthtime_nsec: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_size: off_t,
+    pub st_size: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_blocks: blkcnt_t,
+    pub st_blocks: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_blksize: blksize_t,
+    pub st_blksize: i32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_flags: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]

--- a/src/libstd/os/linux/fs.rs
+++ b/src/libstd/os/linux/fs.rs
@@ -1,0 +1,128 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![stable(feature = "metadata_ext", since = "1.1.0")]
+
+use libc;
+
+use fs::Metadata;
+use sys_common::AsInner;
+
+#[allow(deprecated)]
+use os::linux::raw;
+
+/// OS-specific extension methods for `fs::Metadata`
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+pub trait MetadataExt {
+    /// Gain a reference to the underlying `stat` structure which contains
+    /// the raw information returned by the OS.
+    ///
+    /// The contents of the returned `stat` are **not** consistent across
+    /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
+    /// cross-Unix abstractions contained within the raw stat.
+    #[stable(feature = "metadata_ext", since = "1.1.0")]
+    #[rustc_deprecated(since = "1.8.0",
+                       reason = "deprecated in favor of the accessor \
+                                 methods of this trait")]
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat;
+
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_dev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ino(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mode(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_nlink(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_uid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_gid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_rdev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_size(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blksize(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blocks(&self) -> u64;
+}
+
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+impl MetadataExt for Metadata {
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat {
+        unsafe {
+            &*(self.as_inner().as_inner() as *const libc::stat64
+                                          as *const raw::stat)
+        }
+    }
+    fn st_dev(&self) -> u64 {
+        self.as_inner().as_inner().st_dev as u64
+    }
+    fn st_ino(&self) -> u64 {
+        self.as_inner().as_inner().st_ino as u64
+    }
+    fn st_mode(&self) -> u32 {
+        self.as_inner().as_inner().st_mode as u32
+    }
+    fn st_nlink(&self) -> u64 {
+        self.as_inner().as_inner().st_nlink as u64
+    }
+    fn st_uid(&self) -> u32 {
+        self.as_inner().as_inner().st_uid as u32
+    }
+    fn st_gid(&self) -> u32 {
+        self.as_inner().as_inner().st_gid as u32
+    }
+    fn st_rdev(&self) -> u64 {
+        self.as_inner().as_inner().st_rdev as u64
+    }
+    fn st_size(&self) -> u64 {
+        self.as_inner().as_inner().st_size as u64
+    }
+    fn st_atime(&self) -> i64 {
+        self.as_inner().as_inner().st_atime as i64
+    }
+    fn st_atime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_atime_nsec as i64
+    }
+    fn st_mtime(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime as i64
+    }
+    fn st_mtime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime_nsec as i64
+    }
+    fn st_ctime(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime as i64
+    }
+    fn st_ctime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime_nsec as i64
+    }
+    fn st_blksize(&self) -> u64 {
+        self.as_inner().as_inner().st_blksize as u64
+    }
+    fn st_blocks(&self) -> u64 {
+        self.as_inner().as_inner().st_blocks as u64
+    }
+}

--- a/src/libstd/os/linux/mod.rs
+++ b/src/libstd/os/linux/mod.rs
@@ -13,9 +13,4 @@
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod raw;
-
-#[stable(feature = "raw_ext", since = "1.1.0")]
-pub mod fs {
-    #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub use sys::fs::MetadataExt;
-}
+pub mod fs;

--- a/src/libstd/os/linux/raw.rs
+++ b/src/libstd/os/linux/raw.rs
@@ -11,6 +11,12 @@
 //! Linux-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
+#![rustc_deprecated(since = "1.8.0",
+                    reason = "these type aliases are no longer supported by \
+                              the standard library, the `libc` crate on \
+                              crates.io should be used instead for the correct \
+                              definitions")]
+#![allow(deprecated)]
 
 use os::raw::c_ulong;
 
@@ -29,92 +35,79 @@ pub use self::arch::{off_t, ino_t, nlink_t, blksize_t, blkcnt_t, stat, time_t};
           target_arch = "arm",
           target_arch = "asmjs"))]
 mod arch {
-    use super::{dev_t, mode_t};
-    use os::raw::{c_long, c_short};
-    use os::unix::raw::{gid_t, uid_t};
+    use os::raw::{c_long, c_short, c_uint};
 
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i32;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i32;
-
-    #[stable(feature = "raw_ext", since = "1.1.0")]
-    #[cfg(not(any(target_env = "musl", target_arch = "asmjs")))]
-    pub type ino_t = u32;
-    #[stable(feature = "raw_ext", since = "1.1.0")]
-    #[cfg(any(target_env = "musl", target_arch = "asmjs"))]
-    pub type ino_t = u64;
-
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u32;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i32;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
     #[repr(C)]
     #[derive(Clone)]
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_dev: dev_t,
+        pub st_dev: u64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __pad1: c_short,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_ino: ino_t,
+        pub __st_ino: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_mode: mode_t,
+        pub st_mode: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_nlink: nlink_t,
+        pub st_nlink: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_uid: uid_t,
+        pub st_uid: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_gid: gid_t,
+        pub st_gid: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_rdev: dev_t,
+        pub st_rdev: u64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub __pad2: c_short,
+        pub __pad2: c_uint,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_size: off_t,
+        pub st_size: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_blksize: blksize_t,
+        pub st_blksize: i32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_blocks: blkcnt_t,
+        pub st_blocks: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_atime: time_t,
+        pub st_atime: i32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime_nsec: c_long,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_mtime: time_t,
+        pub st_mtime: i32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime_nsec: c_long,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_ctime: time_t,
+        pub st_ctime: i32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime_nsec: c_long,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub __unused4: c_long,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub __unused5: c_long,
+        pub st_ino: u64,
     }
 }
 
 #[cfg(target_arch = "mips")]
 mod arch {
-    use super::mode_t;
     use os::raw::{c_long, c_ulong};
-    use os::unix::raw::{gid_t, uid_t};
 
     #[cfg(target_env = "musl")]
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
     #[cfg(not(target_env = "musl"))]
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i32;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
     #[cfg(target_env = "musl")]
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
     #[cfg(not(target_env = "musl"))]
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u32;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
     #[cfg(target_env = "musl")]
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
     #[cfg(not(target_env = "musl"))]
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
     #[repr(C)]
     #[derive(Clone)]
@@ -125,39 +118,37 @@ mod arch {
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_pad1: [c_long; 3],
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_ino: ino_t,
+        pub st_ino: u64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_mode: mode_t,
+        pub st_mode: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_nlink: nlink_t,
+        pub st_nlink: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_uid: uid_t,
+        pub st_uid: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_gid: gid_t,
+        pub st_gid: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_rdev: c_ulong,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_pad2: [c_long; 2],
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_size: off_t,
+        pub st_size: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_pad3: c_long,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_atime: time_t,
+        pub st_atime: i32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime_nsec: c_long,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_mtime: time_t,
+        pub st_mtime: i32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime_nsec: c_long,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_ctime: time_t,
+        pub st_ctime: i32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime_nsec: c_long,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_blksize: blksize_t,
+        pub st_blksize: i32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_blocks: blkcnt_t,
+        pub st_blocks: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_pad5: [c_long; 14],
     }
@@ -165,15 +156,13 @@ mod arch {
 
 #[cfg(target_arch = "aarch64")]
 mod arch {
-    use super::{dev_t, mode_t};
     use os::raw::{c_long, c_int};
-    use os::unix::raw::{gid_t, uid_t};
 
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u32;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
     #[repr(C)]
@@ -181,39 +170,39 @@ mod arch {
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_dev: dev_t,
+        pub st_dev: u64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_ino: ino_t,
+        pub st_ino: u64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_mode: mode_t,
+        pub st_mode: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_nlink: nlink_t,
+        pub st_nlink: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_uid: uid_t,
+        pub st_uid: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_gid: gid_t,
+        pub st_gid: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_rdev: dev_t,
+        pub st_rdev: u64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub __pad1: dev_t,
+        pub __pad1: u64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_size: off_t,
+        pub st_size: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_blksize: blksize_t,
+        pub st_blksize: i32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __pad2: c_int,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_blocks: blkcnt_t,
+        pub st_blocks: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_atime: time_t,
+        pub st_atime: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime_nsec: c_long,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_mtime: time_t,
+        pub st_mtime: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime_nsec: c_long,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_ctime: time_t,
+        pub st_ctime: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime_nsec: c_long,
         #[stable(feature = "raw_ext", since = "1.1.0")]
@@ -223,15 +212,13 @@ mod arch {
 
 #[cfg(any(target_arch = "x86_64", target_arch = "powerpc64"))]
 mod arch {
-    use super::{dev_t, mode_t};
     use os::raw::{c_long, c_int};
-    use os::unix::raw::{gid_t, uid_t};
 
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
     #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
     #[repr(C)]
@@ -239,37 +226,37 @@ mod arch {
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_dev: dev_t,
+        pub st_dev: u64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_ino: ino_t,
+        pub st_ino: u64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_nlink: nlink_t,
+        pub st_nlink: u64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_mode: mode_t,
+        pub st_mode: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_uid: uid_t,
+        pub st_uid: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_gid: gid_t,
+        pub st_gid: u32,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __pad0: c_int,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_rdev: dev_t,
+        pub st_rdev: u64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_size: off_t,
+        pub st_size: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_blksize: blksize_t,
+        pub st_blksize: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_blocks: blkcnt_t,
+        pub st_blocks: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_atime: time_t,
+        pub st_atime: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime_nsec: c_long,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_mtime: time_t,
+        pub st_mtime: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime_nsec: c_long,
         #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_ctime: time_t,
+        pub st_ctime: i64,
         #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime_nsec: c_long,
         #[stable(feature = "raw_ext", since = "1.1.0")]

--- a/src/libstd/os/macos/fs.rs
+++ b/src/libstd/os/macos/fs.rs
@@ -1,0 +1,160 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![stable(feature = "metadata_ext", since = "1.1.0")]
+
+use libc;
+
+use fs::Metadata;
+use sys_common::AsInner;
+
+#[allow(deprecated)]
+use os::macos::raw;
+
+/// OS-specific extension methods for `fs::Metadata`
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+pub trait MetadataExt {
+    /// Gain a reference to the underlying `stat` structure which contains
+    /// the raw information returned by the OS.
+    ///
+    /// The contents of the returned `stat` are **not** consistent across
+    /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
+    /// cross-Unix abstractions contained within the raw stat.
+    #[stable(feature = "metadata_ext", since = "1.1.0")]
+    #[rustc_deprecated(since = "1.8.0",
+                       reason = "deprecated in favor of the accessor \
+                                 methods of this trait")]
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat;
+
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_dev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ino(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mode(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_nlink(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_uid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_gid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_rdev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_size(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_birthtime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_birthtime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blksize(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blocks(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_flags(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_gen(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_lspare(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_qspare(&self) -> [u64; 2];
+}
+
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+impl MetadataExt for Metadata {
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat {
+        unsafe {
+            &*(self.as_inner().as_inner() as *const libc::stat
+                                          as *const raw::stat)
+        }
+    }
+    fn st_dev(&self) -> u64 {
+        self.as_inner().as_inner().st_dev as u64
+    }
+    fn st_ino(&self) -> u64 {
+        self.as_inner().as_inner().st_ino as u64
+    }
+    fn st_mode(&self) -> u32 {
+        self.as_inner().as_inner().st_mode as u32
+    }
+    fn st_nlink(&self) -> u64 {
+        self.as_inner().as_inner().st_nlink as u64
+    }
+    fn st_uid(&self) -> u32 {
+        self.as_inner().as_inner().st_uid as u32
+    }
+    fn st_gid(&self) -> u32 {
+        self.as_inner().as_inner().st_gid as u32
+    }
+    fn st_rdev(&self) -> u64 {
+        self.as_inner().as_inner().st_rdev as u64
+    }
+    fn st_size(&self) -> u64 {
+        self.as_inner().as_inner().st_size as u64
+    }
+    fn st_atime(&self) -> i64 {
+        self.as_inner().as_inner().st_atime as i64
+    }
+    fn st_atime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_atime_nsec as i64
+    }
+    fn st_mtime(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime as i64
+    }
+    fn st_mtime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime_nsec as i64
+    }
+    fn st_ctime(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime as i64
+    }
+    fn st_ctime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime_nsec as i64
+    }
+    fn st_birthtime(&self) -> i64 {
+        self.as_inner().as_inner().st_birthtime as i64
+    }
+    fn st_birthtime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_birthtime_nsec as i64
+    }
+    fn st_blksize(&self) -> u64 {
+        self.as_inner().as_inner().st_blksize as u64
+    }
+    fn st_blocks(&self) -> u64 {
+        self.as_inner().as_inner().st_blocks as u64
+    }
+    fn st_gen(&self) -> u32 {
+        self.as_inner().as_inner().st_gen as u32
+    }
+    fn st_flags(&self) -> u32 {
+        self.as_inner().as_inner().st_flags as u32
+    }
+    fn st_lspare(&self) -> u32 {
+        self.as_inner().as_inner().st_lspare as u32
+    }
+    fn st_qspare(&self) -> [u64; 2] {
+        let qspare = self.as_inner().as_inner().st_qspare;
+        [qspare[0] as u64, qspare[1] as u64]
+    }
+}
+

--- a/src/libstd/os/macos/mod.rs
+++ b/src/libstd/os/macos/mod.rs
@@ -13,9 +13,4 @@
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod raw;
-
-#[stable(feature = "raw_ext", since = "1.1.0")]
-pub mod fs {
-    #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub use sys::fs::MetadataExt;
-}
+pub mod fs;

--- a/src/libstd/os/macos/raw.rs
+++ b/src/libstd/os/macos/raw.rs
@@ -11,18 +11,23 @@
 //! MacOS-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
+#![rustc_deprecated(since = "1.8.0",
+                    reason = "these type aliases are no longer supported by \
+                              the standard library, the `libc` crate on \
+                              crates.io should be used instead for the correct \
+                              definitions")]
+#![allow(deprecated)]
 
 use os::raw::c_long;
-use os::unix::raw::{uid_t, gid_t};
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = i32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u16;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u16;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = c_long;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
 #[unstable(feature = "pthread_t", issue = "29791")] pub type pthread_t = usize;
 
@@ -31,41 +36,41 @@ use os::unix::raw::{uid_t, gid_t};
 #[stable(feature = "raw_ext", since = "1.1.0")]
 pub struct stat {
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_dev: dev_t,
+    pub st_dev: i32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_mode: mode_t,
+    pub st_mode: u16,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_nlink: nlink_t,
+    pub st_nlink: u16,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_ino: ino_t,
+    pub st_ino: u64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_uid: uid_t,
+    pub st_uid: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_gid: gid_t,
+    pub st_gid: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_rdev: dev_t,
+    pub st_rdev: i32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_atime: time_t,
+    pub st_atime: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_atime_nsec: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_mtime: time_t,
+    pub st_mtime: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_mtime_nsec: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_ctime: time_t,
+    pub st_ctime: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ctime_nsec: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_birthtime: time_t,
+    pub st_birthtime: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_birthtime_nsec: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_size: off_t,
+    pub st_size: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_blocks: blkcnt_t,
+    pub st_blocks: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_blksize: blksize_t,
+    pub st_blksize: i32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_flags: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]

--- a/src/libstd/os/nacl/fs.rs
+++ b/src/libstd/os/nacl/fs.rs
@@ -1,0 +1,128 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![stable(feature = "metadata_ext", since = "1.1.0")]
+
+use libc;
+
+use fs::Metadata;
+use sys_common::AsInner;
+
+#[allow(deprecated)]
+use os::nacl::raw;
+
+/// OS-specific extension methods for `fs::Metadata`
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+pub trait MetadataExt {
+    /// Gain a reference to the underlying `stat` structure which contains
+    /// the raw information returned by the OS.
+    ///
+    /// The contents of the returned `stat` are **not** consistent across
+    /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
+    /// cross-Unix abstractions contained within the raw stat.
+    #[stable(feature = "metadata_ext", since = "1.1.0")]
+    #[rustc_deprecated(since = "1.8.0",
+                       reason = "deprecated in favor of the accessor \
+                                 methods of this trait")]
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat;
+
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_dev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ino(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mode(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_nlink(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_uid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_gid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_rdev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_size(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blksize(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blocks(&self) -> u64;
+}
+
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+impl MetadataExt for Metadata {
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat {
+        unsafe {
+            &*(self.as_inner().as_inner() as *const libc::stat64
+                                          as *const raw::stat)
+        }
+    }
+    fn st_dev(&self) -> u64 {
+        self.as_inner().as_inner().st_dev as u64
+    }
+    fn st_ino(&self) -> u64 {
+        self.as_inner().as_inner().st_ino as u64
+    }
+    fn st_mode(&self) -> u32 {
+        self.as_inner().as_inner().st_mode as u32
+    }
+    fn st_nlink(&self) -> u64 {
+        self.as_inner().as_inner().st_nlink as u64
+    }
+    fn st_uid(&self) -> u32 {
+        self.as_inner().as_inner().st_uid as u32
+    }
+    fn st_gid(&self) -> u32 {
+        self.as_inner().as_inner().st_gid as u32
+    }
+    fn st_rdev(&self) -> u64 {
+        self.as_inner().as_inner().st_rdev as u64
+    }
+    fn st_size(&self) -> u64 {
+        self.as_inner().as_inner().st_size as u64
+    }
+    fn st_atime(&self) -> i64 {
+        self.as_inner().as_inner().st_atime as i64
+    }
+    fn st_atime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_atime_nsec as i64
+    }
+    fn st_mtime(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime as i64
+    }
+    fn st_mtime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime_nsec as i64
+    }
+    fn st_ctime(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime as i64
+    }
+    fn st_ctime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime_nsec as i64
+    }
+    fn st_blksize(&self) -> u64 {
+        self.as_inner().as_inner().st_blksize as u64
+    }
+    fn st_blocks(&self) -> u64 {
+        self.as_inner().as_inner().st_blocks as u64
+    }
+}

--- a/src/libstd/os/nacl/mod.rs
+++ b/src/libstd/os/nacl/mod.rs
@@ -13,9 +13,4 @@
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod raw;
-
-#[stable(feature = "raw_ext", since = "1.1.0")]
-pub mod fs {
-    #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub use sys::fs::MetadataExt;
-}
+pub mod fs;

--- a/src/libstd/os/nacl/raw.rs
+++ b/src/libstd/os/nacl/raw.rs
@@ -11,18 +11,24 @@
 //! Nacl-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
+#![rustc_deprecated(since = "1.8.0",
+                    reason = "these type aliases are no longer supported by \
+                              the standard library, the `libc` crate on \
+                              crates.io should be used instead for the correct \
+                              definitions")]
+#![allow(deprecated)]
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type pid_t = i32;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type uid_t = u32;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type gid_t = u32;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
 
 #[unstable(feature = "pthread_t", issue = "29791")] pub type pthread_t = usize;
 

--- a/src/libstd/os/netbsd/fs.rs
+++ b/src/libstd/os/netbsd/fs.rs
@@ -1,0 +1,154 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![stable(feature = "metadata_ext", since = "1.1.0")]
+
+use libc;
+
+use fs::Metadata;
+use sys_common::AsInner;
+
+#[allow(deprecated)]
+use os::netbsd::raw;
+
+/// OS-specific extension methods for `fs::Metadata`
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+pub trait MetadataExt {
+    /// Gain a reference to the underlying `stat` structure which contains
+    /// the raw information returned by the OS.
+    ///
+    /// The contents of the returned `stat` are **not** consistent across
+    /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
+    /// cross-Unix abstractions contained within the raw stat.
+    #[stable(feature = "metadata_ext", since = "1.1.0")]
+    #[rustc_deprecated(since = "1.8.0",
+                       reason = "deprecated in favor of the accessor \
+                                 methods of this trait")]
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat;
+
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_dev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ino(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mode(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_nlink(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_uid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_gid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_rdev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_size(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_birthtime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_birthtime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blksize(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blocks(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_flags(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_gen(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_spare(&self) -> u32;
+}
+
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+impl MetadataExt for Metadata {
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat {
+        unsafe {
+            &*(self.as_inner().as_inner() as *const libc::stat
+                                          as *const raw::stat)
+        }
+    }
+    fn st_dev(&self) -> u64 {
+        self.as_inner().as_inner().st_dev as u64
+    }
+    fn st_ino(&self) -> u64 {
+        self.as_inner().as_inner().st_ino as u64
+    }
+    fn st_mode(&self) -> u32 {
+        self.as_inner().as_inner().st_mode as u32
+    }
+    fn st_nlink(&self) -> u64 {
+        self.as_inner().as_inner().st_nlink as u64
+    }
+    fn st_uid(&self) -> u32 {
+        self.as_inner().as_inner().st_uid as u32
+    }
+    fn st_gid(&self) -> u32 {
+        self.as_inner().as_inner().st_gid as u32
+    }
+    fn st_rdev(&self) -> u64 {
+        self.as_inner().as_inner().st_rdev as u64
+    }
+    fn st_size(&self) -> u64 {
+        self.as_inner().as_inner().st_size as u64
+    }
+    fn st_atime(&self) -> i64 {
+        self.as_inner().as_inner().st_atime as i64
+    }
+    fn st_atime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_atime_nsec as i64
+    }
+    fn st_mtime(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime as i64
+    }
+    fn st_mtime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime_nsec as i64
+    }
+    fn st_ctime(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime as i64
+    }
+    fn st_ctime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime_nsec as i64
+    }
+    fn st_birthtime(&self) -> i64 {
+        self.as_inner().as_inner().st_birthtime as i64
+    }
+    fn st_birthtime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_birthtime_nsec as i64
+    }
+    fn st_blksize(&self) -> u64 {
+        self.as_inner().as_inner().st_blksize as u64
+    }
+    fn st_blocks(&self) -> u64 {
+        self.as_inner().as_inner().st_blocks as u64
+    }
+    fn st_gen(&self) -> u32 {
+        self.as_inner().as_inner().st_gen as u32
+    }
+    fn st_flags(&self) -> u32 {
+        self.as_inner().as_inner().st_flags as u32
+    }
+    fn st_spare(&self) -> u32 {
+        self.as_inner().as_inner().st_spare as u32
+    }
+}
+

--- a/src/libstd/os/netbsd/mod.rs
+++ b/src/libstd/os/netbsd/mod.rs
@@ -13,9 +13,4 @@
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod raw;
-
-#[stable(feature = "raw_ext", since = "1.1.0")]
-pub mod fs {
-    #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub use sys::fs::MetadataExt;
-}
+pub mod fs;

--- a/src/libstd/os/netbsd/raw.rs
+++ b/src/libstd/os/netbsd/raw.rs
@@ -11,18 +11,24 @@
 //! NetBSD-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
+#![rustc_deprecated(since = "1.8.0",
+                    reason = "these type aliases are no longer supported by \
+                              the standard library, the `libc` crate on \
+                              crates.io should be used instead for the correct \
+                              definitions")]
+#![allow(deprecated)]
 
 use os::raw::c_long;
 use os::unix::raw::{uid_t, gid_t};
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type fflags_t = u32;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
 #[unstable(feature = "pthread_t", issue = "29791")] pub type pthread_t = usize;
@@ -32,43 +38,43 @@ use os::unix::raw::{uid_t, gid_t};
 #[stable(feature = "raw_ext", since = "1.1.0")]
 pub struct stat {
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_mode: mode_t,
+    pub st_dev: u64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_dev: dev_t,
+    pub st_mode: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_ino: ino_t,
+    pub st_ino: u64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_nlink: nlink_t,
+    pub st_nlink: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_uid: uid_t,
+    pub st_uid: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_gid: gid_t,
+    pub st_gid: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_rdev: dev_t,
+    pub st_rdev: u64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_atime: time_t,
+    pub st_atime: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_atime_nsec: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_mtime: time_t,
+    pub st_mtime: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_mtime_nsec: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_ctime: time_t,
+    pub st_ctime: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ctime_nsec: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_birthtime: time_t,
+    pub st_birthtime: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_birthtime_nsec: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_size: off_t,
+    pub st_size: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_blocks: blkcnt_t,
+    pub st_blocks: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_blksize: blksize_t,
+    pub st_blksize: i32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_flags: fflags_t,
+    pub st_flags: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_gen: u32,
     st_spare: [u32; 2],

--- a/src/libstd/os/openbsd/fs.rs
+++ b/src/libstd/os/openbsd/fs.rs
@@ -1,0 +1,149 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![stable(feature = "metadata_ext", since = "1.1.0")]
+
+use libc;
+
+use fs::Metadata;
+use sys_common::AsInner;
+
+#[allow(deprecated)]
+use os::openbsd::raw;
+
+/// OS-specific extension methods for `fs::Metadata`
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+pub trait MetadataExt {
+    /// Gain a reference to the underlying `stat` structure which contains
+    /// the raw information returned by the OS.
+    ///
+    /// The contents of the returned `stat` are **not** consistent across
+    /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
+    /// cross-Unix abstractions contained within the raw stat.
+    #[stable(feature = "metadata_ext", since = "1.1.0")]
+    #[rustc_deprecated(since = "1.8.0",
+                       reason = "deprecated in favor of the accessor \
+                                 methods of this trait")]
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat;
+
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_dev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ino(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mode(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_nlink(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_uid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_gid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_rdev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_size(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_birthtime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_birthtime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blksize(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blocks(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_flags(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_gen(&self) -> u32;
+}
+
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+impl MetadataExt for Metadata {
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat {
+        unsafe {
+            &*(self.as_inner().as_inner() as *const libc::stat
+                                          as *const raw::stat)
+        }
+    }
+    fn st_dev(&self) -> u64 {
+        self.as_inner().as_inner().st_dev as u64
+    }
+    fn st_ino(&self) -> u64 {
+        self.as_inner().as_inner().st_ino as u64
+    }
+    fn st_mode(&self) -> u32 {
+        self.as_inner().as_inner().st_mode as u32
+    }
+    fn st_nlink(&self) -> u64 {
+        self.as_inner().as_inner().st_nlink as u64
+    }
+    fn st_uid(&self) -> u32 {
+        self.as_inner().as_inner().st_uid as u32
+    }
+    fn st_gid(&self) -> u32 {
+        self.as_inner().as_inner().st_gid as u32
+    }
+    fn st_rdev(&self) -> u64 {
+        self.as_inner().as_inner().st_rdev as u64
+    }
+    fn st_size(&self) -> u64 {
+        self.as_inner().as_inner().st_size as u64
+    }
+    fn st_atime(&self) -> i64 {
+        self.as_inner().as_inner().st_atime as i64
+    }
+    fn st_atime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_atime_nsec as i64
+    }
+    fn st_mtime(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime as i64
+    }
+    fn st_mtime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime_nsec as i64
+    }
+    fn st_ctime(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime as i64
+    }
+    fn st_ctime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime_nsec as i64
+    }
+    fn st_birthtime(&self) -> i64 {
+        self.as_inner().as_inner().st_birthtime as i64
+    }
+    fn st_birthtime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_birthtime_nsec as i64
+    }
+    fn st_blksize(&self) -> u64 {
+        self.as_inner().as_inner().st_blksize as u64
+    }
+    fn st_blocks(&self) -> u64 {
+        self.as_inner().as_inner().st_blocks as u64
+    }
+    fn st_gen(&self) -> u32 {
+        self.as_inner().as_inner().st_gen as u32
+    }
+    fn st_flags(&self) -> u32 {
+        self.as_inner().as_inner().st_flags as u32
+    }
+}
+

--- a/src/libstd/os/openbsd/mod.rs
+++ b/src/libstd/os/openbsd/mod.rs
@@ -13,9 +13,4 @@
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod raw;
-
-#[stable(feature = "raw_ext", since = "1.1.0")]
-pub mod fs {
-    #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub use sys::fs::MetadataExt;
-}
+pub mod fs;

--- a/src/libstd/os/openbsd/raw.rs
+++ b/src/libstd/os/openbsd/raw.rs
@@ -11,18 +11,24 @@
 //! OpenBSD-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
+#![rustc_deprecated(since = "1.8.0",
+                    reason = "these type aliases are no longer supported by \
+                              the standard library, the `libc` crate on \
+                              crates.io should be used instead for the correct \
+                              definitions")]
+#![allow(deprecated)]
 
 use os::raw::c_long;
 use os::unix::raw::{uid_t, gid_t};
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = i32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type fflags_t = u32;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
 #[unstable(feature = "pthread_t", issue = "29791")] pub type pthread_t = usize;
@@ -32,43 +38,43 @@ use os::unix::raw::{uid_t, gid_t};
 #[stable(feature = "raw_ext", since = "1.1.0")]
 pub struct stat {
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_mode: mode_t,
+    pub st_mode: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_dev: dev_t,
+    pub st_dev: i32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_ino: ino_t,
+    pub st_ino: u64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_nlink: nlink_t,
+    pub st_nlink: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_uid: uid_t,
+    pub st_uid: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_gid: gid_t,
+    pub st_gid: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_rdev: dev_t,
+    pub st_rdev: i32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_atime: time_t,
+    pub st_atime: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_atime_nsec: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_mtime: time_t,
+    pub st_mtime: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_mtime_nsec: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_ctime: time_t,
+    pub st_ctime: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ctime_nsec: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_size: off_t,
+    pub st_size: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_blocks: blkcnt_t,
+    pub st_blocks: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_blksize: blksize_t,
+    pub st_blksize: i32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_flags: fflags_t,
+    pub st_flags: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_gen: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_birthtime: time_t,
+    pub st_birthtime: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_birthtime_nsec: c_long,
 }

--- a/src/libstd/os/raw.rs
+++ b/src/libstd/os/raw.rs
@@ -81,36 +81,10 @@ mod tests {
         )*}
     }
 
-    macro_rules! ok_size {
-        ($($t:ident)*) => {$(
-            assert!(mem::size_of::<libc::$t>() == mem::size_of::<raw::$t>(),
-                    "{} is wrong", stringify!($t));
-        )*}
-    }
-
     #[test]
     fn same() {
         use os::raw;
         ok!(c_char c_schar c_uchar c_short c_ushort c_int c_uint c_long c_ulong
             c_longlong c_ulonglong c_float c_double);
-    }
-
-    #[cfg(all(unix, not(target_os = "android")))]
-    #[test]
-    fn unix() {
-        {
-            use os::unix::raw;
-            ok!(uid_t gid_t dev_t ino_t mode_t nlink_t off_t blksize_t blkcnt_t);
-        }
-        {
-            use sys::platform::raw;
-            ok_size!(stat);
-        }
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn windows() {
-        use os::windows::raw;
     }
 }

--- a/src/libstd/os/solaris/fs.rs
+++ b/src/libstd/os/solaris/fs.rs
@@ -1,0 +1,128 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![stable(feature = "metadata_ext", since = "1.1.0")]
+
+use libc;
+
+use fs::Metadata;
+use sys_common::AsInner;
+
+#[allow(deprecated)]
+use os::solaris::raw;
+
+/// OS-specific extension methods for `fs::Metadata`
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+pub trait MetadataExt {
+    /// Gain a reference to the underlying `stat` structure which contains
+    /// the raw information returned by the OS.
+    ///
+    /// The contents of the returned `stat` are **not** consistent across
+    /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
+    /// cross-Unix abstractions contained within the raw stat.
+    #[stable(feature = "metadata_ext", since = "1.1.0")]
+    #[rustc_deprecated(since = "1.8.0",
+                       reason = "deprecated in favor of the accessor \
+                                 methods of this trait")]
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat;
+
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_dev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ino(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mode(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_nlink(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_uid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_gid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_rdev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_size(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blksize(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blocks(&self) -> u64;
+}
+
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+impl MetadataExt for Metadata {
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat {
+        unsafe {
+            &*(self.as_inner().as_inner() as *const libc::stat64
+                                          as *const raw::stat)
+        }
+    }
+    fn st_dev(&self) -> u64 {
+        self.as_inner().as_inner().st_dev as u64
+    }
+    fn st_ino(&self) -> u64 {
+        self.as_inner().as_inner().st_ino as u64
+    }
+    fn st_mode(&self) -> u32 {
+        self.as_inner().as_inner().st_mode as u32
+    }
+    fn st_nlink(&self) -> u64 {
+        self.as_inner().as_inner().st_nlink as u64
+    }
+    fn st_uid(&self) -> u32 {
+        self.as_inner().as_inner().st_uid as u32
+    }
+    fn st_gid(&self) -> u32 {
+        self.as_inner().as_inner().st_gid as u32
+    }
+    fn st_rdev(&self) -> u64 {
+        self.as_inner().as_inner().st_rdev as u64
+    }
+    fn st_size(&self) -> u64 {
+        self.as_inner().as_inner().st_size as u64
+    }
+    fn st_atime(&self) -> i64 {
+        self.as_inner().as_inner().st_atime as i64
+    }
+    fn st_atime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_atime_nsec as i64
+    }
+    fn st_mtime(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime as i64
+    }
+    fn st_mtime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime_nsec as i64
+    }
+    fn st_ctime(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime as i64
+    }
+    fn st_ctime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime_nsec as i64
+    }
+    fn st_blksize(&self) -> u64 {
+        self.as_inner().as_inner().st_blksize as u64
+    }
+    fn st_blocks(&self) -> u64 {
+        self.as_inner().as_inner().st_blocks as u64
+    }
+}

--- a/src/libstd/os/solaris/mod.rs
+++ b/src/libstd/os/solaris/mod.rs
@@ -13,9 +13,4 @@
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod raw;
-
-#[stable(feature = "raw_ext", since = "1.1.0")]
-pub mod fs {
-    #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub use sys::fs::MetadataExt;
-}
+pub mod fs;

--- a/src/libstd/os/solaris/raw.rs
+++ b/src/libstd/os/solaris/raw.rs
@@ -11,18 +11,24 @@
 //! Solaris-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
+#![rustc_deprecated(since = "1.8.0",
+                    reason = "these type aliases are no longer supported by \
+                              the standard library, the `libc` crate on \
+                              crates.io should be used instead for the correct \
+                              definitions")]
+#![allow(deprecated)]
 
 use os::raw::c_long;
 use os::unix::raw::{uid_t, gid_t};
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type fflags_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u32;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
 #[unstable(feature = "pthread_t", issue = "29791")] pub type pthread_t = usize;

--- a/src/libstd/sys/unix/ext/fs.rs
+++ b/src/libstd/sys/unix/ext/fs.rs
@@ -15,69 +15,88 @@
 use fs::{self, Permissions, OpenOptions};
 use io;
 use libc;
-use os::raw::c_long;
+#[allow(deprecated)]
 use os::unix::raw;
 use path::Path;
-use sys::fs::MetadataExt as UnixMetadataExt;
 use sys;
 use sys_common::{FromInner, AsInner, AsInnerMut};
+use sys::platform::fs::MetadataExt as UnixMetadataExt;
 
 #[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 #[rustc_deprecated(since = "1.7.0", reason = "moved to the libc crate instead")]
+#[allow(deprecated)]
 pub const USER_READ: raw::mode_t = 0o400;
 #[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 #[rustc_deprecated(since = "1.7.0", reason = "moved to the libc crate instead")]
+#[allow(deprecated)]
 pub const USER_WRITE: raw::mode_t = 0o200;
 #[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 #[rustc_deprecated(since = "1.7.0", reason = "moved to the libc crate instead")]
+#[allow(deprecated)]
 pub const USER_EXECUTE: raw::mode_t = 0o100;
 #[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 #[rustc_deprecated(since = "1.7.0", reason = "moved to the libc crate instead")]
+#[allow(deprecated)]
 pub const USER_RWX: raw::mode_t = 0o700;
 #[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 #[rustc_deprecated(since = "1.7.0", reason = "moved to the libc crate instead")]
+#[allow(deprecated)]
 pub const GROUP_READ: raw::mode_t = 0o040;
 #[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 #[rustc_deprecated(since = "1.7.0", reason = "moved to the libc crate instead")]
+#[allow(deprecated)]
 pub const GROUP_WRITE: raw::mode_t = 0o020;
 #[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 #[rustc_deprecated(since = "1.7.0", reason = "moved to the libc crate instead")]
+#[allow(deprecated)]
 pub const GROUP_EXECUTE: raw::mode_t = 0o010;
 #[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 #[rustc_deprecated(since = "1.7.0", reason = "moved to the libc crate instead")]
+#[allow(deprecated)]
 pub const GROUP_RWX: raw::mode_t = 0o070;
 #[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 #[rustc_deprecated(since = "1.7.0", reason = "moved to the libc crate instead")]
+#[allow(deprecated)]
 pub const OTHER_READ: raw::mode_t = 0o004;
 #[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 #[rustc_deprecated(since = "1.7.0", reason = "moved to the libc crate instead")]
+#[allow(deprecated)]
 pub const OTHER_WRITE: raw::mode_t = 0o002;
 #[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 #[rustc_deprecated(since = "1.7.0", reason = "moved to the libc crate instead")]
+#[allow(deprecated)]
 pub const OTHER_EXECUTE: raw::mode_t = 0o001;
 #[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 #[rustc_deprecated(since = "1.7.0", reason = "moved to the libc crate instead")]
+#[allow(deprecated)]
 pub const OTHER_RWX: raw::mode_t = 0o007;
 #[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 #[rustc_deprecated(since = "1.7.0", reason = "moved to the libc crate instead")]
+#[allow(deprecated)]
 pub const ALL_READ: raw::mode_t = 0o444;
 #[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 #[rustc_deprecated(since = "1.7.0", reason = "moved to the libc crate instead")]
+#[allow(deprecated)]
 pub const ALL_WRITE: raw::mode_t = 0o222;
 #[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 #[rustc_deprecated(since = "1.7.0", reason = "moved to the libc crate instead")]
+#[allow(deprecated)]
 pub const ALL_EXECUTE: raw::mode_t = 0o111;
 #[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 #[rustc_deprecated(since = "1.7.0", reason = "moved to the libc crate instead")]
+#[allow(deprecated)]
 pub const ALL_RWX: raw::mode_t = 0o777;
 #[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 #[rustc_deprecated(since = "1.7.0", reason = "moved to the libc crate instead")]
+#[allow(deprecated)]
 pub const SETUID: raw::mode_t = 0o4000;
 #[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 #[rustc_deprecated(since = "1.7.0", reason = "moved to the libc crate instead")]
+#[allow(deprecated)]
 pub const SETGID: raw::mode_t = 0o2000;
 #[unstable(feature = "fs_mode", reason = "recently added API", issue = "27712")]
 #[rustc_deprecated(since = "1.7.0", reason = "moved to the libc crate instead")]
+#[allow(deprecated)]
 pub const STICKY_BIT: raw::mode_t = 0o1000;
 
 /// Unix-specific extensions to `Permissions`
@@ -86,28 +105,30 @@ pub trait PermissionsExt {
     /// Returns the underlying raw `mode_t` bits that are the standard Unix
     /// permissions for this file.
     #[stable(feature = "fs_ext", since = "1.1.0")]
-    fn mode(&self) -> raw::mode_t;
+    fn mode(&self) -> u32;
 
-    /// Sets the underlying raw `mode_t` bits for this set of permissions.
+    /// Sets the underlying raw bits for this set of permissions.
     #[stable(feature = "fs_ext", since = "1.1.0")]
-    fn set_mode(&mut self, mode: raw::mode_t);
+    fn set_mode(&mut self, mode: u32);
 
     /// Creates a new instance of `Permissions` from the given set of Unix
     /// permission bits.
     #[stable(feature = "fs_ext", since = "1.1.0")]
-    fn from_mode(mode: raw::mode_t) -> Self;
+    fn from_mode(mode: u32) -> Self;
 }
 
 #[stable(feature = "fs_ext", since = "1.1.0")]
 impl PermissionsExt for Permissions {
-    fn mode(&self) -> raw::mode_t { self.as_inner().mode() }
-
-    fn set_mode(&mut self, mode: raw::mode_t) {
-        *self = FromInner::from_inner(FromInner::from_inner(mode));
+    fn mode(&self) -> u32 {
+        self.as_inner().mode()
     }
 
-    fn from_mode(mode: raw::mode_t) -> Permissions {
-        FromInner::from_inner(FromInner::from_inner(mode))
+    fn set_mode(&mut self, mode: u32) {
+        *self = Permissions::from_inner(FromInner::from_inner(mode));
+    }
+
+    fn from_mode(mode: u32) -> Permissions {
+        Permissions::from_inner(FromInner::from_inner(mode))
     }
 }
 
@@ -122,7 +143,7 @@ pub trait OpenOptionsExt {
     /// The operating system masks out bits with the systems `umask`, to produce
     /// the final permissions.
     #[stable(feature = "fs_ext", since = "1.1.0")]
-    fn mode(&mut self, mode: raw::mode_t) -> &mut Self;
+    fn mode(&mut self, mode: u32) -> &mut Self;
 
     /// Pass custom flags to the `flags` agument of `open`.
     ///
@@ -154,7 +175,7 @@ pub trait OpenOptionsExt {
 
 #[stable(feature = "fs_ext", since = "1.1.0")]
 impl OpenOptionsExt for OpenOptions {
-    fn mode(&mut self, mode: raw::mode_t) -> &mut OpenOptions {
+    fn mode(&mut self, mode: u32) -> &mut OpenOptions {
         self.as_inner_mut().mode(mode); self
     }
 
@@ -173,62 +194,57 @@ impl OpenOptionsExt for OpenOptions {
 #[stable(feature = "metadata_ext", since = "1.1.0")]
 pub trait MetadataExt {
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    fn dev(&self) -> raw::dev_t;
+    fn dev(&self) -> u64;
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    fn ino(&self) -> raw::ino_t;
+    fn ino(&self) -> u64;
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    fn mode(&self) -> raw::mode_t;
+    fn mode(&self) -> u32;
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    fn nlink(&self) -> raw::nlink_t;
+    fn nlink(&self) -> u64;
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    fn uid(&self) -> raw::uid_t;
+    fn uid(&self) -> u32;
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    fn gid(&self) -> raw::gid_t;
+    fn gid(&self) -> u32;
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    fn rdev(&self) -> raw::dev_t;
+    fn rdev(&self) -> u64;
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    fn size(&self) -> raw::off_t;
+    fn size(&self) -> u64;
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    fn atime(&self) -> raw::time_t;
+    fn atime(&self) -> i64;
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    fn atime_nsec(&self) -> c_long;
+    fn atime_nsec(&self) -> i64;
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    fn mtime(&self) -> raw::time_t;
+    fn mtime(&self) -> i64;
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    fn mtime_nsec(&self) -> c_long;
+    fn mtime_nsec(&self) -> i64;
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    fn ctime(&self) -> raw::time_t;
+    fn ctime(&self) -> i64;
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    fn ctime_nsec(&self) -> c_long;
+    fn ctime_nsec(&self) -> i64;
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    fn blksize(&self) -> raw::blksize_t;
+    fn blksize(&self) -> u64;
     #[stable(feature = "metadata_ext", since = "1.1.0")]
-    fn blocks(&self) -> raw::blkcnt_t;
+    fn blocks(&self) -> u64;
 }
 
 #[stable(feature = "metadata_ext", since = "1.1.0")]
 impl MetadataExt for fs::Metadata {
-    fn dev(&self) -> raw::dev_t { self.as_raw_stat().st_dev as raw::dev_t }
-    fn ino(&self) -> raw::ino_t { self.as_raw_stat().st_ino as raw::ino_t }
-    fn mode(&self) -> raw::mode_t { self.as_raw_stat().st_mode as raw::mode_t }
-    fn nlink(&self) -> raw::nlink_t { self.as_raw_stat().st_nlink as raw::nlink_t }
-    fn uid(&self) -> raw::uid_t { self.as_raw_stat().st_uid as raw::uid_t }
-    fn gid(&self) -> raw::gid_t { self.as_raw_stat().st_gid as raw::gid_t }
-    fn rdev(&self) -> raw::dev_t { self.as_raw_stat().st_rdev as raw::dev_t }
-    fn size(&self) -> raw::off_t { self.as_raw_stat().st_size as raw::off_t }
-    fn atime(&self) -> raw::time_t { self.as_raw_stat().st_atime }
-    fn atime_nsec(&self) -> c_long { self.as_raw_stat().st_atime_nsec as c_long }
-    fn mtime(&self) -> raw::time_t { self.as_raw_stat().st_mtime }
-    fn mtime_nsec(&self) -> c_long { self.as_raw_stat().st_mtime_nsec as c_long }
-    fn ctime(&self) -> raw::time_t { self.as_raw_stat().st_ctime }
-    fn ctime_nsec(&self) -> c_long { self.as_raw_stat().st_ctime_nsec as c_long }
-
-    fn blksize(&self) -> raw::blksize_t {
-        self.as_raw_stat().st_blksize as raw::blksize_t
-    }
-    fn blocks(&self) -> raw::blkcnt_t {
-        self.as_raw_stat().st_blocks as raw::blkcnt_t
-    }
+    fn dev(&self) -> u64 { self.st_dev() }
+    fn ino(&self) -> u64 { self.st_ino() }
+    fn mode(&self) -> u32 { self.st_mode() }
+    fn nlink(&self) -> u64 { self.st_nlink() }
+    fn uid(&self) -> u32 { self.st_uid() }
+    fn gid(&self) -> u32 { self.st_gid() }
+    fn rdev(&self) -> u64 { self.st_rdev() }
+    fn size(&self) -> u64 { self.st_size() }
+    fn atime(&self) -> i64 { self.st_atime() }
+    fn atime_nsec(&self) -> i64 { self.st_atime_nsec() }
+    fn mtime(&self) -> i64 { self.st_mtime() }
+    fn mtime_nsec(&self) -> i64 { self.st_mtime_nsec() }
+    fn ctime(&self) -> i64 { self.st_ctime() }
+    fn ctime_nsec(&self) -> i64 { self.st_ctime_nsec() }
+    fn blksize(&self) -> u64 { self.st_blksize() }
+    fn blocks(&self) -> u64 { self.st_blocks() }
 }
 
 /// Add special unix types (block/char device, fifo and socket)
@@ -262,12 +278,12 @@ pub trait DirEntryExt {
     /// Returns the underlying `d_ino` field in the contained `dirent`
     /// structure.
     #[stable(feature = "dir_entry_ext", since = "1.1.0")]
-    fn ino(&self) -> raw::ino_t;
+    fn ino(&self) -> u64;
 }
 
 #[stable(feature = "dir_entry_ext", since = "1.1.0")]
 impl DirEntryExt for fs::DirEntry {
-    fn ino(&self) -> raw::ino_t { self.as_inner().ino() }
+    fn ino(&self) -> u64 { self.as_inner().ino() }
 }
 
 /// Creates a new symbolic link on the filesystem.
@@ -305,12 +321,12 @@ pub trait DirBuilderExt {
     /// Sets the mode to create new directories with. This option defaults to
     /// 0o777.
     #[stable(feature = "dir_builder", since = "1.6.0")]
-    fn mode(&mut self, mode: raw::mode_t) -> &mut Self;
+    fn mode(&mut self, mode: u32) -> &mut Self;
 }
 
 #[stable(feature = "dir_builder", since = "1.6.0")]
 impl DirBuilderExt for fs::DirBuilder {
-    fn mode(&mut self, mode: raw::mode_t) -> &mut fs::DirBuilder {
+    fn mode(&mut self, mode: u32) -> &mut fs::DirBuilder {
         self.as_inner_mut().set_mode(mode);
         self
     }

--- a/src/libstd/sys/unix/ext/process.rs
+++ b/src/libstd/sys/unix/ext/process.rs
@@ -16,7 +16,6 @@ use prelude::v1::*;
 
 use io;
 use os::unix::io::{FromRawFd, RawFd, AsRawFd, IntoRawFd};
-use os::unix::raw::{uid_t, gid_t};
 use process;
 use sys;
 use sys_common::{AsInnerMut, AsInner, FromInner, IntoInner};
@@ -28,12 +27,12 @@ pub trait CommandExt {
     /// `setuid` call in the child process. Failure in the `setuid`
     /// call will cause the spawn to fail.
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn uid(&mut self, id: uid_t) -> &mut process::Command;
+    fn uid(&mut self, id: u32) -> &mut process::Command;
 
     /// Similar to `uid`, but sets the group id of the child process. This has
     /// the same semantics as the `uid` field.
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn gid(&mut self, id: gid_t) -> &mut process::Command;
+    fn gid(&mut self, id: u32) -> &mut process::Command;
 
     /// Create a new session (cf. `setsid(2)`) for the child process. This means
     /// that the child is the leader of a new process group. The parent process
@@ -101,12 +100,12 @@ pub trait CommandExt {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl CommandExt for process::Command {
-    fn uid(&mut self, id: uid_t) -> &mut process::Command {
+    fn uid(&mut self, id: u32) -> &mut process::Command {
         self.as_inner_mut().uid(id);
         self
     }
 
-    fn gid(&mut self, id: gid_t) -> &mut process::Command {
+    fn gid(&mut self, id: u32) -> &mut process::Command {
         self.as_inner_mut().gid(id);
         self
     }

--- a/src/libstd/sys/unix/ext/raw.rs
+++ b/src/libstd/sys/unix/ext/raw.rs
@@ -11,6 +11,12 @@
 //! Unix-specific primitives available on all unix platforms
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
+#![rustc_deprecated(since = "1.8.0",
+                    reason = "these type aliases are no longer supported by \
+                              the standard library, the `libc` crate on \
+                              crates.io should be used instead for the correct \
+                              definitions")]
+#![allow(deprecated)]
 
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type uid_t = u32;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type gid_t = u32;

--- a/src/libstd/sys/unix/ext/thread.rs
+++ b/src/libstd/sys/unix/ext/thread.rs
@@ -12,11 +12,13 @@
 
 #![unstable(feature = "thread_extensions", issue = "29791")]
 
-use os::unix::raw::{pthread_t};
+#[allow(deprecated)]
+use os::unix::raw::pthread_t;
 use sys_common::{AsInner, IntoInner};
-use thread::{JoinHandle};
+use thread::JoinHandle;
 
 #[unstable(feature = "thread_extensions", issue = "29791")]
+#[allow(deprecated)]
 pub type RawPthread = pthread_t;
 
 /// Unix-specific extensions to `std::thread::JoinHandle`


### PR DESCRIPTION
This commit is an implementation of [RFC 1415](https://github.com/rust-lang/rfcs/blob/master/text/1415-trim-std-os.md) which deprecates all types
in the `std::os::*::raw` modules.

Many of the types in these modules don't actually have a canonical platform
representation, for example the definition of `stat` on 32-bit Linux will change
depending on whether C code is compiled with LFS support or not. Unfortunately
the current types in `std::os::*::raw` are billed as "compatible with C", which
in light of this means it isn't really possible.

To make matters worse, platforms like Android sometimes define these types as
_smaller_ than the way they're actually represented in the `stat` structure
itself. This means that when methods like `DirEntry::ino` are called on Android
the result may be truncated as we're tied to returning a `ino_t` type, not the
underlying type.

The commit here incorporates two backwards-compatible components:
- Deprecate all `raw` types that aren't in `std::os::raw`
- Expand the `std::os::*::fs::MetadataExt` trait on all platforms for method
  accessors of all fields. The fields now returned widened types which are the
  same across platforms (consistency across platforms is not required, however,
  it's just convenient).

and two also backwards-incompatible components:
- Change the definition of all `std::os::*::raw` type aliases to
  correspond to the newly widened types that are being returned on each
  platform.
- Change the definition of `std::os::*::raw::stat` on Linux to match the LFS
  definitions rather than the standard ones.

The breaking changes here will specifically break code that assumes that `libc`
and `std` agree on the definition of `std::os::*::raw` types, or that the `std`
types are faithful representations of the types in C. An [audit](https://github.com/rust-lang/rfcs/pull/1415#issuecomment-180645582) has been
performed of crates.io to determine the fallout which was determined two be
minimal, with the two found cases of breakage having been fixed now.

---

Ok, so after all that, we're finally able to support LFS on Linux! This commit
then simultaneously starts using `stat64` and friends on Linux to ensure that we
can open >4GB files on 32-bit Linux. Yay!

Closes #28978
Closes #30050
Closes #31549
