### PR TITLE
std: Use Android LFS off64_t, ftruncate64, and lseek64

### DIFF
--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -27,7 +27,10 @@ use sys_common::{AsInner, FromInner};
 
 #[cfg(target_os = "linux")]
 use libc::{stat64, fstat64, lstat64, off64_t, ftruncate64, lseek64, dirent64, readdir64_r, open64};
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "android")]
+use libc::{stat as stat64, fstat as fstat64, lstat as lstat64, off64_t, ftruncate64, lseek64,
+           dirent as dirent64, open as open64};
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 use libc::{stat as stat64, fstat as fstat64, lstat as lstat64, off_t as off64_t,
            ftruncate as ftruncate64, lseek as lseek64, dirent as dirent64, open as open64};
 #[cfg(not(any(target_os = "linux", target_os = "solaris")))]


### PR DESCRIPTION
Android should use 64-bit LFS symbols for `lseek` and `ftruncate`, lest
those offset parameters suffer a lossy cast down to a 32-bit `off_t`.

Unlike GNU/Linux, Android's `stat`, `dirent`, and related functions are
always 64-bit LFS compatible, and `open` already implies `O_LARGEFILE`,
so all those don't need to follow Linux.  It might be nice to unify them
anyway, but those other LFS symbols aren't present in API 18 bionic.

r? @alexcrichton
