### PR TITLE
Ignore tests that use threads on emscripten

### DIFF
--- a/src/test/run-pass/atomic-print.rs
+++ b/src/test/run-pass/atomic-print.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 use std::{env, fmt, process, sync, thread};
 
 struct SlowFmt(u32);

--- a/src/test/run-pass/box-of-array-of-drop-1.rs
+++ b/src/test/run-pass/box-of-array-of-drop-1.rs
@@ -11,6 +11,8 @@
 // Test that we cleanup a fixed size Box<[D; k]> properly when D has a
 // destructor.
 
+// ignore-emscripten no threads support
+
 #![feature(const_fn)]
 
 use std::thread;

--- a/src/test/run-pass/box-of-array-of-drop-2.rs
+++ b/src/test/run-pass/box-of-array-of-drop-2.rs
@@ -11,6 +11,8 @@
 // Test that we cleanup dynamic sized Box<[D]> properly when D has a
 // destructor.
 
+// ignore-emscripten no threads support
+
 #![feature(const_fn)]
 
 use std::thread;

--- a/src/test/run-pass/cci_capture_clause.rs
+++ b/src/test/run-pass/cci_capture_clause.rs
@@ -14,6 +14,7 @@
 // that use capture clauses.
 
 // pretty-expanded FIXME #23616
+// ignore-emscripten no threads support
 
 extern crate cci_capture_clause;
 

--- a/src/test/run-pass/child-outlives-parent.rs
+++ b/src/test/run-pass/child-outlives-parent.rs
@@ -11,6 +11,7 @@
 // Reported as issue #126, child leaks the string.
 
 // pretty-expanded FIXME #23616
+// ignore-emscripten no threads support
 
 #![feature(std_misc)]
 

--- a/src/test/run-pass/cleanup-rvalue-temp-during-incomplete-alloc.rs
+++ b/src/test/run-pass/cleanup-rvalue-temp-during-incomplete-alloc.rs
@@ -24,6 +24,7 @@
 // It's unclear how likely such a bug is to recur, but it seems like a
 // scenario worth testing.
 
+// ignore-emscripten no threads support
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/clone-with-exterior.rs
+++ b/src/test/run-pass/clone-with-exterior.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
 
 #![allow(unknown_features)]
 #![feature(box_syntax, std_misc)]

--- a/src/test/run-pass/comm.rs
+++ b/src/test/run-pass/comm.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 #![feature(std_misc)]
 
 use std::thread;

--- a/src/test/run-pass/core-run-destroy.rs
+++ b/src/test/run-pass/core-run-destroy.rs
@@ -10,6 +10,7 @@
 
 // ignore-pretty
 // compile-flags:--test
+// ignore-emscripten
 
 // NB: These tests kill child processes. Valgrind sees these children as leaking
 // memory, which makes for some *confusing* logs. That's why these are here

--- a/src/test/run-pass/drop-flag-skip-sanity-check.rs
+++ b/src/test/run-pass/drop-flag-skip-sanity-check.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // compile-flags: -Z force-dropflag-checks=off
+// ignore-emscripten no threads support
 
 // Quick-and-dirty test to ensure -Z force-dropflag-checks=off works as
 // expected. Note that the inlined drop-flag is slated for removal

--- a/src/test/run-pass/extern-call-deep2.rs
+++ b/src/test/run-pass/extern-call-deep2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 #![feature(libc)]
 
 extern crate libc;

--- a/src/test/run-pass/extern-call-scrub.rs
+++ b/src/test/run-pass/extern-call-scrub.rs
@@ -12,6 +12,8 @@
 // make sure the stack pointers are maintained properly in both
 // directions
 
+// ignore-emscripten no threads support
+
 #![feature(libc, std_misc)]
 
 extern crate libc;

--- a/src/test/run-pass/fds-are-cloexec.rs
+++ b/src/test/run-pass/fds-are-cloexec.rs
@@ -10,6 +10,7 @@
 
 // ignore-windows
 // ignore-android
