### PR TITLE
fix aarch64-linux-android

### DIFF
--- a/src/libstd/os/android/raw.rs
+++ b/src/libstd/os/android/raw.rs
@@ -104,7 +104,7 @@ mod arch {
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type dev_t = u64;
     #[stable(feature = "raw_ext", since = "1.1.0")]
-    pub type mode_t = u32;
+    pub type mode_t = u16;
 
     #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type blkcnt_t = u64;


### PR DESCRIPTION
Using the toolchain from android-ndk-r11b, mode_t is u16. libstd fails
to compile without this fix.
