### PR TITLE
rustc: Rebase LLVM on the 3.8 release branch

### DIFF
--- a/src/rustllvm/llvm-auto-clean-trigger
+++ b/src/rustllvm/llvm-auto-clean-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be forcibly cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2015-01-25
+2016-02-16

--- a/src/test/auxiliary/issue-31702-1.rs
+++ b/src/test/auxiliary/issue-31702-1.rs
@@ -1,0 +1,26 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[derive(Copy)]
+pub struct U256(pub [u64; 4]);
+
+impl Clone for U256 {
+    fn clone(&self) -> U256 {
+        *self
+    }
+}
+
+impl U256 {
+    pub fn new(value: u64) -> U256 {
+        let mut ret = [0; 4];
+        ret[0] = value;
+        U256(ret)
+    }
+}

--- a/src/test/auxiliary/issue-31702-2.rs
+++ b/src/test/auxiliary/issue-31702-2.rs
@@ -1,0 +1,30 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -g
+
+extern crate issue_31702_1;
+
+use std::collections::HashMap;
+use issue_31702_1::U256;
+
+pub struct Ethash {
+    engine_params: for<'a> fn() -> Option<&'a Vec<u8>>,
+    u256_params: HashMap<String, U256>,
+}
+
+impl Ethash {
+    pub fn u256_param(&mut self, name: &str) -> U256 {
+        let engine = self.engine_params;
+        *self.u256_params.entry(name.to_owned()).or_insert_with(|| {
+            engine().map_or(U256::new(0u64), |_a| loop {})
+        })
+    }
+}

--- a/src/test/run-pass/issue-31702.rs
+++ b/src/test/run-pass/issue-31702.rs
@@ -1,0 +1,19 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-31702-1.rs
+// aux-build:issue-31702-2.rs
+
+// this test is actually entirely in the linked library crates
+
+extern crate issue_31702_1;
+extern crate issue_31702_2;
+
+fn main() {}


### PR DESCRIPTION
This commit rebases our LLVM submodule on the most recent tip of the
`release_38` branch of LLVM. There's been a few fixes and this notably fixes the
assertion error in #31702.

Closes #31702 
