### PR TITLE
Remove trailing whitespace at the end of lines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,8 +132,8 @@ Some common make targets are:
 - `make check-stage1-std NO_REBUILD=1` - test the standard library without
   rebuilding the entire compiler
 - `make check TESTNAME=<substring-of-test-name>` - Run a matching set of tests.
-  - `TESTNAME` should be a substring of the tests to match against e.g. it could 
-    be the fully qualified test name, or just a part of it. 
+  - `TESTNAME` should be a substring of the tests to match against e.g. it could
+    be the fully qualified test name, or just a part of it.
     `TESTNAME=collections::hash::map::test_map::test_capacity_not_less_than_len`
     or `TESTNAME=test_capacity_not_less_than_len`.
 - `make check-stage1-rpass TESTNAME=<substring-of-test-name>` - Run a single

--- a/src/doc/book/casting-between-types.md
+++ b/src/doc/book/casting-between-types.md
@@ -17,12 +17,12 @@ function result.
 The most common case of coercion is removing mutability from a reference:
 
  * `&mut T` to `&T`
- 
+
 An analogous conversion is to remove mutability from a
 [raw pointer](raw-pointers.md):
 
  * `*mut T` to `*const T`
- 
+
 References can also be coerced to raw pointers:
 
  * `&T` to `*const T`
@@ -32,7 +32,7 @@ References can also be coerced to raw pointers:
 Custom coercions may be defined using [`Deref`](deref-coercions.md).
 
 Coercion is transitive.
- 
+
 # `as`
 
 The `as` keyword does safe casting:
@@ -64,7 +64,7 @@ A cast `e as U` is also valid in any of the following cases:
     and `U` is an integer type; *enum-cast*
  * `e` has type `bool` or `char` and `U` is an integer type; *prim-int-cast*
  * `e` has type `u8` and `U` is `char`; *u8-char-cast*
- 
+
 For example
 
 ```rust
@@ -98,9 +98,9 @@ The semantics of numeric casts are:
 
 [float-int]: https://github.com/rust-lang/rust/issues/10184
 [float-float]: https://github.com/rust-lang/rust/issues/15536
- 
+
 ## Pointer casts
- 
+
 Perhaps surprisingly, it is safe to cast [raw pointers](raw-pointers.md) to and
 from integers, and to cast between pointers to different types subject to
 some constraints. It is only unsafe to dereference the pointer:
@@ -114,7 +114,7 @@ let b = a as u32;
 
 * `e` has type `*T`, `U` has type `*U_0`, and either `U_0: Sized` or
   `unsize_kind(T) == unsize_kind(U_0)`; a *ptr-ptr-cast*
-  
+
 * `e` has type `*T` and `U` is a numeric type, while `T: Sized`; *ptr-addr-cast*
 
 * `e` is an integer and `U` is `*U_0`, while `U_0: Sized`; *addr-ptr-cast*

--- a/src/doc/book/const-and-static.md
+++ b/src/doc/book/const-and-static.md
@@ -72,7 +72,7 @@ a [`Drop`][drop] implementation.
 # Initializing
 
 Both `const` and `static` have requirements for giving them a value. They must
-be given a value that’s a constant expression. In other words, you cannot use 
+be given a value that’s a constant expression. In other words, you cannot use
 the result of a function call or anything similarly complex or at runtime.
 
 # Which construct should I use?

--- a/src/doc/book/match.md
+++ b/src/doc/book/match.md
@@ -28,8 +28,8 @@ patterns][patterns] that covers all the patterns that are possible here.
 
 [patterns]: patterns.html
 
-One of the many advantages of `match` is it enforces ‘exhaustiveness checking’. 
-For example if we remove the last arm with the underscore `_`, the compiler will 
+One of the many advantages of `match` is it enforces ‘exhaustiveness checking’.
+For example if we remove the last arm with the underscore `_`, the compiler will
 give us an error:
 
 ```text
@@ -58,7 +58,7 @@ let number = match x {
 };
 ```
 
-Sometimes it’s a nice way of converting something from one type to another; in 
+Sometimes it’s a nice way of converting something from one type to another; in
 this example the integers are converted to `String`.
 
 # Matching on enums
@@ -90,7 +90,7 @@ fn process_message(msg: Message) {
 
 Again, the Rust compiler checks exhaustiveness, so it demands that you
 have a match arm for every variant of the enum. If you leave one off, it
-will give you a compile-time error unless you use `_` or provide all possible 
+will give you a compile-time error unless you use `_` or provide all possible
 arms.
 
 Unlike the previous uses of `match`, you can’t use the normal `if`

--- a/src/doc/book/ownership.md
+++ b/src/doc/book/ownership.md
@@ -124,7 +124,7 @@ special annotation here, it’s the default thing that Rust does.
 ## The details
 
 The reason that we cannot use a binding after we’ve moved it is subtle, but
-important. 
+important.
 
 When we write code like this:
 
@@ -148,7 +148,7 @@ The first line allocates memory for the vector object `v` on the stack like
 it does for `x` above. But in addition to that it also allocates some memory
 on the [heap][sh] for the actual data (`[1, 2, 3]`). Rust copies the address
 of this heap allocation to an internal pointer, which is part of the vector
-object placed on the stack (let's call it the data pointer). 
+object placed on the stack (let's call it the data pointer).
 
 It is worth pointing out (even at the risk of stating the obvious) that the
 vector object and its data live in separate memory regions instead of being a
@@ -163,7 +163,7 @@ does not create a copy of the heap allocation containing the actual data.
 Which means that there would be two pointers to the contents of the vector
 both pointing to the same memory allocation on the heap. It would violate
 Rust’s safety guarantees by introducing a data race if one could access both
-`v` and `v2` at the same time. 
+`v` and `v2` at the same time.
 
 For example if we truncated the vector to just two elements through `v2`:
 

--- a/src/doc/book/primitive-types.md
+++ b/src/doc/book/primitive-types.md
@@ -164,7 +164,7 @@ copying. For example, you might want to reference only one line of a file read
 into memory. By nature, a slice is not created directly, but from an existing
 variable binding. Slices have a defined length, can be mutable or immutable.
 
-Internally, slices are represented as a pointer to the beginning of the data 
+Internally, slices are represented as a pointer to the beginning of the data
 and a length.
 
 ## Slicing syntax

--- a/src/doc/book/vectors.md
+++ b/src/doc/book/vectors.md
@@ -116,7 +116,7 @@ for i in v {
 ```
 
 Note: You cannot use the vector again once you have iterated by taking ownership of the vector.
-You can iterate the vector multiple times by taking a reference to the vector whilst iterating. 
+You can iterate the vector multiple times by taking a reference to the vector whilst iterating.
 For example, the following code does not compile.
 
 ```rust,ignore


### PR DESCRIPTION
According the rules of styling Rust code there should not be trailing whitespace at the end of lines or files. I thought that it might be good to remove trailing whitespace from other files also, if it does not break anything.
