### PR TITLE
Add note about avoiding spaces in MinGW install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ build.
 
 Download [MinGW from
 here](http://mingw-w64.org/doku.php/download/mingw-builds), and choose the
-`threads=win32,exceptions=dwarf/seh` flavor when installing. After installing,
+`threads=win32,exceptions=dwarf/seh` flavor when installing. Also, make sure to install to a path without spaces in it. After installing,
 add its `bin` directory to your `PATH`. This is due to [#28260](https://github.com/rust-lang/rust/issues/28260), in the future,
 installing from pacman should be just fine.
 


### PR DESCRIPTION
Using spaces in the install path causes the issue in #31293.
