### PR TITLE
Fix broken Solaris build

### DIFF
--- a/src/librustc_back/target/x86_64_sun_solaris.rs
+++ b/src/librustc_back/target/x86_64_sun_solaris.rs
@@ -13,6 +13,7 @@ use target::Target;
 pub fn target() -> Target {
     let mut base = super::solaris_base::opts();
     base.pre_link_args.push("-m64".to_string());
+    base.cpu = "x86-64".to_string();
 
     Target {
         llvm_target: "x86_64-pc-solaris".to_string(),

--- a/src/libstd/os/solaris/fs.rs
+++ b/src/libstd/os/solaris/fs.rs
@@ -73,7 +73,7 @@ impl MetadataExt for Metadata {
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat {
         unsafe {
-            &*(self.as_inner().as_inner() as *const libc::stat64
+            &*(self.as_inner().as_inner() as *const libc::stat
                                           as *const raw::stat)
         }
     }

--- a/src/libstd/sys/unix/stack_overflow.rs
+++ b/src/libstd/sys/unix/stack_overflow.rs
@@ -157,7 +157,8 @@ mod imp {
               target_os = "macos",
               target_os = "bitrig",
               target_os = "netbsd",
-              target_os = "openbsd"))]
+              target_os = "openbsd",
+              target_os = "solaris"))]
     unsafe fn get_stack() -> libc::stack_t {
         libc::stack_t { ss_sp: get_stackp(), ss_flags: 0, ss_size: SIGSTKSZ }
     }


### PR DESCRIPTION
A quick fix for several issues that break a Solaris/Illumos build.
Also, adds a CPU target specification (as seen in a patch for OpenBSD #31727).
