### PR TITLE
Remove unnecessary explicit lifetime bounds.

### DIFF
--- a/src/librustc_data_structures/graph/mod.rs
+++ b/src/librustc_data_structures/graph/mod.rs
@@ -115,7 +115,7 @@ impl<N:Debug,E:Debug> Graph<N,E> {
     // Simple accessors
 
     #[inline]
-    pub fn all_nodes<'a>(&'a self) -> &'a [Node<N>] {
+    pub fn all_nodes(&self) -> &[Node<N>] {
         &self.nodes
     }
 
@@ -125,7 +125,7 @@ impl<N:Debug,E:Debug> Graph<N,E> {
     }
 
     #[inline]
-    pub fn all_edges<'a>(&'a self) -> &'a [Edge<E>] {
+    pub fn all_edges(&self) -> &[Edge<E>] {
         &self.edges
     }
 
@@ -150,15 +150,15 @@ impl<N:Debug,E:Debug> Graph<N,E> {
         idx
     }
 
-    pub fn mut_node_data<'a>(&'a mut self, idx: NodeIndex) -> &'a mut N {
+    pub fn mut_node_data(&mut self, idx: NodeIndex) -> &mut N {
         &mut self.nodes[idx.0].data
     }
 
-    pub fn node_data<'a>(&'a self, idx: NodeIndex) -> &'a N {
+    pub fn node_data(&self, idx: NodeIndex) -> &N {
         &self.nodes[idx.0].data
     }
 
-    pub fn node<'a>(&'a self, idx: NodeIndex) -> &'a Node<N> {
+    pub fn node(&self, idx: NodeIndex) -> &Node<N> {
         &self.nodes[idx.0]
     }
 
@@ -199,15 +199,15 @@ impl<N:Debug,E:Debug> Graph<N,E> {
         return idx;
     }
 
-    pub fn mut_edge_data<'a>(&'a mut self, idx: EdgeIndex) -> &'a mut E {
+    pub fn mut_edge_data(&mut self, idx: EdgeIndex) -> &mut E {
         &mut self.edges[idx.0].data
     }
 
-    pub fn edge_data<'a>(&'a self, idx: EdgeIndex) -> &'a E {
+    pub fn edge_data(&self, idx: EdgeIndex) -> &E {
         &self.edges[idx.0].data
     }
 
-    pub fn edge<'a>(&'a self, idx: EdgeIndex) -> &'a Edge<E> {
+    pub fn edge(&self, idx: EdgeIndex) -> &Edge<E> {
         &self.edges[idx.0]
     }
 
@@ -257,11 +257,11 @@ impl<N:Debug,E:Debug> Graph<N,E> {
         AdjacentEdges { graph: self, direction: direction, next: first_edge }
     }
 
-    pub fn successor_nodes<'a>(&'a self, source: NodeIndex) -> AdjacentTargets<N,E> {
+    pub fn successor_nodes(&self, source: NodeIndex) -> AdjacentTargets<N,E> {
         self.outgoing_edges(source).targets()
     }
 
-    pub fn predecessor_nodes<'a>(&'a self, target: NodeIndex) -> AdjacentSources<N,E> {
+    pub fn predecessor_nodes(&self, target: NodeIndex) -> AdjacentSources<N,E> {
         self.incoming_edges(target).sources()
     }
 

--- a/src/librustc_data_structures/snapshot_vec.rs
+++ b/src/librustc_data_structures/snapshot_vec.rs
@@ -91,14 +91,14 @@ impl<D:SnapshotVecDelegate> SnapshotVec<D> {
         len
     }
 
-    pub fn get<'a>(&'a self, index: usize) -> &'a D::Value {
+    pub fn get(&self, index: usize) -> &D::Value {
         &self.values[index]
     }
 
     /// Returns a mutable pointer into the vec; whatever changes you make here cannot be undone
     /// automatically, so you should be sure call `record()` with some sort of suitable undo
     /// action.
-    pub fn get_mut<'a>(&'a mut self, index: usize) -> &'a mut D::Value {
+    pub fn get_mut(&mut self, index: usize) -> &mut D::Value {
         &mut self.values[index]
     }
 

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -261,12 +261,12 @@ impl AttrBuilder {
         }
     }
 
