### PR TITLE
Deduplicate libraries on hash instead of filename.

### DIFF
--- a/src/librustc/hir/svh.rs
+++ b/src/librustc/hir/svh.rs
@@ -48,7 +48,7 @@
 
 use std::fmt;
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Eq, Hash, PartialEq, Debug)]
 pub struct Svh {
     hash: String,
 }

--- a/src/test/run-make/compiler-lookup-paths/Makefile
+++ b/src/test/run-make/compiler-lookup-paths/Makefile
@@ -18,13 +18,21 @@ all: $(TMPDIR)/libnative.a
 	$(RUSTC) d.rs -L crate=$(TMPDIR)/native && exit 1 || exit 0
 	$(RUSTC) d.rs -L native=$(TMPDIR)/native
 	$(RUSTC) d.rs -L all=$(TMPDIR)/native
+	# Deduplication tests:
+	#   Same hash, no errors.
 	mkdir -p $(TMPDIR)/e1
 	mkdir -p $(TMPDIR)/e2
 	$(RUSTC) e.rs -o $(TMPDIR)/e1/libe.rlib
 	$(RUSTC) e.rs -o $(TMPDIR)/e2/libe.rlib
+	$(RUSTC) f.rs -L $(TMPDIR)/e1 -L $(TMPDIR)/e2
+	$(RUSTC) f.rs -L crate=$(TMPDIR)/e1 -L $(TMPDIR)/e2
+	$(RUSTC) f.rs -L crate=$(TMPDIR)/e1 -L crate=$(TMPDIR)/e2
+	#   Different hash, errors.
+	$(RUSTC) e2.rs -o $(TMPDIR)/e2/libe.rlib
 	$(RUSTC) f.rs -L $(TMPDIR)/e1 -L $(TMPDIR)/e2 && exit 1 || exit 0
 	$(RUSTC) f.rs -L crate=$(TMPDIR)/e1 -L $(TMPDIR)/e2 && exit 1 || exit 0
 	$(RUSTC) f.rs -L crate=$(TMPDIR)/e1 -L crate=$(TMPDIR)/e2 && exit 1 || exit 0
+	#   Native/dependency paths don't cause errors.
 	$(RUSTC) f.rs -L native=$(TMPDIR)/e1 -L $(TMPDIR)/e2
 	$(RUSTC) f.rs -L dependency=$(TMPDIR)/e1 -L $(TMPDIR)/e2
 	$(RUSTC) f.rs -L dependency=$(TMPDIR)/e1 -L crate=$(TMPDIR)/e2

--- a/src/test/run-make/compiler-lookup-paths/e2.rs
+++ b/src/test/run-make/compiler-lookup-paths/e2.rs
@@ -1,0 +1,14 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "e"]
+#![crate_type = "rlib"]
+
+pub fn f() {}

--- a/src/test/run-make/extern-flag-fun/Makefile
+++ b/src/test/run-make/extern-flag-fun/Makefile
@@ -3,14 +3,15 @@
 all:
 	$(RUSTC) bar.rs --crate-type=rlib
 	$(RUSTC) bar.rs --crate-type=rlib -C extra-filename=-a
+	$(RUSTC) bar-alt.rs --crate-type=rlib
 	$(RUSTC) foo.rs --extern hello && exit 1 || exit 0
 	$(RUSTC) foo.rs --extern bar=no-exist && exit 1 || exit 0
 	$(RUSTC) foo.rs --extern bar=foo.rs && exit 1 || exit 0
 	$(RUSTC) foo.rs \
 		--extern bar=$(TMPDIR)/libbar.rlib \
-		--extern bar=$(TMPDIR)/libbar-a.rlib \
+		--extern bar=$(TMPDIR)/libbar-alt.rlib \
 		&& exit 1 || exit 0
 	$(RUSTC) foo.rs \
 		--extern bar=$(TMPDIR)/libbar.rlib \
-		--extern bar=$(TMPDIR)/libbar.rlib
+		--extern bar=$(TMPDIR)/libbar-a.rlib
 	$(RUSTC) foo.rs --extern bar=$(TMPDIR)/libbar.rlib

--- a/src/test/run-make/extern-flag-fun/bar-alt.rs
+++ b/src/test/run-make/extern-flag-fun/bar-alt.rs
@@ -1,0 +1,11 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn f() {}

--- a/src/test/run-make/issue-11908/Makefile
+++ b/src/test/run-make/issue-11908/Makefile
@@ -9,15 +9,13 @@
 
 all:
 	mkdir $(TMPDIR)/other
-	$(RUSTC) foo.rs --crate-type=dylib
+	$(RUSTC) foo.rs --crate-type=dylib -C prefer-dynamic
 	mv $(call DYLIB,foo) $(TMPDIR)/other
-	$(RUSTC) foo.rs --crate-type=dylib
-	$(RUSTC) bar.rs -L $(TMPDIR)/other 2>&1 | \
-		grep "multiple dylib candidates"
+	$(RUSTC) foo.rs --crate-type=dylib -C prefer-dynamic
+	$(RUSTC) bar.rs -L $(TMPDIR)/other
 	rm -rf $(TMPDIR)
 	mkdir -p $(TMPDIR)/other
 	$(RUSTC) foo.rs --crate-type=rlib
 	mv $(TMPDIR)/libfoo.rlib $(TMPDIR)/other
 	$(RUSTC) foo.rs --crate-type=rlib
-	$(RUSTC) bar.rs -L $(TMPDIR)/other 2>&1 | \
-		grep "multiple rlib candidates"
+	$(RUSTC) bar.rs -L $(TMPDIR)/other


### PR DESCRIPTION
Removes the need for canonicalization to prevent #12459.

(Now with passing tests!)

Canonicalization breaks certain environments where the libraries are symlinks to files that don't end in .rlib (e.g. /remote/cas/$HASH).
