### PR TITLE
Fix floating point fast-math intrinsics

### DIFF
--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -165,8 +165,10 @@ extern "C" void LLVMRemoveFunctionAttrString(LLVMValueRef fn, unsigned index, co
 }
 
 // enable fpmath flag UnsafeAlgebra
-extern "C" void LLVMRustSetHasUnsafeAlgebra(LLVMValueRef Instr) {
-    unwrap<Instruction>(Instr)->setHasUnsafeAlgebra(true);
+extern "C" void LLVMRustSetHasUnsafeAlgebra(LLVMValueRef V) {
+    if (auto I = dyn_cast<Instruction>(unwrap<Value>(V))) {
+        I->setHasUnsafeAlgebra(true);
+    }
 }
 
 extern "C" LLVMValueRef LLVMBuildAtomicLoad(LLVMBuilderRef B,

--- a/src/test/run-pass/float_math.rs
+++ b/src/test/run-pass/float_math.rs
@@ -12,13 +12,19 @@
 
 use std::intrinsics::{fadd_fast, fsub_fast, fmul_fast, fdiv_fast, frem_fast};
 
-fn main() {
+#[inline(never)]
+pub fn test_operations(a: f64, b: f64) {
     // make sure they all map to the correct operation
     unsafe {
-        assert_eq!(fadd_fast(1., 2.), 1. + 2.);
-        assert_eq!(fsub_fast(1., 2.), 1. - 2.);
-        assert_eq!(fmul_fast(2., 3.), 2. * 3.);
-        assert_eq!(fdiv_fast(10., 5.), 10. / 5.);
-        assert_eq!(frem_fast(10., 5.), 10. % 5.);
+        assert_eq!(fadd_fast(a, b), a + b);
+        assert_eq!(fsub_fast(a, b), a - b);
+        assert_eq!(fmul_fast(a, b), a * b);
+        assert_eq!(fdiv_fast(a, b), a / b);
+        assert_eq!(frem_fast(a, b), a % b);
     }
+}
+
+fn main() {
+    test_operations(1., 2.);
+    test_operations(10., 5.);
 }


### PR DESCRIPTION
The implementation did not handle the case where both operands were constants, which caused an llvm assertion:

```
rustc: //buildslave//rust-buildbot//slave//nightly-dist-rustc-musl-linux//build//src//llvm//include/llvm/Support/Casting.h:237:
typename llvm::cast_retty<X, Y*>::ret_type llvm::cast(Y*) [with X = llvm::Instruction; Y = llvm::Value; typename llvm::cast_retty<X, Y*>::ret_type = llvm::Instruction*]:
Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"' failed.
```