+// ignore-emscripten
 
 #![feature(libc)]
 

--- a/src/test/run-pass/foreign-call-no-runtime.rs
+++ b/src/test/run-pass/foreign-call-no-runtime.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 // ignore-aarch64
+// ignore-emscripten no threads support
+
 #![feature(libc)]
 
 extern crate libc;

--- a/src/test/run-pass/init-large-type.rs
+++ b/src/test/run-pass/init-large-type.rs
@@ -13,6 +13,7 @@
 // optimisation.
 
 // pretty-expanded FIXME #23616
+// ignore-emscripten no threads support
 
 #![feature(intrinsics, std_misc)]
 

--- a/src/test/run-pass/int-abs-overflow.rs
+++ b/src/test/run-pass/int-abs-overflow.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // compile-flags: -Z force-overflow-checks=on
+// ignore-emscripten no threads support
 
 use std::thread;
 

--- a/src/test/run-pass/intrinsic-move-val-cleanups.rs
+++ b/src/test/run-pass/intrinsic-move-val-cleanups.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 // This test is checking that the move_val_init intrinsic is
 // respecting cleanups for both of its argument expressions.
 //

--- a/src/test/run-pass/issue-13494.rs
+++ b/src/test/run-pass/issue-13494.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 // This test may not always fail, but it can be flaky if the race it used to
 // expose is still present.
 

--- a/src/test/run-pass/issue-16560.rs
+++ b/src/test/run-pass/issue-16560.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
 
 #![feature(unboxed_closures)]
 

--- a/src/test/run-pass/issue-16671.rs
+++ b/src/test/run-pass/issue-16671.rs
@@ -11,6 +11,8 @@
 // DON'T REENABLE THIS UNLESS YOU'VE ACTUALLY FIXED THE UNDERLYING ISSUE
 // ignore-android seems to block forever
 
+// ignore-emscripten no threads support
+
 #![forbid(warnings)]
 
 // Pretty printing tests complain about `use std::predule::*`

--- a/src/test/run-pass/issue-21291.rs
+++ b/src/test/run-pass/issue-21291.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 // Regression test for unwrapping the result of `join`, issue #21291
 
 use std::thread;

