### PR TITLE
std: Fix overflow when subtracting Instant

### DIFF
--- a/src/libstd/sys/unix/time.rs
+++ b/src/libstd/sys/unix/time.rs
@@ -88,11 +88,11 @@ mod inner {
                         -> Result<Duration, Duration> {
             if self >= other {
                 Ok(if self.t.tv_usec >= other.t.tv_usec {
-                    Duration::new(self.t.tv_sec as u64 - other.t.tv_sec as u64,
-                                  (self.t.tv_usec as u32 -
-                                   other.t.tv_usec as u32) * 1000)
+                    Duration::new((self.t.tv_sec - other.t.tv_sec) as u64,
+                                  ((self.t.tv_usec -
+                                    other.t.tv_usec) as u32) * 1000)
                 } else {
-                    Duration::new(self.t.tv_sec as u64 - 1 - other.t.tv_sec as u64,
+                    Duration::new((self.t.tv_sec - 1 - other.t.tv_sec) as u64,
                                   (self.t.tv_usec as u32 + (USEC_PER_SEC as u32) -
                                    other.t.tv_usec as u32) * 1000)
                 })


### PR DESCRIPTION
This code was currently only exercised on OSX, but this applies the same method
of subtraction used on Linux which doesn't have the same overflow issues.

Note that this currently includes no tests, but that's because this is only
visible with debug assertions enabled. Soon, however, I'll enable debug
assertions on all auto builds on the bots so we should get testing for this.

Closes #32268
