### PR TITLE
lint: mark associated types as live for the dead_code pass

### DIFF
--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -351,15 +351,9 @@ impl<'v> Visitor<'v> for LifeSeeder {
             }
             hir::ItemImpl(_, _, _, ref opt_trait, _, ref impl_items) => {
                 for impl_item in impl_items {
-                    match impl_item.node {
-                        hir::ImplItemKind::Const(..) |
-                        hir::ImplItemKind::Method(..) => {
-                            if opt_trait.is_some() ||
-                                    has_allow_dead_code_or_lang_attr(&impl_item.attrs) {
-                                self.worklist.push(impl_item.id);
-                            }
-                        }
-                        hir::ImplItemKind::Type(_) => {}
+                    if opt_trait.is_some() ||
+                            has_allow_dead_code_or_lang_attr(&impl_item.attrs) {
+                        self.worklist.push(impl_item.id);
                     }
                 }
             }

--- a/src/test/run-pass/lint-dead-code-associated-type.rs
+++ b/src/test/run-pass/lint-dead-code-associated-type.rs
@@ -1,0 +1,27 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(dead_code)]
+
+trait Foo {
+    type Bar;
+}
+
+struct Used;
+
+struct Ex;
+
+impl Foo for Ex {
+    type Bar = Used;
+}
+
+pub fn main() {
+    let _x = Ex;
+}


### PR DESCRIPTION
Associated types of trait impls were being excluded from the live list. So types that only appeared in trait impls were being marked as dead code.
