### PR TITLE
Do not use pthreads on emscripten

### DIFF
--- a/src/libstd/sys/common/thread.rs
+++ b/src/libstd/sys/common/thread.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![cfg(not(target_os = "emscripten"))]
+
 use prelude::v1::*;
 
 use alloc::boxed::FnBox;

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -488,6 +488,7 @@ pub fn unsetenv(n: &OsStr) -> io::Result<()> {
     }).map(|_| ())
 }
 
+#[cfg(not(target_os = "emscripten"))]
 pub fn page_size() -> usize {
     unsafe {
         libc::sysconf(libc::_SC_PAGESIZE) as usize

--- a/src/libstd/sys/unix/process.rs
+++ b/src/libstd/sys/unix/process.rs
@@ -380,8 +380,8 @@ impl Command {
             *sys::os::environ() = envp.as_ptr();
         }
 
-        // NaCl has no signal support.
-        if cfg!(not(target_os = "nacl")) {
+        // NaCl and Emscripten have no signal support.
+        if cfg!(not(any(target_os = "nacl", target_os = "emscripten"))) {
             // Reset signal handling so the child process starts in a
             // standardized state. libstd ignores SIGPIPE, and signal-handling
             // libraries often set a mask. Child processes inherit ignored
@@ -634,6 +634,7 @@ mod tests {
     #[test]
     #[cfg_attr(target_os = "macos", ignore)]
     #[cfg_attr(target_os = "nacl", ignore)] // no signals on NaCl.
+    #[cfg_attr(target_os = "emscripten", ignore)] // no signals on Emscripten.
     fn test_process_mask() {
         unsafe {
             // Test to make sure that a signal mask does not get inherited.

--- a/src/libstd/sys/unix/stack_overflow.rs
+++ b/src/libstd/sys/unix/stack_overflow.rs
@@ -11,7 +11,9 @@
 #![cfg_attr(test, allow(dead_code))]
 
 use libc;
-use self::imp::{make_handler, drop_handler};
+#[cfg(not(target_os = "emscripten"))]
+use self::imp::make_handler;
+use self::imp::drop_handler;
 
 pub use self::imp::cleanup;
 pub use self::imp::init;
@@ -21,6 +23,7 @@ pub struct Handler {
 }
 
 impl Handler {
+    #[cfg(not(target_os = "emscripten"))]
     pub unsafe fn new() -> Handler {
         make_handler()
     }
@@ -188,6 +191,7 @@ mod imp {
               all(target_os = "netbsd", not(target_vendor = "rumprun")),
               target_os = "openbsd")))]
 mod imp {
+    #[cfg(not(target_os = "emscripten"))]
     use ptr;
 
     pub unsafe fn init() {
@@ -196,6 +200,7 @@ mod imp {
     pub unsafe fn cleanup() {
     }
 
+    #[cfg(not(target_os = "emscripten"))]
     pub unsafe fn make_handler() -> super::Handler {
         super::Handler { _data: ptr::null_mut() }
     }


### PR DESCRIPTION
Replaces `Condvar`, `Mutex`, `RWLock` and `thread::new` with stubs on emscripten.
`Condvar`, `Mutex`, `RWLock` simply do nothing, while `thread::new` returns an error.

The other changes are to fix warnings about unused imports or unused functions.

I'm submitting this separately because it's probably going to be controversial.

cc @brson @alexcrichton 
