### PR TITLE
mk: Add missing rustbuild dirs to `dist`

### DIFF
--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -48,6 +48,8 @@ PKG_FILES := \
     $(S)configure $(S)Makefile.in              \
     $(S)man                                    \
     $(addprefix $(S)src/,                      \
+      bootstrap                                \
+      build_helper                             \
       compiletest                              \
       doc                                      \
       driver                                   \
@@ -60,6 +62,7 @@ PKG_FILES := \
       rt                                       \
       rtstartup                                \
       rustllvm                                 \
+      rustc                                    \
       snapshots.txt                            \
       rust-installer                           \
       rustbook                                 \


### PR DESCRIPTION
Forgot to add a few directories to `make dist` so `--enable-rustbuild` can
continue to work.

Closes #31801
