### PR TITLE
librustc_llvm: coerce an integral type LLVMBool to a struct with the same size.

### DIFF
--- a/src/librustc_metadata/loader.rs
+++ b/src/librustc_metadata/loader.rs
@@ -223,7 +223,7 @@ use rustc::session::search_paths::PathKind;
 use rustc::util::common;
 
 use rustc_llvm as llvm;
-use rustc_llvm::{False, ObjectFile, mk_section_iter};
+use rustc_llvm::{ObjectFile, mk_section_iter};
 use rustc_llvm::archive_ro::ArchiveRO;
 use syntax::codemap::Span;
 use syntax::errors::DiagnosticBuilder;
@@ -798,7 +798,7 @@ fn get_metadata_section_imp(target: &Target, filename: &Path)
             }
         };
         let si = mk_section_iter(of.llof);
-        while llvm::LLVMIsSectionIteratorAtEnd(of.llof, si.llsi) == False {
+        while ! llvm::LLVMIsSectionIteratorAtEnd(of.llof, si.llsi).as_bool() {
             let mut name_buf = ptr::null();
             let name_len = llvm::LLVMRustGetSectionName(si.llsi, &mut name_buf);
             let name = slice::from_raw_parts(name_buf as *const u8,

--- a/src/librustc_trans/trans/build.rs
+++ b/src/librustc_trans/trans/build.rs
@@ -115,7 +115,7 @@ pub fn Switch(cx: Block, v: ValueRef, else_: BasicBlockRef, num_cases: usize)
 
 pub fn AddCase(s: ValueRef, on_val: ValueRef, dest: BasicBlockRef) {
     unsafe {
-        if llvm::LLVMIsUndef(s) == llvm::True { return; }
+        if llvm::LLVMIsUndef(s).as_bool() { return; }
         llvm::LLVMAddCase(s, on_val, dest);
     }
 }
@@ -871,7 +871,7 @@ pub fn Phi(cx: Block, ty: Type, vals: &[ValueRef],
 
 pub fn AddIncomingToPhi(phi: ValueRef, val: ValueRef, bb: BasicBlockRef) {
     unsafe {
-        if llvm::LLVMIsUndef(phi) == llvm::True { return; }
+        if llvm::LLVMIsUndef(phi).as_bool() { return; }
         llvm::LLVMAddIncoming(phi, &val, &bb, 1 as c_uint);
     }
 }

--- a/src/librustc_trans/trans/common.rs
+++ b/src/librustc_trans/trans/common.rs
@@ -17,7 +17,7 @@ pub use self::ExprOrMethodCall::*;
 use session::Session;
 use llvm;
 use llvm::{ValueRef, BasicBlockRef, BuilderRef, ContextRef, TypeKind};
-use llvm::{True, False, Bool, OperandBundleDef};
+use llvm::{True, OperandBundleDef};
 use middle::cfg;
 use middle::def::Def;
 use middle::def_id::DefId;
@@ -858,7 +858,7 @@ pub fn C_undef(t: Type) -> ValueRef {
 
 pub fn C_integral(t: Type, u: u64, sign_extend: bool) -> ValueRef {
     unsafe {
-        llvm::LLVMConstInt(t.to_ref(), u, sign_extend as Bool)
+        llvm::LLVMConstInt(t.to_ref(), u, sign_extend.into())
     }
 }
 
@@ -951,7 +951,7 @@ pub fn C_cstr(cx: &CrateContext, s: InternedString, null_terminated: bool) -> Va
         let sc = llvm::LLVMConstStringInContext(cx.llcx(),
                                                 s.as_ptr() as *const c_char,
                                                 s.len() as c_uint,
-                                                !null_terminated as Bool);
+                                                (!null_terminated).into());
 
         let gsym = token::gensym("str");
         let sym = format!("str{}", gsym.0);
@@ -983,7 +983,7 @@ pub fn C_struct_in_context(llcx: ContextRef, elts: &[ValueRef], packed: bool) ->
     unsafe {
         llvm::LLVMConstStructInContext(llcx,
                                        elts.as_ptr(), elts.len() as c_uint,
-                                       packed as Bool)
+                                       packed.into())
     }
 }
 
@@ -1068,14 +1068,14 @@ pub fn const_to_opt_uint(v: ValueRef) -> Option<u64> {
 
 pub fn is_undef(val: ValueRef) -> bool {
     unsafe {
-        llvm::LLVMIsUndef(val) != False
+        llvm::LLVMIsUndef(val).as_bool()
     }
 }
 
 #[allow(dead_code)] // potentially useful
 pub fn is_null(val: ValueRef) -> bool {
     unsafe {
-        llvm::LLVMIsNull(val) != False
+        llvm::LLVMIsNull(val).as_bool()
     }
 }
 

--- a/src/librustc_trans/trans/consts.rs
+++ b/src/librustc_trans/trans/consts.rs
@@ -12,7 +12,7 @@
 use back::abi;
 use llvm;
 use llvm::{ConstFCmp, ConstICmp, SetLinkage, SetUnnamedAddr};
-use llvm::{InternalLinkage, ValueRef, Bool, True};
+use llvm::{InternalLinkage, ValueRef, True};
 use middle::const_qualif::ConstQualif;
 use middle::cstore::LOCAL_CRATE;
 use middle::const_eval::{self, ConstVal, ConstEvalErr};
@@ -743,11 +743,11 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                     let repr = adt::represent_type(cx, t_expr);
                     let discr = adt::const_get_discrim(cx, &repr, v);
                     let iv = C_integral(cx.int_type(), discr.0, false);
-                    let s = adt::is_discr_signed(&repr) as Bool;
+                    let s = adt::is_discr_signed(&repr).into();
                     llvm::LLVMConstIntCast(iv, llty.to_ref(), s)
                 },
                 (CastTy::Int(_), CastTy::Int(_)) => {
-                    let s = t_expr.is_signed() as Bool;
+                    let s = t_expr.is_signed().into();
                     llvm::LLVMConstIntCast(v, llty.to_ref(), s)
                 },
                 (CastTy::Int(_), CastTy::Float) => {

--- a/src/librustc_trans/trans/declare.rs
+++ b/src/librustc_trans/trans/declare.rs
@@ -245,7 +245,7 @@ fn get_defined_value(ccx: &CrateContext, name: &str) -> Option<ValueRef> {
     } else {
         let (declaration, aext_link) = unsafe {
             let linkage = llvm::LLVMGetLinkage(val);
-            (llvm::LLVMIsDeclaration(val) != 0,
+            (llvm::LLVMIsDeclaration(val).as_bool(),
              linkage == llvm::AvailableExternallyLinkage as c_uint)
         };
         debug!("get_defined_value: found {:?} value (declaration: {}, \

--- a/src/librustc_trans/trans/type_.rs
+++ b/src/librustc_trans/trans/type_.rs
@@ -11,7 +11,7 @@
 #![allow(non_upper_case_globals)]
 
 use llvm;
-use llvm::{TypeRef, Bool, False, True, TypeKind, ValueRef};
+use llvm::{TypeRef, False, True, TypeKind, ValueRef};
 use llvm::{Float, Double, X86_FP80, PPC_FP128, FP128};
 
 use trans::context::CrateContext;
@@ -168,7 +168,7 @@ impl Type {
         let els: &[TypeRef] = Type::to_ref_slice(els);
         ty!(llvm::LLVMStructTypeInContext(ccx.llcx(), els.as_ptr(),
                                           els.len() as c_uint,
-                                          packed as Bool))
+                                          packed.into()))
     }
 
     pub fn named_struct(ccx: &CrateContext, name: &str) -> Type {
@@ -216,7 +216,7 @@ impl Type {
         let slice: &[TypeRef] = Type::to_ref_slice(els);
         unsafe {
             llvm::LLVMStructSetBody(self.to_ref(), slice.as_ptr(),
-                                    els.len() as c_uint, packed as Bool)
+                                    els.len() as c_uint, packed.into())
         }
     }
 
@@ -233,7 +233,7 @@ impl Type {
 
     pub fn is_packed(&self) -> bool {
         unsafe {
-            llvm::LLVMIsPackedStruct(self.to_ref()) == True
+            llvm::LLVMIsPackedStruct(self.to_ref()).as_bool()
         }
     }
 

--- a/src/test/run-make/execution-engine/test.rs
+++ b/src/test/run-make/execution-engine/test.rs
@@ -173,7 +173,7 @@ impl ExecutionEngine {
 
             let res = unsafe { llvm::LLVMRustLoadDynamicLibrary(cs.as_ptr()) };
 
-            if res == 0 {
+            if ! res.as_bool() {
                 panic!("Failed to load crate {:?}: {}",
                     path.display(), llvm_error());
             }


### PR DESCRIPTION
When the trueness is defined as "!= 0", it's error prone to write such a comparison for each site.
