### PR TITLE
rustdoc: Consider `doc(no_inline)` in crate-local inlining

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -256,7 +256,7 @@ pub fn build_impls(cx: &DocContext,
                 cstore::DlImpl(did) => build_impl(cx, tcx, did, impls),
                 cstore::DlDef(Def::Mod(did)) => {
                     // Don't recurse if this is a #[doc(hidden)] module
-                    if load_attrs(cx, tcx, did).list_def("doc").has_word("hidden") {
+                    if load_attrs(cx, tcx, did).list("doc").has_word("hidden") {
                         return;
                     }
 
@@ -299,7 +299,7 @@ pub fn build_impl(cx: &DocContext,
     if let Some(ref t) = associated_trait {
         // If this is an impl for a #[doc(hidden)] trait, be sure to not inline
         let trait_attrs = load_attrs(cx, tcx, t.def_id);
-        if trait_attrs.list_def("doc").has_word("hidden") {
+        if trait_attrs.list("doc").has_word("hidden") {
             return
         }
     }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -418,7 +418,7 @@ impl Clean<Item> for doctree::Module {
 pub trait Attributes {
     fn has_word(&self, &str) -> bool;
     fn value<'a>(&'a self, &str) -> Option<&'a str>;
-    fn list_def<'a>(&'a self, &str) -> &'a [Attribute];
+    fn list<'a>(&'a self, &str) -> &'a [Attribute];
 }
 
 impl Attributes for [Attribute] {
@@ -447,7 +447,7 @@ impl Attributes for [Attribute] {
     }
 
     /// Finds an attribute as List and returns the list of attributes nested inside.
-    fn list_def<'a>(&'a self, name: &str) -> &'a [Attribute] {
+    fn list<'a>(&'a self, name: &str) -> &'a [Attribute] {
         for attr in self {
             if let List(ref x, ref list) = *attr {
                 if name == *x {
@@ -1535,7 +1535,7 @@ impl PrimitiveType {
     }
 
     fn find(attrs: &[Attribute]) -> Option<PrimitiveType> {
-        for attr in attrs.list_def("doc") {
+        for attr in attrs.list("doc") {
             if let NameValue(ref k, ref v) = *attr {
                 if "primitive" == *k {
                     if let ret@Some(..) = PrimitiveType::from_str(v) {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -432,7 +432,7 @@ pub fn run(mut krate: clean::Crate,
 
     // Crawl the crate attributes looking for attributes which control how we're
     // going to emit HTML
-    if let Some(attrs) = krate.module.as_ref().map(|m| m.attrs.list_def("doc")) {
+    if let Some(attrs) = krate.module.as_ref().map(|m| m.attrs.list("doc")) {
         for attr in attrs {
             match *attr {
                 clean::NameValue(ref x, ref s)
@@ -832,7 +832,7 @@ fn extern_location(e: &clean::ExternalCrate, dst: &Path) -> ExternalLocation {
 
     // Failing that, see if there's an attribute specifying where to find this
     // external crate
-    e.attrs.list_def("doc").value("html_root_url").map(|url| {
+    e.attrs.list("doc").value("html_root_url").map(|url| {
         let mut url = url.to_owned();
         if !url.ends_with("/") {
             url.push('/')
@@ -1846,6 +1846,7 @@ fn item_static(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
 
 fn item_function(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                  f: &clean::Function) -> fmt::Result {
+    // FIXME(#24111): remove when `const_fn` is stabilized
     let vis_constness = match get_unstable_features_setting() {
         UnstableFeatures::Allow => f.constness,
         _ => hir::Constness::NotConst

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -383,7 +383,7 @@ fn rust_input(cratefile: &str, externs: core::Externs, matches: &getopts::Matche
 
     // Process all of the crate attributes, extracting plugin metadata along
     // with the passes which we are supposed to run.
-    for attr in krate.module.as_ref().unwrap().attrs.list_def("doc") {
+    for attr in krate.module.as_ref().unwrap().attrs.list("doc") {
         match *attr {
             clean::Word(ref w) if "no_default_passes" == *w => {
                 default_passes = false;

--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -33,7 +33,7 @@ pub fn strip_hidden(krate: clean::Crate) -> plugins::PluginResult {
         }
         impl<'a> fold::DocFolder for Stripper<'a> {
             fn fold_item(&mut self, i: Item) -> Option<Item> {
-                if i.attrs.list_def("doc").has_word("hidden") {
+                if i.attrs.list("doc").has_word("hidden") {
                     debug!("found one in strip_hidden; removing");
                     self.stripped.insert(i.def_id);
 

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -229,7 +229,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             while let Some(id) = cx.map.get_enclosing_scope(node) {
                 node = id;
                 let attrs = cx.map.attrs(node).clean(cx);
-                if attrs.list_def("doc").has_word("hidden") {
+                if attrs.list("doc").has_word("hidden") {
                     return true;
                 }
                 if node == ast::CRATE_NODE_ID {
@@ -251,11 +251,14 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             Some(analysis) => analysis, None => return false
         };
 
+        let use_attrs = tcx.map.attrs(id).clean(self.cx);
+
         let is_private = !analysis.access_levels.is_public(def);
         let is_hidden = inherits_doc_hidden(self.cx, def_node_id);
+        let is_no_inline = use_attrs.list("doc").has_word("no_inline");
 
         // Only inline if requested or if the item would otherwise be stripped
-        if !please_inline && !is_private && !is_hidden {
+        if (!please_inline && !is_private && !is_hidden) || is_no_inline {
             return false
         }
 

--- a/src/test/rustdoc/inline_local/issue-32343.rs
+++ b/src/test/rustdoc/inline_local/issue-32343.rs
@@ -1,0 +1,33 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// @!has issue_32343/struct.Foo.html
+// @has issue_32343/index.html
+// @has - '//code' 'pub use foo::Foo'
+// @!has - '//code/a' 'Foo'
+#[doc(no_inline)]
+pub use foo::Foo;
+
+// @!has issue_32343/struct.Bar.html
+// @has issue_32343/index.html
+// @has - '//code' 'pub use foo::Bar'
+// @has - '//code/a' 'Bar'
+#[doc(no_inline)]
+pub use foo::Bar;
+
+mod foo {
+    pub struct Foo;
+    pub struct Bar;
+}
+
+pub mod bar {
+    // @has issue_32343/bar/struct.Bar.html
+    pub use ::foo::Bar;
+}


### PR DESCRIPTION
Imports with `doc(no_inline)` will not be inlined, even when `doc(inline)` is present.

fixes #32343 

r? @alexcrichton 
