### PR TITLE
[RFC] Implement `..` in tuple (struct) patterns

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -2398,6 +2398,8 @@ The currently implemented features of the reference compiler are:
 * - `abi_vectorcall` - Allows the usage of the vectorcall calling convention
                              (e.g. `extern "vectorcall" func fn_();`)
 
+* - `dotdot_in_tuple_patterns` - Allows `..` in tuple (struct) patterns.
+
 If a feature is promoted to a language feature, then all existing programs will
 start to receive compilation warnings about `#![feature]` directives which enabled
 the new feature (because the directive is no longer necessary). However, if a

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -39,6 +39,7 @@
 #![feature(slice_patterns)]
 #![feature(staged_api)]
 #![feature(str_char)]
+#![feature(type_ascription)]
 #![cfg_attr(test, feature(test))]
 
 extern crate arena;

--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -100,7 +100,6 @@ impl<'a, 'tcx> CFGBuilder<'a, 'tcx> {
     fn pat(&mut self, pat: &hir::Pat, pred: CFGIndex) -> CFGIndex {
         match pat.node {
             PatKind::Ident(_, _, None) |
-            PatKind::TupleStruct(_, None) |
             PatKind::Path(..) |
             PatKind::QPath(..) |
             PatKind::Lit(..) |
@@ -116,8 +115,8 @@ impl<'a, 'tcx> CFGBuilder<'a, 'tcx> {
                 self.add_ast_node(pat.id, &[subpat_exit])
             }
 
-            PatKind::TupleStruct(_, Some(ref subpats)) |
-            PatKind::Tup(ref subpats) => {
+            PatKind::TupleStruct(_, ref subpats, _) |
+            PatKind::Tuple(ref subpats, _) => {
                 let pats_exit = self.pats_all(subpats.iter(), pred);
                 self.add_ast_node(pat.id, &[pats_exit])
             }

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -325,7 +325,9 @@ impl ConstVal {
 pub fn const_expr_to_pat(tcx: &TyCtxt, expr: &Expr, span: Span) -> P<hir::Pat> {
     let pat = match expr.node {
         hir::ExprTup(ref exprs) =>
-            PatKind::Tup(exprs.iter().map(|expr| const_expr_to_pat(tcx, &expr, span)).collect()),
+            PatKind::Tuple(exprs.iter()
+                              .map(|expr| const_expr_to_pat(tcx, &expr, span))
+                              .collect(), None),
 
         hir::ExprCall(ref callee, ref args) => {
             let def = *tcx.def_map.borrow().get(&callee.id).unwrap();
@@ -343,7 +345,7 @@ pub fn const_expr_to_pat(tcx: &TyCtxt, expr: &Expr, span: Span) -> P<hir::Pat> {
                 _ => unreachable!()
             };
             let pats = args.iter().map(|expr| const_expr_to_pat(tcx, &expr, span)).collect();
-            PatKind::TupleStruct(path, Some(pats))
+            PatKind::TupleStruct(path, pats, None)
         }
 
         hir::ExprStruct(ref path, ref fields, None) => {

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -1135,7 +1135,7 @@ impl<'d,'t,'a,'tcx> ExprUseVisitor<'d,'t,'a,'tcx> {
                     // will visit the substructure recursively.
                 }
 
-                PatKind::Wild | PatKind::Tup(..) | PatKind::Box(..) |
+                PatKind::Wild | PatKind::Tuple(..) | PatKind::Box(..) |
                 PatKind::Ref(..) | PatKind::Lit(..) | PatKind::Range(..) |
                 PatKind::Vec(..) => {
                     // Similarly, each of these cases does not

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -970,8 +970,8 @@ fn resolve_local(visitor: &mut RegionResolutionVisitor, local: &hir::Local) {
                 pats3.iter().any(|p| is_binding_pat(&p))
             }
 
-            PatKind::TupleStruct(_, Some(ref subpats)) |
-            PatKind::Tup(ref subpats) => {
+            PatKind::TupleStruct(_, ref subpats, _) |
+            PatKind::Tuple(ref subpats, _) => {
                 subpats.iter().any(|p| is_binding_pat(&p))
             }
 

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -598,10 +598,13 @@ pub fn check_pat(tcx: &TyCtxt, pat: &hir::Pat,
     };
     match pat.node {
         // Foo(a, b, c)
-        // A Variant(..) pattern `PatKind::TupleStruct(_, None)` doesn't have to be recursed into.
-        PatKind::TupleStruct(_, Some(ref pat_fields)) => {
-            for (field, struct_field) in pat_fields.iter().zip(&v.fields) {
-                maybe_do_stability_check(tcx, struct_field.did, field.span, cb)
+        PatKind::TupleStruct(_, ref pat_fields, ddpos) => {
+            let adjust = |i| {
+                let gap = v.fields.len() - pat_fields.len();
+                if ddpos.is_none() || ddpos.unwrap() > i { i } else { i + gap }
+            };
+            for (i, field) in pat_fields.iter().enumerate() {
+                maybe_do_stability_check(tcx, v.fields[adjust(i)].did, field.span, cb)
             }
         }
         // Foo { a, b, c }

--- a/src/librustc_front/fold.rs
+++ b/src/librustc_front/fold.rs
@@ -970,9 +970,9 @@ pub fn noop_fold_pat<T: Folder>(p: P<Pat>, folder: &mut T) -> P<Pat> {
                              sub.map(|x| folder.fold_pat(x)))
                 }
                 PatKind::Lit(e) => PatKind::Lit(folder.fold_expr(e)),
-                PatKind::TupleStruct(pth, pats) => {
+                PatKind::TupleStruct(pth, pats, ddpos) => {
                     PatKind::TupleStruct(folder.fold_path(pth),
-                            pats.map(|pats| pats.move_map(|x| folder.fold_pat(x))))
+                            pats.move_map(|x| folder.fold_pat(x)), ddpos)
                 }
                 PatKind::Path(pth) => {
                     PatKind::Path(folder.fold_path(pth))
@@ -995,7 +995,9 @@ pub fn noop_fold_pat<T: Folder>(p: P<Pat>, folder: &mut T) -> P<Pat> {
                     });
                     PatKind::Struct(pth, fs, etc)
                 }
-                PatKind::Tup(elts) => PatKind::Tup(elts.move_map(|x| folder.fold_pat(x))),
+                PatKind::Tuple(elts, ddpos) => {
+                    PatKind::Tuple(elts.move_map(|x| folder.fold_pat(x)), ddpos)
+                }
                 PatKind::Box(inner) => PatKind::Box(folder.fold_pat(inner)),
                 PatKind::Ref(inner, mutbl) => PatKind::Ref(folder.fold_pat(inner), mutbl),
                 PatKind::Range(e1, e2) => {

--- a/src/librustc_front/hir.rs
+++ b/src/librustc_front/hir.rs
@@ -522,9 +522,10 @@ pub enum PatKind {
     /// The `bool` is `true` in the presence of a `..`.
     Struct(Path, HirVec<Spanned<FieldPat>>, bool),
 
-    /// A tuple struct/variant pattern `Variant(x, y, z)`.
-    /// "None" means a `Variant(..)` pattern where we don't bind the fields to names.
-    TupleStruct(Path, Option<HirVec<P<Pat>>>),
+    /// A tuple struct/variant pattern `Variant(x, y, .., z)`.
+    /// If the `..` pattern fragment presents, then `Option<usize>` denotes its position.
+    /// 0 <= position <= subpats.len()
+    TupleStruct(Path, HirVec<P<Pat>>, Option<usize>),
 
     /// A path pattern.
     /// Such pattern can be resolved to a unit struct/variant or a constant.
@@ -536,8 +537,10 @@ pub enum PatKind {
     /// PatKind::Path, and the resolver will have to sort that out.
     QPath(QSelf, Path),
 
-    /// A tuple pattern `(a, b)`
-    Tup(HirVec<P<Pat>>),
+    /// A tuple pattern `(a, b)`.
+    /// If the `..` pattern fragment presents, then `Option<usize>` denotes its position.
+    /// 0 <= position <= subpats.len()
+    Tuple(HirVec<P<Pat>>, Option<usize>),
     /// A `box` pattern
     Box(P<Pat>),
     /// A reference pattern, e.g. `&mut (a, b)`

--- a/src/librustc_front/intravisit.rs
+++ b/src/librustc_front/intravisit.rs
@@ -468,11 +468,9 @@ pub fn walk_assoc_type_binding<'v, V: Visitor<'v>>(visitor: &mut V,
 
 pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat) {
     match pattern.node {
-        PatKind::TupleStruct(ref path, ref opt_children) => {
+        PatKind::TupleStruct(ref path, ref children, _) => {
             visitor.visit_path(path, pattern.id);
-            if let Some(ref children) = *opt_children {
-                walk_list!(visitor, visit_pat, children);
-            }
+            walk_list!(visitor, visit_pat, children);
         }
         PatKind::Path(ref path) => {
             visitor.visit_path(path, pattern.id);
@@ -488,7 +486,7 @@ pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat) {
                 visitor.visit_pat(&field.node.pat)
             }
         }
-        PatKind::Tup(ref tuple_elements) => {
+        PatKind::Tuple(ref tuple_elements, _) => {
             walk_list!(visitor, visit_pat, tuple_elements);
         }
         PatKind::Box(ref subpattern) |

--- a/src/librustc_front/lowering.rs
+++ b/src/librustc_front/lowering.rs
@@ -925,10 +925,9 @@ pub fn lower_pat(lctx: &LoweringContext, p: &Pat) -> P<hir::Pat> {
                               sub.as_ref().map(|x| lower_pat(lctx, x)))
             }
             PatKind::Lit(ref e) => hir::PatKind::Lit(lower_expr(lctx, e)),
-            PatKind::TupleStruct(ref pth, ref pats) => {
+            PatKind::TupleStruct(ref pth, ref pats, ddpos) => {
                 hir::PatKind::TupleStruct(lower_path(lctx, pth),
-                             pats.as_ref()
-                                 .map(|pats| pats.iter().map(|x| lower_pat(lctx, x)).collect()))
+                        pats.iter().map(|x| lower_pat(lctx, x)).collect(), ddpos)
             }
             PatKind::Path(ref pth) => {
                 hir::PatKind::Path(lower_path(lctx, pth))
@@ -956,8 +955,8 @@ pub fn lower_pat(lctx: &LoweringContext, p: &Pat) -> P<hir::Pat> {
                                .collect();
                 hir::PatKind::Struct(pth, fs, etc)
             }
-            PatKind::Tup(ref elts) => {
-                hir::PatKind::Tup(elts.iter().map(|x| lower_pat(lctx, x)).collect())
+            PatKind::Tuple(ref elts, ddpos) => {
+                hir::PatKind::Tuple(elts.iter().map(|x| lower_pat(lctx, x)).collect(), ddpos)
             }
             PatKind::Box(ref inner) => hir::PatKind::Box(lower_pat(lctx, inner)),
             PatKind::Ref(ref inner, mutbl) => {
@@ -1839,7 +1838,7 @@ fn pat_enum(lctx: &LoweringContext,
     let pt = if subpats.is_empty() {
         hir::PatKind::Path(path)
     } else {
-        hir::PatKind::TupleStruct(path, Some(subpats))
+        hir::PatKind::TupleStruct(path, subpats, None)
     };
     pat(lctx, span, pt)
 }

--- a/src/librustc_front/print/pprust.rs
+++ b/src/librustc_front/print/pprust.rs
@@ -1729,16 +1729,23 @@ impl<'a> State<'a> {
                     None => (),
                 }
             }
-            PatKind::TupleStruct(ref path, ref args_) => {
+            PatKind::TupleStruct(ref path, ref elts, ddpos) => {
                 try!(self.print_path(path, true, 0));
-                match *args_ {
-                    None => try!(word(&mut self.s, "(..)")),
-                    Some(ref args) => {
-                        try!(self.popen());
-                        try!(self.commasep(Inconsistent, &args[..], |s, p| s.print_pat(&p)));
-                        try!(self.pclose());
+                try!(self.popen());
+                if let Some(ddpos) = ddpos {
+                    try!(self.commasep(Inconsistent, &elts[..ddpos], |s, p| s.print_pat(&p)));
+                    if ddpos != 0 {
+                        try!(self.word_space(","));
                     }
+                    try!(word(&mut self.s, ".."));
+                    if ddpos != elts.len() {
+                        try!(word(&mut self.s, ","));
+                        try!(self.commasep(Inconsistent, &elts[ddpos..], |s, p| s.print_pat(&p)));
+                    }
+                } else {
+                    try!(self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(&p)));
                 }
+                try!(self.pclose());
             }
             PatKind::Path(ref path) => {
                 try!(self.print_path(path, true, 0));
@@ -1771,11 +1778,23 @@ impl<'a> State<'a> {
                 try!(space(&mut self.s));
                 try!(word(&mut self.s, "}"));
             }
-            PatKind::Tup(ref elts) => {
+            PatKind::Tuple(ref elts, ddpos) => {
                 try!(self.popen());
-                try!(self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(&p)));
-                if elts.len() == 1 {
-                    try!(word(&mut self.s, ","));
+                if let Some(ddpos) = ddpos {
+                    try!(self.commasep(Inconsistent, &elts[..ddpos], |s, p| s.print_pat(&p)));
+                    if ddpos != 0 {
+                        try!(self.word_space(","));
+                    }
+                    try!(word(&mut self.s, ".."));
+                    if ddpos != elts.len() {
+                        try!(word(&mut self.s, ","));
+                        try!(self.commasep(Inconsistent, &elts[ddpos..], |s, p| s.print_pat(&p)));
+                    }
+                } else {
+                    try!(self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(&p)));
+                    if elts.len() == 1 {
+                        try!(word(&mut self.s, ","));
+                    }
                 }
                 try!(self.pclose());
             }

--- a/src/librustc_front/util.rs
+++ b/src/librustc_front/util.rs
@@ -32,7 +32,7 @@ pub fn walk_pat<F>(pat: &Pat, mut it: F) -> bool
             PatKind::Struct(_, ref fields, _) => {
                 fields.iter().all(|field| walk_pat_(&field.node.pat, it))
             }
-            PatKind::TupleStruct(_, Some(ref s)) | PatKind::Tup(ref s) => {
+            PatKind::TupleStruct(_, ref s, _) | PatKind::Tuple(ref s, _) => {
                 s.iter().all(|p| walk_pat_(&p, it))
             }
             PatKind::Box(ref s) | PatKind::Ref(ref s, _) => {
@@ -47,7 +47,6 @@ pub fn walk_pat<F>(pat: &Pat, mut it: F) -> bool
             PatKind::Lit(_) |
             PatKind::Range(_, _) |
             PatKind::Ident(_, _, _) |
-            PatKind::TupleStruct(..) |
             PatKind::Path(..) |
             PatKind::QPath(_, _) => {
                 true

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2431,7 +2431,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                     }
                 }
 
-                PatKind::TupleStruct(ref path, _) | PatKind::Path(ref path) => {
+                PatKind::TupleStruct(ref path, _, _) | PatKind::Path(ref path) => {
                     // This must be an enum variant, struct or const.
                     let resolution = match self.resolve_possibly_assoc_item(pat_id,
                                                                             None,

--- a/src/librustc_trans/save/mod.rs
+++ b/src/librustc_trans/save/mod.rs
@@ -762,7 +762,7 @@ impl<'v> Visitor<'v> for PathCollector {
                 self.collected_paths.push((p.id, path.clone(),
                                            ast::Mutability::Mutable, recorder::TypeRef));
             }
-            PatKind::TupleStruct(ref path, _) |
+            PatKind::TupleStruct(ref path, _, _) |
             PatKind::Path(ref path) |
             PatKind::QPath(_, ref path) => {
                 self.collected_paths.push((p.id, path.clone(),

--- a/src/librustc_trans/trans/debuginfo/create_scope_map.rs
+++ b/src/librustc_trans/trans/debuginfo/create_scope_map.rs
@@ -239,13 +239,11 @@ fn walk_pattern(cx: &CrateContext,
             scope_map.insert(pat.id, scope_stack.last().unwrap().scope_metadata);
         }
 
-        PatKind::TupleStruct(_, ref sub_pats_opt) => {
+        PatKind::TupleStruct(_, ref sub_pats, _) => {
             scope_map.insert(pat.id, scope_stack.last().unwrap().scope_metadata);
 
-            if let Some(ref sub_pats) = *sub_pats_opt {
-                for p in sub_pats {
-                    walk_pattern(cx, &p, scope_stack, scope_map);
-                }
+            for p in sub_pats {
+                walk_pattern(cx, &p, scope_stack, scope_map);
             }
         }
 
@@ -264,7 +262,7 @@ fn walk_pattern(cx: &CrateContext,
             }
         }
 
-        PatKind::Tup(ref sub_pats) => {
+        PatKind::Tuple(ref sub_pats, _) => {
             scope_map.insert(pat.id, scope_stack.last().unwrap().scope_metadata);
 
             for sub_pat in sub_pats {

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -81,6 +81,7 @@ This API is completely unstable and subject to change.
 #![feature(rustc_diagnostic_macros)]
 #![feature(rustc_private)]
 #![feature(staged_api)]
+#![feature(type_ascription)]
 
 #[macro_use] extern crate log;
 #[macro_use] extern crate syntax;

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2535,7 +2535,7 @@ fn name_from_pat(p: &hir::Pat) -> String {
     match p.node {
         PatKind::Wild => "_".to_string(),
         PatKind::Ident(_, ref p, _) => p.node.to_string(),
-        PatKind::TupleStruct(ref p, _) | PatKind::Path(ref p) => path_to_string(p),
+        PatKind::TupleStruct(ref p, _, _) | PatKind::Path(ref p) => path_to_string(p),
         PatKind::QPath(..) => panic!("tried to get argument name from PatKind::QPath, \
                                 which is not allowed in function arguments"),
         PatKind::Struct(ref name, ref fields, etc) => {
@@ -2546,7 +2546,7 @@ fn name_from_pat(p: &hir::Pat) -> String {
                 if etc { ", ..." } else { "" }
             )
         },
-        PatKind::Tup(ref elts) => format!("({})", elts.iter().map(|p| name_from_pat(&**p))
+        PatKind::Tuple(ref elts, _) => format!("({})", elts.iter().map(|p| name_from_pat(&**p))
                                             .collect::<Vec<String>>().join(", ")),
         PatKind::Box(ref p) => name_from_pat(&**p),
         PatKind::Ref(ref p, _) => name_from_pat(&**p),

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -569,9 +569,10 @@ pub enum PatKind {
     /// The `bool` is `true` in the presence of a `..`.
     Struct(Path, Vec<Spanned<FieldPat>>, bool),
 
-    /// A tuple struct/variant pattern `Variant(x, y, z)`.
-    /// "None" means a `Variant(..)` pattern where we don't bind the fields to names.
-    TupleStruct(Path, Option<Vec<P<Pat>>>),
+    /// A tuple struct/variant pattern `Variant(x, y, .., z)`.
+    /// If the `..` pattern fragment presents, then `Option<usize>` denotes its position.
+    /// 0 <= position <= subpats.len()
+    TupleStruct(Path, Vec<P<Pat>>, Option<usize>),
 
     /// A path pattern.
     /// Such pattern can be resolved to a unit struct/variant or a constant.
@@ -583,8 +584,10 @@ pub enum PatKind {
     /// PatKind::Path, and the resolver will have to sort that out.
     QPath(QSelf, Path),
 
-    /// A tuple pattern `(a, b)`
-    Tup(Vec<P<Pat>>),
+    /// A tuple pattern `(a, b)`.
+    /// If the `..` pattern fragment presents, then `Option<usize>` denotes its position.
+    /// 0 <= position <= subpats.len()
+    Tuple(Vec<P<Pat>>, Option<usize>),
     /// A `box` pattern
     Box(P<Pat>),
     /// A reference pattern, e.g. `&mut (a, b)`

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -830,7 +830,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         let pat = if subpats.is_empty() {
             PatKind::Path(path)
         } else {
-            PatKind::TupleStruct(path, Some(subpats))
+            PatKind::TupleStruct(path, subpats, None)
         };
         self.pat(span, pat)
     }
@@ -840,7 +840,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         self.pat(span, pat)
     }
     fn pat_tuple(&self, span: Span, pats: Vec<P<ast::Pat>>) -> P<ast::Pat> {
-        self.pat(span, PatKind::Tup(pats))
+        self.pat(span, PatKind::Tuple(pats, None))
     }
 
     fn pat_some(&self, span: Span, pat: P<ast::Pat>) -> P<ast::Pat> {

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -1127,9 +1127,9 @@ pub fn noop_fold_pat<T: Folder>(p: P<Pat>, folder: &mut T) -> P<Pat> {
                         sub.map(|x| folder.fold_pat(x)))
             }
             PatKind::Lit(e) => PatKind::Lit(folder.fold_expr(e)),
-            PatKind::TupleStruct(pth, pats) => {
+            PatKind::TupleStruct(pth, pats, ddpos) => {
                 PatKind::TupleStruct(folder.fold_path(pth),
-                        pats.map(|pats| pats.move_map(|x| folder.fold_pat(x))))
+                        pats.move_map(|x| folder.fold_pat(x)), ddpos)
             }
             PatKind::Path(pth) => {
                 PatKind::Path(folder.fold_path(pth))
@@ -1150,7 +1150,9 @@ pub fn noop_fold_pat<T: Folder>(p: P<Pat>, folder: &mut T) -> P<Pat> {
                 });
                 PatKind::Struct(pth, fs, etc)
             }
-            PatKind::Tup(elts) => PatKind::Tup(elts.move_map(|x| folder.fold_pat(x))),
+            PatKind::Tuple(elts, ddpos) => {
+                PatKind::Tuple(elts.move_map(|x| folder.fold_pat(x)), ddpos)
+            }
             PatKind::Box(inner) => PatKind::Box(folder.fold_pat(inner)),
             PatKind::Ref(inner, mutbl) => PatKind::Ref(folder.fold_pat(inner), mutbl),
             PatKind::Range(e1, e2) => {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -948,25 +948,6 @@ impl<'a> Parser<'a> {
         Ok(result)
     }
 
-    /// Parse a sequence parameter of enum variant. For consistency purposes,
-    /// these should not be empty.
-    pub fn parse_enum_variant_seq<T, F>(&mut self,
-                                        bra: &token::Token,
-                                        ket: &token::Token,
-                                        sep: SeqSep,
-                                        f: F)
-                                        -> PResult<'a, Vec<T>> where
-        F: FnMut(&mut Parser<'a>) -> PResult<'a,  T>,
-    {
-        let result = try!(self.parse_unspanned_seq(bra, ket, sep, f));
-        if result.is_empty() {
-            let last_span = self.last_span;
-            self.span_err(last_span,
-            "nullary enum variants are written with no trailing `( )`");
-        }
-        Ok(result)
-    }
-
     // NB: Do not use this function unless you actually plan to place the
     // spanned list in the AST.
     pub fn parse_seq<T, F>(&mut self,
@@ -3358,21 +3339,29 @@ impl<'a> Parser<'a> {
         };
     }
 
-    fn parse_pat_tuple_elements(&mut self) -> PResult<'a, Vec<P<Pat>>> {
+    fn parse_pat_tuple_elements(&mut self, unary_needs_comma: bool)
+                                -> PResult<'a, (Vec<P<Pat>>, Option<usize>)> {
         let mut fields = vec![];
-        if !self.check(&token::CloseDelim(token::Paren)) {
-            fields.push(try!(self.parse_pat()));
-            if self.look_ahead(1, |t| *t != token::CloseDelim(token::Paren)) {
-                while self.eat(&token::Comma) &&
-                      !self.check(&token::CloseDelim(token::Paren)) {
+        let mut ddpos = None;
+
+        while !self.check(&token::CloseDelim(token::Paren)) {
+            if ddpos.is_none() && self.eat(&token::DotDot) {
+                ddpos = Some(fields.len());
+                if self.eat(&token::Comma) {
+                    // `..` needs to be followed by `)` or `, pat`, `..,)` is disallowed.
                     fields.push(try!(self.parse_pat()));
                 }
+            } else {
+                fields.push(try!(self.parse_pat()));
             }
-            if fields.len() == 1 {
+
+            if !self.check(&token::CloseDelim(token::Paren)) ||
+                    (unary_needs_comma && fields.len() == 1 && ddpos.is_none()) {
                 try!(self.expect(&token::Comma));
             }
         }
-        Ok(fields)
+
+        Ok((fields, ddpos))
     }
 
     fn parse_pat_vec_elements(
@@ -3557,9 +3546,9 @@ impl<'a> Parser<'a> {
           token::OpenDelim(token::Paren) => {
             // Parse (pat,pat,pat,...) as tuple pattern
             self.bump();
-            let fields = try!(self.parse_pat_tuple_elements());
+            let (fields, ddpos) = try!(self.parse_pat_tuple_elements(true));
             try!(self.expect(&token::CloseDelim(token::Paren)));
-            pat = PatKind::Tup(fields);
+            pat = PatKind::Tuple(fields, ddpos);
           }
           token::OpenDelim(token::Bracket) => {
             // Parse [pat,pat,...] as slice pattern
@@ -3646,20 +3635,10 @@ impl<'a> Parser<'a> {
                             return Err(self.fatal("unexpected `(` after qualified path"));
                         }
                         // Parse tuple struct or enum pattern
-                        if self.look_ahead(1, |t| *t == token::DotDot) {
-                            // This is a "top constructor only" pat
-                            self.bump();
-                            self.bump();
-                            try!(self.expect(&token::CloseDelim(token::Paren)));
-                            pat = PatKind::TupleStruct(path, None);
-                        } else {
-                            let args = try!(self.parse_enum_variant_seq(
-                                    &token::OpenDelim(token::Paren),
-                                    &token::CloseDelim(token::Paren),
-                                    SeqSep::trailing_allowed(token::Comma),
-                                    |p| p.parse_pat()));
-                            pat = PatKind::TupleStruct(path, Some(args));
-                        }
+                        self.bump();
+                        let (fields, ddpos) = try!(self.parse_pat_tuple_elements(false));
+                        try!(self.expect(&token::CloseDelim(token::Paren)));
+                        pat = PatKind::TupleStruct(path, fields, ddpos)
                       }
                       _ => {
                         pat = match qself {

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -419,11 +419,9 @@ pub fn walk_assoc_type_binding<'v, V: Visitor<'v>>(visitor: &mut V,
 
 pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat) {
     match pattern.node {
-        PatKind::TupleStruct(ref path, ref opt_children) => {
+        PatKind::TupleStruct(ref path, ref children, _) => {
             visitor.visit_path(path, pattern.id);
-            if let Some(ref children) = *opt_children {
-                walk_list!(visitor, visit_pat, children);
-            }
+            walk_list!(visitor, visit_pat, children);
         }
         PatKind::Path(ref path) => {
             visitor.visit_path(path, pattern.id);
@@ -439,7 +437,7 @@ pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat) {
                 visitor.visit_pat(&field.node.pat)
             }
         }
-        PatKind::Tup(ref tuple_elements) => {
+        PatKind::Tuple(ref tuple_elements, _) => {
             walk_list!(visitor, visit_pat, tuple_elements);
         }
         PatKind::Box(ref subpattern) |

--- a/src/test/compile-fail/match-pattern-field-mismatch-2.rs
+++ b/src/test/compile-fail/match-pattern-field-mismatch-2.rs
@@ -20,7 +20,7 @@ fn main() {
           color::rgb(_, _, _) => { }
           color::cmyk(_, _, _, _) => { }
           color::no_color(_) => { }
-          //~^ ERROR this pattern has 1 field, but the corresponding variant has no fields
+          //~^ ERROR `color::no_color` does not name a tuple variant or a tuple struct
         }
     }
 }

--- a/src/test/compile-fail/pat-tuple-feature-gate.rs
+++ b/src/test/compile-fail/pat-tuple-feature-gate.rs
@@ -8,22 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum Foo {
-    Bar(i32),
-    Baz
-}
-
-struct S;
-
 fn main() {
-    match Foo::Baz {
-        Foo::Bar => {}
-        //~^ ERROR `Foo::Bar` does not name a tuple variant or a tuple struct
-        _ => {}
-    }
-
-    match S {
-        S(()) => {}
-        //~^ ERROR `S` does not name a tuple variant or a tuple struct
+    match 0 {
+        (..) => {} //~ ERROR `..` in tuple patterns is experimental
+        (pat, ..) => {} //~ ERROR `..` in tuple patterns is experimental
+        S(pat, ..) => {} //~ ERROR `..` in tuple struct patterns is experimental
     }
 }

--- a/src/test/compile-fail/pat-tuple-overfield.rs
+++ b/src/test/compile-fail/pat-tuple-overfield.rs
@@ -8,22 +8,21 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum Foo {
-    Bar(i32),
-    Baz
-}
+#![feature(dotdot_in_tuple_patterns)]
 
-struct S;
+struct S(u8, u8, u8);
 
 fn main() {
-    match Foo::Baz {
-        Foo::Bar => {}
-        //~^ ERROR `Foo::Bar` does not name a tuple variant or a tuple struct
+    match (1, 2, 3) {
+        (1, 2, 3, 4) => {} //~ ERROR mismatched types
+        (1, 2, .., 3, 4) => {} //~ ERROR mismatched types
         _ => {}
     }
-
-    match S {
-        S(()) => {}
-        //~^ ERROR `S` does not name a tuple variant or a tuple struct
+    match S(1, 2, 3) {
+        S(1, 2, 3, 4) => {}
+        //~^ ERROR this pattern has 4 fields, but the corresponding struct has 3 fields
+        S(1, 2, .., 3, 4) => {}
+        //~^ ERROR this pattern has 4 fields, but the corresponding struct has 3 fields
+        _ => {}
     }
 }

--- a/src/test/compile-fail/pattern-error-continue.rs
+++ b/src/test/compile-fail/pattern-error-continue.rs
@@ -25,7 +25,7 @@ fn f(_c: char) {}
 fn main() {
     match A::B(1, 2) {
         A::B(_, _, _) => (), //~ ERROR this pattern has 3 fields, but
-        A::D(_) => (),       //~ ERROR this pattern has 1 field, but
+        A::D(_) => (),       //~ ERROR `A::D` does not name a tuple variant or a tuple struct
         _ => ()
     }
     match 'c' {

--- a/src/test/parse-fail/pat-lt-bracket-6.rs
+++ b/src/test/parse-fail/pat-lt-bracket-6.rs
@@ -9,6 +9,5 @@
 // except according to those terms.
 
 fn main() {
-    let Test(&desc[..]) = x; //~ error: expected one of `,` or `@`, found `[`
-    //~^ ERROR expected one of `:`, `;`, or `=`, found `..`
+    let Test(&desc[..]) = x; //~ ERROR: expected one of `)`, `,`, or `@`, found `[`
 }

--- a/src/test/parse-fail/pat-lt-bracket-7.rs
+++ b/src/test/parse-fail/pat-lt-bracket-7.rs
@@ -9,6 +9,5 @@
 // except according to those terms.
 
 fn main() {
-    for thing(x[]) in foo {} //~ error: expected one of `,` or `@`, found `[`
-    //~^ ERROR: expected `in`, found `]`
+    for thing(x[]) in foo {} //~ ERROR: expected one of `)`, `,`, or `@`, found `[`
 }

--- a/src/test/parse-fail/pat-tuple-1.rs
+++ b/src/test/parse-fail/pat-tuple-1.rs
@@ -8,22 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum Foo {
-    Bar(i32),
-    Baz
-}
-
-struct S;
+// compile-flags: -Z parse-only
 
 fn main() {
-    match Foo::Baz {
-        Foo::Bar => {}
-        //~^ ERROR `Foo::Bar` does not name a tuple variant or a tuple struct
-        _ => {}
-    }
-
-    match S {
-        S(()) => {}
-        //~^ ERROR `S` does not name a tuple variant or a tuple struct
+    match 0 {
+        (, ..) => {} //~ ERROR unexpected token: `,`
     }
 }

--- a/src/test/parse-fail/pat-tuple-2.rs
+++ b/src/test/parse-fail/pat-tuple-2.rs
@@ -8,22 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum Foo {
-    Bar(i32),
-    Baz
-}
-
-struct S;
+// compile-flags: -Z parse-only
 
 fn main() {
-    match Foo::Baz {
-        Foo::Bar => {}
-        //~^ ERROR `Foo::Bar` does not name a tuple variant or a tuple struct
-        _ => {}
-    }
-
-    match S {
-        S(()) => {}
-        //~^ ERROR `S` does not name a tuple variant or a tuple struct
+    match 0 {
+        (pat, ..,) => {} //~ ERROR unexpected token: `)`
     }
 }

--- a/src/test/parse-fail/pat-tuple-3.rs
+++ b/src/test/parse-fail/pat-tuple-3.rs
@@ -8,22 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum Foo {
-    Bar(i32),
-    Baz
-}
-
-struct S;
+// compile-flags: -Z parse-only
 
 fn main() {
-    match Foo::Baz {
-        Foo::Bar => {}
-        //~^ ERROR `Foo::Bar` does not name a tuple variant or a tuple struct
-        _ => {}
-    }
-
-    match S {
-        S(()) => {}
-        //~^ ERROR `S` does not name a tuple variant or a tuple struct
+    match 0 {
+        (.., pat, ..) => {} //~ ERROR unexpected token: `..`
     }
 }

--- a/src/test/parse-fail/pat-tuple-4.rs
+++ b/src/test/parse-fail/pat-tuple-4.rs
@@ -8,22 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum Foo {
-    Bar(i32),
-    Baz
-}
-
-struct S;
+// compile-flags: -Z parse-only
 
 fn main() {
-    match Foo::Baz {
-        Foo::Bar => {}
-        //~^ ERROR `Foo::Bar` does not name a tuple variant or a tuple struct
-        _ => {}
-    }
-
-    match S {
-        S(()) => {}
-        //~^ ERROR `S` does not name a tuple variant or a tuple struct
+    match 0 {
+        (.. pat) => {} //~ ERROR expected one of `)` or `,`, found `pat`
     }
 }

--- a/src/test/parse-fail/pat-tuple-5.rs
+++ b/src/test/parse-fail/pat-tuple-5.rs
@@ -8,22 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum Foo {
-    Bar(i32),
-    Baz
-}
-
-struct S;
+// compile-flags: -Z parse-only
 
 fn main() {
-    match Foo::Baz {
-        Foo::Bar => {}
-        //~^ ERROR `Foo::Bar` does not name a tuple variant or a tuple struct
-        _ => {}
-    }
-
-    match S {
-        S(()) => {}
-        //~^ ERROR `S` does not name a tuple variant or a tuple struct
+    match 0 {
+        (pat ..) => {} //~ ERROR expected one of `)`, `,`, or `@`, found `..`
     }
 }

--- a/src/test/parse-fail/pat-tuple-6.rs
+++ b/src/test/parse-fail/pat-tuple-6.rs
@@ -8,22 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum Foo {
-    Bar(i32),
-    Baz
-}
-
-struct S;
+// compile-flags: -Z parse-only
 
 fn main() {
-    match Foo::Baz {
-        Foo::Bar => {}
-        //~^ ERROR `Foo::Bar` does not name a tuple variant or a tuple struct
-        _ => {}
-    }
-
-    match S {
-        S(()) => {}
-        //~^ ERROR `S` does not name a tuple variant or a tuple struct
+    match 0 {
+        (pat) => {} //~ ERROR expected one of `,` or `@`, found `)`
     }
 }

--- a/src/test/run-pass/pat-tuple.rs
+++ b/src/test/run-pass/pat-tuple.rs
@@ -1,0 +1,202 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(dotdot_in_tuple_patterns)]
+
+fn b() {
+    let x = (1, 2, 3);
+    match x {
+        (a, b, ..) => {
+            assert_eq!(a, 1);
+            assert_eq!(b, 2);
+        }
+    }
+    match x {
+        (.., b, c) => {
+            assert_eq!(b, 2);
+            assert_eq!(c, 3);
+        }
+    }
+    match x {
+        (a, .., c) => {
+            assert_eq!(a, 1);
+            assert_eq!(c, 3);
+        }
+    }
+    match x {
+        (a, b, c) => {
+            assert_eq!(a, 1);
+            assert_eq!(b, 2);
+            assert_eq!(c, 3);
+        }
+    }
+}
+
+fn bs() {
+    struct S(u8, u8, u8);
+
+    let x = S(1, 2, 3);
+    match x {
+        S(a, b, ..) => {
+            assert_eq!(a, 1);
+            assert_eq!(b, 2);
+        }
+    }
+    match x {
+        S(.., b, c) => {
+            assert_eq!(b, 2);
+            assert_eq!(c, 3);
+        }
+    }
+    match x {
+        S(a, .., c) => {
+            assert_eq!(a, 1);
+            assert_eq!(c, 3);
+        }
+    }
+    match x {
+        S(a, b, c) => {
+            assert_eq!(a, 1);
+            assert_eq!(b, 2);
+            assert_eq!(c, 3);
+        }
+    }
+}
+
+fn c() {
+    let x = (1,);
+    match x {
+        (2, ..) => panic!(),
+        (..) => ()
+    }
+}
+
+fn cs() {
+    struct S(u8);
+
+    let x = S(1);
+    match x {
+        S(2, ..) => panic!(),
+        S(..) => ()
+    }
+}
+
+fn d() {
+    let x = (1, 2, 3);
+    let branch = match x {
+        (1, 1, ..) => 0,
+        (1, 2, 3, ..) => 1,
+        (1, 2, ..) => 2,
+        _ => 3
+    };
+    assert_eq!(branch, 1);
+}
+
+fn ds() {
+    struct S(u8, u8, u8);
+
+    let x = S(1, 2, 3);
+    let branch = match x {
+        S(1, 1, ..) => 0,
+        S(1, 2, 3, ..) => 1,
+        S(1, 2, ..) => 2,
+        _ => 3
+    };
+    assert_eq!(branch, 1);
+}
+
+fn f() {
+    let x = (1, 2, 3);
+    match x {
+        (1, 2, 4) => unreachable!(),
+        (0, 2, 3, ..) => unreachable!(),
+        (0, .., 3) => unreachable!(),
+        (0, ..) => unreachable!(),
+        (1, 2, 3) => (),
+        (_, _, _) => unreachable!(),
+    }
+    match x {
+        (..) => (),
+    }
+    match x {
+        (_, _, _, ..) => (),
+    }
+    match x {
+        (a, b, c) => {
+            assert_eq!(1, a);
+            assert_eq!(2, b);
+            assert_eq!(3, c);
+        }
+    }
+}
+
+fn fs() {
+    struct S(u8, u8, u8);
+
+    let x = S(1, 2, 3);
+    match x {
+        S(1, 2, 4) => unreachable!(),
+        S(0, 2, 3, ..) => unreachable!(),
+        S(0, .., 3) => unreachable!(),
+        S(0, ..) => unreachable!(),
+        S(1, 2, 3) => (),
+        S(_, _, _) => unreachable!(),
+    }
+    match x {
+        S(..) => (),
+    }
+    match x {
+        S(_, _, _, ..) => (),
+    }
+    match x {
+        S(a, b, c) => {
+            assert_eq!(1, a);
+            assert_eq!(2, b);
+            assert_eq!(3, c);
+        }
+    }
+}
+
+fn g() {
+    struct S;
+    struct Z;
+    struct W;
+    let x = (S, Z, W);
+    match x { (S, ..) => {} }
+    match x { (.., W) => {} }
+    match x { (S, .., W) => {} }
+    match x { (.., Z, _) => {} }
+}
+
+fn gs() {
+    struct SS(S, Z, W);
+
+    struct S;
+    struct Z;
+    struct W;
+    let x = SS(S, Z, W);
+    match x { SS(S, ..) => {} }
+    match x { SS(.., W) => {} }
+    match x { SS(S, .., W) => {} }
+    match x { SS(.., Z, _) => {} }
+}
+
+fn main() {
+    b();
+    bs();
+    c();
+    cs();
+    d();
+    ds();
+    f();
+    fs();
+    g();
+    gs();
+}


### PR DESCRIPTION
An implementation for https://github.com/rust-lang/rfcs/pull/1492
The sub-list bindings `pat..` are not implemented.
The code needs some cleanup, but otherwise works.
