### PR TITLE
Fix minor typos in doc.rust-lang.org/book

### DIFF
--- a/src/doc/book/getting-started.md
+++ b/src/doc/book/getting-started.md
@@ -513,7 +513,7 @@ Cargo checks to see if any of your project’s files have been modified, and onl
 rebuilds your project if they’ve changed since the last time you built it.
 
 With simple projects, Cargo doesn't bring a whole lot over just using `rustc`,
-but it will become useful in future. This is especially true when you start
+but it will become useful in the future. This is especially true when you start
 using crates; these are synonymous with a ‘library’ or ‘package’ in other
 programming languages. For complex projects composed of multiple crates, it’s
 much easier to let Cargo coordinate the build. Using Cargo, you can run `cargo

--- a/src/doc/book/if.md
+++ b/src/doc/book/if.md
@@ -4,7 +4,7 @@ Rust’s take on `if` is not particularly complex, but it’s much more like the
 `if` you’ll find in a dynamically typed language than in a more traditional
 systems language. So let’s talk about it, to make sure you grasp the nuances.
 
-`if` is a specific form of a more general concept, the ‘branch’. The name comes
+`if` is a specific form of a more general concept, the ‘branch’, whose name comes
 from a branch in a tree: a decision point, where depending on a choice,
 multiple paths can be taken.
 

--- a/src/doc/book/strings.md
+++ b/src/doc/book/strings.md
@@ -44,7 +44,7 @@ let s = "foo\
 assert_eq!("foobar", s);
 ```
 
-Rust has more than only `&str`s though. A `String`, is a heap-allocated string.
+Rust has more than only `&str`s though. A `String` is a heap-allocated string.
 This string is growable, and is also guaranteed to be UTF-8. `String`s are
 commonly created by converting from a string slice using the `to_string`
 method.
@@ -89,7 +89,7 @@ Viewing a `String` as a `&str` is cheap, but converting the `&str` to a
 
 ## Indexing
 
-Because strings are valid UTF-8, strings do not support indexing:
+Because strings are valid UTF-8, they do not support indexing:
 
 ```rust,ignore
 let s = "hello";


### PR DESCRIPTION
I've made a few typo and grammar fixes as I've been working through the book.