--- a/src/test/run-pass/issue-22864-2.rs
+++ b/src/test/run-pass/issue-22864-2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 pub fn main() {
     let f = || || 0;
     std::thread::spawn(f());

--- a/src/test/run-pass/issue-25089.rs
+++ b/src/test/run-pass/issue-25089.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 use std::thread;
 
 struct Foo(i32);

--- a/src/test/run-pass/issue-26655.rs
+++ b/src/test/run-pass/issue-26655.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 #![feature(const_fn)]
 
 // Check that the destructors of simple enums are run on unwinding

--- a/src/test/run-pass/issue-29488.rs
+++ b/src/test/run-pass/issue-29488.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 use std::thread;
 
 struct Foo;

--- a/src/test/run-pass/issue-30018-panic.rs
+++ b/src/test/run-pass/issue-30018-panic.rs
@@ -13,6 +13,8 @@
 // spawned thread to isolate the expected error result from the
 // SIGTRAP injected by the drop-flag consistency checking.
 
+// ignore-emscripten no threads support
+
 struct Foo;
 
 impl Drop for Foo {

--- a/src/test/run-pass/issue-4446.rs
+++ b/src/test/run-pass/issue-4446.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 use std::sync::mpsc::channel;
 use std::thread;
 

--- a/src/test/run-pass/issue-4448.rs
+++ b/src/test/run-pass/issue-4448.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
 
 use std::sync::mpsc::channel;
 use std::thread;

--- a/src/test/run-pass/issue-8460.rs
+++ b/src/test/run-pass/issue-8460.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 #![feature(zero_one)]
 
 use std::num::Zero;

--- a/src/test/run-pass/issue-8827.rs
+++ b/src/test/run-pass/issue-8827.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 #![feature(std_misc)]
 
 use std::thread;

--- a/src/test/run-pass/issue-9396.rs
+++ b/src/test/run-pass/issue-9396.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 use std::sync::mpsc::{TryRecvError, channel};
 use std::thread;
 

--- a/src/test/run-pass/ivec-tag.rs
+++ b/src/test/run-pass/ivec-tag.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // pretty-expanded FIXME #23616
+// ignore-emscripten no threads support
 
 #![feature(std_misc)]
 

--- a/src/test/run-pass/logging-only-prints-once.rs
+++ b/src/test/run-pass/logging-only-prints-once.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-windows
+// ignore-emscripten no threads support
 // exec-env:RUST_LOG=debug
 
 use std::cell::Cell;

--- a/src/test/run-pass/macro-with-braces-in-expr-position.rs
+++ b/src/test/run-pass/macro-with-braces-in-expr-position.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 use std::thread;
 
 macro_rules! expr { ($e: expr) => { $e } }

--- a/src/test/run-pass/moves-based-on-type-capture-clause.rs
+++ b/src/test/run-pass/moves-based-on-type-capture-clause.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 #![feature(std_misc)]
 
 use std::thread;

--- a/src/test/run-pass/nested-vec-3.rs
+++ b/src/test/run-pass/nested-vec-3.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 // Test that using the `vec!` macro nested within itself works when
 // the contents implement Drop and we hit a panic in the middle of
 // construction.

--- a/src/test/run-pass/no-landing-pads.rs
+++ b/src/test/run-pass/no-landing-pads.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags: -Z no-landing-pads
-
+// ignore-emscripten no threads support
 
 use std::thread;
 

--- a/src/test/run-pass/panic-handler-flail-wildly.rs
+++ b/src/test/run-pass/panic-handler-flail-wildly.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 #![feature(panic_handler, std_panic)]
 
+// ignore-emscripten no threads support
+
 use std::panic;
 use std::thread;
 

--- a/src/test/run-pass/panic-handler-set-twice.rs
+++ b/src/test/run-pass/panic-handler-set-twice.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 #![feature(panic_handler, const_fn, std_panic)]
 
+// ignore-emscripten no threads support
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::panic;
 use std::thread;

--- a/src/test/run-pass/panic-in-dtor-drops-fields.rs
+++ b/src/test/run-pass/panic-in-dtor-drops-fields.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
 
 use std::thread;
 

--- a/src/test/run-pass/panic-recover-propagate.rs
+++ b/src/test/run-pass/panic-recover-propagate.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 #![feature(std_panic, recover, panic_propagate, panic_handler, const_fn)]
 
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/src/test/run-pass/process-sigpipe.rs
+++ b/src/test/run-pass/process-sigpipe.rs
@@ -18,6 +18,8 @@
 // (instead of running forever), and that it does not print an error
 // message about a broken pipe.
 
+// ignore-emscripten no threads support
+
 use std::process;
 use std::thread;
 

--- a/src/test/run-pass/rust-log-filter.rs
+++ b/src/test/run-pass/rust-log-filter.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // exec-env:RUST_LOG=rust_log_filter/foo
-
+// ignore-emscripten no threads support
 
 #![allow(unknown_features)]
 #![feature(box_syntax, std_misc, rustc_private)]

--- a/src/test/run-pass/send-resource.rs
+++ b/src/test/run-pass/send-resource.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // pretty-expanded FIXME #23616
+// ignore-emscripten no threads support
 
 #![feature(std_misc)]
 

--- a/src/test/run-pass/sendfn-spawn-with-fn-arg.rs
+++ b/src/test/run-pass/sendfn-spawn-with-fn-arg.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 #![allow(unknown_features)]
 #![feature(box_syntax)]
 

--- a/src/test/run-pass/sepcomp-unwind.rs
+++ b/src/test/run-pass/sepcomp-unwind.rs
@@ -10,6 +10,7 @@
 
 // ignore-bitrig
 // compile-flags: -C codegen-units=3
+// ignore-emscripten no threads support
 
 // Test unwinding through multiple compilation units.
 

--- a/src/test/run-pass/slice-panic-1.rs
+++ b/src/test/run-pass/slice-panic-1.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 // Test that if a slicing expr[..] fails, the correct cleanups happen.
 
 

--- a/src/test/run-pass/slice-panic-2.rs
+++ b/src/test/run-pass/slice-panic-2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 // Test that if a slicing expr[..] fails, the correct cleanups happen.
 
 

--- a/src/test/run-pass/spawn-fn.rs
+++ b/src/test/run-pass/spawn-fn.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 use std::thread;
 
 fn x(s: String, n: isize) {

--- a/src/test/run-pass/spawn-types.rs
+++ b/src/test/run-pass/spawn-types.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
 
 /*
   Make sure we can spawn tasks that take different types of

--- a/src/test/run-pass/spawn.rs
+++ b/src/test/run-pass/spawn.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 use std::thread;
 
 pub fn main() {

--- a/src/test/run-pass/spawn2.rs
+++ b/src/test/run-pass/spawn2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 use std::thread;
 
 pub fn main() {

--- a/src/test/run-pass/spawning-with-debug.rs
+++ b/src/test/run-pass/spawning-with-debug.rs
@@ -10,6 +10,7 @@
 
 // ignore-windows
 // exec-env:RUST_LOG=debug
+// ignore-emscripten no threads support
 
 // regression test for issue #10405, make sure we don't call println! too soon.
 

--- a/src/test/run-pass/task-comm-0.rs
+++ b/src/test/run-pass/task-comm-0.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 #![feature(std_misc)]
 
 use std::thread;

--- a/src/test/run-pass/task-comm-1.rs
+++ b/src/test/run-pass/task-comm-1.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 #![feature(std_misc)]
 
 use std::thread;

--- a/src/test/run-pass/task-comm-10.rs
+++ b/src/test/run-pass/task-comm-10.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 #![feature(std_misc)]
 
 use std::thread;

--- a/src/test/run-pass/task-comm-11.rs
+++ b/src/test/run-pass/task-comm-11.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // pretty-expanded FIXME #23616
+// ignore-emscripten no threads support
 
 #![feature(std_misc)]
 

--- a/src/test/run-pass/task-comm-12.rs
+++ b/src/test/run-pass/task-comm-12.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 #![feature(std_misc)]
 
 use std::thread;

--- a/src/test/run-pass/task-comm-13.rs
+++ b/src/test/run-pass/task-comm-13.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 #![feature(std_misc)]
 
 use std::sync::mpsc::{channel, Sender};

--- a/src/test/run-pass/task-comm-14.rs
+++ b/src/test/run-pass/task-comm-14.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 #![feature(std_misc)]
 
 use std::sync::mpsc::{channel, Sender};

--- a/src/test/run-pass/task-comm-15.rs
+++ b/src/test/run-pass/task-comm-15.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
 // pretty-expanded FIXME #23616
 
 #![feature(std_misc)]

--- a/src/test/run-pass/task-comm-17.rs
+++ b/src/test/run-pass/task-comm-17.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
 // pretty-expanded FIXME #23616
 
 #![feature(std_misc)]

--- a/src/test/run-pass/task-comm-3.rs
+++ b/src/test/run-pass/task-comm-3.rs
@@ -10,6 +10,7 @@
 
 #![feature(std_misc)]
 
+// ignore-emscripten no threads support
 // no-pretty-expanded FIXME #15189
 
 use std::thread;

--- a/src/test/run-pass/task-comm-7.rs
+++ b/src/test/run-pass/task-comm-7.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
 
 #![feature(std_misc)]
 #![allow(dead_assignment)]

--- a/src/test/run-pass/task-comm-9.rs
+++ b/src/test/run-pass/task-comm-9.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 #![feature(std_misc)]
 
 use std::thread;

--- a/src/test/run-pass/task-life-0.rs
+++ b/src/test/run-pass/task-life-0.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
 // pretty-expanded FIXME #23616
 
 #![feature(std_misc)]

--- a/src/test/run-pass/task-spawn-move-and-copy.rs
+++ b/src/test/run-pass/task-spawn-move-and-copy.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
 
 #![allow(unknown_features)]
 #![feature(box_syntax, std_misc)]

--- a/src/test/run-pass/task-stderr.rs
+++ b/src/test/run-pass/task-stderr.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 #![feature(box_syntax, set_stdio)]
 
 use std::io::prelude::*;

--- a/src/test/run-pass/tcp-stress.rs
+++ b/src/test/run-pass/tcp-stress.rs
@@ -12,6 +12,7 @@
 // ignore-bitrig system ulimit (Too many open files)
 // ignore-netbsd system ulimit (Too many open files)
 // ignore-openbsd system ulimit (Too many open files)
+// ignore-emscripten no threads or sockets support
 
 use std::io::prelude::*;
 use std::net::{TcpListener, TcpStream};

--- a/src/test/run-pass/terminate-in-initializer.rs
+++ b/src/test/run-pass/terminate-in-initializer.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
 
 // Issue #787
 // Don't try to clean up uninitialized locals

--- a/src/test/run-pass/threads.rs
+++ b/src/test/run-pass/threads.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 #![feature(std_misc)]
 
 use std::thread;

--- a/src/test/run-pass/tls-dtors-are-run-in-a-static-binary.rs
+++ b/src/test/run-pass/tls-dtors-are-run-in-a-static-binary.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // no-prefer-dynamic
+// ignore-emscripten no threads support
 
 static mut HIT: bool = false;
 

--- a/src/test/run-pass/tls-init-on-init.rs
+++ b/src/test/run-pass/tls-init-on-init.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 #![feature(thread_local_state)]
 
 use std::thread::{self, LocalKeyState};

--- a/src/test/run-pass/trait-bounds-in-arc.rs
+++ b/src/test/run-pass/trait-bounds-in-arc.rs
@@ -11,6 +11,7 @@
 // Tests that a heterogeneous list of existential types can be put inside an Arc
 // and shared between threads as long as all types fulfill Send.
 
+// ignore-emscripten no threads support
 // ignore-pretty
 
 #![allow(unknown_features)]

--- a/src/test/run-pass/unique-send-2.rs
+++ b/src/test/run-pass/unique-send-2.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/unit-like-struct-drop-run.rs
+++ b/src/test/run-pass/unit-like-struct-drop-run.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 // Make sure the destructor is run for unit-like structs.
 
 

--- a/src/test/run-pass/unwind-resource.rs
+++ b/src/test/run-pass/unwind-resource.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 use std::sync::mpsc::{channel, Sender};
 use std::thread;
 

--- a/src/test/run-pass/unwind-unique.rs
+++ b/src/test/run-pass/unwind-unique.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/vector-sort-panic-safe.rs
+++ b/src/test/run-pass/vector-sort-panic-safe.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
 
 #![feature(rand, num_bits_bytes)]
 #![feature(const_fn)]

--- a/src/test/run-pass/weak-lang-item.rs
+++ b/src/test/run-pass/weak-lang-item.rs
@@ -10,6 +10,7 @@
 
 // aux-build:weak-lang-items.rs
 
+// ignore-emscripten no threads support
 // pretty-expanded FIXME #23616
 
 extern crate weak_lang_items as other;

--- a/src/test/run-pass/yield.rs
+++ b/src/test/run-pass/yield.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 use std::thread;
 
 pub fn main() {

--- a/src/test/run-pass/yield1.rs
+++ b/src/test/run-pass/yield1.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 use std::thread;
 
 pub fn main() {


### PR DESCRIPTION
Ignores 82 rpass tests that use threads.
I took care to only ignore tests that call `thread::spawn`. Some tests, for example `issue-16597`, also do fail because of lack of threads support, but for other reasons.

With this PR, we're down to 49 failures.

r? @brson 
