### PR TITLE
Add support for naked functions

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -1905,6 +1905,8 @@ type int8_t = i8;
 - `should_panic` - indicates that this test function should panic, inverting the success condition.
 - `cold` - The function is unlikely to be executed, so optimize it (and calls
   to it) differently.
+- `naked` - The function utilizes a custom ABI or custom inline ASM that requires
+  epilogue and prologue to be skipped.
 
 ### Static-only attributes
 

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -212,6 +212,9 @@ const KNOWN_FEATURES: &'static [(&'static str, &'static str, Option<u32>, Status
     // rust runtime internal
     ("unwind_attributes", "1.4.0", None, Active),
 
+	// allow the use of `#[naked]` on functions.
+    ("naked_functions", "1.9.0", None, Active),
+
     // allow empty structs and enum variants with braces
     ("braced_empty_structs", "1.5.0", Some(29720), Accepted),
 
@@ -376,6 +379,9 @@ pub const KNOWN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeGat
     // FIXME: #14406 these are processed in trans, which happens after the
     // lint pass
     ("cold", Whitelisted, Ungated),
+    ("naked", Whitelisted, Gated("naked_functions",
+                                 "the `#[naked]` attribute \
+                                  is an experimental feature")),
     ("export_name", Whitelisted, Ungated),
     ("inline", Whitelisted, Ungated),
     ("link", Whitelisted, Ungated),

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -212,7 +212,7 @@ const KNOWN_FEATURES: &'static [(&'static str, &'static str, Option<u32>, Status
     // rust runtime internal
     ("unwind_attributes", "1.4.0", None, Active),
 
-	// allow the use of `#[naked]` on functions.
+    // allow the use of `#[naked]` on functions.
     ("naked_functions", "1.9.0", None, Active),
 
     // allow empty structs and enum variants with braces

--- a/src/test/codegen/naked-functions.rs
+++ b/src/test/codegen/naked-functions.rs
@@ -1,0 +1,69 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-tidy-linelength
+
+// compile-flags: -C no-prepopulate-passes
+
+#![crate_type = "lib"]
+#![feature(naked_functions)]
+
+// CHECK: Function Attrs: naked uwtable
+// CHECK-NEXT: define internal void @naked_empty()
+#[no_mangle]
+#[naked]
+fn naked_empty() {
+    // CHECK: ret void
+}
+
+// CHECK: Function Attrs: naked uwtable
+#[no_mangle]
+#[naked]
+// CHECK-NEXT: define internal void @naked_with_args(i{{[0-9]+}})
+fn naked_with_args(a: isize) {
+    // CHECK: %a = alloca i{{[0-9]+}}
+    // CHECK: ret void
+}
+
+// CHECK: Function Attrs: naked uwtable
+// CHECK-NEXT: define internal i{{[0-9]+}} @naked_with_return()
+#[no_mangle]
+#[naked]
+fn naked_with_return() -> isize {
+    // CHECK: ret i{{[0-9]+}} 0
+    0
+}
+
+// CHECK: Function Attrs: naked uwtable
+// CHECK-NEXT: define internal i{{[0-9]+}} @naked_with_args_and_return(i{{[0-9]+}})
+#[no_mangle]
+#[naked]
+fn naked_with_args_and_return(a: isize) -> isize {
+    // CHECK: %a = alloca i{{[0-9]+}}
+    // CHECK: ret i{{[0-9]+}} %{{[0-9]+}}
+    a
+}
+
+// CHECK: Function Attrs: naked uwtable
+// CHECK-NEXT: define internal void @naked_recursive()
+#[no_mangle]
+#[naked]
+fn naked_recursive() {
+    // CHECK: call void @naked_empty()
+    naked_empty();
+    // CHECK: %{{[0-9]+}} = call i{{[0-9]+}} @naked_with_return()
+    naked_with_args(
+        // CHECK: %{{[0-9]+}} = call i{{[0-9]+}} @naked_with_args_and_return(i{{[0-9]+}} %{{[0-9]+}})
+        naked_with_args_and_return(
+            // CHECK: call void @naked_with_args(i{{[0-9]+}} %{{[0-9]+}})
+            naked_with_return()
+        )
+    );
+}

--- a/src/test/compile-fail/gated-naked_functions.rs
+++ b/src/test/compile-fail/gated-naked_functions.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[naked]
+//~^ the `#[naked]` attribute is an experimental feature
+fn naked() {}
+
+#[naked]
+//~^ the `#[naked]` attribute is an experimental feature
+fn naked_2() -> isize {
+    0
+}


### PR DESCRIPTION
See https://github.com/rust-lang/rfcs/pull/1201#issuecomment-199442239

This PR adds `#[naked]` for marking naked functions.
