### PR TITLE
Fix `fs::remove_dir_all`

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1426,7 +1426,8 @@ impl Iterator for WalkDir {
 /// # Platform-specific behavior
 ///
 /// This function currently corresponds to the `chmod` function on Unix
-/// and the `SetFileAttributes` function on Windows.
+/// and the `CreateFile`, `GetFileInformationByHandle` and
+/// `SetFileInformationByHandle` function on Windows.
 /// Note that, this [may change in the future][changes].
 /// [changes]: ../io/index.html#platform-specific-behavior
 ///

--- a/src/libstd/sys/windows/c.rs
+++ b/src/libstd/sys/windows/c.rs
@@ -100,6 +100,7 @@ pub const FILE_APPEND_DATA: DWORD = 0x00000004;
 pub const FILE_WRITE_EA: DWORD = 0x00000010;
 pub const FILE_READ_ATTRIBUTES: DWORD = 0x00000080;
 pub const FILE_WRITE_ATTRIBUTES: DWORD = 0x00000100;
+pub const DELETE: DWORD = 0x00010000;
 pub const READ_CONTROL: DWORD = 0x00020000;
 pub const SYNCHRONIZE: DWORD = 0x00100000;
 pub const GENERIC_READ: DWORD = 0x80000000;
@@ -113,6 +114,7 @@ pub const FILE_GENERIC_WRITE: DWORD = STANDARD_RIGHTS_WRITE | FILE_WRITE_DATA |
 
 pub const FILE_FLAG_OPEN_REPARSE_POINT: DWORD = 0x00200000;
 pub const FILE_FLAG_BACKUP_SEMANTICS: DWORD = 0x02000000;
+pub const FILE_FLAG_DELETE_ON_CLOSE: DWORD = 0x04000000;
 pub const SECURITY_SQOS_PRESENT: DWORD = 0x00100000;
 
 #[repr(C)]
@@ -372,6 +374,19 @@ pub struct FILE_BASIC_INFO {
     pub LastWriteTime: LARGE_INTEGER,
     pub ChangeTime: LARGE_INTEGER,
     pub FileAttributes: DWORD,
+}
+
+#[repr(C)]
+pub struct FILE_RENAME_INFO {
+    pub ReplaceIfExists: BOOL, // for true use -1, not TRUE
+    pub RootDirectory: HANDLE, // NULL, or obtained with NtOpenDirectoryObject
+    pub FileNameLength: DWORD,
+    pub FileName: [WCHAR; 0],
+}
+
+#[repr(C)]
+pub struct FILE_DISPOSITION_INFO {
+    pub DeleteFile: BOOL, // for true use -1, not TRUE
 }
 
 #[repr(C)]

--- a/src/libstd/sys/windows/c.rs
+++ b/src/libstd/sys/windows/c.rs
@@ -98,6 +98,7 @@ pub const TRUNCATE_EXISTING: DWORD = 5;
 pub const FILE_WRITE_DATA: DWORD = 0x00000002;
 pub const FILE_APPEND_DATA: DWORD = 0x00000004;
 pub const FILE_WRITE_EA: DWORD = 0x00000010;
+pub const FILE_READ_ATTRIBUTES: DWORD = 0x00000080;
 pub const FILE_WRITE_ATTRIBUTES: DWORD = 0x00000100;
 pub const READ_CONTROL: DWORD = 0x00020000;
 pub const SYNCHRONIZE: DWORD = 0x00100000;
@@ -362,6 +363,15 @@ pub enum FILE_INFO_BY_HANDLE_CLASS {
     FileIdExtdDirectoryInfo         = 19, // 0x13
     FileIdExtdDirectoryRestartInfo  = 20, // 0x14
     MaximumFileInfoByHandlesClass
+}
+
+#[repr(C)]
+pub struct FILE_BASIC_INFO {
+    pub CreationTime: LARGE_INTEGER,
+    pub LastAccessTime: LARGE_INTEGER,
+    pub LastWriteTime: LARGE_INTEGER,
+    pub ChangeTime: LARGE_INTEGER,
+    pub FileAttributes: DWORD,
 }
 
 #[repr(C)]
@@ -855,8 +865,6 @@ extern "system" {
     pub fn GetConsoleMode(hConsoleHandle: HANDLE,
                           lpMode: LPDWORD) -> BOOL;
     pub fn RemoveDirectoryW(lpPathName: LPCWSTR) -> BOOL;
-    pub fn SetFileAttributesW(lpFileName: LPCWSTR,
-                              dwFileAttributes: DWORD) -> BOOL;
     pub fn GetFileInformationByHandle(hFile: HANDLE,
                             lpFileInformation: LPBY_HANDLE_FILE_INFORMATION)
                             -> BOOL;

--- a/src/libstd/sys/windows/c.rs
+++ b/src/libstd/sys/windows/c.rs
@@ -82,6 +82,8 @@ pub const TRUE: BOOL = 1;
 pub const FALSE: BOOL = 0;
 
 pub const FILE_ATTRIBUTE_READONLY: DWORD = 0x1;
+#[cfg(test)]
+pub const FILE_ATTRIBUTE_SYSTEM: DWORD = 0x4;
 pub const FILE_ATTRIBUTE_DIRECTORY: DWORD = 0x10;
 pub const FILE_ATTRIBUTE_REPARSE_POINT: DWORD = 0x400;
 
@@ -382,11 +384,6 @@ pub struct FILE_RENAME_INFO {
     pub RootDirectory: HANDLE, // NULL, or obtained with NtOpenDirectoryObject
     pub FileNameLength: DWORD,
     pub FileName: [WCHAR; 0],
-}
-
-#[repr(C)]
-pub struct FILE_DISPOSITION_INFO {
-    pub DeleteFile: BOOL, // for true use -1, not TRUE
 }
 
 #[repr(C)]

--- a/src/libstd/sys/windows/fs.rs
+++ b/src/libstd/sys/windows/fs.rs
@@ -77,8 +77,8 @@ pub struct OpenOptions {
     security_attributes: usize, // FIXME: should be a reference
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct FilePermissions { attrs: c::DWORD }
+#[derive(Clone, PartialEq, Eq, Debug, Default)]
+pub struct FilePermissions { readonly: bool }
 
 pub struct DirBuilder;
 
@@ -333,6 +333,46 @@ impl File {
         Ok(newpos as u64)
     }
 
+    pub fn set_attributes(&self, attr: c::DWORD) -> io::Result<()> {
+        let mut info = c::FILE_BASIC_INFO {
+            CreationTime: 0, // do not change
+            LastAccessTime: 0, // do not change
+            LastWriteTime: 0, // do not change
+            ChangeTime: 0, // do not change
+            FileAttributes: attr,
+        };
+        let size = mem::size_of_val(&info);
+        try!(cvt(unsafe {
+            c::SetFileInformationByHandle(self.handle.raw(),
+                                          c::FileBasicInfo,
+                                          &mut info as *mut _ as *mut _,
+                                          size as c::DWORD)
+        }));
+        Ok(())
+    }
+
+    pub fn set_perm(&self, perm: FilePermissions) -> io::Result<()> {
+        let attr = try!(self.file_attr()).attributes;
+        if attr & c::FILE_ATTRIBUTE_DIRECTORY != 0 {
+            // this matches directories, dir symlinks, and junctions.
+            if perm.readonly {
+                Err(io::Error::new(io::ErrorKind::PermissionDenied,
+                                   "directories can not be read-only"))
+            } else {
+                Ok(()) // no reason to fail, as the result is what is expected.
+                     // (the directory will not be read-only)
+            }
+        } else {
+            if perm.readonly == (attr & c::FILE_ATTRIBUTE_READONLY != 0) {
+                Ok(())
+            } else if perm.readonly {
+                self.set_attributes(attr | c::FILE_ATTRIBUTE_READONLY)
+            } else {
+                self.set_attributes(attr & !c::FILE_ATTRIBUTE_READONLY)
+            }
+        }
+    }
+
     pub fn duplicate(&self) -> io::Result<File> {
         Ok(File {
             handle: try!(self.handle.duplicate(0, true, c::DUPLICATE_SAME_ACCESS)),
@@ -422,7 +462,12 @@ impl FileAttr {
     }
 
     pub fn perm(&self) -> FilePermissions {
-        FilePermissions { attrs: self.attributes }
+        FilePermissions {
+            // Only files can be read-only. If the flag is set on a directory this means the
+            // directory its view is customized by Windows (with a Desktop.ini file)
+            readonly: self.attributes & c::FILE_ATTRIBUTE_READONLY != 0 &&
+                      self.attributes & c::FILE_ATTRIBUTE_DIRECTORY == 0
+        }
     }
 
     pub fn attrs(&self) -> u32 { self.attributes as u32 }
@@ -465,17 +510,9 @@ fn to_u64(ft: &c::FILETIME) -> u64 {
 }
 
 impl FilePermissions {
-    pub fn readonly(&self) -> bool {
-        self.attrs & c::FILE_ATTRIBUTE_READONLY != 0
-    }
-
-    pub fn set_readonly(&mut self, readonly: bool) {
-        if readonly {
-            self.attrs |= c::FILE_ATTRIBUTE_READONLY;
-        } else {
-            self.attrs &= !c::FILE_ATTRIBUTE_READONLY;
-        }
-    }
+    pub fn new() -> FilePermissions { Default::default() }
+    pub fn readonly(&self) -> bool { self.readonly }
+    pub fn set_readonly(&mut self, readonly: bool) { self.readonly = readonly }
 }
 
 impl FileType {
@@ -640,12 +677,12 @@ pub fn lstat(path: &Path) -> io::Result<FileAttr> {
     file.file_attr()
 }
 
-pub fn set_perm(p: &Path, perm: FilePermissions) -> io::Result<()> {
-    let p = try!(to_u16s(p));
-    unsafe {
-        try!(cvt(c::SetFileAttributesW(p.as_ptr(), perm.attrs)));
-        Ok(())
-    }
+pub fn set_perm(path: &Path, perm: FilePermissions) -> io::Result<()> {
+    let mut opts = OpenOptions::new();
+    opts.access_mode(c::FILE_READ_ATTRIBUTES | c::FILE_WRITE_ATTRIBUTES);
+    opts.custom_flags(c::FILE_FLAG_BACKUP_SEMANTICS);
+    let file = try!(File::open(path, &opts));
+    file.set_perm(perm)
 }
 
 fn get_path(f: &File) -> io::Result<PathBuf> {

--- a/src/libstd/sys/windows/fs.rs
+++ b/src/libstd/sys/windows/fs.rs
@@ -11,7 +11,7 @@
 use io::prelude::*;
 use os::windows::prelude::*;
 
-use ffi::{OsString, OsStr};
+use ffi::OsString;
 use fmt;
 use io::{self, Error, SeekFrom};
 use mem;
@@ -350,15 +350,14 @@ impl File {
 
     pub fn rename(&self, new: &Path, replace: bool) -> io::Result<()> {
         // &self must be opened with DELETE permission
-
+        use iter;
         #[cfg(target_arch = "x86")]
         const STRUCT_SIZE: usize = 12;
         #[cfg(target_arch = "x86_64")]
         const STRUCT_SIZE: usize = 20;
 
         // FIXME: check for internal NULs in 'new'
-        let reserved = OsStr::new(&"\0\0\0\0\0\0\0\0\0\0"[..STRUCT_SIZE/2]);
-        let mut data: Vec<u16> = reserved.encode_wide()
+        let mut data: Vec<u16> = iter::repeat(0u16).take(STRUCT_SIZE/2)
                                  .chain(new.as_os_str().encode_wide())
                                  .collect();
         data.push(0);


### PR DESCRIPTION
This fixes the case where `remove_dir_all` is unable to remove large directories on Windows due to race conditions.
It is now also able to remove read-only files, and when the paths become longer that MAX_PATH.

Fixes #29497

This is based on #31892, I hope I didn't mess up git to much...
