### PR TITLE
test: Fix missing call of function pointer

### DIFF
--- a/src/test/run-pass/variadic-ffi.rs
+++ b/src/test/run-pass/variadic-ffi.rs
@@ -45,15 +45,15 @@ pub fn main() {
         let x: unsafe extern fn(*mut c_char, *const c_char, ...) -> c_int = sprintf;
 
         // A function that takes a function pointer
-        unsafe fn call(p: unsafe extern fn(*mut c_char, *const c_char, ...) -> c_int) {
+        unsafe fn call(fp: unsafe extern fn(*mut c_char, *const c_char, ...) -> c_int) {
             // Call with just the named parameter
             let c = CString::new(&b"Hello World\n"[..]).unwrap();
-            check("Hello World\n", |s| sprintf(s, c.as_ptr()));
+            check("Hello World\n", |s| fp(s, c.as_ptr()));
 
             // Call with variable number of arguments
             let c = CString::new(&b"%d %f %c %s\n"[..]).unwrap();
             check("42 42.500000 a %d %f %c %s\n\n", |s| {
-                sprintf(s, c.as_ptr(), 42, 42.5f64, 'a' as c_int, c.as_ptr());
+                fp(s, c.as_ptr(), 42, 42.5f64, 'a' as c_int, c.as_ptr());
             });
         }
 


### PR DESCRIPTION
Also an unused variable warning was here.
