### PR TITLE
Rustdoc: Omit src-links for items from extern macros

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1501,11 +1501,17 @@ impl<'a> Item<'a> {
                           true, |component| {
                 path.push(component.to_string());
             });
-            Some(format!("{root}src/{krate}/{path}.html#{href}",
-                         root = self.cx.root_path,
-                         krate = self.cx.layout.krate,
-                         path = path.join("/"),
-                         href = href))
+            // If the span points into an external macro the
+            // source-file will be bogus, i.e `<foo macros>`
+            if Path::new(&self.item.source.filename).is_file() {
+                Some(format!("{root}src/{krate}/{path}.html#{href}",
+                             root = self.cx.root_path,
+                             krate = self.cx.layout.krate,
+                             path = path.join("/"),
+                             href = href))
+            } else {
+                None
+            }
 
         // If this item is not part of the local crate, then things get a little
         // trickier. We don't actually know the span of the external item, but

--- a/src/test/auxiliary/issue-26606-macro.rs
+++ b/src/test/auxiliary/issue-26606-macro.rs
@@ -1,0 +1,14 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_export]
+macro_rules! make_item (
+    ($name: ident) => (pub const $name: usize = 42;)
+);

--- a/src/test/rustdoc/issue-26606.rs
+++ b/src/test/rustdoc/issue-26606.rs
@@ -1,0 +1,21 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-26606-macro.rs
+// ignore-cross-compile
+// build-aux-docs
+
+// @has issue_26606_macro/macro.make_item!.html
+#[macro_use]
+extern crate issue_26606_macro;
+
+// @has issue_26606/constant.FOO.html
+// @!has - '//a/@href' '../src/'
+make_item!(FOO);


### PR DESCRIPTION
fixes #26606

r? @alexcrichton 
