### PR TITLE
README: Document that configure script requires Perl

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Read ["Installing Rust"] from [The Book].
 
    * `g++` 4.7 or `clang++` 3.x
    * `python` 2.7 (but not 3.x)
+   * `perl`
    * GNU `make` 3.81 or later
    * `curl`
    * `git`


### PR DESCRIPTION
Without Perl, the script will fail to install Git submodules:

```
$ ./configure
...
configure: configuring submodules
configure:
configure: git: submodule sync
/usr/libexec/git-core/git-submodule: line 1: /usr/bin/perl: not found
configure: git: submodule init
/usr/libexec/git-core/git-submodule: line 1: /usr/bin/perl: not found
configure: git: submodule update
/usr/libexec/git-core/git-submodule: line 1: /usr/bin/perl: not found
configure: git: submodule foreach sync
/usr/libexec/git-core/git-submodule: line 1: /usr/bin/perl: not found
configure: git: submodule foreach update
/usr/libexec/git-core/git-submodule: line 1: /usr/bin/perl: not found
configure: git: submodule status
/usr/libexec/git-core/git-submodule: line 1: /usr/bin/perl: not found
configure: git: submodule clobber
/usr/libexec/git-core/git-submodule: line 1: /usr/bin/perl: not found
/usr/libexec/git-core/git-submodule: line 1: /usr/bin/perl: not found
```
