### PR TITLE
test: Fix a spuriously failing test on valgrind

### DIFF
--- a/src/test/run-pass-valgrind/down-with-thread-dtors.rs
+++ b/src/test/run-pass-valgrind/down-with-thread-dtors.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// no-prefer-dynamic
+
 thread_local!(static FOO: Foo = Foo);
 thread_local!(static BAR: Bar = Bar(1));
 thread_local!(static BAZ: Baz = Baz);


### PR DESCRIPTION
It's unclear to me whether this test failing under valgrind is actually legit.
The test only fails in valgrind when everything is dynamically linked, and it
appears to work when statically linked.

For now just add the `// no-prefer-dynamic` directive and let's just chalk it up
to a weird valgrind issue.

Closes #31328
