### PR TITLE
Enable /LARGEADDRESSAWARE & /SAFESEH for i686-pc-windows-msvc

### DIFF
--- a/src/librustc_back/target/i686_pc_windows_msvc.rs
+++ b/src/librustc_back/target/i686_pc_windows_msvc.rs
@@ -18,6 +18,11 @@ pub fn target() -> Target {
     // space available to x86 Windows binaries on x86_64.
     base.pre_link_args.push("/LARGEADDRESSAWARE".to_string());
 
+    // Ensure the linker will only produce an image if it can also produce a table of
+    // the image's safe exception handlers.
+    // https://msdn.microsoft.com/en-us/library/9a89h429.aspx
+    base.pre_link_args.push("/SAFESEH".to_string());
+
     Target {
         llvm_target: "i686-pc-windows-msvc".to_string(),
         target_endian: "little".to_string(),

--- a/src/librustc_back/target/i686_pc_windows_msvc.rs
+++ b/src/librustc_back/target/i686_pc_windows_msvc.rs
@@ -14,6 +14,10 @@ pub fn target() -> Target {
     let mut base = super::windows_msvc_base::opts();
     base.cpu = "pentium4".to_string();
 
+    // Mark all dynamic libraries and executables as compatible with the larger 4GiB address
+    // space available to x86 Windows binaries on x86_64.
+    base.pre_link_args.push("/LARGEADDRESSAWARE".to_string());
+
     Target {
         llvm_target: "i686-pc-windows-msvc".to_string(),
         target_endian: "little".to_string(),


### PR DESCRIPTION
/LARGEADDRESSAWARE is already enabled for i686-pc-windows-gnu so we should probably be consistent.
https://msdn.microsoft.com/en-us/library/wz223b1z.aspx

/SAFESEH is a good thing to enable by default.
https://msdn.microsoft.com/en-us/library/9a89h429.aspx
