### PR TITLE
Make future-compat lint `match_of_unit_variant_via_paren_dotdot` deny by default

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -132,7 +132,7 @@ declare_lint! {
 
 declare_lint! {
     pub MATCH_OF_UNIT_VARIANT_VIA_PAREN_DOTDOT,
-    Warn,
+    Deny,
     "unit struct or enum variant erroneously allowed to match via path::ident(..)"
 }
 

--- a/src/test/compile-fail/empty-struct-unit-pat.rs
+++ b/src/test/compile-fail/empty-struct-unit-pat.rs
@@ -12,7 +12,6 @@
 
 // aux-build:empty-struct.rs
 
-#![feature(rustc_attrs)]
 // remove prior feature after warning cycle and promoting warnings to errors
 #![feature(braced_empty_structs)]
 
@@ -26,8 +25,7 @@ enum E {
 }
 
 // remove attribute after warning cycle and promoting warnings to errors
-#[rustc_error]
-fn main() { //~ ERROR: compilation successful
+fn main() {
     let e2 = Empty2;
     let e4 = E::Empty4;
     let xe2 = XEmpty2;
@@ -41,12 +39,12 @@ fn main() { //~ ERROR: compilation successful
     //     XEmpty2() => () // ERROR `XEmpty2` does not name a tuple variant or a tuple struct
     // }
     match e2 {
-        Empty2(..) => () //~ WARN `Empty2` does not name a tuple variant or a tuple struct
-            //~^ WARN hard error
+        Empty2(..) => () //~ ERROR `Empty2` does not name a tuple variant or a tuple struct
+            //~^ ERROR hard error
     }
     match xe2 {
-        XEmpty2(..) => () //~ WARN `XEmpty2` does not name a tuple variant or a tuple struct
-            //~^ WARN hard error
+        XEmpty2(..) => () //~ ERROR `XEmpty2` does not name a tuple variant or a tuple struct
+            //~^ ERROR hard error
     }
     // Rejected by parser as yet
     // match e4 {
@@ -57,12 +55,12 @@ fn main() { //~ ERROR: compilation successful
     //     _ => {},
     // }
     match e4 {
-        E::Empty4(..) => () //~ WARN `E::Empty4` does not name a tuple variant or a tuple struct
-            //~^ WARN hard error
+        E::Empty4(..) => () //~ ERROR `E::Empty4` does not name a tuple variant or a tuple struct
+            //~^ ERROR hard error
     }
     match xe4 {
-        XE::XEmpty4(..) => (), //~ WARN `XE::XEmpty4` does not name a tuple variant or a tuple
-            //~^ WARN hard error
+        XE::XEmpty4(..) => (), //~ ERROR `XE::XEmpty4` does not name a tuple variant or a tuple
+            //~^ ERROR hard error
         _ => {},
     }
 }

--- a/src/test/run-pass/issue-pr29383.rs
+++ b/src/test/run-pass/issue-pr29383.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(match_of_unit_variant_via_paren_dotdot)]
+
 enum E {
     A,
     B,


### PR DESCRIPTION
This warning was introduced on Nov 28, 2015 and got into 1.6 stable, it was later requalified from a hardwired warning to a warn-by-default lint.
If this patch is landed soon enough, then `match_of_unit_variant_via_paren_dotdot` will get into 1.8 stable as a deny-by-default lint.
My intention is to turn it into a hard error after March 3, 2016, then it will hit stable at 1.9.

r? @nikomatsakis 
cc @pnkfelix 
