### PR TITLE
Add Pass manager for MIR

### DIFF
--- a/src/librustc/dep_graph/mod.rs
+++ b/src/librustc/dep_graph/mod.rs
@@ -70,6 +70,7 @@ pub enum DepNode {
     IntrinsicCheck(DefId),
     MatchCheck(DefId),
     MirMapConstruction(DefId),
+    MirPasses,
     BorrowCheck(DefId),
     RvalueCheck(DefId),
     Reachability,

--- a/src/librustc/dep_graph/mod.rs
+++ b/src/librustc/dep_graph/mod.rs
@@ -10,6 +10,7 @@
 
 use self::thread::{DepGraphThreadData, DepMessage};
 use middle::def_id::DefId;
+use syntax::ast::NodeId;
 use middle::ty::TyCtxt;
 use rustc_front::hir;
 use rustc_front::intravisit::Visitor;
@@ -70,7 +71,7 @@ pub enum DepNode {
     IntrinsicCheck(DefId),
     MatchCheck(DefId),
     MirMapConstruction(DefId),
-    MirPasses,
+    MirTypeck(NodeId),
     BorrowCheck(DefId),
     RvalueCheck(DefId),
     Reachability,

--- a/src/librustc/mir/mir_map.rs
+++ b/src/librustc/mir/mir_map.rs
@@ -8,31 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use dep_graph::DepNode;
 use util::nodemap::NodeMap;
 use mir::repr::Mir;
-use mir::transform::MirPass;
-use middle::ty::{self, TyCtxt};
-use middle::infer;
 
 pub struct MirMap<'tcx> {
     pub map: NodeMap<Mir<'tcx>>,
-}
-
-impl<'tcx> MirMap<'tcx> {
-    pub fn run_passes(&mut self, passes: &mut [Box<MirPass>], tcx: &TyCtxt<'tcx>) {
-        if passes.is_empty() { return; }
-
-        for (&id, mir) in &mut self.map {
-            let did = tcx.map.local_def_id(id);
-            let _task = tcx.dep_graph.in_task(DepNode::MirMapConstruction(did));
-
-            let param_env = ty::ParameterEnvironment::for_item(tcx, id);
-            let infcx = infer::new_infer_ctxt(tcx, &tcx.tables, Some(param_env));
-
-            for pass in &mut *passes {
-                pass.run_on_mir(mir, &infcx)
-            }
-        }
-    }
 }

--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -207,7 +207,7 @@ impl Debug for BasicBlock {
 }
 
 ///////////////////////////////////////////////////////////////////////////
-// BasicBlock and Terminator
+// BasicBlockData and Terminator
 
 #[derive(Clone, Debug, RustcEncodable, RustcDecodable)]
 pub struct BasicBlockData<'tcx> {

--- a/src/librustc/mir/transform.rs
+++ b/src/librustc/mir/transform.rs
@@ -8,9 +8,66 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use mir::mir_map::MirMap;
 use mir::repr::Mir;
-use middle::infer::InferCtxt;
+use middle::ty::TyCtxt;
 
-pub trait MirPass {
-    fn run_on_mir<'a, 'tcx>(&mut self, mir: &mut Mir<'tcx>, infcx: &InferCtxt<'a, 'tcx>);
+/// Various information about pass.
+pub trait Pass {
+    // fn name() for printouts of various sorts?
+    // fn should_run(Session) to check if pass should run?
+}
+
+/// A pass which inspects the whole MirMap.
+pub trait MirMapPass<'tcx>: Pass {
+    fn run_pass(&mut self, cx: &TyCtxt<'tcx>, map: &mut MirMap<'tcx>);
+}
+
+pub trait MirPass<'tcx>: Pass {
+    fn run_pass(&mut self, cx: &TyCtxt<'tcx>, map: &mut Mir<'tcx>);
+}
+
+impl<'tcx, T: MirPass<'tcx>> MirMapPass<'tcx> for T {
+    fn run_pass(&mut self, tcx: &TyCtxt<'tcx>, map: &mut MirMap<'tcx>) {
+        for (_, mir) in &mut map.map {
+            MirPass::run_pass(self, tcx, mir);
+        }
+    }
+}
+
+/// A manager for MIR passes.
+pub struct Passes {
+    passes: Vec<Box<for<'tcx> MirMapPass<'tcx>>>,
+    plugin_passes: Vec<Box<for<'tcx> MirMapPass<'tcx>>>
+}
+
+impl Passes {
+    pub fn new() -> Passes {
+        let passes = Passes {
+            passes: Vec::new(),
+            plugin_passes: Vec::new()
+        };
+        passes
+    }
+
+    pub fn run_passes<'tcx>(&mut self, pcx: &TyCtxt<'tcx>, map: &mut MirMap<'tcx>) {
+        for pass in &mut self.plugin_passes {
+            pass.run_pass(pcx, map);
+        }
+        for pass in &mut self.passes {
+            pass.run_pass(pcx, map);
+        }
+    }
+
+    /// Pushes a built-in pass.
+    pub fn push_pass(&mut self, pass: Box<for<'a> MirMapPass<'a>>) {
+        self.passes.push(pass);
+    }
+}
+
+/// Copies the plugin passes.
+impl ::std::iter::Extend<Box<for<'a> MirMapPass<'a>>> for Passes {
+    fn extend<I: IntoIterator<Item=Box<for <'a> MirMapPass<'a>>>>(&mut self, it: I) {
+        self.plugin_passes.extend(it);
+    }
 }

