### PR TITLE
Shorter output for `rustc --test` binaries.

### DIFF
--- a/src/compiletest/common.rs
+++ b/src/compiletest/common.rs
@@ -155,5 +155,8 @@ pub struct Config {
     pub lldb_python_dir: Option<String>,
 
     // Explain what's going on
-    pub verbose: bool
+    pub verbose: bool,
+
+    // Print one character per test instead of one line
+    pub quiet: bool,
 }

--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -78,6 +78,7 @@ pub fn parse_config(args: Vec<String> ) -> Config {
           optopt("", "host-rustcflags", "flags to pass to rustc for host", "FLAGS"),
           optopt("", "target-rustcflags", "flags to pass to rustc for target", "FLAGS"),
           optflag("", "verbose", "run tests verbosely, showing all output"),
+          optflag("", "quiet", "print one character per test instead of one line"),
           optopt("", "logfile", "file to log test execution to", "FILE"),
           optopt("", "target", "the target to build for", "TARGET"),
           optopt("", "host", "the host to build for", "HOST"),
@@ -158,6 +159,7 @@ pub fn parse_config(args: Vec<String> ) -> Config {
             !opt_str2(matches.opt_str("adb-test-dir")).is_empty(),
         lldb_python_dir: matches.opt_str("lldb-python-dir"),
         verbose: matches.opt_present("verbose"),
+        quiet: matches.opt_present("quiet"),
     }
 }
 
@@ -191,6 +193,7 @@ pub fn log_config(config: &Config) {
     logv(c, format!("adb_device_status: {}",
                     config.adb_device_status));
     logv(c, format!("verbose: {}", config.verbose));
+    logv(c, format!("quiet: {}", config.quiet));
     logv(c, format!("\n"));
 }
 
@@ -257,6 +260,7 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
             Some(ref filter) => Some(filter.clone()),
         },
         run_ignored: config.run_ignored,
+        quiet: config.quiet,
         logfile: config.logfile.clone(),
         run_tests: true,
         bench_benchmarks: true,

--- a/src/test/run-make/test-harness/Makefile
+++ b/src/test/run-make/test-harness/Makefile
@@ -5,3 +5,5 @@ all:
 	$(RUSTC) --test test-ignore-cfg.rs --cfg ignorecfg
 	$(call RUN,test-ignore-cfg) | grep 'shouldnotignore ... ok'
 	$(call RUN,test-ignore-cfg) | grep 'shouldignore ... ignored'
+	$(call RUN,test-ignore-cfg --quiet) | grep "^i\.$$"
+	$(call RUN,test-ignore-cfg --quiet) | grep -v 'should'


### PR DESCRIPTION
Until now, a program created with `rustc --test` prints at least one line per test. This can be very verbose, especially with [data-driven tests](https://internals.rust-lang.org/t/test-and-external-test-harnesses/3145) when hundreds or thousands of tests is not rare.

This changes the default output to one character per test (except metrics and benchmarks results which have additional data to show):

```
     Running target/debug/wpt-75c594dc1e6e6187

running 314 tests
..............................................................................
..............................................................................
..............................................................................
..............................................................................
..
test result: ok. 314 passed; 0 failed; 0 ignored; 0 measured
```

<s>The previous behavior is available by passing `--verbose` to the test program. Maybe `cargo test --verbose` could be changed to do that?</s> **Edit:** the default is now unchanged, `-q` or `--quiet` enables the new output.
