### PR TITLE
Use raw pointer casts for slice, str's .as_ptr()

### DIFF
--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -285,12 +285,12 @@ impl<T> SliceExt for [T] {
 
     #[inline]
     unsafe fn get_unchecked(&self, index: usize) -> &T {
-        &*(self.repr().data.offset(index as isize))
+        &*(self.as_ptr().offset(index as isize))
     }
 
     #[inline]
     fn as_ptr(&self) -> *const T {
-        self.repr().data
+        self as *const [T] as *const T
     }
 
     fn binary_search_by<F>(&self, mut f: F) -> Result<usize, usize> where
@@ -448,12 +448,12 @@ impl<T> SliceExt for [T] {
 
     #[inline]
     unsafe fn get_unchecked_mut(&mut self, index: usize) -> &mut T {
-        &mut *(self.repr().data as *mut T).offset(index as isize)
+        &mut *self.as_mut_ptr().offset(index as isize)
     }
 
     #[inline]
     fn as_mut_ptr(&mut self) -> *mut T {
-        self.repr().data as *mut T
+        self as *mut [T] as *mut T
     }
 
     #[inline]

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -1894,7 +1894,7 @@ impl StrExt for str {
 
     #[inline]
     fn as_ptr(&self) -> *const u8 {
-        self.repr().data
+        self as *const str as *const u8
     }
 
     #[inline]


### PR DESCRIPTION
Use raw pointer casts for slice, str's .as_ptr()

We can now use raw pointer casts `*const [T] as *const T` and
`*const str as *const u8` instead of .repr() for getting the
pointer out of a slice.