--- a/src/librustc/mir/transform.rs
+++ b/src/librustc/mir/transform.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use dep_graph::DepNode;
 use mir::mir_map::MirMap;
 use mir::repr::Mir;
 use middle::ty::TyCtxt;
@@ -23,8 +24,9 @@ pub trait MirMapPass<'tcx>: Pass {
     fn run_pass(&mut self, cx: &TyCtxt<'tcx>, map: &mut MirMap<'tcx>);
 }
 
+/// A pass which inspects Mir of functions in isolation.
 pub trait MirPass<'tcx>: Pass {
-    fn run_pass(&mut self, cx: &TyCtxt<'tcx>, map: &mut Mir<'tcx>);
+    fn run_pass(&mut self, cx: &TyCtxt<'tcx>, mir: &mut Mir<'tcx>);
 }
 
 impl<'tcx, T: MirPass<'tcx>> MirMapPass<'tcx> for T {

--- a/src/librustc/mir/transform.rs
+++ b/src/librustc/mir/transform.rs
@@ -8,10 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use dep_graph::DepNode;
 use mir::mir_map::MirMap;
 use mir::repr::Mir;
 use middle::ty::TyCtxt;
+use syntax::ast::NodeId;
 
 /// Various information about pass.
 pub trait Pass {
@@ -26,13 +26,13 @@ pub trait MirMapPass<'tcx>: Pass {
 
 /// A pass which inspects Mir of functions in isolation.
 pub trait MirPass<'tcx>: Pass {
-    fn run_pass(&mut self, cx: &TyCtxt<'tcx>, mir: &mut Mir<'tcx>);
+    fn run_pass(&mut self, cx: &TyCtxt<'tcx>, id: NodeId, mir: &mut Mir<'tcx>);
 }
 
 impl<'tcx, T: MirPass<'tcx>> MirMapPass<'tcx> for T {
     fn run_pass(&mut self, tcx: &TyCtxt<'tcx>, map: &mut MirMap<'tcx>) {
-        for (_, mir) in &mut map.map {
-            MirPass::run_pass(self, tcx, mir);
+        for (&id, mir) in &mut map.map {
+            MirPass::run_pass(self, tcx, id, mir);
         }
     }
 }

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -13,7 +13,7 @@ use middle::cstore::CrateStore;
 use middle::dependency_format;
 use session::search_paths::PathKind;
 use util::nodemap::{NodeMap, FnvHashMap};
-use mir::transform::MirPass;
+use mir::transform as mir_pass;
 
 use syntax::ast::{NodeId, NodeIdAssigner, Name};
 use syntax::codemap::{Span, MultiSpan};
