### PR TITLE
Clarify what tx/rx mean in concurrency docs

### DIFF
--- a/src/doc/book/concurrency.md
+++ b/src/doc/book/concurrency.md
@@ -286,6 +286,8 @@ use std::sync::mpsc;
 fn main() {
     let data = Arc::new(Mutex::new(0));
 
+    // `tx` is the "transmitter" or "sender"
+    // `rx` is the "receiver"
     let (tx, rx) = mpsc::channel();
 
     for _ in 0..10 {


### PR DESCRIPTION
Not everyone knows this convention. We could just rename the variables in the
example, but since this notation is commonly used it's a good opportunity to
introduce it.

r? @steveklabnik
