### PR TITLE
fmt: Make sure write_fmt's implementation can use write_char

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -121,6 +121,10 @@ pub trait Write {
                 self.0.write_str(s)
             }
 
+            fn write_char(&mut self, c: char) -> Result {
+                self.0.write_char(c)
+            }
+
             fn write_fmt(&mut self, args: Arguments) -> Result {
                 self.0.write_fmt(args)
             }


### PR DESCRIPTION
fmt: Make sure write_fmt's implementation can use write_char

It looks like the Adapter inside write_fmt was never updated to forward
the write_char method.
