### PR TITLE
Added a few words to indicate where the vector object is created.

### DIFF
--- a/src/doc/book/ownership.md
+++ b/src/doc/book/ownership.md
@@ -51,10 +51,11 @@ fn foo() {
 }
 ```
 
-When `v` comes into scope, a new [vector] is created, and it allocates space on
-[the heap][heap] for each of its elements. When `v` goes out of scope at the
-end of `foo()`, Rust will clean up everything related to the vector, even the
-heap-allocated memory. This happens deterministically, at the end of the scope.
+When `v` comes into scope, a new [vector] is created on [the stack][stack],
+and it allocates space on [the heap][heap] for its elements. When `v` goes out
+of scope at the end of `foo()`, Rust will clean up everything related to the
+vector, even the heap-allocated memory. This happens deterministically, at the
+end of the scope.
 
 We'll cover [vectors] in detail later in this chapter; we only use them
 here as an example of a type that allocates space on the heap at runtime. They
@@ -67,6 +68,7 @@ Vectors have a [generic type][generics] `Vec<T>`, so in this example `v` will ha
 [arrays]: primitive-types.html#arrays
 [vectors]: vectors.html
 [heap]: the-stack-and-the-heap.html
+[stack]: the-stack-and-the-heap.html#the-stack
 [bindings]: variable-bindings.html
 [generics]: generics.html
 


### PR DESCRIPTION
This is a minor change. Please see title. IMO this is important since this is the first instance when we talk about allocating a vector. Not saying that it is allocated on the stack here leaves room for speculation and this might put off some people (they might not even read the later sections which go into more detail about this).
