### PR TITLE
Normalize return type when checking for E0269

### DIFF
--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -113,7 +113,7 @@ use dep_graph::DepNode;
 use middle::def::*;
 use middle::pat_util;
 use middle::ty::{self, TyCtxt, ParameterEnvironment};
-use middle::traits;
+use middle::traits::{self, ProjectionMode};
 use middle::infer;
 use lint;
 use util::nodemap::NodeMap;
@@ -1497,7 +1497,8 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
                 let param_env = ParameterEnvironment::for_item(&self.ir.tcx, id);
                 let infcx = infer::new_infer_ctxt(&self.ir.tcx,
                                                   &self.ir.tcx.tables,
-                                                  Some(param_env));
+                                                  Some(param_env),
+                                                  ProjectionMode::Any);
                 let cause = traits::ObligationCause::dummy();
                 let norm = traits::fully_normalize(&infcx,
                                                    cause,

--- a/src/test/run-pass/issue-31597.rs
+++ b/src/test/run-pass/issue-31597.rs
@@ -1,0 +1,23 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Make {
+    type Out;
+
+    fn make() -> Self::Out;
+}
+
+impl Make for () {
+    type Out = ();
+
+    fn make() -> Self::Out {}
+}
+
+fn main() {}

--- a/src/test/run-pass/issue-31597.rs
+++ b/src/test/run-pass/issue-31597.rs
@@ -20,4 +20,18 @@ impl Make for () {
     fn make() -> Self::Out {}
 }
 
+// Also make sure we don't hit an ICE when the projection can't be known
+fn f<T: Make>() -> <T as Make>::Out { loop {} }
+
+// ...and that it works with a blanket impl
+trait Tr {
+    type Assoc;
+}
+
+impl<T: Make> Tr for T {
+    type Assoc = ();
+}
+
+fn g<T: Make>() -> <T as Tr>::Assoc { }
+
 fn main() {}


### PR DESCRIPTION
Fixes #31597

First time dealing with normalization. Maybe `normalize_associated_type` would be better here, but it seems to imply it's only used during trans.
