### PR TITLE
resolve: Bind primitive types to items in libcore

### DIFF
--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -46,6 +46,7 @@
 #![feature(pattern)]
 #![feature(placement_in)]
 #![feature(placement_new_protocol)]
+#![cfg_attr(not(stage0), feature(primitive_type))]
 #![feature(shared)]
 #![feature(slice_patterns)]
 #![feature(staged_api)]
@@ -56,7 +57,6 @@
 #![feature(unique)]
 #![feature(unsafe_no_drop_flag)]
 #![cfg_attr(test, feature(rand, test))]
-
 #![no_std]
 
 extern crate rustc_unicode;
@@ -99,6 +99,7 @@ pub mod fmt;
 pub mod linked_list;
 pub mod range;
 pub mod slice;
+#[cfg_attr(not(stage0), primitive_type)]
 pub mod str;
 pub mod string;
 pub mod vec;

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -21,7 +21,6 @@ use num::flt2dec;
 use ops::Deref;
 use result;
 use slice;
-use str;
 
 #[unstable(feature = "fmt_flags_align", issue = "27726")]
 /// Possible alignments returned by `Formatter::align`

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -19,7 +19,6 @@ use prelude::v1::*;
 use fmt;
 use num::Zero;
 use ops::{Div, Rem, Sub};
-use str;
 use slice;
 use ptr;
 use mem;

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -58,6 +58,9 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![cfg_attr(not(stage0), deny(warnings))]
+// This is a temporary way to use libcore's prelude in libcore
+#![cfg_attr(not(stage0), feature(primitive_type, local_prelude))]
+#![cfg_attr(not(stage0), local_prelude)]
 
 #![feature(allow_internal_unstable)]
 #![feature(associated_type_defaults)]
@@ -93,19 +96,43 @@ mod int_macros;
 #[macro_use]
 mod uint_macros;
 
+/// The boolean type.
+#[cfg(not(stage0))]
+#[stable(feature = "core_primitive_types", since = "1.9.0")]
+#[allow(non_camel_case_types)]
+#[primitive_type]
+pub type bool = bool;
+
+/// The boolean type.
+#[cfg(stage0)]
+#[stable(feature = "core_primitive_types", since = "1.9.0")]
+pub mod bool {}
+
+#[cfg_attr(not(stage0), primitive_type)]
 #[path = "num/isize.rs"]  pub mod isize;
+#[cfg_attr(not(stage0), primitive_type)]
 #[path = "num/i8.rs"]   pub mod i8;
+#[cfg_attr(not(stage0), primitive_type)]
 #[path = "num/i16.rs"]  pub mod i16;
+#[cfg_attr(not(stage0), primitive_type)]
 #[path = "num/i32.rs"]  pub mod i32;
+#[cfg_attr(not(stage0), primitive_type)]
 #[path = "num/i64.rs"]  pub mod i64;
 
+#[cfg_attr(not(stage0), primitive_type)]
 #[path = "num/usize.rs"] pub mod usize;
+#[cfg_attr(not(stage0), primitive_type)]
 #[path = "num/u8.rs"]   pub mod u8;
+#[cfg_attr(not(stage0), primitive_type)]
 #[path = "num/u16.rs"]  pub mod u16;
+#[cfg_attr(not(stage0), primitive_type)]
 #[path = "num/u32.rs"]  pub mod u32;
+#[cfg_attr(not(stage0), primitive_type)]
 #[path = "num/u64.rs"]  pub mod u64;
 
+#[cfg_attr(not(stage0), primitive_type)]
 #[path = "num/f32.rs"]   pub mod f32;
+#[cfg_attr(not(stage0), primitive_type)]
 #[path = "num/f64.rs"]   pub mod f64;
 
 #[macro_use]
@@ -138,6 +165,7 @@ pub mod any;
 pub mod array;
 pub mod sync;
 pub mod cell;
+#[cfg_attr(not(stage0), primitive_type)]
 pub mod char;
 pub mod panicking;
 pub mod iter;
@@ -146,6 +174,7 @@ pub mod raw;
 pub mod result;
 
 pub mod slice;
