### PR TITLE
Ignore the test added in #31717

### DIFF
--- a/src/test/run-pass/issue-31702.rs
+++ b/src/test/run-pass/issue-31702.rs
@@ -10,6 +10,11 @@
 
 // aux-build:issue-31702-1.rs
 // aux-build:issue-31702-2.rs
+// ignore-test: FIXME(#31702) when this test was added it was thought that the
+//                            accompanying llvm update would fix it, but
+//                            unfortunately it appears that was not the case. In
+//                            the interest of not deleting the test, though,
+//                            this is just tagged with ignore-test
 
 // this test is actually entirely in the linked library crates
 


### PR DESCRIPTION
In #31717 we rebased our LLVM fork over the 3.8 release branch, and it was
thought that this fixed #31702. The testing, however, must have been erroneous,
as it unfortunately didn't fix the issue! Our MUSL nightly builders are failing
from the same assertion reported in the issue, so we at least know the test case
is a reproduction!

I believe the failure is only happening on the MUSL nightly builders because
none of the auto builders have LLVM assertions enabled, and the Linux nightly
builder _does_ have assertions enabled for the binaries we generate but the
distcheck run doesn't test a compiler with LLVM assertions enabled.