-    pub fn arg<'a, T: AttrHelper + 'static>(&'a mut self, idx: usize, a: T) -> &'a mut AttrBuilder {
+    pub fn arg<T: AttrHelper + 'static>(&mut self, idx: usize, a: T) -> &mut AttrBuilder {
         self.attrs.push((idx, box a as Box<AttrHelper+'static>));
         self
     }
 
-    pub fn ret<'a, T: AttrHelper + 'static>(&'a mut self, a: T) -> &'a mut AttrBuilder {
+    pub fn ret<T: AttrHelper + 'static>(&mut self, a: T) -> &mut AttrBuilder {
         self.attrs.push((ReturnIndex as usize, box a as Box<AttrHelper+'static>));
         self
     }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1289,7 +1289,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                      span: Span,
                                      lp: LastPrivate)
                                      -> ResolveResult<(Module<'a>, LastPrivate)> {
-        fn search_parent_externals<'a>(needle: Name, module: Module<'a>) -> Option<Module<'a>> {
+        fn search_parent_externals(needle: Name, module: Module) -> Option<Module> {
             match module.resolve_name(needle, TypeNS, false) {
                 Success(binding) if binding.is_extern_crate() => Some(module),
                 _ => match module.parent_link {
@@ -3513,10 +3513,10 @@ fn path_names_to_string(path: &Path, depth: usize) -> String {
 }
 
 /// A somewhat inefficient routine to obtain the name of a module.
-fn module_to_string<'a>(module: Module<'a>) -> String {
+fn module_to_string(module: Module) -> String {
     let mut names = Vec::new();
 
-    fn collect_mod<'a>(names: &mut Vec<ast::Name>, module: Module<'a>) {
+    fn collect_mod(names: &mut Vec<ast::Name>, module: Module) {
         match module.parent_link {
             NoParentLink => {}
             ModuleParentLink(ref module, name) => {

--- a/src/librustc_unicode/u_str.rs
+++ b/src/librustc_unicode/u_str.rs
@@ -30,9 +30,9 @@ pub trait UnicodeStr {
     fn split_whitespace<'a>(&'a self) -> SplitWhitespace<'a>;
     fn is_whitespace(&self) -> bool;
     fn is_alphanumeric(&self) -> bool;
-    fn trim<'a>(&'a self) -> &'a str;
-    fn trim_left<'a>(&'a self) -> &'a str;
-    fn trim_right<'a>(&'a self) -> &'a str;
+    fn trim(&self) -> &str;
+    fn trim_left(&self) -> &str;
+    fn trim_right(&self) -> &str;
 }
 
 impl UnicodeStr for str {

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -1227,7 +1227,7 @@ impl<'a> Index<&'a str>  for Json {
 impl Index<usize> for Json {
     type Output = Json;
 
-    fn index<'a>(&'a self, idx: usize) -> &'a Json {
+    fn index(&self, idx: usize) -> &Json {
         match *self {
             Json::Array(ref v) => &v[idx],
             _ => panic!("can only index Json with usize if it is an array")
@@ -1309,7 +1309,7 @@ impl Stack {
     /// Provides access to the StackElement at a given index.
     /// lower indices are at the bottom of the stack while higher indices are
     /// at the top.
-    pub fn get<'l>(&'l self, idx: usize) -> StackElement<'l> {
+    pub fn get(&self, idx: usize) -> StackElement {
         match self.stack[idx] {
             InternalIndex(i) => StackElement::Index(i),
             InternalKey(start, size) => {
@@ -1351,7 +1351,7 @@ impl Stack {
     }
 
     /// Returns the top-most element (if any).
-    pub fn top<'l>(&'l self) -> Option<StackElement<'l>> {
+    pub fn top(&self) -> Option<StackElement> {
         match self.stack.last() {
             None => None,
             Some(&InternalIndex(i)) => Some(StackElement::Index(i)),
@@ -1463,7 +1463,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
 
     /// Provides access to the current position in the logical structure of the
     /// JSON stream.
-    pub fn stack<'l>(&'l self) -> &'l Stack {
+    pub fn stack(&self) -> &Stack {
         &self.stack
     }
 

--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -403,10 +403,10 @@ enum Flavor<T> {
 #[doc(hidden)]
 trait UnsafeFlavor<T> {
     fn inner_unsafe(&self) -> &UnsafeCell<Flavor<T>>;
-    unsafe fn inner_mut<'a>(&'a self) -> &'a mut Flavor<T> {
+    unsafe fn inner_mut(&self) -> &mut Flavor<T> {
         &mut *self.inner_unsafe().get()
     }
-    unsafe fn inner<'a>(&'a self) -> &'a Flavor<T> {
+    unsafe fn inner(&self) -> &Flavor<T> {
         &*self.inner_unsafe().get()
     }
 }

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -55,11 +55,11 @@ pub struct TtReader<'a> {
 /// This can do Macro-By-Example transcription. On the other hand, if
 /// `src` contains no `TokenTree::Sequence`s, `MatchNt`s or `SubstNt`s, `interp` can
 /// (and should) be None.
-pub fn new_tt_reader<'a>(sp_diag: &'a Handler,
-                         interp: Option<HashMap<Name, Rc<NamedMatch>>>,
-                         imported_from: Option<Ident>,
-                         src: Vec<ast::TokenTree>)
-                         -> TtReader<'a> {
+pub fn new_tt_reader(sp_diag: &Handler,
+                     interp: Option<HashMap<Name, Rc<NamedMatch>>>,
+                     imported_from: Option<Ident>,
+                     src: Vec<ast::TokenTree>)
+                     -> TtReader {
     new_tt_reader_with_doc_flag(sp_diag, interp, imported_from, src, false)
 }
 
@@ -69,12 +69,12 @@ pub fn new_tt_reader<'a>(sp_diag: &'a Handler,
 /// This can do Macro-By-Example transcription. On the other hand, if
 /// `src` contains no `TokenTree::Sequence`s, `MatchNt`s or `SubstNt`s, `interp` can
 /// (and should) be None.
-pub fn new_tt_reader_with_doc_flag<'a>(sp_diag: &'a Handler,
-                                       interp: Option<HashMap<Name, Rc<NamedMatch>>>,
-                                       imported_from: Option<Ident>,
-                                       src: Vec<ast::TokenTree>,
-                                       desugar_doc_comments: bool)
-                                       -> TtReader<'a> {
+pub fn new_tt_reader_with_doc_flag(sp_diag: &Handler,
+                                   interp: Option<HashMap<Name, Rc<NamedMatch>>>,
+                                   imported_from: Option<Ident>,
+                                   src: Vec<ast::TokenTree>,
+                                   desugar_doc_comments: bool)
+                                   -> TtReader {
     let mut r = TtReader {
         sp_diag: sp_diag,
         stack: vec!(TtFrame {

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -211,10 +211,10 @@ pub trait Terminal: Write {
     fn reset(&mut self) -> io::Result<bool>;
 
     /// Gets an immutable reference to the stream inside
-    fn get_ref<'a>(&'a self) -> &'a Self::Output;
+    fn get_ref(&self) -> &Self::Output;
 
     /// Gets a mutable reference to the stream inside
-    fn get_mut<'a>(&'a mut self) -> &'a mut Self::Output;
+    fn get_mut(&mut self) -> &mut Self::Output;
 
     /// Returns the contained stream, destroying the `Terminal`
     fn into_inner(self) -> Self::Output where Self: Sized;

--- a/src/libterm/terminfo/mod.rs
+++ b/src/libterm/terminfo/mod.rs
@@ -205,11 +205,11 @@ impl<T: Write + Send> Terminal for TerminfoTerminal<T> {
         self.out.write_all(&cmd).and(Ok(true))
     }
 
-    fn get_ref<'a>(&'a self) -> &'a T {
+    fn get_ref(&self) -> &T {
         &self.out
     }
 
-    fn get_mut<'a>(&'a mut self) -> &'a mut T {
+    fn get_mut(&mut self) -> &mut T {
         &mut self.out
     }
 


### PR DESCRIPTION
These explicit lifetimes can be ommitted because of lifetime elision
rules. Instances were found using rust-clippy.
