### PR TITLE
liveness: substitute bound regions with free ones before normalizing the return type

### DIFF
--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -115,6 +115,7 @@ use middle::pat_util;
 use middle::ty::{self, TyCtxt, ParameterEnvironment};
 use middle::traits::{self, ProjectionMode};
 use middle::infer;
+use middle::subst::Subst;
 use lint;
 use util::nodemap::NodeMap;
 
@@ -1495,6 +1496,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
                     if self.live_on_entry(entry_ln, self.s.no_ret_var).is_some() => {
 
                 let param_env = ParameterEnvironment::for_item(&self.ir.tcx, id);
+                let t_ret_subst = t_ret.subst(&self.ir.tcx, &param_env.free_substs);
                 let infcx = infer::new_infer_ctxt(&self.ir.tcx,
                                                   &self.ir.tcx.tables,
                                                   Some(param_env),
@@ -1502,7 +1504,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
                 let cause = traits::ObligationCause::dummy();
                 let norm = traits::fully_normalize(&infcx,
                                                    cause,
-                                                   &t_ret);
+                                                   &t_ret_subst);
 
                 if norm.unwrap().is_nil() {
                     // for nil return types, it is ok to not return a value expl.

--- a/src/test/compile-fail/issue-32323.rs
+++ b/src/test/compile-fail/issue-32323.rs
@@ -1,0 +1,18 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub trait Tr<'a> {
+    type Out;
+}
+
+pub fn f<'a, T: Tr<'a>>() -> <T as Tr<'a>>::Out {}
+//~^ ERROR not all control paths return a value
+
+pub fn main() {}


### PR DESCRIPTION
Fixes #32323

r? @arielb1 
