### PR TITLE
Consistent no_prelude attribute

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -1885,8 +1885,7 @@ type int8_t = i8;
 
 ### Module-only attributes
 
-- `no_implicit_prelude` - disable injecting `use std::prelude::*` in this
-  module.
+- `no_prelude` - disable injecting `use std::prelude::*` in this module.
 - `path` - specifies the file to load the module from. `#[path="foo.rs"] mod
   bar;` is equivalent to `mod bar { /* contents of foo.rs */ }`. The path is
   taken relative to the directory that the current module is in.

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -251,6 +251,9 @@ const KNOWN_FEATURES: &'static [(&'static str, &'static str, Option<u32>, Status
 
     // impl specialization (RFC 1210)
     ("specialization", "1.7.0", Some(31844), Active),
+
+    // Allows using #![no_prelude]
+    ("no_prelude", "1.9.0", Some(20561), Active),
 ];
 // (changing above list without updating src/doc/reference.md makes @cmr sad)
 
@@ -297,6 +300,9 @@ pub const KNOWN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeGat
     ("should_panic", Normal, Ungated),
     ("ignore", Normal, Ungated),
     ("no_implicit_prelude", Normal, Ungated),
+    ("no_prelude", Normal, Gated("no_prelude",
+                                 "the `#[no_prelude]` attribute is an \
+                                  experimental feature")),
     ("reexport_test_harness_main", Normal, Ungated),
     ("link_args", Normal, Ungated),
     ("macro_escape", Normal, Ungated),

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -858,6 +858,11 @@ impl<'a> PostExpansionVisitor<'a> {
 
 impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
     fn visit_attribute(&mut self, attr: &ast::Attribute) {
+        if &*attr.name() == "no_implicit_prelude" {
+            self.context.span_handler.span_warn(attr.span,
+                                                "the `#[no_implicit_prelude]` attribute is \
+                                                 deprecated, use `#[no_prelude]` instead");
+        }
         if !self.context.cm.span_allows_unstable(attr.span) {
             self.context.check_attribute(attr, false);
         }

--- a/src/test/compile-fail/associated-types-issue-20346.rs
+++ b/src/test/compile-fail/associated-types-issue-20346.rs
@@ -11,7 +11,8 @@
 // Test that we reliably check the value of the associated type.
 
 #![crate_type = "lib"]
-#![no_implicit_prelude]
+#![feature(no_prelude)]
+#![no_prelude]
 
 use std::option::Option::{self, None, Some};
 use std::vec::Vec;

--- a/src/test/compile-fail/import-shadow-1.rs
+++ b/src/test/compile-fail/import-shadow-1.rs
@@ -10,7 +10,8 @@
 
 // Test that import shadowing using globs causes errors
 
-#![no_implicit_prelude]
+#![feature(no_prelude)]
+#![no_prelude]
 
 use foo::*;
 use bar::*; //~ERROR a type named `Baz` has already been imported in this module

--- a/src/test/compile-fail/import-shadow-2.rs
+++ b/src/test/compile-fail/import-shadow-2.rs
@@ -10,7 +10,8 @@
 
 // Test that import shadowing using globs causes errors
 
-#![no_implicit_prelude]
+#![feature(no_prelude)]
+#![no_prelude]
 
 use foo::*;
 use foo::*; //~ERROR a type named `Baz` has already been imported in this module

--- a/src/test/compile-fail/import-shadow-3.rs
+++ b/src/test/compile-fail/import-shadow-3.rs
@@ -10,7 +10,8 @@
 
 // Test that import shadowing using globs causes errors
 
-#![no_implicit_prelude]
+#![feature(no_prelude)]
+#![no_prelude]
 
 use foo::Baz;
 use bar::*; //~ERROR a type named `Baz` has already been imported in this module

--- a/src/test/compile-fail/import-shadow-4.rs
+++ b/src/test/compile-fail/import-shadow-4.rs
@@ -10,7 +10,8 @@
 
 // Test that import shadowing using globs causes errors
 
-#![no_implicit_prelude]
+#![feature(no_prelude)]
+#![no_prelude]
 
 use foo::*;
 use bar::Baz; //~ERROR a type named `Baz` has already been imported in this module

--- a/src/test/compile-fail/import-shadow-5.rs
+++ b/src/test/compile-fail/import-shadow-5.rs
@@ -10,7 +10,8 @@
 
 // Test that import shadowing using globs causes errors
 
-#![no_implicit_prelude]
+#![feature(no_prelude)]
+#![no_prelude]
 
 use foo::Baz;
 use bar::Baz; //~ERROR a type named `Baz` has already been imported in this module

--- a/src/test/compile-fail/import-shadow-6.rs
+++ b/src/test/compile-fail/import-shadow-6.rs
@@ -10,7 +10,8 @@
 
 // Test that import shadowing using globs causes errors
 
-#![no_implicit_prelude]
+#![feature(no_prelude)]
+#![no_prelude]
 
 use qux::*;
 use foo::*; //~ERROR a type named `Baz` has already been imported in this module

--- a/src/test/compile-fail/import-shadow-7.rs
+++ b/src/test/compile-fail/import-shadow-7.rs
@@ -10,7 +10,8 @@
 
 // Test that import shadowing using globs causes errors
 
-#![no_implicit_prelude]
+#![feature(no_prelude)]
+#![no_prelude]
 
 use foo::*;
 use qux::*; //~ERROR a type named `Baz` has already been imported in this module

--- a/src/test/compile-fail/no-implicit-prelude-nested.rs
+++ b/src/test/compile-fail/no-implicit-prelude-nested.rs
@@ -15,6 +15,8 @@
 // fail with the same error message).
 
 #[no_implicit_prelude]
+//~^ WARNING: deprecated
+//~^^ WARNING: deprecated
 mod foo {
     mod baz {
         struct Test;
@@ -43,6 +45,8 @@ mod foo {
 
 fn qux() {
     #[no_implicit_prelude]
+    //~^ WARNING: deprecated
+    //~^^ WARNING: deprecated
     mod qux_inner {
         struct Test;
         impl Add for Test {} //~ ERROR: not in scope

--- a/src/test/compile-fail/no-implicit-prelude.rs
+++ b/src/test/compile-fail/no-implicit-prelude.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 #![no_implicit_prelude]
+//~^ WARN deprecated
+//~^^ WARN deprecated
 
 // Test that things from the prelude aren't in scope. Use many of them
 // so that renaming some things won't magically make this test fail

--- a/src/test/compile-fail/no-prelude-feature-gate.rs
+++ b/src/test/compile-fail/no-prelude-feature-gate.rs
@@ -1,0 +1,12 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![no_prelude] //~ ERROR: experimental feature
+//~^ HELP: feature(no_prelude)

--- a/src/test/compile-fail/no-prelude-nested.rs
+++ b/src/test/compile-fail/no-prelude-nested.rs
@@ -1,0 +1,67 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(no_prelude)]
+
+// Test that things from the prelude aren't in scope. Use many of them
+// so that renaming some things won't magically make this test fail
+// for the wrong reason (e.g. if `Add` changes to `Addition`, and
+// `no_prelude` stops working, then the `impl Add` will still
+// fail with the same error message).
+//
+// Unlike `no_implicit_prelude`, `no_prelude` doesn't cascade into nested
+// modules, this makes the impl in foo::baz work.
+
+#[no_prelude]
+mod foo {
+    mod baz {
+        struct Test;
+        impl From<Test> for Test { fn from(t: Test) { Test }}
+        impl Clone for Test { fn clone(&self) { Test } }
+        impl Eq for Test {}
+
+        fn foo() {
+            drop(2)
+        }
+    }
+
+    struct Test;
+    impl From for Test {} //~ ERROR: not in scope
+    impl Clone for Test {} //~ ERROR: not in scope
+    impl Iterator for Test {} //~ ERROR: not in scope
+    impl ToString for Test {} //~ ERROR: not in scope
+    impl Eq for Test {} //~ ERROR: not in scope
+
+    fn foo() {
+        drop(2) //~ ERROR: unresolved name
+    }
+}
+
+fn qux() {
+    #[no_prelude]
+    mod qux_inner {
+        struct Test;
+        impl From for Test {} //~ ERROR: not in scope
+        impl Clone for Test {} //~ ERROR: not in scope
+        impl Iterator for Test {} //~ ERROR: not in scope
+        impl ToString for Test {} //~ ERROR: not in scope
+        impl Eq for Test {} //~ ERROR: not in scope
+
+        fn foo() {
+            drop(2) //~ ERROR: unresolved name
+        }
+    }
+}
+
+
+fn main() {
+    // these should work fine
+    drop(2)
+}

--- a/src/test/compile-fail/no-prelude.rs
+++ b/src/test/compile-fail/no-prelude.rs
@@ -1,0 +1,29 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(no_prelude)]
+#![no_prelude]
+
+// Test that things from the prelude aren't in scope. Use many of them
+// so that renaming some things won't magically make this test fail
+// for the wrong reason (e.g. if `Add` changes to `Addition`, and
+// `no_prelude` stops working, then the `impl Add` will still
+// fail with the same error message).
+
+struct Test;
+impl Add for Test {} //~ ERROR: not in scope
+impl Clone for Test {} //~ ERROR: not in scope
+impl Iterator for Test {} //~ ERROR: not in scope
+impl ToString for Test {} //~ ERROR: not in scope
+impl Writer for Test {} //~ ERROR: not in scope
+
+fn main() {
+    drop(2) //~ ERROR: unresolved name
+}

--- a/src/test/compile-fail/tag-that-dare-not-speak-its-name.rs
+++ b/src/test/compile-fail/tag-that-dare-not-speak-its-name.rs
@@ -10,7 +10,8 @@
 
 // Issue #876
 
-#![no_implicit_prelude]
+#![feature(no_prelude)]
+#![no_prelude]
 use std::vec::Vec;
 
 fn last<T>(v: Vec<&T> ) -> std::option::Option<T> {

--- a/src/test/run-pass/associated-types-impl-redirect.rs
+++ b/src/test/run-pass/associated-types-impl-redirect.rs
@@ -14,8 +14,8 @@
 // for `ByRef`. The right answer was to consider the result ambiguous
 // until more type information was available.
 
-#![feature(lang_items, unboxed_closures)]
-#![no_implicit_prelude]
+#![feature(no_prelude, lang_items, unboxed_closures)]
+#![no_prelude]
 
 use std::marker::Sized;
 use std::option::Option::{None, Some, self};

--- a/src/test/run-pass/associated-types-where-clause-impl-ambiguity.rs
+++ b/src/test/run-pass/associated-types-where-clause-impl-ambiguity.rs
@@ -14,8 +14,8 @@
 // for `ByRef`. The right answer was to consider the result ambiguous
 // until more type information was available.
 
-#![feature(lang_items, unboxed_closures)]
-#![no_implicit_prelude]
+#![feature(no_prelude, lang_items, unboxed_closures)]
+#![no_prelude]
 
 use std::marker::Sized;
 use std::option::Option::{None, Some, self};

--- a/src/test/run-pass/issue-21363.rs
+++ b/src/test/run-pass/issue-21363.rs
@@ -10,7 +10,8 @@
 
 // pretty-expanded FIXME #23616
 
-#![no_implicit_prelude]
+#![feature(no_prelude)]
+#![no_prelude]
 
 trait Iterator {
     type Item;


### PR DESCRIPTION
Implementation of rust-lang/rfcs#501 tracked in #20561.

Adds the `no_prelude` attribute that stops automatic injecting of the standard prelude in a single module behind a feature gate.
Deprecates the existing `no_implicit_prelude`.
