### PR TITLE
doc: fix compiler output

### DIFF
--- a/src/doc/book/functions.md
+++ b/src/doc/book/functions.md
@@ -68,7 +68,7 @@ You get this error:
 
 ```text
 expected one of `!`, `:`, or `@`, found `)`
-fn print_number(x, y) {
+fn print_sum(x, y) {
 ```
 
 This is a deliberate design decision. While full-program inference is possible,


### PR DESCRIPTION
In the Rust code above this block of compiler output, the function is called print_sum, so use the same function name in the error message.
