### PR TITLE
syntax: Always pretty print a newline after doc comments

### DIFF
--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -752,7 +752,8 @@ pub trait PrintState<'a> {
         }
         try!(self.maybe_print_comment(attr.span.lo));
         if attr.node.is_sugared_doc {
-            word(self.writer(), &attr.value_str().unwrap())
+            try!(word(self.writer(), &attr.value_str().unwrap()));
+            hardbreak(self.writer())
         } else {
             match attr.node.style {
                 ast::AttrStyle::Inner => try!(word(self.writer(), "#![")),

--- a/src/test/pretty/top-level-doc-comments.rs
+++ b/src/test/pretty/top-level-doc-comments.rs
@@ -1,0 +1,20 @@
+/// Some doc comment.
+struct X;
+
+// ignore-license
+
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// pp-exact
+
+// Test that rust can properly pretty print a doc comment if it's the first line in a file.  some
+
+fn main() { let x = X; }


### PR DESCRIPTION
Before this patch, code that had a doc comment as the first
line, as in:

``` rust
/// Foo
struct Foo;
```

Was pretty printed into:

``` rust
///Foostruct Foo;
```

This makes sure that that there is always a trailing newline
after a doc comment.

Closes #31722
