### PR TITLE
rBreak Critical Edges and other MIR work

### DIFF
--- a/src/librustc_data_structures/bitvec.rs
+++ b/src/librustc_data_structures/bitvec.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 /// A very simple BitVector type.
+#[derive(Clone)]
 pub struct BitVector {
     data: Vec<u64>,
 }

--- a/src/librustc_data_structures/bitvec.rs
+++ b/src/librustc_data_structures/bitvec.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::iter::FromIterator;
+
 /// A very simple BitVector type.
 #[derive(Clone)]
 pub struct BitVector {
@@ -51,7 +53,9 @@ impl BitVector {
     pub fn grow(&mut self, num_bits: usize) {
         let num_words = u64s(num_bits);
         let extra_words = self.data.len() - num_words;
-        self.data.extend((0..extra_words).map(|_| 0));
+        if extra_words > 0 {
+            self.data.extend((0..extra_words).map(|_| 0));
+        }
     }
 
     /// Iterates over indexes of set bits in a sorted order
@@ -91,6 +95,27 @@ impl<'a> Iterator for BitVectorIter<'a> {
         self.current >>= 1; // shift otherwise overflows for 0b1000_0000_…_0000
         self.idx += offset + 1;
         return Some(self.idx - 1);
+    }
+}
+
+impl FromIterator<bool> for BitVector {
+    fn from_iter<I>(iter: I) -> BitVector where I: IntoIterator<Item=bool> {
+        let iter = iter.into_iter();
+        let (len, _) = iter.size_hint();
+        // Make the minimum length for the bitvector 64 bits since that's
+        // the smallest non-zero size anyway.
+        let len = if len < 64 { 64 } else { len };
+        let mut bv = BitVector::new(len);
+        for (idx, val) in iter.enumerate() {
+            if idx > len {
+                bv.grow(idx);
+            }
+            if val {
+                bv.insert(idx);
+            }
+        }
+
+        bv
     }
 }
 

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -876,10 +876,7 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
             passes.push_pass(box mir::transform::remove_dead_blocks::RemoveDeadBlocks);
             passes.push_pass(box mir::transform::type_check::TypeckMir);
             passes.push_pass(box mir::transform::simplify_cfg::SimplifyCfg);
-            // Late passes
-            passes.push_pass(box mir::transform::no_landing_pads::NoLandingPads);
             passes.push_pass(box mir::transform::remove_dead_blocks::RemoveDeadBlocks);
-            passes.push_pass(box mir::transform::erase_regions::EraseRegions);
             // And run everything.
             passes.run_passes(tcx, &mut mir_map);
         });
@@ -933,22 +930,24 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
 /// Run the translation phase to LLVM, after which the AST and analysis can
 pub fn phase_4_translate_to_llvm<'tcx>(tcx: &TyCtxt<'tcx>,
                                        mut mir_map: MirMap<'tcx>,
