### PR TITLE
Put the `use` in suggested code inside the quotes

### DIFF
--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -271,7 +271,7 @@ fn suggest_traits_to_import<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
 
         for (i, trait_did) in candidates.iter().enumerate() {
             err.fileline_help(span,
-                              &format!("candidate #{}: use `{}`",
+                              &format!("candidate #{}: `use {}`",
                                         i + 1,
                                         fcx.tcx().item_path_str(*trait_did)));
         }

--- a/src/test/compile-fail/no-method-suggested-traits.rs
+++ b/src/test/compile-fail/no-method-suggested-traits.rs
@@ -34,31 +34,31 @@ fn main() {
     1u32.method();
     //~^ HELP following traits are implemented but not in scope, perhaps add a `use` for one of them
     //~^^ ERROR no method named
-    //~^^^ HELP `foo::Bar`
-    //~^^^^ HELP `no_method_suggested_traits::foo::PubPub`
+    //~^^^ HELP `use foo::Bar`
+    //~^^^^ HELP `use no_method_suggested_traits::foo::PubPub`
     std::rc::Rc::new(&mut Box::new(&1u32)).method();
     //~^ HELP following traits are implemented but not in scope, perhaps add a `use` for one of them
     //~^^ ERROR no method named
-    //~^^^ HELP `foo::Bar`
-    //~^^^^ HELP `no_method_suggested_traits::foo::PubPub`
+    //~^^^ HELP `use foo::Bar`
+    //~^^^^ HELP `use no_method_suggested_traits::foo::PubPub`
 
     'a'.method();
     //~^ ERROR no method named
     //~^^ HELP the following trait is implemented but not in scope, perhaps add a `use` for it:
-    //~^^^ HELP `foo::Bar`
+    //~^^^ HELP `use foo::Bar`
     std::rc::Rc::new(&mut Box::new(&'a')).method();
     //~^ ERROR no method named
     //~^^ HELP the following trait is implemented but not in scope, perhaps add a `use` for it:
-    //~^^^ HELP `foo::Bar`
+    //~^^^ HELP `use foo::Bar`
 
     1i32.method();
     //~^ ERROR no method named
     //~^^ HELP the following trait is implemented but not in scope, perhaps add a `use` for it:
-    //~^^^ HELP `no_method_suggested_traits::foo::PubPub`
+    //~^^^ HELP `use no_method_suggested_traits::foo::PubPub`
     std::rc::Rc::new(&mut Box::new(&1i32)).method();
     //~^ ERROR no method named
     //~^^ HELP the following trait is implemented but not in scope, perhaps add a `use` for it:
-    //~^^^ HELP `no_method_suggested_traits::foo::PubPub`
+    //~^^^ HELP `use no_method_suggested_traits::foo::PubPub`
 
     Foo.method();
     //~^ ERROR no method named


### PR DESCRIPTION
suggest: Put the `use` in suggested code inside the quotes

Change import a trait suggestion from:

```
   help: candidate #1: use `std::io::Write`
```

to

```
   help: candidate #1: `use std::io::Write`
```

so that the code can be copied directly.

Fixes #31864
