### PR TITLE
Describe more platform-specific behaviors of `std::fs::rename`

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -968,7 +968,8 @@ pub fn symlink_metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
     fs_imp::lstat(path.as_ref()).map(Metadata)
 }
 
-/// Rename a file or directory to a new name.
+/// Rename a file or directory to a new name, replacing the original file if
+/// `to` already exists.
 ///
 /// This will not work if the new name is on a different mount point.
 ///
@@ -976,6 +977,12 @@ pub fn symlink_metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
 ///
 /// This function currently corresponds to the `rename` function on Unix
 /// and the `MoveFileEx` function with the `MOVEFILE_REPLACE_EXISTING` flag on Windows.
+///
+/// Because of this, the behavior when both `from` and `to` exist differs. On
+/// Unix, if `from` is a directory, `to` must also be an (empty) directory. If
+/// `from` is not a directory, `to` must also be not a directory. In contrast,
+/// on Windows, `from` can be anything, but `to` must *not* be a directory.
+///
 /// Note that, this [may change in the future][changes].
 /// [changes]: ../io/index.html#platform-specific-behavior
 ///


### PR DESCRIPTION
I did some tests myself regarding the situation when both `from` and `to` exist, and the results were:

On Linux:

| `from` | `to` | Result |
| --- | --- | --- |
| Directory | Directory | Ok |
| Directory | File | Error |
| File | Directory | Error |
| File | File | Ok |

On Windows:

| `from` | `to` | Result |
| --- | --- | --- |
| Directory | Directory | Error |
| Directory | File | Ok |
| File | Directory | Error |
| File | File | Ok |

This is a bit against the official MSDN documentation, which says "(`MOVEFILE_REPLACE_EXISTING`) cannot be used if `lpNewFileName` or `lpExistingFileName` names a directory." As evidenced above, `lpExistingFileName` _can_ be a directory.

I also mentioned the atomicity of the operation.

Fixes #31301.
