### PR TITLE
Fix `struct stat` usage on NetBSD

### DIFF
--- a/src/libstd/os/netbsd/fs.rs
+++ b/src/libstd/os/netbsd/fs.rs
@@ -74,8 +74,6 @@ pub trait MetadataExt {
     fn st_flags(&self) -> u32;
     #[stable(feature = "metadata_ext2", since = "1.8.0")]
     fn st_gen(&self) -> u32;
-    #[stable(feature = "metadata_ext2", since = "1.8.0")]
-    fn st_spare(&self) -> u32;
 }
 
 #[stable(feature = "metadata_ext", since = "1.1.0")]
@@ -115,25 +113,25 @@ impl MetadataExt for Metadata {
         self.as_inner().as_inner().st_atime as i64
     }
     fn st_atime_nsec(&self) -> i64 {
-        self.as_inner().as_inner().st_atime_nsec as i64
+        self.as_inner().as_inner().st_atimensec as i64
     }
     fn st_mtime(&self) -> i64 {
         self.as_inner().as_inner().st_mtime as i64
     }
     fn st_mtime_nsec(&self) -> i64 {
-        self.as_inner().as_inner().st_mtime_nsec as i64
+        self.as_inner().as_inner().st_mtimensec as i64
     }
     fn st_ctime(&self) -> i64 {
         self.as_inner().as_inner().st_ctime as i64
     }
     fn st_ctime_nsec(&self) -> i64 {
-        self.as_inner().as_inner().st_ctime_nsec as i64
+        self.as_inner().as_inner().st_ctimensec as i64
     }
     fn st_birthtime(&self) -> i64 {
         self.as_inner().as_inner().st_birthtime as i64
     }
     fn st_birthtime_nsec(&self) -> i64 {
-        self.as_inner().as_inner().st_birthtime_nsec as i64
+        self.as_inner().as_inner().st_birthtimensec as i64
     }
     fn st_blksize(&self) -> u64 {
         self.as_inner().as_inner().st_blksize as u64
@@ -146,9 +144,6 @@ impl MetadataExt for Metadata {
     }
     fn st_flags(&self) -> u32 {
         self.as_inner().as_inner().st_flags as u32
-    }
-    fn st_spare(&self) -> u32 {
-        self.as_inner().as_inner().st_spare as u32
     }
 }
 

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -119,7 +119,31 @@ impl FileAttr {
     }
 }
 
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(target_os = "netbsd")]
+impl FileAttr {
+    pub fn modified(&self) -> io::Result<SystemTime> {
+        Ok(SystemTime::from(libc::timespec {
+            tv_sec: self.stat.st_mtime as libc::time_t,
+            tv_nsec: self.stat.st_mtimensec as libc::c_long,
+        }))
+    }
+
+    pub fn accessed(&self) -> io::Result<SystemTime> {
+        Ok(SystemTime::from(libc::timespec {
+            tv_sec: self.stat.st_atime as libc::time_t,
+            tv_nsec: self.stat.st_atimensec as libc::c_long,
+        }))
+    }
+
+    pub fn created(&self) -> io::Result<SystemTime> {
+        Ok(SystemTime::from(libc::timespec {
+            tv_sec: self.stat.st_birthtime as libc::time_t,
+            tv_nsec: self.stat.st_birthtimensec as libc::c_long,
+        }))
+    }
+}
+
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "netbsd")))]
 impl FileAttr {
     pub fn modified(&self) -> io::Result<SystemTime> {
         Ok(SystemTime::from(libc::timespec {


### PR DESCRIPTION
Some struct members have a slighty different name on NetBSD. This has been fixed in the libc crate, but not in libstd, breaking the NetBSD build. Related C struct definition: http://nxr.netbsd.org/xref/src/sys/sys/stat.h?r=1.68#59

This also removes the broken `st_spare()` from MetadataExt, since it is private field reserved for future use.

@dhuseby In case this conflicts with any of your pending patches, feel free to intervene - I'm happy to withdraw this PR.

r? @alexcrichton 
