### PR TITLE
"can be built on Ref::map"… how?

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -625,7 +625,7 @@ impl<'b, T: ?Sized> Ref<'b, T> {
     /// ```
     #[unstable(feature = "cell_extras", reason = "recently added",
                issue = "27746")]
-    #[rustc_deprecated(since = "1.8.0", reason = "can be built on Ref::map")]
+    #[rustc_deprecated(since = "1.8.0", reason = "can be built on `Ref::map`: https://crates.io/crates/ref_filter_map")]
     #[inline]
     pub fn filter_map<U: ?Sized, F>(orig: Ref<'b, T>, f: F) -> Option<Ref<'b, U>>
         where F: FnOnce(&T) -> Option<&U>
@@ -700,7 +700,7 @@ impl<'b, T: ?Sized> RefMut<'b, T> {
     /// ```
     #[unstable(feature = "cell_extras", reason = "recently added",
                issue = "27746")]
-    #[rustc_deprecated(since = "1.8.0", reason = "can be built on RefMut::map")]
+    #[rustc_deprecated(since = "1.8.0", reason = "can be built on `RefMut::map`: https://crates.io/crates/ref_filter_map")]
     #[inline]
     pub fn filter_map<U: ?Sized, F>(orig: RefMut<'b, T>, f: F) -> Option<RefMut<'b, U>>
         where F: FnOnce(&mut T) -> Option<&mut U>

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -625,7 +625,8 @@ impl<'b, T: ?Sized> Ref<'b, T> {
     /// ```
     #[unstable(feature = "cell_extras", reason = "recently added",
                issue = "27746")]
-    #[rustc_deprecated(since = "1.8.0", reason = "can be built on `Ref::map`: https://crates.io/crates/ref_filter_map")]
+    #[rustc_deprecated(since = "1.8.0", reason = "can be built on `Ref::map`: \
+        https://crates.io/crates/ref_filter_map")]
     #[inline]
     pub fn filter_map<U: ?Sized, F>(orig: Ref<'b, T>, f: F) -> Option<Ref<'b, U>>
         where F: FnOnce(&T) -> Option<&U>
@@ -700,7 +701,8 @@ impl<'b, T: ?Sized> RefMut<'b, T> {
     /// ```
     #[unstable(feature = "cell_extras", reason = "recently added",
                issue = "27746")]
-    #[rustc_deprecated(since = "1.8.0", reason = "can be built on `RefMut::map`: https://crates.io/crates/ref_filter_map")]
+    #[rustc_deprecated(since = "1.8.0", reason = "can be built on `RefMut::map`: \
+        https://crates.io/crates/ref_filter_map")]
     #[inline]
     pub fn filter_map<U: ?Sized, F>(orig: RefMut<'b, T>, f: F) -> Option<RefMut<'b, U>>
         where F: FnOnce(&mut T) -> Option<&mut U>


### PR DESCRIPTION
Now that `std::cell::Ref::filter_map` and `RefMut::filter_map` are deprecated, using them gives a warning like:

```
script/dom/element.rs:754:9: 754:24 warning: use of deprecated item: can be built on Ref::map, #[warn(deprecated)] on by default
```

But it’s not at all obvious _how_ the functionality can be built on `Ref::map`. This PR adds to the warning message a crates.io URL for a crate that does.
