### PR TITLE
reference.md: clarify the limitation of type alias on an enum

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -1118,6 +1118,16 @@ type Point = (u8, u8);
 let p: Point = (41, 68);
 ```
 
+Currently a type alias to an enum type cannot be used to qualify the
+constructors:
+
+```
+enum E { A }
+type F = E;
+let _: F = E::A;  // OK
+// let _: F = F::A;  // Doesn't work
+```
+
 ### Structs
 
 A _struct_ is a nominal [struct type](#struct-types) defined with the


### PR DESCRIPTION
Tentatively define the current behavior as the specification.

Cf. rust-lang/rust#26264, rust-lang/rust#28556, rust-lang/rust#30936