-                                       analysis: ty::CrateAnalysis)
-                                       -> trans::CrateTranslation {
+                                       analysis: ty::CrateAnalysis) -> trans::CrateTranslation {
     let time_passes = tcx.sess.time_passes();
 
     time(time_passes,
          "resolving dependency formats",
          || dependency_format::calculate(&tcx.sess));
 
-    time(time_passes,
-         "erasing regions from MIR",
-         || mir::transform::erase_regions::erase_regions(tcx, &mut mir_map));
+    // Run the passes that transform the MIR into a more suitable for translation
+    // to LLVM code.
+    time(time_passes, "Prepare MIR codegen passes", || {
+        let mut passes = ::rustc::mir::transform::Passes::new();
+        passes.push_pass(box mir::transform::no_landing_pads::NoLandingPads);
+        passes.push_pass(box mir::transform::remove_dead_blocks::RemoveDeadBlocks);
+        passes.push_pass(box mir::transform::erase_regions::EraseRegions);
+        passes.push_pass(box mir::transform::break_critical_edges::BreakCriticalEdges);
+        passes.run_passes(tcx, &mut mir_map);
+    });
 
-    time(time_passes, "breaking critical edges",
-         || mir::transform::break_critical_edges::break_critical_edges(&mut mir_map));
-
-    // Option dance to work around the lack of stack once closures.
     time(time_passes,
          "translation",
          move || trans::trans_crate(tcx, &mir_map, analysis))

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -40,3 +40,4 @@ mod hair;
 pub mod mir_map;
 pub mod pretty;
 pub mod transform;
+pub mod traversal;

--- a/src/librustc_mir/transform/break_critical_edges.rs
+++ b/src/librustc_mir/transform/break_critical_edges.rs
@@ -1,0 +1,180 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+use std::mem;
+
+use rustc_back::slice;
+use rustc::mir::repr::*;
+use rustc::mir::mir_map::MirMap;
+
+use traversal;
+
+/**
+ * Breaks critical edges in the MIR.
+ *
+ * Critical edges are edges that are neither the only edge leaving a
+ * block, nor the only edge entering one.
+ *
+ * When you want something to happen "along" an edge, you can either
+ * do at the end of the predecessor block, or at the start of the
+ * successor block. Critical edges have to be broken in order to prevent
+ * "edge actions" from affecting other edges.
+ *
+ * This function will break those edges by inserting new blocks along them.
+ *
+ * A special case is Drop and Call terminators with unwind/cleanup successors,
+ * They use `invoke` in LLVM, which terminates a block, meaning that code cannot
+ * be inserted after them, so even if an edge is the only edge leaving a block
+ * like that, we still insert blocks if the edge is one of many entering the
+ * target.
+ *
+ * NOTE: Simplify CFG will happily undo most of the work this pass does.
+ *
+ */
+pub fn break_critical_edges<'tcx>(mir_map: &mut MirMap<'tcx>) {
+    for (_, mir) in &mut mir_map.map {
+        break_critical_edges_fn(mir);
+    }
+}
+
+/*
+ * Predecessor map for tracking the predecessors of a block
+ */
+struct PredMap {
+    preds: Vec<BlockPredecessors>
+}
+
+/**
+ * Most blocks only have one predecessor, so we can cut down on
+ * some allocation by not using Vec until we have more than one.
+ */
+#[derive(Clone)]
+enum BlockPredecessors {
+    None,
+    One(BasicBlock),
+    Some(Vec<BasicBlock>)
+}
+
+impl PredMap {
+    pub fn new(n: usize) -> PredMap {
+        let preds = vec![BlockPredecessors::None; n];
+
+        PredMap {
+            preds: preds
+        }
+    }
+
+    fn ensure_len(&mut self, bb: BasicBlock) {
+        let idx = bb.index();
+        while self.preds.len() <= idx {
+            self.preds.push(BlockPredecessors::None);
+        }
+    }
+
+    pub fn add_pred(&mut self, target: BasicBlock, pred: BasicBlock) {
+        self.ensure_len(target);
+
+        let preds = mem::replace(&mut self.preds[target.index()], BlockPredecessors::None);
+        match preds {
+            BlockPredecessors::None => {
+                self.preds[target.index()] = BlockPredecessors::One(pred);
+            }
+            BlockPredecessors::One(bb) => {
+                self.preds[target.index()] = BlockPredecessors::Some(vec![bb, pred]);
+            }
+            BlockPredecessors::Some(mut preds) => {
+                preds.push(pred);
+                self.preds[target.index()] = BlockPredecessors::Some(preds);
+            }
+        }
+    }
+
+    pub fn remove_pred(&mut self, target: BasicBlock, pred: BasicBlock) {
+        self.ensure_len(target);
+
+        let preds = mem::replace(&mut self.preds[target.index()], BlockPredecessors::None);
+        match preds {
+            BlockPredecessors::None => {}
+            BlockPredecessors::One(bb) if bb == pred => {}
+
+            BlockPredecessors::One(bb) => {
+                self.preds[target.index()] = BlockPredecessors::One(bb);
+            }
+
+            BlockPredecessors::Some(mut preds) => {
+                preds.retain(|&bb| bb != pred);
+                self.preds[target.index()] = BlockPredecessors::Some(preds);
+            }
+        }
+    }
+
+    pub fn get_preds(&self, bb: BasicBlock) -> &[BasicBlock] {
+        match self.preds[bb.index()] {
+            BlockPredecessors::None => &[],
+            BlockPredecessors::One(ref bb) => slice::ref_slice(bb),
+            BlockPredecessors::Some(ref bbs) => &bbs[..]
+        }
+    }
+}
+
+
+fn break_critical_edges_fn(mir: &mut Mir) {
+    let mut pred_map = PredMap::new(mir.basic_blocks.len());
+
+    // Build the precedecessor map for the MIR
+    for (pred, data) in traversal::preorder(mir) {
+        if let Some(ref term) = data.terminator {
+            for &tgt in term.successors().iter() {
+                pred_map.add_pred(tgt, pred);
+            }
+        }
+    }
+
+    // We need a place to store the new blocks generated
+    let mut new_blocks = Vec::new();
+
+    let bbs = mir.all_basic_blocks();
+    let cur_len = mir.basic_blocks.len();
+
+    for &bb in &bbs {
+        let data = mir.basic_block_data_mut(bb);
+
+        if let Some(ref mut term) = data.terminator {
+            let is_invoke = term_is_invoke(term);
+            let succs = term.successors_mut();
+            if succs.len() > 1 || (succs.len() > 0 && is_invoke) {
+                for tgt in succs {
+                    let num_preds = pred_map.get_preds(*tgt).len();
+                    if num_preds > 1 {
+                        // It's a critical edge, break it
+                        let goto = Terminator::Goto { target: *tgt };
+                        let data = BasicBlockData::new(Some(goto));
+                        // Get the index it will be when inserted into the MIR
+                        let idx = cur_len + new_blocks.len();
+                        new_blocks.push(data);
+                        *tgt = BasicBlock::new(idx);
+                    }
+                }
+            }
+        }
+    }
+
+    debug!("Broke {} N edges", new_blocks.len());
+
+    mir.basic_blocks.extend_from_slice(&new_blocks);
+}
+
+// Returns true if the terminator would use an invoke in LLVM.
+fn term_is_invoke(term: &Terminator) -> bool {
+    match *term {
+        Terminator::Call { cleanup: Some(_), .. } |
+        Terminator::Drop { unwind: Some(_), .. } => true,
+        _ => false
+    }
+}

