### PR TITLE
Resolve: improve diagnostics for duplicate definitions and imports

### DIFF
--- a/src/test/compile-fail/blind-item-block-item-shadow.rs
+++ b/src/test/compile-fail/blind-item-block-item-shadow.rs
@@ -14,7 +14,7 @@ fn main() {
     {
         struct Bar;
         use foo::Bar;
-        //~^ ERROR import `Bar` conflicts with type in this module
-        //~^^ ERROR import `Bar` conflicts with value in this module
+        //~^ ERROR a type named `Bar` has already been defined in this block
+        //~^^ ERROR a value named `Bar` has already been defined in this block
     }
 }

--- a/src/test/compile-fail/blind-item-item-shadow.rs
+++ b/src/test/compile-fail/blind-item-item-shadow.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-mod foo { pub mod foo {  } }
+mod foo { pub mod foo {  } } //~ NOTE previous definition of `foo` here
 
-use foo::foo; //~ ERROR import `foo` conflicts with existing submodule
+use foo::foo; //~ ERROR a module named `foo` has already been defined in this module
 
 fn main() {}

--- a/src/test/compile-fail/enum-and-module-in-same-scope.rs
+++ b/src/test/compile-fail/enum-and-module-in-same-scope.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum Foo {
+enum Foo { //~ NOTE previous definition
     X
 }
 
-mod Foo { //~ ERROR duplicate definition of type or module `Foo`
+mod Foo { //~ ERROR a type named `Foo` has already been defined
     pub static X: isize = 42;
     fn f() { f() } // Check that this does not result in a resolution error
 }

--- a/src/test/compile-fail/issue-19498.rs
+++ b/src/test/compile-fail/issue-19498.rs
@@ -8,14 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use self::A; //~ ERROR import `A` conflicts with existing submodule
-use self::B; //~ ERROR import `B` conflicts with existing submodule
-mod A {}
-pub mod B {}
+use self::A; //~ NOTE previous import of `A` here
+use self::B; //~ NOTE previous import of `B` here
+mod A {} //~ ERROR a module named `A` has already been imported in this module
+pub mod B {} //~ ERROR a module named `B` has already been imported in this module
 
 mod C {
-    use C::D; //~ ERROR import `D` conflicts with existing submodule
-    mod D {}
+    use C::D; //~ NOTE previous import of `D` here
+    mod D {} //~ ERROR a module named `D` has already been imported in this module
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-21546.rs
+++ b/src/test/compile-fail/issue-21546.rs
@@ -12,54 +12,54 @@
 
 #[allow(non_snake_case)]
 mod Foo { }
-//~^ NOTE first definition of type or module `Foo`
+//~^ NOTE previous definition of `Foo` here
 
 #[allow(dead_code)]
 struct Foo;
-//~^ ERROR duplicate definition of type or module `Foo`
-
+//~^ ERROR a module named `Foo` has already been defined in this module
 
 #[allow(non_snake_case)]
 mod Bar { }
-//~^ NOTE first definition of type or module `Bar`
+//~^ NOTE previous definition of `Bar` here
 
 #[allow(dead_code)]
 struct Bar(i32);
-//~^ ERROR duplicate definition of type or module `Bar`
+//~^ ERROR a module named `Bar` has already been defined
 
 
 #[allow(dead_code)]
 struct Baz(i32);
-//~^ NOTE first definition of type or module
+//~^ NOTE previous definition
 
 #[allow(non_snake_case)]
 mod Baz { }
-//~^ ERROR duplicate definition of type or module `Baz`
+//~^ ERROR a type named `Baz` has already been defined
 
 
 #[allow(dead_code)]
 struct Qux { x: bool }
-//~^ NOTE first definition of type or module
+//~^ NOTE previous definition
 
 #[allow(non_snake_case)]
 mod Qux { }
-//~^ ERROR duplicate definition of type or module `Qux`
+//~^ ERROR a type named `Qux` has already been defined
 
 
 #[allow(dead_code)]
 struct Quux;
-//~^ NOTE first definition of type or module
+//~^ NOTE previous definition
 
 #[allow(non_snake_case)]
 mod Quux { }
-//~^ ERROR duplicate definition of type or module `Quux`
+//~^ ERROR a type named `Quux` has already been defined
 
 
 #[allow(dead_code)]
 enum Corge { A, B }
+//~^ NOTE previous definition
 
 #[allow(non_snake_case)]
 mod Corge { }
-//~^ ERROR duplicate definition of type or module `Corge`
+//~^ ERROR a type named `Corge` has already been defined
 
 fn main() { }

--- a/src/test/compile-fail/issue-24081.rs
+++ b/src/test/compile-fail/issue-24081.rs
@@ -8,16 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::ops::Add; //~ ERROR import `Add` conflicts with type in this module
-use std::ops::Sub; //~ ERROR import `Sub` conflicts with type in this module
-use std::ops::Mul; //~ ERROR import `Mul` conflicts with type in this module
-use std::ops::Div; //~ ERROR import `Div` conflicts with existing submodule
-use std::ops::Rem; //~ ERROR import `Rem` conflicts with trait in this module
+use std::ops::Add; //~ NOTE previous import
+use std::ops::Sub; //~ NOTE previous import
+use std::ops::Mul; //~ NOTE previous import
+use std::ops::Div; //~ NOTE previous import
+use std::ops::Rem; //~ NOTE previous import
 
-type Add = bool;
-struct Sub { x: f32 }
-enum Mul { A, B }
-mod Div { }
-trait Rem { }
+type Add = bool; //~ ERROR a trait named `Add` has already been imported in this module
+struct Sub { x: f32 } //~ ERROR a trait named `Sub` has already been imported in this module
+enum Mul { A, B } //~ ERROR a trait named `Mul` has already been imported in this module
+mod Div { } //~ ERROR a trait named `Div` has already been imported in this module
+trait Rem {  } //~ ERROR a trait named `Rem` has already been imported in this module
 
 fn main() {}

--- a/src/test/compile-fail/issue-28472.rs
+++ b/src/test/compile-fail/issue-28472.rs
@@ -13,10 +13,10 @@
 extern {
   fn foo();
 
-  pub //~ ERROR duplicate definition
+  pub //~ ERROR a value named `foo` has already been defined
   fn foo();
 
-  pub //~ ERROR duplicate definition
+  pub //~ ERROR a value named `foo` has already been defined
   static mut foo: u32;
 }
 

--- a/src/test/compile-fail/issue-3099-a.rs
+++ b/src/test/compile-fail/issue-3099-a.rs
@@ -10,6 +10,6 @@
 
 enum a { b, c }
 
-enum a { d, e } //~ ERROR duplicate definition of type or module `a`
+enum a { d, e } //~ ERROR a type named `a` has already been defined in this module
 
 fn main() {}

--- a/src/test/compile-fail/issue-3099-b.rs
+++ b/src/test/compile-fail/issue-3099-b.rs
@@ -10,6 +10,6 @@
 
 pub mod a {}
 
-pub mod a {} //~ ERROR duplicate definition of type or module `a`
+pub mod a {} //~ ERROR a module named `a` has already been defined in this module
 
 fn main() {}

--- a/src/test/compile-fail/issue-3099.rs
+++ b/src/test/compile-fail/issue-3099.rs
@@ -12,7 +12,7 @@ fn a(x: String) -> String {
     format!("First function with {}", x)
 }
 
-fn a(x: String, y: String) -> String { //~ ERROR duplicate definition of value `a`
+fn a(x: String, y: String) -> String { //~ ERROR a value named `a` has already been defined
     format!("Second function with {} and {}", x, y)
 }
 

--- a/src/test/compile-fail/issue-6936.rs
+++ b/src/test/compile-fail/issue-6936.rs
@@ -12,17 +12,17 @@ struct T;
 
 mod t1 {
     type Foo = ::T;
-    mod Foo {} //~ ERROR: duplicate definition of type or module `Foo`
+    mod Foo {} //~ ERROR: `Foo` has already been defined
 }
 
 mod t2 {
     type Foo = ::T;
-    struct Foo; //~ ERROR: duplicate definition of type or module `Foo`
+    struct Foo; //~ ERROR: `Foo` has already been defined
 }
 
 mod t3 {
     type Foo = ::T;
-    enum Foo {} //~ ERROR: duplicate definition of type or module `Foo`
+    enum Foo {} //~ ERROR: `Foo` has already been defined
 }
 
 mod t4 {
@@ -32,7 +32,7 @@ mod t4 {
 
 mod t5 {
     type Bar<T> = T;
-    mod Bar {} //~ ERROR: duplicate definition of type or module `Bar`
+    mod Bar {} //~ ERROR: `Bar` has already been defined
 }
 
 mod t6 {

--- a/src/test/compile-fail/issue-7044.rs
+++ b/src/test/compile-fail/issue-7044.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 static X: isize = 0;
-struct X; //~ ERROR error: duplicate definition of value `X`
+struct X; //~ ERROR `X` has already been defined
 
 fn main() {}

--- a/src/test/compile-fail/issue-8640.rs
+++ b/src/test/compile-fail/issue-8640.rs
@@ -12,8 +12,8 @@
 
 mod foo {
     use baz::bar;
-    //~^ ERROR import `bar` conflicts with existing submodule
     mod bar {}
+    //~^ ERROR a module named `bar` has already been imported
 }
 mod baz { pub mod bar {} }
 

--- a/src/test/compile-fail/no-std-inject.rs
+++ b/src/test/compile-fail/no-std-inject.rs
@@ -10,7 +10,7 @@
 
 #![no_std]
 
-extern crate core; //~ ERROR: an external crate named `core` has already
+extern crate core; //~ ERROR: an extern crate named `core` has already
 extern crate std;
 
 fn main() {}

--- a/src/test/compile-fail/resolve-conflict-extern-crate-vs-extern-crate.rs
+++ b/src/test/compile-fail/resolve-conflict-extern-crate-vs-extern-crate.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 extern crate std;
-//~^ ERROR an external crate named `std` has already been imported
+//~^ ERROR an extern crate named `std` has already been imported
 
 fn main(){}

--- a/src/test/compile-fail/resolve-conflict-import-vs-extern-crate.rs
+++ b/src/test/compile-fail/resolve-conflict-import-vs-extern-crate.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::slice as std; //~ ERROR import `std` conflicts with imported crate
+use std::slice as std; //~ ERROR an extern crate named `std` has already been imported
 
 fn main() {
 }

--- a/src/test/compile-fail/resolve-conflict-item-vs-extern-crate.rs
+++ b/src/test/compile-fail/resolve-conflict-item-vs-extern-crate.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 fn std() {}
-mod std {}    //~ ERROR the name `std` conflicts with an external crate
+mod std {}    //~ ERROR an extern crate named `std` has already been imported
 
 fn main() {
 }

--- a/src/test/compile-fail/resolve-conflict-item-vs-import.rs
+++ b/src/test/compile-fail/resolve-conflict-item-vs-import.rs
@@ -9,9 +9,10 @@
 // except according to those terms.
 
 use std::mem::transmute;
-//~^ ERROR import `transmute` conflicts with value in this module
+//~^ NOTE previous import of `transmute` here
 
 fn transmute() {}
+//~^ ERROR a value named `transmute` has already been imported in this module
 
 fn main() {
 }

--- a/src/test/compile-fail/resolve-conflict-type-vs-import.rs
+++ b/src/test/compile-fail/resolve-conflict-type-vs-import.rs
@@ -9,9 +9,9 @@
 // except according to those terms.
 
 use std::slice::Iter;
-//~^ ERROR import `Iter` conflicts with type in this module
 
 struct Iter;
+//~^ ERROR a type named `Iter` has already been imported in this module
 
 fn main() {
 }

--- a/src/test/compile-fail/trait-duplicate-methods.rs
+++ b/src/test/compile-fail/trait-duplicate-methods.rs
@@ -9,8 +9,8 @@
 // except according to those terms.
 
 trait Foo {
-    fn orange(&self);
-    fn orange(&self);   //~ ERROR error: duplicate definition of value `orange`
+    fn orange(&self); //~ NOTE previous definition of `orange` here
+    fn orange(&self); //~ ERROR a value named `orange` has already been defined in this trait
 }
 
 fn main() {}

--- a/src/test/compile-fail/unresolved-extern-mod-suggestion.rs
+++ b/src/test/compile-fail/unresolved-extern-mod-suggestion.rs
@@ -10,6 +10,6 @@
 
 extern crate core;
 use core;
-//~^ ERROR import `core` conflicts with imported crate in this module
+//~^ ERROR an extern crate named `core` has already been imported in this module
 
 fn main() {}

--- a/src/test/compile-fail/variant-namespacing.rs
+++ b/src/test/compile-fail/variant-namespacing.rs
@@ -10,22 +10,6 @@
 
 // aux-build:variant-namespacing.rs
 
-extern crate variant_namespacing;
-pub use variant_namespacing::XE::*;
-//~^ ERROR import `XStruct` conflicts with type in this module
-//~| ERROR import `XStruct` conflicts with value in this module
-//~| ERROR import `XTuple` conflicts with type in this module
-//~| ERROR import `XTuple` conflicts with value in this module
-//~| ERROR import `XUnit` conflicts with type in this module
-//~| ERROR import `XUnit` conflicts with value in this module
-pub use E::*;
-//~^ ERROR import `Struct` conflicts with type in this module
-//~| ERROR import `Struct` conflicts with value in this module
-//~| ERROR import `Tuple` conflicts with type in this module
-//~| ERROR import `Tuple` conflicts with value in this module
-//~| ERROR import `Unit` conflicts with type in this module
-//~| ERROR import `Unit` conflicts with value in this module
-
 enum E {
     Struct { a: u8 },
     Tuple(u8),
@@ -45,5 +29,21 @@ const Unit: u8 = 0;
 const XStruct: u8 = 0;
 const XTuple: u8 = 0;
 const XUnit: u8 = 0;
+
+extern crate variant_namespacing;
+pub use variant_namespacing::XE::*;
+//~^ ERROR `XStruct` has already been defined
+//~| ERROR `XStruct` has already been defined
+//~| ERROR `XTuple` has already been defined
+//~| ERROR `XTuple` has already been defined
+//~| ERROR `XUnit` has already been defined
+//~| ERROR `XUnit` has already been defined
+pub use E::*;
+//~^ ERROR `Struct` has already been defined
+//~| ERROR `Struct` has already been defined
+//~| ERROR `Tuple` has already been defined
+//~| ERROR `Tuple` has already been defined
+//~| ERROR `Unit` has already been defined
+//~| ERROR `Unit` has already been defined
 
 fn main() {}


### PR DESCRIPTION
This PR improves and regularizes the diagnostics for duplicate definitions and imports.

After this PR, the second of two duplicate definitions/imports will have the following form:

> a(n) [value|type|module|trait|extern crate] named `_name_` has already been [defined|imported] in this [module|block|trait|enum]

with a note referencing the first of the two duplicate definitions/imports:

> previous [definition|import] of `_name_` here

The error indices remain unchanged.

r? @eddyb
