### PR TITLE
Fix tupling of fn args for rust-call ABI functions

### DIFF
--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -1685,6 +1685,7 @@ impl<'blk, 'tcx> FunctionContext<'blk, 'tcx> {
                     for (j, &tupled_arg_ty) in tupled_arg_tys.iter().enumerate() {
                         let dst = StructGEP(bcx, llval, j);
                         let arg = &self.fn_ty.args[idx];
+                        idx += 1;
                         let b = &bcx.build();
                         if common::type_is_fat_ptr(bcx.tcx(), tupled_arg_ty) {
                             let meta = &self.fn_ty.args[idx];

--- a/src/test/run-pass/issue-32389.rs
+++ b/src/test/run-pass/issue-32389.rs
@@ -1,0 +1,20 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn foo<T>() -> T { loop {} }
+
+fn test() {
+    let ref mut a: &mut FnMut((i8,), i16) = foo();
+    a((0,), 0);
+}
+
+fn main() {
+    let _ = test;
+}


### PR DESCRIPTION
Fixes #32389
