### PR TITLE
Correct Windows build instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ build.
 
 Download [MinGW from
 here](http://mingw-w64.org/doku.php/download/mingw-builds), and choose the
-`threads=win32,exceptions=dwarf/seh` flavor when installing. Also, make sure to install to a path without spaces in it. After installing,
+`version=4.9.x,threads=win32,exceptions=dwarf/seh` flavor when installing. Also, make sure to install to a path without spaces in it. After installing,
 add its `bin` directory to your `PATH`. This is due to [#28260](https://github.com/rust-lang/rust/issues/28260), in the future,
 installing from pacman should be just fine.
 


### PR DESCRIPTION
http://mingw-w64.org/doku.php/download/mingw-builds now provides GCC 5.3 as a default version, but avoiding 5.x is exactly the reason why Mingw-builds are recommended instead of MSYS2's own mingw toolchain. One of the 4.9.x versions has to be manually chosen during installation.

r? @alexcrichton 
