### PR TITLE
Move FulfillmentContext out of InferCtxt

### DIFF
--- a/src/librustc/middle/infer/mod.rs
+++ b/src/librustc/middle/infer/mod.rs
@@ -88,8 +88,6 @@ pub struct InferCtxt<'a, 'tcx: 'a> {
 
     pub parameter_environment: ty::ParameterEnvironment<'a, 'tcx>,
 
-    pub fulfillment_cx: RefCell<traits::FulfillmentContext<'tcx>>,
-
     // the set of predicates on which errors have been reported, to
     // avoid reporting the same error twice.
     pub reported_trait_errors: RefCell<FnvHashSet<traits::TraitErrorKey<'tcx>>>,
@@ -366,7 +364,6 @@ pub fn new_infer_ctxt<'a, 'tcx>(tcx: &'a ty::ctxt<'tcx>,
         float_unification_table: RefCell::new(UnificationTable::new()),
         region_vars: RegionVarBindings::new(tcx),
         parameter_environment: param_env.unwrap_or(tcx.empty_parameter_environment()),
-        fulfillment_cx: RefCell::new(traits::FulfillmentContext::new()),
         reported_trait_errors: RefCell::new(FnvHashSet()),
         normalize: false,
         err_count_on_creation: tcx.sess.err_count()
@@ -525,7 +522,7 @@ pub fn normalize_associated_type<'tcx,T>(tcx: &ty::ctxt<'tcx>, value: &T) -> T
            result,
            obligations);
 
