### PR TITLE
std: Link to gcc_s on NetBSD

### DIFF
--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -50,7 +50,9 @@ fn main() {
 
         if target.contains("rumprun") {
             println!("cargo:rustc-link-lib=unwind");
-        } else if target.contains("netbsd") || target.contains("openbsd") {
+        } else if target.contains("netbsd") {
+            println!("cargo:rustc-link-lib=gcc_s");
+        } else if target.contains("openbsd") {
             println!("cargo:rustc-link-lib=gcc");
         } else if target.contains("bitrig") {
             println!("cargo:rustc-link-lib=c++abi");


### PR DESCRIPTION
Currently the nightlies we're producing fail when linking some C code into a
Rust application with the error message:

```
libgcc_s.so.1: error adding symbols: DSO missing from command line
```

By linking `gcc_s` instead of `gcc` this error goes away. I haven't tested this
on NetBSD itself, but should help get the Linux cross-compile image moreso up
and working!
