### PR TITLE
configure: require Python 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Read ["Installing Rust"] from [The Book].
 1. Make sure you have installed the dependencies:
 
    * `g++` 4.7 or `clang++` 3.x
-   * `python` 2.7 or later (but not 3.x)
+   * `python` 2.7 (but not 3.x)
    * GNU `make` 3.81 or later
    * `curl`
    * `git`

--- a/configure
+++ b/configure
@@ -729,12 +729,12 @@ step_msg "looking for build programs"
 
 probe_need CFG_CURLORWGET  curl wget
 if [ -z "$CFG_PYTHON_PROVIDED" ]; then
-    probe_need CFG_PYTHON      python2.7 python2.6 python2 python
+    probe_need CFG_PYTHON      python2.7 python2 python
 fi
 
 python_version=$($CFG_PYTHON -V 2>&1)
-if [ $(echo $python_version | grep -c '^Python 2\.[4567]') -ne 1 ]; then
-    err "Found $python_version, but LLVM requires Python 2.4-2.7"
+if [ $(echo $python_version | grep -c '^Python 2\.7') -ne 1 ]; then
+    err "Found $python_version, but Python 2.7 is required"
 fi
 
 # If we have no git directory then we are probably a tarball distribution


### PR DESCRIPTION
In other words, enforce what was documented in #30626 (and also stop blaming it on LLVM, we have at least one Python script of our own).

Also, there is no Python later than 2.7 and there never will be.
