### PR TITLE
std: Prefix jemalloc symbols on iOS

### DIFF
--- a/src/liballoc_jemalloc/lib.rs
+++ b/src/liballoc_jemalloc/lib.rs
@@ -45,19 +45,19 @@ extern {}
 // explicitly request it), and on Android we explicitly request it as
 // unprefixing cause segfaults (mismatches in allocators).
 extern {
-    #[cfg_attr(any(target_os = "macos", target_os = "android"),
+    #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios"),
                link_name = "je_mallocx")]
     fn mallocx(size: size_t, flags: c_int) -> *mut c_void;
-    #[cfg_attr(any(target_os = "macos", target_os = "android"),
+    #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios"),
                link_name = "je_rallocx")]
     fn rallocx(ptr: *mut c_void, size: size_t, flags: c_int) -> *mut c_void;
-    #[cfg_attr(any(target_os = "macos", target_os = "android"),
+    #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios"),
                link_name = "je_xallocx")]
     fn xallocx(ptr: *mut c_void, size: size_t, extra: size_t, flags: c_int) -> size_t;
-    #[cfg_attr(any(target_os = "macos", target_os = "android"),
+    #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios"),
                link_name = "je_sdallocx")]
     fn sdallocx(ptr: *mut c_void, size: size_t, flags: c_int);
-    #[cfg_attr(any(target_os = "macos", target_os = "android"),
+    #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios"),
                link_name = "je_nallocx")]
     fn nallocx(size: size_t, flags: c_int) -> size_t;
 }


### PR DESCRIPTION
Similar to OSX, these symbols are prefixed by default.
