### PR TITLE
configure: update required LLVM version

### DIFF
--- a/configure
+++ b/configure
@@ -969,11 +969,11 @@ then
     LLVM_VERSION=$($LLVM_CONFIG --version)
 
     case $LLVM_VERSION in
-        (3.[5-8]*)
+        (3.[6-8]*)
             msg "found ok version of LLVM: $LLVM_VERSION"
             ;;
         (*)
-            err "bad LLVM version: $LLVM_VERSION, need >=3.5"
+            err "bad LLVM version: $LLVM_VERSION, need >=3.6"
             ;;
     esac
 fi


### PR DESCRIPTION
Rust 1.7.0 and newer appears to require LLVM 3.6.0 or newer when
building against a version that's out of the tree with the --llvm-root
flag.

Signed-off-by: Doug Goldstein cardoe@cardoe.com