+#[cfg_attr(not(stage0), primitive_type)]
 pub mod str;
 pub mod hash;
 pub mod fmt;

--- a/src/libcore/num/dec2flt/rawfp.rs
+++ b/src/libcore/num/dec2flt/rawfp.rs
@@ -28,7 +28,6 @@
 //! take the universally-correct slow path (Algorithm M) for very small and very large numbers.
 //! That algorithm needs only next_float() which does handle subnormals and zeros.
 use prelude::v1::*;
-use u32;
 use cmp::Ordering::{Less, Equal, Greater};
 use ops::{Mul, Div, Neg};
 use fmt::{Debug, LowerExp};

--- a/src/libcore/num/flt2dec/decoder.rs
+++ b/src/libcore/num/flt2dec/decoder.rs
@@ -12,7 +12,6 @@
 
 use prelude::v1::*;
 
-use {f32, f64};
 use num::{Float, FpCategory};
 
 /// Decoded unsigned finite value, such that:

--- a/src/libcore/num/flt2dec/mod.rs
+++ b/src/libcore/num/flt2dec/mod.rs
@@ -131,7 +131,6 @@ functions.
             issue = "0")]
 
 use prelude::v1::*;
-use i16;
 pub use self::decoder::{decode, DecodableFloat, FullDecoded, Decoded};
 
 pub mod estimator;

--- a/src/libcore/prelude/v1.rs
+++ b/src/libcore/prelude/v1.rs
@@ -15,6 +15,7 @@
 //! same manner as the standard library's prelude.
 
 #![stable(feature = "core_prelude", since = "1.4.0")]
+#![cfg_attr(not(stage0), no_implicit_prelude)]
 
 // Reexported core operators
 #[stable(feature = "core_prelude", since = "1.4.0")]
@@ -51,3 +52,7 @@
 #[doc(no_inline)] pub use str::StrExt;
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)] pub use char::CharExt;
+
+#[stable(feature = "core_primitive_types", since = "1.9.0")]
+#[doc(no_inline)] pub use {u8, u16, u32, u64, usize, i8, i16, i32, i64, isize,
+                           f32, f64, bool, char, str};

--- a/src/libcore/str/pattern.rs
+++ b/src/libcore/str/pattern.rs
@@ -21,7 +21,6 @@ use prelude::v1::*;
 
 use cmp;
 use fmt;
-use usize;
 
 // Pattern
 

--- a/src/libcoretest/lib.rs
+++ b/src/libcoretest/lib.rs
@@ -28,6 +28,7 @@
 #![feature(libc)]
 #![feature(nonzero)]
 #![feature(peekable_is_empty)]
+#![feature(primitive_type)]
 #![feature(ptr_as_ref)]
 #![feature(rand)]
 #![feature(raw)]

--- a/src/libcoretest/num/flt2dec/mod.rs
+++ b/src/libcoretest/num/flt2dec/mod.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use std::prelude::v1::*;
-use std::{str, mem, i16, f32, f64, fmt};
+use std::{mem, fmt};
 use std::__rand as rand;
 use rand::{Rand, XorShiftRng};
 use rand::distributions::{IndependentSample, Range};

--- a/src/libcoretest/num/flt2dec/strategy/dragon.rs
+++ b/src/libcoretest/num/flt2dec/strategy/dragon.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 use std::prelude::v1::*;
-use std::{i16, f64};
 use super::super::*;
 use core::num::flt2dec::*;
 use core::num::bignum::Big32x40 as Big;

--- a/src/libcoretest/num/mod.rs
+++ b/src/libcoretest/num/mod.rs
@@ -26,6 +26,7 @@ mod uint_macros;
 
 mod u8;
 mod u16;
+#[primitive_type]
 mod u32;
 mod u64;
 

--- a/src/librustc/middle/def.rs
+++ b/src/librustc/middle/def.rs
@@ -121,23 +121,27 @@ impl Def {
         }
     }
 
