### PR TITLE
Prefer 'associated function' over 'static method' in msg.

### DIFF
--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -141,7 +141,8 @@ pub fn report_error<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
             if !static_sources.is_empty() {
                 err.fileline_note(
                     span,
-                    "found defined static methods, maybe a `self` is missing?");
+                    "found the following associated functions; to be used as \
+                     methods, functions must have a `self` parameter");
 
                 report_candidates(fcx, &mut err, span, item_name, static_sources);
             }

--- a/src/test/compile-fail/issue-7575.rs
+++ b/src/test/compile-fail/issue-7575.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // Test the mechanism for warning about possible missing `self` declarations.
+// ignore-tidy-linelength
 
 trait CtxtFn {
     fn f8(self, usize) -> usize;
@@ -72,15 +73,15 @@ impl ManyImplTrait for Myisize {}
 fn no_param_bound(u: usize, m: Myisize) -> usize {
     u.f8(42) + u.f9(342) + m.fff(42)
             //~^ ERROR no method named `f9` found for type `usize` in the current scope
-            //~^^ NOTE found defined static methods, maybe a `self` is missing?
+            //~^^ NOTE found the following associated functions; to be used as methods, functions must have a `self` parameter
             //~^^^ ERROR no method named `fff` found for type `Myisize` in the current scope
-            //~^^^^ NOTE found defined static methods, maybe a `self` is missing?
+            //~^^^^ NOTE found the following associated functions; to be used as methods, functions must have a `self` parameter
 }
 
 fn param_bound<T: ManyImplTrait>(t: T) -> bool {
     t.is_str()
     //~^ ERROR no method named `is_str` found for type `T` in the current scope
-    //~^^ NOTE found defined static methods, maybe a `self` is missing?
+    //~^^ NOTE found the following associated functions; to be used as methods, functions must have a `self` parameter
 }
 
 fn main() {


### PR DESCRIPTION
TRPL seems to refer to 'static functions' as 'associated functions'.
This terminology should be used consistently.
