### PR TITLE
Do not expect blocks to have type str.

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3828,7 +3828,7 @@ impl<'tcx> Expectation<'tcx> {
     /// for examples of where this comes up,.
     fn rvalue_hint(tcx: &ty::ctxt<'tcx>, ty: Ty<'tcx>) -> Expectation<'tcx> {
         match tcx.struct_tail(ty).sty {
-            ty::TySlice(_) | ty::TyTrait(..) => {
+            ty::TySlice(_) | ty::TyStr | ty::TyTrait(..) => {
                 ExpectRvalueLikeUnsized(ty)
             }
             _ => ExpectHasType(ty)

--- a/src/test/run-pass/coerce-expect-unsized.rs
+++ b/src/test/run-pass/coerce-expect-unsized.rs
@@ -44,6 +44,13 @@ pub fn main() {
     let _: &Debug = &if true { false } else { true };
     let _: &Debug = &match true { true => 'a', false => 'b' };
 
+    let _: &str = &{ String::new() };
+    let _: &str = &if true { String::from("...") } else { 5.to_string() };
+    let _: &str = &match true {
+        true => format!("{}", false),
+        false => ["x", "y"].join("+")
+    };
+
     let _: Box<[isize]> = Box::new([1, 2, 3]);
     let _: Box<Fn(isize) -> _> = Box::new(|x| (x as u8));
 


### PR DESCRIPTION
Handles `str` being an expression's expected type, which was missing from #20083.
Fixes #26978.
