### PR TITLE
Changed `std::pattern::Pattern` impl on `&'a &'a str` to `&'a &'b str`

### DIFF
--- a/src/libcollectionstest/str.rs
+++ b/src/libcollectionstest/str.rs
@@ -1508,6 +1508,19 @@ generate_iterator_test! {
     with str::rsplitn;
 }
 
+#[test]
+fn different_str_pattern_forwarding_lifetimes() {
+    use std::str::pattern::Pattern;
+
+    fn foo<'a, P>(p: P) where for<'b> &'b P: Pattern<'a> {
+        for _ in 0..3 {
+            "asdf".find(&p);
+        }
+    }
+
+    foo::<&str>("x");
+}
+
 mod bench {
     use test::{Bencher, black_box};
 

--- a/src/libcore/str/pattern.rs
+++ b/src/libcore/str/pattern.rs
@@ -492,7 +492,7 @@ impl<'a, F> Pattern<'a> for F where F: FnMut(char) -> bool {
 /////////////////////////////////////////////////////////////////////////////
 
 /// Delegates to the `&str` impl.
-impl<'a, 'b> Pattern<'a> for &'b &'b str {
+impl<'a, 'b, 'c> Pattern<'a> for &'c &'b str {
     pattern_methods!(StrSearcher<'a, 'b>, |&s| s, |s| s);
 }
 


### PR DESCRIPTION
This allows a bit more flexibility in how to use it, see the included test case.
