### PR TITLE
reference: clarify use declaration location

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -841,8 +841,8 @@ extern crate std as ruststd; // linking to 'std' under another name
 
 A _use declaration_ creates one or more local name bindings synonymous with
 some other [path](#paths). Usually a `use` declaration is used to shorten the
-path required to refer to a module item. These declarations may appear at the
-top of [modules](#modules) and [blocks](grammar.html#block-expressions).
+path required to refer to a module item. These declarations may appear in
+[modules](#modules) and [blocks](grammar.html#block-expressions), usually at the top.
 
 > **Note**: Unlike in many languages,
 > `use` declarations in Rust do *not* declare linkage dependency with external crates.


### PR DESCRIPTION
Reference implied that use declarations may appear _only_ at the top of blocks and modules, but it is not the case, and the following is valid:

``` Rust
fn foo() {
    let x = 92;
    use baz::bar;
}
```

r? @steveklabnik