--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -13,3 +13,4 @@ pub mod simplify_cfg;
 pub mod erase_regions;
 pub mod no_landing_pads;
 pub mod type_check;
+pub mod break_critical_edges;

--- a/src/librustc_mir/traversal.rs
+++ b/src/librustc_mir/traversal.rs
@@ -163,7 +163,7 @@ impl<'a, 'tcx> Postorder<'a, 'tcx> {
         // Now that the top of the stack has no successors we can traverse, each item will
         // be popped off during iteration until we get back to `A`. This yeilds [E, D, B].
         //
-        // When we yeild `B` and call `traverse_successor`, We push `C` to the stack, but
+        // When we yield `B` and call `traverse_successor`, we push `C` to the stack, but
         // since we've already visited `E`, that child isn't added to the stack. The last
         // two iterations yield `C` and finally `A` for a final traversal of [E, D, B, C, A]
         loop {

--- a/src/librustc_mir/traversal.rs
+++ b/src/librustc_mir/traversal.rs
@@ -1,0 +1,276 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::vec;
+
+use rustc_data_structures::bitvec::BitVector;
+
+use rustc::mir::repr::*;
+
+/// Preorder traversal of a graph.
+///
+/// Preorder traversal is when each node is visited before an of it's
+/// successors
+///
+///         A
+///        / \
+///       /   \
+///      B     C
+///       \   /
+///        \ /
+///         D
+///
+/// A preorder traversal of this graph is either `A B D C` or `A C D B`
+#[derive(Clone)]
+pub struct Preorder<'a, 'tcx: 'a> {
+    mir: &'a Mir<'tcx>,
+    visited: BitVector,
+    worklist: Vec<BasicBlock>,
+}
+
+impl<'a, 'tcx> Preorder<'a, 'tcx> {
+    pub fn new(mir: &'a Mir<'tcx>, root: BasicBlock) -> Preorder<'a, 'tcx> {
+        let worklist = vec![root];
+
+        Preorder {
+            mir: mir,
+            visited: BitVector::new(mir.basic_blocks.len()),
+            worklist: worklist
+        }
+    }
+}
+
+pub fn preorder<'a, 'tcx>(mir: &'a Mir<'tcx>) -> Preorder<'a, 'tcx> {
+    Preorder::new(mir, START_BLOCK)
+}
+
+impl<'a, 'tcx> Iterator for Preorder<'a, 'tcx> {
+    type Item = (BasicBlock, &'a BasicBlockData<'tcx>);
+
+    fn next(&mut self) -> Option<(BasicBlock, &'a BasicBlockData<'tcx>)> {
+        while let Some(idx) = self.worklist.pop() {
+            if !self.visited.insert(idx.index()) {
+                continue;
+            }
+
+            let data = self.mir.basic_block_data(idx);
+
+            if let Some(ref term) = data.terminator {
+                for &succ in term.successors().iter() {
+                    self.worklist.push(succ);
+                }
+            }
+
+            return Some((idx, data));
+        }
+
+        None
+    }
+}
+
+/// Postorder traversal of a graph.
+///
+/// Postorder traversal is when each node is visited after all of it's
+/// successors, except when the successor is only reachable by a back-edge
+///
+///         A
+///        / \
+///       /   \
+///      B     C
+///       \   /
+///        \ /
+///         D
+///
+/// A Postorder traversal of this graph is `D B C A` or `D C B A`
+pub struct Postorder<'a, 'tcx: 'a> {
+    mir: &'a Mir<'tcx>,
+    visited: BitVector,
+    visit_stack: Vec<(BasicBlock, vec::IntoIter<BasicBlock>)>
+}
+
+impl<'a, 'tcx> Postorder<'a, 'tcx> {
+    pub fn new(mir: &'a Mir<'tcx>, root: BasicBlock) -> Postorder<'a, 'tcx> {
+        let mut po = Postorder {
+            mir: mir,
+            visited: BitVector::new(mir.basic_blocks.len()),
+            visit_stack: Vec::new()
+        };
+
+
+        let data = po.mir.basic_block_data(root);
+
+        if let Some(ref term) = data.terminator {
+            po.visited.insert(root.index());
+
+            let succs = term.successors().into_owned().into_iter();
+
+            po.visit_stack.push((root, succs));
+            po.traverse_successor();
+        }
+
+        po
+    }
+
+    fn traverse_successor(&mut self) {
+        // This is quite a complex loop due to 1. the borrow checker not liking it much
+        // and 2. what exactly is going on is not clear
+        //
+        // It does the actual traversal of the graph, while the `next` method on the iterator
+        // just pops off of the stack. `visit_stack` is a stack containing pairs of nodes and
+        // iterators over the sucessors of those nodes. Each iteration attempts to get the next
+        // node from the top of the stack, then pushes that node and an iterator over the
+        // successors to the top of the stack. This loop only grows `visit_stack`, stopping when
+        // we reach a child that has no children that we haven't already visited.
+        //
+        // For a graph that looks like this:
+        //
+        //         A
+        //        / \
+        //       /   \
+        //      B     C
+        //      |     |
+        //      |     |
+        //      D     |
+        //       \   /
+        //        \ /
+        //         E
+        //
+        // The state of the stack starts out with just the root node (`A` in this case);
+        //     [(A, [B, C])]
+        //
+        // When the first call to `traverse_sucessor` happens, the following happens:
+        //
+        //     [(B, [D]),  // `B` taken from the successors of `A`, pushed to the
+        //                 // top of the stack along with the successors of `B`
+        //      (A, [C])]
+        //
+        //     [(D, [E]),  // `D` taken from successors of `B`, pushed to stack
+        //      (B, []),
+        //      (A, [C])]
+        //
+        //     [(E, []),   // `E` taken from successors of `D`, pushed to stack
+        //      (D, []),
+        //      (B, []),
+        //      (A, [C])]
+        //
+        // Now that the top of the stack has no successors we can traverse, each item will
+        // be popped off during iteration until we get back to `A`. This yeilds [E, D, B].
+        //
+        // When we yeild `B` and call `traverse_successor`, We push `C` to the stack, but
+        // since we've already visited `E`, that child isn't added to the stack. The last
+        // two iterations yield `C` and finally `A` for a final traversal of [E, D, B, C, A]
+        loop {
+            let bb = if let Some(&mut (_, ref mut iter)) = self.visit_stack.last_mut() {
+                if let Some(bb) = iter.next() {
+                    bb
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            };
+
+            if self.visited.insert(bb.index()) {
+                let data = self.mir.basic_block_data(bb);
+
+                if let Some(ref term) = data.terminator {
+                    let succs = term.successors().into_owned().into_iter();
+                    self.visit_stack.push((bb, succs));
+                }
+            }
+        }
+    }
+}
+
+pub fn postorder<'a, 'tcx>(mir: &'a Mir<'tcx>) -> Postorder<'a, 'tcx> {
+    Postorder::new(mir, START_BLOCK)
+}
+
+impl<'a, 'tcx> Iterator for Postorder<'a, 'tcx> {
+    type Item = (BasicBlock, &'a BasicBlockData<'tcx>);
+
+    fn next(&mut self) -> Option<(BasicBlock, &'a BasicBlockData<'tcx>)> {
+        let next = self.visit_stack.pop();
+        if next.is_some() {
+            self.traverse_successor();
+        }
+
+        next.map(|(bb, _)| {
+            let data = self.mir.basic_block_data(bb);
+            (bb, data)
+        })
+    }
+}
+
+/// Reverse postorder traversal of a graph
+///
+/// Reverse postorder is the reverse order of a postorder traversal.
+/// This is different to a preorder traversal and represents a natural
+/// linearisation of control-flow.
+///
+///         A
+///        / \
+///       /   \
+///      B     C
+///       \   /
+///        \ /
+///         D
+///
+/// A reverse postorder traversal of this graph is either `A B C D` or `A C B D`
+/// Note that for a graph containing no loops (i.e. A DAG), this is equivalent to
+/// a topological sort.
+///
+/// Construction of a `ReversePostorder` traversal requires doing a full
+/// postorder traversal of the graph, therefore this traversal should be
+/// constructed as few times as possible. Use the `reset` method to be able
+/// to re-use the traversal
+#[derive(Clone)]
+pub struct ReversePostorder<'a, 'tcx: 'a> {
+    mir: &'a Mir<'tcx>,
+    blocks: Vec<BasicBlock>,
+    idx: usize
+}
+
+impl<'a, 'tcx> ReversePostorder<'a, 'tcx> {
+    pub fn new(mir: &'a Mir<'tcx>, root: BasicBlock) -> ReversePostorder<'a, 'tcx> {
+        let blocks : Vec<_> = Postorder::new(mir, root).map(|(bb, _)| bb).collect();
+
+        let len = blocks.len();
+
+        ReversePostorder {
+            mir: mir,
+            blocks: blocks,
+            idx: len
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.idx = self.blocks.len();
+    }
+}
+
+
+pub fn reverse_postorder<'a, 'tcx>(mir: &'a Mir<'tcx>) -> ReversePostorder<'a, 'tcx> {
+    ReversePostorder::new(mir, START_BLOCK)
+}
+
+impl<'a, 'tcx> Iterator for ReversePostorder<'a, 'tcx> {
+    type Item = (BasicBlock, &'a BasicBlockData<'tcx>);
+
+    fn next(&mut self) -> Option<(BasicBlock, &'a BasicBlockData<'tcx>)> {
+        if self.idx == 0 { return None; }
+        self.idx -= 1;
+
+        self.blocks.get(self.idx).map(|&bb| {
+            let data = self.mir.basic_block_data(bb);
+            (bb, data)
+        })
+    }
+}

--- a/src/librustc_trans/basic_block.rs
+++ b/src/librustc_trans/basic_block.rs
@@ -49,4 +49,10 @@ impl BasicBlock {
             _ => None
         }
     }
