### PR TITLE
Disallow methods from traits that are not in scope

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -743,9 +743,9 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
                 }
             }
 
-            // FIXME #31379: We can use methods from imported traits shadowed by non-import items
-            if !binding.is_import() {
-                for glob_binding in resolution.duplicate_globs.iter() {
+            // We can always use methods from the prelude traits
+            for glob_binding in resolution.duplicate_globs.iter() {
+                if glob_binding.defined_with(DefModifiers::PRELUDE) {
                     module.shadowed_traits.borrow_mut().push(glob_binding);
                 }
             }

--- a/src/test/compile-fail/shadowed-trait-methods.rs
+++ b/src/test/compile-fail/shadowed-trait-methods.rs
@@ -1,0 +1,24 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that methods from shadowed traits cannot be used
+
+mod foo {
+    pub trait T { fn f(&self) {} }
+    impl T for () {}
+}
+
+mod bar { pub use foo::T; }
+
+fn main() {
+    pub use bar::*;
+    struct T;
+    ().f() //~ ERROR no method
+}


### PR DESCRIPTION
This PR only allows a trait method to be used if the trait is in scope (fixes #31379).
This is a [breaking-change]. For example, the following would break:

``` rust
mod foo {
    pub trait T { fn f(&self) {} }
    impl T for () {}
}

mod bar { pub use foo::T; }

fn main() {
    pub use bar::*;
    struct T; // This shadows the trait `T`,
    ().f() // making this an error.
}
```

r? @nikomatsakis 
