### PR TITLE
Do not try to remove non-existing directories

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -73,7 +73,8 @@ class RustBuild:
 
         if self.rustc().startswith(self.bin_root()) and \
            (not os.path.exists(self.rustc()) or self.rustc_out_of_date()):
-            shutil.rmtree(self.bin_root())
+            if os.path.exists(self.bin_root()):
+                shutil.rmtree(self.bin_root())
             filename = "rust-std-nightly-" + self.build + ".tar.gz"
             url = "https://static.rust-lang.org/dist/" + self.snap_rustc_date()
             tarball = os.path.join(rustc_cache, filename)


### PR DESCRIPTION
Fixes the following error

```
Traceback (most recent call last):
File ".../src/bootstrap/bootstrap.py", line 303, in <module>
rb.download_rust_nightly()
File ".../src/bootstrap/bootstrap.py", line 76, in download_rust_nightly
shutil.rmtree(self.bin_root())
File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/shutil.py", line 239, in rmtree
onerror(os.listdir, path, sys.exc_info())
File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/shutil.py", line 237, in rmtree
names = os.listdir(path)
OSError: [Errno 2] No such file or directory: '.../build/x86_64-apple-darwin/stage0'
make: *** [all] Error 1
```

which occurs when a rustbuild is started on a clean repository.
