### PR TITLE
Change compare_exchange to return a Result<T, T>

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -53,19 +53,35 @@ extern "rust-intrinsic" {
     // NB: These intrinsics take raw pointers because they mutate aliased
     // memory, which is not valid for either `&` or `&mut`.
 
+    #[cfg(stage0)]
     pub fn atomic_cxchg<T>(dst: *mut T, old: T, src: T) -> T;
+    #[cfg(stage0)]
     pub fn atomic_cxchg_acq<T>(dst: *mut T, old: T, src: T) -> T;
+    #[cfg(stage0)]
     pub fn atomic_cxchg_rel<T>(dst: *mut T, old: T, src: T) -> T;
+    #[cfg(stage0)]
     pub fn atomic_cxchg_acqrel<T>(dst: *mut T, old: T, src: T) -> T;
+    #[cfg(stage0)]
     pub fn atomic_cxchg_relaxed<T>(dst: *mut T, old: T, src: T) -> T;
+
     #[cfg(not(stage0))]
-    pub fn atomic_cxchg_failrelaxed<T>(dst: *mut T, old: T, src: T) -> T;
+    pub fn atomic_cxchg<T>(dst: *mut T, old: T, src: T) -> (T, bool);
     #[cfg(not(stage0))]
-    pub fn atomic_cxchg_failacq<T>(dst: *mut T, old: T, src: T) -> T;
+    pub fn atomic_cxchg_acq<T>(dst: *mut T, old: T, src: T) -> (T, bool);
     #[cfg(not(stage0))]
-    pub fn atomic_cxchg_acq_failrelaxed<T>(dst: *mut T, old: T, src: T) -> T;
+    pub fn atomic_cxchg_rel<T>(dst: *mut T, old: T, src: T) -> (T, bool);
     #[cfg(not(stage0))]
-    pub fn atomic_cxchg_acqrel_failrelaxed<T>(dst: *mut T, old: T, src: T) -> T;
+    pub fn atomic_cxchg_acqrel<T>(dst: *mut T, old: T, src: T) -> (T, bool);
+    #[cfg(not(stage0))]
+    pub fn atomic_cxchg_relaxed<T>(dst: *mut T, old: T, src: T) -> (T, bool);
+    #[cfg(not(stage0))]
+    pub fn atomic_cxchg_failrelaxed<T>(dst: *mut T, old: T, src: T) -> (T, bool);
+    #[cfg(not(stage0))]
+    pub fn atomic_cxchg_failacq<T>(dst: *mut T, old: T, src: T) -> (T, bool);
+    #[cfg(not(stage0))]
+    pub fn atomic_cxchg_acq_failrelaxed<T>(dst: *mut T, old: T, src: T) -> (T, bool);
+    #[cfg(not(stage0))]
+    pub fn atomic_cxchg_acqrel_failrelaxed<T>(dst: *mut T, old: T, src: T) -> (T, bool);
 
     #[cfg(not(stage0))]
     pub fn atomic_cxchgweak<T>(dst: *mut T, old: T, src: T) -> (T, bool);

--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -697,6 +697,7 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         (_, name) if name.starts_with("atomic_") => {
             let split: Vec<&str> = name.split('_').collect();
 
+            let is_cxchg = split[1] == "cxchg" || split[1] == "cxchgweak";
             let (order, failorder) = match split.len() {
                 2 => (llvm::SequentiallyConsistent, llvm::SequentiallyConsistent),
                 3 => match split[2] {
@@ -705,16 +706,16 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
                     "acq"     => (llvm::Acquire, llvm::Acquire),
                     "rel"     => (llvm::Release, llvm::Monotonic),
                     "acqrel"  => (llvm::AcquireRelease, llvm::Acquire),
-                    "failrelaxed" if split[1] == "cxchg" || split[1] == "cxchgweak" =>
+                    "failrelaxed" if is_cxchg =>
                         (llvm::SequentiallyConsistent, llvm::Monotonic),
-                    "failacq" if split[1] == "cxchg" || split[1] == "cxchgweak" =>
+                    "failacq" if is_cxchg =>
                         (llvm::SequentiallyConsistent, llvm::Acquire),
                     _ => ccx.sess().fatal("unknown ordering in atomic intrinsic")
                 },
                 4 => match (split[2], split[3]) {
-                    ("acq", "failrelaxed") if split[1] == "cxchg" || split[1] == "cxchgweak" =>
+                    ("acq", "failrelaxed") if is_cxchg =>
                         (llvm::Acquire, llvm::Monotonic),
-                    ("acqrel", "failrelaxed") if split[1] == "cxchg" || split[1] == "cxchgweak" =>
+                    ("acqrel", "failrelaxed") if is_cxchg =>
                         (llvm::AcquireRelease, llvm::Monotonic),
                     _ => ccx.sess().fatal("unknown ordering in atomic intrinsic")
                 },
@@ -722,22 +723,17 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
             };
 
             match split[1] {
-                "cxchg" => {
+                "cxchg" | "cxchgweak" => {
                     let cmp = from_immediate(bcx, llargs[1]);
                     let src = from_immediate(bcx, llargs[2]);
                     let ptr = PointerCast(bcx, llargs[0], val_ty(src).ptr_to());
-                    let res = AtomicCmpXchg(bcx, ptr, cmp, src, order, failorder, llvm::False);
-                    ExtractValue(bcx, res, 0)
-                }
-
-                "cxchgweak" => {
-                    let cmp = from_immediate(bcx, llargs[1]);
-                    let src = from_immediate(bcx, llargs[2]);
-                    let ptr = PointerCast(bcx, llargs[0], val_ty(src).ptr_to());
-                    let val = AtomicCmpXchg(bcx, ptr, cmp, src, order, failorder, llvm::True);
+                    let weak = if split[1] == "cxchgweak" { llvm::True } else { llvm::False };
+                    let val = AtomicCmpXchg(bcx, ptr, cmp, src, order, failorder, weak);
                     let result = ExtractValue(bcx, val, 0);
                     let success = ZExt(bcx, ExtractValue(bcx, val, 1), Type::bool(bcx.ccx()));
-                    Store(bcx, result, StructGEP(bcx, llresult, 0));
+                    Store(bcx,
+                          result,
+                          PointerCast(bcx, StructGEP(bcx, llresult, 0), val_ty(src).ptr_to()));
                     Store(bcx, success, StructGEP(bcx, llresult, 1));
                     C_nil(ccx)
                 }
@@ -750,6 +746,7 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
                     }
                     to_immediate(bcx, AtomicLoad(bcx, ptr, order), tp_ty)
                 }
+
                 "store" => {
                     let val = from_immediate(bcx, llargs[1]);
                     let ptr = PointerCast(bcx, llargs[0], val_ty(val).ptr_to());

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -84,14 +84,10 @@ pub fn check_intrinsic_type(ccx: &CrateCtxt, it: &hir::ForeignItem) {
 
         //We only care about the operation here
         let (n_tps, inputs, output) = match split[1] {
-            "cxchg" => (1, vec!(tcx.mk_mut_ptr(param(ccx, 0)),
-                                param(ccx, 0),
-                                param(ccx, 0)),
-                        param(ccx, 0)),
-            "cxchgweak" => (1, vec!(tcx.mk_mut_ptr(param(ccx, 0)),
-                                param(ccx, 0),
-                                param(ccx, 0)),
-                            tcx.mk_tup(vec!(param(ccx, 0), tcx.types.bool))),
+            "cxchg" | "cxchgweak" => (1, vec!(tcx.mk_mut_ptr(param(ccx, 0)),
+                                              param(ccx, 0),
+                                              param(ccx, 0)),
+                                      tcx.mk_tup(vec!(param(ccx, 0), tcx.types.bool))),
             "load" => (1, vec!(tcx.mk_imm_ptr(param(ccx, 0))),
                        param(ccx, 0)),
             "store" => (1, vec!(tcx.mk_mut_ptr(param(ccx, 0)), param(ccx, 0)),

--- a/src/test/run-pass/atomic-compare_exchange.rs
+++ b/src/test/run-pass/atomic-compare_exchange.rs
@@ -16,22 +16,22 @@ static ATOMIC: AtomicIsize = ATOMIC_ISIZE_INIT;
 
 fn main() {
     // Make sure trans can emit all the intrinsics correctly
-    ATOMIC.compare_exchange(0, 1, Relaxed, Relaxed);
-    ATOMIC.compare_exchange(0, 1, Acquire, Relaxed);
-    ATOMIC.compare_exchange(0, 1, Release, Relaxed);
-    ATOMIC.compare_exchange(0, 1, AcqRel, Relaxed);
-    ATOMIC.compare_exchange(0, 1, SeqCst, Relaxed);
-    ATOMIC.compare_exchange(0, 1, Acquire, Acquire);
-    ATOMIC.compare_exchange(0, 1, AcqRel, Acquire);
-    ATOMIC.compare_exchange(0, 1, SeqCst, Acquire);
-    ATOMIC.compare_exchange(0, 1, SeqCst, SeqCst);
-    ATOMIC.compare_exchange_weak(0, 1, Relaxed, Relaxed);
-    ATOMIC.compare_exchange_weak(0, 1, Acquire, Relaxed);
-    ATOMIC.compare_exchange_weak(0, 1, Release, Relaxed);
-    ATOMIC.compare_exchange_weak(0, 1, AcqRel, Relaxed);
-    ATOMIC.compare_exchange_weak(0, 1, SeqCst, Relaxed);
-    ATOMIC.compare_exchange_weak(0, 1, Acquire, Acquire);
-    ATOMIC.compare_exchange_weak(0, 1, AcqRel, Acquire);
-    ATOMIC.compare_exchange_weak(0, 1, SeqCst, Acquire);
-    ATOMIC.compare_exchange_weak(0, 1, SeqCst, SeqCst);
+    ATOMIC.compare_exchange(0, 1, Relaxed, Relaxed).ok();
+    ATOMIC.compare_exchange(0, 1, Acquire, Relaxed).ok();
+    ATOMIC.compare_exchange(0, 1, Release, Relaxed).ok();
+    ATOMIC.compare_exchange(0, 1, AcqRel, Relaxed).ok();
+    ATOMIC.compare_exchange(0, 1, SeqCst, Relaxed).ok();
+    ATOMIC.compare_exchange(0, 1, Acquire, Acquire).ok();
+    ATOMIC.compare_exchange(0, 1, AcqRel, Acquire).ok();
+    ATOMIC.compare_exchange(0, 1, SeqCst, Acquire).ok();
+    ATOMIC.compare_exchange(0, 1, SeqCst, SeqCst).ok();
+    ATOMIC.compare_exchange_weak(0, 1, Relaxed, Relaxed).ok();
+    ATOMIC.compare_exchange_weak(0, 1, Acquire, Relaxed).ok();
+    ATOMIC.compare_exchange_weak(0, 1, Release, Relaxed).ok();
+    ATOMIC.compare_exchange_weak(0, 1, AcqRel, Relaxed).ok();
+    ATOMIC.compare_exchange_weak(0, 1, SeqCst, Relaxed).ok();
+    ATOMIC.compare_exchange_weak(0, 1, Acquire, Acquire).ok();
+    ATOMIC.compare_exchange_weak(0, 1, AcqRel, Acquire).ok();
+    ATOMIC.compare_exchange_weak(0, 1, SeqCst, Acquire).ok();
+    ATOMIC.compare_exchange_weak(0, 1, SeqCst, SeqCst).ok();
 }

--- a/src/test/run-pass/intrinsic-atomics.rs
+++ b/src/test/run-pass/intrinsic-atomics.rs
@@ -15,9 +15,9 @@
 
 mod rusti {
     extern "rust-intrinsic" {
-        pub fn atomic_cxchg<T>(dst: *mut T, old: T, src: T) -> T;
-        pub fn atomic_cxchg_acq<T>(dst: *mut T, old: T, src: T) -> T;
-        pub fn atomic_cxchg_rel<T>(dst: *mut T, old: T, src: T) -> T;
+        pub fn atomic_cxchg<T>(dst: *mut T, old: T, src: T) -> (T, bool);
+        pub fn atomic_cxchg_acq<T>(dst: *mut T, old: T, src: T) -> (T, bool);
+        pub fn atomic_cxchg_rel<T>(dst: *mut T, old: T, src: T) -> (T, bool);
 
         pub fn atomic_cxchgweak<T>(dst: *mut T, old: T, src: T) -> (T, bool);
         pub fn atomic_cxchgweak_acq<T>(dst: *mut T, old: T, src: T) -> (T, bool);
@@ -56,13 +56,13 @@ pub fn main() {
         rusti::atomic_store_rel(&mut *x,1);
         assert_eq!(*x, 1);
 
-        assert_eq!(rusti::atomic_cxchg(&mut *x, 1, 2), 1);
+        assert_eq!(rusti::atomic_cxchg(&mut *x, 1, 2), (1, true));
         assert_eq!(*x, 2);
 
-        assert_eq!(rusti::atomic_cxchg_acq(&mut *x, 1, 3), 2);
+        assert_eq!(rusti::atomic_cxchg_acq(&mut *x, 1, 3), (2, false));
         assert_eq!(*x, 2);
 
-        assert_eq!(rusti::atomic_cxchg_rel(&mut *x, 2, 1), 2);
+        assert_eq!(rusti::atomic_cxchg_rel(&mut *x, 2, 1), (2, true));
         assert_eq!(*x, 1);
 
         assert_eq!(rusti::atomic_xchg(&mut *x, 0), 1);


### PR DESCRIPTION
As per the discussion in #31767

I also changed the feature name from `extended_compare_and_swap` to `compare_exchange`.

r? @alexcrichton 
