### PR TITLE
Update of the book; Error handling, section on custom error types: we…

### DIFF
--- a/src/doc/book/error-handling.md
+++ b/src/doc/book/error-handling.md
@@ -2019,6 +2019,16 @@ impl Error for CliError {
             CliError::NotFound => "not found",
         }
     }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {            
+            CliError::Io(ref err) => Some(err),
+            CliError::Parse(ref err) => Some(err),
+            // Our custom error doesn't have an underlying cause, but we could
+            // modify it so that it does.
+            CliError::NotFound() => None,
+        }
+    }
 }
 ```
 


### PR DESCRIPTION
… should also show the changes to the `cause` method.

When I started creating my own error type, I found that we also have to update the cause method, otherwise we have a missing match branch.

It would also be nice to elaborate on the relationship and difference between the description() and fmt() method, but that should be done by someone with more experience with them. :)
