### PR TITLE
rustdoc: Don't inline impls from doc(hidden) modules

### DIFF
--- a/src/test/auxiliary/issue-29584.rs
+++ b/src/test/auxiliary/issue-29584.rs
@@ -1,0 +1,18 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub struct Foo;
+
+#[doc(hidden)]
+mod bar {
+    trait Bar {}
+
+    impl Bar for ::Foo {}
+}

--- a/src/test/rustdoc/issue-29584.rs
+++ b/src/test/rustdoc/issue-29584.rs
@@ -1,0 +1,18 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-29584.rs
+// ignore-cross-compile
+
+extern crate issue_29584;
+
+// @has issue_29584/struct.Foo.html
+// @!has - 'impl Bar for'
+pub use issue_29584::Foo;


### PR DESCRIPTION
fixes #29584

r? @alexcrichton 
