### PR TITLE
Add __rust_unsized_deallocate for C libraries to hook into.

### DIFF
--- a/src/doc/book/custom-allocators.md
+++ b/src/doc/book/custom-allocators.md
@@ -111,6 +111,11 @@ pub extern fn __rust_allocate(size: usize, _align: usize) -> *mut u8 {
 }
 
 #[no_mangle]
+pub extern fn __rust_unsized_deallocate(ptr: *mut u8, _align: usize) {
+    unsafe { libc::free(ptr as *mut libc::c_void) }
+}
+
+#[no_mangle]
 pub extern fn __rust_deallocate(ptr: *mut u8, _old_size: usize, _align: usize) {
     unsafe { libc::free(ptr as *mut libc::c_void) }
 }

--- a/src/liballoc_jemalloc/lib.rs
+++ b/src/liballoc_jemalloc/lib.rs
@@ -55,6 +55,9 @@ extern {
                link_name = "je_xallocx")]
     fn xallocx(ptr: *mut c_void, size: size_t, extra: size_t, flags: c_int) -> size_t;
     #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios"),
+               link_name = "je_dallocx")]
+    fn dallocx(ptr: *mut c_void, flags: c_int);
+    #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios"),
                link_name = "je_sdallocx")]
     fn sdallocx(ptr: *mut c_void, size: size_t, flags: c_int);
     #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios"),
@@ -112,6 +115,12 @@ pub extern "C" fn __rust_reallocate_inplace(ptr: *mut u8,
                                             -> usize {
     let flags = align_to_flags(align);
     unsafe { xallocx(ptr as *mut c_void, size as size_t, 0, flags) as usize }
+}
+
+#[no_mangle]
+pub extern "C" fn __rust_unsized_deallocate(ptr: *mut u8, align: usize) {
+    let flags = align_to_flags(align);
+    unsafe { dallocx(ptr as *mut c_void, flags) }
 }
 
 #[no_mangle]

--- a/src/liballoc_system/lib.rs
+++ b/src/liballoc_system/lib.rs
@@ -43,6 +43,11 @@ pub extern "C" fn __rust_allocate(size: usize, align: usize) -> *mut u8 {
 }
 
 #[no_mangle]
+pub extern "C" fn __rust_unsized_deallocate(ptr: *mut u8, align: usize) {
+    unsafe { imp::deallocate(ptr, 0, align) }
+}
+
+#[no_mangle]
 pub extern "C" fn __rust_deallocate(ptr: *mut u8, old_size: usize, align: usize) {
     unsafe { imp::deallocate(ptr, old_size, align) }
 }

--- a/src/test/auxiliary/allocator-dummy.rs
+++ b/src/test/auxiliary/allocator-dummy.rs
@@ -28,6 +28,14 @@ pub extern fn __rust_allocate(size: usize, align: usize) -> *mut u8 {
 }
 
 #[no_mangle]
+pub extern fn __rust_unsized_deallocate(ptr: *mut u8, align: usize) {
+    unsafe {
+        HITS += 1;
+        libc::free(ptr as *mut _)
+    }
+}
+
+#[no_mangle]
 pub extern fn __rust_deallocate(ptr: *mut u8, old_size: usize, align: usize) {
     unsafe {
         HITS += 1;


### PR DESCRIPTION
__rust_deallocate requires a size to be passed in, especially when jemalloc is used. Most C/C++ libraries don't use sized deallocation, so this allows non-rust code to hook into Rust's allocator without changing every free() call.

Haven't tested this beyond building yet, but I'm putting this PR out first to see if the idea sounds ok. I'm adding sized allocation support to Spidermonkey https://bugzilla.mozilla.org/show_bug.cgi?id=1250998 but not everything can easily be converted to sized deallocation. The __rust_\* functions are being used to hook into rust's allocator.
