### PR TITLE
Make AssertRecoverSafe's field public

### DIFF
--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -257,10 +257,10 @@ fn runtest(test: &str, cratename: &str, cfgs: Vec<String>, libs: SearchPaths,
     }
 
     match {
-        let b_sess = AssertRecoverSafe::new(&sess);
-        let b_cstore = AssertRecoverSafe::new(&cstore);
-        let b_cfg = AssertRecoverSafe::new(cfg.clone());
-        let b_control = AssertRecoverSafe::new(&control);
+        let b_sess = AssertRecoverSafe(&sess);
+        let b_cstore = AssertRecoverSafe(&cstore);
+        let b_cfg = AssertRecoverSafe(cfg.clone());
+        let b_control = AssertRecoverSafe(&control);
 
         panic::recover(|| {
             driver::compile_input(&b_sess, &b_cstore, (*b_cfg).clone(),

--- a/src/libstd/panic.rs
+++ b/src/libstd/panic.rs
@@ -147,7 +147,7 @@ pub trait RefRecoverSafe {}
 /// // });
 ///
 /// // This, however, will compile due to the `AssertRecoverSafe` wrapper
-/// let result = panic::recover(AssertRecoverSafe::new(|| {
+/// let result = panic::recover(AssertRecoverSafe(|| {
 ///     variable += 3;
 /// }));
 /// // ...
@@ -171,7 +171,7 @@ pub trait RefRecoverSafe {}
 /// let other_capture = 3;
 ///
 /// let result = {
-///     let mut wrapper = AssertRecoverSafe::new(&mut variable);
+///     let mut wrapper = AssertRecoverSafe(&mut variable);
 ///     panic::recover(move || {
 ///         **wrapper += other_capture;
 ///     })
@@ -179,7 +179,7 @@ pub trait RefRecoverSafe {}
 /// // ...
 /// ```
 #[unstable(feature = "recover", reason = "awaiting feedback", issue = "27719")]
-pub struct AssertRecoverSafe<T>(T);
+pub struct AssertRecoverSafe<T>(pub T);
 
 // Implementations of the `RecoverSafe` trait:
 //
@@ -216,12 +216,14 @@ impl<T> RefRecoverSafe for AssertRecoverSafe<T> {}
 impl<T> AssertRecoverSafe<T> {
     /// Creates a new `AssertRecoverSafe` wrapper around the provided type.
     #[unstable(feature = "recover", reason = "awaiting feedback", issue = "27719")]
+    #[rustc_deprecated(reason = "the type's field is now public, construct it directly")]
     pub fn new(t: T) -> AssertRecoverSafe<T> {
         AssertRecoverSafe(t)
     }
 
     /// Consumes the `AssertRecoverSafe`, returning the wrapped value.
     #[unstable(feature = "recover", reason = "awaiting feedback", issue = "27719")]
+    #[rustc_deprecated(reason = "the type's field is now public, access it directly")]
     pub fn into_inner(self) -> T {
         self.0
     }

--- a/src/libstd/panic.rs
+++ b/src/libstd/panic.rs
@@ -216,14 +216,14 @@ impl<T> RefRecoverSafe for AssertRecoverSafe<T> {}
 impl<T> AssertRecoverSafe<T> {
     /// Creates a new `AssertRecoverSafe` wrapper around the provided type.
     #[unstable(feature = "recover", reason = "awaiting feedback", issue = "27719")]
-    #[rustc_deprecated(reason = "the type's field is now public, construct it directly")]
+    #[rustc_deprecated(reason = "the type's field is now public, construct it directly", since = "1.9.0")]
     pub fn new(t: T) -> AssertRecoverSafe<T> {
         AssertRecoverSafe(t)
     }
 
     /// Consumes the `AssertRecoverSafe`, returning the wrapped value.
     #[unstable(feature = "recover", reason = "awaiting feedback", issue = "27719")]
-    #[rustc_deprecated(reason = "the type's field is now public, access it directly")]
+    #[rustc_deprecated(reason = "the type's field is now public, access it directly", since = "1.9.0)]
     pub fn into_inner(self) -> T {
         self.0
     }

--- a/src/libstd/panic.rs
+++ b/src/libstd/panic.rs
@@ -216,14 +216,16 @@ impl<T> RefRecoverSafe for AssertRecoverSafe<T> {}
 impl<T> AssertRecoverSafe<T> {
     /// Creates a new `AssertRecoverSafe` wrapper around the provided type.
     #[unstable(feature = "recover", reason = "awaiting feedback", issue = "27719")]
-    #[rustc_deprecated(reason = "the type's field is now public, construct it directly", since = "1.9.0")]
+    #[rustc_deprecated(reason = "the type's field is now public, construct it directly",
+                       since = "1.9.0")]
     pub fn new(t: T) -> AssertRecoverSafe<T> {
         AssertRecoverSafe(t)
     }
 
     /// Consumes the `AssertRecoverSafe`, returning the wrapped value.
     #[unstable(feature = "recover", reason = "awaiting feedback", issue = "27719")]
-    #[rustc_deprecated(reason = "the type's field is now public, access it directly", since = "1.9.0)]
+    #[rustc_deprecated(reason = "the type's field is now public, access it directly",
+                       since = "1.9.0")]
     pub fn into_inner(self) -> T {
         self.0
     }

--- a/src/test/run-pass/binary-heap-panic-safe.rs
+++ b/src/test/run-pass/binary-heap-panic-safe.rs
@@ -70,7 +70,7 @@ fn test_integrity() {
             {
                 // push the panicking item to the heap and catch the panic
                 let thread_result = {
-                    let mut heap_ref = AssertRecoverSafe::new(&mut heap);
+                    let mut heap_ref = AssertRecoverSafe(&mut heap);
                     panic::recover(move || {
                         heap_ref.push(panic_item);
                     })


### PR DESCRIPTION
It's basically the very definition of a newtype, so we might as well
make things easy on people and let them construct and access it
directly.

r? @aturon 
