### PR TITLE
Fix mis-uses of projection mode

### DIFF
--- a/src/librustc/middle/ty/util.rs
+++ b/src/librustc/middle/ty/util.rs
@@ -133,7 +133,7 @@ impl<'a, 'tcx> ParameterEnvironment<'a, 'tcx> {
         let infcx = infer::new_infer_ctxt(tcx,
                                           &tcx.tables,
                                           Some(self.clone()),
-                                          ProjectionMode::AnyFinal);
+                                          ProjectionMode::Topmost);
 
         let adt = match self_type.sty {
             ty::TyStruct(struct_def, substs) => {
@@ -548,7 +548,7 @@ impl<'tcx> ty::TyS<'tcx> {
         let infcx = infer::new_infer_ctxt(tcx,
                                           &tcx.tables,
                                           Some(param_env.clone()),
-                                          ProjectionMode::AnyFinal);
+                                          ProjectionMode::Topmost);
 
         let is_impld = traits::type_known_to_meet_builtin_bound(&infcx,
                                                                 self, bound, span);

--- a/src/test/run-pass/issue-32324.rs
+++ b/src/test/run-pass/issue-32324.rs
@@ -1,0 +1,33 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(dead_code)]
+
+trait Resources {
+    type Buffer: Copy;
+}
+
+#[derive(Copy, Clone)]
+struct ConstantBufferSet<R: Resources>(
+    pub R::Buffer
+);
+
+#[derive(Copy, Clone)]
+enum It {}
+impl Resources for It {
+    type Buffer = u8;
+}
+
+#[derive(Copy, Clone)]
+enum Command {
+    BindConstantBuffers(ConstantBufferSet<It>)
+}
+
+fn main() {}


### PR DESCRIPTION
A couple of places where we construct a fresh inference context were
incorrectly assuming that we were past coherence checking. This commit
corrects them to use `Topmost` rather than `AnyFinal` as the projection mode.

Fixes #32324 

r? @nikomatsakis 
