### PR TITLE
[rustbuild] fix cross compilation of std for mips(el)-linux-musl

### DIFF
--- a/src/bootstrap/build/sanity.rs
+++ b/src/bootstrap/build/sanity.rs
@@ -79,7 +79,7 @@ pub fn check(build: &mut Build) {
         }
 
         // Make sure musl-root is valid if specified
-        if target.contains("musl") {
+        if target.contains("musl") && target.contains("x86_64") {
             match build.config.musl_root {
                 Some(ref root) => {
                     if fs::metadata(root.join("lib/libc.a")).is_err() {

--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -28,7 +28,7 @@ fn main() {
     }
 
     if target.contains("unknown-linux") {
-        if target.contains("musl") {
+        if target.contains("musl") && target.contains("x86_64") {
             println!("cargo:rustc-link-lib=static=unwind");
         } else {
             println!("cargo:rustc-link-lib=dl");


### PR DESCRIPTION
These targets don't link statically to libunwind or libc

---

r? @alexcrichton 
