### PR TITLE
polish `std::os::*::raw` deprecation on openbsd

### DIFF
--- a/src/libstd/os/openbsd/raw.rs
+++ b/src/libstd/os/openbsd/raw.rs
@@ -19,7 +19,6 @@
 #![allow(deprecated)]
 
 use os::raw::c_long;
-use os::unix::raw::{uid_t, gid_t};
 
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;


### PR DESCRIPTION
remove unused import that cause an error at compile-time.

r? @alexcrichton 
