### PR TITLE
Preserve times for fs::copy on Unix.

### DIFF
--- a/src/test/run-pass/paths-containing-nul.rs
+++ b/src/test/run-pass/paths-containing-nul.rs
@@ -23,6 +23,8 @@ fn assert_invalid_input<T>(on: &str, result: io::Result<T>) {
 }
 
 fn main() {
+    fs::File::create("a");
+
     assert_invalid_input("File::open", fs::File::open("\0"));
     assert_invalid_input("File::create", fs::File::create("\0"));
     assert_invalid_input("remove_file", fs::remove_file("\0"));
@@ -45,4 +47,6 @@ fn main() {
     assert_invalid_input("read_dir", fs::read_dir("\0"));
     assert_invalid_input("set_permissions",
                          fs::set_permissions("\0", fs::metadata(".").unwrap().permissions()));
+
+    fs::remove_file("a");
 }


### PR DESCRIPTION
This adds `set_times` to `File` so `fs::copy` can restore the access, modified and created times.
Also permissions are now set during file creation, as a partly fix for #26933.

I did not test the code for setting the creation time, as I do not have BSD.
It probably works as long as the creation time is earlier than what it is currently set to.
If we want to make a method like this public, we probably should add a way to keep some times the same, or set them to the current time.

There are still some things left for #26933, like copying attributes, extended attributes and ACLs.
