### PR TITLE
don't ICE on a couple of missing lang items

### DIFF
--- a/src/librustc_mir/build/scope.rs
+++ b/src/librustc_mir/build/scope.rs
@@ -622,8 +622,8 @@ fn build_free<'tcx>(tcx: &ty::ctxt<'tcx>,
                     unit_temp: Lvalue<'tcx>,
                     data: &FreeData<'tcx>,
                     target: BasicBlock) -> Terminator<'tcx> {
-    let free_func = tcx.lang_items.box_free_fn()
-                       .expect("box_free language item is missing");
+    let free_func = tcx.lang_items.require(lang_items::BoxFreeFnLangItem)
+                       .unwrap_or_else(|e| tcx.sess.fatal(&e));
     let substs = tcx.mk_substs(Substs::new(
         VecPerParamSpace::new(vec![], vec![], vec![data.item_ty]),
         VecPerParamSpace::new(vec![], vec![], vec![])

--- a/src/librustc_trans/trans/collector.rs
+++ b/src/librustc_trans/trans/collector.rs
@@ -501,7 +501,7 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirNeighborCollector<'a, 'tcx> {
                         .tcx()
                         .lang_items
                         .require(ExchangeMallocFnLangItem)
-                        .expect("Could not find ExchangeMallocFnLangItem");
+                        .unwrap_or_else(|e| self.ccx.sess().fatal(&e));
 
                 assert!(can_have_local_instance(self.ccx, exchange_malloc_fn_def_id));
                 let exchange_malloc_fn_trans_item =
@@ -645,7 +645,7 @@ fn find_drop_glue_neighbors<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
         let exchange_free_fn_def_id = ccx.tcx()
                                          .lang_items
                                          .require(ExchangeFreeFnLangItem)
-                                         .expect("Could not find ExchangeFreeFnLangItem");
+                                         .unwrap_or_else(|e| ccx.sess().fatal(&e));
 
         assert!(can_have_local_instance(ccx, exchange_free_fn_def_id));
         let exchange_free_fn_trans_item =


### PR DESCRIPTION
This changes three ICEs to fatal errors.

I've grepped for `lang_item.*expect` and `\.expect.*lang` and didn't come up with any more. But, there could be more ICEs lurking.

I wasn't sure about a test because there already _is_ a cfail test for missing lang items, but it only checks one.

Relevant to (already closed) #31477 #31480 #31558.
cc @lilred
