### PR TITLE
Forbid glob-importing from a type alias

### DIFF
--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -331,10 +331,8 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
 
             // These items live in the type namespace.
             ItemTy(..) => {
-                let parent_link = ModuleParentLink(parent, name);
                 let def = Def::TyAlias(self.ast_map.local_def_id(item.id));
-                let module = self.new_module(parent_link, Some(def), false, is_public);
-                self.define(parent, name, TypeNS, (module, sp));
+                self.define(parent, name, TypeNS, (def, sp, modifiers));
                 parent
             }
 
@@ -505,7 +503,7 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
         }
 
         match def {
-            Def::Mod(_) | Def::ForeignMod(_) | Def::Enum(..) | Def::TyAlias(..) => {
+            Def::Mod(_) | Def::ForeignMod(_) | Def::Enum(..) => {
                 debug!("(building reduced graph for external crate) building module {} {}",
                        final_ident,
                        is_public);
@@ -562,7 +560,7 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
                 let module = self.new_module(parent_link, Some(def), true, is_public);
                 self.try_define(new_parent, name, TypeNS, (module, DUMMY_SP));
             }
-            Def::AssociatedTy(..) => {
+            Def::TyAlias(..) | Def::AssociatedTy(..) => {
                 debug!("(building reduced graph for external crate) building type {}",
                        final_ident);
                 self.try_define(new_parent, name, TypeNS, (def, DUMMY_SP, modifiers));

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -586,6 +586,10 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
                            target_module: Module<'b>,
                            directive: &'b ImportDirective)
                            -> ResolveResult<()> {
+        if let Some(Def::Trait(_)) = target_module.def {
+            self.resolver.session.span_err(directive.span, "items in traits are not importable.");
+        }
+
         if module_.def_id() == target_module.def_id() {
             // This means we are trying to glob import a module into itself, and it is a no-go
             let msg = "Cannot glob-import a module into itself.".into();

--- a/src/test/compile-fail/issue-30560.rs
+++ b/src/test/compile-fail/issue-30560.rs
@@ -12,4 +12,7 @@ type Alias = ();
 use Alias::*; //~ ERROR Not a module
 use std::io::Result::*; //~ ERROR Not a module
 
+trait T {}
+use T::*; //~ ERROR items in traits are not importable
+
 fn main() {}

--- a/src/test/compile-fail/issue-30560.rs
+++ b/src/test/compile-fail/issue-30560.rs
@@ -1,0 +1,15 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+type Alias = ();
+use Alias::*; //~ ERROR Not a module
+use std::io::Result::*; //~ ERROR Not a module
+
+fn main() {}


### PR DESCRIPTION
This PR forbids glob-importing from a type alias or trait (fixes #30560):

``` rust
type Alias = ();
use Alias::*; // This is currently allowed but shouldn't be
```

This is a [breaking-change]. Since the disallowed glob imports don't actually import anything, any breakage can be fixed by removing the offending glob import.

r? @alexcrichton 
