### PR TITLE
rustbuild: fix cross compilation of libstd to i686-unknown-linux-musl

### DIFF
--- a/src/bootstrap/build/compile.rs
+++ b/src/bootstrap/build/compile.rs
@@ -83,6 +83,19 @@ pub fn std_link(build: &Build,
                          libdir.join(staticlib("compiler-rt", target))));
     }
     add_to_sysroot(&out_dir, &libdir);
+
+    if target.contains("musl") && (target.contains("x86_64") || target.contains("i686")) {
+        copy_third_party_objects(build, target, &libdir);
+    }
+}
+
+/// Copies the crt(1,i,n).o startup objects
+///
+/// Only required for musl targets that statically link to libc
+fn copy_third_party_objects(build: &Build, target: &str, into: &Path) {
+    for &obj in &["crt1.o", "crti.o", "crtn.o"] {
+        t!(fs::copy(compiler_file(build.cc(target), obj), into.join(obj)));
+    }
 }
 
 /// Build and prepare startup objects like rsbegin.o and rsend.o

--- a/src/bootstrap/build/sanity.rs
+++ b/src/bootstrap/build/sanity.rs
@@ -79,7 +79,7 @@ pub fn check(build: &mut Build) {
         }
 
         // Make sure musl-root is valid if specified
-        if target.contains("musl") && target.contains("x86_64") {
+        if target.contains("musl") && (target.contains("x86_64") || target.contains("i686")) {
             match build.config.musl_root {
                 Some(ref root) => {
                     if fs::metadata(root.join("lib/libc.a")).is_err() {

--- a/src/liballoc_jemalloc/build.rs
+++ b/src/liballoc_jemalloc/build.rs
@@ -111,7 +111,7 @@ fn main() {
     println!("cargo:rustc-link-search=native={}/lib", build_dir.display());
     if target.contains("android") {
         println!("cargo:rustc-link-lib=gcc");
-    } else if !target.contains("windows") {
+    } else if !target.contains("windows") && !target.contains("musl") {
         println!("cargo:rustc-link-lib=pthread");
     }
 }

--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -28,7 +28,7 @@ fn main() {
     }
 
     if target.contains("unknown-linux") {
-        if target.contains("musl") && target.contains("x86_64") {
+        if target.contains("musl") && (target.contains("x86_64") || target.contains("i686")) {
             println!("cargo:rustc-link-lib=static=unwind");
         } else {
             println!("cargo:rustc-link-lib=dl");

--- a/src/libstd/sys/common/libunwind.rs
+++ b/src/libstd/sys/common/libunwind.rs
@@ -106,9 +106,15 @@ pub type _Unwind_Exception_Cleanup_Fn =
 #[cfg_attr(any(all(target_os = "linux", not(target_env = "musl")),
                target_os = "freebsd",
                target_os = "solaris",
-               all(target_os = "linux", target_env = "musl", not(target_arch = "x86_64"))),
+               all(target_os = "linux",
+                   target_env = "musl",
+                   not(target_arch = "x86"),
+                   not(target_arch = "x86_64"))),
            link(name = "gcc_s"))]
-#[cfg_attr(all(target_os = "linux", target_env = "musl", target_arch = "x86_64", not(test)),
+#[cfg_attr(all(target_os = "linux",
+               target_env = "musl",
+               any(target_arch = "x86", target_arch = "x86_64"),
+               not(test)),
            link(name = "unwind", kind = "static"))]
 #[cfg_attr(any(target_os = "android", target_os = "openbsd"),
            link(name = "gcc"))]


### PR DESCRIPTION
- make sure we copy the third party objects (crt*.o) to the target stage directory.
- apply the x86_64-musl logic also to the i686-musl target.

---

r? @alexcrichton 
