### PR TITLE
derive: use intrinsics::unreachable over unreachable!()

### DIFF
--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -381,6 +381,22 @@ fn find_type_parameters(ty: &ast::Ty, ty_param_names: &[ast::Name]) -> Vec<P<ast
     visitor.types
 }
 
+/// Replacement for expr_unreachable which generates intrinsics::unreachable()
+/// instead of unreachable!()
+fn expr_unreachable_intrinsic(cx: &ExtCtxt, sp: Span) -> P<Expr> {
+    let path = cx.std_path(&["intrinsics", "unreachable"]);
+    let call = cx.expr_call_global(
+        sp, path, vec![]);
+    let unreachable = cx.expr_block(P(ast::Block {
+        stmts: vec![],
+        expr: Some(call),
+        id: ast::DUMMY_NODE_ID,
+        rules: ast::BlockCheckMode::Unsafe(ast::CompilerGenerated),
+        span: sp }));
+
+    unreachable
+}
+
 impl<'a> TraitDef<'a> {
     pub fn expand(&self,
                   cx: &mut ExtCtxt,
@@ -1297,16 +1313,7 @@ impl<'a> MethodDef<'a> {
             //Since we know that all the arguments will match if we reach the match expression we
             //add the unreachable intrinsics as the result of the catch all which should help llvm
             //in optimizing it
-            let path = cx.std_path(&["intrinsics", "unreachable"]);
-            let call = cx.expr_call_global(
-                sp, path, vec![]);
-            let unreachable = cx.expr_block(P(ast::Block {
-                stmts: vec![],
-                expr: Some(call),
-                id: ast::DUMMY_NODE_ID,
-                rules: ast::BlockCheckMode::Unsafe(ast::CompilerGenerated),
-                span: sp }));
-            match_arms.push(cx.arm(sp, vec![cx.pat_wild(sp)], unreachable));
+            match_arms.push(cx.arm(sp, vec![cx.pat_wild(sp)], expr_unreachable_intrinsic(cx, sp)));
 
             // Final wrinkle: the self_args are expressions that deref
             // down to desired l-values, but we cannot actually deref
@@ -1382,7 +1389,7 @@ impl<'a> MethodDef<'a> {
             // derive Debug on such a type could here generate code
             // that needs the feature gate enabled.)
 
-            cx.expr_unreachable(sp)
+            expr_unreachable_intrinsic(cx, sp)
         }
         else {
 

--- a/src/test/auxiliary/derive-no-std.rs
+++ b/src/test/auxiliary/derive-no-std.rs
@@ -1,0 +1,40 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "rlib"]
+#![no_std]
+
+// Issue #16803
+
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord,
+         Debug, Default, Copy)]
+pub struct Foo {
+    pub x: u32,
+}
+
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord,
+         Debug, Copy)]
+pub enum Bar {
+    Qux,
+    Quux(u32),
+}
+
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord,
+         Debug, Copy)]
+pub enum Void {}
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord,
+         Debug, Copy)]
+pub struct Empty;
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord,
+         Debug, Copy)]
+pub struct AlsoEmpty {}
+

--- a/src/test/run-pass/derive-no-std.rs
+++ b/src/test/run-pass/derive-no-std.rs
@@ -8,32 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(rand, collections, rustc_private)]
-#![no_std]
+// aux-build:derive-no-std.rs
 
-extern crate rand;
-extern crate serialize as rustc_serialize;
-extern crate collections;
-
-// Issue #16803
-
-#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord,
-         Debug, Default, Copy)]
-struct Foo {
-    x: u32,
-}
-
-#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord,
-         Debug, Copy)]
-enum Bar {
-    Qux,
-    Quux(u32),
-}
-
-enum Baz { A=0, B=5, }
+extern crate derive_no_std;
+use derive_no_std::*;
 
 fn main() {
-    Foo { x: 0 };
-    Bar::Quux(3);
-    Baz::A;
+    let f = Foo { x: 0 };
+    assert_eq!(f.clone(), Foo::default());
+
+    assert!(Bar::Qux < Bar::Quux(42));
 }
+


### PR DESCRIPTION
derive: use intrinsics::unreachable over unreachable!()

Fixes #31574.

Spawned from #32139.

r? @alexcrichton 
