### PR TITLE
pass CXX to run-make

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -1072,7 +1072,8 @@ $(3)/test/run-make/%-$(1)-T-$(2)-H-$(3).ok: \
 	    $(3) \
 	    "$$(LLVM_LIBDIR_RUSTFLAGS_$(3))" \
 	    "$$(LLVM_ALL_COMPONENTS_$(3))" \
-	    "$$(LLVM_CXXFLAGS_$(3))"
+	    "$$(LLVM_CXXFLAGS_$(3))" \
+	    '$$(CXX_$(3))'
 	@touch -r $$@.start_time $$@ && rm $$@.start_time
 else
 # FIXME #11094 - The above rule doesn't work right for multiple targets

--- a/src/etc/maketest.py
+++ b/src/etc/maketest.py
@@ -57,6 +57,7 @@ putenv('S', os.path.abspath(sys.argv[13]))
 putenv('RUSTFLAGS', sys.argv[15])
 putenv('LLVM_COMPONENTS', sys.argv[16])
 putenv('LLVM_CXXFLAGS', sys.argv[17])
+putenv('CXX', sys.argv[18])
 putenv('PYTHON', sys.executable)
 os.putenv('TARGET', target_triple)
 


### PR DESCRIPTION
use CXX value found at configure time inside run-make tests.

it permits OpenBSD to pass llvm-module-pass test (which use CXX
variable).

r? @alexcrichton
