### PR TITLE
convert 99.9% of `try!`s to `?`s

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -15,6 +15,7 @@
 #![feature(rustc_private)]
 #![feature(str_char)]
 #![feature(test)]
+#![feature(question_mark)]
 
 #![deny(warnings)]
 

--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -280,16 +280,16 @@ fn collect_tests_from_dir(config: &Config,
                           -> io::Result<()> {
     // Ignore directories that contain a file
     // `compiletest-ignore-dir`.
-    for file in try!(fs::read_dir(dir)) {
-        let file = try!(file);
+    for file in fs::read_dir(dir)? {
+        let file = file?;
         if file.file_name() == *"compiletest-ignore-dir" {
             return Ok(());
         }
     }
 
-    let dirs = try!(fs::read_dir(dir));
+    let dirs = fs::read_dir(dir)?;
     for file in dirs {
-        let file = try!(file);
+        let file = file?;
         let file_path = file.path();
         debug!("inspecting file {:?}", file_path.display());
         if is_test(config, &file_path) {
@@ -310,11 +310,11 @@ fn collect_tests_from_dir(config: &Config,
             tests.push(make_test(config, &paths))
         } else if file_path.is_dir() {
             let relative_file_path = relative_dir_path.join(file.file_name());
-            try!(collect_tests_from_dir(config,
+            collect_tests_from_dir(config,
                                         base,
                                         &file_path,
                                         &relative_file_path,
-                                        tests));
+                                        tests)?;
         }
     }
     Ok(())

--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -312,10 +312,10 @@ fn collect_tests_from_dir(config: &Config,
         } else if file_path.is_dir() {
             let relative_file_path = relative_dir_path.join(file.file_name());
             collect_tests_from_dir(config,
-                                        base,
-                                        &file_path,
-                                        &relative_file_path,
-                                        tests)?;
+                                   base,
+                                   &file_path,
+                                   relative_file_path,
+                                   tests)?;
         }
     }
     Ok(())

--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -314,7 +314,7 @@ fn collect_tests_from_dir(config: &Config,
             collect_tests_from_dir(config,
                                    base,
                                    &file_path,
-                                   relative_file_path,
+                                   &relative_file_path,
                                    tests)?;
         }
     }

--- a/src/libcore/fmt/builders.rs
+++ b/src/libcore/fmt/builders.rs
@@ -29,7 +29,7 @@ impl<'a, 'b: 'a> fmt::Write for PadAdapter<'a, 'b> {
     fn write_str(&mut self, mut s: &str) -> fmt::Result {
         while !s.is_empty() {
             if self.on_newline {
-                try!(self.fmt.write_str("    "));
+                self.fmt.write_str("    ")?;
             }
 
             let split = match s.find('\n') {
@@ -42,7 +42,7 @@ impl<'a, 'b: 'a> fmt::Write for PadAdapter<'a, 'b> {
                     s.len()
                 }
             };
-            try!(self.fmt.write_str(&s[..split]));
+            self.fmt.write_str(&s[..split])?;
             s = &s[split..];
         }
 
@@ -169,10 +169,10 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
         if self.fields > 0 {
             self.result = self.result.and_then(|_| {
                 if self.is_pretty() {
-                    try!(self.fmt.write_str("\n"));
+                    self.fmt.write_str("\n")?;
                 }
                 if self.fields == 1 && self.empty_name {
-                    try!(self.fmt.write_str(","));
+                    self.fmt.write_str(",")?;
                 }
                 self.fmt.write_str(")")
             });

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -77,6 +77,7 @@
 #![feature(rustc_attrs)]
 #![feature(staged_api)]
 #![feature(unboxed_closures)]
+#![feature(question_mark)]
 
 #[macro_use]
 mod macros;

--- a/src/libcore/num/dec2flt/mod.rs
+++ b/src/libcore/num/dec2flt/mod.rs
@@ -214,7 +214,7 @@ fn dec2flt<T: RawFloat>(s: &str) -> Result<T, ParseFloatError> {
     }
     let (sign, s) = extract_sign(s);
     let flt = match parse_decimal(s) {
-        ParseResult::Valid(decimal) => try!(convert(decimal)),
+        ParseResult::Valid(decimal) => convert(decimal)?,
         ParseResult::ShortcutToInf => T::infinity(),
         ParseResult::ShortcutToZero => T::zero(),
         ParseResult::Invalid => match s {

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -240,7 +240,7 @@ impl Utf8Error {
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn from_utf8(v: &[u8]) -> Result<&str, Utf8Error> {
-    try!(run_utf8_validation(v));
+    run_utf8_validation(v)?;
     Ok(unsafe { from_utf8_unchecked(v) })
 }
 

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -295,6 +295,7 @@
 #![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(str_escape)]
+#![feature(question_mark)]
 
 use self::LabelText::*;
 

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -662,7 +662,7 @@ pub fn render_opts<'a, N, E, G, W>(g: &'a G,
 {
     fn writeln<W: Write>(w: &mut W, arg: &[&str]) -> io::Result<()> {
         for &s in arg {
-            try!(w.write_all(s.as_bytes()));
+            w.write_all(s.as_bytes())?;
         }
         write!(w, "\n")
     }
@@ -671,9 +671,9 @@ pub fn render_opts<'a, N, E, G, W>(g: &'a G,
         w.write_all(b"    ")
     }
 
-    try!(writeln(w, &["digraph ", g.graph_id().as_slice(), " {"]));
+    writeln(w, &["digraph ", g.graph_id().as_slice(), " {"])?;
     for n in g.nodes().iter() {
-        try!(indent(w));
+        indent(w)?;
         let id = g.node_id(n);
 
         let escaped = &g.node_label(n).to_dot_string();
@@ -702,12 +702,12 @@ pub fn render_opts<'a, N, E, G, W>(g: &'a G,
         }
 
         text.push(";");
-        try!(writeln(w, &text));
+        writeln(w, &text)?;
     }
 
     for e in g.edges().iter() {
         let escaped_label = &g.edge_label(e).to_dot_string();
-        try!(indent(w));
+        indent(w)?;
         let source = g.source(e);
         let target = g.target(e);
         let source_id = g.node_id(&source);
@@ -729,7 +729,7 @@ pub fn render_opts<'a, N, E, G, W>(g: &'a G,
         }
 
         text.push(";");
-        try!(writeln(w, &text));
+        writeln(w, &text)?;
     }
 
     writeln(w, &["}"])
@@ -959,7 +959,7 @@ mod tests {
         let mut writer = Vec::new();
         render(&g, &mut writer).unwrap();
         let mut s = String::new();
-        try!(Read::read_to_string(&mut &*writer, &mut s));
+        Read::read_to_string(&mut &*writer, &mut s)?;
         Ok(s)
     }
 

--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -125,6 +125,7 @@
 #![feature(copy_from_slice)]
 #![feature(rustc_private)]
 #![feature(staged_api)]
+#![feature(question_mark)]
 
 #![cfg_attr(test, feature(test))]
 

--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -398,8 +398,8 @@ pub mod reader {
     }
 
     pub fn doc_at<'a>(data: &'a [u8], start: usize) -> DecodeResult<TaggedDoc<'a>> {
-        let elt_tag = try!(tag_at(data, start));
-        let elt_size = try!(tag_len_at(data, elt_tag));
+        let elt_tag = tag_at(data, start)?;
+        let elt_size = tag_len_at(data, elt_tag)?;
         let end = elt_size.next + elt_size.val;
         Ok(TaggedDoc {
             tag: elt_tag.val,
@@ -581,7 +581,7 @@ pub mod reader {
             if self.pos >= self.parent.end {
                 return Err(Expected(format!("no more documents in current node!")));
             }
-            let TaggedDoc { tag: r_tag, doc: r_doc } = try!(doc_at(self.parent.data, self.pos));
+            let TaggedDoc { tag: r_tag, doc: r_doc } = doc_at(self.parent.data, self.pos)?;
             debug!("self.parent={:?}-{:?} self.pos={:?} r_tag={:?} r_doc={:?}-{:?}",
                    self.parent.start,
                    self.parent.end,
@@ -607,12 +607,12 @@ pub mod reader {
         fn push_doc<T, F>(&mut self, exp_tag: EbmlEncoderTag, f: F) -> DecodeResult<T>
             where F: FnOnce(&mut Decoder<'doc>) -> DecodeResult<T>
         {
-            let d = try!(self.next_doc(exp_tag));
+            let d = self.next_doc(exp_tag)?;
             let old_parent = self.parent;
             let old_pos = self.pos;
             self.parent = d;
             self.pos = d.start;
-            let r = try!(f(self));
+            let r = f(self)?;
             self.parent = old_parent;
             self.pos = old_pos;
             Ok(r)
@@ -624,7 +624,7 @@ pub mod reader {
                 return Ok(0);
             }
 
-            let TaggedDoc { tag: r_tag, doc: r_doc } = try!(doc_at(self.parent.data, self.pos));
+            let TaggedDoc { tag: r_tag, doc: r_doc } = doc_at(self.parent.data, self.pos)?;
             let r = if r_tag == (EsSub8 as usize) {
                 doc_as_u8(r_doc) as usize
             } else if r_tag == (EsSub32 as usize) {
@@ -659,7 +659,7 @@ pub mod reader {
                 return Err(Expected(format!("no more documents in current node!")));
             }
 
-            let TaggedDoc { tag: r_tag, doc: r_doc } = try!(doc_at(self.parent.data, self.pos));
+            let TaggedDoc { tag: r_tag, doc: r_doc } = doc_at(self.parent.data, self.pos)?;
             let r = if first_tag as usize <= r_tag && r_tag <= last_tag as usize {
                 match r_tag - first_tag as usize {
                     0 => doc_as_u8(r_doc) as u64,
@@ -689,11 +689,11 @@ pub mod reader {
         pub fn read_opaque<R, F>(&mut self, op: F) -> DecodeResult<R>
             where F: FnOnce(&mut opaque::Decoder, Doc) -> DecodeResult<R>
         {
-            let doc = try!(self.next_doc(EsOpaque));
+            let doc = self.next_doc(EsOpaque)?;
 
             let result = {
                 let mut opaque_decoder = opaque::Decoder::new(doc.data, doc.start);
-                try!(op(&mut opaque_decoder, doc))
+                op(&mut opaque_decoder, doc)?
             };
 
             Ok(result)
@@ -718,16 +718,16 @@ pub mod reader {
             self._next_int(EsU8, EsU64)
         }
         fn read_u32(&mut self) -> DecodeResult<u32> {
-            Ok(try!(self._next_int(EsU8, EsU32)) as u32)
+            Ok(self._next_int(EsU8, EsU32)? as u32)
         }
         fn read_u16(&mut self) -> DecodeResult<u16> {
-            Ok(try!(self._next_int(EsU8, EsU16)) as u16)
+            Ok(self._next_int(EsU8, EsU16)? as u16)
         }
         fn read_u8(&mut self) -> DecodeResult<u8> {
-            Ok(doc_as_u8(try!(self.next_doc(EsU8))))
+            Ok(doc_as_u8(self.next_doc(EsU8)?))
         }
         fn read_uint(&mut self) -> DecodeResult<usize> {
-            let v = try!(self._next_int(EsU8, EsU64));
+            let v = self._next_int(EsU8, EsU64)?;
             if v > (::std::usize::MAX as u64) {
                 Err(IntTooBig(v as usize))
             } else {
@@ -736,19 +736,19 @@ pub mod reader {
         }
 
         fn read_i64(&mut self) -> DecodeResult<i64> {
-            Ok(try!(self._next_int(EsI8, EsI64)) as i64)
+            Ok(self._next_int(EsI8, EsI64)? as i64)
         }
         fn read_i32(&mut self) -> DecodeResult<i32> {
-            Ok(try!(self._next_int(EsI8, EsI32)) as i32)
+            Ok(self._next_int(EsI8, EsI32)? as i32)
         }
         fn read_i16(&mut self) -> DecodeResult<i16> {
-            Ok(try!(self._next_int(EsI8, EsI16)) as i16)
+            Ok(self._next_int(EsI8, EsI16)? as i16)
         }
         fn read_i8(&mut self) -> DecodeResult<i8> {
-            Ok(doc_as_u8(try!(self.next_doc(EsI8))) as i8)
+            Ok(doc_as_u8(self.next_doc(EsI8)?) as i8)
         }
         fn read_int(&mut self) -> DecodeResult<isize> {
-            let v = try!(self._next_int(EsI8, EsI64)) as i64;
+            let v = self._next_int(EsI8, EsI64)? as i64;
             if v > (isize::MAX as i64) || v < (isize::MIN as i64) {
                 debug!("FIXME \\#6122: Removing this makes this function miscompile");
                 Err(IntTooBig(v as usize))
@@ -758,22 +758,22 @@ pub mod reader {
         }
 
         fn read_bool(&mut self) -> DecodeResult<bool> {
-            Ok(doc_as_u8(try!(self.next_doc(EsBool))) != 0)
+            Ok(doc_as_u8(self.next_doc(EsBool)?) != 0)
         }
 
         fn read_f64(&mut self) -> DecodeResult<f64> {
-            let bits = doc_as_u64(try!(self.next_doc(EsF64)));
+            let bits = doc_as_u64(self.next_doc(EsF64)?);
             Ok(unsafe { transmute(bits) })
         }
         fn read_f32(&mut self) -> DecodeResult<f32> {
-            let bits = doc_as_u32(try!(self.next_doc(EsF32)));
+            let bits = doc_as_u32(self.next_doc(EsF32)?);
             Ok(unsafe { transmute(bits) })
         }
         fn read_char(&mut self) -> DecodeResult<char> {
-            Ok(char::from_u32(doc_as_u32(try!(self.next_doc(EsChar)))).unwrap())
+            Ok(char::from_u32(doc_as_u32(self.next_doc(EsChar)?)).unwrap())
         }
         fn read_str(&mut self) -> DecodeResult<String> {
-            Ok(try!(self.next_doc(EsStr)).as_str())
+            Ok(self.next_doc(EsStr)?.as_str())
         }
 
         // Compound types:
@@ -782,13 +782,13 @@ pub mod reader {
         {
             debug!("read_enum({})", name);
 
-            let doc = try!(self.next_doc(EsEnum));
+            let doc = self.next_doc(EsEnum)?;
 
             let (old_parent, old_pos) = (self.parent, self.pos);
             self.parent = doc;
             self.pos = self.parent.start;
 
-            let result = try!(f(self));
+            let result = f(self)?;
 
             self.parent = old_parent;
             self.pos = old_pos;
@@ -799,7 +799,7 @@ pub mod reader {
             where F: FnMut(&mut Decoder<'doc>, usize) -> DecodeResult<T>
         {
             debug!("read_enum_variant()");
-            let idx = try!(self._next_sub());
+            let idx = self._next_sub()?;
             debug!("  idx={}", idx);
 
             f(self, idx)
@@ -816,7 +816,7 @@ pub mod reader {
             where F: FnMut(&mut Decoder<'doc>, usize) -> DecodeResult<T>
         {
             debug!("read_enum_struct_variant()");
-            let idx = try!(self._next_sub());
+            let idx = self._next_sub()?;
             debug!("  idx={}", idx);
 
             f(self, idx)
@@ -904,7 +904,7 @@ pub mod reader {
         {
             debug!("read_seq()");
             self.push_doc(EsVec, move |d| {
-                let len = try!(d._next_sub());
+                let len = d._next_sub()?;
                 debug!("  len={}", len);
                 f(d, len)
             })
@@ -922,7 +922,7 @@ pub mod reader {
         {
             debug!("read_map()");
             self.push_doc(EsMap, move |d| {
-                let len = try!(d._next_sub());
+                let len = d._next_sub()?;
                 debug!("  len={}", len);
                 f(d, len)
             })
@@ -1020,10 +1020,10 @@ pub mod writer {
             assert!(tag_id >= NUM_IMPLICIT_TAGS);
 
             // Write the enum ID:
-            try!(write_tag(self.writer, tag_id));
+            write_tag(self.writer, tag_id)?;
 
             // Write a placeholder four-byte size.
-            let cur_pos = try!(self.writer.seek(SeekFrom::Current(0)));
+            let cur_pos = self.writer.seek(SeekFrom::Current(0))?;
             self.size_positions.push(cur_pos);
             let zeroes: &[u8] = &[0, 0, 0, 0];
             self.writer.write_all(zeroes)
@@ -1031,8 +1031,8 @@ pub mod writer {
 
         pub fn end_tag(&mut self) -> EncodeResult {
             let last_size_pos = self.size_positions.pop().unwrap();
-            let cur_pos = try!(self.writer.seek(SeekFrom::Current(0)));
-            try!(self.writer.seek(SeekFrom::Start(last_size_pos)));
+            let cur_pos = self.writer.seek(SeekFrom::Current(0))?;
+            self.writer.seek(SeekFrom::Start(last_size_pos))?;
             let size = (cur_pos - last_size_pos - 4) as usize;
 
             // relax the size encoding for small tags (bigger tags are costly to move).
@@ -1048,12 +1048,12 @@ pub mod writer {
                 }
 
                 // overwrite the size and data and continue
-                try!(write_vuint(self.writer, size));
-                try!(self.writer.write_all(&buf[..size]));
+                write_vuint(self.writer, size)?;
+                self.writer.write_all(&buf[..size])?;
             } else {
                 // overwrite the size with an overlong encoding and skip past the data
-                try!(write_sized_vuint(self.writer, size, 4));
-                try!(self.writer.seek(SeekFrom::Start(cur_pos)));
+                write_sized_vuint(self.writer, size, 4)?;
+                self.writer.seek(SeekFrom::Start(cur_pos))?;
             }
 
             debug!("End tag (size = {:?})", size);
@@ -1063,15 +1063,15 @@ pub mod writer {
         pub fn wr_tag<F>(&mut self, tag_id: usize, blk: F) -> EncodeResult
             where F: FnOnce() -> EncodeResult
         {
-            try!(self.start_tag(tag_id));
-            try!(blk());
+            self.start_tag(tag_id)?;
+            blk()?;
             self.end_tag()
         }
 
         pub fn wr_tagged_bytes(&mut self, tag_id: usize, b: &[u8]) -> EncodeResult {
             assert!(tag_id >= NUM_IMPLICIT_TAGS);
-            try!(write_tag(self.writer, tag_id));
-            try!(write_vuint(self.writer, b.len()));
+            write_tag(self.writer, tag_id)?;
+            write_vuint(self.writer, b.len())?;
             self.writer.write_all(b)
         }
 
@@ -1124,7 +1124,7 @@ pub mod writer {
 
         // for auto-serialization
         fn wr_tagged_raw_bytes(&mut self, tag_id: usize, b: &[u8]) -> EncodeResult {
-            try!(write_tag(self.writer, tag_id));
+            write_tag(self.writer, tag_id)?;
             self.writer.write_all(b)
         }
 
@@ -1200,11 +1200,11 @@ pub mod writer {
         pub fn emit_opaque<F>(&mut self, f: F) -> EncodeResult
             where F: FnOnce(&mut opaque::Encoder) -> EncodeResult
         {
-            try!(self.start_tag(EsOpaque as usize));
+            self.start_tag(EsOpaque as usize)?;
 
             {
                 let mut opaque_encoder = opaque::Encoder::new(self.writer);
-                try!(f(&mut opaque_encoder));
+                f(&mut opaque_encoder)?;
             }
 
             self.mark_stable_position();
@@ -1298,15 +1298,15 @@ pub mod writer {
         fn emit_enum<F>(&mut self, _name: &str, f: F) -> EncodeResult
             where F: FnOnce(&mut Encoder<'a>) -> EncodeResult
         {
-            try!(self.start_tag(EsEnum as usize));
-            try!(f(self));
+            self.start_tag(EsEnum as usize)?;
+            f(self)?;
             self.end_tag()
         }
 
         fn emit_enum_variant<F>(&mut self, _: &str, v_id: usize, _: usize, f: F) -> EncodeResult
             where F: FnOnce(&mut Encoder<'a>) -> EncodeResult
         {
-            try!(self._emit_tagged_sub(v_id));
+            self._emit_tagged_sub(v_id)?;
             f(self)
         }
 
@@ -1390,9 +1390,9 @@ pub mod writer {
                 return self.wr_tagged_bytes(EsVec as usize, &[]);
             }
 
-            try!(self.start_tag(EsVec as usize));
-            try!(self._emit_tagged_sub(len));
-            try!(f(self));
+            self.start_tag(EsVec as usize)?;
+            self._emit_tagged_sub(len)?;
+            f(self)?;
             self.end_tag()
         }
 
@@ -1400,8 +1400,8 @@ pub mod writer {
             where F: FnOnce(&mut Encoder<'a>) -> EncodeResult
         {
 
-            try!(self.start_tag(EsVecElt as usize));
-            try!(f(self));
+            self.start_tag(EsVecElt as usize)?;
+            f(self)?;
             self.end_tag()
         }
 
@@ -1413,9 +1413,9 @@ pub mod writer {
                 return self.wr_tagged_bytes(EsMap as usize, &[]);
             }
 
-            try!(self.start_tag(EsMap as usize));
-            try!(self._emit_tagged_sub(len));
-            try!(f(self));
+            self.start_tag(EsMap as usize)?;
+            self._emit_tagged_sub(len)?;
+            f(self)?;
             self.end_tag()
         }
 
@@ -1423,16 +1423,16 @@ pub mod writer {
             where F: FnOnce(&mut Encoder<'a>) -> EncodeResult
         {
 
-            try!(self.start_tag(EsMapKey as usize));
-            try!(f(self));
+            self.start_tag(EsMapKey as usize)?;
+            f(self)?;
             self.end_tag()
         }
 
         fn emit_map_elt_val<F>(&mut self, _idx: usize, f: F) -> EncodeResult
             where F: FnOnce(&mut Encoder<'a>) -> EncodeResult
         {
-            try!(self.start_tag(EsMapVal as usize));
-            try!(f(self));
+            self.start_tag(EsMapVal as usize)?;
+            f(self)?;
             self.end_tag()
         }
     }

--- a/src/librbml/opaque.rs
+++ b/src/librbml/opaque.rs
@@ -120,7 +120,7 @@ impl<'a> serialize::Encoder for Encoder<'a> {
     }
 
     fn emit_str(&mut self, v: &str) -> EncodeResult {
-        try!(self.emit_uint(v.len()));
+        self.emit_uint(v.len())?;
         let _ = self.cursor.write_all(v.as_bytes());
         Ok(())
     }
@@ -139,7 +139,7 @@ impl<'a> serialize::Encoder for Encoder<'a> {
                             -> EncodeResult
         where F: FnOnce(&mut Self) -> EncodeResult
     {
-        try!(self.emit_uint(v_id));
+        self.emit_uint(v_id)?;
         f(self)
     }
 
@@ -221,7 +221,7 @@ impl<'a> serialize::Encoder for Encoder<'a> {
     fn emit_seq<F>(&mut self, len: usize, f: F) -> EncodeResult
         where F: FnOnce(&mut Encoder<'a>) -> EncodeResult
     {
-        try!(self.emit_uint(len));
+        self.emit_uint(len)?;
         f(self)
     }
 
@@ -234,7 +234,7 @@ impl<'a> serialize::Encoder for Encoder<'a> {
     fn emit_map<F>(&mut self, len: usize, f: F) -> EncodeResult
         where F: FnOnce(&mut Encoder<'a>) -> EncodeResult
     {
-        try!(self.emit_uint(len));
+        self.emit_uint(len)?;
         f(self)
     }
 
@@ -356,27 +356,27 @@ impl<'a> serialize::Decoder for Decoder<'a> {
     }
 
     fn read_bool(&mut self) -> Result<bool, Self::Error> {
-        let value = try!(self.read_u8());
+        let value = self.read_u8()?;
         Ok(value != 0)
     }
 
     fn read_f64(&mut self) -> Result<f64, Self::Error> {
-        let bits = try!(self.read_u64());
+        let bits = self.read_u64()?;
         Ok(unsafe { ::std::mem::transmute(bits) })
     }
 
     fn read_f32(&mut self) -> Result<f32, Self::Error> {
-        let bits = try!(self.read_u32());
+        let bits = self.read_u32()?;
         Ok(unsafe { ::std::mem::transmute(bits) })
     }
 
     fn read_char(&mut self) -> Result<char, Self::Error> {
-        let bits = try!(self.read_u32());
+        let bits = self.read_u32()?;
         Ok(::std::char::from_u32(bits).unwrap())
     }
 
     fn read_str(&mut self) -> Result<String, Self::Error> {
-        let len = try!(self.read_uint());
+        let len = self.read_uint()?;
         let s = ::std::str::from_utf8(&self.data[self.position..self.position + len]).unwrap();
         self.position += len;
         Ok(s.to_string())
@@ -391,7 +391,7 @@ impl<'a> serialize::Decoder for Decoder<'a> {
     fn read_enum_variant<T, F>(&mut self, _: &[&str], mut f: F) -> Result<T, Self::Error>
         where F: FnMut(&mut Decoder<'a>, usize) -> Result<T, Self::Error>
     {
-        let disr = try!(self.read_uint());
+        let disr = self.read_uint()?;
         f(self, disr)
     }
 
@@ -404,7 +404,7 @@ impl<'a> serialize::Decoder for Decoder<'a> {
     fn read_enum_struct_variant<T, F>(&mut self, _: &[&str], mut f: F) -> Result<T, Self::Error>
         where F: FnMut(&mut Decoder<'a>, usize) -> Result<T, Self::Error>
     {
-        let disr = try!(self.read_uint());
+        let disr = self.read_uint()?;
         f(self, disr)
     }
 
@@ -483,7 +483,7 @@ impl<'a> serialize::Decoder for Decoder<'a> {
     fn read_seq<T, F>(&mut self, f: F) -> Result<T, Self::Error>
         where F: FnOnce(&mut Decoder<'a>, usize) -> Result<T, Self::Error>
     {
-        let len = try!(self.read_uint());
+        let len = self.read_uint()?;
         f(self, len)
     }
 
@@ -496,7 +496,7 @@ impl<'a> serialize::Decoder for Decoder<'a> {
     fn read_map<T, F>(&mut self, f: F) -> Result<T, Self::Error>
         where F: FnOnce(&mut Decoder<'a>, usize) -> Result<T, Self::Error>
     {
-        let len = try!(self.read_uint());
+        let len = self.read_uint()?;
         f(self, len)
     }
 

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -39,6 +39,7 @@
 #![feature(slice_patterns)]
 #![feature(staged_api)]
 #![feature(str_char)]
+#![feature(question_mark)]
 #![cfg_attr(test, feature(test))]
 
 extern crate arena;

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -68,7 +68,7 @@ struct Matrix<'a>(Vec<Vec<&'a Pat>>);
 /// ++++++++++++++++++++++++++
 impl<'a> fmt::Debug for Matrix<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "\n"));
+        write!(f, "\n")?;
 
         let &Matrix(ref m) = self;
         let pretty_printed_matrix: Vec<Vec<String>> = m.iter().map(|row| {
@@ -85,16 +85,16 @@ impl<'a> fmt::Debug for Matrix<'a> {
 
         let total_width = column_widths.iter().cloned().sum::<usize>() + column_count * 3 + 1;
         let br = repeat('+').take(total_width).collect::<String>();
-        try!(write!(f, "{}\n", br));
+        write!(f, "{}\n", br)?;
         for row in pretty_printed_matrix {
-            try!(write!(f, "+"));
+            write!(f, "+")?;
             for (column, pat_str) in row.into_iter().enumerate() {
-                try!(write!(f, " "));
-                try!(write!(f, "{:1$}", pat_str, column_widths[column]));
-                try!(write!(f, " +"));
+                write!(f, " ")?;
+                write!(f, "{:1$}", pat_str, column_widths[column])?;
+                write!(f, " +")?;
             }
-            try!(write!(f, "\n"));
-            try!(write!(f, "{}\n", br));
+            write!(f, "\n")?;
+            write!(f, "{}\n", br)?;
         }
         Ok(())
     }

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -152,10 +152,10 @@ impl<'a, 'tcx, O:DataFlowOperator> pprust::PpAnn for DataFlowContext<'a, 'tcx, O
                 "".to_string()
             };
 
-            try!(ps.synth_comment(
+            ps.synth_comment(
                 format!("id {}: {}{}{}{}", id, entry_str,
-                        gens_str, action_kills_str, scope_kills_str)));
-            try!(pp::space(&mut ps.s));
+                        gens_str, action_kills_str, scope_kills_str))?;
+            pp::space(&mut ps.s)?;
         }
         Ok(())
     }
@@ -534,9 +534,9 @@ impl<'a, 'tcx, O:DataFlowOperator+Clone+'static> DataFlowContext<'a, 'tcx, O> {
     fn pretty_print_to<'b>(&self, wr: Box<io::Write + 'b>,
                            blk: &hir::Block) -> io::Result<()> {
         let mut ps = pprust::rust_printer_annotated(wr, self, None);
-        try!(ps.cbox(pprust::indent_unit));
-        try!(ps.ibox(0));
-        try!(ps.print_block(blk));
+        ps.cbox(pprust::indent_unit)?;
+        ps.ibox(0)?;
+        ps.print_block(blk)?;
         pp::eof(&mut ps.s)
     }
 }

--- a/src/librustc/middle/def_id.rs
+++ b/src/librustc/middle/def_id.rs
@@ -56,7 +56,7 @@ pub struct DefId {
 impl fmt::Debug for DefId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "DefId {{ krate: {:?}, node: {:?}",
-                    self.krate, self.index)?;
+               self.krate, self.index)?;
 
         // Unfortunately, there seems to be no way to attempt to print
         // a path for a def-id, so I'll just make a best effort for now

--- a/src/librustc/middle/def_id.rs
+++ b/src/librustc/middle/def_id.rs
@@ -55,8 +55,8 @@ pub struct DefId {
 
 impl fmt::Debug for DefId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "DefId {{ krate: {:?}, node: {:?}",
-                    self.krate, self.index));
+        write!(f, "DefId {{ krate: {:?}, node: {:?}",
+                    self.krate, self.index)?;
 
         // Unfortunately, there seems to be no way to attempt to print
         // a path for a def-id, so I'll just make a best effort for now
@@ -64,12 +64,12 @@ impl fmt::Debug for DefId {
         if self.is_local() { // (1)
             // (1) side-step fact that not all external things have paths at
             // the moment, such as type parameters
-            try!(ty::tls::with_opt(|opt_tcx| {
+            ty::tls::with_opt(|opt_tcx| {
                 if let Some(tcx) = opt_tcx {
-                    try!(write!(f, " => {}", tcx.item_path_str(*self)));
+                    write!(f, " => {}", tcx.item_path_str(*self))?;
                 }
                 Ok(())
-            }));
+            })?;
         }
 
         write!(f, " }}")

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -1182,7 +1182,7 @@ impl<'d,'t,'a,'tcx> ExprUseVisitor<'d,'t,'a,'tcx> {
         // Create the cmt for the variable being borrowed, from the
         // caller's perspective
         let var_id = upvar_def.var_id();
-        let var_ty = try!(self.typer.node_ty(var_id));
+        let var_ty = self.typer.node_ty(var_id)?;
         self.mc.cat_def(closure_id, closure_span, var_ty, upvar_def)
     }
 }

--- a/src/librustc/middle/infer/bivariate.rs
+++ b/src/librustc/middle/infer/bivariate.rs
@@ -86,12 +86,12 @@ impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Bivariate<'a, 'tcx> {
             }
 
             (&ty::TyInfer(TyVar(a_id)), _) => {
-                try!(self.fields.instantiate(b, BiTo, a_id));
+                self.fields.instantiate(b, BiTo, a_id)?;
                 Ok(a)
             }
 
             (_, &ty::TyInfer(TyVar(b_id))) => {
-                try!(self.fields.instantiate(a, BiTo, b_id));
+                self.fields.instantiate(a, BiTo, b_id)?;
                 Ok(a)
             }
 
@@ -111,7 +111,7 @@ impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Bivariate<'a, 'tcx> {
     {
         let a1 = self.tcx().erase_late_bound_regions(a);
         let b1 = self.tcx().erase_late_bound_regions(b);
-        let c = try!(self.relate(&a1, &b1));
+        let c = self.relate(&a1, &b1)?;
         Ok(ty::Binder(c))
     }
 }

--- a/src/librustc/middle/infer/combine.rs
+++ b/src/librustc/middle/infer/combine.rs
@@ -71,9 +71,9 @@ pub fn super_combine_tys<'a,'tcx:'a,R>(infcx: &InferCtxt<'a, 'tcx>,
         // Relate integral variables to other types
         (&ty::TyInfer(ty::IntVar(a_id)), &ty::TyInfer(ty::IntVar(b_id))) => {
             infcx.int_unification_table
-                      .borrow_mut()
-                      .unify_var_var(a_id, b_id)
-                      .map_err(|e| int_unification_error(a_is_expected, e))?;
+                 .borrow_mut()
+                 .unify_var_var(a_id, b_id)
+                 .map_err(|e| int_unification_error(a_is_expected, e))?;
             Ok(a)
         }
         (&ty::TyInfer(ty::IntVar(v_id)), &ty::TyInt(v)) => {
@@ -92,9 +92,9 @@ pub fn super_combine_tys<'a,'tcx:'a,R>(infcx: &InferCtxt<'a, 'tcx>,
         // Relate floating-point variables to other types
         (&ty::TyInfer(ty::FloatVar(a_id)), &ty::TyInfer(ty::FloatVar(b_id))) => {
             infcx.float_unification_table
-                      .borrow_mut()
-                      .unify_var_var(a_id, b_id)
-                      .map_err(|e| float_unification_error(relation.a_is_expected(), e))?;
+                 .borrow_mut()
+                 .unify_var_var(a_id, b_id)
+                 .map_err(|e| float_unification_error(relation.a_is_expected(), e))?;
             Ok(a)
         }
         (&ty::TyInfer(ty::FloatVar(v_id)), &ty::TyFloat(v)) => {
@@ -123,8 +123,7 @@ fn unify_integral_variable<'a,'tcx>(infcx: &InferCtxt<'a,'tcx>,
                                     val: ty::IntVarValue)
                                     -> RelateResult<'tcx, Ty<'tcx>>
 {
-    infcx
-         .int_unification_table
+    infcx.int_unification_table
          .borrow_mut()
          .unify_var_value(vid, val)
          .map_err(|e| int_unification_error(vid_is_expected, e))?;
@@ -140,8 +139,7 @@ fn unify_float_variable<'a,'tcx>(infcx: &InferCtxt<'a,'tcx>,
                                  val: ast::FloatTy)
                                  -> RelateResult<'tcx, Ty<'tcx>>
 {
-    infcx
-         .float_unification_table
+    infcx.float_unification_table
          .borrow_mut()
          .unify_var_value(vid, val)
          .map_err(|e| float_unification_error(vid_is_expected, e))?;

--- a/src/librustc/middle/infer/combine.rs
+++ b/src/librustc/middle/infer/combine.rs
@@ -70,10 +70,10 @@ pub fn super_combine_tys<'a,'tcx:'a,R>(infcx: &InferCtxt<'a, 'tcx>,
     match (&a.sty, &b.sty) {
         // Relate integral variables to other types
         (&ty::TyInfer(ty::IntVar(a_id)), &ty::TyInfer(ty::IntVar(b_id))) => {
-            try!(infcx.int_unification_table
+            infcx.int_unification_table
                       .borrow_mut()
                       .unify_var_var(a_id, b_id)
-                      .map_err(|e| int_unification_error(a_is_expected, e)));
+                      .map_err(|e| int_unification_error(a_is_expected, e))?;
             Ok(a)
         }
         (&ty::TyInfer(ty::IntVar(v_id)), &ty::TyInt(v)) => {
@@ -91,10 +91,10 @@ pub fn super_combine_tys<'a,'tcx:'a,R>(infcx: &InferCtxt<'a, 'tcx>,
 
         // Relate floating-point variables to other types
         (&ty::TyInfer(ty::FloatVar(a_id)), &ty::TyInfer(ty::FloatVar(b_id))) => {
-            try!(infcx.float_unification_table
+            infcx.float_unification_table
                       .borrow_mut()
                       .unify_var_var(a_id, b_id)
-                      .map_err(|e| float_unification_error(relation.a_is_expected(), e)));
+                      .map_err(|e| float_unification_error(relation.a_is_expected(), e))?;
             Ok(a)
         }
         (&ty::TyInfer(ty::FloatVar(v_id)), &ty::TyFloat(v)) => {
@@ -123,11 +123,11 @@ fn unify_integral_variable<'a,'tcx>(infcx: &InferCtxt<'a,'tcx>,
                                     val: ty::IntVarValue)
                                     -> RelateResult<'tcx, Ty<'tcx>>
 {
-    try!(infcx
+    infcx
          .int_unification_table
          .borrow_mut()
          .unify_var_value(vid, val)
-         .map_err(|e| int_unification_error(vid_is_expected, e)));
+         .map_err(|e| int_unification_error(vid_is_expected, e))?;
     match val {
         IntType(v) => Ok(infcx.tcx.mk_mach_int(v)),
         UintType(v) => Ok(infcx.tcx.mk_mach_uint(v)),
@@ -140,11 +140,11 @@ fn unify_float_variable<'a,'tcx>(infcx: &InferCtxt<'a,'tcx>,
                                  val: ast::FloatTy)
                                  -> RelateResult<'tcx, Ty<'tcx>>
 {
-    try!(infcx
+    infcx
          .float_unification_table
          .borrow_mut()
          .unify_var_value(vid, val)
-         .map_err(|e| float_unification_error(vid_is_expected, e)));
+         .map_err(|e| float_unification_error(vid_is_expected, e))?;
     Ok(infcx.tcx.mk_mach_float(val))
 }
 
@@ -229,10 +229,10 @@ impl<'a, 'tcx> CombineFields<'a, 'tcx> {
                 Some(t) => t, // ...already instantiated.
                 None => {     // ...not yet instantiated:
                     // Generalize type if necessary.
-                    let generalized_ty = try!(match dir {
+                    let generalized_ty = match dir {
                         EqTo => self.generalize(a_ty, b_vid, false),
                         BiTo | SupertypeOf | SubtypeOf => self.generalize(a_ty, b_vid, true),
-                    });
+                    }?;
                     debug!("instantiate(a_ty={:?}, dir={:?}, \
                                         b_vid={:?}, generalized_ty={:?})",
                            a_ty, dir, b_vid,
@@ -252,12 +252,12 @@ impl<'a, 'tcx> CombineFields<'a, 'tcx> {
             // relations wind up attributed to the same spans. We need
             // to associate causes/spans with each of the relations in
             // the stack to get this right.
-            try!(match dir {
+            match dir {
                 BiTo => self.bivariate().relate(&a_ty, &b_ty),
                 EqTo => self.equate().relate(&a_ty, &b_ty),
                 SubtypeOf => self.sub().relate(&a_ty, &b_ty),
                 SupertypeOf => self.sub().relate_with_variance(ty::Contravariant, &a_ty, &b_ty),
-            });
+            }?;
         }
 
         Ok(())

--- a/src/librustc/middle/infer/equate.rs
+++ b/src/librustc/middle/infer/equate.rs
@@ -59,17 +59,17 @@ impl<'a, 'tcx> TypeRelation<'a,'tcx> for Equate<'a, 'tcx> {
             }
 
             (&ty::TyInfer(TyVar(a_id)), _) => {
-                try!(self.fields.instantiate(b, EqTo, a_id));
+                self.fields.instantiate(b, EqTo, a_id)?;
                 Ok(a)
             }
 
             (_, &ty::TyInfer(TyVar(b_id))) => {
-                try!(self.fields.instantiate(a, EqTo, b_id));
+                self.fields.instantiate(a, EqTo, b_id)?;
                 Ok(a)
             }
 
             _ => {
-                try!(combine::super_combine_tys(self.fields.infcx, self, a, b));
+                combine::super_combine_tys(self.fields.infcx, self, a, b)?;
                 Ok(a)
             }
         }
@@ -89,7 +89,7 @@ impl<'a, 'tcx> TypeRelation<'a,'tcx> for Equate<'a, 'tcx> {
                   -> RelateResult<'tcx, ty::Binder<T>>
         where T: Relate<'a, 'tcx>
     {
-        try!(self.fields.higher_ranked_sub(a, b));
+        self.fields.higher_ranked_sub(a, b)?;
         self.fields.higher_ranked_sub(b, a)
     }
 }

--- a/src/librustc/middle/infer/glb.rs
+++ b/src/librustc/middle/infer/glb.rs
@@ -78,8 +78,8 @@ impl<'a, 'tcx> LatticeDir<'a,'tcx> for Glb<'a, 'tcx> {
 
     fn relate_bound(&self, v: Ty<'tcx>, a: Ty<'tcx>, b: Ty<'tcx>) -> RelateResult<'tcx, ()> {
         let mut sub = self.fields.sub();
-        try!(sub.relate(&v, &a));
-        try!(sub.relate(&v, &b));
+        sub.relate(&v, &a)?;
+        sub.relate(&v, &b)?;
         Ok(())
     }
 }

--- a/src/librustc/middle/infer/higher_ranked/mod.rs
+++ b/src/librustc/middle/infer/higher_ranked/mod.rs
@@ -75,7 +75,7 @@ impl<'a,'tcx> HigherRankedRelations<'a,'tcx> for CombineFields<'a,'tcx> {
             debug!("b_prime={:?}", b_prime);
 
             // Compare types now that bound regions have been replaced.
-            let result = try!(self.sub().relate(&a_prime, &b_prime));
+            let result = self.sub().relate(&a_prime, &b_prime)?;
 
             // Presuming type comparison succeeds, we need to check
             // that the skolemized regions do not "leak".
@@ -118,7 +118,7 @@ impl<'a,'tcx> HigherRankedRelations<'a,'tcx> for CombineFields<'a,'tcx> {
 
             // Collect constraints.
             let result0 =
-                try!(self.lub().relate(&a_with_fresh, &b_with_fresh));
+                self.lub().relate(&a_with_fresh, &b_with_fresh)?;
             let result0 =
                 self.infcx.resolve_type_vars_if_possible(&result0);
             debug!("lub result0 = {:?}", result0);
@@ -212,7 +212,7 @@ impl<'a,'tcx> HigherRankedRelations<'a,'tcx> for CombineFields<'a,'tcx> {
 
             // Collect constraints.
             let result0 =
-                try!(self.glb().relate(&a_with_fresh, &b_with_fresh));
+                self.glb().relate(&a_with_fresh, &b_with_fresh)?;
             let result0 =
                 self.infcx.resolve_type_vars_if_possible(&result0);
             debug!("glb result0 = {:?}", result0);

--- a/src/librustc/middle/infer/lattice.rs
+++ b/src/librustc/middle/infer/lattice.rs
@@ -66,14 +66,14 @@ pub fn super_lattice_tys<'a,'tcx,L:LatticeDir<'a,'tcx>>(this: &mut L,
         (&ty::TyInfer(TyVar(..)), &ty::TyInfer(TyVar(..)))
             if infcx.type_var_diverges(a) && infcx.type_var_diverges(b) => {
             let v = infcx.next_diverging_ty_var();
-            try!(this.relate_bound(v, a, b));
+            this.relate_bound(v, a, b)?;
             Ok(v)
         }
 
         (&ty::TyInfer(TyVar(..)), _) |
         (_, &ty::TyInfer(TyVar(..))) => {
             let v = infcx.next_ty_var();
-            try!(this.relate_bound(v, a, b));
+            this.relate_bound(v, a, b)?;
             Ok(v)
         }
 

--- a/src/librustc/middle/infer/lub.rs
+++ b/src/librustc/middle/infer/lub.rs
@@ -78,8 +78,8 @@ impl<'a, 'tcx> LatticeDir<'a,'tcx> for Lub<'a, 'tcx> {
 
     fn relate_bound(&self, v: Ty<'tcx>, a: Ty<'tcx>, b: Ty<'tcx>) -> RelateResult<'tcx, ()> {
         let mut sub = self.fields.sub();
-        try!(sub.relate(&a, &v));
-        try!(sub.relate(&b, &v));
+        sub.relate(&a, &v)?;
+        sub.relate(&b, &v)?;
         Ok(())
     }
 }

--- a/src/librustc/middle/infer/mod.rs
+++ b/src/librustc/middle/infer/mod.rs
@@ -960,7 +960,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             let (ty::EquatePredicate(a, b), skol_map) =
                 self.skolemize_late_bound_regions(predicate, snapshot);
             let origin = TypeOrigin::EquatePredicate(span);
-            let () = try!(mk_eqty(self, false, origin, a, b));
+            let () = mk_eqty(self, false, origin, a, b)?;
             self.leak_check(&skol_map, snapshot)
         })
     }

--- a/src/librustc/middle/infer/sub.rs
+++ b/src/librustc/middle/infer/sub.rs
@@ -75,13 +75,13 @@ impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Sub<'a, 'tcx> {
                 Ok(a)
             }
             (&ty::TyInfer(TyVar(a_id)), _) => {
-                try!(self.fields
+                self.fields
                          .switch_expected()
-                         .instantiate(b, SupertypeOf, a_id));
+                         .instantiate(b, SupertypeOf, a_id)?;
                 Ok(a)
             }
             (_, &ty::TyInfer(TyVar(b_id))) => {
-                try!(self.fields.instantiate(a, SubtypeOf, b_id));
+                self.fields.instantiate(a, SubtypeOf, b_id)?;
                 Ok(a)
             }
 
@@ -90,7 +90,7 @@ impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Sub<'a, 'tcx> {
             }
 
             _ => {
-                try!(combine::super_combine_tys(self.fields.infcx, self, a, b));
+                combine::super_combine_tys(self.fields.infcx, self, a, b)?;
                 Ok(a)
             }
         }

--- a/src/librustc/middle/infer/sub.rs
+++ b/src/librustc/middle/infer/sub.rs
@@ -76,8 +76,8 @@ impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Sub<'a, 'tcx> {
             }
             (&ty::TyInfer(TyVar(a_id)), _) => {
                 self.fields
-                         .switch_expected()
-                         .instantiate(b, SupertypeOf, a_id)?;
+                    .switch_expected()
+                    .instantiate(b, SupertypeOf, a_id)?;
                 Ok(a)
             }
             (_, &ty::TyInfer(TyVar(b_id))) => {

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -686,7 +686,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
         for var_idx in 0..self.ir.num_vars {
             let idx = node_base_idx + var_idx;
             if test(idx).is_valid() {
-                try!(write!(wr, " {:?}", Variable(var_idx)));
+                write!(wr, " {:?}", Variable(var_idx))?;
             }
         }
         Ok(())

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -41,15 +41,15 @@ pub struct CodeExtent(u32);
 
 impl fmt::Debug for CodeExtent {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "CodeExtent({:?}", self.0));
+        write!(f, "CodeExtent({:?}", self.0)?;
 
-        try!(ty::tls::with_opt(|opt_tcx| {
+        ty::tls::with_opt(|opt_tcx| {
             if let Some(tcx) = opt_tcx {
                 let data = tcx.region_maps.code_extents.borrow()[self.0 as usize];
-                try!(write!(f, "/{:?}", data));
+                write!(f, "/{:?}", data)?;
             }
             Ok(())
-        }));
+        })?;
 
         write!(f, ")")
     }

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -102,7 +102,7 @@ pub fn krate(sess: &Session,
     let _task = hir_map.dep_graph.in_task(DepNode::ResolveLifetimes);
     let krate = hir_map.krate();
     let mut named_region_map = NodeMap();
-    try!(sess.track_errors(|| {
+    sess.track_errors(|| {
         krate.visit_all_items(&mut LifetimeContext {
             sess: sess,
             named_region_map: &mut named_region_map,
@@ -111,7 +111,7 @@ pub fn krate(sess: &Session,
             trait_ref_hack: false,
             labels_in_fn: vec![],
         });
-    }));
+    })?;
     Ok(named_region_map)
 }
 

--- a/src/librustc/middle/traits/fulfill.rs
+++ b/src/librustc/middle/traits/fulfill.rs
@@ -211,7 +211,7 @@ impl<'tcx> FulfillmentContext<'tcx> {
                                    infcx: &InferCtxt<'a,'tcx>)
                                    -> Result<(),Vec<FulfillmentError<'tcx>>>
     {
-        try!(self.select_where_possible(infcx));
+        self.select_where_possible(infcx)?;
         let errors: Vec<_> =
             self.predicates.to_errors(CodeAmbiguity)
                            .into_iter()

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -320,12 +320,12 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         let _task = self.tcx().dep_graph.in_task(dep_node);
 
         let stack = self.push_stack(TraitObligationStackList::empty(), obligation);
-        match try!(self.candidate_from_obligation(&stack)) {
+        match self.candidate_from_obligation(&stack)? {
             None => {
                 self.consider_unification_despite_ambiguity(obligation);
                 Ok(None)
             }
-            Some(candidate) => Ok(Some(try!(self.confirm_candidate(obligation, candidate)))),
+            Some(candidate) => Ok(Some(self.confirm_candidate(obligation, candidate)?)),
         }
     }
 
@@ -786,7 +786,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             return Ok(None);
         }
 
-        let candidate_set = try!(self.assemble_candidates(stack));
+        let candidate_set = self.assemble_candidates(stack)?;
 
         if candidate_set.ambiguous {
             debug!("candidate set contains ambig");
@@ -1034,19 +1034,19 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
                 // User-defined copy impls are permitted, but only for
                 // structs and enums.
-                try!(self.assemble_candidates_from_impls(obligation, &mut candidates));
+                self.assemble_candidates_from_impls(obligation, &mut candidates)?;
 
                 // For other types, we'll use the builtin rules.
-                try!(self.assemble_builtin_bound_candidates(ty::BoundCopy,
+                self.assemble_builtin_bound_candidates(ty::BoundCopy,
                                                             obligation,
-                                                            &mut candidates));
+                                                            &mut candidates)?;
             }
             Some(bound @ ty::BoundSized) => {
                 // Sized is never implementable by end-users, it is
                 // always automatically computed.
-                try!(self.assemble_builtin_bound_candidates(bound,
+                self.assemble_builtin_bound_candidates(bound,
                                                             obligation,
-                                                            &mut candidates));
+                                                            &mut candidates)?;
             }
 
             None if self.tcx().lang_items.unsize_trait() ==
@@ -1057,19 +1057,19 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             Some(ty::BoundSend) |
             Some(ty::BoundSync) |
             None => {
-                try!(self.assemble_closure_candidates(obligation, &mut candidates));
-                try!(self.assemble_fn_pointer_candidates(obligation, &mut candidates));
-                try!(self.assemble_candidates_from_impls(obligation, &mut candidates));
+                self.assemble_closure_candidates(obligation, &mut candidates)?;
+                self.assemble_fn_pointer_candidates(obligation, &mut candidates)?;
+                self.assemble_candidates_from_impls(obligation, &mut candidates)?;
                 self.assemble_candidates_from_object_ty(obligation, &mut candidates);
             }
         }
 
         self.assemble_candidates_from_projected_tys(obligation, &mut candidates);
-        try!(self.assemble_candidates_from_caller_bounds(stack, &mut candidates));
+        self.assemble_candidates_from_caller_bounds(stack, &mut candidates)?;
         // Default implementations have lower priority, so we only
         // consider triggering a default if there is no other impl that can apply.
         if candidates.vec.is_empty() {
-            try!(self.assemble_candidates_from_default_impls(obligation, &mut candidates));
+            self.assemble_candidates_from_default_impls(obligation, &mut candidates)?;
         }
         debug!("candidate list size: {}", candidates.vec.len());
         Ok(candidates)
@@ -2044,7 +2044,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         match candidate {
             BuiltinCandidate(builtin_bound) => {
                 Ok(VtableBuiltin(
-                    try!(self.confirm_builtin_candidate(obligation, builtin_bound))))
+                    self.confirm_builtin_candidate(obligation, builtin_bound)?))
             }
 
             ParamCandidate(param) => {
@@ -2064,13 +2064,13 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
             ImplCandidate(impl_def_id) => {
                 let vtable_impl =
-                    try!(self.confirm_impl_candidate(obligation, impl_def_id));
+                    self.confirm_impl_candidate(obligation, impl_def_id)?;
                 Ok(VtableImpl(vtable_impl))
             }
 
             ClosureCandidate(closure_def_id, substs) => {
                 let vtable_closure =
-                    try!(self.confirm_closure_candidate(obligation, closure_def_id, substs));
+                    self.confirm_closure_candidate(obligation, closure_def_id, substs)?;
                 Ok(VtableClosure(vtable_closure))
             }
 
@@ -2090,7 +2090,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
             FnPointerCandidate => {
                 let fn_type =
-                    try!(self.confirm_fn_pointer_candidate(obligation));
+                    self.confirm_fn_pointer_candidate(obligation)?;
                 Ok(VtableFnPointer(fn_type))
             }
 
@@ -2100,7 +2100,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             }
 
             BuiltinUnsizeCandidate => {
-                let data = try!(self.confirm_builtin_unsize_candidate(obligation));
+                let data = self.confirm_builtin_unsize_candidate(obligation)?;
                 Ok(VtableBuiltin(data))
             }
         }
@@ -2152,7 +2152,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         debug!("confirm_builtin_candidate({:?})",
                obligation);
 
-        match try!(self.builtin_bound(bound, obligation)) {
+        match self.builtin_bound(bound, obligation)? {
             If(nested) => Ok(self.vtable_builtin_data(obligation, bound, nested)),
             AmbiguousBuiltin | ParameterBuiltin => {
                 self.tcx().sess.span_bug(
@@ -2421,9 +2421,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                                                     util::TupleArgumentsFlag::Yes)
             .map_bound(|(trait_ref, _)| trait_ref);
 
-        try!(self.confirm_poly_trait_refs(obligation.cause.clone(),
+        self.confirm_poly_trait_refs(obligation.cause.clone(),
                                           obligation.predicate.to_poly_trait_ref(),
-                                          trait_ref));
+                                          trait_ref)?;
         Ok(self_ty)
     }
 
@@ -2449,9 +2449,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                trait_ref,
                obligations);
 
-        try!(self.confirm_poly_trait_refs(obligation.cause.clone(),
+        self.confirm_poly_trait_refs(obligation.cause.clone(),
                                           obligation.predicate.to_poly_trait_ref(),
-                                          trait_ref));
+                                          trait_ref)?;
 
         Ok(VtableClosureData {
             closure_def_id: closure_def_id,
@@ -2795,7 +2795,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                                     where_clause_trait_ref: ty::PolyTraitRef<'tcx>)
                                     -> Result<Vec<PredicateObligation<'tcx>>,()>
     {
-        try!(self.match_poly_trait_ref(obligation, where_clause_trait_ref));
+        self.match_poly_trait_ref(obligation, where_clause_trait_ref)?;
         Ok(Vec::new())
     }
 

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1038,15 +1038,15 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
                 // For other types, we'll use the builtin rules.
                 self.assemble_builtin_bound_candidates(ty::BoundCopy,
-                                                            obligation,
-                                                            &mut candidates)?;
+                                                       obligation,
+                                                       &mut candidates)?;
             }
             Some(bound @ ty::BoundSized) => {
                 // Sized is never implementable by end-users, it is
                 // always automatically computed.
                 self.assemble_builtin_bound_candidates(bound,
-                                                            obligation,
-                                                            &mut candidates)?;
+                                                       obligation,
+                                                       &mut candidates)?;
             }
 
             None if self.tcx().lang_items.unsize_trait() ==
@@ -2422,8 +2422,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             .map_bound(|(trait_ref, _)| trait_ref);
 
         self.confirm_poly_trait_refs(obligation.cause.clone(),
-                                          obligation.predicate.to_poly_trait_ref(),
-                                          trait_ref)?;
+                                     obligation.predicate.to_poly_trait_ref(),
+                                     trait_ref)?;
         Ok(self_ty)
     }
 
@@ -2450,8 +2450,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                obligations);
 
         self.confirm_poly_trait_refs(obligation.cause.clone(),
-                                          obligation.predicate.to_poly_trait_ref(),
-                                          trait_ref)?;
+                                     obligation.predicate.to_poly_trait_ref(),
+                                     trait_ref)?;
 
         Ok(VtableClosureData {
             closure_def_id: closure_def_id,

--- a/src/librustc/middle/traits/util.rs
+++ b/src/librustc/middle/traits/util.rs
@@ -418,7 +418,7 @@ pub fn predicate_for_builtin_bound<'tcx>(
     param_ty: Ty<'tcx>)
     -> Result<PredicateObligation<'tcx>, ErrorReported>
 {
-    let trait_ref = try!(trait_ref_for_builtin_bound(tcx, builtin_bound, param_ty));
+    let trait_ref = trait_ref_for_builtin_bound(tcx, builtin_bound, param_ty)?;
     Ok(predicate_for_trait_ref(cause, trait_ref, recursion_depth))
 }
 

--- a/src/librustc/middle/ty/_match.rs
+++ b/src/librustc/middle/ty/_match.rs
@@ -91,6 +91,6 @@ impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Match<'a, 'tcx> {
                   -> RelateResult<'tcx, ty::Binder<T>>
         where T: Relate<'a,'tcx>
     {
-        Ok(ty::Binder(try!(self.relate(a.skip_binder(), b.skip_binder()))))
+        Ok(ty::Binder(self.relate(a.skip_binder(), b.skip_binder())?))
     }
 }

--- a/src/librustc/middle/ty/mod.rs
+++ b/src/librustc/middle/ty/mod.rs
@@ -1473,7 +1473,7 @@ impl<'tcx> Encodable for AdtDef<'tcx> {
 
 impl<'tcx> Decodable for AdtDef<'tcx> {
     fn decode<D: Decoder>(d: &mut D) -> Result<AdtDef<'tcx>, D::Error> {
-        let def_id: DefId = try!{ Decodable::decode(d) };
+        let def_id: DefId = Decodable::decode(d)?;
 
         cstore::tls::with_decoding_context(d, |dcx, _| {
             let def_id = dcx.translate_def_id(def_id);

--- a/src/librustc/middle/ty/relate.rs
+++ b/src/librustc/middle/ty/relate.rs
@@ -167,9 +167,9 @@ pub fn relate_substs<'a,'tcx:'a,R>(relation: &mut R,
                 let b_regions = b.get_slice(space);
                 let r_variances = variances.map(|v| v.regions.get_slice(space));
                 let regions = relate_region_params(relation,
-                                                        r_variances,
-                                                        a_regions,
-                                                        b_regions)?;
+                                                   r_variances,
+                                                   a_regions,
+                                                   b_regions)?;
                 substs.mut_regions().replace(space, regions);
             }
         }
@@ -261,8 +261,8 @@ impl<'a,'tcx:'a> Relate<'a,'tcx> for ty::FnSig<'tcx> {
         }
 
         let inputs = relate_arg_vecs(relation,
-                                          &a.inputs,
-                                          &b.inputs)?;
+                                     &a.inputs,
+                                     &b.inputs)?;
 
         let output = match (a.output, b.output) {
             (ty::FnConverging(a_ty), ty::FnConverging(b_ty)) =>
@@ -557,8 +557,8 @@ pub fn super_relate_tys<'a,'tcx:'a,R>(relation: &mut R,
         {
             if as_.len() == bs.len() {
                 let ts = as_.iter().zip(bs)
-                                 .map(|(a, b)| relation.relate(a, b))
-                                 .collect::<Result<_, _>>()?;
+                            .map(|(a, b)| relation.relate(a, b))
+                            .collect::<Result<_, _>>()?;
                 Ok(tcx.mk_tup(ts))
             } else if !(as_.is_empty() || bs.is_empty()) {
                 Err(TypeError::TupleSize(

--- a/src/librustc/middle/ty/relate.rs
+++ b/src/librustc/middle/ty/relate.rs
@@ -108,7 +108,7 @@ impl<'a,'tcx:'a> Relate<'a,'tcx> for ty::TypeAndMut<'tcx> {
                 ast::Mutability::MutImmutable => ty::Covariant,
                 ast::Mutability::MutMutable => ty::Invariant,
             };
-            let ty = try!(relation.relate_with_variance(variance, &a.ty, &b.ty));
+            let ty = relation.relate_with_variance(variance, &a.ty, &b.ty)?;
             Ok(ty::TypeAndMut {ty: ty, mutbl: mutbl})
         }
     }
@@ -152,7 +152,7 @@ pub fn relate_substs<'a,'tcx:'a,R>(relation: &mut R,
         let a_tps = a_subst.types.get_slice(space);
         let b_tps = b_subst.types.get_slice(space);
         let t_variances = variances.map(|v| v.types.get_slice(space));
-        let tps = try!(relate_type_params(relation, t_variances, a_tps, b_tps));
+        let tps = relate_type_params(relation, t_variances, a_tps, b_tps)?;
         substs.types.replace(space, tps);
     }
 
@@ -166,10 +166,10 @@ pub fn relate_substs<'a,'tcx:'a,R>(relation: &mut R,
                 let a_regions = a.get_slice(space);
                 let b_regions = b.get_slice(space);
                 let r_variances = variances.map(|v| v.regions.get_slice(space));
-                let regions = try!(relate_region_params(relation,
+                let regions = relate_region_params(relation,
                                                         r_variances,
                                                         a_regions,
-                                                        b_regions));
+                                                        b_regions)?;
                 substs.mut_regions().replace(space, regions);
             }
         }
@@ -239,9 +239,9 @@ impl<'a,'tcx:'a> Relate<'a,'tcx> for ty::BareFnTy<'tcx> {
                  -> RelateResult<'tcx, ty::BareFnTy<'tcx>>
         where R: TypeRelation<'a,'tcx>
     {
-        let unsafety = try!(relation.relate(&a.unsafety, &b.unsafety));
-        let abi = try!(relation.relate(&a.abi, &b.abi));
-        let sig = try!(relation.relate(&a.sig, &b.sig));
+        let unsafety = relation.relate(&a.unsafety, &b.unsafety)?;
+        let abi = relation.relate(&a.abi, &b.abi)?;
+        let sig = relation.relate(&a.sig, &b.sig)?;
         Ok(ty::BareFnTy {unsafety: unsafety,
                          abi: abi,
                          sig: sig})
@@ -260,19 +260,19 @@ impl<'a,'tcx:'a> Relate<'a,'tcx> for ty::FnSig<'tcx> {
                 expected_found(relation, &a.variadic, &b.variadic)));
         }
 
-        let inputs = try!(relate_arg_vecs(relation,
+        let inputs = relate_arg_vecs(relation,
                                           &a.inputs,
-                                          &b.inputs));
+                                          &b.inputs)?;
 
-        let output = try!(match (a.output, b.output) {
+        let output = match (a.output, b.output) {
             (ty::FnConverging(a_ty), ty::FnConverging(b_ty)) =>
-                Ok(ty::FnConverging(try!(relation.relate(&a_ty, &b_ty)))),
+                Ok(ty::FnConverging(relation.relate(&a_ty, &b_ty)?)),
             (ty::FnDiverging, ty::FnDiverging) =>
                 Ok(ty::FnDiverging),
             (a, b) =>
                 Err(TypeError::ConvergenceMismatch(
                     expected_found(relation, &(a != ty::FnDiverging), &(b != ty::FnDiverging)))),
-        });
+        }?;
 
         return Ok(ty::FnSig {inputs: inputs,
                              output: output,
@@ -336,7 +336,7 @@ impl<'a,'tcx:'a> Relate<'a,'tcx> for ty::ProjectionTy<'tcx> {
             Err(TypeError::ProjectionNameMismatched(
                 expected_found(relation, &a.item_name, &b.item_name)))
         } else {
-            let trait_ref = try!(relation.relate(&a.trait_ref, &b.trait_ref));
+            let trait_ref = relation.relate(&a.trait_ref, &b.trait_ref)?;
             Ok(ty::ProjectionTy { trait_ref: trait_ref, item_name: a.item_name })
         }
     }
@@ -349,8 +349,8 @@ impl<'a,'tcx:'a> Relate<'a,'tcx> for ty::ProjectionPredicate<'tcx> {
                  -> RelateResult<'tcx, ty::ProjectionPredicate<'tcx>>
         where R: TypeRelation<'a,'tcx>
     {
-        let projection_ty = try!(relation.relate(&a.projection_ty, &b.projection_ty));
-        let ty = try!(relation.relate(&a.ty, &b.ty));
+        let projection_ty = relation.relate(&a.projection_ty, &b.projection_ty)?;
+        let ty = relation.relate(&a.ty, &b.ty)?;
         Ok(ty::ProjectionPredicate { projection_ty: projection_ty, ty: ty })
     }
 }
@@ -385,13 +385,13 @@ impl<'a,'tcx:'a> Relate<'a,'tcx> for ty::ExistentialBounds<'tcx> {
         where R: TypeRelation<'a,'tcx>
     {
         let r =
-            try!(relation.with_cause(
+            relation.with_cause(
                 Cause::ExistentialRegionBound,
                 |relation| relation.relate_with_variance(ty::Contravariant,
                                                          &a.region_bound,
-                                                         &b.region_bound)));
-        let nb = try!(relation.relate(&a.builtin_bounds, &b.builtin_bounds));
-        let pb = try!(relation.relate(&a.projection_bounds, &b.projection_bounds));
+                                                         &b.region_bound))?;
+        let nb = relation.relate(&a.builtin_bounds, &b.builtin_bounds)?;
+        let pb = relation.relate(&a.projection_bounds, &b.projection_bounds)?;
         Ok(ty::ExistentialBounds { region_bound: r,
                                    builtin_bounds: nb,
                                    projection_bounds: pb })
@@ -426,7 +426,7 @@ impl<'a,'tcx:'a> Relate<'a,'tcx> for ty::TraitRef<'tcx> {
         if a.def_id != b.def_id {
             Err(TypeError::Traits(expected_found(relation, &a.def_id, &b.def_id)))
         } else {
-            let substs = try!(relate_item_substs(relation, a.def_id, a.substs, b.substs));
+            let substs = relate_item_substs(relation, a.def_id, a.substs, b.substs)?;
             Ok(ty::TraitRef { def_id: a.def_id, substs: relation.tcx().mk_substs(substs) })
         }
     }
@@ -489,21 +489,21 @@ pub fn super_relate_tys<'a,'tcx:'a,R>(relation: &mut R,
         (&ty::TyEnum(a_def, a_substs), &ty::TyEnum(b_def, b_substs))
             if a_def == b_def =>
         {
-            let substs = try!(relate_item_substs(relation, a_def.did, a_substs, b_substs));
+            let substs = relate_item_substs(relation, a_def.did, a_substs, b_substs)?;
             Ok(tcx.mk_enum(a_def, tcx.mk_substs(substs)))
         }
 
         (&ty::TyTrait(ref a_), &ty::TyTrait(ref b_)) =>
         {
-            let principal = try!(relation.relate(&a_.principal, &b_.principal));
-            let bounds = try!(relation.relate(&a_.bounds, &b_.bounds));
+            let principal = relation.relate(&a_.principal, &b_.principal)?;
+            let bounds = relation.relate(&a_.bounds, &b_.bounds)?;
             Ok(tcx.mk_trait(principal, bounds))
         }
 
         (&ty::TyStruct(a_def, a_substs), &ty::TyStruct(b_def, b_substs))
             if a_def == b_def =>
         {
-            let substs = try!(relate_item_substs(relation, a_def.did, a_substs, b_substs));
+            let substs = relate_item_substs(relation, a_def.did, a_substs, b_substs)?;
             Ok(tcx.mk_struct(a_def, tcx.mk_substs(substs)))
         }
 
@@ -514,32 +514,32 @@ pub fn super_relate_tys<'a,'tcx:'a,R>(relation: &mut R,
             // All TyClosure types with the same id represent
             // the (anonymous) type of the same closure expression. So
             // all of their regions should be equated.
-            let substs = try!(relation.relate(a_substs, b_substs));
+            let substs = relation.relate(a_substs, b_substs)?;
             Ok(tcx.mk_closure_from_closure_substs(a_id, substs))
         }
 
         (&ty::TyBox(a_inner), &ty::TyBox(b_inner)) =>
         {
-            let typ = try!(relation.relate(&a_inner, &b_inner));
+            let typ = relation.relate(&a_inner, &b_inner)?;
             Ok(tcx.mk_box(typ))
         }
 
         (&ty::TyRawPtr(ref a_mt), &ty::TyRawPtr(ref b_mt)) =>
         {
-            let mt = try!(relation.relate(a_mt, b_mt));
+            let mt = relation.relate(a_mt, b_mt)?;
             Ok(tcx.mk_ptr(mt))
         }
 
         (&ty::TyRef(a_r, ref a_mt), &ty::TyRef(b_r, ref b_mt)) =>
         {
-            let r = try!(relation.relate_with_variance(ty::Contravariant, a_r, b_r));
-            let mt = try!(relation.relate(a_mt, b_mt));
+            let r = relation.relate_with_variance(ty::Contravariant, a_r, b_r)?;
+            let mt = relation.relate(a_mt, b_mt)?;
             Ok(tcx.mk_ref(tcx.mk_region(r), mt))
         }
 
         (&ty::TyArray(a_t, sz_a), &ty::TyArray(b_t, sz_b)) =>
         {
-            let t = try!(relation.relate(&a_t, &b_t));
+            let t = relation.relate(&a_t, &b_t)?;
             if sz_a == sz_b {
                 Ok(tcx.mk_array(t, sz_a))
             } else {
@@ -549,16 +549,16 @@ pub fn super_relate_tys<'a,'tcx:'a,R>(relation: &mut R,
 
         (&ty::TySlice(a_t), &ty::TySlice(b_t)) =>
         {
-            let t = try!(relation.relate(&a_t, &b_t));
+            let t = relation.relate(&a_t, &b_t)?;
             Ok(tcx.mk_slice(t))
         }
 
         (&ty::TyTuple(ref as_), &ty::TyTuple(ref bs)) =>
         {
             if as_.len() == bs.len() {
-                let ts = try!(as_.iter().zip(bs)
+                let ts = as_.iter().zip(bs)
                                  .map(|(a, b)| relation.relate(a, b))
-                                 .collect::<Result<_, _>>());
+                                 .collect::<Result<_, _>>()?;
                 Ok(tcx.mk_tup(ts))
             } else if !(as_.is_empty() || bs.is_empty()) {
                 Err(TypeError::TupleSize(
@@ -572,20 +572,20 @@ pub fn super_relate_tys<'a,'tcx:'a,R>(relation: &mut R,
          &ty::TyFnDef(b_def_id, b_substs, b_fty))
             if a_def_id == b_def_id =>
         {
-            let substs = try!(relate_substs(relation, None, a_substs, b_substs));
-            let fty = try!(relation.relate(a_fty, b_fty));
+            let substs = relate_substs(relation, None, a_substs, b_substs)?;
+            let fty = relation.relate(a_fty, b_fty)?;
             Ok(tcx.mk_fn_def(a_def_id, tcx.mk_substs(substs), fty))
         }
 
         (&ty::TyFnPtr(a_fty), &ty::TyFnPtr(b_fty)) =>
         {
-            let fty = try!(relation.relate(a_fty, b_fty));
+            let fty = relation.relate(a_fty, b_fty)?;
             Ok(tcx.mk_fn_ptr(fty))
         }
 
         (&ty::TyProjection(ref a_data), &ty::TyProjection(ref b_data)) =>
         {
-            let projection_ty = try!(relation.relate(a_data, b_data));
+            let projection_ty = relation.relate(a_data, b_data)?;
             Ok(tcx.mk_projection(projection_ty.trait_ref, projection_ty.item_name))
         }
 
@@ -603,8 +603,8 @@ impl<'a,'tcx:'a> Relate<'a,'tcx> for ty::ClosureSubsts<'tcx> {
                  -> RelateResult<'tcx, ty::ClosureSubsts<'tcx>>
         where R: TypeRelation<'a,'tcx>
     {
-        let func_substs = try!(relate_substs(relation, None, a.func_substs, b.func_substs));
-        let upvar_tys = try!(relation.relate_zip(&a.upvar_tys, &b.upvar_tys));
+        let func_substs = relate_substs(relation, None, a.func_substs, b.func_substs)?;
+        let upvar_tys = relation.relate_zip(&a.upvar_tys, &b.upvar_tys)?;
         Ok(ty::ClosureSubsts { func_substs: relation.tcx().mk_substs(func_substs),
                                upvar_tys: upvar_tys })
     }
@@ -645,7 +645,7 @@ impl<'a,'tcx:'a,T> Relate<'a,'tcx> for Rc<T>
     {
         let a: &T = a;
         let b: &T = b;
-        Ok(Rc::new(try!(relation.relate(a, b))))
+        Ok(Rc::new(relation.relate(a, b)?))
     }
 }
 
@@ -660,7 +660,7 @@ impl<'a,'tcx:'a,T> Relate<'a,'tcx> for Box<T>
     {
         let a: &T = a;
         let b: &T = b;
-        Ok(Box::new(try!(relation.relate(a, b))))
+        Ok(Box::new(relation.relate(a, b)?))
     }
 }
 

--- a/src/librustc/middle/ty/sty.rs
+++ b/src/librustc/middle/ty/sty.rs
@@ -250,7 +250,7 @@ pub struct ClosureSubsts<'tcx> {
 
 impl<'tcx> Decodable for &'tcx ClosureSubsts<'tcx> {
     fn decode<S: Decoder>(s: &mut S) -> Result<&'tcx ClosureSubsts<'tcx>, S::Error> {
-        let closure_substs = try! { Decodable::decode(s) };
+        let closure_substs = Decodable::decode(s)?;
         let dummy_def_id: DefId = unsafe { mem::zeroed() };
 
         cstore::tls::with_decoding_context(s, |dcx, _| {

--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -809,8 +809,8 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                         let variant_def = &adt_def.variants[variant];
 
                         ppaux::parameterized(fmt, substs, variant_def.did,
-                                                  ppaux::Ns::Value, &[],
-                                                  |tcx| {
+                                             ppaux::Ns::Value, &[],
+                                             |tcx| {
                             tcx.lookup_item_type(variant_def.did).generics
                         })?;
 

--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -356,7 +356,7 @@ impl<'tcx> BasicBlockData<'tcx> {
 
 impl<'tcx> Debug for Terminator<'tcx> {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
-        try!(self.fmt_head(fmt));
+        self.fmt_head(fmt)?;
         let successors = self.successors();
         let labels = self.fmt_successor_labels();
         assert_eq!(successors.len(), labels.len());
@@ -367,12 +367,12 @@ impl<'tcx> Debug for Terminator<'tcx> {
             1 => write!(fmt, " -> {:?}", successors[0]),
 
             _ => {
-                try!(write!(fmt, " -> ["));
+                write!(fmt, " -> [")?;
                 for (i, target) in successors.iter().enumerate() {
                     if i > 0 {
-                        try!(write!(fmt, ", "));
+                        write!(fmt, ", ")?;
                     }
-                    try!(write!(fmt, "{}: {:?}", labels[i], target));
+                    write!(fmt, "{}: {:?}", labels[i], target)?;
                 }
                 write!(fmt, "]")
             }
@@ -397,14 +397,14 @@ impl<'tcx> Terminator<'tcx> {
             Drop { ref value, .. } => write!(fmt, "drop({:?})", value),
             Call { ref func, ref args, ref destination, .. } => {
                 if let Some((ref destination, _)) = *destination {
-                    try!(write!(fmt, "{:?} = ", destination));
+                    write!(fmt, "{:?} = ", destination)?;
                 }
-                try!(write!(fmt, "{:?}(", func));
+                write!(fmt, "{:?}(", func)?;
                 for (index, arg) in args.iter().enumerate() {
                     if index > 0 {
-                        try!(write!(fmt, ", "));
+                        write!(fmt, ", ")?;
                     }
-                    try!(write!(fmt, "{:?}", arg));
+                    write!(fmt, "{:?}", arg)?;
                 }
                 write!(fmt, ")")
             }
@@ -808,11 +808,11 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                     Adt(adt_def, variant, substs) => {
                         let variant_def = &adt_def.variants[variant];
 
-                        try!(ppaux::parameterized(fmt, substs, variant_def.did,
+                        ppaux::parameterized(fmt, substs, variant_def.did,
                                                   ppaux::Ns::Value, &[],
                                                   |tcx| {
                             tcx.lookup_item_type(variant_def.did).generics
-                        }));
+                        })?;
 
                         match variant_def.kind() {
                             ty::VariantKind::Unit => Ok(()),
@@ -903,7 +903,7 @@ impl<'tcx> Debug for Literal<'tcx> {
                                      |tcx| tcx.lookup_item_type(def_id).generics)
             }
             Value { ref value } => {
-                try!(write!(fmt, "const "));
+                write!(fmt, "const ")?;
                 fmt_const_val(fmt, value)
             }
         }

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -34,23 +34,23 @@ fn fn_sig(f: &mut fmt::Formatter,
           variadic: bool,
           output: ty::FnOutput)
           -> fmt::Result {
-    try!(write!(f, "("));
+    write!(f, "(")?;
     let mut inputs = inputs.iter();
     if let Some(&ty) = inputs.next() {
-        try!(write!(f, "{}", ty));
+        write!(f, "{}", ty)?;
         for &ty in inputs {
-            try!(write!(f, ", {}", ty));
+            write!(f, ", {}", ty)?;
         }
         if variadic {
-            try!(write!(f, ", ..."));
+            write!(f, ", ...")?;
         }
     }
-    try!(write!(f, ")"));
+    write!(f, ")")?;
 
     match output {
         ty::FnConverging(ty) => {
             if !ty.is_nil() {
-                try!(write!(f, " -> {}", ty));
+                write!(f, " -> {}", ty)?;
             }
             Ok(())
         }
@@ -77,10 +77,10 @@ pub fn parameterized<GG>(f: &mut fmt::Formatter,
     where GG: for<'tcx> FnOnce(&TyCtxt<'tcx>) -> ty::Generics<'tcx>
 {
     if let (Ns::Value, Some(self_ty)) = (ns, substs.self_ty()) {
-        try!(write!(f, "<{} as ", self_ty));
+        write!(f, "<{} as ", self_ty)?;
     }
 
-    let (fn_trait_kind, verbose, last_name) = try!(ty::tls::with(|tcx| {
+    let (fn_trait_kind, verbose, last_name) = ty::tls::with(|tcx| {
         let (did, last_name) = if ns == Ns::Value {
             // Try to get the impl/trait parent, if this is an
             // associated value item (method or constant).
@@ -89,9 +89,9 @@ pub fn parameterized<GG>(f: &mut fmt::Formatter,
         } else {
             (did, None)
         };
-        try!(write!(f, "{}", tcx.item_path_str(did)));
+        write!(f, "{}", tcx.item_path_str(did))?;
         Ok((tcx.lang_items.fn_trait_kind(did), tcx.sess.verbose(), last_name))
-    }));
+    })?;
 
     let mut empty = true;
     let mut start_or_continue = |f: &mut fmt::Formatter, start: &str, cont: &str| {
@@ -106,25 +106,25 @@ pub fn parameterized<GG>(f: &mut fmt::Formatter,
     if verbose {
         match substs.regions {
             subst::ErasedRegions => {
-                try!(start_or_continue(f, "<", ", "));
-                try!(write!(f, ".."));
+                start_or_continue(f, "<", ", ")?;
+                write!(f, "..")?;
             }
             subst::NonerasedRegions(ref regions) => {
                 for region in regions {
-                    try!(start_or_continue(f, "<", ", "));
-                    try!(write!(f, "{:?}", region));
+                    start_or_continue(f, "<", ", ")?;
+                    write!(f, "{:?}", region)?;
                 }
             }
         }
         for &ty in &substs.types {
-            try!(start_or_continue(f, "<", ", "));
-            try!(write!(f, "{}", ty));
+            start_or_continue(f, "<", ", ")?;
+            write!(f, "{}", ty)?;
         }
         for projection in projections {
-            try!(start_or_continue(f, "<", ", "));
-            try!(write!(f, "{}={}",
+            start_or_continue(f, "<", ", ")?;
+            write!(f, "{}={}",
                         projection.projection_ty.item_name,
-                        projection.ty));
+                        projection.ty)?;
         }
         return start_or_continue(f, "", ">");
     }
@@ -140,7 +140,7 @@ pub fn parameterized<GG>(f: &mut fmt::Formatter,
         subst::ErasedRegions => { }
         subst::NonerasedRegions(ref regions) => {
             for &r in regions {
-                try!(start_or_continue(f, "<", ", "));
+                start_or_continue(f, "<", ", ")?;
                 let s = r.to_string();
                 if s.is_empty() {
                     // This happens when the value of the region
@@ -148,9 +148,9 @@ pub fn parameterized<GG>(f: &mut fmt::Formatter,
                     // because the user omitted it in the first place,
                     // or because it refers to some block in the code,
                     // etc. I'm not sure how best to serialize this.
-                    try!(write!(f, "'_"));
+                    write!(f, "'_")?;
                 } else {
-                    try!(write!(f, "{}", s));
+                    write!(f, "{}", s)?;
                 }
             }
         }
@@ -194,35 +194,35 @@ pub fn parameterized<GG>(f: &mut fmt::Formatter,
     });
 
     for &ty in &tps[..tps.len() - num_defaults] {
-        try!(start_or_continue(f, "<", ", "));
-        try!(write!(f, "{}", ty));
+        start_or_continue(f, "<", ", ")?;
+        write!(f, "{}", ty)?;
     }
 
     for projection in projections {
-        try!(start_or_continue(f, "<", ", "));
-        try!(write!(f, "{}={}",
+        start_or_continue(f, "<", ", ")?;
+        write!(f, "{}={}",
                     projection.projection_ty.item_name,
-                    projection.ty));
+                    projection.ty)?;
     }
 
-    try!(start_or_continue(f, "", ">"));
+    start_or_continue(f, "", ">")?;
 
     // For values, also print their name and type parameters.
     if ns == Ns::Value {
         if substs.self_ty().is_some() {
-            try!(write!(f, ">"));
+            write!(f, ">")?;
         }
 
         if let Some(name) = last_name {
-            try!(write!(f, "::{}", name));
+            write!(f, "::{}", name)?;
         }
         let tps = substs.types.get_slice(subst::FnSpace);
         if !tps.is_empty() {
-            try!(write!(f, "::<{}", tps[0]));
+            write!(f, "::<{}", tps[0])?;
             for ty in &tps[1..] {
-                try!(write!(f, ", {}", ty));
+                write!(f, ", {}", ty)?;
             }
-            try!(write!(f, ">"));
+            write!(f, ">")?;
         }
     }
 
@@ -273,7 +273,7 @@ fn in_binder<'tcx, T, U>(f: &mut fmt::Formatter,
         })
     }).0;
 
-    try!(start_or_continue(f, "", "> "));
+    start_or_continue(f, "", "> ")?;
     write!(f, "{}", new_value)
 }
 
@@ -317,7 +317,7 @@ impl<'tcx> fmt::Display for ty::TraitTy<'tcx> {
         let bounds = &self.bounds;
 
         // Generate the main trait ref, including associated types.
-        try!(ty::tls::with(|tcx| {
+        ty::tls::with(|tcx| {
             let principal = tcx.lift(&self.principal.0)
                                .expect("could not lift TraitRef for printing");
             let projections = tcx.lift(&bounds.projection_bounds[..])
@@ -326,11 +326,11 @@ impl<'tcx> fmt::Display for ty::TraitTy<'tcx> {
 
             let tap = ty::Binder(TraitAndProjections(principal, projections));
             in_binder(f, tcx, &ty::Binder(""), Some(tap))
-        }));
+        })?;
 
         // Builtin bounds.
         for bound in &bounds.builtin_bounds {
-            try!(write!(f, " + {:?}", bound));
+            write!(f, " + {:?}", bound)?;
         }
 
         // FIXME: It'd be nice to compute from context when this bound
@@ -340,7 +340,7 @@ impl<'tcx> fmt::Display for ty::TraitTy<'tcx> {
         // people aware that it's there.
         let bound = bounds.region_bound.to_string();
         if !bound.is_empty() {
-            try!(write!(f, " + {}", bound));
+            write!(f, " + {}", bound)?;
         }
 
         Ok(())
@@ -648,19 +648,19 @@ impl<'tcx> fmt::Debug for ty::InstantiatedPredicates<'tcx> {
 
 impl<'tcx> fmt::Debug for ty::ImplOrTraitItem<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "ImplOrTraitItem("));
-        try!(match *self {
+        write!(f, "ImplOrTraitItem(")?;
+        match *self {
             ty::ImplOrTraitItem::MethodTraitItem(ref i) => write!(f, "{:?}", i),
             ty::ImplOrTraitItem::ConstTraitItem(ref i) => write!(f, "{:?}", i),
             ty::ImplOrTraitItem::TypeTraitItem(ref i) => write!(f, "{:?}", i),
-        });
+        }?;
         write!(f, ")")
     }
 }
 
 impl<'tcx> fmt::Display for ty::FnSig<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "fn"));
+        write!(f, "fn")?;
         fn_sig(f, &self.inputs, self.variadic, self.output)
     }
 }
@@ -679,18 +679,18 @@ impl<'tcx> fmt::Debug for ty::ExistentialBounds<'tcx> {
 
         let region_str = format!("{:?}", self.region_bound);
         if !region_str.is_empty() {
-            try!(maybe_continue(f));
-            try!(write!(f, "{}", region_str));
+            maybe_continue(f)?;
+            write!(f, "{}", region_str)?;
         }
 
         for bound in &self.builtin_bounds {
-            try!(maybe_continue(f));
-            try!(write!(f, "{:?}", bound));
+            maybe_continue(f)?;
+            write!(f, "{:?}", bound)?;
         }
 
         for projection_bound in &self.projection_bounds {
-            try!(maybe_continue(f));
-            try!(write!(f, "{:?}", projection_bound));
+            maybe_continue(f)?;
+            write!(f, "{:?}", projection_bound)?;
         }
 
         Ok(())
@@ -701,9 +701,9 @@ impl fmt::Display for ty::BuiltinBounds {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut bounds = self.iter();
         if let Some(bound) = bounds.next() {
-            try!(write!(f, "{:?}", bound));
+            write!(f, "{:?}", bound)?;
             for bound in bounds {
-                try!(write!(f, " + {:?}", bound));
+                write!(f, " + {:?}", bound)?;
             }
         }
         Ok(())
@@ -832,23 +832,23 @@ impl<'tcx> fmt::Display for ty::TypeVariants<'tcx> {
                 },  tm.ty)
             }
             TyRef(r, ref tm) => {
-                try!(write!(f, "&"));
+                write!(f, "&")?;
                 let s = r.to_string();
-                try!(write!(f, "{}", s));
+                write!(f, "{}", s)?;
                 if !s.is_empty() {
-                    try!(write!(f, " "));
+                    write!(f, " ")?;
                 }
                 write!(f, "{}", tm)
             }
             TyTuple(ref tys) => {
-                try!(write!(f, "("));
+                write!(f, "(")?;
                 let mut tys = tys.iter();
                 if let Some(&ty) = tys.next() {
-                    try!(write!(f, "{},", ty));
+                    write!(f, "{},", ty)?;
                     if let Some(&ty) = tys.next() {
-                        try!(write!(f, " {}", ty));
+                        write!(f, " {}", ty)?;
                         for &ty in tys {
-                            try!(write!(f, ", {}", ty));
+                            write!(f, ", {}", ty)?;
                         }
                     }
                 }
@@ -856,25 +856,25 @@ impl<'tcx> fmt::Display for ty::TypeVariants<'tcx> {
             }
             TyFnDef(def_id, substs, ref bare_fn) => {
                 if bare_fn.unsafety == hir::Unsafety::Unsafe {
-                    try!(write!(f, "unsafe "));
+                    write!(f, "unsafe ")?;
                 }
 
                 if bare_fn.abi != Abi::Rust {
-                    try!(write!(f, "extern {} ", bare_fn.abi));
+                    write!(f, "extern {} ", bare_fn.abi)?;
                 }
 
-                try!(write!(f, "{} {{", bare_fn.sig.0));
-                try!(parameterized(f, substs, def_id, Ns::Value, &[],
-                                   |tcx| tcx.lookup_item_type(def_id).generics));
+                write!(f, "{} {{", bare_fn.sig.0)?;
+                parameterized(f, substs, def_id, Ns::Value, &[],
+                                   |tcx| tcx.lookup_item_type(def_id).generics)?;
                 write!(f, "}}")
             }
             TyFnPtr(ref bare_fn) => {
                 if bare_fn.unsafety == hir::Unsafety::Unsafe {
-                    try!(write!(f, "unsafe "));
+                    write!(f, "unsafe ")?;
                 }
 
                 if bare_fn.abi != Abi::Rust {
-                    try!(write!(f, "extern {} ", bare_fn.abi));
+                    write!(f, "extern {} ", bare_fn.abi)?;
                 }
 
                 write!(f, "{}", bare_fn.sig.0)
@@ -897,30 +897,30 @@ impl<'tcx> fmt::Display for ty::TypeVariants<'tcx> {
             ty::TyProjection(ref data) => write!(f, "{}", data),
             TyStr => write!(f, "str"),
             TyClosure(did, ref substs) => ty::tls::with(|tcx| {
-                try!(write!(f, "[closure"));
+                write!(f, "[closure")?;
 
                 if let Some(node_id) = tcx.map.as_local_node_id(did) {
-                    try!(write!(f, "@{:?}", tcx.map.span(node_id)));
+                    write!(f, "@{:?}", tcx.map.span(node_id))?;
                     let mut sep = " ";
-                    try!(tcx.with_freevars(node_id, |freevars| {
+                    tcx.with_freevars(node_id, |freevars| {
                         for (freevar, upvar_ty) in freevars.iter().zip(&substs.upvar_tys) {
                             let node_id = freevar.def.var_id();
-                            try!(write!(f,
+                            write!(f,
                                         "{}{}:{}",
                                         sep,
                                         tcx.local_var_name_str(node_id),
-                                        upvar_ty));
+                                        upvar_ty)?;
                             sep = ", ";
                         }
                         Ok(())
-                    }))
+                    })?
                 } else {
                     // cross-crate closure types should only be
                     // visible in trans bug reports, I imagine.
-                    try!(write!(f, "@{:?}", did));
+                    write!(f, "@{:?}", did)?;
                     let mut sep = " ";
                     for (index, upvar_ty) in substs.upvar_tys.iter().enumerate() {
-                        try!(write!(f, "{}{}:{}", sep, index, upvar_ty));
+                        write!(f, "{}{}:{}", sep, index, upvar_ty)?;
                         sep = ", ";
                     }
                 }

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -123,8 +123,8 @@ pub fn parameterized<GG>(f: &mut fmt::Formatter,
         for projection in projections {
             start_or_continue(f, "<", ", ")?;
             write!(f, "{}={}",
-                        projection.projection_ty.item_name,
-                        projection.ty)?;
+                   projection.projection_ty.item_name,
+                   projection.ty)?;
         }
         return start_or_continue(f, "", ">");
     }
@@ -201,8 +201,8 @@ pub fn parameterized<GG>(f: &mut fmt::Formatter,
     for projection in projections {
         start_or_continue(f, "<", ", ")?;
         write!(f, "{}={}",
-                    projection.projection_ty.item_name,
-                    projection.ty)?;
+               projection.projection_ty.item_name,
+               projection.ty)?;
     }
 
     start_or_continue(f, "", ">")?;
@@ -865,7 +865,7 @@ impl<'tcx> fmt::Display for ty::TypeVariants<'tcx> {
 
                 write!(f, "{} {{", bare_fn.sig.0)?;
                 parameterized(f, substs, def_id, Ns::Value, &[],
-                                   |tcx| tcx.lookup_item_type(def_id).generics)?;
+                              |tcx| tcx.lookup_item_type(def_id).generics)?;
                 write!(f, "}}")
             }
             TyFnPtr(ref bare_fn) => {

--- a/src/librustc_back/lib.rs
+++ b/src/librustc_back/lib.rs
@@ -38,6 +38,7 @@
 #![feature(rustc_private)]
 #![feature(staged_api)]
 #![feature(step_by)]
+#![feature(question_mark)]
 #![cfg_attr(unix, feature(static_mutex))]
 #![cfg_attr(test, feature(test, rand))]
 

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -464,11 +464,11 @@ impl Target {
         use serialize::json;
 
         fn load_file(path: &Path) -> Result<Target, String> {
-            let mut f = try!(File::open(path).map_err(|e| e.to_string()));
+            let mut f = File::open(path).map_err(|e| e.to_string())?;
             let mut contents = Vec::new();
-            try!(f.read_to_end(&mut contents).map_err(|e| e.to_string()));
-            let obj = try!(json::from_reader(&mut &contents[..])
-                                .map_err(|e| e.to_string()));
+            f.read_to_end(&mut contents).map_err(|e| e.to_string())?;
+            let obj = json::from_reader(&mut &contents[..])
+                                .map_err(|e| e.to_string())?;
             Ok(Target::from_json(obj))
         }
 

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -468,7 +468,7 @@ impl Target {
             let mut contents = Vec::new();
             f.read_to_end(&mut contents).map_err(|e| e.to_string())?;
             let obj = json::from_reader(&mut &contents[..])
-                                .map_err(|e| e.to_string())?;
+                           .map_err(|e| e.to_string())?;
             Ok(Target::from_json(obj))
         }
 

--- a/src/librustc_back/tempdir.rs
+++ b/src/librustc_back/tempdir.rs
@@ -45,7 +45,7 @@ impl TempDir {
         let storage;
         let mut tmpdir = tmpdir;
         if !tmpdir.is_absolute() {
-            let cur_dir = try!(env::current_dir());
+            let cur_dir = env::current_dir()?;
             storage = cur_dir.join(tmpdir);
             tmpdir = &storage;
             // return TempDir::new_in(&cur_dir.join(tmpdir), prefix);

--- a/src/librustc_borrowck/borrowck/mir/gather_moves.rs
+++ b/src/librustc_borrowck/borrowck/mir/gather_moves.rs
@@ -112,15 +112,15 @@ impl<'tcx> PreMovePath<'tcx> {
 
 impl<'tcx> fmt::Debug for MovePath<'tcx> {
     fn fmt(&self, w: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(w, "MovePath {{"));
+        write!(w, "MovePath {{")?;
         if let Some(parent) = self.parent {
-            try!(write!(w, " parent: {:?},", parent));
+            write!(w, " parent: {:?},", parent)?;
         }
         if let Some(first_child) = self.first_child {
-            try!(write!(w, " first_child: {:?},", first_child));
+            write!(w, " first_child: {:?},", first_child)?;
         }
         if let Some(next_sibling) = self.next_sibling {
-            try!(write!(w, " next_sibling: {:?}", next_sibling));
+            write!(w, " next_sibling: {:?}", next_sibling)?;
         }
         write!(w, " content: {:?} }}", self.content)
     }

--- a/src/librustc_borrowck/borrowck/mir/graphviz.rs
+++ b/src/librustc_borrowck/borrowck/mir/graphviz.rs
@@ -124,15 +124,15 @@ impl<'c, 'b:'c, 'a:'b, 'tcx:'a> dot::Labeller<'c> for Graph<'c,'b,'a,'tcx> {
                     write!(w, "</td><td></td><td></td></tr>")?;
                 }
                 write!(w, "<tr><td></td><td {bg} {align}>{objs:?}",
-                            bg = BG_FLOWCONTENT,
-                            align = ALIGN_RIGHT,
-                            objs = c)?;
+                       bg = BG_FLOWCONTENT,
+                       align = ALIGN_RIGHT,
+                       objs = c)?;
                 seen_one = true;
             }
             if !seen_one {
                 write!(w, "<tr><td></td><td {bg} {align}>[]",
-                            bg = BG_FLOWCONTENT,
-                            align = ALIGN_RIGHT)?;
+                       bg = BG_FLOWCONTENT,
+                       align = ALIGN_RIGHT)?;
             }
             Ok(())
         }
@@ -155,18 +155,18 @@ impl<'c, 'b:'c, 'a:'b, 'tcx:'a> dot::Labeller<'c> for Graph<'c,'b,'a,'tcx> {
                 let kill = flow.interpret_set(flow.sets.kill_set_for(i));
                 chunked_present_left(w, &gen[..], chunk_size)?;
                 write!(w, " = GEN:</td><td {bg}><FONT {face}>{genbits:?}</FONT></td>\
-                                            <td></td></tr>",
-                            bg = BG_FLOWCONTENT,
-                            face = FACE_MONOSPACE,
-                            genbits=bits_to_string( flow.sets.gen_set_for(i),
-                                                    flow.sets.bytes_per_block()))?;
+                                       <td></td></tr>",
+                       bg = BG_FLOWCONTENT,
+                       face = FACE_MONOSPACE,
+                       genbits=bits_to_string( flow.sets.gen_set_for(i),
+                                               flow.sets.bytes_per_block()))?;
                 write!(w, "<tr><td></td><td {bg} {align}>KILL:</td>\
-                                             <td {bg}><FONT {face}>{killbits:?}</FONT></td>",
-                            bg = BG_FLOWCONTENT,
-                            align = ALIGN_RIGHT,
-                            face = FACE_MONOSPACE,
-                            killbits=bits_to_string(flow.sets.kill_set_for(i),
-                                                    flow.sets.bytes_per_block()))?;
+                                        <td {bg}><FONT {face}>{killbits:?}</FONT></td>",
+                       bg = BG_FLOWCONTENT,
+                       align = ALIGN_RIGHT,
+                       face = FACE_MONOSPACE,
+                       killbits=bits_to_string(flow.sets.kill_set_for(i),
+                                               flow.sets.bytes_per_block()))?;
 
                 // (chunked_present_right)
                 let mut seen_one = false;
@@ -174,19 +174,19 @@ impl<'c, 'b:'c, 'a:'b, 'tcx:'a> dot::Labeller<'c> for Graph<'c,'b,'a,'tcx> {
                     if !seen_one {
                         // continuation of row; this is fourth <td>
                         write!(w, "<td {bg}>= {kill:?}</td></tr>",
-                                    bg = BG_FLOWCONTENT,
-                                    kill=k)?;
+                               bg = BG_FLOWCONTENT,
+                               kill=k)?;
                     } else {
                         // new row, with indent of three <td>'s
                         write!(w, "<tr><td></td><td></td><td></td><td {bg}>{kill:?}</td></tr>",
-                                    bg = BG_FLOWCONTENT,
-                                    kill=k)?;
+                               bg = BG_FLOWCONTENT,
+                               kill=k)?;
                     }
                     seen_one = true;
                 }
                 if !seen_one {
                     write!(w, "<td {bg}>= []</td></tr>",
-                                bg = BG_FLOWCONTENT)?;
+                           bg = BG_FLOWCONTENT)?;
                 }
 
                 Ok(())

--- a/src/librustc_borrowck/borrowck/mir/graphviz.rs
+++ b/src/librustc_borrowck/borrowck/mir/graphviz.rs
@@ -31,7 +31,7 @@ pub fn print_borrowck_graph_to(mbcx: &MirBorrowckCtxt,
                                path: &str) -> io::Result<()> {
     let g = Graph { mbcx: mbcx, context: context };
     let mut v = Vec::new();
-    try!(dot::render(&g, &mut v));
+    dot::render(&g, &mut v)?;
     println!("print_borrowck_graph_to path: {} context: {} node_id: {}",
              path, context, mbcx.node_id);
     File::create(path).and_then(|mut f| f.write_all(&v))
@@ -121,18 +121,18 @@ impl<'c, 'b:'c, 'a:'b, 'tcx:'a> dot::Labeller<'c> for Graph<'c,'b,'a,'tcx> {
             for c in interpreted.chunks(chunk_size) {
                 if seen_one {
                     // if not the first row, finish off the previous row
-                    try!(write!(w, "</td><td></td><td></td></tr>"));
+                    write!(w, "</td><td></td><td></td></tr>")?;
                 }
-                try!(write!(w, "<tr><td></td><td {bg} {align}>{objs:?}",
+                write!(w, "<tr><td></td><td {bg} {align}>{objs:?}",
                             bg = BG_FLOWCONTENT,
                             align = ALIGN_RIGHT,
-                            objs = c));
+                            objs = c)?;
                 seen_one = true;
             }
             if !seen_one {
-                try!(write!(w, "<tr><td></td><td {bg} {align}>[]",
+                write!(w, "<tr><td></td><td {bg} {align}>[]",
                             bg = BG_FLOWCONTENT,
-                            align = ALIGN_RIGHT));
+                            align = ALIGN_RIGHT)?;
             }
             Ok(())
         }
@@ -141,7 +141,7 @@ impl<'c, 'b:'c, 'a:'b, 'tcx:'a> dot::Labeller<'c> for Graph<'c,'b,'a,'tcx> {
             |w| {
                 let flow = &self.mbcx.flow_state;
                 let entry = flow.interpret_set(flow.sets.on_entry_set_for(i));
-                try!(chunked_present_left(w, &entry[..], chunk_size));
+                chunked_present_left(w, &entry[..], chunk_size)?;
                 write!(w, "= ENTRY:</td><td {bg}><FONT {face}>{entrybits:?}</FONT></td>\
                                         <td></td></tr>",
                        bg = BG_FLOWCONTENT,
@@ -153,40 +153,40 @@ impl<'c, 'b:'c, 'a:'b, 'tcx:'a> dot::Labeller<'c> for Graph<'c,'b,'a,'tcx> {
                 let flow = &self.mbcx.flow_state;
                 let gen = flow.interpret_set( flow.sets.gen_set_for(i));
                 let kill = flow.interpret_set(flow.sets.kill_set_for(i));
-                try!(chunked_present_left(w, &gen[..], chunk_size));
-                try!(write!(w, " = GEN:</td><td {bg}><FONT {face}>{genbits:?}</FONT></td>\
+                chunked_present_left(w, &gen[..], chunk_size)?;
+                write!(w, " = GEN:</td><td {bg}><FONT {face}>{genbits:?}</FONT></td>\
                                             <td></td></tr>",
                             bg = BG_FLOWCONTENT,
                             face = FACE_MONOSPACE,
                             genbits=bits_to_string( flow.sets.gen_set_for(i),
-                                                    flow.sets.bytes_per_block())));
-                try!(write!(w, "<tr><td></td><td {bg} {align}>KILL:</td>\
+                                                    flow.sets.bytes_per_block()))?;
+                write!(w, "<tr><td></td><td {bg} {align}>KILL:</td>\
                                              <td {bg}><FONT {face}>{killbits:?}</FONT></td>",
                             bg = BG_FLOWCONTENT,
                             align = ALIGN_RIGHT,
                             face = FACE_MONOSPACE,
                             killbits=bits_to_string(flow.sets.kill_set_for(i),
-                                                    flow.sets.bytes_per_block())));
+                                                    flow.sets.bytes_per_block()))?;
 
                 // (chunked_present_right)
                 let mut seen_one = false;
                 for k in kill.chunks(chunk_size) {
                     if !seen_one {
                         // continuation of row; this is fourth <td>
-                        try!(write!(w, "<td {bg}>= {kill:?}</td></tr>",
+                        write!(w, "<td {bg}>= {kill:?}</td></tr>",
                                     bg = BG_FLOWCONTENT,
-                                    kill=k));
+                                    kill=k)?;
                     } else {
                         // new row, with indent of three <td>'s
-                        try!(write!(w, "<tr><td></td><td></td><td></td><td {bg}>{kill:?}</td></tr>",
+                        write!(w, "<tr><td></td><td></td><td></td><td {bg}>{kill:?}</td></tr>",
                                     bg = BG_FLOWCONTENT,
-                                    kill=k));
+                                    kill=k)?;
                     }
                     seen_one = true;
                 }
                 if !seen_one {
-                    try!(write!(w, "<td {bg}>= []</td></tr>",
-                                bg = BG_FLOWCONTENT));
+                    write!(w, "<td {bg}>= []</td></tr>",
+                                bg = BG_FLOWCONTENT)?;
                 }
 
                 Ok(())

--- a/src/librustc_borrowck/lib.rs
+++ b/src/librustc_borrowck/lib.rs
@@ -25,6 +25,7 @@
 #![feature(staged_api)]
 #![feature(associated_consts)]
 #![feature(nonzero)]
+#![feature(question_mark)]
 #[macro_use] extern crate log;
 #[macro_use] extern crate syntax;
 

--- a/src/librustc_const_eval/int.rs
+++ b/src/librustc_const_eval/int.rs
@@ -220,7 +220,7 @@ impl ConstInt {
 
     /// Compares the values if they are of the same type
     pub fn try_cmp(self, rhs: Self) -> Result<::std::cmp::Ordering, ConstMathErr> {
-        match try!(self.infer(rhs)) {
+        match self.infer(rhs)? {
             (I8(a), I8(b)) => Ok(a.cmp(&b)),
             (I16(a), I16(b)) => Ok(a.cmp(&b)),
             (I32(a), I32(b)) => Ok(a.cmp(&b)),
@@ -420,8 +420,8 @@ fn check_division(
 impl ::std::ops::Div for ConstInt {
     type Output = Result<Self, ConstMathErr>;
     fn div(self, rhs: Self) -> Result<Self, ConstMathErr> {
-        let (lhs, rhs) = try!(self.infer(rhs));
-        try!(check_division(lhs, rhs, Op::Div, DivisionByZero));
+        let (lhs, rhs) = self.infer(rhs)?;
+        check_division(lhs, rhs, Op::Div, DivisionByZero)?;
         match (lhs, rhs) {
             (I8(a), I8(b)) => Ok(I8(a/b)),
             (I16(a), I16(b)) => Ok(I16(a/b)),
@@ -447,9 +447,9 @@ impl ::std::ops::Div for ConstInt {
 impl ::std::ops::Rem for ConstInt {
     type Output = Result<Self, ConstMathErr>;
     fn rem(self, rhs: Self) -> Result<Self, ConstMathErr> {
-        let (lhs, rhs) = try!(self.infer(rhs));
+        let (lhs, rhs) = self.infer(rhs)?;
         // should INT_MIN%-1 be zero or an error?
-        try!(check_division(lhs, rhs, Op::Rem, RemainderByZero));
+        check_division(lhs, rhs, Op::Rem, RemainderByZero)?;
         match (lhs, rhs) {
             (I8(a), I8(b)) => Ok(I8(a%b)),
             (I16(a), I16(b)) => Ok(I16(a%b)),
@@ -475,7 +475,7 @@ impl ::std::ops::Rem for ConstInt {
 impl ::std::ops::Shl<ConstInt> for ConstInt {
     type Output = Result<Self, ConstMathErr>;
     fn shl(self, rhs: Self) -> Result<Self, ConstMathErr> {
-        let b = try!(rhs.to_u32().ok_or(ShiftNegative));
+        let b = rhs.to_u32().ok_or(ShiftNegative)?;
         match self {
             I8(a) => Ok(I8(overflowing!(a.overflowing_shl(b), Op::Shl))),
             I16(a) => Ok(I16(overflowing!(a.overflowing_shl(b), Op::Shl))),
@@ -498,7 +498,7 @@ impl ::std::ops::Shl<ConstInt> for ConstInt {
 impl ::std::ops::Shr<ConstInt> for ConstInt {
     type Output = Result<Self, ConstMathErr>;
     fn shr(self, rhs: Self) -> Result<Self, ConstMathErr> {
-        let b = try!(rhs.to_u32().ok_or(ShiftNegative));
+        let b = rhs.to_u32().ok_or(ShiftNegative)?;
         match self {
             I8(a) => Ok(I8(overflowing!(a.overflowing_shr(b), Op::Shr))),
             I16(a) => Ok(I16(overflowing!(a.overflowing_shr(b), Op::Shr))),

--- a/src/librustc_const_eval/lib.rs
+++ b/src/librustc_const_eval/lib.rs
@@ -25,6 +25,7 @@
 
 #![feature(rustc_private)]
 #![feature(staged_api)]
+#![feature(question_mark)]
 
 #[macro_use] extern crate log;
 #[macro_use] extern crate syntax;

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -100,10 +100,10 @@ pub fn compile_input(sess: &Session,
             let outputs = build_output_filenames(input, outdir, output, &krate.attrs, sess);
             let id = link::find_crate_name(Some(sess), &krate.attrs, input);
             let expanded_crate = phase_2_configure_and_expand(sess,
-                                                                   &cstore,
-                                                                   krate,
-                                                                   &id[..],
-                                                                   addl_plugins)?;
+                                                              &cstore,
+                                                              krate,
+                                                              &id[..],
+                                                              addl_plugins)?;
 
             (outputs, expanded_crate, id)
         };
@@ -169,12 +169,12 @@ pub fn compile_input(sess: &Session,
         };
 
         phase_3_run_analysis_passes(sess,
-                                              &cstore,
-                                              hir_map,
-                                              &arenas,
-                                              &id,
-                                              control.make_glob_map,
-                                              |tcx, mir_map, analysis, result| {
+                                    &cstore,
+                                    hir_map,
+                                    &arenas,
+                                    &id,
+                                    control.make_glob_map,
+                                    |tcx, mir_map, analysis, result| {
             {
                 // Eventually, we will want to track plugins.
                 let _ignore = tcx.dep_graph.in_ignore();
@@ -683,8 +683,8 @@ pub fn phase_2_configure_and_expand(sess: &Session,
     })?;
 
     time(time_passes,
-              "const fn bodies and arguments",
-              || const_fn::check_crate(sess, &krate))?;
+         "const fn bodies and arguments",
+         || const_fn::check_crate(sess, &krate))?;
 
     if sess.opts.debugging_opts.input_stats {
         println!("Post-expansion node count: {}", count_nodes(&krate));
@@ -781,10 +781,10 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
     };
 
     let named_region_map = time(time_passes,
-                                     "lifetime resolution",
-                                     || middle::resolve_lifetime::krate(sess,
-                                                                        &hir_map,
-                                                                        &def_map.borrow()))?;
+                                "lifetime resolution",
+                                || middle::resolve_lifetime::krate(sess,
+                                                                   &hir_map,
+                                                                   &def_map.borrow()))?;
 
     time(time_passes,
          "looking for entry point",

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -99,11 +99,11 @@ pub fn compile_input(sess: &Session,
 
             let outputs = build_output_filenames(input, outdir, output, &krate.attrs, sess);
             let id = link::find_crate_name(Some(sess), &krate.attrs, input);
-            let expanded_crate = try!(phase_2_configure_and_expand(sess,
+            let expanded_crate = phase_2_configure_and_expand(sess,
                                                                    &cstore,
                                                                    krate,
                                                                    &id[..],
-                                                                   addl_plugins));
+                                                                   addl_plugins)?;
 
             (outputs, expanded_crate, id)
         };
@@ -168,7 +168,7 @@ pub fn compile_input(sess: &Session,
             None
         };
 
-        try!(try!(phase_3_run_analysis_passes(sess,
+        phase_3_run_analysis_passes(sess,
                                               &cstore,
                                               hir_map,
                                               &arenas,
@@ -196,7 +196,7 @@ pub fn compile_input(sess: &Session,
                 }
             }
 
-            try!(result);
+            result?;
 
             if log_enabled!(::log::INFO) {
                 println!("Pre-trans");
@@ -215,7 +215,7 @@ pub fn compile_input(sess: &Session,
             token::get_ident_interner().clear();
 
             Ok((outputs, trans))
-        })))
+        })??
     };
 
     let phase5_result = phase_5_run_llvm_passes(sess, &trans, &outputs);
@@ -224,7 +224,7 @@ pub fn compile_input(sess: &Session,
                             sess,
                             CompileState::state_after_llvm(input, sess, outdir, &trans),
                             phase5_result);
-    try!(phase5_result);
+    phase5_result?;
 
     phase_6_link_output(sess, &trans, &outputs);
 
@@ -428,7 +428,7 @@ pub fn phase_1_parse_input<'a>(sess: &'a Session,
     syntax::ext::mtwt::reset_tables();
     token::reset_ident_interner();
 
-    let krate = try!(time(sess.time_passes(), "parsing", || {
+    let krate = time(sess.time_passes(), "parsing", || {
         match *input {
             Input::File(ref file) => {
                 parse::parse_crate_from_file(file, cfg.clone(), &sess.parse_sess)
@@ -440,7 +440,7 @@ pub fn phase_1_parse_input<'a>(sess: &'a Session,
                                                    &sess.parse_sess)
             }
         }
-    }));
+    })?;
 
     if sess.opts.debugging_opts.ast_json_noexpand {
         println!("{}", json::as_json(&krate));
@@ -491,13 +491,13 @@ pub fn phase_2_configure_and_expand(sess: &Session,
     // baz! should not use this definition unless foo is enabled.
 
     let mut feature_gated_cfgs = vec![];
-    krate = try!(time(time_passes, "configuration 1", || {
+    krate = time(time_passes, "configuration 1", || {
         sess.track_errors(|| {
             syntax::config::strip_unconfigured_items(sess.diagnostic(),
                                                      krate,
                                                      &mut feature_gated_cfgs)
         })
-    }));
+    })?;
 
     *sess.crate_types.borrow_mut() = collect_crate_types(sess, &krate.attrs);
     *sess.crate_metadata.borrow_mut() = collect_crate_metadata(sess, &krate.attrs);
@@ -506,7 +506,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
         middle::recursion_limit::update_recursion_limit(sess, &krate);
     });
 
-    try!(time(time_passes, "gated macro checking", || {
+    time(time_passes, "gated macro checking", || {
         sess.track_errors(|| {
             let features =
               syntax::feature_gate::check_crate_macros(sess.codemap(),
@@ -516,7 +516,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
             // these need to be set "early" so that expansion sees `quote` if enabled.
             *sess.features.borrow_mut() = features;
         })
-    }));
+    })?;
 
 
     krate = time(time_passes, "crate injection", || {
@@ -553,7 +553,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
     let Registry { syntax_exts, early_lint_passes, late_lint_passes, lint_groups,
                    llvm_passes, attributes, mir_passes, .. } = registry;
 
-    try!(sess.track_errors(|| {
+    sess.track_errors(|| {
         let mut ls = sess.lint_store.borrow_mut();
         for pass in early_lint_passes {
             ls.register_early_pass(Some(sess), true, pass);
@@ -569,14 +569,14 @@ pub fn phase_2_configure_and_expand(sess: &Session,
         *sess.plugin_llvm_passes.borrow_mut() = llvm_passes;
         sess.mir_passes.borrow_mut().extend(mir_passes);
         *sess.plugin_attributes.borrow_mut() = attributes.clone();
-    }));
+    })?;
 
     // Lint plugins are registered; now we can process command line flags.
     if sess.opts.describe_lints {
         super::describe_lints(&sess.lint_store.borrow(), true);
         return Err(0);
     }
-    try!(sess.track_errors(|| sess.lint_store.borrow_mut().process_command_line(sess)));
+    sess.track_errors(|| sess.lint_store.borrow_mut().process_command_line(sess))?;
 
     krate = time(time_passes, "expansion", || {
         // Windows dlls do not have rpaths, so they don't know how to find their
@@ -619,7 +619,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
     // of macro expansion.  This runs before #[cfg] to try to catch as
     // much as possible (e.g. help the programmer avoid platform
     // specific differences)
-    try!(time(time_passes, "complete gated feature checking 1", || {
+    time(time_passes, "complete gated feature checking 1", || {
         sess.track_errors(|| {
             let features = syntax::feature_gate::check_crate(sess.codemap(),
                                                              &sess.parse_sess.span_diagnostic,
@@ -628,12 +628,12 @@ pub fn phase_2_configure_and_expand(sess: &Session,
                                                              sess.opts.unstable_features);
             *sess.features.borrow_mut() = features;
         })
-    }));
+    })?;
 
     // JBC: make CFG processing part of expansion to avoid this problem:
 
     // strip again, in case expansion added anything with a #[cfg].
-    krate = try!(sess.track_errors(|| {
+    krate = sess.track_errors(|| {
         let krate = time(time_passes, "configuration 2", || {
             syntax::config::strip_unconfigured_items(sess.diagnostic(),
                                                      krate,
@@ -650,7 +650,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
         });
 
         krate
-    }));
+    })?;
 
     krate = time(time_passes, "maybe building test harness", || {
         syntax::test::modify_for_testing(&sess.parse_sess, &sess.opts.cfg, krate, sess.diagnostic())
@@ -671,7 +671,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
     // One final feature gating of the true AST that gets compiled
     // later, to make sure we've got everything (e.g. configuration
     // can insert new attributes via `cfg_attr`)
-    try!(time(time_passes, "complete gated feature checking 2", || {
+    time(time_passes, "complete gated feature checking 2", || {
         sess.track_errors(|| {
             let features = syntax::feature_gate::check_crate(sess.codemap(),
                                                              &sess.parse_sess.span_diagnostic,
@@ -680,11 +680,11 @@ pub fn phase_2_configure_and_expand(sess: &Session,
                                                              sess.opts.unstable_features);
             *sess.features.borrow_mut() = features;
         })
-    }));
+    })?;
 
-    try!(time(time_passes,
+    time(time_passes,
               "const fn bodies and arguments",
-              || const_fn::check_crate(sess, &krate)));
+              || const_fn::check_crate(sess, &krate))?;
 
     if sess.opts.debugging_opts.input_stats {
         println!("Post-expansion node count: {}", count_nodes(&krate));
@@ -756,11 +756,11 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
          "external crate/lib resolution",
          || LocalCrateReader::new(sess, cstore, &hir_map).read_crates());
 
-    let lang_items = try!(time(time_passes, "language item collection", || {
+    let lang_items = time(time_passes, "language item collection", || {
         sess.track_errors(|| {
             middle::lang_items::collect_language_items(&sess, &hir_map)
         })
-    }));
+    })?;
 
     let resolve::CrateMap {
         def_map,
@@ -780,11 +780,11 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
         glob_map: glob_map,
     };
 
-    let named_region_map = try!(time(time_passes,
+    let named_region_map = time(time_passes,
                                      "lifetime resolution",
                                      || middle::resolve_lifetime::krate(sess,
                                                                         &hir_map,
-                                                                        &def_map.borrow())));
+                                                                        &def_map.borrow()))?;
 
     time(time_passes,
          "looking for entry point",
@@ -802,9 +802,9 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
          "loop checking",
          || loops::check_crate(sess, &hir_map));
 
-    try!(time(time_passes,
+    time(time_passes,
               "static item recursion checking",
-              || static_recursion::check_crate(sess, &def_map.borrow(), &hir_map)));
+              || static_recursion::check_crate(sess, &def_map.borrow(), &hir_map))?;
 
     let index = stability::Index::new(&hir_map);
 
@@ -1023,16 +1023,16 @@ fn write_out_deps(sess: &Session, outputs: &OutputFilenames, id: &str) {
                                          .filter(|fmap| !fmap.is_imported())
                                          .map(|fmap| escape_dep_filename(&fmap.name))
                                          .collect();
-            let mut file = try!(fs::File::create(&deps_filename));
+            let mut file = fs::File::create(&deps_filename)?;
             for path in &out_filenames {
-                try!(write!(file, "{}: {}\n\n", path.display(), files.join(" ")));
+                write!(file, "{}: {}\n\n", path.display(), files.join(" "))?;
             }
 
             // Emit a fake target for each input file to the compilation. This
             // prevents `make` from spitting out an error if a file is later
             // deleted. For more info see #28735
             for path in files {
-                try!(writeln!(file, "{}:", path));
+                writeln!(file, "{}:", path)?;
             }
             Ok(())
         })();

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -30,6 +30,7 @@
 #![feature(rustc_private)]
 #![feature(set_stdio)]
 #![feature(staged_api)]
+#![feature(question_mark)]
 
 extern crate arena;
 extern crate flate;

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -325,24 +325,24 @@ impl<'ast> pprust::PpAnn for IdentifiedAnnotation<'ast> {
             pprust::NodeIdent(_) | pprust::NodeName(_) => Ok(()),
 
             pprust::NodeItem(item) => {
-                try!(pp::space(&mut s.s));
+                pp::space(&mut s.s)?;
                 s.synth_comment(item.id.to_string())
             }
             pprust::NodeSubItem(id) => {
-                try!(pp::space(&mut s.s));
+                pp::space(&mut s.s)?;
                 s.synth_comment(id.to_string())
             }
             pprust::NodeBlock(blk) => {
-                try!(pp::space(&mut s.s));
+                pp::space(&mut s.s)?;
                 s.synth_comment(format!("block {}", blk.id))
             }
             pprust::NodeExpr(expr) => {
-                try!(pp::space(&mut s.s));
-                try!(s.synth_comment(expr.id.to_string()));
+                pp::space(&mut s.s)?;
+                s.synth_comment(expr.id.to_string())?;
                 s.pclose()
             }
             pprust::NodePat(pat) => {
-                try!(pp::space(&mut s.s));
+                pp::space(&mut s.s)?;
                 s.synth_comment(format!("pat {}", pat.id))
             }
         }
@@ -374,24 +374,24 @@ impl<'ast> pprust_hir::PpAnn for IdentifiedAnnotation<'ast> {
         match node {
             pprust_hir::NodeName(_) => Ok(()),
             pprust_hir::NodeItem(item) => {
-                try!(pp::space(&mut s.s));
+                pp::space(&mut s.s)?;
                 s.synth_comment(item.id.to_string())
             }
             pprust_hir::NodeSubItem(id) => {
-                try!(pp::space(&mut s.s));
+                pp::space(&mut s.s)?;
                 s.synth_comment(id.to_string())
             }
             pprust_hir::NodeBlock(blk) => {
-                try!(pp::space(&mut s.s));
+                pp::space(&mut s.s)?;
                 s.synth_comment(format!("block {}", blk.id))
             }
             pprust_hir::NodeExpr(expr) => {
-                try!(pp::space(&mut s.s));
-                try!(s.synth_comment(expr.id.to_string()));
+                pp::space(&mut s.s)?;
+                s.synth_comment(expr.id.to_string())?;
                 s.pclose()
             }
             pprust_hir::NodePat(pat) => {
-                try!(pp::space(&mut s.s));
+                pp::space(&mut s.s)?;
                 s.synth_comment(format!("pat {}", pat.id))
             }
         }
@@ -421,13 +421,13 @@ impl<'ast> pprust::PpAnn for HygieneAnnotation<'ast> {
     fn post(&self, s: &mut pprust::State, node: pprust::AnnNode) -> io::Result<()> {
         match node {
             pprust::NodeIdent(&ast::Ident { name: ast::Name(nm), ctxt }) => {
-                try!(pp::space(&mut s.s));
+                pp::space(&mut s.s)?;
                 // FIXME #16420: this doesn't display the connections
                 // between syntax contexts
                 s.synth_comment(format!("{}#{}", nm, ctxt.0))
             }
             pprust::NodeName(&ast::Name(nm)) => {
-                try!(pp::space(&mut s.s));
+                pp::space(&mut s.s)?;
                 s.synth_comment(nm.to_string())
             }
             _ => Ok(()),
@@ -464,10 +464,10 @@ impl<'a, 'tcx> pprust_hir::PpAnn for TypedAnnotation<'a, 'tcx> {
     fn post(&self, s: &mut pprust_hir::State, node: pprust_hir::AnnNode) -> io::Result<()> {
         match node {
             pprust_hir::NodeExpr(expr) => {
-                try!(pp::space(&mut s.s));
-                try!(pp::word(&mut s.s, "as"));
-                try!(pp::space(&mut s.s));
-                try!(pp::word(&mut s.s, &self.tcx.expr_ty(expr).to_string()));
+                pp::space(&mut s.s)?;
+                pp::word(&mut s.s, "as")?;
+                pp::space(&mut s.s)?;
+                pp::word(&mut s.s, &self.tcx.expr_ty(expr).to_string())?;
                 s.pclose()
             }
             _ => Ok(()),
@@ -806,10 +806,10 @@ pub fn pretty_print_input(sess: Session,
                                                       Some(ast_map.krate()));
                 for node_id in uii.all_matching_node_ids(ast_map) {
                     let node = ast_map.get(node_id);
-                    try!(pp_state.print_node(&node));
-                    try!(pp::space(&mut pp_state.s));
-                    try!(pp_state.synth_comment(ast_map.path_to_string(node_id)));
-                    try!(pp::hardbreak(&mut pp_state.s));
+                    pp_state.print_node(&node)?;
+                    pp::space(&mut pp_state.s)?;
+                    pp_state.synth_comment(ast_map.path_to_string(node_id))?;
+                    pp::hardbreak(&mut pp_state.s)?;
                 }
                 pp::eof(&mut pp_state.s)
             })
@@ -836,15 +836,15 @@ pub fn pretty_print_input(sess: Session,
                         let mir = mir_map.map.get(&nodeid).unwrap_or_else(|| {
                             sess.fatal(&format!("no MIR map entry for node {}", nodeid))
                         });
-                        try!(match pp_type {
+                        match pp_type {
                             PpmMir => write_mir_pretty(tcx, iter::once((&nodeid, mir)), &mut out),
                             _ => write_mir_graphviz(tcx, iter::once((&nodeid, mir)), &mut out)
-                        });
+                        }?;
                     } else {
-                        try!(match pp_type {
+                        match pp_type {
                             PpmMir => write_mir_pretty(tcx, mir_map.map.iter(), &mut out),
                             _ => write_mir_graphviz(tcx, mir_map.map.iter(), &mut out)
-                        });
+                        }?;
                     }
                 }
                 Ok(())

--- a/src/librustc_front/hir.rs
+++ b/src/librustc_front/hir.rs
@@ -119,7 +119,7 @@ impl Encodable for Ident {
 
 impl Decodable for Ident {
     fn decode<D: Decoder>(d: &mut D) -> Result<Ident, D::Error> {
-        Ok(Ident::from_name(try!(Name::decode(d))))
+        Ok(Ident::from_name(Name::decode(d)?))
     }
 }
 

--- a/src/librustc_front/lib.rs
+++ b/src/librustc_front/lib.rs
@@ -33,6 +33,7 @@
 #![feature(slice_patterns)]
 #![feature(staged_api)]
 #![feature(str_char)]
+#![feature(question_mark)]
 
 extern crate serialize;
 #[macro_use]

--- a/src/librustc_front/print/pprust.rs
+++ b/src/librustc_front/print/pprust.rs
@@ -288,13 +288,13 @@ pub fn fun_to_string(decl: &hir::FnDecl,
     to_string(|s| {
         s.head("")?;
         s.print_fn(decl,
-                        unsafety,
-                        constness,
-                        Abi::Rust,
-                        Some(name),
-                        generics,
-                        opt_explicit_self,
-                        hir::Inherited)?;
+                   unsafety,
+                   constness,
+                   Abi::Rust,
+                   Some(name),
+                   generics,
+                   opt_explicit_self,
+                   hir::Inherited)?;
         s.end()?; // Close the head box
         s.end() // Close the outer box
     })
@@ -567,13 +567,13 @@ impl<'a> State<'a> {
             hir::ForeignItemFn(ref decl, ref generics) => {
                 self.head("")?;
                 self.print_fn(decl,
-                                   hir::Unsafety::Normal,
-                                   hir::Constness::NotConst,
-                                   Abi::Rust,
-                                   Some(item.name),
-                                   generics,
-                                   None,
-                                   item.vis)?;
+                              hir::Unsafety::Normal,
+                              hir::Constness::NotConst,
+                              Abi::Rust,
+                              Some(item.name),
+                              generics,
+                              None,
+                              item.vis)?;
                 self.end()?; // end head-ibox
                 word(&mut self.s, ";")?;
                 self.end() // end the outer fn box
@@ -704,13 +704,13 @@ impl<'a> State<'a> {
             hir::ItemFn(ref decl, unsafety, constness, abi, ref typarams, ref body) => {
                 self.head("")?;
                 self.print_fn(decl,
-                                   unsafety,
-                                   constness,
-                                   abi,
-                                   Some(item.name),
-                                   typarams,
-                                   None,
-                                   item.vis)?;
+                              unsafety,
+                              constness,
+                              abi,
+                              Some(item.name),
+                              typarams,
+                              None,
+                              item.vis)?;
                 word(&mut self.s, " ")?;
                 self.print_block_with_attrs(&body, &item.attrs)?;
             }
@@ -984,9 +984,9 @@ impl<'a> State<'a> {
         match ti.node {
             hir::ConstTraitItem(ref ty, ref default) => {
                 self.print_associated_const(ti.name,
-                                                 &ty,
-                                                 default.as_ref().map(|expr| &**expr),
-                                                 hir::Inherited)?;
+                                            &ty,
+                                            default.as_ref().map(|expr| &**expr),
+                                            hir::Inherited)?;
             }
             hir::MethodTraitItem(ref sig, ref body) => {
                 if body.is_some() {
@@ -1002,8 +1002,8 @@ impl<'a> State<'a> {
             }
             hir::TypeTraitItem(ref bounds, ref default) => {
                 self.print_associated_type(ti.name,
-                                                Some(bounds),
-                                                default.as_ref().map(|ty| &**ty))?;
+                                           Some(bounds),
+                                           default.as_ref().map(|ty| &**ty))?;
             }
         }
         self.ann.post(self, NodeSubItem(ti.id))
@@ -1219,15 +1219,15 @@ impl<'a> State<'a> {
         self.print_path(path, true, 0)?;
         word(&mut self.s, "{")?;
         self.commasep_cmnt(Consistent,
-                                &fields[..],
-                                |s, field| {
-                                    s.ibox(indent_unit)?;
-                                    s.print_name(field.name.node)?;
-                                    s.word_space(":")?;
-                                    s.print_expr(&field.expr)?;
-                                    s.end()
-                                },
-                                |f| f.span)?;
+                           &fields[..],
+                           |s, field| {
+                               s.ibox(indent_unit)?;
+                               s.print_name(field.name.node)?;
+                               s.word_space(":")?;
+                               s.print_expr(&field.expr)?;
+                               s.end()
+                           },
+                           |f| f.span)?;
         match *wth {
             Some(ref expr) => {
                 self.ibox(indent_unit)?;
@@ -1760,17 +1760,17 @@ impl<'a> State<'a> {
                 self.nbsp()?;
                 self.word_space("{")?;
                 self.commasep_cmnt(Consistent,
-                                        &fields[..],
-                                        |s, f| {
-                                            s.cbox(indent_unit)?;
-                                            if !f.node.is_shorthand {
-                                                s.print_name(f.node.name)?;
-                                                s.word_nbsp(":")?;
-                                            }
-                                            s.print_pat(&f.node.pat)?;
-                                            s.end()
-                                        },
-                                        |f| f.node.pat.span)?;
+                                   &fields[..],
+                                   |s, f| {
+                                       s.cbox(indent_unit)?;
+                                       if !f.node.is_shorthand {
+                                           s.print_name(f.node.name)?;
+                                           s.word_nbsp(":")?;
+                                       }
+                                       s.print_pat(&f.node.pat)?;
+                                       s.end()
+                                   },
+                                   |f| f.node.pat.span)?;
                 if etc {
                     if !fields.is_empty() {
                         self.word_space(",")?;
@@ -2261,13 +2261,13 @@ impl<'a> State<'a> {
             },
         };
         self.print_fn(decl,
-                           unsafety,
-                           hir::Constness::NotConst,
-                           abi,
-                           name,
-                           &generics,
-                           opt_explicit_self,
-                           hir::Inherited)?;
+                      unsafety,
+                      hir::Constness::NotConst,
+                      abi,
+                      name,
+                      &generics,
+                      opt_explicit_self,
+                      hir::Inherited)?;
         self.end()
     }
 

--- a/src/librustc_front/print/pprust.rs
+++ b/src/librustc_front/print/pprust.rs
@@ -134,8 +134,8 @@ pub fn print_crate<'a>(cm: &'a CodeMap,
     // When printing the AST, we sometimes need to inject `#[no_std]` here.
     // Since you can't compile the HIR, it's not necessary.
 
-    try!(s.print_mod(&krate.module, &krate.attrs));
-    try!(s.print_remaining_comments());
+    s.print_mod(&krate.module, &krate.attrs)?;
+    s.print_remaining_comments()?;
     eof(&mut s.s)
 }
 
@@ -286,16 +286,16 @@ pub fn fun_to_string(decl: &hir::FnDecl,
                      generics: &hir::Generics)
                      -> String {
     to_string(|s| {
-        try!(s.head(""));
-        try!(s.print_fn(decl,
+        s.head("")?;
+        s.print_fn(decl,
                         unsafety,
                         constness,
                         Abi::Rust,
                         Some(name),
                         generics,
                         opt_explicit_self,
-                        hir::Inherited));
-        try!(s.end()); // Close the head box
+                        hir::Inherited)?;
+        s.end()?; // Close the head box
         s.end() // Close the outer box
     })
 }
@@ -303,9 +303,9 @@ pub fn fun_to_string(decl: &hir::FnDecl,
 pub fn block_to_string(blk: &hir::Block) -> String {
     to_string(|s| {
         // containing cbox, will be closed by print-block at }
-        try!(s.cbox(indent_unit));
+        s.cbox(indent_unit)?;
         // head-ibox, will be closed by print-block after {
-        try!(s.ibox(0));
+        s.ibox(0)?;
         s.print_block(blk)
     })
 }
@@ -352,24 +352,24 @@ impl<'a> State<'a> {
     }
 
     pub fn word_nbsp(&mut self, w: &str) -> io::Result<()> {
-        try!(word(&mut self.s, w));
+        word(&mut self.s, w)?;
         self.nbsp()
     }
 
     pub fn head(&mut self, w: &str) -> io::Result<()> {
         // outer-box is consistent
-        try!(self.cbox(indent_unit));
+        self.cbox(indent_unit)?;
         // head-box is inconsistent
-        try!(self.ibox(w.len() + 1));
+        self.ibox(w.len() + 1)?;
         // keyword that starts the head
         if !w.is_empty() {
-            try!(self.word_nbsp(w));
+            self.word_nbsp(w)?;
         }
         Ok(())
     }
 
     pub fn bopen(&mut self) -> io::Result<()> {
-        try!(word(&mut self.s, "{"));
+        word(&mut self.s, "{")?;
         self.end() // close the head-box
     }
 
@@ -381,11 +381,11 @@ impl<'a> State<'a> {
                              indented: usize,
                              close_box: bool)
                              -> io::Result<()> {
-        try!(self.maybe_print_comment(span.hi));
-        try!(self.break_offset_if_not_bol(1, -(indented as isize)));
-        try!(word(&mut self.s, "}"));
+        self.maybe_print_comment(span.hi)?;
+        self.break_offset_if_not_bol(1, -(indented as isize))?;
+        word(&mut self.s, "}")?;
         if close_box {
-            try!(self.end()); // close the outer-box
+            self.end()?; // close the outer-box
         }
         Ok(())
     }
@@ -401,7 +401,7 @@ impl<'a> State<'a> {
     }
     pub fn space_if_not_bol(&mut self) -> io::Result<()> {
         if !self.is_bol() {
-            try!(space(&mut self.s));
+            space(&mut self.s)?;
         }
         Ok(())
     }
@@ -422,10 +422,10 @@ impl<'a> State<'a> {
     // Synthesizes a comment that was not textually present in the original source
     // file.
     pub fn synth_comment(&mut self, text: String) -> io::Result<()> {
-        try!(word(&mut self.s, "/*"));
-        try!(space(&mut self.s));
-        try!(word(&mut self.s, &text[..]));
-        try!(space(&mut self.s));
+        word(&mut self.s, "/*")?;
+        space(&mut self.s)?;
+        word(&mut self.s, &text[..])?;
+        space(&mut self.s)?;
         word(&mut self.s, "*/")
     }
 
@@ -439,17 +439,17 @@ impl<'a> State<'a> {
         where F: FnMut(&mut State, &T) -> io::Result<()>,
               G: FnMut(&T) -> codemap::Span
     {
-        try!(self.rbox(0, b));
+        self.rbox(0, b)?;
         let len = elts.len();
         let mut i = 0;
         for elt in elts {
-            try!(self.maybe_print_comment(get_span(elt).hi));
-            try!(op(self, elt));
+            self.maybe_print_comment(get_span(elt).hi)?;
+            op(self, elt)?;
             i += 1;
             if i < len {
-                try!(word(&mut self.s, ","));
-                try!(self.maybe_print_trailing_comment(get_span(elt), Some(get_span(&elts[i]).hi)));
-                try!(self.space_if_not_bol());
+                word(&mut self.s, ",")?;
+                self.maybe_print_trailing_comment(get_span(elt), Some(get_span(&elts[i]).hi))?;
+                self.space_if_not_bol()?;
             }
         }
         self.end()
@@ -460,9 +460,9 @@ impl<'a> State<'a> {
     }
 
     pub fn print_mod(&mut self, _mod: &hir::Mod, attrs: &[ast::Attribute]) -> io::Result<()> {
-        try!(self.print_inner_attributes(attrs));
+        self.print_inner_attributes(attrs)?;
         for item_id in &_mod.item_ids {
-            try!(self.print_item_id(item_id));
+            self.print_item_id(item_id)?;
         }
         Ok(())
     }
@@ -471,50 +471,50 @@ impl<'a> State<'a> {
                              nmod: &hir::ForeignMod,
                              attrs: &[ast::Attribute])
                              -> io::Result<()> {
-        try!(self.print_inner_attributes(attrs));
+        self.print_inner_attributes(attrs)?;
         for item in &nmod.items {
-            try!(self.print_foreign_item(item));
+            self.print_foreign_item(item)?;
         }
         Ok(())
     }
 
     pub fn print_opt_lifetime(&mut self, lifetime: &Option<hir::Lifetime>) -> io::Result<()> {
         if let Some(l) = *lifetime {
-            try!(self.print_lifetime(&l));
-            try!(self.nbsp());
+            self.print_lifetime(&l)?;
+            self.nbsp()?;
         }
         Ok(())
     }
 
     pub fn print_type(&mut self, ty: &hir::Ty) -> io::Result<()> {
-        try!(self.maybe_print_comment(ty.span.lo));
-        try!(self.ibox(0));
+        self.maybe_print_comment(ty.span.lo)?;
+        self.ibox(0)?;
         match ty.node {
             hir::TyVec(ref ty) => {
-                try!(word(&mut self.s, "["));
-                try!(self.print_type(&ty));
-                try!(word(&mut self.s, "]"));
+                word(&mut self.s, "[")?;
+                self.print_type(&ty)?;
+                word(&mut self.s, "]")?;
             }
             hir::TyPtr(ref mt) => {
-                try!(word(&mut self.s, "*"));
+                word(&mut self.s, "*")?;
                 match mt.mutbl {
-                    hir::MutMutable => try!(self.word_nbsp("mut")),
-                    hir::MutImmutable => try!(self.word_nbsp("const")),
+                    hir::MutMutable => self.word_nbsp("mut")?,
+                    hir::MutImmutable => self.word_nbsp("const")?,
                 }
-                try!(self.print_type(&mt.ty));
+                self.print_type(&mt.ty)?;
             }
             hir::TyRptr(ref lifetime, ref mt) => {
-                try!(word(&mut self.s, "&"));
-                try!(self.print_opt_lifetime(lifetime));
-                try!(self.print_mt(mt));
+                word(&mut self.s, "&")?;
+                self.print_opt_lifetime(lifetime)?;
+                self.print_mt(mt)?;
             }
             hir::TyTup(ref elts) => {
-                try!(self.popen());
-                try!(self.commasep(Inconsistent, &elts[..], |s, ty| s.print_type(&ty)));
+                self.popen()?;
+                self.commasep(Inconsistent, &elts[..], |s, ty| s.print_type(&ty))?;
                 if elts.len() == 1 {
-                    try!(word(&mut self.s, ","));
+                    word(&mut self.s, ",")?;
                 }
-                try!(self.pclose());
+                self.pclose()?;
             }
             hir::TyBareFn(ref f) => {
                 let generics = hir::Generics {
@@ -525,69 +525,69 @@ impl<'a> State<'a> {
                         predicates: hir::HirVec::new(),
                     },
                 };
-                try!(self.print_ty_fn(f.abi, f.unsafety, &f.decl, None, &generics, None));
+                self.print_ty_fn(f.abi, f.unsafety, &f.decl, None, &generics, None)?;
             }
             hir::TyPath(None, ref path) => {
-                try!(self.print_path(path, false, 0));
+                self.print_path(path, false, 0)?;
             }
             hir::TyPath(Some(ref qself), ref path) => {
-                try!(self.print_qpath(path, qself, false))
+                self.print_qpath(path, qself, false)?
             }
             hir::TyObjectSum(ref ty, ref bounds) => {
-                try!(self.print_type(&ty));
-                try!(self.print_bounds("+", &bounds[..]));
+                self.print_type(&ty)?;
+                self.print_bounds("+", &bounds[..])?;
             }
             hir::TyPolyTraitRef(ref bounds) => {
-                try!(self.print_bounds("", &bounds[..]));
+                self.print_bounds("", &bounds[..])?;
             }
             hir::TyFixedLengthVec(ref ty, ref v) => {
-                try!(word(&mut self.s, "["));
-                try!(self.print_type(&ty));
-                try!(word(&mut self.s, "; "));
-                try!(self.print_expr(&v));
-                try!(word(&mut self.s, "]"));
+                word(&mut self.s, "[")?;
+                self.print_type(&ty)?;
+                word(&mut self.s, "; ")?;
+                self.print_expr(&v)?;
+                word(&mut self.s, "]")?;
             }
             hir::TyTypeof(ref e) => {
-                try!(word(&mut self.s, "typeof("));
-                try!(self.print_expr(&e));
-                try!(word(&mut self.s, ")"));
+                word(&mut self.s, "typeof(")?;
+                self.print_expr(&e)?;
+                word(&mut self.s, ")")?;
             }
             hir::TyInfer => {
-                try!(word(&mut self.s, "_"));
+                word(&mut self.s, "_")?;
             }
         }
         self.end()
     }
 
     pub fn print_foreign_item(&mut self, item: &hir::ForeignItem) -> io::Result<()> {
-        try!(self.hardbreak_if_not_bol());
-        try!(self.maybe_print_comment(item.span.lo));
-        try!(self.print_outer_attributes(&item.attrs));
+        self.hardbreak_if_not_bol()?;
+        self.maybe_print_comment(item.span.lo)?;
+        self.print_outer_attributes(&item.attrs)?;
         match item.node {
             hir::ForeignItemFn(ref decl, ref generics) => {
-                try!(self.head(""));
-                try!(self.print_fn(decl,
+                self.head("")?;
+                self.print_fn(decl,
                                    hir::Unsafety::Normal,
                                    hir::Constness::NotConst,
                                    Abi::Rust,
                                    Some(item.name),
                                    generics,
                                    None,
-                                   item.vis));
-                try!(self.end()); // end head-ibox
-                try!(word(&mut self.s, ";"));
+                                   item.vis)?;
+                self.end()?; // end head-ibox
+                word(&mut self.s, ";")?;
                 self.end() // end the outer fn box
             }
             hir::ForeignItemStatic(ref t, m) => {
-                try!(self.head(&visibility_qualified(item.vis, "static")));
+                self.head(&visibility_qualified(item.vis, "static"))?;
                 if m {
-                    try!(self.word_space("mut"));
+                    self.word_space("mut")?;
                 }
-                try!(self.print_name(item.name));
-                try!(self.word_space(":"));
-                try!(self.print_type(&t));
-                try!(word(&mut self.s, ";"));
-                try!(self.end()); // end the head-ibox
+                self.print_name(item.name)?;
+                self.word_space(":")?;
+                self.print_type(&t)?;
+                word(&mut self.s, ";")?;
+                self.end()?; // end the head-ibox
                 self.end() // end the outer cbox
             }
         }
@@ -599,15 +599,15 @@ impl<'a> State<'a> {
                               default: Option<&hir::Expr>,
                               vis: hir::Visibility)
                               -> io::Result<()> {
-        try!(word(&mut self.s, &visibility_qualified(vis, "")));
-        try!(self.word_space("const"));
-        try!(self.print_name(name));
-        try!(self.word_space(":"));
-        try!(self.print_type(ty));
+        word(&mut self.s, &visibility_qualified(vis, ""))?;
+        self.word_space("const")?;
+        self.print_name(name)?;
+        self.word_space(":")?;
+        self.print_type(ty)?;
         if let Some(expr) = default {
-            try!(space(&mut self.s));
-            try!(self.word_space("="));
-            try!(self.print_expr(expr));
+            space(&mut self.s)?;
+            self.word_space("=")?;
+            self.print_expr(expr)?;
         }
         word(&mut self.s, ";")
     }
@@ -617,15 +617,15 @@ impl<'a> State<'a> {
                              bounds: Option<&hir::TyParamBounds>,
                              ty: Option<&hir::Ty>)
                              -> io::Result<()> {
-        try!(self.word_space("type"));
-        try!(self.print_name(name));
+        self.word_space("type")?;
+        self.print_name(name)?;
         if let Some(bounds) = bounds {
-            try!(self.print_bounds(":", bounds));
+            self.print_bounds(":", bounds)?;
         }
         if let Some(ty) = ty {
-            try!(space(&mut self.s));
-            try!(self.word_space("="));
-            try!(self.print_type(ty));
+            space(&mut self.s)?;
+            self.word_space("=")?;
+            self.print_type(ty)?;
         }
         word(&mut self.s, ";")
     }
@@ -642,127 +642,127 @@ impl<'a> State<'a> {
 
     /// Pretty-print an item
     pub fn print_item(&mut self, item: &hir::Item) -> io::Result<()> {
-        try!(self.hardbreak_if_not_bol());
-        try!(self.maybe_print_comment(item.span.lo));
-        try!(self.print_outer_attributes(&item.attrs));
-        try!(self.ann.pre(self, NodeItem(item)));
+        self.hardbreak_if_not_bol()?;
+        self.maybe_print_comment(item.span.lo)?;
+        self.print_outer_attributes(&item.attrs)?;
+        self.ann.pre(self, NodeItem(item))?;
         match item.node {
             hir::ItemExternCrate(ref optional_path) => {
-                try!(self.head(&visibility_qualified(item.vis, "extern crate")));
+                self.head(&visibility_qualified(item.vis, "extern crate"))?;
                 if let Some(p) = *optional_path {
                     let val = p.as_str();
                     if val.contains("-") {
-                        try!(self.print_string(&val, ast::StrStyle::Cooked));
+                        self.print_string(&val, ast::StrStyle::Cooked)?;
                     } else {
-                        try!(self.print_name(p));
+                        self.print_name(p)?;
                     }
-                    try!(space(&mut self.s));
-                    try!(word(&mut self.s, "as"));
-                    try!(space(&mut self.s));
+                    space(&mut self.s)?;
+                    word(&mut self.s, "as")?;
+                    space(&mut self.s)?;
                 }
-                try!(self.print_name(item.name));
-                try!(word(&mut self.s, ";"));
-                try!(self.end()); // end inner head-block
-                try!(self.end()); // end outer head-block
+                self.print_name(item.name)?;
+                word(&mut self.s, ";")?;
+                self.end()?; // end inner head-block
+                self.end()?; // end outer head-block
             }
             hir::ItemUse(ref vp) => {
-                try!(self.head(&visibility_qualified(item.vis, "use")));
-                try!(self.print_view_path(&vp));
-                try!(word(&mut self.s, ";"));
-                try!(self.end()); // end inner head-block
-                try!(self.end()); // end outer head-block
+                self.head(&visibility_qualified(item.vis, "use"))?;
+                self.print_view_path(&vp)?;
+                word(&mut self.s, ";")?;
+                self.end()?; // end inner head-block
+                self.end()?; // end outer head-block
             }
             hir::ItemStatic(ref ty, m, ref expr) => {
-                try!(self.head(&visibility_qualified(item.vis, "static")));
+                self.head(&visibility_qualified(item.vis, "static"))?;
                 if m == hir::MutMutable {
-                    try!(self.word_space("mut"));
+                    self.word_space("mut")?;
                 }
-                try!(self.print_name(item.name));
-                try!(self.word_space(":"));
-                try!(self.print_type(&ty));
-                try!(space(&mut self.s));
-                try!(self.end()); // end the head-ibox
+                self.print_name(item.name)?;
+                self.word_space(":")?;
+                self.print_type(&ty)?;
+                space(&mut self.s)?;
+                self.end()?; // end the head-ibox
 
-                try!(self.word_space("="));
-                try!(self.print_expr(&expr));
-                try!(word(&mut self.s, ";"));
-                try!(self.end()); // end the outer cbox
+                self.word_space("=")?;
+                self.print_expr(&expr)?;
+                word(&mut self.s, ";")?;
+                self.end()?; // end the outer cbox
             }
             hir::ItemConst(ref ty, ref expr) => {
-                try!(self.head(&visibility_qualified(item.vis, "const")));
-                try!(self.print_name(item.name));
-                try!(self.word_space(":"));
-                try!(self.print_type(&ty));
-                try!(space(&mut self.s));
-                try!(self.end()); // end the head-ibox
+                self.head(&visibility_qualified(item.vis, "const"))?;
+                self.print_name(item.name)?;
+                self.word_space(":")?;
+                self.print_type(&ty)?;
+                space(&mut self.s)?;
+                self.end()?; // end the head-ibox
 
-                try!(self.word_space("="));
-                try!(self.print_expr(&expr));
-                try!(word(&mut self.s, ";"));
-                try!(self.end()); // end the outer cbox
+                self.word_space("=")?;
+                self.print_expr(&expr)?;
+                word(&mut self.s, ";")?;
+                self.end()?; // end the outer cbox
             }
             hir::ItemFn(ref decl, unsafety, constness, abi, ref typarams, ref body) => {
-                try!(self.head(""));
-                try!(self.print_fn(decl,
+                self.head("")?;
+                self.print_fn(decl,
                                    unsafety,
                                    constness,
                                    abi,
                                    Some(item.name),
                                    typarams,
                                    None,
-                                   item.vis));
-                try!(word(&mut self.s, " "));
-                try!(self.print_block_with_attrs(&body, &item.attrs));
+                                   item.vis)?;
+                word(&mut self.s, " ")?;
+                self.print_block_with_attrs(&body, &item.attrs)?;
             }
             hir::ItemMod(ref _mod) => {
-                try!(self.head(&visibility_qualified(item.vis, "mod")));
-                try!(self.print_name(item.name));
-                try!(self.nbsp());
-                try!(self.bopen());
-                try!(self.print_mod(_mod, &item.attrs));
-                try!(self.bclose(item.span));
+                self.head(&visibility_qualified(item.vis, "mod"))?;
+                self.print_name(item.name)?;
+                self.nbsp()?;
+                self.bopen()?;
+                self.print_mod(_mod, &item.attrs)?;
+                self.bclose(item.span)?;
             }
             hir::ItemForeignMod(ref nmod) => {
-                try!(self.head("extern"));
-                try!(self.word_nbsp(&nmod.abi.to_string()));
-                try!(self.bopen());
-                try!(self.print_foreign_mod(nmod, &item.attrs));
-                try!(self.bclose(item.span));
+                self.head("extern")?;
+                self.word_nbsp(&nmod.abi.to_string())?;
+                self.bopen()?;
+                self.print_foreign_mod(nmod, &item.attrs)?;
+                self.bclose(item.span)?;
             }
             hir::ItemTy(ref ty, ref params) => {
-                try!(self.ibox(indent_unit));
-                try!(self.ibox(0));
-                try!(self.word_nbsp(&visibility_qualified(item.vis, "type")));
-                try!(self.print_name(item.name));
-                try!(self.print_generics(params));
-                try!(self.end()); // end the inner ibox
+                self.ibox(indent_unit)?;
+                self.ibox(0)?;
+                self.word_nbsp(&visibility_qualified(item.vis, "type"))?;
+                self.print_name(item.name)?;
+                self.print_generics(params)?;
+                self.end()?; // end the inner ibox
 
-                try!(self.print_where_clause(&params.where_clause));
-                try!(space(&mut self.s));
-                try!(self.word_space("="));
-                try!(self.print_type(&ty));
-                try!(word(&mut self.s, ";"));
-                try!(self.end()); // end the outer ibox
+                self.print_where_clause(&params.where_clause)?;
+                space(&mut self.s)?;
+                self.word_space("=")?;
+                self.print_type(&ty)?;
+                word(&mut self.s, ";")?;
+                self.end()?; // end the outer ibox
             }
             hir::ItemEnum(ref enum_definition, ref params) => {
-                try!(self.print_enum_def(enum_definition, params, item.name, item.span, item.vis));
+                self.print_enum_def(enum_definition, params, item.name, item.span, item.vis)?;
             }
             hir::ItemStruct(ref struct_def, ref generics) => {
-                try!(self.head(&visibility_qualified(item.vis, "struct")));
-                try!(self.print_struct(struct_def, generics, item.name, item.span, true));
+                self.head(&visibility_qualified(item.vis, "struct"))?;
+                self.print_struct(struct_def, generics, item.name, item.span, true)?;
             }
 
             hir::ItemDefaultImpl(unsafety, ref trait_ref) => {
-                try!(self.head(""));
-                try!(self.print_visibility(item.vis));
-                try!(self.print_unsafety(unsafety));
-                try!(self.word_nbsp("impl"));
-                try!(self.print_trait_ref(trait_ref));
-                try!(space(&mut self.s));
-                try!(self.word_space("for"));
-                try!(self.word_space(".."));
-                try!(self.bopen());
-                try!(self.bclose(item.span));
+                self.head("")?;
+                self.print_visibility(item.vis)?;
+                self.print_unsafety(unsafety)?;
+                self.word_nbsp("impl")?;
+                self.print_trait_ref(trait_ref)?;
+                space(&mut self.s)?;
+                self.word_space("for")?;
+                self.word_space("..")?;
+                self.bopen()?;
+                self.bclose(item.span)?;
             }
             hir::ItemImpl(unsafety,
                           polarity,
@@ -770,68 +770,68 @@ impl<'a> State<'a> {
                           ref opt_trait,
                           ref ty,
                           ref impl_items) => {
-                try!(self.head(""));
-                try!(self.print_visibility(item.vis));
-                try!(self.print_unsafety(unsafety));
-                try!(self.word_nbsp("impl"));
+                self.head("")?;
+                self.print_visibility(item.vis)?;
+                self.print_unsafety(unsafety)?;
+                self.word_nbsp("impl")?;
 
                 if generics.is_parameterized() {
-                    try!(self.print_generics(generics));
-                    try!(space(&mut self.s));
+                    self.print_generics(generics)?;
+                    space(&mut self.s)?;
                 }
 
                 match polarity {
                     hir::ImplPolarity::Negative => {
-                        try!(word(&mut self.s, "!"));
+                        word(&mut self.s, "!")?;
                     }
                     _ => {}
                 }
 
                 match opt_trait {
                     &Some(ref t) => {
-                        try!(self.print_trait_ref(t));
-                        try!(space(&mut self.s));
-                        try!(self.word_space("for"));
+                        self.print_trait_ref(t)?;
+                        space(&mut self.s)?;
+                        self.word_space("for")?;
                     }
                     &None => {}
                 }
 
-                try!(self.print_type(&ty));
-                try!(self.print_where_clause(&generics.where_clause));
+                self.print_type(&ty)?;
+                self.print_where_clause(&generics.where_clause)?;
 
-                try!(space(&mut self.s));
-                try!(self.bopen());
-                try!(self.print_inner_attributes(&item.attrs));
+                space(&mut self.s)?;
+                self.bopen()?;
+                self.print_inner_attributes(&item.attrs)?;
                 for impl_item in impl_items {
-                    try!(self.print_impl_item(impl_item));
+                    self.print_impl_item(impl_item)?;
                 }
-                try!(self.bclose(item.span));
+                self.bclose(item.span)?;
             }
             hir::ItemTrait(unsafety, ref generics, ref bounds, ref trait_items) => {
-                try!(self.head(""));
-                try!(self.print_visibility(item.vis));
-                try!(self.print_unsafety(unsafety));
-                try!(self.word_nbsp("trait"));
-                try!(self.print_name(item.name));
-                try!(self.print_generics(generics));
+                self.head("")?;
+                self.print_visibility(item.vis)?;
+                self.print_unsafety(unsafety)?;
+                self.word_nbsp("trait")?;
+                self.print_name(item.name)?;
+                self.print_generics(generics)?;
                 let mut real_bounds = Vec::with_capacity(bounds.len());
                 for b in bounds.iter() {
                     if let TraitTyParamBound(ref ptr, hir::TraitBoundModifier::Maybe) = *b {
-                        try!(space(&mut self.s));
-                        try!(self.word_space("for ?"));
-                        try!(self.print_trait_ref(&ptr.trait_ref));
+                        space(&mut self.s)?;
+                        self.word_space("for ?")?;
+                        self.print_trait_ref(&ptr.trait_ref)?;
                     } else {
                         real_bounds.push(b.clone());
                     }
                 }
-                try!(self.print_bounds(":", &real_bounds[..]));
-                try!(self.print_where_clause(&generics.where_clause));
-                try!(word(&mut self.s, " "));
-                try!(self.bopen());
+                self.print_bounds(":", &real_bounds[..])?;
+                self.print_where_clause(&generics.where_clause)?;
+                word(&mut self.s, " ")?;
+                self.bopen()?;
                 for trait_item in trait_items {
-                    try!(self.print_trait_item(trait_item));
+                    self.print_trait_item(trait_item)?;
                 }
-                try!(self.bclose(item.span));
+                self.bclose(item.span)?;
             }
         }
         self.ann.post(self, NodeItem(item))
@@ -843,22 +843,22 @@ impl<'a> State<'a> {
 
     fn print_formal_lifetime_list(&mut self, lifetimes: &[hir::LifetimeDef]) -> io::Result<()> {
         if !lifetimes.is_empty() {
-            try!(word(&mut self.s, "for<"));
+            word(&mut self.s, "for<")?;
             let mut comma = false;
             for lifetime_def in lifetimes {
                 if comma {
-                    try!(self.word_space(","))
+                    self.word_space(",")?
                 }
-                try!(self.print_lifetime_def(lifetime_def));
+                self.print_lifetime_def(lifetime_def)?;
                 comma = true;
             }
-            try!(word(&mut self.s, ">"));
+            word(&mut self.s, ">")?;
         }
         Ok(())
     }
 
     fn print_poly_trait_ref(&mut self, t: &hir::PolyTraitRef) -> io::Result<()> {
-        try!(self.print_formal_lifetime_list(&t.bound_lifetimes));
+        self.print_formal_lifetime_list(&t.bound_lifetimes)?;
         self.print_trait_ref(&t.trait_ref)
     }
 
@@ -869,11 +869,11 @@ impl<'a> State<'a> {
                           span: codemap::Span,
                           visibility: hir::Visibility)
                           -> io::Result<()> {
-        try!(self.head(&visibility_qualified(visibility, "enum")));
-        try!(self.print_name(name));
-        try!(self.print_generics(generics));
-        try!(self.print_where_clause(&generics.where_clause));
-        try!(space(&mut self.s));
+        self.head(&visibility_qualified(visibility, "enum"))?;
+        self.print_name(name)?;
+        self.print_generics(generics)?;
+        self.print_where_clause(&generics.where_clause)?;
+        space(&mut self.s)?;
         self.print_variants(&enum_definition.variants, span)
     }
 
@@ -881,16 +881,16 @@ impl<'a> State<'a> {
                           variants: &[hir::Variant],
                           span: codemap::Span)
                           -> io::Result<()> {
-        try!(self.bopen());
+        self.bopen()?;
         for v in variants {
-            try!(self.space_if_not_bol());
-            try!(self.maybe_print_comment(v.span.lo));
-            try!(self.print_outer_attributes(&v.node.attrs));
-            try!(self.ibox(indent_unit));
-            try!(self.print_variant(v));
-            try!(word(&mut self.s, ","));
-            try!(self.end());
-            try!(self.maybe_print_trailing_comment(v.span, None));
+            self.space_if_not_bol()?;
+            self.maybe_print_comment(v.span.lo)?;
+            self.print_outer_attributes(&v.node.attrs)?;
+            self.ibox(indent_unit)?;
+            self.print_variant(v)?;
+            word(&mut self.s, ",")?;
+            self.end()?;
+            self.maybe_print_trailing_comment(v.span, None)?;
         }
         self.bclose(span)
     }
@@ -909,39 +909,39 @@ impl<'a> State<'a> {
                         span: codemap::Span,
                         print_finalizer: bool)
                         -> io::Result<()> {
-        try!(self.print_name(name));
-        try!(self.print_generics(generics));
+        self.print_name(name)?;
+        self.print_generics(generics)?;
         if !struct_def.is_struct() {
             if struct_def.is_tuple() {
-                try!(self.popen());
-                try!(self.commasep(Inconsistent, struct_def.fields(), |s, field| {
-                    try!(s.print_visibility(field.vis));
-                    try!(s.maybe_print_comment(field.span.lo));
+                self.popen()?;
+                self.commasep(Inconsistent, struct_def.fields(), |s, field| {
+                    s.print_visibility(field.vis)?;
+                    s.maybe_print_comment(field.span.lo)?;
                     s.print_type(&field.ty)
-                }));
-                try!(self.pclose());
+                })?;
+                self.pclose()?;
             }
-            try!(self.print_where_clause(&generics.where_clause));
+            self.print_where_clause(&generics.where_clause)?;
             if print_finalizer {
-                try!(word(&mut self.s, ";"));
+                word(&mut self.s, ";")?;
             }
-            try!(self.end());
+            self.end()?;
             self.end() // close the outer-box
         } else {
-            try!(self.print_where_clause(&generics.where_clause));
-            try!(self.nbsp());
-            try!(self.bopen());
-            try!(self.hardbreak_if_not_bol());
+            self.print_where_clause(&generics.where_clause)?;
+            self.nbsp()?;
+            self.bopen()?;
+            self.hardbreak_if_not_bol()?;
 
             for field in struct_def.fields() {
-                try!(self.hardbreak_if_not_bol());
-                try!(self.maybe_print_comment(field.span.lo));
-                try!(self.print_outer_attributes(&field.attrs));
-                try!(self.print_visibility(field.vis));
-                try!(self.print_name(field.name));
-                try!(self.word_nbsp(":"));
-                try!(self.print_type(&field.ty));
-                try!(word(&mut self.s, ","));
+                self.hardbreak_if_not_bol()?;
+                self.maybe_print_comment(field.span.lo)?;
+                self.print_outer_attributes(&field.attrs)?;
+                self.print_visibility(field.vis)?;
+                self.print_name(field.name)?;
+                self.word_nbsp(":")?;
+                self.print_type(&field.ty)?;
+                word(&mut self.s, ",")?;
             }
 
             self.bclose(span)
@@ -949,13 +949,13 @@ impl<'a> State<'a> {
     }
 
     pub fn print_variant(&mut self, v: &hir::Variant) -> io::Result<()> {
-        try!(self.head(""));
+        self.head("")?;
         let generics = ::util::empty_generics();
-        try!(self.print_struct(&v.node.data, &generics, v.node.name, v.span, false));
+        self.print_struct(&v.node.data, &generics, v.node.name, v.span, false)?;
         match v.node.disr_expr {
             Some(ref d) => {
-                try!(space(&mut self.s));
-                try!(self.word_space("="));
+                space(&mut self.s)?;
+                self.word_space("=")?;
                 self.print_expr(&d)
             }
             _ => Ok(()),
@@ -977,83 +977,83 @@ impl<'a> State<'a> {
     }
 
     pub fn print_trait_item(&mut self, ti: &hir::TraitItem) -> io::Result<()> {
-        try!(self.ann.pre(self, NodeSubItem(ti.id)));
-        try!(self.hardbreak_if_not_bol());
-        try!(self.maybe_print_comment(ti.span.lo));
-        try!(self.print_outer_attributes(&ti.attrs));
+        self.ann.pre(self, NodeSubItem(ti.id))?;
+        self.hardbreak_if_not_bol()?;
+        self.maybe_print_comment(ti.span.lo)?;
+        self.print_outer_attributes(&ti.attrs)?;
         match ti.node {
             hir::ConstTraitItem(ref ty, ref default) => {
-                try!(self.print_associated_const(ti.name,
+                self.print_associated_const(ti.name,
                                                  &ty,
                                                  default.as_ref().map(|expr| &**expr),
-                                                 hir::Inherited));
+                                                 hir::Inherited)?;
             }
             hir::MethodTraitItem(ref sig, ref body) => {
                 if body.is_some() {
-                    try!(self.head(""));
+                    self.head("")?;
                 }
-                try!(self.print_method_sig(ti.name, sig, hir::Inherited));
+                self.print_method_sig(ti.name, sig, hir::Inherited)?;
                 if let Some(ref body) = *body {
-                    try!(self.nbsp());
-                    try!(self.print_block_with_attrs(body, &ti.attrs));
+                    self.nbsp()?;
+                    self.print_block_with_attrs(body, &ti.attrs)?;
                 } else {
-                    try!(word(&mut self.s, ";"));
+                    word(&mut self.s, ";")?;
                 }
             }
             hir::TypeTraitItem(ref bounds, ref default) => {
-                try!(self.print_associated_type(ti.name,
+                self.print_associated_type(ti.name,
                                                 Some(bounds),
-                                                default.as_ref().map(|ty| &**ty)));
+                                                default.as_ref().map(|ty| &**ty))?;
             }
         }
         self.ann.post(self, NodeSubItem(ti.id))
     }
 
     pub fn print_impl_item(&mut self, ii: &hir::ImplItem) -> io::Result<()> {
-        try!(self.ann.pre(self, NodeSubItem(ii.id)));
-        try!(self.hardbreak_if_not_bol());
-        try!(self.maybe_print_comment(ii.span.lo));
-        try!(self.print_outer_attributes(&ii.attrs));
+        self.ann.pre(self, NodeSubItem(ii.id))?;
+        self.hardbreak_if_not_bol()?;
+        self.maybe_print_comment(ii.span.lo)?;
+        self.print_outer_attributes(&ii.attrs)?;
 
         if let hir::Defaultness::Default = ii.defaultness {
-            try!(self.word_nbsp("default"));
+            self.word_nbsp("default")?;
         }
 
         match ii.node {
             hir::ImplItemKind::Const(ref ty, ref expr) => {
-                try!(self.print_associated_const(ii.name, &ty, Some(&expr), ii.vis));
+                self.print_associated_const(ii.name, &ty, Some(&expr), ii.vis)?;
             }
             hir::ImplItemKind::Method(ref sig, ref body) => {
-                try!(self.head(""));
-                try!(self.print_method_sig(ii.name, sig, ii.vis));
-                try!(self.nbsp());
-                try!(self.print_block_with_attrs(body, &ii.attrs));
+                self.head("")?;
+                self.print_method_sig(ii.name, sig, ii.vis)?;
+                self.nbsp()?;
+                self.print_block_with_attrs(body, &ii.attrs)?;
             }
             hir::ImplItemKind::Type(ref ty) => {
-                try!(self.print_associated_type(ii.name, None, Some(ty)));
+                self.print_associated_type(ii.name, None, Some(ty))?;
             }
         }
         self.ann.post(self, NodeSubItem(ii.id))
     }
 
     pub fn print_stmt(&mut self, st: &hir::Stmt) -> io::Result<()> {
-        try!(self.maybe_print_comment(st.span.lo));
+        self.maybe_print_comment(st.span.lo)?;
         match st.node {
             hir::StmtDecl(ref decl, _) => {
-                try!(self.print_decl(&decl));
+                self.print_decl(&decl)?;
             }
             hir::StmtExpr(ref expr, _) => {
-                try!(self.space_if_not_bol());
-                try!(self.print_expr(&expr));
+                self.space_if_not_bol()?;
+                self.print_expr(&expr)?;
             }
             hir::StmtSemi(ref expr, _) => {
-                try!(self.space_if_not_bol());
-                try!(self.print_expr(&expr));
-                try!(word(&mut self.s, ";"));
+                self.space_if_not_bol()?;
+                self.print_expr(&expr)?;
+                word(&mut self.s, ";")?;
             }
         }
         if stmt_ends_with_semi(&st.node) {
-            try!(word(&mut self.s, ";"));
+            word(&mut self.s, ";")?;
         }
         self.maybe_print_trailing_comment(st.span, None)
     }
@@ -1087,31 +1087,31 @@ impl<'a> State<'a> {
                                       close_box: bool)
                                       -> io::Result<()> {
         match blk.rules {
-            hir::UnsafeBlock(..) => try!(self.word_space("unsafe")),
-            hir::PushUnsafeBlock(..) => try!(self.word_space("push_unsafe")),
-            hir::PopUnsafeBlock(..) => try!(self.word_space("pop_unsafe")),
-            hir::PushUnstableBlock => try!(self.word_space("push_unstable")),
-            hir::PopUnstableBlock => try!(self.word_space("pop_unstable")),
+            hir::UnsafeBlock(..) => self.word_space("unsafe")?,
+            hir::PushUnsafeBlock(..) => self.word_space("push_unsafe")?,
+            hir::PopUnsafeBlock(..) => self.word_space("pop_unsafe")?,
+            hir::PushUnstableBlock => self.word_space("push_unstable")?,
+            hir::PopUnstableBlock => self.word_space("pop_unstable")?,
             hir::DefaultBlock => (),
         }
-        try!(self.maybe_print_comment(blk.span.lo));
-        try!(self.ann.pre(self, NodeBlock(blk)));
-        try!(self.bopen());
+        self.maybe_print_comment(blk.span.lo)?;
+        self.ann.pre(self, NodeBlock(blk))?;
+        self.bopen()?;
 
-        try!(self.print_inner_attributes(attrs));
+        self.print_inner_attributes(attrs)?;
 
         for st in &blk.stmts {
-            try!(self.print_stmt(st));
+            self.print_stmt(st)?;
         }
         match blk.expr {
             Some(ref expr) => {
-                try!(self.space_if_not_bol());
-                try!(self.print_expr(&expr));
-                try!(self.maybe_print_trailing_comment(expr.span, Some(blk.span.hi)));
+                self.space_if_not_bol()?;
+                self.print_expr(&expr)?;
+                self.maybe_print_trailing_comment(expr.span, Some(blk.span.hi))?;
             }
             _ => (),
         }
-        try!(self.bclose_maybe_open(blk.span, indented, close_box));
+        self.bclose_maybe_open(blk.span, indented, close_box)?;
         self.ann.post(self, NodeBlock(blk))
     }
 
@@ -1121,19 +1121,19 @@ impl<'a> State<'a> {
                 match _else.node {
                     // "another else-if"
                     hir::ExprIf(ref i, ref then, ref e) => {
-                        try!(self.cbox(indent_unit - 1));
-                        try!(self.ibox(0));
-                        try!(word(&mut self.s, " else if "));
-                        try!(self.print_expr(&i));
-                        try!(space(&mut self.s));
-                        try!(self.print_block(&then));
+                        self.cbox(indent_unit - 1)?;
+                        self.ibox(0)?;
+                        word(&mut self.s, " else if ")?;
+                        self.print_expr(&i)?;
+                        space(&mut self.s)?;
+                        self.print_block(&then)?;
                         self.print_else(e.as_ref().map(|e| &**e))
                     }
                     // "final else"
                     hir::ExprBlock(ref b) => {
-                        try!(self.cbox(indent_unit - 1));
-                        try!(self.ibox(0));
-                        try!(word(&mut self.s, " else "));
+                        self.cbox(indent_unit - 1)?;
+                        self.ibox(0)?;
+                        word(&mut self.s, " else ")?;
                         self.print_block(&b)
                     }
                     // BLEAH, constraints would be great here
@@ -1151,10 +1151,10 @@ impl<'a> State<'a> {
                     blk: &hir::Block,
                     elseopt: Option<&hir::Expr>)
                     -> io::Result<()> {
-        try!(self.head("if"));
-        try!(self.print_expr(test));
-        try!(space(&mut self.s));
-        try!(self.print_block(blk));
+        self.head("if")?;
+        self.print_expr(test)?;
+        space(&mut self.s)?;
+        self.print_block(blk)?;
         self.print_else(elseopt)
     }
 
@@ -1164,50 +1164,50 @@ impl<'a> State<'a> {
                         blk: &hir::Block,
                         elseopt: Option<&hir::Expr>)
                         -> io::Result<()> {
-        try!(self.head("if let"));
-        try!(self.print_pat(pat));
-        try!(space(&mut self.s));
-        try!(self.word_space("="));
-        try!(self.print_expr(expr));
-        try!(space(&mut self.s));
-        try!(self.print_block(blk));
+        self.head("if let")?;
+        self.print_pat(pat)?;
+        space(&mut self.s)?;
+        self.word_space("=")?;
+        self.print_expr(expr)?;
+        space(&mut self.s)?;
+        self.print_block(blk)?;
         self.print_else(elseopt)
     }
 
 
     fn print_call_post(&mut self, args: &[P<hir::Expr>]) -> io::Result<()> {
-        try!(self.popen());
-        try!(self.commasep_exprs(Inconsistent, args));
+        self.popen()?;
+        self.commasep_exprs(Inconsistent, args)?;
         self.pclose()
     }
 
     pub fn print_expr_maybe_paren(&mut self, expr: &hir::Expr) -> io::Result<()> {
         let needs_par = needs_parentheses(expr);
         if needs_par {
-            try!(self.popen());
+            self.popen()?;
         }
-        try!(self.print_expr(expr));
+        self.print_expr(expr)?;
         if needs_par {
-            try!(self.pclose());
+            self.pclose()?;
         }
         Ok(())
     }
 
     fn print_expr_vec(&mut self, exprs: &[P<hir::Expr>]) -> io::Result<()> {
-        try!(self.ibox(indent_unit));
-        try!(word(&mut self.s, "["));
-        try!(self.commasep_exprs(Inconsistent, &exprs[..]));
-        try!(word(&mut self.s, "]"));
+        self.ibox(indent_unit)?;
+        word(&mut self.s, "[")?;
+        self.commasep_exprs(Inconsistent, &exprs[..])?;
+        word(&mut self.s, "]")?;
         self.end()
     }
 
     fn print_expr_repeat(&mut self, element: &hir::Expr, count: &hir::Expr) -> io::Result<()> {
-        try!(self.ibox(indent_unit));
-        try!(word(&mut self.s, "["));
-        try!(self.print_expr(element));
-        try!(self.word_space(";"));
-        try!(self.print_expr(count));
-        try!(word(&mut self.s, "]"));
+        self.ibox(indent_unit)?;
+        word(&mut self.s, "[")?;
+        self.print_expr(element)?;
+        self.word_space(";")?;
+        self.print_expr(count)?;
+        word(&mut self.s, "]")?;
         self.end()
     }
 
@@ -1216,48 +1216,48 @@ impl<'a> State<'a> {
                          fields: &[hir::Field],
                          wth: &Option<P<hir::Expr>>)
                          -> io::Result<()> {
-        try!(self.print_path(path, true, 0));
-        try!(word(&mut self.s, "{"));
-        try!(self.commasep_cmnt(Consistent,
+        self.print_path(path, true, 0)?;
+        word(&mut self.s, "{")?;
+        self.commasep_cmnt(Consistent,
                                 &fields[..],
                                 |s, field| {
-                                    try!(s.ibox(indent_unit));
-                                    try!(s.print_name(field.name.node));
-                                    try!(s.word_space(":"));
-                                    try!(s.print_expr(&field.expr));
+                                    s.ibox(indent_unit)?;
+                                    s.print_name(field.name.node)?;
+                                    s.word_space(":")?;
+                                    s.print_expr(&field.expr)?;
                                     s.end()
                                 },
-                                |f| f.span));
+                                |f| f.span)?;
         match *wth {
             Some(ref expr) => {
-                try!(self.ibox(indent_unit));
+                self.ibox(indent_unit)?;
                 if !fields.is_empty() {
-                    try!(word(&mut self.s, ","));
-                    try!(space(&mut self.s));
+                    word(&mut self.s, ",")?;
+                    space(&mut self.s)?;
                 }
-                try!(word(&mut self.s, ".."));
-                try!(self.print_expr(&expr));
-                try!(self.end());
+                word(&mut self.s, "..")?;
+                self.print_expr(&expr)?;
+                self.end()?;
             }
             _ => if !fields.is_empty() {
-                try!(word(&mut self.s, ","))
+                word(&mut self.s, ",")?
             },
         }
-        try!(word(&mut self.s, "}"));
+        word(&mut self.s, "}")?;
         Ok(())
     }
 
     fn print_expr_tup(&mut self, exprs: &[P<hir::Expr>]) -> io::Result<()> {
-        try!(self.popen());
-        try!(self.commasep_exprs(Inconsistent, &exprs[..]));
+        self.popen()?;
+        self.commasep_exprs(Inconsistent, &exprs[..])?;
         if exprs.len() == 1 {
-            try!(word(&mut self.s, ","));
+            word(&mut self.s, ",")?;
         }
         self.pclose()
     }
 
     fn print_expr_call(&mut self, func: &hir::Expr, args: &[P<hir::Expr>]) -> io::Result<()> {
-        try!(self.print_expr_maybe_paren(func));
+        self.print_expr_maybe_paren(func)?;
         self.print_call_post(args)
     }
 
@@ -1267,13 +1267,13 @@ impl<'a> State<'a> {
                               args: &[P<hir::Expr>])
                               -> io::Result<()> {
         let base_args = &args[1..];
-        try!(self.print_expr(&args[0]));
-        try!(word(&mut self.s, "."));
-        try!(self.print_name(name.node));
+        self.print_expr(&args[0])?;
+        word(&mut self.s, ".")?;
+        self.print_name(name.node)?;
         if !tys.is_empty() {
-            try!(word(&mut self.s, "::<"));
-            try!(self.commasep(Inconsistent, tys, |s, ty| s.print_type(&ty)));
-            try!(word(&mut self.s, ">"));
+            word(&mut self.s, "::<")?;
+            self.commasep(Inconsistent, tys, |s, ty| s.print_type(&ty))?;
+            word(&mut self.s, ">")?;
         }
         self.print_call_post(base_args)
     }
@@ -1283,14 +1283,14 @@ impl<'a> State<'a> {
                          lhs: &hir::Expr,
                          rhs: &hir::Expr)
                          -> io::Result<()> {
-        try!(self.print_expr(lhs));
-        try!(space(&mut self.s));
-        try!(self.word_space(::util::binop_to_string(op.node)));
+        self.print_expr(lhs)?;
+        space(&mut self.s)?;
+        self.word_space(::util::binop_to_string(op.node))?;
         self.print_expr(rhs)
     }
 
     fn print_expr_unary(&mut self, op: hir::UnOp, expr: &hir::Expr) -> io::Result<()> {
-        try!(word(&mut self.s, ::util::unop_to_string(op)));
+        word(&mut self.s, ::util::unop_to_string(op))?;
         self.print_expr_maybe_paren(expr)
     }
 
@@ -1298,100 +1298,100 @@ impl<'a> State<'a> {
                           mutability: hir::Mutability,
                           expr: &hir::Expr)
                           -> io::Result<()> {
-        try!(word(&mut self.s, "&"));
-        try!(self.print_mutability(mutability));
+        word(&mut self.s, "&")?;
+        self.print_mutability(mutability)?;
         self.print_expr_maybe_paren(expr)
     }
 
     pub fn print_expr(&mut self, expr: &hir::Expr) -> io::Result<()> {
-        try!(self.maybe_print_comment(expr.span.lo));
-        try!(self.ibox(indent_unit));
-        try!(self.ann.pre(self, NodeExpr(expr)));
+        self.maybe_print_comment(expr.span.lo)?;
+        self.ibox(indent_unit)?;
+        self.ann.pre(self, NodeExpr(expr))?;
         match expr.node {
             hir::ExprBox(ref expr) => {
-                try!(self.word_space("box"));
-                try!(self.print_expr(expr));
+                self.word_space("box")?;
+                self.print_expr(expr)?;
             }
             hir::ExprVec(ref exprs) => {
-                try!(self.print_expr_vec(&exprs[..]));
+                self.print_expr_vec(&exprs[..])?;
             }
             hir::ExprRepeat(ref element, ref count) => {
-                try!(self.print_expr_repeat(&element, &count));
+                self.print_expr_repeat(&element, &count)?;
             }
             hir::ExprStruct(ref path, ref fields, ref wth) => {
-                try!(self.print_expr_struct(path, &fields[..], wth));
+                self.print_expr_struct(path, &fields[..], wth)?;
             }
             hir::ExprTup(ref exprs) => {
-                try!(self.print_expr_tup(&exprs[..]));
+                self.print_expr_tup(&exprs[..])?;
             }
             hir::ExprCall(ref func, ref args) => {
-                try!(self.print_expr_call(&func, &args[..]));
+                self.print_expr_call(&func, &args[..])?;
             }
             hir::ExprMethodCall(name, ref tys, ref args) => {
-                try!(self.print_expr_method_call(name, &tys[..], &args[..]));
+                self.print_expr_method_call(name, &tys[..], &args[..])?;
             }
             hir::ExprBinary(op, ref lhs, ref rhs) => {
-                try!(self.print_expr_binary(op, &lhs, &rhs));
+                self.print_expr_binary(op, &lhs, &rhs)?;
             }
             hir::ExprUnary(op, ref expr) => {
-                try!(self.print_expr_unary(op, &expr));
+                self.print_expr_unary(op, &expr)?;
             }
             hir::ExprAddrOf(m, ref expr) => {
-                try!(self.print_expr_addr_of(m, &expr));
+                self.print_expr_addr_of(m, &expr)?;
             }
             hir::ExprLit(ref lit) => {
-                try!(self.print_literal(&lit));
+                self.print_literal(&lit)?;
             }
             hir::ExprCast(ref expr, ref ty) => {
-                try!(self.print_expr(&expr));
-                try!(space(&mut self.s));
-                try!(self.word_space("as"));
-                try!(self.print_type(&ty));
+                self.print_expr(&expr)?;
+                space(&mut self.s)?;
+                self.word_space("as")?;
+                self.print_type(&ty)?;
             }
             hir::ExprType(ref expr, ref ty) => {
-                try!(self.print_expr(&expr));
-                try!(self.word_space(":"));
-                try!(self.print_type(&ty));
+                self.print_expr(&expr)?;
+                self.word_space(":")?;
+                self.print_type(&ty)?;
             }
             hir::ExprIf(ref test, ref blk, ref elseopt) => {
-                try!(self.print_if(&test, &blk, elseopt.as_ref().map(|e| &**e)));
+                self.print_if(&test, &blk, elseopt.as_ref().map(|e| &**e))?;
             }
             hir::ExprWhile(ref test, ref blk, opt_ident) => {
                 if let Some(ident) = opt_ident {
-                    try!(self.print_name(ident.name));
-                    try!(self.word_space(":"));
+                    self.print_name(ident.name)?;
+                    self.word_space(":")?;
                 }
-                try!(self.head("while"));
-                try!(self.print_expr(&test));
-                try!(space(&mut self.s));
-                try!(self.print_block(&blk));
+                self.head("while")?;
+                self.print_expr(&test)?;
+                space(&mut self.s)?;
+                self.print_block(&blk)?;
             }
             hir::ExprLoop(ref blk, opt_ident) => {
                 if let Some(ident) = opt_ident {
-                    try!(self.print_name(ident.name));
-                    try!(self.word_space(":"));
+                    self.print_name(ident.name)?;
+                    self.word_space(":")?;
                 }
-                try!(self.head("loop"));
-                try!(space(&mut self.s));
-                try!(self.print_block(&blk));
+                self.head("loop")?;
+                space(&mut self.s)?;
+                self.print_block(&blk)?;
             }
             hir::ExprMatch(ref expr, ref arms, _) => {
-                try!(self.cbox(indent_unit));
-                try!(self.ibox(4));
-                try!(self.word_nbsp("match"));
-                try!(self.print_expr(&expr));
-                try!(space(&mut self.s));
-                try!(self.bopen());
+                self.cbox(indent_unit)?;
+                self.ibox(4)?;
+                self.word_nbsp("match")?;
+                self.print_expr(&expr)?;
+                space(&mut self.s)?;
+                self.bopen()?;
                 for arm in arms {
-                    try!(self.print_arm(arm));
+                    self.print_arm(arm)?;
                 }
-                try!(self.bclose_(expr.span, indent_unit));
+                self.bclose_(expr.span, indent_unit)?;
             }
             hir::ExprClosure(capture_clause, ref decl, ref body) => {
-                try!(self.print_capture_clause(capture_clause));
+                self.print_capture_clause(capture_clause)?;
 
-                try!(self.print_fn_block_args(&decl));
-                try!(space(&mut self.s));
+                self.print_fn_block_args(&decl)?;
+                space(&mut self.s)?;
 
                 let default_return = match decl.output {
                     hir::DefaultReturn(..) => true,
@@ -1399,132 +1399,132 @@ impl<'a> State<'a> {
                 };
 
                 if !default_return || !body.stmts.is_empty() || body.expr.is_none() {
-                    try!(self.print_block_unclosed(&body));
+                    self.print_block_unclosed(&body)?;
                 } else {
                     // we extract the block, so as not to create another set of boxes
                     match body.expr.as_ref().unwrap().node {
                         hir::ExprBlock(ref blk) => {
-                            try!(self.print_block_unclosed(&blk));
+                            self.print_block_unclosed(&blk)?;
                         }
                         _ => {
                             // this is a bare expression
-                            try!(self.print_expr(body.expr.as_ref().map(|e| &**e).unwrap()));
-                            try!(self.end()); // need to close a box
+                            self.print_expr(body.expr.as_ref().map(|e| &**e).unwrap())?;
+                            self.end()?; // need to close a box
                         }
                     }
                 }
                 // a box will be closed by print_expr, but we didn't want an overall
                 // wrapper so we closed the corresponding opening. so create an
                 // empty box to satisfy the close.
-                try!(self.ibox(0));
+                self.ibox(0)?;
             }
             hir::ExprBlock(ref blk) => {
                 // containing cbox, will be closed by print-block at }
-                try!(self.cbox(indent_unit));
+                self.cbox(indent_unit)?;
                 // head-box, will be closed by print-block after {
-                try!(self.ibox(0));
-                try!(self.print_block(&blk));
+                self.ibox(0)?;
+                self.print_block(&blk)?;
             }
             hir::ExprAssign(ref lhs, ref rhs) => {
-                try!(self.print_expr(&lhs));
-                try!(space(&mut self.s));
-                try!(self.word_space("="));
-                try!(self.print_expr(&rhs));
+                self.print_expr(&lhs)?;
+                space(&mut self.s)?;
+                self.word_space("=")?;
+                self.print_expr(&rhs)?;
             }
             hir::ExprAssignOp(op, ref lhs, ref rhs) => {
-                try!(self.print_expr(&lhs));
-                try!(space(&mut self.s));
-                try!(word(&mut self.s, ::util::binop_to_string(op.node)));
-                try!(self.word_space("="));
-                try!(self.print_expr(&rhs));
+                self.print_expr(&lhs)?;
+                space(&mut self.s)?;
+                word(&mut self.s, ::util::binop_to_string(op.node))?;
+                self.word_space("=")?;
+                self.print_expr(&rhs)?;
             }
             hir::ExprField(ref expr, name) => {
-                try!(self.print_expr(&expr));
-                try!(word(&mut self.s, "."));
-                try!(self.print_name(name.node));
+                self.print_expr(&expr)?;
+                word(&mut self.s, ".")?;
+                self.print_name(name.node)?;
             }
             hir::ExprTupField(ref expr, id) => {
-                try!(self.print_expr(&expr));
-                try!(word(&mut self.s, "."));
-                try!(self.print_usize(id.node));
+                self.print_expr(&expr)?;
+                word(&mut self.s, ".")?;
+                self.print_usize(id.node)?;
             }
             hir::ExprIndex(ref expr, ref index) => {
-                try!(self.print_expr(&expr));
-                try!(word(&mut self.s, "["));
-                try!(self.print_expr(&index));
-                try!(word(&mut self.s, "]"));
+                self.print_expr(&expr)?;
+                word(&mut self.s, "[")?;
+                self.print_expr(&index)?;
+                word(&mut self.s, "]")?;
             }
             hir::ExprPath(None, ref path) => {
-                try!(self.print_path(path, true, 0))
+                self.print_path(path, true, 0)?
             }
             hir::ExprPath(Some(ref qself), ref path) => {
-                try!(self.print_qpath(path, qself, true))
+                self.print_qpath(path, qself, true)?
             }
             hir::ExprBreak(opt_ident) => {
-                try!(word(&mut self.s, "break"));
-                try!(space(&mut self.s));
+                word(&mut self.s, "break")?;
+                space(&mut self.s)?;
                 if let Some(ident) = opt_ident {
-                    try!(self.print_name(ident.node.name));
-                    try!(space(&mut self.s));
+                    self.print_name(ident.node.name)?;
+                    space(&mut self.s)?;
                 }
             }
             hir::ExprAgain(opt_ident) => {
-                try!(word(&mut self.s, "continue"));
-                try!(space(&mut self.s));
+                word(&mut self.s, "continue")?;
+                space(&mut self.s)?;
                 if let Some(ident) = opt_ident {
-                    try!(self.print_name(ident.node.name));
-                    try!(space(&mut self.s))
+                    self.print_name(ident.node.name)?;
+                    space(&mut self.s)?
                 }
             }
             hir::ExprRet(ref result) => {
-                try!(word(&mut self.s, "return"));
+                word(&mut self.s, "return")?;
                 match *result {
                     Some(ref expr) => {
-                        try!(word(&mut self.s, " "));
-                        try!(self.print_expr(&expr));
+                        word(&mut self.s, " ")?;
+                        self.print_expr(&expr)?;
                     }
                     _ => (),
                 }
             }
             hir::ExprInlineAsm(ref a, ref outputs, ref inputs) => {
-                try!(word(&mut self.s, "asm!"));
-                try!(self.popen());
-                try!(self.print_string(&a.asm, a.asm_str_style));
-                try!(self.word_space(":"));
+                word(&mut self.s, "asm!")?;
+                self.popen()?;
+                self.print_string(&a.asm, a.asm_str_style)?;
+                self.word_space(":")?;
 
                 let mut out_idx = 0;
-                try!(self.commasep(Inconsistent, &a.outputs, |s, out| {
+                self.commasep(Inconsistent, &a.outputs, |s, out| {
                     match out.constraint.slice_shift_char() {
                         Some(('=', operand)) if out.is_rw => {
-                            try!(s.print_string(&format!("+{}", operand), ast::StrStyle::Cooked))
+                            s.print_string(&format!("+{}", operand), ast::StrStyle::Cooked)?
                         }
-                        _ => try!(s.print_string(&out.constraint, ast::StrStyle::Cooked)),
+                        _ => s.print_string(&out.constraint, ast::StrStyle::Cooked)?,
                     }
-                    try!(s.popen());
-                    try!(s.print_expr(&outputs[out_idx]));
-                    try!(s.pclose());
+                    s.popen()?;
+                    s.print_expr(&outputs[out_idx])?;
+                    s.pclose()?;
                     out_idx += 1;
                     Ok(())
-                }));
-                try!(space(&mut self.s));
-                try!(self.word_space(":"));
+                })?;
+                space(&mut self.s)?;
+                self.word_space(":")?;
 
                 let mut in_idx = 0;
-                try!(self.commasep(Inconsistent, &a.inputs, |s, co| {
-                    try!(s.print_string(&co, ast::StrStyle::Cooked));
-                    try!(s.popen());
-                    try!(s.print_expr(&inputs[in_idx]));
-                    try!(s.pclose());
+                self.commasep(Inconsistent, &a.inputs, |s, co| {
+                    s.print_string(&co, ast::StrStyle::Cooked)?;
+                    s.popen()?;
+                    s.print_expr(&inputs[in_idx])?;
+                    s.pclose()?;
                     in_idx += 1;
                     Ok(())
-                }));
-                try!(space(&mut self.s));
-                try!(self.word_space(":"));
+                })?;
+                space(&mut self.s)?;
+                self.word_space(":")?;
 
-                try!(self.commasep(Inconsistent, &a.clobbers, |s, co| {
-                    try!(s.print_string(&co, ast::StrStyle::Cooked));
+                self.commasep(Inconsistent, &a.clobbers, |s, co| {
+                    s.print_string(&co, ast::StrStyle::Cooked)?;
                     Ok(())
-                }));
+                })?;
 
                 let mut options = vec![];
                 if a.volatile {
@@ -1538,45 +1538,45 @@ impl<'a> State<'a> {
                 }
 
                 if !options.is_empty() {
-                    try!(space(&mut self.s));
-                    try!(self.word_space(":"));
-                    try!(self.commasep(Inconsistent, &options, |s, &co| {
-                        try!(s.print_string(co, ast::StrStyle::Cooked));
+                    space(&mut self.s)?;
+                    self.word_space(":")?;
+                    self.commasep(Inconsistent, &options, |s, &co| {
+                        s.print_string(co, ast::StrStyle::Cooked)?;
                         Ok(())
-                    }));
+                    })?;
                 }
 
-                try!(self.pclose());
+                self.pclose()?;
             }
         }
-        try!(self.ann.post(self, NodeExpr(expr)));
+        self.ann.post(self, NodeExpr(expr))?;
         self.end()
     }
 
     pub fn print_local_decl(&mut self, loc: &hir::Local) -> io::Result<()> {
-        try!(self.print_pat(&loc.pat));
+        self.print_pat(&loc.pat)?;
         if let Some(ref ty) = loc.ty {
-            try!(self.word_space(":"));
-            try!(self.print_type(&ty));
+            self.word_space(":")?;
+            self.print_type(&ty)?;
         }
         Ok(())
     }
 
     pub fn print_decl(&mut self, decl: &hir::Decl) -> io::Result<()> {
-        try!(self.maybe_print_comment(decl.span.lo));
+        self.maybe_print_comment(decl.span.lo)?;
         match decl.node {
             hir::DeclLocal(ref loc) => {
-                try!(self.space_if_not_bol());
-                try!(self.ibox(indent_unit));
-                try!(self.word_nbsp("let"));
+                self.space_if_not_bol()?;
+                self.ibox(indent_unit)?;
+                self.word_nbsp("let")?;
 
-                try!(self.ibox(indent_unit));
-                try!(self.print_local_decl(&loc));
-                try!(self.end());
+                self.ibox(indent_unit)?;
+                self.print_local_decl(&loc)?;
+                self.end()?;
                 if let Some(ref init) = loc.init {
-                    try!(self.nbsp());
-                    try!(self.word_space("="));
-                    try!(self.print_expr(&init));
+                    self.nbsp()?;
+                    self.word_space("=")?;
+                    self.print_expr(&init)?;
                 }
                 self.end()
             }
@@ -1591,14 +1591,14 @@ impl<'a> State<'a> {
     }
 
     pub fn print_name(&mut self, name: ast::Name) -> io::Result<()> {
-        try!(word(&mut self.s, &name.as_str()));
+        word(&mut self.s, &name.as_str())?;
         self.ann.post(self, NodeName(&name))
     }
 
     pub fn print_for_decl(&mut self, loc: &hir::Local, coll: &hir::Expr) -> io::Result<()> {
-        try!(self.print_local_decl(loc));
-        try!(space(&mut self.s));
-        try!(self.word_space("in"));
+        self.print_local_decl(loc)?;
+        space(&mut self.s)?;
+        self.word_space("in")?;
         self.print_expr(coll)
     }
 
@@ -1607,19 +1607,19 @@ impl<'a> State<'a> {
                   colons_before_params: bool,
                   depth: usize)
                   -> io::Result<()> {
-        try!(self.maybe_print_comment(path.span.lo));
+        self.maybe_print_comment(path.span.lo)?;
 
         let mut first = !path.global;
         for segment in &path.segments[..path.segments.len() - depth] {
             if first {
                 first = false
             } else {
-                try!(word(&mut self.s, "::"))
+                word(&mut self.s, "::")?
             }
 
-            try!(self.print_name(segment.identifier.name));
+            self.print_name(segment.identifier.name)?;
 
-            try!(self.print_path_parameters(&segment.parameters, colons_before_params));
+            self.print_path_parameters(&segment.parameters, colons_before_params)?;
         }
 
         Ok(())
@@ -1630,18 +1630,18 @@ impl<'a> State<'a> {
                    qself: &hir::QSelf,
                    colons_before_params: bool)
                    -> io::Result<()> {
-        try!(word(&mut self.s, "<"));
-        try!(self.print_type(&qself.ty));
+        word(&mut self.s, "<")?;
+        self.print_type(&qself.ty)?;
         if qself.position > 0 {
-            try!(space(&mut self.s));
-            try!(self.word_space("as"));
+            space(&mut self.s)?;
+            self.word_space("as")?;
             let depth = path.segments.len() - qself.position;
-            try!(self.print_path(&path, false, depth));
+            self.print_path(&path, false, depth)?;
         }
-        try!(word(&mut self.s, ">"));
-        try!(word(&mut self.s, "::"));
+        word(&mut self.s, ">")?;
+        word(&mut self.s, "::")?;
         let item_segment = path.segments.last().unwrap();
-        try!(self.print_name(item_segment.identifier.name));
+        self.print_name(item_segment.identifier.name)?;
         self.print_path_parameters(&item_segment.parameters, colons_before_params)
     }
 
@@ -1654,55 +1654,55 @@ impl<'a> State<'a> {
         }
 
         if colons_before_params {
-            try!(word(&mut self.s, "::"))
+            word(&mut self.s, "::")?
         }
 
         match *parameters {
             hir::AngleBracketedParameters(ref data) => {
-                try!(word(&mut self.s, "<"));
+                word(&mut self.s, "<")?;
 
                 let mut comma = false;
                 for lifetime in &data.lifetimes {
                     if comma {
-                        try!(self.word_space(","))
+                        self.word_space(",")?
                     }
-                    try!(self.print_lifetime(lifetime));
+                    self.print_lifetime(lifetime)?;
                     comma = true;
                 }
 
                 if !data.types.is_empty() {
                     if comma {
-                        try!(self.word_space(","))
+                        self.word_space(",")?
                     }
-                    try!(self.commasep(Inconsistent, &data.types, |s, ty| s.print_type(&ty)));
+                    self.commasep(Inconsistent, &data.types, |s, ty| s.print_type(&ty))?;
                     comma = true;
                 }
 
                 for binding in data.bindings.iter() {
                     if comma {
-                        try!(self.word_space(","))
+                        self.word_space(",")?
                     }
-                    try!(self.print_name(binding.name));
-                    try!(space(&mut self.s));
-                    try!(self.word_space("="));
-                    try!(self.print_type(&binding.ty));
+                    self.print_name(binding.name)?;
+                    space(&mut self.s)?;
+                    self.word_space("=")?;
+                    self.print_type(&binding.ty)?;
                     comma = true;
                 }
 
-                try!(word(&mut self.s, ">"))
+                word(&mut self.s, ">")?
             }
 
             hir::ParenthesizedParameters(ref data) => {
-                try!(word(&mut self.s, "("));
-                try!(self.commasep(Inconsistent, &data.inputs, |s, ty| s.print_type(&ty)));
-                try!(word(&mut self.s, ")"));
+                word(&mut self.s, "(")?;
+                self.commasep(Inconsistent, &data.inputs, |s, ty| s.print_type(&ty))?;
+                word(&mut self.s, ")")?;
 
                 match data.output {
                     None => {}
                     Some(ref ty) => {
-                        try!(self.space_if_not_bol());
-                        try!(self.word_space("->"));
-                        try!(self.print_type(&ty));
+                        self.space_if_not_bol()?;
+                        self.word_space("->")?;
+                        self.print_type(&ty)?;
                     }
                 }
             }
@@ -1712,117 +1712,117 @@ impl<'a> State<'a> {
     }
 
     pub fn print_pat(&mut self, pat: &hir::Pat) -> io::Result<()> {
-        try!(self.maybe_print_comment(pat.span.lo));
-        try!(self.ann.pre(self, NodePat(pat)));
+        self.maybe_print_comment(pat.span.lo)?;
+        self.ann.pre(self, NodePat(pat))?;
         // Pat isn't normalized, but the beauty of it
         // is that it doesn't matter
         match pat.node {
-            PatKind::Wild => try!(word(&mut self.s, "_")),
+            PatKind::Wild => word(&mut self.s, "_")?,
             PatKind::Ident(binding_mode, ref path1, ref sub) => {
                 match binding_mode {
                     hir::BindByRef(mutbl) => {
-                        try!(self.word_nbsp("ref"));
-                        try!(self.print_mutability(mutbl));
+                        self.word_nbsp("ref")?;
+                        self.print_mutability(mutbl)?;
                     }
                     hir::BindByValue(hir::MutImmutable) => {}
                     hir::BindByValue(hir::MutMutable) => {
-                        try!(self.word_nbsp("mut"));
+                        self.word_nbsp("mut")?;
                     }
                 }
-                try!(self.print_name(path1.node.name));
+                self.print_name(path1.node.name)?;
                 match *sub {
                     Some(ref p) => {
-                        try!(word(&mut self.s, "@"));
-                        try!(self.print_pat(&p));
+                        word(&mut self.s, "@")?;
+                        self.print_pat(&p)?;
                     }
                     None => (),
                 }
             }
             PatKind::TupleStruct(ref path, ref args_) => {
-                try!(self.print_path(path, true, 0));
+                self.print_path(path, true, 0)?;
                 match *args_ {
-                    None => try!(word(&mut self.s, "(..)")),
+                    None => word(&mut self.s, "(..)")?,
                     Some(ref args) => {
-                        try!(self.popen());
-                        try!(self.commasep(Inconsistent, &args[..], |s, p| s.print_pat(&p)));
-                        try!(self.pclose());
+                        self.popen()?;
+                        self.commasep(Inconsistent, &args[..], |s, p| s.print_pat(&p))?;
+                        self.pclose()?;
                     }
                 }
             }
             PatKind::Path(ref path) => {
-                try!(self.print_path(path, true, 0));
+                self.print_path(path, true, 0)?;
             }
             PatKind::QPath(ref qself, ref path) => {
-                try!(self.print_qpath(path, qself, false));
+                self.print_qpath(path, qself, false)?;
             }
             PatKind::Struct(ref path, ref fields, etc) => {
-                try!(self.print_path(path, true, 0));
-                try!(self.nbsp());
-                try!(self.word_space("{"));
-                try!(self.commasep_cmnt(Consistent,
+                self.print_path(path, true, 0)?;
+                self.nbsp()?;
+                self.word_space("{")?;
+                self.commasep_cmnt(Consistent,
                                         &fields[..],
                                         |s, f| {
-                                            try!(s.cbox(indent_unit));
+                                            s.cbox(indent_unit)?;
                                             if !f.node.is_shorthand {
-                                                try!(s.print_name(f.node.name));
-                                                try!(s.word_nbsp(":"));
+                                                s.print_name(f.node.name)?;
+                                                s.word_nbsp(":")?;
                                             }
-                                            try!(s.print_pat(&f.node.pat));
+                                            s.print_pat(&f.node.pat)?;
                                             s.end()
                                         },
-                                        |f| f.node.pat.span));
+                                        |f| f.node.pat.span)?;
                 if etc {
                     if !fields.is_empty() {
-                        try!(self.word_space(","));
+                        self.word_space(",")?;
                     }
-                    try!(word(&mut self.s, ".."));
+                    word(&mut self.s, "..")?;
                 }
-                try!(space(&mut self.s));
-                try!(word(&mut self.s, "}"));
+                space(&mut self.s)?;
+                word(&mut self.s, "}")?;
             }
             PatKind::Tup(ref elts) => {
-                try!(self.popen());
-                try!(self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(&p)));
+                self.popen()?;
+                self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(&p))?;
                 if elts.len() == 1 {
-                    try!(word(&mut self.s, ","));
+                    word(&mut self.s, ",")?;
                 }
-                try!(self.pclose());
+                self.pclose()?;
             }
             PatKind::Box(ref inner) => {
-                try!(word(&mut self.s, "box "));
-                try!(self.print_pat(&inner));
+                word(&mut self.s, "box ")?;
+                self.print_pat(&inner)?;
             }
             PatKind::Ref(ref inner, mutbl) => {
-                try!(word(&mut self.s, "&"));
+                word(&mut self.s, "&")?;
                 if mutbl == hir::MutMutable {
-                    try!(word(&mut self.s, "mut "));
+                    word(&mut self.s, "mut ")?;
                 }
-                try!(self.print_pat(&inner));
+                self.print_pat(&inner)?;
             }
-            PatKind::Lit(ref e) => try!(self.print_expr(&e)),
+            PatKind::Lit(ref e) => self.print_expr(&e)?,
             PatKind::Range(ref begin, ref end) => {
-                try!(self.print_expr(&begin));
-                try!(space(&mut self.s));
-                try!(word(&mut self.s, "..."));
-                try!(self.print_expr(&end));
+                self.print_expr(&begin)?;
+                space(&mut self.s)?;
+                word(&mut self.s, "...")?;
+                self.print_expr(&end)?;
             }
             PatKind::Vec(ref before, ref slice, ref after) => {
-                try!(word(&mut self.s, "["));
-                try!(self.commasep(Inconsistent, &before[..], |s, p| s.print_pat(&p)));
+                word(&mut self.s, "[")?;
+                self.commasep(Inconsistent, &before[..], |s, p| s.print_pat(&p))?;
                 if let Some(ref p) = *slice {
                     if !before.is_empty() {
-                        try!(self.word_space(","));
+                        self.word_space(",")?;
                     }
                     if p.node != PatKind::Wild {
-                        try!(self.print_pat(&p));
+                        self.print_pat(&p)?;
                     }
-                    try!(word(&mut self.s, ".."));
+                    word(&mut self.s, "..")?;
                     if !after.is_empty() {
-                        try!(self.word_space(","));
+                        self.word_space(",")?;
                     }
                 }
-                try!(self.commasep(Inconsistent, &after[..], |s, p| s.print_pat(&p)));
-                try!(word(&mut self.s, "]"));
+                self.commasep(Inconsistent, &after[..], |s, p| s.print_pat(&p))?;
+                word(&mut self.s, "]")?;
             }
         }
         self.ann.post(self, NodePat(pat))
@@ -1832,43 +1832,43 @@ impl<'a> State<'a> {
         // I have no idea why this check is necessary, but here it
         // is :(
         if arm.attrs.is_empty() {
-            try!(space(&mut self.s));
+            space(&mut self.s)?;
         }
-        try!(self.cbox(indent_unit));
-        try!(self.ibox(0));
-        try!(self.print_outer_attributes(&arm.attrs));
+        self.cbox(indent_unit)?;
+        self.ibox(0)?;
+        self.print_outer_attributes(&arm.attrs)?;
         let mut first = true;
         for p in &arm.pats {
             if first {
                 first = false;
             } else {
-                try!(space(&mut self.s));
-                try!(self.word_space("|"));
+                space(&mut self.s)?;
+                self.word_space("|")?;
             }
-            try!(self.print_pat(&p));
+            self.print_pat(&p)?;
         }
-        try!(space(&mut self.s));
+        space(&mut self.s)?;
         if let Some(ref e) = arm.guard {
-            try!(self.word_space("if"));
-            try!(self.print_expr(&e));
-            try!(space(&mut self.s));
+            self.word_space("if")?;
+            self.print_expr(&e)?;
+            space(&mut self.s)?;
         }
-        try!(self.word_space("=>"));
+        self.word_space("=>")?;
 
         match arm.body.node {
             hir::ExprBlock(ref blk) => {
                 // the block will close the pattern's ibox
-                try!(self.print_block_unclosed_indent(&blk, indent_unit));
+                self.print_block_unclosed_indent(&blk, indent_unit)?;
 
                 // If it is a user-provided unsafe block, print a comma after it
                 if let hir::UnsafeBlock(hir::UserProvided) = blk.rules {
-                    try!(word(&mut self.s, ","));
+                    word(&mut self.s, ",")?;
                 }
             }
             _ => {
-                try!(self.end()); // close the ibox for the pattern
-                try!(self.print_expr(&arm.body));
-                try!(word(&mut self.s, ","));
+                self.end()?; // close the ibox for the pattern
+                self.print_expr(&arm.body)?;
+                word(&mut self.s, ",")?;
             }
         }
         self.end() // close enclosing cbox
@@ -1879,24 +1879,24 @@ impl<'a> State<'a> {
                            explicit_self: &hir::ExplicitSelf_,
                            mutbl: hir::Mutability)
                            -> io::Result<bool> {
-        try!(self.print_mutability(mutbl));
+        self.print_mutability(mutbl)?;
         match *explicit_self {
             hir::SelfStatic => {
                 return Ok(false);
             }
             hir::SelfValue(_) => {
-                try!(word(&mut self.s, "self"));
+                word(&mut self.s, "self")?;
             }
             hir::SelfRegion(ref lt, m, _) => {
-                try!(word(&mut self.s, "&"));
-                try!(self.print_opt_lifetime(lt));
-                try!(self.print_mutability(m));
-                try!(word(&mut self.s, "self"));
+                word(&mut self.s, "&")?;
+                self.print_opt_lifetime(lt)?;
+                self.print_mutability(m)?;
+                word(&mut self.s, "self")?;
             }
             hir::SelfExplicit(ref typ, _) => {
-                try!(word(&mut self.s, "self"));
-                try!(self.word_space(":"));
-                try!(self.print_type(&typ));
+                word(&mut self.s, "self")?;
+                self.word_space(":")?;
+                self.print_type(&typ)?;
             }
         }
         return Ok(true);
@@ -1912,14 +1912,14 @@ impl<'a> State<'a> {
                     opt_explicit_self: Option<&hir::ExplicitSelf_>,
                     vis: hir::Visibility)
                     -> io::Result<()> {
-        try!(self.print_fn_header_info(unsafety, constness, abi, vis));
+        self.print_fn_header_info(unsafety, constness, abi, vis)?;
 
         if let Some(name) = name {
-            try!(self.nbsp());
-            try!(self.print_name(name));
+            self.nbsp()?;
+            self.print_name(name)?;
         }
-        try!(self.print_generics(generics));
-        try!(self.print_fn_args_and_ret(decl, opt_explicit_self));
+        self.print_generics(generics)?;
+        self.print_fn_args_and_ret(decl, opt_explicit_self)?;
         self.print_where_clause(&generics.where_clause)
     }
 
@@ -1930,7 +1930,7 @@ impl<'a> State<'a> {
                          -> io::Result<()> {
         // It is unfortunate to duplicate the commasep logic, but we want the
         // self type and the args all in the same box.
-        try!(self.rbox(0, Inconsistent));
+        self.rbox(0, Inconsistent)?;
         let mut first = true;
         if let Some(explicit_self) = opt_explicit_self {
             let m = match explicit_self {
@@ -1940,7 +1940,7 @@ impl<'a> State<'a> {
                     _ => hir::MutImmutable,
                 },
             };
-            first = !try!(self.print_explicit_self(explicit_self, m));
+            first = !self.print_explicit_self(explicit_self, m)?;
         }
 
         // HACK(eddyb) ignore the separately printed self argument.
@@ -1954,9 +1954,9 @@ impl<'a> State<'a> {
             if first {
                 first = false;
             } else {
-                try!(self.word_space(","));
+                self.word_space(",")?;
             }
-            try!(self.print_arg(arg, is_closure));
+            self.print_arg(arg, is_closure)?;
         }
 
         self.end()
@@ -1966,35 +1966,35 @@ impl<'a> State<'a> {
                                  decl: &hir::FnDecl,
                                  opt_explicit_self: Option<&hir::ExplicitSelf_>)
                                  -> io::Result<()> {
-        try!(self.popen());
-        try!(self.print_fn_args(decl, opt_explicit_self, false));
+        self.popen()?;
+        self.print_fn_args(decl, opt_explicit_self, false)?;
         if decl.variadic {
-            try!(word(&mut self.s, ", ..."));
+            word(&mut self.s, ", ...")?;
         }
-        try!(self.pclose());
+        self.pclose()?;
 
         self.print_fn_output(decl)
     }
 
     pub fn print_fn_block_args(&mut self, decl: &hir::FnDecl) -> io::Result<()> {
-        try!(word(&mut self.s, "|"));
-        try!(self.print_fn_args(decl, None, true));
-        try!(word(&mut self.s, "|"));
+        word(&mut self.s, "|")?;
+        self.print_fn_args(decl, None, true)?;
+        word(&mut self.s, "|")?;
 
         if let hir::DefaultReturn(..) = decl.output {
             return Ok(());
         }
 
-        try!(self.space_if_not_bol());
-        try!(self.word_space("->"));
+        self.space_if_not_bol()?;
+        self.word_space("->")?;
         match decl.output {
             hir::Return(ref ty) => {
-                try!(self.print_type(&ty));
+                self.print_type(&ty)?;
                 self.maybe_print_comment(ty.span.lo)
             }
             hir::DefaultReturn(..) => unreachable!(),
             hir::NoReturn(span) => {
-                try!(self.word_nbsp("!"));
+                self.word_nbsp("!")?;
                 self.maybe_print_comment(span.lo)
             }
         }
@@ -2009,28 +2009,28 @@ impl<'a> State<'a> {
 
     pub fn print_bounds(&mut self, prefix: &str, bounds: &[hir::TyParamBound]) -> io::Result<()> {
         if !bounds.is_empty() {
-            try!(word(&mut self.s, prefix));
+            word(&mut self.s, prefix)?;
             let mut first = true;
             for bound in bounds {
-                try!(self.nbsp());
+                self.nbsp()?;
                 if first {
                     first = false;
                 } else {
-                    try!(self.word_space("+"));
+                    self.word_space("+")?;
                 }
 
-                try!(match *bound {
+                match *bound {
                     TraitTyParamBound(ref tref, TraitBoundModifier::None) => {
                         self.print_poly_trait_ref(tref)
                     }
                     TraitTyParamBound(ref tref, TraitBoundModifier::Maybe) => {
-                        try!(word(&mut self.s, "?"));
+                        word(&mut self.s, "?")?;
                         self.print_poly_trait_ref(tref)
                     }
                     RegionTyParamBound(ref lt) => {
                         self.print_lifetime(lt)
                     }
-                })
+                }?
             }
             Ok(())
         } else {
@@ -2043,11 +2043,11 @@ impl<'a> State<'a> {
     }
 
     pub fn print_lifetime_def(&mut self, lifetime: &hir::LifetimeDef) -> io::Result<()> {
-        try!(self.print_lifetime(&lifetime.lifetime));
+        self.print_lifetime(&lifetime.lifetime)?;
         let mut sep = ":";
         for v in &lifetime.bounds {
-            try!(word(&mut self.s, sep));
-            try!(self.print_lifetime(v));
+            word(&mut self.s, sep)?;
+            self.print_lifetime(v)?;
             sep = "+";
         }
         Ok(())
@@ -2059,14 +2059,14 @@ impl<'a> State<'a> {
             return Ok(());
         }
 
-        try!(word(&mut self.s, "<"));
+        word(&mut self.s, "<")?;
 
         let mut ints = Vec::new();
         for i in 0..total {
             ints.push(i);
         }
 
-        try!(self.commasep(Inconsistent, &ints[..], |s, &idx| {
+        self.commasep(Inconsistent, &ints[..], |s, &idx| {
             if idx < generics.lifetimes.len() {
                 let lifetime = &generics.lifetimes[idx];
                 s.print_lifetime_def(lifetime)
@@ -2075,19 +2075,19 @@ impl<'a> State<'a> {
                 let param = &generics.ty_params[idx];
                 s.print_ty_param(param)
             }
-        }));
+        })?;
 
-        try!(word(&mut self.s, ">"));
+        word(&mut self.s, ">")?;
         Ok(())
     }
 
     pub fn print_ty_param(&mut self, param: &hir::TyParam) -> io::Result<()> {
-        try!(self.print_name(param.name));
-        try!(self.print_bounds(":", &param.bounds));
+        self.print_name(param.name)?;
+        self.print_bounds(":", &param.bounds)?;
         match param.default {
             Some(ref default) => {
-                try!(space(&mut self.s));
-                try!(self.word_space("="));
+                space(&mut self.s)?;
+                self.word_space("=")?;
                 self.print_type(&default)
             }
             _ => Ok(()),
@@ -2099,12 +2099,12 @@ impl<'a> State<'a> {
             return Ok(());
         }
 
-        try!(space(&mut self.s));
-        try!(self.word_space("where"));
+        space(&mut self.s)?;
+        self.word_space("where")?;
 
         for (i, predicate) in where_clause.predicates.iter().enumerate() {
             if i != 0 {
-                try!(self.word_space(","));
+                self.word_space(",")?;
             }
 
             match predicate {
@@ -2112,29 +2112,29 @@ impl<'a> State<'a> {
                                                                               ref bounded_ty,
                                                                               ref bounds,
                                                                               ..}) => {
-                    try!(self.print_formal_lifetime_list(bound_lifetimes));
-                    try!(self.print_type(&bounded_ty));
-                    try!(self.print_bounds(":", bounds));
+                    self.print_formal_lifetime_list(bound_lifetimes)?;
+                    self.print_type(&bounded_ty)?;
+                    self.print_bounds(":", bounds)?;
                 }
                 &hir::WherePredicate::RegionPredicate(hir::WhereRegionPredicate{ref lifetime,
                                                                                 ref bounds,
                                                                                 ..}) => {
-                    try!(self.print_lifetime(lifetime));
-                    try!(word(&mut self.s, ":"));
+                    self.print_lifetime(lifetime)?;
+                    word(&mut self.s, ":")?;
 
                     for (i, bound) in bounds.iter().enumerate() {
-                        try!(self.print_lifetime(bound));
+                        self.print_lifetime(bound)?;
 
                         if i != 0 {
-                            try!(word(&mut self.s, ":"));
+                            word(&mut self.s, ":")?;
                         }
                     }
                 }
                 &hir::WherePredicate::EqPredicate(hir::WhereEqPredicate{ref path, ref ty, ..}) => {
-                    try!(self.print_path(path, false, 0));
-                    try!(space(&mut self.s));
-                    try!(self.word_space("="));
-                    try!(self.print_type(&ty));
+                    self.print_path(path, false, 0)?;
+                    space(&mut self.s)?;
+                    self.word_space("=")?;
+                    self.print_type(&ty)?;
                 }
             }
         }
@@ -2145,30 +2145,30 @@ impl<'a> State<'a> {
     pub fn print_view_path(&mut self, vp: &hir::ViewPath) -> io::Result<()> {
         match vp.node {
             hir::ViewPathSimple(name, ref path) => {
-                try!(self.print_path(path, false, 0));
+                self.print_path(path, false, 0)?;
 
                 if path.segments.last().unwrap().identifier.name != name {
-                    try!(space(&mut self.s));
-                    try!(self.word_space("as"));
-                    try!(self.print_name(name));
+                    space(&mut self.s)?;
+                    self.word_space("as")?;
+                    self.print_name(name)?;
                 }
 
                 Ok(())
             }
 
             hir::ViewPathGlob(ref path) => {
-                try!(self.print_path(path, false, 0));
+                self.print_path(path, false, 0)?;
                 word(&mut self.s, "::*")
             }
 
             hir::ViewPathList(ref path, ref segments) => {
                 if path.segments.is_empty() {
-                    try!(word(&mut self.s, "{"));
+                    word(&mut self.s, "{")?;
                 } else {
-                    try!(self.print_path(path, false, 0));
-                    try!(word(&mut self.s, "::{"));
+                    self.print_path(path, false, 0)?;
+                    word(&mut self.s, "::{")?;
                 }
-                try!(self.commasep(Inconsistent, &segments[..], |s, w| {
+                self.commasep(Inconsistent, &segments[..], |s, w| {
                     match w.node {
                         hir::PathListIdent { name, .. } => {
                             s.print_name(name)
@@ -2177,7 +2177,7 @@ impl<'a> State<'a> {
                             word(&mut s.s, "self")
                         }
                     }
-                }));
+                })?;
                 word(&mut self.s, "}")
             }
         }
@@ -2191,14 +2191,14 @@ impl<'a> State<'a> {
     }
 
     pub fn print_mt(&mut self, mt: &hir::MutTy) -> io::Result<()> {
-        try!(self.print_mutability(mt.mutbl));
+        self.print_mutability(mt.mutbl)?;
         self.print_type(&mt.ty)
     }
 
     pub fn print_arg(&mut self, input: &hir::Arg, is_closure: bool) -> io::Result<()> {
-        try!(self.ibox(indent_unit));
+        self.ibox(indent_unit)?;
         match input.ty.node {
-            hir::TyInfer if is_closure => try!(self.print_pat(&input.pat)),
+            hir::TyInfer if is_closure => self.print_pat(&input.pat)?,
             _ => {
                 match input.pat.node {
                     PatKind::Ident(_, ref path1, _) if
@@ -2207,12 +2207,12 @@ impl<'a> State<'a> {
                         // Do nothing.
                     }
                     _ => {
-                        try!(self.print_pat(&input.pat));
-                        try!(word(&mut self.s, ":"));
-                        try!(space(&mut self.s));
+                        self.print_pat(&input.pat)?;
+                        word(&mut self.s, ":")?;
+                        space(&mut self.s)?;
                     }
                 }
-                try!(self.print_type(&input.ty));
+                self.print_type(&input.ty)?;
             }
         }
         self.end()
@@ -2223,15 +2223,15 @@ impl<'a> State<'a> {
             return Ok(());
         }
 
-        try!(self.space_if_not_bol());
-        try!(self.ibox(indent_unit));
-        try!(self.word_space("->"));
+        self.space_if_not_bol()?;
+        self.ibox(indent_unit)?;
+        self.word_space("->")?;
         match decl.output {
-            hir::NoReturn(_) => try!(self.word_nbsp("!")),
+            hir::NoReturn(_) => self.word_nbsp("!")?,
             hir::DefaultReturn(..) => unreachable!(),
-            hir::Return(ref ty) => try!(self.print_type(&ty)),
+            hir::Return(ref ty) => self.print_type(&ty)?,
         }
-        try!(self.end());
+        self.end()?;
 
         match decl.output {
             hir::Return(ref output) => self.maybe_print_comment(output.span.lo),
@@ -2247,10 +2247,10 @@ impl<'a> State<'a> {
                        generics: &hir::Generics,
                        opt_explicit_self: Option<&hir::ExplicitSelf_>)
                        -> io::Result<()> {
-        try!(self.ibox(indent_unit));
+        self.ibox(indent_unit)?;
         if !generics.lifetimes.is_empty() || !generics.ty_params.is_empty() {
-            try!(word(&mut self.s, "for"));
-            try!(self.print_generics(generics));
+            word(&mut self.s, "for")?;
+            self.print_generics(generics)?;
         }
         let generics = hir::Generics {
             lifetimes: hir::HirVec::new(),
@@ -2260,14 +2260,14 @@ impl<'a> State<'a> {
                 predicates: hir::HirVec::new(),
             },
         };
-        try!(self.print_fn(decl,
+        self.print_fn(decl,
                            unsafety,
                            hir::Constness::NotConst,
                            abi,
                            name,
                            &generics,
                            opt_explicit_self,
-                           hir::Inherited));
+                           hir::Inherited)?;
         self.end()
     }
 
@@ -2293,7 +2293,7 @@ impl<'a> State<'a> {
                 }
                 if span.hi < (*cmnt).pos && (*cmnt).pos < next &&
                    span_line.line == comment_line.line {
-                    try!(self.print_comment(cmnt));
+                    self.print_comment(cmnt)?;
                     self.cur_cmnt_and_lit.cur_cmnt += 1;
                 }
             }
@@ -2306,12 +2306,12 @@ impl<'a> State<'a> {
         // If there aren't any remaining comments, then we need to manually
         // make sure there is a line break at the end.
         if self.next_comment().is_none() {
-            try!(hardbreak(&mut self.s));
+            hardbreak(&mut self.s)?;
         }
         loop {
             match self.next_comment() {
                 Some(ref cmnt) => {
-                    try!(self.print_comment(cmnt));
+                    self.print_comment(cmnt)?;
                     self.cur_cmnt_and_lit.cur_cmnt += 1;
                 }
                 _ => break,
@@ -2326,7 +2326,7 @@ impl<'a> State<'a> {
         match opt_abi {
             Some(Abi::Rust) => Ok(()),
             Some(abi) => {
-                try!(self.word_nbsp("extern"));
+                self.word_nbsp("extern")?;
                 self.word_nbsp(&abi.to_string())
             }
             None => Ok(()),
@@ -2336,7 +2336,7 @@ impl<'a> State<'a> {
     pub fn print_extern_opt_abi(&mut self, opt_abi: Option<Abi>) -> io::Result<()> {
         match opt_abi {
             Some(abi) => {
-                try!(self.word_nbsp("extern"));
+                self.word_nbsp("extern")?;
                 self.word_nbsp(&abi.to_string())
             }
             None => Ok(()),
@@ -2349,17 +2349,17 @@ impl<'a> State<'a> {
                                 abi: Abi,
                                 vis: hir::Visibility)
                                 -> io::Result<()> {
-        try!(word(&mut self.s, &visibility_qualified(vis, "")));
-        try!(self.print_unsafety(unsafety));
+        word(&mut self.s, &visibility_qualified(vis, ""))?;
+        self.print_unsafety(unsafety)?;
 
         match constness {
             hir::Constness::NotConst => {}
-            hir::Constness::Const => try!(self.word_nbsp("const")),
+            hir::Constness::Const => self.word_nbsp("const")?,
         }
 
         if abi != Abi::Rust {
-            try!(self.word_nbsp("extern"));
-            try!(self.word_nbsp(&abi.to_string()));
+            self.word_nbsp("extern")?;
+            self.word_nbsp(&abi.to_string())?;
         }
 
         word(&mut self.s, "fn")

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -1221,11 +1221,11 @@ fn get_attributes(md: rbml::Doc) -> Vec<ast::Attribute> {
 
 fn list_crate_attributes(md: rbml::Doc, hash: &Svh,
                          out: &mut io::Write) -> io::Result<()> {
-    try!(write!(out, "=Crate Attributes ({})=\n", *hash));
+    write!(out, "=Crate Attributes ({})=\n", *hash)?;
 
     let r = get_attributes(md);
     for attr in &r {
-        try!(write!(out, "{}\n", pprust::attribute_to_string(attr)));
+        write!(out, "{}\n", pprust::attribute_to_string(attr))?;
     }
 
     write!(out, "\n\n")
@@ -1267,11 +1267,11 @@ pub fn get_crate_deps(data: &[u8]) -> Vec<CrateDep> {
 }
 
 fn list_crate_deps(data: &[u8], out: &mut io::Write) -> io::Result<()> {
-    try!(write!(out, "=External Dependencies=\n"));
+    write!(out, "=External Dependencies=\n")?;
     for dep in &get_crate_deps(data) {
-        try!(write!(out, "{} {}-{}\n", dep.cnum, dep.name, dep.hash));
+        write!(out, "{} {}-{}\n", dep.cnum, dep.name, dep.hash)?;
     }
-    try!(write!(out, "\n"));
+    write!(out, "\n")?;
     Ok(())
 }
 
@@ -1308,7 +1308,7 @@ pub fn get_crate_name(data: &[u8]) -> String {
 pub fn list_crate_metadata(bytes: &[u8], out: &mut io::Write) -> io::Result<()> {
     let hash = get_crate_hash(bytes);
     let md = rbml::Doc::new(bytes);
-    try!(list_crate_attributes(md, &hash, out));
+    list_crate_attributes(md, &hash, out)?;
     list_crate_deps(bytes, out)
 }
 

--- a/src/librustc_metadata/lib.rs
+++ b/src/librustc_metadata/lib.rs
@@ -23,6 +23,7 @@
 #![feature(rustc_diagnostic_macros)]
 #![feature(rustc_private)]
 #![feature(staged_api)]
+#![feature(question_mark)]
 
 #[macro_use] extern crate log;
 #[macro_use] extern crate syntax;

--- a/src/librustc_mir/graphviz.rs
+++ b/src/librustc_mir/graphviz.rs
@@ -65,9 +65,9 @@ pub fn write_node_label<W: Write, INIT, FINI>(block: BasicBlock,
 
     // Basic block number at the top.
     write!(w, r#"<tr><td {attrs} colspan="{colspan}">{blk}</td></tr>"#,
-                attrs=r#"bgcolor="gray" align="center""#,
-                colspan=num_cols,
-                blk=block.index())?;
+           attrs=r#"bgcolor="gray" align="center""#,
+           colspan=num_cols,
+           blk=block.index())?;
 
     init(w)?;
 
@@ -145,13 +145,13 @@ fn write_graph_label<W: Write>(tcx: &ty::TyCtxt, nid: NodeId, mir: &Mir, w: &mut
             write!(w, "mut ")?;
         }
         write!(w, r#"{:?}: {}; // {}<br align="left"/>"#,
-                    Lvalue::Var(i as u32), escape(&var.ty), var.name)?;
+               Lvalue::Var(i as u32), escape(&var.ty), var.name)?;
     }
 
     // Compiler-introduced temporary types.
     for (i, temp) in mir.temp_decls.iter().enumerate() {
         write!(w, r#"let mut {:?}: {};<br align="left"/>"#,
-                    Lvalue::Temp(i as u32), escape(&temp.ty))?;
+               Lvalue::Temp(i as u32), escape(&temp.ty))?;
     }
 
     writeln!(w, ">;")

--- a/src/librustc_mir/graphviz.rs
+++ b/src/librustc_mir/graphviz.rs
@@ -19,26 +19,26 @@ use syntax::ast::NodeId;
 pub fn write_mir_graphviz<'a, 't, W, I>(tcx: &ty::TyCtxt<'t>, iter: I, w: &mut W) -> io::Result<()>
 where W: Write, I: Iterator<Item=(&'a NodeId, &'a Mir<'a>)> {
     for (&nodeid, mir) in iter {
-        try!(writeln!(w, "digraph Mir_{} {{", nodeid));
+        writeln!(w, "digraph Mir_{} {{", nodeid)?;
 
         // Global graph properties
-        try!(writeln!(w, r#"    graph [fontname="monospace"];"#));
-        try!(writeln!(w, r#"    node [fontname="monospace"];"#));
-        try!(writeln!(w, r#"    edge [fontname="monospace"];"#));
+        writeln!(w, r#"    graph [fontname="monospace"];"#)?;
+        writeln!(w, r#"    node [fontname="monospace"];"#)?;
+        writeln!(w, r#"    edge [fontname="monospace"];"#)?;
 
         // Graph label
-        try!(write_graph_label(tcx, nodeid, mir, w));
+        write_graph_label(tcx, nodeid, mir, w)?;
 
         // Nodes
         for block in mir.all_basic_blocks() {
-            try!(write_node(block, mir, w));
+            write_node(block, mir, w)?;
         }
 
         // Edges
         for source in mir.all_basic_blocks() {
-            try!(write_edges(source, mir, w));
+            write_edges(source, mir, w)?;
         }
-        try!(writeln!(w, "}}"))
+        writeln!(w, "}}")?
     }
     Ok(())
 }
@@ -61,32 +61,32 @@ pub fn write_node_label<W: Write, INIT, FINI>(block: BasicBlock,
 {
     let data = mir.basic_block_data(block);
 
-    try!(write!(w, r#"<table border="0" cellborder="1" cellspacing="0">"#));
+    write!(w, r#"<table border="0" cellborder="1" cellspacing="0">"#)?;
 
     // Basic block number at the top.
-    try!(write!(w, r#"<tr><td {attrs} colspan="{colspan}">{blk}</td></tr>"#,
+    write!(w, r#"<tr><td {attrs} colspan="{colspan}">{blk}</td></tr>"#,
                 attrs=r#"bgcolor="gray" align="center""#,
                 colspan=num_cols,
-                blk=block.index()));
+                blk=block.index())?;
 
-    try!(init(w));
+    init(w)?;
 
     // List of statements in the middle.
     if !data.statements.is_empty() {
-        try!(write!(w, r#"<tr><td align="left" balign="left">"#));
+        write!(w, r#"<tr><td align="left" balign="left">"#)?;
         for statement in &data.statements {
-            try!(write!(w, "{}<br/>", escape(statement)));
+            write!(w, "{}<br/>", escape(statement))?;
         }
-        try!(write!(w, "</td></tr>"));
+        write!(w, "</td></tr>")?;
     }
 
     // Terminator head at the bottom, not including the list of successor blocks. Those will be
     // displayed as labels on the edges between blocks.
     let mut terminator_head = String::new();
     data.terminator().fmt_head(&mut terminator_head).unwrap();
-    try!(write!(w, r#"<tr><td align="left">{}</td></tr>"#, dot::escape_html(&terminator_head)));
+    write!(w, r#"<tr><td align="left">{}</td></tr>"#, dot::escape_html(&terminator_head))?;
 
-    try!(fini(w));
+    fini(w)?;
 
     // Close the table
     writeln!(w, "</table>")
@@ -95,8 +95,8 @@ pub fn write_node_label<W: Write, INIT, FINI>(block: BasicBlock,
 /// Write a graphviz DOT node for the given basic block.
 fn write_node<W: Write>(block: BasicBlock, mir: &Mir, w: &mut W) -> io::Result<()> {
     // Start a new node with the label to follow, in one of DOT's pseudo-HTML tables.
-    try!(write!(w, r#"    {} [shape="none", label=<"#, node(block)));
-    try!(write_node_label(block, mir, w, 1, |_| Ok(()), |_| Ok(())));
+    write!(w, r#"    {} [shape="none", label=<"#, node(block))?;
+    write_node_label(block, mir, w, 1, |_| Ok(()), |_| Ok(()))?;
     // Close the node label and the node itself.
     writeln!(w, ">];")
 }
@@ -107,7 +107,7 @@ fn write_edges<W: Write>(source: BasicBlock, mir: &Mir, w: &mut W) -> io::Result
     let labels = terminator.fmt_successor_labels();
 
     for (&target, label) in terminator.successors().iter().zip(labels) {
-        try!(writeln!(w, r#"    {} -> {} [label="{}"];"#, node(source), node(target), label));
+        writeln!(w, r#"    {} -> {} [label="{}"];"#, node(source), node(target), label)?;
     }
 
     Ok(())
@@ -118,40 +118,40 @@ fn write_edges<W: Write>(source: BasicBlock, mir: &Mir, w: &mut W) -> io::Result
 /// all the variables and temporaries.
 fn write_graph_label<W: Write>(tcx: &ty::TyCtxt, nid: NodeId, mir: &Mir, w: &mut W)
 -> io::Result<()> {
-    try!(write!(w, "    label=<fn {}(", dot::escape_html(&tcx.map.path_to_string(nid))));
+    write!(w, "    label=<fn {}(", dot::escape_html(&tcx.map.path_to_string(nid)))?;
 
     // fn argument types.
     for (i, arg) in mir.arg_decls.iter().enumerate() {
         if i > 0 {
-            try!(write!(w, ", "));
+            write!(w, ", ")?;
         }
-        try!(write!(w, "{:?}: {}", Lvalue::Arg(i as u32), escape(&arg.ty)));
+        write!(w, "{:?}: {}", Lvalue::Arg(i as u32), escape(&arg.ty))?;
     }
 
-    try!(write!(w, ") -&gt; "));
+    write!(w, ") -&gt; ")?;
 
     // fn return type.
     match mir.return_ty {
-        ty::FnOutput::FnConverging(ty) => try!(write!(w, "{}", escape(ty))),
-        ty::FnOutput::FnDiverging => try!(write!(w, "!")),
+        ty::FnOutput::FnConverging(ty) => write!(w, "{}", escape(ty))?,
+        ty::FnOutput::FnDiverging => write!(w, "!")?,
     }
 
-    try!(write!(w, r#"<br align="left"/>"#));
+    write!(w, r#"<br align="left"/>"#)?;
 
     // User variable types (including the user's name in a comment).
     for (i, var) in mir.var_decls.iter().enumerate() {
-        try!(write!(w, "let "));
+        write!(w, "let ")?;
         if var.mutability == Mutability::Mut {
-            try!(write!(w, "mut "));
+            write!(w, "mut ")?;
         }
-        try!(write!(w, r#"{:?}: {}; // {}<br align="left"/>"#,
-                    Lvalue::Var(i as u32), escape(&var.ty), var.name));
+        write!(w, r#"{:?}: {}; // {}<br align="left"/>"#,
+                    Lvalue::Var(i as u32), escape(&var.ty), var.name)?;
     }
 
     // Compiler-introduced temporary types.
     for (i, temp) in mir.temp_decls.iter().enumerate() {
-        try!(write!(w, r#"let mut {:?}: {};<br align="left"/>"#,
-                    Lvalue::Temp(i as u32), escape(&temp.ty)));
+        write!(w, r#"let mut {:?}: {};<br align="left"/>"#,
+                    Lvalue::Temp(i as u32), escape(&temp.ty))?;
     }
 
     writeln!(w, ">;")

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -23,6 +23,7 @@ Rust MIR: a lowered representation of Rust. Also: an experiment!
 #![feature(box_patterns)]
 #![feature(rustc_private)]
 #![feature(staged_api)]
+#![feature(question_mark)]
 
 #[macro_use] extern crate log;
 extern crate graphviz as dot;

--- a/src/librustc_trans/back/archive.rs
+++ b/src/librustc_trans/back/archive.rs
@@ -255,7 +255,7 @@ impl<'a> ArchiveBuilder<'a> {
         // permission bits.
         if let Some(ref s) = self.config.src {
             io::copy(&mut File::open(s)?,
-                          &mut File::create(&self.config.dst)?)?;
+                     &mut File::create(&self.config.dst)?)?;
         }
 
         if removals.len() > 0 {
@@ -272,7 +272,7 @@ impl<'a> ArchiveBuilder<'a> {
                 }
                 Addition::Archive { archive, archive_name, mut skip } => {
                     self.add_archive_members(&mut members, archive,
-                                                  &archive_name, &mut *skip)?;
+                                             &archive_name, &mut *skip)?;
                 }
             }
         }

--- a/src/librustc_trans/back/archive.rs
+++ b/src/librustc_trans/back/archive.rs
@@ -254,8 +254,8 @@ impl<'a> ArchiveBuilder<'a> {
         // want to modify this archive, so we use `io::copy` to not preserve
         // permission bits.
         if let Some(ref s) = self.config.src {
-            try!(io::copy(&mut try!(File::open(s)),
-                          &mut try!(File::create(&self.config.dst))));
+            io::copy(&mut File::open(s)?,
+                          &mut File::create(&self.config.dst)?)?;
         }
 
         if removals.len() > 0 {
@@ -267,12 +267,12 @@ impl<'a> ArchiveBuilder<'a> {
             match addition {
                 Addition::File { path, name_in_archive } => {
                     let dst = self.work_dir.path().join(&name_in_archive);
-                    try!(fs::copy(&path, &dst));
+                    fs::copy(&path, &dst)?;
                     members.push(PathBuf::from(name_in_archive));
                 }
                 Addition::Archive { archive, archive_name, mut skip } => {
-                    try!(self.add_archive_members(&mut members, archive,
-                                                  &archive_name, &mut *skip));
+                    self.add_archive_members(&mut members, archive,
+                                                  &archive_name, &mut *skip)?;
                 }
             }
         }
@@ -334,7 +334,7 @@ impl<'a> ArchiveBuilder<'a> {
         // all SYMDEF files as these are just magical placeholders which get
         // re-created when we make a new archive anyway.
         for file in archive.iter() {
-            let file = try!(file.map_err(string_to_io_error));
+            let file = file.map_err(string_to_io_error)?;
             if !is_relevant_child(&file) {
                 continue
             }
@@ -388,7 +388,7 @@ impl<'a> ArchiveBuilder<'a> {
                 }
             }
             let dst = self.work_dir.path().join(&new_filename);
-            try!(try!(File::create(&dst)).write_all(file.data()));
+            File::create(&dst)?.write_all(file.data())?;
             members.push(PathBuf::from(new_filename));
         }
         Ok(())
@@ -455,7 +455,7 @@ impl<'a> ArchiveBuilder<'a> {
         unsafe {
             if let Some(archive) = self.src_archive() {
                 for child in archive.iter() {
-                    let child = try!(child.map_err(string_to_io_error));
+                    let child = child.map_err(string_to_io_error)?;
                     let child_name = match child.name() {
                         Some(s) => s,
                         None => continue,
@@ -464,7 +464,7 @@ impl<'a> ArchiveBuilder<'a> {
                         continue
                     }
 
-                    let name = try!(CString::new(child_name));
+                    let name = CString::new(child_name)?;
                     members.push(llvm::LLVMRustArchiveMemberNew(ptr::null(),
                                                                 name.as_ptr(),
                                                                 child.raw()));
@@ -474,8 +474,8 @@ impl<'a> ArchiveBuilder<'a> {
             for addition in mem::replace(&mut self.additions, Vec::new()) {
                 match addition {
                     Addition::File { path, name_in_archive } => {
-                        let path = try!(CString::new(path.to_str().unwrap()));
-                        let name = try!(CString::new(name_in_archive));
+                        let path = CString::new(path.to_str().unwrap())?;
+                        let name = CString::new(name_in_archive)?;
                         members.push(llvm::LLVMRustArchiveMemberNew(path.as_ptr(),
                                                                     name.as_ptr(),
                                                                     ptr::null_mut()));
@@ -484,7 +484,7 @@ impl<'a> ArchiveBuilder<'a> {
                     }
                     Addition::Archive { archive, archive_name: _, mut skip } => {
                         for child in archive.iter() {
-                            let child = try!(child.map_err(string_to_io_error));
+                            let child = child.map_err(string_to_io_error)?;
                             if !is_relevant_child(&child) {
                                 continue
                             }
@@ -502,7 +502,7 @@ impl<'a> ArchiveBuilder<'a> {
                             let child_name = Path::new(child_name)
                                                   .file_name().unwrap()
                                                   .to_str().unwrap();
-                            let name = try!(CString::new(child_name));
+                            let name = CString::new(child_name)?;
                             let m = llvm::LLVMRustArchiveMemberNew(ptr::null(),
                                                                    name.as_ptr(),
                                                                    child.raw());
@@ -515,7 +515,7 @@ impl<'a> ArchiveBuilder<'a> {
             }
 
             let dst = self.config.dst.to_str().unwrap().as_bytes();
-            let dst = try!(CString::new(dst));
+            let dst = CString::new(dst)?;
             let r = llvm::LLVMRustWriteArchive(dst.as_ptr(),
                                                members.len() as libc::size_t,
                                                members.as_ptr(),

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -757,9 +757,9 @@ fn write_rlib_bytecode_object_v1(writer: &mut Write,
                                  bc_data_deflated: &[u8]) -> io::Result<()> {
     let bc_data_deflated_size: u64 = bc_data_deflated.len() as u64;
 
-    try!(writer.write_all(RLIB_BYTECODE_OBJECT_MAGIC));
-    try!(writer.write_all(&[1, 0, 0, 0]));
-    try!(writer.write_all(&[
+    writer.write_all(RLIB_BYTECODE_OBJECT_MAGIC)?;
+    writer.write_all(&[1, 0, 0, 0])?;
+    writer.write_all(&[
         (bc_data_deflated_size >>  0) as u8,
         (bc_data_deflated_size >>  8) as u8,
         (bc_data_deflated_size >> 16) as u8,
@@ -768,8 +768,8 @@ fn write_rlib_bytecode_object_v1(writer: &mut Write,
         (bc_data_deflated_size >> 40) as u8,
         (bc_data_deflated_size >> 48) as u8,
         (bc_data_deflated_size >> 56) as u8,
-    ]));
-    try!(writer.write_all(&bc_data_deflated));
+    ])?;
+    writer.write_all(&bc_data_deflated)?;
 
     let number_of_bytes_written_so_far =
         RLIB_BYTECODE_OBJECT_MAGIC.len() +                // magic id
@@ -781,7 +781,7 @@ fn write_rlib_bytecode_object_v1(writer: &mut Write,
     // padding byte to make it even. This works around a crash bug in LLDB
     // (see issue #15950)
     if number_of_bytes_written_so_far % 2 == 1 {
-        try!(writer.write_all(&[0]));
+        writer.write_all(&[0])?;
     }
 
     return Ok(());

--- a/src/librustc_trans/back/linker.rs
+++ b/src/librustc_trans/back/linker.rs
@@ -327,16 +327,16 @@ impl<'a> Linker for MsvcLinker<'a> {
                       tmpdir: &Path) {
         let path = tmpdir.join("lib.def");
         let res = (|| -> io::Result<()> {
-            let mut f = BufWriter::new(try!(File::create(&path)));
+            let mut f = BufWriter::new(File::create(&path)?);
 
             // Start off with the standard module name header and then go
             // straight to exports.
-            try!(writeln!(f, "LIBRARY"));
-            try!(writeln!(f, "EXPORTS"));
+            writeln!(f, "LIBRARY")?;
+            writeln!(f, "EXPORTS")?;
 
             // Write out all our local symbols
             for sym in trans.reachable.iter() {
-                try!(writeln!(f, "  {}", sym));
+                writeln!(f, "  {}", sym)?;
             }
 
             // Take a look at how all upstream crates are linked into this
@@ -357,7 +357,7 @@ impl<'a> Linker for MsvcLinker<'a> {
                 cstore.item_symbol(did)
             });
             for symbol in symbols {
-                try!(writeln!(f, "  {}", symbol));
+                writeln!(f, "  {}", symbol)?;
             }
             Ok(())
         })();

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -36,6 +36,7 @@
 #![feature(slice_patterns)]
 #![feature(staged_api)]
 #![feature(unicode)]
+#![feature(question_mark)]
 
 extern crate arena;
 extern crate flate;

--- a/src/librustc_trans/trans/cleanup.rs
+++ b/src/librustc_trans/trans/cleanup.rs
@@ -175,9 +175,9 @@ impl<'blk, 'tcx: 'blk> fmt::Debug for CleanupScopeKind<'blk, 'tcx> {
             CustomScopeKind => write!(f, "CustomScopeKind"),
             AstScopeKind(nid) => write!(f, "AstScopeKind({})", nid),
             LoopScopeKind(nid, ref blks) => {
-                try!(write!(f, "LoopScopeKind({}, [", nid));
+                write!(f, "LoopScopeKind({}, [", nid)?;
                 for blk in blks {
-                    try!(write!(f, "{:p}, ", blk));
+                    write!(f, "{:p}, ", blk)?;
                 }
                 write!(f, "])")
             }

--- a/src/librustc_trans/trans/consts.rs
+++ b/src/librustc_trans/trans/consts.rs
@@ -316,9 +316,9 @@ pub fn get_const_expr_as_global<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     let val = if qualif.intersects(ConstQualif::NON_STATIC_BORROWS) {
         // Avoid autorefs as they would create global instead of stack
         // references, even when only the latter are correct.
-        try!(const_expr_unadjusted(ccx, expr, ty, param_substs, None, trueconst))
+        const_expr_unadjusted(ccx, expr, ty, param_substs, None, trueconst)?
     } else {
-        try!(const_expr(ccx, expr, param_substs, None, trueconst)).0
+        const_expr(ccx, expr, param_substs, None, trueconst)?.0
     };
 
     // boolean SSA values are i1, but they have to be stored in i8 slots,
@@ -344,7 +344,7 @@ pub fn const_expr<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                             -> Result<(ValueRef, Ty<'tcx>), ConstEvalFailure> {
     let ety = monomorphize::apply_param_substs(cx.tcx(), param_substs,
                                                &cx.tcx().expr_ty(e));
-    let llconst = try!(const_expr_unadjusted(cx, e, ety, param_substs, fn_args, trueconst));
+    let llconst = const_expr_unadjusted(cx, e, ety, param_substs, fn_args, trueconst)?;
     let mut llconst = llconst;
     let mut ety_adjusted = monomorphize::apply_param_substs(cx.tcx(), param_substs,
                                                             &cx.tcx().expr_ty_adjusted(e));
@@ -594,18 +594,18 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
         hir::ExprBinary(b, ref e1, ref e2) => {
             /* Neither type is bottom, and we expect them to be unified
              * already, so the following is safe. */
-            let (te1, ty) = try!(const_expr(cx, &e1, param_substs, fn_args, trueconst));
+            let (te1, ty) = const_expr(cx, &e1, param_substs, fn_args, trueconst)?;
             debug!("const_expr_unadjusted: te1={:?}, ty={:?}",
                    Value(te1), ty);
             assert!(!ty.is_simd());
             let is_float = ty.is_fp();
             let signed = ty.is_signed();
 
-            let (te2, ty2) = try!(const_expr(cx, &e2, param_substs, fn_args, trueconst));
+            let (te2, ty2) = const_expr(cx, &e2, param_substs, fn_args, trueconst)?;
             debug!("const_expr_unadjusted: te2={:?}, ty={:?}",
                    Value(te2), ty2);
 
-            try!(check_binary_expr_validity(cx, e, ty, te1, te2, trueconst));
+            check_binary_expr_validity(cx, e, ty, te1, te2, trueconst)?;
 
             unsafe { match b.node {
                 hir::BiAdd if is_float => llvm::LLVMConstFAdd(te1, te2),
@@ -651,9 +651,9 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             } } // unsafe { match b.node {
         },
         hir::ExprUnary(u, ref inner_e) => {
-            let (te, ty) = try!(const_expr(cx, &inner_e, param_substs, fn_args, trueconst));
+            let (te, ty) = const_expr(cx, &inner_e, param_substs, fn_args, trueconst)?;
 
-            try!(check_unary_expr_validity(cx, e, ty, te, trueconst));
+            check_unary_expr_validity(cx, e, ty, te, trueconst)?;
 
             let is_float = ty.is_fp();
             unsafe { match u {
@@ -664,21 +664,21 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             } }
         },
         hir::ExprField(ref base, field) => {
-            let (bv, bt) = try!(const_expr(cx, &base, param_substs, fn_args, trueconst));
+            let (bv, bt) = const_expr(cx, &base, param_substs, fn_args, trueconst)?;
             let brepr = adt::represent_type(cx, bt);
             let vinfo = VariantInfo::from_ty(cx.tcx(), bt, None);
             let ix = vinfo.field_index(field.node);
             adt::const_get_field(cx, &brepr, bv, vinfo.discr, ix)
         },
         hir::ExprTupField(ref base, idx) => {
-            let (bv, bt) = try!(const_expr(cx, &base, param_substs, fn_args, trueconst));
+            let (bv, bt) = const_expr(cx, &base, param_substs, fn_args, trueconst)?;
             let brepr = adt::represent_type(cx, bt);
             let vinfo = VariantInfo::from_ty(cx.tcx(), bt, None);
             adt::const_get_field(cx, &brepr, bv, vinfo.discr, idx.node)
         },
         hir::ExprIndex(ref base, ref index) => {
-            let (bv, bt) = try!(const_expr(cx, &base, param_substs, fn_args, trueconst));
-            let iv = try!(const_expr(cx, &index, param_substs, fn_args, TrueConst::Yes)).0;
+            let (bv, bt) = const_expr(cx, &base, param_substs, fn_args, trueconst)?;
+            let iv = const_expr(cx, &index, param_substs, fn_args, TrueConst::Yes)?.0;
             let iv = if let Some(iv) = const_to_opt_uint(iv) {
                 iv
             } else {
@@ -729,7 +729,7 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
         hir::ExprCast(ref base, _) => {
             let t_cast = ety;
             let llty = type_of::type_of(cx, t_cast);
-            let (v, t_expr) = try!(const_expr(cx, &base, param_substs, fn_args, trueconst));
+            let (v, t_expr) = const_expr(cx, &base, param_substs, fn_args, trueconst)?;
             debug!("trans_const_cast({:?} as {:?})", t_expr, t_cast);
             if expr::cast_is_noop(cx.tcx(), base, t_expr, t_cast) {
                 return Ok(v);
@@ -811,30 +811,30 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             } else {
                 // If this isn't the address of a static, then keep going through
                 // normal constant evaluation.
-                let (v, ty) = try!(const_expr(cx, &sub, param_substs, fn_args, trueconst));
+                let (v, ty) = const_expr(cx, &sub, param_substs, fn_args, trueconst)?;
                 addr_of(cx, v, type_of::align_of(cx, ty), "ref")
             }
         },
         hir::ExprAddrOf(hir::MutMutable, ref sub) => {
-            let (v, ty) = try!(const_expr(cx, &sub, param_substs, fn_args, trueconst));
+            let (v, ty) = const_expr(cx, &sub, param_substs, fn_args, trueconst)?;
             addr_of_mut(cx, v, type_of::align_of(cx, ty), "ref_mut_slice")
         },
         hir::ExprTup(ref es) => {
             let repr = adt::represent_type(cx, ety);
-            let vals = try!(map_list(&es[..]));
+            let vals = map_list(&es[..])?;
             adt::trans_const(cx, &repr, Disr(0), &vals[..])
         },
         hir::ExprStruct(_, ref fs, ref base_opt) => {
             let repr = adt::represent_type(cx, ety);
 
             let base_val = match *base_opt {
-                Some(ref base) => Some(try!(const_expr(
+                Some(ref base) => Some(const_expr(
                     cx,
                     &base,
                     param_substs,
                     fn_args,
                     trueconst,
-                ))),
+                )?),
                 None => None
             };
 
@@ -851,7 +851,7 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             .collect::<Vec<Result<_, ConstEvalFailure>>>()
             .into_iter()
             .collect::<Result<Vec<_>,ConstEvalFailure>>();
-            let cs = try!(cs);
+            let cs = cs?;
             if ety.is_simd() {
                 C_vector(&cs[..])
             } else {
@@ -872,7 +872,7 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                        .collect::<Vec<Result<_, ConstEvalFailure>>>()
                        .into_iter()
                        .collect::<Result<Vec<_>, ConstEvalFailure>>();
-            let vs = try!(vs);
+            let vs = vs?;
             // If the vector contains enums, an LLVM array won't work.
             if vs.iter().any(|vi| val_ty(*vi) != llunitty) {
                 C_struct(cx, &vs[..], false)
@@ -884,7 +884,7 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             let unit_ty = ety.sequence_element_type(cx.tcx());
             let llunitty = type_of::type_of(cx, unit_ty);
             let n = cx.tcx().eval_repeat_count(count);
-            let unit_val = try!(const_expr(cx, &elem, param_substs, fn_args, trueconst)).0;
+            let unit_val = const_expr(cx, &elem, param_substs, fn_args, trueconst)?.0;
             let vs = vec![unit_val; n];
             if val_ty(unit_val) != llunitty {
                 C_struct(cx, &vs[..], false)
@@ -904,7 +904,7 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                 }
                 Def::Fn(..) | Def::Method(..) => C_nil(cx),
                 Def::Const(def_id) | Def::AssociatedConst(def_id) => {
-                    load_const(cx, try!(get_const_val(cx, def_id, e, param_substs)),
+                    load_const(cx, get_const_val(cx, def_id, e, param_substs)?,
                                ety)
                 }
                 Def::Variant(enum_did, variant_did) => {
@@ -940,17 +940,17 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                 };
             }
             let def = cx.tcx().def_map.borrow()[&callee.id].full_def();
-            let arg_vals = try!(map_list(args));
+            let arg_vals = map_list(args)?;
             match def {
                 Def::Fn(did) | Def::Method(did) => {
-                    try!(const_fn_call(
+                    const_fn_call(
                         cx,
                         did,
                         cx.tcx().node_id_item_substs(callee.id).substs,
                         &arg_vals,
                         param_substs,
                         trueconst,
-                    ))
+                    )?
                 }
                 Def::Struct(..) => {
                     if ety.is_simd() {
@@ -972,22 +972,22 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             }
         },
         hir::ExprMethodCall(_, _, ref args) => {
-            let arg_vals = try!(map_list(args));
+            let arg_vals = map_list(args)?;
             let method_call = ty::MethodCall::expr(e.id);
             let method = cx.tcx().tables.borrow().method_map[&method_call];
-            try!(const_fn_call(cx, method.def_id, method.substs.clone(),
-                               &arg_vals, param_substs, trueconst))
+            const_fn_call(cx, method.def_id, method.substs.clone(),
+                               &arg_vals, param_substs, trueconst)?
         },
-        hir::ExprType(ref e, _) => try!(const_expr(cx, &e, param_substs, fn_args, trueconst)).0,
+        hir::ExprType(ref e, _) => const_expr(cx, &e, param_substs, fn_args, trueconst)?.0,
         hir::ExprBlock(ref block) => {
             match block.expr {
-                Some(ref expr) => try!(const_expr(
+                Some(ref expr) => const_expr(
                     cx,
                     &expr,
                     param_substs,
                     fn_args,
                     trueconst,
-                )).0,
+                )?.0,
                 None => C_nil(cx),
             }
         },
@@ -1149,13 +1149,13 @@ pub fn trans_static(ccx: &CrateContext,
         let datum = get_static(ccx, def_id);
 
         let empty_substs = ccx.tcx().mk_substs(Substs::trans_empty());
-        let (v, _) = try!(const_expr(
+        let (v, _) = const_expr(
             ccx,
             expr,
             empty_substs,
             None,
             TrueConst::Yes,
-        ).map_err(|e| e.into_inner()));
+        ).map_err(|e| e.into_inner())?;
 
         // boolean SSA values are i1, but they have to be stored in i8 slots,
         // otherwise some LLVM optimization passes don't work as expected

--- a/src/librustc_trans/trans/consts.rs
+++ b/src/librustc_trans/trans/consts.rs
@@ -976,7 +976,7 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             let method_call = ty::MethodCall::expr(e.id);
             let method = cx.tcx().tables.borrow().method_map[&method_call];
             const_fn_call(cx, method.def_id, method.substs.clone(),
-                               &arg_vals, param_substs, trueconst)?
+                          &arg_vals, param_substs, trueconst)?
         },
         hir::ExprType(ref e, _) => const_expr(cx, &e, param_substs, fn_args, trueconst)?.0,
         hir::ExprBlock(ref block) => {

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -934,7 +934,7 @@ fn ast_type_binding_to_poly_projection_predicate<'tcx>(
                                                  tcx.mk_substs(dummy_substs)));
     }
 
-    try!(this.ensure_super_predicates(binding.span, trait_ref.def_id()));
+    this.ensure_super_predicates(binding.span, trait_ref.def_id())?;
 
     let mut candidates: Vec<ty::PolyTraitRef> =
         traits::supertraits(tcx, trait_ref.clone())
@@ -953,11 +953,11 @@ fn ast_type_binding_to_poly_projection_predicate<'tcx>(
         }
     }
 
-    let candidate = try!(one_bound_for_assoc_type(tcx,
+    let candidate = one_bound_for_assoc_type(tcx,
                                                   candidates,
                                                   &trait_ref.to_string(),
                                                   &binding.item_name.as_str(),
-                                                  binding.span));
+                                                  binding.span)?;
 
     Ok(ty::Binder(ty::ProjectionPredicate {             // <-------------------------+
         projection_ty: ty::ProjectionTy {               //                           |

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -954,10 +954,10 @@ fn ast_type_binding_to_poly_projection_predicate<'tcx>(
     }
 
     let candidate = one_bound_for_assoc_type(tcx,
-                                                  candidates,
-                                                  &trait_ref.to_string(),
-                                                  &binding.item_name.as_str(),
-                                                  binding.span)?;
+                                             candidates,
+                                             &trait_ref.to_string(),
+                                             &binding.item_name.as_str(),
+                                             binding.span)?;
 
     Ok(ty::Binder(ty::ProjectionPredicate {             // <-------------------------+
         projection_ty: ty::ProjectionTy {               //                           |

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -323,7 +323,7 @@ pub fn compare_impl_method<'tcx>(tcx: &TyCtxt<'tcx>,
         debug!("compare_impl_method: trait_fty={:?}",
                trait_fty);
 
-        try!(infer::mk_subty(&infcx, false, origin, impl_fty, trait_fty));
+        infer::mk_subty(&infcx, false, origin, impl_fty, trait_fty)?;
 
         infcx.leak_check(&skol_map, snapshot)
     });

--- a/src/librustc_typeck/check/dropck.rs
+++ b/src/librustc_typeck/check/dropck.rs
@@ -47,10 +47,10 @@ pub fn check_drop_impl(tcx: &TyCtxt, drop_impl_did: DefId) -> Result<(), ()> {
         ty::TyEnum(adt_def, self_to_impl_substs) |
         ty::TyStruct(adt_def, self_to_impl_substs) => {
             ensure_drop_params_and_item_params_correspond(tcx,
-                                                               drop_impl_did,
-                                                               dtor_generics,
-                                                               &dtor_self_type,
-                                                               adt_def.did)?;
+                                                          drop_impl_did,
+                                                          dtor_generics,
+                                                          &dtor_self_type,
+                                                          adt_def.did)?;
 
             ensure_drop_predicates_are_implied_by_item_defn(tcx,
                                                             drop_impl_did,
@@ -469,8 +469,7 @@ fn iterate_over_potentially_unsafe_regions_in_type<'a, 'b, 'tcx>(
         ty::TyTuple(ref tys) |
         ty::TyClosure(_, box ty::ClosureSubsts { upvar_tys: ref tys, .. }) => {
             for ty in tys {
-                iterate_over_potentially_unsafe_regions_in_type(
-                    cx, context, ty, depth+1)?
+                iterate_over_potentially_unsafe_regions_in_type(cx, context, ty, depth+1)?
             }
             Ok(())
         }

--- a/src/librustc_typeck/check/dropck.rs
+++ b/src/librustc_typeck/check/dropck.rs
@@ -46,11 +46,11 @@ pub fn check_drop_impl(tcx: &TyCtxt, drop_impl_did: DefId) -> Result<(), ()> {
     match dtor_self_type.sty {
         ty::TyEnum(adt_def, self_to_impl_substs) |
         ty::TyStruct(adt_def, self_to_impl_substs) => {
-            try!(ensure_drop_params_and_item_params_correspond(tcx,
+            ensure_drop_params_and_item_params_correspond(tcx,
                                                                drop_impl_did,
                                                                dtor_generics,
                                                                &dtor_self_type,
-                                                               adt_def.did));
+                                                               adt_def.did)?;
 
             ensure_drop_predicates_are_implied_by_item_defn(tcx,
                                                             drop_impl_did,
@@ -452,7 +452,7 @@ fn iterate_over_potentially_unsafe_regions_in_type<'a, 'b, 'tcx>(
                     let fty = field.ty(tcx, substs);
                     let fty = cx.rcx.fcx.resolve_type_vars_if_possible(
                         cx.rcx.fcx.normalize_associated_types_in(cx.span, &fty));
-                    try!(iterate_over_potentially_unsafe_regions_in_type(
+                    iterate_over_potentially_unsafe_regions_in_type(
                         cx,
                         TypeContext::ADT {
                             def_id: did,
@@ -460,7 +460,7 @@ fn iterate_over_potentially_unsafe_regions_in_type<'a, 'b, 'tcx>(
                             variant: variant.name,
                         },
                         fty,
-                        depth+1))
+                        depth+1)?
                 }
             }
             Ok(())
@@ -469,8 +469,8 @@ fn iterate_over_potentially_unsafe_regions_in_type<'a, 'b, 'tcx>(
         ty::TyTuple(ref tys) |
         ty::TyClosure(_, box ty::ClosureSubsts { upvar_tys: ref tys, .. }) => {
             for ty in tys {
-                try!(iterate_over_potentially_unsafe_regions_in_type(
-                    cx, context, ty, depth+1))
+                iterate_over_potentially_unsafe_regions_in_type(
+                    cx, context, ty, depth+1)?
             }
             Ok(())
         }

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -124,7 +124,7 @@ pub fn lookup<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
 
     let mode = probe::Mode::MethodCall;
     let self_ty = fcx.infcx().resolve_type_vars_if_possible(&self_ty);
-    let pick = try!(probe::probe(fcx, span, mode, method_name, self_ty, call_expr.id));
+    let pick = probe::probe(fcx, span, mode, method_name, self_ty, call_expr.id)?;
     Ok(confirm::confirm(fcx, span, self_expr, call_expr, self_ty, pick, supplied_method_types))
 }
 
@@ -337,7 +337,7 @@ pub fn resolve_ufcs<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                               -> Result<Def, MethodError<'tcx>>
 {
     let mode = probe::Mode::Path;
-    let pick = try!(probe::probe(fcx, span, mode, method_name, self_ty, expr_id));
+    let pick = probe::probe(fcx, span, mode, method_name, self_ty, expr_id)?;
     let def = pick.item.def();
 
     if let probe::InherentImplPick = pick.kind {

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -186,7 +186,7 @@ pub fn probe<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                                              steps,
                                              opt_simplified_steps);
         probe_cx.assemble_inherent_candidates();
-        try!(probe_cx.assemble_extension_candidates_for_traits_in_scope(scope_expr_id));
+        probe_cx.assemble_extension_candidates_for_traits_in_scope(scope_expr_id)?;
         probe_cx.pick()
     })
 }
@@ -568,7 +568,7 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
         if let Some(applicable_traits) = opt_applicable_traits {
             for &trait_did in applicable_traits {
                 if duplicates.insert(trait_did) {
-                    try!(self.assemble_extension_candidates_for_trait(trait_did));
+                    self.assemble_extension_candidates_for_trait(trait_did)?;
                 }
             }
         }
@@ -579,7 +579,7 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
         let mut duplicates = HashSet::new();
         for trait_info in suggest::all_traits(self.fcx.ccx) {
             if duplicates.insert(trait_info.def_id) {
-                try!(self.assemble_extension_candidates_for_trait(trait_info.def_id));
+                self.assemble_extension_candidates_for_trait(trait_info.def_id)?;
             }
         }
         Ok(())
@@ -612,7 +612,7 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
 
         self.assemble_extension_candidates_for_trait_impls(trait_def_id, item.clone());
 
-        try!(self.assemble_closure_candidates(trait_def_id, item.clone()));
+        self.assemble_closure_candidates(trait_def_id, item.clone())?;
 
         self.assemble_projection_candidates(trait_def_id, item.clone());
 
@@ -854,7 +854,7 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
         let span = self.span;
         let tcx = self.tcx();
 
-        try!(self.assemble_extension_candidates_for_all_traits());
+        self.assemble_extension_candidates_for_all_traits()?;
 
         let out_of_scope_traits = match self.pick_core() {
             Some(Ok(p)) => vec![p.item.container().id()],

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -292,7 +292,7 @@ impl<'a,'tcx> CrateCtxt<'a,'tcx> {
             let def_ids = ensure_super_predicates_step(self, trait_def_id);
 
             for def_id in def_ids {
-                try!(self.ensure_super_predicates(span, def_id));
+                self.ensure_super_predicates(span, def_id)?;
             }
 
             Ok(())

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -339,31 +339,31 @@ pub fn check_crate(tcx: &TyCtxt, trait_map: ty::TraitMap) -> CompileResult {
 
     // this ensures that later parts of type checking can assume that items
     // have valid types and not error
-    try!(tcx.sess.track_errors(|| {
+    tcx.sess.track_errors(|| {
         time(time_passes, "type collecting", ||
              collect::collect_item_types(tcx));
 
-    }));
+    })?;
 
     time(time_passes, "variance inference", ||
          variance::infer_variance(tcx));
 
-    try!(tcx.sess.track_errors(|| {
+    tcx.sess.track_errors(|| {
       time(time_passes, "coherence checking", ||
           coherence::check_coherence(&ccx));
-    }));
+    })?;
 
-    try!(time(time_passes, "wf checking", ||
-        check::check_wf_new(&ccx)));
+    time(time_passes, "wf checking", ||
+        check::check_wf_new(&ccx))?;
 
-    try!(time(time_passes, "item-types checking", ||
-        check::check_item_types(&ccx)));
+    time(time_passes, "item-types checking", ||
+        check::check_item_types(&ccx))?;
 
-    try!(time(time_passes, "item-bodies checking", ||
-        check::check_item_bodies(&ccx)));
+    time(time_passes, "item-bodies checking", ||
+        check::check_item_bodies(&ccx))?;
 
-    try!(time(time_passes, "drop-impl checking", ||
-        check::check_drop_impls(&ccx)));
+    time(time_passes, "drop-impl checking", ||
+        check::check_drop_impls(&ccx))?;
 
     check_for_entry_fn(&ccx);
 

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -81,6 +81,7 @@ This API is completely unstable and subject to change.
 #![feature(rustc_diagnostic_macros)]
 #![feature(rustc_private)]
 #![feature(staged_api)]
+#![feature(question_mark)]
 
 #[macro_use] extern crate log;
 #[macro_use] extern crate syntax;

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -354,17 +354,13 @@ pub fn check_crate(tcx: &TyCtxt, trait_map: ty::TraitMap) -> CompileResult {
           coherence::check_coherence(&ccx));
     })?;
 
-    time(time_passes, "wf checking", ||
-        check::check_wf_new(&ccx))?;
+    time(time_passes, "wf checking", || check::check_wf_new(&ccx))?;
 
-    time(time_passes, "item-types checking", ||
-        check::check_item_types(&ccx))?;
+    time(time_passes, "item-types checking", || check::check_item_types(&ccx))?;
 
-    time(time_passes, "item-bodies checking", ||
-        check::check_item_bodies(&ccx))?;
+    time(time_passes, "item-bodies checking", || check::check_item_bodies(&ccx))?;
 
-    time(time_passes, "drop-impl checking", ||
-        check::check_drop_impls(&ccx))?;
+    time(time_passes, "drop-impl checking", || check::check_drop_impls(&ccx))?;
 
     check_for_entry_fn(&ccx);
 

--- a/src/librustdoc/externalfiles.rs
+++ b/src/librustdoc/externalfiles.rs
@@ -38,9 +38,9 @@ impl ExternalHtml {
 }
 
 pub fn load_string(input: &Path) -> io::Result<Option<String>> {
-    let mut f = try!(File::open(input));
+    let mut f = File::open(input)?;
     let mut d = Vec::new();
-    try!(f.read_to_end(&mut d));
+    f.read_to_end(&mut d)?;
     Ok(str::from_utf8(&d).map(|s| s.to_string()).ok())
 }
 

--- a/src/librustdoc/html/escape.rs
+++ b/src/librustdoc/html/escape.rs
@@ -29,7 +29,7 @@ impl<'a> fmt::Display for Escape<'a> {
         for (i, ch) in s.bytes().enumerate() {
             match ch as char {
                 '<' | '>' | '&' | '\'' | '"' => {
-                    try!(fmt.write_str(&pile_o_bits[last.. i]));
+                    fmt.write_str(&pile_o_bits[last.. i])?;
                     let s = match ch as char {
                         '>' => "&gt;",
                         '<' => "&lt;",
@@ -38,7 +38,7 @@ impl<'a> fmt::Display for Escape<'a> {
                         '"' => "&quot;",
                         _ => unreachable!()
                     };
-                    try!(fmt.write_str(s));
+                    fmt.write_str(s)?;
                     last = i + 1;
                 }
                 _ => {}
@@ -46,7 +46,7 @@ impl<'a> fmt::Display for Escape<'a> {
         }
 
         if last < s.len() {
-            try!(fmt.write_str(&pile_o_bits[last..]));
+            fmt.write_str(&pile_o_bits[last..])?;
         }
         Ok(())
     }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -77,8 +77,8 @@ impl ConstnessSpace {
 impl<'a, T: fmt::Display> fmt::Display for CommaSep<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for (i, item) in self.0.iter().enumerate() {
-            if i != 0 { try!(write!(f, ", ")); }
-            try!(write!(f, "{}", item));
+            if i != 0 { write!(f, ", ")?; }
+            write!(f, "{}", item)?;
         }
         Ok(())
     }
@@ -89,9 +89,9 @@ impl<'a> fmt::Display for TyParamBounds<'a> {
         let &TyParamBounds(bounds) = self;
         for (i, bound) in bounds.iter().enumerate() {
             if i > 0 {
-                try!(f.write_str(" + "));
+                f.write_str(" + ")?;
             }
-            try!(write!(f, "{}", *bound));
+            write!(f, "{}", *bound)?;
         }
         Ok(())
     }
@@ -100,36 +100,36 @@ impl<'a> fmt::Display for TyParamBounds<'a> {
 impl fmt::Display for clean::Generics {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.lifetimes.is_empty() && self.type_params.is_empty() { return Ok(()) }
-        try!(f.write_str("&lt;"));
+        f.write_str("&lt;")?;
 
         for (i, life) in self.lifetimes.iter().enumerate() {
             if i > 0 {
-                try!(f.write_str(", "));
+                f.write_str(", ")?;
             }
-            try!(write!(f, "{}", *life));
+            write!(f, "{}", *life)?;
         }
 
         if !self.type_params.is_empty() {
             if !self.lifetimes.is_empty() {
-                try!(f.write_str(", "));
+                f.write_str(", ")?;
             }
             for (i, tp) in self.type_params.iter().enumerate() {
                 if i > 0 {
-                    try!(f.write_str(", "))
+                    f.write_str(", ")?
                 }
-                try!(f.write_str(&tp.name));
+                f.write_str(&tp.name)?;
 
                 if !tp.bounds.is_empty() {
-                    try!(write!(f, ": {}", TyParamBounds(&tp.bounds)));
+                    write!(f, ": {}", TyParamBounds(&tp.bounds))?;
                 }
 
                 match tp.default {
-                    Some(ref ty) => { try!(write!(f, " = {}", ty)); },
+                    Some(ref ty) => { write!(f, " = {}", ty)?; },
                     None => {}
                 };
             }
         }
-        try!(f.write_str("&gt;"));
+        f.write_str("&gt;")?;
         Ok(())
     }
 }
@@ -140,40 +140,40 @@ impl<'a> fmt::Display for WhereClause<'a> {
         if gens.where_predicates.is_empty() {
             return Ok(());
         }
-        try!(f.write_str(" <span class='where'>where "));
+        f.write_str(" <span class='where'>where ")?;
         for (i, pred) in gens.where_predicates.iter().enumerate() {
             if i > 0 {
-                try!(f.write_str(", "));
+                f.write_str(", ")?;
             }
             match pred {
                 &clean::WherePredicate::BoundPredicate { ref ty, ref bounds } => {
                     let bounds = bounds;
-                    try!(write!(f, "{}: {}", ty, TyParamBounds(bounds)));
+                    write!(f, "{}: {}", ty, TyParamBounds(bounds))?;
                 }
                 &clean::WherePredicate::RegionPredicate { ref lifetime,
                                                           ref bounds } => {
-                    try!(write!(f, "{}: ", lifetime));
+                    write!(f, "{}: ", lifetime)?;
                     for (i, lifetime) in bounds.iter().enumerate() {
                         if i > 0 {
-                            try!(f.write_str(" + "));
+                            f.write_str(" + ")?;
                         }
 
-                        try!(write!(f, "{}", lifetime));
+                        write!(f, "{}", lifetime)?;
                     }
                 }
                 &clean::WherePredicate::EqPredicate { ref lhs, ref rhs } => {
-                    try!(write!(f, "{} == {}", lhs, rhs));
+                    write!(f, "{} == {}", lhs, rhs)?;
                 }
             }
         }
-        try!(f.write_str("</span>"));
+        f.write_str("</span>")?;
         Ok(())
     }
 }
 
 impl fmt::Display for clean::Lifetime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(f.write_str(self.get_ref()));
+        f.write_str(self.get_ref())?;
         Ok(())
     }
 }
@@ -181,14 +181,14 @@ impl fmt::Display for clean::Lifetime {
 impl fmt::Display for clean::PolyTrait {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if !self.lifetimes.is_empty() {
-            try!(f.write_str("for&lt;"));
+            f.write_str("for&lt;")?;
             for (i, lt) in self.lifetimes.iter().enumerate() {
                 if i > 0 {
-                    try!(f.write_str(", "));
+                    f.write_str(", ")?;
                 }
-                try!(write!(f, "{}", lt));
+                write!(f, "{}", lt)?;
             }
-            try!(f.write_str("&gt; "));
+            f.write_str("&gt; ")?;
         }
         write!(f, "{}", self.trait_)
     }
@@ -218,46 +218,46 @@ impl fmt::Display for clean::PathParameters {
                 ref lifetimes, ref types, ref bindings
             } => {
                 if !lifetimes.is_empty() || !types.is_empty() || !bindings.is_empty() {
-                    try!(f.write_str("&lt;"));
+                    f.write_str("&lt;")?;
                     let mut comma = false;
                     for lifetime in lifetimes {
                         if comma {
-                            try!(f.write_str(", "));
+                            f.write_str(", ")?;
                         }
                         comma = true;
-                        try!(write!(f, "{}", *lifetime));
+                        write!(f, "{}", *lifetime)?;
                     }
                     for ty in types {
                         if comma {
-                            try!(f.write_str(", "));
+                            f.write_str(", ")?;
                         }
                         comma = true;
-                        try!(write!(f, "{}", *ty));
+                        write!(f, "{}", *ty)?;
                     }
                     for binding in bindings {
                         if comma {
-                            try!(f.write_str(", "));
+                            f.write_str(", ")?;
                         }
                         comma = true;
-                        try!(write!(f, "{}", *binding));
+                        write!(f, "{}", *binding)?;
                     }
-                    try!(f.write_str("&gt;"));
+                    f.write_str("&gt;")?;
                 }
             }
             clean::PathParameters::Parenthesized { ref inputs, ref output } => {
-                try!(f.write_str("("));
+                f.write_str("(")?;
                 let mut comma = false;
                 for ty in inputs {
                     if comma {
-                        try!(f.write_str(", "));
+                        f.write_str(", ")?;
                     }
                     comma = true;
-                    try!(write!(f, "{}", *ty));
+                    write!(f, "{}", *ty)?;
                 }
-                try!(f.write_str(")"));
+                f.write_str(")")?;
                 if let Some(ref ty) = *output {
-                    try!(f.write_str(" -&gt; "));
-                    try!(write!(f, "{}", ty));
+                    f.write_str(" -&gt; ")?;
+                    write!(f, "{}", ty)?;
                 }
             }
         }
@@ -267,7 +267,7 @@ impl fmt::Display for clean::PathParameters {
 
 impl fmt::Display for clean::PathSegment {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(f.write_str(&self.name));
+        f.write_str(&self.name)?;
         write!(f, "{}", self.params)
     }
 }
@@ -275,14 +275,14 @@ impl fmt::Display for clean::PathSegment {
 impl fmt::Display for clean::Path {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.global {
-            try!(f.write_str("::"))
+            f.write_str("::")?
         }
 
         for (i, seg) in self.segments.iter().enumerate() {
             if i > 0 {
-                try!(f.write_str("::"))
+                f.write_str("::")?
             }
-            try!(write!(f, "{}", seg));
+            write!(f, "{}", seg)?;
         }
         Ok(())
     }
@@ -339,20 +339,20 @@ fn resolved_path(w: &mut fmt::Formatter, did: DefId, path: &clean::Path,
             Some(mut root) => {
                 for seg in &path.segments[..amt] {
                     if "super" == seg.name || "self" == seg.name {
-                        try!(write!(w, "{}::", seg.name));
+                        write!(w, "{}::", seg.name)?;
                     } else {
                         root.push_str(&seg.name);
                         root.push_str("/");
-                        try!(write!(w, "<a class='mod'
+                        write!(w, "<a class='mod'
                                             href='{}index.html'>{}</a>::",
                                       root,
-                                      seg.name));
+                                      seg.name)?;
                     }
                 }
             }
             None => {
                 for seg in &path.segments[..amt] {
-                    try!(write!(w, "{}::", seg.name));
+                    write!(w, "{}::", seg.name)?;
                 }
             }
         }
@@ -360,12 +360,12 @@ fn resolved_path(w: &mut fmt::Formatter, did: DefId, path: &clean::Path,
 
     match href(did) {
         Some((url, shortty, fqp)) => {
-            try!(write!(w, "<a class='{}' href='{}' title='{}'>{}</a>",
-                          shortty, url, fqp.join("::"), last.name));
+            write!(w, "<a class='{}' href='{}' title='{}'>{}</a>",
+                          shortty, url, fqp.join("::"), last.name)?;
         }
-        _ => try!(write!(w, "{}", last.name)),
+        _ => write!(w, "{}", last.name)?,
     }
-    try!(write!(w, "{}", last.params));
+    write!(w, "{}", last.params)?;
     Ok(())
 }
 
@@ -378,9 +378,9 @@ fn primitive_link(f: &mut fmt::Formatter,
         Some(&LOCAL_CRATE) => {
             let len = CURRENT_LOCATION_KEY.with(|s| s.borrow().len());
             let len = if len == 0 {0} else {len - 1};
-            try!(write!(f, "<a class='primitive' href='{}primitive.{}.html'>",
+            write!(f, "<a class='primitive' href='{}primitive.{}.html'>",
                         repeat("../").take(len).collect::<String>(),
-                        prim.to_url_str()));
+                        prim.to_url_str())?;
             needs_termination = true;
         }
         Some(&cnum) => {
@@ -398,10 +398,10 @@ fn primitive_link(f: &mut fmt::Formatter,
             };
             match loc {
                 Some(root) => {
-                    try!(write!(f, "<a class='primitive' href='{}{}/primitive.{}.html'>",
+                    write!(f, "<a class='primitive' href='{}{}/primitive.{}.html'>",
                                 root,
                                 path.0.first().unwrap(),
-                                prim.to_url_str()));
+                                prim.to_url_str())?;
                     needs_termination = true;
                 }
                 None => {}
@@ -409,9 +409,9 @@ fn primitive_link(f: &mut fmt::Formatter,
         }
         None => {}
     }
-    try!(write!(f, "{}", name));
+    write!(f, "{}", name)?;
     if needs_termination {
-        try!(write!(f, "</a>"));
+        write!(f, "</a>")?;
     }
     Ok(())
 }
@@ -422,8 +422,8 @@ fn tybounds(w: &mut fmt::Formatter,
     match *typarams {
         Some(ref params) => {
             for param in params {
-                try!(write!(w, " + "));
-                try!(write!(w, "{}", *param));
+                write!(w, " + ")?;
+                write!(w, "{}", *param)?;
             }
             Ok(())
         }
@@ -439,7 +439,7 @@ impl fmt::Display for clean::Type {
             }
             clean::ResolvedPath{ did, ref typarams, ref path, is_generic } => {
                 // Paths like T::Output and Self::Output should be rendered with all segments
-                try!(resolved_path(f, did, path, is_generic));
+                resolved_path(f, did, path, is_generic)?;
                 tybounds(f, typarams)
             }
             clean::Infer => write!(f, "_"),
@@ -459,25 +459,25 @@ impl fmt::Display for clean::Type {
                 match &**typs {
                     [] => primitive_link(f, clean::PrimitiveTuple, "()"),
                     [ref one] => {
-                        try!(primitive_link(f, clean::PrimitiveTuple, "("));
-                        try!(write!(f, "{},", one));
+                        primitive_link(f, clean::PrimitiveTuple, "(")?;
+                        write!(f, "{},", one)?;
                         primitive_link(f, clean::PrimitiveTuple, ")")
                     }
                     many => {
-                        try!(primitive_link(f, clean::PrimitiveTuple, "("));
-                        try!(write!(f, "{}", CommaSep(&many)));
+                        primitive_link(f, clean::PrimitiveTuple, "(")?;
+                        write!(f, "{}", CommaSep(&many))?;
                         primitive_link(f, clean::PrimitiveTuple, ")")
                     }
                 }
             }
             clean::Vector(ref t) => {
-                try!(primitive_link(f, clean::Slice, &format!("[")));
-                try!(write!(f, "{}", t));
+                primitive_link(f, clean::Slice, &format!("["))?;
+                write!(f, "{}", t)?;
                 primitive_link(f, clean::Slice, &format!("]"))
             }
             clean::FixedVector(ref t, ref s) => {
-                try!(primitive_link(f, clean::PrimitiveType::Array, "["));
-                try!(write!(f, "{}", t));
+                primitive_link(f, clean::PrimitiveType::Array, "[")?;
+                write!(f, "{}", t)?;
                 primitive_link(f, clean::PrimitiveType::Array,
                                &format!("; {}]", *s))
             }
@@ -489,8 +489,8 @@ impl fmt::Display for clean::Type {
                                        &format!("*{}{}", RawMutableSpace(m), t))
                     }
                     _ => {
-                        try!(primitive_link(f, clean::PrimitiveType::PrimitiveRawPointer,
-                                            &format!("*{}", RawMutableSpace(m))));
+                        primitive_link(f, clean::PrimitiveType::PrimitiveRawPointer,
+                                            &format!("*{}", RawMutableSpace(m)))?;
                         write!(f, "{}", t)
                     }
                 }
@@ -508,9 +508,9 @@ impl fmt::Display for clean::Type {
                                 primitive_link(f, clean::Slice,
                                     &format!("&amp;{}{}[{}]", lt, m, **bt)),
                             _ => {
-                                try!(primitive_link(f, clean::Slice,
-                                    &format!("&amp;{}{}[", lt, m)));
-                                try!(write!(f, "{}", **bt));
+                                primitive_link(f, clean::Slice,
+                                    &format!("&amp;{}{}[", lt, m))?;
+                                write!(f, "{}", **bt)?;
                                 primitive_link(f, clean::Slice, "]")
                             }
                         }
@@ -523,9 +523,9 @@ impl fmt::Display for clean::Type {
             clean::PolyTraitRef(ref bounds) => {
                 for (i, bound) in bounds.iter().enumerate() {
                     if i != 0 {
-                        try!(write!(f, " + "));
+                        write!(f, " + ")?;
                     }
-                    try!(write!(f, "{}", *bound));
+                    write!(f, "{}", *bound)?;
                 }
                 Ok(())
             }
@@ -544,9 +544,9 @@ impl fmt::Display for clean::Type {
                 ref self_type,
                 trait_: box clean::ResolvedPath { did, ref typarams, .. },
             } => {
-                try!(write!(f, "{}::", self_type));
+                write!(f, "{}::", self_type)?;
                 let path = clean::Path::singleton(name.clone());
-                try!(resolved_path(f, did, &path, false));
+                resolved_path(f, did, &path, false)?;
 
                 // FIXME: `typarams` are not rendered, and this seems bad?
                 drop(typarams);
@@ -564,13 +564,13 @@ impl fmt::Display for clean::Type {
 
 impl fmt::Display for clean::Impl {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "impl{} ", self.generics));
+        write!(f, "impl{} ", self.generics)?;
         if let Some(ref ty) = self.trait_ {
-            try!(write!(f, "{}{} for ",
+            write!(f, "{}{} for ",
                         if self.polarity == Some(clean::ImplPolarity::Negative) { "!" } else { "" },
-                        *ty));
+                        *ty)?;
         }
-        try!(write!(f, "{}{}", self.for_, WhereClause(&self.generics)));
+        write!(f, "{}{}", self.for_, WhereClause(&self.generics))?;
         Ok(())
     }
 }
@@ -578,11 +578,11 @@ impl fmt::Display for clean::Impl {
 impl fmt::Display for clean::Arguments {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for (i, input) in self.values.iter().enumerate() {
-            if i > 0 { try!(write!(f, ", ")); }
+            if i > 0 { write!(f, ", ")?; }
             if !input.name.is_empty() {
-                try!(write!(f, "{}: ", input.name));
+                write!(f, "{}: ", input.name)?;
             }
-            try!(write!(f, "{}", input.type_));
+            write!(f, "{}", input.type_)?;
         }
         Ok(())
     }
@@ -678,12 +678,12 @@ impl fmt::Display for clean::Import {
                 write!(f, "use {}::*;", *src)
             }
             clean::ImportList(ref src, ref names) => {
-                try!(write!(f, "use {}::{{", *src));
+                write!(f, "use {}::{{", *src)?;
                 for (i, n) in names.iter().enumerate() {
                     if i > 0 {
-                        try!(write!(f, ", "));
+                        write!(f, ", ")?;
                     }
-                    try!(write!(f, "{}", *n));
+                    write!(f, "{}", *n)?;
                 }
                 write!(f, "}};")
             }
@@ -698,9 +698,9 @@ impl fmt::Display for clean::ImportSource {
             _ => {
                 for (i, seg) in self.path.segments.iter().enumerate() {
                     if i > 0 {
-                        try!(write!(f, "::"))
+                        write!(f, "::")?
                     }
-                    try!(write!(f, "{}", seg.name));
+                    write!(f, "{}", seg.name)?;
                 }
                 Ok(())
             }
@@ -713,13 +713,13 @@ impl fmt::Display for clean::ViewListIdent {
         match self.source {
             Some(did) => {
                 let path = clean::Path::singleton(self.name.clone());
-                try!(resolved_path(f, did, &path, false));
+                resolved_path(f, did, &path, false)?;
             }
-            _ => try!(write!(f, "{}", self.name)),
+            _ => write!(f, "{}", self.name)?,
         }
 
         if let Some(ref name) = self.rename {
-            try!(write!(f, " as {}", name));
+            write!(f, " as {}", name)?;
         }
         Ok(())
     }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -344,9 +344,9 @@ fn resolved_path(w: &mut fmt::Formatter, did: DefId, path: &clean::Path,
                         root.push_str(&seg.name);
                         root.push_str("/");
                         write!(w, "<a class='mod'
-                                            href='{}index.html'>{}</a>::",
-                                      root,
-                                      seg.name)?;
+                                       href='{}index.html'>{}</a>::",
+                                 root,
+                                 seg.name)?;
                     }
                 }
             }
@@ -361,7 +361,7 @@ fn resolved_path(w: &mut fmt::Formatter, did: DefId, path: &clean::Path,
     match href(did) {
         Some((url, shortty, fqp)) => {
             write!(w, "<a class='{}' href='{}' title='{}'>{}</a>",
-                          shortty, url, fqp.join("::"), last.name)?;
+                   shortty, url, fqp.join("::"), last.name)?;
         }
         _ => write!(w, "{}", last.name)?,
     }
@@ -379,8 +379,8 @@ fn primitive_link(f: &mut fmt::Formatter,
             let len = CURRENT_LOCATION_KEY.with(|s| s.borrow().len());
             let len = if len == 0 {0} else {len - 1};
             write!(f, "<a class='primitive' href='{}primitive.{}.html'>",
-                        repeat("../").take(len).collect::<String>(),
-                        prim.to_url_str())?;
+                   repeat("../").take(len).collect::<String>(),
+                   prim.to_url_str())?;
             needs_termination = true;
         }
         Some(&cnum) => {
@@ -399,9 +399,9 @@ fn primitive_link(f: &mut fmt::Formatter,
             match loc {
                 Some(root) => {
                     write!(f, "<a class='primitive' href='{}{}/primitive.{}.html'>",
-                                root,
-                                path.0.first().unwrap(),
-                                prim.to_url_str())?;
+                           root,
+                           path.0.first().unwrap(),
+                           prim.to_url_str())?;
                     needs_termination = true;
                 }
                 None => {}
@@ -490,7 +490,7 @@ impl fmt::Display for clean::Type {
                     }
                     _ => {
                         primitive_link(f, clean::PrimitiveType::PrimitiveRawPointer,
-                                            &format!("*{}", RawMutableSpace(m)))?;
+                                       &format!("*{}", RawMutableSpace(m)))?;
                         write!(f, "{}", t)
                     }
                 }
@@ -508,8 +508,7 @@ impl fmt::Display for clean::Type {
                                 primitive_link(f, clean::Slice,
                                     &format!("&amp;{}{}[{}]", lt, m, **bt)),
                             _ => {
-                                primitive_link(f, clean::Slice,
-                                    &format!("&amp;{}{}[", lt, m))?;
+                                primitive_link(f, clean::Slice, &format!("&amp;{}{}[", lt, m))?;
                                 write!(f, "{}", **bt)?;
                                 primitive_link(f, clean::Slice, "]")
                             }
@@ -567,8 +566,8 @@ impl fmt::Display for clean::Impl {
         write!(f, "impl{} ", self.generics)?;
         if let Some(ref ty) = self.trait_ {
             write!(f, "{}{} for ",
-                        if self.polarity == Some(clean::ImplPolarity::Negative) { "!" } else { "" },
-                        *ty)?;
+                   if self.polarity == Some(clean::ImplPolarity::Negative) { "!" } else { "" },
+                   *ty)?;
         }
         write!(f, "{}{}", self.for_, WhereClause(&self.generics))?;
         Ok(())

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -48,12 +48,12 @@ fn doit(sess: &parse::ParseSess, mut lexer: lexer::StringReader,
         out: &mut Write) -> io::Result<()> {
     use syntax::parse::lexer::Reader;
 
-    try!(write!(out, "<pre "));
+    write!(out, "<pre ")?;
     match id {
-        Some(id) => try!(write!(out, "id='{}' ", id)),
+        Some(id) => write!(out, "id='{}' ", id)?,
         None => {}
     }
-    try!(write!(out, "class='rust {}'>\n", class.unwrap_or("")));
+    write!(out, "class='rust {}'>\n", class.unwrap_or(""))?;
     let mut is_attribute = false;
     let mut is_macro = false;
     let mut is_macro_nonterminal = false;
@@ -66,16 +66,16 @@ fn doit(sess: &parse::ParseSess, mut lexer: lexer::StringReader,
 
         let klass = match next.tok {
             token::Whitespace => {
-                try!(write!(out, "{}", Escape(&snip(next.sp))));
+                write!(out, "{}", Escape(&snip(next.sp)))?;
                 continue
             },
             token::Comment => {
-                try!(write!(out, "<span class='comment'>{}</span>",
-                            Escape(&snip(next.sp))));
+                write!(out, "<span class='comment'>{}</span>",
+                            Escape(&snip(next.sp)))?;
                 continue
             },
             token::Shebang(s) => {
-                try!(write!(out, "{}", Escape(&s.as_str())));
+                write!(out, "{}", Escape(&s.as_str()))?;
                 continue
             },
             // If this '&' token is directly adjacent to another token, assume
@@ -114,13 +114,13 @@ fn doit(sess: &parse::ParseSess, mut lexer: lexer::StringReader,
             // span when we see the ']'.
             token::Pound => {
                 is_attribute = true;
-                try!(write!(out, r"<span class='attribute'>#"));
+                write!(out, r"<span class='attribute'>#")?;
                 continue
             }
             token::CloseDelim(token::Bracket) => {
                 if is_attribute {
                     is_attribute = false;
-                    try!(write!(out, "]</span>"));
+                    write!(out, "]</span>")?;
                     continue
                 } else {
                     ""
@@ -178,10 +178,10 @@ fn doit(sess: &parse::ParseSess, mut lexer: lexer::StringReader,
         // stringifying this token
         let snip = sess.codemap().span_to_snippet(next.sp).unwrap();
         if klass == "" {
-            try!(write!(out, "{}", Escape(&snip)));
+            write!(out, "{}", Escape(&snip))?;
         } else {
-            try!(write!(out, "<span class='{}'>{}</span>", klass,
-                          Escape(&snip)));
+            write!(out, "<span class='{}'>{}</span>", klass,
+                          Escape(&snip))?;
         }
     }
 

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -71,7 +71,7 @@ fn doit(sess: &parse::ParseSess, mut lexer: lexer::StringReader,
             },
             token::Comment => {
                 write!(out, "<span class='comment'>{}</span>",
-                            Escape(&snip(next.sp)))?;
+                       Escape(&snip(next.sp)))?;
                 continue
             },
             token::Shebang(s) => {
@@ -180,8 +180,7 @@ fn doit(sess: &parse::ParseSess, mut lexer: lexer::StringReader,
         if klass == "" {
             write!(out, "{}", Escape(&snip))?;
         } else {
-            write!(out, "<span class='{}'>{}</span>", klass,
-                          Escape(&snip))?;
+            write!(out, "<span class='{}'>{}</span>", klass, Escape(&snip))?;
         }
     }
 

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -630,45 +630,45 @@ fn write_shared(cx: &Context,
     // Add all the static files. These may already exist, but we just
     // overwrite them anyway to make sure that they're fresh and up-to-date.
     write(cx.dst.join("jquery.js"),
-               include_bytes!("static/jquery-2.1.4.min.js"))?;
+          include_bytes!("static/jquery-2.1.4.min.js"))?;
     write(cx.dst.join("main.js"),
-               include_bytes!("static/main.js"))?;
+          include_bytes!("static/main.js"))?;
     write(cx.dst.join("playpen.js"),
-               include_bytes!("static/playpen.js"))?;
+          include_bytes!("static/playpen.js"))?;
     write(cx.dst.join("rustdoc.css"),
-               include_bytes!("static/rustdoc.css"))?;
+          include_bytes!("static/rustdoc.css"))?;
     write(cx.dst.join("main.css"),
-               include_bytes!("static/styles/main.css"))?;
+          include_bytes!("static/styles/main.css"))?;
     write(cx.dst.join("normalize.css"),
-               include_bytes!("static/normalize.css"))?;
+          include_bytes!("static/normalize.css"))?;
     write(cx.dst.join("FiraSans-Regular.woff"),
-               include_bytes!("static/FiraSans-Regular.woff"))?;
+          include_bytes!("static/FiraSans-Regular.woff"))?;
     write(cx.dst.join("FiraSans-Medium.woff"),
-               include_bytes!("static/FiraSans-Medium.woff"))?;
+          include_bytes!("static/FiraSans-Medium.woff"))?;
     write(cx.dst.join("FiraSans-LICENSE.txt"),
-               include_bytes!("static/FiraSans-LICENSE.txt"))?;
+          include_bytes!("static/FiraSans-LICENSE.txt"))?;
     write(cx.dst.join("Heuristica-Italic.woff"),
-               include_bytes!("static/Heuristica-Italic.woff"))?;
+          include_bytes!("static/Heuristica-Italic.woff"))?;
     write(cx.dst.join("Heuristica-LICENSE.txt"),
-               include_bytes!("static/Heuristica-LICENSE.txt"))?;
+          include_bytes!("static/Heuristica-LICENSE.txt"))?;
     write(cx.dst.join("SourceSerifPro-Regular.woff"),
-               include_bytes!("static/SourceSerifPro-Regular.woff"))?;
+          include_bytes!("static/SourceSerifPro-Regular.woff"))?;
     write(cx.dst.join("SourceSerifPro-Bold.woff"),
-               include_bytes!("static/SourceSerifPro-Bold.woff"))?;
+          include_bytes!("static/SourceSerifPro-Bold.woff"))?;
     write(cx.dst.join("SourceSerifPro-LICENSE.txt"),
-               include_bytes!("static/SourceSerifPro-LICENSE.txt"))?;
+          include_bytes!("static/SourceSerifPro-LICENSE.txt"))?;
     write(cx.dst.join("SourceCodePro-Regular.woff"),
-               include_bytes!("static/SourceCodePro-Regular.woff"))?;
+          include_bytes!("static/SourceCodePro-Regular.woff"))?;
     write(cx.dst.join("SourceCodePro-Semibold.woff"),
-               include_bytes!("static/SourceCodePro-Semibold.woff"))?;
+          include_bytes!("static/SourceCodePro-Semibold.woff"))?;
     write(cx.dst.join("SourceCodePro-LICENSE.txt"),
-               include_bytes!("static/SourceCodePro-LICENSE.txt"))?;
+          include_bytes!("static/SourceCodePro-LICENSE.txt"))?;
     write(cx.dst.join("LICENSE-MIT.txt"),
-               include_bytes!("static/LICENSE-MIT.txt"))?;
+          include_bytes!("static/LICENSE-MIT.txt"))?;
     write(cx.dst.join("LICENSE-APACHE.txt"),
-               include_bytes!("static/LICENSE-APACHE.txt"))?;
+          include_bytes!("static/LICENSE-APACHE.txt"))?;
     write(cx.dst.join("COPYRIGHT.txt"),
-               include_bytes!("static/COPYRIGHT.txt"))?;
+          include_bytes!("static/COPYRIGHT.txt"))?;
 
     fn collect(path: &Path, krate: &str,
                key: &str) -> io::Result<Vec<String>> {
@@ -925,7 +925,7 @@ impl<'a> SourceCollector<'a> {
             keywords: BASIC_KEYWORDS,
         };
         layout::render(&mut w, &self.cx.layout,
-                            &page, &(""), &Source(contents))?;
+                       &page, &(""), &Source(contents))?;
         w.flush()?;
         self.cx.local_sources.insert(p, href);
         Ok(())
@@ -1290,8 +1290,8 @@ impl Context {
             let mut writer = BufWriter::new(w);
             if !cx.render_redirect_pages {
                 layout::render(&mut writer, &cx.layout, &page,
-                                    &Sidebar{ cx: cx, item: it },
-                                    &Item{ cx: cx, item: it })?;
+                               &Sidebar{ cx: cx, item: it },
+                               &Item{ cx: cx, item: it })?;
             } else {
                 let mut url = repeat("../").take(cx.current.len())
                                            .collect::<String>();
@@ -1515,22 +1515,22 @@ impl<'a> fmt::Display for Item<'a> {
             let amt = if self.ismodule() { cur.len() - 1 } else { cur.len() };
             for (i, component) in cur.iter().enumerate().take(amt) {
                 write!(fmt, "<a href='{}index.html'>{}</a>::<wbr>",
-                            repeat("../").take(cur.len() - i - 1)
-                                         .collect::<String>(),
-                            component)?;
+                       repeat("../").take(cur.len() - i - 1)
+                                    .collect::<String>(),
+                       component)?;
             }
         }
         write!(fmt, "<a class='{}' href=''>{}</a>",
-                    shortty(self.item), self.item.name.as_ref().unwrap())?;
+               shortty(self.item), self.item.name.as_ref().unwrap())?;
 
         write!(fmt, "</span>")?; // in-band
         write!(fmt, "<span class='out-of-band'>")?;
         write!(fmt,
-        r##"<span id='render-detail'>
-            <a id="toggle-all-docs" href="javascript:void(0)" title="collapse all docs">
-                [<span class='inner'>&#x2212;</span>]
-            </a>
-        </span>"##)?;
+               r##"<span id='render-detail'>
+                   <a id="toggle-all-docs" href="javascript:void(0)" title="collapse all docs">
+                       [<span class='inner'>&#x2212;</span>]
+                   </a>
+               </span>"##)?;
 
         // Write `src` tag
         //
@@ -1541,8 +1541,8 @@ impl<'a> fmt::Display for Item<'a> {
         if self.cx.include_sources && !is_primitive {
             if let Some(l) = self.href() {
                 write!(fmt, "<a id='src-{}' class='srclink' \
-                                   href='{}' title='{}'>[src]</a>",
-                            self.item.def_id.index.as_usize(), l, "goto source code")?;
+                              href='{}' title='{}'>[src]</a>",
+                       self.item.def_id.index.as_usize(), l, "goto source code")?;
             }
         }
 
@@ -1698,8 +1698,8 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
                 ItemType::AssociatedConst => ("associated-consts", "Associated Constants"),
             };
             write!(w, "<h2 id='{id}' class='section-header'>\
-                           <a href=\"#{id}\">{name}</a></h2>\n<table>",
-                           id = derive_id(short.to_owned()), name = name)?;
+                       <a href=\"#{id}\">{name}</a></h2>\n<table>",
+                   id = derive_id(short.to_owned()), name = name)?;
         }
 
         match myitem.inner {
@@ -1707,13 +1707,13 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
                 match *src {
                     Some(ref src) => {
                         write!(w, "<tr><td><code>{}extern crate {} as {};",
-                                    VisSpace(myitem.visibility),
-                                    src,
-                                    name)?
+                               VisSpace(myitem.visibility),
+                               src,
+                               name)?
                     }
                     None => {
                         write!(w, "<tr><td><code>{}extern crate {};",
-                                    VisSpace(myitem.visibility), name)?
+                               VisSpace(myitem.visibility), name)?
                     }
                 }
                 write!(w, "</code></td></tr>")?;
@@ -1721,7 +1721,7 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
 
             clean::ImportItem(ref import) => {
                 write!(w, "<tr><td><code>{}{}</code></td></tr>",
-                            VisSpace(myitem.visibility), *import)?;
+                       VisSpace(myitem.visibility), *import)?;
             }
 
             _ => {
@@ -1733,21 +1733,20 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
                 };
                 let doc_value = myitem.doc_value().unwrap_or("");
                 write!(w, "
-                    <tr class='{stab} module-item'>
-                        <td><a class='{class}' href='{href}'
-                               title='{title}'>{name}</a></td>
-                        <td class='docblock short'>
-                            {stab_docs} {docs}
-                        </td>
-                    </tr>
-                ",
-                name = *myitem.name.as_ref().unwrap(),
-                stab_docs = stab_docs,
-                docs = shorter(Some(&Markdown(doc_value).to_string())),
-                class = shortty(myitem),
-                stab = myitem.stability_class(),
-                href = item_path(myitem),
-                title = full_path(cx, myitem))?;
+                       <tr class='{stab} module-item'>
+                           <td><a class='{class}' href='{href}'
+                                  title='{title}'>{name}</a></td>
+                           <td class='docblock short'>
+                               {stab_docs} {docs}
+                           </td>
+                       </tr>",
+                       name = *myitem.name.as_ref().unwrap(),
+                       stab_docs = stab_docs,
+                       docs = shorter(Some(&Markdown(doc_value).to_string())),
+                       class = shortty(myitem),
+                       stab = myitem.stability_class(),
+                       href = item_path(myitem),
+                       title = full_path(cx, myitem))?;
             }
         }
     }
@@ -1824,7 +1823,7 @@ impl<'a> fmt::Display for Initializer<'a> {
 fn item_constant(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                  c: &clean::Constant) -> fmt::Result {
     write!(w, "<pre class='rust const'>{vis}const \
-                    {name}: {typ}{init}</pre>",
+               {name}: {typ}{init}</pre>",
            vis = VisSpace(it.visibility),
            name = it.name.as_ref().unwrap(),
            typ = c.type_,
@@ -1835,7 +1834,7 @@ fn item_constant(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
 fn item_static(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                s: &clean::Static) -> fmt::Result {
     write!(w, "<pre class='rust static'>{vis}static {mutability}\
-                    {name}: {typ}{init}</pre>",
+               {name}: {typ}{init}</pre>",
            vis = VisSpace(it.visibility),
            mutability = MutableSpace(s.mutability),
            name = it.name.as_ref().unwrap(),
@@ -1851,7 +1850,7 @@ fn item_function(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
         _ => hir::Constness::NotConst
     };
     write!(w, "<pre class='rust fn'>{vis}{constness}{unsafety}{abi}fn \
-                    {name}{generics}{decl}{where_clause}</pre>",
+               {name}{generics}{decl}{where_clause}</pre>",
            vis = VisSpace(it.visibility),
            constness = ConstnessSpace(vis_constness),
            unsafety = UnsafetySpace(f.unsafety),
@@ -1880,12 +1879,12 @@ fn item_trait(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
 
     // Output the trait definition
     write!(w, "<pre class='rust trait'>{}{}trait {}{}{}{} ",
-                  VisSpace(it.visibility),
-                  UnsafetySpace(t.unsafety),
-                  it.name.as_ref().unwrap(),
-                  t.generics,
-                  bounds,
-                  WhereClause(&t.generics))?;
+           VisSpace(it.visibility),
+           UnsafetySpace(t.unsafety),
+           it.name.as_ref().unwrap(),
+           t.generics,
+           bounds,
+           WhereClause(&t.generics))?;
 
     let types = t.items.iter().filter(|m| m.is_associated_type()).collect::<Vec<_>>();
     let consts = t.items.iter().filter(|m| m.is_associated_const()).collect::<Vec<_>>();
@@ -1937,8 +1936,8 @@ fn item_trait(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
         let name = m.name.as_ref().unwrap();
         let id = derive_id(format!("{}.{}", shortty(m), name));
         write!(w, "<h3 id='{id}' class='method stab {stab}'><code>",
-                       id = id,
-                       stab = m.stability_class())?;
+               id = id,
+               stab = m.stability_class())?;
         render_assoc_item(w, m, AssocItemLink::Anchor)?;
         write!(w, "</code>")?;
         render_stability_since(w, m, t)?;
@@ -2009,17 +2008,17 @@ fn item_trait(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
     }
     write!(w, "</ul>")?;
     write!(w, r#"<script type="text/javascript" async
-                              src="{root_path}/implementors/{path}/{ty}.{name}.js">
-                      </script>"#,
-                root_path = vec![".."; cx.current.len()].join("/"),
-                path = if it.def_id.is_local() {
-                    cx.current.join("/")
-                } else {
-                    let path = &cache.external_paths[&it.def_id];
-                    path[..path.len() - 1].join("/")
-                },
-                ty = shortty(it).to_static_str(),
-                name = *it.name.as_ref().unwrap())?;
+                         src="{root_path}/implementors/{path}/{ty}.{name}.js">
+                 </script>"#,
+           root_path = vec![".."; cx.current.len()].join("/"),
+           path = if it.def_id.is_local() {
+               cx.current.join("/")
+           } else {
+               let path = &cache.external_paths[&it.def_id];
+               path[..path.len() - 1].join("/")
+           },
+           ty = shortty(it).to_static_str(),
+           name = *it.name.as_ref().unwrap())?;
     Ok(())
 }
 
@@ -2054,7 +2053,7 @@ fn render_stability_since_raw<'a>(w: &mut fmt::Formatter,
     if let Some(v) = ver {
         if containing_ver != ver && v.len() > 0 {
             write!(w, "<span class=\"since\">{}</span>",
-                        v)?
+                   v)?
         }
     }
     Ok(())
@@ -2131,12 +2130,12 @@ fn item_struct(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
     write!(w, "<pre class='rust struct'>")?;
     render_attributes(w, it)?;
     render_struct(w,
-                       it,
-                       Some(&s.generics),
-                       s.struct_type,
-                       &s.fields,
-                       "",
-                       true)?;
+                  it,
+                  Some(&s.generics),
+                  s.struct_type,
+                  &s.fields,
+                  "",
+                  true)?;
     write!(w, "</pre>")?;
     render_stability_since_raw(w, it.stable_since(), None)?;
 
@@ -2153,10 +2152,10 @@ fn item_struct(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
             write!(w, "<h2 class='fields'>Fields</h2>\n<table>")?;
             for field in fields {
                 write!(w, "<tr class='stab {stab}'>
-                                  <td id='structfield.{name}'>\
-                                    <code>{name}</code></td><td>",
-                            stab = field.stability_class(),
-                            name = field.name.as_ref().unwrap())?;
+                             <td id='structfield.{name}'>\
+                               <code>{name}</code></td><td>",
+                       stab = field.stability_class(),
+                       name = field.name.as_ref().unwrap())?;
                 document(w, cx, field)?;
                 write!(w, "</td></tr>")?;
             }
@@ -2171,10 +2170,10 @@ fn item_enum(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
     write!(w, "<pre class='rust enum'>")?;
     render_attributes(w, it)?;
     write!(w, "{}enum {}{}{}",
-                  VisSpace(it.visibility),
-                  it.name.as_ref().unwrap(),
-                  e.generics,
-                  WhereClause(&e.generics))?;
+           VisSpace(it.visibility),
+           it.name.as_ref().unwrap(),
+           e.generics,
+           WhereClause(&e.generics))?;
     if e.variants.is_empty() && !e.variants_stripped {
         write!(w, " {{}}")?;
     } else {
@@ -2198,12 +2197,12 @@ fn item_enum(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                         }
                         clean::StructVariant(ref s) => {
                             render_struct(w,
-                                               v,
-                                               None,
-                                               s.struct_type,
-                                               &s.fields,
-                                               "    ",
-                                               false)?;
+                                          v,
+                                          None,
+                                          s.struct_type,
+                                          &s.fields,
+                                          "    ",
+                                          false)?;
                         }
                     }
                 }
@@ -2225,7 +2224,7 @@ fn item_enum(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
         write!(w, "<h2 class='variants'>Variants</h2>\n<table class='variants_table'>")?;
         for variant in &e.variants {
             write!(w, "<tr><td id='variant.{name}'><code>{name}</code></td><td>",
-                          name = variant.name.as_ref().unwrap())?;
+                   name = variant.name.as_ref().unwrap())?;
             document(w, cx, variant)?;
 
             use clean::{Variant, StructVariant};
@@ -2237,13 +2236,13 @@ fn item_enum(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                     }
                 });
                 write!(w, "<h3 class='fields'>Fields</h3>\n
-                                  <table>")?;
+                           <table>")?;
                 for field in fields {
                     write!(w, "<tr><td \
-                                      id='variant.{v}.field.{f}'>\
-                                      <code>{f}</code></td><td>",
-                                  v = variant.name.as_ref().unwrap(),
-                                  f = field.name.as_ref().unwrap())?;
+                               id='variant.{v}.field.{f}'>\
+                               <code>{f}</code></td><td>",
+                           v = variant.name.as_ref().unwrap(),
+                           f = field.name.as_ref().unwrap())?;
                     document(w, cx, field)?;
                     write!(w, "</td></tr>")?;
                 }
@@ -2281,9 +2280,9 @@ fn render_struct(w: &mut fmt::Formatter, it: &clean::Item,
                  tab: &str,
                  structhead: bool) -> fmt::Result {
     write!(w, "{}{}{}",
-                  VisSpace(it.visibility),
-                  if structhead {"struct "} else {""},
-                  it.name.as_ref().unwrap())?;
+           VisSpace(it.visibility),
+           if structhead {"struct "} else {""},
+           it.name.as_ref().unwrap())?;
     if let Some(g) = g {
         write!(w, "{}{}", *g, WhereClause(g))?
     }
@@ -2298,10 +2297,10 @@ fn render_struct(w: &mut fmt::Formatter, it: &clean::Item,
                     }
                     clean::StructFieldItem(clean::TypedStructField(ref ty)) => {
                         write!(w, "    {}{}: {},\n{}",
-                                      VisSpace(field.visibility),
-                                      field.name.as_ref().unwrap(),
-                                      *ty,
-                                      tab)?;
+                               VisSpace(field.visibility),
+                               field.name.as_ref().unwrap(),
+                               *ty,
+                               tab)?;
                     }
                     _ => unreachable!(),
                 };
@@ -2369,13 +2368,13 @@ fn render_assoc_items(w: &mut fmt::Formatter,
             }
             AssocItemRender::DerefFor { trait_, type_ } => {
                 write!(w, "<h2 id='deref-methods'>Methods from \
-                                    {}&lt;Target={}&gt;</h2>", trait_, type_)?;
+                               {}&lt;Target={}&gt;</h2>", trait_, type_)?;
                 false
             }
         };
         for i in &non_trait {
             render_impl(w, cx, i, AssocItemLink::Anchor, render_header,
-                             containing_item.stable_since())?;
+                        containing_item.stable_since())?;
         }
     }
     if let AssocItemRender::DerefFor { .. } = what {
@@ -2394,23 +2393,23 @@ fn render_assoc_items(w: &mut fmt::Formatter,
             render_deref_methods(w, cx, impl_, containing_item)?;
         }
         write!(w, "<h2 id='implementations'>Trait \
-                          Implementations</h2>")?;
+                   Implementations</h2>")?;
         let (derived, manual): (Vec<_>, Vec<&Impl>) = traits.iter().partition(|i| {
             i.impl_.derived
         });
         for i in &manual {
             let did = i.trait_did().unwrap();
             render_impl(w, cx, i, AssocItemLink::GotoSource(did), true,
-                             containing_item.stable_since())?;
+                        containing_item.stable_since())?;
         }
         if !derived.is_empty() {
             write!(w, "<h3 id='derived_implementations'>\
-                Derived Implementations \
-            </h3>")?;
+                           Derived Implementations \
+                       </h3>")?;
             for i in &derived {
                 let did = i.trait_did().unwrap();
                 render_impl(w, cx, i, AssocItemLink::GotoSource(did), true,
-                                 containing_item.stable_since())?;
+                            containing_item.stable_since())?;
             }
         }
     }
@@ -2533,7 +2532,7 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
             }
 
             doctraititem(w, cx, trait_item, AssocItemLink::GotoSource(did), render_static,
-                              outer_version)?;
+                         outer_version)?;
         }
         Ok(())
     }
@@ -2554,10 +2553,10 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
 fn item_typedef(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                 t: &clean::Typedef) -> fmt::Result {
     write!(w, "<pre class='rust typedef'>type {}{}{where_clause} = {type_};</pre>",
-                  it.name.as_ref().unwrap(),
-                  t.generics,
-                  where_clause = WhereClause(&t.generics),
-                  type_ = t.type_)?;
+           it.name.as_ref().unwrap(),
+           t.generics,
+           where_clause = WhereClause(&t.generics),
+           type_ = t.type_)?;
 
     document(w, cx, it)
 }
@@ -2582,28 +2581,28 @@ impl<'a> fmt::Display for Sidebar<'a> {
                 write!(fmt, "::<wbr>")?;
             }
             write!(fmt, "<a href='{}index.html'>{}</a>",
-                          &cx.root_path[..(cx.current.len() - i - 1) * 3],
-                          *name)?;
+                   &cx.root_path[..(cx.current.len() - i - 1) * 3],
+                   *name)?;
         }
         write!(fmt, "</p>")?;
 
         // sidebar refers to the enclosing module, not this module
         let relpath = if it.is_mod() { "../" } else { "" };
         write!(fmt,
-                    "<script>window.sidebarCurrent = {{\
-                        name: '{name}', \
-                        ty: '{ty}', \
-                        relpath: '{path}'\
-                     }};</script>",
-                    name = it.name.as_ref().map(|x| &x[..]).unwrap_or(""),
-                    ty = shortty(it).to_static_str(),
-                    path = relpath)?;
+               "<script>window.sidebarCurrent = {{\
+                   name: '{name}', \
+                   ty: '{ty}', \
+                   relpath: '{path}'\
+                }};</script>",
+               name = it.name.as_ref().map(|x| &x[..]).unwrap_or(""),
+               ty = shortty(it).to_static_str(),
+               path = relpath)?;
         if parentlen == 0 {
             // there is no sidebar-items.js beyond the crate root path
             // FIXME maybe dynamic crate loading can be merged here
         } else {
             write!(fmt, "<script defer src=\"{path}sidebar-items.js\"></script>",
-                        path = relpath)?;
+                   path = relpath)?;
         }
 
         Ok(())
@@ -2633,8 +2632,8 @@ impl<'a> fmt::Display for Source<'a> {
 fn item_macro(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
               t: &clean::Macro) -> fmt::Result {
     w.write_str(&highlight::highlight(&t.source,
-                                          Some("macro"),
-                                          None))?;
+                                      Some("macro"),
+                                      None))?;
     render_stability_since_raw(w, it.stable_since(), None)?;
     document(w, cx, it)
 }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -535,8 +535,8 @@ pub fn run(mut krate: clean::Crate,
     CACHE_KEY.with(|v| *v.borrow_mut() = cache.clone());
     CURRENT_LOCATION_KEY.with(|s| s.borrow_mut().clear());
 
-    try!(write_shared(&cx, &krate, &*cache, index));
-    let krate = try!(render_sources(&mut cx, krate));
+    write_shared(&cx, &krate, &*cache, index)?;
+    let krate = render_sources(&mut cx, krate)?;
 
     // And finally render the whole crate's documentation
     cx.krate(krate)
@@ -629,53 +629,53 @@ fn write_shared(cx: &Context,
 
     // Add all the static files. These may already exist, but we just
     // overwrite them anyway to make sure that they're fresh and up-to-date.
-    try!(write(cx.dst.join("jquery.js"),
-               include_bytes!("static/jquery-2.1.4.min.js")));
-    try!(write(cx.dst.join("main.js"),
-               include_bytes!("static/main.js")));
-    try!(write(cx.dst.join("playpen.js"),
-               include_bytes!("static/playpen.js")));
-    try!(write(cx.dst.join("rustdoc.css"),
-               include_bytes!("static/rustdoc.css")));
-    try!(write(cx.dst.join("main.css"),
-               include_bytes!("static/styles/main.css")));
-    try!(write(cx.dst.join("normalize.css"),
-               include_bytes!("static/normalize.css")));
-    try!(write(cx.dst.join("FiraSans-Regular.woff"),
-               include_bytes!("static/FiraSans-Regular.woff")));
-    try!(write(cx.dst.join("FiraSans-Medium.woff"),
-               include_bytes!("static/FiraSans-Medium.woff")));
-    try!(write(cx.dst.join("FiraSans-LICENSE.txt"),
-               include_bytes!("static/FiraSans-LICENSE.txt")));
-    try!(write(cx.dst.join("Heuristica-Italic.woff"),
-               include_bytes!("static/Heuristica-Italic.woff")));
-    try!(write(cx.dst.join("Heuristica-LICENSE.txt"),
-               include_bytes!("static/Heuristica-LICENSE.txt")));
-    try!(write(cx.dst.join("SourceSerifPro-Regular.woff"),
-               include_bytes!("static/SourceSerifPro-Regular.woff")));
-    try!(write(cx.dst.join("SourceSerifPro-Bold.woff"),
-               include_bytes!("static/SourceSerifPro-Bold.woff")));
-    try!(write(cx.dst.join("SourceSerifPro-LICENSE.txt"),
-               include_bytes!("static/SourceSerifPro-LICENSE.txt")));
-    try!(write(cx.dst.join("SourceCodePro-Regular.woff"),
-               include_bytes!("static/SourceCodePro-Regular.woff")));
-    try!(write(cx.dst.join("SourceCodePro-Semibold.woff"),
-               include_bytes!("static/SourceCodePro-Semibold.woff")));
-    try!(write(cx.dst.join("SourceCodePro-LICENSE.txt"),
-               include_bytes!("static/SourceCodePro-LICENSE.txt")));
-    try!(write(cx.dst.join("LICENSE-MIT.txt"),
-               include_bytes!("static/LICENSE-MIT.txt")));
-    try!(write(cx.dst.join("LICENSE-APACHE.txt"),
-               include_bytes!("static/LICENSE-APACHE.txt")));
-    try!(write(cx.dst.join("COPYRIGHT.txt"),
-               include_bytes!("static/COPYRIGHT.txt")));
+    write(cx.dst.join("jquery.js"),
+               include_bytes!("static/jquery-2.1.4.min.js"))?;
+    write(cx.dst.join("main.js"),
+               include_bytes!("static/main.js"))?;
+    write(cx.dst.join("playpen.js"),
+               include_bytes!("static/playpen.js"))?;
+    write(cx.dst.join("rustdoc.css"),
+               include_bytes!("static/rustdoc.css"))?;
+    write(cx.dst.join("main.css"),
+               include_bytes!("static/styles/main.css"))?;
+    write(cx.dst.join("normalize.css"),
+               include_bytes!("static/normalize.css"))?;
+    write(cx.dst.join("FiraSans-Regular.woff"),
+               include_bytes!("static/FiraSans-Regular.woff"))?;
+    write(cx.dst.join("FiraSans-Medium.woff"),
+               include_bytes!("static/FiraSans-Medium.woff"))?;
+    write(cx.dst.join("FiraSans-LICENSE.txt"),
+               include_bytes!("static/FiraSans-LICENSE.txt"))?;
+    write(cx.dst.join("Heuristica-Italic.woff"),
+               include_bytes!("static/Heuristica-Italic.woff"))?;
+    write(cx.dst.join("Heuristica-LICENSE.txt"),
+               include_bytes!("static/Heuristica-LICENSE.txt"))?;
+    write(cx.dst.join("SourceSerifPro-Regular.woff"),
+               include_bytes!("static/SourceSerifPro-Regular.woff"))?;
+    write(cx.dst.join("SourceSerifPro-Bold.woff"),
+               include_bytes!("static/SourceSerifPro-Bold.woff"))?;
+    write(cx.dst.join("SourceSerifPro-LICENSE.txt"),
+               include_bytes!("static/SourceSerifPro-LICENSE.txt"))?;
+    write(cx.dst.join("SourceCodePro-Regular.woff"),
+               include_bytes!("static/SourceCodePro-Regular.woff"))?;
+    write(cx.dst.join("SourceCodePro-Semibold.woff"),
+               include_bytes!("static/SourceCodePro-Semibold.woff"))?;
+    write(cx.dst.join("SourceCodePro-LICENSE.txt"),
+               include_bytes!("static/SourceCodePro-LICENSE.txt"))?;
+    write(cx.dst.join("LICENSE-MIT.txt"),
+               include_bytes!("static/LICENSE-MIT.txt"))?;
+    write(cx.dst.join("LICENSE-APACHE.txt"),
+               include_bytes!("static/LICENSE-APACHE.txt"))?;
+    write(cx.dst.join("COPYRIGHT.txt"),
+               include_bytes!("static/COPYRIGHT.txt"))?;
 
     fn collect(path: &Path, krate: &str,
                key: &str) -> io::Result<Vec<String>> {
         let mut ret = Vec::new();
         if path.exists() {
-            for line in BufReader::new(try!(File::open(path))).lines() {
-                let line = try!(line);
+            for line in BufReader::new(File::open(path)?).lines() {
+                let line = line?;
                 if !line.starts_with(key) {
                     continue
                 }
@@ -885,7 +885,7 @@ impl<'a> SourceCollector<'a> {
         }
 
         let mut contents = Vec::new();
-        try!(File::open(&p).and_then(|mut f| f.read_to_end(&mut contents)));
+        File::open(&p).and_then(|mut f| f.read_to_end(&mut contents))?;
 
         let contents = str::from_utf8(&contents).unwrap();
 
@@ -913,7 +913,7 @@ impl<'a> SourceCollector<'a> {
         cur.push(&fname[..]);
         href.push_str(&fname.to_string_lossy());
 
-        let mut w = BufWriter::new(try!(File::create(&cur)));
+        let mut w = BufWriter::new(File::create(&cur)?);
         let title = format!("{} -- source", cur.file_name().unwrap()
                                                .to_string_lossy());
         let desc = format!("Source to the Rust file `{}`.", filename);
@@ -924,9 +924,9 @@ impl<'a> SourceCollector<'a> {
             description: &desc,
             keywords: BASIC_KEYWORDS,
         };
-        try!(layout::render(&mut w, &self.cx.layout,
-                            &page, &(""), &Source(contents)));
-        try!(w.flush());
+        layout::render(&mut w, &self.cx.layout,
+                            &page, &(""), &Source(contents))?;
+        w.flush()?;
         self.cx.local_sources.insert(p, href);
         Ok(())
     }
@@ -1231,9 +1231,9 @@ impl Context {
         let mut work = vec!((self, item));
         loop {
             match work.pop() {
-                Some((mut cx, item)) => try!(cx.item(item, |cx, item| {
+                Some((mut cx, item)) => cx.item(item, |cx, item| {
                     work.push((cx.clone(), item));
-                })),
+                })?,
                 None => break,
             }
         }
@@ -1289,9 +1289,9 @@ impl Context {
             // write syscall all the time.
             let mut writer = BufWriter::new(w);
             if !cx.render_redirect_pages {
-                try!(layout::render(&mut writer, &cx.layout, &page,
+                layout::render(&mut writer, &cx.layout, &page,
                                     &Sidebar{ cx: cx, item: it },
-                                    &Item{ cx: cx, item: it }));
+                                    &Item{ cx: cx, item: it })?;
             } else {
                 let mut url = repeat("../").take(cx.current.len())
                                            .collect::<String>();
@@ -1302,7 +1302,7 @@ impl Context {
                             url.push_str("/");
                         }
                         url.push_str(&item_path(it));
-                        try!(layout::redirect(&mut writer, &url));
+                        layout::redirect(&mut writer, &url)?;
                     }
                     None => {}
                 }
@@ -1492,18 +1492,18 @@ impl<'a> Item<'a> {
 impl<'a> fmt::Display for Item<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         // Write the breadcrumb trail header for the top
-        try!(write!(fmt, "\n<h1 class='fqn'><span class='in-band'>"));
+        write!(fmt, "\n<h1 class='fqn'><span class='in-band'>")?;
         match self.item.inner {
             clean::ModuleItem(ref m) => if m.is_crate {
-                    try!(write!(fmt, "Crate "));
+                    write!(fmt, "Crate ")?;
                 } else {
-                    try!(write!(fmt, "Module "));
+                    write!(fmt, "Module ")?;
                 },
-            clean::FunctionItem(..) => try!(write!(fmt, "Function ")),
-            clean::TraitItem(..) => try!(write!(fmt, "Trait ")),
-            clean::StructItem(..) => try!(write!(fmt, "Struct ")),
-            clean::EnumItem(..) => try!(write!(fmt, "Enum ")),
-            clean::PrimitiveItem(..) => try!(write!(fmt, "Primitive Type ")),
+            clean::FunctionItem(..) => write!(fmt, "Function ")?,
+            clean::TraitItem(..) => write!(fmt, "Trait ")?,
+            clean::StructItem(..) => write!(fmt, "Struct ")?,
+            clean::EnumItem(..) => write!(fmt, "Enum ")?,
+            clean::PrimitiveItem(..) => write!(fmt, "Primitive Type ")?,
             _ => {}
         }
         let is_primitive = match self.item.inner {
@@ -1514,23 +1514,23 @@ impl<'a> fmt::Display for Item<'a> {
             let cur = &self.cx.current;
             let amt = if self.ismodule() { cur.len() - 1 } else { cur.len() };
             for (i, component) in cur.iter().enumerate().take(amt) {
-                try!(write!(fmt, "<a href='{}index.html'>{}</a>::<wbr>",
+                write!(fmt, "<a href='{}index.html'>{}</a>::<wbr>",
                             repeat("../").take(cur.len() - i - 1)
                                          .collect::<String>(),
-                            component));
+                            component)?;
             }
         }
-        try!(write!(fmt, "<a class='{}' href=''>{}</a>",
-                    shortty(self.item), self.item.name.as_ref().unwrap()));
+        write!(fmt, "<a class='{}' href=''>{}</a>",
+                    shortty(self.item), self.item.name.as_ref().unwrap())?;
 
-        try!(write!(fmt, "</span>")); // in-band
-        try!(write!(fmt, "<span class='out-of-band'>"));
-        try!(write!(fmt,
+        write!(fmt, "</span>")?; // in-band
+        write!(fmt, "<span class='out-of-band'>")?;
+        write!(fmt,
         r##"<span id='render-detail'>
             <a id="toggle-all-docs" href="javascript:void(0)" title="collapse all docs">
                 [<span class='inner'>&#x2212;</span>]
             </a>
-        </span>"##));
+        </span>"##)?;
 
         // Write `src` tag
         //
@@ -1540,15 +1540,15 @@ impl<'a> fmt::Display for Item<'a> {
         // used to find the link to auto-click.
         if self.cx.include_sources && !is_primitive {
             if let Some(l) = self.href() {
-                try!(write!(fmt, "<a id='src-{}' class='srclink' \
+                write!(fmt, "<a id='src-{}' class='srclink' \
                                    href='{}' title='{}'>[src]</a>",
-                            self.item.def_id.index.as_usize(), l, "goto source code"));
+                            self.item.def_id.index.as_usize(), l, "goto source code")?;
             }
         }
 
-        try!(write!(fmt, "</span>")); // out-of-band
+        write!(fmt, "</span>")?; // out-of-band
 
-        try!(write!(fmt, "</h1>\n"));
+        write!(fmt, "</h1>\n")?;
 
         match self.item.inner {
             clean::ModuleItem(ref m) => {
@@ -1609,17 +1609,17 @@ fn plain_summary_line(s: Option<&str>) -> String {
 
 fn document(w: &mut fmt::Formatter, cx: &Context, item: &clean::Item) -> fmt::Result {
     if let Some(s) = short_stability(item, cx, true) {
-        try!(write!(w, "<div class='stability'>{}</div>", s));
+        write!(w, "<div class='stability'>{}</div>", s)?;
     }
     if let Some(s) = item.doc_value() {
-        try!(write!(w, "<div class='docblock'>{}</div>", Markdown(s)));
+        write!(w, "<div class='docblock'>{}</div>", Markdown(s))?;
     }
     Ok(())
 }
 
 fn item_module(w: &mut fmt::Formatter, cx: &Context,
                item: &clean::Item, items: &[clean::Item]) -> fmt::Result {
-    try!(document(w, cx, item));
+    document(w, cx, item)?;
 
     let mut indices = (0..items.len()).filter(|i| {
         !cx.ignore_private_item(&items[*i])
@@ -1673,7 +1673,7 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
             curty = myty;
         } else if myty != curty {
             if curty.is_some() {
-                try!(write!(w, "</table>"));
+                write!(w, "</table>")?;
             }
             curty = myty;
             let (short, name) = match myty.unwrap() {
@@ -1697,31 +1697,31 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
                 ItemType::AssociatedType  => ("associated-types", "Associated Types"),
                 ItemType::AssociatedConst => ("associated-consts", "Associated Constants"),
             };
-            try!(write!(w, "<h2 id='{id}' class='section-header'>\
+            write!(w, "<h2 id='{id}' class='section-header'>\
                            <a href=\"#{id}\">{name}</a></h2>\n<table>",
-                           id = derive_id(short.to_owned()), name = name));
+                           id = derive_id(short.to_owned()), name = name)?;
         }
 
         match myitem.inner {
             clean::ExternCrateItem(ref name, ref src) => {
                 match *src {
                     Some(ref src) => {
-                        try!(write!(w, "<tr><td><code>{}extern crate {} as {};",
+                        write!(w, "<tr><td><code>{}extern crate {} as {};",
                                     VisSpace(myitem.visibility),
                                     src,
-                                    name))
+                                    name)?
                     }
                     None => {
-                        try!(write!(w, "<tr><td><code>{}extern crate {};",
-                                    VisSpace(myitem.visibility), name))
+                        write!(w, "<tr><td><code>{}extern crate {};",
+                                    VisSpace(myitem.visibility), name)?
                     }
                 }
-                try!(write!(w, "</code></td></tr>"));
+                write!(w, "</code></td></tr>")?;
             }
 
             clean::ImportItem(ref import) => {
-                try!(write!(w, "<tr><td><code>{}{}</code></td></tr>",
-                            VisSpace(myitem.visibility), *import));
+                write!(w, "<tr><td><code>{}{}</code></td></tr>",
+                            VisSpace(myitem.visibility), *import)?;
             }
 
             _ => {
@@ -1732,7 +1732,7 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
                     String::new()
                 };
                 let doc_value = myitem.doc_value().unwrap_or("");
-                try!(write!(w, "
+                write!(w, "
                     <tr class='{stab} module-item'>
                         <td><a class='{class}' href='{href}'
                                title='{title}'>{name}</a></td>
@@ -1747,7 +1747,7 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
                 class = shortty(myitem),
                 stab = myitem.stability_class(),
                 href = item_path(myitem),
-                title = full_path(cx, myitem)));
+                title = full_path(cx, myitem))?;
             }
         }
     }
@@ -1816,31 +1816,31 @@ impl<'a> fmt::Display for Initializer<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Initializer(s) = *self;
         if s.is_empty() { return Ok(()); }
-        try!(write!(f, "<code> = </code>"));
+        write!(f, "<code> = </code>")?;
         write!(f, "<code>{}</code>", s)
     }
 }
 
 fn item_constant(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                  c: &clean::Constant) -> fmt::Result {
-    try!(write!(w, "<pre class='rust const'>{vis}const \
+    write!(w, "<pre class='rust const'>{vis}const \
                     {name}: {typ}{init}</pre>",
            vis = VisSpace(it.visibility),
            name = it.name.as_ref().unwrap(),
            typ = c.type_,
-           init = Initializer(&c.expr)));
+           init = Initializer(&c.expr))?;
     document(w, cx, it)
 }
 
 fn item_static(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                s: &clean::Static) -> fmt::Result {
-    try!(write!(w, "<pre class='rust static'>{vis}static {mutability}\
+    write!(w, "<pre class='rust static'>{vis}static {mutability}\
                     {name}: {typ}{init}</pre>",
            vis = VisSpace(it.visibility),
            mutability = MutableSpace(s.mutability),
            name = it.name.as_ref().unwrap(),
            typ = s.type_,
-           init = Initializer(&s.expr)));
+           init = Initializer(&s.expr))?;
     document(w, cx, it)
 }
 
@@ -1850,7 +1850,7 @@ fn item_function(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
         UnstableFeatures::Allow => f.constness,
         _ => hir::Constness::NotConst
     };
-    try!(write!(w, "<pre class='rust fn'>{vis}{constness}{unsafety}{abi}fn \
+    write!(w, "<pre class='rust fn'>{vis}{constness}{unsafety}{abi}fn \
                     {name}{generics}{decl}{where_clause}</pre>",
            vis = VisSpace(it.visibility),
            constness = ConstnessSpace(vis_constness),
@@ -1859,8 +1859,8 @@ fn item_function(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
            name = it.name.as_ref().unwrap(),
            generics = f.generics,
            where_clause = WhereClause(&f.generics),
-           decl = f.decl));
-    try!(render_stability_since_raw(w, it.stable_since(), None));
+           decl = f.decl)?;
+    render_stability_since_raw(w, it.stable_since(), None)?;
     document(w, cx, it)
 }
 
@@ -1879,13 +1879,13 @@ fn item_trait(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
     }
 
     // Output the trait definition
-    try!(write!(w, "<pre class='rust trait'>{}{}trait {}{}{}{} ",
+    write!(w, "<pre class='rust trait'>{}{}trait {}{}{}{} ",
                   VisSpace(it.visibility),
                   UnsafetySpace(t.unsafety),
                   it.name.as_ref().unwrap(),
                   t.generics,
                   bounds,
-                  WhereClause(&t.generics)));
+                  WhereClause(&t.generics))?;
 
     let types = t.items.iter().filter(|m| m.is_associated_type()).collect::<Vec<_>>();
     let consts = t.items.iter().filter(|m| m.is_associated_const()).collect::<Vec<_>>();
@@ -1893,122 +1893,122 @@ fn item_trait(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
     let provided = t.items.iter().filter(|m| m.is_method()).collect::<Vec<_>>();
 
     if t.items.is_empty() {
-        try!(write!(w, "{{ }}"));
+        write!(w, "{{ }}")?;
     } else {
-        try!(write!(w, "{{\n"));
+        write!(w, "{{\n")?;
         for t in &types {
-            try!(write!(w, "    "));
-            try!(render_assoc_item(w, t, AssocItemLink::Anchor));
-            try!(write!(w, ";\n"));
+            write!(w, "    ")?;
+            render_assoc_item(w, t, AssocItemLink::Anchor)?;
+            write!(w, ";\n")?;
         }
         if !types.is_empty() && !consts.is_empty() {
-            try!(w.write_str("\n"));
+            w.write_str("\n")?;
         }
         for t in &consts {
-            try!(write!(w, "    "));
-            try!(render_assoc_item(w, t, AssocItemLink::Anchor));
-            try!(write!(w, ";\n"));
+            write!(w, "    ")?;
+            render_assoc_item(w, t, AssocItemLink::Anchor)?;
+            write!(w, ";\n")?;
         }
         if !consts.is_empty() && !required.is_empty() {
-            try!(w.write_str("\n"));
+            w.write_str("\n")?;
         }
         for m in &required {
-            try!(write!(w, "    "));
-            try!(render_assoc_item(w, m, AssocItemLink::Anchor));
-            try!(write!(w, ";\n"));
+            write!(w, "    ")?;
+            render_assoc_item(w, m, AssocItemLink::Anchor)?;
+            write!(w, ";\n")?;
         }
         if !required.is_empty() && !provided.is_empty() {
-            try!(w.write_str("\n"));
+            w.write_str("\n")?;
         }
         for m in &provided {
-            try!(write!(w, "    "));
-            try!(render_assoc_item(w, m, AssocItemLink::Anchor));
-            try!(write!(w, " {{ ... }}\n"));
+            write!(w, "    ")?;
+            render_assoc_item(w, m, AssocItemLink::Anchor)?;
+            write!(w, " {{ ... }}\n")?;
         }
-        try!(write!(w, "}}"));
+        write!(w, "}}")?;
     }
-    try!(write!(w, "</pre>"));
+    write!(w, "</pre>")?;
 
     // Trait documentation
-    try!(document(w, cx, it));
+    document(w, cx, it)?;
 
     fn trait_item(w: &mut fmt::Formatter, cx: &Context, m: &clean::Item, t: &clean::Item)
                   -> fmt::Result {
         let name = m.name.as_ref().unwrap();
         let id = derive_id(format!("{}.{}", shortty(m), name));
-        try!(write!(w, "<h3 id='{id}' class='method stab {stab}'><code>",
+        write!(w, "<h3 id='{id}' class='method stab {stab}'><code>",
                        id = id,
-                       stab = m.stability_class()));
-        try!(render_assoc_item(w, m, AssocItemLink::Anchor));
-        try!(write!(w, "</code>"));
-        try!(render_stability_since(w, m, t));
-        try!(write!(w, "</h3>"));
-        try!(document(w, cx, m));
+                       stab = m.stability_class())?;
+        render_assoc_item(w, m, AssocItemLink::Anchor)?;
+        write!(w, "</code>")?;
+        render_stability_since(w, m, t)?;
+        write!(w, "</h3>")?;
+        document(w, cx, m)?;
         Ok(())
     }
 
     if !types.is_empty() {
-        try!(write!(w, "
+        write!(w, "
             <h2 id='associated-types'>Associated Types</h2>
             <div class='methods'>
-        "));
+        ")?;
         for t in &types {
-            try!(trait_item(w, cx, *t, it));
+            trait_item(w, cx, *t, it)?;
         }
-        try!(write!(w, "</div>"));
+        write!(w, "</div>")?;
     }
 
     if !consts.is_empty() {
-        try!(write!(w, "
+        write!(w, "
             <h2 id='associated-const'>Associated Constants</h2>
             <div class='methods'>
-        "));
+        ")?;
         for t in &consts {
-            try!(trait_item(w, cx, *t, it));
+            trait_item(w, cx, *t, it)?;
         }
-        try!(write!(w, "</div>"));
+        write!(w, "</div>")?;
     }
 
     // Output the documentation for each function individually
     if !required.is_empty() {
-        try!(write!(w, "
+        write!(w, "
             <h2 id='required-methods'>Required Methods</h2>
             <div class='methods'>
-        "));
+        ")?;
         for m in &required {
-            try!(trait_item(w, cx, *m, it));
+            trait_item(w, cx, *m, it)?;
         }
-        try!(write!(w, "</div>"));
+        write!(w, "</div>")?;
     }
     if !provided.is_empty() {
-        try!(write!(w, "
+        write!(w, "
             <h2 id='provided-methods'>Provided Methods</h2>
             <div class='methods'>
-        "));
+        ")?;
         for m in &provided {
-            try!(trait_item(w, cx, *m, it));
+            trait_item(w, cx, *m, it)?;
         }
-        try!(write!(w, "</div>"));
+        write!(w, "</div>")?;
     }
 
     // If there are methods directly on this trait object, render them here.
-    try!(render_assoc_items(w, cx, it, it.def_id, AssocItemRender::All));
+    render_assoc_items(w, cx, it, it.def_id, AssocItemRender::All)?;
 
     let cache = cache();
-    try!(write!(w, "
+    write!(w, "
         <h2 id='implementors'>Implementors</h2>
         <ul class='item-list' id='implementors-list'>
-    "));
+    ")?;
     match cache.implementors.get(&it.def_id) {
         Some(implementors) => {
             for i in implementors {
-                try!(writeln!(w, "<li><code>{}</code></li>", i.impl_));
+                writeln!(w, "<li><code>{}</code></li>", i.impl_)?;
             }
         }
         None => {}
     }
-    try!(write!(w, "</ul>"));
-    try!(write!(w, r#"<script type="text/javascript" async
+    write!(w, "</ul>")?;
+    write!(w, r#"<script type="text/javascript" async
                               src="{root_path}/implementors/{path}/{ty}.{name}.js">
                       </script>"#,
                 root_path = vec![".."; cx.current.len()].join("/"),
@@ -2019,17 +2019,17 @@ fn item_trait(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                     path[..path.len() - 1].join("/")
                 },
                 ty = shortty(it).to_static_str(),
-                name = *it.name.as_ref().unwrap()));
+                name = *it.name.as_ref().unwrap())?;
     Ok(())
 }
 
 fn assoc_const(w: &mut fmt::Formatter, it: &clean::Item,
                ty: &clean::Type, default: Option<&String>)
                -> fmt::Result {
-    try!(write!(w, "const {}", it.name.as_ref().unwrap()));
-    try!(write!(w, ": {}", ty));
+    write!(w, "const {}", it.name.as_ref().unwrap())?;
+    write!(w, ": {}", ty)?;
     if let Some(default) = default {
-        try!(write!(w, " = {}", default));
+        write!(w, " = {}", default)?;
     }
     Ok(())
 }
@@ -2038,12 +2038,12 @@ fn assoc_type(w: &mut fmt::Formatter, it: &clean::Item,
               bounds: &Vec<clean::TyParamBound>,
               default: &Option<clean::Type>)
               -> fmt::Result {
-    try!(write!(w, "type {}", it.name.as_ref().unwrap()));
+    write!(w, "type {}", it.name.as_ref().unwrap())?;
     if !bounds.is_empty() {
-        try!(write!(w, ": {}", TyParamBounds(bounds)))
+        write!(w, ": {}", TyParamBounds(bounds))?
     }
     if let Some(ref default) = *default {
-        try!(write!(w, " = {}", default));
+        write!(w, " = {}", default)?;
     }
     Ok(())
 }
@@ -2053,8 +2053,8 @@ fn render_stability_since_raw<'a>(w: &mut fmt::Formatter,
                                   containing_ver: Option<&'a str>) -> fmt::Result {
     if let Some(v) = ver {
         if containing_ver != ver && v.len() > 0 {
-            try!(write!(w, "<span class=\"since\">{}</span>",
-                        v))
+            write!(w, "<span class=\"since\">{}</span>",
+                        v)?
         }
     }
     Ok(())
@@ -2128,19 +2128,19 @@ fn render_assoc_item(w: &mut fmt::Formatter, meth: &clean::Item,
 
 fn item_struct(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                s: &clean::Struct) -> fmt::Result {
-    try!(write!(w, "<pre class='rust struct'>"));
-    try!(render_attributes(w, it));
-    try!(render_struct(w,
+    write!(w, "<pre class='rust struct'>")?;
+    render_attributes(w, it)?;
+    render_struct(w,
                        it,
                        Some(&s.generics),
                        s.struct_type,
                        &s.fields,
                        "",
-                       true));
-    try!(write!(w, "</pre>"));
-    try!(render_stability_since_raw(w, it.stable_since(), None));
+                       true)?;
+    write!(w, "</pre>")?;
+    render_stability_since_raw(w, it.stable_since(), None)?;
 
-    try!(document(w, cx, it));
+    document(w, cx, it)?;
     let mut fields = s.fields.iter().filter(|f| {
         match f.inner {
             clean::StructFieldItem(clean::HiddenStructField) => false,
@@ -2150,17 +2150,17 @@ fn item_struct(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
     }).peekable();
     if let doctree::Plain = s.struct_type {
         if fields.peek().is_some() {
-            try!(write!(w, "<h2 class='fields'>Fields</h2>\n<table>"));
+            write!(w, "<h2 class='fields'>Fields</h2>\n<table>")?;
             for field in fields {
-                try!(write!(w, "<tr class='stab {stab}'>
+                write!(w, "<tr class='stab {stab}'>
                                   <td id='structfield.{name}'>\
                                     <code>{name}</code></td><td>",
                             stab = field.stability_class(),
-                            name = field.name.as_ref().unwrap()));
-                try!(document(w, cx, field));
-                try!(write!(w, "</td></tr>"));
+                            name = field.name.as_ref().unwrap())?;
+                document(w, cx, field)?;
+                write!(w, "</td></tr>")?;
             }
-            try!(write!(w, "</table>"));
+            write!(w, "</table>")?;
         }
     }
     render_assoc_items(w, cx, it, it.def_id, AssocItemRender::All)
@@ -2168,65 +2168,65 @@ fn item_struct(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
 
 fn item_enum(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
              e: &clean::Enum) -> fmt::Result {
-    try!(write!(w, "<pre class='rust enum'>"));
-    try!(render_attributes(w, it));
-    try!(write!(w, "{}enum {}{}{}",
+    write!(w, "<pre class='rust enum'>")?;
+    render_attributes(w, it)?;
+    write!(w, "{}enum {}{}{}",
                   VisSpace(it.visibility),
                   it.name.as_ref().unwrap(),
                   e.generics,
-                  WhereClause(&e.generics)));
+                  WhereClause(&e.generics))?;
     if e.variants.is_empty() && !e.variants_stripped {
-        try!(write!(w, " {{}}"));
+        write!(w, " {{}}")?;
     } else {
-        try!(write!(w, " {{\n"));
+        write!(w, " {{\n")?;
         for v in &e.variants {
-            try!(write!(w, "    "));
+            write!(w, "    ")?;
             let name = v.name.as_ref().unwrap();
             match v.inner {
                 clean::VariantItem(ref var) => {
                     match var.kind {
-                        clean::CLikeVariant => try!(write!(w, "{}", name)),
+                        clean::CLikeVariant => write!(w, "{}", name)?,
                         clean::TupleVariant(ref tys) => {
-                            try!(write!(w, "{}(", name));
+                            write!(w, "{}(", name)?;
                             for (i, ty) in tys.iter().enumerate() {
                                 if i > 0 {
-                                    try!(write!(w, ", "))
+                                    write!(w, ", ")?
                                 }
-                                try!(write!(w, "{}", *ty));
+                                write!(w, "{}", *ty)?;
                             }
-                            try!(write!(w, ")"));
+                            write!(w, ")")?;
                         }
                         clean::StructVariant(ref s) => {
-                            try!(render_struct(w,
+                            render_struct(w,
                                                v,
                                                None,
                                                s.struct_type,
                                                &s.fields,
                                                "    ",
-                                               false));
+                                               false)?;
                         }
                     }
                 }
                 _ => unreachable!()
             }
-            try!(write!(w, ",\n"));
+            write!(w, ",\n")?;
         }
 
         if e.variants_stripped {
-            try!(write!(w, "    // some variants omitted\n"));
+            write!(w, "    // some variants omitted\n")?;
         }
-        try!(write!(w, "}}"));
+        write!(w, "}}")?;
     }
-    try!(write!(w, "</pre>"));
-    try!(render_stability_since_raw(w, it.stable_since(), None));
+    write!(w, "</pre>")?;
+    render_stability_since_raw(w, it.stable_since(), None)?;
 
-    try!(document(w, cx, it));
+    document(w, cx, it)?;
     if !e.variants.is_empty() {
-        try!(write!(w, "<h2 class='variants'>Variants</h2>\n<table class='variants_table'>"));
+        write!(w, "<h2 class='variants'>Variants</h2>\n<table class='variants_table'>")?;
         for variant in &e.variants {
-            try!(write!(w, "<tr><td id='variant.{name}'><code>{name}</code></td><td>",
-                          name = variant.name.as_ref().unwrap()));
-            try!(document(w, cx, variant));
+            write!(w, "<tr><td id='variant.{name}'><code>{name}</code></td><td>",
+                          name = variant.name.as_ref().unwrap())?;
+            document(w, cx, variant)?;
 
             use clean::{Variant, StructVariant};
             if let clean::VariantItem( Variant { kind: StructVariant(ref s) } ) = variant.inner {
@@ -2236,26 +2236,26 @@ fn item_enum(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                         _ => false,
                     }
                 });
-                try!(write!(w, "<h3 class='fields'>Fields</h3>\n
-                                  <table>"));
+                write!(w, "<h3 class='fields'>Fields</h3>\n
+                                  <table>")?;
                 for field in fields {
-                    try!(write!(w, "<tr><td \
+                    write!(w, "<tr><td \
                                       id='variant.{v}.field.{f}'>\
                                       <code>{f}</code></td><td>",
                                   v = variant.name.as_ref().unwrap(),
-                                  f = field.name.as_ref().unwrap()));
-                    try!(document(w, cx, field));
-                    try!(write!(w, "</td></tr>"));
+                                  f = field.name.as_ref().unwrap())?;
+                    document(w, cx, field)?;
+                    write!(w, "</td></tr>")?;
                 }
-                try!(write!(w, "</table>"));
+                write!(w, "</table>")?;
             }
-            try!(write!(w, "</td><td>"));
-            try!(render_stability_since(w, variant, it));
-            try!(write!(w, "</td></tr>"));
+            write!(w, "</td><td>")?;
+            render_stability_since(w, variant, it)?;
+            write!(w, "</td></tr>")?;
         }
-        try!(write!(w, "</table>"));
+        write!(w, "</table>")?;
     }
-    try!(render_assoc_items(w, cx, it, it.def_id, AssocItemRender::All));
+    render_assoc_items(w, cx, it, it.def_id, AssocItemRender::All)?;
     Ok(())
 }
 
@@ -2263,10 +2263,10 @@ fn render_attributes(w: &mut fmt::Formatter, it: &clean::Item) -> fmt::Result {
     for attr in &it.attrs {
         match *attr {
             clean::Word(ref s) if *s == "must_use" => {
-                try!(write!(w, "#[{}]\n", s));
+                write!(w, "#[{}]\n", s)?;
             }
             clean::NameValue(ref k, ref v) if *k == "must_use" => {
-                try!(write!(w, "#[{} = \"{}\"]\n", k, v));
+                write!(w, "#[{} = \"{}\"]\n", k, v)?;
             }
             _ => ()
         }
@@ -2280,16 +2280,16 @@ fn render_struct(w: &mut fmt::Formatter, it: &clean::Item,
                  fields: &[clean::Item],
                  tab: &str,
                  structhead: bool) -> fmt::Result {
-    try!(write!(w, "{}{}{}",
+    write!(w, "{}{}{}",
                   VisSpace(it.visibility),
                   if structhead {"struct "} else {""},
-                  it.name.as_ref().unwrap()));
+                  it.name.as_ref().unwrap())?;
     if let Some(g) = g {
-        try!(write!(w, "{}{}", *g, WhereClause(g)))
+        write!(w, "{}{}", *g, WhereClause(g))?
     }
     match ty {
         doctree::Plain => {
-            try!(write!(w, " {{\n{}", tab));
+            write!(w, " {{\n{}", tab)?;
             let mut fields_stripped = false;
             for field in fields {
                 match field.inner {
@@ -2297,41 +2297,41 @@ fn render_struct(w: &mut fmt::Formatter, it: &clean::Item,
                         fields_stripped = true;
                     }
                     clean::StructFieldItem(clean::TypedStructField(ref ty)) => {
-                        try!(write!(w, "    {}{}: {},\n{}",
+                        write!(w, "    {}{}: {},\n{}",
                                       VisSpace(field.visibility),
                                       field.name.as_ref().unwrap(),
                                       *ty,
-                                      tab));
+                                      tab)?;
                     }
                     _ => unreachable!(),
                 };
             }
 
             if fields_stripped {
-                try!(write!(w, "    // some fields omitted\n{}", tab));
+                write!(w, "    // some fields omitted\n{}", tab)?;
             }
-            try!(write!(w, "}}"));
+            write!(w, "}}")?;
         }
         doctree::Tuple | doctree::Newtype => {
-            try!(write!(w, "("));
+            write!(w, "(")?;
             for (i, field) in fields.iter().enumerate() {
                 if i > 0 {
-                    try!(write!(w, ", "));
+                    write!(w, ", ")?;
                 }
                 match field.inner {
                     clean::StructFieldItem(clean::HiddenStructField) => {
-                        try!(write!(w, "_"))
+                        write!(w, "_")?
                     }
                     clean::StructFieldItem(clean::TypedStructField(ref ty)) => {
-                        try!(write!(w, "{}{}", VisSpace(field.visibility), *ty))
+                        write!(w, "{}{}", VisSpace(field.visibility), *ty)?
                     }
                     _ => unreachable!()
                 }
             }
-            try!(write!(w, ");"));
+            write!(w, ");")?;
         }
         doctree::Unit => {
-            try!(write!(w, ";"));
+            write!(w, ";")?;
         }
     }
     Ok(())
@@ -2364,18 +2364,18 @@ fn render_assoc_items(w: &mut fmt::Formatter,
     if !non_trait.is_empty() {
         let render_header = match what {
             AssocItemRender::All => {
-                try!(write!(w, "<h2 id='methods'>Methods</h2>"));
+                write!(w, "<h2 id='methods'>Methods</h2>")?;
                 true
             }
             AssocItemRender::DerefFor { trait_, type_ } => {
-                try!(write!(w, "<h2 id='deref-methods'>Methods from \
-                                    {}&lt;Target={}&gt;</h2>", trait_, type_));
+                write!(w, "<h2 id='deref-methods'>Methods from \
+                                    {}&lt;Target={}&gt;</h2>", trait_, type_)?;
                 false
             }
         };
         for i in &non_trait {
-            try!(render_impl(w, cx, i, AssocItemLink::Anchor, render_header,
-                             containing_item.stable_since()));
+            render_impl(w, cx, i, AssocItemLink::Anchor, render_header,
+                             containing_item.stable_since())?;
         }
     }
     if let AssocItemRender::DerefFor { .. } = what {
@@ -2391,26 +2391,26 @@ fn render_assoc_items(w: &mut fmt::Formatter,
             }
         });
         if let Some(impl_) = deref_impl {
-            try!(render_deref_methods(w, cx, impl_, containing_item));
+            render_deref_methods(w, cx, impl_, containing_item)?;
         }
-        try!(write!(w, "<h2 id='implementations'>Trait \
-                          Implementations</h2>"));
+        write!(w, "<h2 id='implementations'>Trait \
+                          Implementations</h2>")?;
         let (derived, manual): (Vec<_>, Vec<&Impl>) = traits.iter().partition(|i| {
             i.impl_.derived
         });
         for i in &manual {
             let did = i.trait_did().unwrap();
-            try!(render_impl(w, cx, i, AssocItemLink::GotoSource(did), true,
-                             containing_item.stable_since()));
+            render_impl(w, cx, i, AssocItemLink::GotoSource(did), true,
+                             containing_item.stable_since())?;
         }
         if !derived.is_empty() {
-            try!(write!(w, "<h3 id='derived_implementations'>\
+            write!(w, "<h3 id='derived_implementations'>\
                 Derived Implementations \
-            </h3>"));
+            </h3>")?;
             for i in &derived {
                 let did = i.trait_did().unwrap();
-                try!(render_impl(w, cx, i, AssocItemLink::GotoSource(did), true,
-                                 containing_item.stable_since()));
+                render_impl(w, cx, i, AssocItemLink::GotoSource(did), true,
+                                 containing_item.stable_since())?;
             }
         }
     }
@@ -2433,7 +2433,7 @@ fn render_deref_methods(w: &mut fmt::Formatter, cx: &Context, impl_: &Impl,
             if let Some(prim) = target.primitive_type() {
                 if let Some(c) = cache().primitive_locations.get(&prim) {
                     let did = DefId { krate: *c, index: prim.to_def_index() };
-                    try!(render_assoc_items(w, cx, container_item, did, what));
+                    render_assoc_items(w, cx, container_item, did, what)?;
                 }
             }
             Ok(())
@@ -2447,12 +2447,12 @@ fn render_deref_methods(w: &mut fmt::Formatter, cx: &Context, impl_: &Impl,
 fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLink,
                render_header: bool, outer_version: Option<&str>) -> fmt::Result {
     if render_header {
-        try!(write!(w, "<h3 class='impl'><code>{}</code>", i.impl_));
+        write!(w, "<h3 class='impl'><code>{}</code>", i.impl_)?;
         let since = i.stability.as_ref().map(|s| &s.since[..]);
-        try!(render_stability_since_raw(w, since, outer_version));
-        try!(write!(w, "</h3>"));
+        render_stability_since_raw(w, since, outer_version)?;
+        write!(w, "</h3>")?;
         if let Some(ref dox) = i.dox {
-            try!(write!(w, "<div class='docblock'>{}</div>", Markdown(dox)));
+            write!(w, "<div class='docblock'>{}</div>", Markdown(dox))?;
         }
     }
 
@@ -2472,36 +2472,36 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
                 // Only render when the method is not static or we allow static methods
                 if !is_static || render_static {
                     let id = derive_id(format!("method.{}", name));
-                    try!(write!(w, "<h4 id='{}' class='{}'>", id, shortty(item)));
-                    try!(render_stability_since_raw(w, item.stable_since(), outer_version));
-                    try!(write!(w, "<code>"));
-                    try!(render_assoc_item(w, item, link));
-                    try!(write!(w, "</code></h4>\n"));
+                    write!(w, "<h4 id='{}' class='{}'>", id, shortty(item))?;
+                    render_stability_since_raw(w, item.stable_since(), outer_version)?;
+                    write!(w, "<code>")?;
+                    render_assoc_item(w, item, link)?;
+                    write!(w, "</code></h4>\n")?;
                 }
             }
             clean::TypedefItem(ref tydef, _) => {
                 let id = derive_id(format!("associatedtype.{}", name));
-                try!(write!(w, "<h4 id='{}' class='{}'><code>", id, shortty(item)));
-                try!(write!(w, "type {} = {}", name, tydef.type_));
-                try!(write!(w, "</code></h4>\n"));
+                write!(w, "<h4 id='{}' class='{}'><code>", id, shortty(item))?;
+                write!(w, "type {} = {}", name, tydef.type_)?;
+                write!(w, "</code></h4>\n")?;
             }
             clean::AssociatedConstItem(ref ty, ref default) => {
                 let id = derive_id(format!("associatedconstant.{}", name));
-                try!(write!(w, "<h4 id='{}' class='{}'><code>", id, shortty(item)));
-                try!(assoc_const(w, item, ty, default.as_ref()));
-                try!(write!(w, "</code></h4>\n"));
+                write!(w, "<h4 id='{}' class='{}'><code>", id, shortty(item))?;
+                assoc_const(w, item, ty, default.as_ref())?;
+                write!(w, "</code></h4>\n")?;
             }
             clean::ConstantItem(ref c) => {
                 let id = derive_id(format!("associatedconstant.{}", name));
-                try!(write!(w, "<h4 id='{}' class='{}'><code>", id, shortty(item)));
-                try!(assoc_const(w, item, &c.type_, Some(&c.expr)));
-                try!(write!(w, "</code></h4>\n"));
+                write!(w, "<h4 id='{}' class='{}'><code>", id, shortty(item))?;
+                assoc_const(w, item, &c.type_, Some(&c.expr))?;
+                write!(w, "</code></h4>\n")?;
             }
             clean::AssociatedTypeItem(ref bounds, ref default) => {
                 let id = derive_id(format!("associatedtype.{}", name));
-                try!(write!(w, "<h4 id='{}' class='{}'><code>", id, shortty(item)));
-                try!(assoc_type(w, item, bounds, default));
-                try!(write!(w, "</code></h4>\n"));
+                write!(w, "<h4 id='{}' class='{}'><code>", id, shortty(item))?;
+                assoc_type(w, item, bounds, default)?;
+                write!(w, "</code></h4>\n")?;
             }
             _ => panic!("can't make docs for trait item with name {:?}", item.name)
         }
@@ -2514,9 +2514,9 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
         }
     }
 
-    try!(write!(w, "<div class='impl-items'>"));
+    write!(w, "<div class='impl-items'>")?;
     for trait_item in &i.impl_.items {
-        try!(doctraititem(w, cx, trait_item, link, render_header, outer_version));
+        doctraititem(w, cx, trait_item, link, render_header, outer_version)?;
     }
 
     fn render_default_items(w: &mut fmt::Formatter,
@@ -2532,8 +2532,8 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
                 continue;
             }
 
-            try!(doctraititem(w, cx, trait_item, AssocItemLink::GotoSource(did), render_static,
-                              outer_version));
+            doctraititem(w, cx, trait_item, AssocItemLink::GotoSource(did), render_static,
+                              outer_version)?;
         }
         Ok(())
     }
@@ -2544,20 +2544,20 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
     // for them work.
     if let Some(clean::ResolvedPath { did, .. }) = i.impl_.trait_ {
         if let Some(t) = cache().traits.get(&did) {
-            try!(render_default_items(w, cx, did, t, &i.impl_, render_header, outer_version));
+            render_default_items(w, cx, did, t, &i.impl_, render_header, outer_version)?;
         }
     }
-    try!(write!(w, "</div>"));
+    write!(w, "</div>")?;
     Ok(())
 }
 
 fn item_typedef(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                 t: &clean::Typedef) -> fmt::Result {
-    try!(write!(w, "<pre class='rust typedef'>type {}{}{where_clause} = {type_};</pre>",
+    write!(w, "<pre class='rust typedef'>type {}{}{where_clause} = {type_};</pre>",
                   it.name.as_ref().unwrap(),
                   t.generics,
                   where_clause = WhereClause(&t.generics),
-                  type_ = t.type_));
+                  type_ = t.type_)?;
 
     document(w, cx, it)
 }
@@ -2576,20 +2576,20 @@ impl<'a> fmt::Display for Sidebar<'a> {
         // as much HTML as possible in order to allow non-JS-enabled browsers
         // to navigate the documentation (though slightly inefficiently).
 
-        try!(write!(fmt, "<p class='location'>"));
+        write!(fmt, "<p class='location'>")?;
         for (i, name) in cx.current.iter().take(parentlen).enumerate() {
             if i > 0 {
-                try!(write!(fmt, "::<wbr>"));
+                write!(fmt, "::<wbr>")?;
             }
-            try!(write!(fmt, "<a href='{}index.html'>{}</a>",
+            write!(fmt, "<a href='{}index.html'>{}</a>",
                           &cx.root_path[..(cx.current.len() - i - 1) * 3],
-                          *name));
+                          *name)?;
         }
-        try!(write!(fmt, "</p>"));
+        write!(fmt, "</p>")?;
 
         // sidebar refers to the enclosing module, not this module
         let relpath = if it.is_mod() { "../" } else { "" };
-        try!(write!(fmt,
+        write!(fmt,
                     "<script>window.sidebarCurrent = {{\
                         name: '{name}', \
                         ty: '{ty}', \
@@ -2597,13 +2597,13 @@ impl<'a> fmt::Display for Sidebar<'a> {
                      }};</script>",
                     name = it.name.as_ref().map(|x| &x[..]).unwrap_or(""),
                     ty = shortty(it).to_static_str(),
-                    path = relpath));
+                    path = relpath)?;
         if parentlen == 0 {
             // there is no sidebar-items.js beyond the crate root path
             // FIXME maybe dynamic crate loading can be merged here
         } else {
-            try!(write!(fmt, "<script defer src=\"{path}sidebar-items.js\"></script>",
-                        path = relpath));
+            write!(fmt, "<script defer src=\"{path}sidebar-items.js\"></script>",
+                        path = relpath)?;
         }
 
         Ok(())
@@ -2620,29 +2620,29 @@ impl<'a> fmt::Display for Source<'a> {
             cols += 1;
             tmp /= 10;
         }
-        try!(write!(fmt, "<pre class=\"line-numbers\">"));
+        write!(fmt, "<pre class=\"line-numbers\">")?;
         for i in 1..lines + 1 {
-            try!(write!(fmt, "<span id=\"{0}\">{0:1$}</span>\n", i, cols));
+            write!(fmt, "<span id=\"{0}\">{0:1$}</span>\n", i, cols)?;
         }
-        try!(write!(fmt, "</pre>"));
-        try!(write!(fmt, "{}", highlight::highlight(s, None, None)));
+        write!(fmt, "</pre>")?;
+        write!(fmt, "{}", highlight::highlight(s, None, None))?;
         Ok(())
     }
 }
 
 fn item_macro(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
               t: &clean::Macro) -> fmt::Result {
-    try!(w.write_str(&highlight::highlight(&t.source,
+    w.write_str(&highlight::highlight(&t.source,
                                           Some("macro"),
-                                          None)));
-    try!(render_stability_since_raw(w, it.stable_since(), None));
+                                          None))?;
+    render_stability_since_raw(w, it.stable_since(), None)?;
     document(w, cx, it)
 }
 
 fn item_primitive(w: &mut fmt::Formatter, cx: &Context,
                   it: &clean::Item,
                   _p: &clean::PrimitiveType) -> fmt::Result {
-    try!(document(w, cx, it));
+    document(w, cx, it)?;
     render_assoc_items(w, cx, it, it.def_id, AssocItemRender::All)
 }
 

--- a/src/librustdoc/html/toc.rs
+++ b/src/librustdoc/html/toc.rs
@@ -188,10 +188,10 @@ impl fmt::Display for Toc {
             // recursively format this table of contents (the
             // `{children}` is the key).
             write!(fmt,
-                        "\n<li><a href=\"#{id}\">{num} {name}</a>{children}</li>",
-                        id = entry.id,
-                        num = entry.sec_number, name = entry.name,
-                        children = entry.children)?
+                   "\n<li><a href=\"#{id}\">{num} {name}</a>{children}</li>",
+                   id = entry.id,
+                   num = entry.sec_number, name = entry.name,
+                   children = entry.children)?
         }
         write!(fmt, "</ul>")
     }

--- a/src/librustdoc/html/toc.rs
+++ b/src/librustdoc/html/toc.rs
@@ -183,15 +183,15 @@ impl fmt::Debug for Toc {
 
 impl fmt::Display for Toc {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(fmt, "<ul>"));
+        write!(fmt, "<ul>")?;
         for entry in &self.entries {
             // recursively format this table of contents (the
             // `{children}` is the key).
-            try!(write!(fmt,
+            write!(fmt,
                         "\n<li><a href=\"#{id}\">{num} {name}</a>{children}</li>",
                         id = entry.id,
                         num = entry.sec_number, name = entry.name,
-                        children = entry.children))
+                        children = entry.children)?
         }
         write!(fmt, "</ul>")
     }

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -332,10 +332,10 @@ fn parse_externs(matches: &getopts::Matches) -> Result<core::Externs, String> {
     let mut externs = HashMap::new();
     for arg in &matches.opt_strs("extern") {
         let mut parts = arg.splitn(2, '=');
-        let name = try!(parts.next().ok_or("--extern value must not be empty".to_string()));
-        let location = try!(parts.next()
+        let name = parts.next().ok_or("--extern value must not be empty".to_string())?;
+        let location = parts.next()
                                  .ok_or("--extern value must be of the format `foo=bar`"
-                                    .to_string()));
+                                    .to_string())?;
         let name = name.to_string();
         externs.entry(name).or_insert(vec![]).push(location.to_string());
     }
@@ -502,6 +502,6 @@ fn json_output(krate: clean::Crate, res: Vec<plugins::PluginJson> ,
     json.insert("crate".to_string(), crate_json);
     json.insert("plugins".to_string(), Json::Object(plugins_json));
 
-    let mut file = try!(File::create(&dst));
+    let mut file = File::create(&dst)?;
     write!(&mut file, "{}", Json::Object(json))
 }

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -29,6 +29,7 @@
 #![feature(std_panic)]
 #![feature(test)]
 #![feature(unicode)]
+#![feature(question_mark)]
 
 extern crate arena;
 extern crate getopts;

--- a/src/libserialize/collection_impls.rs
+++ b/src/libserialize/collection_impls.rs
@@ -23,7 +23,7 @@ impl<
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         s.emit_seq(self.len(), |s| {
             for (i, e) in self.iter().enumerate() {
-                try!(s.emit_seq_elt(i, |s| e.encode(s)));
+                s.emit_seq_elt(i, |s| e.encode(s))?;
             }
             Ok(())
         })
@@ -35,7 +35,7 @@ impl<T:Decodable> Decodable for LinkedList<T> {
         d.read_seq(|d, len| {
             let mut list = LinkedList::new();
             for i in 0..len {
-                list.push_back(try!(d.read_seq_elt(i, |d| Decodable::decode(d))));
+                list.push_back(d.read_seq_elt(i, |d| Decodable::decode(d))?);
             }
             Ok(list)
         })
@@ -46,7 +46,7 @@ impl<T: Encodable> Encodable for VecDeque<T> {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         s.emit_seq(self.len(), |s| {
             for (i, e) in self.iter().enumerate() {
-                try!(s.emit_seq_elt(i, |s| e.encode(s)));
+                s.emit_seq_elt(i, |s| e.encode(s))?;
             }
             Ok(())
         })
@@ -58,7 +58,7 @@ impl<T:Decodable> Decodable for VecDeque<T> {
         d.read_seq(|d, len| {
             let mut deque: VecDeque<T> = VecDeque::new();
             for i in 0..len {
-                deque.push_back(try!(d.read_seq_elt(i, |d| Decodable::decode(d))));
+                deque.push_back(d.read_seq_elt(i, |d| Decodable::decode(d))?);
             }
             Ok(deque)
         })
@@ -73,8 +73,8 @@ impl<
         e.emit_map(self.len(), |e| {
             let mut i = 0;
             for (key, val) in self {
-                try!(e.emit_map_elt_key(i, |e| key.encode(e)));
-                try!(e.emit_map_elt_val(i, |e| val.encode(e)));
+                e.emit_map_elt_key(i, |e| key.encode(e))?;
+                e.emit_map_elt_val(i, |e| val.encode(e))?;
                 i += 1;
             }
             Ok(())
@@ -90,8 +90,8 @@ impl<
         d.read_map(|d, len| {
             let mut map = BTreeMap::new();
             for i in 0..len {
-                let key = try!(d.read_map_elt_key(i, |d| Decodable::decode(d)));
-                let val = try!(d.read_map_elt_val(i, |d| Decodable::decode(d)));
+                let key = d.read_map_elt_key(i, |d| Decodable::decode(d))?;
+                let val = d.read_map_elt_val(i, |d| Decodable::decode(d))?;
                 map.insert(key, val);
             }
             Ok(map)
@@ -106,7 +106,7 @@ impl<
         s.emit_seq(self.len(), |s| {
             let mut i = 0;
             for e in self {
-                try!(s.emit_seq_elt(i, |s| e.encode(s)));
+                s.emit_seq_elt(i, |s| e.encode(s))?;
                 i += 1;
             }
             Ok(())
@@ -121,7 +121,7 @@ impl<
         d.read_seq(|d, len| {
             let mut set = BTreeSet::new();
             for i in 0..len {
-                set.insert(try!(d.read_seq_elt(i, |d| Decodable::decode(d))));
+                set.insert(d.read_seq_elt(i, |d| Decodable::decode(d))?);
             }
             Ok(set)
         })
@@ -144,7 +144,7 @@ impl<
     T: Decodable + CLike
 > Decodable for EnumSet<T> {
     fn decode<D: Decoder>(d: &mut D) -> Result<EnumSet<T>, D::Error> {
-        let bits = try!(d.read_uint());
+        let bits = d.read_uint()?;
         let mut set = EnumSet::new();
         for bit in 0..(mem::size_of::<usize>()*8) {
             if bits & (1 << bit) != 0 {
@@ -164,8 +164,8 @@ impl<K, V, S> Encodable for HashMap<K, V, S>
         e.emit_map(self.len(), |e| {
             let mut i = 0;
             for (key, val) in self {
-                try!(e.emit_map_elt_key(i, |e| key.encode(e)));
-                try!(e.emit_map_elt_val(i, |e| val.encode(e)));
+                e.emit_map_elt_key(i, |e| key.encode(e))?;
+                e.emit_map_elt_val(i, |e| val.encode(e))?;
                 i += 1;
             }
             Ok(())
@@ -183,8 +183,8 @@ impl<K, V, S> Decodable for HashMap<K, V, S>
             let state = Default::default();
             let mut map = HashMap::with_capacity_and_hasher(len, state);
             for i in 0..len {
-                let key = try!(d.read_map_elt_key(i, |d| Decodable::decode(d)));
-                let val = try!(d.read_map_elt_val(i, |d| Decodable::decode(d)));
+                let key = d.read_map_elt_key(i, |d| Decodable::decode(d))?;
+                let val = d.read_map_elt_val(i, |d| Decodable::decode(d))?;
                 map.insert(key, val);
             }
             Ok(map)
@@ -200,7 +200,7 @@ impl<T, S> Encodable for HashSet<T, S>
         s.emit_seq(self.len(), |s| {
             let mut i = 0;
             for e in self {
-                try!(s.emit_seq_elt(i, |s| e.encode(s)));
+                s.emit_seq_elt(i, |s| e.encode(s))?;
                 i += 1;
             }
             Ok(())
@@ -217,7 +217,7 @@ impl<T, S> Decodable for HashSet<T, S>
             let state = Default::default();
             let mut set = HashSet::with_capacity_and_hasher(len, state);
             for i in 0..len {
-                set.insert(try!(d.read_seq_elt(i, |d| Decodable::decode(d))));
+                set.insert(d.read_seq_elt(i, |d| Decodable::decode(d))?);
             }
             Ok(set)
         })

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -319,7 +319,7 @@ pub fn encode<T: ::Encodable>(object: &T) -> Result<string::String, EncoderError
     let mut s = String::new();
     {
         let mut encoder = Encoder::new(&mut s);
-        try!(object.encode(&mut encoder));
+        object.encode(&mut encoder)?;
     }
     Ok(s)
 }
@@ -371,7 +371,7 @@ pub type EncodeResult = Result<(), EncoderError>;
 pub type DecodeResult<T> = Result<T, DecoderError>;
 
 fn escape_str(wr: &mut fmt::Write, v: &str) -> EncodeResult {
-    try!(wr.write_str("\""));
+    wr.write_str("\"")?;
 
     let mut start = 0;
 
@@ -416,19 +416,19 @@ fn escape_str(wr: &mut fmt::Write, v: &str) -> EncodeResult {
         };
 
         if start < i {
-            try!(wr.write_str(&v[start..i]));
+            wr.write_str(&v[start..i])?;
         }
 
-        try!(wr.write_str(escaped));
+        wr.write_str(escaped)?;
 
         start = i + 1;
     }
 
     if start != v.len() {
-        try!(wr.write_str(&v[start..]));
+        wr.write_str(&v[start..])?;
     }
 
-    try!(wr.write_str("\""));
+    wr.write_str("\"")?;
     Ok(())
 }
 
@@ -442,12 +442,12 @@ fn spaces(wr: &mut fmt::Write, mut n: usize) -> EncodeResult {
     const BUF: &'static str = "                ";
 
     while n >= BUF.len() {
-        try!(wr.write_str(BUF));
+        wr.write_str(BUF)?;
         n -= BUF.len();
     }
 
     if n > 0 {
-        try!(wr.write_str(&BUF[..n]));
+        wr.write_str(&BUF[..n])?;
     }
     Ok(())
 }
@@ -491,7 +491,7 @@ impl<'a> ::Encoder for Encoder<'a> {
 
     fn emit_nil(&mut self) -> EncodeResult {
         if self.is_emitting_map_key { return Err(EncoderError::BadHashmapKey); }
-        try!(write!(self.writer, "null"));
+        write!(self.writer, "null")?;
         Ok(())
     }
 
@@ -510,9 +510,9 @@ impl<'a> ::Encoder for Encoder<'a> {
     fn emit_bool(&mut self, v: bool) -> EncodeResult {
         if self.is_emitting_map_key { return Err(EncoderError::BadHashmapKey); }
         if v {
-            try!(write!(self.writer, "true"));
+            write!(self.writer, "true")?;
         } else {
-            try!(write!(self.writer, "false"));
+            write!(self.writer, "false")?;
         }
         Ok(())
     }
@@ -551,11 +551,11 @@ impl<'a> ::Encoder for Encoder<'a> {
             escape_str(self.writer, name)
         } else {
             if self.is_emitting_map_key { return Err(EncoderError::BadHashmapKey); }
-            try!(write!(self.writer, "{{\"variant\":"));
-            try!(escape_str(self.writer, name));
-            try!(write!(self.writer, ",\"fields\":["));
-            try!(f(self));
-            try!(write!(self.writer, "]}}"));
+            write!(self.writer, "{{\"variant\":")?;
+            escape_str(self.writer, name)?;
+            write!(self.writer, ",\"fields\":[")?;
+            f(self)?;
+            write!(self.writer, "]}}")?;
             Ok(())
         }
     }
@@ -565,7 +565,7 @@ impl<'a> ::Encoder for Encoder<'a> {
     {
         if self.is_emitting_map_key { return Err(EncoderError::BadHashmapKey); }
         if idx != 0 {
-            try!(write!(self.writer, ","));
+            write!(self.writer, ",")?;
         }
         f(self)
     }
@@ -595,9 +595,9 @@ impl<'a> ::Encoder for Encoder<'a> {
         F: FnOnce(&mut Encoder<'a>) -> EncodeResult,
     {
         if self.is_emitting_map_key { return Err(EncoderError::BadHashmapKey); }
-        try!(write!(self.writer, "{{"));
-        try!(f(self));
-        try!(write!(self.writer, "}}"));
+        write!(self.writer, "{{")?;
+        f(self)?;
+        write!(self.writer, "}}")?;
         Ok(())
     }
 
@@ -605,9 +605,9 @@ impl<'a> ::Encoder for Encoder<'a> {
         F: FnOnce(&mut Encoder<'a>) -> EncodeResult,
     {
         if self.is_emitting_map_key { return Err(EncoderError::BadHashmapKey); }
-        if idx != 0 { try!(write!(self.writer, ",")); }
-        try!(escape_str(self.writer, name));
-        try!(write!(self.writer, ":"));
+        if idx != 0 { write!(self.writer, ",")?; }
+        escape_str(self.writer, name)?;
+        write!(self.writer, ":")?;
         f(self)
     }
 
@@ -658,9 +658,9 @@ impl<'a> ::Encoder for Encoder<'a> {
         F: FnOnce(&mut Encoder<'a>) -> EncodeResult,
     {
         if self.is_emitting_map_key { return Err(EncoderError::BadHashmapKey); }
-        try!(write!(self.writer, "["));
-        try!(f(self));
-        try!(write!(self.writer, "]"));
+        write!(self.writer, "[")?;
+        f(self)?;
+        write!(self.writer, "]")?;
         Ok(())
     }
 
@@ -669,7 +669,7 @@ impl<'a> ::Encoder for Encoder<'a> {
     {
         if self.is_emitting_map_key { return Err(EncoderError::BadHashmapKey); }
         if idx != 0 {
-            try!(write!(self.writer, ","));
+            write!(self.writer, ",")?;
         }
         f(self)
     }
@@ -678,9 +678,9 @@ impl<'a> ::Encoder for Encoder<'a> {
         F: FnOnce(&mut Encoder<'a>) -> EncodeResult,
     {
         if self.is_emitting_map_key { return Err(EncoderError::BadHashmapKey); }
-        try!(write!(self.writer, "{{"));
-        try!(f(self));
-        try!(write!(self.writer, "}}"));
+        write!(self.writer, "{{")?;
+        f(self)?;
+        write!(self.writer, "}}")?;
         Ok(())
     }
 
@@ -688,9 +688,9 @@ impl<'a> ::Encoder for Encoder<'a> {
         F: FnOnce(&mut Encoder<'a>) -> EncodeResult,
     {
         if self.is_emitting_map_key { return Err(EncoderError::BadHashmapKey); }
-        if idx != 0 { try!(write!(self.writer, ",")) }
+        if idx != 0 { write!(self.writer, ",")? }
         self.is_emitting_map_key = true;
-        try!(f(self));
+        f(self)?;
         self.is_emitting_map_key = false;
         Ok(())
     }
@@ -699,7 +699,7 @@ impl<'a> ::Encoder for Encoder<'a> {
         F: FnOnce(&mut Encoder<'a>) -> EncodeResult,
     {
         if self.is_emitting_map_key { return Err(EncoderError::BadHashmapKey); }
-        try!(write!(self.writer, ":"));
+        write!(self.writer, ":")?;
         f(self)
     }
 }
@@ -739,7 +739,7 @@ impl<'a> ::Encoder for PrettyEncoder<'a> {
 
     fn emit_nil(&mut self) -> EncodeResult {
         if self.is_emitting_map_key { return Err(EncoderError::BadHashmapKey); }
-        try!(write!(self.writer, "null"));
+        write!(self.writer, "null")?;
         Ok(())
     }
 
@@ -758,9 +758,9 @@ impl<'a> ::Encoder for PrettyEncoder<'a> {
     fn emit_bool(&mut self, v: bool) -> EncodeResult {
         if self.is_emitting_map_key { return Err(EncoderError::BadHashmapKey); }
         if v {
-            try!(write!(self.writer, "true"));
+            write!(self.writer, "true")?;
         } else {
-            try!(write!(self.writer, "false"));
+            write!(self.writer, "false")?;
         }
         Ok(())
     }
@@ -797,23 +797,23 @@ impl<'a> ::Encoder for PrettyEncoder<'a> {
             escape_str(self.writer, name)
         } else {
             if self.is_emitting_map_key { return Err(EncoderError::BadHashmapKey); }
-            try!(write!(self.writer, "{{\n"));
+            write!(self.writer, "{{\n")?;
             self.curr_indent += self.indent;
-            try!(spaces(self.writer, self.curr_indent));
-            try!(write!(self.writer, "\"variant\": "));
-            try!(escape_str(self.writer, name));
-            try!(write!(self.writer, ",\n"));
-            try!(spaces(self.writer, self.curr_indent));
-            try!(write!(self.writer, "\"fields\": [\n"));
+            spaces(self.writer, self.curr_indent)?;
+            write!(self.writer, "\"variant\": ")?;
+            escape_str(self.writer, name)?;
+            write!(self.writer, ",\n")?;
+            spaces(self.writer, self.curr_indent)?;
+            write!(self.writer, "\"fields\": [\n")?;
             self.curr_indent += self.indent;
-            try!(f(self));
+            f(self)?;
             self.curr_indent -= self.indent;
-            try!(write!(self.writer, "\n"));
-            try!(spaces(self.writer, self.curr_indent));
+            write!(self.writer, "\n")?;
+            spaces(self.writer, self.curr_indent)?;
             self.curr_indent -= self.indent;
-            try!(write!(self.writer, "]\n"));
-            try!(spaces(self.writer, self.curr_indent));
-            try!(write!(self.writer, "}}"));
+            write!(self.writer, "]\n")?;
+            spaces(self.writer, self.curr_indent)?;
+            write!(self.writer, "}}")?;
             Ok(())
         }
     }
@@ -823,9 +823,9 @@ impl<'a> ::Encoder for PrettyEncoder<'a> {
     {
         if self.is_emitting_map_key { return Err(EncoderError::BadHashmapKey); }
         if idx != 0 {
-            try!(write!(self.writer, ",\n"));
+            write!(self.writer, ",\n")?;
         }
-        try!(spaces(self.writer, self.curr_indent));
+        spaces(self.writer, self.curr_indent)?;
         f(self)
     }
 
@@ -856,15 +856,15 @@ impl<'a> ::Encoder for PrettyEncoder<'a> {
     {
         if self.is_emitting_map_key { return Err(EncoderError::BadHashmapKey); }
         if len == 0 {
-            try!(write!(self.writer, "{{}}"));
+            write!(self.writer, "{{}}")?;
         } else {
-            try!(write!(self.writer, "{{"));
+            write!(self.writer, "{{")?;
             self.curr_indent += self.indent;
-            try!(f(self));
+            f(self)?;
             self.curr_indent -= self.indent;
-            try!(write!(self.writer, "\n"));
-            try!(spaces(self.writer, self.curr_indent));
-            try!(write!(self.writer, "}}"));
+            write!(self.writer, "\n")?;
+            spaces(self.writer, self.curr_indent)?;
+            write!(self.writer, "}}")?;
         }
         Ok(())
     }
@@ -874,13 +874,13 @@ impl<'a> ::Encoder for PrettyEncoder<'a> {
     {
         if self.is_emitting_map_key { return Err(EncoderError::BadHashmapKey); }
         if idx == 0 {
-            try!(write!(self.writer, "\n"));
+            write!(self.writer, "\n")?;
         } else {
-            try!(write!(self.writer, ",\n"));
+            write!(self.writer, ",\n")?;
         }
-        try!(spaces(self.writer, self.curr_indent));
-        try!(escape_str(self.writer, name));
-        try!(write!(self.writer, ": "));
+        spaces(self.writer, self.curr_indent)?;
+        escape_str(self.writer, name)?;
+        write!(self.writer, ": ")?;
         f(self)
     }
 
@@ -932,15 +932,15 @@ impl<'a> ::Encoder for PrettyEncoder<'a> {
     {
         if self.is_emitting_map_key { return Err(EncoderError::BadHashmapKey); }
         if len == 0 {
-            try!(write!(self.writer, "[]"));
+            write!(self.writer, "[]")?;
         } else {
-            try!(write!(self.writer, "["));
+            write!(self.writer, "[")?;
             self.curr_indent += self.indent;
-            try!(f(self));
+            f(self)?;
             self.curr_indent -= self.indent;
-            try!(write!(self.writer, "\n"));
-            try!(spaces(self.writer, self.curr_indent));
-            try!(write!(self.writer, "]"));
+            write!(self.writer, "\n")?;
+            spaces(self.writer, self.curr_indent)?;
+            write!(self.writer, "]")?;
         }
         Ok(())
     }
@@ -950,11 +950,11 @@ impl<'a> ::Encoder for PrettyEncoder<'a> {
     {
         if self.is_emitting_map_key { return Err(EncoderError::BadHashmapKey); }
         if idx == 0 {
-            try!(write!(self.writer, "\n"));
+            write!(self.writer, "\n")?;
         } else {
-            try!(write!(self.writer, ",\n"));
+            write!(self.writer, ",\n")?;
         }
-        try!(spaces(self.writer, self.curr_indent));
+        spaces(self.writer, self.curr_indent)?;
         f(self)
     }
 
@@ -963,15 +963,15 @@ impl<'a> ::Encoder for PrettyEncoder<'a> {
     {
         if self.is_emitting_map_key { return Err(EncoderError::BadHashmapKey); }
         if len == 0 {
-            try!(write!(self.writer, "{{}}"));
+            write!(self.writer, "{{}}")?;
         } else {
-            try!(write!(self.writer, "{{"));
+            write!(self.writer, "{{")?;
             self.curr_indent += self.indent;
-            try!(f(self));
+            f(self)?;
             self.curr_indent -= self.indent;
-            try!(write!(self.writer, "\n"));
-            try!(spaces(self.writer, self.curr_indent));
-            try!(write!(self.writer, "}}"));
+            write!(self.writer, "\n")?;
+            spaces(self.writer, self.curr_indent)?;
+            write!(self.writer, "}}")?;
         }
         Ok(())
     }
@@ -981,13 +981,13 @@ impl<'a> ::Encoder for PrettyEncoder<'a> {
     {
         if self.is_emitting_map_key { return Err(EncoderError::BadHashmapKey); }
         if idx == 0 {
-            try!(write!(self.writer, "\n"));
+            write!(self.writer, "\n")?;
         } else {
-            try!(write!(self.writer, ",\n"));
+            write!(self.writer, ",\n")?;
         }
-        try!(spaces(self.writer, self.curr_indent));
+        spaces(self.writer, self.curr_indent)?;
         self.is_emitting_map_key = true;
-        try!(f(self));
+        f(self)?;
         self.is_emitting_map_key = false;
         Ok(())
     }
@@ -996,7 +996,7 @@ impl<'a> ::Encoder for PrettyEncoder<'a> {
         F: FnOnce(&mut PrettyEncoder<'a>) -> EncodeResult,
     {
         if self.is_emitting_map_key { return Err(EncoderError::BadHashmapKey); }
-        try!(write!(self.writer, ": "));
+        write!(self.writer, ": ")?;
         f(self)
     }
 }
@@ -1695,7 +1695,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
                     'n' => res.push('\n'),
                     'r' => res.push('\r'),
                     't' => res.push('\t'),
-                    'u' => match try!(self.decode_hex_escape()) {
+                    'u' => match self.decode_hex_escape()? {
                         0xDC00 ... 0xDFFF => {
                             return self.error(LoneLeadingSurrogateInHexEscape)
                         }
@@ -1708,7 +1708,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
                                 _ => return self.error(UnexpectedEndOfHexEscape),
                             }
 
-                            let n2 = try!(self.decode_hex_escape());
+                            let n2 = self.decode_hex_escape()?;
                             if n2 < 0xDC00 || n2 > 0xDFFF {
                                 return self.error(LoneLeadingSurrogateInHexEscape)
                             }
@@ -2174,7 +2174,7 @@ impl ::Decoder for Decoder {
     }
 
     fn read_char(&mut self) -> DecodeResult<char> {
-        let s = try!(self.read_str());
+        let s = self.read_str()?;
         {
             let mut it = s.chars();
             match (it.next(), it.next()) {
@@ -2264,7 +2264,7 @@ impl ::Decoder for Decoder {
     fn read_struct<T, F>(&mut self, _name: &str, _len: usize, f: F) -> DecodeResult<T> where
         F: FnOnce(&mut Decoder) -> DecodeResult<T>,
     {
-        let value = try!(f(self));
+        let value = f(self)?;
         self.pop();
         Ok(value)
     }
@@ -2276,7 +2276,7 @@ impl ::Decoder for Decoder {
                                -> DecodeResult<T> where
         F: FnOnce(&mut Decoder) -> DecodeResult<T>,
     {
-        let mut obj = try!(expect!(self.pop(), Object));
+        let mut obj = expect!(self.pop(), Object)?;
 
         let value = match obj.remove(&name.to_string()) {
             None => {
@@ -2290,7 +2290,7 @@ impl ::Decoder for Decoder {
             },
             Some(json) => {
                 self.stack.push(json);
-                try!(f(self))
+                f(self)?
             }
         };
         self.stack.push(Json::Object(obj));
@@ -2346,7 +2346,7 @@ impl ::Decoder for Decoder {
     fn read_seq<T, F>(&mut self, f: F) -> DecodeResult<T> where
         F: FnOnce(&mut Decoder, usize) -> DecodeResult<T>,
     {
-        let array = try!(expect!(self.pop(), Array));
+        let array = expect!(self.pop(), Array)?;
         let len = array.len();
         for v in array.into_iter().rev() {
             self.stack.push(v);
@@ -2363,7 +2363,7 @@ impl ::Decoder for Decoder {
     fn read_map<T, F>(&mut self, f: F) -> DecodeResult<T> where
         F: FnOnce(&mut Decoder, usize) -> DecodeResult<T>,
     {
-        let obj = try!(expect!(self.pop(), Object));
+        let obj = expect!(self.pop(), Object)?;
         let len = obj.len();
         for (key, value) in obj {
             self.stack.push(value);

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -34,6 +34,7 @@ Core encoding and decoding interfaces.
 #![feature(staged_api)]
 #![feature(str_char)]
 #![feature(unicode)]
+#![feature(question_mark)]
 #![cfg_attr(test, feature(test))]
 
 // test harness access

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -318,9 +318,9 @@ impl From<CString> for Vec<u8> {
 #[stable(feature = "cstr_debug", since = "1.3.0")]
 impl fmt::Debug for CStr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "\""));
+        write!(f, "\"")?;
         for byte in self.to_bytes().iter().flat_map(|&b| ascii::escape_default(b)) {
-            try!(f.write_char(byte as char));
+            f.write_char(byte as char)?;
         }
         write!(f, "\"")
     }

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -305,7 +305,7 @@ impl File {
     #[unstable(feature = "file_try_clone", reason = "newly added", issue = "31405")]
     pub fn try_clone(&self) -> io::Result<File> {
         Ok(File {
-            inner: try!(self.inner.duplicate())
+            inner: self.inner.duplicate()?
         })
     }
 }
@@ -565,7 +565,7 @@ impl OpenOptions {
     }
 
     fn _open(&self, path: &Path) -> io::Result<File> {
-        let inner = try!(fs_imp::File::open(path, &self.0));
+        let inner = fs_imp::File::open(path, &self.0)?;
         Ok(File { inner: inner })
     }
 }
@@ -1440,7 +1440,7 @@ impl DirBuilder {
     fn create_dir_all(&self, path: &Path) -> io::Result<()> {
         if path == Path::new("") || path.is_dir() { return Ok(()) }
         if let Some(p) = path.parent() {
-            try!(self.create_dir_all(p))
+            self.create_dir_all(p)?
         }
         self.inner.mkdir(path)
     }

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -213,7 +213,7 @@ impl<T> io::Seek for Cursor<T> where T: AsRef<[u8]> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let n = try!(Read::read(&mut try!(self.fill_buf()), buf));
+        let n = Read::read(&mut self.fill_buf()?, buf)?;
         self.pos += n as u64;
         Ok(n)
     }
@@ -232,7 +232,7 @@ impl<T> BufRead for Cursor<T> where T: AsRef<[u8]> {
 impl<'a> Write for Cursor<&'a mut [u8]> {
     fn write(&mut self, data: &[u8]) -> io::Result<usize> {
         let pos = cmp::min(self.pos, self.inner.len() as u64);
-        let amt = try!((&mut self.inner[(pos as usize)..]).write(data));
+        let amt = (&mut self.inner[(pos as usize)..]).write(data)?;
         self.pos += amt as u64;
         Ok(amt)
     }
@@ -271,7 +271,7 @@ impl Write for Cursor<Vec<u8>> {
 impl Write for Cursor<Box<[u8]>> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let pos = cmp::min(self.pos, self.inner.len() as u64);
-        let amt = try!((&mut self.inner[(pos as usize)..]).write(buf));
+        let amt = (&mut self.inner[(pos as usize)..]).write(buf)?;
         self.pos += amt as u64;
         Ok(amt)
     }

--- a/src/libstd/io/impls.rs
+++ b/src/libstd/io/impls.rs
@@ -196,7 +196,7 @@ impl<'a> Write for &'a mut [u8] {
 
     #[inline]
     fn write_all(&mut self, data: &[u8]) -> io::Result<()> {
-        if try!(self.write(data)) == data.len() {
+        if self.write(data)? == data.len() {
             Ok(())
         } else {
             Err(Error::new(ErrorKind::WriteZero, "failed to write whole buffer"))

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1433,7 +1433,7 @@ pub struct Chain<T, U> {
 impl<T: Read, U: Read> Read for Chain<T, U> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         if !self.done_first {
-            match try!(self.first.read(buf)) {
+            match self.first.read(buf)? {
                 0 => { self.done_first = true; }
                 n => return Ok(n),
             }
@@ -1475,7 +1475,7 @@ impl<T: Read> Read for Take<T> {
         }
 
         let max = cmp::min(buf.len() as u64, self.limit) as usize;
-        let n = try!(self.inner.read(&mut buf[..max]));
+        let n = self.inner.read(&mut buf[..max])?;
         self.limit -= n as u64;
         Ok(n)
     }
@@ -1484,7 +1484,7 @@ impl<T: Read> Read for Take<T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: BufRead> BufRead for Take<T> {
     fn fill_buf(&mut self) -> Result<&[u8]> {
-        let buf = try!(self.inner.fill_buf());
+        let buf = self.inner.fill_buf()?;
         let cap = cmp::min(buf.len() as u64, self.limit) as usize;
         Ok(&buf[..cap])
     }

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -55,7 +55,7 @@ pub fn copy<R: ?Sized, W: ?Sized>(reader: &mut R, writer: &mut W) -> io::Result<
             Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
             Err(e) => return Err(e),
         };
-        try!(writer.write_all(&buf[..len]));
+        writer.write_all(&buf[..len])?;
         written += len as u64;
     }
 }

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -270,6 +270,7 @@
 #![feature(unwind_attributes)]
 #![feature(vec_push_all)]
 #![feature(zero_one)]
+#![feature(question_mark)]
 
 // Issue# 30592: Systematically use alloc_system during stage0 since jemalloc
 // might be unavailable or disabled

--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -431,13 +431,13 @@ impl ToSocketAddrs for (Ipv6Addr, u16) {
 }
 
 fn resolve_socket_addr(s: &str, p: u16) -> io::Result<vec::IntoIter<SocketAddr>> {
-    let ips = try!(lookup_host(s));
-    let v: Vec<_> = try!(ips.map(|a| {
+    let ips = lookup_host(s)?;
+    let v: Vec<_> = ips.map(|a| {
         a.map(|mut a| {
             a.set_port(p);
             a
         })
-    }).collect());
+    }).collect()?;
     Ok(v.into_iter())
 }
 

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -487,16 +487,16 @@ impl fmt::Display for Ipv6Addr {
                 if zeros_len > 1 {
                     fn fmt_subslice(segments: &[u16], fmt: &mut fmt::Formatter) -> fmt::Result {
                         if !segments.is_empty() {
-                            try!(write!(fmt, "{:x}", segments[0]));
+                            write!(fmt, "{:x}", segments[0])?;
                             for &seg in &segments[1..] {
-                                try!(write!(fmt, ":{:x}", seg));
+                                write!(fmt, ":{:x}", seg)?;
                             }
                         }
                         Ok(())
                     }
 
-                    try!(fmt_subslice(&self.segments()[..zeros_at], fmt));
-                    try!(fmt.write_str("::"));
+                    fmt_subslice(&self.segments()[..zeros_at], fmt)?;
+                    fmt.write_str("::")?;
                     fmt_subslice(&self.segments()[zeros_at + zeros_len..], fmt)
                 } else {
                     let &[a, b, c, d, e, f, g, h] = &self.segments();

--- a/src/libstd/net/mod.rs
+++ b/src/libstd/net/mod.rs
@@ -74,7 +74,7 @@ fn each_addr<A: ToSocketAddrs, F, T>(addr: A, mut f: F) -> io::Result<T>
     where F: FnMut(&SocketAddr) -> io::Result<T>
 {
     let mut last_err = None;
-    for addr in try!(addr.to_socket_addrs()) {
+    for addr in addr.to_socket_addrs()? {
         match f(&addr) {
             Ok(l) => return Ok(l),
             Err(e) => last_err = Some(e),

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -70,7 +70,7 @@ impl UdpSocket {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn send_to<A: ToSocketAddrs>(&self, buf: &[u8], addr: A)
                                      -> io::Result<usize> {
-        match try!(addr.to_socket_addrs()).next() {
+        match addr.to_socket_addrs()?.next() {
             Some(addr) => self.0.send_to(buf, &addr),
             None => Err(Error::new(ErrorKind::InvalidInput,
                                    "no addresses to send data to")),

--- a/src/libstd/panic.rs
+++ b/src/libstd/panic.rs
@@ -315,7 +315,7 @@ pub fn recover<F: FnOnce() -> R + RecoverSafe, R>(f: F) -> Result<R> {
     let mut result = None;
     unsafe {
         let result = &mut result;
-        try!(unwind::try(move || *result = Some(f())))
+        unwind::try(move || *result = Some(f()))?
     }
     Ok(result.unwrap())
 }

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -520,7 +520,7 @@ impl Child {
             }
         }
 
-        let status = try!(self.wait());
+        let status = self.wait()?;
         Ok(Output {
             status: status,
             stdout: stdout,

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -234,7 +234,7 @@ impl<T: ?Sized> Mutex<T> {
     pub fn try_lock(&self) -> TryLockResult<MutexGuard<T>> {
         unsafe {
             if self.inner.lock.try_lock() {
-                Ok(try!(MutexGuard::new(&*self.inner, &self.data)))
+                Ok(MutexGuard::new(&*self.inner, &self.data)?)
             } else {
                 Err(TryLockError::WouldBlock)
             }
@@ -353,7 +353,7 @@ impl StaticMutex {
     pub fn try_lock(&'static self) -> TryLockResult<MutexGuard<()>> {
         unsafe {
             if self.lock.try_lock() {
-                Ok(try!(MutexGuard::new(self, &DUMMY.0)))
+                Ok(MutexGuard::new(self, &DUMMY.0)?)
             } else {
                 Err(TryLockError::WouldBlock)
             }

--- a/src/libstd/sync/rwlock.rs
+++ b/src/libstd/sync/rwlock.rs
@@ -205,7 +205,7 @@ impl<T: ?Sized> RwLock<T> {
     pub fn try_read(&self) -> TryLockResult<RwLockReadGuard<T>> {
         unsafe {
             if self.inner.lock.try_read() {
-                Ok(try!(RwLockReadGuard::new(&*self.inner, &self.data)))
+                Ok(RwLockReadGuard::new(&*self.inner, &self.data)?)
             } else {
                 Err(TryLockError::WouldBlock)
             }
@@ -257,7 +257,7 @@ impl<T: ?Sized> RwLock<T> {
     pub fn try_write(&self) -> TryLockResult<RwLockWriteGuard<T>> {
         unsafe {
             if self.inner.lock.try_write() {
-                Ok(try!(RwLockWriteGuard::new(&*self.inner, &self.data)))
+                Ok(RwLockWriteGuard::new(&*self.inner, &self.data)?)
             } else {
                 Err(TryLockError::WouldBlock)
             }
@@ -382,7 +382,7 @@ impl StaticRwLock {
                     -> TryLockResult<RwLockReadGuard<'static, ()>> {
         unsafe {
             if self.lock.try_read(){
-                Ok(try!(RwLockReadGuard::new(self, &DUMMY.0)))
+                Ok(RwLockReadGuard::new(self, &DUMMY.0)?)
             } else {
                 Err(TryLockError::WouldBlock)
             }
@@ -409,7 +409,7 @@ impl StaticRwLock {
                      -> TryLockResult<RwLockWriteGuard<'static, ()>> {
         unsafe {
             if self.lock.try_write() {
-                Ok(try!(RwLockWriteGuard::new(self, &DUMMY.0)))
+                Ok(RwLockWriteGuard::new(self, &DUMMY.0)?)
             } else {
                 Err(TryLockError::WouldBlock)
             }

--- a/src/libstd/sys/common/backtrace.rs
+++ b/src/libstd/sys/common/backtrace.rs
@@ -46,10 +46,10 @@ pub fn log_enabled() -> bool {
 // These output functions should now be used everywhere to ensure consistency.
 pub fn output(w: &mut Write, idx: isize, addr: *mut libc::c_void,
               s: Option<&[u8]>) -> io::Result<()> {
-    try!(write!(w, "  {:2}: {:2$?} - ", idx, addr, HEX_WIDTH));
+    write!(w, "  {:2}: {:2$?} - ", idx, addr, HEX_WIDTH)?;
     match s.and_then(|s| str::from_utf8(s).ok()) {
-        Some(string) => try!(demangle(w, string)),
-        None => try!(write!(w, "<unknown>")),
+        Some(string) => demangle(w, string)?,
+        None => write!(w, "<unknown>")?,
     }
     w.write_all(&['\n' as u8])
 }
@@ -59,9 +59,9 @@ pub fn output_fileline(w: &mut Write, file: &[u8], line: libc::c_int,
                        more: bool) -> io::Result<()> {
     let file = str::from_utf8(file).unwrap_or("<unknown>");
     // prior line: "  ##: {:2$} - func"
-    try!(write!(w, "      {:3$}at {}:{}", "", file, line, HEX_WIDTH));
+    write!(w, "      {:3$}at {}:{}", "", file, line, HEX_WIDTH)?;
     if more {
-        try!(write!(w, " <... and possibly more>"));
+        write!(w, " <... and possibly more>")?;
     }
     w.write_all(&['\n' as u8])
 }
@@ -121,12 +121,12 @@ pub fn demangle(writer: &mut Write, s: &str) -> io::Result<()> {
 
     // Alright, let's do this.
     if !valid {
-        try!(writer.write_all(s.as_bytes()));
+        writer.write_all(s.as_bytes())?;
     } else {
         let mut first = true;
         while !inner.is_empty() {
             if !first {
-                try!(writer.write_all(b"::"));
+                writer.write_all(b"::")?;
             } else {
                 first = false;
             }
@@ -177,7 +177,7 @@ pub fn demangle(writer: &mut Write, s: &str) -> io::Result<()> {
                         None => rest.len(),
                         Some(i) => i,
                     };
-                    try!(writer.write_all(rest[..idx].as_bytes()));
+                    writer.write_all(rest[..idx].as_bytes())?;
                     rest = &rest[idx..];
                 }
             }

--- a/src/libstd/sys/common/gnu/libbacktrace.rs
+++ b/src/libstd/sys/common/gnu/libbacktrace.rs
@@ -172,9 +172,9 @@ pub fn print(w: &mut Write, idx: isize, addr: *mut libc::c_void,
                           data_addr as *mut libc::c_void)
     };
     if ret == 0 || data.is_null() {
-        try!(output(w, idx, addr, None));
+        output(w, idx, addr, None)?;
     } else {
-        try!(output(w, idx, addr, Some(unsafe { CStr::from_ptr(data).to_bytes() })));
+        output(w, idx, addr, Some(unsafe { CStr::from_ptr(data).to_bytes() }))?;
     }
 
     // pcinfo may return an arbitrary number of file:line pairs,
@@ -198,7 +198,7 @@ pub fn print(w: &mut Write, idx: isize, addr: *mut libc::c_void,
         for (i, &(file, line)) in fileline_buf[..fileline_count].iter().enumerate() {
             if file.is_null() { continue; } // just to be sure
             let file = unsafe { CStr::from_ptr(file).to_bytes() };
-            try!(output_fileline(w, file, line, i == FILELINE_SIZE - 1));
+            output_fileline(w, file, line, i == FILELINE_SIZE - 1)?;
         }
     }
 

--- a/src/libstd/sys/common/net.rs
+++ b/src/libstd/sys/common/net.rs
@@ -48,8 +48,8 @@ pub fn setsockopt<T>(sock: &Socket, opt: c_int, val: c_int,
                      payload: T) -> io::Result<()> {
     unsafe {
         let payload = &payload as *const T as *const c_void;
-        try!(cvt(c::setsockopt(*sock.as_inner(), opt, val, payload,
-                               mem::size_of::<T>() as c::socklen_t)));
+        cvt(c::setsockopt(*sock.as_inner(), opt, val, payload,
+                               mem::size_of::<T>() as c::socklen_t))?;
         Ok(())
     }
 }
@@ -59,9 +59,9 @@ pub fn getsockopt<T: Copy>(sock: &Socket, opt: c_int,
     unsafe {
         let mut slot: T = mem::zeroed();
         let mut len = mem::size_of::<T>() as c::socklen_t;
-        try!(cvt(c::getsockopt(*sock.as_inner(), opt, val,
+        cvt(c::getsockopt(*sock.as_inner(), opt, val,
                                &mut slot as *mut _ as *mut _,
-                               &mut len)));
+                               &mut len))?;
         assert_eq!(len as usize, mem::size_of::<T>());
         Ok(slot)
     }
@@ -73,7 +73,7 @@ fn sockname<F>(f: F) -> io::Result<SocketAddr>
     unsafe {
         let mut storage: c::sockaddr_storage = mem::zeroed();
         let mut len = mem::size_of_val(&storage) as c::socklen_t;
-        try!(cvt(f(&mut storage as *mut _ as *mut _, &mut len)));
+        cvt(f(&mut storage as *mut _ as *mut _, &mut len))?;
         sockaddr_to_addr(&storage, len as usize)
     }
 }
@@ -143,11 +143,11 @@ impl Drop for LookupHost {
 pub fn lookup_host(host: &str) -> io::Result<LookupHost> {
     init();
 
-    let c_host = try!(CString::new(host));
+    let c_host = CString::new(host)?;
     let mut res = ptr::null_mut();
     unsafe {
-        try!(cvt_gai(c::getaddrinfo(c_host.as_ptr(), ptr::null(), ptr::null(),
-                                   &mut res)));
+        cvt_gai(c::getaddrinfo(c_host.as_ptr(), ptr::null(), ptr::null(),
+                                   &mut res))?;
         Ok(LookupHost { original: res, cur: res })
     }
 }
@@ -164,10 +164,10 @@ impl TcpStream {
     pub fn connect(addr: &SocketAddr) -> io::Result<TcpStream> {
         init();
 
-        let sock = try!(Socket::new(addr, c::SOCK_STREAM));
+        let sock = Socket::new(addr, c::SOCK_STREAM)?;
 
         let (addrp, len) = addr.into_inner();
-        try!(cvt_r(|| unsafe { c::connect(*sock.as_inner(), addrp, len) }));
+        cvt_r(|| unsafe { c::connect(*sock.as_inner(), addrp, len) })?;
         Ok(TcpStream { inner: sock })
     }
 
@@ -201,12 +201,12 @@ impl TcpStream {
 
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
         let len = cmp::min(buf.len(), <wrlen_t>::max_value() as usize) as wrlen_t;
-        let ret = try!(cvt(unsafe {
+        let ret = cvt(unsafe {
             c::send(*self.inner.as_inner(),
                     buf.as_ptr() as *const c_void,
                     len,
                     0)
-        }));
+        })?;
         Ok(ret as usize)
     }
 
@@ -243,7 +243,7 @@ impl TcpStream {
     }
 
     pub fn ttl(&self) -> io::Result<u32> {
-        let raw: c_int = try!(getsockopt(&self.inner, c::IPPROTO_IP, c::IP_TTL));
+        let raw: c_int = getsockopt(&self.inner, c::IPPROTO_IP, c::IP_TTL)?;
         Ok(raw as u32)
     }
 
@@ -252,7 +252,7 @@ impl TcpStream {
     }
 
     pub fn only_v6(&self) -> io::Result<bool> {
-        let raw: c_int = try!(getsockopt(&self.inner, c::IPPROTO_IPV6, c::IPV6_V6ONLY));
+        let raw: c_int = getsockopt(&self.inner, c::IPPROTO_IPV6, c::IPV6_V6ONLY)?;
         Ok(raw != 0)
     }
 
@@ -301,22 +301,22 @@ impl TcpListener {
     pub fn bind(addr: &SocketAddr) -> io::Result<TcpListener> {
         init();
 
-        let sock = try!(Socket::new(addr, c::SOCK_STREAM));
+        let sock = Socket::new(addr, c::SOCK_STREAM)?;
 
         // On platforms with Berkeley-derived sockets, this allows
         // to quickly rebind a socket, without needing to wait for
         // the OS to clean up the previous one.
         if !cfg!(windows) {
-            try!(setsockopt(&sock, c::SOL_SOCKET, c::SO_REUSEADDR,
-                            1 as c_int));
+            setsockopt(&sock, c::SOL_SOCKET, c::SO_REUSEADDR,
+                            1 as c_int)?;
         }
 
         // Bind our new socket
         let (addrp, len) = addr.into_inner();
-        try!(cvt(unsafe { c::bind(*sock.as_inner(), addrp, len) }));
+        cvt(unsafe { c::bind(*sock.as_inner(), addrp, len) })?;
 
         // Start listening
-        try!(cvt(unsafe { c::listen(*sock.as_inner(), 128) }));
+        cvt(unsafe { c::listen(*sock.as_inner(), 128) })?;
         Ok(TcpListener { inner: sock })
     }
 
@@ -333,9 +333,9 @@ impl TcpListener {
     pub fn accept(&self) -> io::Result<(TcpStream, SocketAddr)> {
         let mut storage: c::sockaddr_storage = unsafe { mem::zeroed() };
         let mut len = mem::size_of_val(&storage) as c::socklen_t;
-        let sock = try!(self.inner.accept(&mut storage as *mut _ as *mut _,
-                                          &mut len));
-        let addr = try!(sockaddr_to_addr(&storage, len as usize));
+        let sock = self.inner.accept(&mut storage as *mut _ as *mut _,
+                                          &mut len)?;
+        let addr = sockaddr_to_addr(&storage, len as usize)?;
         Ok((TcpStream { inner: sock, }, addr))
     }
 
@@ -348,7 +348,7 @@ impl TcpListener {
     }
 
     pub fn ttl(&self) -> io::Result<u32> {
-        let raw: c_int = try!(getsockopt(&self.inner, c::IPPROTO_IP, c::IP_TTL));
+        let raw: c_int = getsockopt(&self.inner, c::IPPROTO_IP, c::IP_TTL)?;
         Ok(raw as u32)
     }
 
@@ -357,7 +357,7 @@ impl TcpListener {
     }
 
     pub fn only_v6(&self) -> io::Result<bool> {
-        let raw: c_int = try!(getsockopt(&self.inner, c::IPPROTO_IPV6, c::IPV6_V6ONLY));
+        let raw: c_int = getsockopt(&self.inner, c::IPPROTO_IPV6, c::IPV6_V6ONLY)?;
         Ok(raw != 0)
     }
 
@@ -402,9 +402,9 @@ impl UdpSocket {
     pub fn bind(addr: &SocketAddr) -> io::Result<UdpSocket> {
         init();
 
-        let sock = try!(Socket::new(addr, c::SOCK_DGRAM));
+        let sock = Socket::new(addr, c::SOCK_DGRAM)?;
         let (addrp, len) = addr.into_inner();
-        try!(cvt(unsafe { c::bind(*sock.as_inner(), addrp, len) }));
+        cvt(unsafe { c::bind(*sock.as_inner(), addrp, len) })?;
         Ok(UdpSocket { inner: sock })
     }
 
@@ -423,23 +423,23 @@ impl UdpSocket {
         let mut addrlen = mem::size_of_val(&storage) as c::socklen_t;
         let len = cmp::min(buf.len(), <wrlen_t>::max_value() as usize) as wrlen_t;
 
-        let n = try!(cvt(unsafe {
+        let n = cvt(unsafe {
             c::recvfrom(*self.inner.as_inner(),
                         buf.as_mut_ptr() as *mut c_void,
                         len, 0,
                         &mut storage as *mut _ as *mut _, &mut addrlen)
-        }));
-        Ok((n as usize, try!(sockaddr_to_addr(&storage, addrlen as usize))))
+        })?;
+        Ok((n as usize, sockaddr_to_addr(&storage, addrlen as usize)?))
     }
 
     pub fn send_to(&self, buf: &[u8], dst: &SocketAddr) -> io::Result<usize> {
         let len = cmp::min(buf.len(), <wrlen_t>::max_value() as usize) as wrlen_t;
         let (dstp, dstlen) = dst.into_inner();
-        let ret = try!(cvt(unsafe {
+        let ret = cvt(unsafe {
             c::sendto(*self.inner.as_inner(),
                       buf.as_ptr() as *const c_void, len,
                       0, dstp, dstlen)
-        }));
+        })?;
         Ok(ret as usize)
     }
 
@@ -468,7 +468,7 @@ impl UdpSocket {
     }
 
     pub fn broadcast(&self) -> io::Result<bool> {
-        let raw: c_int = try!(getsockopt(&self.inner, c::SOL_SOCKET, c::SO_BROADCAST));
+        let raw: c_int = getsockopt(&self.inner, c::SOL_SOCKET, c::SO_BROADCAST)?;
         Ok(raw != 0)
     }
 
@@ -477,7 +477,7 @@ impl UdpSocket {
     }
 
     pub fn multicast_loop_v4(&self) -> io::Result<bool> {
-        let raw: c_int = try!(getsockopt(&self.inner, c::IPPROTO_IP, c::IP_MULTICAST_LOOP));
+        let raw: c_int = getsockopt(&self.inner, c::IPPROTO_IP, c::IP_MULTICAST_LOOP)?;
         Ok(raw != 0)
     }
 
@@ -486,7 +486,7 @@ impl UdpSocket {
     }
 
     pub fn multicast_ttl_v4(&self) -> io::Result<u32> {
-        let raw: c_int = try!(getsockopt(&self.inner, c::IPPROTO_IP, c::IP_MULTICAST_TTL));
+        let raw: c_int = getsockopt(&self.inner, c::IPPROTO_IP, c::IP_MULTICAST_TTL)?;
         Ok(raw as u32)
     }
 
@@ -495,7 +495,7 @@ impl UdpSocket {
     }
 
     pub fn multicast_loop_v6(&self) -> io::Result<bool> {
-        let raw: c_int = try!(getsockopt(&self.inner, c::IPPROTO_IPV6, c::IPV6_MULTICAST_LOOP));
+        let raw: c_int = getsockopt(&self.inner, c::IPPROTO_IPV6, c::IPV6_MULTICAST_LOOP)?;
         Ok(raw != 0)
     }
 
@@ -540,7 +540,7 @@ impl UdpSocket {
     }
 
     pub fn ttl(&self) -> io::Result<u32> {
-        let raw: c_int = try!(getsockopt(&self.inner, c::IPPROTO_IP, c::IP_TTL));
+        let raw: c_int = getsockopt(&self.inner, c::IPPROTO_IP, c::IP_TTL)?;
         Ok(raw as u32)
     }
 
@@ -549,7 +549,7 @@ impl UdpSocket {
     }
 
     pub fn only_v6(&self) -> io::Result<bool> {
-        let raw: c_int = try!(getsockopt(&self.inner, c::IPPROTO_IPV6, c::IPV6_V6ONLY));
+        let raw: c_int = getsockopt(&self.inner, c::IPPROTO_IPV6, c::IPV6_V6ONLY)?;
         Ok(raw != 0)
     }
 
@@ -567,12 +567,12 @@ impl UdpSocket {
 
     pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
         let len = cmp::min(buf.len(), <wrlen_t>::max_value() as usize) as wrlen_t;
-        let ret = try!(cvt(unsafe {
+        let ret = cvt(unsafe {
             c::send(*self.inner.as_inner(),
                     buf.as_ptr() as *const c_void,
                     len,
                     0)
-        }));
+        })?;
         Ok(ret as usize)
     }
 

--- a/src/libstd/sys/common/net.rs
+++ b/src/libstd/sys/common/net.rs
@@ -49,7 +49,7 @@ pub fn setsockopt<T>(sock: &Socket, opt: c_int, val: c_int,
     unsafe {
         let payload = &payload as *const T as *const c_void;
         cvt(c::setsockopt(*sock.as_inner(), opt, val, payload,
-                               mem::size_of::<T>() as c::socklen_t))?;
+                          mem::size_of::<T>() as c::socklen_t))?;
         Ok(())
     }
 }
@@ -60,8 +60,8 @@ pub fn getsockopt<T: Copy>(sock: &Socket, opt: c_int,
         let mut slot: T = mem::zeroed();
         let mut len = mem::size_of::<T>() as c::socklen_t;
         cvt(c::getsockopt(*sock.as_inner(), opt, val,
-                               &mut slot as *mut _ as *mut _,
-                               &mut len))?;
+                          &mut slot as *mut _ as *mut _,
+                          &mut len))?;
         assert_eq!(len as usize, mem::size_of::<T>());
         Ok(slot)
     }
@@ -147,7 +147,7 @@ pub fn lookup_host(host: &str) -> io::Result<LookupHost> {
     let mut res = ptr::null_mut();
     unsafe {
         cvt_gai(c::getaddrinfo(c_host.as_ptr(), ptr::null(), ptr::null(),
-                                   &mut res))?;
+                               &mut res))?;
         Ok(LookupHost { original: res, cur: res })
     }
 }
@@ -308,7 +308,7 @@ impl TcpListener {
         // the OS to clean up the previous one.
         if !cfg!(windows) {
             setsockopt(&sock, c::SOL_SOCKET, c::SO_REUSEADDR,
-                            1 as c_int)?;
+                       1 as c_int)?;
         }
 
         // Bind our new socket
@@ -334,7 +334,7 @@ impl TcpListener {
         let mut storage: c::sockaddr_storage = unsafe { mem::zeroed() };
         let mut len = mem::size_of_val(&storage) as c::socklen_t;
         let sock = self.inner.accept(&mut storage as *mut _ as *mut _,
-                                          &mut len)?;
+                                     &mut len)?;
         let addr = sockaddr_to_addr(&storage, len as usize)?;
         Ok((TcpStream { inner: sock, }, addr))
     }

--- a/src/libstd/sys/common/remutex.rs
+++ b/src/libstd/sys/common/remutex.rs
@@ -99,7 +99,7 @@ impl<T> ReentrantMutex<T> {
     /// acquired.
     pub fn try_lock(&self) -> TryLockResult<ReentrantMutexGuard<T>> {
         if unsafe { self.inner.try_lock() } {
-            Ok(try!(ReentrantMutexGuard::new(&self)))
+            Ok(ReentrantMutexGuard::new(&self)?)
         } else {
             Err(TryLockError::WouldBlock)
         }

--- a/src/libstd/sys/common/wtf8.rs
+++ b/src/libstd/sys/common/wtf8.rs
@@ -388,32 +388,32 @@ impl fmt::Debug for Wtf8 {
         fn write_str_escaped(f: &mut fmt::Formatter, s: &str) -> fmt::Result {
             use fmt::Write;
             for c in s.chars().flat_map(|c| c.escape_default()) {
-                try!(f.write_char(c))
+                f.write_char(c)?
             }
             Ok(())
         }
 
-        try!(formatter.write_str("\""));
+        formatter.write_str("\"")?;
         let mut pos = 0;
         loop {
             match self.next_surrogate(pos) {
                 None => break,
                 Some((surrogate_pos, surrogate)) => {
-                    try!(write_str_escaped(
+                    write_str_escaped(
                         formatter,
                         unsafe { str::from_utf8_unchecked(
                             &self.bytes[pos .. surrogate_pos]
                         )},
-                    ));
-                    try!(write!(formatter, "\\u{{{:X}}}", surrogate));
+                    )?;
+                    write!(formatter, "\\u{{{:X}}}", surrogate)?;
                     pos = surrogate_pos + 3;
                 }
             }
         }
-        try!(write_str_escaped(
+        write_str_escaped(
             formatter,
             unsafe { str::from_utf8_unchecked(&self.bytes[pos..]) },
-        ));
+        )?;
         formatter.write_str("\"")
     }
 }

--- a/src/libstd/sys/unix/backtrace/tracing/backtrace_fn.rs
+++ b/src/libstd/sys/unix/backtrace/tracing/backtrace_fn.rs
@@ -40,7 +40,7 @@ pub fn write(w: &mut Write) -> io::Result<()> {
     static LOCK: StaticMutex = StaticMutex::new();
     let _g = LOCK.lock();
 
-    try!(writeln!(w, "stack backtrace:"));
+    writeln!(w, "stack backtrace:")?;
     // 100 lines should be enough
     const SIZE: usize = 100;
     let mut buf: [*mut libc::c_void; SIZE] = unsafe { mem::zeroed() };
@@ -48,7 +48,7 @@ pub fn write(w: &mut Write) -> io::Result<()> {
 
     // skipping the first one as it is write itself
     for i in 1..cnt {
-        try!(print(w, i as isize, buf[i], buf[i]))
+        print(w, i as isize, buf[i], buf[i])?
     }
     Ok(())
 }

--- a/src/libstd/sys/unix/backtrace/tracing/gcc_s.rs
+++ b/src/libstd/sys/unix/backtrace/tracing/gcc_s.rs
@@ -33,7 +33,7 @@ pub fn write(w: &mut Write) -> io::Result<()> {
     static LOCK: StaticMutex = StaticMutex::new();
     let _g = LOCK.lock();
 
-    try!(writeln!(w, "stack backtrace:"));
+    writeln!(w, "stack backtrace:")?;
 
     let mut cx = Context { writer: w, last_error: None, idx: 0 };
     return match unsafe {

--- a/src/libstd/sys/unix/ext/net.rs
+++ b/src/libstd/sys/unix/ext/net.rs
@@ -642,11 +642,11 @@ impl UnixDatagram {
                 let (addr, len) = sockaddr_un(path)?;
 
                 let count = cvt(libc::sendto(*d.0.as_inner(),
-                                                  buf.as_ptr() as *const _,
-                                                  buf.len(),
-                                                  0,
-                                                  &addr as *const _ as *const _,
-                                                  len))?;
+                                             buf.as_ptr() as *const _,
+                                             buf.len(),
+                                             0,
+                                             &addr as *const _ as *const _,
+                                             len))?;
                 Ok(count as usize)
             }
         }

--- a/src/libstd/sys/unix/ext/net.rs
+++ b/src/libstd/sys/unix/ext/net.rs
@@ -87,7 +87,7 @@ impl SocketAddr {
         unsafe {
             let mut addr: libc::sockaddr_un = mem::zeroed();
             let mut len = mem::size_of::<libc::sockaddr_un>() as libc::socklen_t;
-            try!(cvt(f(&mut addr as *mut _ as *mut _, &mut len)));
+            cvt(f(&mut addr as *mut _ as *mut _, &mut len))?;
             SocketAddr::from_parts(addr, len)
         }
     }
@@ -155,9 +155,9 @@ struct AsciiEscaped<'a>(&'a [u8]);
 
 impl<'a> fmt::Display for AsciiEscaped<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(fmt, "\""));
+        write!(fmt, "\"")?;
         for byte in self.0.iter().cloned().flat_map(ascii::escape_default) {
-            try!(write!(fmt, "{}", byte as char));
+            write!(fmt, "{}", byte as char)?;
         }
         write!(fmt, "\"")
     }
@@ -200,10 +200,10 @@ impl UnixStream {
     pub fn connect<P: AsRef<Path>>(path: P) -> io::Result<UnixStream> {
         fn inner(path: &Path) -> io::Result<UnixStream> {
             unsafe {
-                let inner = try!(Socket::new_raw(libc::AF_UNIX, libc::SOCK_STREAM));
-                let (addr, len) = try!(sockaddr_un(path));
+                let inner = Socket::new_raw(libc::AF_UNIX, libc::SOCK_STREAM)?;
+                let (addr, len) = sockaddr_un(path)?;
 
-                try!(cvt(libc::connect(*inner.as_inner(), &addr as *const _ as *const _, len)));
+                cvt(libc::connect(*inner.as_inner(), &addr as *const _ as *const _, len))?;
                 Ok(UnixStream(inner))
             }
         }
@@ -214,7 +214,7 @@ impl UnixStream {
     ///
     /// Returns two `UnixStream`s which are connected to each other.
     pub fn pair() -> io::Result<(UnixStream, UnixStream)> {
-        let (i1, i2) = try!(Socket::new_pair(libc::AF_UNIX, libc::SOCK_STREAM));
+        let (i1, i2) = Socket::new_pair(libc::AF_UNIX, libc::SOCK_STREAM)?;
         Ok((UnixStream(i1), UnixStream(i2)))
     }
 
@@ -395,11 +395,11 @@ impl UnixListener {
     pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixListener> {
         fn inner(path: &Path) -> io::Result<UnixListener> {
             unsafe {
-                let inner = try!(Socket::new_raw(libc::AF_UNIX, libc::SOCK_STREAM));
-                let (addr, len) = try!(sockaddr_un(path));
+                let inner = Socket::new_raw(libc::AF_UNIX, libc::SOCK_STREAM)?;
+                let (addr, len) = sockaddr_un(path)?;
 
-                try!(cvt(libc::bind(*inner.as_inner(), &addr as *const _ as *const _, len)));
-                try!(cvt(libc::listen(*inner.as_inner(), 128)));
+                cvt(libc::bind(*inner.as_inner(), &addr as *const _ as *const _, len))?;
+                cvt(libc::listen(*inner.as_inner(), 128))?;
 
                 Ok(UnixListener(inner))
             }
@@ -415,8 +415,8 @@ impl UnixListener {
     pub fn accept(&self) -> io::Result<(UnixStream, SocketAddr)> {
         let mut storage: libc::sockaddr_un = unsafe { mem::zeroed() };
         let mut len = mem::size_of_val(&storage) as libc::socklen_t;
-        let sock = try!(self.0.accept(&mut storage as *mut _ as *mut _, &mut len));
-        let addr = try!(SocketAddr::from_parts(storage, len));
+        let sock = self.0.accept(&mut storage as *mut _ as *mut _, &mut len)?;
+        let addr = SocketAddr::from_parts(storage, len)?;
         Ok((UnixStream(sock), addr))
     }
 
@@ -536,10 +536,10 @@ impl UnixDatagram {
     pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixDatagram> {
         fn inner(path: &Path) -> io::Result<UnixDatagram> {
             unsafe {
-                let socket = try!(UnixDatagram::unbound());
-                let (addr, len) = try!(sockaddr_un(path));
+                let socket = UnixDatagram::unbound()?;
+                let (addr, len) = sockaddr_un(path)?;
 
-                try!(cvt(libc::bind(*socket.0.as_inner(), &addr as *const _ as *const _, len)));
+                cvt(libc::bind(*socket.0.as_inner(), &addr as *const _ as *const _, len))?;
 
                 Ok(socket)
             }
@@ -549,7 +549,7 @@ impl UnixDatagram {
 
     /// Creates a Unix Datagram socket which is not bound to any address.
     pub fn unbound() -> io::Result<UnixDatagram> {
-        let inner = try!(Socket::new_raw(libc::AF_UNIX, libc::SOCK_DGRAM));
+        let inner = Socket::new_raw(libc::AF_UNIX, libc::SOCK_DGRAM)?;
         Ok(UnixDatagram(inner))
     }
 
@@ -557,7 +557,7 @@ impl UnixDatagram {
     ///
     /// Returns two `UnixDatagrams`s which are connected to each other.
     pub fn pair() -> io::Result<(UnixDatagram, UnixDatagram)> {
-        let (i1, i2) = try!(Socket::new_pair(libc::AF_UNIX, libc::SOCK_DGRAM));
+        let (i1, i2) = Socket::new_pair(libc::AF_UNIX, libc::SOCK_DGRAM)?;
         Ok((UnixDatagram(i1), UnixDatagram(i2)))
     }
 
@@ -568,9 +568,9 @@ impl UnixDatagram {
     pub fn connect<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
         fn inner(d: &UnixDatagram, path: &Path) -> io::Result<()> {
             unsafe {
-                let (addr, len) = try!(sockaddr_un(path));
+                let (addr, len) = sockaddr_un(path)?;
 
-                try!(cvt(libc::connect(*d.0.as_inner(), &addr as *const _ as *const _, len)));
+                cvt(libc::connect(*d.0.as_inner(), &addr as *const _ as *const _, len))?;
 
                 Ok(())
             }
@@ -605,7 +605,7 @@ impl UnixDatagram {
     /// whence the data came.
     pub fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
         let mut count = 0;
-        let addr = try!(SocketAddr::new(|addr, len| {
+        let addr = SocketAddr::new(|addr, len| {
             unsafe {
                 count = libc::recvfrom(*self.0.as_inner(),
                                        buf.as_mut_ptr() as *mut _,
@@ -621,7 +621,7 @@ impl UnixDatagram {
                     -1
                 }
             }
-        }));
+        })?;
 
         Ok((count as usize, addr))
     }
@@ -639,14 +639,14 @@ impl UnixDatagram {
     pub fn send_to<P: AsRef<Path>>(&self, buf: &[u8], path: P) -> io::Result<usize> {
         fn inner(d: &UnixDatagram, buf: &[u8], path: &Path) -> io::Result<usize> {
             unsafe {
-                let (addr, len) = try!(sockaddr_un(path));
+                let (addr, len) = sockaddr_un(path)?;
 
-                let count = try!(cvt(libc::sendto(*d.0.as_inner(),
+                let count = cvt(libc::sendto(*d.0.as_inner(),
                                                   buf.as_ptr() as *const _,
                                                   buf.len(),
                                                   0,
                                                   &addr as *const _ as *const _,
-                                                  len)));
+                                                  len))?;
                 Ok(count as usize)
             }
         }

--- a/src/libstd/sys/unix/fd.rs
+++ b/src/libstd/sys/unix/fd.rs
@@ -39,11 +39,11 @@ impl FileDesc {
     }
 
     pub fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
-        let ret = try!(cvt(unsafe {
+        let ret = cvt(unsafe {
             libc::read(self.fd,
                        buf.as_mut_ptr() as *mut c_void,
                        buf.len() as size_t)
-        }));
+        })?;
         Ok(ret as usize)
     }
 
@@ -53,11 +53,11 @@ impl FileDesc {
     }
 
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
-        let ret = try!(cvt(unsafe {
+        let ret = cvt(unsafe {
             libc::write(self.fd,
                         buf.as_ptr() as *const c_void,
                         buf.len() as size_t)
-        }));
+        })?;
         Ok(ret as usize)
     }
 

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -418,18 +418,18 @@ impl OpenOptions {
 
 impl File {
     pub fn open(path: &Path, opts: &OpenOptions) -> io::Result<File> {
-        let path = try!(cstr(path));
+        let path = cstr(path)?;
         File::open_c(&path, opts)
     }
 
     pub fn open_c(path: &CStr, opts: &OpenOptions) -> io::Result<File> {
         let flags = libc::O_CLOEXEC |
-                    try!(opts.get_access_mode()) |
-                    try!(opts.get_creation_mode()) |
+                    opts.get_access_mode()? |
+                    opts.get_creation_mode()? |
                     (opts.custom_flags as c_int & !libc::O_ACCMODE);
-        let fd = try!(cvt_r(|| unsafe {
+        let fd = cvt_r(|| unsafe {
             open64(path.as_ptr(), flags, opts.mode as c_int)
-        }));
+        })?;
         let fd = FileDesc::new(fd);
 
         // Currently the standard library supports Linux 2.6.18 which did not
@@ -448,19 +448,19 @@ impl File {
 
     pub fn file_attr(&self) -> io::Result<FileAttr> {
         let mut stat: stat64 = unsafe { mem::zeroed() };
-        try!(cvt(unsafe {
+        cvt(unsafe {
             fstat64(self.0.raw(), &mut stat)
-        }));
+        })?;
         Ok(FileAttr { stat: stat })
     }
 
     pub fn fsync(&self) -> io::Result<()> {
-        try!(cvt_r(|| unsafe { libc::fsync(self.0.raw()) }));
+        cvt_r(|| unsafe { libc::fsync(self.0.raw()) })?;
         Ok(())
     }
 
     pub fn datasync(&self) -> io::Result<()> {
-        try!(cvt_r(|| unsafe { os_datasync(self.0.raw()) }));
+        cvt_r(|| unsafe { os_datasync(self.0.raw()) })?;
         return Ok(());
 
         #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -476,9 +476,9 @@ impl File {
     }
 
     pub fn truncate(&self, size: u64) -> io::Result<()> {
-        try!(cvt_r(|| unsafe {
+        cvt_r(|| unsafe {
             ftruncate64(self.0.raw(), size as off64_t)
-        }));
+        })?;
         Ok(())
     }
 
@@ -502,7 +502,7 @@ impl File {
             SeekFrom::End(off) => (libc::SEEK_END, off as off64_t),
             SeekFrom::Current(off) => (libc::SEEK_CUR, off as off64_t),
         };
-        let n = try!(cvt(unsafe { lseek64(self.0.raw(), pos, whence) }));
+        let n = cvt(unsafe { lseek64(self.0.raw(), pos, whence) })?;
         Ok(n as u64)
     }
 
@@ -521,8 +521,8 @@ impl DirBuilder {
     }
 
     pub fn mkdir(&self, p: &Path) -> io::Result<()> {
-        let p = try!(cstr(p));
-        try!(cvt(unsafe { libc::mkdir(p.as_ptr(), self.mode) }));
+        let p = cstr(p)?;
+        cvt(unsafe { libc::mkdir(p.as_ptr(), self.mode) })?;
         Ok(())
     }
 
@@ -532,7 +532,7 @@ impl DirBuilder {
 }
 
 fn cstr(path: &Path) -> io::Result<CString> {
-    Ok(try!(CString::new(path.as_os_str().as_bytes())))
+    Ok(CString::new(path.as_os_str().as_bytes())?)
 }
 
 impl FromInner<c_int> for File {
@@ -610,7 +610,7 @@ impl fmt::Debug for File {
 
 pub fn readdir(p: &Path) -> io::Result<ReadDir> {
     let root = Arc::new(p.to_path_buf());
-    let p = try!(cstr(p));
+    let p = cstr(p)?;
     unsafe {
         let ptr = libc::opendir(p.as_ptr());
         if ptr.is_null() {
@@ -622,32 +622,32 @@ pub fn readdir(p: &Path) -> io::Result<ReadDir> {
 }
 
 pub fn unlink(p: &Path) -> io::Result<()> {
-    let p = try!(cstr(p));
-    try!(cvt(unsafe { libc::unlink(p.as_ptr()) }));
+    let p = cstr(p)?;
+    cvt(unsafe { libc::unlink(p.as_ptr()) })?;
     Ok(())
 }
 
 pub fn rename(old: &Path, new: &Path) -> io::Result<()> {
-    let old = try!(cstr(old));
-    let new = try!(cstr(new));
-    try!(cvt(unsafe { libc::rename(old.as_ptr(), new.as_ptr()) }));
+    let old = cstr(old)?;
+    let new = cstr(new)?;
+    cvt(unsafe { libc::rename(old.as_ptr(), new.as_ptr()) })?;
     Ok(())
 }
 
 pub fn set_perm(p: &Path, perm: FilePermissions) -> io::Result<()> {
-    let p = try!(cstr(p));
-    try!(cvt_r(|| unsafe { libc::chmod(p.as_ptr(), perm.mode) }));
+    let p = cstr(p)?;
+    cvt_r(|| unsafe { libc::chmod(p.as_ptr(), perm.mode) })?;
     Ok(())
 }
 
 pub fn rmdir(p: &Path) -> io::Result<()> {
-    let p = try!(cstr(p));
-    try!(cvt(unsafe { libc::rmdir(p.as_ptr()) }));
+    let p = cstr(p)?;
+    cvt(unsafe { libc::rmdir(p.as_ptr()) })?;
     Ok(())
 }
 
 pub fn remove_dir_all(path: &Path) -> io::Result<()> {
-    let filetype = try!(lstat(path)).file_type();
+    let filetype = lstat(path)?.file_type();
     if filetype.is_symlink() {
         unlink(path)
     } else {
@@ -656,27 +656,27 @@ pub fn remove_dir_all(path: &Path) -> io::Result<()> {
 }
 
 fn remove_dir_all_recursive(path: &Path) -> io::Result<()> {
-    for child in try!(readdir(path)) {
-        let child = try!(child);
-        if try!(child.file_type()).is_dir() {
-            try!(remove_dir_all_recursive(&child.path()));
+    for child in readdir(path)? {
+        let child = child?;
+        if child.file_type()?.is_dir() {
+            remove_dir_all_recursive(&child.path())?;
         } else {
-            try!(unlink(&child.path()));
+            unlink(&child.path())?;
         }
     }
     rmdir(path)
 }
 
 pub fn readlink(p: &Path) -> io::Result<PathBuf> {
-    let c_path = try!(cstr(p));
+    let c_path = cstr(p)?;
     let p = c_path.as_ptr();
 
     let mut buf = Vec::with_capacity(256);
 
     loop {
-        let buf_read = try!(cvt(unsafe {
+        let buf_read = cvt(unsafe {
             libc::readlink(p, buf.as_mut_ptr() as *mut _, buf.capacity() as libc::size_t)
-        })) as usize;
+        })? as usize;
 
         unsafe { buf.set_len(buf_read); }
 
@@ -694,39 +694,39 @@ pub fn readlink(p: &Path) -> io::Result<PathBuf> {
 }
 
 pub fn symlink(src: &Path, dst: &Path) -> io::Result<()> {
-    let src = try!(cstr(src));
-    let dst = try!(cstr(dst));
-    try!(cvt(unsafe { libc::symlink(src.as_ptr(), dst.as_ptr()) }));
+    let src = cstr(src)?;
+    let dst = cstr(dst)?;
+    cvt(unsafe { libc::symlink(src.as_ptr(), dst.as_ptr()) })?;
     Ok(())
 }
 
 pub fn link(src: &Path, dst: &Path) -> io::Result<()> {
-    let src = try!(cstr(src));
-    let dst = try!(cstr(dst));
-    try!(cvt(unsafe { libc::link(src.as_ptr(), dst.as_ptr()) }));
+    let src = cstr(src)?;
+    let dst = cstr(dst)?;
+    cvt(unsafe { libc::link(src.as_ptr(), dst.as_ptr()) })?;
     Ok(())
 }
 
 pub fn stat(p: &Path) -> io::Result<FileAttr> {
-    let p = try!(cstr(p));
+    let p = cstr(p)?;
     let mut stat: stat64 = unsafe { mem::zeroed() };
-    try!(cvt(unsafe {
+    cvt(unsafe {
         stat64(p.as_ptr(), &mut stat as *mut _ as *mut _)
-    }));
+    })?;
     Ok(FileAttr { stat: stat })
 }
 
 pub fn lstat(p: &Path) -> io::Result<FileAttr> {
-    let p = try!(cstr(p));
+    let p = cstr(p)?;
     let mut stat: stat64 = unsafe { mem::zeroed() };
-    try!(cvt(unsafe {
+    cvt(unsafe {
         lstat64(p.as_ptr(), &mut stat as *mut _ as *mut _)
-    }));
+    })?;
     Ok(FileAttr { stat: stat })
 }
 
 pub fn canonicalize(p: &Path) -> io::Result<PathBuf> {
-    let path = try!(CString::new(p.as_os_str().as_bytes()));
+    let path = CString::new(p.as_os_str().as_bytes())?;
     let buf;
     unsafe {
         let r = libc::realpath(path.as_ptr(), ptr::null_mut());
@@ -746,11 +746,11 @@ pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
                               "the source path is not an existing regular file"))
     }
 
-    let mut reader = try!(File::open(from));
-    let mut writer = try!(File::create(to));
-    let perm = try!(reader.metadata()).permissions();
+    let mut reader = File::open(from)?;
+    let mut writer = File::create(to)?;
+    let perm = reader.metadata()?.permissions();
 
-    let ret = try!(io::copy(&mut reader, &mut writer));
-    try!(set_permissions(to, perm));
+    let ret = io::copy(&mut reader, &mut writer)?;
+    set_permissions(to, perm)?;
     Ok(ret)
 }

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -110,7 +110,7 @@ pub fn getcwd() -> io::Result<PathBuf> {
 
 pub fn chdir(p: &path::Path) -> io::Result<()> {
     let p: &OsStr = p.as_ref();
-    let p = try!(CString::new(p.as_bytes()));
+    let p = CString::new(p.as_bytes())?;
     unsafe {
         match libc::chdir(p.as_ptr()) == (0 as c_int) {
             true => Ok(()),
@@ -180,16 +180,16 @@ pub fn current_exe() -> io::Result<PathBuf> {
                        libc::KERN_PROC_PATHNAME as c_int,
                        -1 as c_int];
         let mut sz: libc::size_t = 0;
-        try!(cvt(libc::sysctl(mib.as_mut_ptr(), mib.len() as ::libc::c_uint,
+        cvt(libc::sysctl(mib.as_mut_ptr(), mib.len() as ::libc::c_uint,
                               ptr::null_mut(), &mut sz, ptr::null_mut(),
-                              0 as libc::size_t)));
+                              0 as libc::size_t))?;
         if sz == 0 {
             return Err(io::Error::last_os_error())
         }
         let mut v: Vec<u8> = Vec::with_capacity(sz as usize);
-        try!(cvt(libc::sysctl(mib.as_mut_ptr(), mib.len() as ::libc::c_uint,
+        cvt(libc::sysctl(mib.as_mut_ptr(), mib.len() as ::libc::c_uint,
                               v.as_mut_ptr() as *mut libc::c_void, &mut sz,
-                              ptr::null_mut(), 0 as libc::size_t)));
+                              ptr::null_mut(), 0 as libc::size_t))?;
         if sz == 0 {
             return Err(io::Error::last_os_error());
         }
@@ -217,11 +217,11 @@ pub fn current_exe() -> io::Result<PathBuf> {
                        libc::KERN_PROC_ARGV];
         let mib = mib.as_mut_ptr();
         let mut argv_len = 0;
-        try!(cvt(libc::sysctl(mib, 4, 0 as *mut _, &mut argv_len,
-                              0 as *mut _, 0)));
+        cvt(libc::sysctl(mib, 4, 0 as *mut _, &mut argv_len,
+                              0 as *mut _, 0))?;
         let mut argv = Vec::<*const libc::c_char>::with_capacity(argv_len as usize);
-        try!(cvt(libc::sysctl(mib, 4, argv.as_mut_ptr() as *mut _,
-                              &mut argv_len, 0 as *mut _, 0)));
+        cvt(libc::sysctl(mib, 4, argv.as_mut_ptr() as *mut _,
+                              &mut argv_len, 0 as *mut _, 0))?;
         argv.set_len(argv_len as usize);
         if argv[0].is_null() {
             return Err(io::Error::new(io::ErrorKind::Other,
@@ -460,7 +460,7 @@ pub fn env() -> Env {
 pub fn getenv(k: &OsStr) -> io::Result<Option<OsString>> {
     // environment variables with a nul byte can't be set, so their value is
     // always None as well
-    let k = try!(CString::new(k.as_bytes()));
+    let k = CString::new(k.as_bytes())?;
     let _g = ENV_LOCK.lock();
     Ok(unsafe {
         let s = libc::getenv(k.as_ptr()) as *const _;
@@ -473,8 +473,8 @@ pub fn getenv(k: &OsStr) -> io::Result<Option<OsString>> {
 }
 
 pub fn setenv(k: &OsStr, v: &OsStr) -> io::Result<()> {
-    let k = try!(CString::new(k.as_bytes()));
-    let v = try!(CString::new(v.as_bytes()));
+    let k = CString::new(k.as_bytes())?;
+    let v = CString::new(v.as_bytes())?;
     let _g = ENV_LOCK.lock();
     cvt(unsafe {
         libc::setenv(k.as_ptr(), v.as_ptr(), 1)
@@ -482,7 +482,7 @@ pub fn setenv(k: &OsStr, v: &OsStr) -> io::Result<()> {
 }
 
 pub fn unsetenv(n: &OsStr) -> io::Result<()> {
-    let nbuf = try!(CString::new(n.as_bytes()));
+    let nbuf = CString::new(n.as_bytes())?;
     let _g = ENV_LOCK.lock();
     cvt(unsafe {
         libc::unsetenv(nbuf.as_ptr())

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -181,15 +181,15 @@ pub fn current_exe() -> io::Result<PathBuf> {
                        -1 as c_int];
         let mut sz: libc::size_t = 0;
         cvt(libc::sysctl(mib.as_mut_ptr(), mib.len() as ::libc::c_uint,
-                              ptr::null_mut(), &mut sz, ptr::null_mut(),
-                              0 as libc::size_t))?;
+                         ptr::null_mut(), &mut sz, ptr::null_mut(),
+                         0 as libc::size_t))?;
         if sz == 0 {
             return Err(io::Error::last_os_error())
         }
         let mut v: Vec<u8> = Vec::with_capacity(sz as usize);
         cvt(libc::sysctl(mib.as_mut_ptr(), mib.len() as ::libc::c_uint,
-                              v.as_mut_ptr() as *mut libc::c_void, &mut sz,
-                              ptr::null_mut(), 0 as libc::size_t))?;
+                         v.as_mut_ptr() as *mut libc::c_void, &mut sz,
+                         ptr::null_mut(), 0 as libc::size_t))?;
         if sz == 0 {
             return Err(io::Error::last_os_error());
         }
@@ -218,10 +218,10 @@ pub fn current_exe() -> io::Result<PathBuf> {
         let mib = mib.as_mut_ptr();
         let mut argv_len = 0;
         cvt(libc::sysctl(mib, 4, 0 as *mut _, &mut argv_len,
-                              0 as *mut _, 0))?;
+                         0 as *mut _, 0))?;
         let mut argv = Vec::<*const libc::c_char>::with_capacity(argv_len as usize);
         cvt(libc::sysctl(mib, 4, argv.as_mut_ptr() as *mut _,
-                              &mut argv_len, 0 as *mut _, 0))?;
+                         &mut argv_len, 0 as *mut _, 0))?;
         argv.set_len(argv_len as usize);
         if argv[0].is_null() {
             return Err(io::Error::new(io::ErrorKind::Other,

--- a/src/libstd/sys/unix/pipe.rs
+++ b/src/libstd/sys/unix/pipe.rs
@@ -87,13 +87,13 @@ pub fn read2(p1: AnonPipe,
     let max = cmp::max(p1.raw(), p2.raw());
     loop {
         // wait for either pipe to become readable using `select`
-        try!(cvt_r(|| unsafe {
+        cvt_r(|| unsafe {
             let mut read: libc::fd_set = mem::zeroed();
             libc::FD_SET(p1.raw(), &mut read);
             libc::FD_SET(p2.raw(), &mut read);
             libc::select(max + 1, &mut read, 0 as *mut _, 0 as *mut _,
                          0 as *mut _)
-        }));
+        })?;
 
         // Read as much as we can from each pipe, ignoring EWOULDBLOCK or
         // EAGAIN. If we hit EOF, then this will happen because the underlying
@@ -113,11 +113,11 @@ pub fn read2(p1: AnonPipe,
                 }
             }
         };
-        if try!(read(&p1, v1)) {
+        if read(&p1, v1)? {
             p2.set_nonblocking(false);
             return p2.read_to_end(v2).map(|_| ());
         }
-        if try!(read(&p2, v2)) {
+        if read(&p2, v2)? {
             p1.set_nonblocking(false);
             return p1.read_to_end(v1).map(|_| ());
         }

--- a/src/libstd/sys/unix/process.rs
+++ b/src/libstd/sys/unix/process.rs
@@ -225,11 +225,11 @@ impl Command {
                                       "nul byte found in provided data"));
         }
 
-        let (ours, theirs) = try!(self.setup_io(default, needs_stdin));
-        let (input, output) = try!(sys::pipe::anon_pipe());
+        let (ours, theirs) = self.setup_io(default, needs_stdin)?;
+        let (input, output) = sys::pipe::anon_pipe()?;
 
         let pid = unsafe {
-            match try!(cvt(libc::fork())) {
+            match cvt(libc::fork())? {
                 0 => {
                     drop(input);
                     let err = self.do_exec(theirs);
@@ -343,17 +343,17 @@ impl Command {
         }
 
         if let Some(fd) = stdio.stdin.fd() {
-            try!(cvt_r(|| libc::dup2(fd, libc::STDIN_FILENO)));
+            cvt_r(|| libc::dup2(fd, libc::STDIN_FILENO))?;
         }
         if let Some(fd) = stdio.stdout.fd() {
-            try!(cvt_r(|| libc::dup2(fd, libc::STDOUT_FILENO)));
+            cvt_r(|| libc::dup2(fd, libc::STDOUT_FILENO))?;
         }
         if let Some(fd) = stdio.stderr.fd() {
-            try!(cvt_r(|| libc::dup2(fd, libc::STDERR_FILENO)));
+            cvt_r(|| libc::dup2(fd, libc::STDERR_FILENO))?;
         }
 
         if let Some(u) = self.gid {
-            try!(cvt(libc::setgid(u as gid_t)));
+            cvt(libc::setgid(u as gid_t))?;
         }
         if let Some(u) = self.uid {
             // When dropping privileges from root, the `setgroups` call
@@ -365,7 +365,7 @@ impl Command {
             // privilege dropping function.
             let _ = libc::setgroups(0, ptr::null());
 
-            try!(cvt(libc::setuid(u as uid_t)));
+            cvt(libc::setuid(u as uid_t))?;
         }
         if self.session_leader {
             // Don't check the error of setsid because it fails if we're the
@@ -374,7 +374,7 @@ impl Command {
             let _ = libc::setsid();
         }
         if let Some(ref cwd) = self.cwd {
-            try!(cvt(libc::chdir(cwd.as_ptr())));
+            cvt(libc::chdir(cwd.as_ptr()))?;
         }
         if let Some(ref envp) = self.envp {
             *sys::os::environ() = envp.as_ptr();
@@ -390,9 +390,9 @@ impl Command {
             // need to clean things up now to avoid confusing the program
             // we're about to run.
             let mut set: libc::sigset_t = mem::uninitialized();
-            try!(cvt(libc::sigemptyset(&mut set)));
-            try!(cvt(libc::pthread_sigmask(libc::SIG_SETMASK, &set,
-                                           ptr::null_mut())));
+            cvt(libc::sigemptyset(&mut set))?;
+            cvt(libc::pthread_sigmask(libc::SIG_SETMASK, &set,
+                                           ptr::null_mut()))?;
             let ret = libc::signal(libc::SIGPIPE, libc::SIG_DFL);
             if ret == libc::SIG_ERR {
                 return io::Error::last_os_error()
@@ -400,7 +400,7 @@ impl Command {
         }
 
         for callback in self.closures.iter_mut() {
-            try!(callback());
+            callback()?;
         }
 
         libc::execvp(self.argv[0], self.argv.as_ptr());
@@ -415,9 +415,9 @@ impl Command {
         let stdin = self.stdin.as_ref().unwrap_or(default_stdin);
         let stdout = self.stdout.as_ref().unwrap_or(&default);
         let stderr = self.stderr.as_ref().unwrap_or(&default);
-        let (their_stdin, our_stdin) = try!(stdin.to_child_stdio(true));
-        let (their_stdout, our_stdout) = try!(stdout.to_child_stdio(false));
-        let (their_stderr, our_stderr) = try!(stderr.to_child_stdio(false));
+        let (their_stdin, our_stdin) = stdin.to_child_stdio(true)?;
+        let (their_stdout, our_stdout) = stdout.to_child_stdio(false)?;
+        let (their_stderr, our_stderr) = stderr.to_child_stdio(false)?;
         let ours = StdioPipes {
             stdin: our_stdin,
             stdout: our_stdout,
@@ -454,14 +454,14 @@ impl Stdio {
             // overwritten prematurely.
             Stdio::Fd(ref fd) => {
                 if fd.raw() >= 0 && fd.raw() <= libc::STDERR_FILENO {
-                    Ok((ChildStdio::Owned(try!(fd.duplicate())), None))
+                    Ok((ChildStdio::Owned(fd.duplicate()?), None))
                 } else {
                     Ok((ChildStdio::Explicit(fd.raw()), None))
                 }
             }
 
             Stdio::MakePipe => {
-                let (reader, writer) = try!(pipe::anon_pipe());
+                let (reader, writer) = pipe::anon_pipe()?;
                 let (ours, theirs) = if readable {
                     (writer, reader)
                 } else {
@@ -477,7 +477,7 @@ impl Stdio {
                 let path = unsafe {
                     CStr::from_ptr("/dev/null\0".as_ptr() as *const _)
                 };
-                let fd = try!(File::open_c(&path, &opts));
+                let fd = File::open_c(&path, &opts)?;
                 Ok((ChildStdio::Owned(fd.into_fd()), None))
             }
         }
@@ -508,9 +508,9 @@ fn pair_to_key(key: &OsStr, value: &OsStr, saw_nul: &mut bool) -> CString {
 
 impl fmt::Debug for Command {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "{:?}", self.program));
+        write!(f, "{:?}", self.program)?;
         for arg in &self.args {
-            try!(write!(f, " {:?}", arg));
+            write!(f, " {:?}", arg)?;
         }
         Ok(())
     }
@@ -589,7 +589,7 @@ impl Process {
             return Ok(status)
         }
         let mut status = 0 as c_int;
-        try!(cvt_r(|| unsafe { libc::waitpid(self.pid, &mut status, 0) }));
+        cvt_r(|| unsafe { libc::waitpid(self.pid, &mut status, 0) })?;
         self.status = Some(ExitStatus(status));
         Ok(ExitStatus(status))
     }

--- a/src/libstd/sys/unix/process.rs
+++ b/src/libstd/sys/unix/process.rs
@@ -392,7 +392,7 @@ impl Command {
             let mut set: libc::sigset_t = mem::uninitialized();
             t!(cvt(libc::sigemptyset(&mut set)));
             t!(cvt(libc::pthread_sigmask(libc::SIG_SETMASK, &set,
-                                           ptr::null_mut())));
+                                         ptr::null_mut())));
             let ret = libc::signal(libc::SIGPIPE, libc::SIG_DFL);
             if ret == libc::SIG_ERR {
                 return io::Error::last_os_error()

--- a/src/libstd/sys/unix/rand.rs
+++ b/src/libstd/sys/unix/rand.rs
@@ -138,7 +138,7 @@ mod imp {
                 return Ok(OsRng { inner: OsGetrandomRng });
             }
 
-            let reader = try!(File::open("/dev/urandom"));
+            let reader = File::open("/dev/urandom")?;
             let reader_rng = ReaderRng::new(reader);
 
             Ok(OsRng { inner: OsReaderRng(reader_rng) })

--- a/src/libstd/sys/windows/backtrace.rs
+++ b/src/libstd/sys/windows/backtrace.rs
@@ -131,7 +131,7 @@ pub fn write(w: &mut Write) -> io::Result<()> {
         // Start from -1 to avoid printing this stack frame, which will
         // always be exactly the same.
         let mut i = -1;
-        try!(write!(w, "stack backtrace:\n"));
+        write!(w, "stack backtrace:\n")?;
         while StackWalk64(image, process, thread, &mut frame, &mut context,
                           ptr::null_mut(),
                           ptr::null_mut(),
@@ -144,7 +144,7 @@ pub fn write(w: &mut Write) -> io::Result<()> {
             i += 1;
 
             if i >= 0 {
-                try!(printing::print(w, i, addr - 1, process, &dbghelp));
+                printing::print(w, i, addr - 1, process, &dbghelp)?;
             }
         }
 

--- a/src/libstd/sys/windows/dynamic_lib.rs
+++ b/src/libstd/sys/windows/dynamic_lib.rs
@@ -36,7 +36,7 @@ impl DynamicLibrary {
     }
 
     pub fn symbol(&self, symbol: &str) -> io::Result<usize> {
-        let symbol = try!(CString::new(symbol));
+        let symbol = CString::new(symbol)?;
         unsafe {
             match c::GetProcAddress(self.handle, symbol.as_ptr()) as usize {
                 0 => Err(io::Error::last_os_error()),

--- a/src/libstd/sys/windows/fs.rs
+++ b/src/libstd/sys/windows/fs.rs
@@ -290,7 +290,7 @@ impl File {
         unsafe {
             let mut info: c::BY_HANDLE_FILE_INFORMATION = mem::zeroed();
             cvt(c::GetFileInformationByHandle(self.handle.raw(),
-                                                   &mut info))?;
+                                              &mut info))?;
             let mut attr = FileAttr {
                 attributes: info.dwFileAttributes,
                 creation_time: info.ftCreationTime,

--- a/src/libstd/sys/windows/fs.rs
+++ b/src/libstd/sys/windows/fs.rs
@@ -248,13 +248,13 @@ impl OpenOptions {
 
 impl File {
     pub fn open(path: &Path, opts: &OpenOptions) -> io::Result<File> {
-        let path = try!(to_u16s(path));
+        let path = to_u16s(path)?;
         let handle = unsafe {
             c::CreateFileW(path.as_ptr(),
-                           try!(opts.get_access_mode()),
+                           opts.get_access_mode()?,
                            opts.share_mode,
                            opts.security_attributes as *mut _,
-                           try!(opts.get_creation_mode()),
+                           opts.get_creation_mode()?,
                            opts.get_flags_and_attributes(),
                            ptr::null_mut())
         };
@@ -266,7 +266,7 @@ impl File {
     }
 
     pub fn fsync(&self) -> io::Result<()> {
-        try!(cvt(unsafe { c::FlushFileBuffers(self.handle.raw()) }));
+        cvt(unsafe { c::FlushFileBuffers(self.handle.raw()) })?;
         Ok(())
     }
 
@@ -277,20 +277,20 @@ impl File {
             EndOfFile: size as c::LARGE_INTEGER,
         };
         let size = mem::size_of_val(&info);
-        try!(cvt(unsafe {
+        cvt(unsafe {
             c::SetFileInformationByHandle(self.handle.raw(),
                                           c::FileEndOfFileInfo,
                                           &mut info as *mut _ as *mut _,
                                           size as c::DWORD)
-        }));
+        })?;
         Ok(())
     }
 
     pub fn file_attr(&self) -> io::Result<FileAttr> {
         unsafe {
             let mut info: c::BY_HANDLE_FILE_INFORMATION = mem::zeroed();
-            try!(cvt(c::GetFileInformationByHandle(self.handle.raw(),
-                                                   &mut info)));
+            cvt(c::GetFileInformationByHandle(self.handle.raw(),
+                                                   &mut info))?;
             let mut attr = FileAttr {
                 attributes: info.dwFileAttributes,
                 creation_time: info.ftCreationTime,
@@ -331,16 +331,16 @@ impl File {
         };
         let pos = pos as c::LARGE_INTEGER;
         let mut newpos = 0;
-        try!(cvt(unsafe {
+        cvt(unsafe {
             c::SetFilePointerEx(self.handle.raw(), pos,
                                 &mut newpos, whence)
-        }));
+        })?;
         Ok(newpos as u64)
     }
 
     pub fn duplicate(&self) -> io::Result<File> {
         Ok(File {
-            handle: try!(self.handle.duplicate(0, true, c::DUPLICATE_SAME_ACCESS)),
+            handle: self.handle.duplicate(0, true, c::DUPLICATE_SAME_ACCESS)?,
         })
     }
 
@@ -353,7 +353,7 @@ impl File {
                          -> io::Result<(c::DWORD, &'a c::REPARSE_DATA_BUFFER)> {
         unsafe {
             let mut bytes = 0;
-            try!(cvt({
+            cvt({
                 c::DeviceIoControl(self.handle.raw(),
                                    c::FSCTL_GET_REPARSE_POINT,
                                    ptr::null_mut(),
@@ -362,14 +362,14 @@ impl File {
                                    space.len() as c::DWORD,
                                    &mut bytes,
                                    ptr::null_mut())
-            }));
+            })?;
             Ok((bytes, &*(space.as_ptr() as *const c::REPARSE_DATA_BUFFER)))
         }
     }
 
     fn readlink(&self) -> io::Result<PathBuf> {
         let mut space = [0u8; c::MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
-        let (_bytes, buf) = try!(self.reparse_point(&mut space));
+        let (_bytes, buf) = self.reparse_point(&mut space)?;
         unsafe {
             let (path_buffer, subst_off, subst_len, relative) = match buf.ReparseTag {
                 c::IO_REPARSE_TAG_SYMLINK => {
@@ -516,10 +516,10 @@ impl DirBuilder {
     pub fn new() -> DirBuilder { DirBuilder }
 
     pub fn mkdir(&self, p: &Path) -> io::Result<()> {
-        let p = try!(to_u16s(p));
-        try!(cvt(unsafe {
+        let p = to_u16s(p)?;
+        cvt(unsafe {
             c::CreateDirectoryW(p.as_ptr(), ptr::null_mut())
-        }));
+        })?;
         Ok(())
     }
 }
@@ -527,7 +527,7 @@ impl DirBuilder {
 pub fn readdir(p: &Path) -> io::Result<ReadDir> {
     let root = p.to_path_buf();
     let star = p.join("*");
-    let path = try!(to_u16s(&star));
+    let path = to_u16s(&star)?;
 
     unsafe {
         let mut wfd = mem::zeroed();
@@ -545,28 +545,28 @@ pub fn readdir(p: &Path) -> io::Result<ReadDir> {
 }
 
 pub fn unlink(p: &Path) -> io::Result<()> {
-    let p_u16s = try!(to_u16s(p));
-    try!(cvt(unsafe { c::DeleteFileW(p_u16s.as_ptr()) }));
+    let p_u16s = to_u16s(p)?;
+    cvt(unsafe { c::DeleteFileW(p_u16s.as_ptr()) })?;
     Ok(())
 }
 
 pub fn rename(old: &Path, new: &Path) -> io::Result<()> {
-    let old = try!(to_u16s(old));
-    let new = try!(to_u16s(new));
-    try!(cvt(unsafe {
+    let old = to_u16s(old)?;
+    let new = to_u16s(new)?;
+    cvt(unsafe {
         c::MoveFileExW(old.as_ptr(), new.as_ptr(), c::MOVEFILE_REPLACE_EXISTING)
-    }));
+    })?;
     Ok(())
 }
 
 pub fn rmdir(p: &Path) -> io::Result<()> {
-    let p = try!(to_u16s(p));
-    try!(cvt(unsafe { c::RemoveDirectoryW(p.as_ptr()) }));
+    let p = to_u16s(p)?;
+    cvt(unsafe { c::RemoveDirectoryW(p.as_ptr()) })?;
     Ok(())
 }
 
 pub fn remove_dir_all(path: &Path) -> io::Result<()> {
-    let filetype = try!(lstat(path)).file_type();
+    let filetype = lstat(path)?.file_type();
     if filetype.is_symlink() {
         // On Windows symlinks to files and directories are removed differently.
         // rmdir only deletes dir symlinks and junctions, not file symlinks.
@@ -577,15 +577,15 @@ pub fn remove_dir_all(path: &Path) -> io::Result<()> {
 }
 
 fn remove_dir_all_recursive(path: &Path) -> io::Result<()> {
-    for child in try!(readdir(path)) {
-        let child = try!(child);
-        let child_type = try!(child.file_type());
+    for child in readdir(path)? {
+        let child = child?;
+        let child_type = child.file_type()?;
         if child_type.is_dir() {
-            try!(remove_dir_all_recursive(&child.path()));
+            remove_dir_all_recursive(&child.path())?;
         } else if child_type.is_symlink_dir() {
-            try!(rmdir(&child.path()));
+            rmdir(&child.path())?;
         } else {
-            try!(unlink(&child.path()));
+            unlink(&child.path())?;
         }
     }
     rmdir(path)
@@ -599,7 +599,7 @@ pub fn readlink(path: &Path) -> io::Result<PathBuf> {
     opts.access_mode(0);
     opts.custom_flags(c::FILE_FLAG_OPEN_REPARSE_POINT |
                       c::FILE_FLAG_BACKUP_SEMANTICS);
-    let file = try!(File::open(&path, &opts));
+    let file = File::open(&path, &opts)?;
     file.readlink()
 }
 
@@ -608,21 +608,21 @@ pub fn symlink(src: &Path, dst: &Path) -> io::Result<()> {
 }
 
 pub fn symlink_inner(src: &Path, dst: &Path, dir: bool) -> io::Result<()> {
-    let src = try!(to_u16s(src));
-    let dst = try!(to_u16s(dst));
+    let src = to_u16s(src)?;
+    let dst = to_u16s(dst)?;
     let flags = if dir { c::SYMBOLIC_LINK_FLAG_DIRECTORY } else { 0 };
-    try!(cvt(unsafe {
+    cvt(unsafe {
         c::CreateSymbolicLinkW(dst.as_ptr(), src.as_ptr(), flags) as c::BOOL
-    }));
+    })?;
     Ok(())
 }
 
 pub fn link(src: &Path, dst: &Path) -> io::Result<()> {
-    let src = try!(to_u16s(src));
-    let dst = try!(to_u16s(dst));
-    try!(cvt(unsafe {
+    let src = to_u16s(src)?;
+    let dst = to_u16s(dst)?;
+    cvt(unsafe {
         c::CreateHardLinkW(dst.as_ptr(), src.as_ptr(), ptr::null_mut())
-    }));
+    })?;
     Ok(())
 }
 
@@ -632,7 +632,7 @@ pub fn stat(path: &Path) -> io::Result<FileAttr> {
     opts.access_mode(0);
     // This flag is so we can open directories too
     opts.custom_flags(c::FILE_FLAG_BACKUP_SEMANTICS);
-    let file = try!(File::open(path, &opts));
+    let file = File::open(path, &opts)?;
     file.file_attr()
 }
 
@@ -641,14 +641,14 @@ pub fn lstat(path: &Path) -> io::Result<FileAttr> {
     // No read or write permissions are necessary
     opts.access_mode(0);
     opts.custom_flags(c::FILE_FLAG_BACKUP_SEMANTICS | c::FILE_FLAG_OPEN_REPARSE_POINT);
-    let file = try!(File::open(path, &opts));
+    let file = File::open(path, &opts)?;
     file.file_attr()
 }
 
 pub fn set_perm(p: &Path, perm: FilePermissions) -> io::Result<()> {
-    let p = try!(to_u16s(p));
+    let p = to_u16s(p)?;
     unsafe {
-        try!(cvt(c::SetFileAttributesW(p.as_ptr(), perm.attrs)));
+        cvt(c::SetFileAttributesW(p.as_ptr(), perm.attrs))?;
         Ok(())
     }
 }
@@ -668,7 +668,7 @@ pub fn canonicalize(p: &Path) -> io::Result<PathBuf> {
     opts.access_mode(0);
     // This flag is so we can open directories too
     opts.custom_flags(c::FILE_FLAG_BACKUP_SEMANTICS);
-    let f = try!(File::open(p, &opts));
+    let f = File::open(p, &opts)?;
     get_path(&f)
 }
 
@@ -687,13 +687,13 @@ pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
         *(lpData as *mut i64) = TotalBytesTransferred;
         c::PROGRESS_CONTINUE
     }
-    let pfrom = try!(to_u16s(from));
-    let pto = try!(to_u16s(to));
+    let pfrom = to_u16s(from)?;
+    let pto = to_u16s(to)?;
     let mut size = 0i64;
-    try!(cvt(unsafe {
+    cvt(unsafe {
         c::CopyFileExW(pfrom.as_ptr(), pto.as_ptr(), Some(callback),
                        &mut size as *mut _ as *mut _, ptr::null_mut(), 0)
-    }));
+    })?;
     Ok(size as u64)
 }
 
@@ -710,13 +710,13 @@ pub fn symlink_junction<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::R
 #[allow(dead_code)]
 fn symlink_junction_inner(target: &Path, junction: &Path) -> io::Result<()> {
     let d = DirBuilder::new();
-    try!(d.mkdir(&junction));
+    d.mkdir(&junction)?;
 
     let mut opts = OpenOptions::new();
     opts.write(true);
     opts.custom_flags(c::FILE_FLAG_OPEN_REPARSE_POINT |
                       c::FILE_FLAG_BACKUP_SEMANTICS);
-    let f = try!(File::open(junction, &opts));
+    let f = File::open(junction, &opts)?;
     let h = f.handle().raw();
 
     unsafe {

--- a/src/libstd/sys/windows/handle.rs
+++ b/src/libstd/sys/windows/handle.rs
@@ -169,22 +169,22 @@ impl RawHandle {
         // WriteFile takes a DWORD (u32) for the length so it only supports
         // writing u32::MAX bytes at a time.
         let len = cmp::min(buf.len(), u32::MAX as usize) as c::DWORD;
-        try!(cvt(unsafe {
+        cvt(unsafe {
             c::WriteFile(self.0, buf.as_ptr() as c::LPVOID,
                          len, &mut amt, ptr::null_mut())
-        }));
+        })?;
         Ok(amt as usize)
     }
 
     pub fn duplicate(&self, access: c::DWORD, inherit: bool,
                      options: c::DWORD) -> io::Result<Handle> {
         let mut ret = 0 as c::HANDLE;
-        try!(cvt(unsafe {
+        cvt(unsafe {
             let cur_proc = c::GetCurrentProcess();
             c::DuplicateHandle(cur_proc, self.0, cur_proc, &mut ret,
                             access, inherit as c::BOOL,
                             options)
-        }));
+        })?;
         Ok(Handle::new(ret))
     }
 }

--- a/src/libstd/sys/windows/os.rs
+++ b/src/libstd/sys/windows/os.rs
@@ -239,7 +239,7 @@ pub fn chdir(p: &path::Path) -> io::Result<()> {
 }
 
 pub fn getenv(k: &OsStr) -> io::Result<Option<OsString>> {
-    let k = try!(to_u16s(k));
+    let k = to_u16s(k)?;
     let res = super::fill_utf16_buf(|buf, sz| unsafe {
         c::GetEnvironmentVariableW(k.as_ptr(), buf, sz)
     }, |buf| {
@@ -258,8 +258,8 @@ pub fn getenv(k: &OsStr) -> io::Result<Option<OsString>> {
 }
 
 pub fn setenv(k: &OsStr, v: &OsStr) -> io::Result<()> {
-    let k = try!(to_u16s(k));
-    let v = try!(to_u16s(v));
+    let k = to_u16s(k)?;
+    let v = to_u16s(v)?;
 
     cvt(unsafe {
         c::SetEnvironmentVariableW(k.as_ptr(), v.as_ptr())
@@ -267,7 +267,7 @@ pub fn setenv(k: &OsStr, v: &OsStr) -> io::Result<()> {
 }
 
 pub fn unsetenv(n: &OsStr) -> io::Result<()> {
-    let v = try!(to_u16s(n));
+    let v = to_u16s(n)?;
     cvt(unsafe {
         c::SetEnvironmentVariableW(v.as_ptr(), ptr::null())
     }).map(|_| ())

--- a/src/libstd/sys/windows/printing/msvc.rs
+++ b/src/libstd/sys/windows/printing/msvc.rs
@@ -53,7 +53,7 @@ pub fn print(w: &mut Write,
             None
         };
 
-        try!(output(w, i, addr as usize as *mut c_void, name));
+        output(w, i, addr as usize as *mut c_void, name)?;
 
         // Now find out the filename and line number
         let mut line: c::IMAGEHLP_LINE64 = mem::zeroed();

--- a/src/libstd/sys/windows/process.rs
+++ b/src/libstd/sys/windows/process.rs
@@ -151,7 +151,7 @@ impl Command {
         si.dwFlags = c::STARTF_USESTDHANDLES;
 
         let program = program.as_ref().unwrap_or(&self.program);
-        let mut cmd_str = try!(make_command_line(program, &self.args));
+        let mut cmd_str = make_command_line(program, &self.args)?;
         cmd_str.push(0); // add null terminator
 
         // stolen from the libuv code.
@@ -160,8 +160,8 @@ impl Command {
             flags |= c::DETACHED_PROCESS | c::CREATE_NEW_PROCESS_GROUP;
         }
 
-        let (envp, _data) = try!(make_envp(self.env.as_ref()));
-        let (dirp, _data) = try!(make_dirp(self.cwd.as_ref()));
+        let (envp, _data) = make_envp(self.env.as_ref())?;
+        let (dirp, _data) = make_dirp(self.cwd.as_ref())?;
         let mut pi = zeroed_process_information();
 
         // Prepare all stdio handles to be inherited by the child. This
@@ -186,23 +186,23 @@ impl Command {
         let stdin = self.stdin.as_ref().unwrap_or(default_stdin);
         let stdout = self.stdout.as_ref().unwrap_or(&default);
         let stderr = self.stderr.as_ref().unwrap_or(&default);
-        let stdin = try!(stdin.to_handle(c::STD_INPUT_HANDLE, &mut pipes.stdin));
-        let stdout = try!(stdout.to_handle(c::STD_OUTPUT_HANDLE,
-                                           &mut pipes.stdout));
-        let stderr = try!(stderr.to_handle(c::STD_ERROR_HANDLE,
-                                           &mut pipes.stderr));
+        let stdin = stdin.to_handle(c::STD_INPUT_HANDLE, &mut pipes.stdin)?;
+        let stdout = stdout.to_handle(c::STD_OUTPUT_HANDLE,
+                                           &mut pipes.stdout)?;
+        let stderr = stderr.to_handle(c::STD_ERROR_HANDLE,
+                                           &mut pipes.stderr)?;
         si.hStdInput = stdin.raw();
         si.hStdOutput = stdout.raw();
         si.hStdError = stderr.raw();
 
-        try!(unsafe {
+        unsafe {
             cvt(c::CreateProcessW(ptr::null(),
                                   cmd_str.as_mut_ptr(),
                                   ptr::null_mut(),
                                   ptr::null_mut(),
                                   c::TRUE, flags, envp, dirp,
                                   &mut si, &mut pi))
-        });
+        }?;
 
         // We close the thread handle because we don't care about keeping
         // the thread id valid, and we aren't keeping the thread handle
@@ -216,9 +216,9 @@ impl Command {
 
 impl fmt::Debug for Command {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "{:?}", self.program));
+        write!(f, "{:?}", self.program)?;
         for arg in &self.args {
-            try!(write!(f, " {:?}", arg));
+            write!(f, " {:?}", arg)?;
         }
         Ok(())
     }
@@ -240,18 +240,18 @@ impl Stdio {
             }
 
             Stdio::MakePipe => {
-                let (reader, writer) = try!(pipe::anon_pipe());
+                let (reader, writer) = pipe::anon_pipe()?;
                 let (ours, theirs) = if stdio_id == c::STD_INPUT_HANDLE {
                     (writer, reader)
                 } else {
                     (reader, writer)
                 };
                 *pipe = Some(ours);
-                try!(cvt(unsafe {
+                cvt(unsafe {
                     c::SetHandleInformation(theirs.handle().raw(),
                                             c::HANDLE_FLAG_INHERIT,
                                             c::HANDLE_FLAG_INHERIT)
-                }));
+                })?;
                 Ok(theirs.into_handle())
             }
 
@@ -296,9 +296,9 @@ pub struct Process {
 
 impl Process {
     pub fn kill(&mut self) -> io::Result<()> {
-        try!(cvt(unsafe {
+        cvt(unsafe {
             c::TerminateProcess(self.handle.raw(), 1)
-        }));
+        })?;
         Ok(())
     }
 
@@ -315,7 +315,7 @@ impl Process {
                 return Err(Error::last_os_error())
             }
             let mut status = 0;
-            try!(cvt(c::GetExitCodeProcess(self.handle.raw(), &mut status)));
+            cvt(c::GetExitCodeProcess(self.handle.raw(), &mut status))?;
             Ok(ExitStatus(status))
         }
     }
@@ -381,10 +381,10 @@ fn make_command_line(prog: &OsStr, args: &[OsString]) -> io::Result<Vec<u16>> {
     // Encode the command and arguments in a command line string such
     // that the spawned process may recover them using CommandLineToArgvW.
     let mut cmd: Vec<u16> = Vec::new();
-    try!(append_arg(&mut cmd, prog));
+    append_arg(&mut cmd, prog)?;
     for arg in args {
         cmd.push(' ' as u16);
-        try!(append_arg(&mut cmd, arg));
+        append_arg(&mut cmd, arg)?;
     }
     return Ok(cmd);
 
@@ -392,7 +392,7 @@ fn make_command_line(prog: &OsStr, args: &[OsString]) -> io::Result<Vec<u16>> {
         // If an argument has 0 characters then we need to quote it to ensure
         // that it actually gets passed through on the command line or otherwise
         // it will be dropped entirely when parsed on the other end.
-        try!(ensure_no_nuls(arg));
+        ensure_no_nuls(arg)?;
         let arg_bytes = &arg.as_inner().inner.as_inner();
         let quote = arg_bytes.iter().any(|c| *c == b' ' || *c == b'\t')
             || arg_bytes.is_empty();
@@ -438,9 +438,9 @@ fn make_envp(env: Option<&collections::HashMap<OsString, OsString>>)
             let mut blk = Vec::new();
 
             for pair in env {
-                blk.extend(try!(ensure_no_nuls(pair.0)).encode_wide());
+                blk.extend(ensure_no_nuls(pair.0)?.encode_wide());
                 blk.push('=' as u16);
-                blk.extend(try!(ensure_no_nuls(pair.1)).encode_wide());
+                blk.extend(ensure_no_nuls(pair.1)?.encode_wide());
                 blk.push(0);
             }
             blk.push(0);
@@ -454,7 +454,7 @@ fn make_dirp(d: Option<&OsString>) -> io::Result<(*const u16, Vec<u16>)> {
 
     match d {
         Some(dir) => {
-            let mut dir_str: Vec<u16> = try!(ensure_no_nuls(dir)).encode_wide().collect();
+            let mut dir_str: Vec<u16> = ensure_no_nuls(dir)?.encode_wide().collect();
             dir_str.push(0);
             Ok((dir_str.as_ptr(), dir_str))
         },

--- a/src/libstd/sys/windows/process.rs
+++ b/src/libstd/sys/windows/process.rs
@@ -188,9 +188,9 @@ impl Command {
         let stderr = self.stderr.as_ref().unwrap_or(&default);
         let stdin = stdin.to_handle(c::STD_INPUT_HANDLE, &mut pipes.stdin)?;
         let stdout = stdout.to_handle(c::STD_OUTPUT_HANDLE,
-                                           &mut pipes.stdout)?;
+                                      &mut pipes.stdout)?;
         let stderr = stderr.to_handle(c::STD_ERROR_HANDLE,
-                                           &mut pipes.stderr)?;
+                                      &mut pipes.stderr)?;
         si.hStdInput = stdin.raw();
         si.hStdOutput = stdout.raw();
         si.hStdError = stderr.raw();

--- a/src/libstd/sys/windows/stdio.rs
+++ b/src/libstd/sys/windows/stdio.rs
@@ -78,13 +78,13 @@ fn write(out: &Output, data: &[u8]) -> io::Result<usize> {
     };
     let utf16 = utf8.encode_utf16().collect::<Vec<u16>>();
     let mut written = 0;
-    try!(cvt(unsafe {
+    cvt(unsafe {
         c::WriteConsoleW(handle,
                          utf16.as_ptr() as c::LPCVOID,
                          utf16.len() as u32,
                          &mut written,
                          ptr::null_mut())
-    }));
+    })?;
 
     // FIXME if this only partially writes the utf16 buffer then we need to
     //       figure out how many bytes of `data` were actually written
@@ -112,13 +112,13 @@ impl Stdin {
         if utf8.position() as usize == utf8.get_ref().len() {
             let mut utf16 = vec![0u16; 0x1000];
             let mut num = 0;
-            try!(cvt(unsafe {
+            cvt(unsafe {
                 c::ReadConsoleW(handle,
                                 utf16.as_mut_ptr() as c::LPVOID,
                                 utf16.len() as u32,
                                 &mut num,
                                 ptr::null_mut())
-            }));
+            })?;
             utf16.truncate(num as usize);
             // FIXME: what to do about this data that has already been read?
             let data = match String::from_utf16(&utf16) {

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -285,7 +285,7 @@ impl Builder {
 
         Ok(JoinHandle(JoinInner {
             native: unsafe {
-                Some(try!(imp::Thread::new(stack_size, Box::new(main))))
+                Some(imp::Thread::new(stack_size, Box::new(main))?)
             },
             thread: my_thread,
             packet: Packet(my_packet),

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -83,7 +83,7 @@ impl Encodable for Name {
 
 impl Decodable for Name {
     fn decode<D: Decoder>(d: &mut D) -> Result<Name, D::Error> {
-        Ok(token::intern(&try!(d.read_str())[..]))
+        Ok(token::intern(&d.read_str()?[..]))
     }
 }
 
@@ -152,7 +152,7 @@ impl Encodable for Ident {
 
 impl Decodable for Ident {
     fn decode<D: Decoder>(d: &mut D) -> Result<Ident, D::Error> {
-        Ok(Ident::with_empty_ctxt(try!(Name::decode(d))))
+        Ok(Ident::with_empty_ctxt(Name::decode(d)?))
     }
 }
 

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -86,7 +86,7 @@ impl Encodable for BytePos {
 
 impl Decodable for BytePos {
     fn decode<D: Decoder>(d: &mut D) -> Result<BytePos, D::Error> {
-        Ok(BytePos(try!{ d.read_u32() }))
+        Ok(BytePos(d.read_u32()?))
     }
 }
 
@@ -203,9 +203,9 @@ pub struct Spanned<T> {
 impl Encodable for Span {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         s.emit_struct("Span", 2, |s| {
-            try!(s.emit_struct_field("lo", 0, |s| {
+            s.emit_struct_field("lo", 0, |s| {
                 self.lo.encode(s)
-            }));
+            })?;
 
             s.emit_struct_field("hi", 1, |s| {
                 self.hi.encode(s)
@@ -217,13 +217,13 @@ impl Encodable for Span {
 impl Decodable for Span {
     fn decode<D: Decoder>(d: &mut D) -> Result<Span, D::Error> {
         d.read_struct("Span", 2, |d| {
-            let lo = try!(d.read_struct_field("lo", 0, |d| {
+            let lo = d.read_struct_field("lo", 0, |d| {
                 BytePos::decode(d)
-            }));
+            })?;
 
-            let hi = try!(d.read_struct_field("hi", 1, |d| {
+            let hi = d.read_struct_field("hi", 1, |d| {
                 BytePos::decode(d)
-            }));
+            })?;
 
             Ok(mk_sp(lo, hi))
         })
@@ -526,13 +526,13 @@ pub struct FileMap {
 impl Encodable for FileMap {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         s.emit_struct("FileMap", 5, |s| {
-            try! { s.emit_struct_field("name", 0, |s| self.name.encode(s)) };
-            try! { s.emit_struct_field("start_pos", 1, |s| self.start_pos.encode(s)) };
-            try! { s.emit_struct_field("end_pos", 2, |s| self.end_pos.encode(s)) };
-            try! { s.emit_struct_field("lines", 3, |s| {
+            s.emit_struct_field("name", 0, |s| self.name.encode(s))?;
+            s.emit_struct_field("start_pos", 1, |s| self.start_pos.encode(s))?;
+            s.emit_struct_field("end_pos", 2, |s| self.end_pos.encode(s))?;
+            s.emit_struct_field("lines", 3, |s| {
                     let lines = self.lines.borrow();
                     // store the length
-                    try! { s.emit_u32(lines.len() as u32) };
+                    s.emit_u32(lines.len() as u32)?;
 
                     if !lines.is_empty() {
                         // In order to preserve some space, we exploit the fact that
@@ -557,25 +557,24 @@ impl Encodable for FileMap {
                         };
 
                         // Encode the number of bytes used per diff.
-                        try! { bytes_per_diff.encode(s) };
+                        bytes_per_diff.encode(s)?;
 
                         // Encode the first element.
-                        try! { lines[0].encode(s) };
+                        lines[0].encode(s)?;
 
                         let diff_iter = (&lines[..]).windows(2)
                                                     .map(|w| (w[1] - w[0]));
 
                         match bytes_per_diff {
-                            1 => for diff in diff_iter { try! { (diff.0 as u8).encode(s) } },
-                            2 => for diff in diff_iter { try! { (diff.0 as u16).encode(s) } },
-                            4 => for diff in diff_iter { try! { diff.0.encode(s) } },
+                            1 => for diff in diff_iter { (diff.0 as u8).encode(s)? },
+                            2 => for diff in diff_iter { (diff.0 as u16).encode(s)? },
+                            4 => for diff in diff_iter { diff.0.encode(s)? },
                             _ => unreachable!()
                         }
                     }
 
                     Ok(())
-                })
-            };
+                })?;
             s.emit_struct_field("multibyte_chars", 4, |s| {
                 (*self.multibyte_chars.borrow()).encode(s)
             })
@@ -587,33 +586,26 @@ impl Decodable for FileMap {
     fn decode<D: Decoder>(d: &mut D) -> Result<FileMap, D::Error> {
 
         d.read_struct("FileMap", 5, |d| {
-            let name: String = try! {
-                d.read_struct_field("name", 0, |d| Decodable::decode(d))
-            };
-            let start_pos: BytePos = try! {
-                d.read_struct_field("start_pos", 1, |d| Decodable::decode(d))
-            };
-            let end_pos: BytePos = try! {
-                d.read_struct_field("end_pos", 2, |d| Decodable::decode(d))
-            };
-            let lines: Vec<BytePos> = try! {
-                d.read_struct_field("lines", 3, |d| {
-                    let num_lines: u32 = try! { Decodable::decode(d) };
+            let name: String = d.read_struct_field("name", 0, |d| Decodable::decode(d))?;
+            let start_pos: BytePos = d.read_struct_field("start_pos", 1, |d| Decodable::decode(d))?;
+            let end_pos: BytePos = d.read_struct_field("end_pos", 2, |d| Decodable::decode(d))?;
+            let lines: Vec<BytePos> = d.read_struct_field("lines", 3, |d| {
+                    let num_lines: u32 = Decodable::decode(d)?;
                     let mut lines = Vec::with_capacity(num_lines as usize);
 
                     if num_lines > 0 {
                         // Read the number of bytes used per diff.
-                        let bytes_per_diff: u8 = try! { Decodable::decode(d) };
+                        let bytes_per_diff: u8 = Decodable::decode(d)?;
 
                         // Read the first element.
-                        let mut line_start: BytePos = try! { Decodable::decode(d) };
+                        let mut line_start: BytePos = Decodable::decode(d)?;
                         lines.push(line_start);
 
                         for _ in 1..num_lines {
                             let diff = match bytes_per_diff {
-                                1 => try! { d.read_u8() } as u32,
-                                2 => try! { d.read_u16() } as u32,
-                                4 => try! { d.read_u32() },
+                                1 => d.read_u8()? as u32,
+                                2 => d.read_u16()? as u32,
+                                4 => d.read_u32()?,
                                 _ => unreachable!()
                             };
 
@@ -624,11 +616,8 @@ impl Decodable for FileMap {
                     }
 
                     Ok(lines)
-                })
-            };
-            let multibyte_chars: Vec<MultiByteChar> = try! {
-                d.read_struct_field("multibyte_chars", 4, |d| Decodable::decode(d))
-            };
+                })?;
+            let multibyte_chars: Vec<MultiByteChar> = d.read_struct_field("multibyte_chars", 4, |d| Decodable::decode(d))?;
             Ok(FileMap {
                 name: name,
                 start_pos: start_pos,
@@ -730,7 +719,7 @@ impl FileLoader for RealFileLoader {
 
     fn read_file(&self, path: &Path) -> io::Result<String> {
         let mut src = String::new();
-        try!(try!(fs::File::open(path)).read_to_string(&mut src));
+        fs::File::open(path)?.read_to_string(&mut src)?;
         Ok(src)
     }
 }
@@ -767,7 +756,7 @@ impl CodeMap {
     }
 
     pub fn load_file(&self, path: &Path) -> io::Result<Rc<FileMap>> {
-        let src = try!(self.file_loader.read_file(path));
+        let src = self.file_loader.read_file(path)?;
         Ok(self.new_filemap(path.to_str().unwrap().to_string(), src))
     }
 

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -617,7 +617,8 @@ impl Decodable for FileMap {
 
                     Ok(lines)
                 })?;
-            let multibyte_chars: Vec<MultiByteChar> = d.read_struct_field("multibyte_chars", 4, |d| Decodable::decode(d))?;
+            let multibyte_chars: Vec<MultiByteChar> =
+                d.read_struct_field("multibyte_chars", 4, |d| Decodable::decode(d))?;
             Ok(FileMap {
                 name: name,
                 start_pos: start_pos,

--- a/src/libsyntax/diagnostics/metadata.rs
+++ b/src/libsyntax/diagnostics/metadata.rs
@@ -76,11 +76,11 @@ pub fn output_metadata(ecx: &ExtCtxt, prefix: &str, name: &str, err_map: &ErrorM
 {
     // Create the directory to place the file in.
     let metadata_dir = get_metadata_dir(prefix);
-    try!(create_dir_all(&metadata_dir));
+    create_dir_all(&metadata_dir)?;
 
     // Open the metadata file.
     let metadata_path = get_metadata_path(metadata_dir, name);
-    let mut metadata_file = try!(File::create(&metadata_path));
+    let mut metadata_file = File::create(&metadata_path)?;
 
     // Construct a serializable map.
     let json_map = err_map.iter().map(|(k, &ErrorInfo { description, use_site })| {
@@ -95,7 +95,7 @@ pub fn output_metadata(ecx: &ExtCtxt, prefix: &str, name: &str, err_map: &ErrorM
     // Write the data to the file, deleting it if the write fails.
     let result = write!(&mut metadata_file, "{}", as_json(&json_map));
     if result.is_err() {
-        try!(remove_file(&metadata_path));
+        remove_file(&metadata_path)?;
     }
-    Ok(try!(result))
+    Ok(result?)
 }

--- a/src/libsyntax/errors/emitter.rs
+++ b/src/libsyntax/errors/emitter.rs
@@ -184,20 +184,20 @@ impl EmitterWriter {
             self.cm.span_to_string(bounds)
         };
 
-        try!(print_diagnostic(&mut self.dst, &ss[..], lvl, msg, code));
+        print_diagnostic(&mut self.dst, &ss[..], lvl, msg, code)?;
 
         match *rsp {
             FullSpan(_) => {
-                try!(self.highlight_lines(msp, lvl));
-                try!(self.print_macro_backtrace(bounds));
+                self.highlight_lines(msp, lvl)?;
+                self.print_macro_backtrace(bounds)?;
             }
             EndSpan(_) => {
-                try!(self.end_highlight_lines(msp, lvl));
-                try!(self.print_macro_backtrace(bounds));
+                self.end_highlight_lines(msp, lvl)?;
+                self.print_macro_backtrace(bounds)?;
             }
             Suggestion(ref suggestion) => {
-                try!(self.highlight_suggestion(suggestion));
-                try!(self.print_macro_backtrace(bounds));
+                self.highlight_suggestion(suggestion)?;
+                self.print_macro_backtrace(bounds)?;
             }
             FileLine(..) => {
                 // no source text in this case!
@@ -207,9 +207,9 @@ impl EmitterWriter {
         if let Some(code) = code {
             if let Some(_) = self.registry.as_ref()
                                           .and_then(|registry| registry.find_description(code)) {
-                try!(print_diagnostic(&mut self.dst, &ss[..], Help,
+                print_diagnostic(&mut self.dst, &ss[..], Help,
                                       &format!("run `rustc --explain {}` to see a \
-                                               detailed explanation", code), None));
+                                               detailed explanation", code), None)?;
             }
         }
         Ok(())
@@ -233,14 +233,14 @@ impl EmitterWriter {
         // snippets from the actual error being reported.
         let mut lines = complete.lines();
         for line in lines.by_ref().take(MAX_HIGHLIGHT_LINES) {
-            try!(write!(&mut self.dst, "{0}:{1:2$} {3}\n",
-                        fm.name, "", max_digits, line));
+            write!(&mut self.dst, "{0}:{1:2$} {3}\n",
+                        fm.name, "", max_digits, line)?;
         }
 
         // if we elided some lines, add an ellipsis
         if let Some(_) = lines.next() {
-            try!(write!(&mut self.dst, "{0:1$} {0:2$} ...\n",
-                        "", fm.name.len(), max_digits));
+            write!(&mut self.dst, "{0:1$} {0:2$} ...\n",
+                        "", fm.name.len(), max_digits)?;
         }
 
         Ok(())
@@ -254,7 +254,7 @@ impl EmitterWriter {
         let lines = match self.cm.span_to_lines(msp.to_span_bounds()) {
             Ok(lines) => lines,
             Err(_) => {
-                try!(write!(&mut self.dst, "(internal compiler error: unprintable span)\n"));
+                write!(&mut self.dst, "(internal compiler error: unprintable span)\n")?;
                 return Ok(());
             }
         };
@@ -418,26 +418,26 @@ impl EmitterWriter {
 
             // If we elided something put an ellipsis.
             if prev_line_index != line.line_index.wrapping_sub(1) && !overflowed {
-                try!(write!(&mut self.dst, "{0:1$}...\n", "", skip));
+                write!(&mut self.dst, "{0:1$}...\n", "", skip)?;
             }
 
             // Print offending code-line
             remaining_err_lines -= 1;
-            try!(write!(&mut self.dst, "{}:{:>width$} {}\n",
+            write!(&mut self.dst, "{}:{:>width$} {}\n",
                         fm.name,
                         line.line_index + 1,
                         cur_line_str,
-                        width=digits));
+                        width=digits)?;
 
             if s.len() > skip {
                 // Render the spans we assembled previously (if any).
-                try!(println_maybe_styled!(&mut self.dst, term::Attr::ForegroundColor(lvl.color()),
-                                           "{}", s));
+                println_maybe_styled!(&mut self.dst, term::Attr::ForegroundColor(lvl.color()),
+                                           "{}", s)?;
             }
 
             if !overflowed_buf.is_empty() {
                 // Print code-lines trailing the rendered spans (when a span overflows)
-                try!(write!(&mut self.dst, "{}", &overflowed_buf));
+                write!(&mut self.dst, "{}", &overflowed_buf)?;
                 overflowed_buf.clear();
             } else {
                 prev_line_index = line.line_index;
@@ -446,7 +446,7 @@ impl EmitterWriter {
 
         // If we elided something, put an ellipsis.
         if lines.next().is_some() {
-            try!(write!(&mut self.dst, "{0:1$}...\n", "", skip));
+            write!(&mut self.dst, "{0:1$}...\n", "", skip)?;
         }
         Ok(())
     }
@@ -465,7 +465,7 @@ impl EmitterWriter {
         let lines = match self.cm.span_to_lines(msp.to_span_bounds()) {
             Ok(lines) => lines,
             Err(_) => {
-                try!(write!(&mut self.dst, "(internal compiler error: unprintable span)\n"));
+                write!(&mut self.dst, "(internal compiler error: unprintable span)\n")?;
                 return Ok(());
             }
         };
@@ -556,18 +556,18 @@ impl EmitterWriter {
 
             if prev_line_index != line.line_index.wrapping_sub(1) {
                 // If we elided something, put an ellipsis.
-                try!(write!(&mut self.dst, "{0:1$}...\n", "", skip));
+                write!(&mut self.dst, "{0:1$}...\n", "", skip)?;
             }
 
             // Print offending code-lines
-            try!(write!(&mut self.dst, "{}:{:>width$} {}\n", fm.name,
-                        line.line_index + 1, line_str, width=digits));
+            write!(&mut self.dst, "{}:{:>width$} {}\n", fm.name,
+                        line.line_index + 1, line_str, width=digits)?;
             remaining_err_lines -= 1;
 
             if s.len() > skip {
                 // Render the spans we assembled previously (if any)
-                try!(println_maybe_styled!(&mut self.dst, term::Attr::ForegroundColor(lvl.color()),
-                                           "{}", s));
+                println_maybe_styled!(&mut self.dst, term::Attr::ForegroundColor(lvl.color()),
+                                           "{}", s)?;
             }
             prev_line_index = line.line_index;
         }
@@ -612,7 +612,7 @@ impl EmitterWriter {
                 }
 
                 let snippet = self.cm.span_to_string(span);
-                try!(print_diagnostic(&mut self.dst, &snippet, Note, &diag_string, None));
+                print_diagnostic(&mut self.dst, &snippet, Note, &diag_string, None)?;
             }
             last_span = span;
         }
@@ -638,18 +638,18 @@ fn print_diagnostic(dst: &mut Destination,
                     code: Option<&str>)
                     -> io::Result<()> {
     if !topic.is_empty() {
-        try!(write!(dst, "{} ", topic));
+        write!(dst, "{} ", topic)?;
     }
 
-    try!(print_maybe_styled!(dst, term::Attr::ForegroundColor(lvl.color()),
-                             "{}: ", lvl.to_string()));
-    try!(print_maybe_styled!(dst, term::Attr::Bold, "{}", msg));
+    print_maybe_styled!(dst, term::Attr::ForegroundColor(lvl.color()),
+                             "{}: ", lvl.to_string())?;
+    print_maybe_styled!(dst, term::Attr::Bold, "{}", msg)?;
 
     if let Some(code) = code {
         let style = term::Attr::ForegroundColor(term::color::BRIGHT_MAGENTA);
-        try!(print_maybe_styled!(dst, style, " [{}]", code.clone()));
+        print_maybe_styled!(dst, style, " [{}]", code.clone())?;
     }
-    try!(write!(dst, "\n"));
+    write!(dst, "\n")?;
     Ok(())
 }
 
@@ -696,7 +696,7 @@ impl Destination {
                           -> io::Result<()> {
         match *self {
             Terminal(ref mut t) => {
-                try!(t.attr(color));
+                t.attr(color)?;
                 // If `msg` ends in a newline, we need to reset the color before
                 // the newline. We're making the assumption that we end up writing
                 // to a `LineBufferedWriter`, which means that emitting the reset
@@ -710,8 +710,8 @@ impl Destination {
                 // once, which still leaves the opportunity for interleaved output
                 // to be miscolored. We assume this is rare enough that we don't
                 // have to worry about it.
-                try!(t.write_fmt(args));
-                try!(t.reset());
+                t.write_fmt(args)?;
+                t.reset()?;
                 if print_newline_at_end {
                     t.write_all(b"\n")
                 } else {
@@ -719,7 +719,7 @@ impl Destination {
                 }
             }
             Raw(ref mut w) => {
-                try!(w.write_fmt(args));
+                w.write_fmt(args)?;
                 if print_newline_at_end {
                     w.write_all(b"\n")
                 } else {

--- a/src/libsyntax/errors/emitter.rs
+++ b/src/libsyntax/errors/emitter.rs
@@ -208,8 +208,8 @@ impl EmitterWriter {
             if let Some(_) = self.registry.as_ref()
                                           .and_then(|registry| registry.find_description(code)) {
                 print_diagnostic(&mut self.dst, &ss[..], Help,
-                                      &format!("run `rustc --explain {}` to see a \
-                                               detailed explanation", code), None)?;
+                                 &format!("run `rustc --explain {}` to see a \
+                                           detailed explanation", code), None)?;
             }
         }
         Ok(())
@@ -234,13 +234,13 @@ impl EmitterWriter {
         let mut lines = complete.lines();
         for line in lines.by_ref().take(MAX_HIGHLIGHT_LINES) {
             write!(&mut self.dst, "{0}:{1:2$} {3}\n",
-                        fm.name, "", max_digits, line)?;
+                   fm.name, "", max_digits, line)?;
         }
 
         // if we elided some lines, add an ellipsis
         if let Some(_) = lines.next() {
             write!(&mut self.dst, "{0:1$} {0:2$} ...\n",
-                        "", fm.name.len(), max_digits)?;
+                   "", fm.name.len(), max_digits)?;
         }
 
         Ok(())
@@ -424,15 +424,15 @@ impl EmitterWriter {
             // Print offending code-line
             remaining_err_lines -= 1;
             write!(&mut self.dst, "{}:{:>width$} {}\n",
-                        fm.name,
-                        line.line_index + 1,
-                        cur_line_str,
-                        width=digits)?;
+                   fm.name,
+                   line.line_index + 1,
+                   cur_line_str,
+                   width=digits)?;
 
             if s.len() > skip {
                 // Render the spans we assembled previously (if any).
                 println_maybe_styled!(&mut self.dst, term::Attr::ForegroundColor(lvl.color()),
-                                           "{}", s)?;
+                                      "{}", s)?;
             }
 
             if !overflowed_buf.is_empty() {
@@ -561,13 +561,13 @@ impl EmitterWriter {
 
             // Print offending code-lines
             write!(&mut self.dst, "{}:{:>width$} {}\n", fm.name,
-                        line.line_index + 1, line_str, width=digits)?;
+                   line.line_index + 1, line_str, width=digits)?;
             remaining_err_lines -= 1;
 
             if s.len() > skip {
                 // Render the spans we assembled previously (if any)
                 println_maybe_styled!(&mut self.dst, term::Attr::ForegroundColor(lvl.color()),
-                                           "{}", s)?;
+                                      "{}", s)?;
             }
             prev_line_index = line.line_index;
         }
@@ -642,7 +642,7 @@ fn print_diagnostic(dst: &mut Destination,
     }
 
     print_maybe_styled!(dst, term::Attr::ForegroundColor(lvl.color()),
-                             "{}: ", lvl.to_string())?;
+                        "{}: ", lvl.to_string())?;
     print_maybe_styled!(dst, term::Attr::Bold, "{}", msg)?;
 
     if let Some(code) = code {

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -208,12 +208,12 @@ pub fn nameize(p_s: &ParseSess, ms: &[TokenTree], res: &[Rc<NamedMatch>])
         match *m {
             TokenTree::Sequence(_, ref seq) => {
                 for next_m in &seq.tts {
-                    try!(n_rec(p_s, next_m, res, ret_val, idx))
+                    n_rec(p_s, next_m, res, ret_val, idx)?
                 }
             }
             TokenTree::Delimited(_, ref delim) => {
                 for next_m in &delim.tts {
-                    try!(n_rec(p_s, next_m, res, ret_val, idx));
+                    n_rec(p_s, next_m, res, ret_val, idx)?;
                 }
             }
             TokenTree::Token(sp, MatchNt(bind_name, _, _, _)) => {

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -32,6 +32,7 @@
 #![feature(str_char)]
 #![feature(str_escape)]
 #![feature(unicode)]
+#![feature(question_mark)]
 
 extern crate serialize;
 extern crate term;

--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -25,7 +25,7 @@ impl<'a> Parser<'a> {
             debug!("parse_outer_attributes: self.token={:?}", self.token);
             match self.token {
                 token::Pound => {
-                    attrs.push(try!(self.parse_attribute(false)));
+                    attrs.push(self.parse_attribute(false)?);
                 }
                 token::DocComment(s) => {
                     let attr = ::attr::mk_sugared_doc_attr(
@@ -79,10 +79,10 @@ impl<'a> Parser<'a> {
                     ast::AttrStyle::Outer
                 };
 
-                try!(self.expect(&token::OpenDelim(token::Bracket)));
-                let meta_item = try!(self.parse_meta_item());
+                self.expect(&token::OpenDelim(token::Bracket))?;
+                let meta_item = self.parse_meta_item()?;
                 let hi = self.span.hi;
-                try!(self.expect(&token::CloseDelim(token::Bracket)));
+                self.expect(&token::CloseDelim(token::Bracket))?;
 
                 (mk_sp(lo, hi), meta_item, style)
             }
@@ -126,7 +126,7 @@ impl<'a> Parser<'a> {
                         break;
                     }
 
-                    let attr = try!(self.parse_attribute(true));
+                    let attr = self.parse_attribute(true)?;
                     assert!(attr.node.style == ast::AttrStyle::Inner);
                     attrs.push(attr);
                 }
@@ -166,12 +166,12 @@ impl<'a> Parser<'a> {
         }
 
         let lo = self.span.lo;
-        let ident = try!(self.parse_ident());
+        let ident = self.parse_ident()?;
         let name = self.id_to_interned_str(ident);
         match self.token {
             token::Eq => {
                 self.bump();
-                let lit = try!(self.parse_lit());
+                let lit = self.parse_lit()?;
                 // FIXME #623 Non-string meta items are not serialized correctly;
                 // just forbid them for now
                 match lit.node {
@@ -185,7 +185,7 @@ impl<'a> Parser<'a> {
                 Ok(P(spanned(lo, hi, ast::MetaItemKind::NameValue(name, lit))))
             }
             token::OpenDelim(token::Paren) => {
-                let inner_items = try!(self.parse_meta_seq());
+                let inner_items = self.parse_meta_seq()?;
                 let hi = self.span.hi;
                 Ok(P(spanned(lo, hi, ast::MetaItemKind::List(name, inner_items))))
             }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -590,11 +590,11 @@ impl<'a> Parser<'a> {
     pub fn parse_path_list_item(&mut self) -> PResult<'a, ast::PathListItem> {
         let lo = self.span.lo;
         let node = if self.eat_keyword(keywords::SelfValue) {
-            let rename = try!(self.parse_rename());
+            let rename = self.parse_rename()?;
             ast::PathListItemKind::Mod { id: ast::DUMMY_NODE_ID, rename: rename }
         } else {
-            let ident = try!(self.parse_ident());
-            let rename = try!(self.parse_rename());
+            let ident = self.parse_ident()?;
+            let rename = self.parse_rename()?;
             ast::PathListItemKind::Ident { name: ident, rename: rename, id: ast::DUMMY_NODE_ID }
         };
         let hi = self.last_span.hi;
@@ -811,13 +811,13 @@ impl<'a> Parser<'a> {
             }
 
             if i % 2 == 0 {
-                match try!(f(self)) {
+                match f(self)? {
                     Some(result) => v.push(result),
                     None => return Ok((P::from_vec(v), true))
                 }
             } else {
                 if let Some(t) = sep.as_ref() {
-                    try!(self.expect(t));
+                    self.expect(t)?;
                 }
 
             }
@@ -833,8 +833,8 @@ impl<'a> Parser<'a> {
                                         -> PResult<'a, P<[T]>> where
         F: FnMut(&mut Parser<'a>) -> PResult<'a, T>,
     {
-        let (result, returned) = try!(self.parse_seq_to_before_gt_or_return(sep,
-                                                    |p| Ok(Some(try!(f(p))))));
+        let (result, returned) = self.parse_seq_to_before_gt_or_return(sep,
+                                                    |p| Ok(Some(f(p)?)))?;
         assert!(!returned);
         return Ok(result);
     }
@@ -845,8 +845,8 @@ impl<'a> Parser<'a> {
                                  -> PResult<'a, P<[T]>> where
         F: FnMut(&mut Parser<'a>) -> PResult<'a, T>,
     {
-        let v = try!(self.parse_seq_to_before_gt(sep, f));
-        try!(self.expect_gt());
+        let v = self.parse_seq_to_before_gt(sep, f)?;
+        self.expect_gt()?;
         return Ok(v);
     }
 
@@ -856,9 +856,9 @@ impl<'a> Parser<'a> {
                                            -> PResult<'a, (P<[T]>, bool)> where
         F: FnMut(&mut Parser<'a>) -> PResult<'a, Option<T>>,
     {
-        let (v, returned) = try!(self.parse_seq_to_before_gt_or_return(sep, f));
+        let (v, returned) = self.parse_seq_to_before_gt_or_return(sep, f)?;
         if !returned {
-            try!(self.expect_gt());
+            self.expect_gt()?;
         }
         return Ok((v, returned));
     }
@@ -953,7 +953,7 @@ impl<'a> Parser<'a> {
                                      -> PResult<'a, Vec<T>> where
         F: FnMut(&mut Parser<'a>) -> PResult<'a,  T>,
     {
-        try!(self.expect(bra));
+        self.expect(bra)?;
         let result = self.parse_seq_to_before_end(ket, sep, f);
         self.bump();
         Ok(result)
@@ -969,7 +969,7 @@ impl<'a> Parser<'a> {
                                         -> PResult<'a, Vec<T>> where
         F: FnMut(&mut Parser<'a>) -> PResult<'a,  T>,
     {
-        let result = try!(self.parse_unspanned_seq(bra, ket, sep, f));
+        let result = self.parse_unspanned_seq(bra, ket, sep, f)?;
         if result.is_empty() {
             let last_span = self.last_span;
             self.span_err(last_span,
@@ -989,7 +989,7 @@ impl<'a> Parser<'a> {
         F: FnMut(&mut Parser<'a>) -> PResult<'a,  T>,
     {
         let lo = self.span.lo;
-        try!(self.expect(bra));
+        self.expect(bra)?;
         let result = self.parse_seq_to_before_end(ket, sep, f);
         let hi = self.span.hi;
         self.bump();
@@ -1142,19 +1142,19 @@ impl<'a> Parser<'a> {
         // parse <'lt>
         let lo = self.span.lo;
 
-        let lifetime_defs = try!(self.parse_late_bound_lifetime_defs());
+        let lifetime_defs = self.parse_late_bound_lifetime_defs()?;
 
         // examine next token to decide to do
         if self.token_is_bare_fn_keyword() {
             self.parse_ty_bare_fn(lifetime_defs)
         } else {
             let hi = self.span.hi;
-            let trait_ref = try!(self.parse_trait_ref());
+            let trait_ref = self.parse_trait_ref()?;
             let poly_trait_ref = ast::PolyTraitRef { bound_lifetimes: lifetime_defs,
                                                      trait_ref: trait_ref,
                                                      span: mk_sp(lo, hi)};
             let other_bounds = if self.eat(&token::BinOp(token::Plus)) {
-                try!(self.parse_ty_param_bounds(BoundParsingMode::Bare))
+                self.parse_ty_param_bounds(BoundParsingMode::Bare)?
             } else {
                 P::empty()
             };
@@ -1167,7 +1167,7 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_ty_path(&mut self) -> PResult<'a, TyKind> {
-        Ok(TyKind::Path(None, try!(self.parse_path(LifetimeAndTypesWithoutColons))))
+        Ok(TyKind::Path(None, self.parse_path(LifetimeAndTypesWithoutColons)?))
     }
 
     /// parse a TyKind::BareFn type:
@@ -1185,16 +1185,16 @@ impl<'a> Parser<'a> {
         Function Style
         */
 
-        let unsafety = try!(self.parse_unsafety());
+        let unsafety = self.parse_unsafety()?;
         let abi = if self.eat_keyword(keywords::Extern) {
-            try!(self.parse_opt_abi()).unwrap_or(Abi::C)
+            self.parse_opt_abi()?.unwrap_or(Abi::C)
         } else {
             Abi::Rust
         };
 
-        try!(self.expect_keyword(keywords::Fn));
-        let (inputs, variadic) = try!(self.parse_fn_args(false, true));
-        let ret_ty = try!(self.parse_ret_ty());
+        self.expect_keyword(keywords::Fn)?;
+        let (inputs, variadic) = self.parse_fn_args(false, true)?;
+        let ret_ty = self.parse_ret_ty()?;
         let decl = P(FnDecl {
             inputs: inputs,
             output: ret_ty,
@@ -1254,25 +1254,25 @@ impl<'a> Parser<'a> {
             SeqSep::none(),
             |p| -> PResult<'a, TraitItem> {
             maybe_whole!(no_clone_from_p p, NtTraitItem);
-            let mut attrs = try!(p.parse_outer_attributes());
+            let mut attrs = p.parse_outer_attributes()?;
             let lo = p.span.lo;
 
             let (name, node) = if p.eat_keyword(keywords::Type) {
-                let TyParam {ident, bounds, default, ..} = try!(p.parse_ty_param());
-                try!(p.expect(&token::Semi));
+                let TyParam {ident, bounds, default, ..} = p.parse_ty_param()?;
+                p.expect(&token::Semi)?;
                 (ident, TraitItemKind::Type(bounds, default))
             } else if p.is_const_item() {
-                try!(p.expect_keyword(keywords::Const));
-                let ident = try!(p.parse_ident());
-                try!(p.expect(&token::Colon));
-                let ty = try!(p.parse_ty_sum());
+                p.expect_keyword(keywords::Const)?;
+                let ident = p.parse_ident()?;
+                p.expect(&token::Colon)?;
+                let ty = p.parse_ty_sum()?;
                 let default = if p.check(&token::Eq) {
                     p.bump();
-                    let expr = try!(p.parse_expr());
-                    try!(p.commit_expr_expecting(&expr, token::Semi));
+                    let expr = p.parse_expr()?;
+                    p.commit_expr_expecting(&expr, token::Semi)?;
                     Some(expr)
                 } else {
-                    try!(p.expect(&token::Semi));
+                    p.expect(&token::Semi)?;
                     None
                 };
                 (ident, TraitItemKind::Const(ty, default))
@@ -1288,7 +1288,7 @@ impl<'a> Parser<'a> {
                             }
 
                             if p.token == token::OpenDelim(token::DelimToken::Brace) {
-                                try!(p.parse_token_tree());
+                                p.parse_token_tree()?;
                                 break;
                             }
                         }
@@ -1297,17 +1297,17 @@ impl<'a> Parser<'a> {
                     }
                 };
 
-                let ident = try!(p.parse_ident());
-                let mut generics = try!(p.parse_generics());
+                let ident = p.parse_ident()?;
+                let mut generics = p.parse_generics()?;
 
-                let (explicit_self, d) = try!(p.parse_fn_decl_with_self(|p: &mut Parser<'a>|{
+                let (explicit_self, d) = p.parse_fn_decl_with_self(|p: &mut Parser<'a>|{
                     // This is somewhat dubious; We don't want to allow
                     // argument names to be left off if there is a
                     // definition...
                     p.parse_arg_general(false)
-                }));
+                })?;
 
-                generics.where_clause = try!(p.parse_where_clause());
+                generics.where_clause = p.parse_where_clause()?;
                 let sig = ast::MethodSig {
                     unsafety: unsafety,
                     constness: constness,
@@ -1326,7 +1326,7 @@ impl<'a> Parser<'a> {
                   token::OpenDelim(token::Brace) => {
                     debug!("parse_trait_methods(): parsing provided method");
                     let (inner_attrs, body) =
-                        try!(p.parse_inner_attrs_and_block());
+                        p.parse_inner_attrs_and_block()?;
                     attrs.extend(inner_attrs.iter().cloned());
                     Some(body)
                   }
@@ -1352,8 +1352,8 @@ impl<'a> Parser<'a> {
 
     /// Parse a possibly mutable type
     pub fn parse_mt(&mut self) -> PResult<'a, MutTy> {
-        let mutbl = try!(self.parse_mutability());
-        let t = try!(self.parse_ty());
+        let mutbl = self.parse_mutability()?;
+        let t = self.parse_ty()?;
         Ok(MutTy { ty: t, mutbl: mutbl })
     }
 
@@ -1363,7 +1363,7 @@ impl<'a> Parser<'a> {
             if self.eat(&token::Not) {
                 Ok(FunctionRetTy::None(self.last_span))
             } else {
-                Ok(FunctionRetTy::Ty(try!(self.parse_ty())))
+                Ok(FunctionRetTy::Ty(self.parse_ty()?))
             }
         } else {
             let pos = self.span.lo;
@@ -1374,13 +1374,13 @@ impl<'a> Parser<'a> {
     /// Parse a type in a context where `T1+T2` is allowed.
     pub fn parse_ty_sum(&mut self) -> PResult<'a, P<Ty>> {
         let lo = self.span.lo;
-        let lhs = try!(self.parse_ty());
+        let lhs = self.parse_ty()?;
 
         if !self.eat(&token::BinOp(token::Plus)) {
             return Ok(lhs);
         }
 
-        let bounds = try!(self.parse_ty_param_bounds(BoundParsingMode::Bare));
+        let bounds = self.parse_ty_param_bounds(BoundParsingMode::Bare)?;
 
         // In type grammar, `+` is treated like a binary operator,
         // and hence both L and R side are required.
@@ -1411,7 +1411,7 @@ impl<'a> Parser<'a> {
             let mut ts = vec![];
             let mut last_comma = false;
             while self.token != token::CloseDelim(token::Paren) {
-                ts.push(try!(self.parse_ty_sum()));
+                ts.push(self.parse_ty_sum()?);
                 if self.check(&token::Comma) {
                     last_comma = true;
                     self.bump();
@@ -1421,7 +1421,7 @@ impl<'a> Parser<'a> {
                 }
             }
 
-            try!(self.expect(&token::CloseDelim(token::Paren)));
+            self.expect(&token::CloseDelim(token::Paren))?;
             if ts.len() == 1 && !last_comma {
                 TyKind::Paren(ts.into_iter().nth(0).unwrap())
             } else {
@@ -1430,54 +1430,54 @@ impl<'a> Parser<'a> {
         } else if self.check(&token::BinOp(token::Star)) {
             // STAR POINTER (bare pointer?)
             self.bump();
-            TyKind::Ptr(try!(self.parse_ptr()))
+            TyKind::Ptr(self.parse_ptr()?)
         } else if self.check(&token::OpenDelim(token::Bracket)) {
             // VECTOR
-            try!(self.expect(&token::OpenDelim(token::Bracket)));
-            let t = try!(self.parse_ty_sum());
+            self.expect(&token::OpenDelim(token::Bracket))?;
+            let t = self.parse_ty_sum()?;
 
             // Parse the `; e` in `[ i32; e ]`
             // where `e` is a const expression
-            let t = match try!(self.maybe_parse_fixed_length_of_vec()) {
+            let t = match self.maybe_parse_fixed_length_of_vec()? {
                 None => TyKind::Vec(t),
                 Some(suffix) => TyKind::FixedLengthVec(t, suffix)
             };
-            try!(self.expect(&token::CloseDelim(token::Bracket)));
+            self.expect(&token::CloseDelim(token::Bracket))?;
             t
         } else if self.check(&token::BinOp(token::And)) ||
                   self.token == token::AndAnd {
             // BORROWED POINTER
-            try!(self.expect_and());
-            try!(self.parse_borrowed_pointee())
+            self.expect_and()?;
+            self.parse_borrowed_pointee()?
         } else if self.check_keyword(keywords::For) {
-            try!(self.parse_for_in_type())
+            self.parse_for_in_type()?
         } else if self.token_is_bare_fn_keyword() {
             // BARE FUNCTION
-            try!(self.parse_ty_bare_fn(Vec::new()))
+            self.parse_ty_bare_fn(Vec::new())?
         } else if self.eat_keyword_noexpect(keywords::Typeof) {
             // TYPEOF
             // In order to not be ambiguous, the type must be surrounded by parens.
-            try!(self.expect(&token::OpenDelim(token::Paren)));
-            let e = try!(self.parse_expr());
-            try!(self.expect(&token::CloseDelim(token::Paren)));
+            self.expect(&token::OpenDelim(token::Paren))?;
+            let e = self.parse_expr()?;
+            self.expect(&token::CloseDelim(token::Paren))?;
             TyKind::Typeof(e)
         } else if self.eat_lt() {
 
             let (qself, path) =
-                 try!(self.parse_qualified_path(NoTypesAllowed));
+                 self.parse_qualified_path(NoTypesAllowed)?;
 
             TyKind::Path(Some(qself), path)
         } else if self.check(&token::ModSep) ||
                   self.token.is_ident() ||
                   self.token.is_path() {
-            let path = try!(self.parse_path(LifetimeAndTypesWithoutColons));
+            let path = self.parse_path(LifetimeAndTypesWithoutColons)?;
             if self.check(&token::Not) {
                 // MACRO INVOCATION
                 self.bump();
-                let delim = try!(self.expect_open_delim());
-                let tts = try!(self.parse_seq_to_end(&token::CloseDelim(delim),
+                let delim = self.expect_open_delim()?;
+                let tts = self.parse_seq_to_end(&token::CloseDelim(delim),
                                                      SeqSep::none(),
-                                                     |p| p.parse_token_tree()));
+                                                     |p| p.parse_token_tree())?;
                 let hi = self.span.hi;
                 TyKind::Mac(spanned(lo, hi, Mac_ { path: path, tts: tts, ctxt: EMPTY_CTXT }))
             } else {
@@ -1499,9 +1499,9 @@ impl<'a> Parser<'a> {
 
     pub fn parse_borrowed_pointee(&mut self) -> PResult<'a, TyKind> {
         // look for `&'lt` or `&'foo ` and interpret `foo` as the region name:
-        let opt_lifetime = try!(self.parse_opt_lifetime());
+        let opt_lifetime = self.parse_opt_lifetime()?;
 
-        let mt = try!(self.parse_mt());
+        let mt = self.parse_mt()?;
         return Ok(TyKind::Rptr(opt_lifetime, mt));
     }
 
@@ -1518,7 +1518,7 @@ impl<'a> Parser<'a> {
                            known as `*const T`");
             Mutability::Immutable
         };
-        let t = try!(self.parse_ty());
+        let t = self.parse_ty()?;
         Ok(MutTy { ty: t, mutbl: mutbl })
     }
 
@@ -1549,9 +1549,9 @@ impl<'a> Parser<'a> {
         let pat = if require_name || self.is_named_argument() {
             debug!("parse_arg_general parse_pat (require_name:{})",
                    require_name);
-            let pat = try!(self.parse_pat());
+            let pat = self.parse_pat()?;
 
-            try!(self.expect(&token::Colon));
+            self.expect(&token::Colon)?;
             pat
         } else {
             debug!("parse_arg_general ident_to_pat");
@@ -1560,7 +1560,7 @@ impl<'a> Parser<'a> {
                                    special_idents::invalid)
         };
 
-        let t = try!(self.parse_ty_sum());
+        let t = self.parse_ty_sum()?;
 
         Ok(Arg {
             ty: t,
@@ -1576,9 +1576,9 @@ impl<'a> Parser<'a> {
 
     /// Parse an argument in a lambda header e.g. |arg, arg|
     pub fn parse_fn_block_arg(&mut self) -> PResult<'a, Arg> {
-        let pat = try!(self.parse_pat());
+        let pat = self.parse_pat()?;
         let t = if self.eat(&token::Colon) {
-            try!(self.parse_ty_sum())
+            self.parse_ty_sum()?
         } else {
             P(Ty {
                 id: ast::DUMMY_NODE_ID,
@@ -1596,7 +1596,7 @@ impl<'a> Parser<'a> {
     pub fn maybe_parse_fixed_length_of_vec(&mut self) -> PResult<'a, Option<P<ast::Expr>>> {
         if self.check(&token::Semi) {
             self.bump();
-            Ok(Some(try!(self.parse_expr())))
+            Ok(Some(self.parse_expr()?))
         } else {
             Ok(None)
         }
@@ -1670,7 +1670,7 @@ impl<'a> Parser<'a> {
             LitKind::Bool(false)
         } else {
             let token = self.bump_and_get();
-            let lit = try!(self.lit_from_token(&token));
+            let lit = self.lit_from_token(&token)?;
             lit
         };
         Ok(codemap::Spanned { node: lit, span: mk_sp(lo, self.last_span.hi) })
@@ -1681,7 +1681,7 @@ impl<'a> Parser<'a> {
         let minus_lo = self.span.lo;
         let minus_present = self.eat(&token::BinOp(token::Minus));
         let lo = self.span.lo;
-        let literal = P(try!(self.parse_lit()));
+        let literal = P(self.parse_lit()?);
         let hi = self.last_span.hi;
         let expr = self.mk_expr(lo, hi, ExprKind::Lit(literal), None);
 
@@ -1712,9 +1712,9 @@ impl<'a> Parser<'a> {
     pub fn parse_qualified_path(&mut self, mode: PathParsingMode)
                                 -> PResult<'a, (QSelf, ast::Path)> {
         let span = self.last_span;
-        let self_type = try!(self.parse_ty_sum());
+        let self_type = self.parse_ty_sum()?;
         let mut path = if self.eat_keyword(keywords::As) {
-            try!(self.parse_path(LifetimeAndTypesWithoutColons))
+            self.parse_path(LifetimeAndTypesWithoutColons)?
         } else {
             ast::Path {
                 span: span,
@@ -1728,18 +1728,18 @@ impl<'a> Parser<'a> {
             position: path.segments.len()
         };
 
-        try!(self.expect(&token::Gt));
-        try!(self.expect(&token::ModSep));
+        self.expect(&token::Gt)?;
+        self.expect(&token::ModSep)?;
 
         let segments = match mode {
             LifetimeAndTypesWithoutColons => {
-                try!(self.parse_path_segments_without_colons())
+                self.parse_path_segments_without_colons()?
             }
             LifetimeAndTypesWithColons => {
-                try!(self.parse_path_segments_with_colons())
+                self.parse_path_segments_with_colons()?
             }
             NoTypesAllowed => {
-                try!(self.parse_path_segments_without_types())
+                self.parse_path_segments_without_types()?
             }
         };
         path.segments.extend(segments);
@@ -1771,13 +1771,13 @@ impl<'a> Parser<'a> {
         // A bound set is a set of type parameter bounds.
         let segments = match mode {
             LifetimeAndTypesWithoutColons => {
-                try!(self.parse_path_segments_without_colons())
+                self.parse_path_segments_without_colons()?
             }
             LifetimeAndTypesWithColons => {
-                try!(self.parse_path_segments_with_colons())
+                self.parse_path_segments_with_colons()?
             }
             NoTypesAllowed => {
-                try!(self.parse_path_segments_without_types())
+                self.parse_path_segments_without_types()?
             }
         };
 
@@ -1800,11 +1800,11 @@ impl<'a> Parser<'a> {
         let mut segments = Vec::new();
         loop {
             // First, parse an identifier.
-            let identifier = try!(self.parse_ident_or_self_type());
+            let identifier = self.parse_ident_or_self_type()?;
 
             // Parse types, optionally.
             let parameters = if self.eat_lt() {
-                let (lifetimes, types, bindings) = try!(self.parse_generic_values_after_lt());
+                let (lifetimes, types, bindings) = self.parse_generic_values_after_lt()?;
 
                 ast::PathParameters::AngleBracketed(ast::AngleBracketedParameterData {
                     lifetimes: lifetimes,
@@ -1814,13 +1814,13 @@ impl<'a> Parser<'a> {
             } else if self.eat(&token::OpenDelim(token::Paren)) {
                 let lo = self.last_span.lo;
 
-                let inputs = try!(self.parse_seq_to_end(
+                let inputs = self.parse_seq_to_end(
                     &token::CloseDelim(token::Paren),
                     SeqSep::trailing_allowed(token::Comma),
-                    |p| p.parse_ty_sum()));
+                    |p| p.parse_ty_sum())?;
 
                 let output_ty = if self.eat(&token::RArrow) {
-                    Some(try!(self.parse_ty()))
+                    Some(self.parse_ty()?)
                 } else {
                     None
                 };
@@ -1853,7 +1853,7 @@ impl<'a> Parser<'a> {
         let mut segments = Vec::new();
         loop {
             // First, parse an identifier.
-            let identifier = try!(self.parse_ident_or_self_type());
+            let identifier = self.parse_ident_or_self_type()?;
 
             // If we do not see a `::`, stop.
             if !self.eat(&token::ModSep) {
@@ -1867,7 +1867,7 @@ impl<'a> Parser<'a> {
             // Check for a type segment.
             if self.eat_lt() {
                 // Consumed `a::b::<`, go look for types
-                let (lifetimes, types, bindings) = try!(self.parse_generic_values_after_lt());
+                let (lifetimes, types, bindings) = self.parse_generic_values_after_lt()?;
                 let parameters = ast::AngleBracketedParameterData {
                     lifetimes: lifetimes,
                     types: P::from_vec(types),
@@ -1899,7 +1899,7 @@ impl<'a> Parser<'a> {
         let mut segments = Vec::new();
         loop {
             // First, parse an identifier.
-            let identifier = try!(self.parse_ident_or_self_type());
+            let identifier = self.parse_ident_or_self_type()?;
 
             // Assemble and push the result.
             segments.push(ast::PathSegment {
@@ -1918,7 +1918,7 @@ impl<'a> Parser<'a> {
     pub fn parse_opt_lifetime(&mut self) -> PResult<'a, Option<ast::Lifetime>> {
         match self.token {
             token::Lifetime(..) => {
-                Ok(Some(try!(self.parse_lifetime())))
+                Ok(Some(self.parse_lifetime()?))
             }
             _ => {
                 Ok(None)
@@ -1953,10 +1953,10 @@ impl<'a> Parser<'a> {
         loop {
             match self.token {
                 token::Lifetime(_) => {
-                    let lifetime = try!(self.parse_lifetime());
+                    let lifetime = self.parse_lifetime()?;
                     let bounds =
                         if self.eat(&token::Colon) {
-                            try!(self.parse_lifetimes(token::BinOp(token::Plus)))
+                            self.parse_lifetimes(token::BinOp(token::Plus))?
                         } else {
                             Vec::new()
                         };
@@ -1996,7 +1996,7 @@ impl<'a> Parser<'a> {
         loop {
             match self.token {
                 token::Lifetime(_) => {
-                    res.push(try!(self.parse_lifetime()));
+                    res.push(self.parse_lifetime()?);
                 }
                 _ => {
                     return Ok(res);
@@ -2023,10 +2023,10 @@ impl<'a> Parser<'a> {
     /// Parse ident COLON expr
     pub fn parse_field(&mut self) -> PResult<'a, Field> {
         let lo = self.span.lo;
-        let i = try!(self.parse_ident());
+        let i = self.parse_ident()?;
         let hi = self.last_span.hi;
-        try!(self.expect(&token::Colon));
-        let e = try!(self.parse_expr());
+        self.expect(&token::Colon)?;
+        let e = self.parse_expr()?;
         Ok(ast::Field {
             ident: spanned(lo, hi, i),
             span: mk_sp(lo, e.span.hi),
@@ -2152,7 +2152,7 @@ impl<'a> Parser<'a> {
             token::OpenDelim(token::Paren) => {
                 self.bump();
 
-                let attrs = try!(self.parse_inner_attributes())
+                let attrs = self.parse_inner_attributes()?
                     .into_thin_attrs()
                     .prepend(attrs);
 
@@ -2161,9 +2161,9 @@ impl<'a> Parser<'a> {
                 let mut es = vec![];
                 let mut trailing_comma = false;
                 while self.token != token::CloseDelim(token::Paren) {
-                    es.push(try!(self.parse_expr()));
-                    try!(self.commit_expr(&es.last().unwrap(), &[],
-                                     &[token::Comma, token::CloseDelim(token::Paren)]));
+                    es.push(self.parse_expr()?);
+                    self.commit_expr(&es.last().unwrap(), &[],
+                                     &[token::Comma, token::CloseDelim(token::Paren)])?;
                     if self.check(&token::Comma) {
                         trailing_comma = true;
 
@@ -2201,7 +2201,7 @@ impl<'a> Parser<'a> {
             token::OpenDelim(token::Bracket) => {
                 self.bump();
 
-                let inner_attrs = try!(self.parse_inner_attributes())
+                let inner_attrs = self.parse_inner_attributes()?
                     .into_thin_attrs();
                 attrs.update(|attrs| attrs.append(inner_attrs));
 
@@ -2211,27 +2211,27 @@ impl<'a> Parser<'a> {
                     ex = ExprKind::Vec(Vec::new());
                 } else {
                     // Nonempty vector.
-                    let first_expr = try!(self.parse_expr());
+                    let first_expr = self.parse_expr()?;
                     if self.check(&token::Semi) {
                         // Repeating array syntax: [ 0; 512 ]
                         self.bump();
-                        let count = try!(self.parse_expr());
-                        try!(self.expect(&token::CloseDelim(token::Bracket)));
+                        let count = self.parse_expr()?;
+                        self.expect(&token::CloseDelim(token::Bracket))?;
                         ex = ExprKind::Repeat(first_expr, count);
                     } else if self.check(&token::Comma) {
                         // Vector with two or more elements.
                         self.bump();
-                        let remaining_exprs = try!(self.parse_seq_to_end(
+                        let remaining_exprs = self.parse_seq_to_end(
                             &token::CloseDelim(token::Bracket),
                             SeqSep::trailing_allowed(token::Comma),
-                            |p| Ok(try!(p.parse_expr()))
-                                ));
+                            |p| Ok(p.parse_expr()?)
+                                )?;
                         let mut exprs = vec!(first_expr);
                         exprs.extend(remaining_exprs);
                         ex = ExprKind::Vec(exprs);
                     } else {
                         // Vector with one element.
-                        try!(self.expect(&token::CloseDelim(token::Bracket)));
+                        self.expect(&token::CloseDelim(token::Bracket))?;
                         ex = ExprKind::Vec(vec!(first_expr));
                     }
                 }
@@ -2240,7 +2240,7 @@ impl<'a> Parser<'a> {
             _ => {
                 if self.eat_lt() {
                     let (qself, path) =
-                        try!(self.parse_qualified_path(LifetimeAndTypesWithColons));
+                        self.parse_qualified_path(LifetimeAndTypesWithColons)?;
                     hi = path.span.hi;
                     return Ok(self.mk_expr(lo, hi, ExprKind::Path(Some(qself), path), attrs));
                 }
@@ -2263,7 +2263,7 @@ impl<'a> Parser<'a> {
                     let lifetime = self.get_lifetime();
                     let lo = self.span.lo;
                     self.bump();
-                    try!(self.expect(&token::Colon));
+                    self.expect(&token::Colon)?;
                     if self.eat_keyword(keywords::While) {
                         return self.parse_while_expr(Some(lifetime), lo, attrs)
                     }
@@ -2304,7 +2304,7 @@ impl<'a> Parser<'a> {
                 }
                 if self.eat_keyword(keywords::Return) {
                     if self.token.can_begin_expr() {
-                        let e = try!(self.parse_expr());
+                        let e = self.parse_expr()?;
                         hi = e.span.hi;
                         ex = ExprKind::Ret(Some(e));
                     } else {
@@ -2332,18 +2332,18 @@ impl<'a> Parser<'a> {
                         !self.check_keyword(keywords::True) &&
                         !self.check_keyword(keywords::False) {
                     let pth =
-                        try!(self.parse_path(LifetimeAndTypesWithColons));
+                        self.parse_path(LifetimeAndTypesWithColons)?;
 
                     // `!`, as an operator, is prefix, so we know this isn't that
                     if self.check(&token::Not) {
                         // MACRO INVOCATION expression
                         self.bump();
 
-                        let delim = try!(self.expect_open_delim());
-                        let tts = try!(self.parse_seq_to_end(
+                        let delim = self.expect_open_delim()?;
+                        let tts = self.parse_seq_to_end(
                             &token::CloseDelim(delim),
                             SeqSep::none(),
-                            |p| p.parse_token_tree()));
+                            |p| p.parse_token_tree())?;
                         let hi = self.last_span.hi;
 
                         return Ok(self.mk_mac_expr(lo,
@@ -2364,7 +2364,7 @@ impl<'a> Parser<'a> {
                             let mut base = None;
 
                             let attrs = attrs.append(
-                                try!(self.parse_inner_attributes())
+                                self.parse_inner_attributes()?
                                     .into_thin_attrs());
 
                             while self.token != token::CloseDelim(token::Brace) {
@@ -2403,7 +2403,7 @@ impl<'a> Parser<'a> {
                             }
 
                             hi = self.span.hi;
-                            try!(self.expect(&token::CloseDelim(token::Brace)));
+                            self.expect(&token::CloseDelim(token::Brace))?;
                             ex = ExprKind::Struct(pth, fields, base);
                             return Ok(self.mk_expr(lo, hi, ex, attrs));
                         }
@@ -2413,7 +2413,7 @@ impl<'a> Parser<'a> {
                     ex = ExprKind::Path(None, pth);
                 } else {
                     // other literal expression
-                    let lit = try!(self.parse_lit());
+                    let lit = self.parse_lit()?;
                     hi = lit.span.hi;
                     ex = ExprKind::Lit(P(lit));
                 }
@@ -2439,12 +2439,12 @@ impl<'a> Parser<'a> {
                             -> PResult<'a, P<Expr>> {
 
         let outer_attrs = attrs;
-        try!(self.expect(&token::OpenDelim(token::Brace)));
+        self.expect(&token::OpenDelim(token::Brace))?;
 
-        let inner_attrs = try!(self.parse_inner_attributes()).into_thin_attrs();
+        let inner_attrs = self.parse_inner_attributes()?.into_thin_attrs();
         let attrs = outer_attrs.append(inner_attrs);
 
-        let blk = try!(self.parse_block_tail(lo, blk_mode));
+        let blk = self.parse_block_tail(lo, blk_mode)?;
         return Ok(self.mk_expr(blk.span.lo, blk.span.hi, ExprKind::Block(blk), attrs));
     }
 
@@ -2452,10 +2452,10 @@ impl<'a> Parser<'a> {
     pub fn parse_dot_or_call_expr(&mut self,
                                   already_parsed_attrs: Option<ThinAttributes>)
                                   -> PResult<'a, P<Expr>> {
-        let attrs = try!(self.parse_or_use_outer_attributes(already_parsed_attrs));
+        let attrs = self.parse_or_use_outer_attributes(already_parsed_attrs)?;
 
         let b = self.parse_bottom_expr();
-        let (span, b) = try!(self.interpolated_or_expr_span(b));
+        let (span, b) = self.interpolated_or_expr_span(b)?;
         self.parse_dot_or_call_expr_with(b, span.lo, attrs)
     }
 
@@ -2498,8 +2498,8 @@ impl<'a> Parser<'a> {
                         lo: BytePos)
                         -> PResult<'a, P<Expr>> {
         let (_, tys, bindings) = if self.eat(&token::ModSep) {
-            try!(self.expect_lt());
-            try!(self.parse_generic_values_after_lt())
+            self.expect_lt()?;
+            self.parse_generic_values_after_lt()?
         } else {
             (Vec::new(), Vec::new(), Vec::new())
         };
@@ -2512,12 +2512,12 @@ impl<'a> Parser<'a> {
         Ok(match self.token {
             // expr.f() method call.
             token::OpenDelim(token::Paren) => {
-                let mut es = try!(self.parse_unspanned_seq(
+                let mut es = self.parse_unspanned_seq(
                     &token::OpenDelim(token::Paren),
                     &token::CloseDelim(token::Paren),
                     SeqSep::trailing_allowed(token::Comma),
-                    |p| Ok(try!(p.parse_expr()))
-                ));
+                    |p| Ok(p.parse_expr()?)
+                )?;
                 let hi = self.last_span.hi;
 
                 es.insert(0, self_value);
@@ -2559,7 +2559,7 @@ impl<'a> Parser<'a> {
                     hi = self.span.hi;
                     self.bump();
 
-                    e = try!(self.parse_dot_suffix(i, mk_sp(dot_pos, hi), e, lo));
+                    e = self.parse_dot_suffix(i, mk_sp(dot_pos, hi), e, lo)?;
                   }
                   token::Literal(token::Integer(n), suf) => {
                     let sp = self.span;
@@ -2609,9 +2609,9 @@ impl<'a> Parser<'a> {
                     self.span_err(self.span, &format!("unexpected token: `{}`", actual));
 
                     let dot_pos = self.last_span.hi;
-                    e = try!(self.parse_dot_suffix(special_idents::invalid,
+                    e = self.parse_dot_suffix(special_idents::invalid,
                                                    mk_sp(dot_pos, dot_pos),
-                                                   e, lo));
+                                                   e, lo)?;
                   }
                 }
                 continue;
@@ -2620,12 +2620,12 @@ impl<'a> Parser<'a> {
             match self.token {
               // expr(...)
               token::OpenDelim(token::Paren) => {
-                let es = try!(self.parse_unspanned_seq(
+                let es = self.parse_unspanned_seq(
                     &token::OpenDelim(token::Paren),
                     &token::CloseDelim(token::Paren),
                     SeqSep::trailing_allowed(token::Comma),
-                    |p| Ok(try!(p.parse_expr()))
-                ));
+                    |p| Ok(p.parse_expr()?)
+                )?;
                 hi = self.last_span.hi;
 
                 let nd = self.mk_call(e, es);
@@ -2636,9 +2636,9 @@ impl<'a> Parser<'a> {
               // Could be either an index expression or a slicing expression.
               token::OpenDelim(token::Bracket) => {
                 self.bump();
-                let ix = try!(self.parse_expr());
+                let ix = self.parse_expr()?;
                 hi = self.span.hi;
-                try!(self.commit_expr_expecting(&ix, token::CloseDelim(token::Bracket)));
+                self.commit_expr_expecting(&ix, token::CloseDelim(token::Bracket))?;
                 let index = self.mk_index(e, ix);
                 e = self.mk_expr(lo, hi, index, None)
               }
@@ -2656,13 +2656,13 @@ impl<'a> Parser<'a> {
                 self.bump();
 
                 if self.token == token::OpenDelim(token::Paren) {
-                    let Spanned { node: seq, span: seq_span } = try!(self.parse_seq(
+                    let Spanned { node: seq, span: seq_span } = self.parse_seq(
                         &token::OpenDelim(token::Paren),
                         &token::CloseDelim(token::Paren),
                         SeqSep::none(),
                         |p| p.parse_token_tree()
-                    ));
-                    let (sep, repeat) = try!(self.parse_sep_and_kleene_op());
+                    )?;
+                    let (sep, repeat) = self.parse_sep_and_kleene_op()?;
                     let name_num = macro_parser::count_names(&seq);
                     return Ok(TokenTree::Sequence(mk_sp(sp.lo, seq_span.hi),
                                       Rc::new(SequenceRepetition {
@@ -2677,7 +2677,7 @@ impl<'a> Parser<'a> {
                 } else {
                     sp = mk_sp(sp.lo, self.span.hi);
                     let namep = match self.token { token::Ident(_, p) => p, _ => token::Plain };
-                    let name = try!(self.parse_ident());
+                    let name = self.parse_ident()?;
                     (name, namep)
                 }
             }
@@ -2694,7 +2694,7 @@ impl<'a> Parser<'a> {
             self.bump();
             sp = mk_sp(sp.lo, self.span.hi);
             let kindp = match self.token { token::Ident(_, p) => p, _ => token::Plain };
-            let nt_kind = try!(self.parse_ident());
+            let nt_kind = self.parse_ident()?;
             Ok(TokenTree::Token(sp, MatchNt(name, nt_kind, namep, kindp)))
         } else {
             Ok(TokenTree::Token(sp, SubstNt(name, namep)))
@@ -2729,13 +2729,13 @@ impl<'a> Parser<'a> {
             }
         };
 
-        match try!(parse_kleene_op(self)) {
+        match parse_kleene_op(self)? {
             Some(kleene_op) => return Ok((None, kleene_op)),
             None => {}
         }
 
         let separator = self.bump_and_get();
-        match try!(parse_kleene_op(self)) {
+        match parse_kleene_op(self)? {
             Some(zerok) => Ok((Some(separator), zerok)),
             None => return Err(self.fatal("expected `*` or `+`"))
         }
@@ -2827,7 +2827,7 @@ impl<'a> Parser<'a> {
     pub fn parse_all_token_trees(&mut self) -> PResult<'a, Vec<TokenTree>> {
         let mut tts = Vec::new();
         while self.token != token::Eof {
-            tts.push(try!(self.parse_token_tree()));
+            tts.push(self.parse_token_tree()?);
         }
         Ok(tts)
     }
@@ -2836,7 +2836,7 @@ impl<'a> Parser<'a> {
     pub fn parse_prefix_expr(&mut self,
                              already_parsed_attrs: Option<ThinAttributes>)
                              -> PResult<'a, P<Expr>> {
-        let attrs = try!(self.parse_or_use_outer_attributes(already_parsed_attrs));
+        let attrs = self.parse_or_use_outer_attributes(already_parsed_attrs)?;
         let lo = self.span.lo;
         let hi;
         // Note: when adding new unary operators, don't forget to adjust Token::can_begin_expr()
@@ -2844,39 +2844,39 @@ impl<'a> Parser<'a> {
             token::Not => {
                 self.bump();
                 let e = self.parse_prefix_expr(None);
-                let (span, e) = try!(self.interpolated_or_expr_span(e));
+                let (span, e) = self.interpolated_or_expr_span(e)?;
                 hi = span.hi;
                 self.mk_unary(UnOp::Not, e)
             }
             token::BinOp(token::Minus) => {
                 self.bump();
                 let e = self.parse_prefix_expr(None);
-                let (span, e) = try!(self.interpolated_or_expr_span(e));
+                let (span, e) = self.interpolated_or_expr_span(e)?;
                 hi = span.hi;
                 self.mk_unary(UnOp::Neg, e)
             }
             token::BinOp(token::Star) => {
                 self.bump();
                 let e = self.parse_prefix_expr(None);
-                let (span, e) = try!(self.interpolated_or_expr_span(e));
+                let (span, e) = self.interpolated_or_expr_span(e)?;
                 hi = span.hi;
                 self.mk_unary(UnOp::Deref, e)
             }
             token::BinOp(token::And) | token::AndAnd => {
-                try!(self.expect_and());
-                let m = try!(self.parse_mutability());
+                self.expect_and()?;
+                let m = self.parse_mutability()?;
                 let e = self.parse_prefix_expr(None);
-                let (span, e) = try!(self.interpolated_or_expr_span(e));
+                let (span, e) = self.interpolated_or_expr_span(e)?;
                 hi = span.hi;
                 ExprKind::AddrOf(m, e)
             }
             token::Ident(..) if self.token.is_keyword(keywords::In) => {
                 self.bump();
-                let place = try!(self.parse_expr_res(
+                let place = self.parse_expr_res(
                     Restrictions::RESTRICTION_NO_STRUCT_LITERAL,
                     None,
-                ));
-                let blk = try!(self.parse_block());
+                )?;
+                let blk = self.parse_block()?;
                 let span = blk.span;
                 hi = span.hi;
                 let blk_expr = self.mk_expr(span.lo, span.hi, ExprKind::Block(blk),
@@ -2886,7 +2886,7 @@ impl<'a> Parser<'a> {
             token::Ident(..) if self.token.is_keyword(keywords::Box) => {
                 self.bump();
                 let e = self.parse_prefix_expr(None);
-                let (span, e) = try!(self.interpolated_or_expr_span(e));
+                let (span, e) = self.interpolated_or_expr_span(e)?;
                 hi = span.hi;
                 ExprKind::Box(e)
             }
@@ -2920,7 +2920,7 @@ impl<'a> Parser<'a> {
             if self.token == token::DotDot || self.token == token::DotDotDot {
                 return self.parse_prefix_range_expr(attrs);
             } else {
-                try!(self.parse_prefix_expr(attrs))
+                self.parse_prefix_expr(attrs)?
             }
         };
 
@@ -2952,12 +2952,12 @@ impl<'a> Parser<'a> {
             }
             // Special cases:
             if op == AssocOp::As {
-                let rhs = try!(self.parse_ty());
+                let rhs = self.parse_ty()?;
                 lhs = self.mk_expr(lhs_span.lo, rhs.span.hi,
                                    ExprKind::Cast(lhs, rhs), None);
                 continue
             } else if op == AssocOp::Colon {
-                let rhs = try!(self.parse_ty());
+                let rhs = self.parse_ty()?;
                 lhs = self.mk_expr(lhs_span.lo, rhs.span.hi,
                                    ExprKind::Type(lhs, rhs), None);
                 continue
@@ -2990,7 +2990,7 @@ impl<'a> Parser<'a> {
                 break
             }
 
-            let rhs = try!(match op.fixity() {
+            let rhs = match op.fixity() {
                 Fixity::Right => self.with_res(
                     restrictions - Restrictions::RESTRICTION_STMT_EXPR,
                     |this| {
@@ -3011,7 +3011,7 @@ impl<'a> Parser<'a> {
                         this.parse_assoc_expr_with(op.precedence() + 1,
                             LhsExpr::NotYetParsed)
                 }),
-            });
+            }?;
 
             lhs = match op {
                 AssocOp::Add | AssocOp::Subtract | AssocOp::Multiply | AssocOp::Divide |
@@ -3087,19 +3087,19 @@ impl<'a> Parser<'a> {
                                -> PResult<'a, P<Expr>> {
         debug_assert!(self.token == token::DotDot || self.token == token::DotDotDot);
         let tok = self.token.clone();
-        let attrs = try!(self.parse_or_use_outer_attributes(already_parsed_attrs));
+        let attrs = self.parse_or_use_outer_attributes(already_parsed_attrs)?;
         let lo = self.span.lo;
         let mut hi = self.span.hi;
         self.bump();
         let opt_end = if self.is_at_start_of_range_notation_rhs() {
             // RHS must be parsed with more associativity than the dots.
             let next_prec = AssocOp::from_token(&tok).unwrap().precedence() + 1;
-            Some(try!(self.parse_assoc_expr_with(next_prec,
+            Some(self.parse_assoc_expr_with(next_prec,
                                                  LhsExpr::NotYetParsed)
             .map(|x|{
                 hi = x.span.hi;
                 x
-            })))
+            })?)
          } else {
             None
         };
@@ -3131,12 +3131,12 @@ impl<'a> Parser<'a> {
             return self.parse_if_let_expr(attrs);
         }
         let lo = self.last_span.lo;
-        let cond = try!(self.parse_expr_res(Restrictions::RESTRICTION_NO_STRUCT_LITERAL, None));
-        let thn = try!(self.parse_block());
+        let cond = self.parse_expr_res(Restrictions::RESTRICTION_NO_STRUCT_LITERAL, None)?;
+        let thn = self.parse_block()?;
         let mut els: Option<P<Expr>> = None;
         let mut hi = thn.span.hi;
         if self.eat_keyword(keywords::Else) {
-            let elexpr = try!(self.parse_else_expr());
+            let elexpr = self.parse_else_expr()?;
             hi = elexpr.span.hi;
             els = Some(elexpr);
         }
@@ -3147,13 +3147,13 @@ impl<'a> Parser<'a> {
     pub fn parse_if_let_expr(&mut self, attrs: ThinAttributes)
                              -> PResult<'a, P<Expr>> {
         let lo = self.last_span.lo;
-        try!(self.expect_keyword(keywords::Let));
-        let pat = try!(self.parse_pat());
-        try!(self.expect(&token::Eq));
-        let expr = try!(self.parse_expr_res(Restrictions::RESTRICTION_NO_STRUCT_LITERAL, None));
-        let thn = try!(self.parse_block());
+        self.expect_keyword(keywords::Let)?;
+        let pat = self.parse_pat()?;
+        self.expect(&token::Eq)?;
+        let expr = self.parse_expr_res(Restrictions::RESTRICTION_NO_STRUCT_LITERAL, None)?;
+        let thn = self.parse_block()?;
         let (hi, els) = if self.eat_keyword(keywords::Else) {
-            let expr = try!(self.parse_else_expr());
+            let expr = self.parse_else_expr()?;
             (expr.span.hi, Some(expr))
         } else {
             (thn.span.hi, None)
@@ -3167,12 +3167,12 @@ impl<'a> Parser<'a> {
                              attrs: ThinAttributes)
                              -> PResult<'a, P<Expr>>
     {
-        let decl = try!(self.parse_fn_block_decl());
+        let decl = self.parse_fn_block_decl()?;
         let body = match decl.output {
             FunctionRetTy::Default(_) => {
                 // If no explicit return type is given, parse any
                 // expr and wrap it up in a dummy block:
-                let body_expr = try!(self.parse_expr());
+                let body_expr = self.parse_expr()?;
                 P(ast::Block {
                     id: ast::DUMMY_NODE_ID,
                     stmts: vec![],
@@ -3184,7 +3184,7 @@ impl<'a> Parser<'a> {
             _ => {
                 // If an explicit return type is given, require a
                 // block to appear (RFC 968).
-                try!(self.parse_block())
+                self.parse_block()?
             }
         };
 
@@ -3199,7 +3199,7 @@ impl<'a> Parser<'a> {
         if self.eat_keyword(keywords::If) {
             return self.parse_if_expr(None);
         } else {
-            let blk = try!(self.parse_block());
+            let blk = self.parse_block()?;
             return Ok(self.mk_expr(blk.span.lo, blk.span.hi, ExprKind::Block(blk), None));
         }
     }
@@ -3210,10 +3210,10 @@ impl<'a> Parser<'a> {
                           attrs: ThinAttributes) -> PResult<'a, P<Expr>> {
         // Parse: `for <src_pat> in <src_expr> <src_loop_block>`
 
-        let pat = try!(self.parse_pat());
-        try!(self.expect_keyword(keywords::In));
-        let expr = try!(self.parse_expr_res(Restrictions::RESTRICTION_NO_STRUCT_LITERAL, None));
-        let (iattrs, loop_block) = try!(self.parse_inner_attrs_and_block());
+        let pat = self.parse_pat()?;
+        self.expect_keyword(keywords::In)?;
+        let expr = self.parse_expr_res(Restrictions::RESTRICTION_NO_STRUCT_LITERAL, None)?;
+        let (iattrs, loop_block) = self.parse_inner_attrs_and_block()?;
         let attrs = attrs.append(iattrs.into_thin_attrs());
 
         let hi = self.last_span.hi;
@@ -3230,8 +3230,8 @@ impl<'a> Parser<'a> {
         if self.token.is_keyword(keywords::Let) {
             return self.parse_while_let_expr(opt_ident, span_lo, attrs);
         }
-        let cond = try!(self.parse_expr_res(Restrictions::RESTRICTION_NO_STRUCT_LITERAL, None));
-        let (iattrs, body) = try!(self.parse_inner_attrs_and_block());
+        let cond = self.parse_expr_res(Restrictions::RESTRICTION_NO_STRUCT_LITERAL, None)?;
+        let (iattrs, body) = self.parse_inner_attrs_and_block()?;
         let attrs = attrs.append(iattrs.into_thin_attrs());
         let hi = body.span.hi;
         return Ok(self.mk_expr(span_lo, hi, ExprKind::While(cond, body, opt_ident),
@@ -3242,11 +3242,11 @@ impl<'a> Parser<'a> {
     pub fn parse_while_let_expr(&mut self, opt_ident: Option<ast::Ident>,
                                 span_lo: BytePos,
                                 attrs: ThinAttributes) -> PResult<'a, P<Expr>> {
-        try!(self.expect_keyword(keywords::Let));
-        let pat = try!(self.parse_pat());
-        try!(self.expect(&token::Eq));
-        let expr = try!(self.parse_expr_res(Restrictions::RESTRICTION_NO_STRUCT_LITERAL, None));
-        let (iattrs, body) = try!(self.parse_inner_attrs_and_block());
+        self.expect_keyword(keywords::Let)?;
+        let pat = self.parse_pat()?;
+        self.expect(&token::Eq)?;
+        let expr = self.parse_expr_res(Restrictions::RESTRICTION_NO_STRUCT_LITERAL, None)?;
+        let (iattrs, body) = self.parse_inner_attrs_and_block()?;
         let attrs = attrs.append(iattrs.into_thin_attrs());
         let hi = body.span.hi;
         return Ok(self.mk_expr(span_lo, hi, ExprKind::WhileLet(pat, expr, body, opt_ident), attrs));
@@ -3256,7 +3256,7 @@ impl<'a> Parser<'a> {
     pub fn parse_loop_expr(&mut self, opt_ident: Option<ast::Ident>,
                            span_lo: BytePos,
                            attrs: ThinAttributes) -> PResult<'a, P<Expr>> {
-        let (iattrs, body) = try!(self.parse_inner_attrs_and_block());
+        let (iattrs, body) = self.parse_inner_attrs_and_block()?;
         let attrs = attrs.append(iattrs.into_thin_attrs());
         let hi = body.span.hi;
         Ok(self.mk_expr(span_lo, hi, ExprKind::Loop(body, opt_ident), attrs))
@@ -3266,8 +3266,8 @@ impl<'a> Parser<'a> {
     fn parse_match_expr(&mut self, attrs: ThinAttributes) -> PResult<'a, P<Expr>> {
         let match_span = self.last_span;
         let lo = self.last_span.lo;
-        let discriminant = try!(self.parse_expr_res(Restrictions::RESTRICTION_NO_STRUCT_LITERAL,
-                                                    None));
+        let discriminant = self.parse_expr_res(Restrictions::RESTRICTION_NO_STRUCT_LITERAL,
+                                                    None)?;
         if let Err(mut e) = self.commit_expr_expecting(&discriminant,
                                                        token::OpenDelim(token::Brace)) {
             if self.token == token::Token::Semi {
@@ -3276,7 +3276,7 @@ impl<'a> Parser<'a> {
             return Err(e)
         }
         let attrs = attrs.append(
-            try!(self.parse_inner_attributes()).into_thin_attrs());
+            self.parse_inner_attributes()?.into_thin_attrs());
         let mut arms: Vec<Arm> = Vec::new();
         while self.token != token::CloseDelim(token::Brace) {
             match self.parse_arm() {
@@ -3301,21 +3301,21 @@ impl<'a> Parser<'a> {
     pub fn parse_arm(&mut self) -> PResult<'a, Arm> {
         maybe_whole!(no_clone self, NtArm);
 
-        let attrs = try!(self.parse_outer_attributes());
-        let pats = try!(self.parse_pats());
+        let attrs = self.parse_outer_attributes()?;
+        let pats = self.parse_pats()?;
         let mut guard = None;
         if self.eat_keyword(keywords::If) {
-            guard = Some(try!(self.parse_expr()));
+            guard = Some(self.parse_expr()?);
         }
-        try!(self.expect(&token::FatArrow));
-        let expr = try!(self.parse_expr_res(Restrictions::RESTRICTION_STMT_EXPR, None));
+        self.expect(&token::FatArrow)?;
+        let expr = self.parse_expr_res(Restrictions::RESTRICTION_STMT_EXPR, None)?;
 
         let require_comma =
             !classify::expr_is_simple_block(&expr)
             && self.token != token::CloseDelim(token::Brace);
 
         if require_comma {
-            try!(self.commit_expr(&expr, &[token::Comma], &[token::CloseDelim(token::Brace)]));
+            self.commit_expr(&expr, &[token::Comma], &[token::CloseDelim(token::Brace)])?;
         } else {
             self.eat(&token::Comma);
         }
@@ -3358,7 +3358,7 @@ impl<'a> Parser<'a> {
     fn parse_initializer(&mut self) -> PResult<'a, Option<P<Expr>>> {
         if self.check(&token::Eq) {
             self.bump();
-            Ok(Some(try!(self.parse_expr())))
+            Ok(Some(self.parse_expr()?))
         } else {
             Ok(None)
         }
@@ -3368,7 +3368,7 @@ impl<'a> Parser<'a> {
     fn parse_pats(&mut self) -> PResult<'a, Vec<P<Pat>>> {
         let mut pats = Vec::new();
         loop {
-            pats.push(try!(self.parse_pat()));
+            pats.push(self.parse_pat()?);
             if self.check(&token::BinOp(token::Or)) { self.bump();}
             else { return Ok(pats); }
         };
@@ -3377,15 +3377,15 @@ impl<'a> Parser<'a> {
     fn parse_pat_tuple_elements(&mut self) -> PResult<'a, Vec<P<Pat>>> {
         let mut fields = vec![];
         if !self.check(&token::CloseDelim(token::Paren)) {
-            fields.push(try!(self.parse_pat()));
+            fields.push(self.parse_pat()?);
             if self.look_ahead(1, |t| *t != token::CloseDelim(token::Paren)) {
                 while self.eat(&token::Comma) &&
                       !self.check(&token::CloseDelim(token::Paren)) {
-                    fields.push(try!(self.parse_pat()));
+                    fields.push(self.parse_pat()?);
                 }
             }
             if fields.len() == 1 {
-                try!(self.expect(&token::Comma));
+                self.expect(&token::Comma)?;
             }
         }
         Ok(fields)
@@ -3404,7 +3404,7 @@ impl<'a> Parser<'a> {
             if first {
                 first = false;
             } else {
-                try!(self.expect(&token::Comma));
+                self.expect(&token::Comma)?;
 
                 if self.token == token::CloseDelim(token::Bracket)
                         && (before_slice || !after.is_empty()) {
@@ -3429,7 +3429,7 @@ impl<'a> Parser<'a> {
                 }
             }
 
-            let subpat = try!(self.parse_pat());
+            let subpat = self.parse_pat()?;
             if before_slice && self.check(&token::DotDot) {
                 self.bump();
                 slice = Some(subpat);
@@ -3453,7 +3453,7 @@ impl<'a> Parser<'a> {
             if first {
                 first = false;
             } else {
-                try!(self.expect(&token::Comma));
+                self.expect(&token::Comma)?;
                 // accept trailing commas
                 if self.check(&token::CloseDelim(token::Brace)) { break }
             }
@@ -3475,9 +3475,9 @@ impl<'a> Parser<'a> {
             // Check if a colon exists one ahead. This means we're parsing a fieldname.
             let (subpat, fieldname, is_shorthand) = if self.look_ahead(1, |t| t == &token::Colon) {
                 // Parsing a pattern of the form "fieldname: pat"
-                let fieldname = try!(self.parse_ident());
+                let fieldname = self.parse_ident()?;
                 self.bump();
-                let pat = try!(self.parse_pat());
+                let pat = self.parse_pat()?;
                 hi = pat.span.hi;
                 (pat, fieldname, false)
             } else {
@@ -3486,7 +3486,7 @@ impl<'a> Parser<'a> {
                 let boxed_span_lo = self.span.lo;
                 let is_ref = self.eat_keyword(keywords::Ref);
                 let is_mut = self.eat_keyword(keywords::Mut);
-                let fieldname = try!(self.parse_ident());
+                let fieldname = self.parse_ident()?;
                 hi = self.last_span.hi;
 
                 let bind_type = match (is_ref, is_mut) {
@@ -3528,11 +3528,11 @@ impl<'a> Parser<'a> {
             let (qself, path) = if self.eat_lt() {
                 // Parse a qualified path
                 let (qself, path) =
-                    try!(self.parse_qualified_path(NoTypesAllowed));
+                    self.parse_qualified_path(NoTypesAllowed)?;
                 (Some(qself), path)
             } else {
                 // Parse an unqualified path
-                (None, try!(self.parse_path(LifetimeAndTypesWithColons)))
+                (None, self.parse_path(LifetimeAndTypesWithColons)?)
             };
             let hi = self.last_span.hi;
             Ok(self.mk_expr(lo, hi, ExprKind::Path(qself, path), None))
@@ -3561,41 +3561,41 @@ impl<'a> Parser<'a> {
           }
           token::BinOp(token::And) | token::AndAnd => {
             // Parse &pat / &mut pat
-            try!(self.expect_and());
-            let mutbl = try!(self.parse_mutability());
+            self.expect_and()?;
+            let mutbl = self.parse_mutability()?;
             if let token::Lifetime(ident) = self.token {
                 return Err(self.fatal(&format!("unexpected lifetime `{}` in pattern", ident)));
             }
 
-            let subpat = try!(self.parse_pat());
+            let subpat = self.parse_pat()?;
             pat = PatKind::Ref(subpat, mutbl);
           }
           token::OpenDelim(token::Paren) => {
             // Parse (pat,pat,pat,...) as tuple pattern
             self.bump();
-            let fields = try!(self.parse_pat_tuple_elements());
-            try!(self.expect(&token::CloseDelim(token::Paren)));
+            let fields = self.parse_pat_tuple_elements()?;
+            self.expect(&token::CloseDelim(token::Paren))?;
             pat = PatKind::Tup(fields);
           }
           token::OpenDelim(token::Bracket) => {
             // Parse [pat,pat,...] as slice pattern
             self.bump();
-            let (before, slice, after) = try!(self.parse_pat_vec_elements());
-            try!(self.expect(&token::CloseDelim(token::Bracket)));
+            let (before, slice, after) = self.parse_pat_vec_elements()?;
+            self.expect(&token::CloseDelim(token::Bracket))?;
             pat = PatKind::Vec(before, slice, after);
           }
           _ => {
             // At this point, token != _, &, &&, (, [
             if self.eat_keyword(keywords::Mut) {
                 // Parse mut ident @ pat
-                pat = try!(self.parse_pat_ident(BindingMode::ByValue(Mutability::Mutable)));
+                pat = self.parse_pat_ident(BindingMode::ByValue(Mutability::Mutable))?;
             } else if self.eat_keyword(keywords::Ref) {
                 // Parse ref ident @ pat / ref mut ident @ pat
-                let mutbl = try!(self.parse_mutability());
-                pat = try!(self.parse_pat_ident(BindingMode::ByRef(mutbl)));
+                let mutbl = self.parse_mutability()?;
+                pat = self.parse_pat_ident(BindingMode::ByRef(mutbl))?;
             } else if self.eat_keyword(keywords::Box) {
                 // Parse box pat
-                let subpat = try!(self.parse_pat());
+                let subpat = self.parse_pat()?;
                 pat = PatKind::Box(subpat);
             } else if self.is_path_start() {
                 // Parse pattern starting with a path
@@ -3607,13 +3607,13 @@ impl<'a> Parser<'a> {
                     // Plain idents have some extra abilities here compared to general paths
                     if self.look_ahead(1, |t| *t == token::Not) {
                         // Parse macro invocation
-                        let ident = try!(self.parse_ident());
+                        let ident = self.parse_ident()?;
                         let ident_span = self.last_span;
                         let path = ident_to_path(ident_span, ident);
                         self.bump();
-                        let delim = try!(self.expect_open_delim());
-                        let tts = try!(self.parse_seq_to_end(&token::CloseDelim(delim),
-                                SeqSep::none(), |p| p.parse_token_tree()));
+                        let delim = self.expect_open_delim()?;
+                        let tts = self.parse_seq_to_end(&token::CloseDelim(delim),
+                                SeqSep::none(), |p| p.parse_token_tree())?;
                         let mac = Mac_ { path: path, tts: tts, ctxt: EMPTY_CTXT };
                         pat = PatKind::Mac(codemap::Spanned {node: mac,
                                                        span: mk_sp(lo, self.last_span.hi)});
@@ -3622,17 +3622,17 @@ impl<'a> Parser<'a> {
                         // This can give false positives and parse nullary enums,
                         // they are dealt with later in resolve
                         let binding_mode = BindingMode::ByValue(Mutability::Immutable);
-                        pat = try!(self.parse_pat_ident(binding_mode));
+                        pat = self.parse_pat_ident(binding_mode)?;
                     }
                 } else {
                     let (qself, path) = if self.eat_lt() {
                         // Parse a qualified path
                         let (qself, path) =
-                            try!(self.parse_qualified_path(NoTypesAllowed));
+                            self.parse_qualified_path(NoTypesAllowed)?;
                         (Some(qself), path)
                     } else {
                         // Parse an unqualified path
-                        (None, try!(self.parse_path(LifetimeAndTypesWithColons)))
+                        (None, self.parse_path(LifetimeAndTypesWithColons)?)
                     };
                     match self.token {
                       token::DotDotDot => {
@@ -3640,7 +3640,7 @@ impl<'a> Parser<'a> {
                         let hi = self.last_span.hi;
                         let begin = self.mk_expr(lo, hi, ExprKind::Path(qself, path), None);
                         self.bump();
-                        let end = try!(self.parse_pat_range_end());
+                        let end = self.parse_pat_range_end()?;
                         pat = PatKind::Range(begin, end);
                       }
                       token::OpenDelim(token::Brace) => {
@@ -3666,14 +3666,14 @@ impl<'a> Parser<'a> {
                             // This is a "top constructor only" pat
                             self.bump();
                             self.bump();
-                            try!(self.expect(&token::CloseDelim(token::Paren)));
+                            self.expect(&token::CloseDelim(token::Paren))?;
                             pat = PatKind::TupleStruct(path, None);
                         } else {
-                            let args = try!(self.parse_enum_variant_seq(
+                            let args = self.parse_enum_variant_seq(
                                     &token::OpenDelim(token::Paren),
                                     &token::CloseDelim(token::Paren),
                                     SeqSep::trailing_allowed(token::Comma),
-                                    |p| p.parse_pat()));
+                                    |p| p.parse_pat())?;
                             pat = PatKind::TupleStruct(path, Some(args));
                         }
                       }
@@ -3689,9 +3689,9 @@ impl<'a> Parser<'a> {
                 }
             } else {
                 // Try to parse everything else as literal with optional minus
-                let begin = try!(self.parse_pat_literal_maybe_minus());
+                let begin = self.parse_pat_literal_maybe_minus()?;
                 if self.eat(&token::DotDotDot) {
-                    let end = try!(self.parse_pat_range_end());
+                    let end = self.parse_pat_range_end()?;
                     pat = PatKind::Range(begin, end);
                 } else {
                     pat = PatKind::Lit(begin);
@@ -3720,11 +3720,11 @@ impl<'a> Parser<'a> {
             return Err(self.span_fatal(span,
                             &format!("expected identifier, found `{}`", tok_str)))
         }
-        let ident = try!(self.parse_ident());
+        let ident = self.parse_ident()?;
         let last_span = self.last_span;
         let name = codemap::Spanned{span: last_span, node: ident};
         let sub = if self.eat(&token::At) {
-            Some(try!(self.parse_pat()))
+            Some(self.parse_pat()?)
         } else {
             None
         };
@@ -3748,13 +3748,13 @@ impl<'a> Parser<'a> {
     /// Parse a local variable declaration
     fn parse_local(&mut self, attrs: ThinAttributes) -> PResult<'a, P<Local>> {
         let lo = self.span.lo;
-        let pat = try!(self.parse_pat());
+        let pat = self.parse_pat()?;
 
         let mut ty = None;
         if self.eat(&token::Colon) {
-            ty = Some(try!(self.parse_ty_sum()));
+            ty = Some(self.parse_ty_sum()?);
         }
-        let init = try!(self.parse_initializer());
+        let init = self.parse_initializer()?;
         Ok(P(ast::Local {
             ty: ty,
             pat: pat,
@@ -3768,7 +3768,7 @@ impl<'a> Parser<'a> {
     /// Parse a "let" stmt
     fn parse_let(&mut self, attrs: ThinAttributes) -> PResult<'a, P<Decl>> {
         let lo = self.span.lo;
-        let local = try!(self.parse_local(attrs));
+        let local = self.parse_local(attrs)?;
         Ok(P(spanned(lo, self.last_span.hi, DeclKind::Local(local))))
     }
 
@@ -3782,9 +3782,9 @@ impl<'a> Parser<'a> {
         if !self.token.is_plain_ident() {
             return Err(self.fatal("expected ident"));
         }
-        let name = try!(self.parse_ident());
-        try!(self.expect(&token::Colon));
-        let ty = try!(self.parse_ty_sum());
+        let name = self.parse_ident()?;
+        self.expect(&token::Colon)?;
+        let ty = self.parse_ty_sum()?;
         Ok(spanned(lo, self.last_span.hi, ast::StructField_ {
             kind: NamedField(name, pr),
             id: ast::DUMMY_NODE_ID,
@@ -3875,12 +3875,12 @@ impl<'a> Parser<'a> {
     fn parse_stmt_without_recovery(&mut self) -> PResult<'a, Option<Stmt>> {
         maybe_whole!(Some deref self, NtStmt);
 
-        let attrs = try!(self.parse_outer_attributes());
+        let attrs = self.parse_outer_attributes()?;
         let lo = self.span.lo;
 
         Ok(Some(if self.check_keyword(keywords::Let) {
-            try!(self.expect_keyword(keywords::Let));
-            let decl = try!(self.parse_let(attrs.into_thin_attrs()));
+            self.expect_keyword(keywords::Let)?;
+            let decl = self.parse_let(attrs.into_thin_attrs())?;
             let hi = decl.span.hi;
             let stmt = StmtKind::Decl(decl, ast::DUMMY_NODE_ID);
             spanned(lo, hi, stmt)
@@ -3891,12 +3891,12 @@ impl<'a> Parser<'a> {
 
             // Potential trouble: if we allow macros with paths instead of
             // idents, we'd need to look ahead past the whole path here...
-            let pth = try!(self.parse_path(NoTypesAllowed));
+            let pth = self.parse_path(NoTypesAllowed)?;
             self.bump();
 
             let id = match self.token {
                 token::OpenDelim(_) => token::special_idents::invalid, // no special identifier
-                _ => try!(self.parse_ident()),
+                _ => self.parse_ident()?,
             };
 
             // check that we're pointing at delimiters (need to check
@@ -3919,12 +3919,12 @@ impl<'a> Parser<'a> {
                 },
             };
 
-            let tts = try!(self.parse_unspanned_seq(
+            let tts = self.parse_unspanned_seq(
                 &token::OpenDelim(delim),
                 &token::CloseDelim(delim),
                 SeqSep::none(),
                 |p| p.parse_token_tree()
-            ));
+            )?;
             let hi = self.last_span.hi;
 
             let style = if delim == token::Brace {
@@ -3962,8 +3962,8 @@ impl<'a> Parser<'a> {
         } else {
             // FIXME: Bad copy of attrs
             let restrictions = self.restrictions | Restrictions::NO_NONINLINE_MOD;
-            match try!(self.with_res(restrictions,
-                                     |this| this.parse_item_(attrs.clone(), false, true))) {
+            match self.with_res(restrictions,
+                                     |this| this.parse_item_(attrs.clone(), false, true))? {
                 Some(i) => {
                     let hi = i.span.hi;
                     let decl = P(spanned(lo, hi, DeclKind::Item(i)));
@@ -3990,8 +3990,8 @@ impl<'a> Parser<'a> {
                     }
 
                     // Remainder are line-expr stmts.
-                    let e = try!(self.parse_expr_res(
-                        Restrictions::RESTRICTION_STMT_EXPR, Some(attrs.into_thin_attrs())));
+                    let e = self.parse_expr_res(
+                        Restrictions::RESTRICTION_STMT_EXPR, Some(attrs.into_thin_attrs()))?;
                     let hi = e.span.hi;
                     let stmt = StmtKind::Expr(e, ast::DUMMY_NODE_ID);
                     spanned(lo, hi, stmt)
@@ -4028,9 +4028,9 @@ impl<'a> Parser<'a> {
         maybe_whole!(pair_empty self, NtBlock);
 
         let lo = self.span.lo;
-        try!(self.expect(&token::OpenDelim(token::Brace)));
-        Ok((try!(self.parse_inner_attributes()),
-            try!(self.parse_block_tail(lo, BlockCheckMode::Default))))
+        self.expect(&token::OpenDelim(token::Brace))?;
+        Ok((self.parse_inner_attributes()?,
+            self.parse_block_tail(lo, BlockCheckMode::Default)?))
     }
 
     /// Parse the rest of a block expression or function body
@@ -4048,7 +4048,7 @@ impl<'a> Parser<'a> {
             };
             match node {
                 StmtKind::Expr(e, _) => {
-                    try!(self.handle_expression_like_statement(e, span, &mut stmts, &mut expr));
+                    self.handle_expression_like_statement(e, span, &mut stmts, &mut expr)?;
                 }
                 StmtKind::Mac(mac, MacStmtStyle::NoBraces, attrs) => {
                     // statement macro without braces; might be an
@@ -4066,13 +4066,13 @@ impl<'a> Parser<'a> {
                                                      mac.and_then(|m| m.node),
                                                      None);
                             let lo = e.span.lo;
-                            let e = try!(self.parse_dot_or_call_expr_with(e, lo, attrs));
-                            let e = try!(self.parse_assoc_expr_with(0, LhsExpr::AlreadyParsed(e)));
-                            try!(self.handle_expression_like_statement(
+                            let e = self.parse_dot_or_call_expr_with(e, lo, attrs)?;
+                            let e = self.parse_assoc_expr_with(0, LhsExpr::AlreadyParsed(e))?;
+                            self.handle_expression_like_statement(
                                 e,
                                 span,
                                 &mut stmts,
-                                &mut expr));
+                                &mut expr)?;
                         }
                     }
                 }
@@ -4104,7 +4104,7 @@ impl<'a> Parser<'a> {
                 _ => { // all other kinds of statements:
                     let mut hi = span.hi;
                     if classify::stmt_ends_with_semi(&node) {
-                        try!(self.commit_stmt_expecting(token::Semi));
+                        self.commit_stmt_expecting(token::Semi)?;
                         hi = self.last_span.hi;
                     }
 
@@ -4205,7 +4205,7 @@ impl<'a> Parser<'a> {
                     self.bump();
                 }
                 token::ModSep | token::Ident(..) => {
-                    let poly_trait_ref = try!(self.parse_poly_trait_ref());
+                    let poly_trait_ref = self.parse_poly_trait_ref()?;
                     let modifier = if ate_question {
                         if mode == BoundParsingMode::Modified {
                             TraitBoundModifier::Maybe
@@ -4233,13 +4233,13 @@ impl<'a> Parser<'a> {
     /// Matches typaram = IDENT (`?` unbound)? optbounds ( EQ ty )?
     fn parse_ty_param(&mut self) -> PResult<'a, TyParam> {
         let span = self.span;
-        let ident = try!(self.parse_ident());
+        let ident = self.parse_ident()?;
 
-        let bounds = try!(self.parse_colon_then_ty_param_bounds(BoundParsingMode::Modified));
+        let bounds = self.parse_colon_then_ty_param_bounds(BoundParsingMode::Modified)?;
 
         let default = if self.check(&token::Eq) {
             self.bump();
-            Some(try!(self.parse_ty_sum()))
+            Some(self.parse_ty_sum()?)
         } else {
             None
         };
@@ -4264,11 +4264,11 @@ impl<'a> Parser<'a> {
         maybe_whole!(self, NtGenerics);
 
         if self.eat(&token::Lt) {
-            let lifetime_defs = try!(self.parse_lifetime_defs());
+            let lifetime_defs = self.parse_lifetime_defs()?;
             let mut seen_default = false;
-            let ty_params = try!(self.parse_seq_to_gt(Some(token::Comma), |p| {
-                try!(p.forbid_lifetime());
-                let ty_param = try!(p.parse_ty_param());
+            let ty_params = self.parse_seq_to_gt(Some(token::Comma), |p| {
+                p.forbid_lifetime()?;
+                let ty_param = p.parse_ty_param()?;
                 if ty_param.default.is_some() {
                     seen_default = true;
                 } else if seen_default {
@@ -4277,7 +4277,7 @@ impl<'a> Parser<'a> {
                                "type parameters with a default must be trailing");
                 }
                 Ok(ty_param)
-            }));
+            })?;
             Ok(ast::Generics {
                 lifetimes: lifetime_defs,
                 ty_params: ty_params,
@@ -4295,7 +4295,7 @@ impl<'a> Parser<'a> {
                                                             Vec<P<Ty>>,
                                                             Vec<TypeBinding>)> {
         let span_lo = self.span.lo;
-        let lifetimes = try!(self.parse_lifetimes(token::Comma));
+        let lifetimes = self.parse_lifetimes(token::Comma)?;
 
         let missing_comma = !lifetimes.is_empty() &&
                             !self.token.is_like_gt() &&
@@ -4327,17 +4327,17 @@ impl<'a> Parser<'a> {
         }
 
         // First parse types.
-        let (types, returned) = try!(self.parse_seq_to_gt_or_return(
+        let (types, returned) = self.parse_seq_to_gt_or_return(
             Some(token::Comma),
             |p| {
-                try!(p.forbid_lifetime());
+                p.forbid_lifetime()?;
                 if p.look_ahead(1, |t| t == &token::Eq) {
                     Ok(None)
                 } else {
-                    Ok(Some(try!(p.parse_ty_sum())))
+                    Ok(Some(p.parse_ty_sum()?))
                 }
             }
-        ));
+        )?;
 
         // If we found the `>`, don't continue.
         if !returned {
@@ -4345,18 +4345,18 @@ impl<'a> Parser<'a> {
         }
 
         // Then parse type bindings.
-        let bindings = try!(self.parse_seq_to_gt(
+        let bindings = self.parse_seq_to_gt(
             Some(token::Comma),
             |p| {
-                try!(p.forbid_lifetime());
+                p.forbid_lifetime()?;
                 let lo = p.span.lo;
-                let ident = try!(p.parse_ident());
+                let ident = p.parse_ident()?;
                 let found_eq = p.eat(&token::Eq);
                 if !found_eq {
                     let span = p.span;
                     p.span_warn(span, "whoops, no =?");
                 }
-                let ty = try!(p.parse_ty());
+                let ty = p.parse_ty()?;
                 let hi = ty.span.hi;
                 let span = mk_sp(lo, hi);
                 return Ok(TypeBinding{id: ast::DUMMY_NODE_ID,
@@ -4365,7 +4365,7 @@ impl<'a> Parser<'a> {
                     span: span,
                 });
             }
-        ));
+        )?;
         Ok((lifetimes, types.into_vec(), bindings.into_vec()))
     }
 
@@ -4405,12 +4405,12 @@ impl<'a> Parser<'a> {
 
                 token::Lifetime(..) => {
                     let bounded_lifetime =
-                        try!(self.parse_lifetime());
+                        self.parse_lifetime()?;
 
                     self.eat(&token::Colon);
 
                     let bounds =
-                        try!(self.parse_lifetimes(token::BinOp(token::Plus)));
+                        self.parse_lifetimes(token::BinOp(token::Plus))?;
 
                     let hi = self.last_span.hi;
                     let span = mk_sp(lo, hi);
@@ -4429,18 +4429,18 @@ impl<'a> Parser<'a> {
                 _ => {
                     let bound_lifetimes = if self.eat_keyword(keywords::For) {
                         // Higher ranked constraint.
-                        try!(self.expect(&token::Lt));
-                        let lifetime_defs = try!(self.parse_lifetime_defs());
-                        try!(self.expect_gt());
+                        self.expect(&token::Lt)?;
+                        let lifetime_defs = self.parse_lifetime_defs()?;
+                        self.expect_gt()?;
                         lifetime_defs
                     } else {
                         vec![]
                     };
 
-                    let bounded_ty = try!(self.parse_ty());
+                    let bounded_ty = self.parse_ty()?;
 
                     if self.eat(&token::Colon) {
-                        let bounds = try!(self.parse_ty_param_bounds(BoundParsingMode::Bare));
+                        let bounds = self.parse_ty_param_bounds(BoundParsingMode::Bare)?;
                         let hi = self.last_span.hi;
                         let span = mk_sp(lo, hi);
 
@@ -4503,7 +4503,7 @@ impl<'a> Parser<'a> {
         let sp = self.span;
         let mut variadic = false;
         let args: Vec<Option<Arg>> =
-            try!(self.parse_unspanned_seq(
+            self.parse_unspanned_seq(
                 &token::OpenDelim(token::Paren),
                 &token::CloseDelim(token::Paren),
                 SeqSep::trailing_allowed(token::Comma),
@@ -4534,7 +4534,7 @@ impl<'a> Parser<'a> {
                         }
                     }
                 }
-            ));
+            )?;
 
         let args: Vec<_> = args.into_iter().filter_map(|x| x).collect();
 
@@ -4549,8 +4549,8 @@ impl<'a> Parser<'a> {
     /// Parse the argument list and result type of a function declaration
     pub fn parse_fn_decl(&mut self, allow_variadic: bool) -> PResult<'a, P<FnDecl>> {
 
-        let (args, variadic) = try!(self.parse_fn_args(true, allow_variadic));
-        let ret_ty = try!(self.parse_ret_ty());
+        let (args, variadic) = self.parse_fn_args(true, allow_variadic)?;
+        let ret_ty = self.parse_ret_ty()?;
 
         Ok(P(FnDecl {
             inputs: args,
@@ -4620,31 +4620,31 @@ impl<'a> Parser<'a> {
 
             if this.look_ahead(1, |t| t.is_keyword(keywords::SelfValue)) {
                 this.bump();
-                Ok(SelfKind::Region(None, Mutability::Immutable, try!(this.expect_self_ident())))
+                Ok(SelfKind::Region(None, Mutability::Immutable, this.expect_self_ident()?))
             } else if this.look_ahead(1, |t| t.is_mutability()) &&
                       this.look_ahead(2, |t| t.is_keyword(keywords::SelfValue)) {
                 this.bump();
-                let mutability = try!(this.parse_mutability());
-                Ok(SelfKind::Region(None, mutability, try!(this.expect_self_ident())))
+                let mutability = this.parse_mutability()?;
+                Ok(SelfKind::Region(None, mutability, this.expect_self_ident()?))
             } else if this.look_ahead(1, |t| t.is_lifetime()) &&
                       this.look_ahead(2, |t| t.is_keyword(keywords::SelfValue)) {
                 this.bump();
-                let lifetime = try!(this.parse_lifetime());
-                let ident = try!(this.expect_self_ident());
+                let lifetime = this.parse_lifetime()?;
+                let ident = this.expect_self_ident()?;
                 Ok(SelfKind::Region(Some(lifetime), Mutability::Immutable, ident))
             } else if this.look_ahead(1, |t| t.is_lifetime()) &&
                       this.look_ahead(2, |t| t.is_mutability()) &&
                       this.look_ahead(3, |t| t.is_keyword(keywords::SelfValue)) {
                 this.bump();
-                let lifetime = try!(this.parse_lifetime());
-                let mutability = try!(this.parse_mutability());
-                Ok(SelfKind::Region(Some(lifetime), mutability, try!(this.expect_self_ident())))
+                let lifetime = this.parse_lifetime()?;
+                let mutability = this.parse_mutability()?;
+                Ok(SelfKind::Region(Some(lifetime), mutability, this.expect_self_ident()?))
             } else {
                 Ok(SelfKind::Static)
             }
         }
 
-        try!(self.expect(&token::OpenDelim(token::Paren)));
+        self.expect(&token::OpenDelim(token::Paren))?;
 
         // A bit of complexity and lookahead is needed here in order to be
         // backwards compatible.
@@ -4655,7 +4655,7 @@ impl<'a> Parser<'a> {
         let mut mutbl_self = Mutability::Immutable;
         let explicit_self = match self.token {
             token::BinOp(token::And) => {
-                let eself = try!(maybe_parse_borrowed_explicit_self(self));
+                let eself = maybe_parse_borrowed_explicit_self(self)?;
                 self_ident_lo = self.last_span.lo;
                 self_ident_hi = self.last_span.hi;
                 eself
@@ -4665,7 +4665,7 @@ impl<'a> Parser<'a> {
                 // emitting cryptic "unexpected token" errors.
                 self.bump();
                 let _mutability = if self.token.is_mutability() {
-                    try!(self.parse_mutability())
+                    self.parse_mutability()?
                 } else {
                     Mutability::Immutable
                 };
@@ -4679,24 +4679,24 @@ impl<'a> Parser<'a> {
             }
             token::Ident(..) => {
                 if self.is_self_ident() {
-                    let self_ident = try!(self.expect_self_ident());
+                    let self_ident = self.expect_self_ident()?;
 
                     // Determine whether this is the fully explicit form, `self:
                     // TYPE`.
                     if self.eat(&token::Colon) {
-                        SelfKind::Explicit(try!(self.parse_ty_sum()), self_ident)
+                        SelfKind::Explicit(self.parse_ty_sum()?, self_ident)
                     } else {
                         SelfKind::Value(self_ident)
                     }
                 } else if self.token.is_mutability() &&
                         self.look_ahead(1, |t| t.is_keyword(keywords::SelfValue)) {
-                    mutbl_self = try!(self.parse_mutability());
-                    let self_ident = try!(self.expect_self_ident());
+                    mutbl_self = self.parse_mutability()?;
+                    let self_ident = self.expect_self_ident()?;
 
                     // Determine whether this is the fully explicit form,
                     // `self: TYPE`.
                     if self.eat(&token::Colon) {
-                        SelfKind::Explicit(try!(self.parse_ty_sum()), self_ident)
+                        SelfKind::Explicit(self.parse_ty_sum()?, self_ident)
                     } else {
                         SelfKind::Value(self_ident)
                     }
@@ -4750,11 +4750,11 @@ impl<'a> Parser<'a> {
         };
 
 
-        try!(self.expect(&token::CloseDelim(token::Paren)));
+        self.expect(&token::CloseDelim(token::Paren))?;
 
         let hi = self.span.hi;
 
-        let ret_ty = try!(self.parse_ret_ty());
+        let ret_ty = self.parse_ret_ty()?;
 
         let fn_decl = P(FnDecl {
             inputs: fn_inputs,
@@ -4771,8 +4771,8 @@ impl<'a> Parser<'a> {
             if self.eat(&token::OrOr) {
                 Vec::new()
             } else {
-                try!(self.expect(&token::BinOp(token::Or)));
-                try!(self.parse_obsolete_closure_kind());
+                self.expect(&token::BinOp(token::Or))?;
+                self.parse_obsolete_closure_kind()?;
                 let args = self.parse_seq_to_before_end(
                     &token::BinOp(token::Or),
                     SeqSep::trailing_allowed(token::Comma),
@@ -4782,7 +4782,7 @@ impl<'a> Parser<'a> {
                 args
             }
         };
-        let output = try!(self.parse_ret_ty());
+        let output = self.parse_ret_ty()?;
 
         Ok(P(FnDecl {
             inputs: inputs_captures,
@@ -4793,8 +4793,8 @@ impl<'a> Parser<'a> {
 
     /// Parse the name and optional generic types of a function header.
     fn parse_fn_header(&mut self) -> PResult<'a, (Ident, ast::Generics)> {
-        let id = try!(self.parse_ident());
-        let generics = try!(self.parse_generics());
+        let id = self.parse_ident()?;
+        let generics = self.parse_generics()?;
         Ok((id, generics))
     }
 
@@ -4817,10 +4817,10 @@ impl<'a> Parser<'a> {
                      constness: Constness,
                      abi: abi::Abi)
                      -> PResult<'a, ItemInfo> {
-        let (ident, mut generics) = try!(self.parse_fn_header());
-        let decl = try!(self.parse_fn_decl(false));
-        generics.where_clause = try!(self.parse_where_clause());
-        let (inner_attrs, body) = try!(self.parse_inner_attrs_and_block());
+        let (ident, mut generics) = self.parse_fn_header()?;
+        let decl = self.parse_fn_decl(false)?;
+        generics.where_clause = self.parse_where_clause()?;
+        let (inner_attrs, body) = self.parse_inner_attrs_and_block()?;
         Ok((ident, ItemKind::Fn(decl, unsafety, constness, abi, generics, body), Some(inner_attrs)))
     }
 
@@ -4842,18 +4842,18 @@ impl<'a> Parser<'a> {
     pub fn parse_fn_front_matter(&mut self)
                                  -> PResult<'a, (ast::Constness, ast::Unsafety, abi::Abi)> {
         let is_const_fn = self.eat_keyword(keywords::Const);
-        let unsafety = try!(self.parse_unsafety());
+        let unsafety = self.parse_unsafety()?;
         let (constness, unsafety, abi) = if is_const_fn {
             (Constness::Const, unsafety, Abi::Rust)
         } else {
             let abi = if self.eat_keyword(keywords::Extern) {
-                try!(self.parse_opt_abi()).unwrap_or(Abi::C)
+                self.parse_opt_abi()?.unwrap_or(Abi::C)
             } else {
                 Abi::Rust
             };
             (Constness::NotConst, unsafety, abi)
         };
-        try!(self.expect_keyword(keywords::Fn));
+        self.expect_keyword(keywords::Fn)?;
         Ok((constness, unsafety, abi))
     }
 
@@ -4861,27 +4861,27 @@ impl<'a> Parser<'a> {
     pub fn parse_impl_item(&mut self) -> PResult<'a, ImplItem> {
         maybe_whole!(no_clone_from_p self, NtImplItem);
 
-        let mut attrs = try!(self.parse_outer_attributes());
+        let mut attrs = self.parse_outer_attributes()?;
         let lo = self.span.lo;
-        let vis = try!(self.parse_visibility());
-        let defaultness = try!(self.parse_defaultness());
+        let vis = self.parse_visibility()?;
+        let defaultness = self.parse_defaultness()?;
         let (name, node) = if self.eat_keyword(keywords::Type) {
-            let name = try!(self.parse_ident());
-            try!(self.expect(&token::Eq));
-            let typ = try!(self.parse_ty_sum());
-            try!(self.expect(&token::Semi));
+            let name = self.parse_ident()?;
+            self.expect(&token::Eq)?;
+            let typ = self.parse_ty_sum()?;
+            self.expect(&token::Semi)?;
             (name, ast::ImplItemKind::Type(typ))
         } else if self.is_const_item() {
-            try!(self.expect_keyword(keywords::Const));
-            let name = try!(self.parse_ident());
-            try!(self.expect(&token::Colon));
-            let typ = try!(self.parse_ty_sum());
-            try!(self.expect(&token::Eq));
-            let expr = try!(self.parse_expr());
-            try!(self.commit_expr_expecting(&expr, token::Semi));
+            self.expect_keyword(keywords::Const)?;
+            let name = self.parse_ident()?;
+            self.expect(&token::Colon)?;
+            let typ = self.parse_ty_sum()?;
+            self.expect(&token::Eq)?;
+            let expr = self.parse_expr()?;
+            self.commit_expr_expecting(&expr, token::Semi)?;
             (name, ast::ImplItemKind::Const(typ, expr))
         } else {
-            let (name, inner_attrs, node) = try!(self.parse_impl_method(vis));
+            let (name, inner_attrs, node) = self.parse_impl_method(vis)?;
             attrs.extend(inner_attrs);
             (name, node)
         };
@@ -4935,31 +4935,31 @@ impl<'a> Parser<'a> {
             self.complain_if_pub_macro(vis, last_span);
 
             let lo = self.span.lo;
-            let pth = try!(self.parse_path(NoTypesAllowed));
-            try!(self.expect(&token::Not));
+            let pth = self.parse_path(NoTypesAllowed)?;
+            self.expect(&token::Not)?;
 
             // eat a matched-delimiter token tree:
-            let delim = try!(self.expect_open_delim());
-            let tts = try!(self.parse_seq_to_end(&token::CloseDelim(delim),
+            let delim = self.expect_open_delim()?;
+            let tts = self.parse_seq_to_end(&token::CloseDelim(delim),
                                                  SeqSep::none(),
-                                                 |p| p.parse_token_tree()));
+                                                 |p| p.parse_token_tree())?;
             let m_ = Mac_ { path: pth, tts: tts, ctxt: EMPTY_CTXT };
             let m: ast::Mac = codemap::Spanned { node: m_,
                                                 span: mk_sp(lo,
                                                             self.last_span.hi) };
             if delim != token::Brace {
-                try!(self.expect(&token::Semi))
+                self.expect(&token::Semi)?
             }
             Ok((token::special_idents::invalid, vec![], ast::ImplItemKind::Macro(m)))
         } else {
-            let (constness, unsafety, abi) = try!(self.parse_fn_front_matter());
-            let ident = try!(self.parse_ident());
-            let mut generics = try!(self.parse_generics());
-            let (explicit_self, decl) = try!(self.parse_fn_decl_with_self(|p| {
+            let (constness, unsafety, abi) = self.parse_fn_front_matter()?;
+            let ident = self.parse_ident()?;
+            let mut generics = self.parse_generics()?;
+            let (explicit_self, decl) = self.parse_fn_decl_with_self(|p| {
                     p.parse_arg()
-                }));
-            generics.where_clause = try!(self.parse_where_clause());
-            let (inner_attrs, body) = try!(self.parse_inner_attrs_and_block());
+                })?;
+            generics.where_clause = self.parse_where_clause()?;
+            let (inner_attrs, body) = self.parse_inner_attrs_and_block()?;
             Ok((ident, inner_attrs, ast::ImplItemKind::Method(ast::MethodSig {
                 generics: generics,
                 abi: abi,
@@ -4974,15 +4974,15 @@ impl<'a> Parser<'a> {
     /// Parse trait Foo { ... }
     fn parse_item_trait(&mut self, unsafety: Unsafety) -> PResult<'a, ItemInfo> {
 
-        let ident = try!(self.parse_ident());
-        let mut tps = try!(self.parse_generics());
+        let ident = self.parse_ident()?;
+        let mut tps = self.parse_generics()?;
 
         // Parse supertrait bounds.
-        let bounds = try!(self.parse_colon_then_ty_param_bounds(BoundParsingMode::Bare));
+        let bounds = self.parse_colon_then_ty_param_bounds(BoundParsingMode::Bare)?;
 
-        tps.where_clause = try!(self.parse_where_clause());
+        tps.where_clause = self.parse_where_clause()?;
 
-        let meths = try!(self.parse_trait_items());
+        let meths = self.parse_trait_items()?;
         Ok((ident, ItemKind::Trait(unsafety, tps, bounds, meths), None))
     }
 
@@ -4994,7 +4994,7 @@ impl<'a> Parser<'a> {
         let impl_span = self.span;
 
         // First, parse type parameters if necessary.
-        let mut generics = try!(self.parse_generics());
+        let mut generics = self.parse_generics()?;
 
         // Special case: if the next identifier that follows is '(', don't
         // allow this to be parsed as a trait.
@@ -5008,7 +5008,7 @@ impl<'a> Parser<'a> {
         };
 
         // Parse the trait.
-        let mut ty = try!(self.parse_ty_sum());
+        let mut ty = self.parse_ty_sum()?;
 
         // Parse traits, if necessary.
         let opt_trait = if could_be_trait && self.eat_keyword(keywords::For) {
@@ -5043,22 +5043,22 @@ impl<'a> Parser<'a> {
                                           allowed to have generics");
             }
 
-            try!(self.expect(&token::OpenDelim(token::Brace)));
-            try!(self.expect(&token::CloseDelim(token::Brace)));
+            self.expect(&token::OpenDelim(token::Brace))?;
+            self.expect(&token::CloseDelim(token::Brace))?;
             Ok((ast_util::impl_pretty_name(&opt_trait, None),
              ItemKind::DefaultImpl(unsafety, opt_trait.unwrap()), None))
         } else {
             if opt_trait.is_some() {
-                ty = try!(self.parse_ty_sum());
+                ty = self.parse_ty_sum()?;
             }
-            generics.where_clause = try!(self.parse_where_clause());
+            generics.where_clause = self.parse_where_clause()?;
 
-            try!(self.expect(&token::OpenDelim(token::Brace)));
-            let attrs = try!(self.parse_inner_attributes());
+            self.expect(&token::OpenDelim(token::Brace))?;
+            let attrs = self.parse_inner_attributes()?;
 
             let mut impl_items = vec![];
             while !self.eat(&token::CloseDelim(token::Brace)) {
-                impl_items.push(try!(self.parse_impl_item()));
+                impl_items.push(self.parse_impl_item()?);
             }
 
             Ok((ast_util::impl_pretty_name(&opt_trait, Some(&ty)),
@@ -5070,16 +5070,16 @@ impl<'a> Parser<'a> {
     /// Parse a::B<String,i32>
     fn parse_trait_ref(&mut self) -> PResult<'a, TraitRef> {
         Ok(ast::TraitRef {
-            path: try!(self.parse_path(LifetimeAndTypesWithoutColons)),
+            path: self.parse_path(LifetimeAndTypesWithoutColons)?,
             ref_id: ast::DUMMY_NODE_ID,
         })
     }
 
     fn parse_late_bound_lifetime_defs(&mut self) -> PResult<'a, Vec<ast::LifetimeDef>> {
         if self.eat_keyword(keywords::For) {
-            try!(self.expect(&token::Lt));
-            let lifetime_defs = try!(self.parse_lifetime_defs());
-            try!(self.expect_gt());
+            self.expect(&token::Lt)?;
+            let lifetime_defs = self.parse_lifetime_defs()?;
+            self.expect_gt()?;
             Ok(lifetime_defs)
         } else {
             Ok(Vec::new())
@@ -5089,19 +5089,19 @@ impl<'a> Parser<'a> {
     /// Parse for<'l> a::B<String,i32>
     fn parse_poly_trait_ref(&mut self) -> PResult<'a, PolyTraitRef> {
         let lo = self.span.lo;
-        let lifetime_defs = try!(self.parse_late_bound_lifetime_defs());
+        let lifetime_defs = self.parse_late_bound_lifetime_defs()?;
 
         Ok(ast::PolyTraitRef {
             bound_lifetimes: lifetime_defs,
-            trait_ref: try!(self.parse_trait_ref()),
+            trait_ref: self.parse_trait_ref()?,
             span: mk_sp(lo, self.last_span.hi),
         })
     }
 
     /// Parse struct Foo { ... }
     fn parse_item_struct(&mut self) -> PResult<'a, ItemInfo> {
-        let class_name = try!(self.parse_ident());
-        let mut generics = try!(self.parse_generics());
+        let class_name = self.parse_ident()?;
+        let mut generics = self.parse_generics()?;
 
         // There is a special case worth noting here, as reported in issue #17904.
         // If we are parsing a tuple struct it is the case that the where clause
@@ -5118,25 +5118,25 @@ impl<'a> Parser<'a> {
         // struct.
 
         let vdata = if self.token.is_keyword(keywords::Where) {
-            generics.where_clause = try!(self.parse_where_clause());
+            generics.where_clause = self.parse_where_clause()?;
             if self.eat(&token::Semi) {
                 // If we see a: `struct Foo<T> where T: Copy;` style decl.
                 VariantData::Unit(ast::DUMMY_NODE_ID)
             } else {
                 // If we see: `struct Foo<T> where T: Copy { ... }`
-                VariantData::Struct(try!(self.parse_record_struct_body()), ast::DUMMY_NODE_ID)
+                VariantData::Struct(self.parse_record_struct_body()?, ast::DUMMY_NODE_ID)
             }
         // No `where` so: `struct Foo<T>;`
         } else if self.eat(&token::Semi) {
             VariantData::Unit(ast::DUMMY_NODE_ID)
         // Record-style struct definition
         } else if self.token == token::OpenDelim(token::Brace) {
-            VariantData::Struct(try!(self.parse_record_struct_body()), ast::DUMMY_NODE_ID)
+            VariantData::Struct(self.parse_record_struct_body()?, ast::DUMMY_NODE_ID)
         // Tuple-style struct definition with optional where-clause.
         } else if self.token == token::OpenDelim(token::Paren) {
-            let body = VariantData::Tuple(try!(self.parse_tuple_struct_body()), ast::DUMMY_NODE_ID);
-            generics.where_clause = try!(self.parse_where_clause());
-            try!(self.expect(&token::Semi));
+            let body = VariantData::Tuple(self.parse_tuple_struct_body()?, ast::DUMMY_NODE_ID);
+            generics.where_clause = self.parse_where_clause()?;
+            self.expect(&token::Semi)?;
             body
         } else {
             let token_str = self.this_token_to_string();
@@ -5151,7 +5151,7 @@ impl<'a> Parser<'a> {
         let mut fields = Vec::new();
         if self.eat(&token::OpenDelim(token::Brace)) {
             while self.token != token::CloseDelim(token::Brace) {
-                fields.push(try!(self.parse_struct_decl_field()));
+                fields.push(self.parse_struct_decl_field()?);
             }
 
             self.bump();
@@ -5168,21 +5168,21 @@ impl<'a> Parser<'a> {
     pub fn parse_tuple_struct_body(&mut self) -> PResult<'a, Vec<StructField>> {
         // This is the case where we find `struct Foo<T>(T) where T: Copy;`
         // Unit like structs are handled in parse_item_struct function
-        let fields = try!(self.parse_unspanned_seq(
+        let fields = self.parse_unspanned_seq(
             &token::OpenDelim(token::Paren),
             &token::CloseDelim(token::Paren),
             SeqSep::trailing_allowed(token::Comma),
             |p| {
-                let attrs = try!(p.parse_outer_attributes());
+                let attrs = p.parse_outer_attributes()?;
                 let lo = p.span.lo;
                 let struct_field_ = ast::StructField_ {
-                    kind: UnnamedField(try!(p.parse_visibility())),
+                    kind: UnnamedField(p.parse_visibility()?),
                     id: ast::DUMMY_NODE_ID,
-                    ty: try!(p.parse_ty_sum()),
+                    ty: p.parse_ty_sum()?,
                     attrs: attrs,
                 };
                 Ok(spanned(lo, p.span.hi, struct_field_))
-            }));
+            })?;
 
         Ok(fields)
     }
@@ -5192,7 +5192,7 @@ impl<'a> Parser<'a> {
                                      vis: Visibility,
                                      attrs: Vec<Attribute> )
                                      -> PResult<'a, StructField> {
-        let a_var = try!(self.parse_name_and_ty(vis, attrs));
+        let a_var = self.parse_name_and_ty(vis, attrs)?;
         match self.token {
             token::Comma => {
                 self.bump();
@@ -5213,7 +5213,7 @@ impl<'a> Parser<'a> {
     /// Parse an element of a struct definition
     fn parse_struct_decl_field(&mut self) -> PResult<'a, StructField> {
 
-        let attrs = try!(self.parse_outer_attributes());
+        let attrs = self.parse_outer_attributes()?;
 
         if self.eat_keyword(keywords::Pub) {
             return self.parse_single_struct_field(Visibility::Public, attrs);
@@ -5240,7 +5240,7 @@ impl<'a> Parser<'a> {
     /// Given a termination token, parse all of the items in a module
     fn parse_mod_items(&mut self, term: &token::Token, inner_lo: BytePos) -> PResult<'a, Mod> {
         let mut items = vec![];
-        while let Some(item) = try!(self.parse_item()) {
+        while let Some(item) = self.parse_item()? {
             items.push(item);
         }
 
@@ -5262,12 +5262,12 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_item_const(&mut self, m: Option<Mutability>) -> PResult<'a, ItemInfo> {
-        let id = try!(self.parse_ident());
-        try!(self.expect(&token::Colon));
-        let ty = try!(self.parse_ty_sum());
-        try!(self.expect(&token::Eq));
-        let e = try!(self.parse_expr());
-        try!(self.commit_expr_expecting(&e, token::Semi));
+        let id = self.parse_ident()?;
+        self.expect(&token::Colon)?;
+        let ty = self.parse_ty_sum()?;
+        self.expect(&token::Eq)?;
+        let e = self.parse_expr()?;
+        self.commit_expr_expecting(&e, token::Semi)?;
         let item = match m {
             Some(m) => ItemKind::Static(ty, m, e),
             None => ItemKind::Const(ty, e),
@@ -5278,18 +5278,18 @@ impl<'a> Parser<'a> {
     /// Parse a `mod <foo> { ... }` or `mod <foo>;` item
     fn parse_item_mod(&mut self, outer_attrs: &[Attribute]) -> PResult<'a, ItemInfo> {
         let id_span = self.span;
-        let id = try!(self.parse_ident());
+        let id = self.parse_ident()?;
         if self.check(&token::Semi) {
             self.bump();
             // This mod is in an external file. Let's go get it!
-            let (m, attrs) = try!(self.eval_src_mod(id, outer_attrs, id_span));
+            let (m, attrs) = self.eval_src_mod(id, outer_attrs, id_span)?;
             Ok((id, m, Some(attrs)))
         } else {
             self.push_mod_path(id, outer_attrs);
-            try!(self.expect(&token::OpenDelim(token::Brace)));
+            self.expect(&token::OpenDelim(token::Brace))?;
             let mod_inner_lo = self.span.lo;
-            let attrs = try!(self.parse_inner_attributes());
-            let m = try!(self.parse_mod_items(&token::CloseDelim(token::Brace), mod_inner_lo));
+            let attrs = self.parse_inner_attributes()?;
+            let m = self.parse_mod_items(&token::CloseDelim(token::Brace), mod_inner_lo)?;
             self.pop_mod_path();
             Ok((id, ItemKind::Mod(m), Some(attrs)))
         }
@@ -5408,9 +5408,9 @@ impl<'a> Parser<'a> {
                     outer_attrs: &[ast::Attribute],
                     id_sp: Span)
                     -> PResult<'a, (ast::ItemKind, Vec<ast::Attribute> )> {
-        let ModulePathSuccess { path, owns_directory } = try!(self.submod_path(id,
+        let ModulePathSuccess { path, owns_directory } = self.submod_path(id,
                                                                                outer_attrs,
-                                                                               id_sp));
+                                                                               id_sp)?;
 
         self.eval_src_mod_from_path(path,
                                     owns_directory,
@@ -5447,8 +5447,8 @@ impl<'a> Parser<'a> {
                                               Some(name),
                                               id_sp);
         let mod_inner_lo = p0.span.lo;
-        let mod_attrs = try!(p0.parse_inner_attributes());
-        let m0 = try!(p0.parse_mod_items(&token::Eof, mod_inner_lo));
+        let mod_attrs = p0.parse_inner_attributes()?;
+        let m0 = p0.parse_mod_items(&token::Eof, mod_inner_lo)?;
         self.sess.included_mod_stack.borrow_mut().pop();
         Ok((ast::ItemKind::Mod(m0), mod_attrs))
     }
@@ -5456,13 +5456,13 @@ impl<'a> Parser<'a> {
     /// Parse a function declaration from a foreign module
     fn parse_item_foreign_fn(&mut self, vis: ast::Visibility, lo: BytePos,
                              attrs: Vec<Attribute>) -> PResult<'a, ForeignItem> {
-        try!(self.expect_keyword(keywords::Fn));
+        self.expect_keyword(keywords::Fn)?;
 
-        let (ident, mut generics) = try!(self.parse_fn_header());
-        let decl = try!(self.parse_fn_decl(true));
-        generics.where_clause = try!(self.parse_where_clause());
+        let (ident, mut generics) = self.parse_fn_header()?;
+        let decl = self.parse_fn_decl(true)?;
+        generics.where_clause = self.parse_where_clause()?;
         let hi = self.span.hi;
-        try!(self.expect(&token::Semi));
+        self.expect(&token::Semi)?;
         Ok(ast::ForeignItem {
             ident: ident,
             attrs: attrs,
@@ -5476,14 +5476,14 @@ impl<'a> Parser<'a> {
     /// Parse a static item from a foreign module
     fn parse_item_foreign_static(&mut self, vis: ast::Visibility, lo: BytePos,
                                  attrs: Vec<Attribute>) -> PResult<'a, ForeignItem> {
-        try!(self.expect_keyword(keywords::Static));
+        self.expect_keyword(keywords::Static)?;
         let mutbl = self.eat_keyword(keywords::Mut);
 
-        let ident = try!(self.parse_ident());
-        try!(self.expect(&token::Colon));
-        let ty = try!(self.parse_ty_sum());
+        let ident = self.parse_ident()?;
+        self.expect(&token::Colon)?;
+        let ty = self.parse_ty_sum()?;
         let hi = self.span.hi;
-        try!(self.expect(&token::Semi));
+        self.expect(&token::Semi)?;
         Ok(ForeignItem {
             ident: ident,
             attrs: attrs,
@@ -5506,13 +5506,13 @@ impl<'a> Parser<'a> {
                                attrs: Vec<Attribute>)
                                 -> PResult<'a, P<Item>> {
 
-        let crate_name = try!(self.parse_ident());
-        let (maybe_path, ident) = if let Some(ident) = try!(self.parse_rename()) {
+        let crate_name = self.parse_ident()?;
+        let (maybe_path, ident) = if let Some(ident) = self.parse_rename()? {
             (Some(crate_name.name), ident)
         } else {
             (None, crate_name)
         };
-        try!(self.expect(&token::Semi));
+        self.expect(&token::Semi)?;
 
         let last_span = self.last_span;
         Ok(self.mk_item(lo,
@@ -5539,17 +5539,17 @@ impl<'a> Parser<'a> {
                               visibility: Visibility,
                               mut attrs: Vec<Attribute>)
                               -> PResult<'a, P<Item>> {
-        try!(self.expect(&token::OpenDelim(token::Brace)));
+        self.expect(&token::OpenDelim(token::Brace))?;
 
         let abi = opt_abi.unwrap_or(Abi::C);
 
-        attrs.extend(try!(self.parse_inner_attributes()));
+        attrs.extend(self.parse_inner_attributes()?);
 
         let mut foreign_items = vec![];
-        while let Some(item) = try!(self.parse_foreign_item()) {
+        while let Some(item) = self.parse_foreign_item()? {
             foreign_items.push(item);
         }
-        try!(self.expect(&token::CloseDelim(token::Brace)));
+        self.expect(&token::CloseDelim(token::Brace))?;
 
         let last_span = self.last_span;
         let m = ast::ForeignMod {
@@ -5566,12 +5566,12 @@ impl<'a> Parser<'a> {
 
     /// Parse type Foo = Bar;
     fn parse_item_type(&mut self) -> PResult<'a, ItemInfo> {
-        let ident = try!(self.parse_ident());
-        let mut tps = try!(self.parse_generics());
-        tps.where_clause = try!(self.parse_where_clause());
-        try!(self.expect(&token::Eq));
-        let ty = try!(self.parse_ty_sum());
-        try!(self.expect(&token::Semi));
+        let ident = self.parse_ident()?;
+        let mut tps = self.parse_generics()?;
+        tps.where_clause = self.parse_where_clause()?;
+        self.expect(&token::Eq)?;
+        let ty = self.parse_ty_sum()?;
+        self.expect(&token::Semi)?;
         Ok((ident, ItemKind::Ty(ty, tps), None))
     }
 
@@ -5581,23 +5581,23 @@ impl<'a> Parser<'a> {
         let mut all_nullary = true;
         let mut any_disr = None;
         while self.token != token::CloseDelim(token::Brace) {
-            let variant_attrs = try!(self.parse_outer_attributes());
+            let variant_attrs = self.parse_outer_attributes()?;
             let vlo = self.span.lo;
 
             let struct_def;
             let mut disr_expr = None;
-            let ident = try!(self.parse_ident());
+            let ident = self.parse_ident()?;
             if self.check(&token::OpenDelim(token::Brace)) {
                 // Parse a struct variant.
                 all_nullary = false;
-                struct_def = VariantData::Struct(try!(self.parse_record_struct_body()),
+                struct_def = VariantData::Struct(self.parse_record_struct_body()?,
                                                  ast::DUMMY_NODE_ID);
             } else if self.check(&token::OpenDelim(token::Paren)) {
                 all_nullary = false;
-                struct_def = VariantData::Tuple(try!(self.parse_tuple_struct_body()),
+                struct_def = VariantData::Tuple(self.parse_tuple_struct_body()?,
                                                 ast::DUMMY_NODE_ID);
             } else if self.eat(&token::Eq) {
-                disr_expr = Some(try!(self.parse_expr()));
+                disr_expr = Some(self.parse_expr()?);
                 any_disr = disr_expr.as_ref().map(|expr| expr.span);
                 struct_def = VariantData::Unit(ast::DUMMY_NODE_ID);
             } else {
@@ -5614,7 +5614,7 @@ impl<'a> Parser<'a> {
 
             if !self.eat(&token::Comma) { break; }
         }
-        try!(self.expect(&token::CloseDelim(token::Brace)));
+        self.expect(&token::CloseDelim(token::Brace))?;
         match any_disr {
             Some(disr_span) if !all_nullary =>
                 self.span_err(disr_span,
@@ -5627,12 +5627,12 @@ impl<'a> Parser<'a> {
 
     /// Parse an "enum" declaration
     fn parse_item_enum(&mut self) -> PResult<'a, ItemInfo> {
-        let id = try!(self.parse_ident());
-        let mut generics = try!(self.parse_generics());
-        generics.where_clause = try!(self.parse_where_clause());
-        try!(self.expect(&token::OpenDelim(token::Brace)));
+        let id = self.parse_ident()?;
+        let mut generics = self.parse_generics()?;
+        generics.where_clause = self.parse_where_clause()?;
+        self.expect(&token::OpenDelim(token::Brace))?;
 
-        let enum_definition = try!(self.parse_enum_def(&generics));
+        let enum_definition = self.parse_enum_def(&generics)?;
         Ok((id, ItemKind::Enum(enum_definition, generics), None))
     }
 
@@ -5687,12 +5687,12 @@ impl<'a> Parser<'a> {
 
         let lo = self.span.lo;
 
-        let visibility = try!(self.parse_visibility());
+        let visibility = self.parse_visibility()?;
 
         if self.eat_keyword(keywords::Use) {
             // USE ITEM
-            let item_ = ItemKind::Use(try!(self.parse_view_path()));
-            try!(self.expect(&token::Semi));
+            let item_ = ItemKind::Use(self.parse_view_path()?);
+            self.expect(&token::Semi)?;
 
             let last_span = self.last_span;
             let item = self.mk_item(lo,
@@ -5706,16 +5706,16 @@ impl<'a> Parser<'a> {
 
         if self.eat_keyword(keywords::Extern) {
             if self.eat_keyword(keywords::Crate) {
-                return Ok(Some(try!(self.parse_item_extern_crate(lo, visibility, attrs))));
+                return Ok(Some(self.parse_item_extern_crate(lo, visibility, attrs)?));
             }
 
-            let opt_abi = try!(self.parse_opt_abi());
+            let opt_abi = self.parse_opt_abi()?;
 
             if self.eat_keyword(keywords::Fn) {
                 // EXTERN FUNCTION ITEM
                 let abi = opt_abi.unwrap_or(Abi::C);
                 let (ident, item_, extra_attrs) =
-                    try!(self.parse_item_fn(Unsafety::Normal, Constness::NotConst, abi));
+                    self.parse_item_fn(Unsafety::Normal, Constness::NotConst, abi)?;
                 let last_span = self.last_span;
                 let item = self.mk_item(lo,
                                         last_span.hi,
@@ -5725,10 +5725,10 @@ impl<'a> Parser<'a> {
                                         maybe_append(attrs, extra_attrs));
                 return Ok(Some(item));
             } else if self.check(&token::OpenDelim(token::Brace)) {
-                return Ok(Some(try!(self.parse_item_foreign_mod(lo, opt_abi, visibility, attrs))));
+                return Ok(Some(self.parse_item_foreign_mod(lo, opt_abi, visibility, attrs)?));
             }
 
-            try!(self.unexpected());
+            self.unexpected()?;
         }
 
         if self.eat_keyword(keywords::Static) {
@@ -5738,7 +5738,7 @@ impl<'a> Parser<'a> {
             } else {
                 Mutability::Immutable
             };
-            let (ident, item_, extra_attrs) = try!(self.parse_item_const(Some(m)));
+            let (ident, item_, extra_attrs) = self.parse_item_const(Some(m))?;
             let last_span = self.last_span;
             let item = self.mk_item(lo,
                                     last_span.hi,
@@ -5760,7 +5760,7 @@ impl<'a> Parser<'a> {
                 };
                 self.bump();
                 let (ident, item_, extra_attrs) =
-                    try!(self.parse_item_fn(unsafety, Constness::Const, Abi::Rust));
+                    self.parse_item_fn(unsafety, Constness::Const, Abi::Rust)?;
                 let last_span = self.last_span;
                 let item = self.mk_item(lo,
                                         last_span.hi,
@@ -5778,7 +5778,7 @@ impl<'a> Parser<'a> {
                                  .fileline_help(last_span, "did you mean to declare a static?")
                                  .emit();
             }
-            let (ident, item_, extra_attrs) = try!(self.parse_item_const(None));
+            let (ident, item_, extra_attrs) = self.parse_item_const(None)?;
             let last_span = self.last_span;
             let item = self.mk_item(lo,
                                     last_span.hi,
@@ -5792,10 +5792,10 @@ impl<'a> Parser<'a> {
             self.look_ahead(1, |t| t.is_keyword(keywords::Trait))
         {
             // UNSAFE TRAIT ITEM
-            try!(self.expect_keyword(keywords::Unsafe));
-            try!(self.expect_keyword(keywords::Trait));
+            self.expect_keyword(keywords::Unsafe)?;
+            self.expect_keyword(keywords::Trait)?;
             let (ident, item_, extra_attrs) =
-                try!(self.parse_item_trait(ast::Unsafety::Unsafe));
+                self.parse_item_trait(ast::Unsafety::Unsafe)?;
             let last_span = self.last_span;
             let item = self.mk_item(lo,
                                     last_span.hi,
@@ -5809,9 +5809,9 @@ impl<'a> Parser<'a> {
             self.look_ahead(1, |t| t.is_keyword(keywords::Impl))
         {
             // IMPL ITEM
-            try!(self.expect_keyword(keywords::Unsafe));
-            try!(self.expect_keyword(keywords::Impl));
-            let (ident, item_, extra_attrs) = try!(self.parse_item_impl(ast::Unsafety::Unsafe));
+            self.expect_keyword(keywords::Unsafe)?;
+            self.expect_keyword(keywords::Impl)?;
+            let (ident, item_, extra_attrs) = self.parse_item_impl(ast::Unsafety::Unsafe)?;
             let last_span = self.last_span;
             let item = self.mk_item(lo,
                                     last_span.hi,
@@ -5825,7 +5825,7 @@ impl<'a> Parser<'a> {
             // FUNCTION ITEM
             self.bump();
             let (ident, item_, extra_attrs) =
-                try!(self.parse_item_fn(Unsafety::Normal, Constness::NotConst, Abi::Rust));
+                self.parse_item_fn(Unsafety::Normal, Constness::NotConst, Abi::Rust)?;
             let last_span = self.last_span;
             let item = self.mk_item(lo,
                                     last_span.hi,
@@ -5840,13 +5840,13 @@ impl<'a> Parser<'a> {
             // UNSAFE FUNCTION ITEM
             self.bump();
             let abi = if self.eat_keyword(keywords::Extern) {
-                try!(self.parse_opt_abi()).unwrap_or(Abi::C)
+                self.parse_opt_abi()?.unwrap_or(Abi::C)
             } else {
                 Abi::Rust
             };
-            try!(self.expect_keyword(keywords::Fn));
+            self.expect_keyword(keywords::Fn)?;
             let (ident, item_, extra_attrs) =
-                try!(self.parse_item_fn(Unsafety::Unsafe, Constness::NotConst, abi));
+                self.parse_item_fn(Unsafety::Unsafe, Constness::NotConst, abi)?;
             let last_span = self.last_span;
             let item = self.mk_item(lo,
                                     last_span.hi,
@@ -5859,7 +5859,7 @@ impl<'a> Parser<'a> {
         if self.eat_keyword(keywords::Mod) {
             // MODULE ITEM
             let (ident, item_, extra_attrs) =
-                try!(self.parse_item_mod(&attrs[..]));
+                self.parse_item_mod(&attrs[..])?;
             let last_span = self.last_span;
             let item = self.mk_item(lo,
                                     last_span.hi,
@@ -5871,7 +5871,7 @@ impl<'a> Parser<'a> {
         }
         if self.eat_keyword(keywords::Type) {
             // TYPE ITEM
-            let (ident, item_, extra_attrs) = try!(self.parse_item_type());
+            let (ident, item_, extra_attrs) = self.parse_item_type()?;
             let last_span = self.last_span;
             let item = self.mk_item(lo,
                                     last_span.hi,
@@ -5883,7 +5883,7 @@ impl<'a> Parser<'a> {
         }
         if self.eat_keyword(keywords::Enum) {
             // ENUM ITEM
-            let (ident, item_, extra_attrs) = try!(self.parse_item_enum());
+            let (ident, item_, extra_attrs) = self.parse_item_enum()?;
             let last_span = self.last_span;
             let item = self.mk_item(lo,
                                     last_span.hi,
@@ -5896,7 +5896,7 @@ impl<'a> Parser<'a> {
         if self.eat_keyword(keywords::Trait) {
             // TRAIT ITEM
             let (ident, item_, extra_attrs) =
-                try!(self.parse_item_trait(ast::Unsafety::Normal));
+                self.parse_item_trait(ast::Unsafety::Normal)?;
             let last_span = self.last_span;
             let item = self.mk_item(lo,
                                     last_span.hi,
@@ -5908,7 +5908,7 @@ impl<'a> Parser<'a> {
         }
         if self.eat_keyword(keywords::Impl) {
             // IMPL ITEM
-            let (ident, item_, extra_attrs) = try!(self.parse_item_impl(ast::Unsafety::Normal));
+            let (ident, item_, extra_attrs) = self.parse_item_impl(ast::Unsafety::Normal)?;
             let last_span = self.last_span;
             let item = self.mk_item(lo,
                                     last_span.hi,
@@ -5920,7 +5920,7 @@ impl<'a> Parser<'a> {
         }
         if self.eat_keyword(keywords::Struct) {
             // STRUCT ITEM
-            let (ident, item_, extra_attrs) = try!(self.parse_item_struct());
+            let (ident, item_, extra_attrs) = self.parse_item_struct()?;
             let last_span = self.last_span;
             let item = self.mk_item(lo,
                                     last_span.hi,
@@ -5935,21 +5935,21 @@ impl<'a> Parser<'a> {
 
     /// Parse a foreign item.
     fn parse_foreign_item(&mut self) -> PResult<'a, Option<ForeignItem>> {
-        let attrs = try!(self.parse_outer_attributes());
+        let attrs = self.parse_outer_attributes()?;
         let lo = self.span.lo;
-        let visibility = try!(self.parse_visibility());
+        let visibility = self.parse_visibility()?;
 
         if self.check_keyword(keywords::Static) {
             // FOREIGN STATIC ITEM
-            return Ok(Some(try!(self.parse_item_foreign_static(visibility, lo, attrs))));
+            return Ok(Some(self.parse_item_foreign_static(visibility, lo, attrs)?));
         }
         if self.check_keyword(keywords::Fn) || self.check_keyword(keywords::Unsafe) {
             // FOREIGN FUNCTION ITEM
-            return Ok(Some(try!(self.parse_item_foreign_fn(visibility, lo, attrs))));
+            return Ok(Some(self.parse_item_foreign_fn(visibility, lo, attrs)?));
         }
 
         // FIXME #5668: this will occur for a macro invocation:
-        match try!(self.parse_macro_use_or_failure(attrs, true, false, lo, visibility)) {
+        match self.parse_macro_use_or_failure(attrs, true, false, lo, visibility)? {
             Some(item) => {
                 return Err(self.span_fatal(item.span, "macros cannot expand to foreign items"));
             }
@@ -5979,22 +5979,22 @@ impl<'a> Parser<'a> {
             let mac_lo = self.span.lo;
 
             // item macro.
-            let pth = try!(self.parse_path(NoTypesAllowed));
-            try!(self.expect(&token::Not));
+            let pth = self.parse_path(NoTypesAllowed)?;
+            self.expect(&token::Not)?;
 
             // a 'special' identifier (like what `macro_rules!` uses)
             // is optional. We should eventually unify invoc syntax
             // and remove this.
             let id = if self.token.is_plain_ident() {
-                try!(self.parse_ident())
+                self.parse_ident()?
             } else {
                 token::special_idents::invalid // no special identifier
             };
             // eat a matched-delimiter token tree:
-            let delim = try!(self.expect_open_delim());
-            let tts = try!(self.parse_seq_to_end(&token::CloseDelim(delim),
+            let delim = self.expect_open_delim()?;
+            let tts = self.parse_seq_to_end(&token::CloseDelim(delim),
                                                  SeqSep::none(),
-                                                 |p| p.parse_token_tree()));
+                                                 |p| p.parse_token_tree())?;
             // single-variant-enum... :
             let m = Mac_ { path: pth, tts: tts, ctxt: EMPTY_CTXT };
             let m: ast::Mac = codemap::Spanned { node: m,
@@ -6038,7 +6038,7 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_item(&mut self) -> PResult<'a, Option<P<Item>>> {
-        let attrs = try!(self.parse_outer_attributes());
+        let attrs = self.parse_outer_attributes()?;
         self.parse_item_(attrs, true, false)
     }
 
@@ -6057,11 +6057,11 @@ impl<'a> Parser<'a> {
 
         if self.check(&token::OpenDelim(token::Brace)) {
             // use {foo,bar}
-            let idents = try!(self.parse_unspanned_seq(
+            let idents = self.parse_unspanned_seq(
                 &token::OpenDelim(token::Brace),
                 &token::CloseDelim(token::Brace),
                 SeqSep::trailing_allowed(token::Comma),
-                |p| p.parse_path_list_item()));
+                |p| p.parse_path_list_item())?;
             let path = ast::Path {
                 span: mk_sp(lo, self.span.hi),
                 global: false,
@@ -6070,7 +6070,7 @@ impl<'a> Parser<'a> {
             return Ok(P(spanned(lo, self.span.hi, ViewPathList(path, idents))));
         }
 
-        let first_ident = try!(self.parse_ident());
+        let first_ident = self.parse_ident()?;
         let mut path = vec!(first_ident);
         if let token::ModSep = self.token {
             // foo::bar or foo::{a,b,c} or foo::*
@@ -6079,18 +6079,18 @@ impl<'a> Parser<'a> {
 
                 match self.token {
                   token::Ident(..) => {
-                    let ident = try!(self.parse_ident());
+                    let ident = self.parse_ident()?;
                     path.push(ident);
                   }
 
                   // foo::bar::{a,b,c}
                   token::OpenDelim(token::Brace) => {
-                    let idents = try!(self.parse_unspanned_seq(
+                    let idents = self.parse_unspanned_seq(
                         &token::OpenDelim(token::Brace),
                         &token::CloseDelim(token::Brace),
                         SeqSep::trailing_allowed(token::Comma),
                         |p| p.parse_path_list_item()
-                    ));
+                    )?;
                     let path = ast::Path {
                         span: mk_sp(lo, self.span.hi),
                         global: false,
@@ -6140,7 +6140,7 @@ impl<'a> Parser<'a> {
                 }
             }).collect()
         };
-        rename_to = try!(self.parse_rename()).unwrap_or(rename_to);
+        rename_to = self.parse_rename()?.unwrap_or(rename_to);
         Ok(P(spanned(lo, self.last_span.hi, ViewPathSimple(rename_to, path))))
     }
 
@@ -6157,8 +6157,8 @@ impl<'a> Parser<'a> {
     pub fn parse_crate_mod(&mut self) -> PResult<'a, Crate> {
         let lo = self.span.lo;
         Ok(ast::Crate {
-            attrs: try!(self.parse_inner_attributes()),
-            module: try!(self.parse_mod_items(&token::Eof, lo)),
+            attrs: self.parse_inner_attributes()?,
+            module: self.parse_mod_items(&token::Eof, lo)?,
             config: self.cfg.clone(),
             span: mk_sp(lo, self.span.lo),
             exported_macros: Vec::new(),

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -834,7 +834,7 @@ impl<'a> Parser<'a> {
         F: FnMut(&mut Parser<'a>) -> PResult<'a, T>,
     {
         let (result, returned) = self.parse_seq_to_before_gt_or_return(sep,
-                                                    |p| Ok(Some(f(p)?)))?;
+                                                                       |p| Ok(Some(f(p)?)))?;
         assert!(!returned);
         return Ok(result);
     }
@@ -1476,8 +1476,8 @@ impl<'a> Parser<'a> {
                 self.bump();
                 let delim = self.expect_open_delim()?;
                 let tts = self.parse_seq_to_end(&token::CloseDelim(delim),
-                                                     SeqSep::none(),
-                                                     |p| p.parse_token_tree())?;
+                                                SeqSep::none(),
+                                                |p| p.parse_token_tree())?;
                 let hi = self.span.hi;
                 TyKind::Mac(spanned(lo, hi, Mac_ { path: path, tts: tts, ctxt: EMPTY_CTXT }))
             } else {
@@ -2225,7 +2225,7 @@ impl<'a> Parser<'a> {
                             &token::CloseDelim(token::Bracket),
                             SeqSep::trailing_allowed(token::Comma),
                             |p| Ok(p.parse_expr()?)
-                                )?;
+                        )?;
                         let mut exprs = vec!(first_expr);
                         exprs.extend(remaining_exprs);
                         ex = ExprKind::Vec(exprs);
@@ -2610,8 +2610,8 @@ impl<'a> Parser<'a> {
 
                     let dot_pos = self.last_span.hi;
                     e = self.parse_dot_suffix(special_idents::invalid,
-                                                   mk_sp(dot_pos, dot_pos),
-                                                   e, lo)?;
+                                              mk_sp(dot_pos, dot_pos),
+                                              e, lo)?;
                   }
                 }
                 continue;
@@ -3267,7 +3267,7 @@ impl<'a> Parser<'a> {
         let match_span = self.last_span;
         let lo = self.last_span.lo;
         let discriminant = self.parse_expr_res(Restrictions::RESTRICTION_NO_STRUCT_LITERAL,
-                                                    None)?;
+                                               None)?;
         if let Err(mut e) = self.commit_expr_expecting(&discriminant,
                                                        token::OpenDelim(token::Brace)) {
             if self.token == token::Token::Semi {
@@ -3612,8 +3612,9 @@ impl<'a> Parser<'a> {
                         let path = ident_to_path(ident_span, ident);
                         self.bump();
                         let delim = self.expect_open_delim()?;
-                        let tts = self.parse_seq_to_end(&token::CloseDelim(delim),
-                                SeqSep::none(), |p| p.parse_token_tree())?;
+                        let tts = self.parse_seq_to_end(
+                            &token::CloseDelim(delim),
+                            SeqSep::none(), |p| p.parse_token_tree())?;
                         let mac = Mac_ { path: path, tts: tts, ctxt: EMPTY_CTXT };
                         pat = PatKind::Mac(codemap::Spanned {node: mac,
                                                        span: mk_sp(lo, self.last_span.hi)});
@@ -3670,10 +3671,10 @@ impl<'a> Parser<'a> {
                             pat = PatKind::TupleStruct(path, None);
                         } else {
                             let args = self.parse_enum_variant_seq(
-                                    &token::OpenDelim(token::Paren),
-                                    &token::CloseDelim(token::Paren),
-                                    SeqSep::trailing_allowed(token::Comma),
-                                    |p| p.parse_pat())?;
+                                &token::OpenDelim(token::Paren),
+                                &token::CloseDelim(token::Paren),
+                                SeqSep::trailing_allowed(token::Comma),
+                                |p| p.parse_pat())?;
                             pat = PatKind::TupleStruct(path, Some(args));
                         }
                       }
@@ -3963,7 +3964,7 @@ impl<'a> Parser<'a> {
             // FIXME: Bad copy of attrs
             let restrictions = self.restrictions | Restrictions::NO_NONINLINE_MOD;
             match self.with_res(restrictions,
-                                     |this| this.parse_item_(attrs.clone(), false, true))? {
+                                |this| this.parse_item_(attrs.clone(), false, true))? {
                 Some(i) => {
                     let hi = i.span.hi;
                     let decl = P(spanned(lo, hi, DeclKind::Item(i)));
@@ -4941,8 +4942,8 @@ impl<'a> Parser<'a> {
             // eat a matched-delimiter token tree:
             let delim = self.expect_open_delim()?;
             let tts = self.parse_seq_to_end(&token::CloseDelim(delim),
-                                                 SeqSep::none(),
-                                                 |p| p.parse_token_tree())?;
+                                            SeqSep::none(),
+                                            |p| p.parse_token_tree())?;
             let m_ = Mac_ { path: pth, tts: tts, ctxt: EMPTY_CTXT };
             let m: ast::Mac = codemap::Spanned { node: m_,
                                                 span: mk_sp(lo,
@@ -5409,8 +5410,8 @@ impl<'a> Parser<'a> {
                     id_sp: Span)
                     -> PResult<'a, (ast::ItemKind, Vec<ast::Attribute> )> {
         let ModulePathSuccess { path, owns_directory } = self.submod_path(id,
-                                                                               outer_attrs,
-                                                                               id_sp)?;
+                                                                          outer_attrs,
+                                                                          id_sp)?;
 
         self.eval_src_mod_from_path(path,
                                     owns_directory,
@@ -5993,8 +5994,8 @@ impl<'a> Parser<'a> {
             // eat a matched-delimiter token tree:
             let delim = self.expect_open_delim()?;
             let tts = self.parse_seq_to_end(&token::CloseDelim(delim),
-                                                 SeqSep::none(),
-                                                 |p| p.parse_token_tree())?;
+                                            SeqSep::none(),
+                                            |p| p.parse_token_tree())?;
             // single-variant-enum... :
             let m = Mac_ { path: pth, tts: tts, ctxt: EMPTY_CTXT };
             let m: ast::Mac = codemap::Spanned { node: m,

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -706,7 +706,7 @@ impl<'a> PartialEq<InternedString> for &'a str {
 
 impl Decodable for InternedString {
     fn decode<D: Decoder>(d: &mut D) -> Result<InternedString, D::Error> {
-        Ok(intern(try!(d.read_str()).as_ref()).as_str())
+        Ok(intern(d.read_str()?.as_ref()).as_str())
     }
 }
 

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -318,7 +318,7 @@ impl<'a> Printer<'a> {
           Token::Eof => {
             if !self.scan_stack_empty {
                 self.check_stack(0);
-                try!(self.advance_left());
+                self.advance_left()?;
             }
             self.indent(0);
             Ok(())
@@ -399,9 +399,9 @@ impl<'a> Printer<'a> {
                     self.size[scanned] = SIZE_INFINITY;
                 }
             }
-            try!(self.advance_left());
+            self.advance_left()?;
             if self.left != self.right {
-                try!(self.check_stream());
+                self.check_stream()?;
             }
         }
         Ok(())
@@ -464,7 +464,7 @@ impl<'a> Printer<'a> {
                 _ => 0
             };
 
-            try!(self.print(left, left_size));
+            self.print(left, left_size)?;
 
             self.left_total += len;
 
@@ -532,7 +532,7 @@ impl<'a> Printer<'a> {
     }
     pub fn print_str(&mut self, s: &str) -> io::Result<()> {
         while self.pending_indentation > 0 {
-            try!(write!(self.out, " "));
+            write!(self.out, " ")?;
             self.pending_indentation -= 1;
         }
         write!(self.out, "{}", s)

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -123,16 +123,16 @@ pub fn print_crate<'a>(cm: &'a CodeMap,
         let list = attr::mk_list_item(InternedString::new("feature"),
                                       vec![prelude_import_meta]);
         let fake_attr = attr::mk_attr_inner(attr::mk_attr_id(), list);
-        try!(s.print_attribute(&fake_attr));
+        s.print_attribute(&fake_attr)?;
 
         // #![no_std]
         let no_std_meta = attr::mk_word_item(InternedString::new("no_std"));
         let fake_attr = attr::mk_attr_inner(attr::mk_attr_id(), no_std_meta);
-        try!(s.print_attribute(&fake_attr));
+        s.print_attribute(&fake_attr)?;
     }
 
-    try!(s.print_mod(&krate.module, &krate.attrs));
-    try!(s.print_remaining_comments());
+    s.print_mod(&krate.module, &krate.attrs)?;
+    s.print_remaining_comments()?;
     eof(&mut s.s)
 }
 
@@ -386,10 +386,10 @@ pub fn fun_to_string(decl: &ast::FnDecl,
                      generics: &ast::Generics)
                      -> String {
     to_string(|s| {
-        try!(s.head(""));
-        try!(s.print_fn(decl, unsafety, constness, Abi::Rust, Some(name),
-                        generics, opt_explicit_self, ast::Visibility::Inherited));
-        try!(s.end()); // Close the head box
+        s.head("")?;
+        s.print_fn(decl, unsafety, constness, Abi::Rust, Some(name),
+                        generics, opt_explicit_self, ast::Visibility::Inherited)?;
+        s.end()?; // Close the head box
         s.end() // Close the outer box
     })
 }
@@ -397,9 +397,9 @@ pub fn fun_to_string(decl: &ast::FnDecl,
 pub fn block_to_string(blk: &ast::Block) -> String {
     to_string(|s| {
         // containing cbox, will be closed by print-block at }
-        try!(s.cbox(INDENT_UNIT));
+        s.cbox(INDENT_UNIT)?;
         // head-ibox, will be closed by print-block after {
-        try!(s.ibox(0));
+        s.ibox(0)?;
         s.print_block(blk)
     })
 }
@@ -457,7 +457,7 @@ pub trait PrintState<'a> {
     fn literals(&self) -> &Option<Vec<comments::Literal>>;
 
     fn word_space(&mut self, w: &str) -> io::Result<()> {
-        try!(word(self.writer(), w));
+        word(self.writer(), w)?;
         space(self.writer())
     }
 
@@ -486,7 +486,7 @@ pub trait PrintState<'a> {
 
     fn hardbreak_if_not_bol(&mut self) -> io::Result<()> {
         if !self.is_bol() {
-            try!(hardbreak(self.writer()))
+            hardbreak(self.writer())?
         }
         Ok(())
     }
@@ -510,11 +510,11 @@ pub trait PrintState<'a> {
     fn commasep<T, F>(&mut self, b: Breaks, elts: &[T], mut op: F) -> io::Result<()>
         where F: FnMut(&mut Self, &T) -> io::Result<()>,
     {
-        try!(self.rbox(0, b));
+        self.rbox(0, b)?;
         let mut first = true;
         for elt in elts {
-            if first { first = false; } else { try!(self.word_space(",")); }
-            try!(op(self, elt));
+            if first { first = false; } else { self.word_space(",")?; }
+            op(self, elt)?;
         }
         self.end()
     }
@@ -546,7 +546,7 @@ pub trait PrintState<'a> {
             match self.next_comment() {
                 Some(ref cmnt) => {
                     if (*cmnt).pos < pos {
-                        try!(self.print_comment(cmnt));
+                        self.print_comment(cmnt)?;
                         self.cur_cmnt_and_lit().cur_cmnt += 1;
                     } else { break; }
                 }
@@ -561,34 +561,34 @@ pub trait PrintState<'a> {
         match cmnt.style {
             comments::Mixed => {
                 assert_eq!(cmnt.lines.len(), 1);
-                try!(zerobreak(self.writer()));
-                try!(word(self.writer(), &cmnt.lines[0]));
+                zerobreak(self.writer())?;
+                word(self.writer(), &cmnt.lines[0])?;
                 zerobreak(self.writer())
             }
             comments::Isolated => {
-                try!(self.hardbreak_if_not_bol());
+                self.hardbreak_if_not_bol()?;
                 for line in &cmnt.lines {
                     // Don't print empty lines because they will end up as trailing
                     // whitespace
                     if !line.is_empty() {
-                        try!(word(self.writer(), &line[..]));
+                        word(self.writer(), &line[..])?;
                     }
-                    try!(hardbreak(self.writer()));
+                    hardbreak(self.writer())?;
                 }
                 Ok(())
             }
             comments::Trailing => {
-                try!(word(self.writer(), " "));
+                word(self.writer(), " ")?;
                 if cmnt.lines.len() == 1 {
-                    try!(word(self.writer(), &cmnt.lines[0]));
+                    word(self.writer(), &cmnt.lines[0])?;
                     hardbreak(self.writer())
                 } else {
-                    try!(self.ibox(0));
+                    self.ibox(0)?;
                     for line in &cmnt.lines {
                         if !line.is_empty() {
-                            try!(word(self.writer(), &line[..]));
+                            word(self.writer(), &line[..])?;
                         }
-                        try!(hardbreak(self.writer()));
+                        hardbreak(self.writer())?;
                     }
                     self.end()
                 }
@@ -600,7 +600,7 @@ pub trait PrintState<'a> {
                     _ => false
                 };
                 if is_semi || self.is_begin() || self.is_end() {
-                    try!(hardbreak(self.writer()));
+                    hardbreak(self.writer())?;
                 }
                 hardbreak(self.writer())
             }
@@ -622,7 +622,7 @@ pub trait PrintState<'a> {
     }
 
     fn print_literal(&mut self, lit: &ast::Lit) -> io::Result<()> {
-        try!(self.maybe_print_comment(lit.span.lo));
+        self.maybe_print_comment(lit.span.lo)?;
         match self.next_lit(lit.span.lo) {
             Some(ref ltrl) => {
                 return word(self.writer(), &(*ltrl).lit);
@@ -728,15 +728,15 @@ pub trait PrintState<'a> {
         let mut count = 0;
         for attr in attrs {
             if attr.node.style == kind {
-                    try!(self.print_attribute_inline(attr, is_inline));
+                    self.print_attribute_inline(attr, is_inline)?;
                     if is_inline {
-                        try!(self.nbsp());
+                        self.nbsp()?;
                     }
                     count += 1;
             }
         }
         if count > 0 && trailing_hardbreak && !is_inline {
-            try!(self.hardbreak_if_not_bol());
+            self.hardbreak_if_not_bol()?;
         }
         Ok(())
     }
@@ -748,47 +748,47 @@ pub trait PrintState<'a> {
     fn print_attribute_inline(&mut self, attr: &ast::Attribute,
                               is_inline: bool) -> io::Result<()> {
         if !is_inline {
-            try!(self.hardbreak_if_not_bol());
+            self.hardbreak_if_not_bol()?;
         }
-        try!(self.maybe_print_comment(attr.span.lo));
+        self.maybe_print_comment(attr.span.lo)?;
         if attr.node.is_sugared_doc {
-            try!(word(self.writer(), &attr.value_str().unwrap()));
+            word(self.writer(), &attr.value_str().unwrap())?;
             hardbreak(self.writer())
         } else {
             match attr.node.style {
-                ast::AttrStyle::Inner => try!(word(self.writer(), "#![")),
-                ast::AttrStyle::Outer => try!(word(self.writer(), "#[")),
+                ast::AttrStyle::Inner => word(self.writer(), "#![")?,
+                ast::AttrStyle::Outer => word(self.writer(), "#[")?,
             }
-            try!(self.print_meta_item(&attr.meta()));
+            self.print_meta_item(&attr.meta())?;
             word(self.writer(), "]")
         }
     }
 
     fn print_meta_item(&mut self, item: &ast::MetaItem) -> io::Result<()> {
-        try!(self.ibox(INDENT_UNIT));
+        self.ibox(INDENT_UNIT)?;
         match item.node {
             ast::MetaItemKind::Word(ref name) => {
-                try!(word(self.writer(), &name));
+                word(self.writer(), &name)?;
             }
             ast::MetaItemKind::NameValue(ref name, ref value) => {
-                try!(self.word_space(&name[..]));
-                try!(self.word_space("="));
-                try!(self.print_literal(value));
+                self.word_space(&name[..])?;
+                self.word_space("=")?;
+                self.print_literal(value)?;
             }
             ast::MetaItemKind::List(ref name, ref items) => {
-                try!(word(self.writer(), &name));
-                try!(self.popen());
-                try!(self.commasep(Consistent,
+                word(self.writer(), &name)?;
+                self.popen()?;
+                self.commasep(Consistent,
                                    &items[..],
-                                   |s, i| s.print_meta_item(&i)));
-                try!(self.pclose());
+                                   |s, i| s.print_meta_item(&i))?;
+                self.pclose()?;
             }
         }
         self.end()
     }
 
     fn space_if_not_bol(&mut self) -> io::Result<()> {
-        if !self.is_bol() { try!(space(self.writer())); }
+        if !self.is_bol() { space(self.writer())?; }
         Ok(())
     }
 
@@ -824,24 +824,24 @@ impl<'a> State<'a> {
     }
 
     pub fn word_nbsp(&mut self, w: &str) -> io::Result<()> {
-        try!(word(&mut self.s, w));
+        word(&mut self.s, w)?;
         self.nbsp()
     }
 
     pub fn head(&mut self, w: &str) -> io::Result<()> {
         // outer-box is consistent
-        try!(self.cbox(INDENT_UNIT));
+        self.cbox(INDENT_UNIT)?;
         // head-box is inconsistent
-        try!(self.ibox(w.len() + 1));
+        self.ibox(w.len() + 1)?;
         // keyword that starts the head
         if !w.is_empty() {
-            try!(self.word_nbsp(w));
+            self.word_nbsp(w)?;
         }
         Ok(())
     }
 
     pub fn bopen(&mut self) -> io::Result<()> {
-        try!(word(&mut self.s, "{"));
+        word(&mut self.s, "{")?;
         self.end() // close the head-box
     }
 
@@ -851,11 +851,11 @@ impl<'a> State<'a> {
     }
     pub fn bclose_maybe_open(&mut self, span: codemap::Span,
                              indented: usize, close_box: bool) -> io::Result<()> {
-        try!(self.maybe_print_comment(span.hi));
-        try!(self.break_offset_if_not_bol(1, -(indented as isize)));
-        try!(word(&mut self.s, "}"));
+        self.maybe_print_comment(span.hi)?;
+        self.break_offset_if_not_bol(1, -(indented as isize))?;
+        word(&mut self.s, "}")?;
         if close_box {
-            try!(self.end()); // close the outer-box
+            self.end()?; // close the outer-box
         }
         Ok(())
     }
@@ -888,10 +888,10 @@ impl<'a> State<'a> {
     // Synthesizes a comment that was not textually present in the original source
     // file.
     pub fn synth_comment(&mut self, text: String) -> io::Result<()> {
-        try!(word(&mut self.s, "/*"));
-        try!(space(&mut self.s));
-        try!(word(&mut self.s, &text[..]));
-        try!(space(&mut self.s));
+        word(&mut self.s, "/*")?;
+        space(&mut self.s)?;
+        word(&mut self.s, &text[..])?;
+        space(&mut self.s)?;
         word(&mut self.s, "*/")
     }
 
@@ -905,18 +905,18 @@ impl<'a> State<'a> {
         F: FnMut(&mut State, &T) -> io::Result<()>,
         G: FnMut(&T) -> codemap::Span,
     {
-        try!(self.rbox(0, b));
+        self.rbox(0, b)?;
         let len = elts.len();
         let mut i = 0;
         for elt in elts {
-            try!(self.maybe_print_comment(get_span(elt).hi));
-            try!(op(self, elt));
+            self.maybe_print_comment(get_span(elt).hi)?;
+            op(self, elt)?;
             i += 1;
             if i < len {
-                try!(word(&mut self.s, ","));
-                try!(self.maybe_print_trailing_comment(get_span(elt),
-                                                    Some(get_span(&elts[i]).hi)));
-                try!(self.space_if_not_bol());
+                word(&mut self.s, ",")?;
+                self.maybe_print_trailing_comment(get_span(elt),
+                                                    Some(get_span(&elts[i]).hi))?;
+                self.space_if_not_bol()?;
             }
         }
         self.end()
@@ -929,18 +929,18 @@ impl<'a> State<'a> {
 
     pub fn print_mod(&mut self, _mod: &ast::Mod,
                      attrs: &[ast::Attribute]) -> io::Result<()> {
-        try!(self.print_inner_attributes(attrs));
+        self.print_inner_attributes(attrs)?;
         for item in &_mod.items {
-            try!(self.print_item(&item));
+            self.print_item(&item)?;
         }
         Ok(())
     }
 
     pub fn print_foreign_mod(&mut self, nmod: &ast::ForeignMod,
                              attrs: &[ast::Attribute]) -> io::Result<()> {
-        try!(self.print_inner_attributes(attrs));
+        self.print_inner_attributes(attrs)?;
         for item in &nmod.items {
-            try!(self.print_foreign_item(item));
+            self.print_foreign_item(item)?;
         }
         Ok(())
     }
@@ -948,47 +948,47 @@ impl<'a> State<'a> {
     pub fn print_opt_lifetime(&mut self,
                               lifetime: &Option<ast::Lifetime>) -> io::Result<()> {
         if let Some(l) = *lifetime {
-            try!(self.print_lifetime(&l));
-            try!(self.nbsp());
+            self.print_lifetime(&l)?;
+            self.nbsp()?;
         }
         Ok(())
     }
 
     pub fn print_type(&mut self, ty: &ast::Ty) -> io::Result<()> {
-        try!(self.maybe_print_comment(ty.span.lo));
-        try!(self.ibox(0));
+        self.maybe_print_comment(ty.span.lo)?;
+        self.ibox(0)?;
         match ty.node {
             ast::TyKind::Vec(ref ty) => {
-                try!(word(&mut self.s, "["));
-                try!(self.print_type(&ty));
-                try!(word(&mut self.s, "]"));
+                word(&mut self.s, "[")?;
+                self.print_type(&ty)?;
+                word(&mut self.s, "]")?;
             }
             ast::TyKind::Ptr(ref mt) => {
-                try!(word(&mut self.s, "*"));
+                word(&mut self.s, "*")?;
                 match mt.mutbl {
-                    ast::Mutability::Mutable => try!(self.word_nbsp("mut")),
-                    ast::Mutability::Immutable => try!(self.word_nbsp("const")),
+                    ast::Mutability::Mutable => self.word_nbsp("mut")?,
+                    ast::Mutability::Immutable => self.word_nbsp("const")?,
                 }
-                try!(self.print_type(&mt.ty));
+                self.print_type(&mt.ty)?;
             }
             ast::TyKind::Rptr(ref lifetime, ref mt) => {
-                try!(word(&mut self.s, "&"));
-                try!(self.print_opt_lifetime(lifetime));
-                try!(self.print_mt(mt));
+                word(&mut self.s, "&")?;
+                self.print_opt_lifetime(lifetime)?;
+                self.print_mt(mt)?;
             }
             ast::TyKind::Tup(ref elts) => {
-                try!(self.popen());
-                try!(self.commasep(Inconsistent, &elts[..],
-                                   |s, ty| s.print_type(&ty)));
+                self.popen()?;
+                self.commasep(Inconsistent, &elts[..],
+                                   |s, ty| s.print_type(&ty))?;
                 if elts.len() == 1 {
-                    try!(word(&mut self.s, ","));
+                    word(&mut self.s, ",")?;
                 }
-                try!(self.pclose());
+                self.pclose()?;
             }
             ast::TyKind::Paren(ref typ) => {
-                try!(self.popen());
-                try!(self.print_type(&typ));
-                try!(self.pclose());
+                self.popen()?;
+                self.print_type(&typ)?;
+                self.pclose()?;
             }
             ast::TyKind::BareFn(ref f) => {
                 let generics = ast::Generics {
@@ -999,43 +999,43 @@ impl<'a> State<'a> {
                         predicates: Vec::new(),
                     },
                 };
-                try!(self.print_ty_fn(f.abi,
+                self.print_ty_fn(f.abi,
                                       f.unsafety,
                                       &f.decl,
                                       None,
                                       &generics,
-                                      None));
+                                      None)?;
             }
             ast::TyKind::Path(None, ref path) => {
-                try!(self.print_path(path, false, 0));
+                self.print_path(path, false, 0)?;
             }
             ast::TyKind::Path(Some(ref qself), ref path) => {
-                try!(self.print_qpath(path, qself, false))
+                self.print_qpath(path, qself, false)?
             }
             ast::TyKind::ObjectSum(ref ty, ref bounds) => {
-                try!(self.print_type(&ty));
-                try!(self.print_bounds("+", &bounds[..]));
+                self.print_type(&ty)?;
+                self.print_bounds("+", &bounds[..])?;
             }
             ast::TyKind::PolyTraitRef(ref bounds) => {
-                try!(self.print_bounds("", &bounds[..]));
+                self.print_bounds("", &bounds[..])?;
             }
             ast::TyKind::FixedLengthVec(ref ty, ref v) => {
-                try!(word(&mut self.s, "["));
-                try!(self.print_type(&ty));
-                try!(word(&mut self.s, "; "));
-                try!(self.print_expr(&v));
-                try!(word(&mut self.s, "]"));
+                word(&mut self.s, "[")?;
+                self.print_type(&ty)?;
+                word(&mut self.s, "; ")?;
+                self.print_expr(&v)?;
+                word(&mut self.s, "]")?;
             }
             ast::TyKind::Typeof(ref e) => {
-                try!(word(&mut self.s, "typeof("));
-                try!(self.print_expr(&e));
-                try!(word(&mut self.s, ")"));
+                word(&mut self.s, "typeof(")?;
+                self.print_expr(&e)?;
+                word(&mut self.s, ")")?;
             }
             ast::TyKind::Infer => {
-                try!(word(&mut self.s, "_"));
+                word(&mut self.s, "_")?;
             }
             ast::TyKind::Mac(ref m) => {
-                try!(self.print_mac(m, token::Paren));
+                self.print_mac(m, token::Paren)?;
             }
         }
         self.end()
@@ -1043,31 +1043,31 @@ impl<'a> State<'a> {
 
     pub fn print_foreign_item(&mut self,
                               item: &ast::ForeignItem) -> io::Result<()> {
-        try!(self.hardbreak_if_not_bol());
-        try!(self.maybe_print_comment(item.span.lo));
-        try!(self.print_outer_attributes(&item.attrs));
+        self.hardbreak_if_not_bol()?;
+        self.maybe_print_comment(item.span.lo)?;
+        self.print_outer_attributes(&item.attrs)?;
         match item.node {
             ast::ForeignItemKind::Fn(ref decl, ref generics) => {
-                try!(self.head(""));
-                try!(self.print_fn(decl, ast::Unsafety::Normal,
+                self.head("")?;
+                self.print_fn(decl, ast::Unsafety::Normal,
                                    ast::Constness::NotConst,
                                    Abi::Rust, Some(item.ident),
-                                   generics, None, item.vis));
-                try!(self.end()); // end head-ibox
-                try!(word(&mut self.s, ";"));
+                                   generics, None, item.vis)?;
+                self.end()?; // end head-ibox
+                word(&mut self.s, ";")?;
                 self.end() // end the outer fn box
             }
             ast::ForeignItemKind::Static(ref t, m) => {
-                try!(self.head(&visibility_qualified(item.vis,
-                                                    "static")));
+                self.head(&visibility_qualified(item.vis,
+                                                    "static"))?;
                 if m {
-                    try!(self.word_space("mut"));
+                    self.word_space("mut")?;
                 }
-                try!(self.print_ident(item.ident));
-                try!(self.word_space(":"));
-                try!(self.print_type(&t));
-                try!(word(&mut self.s, ";"));
-                try!(self.end()); // end the head-ibox
+                self.print_ident(item.ident)?;
+                self.word_space(":")?;
+                self.print_type(&t)?;
+                word(&mut self.s, ";")?;
+                self.end()?; // end the head-ibox
                 self.end() // end the outer cbox
             }
         }
@@ -1080,15 +1080,15 @@ impl<'a> State<'a> {
                               vis: ast::Visibility)
                               -> io::Result<()>
     {
-        try!(word(&mut self.s, &visibility_qualified(vis, "")));
-        try!(self.word_space("const"));
-        try!(self.print_ident(ident));
-        try!(self.word_space(":"));
-        try!(self.print_type(ty));
+        word(&mut self.s, &visibility_qualified(vis, ""))?;
+        self.word_space("const")?;
+        self.print_ident(ident)?;
+        self.word_space(":")?;
+        self.print_type(ty)?;
         if let Some(expr) = default {
-            try!(space(&mut self.s));
-            try!(self.word_space("="));
-            try!(self.print_expr(expr));
+            space(&mut self.s)?;
+            self.word_space("=")?;
+            self.print_expr(expr)?;
         }
         word(&mut self.s, ";")
     }
@@ -1098,87 +1098,87 @@ impl<'a> State<'a> {
                              bounds: Option<&ast::TyParamBounds>,
                              ty: Option<&ast::Ty>)
                              -> io::Result<()> {
-        try!(self.word_space("type"));
-        try!(self.print_ident(ident));
+        self.word_space("type")?;
+        self.print_ident(ident)?;
         if let Some(bounds) = bounds {
-            try!(self.print_bounds(":", bounds));
+            self.print_bounds(":", bounds)?;
         }
         if let Some(ty) = ty {
-            try!(space(&mut self.s));
-            try!(self.word_space("="));
-            try!(self.print_type(ty));
+            space(&mut self.s)?;
+            self.word_space("=")?;
+            self.print_type(ty)?;
         }
         word(&mut self.s, ";")
     }
 
     /// Pretty-print an item
     pub fn print_item(&mut self, item: &ast::Item) -> io::Result<()> {
-        try!(self.hardbreak_if_not_bol());
-        try!(self.maybe_print_comment(item.span.lo));
-        try!(self.print_outer_attributes(&item.attrs));
-        try!(self.ann.pre(self, NodeItem(item)));
+        self.hardbreak_if_not_bol()?;
+        self.maybe_print_comment(item.span.lo)?;
+        self.print_outer_attributes(&item.attrs)?;
+        self.ann.pre(self, NodeItem(item))?;
         match item.node {
             ast::ItemKind::ExternCrate(ref optional_path) => {
-                try!(self.head(&visibility_qualified(item.vis,
-                                                     "extern crate")));
+                self.head(&visibility_qualified(item.vis,
+                                                     "extern crate"))?;
                 if let Some(p) = *optional_path {
                     let val = p.as_str();
                     if val.contains("-") {
-                        try!(self.print_string(&val, ast::StrStyle::Cooked));
+                        self.print_string(&val, ast::StrStyle::Cooked)?;
                     } else {
-                        try!(self.print_name(p));
+                        self.print_name(p)?;
                     }
-                    try!(space(&mut self.s));
-                    try!(word(&mut self.s, "as"));
-                    try!(space(&mut self.s));
+                    space(&mut self.s)?;
+                    word(&mut self.s, "as")?;
+                    space(&mut self.s)?;
                 }
-                try!(self.print_ident(item.ident));
-                try!(word(&mut self.s, ";"));
-                try!(self.end()); // end inner head-block
-                try!(self.end()); // end outer head-block
+                self.print_ident(item.ident)?;
+                word(&mut self.s, ";")?;
+                self.end()?; // end inner head-block
+                self.end()?; // end outer head-block
             }
             ast::ItemKind::Use(ref vp) => {
-                try!(self.head(&visibility_qualified(item.vis,
-                                                     "use")));
-                try!(self.print_view_path(&vp));
-                try!(word(&mut self.s, ";"));
-                try!(self.end()); // end inner head-block
-                try!(self.end()); // end outer head-block
+                self.head(&visibility_qualified(item.vis,
+                                                     "use"))?;
+                self.print_view_path(&vp)?;
+                word(&mut self.s, ";")?;
+                self.end()?; // end inner head-block
+                self.end()?; // end outer head-block
             }
             ast::ItemKind::Static(ref ty, m, ref expr) => {
-                try!(self.head(&visibility_qualified(item.vis,
-                                                    "static")));
+                self.head(&visibility_qualified(item.vis,
+                                                    "static"))?;
                 if m == ast::Mutability::Mutable {
-                    try!(self.word_space("mut"));
+                    self.word_space("mut")?;
                 }
-                try!(self.print_ident(item.ident));
-                try!(self.word_space(":"));
-                try!(self.print_type(&ty));
-                try!(space(&mut self.s));
-                try!(self.end()); // end the head-ibox
+                self.print_ident(item.ident)?;
+                self.word_space(":")?;
+                self.print_type(&ty)?;
+                space(&mut self.s)?;
+                self.end()?; // end the head-ibox
 
-                try!(self.word_space("="));
-                try!(self.print_expr(&expr));
-                try!(word(&mut self.s, ";"));
-                try!(self.end()); // end the outer cbox
+                self.word_space("=")?;
+                self.print_expr(&expr)?;
+                word(&mut self.s, ";")?;
+                self.end()?; // end the outer cbox
             }
             ast::ItemKind::Const(ref ty, ref expr) => {
-                try!(self.head(&visibility_qualified(item.vis,
-                                                    "const")));
-                try!(self.print_ident(item.ident));
-                try!(self.word_space(":"));
-                try!(self.print_type(&ty));
-                try!(space(&mut self.s));
-                try!(self.end()); // end the head-ibox
+                self.head(&visibility_qualified(item.vis,
+                                                    "const"))?;
+                self.print_ident(item.ident)?;
+                self.word_space(":")?;
+                self.print_type(&ty)?;
+                space(&mut self.s)?;
+                self.end()?; // end the head-ibox
 
-                try!(self.word_space("="));
-                try!(self.print_expr(&expr));
-                try!(word(&mut self.s, ";"));
-                try!(self.end()); // end the outer cbox
+                self.word_space("=")?;
+                self.print_expr(&expr)?;
+                word(&mut self.s, ";")?;
+                self.end()?; // end the outer cbox
             }
             ast::ItemKind::Fn(ref decl, unsafety, constness, abi, ref typarams, ref body) => {
-                try!(self.head(""));
-                try!(self.print_fn(
+                self.head("")?;
+                self.print_fn(
                     decl,
                     unsafety,
                     constness,
@@ -1187,66 +1187,66 @@ impl<'a> State<'a> {
                     typarams,
                     None,
                     item.vis
-                ));
-                try!(word(&mut self.s, " "));
-                try!(self.print_block_with_attrs(&body, &item.attrs));
+                )?;
+                word(&mut self.s, " ")?;
+                self.print_block_with_attrs(&body, &item.attrs)?;
             }
             ast::ItemKind::Mod(ref _mod) => {
-                try!(self.head(&visibility_qualified(item.vis,
-                                                    "mod")));
-                try!(self.print_ident(item.ident));
-                try!(self.nbsp());
-                try!(self.bopen());
-                try!(self.print_mod(_mod, &item.attrs));
-                try!(self.bclose(item.span));
+                self.head(&visibility_qualified(item.vis,
+                                                    "mod"))?;
+                self.print_ident(item.ident)?;
+                self.nbsp()?;
+                self.bopen()?;
+                self.print_mod(_mod, &item.attrs)?;
+                self.bclose(item.span)?;
             }
             ast::ItemKind::ForeignMod(ref nmod) => {
-                try!(self.head("extern"));
-                try!(self.word_nbsp(&nmod.abi.to_string()));
-                try!(self.bopen());
-                try!(self.print_foreign_mod(nmod, &item.attrs));
-                try!(self.bclose(item.span));
+                self.head("extern")?;
+                self.word_nbsp(&nmod.abi.to_string())?;
+                self.bopen()?;
+                self.print_foreign_mod(nmod, &item.attrs)?;
+                self.bclose(item.span)?;
             }
             ast::ItemKind::Ty(ref ty, ref params) => {
-                try!(self.ibox(INDENT_UNIT));
-                try!(self.ibox(0));
-                try!(self.word_nbsp(&visibility_qualified(item.vis, "type")));
-                try!(self.print_ident(item.ident));
-                try!(self.print_generics(params));
-                try!(self.end()); // end the inner ibox
+                self.ibox(INDENT_UNIT)?;
+                self.ibox(0)?;
+                self.word_nbsp(&visibility_qualified(item.vis, "type"))?;
+                self.print_ident(item.ident)?;
+                self.print_generics(params)?;
+                self.end()?; // end the inner ibox
 
-                try!(self.print_where_clause(&params.where_clause));
-                try!(space(&mut self.s));
-                try!(self.word_space("="));
-                try!(self.print_type(&ty));
-                try!(word(&mut self.s, ";"));
-                try!(self.end()); // end the outer ibox
+                self.print_where_clause(&params.where_clause)?;
+                space(&mut self.s)?;
+                self.word_space("=")?;
+                self.print_type(&ty)?;
+                word(&mut self.s, ";")?;
+                self.end()?; // end the outer ibox
             }
             ast::ItemKind::Enum(ref enum_definition, ref params) => {
-                try!(self.print_enum_def(
+                self.print_enum_def(
                     enum_definition,
                     params,
                     item.ident,
                     item.span,
                     item.vis
-                ));
+                )?;
             }
             ast::ItemKind::Struct(ref struct_def, ref generics) => {
-                try!(self.head(&visibility_qualified(item.vis,"struct")));
-                try!(self.print_struct(&struct_def, generics, item.ident, item.span, true));
+                self.head(&visibility_qualified(item.vis,"struct"))?;
+                self.print_struct(&struct_def, generics, item.ident, item.span, true)?;
             }
 
             ast::ItemKind::DefaultImpl(unsafety, ref trait_ref) => {
-                try!(self.head(""));
-                try!(self.print_visibility(item.vis));
-                try!(self.print_unsafety(unsafety));
-                try!(self.word_nbsp("impl"));
-                try!(self.print_trait_ref(trait_ref));
-                try!(space(&mut self.s));
-                try!(self.word_space("for"));
-                try!(self.word_space(".."));
-                try!(self.bopen());
-                try!(self.bclose(item.span));
+                self.head("")?;
+                self.print_visibility(item.vis)?;
+                self.print_unsafety(unsafety)?;
+                self.word_nbsp("impl")?;
+                self.print_trait_ref(trait_ref)?;
+                space(&mut self.s)?;
+                self.word_space("for")?;
+                self.word_space("..")?;
+                self.bopen()?;
+                self.bclose(item.span)?;
             }
             ast::ItemKind::Impl(unsafety,
                           polarity,
@@ -1254,80 +1254,80 @@ impl<'a> State<'a> {
                           ref opt_trait,
                           ref ty,
                           ref impl_items) => {
-                try!(self.head(""));
-                try!(self.print_visibility(item.vis));
-                try!(self.print_unsafety(unsafety));
-                try!(self.word_nbsp("impl"));
+                self.head("")?;
+                self.print_visibility(item.vis)?;
+                self.print_unsafety(unsafety)?;
+                self.word_nbsp("impl")?;
 
                 if generics.is_parameterized() {
-                    try!(self.print_generics(generics));
-                    try!(space(&mut self.s));
+                    self.print_generics(generics)?;
+                    space(&mut self.s)?;
                 }
 
                 match polarity {
                     ast::ImplPolarity::Negative => {
-                        try!(word(&mut self.s, "!"));
+                        word(&mut self.s, "!")?;
                     },
                     _ => {}
                 }
 
                 match *opt_trait {
                     Some(ref t) => {
-                        try!(self.print_trait_ref(t));
-                        try!(space(&mut self.s));
-                        try!(self.word_space("for"));
+                        self.print_trait_ref(t)?;
+                        space(&mut self.s)?;
+                        self.word_space("for")?;
                     }
                     None => {}
                 }
 
-                try!(self.print_type(&ty));
-                try!(self.print_where_clause(&generics.where_clause));
+                self.print_type(&ty)?;
+                self.print_where_clause(&generics.where_clause)?;
 
-                try!(space(&mut self.s));
-                try!(self.bopen());
-                try!(self.print_inner_attributes(&item.attrs));
+                space(&mut self.s)?;
+                self.bopen()?;
+                self.print_inner_attributes(&item.attrs)?;
                 for impl_item in impl_items {
-                    try!(self.print_impl_item(impl_item));
+                    self.print_impl_item(impl_item)?;
                 }
-                try!(self.bclose(item.span));
+                self.bclose(item.span)?;
             }
             ast::ItemKind::Trait(unsafety, ref generics, ref bounds, ref trait_items) => {
-                try!(self.head(""));
-                try!(self.print_visibility(item.vis));
-                try!(self.print_unsafety(unsafety));
-                try!(self.word_nbsp("trait"));
-                try!(self.print_ident(item.ident));
-                try!(self.print_generics(generics));
+                self.head("")?;
+                self.print_visibility(item.vis)?;
+                self.print_unsafety(unsafety)?;
+                self.word_nbsp("trait")?;
+                self.print_ident(item.ident)?;
+                self.print_generics(generics)?;
                 let mut real_bounds = Vec::with_capacity(bounds.len());
                 for b in bounds.iter() {
                     if let TraitTyParamBound(ref ptr, ast::TraitBoundModifier::Maybe) = *b {
-                        try!(space(&mut self.s));
-                        try!(self.word_space("for ?"));
-                        try!(self.print_trait_ref(&ptr.trait_ref));
+                        space(&mut self.s)?;
+                        self.word_space("for ?")?;
+                        self.print_trait_ref(&ptr.trait_ref)?;
                     } else {
                         real_bounds.push(b.clone());
                     }
                 }
-                try!(self.print_bounds(":", &real_bounds[..]));
-                try!(self.print_where_clause(&generics.where_clause));
-                try!(word(&mut self.s, " "));
-                try!(self.bopen());
+                self.print_bounds(":", &real_bounds[..])?;
+                self.print_where_clause(&generics.where_clause)?;
+                word(&mut self.s, " ")?;
+                self.bopen()?;
                 for trait_item in trait_items {
-                    try!(self.print_trait_item(trait_item));
+                    self.print_trait_item(trait_item)?;
                 }
-                try!(self.bclose(item.span));
+                self.bclose(item.span)?;
             }
             ast::ItemKind::Mac(codemap::Spanned { ref node, .. }) => {
-                try!(self.print_visibility(item.vis));
-                try!(self.print_path(&node.path, false, 0));
-                try!(word(&mut self.s, "! "));
-                try!(self.print_ident(item.ident));
-                try!(self.cbox(INDENT_UNIT));
-                try!(self.popen());
-                try!(self.print_tts(&node.tts[..]));
-                try!(self.pclose());
-                try!(word(&mut self.s, ";"));
-                try!(self.end());
+                self.print_visibility(item.vis)?;
+                self.print_path(&node.path, false, 0)?;
+                word(&mut self.s, "! ")?;
+                self.print_ident(item.ident)?;
+                self.cbox(INDENT_UNIT)?;
+                self.popen()?;
+                self.print_tts(&node.tts[..])?;
+                self.pclose()?;
+                word(&mut self.s, ";")?;
+                self.end()?;
             }
         }
         self.ann.post(self, NodeItem(item))
@@ -1339,22 +1339,22 @@ impl<'a> State<'a> {
 
     fn print_formal_lifetime_list(&mut self, lifetimes: &[ast::LifetimeDef]) -> io::Result<()> {
         if !lifetimes.is_empty() {
-            try!(word(&mut self.s, "for<"));
+            word(&mut self.s, "for<")?;
             let mut comma = false;
             for lifetime_def in lifetimes {
                 if comma {
-                    try!(self.word_space(","))
+                    self.word_space(",")?
                 }
-                try!(self.print_lifetime_def(lifetime_def));
+                self.print_lifetime_def(lifetime_def)?;
                 comma = true;
             }
-            try!(word(&mut self.s, ">"));
+            word(&mut self.s, ">")?;
         }
         Ok(())
     }
 
     fn print_poly_trait_ref(&mut self, t: &ast::PolyTraitRef) -> io::Result<()> {
-        try!(self.print_formal_lifetime_list(&t.bound_lifetimes));
+        self.print_formal_lifetime_list(&t.bound_lifetimes)?;
         self.print_trait_ref(&t.trait_ref)
     }
 
@@ -1362,27 +1362,27 @@ impl<'a> State<'a> {
                           generics: &ast::Generics, ident: ast::Ident,
                           span: codemap::Span,
                           visibility: ast::Visibility) -> io::Result<()> {
-        try!(self.head(&visibility_qualified(visibility, "enum")));
-        try!(self.print_ident(ident));
-        try!(self.print_generics(generics));
-        try!(self.print_where_clause(&generics.where_clause));
-        try!(space(&mut self.s));
+        self.head(&visibility_qualified(visibility, "enum"))?;
+        self.print_ident(ident)?;
+        self.print_generics(generics)?;
+        self.print_where_clause(&generics.where_clause)?;
+        space(&mut self.s)?;
         self.print_variants(&enum_definition.variants, span)
     }
 
     pub fn print_variants(&mut self,
                           variants: &[ast::Variant],
                           span: codemap::Span) -> io::Result<()> {
-        try!(self.bopen());
+        self.bopen()?;
         for v in variants {
-            try!(self.space_if_not_bol());
-            try!(self.maybe_print_comment(v.span.lo));
-            try!(self.print_outer_attributes(&v.node.attrs));
-            try!(self.ibox(INDENT_UNIT));
-            try!(self.print_variant(v));
-            try!(word(&mut self.s, ","));
-            try!(self.end());
-            try!(self.maybe_print_trailing_comment(v.span, None));
+            self.space_if_not_bol()?;
+            self.maybe_print_comment(v.span.lo)?;
+            self.print_outer_attributes(&v.node.attrs)?;
+            self.ibox(INDENT_UNIT)?;
+            self.print_variant(v)?;
+            word(&mut self.s, ",")?;
+            self.end()?;
+            self.maybe_print_trailing_comment(v.span, None)?;
         }
         self.bclose(span)
     }
@@ -1400,50 +1400,50 @@ impl<'a> State<'a> {
                         ident: ast::Ident,
                         span: codemap::Span,
                         print_finalizer: bool) -> io::Result<()> {
-        try!(self.print_ident(ident));
-        try!(self.print_generics(generics));
+        self.print_ident(ident)?;
+        self.print_generics(generics)?;
         if !struct_def.is_struct() {
             if struct_def.is_tuple() {
-                try!(self.popen());
-                try!(self.commasep(
+                self.popen()?;
+                self.commasep(
                     Inconsistent, struct_def.fields(),
                     |s, field| {
                         match field.node.kind {
                             ast::NamedField(..) => panic!("unexpected named field"),
                             ast::UnnamedField(vis) => {
-                                try!(s.print_visibility(vis));
-                                try!(s.maybe_print_comment(field.span.lo));
+                                s.print_visibility(vis)?;
+                                s.maybe_print_comment(field.span.lo)?;
                                 s.print_type(&field.node.ty)
                             }
                         }
                     }
-                ));
-                try!(self.pclose());
+                )?;
+                self.pclose()?;
             }
-            try!(self.print_where_clause(&generics.where_clause));
+            self.print_where_clause(&generics.where_clause)?;
             if print_finalizer {
-                try!(word(&mut self.s, ";"));
+                word(&mut self.s, ";")?;
             }
-            try!(self.end());
+            self.end()?;
             self.end() // close the outer-box
         } else {
-            try!(self.print_where_clause(&generics.where_clause));
-            try!(self.nbsp());
-            try!(self.bopen());
-            try!(self.hardbreak_if_not_bol());
+            self.print_where_clause(&generics.where_clause)?;
+            self.nbsp()?;
+            self.bopen()?;
+            self.hardbreak_if_not_bol()?;
 
             for field in struct_def.fields() {
                 match field.node.kind {
                     ast::UnnamedField(..) => panic!("unexpected unnamed field"),
                     ast::NamedField(ident, visibility) => {
-                        try!(self.hardbreak_if_not_bol());
-                        try!(self.maybe_print_comment(field.span.lo));
-                        try!(self.print_outer_attributes(&field.node.attrs));
-                        try!(self.print_visibility(visibility));
-                        try!(self.print_ident(ident));
-                        try!(self.word_nbsp(":"));
-                        try!(self.print_type(&field.node.ty));
-                        try!(word(&mut self.s, ","));
+                        self.hardbreak_if_not_bol()?;
+                        self.maybe_print_comment(field.span.lo)?;
+                        self.print_outer_attributes(&field.node.attrs)?;
+                        self.print_visibility(visibility)?;
+                        self.print_ident(ident)?;
+                        self.word_nbsp(":")?;
+                        self.print_type(&field.node.ty)?;
+                        word(&mut self.s, ",")?;
                     }
                 }
             }
@@ -1462,7 +1462,7 @@ impl<'a> State<'a> {
     pub fn print_tt(&mut self, tt: &ast::TokenTree) -> io::Result<()> {
         match *tt {
             TokenTree::Token(_, ref tk) => {
-                try!(word(&mut self.s, &token_to_string(tk)));
+                word(&mut self.s, &token_to_string(tk))?;
                 match *tk {
                     parse::token::DocComment(..) => {
                         hardbreak(&mut self.s)
@@ -1471,21 +1471,21 @@ impl<'a> State<'a> {
                 }
             }
             TokenTree::Delimited(_, ref delimed) => {
-                try!(word(&mut self.s, &token_to_string(&delimed.open_token())));
-                try!(space(&mut self.s));
-                try!(self.print_tts(&delimed.tts));
-                try!(space(&mut self.s));
+                word(&mut self.s, &token_to_string(&delimed.open_token()))?;
+                space(&mut self.s)?;
+                self.print_tts(&delimed.tts)?;
+                space(&mut self.s)?;
                 word(&mut self.s, &token_to_string(&delimed.close_token()))
             },
             TokenTree::Sequence(_, ref seq) => {
-                try!(word(&mut self.s, "$("));
+                word(&mut self.s, "$(")?;
                 for tt_elt in &seq.tts {
-                    try!(self.print_tt(tt_elt));
+                    self.print_tt(tt_elt)?;
                 }
-                try!(word(&mut self.s, ")"));
+                word(&mut self.s, ")")?;
                 match seq.separator {
                     Some(ref tk) => {
-                        try!(word(&mut self.s, &token_to_string(tk)));
+                        word(&mut self.s, &token_to_string(tk))?;
                     }
                     None => {},
                 }
@@ -1498,13 +1498,13 @@ impl<'a> State<'a> {
     }
 
     pub fn print_tts(&mut self, tts: &[ast::TokenTree]) -> io::Result<()> {
-        try!(self.ibox(0));
+        self.ibox(0)?;
         let mut suppress_space = false;
         for (i, tt) in tts.iter().enumerate() {
             if i != 0 && !suppress_space {
-                try!(space(&mut self.s));
+                space(&mut self.s)?;
             }
-            try!(self.print_tt(tt));
+            self.print_tt(tt)?;
             // There should be no space between the module name and the following `::` in paths,
             // otherwise imported macros get re-parsed from crate metadata incorrectly (#20701)
             suppress_space = match *tt {
@@ -1518,13 +1518,13 @@ impl<'a> State<'a> {
     }
 
     pub fn print_variant(&mut self, v: &ast::Variant) -> io::Result<()> {
-        try!(self.head(""));
+        self.head("")?;
         let generics = ast::Generics::default();
-        try!(self.print_struct(&v.node.data, &generics, v.node.name, v.span, false));
+        self.print_struct(&v.node.data, &generics, v.node.name, v.span, false)?;
         match v.node.disr_expr {
             Some(ref d) => {
-                try!(space(&mut self.s));
-                try!(self.word_space("="));
+                space(&mut self.s)?;
+                self.word_space("=")?;
                 self.print_expr(&d)
             }
             _ => Ok(())
@@ -1548,103 +1548,103 @@ impl<'a> State<'a> {
 
     pub fn print_trait_item(&mut self, ti: &ast::TraitItem)
                             -> io::Result<()> {
-        try!(self.ann.pre(self, NodeSubItem(ti.id)));
-        try!(self.hardbreak_if_not_bol());
-        try!(self.maybe_print_comment(ti.span.lo));
-        try!(self.print_outer_attributes(&ti.attrs));
+        self.ann.pre(self, NodeSubItem(ti.id))?;
+        self.hardbreak_if_not_bol()?;
+        self.maybe_print_comment(ti.span.lo)?;
+        self.print_outer_attributes(&ti.attrs)?;
         match ti.node {
             ast::TraitItemKind::Const(ref ty, ref default) => {
-                try!(self.print_associated_const(ti.ident, &ty,
+                self.print_associated_const(ti.ident, &ty,
                                                  default.as_ref().map(|expr| &**expr),
-                                                 ast::Visibility::Inherited));
+                                                 ast::Visibility::Inherited)?;
             }
             ast::TraitItemKind::Method(ref sig, ref body) => {
                 if body.is_some() {
-                    try!(self.head(""));
+                    self.head("")?;
                 }
-                try!(self.print_method_sig(ti.ident, sig, ast::Visibility::Inherited));
+                self.print_method_sig(ti.ident, sig, ast::Visibility::Inherited)?;
                 if let Some(ref body) = *body {
-                    try!(self.nbsp());
-                    try!(self.print_block_with_attrs(body, &ti.attrs));
+                    self.nbsp()?;
+                    self.print_block_with_attrs(body, &ti.attrs)?;
                 } else {
-                    try!(word(&mut self.s, ";"));
+                    word(&mut self.s, ";")?;
                 }
             }
             ast::TraitItemKind::Type(ref bounds, ref default) => {
-                try!(self.print_associated_type(ti.ident, Some(bounds),
-                                                default.as_ref().map(|ty| &**ty)));
+                self.print_associated_type(ti.ident, Some(bounds),
+                                                default.as_ref().map(|ty| &**ty))?;
             }
         }
         self.ann.post(self, NodeSubItem(ti.id))
     }
 
     pub fn print_impl_item(&mut self, ii: &ast::ImplItem) -> io::Result<()> {
-        try!(self.ann.pre(self, NodeSubItem(ii.id)));
-        try!(self.hardbreak_if_not_bol());
-        try!(self.maybe_print_comment(ii.span.lo));
-        try!(self.print_outer_attributes(&ii.attrs));
+        self.ann.pre(self, NodeSubItem(ii.id))?;
+        self.hardbreak_if_not_bol()?;
+        self.maybe_print_comment(ii.span.lo)?;
+        self.print_outer_attributes(&ii.attrs)?;
         if let ast::Defaultness::Default = ii.defaultness {
-            try!(self.word_nbsp("default"));
+            self.word_nbsp("default")?;
         }
         match ii.node {
             ast::ImplItemKind::Const(ref ty, ref expr) => {
-                try!(self.print_associated_const(ii.ident, &ty, Some(&expr), ii.vis));
+                self.print_associated_const(ii.ident, &ty, Some(&expr), ii.vis)?;
             }
             ast::ImplItemKind::Method(ref sig, ref body) => {
-                try!(self.head(""));
-                try!(self.print_method_sig(ii.ident, sig, ii.vis));
-                try!(self.nbsp());
-                try!(self.print_block_with_attrs(body, &ii.attrs));
+                self.head("")?;
+                self.print_method_sig(ii.ident, sig, ii.vis)?;
+                self.nbsp()?;
+                self.print_block_with_attrs(body, &ii.attrs)?;
             }
             ast::ImplItemKind::Type(ref ty) => {
-                try!(self.print_associated_type(ii.ident, None, Some(ty)));
+                self.print_associated_type(ii.ident, None, Some(ty))?;
             }
             ast::ImplItemKind::Macro(codemap::Spanned { ref node, .. }) => {
                 // code copied from ItemKind::Mac:
-                try!(self.print_path(&node.path, false, 0));
-                try!(word(&mut self.s, "! "));
-                try!(self.cbox(INDENT_UNIT));
-                try!(self.popen());
-                try!(self.print_tts(&node.tts[..]));
-                try!(self.pclose());
-                try!(word(&mut self.s, ";"));
-                try!(self.end())
+                self.print_path(&node.path, false, 0)?;
+                word(&mut self.s, "! ")?;
+                self.cbox(INDENT_UNIT)?;
+                self.popen()?;
+                self.print_tts(&node.tts[..])?;
+                self.pclose()?;
+                word(&mut self.s, ";")?;
+                self.end()?
             }
         }
         self.ann.post(self, NodeSubItem(ii.id))
     }
 
     pub fn print_stmt(&mut self, st: &ast::Stmt) -> io::Result<()> {
-        try!(self.maybe_print_comment(st.span.lo));
+        self.maybe_print_comment(st.span.lo)?;
         match st.node {
             ast::StmtKind::Decl(ref decl, _) => {
-                try!(self.print_decl(&decl));
+                self.print_decl(&decl)?;
             }
             ast::StmtKind::Expr(ref expr, _) => {
-                try!(self.space_if_not_bol());
-                try!(self.print_expr_outer_attr_style(&expr, false));
+                self.space_if_not_bol()?;
+                self.print_expr_outer_attr_style(&expr, false)?;
             }
             ast::StmtKind::Semi(ref expr, _) => {
-                try!(self.space_if_not_bol());
-                try!(self.print_expr_outer_attr_style(&expr, false));
-                try!(word(&mut self.s, ";"));
+                self.space_if_not_bol()?;
+                self.print_expr_outer_attr_style(&expr, false)?;
+                word(&mut self.s, ";")?;
             }
             ast::StmtKind::Mac(ref mac, style, ref attrs) => {
-                try!(self.space_if_not_bol());
-                try!(self.print_outer_attributes(attrs.as_attr_slice()));
+                self.space_if_not_bol()?;
+                self.print_outer_attributes(attrs.as_attr_slice())?;
                 let delim = match style {
                     ast::MacStmtStyle::Braces => token::Brace,
                     _ => token::Paren
                 };
-                try!(self.print_mac(&mac, delim));
+                self.print_mac(&mac, delim)?;
                 match style {
                     ast::MacStmtStyle::Braces => {}
-                    _ => try!(word(&mut self.s, ";")),
+                    _ => word(&mut self.s, ";")?,
                 }
             }
         }
         if parse::classify::stmt_ends_with_semi(&st.node) {
-            try!(word(&mut self.s, ";"));
+            word(&mut self.s, ";")?;
         }
         self.maybe_print_trailing_comment(st.span, None)
     }
@@ -1680,27 +1680,27 @@ impl<'a> State<'a> {
                                       attrs: &[ast::Attribute],
                                       close_box: bool) -> io::Result<()> {
         match blk.rules {
-            BlockCheckMode::Unsafe(..) => try!(self.word_space("unsafe")),
+            BlockCheckMode::Unsafe(..) => self.word_space("unsafe")?,
             BlockCheckMode::Default => ()
         }
-        try!(self.maybe_print_comment(blk.span.lo));
-        try!(self.ann.pre(self, NodeBlock(blk)));
-        try!(self.bopen());
+        self.maybe_print_comment(blk.span.lo)?;
+        self.ann.pre(self, NodeBlock(blk))?;
+        self.bopen()?;
 
-        try!(self.print_inner_attributes(attrs));
+        self.print_inner_attributes(attrs)?;
 
         for st in &blk.stmts {
-            try!(self.print_stmt(st));
+            self.print_stmt(st)?;
         }
         match blk.expr {
             Some(ref expr) => {
-                try!(self.space_if_not_bol());
-                try!(self.print_expr_outer_attr_style(&expr, false));
-                try!(self.maybe_print_trailing_comment(expr.span, Some(blk.span.hi)));
+                self.space_if_not_bol()?;
+                self.print_expr_outer_attr_style(&expr, false)?;
+                self.maybe_print_trailing_comment(expr.span, Some(blk.span.hi))?;
             }
             _ => ()
         }
-        try!(self.bclose_maybe_open(blk.span, indented, close_box));
+        self.bclose_maybe_open(blk.span, indented, close_box)?;
         self.ann.post(self, NodeBlock(blk))
     }
 
@@ -1710,32 +1710,32 @@ impl<'a> State<'a> {
                 match _else.node {
                     // "another else-if"
                     ast::ExprKind::If(ref i, ref then, ref e) => {
-                        try!(self.cbox(INDENT_UNIT - 1));
-                        try!(self.ibox(0));
-                        try!(word(&mut self.s, " else if "));
-                        try!(self.print_expr(&i));
-                        try!(space(&mut self.s));
-                        try!(self.print_block(&then));
+                        self.cbox(INDENT_UNIT - 1)?;
+                        self.ibox(0)?;
+                        word(&mut self.s, " else if ")?;
+                        self.print_expr(&i)?;
+                        space(&mut self.s)?;
+                        self.print_block(&then)?;
                         self.print_else(e.as_ref().map(|e| &**e))
                     }
                     // "another else-if-let"
                     ast::ExprKind::IfLet(ref pat, ref expr, ref then, ref e) => {
-                        try!(self.cbox(INDENT_UNIT - 1));
-                        try!(self.ibox(0));
-                        try!(word(&mut self.s, " else if let "));
-                        try!(self.print_pat(&pat));
-                        try!(space(&mut self.s));
-                        try!(self.word_space("="));
-                        try!(self.print_expr(&expr));
-                        try!(space(&mut self.s));
-                        try!(self.print_block(&then));
+                        self.cbox(INDENT_UNIT - 1)?;
+                        self.ibox(0)?;
+                        word(&mut self.s, " else if let ")?;
+                        self.print_pat(&pat)?;
+                        space(&mut self.s)?;
+                        self.word_space("=")?;
+                        self.print_expr(&expr)?;
+                        space(&mut self.s)?;
+                        self.print_block(&then)?;
                         self.print_else(e.as_ref().map(|e| &**e))
                     }
                     // "final else"
                     ast::ExprKind::Block(ref b) => {
-                        try!(self.cbox(INDENT_UNIT - 1));
-                        try!(self.ibox(0));
-                        try!(word(&mut self.s, " else "));
+                        self.cbox(INDENT_UNIT - 1)?;
+                        self.ibox(0)?;
+                        word(&mut self.s, " else ")?;
                         self.print_block(&b)
                     }
                     // BLEAH, constraints would be great here
@@ -1750,38 +1750,38 @@ impl<'a> State<'a> {
 
     pub fn print_if(&mut self, test: &ast::Expr, blk: &ast::Block,
                     elseopt: Option<&ast::Expr>) -> io::Result<()> {
-        try!(self.head("if"));
-        try!(self.print_expr(test));
-        try!(space(&mut self.s));
-        try!(self.print_block(blk));
+        self.head("if")?;
+        self.print_expr(test)?;
+        space(&mut self.s)?;
+        self.print_block(blk)?;
         self.print_else(elseopt)
     }
 
     pub fn print_if_let(&mut self, pat: &ast::Pat, expr: &ast::Expr, blk: &ast::Block,
                         elseopt: Option<&ast::Expr>) -> io::Result<()> {
-        try!(self.head("if let"));
-        try!(self.print_pat(pat));
-        try!(space(&mut self.s));
-        try!(self.word_space("="));
-        try!(self.print_expr(expr));
-        try!(space(&mut self.s));
-        try!(self.print_block(blk));
+        self.head("if let")?;
+        self.print_pat(pat)?;
+        space(&mut self.s)?;
+        self.word_space("=")?;
+        self.print_expr(expr)?;
+        space(&mut self.s)?;
+        self.print_block(blk)?;
         self.print_else(elseopt)
     }
 
     pub fn print_mac(&mut self, m: &ast::Mac, delim: token::DelimToken)
                      -> io::Result<()> {
-        try!(self.print_path(&m.node.path, false, 0));
-        try!(word(&mut self.s, "!"));
+        self.print_path(&m.node.path, false, 0)?;
+        word(&mut self.s, "!")?;
         match delim {
-            token::Paren => try!(self.popen()),
-            token::Bracket => try!(word(&mut self.s, "[")),
+            token::Paren => self.popen()?,
+            token::Bracket => word(&mut self.s, "[")?,
             token::Brace => {
-                try!(self.head(""));
-                try!(self.bopen());
+                self.head("")?;
+                self.bopen()?;
             }
         }
-        try!(self.print_tts(&m.node.tts));
+        self.print_tts(&m.node.tts)?;
         match delim {
             token::Paren => self.pclose(),
             token::Bracket => word(&mut self.s, "]"),
@@ -1791,8 +1791,8 @@ impl<'a> State<'a> {
 
 
     fn print_call_post(&mut self, args: &[P<ast::Expr>]) -> io::Result<()> {
-        try!(self.popen());
-        try!(self.commasep_exprs(Inconsistent, args));
+        self.popen()?;
+        self.commasep_exprs(Inconsistent, args)?;
         self.pclose()
     }
 
@@ -1814,11 +1814,11 @@ impl<'a> State<'a> {
     pub fn print_expr_maybe_paren(&mut self, expr: &ast::Expr) -> io::Result<()> {
         let needs_par = needs_parentheses(expr);
         if needs_par {
-            try!(self.popen());
+            self.popen()?;
         }
-        try!(self.print_expr(expr));
+        self.print_expr(expr)?;
         if needs_par {
-            try!(self.pclose());
+            self.pclose()?;
         }
         Ok(())
     }
@@ -1826,19 +1826,19 @@ impl<'a> State<'a> {
     fn print_expr_in_place(&mut self,
                            place: &ast::Expr,
                            expr: &ast::Expr) -> io::Result<()> {
-        try!(self.print_expr_maybe_paren(place));
-        try!(space(&mut self.s));
-        try!(self.word_space("<-"));
+        self.print_expr_maybe_paren(place)?;
+        space(&mut self.s)?;
+        self.word_space("<-")?;
         self.print_expr_maybe_paren(expr)
     }
 
     fn print_expr_vec(&mut self, exprs: &[P<ast::Expr>],
                       attrs: &[Attribute]) -> io::Result<()> {
-        try!(self.ibox(INDENT_UNIT));
-        try!(word(&mut self.s, "["));
-        try!(self.print_inner_attributes_inline(attrs));
-        try!(self.commasep_exprs(Inconsistent, &exprs[..]));
-        try!(word(&mut self.s, "]"));
+        self.ibox(INDENT_UNIT)?;
+        word(&mut self.s, "[")?;
+        self.print_inner_attributes_inline(attrs)?;
+        self.commasep_exprs(Inconsistent, &exprs[..])?;
+        word(&mut self.s, "]")?;
         self.end()
     }
 
@@ -1846,13 +1846,13 @@ impl<'a> State<'a> {
                          element: &ast::Expr,
                          count: &ast::Expr,
                          attrs: &[Attribute]) -> io::Result<()> {
-        try!(self.ibox(INDENT_UNIT));
-        try!(word(&mut self.s, "["));
-        try!(self.print_inner_attributes_inline(attrs));
-        try!(self.print_expr(element));
-        try!(self.word_space(";"));
-        try!(self.print_expr(count));
-        try!(word(&mut self.s, "]"));
+        self.ibox(INDENT_UNIT)?;
+        word(&mut self.s, "[")?;
+        self.print_inner_attributes_inline(attrs)?;
+        self.print_expr(element)?;
+        self.word_space(";")?;
+        self.print_expr(count)?;
+        word(&mut self.s, "]")?;
         self.end()
     }
 
@@ -1861,46 +1861,46 @@ impl<'a> State<'a> {
                          fields: &[ast::Field],
                          wth: &Option<P<ast::Expr>>,
                          attrs: &[Attribute]) -> io::Result<()> {
-        try!(self.print_path(path, true, 0));
-        try!(word(&mut self.s, "{"));
-        try!(self.print_inner_attributes_inline(attrs));
-        try!(self.commasep_cmnt(
+        self.print_path(path, true, 0)?;
+        word(&mut self.s, "{")?;
+        self.print_inner_attributes_inline(attrs)?;
+        self.commasep_cmnt(
             Consistent,
             &fields[..],
             |s, field| {
-                try!(s.ibox(INDENT_UNIT));
-                try!(s.print_ident(field.ident.node));
-                try!(s.word_space(":"));
-                try!(s.print_expr(&field.expr));
+                s.ibox(INDENT_UNIT)?;
+                s.print_ident(field.ident.node)?;
+                s.word_space(":")?;
+                s.print_expr(&field.expr)?;
                 s.end()
             },
-            |f| f.span));
+            |f| f.span)?;
         match *wth {
             Some(ref expr) => {
-                try!(self.ibox(INDENT_UNIT));
+                self.ibox(INDENT_UNIT)?;
                 if !fields.is_empty() {
-                    try!(word(&mut self.s, ","));
-                    try!(space(&mut self.s));
+                    word(&mut self.s, ",")?;
+                    space(&mut self.s)?;
                 }
-                try!(word(&mut self.s, ".."));
-                try!(self.print_expr(&expr));
-                try!(self.end());
+                word(&mut self.s, "..")?;
+                self.print_expr(&expr)?;
+                self.end()?;
             }
             _ => if !fields.is_empty() {
-                try!(word(&mut self.s, ","))
+                word(&mut self.s, ",")?
             }
         }
-        try!(word(&mut self.s, "}"));
+        word(&mut self.s, "}")?;
         Ok(())
     }
 
     fn print_expr_tup(&mut self, exprs: &[P<ast::Expr>],
                       attrs: &[Attribute]) -> io::Result<()> {
-        try!(self.popen());
-        try!(self.print_inner_attributes_inline(attrs));
-        try!(self.commasep_exprs(Inconsistent, &exprs[..]));
+        self.popen()?;
+        self.print_inner_attributes_inline(attrs)?;
+        self.commasep_exprs(Inconsistent, &exprs[..])?;
         if exprs.len() == 1 {
-            try!(word(&mut self.s, ","));
+            word(&mut self.s, ",")?;
         }
         self.pclose()
     }
@@ -1908,7 +1908,7 @@ impl<'a> State<'a> {
     fn print_expr_call(&mut self,
                        func: &ast::Expr,
                        args: &[P<ast::Expr>]) -> io::Result<()> {
-        try!(self.print_expr_maybe_paren(func));
+        self.print_expr_maybe_paren(func)?;
         self.print_call_post(args)
     }
 
@@ -1917,14 +1917,14 @@ impl<'a> State<'a> {
                               tys: &[P<ast::Ty>],
                               args: &[P<ast::Expr>]) -> io::Result<()> {
         let base_args = &args[1..];
-        try!(self.print_expr(&args[0]));
-        try!(word(&mut self.s, "."));
-        try!(self.print_ident(ident.node));
+        self.print_expr(&args[0])?;
+        word(&mut self.s, ".")?;
+        self.print_ident(ident.node)?;
         if !tys.is_empty() {
-            try!(word(&mut self.s, "::<"));
-            try!(self.commasep(Inconsistent, tys,
-                               |s, ty| s.print_type(&ty)));
-            try!(word(&mut self.s, ">"));
+            word(&mut self.s, "::<")?;
+            self.commasep(Inconsistent, tys,
+                               |s, ty| s.print_type(&ty))?;
+            word(&mut self.s, ">")?;
         }
         self.print_call_post(base_args)
     }
@@ -1934,12 +1934,12 @@ impl<'a> State<'a> {
                          lhs: &ast::Expr,
                          rhs: &ast::Expr) -> io::Result<()> {
         if self.check_expr_bin_needs_paren(lhs, op) {
-            try!(self.print_expr_maybe_paren(lhs));
+            self.print_expr_maybe_paren(lhs)?;
         } else {
-            try!(self.print_expr(lhs));
+            self.print_expr(lhs)?;
         }
-        try!(space(&mut self.s));
-        try!(self.word_space(op.node.to_string()));
+        space(&mut self.s)?;
+        self.word_space(op.node.to_string())?;
         if self.check_expr_bin_needs_paren(rhs, op) {
             self.print_expr_maybe_paren(rhs)
         } else {
@@ -1950,15 +1950,15 @@ impl<'a> State<'a> {
     fn print_expr_unary(&mut self,
                         op: ast::UnOp,
                         expr: &ast::Expr) -> io::Result<()> {
-        try!(word(&mut self.s, ast::UnOp::to_string(op)));
+        word(&mut self.s, ast::UnOp::to_string(op))?;
         self.print_expr_maybe_paren(expr)
     }
 
     fn print_expr_addr_of(&mut self,
                           mutability: ast::Mutability,
                           expr: &ast::Expr) -> io::Result<()> {
-        try!(word(&mut self.s, "&"));
-        try!(self.print_mutability(mutability));
+        word(&mut self.s, "&")?;
+        self.print_mutability(mutability)?;
         self.print_expr_maybe_paren(expr)
     }
 
@@ -1969,139 +1969,139 @@ impl<'a> State<'a> {
     fn print_expr_outer_attr_style(&mut self,
                                   expr: &ast::Expr,
                                   is_inline: bool) -> io::Result<()> {
-        try!(self.maybe_print_comment(expr.span.lo));
+        self.maybe_print_comment(expr.span.lo)?;
 
         let attrs = expr.attrs.as_attr_slice();
         if is_inline {
-            try!(self.print_outer_attributes_inline(attrs));
+            self.print_outer_attributes_inline(attrs)?;
         } else {
-            try!(self.print_outer_attributes(attrs));
+            self.print_outer_attributes(attrs)?;
         }
 
-        try!(self.ibox(INDENT_UNIT));
-        try!(self.ann.pre(self, NodeExpr(expr)));
+        self.ibox(INDENT_UNIT)?;
+        self.ann.pre(self, NodeExpr(expr))?;
         match expr.node {
             ast::ExprKind::Box(ref expr) => {
-                try!(self.word_space("box"));
-                try!(self.print_expr(expr));
+                self.word_space("box")?;
+                self.print_expr(expr)?;
             }
             ast::ExprKind::InPlace(ref place, ref expr) => {
-                try!(self.print_expr_in_place(place, expr));
+                self.print_expr_in_place(place, expr)?;
             }
             ast::ExprKind::Vec(ref exprs) => {
-                try!(self.print_expr_vec(&exprs[..], attrs));
+                self.print_expr_vec(&exprs[..], attrs)?;
             }
             ast::ExprKind::Repeat(ref element, ref count) => {
-                try!(self.print_expr_repeat(&element, &count, attrs));
+                self.print_expr_repeat(&element, &count, attrs)?;
             }
             ast::ExprKind::Struct(ref path, ref fields, ref wth) => {
-                try!(self.print_expr_struct(path, &fields[..], wth, attrs));
+                self.print_expr_struct(path, &fields[..], wth, attrs)?;
             }
             ast::ExprKind::Tup(ref exprs) => {
-                try!(self.print_expr_tup(&exprs[..], attrs));
+                self.print_expr_tup(&exprs[..], attrs)?;
             }
             ast::ExprKind::Call(ref func, ref args) => {
-                try!(self.print_expr_call(&func, &args[..]));
+                self.print_expr_call(&func, &args[..])?;
             }
             ast::ExprKind::MethodCall(ident, ref tys, ref args) => {
-                try!(self.print_expr_method_call(ident, &tys[..], &args[..]));
+                self.print_expr_method_call(ident, &tys[..], &args[..])?;
             }
             ast::ExprKind::Binary(op, ref lhs, ref rhs) => {
-                try!(self.print_expr_binary(op, &lhs, &rhs));
+                self.print_expr_binary(op, &lhs, &rhs)?;
             }
             ast::ExprKind::Unary(op, ref expr) => {
-                try!(self.print_expr_unary(op, &expr));
+                self.print_expr_unary(op, &expr)?;
             }
             ast::ExprKind::AddrOf(m, ref expr) => {
-                try!(self.print_expr_addr_of(m, &expr));
+                self.print_expr_addr_of(m, &expr)?;
             }
             ast::ExprKind::Lit(ref lit) => {
-                try!(self.print_literal(&lit));
+                self.print_literal(&lit)?;
             }
             ast::ExprKind::Cast(ref expr, ref ty) => {
                 if let ast::ExprKind::Cast(..) = expr.node {
-                    try!(self.print_expr(&expr));
+                    self.print_expr(&expr)?;
                 } else {
-                    try!(self.print_expr_maybe_paren(&expr));
+                    self.print_expr_maybe_paren(&expr)?;
                 }
-                try!(space(&mut self.s));
-                try!(self.word_space("as"));
-                try!(self.print_type(&ty));
+                space(&mut self.s)?;
+                self.word_space("as")?;
+                self.print_type(&ty)?;
             }
             ast::ExprKind::Type(ref expr, ref ty) => {
-                try!(self.print_expr(&expr));
-                try!(self.word_space(":"));
-                try!(self.print_type(&ty));
+                self.print_expr(&expr)?;
+                self.word_space(":")?;
+                self.print_type(&ty)?;
             }
             ast::ExprKind::If(ref test, ref blk, ref elseopt) => {
-                try!(self.print_if(&test, &blk, elseopt.as_ref().map(|e| &**e)));
+                self.print_if(&test, &blk, elseopt.as_ref().map(|e| &**e))?;
             }
             ast::ExprKind::IfLet(ref pat, ref expr, ref blk, ref elseopt) => {
-                try!(self.print_if_let(&pat, &expr, &blk, elseopt.as_ref().map(|e| &**e)));
+                self.print_if_let(&pat, &expr, &blk, elseopt.as_ref().map(|e| &**e))?;
             }
             ast::ExprKind::While(ref test, ref blk, opt_ident) => {
                 if let Some(ident) = opt_ident {
-                    try!(self.print_ident(ident));
-                    try!(self.word_space(":"));
+                    self.print_ident(ident)?;
+                    self.word_space(":")?;
                 }
-                try!(self.head("while"));
-                try!(self.print_expr(&test));
-                try!(space(&mut self.s));
-                try!(self.print_block_with_attrs(&blk, attrs));
+                self.head("while")?;
+                self.print_expr(&test)?;
+                space(&mut self.s)?;
+                self.print_block_with_attrs(&blk, attrs)?;
             }
             ast::ExprKind::WhileLet(ref pat, ref expr, ref blk, opt_ident) => {
                 if let Some(ident) = opt_ident {
-                    try!(self.print_ident(ident));
-                    try!(self.word_space(":"));
+                    self.print_ident(ident)?;
+                    self.word_space(":")?;
                 }
-                try!(self.head("while let"));
-                try!(self.print_pat(&pat));
-                try!(space(&mut self.s));
-                try!(self.word_space("="));
-                try!(self.print_expr(&expr));
-                try!(space(&mut self.s));
-                try!(self.print_block_with_attrs(&blk, attrs));
+                self.head("while let")?;
+                self.print_pat(&pat)?;
+                space(&mut self.s)?;
+                self.word_space("=")?;
+                self.print_expr(&expr)?;
+                space(&mut self.s)?;
+                self.print_block_with_attrs(&blk, attrs)?;
             }
             ast::ExprKind::ForLoop(ref pat, ref iter, ref blk, opt_ident) => {
                 if let Some(ident) = opt_ident {
-                    try!(self.print_ident(ident));
-                    try!(self.word_space(":"));
+                    self.print_ident(ident)?;
+                    self.word_space(":")?;
                 }
-                try!(self.head("for"));
-                try!(self.print_pat(&pat));
-                try!(space(&mut self.s));
-                try!(self.word_space("in"));
-                try!(self.print_expr(&iter));
-                try!(space(&mut self.s));
-                try!(self.print_block_with_attrs(&blk, attrs));
+                self.head("for")?;
+                self.print_pat(&pat)?;
+                space(&mut self.s)?;
+                self.word_space("in")?;
+                self.print_expr(&iter)?;
+                space(&mut self.s)?;
+                self.print_block_with_attrs(&blk, attrs)?;
             }
             ast::ExprKind::Loop(ref blk, opt_ident) => {
                 if let Some(ident) = opt_ident {
-                    try!(self.print_ident(ident));
-                    try!(self.word_space(":"));
+                    self.print_ident(ident)?;
+                    self.word_space(":")?;
                 }
-                try!(self.head("loop"));
-                try!(space(&mut self.s));
-                try!(self.print_block_with_attrs(&blk, attrs));
+                self.head("loop")?;
+                space(&mut self.s)?;
+                self.print_block_with_attrs(&blk, attrs)?;
             }
             ast::ExprKind::Match(ref expr, ref arms) => {
-                try!(self.cbox(INDENT_UNIT));
-                try!(self.ibox(4));
-                try!(self.word_nbsp("match"));
-                try!(self.print_expr(&expr));
-                try!(space(&mut self.s));
-                try!(self.bopen());
-                try!(self.print_inner_attributes_no_trailing_hardbreak(attrs));
+                self.cbox(INDENT_UNIT)?;
+                self.ibox(4)?;
+                self.word_nbsp("match")?;
+                self.print_expr(&expr)?;
+                space(&mut self.s)?;
+                self.bopen()?;
+                self.print_inner_attributes_no_trailing_hardbreak(attrs)?;
                 for arm in arms {
-                    try!(self.print_arm(arm));
+                    self.print_arm(arm)?;
                 }
-                try!(self.bclose_(expr.span, INDENT_UNIT));
+                self.bclose_(expr.span, INDENT_UNIT)?;
             }
             ast::ExprKind::Closure(capture_clause, ref decl, ref body) => {
-                try!(self.print_capture_clause(capture_clause));
+                self.print_capture_clause(capture_clause)?;
 
-                try!(self.print_fn_block_args(&decl));
-                try!(space(&mut self.s));
+                self.print_fn_block_args(&decl)?;
+                space(&mut self.s)?;
 
                 let default_return = match decl.output {
                     ast::FunctionRetTy::Default(..) => true,
@@ -2109,148 +2109,148 @@ impl<'a> State<'a> {
                 };
 
                 if !default_return || !body.stmts.is_empty() || body.expr.is_none() {
-                    try!(self.print_block_unclosed(&body));
+                    self.print_block_unclosed(&body)?;
                 } else {
                     // we extract the block, so as not to create another set of boxes
                     let i_expr = body.expr.as_ref().unwrap();
                     match i_expr.node {
                         ast::ExprKind::Block(ref blk) => {
-                            try!(self.print_block_unclosed_with_attrs(
+                            self.print_block_unclosed_with_attrs(
                                 &blk,
-                                i_expr.attrs.as_attr_slice()));
+                                i_expr.attrs.as_attr_slice())?;
                         }
                         _ => {
                             // this is a bare expression
-                            try!(self.print_expr(&i_expr));
-                            try!(self.end()); // need to close a box
+                            self.print_expr(&i_expr)?;
+                            self.end()?; // need to close a box
                         }
                     }
                 }
                 // a box will be closed by print_expr, but we didn't want an overall
                 // wrapper so we closed the corresponding opening. so create an
                 // empty box to satisfy the close.
-                try!(self.ibox(0));
+                self.ibox(0)?;
             }
             ast::ExprKind::Block(ref blk) => {
                 // containing cbox, will be closed by print-block at }
-                try!(self.cbox(INDENT_UNIT));
+                self.cbox(INDENT_UNIT)?;
                 // head-box, will be closed by print-block after {
-                try!(self.ibox(0));
-                try!(self.print_block_with_attrs(&blk, attrs));
+                self.ibox(0)?;
+                self.print_block_with_attrs(&blk, attrs)?;
             }
             ast::ExprKind::Assign(ref lhs, ref rhs) => {
-                try!(self.print_expr(&lhs));
-                try!(space(&mut self.s));
-                try!(self.word_space("="));
-                try!(self.print_expr(&rhs));
+                self.print_expr(&lhs)?;
+                space(&mut self.s)?;
+                self.word_space("=")?;
+                self.print_expr(&rhs)?;
             }
             ast::ExprKind::AssignOp(op, ref lhs, ref rhs) => {
-                try!(self.print_expr(&lhs));
-                try!(space(&mut self.s));
-                try!(word(&mut self.s, op.node.to_string()));
-                try!(self.word_space("="));
-                try!(self.print_expr(&rhs));
+                self.print_expr(&lhs)?;
+                space(&mut self.s)?;
+                word(&mut self.s, op.node.to_string())?;
+                self.word_space("=")?;
+                self.print_expr(&rhs)?;
             }
             ast::ExprKind::Field(ref expr, id) => {
-                try!(self.print_expr(&expr));
-                try!(word(&mut self.s, "."));
-                try!(self.print_ident(id.node));
+                self.print_expr(&expr)?;
+                word(&mut self.s, ".")?;
+                self.print_ident(id.node)?;
             }
             ast::ExprKind::TupField(ref expr, id) => {
-                try!(self.print_expr(&expr));
-                try!(word(&mut self.s, "."));
-                try!(self.print_usize(id.node));
+                self.print_expr(&expr)?;
+                word(&mut self.s, ".")?;
+                self.print_usize(id.node)?;
             }
             ast::ExprKind::Index(ref expr, ref index) => {
-                try!(self.print_expr(&expr));
-                try!(word(&mut self.s, "["));
-                try!(self.print_expr(&index));
-                try!(word(&mut self.s, "]"));
+                self.print_expr(&expr)?;
+                word(&mut self.s, "[")?;
+                self.print_expr(&index)?;
+                word(&mut self.s, "]")?;
             }
             ast::ExprKind::Range(ref start, ref end, limits) => {
                 if let &Some(ref e) = start {
-                    try!(self.print_expr(&e));
+                    self.print_expr(&e)?;
                 }
                 if limits == ast::RangeLimits::HalfOpen {
-                    try!(word(&mut self.s, ".."));
+                    word(&mut self.s, "..")?;
                 } else {
-                    try!(word(&mut self.s, "..."));
+                    word(&mut self.s, "...")?;
                 }
                 if let &Some(ref e) = end {
-                    try!(self.print_expr(&e));
+                    self.print_expr(&e)?;
                 }
             }
             ast::ExprKind::Path(None, ref path) => {
-                try!(self.print_path(path, true, 0))
+                self.print_path(path, true, 0)?
             }
             ast::ExprKind::Path(Some(ref qself), ref path) => {
-                try!(self.print_qpath(path, qself, true))
+                self.print_qpath(path, qself, true)?
             }
             ast::ExprKind::Break(opt_ident) => {
-                try!(word(&mut self.s, "break"));
-                try!(space(&mut self.s));
+                word(&mut self.s, "break")?;
+                space(&mut self.s)?;
                 if let Some(ident) = opt_ident {
-                    try!(self.print_ident(ident.node));
-                    try!(space(&mut self.s));
+                    self.print_ident(ident.node)?;
+                    space(&mut self.s)?;
                 }
             }
             ast::ExprKind::Again(opt_ident) => {
-                try!(word(&mut self.s, "continue"));
-                try!(space(&mut self.s));
+                word(&mut self.s, "continue")?;
+                space(&mut self.s)?;
                 if let Some(ident) = opt_ident {
-                    try!(self.print_ident(ident.node));
-                    try!(space(&mut self.s))
+                    self.print_ident(ident.node)?;
+                    space(&mut self.s)?
                 }
             }
             ast::ExprKind::Ret(ref result) => {
-                try!(word(&mut self.s, "return"));
+                word(&mut self.s, "return")?;
                 match *result {
                     Some(ref expr) => {
-                        try!(word(&mut self.s, " "));
-                        try!(self.print_expr(&expr));
+                        word(&mut self.s, " ")?;
+                        self.print_expr(&expr)?;
                     }
                     _ => ()
                 }
             }
             ast::ExprKind::InlineAsm(ref a) => {
-                try!(word(&mut self.s, "asm!"));
-                try!(self.popen());
-                try!(self.print_string(&a.asm, a.asm_str_style));
-                try!(self.word_space(":"));
+                word(&mut self.s, "asm!")?;
+                self.popen()?;
+                self.print_string(&a.asm, a.asm_str_style)?;
+                self.word_space(":")?;
 
-                try!(self.commasep(Inconsistent, &a.outputs,
+                self.commasep(Inconsistent, &a.outputs,
                                    |s, out| {
                     match out.constraint.slice_shift_char() {
                         Some(('=', operand)) if out.is_rw => {
-                            try!(s.print_string(&format!("+{}", operand),
-                                                ast::StrStyle::Cooked))
+                            s.print_string(&format!("+{}", operand),
+                                                ast::StrStyle::Cooked)?
                         }
-                        _ => try!(s.print_string(&out.constraint, ast::StrStyle::Cooked))
+                        _ => s.print_string(&out.constraint, ast::StrStyle::Cooked)?
                     }
-                    try!(s.popen());
-                    try!(s.print_expr(&out.expr));
-                    try!(s.pclose());
+                    s.popen()?;
+                    s.print_expr(&out.expr)?;
+                    s.pclose()?;
                     Ok(())
-                }));
-                try!(space(&mut self.s));
-                try!(self.word_space(":"));
+                })?;
+                space(&mut self.s)?;
+                self.word_space(":")?;
 
-                try!(self.commasep(Inconsistent, &a.inputs,
+                self.commasep(Inconsistent, &a.inputs,
                                    |s, &(ref co, ref o)| {
-                    try!(s.print_string(&co, ast::StrStyle::Cooked));
-                    try!(s.popen());
-                    try!(s.print_expr(&o));
-                    try!(s.pclose());
+                    s.print_string(&co, ast::StrStyle::Cooked)?;
+                    s.popen()?;
+                    s.print_expr(&o)?;
+                    s.pclose()?;
                     Ok(())
-                }));
-                try!(space(&mut self.s));
-                try!(self.word_space(":"));
+                })?;
+                space(&mut self.s)?;
+                self.word_space(":")?;
 
-                try!(self.commasep(Inconsistent, &a.clobbers,
+                self.commasep(Inconsistent, &a.clobbers,
                                    |s, co| {
-                    try!(s.print_string(&co, ast::StrStyle::Cooked));
+                    s.print_string(&co, ast::StrStyle::Cooked)?;
                     Ok(())
-                }));
+                })?;
 
                 let mut options = vec!();
                 if a.volatile {
@@ -2264,58 +2264,58 @@ impl<'a> State<'a> {
                 }
 
                 if !options.is_empty() {
-                    try!(space(&mut self.s));
-                    try!(self.word_space(":"));
-                    try!(self.commasep(Inconsistent, &options,
+                    space(&mut self.s)?;
+                    self.word_space(":")?;
+                    self.commasep(Inconsistent, &options,
                                        |s, &co| {
-                        try!(s.print_string(co, ast::StrStyle::Cooked));
+                        s.print_string(co, ast::StrStyle::Cooked)?;
                         Ok(())
-                    }));
+                    })?;
                 }
 
-                try!(self.pclose());
+                self.pclose()?;
             }
-            ast::ExprKind::Mac(ref m) => try!(self.print_mac(m, token::Paren)),
+            ast::ExprKind::Mac(ref m) => self.print_mac(m, token::Paren)?,
             ast::ExprKind::Paren(ref e) => {
-                try!(self.popen());
-                try!(self.print_inner_attributes_inline(attrs));
-                try!(self.print_expr(&e));
-                try!(self.pclose());
+                self.popen()?;
+                self.print_inner_attributes_inline(attrs)?;
+                self.print_expr(&e)?;
+                self.pclose()?;
             },
             ast::ExprKind::Try(ref e) => {
-                try!(self.print_expr(e));
-                try!(word(&mut self.s, "?"))
+                self.print_expr(e)?;
+                word(&mut self.s, "?")?
             }
         }
-        try!(self.ann.post(self, NodeExpr(expr)));
+        self.ann.post(self, NodeExpr(expr))?;
         self.end()
     }
 
     pub fn print_local_decl(&mut self, loc: &ast::Local) -> io::Result<()> {
-        try!(self.print_pat(&loc.pat));
+        self.print_pat(&loc.pat)?;
         if let Some(ref ty) = loc.ty {
-            try!(self.word_space(":"));
-            try!(self.print_type(&ty));
+            self.word_space(":")?;
+            self.print_type(&ty)?;
         }
         Ok(())
     }
 
     pub fn print_decl(&mut self, decl: &ast::Decl) -> io::Result<()> {
-        try!(self.maybe_print_comment(decl.span.lo));
+        self.maybe_print_comment(decl.span.lo)?;
         match decl.node {
             ast::DeclKind::Local(ref loc) => {
-                try!(self.print_outer_attributes(loc.attrs.as_attr_slice()));
-                try!(self.space_if_not_bol());
-                try!(self.ibox(INDENT_UNIT));
-                try!(self.word_nbsp("let"));
+                self.print_outer_attributes(loc.attrs.as_attr_slice())?;
+                self.space_if_not_bol()?;
+                self.ibox(INDENT_UNIT)?;
+                self.word_nbsp("let")?;
 
-                try!(self.ibox(INDENT_UNIT));
-                try!(self.print_local_decl(&loc));
-                try!(self.end());
+                self.ibox(INDENT_UNIT)?;
+                self.print_local_decl(&loc)?;
+                self.end()?;
                 if let Some(ref init) = loc.init {
-                    try!(self.nbsp());
-                    try!(self.word_space("="));
-                    try!(self.print_expr(&init));
+                    self.nbsp()?;
+                    self.word_space("=")?;
+                    self.print_expr(&init)?;
                 }
                 self.end()
             }
@@ -2324,7 +2324,7 @@ impl<'a> State<'a> {
     }
 
     pub fn print_ident(&mut self, ident: ast::Ident) -> io::Result<()> {
-        try!(word(&mut self.s, &ident.name.as_str()));
+        word(&mut self.s, &ident.name.as_str())?;
         self.ann.post(self, NodeIdent(&ident))
     }
 
@@ -2333,15 +2333,15 @@ impl<'a> State<'a> {
     }
 
     pub fn print_name(&mut self, name: ast::Name) -> io::Result<()> {
-        try!(word(&mut self.s, &name.as_str()));
+        word(&mut self.s, &name.as_str())?;
         self.ann.post(self, NodeName(&name))
     }
 
     pub fn print_for_decl(&mut self, loc: &ast::Local,
                           coll: &ast::Expr) -> io::Result<()> {
-        try!(self.print_local_decl(loc));
-        try!(space(&mut self.s));
-        try!(self.word_space("in"));
+        self.print_local_decl(loc)?;
+        space(&mut self.s)?;
+        self.word_space("in")?;
         self.print_expr(coll)
     }
 
@@ -2351,19 +2351,19 @@ impl<'a> State<'a> {
                   depth: usize)
                   -> io::Result<()>
     {
-        try!(self.maybe_print_comment(path.span.lo));
+        self.maybe_print_comment(path.span.lo)?;
 
         let mut first = !path.global;
         for segment in &path.segments[..path.segments.len()-depth] {
             if first {
                 first = false
             } else {
-                try!(word(&mut self.s, "::"))
+                word(&mut self.s, "::")?
             }
 
-            try!(self.print_ident(segment.identifier));
+            self.print_ident(segment.identifier)?;
 
-            try!(self.print_path_parameters(&segment.parameters, colons_before_params));
+            self.print_path_parameters(&segment.parameters, colons_before_params)?;
         }
 
         Ok(())
@@ -2375,18 +2375,18 @@ impl<'a> State<'a> {
                    colons_before_params: bool)
                    -> io::Result<()>
     {
-        try!(word(&mut self.s, "<"));
-        try!(self.print_type(&qself.ty));
+        word(&mut self.s, "<")?;
+        self.print_type(&qself.ty)?;
         if qself.position > 0 {
-            try!(space(&mut self.s));
-            try!(self.word_space("as"));
+            space(&mut self.s)?;
+            self.word_space("as")?;
             let depth = path.segments.len() - qself.position;
-            try!(self.print_path(&path, false, depth));
+            self.print_path(&path, false, depth)?;
         }
-        try!(word(&mut self.s, ">"));
-        try!(word(&mut self.s, "::"));
+        word(&mut self.s, ">")?;
+        word(&mut self.s, "::")?;
         let item_segment = path.segments.last().unwrap();
-        try!(self.print_ident(item_segment.identifier));
+        self.print_ident(item_segment.identifier)?;
         self.print_path_parameters(&item_segment.parameters, colons_before_params)
     }
 
@@ -2400,61 +2400,61 @@ impl<'a> State<'a> {
         }
 
         if colons_before_params {
-            try!(word(&mut self.s, "::"))
+            word(&mut self.s, "::")?
         }
 
         match *parameters {
             ast::PathParameters::AngleBracketed(ref data) => {
-                try!(word(&mut self.s, "<"));
+                word(&mut self.s, "<")?;
 
                 let mut comma = false;
                 for lifetime in &data.lifetimes {
                     if comma {
-                        try!(self.word_space(","))
+                        self.word_space(",")?
                     }
-                    try!(self.print_lifetime(lifetime));
+                    self.print_lifetime(lifetime)?;
                     comma = true;
                 }
 
                 if !data.types.is_empty() {
                     if comma {
-                        try!(self.word_space(","))
+                        self.word_space(",")?
                     }
-                    try!(self.commasep(
+                    self.commasep(
                         Inconsistent,
                         &data.types,
-                        |s, ty| s.print_type(&ty)));
+                        |s, ty| s.print_type(&ty))?;
                         comma = true;
                 }
 
                 for binding in data.bindings.iter() {
                     if comma {
-                        try!(self.word_space(","))
+                        self.word_space(",")?
                     }
-                    try!(self.print_ident(binding.ident));
-                    try!(space(&mut self.s));
-                    try!(self.word_space("="));
-                    try!(self.print_type(&binding.ty));
+                    self.print_ident(binding.ident)?;
+                    space(&mut self.s)?;
+                    self.word_space("=")?;
+                    self.print_type(&binding.ty)?;
                     comma = true;
                 }
 
-                try!(word(&mut self.s, ">"))
+                word(&mut self.s, ">")?
             }
 
             ast::PathParameters::Parenthesized(ref data) => {
-                try!(word(&mut self.s, "("));
-                try!(self.commasep(
+                word(&mut self.s, "(")?;
+                self.commasep(
                     Inconsistent,
                     &data.inputs,
-                    |s, ty| s.print_type(&ty)));
-                try!(word(&mut self.s, ")"));
+                    |s, ty| s.print_type(&ty))?;
+                word(&mut self.s, ")")?;
 
                 match data.output {
                     None => { }
                     Some(ref ty) => {
-                        try!(self.space_if_not_bol());
-                        try!(self.word_space("->"));
-                        try!(self.print_type(&ty));
+                        self.space_if_not_bol()?;
+                        self.word_space("->")?;
+                        self.print_type(&ty)?;
                     }
                 }
             }
@@ -2464,120 +2464,120 @@ impl<'a> State<'a> {
     }
 
     pub fn print_pat(&mut self, pat: &ast::Pat) -> io::Result<()> {
-        try!(self.maybe_print_comment(pat.span.lo));
-        try!(self.ann.pre(self, NodePat(pat)));
+        self.maybe_print_comment(pat.span.lo)?;
+        self.ann.pre(self, NodePat(pat))?;
         /* Pat isn't normalized, but the beauty of it
          is that it doesn't matter */
         match pat.node {
-            PatKind::Wild => try!(word(&mut self.s, "_")),
+            PatKind::Wild => word(&mut self.s, "_")?,
             PatKind::Ident(binding_mode, ref path1, ref sub) => {
                 match binding_mode {
                     ast::BindingMode::ByRef(mutbl) => {
-                        try!(self.word_nbsp("ref"));
-                        try!(self.print_mutability(mutbl));
+                        self.word_nbsp("ref")?;
+                        self.print_mutability(mutbl)?;
                     }
                     ast::BindingMode::ByValue(ast::Mutability::Immutable) => {}
                     ast::BindingMode::ByValue(ast::Mutability::Mutable) => {
-                        try!(self.word_nbsp("mut"));
+                        self.word_nbsp("mut")?;
                     }
                 }
-                try!(self.print_ident(path1.node));
+                self.print_ident(path1.node)?;
                 match *sub {
                     Some(ref p) => {
-                        try!(word(&mut self.s, "@"));
-                        try!(self.print_pat(&p));
+                        word(&mut self.s, "@")?;
+                        self.print_pat(&p)?;
                     }
                     None => ()
                 }
             }
             PatKind::TupleStruct(ref path, ref args_) => {
-                try!(self.print_path(path, true, 0));
+                self.print_path(path, true, 0)?;
                 match *args_ {
-                    None => try!(word(&mut self.s, "(..)")),
+                    None => word(&mut self.s, "(..)")?,
                     Some(ref args) => {
-                        try!(self.popen());
-                        try!(self.commasep(Inconsistent, &args[..],
-                                          |s, p| s.print_pat(&p)));
-                        try!(self.pclose());
+                        self.popen()?;
+                        self.commasep(Inconsistent, &args[..],
+                                          |s, p| s.print_pat(&p))?;
+                        self.pclose()?;
                     }
                 }
             }
             PatKind::Path(ref path) => {
-                try!(self.print_path(path, true, 0));
+                self.print_path(path, true, 0)?;
             }
             PatKind::QPath(ref qself, ref path) => {
-                try!(self.print_qpath(path, qself, false));
+                self.print_qpath(path, qself, false)?;
             }
             PatKind::Struct(ref path, ref fields, etc) => {
-                try!(self.print_path(path, true, 0));
-                try!(self.nbsp());
-                try!(self.word_space("{"));
-                try!(self.commasep_cmnt(
+                self.print_path(path, true, 0)?;
+                self.nbsp()?;
+                self.word_space("{")?;
+                self.commasep_cmnt(
                     Consistent, &fields[..],
                     |s, f| {
-                        try!(s.cbox(INDENT_UNIT));
+                        s.cbox(INDENT_UNIT)?;
                         if !f.node.is_shorthand {
-                            try!(s.print_ident(f.node.ident));
-                            try!(s.word_nbsp(":"));
+                            s.print_ident(f.node.ident)?;
+                            s.word_nbsp(":")?;
                         }
-                        try!(s.print_pat(&f.node.pat));
+                        s.print_pat(&f.node.pat)?;
                         s.end()
                     },
-                    |f| f.node.pat.span));
+                    |f| f.node.pat.span)?;
                 if etc {
-                    if !fields.is_empty() { try!(self.word_space(",")); }
-                    try!(word(&mut self.s, ".."));
+                    if !fields.is_empty() { self.word_space(",")?; }
+                    word(&mut self.s, "..")?;
                 }
-                try!(space(&mut self.s));
-                try!(word(&mut self.s, "}"));
+                space(&mut self.s)?;
+                word(&mut self.s, "}")?;
             }
             PatKind::Tup(ref elts) => {
-                try!(self.popen());
-                try!(self.commasep(Inconsistent,
+                self.popen()?;
+                self.commasep(Inconsistent,
                                    &elts[..],
-                                   |s, p| s.print_pat(&p)));
+                                   |s, p| s.print_pat(&p))?;
                 if elts.len() == 1 {
-                    try!(word(&mut self.s, ","));
+                    word(&mut self.s, ",")?;
                 }
-                try!(self.pclose());
+                self.pclose()?;
             }
             PatKind::Box(ref inner) => {
-                try!(word(&mut self.s, "box "));
-                try!(self.print_pat(&inner));
+                word(&mut self.s, "box ")?;
+                self.print_pat(&inner)?;
             }
             PatKind::Ref(ref inner, mutbl) => {
-                try!(word(&mut self.s, "&"));
+                word(&mut self.s, "&")?;
                 if mutbl == ast::Mutability::Mutable {
-                    try!(word(&mut self.s, "mut "));
+                    word(&mut self.s, "mut ")?;
                 }
-                try!(self.print_pat(&inner));
+                self.print_pat(&inner)?;
             }
-            PatKind::Lit(ref e) => try!(self.print_expr(&**e)),
+            PatKind::Lit(ref e) => self.print_expr(&**e)?,
             PatKind::Range(ref begin, ref end) => {
-                try!(self.print_expr(&begin));
-                try!(space(&mut self.s));
-                try!(word(&mut self.s, "..."));
-                try!(self.print_expr(&end));
+                self.print_expr(&begin)?;
+                space(&mut self.s)?;
+                word(&mut self.s, "...")?;
+                self.print_expr(&end)?;
             }
             PatKind::Vec(ref before, ref slice, ref after) => {
-                try!(word(&mut self.s, "["));
-                try!(self.commasep(Inconsistent,
+                word(&mut self.s, "[")?;
+                self.commasep(Inconsistent,
                                    &before[..],
-                                   |s, p| s.print_pat(&p)));
+                                   |s, p| s.print_pat(&p))?;
                 if let Some(ref p) = *slice {
-                    if !before.is_empty() { try!(self.word_space(",")); }
+                    if !before.is_empty() { self.word_space(",")?; }
                     if p.node != PatKind::Wild {
-                        try!(self.print_pat(&p));
+                        self.print_pat(&p)?;
                     }
-                    try!(word(&mut self.s, ".."));
-                    if !after.is_empty() { try!(self.word_space(",")); }
+                    word(&mut self.s, "..")?;
+                    if !after.is_empty() { self.word_space(",")?; }
                 }
-                try!(self.commasep(Inconsistent,
+                self.commasep(Inconsistent,
                                    &after[..],
-                                   |s, p| s.print_pat(&p)));
-                try!(word(&mut self.s, "]"));
+                                   |s, p| s.print_pat(&p))?;
+                word(&mut self.s, "]")?;
             }
-            PatKind::Mac(ref m) => try!(self.print_mac(m, token::Paren)),
+            PatKind::Mac(ref m) => self.print_mac(m, token::Paren)?,
         }
         self.ann.post(self, NodePat(pat))
     }
@@ -2586,43 +2586,43 @@ impl<'a> State<'a> {
         // I have no idea why this check is necessary, but here it
         // is :(
         if arm.attrs.is_empty() {
-            try!(space(&mut self.s));
+            space(&mut self.s)?;
         }
-        try!(self.cbox(INDENT_UNIT));
-        try!(self.ibox(0));
-        try!(self.print_outer_attributes(&arm.attrs));
+        self.cbox(INDENT_UNIT)?;
+        self.ibox(0)?;
+        self.print_outer_attributes(&arm.attrs)?;
         let mut first = true;
         for p in &arm.pats {
             if first {
                 first = false;
             } else {
-                try!(space(&mut self.s));
-                try!(self.word_space("|"));
+                space(&mut self.s)?;
+                self.word_space("|")?;
             }
-            try!(self.print_pat(&p));
+            self.print_pat(&p)?;
         }
-        try!(space(&mut self.s));
+        space(&mut self.s)?;
         if let Some(ref e) = arm.guard {
-            try!(self.word_space("if"));
-            try!(self.print_expr(&e));
-            try!(space(&mut self.s));
+            self.word_space("if")?;
+            self.print_expr(&e)?;
+            space(&mut self.s)?;
         }
-        try!(self.word_space("=>"));
+        self.word_space("=>")?;
 
         match arm.body.node {
             ast::ExprKind::Block(ref blk) => {
                 // the block will close the pattern's ibox
-                try!(self.print_block_unclosed_indent(&blk, INDENT_UNIT));
+                self.print_block_unclosed_indent(&blk, INDENT_UNIT)?;
 
                 // If it is a user-provided unsafe block, print a comma after it
                 if let BlockCheckMode::Unsafe(ast::UserProvided) = blk.rules {
-                    try!(word(&mut self.s, ","));
+                    word(&mut self.s, ",")?;
                 }
             }
             _ => {
-                try!(self.end()); // close the ibox for the pattern
-                try!(self.print_expr(&arm.body));
-                try!(word(&mut self.s, ","));
+                self.end()?; // close the ibox for the pattern
+                self.print_expr(&arm.body)?;
+                word(&mut self.s, ",")?;
             }
         }
         self.end() // close enclosing cbox
@@ -2632,22 +2632,22 @@ impl<'a> State<'a> {
     fn print_explicit_self(&mut self,
                            explicit_self: &ast::SelfKind,
                            mutbl: ast::Mutability) -> io::Result<bool> {
-        try!(self.print_mutability(mutbl));
+        self.print_mutability(mutbl)?;
         match *explicit_self {
             ast::SelfKind::Static => { return Ok(false); }
             ast::SelfKind::Value(_) => {
-                try!(word(&mut self.s, "self"));
+                word(&mut self.s, "self")?;
             }
             ast::SelfKind::Region(ref lt, m, _) => {
-                try!(word(&mut self.s, "&"));
-                try!(self.print_opt_lifetime(lt));
-                try!(self.print_mutability(m));
-                try!(word(&mut self.s, "self"));
+                word(&mut self.s, "&")?;
+                self.print_opt_lifetime(lt)?;
+                self.print_mutability(m)?;
+                word(&mut self.s, "self")?;
             }
             ast::SelfKind::Explicit(ref typ, _) => {
-                try!(word(&mut self.s, "self"));
-                try!(self.word_space(":"));
-                try!(self.print_type(&typ));
+                word(&mut self.s, "self")?;
+                self.word_space(":")?;
+                self.print_type(&typ)?;
             }
         }
         return Ok(true);
@@ -2662,14 +2662,14 @@ impl<'a> State<'a> {
                     generics: &ast::Generics,
                     opt_explicit_self: Option<&ast::SelfKind>,
                     vis: ast::Visibility) -> io::Result<()> {
-        try!(self.print_fn_header_info(unsafety, constness, abi, vis));
+        self.print_fn_header_info(unsafety, constness, abi, vis)?;
 
         if let Some(name) = name {
-            try!(self.nbsp());
-            try!(self.print_ident(name));
+            self.nbsp()?;
+            self.print_ident(name)?;
         }
-        try!(self.print_generics(generics));
-        try!(self.print_fn_args_and_ret(decl, opt_explicit_self));
+        self.print_generics(generics)?;
+        self.print_fn_args_and_ret(decl, opt_explicit_self)?;
         self.print_where_clause(&generics.where_clause)
     }
 
@@ -2678,7 +2678,7 @@ impl<'a> State<'a> {
                          is_closure: bool) -> io::Result<()> {
         // It is unfortunate to duplicate the commasep logic, but we want the
         // self type and the args all in the same box.
-        try!(self.rbox(0, Inconsistent));
+        self.rbox(0, Inconsistent)?;
         let mut first = true;
         if let Some(explicit_self) = opt_explicit_self {
             let m = match *explicit_self {
@@ -2688,7 +2688,7 @@ impl<'a> State<'a> {
                     _ => ast::Mutability::Immutable
                 }
             };
-            first = !try!(self.print_explicit_self(explicit_self, m));
+            first = !self.print_explicit_self(explicit_self, m)?;
         }
 
         // HACK(eddyb) ignore the separately printed self argument.
@@ -2699,8 +2699,8 @@ impl<'a> State<'a> {
         };
 
         for arg in args {
-            if first { first = false; } else { try!(self.word_space(",")); }
-            try!(self.print_arg(arg, is_closure));
+            if first { first = false; } else { self.word_space(",")?; }
+            self.print_arg(arg, is_closure)?;
         }
 
         self.end()
@@ -2709,12 +2709,12 @@ impl<'a> State<'a> {
     pub fn print_fn_args_and_ret(&mut self, decl: &ast::FnDecl,
                                  opt_explicit_self: Option<&ast::SelfKind>)
         -> io::Result<()> {
-        try!(self.popen());
-        try!(self.print_fn_args(decl, opt_explicit_self, false));
+        self.popen()?;
+        self.print_fn_args(decl, opt_explicit_self, false)?;
         if decl.variadic {
-            try!(word(&mut self.s, ", ..."));
+            word(&mut self.s, ", ...")?;
         }
-        try!(self.pclose());
+        self.pclose()?;
 
         self.print_fn_output(decl)
     }
@@ -2723,24 +2723,24 @@ impl<'a> State<'a> {
             &mut self,
             decl: &ast::FnDecl)
             -> io::Result<()> {
-        try!(word(&mut self.s, "|"));
-        try!(self.print_fn_args(decl, None, true));
-        try!(word(&mut self.s, "|"));
+        word(&mut self.s, "|")?;
+        self.print_fn_args(decl, None, true)?;
+        word(&mut self.s, "|")?;
 
         if let ast::FunctionRetTy::Default(..) = decl.output {
             return Ok(());
         }
 
-        try!(self.space_if_not_bol());
-        try!(self.word_space("->"));
+        self.space_if_not_bol()?;
+        self.word_space("->")?;
         match decl.output {
             ast::FunctionRetTy::Ty(ref ty) => {
-                try!(self.print_type(&ty));
+                self.print_type(&ty)?;
                 self.maybe_print_comment(ty.span.lo)
             }
             ast::FunctionRetTy::Default(..) => unreachable!(),
             ast::FunctionRetTy::None(span) => {
-                try!(self.word_nbsp("!"));
+                self.word_nbsp("!")?;
                 self.maybe_print_comment(span.lo)
             }
         }
@@ -2759,28 +2759,28 @@ impl<'a> State<'a> {
                         bounds: &[ast::TyParamBound])
                         -> io::Result<()> {
         if !bounds.is_empty() {
-            try!(word(&mut self.s, prefix));
+            word(&mut self.s, prefix)?;
             let mut first = true;
             for bound in bounds {
-                try!(self.nbsp());
+                self.nbsp()?;
                 if first {
                     first = false;
                 } else {
-                    try!(self.word_space("+"));
+                    self.word_space("+")?;
                 }
 
-                try!(match *bound {
+                match *bound {
                     TraitTyParamBound(ref tref, TraitBoundModifier::None) => {
                         self.print_poly_trait_ref(tref)
                     }
                     TraitTyParamBound(ref tref, TraitBoundModifier::Maybe) => {
-                        try!(word(&mut self.s, "?"));
+                        word(&mut self.s, "?")?;
                         self.print_poly_trait_ref(tref)
                     }
                     RegionTyParamBound(ref lt) => {
                         self.print_lifetime(lt)
                     }
-                })
+                }?
             }
             Ok(())
         } else {
@@ -2799,11 +2799,11 @@ impl<'a> State<'a> {
                               lifetime: &ast::LifetimeDef)
                               -> io::Result<()>
     {
-        try!(self.print_lifetime(&lifetime.lifetime));
+        self.print_lifetime(&lifetime.lifetime)?;
         let mut sep = ":";
         for v in &lifetime.bounds {
-            try!(word(&mut self.s, sep));
-            try!(self.print_lifetime(v));
+            word(&mut self.s, sep)?;
+            self.print_lifetime(v)?;
             sep = "+";
         }
         Ok(())
@@ -2818,14 +2818,14 @@ impl<'a> State<'a> {
             return Ok(());
         }
 
-        try!(word(&mut self.s, "<"));
+        word(&mut self.s, "<")?;
 
         let mut ints = Vec::new();
         for i in 0..total {
             ints.push(i);
         }
 
-        try!(self.commasep(Inconsistent, &ints[..], |s, &idx| {
+        self.commasep(Inconsistent, &ints[..], |s, &idx| {
             if idx < generics.lifetimes.len() {
                 let lifetime = &generics.lifetimes[idx];
                 s.print_lifetime_def(lifetime)
@@ -2834,19 +2834,19 @@ impl<'a> State<'a> {
                 let param = &generics.ty_params[idx];
                 s.print_ty_param(param)
             }
-        }));
+        })?;
 
-        try!(word(&mut self.s, ">"));
+        word(&mut self.s, ">")?;
         Ok(())
     }
 
     pub fn print_ty_param(&mut self, param: &ast::TyParam) -> io::Result<()> {
-        try!(self.print_ident(param.ident));
-        try!(self.print_bounds(":", &param.bounds));
+        self.print_ident(param.ident)?;
+        self.print_bounds(":", &param.bounds)?;
         match param.default {
             Some(ref default) => {
-                try!(space(&mut self.s));
-                try!(self.word_space("="));
+                space(&mut self.s)?;
+                self.word_space("=")?;
                 self.print_type(&default)
             }
             _ => Ok(())
@@ -2859,12 +2859,12 @@ impl<'a> State<'a> {
             return Ok(())
         }
 
-        try!(space(&mut self.s));
-        try!(self.word_space("where"));
+        space(&mut self.s)?;
+        self.word_space("where")?;
 
         for (i, predicate) in where_clause.predicates.iter().enumerate() {
             if i != 0 {
-                try!(self.word_space(","));
+                self.word_space(",")?;
             }
 
             match *predicate {
@@ -2872,29 +2872,29 @@ impl<'a> State<'a> {
                                                                              ref bounded_ty,
                                                                              ref bounds,
                                                                              ..}) => {
-                    try!(self.print_formal_lifetime_list(bound_lifetimes));
-                    try!(self.print_type(&bounded_ty));
-                    try!(self.print_bounds(":", bounds));
+                    self.print_formal_lifetime_list(bound_lifetimes)?;
+                    self.print_type(&bounded_ty)?;
+                    self.print_bounds(":", bounds)?;
                 }
                 ast::WherePredicate::RegionPredicate(ast::WhereRegionPredicate{ref lifetime,
                                                                                ref bounds,
                                                                                ..}) => {
-                    try!(self.print_lifetime(lifetime));
-                    try!(word(&mut self.s, ":"));
+                    self.print_lifetime(lifetime)?;
+                    word(&mut self.s, ":")?;
 
                     for (i, bound) in bounds.iter().enumerate() {
-                        try!(self.print_lifetime(bound));
+                        self.print_lifetime(bound)?;
 
                         if i != 0 {
-                            try!(word(&mut self.s, ":"));
+                            word(&mut self.s, ":")?;
                         }
                     }
                 }
                 ast::WherePredicate::EqPredicate(ast::WhereEqPredicate{ref path, ref ty, ..}) => {
-                    try!(self.print_path(path, false, 0));
-                    try!(space(&mut self.s));
-                    try!(self.word_space("="));
-                    try!(self.print_type(&ty));
+                    self.print_path(path, false, 0)?;
+                    space(&mut self.s)?;
+                    self.word_space("=")?;
+                    self.print_type(&ty)?;
                 }
             }
         }
@@ -2905,52 +2905,52 @@ impl<'a> State<'a> {
     pub fn print_view_path(&mut self, vp: &ast::ViewPath) -> io::Result<()> {
         match vp.node {
             ast::ViewPathSimple(ident, ref path) => {
-                try!(self.print_path(path, false, 0));
+                self.print_path(path, false, 0)?;
 
                 if path.segments.last().unwrap().identifier.name !=
                         ident.name {
-                    try!(space(&mut self.s));
-                    try!(self.word_space("as"));
-                    try!(self.print_ident(ident));
+                    space(&mut self.s)?;
+                    self.word_space("as")?;
+                    self.print_ident(ident)?;
                 }
 
                 Ok(())
             }
 
             ast::ViewPathGlob(ref path) => {
-                try!(self.print_path(path, false, 0));
+                self.print_path(path, false, 0)?;
                 word(&mut self.s, "::*")
             }
 
             ast::ViewPathList(ref path, ref idents) => {
                 if path.segments.is_empty() {
-                    try!(word(&mut self.s, "{"));
+                    word(&mut self.s, "{")?;
                 } else {
-                    try!(self.print_path(path, false, 0));
-                    try!(word(&mut self.s, "::{"));
+                    self.print_path(path, false, 0)?;
+                    word(&mut self.s, "::{")?;
                 }
-                try!(self.commasep(Inconsistent, &idents[..], |s, w| {
+                self.commasep(Inconsistent, &idents[..], |s, w| {
                     match w.node {
                         ast::PathListItemKind::Ident { name, rename, .. } => {
-                            try!(s.print_ident(name));
+                            s.print_ident(name)?;
                             if let Some(ident) = rename {
-                                try!(space(&mut s.s));
-                                try!(s.word_space("as"));
-                                try!(s.print_ident(ident));
+                                space(&mut s.s)?;
+                                s.word_space("as")?;
+                                s.print_ident(ident)?;
                             }
                             Ok(())
                         },
                         ast::PathListItemKind::Mod { rename, .. } => {
-                            try!(word(&mut s.s, "self"));
+                            word(&mut s.s, "self")?;
                             if let Some(ident) = rename {
-                                try!(space(&mut s.s));
-                                try!(s.word_space("as"));
-                                try!(s.print_ident(ident));
+                                space(&mut s.s)?;
+                                s.word_space("as")?;
+                                s.print_ident(ident)?;
                             }
                             Ok(())
                         }
                     }
-                }));
+                })?;
                 word(&mut self.s, "}")
             }
         }
@@ -2965,14 +2965,14 @@ impl<'a> State<'a> {
     }
 
     pub fn print_mt(&mut self, mt: &ast::MutTy) -> io::Result<()> {
-        try!(self.print_mutability(mt.mutbl));
+        self.print_mutability(mt.mutbl)?;
         self.print_type(&mt.ty)
     }
 
     pub fn print_arg(&mut self, input: &ast::Arg, is_closure: bool) -> io::Result<()> {
-        try!(self.ibox(INDENT_UNIT));
+        self.ibox(INDENT_UNIT)?;
         match input.ty.node {
-            ast::TyKind::Infer if is_closure => try!(self.print_pat(&input.pat)),
+            ast::TyKind::Infer if is_closure => self.print_pat(&input.pat)?,
             _ => {
                 match input.pat.node {
                     PatKind::Ident(_, ref path1, _) if
@@ -2981,12 +2981,12 @@ impl<'a> State<'a> {
                         // Do nothing.
                     }
                     _ => {
-                        try!(self.print_pat(&input.pat));
-                        try!(word(&mut self.s, ":"));
-                        try!(space(&mut self.s));
+                        self.print_pat(&input.pat)?;
+                        word(&mut self.s, ":")?;
+                        space(&mut self.s)?;
                     }
                 }
-                try!(self.print_type(&input.ty));
+                self.print_type(&input.ty)?;
             }
         }
         self.end()
@@ -2997,17 +2997,17 @@ impl<'a> State<'a> {
             return Ok(());
         }
 
-        try!(self.space_if_not_bol());
-        try!(self.ibox(INDENT_UNIT));
-        try!(self.word_space("->"));
+        self.space_if_not_bol()?;
+        self.ibox(INDENT_UNIT)?;
+        self.word_space("->")?;
         match decl.output {
             ast::FunctionRetTy::None(_) =>
-                try!(self.word_nbsp("!")),
+                self.word_nbsp("!")?,
             ast::FunctionRetTy::Default(..) => unreachable!(),
             ast::FunctionRetTy::Ty(ref ty) =>
-                try!(self.print_type(&ty))
+                self.print_type(&ty)?
         }
-        try!(self.end());
+        self.end()?;
 
         match decl.output {
             ast::FunctionRetTy::Ty(ref output) => self.maybe_print_comment(output.span.lo),
@@ -3023,10 +3023,10 @@ impl<'a> State<'a> {
                        generics: &ast::Generics,
                        opt_explicit_self: Option<&ast::SelfKind>)
                        -> io::Result<()> {
-        try!(self.ibox(INDENT_UNIT));
+        self.ibox(INDENT_UNIT)?;
         if !generics.lifetimes.is_empty() || !generics.ty_params.is_empty() {
-            try!(word(&mut self.s, "for"));
-            try!(self.print_generics(generics));
+            word(&mut self.s, "for")?;
+            self.print_generics(generics)?;
         }
         let generics = ast::Generics {
             lifetimes: Vec::new(),
@@ -3036,14 +3036,14 @@ impl<'a> State<'a> {
                 predicates: Vec::new(),
             },
         };
-        try!(self.print_fn(decl,
+        self.print_fn(decl,
                            unsafety,
                            ast::Constness::NotConst,
                            abi,
                            name,
                            &generics,
                            opt_explicit_self,
-                           ast::Visibility::Inherited));
+                           ast::Visibility::Inherited)?;
         self.end()
     }
 
@@ -3063,7 +3063,7 @@ impl<'a> State<'a> {
                 match next_pos { None => (), Some(p) => next = p }
                 if span.hi < (*cmnt).pos && (*cmnt).pos < next &&
                     span_line.line == comment_line.line {
-                        try!(self.print_comment(cmnt));
+                        self.print_comment(cmnt)?;
                         self.cur_cmnt_and_lit.cur_cmnt += 1;
                     }
             }
@@ -3076,12 +3076,12 @@ impl<'a> State<'a> {
         // If there aren't any remaining comments, then we need to manually
         // make sure there is a line break at the end.
         if self.next_comment().is_none() {
-            try!(hardbreak(&mut self.s));
+            hardbreak(&mut self.s)?;
         }
         loop {
             match self.next_comment() {
                 Some(ref cmnt) => {
-                    try!(self.print_comment(cmnt));
+                    self.print_comment(cmnt)?;
                     self.cur_cmnt_and_lit.cur_cmnt += 1;
                 }
                 _ => break
@@ -3096,7 +3096,7 @@ impl<'a> State<'a> {
         match opt_abi {
             Some(Abi::Rust) => Ok(()),
             Some(abi) => {
-                try!(self.word_nbsp("extern"));
+                self.word_nbsp("extern")?;
                 self.word_nbsp(&abi.to_string())
             }
             None => Ok(())
@@ -3107,7 +3107,7 @@ impl<'a> State<'a> {
                                 opt_abi: Option<Abi>) -> io::Result<()> {
         match opt_abi {
             Some(abi) => {
-                try!(self.word_nbsp("extern"));
+                self.word_nbsp("extern")?;
                 self.word_nbsp(&abi.to_string())
             }
             None => Ok(())
@@ -3119,18 +3119,18 @@ impl<'a> State<'a> {
                                 constness: ast::Constness,
                                 abi: Abi,
                                 vis: ast::Visibility) -> io::Result<()> {
-        try!(word(&mut self.s, &visibility_qualified(vis, "")));
+        word(&mut self.s, &visibility_qualified(vis, ""))?;
 
         match constness {
             ast::Constness::NotConst => {}
-            ast::Constness::Const => try!(self.word_nbsp("const"))
+            ast::Constness::Const => self.word_nbsp("const")?
         }
 
-        try!(self.print_unsafety(unsafety));
+        self.print_unsafety(unsafety)?;
 
         if abi != Abi::Rust {
-            try!(self.word_nbsp("extern"));
-            try!(self.word_nbsp(&abi.to_string()));
+            self.word_nbsp("extern")?;
+            self.word_nbsp(&abi.to_string())?;
         }
 
         word(&mut self.s, "fn")

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -388,7 +388,7 @@ pub fn fun_to_string(decl: &ast::FnDecl,
     to_string(|s| {
         s.head("")?;
         s.print_fn(decl, unsafety, constness, Abi::Rust, Some(name),
-                        generics, opt_explicit_self, ast::Visibility::Inherited)?;
+                   generics, opt_explicit_self, ast::Visibility::Inherited)?;
         s.end()?; // Close the head box
         s.end() // Close the outer box
     })
@@ -779,8 +779,8 @@ pub trait PrintState<'a> {
                 word(self.writer(), &name)?;
                 self.popen()?;
                 self.commasep(Consistent,
-                                   &items[..],
-                                   |s, i| s.print_meta_item(&i))?;
+                              &items[..],
+                              |s, i| s.print_meta_item(&i))?;
                 self.pclose()?;
             }
         }
@@ -915,7 +915,7 @@ impl<'a> State<'a> {
             if i < len {
                 word(&mut self.s, ",")?;
                 self.maybe_print_trailing_comment(get_span(elt),
-                                                    Some(get_span(&elts[i]).hi))?;
+                                                  Some(get_span(&elts[i]).hi))?;
                 self.space_if_not_bol()?;
             }
         }
@@ -979,7 +979,7 @@ impl<'a> State<'a> {
             ast::TyKind::Tup(ref elts) => {
                 self.popen()?;
                 self.commasep(Inconsistent, &elts[..],
-                                   |s, ty| s.print_type(&ty))?;
+                              |s, ty| s.print_type(&ty))?;
                 if elts.len() == 1 {
                     word(&mut self.s, ",")?;
                 }
@@ -1000,11 +1000,11 @@ impl<'a> State<'a> {
                     },
                 };
                 self.print_ty_fn(f.abi,
-                                      f.unsafety,
-                                      &f.decl,
-                                      None,
-                                      &generics,
-                                      None)?;
+                                 f.unsafety,
+                                 &f.decl,
+                                 None,
+                                 &generics,
+                                 None)?;
             }
             ast::TyKind::Path(None, ref path) => {
                 self.print_path(path, false, 0)?;
@@ -1050,16 +1050,15 @@ impl<'a> State<'a> {
             ast::ForeignItemKind::Fn(ref decl, ref generics) => {
                 self.head("")?;
                 self.print_fn(decl, ast::Unsafety::Normal,
-                                   ast::Constness::NotConst,
-                                   Abi::Rust, Some(item.ident),
-                                   generics, None, item.vis)?;
+                              ast::Constness::NotConst,
+                              Abi::Rust, Some(item.ident),
+                              generics, None, item.vis)?;
                 self.end()?; // end head-ibox
                 word(&mut self.s, ";")?;
                 self.end() // end the outer fn box
             }
             ast::ForeignItemKind::Static(ref t, m) => {
-                self.head(&visibility_qualified(item.vis,
-                                                    "static"))?;
+                self.head(&visibility_qualified(item.vis, "static"))?;
                 if m {
                     self.word_space("mut")?;
                 }
@@ -1119,8 +1118,7 @@ impl<'a> State<'a> {
         self.ann.pre(self, NodeItem(item))?;
         match item.node {
             ast::ItemKind::ExternCrate(ref optional_path) => {
-                self.head(&visibility_qualified(item.vis,
-                                                     "extern crate"))?;
+                self.head(&visibility_qualified(item.vis, "extern crate"))?;
                 if let Some(p) = *optional_path {
                     let val = p.as_str();
                     if val.contains("-") {
@@ -1138,16 +1136,14 @@ impl<'a> State<'a> {
                 self.end()?; // end outer head-block
             }
             ast::ItemKind::Use(ref vp) => {
-                self.head(&visibility_qualified(item.vis,
-                                                     "use"))?;
+                self.head(&visibility_qualified(item.vis, "use"))?;
                 self.print_view_path(&vp)?;
                 word(&mut self.s, ";")?;
                 self.end()?; // end inner head-block
                 self.end()?; // end outer head-block
             }
             ast::ItemKind::Static(ref ty, m, ref expr) => {
-                self.head(&visibility_qualified(item.vis,
-                                                    "static"))?;
+                self.head(&visibility_qualified(item.vis, "static"))?;
                 if m == ast::Mutability::Mutable {
                     self.word_space("mut")?;
                 }
@@ -1163,8 +1159,7 @@ impl<'a> State<'a> {
                 self.end()?; // end the outer cbox
             }
             ast::ItemKind::Const(ref ty, ref expr) => {
-                self.head(&visibility_qualified(item.vis,
-                                                    "const"))?;
+                self.head(&visibility_qualified(item.vis, "const"))?;
                 self.print_ident(item.ident)?;
                 self.word_space(":")?;
                 self.print_type(&ty)?;
@@ -1192,8 +1187,7 @@ impl<'a> State<'a> {
                 self.print_block_with_attrs(&body, &item.attrs)?;
             }
             ast::ItemKind::Mod(ref _mod) => {
-                self.head(&visibility_qualified(item.vis,
-                                                    "mod"))?;
+                self.head(&visibility_qualified(item.vis, "mod"))?;
                 self.print_ident(item.ident)?;
                 self.nbsp()?;
                 self.bopen()?;
@@ -1555,8 +1549,8 @@ impl<'a> State<'a> {
         match ti.node {
             ast::TraitItemKind::Const(ref ty, ref default) => {
                 self.print_associated_const(ti.ident, &ty,
-                                                 default.as_ref().map(|expr| &**expr),
-                                                 ast::Visibility::Inherited)?;
+                                            default.as_ref().map(|expr| &**expr),
+                                            ast::Visibility::Inherited)?;
             }
             ast::TraitItemKind::Method(ref sig, ref body) => {
                 if body.is_some() {
@@ -1572,7 +1566,7 @@ impl<'a> State<'a> {
             }
             ast::TraitItemKind::Type(ref bounds, ref default) => {
                 self.print_associated_type(ti.ident, Some(bounds),
-                                                default.as_ref().map(|ty| &**ty))?;
+                                           default.as_ref().map(|ty| &**ty))?;
             }
         }
         self.ann.post(self, NodeSubItem(ti.id))
@@ -1923,7 +1917,7 @@ impl<'a> State<'a> {
         if !tys.is_empty() {
             word(&mut self.s, "::<")?;
             self.commasep(Inconsistent, tys,
-                               |s, ty| s.print_type(&ty))?;
+                          |s, ty| s.print_type(&ty))?;
             word(&mut self.s, ">")?;
         }
         self.print_call_post(base_args)
@@ -2223,7 +2217,7 @@ impl<'a> State<'a> {
                     match out.constraint.slice_shift_char() {
                         Some(('=', operand)) if out.is_rw => {
                             s.print_string(&format!("+{}", operand),
-                                                ast::StrStyle::Cooked)?
+                                           ast::StrStyle::Cooked)?
                         }
                         _ => s.print_string(&out.constraint, ast::StrStyle::Cooked)?
                     }
@@ -2267,10 +2261,10 @@ impl<'a> State<'a> {
                     space(&mut self.s)?;
                     self.word_space(":")?;
                     self.commasep(Inconsistent, &options,
-                                       |s, &co| {
-                        s.print_string(co, ast::StrStyle::Cooked)?;
-                        Ok(())
-                    })?;
+                                  |s, &co| {
+                                      s.print_string(co, ast::StrStyle::Cooked)?;
+                                      Ok(())
+                                  })?;
                 }
 
                 self.pclose()?;
@@ -3037,13 +3031,13 @@ impl<'a> State<'a> {
             },
         };
         self.print_fn(decl,
-                           unsafety,
-                           ast::Constness::NotConst,
-                           abi,
-                           name,
-                           &generics,
-                           opt_explicit_self,
-                           ast::Visibility::Inherited)?;
+                      unsafety,
+                      ast::Constness::NotConst,
+                      abi,
+                      name,
+                      &generics,
+                      opt_explicit_self,
+                      ast::Visibility::Inherited)?;
         self.end()
     }
 

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -59,6 +59,7 @@
 #![cfg_attr(windows, feature(libc))]
 // Handle rustfmt skips
 #![feature(custom_attribute)]
+#![feature(question_mark)]
 #![allow(unused_attributes)]
 
 use std::io::prelude::*;

--- a/src/libterm/terminfo/mod.rs
+++ b/src/libterm/terminfo/mod.rs
@@ -109,7 +109,7 @@ impl TermInfo {
     }
     // Keep the metadata small
     fn _from_path(path: &Path) -> Result<TermInfo, Error> {
-        let file = try!(File::open(path).map_err(|e| Error::IoError(e)));
+        let file = File::open(path).map_err(|e| Error::IoError(e))?;
         let mut reader = BufReader::new(file);
         parse(&mut reader, false).map_err(|e| Error::MalformedTerminfo(e))
     }

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -209,7 +209,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables) -> Result<Vec<
                     'd' | 'o' | 'x' | 'X' | 's' => {
                         if let Some(arg) = stack.pop() {
                             let flags = Flags::new();
-                            let res = try!(format(arg, FormatOp::from_char(cur), flags));
+                            let res = format(arg, FormatOp::from_char(cur), flags)?;
                             output.extend(res.iter().map(|x| *x));
                         } else {
                             return Err("stack is empty".to_string());
@@ -317,7 +317,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables) -> Result<Vec<
                 match (*fstate, cur) {
                     (_, 'd') | (_, 'o') | (_, 'x') | (_, 'X') | (_, 's') => {
                         if let Some(arg) = stack.pop() {
-                            let res = try!(format(arg, FormatOp::from_char(cur), *flags));
+                            let res = format(arg, FormatOp::from_char(cur), *flags)?;
                             output.extend(res.iter().map(|x| *x));
                             // will cause state to go to Nothing
                             old_state = FormatPattern(*flags, *fstate);

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -467,7 +467,7 @@ struct ConsoleTestState<T> {
 impl<T: Write> ConsoleTestState<T> {
     pub fn new(opts: &TestOpts, _: Option<T>) -> io::Result<ConsoleTestState<io::Stdout>> {
         let log_out = match opts.logfile {
-            Some(ref path) => Some(try!(File::create(path))),
+            Some(ref path) => Some(File::create(path)?),
             None => None,
         };
         let out = match term::stdout() {
@@ -516,7 +516,7 @@ impl<T: Write> ConsoleTestState<T> {
         if self.quiet {
             self.write_pretty(quiet, color)
         } else {
-            try!(self.write_pretty(verbose, color));
+            self.write_pretty(verbose, color)?;
             self.write_plain("\n")
         }
     }
@@ -525,16 +525,16 @@ impl<T: Write> ConsoleTestState<T> {
         match self.out {
             Pretty(ref mut term) => {
                 if self.use_color {
-                    try!(term.fg(color));
+                    term.fg(color)?;
                 }
-                try!(term.write_all(word.as_bytes()));
+                term.write_all(word.as_bytes())?;
                 if self.use_color {
-                    try!(term.reset());
+                    term.reset()?;
                 }
                 term.flush()
             }
             Raw(ref mut stdout) => {
-                try!(stdout.write_all(word.as_bytes()));
+                stdout.write_all(word.as_bytes())?;
                 stdout.flush()
             }
         }
@@ -543,11 +543,11 @@ impl<T: Write> ConsoleTestState<T> {
     pub fn write_plain(&mut self, s: &str) -> io::Result<()> {
         match self.out {
             Pretty(ref mut term) => {
-                try!(term.write_all(s.as_bytes()));
+                term.write_all(s.as_bytes())?;
                 term.flush()
             }
             Raw(ref mut stdout) => {
-                try!(stdout.write_all(s.as_bytes()));
+                stdout.write_all(s.as_bytes())?;
                 stdout.flush()
             }
         }
@@ -578,11 +578,11 @@ impl<T: Write> ConsoleTestState<T> {
             TrFailed => self.write_failed(),
             TrIgnored => self.write_ignored(),
             TrMetrics(ref mm) => {
-                try!(self.write_metric());
+                self.write_metric()?;
                 self.write_plain(&format!(": {}\n", mm.fmt_metrics()))
             }
             TrBench(ref bs) => {
-                try!(self.write_bench());
+                self.write_bench()?;
                 self.write_plain(&format!(": {}\n", fmt_bench_samples(bs)))
             }
         }
@@ -607,7 +607,7 @@ impl<T: Write> ConsoleTestState<T> {
     }
 
     pub fn write_failures(&mut self) -> io::Result<()> {
-        try!(self.write_plain("\nfailures:\n"));
+        self.write_plain("\nfailures:\n")?;
         let mut failures = Vec::new();
         let mut fail_out = String::new();
         for &(ref f, ref stdout) in &self.failures {
@@ -620,14 +620,14 @@ impl<T: Write> ConsoleTestState<T> {
             }
         }
         if !fail_out.is_empty() {
-            try!(self.write_plain("\n"));
-            try!(self.write_plain(&fail_out));
+            self.write_plain("\n")?;
+            self.write_plain(&fail_out)?;
         }
 
-        try!(self.write_plain("\nfailures:\n"));
+        self.write_plain("\nfailures:\n")?;
         failures.sort();
         for name in &failures {
-            try!(self.write_plain(&format!("    {}\n", name)));
+            self.write_plain(&format!("    {}\n", name))?;
         }
         Ok(())
     }
@@ -637,22 +637,22 @@ impl<T: Write> ConsoleTestState<T> {
 
         let success = self.failed == 0;
         if !success {
-            try!(self.write_failures());
+            self.write_failures()?;
         }
 
-        try!(self.write_plain("\ntest result: "));
+        self.write_plain("\ntest result: ")?;
         if success {
             // There's no parallelism at this point so it's safe to use color
-            try!(self.write_pretty("ok", term::color::GREEN));
+            self.write_pretty("ok", term::color::GREEN)?;
         } else {
-            try!(self.write_pretty("FAILED", term::color::RED));
+            self.write_pretty("FAILED", term::color::RED)?;
         }
         let s = format!(". {} passed; {} failed; {} ignored; {} measured\n\n",
                         self.passed,
                         self.failed,
                         self.ignored,
                         self.measured);
-        try!(self.write_plain(&s));
+        self.write_plain(&s)?;
         return Ok(success);
     }
 }
@@ -706,8 +706,8 @@ pub fn run_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Resu
             TeFiltered(ref filtered_tests) => st.write_run_start(filtered_tests.len()),
             TeWait(ref test, padding) => st.write_test_start(test, padding),
             TeResult(test, result, stdout) => {
-                try!(st.write_log(&test, &result));
-                try!(st.write_result(&result));
+                st.write_log(&test, &result)?;
+                st.write_result(&result)?;
                 match result {
                     TrOk => st.passed += 1,
                     TrIgnored => st.ignored += 1,
@@ -736,7 +736,7 @@ pub fn run_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Resu
         }
     }
 
-    let mut st = try!(ConsoleTestState::new(opts, None::<io::Stdout>));
+    let mut st = ConsoleTestState::new(opts, None::<io::Stdout>)?;
     fn len_if_padded(t: &TestDescAndFn) -> usize {
         match t.testfn.padding() {
             PadNone => 0,
@@ -750,7 +750,7 @@ pub fn run_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Resu
         }
         None => {}
     }
-    try!(run_tests(opts, tests, |x| callback(&x, &mut st)));
+    run_tests(opts, tests, |x| callback(&x, &mut st))?;
     return st.write_run_finish();
 }
 
@@ -846,7 +846,7 @@ fn run_tests<F>(opts: &TestOpts, tests: Vec<TestDescAndFn>, mut callback: F) -> 
                                        .map(|t| t.desc.clone())
                                        .collect();
 
-    try!(callback(TeFiltered(filtered_descs)));
+    callback(TeFiltered(filtered_descs))?;
 
     let (filtered_tests, filtered_benchs_and_metrics): (Vec<_>, _) =
         filtered_tests.into_iter().partition(|e| {
@@ -873,7 +873,7 @@ fn run_tests<F>(opts: &TestOpts, tests: Vec<TestDescAndFn>, mut callback: F) -> 
                 // We are doing one test at a time so we can print the name
                 // of the test before we run it. Useful for debugging tests
                 // that hang forever.
-                try!(callback(TeWait(test.desc.clone(), test.testfn.padding())));
+                callback(TeWait(test.desc.clone(), test.testfn.padding()))?;
             }
             run_test(opts, !opts.run_tests, test, tx.clone());
             pending += 1;
@@ -881,9 +881,9 @@ fn run_tests<F>(opts: &TestOpts, tests: Vec<TestDescAndFn>, mut callback: F) -> 
 
         let (desc, result, stdout) = rx.recv().unwrap();
         if concurrency != 1 {
-            try!(callback(TeWait(desc.clone(), PadNone)));
+            callback(TeWait(desc.clone(), PadNone))?;
         }
-        try!(callback(TeResult(desc, result, stdout)));
+        callback(TeResult(desc, result, stdout))?;
         pending -= 1;
     }
 
@@ -891,10 +891,10 @@ fn run_tests<F>(opts: &TestOpts, tests: Vec<TestDescAndFn>, mut callback: F) -> 
         // All benchmarks run at the end, in serial.
         // (this includes metric fns)
         for b in filtered_benchs_and_metrics {
-            try!(callback(TeWait(b.desc.clone(), b.testfn.padding())));
+            callback(TeWait(b.desc.clone(), b.testfn.padding()))?;
             run_test(opts, false, b, tx.clone());
             let (test, result, stdout) = rx.recv().unwrap();
-            try!(callback(TeResult(test, result, stdout)));
+            callback(TeResult(test, result, stdout))?;
         }
     }
     Ok(())

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -40,6 +40,7 @@
 #![feature(rustc_private)]
 #![feature(set_stdio)]
 #![feature(staged_api)]
+#![feature(question_mark)]
 
 extern crate getopts;
 extern crate term;

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -40,8 +40,8 @@ impl fmt::Display for C {
 }
 impl fmt::Binary for D {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(f.write_str("aa"));
-        try!(f.write_char('☃'));
+        f.write_str("aa")?;
+        f.write_char('☃')?;
         f.write_str("bb")
     }
 }

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -14,6 +14,7 @@
 #![allow(unused_must_use)]
 #![allow(unknown_features)]
 #![feature(box_syntax)]
+#![feature(question_mark)]
 
 use std::fmt::{self, Write};
 use std::usize;

--- a/src/test/run-pass/issue-17121.rs
+++ b/src/test/run-pass/issue-17121.rs
@@ -27,7 +27,7 @@ impl<R: Read> Lexer<R>
 
     pub fn new_from_file(p: &str) -> io::Result<Lexer<File>>
     {
-        Ok(Lexer::new_from_reader(try!(File::open(p))))
+        Ok(Lexer::new_from_reader(File::open(p)?))
     }
 
     pub fn new_from_str<'a>(s: &'a str) -> Lexer<&'a [u8]>

--- a/src/test/run-pass/issue-17121.rs
+++ b/src/test/run-pass/issue-17121.rs
@@ -10,6 +10,8 @@
 
 // pretty-expanded FIXME #23616
 
+#![feature(question_mark)]
+
 use std::fs::File;
 use std::io::{self, BufReader, Read};
 

--- a/src/test/run-pass/issue-20797.rs
+++ b/src/test/run-pass/issue-20797.rs
@@ -12,6 +12,8 @@
 
 // pretty-expanded FIXME #23616
 
+#![feature(question_mark)]
+
 use std::default::Default;
 use std::io;
 use std::fs;

--- a/src/test/run-pass/issue-20797.rs
+++ b/src/test/run-pass/issue-20797.rs
@@ -55,7 +55,7 @@ pub struct Subpaths<S: Strategy> {
 impl<S: Strategy> Subpaths<S> {
     /// Create a directory walker with a root path and strategy.
     pub fn new(p: &S::P, strategy: S) -> io::Result<Subpaths<S>> {
-        let stack = try!(strategy.get_more(p));
+        let stack = strategy.get_more(p)?;
         Ok(Subpaths { stack: stack, strategy: strategy })
     }
 }

--- a/src/test/run-pass/issue-21400.rs
+++ b/src/test/run-pass/issue-21400.rs
@@ -54,7 +54,7 @@ impl GitConnect {
         let c = format!("git-upload-pack");
 
         let mut out = String::new();
-        let data = try!(self.command(&c));
+        let data = self.command(&c)?;
 
         for line in data.iter() {
             out.push_str(&format!("{:?}", line));

--- a/src/test/run-pass/issue-21400.rs
+++ b/src/test/run-pass/issue-21400.rs
@@ -11,6 +11,8 @@
 // Regression test for #21400 which itself was extracted from
 // stackoverflow.com/questions/28031155/is-my-borrow-checker-drunk/28031580
 
+#![feature(question_mark)]
+
 fn main() {
     let mut t = Test;
     assert_eq!(t.method1("one"), Ok(1));

--- a/src/tools/error_index_generator/main.rs
+++ b/src/tools/error_index_generator/main.rs
@@ -56,7 +56,7 @@ struct MarkdownFormatter;
 
 impl Formatter for HTMLFormatter {
     fn header(&self, output: &mut Write) -> Result<(), Box<Error>> {
-        try!(write!(output, r##"<!DOCTYPE html>
+        write!(output, r##"<!DOCTYPE html>
 <html>
 <head>
 <title>Rust Compiler Error Index</title>
@@ -71,12 +71,12 @@ impl Formatter for HTMLFormatter {
 </style>
 </head>
 <body>
-"##));
+"##)?;
         Ok(())
     }
 
     fn title(&self, output: &mut Write) -> Result<(), Box<Error>> {
-        try!(write!(output, "<h1>Rust Compiler Error Index</h1>\n"));
+        write!(output, "<h1>Rust Compiler Error Index</h1>\n")?;
         Ok(())
     }
 
@@ -91,25 +91,25 @@ impl Formatter for HTMLFormatter {
             Some(_) => "error-used",
             None => "error-unused",
         };
-        try!(write!(output, "<div class=\"{} {}\">", desc_desc, use_desc));
+        write!(output, "<div class=\"{} {}\">", desc_desc, use_desc)?;
 
         // Error title (with self-link).
-        try!(write!(output,
+        write!(output,
                     "<h2 id=\"{0}\" class=\"section-header\"><a href=\"#{0}\">{0}</a></h2>\n",
-                    err_code));
+                    err_code)?;
 
         // Description rendered as markdown.
         match info.description {
-            Some(ref desc) => try!(write!(output, "{}", Markdown(desc))),
-            None => try!(write!(output, "<p>No description.</p>\n")),
+            Some(ref desc) => write!(output, "{}", Markdown(desc))?,
+            None => write!(output, "<p>No description.</p>\n")?,
         }
 
-        try!(write!(output, "</div>\n"));
+        write!(output, "</div>\n")?;
         Ok(())
     }
 
     fn footer(&self, output: &mut Write) -> Result<(), Box<Error>> {
-        try!(write!(output, "</body>\n</html>"));
+        write!(output, "</body>\n</html>")?;
         Ok(())
     }
 }
@@ -121,14 +121,14 @@ impl Formatter for MarkdownFormatter {
     }
 
     fn title(&self, output: &mut Write) -> Result<(), Box<Error>> {
-        try!(write!(output, "# Rust Compiler Error Index\n"));
+        write!(output, "# Rust Compiler Error Index\n")?;
         Ok(())
     }
 
     fn error_code_block(&self, output: &mut Write, info: &ErrorMetadata,
                         err_code: &str) -> Result<(), Box<Error>> {
         Ok(match info.description {
-            Some(ref desc) => try!(write!(output, "## {}\n{}\n", err_code, desc)),
+            Some(ref desc) => write!(output, "## {}\n{}\n", err_code, desc)?,
             None => (),
         })
     }
@@ -143,13 +143,13 @@ impl Formatter for MarkdownFormatter {
 fn load_all_errors(metadata_dir: &Path) -> Result<ErrorMetadataMap, Box<Error>> {
     let mut all_errors = BTreeMap::new();
 
-    for entry in try!(read_dir(metadata_dir)) {
-        let path = try!(entry).path();
+    for entry in read_dir(metadata_dir)? {
+        let path = entry?.path();
 
         let mut metadata_str = String::new();
-        try!(File::open(&path).and_then(|mut f| f.read_to_string(&mut metadata_str)));
+        File::open(&path).and_then(|mut f| f.read_to_string(&mut metadata_str))?;
 
-        let some_errors: ErrorMetadataMap = try!(json::decode(&metadata_str));
+        let some_errors: ErrorMetadataMap = json::decode(&metadata_str)?;
 
         for (err_code, info) in some_errors {
             all_errors.insert(err_code, info);
@@ -162,26 +162,26 @@ fn load_all_errors(metadata_dir: &Path) -> Result<ErrorMetadataMap, Box<Error>> 
 /// Output an HTML page for the errors in `err_map` to `output_path`.
 fn render_error_page<T: Formatter>(err_map: &ErrorMetadataMap, output_path: &Path,
                                    formatter: T) -> Result<(), Box<Error>> {
-    let mut output_file = try!(File::create(output_path));
+    let mut output_file = File::create(output_path)?;
 
-    try!(formatter.header(&mut output_file));
-    try!(formatter.title(&mut output_file));
+    formatter.header(&mut output_file)?;
+    formatter.title(&mut output_file)?;
 
     for (err_code, info) in err_map {
-        try!(formatter.error_code_block(&mut output_file, info, err_code));
+        formatter.error_code_block(&mut output_file, info, err_code)?;
     }
 
     formatter.footer(&mut output_file)
 }
 
 fn main_with_result(format: OutputFormat, dst: &Path) -> Result<(), Box<Error>> {
-    let build_arch = try!(env::var("CFG_BUILD"));
+    let build_arch = env::var("CFG_BUILD")?;
     let metadata_dir = get_metadata_dir(&build_arch);
-    let err_map = try!(load_all_errors(&metadata_dir));
+    let err_map = load_all_errors(&metadata_dir)?;
     match format {
         OutputFormat::Unknown(s)  => panic!("Unknown output format: {}", s),
-        OutputFormat::HTML(h)     => try!(render_error_page(&err_map, dst, h)),
-        OutputFormat::Markdown(m) => try!(render_error_page(&err_map, dst, m)),
+        OutputFormat::HTML(h)     => render_error_page(&err_map, dst, h)?,
+        OutputFormat::Markdown(m) => render_error_page(&err_map, dst, m)?,
     }
     Ok(())
 }

--- a/src/tools/error_index_generator/main.rs
+++ b/src/tools/error_index_generator/main.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(rustc_private, rustdoc)]
+#![feature(question_mark)]
 
 extern crate syntax;
 extern crate rustdoc;

--- a/src/tools/error_index_generator/main.rs
+++ b/src/tools/error_index_generator/main.rs
@@ -96,8 +96,8 @@ impl Formatter for HTMLFormatter {
 
         // Error title (with self-link).
         write!(output,
-                    "<h2 id=\"{0}\" class=\"section-header\"><a href=\"#{0}\">{0}</a></h2>\n",
-                    err_code)?;
+               "<h2 id=\"{0}\" class=\"section-header\"><a href=\"#{0}\">{0}</a></h2>\n",
+               err_code)?;
 
         // Description rendered as markdown.
         match info.description {

--- a/src/tools/rustbook/build.rs
+++ b/src/tools/rustbook/build.rs
@@ -41,7 +41,7 @@ fn write_toc(book: &Book, current_page: &BookItem, out: &mut Write) -> io::Resul
                   current_page: &BookItem,
                   out: &mut Write) -> io::Result<()> {
         for (i, item) in items.iter().enumerate() {
-            try!(walk_item(item, &format!("{}{}.", section, i + 1)[..], current_page, out));
+            walk_item(item, &format!("{}{}.", section, i + 1)[..], current_page, out)?;
         }
         Ok(())
     }
@@ -55,32 +55,32 @@ fn write_toc(book: &Book, current_page: &BookItem, out: &mut Write) -> io::Resul
             ""
         };
 
-        try!(writeln!(out, "<li><a {} href='{}'><b>{}</b> {}</a>",
+        writeln!(out, "<li><a {} href='{}'><b>{}</b> {}</a>",
                       class_string,
                       current_page.path_to_root.join(&item.path).with_extension("html").display(),
                       section,
-                      item.title));
+                      item.title)?;
         if !item.children.is_empty() {
-            try!(writeln!(out, "<ul class='section'>"));
+            writeln!(out, "<ul class='section'>")?;
             let _ = walk_items(&item.children[..], section, current_page, out);
-            try!(writeln!(out, "</ul>"));
+            writeln!(out, "</ul>")?;
         }
-        try!(writeln!(out, "</li>"));
+        writeln!(out, "</li>")?;
 
         Ok(())
     }
 
-    try!(writeln!(out, "<div id='toc' class='mobile-hidden'>"));
-    try!(writeln!(out, "<ul class='chapter'>"));
-    try!(walk_items(&book.chapters[..], "", &current_page, out));
-    try!(writeln!(out, "</ul>"));
-    try!(writeln!(out, "</div>"));
+    writeln!(out, "<div id='toc' class='mobile-hidden'>")?;
+    writeln!(out, "<ul class='chapter'>")?;
+    walk_items(&book.chapters[..], "", &current_page, out)?;
+    writeln!(out, "</ul>")?;
+    writeln!(out, "</div>")?;
 
     Ok(())
 }
 
 fn render(book: &Book, tgt: &Path) -> CliResult<()> {
-    let tmp = try!(TempDir::new("rustbook"));
+    let tmp = TempDir::new("rustbook")?;
 
     for (_section, item) in book.iter() {
         let out_path = match item.path.parent() {
@@ -97,22 +97,22 @@ fn render(book: &Book, tgt: &Path) -> CliResult<()> {
         // preprocess the markdown, rerouting markdown references to html
         // references
         let mut markdown_data = String::new();
-        try!(File::open(&src.join(&item.path)).and_then(|mut f| {
+        File::open(&src.join(&item.path)).and_then(|mut f| {
             f.read_to_string(&mut markdown_data)
-        }));
+        })?;
         let preprocessed_path = tmp.path().join(item.path.file_name().unwrap());
         {
             let urls = markdown_data.replace(".md)", ".html)");
-            try!(File::create(&preprocessed_path).and_then(|mut f| {
+            File::create(&preprocessed_path).and_then(|mut f| {
                 f.write_all(urls.as_bytes())
-            }));
+            })?;
         }
 
         // write the prelude to a temporary HTML file for rustdoc inclusion
         let prelude = tmp.path().join("prelude.html");
         {
-            let mut buffer = BufWriter::new(try!(File::create(&prelude)));
-            try!(writeln!(&mut buffer, r#"
+            let mut buffer = BufWriter::new(File::create(&prelude)?);
+            writeln!(&mut buffer, r#"
                 <div id="nav">
                     <button id="toggle-nav">
                         <span class="sr-only">Toggle navigation</span>
@@ -120,22 +120,22 @@ fn render(book: &Book, tgt: &Path) -> CliResult<()> {
                         <span class="bar"></span>
                         <span class="bar"></span>
                     </button>
-                </div>"#));
+                </div>"#)?;
             let _ = write_toc(book, &item, &mut buffer);
-            try!(writeln!(&mut buffer, "<div id='page-wrapper'>"));
-            try!(writeln!(&mut buffer, "<div id='page'>"));
+            writeln!(&mut buffer, "<div id='page-wrapper'>")?;
+            writeln!(&mut buffer, "<div id='page'>")?;
         }
 
         // write the postlude to a temporary HTML file for rustdoc inclusion
         let postlude = tmp.path().join("postlude.html");
         {
-            let mut buffer = BufWriter::new(try!(File::create(&postlude)));
-            try!(writeln!(&mut buffer, "<script src='rustbook.js'></script>"));
-            try!(writeln!(&mut buffer, "<script src='playpen.js'></script>"));
-            try!(writeln!(&mut buffer, "</div></div>"));
+            let mut buffer = BufWriter::new(File::create(&postlude)?);
+            writeln!(&mut buffer, "<script src='rustbook.js'></script>")?;
+            writeln!(&mut buffer, "<script src='playpen.js'></script>")?;
+            writeln!(&mut buffer, "</div></div>")?;
         }
 
-        try!(fs::create_dir_all(&out_path));
+        fs::create_dir_all(&out_path)?;
 
         let rustdoc_args: &[String] = &[
             "".to_string(),
@@ -156,12 +156,12 @@ fn render(book: &Book, tgt: &Path) -> CliResult<()> {
     }
 
     // create index.html from the root README
-    try!(fs::copy(&tgt.join("README.html"), &tgt.join("index.html")));
+    fs::copy(&tgt.join("README.html"), &tgt.join("index.html"))?;
 
     // Copy js for playpen
-    let mut playpen = try!(File::create(tgt.join("playpen.js")));
+    let mut playpen = File::create(tgt.join("playpen.js"))?;
     let js = include_bytes!("../../librustdoc/html/static/playpen.js");
-    try!(playpen.write_all(js));
+    playpen.write_all(js)?;
     Ok(())
 }
 
@@ -189,24 +189,24 @@ impl Subcommand for Build {
 
         // `_book` directory may already exist from previous runs. Check and
         // delete it if it exists.
-        for entry in try!(fs::read_dir(&cwd)) {
-            let path = try!(entry).path();
-            if path == tgt { try!(fs::remove_dir_all(&tgt)) }
+        for entry in fs::read_dir(&cwd)? {
+            let path = entry?.path();
+            if path == tgt { fs::remove_dir_all(&tgt)? }
         }
-        try!(fs::create_dir(&tgt));
+        fs::create_dir(&tgt)?;
 
         // Copy static files
         let css = include_bytes!("static/rustbook.css");
         let js = include_bytes!("static/rustbook.js");
 
-        let mut css_file = try!(File::create(tgt.join("rustbook.css")));
-        try!(css_file.write_all(css));
+        let mut css_file = File::create(tgt.join("rustbook.css"))?;
+        css_file.write_all(css)?;
 
-        let mut js_file = try!(File::create(tgt.join("rustbook.js")));
-        try!(js_file.write_all(js));
+        let mut js_file = File::create(tgt.join("rustbook.js"))?;
+        js_file.write_all(js)?;
 
 
-        let mut summary = try!(File::open(&src.join("SUMMARY.md")));
+        let mut summary = File::open(&src.join("SUMMARY.md"))?;
         match book::parse_summary(&mut summary, &src) {
             Ok(book) => {
                 // execute rustdoc on the whole book

--- a/src/tools/rustbook/build.rs
+++ b/src/tools/rustbook/build.rs
@@ -56,10 +56,10 @@ fn write_toc(book: &Book, current_page: &BookItem, out: &mut Write) -> io::Resul
         };
 
         writeln!(out, "<li><a {} href='{}'><b>{}</b> {}</a>",
-                      class_string,
-                      current_page.path_to_root.join(&item.path).with_extension("html").display(),
-                      section,
-                      item.title)?;
+                 class_string,
+                 current_page.path_to_root.join(&item.path).with_extension("html").display(),
+                 section,
+                 item.title)?;
         if !item.children.is_empty() {
             writeln!(out, "<ul class='section'>")?;
             let _ = walk_items(&item.children[..], section, current_page, out);

--- a/src/tools/rustbook/main.rs
+++ b/src/tools/rustbook/main.rs
@@ -13,6 +13,7 @@
 #![feature(iter_arith)]
 #![feature(rustc_private)]
 #![feature(rustdoc)]
+#![feature(question_mark)]
 
 extern crate rustdoc;
 extern crate rustc_back;

--- a/src/tools/rustbook/test.rs
+++ b/src/tools/rustbook/test.rs
@@ -38,7 +38,7 @@ impl Subcommand for Test {
         let cwd = env::current_dir().unwrap();
         let src = cwd.clone();
 
-        let mut summary = try!(File::open(&src.join("SUMMARY.md")));
+        let mut summary = File::open(&src.join("SUMMARY.md"))?;
         match book::parse_summary(&mut summary, &src) {
             Ok(book) => {
                 for (_, item) in book.iter() {


### PR DESCRIPTION
The first commit is an automated conversion using the [untry](https://github.com/japaric/untry) tool and the following command:

```
$ find -name '*.rs' -type f | xargs untry
```

at the root of the Rust repo.

cc @rust-lang/lang @alexcrichton @brson 
