### PR TITLE
rustbuild: Fix cross to netbsd from Linux

### DIFF
--- a/src/bootstrap/build/native.rs
+++ b/src/bootstrap/build/native.rs
@@ -114,7 +114,8 @@ pub fn compiler_rt(build: &Build, target: &str) {
     let arch = target.split('-').next().unwrap();
     let mode = if build.config.rust_optimize {"Release"} else {"Debug"};
     let (dir, build_target, libname) = if target.contains("linux") ||
-                                          target.contains("freebsd") {
+                                          target.contains("freebsd") ||
+                                          target.contains("netbsd") {
         let os = if target.contains("android") {"-android"} else {""};
         let arch = if arch.starts_with("arm") && target.contains("eabihf") {
             "armhf"


### PR DESCRIPTION
Apparently the NetBSD compiler-rt builds into the linux directory as well.
I'm... detecting a trend!