-    pub fn def_id(&self) -> DefId {
+    pub fn opt_def_id(&self) -> Option<DefId> {
         match *self {
             Def::Fn(id) | Def::Mod(id) | Def::ForeignMod(id) | Def::Static(id, _) |
             Def::Variant(_, id) | Def::Enum(id) | Def::TyAlias(id) | Def::AssociatedTy(_, id) |
             Def::TyParam(_, _, id, _) | Def::Struct(id) | Def::Trait(id) |
             Def::Method(id) | Def::Const(id) | Def::AssociatedConst(id) |
             Def::Local(id, _) | Def::Upvar(id, _, _, _) => {
-                id
+                Some(id)
             }
 
             Def::Label(..)  |
             Def::PrimTy(..) |
             Def::SelfTy(..) |
             Def::Err => {
-                panic!("attempted .def_id() on invalid def: {:?}", self)
+                None
             }
         }
+    }
+
+    pub fn def_id(&self) -> DefId {
+        self.opt_def_id().expect(&format!("attempted .def_id() on invalid def: {:?}", self))
     }
 
     pub fn variant_def_ids(&self) -> Option<(DefId, DefId)> {

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -134,6 +134,11 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
         } else {
             DefModifiers::empty()
         } | DefModifiers::IMPORTABLE;
+        if item.attrs.iter().any(|attr| attr.name() == "primitive_type") {
+            if let Some(def_id) = self.ast_map.opt_local_def_id(item.id) {
+                self.resolver.primitive_type_items.insert(def_id);
+            }
+        }
 
         match item.node {
             ItemUse(ref view_path) => {
@@ -462,6 +467,10 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
         }
         if new_parent.is_normal() {
             modifiers = modifiers | DefModifiers::IMPORTABLE;
+        }
+        if self.session.cstore.item_attrs(def.def_id()).
+                               iter().any(|attr| attr.name() == "primitive_type") {
+            self.resolver.primitive_type_items.insert(def.def_id());
         }
 
         match def {

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -205,51 +205,6 @@ about what constitutes an Item declaration and what does not:
 https://doc.rust-lang.org/reference.html#statements
 "##,
 
-E0317: r##"
-User-defined types or type parameters cannot shadow the primitive types.
-This error indicates you tried to define a type, struct or enum with the same
-name as an existing primitive type:
-
-```compile_fail
-struct u8 {
-    // ...
-}
-```
-
-To fix this, simply name it something else.
-
-Such an error may also occur if you define a type parameter which shadows a
-primitive type. An example would be something like:
-
-```compile_fail
-impl<u8> MyTrait for Option<u8> {
-    // ...
-}
-```
-
-In such a case, if you meant for `u8` to be a generic type parameter (i.e. any
-type can be used in its place), use something like `T` instead:
-
-```ignore
-impl<T> MyTrait for Option<T> {
-    // ...
-}
-```
-
-On the other hand, if you wished to refer to the specific type `u8`, remove it
-from the type parameter list:
-
-```ignore
-impl MyTrait for Option<u8> {
-    // ...
-}
-
-See the Types section of the reference for more information about the primitive
-types:
-
-https://doc.rust-lang.org/reference.html#types
-"##,
-
 E0364: r##"
 Private items cannot be publicly re-exported.  This error indicates that you
 attempted to `pub use` a type or value that was not itself public.

--- a/src/librustc_unicode/lib.rs
+++ b/src/librustc_unicode/lib.rs
@@ -34,10 +34,12 @@
 
 #![feature(core_char_ext)]
 #![feature(lang_items)]
+#![cfg_attr(not(stage0), feature(primitive_type))]
 #![feature(staged_api)]
 
 mod tables;
 mod u_str;
+#[cfg_attr(not(stage0), primitive_type)]
 pub mod char;
 
 #[allow(deprecated)]

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1461,7 +1461,6 @@ mod tests {
     use io::{ErrorKind, SeekFrom};
     use path::Path;
     use rand::{StdRng, Rng};
-    use str;
     use sys_common::io::test::{TempDir, tmpdir};
 
     #[cfg(windows)]

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -247,6 +247,7 @@
 #![feature(oom)]
 #![feature(optin_builtin_traits)]
 #![feature(placement_in_syntax)]
+#![cfg_attr(not(stage0), feature(primitive_type))]
 #![feature(rand)]
 #![feature(raw)]
 #![feature(repr_simd)]
@@ -382,6 +383,9 @@ pub mod prelude;
 // doc pages are inlined from the public re-exports of core_collections::{slice,
 // str} above.
 
+#[stable(feature = "core_primitive_types", since = "1.9.0")]
+pub use core::bool;
+
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::isize;
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -404,7 +408,9 @@ pub use core::u32;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::u64;
 
+#[cfg_attr(not(stage0), primitive_type)]
 #[path = "num/f32.rs"]   pub mod f32;
+#[cfg_attr(not(stage0), primitive_type)]
 #[path = "num/f64.rs"]   pub mod f64;
 
 pub mod ascii;

--- a/src/libstd/prelude/v1.rs
+++ b/src/libstd/prelude/v1.rs
@@ -51,3 +51,8 @@
 #[doc(no_inline)] pub use string::{String, ToString};
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)] pub use vec::Vec;
+
+
+#[stable(feature = "core_primitive_types", since = "1.9.0")]
+#[doc(no_inline)] pub use {u8, u16, u32, u64, usize, i8, i16, i32, i64, isize,
+                           f32, f64, bool, char, str};

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -19,7 +19,6 @@ use ffi::OsStr;
 use fmt;
 use io;
 use path::Path;
-use str;
 use sys::pipe::{read2, AnonPipe};
 use sys::process as imp;
 use sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
@@ -552,7 +551,6 @@ mod tests {
     use io::prelude::*;
 
     use io::ErrorKind;
-    use str;
     use super::{Command, Output, Stdio};
 
     // FIXME(#10380) these tests should not all be ignored on android.

--- a/src/libstd/sync/condvar.rs
+++ b/src/libstd/sync/condvar.rs
@@ -394,7 +394,6 @@ mod tests {
     use sync::atomic::{AtomicUsize, Ordering};
     use thread;
     use time::Duration;
-    use u32;
 
     #[test]
     fn smoke() {

--- a/src/libstd/sys/unix/net.rs
+++ b/src/libstd/sys/unix/net.rs
@@ -14,7 +14,6 @@ use ffi::CStr;
 use io;
 use libc::{self, c_int, size_t, sockaddr, socklen_t};
 use net::{SocketAddr, Shutdown};
-use str;
 use sys::fd::FileDesc;
 use sys_common::{AsInner, FromInner, IntoInner};
 use sys_common::net::{getsockopt, setsockopt};

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -26,7 +26,6 @@ use memchr;
 use path::{self, PathBuf};
 use ptr;
 use slice;
-use str;
 use sync::StaticMutex;
 use sys::cvt;
 use sys::fd;

--- a/src/libstd/sys/windows/handle.rs
+++ b/src/libstd/sys/windows/handle.rs
@@ -21,7 +21,6 @@ use ptr;
 use sys::c;
 use sys::cvt;
 use sys_common::io::read_to_end_uninitialized;
-use u32;
 
 /// An owned container for `HANDLE` object, closing them on Drop.
 ///

--- a/src/libstd/sys/windows/stdio.rs
+++ b/src/libstd/sys/windows/stdio.rs
@@ -16,7 +16,6 @@ use io::prelude::*;
 use cmp;
 use io::{self, Cursor};
 use ptr;
-use str;
 use sync::Mutex;
 use sys::c;
 use sys::cvt;

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -603,7 +603,6 @@ mod tests {
     use super::{Builder};
     use thread;
     use time::Duration;
-    use u32;
 
     // !!! These tests are dangerous. If something is buggy, they will hang, !!!
     // !!! instead of exiting cleanly. This might wedge the buildbots.       !!!

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -89,6 +89,8 @@ const KNOWN_FEATURES: &'static [(&'static str, &'static str, Option<u32>, Status
 
     // rustc internal.
     ("pushpop_unsafe", "1.2.0", None, Active),
+    ("local_prelude", "1.9.0", None, Active),
+    ("primitive_type", "1.9.0", None, Active),
 
     ("on_unimplemented", "1.0.0", Some(29628), Active),
     ("simd_ffi", "1.0.0", Some(27731), Active),
@@ -416,6 +418,9 @@ pub const KNOWN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeGat
                                         "unboxed_closures are still evolving")),
     ("rustc_reflect_like", Whitelisted, Gated("reflect",
                                               "defining reflective traits is still evolving")),
+    // Items marked with #[primitive_type] resolve to primitive types when used in type context
+    ("primitive_type", Whitelisted, Gated("primitive_type",
+                                        "primitive_type is internal to rustc and libcore")),
 
     // Crate level attributes
     ("crate_name", CrateLevel, Ungated),
@@ -426,6 +431,8 @@ pub const KNOWN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeGat
     ("no_main", CrateLevel, Ungated),
     ("no_builtins", CrateLevel, Ungated),
     ("recursion_limit", CrateLevel, Ungated),
+    ("local_prelude", CrateLevel, Gated("local_prelude",
+                                          "this attribute is an implementation detail of libcore")),
 ];
 
 macro_rules! cfg_fn {

--- a/src/test/compile-fail/associated-types-issue-20346.rs
+++ b/src/test/compile-fail/associated-types-issue-20346.rs
@@ -15,6 +15,7 @@
 
 use std::option::Option::{self, None, Some};
 use std::vec::Vec;
+use std::bool;
 
 trait Iterator {
     type Item;

--- a/src/test/compile-fail/import-shadow-1.rs
+++ b/src/test/compile-fail/import-shadow-1.rs
@@ -16,11 +16,11 @@ use foo::*;
 use bar::*; //~ERROR a type named `Baz` has already been imported in this module
 
 mod foo {
-    pub type Baz = isize;
+    pub type Baz = ();
 }
 
 mod bar {
-    pub type Baz = isize;
+    pub type Baz = ();
 }
 
 mod qux {

--- a/src/test/compile-fail/import-shadow-2.rs
+++ b/src/test/compile-fail/import-shadow-2.rs
@@ -16,11 +16,11 @@ use foo::*;
 use foo::*; //~ERROR a type named `Baz` has already been imported in this module
 
 mod foo {
-    pub type Baz = isize;
+    pub type Baz = ();
 }
 
 mod bar {
-    pub type Baz = isize;
+    pub type Baz = ();
 }
 
 mod qux {

--- a/src/test/compile-fail/import-shadow-3.rs
+++ b/src/test/compile-fail/import-shadow-3.rs
@@ -16,11 +16,11 @@ use foo::Baz;
 use bar::*; //~ERROR a type named `Baz` has already been imported in this module
 
 mod foo {
-    pub type Baz = isize;
+    pub type Baz = ();
 }
 
 mod bar {
-    pub type Baz = isize;
+    pub type Baz = ();
 }
 
 mod qux {

--- a/src/test/compile-fail/import-shadow-4.rs
+++ b/src/test/compile-fail/import-shadow-4.rs
@@ -16,11 +16,11 @@ use foo::*;
 use bar::Baz; //~ERROR a type named `Baz` has already been imported in this module
 
 mod foo {
-    pub type Baz = isize;
+    pub type Baz = ();
 }
 
 mod bar {
-    pub type Baz = isize;
+    pub type Baz = ();
 }
 
 mod qux {

--- a/src/test/compile-fail/import-shadow-5.rs
+++ b/src/test/compile-fail/import-shadow-5.rs
@@ -16,11 +16,11 @@ use foo::Baz;
 use bar::Baz; //~ERROR a type named `Baz` has already been imported in this module
 
 mod foo {
-    pub type Baz = isize;
+    pub type Baz = ();
 }
 
 mod bar {
-    pub type Baz = isize;
+    pub type Baz = ();
 }
 
 mod qux {

--- a/src/test/compile-fail/import-shadow-6.rs
+++ b/src/test/compile-fail/import-shadow-6.rs
@@ -16,11 +16,11 @@ use qux::*;
 use foo::*; //~ERROR a type named `Baz` has already been imported in this module
 
 mod foo {
-    pub type Baz = isize;
+    pub type Baz = ();
 }
 
 mod bar {
-    pub type Baz = isize;
+    pub type Baz = ();
 }
 
 mod qux {

--- a/src/test/compile-fail/import-shadow-7.rs
+++ b/src/test/compile-fail/import-shadow-7.rs
@@ -16,11 +16,11 @@ use foo::*;
 use qux::*; //~ERROR a type named `Baz` has already been imported in this module
 
 mod foo {
-    pub type Baz = isize;
+    pub type Baz = ();
 }
 
 mod bar {
-    pub type Baz = isize;
+    pub type Baz = ();
 }
 
 mod qux {

--- a/src/test/compile-fail/issue-19660.rs
+++ b/src/test/compile-fail/issue-19660.rs
@@ -10,11 +10,13 @@
 
 // error-pattern: requires `copy` lang_item
 
-#![feature(lang_items, start, no_core)]
+#![feature(lang_items, start, no_core, primitive_type)]
 #![no_core]
 
 #[lang = "sized"]
 trait Sized { }
+#[primitive_type] type isize = isize;
+#[primitive_type] type u8 = u8;
 
 struct S;
 

--- a/src/test/compile-fail/issue-20427.rs
+++ b/src/test/compile-fail/issue-20427.rs
@@ -17,6 +17,7 @@ fn u8(f32: f32) {}
 fn f<f64>(f64: f64) {}
 //~^ ERROR user-defined types or type parameters cannot shadow the primitive types
 type u16 = u16; //~ ERROR user-defined types or type parameters cannot shadow the primitive types
+//~^ ERROR unsupported cyclic reference between types/traits detected
 enum u32 {} //~ ERROR user-defined types or type parameters cannot shadow the primitive types
 struct u64; //~ ERROR user-defined types or type parameters cannot shadow the primitive types
 trait bool {} //~ ERROR user-defined types or type parameters cannot shadow the primitive types

--- a/src/test/compile-fail/privacy1.rs
+++ b/src/test/compile-fail/privacy1.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(lang_items, start, no_core)]
+#![feature(lang_items, start, no_core, primitive_type)]
 #![no_core] // makes debugging this test *a lot* easier (during resolve)
 
 #[lang="sized"]
@@ -17,8 +17,12 @@ pub trait Sized {}
 #[lang="copy"]
 pub trait Copy {}
 
+#[primitive_type] type isize = isize;
+#[primitive_type] type u8 = u8;
+
 mod bar {
     // shouldn't bring in too much
+    #[primitive_type] type isize = isize;
     pub use self::glob::*;
 
     // can't publicly re-export private items
@@ -93,6 +97,9 @@ fn lol() {
 }
 
 mod foo {
+    #[primitive_type] type isize = isize;
+    #[primitive_type] type f32 = f32;
+
     fn test() {
         ::bar::A::foo();
         ::bar::A::bar();        //~ ERROR: method `bar` is private

--- a/src/test/compile-fail/privacy2.rs
+++ b/src/test/compile-fail/privacy2.rs
@@ -8,10 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(start, no_core)]
+#![feature(start, no_core, primitive_type)]
 #![no_core] // makes debugging this test *a lot* easier (during resolve)
 
 // Test to make sure that globs don't leak in regular `use` statements.
+
+#[primitive_type] type isize = isize;
+#[primitive_type] type u8 = u8;
 
 mod bar {
     pub use self::glob::*;

--- a/src/test/compile-fail/privacy3.rs
+++ b/src/test/compile-fail/privacy3.rs
@@ -8,11 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(start, no_core)]
+#![feature(start, no_core, primitive_type)]
 #![no_core] // makes debugging this test *a lot* easier (during resolve)
 
 // Test to make sure that private items imported through globs remain private
 // when  they're used.
+
+#[primitive_type] type isize = isize;
+#[primitive_type] type u8 = u8;
 
 mod bar {
     pub use self::glob::*;

--- a/src/test/compile-fail/privacy4.rs
+++ b/src/test/compile-fail/privacy4.rs
@@ -8,11 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(lang_items, start, no_core)]
+#![feature(lang_items, start, no_core, primitive_type)]
 #![no_core] // makes debugging this test *a lot* easier (during resolve)
 
 #[lang = "sized"] pub trait Sized {}
 #[lang="copy"] pub trait Copy {}
+#[primitive_type] type isize = isize;
+#[primitive_type] type u8 = u8;
 
 // Test to make sure that private items imported through globs remain private
 // when  they're used.

--- a/src/test/compile-fail/tag-that-dare-not-speak-its-name.rs
+++ b/src/test/compile-fail/tag-that-dare-not-speak-its-name.rs
@@ -12,6 +12,7 @@
 
 #![no_implicit_prelude]
 use std::vec::Vec;
+use std::{char, str, u32};
 
 fn last<T>(v: Vec<&T> ) -> std::option::Option<T> {
     panic!();

--- a/src/test/run-make/simd-ffi/simd.rs
+++ b/src/test/run-make/simd-ffi/simd.rs
@@ -12,11 +12,13 @@
 #![crate_type = "lib"]
 // we can compile to a variety of platforms, because we don't need
 // cross-compiled standard libraries.
-#![feature(no_core)]
+#![feature(no_core, primitive_type)]
 #![no_core]
 
 #![feature(repr_simd, simd_ffi, link_llvm_intrinsics, lang_items)]
 
+#[primitive_type] type i32 = i32;
+#[primitive_type] type f32 = f32;
 
 #[repr(C)]
 #[derive(Copy)]

--- a/src/test/run-make/target-specs/foo.rs
+++ b/src/test/run-make/target-specs/foo.rs
@@ -8,8 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(lang_items, no_core)]
+#![feature(lang_items, no_core, primitive_type)]
 #![no_core]
+
+#[primitive_type] type u8 = u8;
+#[primitive_type] type isize = isize;
 
 #[lang="copy"]
 trait Copy { }

--- a/src/test/run-pass/issue-20427.rs
+++ b/src/test/run-pass/issue-20427.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -15,12 +15,9 @@ static i32: i32 = 0;
 const i64: i64 = 0;
 fn u8(f32: f32) {}
 fn f<f64>(f64: f64) {}
-//~^ ERROR user-defined types or type parameters cannot shadow the primitive types
-type u16 = u16; //~ ERROR user-defined types or type parameters cannot shadow the primitive types
-//~^ ERROR unsupported cyclic reference between types/traits detected
-enum u32 {} //~ ERROR user-defined types or type parameters cannot shadow the primitive types
-struct u64; //~ ERROR user-defined types or type parameters cannot shadow the primitive types
-trait bool {} //~ ERROR user-defined types or type parameters cannot shadow the primitive types
+enum u32 {}
+struct u64;
+trait bool {}
 
 mod char {
     extern crate i8;
@@ -41,29 +38,40 @@ mod char {
         use super::u8_ as u8;
         use super::f_ as f64;
         use super::u16_ as u16;
-        //~^ ERROR user-defined types or type parameters cannot shadow the primitive types
         use super::u32_ as u32;
-        //~^ ERROR user-defined types or type parameters cannot shadow the primitive types
         use super::u64_ as u64;
-        //~^ ERROR user-defined types or type parameters cannot shadow the primitive types
         use super::bool_ as bool;
-        //~^ ERROR user-defined types or type parameters cannot shadow the primitive types
         use super::{bool_ as str};
-        //~^ ERROR user-defined types or type parameters cannot shadow the primitive types
         use super::char_ as char;
     }
 }
 
 trait isize_ {
-    type isize; //~ ERROR user-defined types or type parameters cannot shadow the primitive types
+    type isize;
 }
 
 fn usize<'usize>(usize: &'usize usize) -> &'usize usize { usize }
 
+mod reuse {
+    use std::mem::size_of;
+
+    type u8 = u64;
+    use std::string::String as i16;
+
+    pub fn check<u16>() {
+        assert_eq!(size_of::<u8>(), 8);
+        assert_eq!(size_of::<::u64>(), 0);
+        assert_eq!(size_of::<i16>(), 3 * size_of::<*const ()>());
+        assert_eq!(size_of::<u16>(), 0);
+    }
+}
+
 fn main() {
     let bool = true;
-    match bool {
+    let _ = match bool {
         str @ true => if str { i32 as i64 } else { i64 },
         false => i64,
     };
+
+    reuse::check::<u64>();
 }

--- a/src/test/run-pass/issue-20427.rs
+++ b/src/test/run-pass/issue-20427.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 // aux-build:i8.rs
+// ignore-pretty (#23623)
+
 extern crate i8;
 use std::string as i16;
 static i32: i32 = 0;
@@ -66,6 +68,17 @@ mod reuse {
     }
 }
 
+mod guard {
+    pub fn check() {
+        use std::u8; // bring module u8 in scope
+        fn f() -> u8 { // OK, resolves to primitive u8, not to std::u8
+            u8::max_value() // OK, resolves to associated function <u8>::max_value,
+                            // not to non-existent std::u8::max_value
+        }
+        assert_eq!(f(), u8::MAX); // OK, resolves to std::u8::MAX
+    }
+}
+
 fn main() {
     let bool = true;
     let _ = match bool {
@@ -74,4 +87,5 @@ fn main() {
     };
 
     reuse::check::<u64>();
+    guard::check();
 }

--- a/src/test/run-pass/num-wrapping.rs
+++ b/src/test/run-pass/num-wrapping.rs
@@ -12,7 +12,7 @@
 //
 // Test std::num::Wrapping<T> for {uN, iN, usize, isize}
 
-#![feature(test)]
+#![feature(test, primitive_type)]
 
 extern crate test;
 
@@ -26,6 +26,7 @@ use test::black_box;
 
 macro_rules! int_modules {
     ($(($name:ident, $size:expr),)*) => ($(
+        #[primitive_type]
         mod $name {
             pub const BITS: usize = $size;
             pub use std::$name::*;

--- a/src/test/run-pass/smallest-hello-world.rs
+++ b/src/test/run-pass/smallest-hello-world.rs
@@ -12,7 +12,7 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(intrinsics, lang_items, start, no_core, libc)]
+#![feature(intrinsics, lang_items, start, no_core, libc, primitive_type)]
 #![no_core]
 
 extern crate libc;
@@ -25,6 +25,9 @@ extern "rust-intrinsic" { fn transmute<T, U>(t: T) -> U; }
 #[lang = "panic_fmt"] fn panic_fmt() -> ! { loop {} }
 #[no_mangle] pub extern fn rust_eh_register_frames () {}
 #[no_mangle] pub extern fn rust_eh_unregister_frames () {}
+#[primitive_type] type isize = isize;
+#[primitive_type] type usize = usize;
+#[primitive_type] type u8 = u8;
 
 #[start]
 fn main(_: isize, _: *const *const u8) -> isize {

--- a/src/test/run-pass/use.rs
+++ b/src/test/run-pass/use.rs
@@ -27,4 +27,4 @@ mod baz {
 }
 
 #[start]
-pub fn start(_: isize, _: *const *const u8) -> isize { 0 }
+pub fn start(_: std::isize, _: *const *const ::std::u8) -> std::isize { 0 }


### PR DESCRIPTION
This is a more radical alternative to https://github.com/rust-lang/rust/pull/32131
A new attribute `#[primitive_type]` is introduced. If path used in type position resolves to a `#[primitive_type]` item, the definition of a primitive type with the same name is used instead of this item.
A path cannot resolve to a primitive type in any other way. Several different `#[primitive_type]` items can be resolved to one primitive type.
Most of primitive types are bound to modules (`core::u8`, `core::str` etc.) for backward compatibility.
All the primitive type items are added to the prelude.

Pros:
This makes primitive types appear to be less special and more similar to lang items - they are defined in `libcore` (and also `libcollections`, `librustc_unicode` and `libstd`), shadowed by other items (including modules) and need to be imported before use (but prelude does it for you).

Cons:
It doesn't makes name resolution simpler internally, primitive types are still a hardcoded limited set of `Def::PrimTy`s known to the compiler.
It puts the burden of defining/importing primitive types on `#[no_core]` and `#[no_implicit_prelude]` code. [The alternative PR](https://github.com/rust-lang/rust/pull/32131) presents them as the second small prelude which is hardcoded and has lower priority, so the primitive types are always available.

[breaking-change]
Needs crater before proceeding.

cc https://github.com/rust-lang/rust/pull/32131#issuecomment-196566397
cc @jseyfried 
r? @eddyb 
