### PR TITLE
Harmonize fpu options on armv7 Linux

### DIFF
--- a/mk/cfg/armv7-unknown-linux-gnueabihf.mk
+++ b/mk/cfg/armv7-unknown-linux-gnueabihf.mk
@@ -21,6 +21,6 @@ CFG_UNIXY_armv7-unknown-linux-gnueabihf := 1
 CFG_LDPATH_armv7-unknown-linux-gnueabihf :=
 CFG_RUN_armv7-unknown-linux-gnueabihf=$(2)
 CFG_RUN_TARG_armv7-unknown-linux-gnueabihf=$(call CFG_RUN_armv7-unknown-linux-gnueabihf,,$(2))
-RUSTC_FLAGS_armv7-unknown-linux-gnueabihf := -C target-feature=+v7,+vfp2,+neon
+RUSTC_FLAGS_armv7-unknown-linux-gnueabihf :=
 RUSTC_CROSS_FLAGS_armv7-unknown-linux-gnueabihf :=
 CFG_GNU_TRIPLE_armv7-unknown-linux-gnueabihf := armv7-unknown-linux-gnueabihf

--- a/src/librustc_back/target/armv7_unknown_linux_gnueabihf.rs
+++ b/src/librustc_back/target/armv7_unknown_linux_gnueabihf.rs
@@ -22,7 +22,7 @@ pub fn target() -> Target {
         target_vendor: "unknown".to_string(),
 
         options: TargetOptions {
-            features: "+v7,+vfp2,+neon".to_string(),
+            features: "+v7,+vfp3,+neon".to_string(),
             cpu: "cortex-a8".to_string(),
             .. base
         }


### PR DESCRIPTION
The `vfp2` option was a leftover from `armv6` compatibility features of the original armhf target.
Gcc defaults to `vfp3`on `armv7` hard-float linux systems so we should make it the default for rustc too. 
