### PR TITLE
Add _post methods for blocks and crates

### DIFF
--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -758,6 +758,7 @@ impl<'a, 'tcx, 'v> hir_visit::Visitor<'v> for LateContext<'a, 'tcx> {
             run_lints!(cx, check_item, late_passes, it);
             cx.visit_ids(|v| v.visit_item(it));
             hir_visit::walk_item(cx, it);
+            run_lints!(cx, check_item_post, late_passes, it);
         })
     }
 
@@ -919,6 +920,7 @@ impl<'a, 'v> ast_visit::Visitor<'v> for EarlyContext<'a> {
             run_lints!(cx, check_item, early_passes, it);
             cx.visit_ids(|v| v.visit_item(it));
             ast_visit::walk_item(cx, it);
+            run_lints!(cx, check_item, early_passes, it);
         })
     }
 

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -920,7 +920,7 @@ impl<'a, 'v> ast_visit::Visitor<'v> for EarlyContext<'a> {
             run_lints!(cx, check_item, early_passes, it);
             cx.visit_ids(|v| v.visit_item(it));
             ast_visit::walk_item(cx, it);
-            run_lints!(cx, check_item, early_passes, it);
+            run_lints!(cx, check_item_post, early_passes, it);
         })
     }
 

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -846,6 +846,7 @@ impl<'a, 'tcx, 'v> hir_visit::Visitor<'v> for LateContext<'a, 'tcx> {
     fn visit_block(&mut self, b: &hir::Block) {
         run_lints!(self, check_block, late_passes, b);
         hir_visit::walk_block(self, b);
+        run_lints!(self, check_block_post, late_passes, b);
     }
 
     fn visit_arm(&mut self, a: &hir::Arm) {
@@ -1001,6 +1002,7 @@ impl<'a, 'v> ast_visit::Visitor<'v> for EarlyContext<'a> {
     fn visit_block(&mut self, b: &ast::Block) {
         run_lints!(self, check_block, early_passes, b);
         ast_visit::walk_block(self, b);
+        run_lints!(self, check_block_post, early_passes, b);
     }
 
     fn visit_arm(&mut self, a: &ast::Arm) {
@@ -1253,6 +1255,8 @@ pub fn check_crate(tcx: &ty::ctxt, access_levels: &AccessLevels) {
         run_lints!(cx, check_crate, late_passes, krate);
 
         hir_visit::walk_crate(cx, krate);
+
+        run_lints!(cx, check_crate_post, late_passes, krate);
     });
 
     // If we missed any lints added to the session, then there's a bug somewhere
@@ -1284,6 +1288,8 @@ pub fn check_ast_crate(sess: &Session, krate: &ast::Crate) {
         run_lints!(cx, check_crate, early_passes, krate);
 
         ast_visit::walk_crate(cx, krate);
+
+        run_lints!(cx, check_crate_post, early_passes, krate);
     });
 
     // Put the lint store back in the session.

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -132,11 +132,13 @@ pub trait LintPass {
 pub trait LateLintPass: LintPass {
     fn check_name(&mut self, _: &LateContext, _: Span, _: ast::Name) { }
     fn check_crate(&mut self, _: &LateContext, _: &hir::Crate) { }
+    fn check_crate_post(&mut self, _: &LateContext, _: &hir::Crate) { }
     fn check_mod(&mut self, _: &LateContext, _: &hir::Mod, _: Span, _: ast::NodeId) { }
     fn check_foreign_item(&mut self, _: &LateContext, _: &hir::ForeignItem) { }
     fn check_item(&mut self, _: &LateContext, _: &hir::Item) { }
     fn check_local(&mut self, _: &LateContext, _: &hir::Local) { }
     fn check_block(&mut self, _: &LateContext, _: &hir::Block) { }
+    fn check_block_post(&mut self, _: &LateContext, _: &hir::Block) { }
     fn check_stmt(&mut self, _: &LateContext, _: &hir::Stmt) { }
     fn check_arm(&mut self, _: &LateContext, _: &hir::Arm) { }
     fn check_pat(&mut self, _: &LateContext, _: &hir::Pat) { }
@@ -174,11 +176,13 @@ pub trait LateLintPass: LintPass {
 pub trait EarlyLintPass: LintPass {
     fn check_ident(&mut self, _: &EarlyContext, _: Span, _: ast::Ident) { }
     fn check_crate(&mut self, _: &EarlyContext, _: &ast::Crate) { }
+    fn check_crate_post(&mut self, _: &EarlyContext, _: &ast::Crate) { }
     fn check_mod(&mut self, _: &EarlyContext, _: &ast::Mod, _: Span, _: ast::NodeId) { }
     fn check_foreign_item(&mut self, _: &EarlyContext, _: &ast::ForeignItem) { }
     fn check_item(&mut self, _: &EarlyContext, _: &ast::Item) { }
     fn check_local(&mut self, _: &EarlyContext, _: &ast::Local) { }
     fn check_block(&mut self, _: &EarlyContext, _: &ast::Block) { }
+    fn check_block_post(&mut self, _: &EarlyContext, _: &ast::Block) { }
     fn check_stmt(&mut self, _: &EarlyContext, _: &ast::Stmt) { }
     fn check_arm(&mut self, _: &EarlyContext, _: &ast::Arm) { }
     fn check_pat(&mut self, _: &EarlyContext, _: &ast::Pat) { }

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -136,6 +136,7 @@ pub trait LateLintPass: LintPass {
     fn check_mod(&mut self, _: &LateContext, _: &hir::Mod, _: Span, _: ast::NodeId) { }
     fn check_foreign_item(&mut self, _: &LateContext, _: &hir::ForeignItem) { }
     fn check_item(&mut self, _: &LateContext, _: &hir::Item) { }
+    fn check_item_post(&mut self, _: &LateContext, _: &hir::Item) { }
     fn check_local(&mut self, _: &LateContext, _: &hir::Local) { }
     fn check_block(&mut self, _: &LateContext, _: &hir::Block) { }
     fn check_block_post(&mut self, _: &LateContext, _: &hir::Block) { }
@@ -180,6 +181,7 @@ pub trait EarlyLintPass: LintPass {
     fn check_mod(&mut self, _: &EarlyContext, _: &ast::Mod, _: Span, _: ast::NodeId) { }
     fn check_foreign_item(&mut self, _: &EarlyContext, _: &ast::ForeignItem) { }
     fn check_item(&mut self, _: &EarlyContext, _: &ast::Item) { }
+    fn check_item_post(&mut self, _: &EarlyContext, _: &ast::Item) { }
     fn check_local(&mut self, _: &EarlyContext, _: &ast::Local) { }
     fn check_block(&mut self, _: &EarlyContext, _: &ast::Block) { }
     fn check_block_post(&mut self, _: &EarlyContext, _: &ast::Block) { }


### PR DESCRIPTION
This fixes #31512 for me.

A bit of explanation: I want to have `check_block_post(&mut self, &Context, &Block)` and `check_crate_post(&mut self, &Context, &Crate)` methods in both early and late lint passes. Ideally we'd have _post methods for all operations that walk, but this'll do for now.

@Manishearth r?
