### PR TITLE
Add note on `str` being an unsized type in strings section of book

### DIFF
--- a/src/doc/book/strings.md
+++ b/src/doc/book/strings.md
@@ -44,6 +44,11 @@ let s = "foo\
 assert_eq!("foobar", s);
 ```
 
+Note that you normally cannot access a `str` directly, but only through a `&str`
+reference. This is because `str` is an unsized type which requires additional
+runtime information to be usable. For more information see the chapter on
+[unsized types][ut].
+
 Rust has more than only `&str`s though. A `String` is a heap-allocated string.
 This string is growable, and is also guaranteed to be UTF-8. `String`s are
 commonly created by converting from a string slice using the `to_string`
@@ -185,5 +190,6 @@ let hello_world = hello + &world;
 This is because `&String` can automatically coerce to a `&str`. This is a
 feature called ‘[`Deref` coercions][dc]’.
 
+[ut]: unsized-types.html
 [dc]: deref-coercions.html
 [connect]: ../std/net/struct.TcpStream.html#method.connect


### PR DESCRIPTION
The book section on Rust strings mentions `&str` and `String` but does not address why `str` is not used directly. This adds a short blurb and a link to the unsized types chapter. The second draft of the book will go more in-depth on this, but this should help a bit for now. Thanks #rust for clarifying this point, and let me know if it needs rewording or different placement :smile:.

CC @steveklabnik @Kimundi 
