### PR TITLE
Define AVX compare and blend intrinsics

### DIFF
--- a/src/etc/platform-intrinsics/x86/avx.json
+++ b/src/etc/platform-intrinsics/x86/avx.json
@@ -16,6 +16,13 @@
             "args": ["s8SPc"]
         },
         {
+            "intrinsic": "256_cmp_{0.data_type}",
+            "width": [256],
+            "llvm": "cmp.{1.data_type}.256",
+            "ret": "f(32-64)",
+            "args": ["0", "0", "s8S"]
+        },
+        {
             "intrinsic": "256_cvtepi32_pd",
             "width": [256],
             "llvm": "cvtdq2.pd.256",

--- a/src/etc/platform-intrinsics/x86/avx.json
+++ b/src/etc/platform-intrinsics/x86/avx.json
@@ -9,6 +9,13 @@
             "args": ["0", "0"]
         },
         {
+            "intrinsic": "256_blendv_{0.data_type}",
+            "width": [256],
+            "llvm": "blendv.{0.data_type}.256",
+            "ret": "f(32-64)",
+            "args": ["0", "0", "0"]
+        },
+        {
             "intrinsic": "256_broadcast_{0.data_type}",
             "width": [256],
             "llvm": "vbroadcastf128.{0.data_type}.256",

--- a/src/librustc_platform_intrinsics/x86.rs
+++ b/src/librustc_platform_intrinsics/x86.rs
@@ -498,6 +498,16 @@ pub fn find<'tcx>(_tcx: &TyCtxt<'tcx>, name: &str) -> Option<Intrinsic> {
             output: v(f(64), 4),
             definition: Named("llvm.x86.avx.addsub.pd.256")
         },
+        "256_blendv_ps" => Intrinsic {
+            inputs: vec![v(f(32), 8), v(f(32), 8), v(f(32), 8)],
+            output: v(f(32), 8),
+            definition: Named("llvm.x86.avx.blendv.ps.256")
+        },
+        "256_blendv_pd" => Intrinsic {
+            inputs: vec![v(f(64), 4), v(f(64), 4), v(f(64), 4)],
+            output: v(f(64), 4),
+            definition: Named("llvm.x86.avx.blendv.pd.256")
+        },
         "256_broadcast_ps" => Intrinsic {
             inputs: vec![p(true, i(8), None)],
             output: v(f(32), 8),
@@ -507,6 +517,16 @@ pub fn find<'tcx>(_tcx: &TyCtxt<'tcx>, name: &str) -> Option<Intrinsic> {
             inputs: vec![p(true, i(8), None)],
             output: v(f(64), 4),
             definition: Named("llvm.x86.avx.vbroadcastf128.pd.256")
+        },
+        "256_cmp_ps" => Intrinsic {
+            inputs: vec![v(f(32), 8), v(f(32), 8), i(8)],
+            output: v(f(32), 8),
+            definition: Named("llvm.x86.avx.cmp.ps.256")
+        },
+        "256_cmp_pd" => Intrinsic {
+            inputs: vec![v(f(64), 4), v(f(64), 4), i(8)],
+            output: v(f(64), 4),
+            definition: Named("llvm.x86.avx.cmp.pd.256")
         },
         "256_cvtepi32_pd" => Intrinsic {
             inputs: vec![v(i(32), 4)],


### PR DESCRIPTION
This defines the following intrinsics:
- `_mm256_blendv_pd`
- `_mm256_blendv_ps`
- `_mm256_cmp_pd`
- `_mm256_cmp_ps`

I verified these locally.