@@ -60,7 +60,7 @@ pub struct Session {
     pub lint_store: RefCell<lint::LintStore>,
     pub lints: RefCell<NodeMap<Vec<(lint::LintId, Span, String)>>>,
     pub plugin_llvm_passes: RefCell<Vec<String>>,
-    pub plugin_mir_passes: RefCell<Vec<Box<MirPass>>>,
+    pub mir_passes: RefCell<mir_pass::Passes>,
     pub plugin_attributes: RefCell<Vec<(String, AttributeType)>>,
     pub crate_types: RefCell<Vec<config::CrateType>>,
     pub dependency_formats: RefCell<dependency_format::Dependencies>,
@@ -477,7 +477,7 @@ pub fn build_session_(sopts: config::Options,
         lint_store: RefCell::new(lint::LintStore::new()),
         lints: RefCell::new(NodeMap()),
         plugin_llvm_passes: RefCell::new(Vec::new()),
-        plugin_mir_passes: RefCell::new(Vec::new()),
+        mir_passes: RefCell::new(mir_pass::Passes::new()),
         plugin_attributes: RefCell::new(Vec::new()),
         crate_types: RefCell::new(Vec::new()),
         dependency_formats: RefCell::new(FnvHashMap()),

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use rustc::dep_graph::{DepGraph, DepNode};
+use rustc::dep_graph::DepGraph;
 use rustc::front;
 use rustc::front::map as hir_map;
 use rustc_mir as mir;
@@ -862,7 +862,6 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
                  || mir::mir_map::build_mir_for_crate(tcx));
 
         time(time_passes, "MIR passes", || {
-            let _task = tcx.dep_graph.in_task(DepNode::MirPasses);
             let mut passes = sess.mir_passes.borrow_mut();
             // Push all the built-in passes.
             passes.push_pass(box mir::transform::remove_dead_blocks::RemoveDeadBlocks);

--- a/src/librustc_mir/transform/erase_regions.rs
+++ b/src/librustc_mir/transform/erase_regions.rs
@@ -16,6 +16,7 @@ use rustc::middle::ty::{self, TyCtxt};
 use rustc::mir::repr::*;
 use rustc::mir::visit::MutVisitor;
 use rustc::mir::transform::{MirPass, Pass};
+use syntax::ast::NodeId;
 
 struct EraseRegionsVisitor<'a, 'tcx: 'a> {
     tcx: &'a TyCtxt<'tcx>,
@@ -123,7 +124,7 @@ pub struct EraseRegions;
 impl Pass for EraseRegions {}
 
 impl<'tcx> MirPass<'tcx> for EraseRegions {
-    fn run_pass(&mut self, tcx: &TyCtxt<'tcx>, mir: &mut Mir<'tcx>) {
+    fn run_pass(&mut self, tcx: &TyCtxt<'tcx>, _: NodeId, mir: &mut Mir<'tcx>) {
         EraseRegionsVisitor::new(tcx).visit_mir(mir);
     }
 }

--- a/src/librustc_mir/transform/erase_regions.rs
+++ b/src/librustc_mir/transform/erase_regions.rs
@@ -15,13 +15,7 @@
 use rustc::middle::ty::{self, TyCtxt};
 use rustc::mir::repr::*;
 use rustc::mir::visit::MutVisitor;
-use rustc::mir::mir_map::MirMap;
-
-pub fn erase_regions<'tcx>(tcx: &TyCtxt<'tcx>, mir_map: &mut MirMap<'tcx>) {
-    for (_, mir) in &mut mir_map.map {
-        EraseRegionsVisitor::new(tcx).visit_mir(mir);
-    }
-}
+use rustc::mir::transform::{MirPass, Pass};
 
 struct EraseRegionsVisitor<'a, 'tcx: 'a> {
     tcx: &'a TyCtxt<'tcx>,
@@ -121,5 +115,15 @@ impl<'a, 'tcx> MutVisitor<'tcx> for EraseRegionsVisitor<'a, 'tcx> {
             Literal::Value { .. } => { /* nothing to do */ }
         }
         self.super_constant(constant);
+    }
+}
+
+pub struct EraseRegions;
+
+impl Pass for EraseRegions {}
+
+impl<'tcx> MirPass<'tcx> for EraseRegions {
+    fn run_pass(&mut self, tcx: &TyCtxt<'tcx>, mir: &mut Mir<'tcx>) {
+        EraseRegionsVisitor::new(tcx).visit_mir(mir);
     }
 }

