### PR TITLE
Fix compiling libstd with emscripten target.

### DIFF
--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -23,7 +23,7 @@ fn main() {
 
     let target = env::var("TARGET").unwrap();
     let host = env::var("HOST").unwrap();
-    if !target.contains("apple") && !target.contains("msvc") {
+    if !target.contains("apple") && !target.contains("msvc") && !target.contains("emscripten"){
         build_libbacktrace(&host, &target);
     }
 


### PR DESCRIPTION
Was getting error:

```
running: "sh" "/home/flubba86/rust/src/libstd/../libbacktrace/configure" "--with-pic" "--disable-multilib" "--disable-shared" "--disable-host-shared" "--host=asmjs-unknown-emscripten" "--build=x86_64-unknown-linux-gnu"
...
Invalid configuration `asmjs-unknown-emscripten': system `emscripten' not recognized
```

This commit adds the emscripten target to the libbacktrace configure script so it is no longer unrecognized.
