### PR TITLE
Fix regression in resolve

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -524,6 +524,7 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
         build_reduced_graph::populate_module_if_necessary(self.resolver, target_module);
         target_module.for_each_child(|name, ns, binding| {
             if !binding.defined_with(DefModifiers::IMPORTABLE | DefModifiers::PUBLIC) { return }
+            if binding.is_extern_crate() { return }
             self.define(module_, name, ns, directive.import(binding));
 
             if ns == TypeNS && directive.is_public &&

--- a/src/test/compile-fail/no-extern-crate-in-glob-import.rs
+++ b/src/test/compile-fail/no-extern-crate-in-glob-import.rs
@@ -14,7 +14,7 @@
 extern crate core;
 
 mod T {
-    use super::*;
+    pub use super::*;
 }
 
 fn main() {


### PR DESCRIPTION
This fixes a regression caused by #31461 allowing extern crates to be glob imported, and it fixes the test that was supposed to catch it.
r? @nrc 
