### PR TITLE
More emscripten test fixes

### DIFF
--- a/src/librustc_back/target/asmjs_unknown_emscripten.rs
+++ b/src/librustc_back/target/asmjs_unknown_emscripten.rs
@@ -15,6 +15,13 @@ pub fn target() -> Target {
         linker: "emcc".to_string(),
         ar: "emar".to_string(),
 
+        pre_link_args: vec![
+            // Emscripten has exceptions disabled by default when building with -01 or more.
+            // This flag forces them to be enabled.
+            "-s".to_owned(), "DISABLE_EXCEPTION_CATCHING=0".to_owned(),
+            "-s".to_owned(), "ERROR_ON_UNDEFINED_SYMBOLS=1".to_owned(),
+        ],
+
         dynamic_linking: false,
         executables: true,
         exe_suffix: ".js".to_string(),

--- a/src/libstd/sys/common/libunwind.rs
+++ b/src/libstd/sys/common/libunwind.rs
@@ -87,7 +87,6 @@ pub const unwinder_private_data_size: usize = 2;
 pub const unwinder_private_data_size: usize = 2;
 
 #[cfg(target_arch = "asmjs")]
-// FIXME: Copied from arm. Need to confirm.
 pub const unwinder_private_data_size: usize = 20;
 
 #[repr(C)]

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -82,11 +82,11 @@ pub fn init() {
         }
     }
 
-    #[cfg(not(target_os = "nacl"))]
+    #[cfg(not(any(target_os = "nacl", target_os = "emscripten")))]
     unsafe fn reset_sigpipe() {
         assert!(libc::signal(libc::SIGPIPE, libc::SIG_IGN) != !0);
     }
-    #[cfg(target_os = "nacl")]
+    #[cfg(any(target_os = "nacl", target_os = "emscripten"))]
     unsafe fn reset_sigpipe() {}
 }
 

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -512,11 +512,13 @@ pub fn home_dir() -> Option<PathBuf> {
 
     #[cfg(any(target_os = "android",
               target_os = "ios",
-              target_os = "nacl"))]
+              target_os = "nacl",
+              target_os = "emscripten"))]
     unsafe fn fallback() -> Option<OsString> { None }
     #[cfg(not(any(target_os = "android",
                   target_os = "ios",
