### PR TITLE
Add links to how to disable the default prelude

### DIFF
--- a/src/libcore/prelude/v1.rs
+++ b/src/libcore/prelude/v1.rs
@@ -12,7 +12,10 @@
 //!
 //! This module is intended for users of libcore which do not link to libstd as
 //! well. This module is imported by default when `#![no_std]` is used in the
-//! same manner as the standard library's prelude.
+//! same manner as the standard library's prelude (so not at all if the
+//! [`no_implicit_prelude` attribute][module-only-attributes] is used).
+//!
+//! [module-only-attributes]: ../../../reference.html#module-only-attributes
 
 #![stable(feature = "core_prelude", since = "1.4.0")]
 

--- a/src/libstd/prelude/mod.rs
+++ b/src/libstd/prelude/mod.rs
@@ -47,6 +47,15 @@
 //! are not automatically `use`'d, and must be imported manually. This is still
 //! easier than importing all of their constituent components.
 //!
+//! # Disabling
+//!
+//! To disable automatic inclusion of the standard prelude you can use the
+//! [`no_implicit_prelude` attribute][module-only-attributes]. This should be
+//! rarely used, but can be useful if you have a need for very careful control
+//! of what parts of `std` are included.
+//!
+//! [module-only-attributes]: ../../reference.html#module-only-attributes
+//!
 //! # Prelude contents
 //!
 //! The current version of the prelude (version 1) lives in


### PR DESCRIPTION
Running `grep -r no_implicit_prelude doc src/{libstd,libcore}` resulted in only
the one hit in the reference. Added links from the documentation for
`std::prelude` and `core::prelude::v1` to make it easier to find.

r? @steveklabnik
