### PR TITLE
Remove `ErasedRegions` from substs

### DIFF
--- a/src/librustc/middle/traits/specialize/mod.rs
+++ b/src/librustc/middle/traits/specialize/mod.rs
@@ -102,14 +102,6 @@ pub fn translate_substs<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
         specialization_graph::Node::Trait(..) => source_trait_ref.substs.clone(),
     };
 
-    // retain erasure mode
-    // NB: this must happen before inheriting method generics below
-    let target_substs = if source_substs.regions.is_erased() {
-        target_substs.erase_regions()
-    } else {
-        target_substs
-    };
-
     // directly inherent the method generics, since those do not vary across impls
     infcx.tcx.mk_substs(target_substs.with_method_from_subst(source_substs))
 }

--- a/src/librustc/middle/ty/flags.rs
+++ b/src/librustc/middle/ty/flags.rs
@@ -194,13 +194,8 @@ impl FlagComputation {
 
     fn add_substs(&mut self, substs: &subst::Substs) {
         self.add_tys(substs.types.as_slice());
-        match substs.regions {
-            subst::ErasedRegions => {}
-            subst::NonerasedRegions(ref regions) => {
-                for &r in regions {
-                    self.add_region(r);
-                }
-            }
+        for &r in &substs.regions {
+            self.add_region(r);
         }
     }
 

--- a/src/librustc/middle/ty/fold.rs
+++ b/src/librustc/middle/ty/fold.rs
@@ -532,7 +532,7 @@ impl<'tcx> TyCtxt<'tcx> {
             fn fold_substs(&mut self,
                            substs: &subst::Substs<'tcx>)
                            -> subst::Substs<'tcx> {
-                subst::Substs { regions: subst::ErasedRegions,
+                subst::Substs { regions: substs.regions.fold_with(self),
                                 types: substs.types.fold_with(self) }
             }
         }

--- a/src/librustc/middle/ty/mod.rs
+++ b/src/librustc/middle/ty/mod.rs
@@ -2605,7 +2605,7 @@ impl<'tcx> TyCtxt<'tcx> {
 
         Substs {
             types: types,
-            regions: subst::NonerasedRegions(regions)
+            regions: regions,
         }
     }
 

--- a/src/librustc/middle/ty/structural_impls.rs
+++ b/src/librustc/middle/ty/structural_impls.rs
@@ -487,14 +487,7 @@ impl<'tcx> TypeFoldable<'tcx> for ty::Region {
 
 impl<'tcx> TypeFoldable<'tcx> for subst::Substs<'tcx> {
     fn super_fold_with<F: TypeFolder<'tcx>>(&self, folder: &mut F) -> Self {
-        let regions = match self.regions {
-            subst::ErasedRegions => subst::ErasedRegions,
-            subst::NonerasedRegions(ref regions) => {
-                subst::NonerasedRegions(regions.fold_with(folder))
-            }
-        };
-
-        subst::Substs { regions: regions,
+        subst::Substs { regions: self.regions.fold_with(folder),
                         types: self.types.fold_with(folder) }
     }
 
@@ -503,10 +496,7 @@ impl<'tcx> TypeFoldable<'tcx> for subst::Substs<'tcx> {
     }
 
     fn super_visit_with<V: TypeVisitor<'tcx>>(&self, visitor: &mut V) -> bool {
-        self.types.visit_with(visitor) || match self.regions {
-            subst::ErasedRegions => false,
-            subst::NonerasedRegions(ref regions) => regions.visit_with(visitor),
-        }
+        self.types.visit_with(visitor) || self.regions.visit_with(visitor)
     }
 }
 

--- a/src/librustc/middle/ty/sty.rs
+++ b/src/librustc/middle/ty/sty.rs
@@ -1204,18 +1204,18 @@ impl<'tcx> TyS<'tcx> {
             TyTrait(ref obj) => {
                 let mut v = vec![obj.bounds.region_bound];
                 v.extend_from_slice(obj.principal.skip_binder()
-                                       .substs.regions().as_slice());
+                                       .substs.regions.as_slice());
                 v
             }
             TyEnum(_, substs) |
             TyStruct(_, substs) => {
-                substs.regions().as_slice().to_vec()
+                substs.regions.as_slice().to_vec()
             }
             TyClosure(_, ref substs) => {
-                substs.func_substs.regions().as_slice().to_vec()
+                substs.func_substs.regions.as_slice().to_vec()
             }
             TyProjection(ref data) => {
-                data.trait_ref.substs.regions().as_slice().to_vec()
+                data.trait_ref.substs.regions.as_slice().to_vec()
             }
             TyFnDef(..) |
             TyFnPtr(_) |

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -104,17 +104,9 @@ pub fn parameterized<GG>(f: &mut fmt::Formatter,
     };
 
     if verbose {
-        match substs.regions {
-            subst::ErasedRegions => {
-                start_or_continue(f, "<", ", ")?;
-                write!(f, "..")?;
-            }
-            subst::NonerasedRegions(ref regions) => {
-                for region in regions {
-                    start_or_continue(f, "<", ", ")?;
-                    write!(f, "{:?}", region)?;
-                }
-            }
+        for region in &substs.regions {
+            start_or_continue(f, "<", ", ")?;
+            write!(f, "{:?}", region)?;
         }
         for &ty in &substs.types {
             start_or_continue(f, "<", ", ")?;
@@ -136,23 +128,18 @@ pub fn parameterized<GG>(f: &mut fmt::Formatter,
         }
     }
 
-    match substs.regions {
-        subst::ErasedRegions => { }
-        subst::NonerasedRegions(ref regions) => {
-            for &r in regions {
-                start_or_continue(f, "<", ", ")?;
-                let s = r.to_string();
-                if s.is_empty() {
-                    // This happens when the value of the region
-                    // parameter is not easily serialized. This may be
-                    // because the user omitted it in the first place,
-                    // or because it refers to some block in the code,
-                    // etc. I'm not sure how best to serialize this.
-                    write!(f, "'_")?;
-                } else {
-                    write!(f, "{}", s)?;
-                }
-            }
+    for &r in &substs.regions {
+        start_or_continue(f, "<", ", ")?;
+        let s = r.to_string();
+        if s.is_empty() {
+            // This happens when the value of the region
+            // parameter is not easily serialized. This may be
+            // because the user omitted it in the first place,
+            // or because it refers to some block in the code,
+            // etc. I'm not sure how best to serialize this.
+            write!(f, "'_")?;
+        } else {
+            write!(f, "{}", s)?;
         }
     }
 
@@ -390,15 +377,6 @@ impl<'tcx> fmt::Debug for subst::Substs<'tcx> {
 impl<'tcx> fmt::Debug for ty::ItemSubsts<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "ItemSubsts({:?})", self.substs)
-    }
-}
-
-impl fmt::Debug for subst::RegionSubsts {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            subst::ErasedRegions => write!(f, "erased"),
-            subst::NonerasedRegions(ref regions) => write!(f, "{:?}", regions)
-        }
     }
 }
 

--- a/src/librustc_metadata/tydecode.rs
+++ b/src/librustc_metadata/tydecode.rs
@@ -144,20 +144,9 @@ impl<'a,'tcx> TyDecoder<'a,'tcx> {
     }
 
     pub fn parse_substs(&mut self) -> subst::Substs<'tcx> {
-        let regions = self.parse_region_substs();
+        let regions = self.parse_vec_per_param_space(|this| this.parse_region());
         let types = self.parse_vec_per_param_space(|this| this.parse_ty());
         subst::Substs { types: types, regions: regions }
-    }
-
-    fn parse_region_substs(&mut self) -> subst::RegionSubsts {
-        match self.next() {
-            'e' => subst::ErasedRegions,
-            'n' => {
-                subst::NonerasedRegions(
-                    self.parse_vec_per_param_space(|this| this.parse_region()))
-            }
-            _ => panic!("parse_bound_region: bad input")
-        }
     }
 
     fn parse_bound_region(&mut self) -> ty::BoundRegion {

--- a/src/librustc_metadata/tyencode.rs
+++ b/src/librustc_metadata/tyencode.rs
@@ -246,22 +246,10 @@ fn enc_vec_per_param_space<'a, 'tcx, T, F>(w: &mut Cursor<Vec<u8>>,
 
 pub fn enc_substs<'a, 'tcx>(w: &mut Cursor<Vec<u8>>, cx: &ctxt<'a, 'tcx>,
                             substs: &subst::Substs<'tcx>) {
-    enc_region_substs(w, cx, &substs.regions);
+    enc_vec_per_param_space(w, cx, &substs.regions,
+                            |w, cx, &r| enc_region(w, cx, r));
     enc_vec_per_param_space(w, cx, &substs.types,
                             |w, cx, &ty| enc_ty(w, cx, ty));
-}
-
-fn enc_region_substs(w: &mut Cursor<Vec<u8>>, cx: &ctxt, substs: &subst::RegionSubsts) {
-    match *substs {
-        subst::ErasedRegions => {
-            write!(w, "e");
-        }
-        subst::NonerasedRegions(ref regions) => {
-            write!(w, "n");
-            enc_vec_per_param_space(w, cx, regions,
-                                    |w, cx, &r| enc_region(w, cx, r));
-        }
-    }
 }
 
 pub fn enc_region(w: &mut Cursor<Vec<u8>>, cx: &ctxt, r: ty::Region) {

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -673,9 +673,11 @@ pub fn custom_coerce_unsize_info<'ccx, 'tcx>(ccx: &CrateContext<'ccx, 'tcx>,
                                              source_ty: Ty<'tcx>,
                                              target_ty: Ty<'tcx>)
                                              -> CustomCoerceUnsized {
-    let trait_substs = Substs::erased(subst::VecPerParamSpace::new(vec![target_ty],
-                                                                   vec![source_ty],
-                                                                   Vec::new()));
+    let trait_substs = Substs::new(subst::VecPerParamSpace::new(vec![target_ty],
+                                                                vec![source_ty],
+                                                                Vec::new()),
+                                   subst::VecPerParamSpace::empty());
+
     let trait_ref = ty::Binder(ty::TraitRef {
         def_id: ccx.tcx().lang_items.coerce_unsized_trait().unwrap(),
         substs: ccx.tcx().mk_substs(trait_substs)
@@ -1824,10 +1826,8 @@ pub fn trans_closure<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     ccx.stats().n_closures.set(ccx.stats().n_closures.get() + 1);
 
     if collector::collecting_debug_information(ccx) {
-        ccx.record_translation_item_as_generated(TransItem::Fn(Instance {
-            def: def_id,
-            params: &param_substs.types
-        }))
+        ccx.record_translation_item_as_generated(
+            TransItem::Fn(Instance::new(def_id, param_substs)));
     }
 
     let _icx = push_ctxt("trans_closure");
@@ -2259,7 +2259,7 @@ pub fn trans_item(ccx: &CrateContext, item: &hir::Item) {
                 // compilation unit that references the item, so it will still get
                 // translated everywhere it's needed.
                 for (ref ccx, is_origin) in ccx.maybe_iter(!from_external && trans_everywhere) {
-                    let empty_substs = tcx.mk_substs(Substs::trans_empty());
+                    let empty_substs = ccx.empty_substs_for_node_id(item.id);
                     let def_id = tcx.map.local_def_id(item.id);
                     let llfn = Callee::def(ccx, def_id, empty_substs).reify(ccx).val;
                     trans_fn(ccx, &decl, &body, llfn, empty_substs, item.id);
@@ -2298,7 +2298,7 @@ pub fn trans_item(ccx: &CrateContext, item: &hir::Item) {
                     if sig.generics.ty_params.is_empty() {
                         let trans_everywhere = attr::requests_inline(&impl_item.attrs);
                         for (ref ccx, is_origin) in ccx.maybe_iter(trans_everywhere) {
-                            let empty_substs = tcx.mk_substs(Substs::trans_empty());
+                            let empty_substs = ccx.empty_substs_for_node_id(impl_item.id);
                             let def_id = tcx.map.local_def_id(impl_item.id);
                             let llfn = Callee::def(ccx, def_id, empty_substs).reify(ccx).val;
                             trans_fn(ccx, &sig.decl, body, llfn, empty_substs, impl_item.id);
@@ -2389,7 +2389,7 @@ pub fn create_entry_wrapper(ccx: &CrateContext, sp: Span, main_llfn: ValueRef) {
                     Ok(id) => id,
                     Err(s) => ccx.sess().fatal(&s)
                 };
-                let empty_substs = ccx.tcx().mk_substs(Substs::trans_empty());
+                let empty_substs = ccx.tcx().mk_substs(Substs::empty());
                 let start_fn = Callee::def(ccx, start_def_id, empty_substs).reify(ccx).val;
                 let args = {
                     let opaque_rust_main =

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -2259,8 +2259,8 @@ pub fn trans_item(ccx: &CrateContext, item: &hir::Item) {
                 // compilation unit that references the item, so it will still get
                 // translated everywhere it's needed.
                 for (ref ccx, is_origin) in ccx.maybe_iter(!from_external && trans_everywhere) {
-                    let empty_substs = ccx.empty_substs_for_node_id(item.id);
                     let def_id = tcx.map.local_def_id(item.id);
+                    let empty_substs = ccx.empty_substs_for_def_id(def_id);
                     let llfn = Callee::def(ccx, def_id, empty_substs).reify(ccx).val;
                     trans_fn(ccx, &decl, &body, llfn, empty_substs, item.id);
                     set_global_section(ccx, llfn, item);
@@ -2298,8 +2298,8 @@ pub fn trans_item(ccx: &CrateContext, item: &hir::Item) {
                     if sig.generics.ty_params.is_empty() {
                         let trans_everywhere = attr::requests_inline(&impl_item.attrs);
                         for (ref ccx, is_origin) in ccx.maybe_iter(trans_everywhere) {
-                            let empty_substs = ccx.empty_substs_for_node_id(impl_item.id);
                             let def_id = tcx.map.local_def_id(impl_item.id);
+                            let empty_substs = ccx.empty_substs_for_def_id(def_id);
                             let llfn = Callee::def(ccx, def_id, empty_substs).reify(ccx).val;
                             trans_fn(ccx, &sig.decl, body, llfn, empty_substs, impl_item.id);
                             update_linkage(ccx, llfn, Some(impl_item.id),

--- a/src/librustc_trans/trans/callee.rs
+++ b/src/librustc_trans/trans/callee.rs
@@ -383,7 +383,7 @@ pub fn trans_fn_pointer_shim<'a, 'tcx>(
     let llfn = declare::define_internal_fn(ccx, &function_name, tuple_fn_ty);
 
     //
-    let empty_substs = tcx.mk_substs(Substs::trans_empty());
+    let empty_substs = tcx.mk_substs(Substs::empty());
     let (block_arena, fcx): (TypedArena<_>, FunctionContext);
     block_arena = TypedArena::new();
     fcx = FunctionContext::new(ccx, llfn, fn_ty, None, empty_substs, &block_arena);

--- a/src/librustc_trans/trans/closure.rs
+++ b/src/librustc_trans/trans/closure.rs
@@ -144,10 +144,7 @@ fn get_or_create_closure_declaration<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     // duplicate declarations
     let tcx = ccx.tcx();
     let substs = tcx.erase_regions(substs);
-    let instance = Instance {
-        def: closure_id,
-        params: &substs.func_substs.types
-    };
+    let instance = Instance::new(closure_id, &substs.func_substs);
 
     if let Some(&llfn) = ccx.instances().borrow().get(&instance) {
         debug!("get_or_create_closure_declaration(): found closure {:?}: {:?}",

--- a/src/librustc_trans/trans/consts.rs
+++ b/src/librustc_trans/trans/consts.rs
@@ -272,7 +272,7 @@ fn get_const_val<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
                            param_substs: &'tcx Substs<'tcx>)
                            -> Result<ValueRef, ConstEvalFailure> {
     let expr = get_const_expr(ccx, def_id, ref_expr, param_substs);
-    let empty_substs = ccx.tcx().mk_substs(Substs::trans_empty());
+    let empty_substs = ccx.tcx().mk_substs(Substs::empty());
     match get_const_expr_as_global(ccx, expr, ConstQualif::empty(), empty_substs, TrueConst::Yes) {
         Err(Runtime(err)) => {
             ccx.tcx().sess.span_err(expr.span, &err.description());
@@ -1148,7 +1148,7 @@ pub fn trans_static(ccx: &CrateContext,
         let def_id = ccx.tcx().map.local_def_id(id);
         let datum = get_static(ccx, def_id);
 
-        let empty_substs = ccx.tcx().mk_substs(Substs::trans_empty());
+        let empty_substs = ccx.tcx().mk_substs(Substs::empty());
         let (v, _) = const_expr(
             ccx,
             expr,

--- a/src/librustc_trans/trans/context.rs
+++ b/src/librustc_trans/trans/context.rs
@@ -28,7 +28,7 @@ use trans::mir::CachedMir;
 use trans::monomorphize::Instance;
 use trans::collector::{TransItem, TransItemState};
 use trans::type_::{Type, TypeNames};
-use middle::subst::Substs;
+use middle::subst::{Substs, VecPerParamSpace};
 use middle::ty::{self, Ty, TyCtxt};
 use session::config::NoDebugInfo;
 use session::Session;
@@ -551,7 +551,6 @@ impl<'b, 'tcx> CrateContext<'b, 'tcx> {
         self.local
     }
 
-
     /// Get a (possibly) different `CrateContext` from the same
     /// `SharedCrateContext`.
     pub fn rotate(&self) -> CrateContext<'b, 'tcx> {
@@ -855,6 +854,29 @@ impl<'b, 'tcx> CrateContext<'b, 'tcx> {
         } else {
             codegen_items.insert(cgi, TransItemState::NotPredictedButGenerated);
         }
+    }
+
+    /// Given the node-id of some local item that has no type
+    /// parameters, make a suitable "empty substs" for it.
+    pub fn empty_substs_for_node_id(&self, item_node_id: ast::NodeId)
+                                    -> &'tcx Substs<'tcx> {
+        let item_def_id = self.tcx().map.local_def_id(item_node_id);
+        self.empty_substs_for_def_id(item_def_id)
+    }
+
+    /// Given the def-id of some item that has no type parameters, make
+    /// a suitable "empty substs" for it.
+    pub fn empty_substs_for_def_id(&self, item_def_id: DefId) -> &'tcx Substs<'tcx> {
+        let scheme = self.tcx().lookup_item_type(item_def_id);
+        self.empty_substs_for_scheme(&scheme)
+    }
+
+    pub fn empty_substs_for_scheme(&self, scheme: &ty::TypeScheme<'tcx>)
+                                   -> &'tcx Substs<'tcx> {
+        assert!(scheme.generics.types.is_empty());
+        self.tcx().mk_substs(
+            Substs::new(VecPerParamSpace::empty(),
+                        scheme.generics.regions.map(|_| ty::ReStatic)))
     }
 }
 

--- a/src/librustc_trans/trans/context.rs
+++ b/src/librustc_trans/trans/context.rs
@@ -856,14 +856,6 @@ impl<'b, 'tcx> CrateContext<'b, 'tcx> {
         }
     }
 
-    /// Given the node-id of some local item that has no type
-    /// parameters, make a suitable "empty substs" for it.
-    pub fn empty_substs_for_node_id(&self, item_node_id: ast::NodeId)
-                                    -> &'tcx Substs<'tcx> {
-        let item_def_id = self.tcx().map.local_def_id(item_node_id);
-        self.empty_substs_for_def_id(item_def_id)
-    }
-
     /// Given the def-id of some item that has no type parameters, make
     /// a suitable "empty substs" for it.
     pub fn empty_substs_for_def_id(&self, item_def_id: DefId) -> &'tcx Substs<'tcx> {

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -176,7 +176,7 @@ pub fn trans_into<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                 hir::ExprPath(..) => {
                     match bcx.def(expr.id) {
                         Def::Const(did) | Def::AssociatedConst(did) => {
-                            let empty_substs = bcx.tcx().mk_substs(Substs::trans_empty());
+                            let empty_substs = bcx.tcx().mk_substs(Substs::empty());
                             let const_expr = consts::get_const_expr(bcx.ccx(), did, expr,
                                                                     empty_substs);
                             // Temporarily get cleanup scopes out of the way,

--- a/src/librustc_trans/trans/glue.rs
+++ b/src/librustc_trans/trans/glue.rs
@@ -267,7 +267,7 @@ fn get_drop_glue_core<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
 
     let _s = StatRecorder::new(ccx, format!("drop {:?}", t));
 
-    let empty_substs = tcx.mk_substs(Substs::trans_empty());
+    let empty_substs = ccx.tcx().mk_substs(Substs::empty());
     let (arena, fcx): (TypedArena<_>, FunctionContext);
     arena = TypedArena::new();
     fcx = FunctionContext::new(ccx, llfn, fn_ty, None, empty_substs, &arena);
@@ -358,7 +358,7 @@ fn trans_struct_drop<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 
     let trait_ref = ty::Binder(ty::TraitRef {
         def_id: tcx.lang_items.drop_trait().unwrap(),
-        substs: tcx.mk_substs(Substs::trans_empty().with_self_ty(t))
+        substs: tcx.mk_substs(Substs::empty().with_self_ty(t))
     });
     let vtbl = match fulfill_obligation(bcx.ccx(), DUMMY_SP, trait_ref) {
         traits::VtableImpl(data) => data,

--- a/src/librustc_trans/trans/inline.rs
+++ b/src/librustc_trans/trans/inline.rs
@@ -144,8 +144,8 @@ fn instantiate_inline(ccx: &CrateContext, fn_id: DefId) -> Option<DefId> {
                 let impl_tpt = tcx.lookup_item_type(impl_did);
                 if impl_tpt.generics.types.is_empty() &&
                         sig.generics.ty_params.is_empty() {
-                    let empty_substs = ccx.empty_substs_for_node_id(impl_item.id);
                     let def_id = tcx.map.local_def_id(impl_item.id);
+                    let empty_substs = ccx.empty_substs_for_def_id(def_id);
                     let llfn = Callee::def(ccx, def_id, empty_substs).reify(ccx).val;
                     trans_fn(ccx,
                              &sig.decl,

--- a/src/librustc_trans/trans/inline.rs
+++ b/src/librustc_trans/trans/inline.rs
@@ -70,7 +70,7 @@ fn instantiate_inline(ccx: &CrateContext, fn_id: DefId) -> Option<DefId> {
                         // performance.
                         AvailableExternallyLinkage
                     };
-                    let empty_substs = tcx.mk_substs(Substs::trans_empty());
+                    let empty_substs = tcx.mk_substs(Substs::empty());
                     let def_id = tcx.map.local_def_id(item.id);
                     let llfn = Callee::def(ccx, def_id, empty_substs).reify(ccx).val;
                     SetLinkage(llfn, linkage);
@@ -144,7 +144,7 @@ fn instantiate_inline(ccx: &CrateContext, fn_id: DefId) -> Option<DefId> {
                 let impl_tpt = tcx.lookup_item_type(impl_did);
                 if impl_tpt.generics.types.is_empty() &&
                         sig.generics.ty_params.is_empty() {
-                    let empty_substs = tcx.mk_substs(Substs::trans_empty());
+                    let empty_substs = ccx.empty_substs_for_node_id(impl_item.id);
                     let def_id = tcx.map.local_def_id(impl_item.id);
                     let llfn = Callee::def(ccx, def_id, empty_substs).reify(ccx).val;
                     trans_fn(ccx,

--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -1298,7 +1298,7 @@ fn gen_fn<'a, 'tcx>(fcx: &FunctionContext<'a, 'tcx>,
         sig: ty::Binder(sig)
     });
     let llfn = declare::define_internal_fn(ccx, name, rust_fn_ty);
-    let empty_substs = ccx.tcx().mk_substs(Substs::trans_empty());
+    let empty_substs = ccx.tcx().mk_substs(Substs::empty());
     let (fcx, block_arena);
     block_arena = TypedArena::new();
     fcx = FunctionContext::new(ccx, llfn, fn_ty, None, empty_substs, &block_arena);

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -411,7 +411,7 @@ fn create_substs_for_ast_path<'tcx>(
            decl_generics, self_ty, types_provided,
            region_substs);
 
-    assert_eq!(region_substs.regions().len(TypeSpace), decl_generics.regions.len(TypeSpace));
+    assert_eq!(region_substs.regions.len(TypeSpace), decl_generics.regions.len(TypeSpace));
     assert!(region_substs.types.is_empty());
 
     // Convert the type parameters supplied by the user.

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -180,7 +180,7 @@ pub fn compare_impl_method<'tcx>(tcx: &TyCtxt<'tcx>,
         trait_to_impl_substs
         .subst(tcx, impl_to_skol_substs)
         .with_method(impl_to_skol_substs.types.get_slice(subst::FnSpace).to_vec(),
-                     impl_to_skol_substs.regions().get_slice(subst::FnSpace).to_vec());
+                     impl_to_skol_substs.regions.get_slice(subst::FnSpace).to_vec());
     debug!("compare_impl_method: trait_to_skol_substs={:?}",
            trait_to_skol_substs);
 
@@ -439,7 +439,7 @@ pub fn compare_const_impl<'tcx>(tcx: &TyCtxt<'tcx>,
         trait_to_impl_substs
         .subst(tcx, impl_to_skol_substs)
         .with_method(impl_to_skol_substs.types.get_slice(subst::FnSpace).to_vec(),
-                     impl_to_skol_substs.regions().get_slice(subst::FnSpace).to_vec());
+                     impl_to_skol_substs.regions.get_slice(subst::FnSpace).to_vec());
     debug!("compare_const_impl: trait_to_skol_substs={:?}",
            trait_to_skol_substs);
 

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -334,7 +334,7 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
                     .generics.regions.get_slice(subst::FnSpace));
 
         let subst::Substs { types, regions } = substs;
-        let regions = regions.map(|r| r.with_slice(subst::FnSpace, &method_regions));
+        let regions = regions.with_slice(subst::FnSpace, &method_regions);
         let mut final_substs = subst::Substs { types: types, regions: regions };
 
         if num_supplied_types == 0 {

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -505,11 +505,11 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
                 assert_eq!(m.generics.types.get_slice(subst::TypeSpace).len(),
                            trait_ref.substs.types.get_slice(subst::TypeSpace).len());
                 assert_eq!(m.generics.regions.get_slice(subst::TypeSpace).len(),
-                           trait_ref.substs.regions().get_slice(subst::TypeSpace).len());
+                           trait_ref.substs.regions.get_slice(subst::TypeSpace).len());
                 assert_eq!(m.generics.types.get_slice(subst::SelfSpace).len(),
                            trait_ref.substs.types.get_slice(subst::SelfSpace).len());
                 assert_eq!(m.generics.regions.get_slice(subst::SelfSpace).len(),
-                           trait_ref.substs.regions().get_slice(subst::SelfSpace).len());
+                           trait_ref.substs.regions.get_slice(subst::SelfSpace).len());
             }
 
             // Because this trait derives from a where-clause, it
@@ -1194,7 +1194,7 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
         // method yet. So create fresh variables here for those too,
         // if there are any.
         assert_eq!(substs.types.len(subst::FnSpace), 0);
-        assert_eq!(substs.regions().len(subst::FnSpace), 0);
+        assert_eq!(substs.regions.len(subst::FnSpace), 0);
 
         if self.mode == Mode::Path {
             return impl_ty;

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4431,7 +4431,7 @@ pub fn instantiate_path<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
         assert_eq!(substs.types.len(space), type_defs.len(space));
 
         adjust_region_parameters(fcx, span, space, region_defs, &mut substs);
-        assert_eq!(substs.regions().len(space), region_defs.len(space));
+        assert_eq!(substs.regions.len(space), region_defs.len(space));
     }
 
     // The things we are substituting into the type should not contain
@@ -4459,7 +4459,7 @@ pub fn instantiate_path<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
         let impl_scheme = fcx.tcx().lookup_item_type(impl_def_id);
         assert_eq!(substs.types.len(subst::TypeSpace),
                    impl_scheme.generics.types.len(subst::TypeSpace));
-        assert_eq!(substs.regions().len(subst::TypeSpace),
+        assert_eq!(substs.regions.len(subst::TypeSpace),
                    impl_scheme.generics.regions.len(subst::TypeSpace));
 
         let impl_ty = fcx.instantiate_type_scheme(span, &substs, &impl_scheme.ty);
@@ -4550,11 +4550,11 @@ pub fn instantiate_path<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
 
         {
             let region_count = region_defs.len(space);
-            assert_eq!(substs.regions().len(space), 0);
+            assert_eq!(substs.regions.len(space), 0);
             for (i, lifetime) in data.lifetimes.iter().enumerate() {
                 let r = ast_region_to_region(fcx.tcx(), lifetime);
                 if i < region_count {
-                    substs.mut_regions().push(space, r);
+                    substs.regions.push(space, r);
                 } else if i == region_count {
                     span_err!(fcx.tcx().sess, lifetime.span, E0088,
                         "too many lifetime parameters provided: \
@@ -4563,7 +4563,7 @@ pub fn instantiate_path<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                         if region_count == 1 {""} else {"s"},
                         data.lifetimes.len(),
                         if data.lifetimes.len() == 1 {""} else {"s"});
-                    substs.mut_regions().truncate(space, 0);
+                    substs.regions.truncate(space, 0);
                     break;
                 }
             }
@@ -4686,7 +4686,7 @@ pub fn instantiate_path<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
         defs: &VecPerParamSpace<ty::RegionParameterDef>,
         substs: &mut Substs)
     {
-        let provided_len = substs.mut_regions().len(space);
+        let provided_len = substs.regions.len(space);
         let desired = defs.get_slice(space);
 
         // Enforced by `push_explicit_parameters_from_segment_to_substs()`.
@@ -4694,7 +4694,7 @@ pub fn instantiate_path<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
 
         // If nothing was provided, just use inference variables.
         if provided_len == 0 {
-            substs.mut_regions().replace(
+            substs.regions.replace(
                 space,
                 fcx.infcx().region_vars_for_defs(span, desired));
             return;
@@ -4715,7 +4715,7 @@ pub fn instantiate_path<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
             provided_len,
             if provided_len == 1 {""} else {"s"});
 
-        substs.mut_regions().replace(
+        substs.regions.replace(
             space,
             fcx.infcx().region_vars_for_defs(span, desired));
     }

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -1496,7 +1496,7 @@ pub fn substs_wf_in_scope<'a,'tcx>(rcx: &mut Rcx<'a,'tcx>,
 
     let origin = infer::ParameterInScope(origin, expr_span);
 
-    for &region in substs.regions() {
+    for &region in &substs.regions {
         rcx.fcx.mk_subr(origin.clone(), expr_region, region);
     }
 
@@ -1624,7 +1624,7 @@ fn projection_must_outlive<'a, 'tcx>(rcx: &Rcx<'a, 'tcx>,
     // edges, which winds up enforcing the same condition.
     let needs_infer = {
         projection_ty.trait_ref.substs.types.iter().any(|t| t.needs_infer()) ||
-            projection_ty.trait_ref.substs.regions().iter().any(|r| r.needs_infer())
+            projection_ty.trait_ref.substs.regions.iter().any(|r| r.needs_infer())
     };
     if env_bounds.is_empty() && needs_infer {
         debug!("projection_must_outlive: no declared bounds");
@@ -1633,7 +1633,7 @@ fn projection_must_outlive<'a, 'tcx>(rcx: &Rcx<'a, 'tcx>,
             type_must_outlive(rcx, origin.clone(), component_ty, region);
         }
 
-        for &r in projection_ty.trait_ref.substs.regions() {
+        for &r in &projection_ty.trait_ref.substs.regions {
             rcx.fcx.mk_subr(origin.clone(), region, r);
         }
 
@@ -1650,7 +1650,7 @@ fn projection_must_outlive<'a, 'tcx>(rcx: &Rcx<'a, 'tcx>,
     if !env_bounds.is_empty() && env_bounds[1..].iter().all(|b| *b == env_bounds[0]) {
         let unique_bound = env_bounds[0];
         debug!("projection_must_outlive: unique declared bound = {:?}", unique_bound);
-        if projection_ty.trait_ref.substs.regions()
+        if projection_ty.trait_ref.substs.regions
                                          .iter()
                                          .any(|r| env_bounds.contains(r))
         {

--- a/src/librustc_typeck/constrained_type_params.rs
+++ b/src/librustc_typeck/constrained_type_params.rs
@@ -81,7 +81,7 @@ fn parameters_for_type_shallow<'tcx>(ty: Ty<'tcx>) -> Vec<Parameter> {
 }
 
 fn parameters_for_regions_in_substs(substs: &subst::Substs) -> Vec<Parameter> {
-    substs.regions()
+    substs.regions
           .iter()
           .filter_map(|r| parameters_for_region(r))
           .collect()

--- a/src/librustc_typeck/variance/constraints.rs
+++ b/src/librustc_typeck/variance/constraints.rs
@@ -477,7 +477,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
                 self.declared_variance(p.def_id, def_id,
                                        RegionParam, p.space, p.index as usize);
             let variance_i = self.xform(variance, variance_decl);
-            let substs_r = *substs.regions().get(p.space, p.index as usize);
+            let substs_r = *substs.regions.get(p.space, p.index as usize);
             self.add_constraints_from_region(generics, substs_r, variance_i);
         }
     }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -606,7 +606,7 @@ impl<'tcx> Clean<(Vec<TyParamBound>, Vec<TypeBinding>)> for ty::ExistentialBound
 
 fn external_path_params(cx: &DocContext, trait_did: Option<DefId>,
                         bindings: Vec<TypeBinding>, substs: &subst::Substs) -> PathParameters {
-    let lifetimes = substs.regions().get_slice(subst::TypeSpace)
+    let lifetimes = substs.regions.get_slice(subst::TypeSpace)
                     .iter()
                     .filter_map(|v| v.clean(cx))
                     .collect();
@@ -739,7 +739,7 @@ impl<'tcx> Clean<TyParamBound> for ty::TraitRef<'tcx> {
 impl<'tcx> Clean<Option<Vec<TyParamBound>>> for subst::Substs<'tcx> {
     fn clean(&self, cx: &DocContext) -> Option<Vec<TyParamBound>> {
         let mut v = Vec::new();
-        v.extend(self.regions().iter().filter_map(|r| r.clean(cx)).map(RegionBound));
+        v.extend(self.regions.iter().filter_map(|r| r.clean(cx)).map(RegionBound));
         v.extend(self.types.iter().map(|t| TraitBound(PolyTrait {
             trait_: t.clean(cx),
             lifetimes: vec![]


### PR DESCRIPTION
This commit removes the `ErasedRegions` enum from `Substs`. Instead, in trans, we just generate a vector of `ReStatic` of suitable length. The goal is both general cleanup and to help pave the way for a glorious future where erasure is used in type check.

r? @eddyb 

One concern: might be nice to do some profiling. Not sure the best way to do that. Perhaps I'll investigate running nrc's test suite locally.
