### PR TITLE
derive: assume enum repr defaults to isize

### DIFF
--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -758,7 +758,7 @@ impl<'a> TraitDef<'a> {
 
 fn find_repr_type_name(diagnostic: &Handler,
                        type_attrs: &[ast::Attribute]) -> &'static str {
-    let mut repr_type_name = "i32";
+    let mut repr_type_name = "isize";
     for a in type_attrs {
         for r in &attr::find_repr_attrs(diagnostic, a) {
             repr_type_name = match *r {

--- a/src/test/compile-fail/enum-discrim-autosizing.rs
+++ b/src/test/compile-fail/enum-discrim-autosizing.rs
@@ -1,0 +1,20 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// With no repr attribute the discriminant will default to isize.
+// On 32-bit architectures this is equivalent to i32 so the variants
+// collide. On other architectures we need compilation to fail anyway,
+// so force the repr.
+#[cfg_attr(not(target_pointer_width = "32"), repr(i32))]
+enum Eu64 {
+    Au64 = 0,
+    Bu64 = 0x8000_0000_0000_0000 //~ERROR already exists
+}
+

--- a/src/test/run-pass/enum-discrim-autosizing.rs
+++ b/src/test/run-pass/enum-discrim-autosizing.rs
@@ -47,12 +47,6 @@ enum Ei64 {
     Bi64 = 0x8000_0000
 }
 
-#[derive(PartialEq)]
-enum Eu64 {
-    Au64 = 0,
-    Bu64 = 0x8000_0000_0000_0000
-}
-
 pub fn main() {
     assert_eq!(size_of::<Ei8>(), 1);
     assert_eq!(size_of::<Eu8>(), 1);
@@ -64,8 +58,4 @@ pub fn main() {
     assert_eq!(size_of::<Ei64>(), 8);
     #[cfg(target_pointer_width = "32")]
     assert_eq!(size_of::<Ei64>(), 4);
-    assert_eq!(size_of::<Eu64>(), 8);
-
-    // ensure no i32 collisions
-    assert!(Eu64::Au64 != Eu64::Bu64);
 }

--- a/src/test/run-pass/enum-discrim-autosizing.rs
+++ b/src/test/run-pass/enum-discrim-autosizing.rs
@@ -47,6 +47,12 @@ enum Ei64 {
     Bi64 = 0x8000_0000
 }
 
+#[derive(PartialEq)]
+enum Eu64 {
+    Au64 = 0,
+    Bu64 = 0x8000_0000_0000_0000
+}
+
 pub fn main() {
     assert_eq!(size_of::<Ei8>(), 1);
     assert_eq!(size_of::<Eu8>(), 1);
@@ -58,4 +64,8 @@ pub fn main() {
     assert_eq!(size_of::<Ei64>(), 8);
     #[cfg(target_pointer_width = "32")]
     assert_eq!(size_of::<Ei64>(), 4);
+    assert_eq!(size_of::<Eu64>(), 8);
+
+    // ensure no i32 collisions
+    assert!(Eu64::Au64 != Eu64::Bu64);
 }


### PR DESCRIPTION
derive: assume enum repr defaults to isize

Fixes #31886.

Spawned from #32139.

r? @alexcrichton 
