### PR TITLE
Fix build failure on FreeBSD, due to useless annotations.

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -169,7 +169,7 @@ pub enum Option<T> {
     None,
     /// Some value `T`
     #[stable(feature = "rust1", since = "1.0.0")]
-    Some(#[stable(feature = "rust1", since = "1.0.0")] T)
+    Some(T)
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -250,11 +250,11 @@ use option::Option::{self, None, Some};
 pub enum Result<T, E> {
     /// Contains the success value
     #[stable(feature = "rust1", since = "1.0.0")]
-    Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
+    Ok(T),
 
     /// Contains the error value
     #[stable(feature = "rust1", since = "1.0.0")]
-    Err(#[stable(feature = "rust1", since = "1.0.0")] E)
+    Err(E)
 }
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This patch tries to fix a failure I hit while trying to build rust on FreeBSD.

Example:

```
src/libcore/result.rs:253:54: 253:56 error: This stability annotation is useless
src/libcore/result.rs:253     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
                                                                               ^~
src/libcore/result.rs:257:55: 257:57 error: This stability annotation is useless
src/libcore/result.rs:257     Err(#[stable(feature = "rust1", since = "1.0.0")] E)
                                                                                ^~
```

I'm not terribly sure this is correct as this is my first contribution to rust, but still i thougth it was worth a try. Also, isn't the annotation highlighting the wrong piece? (T and E instead of #[stable ...]).

Thanks!
## 

Davide
