### PR TITLE
mk: Tweak tidy script to work on Windows python

### DIFF
--- a/src/etc/licenseck.py
+++ b/src/etc/licenseck.py
@@ -9,6 +9,7 @@
 # except according to those terms.
 
 import re
+import os
 
 license_re = re.compile(
 u"""(#|//) Copyright .* The Rust Project Developers. See the COPYRIGHT
@@ -40,8 +41,9 @@ exceptions = [
 ]
 
 def check_license(name, contents):
+    name = os.path.normpath(name)
     # Whitelist check
-    if any(name.endswith(e) for e in exceptions):
+    if any(name.endswith(os.path.normpath(e)) for e in exceptions):
         return True
 
     # Xfail check

--- a/src/etc/tidy.py
+++ b/src/etc/tidy.py
@@ -122,7 +122,8 @@ try:
             'src/liblibc',
         }
 
-        if any(d in dirpath for d in skippable_dirs):
+        dirpath = os.path.normpath(dirpath)
+        if any(os.path.normpath(d) in dirpath for d in skippable_dirs):
             continue
 
         file_names = [os.path.join(dirpath, f) for f in filenames


### PR DESCRIPTION
The MinGW-based Python implementations would automatically do this, but if we
want to use Python from the official downloads our usage of `/` instead of `\`
can wreak havoc. In a few select locations just use `os.path.normpath` do do the
conversions properly for us.
