### PR TITLE
rustbuild: Sync some Cargo.toml/lib.rs dependencies

### DIFF
--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -17,6 +17,7 @@ graphviz = { path = "../libgraphviz" }
 log = { path = "../liblog" }
 rbml = { path = "../librbml" }
 rustc_back = { path = "../librustc_back" }
+rustc_bitflags = { path = "../librustc_bitflags" }
 rustc_data_structures = { path = "../librustc_data_structures" }
 rustc_front = { path = "../librustc_front" }
 rustc_llvm = { path = "../librustc_llvm" }

--- a/src/librustc_bitflags/Cargo.toml
+++ b/src/librustc_bitflags/Cargo.toml
@@ -7,6 +7,3 @@ version = "0.0.0"
 name = "rustc_bitflags"
 path = "lib.rs"
 test = false
-
-[dependencies]
-core = { path = "../libcore" }

--- a/src/librustc_front/Cargo.toml
+++ b/src/librustc_front/Cargo.toml
@@ -12,3 +12,4 @@ crate-type = ["dylib"]
 log = { path = "../liblog" }
 syntax = { path = "../libsyntax" }
 serialize = { path = "../libserialize" }
+rustc_bitflags = { path = "../librustc_bitflags" }

--- a/src/librustc_llvm/Cargo.toml
+++ b/src/librustc_llvm/Cargo.toml
@@ -12,6 +12,9 @@ crate-type = ["dylib"]
 [features]
 static-libstdcpp = []
 
+[dependencies]
+rustc_bitflags = { path = "../librustc_bitflags" }
+
 [build-dependencies]
 build_helper = { path = "../build_helper" }
 gcc = "0.3"

--- a/src/librustc_metadata/Cargo.toml
+++ b/src/librustc_metadata/Cargo.toml
@@ -14,6 +14,7 @@ log = { path = "../liblog" }
 rbml = { path = "../librbml" }
 rustc = { path = "../librustc" }
 rustc_back = { path = "../librustc_back" }
+rustc_bitflags = { path = "../librustc_bitflags" }
 rustc_front = { path = "../librustc_front" }
 rustc_llvm = { path = "../librustc_llvm" }
 serialize = { path = "../libserialize" }

--- a/src/librustc_plugin/Cargo.toml
+++ b/src/librustc_plugin/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["dylib"]
 [dependencies]
 log = { path = "../liblog" }
 rustc = { path = "../librustc" }
+rustc_bitflags = { path = "../librustc_bitflags" }
 rustc_front = { path = "../librustc_front" }
 rustc_metadata = { path = "../librustc_metadata" }
 rustc_mir = { path = "../librustc_mir" }

--- a/src/librustc_resolve/Cargo.toml
+++ b/src/librustc_resolve/Cargo.toml
@@ -12,5 +12,6 @@ crate-type = ["dylib"]
 log = { path = "../liblog" }
 syntax = { path = "../libsyntax" }
 rustc = { path = "../librustc" }
+rustc_bitflags = { path = "../librustc_bitflags" }
 rustc_front = { path = "../librustc_front" }
 arena = { path = "../libarena" }

--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -18,7 +18,6 @@ collections = { path = "../libcollections" }
 core = { path = "../libcore" }
 libc = { path = "../rustc/libc_shim" }
 rand = { path = "../librand" }
-rustc_bitflags = { path = "../librustc_bitflags" }
 rustc_unicode = { path = "../librustc_unicode" }
 
 [build-dependencies]

--- a/src/libsyntax/Cargo.toml
+++ b/src/libsyntax/Cargo.toml
@@ -9,8 +9,7 @@ path = "lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-arena = { path = "../libarena" }
-fmt_macros = { path = "../libfmt_macros" }
 serialize = { path = "../libserialize" }
 term = { path = "../libterm" }
 log = { path = "../liblog" }
+rustc_bitflags = { path = "../librustc_bitflags" }

--- a/src/libterm/Cargo.toml
+++ b/src/libterm/Cargo.toml
@@ -7,6 +7,3 @@ version = "0.0.0"
 name = "term"
 path = "lib.rs"
 crate-type = ["dylib", "rlib"]
-
-[dependencies]
-log = { path = "../liblog" }

--- a/src/rustc/Cargo.lock
+++ b/src/rustc/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
  "log 0.0.0",
  "rbml 0.0.0",
  "rustc_back 0.0.0",
+ "rustc_bitflags 0.0.0",
  "rustc_data_structures 0.0.0",
  "rustc_front 0.0.0",
  "rustc_llvm 0.0.0",
@@ -103,6 +104,10 @@ dependencies = [
  "serialize 0.0.0",
  "syntax 0.0.0",
 ]
+
+[[package]]
+name = "rustc_bitflags"
+version = "0.0.0"
 
 [[package]]
 name = "rustc_borrowck"
@@ -156,6 +161,7 @@ name = "rustc_front"
 version = "0.0.0"
 dependencies = [
  "log 0.0.0",
+ "rustc_bitflags 0.0.0",
  "serialize 0.0.0",
  "syntax 0.0.0",
 ]
@@ -177,6 +183,7 @@ version = "0.0.0"
 dependencies = [
  "build_helper 0.1.0",
  "gcc 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_bitflags 0.0.0",
 ]
 
 [[package]]
@@ -188,6 +195,7 @@ dependencies = [
  "rbml 0.0.0",
  "rustc 0.0.0",
  "rustc_back 0.0.0",
+ "rustc_bitflags 0.0.0",
  "rustc_front 0.0.0",
  "rustc_llvm 0.0.0",
  "serialize 0.0.0",
@@ -231,6 +239,7 @@ version = "0.0.0"
 dependencies = [
  "log 0.0.0",
  "rustc 0.0.0",
+ "rustc_bitflags 0.0.0",
  "rustc_front 0.0.0",
  "rustc_metadata 0.0.0",
  "rustc_mir 0.0.0",
@@ -254,6 +263,7 @@ dependencies = [
  "arena 0.0.0",
  "log 0.0.0",
  "rustc 0.0.0",
+ "rustc_bitflags 0.0.0",
  "rustc_front 0.0.0",
  "syntax 0.0.0",
 ]
@@ -325,9 +335,8 @@ dependencies = [
 name = "syntax"
 version = "0.0.0"
 dependencies = [
- "arena 0.0.0",
- "fmt_macros 0.0.0",
  "log 0.0.0",
+ "rustc_bitflags 0.0.0",
  "serialize 0.0.0",
  "term 0.0.0",
 ]
@@ -343,9 +352,6 @@ dependencies = [
 [[package]]
 name = "term"
 version = "0.0.0"
-dependencies = [
- "log 0.0.0",
-]
 
 [[package]]
 name = "test"

--- a/src/rustc/std_shim/Cargo.lock
+++ b/src/rustc/std_shim/Cargo.lock
@@ -82,13 +82,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_bitflags"
-version = "0.0.0"
-dependencies = [
- "core 0.0.0",
-]
-
-[[package]]
 name = "rustc_unicode"
 version = "0.0.0"
 dependencies = [
@@ -108,7 +101,6 @@ dependencies = [
  "gcc 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.0.0",
  "rand 0.0.0",
- "rustc_bitflags 0.0.0",
  "rustc_unicode 0.0.0",
 ]
 


### PR DESCRIPTION
The standard library doesn't depend on rustc_bitflags, so move it to explicit
dependencies on all other crates. Additionally, the arena/fmt_macros deps could
be dropped from libsyntax.