-    let mut fulfill_cx = infcx.fulfillment_cx.borrow_mut();
+    let mut fulfill_cx = traits::FulfillmentContext::new();
 
     for obligation in obligations {
         fulfill_cx.register_predicate_obligation(&infcx, obligation);

--- a/src/librustc/middle/traits/fulfill.rs
+++ b/src/librustc/middle/traits/fulfill.rs
@@ -133,7 +133,7 @@ impl<'tcx> FulfillmentContext<'tcx> {
                                          cause: ObligationCause<'tcx>)
                                          -> Ty<'tcx>
     {
-        debug!("normalize_associated_type(projection_ty={:?})",
+        debug!("normalize_projection_type(projection_ty={:?})",
                projection_ty);
 
         assert!(!projection_ty.has_escaping_regions());
@@ -147,7 +147,7 @@ impl<'tcx> FulfillmentContext<'tcx> {
             self.register_predicate_obligation(infcx, obligation);
         }
 
-        debug!("normalize_associated_type: result={:?}", normalized.value);
+        debug!("normalize_projection_type: result={:?}", normalized.value);
 
         normalized.value
     }
@@ -185,11 +185,11 @@ impl<'tcx> FulfillmentContext<'tcx> {
         assert!(!obligation.has_escaping_regions());
 
         if self.is_duplicate_or_add(infcx.tcx, &obligation.predicate) {
-            debug!("register_predicate({:?}) -- already seen, skip", obligation);
+            debug!("register_predicate_obligation({:?}) -- already seen, skip", obligation);
             return;
         }
 
-        debug!("register_predicate({:?})", obligation);
+        debug!("register_predicate_obligation({:?})", obligation);
         let obligation = PendingPredicateObligation {
             obligation: obligation,
             stalled_on: vec![]
@@ -274,7 +274,7 @@ impl<'tcx> FulfillmentContext<'tcx> {
         let mut errors = Vec::new();
 
         loop {
-            debug!("select_where_possible: starting another iteration");
+            debug!("select: starting another iteration");
 
             // Process pending obligations.
             let outcome = {
@@ -287,7 +287,7 @@ impl<'tcx> FulfillmentContext<'tcx> {
                                                                      region_obligations))
             };
 
-            debug!("select_where_possible: outcome={:?}", outcome);
+            debug!("select: outcome={:?}", outcome);
 
             // these are obligations that were proven to be true.
             for pending_obligation in outcome.completed {

--- a/src/librustc_passes/consts.rs
+++ b/src/librustc_passes/consts.rs
@@ -249,9 +249,9 @@ impl<'a, 'tcx> CheckCrateVisitor<'a, 'tcx> {
         let ty = self.tcx.node_id_to_type(e.id);
         let infcx = infer::new_infer_ctxt(self.tcx, &self.tcx.tables, None);
         let cause = traits::ObligationCause::new(e.span, e.id, traits::SharedStatic);
-        let mut fulfill_cx = infcx.fulfillment_cx.borrow_mut();
-        fulfill_cx.register_builtin_bound(&infcx, ty, ty::BoundSync, cause);
-        match fulfill_cx.select_all_or_error(&infcx) {
+        let mut fulfillment_cx = traits::FulfillmentContext::new();
+        fulfillment_cx.register_builtin_bound(&infcx, ty, ty::BoundSync, cause);
+        match fulfillment_cx.select_all_or_error(&infcx) {
             Ok(()) => { },
             Err(ref errors) => {
                 traits::report_fulfillment_errors(&infcx, errors);

--- a/src/librustc_trans/trans/common.rs
+++ b/src/librustc_trans/trans/common.rs
@@ -1159,7 +1159,7 @@ pub fn fulfill_obligation<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     // Currently, we use a fulfillment context to completely resolve
     // all nested obligations. This is because they can inform the
     // inference of the impl's type parameters.
-    let mut fulfill_cx = infcx.fulfillment_cx.borrow_mut();
+    let mut fulfill_cx = traits::FulfillmentContext::new();
     let vtable = selection.map(|predicate| {
         fulfill_cx.register_predicate_obligation(&infcx, predicate);
     });
@@ -1188,7 +1188,7 @@ pub fn normalize_and_test_predicates<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     let tcx = ccx.tcx();
     let infcx = infer::normalizing_infer_ctxt(tcx, &tcx.tables);
     let mut selcx = traits::SelectionContext::new(&infcx);
-    let mut fulfill_cx = infcx.fulfillment_cx.borrow_mut();
+    let mut fulfill_cx = traits::FulfillmentContext::new();
     let cause = traits::ObligationCause::dummy();
     let traits::Normalized { value: predicates, obligations } =
         traits::normalize(&mut selcx, cause.clone(), &predicates);

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -134,7 +134,7 @@ fn deduce_expectations_from_obligations<'a,'tcx>(
     expected_vid: ty::TyVid)
     -> (Option<ty::FnSig<'tcx>>, Option<ty::ClosureKind>)
 {
-    let fulfillment_cx = fcx.inh.infcx.fulfillment_cx.borrow();
+    let fulfillment_cx = fcx.inh.fulfillment_cx.borrow();
     // Here `expected_ty` is known to be a type inference variable.
 
     let expected_sig =

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -43,7 +43,7 @@ pub fn compare_impl_method<'tcx>(tcx: &ty::ctxt<'tcx>,
            impl_trait_ref);
 
     let mut infcx = infer::new_infer_ctxt(tcx, &tcx.tables, None);
-    let mut fulfillment_cx = infcx.fulfillment_cx.borrow_mut();
+    let mut fulfillment_cx = traits::FulfillmentContext::new();
 
     let trait_to_impl_substs = &impl_trait_ref.substs;
 
@@ -417,7 +417,7 @@ pub fn compare_const_impl<'tcx>(tcx: &ty::ctxt<'tcx>,
            impl_trait_ref);
 
     let infcx = infer::new_infer_ctxt(tcx, &tcx.tables, None);
-    let mut fulfillment_cx = infcx.fulfillment_cx.borrow_mut();
+    let mut fulfillment_cx = traits::FulfillmentContext::new();
 
     // The below is for the most part highly similar to the procedure
     // for methods above. It is simpler in many respects, especially

--- a/src/librustc_typeck/check/dropck.rs
+++ b/src/librustc_typeck/check/dropck.rs
@@ -84,6 +84,7 @@ fn ensure_drop_params_and_item_params_correspond<'tcx>(
 
     let impl_param_env = ty::ParameterEnvironment::for_item(tcx, self_type_node_id);
     let infcx = infer::new_infer_ctxt(tcx, &tcx.tables, Some(impl_param_env));
+    let mut fulfillment_cx = traits::FulfillmentContext::new();
 
     let named_type = tcx.lookup_item_type(self_type_did).ty;
     let named_type = named_type.subst(tcx, &infcx.parameter_environment.free_substs);
@@ -105,7 +106,7 @@ fn ensure_drop_params_and_item_params_correspond<'tcx>(
         return Err(());
     }
 
-    if let Err(ref errors) = infcx.fulfillment_cx.borrow_mut().select_all_or_error(&infcx) {
+    if let Err(ref errors) = fulfillment_cx.select_all_or_error(&infcx) {
         // this could be reached when we get lazy normalization
         traits::report_fulfillment_errors(&infcx, errors);
         return Err(());

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -353,7 +353,6 @@ impl<'a, 'tcx> Rcx<'a, 'tcx> {
         let region_obligations =
             self.fcx
                 .inh
-                .infcx
                 .fulfillment_cx
                 .borrow()
                 .region_obligations(node_id)
@@ -369,7 +368,7 @@ impl<'a, 'tcx> Rcx<'a, 'tcx> {
 
         // Processing the region obligations should not cause the list to grow further:
         assert_eq!(region_obligations.len(),
-                   self.fcx.inh.infcx.fulfillment_cx.borrow().region_obligations(node_id).len());
+                   self.fcx.inh.fulfillment_cx.borrow().region_obligations(node_id).len());
     }
 
     fn code_to_origin(&self,

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -473,7 +473,7 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
                 }
             };
 
-            let mut fulfill_cx = infcx.fulfillment_cx.borrow_mut();
+            let mut fulfill_cx = traits::FulfillmentContext::new();
 
             // Register an obligation for `A: Trait<B>`.
             let cause = traits::ObligationCause::misc(span, impl_node_id);


### PR DESCRIPTION
<sup>**context:** moving back to a layered approach to type checking.</sup>

It looks like they'd not ended up tightly coupled in the time one was owned by the other. Every instance outside of `FnCtxt.inh` was from an `InferCtxt` created and dropped in the same function body.

This conflicts slightly with #30652, but there too it looks like the `FulfillmentContext` is from an `InferCtxt` that is created and dropped within the same function body (across one call to a module-private function).

That said, I heard that the PR that originally moved `FulfillmentContext` into `InferCtxt` was big, which leaves me concerned that I'm missing something.

r? @nikomatsakis
