### PR TITLE
Alter E0412 help message wording

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3625,7 +3625,7 @@ fn show_candidates(session: &mut DiagnosticBuilder,
             if paths.len() == 1 {
                 session.fileline_help(
                     span,
-                    &format!("you can to import it into scope: `use {};`.",
+                    &format!("you can import it into scope: `use {};`.",
                         &path_strings[0]),
                 );
             } else {

--- a/src/test/compile-fail/issue-21221-2.rs
+++ b/src/test/compile-fail/issue-21221-2.rs
@@ -27,5 +27,5 @@ pub mod baz {
 struct Foo;
 impl T for Foo { }
 //~^ ERROR trait `T` is not in scope
-//~| HELP you can to import it into scope: `use foo::bar::T;`.
+//~| HELP you can import it into scope: `use foo::bar::T;`.
 //~| HELP run `rustc --explain E0405` to see a detailed explanation

--- a/src/test/compile-fail/issue-21221-3.rs
+++ b/src/test/compile-fail/issue-21221-3.rs
@@ -24,7 +24,7 @@ struct Foo;
 // are hidden from the view.
 impl OuterTrait for Foo {}
 //~^ ERROR trait `OuterTrait` is not in scope
-//~| HELP you can to import it into scope: `use issue_21221_3::outer::OuterTrait;`.
+//~| HELP you can import it into scope: `use issue_21221_3::outer::OuterTrait;`.
 //~| HELP run `rustc --explain E0405` to see a detailed explanation
 fn main() {
     println!("Hello, world!");

--- a/src/test/compile-fail/issue-21221-4.rs
+++ b/src/test/compile-fail/issue-21221-4.rs
@@ -19,7 +19,7 @@ struct Foo;
 
 impl T for Foo {}
 //~^ ERROR trait `T` is not in scope
-//~| HELP you can to import it into scope: `use issue_21221_4::T;`.
+//~| HELP you can import it into scope: `use issue_21221_4::T;`.
 //~| HELP run `rustc --explain E0405` to see a detailed explanation
 
 fn main() {


### PR DESCRIPTION
The initial wording does not make sense due to an extra 'to'.

There are two potential candidates we can change this to:
- 'you can import it into scope'
- 'to import it into scope'

In keeping the changes minimal, we choose the first, as this is more in line with the grammar of the extended candidates help message.
