### PR TITLE
Check the docs as part of check-stageN

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -161,7 +161,8 @@ $(foreach file,$(wildcard $(S)src/doc/nomicon/*.md), \
 ######################################################################
 
 # The main testing target. Tests lots of stuff.
-check: check-sanitycheck cleantmptestlogs cleantestlibs all check-stage2 tidy
+check: check-sanitycheck cleantmptestlogs cleantestlibs all check-stage2 tidy \
+	check-stage2-docs
 	$(Q)$(CFG_PYTHON) $(S)src/etc/check-summary.py tmp/*.log
 
 # As above but don't bother running tidy.

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -161,8 +161,7 @@ $(foreach file,$(wildcard $(S)src/doc/nomicon/*.md), \
 ######################################################################
 
 # The main testing target. Tests lots of stuff.
-check: check-sanitycheck cleantmptestlogs cleantestlibs all check-stage2 tidy \
-	check-stage2-docs
+check: check-sanitycheck cleantmptestlogs cleantestlibs all check-stage2 tidy
 	$(Q)$(CFG_PYTHON) $(S)src/etc/check-summary.py tmp/*.log
 
 # As above but don't bother running tidy.
@@ -968,7 +967,7 @@ $(foreach stage,$(STAGES), \
     $(eval $(call DEF_CHECK_FOR_STAGE_AND_TARGET_AND_HOST_AND_GROUP,$(stage),$(target),$(host),$(group)))))))
 
 define DEF_CHECK_FOR_STAGE
-check-stage$(1): check-stage$(1)-H-$$(CFG_BUILD)
+check-stage$(1): check-stage$(1)-H-$$(CFG_BUILD) check-stage$(1)-docs
 check-stage$(1)-H-all: $$(foreach target,$$(CFG_TARGET), \
                            check-stage$(1)-H-$$(target))
 endef


### PR DESCRIPTION
This addresses #31587 by adding check-stage2-docs as a dependency
of make check.

With this change `make check` output shows

```
LD_LIBRARY_PATH=/home/jw2328/devel/rust/x86_64-unknown-linux-gnu/stage2/lib:/home/jw2328/devel/rust/x86_64-unknown-linux-gnu/llvm/Release/lib:$LD_LIBRARY_PATH x86_64-unknown-linux-gnu/stage2/bin/rustdoc --test doc/error-index.md

running 453 tests
test Rust_Compiler_Error_Index_0 ... ok
test Rust_Compiler_Error_Index_100 ... ok
test Rust_Compiler_Error_Index_1 ... ok
test Rust_Compiler_Error_Index_10 ... ok
test Rust_Compiler_Error_Index_103 ... ok
test Rust_Compiler_Error_Index_101 ... ok
test Rust_Compiler_Error_Index_105 ... ok
test Rust_Compiler_Error_Index_104 ... ok
...
```

I'm not entirely sure this is the right fix, we may instead want to depend
on a slightly more specific target, but I'm not sure what the
expected behaviour of each target is. Running all the docs tests
on `make check` seems perfectly reasonable, and the dependencies
should mean there is no duplicated work.

If you do suggest a change I would appreciate it if you could also
let me know if there's a trick to avoid the process from deleting
all the build artefacts if the makefiles are changed. A simple tweak
to this rule means that I have to rebuild all of rust to test it. If there's
a way to avoid running get-snapshot then I would like to know,
because NO_REBUILD=1 doesn't seem to be it.

This is my first PR for rust, so I likely missed some simple things
(commit message template, NEWS entry?) Please let me know
what they are and I will happily adjust my submission.

Thanks,

James