+
+    pub fn delete(self) {
+        unsafe {
+            llvm::LLVMDeleteBasicBlock(self.0);
+        }
+    }
 }

--- a/src/librustc_trans/mir/mod.rs
+++ b/src/librustc_trans/mir/mod.rs
@@ -19,7 +19,7 @@ use common::{self, Block, BlockAndBuilder, FunctionContext};
 use std::ops::Deref;
 use std::rc::Rc;
 
-use trans::basic_block::BasicBlock;
+use basic_block::BasicBlock;
 
 use rustc_data_structures::bitvec::BitVector;
 

--- a/src/librustc_trans/mir/mod.rs
+++ b/src/librustc_trans/mir/mod.rs
@@ -20,6 +20,9 @@ use std::ops::Deref;
 use std::rc::Rc;
 
 use self::lvalue::{LvalueRef, get_dataptr, get_meta};
+use rustc_mir::traversal;
+
+use self::lvalue::LvalueRef;
 use self::operand::OperandRef;
 
 #[derive(Clone)]
@@ -152,8 +155,9 @@ pub fn trans_mir<'blk, 'tcx>(fcx: &'blk FunctionContext<'blk, 'tcx>) {
         args: args,
     };
 
-    // Translate the body of each block
-    for &bb in &mir_blocks {
+    let rpo = traversal::reverse_postorder(mir);
+    // Translate the body of each block using reverse postorder
+    for (bb, _) in rpo {
         mircx.trans_block(bb);
     }
 

--- a/src/test/run-pass/mir_trans_critical_edge.rs
+++ b/src/test/run-pass/mir_trans_critical_edge.rs
@@ -1,0 +1,53 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This code produces a CFG with critical edges that, if we don't
+// handle properly, will cause invalid codegen.
+
+#![feature(rustc_attrs)]
+
+enum State {
+    Both,
+    Front,
+    Back
+}
+
+pub struct Foo<A: Iterator, B: Iterator> {
+    state: State,
+    a: A,
+    b: B
+}
+
+impl<A, B> Foo<A, B>
+where A: Iterator, B: Iterator<Item=A::Item>
+{
+    // This is the function we care about
+    #[rustc_mir]
+    fn next(&mut self) -> Option<A::Item> {
+        match self.state {
+            State::Both => match self.a.next() {
+                elt @ Some(..) => elt,
+                None => {
+                    self.state = State::Back;
+                    self.b.next()
+                }
+            },
+            State::Front => self.a.next(),
+            State::Back => self.b.next(),
+        }
+    }
+}
+
+// Make sure we actually translate a version of the function
+pub fn do_stuff(mut f: Foo<Box<Iterator<Item=u32>>, Box<Iterator<Item=u32>>>) {
+    let _x = f.next();
+}
+
+fn main() {}


### PR DESCRIPTION
This PR is built on top of #32080.

This adds the basic depth-first traversals for MIR, preorder, postorder and reverse postorder. The MIR blocks are now translated using reverse postorder. There is also a transform for breaking critical edges, which includes the edges from `invoke`d calls (`Drop` and `Call`), to account for the fact that we can't add code after an `invoke`. It also stops generating the intermediate block (since the transform essentially does it if necessary already).

The kinds of cases this deals with are difficult to produce, so the test is the one I managed to get. However, it seems to bootstrap with `-Z orbit`, which it didn't before my changes.
