### PR TITLE
truncate i8-s to i1-s when loading constants

### DIFF
--- a/src/test/run-pass/issue-30891.rs
+++ b/src/test/run-pass/issue-30891.rs
@@ -1,0 +1,19 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+const ERROR_CONST: bool = true;
+
+fn get() -> bool {
+    false || ERROR_CONST
+}
+
+pub fn main() {
+    assert_eq!(get(), true);
+}


### PR DESCRIPTION
Fixes #30891

r? @eddyb 
