### PR TITLE
[beta] Ignore a rustdoc test that does not work on beta

### DIFF
--- a/src/test/rustdoc/issue-27362.rs
+++ b/src/test/rustdoc/issue-27362.rs
@@ -10,6 +10,7 @@
 
 // aux-build:issue-27362.rs
 // ignore-cross-compile
+// ignore-test This test fails on beta/stable
 
 extern crate issue_27362;
 pub use issue_27362 as quux;


### PR DESCRIPTION
Port of https://github.com/rust-lang/rust/pull/32017
