### PR TITLE
Do not report errors from regionck if other errors were already reported

### DIFF
--- a/src/librustc/middle/infer/mod.rs
+++ b/src/librustc/middle/infer/mod.rs
@@ -1107,11 +1107,15 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                                         .map(|method| resolve_ty(method.ty)))
     }
 
+    pub fn errors_since_creation(&self) -> bool {
+        self.tcx.sess.err_count() - self.err_count_on_creation != 0
+    }
+
     pub fn node_type(&self, id: ast::NodeId) -> Ty<'tcx> {
         match self.tables.borrow().node_types.get(&id) {
             Some(&t) => t,
             // FIXME
-            None if self.tcx.sess.err_count() - self.err_count_on_creation != 0 =>
+            None if self.errors_since_creation() =>
                 self.tcx.types.err,
             None => {
                 self.tcx.sess.bug(
@@ -1134,7 +1138,14 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                                              free_regions: &FreeRegionMap,
                                              subject_node_id: ast::NodeId) {
         let errors = self.region_vars.resolve_regions(free_regions, subject_node_id);
-        self.report_region_errors(&errors); // see error_reporting.rs
+        if !self.errors_since_creation() {
+            // As a heuristic, just skip reporting region errors
+            // altogether if other errors have been reported while
+            // this infcx was in use.  This is totally hokey but
+            // otherwise we have a hard time separating legit region
+            // errors from silly ones.
+            self.report_region_errors(&errors); // see error_reporting.rs
+        }
     }
 
     pub fn ty_to_string(&self, t: Ty<'tcx>) -> String {

--- a/src/test/compile-fail/issue-30580.rs
+++ b/src/test/compile-fail/issue-30580.rs
@@ -1,0 +1,24 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub struct Foo { a: u32 }
+pub struct Pass<'a, 'tcx: 'a>(&'a mut &'a (), &'a &'tcx ());
+
+impl<'a, 'tcx> Pass<'a, 'tcx>
+{
+    pub fn tcx(&self) -> &'a &'tcx () { self.1 }
+    fn lol(&mut self, b: &Foo)
+    {
+        b.c; //~ ERROR no field with that name was found
+        self.tcx();
+    }
+}
+
+fn main() {}

--- a/src/test/compile-fail/issue-30580.rs
+++ b/src/test/compile-fail/issue-30580.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Test that we do not see uninformative region-related errors
+// when we get some basic type-checking failure. See #30580.
+
 pub struct Foo { a: u32 }
 pub struct Pass<'a, 'tcx: 'a>(&'a mut &'a (), &'a &'tcx ());
 


### PR DESCRIPTION
Do not report errors from regionck if other errors were already reported during the lifetime of this inferencer. Fixes #30580.

r? @arielb1 
