### PR TITLE
cover more linux targets in libstd cargobuild

### DIFF
--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -27,19 +27,19 @@ fn main() {
         build_libbacktrace(&host, &target);
     }
 
-    if target.contains("unknown-linux") {
+    if target.contains("linux") {
         if target.contains("musl") && (target.contains("x86_64") || target.contains("i686")) {
             println!("cargo:rustc-link-lib=static=unwind");
+        } else if target.contains("android") {
+            println!("cargo:rustc-link-lib=dl");
+            println!("cargo:rustc-link-lib=log");
+            println!("cargo:rustc-link-lib=gcc");
         } else {
             println!("cargo:rustc-link-lib=dl");
             println!("cargo:rustc-link-lib=rt");
             println!("cargo:rustc-link-lib=pthread");
             println!("cargo:rustc-link-lib=gcc_s");
         }
-    } else if target.contains("android") {
-        println!("cargo:rustc-link-lib=dl");
-        println!("cargo:rustc-link-lib=log");
-        println!("cargo:rustc-link-lib=gcc");
     } else if target.contains("freebsd") {
         println!("cargo:rustc-link-lib=execinfo");
         println!("cargo:rustc-link-lib=pthread");


### PR DESCRIPTION
libstd/build.rs checked the target name against `"unknown-linux"`... That doesn't necessarily apply to all Linux targets as some toolchains for embedded targets will change that `unknown` field to some vendor name. Some shifting around was needed since Android is also a Linux target.

r? @alexcrichton