--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub mod clear_dead_blocks;
+pub mod remove_dead_blocks;
 pub mod simplify_cfg;
 pub mod erase_regions;
 pub mod no_landing_pads;

--- a/src/librustc_mir/transform/no_landing_pads.rs
+++ b/src/librustc_mir/transform/no_landing_pads.rs
@@ -15,6 +15,7 @@ use rustc::middle::ty::TyCtxt;
 use rustc::mir::repr::*;
 use rustc::mir::visit::MutVisitor;
 use rustc::mir::transform::{Pass, MirPass};
+use syntax::ast::NodeId;
 
 pub struct NoLandingPads;
 
@@ -41,7 +42,7 @@ impl<'tcx> MutVisitor<'tcx> for NoLandingPads {
 }
 
 impl<'tcx> MirPass<'tcx> for NoLandingPads {
-    fn run_pass(&mut self, tcx: &TyCtxt<'tcx>, mir: &mut Mir<'tcx>) {
+    fn run_pass(&mut self, tcx: &TyCtxt<'tcx>, _: NodeId, mir: &mut Mir<'tcx>) {
         if tcx.sess.no_landing_pads() {
             self.visit_mir(mir);
         }

--- a/src/librustc_mir/transform/no_landing_pads.rs
+++ b/src/librustc_mir/transform/no_landing_pads.rs
@@ -11,10 +11,10 @@
 //! This pass removes the unwind branch of all the terminators when the no-landing-pads option is
 //! specified.
 
-use rustc::middle::infer;
+use rustc::middle::ty::TyCtxt;
 use rustc::mir::repr::*;
 use rustc::mir::visit::MutVisitor;
-use rustc::mir::transform::MirPass;
+use rustc::mir::transform::{Pass, MirPass};
 
 pub struct NoLandingPads;
 
@@ -40,11 +40,12 @@ impl<'tcx> MutVisitor<'tcx> for NoLandingPads {
     }
 }
 
-impl MirPass for NoLandingPads {
-    fn run_on_mir<'a, 'tcx>(&mut self, mir: &mut Mir<'tcx>,
-                            infcx: &infer::InferCtxt<'a, 'tcx>) {
-        if infcx.tcx.sess.no_landing_pads() {
+impl<'tcx> MirPass<'tcx> for NoLandingPads {
+    fn run_pass(&mut self, tcx: &TyCtxt<'tcx>, mir: &mut Mir<'tcx>) {
+        if tcx.sess.no_landing_pads() {
             self.visit_mir(mir);
         }
     }
 }
+
+impl Pass for NoLandingPads {}

--- a/src/librustc_mir/transform/remove_dead_blocks.rs
+++ b/src/librustc_mir/transform/remove_dead_blocks.rs
@@ -32,50 +32,55 @@
 //! this pass just replaces the blocks with empty "return" blocks
 //! and does not renumber anything.
 
-use rustc::middle::infer;
+use rustc_data_structures::bitvec::BitVector;
+use rustc::middle::ty::TyCtxt;
 use rustc::mir::repr::*;
-use rustc::mir::transform::MirPass;
+use rustc::mir::transform::{Pass, MirPass};
 
-pub struct ClearDeadBlocks;
+pub struct RemoveDeadBlocks;
 
-impl ClearDeadBlocks {
-    pub fn new() -> ClearDeadBlocks {
-        ClearDeadBlocks
-    }
-
-    fn clear_dead_blocks(&self, mir: &mut Mir) {
-        let mut seen = vec![false; mir.basic_blocks.len()];
-
+impl<'tcx> MirPass<'tcx> for RemoveDeadBlocks {
+    fn run_pass(&mut self, _: &TyCtxt<'tcx>, mir: &mut Mir<'tcx>) {
+        let mut seen = BitVector::new(mir.basic_blocks.len());
         // These blocks are always required.
-        seen[START_BLOCK.index()] = true;
-        seen[END_BLOCK.index()] = true;
+        seen.insert(START_BLOCK.index());
+        seen.insert(END_BLOCK.index());
 
-        let mut worklist = vec![START_BLOCK];
+        let mut worklist = Vec::with_capacity(4);
+        worklist.push(START_BLOCK);
         while let Some(bb) = worklist.pop() {
             for succ in mir.basic_block_data(bb).terminator().successors().iter() {
-                if !seen[succ.index()] {
-                    seen[succ.index()] = true;
+                if seen.insert(succ.index()) {
                     worklist.push(*succ);
                 }
             }
         }
-
-        for (n, (block, seen)) in mir.basic_blocks.iter_mut().zip(seen).enumerate() {
-            if !seen {
-                info!("clearing block #{}: {:?}", n, block);
-                *block = BasicBlockData {
-                    statements: vec![],
-                    terminator: Some(Terminator::Return),
-                    is_cleanup: false
-                };
-            }
-        }
+        retain_basic_blocks(mir, &seen);
     }
 }
 
-impl MirPass for ClearDeadBlocks {
-    fn run_on_mir<'a, 'tcx>(&mut self, mir: &mut Mir<'tcx>, _: &infer::InferCtxt<'a, 'tcx>)
-    {
-        self.clear_dead_blocks(mir);
+impl Pass for RemoveDeadBlocks {}
+
+/// Mass removal of basic blocks to keep the ID-remapping cheap.
+fn retain_basic_blocks(mir: &mut Mir, keep: &BitVector) {
+    let num_blocks = mir.basic_blocks.len();
+
+    let mut replacements: Vec<_> = (0..num_blocks).map(BasicBlock::new).collect();
+    let mut used_blocks = 0;
+    for alive_index in keep.iter() {
+        replacements[alive_index] = BasicBlock::new(used_blocks);
+        if alive_index != used_blocks {
+            // Swap the next alive block data with the current available slot. Since alive_index is
+            // non-decreasing this is a valid operation.
+            mir.basic_blocks.swap(alive_index, used_blocks);
+        }
+        used_blocks += 1;
+    }
+    mir.basic_blocks.truncate(used_blocks);
+
+    for bb in mir.all_basic_blocks() {
+        for target in mir.basic_block_data_mut(bb).terminator_mut().successors_mut() {
+            *target = replacements[target.index()];
+        }
     }
 }

--- a/src/librustc_mir/transform/remove_dead_blocks.rs
+++ b/src/librustc_mir/transform/remove_dead_blocks.rs
@@ -36,11 +36,12 @@ use rustc_data_structures::bitvec::BitVector;
 use rustc::middle::ty::TyCtxt;
 use rustc::mir::repr::*;
 use rustc::mir::transform::{Pass, MirPass};
+use syntax::ast::NodeId;
 
 pub struct RemoveDeadBlocks;
 
 impl<'tcx> MirPass<'tcx> for RemoveDeadBlocks {
-    fn run_pass(&mut self, _: &TyCtxt<'tcx>, mir: &mut Mir<'tcx>) {
+    fn run_pass(&mut self, _: &TyCtxt<'tcx>, _: NodeId, mir: &mut Mir<'tcx>) {
         let mut seen = BitVector::new(mir.basic_blocks.len());
         // These blocks are always required.
         seen.insert(START_BLOCK.index());

--- a/src/librustc_mir/transform/simplify_cfg.rs
+++ b/src/librustc_mir/transform/simplify_cfg.rs
@@ -12,6 +12,7 @@ use rustc::middle::const_eval::ConstVal;
 use rustc::middle::ty::TyCtxt;
 use rustc::mir::repr::*;
 use rustc::mir::transform::{MirPass, Pass};
+use syntax::ast::NodeId;
 
 use super::remove_dead_blocks::RemoveDeadBlocks;
 
@@ -101,12 +102,12 @@ impl SimplifyCfg {
 }
 
 impl<'tcx> MirPass<'tcx> for SimplifyCfg {
-    fn run_pass(&mut self, tcx: &TyCtxt<'tcx>, mir: &mut Mir<'tcx>) {
+    fn run_pass(&mut self, tcx: &TyCtxt<'tcx>, id: NodeId, mir: &mut Mir<'tcx>) {
         let mut changed = true;
         while changed {
             changed = self.simplify_branches(mir);
             changed |= self.remove_goto_chains(mir);
-            RemoveDeadBlocks.run_pass(tcx, mir);
+            RemoveDeadBlocks.run_pass(tcx, id, mir);
         }
         // FIXME: Should probably be moved into some kind of pass manager
         mir.basic_blocks.shrink_to_fit();

--- a/src/librustc_mir/transform/simplify_cfg.rs
+++ b/src/librustc_mir/transform/simplify_cfg.rs
@@ -8,11 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use rustc_data_structures::bitvec::BitVector;
 use rustc::middle::const_eval::ConstVal;
-use rustc::middle::infer;
+use rustc::middle::ty::TyCtxt;
 use rustc::mir::repr::*;
-use rustc::mir::transform::MirPass;
+use rustc::mir::transform::{MirPass, Pass};
+
+use super::remove_dead_blocks::RemoveDeadBlocks;
 
 pub struct SimplifyCfg;
 
@@ -21,26 +22,7 @@ impl SimplifyCfg {
         SimplifyCfg
     }
 
-    fn remove_dead_blocks(&self, mir: &mut Mir) {
-        let mut seen = BitVector::new(mir.basic_blocks.len());
-        // These blocks are always required.
-        seen.insert(START_BLOCK.index());
-        seen.insert(END_BLOCK.index());
-
-        let mut worklist = Vec::with_capacity(4);
-        worklist.push(START_BLOCK);
-        while let Some(bb) = worklist.pop() {
-            for succ in mir.basic_block_data(bb).terminator().successors().iter() {
-                if seen.insert(succ.index()) {
-                    worklist.push(*succ);
-                }
-            }
-        }
-        retain_basic_blocks(mir, &seen);
-    }
-
     fn remove_goto_chains(&self, mir: &mut Mir) -> bool {
-
         // Find the target at the end of the jump chain, return None if there is a loop
         fn final_target(mir: &Mir, mut target: BasicBlock) -> Option<BasicBlock> {
             // Keep track of already seen blocks to detect loops
@@ -118,39 +100,17 @@ impl SimplifyCfg {
     }
 }
 
-impl MirPass for SimplifyCfg {
-    fn run_on_mir<'a, 'tcx>(&mut self, mir: &mut Mir<'tcx>, _: &infer::InferCtxt<'a, 'tcx>) {
+impl<'tcx> MirPass<'tcx> for SimplifyCfg {
+    fn run_pass(&mut self, tcx: &TyCtxt<'tcx>, mir: &mut Mir<'tcx>) {
         let mut changed = true;
         while changed {
             changed = self.simplify_branches(mir);
             changed |= self.remove_goto_chains(mir);
-            self.remove_dead_blocks(mir);
+            RemoveDeadBlocks.run_pass(tcx, mir);
         }
         // FIXME: Should probably be moved into some kind of pass manager
         mir.basic_blocks.shrink_to_fit();
     }
 }
 
-/// Mass removal of basic blocks to keep the ID-remapping cheap.
-fn retain_basic_blocks(mir: &mut Mir, keep: &BitVector) {
-    let num_blocks = mir.basic_blocks.len();
-
-    let mut replacements: Vec<_> = (0..num_blocks).map(BasicBlock::new).collect();
-    let mut used_blocks = 0;
-    for alive_index in keep.iter() {
-        replacements[alive_index] = BasicBlock::new(used_blocks);
-        if alive_index != used_blocks {
-            // Swap the next alive block data with the current available slot. Since alive_index is
-            // non-decreasing this is a valid operation.
-            mir.basic_blocks.swap(alive_index, used_blocks);
-        }
-        used_blocks += 1;
-    }
-    mir.basic_blocks.truncate(used_blocks);
-
-    for bb in mir.all_basic_blocks() {
-        for target in mir.basic_block_data_mut(bb).terminator_mut().successors_mut() {
-            *target = replacements[target.index()];
-        }
-    }
-}
+impl Pass for SimplifyCfg {}

--- a/src/librustc_mir/transform/type_check.rs
+++ b/src/librustc_mir/transform/type_check.rs
@@ -11,6 +11,7 @@
 //! This pass type-checks the MIR to ensure it is not broken.
 #![allow(unreachable_code)]
 
+use rustc::dep_graph::DepNode;
 use rustc::middle::infer::{self, InferCtxt};
 use rustc::middle::traits;
 use rustc::middle::ty::{self, Ty, TyCtxt};
@@ -581,6 +582,7 @@ impl<'tcx> MirMapPass<'tcx> for TypeckMir {
             return;
         }
         for (&id, mir) in &mut map.map {
+            let _task = tcx.dep_graph.in_task(DepNode::MirTypeck(id));
             let param_env = ty::ParameterEnvironment::for_item(tcx, id);
             let infcx = infer::new_infer_ctxt(tcx, &tcx.tables, Some(param_env));
             let mut checker = TypeChecker::new(&infcx);

--- a/src/librustc_plugin/registry.rs
+++ b/src/librustc_plugin/registry.rs
@@ -13,7 +13,7 @@
 use rustc::lint::{EarlyLintPassObject, LateLintPassObject, LintId, Lint};
 use rustc::session::Session;
 
-use rustc::mir::transform::MirPass;
+use rustc::mir::transform::MirMapPass;
 
 use syntax::ext::base::{SyntaxExtension, NamedSyntaxExtension, NormalTT};
 use syntax::ext::base::{IdentTT, MultiModifier, MultiDecorator};
@@ -56,7 +56,7 @@ pub struct Registry<'a> {
     pub late_lint_passes: Vec<LateLintPassObject>,
 
     #[doc(hidden)]
-    pub mir_passes: Vec<Box<MirPass>>,
+    pub mir_passes: Vec<Box<for<'pcx> MirMapPass<'pcx>>>,
 
     #[doc(hidden)]
     pub lint_groups: HashMap<&'static str, Vec<LintId>>,
@@ -141,7 +141,7 @@ impl<'a> Registry<'a> {
     }
 
     /// Register a MIR pass
-    pub fn register_mir_pass(&mut self, pass: Box<MirPass>) {
+    pub fn register_mir_pass(&mut self, pass: Box<for<'pcx> MirMapPass<'pcx>>) {
         self.mir_passes.push(pass);
     }
 

--- a/src/test/auxiliary/dummy_mir_pass.rs
+++ b/src/test/auxiliary/dummy_mir_pass.rs
@@ -18,17 +18,18 @@ extern crate rustc_front;
 extern crate rustc_plugin;
 extern crate syntax;
 
-use rustc::mir::transform::MirPass;
+use rustc::mir::transform::{self, MirPass};
 use rustc::mir::repr::{Mir, Literal};
 use rustc::mir::visit::MutVisitor;
-use rustc::middle::infer::InferCtxt;
+use rustc::middle::ty;
 use rustc::middle::const_eval::ConstVal;
 use rustc_plugin::Registry;
 
 struct Pass;
 
-impl MirPass for Pass {
-    fn run_on_mir<'a, 'tcx>(&mut self, mir: &mut Mir<'tcx>, _: &InferCtxt<'a, 'tcx>) {
+impl transform::Pass for Pass {}
+impl<'tcx> MirPass<'tcx> for Pass {
+    fn run_pass(&mut self, _: &ty::ctxt<'tcx>, mir: &mut Mir<'tcx>) {
         Visitor.visit_mir(mir)
     }
 }

--- a/src/test/auxiliary/dummy_mir_pass.rs
+++ b/src/test/auxiliary/dummy_mir_pass.rs
@@ -25,11 +25,13 @@ use rustc::middle::ty;
 use rustc::middle::const_eval::ConstVal;
 use rustc_plugin::Registry;
 
+use syntax::ast::NodeId;
+
 struct Pass;
 
 impl transform::Pass for Pass {}
 impl<'tcx> MirPass<'tcx> for Pass {
-    fn run_pass(&mut self, _: &ty::ctxt<'tcx>, mir: &mut Mir<'tcx>) {
+    fn run_pass(&mut self, _: &ty::TyCtxt<'tcx>, _: NodeId, mir: &mut Mir<'tcx>) {
         Visitor.visit_mir(mir)
     }
 }


### PR DESCRIPTION
A new PR, since rebasing the original one (https://github.com/rust-lang/rust/pull/31448) properly was a pain. Since then there has been several changes most notable of which:
1. Removed the pretty-printing with `#[rustc_mir(graphviz/pretty)]`, mostly because we now have `--unpretty=mir`, IMHO that’s the direction we should expand this functionality into;
2. Reverted the infercx change done for typeck, because typeck can make an infercx for itself by being a `MirMapPass`

r? @nikomatsakis 
