### PR TITLE
Alter Once to remove unnecessary SeqCst usage

### DIFF
--- a/src/libstd/sync/once.rs
+++ b/src/libstd/sync/once.rs
@@ -201,7 +201,7 @@ impl Once {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn call_once<F>(&'static self, f: F) where F: FnOnce() {
         // Fast path, just see if we've completed initialization.
-        if self.state.load(Ordering::SeqCst) == COMPLETE {
+        if self.state.load(Ordering::Acquire) == COMPLETE {
             return
         }
 
@@ -222,7 +222,7 @@ impl Once {
     #[unstable(feature = "once_poison", issue = "31688")]
     pub fn call_once_force<F>(&'static self, f: F) where F: FnOnce(&OnceState) {
         // same as above, just with a different parameter to `call_inner`.
-        if self.state.load(Ordering::SeqCst) == COMPLETE {
+        if self.state.load(Ordering::Acquire) == COMPLETE {
             return
         }
 


### PR DESCRIPTION
Just had a look at Once, and it looks like it's unnecessarily using SeqCst where acquire/release semantics would be sufficient.  Would appreciate a review to be sure, but I can't see why it would require SeqCst.
