### PR TITLE
ensure that the assert! macro doesn't ICE on non-booleans

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -59,15 +59,14 @@ macro_rules! panic {
 #[stable(feature = "rust1", since = "1.0.0")]
 macro_rules! assert {
     ($cond:expr) => (
-        if !$cond {
-            panic!(concat!("assertion failed: ", stringify!($cond)))
-        }
+        assert!($cond, concat!("assertion failed: ", stringify!($cond)))
     );
-    ($cond:expr, $($arg:tt)+) => (
-        if !$cond {
+    ($cond:expr, $($arg:tt)+) => ({
+        let cond: bool = $cond;
+        if !cond {
             panic!($($arg)+)
         }
-    );
+    });
 }
 
 /// Asserts that two expressions are equal to each other.

--- a/src/librustc_trans/trans/builder.rs
+++ b/src/librustc_trans/trans/builder.rs
@@ -953,7 +953,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             let m: ModuleRef = llvm::LLVMGetGlobalParent(fn_);
             let p = "llvm.trap\0".as_ptr();
             let t: ValueRef = llvm::LLVMGetNamedFunction(m, p as *const _);
-            assert!((t as isize != 0));
+            assert!(t as isize != 0);
             let args: &[ValueRef] = &[];
             self.count_insn("trap");
             llvm::LLVMRustBuildCall(self.llbuilder, t,

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -413,12 +413,12 @@ impl<'a> Printer<'a> {
         } else {
             self.top += 1;
             self.top %= self.buf_len;
-            assert!((self.top != self.bottom));
+            assert!(self.top != self.bottom);
         }
         self.scan_stack[self.top] = x;
     }
     pub fn scan_pop(&mut self) -> usize {
-        assert!((!self.scan_stack_empty));
+        assert!(!self.scan_stack_empty);
         let x = self.scan_stack[self.top];
         if self.top == self.bottom {
             self.scan_stack_empty = true;
@@ -428,11 +428,11 @@ impl<'a> Printer<'a> {
         return x;
     }
     pub fn scan_top(&mut self) -> usize {
-        assert!((!self.scan_stack_empty));
+        assert!(!self.scan_stack_empty);
         return self.scan_stack[self.top];
     }
     pub fn scan_pop_bottom(&mut self) -> usize {
-        assert!((!self.scan_stack_empty));
+        assert!(!self.scan_stack_empty);
         let x = self.scan_stack[self.bottom];
         if self.top == self.bottom {
             self.scan_stack_empty = true;
@@ -444,7 +444,7 @@ impl<'a> Printer<'a> {
     pub fn advance_right(&mut self) {
         self.right += 1;
         self.right %= self.buf_len;
-        assert!((self.right != self.left));
+        assert!(self.right != self.left);
     }
     pub fn advance_left(&mut self) -> io::Result<()> {
         debug!("advance_left Vec<{},{}>, sizeof({})={}", self.left, self.right,
@@ -566,7 +566,7 @@ impl<'a> Printer<'a> {
           Token::End => {
             debug!("print End -> pop End");
             let print_stack = &mut self.print_stack;
-            assert!((!print_stack.is_empty()));
+            assert!(!print_stack.is_empty());
             print_stack.pop().unwrap();
             Ok(())
           }

--- a/src/test/compile-fail/assert_non_bool.rs
+++ b/src/test/compile-fail/assert_non_bool.rs
@@ -9,5 +9,7 @@
 // except according to those terms.
 
 fn main() {
-    assert!("foo"); //~ERROR: mismatched types
+    assert!(Ok(1)); //~ ERROR: mismatched types
+    assert!(true);
+    assert!(false);
 }

--- a/src/test/compile-fail/issue-14091-2.rs
+++ b/src/test/compile-fail/issue-14091-2.rs
@@ -8,19 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: cannot apply unary operator `!` to type `BytePos`
-
-// Very
-
-// sensitive
 pub struct BytePos(pub u32);
-
-// to particular
-
-// line numberings / offsets
 
 fn main() {
     let x = BytePos(1);
 
-    assert!(x, x);
+    assert!(x, x); //~ ERROR: mismatched types
 }


### PR DESCRIPTION
cc #31592

Note that this is not a fix, it exposes the span-bug even more. During stage1 `command-before-exec.rs` fails to run, because 

```
{...}x86_64-unknown-linux-gnu/test/run-pass/command-before-exec.stage1-x86_64-unknown-linux-gnu: symbol lookup error: {...}x86_64-unknown-linux-gnu/test/run-pass/command-before-exec.stage1-x86_64-unknown-linux-gnu: undefined symbol: _ZN6option15Option$LT$T$GT$6unwrap14_MSG_FILE_LINE20hc561c4c240f9e4ddnxOE
```

it works fine in stage2

---

This cannot be done for assert_eq, because ~~there's no way~~ I couldn't find a way to ensure two expressions have the same types without moving them into an array. `decltype` ftw
