### PR TITLE
Fix unsound behaviour with null characters in thread names (issue #32475)

### DIFF
--- a/src/libstd/sys/windows/thread.rs
+++ b/src/libstd/sys/windows/thread.rs
@@ -54,7 +54,7 @@ impl Thread {
         }
     }
 
-    pub fn set_name(_name: &str) {
+    pub fn set_name(_name: &CStr) {
         // Windows threads are nameless
         // The names in MSVC debugger are obtained using a "magic" exception,
         // which requires a use of MS C++ extensions.


### PR DESCRIPTION
Previously, the thread name (&str) was converted to a CString in the
new thread, but outside unwind::try, causing a panic to continue into FFI.

This patch changes that behaviour, so that the panic instead happens
in the parent thread (where panic infrastructure is properly set up),
not the new thread.

This could potentially be a breaking change for architectures who don't
support thread names.
