### PR TITLE
Documentation fix for E0368

### DIFF
--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -3167,8 +3167,8 @@ x <<= 2;
 To fix this error, please check that this type implements this binary
 operation. Example:
 
-```compile_fail
-let x = 12u32; // the `u32` type does implement the `ShlAssign` trait
+```
+let mut x = 12u32; // the `u32` type does implement the `ShlAssign` trait
 
 x <<= 2; // ok!
 ```


### PR DESCRIPTION
Made the 'good' example compile.

I got to the [E0368 error page](https://doc.rust-lang.org/error-index.html#E0368) by following the link in the output of the
compiler. My understanding is that the first example is 'bad' and the
second one is 'good'. Following that logic, I pasted the second example
into the file and to my surprise it did not compile. This commit fixes
the example to make it paste-able.

On the other hand the docstring contained `compile_fail` flag, which might indicate that this was intentional.
I am also assuming here that the `Rust Compiler Error Index` page is generated from the file I changed.

Please let me know what do you think. Thanks a lot !
