### PR TITLE
Add CodeGen options to optimize for size.

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1127,17 +1127,18 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
             }
             OptLevel::Default
         } else {
-            match cg.opt_level.as_ref().map(String::as_ref) {
-                None => OptLevel::No,
-                Some("0") => OptLevel::No,
-                Some("1") => OptLevel::Less,
-                Some("2") => OptLevel::Default,
-                Some("3") => OptLevel::Aggressive,
-                Some("s") => OptLevel::Size,
-                Some("z") => OptLevel::SizeMin,
-                Some(arg) => {
+            match (cg.opt_level.as_ref().map(String::as_ref),
+                   nightly_options::is_nightly_build()) {
+                (None, _) => OptLevel::No,
+                (Some("0"), _) => OptLevel::No,
+                (Some("1"), _) => OptLevel::Less,
+                (Some("2"), _) => OptLevel::Default,
+                (Some("3"), _) => OptLevel::Aggressive,
+                (Some("s"), true) => OptLevel::Size,
+                (Some("z"), true) => OptLevel::SizeMin,
+                (Some(arg), _) => {
                     early_error(error_format, &format!("optimization level needs to be \
-                                                      between 0-3, s, or z (instead was `{}`)",
+                                                      between 0-3 (instead was `{}`)",
                                                      arg));
                 }
             }
@@ -1308,7 +1309,7 @@ pub mod nightly_options {
         is_nightly_build() && matches.opt_strs("Z").iter().any(|x| *x == "unstable-options")
     }
 
-    fn is_nightly_build() -> bool {
+    pub fn is_nightly_build() -> bool {
         match get_unstable_features_setting() {
             UnstableFeatures::Allow | UnstableFeatures::Cheat => true,
             _ => false,

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1136,6 +1136,10 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
                 (Some("3"), _) => OptLevel::Aggressive,
                 (Some("s"), true) => OptLevel::Size,
                 (Some("z"), true) => OptLevel::SizeMin,
+                (Some("s"), false) | (Some("z"), false) => {
+                    early_error(error_format, &format!("the optimizations s or z are only \
+                                                        accepted on the nightly compiler"));
+                },
                 (Some(arg), _) => {
                     early_error(error_format, &format!("optimization level needs to be \
                                                       between 0-3 (instead was `{}`)",

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -48,7 +48,9 @@ pub enum OptLevel {
     No, // -O0
     Less, // -O1
     Default, // -O2
-    Aggressive // -O3
+    Aggressive, // -O3
+    Size, // -Os
+    SizeMin, // -Oz
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -567,8 +569,8 @@ options! {CodegenOptions, CodegenSetter, basic_codegen_options,
     debuginfo: Option<usize> = (None, parse_opt_uint,
         "debug info emission level, 0 = no debug info, 1 = line tables only, \
          2 = full debug info with variable and type information"),
-    opt_level: Option<usize> = (None, parse_opt_uint,
-        "optimize with possible levels 0-3"),
+    opt_level: Option<String> = (None, parse_opt_string,
+        "optimize with possible levels 0-3, s, or z"),
     debug_assertions: Option<bool> = (None, parse_opt_bool,
         "explicitly enable the cfg(debug_assertions) directive"),
     inline_threshold: Option<usize> = (None, parse_opt_uint,
@@ -1125,15 +1127,17 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
             }
             OptLevel::Default
         } else {
-            match cg.opt_level {
+            match cg.opt_level.as_ref().map(String::as_ref) {
                 None => OptLevel::No,
-                Some(0) => OptLevel::No,
-                Some(1) => OptLevel::Less,
-                Some(2) => OptLevel::Default,
-                Some(3) => OptLevel::Aggressive,
+                Some("0") => OptLevel::No,
+                Some("1") => OptLevel::Less,
+                Some("2") => OptLevel::Default,
+                Some("3") => OptLevel::Aggressive,
+                Some("s") => OptLevel::Size,
+                Some("z") => OptLevel::SizeMin,
                 Some(arg) => {
                     early_error(error_format, &format!("optimization level needs to be \
-                                                      between 0-3 (instead was `{}`)",
+                                                      between 0-3, s, or z (instead was `{}`)",
                                                      arg));
                 }
             }

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -44,6 +44,7 @@ pub use self::FileType::*;
 pub use self::MetadataType::*;
 pub use self::AsmDialect::*;
 pub use self::CodeGenOptLevel::*;
+pub use self::CodeGenOptSize::*;
 pub use self::RelocMode::*;
 pub use self::CodeGenModel::*;
 pub use self::DiagnosticKind::*;
@@ -373,6 +374,14 @@ pub enum CodeGenOptLevel {
     CodeGenLevelLess = 1,
     CodeGenLevelDefault = 2,
     CodeGenLevelAggressive = 3,
+}
+
+#[derive(Copy, Clone, PartialEq)]
+#[repr(C)]
+pub enum CodeGenOptSize {
+    CodeGenOptSizeNone = 0,
+    CodeGenOptSizeDefault = 1,
+    CodeGenOptSizeAggressive = 2,
 }
 
 #[derive(Copy, Clone, PartialEq)]

--- a/src/librustc_trans/declare.rs
+++ b/src/librustc_trans/declare.rs
@@ -69,6 +69,17 @@ fn declare_raw_fn(ccx: &CrateContext, name: &str, callconv: llvm::CallConv, ty: 
         llvm::SetFunctionAttribute(llfn, llvm::Attribute::NoRedZone)
     }
 
+    match ccx.tcx().sess.opts.cg.opt_level.as_ref().map(String::as_ref) {
+        Some("s") => {
+            llvm::SetFunctionAttribute(llfn, llvm::Attribute::OptimizeForSize);
+        },
+        Some("z") => {
+            llvm::SetFunctionAttribute(llfn, llvm::Attribute::MinSize);
+            llvm::SetFunctionAttribute(llfn, llvm::Attribute::OptimizeForSize);
+        },
+        _ => {},
+    }
+
     llfn
 }
 

--- a/src/test/run-make/debug-assertions/Makefile
+++ b/src/test/run-make/debug-assertions/Makefile
@@ -11,6 +11,10 @@ all:
 	$(call RUN,debug) good
 	$(RUSTC) debug.rs -C opt-level=3
 	$(call RUN,debug) good
+	$(RUSTC) debug.rs -C opt-level=s
+	$(call RUN,debug) good
+	$(RUSTC) debug.rs -C opt-level=z
+	$(call RUN,debug) good
 	$(RUSTC) debug.rs -O
 	$(call RUN,debug) good
 	$(RUSTC) debug.rs

--- a/src/test/run-make/emit/Makefile
+++ b/src/test/run-make/emit/Makefile
@@ -5,6 +5,8 @@ all:
 	$(RUSTC) -Copt-level=1 --emit=llvm-bc,llvm-ir,asm,obj,link test-24876.rs
 	$(RUSTC) -Copt-level=2 --emit=llvm-bc,llvm-ir,asm,obj,link test-24876.rs
 	$(RUSTC) -Copt-level=3 --emit=llvm-bc,llvm-ir,asm,obj,link test-24876.rs
+	$(RUSTC) -Copt-level=s --emit=llvm-bc,llvm-ir,asm,obj,link test-24876.rs
+	$(RUSTC) -Copt-level=z --emit=llvm-bc,llvm-ir,asm,obj,link test-24876.rs
 	$(RUSTC) -Copt-level=0 --emit=llvm-bc,llvm-ir,asm,obj,link test-26235.rs
 	$(call RUN,test-26235) || exit 1
 	$(RUSTC) -Copt-level=1 --emit=llvm-bc,llvm-ir,asm,obj,link test-26235.rs
@@ -12,4 +14,8 @@ all:
 	$(RUSTC) -Copt-level=2 --emit=llvm-bc,llvm-ir,asm,obj,link test-26235.rs
 	$(call RUN,test-26235) || exit 1
 	$(RUSTC) -Copt-level=3 --emit=llvm-bc,llvm-ir,asm,obj,link test-26235.rs
+	$(call RUN,test-26235) || exit 1
+	$(RUSTC) -Copt-level=s --emit=llvm-bc,llvm-ir,asm,obj,link test-26235.rs
+	$(call RUN,test-26235) || exit 1
+	$(RUSTC) -Copt-level=z --emit=llvm-bc,llvm-ir,asm,obj,link test-26235.rs
 	$(call RUN,test-26235) || exit 1


### PR DESCRIPTION
Add CodeGen options to annotate functions with the attributes OptimizeSize and/or MinSize used by LLVM to reduce .text size.
Closes #32296
