### PR TITLE
Bsd stat fixes

### DIFF
--- a/src/libstd/os/dragonfly/raw.rs
+++ b/src/libstd/os/dragonfly/raw.rs
@@ -18,6 +18,8 @@
                               definitions")]
 #![allow(deprecated)]
 
+use os::raw::c_long;
+
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
@@ -49,17 +51,17 @@ pub struct stat {
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_rdev: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_atime: i64,
+    pub st_atime: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_atime_nsec: i64,
+    pub st_atime_nsec: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_mtime: i64,
+    pub st_mtime: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_mtime_nsec: i64,
+    pub st_mtime_nsec: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_ctime: i64,
+    pub st_ctime: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_ctime_nsec: i64,
+    pub st_ctime_nsec: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_size: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
@@ -73,7 +75,7 @@ pub struct stat {
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_lspare: i32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_birthtime: i64,
+    pub st_birthtime: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_birthtime_nsec: i64,
+    pub st_birthtime_nsec: c_long,
 }

--- a/src/libstd/os/dragonfly/raw.rs
+++ b/src/libstd/os/dragonfly/raw.rs
@@ -18,9 +18,6 @@
                               definitions")]
 #![allow(deprecated)]
 
-use os::raw::c_long;
-use os::unix::raw::{uid_t, gid_t};
-
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;

--- a/src/libstd/os/freebsd/raw.rs
+++ b/src/libstd/os/freebsd/raw.rs
@@ -78,4 +78,7 @@ pub struct stat {
     pub st_birthtime: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_birthtime_nsec: c_long,
+    #[cfg(target_arch = "x86")]
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub __unused: [u8; 8],
 }

--- a/src/libstd/os/freebsd/raw.rs
+++ b/src/libstd/os/freebsd/raw.rs
@@ -18,134 +18,62 @@
                               definitions")]
 #![allow(deprecated)]
 
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type fflags_t = u32;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type fflags_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
 #[unstable(feature = "pthread_t", issue = "29791")] pub type pthread_t = usize;
 
-#[doc(inline)]
+#[repr(C)]
+#[derive(Clone)]
 #[stable(feature = "raw_ext", since = "1.1.0")]
-pub use self::arch::{stat, time_t};
-
-#[cfg(target_arch = "x86")]
-mod arch {
-    use super::{off_t, dev_t, ino_t, mode_t, nlink_t, blksize_t, blkcnt_t, fflags_t};
-    use os::raw::c_long;
-    use os::unix::raw::{uid_t, gid_t};
-
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
-
-    #[repr(C)]
-    #[derive(Clone)]
+pub struct stat {
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub struct stat {
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_dev: dev_t,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_ino: ino_t,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_mode: mode_t,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_nlink: nlink_t,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_uid: uid_t,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_gid: gid_t,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_rdev: dev_t,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_atime: time_t,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_atime_nsec: c_long,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_mtime: time_t,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_mtime_nsec: c_long,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_ctime: time_t,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_ctime_nsec: c_long,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_size: off_t,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_blocks: blkcnt_t,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_blksize: blksize_t,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_flags: fflags_t,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_gen: u32,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_lspare: i32,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_birthtime: time_t,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_birthtime_nsec: c_long,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub __unused: [u8; 8],
-    }
-}
-
-#[cfg(target_arch = "x86_64")]
-mod arch {
-    use super::{off_t, dev_t, ino_t, mode_t, nlink_t, blksize_t, blkcnt_t, fflags_t};
-    use os::raw::c_long;
-    use os::unix::raw::{uid_t, gid_t};
-
-    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
-
-    #[repr(C)]
-    #[derive(Clone)]
+    pub st_dev: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub struct stat {
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_dev: u32,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_ino: u32,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_mode: u16,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_nlink: u16,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_uid: u32,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_gid: u32,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_rdev: u32,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_atime: i64,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_atime_nsec: i64,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_mtime: i64,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_mtime_nsec: i64,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_ctime: i64,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_ctime_nsec: i64,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_size: i64,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_blocks: i64,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_blksize: u32,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_flags: u32,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_gen: u32,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_lspare: i32,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_birthtime: i64,
-        #[stable(feature = "raw_ext", since = "1.1.0")]
-        pub st_birthtime_nsec: i64,
-    }
+    pub st_ino: u32,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_mode: u16,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_nlink: u16,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_uid: u32,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_gid: u32,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_rdev: u32,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_atime: i64,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_atime_nsec: i64,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_mtime: i64,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_mtime_nsec: i64,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_ctime: i64,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_ctime_nsec: i64,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_size: i64,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_blocks: i64,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_blksize: u32,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_flags: u32,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_gen: u32,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_lspare: i32,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_birthtime: i64,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_birthtime_nsec: i64,
 }
-

--- a/src/libstd/os/freebsd/raw.rs
+++ b/src/libstd/os/freebsd/raw.rs
@@ -18,6 +18,8 @@
                               definitions")]
 #![allow(deprecated)]
 
+use os::raw::c_long;
+
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u64;
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
@@ -49,17 +51,17 @@ pub struct stat {
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_rdev: u32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_atime: i64,
+    pub st_atime: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_atime_nsec: i64,
+    pub st_atime_nsec: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_mtime: i64,
+    pub st_mtime: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_mtime_nsec: i64,
+    pub st_mtime_nsec: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_ctime: i64,
+    pub st_ctime: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_ctime_nsec: i64,
+    pub st_ctime_nsec: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_size: i64,
     #[stable(feature = "raw_ext", since = "1.1.0")]
@@ -73,7 +75,7 @@ pub struct stat {
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_lspare: i32,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_birthtime: i64,
+    pub st_birthtime: c_long,
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub st_birthtime_nsec: i64,
+    pub st_birthtime_nsec: c_long,
 }


### PR DESCRIPTION
In https://github.com/rust-lang/rust/issues/25155 the os::freebsd::raw stat was split for the x86 vs. x86-64 cases, which appears to have been done to implement the padding on the end of struct stat for the x86 case (the struct is otherwise the same notwistanding the size of long).

This PR de-duplicates the struct using #[cfg(target_arch = "x86")] for the __unused field, which also fixes the definitions which had sinced changed with the LFS work d088b671872f1df6993ccca6fa6139ebed0a8cf3.

Also changed definitions to c_long for dragonfly and freebsd where appropriate.

Also removes some unused imports that the compiler was complaining about.

dragonfly's long time_t:
https://gitweb.dragonflybsd.org/dragonfly.git/blob/a2a57c243ff8016578bc559f8603fb25bbcf1768:/lib/libstand/machine/stdint.h

freebsd's long time_t:
https://svnweb.freebsd.org/base/release/10.1.0/sys/x86/include/_types.h?view=markup
https://github.com/rust-lang/rust/blob/d088b671872f1df6993ccca6fa6139ebed0a8cf3/src/liblibc/lib.rs#L980

freebsd's padding for i686 stat:
https://svnweb.freebsd.org/base/release/10.1.0/sys/sys/stat.h?view=markup#l139
https://github.com/rust-lang/rust/blob/d088b671872f1df6993ccca6fa6139ebed0a8cf3/src/liblibc/lib.rs#L1038
