### PR TITLE
Implement read_volatile and write_volatile

### DIFF
--- a/src/test/run-make/volatile-intrinsics/main.rs
+++ b/src/test/run-make/volatile-intrinsics/main.rs
@@ -8,14 +8,20 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(core_intrinsics)]
+#![feature(core_intrinsics, volatile)]
 
 use std::intrinsics::{volatile_load, volatile_store};
+use std::ptr::{read_volatile, write_volatile};
 
 pub fn main() {
     unsafe {
         let mut i : isize = 1;
         volatile_store(&mut i, 2);
         assert_eq!(volatile_load(&i), 2);
+    }
+    unsafe {
+        let mut i : isize = 1;
+        write_volatile(&mut i, 2);
+        assert_eq!(read_volatile(&i), 2);
     }
 }


### PR DESCRIPTION
Tracking issue: #31756
RFC: rust-lang/rfcs#1467

I've made these unstable for now. Should they be stabilized straight away since we've had plenty of experience with people using the unstable intrinsics?
