### PR TITLE
Derive Eq for RandomState

### DIFF
--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1732,6 +1732,8 @@ mod test_map {
 
     use super::HashMap;
     use super::Entry::{Occupied, Vacant};
+    use super::RandomState;
+    use hash::{Hash, BuildHasher, Hasher};
     use cell::RefCell;
     use rand::{thread_rng, Rng};
 
@@ -2462,6 +2464,12 @@ mod test_map {
         let b = a.clone();
         assert!(a == b);
 
-        assert!(1u32.hash(a.build_hasher()) == 1u32.hash(b.build_hasher()))
+        let mut a_hasher = a.build_hasher();
+        let mut b_hasher = b.build_hasher();
+
+        1u32.hash(&mut a_hasher);
+        1u32.hash(&mut b_hasher);
+
+        assert_eq!(a_hasher.finish(), b_hasher.finish())
     }
 }

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1662,7 +1662,7 @@ impl<'a, K, V, S> Extend<(&'a K, &'a V)> for HashMap<K, V, S>
 /// A particular instance `RandomState` will create the same instances of
 /// `Hasher`, but the hashers created by two different `RandomState`
 /// instances are unlikely to produce the same result for the same values.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 #[stable(feature = "hashmap_build_hasher", since = "1.7.0")]
 pub struct RandomState {
     k0: u64,
@@ -2453,5 +2453,15 @@ mod test_map {
         // Insert at capacity should cause allocation.
         a.insert(item, 0);
         assert!(a.capacity() > a.len());
+    }
+
+
+    #[test]
+    fn test_randomstate_eq() {
+        let a = RandomState::new();
+        let b = a.clone();
+        assert!(a == b);
+
+        assert!(1u32.hash(a.build_hasher()) == 1u32.hash(b.build_hasher()))
     }
 }


### PR DESCRIPTION
It should be possible to see if two hash functions are equal. In my case I need this in order to quickly union two Bloom filters (a simple bitwise OR if the hash functions are equal).
