### PR TITLE
Add `make clean` support to rustbuild

### DIFF
--- a/src/bootstrap/build/clean.rs
+++ b/src/bootstrap/build/clean.rs
@@ -1,0 +1,36 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::fs;
+use std::path::Path;
+
+use build::Build;
+
+pub fn clean(build: &Build) {
+    for host in build.config.host.iter() {
+
+        let out = build.out.join(host);
+
+        rm_rf(build, &out.join("compiler-rt"));
+
+        for stage in 0..4 {
+            rm_rf(build, &out.join(format!("stage{}", stage)));
+            rm_rf(build, &out.join(format!("stage{}-std", stage)));
+            rm_rf(build, &out.join(format!("stage{}-rustc", stage)));
+        }
+    }
+}
+
+fn rm_rf(build: &Build, path: &Path) {
+    if path.exists() {
+        build.verbose(&format!("removing `{}`", path.display()));
+        t!(fs::remove_dir_all(path));
+    }
+}

--- a/src/bootstrap/build/flags.rs
+++ b/src/bootstrap/build/flags.rs
@@ -26,6 +26,7 @@ pub struct Flags {
     pub src: Option<PathBuf>,
     pub jobs: Option<u32>,
     pub args: Vec<String>,
+    pub clean: bool,
 }
 
 pub struct Filter {
@@ -44,6 +45,7 @@ impl Flags {
         opts.optopt("", "stage", "stage to build", "N");
         opts.optopt("", "src", "path to repo root", "DIR");
         opts.optopt("j", "jobs", "number of jobs to run in parallel", "JOBS");
+        opts.optflag("", "clean", "clean output directory");
         opts.optflag("h", "help", "print this help message");
 
         let usage = |n| -> ! {
@@ -75,6 +77,7 @@ impl Flags {
 
         Flags {
             verbose: m.opt_present("v"),
+            clean: m.opt_present("clean"),
             stage: m.opt_str("stage").map(|j| j.parse().unwrap()),
             build: m.opt_str("build").unwrap(),
             host: Filter { values: m.opt_strs("host") },

--- a/src/bootstrap/build/mod.rs
+++ b/src/bootstrap/build/mod.rs
@@ -30,6 +30,7 @@ macro_rules! t {
 
 mod cc;
 mod channel;
+mod clean;
 mod compile;
 mod config;
 mod flags;
@@ -121,6 +122,10 @@ impl Build {
         }
         #[cfg(not(windows))] fn setup_job() {}
         setup_job();
+
+        if self.flags.clean {
+            return clean::clean(self);
+        }
 
         cc::find(self);
         sanity::check(self);

--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -21,3 +21,6 @@ BOOTSTRAP := $(CFG_PYTHON) $(CFG_SRC_DIR)src/bootstrap/bootstrap.py $(BOOTSTRAP_
 
 all:
 	$(Q)$(BOOTSTRAP)
+
+clean:
+	$(Q)$(BOOTSTRAP) --clean


### PR DESCRIPTION
At the same time also touch up the job management on Windows to be a little more resilient to failure.
