### PR TITLE
Plumb inference obligations through librustc/middle and librustc_typeck, take 2

### DIFF
--- a/src/librustc/middle/infer/bivariate.rs
+++ b/src/librustc/middle/infer/bivariate.rs
@@ -28,24 +28,27 @@
 use super::combine::{self, CombineFields};
 use super::type_variable::{BiTo};
 
+use middle::traits::PredicateObligation;
 use middle::ty::{self, Ty};
 use middle::ty::TyVar;
 use middle::ty::relate::{Relate, RelateResult, TypeRelation};
 
-pub struct Bivariate<'a, 'tcx: 'a> {
-    fields: CombineFields<'a, 'tcx>
+pub struct Bivariate<'a, 'o, 'tcx: 'a + 'o> {
+    fields: CombineFields<'a, 'o, 'tcx>
 }
 
-impl<'a, 'tcx> Bivariate<'a, 'tcx> {
-    pub fn new(fields: CombineFields<'a, 'tcx>) -> Bivariate<'a, 'tcx> {
+impl<'a, 'o, 'tcx> Bivariate<'a, 'o, 'tcx> {
+    pub fn new(fields: CombineFields<'a, 'o, 'tcx>) -> Bivariate<'a, 'o, 'tcx> {
         Bivariate { fields: fields }
     }
 }
 
-impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Bivariate<'a, 'tcx> {
+impl<'a, 'o, 'tcx> TypeRelation<'a, 'tcx> for Bivariate<'a, 'o, 'tcx> {
     fn tag(&self) -> &'static str { "Bivariate" }
 
     fn tcx(&self) -> &'a ty::ctxt<'tcx> { self.fields.tcx() }
+
+    fn obligations(&self) -> &Vec<PredicateObligation<'tcx>> { self.fields.obligations }
 
     fn a_is_expected(&self) -> bool { self.fields.a_is_expected }
 

--- a/src/librustc/middle/infer/equate.rs
+++ b/src/librustc/middle/infer/equate.rs
@@ -13,25 +13,28 @@ use super::higher_ranked::HigherRankedRelations;
 use super::{Subtype};
 use super::type_variable::{EqTo};
 
+use middle::traits::PredicateObligation;
 use middle::ty::{self, Ty};
 use middle::ty::TyVar;
 use middle::ty::relate::{Relate, RelateResult, TypeRelation};
 
 /// Ensures `a` is made equal to `b`. Returns `a` on success.
-pub struct Equate<'a, 'tcx: 'a> {
-    fields: CombineFields<'a, 'tcx>
+pub struct Equate<'a, 'o, 'tcx: 'a + 'o> {
+    fields: CombineFields<'a, 'o, 'tcx>
 }
 
-impl<'a, 'tcx> Equate<'a, 'tcx> {
-    pub fn new(fields: CombineFields<'a, 'tcx>) -> Equate<'a, 'tcx> {
+impl<'a, 'o, 'tcx> Equate<'a, 'o, 'tcx> {
+    pub fn new(fields: CombineFields<'a, 'o, 'tcx>) -> Equate<'a, 'o, 'tcx> {
         Equate { fields: fields }
     }
 }
 
-impl<'a, 'tcx> TypeRelation<'a,'tcx> for Equate<'a, 'tcx> {
+impl<'a, 'o, 'tcx> TypeRelation<'a,'tcx> for Equate<'a, 'o, 'tcx> {
     fn tag(&self) -> &'static str { "Equate" }
 
     fn tcx(&self) -> &'a ty::ctxt<'tcx> { self.fields.tcx() }
+
+    fn obligations(&self) -> &Vec<PredicateObligation<'tcx>> { self.fields.obligations }
 
     fn a_is_expected(&self) -> bool { self.fields.a_is_expected }
 

--- a/src/librustc/middle/infer/higher_ranked/mod.rs
+++ b/src/librustc/middle/infer/higher_ranked/mod.rs
@@ -21,13 +21,13 @@ use syntax::codemap::Span;
 use util::nodemap::{FnvHashMap, FnvHashSet};
 
 pub trait HigherRankedRelations<'a,'tcx> {
-    fn higher_ranked_sub<T>(&self, a: &Binder<T>, b: &Binder<T>) -> RelateResult<'tcx, Binder<T>>
+    fn higher_ranked_sub<T>(&mut self, a: &Binder<T>, b: &Binder<T>) -> RelateResult<'tcx, Binder<T>>
         where T: Relate<'a,'tcx>;
 
-    fn higher_ranked_lub<T>(&self, a: &Binder<T>, b: &Binder<T>) -> RelateResult<'tcx, Binder<T>>
+    fn higher_ranked_lub<T>(&mut self, a: &Binder<T>, b: &Binder<T>) -> RelateResult<'tcx, Binder<T>>
         where T: Relate<'a,'tcx>;
 
-    fn higher_ranked_glb<T>(&self, a: &Binder<T>, b: &Binder<T>) -> RelateResult<'tcx, Binder<T>>
+    fn higher_ranked_glb<T>(&mut self, a: &Binder<T>, b: &Binder<T>) -> RelateResult<'tcx, Binder<T>>
         where T: Relate<'a,'tcx>;
 }
 
@@ -39,8 +39,8 @@ trait InferCtxtExt {
                                         -> Vec<ty::RegionVid>;
 }
 
-impl<'a,'tcx> HigherRankedRelations<'a,'tcx> for CombineFields<'a,'tcx> {
-    fn higher_ranked_sub<T>(&self, a: &Binder<T>, b: &Binder<T>)
+impl<'a,'o,'tcx> HigherRankedRelations<'a,'tcx> for CombineFields<'a,'o,'tcx> {
+    fn higher_ranked_sub<T>(&mut self, a: &Binder<T>, b: &Binder<T>)
                             -> RelateResult<'tcx, Binder<T>>
         where T: Relate<'a,'tcx>
     {
@@ -101,7 +101,7 @@ impl<'a,'tcx> HigherRankedRelations<'a,'tcx> for CombineFields<'a,'tcx> {
         });
     }
 
-    fn higher_ranked_lub<T>(&self, a: &Binder<T>, b: &Binder<T>) -> RelateResult<'tcx, Binder<T>>
+    fn higher_ranked_lub<T>(&mut self, a: &Binder<T>, b: &Binder<T>) -> RelateResult<'tcx, Binder<T>>
         where T: Relate<'a,'tcx>
     {
         // Start a snapshot so we can examine "all bindings that were
@@ -191,7 +191,7 @@ impl<'a,'tcx> HigherRankedRelations<'a,'tcx> for CombineFields<'a,'tcx> {
         }
     }
 
-    fn higher_ranked_glb<T>(&self, a: &Binder<T>, b: &Binder<T>) -> RelateResult<'tcx, Binder<T>>
+    fn higher_ranked_glb<T>(&mut self, a: &Binder<T>, b: &Binder<T>) -> RelateResult<'tcx, Binder<T>>
         where T: Relate<'a,'tcx>
     {
         debug!("higher_ranked_glb({:?}, {:?})",
@@ -329,9 +329,10 @@ impl<'a,'tcx> HigherRankedRelations<'a,'tcx> for CombineFields<'a,'tcx> {
     }
 }
 
-fn var_ids<'a, 'tcx>(fields: &CombineFields<'a, 'tcx>,
-                      map: &FnvHashMap<ty::BoundRegion, ty::Region>)
-                     -> Vec<ty::RegionVid> {
+fn var_ids<'a, 'o, 'tcx>(fields: &CombineFields<'a, 'o, 'tcx>,
+                         map: &FnvHashMap<ty::BoundRegion, ty::Region>)
+    -> Vec<ty::RegionVid>
+{
     map.iter()
        .map(|(_, r)| match *r {
            ty::ReVar(r) => { r }
@@ -486,7 +487,7 @@ pub fn leak_check<'a,'tcx>(infcx: &InferCtxt<'a,'tcx>,
                            -> Result<(),(ty::BoundRegion,ty::Region)>
 {
     /*!
-     * Searches the region constriants created since `snapshot` was started
+     * Searches the region constraints created since `snapshot` was started
      * and checks to determine whether any of the skolemized regions created
      * in `skol_map` would "escape" -- meaning that they are related to
      * other regions in some way. If so, the higher-ranked subtyping doesn't
@@ -531,7 +532,7 @@ pub fn leak_check<'a,'tcx>(infcx: &InferCtxt<'a,'tcx>,
 ///
 /// This routine is only intended to be used when the leak-check has
 /// passed; currently, it's used in the trait matching code to create
-/// a set of nested obligations frmo an impl that matches against
+/// a set of nested obligations from an impl that matches against
 /// something higher-ranked.  More details can be found in
 /// `librustc/middle/traits/README.md`.
 ///

--- a/src/librustc/middle/infer/higher_ranked/mod.rs
+++ b/src/librustc/middle/infer/higher_ranked/mod.rs
@@ -21,13 +21,16 @@ use syntax::codemap::Span;
 use util::nodemap::{FnvHashMap, FnvHashSet};
 
 pub trait HigherRankedRelations<'a,'tcx> {
-    fn higher_ranked_sub<T>(&mut self, a: &Binder<T>, b: &Binder<T>) -> RelateResult<'tcx, Binder<T>>
+    fn higher_ranked_sub<T>(&mut self, a: &Binder<T>, b: &Binder<T>)
+        -> RelateResult<'tcx, Binder<T>>
         where T: Relate<'a,'tcx>;
 
-    fn higher_ranked_lub<T>(&mut self, a: &Binder<T>, b: &Binder<T>) -> RelateResult<'tcx, Binder<T>>
+    fn higher_ranked_lub<T>(&mut self, a: &Binder<T>, b: &Binder<T>)
+        -> RelateResult<'tcx, Binder<T>>
         where T: Relate<'a,'tcx>;
 
-    fn higher_ranked_glb<T>(&mut self, a: &Binder<T>, b: &Binder<T>) -> RelateResult<'tcx, Binder<T>>
+    fn higher_ranked_glb<T>(&mut self, a: &Binder<T>, b: &Binder<T>)
+        -> RelateResult<'tcx, Binder<T>>
         where T: Relate<'a,'tcx>;
 }
 
@@ -101,7 +104,8 @@ impl<'a,'o,'tcx> HigherRankedRelations<'a,'tcx> for CombineFields<'a,'o,'tcx> {
         });
     }
 
-    fn higher_ranked_lub<T>(&mut self, a: &Binder<T>, b: &Binder<T>) -> RelateResult<'tcx, Binder<T>>
+    fn higher_ranked_lub<T>(&mut self, a: &Binder<T>, b: &Binder<T>)
+        -> RelateResult<'tcx, Binder<T>>
         where T: Relate<'a,'tcx>
     {
         // Start a snapshot so we can examine "all bindings that were
@@ -191,7 +195,8 @@ impl<'a,'o,'tcx> HigherRankedRelations<'a,'tcx> for CombineFields<'a,'o,'tcx> {
         }
     }
 
-    fn higher_ranked_glb<T>(&mut self, a: &Binder<T>, b: &Binder<T>) -> RelateResult<'tcx, Binder<T>>
+    fn higher_ranked_glb<T>(&mut self, a: &Binder<T>, b: &Binder<T>)
+        -> RelateResult<'tcx, Binder<T>>
         where T: Relate<'a,'tcx>
     {
         debug!("higher_ranked_glb({:?}, {:?})",

--- a/src/librustc/middle/infer/lattice.rs
+++ b/src/librustc/middle/infer/lattice.rs
@@ -41,7 +41,7 @@ pub trait LatticeDir<'f,'tcx> : TypeRelation<'f,'tcx> {
 
     // Relates the type `v` to `a` and `b` such that `v` represents
     // the LUB/GLB of `a` and `b` as appropriate.
-    fn relate_bound(&self, v: Ty<'tcx>, a: Ty<'tcx>, b: Ty<'tcx>) -> RelateResult<'tcx, ()>;
+    fn relate_bound(&mut self, v: Ty<'tcx>, a: Ty<'tcx>, b: Ty<'tcx>) -> RelateResult<'tcx, ()>;
 }
 
 pub fn super_lattice_tys<'a,'tcx,L:LatticeDir<'a,'tcx>>(this: &mut L,

--- a/src/librustc/middle/infer/lub.rs
+++ b/src/librustc/middle/infer/lub.rs
@@ -14,24 +14,27 @@ use super::InferCtxt;
 use super::lattice::{self, LatticeDir};
 use super::Subtype;
 
+use middle::traits::PredicateObligation;
 use middle::ty::{self, Ty};
 use middle::ty::relate::{Relate, RelateResult, TypeRelation};
 
 /// "Least upper bound" (common supertype)
-pub struct Lub<'a, 'tcx: 'a> {
-    fields: CombineFields<'a, 'tcx>
+pub struct Lub<'a, 'o, 'tcx: 'a + 'o> {
+    fields: CombineFields<'a, 'o, 'tcx>
 }
 
-impl<'a, 'tcx> Lub<'a, 'tcx> {
-    pub fn new(fields: CombineFields<'a, 'tcx>) -> Lub<'a, 'tcx> {
+impl<'a, 'o, 'tcx> Lub<'a, 'o, 'tcx> {
+    pub fn new(fields: CombineFields<'a, 'o, 'tcx>) -> Lub<'a, 'o, 'tcx> {
         Lub { fields: fields }
     }
 }
 
-impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Lub<'a, 'tcx> {
+impl<'a, 'o, 'tcx> TypeRelation<'a, 'tcx> for Lub<'a, 'o, 'tcx> {
     fn tag(&self) -> &'static str { "Lub" }
 
     fn tcx(&self) -> &'a ty::ctxt<'tcx> { self.fields.tcx() }
+
+    fn obligations(&self) -> &Vec<PredicateObligation<'tcx>> { self.fields.obligations }
 
     fn a_is_expected(&self) -> bool { self.fields.a_is_expected }
 
@@ -71,12 +74,12 @@ impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Lub<'a, 'tcx> {
     }
 }
 
-impl<'a, 'tcx> LatticeDir<'a,'tcx> for Lub<'a, 'tcx> {
+impl<'a, 'o, 'tcx> LatticeDir<'a,'tcx> for Lub<'a, 'o, 'tcx> {
     fn infcx(&self) -> &'a InferCtxt<'a,'tcx> {
         self.fields.infcx
     }
 
-    fn relate_bound(&self, v: Ty<'tcx>, a: Ty<'tcx>, b: Ty<'tcx>) -> RelateResult<'tcx, ()> {
+    fn relate_bound(&mut self, v: Ty<'tcx>, a: Ty<'tcx>, b: Ty<'tcx>) -> RelateResult<'tcx, ()> {
         let mut sub = self.fields.sub();
         try!(sub.relate(&a, &v));
         try!(sub.relate(&b, &v));

--- a/src/librustc/middle/infer/mod.rs
+++ b/src/librustc/middle/infer/mod.rs
@@ -406,7 +406,7 @@ pub fn common_supertype<'a, 'tcx>(cx: &InferCtxt<'a, 'tcx>,
         cx.lub(a_is_expected, trace.clone(), &mut obligations).relate(&a, &b)
     });
     match result {
-        Ok(t) => InferOk { value: t, obligations: obligations},
+        Ok(t) => InferOk { value: t, obligations: obligations },
         Err(ref err) => {
             cx.report_and_explain_type_error(trace, err);
             InferOk { value: cx.tcx.types.err, obligations: Vec::new() }

--- a/src/librustc/middle/infer/sub.rs
+++ b/src/librustc/middle/infer/sub.rs
@@ -13,25 +13,27 @@ use super::higher_ranked::HigherRankedRelations;
 use super::SubregionOrigin;
 use super::type_variable::{SubtypeOf, SupertypeOf};
 
+use middle::traits::PredicateObligation;
 use middle::ty::{self, Ty};
 use middle::ty::TyVar;
 use middle::ty::relate::{Cause, Relate, RelateResult, TypeRelation};
 use std::mem;
 
 /// Ensures `a` is made a subtype of `b`. Returns `a` on success.
-pub struct Sub<'a, 'tcx: 'a> {
-    fields: CombineFields<'a, 'tcx>,
+pub struct Sub<'a, 'o, 'tcx: 'a + 'o> {
+    fields: CombineFields<'a, 'o, 'tcx>,
 }
 
-impl<'a, 'tcx> Sub<'a, 'tcx> {
-    pub fn new(f: CombineFields<'a, 'tcx>) -> Sub<'a, 'tcx> {
+impl<'a, 'o, 'tcx> Sub<'a, 'o, 'tcx> {
+    pub fn new(f: CombineFields<'a, 'o, 'tcx>) -> Sub<'a, 'o, 'tcx> {
         Sub { fields: f }
     }
 }
 
-impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Sub<'a, 'tcx> {
+impl<'a, 'o, 'tcx> TypeRelation<'a, 'tcx> for Sub<'a, 'o, 'tcx> {
     fn tag(&self) -> &'static str { "Sub" }
     fn tcx(&self) -> &'a ty::ctxt<'tcx> { self.fields.infcx.tcx }
+    fn obligations(&self) -> &Vec<PredicateObligation<'tcx>> { self.fields.obligations }
     fn a_is_expected(&self) -> bool { self.fields.a_is_expected }
 
     fn with_cause<F,R>(&mut self, cause: Cause, f: F) -> R

--- a/src/librustc/middle/traits/fulfill.rs
+++ b/src/librustc/middle/traits/fulfill.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use dep_graph::DepGraph;
-use middle::infer::InferCtxt;
+use middle::infer::{InferCtxt, InferOk};
 use middle::ty::{self, Ty, TypeFoldable, ToPolyTraitRef};
 use rustc_data_structures::obligation_forest::{Backtrace, ObligationForest, Error};
 use std::iter;
@@ -526,7 +526,7 @@ fn process_predicate1<'a,'tcx>(selcx: &mut SelectionContext<'a,'tcx>,
 
         ty::Predicate::Equate(ref binder) => {
             match selcx.infcx().equality_predicate(obligation.cause.span, binder) {
-                Ok(()) => Ok(Some(Vec::new())),
+                Ok(InferOk { obligations, .. }) => Ok(Some(obligations)),
                 Err(_) => Err(CodeSelectionError(Unimplemented)),
             }
         }

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1165,7 +1165,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                                              origin,
                                              trait_bound.clone(),
                                              ty::Binder(skol_trait_ref.clone())) {
-            Ok(InferOk { .. }) => { }
+            Ok(InferOk { obligations, .. }) => {
+                // FIXME Once obligations start getting generated, they ought to be propagated.
+                assert!(obligations.is_empty());
+            }
             Err(_) => { return false; }
         }
 
@@ -2454,7 +2457,11 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                                              origin,
                                              expected_trait_ref.clone(),
                                              obligation_trait_ref.clone()) {
-            Ok(InferOk { .. }) => Ok(()),
+            Ok(InferOk { obligations, .. }) => {
+                // FIXME Once obligations start getting generated, they ought tobe propagated.
+                assert!(obligations.is_empty());
+                Ok(())
+            },
             Err(e) => Err(OutputTypeParameterMismatch(expected_trait_ref, obligation_trait_ref, e))
         }
     }
@@ -2771,7 +2778,11 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                                              origin,
                                              poly_trait_ref,
                                              obligation.predicate.to_poly_trait_ref()) {
-            Ok(InferOk { .. }) => Ok(()),
+            Ok(InferOk { obligations, .. }) => {
+                // FIXME Once obligations start getting generated, they ought to be propagated.
+                assert!(obligations.is_empty());
+                Ok(())
+            },
             Err(_) => Err(()),
         }
     }

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -476,7 +476,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             ty::Predicate::Equate(ref p) => {
                 // does this code ever run?
                 match self.infcx.equality_predicate(obligation.cause.span, p) {
-                    Ok(InferOk { .. }) => EvaluatedToOk,
+                    Ok(InferOk { obligations, .. }) =>
+                        self.evaluate_predicates_recursively(previous_stack, obligations.iter()),
                     Err(_) => EvaluatedToErr
                 }
             }

--- a/src/librustc/middle/ty/_match.rs
+++ b/src/librustc/middle/ty/_match.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use middle::traits::PredicateObligation;
+
 use middle::ty::{self, Ty};
 use middle::ty::error::TypeError;
 use middle::ty::relate::{self, Relate, TypeRelation, RelateResult};
@@ -29,18 +31,22 @@ use middle::ty::relate::{self, Relate, TypeRelation, RelateResult};
 /// important thing about the result is Ok/Err. Also, matching never
 /// affects any type variables or unification state.
 pub struct Match<'a, 'tcx: 'a> {
-    tcx: &'a ty::ctxt<'tcx>
+    tcx: &'a ty::ctxt<'tcx>,
+    obligations: &'a mut Vec<PredicateObligation<'tcx>>,
 }
 
 impl<'a, 'tcx> Match<'a, 'tcx> {
-    pub fn new(tcx: &'a ty::ctxt<'tcx>) -> Match<'a, 'tcx> {
-        Match { tcx: tcx }
+    pub fn new(tcx: &'a ty::ctxt<'tcx>, obligations: &'a mut Vec<PredicateObligation<'tcx>>)
+        -> Match<'a, 'tcx>
+    {
+        Match { tcx: tcx, obligations: obligations }
     }
 }
 
 impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Match<'a, 'tcx> {
     fn tag(&self) -> &'static str { "Match" }
     fn tcx(&self) -> &'a ty::ctxt<'tcx> { self.tcx }
+    fn obligations(&self) -> &Vec<PredicateObligation<'tcx>> { self.obligations }
     fn a_is_expected(&self) -> bool { true } // irrelevant
 
     fn relate_with_variance<T:Relate<'a,'tcx>>(&mut self,

--- a/src/librustc/middle/ty/relate.rs
+++ b/src/librustc/middle/ty/relate.rs
@@ -15,6 +15,7 @@
 
 use middle::def_id::DefId;
 use middle::subst::{ErasedRegions, NonerasedRegions, ParamSpace, Substs};
+use middle::traits::PredicateObligation;
 use middle::ty::{self, Ty, TypeFoldable};
 use middle::ty::error::{ExpectedFound, TypeError};
 use std::rc::Rc;
@@ -30,6 +31,9 @@ pub enum Cause {
 
 pub trait TypeRelation<'a,'tcx> : Sized {
     fn tcx(&self) -> &'a ty::ctxt<'tcx>;
+
+    /// Obligations that have been collected over the course of using this relation.
+    fn obligations(&self) -> &Vec<PredicateObligation<'tcx>>;
 
     /// Returns a static string we can use for printouts.
     fn tag(&self) -> &'static str;

--- a/src/librustc_mir/transform/type_check.rs
+++ b/src/librustc_mir/transform/type_check.rs
@@ -11,8 +11,6 @@
 //! This pass type-checks the MIR to ensure it is not broken.
 #![allow(unreachable_code)]
 
-use std::cell::RefCell;
-
 use rustc::middle::infer::{self, InferCtxt};
 use rustc::middle::traits;
 use rustc::middle::ty::{self, Ty};
@@ -310,7 +308,7 @@ impl<'a, 'b, 'tcx> TypeVerifier<'a, 'b, 'tcx> {
                ty,
                obligations);
 
-        let mut fulfill_cx = self.cx.fulfillment_cx.borrow_mut();
+        let mut fulfill_cx = &mut self.cx.fulfillment_cx;
         for obligation in obligations {
             fulfill_cx.register_predicate_obligation(infcx, obligation);
         }
@@ -321,7 +319,7 @@ impl<'a, 'b, 'tcx> TypeVerifier<'a, 'b, 'tcx> {
 
 pub struct TypeChecker<'a, 'tcx: 'a> {
     infcx: &'a InferCtxt<'a, 'tcx>,
-    fulfillment_cx: RefCell<traits::FulfillmentContext<'tcx>>,
+    fulfillment_cx: traits::FulfillmentContext<'tcx>,
     last_span: Span
 }
 
@@ -329,32 +327,30 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
     fn new(infcx: &'a InferCtxt<'a, 'tcx>) -> Self {
         TypeChecker {
             infcx: infcx,
-            fulfillment_cx: RefCell::new(traits::FulfillmentContext::new()),
+            fulfillment_cx: traits::FulfillmentContext::new(),
             last_span: DUMMY_SP
         }
     }
 
-    fn mk_subty(&self, span: Span, sup: Ty<'tcx>, sub: Ty<'tcx>)
+    fn mk_subty(&mut self, span: Span, sup: Ty<'tcx>, sub: Ty<'tcx>)
                 -> infer::UnitResult<'tcx>
     {
         infer::mk_subty(self.infcx, false, infer::TypeOrigin::Misc(span), sup, sub)
             .map(|infer::InferOk { obligations, .. }| {
                 for obligation in obligations {
-                    self.fulfillment_cx.borrow_mut()
-                        .register_predicate_obligation(self.infcx, obligation);
+                    self.fulfillment_cx.register_predicate_obligation(self.infcx, obligation);
                 }
                 ()
             })
     }
 
-    fn mk_eqty(&self, span: Span, a: Ty<'tcx>, b: Ty<'tcx>)
+    fn mk_eqty(&mut self, span: Span, a: Ty<'tcx>, b: Ty<'tcx>)
                 -> infer::UnitResult<'tcx>
     {
         infer::mk_eqty(self.infcx, false, infer::TypeOrigin::Misc(span), a, b)
             .map(|infer::InferOk { obligations, .. }| {
                 for obligation in obligations {
-                    self.fulfillment_cx.borrow_mut()
-                        .register_predicate_obligation(self.infcx, obligation);
+                    self.fulfillment_cx.register_predicate_obligation(self.infcx, obligation);
                 }
                 ()
             })
@@ -372,7 +368,8 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 let lv_ty = mir.lvalue_ty(tcx, lv).to_ty(tcx);
                 let rv_ty = mir.rvalue_ty(tcx, rv);
                 if let Some(rv_ty) = rv_ty {
-                    if let Err(terr) = self.mk_subty(self.last_span, rv_ty, lv_ty) {
+                    let last_span = self.last_span;
+                    if let Err(terr) = self.mk_subty(last_span, rv_ty, lv_ty) {
                         span_mirbug!(self, stmt, "bad assignment ({:?} = {:?}): {:?}",
                                      lv_ty, rv_ty, terr);
                     }
@@ -384,7 +381,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         }
     }
 
-    fn check_terminator(&self,
+    fn check_terminator(&mut self,
                         mir: &Mir<'tcx>,
                         term: &Terminator<'tcx>) {
         debug!("check_terminator: {:?}", term);
@@ -408,7 +405,8 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             }
             Terminator::SwitchInt { ref discr, switch_ty, .. } => {
                 let discr_ty = mir.lvalue_ty(tcx, discr).to_ty(tcx);
-                if let Err(terr) = self.mk_subty(self.last_span, discr_ty, switch_ty) {
+                let last_span = self.last_span;
+                if let Err(terr) = self.mk_subty(last_span, discr_ty, switch_ty) {
                     span_mirbug!(self, term, "bad SwitchInt ({:?} on {:?}): {:?}",
                                  switch_ty, discr_ty, terr);
                 }
@@ -453,7 +451,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         }
     }
 
-    fn check_call_dest(&self,
+    fn check_call_dest(&mut self,
                        mir: &Mir<'tcx>,
                        term: &Terminator<'tcx>,
                        sig: &ty::FnSig<'tcx>,
@@ -465,7 +463,8 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             }
             (&Some((ref dest, _)), ty::FnConverging(ty)) => {
                 let dest_ty = mir.lvalue_ty(tcx, dest).to_ty(tcx);
-                if let Err(terr) = self.mk_subty(self.last_span, ty, dest_ty) {
+                let last_span = self.last_span;
+                if let Err(terr) = self.mk_subty(last_span, ty, dest_ty) {
                     span_mirbug!(self, term,
                                  "call dest mismatch ({:?} <- {:?}): {:?}",
                                  dest_ty, ty, terr);
@@ -478,7 +477,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         }
     }
 
-    fn check_call_inputs(&self,
+    fn check_call_inputs(&mut self,
                          mir: &Mir<'tcx>,
                          term: &Terminator<'tcx>,
                          sig: &ty::FnSig<'tcx>,
@@ -491,7 +490,8 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         }
         for (n, (fn_arg, op_arg)) in sig.inputs.iter().zip(args).enumerate() {
             let op_arg_ty = mir.operand_ty(self.tcx(), op_arg);
-            if let Err(terr) = self.mk_subty(self.last_span, op_arg_ty, fn_arg) {
+            let last_span = self.last_span;
+            if let Err(terr) = self.mk_subty(last_span, op_arg_ty, fn_arg) {
                 span_mirbug!(self, term, "bad arg #{:?} ({:?} <- {:?}): {:?}",
                              n, fn_arg, op_arg_ty, terr);
             }
@@ -509,7 +509,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         }
     }
 
-    fn check_box_free_inputs(&self,
+    fn check_box_free_inputs(&mut self,
                              mir: &Mir<'tcx>,
                              term: &Terminator<'tcx>,
                              sig: &ty::FnSig<'tcx>,
@@ -546,7 +546,8 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             }
         };
 
-        if let Err(terr) = self.mk_subty(self.last_span, arg_ty, pointee_ty) {
+        let last_span = self.last_span;
+        if let Err(terr) = self.mk_subty(last_span, arg_ty, pointee_ty) {
             span_mirbug!(self, term, "bad box_free arg ({:?} <- {:?}): {:?}",
                          pointee_ty, arg_ty, terr);
         }
@@ -571,7 +572,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
 
     fn verify_obligations(&mut self, mir: &Mir<'tcx>) {
         self.last_span = mir.span;
-        if let Err(e) = self.fulfillment_cx.borrow_mut().select_all_or_error(self.infcx) {
+        if let Err(e) = self.fulfillment_cx.select_all_or_error(self.infcx) {
             span_mirbug!(self, "", "errors selecting obligation: {:?}",
                          e);
         }

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -533,13 +533,7 @@ pub fn check_match<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                 ),
             };
 
-            infer::common_supertype(
-                fcx.infcx(),
-                origin,
-                true,
-                expected,
-                found,
-            )
+            fcx.common_supertype(origin, true, expected, found)
         }
     });
 

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -62,7 +62,7 @@
 
 use check::{autoderef, FnCtxt, UnresolvedTypeAction};
 
-use middle::infer::{self, Coercion, TypeOrigin};
+use middle::infer::{self, Coercion, TypeOrigin, InferOk};
 use middle::traits::{self, ObligationCause};
 use middle::traits::{predicate_for_trait_def, report_selection_error};
 use middle::ty::adjustment::{AutoAdjustment, AutoDerefRef, AdjustDerefRef};
@@ -71,7 +71,6 @@ use middle::ty::adjustment::{AdjustUnsafeFnPointer, AdjustMutToConstPointer};
 use middle::ty::{self, LvaluePreference, TypeAndMut, Ty};
 use middle::ty::fold::TypeFoldable;
 use middle::ty::error::TypeError;
-use middle::ty::relate::RelateResult;
 use util::common::indent;
 
 use std::cell::RefCell;
@@ -84,7 +83,7 @@ struct Coerce<'a, 'tcx: 'a> {
     unsizing_obligations: RefCell<Vec<traits::PredicateObligation<'tcx>>>,
 }
 
-type CoerceResult<'tcx> = RelateResult<'tcx, Option<AutoAdjustment<'tcx>>>;
+type CoerceResult<'tcx> = Result<Option<AutoAdjustment<'tcx>>, TypeError<'tcx>>;
 
 impl<'f, 'tcx> Coerce<'f, 'tcx> {
     fn tcx(&self) -> &ty::ctxt<'tcx> {
@@ -92,8 +91,13 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
     }
 
     fn subtype(&self, a: Ty<'tcx>, b: Ty<'tcx>) -> CoerceResult<'tcx> {
-        try!(self.fcx.infcx().sub_types(false, self.origin.clone(), a, b));
-        Ok(None) // No coercion required.
+        self.fcx.infcx().sub_types(false, self.origin.clone(), a, b)
+            .map(|InferOk { obligations, .. }| {
+                for obligation in obligations {
+                    self.fcx.register_predicate(obligation);
+                }
+                None
+            })
     }
 
     fn unpack_actual_value<T, F>(&self, a: Ty<'tcx>, f: F) -> T where
@@ -206,13 +210,16 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
             }
             let ty = self.tcx().mk_ref(r_borrow,
                                         TypeAndMut {ty: inner_ty, mutbl: mutbl_b});
-            if let Err(err) = self.subtype(ty, b) {
-                if first_error.is_none() {
-                    first_error = Some(err);
+            match self.subtype(ty, b) {
+                Err(err) => {
+                    if first_error.is_none() {
+                        first_error = Some(err);
+                    }
+                    None
+                },
+                Ok(_) => {
+                    Some(())
                 }
-                None
-            } else {
-                Some(())
             }
         });
 
@@ -439,7 +446,7 @@ pub fn mk_assignty<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                              expr: &hir::Expr,
                              a: Ty<'tcx>,
                              b: Ty<'tcx>)
-                             -> RelateResult<'tcx, ()> {
+                             -> Result<(), TypeError<'tcx>> {
     debug!("mk_assignty({:?} -> {:?})", a, b);
     let mut unsizing_obligations = vec![];
     let adjustment = try!(indent(|| {

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -11,7 +11,7 @@
 
 use check::{coercion, FnCtxt};
 use middle::ty::{self, Ty};
-use middle::infer::{self, TypeOrigin};
+use middle::infer::{TypeOrigin};
 
 use std::result::Result::{Err, Ok};
 use syntax::codemap::Span;
@@ -35,8 +35,8 @@ pub fn suptype_with_fn<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
     F: FnOnce(Span, Ty<'tcx>, Ty<'tcx>, &ty::error::TypeError<'tcx>),
 {
     // n.b.: order of actual, expected is reversed
-    match infer::mk_subty(fcx.infcx(), b_is_expected, TypeOrigin::Misc(sp),
-                          ty_b, ty_a) {
+    match fcx.mk_subty(b_is_expected, TypeOrigin::Misc(sp),
+                       ty_b, ty_a) {
       Ok(()) => { /* ok */ }
       Err(ref err) => {
           handle_err(sp, ty_a, ty_b, err);
@@ -46,7 +46,7 @@ pub fn suptype_with_fn<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
 
 pub fn eqtype<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>, sp: Span,
                         expected: Ty<'tcx>, actual: Ty<'tcx>) {
-    match infer::mk_eqty(fcx.infcx(), false, TypeOrigin::Misc(sp), actual, expected) {
+    match fcx.mk_eqty(false, TypeOrigin::Misc(sp), actual, expected) {
         Ok(()) => { /* ok */ }
         Err(ref err) => { fcx.report_mismatched_types(sp, expected, actual, err); }
     }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -88,8 +88,7 @@ use middle::astconv_util::prohibit_type_params;
 use middle::cstore::LOCAL_CRATE;
 use middle::def::{self, Def};
 use middle::def_id::DefId;
-use middle::infer;
-use middle::infer::{TypeOrigin, type_variable};
+use middle::infer::{self, TypeOrigin, type_variable, InferOk};
 use middle::pat_util::{self, pat_id_map};
 use middle::privacy::{AllPublic, LastMod};
 use middle::subst::{self, Subst, Substs, VecPerParamSpace, ParamSpace};
@@ -1206,6 +1205,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         &self.inh.infcx
     }
 
+    pub fn fulfillment_cx(&self) -> &RefCell<traits::FulfillmentContext<'tcx>> {
+        &self.inh.fulfillment_cx
+    }
+
     pub fn param_env(&self) -> &ty::ParameterEnvironment<'a,'tcx> {
         &self.inh.infcx.parameter_environment
     }
@@ -1246,6 +1249,21 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         debug!("resolve_type_vars_if_possible: ty={:?}", ty);
         ty
+    }
+
+    pub fn common_supertype(&self,
+                            origin: TypeOrigin,
+                            a_is_expected: bool,
+                            a: Ty<'tcx>,
+                            b: Ty<'tcx>)
+                            -> Ty<'tcx>
+    {
+        let InferOk { value, obligations } = infer::common_supertype(
+            self.infcx(), origin, a_is_expected, a, b);
+        for obligation in obligations {
+            self.register_predicate(obligation);
+        }
+        value
     }
 
     fn record_deferred_call_resolution(&self,
@@ -1593,6 +1611,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     sup: Ty<'tcx>)
                     -> Result<(), TypeError<'tcx>> {
         infer::mk_subty(self.infcx(), a_is_expected, origin, sub, sup)
+            .map(|InferOk { value, obligations }| {
+                for obligation in obligations {
+                    self.register_predicate(obligation);
+                }
+                value
+            })
     }
 
     pub fn mk_eqty(&self,
@@ -1602,6 +1626,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                    sup: Ty<'tcx>)
                    -> Result<(), TypeError<'tcx>> {
         infer::mk_eqty(self.infcx(), a_is_expected, origin, sub, sup)
+            .map(|InferOk { value, obligations }| {
+                for obligation in obligations {
+                    self.register_predicate(obligation);
+                }
+                value
+            })
     }
 
     pub fn mk_subr(&self,
@@ -1885,9 +1915,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             Neither => {
                                 if let Some(default) = default_map.get(ty) {
                                     let default = default.clone();
-                                    match infer::mk_eqty(self.infcx(), false,
-                                                         TypeOrigin::Misc(default.origin_span),
-                                                         ty, default.ty) {
+                                    match self.mk_eqty(false,
+                                                       TypeOrigin::Misc(default.origin_span),
+                                                       ty, default.ty) {
                                         Ok(()) => {}
                                         Err(_) => {
                                             conflicts.push((*ty, default));
@@ -1978,9 +2008,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     Neither => {
                         if let Some(default) = default_map.get(ty) {
                             let default = default.clone();
-                            match infer::mk_eqty(self.infcx(), false,
-                                                 TypeOrigin::Misc(default.origin_span),
-                                                 ty, default.ty) {
+                            match self.mk_eqty(false,
+                                               TypeOrigin::Misc(default.origin_span),
+                                               ty, default.ty) {
                                 Ok(()) => {}
                                 Err(_) => {
                                     result = Some(default);
@@ -2880,18 +2910,16 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
             Some(ref else_expr) => {
                 check_expr_with_expectation(fcx, &else_expr, expected);
                 let else_ty = fcx.expr_ty(&else_expr);
-                infer::common_supertype(fcx.infcx(),
-                                        TypeOrigin::IfExpression(sp),
-                                        true,
-                                        then_ty,
-                                        else_ty)
+                fcx.common_supertype(TypeOrigin::IfExpression(sp),
+                                     true,
+                                     then_ty,
+                                     else_ty)
             }
             None => {
-                infer::common_supertype(fcx.infcx(),
-                                        TypeOrigin::IfExpressionWithNoElse(sp),
-                                        false,
-                                        then_ty,
-                                        fcx.tcx().mk_nil())
+                fcx.common_supertype(TypeOrigin::IfExpressionWithNoElse(sp),
+                                     false,
+                                     then_ty,
+                                     fcx.tcx().mk_nil())
             }
         };
 
@@ -3696,11 +3724,10 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
                   Some(fcx.tcx().types.err)
               }
               (Some(t_start), Some(t_end)) => {
-                  Some(infer::common_supertype(fcx.infcx(),
-                                               TypeOrigin::RangeExpression(expr.span),
-                                               true,
-                                               t_start,
-                                               t_end))
+                  Some(fcx.common_supertype(TypeOrigin::RangeExpression(expr.span),
+                                            true,
+                                            t_start,
+                                            t_end))
               }
               _ => None
           };

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -92,7 +92,7 @@ use middle::region::{self, CodeExtent};
 use middle::subst::Substs;
 use middle::traits;
 use middle::ty::{self, Ty, MethodCall, TypeFoldable};
-use middle::infer::{self, GenericKind, InferCtxt, SubregionOrigin, TypeOrigin, VerifyBound};
+use middle::infer::{self, GenericKind, InferCtxt, SubregionOrigin, TypeOrigin, VerifyBound, InferOk};
 use middle::pat_util;
 use middle::ty::adjustment;
 use middle::ty::wf::ImpliedBound;
@@ -1846,7 +1846,12 @@ fn declared_projection_bounds_from_trait<'a,'tcx>(rcx: &Rcx<'a, 'tcx>,
 
                 // check whether this predicate applies to our current projection
                 match infer::mk_eqty(infcx, false, TypeOrigin::Misc(span), ty, outlives.0) {
-                    Ok(()) => { Ok(outlives.1) }
+                    Ok(InferOk { obligations, .. }) => {
+                        for obligation in obligations {
+                            fcx.register_predicate(obligation);
+                        }
+                        Ok(outlives.1)
+                    }
                     Err(_) => { Err(()) }
                 }
             });

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -92,7 +92,8 @@ use middle::region::{self, CodeExtent};
 use middle::subst::Substs;
 use middle::traits;
 use middle::ty::{self, Ty, MethodCall, TypeFoldable};
-use middle::infer::{self, GenericKind, InferCtxt, SubregionOrigin, TypeOrigin, VerifyBound, InferOk};
+use middle::infer::{self, GenericKind, InferCtxt, SubregionOrigin, TypeOrigin, VerifyBound,
+                    InferOk};
 use middle::pat_util;
 use middle::ty::adjustment;
 use middle::ty::wf::ImpliedBound;


### PR DESCRIPTION
Next time I'm just going to ask what @nikomatsakis intends to do for a task; it seems to end up cleaner every time. :-)

I'm unsure whether some places should or should not be propagating obligations (namely locations in `infer/mod.rs` that return in this PR `UnitResult` as opposed to `InferResult`).

r? @nikomatsakis 
