### PR TITLE
fmt: Skip calling write_str for empty strings

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -792,7 +792,9 @@ pub fn write(output: &mut Write, args: Arguments) -> Result {
         None => {
             // We can use default formatting parameters for all arguments.
             for (arg, piece) in args.args.iter().zip(pieces.by_ref()) {
-                try!(formatter.buf.write_str(*piece));
+                if !piece.is_empty() {
+                    try!(formatter.buf.write_str(*piece));
+                }
                 try!((arg.formatter)(arg.value, &mut formatter));
             }
         }
@@ -800,7 +802,9 @@ pub fn write(output: &mut Write, args: Arguments) -> Result {
             // Every spec has a corresponding argument that is preceded by
             // a string piece.
             for (arg, piece) in fmt.iter().zip(pieces.by_ref()) {
-                try!(formatter.buf.write_str(*piece));
+                if !piece.is_empty() {
+                    try!(formatter.buf.write_str(*piece));
+                }
                 try!(formatter.run(arg));
             }
         }
@@ -809,7 +813,9 @@ pub fn write(output: &mut Write, args: Arguments) -> Result {
     // There can be only one trailing string piece left.
     match pieces.next() {
         Some(piece) => {
-            try!(formatter.buf.write_str(*piece));
+            if !piece.is_empty() {
+                try!(formatter.buf.write_str(*piece));
+            }
         }
         None => {}
     }


### PR DESCRIPTION
fmt: Skip calling write_str for empty strings

`format_args!` uses one string literal per used `{}`, in many cases, the
separating string pieces are empty.

For example, `write!(w, "{}", x);` will attempt to write one empty
string before the `{}` format, and `write!(w, "{}{}{}", x, y, z);"` will
write one empty string piece between each format.

Simply skip writing if the string is empty. It is a cheap branch
compared to the virtual Write::write_str call that it makes possible to
skip.

It does not solve issue #10761 in any way, yet that's where I noticed
this. The testcase in the issue shows a performance difference between
`write!(w, "abc")` and `write!(w, "{}", "abc")`, and this change halves
the size of the difference.
