### PR TITLE
Add link-flags-ld emit option.

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -69,6 +69,7 @@ pub enum OutputType {
     Object,
     Exe,
     DepInfo,
+    LinkFlagsLd,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -87,7 +88,8 @@ impl OutputType {
     fn is_compatible_with_codegen_units_and_single_output_file(&self) -> bool {
         match *self {
             OutputType::Exe |
-            OutputType::DepInfo => true,
+            OutputType::DepInfo |
+            OutputType::LinkFlagsLd => true,
             OutputType::Bitcode |
             OutputType::Assembly |
             OutputType::LlvmAssembly |
@@ -103,6 +105,7 @@ impl OutputType {
             OutputType::Object => "obj",
             OutputType::Exe => "link",
             OutputType::DepInfo => "dep-info",
+            OutputType::LinkFlagsLd => "link-flags-ld",
         }
     }
 }
@@ -210,6 +213,7 @@ impl OutputFilenames {
             OutputType::LlvmAssembly => base.with_extension("ll"),
             OutputType::Object => base.with_extension("o"),
             OutputType::DepInfo => base.with_extension("d"),
+            OutputType::LinkFlagsLd => base.with_extension("ldflags"),
             OutputType::Exe => base,
         }
     }
@@ -884,7 +888,7 @@ pub fn rustc_short_optgroups() -> Vec<RustcOptGroup> {
                "NAME"),
         opt::multi_s("", "emit", "Comma separated list of types of output for \
                               the compiler to emit",
-                 "[asm|llvm-bc|llvm-ir|obj|link|dep-info]"),
+                 "[asm|llvm-bc|llvm-ir|obj|link|link-flags-ld|dep-info]"),
         opt::multi_s("", "print", "Comma separated list of compiler information to \
                                print on stdout",
                  "[crate-name|file-names|sysroot|target-list]"),
@@ -1059,6 +1063,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
                     "llvm-bc" => OutputType::Bitcode,
                     "obj" => OutputType::Object,
                     "link" => OutputType::Exe,
+                    "link-flags-ld" => OutputType::LinkFlagsLd,
                     "dep-info" => OutputType::DepInfo,
                     part => {
                         early_error(error_format, &format!("unknown emission type: `{}`",

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -822,14 +822,20 @@ fn link_staticlib(sess: &Session, objects: &[PathBuf], out_filename: &Path,
     ab.update_symbols();
     ab.build();
 
-    if !all_native_libs.is_empty() {
-        sess.note_without_error("link against the following native artifacts when linking against \
+    report_link_line(sess, all_native_libs);
+}
+
+fn report_link_line(sess: &Session, native_libs: Vec<(NativeLibraryKind, String)>) {
+    if !native_libs.is_empty() {
+        sess.note_without_error(
+            "link against the following native artifacts when linking against \
                                  this static library");
-        sess.note_without_error("the order and any duplication can be significant on some \
+        sess.note_without_error(
+            "the order and any duplication can be significant on some \
                                  platforms, and so may need to be preserved");
     }
 
-    for &(kind, ref lib) in &all_native_libs {
+    for &(kind, ref lib) in &native_libs {
         let name = match kind {
             NativeLibraryKind::NativeStatic => "static library",
             NativeLibraryKind::NativeUnknown => "library",

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -826,14 +826,16 @@ fn link_staticlib(sess: &Session, objects: &[PathBuf], out_filename: &Path,
 }
 
 fn report_link_line(sess: &Session, native_libs: Vec<(NativeLibraryKind, String)>) {
-    if !native_libs.is_empty() {
-        sess.note_without_error(
-            "link against the following native artifacts when linking against \
-                                 this static library");
-        sess.note_without_error(
-            "the order and any duplication can be significant on some \
-                                 platforms, and so may need to be preserved");
+    if native_libs.is_empty() {
+        return;
     }
+
+    sess.note_without_error(
+        "link against the following native artifacts when linking against \
+                             this static library");
+    sess.note_without_error(
+        "the order and any duplication can be significant on some \
+                             platforms, and so may need to be preserved");
 
     for &(kind, ref lib) in &native_libs {
         let name = match kind {

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -676,6 +676,7 @@ pub fn run_passes(sess: &Session,
                 modules_config.emit_obj = true;
                 metadata_config.emit_obj = true;
             },
+            OutputType::LinkFlagsLd |
             OutputType::DepInfo => {}
         }
     }
@@ -780,6 +781,7 @@ pub fn run_passes(sess: &Session,
                 copy_if_one_unit("0.o", OutputType::Object, true);
             }
             OutputType::Exe |
+            OutputType::LinkFlagsLd |
             OutputType::DepInfo => {}
         }
     }


### PR DESCRIPTION
Attempt to address #31471. r? @alexcrichton 
- Assumes unix-style ldflags.
- Doesn't propagate OutputFilenames, so the default output filename doesn't work.
- Wasn't sure where/how to add a test for this run-make and check if a file is produced?
