### PR TITLE
rustbuild: Fix LLVM compile on MinGW

### DIFF
--- a/src/rustllvm/llvm-auto-clean-trigger
+++ b/src/rustllvm/llvm-auto-clean-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be forcibly cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2016-03-13
+2016-03-15


### PR DESCRIPTION
The LLVM change [1](https://github.com/rust-lang/llvm/commit/be89e4b5) in #32239 unfortunately broke the LLVM build on MinGW, so
this LLVM submodule update brings in one more fix [2](https://github.com/rust-lang/llvm/commit/3dcd2c84) which should hopefully
remedy that.

Once this lands we should be able to immediately start gating on this to prevent
it from happening again.
