### PR TITLE
bring freebsd linker config up-to-date (same as dragonfly)

### DIFF
--- a/src/librustc_back/target/freebsd_base.rs
+++ b/src/librustc_back/target/freebsd_base.rs
@@ -16,13 +16,20 @@ pub fn opts() -> TargetOptions {
         linker: "cc".to_string(),
         dynamic_linking: true,
         executables: true,
+        linker_is_gnu: true,
         has_rpath: true,
-        pre_link_args: vec![
+        pre_link_args: vec!(
+            // GNU-style linkers will use this to omit linking to libraries
+            // which don't actually fulfill any relocations, but only for
+            // libraries which follow this flag.  Thus, use it before
+            // specifying libraries to link to.
+            "-Wl,--as-needed".to_string(),
+
             // Always enable NX protection when it is available
             "-Wl,-z,noexecstack".to_string(),
-        ],
+        ),
+        position_independent_executables: true,
         exe_allocation_crate: super::maybe_jemalloc(),
-
         .. Default::default()
     }
 }


### PR DESCRIPTION
The FreeBSD linker config is missing some options present in the other BSD configs.

This seems accidental, with other BSDs having the flags added in platform-specific commits, or with the flags present from day 1.

Some other BSD commits for reference:
https://github.com/aliclark/rust/commit/fcb30a0b67b1bd4acbc3422ff74fac5d031ae1ae#diff-db69d903e469b7769aefaa31786fc2c4R1
https://github.com/aliclark/rust/commit/0b7c4f57f6ba59dabe4db2808fe45e8bd8bbce22#diff-1c7b74536ce0291d1f89953035f26a71R1

https://github.com/aliclark/rust/commit/cfd2a5cfa148b1c927571cc2e9f06e242831b696
