### PR TITLE
Stop ignoring expected note/help messages in compiletest suite.

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -1013,8 +1013,8 @@ fn check_expected_errors(revision: Option<&str>,
         expected_errors.iter()
                         .fold((false, false),
                               |(acc_help, acc_note), ee|
-                                  (acc_help || ee.kind == "help:", acc_note ||
-                                   ee.kind == "note:"));
+                                  (acc_help || ee.kind == "help:" || ee.kind == "help",
+                                   acc_note || ee.kind == "note:" || ee.kind == "note"));
 
     // Scan and extract our error/warning messages,
     // which look like:

--- a/src/test/compile-fail/asm-out-assign-imm.rs
+++ b/src/test/compile-fail/asm-out-assign-imm.rs
@@ -23,6 +23,7 @@ pub fn main() {
     unsafe {
         asm!("mov $1, $0" : "=r"(x) : "r"(5));
         //~^ ERROR re-assignment of immutable variable `x`
+        //~| NOTE in this expansion of asm!
     }
     foo(x);
 }

--- a/src/test/compile-fail/borrowck/borrowck-box-insensitivity.rs
+++ b/src/test/compile-fail/borrowck/borrowck-box-insensitivity.rs
@@ -54,80 +54,97 @@ fn borrow_after_move() {
 fn move_after_borrow() {
     let a: Box<_> = box B { x: box 0, y: box 1 };
     let _x = &a.x;
+    //~^ NOTE borrow of `a.x` occurs here
     let _y = a.y; //~ ERROR cannot move
 }
 
 fn copy_after_mut_borrow() {
     let mut a: Box<_> = box A { x: box 0, y: 1 };
     let _x = &mut a.x;
+    //~^ NOTE borrow of `a.x` occurs here
     let _y = a.y; //~ ERROR cannot use
 }
 
 fn move_after_mut_borrow() {
     let mut a: Box<_> = box B { x: box 0, y: box 1 };
     let _x = &mut a.x;
+    //~^ NOTE borrow of `a.x` occurs here
     let _y = a.y; //~ ERROR cannot move
 }
 
 fn borrow_after_mut_borrow() {
     let mut a: Box<_> = box A { x: box 0, y: 1 };
     let _x = &mut a.x;
+    //~^ NOTE previous borrow of `a` occurs here (through borrowing `a.x`);
     let _y = &a.y; //~ ERROR cannot borrow
 }
+//~^ NOTE previous borrow ends here
 
 fn mut_borrow_after_borrow() {
     let mut a: Box<_> = box A { x: box 0, y: 1 };
     let _x = &a.x;
+    //~^ NOTE previous borrow of `a` occurs here (through borrowing `a.x`)
     let _y = &mut a.y; //~ ERROR cannot borrow
 }
+//~^ NOTE previous borrow ends here
 
 fn copy_after_move_nested() {
     let a: Box<_> = box C { x: box A { x: box 0, y: 1 }, y: 2 };
     let _x = a.x.x;
+    //~^ NOTE `a.x.x` moved here because it has type `Box<isize>`, which is moved by default
     let _y = a.y; //~ ERROR use of collaterally moved
 }
 
 fn move_after_move_nested() {
     let a: Box<_> = box D { x: box A { x: box 0, y: 1 }, y: box 2 };
     let _x = a.x.x;
+    //~^ NOTE `a.x.x` moved here because it has type `Box<isize>`, which is moved by default
     let _y = a.y; //~ ERROR use of collaterally moved
 }
 
 fn borrow_after_move_nested() {
     let a: Box<_> = box C { x: box A { x: box 0, y: 1 }, y: 2 };
     let _x = a.x.x;
+    //~^ NOTE `a.x.x` moved here because it has type `Box<isize>`, which is moved by default
     let _y = &a.y; //~ ERROR use of collaterally moved
 }
 
 fn move_after_borrow_nested() {
     let a: Box<_> = box D { x: box A { x: box 0, y: 1 }, y: box 2 };
     let _x = &a.x.x;
+    //~^ NOTE borrow of `a.x.x` occurs here
     let _y = a.y; //~ ERROR cannot move
 }
 
 fn copy_after_mut_borrow_nested() {
     let mut a: Box<_> = box C { x: box A { x: box 0, y: 1 }, y: 2 };
     let _x = &mut a.x.x;
+    //~^ NOTE borrow of `a.x.x` occurs here
     let _y = a.y; //~ ERROR cannot use
 }
 
 fn move_after_mut_borrow_nested() {
     let mut a: Box<_> = box D { x: box A { x: box 0, y: 1 }, y: box 2 };
     let _x = &mut a.x.x;
+    //~^ NOTE borrow of `a.x.x` occurs here
     let _y = a.y; //~ ERROR cannot move
 }
 
 fn borrow_after_mut_borrow_nested() {
     let mut a: Box<_> = box C { x: box A { x: box 0, y: 1 }, y: 2 };
     let _x = &mut a.x.x;
+    //~^ NOTE previous borrow of `a.x.x` occurs here; the mutable borrow prevents
     let _y = &a.y; //~ ERROR cannot borrow
 }
+//~^ NOTE previous borrow ends here
 
 fn mut_borrow_after_borrow_nested() {
     let mut a: Box<_> = box C { x: box A { x: box 0, y: 1 }, y: 2 };
     let _x = &a.x.x;
+    //~^ NOTE previous borrow of `a.x.x` occurs here; the immutable borrow prevents
     let _y = &mut a.y; //~ ERROR cannot borrow
 }
+//~^ NOTE previous borrow ends here
 
 fn main() {
     copy_after_move();

--- a/src/test/compile-fail/borrowck/borrowck-let-suggestion.rs
+++ b/src/test/compile-fail/borrowck/borrowck-let-suggestion.rs
@@ -12,6 +12,7 @@ fn f() {
     let x = [1].iter(); //~ ERROR borrowed value does not live long enough
                          //~^ NOTE reference must be valid for the block suffix following statement
                          //~^^ HELP consider using a `let` binding to increase its lifetime
+                         //~^^^ NOTE ...but borrowed value is only valid for the statement at 12:4
 }
 
 fn main() {

--- a/src/test/compile-fail/borrowck/borrowck-report-with-custom-diagnostic.rs
+++ b/src/test/compile-fail/borrowck/borrowck-report-with-custom-diagnostic.rs
@@ -13,6 +13,7 @@ fn main() {
     // Original borrow ends at end of function
     let mut x = 1;
     let y = &mut x;
+    //~^ previous borrow of `x` occurs here; the mutable borrow prevents
     let z = &x; //~ ERROR cannot borrow
 }
 //~^ NOTE previous borrow ends here
@@ -23,6 +24,7 @@ fn foo() {
             // Original borrow ends at end of match arm
             let mut x = 1;
             let y = &x;
+            //~^ previous borrow of `x` occurs here; the immutable borrow prevents
             let z = &mut x; //~ ERROR cannot borrow
         }
      //~^ NOTE previous borrow ends here
@@ -35,6 +37,7 @@ fn bar() {
     || {
         let mut x = 1;
         let y = &mut x;
+        //~^ previous borrow of `x` occurs here; the mutable borrow prevents
         let z = &mut x; //~ ERROR cannot borrow
     };
  //~^ NOTE previous borrow ends here

--- a/src/test/compile-fail/borrowck/borrowck-vec-pattern-nesting.rs
+++ b/src/test/compile-fail/borrowck/borrowck-vec-pattern-nesting.rs
@@ -17,6 +17,7 @@ fn a() {
     let mut vec = [box 1, box 2, box 3];
     match vec {
         [box ref _a, _, _] => {
+        //~^ borrow of `vec[..]` occurs here
             vec[0] = box 4; //~ ERROR cannot assign
         }
     }
@@ -27,6 +28,7 @@ fn b() {
     let vec: &mut [Box<isize>] = &mut vec;
     match vec {
         [_b..] => {
+        //~^ borrow of `vec[..]` occurs here
             vec[0] = box 4; //~ ERROR cannot assign
         }
     }
@@ -48,6 +50,7 @@ fn c() {
         _ => {}
     }
     let a = vec[0]; //~ ERROR cannot move out
+    //~^ NOTE attempting to move value to here
 }
 
 fn d() {
@@ -59,6 +62,7 @@ fn d() {
         _ => {}
     }
     let a = vec[0]; //~ ERROR cannot move out
+    //~^ NOTE attempting to move value to here
 }
 
 fn e() {

--- a/src/test/compile-fail/cast-as-bool.rs
+++ b/src/test/compile-fail/cast-as-bool.rs
@@ -12,4 +12,5 @@ fn main() {
     let u = 5 as bool;
     //~^ ERROR cannot cast as `bool`
     //~^^ HELP compare with zero instead
+    //~^^^ HELP run `rustc --explain E0054` to see a detailed explanation
 }

--- a/src/test/compile-fail/cast-rfc0401.rs
+++ b/src/test/compile-fail/cast-rfc0401.rs
@@ -61,9 +61,11 @@ fn main()
     let _ = 3 as bool;
     //~^ ERROR cannot cast as `bool`
     //~^^ HELP compare with zero
+    //~^^^ HELP run `rustc --explain E0054` to see a detailed explanation
     let _ = E::A as bool;
     //~^ ERROR cannot cast as `bool`
     //~^^ HELP compare with zero
+    //~^^^ HELP run `rustc --explain E0054` to see a detailed explanation
     let _ = 0x61u32 as char; //~ ERROR only `u8` can be cast
 
     let _ = false as f32;
@@ -90,6 +92,9 @@ fn main()
     let _ = v as *const [u8]; //~ ERROR cannot cast
     let _ = fat_v as *const Foo;
     //~^ ERROR `core::marker::Sized` is not implemented for the type `[u8]`
+    //~^^ HELP run `rustc --explain E0277` to see a detailed explanation
+    //~^^^ NOTE `[u8]` does not have a constant size known at compile-time
+    //~^^^^ NOTE required for the cast to the object type `Foo`
     let _ = foo as *const str; //~ ERROR casting
     let _ = foo as *mut str; //~ ERROR casting
     let _ = main as *mut str; //~ ERROR casting
@@ -102,6 +107,9 @@ fn main()
     let a : *const str = "hello";
     let _ = a as *const Foo;
     //~^ ERROR `core::marker::Sized` is not implemented for the type `str`
+    //~^^ HELP run `rustc --explain E0277` to see a detailed explanation
+    //~^^^ NOTE `str` does not have a constant size known at compile-time
+    //~^^^^ NOTE required for the cast to the object type `Foo`
 
     // check no error cascade
     let _ = main.f as *const u32; //~ ERROR attempted access of field

--- a/src/test/compile-fail/fat-ptr-cast.rs
+++ b/src/test/compile-fail/fat-ptr-cast.rs
@@ -18,6 +18,7 @@ fn main() {
     let q = a.as_ptr();
 
     a as usize; //~ ERROR casting
+    //~^ HELP cast through a raw pointer first
     b as usize; //~ ERROR non-scalar cast
     p as usize;
     //~^ ERROR casting

--- a/src/test/compile-fail/feature-gate-negate-unsigned.rs
+++ b/src/test/compile-fail/feature-gate-negate-unsigned.rs
@@ -23,5 +23,6 @@ const _MAX: usize = -1;
 fn main() {
     let x = 5u8;
     let _y = -x; //~ ERROR unary negation of unsigned integer
+    //~^ HELP use a cast or the `!` operator
     -S; // should not trigger the gate; issue 26840
 }

--- a/src/test/compile-fail/issue-11714.rs
+++ b/src/test/compile-fail/issue-11714.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 fn blah() -> i32 { //~ ERROR not all control paths return a value
+    //~^ HELP run `rustc --explain E0269` to see a detailed explanation
     1
 
     ; //~ HELP consider removing this semicolon:

--- a/src/test/compile-fail/issue-13058.rs
+++ b/src/test/compile-fail/issue-13058.rs
@@ -40,4 +40,5 @@ fn main() {
 //~| found `(_, _)`
 //~| expected &-ptr
 //~| found tuple
+//~| HELP run `rustc --explain E0308` to see a detailed explanation
 }

--- a/src/test/compile-fail/issue-13428.rs
+++ b/src/test/compile-fail/issue-13428.rs
@@ -11,6 +11,7 @@
 // Regression test for #13428
 
 fn foo() -> String {  //~ ERROR not all control paths return a value
+    //~^ HELP run `rustc --explain E0269` to see a detailed explanation
     format!("Hello {}",
             "world")
     // Put the trailing semicolon on its own line to test that the
@@ -19,6 +20,7 @@ fn foo() -> String {  //~ ERROR not all control paths return a value
 }
 
 fn bar() -> String {  //~ ERROR not all control paths return a value
+    //~^ HELP run `rustc --explain E0269` to see a detailed explanation
     "foobar".to_string()
     ;   //~ HELP consider removing this semicolon
 }

--- a/src/test/compile-fail/issue-15260.rs
+++ b/src/test/compile-fail/issue-15260.rs
@@ -25,6 +25,7 @@ fn main() {
 
     let Foo {
         a, //~ NOTE field `a` previously bound here
+        //~^ NOTE field `a` previously bound here
         a: _, //~ ERROR field `a` bound multiple times in the pattern
         a: x //~ ERROR field `a` bound multiple times in the pattern
     } = Foo { a: 29 };

--- a/src/test/compile-fail/issue-16747.rs
+++ b/src/test/compile-fail/issue-16747.rs
@@ -19,6 +19,7 @@ struct List<'a, T: ListItem<'a>> {
 //~^ ERROR the parameter type `T` may not live long enough
 //~| HELP consider adding an explicit lifetime bound
 //~| NOTE ...so that the reference type `&'a [T]` does not outlive the data it points at
+//~| HELP run `rustc --explain E0309` to see a detailed explanation
 }
 impl<'a, T: ListItem<'a>> Collection for List<'a, T> {
     fn len(&self) -> usize {

--- a/src/test/compile-fail/issue-17263.rs
+++ b/src/test/compile-fail/issue-17263.rs
@@ -23,3 +23,5 @@ fn main() {
     //~^ ERROR cannot borrow `foo` (here through borrowing `foo.b`) as immutable
     //~^^ NOTE previous borrow of `foo` occurs here (through borrowing `foo.a`)
 }
+//~^ NOTE previous borrow ends here
+//~^^ NOTE previous borrow ends here

--- a/src/test/compile-fail/issue-19707.rs
+++ b/src/test/compile-fail/issue-19707.rs
@@ -13,8 +13,10 @@
 
 type foo = fn(&u8, &u8) -> &u8; //~ ERROR missing lifetime specifier
 //~^ HELP the signature does not say whether it is borrowed from argument 1 or argument 2
+//~^^ HELP run `rustc --explain E0106` to see a detailed explanation
 
 fn bar<F: Fn(&u8, &u8) -> &u8>(f: &F) {} //~ ERROR missing lifetime specifier
 //~^ HELP the signature does not say whether it is borrowed from argument 1 or argument 2
+//~^^ HELP run `rustc --explain E0106` to see a detailed explanation
 
 fn main() {}

--- a/src/test/compile-fail/issue-21221-1.rs
+++ b/src/test/compile-fail/issue-21221-1.rs
@@ -55,6 +55,8 @@ impl Mul for Foo {
 //~| HELP `mul1::Mul`
 //~| HELP `mul2::Mul`
 //~| HELP `std::ops::Mul`
+//~| HELP run `rustc --explain E0405` to see a detailed explanation
+//~| HELP you can import several candidates into scope (`use ...;`):
 }
 
 // BEFORE, we got:
@@ -75,17 +77,22 @@ fn getMul() -> Mul {
 //~| HELP `mul3::Mul`
 //~| HELP `mul4::Mul`
 //~| HELP and 2 other candidates
+//~| HELP run `rustc --explain E0412` to see a detailed explanation
+//~| HELP you can import several candidates into scope (`use ...;`):
 }
 
 // Let's also test what happens if the trait doesn't exist:
 impl ThisTraitReallyDoesntExistInAnyModuleReally for Foo {
 //~^ ERROR trait `ThisTraitReallyDoesntExistInAnyModuleReally` is not in scope
+//~^^ HELP run `rustc --explain E0405` to see a detailed explanation
+//~^^^ HELP no candidates by the name of `ThisTraitReallyDoesntExistInAnyModuleReally` found
 }
 
 // Let's also test what happens if there's just one alternative:
 impl Div for Foo {
 //~^ ERROR trait `Div` is not in scope
 //~| HELP `use std::ops::Div;`
+//~| HELP run `rustc --explain E0405` to see a detailed explanation
 }
 
 fn main() {

--- a/src/test/compile-fail/issue-21221-2.rs
+++ b/src/test/compile-fail/issue-21221-2.rs
@@ -28,3 +28,4 @@ struct Foo;
 impl T for Foo { }
 //~^ ERROR trait `T` is not in scope
 //~| HELP you can to import it into scope: `use foo::bar::T;`.
+//~| HELP run `rustc --explain E0405` to see a detailed explanation

--- a/src/test/compile-fail/issue-21221-3.rs
+++ b/src/test/compile-fail/issue-21221-3.rs
@@ -25,6 +25,7 @@ struct Foo;
 impl OuterTrait for Foo {}
 //~^ ERROR trait `OuterTrait` is not in scope
 //~| HELP you can to import it into scope: `use issue_21221_3::outer::OuterTrait;`.
+//~| HELP run `rustc --explain E0405` to see a detailed explanation
 fn main() {
     println!("Hello, world!");
 }

--- a/src/test/compile-fail/issue-21221-4.rs
+++ b/src/test/compile-fail/issue-21221-4.rs
@@ -20,6 +20,7 @@ struct Foo;
 impl T for Foo {}
 //~^ ERROR trait `T` is not in scope
 //~| HELP you can to import it into scope: `use issue_21221_4::T;`.
+//~| HELP run `rustc --explain E0405` to see a detailed explanation
 
 fn main() {
     println!("Hello, world!");

--- a/src/test/compile-fail/issue-21600.rs
+++ b/src/test/compile-fail/issue-21600.rs
@@ -23,5 +23,8 @@ fn main() {
         call_it(|| x.gen());
         call_it(|| x.gen_mut()); //~ ERROR cannot borrow data mutably in a captured outer
         //~^ ERROR cannot borrow data mutably in a captured outer
+        //~^^ HELP run `rustc --explain E0387` to see a detailed explanation
+        //~^^^ HELP run `rustc --explain E0387` to see a detailed explanation
+        //~^^^^ HELP consider changing this closure to take self by mutable reference
     });
 }

--- a/src/test/compile-fail/issue-24036.rs
+++ b/src/test/compile-fail/issue-24036.rs
@@ -14,17 +14,20 @@ fn closure_to_loc() {
     //~^ ERROR mismatched types
     //~| NOTE no two closures, even if identical, have the same type
     //~| HELP consider boxing your closure and/or using it as a trait object
+    //~| HELP run `rustc --explain E0308` to see a detailed explanation
 }
 
 fn closure_from_match() {
     let x = match 1usize {
         1 => |c| c + 1,
         2 => |c| c - 1,
+        //~^ NOTE match arm with an incompatible type
         _ => |c| c - 1
     };
-    //~^^^^^ ERROR match arms have incompatible types
+    //~^^^^^^ ERROR match arms have incompatible types
     //~| NOTE no two closures, even if identical, have the same type
     //~| HELP consider boxing your closure and/or using it as a trait object
+    //~| HELP run `rustc --explain E0308` to see a detailed explanation
 }
 
 fn main() { }

--- a/src/test/compile-fail/issue-25385.rs
+++ b/src/test/compile-fail/issue-25385.rs
@@ -21,4 +21,5 @@ fn main() {
 
     foo!(1i32.foo());
     //~^ ERROR no method named `foo` found for type `i32` in the current scope
+    //~^^ NOTE in this expansion of foo!
 }

--- a/src/test/compile-fail/issue-25386.rs
+++ b/src/test/compile-fail/issue-25386.rs
@@ -35,6 +35,4 @@ macro_rules! check_ptr_exist {
 fn main() {
     let item = stuff::Item::new();
     println!("{}", check_ptr_exist!(item, name));
-    //~^ NOTE in this expansion of check_ptr_exist!
-    //~^^ NOTE in this expansion of check_ptr_exist!
 }

--- a/src/test/compile-fail/issue-25793.rs
+++ b/src/test/compile-fail/issue-25793.rs
@@ -27,6 +27,7 @@ impl HasInfo {
     fn get_other(&mut self) -> usize {
         self.get_size(width!(self))
         //~^ NOTE in this expansion of width!
+        //~| NOTE borrow of `*self` occurs here
     }
 }
 

--- a/src/test/compile-fail/issue-26638.rs
+++ b/src/test/compile-fail/issue-26638.rs
@@ -11,13 +11,18 @@
 fn parse_type(iter: Box<Iterator<Item=&str>+'static>) -> &str { iter.next() }
 //~^ ERROR missing lifetime specifier [E0106]
 //~^^ HELP 2 elided lifetimes
+//~^^^ HELP run `rustc --explain E0106` to see a detailed explanation
 
 fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter() }
 //~^ ERROR missing lifetime specifier [E0106]
 //~^^ HELP lifetime cannot be derived
+//~^^^ HELP run `rustc --explain E0106` to see a detailed explanation
+//~^^^^ HELP consider giving it an explicit bounded or 'static lifetime
 
 fn parse_type_3() -> &str { unimplemented!() }
 //~^ ERROR missing lifetime specifier [E0106]
 //~^^ HELP no value for it to be borrowed from
+//~^^^ HELP run `rustc --explain E0106` to see a detailed explanation
+//~^^^^ HELP consider giving it a 'static lifetime
 
 fn main() {}

--- a/src/test/compile-fail/issue-30302.rs
+++ b/src/test/compile-fail/issue-30302.rs
@@ -18,8 +18,10 @@ fn is_empty<T>(s: Stack<T>) -> bool {
         Nil => true,
 //~^ WARN pattern binding `Nil` is named the same as one of the variants of the type `Stack`
 //~| HELP consider making the path in the pattern qualified: `Stack::Nil`
+//~| HELP run `rustc --explain E0170` to see a detailed explanation
         _ => false
 //~^ ERROR unreachable pattern
+//~| HELP run `rustc --explain E0001` to see a detailed explanation
     }
 }
 

--- a/src/test/compile-fail/issue-6702.rs
+++ b/src/test/compile-fail/issue-6702.rs
@@ -16,4 +16,5 @@ struct Monster {
 fn main() {
     let _m = Monster(); //~ ERROR `Monster` is the name of a struct or
     //~^ HELP did you mean to write: `Monster { /* fields */ }`?
+    //~| HELP run `rustc --explain E0423` to see a detailed explanation
 }

--- a/src/test/compile-fail/lifetime-elision-return-type-requires-explicit-lifetime.rs
+++ b/src/test/compile-fail/lifetime-elision-return-type-requires-explicit-lifetime.rs
@@ -11,12 +11,15 @@
 // Lifetime annotation needed because we have no arguments.
 fn f() -> &isize {    //~ ERROR missing lifetime specifier
 //~^ HELP there is no value for it to be borrowed from
+//~| HELP run `rustc --explain E0106` to see a detailed explanation
+//~| HELP consider giving it a 'static lifetime
     panic!()
 }
 
 // Lifetime annotation needed because we have two by-reference parameters.
 fn g(_x: &isize, _y: &isize) -> &isize {    //~ ERROR missing lifetime specifier
 //~^ HELP the signature does not say whether it is borrowed from `_x` or `_y`
+//~| HELP run `rustc --explain E0106` to see a detailed explanation
     panic!()
 }
 
@@ -28,11 +31,14 @@ struct Foo<'a> {
 // and one on the reference.
 fn h(_x: &Foo) -> &isize { //~ ERROR missing lifetime specifier
 //~^ HELP the signature does not say which one of `_x`'s 2 elided lifetimes it is borrowed from
+//~| HELP run `rustc --explain E0106` to see a detailed explanation
     panic!()
 }
 
 fn i(_x: isize) -> &isize { //~ ERROR missing lifetime specifier
 //~^ HELP this function's return type contains a borrowed value
+//~| HELP run `rustc --explain E0106` to see a detailed explanation
+//~| HELP consider giving it an explicit bounded or 'static lifetime
     panic!()
 }
 

--- a/src/test/compile-fail/lint-group-style.rs
+++ b/src/test/compile-fail/lint-group-style.rs
@@ -30,6 +30,7 @@ mod test {
     mod warn {
         #![warn(bad_style)]
         //~^ NOTE lint level defined here
+        //~| NOTE lint level defined here
 
         fn CamelCase() {} //~ WARN function `CamelCase` should have a snake case name
 

--- a/src/test/compile-fail/lint-no-drop-on-repr-extern.rs
+++ b/src/test/compile-fail/lint-no-drop-on-repr-extern.rs
@@ -15,6 +15,8 @@
 
 #![feature(unsafe_no_drop_flag)]
 #![deny(drop_with_repr_extern)]
+//~^ NOTE lint level defined here
+//~| NOTE lint level defined here
 
 #[repr(C)] struct As { x: Box<i8> }
 #[repr(C)] enum Ae { Ae(Box<i8>), _None }

--- a/src/test/compile-fail/lint-unconditional-recursion.rs
+++ b/src/test/compile-fail/lint-unconditional-recursion.rs
@@ -9,6 +9,20 @@
 // except according to those terms.
 
 #![deny(unconditional_recursion)]
+//~^ NOTE lint level defined here
+//~| NOTE lint level defined here
+//~| NOTE lint level defined here
+//~| NOTE lint level defined here
+//~| NOTE lint level defined here
+//~| NOTE lint level defined here
+//~| NOTE lint level defined here
+//~| NOTE lint level defined here
+//~| NOTE lint level defined here
+//~| NOTE lint level defined here
+//~| NOTE lint level defined here
+//~| NOTE lint level defined here
+//~| NOTE lint level defined here
+//~| NOTE lint level defined here
 #![allow(dead_code)]
 fn foo() { //~ ERROR function cannot return without recurring
     foo(); //~ NOTE recursive call site

--- a/src/test/compile-fail/liveness-return-last-stmt-semi.rs
+++ b/src/test/compile-fail/liveness-return-last-stmt-semi.rs
@@ -13,14 +13,18 @@
 macro_rules! test { () => { fn foo() -> i32 { 1; } } }
                                            //~^ ERROR not all control paths return a value
                                            //~^^ HELP consider removing this semicolon
+                                           //~^^^ HELP run `rustc --explain E0269` to see a
 
 fn no_return() -> i32 {} //~ ERROR  not all control paths return a value
+                         //~^ HELP run `rustc --explain E0269` to see a detailed explanation
 
 fn bar(x: u32) -> u32 { //~ ERROR  not all control paths return a value
+                        //~^ HELP run `rustc --explain E0269` to see a detailed explanation
     x * 2; //~ HELP consider removing this semicolon
 }
 
 fn baz(x: u64) -> u32 { //~ ERROR  not all control paths return a value
+                        //~^ HELP run `rustc --explain E0269` to see a detailed explanation
     x * 2;
 }
 

--- a/src/test/compile-fail/macro-backtrace-nested.rs
+++ b/src/test/compile-fail/macro-backtrace-nested.rs
@@ -21,9 +21,11 @@ macro_rules! call_nested_expr {
 
 macro_rules! call_nested_expr_sum {
     () => { 1 + nested_expr!(); } //~ ERROR unresolved name
+                                  //~^ NOTE in this expansion of nested_expr!
 }
 
 fn main() {
     1 + call_nested_expr!(); //~ ERROR unresolved name
+                             //~^ NOTE in this expansion of call_nested_expr!
     call_nested_expr_sum!(); //~ NOTE in this expansion of
 }

--- a/src/test/compile-fail/macro-backtrace-println.rs
+++ b/src/test/compile-fail/macro-backtrace-println.rs
@@ -22,7 +22,8 @@ macro_rules! myprint {
 
 macro_rules! myprintln {
     ($fmt:expr) => (myprint!(concat!($fmt, "\n"))); //~ ERROR invalid reference to argument `0`
-                                                    //~^ NOTE in this expansion of
+                                                    //~^ NOTE in this expansion of myprint!
+                                                    //~^^ NOTE in this expansion of concat!
 }
 
 fn main() {

--- a/src/test/compile-fail/method-suggestion-no-duplication.rs
+++ b/src/test/compile-fail/method-suggestion-no-duplication.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // issue #21405
+// ignore-tidy-linelength
 
 struct Foo;
 
@@ -19,4 +20,5 @@ fn main() {
     //~^ ERROR no method named `is_empty` found
     //~^^ HELP #1: `core::slice::SliceExt`
     //~^^^ HELP #2: `core::str::StrExt`
+    //~^^^^ HELP items from traits can only be used if the trait is implemented and in scope; the following traits define an item `is_empty`, perhaps you need to implement one of them:
 }

--- a/src/test/compile-fail/object-safety-generics.rs
+++ b/src/test/compile-fail/object-safety-generics.rs
@@ -29,6 +29,7 @@ fn make_bar<T:Bar>(t: &T) -> &Bar {
 
 fn make_bar_explicit<T:Bar>(t: &T) -> &Bar {
     //~^ ERROR E0038
+    //~^^ NOTE method `bar` has generic type parameters
     t as &Bar
 }
 

--- a/src/test/compile-fail/on-unimplemented.rs
+++ b/src/test/compile-fail/on-unimplemented.rs
@@ -34,6 +34,8 @@ pub fn main() {
     let y: Option<Vec<u8>> = collect(x.iter()); // this should give approximately the same error for x.iter().collect()
     //~^ ERROR
     //~^^ NOTE a collection of type `core::option::Option<collections::vec::Vec<u8>>` cannot be built from an iterator over elements of type `&u8`
+    //~^^^ NOTE required by `collect`
     let x: String = foobar(); //~ ERROR
     //~^ NOTE test error `collections::string::String` with `u8` `_` `u32`
+    //~^^ NOTE required by `foobar`
 }

--- a/src/test/compile-fail/recursion_limit.rs
+++ b/src/test/compile-fail/recursion_limit.rs
@@ -43,4 +43,15 @@ fn main() {
     is_send::<A>();
     //~^ ERROR overflow evaluating
     //~| NOTE consider adding a `#![recursion_limit="20"]` attribute to your crate
+    //~| NOTE required because it appears within the type `A`
+    //~| NOTE required because it appears within the type `B`
+    //~| NOTE required because it appears within the type `C`
+    //~| NOTE required because it appears within the type `D`
+    //~| NOTE required because it appears within the type `E`
+    //~| NOTE required because it appears within the type `F`
+    //~| NOTE required because it appears within the type `G`
+    //~| NOTE required because it appears within the type `H`
+    //~| NOTE required because it appears within the type `I`
+    //~| NOTE required because it appears within the type `J`
+    //~| NOTE required by `is_send`
 }

--- a/src/test/compile-fail/ref-suggestion.rs
+++ b/src/test/compile-fail/ref-suggestion.rs
@@ -14,12 +14,14 @@ fn main() {
     //~^ HELP use a `ref` binding as shown
     //~| SUGGESTION let ref y = x;
     x; //~ ERROR use of moved value
+    //~^ HELP run `rustc --explain E0382` to see a detailed explanation
 
     let x = vec![1];
     let mut y = x;
     //~^ HELP use a `ref` binding as shown
     //~| SUGGESTION let ref mut y = x;
     x; //~ ERROR use of moved value
+    //~^ HELP run `rustc --explain E0382` to see a detailed explanation
 
     let x = (Some(vec![1]), ());
 
@@ -30,4 +32,5 @@ fn main() {
         _ => {},
     }
     x; //~ ERROR use of partially moved value
+    //~^ HELP run `rustc --explain E0382` to see a detailed explanation
 }

--- a/src/test/compile-fail/suggest-path-instead-of-mod-dot-item.rs
+++ b/src/test/compile-fail/suggest-path-instead-of-mod-dot-item.rs
@@ -27,46 +27,54 @@ fn h1() -> i32 {
     a.I
         //~^ ERROR E0425
         //~| HELP To reference an item from the `a` module, use `a::I`
+        //~| HELP run `rustc --explain E0425` to see a detailed explanation
 }
 
 fn h2() -> i32 {
     a.g()
         //~^ ERROR E0425
         //~| HELP To call a function from the `a` module, use `a::g(..)`
+        //~| HELP run `rustc --explain E0425` to see a detailed explanation
 }
 
 fn h3() -> i32 {
     a.b.J
         //~^ ERROR E0425
         //~| HELP To reference an item from the `a` module, use `a::b`
+        //~| HELP run `rustc --explain E0425` to see a detailed explanation
 }
 
 fn h4() -> i32 {
     a::b.J
         //~^ ERROR E0425
         //~| HELP To reference an item from the `a::b` module, use `a::b::J`
+        //~| HELP run `rustc --explain E0425` to see a detailed explanation
 }
 
 fn h5() -> i32 {
     a.b.f()
         //~^ ERROR E0425
         //~| HELP To reference an item from the `a` module, use `a::b`
+        //~| HELP run `rustc --explain E0425` to see a detailed explanation
 }
 
 fn h6() -> i32 {
     a::b.f()
         //~^ ERROR E0425
         //~| HELP To call a function from the `a::b` module, use `a::b::f(..)`
+        //~| HELP run `rustc --explain E0425` to see a detailed explanation
 }
 
 fn h7() {
     a::b
         //~^ ERROR E0425
         //~| HELP Module `a::b` cannot be the value of an expression
+        //~| HELP run `rustc --explain E0425` to see a detailed explanation
 }
 
 fn h8() -> i32 {
     a::b()
         //~^ ERROR E0425
         //~| HELP No function corresponds to `a::b(..)`
+        //~| HELP run `rustc --explain E0425` to see a detailed explanation
 }

--- a/src/test/compile-fail/suggest-private-fields.rs
+++ b/src/test/compile-fail/suggest-private-fields.rs
@@ -25,6 +25,7 @@ fn main () {
         aa: 20, //~ ERROR structure `xc::B` has no field named `aa`
         //~^ HELP did you mean `a`?
         bb: 20, //~ ERROR structure `xc::B` has no field named `bb`
+        //~^ HELP did you mean `a`?
     };
     // local crate struct
     let l = A {

--- a/src/test/compile-fail/trait-object-reference-without-parens-suggestion.rs
+++ b/src/test/compile-fail/trait-object-reference-without-parens-suggestion.rs
@@ -13,8 +13,10 @@ fn main() {
     //~^ ERROR expected a path
     //~| HELP try adding parentheses
     //~| SUGGESTION let _: &(Copy + 'static);
+    //~| HELP run `rustc --explain E0178` to see a detailed explanation
     let _: &'static Copy + 'static;
     //~^ ERROR expected a path
     //~| HELP try adding parentheses
     //~| SUGGESTION let _: &'static (Copy + 'static);
+    //~| HELP run `rustc --explain E0178` to see a detailed explanation
 }

--- a/src/test/compile-fail/use-mod.rs
+++ b/src/test/compile-fail/use-mod.rs
@@ -11,6 +11,7 @@
 use foo::bar::{
     self,
 //~^ ERROR `self` import can only appear once in the list
+//~^^ NOTE previous import of `bar` here
     Bar,
     self
 //~^ NOTE another `self` import appears here

--- a/src/test/compile-fail/variance-unused-type-param.rs
+++ b/src/test/compile-fail/variance-unused-type-param.rs
@@ -16,15 +16,18 @@
 struct SomeStruct<A> { x: u32 }
 //~^ ERROR parameter `A` is never used
 //~| HELP PhantomData
+//~| HELP run `rustc --explain E0392` to see a detailed explanation
 
 enum SomeEnum<A> { Nothing }
 //~^ ERROR parameter `A` is never used
 //~| HELP PhantomData
+//~| HELP run `rustc --explain E0392` to see a detailed explanation
 
 // Here T might *appear* used, but in fact it isn't.
 enum ListCell<T> {
 //~^ ERROR parameter `T` is never used
 //~| HELP PhantomData
+//~| HELP run `rustc --explain E0392` to see a detailed explanation
     Cons(Box<ListCell<T>>),
     Nil
 }


### PR DESCRIPTION
Original issue: https://github.com/rust-lang/rust/issues/21195

Relevant PR: https://github.com/rust-lang/rust/pull/30778

Prior to this commit, if a compiletest testcase included the text
"HELP:" or "NOTE:" (note the colons), then it would indicate to the
compiletest suite that we should verify "help" and "note" expected
messages.

This commit updates this check to also check "HELP" and "NOTE" (not the
absense of colons) so that we always verify "help" and "note" expected
messages.
