### PR TITLE
syntax: impl ToTokens for P<ast::ImplItem>

### DIFF
--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -121,6 +121,12 @@ pub mod rt {
         }
     }
 
+    impl ToTokens for P<ast::ImplItem> {
+        fn to_tokens(&self, _cx: &ExtCtxt) -> Vec<TokenTree> {
+            vec![TokenTree::Token(self.span, token::Interpolated(token::NtImplItem(self.clone())))]
+        }
+    }
+
     impl ToTokens for ast::TraitItem {
         fn to_tokens(&self, _cx: &ExtCtxt) -> Vec<TokenTree> {
             vec![TokenTree::Token(self.span,


### PR DESCRIPTION
I'm working on updating zinc for latest rust, and it appears that I need this impl[0].

More generally, I realise that libsyntax is "Whatever the compiler team needs to build a compiler", but should I just open a PR fleshing this out for all types?

https://github.com/hackndev/zinc/blob/master/ioreg/src/builder/setter.rs#L194-L197
