### PR TITLE
Use .copy_from_slice() where applicable

### DIFF
--- a/src/libcore/num/flt2dec/mod.rs
+++ b/src/libcore/num/flt2dec/mod.rs
@@ -210,7 +210,7 @@ impl<'a> Part<'a> {
                     }
                 }
                 Part::Copy(buf) => {
-                    out[..buf.len()].clone_from_slice(buf);
+                    out[..buf.len()].copy_from_slice(buf);
                 }
             }
             Some(len)
@@ -245,7 +245,7 @@ impl<'a> Formatted<'a> {
     /// (It may still leave partially written bytes in the buffer; do not rely on that.)
     pub fn write(&self, out: &mut [u8]) -> Option<usize> {
         if out.len() < self.sign.len() { return None; }
-        out[..self.sign.len()].clone_from_slice(self.sign);
+        out[..self.sign.len()].copy_from_slice(self.sign);
 
         let mut written = self.sign.len();
         for part in self.parts {

--- a/src/libcoretest/lib.rs
+++ b/src/libcoretest/lib.rs
@@ -15,6 +15,7 @@
 #![feature(box_syntax)]
 #![feature(cell_extras)]
 #![feature(const_fn)]
+#![feature(copy_from_slice)]
 #![feature(core_float)]
 #![feature(core_private_bignum)]
 #![feature(core_private_diy_float)]

--- a/src/libcoretest/num/flt2dec/mod.rs
+++ b/src/libcoretest/num/flt2dec/mod.rs
@@ -100,7 +100,7 @@ fn check_exact<F, T>(mut f: F, v: T, vstr: &str, expected: &[u8], expectedk: i16
 
     // check significant digits
     for i in 1..cut.unwrap_or(expected.len() - 1) {
-        expected_[..i].clone_from_slice(&expected[..i]);
+        expected_[..i].copy_from_slice(&expected[..i]);
         let mut expectedk_ = expectedk;
         if expected[i] >= b'5' {
             // check if this is a rounding-to-even case.
@@ -147,7 +147,7 @@ fn check_exact<F, T>(mut f: F, v: T, vstr: &str, expected: &[u8], expectedk: i16
     // check infinite zero digits
     if let Some(cut) = cut {
         for i in cut..expected.len()-1 {
-            expected_[..cut].clone_from_slice(&expected[..cut]);
+            expected_[..cut].copy_from_slice(&expected[..cut]);
             for c in &mut expected_[cut..i] { *c = b'0'; }
 
             try_exact!(f(&decoded) => &mut buf, &expected_[..i], expectedk;

--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -122,6 +122,7 @@
        test(attr(deny(warnings))))]
 #![cfg_attr(not(stage0), deny(warnings))]
 
+#![feature(copy_from_slice)]
 #![feature(rustc_private)]
 #![feature(staged_api)]
 
@@ -519,7 +520,7 @@ pub mod reader {
             // of the page and segfault.
 
             let mut b = [0; 8];
-            b.clone_from_slice(&d.data[d.end - 8..d.end]);
+            b.copy_from_slice(&d.data[d.end - 8..d.end]);
             let data = unsafe { (*(b.as_ptr() as *const u64)).to_be() };
             let len = d.end - d.start;
             if len < 8 {
@@ -1043,7 +1044,7 @@ pub mod writer {
                 {
                     let last_size_pos = last_size_pos as usize;
                     let data = &self.writer.get_ref()[last_size_pos + 4..cur_pos as usize];
-                    buf[..size].clone_from_slice(data);
+                    buf[..size].copy_from_slice(data);
                 }
 
                 // overwrite the size and data and continue

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -29,6 +29,7 @@
 #![feature(cell_extras)]
 #![feature(collections)]
 #![feature(const_fn)]
+#![feature(copy_from_slice)]
 #![feature(enumset)]
 #![feature(iter_arith)]
 #![feature(libc)]

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -489,7 +489,7 @@ impl<'a, 'tcx, O:DataFlowOperator> DataFlowContext<'a, 'tcx, O> {
                 let bits = &mut self.scope_kills[start.. end];
                 debug!("{} add_kills_from_flow_exits flow_exit={:?} bits={} [before]",
                        self.analysis_name, flow_exit, mut_bits_to_string(bits));
-                bits.clone_from_slice(&orig_kills[..]);
+                bits.copy_from_slice(&orig_kills[..]);
                 debug!("{} add_kills_from_flow_exits flow_exit={:?} bits={} [after]",
                        self.analysis_name, flow_exit, mut_bits_to_string(bits));
             }
@@ -556,7 +556,7 @@ impl<'a, 'b, 'tcx, O:DataFlowOperator> PropagationContext<'a, 'b, 'tcx, O> {
             let (start, end) = self.dfcx.compute_id_range(node_index);
 
             // Initialize local bitvector with state on-entry.
-            in_out.clone_from_slice(&self.dfcx.on_entry[start.. end]);
+            in_out.copy_from_slice(&self.dfcx.on_entry[start.. end]);
 
             // Compute state on-exit by applying transfer function to
             // state on-entry.

--- a/src/librustc_back/lib.rs
+++ b/src/librustc_back/lib.rs
@@ -31,6 +31,7 @@
 #![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(box_syntax)]
+#![feature(copy_from_slice)]
 #![feature(libc)]
 #![feature(rand)]
 #![feature(rustc_private)]

--- a/src/librustc_back/sha2.rs
+++ b/src/librustc_back/sha2.rs
@@ -134,13 +134,13 @@ impl FixedBuffer for FixedBuffer64 {
             let buffer_remaining = size - self.buffer_idx;
             if input.len() >= buffer_remaining {
                 self.buffer[self.buffer_idx..size]
-                    .clone_from_slice(&input[..buffer_remaining]);
+                    .copy_from_slice(&input[..buffer_remaining]);
                 self.buffer_idx = 0;
                 func(&self.buffer);
                 i += buffer_remaining;
             } else {
                 self.buffer[self.buffer_idx..self.buffer_idx + input.len()]
-                    .clone_from_slice(input);
+                    .copy_from_slice(input);
                 self.buffer_idx += input.len();
                 return;
             }
@@ -157,7 +157,7 @@ impl FixedBuffer for FixedBuffer64 {
         // data left in the input vector will be less than the buffer size and the buffer will
         // be empty.
         let input_remaining = input.len() - i;
-        self.buffer[..input_remaining].clone_from_slice(&input[i..]);
+        self.buffer[..input_remaining].copy_from_slice(&input[i..]);
         self.buffer_idx += input_remaining;
     }
 

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -256,7 +256,7 @@ impl Write for Cursor<Vec<u8>> {
             let pos = pos as usize;
             let space = self.inner.len() - pos;
             let (left, right) = buf.split_at(cmp::min(space, buf.len()));
-            self.inner[pos..pos + left.len()].clone_from_slice(left);
+            self.inner[pos..pos + left.len()].copy_from_slice(left);
             self.inner.extend_from_slice(right);
         }
 

--- a/src/libstd/io/impls.rs
+++ b/src/libstd/io/impls.rs
@@ -156,7 +156,7 @@ impl<'a> Read for &'a [u8] {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let amt = cmp::min(buf.len(), self.len());
         let (a, b) = self.split_at(amt);
-        buf[..amt].clone_from_slice(a);
+        buf[..amt].copy_from_slice(a);
         *self = b;
         Ok(amt)
     }
@@ -168,7 +168,7 @@ impl<'a> Read for &'a [u8] {
                                   "failed to fill whole buffer"));
         }
         let (a, b) = self.split_at(buf.len());
-        buf.clone_from_slice(a);
+        buf.copy_from_slice(a);
         *self = b;
         Ok(())
     }
@@ -189,7 +189,7 @@ impl<'a> Write for &'a mut [u8] {
     fn write(&mut self, data: &[u8]) -> io::Result<usize> {
         let amt = cmp::min(data.len(), self.len());
         let (a, b) = mem::replace(self, &mut []).split_at_mut(amt);
-        a.clone_from_slice(&data[..amt]);
+        a.copy_from_slice(&data[..amt]);
         *self = b;
         Ok(amt)
     }

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -222,6 +222,7 @@
 #![feature(collections)]
 #![feature(collections_bound)]
 #![feature(const_fn)]
+#![feature(copy_from_slice)]
 #![feature(core_float)]
 #![feature(core_intrinsics)]
 #![feature(decode_utf16)]

--- a/src/libstd/net/parser.rs
+++ b/src/libstd/net/parser.rs
@@ -191,8 +191,8 @@ impl<'a> Parser<'a> {
         fn ipv6_addr_from_head_tail(head: &[u16], tail: &[u16]) -> Ipv6Addr {
             assert!(head.len() + tail.len() <= 8);
             let mut gs = [0; 8];
-            gs[..head.len()].clone_from_slice(head);
-            gs[(8 - tail.len()) .. 8].clone_from_slice(tail);
+            gs[..head.len()].copy_from_slice(head);
+            gs[(8 - tail.len()) .. 8].copy_from_slice(tail);
             Ipv6Addr::new(gs[0], gs[1], gs[2], gs[3], gs[4], gs[5], gs[6], gs[7])
         }
 

--- a/src/libstd/sys/common/wtf8.rs
+++ b/src/libstd/sys/common/wtf8.rs
@@ -341,7 +341,7 @@ impl Wtf8Buf {
                 Some((surrogate_pos, _)) => {
                     pos = surrogate_pos + 3;
                     self.bytes[surrogate_pos..pos]
-                        .clone_from_slice(UTF8_REPLACEMENT_CHARACTER);
+                        .copy_from_slice(UTF8_REPLACEMENT_CHARACTER);
                 },
                 None => return unsafe { String::from_utf8_unchecked(self.bytes) }
             }


### PR DESCRIPTION
Use .copy_from_slice() where applicable

.copy_from_slice() does the same job of .clone_from_slice(), but the
former is explicitly for Copy elements and calls `memcpy` directly, and
thus is it efficient without optimization too.
