### PR TITLE
resolve: Minimize hacks in name resolution of primitive types

### DIFF
--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -205,51 +205,6 @@ about what constitutes an Item declaration and what does not:
 https://doc.rust-lang.org/reference.html#statements
 "##,
 
-E0317: r##"
-User-defined types or type parameters cannot shadow the primitive types.
-This error indicates you tried to define a type, struct or enum with the same
-name as an existing primitive type:
-
-```compile_fail
-struct u8 {
-    // ...
-}
-```
-
-To fix this, simply name it something else.
-
-Such an error may also occur if you define a type parameter which shadows a
-primitive type. An example would be something like:
-
-```compile_fail
-impl<u8> MyTrait for Option<u8> {
-    // ...
-}
-```
-
-In such a case, if you meant for `u8` to be a generic type parameter (i.e. any
-type can be used in its place), use something like `T` instead:
-
-```ignore
-impl<T> MyTrait for Option<T> {
-    // ...
-}
-```
-
-On the other hand, if you wished to refer to the specific type `u8`, remove it
-from the type parameter list:
-
-```ignore
-impl MyTrait for Option<u8> {
-    // ...
-}
-
-See the Types section of the reference for more information about the primitive
-types:
-
-https://doc.rust-lang.org/reference.html#types
-"##,
-
 E0364: r##"
 Private items cannot be publicly re-exported.  This error indicates that you
 attempted to `pub use` a type or value that was not itself public.

--- a/src/test/compile-fail/issue-20427.rs
+++ b/src/test/compile-fail/issue-20427.rs
@@ -17,6 +17,7 @@ fn u8(f32: f32) {}
 fn f<f64>(f64: f64) {}
 //~^ ERROR user-defined types or type parameters cannot shadow the primitive types
 type u16 = u16; //~ ERROR user-defined types or type parameters cannot shadow the primitive types
+//~^ ERROR unsupported cyclic reference between types/traits detected
 enum u32 {} //~ ERROR user-defined types or type parameters cannot shadow the primitive types
 struct u64; //~ ERROR user-defined types or type parameters cannot shadow the primitive types
 trait bool {} //~ ERROR user-defined types or type parameters cannot shadow the primitive types

--- a/src/test/run-pass/issue-20427.rs
+++ b/src/test/run-pass/issue-20427.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -15,12 +15,9 @@ static i32: i32 = 0;
 const i64: i64 = 0;
 fn u8(f32: f32) {}
 fn f<f64>(f64: f64) {}
-//~^ ERROR user-defined types or type parameters cannot shadow the primitive types
-type u16 = u16; //~ ERROR user-defined types or type parameters cannot shadow the primitive types
-//~^ ERROR unsupported cyclic reference between types/traits detected
-enum u32 {} //~ ERROR user-defined types or type parameters cannot shadow the primitive types
-struct u64; //~ ERROR user-defined types or type parameters cannot shadow the primitive types
-trait bool {} //~ ERROR user-defined types or type parameters cannot shadow the primitive types
+enum u32 {}
+struct u64;
+trait bool {}
 
 mod char {
     extern crate i8;
@@ -41,29 +38,40 @@ mod char {
         use super::u8_ as u8;
         use super::f_ as f64;
         use super::u16_ as u16;
-        //~^ ERROR user-defined types or type parameters cannot shadow the primitive types
         use super::u32_ as u32;
-        //~^ ERROR user-defined types or type parameters cannot shadow the primitive types
         use super::u64_ as u64;
-        //~^ ERROR user-defined types or type parameters cannot shadow the primitive types
         use super::bool_ as bool;
-        //~^ ERROR user-defined types or type parameters cannot shadow the primitive types
         use super::{bool_ as str};
-        //~^ ERROR user-defined types or type parameters cannot shadow the primitive types
         use super::char_ as char;
     }
 }
 
 trait isize_ {
-    type isize; //~ ERROR user-defined types or type parameters cannot shadow the primitive types
+    type isize;
 }
 
 fn usize<'usize>(usize: &'usize usize) -> &'usize usize { usize }
 
+mod reuse {
+    use std::mem::size_of;
+
+    type u8 = u64;
+    use std::string::String as i16;
+
+    pub fn check<u16>() {
+        assert_eq!(size_of::<u8>(), 8);
+        assert_eq!(size_of::<::u64>(), 0);
+        assert_eq!(size_of::<i16>(), 3 * size_of::<*const ()>());
+        assert_eq!(size_of::<u16>(), 0);
+    }
+}
+
 fn main() {
     let bool = true;
-    match bool {
+    let _ = match bool {
         str @ true => if str { i32 as i64 } else { i64 },
         false => i64,
     };
+
+    reuse::check::<u64>();
 }

--- a/src/test/run-pass/issue-20427.rs
+++ b/src/test/run-pass/issue-20427.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 // aux-build:i8.rs
+// ignore-pretty (#23623)
+
 extern crate i8;
 use std::string as i16;
 static i32: i32 = 0;
@@ -66,6 +68,17 @@ mod reuse {
     }
 }
 
+mod guard {
+    pub fn check() {
+        use std::u8; // bring module u8 in scope
+        fn f() -> u8 { // OK, resolves to primitive u8, not to std::u8
+            u8::max_value() // OK, resolves to associated function <u8>::max_value,
+                            // not to non-existent std::u8::max_value
+        }
+        assert_eq!(f(), u8::MAX); // OK, resolves to std::u8::MAX
+    }
+}
+
 fn main() {
     let bool = true;
     let _ = match bool {
@@ -74,4 +87,5 @@ fn main() {
     };
 
     reuse::check::<u64>();
+    guard::check();
 }


### PR DESCRIPTION
When resolving the first unqualified segment in a path with `n` segments and `n - 1` associated item segments, e.g. (`a` or `a::assoc` or `a::assoc::assoc` etc) try to resolve `a` without considering primitive types first. If the "normal" lookup fails or results in a module, then try to resolve `a` as a primitive type as a fallback.

This way backward compatibility is respected, but the restriction from E0317 can be lifted, i.e. primitive names mostly can be shadowed like any other names.

Furthermore, if names of primitive types are [put into prelude](https://github.com/petrochenkov/rust/tree/prim2) (now it's possible to do), then most of names will be resolved in conventional way and amount of code relying on this fallback will be greatly reduced. Although, it's not entirely convenient to put them into prelude right now due to temporary conflicts like `use prelude::v1::*; use usize;` in libcore/libstd, I'd better wait for proper glob shadowing before doing it.
I wish the `no_prelude` attribute were unstable as intended :(

cc @jseyfried @arielb1 
r? @eddyb 
