### PR TITLE
Call str::to_owned in String::from and uninline it

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -66,7 +66,7 @@ use core::str::pattern::Pattern;
 use rustc_unicode::char::{decode_utf16, REPLACEMENT_CHARACTER};
 use rustc_unicode::str as unicode_str;
 
-use borrow::Cow;
+use borrow::{Cow, ToOwned};
 use range::RangeArgument;
 use str::{self, FromStr, Utf8Error, Chars};
 use vec::Vec;
@@ -1797,20 +1797,8 @@ impl AsRef<[u8]> for String {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> From<&'a str> for String {
-    #[cfg(not(test))]
-    #[inline]
     fn from(s: &'a str) -> String {
-        String { vec: <[_]>::to_vec(s.as_bytes()) }
-    }
-
-    // HACK(japaric): with cfg(test) the inherent `[T]::to_vec` method, which is
-    // required for this method definition, is not available. Since we don't
-    // require this method for testing purposes, I'll just stub it
-    // NB see the slice::hack module in slice.rs for more information
-    #[inline]
-    #[cfg(test)]
-    fn from(_: &str) -> String {
-        panic!("not available with cfg(test)");
+        s.to_owned()
     }
 }
 


### PR DESCRIPTION
Call str::to_owned in String::from and uninline it

These methods were already effectively equal, but now one calls
the other, and neither is marked inline.
String::from does not need to be inlined, it can be without it just like
str::to_owned and String::clone are.

Fixes #32163 
