### PR TITLE
docs: `let` introduces a statement

### DIFF
--- a/src/doc/book/variable-bindings.md
+++ b/src/doc/book/variable-bindings.md
@@ -18,14 +18,14 @@ function, rather than leaving it off. Otherwise, you’ll get an error.
 
 In many languages, a variable binding would be called a *variable*, but Rust’s
 variable bindings have a few tricks up their sleeves. For example the
-left-hand side of a `let` expression is a ‘[pattern][pattern]’, not a
+left-hand side of a `let` statement is a ‘[pattern][pattern]’, not a
 variable name. This means we can do things like:
 
 ```rust
 let (x, y) = (1, 2);
 ```
 
-After this expression is evaluated, `x` will be one, and `y` will be two.
+After this statement is evaluated, `x` will be one, and `y` will be two.
 Patterns are really powerful, and have [their own section][pattern] in the
 book. We don’t need those features for now, so we’ll keep this in the back
 of our minds as we go forward.


### PR DESCRIPTION
I changes _expression_ to _statement_ to make more accurate, because in Rust, `let` introduces a declaration statement.
