### PR TITLE
Make warnings of renamed and removed lints themselves lints

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -160,6 +160,12 @@ declare_lint! {
     "two overlapping inherent impls define an item with the same name were erroneously allowed"
 }
 
+declare_lint! {
+    pub RENAMED_AND_REMOVED_LINTS,
+    Warn,
+    "lints that have been renamed or removed"
+}
+
 /// Does nothing as a lint pass, but registers some `Lint`s
 /// which are used by other parts of the compiler.
 #[derive(Copy, Clone)]
@@ -191,7 +197,8 @@ impl LintPass for HardwiredLints {
             CONST_ERR,
             RAW_POINTER_DERIVE,
             TRANSMUTE_FROM_FN_ITEM_TYPES,
-            OVERLAPPING_INHERENT_IMPLS
+            OVERLAPPING_INHERENT_IMPLS,
+            RENAMED_AND_REMOVED_LINTS
         )
     }
 }

--- a/src/test/compile-fail/lint-removed-allow.rs
+++ b/src/test/compile-fail/lint-removed-allow.rs
@@ -8,11 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// The raw_pointer_derived lint was removed, but is now reported by
-// the renamed_and_removed_lints lint, which means it's a warning by
-// default, and allowed in cargo dependency builds.
-// cc #30346
+// No warnings about removed lint when
+// allow(renamed_and_removed_lints)
 
-#[deny(raw_pointer_derive)] //~ WARN raw_pointer_derive has been removed
+#[deny(raw_pointer_derive)]
+#[allow(renamed_and_removed_lints)]
 #[deny(unused_variables)]
 fn main() { let unused = (); } //~ ERR unused

--- a/src/test/compile-fail/lint-renamed-allow.rs
+++ b/src/test/compile-fail/lint-renamed-allow.rs
@@ -8,11 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// The raw_pointer_derived lint was removed, but is now reported by
-// the renamed_and_removed_lints lint, which means it's a warning by
-// default, and allowed in cargo dependency builds.
-// cc #30346
+// No warnings about renamed lint when
+// allow(renamed_and_removed_lints)
 
-#[deny(raw_pointer_derive)] //~ WARN raw_pointer_derive has been removed
-#[deny(unused_variables)]
+#[deny(unknown_features)]
+#[allow(renamed_and_removed_lints)]
+#[deny(unused)]
 fn main() { let unused = (); } //~ ERR unused

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -12,7 +12,7 @@
 
 #![deny(warnings)]
 #![allow(unused_must_use)]
-#![allow(unknown_features)]
+#![allow(unused_features)]
 #![feature(box_syntax)]
 #![feature(question_mark)]
 


### PR DESCRIPTION
This adds the `renamed_and_removed_lints` warning, defaulting
to the warning level.

Fixes #31141
