### PR TITLE
tests: add test for empty <>

### DIFF
--- a/src/test/run-pass/empty-type-parameter-list.rs
+++ b/src/test/run-pass/empty-type-parameter-list.rs
@@ -1,0 +1,33 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that empty type parameter list (<>) is synonymous with
+// no type parameters at all
+
+struct S<>;
+trait T<> {}
+enum E<> { V }
+impl<> T<> for S<> {}
+impl T for E {}
+fn foo<>() {}
+fn bar() {}
+
+fn main() {
+    let _ = S;
+    let _ = S::<>;
+    let _ = E::V;
+    let _ = E::<>::V;
+    foo();
+    foo::<>();
+
+    // Test that we can supply <> to non generic things
+    bar::<>();
+    let _: i32<>;
+}


### PR DESCRIPTION
Rust allows to specify an empty list of type and lifetime parameters, but there are no tests for it:

```
user@UNIT-326 [12:53:45] [~/projects/rust] [diamonds-and-rust]
-> % grep "<>" -R src/test
src/test/compile-fail/generic-type-params-name-repr.rs:    // And don't print <> at all when there's just defaults.
src/test/debuginfo/issue22656.rs:// when trying to handle a Vec<> or anything else that contains zero-sized
```

So let's add them! Besides it's such a wonderful opportunity to put a reference to Judas Priest band into the branch name ;)
