### PR TITLE
documentation fix

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -3036,7 +3036,7 @@ the case of a `while` loop, the head is the conditional expression controlling
 the loop. In the case of a `for` loop, the head is the call-expression
 controlling the loop. If the label is present, then `continue 'foo` returns
 control to the head of the loop with label `'foo`, which need not be the
-innermost label enclosing the `break` expression, but must enclose it.
+innermost label enclosing the `continue` expression, but must enclose it.
 
 A `continue` expression is only permitted in the body of a loop.
 


### PR DESCRIPTION
`continue` expression's description mentioned `break` instead of `continue`
