### PR TITLE
Add a new i586 Linux target

### DIFF
--- a/mk/cfg/i586-unknown-linux-gnu.mk
+++ b/mk/cfg/i586-unknown-linux-gnu.mk
@@ -1,0 +1,23 @@
+# i586-unknown-linux-gnu configuration
+CC_i586-unknown-linux-gnu=$(CC)
+CXX_i586-unknown-linux-gnu=$(CXX)
+CPP_i586-unknown-linux-gnu=$(CPP)
+AR_i586-unknown-linux-gnu=$(AR)
+CFG_LIB_NAME_i586-unknown-linux-gnu=lib$(1).so
+CFG_STATIC_LIB_NAME_i586-unknown-linux-gnu=lib$(1).a
+CFG_LIB_GLOB_i586-unknown-linux-gnu=lib$(1)-*.so
+CFG_LIB_DSYM_GLOB_i586-unknown-linux-gnu=lib$(1)-*.dylib.dSYM
+CFG_JEMALLOC_CFLAGS_i586-unknown-linux-gnu := -m32 $(CFLAGS)
+CFG_GCCISH_CFLAGS_i586-unknown-linux-gnu := -Wall -Werror -g -fPIC -m32 $(CFLAGS)
+CFG_GCCISH_CXXFLAGS_i586-unknown-linux-gnu := -fno-rtti $(CXXFLAGS)
+CFG_GCCISH_LINK_FLAGS_i586-unknown-linux-gnu := -shared -fPIC -ldl -pthread  -lrt -g -m32
+CFG_GCCISH_DEF_FLAG_i586-unknown-linux-gnu := -Wl,--export-dynamic,--dynamic-list=
+CFG_LLC_FLAGS_i586-unknown-linux-gnu :=
+CFG_INSTALL_NAME_i586-unknown-linux-gnu =
+CFG_EXE_SUFFIX_i586-unknown-linux-gnu =
+CFG_WINDOWSY_i586-unknown-linux-gnu :=
+CFG_UNIXY_i586-unknown-linux-gnu := 1
+CFG_LDPATH_i586-unknown-linux-gnu :=
+CFG_RUN_i586-unknown-linux-gnu=$(2)
+CFG_RUN_TARG_i586-unknown-linux-gnu=$(call CFG_RUN_i586-unknown-linux-gnu,,$(2))
+CFG_GNU_TRIPLE_i586-unknown-linux-gnu := i586-unknown-linux-gnu

--- a/src/librustc_back/target/i586_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/i586_unknown_linux_gnu.rs
@@ -1,0 +1,28 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use target::Target;
+
+pub fn target() -> Target {
+    let mut base = super::linux_base::opts();
+    base.cpu = "pentium".to_string();
+    base.pre_link_args.push("-m32".to_string());
+
+    Target {
+        llvm_target: "i586-unknown-linux-gnu".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "32".to_string(),
+        arch: "x86".to_string(),
+        target_os: "linux".to_string(),
+        target_env: "gnu".to_string(),
+        target_vendor: "unknown".to_string(),
+        options: base,
+    }
+}

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -89,6 +89,7 @@ macro_rules! supported_targets {
 supported_targets! {
     ("x86_64-unknown-linux-gnu", x86_64_unknown_linux_gnu),
     ("i686-unknown-linux-gnu", i686_unknown_linux_gnu),
+    ("i586-unknown-linux-gnu", i586_unknown_linux_gnu),
     ("mips-unknown-linux-gnu", mips_unknown_linux_gnu),
     ("mipsel-unknown-linux-gnu", mipsel_unknown_linux_gnu),
     ("powerpc-unknown-linux-gnu", powerpc_unknown_linux_gnu),


### PR DESCRIPTION
This PR should make it easier to create a baseline x86 compiler  as well as make cross-compilation possible through a separate set of rlibs.

Plus, a few Linux distributions (e.g. Debian) have voiced interest in having this target available.
