### PR TITLE
rustc: Add an i586-pc-windows-msvc target

### DIFF
--- a/mk/cfg/i586-pc-windows-msvc.mk
+++ b/mk/cfg/i586-pc-windows-msvc.mk
@@ -1,0 +1,28 @@
+# i586-pc-windows-msvc configuration
+CC_i586-pc-windows-msvc="$(CFG_MSVC_CL_i386)" -nologo
+LINK_i586-pc-windows-msvc="$(CFG_MSVC_LINK_i386)" -nologo
+CXX_i586-pc-windows-msvc="$(CFG_MSVC_CL_i386)" -nologo
+CPP_i586-pc-windows-msvc="$(CFG_MSVC_CL_i386)" -nologo
+AR_i586-pc-windows-msvc="$(CFG_MSVC_LIB_i386)" -nologo
+CFG_LIB_NAME_i586-pc-windows-msvc=$(1).dll
+CFG_STATIC_LIB_NAME_i586-pc-windows-msvc=$(1).lib
+CFG_LIB_GLOB_i586-pc-windows-msvc=$(1)-*.{dll,lib}
+CFG_LIB_DSYM_GLOB_i586-pc-windows-msvc=$(1)-*.dylib.dSYM
+CFG_JEMALLOC_CFLAGS_i586-pc-windows-msvc :=
+CFG_GCCISH_CFLAGS_i586-pc-windows-msvc := -MD -arch:IA32
+CFG_GCCISH_CXXFLAGS_i586-pc-windows-msvc := -MD -arch:IA32
+CFG_GCCISH_LINK_FLAGS_i586-pc-windows-msvc :=
+CFG_GCCISH_DEF_FLAG_i586-pc-windows-msvc :=
+CFG_LLC_FLAGS_i586-pc-windows-msvc :=
+CFG_INSTALL_NAME_i586-pc-windows-msvc =
+CFG_EXE_SUFFIX_i586-pc-windows-msvc := .exe
+CFG_WINDOWSY_i586-pc-windows-msvc := 1
+CFG_UNIXY_i586-pc-windows-msvc :=
+CFG_LDPATH_i586-pc-windows-msvc :=
+CFG_RUN_i586-pc-windows-msvc=$(2)
+CFG_RUN_TARG_i586-pc-windows-msvc=$(call CFG_RUN_i586-pc-windows-msvc,,$(2))
+CFG_GNU_TRIPLE_i586-pc-windows-msvc := i586-pc-win32
+
+# Currently the build system is not configured to build jemalloc
+# with MSVC, so we omit this optional dependency.
+CFG_DISABLE_JEMALLOC_i586-pc-windows-msvc := 1

--- a/src/librustc_back/target/i586_pc_windows_msvc.rs
+++ b/src/librustc_back/target/i586_pc_windows_msvc.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -11,8 +11,8 @@
 use target::Target;
 
 pub fn target() -> Target {
-    let mut base = super::i686_unknown_linux_gnu::target();
+    let mut base = super::i686_pc_windows_msvc::target();
     base.options.cpu = "pentium".to_string();
-    base.llvm_target = "i586-unknown-linux-gnu".to_string();
+    base.llvm_target = "i586-pc-windows-msvc".to_string();
     return base
 }

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -136,6 +136,7 @@ supported_targets! {
 
     ("x86_64-pc-windows-msvc", x86_64_pc_windows_msvc),
     ("i686-pc-windows-msvc", i686_pc_windows_msvc),
+    ("i586-pc-windows-msvc", i586_pc_windows_msvc),
 
     ("le32-unknown-nacl", le32_unknown_nacl),
     ("asmjs-unknown-emscripten", asmjs_unknown_emscripten)


### PR DESCRIPTION
Similarly to #31629 where an i586-unknown-linux-gnu target was added, there is
sometimes a desire to compile for x86 Windows as well where SSE2 is disabled.
This commit mirrors the i586-unknown-linux-gnu target and simply adds a variant
for Windows as well.

This is motivated by a recent [Gecko bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1253202) where crashes were seen on 32-bit
Windows due to users having CPUs that don't support SSE2 instructions. It was
requested that we could have non-SSE2 builds of the standard library available
so they could continue to use vanilla releases and nightlies.
