### PR TITLE
Document and update i686 triples

### DIFF
--- a/src/librustc_back/target/i686_apple_darwin.rs
+++ b/src/librustc_back/target/i686_apple_darwin.rs
@@ -12,7 +12,12 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::apple_base::opts();
+
+    // Use yonah as default CPU to enable SSE[2] instructions.
+    // Clang defaults to i686 for this target, but defaulting to yonah
+    // is consistent with what Clang does for i386-apple-darwin.
     base.cpu = "yonah".to_string();
+
     base.pre_link_args.push("-m32".to_string());
 
     Target {

--- a/src/librustc_back/target/i686_apple_darwin.rs
+++ b/src/librustc_back/target/i686_apple_darwin.rs
@@ -12,11 +12,8 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::apple_base::opts();
-
-    // Use yonah as default CPU to enable SSE[2] instructions.
-    // Clang defaults to i686 for this target, but defaulting to yonah
-    // is consistent with what Clang does for i386-apple-darwin.
-    base.cpu = "yonah".to_string();
+    // Use i686 as default CPU. Clang uses the same default.
+    base.cpu = "i686".to_string();
 
     base.pre_link_args.push("-m32".to_string());
 

--- a/src/librustc_back/target/i686_linux_android.rs
+++ b/src/librustc_back/target/i686_linux_android.rs
@@ -12,6 +12,11 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::android_base::opts();
+
+    // Use pentium4 as default CPU to enable SSE[2] instructions.
+    // Clang defaults to i686 and enables SSSE3 for this target, but
+    // defaulting to pentium4 is consistent with linux and windows
+    // targets.
     base.cpu = "pentium4".to_string();
 
     Target {

--- a/src/librustc_back/target/i686_linux_android.rs
+++ b/src/librustc_back/target/i686_linux_android.rs
@@ -13,11 +13,10 @@ use target::Target;
 pub fn target() -> Target {
     let mut base = super::android_base::opts();
 
-    // Use pentium4 as default CPU to enable SSE[2] instructions.
-    // Clang defaults to i686 and enables SSSE3 for this target, but
-    // defaulting to pentium4 is consistent with linux and windows
-    // targets.
-    base.cpu = "pentium4".to_string();
+    // Use i686 as default CPU and enable SSSE3.
+    // Clang and GCC do the same.
+    base.cpu = "i686".to_string();
+    base.features = "+ssse3".to_string();
 
     Target {
         llvm_target: "i686-linux-android".to_string(),

--- a/src/librustc_back/target/i686_pc_windows_gnu.rs
+++ b/src/librustc_back/target/i686_pc_windows_gnu.rs
@@ -12,6 +12,9 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::windows_base::opts();
+
+    // Use pentium4 as default CPU to enable SSE[2] instructions.
+    // Clang uses the same default.
     base.cpu = "pentium4".to_string();
 
     // Mark all dynamic libraries and executables as compatible with the larger 4GiB address

--- a/src/librustc_back/target/i686_pc_windows_msvc.rs
+++ b/src/librustc_back/target/i686_pc_windows_msvc.rs
@@ -12,6 +12,9 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::windows_msvc_base::opts();
+
+    // Use pentium4 as default CPU to enable SSE[2] instructions.
+    // Clang uses the same default.
     base.cpu = "pentium4".to_string();
 
     // Mark all dynamic libraries and executables as compatible with the larger 4GiB address

--- a/src/librustc_back/target/i686_unknown_dragonfly.rs
+++ b/src/librustc_back/target/i686_unknown_dragonfly.rs
@@ -12,7 +12,11 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::dragonfly_base::opts();
+
+    // Use pentium4 as default CPU to enable SSE[2] instructions.
+    // Clang uses the same default.
     base.cpu = "pentium4".to_string();
+
     base.pre_link_args.push("-m32".to_string());
 
     Target {

--- a/src/librustc_back/target/i686_unknown_freebsd.rs
+++ b/src/librustc_back/target/i686_unknown_freebsd.rs
@@ -13,10 +13,8 @@ use target::Target;
 pub fn target() -> Target {
     let mut base = super::freebsd_base::opts();
 
-    // Use pentium4 as default CPU to enable SSE[2] instructions.
-    // Clang defaults to i486 for this target, but defaulting to
-    // pentium4 is consistent with linux and windows targets.
-    base.cpu = "pentium4".to_string();
+    // Use i486 as default CPU. Clang uses the same default.
+    base.cpu = "i486".to_string();
 
     base.pre_link_args.push("-m32".to_string());
 

--- a/src/librustc_back/target/i686_unknown_freebsd.rs
+++ b/src/librustc_back/target/i686_unknown_freebsd.rs
@@ -12,7 +12,12 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::freebsd_base::opts();
+
+    // Use pentium4 as default CPU to enable SSE[2] instructions.
+    // Clang defaults to i486 for this target, but defaulting to
+    // pentium4 is consistent with linux and windows targets.
     base.cpu = "pentium4".to_string();
+
     base.pre_link_args.push("-m32".to_string());
 
     Target {

--- a/src/librustc_back/target/i686_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/i686_unknown_linux_gnu.rs
@@ -12,7 +12,11 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::linux_base::opts();
+
+    // Use pentium4 as default CPU to enable SSE[2] instructions.
+    // Clang uses the same default.
     base.cpu = "pentium4".to_string();
+
     base.pre_link_args.push("-m32".to_string());
 
     Target {

--- a/src/librustc_back/target/i686_unknown_linux_musl.rs
+++ b/src/librustc_back/target/i686_unknown_linux_musl.rs
@@ -14,7 +14,11 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::linux_base::opts();
+
+    // Use pentium4 as default CPU to enable SSE[2] instructions.
+    // Clang uses the same default.
     base.cpu = "pentium4".to_string();
+
     base.pre_link_args.push("-m32".to_string());
     base.pre_link_args.push("-Wl,-melf_i386".to_string());
 


### PR DESCRIPTION
They now (should) match the behaviour of Clang and there is a brief comment in each documenting this.

As per discussion in #31110
