### PR TITLE
Fix the check in is_loopback

### DIFF
--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -92,7 +92,11 @@ impl Ipv4Addr {
     /// This property is defined by RFC 6890
     #[stable(since = "1.7.0", feature = "ip_17")]
     pub fn is_loopback(&self) -> bool {
-        self.octets()[0] == 127
+        let parts = self.octets();
+        match (parts[0], parts[1], parts[2], parts[3]) {
+            (127, 0 ... 255, 0 ... 255, 0 ... 255) => true,
+            _ => false
+        }
     }
 
     /// Returns true if this is a private address.


### PR DESCRIPTION
According to RFC 5735 (https://tools.ietf.org/html/rfc5735) any address
in the range 127.0.0.0/8 is a loopback address
