### PR TITLE
Add zeroext/signext attributes to C ABI functions where appropriate

### DIFF
--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -261,6 +261,12 @@ impl AttrBuilder {
         }
     }
 
+    pub fn merge(&mut self, other: AttrBuilder) {
+        for attr in other.attrs {
+            self.attrs.push(attr);
+        }
+    }
+
     pub fn arg<'a, T: AttrHelper + 'static>(&'a mut self, idx: usize, a: T) -> &'a mut AttrBuilder {
         self.attrs.push((idx, box a as Box<AttrHelper+'static>));
         self

--- a/src/librustc_trans/trans/cabi.rs
+++ b/src/librustc_trans/trans/cabi.rs
@@ -149,7 +149,6 @@ pub fn compute_abi_info(ccx: &CrateContext,
         "powerpc" => cabi_powerpc::compute_abi_info(ccx, atys, rty, ret_def),
         "powerpc64" => cabi_powerpc64::compute_abi_info(ccx, atys, rty, ret_def),
         "asmjs" => cabi_asmjs::compute_abi_info(ccx, atys, rty, ret_def),
-        a => ccx.sess().fatal(&format!("unrecognized arch \"{}\" in target specification", a)
-                              ),
+        a => ccx.sess().fatal(&format!("unrecognized arch \"{}\" in target specification", a)),
     }
 }

--- a/src/librustc_trans/trans/cabi.rs
+++ b/src/librustc_trans/trans/cabi.rs
@@ -29,6 +29,10 @@ pub enum ArgKind {
     /// Pass the argument directly using the normal converted
     /// LLVM type or by coercing to another specified type
     Direct,
+    /// Extend the argument for ABI requirements. The signedness
+    /// of the argument is required to select the appropriate
+    /// extension method
+    Extend,
     /// Pass the argument indirectly via a hidden pointer
     Indirect,
     /// Ignore the argument (useful for empty struct)
@@ -85,12 +89,26 @@ impl ArgType {
         }
     }
 
+    pub fn extend(ty: Type) -> ArgType {
+        ArgType {
+            kind: Extend,
+            ty: ty,
+            cast: None,
+            pad: None,
+            attr: None,
+        }
+    }
+
     pub fn is_indirect(&self) -> bool {
         return self.kind == Indirect;
     }
 
     pub fn is_ignore(&self) -> bool {
         return self.kind == Ignore;
+    }
+
+    pub fn is_extend(&self) -> bool {
+        return self.kind == Extend;
     }
 }
 

--- a/src/librustc_trans/trans/cabi_aarch64.rs
+++ b/src/librustc_trans/trans/cabi_aarch64.rs
@@ -163,8 +163,11 @@ fn is_homogenous_aggregate_ty(ty: Type) -> Option<(Type, u64)> {
 
 fn classify_ret_ty(ccx: &CrateContext, ty: Type) -> ArgType {
     if is_reg_ty(ty) {
-        let attr = if ty == Type::i1(ccx) { Some(Attribute::ZExt) } else { None };
-        return ArgType::direct(ty, None, None, attr);
+        if ty.kind() == Integer && ty.int_width() < 32 {
+            return ArgType::extend(ty);
+        } else {
+            return ArgType::direct(ty, None, None, None);
+        }
     }
     if let Some((base_ty, members)) = is_homogenous_aggregate_ty(ty) {
         let llty = Type::array(&base_ty, members);
@@ -190,8 +193,11 @@ fn classify_ret_ty(ccx: &CrateContext, ty: Type) -> ArgType {
 
 fn classify_arg_ty(ccx: &CrateContext, ty: Type) -> ArgType {
     if is_reg_ty(ty) {
-        let attr = if ty == Type::i1(ccx) { Some(Attribute::ZExt) } else { None };
-        return ArgType::direct(ty, None, None, attr);
+        if ty.kind() == Integer && ty.int_width() < 32 {
+            return ArgType::extend(ty);
+        } else {
+            return ArgType::direct(ty, None, None, None);
+        }
     }
     if let Some((base_ty, members)) = is_homogenous_aggregate_ty(ty) {
         let llty = Type::array(&base_ty, members);

--- a/src/librustc_trans/trans/cabi_arm.rs
+++ b/src/librustc_trans/trans/cabi_arm.rs
@@ -131,8 +131,11 @@ fn ty_size(ty: Type, align_fn: TyAlignFn) -> usize {
 
 fn classify_ret_ty(ccx: &CrateContext, ty: Type, align_fn: TyAlignFn) -> ArgType {
     if is_reg_ty(ty) {
-        let attr = if ty == Type::i1(ccx) { Some(Attribute::ZExt) } else { None };
-        return ArgType::direct(ty, None, None, attr);
+        if ty.kind() == Integer && ty.int_width() < 32 {
+            return ArgType::extend(ty);
+        } else {
+            return ArgType::direct(ty, None, None, None);
+        }
     }
     let size = ty_size(ty, align_fn);
     if size <= 4 {
@@ -150,8 +153,11 @@ fn classify_ret_ty(ccx: &CrateContext, ty: Type, align_fn: TyAlignFn) -> ArgType
 
 fn classify_arg_ty(ccx: &CrateContext, ty: Type, align_fn: TyAlignFn) -> ArgType {
     if is_reg_ty(ty) {
-        let attr = if ty == Type::i1(ccx) { Some(Attribute::ZExt) } else { None };
-        return ArgType::direct(ty, None, None, attr);
+        if ty.kind() == Integer && ty.int_width() < 32 {
+            return ArgType::extend(ty);
+        } else {
+            return ArgType::direct(ty, None, None, None);
+        }
     }
     let align = align_fn(ty);
     let size = ty_size(ty, align_fn);

--- a/src/librustc_trans/trans/cabi_powerpc.rs
+++ b/src/librustc_trans/trans/cabi_powerpc.rs
@@ -82,10 +82,13 @@ fn ty_size(ty: Type) -> usize {
     }
 }
 
-fn classify_ret_ty(ccx: &CrateContext, ty: Type) -> ArgType {
+fn classify_ret_ty(_ccx: &CrateContext, ty: Type) -> ArgType {
     if is_reg_ty(ty) {
-        let attr = if ty == Type::i1(ccx) { Some(Attribute::ZExt) } else { None };
-        ArgType::direct(ty, None, None, attr)
+        if ty.kind() == Integer && ty.int_width() < 32 {
+            ArgType::extend(ty)
+        } else {
+            ArgType::direct(ty, None, None, None)
+        }
     } else {
         ArgType::indirect(ty, Some(Attribute::StructRet))
     }
@@ -101,8 +104,11 @@ fn classify_arg_ty(ccx: &CrateContext, ty: Type, offset: &mut usize) -> ArgType 
     *offset += align_up_to(size, align * 8) / 8;
 
     if is_reg_ty(ty) {
-        let attr = if ty == Type::i1(ccx) { Some(Attribute::ZExt) } else { None };
-        ArgType::direct(ty, None, None, attr)
+        if ty.kind() == Integer && ty.int_width() < 32 {
+            ArgType::extend(ty)
+        } else {
+            ArgType::direct(ty, None, None, None)
+        }
     } else {
         ArgType::direct(
             ty,

--- a/src/librustc_trans/trans/cabi_powerpc64.rs
+++ b/src/librustc_trans/trans/cabi_powerpc64.rs
@@ -153,8 +153,11 @@ fn is_homogenous_aggregate_ty(ty: Type) -> Option<(Type, u64)> {
 
 fn classify_ret_ty(ccx: &CrateContext, ty: Type) -> ArgType {
     if is_reg_ty(ty) {
-        let attr = if ty == Type::i1(ccx) { Some(Attribute::ZExt) } else { None };
-        return ArgType::direct(ty, None, None, attr);
+        if ty.kind() == Integer && ty.int_width() < 32 {
+            return ArgType::extend(ty);
+        } else {
+            return ArgType::direct(ty, None, None, None);
+        }
     }
 
     // The PowerPC64 big endian ABI doesn't return aggregates in registers
@@ -187,8 +190,11 @@ fn classify_ret_ty(ccx: &CrateContext, ty: Type) -> ArgType {
 
 fn classify_arg_ty(ccx: &CrateContext, ty: Type) -> ArgType {
     if is_reg_ty(ty) {
-        let attr = if ty == Type::i1(ccx) { Some(Attribute::ZExt) } else { None };
-        return ArgType::direct(ty, None, None, attr);
+        if ty.kind() == Integer && ty.int_width() < 32 {
+            return ArgType::extend(ty);
+        } else {
+            return ArgType::direct(ty, None, None, None);
+        }
     }
     if let Some((base_ty, members)) = is_homogenous_aggregate_ty(ty) {
         let llty = Type::array(&base_ty, members);

--- a/src/librustc_trans/trans/cabi_x86.rs
+++ b/src/librustc_trans/trans/cabi_x86.rs
@@ -56,8 +56,11 @@ pub fn compute_abi_info(ccx: &CrateContext,
             }
         }
     } else {
-        let attr = if rty == Type::i1(ccx) { Some(Attribute::ZExt) } else { None };
-        ret_ty = ArgType::direct(rty, None, None, attr);
+        ret_ty = if rty.kind() == Integer && rty.int_width() < 32 {
+            ArgType::extend(rty)
+        } else {
+            ArgType::direct(rty, None, None, None)
+        };
     }
 
     for &t in atys {
@@ -71,8 +74,11 @@ pub fn compute_abi_info(ccx: &CrateContext,
                 }
             }
             _ => {
-                let attr = if t == Type::i1(ccx) { Some(Attribute::ZExt) } else { None };
-                ArgType::direct(t, None, None, attr)
+                if t.kind() == Integer && t.int_width() < 32 {
+                    ArgType::extend(t)
+                } else {
+                    ArgType::direct(t, None, None, None)
+                }
             }
         };
         arg_tys.push(ty);

--- a/src/librustc_trans/trans/cabi_x86_64.rs
+++ b/src/librustc_trans/trans/cabi_x86_64.rs
@@ -405,8 +405,12 @@ pub fn compute_abi_info(ccx: &CrateContext,
                                 None)
             }
         } else {
-            let attr = if ty == Type::i1(ccx) { Some(Attribute::ZExt) } else { None };
-            ArgType::direct(ty, None, None, attr)
+            // Extend integer types that are < 32 bits wide
+            if ty.kind() == Integer && ty.int_width() < 32 {
+                ArgType::extend(ty)
+            } else {
+                ArgType::direct(ty, None, None, None)
+            }
         }
     }
 

--- a/src/test/run-make/cabi-int-widening/Makefile
+++ b/src/test/run-make/cabi-int-widening/Makefile
@@ -1,0 +1,10 @@
+-include ../tools.mk
+
+all: $(call NATIVE_STATICLIB,cfoo)
+	$(RUSTC) foo.rs
+	$(call RUN,foo)
+
+# Need to optimize the C code so it actually takes advantage
+# of the ABI semantics
+$(TMPDIR)/libcfoo.o: cfoo.c
+	$(call COMPILE_OBJ,$(TMPDIR)/libcfoo.o,cfoo.c -O)

--- a/src/test/run-make/cabi-int-widening/cfoo.c
+++ b/src/test/run-make/cabi-int-widening/cfoo.c
@@ -1,0 +1,4 @@
+// ignore-license
+int foo(char x) {
+    return (int)x;
+}

--- a/src/test/run-make/cabi-int-widening/foo.rs
+++ b/src/test/run-make/cabi-int-widening/foo.rs
@@ -1,0 +1,22 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[link(name = "cfoo")]
+extern {
+    fn foo(x: i8) -> i32;
+}
+
+fn main() {
+    let x = unsafe {
+        foo(-1)
+    };
+
+    assert!(x == -1);
+}


### PR DESCRIPTION
The C ABI on most platforms expects integers to be extended up to the appropriate size. This requires annotation in LLVM to indicate whether or not to do sign extension or zero extension. Foreign code may rely on the extension behaviour and for signed integers the value passed may be incorrect.

Fixes #30841 and #31315
