### PR TITLE
rustdoc: Omit `pub` for inlined variant-struct fields

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1885,7 +1885,7 @@ impl<'tcx> Clean<Item> for ty::VariantDefData<'tcx, 'static> {
                             source: Span::empty(),
                             name: Some(field.name.clean(cx)),
                             attrs: Vec::new(),
-                            visibility: Some(hir::Public),
+                            visibility: Some(field.vis),
                             // FIXME: this is not accurate, we need an id for
                             //        the specific field but we're using the id
                             //        for the whole variant. Thus we read the

--- a/src/test/auxiliary/variant-struct.rs
+++ b/src/test/auxiliary/variant-struct.rs
@@ -1,0 +1,15 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub enum Foo {
+    Bar {
+        qux: (),
+    }
+}

--- a/src/test/rustdoc/issue-32395.rs
+++ b/src/test/rustdoc/issue-32395.rs
@@ -1,0 +1,21 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:variant-struct.rs
+// build-aux-docs
+// ignore-cross-compile
+
+// @has variant_struct/enum.Foo.html
+// @!has - 'pub qux'
+extern crate variant_struct;
+
+// @has issue_32395/enum.Foo.html
+// @!has - 'pub qux'
+pub use variant_struct::Foo;


### PR DESCRIPTION
fixes #32395 

r? @alexcrichton 
