### PR TITLE
docs: Correct an  improper description

### DIFF
--- a/src/doc/book/references-and-borrowing.md
+++ b/src/doc/book/references-and-borrowing.md
@@ -212,7 +212,7 @@ fn main() {
 
 In other words, the mutable borrow is held through the rest of our example. What
 we want is for the mutable borrow by `y` to end so that the resource can be
-returned to the owner, `x`. `x` can then provide a mutable borrow to `println!`.
+returned to the owner, `x`. `x` can then provide a immutable borrow to `println!`.
 In Rust, borrowing is tied to the scope that the borrow is valid for. And our
 scopes look like this:
 


### PR DESCRIPTION
In the example, we made a immutable borrow to `println!`, not a mutable one.
