### PR TITLE
use a compatible syntax for grep GNU/BSD

### DIFF
--- a/src/test/run-make/codegen-options-parsing/Makefile
+++ b/src/test/run-make/codegen-options-parsing/Makefile
@@ -25,7 +25,7 @@ all:
 
 	# Should not link dead code...
 	$(RUSTC) -Z print-link-args dummy.rs 2>&1 | \
-		grep -e '--gc-sections\|-dead_strip\|/OPT:REF,ICF'
+		grep -e '--gc-sections' -e '-dead_strip' -e '/OPT:REF,ICF'
 	# ... unless you specifically ask to keep it
 	$(RUSTC) -Z print-link-args -C link-dead-code dummy.rs 2>&1 | \
-		(! grep -e '--gc-sections\|-dead_strip\|/OPT:REF,ICF')
+		(! grep -e '--gc-sections' -e '-dead_strip' -e '/OPT:REF,ICF')


### PR DESCRIPTION
The BSD grep for "basic regex" don't support | as alternate operator (at least under OpenBSD).

Use multiple -e arguments for expressing alternative. I have checked it under Linux (Debian).
