### PR TITLE
Forbid items with the same name from appearing in overlapping inherent impl blocks

### DIFF
--- a/src/librustc/dep_graph/mod.rs
+++ b/src/librustc/dep_graph/mod.rs
@@ -58,6 +58,7 @@ pub enum DepNode {
     CoherenceCheckImpl(DefId),
     CoherenceOverlapCheck(DefId),
     CoherenceOverlapCheckSpecial(DefId),
+    CoherenceOverlapInherentCheck(DefId),
     CoherenceOrphanCheck(DefId),
     Variance,
     WfCheck(DefId),

--- a/src/librustc/middle/infer/mod.rs
+++ b/src/librustc/middle/infer/mod.rs
@@ -458,14 +458,13 @@ pub fn mk_eqty<'a, 'tcx>(cx: &InferCtxt<'a, 'tcx>,
 }
 
 pub fn mk_eq_trait_refs<'a, 'tcx>(cx: &InferCtxt<'a, 'tcx>,
-                                   a_is_expected: bool,
-                                   origin: TypeOrigin,
-                                   a: ty::TraitRef<'tcx>,
-                                   b: ty::TraitRef<'tcx>)
-                                   -> UnitResult<'tcx>
+                                  a_is_expected: bool,
+                                  origin: TypeOrigin,
+                                  a: ty::TraitRef<'tcx>,
+                                  b: ty::TraitRef<'tcx>)
+                                  -> UnitResult<'tcx>
 {
-    debug!("mk_eq_trait_refs({:?} <: {:?})",
-           a, b);
+    debug!("mk_eq_trait_refs({:?} = {:?})", a, b);
     cx.eq_trait_refs(a_is_expected, origin, a, b)
 }
 
@@ -476,9 +475,23 @@ pub fn mk_sub_poly_trait_refs<'a, 'tcx>(cx: &InferCtxt<'a, 'tcx>,
                                         b: ty::PolyTraitRef<'tcx>)
                                         -> UnitResult<'tcx>
 {
-    debug!("mk_sub_poly_trait_refs({:?} <: {:?})",
-           a, b);
+    debug!("mk_sub_poly_trait_refs({:?} <: {:?})", a, b);
     cx.sub_poly_trait_refs(a_is_expected, origin, a, b)
+}
+
+pub fn mk_eq_impl_headers<'a, 'tcx>(cx: &InferCtxt<'a, 'tcx>,
+                                    a_is_expected: bool,
+                                    origin: TypeOrigin,
+                                    a: ty::ImplHeader<'tcx>,
+                                    b: ty::ImplHeader<'tcx>)
+                                    -> UnitResult<'tcx>
+{
+    debug!("mk_eq_impl_header({:?} = {:?})", a, b);
+    match (a.trait_ref, b.trait_ref) {
+        (Some(a_ref), Some(b_ref)) => mk_eq_trait_refs(cx, a_is_expected, a_ref, b_ref),
+        (None, None) => mk_eqty(cx, a_is_expected, a.self_ty, b.self_ty),
+        _ => cx.tcx.sess.bug("mk_eq_impl_headers given mismatched impl kinds"),
+    }
 }
 
 fn expected_found<T>(a_is_expected: bool,

--- a/src/librustc/middle/infer/mod.rs
+++ b/src/librustc/middle/infer/mod.rs
@@ -482,14 +482,14 @@ pub fn mk_sub_poly_trait_refs<'a, 'tcx>(cx: &InferCtxt<'a, 'tcx>,
 pub fn mk_eq_impl_headers<'a, 'tcx>(cx: &InferCtxt<'a, 'tcx>,
                                     a_is_expected: bool,
                                     origin: TypeOrigin,
-                                    a: ty::ImplHeader<'tcx>,
-                                    b: ty::ImplHeader<'tcx>)
+                                    a: &ty::ImplHeader<'tcx>,
+                                    b: &ty::ImplHeader<'tcx>)
                                     -> UnitResult<'tcx>
 {
     debug!("mk_eq_impl_header({:?} = {:?})", a, b);
     match (a.trait_ref, b.trait_ref) {
-        (Some(a_ref), Some(b_ref)) => mk_eq_trait_refs(cx, a_is_expected, a_ref, b_ref),
-        (None, None) => mk_eqty(cx, a_is_expected, a.self_ty, b.self_ty),
+        (Some(a_ref), Some(b_ref)) => mk_eq_trait_refs(cx, a_is_expected, origin, a_ref, b_ref),
+        (None, None) => mk_eqty(cx, a_is_expected, origin, a.self_ty, b.self_ty),
         _ => cx.tcx.sess.bug("mk_eq_impl_headers given mismatched impl kinds"),
     }
 }

--- a/src/librustc/middle/traits/coherence.rs
+++ b/src/librustc/middle/traits/coherence.rs
@@ -10,10 +10,8 @@
 
 //! See `README.md` for high-level documentation
 
-use super::Normalized;
-use super::SelectionContext;
-use super::ObligationCause;
-use super::PredicateObligation;
+use super::{Normalized, SelectionContext};
+use super::{Obligation, ObligationCause, PredicateObligation};
 use super::project;
 use super::util;
 
@@ -21,18 +19,19 @@ use middle::cstore::LOCAL_CRATE;
 use middle::def_id::DefId;
 use middle::subst::{Subst, Substs, TypeSpace};
 use middle::ty::{self, Ty, TyCtxt};
+use middle::ty::error::TypeError;
 use middle::infer::{self, InferCtxt, TypeOrigin};
 use syntax::codemap::{DUMMY_SP, Span};
 
 #[derive(Copy, Clone)]
 struct InferIsLocal(bool);
 
-/// If there are types that satisfy both impls, returns a `TraitRef`
+/// If there are types that satisfy both impls, returns an `ImplTy`
 /// with those types substituted (by updating the given `infcx`)
 pub fn overlapping_impls<'cx, 'tcx>(infcx: &InferCtxt<'cx, 'tcx>,
                                     impl1_def_id: DefId,
                                     impl2_def_id: DefId)
-                                    -> Option<ty::TraitRef<'tcx>>
+                                    -> Option<ImplTy<'tcx>>
 {
     debug!("impl_can_satisfy(\
            impl1_def_id={:?}, \
@@ -45,34 +44,28 @@ pub fn overlapping_impls<'cx, 'tcx>(infcx: &InferCtxt<'cx, 'tcx>,
 }
 
 /// Can both impl `a` and impl `b` be satisfied by a common type (including
-/// `where` clauses)? If so, returns a `TraitRef` that unifies the two impls.
+/// `where` clauses)? If so, returns an `ImplHeader` that unifies the two impls.
 fn overlap<'cx, 'tcx>(selcx: &mut SelectionContext<'cx, 'tcx>,
                       a_def_id: DefId,
                       b_def_id: DefId)
-                      -> Option<ty::TraitRef<'tcx>>
+                      -> Option<ImplHeader<'tcx>>
 {
     debug!("overlap(a_def_id={:?}, b_def_id={:?})",
            a_def_id,
            b_def_id);
 
-    let (a_trait_ref, a_obligations) = impl_trait_ref_and_oblig(selcx,
-                                                                a_def_id,
-                                                                util::fresh_type_vars_for_impl);
+    let a_impl_header = ty::ImplHeader::with_fresh_ty_vars(selcx, a_def_id);
+    let b_impl_header = ty::ImplHeader::with_fresh_ty_vars(selcx, b_def_id);
 
-    let (b_trait_ref, b_obligations) = impl_trait_ref_and_oblig(selcx,
-                                                                b_def_id,
-                                                                util::fresh_type_vars_for_impl);
-
-    debug!("overlap: a_trait_ref={:?} a_obligations={:?}", a_trait_ref, a_obligations);
-
-    debug!("overlap: b_trait_ref={:?} b_obligations={:?}", b_trait_ref, b_obligations);
+    debug!("overlap: a_impl_header={:?}", a_impl_header);
+    debug!("overlap: b_impl_header={:?}", b_impl_header);
 
     // Do `a` and `b` unify? If not, no overlap.
-    if let Err(_) = infer::mk_eq_trait_refs(selcx.infcx(),
-                                            true,
-                                            TypeOrigin::Misc(DUMMY_SP),
-                                            a_trait_ref,
-                                            b_trait_ref) {
+    if let Err(_) = infer::mk_eq_impl_headers(selcx.infcx(),
+                                              true,
+                                              TypeOrigin::Misc(DUMMY_SP),
+                                              a_impl_header,
+                                              b_impl_header) {
         return None;
     }
 
@@ -81,9 +74,13 @@ fn overlap<'cx, 'tcx>(selcx: &mut SelectionContext<'cx, 'tcx>,
     // Are any of the obligations unsatisfiable? If so, no overlap.
     let infcx = selcx.infcx();
     let opt_failing_obligation =
-        a_obligations.iter()
-                     .chain(&b_obligations)
-                     .map(|o| infcx.resolve_type_vars_if_possible(o))
+        a_impl_header.prediates
+                     .iter()
+                     .chain(&b_impl_header.predicates)
+                     .map(|p| infcx.resolve_type_vars_if_possible(p))
+                     .map(|p| Obligation { cause: ObligationCause::dummy(),
+                                           recursion_depth: 0,
+                                           predicate: p })
                      .find(|o| !selcx.evaluate_obligation(o));
 
     if let Some(failing_obligation) = opt_failing_obligation {
@@ -91,7 +88,7 @@ fn overlap<'cx, 'tcx>(selcx: &mut SelectionContext<'cx, 'tcx>,
         return None
     }
 
-    Some(selcx.infcx().resolve_type_vars_if_possible(&a_trait_ref))
+    Some(selcx.infcx().resolve_type_vars_if_possible(&a_impl_header))
 }
 
 pub fn trait_ref_is_knowable<'tcx>(tcx: &TyCtxt<'tcx>, trait_ref: &ty::TraitRef<'tcx>) -> bool
@@ -123,44 +120,6 @@ pub fn trait_ref_is_knowable<'tcx>(tcx: &TyCtxt<'tcx>, trait_ref: &ty::TraitRef<
     // must be visible to us, and -- since the trait is fundamental
     // -- we can test.
     orphan_check_trait_ref(tcx, trait_ref, InferIsLocal(true)).is_err()
-}
-
-type SubstsFn = for<'a,'tcx> fn(infcx: &InferCtxt<'a, 'tcx>,
-                                span: Span,
-                                impl_def_id: DefId)
-                                -> Substs<'tcx>;
-
-/// Instantiate fresh variables for all bound parameters of the impl
-/// and return the impl trait ref with those variables substituted.
-fn impl_trait_ref_and_oblig<'a,'tcx>(selcx: &mut SelectionContext<'a,'tcx>,
-                                     impl_def_id: DefId,
-                                     substs_fn: SubstsFn)
-                                     -> (ty::TraitRef<'tcx>,
-                                         Vec<PredicateObligation<'tcx>>)
-{
-    let impl_substs =
-        &substs_fn(selcx.infcx(), DUMMY_SP, impl_def_id);
-    let impl_trait_ref =
-        selcx.tcx().impl_trait_ref(impl_def_id).unwrap();
-    let impl_trait_ref =
-        impl_trait_ref.subst(selcx.tcx(), impl_substs);
-    let Normalized { value: impl_trait_ref, obligations: normalization_obligations1 } =
-        project::normalize(selcx, ObligationCause::dummy(), &impl_trait_ref);
-
-    let predicates = selcx.tcx().lookup_predicates(impl_def_id);
-    let predicates = predicates.instantiate(selcx.tcx(), impl_substs);
-    let Normalized { value: predicates, obligations: normalization_obligations2 } =
-        project::normalize(selcx, ObligationCause::dummy(), &predicates);
-    let impl_obligations =
-        util::predicates_for_generics(ObligationCause::dummy(), 0, &predicates);
-
-    let impl_obligations: Vec<_> =
-        impl_obligations.into_iter()
-        .chain(normalization_obligations1)
-        .chain(normalization_obligations2)
-        .collect();
-
-    (impl_trait_ref, impl_obligations)
 }
 
 pub enum OrphanCheckErr<'tcx> {

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -391,7 +391,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     // The result is "true" if the obligation *may* hold and "false" if
     // we can be sure it does not.
 
-
     /// Evaluates whether the obligation `obligation` can be satisfied (by any means).
     pub fn evaluate_obligation(&mut self,
                                obligation: &PredicateObligation<'tcx>)

--- a/src/librustc/middle/ty/fold.rs
+++ b/src/librustc/middle/ty/fold.rs
@@ -146,6 +146,10 @@ pub trait TypeFolder<'tcx> : Sized {
         t.super_fold_with(self)
     }
 
+    fn fold_impl_header(&mut self, imp: &ty::ImplHeader<'tcx>) -> ty::ImplHeader<'tcx> {
+        imp.super_fold_with(self)
+    }
+
     fn fold_substs(&mut self,
                    substs: &subst::Substs<'tcx>)
                    -> subst::Substs<'tcx> {

--- a/src/librustc/middle/ty/mod.rs
+++ b/src/librustc/middle/ty/mod.rs
@@ -164,9 +164,9 @@ pub struct ImplHeader<'tcx> {
 }
 
 impl<'tcx> ImplHeader<'tcx> {
-    pub fn with_fresh_ty_vars<'a,'tcx>(selcx: &mut traits::SelectionContext<'a,'tcx>,
-                                       impl_def_id: DefId)
-                                       -> ImplHeader<'tcx>
+    pub fn with_fresh_ty_vars<'a>(selcx: &mut traits::SelectionContext<'a, 'tcx>,
+                                  impl_def_id: DefId)
+                                  -> ImplHeader<'tcx>
     {
         let tcx = selcx.tcx();
         let impl_generics = tcx.lookup_item_type(impl_def_id).generics;
@@ -174,13 +174,13 @@ impl<'tcx> ImplHeader<'tcx> {
 
         let header = ImplHeader {
             impl_def_id: impl_def_id,
-            self_ty: tcx.lookup_item_type(impl_def_id),
+            self_ty: tcx.lookup_item_type(impl_def_id).ty,
             trait_ref: tcx.impl_trait_ref(impl_def_id),
-            predicates: tcx.lookup_predicates(impl_def_id),
-        }.subst(tcx, impl_substs);
+            predicates: tcx.lookup_predicates(impl_def_id).predicates.into_vec(),
+        }.subst(tcx, &impl_substs);
 
-        let Normalized { value: mut header, obligations: obligations } =
-            proect::normalize(selcx, ObligationCause::dummy(), &header);
+        let traits::Normalized { value: mut header, obligations } =
+            traits::normalize(selcx, traits::ObligationCause::dummy(), &header);
 
         header.predicates.extend(obligations.into_iter().map(|o| o.predicate));
         header

--- a/src/librustc/middle/ty/mod.rs
+++ b/src/librustc/middle/ty/mod.rs
@@ -152,6 +152,41 @@ impl ImplOrTraitItemContainer {
     }
 }
 
+/// The "header" of an impl is everything outside the body: a Self type, a trait
+/// ref (in the case of a trait impl), and a set of predicates (from the
+/// bounds/where clauses).
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct ImplHeader<'tcx> {
+    pub impl_def_id: DefId,
+    pub self_ty: Ty<'tcx>,
+    pub trait_ref: Option<TraitRef<'tcx>>,
+    pub predicates: Vec<Predicate<'tcx>>,
+}
+
+impl<'tcx> ImplHeader<'tcx> {
+    pub fn with_fresh_ty_vars<'a,'tcx>(selcx: &mut traits::SelectionContext<'a,'tcx>,
+                                       impl_def_id: DefId)
+                                       -> ImplHeader<'tcx>
+    {
+        let tcx = selcx.tcx();
+        let impl_generics = tcx.lookup_item_type(impl_def_id).generics;
+        let impl_substs = selcx.infcx().fresh_substs_for_generics(DUMMY_SP, &impl_generics);
+
+        let header = ImplHeader {
+            impl_def_id: impl_def_id,
+            self_ty: tcx.lookup_item_type(impl_def_id),
+            trait_ref: tcx.impl_trait_ref(impl_def_id),
+            predicates: tcx.lookup_predicates(impl_def_id),
+        }.subst(tcx, impl_substs);
+
+        let Normalized { value: mut header, obligations: obligations } =
+            proect::normalize(selcx, ObligationCause::dummy(), &header);
+
+        header.predicates.extend(obligations.into_iter().map(|o| o.predicate));
+        header
+    }
+}
+
 #[derive(Clone)]
 pub enum ImplOrTraitItem<'tcx> {
     ConstTraitItem(Rc<AssociatedConst<'tcx>>),

--- a/src/librustc/middle/ty/structural_impls.rs
+++ b/src/librustc/middle/ty/structural_impls.rs
@@ -446,6 +446,28 @@ impl<'tcx> TypeFoldable<'tcx> for ty::TraitRef<'tcx> {
     }
 }
 
+impl<'tcx> TypeFoldable<'tcx> for ty::ImplHeader<'tcx> {
+    fn super_fold_with<F: TypeFolder<'tcx>>(&self, folder: &mut F) -> Self {
+        ty::ImplHeader {
+            impl_def_id: self.impl_def_id,
+            self_ty: self.self_ty.fold_with(folder),
+            trait_ref: self.trait_ref.map(|t| t.fold_with(folder)),
+            predicates: self.predicates.into_iter().map(|p| p.fold_with(folder)).collect(),
+            polarity: self.polarity,
+        }
+    }
+
+    fn fold_with<F: TypeFolder<'tcx>>(&self, folder: &mut F) -> Self {
+        folder.fold_impl_header(self)
+    }
+
+    fn super_visit_with<V: TypeVisitor<'tcx>>(&self, visitor: &mut V) -> bool {
+        self.self_ty.visit_with(visitor) ||
+            self.trait_ref.map(|r| r.visit_with(visitor)).unwrap_or(false) ||
+            self.predicates.iter().any(|p| p.visit_with(visitor))
+    }
+}
+
 impl<'tcx> TypeFoldable<'tcx> for ty::Region {
     fn super_fold_with<F: TypeFolder<'tcx>>(&self, _folder: &mut F) -> Self {
         *self

--- a/src/librustc/middle/ty/structural_impls.rs
+++ b/src/librustc/middle/ty/structural_impls.rs
@@ -452,8 +452,7 @@ impl<'tcx> TypeFoldable<'tcx> for ty::ImplHeader<'tcx> {
             impl_def_id: self.impl_def_id,
             self_ty: self.self_ty.fold_with(folder),
             trait_ref: self.trait_ref.map(|t| t.fold_with(folder)),
-            predicates: self.predicates.into_iter().map(|p| p.fold_with(folder)).collect(),
-            polarity: self.polarity,
+            predicates: self.predicates.iter().map(|p| p.fold_with(folder)).collect(),
         }
     }
 

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -35,7 +35,9 @@ use CrateCtxt;
 use middle::infer::{self, InferCtxt, TypeOrigin, new_infer_ctxt};
 use std::cell::RefCell;
 use std::rc::Rc;
+use syntax::ast;
 use syntax::codemap::Span;
+use syntax::errors::DiagnosticBuilder;
 use util::nodemap::{DefIdMap, FnvHashMap};
 use rustc::dep_graph::DepNode;
 use rustc::front::map as hir_map;
@@ -517,6 +519,13 @@ fn enforce_trait_manually_implementable(tcx: &TyCtxt, sp: Span, trait_def_id: De
     fileline_help!(&mut err, sp,
                    "add `#![feature(unboxed_closures)]` to the crate attributes to enable");
     err.emit();
+}
+
+// Factored out into helper because the error cannot be defined in multiple locations.
+pub fn report_duplicate_item<'tcx>(tcx: &TyCtxt<'tcx>, sp: Span, name: ast::Name)
+                                   -> DiagnosticBuilder<'tcx>
+{
+    struct_span_err!(tcx.sess, sp, E0201, "duplicate definitions with name `{}`:", name)
 }
 
 pub fn check_coherence(crate_context: &CrateCtxt) {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -63,6 +63,7 @@ use lint;
 use middle::def::Def;
 use middle::def_id::DefId;
 use constrained_type_params as ctp;
+use coherence;
 use middle::lang_items::SizedTraitLangItem;
 use middle::resolve_lifetime;
 use middle::const_eval::{self, ConstVal};
@@ -750,17 +751,7 @@ fn convert_item(ccx: &CrateCtxt, it: &hir::Item) {
                     _                    => &mut seen_value_items,
                 };
                 if !seen_items.insert(impl_item.name) {
-                    let desc = match impl_item.node {
-                        hir::ImplItemKind::Const(_, _) => "associated constant",
-                        hir::ImplItemKind::Type(_) => "associated type",
-                        hir::ImplItemKind::Method(ref sig, _) =>
-                            match sig.explicit_self.node {
-                                hir::SelfStatic => "associated function",
-                                _ => "method",
-                            },
-                    };
-
-                    span_err!(tcx.sess, impl_item.span, E0201, "duplicate {}", desc);
+                    coherence::report_duplicate_item(tcx, impl_item.span, impl_item.name).emit();
                 }
 
                 if let hir::ImplItemKind::Const(ref ty, _) = impl_item.node {

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -2285,6 +2285,21 @@ impl Baz for Foo {
     type Quux = u32;
 }
 ```
+
+Note, however, that items with the same name are allowed for inherent `impl`
+blocks that don't overlap:
+
+```
+struct Foo<T>(T);
+
+impl Foo<u8> {
+    fn bar(&self) -> bool { self.0 > 5 }
+}
+
+impl Foo<bool> {
+    fn bar(&self) -> bool { self.0 }
+}
+```
 "##,
 
 E0202: r##"

--- a/src/test/compile-fail/associated-item-duplicate-names-2.rs
+++ b/src/test/compile-fail/associated-item-duplicate-names-2.rs
@@ -14,7 +14,7 @@ struct Foo;
 
 impl Foo {
     const bar: bool = true;
-    fn bar() {} //~ ERROR duplicate associated function
+    fn bar() {} //~ ERROR duplicate definitions
 }
 
 fn main() {}

--- a/src/test/compile-fail/associated-item-duplicate-names-3.rs
+++ b/src/test/compile-fail/associated-item-duplicate-names-3.rs
@@ -20,7 +20,7 @@ struct Baz;
 
 impl Foo for Baz {
     type Bar = i16;
-    type Bar = u16; //~ ERROR duplicate associated type
+    type Bar = u16; //~ ERROR duplicate definitions
 }
 
 fn main() {

--- a/src/test/compile-fail/associated-item-duplicate-names.rs
+++ b/src/test/compile-fail/associated-item-duplicate-names.rs
@@ -19,9 +19,9 @@ trait Foo {
 
 impl Foo for () {
     type Ty = ();
-    type Ty = usize; //~ ERROR duplicate associated type
+    type Ty = usize; //~ ERROR duplicate definitions
     const BAR: u32 = 7;
-    const BAR: u32 = 8; //~ ERROR duplicate associated constant
+    const BAR: u32 = 8; //~ ERROR duplicate definitions
 }
 
 fn main() {

--- a/src/test/compile-fail/impl-duplicate-methods.rs
+++ b/src/test/compile-fail/impl-duplicate-methods.rs
@@ -11,7 +11,7 @@
 struct Foo;
 impl Foo {
     fn orange(&self){}
-    fn orange(&self){}   //~ ERROR duplicate method
+    fn orange(&self){}   //~ ERROR duplicate definitions
 }
 
 fn main() {}

--- a/src/test/compile-fail/inherent-overlap.rs
+++ b/src/test/compile-fail/inherent-overlap.rs
@@ -1,0 +1,44 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that you cannot define items with the same name in overlapping inherent
+// impl blocks.
+
+struct Foo;
+
+impl Foo {
+    fn id() {} //~ ERROR E0201
+}
+
+impl Foo {
+    fn id() {}
+}
+
+struct Bar<T>(T);
+
+impl<T> Bar<T> {
+    fn bar(&self) {} //~ ERROR E0201
+}
+
+impl Bar<u32> {
+    fn bar(&self) {}
+}
+
+struct Baz<T>(T);
+
+impl<T: Copy> Baz<T> {
+    fn baz(&self) {} //~ ERROR E0201
+}
+
+impl<T> Baz<Vec<T>> {
+    fn baz(&self) {}
+}
+
+fn main() {}

--- a/src/test/compile-fail/issue-4265.rs
+++ b/src/test/compile-fail/issue-4265.rs
@@ -17,7 +17,7 @@ impl Foo {
         Foo { baz: 0 }.bar();
     }
 
-    fn bar() { //~ ERROR duplicate associated function
+    fn bar() { //~ ERROR duplicate definitions
     }
 }
 

--- a/src/test/compile-fail/issue-8153.rs
+++ b/src/test/compile-fail/issue-8153.rs
@@ -18,7 +18,7 @@ trait Bar {
 
 impl Bar for Foo {
     fn bar(&self) -> isize {1}
-    fn bar(&self) -> isize {2} //~ ERROR duplicate method
+    fn bar(&self) -> isize {2} //~ ERROR duplicate definitions
 }
 
 fn main() {

--- a/src/test/compile-fail/method-macro-backtrace.rs
+++ b/src/test/compile-fail/method-macro-backtrace.rs
@@ -29,7 +29,7 @@ impl S {
 
     // Cause an error. It shouldn't have any macro backtrace frames.
     fn bar(&self) { }
-    fn bar(&self) { } //~ ERROR duplicate method
+    fn bar(&self) { } //~ ERROR duplicate definitions
 }
 
 fn main() { }

--- a/src/test/rustdoc/issue-25001.rs
+++ b/src/test/rustdoc/issue-25001.rs
@@ -17,15 +17,15 @@ pub trait Bar {
     fn quux(self);
 }
 
-impl<T> Foo<T> {
+impl Foo<u8> {
     // @has - '//*[@id="method.pass"]//code' 'fn pass()'
     pub fn pass() {}
 }
-impl<T> Foo<T> {
+impl Foo<u16> {
     // @has - '//*[@id="method.pass-1"]//code' 'fn pass() -> usize'
     pub fn pass() -> usize { 42 }
 }
-impl<T> Foo<T> {
+impl Foo<u32> {
     // @has - '//*[@id="method.pass-2"]//code' 'fn pass() -> isize'
     pub fn pass() -> isize { 42 }
 }


### PR DESCRIPTION
For example, the following is now correctly illegal:

``` rust
struct Foo;

impl Foo {
    fn id() {}
}

impl Foo {
    fn id() {}
}
```

"Overlapping" here is determined the same way it is for traits (and in fact shares the same code path): roughly, there must be some way of substituting any generic types to unify the impls, such that none of the `where` clauses are provably unsatisfiable under such a unification.

Along the way, this PR also introduces an `ImplHeader` abstraction (the first commit) that makes it easier to work with impls abstractly (without caring whether they are trait or inherent impl blocks); see the first commit.

Closes #22889
r? @nikomatsakis 