-                  target_os = "nacl")))]
+                  target_os = "nacl",
+                  target_os = "emscripten")))]
     unsafe fn fallback() -> Option<OsString> {
         #[cfg(not(target_os = "solaris"))]
         unsafe fn getpwduid_r(me: libc::uid_t, passwd: &mut libc::passwd,

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -12,7 +12,7 @@ use prelude::v1::*;
 
 use alloc::boxed::FnBox;
 use cmp;
-#[cfg(not(any(target_env = "newlib", target_os = "solaris")))]
+#[cfg(not(any(target_env = "newlib", target_os = "solaris", target_os = "emscripten")))]
 use ffi::CString;
 use io;
 use libc;
@@ -82,8 +82,7 @@ impl Thread {
     }
 
     #[cfg(any(target_os = "linux",
-              target_os = "android",
-              target_os = "emscripten"))]
+              target_os = "android"))]
     pub fn set_name(name: &str) {
         const PR_SET_NAME: libc::c_int = 15;
         let cname = CString::new(name).unwrap_or_else(|_| {
@@ -124,9 +123,9 @@ impl Thread {
                                      carg.as_ptr() as *mut libc::c_void);
         }
     }
-    #[cfg(any(target_env = "newlib", target_os = "solaris"))]
+    #[cfg(any(target_env = "newlib", target_os = "solaris", target_os = "emscripten"))]
     pub fn set_name(_name: &str) {
-        // Newlib and Illumos has no way to set a thread name.
+        // Newlib, Illumos and Emscripten have no way to set a thread name.
     }
 
     pub fn sleep(dur: Duration) {

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -37,9 +37,11 @@
 #![feature(box_syntax)]
 #![feature(fnbox)]
 #![feature(libc)]
+#![feature(recover)]
 #![feature(rustc_private)]
 #![feature(set_stdio)]
 #![feature(staged_api)]
+#![feature(std_panic)]
 #![feature(time2)]
 
 extern crate getopts;
@@ -70,6 +72,7 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::io;
 use std::iter::repeat;
+use std::panic;
 use std::path::PathBuf;
 use std::sync::mpsc::{channel, Sender};
 use std::sync::{Arc, Mutex};
@@ -1067,9 +1070,17 @@ pub fn run_test(opts: &TestOpts,
             }
         }
 
-        thread::spawn(move || {
-            let data = Arc::new(Mutex::new(Vec::new()));
-            let data2 = data.clone();
+        let testfn = Arc::new(Mutex::new(Some(testfn)));
+        let testfn2 = testfn.clone();
+        let desc2 = desc.clone();
+        let monitor_ch2 = monitor_ch.clone();
+
+        // This Vec will contain the output of stderr and stdout.
+        let data = Arc::new(Mutex::new(Vec::new()));
+        let data2 = data.clone();
+        let data3 = data.clone();
+
+        let res = thread::Builder::new().spawn(move || {
             let cfg = thread::Builder::new().name(match desc.name {
                 DynTestName(ref name) => name.clone(),
                 StaticTestName(name) => name.to_owned(),
@@ -1080,6 +1091,7 @@ pub fn run_test(opts: &TestOpts,
                                           io::set_print(box Sink(data2.clone()));
                                           io::set_panic(box Sink(data2));
                                       }
+                                      let testfn = testfn.lock().unwrap().take().unwrap();
                                       testfn()
                                   })
                                   .unwrap();
@@ -1087,6 +1099,28 @@ pub fn run_test(opts: &TestOpts,
             let stdout = data.lock().unwrap().to_vec();
             monitor_ch.send((desc.clone(), test_result, stdout)).unwrap();
         });
+
+        // If the thread failed to spawn (for example if the platform doesn't support threads),
+        // we do everything in a single-threaded way instead.
+        if let Err(_) = res {
+            let testfn = testfn2.lock().unwrap().take().unwrap();
+            let mut testfn = panic::AssertRecoverSafe::new(Some(testfn));
+
+            let test_result = if !nocapture {
+                let old_print = io::set_print(box Sink(data3.clone()));
+                let old_panic = io::set_panic(box Sink(data3.clone()));
+                let r = panic::recover(move || (testfn.take().unwrap())());
+                if let Some(old_print) = old_print { io::set_print(old_print); }
+                if let Some(old_panic) = old_panic { io::set_panic(old_panic); }
+                r
+            } else {
+                panic::recover(move || (testfn.take().unwrap())())
+            };
+
+            let test_result = calc_result(&desc2, test_result);
+            let stdout = data3.lock().unwrap().to_vec();
+            monitor_ch2.send((desc2.clone(), test_result, stdout)).unwrap();
+        }
     }
 
     match testfn {

--- a/src/test/run-pass/backtrace-debuginfo.rs
+++ b/src/test/run-pass/backtrace-debuginfo.rs
@@ -16,6 +16,7 @@
 // "enable" to 0 instead.
 
 // compile-flags:-g -Cllvm-args=-enable-tail-merge=0
+// ignore-emscripten spawning processes is not supported
 // ignore-pretty as this critically relies on line numbers
 
 use std::io;

--- a/src/test/run-pass/backtrace.rs
+++ b/src/test/run-pass/backtrace.rs
@@ -10,6 +10,7 @@
 
 // no-pretty-expanded FIXME #15189
 // ignore-android FIXME #17520
+// ignore-emscripten spawning processes is not supported
 // compile-flags:-g
 
 use std::env;

--- a/src/test/run-pass/command-before-exec.rs
+++ b/src/test/run-pass/command-before-exec.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-windows - this is a unix-specific test
+// ignore-emscripten
 
 #![feature(process_exec, libc)]
 

--- a/src/test/run-pass/command-exec.rs
+++ b/src/test/run-pass/command-exec.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-windows - this is a unix-specific test
+// ignore-emscripten
 // ignore-pretty
 
 #![feature(process_exec)]

--- a/src/test/run-pass/drop-flag-sanity-check.rs
+++ b/src/test/run-pass/drop-flag-sanity-check.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // compile-flags: -Z force-dropflag-checks=on
+// ignore-emscripten
 
 // Quick-and-dirty test to ensure -Z force-dropflag-checks=on works as
 // expected. Note that the inlined drop-flag is slated for removal

--- a/src/test/run-pass/drop-trait-enum.rs
+++ b/src/test/run-pass/drop-trait-enum.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 #![allow(unknown_features)]
 #![feature(box_syntax)]
 

--- a/src/test/run-pass/env-home-dir.rs
+++ b/src/test/run-pass/env-home-dir.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
 
 #![feature(path)]
 

--- a/src/test/run-pass/exec-env.rs
+++ b/src/test/run-pass/exec-env.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // exec-env:TEST_EXEC_ENV=22
-
+// ignore-emscripten FIXME: issue #31622
 
 use std::env;
 

--- a/src/test/run-pass/hashmap-memory.rs
+++ b/src/test/run-pass/hashmap-memory.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten No support for threads
+
 #![allow(unknown_features)]
 #![feature(unboxed_closures, std_misc)]
 

--- a/src/test/run-pass/intrinsic-alignment.rs
+++ b/src/test/run-pass/intrinsic-alignment.rs
@@ -24,7 +24,8 @@ mod rusti {
           target_os = "dragonfly",
           target_os = "netbsd",
           target_os = "openbsd",
-          target_os = "solaris"))]
+          target_os = "solaris",
+          target_os = "emscripten"))]
 mod m {
     #[main]
     #[cfg(target_arch = "x86")]

--- a/src/test/run-pass/issue-10626.rs
+++ b/src/test/run-pass/issue-10626.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
 
 // Make sure that if a process doesn't have its stdio/stderr descriptors set up
 // that we don't die in a large ball of fire

--- a/src/test/run-pass/issue-12133-3.rs
+++ b/src/test/run-pass/issue-12133-3.rs
@@ -12,6 +12,7 @@
 // aux-build:issue-12133-dylib.rs
 // aux-build:issue-12133-dylib2.rs
 // ignore-musl
+// ignore-emscripten no dylib support
 
 // pretty-expanded FIXME #23616
 

--- a/src/test/run-pass/issue-13304.rs
+++ b/src/test/run-pass/issue-13304.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-aarch64
+// ignore-emscripten
 #![feature(io, process_capture)]
 
 use std::env;

--- a/src/test/run-pass/issue-14456.rs
+++ b/src/test/run-pass/issue-14456.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
 
 #![feature(io, process_capture)]
 

--- a/src/test/run-pass/issue-14940.rs
+++ b/src/test/run-pass/issue-14940.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
 
 use std::env;
 use std::process::Command;

--- a/src/test/run-pass/issue-16272.rs
+++ b/src/test/run-pass/issue-16272.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-aarch64
+// ignore-emscripten
 
 use std::process::Command;
 use std::env;

--- a/src/test/run-pass/issue-20091.rs
+++ b/src/test/run-pass/issue-20091.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-aarch64
+// ignore-emscripten
 #![feature(std_misc, os)]
 
 #[cfg(unix)]

--- a/src/test/run-pass/issue-24313.rs
+++ b/src/test/run-pass/issue-24313.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
+
 use std::thread;
 use std::env;
 use std::process::Command;

--- a/src/test/run-pass/issue-30490.rs
+++ b/src/test/run-pass/issue-30490.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
+
 // Previously libstd would set stdio descriptors of a child process
 // by `dup`ing the requested descriptors to inherit directly into the
 // stdio descriptors. This, however, would incorrectly handle cases

--- a/src/test/run-pass/linkage-visibility.rs
+++ b/src/test/run-pass/linkage-visibility.rs
@@ -12,6 +12,7 @@
 // ignore-android: FIXME(#10356)
 // ignore-windows: std::dynamic_lib does not work on Windows well
 // ignore-musl
+// ignore-emscripten no dynamic linking
 
 extern crate linkage_visibility as foo;
 

--- a/src/test/run-pass/linkage1.rs
+++ b/src/test/run-pass/linkage1.rs
@@ -10,6 +10,7 @@
 
 // ignore-windows
 // ignore-macos
+// ignore-emscripten
 // aux-build:linkage1.rs
 
 #![feature(linkage)]

--- a/src/test/run-pass/logging-enabled.rs
+++ b/src/test/run-pass/logging-enabled.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // exec-env:RUST_LOG=logging_enabled=info
-
+// ignore-emscripten: FIXME(#31622)
 
 #![feature(rustc_private)]
 

--- a/src/test/run-pass/logging-separate-lines.rs
+++ b/src/test/run-pass/logging-separate-lines.rs
@@ -11,6 +11,7 @@
 // ignore-windows
 // exec-env:RUST_LOG=debug
 // compile-flags:-C debug-assertions=y
+// ignore-emscripten: FIXME(#31622)
 
 #![feature(rustc_private)]
 

--- a/src/test/run-pass/multi-panic.rs
+++ b/src/test/run-pass/multi-panic.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
+
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     if args.len() > 1 && args[1] == "run_test" {

--- a/src/test/run-pass/no-stdio.rs
+++ b/src/test/run-pass/no-stdio.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
+
 #![feature(libc)]
 
 extern crate libc;

--- a/src/test/run-pass/panic-handler-chain.rs
+++ b/src/test/run-pass/panic-handler-chain.rs
@@ -7,6 +7,9 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
+// ignore-emscripten no threads support
+
 #![feature(panic_handler, const_fn, std_panic)]
 
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/src/test/run-pass/process-exit.rs
+++ b/src/test/run-pass/process-exit.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
+
 use std::env;
 use std::process::{self, Command, Stdio};
 

--- a/src/test/run-pass/process-remove-from-env.rs
+++ b/src/test/run-pass/process-remove-from-env.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
 
 use std::process::Command;
 use std::env;

--- a/src/test/run-pass/process-spawn-with-unicode-params.rs
+++ b/src/test/run-pass/process-spawn-with-unicode-params.rs
@@ -17,6 +17,7 @@
 // intact.
 
 // ignore-aarch64
+// ignore-emscripten
 
 use std::io::prelude::*;
 use std::io;

--- a/src/test/run-pass/rec-align-u64.rs
+++ b/src/test/run-pass/rec-align-u64.rs
@@ -42,15 +42,16 @@ struct Outer {
           target_os = "dragonfly",
           target_os = "netbsd",
           target_os = "openbsd",
-          target_os = "solaris"))]
+          target_os = "solaris",
+          target_os = "emscripten"))]
 mod m {
-    #[cfg(target_arch = "x86")]
+    #[cfg(any(target_arch = "x86", target_arch = "asmjs"))]
     pub mod m {
         pub fn align() -> usize { 4 }
         pub fn size() -> usize { 12 }
     }
 
-    #[cfg(not(target_arch = "x86"))]
+    #[cfg(not(any(target_arch = "x86", target_arch = "asmjs")))]
     pub mod m {
         pub fn align() -> usize { 8 }
         pub fn size() -> usize { 16 }

--- a/src/test/run-pass/rec-align-u64.rs
+++ b/src/test/run-pass/rec-align-u64.rs
@@ -45,13 +45,13 @@ struct Outer {
           target_os = "solaris",
           target_os = "emscripten"))]
 mod m {
-    #[cfg(any(target_arch = "x86", target_arch = "asmjs"))]
+    #[cfg(any(target_arch = "x86"))]
     pub mod m {
         pub fn align() -> usize { 4 }
         pub fn size() -> usize { 12 }
     }
 
-    #[cfg(not(any(target_arch = "x86", target_arch = "asmjs")))]
+    #[cfg(not(any(target_arch = "x86")))]
     pub mod m {
         pub fn align() -> usize { 8 }
         pub fn size() -> usize { 16 }

--- a/src/test/run-pass/running-with-no-runtime.rs
+++ b/src/test/run-pass/running-with-no-runtime.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
+
 #![feature(std_panic, recover, start)]
 
 use std::ffi::CStr;

--- a/src/test/run-pass/segfault-no-out-of-stack.rs
+++ b/src/test/run-pass/segfault-no-out-of-stack.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten can't run commands
+
 #![feature(libc)]
 
 extern crate libc;

--- a/src/test/run-pass/signal-exit-status.rs
+++ b/src/test/run-pass/signal-exit-status.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-windows
+// ignore-emscripten
 
 use std::env;
 use std::process::Command;

--- a/src/test/run-pass/sigpipe-should-be-ignored.rs
+++ b/src/test/run-pass/sigpipe-should-be-ignored.rs
@@ -12,6 +12,7 @@
 // doesn't die in a ball of fire, but rather it's gracefully handled.
 
 // ignore-aarch64
+// ignore-emscripten
 
 use std::env;
 use std::io::prelude::*;

--- a/src/test/run-pass/wait-forked-but-failed-child.rs
+++ b/src/test/run-pass/wait-forked-but-failed-child.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
 
 #![feature(libc)]
 


### PR DESCRIPTION
r? @brson 
- `libtest` now runs each test in single-threaded mode (around `panic::recover`) if the test thread fails to spawn. This is required since emscripten doesn't have threads.
- Previously linking errors only triggered warnings, and missing symbols were replaced with `abort(-1)`. I think it's better to always error when a symbol is missing.
- `DISABLE_EXCEPTION_CATCHING=0` is required to make exceptions work when optimizations are on. However the docs say that this causes a big difference in binary size and runtime performances. From my experience with emscripten, these differences can sometimes be massive.
- All tests that rely on spawning a new process have been ignored, as this is not supported by emscripten.

I also have some modifications in my local clone of the emscripten SDK to make all this work.
