### PR TITLE
Avoid excessive reallocations during item-bodies checking

### DIFF
--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -555,6 +555,11 @@ impl<'a,T> Iterator for EnumeratedItems<'a,T> {
             None
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let size = self.vec.as_slice().len();
+        (size, Some(size))
+    }
 }
 
 impl<T> IntoIterator for VecPerParamSpace<T> {


### PR DESCRIPTION
When foldings Substs, we map over VecPerParamSpace instances using
EnumeratedItems which does not provide an accurate size_hint()
in its Iterator implementation. This leads to quite a large number or
reallocations. Providing a suitable size_hint() implementation reduces
the time spent in item-bodies checking quite a bit.

```
crate  | before | after | ~change
-------|-------------------------
core   |  7.28s | 5.44s |   -25%
std    |  2.07s | 1.88s |  -9.2%
syntax |  8.86s | 8.30s |  -6.3%
```
