### PR TITLE
[breaking batch] Rename and refactor ast::Pat_ variants

### DIFF
--- a/src/librustc_front/lowering.rs
+++ b/src/librustc_front/lowering.rs
@@ -920,10 +920,13 @@ pub fn lower_pat(lctx: &LoweringContext, p: &Pat) -> P<hir::Pat> {
                               sub.as_ref().map(|x| lower_pat(lctx, x)))
             }
             PatKind::Lit(ref e) => hir::PatLit(lower_expr(lctx, e)),
-            PatKind::Enum(ref pth, ref pats) => {
+            PatKind::TupleStruct(ref pth, ref pats) => {
                 hir::PatEnum(lower_path(lctx, pth),
                              pats.as_ref()
                                  .map(|pats| pats.iter().map(|x| lower_pat(lctx, x)).collect()))
+            }
+            PatKind::Path(ref pth) => {
+                hir::PatEnum(lower_path(lctx, pth), Some(hir::HirVec::new()))
             }
             PatKind::QPath(ref qself, ref pth) => {
                 let qself = hir::QSelf {

--- a/src/librustc_front/lowering.rs
+++ b/src/librustc_front/lowering.rs
@@ -913,26 +913,26 @@ pub fn lower_pat(lctx: &LoweringContext, p: &Pat) -> P<hir::Pat> {
     P(hir::Pat {
         id: p.id,
         node: match p.node {
-            PatWild => hir::PatWild,
-            PatIdent(ref binding_mode, pth1, ref sub) => {
+            PatKind::Wild => hir::PatWild,
+            PatKind::Ident(ref binding_mode, pth1, ref sub) => {
                 hir::PatIdent(lower_binding_mode(lctx, binding_mode),
                               respan(pth1.span, lower_ident(lctx, pth1.node)),
                               sub.as_ref().map(|x| lower_pat(lctx, x)))
             }
-            PatLit(ref e) => hir::PatLit(lower_expr(lctx, e)),
-            PatEnum(ref pth, ref pats) => {
+            PatKind::Lit(ref e) => hir::PatLit(lower_expr(lctx, e)),
+            PatKind::Enum(ref pth, ref pats) => {
                 hir::PatEnum(lower_path(lctx, pth),
                              pats.as_ref()
                                  .map(|pats| pats.iter().map(|x| lower_pat(lctx, x)).collect()))
             }
-            PatQPath(ref qself, ref pth) => {
+            PatKind::QPath(ref qself, ref pth) => {
                 let qself = hir::QSelf {
                     ty: lower_ty(lctx, &qself.ty),
                     position: qself.position,
                 };
                 hir::PatQPath(qself, lower_path(lctx, pth))
             }
-            PatStruct(ref pth, ref fields, etc) => {
+            PatKind::Struct(ref pth, ref fields, etc) => {
                 let pth = lower_path(lctx, pth);
                 let fs = fields.iter()
                                .map(|f| {
@@ -948,20 +948,22 @@ pub fn lower_pat(lctx: &LoweringContext, p: &Pat) -> P<hir::Pat> {
                                .collect();
                 hir::PatStruct(pth, fs, etc)
             }
-            PatTup(ref elts) => hir::PatTup(elts.iter().map(|x| lower_pat(lctx, x)).collect()),
-            PatBox(ref inner) => hir::PatBox(lower_pat(lctx, inner)),
-            PatRegion(ref inner, mutbl) => {
+            PatKind::Tup(ref elts) => {
+                hir::PatTup(elts.iter().map(|x| lower_pat(lctx, x)).collect())
+            }
+            PatKind::Box(ref inner) => hir::PatBox(lower_pat(lctx, inner)),
+            PatKind::Ref(ref inner, mutbl) => {
                 hir::PatRegion(lower_pat(lctx, inner), lower_mutability(lctx, mutbl))
             }
-            PatRange(ref e1, ref e2) => {
+            PatKind::Range(ref e1, ref e2) => {
                 hir::PatRange(lower_expr(lctx, e1), lower_expr(lctx, e2))
             }
-            PatVec(ref before, ref slice, ref after) => {
+            PatKind::Vec(ref before, ref slice, ref after) => {
                 hir::PatVec(before.iter().map(|x| lower_pat(lctx, x)).collect(),
                             slice.as_ref().map(|x| lower_pat(lctx, x)),
                             after.iter().map(|x| lower_pat(lctx, x)).collect())
             }
-            PatMac(_) => panic!("Shouldn't exist here"),
+            PatKind::Mac(_) => panic!("Shouldn't exist here"),
         },
         span: p.span,
     })

--- a/src/librustc_passes/const_fn.rs
+++ b/src/librustc_passes/const_fn.rs
@@ -13,7 +13,7 @@
 
 use rustc::session::{Session, CompileResult};
 
-use syntax::ast;
+use syntax::ast::{self, PatKind};
 use syntax::visit::{self, Visitor, FnKind};
 use syntax::codemap::Span;
 
@@ -104,8 +104,8 @@ impl<'a, 'v> Visitor<'v> for CheckConstFn<'a> {
         // Ensure the arguments are simple, not mutable/by-ref or patterns.
         for arg in &fd.inputs {
             match arg.pat.node {
-                ast::PatWild => {}
-                ast::PatIdent(ast::BindingMode::ByValue(ast::Mutability::Immutable), _, None) => {}
+                PatKind::Wild => {}
+                PatKind::Ident(ast::BindingMode::ByValue(ast::Mutability::Immutable), _, None) => {}
                 _ => {
                     span_err!(self.sess, arg.pat.span, E0022,
                               "arguments of constant functions can only \

--- a/src/librustc_trans/save/dump_csv.rs
+++ b/src/librustc_trans/save/dump_csv.rs
@@ -40,7 +40,7 @@ use std::fs::File;
 use std::hash::*;
 use std::collections::HashSet;
 
-use syntax::ast::{self, NodeId};
+use syntax::ast::{self, NodeId, PatKind};
 use syntax::codemap::*;
 use syntax::parse::token::{self, keywords};
 use syntax::visit::{self, Visitor};
@@ -780,7 +780,7 @@ impl <'l, 'tcx> DumpCsvVisitor<'l, 'tcx> {
 
     fn process_pat(&mut self, p: &ast::Pat) {
         match p.node {
-            ast::PatStruct(ref path, ref fields, _) => {
+            PatKind::Struct(ref path, ref fields, _) => {
                 visit::walk_path(self, path);
                 let adt = self.tcx.node_id_to_type(p.id).ty_adt_def().unwrap();
                 let def = self.tcx.def_map.borrow()[&p.id].full_def();

--- a/src/librustc_trans/save/mod.rs
+++ b/src/librustc_trans/save/mod.rs
@@ -762,7 +762,8 @@ impl<'v> Visitor<'v> for PathCollector {
                 self.collected_paths.push((p.id, path.clone(),
                                            ast::Mutability::Mutable, recorder::TypeRef));
             }
-            PatKind::Enum(ref path, _) |
+            PatKind::TupleStruct(ref path, _) |
+            PatKind::Path(ref path) |
             PatKind::QPath(_, ref path) => {
                 self.collected_paths.push((p.id, path.clone(),
                                            ast::Mutability::Mutable, recorder::VarRef));

--- a/src/librustc_trans/save/mod.rs
+++ b/src/librustc_trans/save/mod.rs
@@ -21,7 +21,7 @@ use rustc_front::{hir, lowering};
 use rustc::front::map::NodeItem;
 use rustc::session::config::CrateType::CrateTypeExecutable;
 
-use syntax::ast::{self, NodeId};
+use syntax::ast::{self, NodeId, PatKind};
 use syntax::ast_util;
 use syntax::codemap::*;
 use syntax::parse::token::{self, keywords};
@@ -758,16 +758,16 @@ impl PathCollector {
 impl<'v> Visitor<'v> for PathCollector {
     fn visit_pat(&mut self, p: &ast::Pat) {
         match p.node {
-            ast::PatStruct(ref path, _, _) => {
+            PatKind::Struct(ref path, _, _) => {
                 self.collected_paths.push((p.id, path.clone(),
                                            ast::Mutability::Mutable, recorder::TypeRef));
             }
-            ast::PatEnum(ref path, _) |
-            ast::PatQPath(_, ref path) => {
+            PatKind::Enum(ref path, _) |
+            PatKind::QPath(_, ref path) => {
                 self.collected_paths.push((p.id, path.clone(),
                                            ast::Mutability::Mutable, recorder::VarRef));
             }
-            ast::PatIdent(bm, ref path1, _) => {
+            PatKind::Ident(bm, ref path1, _) => {
                 debug!("PathCollector, visit ident in pat {}: {:?} {:?}",
                        path1.node,
                        p.span,

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -10,7 +10,6 @@
 
 // The Rust abstract syntax tree.
 
-pub use self::Pat_::*;
 pub use self::StructFieldKind::*;
 pub use self::TyParamBound::*;
 pub use self::UnsafeSource::*;
@@ -521,7 +520,7 @@ pub struct Block {
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash)]
 pub struct Pat {
     pub id: NodeId,
-    pub node: Pat_,
+    pub node: PatKind,
     pub span: Span,
 }
 
@@ -552,11 +551,11 @@ pub enum BindingMode {
 }
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
-pub enum Pat_ {
+pub enum PatKind {
     /// Represents a wildcard pattern (`_`)
-    PatWild,
+    Wild,
 
-    /// A PatIdent may either be a new bound variable,
+    /// A PatKind::Ident may either be a new bound variable,
     /// or a nullary enum (in which case the third field
     /// is None).
     ///
@@ -564,35 +563,35 @@ pub enum Pat_ {
     /// which it is. The resolver determines this, and
     /// records this pattern's NodeId in an auxiliary
     /// set (of "PatIdents that refer to nullary enums")
-    PatIdent(BindingMode, SpannedIdent, Option<P<Pat>>),
+    Ident(BindingMode, SpannedIdent, Option<P<Pat>>),
 
     /// "None" means a `Variant(..)` pattern where we don't bind the fields to names.
-    PatEnum(Path, Option<Vec<P<Pat>>>),
+    Enum(Path, Option<Vec<P<Pat>>>),
 
     /// An associated const named using the qualified path `<T>::CONST` or
     /// `<T as Trait>::CONST`. Associated consts from inherent impls can be
     /// referred to as simply `T::CONST`, in which case they will end up as
-    /// PatEnum, and the resolver will have to sort that out.
-    PatQPath(QSelf, Path),
+    /// PatKind::Enum, and the resolver will have to sort that out.
+    QPath(QSelf, Path),
 
     /// Destructuring of a struct, e.g. `Foo {x, y, ..}`
     /// The `bool` is `true` in the presence of a `..`
-    PatStruct(Path, Vec<Spanned<FieldPat>>, bool),
+    Struct(Path, Vec<Spanned<FieldPat>>, bool),
     /// A tuple pattern `(a, b)`
-    PatTup(Vec<P<Pat>>),
+    Tup(Vec<P<Pat>>),
     /// A `box` pattern
-    PatBox(P<Pat>),
+    Box(P<Pat>),
     /// A reference pattern, e.g. `&mut (a, b)`
-    PatRegion(P<Pat>, Mutability),
+    Ref(P<Pat>, Mutability),
     /// A literal
-    PatLit(P<Expr>),
+    Lit(P<Expr>),
     /// A range pattern, e.g. `1...2`
-    PatRange(P<Expr>, P<Expr>),
+    Range(P<Expr>, P<Expr>),
     /// `[a, b, ..i, y, z]` is represented as:
-    ///     `PatVec(box [a, b], Some(i), box [y, z])`
-    PatVec(Vec<P<Pat>>, Option<P<Pat>>, Vec<P<Pat>>),
+    ///     `PatKind::Vec(box [a, b], Some(i), box [y, z])`
+    Vec(Vec<P<Pat>>, Option<P<Pat>>, Vec<P<Pat>>),
     /// A macro pattern; pre-expansion
-    PatMac(Mac),
+    Mac(Mac),
 }
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
@@ -1609,7 +1608,7 @@ impl Arg {
             }),
             pat: P(Pat {
                 id: DUMMY_NODE_ID,
-                node: PatIdent(BindingMode::ByValue(mutability), path, None),
+                node: PatKind::Ident(BindingMode::ByValue(mutability), path, None),
                 span: span
             }),
             id: DUMMY_NODE_ID

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -555,18 +555,27 @@ pub enum PatKind {
     /// Represents a wildcard pattern (`_`)
     Wild,
 
-    /// A PatKind::Ident may either be a new bound variable,
-    /// or a nullary enum (in which case the third field
-    /// is None).
+    /// A `PatKind::Ident` may either be a new bound variable,
+    /// or a unit struct/variant pattern, or a const pattern (in the last two cases
+    /// the third field must be `None`).
     ///
-    /// In the nullary enum case, the parser can't determine
+    /// In the unit or const pattern case, the parser can't determine
     /// which it is. The resolver determines this, and
-    /// records this pattern's NodeId in an auxiliary
-    /// set (of "PatIdents that refer to nullary enums")
+    /// records this pattern's `NodeId` in an auxiliary
+    /// set (of "PatIdents that refer to unit patterns or constants").
     Ident(BindingMode, SpannedIdent, Option<P<Pat>>),
 
+    /// A struct or struct variant pattern, e.g. `Variant {x, y, ..}`.
+    /// The `bool` is `true` in the presence of a `..`.
+    Struct(Path, Vec<Spanned<FieldPat>>, bool),
+
+    /// A tuple struct/variant pattern `Variant(x, y, z)`.
     /// "None" means a `Variant(..)` pattern where we don't bind the fields to names.
-    Enum(Path, Option<Vec<P<Pat>>>),
+    TupleStruct(Path, Option<Vec<P<Pat>>>),
+
+    /// A path pattern.
+    /// Such pattern can be resolved to a unit struct/variant or a constant.
+    Path(Path),
 
     /// An associated const named using the qualified path `<T>::CONST` or
     /// `<T as Trait>::CONST`. Associated consts from inherent impls can be
@@ -574,9 +583,6 @@ pub enum PatKind {
     /// PatKind::Enum, and the resolver will have to sort that out.
     QPath(QSelf, Path),
 
-    /// Destructuring of a struct, e.g. `Foo {x, y, ..}`
-    /// The `bool` is `true` in the presence of a `..`
-    Struct(Path, Vec<Spanned<FieldPat>>, bool),
     /// A tuple pattern `(a, b)`
     Tup(Vec<P<Pat>>),
     /// A `box` pattern

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -69,7 +69,7 @@ pub fn ident_to_pat(id: NodeId, s: Span, i: Ident) -> P<Pat> {
     let spanned = codemap::Spanned{ span: s, node: i };
     P(Pat {
         id: id,
-        node: PatIdent(BindingMode::ByValue(Mutability::Immutable), spanned, None),
+        node: PatKind::Ident(BindingMode::ByValue(Mutability::Immutable), spanned, None),
         span: s
     })
 }
@@ -348,7 +348,7 @@ pub fn compute_id_range_for_fn_body(fk: FnKind,
 /// and false otherwise.
 pub fn pat_is_ident(pat: P<ast::Pat>) -> bool {
     match pat.node {
-        ast::PatIdent(..) => true,
+        PatKind::Ident(..) => true,
         _ => false,
     }
 }

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -11,7 +11,7 @@
 pub use self::SyntaxExtension::*;
 
 use ast;
-use ast::Name;
+use ast::{Name, PatKind};
 use codemap;
 use codemap::{CodeMap, Span, ExpnId, ExpnInfo, NO_EXPANSION};
 use errors::DiagnosticBuilder;
@@ -307,7 +307,7 @@ impl MacResult for MacEager {
                 return Some(P(ast::Pat {
                     id: ast::DUMMY_NODE_ID,
                     span: e.span,
-                    node: ast::PatLit(e),
+                    node: PatKind::Lit(e),
                 }));
             }
         }
@@ -359,7 +359,7 @@ impl DummyResult {
     pub fn raw_pat(sp: Span) -> ast::Pat {
         ast::Pat {
             id: ast::DUMMY_NODE_ID,
-            node: ast::PatWild,
+            node: PatKind::Wild,
             span: sp,
         }
     }

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use abi::Abi;
-use ast::{self, Ident, Generics, Expr, BlockCheckMode, UnOp};
+use ast::{self, Ident, Generics, Expr, BlockCheckMode, UnOp, PatKind};
 use attr;
 use codemap::{Span, respan, Spanned, DUMMY_SP, Pos};
 use ext::base::ExtCtxt;
@@ -166,7 +166,7 @@ pub trait AstBuilder {
     fn expr_err(&self, span: Span, expr: P<ast::Expr>) -> P<ast::Expr>;
     fn expr_try(&self, span: Span, head: P<ast::Expr>) -> P<ast::Expr>;
 
-    fn pat(&self, span: Span, pat: ast::Pat_) -> P<ast::Pat>;
+    fn pat(&self, span: Span, pat: PatKind) -> P<ast::Pat>;
     fn pat_wild(&self, span: Span) -> P<ast::Pat>;
     fn pat_lit(&self, span: Span, expr: P<ast::Expr>) -> P<ast::Pat>;
     fn pat_ident(&self, span: Span, ident: ast::Ident) -> P<ast::Pat>;
@@ -805,14 +805,14 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     }
 
 
-    fn pat(&self, span: Span, pat: ast::Pat_) -> P<ast::Pat> {
+    fn pat(&self, span: Span, pat: PatKind) -> P<ast::Pat> {
         P(ast::Pat { id: ast::DUMMY_NODE_ID, node: pat, span: span })
     }
     fn pat_wild(&self, span: Span) -> P<ast::Pat> {
-        self.pat(span, ast::PatWild)
+        self.pat(span, PatKind::Wild)
     }
     fn pat_lit(&self, span: Span, expr: P<ast::Expr>) -> P<ast::Pat> {
-        self.pat(span, ast::PatLit(expr))
+        self.pat(span, PatKind::Lit(expr))
     }
     fn pat_ident(&self, span: Span, ident: ast::Ident) -> P<ast::Pat> {
         let binding_mode = ast::BindingMode::ByValue(ast::Mutability::Immutable);
@@ -823,20 +823,20 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                               span: Span,
                               ident: ast::Ident,
                               bm: ast::BindingMode) -> P<ast::Pat> {
-        let pat = ast::PatIdent(bm, Spanned{span: span, node: ident}, None);
+        let pat = PatKind::Ident(bm, Spanned{span: span, node: ident}, None);
         self.pat(span, pat)
     }
     fn pat_enum(&self, span: Span, path: ast::Path, subpats: Vec<P<ast::Pat>>) -> P<ast::Pat> {
-        let pat = ast::PatEnum(path, Some(subpats));
+        let pat = PatKind::Enum(path, Some(subpats));
         self.pat(span, pat)
     }
     fn pat_struct(&self, span: Span,
                   path: ast::Path, field_pats: Vec<Spanned<ast::FieldPat>>) -> P<ast::Pat> {
-        let pat = ast::PatStruct(path, field_pats, false);
+        let pat = PatKind::Struct(path, field_pats, false);
         self.pat(span, pat)
     }
     fn pat_tuple(&self, span: Span, pats: Vec<P<ast::Pat>>) -> P<ast::Pat> {
-        self.pat(span, ast::PatTup(pats))
+        self.pat(span, PatKind::Tup(pats))
     }
 
     fn pat_some(&self, span: Span, pat: P<ast::Pat>) -> P<ast::Pat> {

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -827,7 +827,11 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         self.pat(span, pat)
     }
     fn pat_enum(&self, span: Span, path: ast::Path, subpats: Vec<P<ast::Pat>>) -> P<ast::Pat> {
-        let pat = PatKind::Enum(path, Some(subpats));
+        let pat = if subpats.is_empty() {
+            PatKind::Path(path)
+        } else {
+            PatKind::TupleStruct(path, Some(subpats))
+        };
         self.pat(span, pat)
     }
     fn pat_struct(&self, span: Span,

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -27,7 +27,7 @@ use self::AttributeType::*;
 use self::AttributeGate::*;
 
 use abi::Abi;
-use ast::NodeId;
+use ast::{NodeId, PatKind};
 use ast;
 use attr;
 use attr::AttrMetaMethods;
@@ -1005,19 +1005,19 @@ impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
 
     fn visit_pat(&mut self, pattern: &ast::Pat) {
         match pattern.node {
-            ast::PatVec(_, Some(_), ref last) if !last.is_empty() => {
+            PatKind::Vec(_, Some(_), ref last) if !last.is_empty() => {
                 self.gate_feature("advanced_slice_patterns",
                                   pattern.span,
                                   "multiple-element slice matches anywhere \
                                    but at the end of a slice (e.g. \
                                    `[0, ..xs, 0]`) are experimental")
             }
-            ast::PatVec(..) => {
+            PatKind::Vec(..) => {
                 self.gate_feature("slice_patterns",
                                   pattern.span,
                                   "slice pattern syntax is experimental");
             }
-            ast::PatBox(..) => {
+            PatKind::Box(..) => {
                 self.gate_feature("box_patterns",
                                   pattern.span,
                                   "box pattern syntax is experimental");

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -1119,23 +1119,23 @@ pub fn noop_fold_pat<T: Folder>(p: P<Pat>, folder: &mut T) -> P<Pat> {
     p.map(|Pat {id, node, span}| Pat {
         id: folder.new_id(id),
         node: match node {
-            PatWild => PatWild,
-            PatIdent(binding_mode, pth1, sub) => {
-                PatIdent(binding_mode,
+            PatKind::Wild => PatKind::Wild,
+            PatKind::Ident(binding_mode, pth1, sub) => {
+                PatKind::Ident(binding_mode,
                         Spanned{span: folder.new_span(pth1.span),
                                 node: folder.fold_ident(pth1.node)},
                         sub.map(|x| folder.fold_pat(x)))
             }
-            PatLit(e) => PatLit(folder.fold_expr(e)),
-            PatEnum(pth, pats) => {
-                PatEnum(folder.fold_path(pth),
+            PatKind::Lit(e) => PatKind::Lit(folder.fold_expr(e)),
+            PatKind::Enum(pth, pats) => {
+                PatKind::Enum(folder.fold_path(pth),
                         pats.map(|pats| pats.move_map(|x| folder.fold_pat(x))))
             }
-            PatQPath(qself, pth) => {
+            PatKind::QPath(qself, pth) => {
                 let qself = QSelf {ty: folder.fold_ty(qself.ty), .. qself};
-                PatQPath(qself, folder.fold_path(pth))
+                PatKind::QPath(qself, folder.fold_path(pth))
             }
-            PatStruct(pth, fields, etc) => {
+            PatKind::Struct(pth, fields, etc) => {
                 let pth = folder.fold_path(pth);
                 let fs = fields.move_map(|f| {
                     Spanned { span: folder.new_span(f.span),
@@ -1145,20 +1145,20 @@ pub fn noop_fold_pat<T: Folder>(p: P<Pat>, folder: &mut T) -> P<Pat> {
                                   is_shorthand: f.node.is_shorthand,
                               }}
                 });
-                PatStruct(pth, fs, etc)
+                PatKind::Struct(pth, fs, etc)
             }
-            PatTup(elts) => PatTup(elts.move_map(|x| folder.fold_pat(x))),
-            PatBox(inner) => PatBox(folder.fold_pat(inner)),
-            PatRegion(inner, mutbl) => PatRegion(folder.fold_pat(inner), mutbl),
-            PatRange(e1, e2) => {
-                PatRange(folder.fold_expr(e1), folder.fold_expr(e2))
+            PatKind::Tup(elts) => PatKind::Tup(elts.move_map(|x| folder.fold_pat(x))),
+            PatKind::Box(inner) => PatKind::Box(folder.fold_pat(inner)),
+            PatKind::Ref(inner, mutbl) => PatKind::Ref(folder.fold_pat(inner), mutbl),
+            PatKind::Range(e1, e2) => {
+                PatKind::Range(folder.fold_expr(e1), folder.fold_expr(e2))
             },
-            PatVec(before, slice, after) => {
-                PatVec(before.move_map(|x| folder.fold_pat(x)),
+            PatKind::Vec(before, slice, after) => {
+                PatKind::Vec(before.move_map(|x| folder.fold_pat(x)),
                        slice.map(|x| folder.fold_pat(x)),
                        after.move_map(|x| folder.fold_pat(x)))
             }
-            PatMac(mac) => PatMac(folder.fold_mac(mac))
+            PatKind::Mac(mac) => PatKind::Mac(folder.fold_mac(mac))
         },
         span: folder.new_span(span)
     })

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -1127,9 +1127,12 @@ pub fn noop_fold_pat<T: Folder>(p: P<Pat>, folder: &mut T) -> P<Pat> {
                         sub.map(|x| folder.fold_pat(x)))
             }
             PatKind::Lit(e) => PatKind::Lit(folder.fold_expr(e)),
-            PatKind::Enum(pth, pats) => {
-                PatKind::Enum(folder.fold_path(pth),
+            PatKind::TupleStruct(pth, pats) => {
+                PatKind::TupleStruct(folder.fold_path(pth),
                         pats.map(|pats| pats.move_map(|x| folder.fold_pat(x))))
+            }
+            PatKind::Path(pth) => {
+                PatKind::Path(folder.fold_path(pth))
             }
             PatKind::QPath(qself, pth) => {
                 let qself = QSelf {ty: folder.fold_ty(qself.ty), .. qself};

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -675,7 +675,7 @@ mod tests {
     use super::*;
     use std::rc::Rc;
     use codemap::{Span, BytePos, Pos, Spanned, NO_EXPANSION};
-    use ast::{self, TokenTree};
+    use ast::{self, TokenTree, PatKind};
     use abi::Abi;
     use attr::{first_attr_value_str_by_name, AttrMetaMethods};
     use parse;
@@ -896,7 +896,7 @@ mod tests {
         assert!(panictry!(parser.parse_pat())
                 == P(ast::Pat{
                 id: ast::DUMMY_NODE_ID,
-                node: ast::PatIdent(ast::BindingMode::ByValue(ast::Mutability::Immutable),
+                node: PatKind::Ident(ast::BindingMode::ByValue(ast::Mutability::Immutable),
                                     Spanned{ span:sp(0, 1),
                                              node: str_to_ident("b")
                     },
@@ -931,7 +931,7 @@ mod tests {
                                     }),
                                     pat: P(ast::Pat {
                                         id: ast::DUMMY_NODE_ID,
-                                        node: ast::PatIdent(
+                                        node: PatKind::Ident(
                                             ast::BindingMode::ByValue(ast::Mutability::Immutable),
                                                 Spanned{
                                                     span: sp(6,7),
@@ -1020,7 +1020,7 @@ mod tests {
         impl<'v> ::visit::Visitor<'v> for PatIdentVisitor {
             fn visit_pat(&mut self, p: &'v ast::Pat) {
                 match p.node {
-                    ast::PatIdent(_ , ref spannedident, _) => {
+                    PatKind::Ident(_ , ref spannedident, _) => {
                         self.spans.push(spannedident.span.clone());
                     }
                     _ => {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3534,14 +3534,14 @@ impl<'a> Parser<'a> {
                             self.bump();
                             self.bump();
                             try!(self.expect(&token::CloseDelim(token::Paren)));
-                            pat = PatKind::Enum(path, None);
+                            pat = PatKind::TupleStruct(path, None);
                         } else {
                             let args = try!(self.parse_enum_variant_seq(
                                     &token::OpenDelim(token::Paren),
                                     &token::CloseDelim(token::Paren),
                                     seq_sep_trailing_allowed(token::Comma),
                                     |p| p.parse_pat()));
-                            pat = PatKind::Enum(path, Some(args));
+                            pat = PatKind::TupleStruct(path, Some(args));
                         }
                       }
                       _ => {
@@ -3549,7 +3549,7 @@ impl<'a> Parser<'a> {
                             // Parse qualified path
                             Some(qself) => PatKind::QPath(qself, path),
                             // Parse nullary enum
-                            None => PatKind::Enum(path, Some(vec![]))
+                            None => PatKind::Path(path)
                         };
                       }
                     }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -30,8 +30,7 @@ use ast::MacStmtStyle;
 use ast::Mac_;
 use ast::{MutTy, Mutability};
 use ast::NamedField;
-use ast::{Pat, PatBox, PatEnum, PatIdent, PatLit, PatQPath, PatMac, PatRange};
-use ast::{PatRegion, PatStruct, PatTup, PatVec, PatWild};
+use ast::{Pat, PatKind};
 use ast::{PolyTraitRef, QSelf};
 use ast::{Stmt, StmtKind};
 use ast::{VariantData, StructField};
@@ -3292,7 +3291,7 @@ impl<'a> Parser<'a> {
                             self.check(&token::CloseDelim(token::Bracket)) {
                         slice = Some(P(ast::Pat {
                             id: ast::DUMMY_NODE_ID,
-                            node: PatWild,
+                            node: PatKind::Wild,
                             span: self.span,
                         }));
                         before_slice = false;
@@ -3370,14 +3369,14 @@ impl<'a> Parser<'a> {
                 let fieldpath = codemap::Spanned{span:self.last_span, node:fieldname};
                 let fieldpat = P(ast::Pat{
                     id: ast::DUMMY_NODE_ID,
-                    node: PatIdent(bind_type, fieldpath, None),
+                    node: PatKind::Ident(bind_type, fieldpath, None),
                     span: mk_sp(boxed_span_lo, hi),
                 });
 
                 let subpat = if is_box {
                     P(ast::Pat{
                         id: ast::DUMMY_NODE_ID,
-                        node: PatBox(fieldpat),
+                        node: PatKind::Box(fieldpat),
                         span: mk_sp(lo, hi),
                     })
                 } else {
@@ -3429,7 +3428,7 @@ impl<'a> Parser<'a> {
           token::Underscore => {
             // Parse _
             self.bump();
-            pat = PatWild;
+            pat = PatKind::Wild;
           }
           token::BinOp(token::And) | token::AndAnd => {
             // Parse &pat / &mut pat
@@ -3440,21 +3439,21 @@ impl<'a> Parser<'a> {
             }
 
             let subpat = try!(self.parse_pat());
-            pat = PatRegion(subpat, mutbl);
+            pat = PatKind::Ref(subpat, mutbl);
           }
           token::OpenDelim(token::Paren) => {
             // Parse (pat,pat,pat,...) as tuple pattern
             self.bump();
             let fields = try!(self.parse_pat_tuple_elements());
             try!(self.expect(&token::CloseDelim(token::Paren)));
-            pat = PatTup(fields);
+            pat = PatKind::Tup(fields);
           }
           token::OpenDelim(token::Bracket) => {
             // Parse [pat,pat,...] as slice pattern
             self.bump();
             let (before, slice, after) = try!(self.parse_pat_vec_elements());
             try!(self.expect(&token::CloseDelim(token::Bracket)));
-            pat = PatVec(before, slice, after);
+            pat = PatKind::Vec(before, slice, after);
           }
           _ => {
             // At this point, token != _, &, &&, (, [
@@ -3468,7 +3467,7 @@ impl<'a> Parser<'a> {
             } else if self.eat_keyword(keywords::Box) {
                 // Parse box pat
                 let subpat = try!(self.parse_pat());
-                pat = PatBox(subpat);
+                pat = PatKind::Box(subpat);
             } else if self.is_path_start() {
                 // Parse pattern starting with a path
                 if self.token.is_plain_ident() && self.look_ahead(1, |t| *t != token::DotDotDot &&
@@ -3487,7 +3486,7 @@ impl<'a> Parser<'a> {
                         let tts = try!(self.parse_seq_to_end(&token::CloseDelim(delim),
                                 seq_sep_none(), |p| p.parse_token_tree()));
                         let mac = Mac_ { path: path, tts: tts, ctxt: EMPTY_CTXT };
-                        pat = PatMac(codemap::Spanned {node: mac,
+                        pat = PatKind::Mac(codemap::Spanned {node: mac,
                                                        span: mk_sp(lo, self.last_span.hi)});
                     } else {
                         // Parse ident @ pat
@@ -3513,7 +3512,7 @@ impl<'a> Parser<'a> {
                         let begin = self.mk_expr(lo, hi, ExprKind::Path(qself, path), None);
                         self.bump();
                         let end = try!(self.parse_pat_range_end());
-                        pat = PatRange(begin, end);
+                        pat = PatKind::Range(begin, end);
                       }
                       token::OpenDelim(token::Brace) => {
                          if qself.is_some() {
@@ -3523,7 +3522,7 @@ impl<'a> Parser<'a> {
                         self.bump();
                         let (fields, etc) = try!(self.parse_pat_fields());
                         self.bump();
-                        pat = PatStruct(path, fields, etc);
+                        pat = PatKind::Struct(path, fields, etc);
                       }
                       token::OpenDelim(token::Paren) => {
                         if qself.is_some() {
@@ -3535,22 +3534,22 @@ impl<'a> Parser<'a> {
                             self.bump();
                             self.bump();
                             try!(self.expect(&token::CloseDelim(token::Paren)));
-                            pat = PatEnum(path, None);
+                            pat = PatKind::Enum(path, None);
                         } else {
                             let args = try!(self.parse_enum_variant_seq(
                                     &token::OpenDelim(token::Paren),
                                     &token::CloseDelim(token::Paren),
                                     seq_sep_trailing_allowed(token::Comma),
                                     |p| p.parse_pat()));
-                            pat = PatEnum(path, Some(args));
+                            pat = PatKind::Enum(path, Some(args));
                         }
                       }
                       _ => {
                         pat = match qself {
                             // Parse qualified path
-                            Some(qself) => PatQPath(qself, path),
+                            Some(qself) => PatKind::QPath(qself, path),
                             // Parse nullary enum
-                            None => PatEnum(path, Some(vec![]))
+                            None => PatKind::Enum(path, Some(vec![]))
                         };
                       }
                     }
@@ -3560,9 +3559,9 @@ impl<'a> Parser<'a> {
                 let begin = try!(self.parse_pat_literal_maybe_minus());
                 if self.eat(&token::DotDotDot) {
                     let end = try!(self.parse_pat_range_end());
-                    pat = PatRange(begin, end);
+                    pat = PatKind::Range(begin, end);
                 } else {
-                    pat = PatLit(begin);
+                    pat = PatKind::Lit(begin);
                 }
             }
           }
@@ -3581,7 +3580,7 @@ impl<'a> Parser<'a> {
     /// error message when parsing mistakes like ref foo(a,b)
     fn parse_pat_ident(&mut self,
                        binding_mode: ast::BindingMode)
-                       -> PResult<'a, ast::Pat_> {
+                       -> PResult<'a, PatKind> {
         if !self.token.is_plain_ident() {
             let span = self.span;
             let tok_str = self.this_token_to_string();
@@ -3610,7 +3609,7 @@ impl<'a> Parser<'a> {
                 "expected identifier, found enum pattern"))
         }
 
-        Ok(PatIdent(binding_mode, name, sub))
+        Ok(PatKind::Ident(binding_mode, name, sub))
     }
 
     /// Parse a local variable declaration

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -11,7 +11,7 @@
 pub use self::AnnNode::*;
 
 use abi::{self, Abi};
-use ast::{self, TokenTree, BlockCheckMode};
+use ast::{self, TokenTree, BlockCheckMode, PatKind};
 use ast::{RegionTyParamBound, TraitTyParamBound, TraitBoundModifier};
 use ast::Attribute;
 use attr::ThinAttributesExt;
@@ -2457,8 +2457,8 @@ impl<'a> State<'a> {
         /* Pat isn't normalized, but the beauty of it
          is that it doesn't matter */
         match pat.node {
-            ast::PatWild => try!(word(&mut self.s, "_")),
-            ast::PatIdent(binding_mode, ref path1, ref sub) => {
+            PatKind::Wild => try!(word(&mut self.s, "_")),
+            PatKind::Ident(binding_mode, ref path1, ref sub) => {
                 match binding_mode {
                     ast::BindingMode::ByRef(mutbl) => {
                         try!(self.word_nbsp("ref"));
@@ -2478,7 +2478,7 @@ impl<'a> State<'a> {
                     None => ()
                 }
             }
-            ast::PatEnum(ref path, ref args_) => {
+            PatKind::Enum(ref path, ref args_) => {
                 try!(self.print_path(path, true, 0));
                 match *args_ {
                     None => try!(word(&mut self.s, "(..)")),
@@ -2492,10 +2492,10 @@ impl<'a> State<'a> {
                     }
                 }
             }
-            ast::PatQPath(ref qself, ref path) => {
+            PatKind::QPath(ref qself, ref path) => {
                 try!(self.print_qpath(path, qself, false));
             }
-            ast::PatStruct(ref path, ref fields, etc) => {
+            PatKind::Struct(ref path, ref fields, etc) => {
                 try!(self.print_path(path, true, 0));
                 try!(self.nbsp());
                 try!(self.word_space("{"));
@@ -2518,7 +2518,7 @@ impl<'a> State<'a> {
                 try!(space(&mut self.s));
                 try!(word(&mut self.s, "}"));
             }
-            ast::PatTup(ref elts) => {
+            PatKind::Tup(ref elts) => {
                 try!(self.popen());
                 try!(self.commasep(Inconsistent,
                                    &elts[..],
@@ -2528,32 +2528,32 @@ impl<'a> State<'a> {
                 }
                 try!(self.pclose());
             }
-            ast::PatBox(ref inner) => {
+            PatKind::Box(ref inner) => {
                 try!(word(&mut self.s, "box "));
                 try!(self.print_pat(&inner));
             }
-            ast::PatRegion(ref inner, mutbl) => {
+            PatKind::Ref(ref inner, mutbl) => {
                 try!(word(&mut self.s, "&"));
                 if mutbl == ast::Mutability::Mutable {
                     try!(word(&mut self.s, "mut "));
                 }
                 try!(self.print_pat(&inner));
             }
-            ast::PatLit(ref e) => try!(self.print_expr(&e)),
-            ast::PatRange(ref begin, ref end) => {
+            PatKind::Lit(ref e) => try!(self.print_expr(&**e)),
+            PatKind::Range(ref begin, ref end) => {
                 try!(self.print_expr(&begin));
                 try!(space(&mut self.s));
                 try!(word(&mut self.s, "..."));
                 try!(self.print_expr(&end));
             }
-            ast::PatVec(ref before, ref slice, ref after) => {
+            PatKind::Vec(ref before, ref slice, ref after) => {
                 try!(word(&mut self.s, "["));
                 try!(self.commasep(Inconsistent,
                                    &before[..],
                                    |s, p| s.print_pat(&p)));
                 if let Some(ref p) = *slice {
                     if !before.is_empty() { try!(self.word_space(",")); }
-                    if p.node != ast::PatWild {
+                    if p.node != PatKind::Wild {
                         try!(self.print_pat(&p));
                     }
                     try!(word(&mut self.s, ".."));
@@ -2564,7 +2564,7 @@ impl<'a> State<'a> {
                                    |s, p| s.print_pat(&p)));
                 try!(word(&mut self.s, "]"));
             }
-            ast::PatMac(ref m) => try!(self.print_mac(m, token::Paren)),
+            PatKind::Mac(ref m) => try!(self.print_mac(m, token::Paren)),
         }
         self.ann.post(self, NodePat(pat))
     }
@@ -2671,7 +2671,7 @@ impl<'a> State<'a> {
             let m = match *explicit_self {
                 ast::SelfKind::Static => ast::Mutability::Immutable,
                 _ => match decl.inputs[0].pat.node {
-                    ast::PatIdent(ast::BindingMode::ByValue(m), _, _) => m,
+                    PatKind::Ident(ast::BindingMode::ByValue(m), _, _) => m,
                     _ => ast::Mutability::Immutable
                 }
             };
@@ -2962,7 +2962,7 @@ impl<'a> State<'a> {
             ast::TyKind::Infer if is_closure => try!(self.print_pat(&input.pat)),
             _ => {
                 match input.pat.node {
-                    ast::PatIdent(_, ref path1, _) if
+                    PatKind::Ident(_, ref path1, _) if
                         path1.node.name ==
                             parse::token::special_idents::invalid.name => {
                         // Do nothing.

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2478,19 +2478,20 @@ impl<'a> State<'a> {
                     None => ()
                 }
             }
-            PatKind::Enum(ref path, ref args_) => {
+            PatKind::TupleStruct(ref path, ref args_) => {
                 try!(self.print_path(path, true, 0));
                 match *args_ {
                     None => try!(word(&mut self.s, "(..)")),
                     Some(ref args) => {
-                        if !args.is_empty() {
-                            try!(self.popen());
-                            try!(self.commasep(Inconsistent, &args[..],
-                                              |s, p| s.print_pat(&p)));
-                            try!(self.pclose());
-                        }
+                        try!(self.popen());
+                        try!(self.commasep(Inconsistent, &args[..],
+                                          |s, p| s.print_pat(&p)));
+                        try!(self.pclose());
                     }
                 }
+            }
+            PatKind::Path(ref path) => {
+                try!(self.print_path(path, true, 0));
             }
             PatKind::QPath(ref qself, ref path) => {
                 try!(self.print_qpath(path, qself, false));

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -419,46 +419,46 @@ pub fn walk_assoc_type_binding<'v, V: Visitor<'v>>(visitor: &mut V,
 
 pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat) {
     match pattern.node {
-        PatEnum(ref path, ref opt_children) => {
+        PatKind::Enum(ref path, ref opt_children) => {
             visitor.visit_path(path, pattern.id);
             if let Some(ref children) = *opt_children {
                 walk_list!(visitor, visit_pat, children);
             }
         }
-        PatQPath(ref qself, ref path) => {
+        PatKind::QPath(ref qself, ref path) => {
             visitor.visit_ty(&qself.ty);
             visitor.visit_path(path, pattern.id)
         }
-        PatStruct(ref path, ref fields, _) => {
+        PatKind::Struct(ref path, ref fields, _) => {
             visitor.visit_path(path, pattern.id);
             for field in fields {
                 visitor.visit_ident(field.span, field.node.ident);
                 visitor.visit_pat(&field.node.pat)
             }
         }
-        PatTup(ref tuple_elements) => {
+        PatKind::Tup(ref tuple_elements) => {
             walk_list!(visitor, visit_pat, tuple_elements);
         }
-        PatBox(ref subpattern) |
-        PatRegion(ref subpattern, _) => {
+        PatKind::Box(ref subpattern) |
+        PatKind::Ref(ref subpattern, _) => {
             visitor.visit_pat(subpattern)
         }
-        PatIdent(_, ref pth1, ref optional_subpattern) => {
+        PatKind::Ident(_, ref pth1, ref optional_subpattern) => {
             visitor.visit_ident(pth1.span, pth1.node);
             walk_list!(visitor, visit_pat, optional_subpattern);
         }
-        PatLit(ref expression) => visitor.visit_expr(expression),
-        PatRange(ref lower_bound, ref upper_bound) => {
+        PatKind::Lit(ref expression) => visitor.visit_expr(expression),
+        PatKind::Range(ref lower_bound, ref upper_bound) => {
             visitor.visit_expr(lower_bound);
             visitor.visit_expr(upper_bound)
         }
-        PatWild => (),
-        PatVec(ref prepatterns, ref slice_pattern, ref postpatterns) => {
+        PatKind::Wild => (),
+        PatKind::Vec(ref prepatterns, ref slice_pattern, ref postpatterns) => {
             walk_list!(visitor, visit_pat, prepatterns);
             walk_list!(visitor, visit_pat, slice_pattern);
             walk_list!(visitor, visit_pat, postpatterns);
         }
-        PatMac(ref mac) => visitor.visit_mac(mac),
+        PatKind::Mac(ref mac) => visitor.visit_mac(mac),
     }
 }
 

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -419,11 +419,14 @@ pub fn walk_assoc_type_binding<'v, V: Visitor<'v>>(visitor: &mut V,
 
 pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat) {
     match pattern.node {
-        PatKind::Enum(ref path, ref opt_children) => {
+        PatKind::TupleStruct(ref path, ref opt_children) => {
             visitor.visit_path(path, pattern.id);
             if let Some(ref children) = *opt_children {
                 walk_list!(visitor, visit_pat, children);
             }
+        }
+        PatKind::Path(ref path) => {
+            visitor.visit_path(path, pattern.id);
         }
         PatKind::QPath(ref qself, ref path) => {
             visitor.visit_ty(&qself.ty);

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -193,7 +193,7 @@ use std::collections::HashSet;
 use std::vec;
 
 use syntax::abi::Abi;
-use syntax::ast::{EnumDef, Expr, Ident, Generics, VariantData, BinOpKind, self};
+use syntax::ast::{self, EnumDef, Expr, Ident, Generics, VariantData, BinOpKind, PatKind};
 use syntax::ast_util;
 use syntax::attr;
 use syntax::attr::AttrMetaMethods;
@@ -1142,7 +1142,7 @@ impl<'a> MethodDef<'a> {
                         variant,
                         self_arg_name,
                         ast::Mutability::Immutable);
-                    (cx.pat(sp, ast::PatRegion(p, ast::Mutability::Immutable)), idents)
+                    (cx.pat(sp, PatKind::Ref(p, ast::Mutability::Immutable)), idents)
                 };
 
                 // A single arm has form (&VariantK, &VariantK, ...) => BodyK
@@ -1472,7 +1472,7 @@ impl<'a> TraitDef<'a> {
                           -> Vec<P<ast::Pat>> {
         field_paths.iter().map(|path| {
             cx.pat(path.span,
-                        ast::PatIdent(ast::BindingMode::ByRef(mutbl), (*path).clone(), None))
+                        PatKind::Ident(ast::BindingMode::ByRef(mutbl), (*path).clone(), None))
         }).collect()
     }
 


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/pull/31487#issuecomment-182945101
plugin-[breaking-change]

The first commit renames `ast::Pat_` to `ast::PatKind` and uses its variants in enum qualified form. I've also taken the opportunity and renamed `PatKind::Region` into `PatKind::Ref`.

The second commit splits `PatKind::Enum` into `PatKind::TupleStruct` and `PatKind::UnitStruct`.
So, pattern kinds now correspond to their struct/variant kinds - `Struct`, `TupleStruct` and `UnitStruct`.
@nikomatsakis @nrc @arielb1 Are you okay with this naming scheme?
An alternative possible naming scheme is `PatKind::StructVariant`, `PatKind::TupleVariant`, `PatKind::UnitVariant` (it's probably closer to the common use, but I like it less).

I intend to apply these changes to HIR later, they should not necessarily go in the same nightly with https://github.com/rust-lang/rust/pull/31487
r? @Manishearth 
