### PR TITLE
Annotate run-pass/backtrace with #[rustc_no_mir] on MSVC.

### DIFF
--- a/src/test/run-pass/backtrace.rs
+++ b/src/test/run-pass/backtrace.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(rustc_attrs)]
+
 // no-pretty-expanded FIXME #15189
 // ignore-android FIXME #17520
 // compile-flags:-g
@@ -16,6 +18,8 @@ use std::env;
 use std::process::{Command, Stdio};
 use std::str;
 
+// FIXME #31005 MIR missing debuginfo currently.
+#[cfg_attr(target_env = "msvc", rustc_no_mir)]
 #[inline(never)]
 fn foo() {
     let _v = vec![1, 2, 3];
@@ -24,6 +28,8 @@ fn foo() {
     }
 }
 
+// FIXME #31005 MIR missing debuginfo currently.
+#[cfg_attr(target_env = "msvc", rustc_no_mir)]
 #[inline(never)]
 fn double() {
     struct Double;


### PR DESCRIPTION
Fixes #32384 by not using MIR on MSVC for the functions in the path of the backtrace.
This is the known blocker for the MSVC MIR builder, hopefully the only one overall.
r? @alexcrichton Confirmed to work on a nightly, by @retep998. 
