### PR TITLE
Restrict constants in patterns

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -137,6 +137,19 @@ declare_lint! {
 }
 
 declare_lint! {
+    pub ILLEGAL_FLOATING_POINT_CONSTANT_PATTERN,
+    Warn,
+    "floating-point constants cannot be used in patterns"
+}
+
+declare_lint! {
+    pub ILLEGAL_STRUCT_OR_ENUM_CONSTANT_PATTERN,
+    Deny,
+    "constants of struct or enum type can only be used in a pattern if \
+     the struct or enum has `#[derive(Eq)]`"
+}
+
+declare_lint! {
     pub MATCH_OF_UNIT_VARIANT_VIA_PAREN_DOTDOT,
     Deny,
     "unit struct or enum variant erroneously allowed to match via path::ident(..)"
@@ -193,6 +206,8 @@ impl LintPass for HardwiredLints {
             PRIVATE_IN_PUBLIC,
             INACCESSIBLE_EXTERN_CRATE,
             INVALID_TYPE_PARAM_DEFAULT,
+            ILLEGAL_FLOATING_POINT_CONSTANT_PATTERN,
+            ILLEGAL_STRUCT_OR_ENUM_CONSTANT_PATTERN,
             MATCH_OF_UNIT_VARIANT_VIA_PAREN_DOTDOT,
             CONST_ERR,
             RAW_POINTER_DERIVE,

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -146,7 +146,7 @@ declare_lint! {
     pub ILLEGAL_STRUCT_OR_ENUM_CONSTANT_PATTERN,
     Deny,
     "constants of struct or enum type can only be used in a pattern if \
-     the struct or enum has `#[derive(Eq)]`"
+     the struct or enum has `#[derive(PartialEq, Eq)]`"
 }
 
 declare_lint! {

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -478,15 +478,25 @@ impl<'a, 'tcx> Folder for StaticInliner<'a, 'tcx> {
                     Some(Def::Const(did)) => {
                         let substs = Some(self.tcx.node_id_item_substs(pat.id).substs);
                         if let Some((const_expr, _)) = lookup_const_by_id(self.tcx, did, substs) {
-                            const_expr_to_pat(self.tcx, const_expr, pat.span).map(|new_pat| {
-
-                                if let Some(ref mut renaming_map) = self.renaming_map {
-                                    // Record any renamings we do here
-                                    record_renamings(const_expr, &pat, renaming_map);
+                            match const_expr_to_pat(self.tcx, const_expr, pat.span) {
+                                Ok(new_pat) => {
+                                    if let Some(ref mut map) = self.renaming_map {
+                                        // Record any renamings we do here
+                                        record_renamings(const_expr, &pat, map);
+                                    }
+                                    new_pat
                                 }
-
-                                new_pat
-                            })
+                                Err(def_id) => {
+                                    // TODO back-compat
+                                    self.failed = true;
+                                    self.tcx.sess.span_err(
+                                        pat.span,
+                                        &format!("constants of the type `{}` \
+                                                  cannot be used in patterns",
+                                                 self.tcx.item_path_str(def_id)));
+                                    pat
+                                }
+                            }
                         } else {
                             self.failed = true;
                             span_err!(self.tcx.sess, pat.span, E0158,

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -478,7 +478,7 @@ impl<'a, 'tcx> Folder for StaticInliner<'a, 'tcx> {
                     Some(Def::Const(did)) => {
                         let substs = Some(self.tcx.node_id_item_substs(pat.id).substs);
                         if let Some((const_expr, _)) = lookup_const_by_id(self.tcx, did, substs) {
-                            match const_expr_to_pat(self.tcx, const_expr, pat.span) {
+                            match const_expr_to_pat(self.tcx, const_expr, pat.id, pat.span) {
                                 Ok(new_pat) => {
                                     if let Some(ref mut map) = self.renaming_map {
                                         // Record any renamings we do here
@@ -487,7 +487,6 @@ impl<'a, 'tcx> Folder for StaticInliner<'a, 'tcx> {
                                     new_pat
                                 }
                                 Err(def_id) => {
-                                    // TODO back-compat
                                     self.failed = true;
                                     self.tcx.sess.span_err(
                                         pat.span,

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -345,7 +345,7 @@ pub fn const_expr_to_pat(tcx: &ty::TyCtxt, expr: &Expr, pat_id: ast::NodeId, spa
                     span,
                     format!("to use a constant of type `{}` \
                              in a pattern, \
-                             `{}` must be annotated with `#[derive(Eq)]`",
+                             `{}` must be annotated with `#[derive(PartialEq, Eq)]`",
                             tcx.item_path_str(adt_def.did),
                             tcx.item_path_str(adt_def.did)));
             }

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -246,7 +246,13 @@ impl Session {
         let lint_id = lint::LintId::of(lint);
         let mut lints = self.lints.borrow_mut();
         match lints.get_mut(&id) {
-            Some(arr) => { arr.push((lint_id, sp, msg)); return; }
+            Some(arr) => {
+                let tuple = (lint_id, sp, msg);
+                if !arr.contains(&tuple) {
+                    arr.push(tuple);
+                }
+                return;
+            }
             None => {}
         }
         lints.insert(id, vec!((lint_id, sp, msg)));

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -179,6 +179,14 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
             id: LintId::of(OVERLAPPING_INHERENT_IMPLS),
             reference: "issue #22889 <https://github.com/rust-lang/rust/issues/22889>",
         },
+        FutureIncompatibleInfo {
+            id: LintId::of(ILLEGAL_FLOATING_POINT_CONSTANT_PATTERN),
+            reference: "RFC 1445 <https://github.com/rust-lang/rfcs/pull/1445>",
+        },
+        FutureIncompatibleInfo {
+            id: LintId::of(ILLEGAL_STRUCT_OR_ENUM_CONSTANT_PATTERN),
+            reference: "RFC 1445 <https://github.com/rust-lang/rfcs/pull/1445>",
+        },
         ]);
 
     // We have one lint pass defined specially

--- a/src/librustc_mir/hair/cx/pattern.rs
+++ b/src/librustc_mir/hair/cx/pattern.rs
@@ -92,6 +92,7 @@ impl<'patcx, 'cx, 'tcx> PatCx<'patcx, 'cx, 'tcx> {
                             Some((const_expr, _const_ty)) => {
                                 match const_eval::const_expr_to_pat(self.cx.tcx,
                                                                     const_expr,
+                                                                    pat.id,
                                                                     pat.span) {
                                     Ok(pat) =>
                                         return self.to_pattern(&pat),

--- a/src/librustc_mir/hair/cx/pattern.rs
+++ b/src/librustc_mir/hair/cx/pattern.rs
@@ -90,9 +90,15 @@ impl<'patcx, 'cx, 'tcx> PatCx<'patcx, 'cx, 'tcx> {
                         let substs = Some(self.cx.tcx.node_id_item_substs(pat.id).substs);
                         match const_eval::lookup_const_by_id(self.cx.tcx, def_id, substs) {
                             Some((const_expr, _const_ty)) => {
-                                let pat = const_eval::const_expr_to_pat(self.cx.tcx, const_expr,
-                                                                        pat.span);
-                                return self.to_pattern(&pat);
+                                match const_eval::const_expr_to_pat(self.cx.tcx,
+                                                                    const_expr,
+                                                                    pat.span) {
+                                    Ok(pat) =>
+                                        return self.to_pattern(&pat),
+                                    Err(_) =>
+                                        self.cx.tcx.sess.span_bug(
+                                            pat.span, "illegal constant"),
+                                }
                             }
                             None => {
                                 self.cx.tcx.sess.span_bug(

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -1152,9 +1152,10 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn asinh(self) -> f32 {
-        match self {
-            NEG_INFINITY => NEG_INFINITY,
-            x => (x + ((x * x) + 1.0).sqrt()).ln(),
+        if self == NEG_INFINITY {
+            NEG_INFINITY
+        } else {
+            (self + ((self * self) + 1.0).sqrt()).ln()
         }
     }
 

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -1023,9 +1023,10 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn asinh(self) -> f64 {
-        match self {
-            NEG_INFINITY => NEG_INFINITY,
-            x => (x + ((x * x) + 1.0).sqrt()).ln(),
+        if self == NEG_INFINITY {
+            NEG_INFINITY
+        } else {
+            (self + ((self * self) + 1.0).sqrt()).ln()
         }
     }
 

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -1304,6 +1304,31 @@ impl CodeMap {
         return a;
     }
 
+    /// Check if the backtrace `subtrace` contains `suptrace` as a prefix.
+    pub fn more_specific_trace(&self,
+                              mut subtrace: ExpnId,
+                              suptrace: ExpnId)
+                              -> bool {
+        loop {
+            if subtrace == suptrace {
+                return true;
+            }
+
+            let stop = self.with_expn_info(subtrace, |opt_expn_info| {
+                if let Some(expn_info) = opt_expn_info {
+                    subtrace = expn_info.call_site.expn_id;
+                    false
+                } else {
+                    true
+                }
+            });
+
+            if stop {
+                return false;
+            }
+        }
+    }
+
     pub fn record_expansion(&self, expn_info: ExpnInfo) -> ExpnId {
         let mut expansions = self.expansions.borrow_mut();
         expansions.push(expn_info);

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -109,6 +109,8 @@ const KNOWN_FEATURES: &'static [(&'static str, &'static str, Option<u32>, Status
     // to bootstrap fix for #5723.
     ("issue_5723_bootstrap", "1.0.0", None, Accepted),
 
+    ("structural_match", "1.8.0", Some(31434), Active),
+
     // A way to temporarily opt out of opt in copy. This will *never* be accepted.
     ("opt_out_copy", "1.0.0", None, Removed),
 
@@ -303,6 +305,11 @@ pub const KNOWN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeGat
     ("reexport_test_harness_main", Normal, Ungated),
     ("link_args", Normal, Ungated),
     ("macro_escape", Normal, Ungated),
+
+    // RFC #1445.
+    ("structural_match", Whitelisted, Gated("structural_match",
+                                            "the semantics of constant patterns is \
+                                             not yet settled")),
 
     // Not used any more, but we can't feature gate it
     ("no_stack_check", Normal, Ungated),
@@ -676,7 +683,7 @@ impl<'a> Context<'a> {
     fn gate_feature(&self, feature: &str, span: Span, explain: &str) {
         let has_feature = self.has_feature(feature);
         debug!("gate_feature(feature = {:?}, span = {:?}); has? {}", feature, span, has_feature);
-        if !has_feature {
+        if !has_feature && !self.cm.span_allows_unstable(span) {
             emit_feature_err(self.span_handler, feature, span, GateIssue::Language, explain);
         }
     }

--- a/src/libsyntax_ext/Cargo.toml
+++ b/src/libsyntax_ext/Cargo.toml
@@ -10,4 +10,5 @@ crate-type = ["dylib"]
 
 [dependencies]
 fmt_macros = { path = "../libfmt_macros" }
+log = { path = "../liblog" }
 syntax = { path = "../libsyntax" }

--- a/src/libsyntax_ext/deriving/mod.rs
+++ b/src/libsyntax_ext/deriving/mod.rs
@@ -78,7 +78,10 @@ fn expand_derive(cx: &mut ExtCtxt,
                  mitem: &MetaItem,
                  annotatable: Annotatable)
                  -> Annotatable {
-    annotatable.map_item_or(|item| {
+    debug!("expand_derive: span = {:?}", span);
+    debug!("expand_derive: mitem = {:?}", mitem);
+    debug!("expand_derive: annotatable input  = {:?}", annotatable);
+    let annot = annotatable.map_item_or(|item| {
         item.map(|mut item| {
             if mitem.value_str().is_some() {
                 cx.span_err(mitem.span, "unexpected value in `derive`");
@@ -107,6 +110,45 @@ fn expand_derive(cx: &mut ExtCtxt,
                     continue;
                 }
 
+                // RFC #1445. `#[derive(Eq)]` adds a (trusted)
+                // `#[structural_match]` attribute.
+                if &tname[..] == "Eq" {
+                    // This span is **very** sensitive and crucial to
+                    // getting the stability behavior we want. What we
+                    // are doing is marking `#[structural_match]` with
+                    // the span of the `#[deriving(Eq)]` attribute
+                    // (the entire attribute, not just the `Eq` part),
+                    // but with the current backtrace. The current
+                    // backtrace will contain a topmost entry that IS
+                    // this `#[deriving(Eq)]` attribute and with the
+                    // "allow-unstable" flag set to true.
+                    //
+                    // Note that we do NOT use the span of the `Eq`
+                    // text itself.  You might think this is
+                    // equivalent, because the `Eq` appears within the
+                    // `#[deriving(Eq)]` attribute, and hence we would
+                    // inherit the "allows unstable" from the
+                    // backtrace.  But in fact this is not always the
+                    // case. The actual source text that led to
+                    // deriving can be `#[$attr]`, for example, where
+                    // `$attr == deriving(Eq)`. In that case, the
+                    // "#[structural_match]" would be considered to
+                    // originate not from the deriving call but from
+                    // text outside the deriving call, and hence would
+                    // be forbidden from using unstable
+                    // content.
+                    //
+                    // See tests src/run-pass/rfc1445 for
+                    // examples. --nmatsakis
+                    let span = Span { expn_id: cx.backtrace(), .. span };
+                    assert!(cx.parse_sess.codemap().span_allows_unstable(span));
+                    debug!("inserting structural_match with span {:?}", span);
+                    let structural_match = intern_and_get_ident("structural_match");
+                    item.attrs.push(cx.attribute(span,
+                                                 cx.meta_word(span,
+                                                              structural_match)));
+                }
+
                 // #[derive(Foo, Bar)] expands to #[derive_Foo] #[derive_Bar]
                 item.attrs.push(cx.attribute(titem.span, cx.meta_word(titem.span,
                     intern_and_get_ident(&format!("derive_{}", tname)))));
@@ -117,7 +159,9 @@ fn expand_derive(cx: &mut ExtCtxt,
     }, |a| {
         cx.span_err(span, "`derive` can only be applied to items");
         a
-    })
+    });
+    debug!("expand_derive: annotatable output = {:?}", annot);
+    annot
 }
 
 macro_rules! derive_traits {

--- a/src/libsyntax_ext/deriving/mod.rs
+++ b/src/libsyntax_ext/deriving/mod.rs
@@ -92,6 +92,9 @@ fn expand_derive(cx: &mut ExtCtxt,
                 cx.span_warn(mitem.span, "empty trait list in `derive`");
             }
 
+            let mut found_partial_eq = false;
+            let mut found_eq = false;
+
             for titem in traits.iter().rev() {
                 let tname = match titem.node {
                     MetaItemKind::Word(ref tname) => tname,
@@ -110,48 +113,54 @@ fn expand_derive(cx: &mut ExtCtxt,
                     continue;
                 }
 
-                // RFC #1445. `#[derive(Eq)]` adds a (trusted)
-                // `#[structural_match]` attribute.
                 if &tname[..] == "Eq" {
-                    // This span is **very** sensitive and crucial to
-                    // getting the stability behavior we want. What we
-                    // are doing is marking `#[structural_match]` with
-                    // the span of the `#[deriving(Eq)]` attribute
-                    // (the entire attribute, not just the `Eq` part),
-                    // but with the current backtrace. The current
-                    // backtrace will contain a topmost entry that IS
-                    // this `#[deriving(Eq)]` attribute and with the
-                    // "allow-unstable" flag set to true.
-                    //
-                    // Note that we do NOT use the span of the `Eq`
-                    // text itself.  You might think this is
-                    // equivalent, because the `Eq` appears within the
-                    // `#[deriving(Eq)]` attribute, and hence we would
-                    // inherit the "allows unstable" from the
-                    // backtrace.  But in fact this is not always the
-                    // case. The actual source text that led to
-                    // deriving can be `#[$attr]`, for example, where
-                    // `$attr == deriving(Eq)`. In that case, the
-                    // "#[structural_match]" would be considered to
-                    // originate not from the deriving call but from
-                    // text outside the deriving call, and hence would
-                    // be forbidden from using unstable
-                    // content.
-                    //
-                    // See tests src/run-pass/rfc1445 for
-                    // examples. --nmatsakis
-                    let span = Span { expn_id: cx.backtrace(), .. span };
-                    assert!(cx.parse_sess.codemap().span_allows_unstable(span));
-                    debug!("inserting structural_match with span {:?}", span);
-                    let structural_match = intern_and_get_ident("structural_match");
-                    item.attrs.push(cx.attribute(span,
-                                                 cx.meta_word(span,
-                                                              structural_match)));
+                    found_eq = true;
+                } else if &tname[..] == "PartialEq" {
+                    found_partial_eq = true;
                 }
 
                 // #[derive(Foo, Bar)] expands to #[derive_Foo] #[derive_Bar]
                 item.attrs.push(cx.attribute(titem.span, cx.meta_word(titem.span,
                     intern_and_get_ident(&format!("derive_{}", tname)))));
+            }
+
+            // RFC #1445. `#[derive(PartialEq, Eq)]` adds a (trusted)
+            // `#[structural_match]` attribute.
+            if found_partial_eq && found_eq {
+                // This span is **very** sensitive and crucial to
+                // getting the stability behavior we want. What we are
+                // doing is marking `#[structural_match]` with the
+                // span of the `#[deriving(...)]` attribute (the
+                // entire attribute, not just the `PartialEq` or `Eq`
+                // part), but with the current backtrace. The current
+                // backtrace will contain a topmost entry that IS this
+                // `#[deriving(...)]` attribute and with the
+                // "allow-unstable" flag set to true.
+                //
+                // Note that we do NOT use the span of the `Eq`
+                // text itself. You might think this is
+                // equivalent, because the `Eq` appears within the
+                // `#[deriving(Eq)]` attribute, and hence we would
+                // inherit the "allows unstable" from the
+                // backtrace.  But in fact this is not always the
+                // case. The actual source text that led to
+                // deriving can be `#[$attr]`, for example, where
+                // `$attr == deriving(Eq)`. In that case, the
+                // "#[structural_match]" would be considered to
+                // originate not from the deriving call but from
+                // text outside the deriving call, and hence would
+                // be forbidden from using unstable
+                // content.
+                //
+                // See tests src/run-pass/rfc1445 for
+                // examples. --nmatsakis
+                let span = Span { expn_id: cx.backtrace(), .. span };
+                assert!(cx.parse_sess.codemap().span_allows_unstable(span));
+                debug!("inserting structural_match with span {:?}", span);
+                let structural_match = intern_and_get_ident("structural_match");
+                item.attrs.push(cx.attribute(span,
+                                             cx.meta_word(span,
+                                                          structural_match)));
             }
 
             item

--- a/src/libsyntax_ext/lib.rs
+++ b/src/libsyntax_ext/lib.rs
@@ -24,6 +24,7 @@
 #![feature(str_char)]
 
 extern crate fmt_macros;
+#[macro_use] extern crate log;
 #[macro_use]
 extern crate syntax;
 

--- a/src/test/compile-fail/issue-6804.rs
+++ b/src/test/compile-fail/issue-6804.rs
@@ -24,9 +24,17 @@ fn main() { //~ ERROR compilation successful
         _ => {},
     };
     //~^^^ WARNING unmatchable NaN in pattern, use the is_nan method in a guard instead
+    //~| WARNING floating point constants cannot be used
+    //~| WARNING this was previously accepted
+    //~| WARNING floating point constants cannot be used
+    //~| WARNING this was previously accepted
     match [x, 1.0] {
         [NAN, _] => {},
         _ => {},
     };
     //~^^^ WARNING unmatchable NaN in pattern, use the is_nan method in a guard instead
+    //~| WARNING floating point constants cannot be used
+    //~| WARNING this was previously accepted
+    //~| WARNING floating point constants cannot be used
+    //~| WARNING this was previously accepted
 }

--- a/src/test/compile-fail/issue-6804.rs
+++ b/src/test/compile-fail/issue-6804.rs
@@ -26,15 +26,11 @@ fn main() { //~ ERROR compilation successful
     //~^^^ WARNING unmatchable NaN in pattern, use the is_nan method in a guard instead
     //~| WARNING floating point constants cannot be used
     //~| WARNING this was previously accepted
-    //~| WARNING floating point constants cannot be used
-    //~| WARNING this was previously accepted
     match [x, 1.0] {
         [NAN, _] => {},
         _ => {},
     };
     //~^^^ WARNING unmatchable NaN in pattern, use the is_nan method in a guard instead
-    //~| WARNING floating point constants cannot be used
-    //~| WARNING this was previously accepted
     //~| WARNING floating point constants cannot be used
     //~| WARNING this was previously accepted
 }

--- a/src/test/compile-fail/rfc1445/feature-gate.rs
+++ b/src/test/compile-fail/rfc1445/feature-gate.rs
@@ -1,0 +1,36 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that structural match is only permitted with a feature gate,
+// and that if a feature gate is supplied, it permits the type to be
+// used in a match.
+
+// revisions: with_gate no_gate
+
+#![allow(dead_code)]
+#![deny(future_incompatible)]
+#![feature(rustc_attrs)]
+#![cfg_attr(with_gate, feature(structural_match))]
+
+#[structural_match] //[no_gate]~ ERROR semantics of constant patterns is not yet settled
+struct Foo {
+    x: u32
+}
+
+const FOO: Foo = Foo { x: 0 };
+
+#[rustc_error]
+fn main() { //[with_gate]~ ERROR compilation successful
+    let y = Foo { x: 1 };
+    match y {
+        FOO => { }
+        _ => { }
+    }
+}

--- a/src/test/compile-fail/rfc1445/match-forbidden-without-eq.rs
+++ b/src/test/compile-fail/rfc1445/match-forbidden-without-eq.rs
@@ -24,7 +24,7 @@ fn main() {
     let y = Foo { x: 1 };
     match y {
         FOO => { }
-        //~^ ERROR must be annotated with `#[derive(Eq)]`
+        //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
         //~| WARNING will become a hard error
         _ => { }
     }

--- a/src/test/compile-fail/rfc1445/match-forbidden-without-eq.rs
+++ b/src/test/compile-fail/rfc1445/match-forbidden-without-eq.rs
@@ -1,0 +1,39 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(dead_code)]
+#![deny(future_incompatible)]
+
+use std::f32;
+
+#[derive(PartialEq)]
+struct Foo {
+    x: u32
+}
+
+const FOO: Foo = Foo { x: 0 };
+
+fn main() {
+    let y = Foo { x: 1 };
+    match y {
+        FOO => { }
+        //~^ ERROR must be annotated with `#[derive(Eq)]`
+        //~| WARNING will become a hard error
+        _ => { }
+    }
+
+    let x = 0.0;
+    match x {
+        f32::INFINITY => { }
+        //~^ ERROR floating point constants cannot be used in patterns
+        //~| WARNING will become a hard error
+        _ => { }
+    }
+}

--- a/src/test/compile-fail/rfc1445/match-requires-both-partialeq-and-eq.rs
+++ b/src/test/compile-fail/rfc1445/match-requires-both-partialeq-and-eq.rs
@@ -1,0 +1,35 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(dead_code)]
+#![deny(future_incompatible)]
+
+#[derive(Eq)]
+struct Foo {
+    x: u32
+}
+
+impl PartialEq for Foo {
+    fn eq(&self, _: &Foo) -> bool {
+        false // ha ha sucker!
+    }
+}
+
+const FOO: Foo = Foo { x: 0 };
+
+fn main() {
+    let y = Foo { x: 1 };
+    match y {
+        FOO => { }
+        //~^ ERROR must be annotated with `#[derive(PartialEq, Eq)]`
+        //~| WARNING will become a hard error
+        _ => { }
+    }
+}

--- a/src/test/debuginfo/constant-in-match-pattern.rs
+++ b/src/test/debuginfo/constant-in-match-pattern.rs
@@ -21,15 +21,18 @@
 
 const CONSTANT: u64 = 3;
 
+#[derive(PartialEq, Eq)]
 struct Struct {
     a: isize,
     b: usize,
 }
 const STRUCT: Struct = Struct { a: 1, b: 2 };
 
+#[derive(PartialEq, Eq)]
 struct TupleStruct(u32);
 const TUPLE_STRUCT: TupleStruct = TupleStruct(4);
 
+#[derive(PartialEq, Eq)]
 enum Enum {
     Variant1(char),
     Variant2 { a: u8 },

--- a/src/test/run-pass/associated-const-match-patterns.rs
+++ b/src/test/run-pass/associated-const-match-patterns.rs
@@ -17,6 +17,7 @@ use empty_struct::XEmpty2 as XFoo;
 
 struct Foo;
 
+#[derive(PartialEq, Eq)]
 enum Bar {
     Var1,
     Var2,

--- a/src/test/run-pass/empty-struct-braces.rs
+++ b/src/test/run-pass/empty-struct-braces.rs
@@ -18,7 +18,10 @@ use empty_struct::*;
 
 struct Empty1 {}
 struct Empty2;
+
+#[derive(PartialEq, Eq)]
 struct Empty3 {}
+
 const Empty3: Empty3 = Empty3 {};
 
 enum E {

--- a/src/test/run-pass/issue-12860.rs
+++ b/src/test/run-pass/issue-12860.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
-
 #![feature(collections)]
 
 extern crate collections;

--- a/src/test/run-pass/match-arm-statics.rs
+++ b/src/test/run-pass/match-arm-statics.rs
@@ -9,18 +9,24 @@
 // except according to those terms.
 
 
+#[derive(PartialEq, Eq)]
 struct NewBool(bool);
 
+#[derive(PartialEq, Eq)]
 enum Direction {
     North,
     East,
     South,
     West
 }
+
+#[derive(PartialEq, Eq)]
 struct Foo {
     bar: Option<Direction>,
     baz: NewBool
 }
+
+#[derive(PartialEq, Eq)]
 enum EnumWithStructVariants {
     Variant1(bool),
     Variant2 {
@@ -37,7 +43,7 @@ const VARIANT2_NORTH: EnumWithStructVariants = EnumWithStructVariants::Variant2 
     dir: Direction::North };
 
 pub mod glfw {
-    #[derive(Copy, Clone)]
+    #[derive(Copy, Clone, PartialEq, Eq)]
     pub struct InputState(usize);
 
     pub const RELEASE  : InputState = InputState(0);
@@ -82,6 +88,7 @@ fn issue_14576() {
         _ => unreachable!()
     }
 
+    #[derive(PartialEq, Eq)]
     enum C { D = 3, E = 4 }
     const F : C = C::D;
 
@@ -89,6 +96,7 @@ fn issue_14576() {
 }
 
 fn issue_13731() {
+    #[derive(PartialEq, Eq)]
     enum A { AA(()) }
     const B: A = A::AA(());
 
@@ -99,6 +107,7 @@ fn issue_13731() {
 
 fn issue_15393() {
     #![allow(dead_code)]
+    #[derive(PartialEq, Eq)]
     struct Flags {
         bits: usize
     }

--- a/src/test/run-pass/rfc1445/eq-allows-match-on-ty-in-macro.rs
+++ b/src/test/run-pass/rfc1445/eq-allows-match-on-ty-in-macro.rs
@@ -1,0 +1,32 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(dead_code)]
+
+macro_rules! foo {
+    (#[$attr:meta] $x:ident) => {
+        #[$attr]
+        struct $x {
+            x: u32
+        }
+    }
+}
+
+foo! { #[derive(PartialEq, Eq)] Foo }
+
+const FOO: Foo = Foo { x: 0 };
+
+fn main() {
+    let y = Foo { x: 1 };
+    match y {
+        FOO => { }
+        _ => { }
+    }
+}

--- a/src/test/run-pass/rfc1445/eq-allows-match.rs
+++ b/src/test/run-pass/rfc1445/eq-allows-match.rs
@@ -1,0 +1,26 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(dead_code)]
+
+#[derive(PartialEq, Eq)]
+struct Foo {
+    x: u32
+}
+
+const FOO: Foo = Foo { x: 0 };
+
+fn main() {
+    let y = Foo { x: 1 };
+    match y {
+        FOO => { }
+        _ => { }
+    }
+}


### PR DESCRIPTION
This implements [RFC 1445](https://github.com/rust-lang/rfcs/blob/master/text/1445-restrict-constants-in-patterns.md). The primary change is to limit the types of constants used in patterns to those that _derive_ `Eq` (note that implementing `Eq` is not sufficient). This has two main effects:
1. Floating point constants are linted, and will eventually be disallowed. This is because floating point constants do not implement `Eq` but only `PartialEq`. This check replaces the existing special case code that aimed to detect the use of `NaN`.
2. Structs and enums must derive `Eq` to be usable within a match.

This is a [breaking-change]: if you encounter a problem, you are most likely using a constant in an expression where the type of the constant is some struct that does not currently implement
`Eq`. Something like the following:

``` rust
struct SomeType { ... }
const SOME_CONST: SomeType = ...;

match foo {
    SOME_CONST => ...
}
```

The easiest and most future compatible fix is to annotate the type in question with `#[derive(Eq)]` (note that merely _implementing_ `Eq` is not enough, it must be _derived_):

``` rust
struct SomeType { ... }
const SOME_CONST: SomeType = ...;

match foo {
    SOME_CONST => ...
}
```

Another good option is to rewrite the match arm to use an `if` condition (this is also particularly good for floating point types, which implement `PartialEq` but not `Eq`):

``` rust
match foo {
    c if c == SOME_CONST => ...
}
```

Finally, a third alternative is to tag the type with `#[structural_match]`; but this is not recommended, as the attribute is never expected to be stabilized. Please see RFC #1445 for more details.

cc https://github.com/rust-lang/rust/issues/31434

r? @pnkfelix 
