### PR TITLE
Enable building freestanding sysroot with cargo

### DIFF
--- a/src/liballoc/Cargo.toml
+++ b/src/liballoc/Cargo.toml
@@ -10,5 +10,3 @@ test = false
 
 [dependencies]
 core = { path = "../libcore" }
-libc = { path = "../rustc/libc_shim" }
-alloc_system = { path = "../liballoc_system" }

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -92,15 +92,8 @@
 #![feature(unsafe_no_drop_flag, filling_drop)]
 #![feature(unsize)]
 
-// Issue# 30592: Systematically use alloc_system during stage0 since jemalloc
-// might be unavailable or disabled
-#![cfg_attr(stage0, feature(alloc_system))]
-
 #![cfg_attr(not(test), feature(raw, fn_traits, placement_new_protocol))]
 #![cfg_attr(test, feature(test, rustc_private, box_heap))]
-
-#[cfg(stage0)]
-extern crate alloc_system;
 
 // Allow testing this library
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -269,6 +269,10 @@
 #![feature(vec_push_all)]
 #![feature(zero_one)]
 
+// Issue# 30592: Systematically use alloc_system during stage0 since jemalloc
+// might be unavailable or disabled
+#![cfg_attr(stage0, feature(alloc_system))]
+
 // Don't link to std. We are std.
 #![no_std]
 
@@ -294,6 +298,9 @@ extern crate collections as core_collections;
 extern crate alloc;
 extern crate rustc_unicode;
 extern crate libc;
+
+#[cfg(stage0)]
+extern crate alloc_system;
 
 // Make std testable by not duplicating lang items and other globals. See #2912
 #[cfg(test)] extern crate std as realstd;


### PR DESCRIPTION
With these changes you can build a freestanding sysroot without using floating points using a Cargo.toml and copying the `deps` folder cargo outputs.

```
[package]
name = "sysroot"
version = "0.1.0"

[lib]
path = "lib.rs"
crate-type = ["rlib"]

[dependencies.core]
path = "../vendor/rust/src/src/libcore"
features = ["disable_float"]

[dependencies]
collections = { path = "../vendor/rust/src/src/libcollections" }
```
