### PR TITLE
Use HIR map instead of tcx in constant evaluator

### DIFF
--- a/src/test/compile-fail/issue-31910.rs
+++ b/src/test/compile-fail/issue-31910.rs
@@ -1,0 +1,21 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(associated_consts)]
+
+enum Enum<T: Trait> {
+    X = Trait::Number, //~ ERROR constant evaluation error
+}
+
+trait Trait {
+    const Number: i32 = 1;
+}
+
+fn main() {}


### PR DESCRIPTION
Fix #31910.
