### PR TITLE
Add comment about opt-in nature of compiletest note/help messages.

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -1009,6 +1009,10 @@ fn check_expected_errors(revision: Option<&str>,
         expected.replace(r"\", "/")
     }).collect::<Vec<String>>();
 
+    // If the testcase being checked contains at least one expected "help"
+    // message, then we'll ensure that all "help" messages are expected.
+    // Otherwise, all "help" messages reported by the compiler will be ignored.
+    // This logic also applies to "note" messages.
     let (expect_help, expect_note) =
         expected_errors.iter()
                         .fold((false, false),


### PR DESCRIPTION
The opt-in functionality was proposed and discussed in
https://github.com/rust-lang/rust/issues/21195
