### PR TITLE
Fix const trans

### DIFF
--- a/src/librustc_trans/trans/consts.rs
+++ b/src/librustc_trans/trans/consts.rs
@@ -381,7 +381,7 @@ pub fn const_expr<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                     llconst = addr_of(cx, llconst, type_of::align_of(cx, ty), "autoref");
                     ty = cx.tcx().mk_imm_ref(cx.tcx().mk_region(ty::ReStatic), ty);
                 }
-            } else {
+            } else if adj.autoderefs > 0 {
                 let (dv, dt) = const_deref(cx, llconst, ty);
                 llconst = dv;
 

--- a/src/test/run-pass/issue-30615.rs
+++ b/src/test/run-pass/issue-30615.rs
@@ -1,0 +1,14 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    &0u8 as *const u8 as *const PartialEq<u8>;
+    &[0u8] as *const [u8; 1] as *const [u8];
+}


### PR DESCRIPTION
Fix #30615.

The idea was that when there are N autoderefs, first do N-1 derefs and check for autoref. If there is autoref, done, if not, do one more deref. But when N is zero, doing one more deref is wrong.
