### PR TITLE
Environment variable iterator overrides

### DIFF
--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -142,6 +142,17 @@ impl Iterator for Vars {
         })
     }
     fn size_hint(&self) -> (usize, Option<usize>) { self.inner.size_hint() }
+    fn count(self) -> usize { self.inner.count() }
+    fn nth(&mut self, n: usize) -> Option<(String, String)> {
+        self.inner.nth(n).map(|(a, b)| {
+            (a.into_string().unwrap(), b.into_string().unwrap())
+        })
+    }
+    fn last(self) -> Option<(String, String)> {
+        self.inner.last().map(|(a, b)| {
+            (a.into_string().unwrap(), b.into_string().unwrap())
+        })
+    }
 }
 
 #[stable(feature = "env", since = "1.0.0")]
@@ -149,6 +160,11 @@ impl Iterator for VarsOs {
     type Item = (OsString, OsString);
     fn next(&mut self) -> Option<(OsString, OsString)> { self.inner.next() }
     fn size_hint(&self) -> (usize, Option<usize>) { self.inner.size_hint() }
+    fn count(self) -> usize { self.inner.count() }
+    fn nth(&mut self, n: usize) -> Option<(OsString, OsString)> {
+        self.inner.nth(n)
+    }
+    fn last(self) -> Option<(OsString, OsString)> { self.inner.last() }
 }
 
 /// Fetches the environment variable `key` from the current process.

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -407,6 +407,11 @@ impl Iterator for Env {
     type Item = (OsString, OsString);
     fn next(&mut self) -> Option<(OsString, OsString)> { self.iter.next() }
     fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
+    fn count(self) -> usize { self.iter.count() }
+    fn nth(&mut self, n: usize) -> Option<(OsString, OsString)> {
+        self.iter.nth(n)
+    }
+    fn last(self) -> Option<(OsString, OsString)> { self.iter.last() }
 }
 
 #[cfg(target_os = "macos")]

--- a/src/test/run-pass/env-vars-iter.rs
+++ b/src/test/run-pass/env-vars-iter.rs
@@ -1,0 +1,68 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::process::Command;
+use std::env;
+
+fn check_var(&(ref key, ref val): &(String, String)) -> bool {
+    match &**key {
+        "FOO" => { assert_eq!(val, "BAR"); true },
+        "BAR" => { assert_eq!(val, "BAZ"); true },
+        "BAZ" => { assert_eq!(val, "FOO"); true },
+        _ => false,
+    }
+}
+
+fn main() {
+    if let Some(arg) = env::args().nth(1) {
+        match &*arg {
+            "empty" => {
+                assert_eq!(env::vars().count(), 0);
+                assert_eq!(env::vars().next(), None);
+                assert_eq!(env::vars().nth(1), None);
+                assert_eq!(env::vars().last(), None);
+            },
+            "many" => {
+                assert!(env::vars().count() >= 3);
+                assert!(env::vars().last().is_some());
+                assert_eq!(env::vars().filter(check_var).count(), 3);
+                assert_eq!(
+                    (0..env::vars().count())
+                        .map(|i| env::vars().nth(i).unwrap())
+                        .filter(check_var)
+                        .count(),
+                    3);
+            },
+            arg => {
+                panic!("Unexpected arg {}", arg);
+            },
+        }
+    } else {
+        // Command::env_clear does not work on Windows.
+        // https://github.com/rust-lang/rust/issues/31259
+        if !cfg!(windows) {
+            let status = Command::new(env::current_exe().unwrap())
+                                 .arg("empty")
+                                 .env_clear()
+                                 .status()
+                                 .unwrap();
+            assert_eq!(status.code(), Some(0));
+        }
+
+        let status = Command::new(env::current_exe().unwrap())
+                             .arg("many")
+                             .env("FOO", "BAR")
+                             .env("BAR", "BAZ")
+                             .env("BAZ", "FOO")
+                             .status()
+                             .unwrap();
+        assert_eq!(status.code(), Some(0));
+    }
+}


### PR DESCRIPTION
For case #24214, additional iterators mentioned in https://github.com/rust-lang/rust/issues/24214#issuecomment-98555383.

Overrides `std::env::{ Vars, VarsOs }::{ count, nth, last}` to proxy through to their inner iterator (would be nice if there were some iterator wrapper trait that meant these didn't need to be implemented every time an iterator was wrapped...).

Overrides `std::sys::unix::os::Env::{ count, nth, last }` to proxy through to the inner `vec::IntoIter`. Should make `count` faster, and future proofs in case `last` or `nth` get optimised implementations in the future.

Overrides `std::sys::windows::Env::{ count, nth, last }` to not allocate `OsString`s when not needed. Done by defining a sub-iterator that returns the raw pointers and lengths, this uses the default implementations as they should be pretty much equivalent to manually implemented versions, then in the outer iterator does the allocation with the result.

I don't have a machine I can actually test the windows changes on, with some hackery (https://gist.github.com/Nemo157/0d1f02b08c132f1a00da) I managed to get the type checker at least running to ensure it should compile. It would be nice if there were some way to test the higher level platform specific code. As far as I can tell testing `windows::Env` on unix would work fine if the infrastructure was setup for it.
