### PR TITLE
Remove final note from testing chapter.

### DIFF
--- a/src/doc/book/testing.md
+++ b/src/doc/book/testing.md
@@ -515,7 +515,3 @@ you add more examples.
 
 We haven’t covered all of the details with writing documentation tests. For more,
 please see the [Documentation chapter](documentation.html).
-
-One final note: documentation tests *cannot* be run on binary crates.
-To see more on file arrangement see the [Crates and
-Modules](crates-and-modules.html) section.


### PR DESCRIPTION
The information that documentation tests cannot be run in binary crates is already given at the beginning of the section.
