### PR TITLE
Issue warnings for late-bound regions in assoc type bindings and output types

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -168,6 +168,13 @@ declare_lint! {
 }
 
 declare_lint! {
+    pub HR_LIFETIME_IN_ASSOC_TYPE,
+    Warn,
+    "binding for associated type references higher-ranked lifetime \
+     that does not appear in the trait input types"
+}
+
+declare_lint! {
     pub OVERLAPPING_INHERENT_IMPLS,
     Warn,
     "two overlapping inherent impls define an item with the same name were erroneously allowed"
@@ -213,7 +220,8 @@ impl LintPass for HardwiredLints {
             RAW_POINTER_DERIVE,
             TRANSMUTE_FROM_FN_ITEM_TYPES,
             OVERLAPPING_INHERENT_IMPLS,
-            RENAMED_AND_REMOVED_LINTS
+            RENAMED_AND_REMOVED_LINTS,
+            HR_LIFETIME_IN_ASSOC_TYPE
         )
     }
 }

--- a/src/librustc/traits/project.rs
+++ b/src/librustc/traits/project.rs
@@ -650,76 +650,7 @@ fn project_type<'cx,'tcx>(
 
     assert!(candidates.vec.len() <= 1);
 
-    let possible_candidate = candidates.vec.pop().and_then(|candidate| {
-        // In Any (i.e. trans) mode, all projections succeed;
-        // otherwise, we need to be sensitive to `default` and
-        // specialization.
-        if !selcx.projection_mode().is_any() {
-            if let ProjectionTyCandidate::Impl(ref impl_data) = candidate {
-                if let Some(node_item) = assoc_ty_def(selcx,
-                                                      impl_data.impl_def_id,
-                                                      obligation.predicate.item_name) {
-                    if node_item.node.is_from_trait() {
-                        if node_item.item.ty.is_some() {
-                            // If the associated type has a default from the
-                            // trait, that should be considered `default` and
-                            // hence not projected.
-                            //
-                            // Note, however, that we allow a projection from
-                            // the trait specifically in the case that the trait
-                            // does *not* give a default. This is purely to
-                            // avoid spurious errors: the situation can only
-                            // arise when *no* impl in the specialization chain
-                            // has provided a definition for the type. When we
-                            // confirm the candidate, we'll turn the projection
-                            // into a TyError, since the actual error will be
-                            // reported in `check_impl_items_against_trait`.
-                            return None;
-                        }
-                    } else if node_item.item.defaultness.is_default() {
-                        return None;
-                    }
-                } else {
-                    // Normally this situation could only arise througha
-                    // compiler bug, but at coherence-checking time we only look
-                    // at the topmost impl (we don't even consider the trait
-                    // itself) for the definition -- so we can fail to find a
-                    // definition of the type even if it exists.
-
-                    // For now, we just unconditionally ICE, because otherwise,
-                    // examples like the following will succeed:
-                    //
-                    // ```
-                    // trait Assoc {
-                    //     type Output;
-                    // }
-                    //
-                    // impl<T> Assoc for T {
-                    //     default type Output = bool;
-                    // }
-                    //
-                    // impl Assoc for u8 {}
-                    // impl Assoc for u16 {}
-                    //
-                    // trait Foo {}
-                    // impl Foo for <u8 as Assoc>::Output {}
-                    // impl Foo for <u16 as Assoc>::Output {}
-                    //     return None;
-                    // }
-                    // ```
-                    //
-                    // The essential problem here is that the projection fails,
-                    // leaving two unnormalized types, which appear not to unify
-                    // -- so the overlap check succeeds, when it should fail.
-                    bug!("Tried to project an inherited associated type during \
-                          coherence checking, which is currently not supported.");
-                }
-            }
-        }
-        Some(candidate)
-    });
-
-    match possible_candidate {
+    match candidates.vec.pop() {
         Some(candidate) => {
             let (ty, obligations) = confirm_candidate(selcx,
                                                       obligation,
@@ -866,13 +797,121 @@ fn assemble_candidates_from_impls<'cx,'tcx>(
         };
 
         match vtable {
-            super::VtableImpl(_) |
             super::VtableClosure(_) |
             super::VtableFnPointer(_) |
             super::VtableObject(_) => {
                 debug!("assemble_candidates_from_impls: vtable={:?}",
                        vtable);
 
+                candidate_set.vec.push(ProjectionTyCandidate::Select);
+            }
+            super::VtableImpl(ref impl_data) if !selcx.projection_mode().is_any() => {
+                // We have to be careful when projecting out of an
+                // impl because of specialization. If we are not in
+                // trans (i.e., projection mode is not "any"), and the
+                // impl's type is declared as default, then we disable
+                // projection (even if the trait ref is fully
+                // monomorphic). In the case where trait ref is not
+                // fully monomorphic (i.e., includes type parameters),
+                // this is because those type parameters may
+                // ultimately be bound to types from other crates that
+                // may have specialized impls we can't see. In the
+                // case where the trait ref IS fully monomorphic, this
+                // is a policy decision that we made in the RFC in
+                // order to preserve flexibility for the crate that
+                // defined the specializable impl to specialize later
+                // for existing types.
+                //
+                // In either case, we handle this by not adding a
+                // candidate for an impl if it contains a `default`
+                // type.
+                let opt_node_item = assoc_ty_def(selcx,
+                                                 impl_data.impl_def_id,
+                                                 obligation.predicate.item_name);
+                let new_candidate = if let Some(node_item) = opt_node_item {
+                    if node_item.node.is_from_trait() {
+                        if node_item.item.ty.is_some() {
+                            // The impl inherited a `type Foo =
+                            // Bar` given in the trait, which is
+                            // implicitly default. No candidate.
+                            None
+                        } else {
+                            // The impl did not specify `type` and neither
+                            // did the trait:
+                            //
+                            // ```rust
+                            // trait Foo { type T; }
+                            // impl Foo for Bar { }
+                            // ```
+                            //
+                            // This is an error, but it will be
+                            // reported in `check_impl_items_against_trait`.
+                            // We accept it here but will flag it as
+                            // an error when we confirm the candidate
+                            // (which will ultimately lead to `normalize_to_error`
+                            // being invoked).
+                            Some(ProjectionTyCandidate::Select)
+                        }
+                    } else if node_item.item.defaultness.is_default() {
+                        // The impl specified `default type Foo =
+                        // Bar`. No candidate.
+                        None
+                    } else {
+                        // The impl specified `type Foo = Bar`
+                        // with no default. Add a candidate.
+                        Some(ProjectionTyCandidate::Select)
+                    }
+                } else {
+                    // This is saying that neither the trait nor
+                    // the impl contain a definition for this
+                    // associated type.  Normally this situation
+                    // could only arise through a compiler bug --
+                    // if the user wrote a bad item name, it
+                    // should have failed in astconv. **However**,
+                    // at coherence-checking time, we only look at
+                    // the topmost impl (we don't even consider
+                    // the trait itself) for the definition -- and
+                    // so in that case it may be that the trait
+                    // *DOES* have a declaration, but we don't see
+                    // it, and we end up in this branch.
+                    //
+                    // This is kind of tricky to handle actually.
+                    // For now, we just unconditionally ICE,
+                    // because otherwise, examples like the
+                    // following will succeed:
+                    //
+                    // ```
+                    // trait Assoc {
+                    //     type Output;
+                    // }
+                    //
+                    // impl<T> Assoc for T {
+                    //     default type Output = bool;
+                    // }
+                    //
+                    // impl Assoc for u8 {}
+                    // impl Assoc for u16 {}
+                    //
+                    // trait Foo {}
+                    // impl Foo for <u8 as Assoc>::Output {}
+                    // impl Foo for <u16 as Assoc>::Output {}
+                    //     return None;
+                    // }
+                    // ```
+                    //
+                    // The essential problem here is that the
+                    // projection fails, leaving two unnormalized
+                    // types, which appear not to unify -- so the
+                    // overlap check succeeds, when it should
+                    // fail.
+                    bug!("Tried to project an inherited associated type during \
+                          coherence checking, which is currently not supported.");
+                };
+                candidate_set.vec.extend(new_candidate);
+            }
+            super::VtableImpl(_) => {
+                // In trans mode, we can just project out of impls, no prob.
+                assert!(selcx.projection_mode().is_any());
                 candidate_set.vec.push(ProjectionTyCandidate::Select);
             }
             super::VtableParam(..) => {

--- a/src/librustc/traits/project.rs
+++ b/src/librustc/traits/project.rs
@@ -1024,14 +1024,14 @@ fn confirm_object_candidate<'cx,'tcx>(
 {
     let self_ty = obligation_trait_ref.self_ty();
     let object_ty = selcx.infcx().shallow_resolve(self_ty);
-    debug!("assemble_candidates_from_object_type(object_ty={:?})",
+    debug!("confirm_object_candidate(object_ty={:?})",
            object_ty);
     let data = match object_ty.sty {
         ty::TyTrait(ref data) => data,
         _ => {
             span_bug!(
                 obligation.cause.span,
-                "assemble_candidates_from_object_type called with non-object: {:?}",
+                "confirm_object_candidate called with non-object: {:?}",
                 object_ty);
         }
     };

--- a/src/librustc/traits/project.rs
+++ b/src/librustc/traits/project.rs
@@ -152,14 +152,8 @@ enum ProjectionTyCandidate<'tcx> {
     // from the definition of `Trait` when you have something like <<A as Trait>::B as Trait2>::C
     TraitDef(ty::PolyProjectionPredicate<'tcx>),
 
-    // defined in an impl
-    Impl(VtableImplData<'tcx, PredicateObligation<'tcx>>),
-
-    // closure return type
-    Closure(VtableClosureData<'tcx, PredicateObligation<'tcx>>),
-
-    // fn pointer return type
-    FnPointer(Ty<'tcx>),
+    // from a "impl" (or a "pseudo-impl" returned by select)
+    Select,
 }
 
 struct ProjectionTyCandidateSet<'tcx> {
@@ -645,10 +639,8 @@ fn project_type<'cx,'tcx>(
         debug!("retaining param-env candidates only from {:?}", candidates.vec);
         candidates.vec.retain(|c| match *c {
             ProjectionTyCandidate::ParamEnv(..) => true,
-            ProjectionTyCandidate::Impl(..) |
-            ProjectionTyCandidate::Closure(..) |
             ProjectionTyCandidate::TraitDef(..) |
-            ProjectionTyCandidate::FnPointer(..) => false,
+            ProjectionTyCandidate::Select => false,
         });
         debug!("resulting candidate set: {:?}", candidates.vec);
         if candidates.vec.len() != 1 {
@@ -729,7 +721,10 @@ fn project_type<'cx,'tcx>(
 
     match possible_candidate {
         Some(candidate) => {
-            let (ty, obligations) = confirm_candidate(selcx, obligation, candidate);
+            let (ty, obligations) = confirm_candidate(selcx,
+                                                      obligation,
+                                                      &obligation_trait_ref,
+                                                      candidate);
             Ok(ProjectedTy::Progress(ty, obligations))
         }
         None => {
@@ -845,11 +840,148 @@ fn assemble_candidates_from_predicates<'cx,'tcx,I>(
     }
 }
 
-fn assemble_candidates_from_object_type<'cx,'tcx>(
+fn assemble_candidates_from_impls<'cx,'tcx>(
     selcx: &mut SelectionContext<'cx,'tcx>,
-    obligation:  &ProjectionTyObligation<'tcx>,
+    obligation: &ProjectionTyObligation<'tcx>,
     obligation_trait_ref: &ty::TraitRef<'tcx>,
     candidate_set: &mut ProjectionTyCandidateSet<'tcx>)
+    -> Result<(), SelectionError<'tcx>>
+{
+    // If we are resolving `<T as TraitRef<...>>::Item == Type`,
+    // start out by selecting the predicate `T as TraitRef<...>`:
+    let poly_trait_ref = obligation_trait_ref.to_poly_trait_ref();
+    let trait_obligation = obligation.with(poly_trait_ref.to_poly_trait_predicate());
+    selcx.infcx().probe(|_| {
+        let vtable = match selcx.select(&trait_obligation) {
+            Ok(Some(vtable)) => vtable,
+            Ok(None) => {
+                candidate_set.ambiguous = true;
+                return Ok(());
+            }
+            Err(e) => {
+                debug!("assemble_candidates_from_impls: selection error {:?}",
+                       e);
+                return Err(e);
+            }
+        };
+
+        match vtable {
+            super::VtableImpl(_) |
+            super::VtableClosure(_) |
+            super::VtableFnPointer(_) |
+            super::VtableObject(_) => {
+                debug!("assemble_candidates_from_impls: vtable={:?}",
+                       vtable);
+
+                candidate_set.vec.push(ProjectionTyCandidate::Select);
+            }
+            super::VtableParam(..) => {
+                // This case tell us nothing about the value of an
+                // associated type. Consider:
+                //
+                // ```
+                // trait SomeTrait { type Foo; }
+                // fn foo<T:SomeTrait>(...) { }
+                // ```
+                //
+                // If the user writes `<T as SomeTrait>::Foo`, then the `T
+                // : SomeTrait` binding does not help us decide what the
+                // type `Foo` is (at least, not more specifically than
+                // what we already knew).
+                //
+                // But wait, you say! What about an example like this:
+                //
+                // ```
+                // fn bar<T:SomeTrait<Foo=usize>>(...) { ... }
+                // ```
+                //
+                // Doesn't the `T : Sometrait<Foo=usize>` predicate help
+                // resolve `T::Foo`? And of course it does, but in fact
+                // that single predicate is desugared into two predicates
+                // in the compiler: a trait predicate (`T : SomeTrait`) and a
+                // projection. And the projection where clause is handled
+                // in `assemble_candidates_from_param_env`.
+            }
+            super::VtableDefaultImpl(..) |
+            super::VtableBuiltin(..) => {
+                // These traits have no associated types.
+                span_bug!(
+                    obligation.cause.span,
+                    "Cannot project an associated type from `{:?}`",
+                    vtable);
+            }
+        }
+
+        Ok(())
+    })
+}
+
+fn confirm_candidate<'cx,'tcx>(
+    selcx: &mut SelectionContext<'cx,'tcx>,
+    obligation: &ProjectionTyObligation<'tcx>,
+    obligation_trait_ref: &ty::TraitRef<'tcx>,
+    candidate: ProjectionTyCandidate<'tcx>)
+    -> (Ty<'tcx>, Vec<PredicateObligation<'tcx>>)
+{
+    debug!("confirm_candidate(candidate={:?}, obligation={:?})",
+           candidate,
+           obligation);
+
+    match candidate {
+        ProjectionTyCandidate::ParamEnv(poly_projection) |
+        ProjectionTyCandidate::TraitDef(poly_projection) => {
+            confirm_param_env_candidate(selcx, obligation, poly_projection)
+        }
+
+        ProjectionTyCandidate::Select => {
+            confirm_select_candidate(selcx, obligation, obligation_trait_ref)
+        }
+    }
+}
+
+fn confirm_select_candidate<'cx,'tcx>(
+    selcx: &mut SelectionContext<'cx,'tcx>,
+    obligation: &ProjectionTyObligation<'tcx>,
+    obligation_trait_ref: &ty::TraitRef<'tcx>)
+    -> (Ty<'tcx>, Vec<PredicateObligation<'tcx>>)
+{
+    let poly_trait_ref = obligation_trait_ref.to_poly_trait_ref();
+    let trait_obligation = obligation.with(poly_trait_ref.to_poly_trait_predicate());
+    let vtable = match selcx.select(&trait_obligation) {
+        Ok(Some(vtable)) => vtable,
+        _ => {
+            span_bug!(
+                obligation.cause.span,
+                "Failed to select `{:?}`",
+                trait_obligation);
+        }
+    };
+
+    match vtable {
+        super::VtableImpl(data) =>
+            confirm_impl_candidate(selcx, obligation, data),
+        super::VtableClosure(data) =>
+            confirm_closure_candidate(selcx, obligation, data),
+        super::VtableFnPointer(data) =>
+            confirm_fn_pointer_candidate(selcx, obligation, data),
+        super::VtableObject(_) =>
+            confirm_object_candidate(selcx, obligation, obligation_trait_ref),
+        super::VtableDefaultImpl(..) |
+        super::VtableParam(..) |
+        super::VtableBuiltin(..) =>
+            // we don't create Select candidates with this kind of resolution
+            span_bug!(
+                obligation.cause.span,
+                "Cannot project an associated type from `{:?}`",
+                vtable),
+    }
+}
+
+fn confirm_object_candidate<'cx,'tcx>(
+    selcx: &mut SelectionContext<'cx,'tcx>,
+    obligation:  &ProjectionTyObligation<'tcx>,
+    obligation_trait_ref: &ty::TraitRef<'tcx>)
+    -> (Ty<'tcx>, Vec<PredicateObligation<'tcx>>)
 {
     let self_ty = obligation_trait_ref.self_ty();
     let object_ty = selcx.infcx().shallow_resolve(self_ty);
@@ -868,127 +1000,49 @@ fn assemble_candidates_from_object_type<'cx,'tcx>(
     let env_predicates = projection_bounds.iter()
                                           .map(|p| p.to_predicate())
                                           .collect();
-    let env_predicates = elaborate_predicates(selcx.tcx(), env_predicates);
-    assemble_candidates_from_predicates(selcx,
-                                        obligation,
-                                        obligation_trait_ref,
-                                        candidate_set,
-                                        ProjectionTyCandidate::ParamEnv,
-                                        env_predicates)
-}
+    let env_predicate = {
+        let env_predicates = elaborate_predicates(selcx.tcx(), env_predicates);
 
-fn assemble_candidates_from_impls<'cx,'tcx>(
-    selcx: &mut SelectionContext<'cx,'tcx>,
-    obligation: &ProjectionTyObligation<'tcx>,
-    obligation_trait_ref: &ty::TraitRef<'tcx>,
-    candidate_set: &mut ProjectionTyCandidateSet<'tcx>)
-    -> Result<(), SelectionError<'tcx>>
-{
-    // If we are resolving `<T as TraitRef<...>>::Item == Type`,
-    // start out by selecting the predicate `T as TraitRef<...>`:
-    let poly_trait_ref = obligation_trait_ref.to_poly_trait_ref();
-    let trait_obligation = obligation.with(poly_trait_ref.to_poly_trait_predicate());
-    let vtable = match selcx.select(&trait_obligation) {
-        Ok(Some(vtable)) => vtable,
-        Ok(None) => {
-            candidate_set.ambiguous = true;
-            return Ok(());
-        }
-        Err(e) => {
-            debug!("assemble_candidates_from_impls: selection error {:?}",
-                   e);
-            return Err(e);
+        // select only those projections that are actually projecting an
+        // item with the correct name
+        let env_predicates = env_predicates.filter_map(|p| match p {
+            ty::Predicate::Projection(data) =>
+                if data.item_name() == obligation.predicate.item_name {
+                    Some(data)
+                } else {
+                    None
+                },
+            _ => None
+        });
+
+        // select those with a relevant trait-ref
+        let mut env_predicates = env_predicates.filter(|data| {
+            let origin = TypeOrigin::RelateOutputImplTypes(obligation.cause.span);
+            let data_poly_trait_ref = data.to_poly_trait_ref();
+            let obligation_poly_trait_ref = obligation_trait_ref.to_poly_trait_ref();
+            selcx.infcx().probe(|_| {
+                selcx.infcx().sub_poly_trait_refs(false,
+                                                  origin,
+                                                  data_poly_trait_ref,
+                                                  obligation_poly_trait_ref).is_ok()
+            })
+        });
+
+        // select the first matching one; there really ought to be one or
+        // else the object type is not WF, since an object type should
+        // include all of its projections explicitly
+        match env_predicates.next() {
+            Some(env_predicate) => env_predicate,
+            None => {
+                debug!("confirm_object_candidate: no env-predicate \
+                        found in object type `{:?}`; ill-formed",
+                       object_ty);
+                return (selcx.tcx().types.err, vec!());
+            }
         }
     };
 
-    match vtable {
-        super::VtableImpl(data) => {
-            debug!("assemble_candidates_from_impls: impl candidate {:?}",
-                   data);
-
-            candidate_set.vec.push(
-                ProjectionTyCandidate::Impl(data));
-        }
-        super::VtableObject(_) => {
-            assemble_candidates_from_object_type(
-                selcx, obligation, obligation_trait_ref, candidate_set);
-        }
-        super::VtableClosure(data) => {
-            candidate_set.vec.push(
-                ProjectionTyCandidate::Closure(data));
-        }
-        super::VtableFnPointer(fn_type) => {
-            candidate_set.vec.push(
-                ProjectionTyCandidate::FnPointer(fn_type));
-        }
-        super::VtableParam(..) => {
-            // This case tell us nothing about the value of an
-            // associated type. Consider:
-            //
-            // ```
-            // trait SomeTrait { type Foo; }
-            // fn foo<T:SomeTrait>(...) { }
-            // ```
-            //
-            // If the user writes `<T as SomeTrait>::Foo`, then the `T
-            // : SomeTrait` binding does not help us decide what the
-            // type `Foo` is (at least, not more specifically than
-            // what we already knew).
-            //
-            // But wait, you say! What about an example like this:
-            //
-            // ```
-            // fn bar<T:SomeTrait<Foo=usize>>(...) { ... }
-            // ```
-            //
-            // Doesn't the `T : Sometrait<Foo=usize>` predicate help
-            // resolve `T::Foo`? And of course it does, but in fact
-            // that single predicate is desugared into two predicates
-            // in the compiler: a trait predicate (`T : SomeTrait`) and a
-            // projection. And the projection where clause is handled
-            // in `assemble_candidates_from_param_env`.
-        }
-        super::VtableDefaultImpl(..) |
-        super::VtableBuiltin(..) => {
-            // These traits have no associated types.
-            span_bug!(
-                obligation.cause.span,
-                "Cannot project an associated type from `{:?}`",
-                vtable);
-        }
-    }
-
-    Ok(())
-}
-
-fn confirm_candidate<'cx,'tcx>(
-    selcx: &mut SelectionContext<'cx,'tcx>,
-    obligation: &ProjectionTyObligation<'tcx>,
-    candidate: ProjectionTyCandidate<'tcx>)
-    -> (Ty<'tcx>, Vec<PredicateObligation<'tcx>>)
-{
-    debug!("confirm_candidate(candidate={:?}, obligation={:?})",
-           candidate,
-           obligation);
-
-    match candidate {
-        ProjectionTyCandidate::ParamEnv(poly_projection) |
-        ProjectionTyCandidate::TraitDef(poly_projection) => {
-            confirm_param_env_candidate(selcx, obligation, poly_projection)
-        }
-
-        ProjectionTyCandidate::Impl(impl_vtable) => {
-            confirm_impl_candidate(selcx, obligation, impl_vtable)
-        }
-
-        ProjectionTyCandidate::Closure(closure_vtable) => {
-            confirm_closure_candidate(selcx, obligation, closure_vtable)
-        }
-
-        ProjectionTyCandidate::FnPointer(fn_type) => {
-            confirm_fn_pointer_candidate(selcx, obligation, fn_type)
-        }
-    }
+    confirm_param_env_candidate(selcx, obligation, env_predicate)
 }
 
 fn confirm_fn_pointer_candidate<'cx,'tcx>(

--- a/src/librustc/ty/flags.rs
+++ b/src/librustc/ty/flags.rs
@@ -170,8 +170,13 @@ impl FlagComputation {
 
     fn add_region(&mut self, r: ty::Region) {
         match r {
-            ty::ReVar(..) |
-            ty::ReSkolemized(..) => { self.add_flags(TypeFlags::HAS_RE_INFER); }
+            ty::ReVar(..) => {
+                self.add_flags(TypeFlags::HAS_RE_INFER);
+            }
+            ty::ReSkolemized(..) => {
+                self.add_flags(TypeFlags::HAS_RE_INFER);
+                self.add_flags(TypeFlags::HAS_RE_SKOL);
+            }
             ty::ReLateBound(debruijn, _) => { self.add_depth(debruijn.depth); }
             ty::ReEarlyBound(..) => { self.add_flags(TypeFlags::HAS_RE_EARLY_BOUND); }
             ty::ReStatic => {}

--- a/src/librustc/ty/fold.rs
+++ b/src/librustc/ty/fold.rs
@@ -394,6 +394,15 @@ impl<'tcx> TyCtxt<'tcx> {
         }
     }
 
+    pub fn collect_late_bound_regions<T>(&self, value: &Binder<T>)
+                                         -> FnvHashSet<ty::BoundRegion>
+        where T : TypeFoldable<'tcx>
+    {
+        let mut collector = LateBoundRegionsCollector::new();
+        value.skip_binder().visit_with(&mut collector);
+        collector.regions
+    }
+
     /// Replace any late-bound regions bound in `value` with `'static`. Useful in trans but also
     /// method lookup and a few other places where precise region relationships are not required.
     pub fn erase_late_bound_regions<T>(&self, value: &Binder<T>) -> T
@@ -640,3 +649,39 @@ impl<'tcx> TypeVisitor<'tcx> for HasTypeFlagsVisitor {
         false
     }
 }
+
+/// Collects all the late-bound regions it finds into a hash set.
+struct LateBoundRegionsCollector {
+    current_depth: u32,
+    regions: FnvHashSet<ty::BoundRegion>,
+}
+
+impl LateBoundRegionsCollector {
+    fn new() -> Self {
+        LateBoundRegionsCollector {
+            current_depth: 1,
+            regions: FnvHashSet(),
+        }
+    }
+}
+
+impl<'tcx> TypeVisitor<'tcx> for LateBoundRegionsCollector {
+    fn enter_region_binder(&mut self) {
+        self.current_depth += 1;
+    }
+
+    fn exit_region_binder(&mut self) {
+        self.current_depth -= 1;
+    }
+
+    fn visit_region(&mut self, r: ty::Region) -> bool {
+        match r {
+            ty::ReLateBound(debruijn, br) if debruijn.depth == self.current_depth => {
+                self.regions.insert(br);
+            }
+            _ => { }
+        }
+        true
+    }
+}
+

--- a/src/librustc/ty/fold.rs
+++ b/src/librustc/ty/fold.rs
@@ -399,7 +399,8 @@ impl<'tcx> TyCtxt<'tcx> {
         where T : TypeFoldable<'tcx>
     {
         let mut collector = LateBoundRegionsCollector::new();
-        value.skip_binder().visit_with(&mut collector);
+        let result = value.skip_binder().visit_with(&mut collector);
+        assert!(!result); // should never have stopped early
         collector.regions
     }
 
@@ -681,7 +682,7 @@ impl<'tcx> TypeVisitor<'tcx> for LateBoundRegionsCollector {
             }
             _ => { }
         }
-        true
+        false
     }
 }
 

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -475,15 +475,16 @@ bitflags! {
         const HAS_SELF           = 1 << 1,
         const HAS_TY_INFER       = 1 << 2,
         const HAS_RE_INFER       = 1 << 3,
-        const HAS_RE_EARLY_BOUND = 1 << 4,
-        const HAS_FREE_REGIONS   = 1 << 5,
-        const HAS_TY_ERR         = 1 << 6,
-        const HAS_PROJECTION     = 1 << 7,
-        const HAS_TY_CLOSURE     = 1 << 8,
+        const HAS_RE_SKOL        = 1 << 4,
+        const HAS_RE_EARLY_BOUND = 1 << 5,
+        const HAS_FREE_REGIONS   = 1 << 6,
+        const HAS_TY_ERR         = 1 << 7,
+        const HAS_PROJECTION     = 1 << 8,
+        const HAS_TY_CLOSURE     = 1 << 9,
 
         // true if there are "names" of types and regions and so forth
         // that are local to a particular fn
-        const HAS_LOCAL_NAMES   = 1 << 9,
+        const HAS_LOCAL_NAMES    = 1 << 10,
 
         const NEEDS_SUBST        = TypeFlags::HAS_PARAMS.bits |
                                    TypeFlags::HAS_SELF.bits |

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -188,6 +188,10 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
             id: LintId::of(ILLEGAL_STRUCT_OR_ENUM_CONSTANT_PATTERN),
             reference: "RFC 1445 <https://github.com/rust-lang/rfcs/pull/1445>",
         },
+        FutureIncompatibleInfo {
+            id: LintId::of(HR_LIFETIME_IN_ASSOC_TYPE),
+            reference: "issue #32330 <https://github.com/rust-lang/rust/issues/32330>",
+        },
         ]);
 
     // We have one lint pass defined specially

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -922,8 +922,8 @@ fn ast_type_binding_to_poly_projection_predicate<'tcx>(
     //
     //     for<'a> <T as Iterator>::Item = &'a str // <-- 'a is bad
     //     for<'a> <T as FnMut<(&'a u32,)>>::Output = &'a str // <-- 'a is ok
-    let late_bound_in_trait_ref = tcx.collect_late_bound_regions(&trait_ref);
-    let late_bound_in_ty = tcx.collect_late_bound_regions(&ty::Binder(binding.ty));
+    let late_bound_in_trait_ref = tcx.collect_constrained_late_bound_regions(&trait_ref);
+    let late_bound_in_ty = tcx.collect_referenced_late_bound_regions(&ty::Binder(binding.ty));
     debug!("late_bound_in_trait_ref = {:?}", late_bound_in_trait_ref);
     debug!("late_bound_in_ty = {:?}", late_bound_in_ty);
     for br in late_bound_in_ty.difference(&late_bound_in_trait_ref) {
@@ -1702,9 +1702,9 @@ pub fn ast_ty_to_ty<'tcx>(this: &AstConv<'tcx>,
             // checking for here would be considered early bound
             // anyway.)
             let inputs = bare_fn_ty.sig.inputs();
-            let late_bound_in_args = this.tcx().collect_late_bound_regions(&inputs);
+            let late_bound_in_args = this.tcx().collect_constrained_late_bound_regions(&inputs);
             let output = bare_fn_ty.sig.output();
-            let late_bound_in_ret = this.tcx().collect_late_bound_regions(&output);
+            let late_bound_in_ret = this.tcx().collect_referenced_late_bound_regions(&output);
             for br in late_bound_in_ret.difference(&late_bound_in_args) {
                 let br_name = match *br {
                     ty::BrNamed(_, name) => name,

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -930,10 +930,10 @@ fn ast_type_binding_to_poly_projection_predicate<'tcx>(
         let br_name = match *br {
             ty::BrNamed(_, name) => name,
             _ => {
-                this.tcx().sess.span_bug(
+                span_bug!(
                     binding.span,
-                    &format!("anonymous bound region {:?} in binding but not trait ref",
-                             br));
+                    "anonymous bound region {:?} in binding but not trait ref",
+                    br);
             }
         };
         this.tcx().sess.add_lint(
@@ -1709,11 +1709,10 @@ pub fn ast_ty_to_ty<'tcx>(this: &AstConv<'tcx>,
                 let br_name = match *br {
                     ty::BrNamed(_, name) => name,
                     _ => {
-                        this.tcx().sess.span_bug(
+                        span_bug!(
                             bf.decl.output.span(),
-                            &format!("anonymous bound region {:?} in \
-                                      return but not args",
-                                     br));
+                            "anonymous bound region {:?} in return but not args",
+                            br);
                     }
                 };
                 this.tcx().sess.add_lint(

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -63,20 +63,18 @@ use require_c_abi_if_variadic;
 use rscope::{self, UnelidableRscope, RegionScope, ElidableRscope,
              ObjectLifetimeDefaultRscope, ShiftedRscope, BindingRscope,
              ElisionFailureInfo, ElidedLifetime};
-use util::common::{ErrorReported, FN_OUTPUT_NAME};
-use util::nodemap::FnvHashSet;
-
+use rustc::lint;
+use rustc_back::slice;
 use rustc_const_math::ConstInt;
-
+use rustc_front::print::pprust;
+use rustc_front::hir;
 use syntax::{abi, ast};
 use syntax::codemap::{Span, Pos};
 use syntax::errors::DiagnosticBuilder;
 use syntax::feature_gate::{GateIssue, emit_feature_err};
 use syntax::parse::token;
-
-use rustc_front::print::pprust;
-use rustc_front::hir;
-use rustc_back::slice;
+use util::common::{ErrorReported, FN_OUTPUT_NAME};
+use util::nodemap::FnvHashSet;
 
 pub trait AstConv<'tcx> {
     fn tcx<'a>(&'a self) -> &'a TyCtxt<'tcx>;
@@ -690,6 +688,7 @@ pub fn instantiate_poly_trait_ref<'tcx>(
                                PathParamMode::Explicit,
                                trait_def_id,
                                self_ty,
+                               trait_ref.ref_id,
                                trait_ref.path.segments.last().unwrap(),
                                poly_projections)
 }
@@ -737,6 +736,7 @@ fn object_path_to_poly_trait_ref<'a,'tcx>(
     span: Span,
     param_mode: PathParamMode,
     trait_def_id: DefId,
+    trait_path_ref_id: ast::NodeId,
     trait_segment: &hir::PathSegment,
     mut projections: &mut Vec<ty::PolyProjectionPredicate<'tcx>>)
     -> ty::PolyTraitRef<'tcx>
@@ -747,6 +747,7 @@ fn object_path_to_poly_trait_ref<'a,'tcx>(
                                param_mode,
                                trait_def_id,
                                None,
+                               trait_path_ref_id,
                                trait_segment,
                                projections)
 }
@@ -758,6 +759,7 @@ fn ast_path_to_poly_trait_ref<'a,'tcx>(
     param_mode: PathParamMode,
     trait_def_id: DefId,
     self_ty: Option<Ty<'tcx>>,
+    path_id: ast::NodeId,
     trait_segment: &hir::PathSegment,
     poly_projections: &mut Vec<ty::PolyProjectionPredicate<'tcx>>)
     -> ty::PolyTraitRef<'tcx>
@@ -788,6 +790,7 @@ fn ast_path_to_poly_trait_ref<'a,'tcx>(
                 // specify type to assert that error was already reported in Err case:
                 let predicate: Result<_, ErrorReported> =
                     ast_type_binding_to_poly_projection_predicate(this,
+                                                                  path_id,
                                                                   poly_trait_ref.clone(),
                                                                   self_ty,
                                                                   binding);
@@ -884,6 +887,7 @@ fn create_substs_for_ast_trait_ref<'a,'tcx>(this: &AstConv<'tcx>,
 
 fn ast_type_binding_to_poly_projection_predicate<'tcx>(
     this: &AstConv<'tcx>,
+    path_id: ast::NodeId,
     mut trait_ref: ty::PolyTraitRef<'tcx>,
     self_ty: Option<Ty<'tcx>>,
     binding: &ConvertedBinding<'tcx>)
@@ -932,11 +936,13 @@ fn ast_type_binding_to_poly_projection_predicate<'tcx>(
                              br));
             }
         };
-        this.tcx().sess.span_err(
+        this.tcx().sess.add_lint(
+            lint::builtin::HR_LIFETIME_IN_ASSOC_TYPE,
+            path_id,
             binding.span,
-            &format!("binding for associated type `{}` references lifetime `{}`, \
-                      which does not appear in the trait input types",
-                     binding.item_name, br_name));
+            format!("binding for associated type `{}` references lifetime `{}`, \
+                     which does not appear in the trait input types",
+                    binding.item_name, br_name));
     }
 
     // Simple case: X is defined in the current trait.
@@ -1069,6 +1075,7 @@ fn ast_ty_to_trait_ref<'tcx>(this: &AstConv<'tcx>,
                                                                   path.span,
                                                                   PathParamMode::Explicit,
                                                                   trait_def_id,
+                                                                  ty.id,
                                                                   path.segments.last().unwrap(),
                                                                   &mut projection_bounds);
                     Ok((trait_ref, projection_bounds))
@@ -1479,6 +1486,7 @@ fn base_def_to_ty<'tcx>(this: &AstConv<'tcx>,
                         param_mode: PathParamMode,
                         def: &Def,
                         opt_self_ty: Option<Ty<'tcx>>,
+                        base_path_ref_id: ast::NodeId,
                         base_segments: &[hir::PathSegment])
                         -> Ty<'tcx> {
     let tcx = this.tcx();
@@ -1494,6 +1502,7 @@ fn base_def_to_ty<'tcx>(this: &AstConv<'tcx>,
                                                           span,
                                                           param_mode,
                                                           trait_def_id,
+                                                          base_path_ref_id,
                                                           base_segments.last().unwrap(),
                                                           &mut projection_bounds);
 
@@ -1583,6 +1592,7 @@ pub fn finish_resolving_def_to_ty<'tcx>(this: &AstConv<'tcx>,
                                         param_mode: PathParamMode,
                                         def: &Def,
                                         opt_self_ty: Option<Ty<'tcx>>,
+                                        base_path_ref_id: ast::NodeId,
                                         base_segments: &[hir::PathSegment],
                                         assoc_segments: &[hir::PathSegment])
                                         -> Ty<'tcx> {
@@ -1592,6 +1602,7 @@ pub fn finish_resolving_def_to_ty<'tcx>(this: &AstConv<'tcx>,
                                 param_mode,
                                 def,
                                 opt_self_ty,
+                                base_path_ref_id,
                                 base_segments);
     let mut def = *def;
     // If any associated type segments remain, attempt to resolve them.
@@ -1671,7 +1682,50 @@ pub fn ast_ty_to_ty<'tcx>(this: &AstConv<'tcx>,
         }
         hir::TyBareFn(ref bf) => {
             require_c_abi_if_variadic(tcx, &bf.decl, bf.abi, ast_ty.span);
-            tcx.mk_fn_ptr(ty_of_bare_fn(this, bf.unsafety, bf.abi, &bf.decl))
+            let bare_fn_ty = ty_of_bare_fn(this,
+                                           bf.unsafety,
+                                           bf.abi,
+                                           &bf.decl);
+
+            // Find any late-bound regions declared in return type that do
+            // not appear in the arguments. These are not wellformed.
+            //
+            // Example:
+            //
+            //     for<'a> fn() -> &'a str <-- 'a is bad
+            //     for<'a> fn(&'a String) -> &'a str <-- 'a is ok
+            //
+            // Note that we do this check **here** and not in
+            // `ty_of_bare_fn` because the latter is also used to make
+            // the types for fn items, and we do not want to issue a
+            // warning then. (Once we fix #32330, the regions we are
+            // checking for here would be considered early bound
+            // anyway.)
+            let inputs = bare_fn_ty.sig.inputs();
+            let late_bound_in_args = this.tcx().collect_late_bound_regions(&inputs);
+            let output = bare_fn_ty.sig.output();
+            let late_bound_in_ret = this.tcx().collect_late_bound_regions(&output);
+            for br in late_bound_in_ret.difference(&late_bound_in_args) {
+                let br_name = match *br {
+                    ty::BrNamed(_, name) => name,
+                    _ => {
+                        this.tcx().sess.span_bug(
+                            bf.decl.output.span(),
+                            &format!("anonymous bound region {:?} in \
+                                      return but not args",
+                                     br));
+                    }
+                };
+                this.tcx().sess.add_lint(
+                    lint::builtin::HR_LIFETIME_IN_ASSOC_TYPE,
+                    ast_ty.id,
+                    bf.decl.output.span(),
+                    format!("return type references lifetime `{}`, \
+                             which does not appear in the argument types",
+                            br_name));
+            }
+
+            tcx.mk_fn_ptr(bare_fn_ty)
         }
         hir::TyPolyTraitRef(ref bounds) => {
             conv_ty_poly_trait_ref(this, rscope, ast_ty.span, bounds)
@@ -1699,6 +1753,7 @@ pub fn ast_ty_to_ty<'tcx>(this: &AstConv<'tcx>,
                                                 PathParamMode::Explicit,
                                                 &def,
                                                 opt_self_ty,
+                                                ast_ty.id,
                                                 &path.segments[..base_ty_end],
                                                 &path.segments[base_ty_end..]);
 
@@ -1791,8 +1846,11 @@ pub fn ty_of_method<'tcx>(this: &AstConv<'tcx>,
     (bare_fn_ty, optional_explicit_self_category.unwrap())
 }
 
-pub fn ty_of_bare_fn<'tcx>(this: &AstConv<'tcx>, unsafety: hir::Unsafety, abi: abi::Abi,
-                                              decl: &hir::FnDecl) -> ty::BareFnTy<'tcx> {
+pub fn ty_of_bare_fn<'tcx>(this: &AstConv<'tcx>,
+                           unsafety: hir::Unsafety,
+                           abi: abi::Abi,
+                           decl: &hir::FnDecl)
+                           -> ty::BareFnTy<'tcx> {
     let (bare_fn_ty, _) = ty_of_method_or_bare_fn(this, unsafety, abi, None, decl);
     bare_fn_ty
 }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3749,6 +3749,7 @@ pub fn resolve_ty_and_def_ufcs<'a, 'b, 'tcx>(fcx: &FnCtxt<'b, 'tcx>,
                                                      PathParamMode::Optional,
                                                      &mut def,
                                                      opt_self_ty,
+                                                     node_id,
                                                      &ty_segments[..base_ty_end],
                                                      &ty_segments[base_ty_end..]);
         let item_segment = path.segments.last().unwrap();

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -545,7 +545,8 @@ fn convert_method<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
 
     let (fty, explicit_self_category) =
         astconv::ty_of_method(&ccx.icx(&(rcvr_ty_predicates, &sig.generics)),
-                              sig, untransformed_rcvr_ty);
+                              sig,
+                              untransformed_rcvr_ty);
 
     let def_id = ccx.tcx.map.local_def_id(id);
     let substs = ccx.tcx.mk_substs(mk_item_substs(ccx, &ty_generics));
@@ -1457,7 +1458,10 @@ fn compute_type_scheme_of_item<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
         }
         hir::ItemFn(ref decl, unsafety, _, abi, ref generics, _) => {
             let ty_generics = ty_generics_for_fn(ccx, generics, &ty::Generics::empty());
-            let tofd = astconv::ty_of_bare_fn(&ccx.icx(generics), unsafety, abi, &decl);
+            let tofd = astconv::ty_of_bare_fn(&ccx.icx(generics),
+                                              unsafety,
+                                              abi,
+                                              &decl);
             let def_id = ccx.tcx.map.local_def_id(it.id);
             let substs = tcx.mk_substs(mk_item_substs(ccx, &ty_generics));
             let ty = tcx.mk_fn_def(def_id, substs, tofd);

--- a/src/test/compile-fail/associated-types/bound-lifetime-constrained.rs
+++ b/src/test/compile-fail/associated-types/bound-lifetime-constrained.rs
@@ -1,0 +1,66 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// revisions: func object clause 
+
+#![allow(dead_code)]
+#![feature(rustc_attrs)]
+#![feature(unboxed_closures)]
+#![deny(hr_lifetime_in_assoc_type)]
+
+trait Foo<'a> {
+    type Item;
+}
+
+impl<'a> Foo<'a> for() {
+    type Item = ();
+}
+
+// Check that appearing in a projection input in the argument is not enough:
+#[cfg(func)]
+fn func1(_: for<'a> fn(<() as Foo<'a>>::Item) -> &'a i32) {
+    //[func]~^ ERROR return type references lifetime `'a`
+    //[func]~| WARNING previously accepted
+}
+
+// Check that appearing in a projection input in the return still
+// causes an error:
+#[cfg(func)]
+fn func2(_: for<'a> fn() -> <() as Foo<'a>>::Item) {
+    //[func]~^ ERROR return type references lifetime `'a`
+    //[func]~| WARNING previously accepted
+}
+
+#[cfg(object)]
+fn object1(_: Box<for<'a> Fn(<() as Foo<'a>>::Item) -> &'a i32>) {
+    //[object]~^ ERROR return type references lifetime `'a`
+    //[object]~| WARNING previously accepted
+}
+
+#[cfg(object)]
+fn object2(_: Box<for<'a> Fn() -> <() as Foo<'a>>::Item>) {
+    //[object]~^ ERROR return type references lifetime `'a`
+    //[object]~| WARNING previously accepted
+}
+
+#[cfg(clause)]
+fn clause1<T>() where T: for<'a> Fn(<() as Foo<'a>>::Item) -> &'a i32 {
+    //[clause]~^ ERROR return type references lifetime `'a`
+    //[clause]~| WARNING previously accepted
+}
+
+#[cfg(clause)]
+fn clause2<T>() where T: for<'a> Fn() -> <() as Foo<'a>>::Item {
+    //[clause]~^ ERROR return type references lifetime `'a`
+    //[clause]~| WARNING previously accepted
+}
+
+#[rustc_error]
+fn main() { } //[ok]~ ERROR compilation successful

--- a/src/test/compile-fail/associated-types/bound-lifetime-constrained.rs
+++ b/src/test/compile-fail/associated-types/bound-lifetime-constrained.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// revisions: func object clause 
+// revisions: func object clause
 
 #![allow(dead_code)]
 #![feature(rustc_attrs)]
@@ -40,25 +40,25 @@ fn func2(_: for<'a> fn() -> <() as Foo<'a>>::Item) {
 
 #[cfg(object)]
 fn object1(_: Box<for<'a> Fn(<() as Foo<'a>>::Item) -> &'a i32>) {
-    //[object]~^ ERROR return type references lifetime `'a`
+    //[object]~^ ERROR `Output` references lifetime `'a`
     //[object]~| WARNING previously accepted
 }
 
 #[cfg(object)]
 fn object2(_: Box<for<'a> Fn() -> <() as Foo<'a>>::Item>) {
-    //[object]~^ ERROR return type references lifetime `'a`
+    //[object]~^ ERROR `Output` references lifetime `'a`
     //[object]~| WARNING previously accepted
 }
 
 #[cfg(clause)]
 fn clause1<T>() where T: for<'a> Fn(<() as Foo<'a>>::Item) -> &'a i32 {
-    //[clause]~^ ERROR return type references lifetime `'a`
+    //[clause]~^ ERROR `Output` references lifetime `'a`
     //[clause]~| WARNING previously accepted
 }
 
 #[cfg(clause)]
 fn clause2<T>() where T: for<'a> Fn() -> <() as Foo<'a>>::Item {
-    //[clause]~^ ERROR return type references lifetime `'a`
+    //[clause]~^ ERROR `Output` references lifetime `'a`
     //[clause]~| WARNING previously accepted
 }
 

--- a/src/test/compile-fail/associated-types/bound-lifetime-in-binding-only.rs
+++ b/src/test/compile-fail/associated-types/bound-lifetime-in-binding-only.rs
@@ -1,0 +1,71 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// revisions: angle paren ok elision
+
+#![allow(dead_code)]
+#![feature(rustc_attrs)]
+#![feature(unboxed_closures)]
+
+trait Foo {
+    type Item;
+}
+
+#[cfg(angle)]
+fn angle<T: for<'a> Foo<Item=&'a i32>>() {
+    //[angle]~^ ERROR binding for associated type `Item` references lifetime `'a`
+}
+
+#[cfg(angle)]
+fn angle1<T>() where T: for<'a> Foo<Item=&'a i32>>() {
+    //[angle]~^ ERROR binding for associated type `Item` references lifetime `'a`
+}
+
+#[cfg(angle)]
+fn angle2<T>() where for<'a> T: Foo<Item=&'a i32>>() {
+    //[angle]~^ ERROR binding for associated type `Item` references lifetime `'a`
+}
+
+#[cfg(paren)]
+fn paren<T: for<'a> Fn() -> &'a i32>() {
+    //[paren]~^ ERROR binding for associated type `Output` references lifetime `'a`
+}
+
+#[cfg(paren)]
+fn paren1<T> where T: for<'a> Fn() -> &'a i32>() {
+    //[paren]~^ ERROR binding for associated type `Output` references lifetime `'a`
+}
+
+#[cfg(paren)]
+fn paren2<T> where for<'a> T: Fn() -> &'a i32>() {
+    //[paren]~^ ERROR binding for associated type `Output` references lifetime `'a`
+}
+
+#[cfg(elision)]
+fn elision<T: Fn() -> &i32>() {
+    //[elision]~^ ERROR E0106
+}
+
+struct Parameterized<'a> { x: &'a str }
+
+#[cfg(ok)]
+fn ok1<T: for<'a> Fn(&Parameterized<'a>) -> &'a i32>() {
+}
+
+#[cfg(ok)]
+fn ok2<T: for<'a,'b> Fn<(&'b Parameterized<'a>,), Output=&'a i32>>() {
+}
+
+#[cfg(ok)]
+fn ok3<T> where for<'a> Parameterized<'a>: Foo<Item=&'a i32> {
+}
+
+#[rustc_error]
+fn main() { } //[ok]~ ERROR compilation successful

--- a/src/test/compile-fail/associated-types/bound-lifetime-in-binding-only.rs
+++ b/src/test/compile-fail/associated-types/bound-lifetime-in-binding-only.rs
@@ -13,6 +13,7 @@
 #![allow(dead_code)]
 #![feature(rustc_attrs)]
 #![feature(unboxed_closures)]
+#![deny(hr_lifetime_in_assoc_type)]
 
 trait Foo {
     type Item;
@@ -21,31 +22,49 @@ trait Foo {
 #[cfg(angle)]
 fn angle<T: for<'a> Foo<Item=&'a i32>>() {
     //[angle]~^ ERROR binding for associated type `Item` references lifetime `'a`
+    //[angle]~| WARNING previously accepted
 }
 
 #[cfg(angle)]
-fn angle1<T>() where T: for<'a> Foo<Item=&'a i32>>() {
+fn angle1<T>() where T: for<'a> Foo<Item=&'a i32> {
     //[angle]~^ ERROR binding for associated type `Item` references lifetime `'a`
+    //[angle]~| WARNING previously accepted
 }
 
 #[cfg(angle)]
-fn angle2<T>() where for<'a> T: Foo<Item=&'a i32>>() {
+fn angle2<T>() where for<'a> T: Foo<Item=&'a i32> {
     //[angle]~^ ERROR binding for associated type `Item` references lifetime `'a`
+    //[angle]~| WARNING previously accepted
+}
+
+#[cfg(angle)]
+fn angle3(_: &for<'a> Foo<Item=&'a i32>) {
+    //[angle]~^ ERROR binding for associated type `Item` references lifetime `'a`
+    //[angle]~| WARNING previously accepted
 }
 
 #[cfg(paren)]
 fn paren<T: for<'a> Fn() -> &'a i32>() {
     //[paren]~^ ERROR binding for associated type `Output` references lifetime `'a`
+    //[paren]~| WARNING previously accepted
 }
 
 #[cfg(paren)]
-fn paren1<T> where T: for<'a> Fn() -> &'a i32>() {
+fn paren1<T>() where T: for<'a> Fn() -> &'a i32 {
     //[paren]~^ ERROR binding for associated type `Output` references lifetime `'a`
+    //[paren]~| WARNING previously accepted
 }
 
 #[cfg(paren)]
-fn paren2<T> where for<'a> T: Fn() -> &'a i32>() {
+fn paren2<T>() where for<'a> T: Fn() -> &'a i32 {
     //[paren]~^ ERROR binding for associated type `Output` references lifetime `'a`
+    //[paren]~| WARNING previously accepted
+}
+
+#[cfg(paren)]
+fn paren3(_: &for<'a> Fn() -> &'a i32) {
+    //[paren]~^ ERROR binding for associated type `Output` references lifetime `'a`
+    //[paren]~| WARNING previously accepted
 }
 
 #[cfg(elision)]
@@ -64,7 +83,7 @@ fn ok2<T: for<'a,'b> Fn<(&'b Parameterized<'a>,), Output=&'a i32>>() {
 }
 
 #[cfg(ok)]
-fn ok3<T> where for<'a> Parameterized<'a>: Foo<Item=&'a i32> {
+fn ok3<T>() where for<'a> Parameterized<'a>: Foo<Item=&'a i32> {
 }
 
 #[rustc_error]

--- a/src/test/compile-fail/associated-types/bound-lifetime-in-return-only.rs
+++ b/src/test/compile-fail/associated-types/bound-lifetime-in-return-only.rs
@@ -1,0 +1,64 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// revisions: sig local structure ok elision
+
+#![allow(dead_code)]
+#![feature(rustc_attrs)]
+#![feature(unboxed_closures)]
+#![deny(hr_lifetime_in_assoc_type)]
+
+trait Foo {
+    type Item;
+}
+
+#[cfg(sig)]
+fn sig1(_: for<'a> fn() -> &'a i32) {
+    //[sig]~^ ERROR return type references lifetime `'a`
+    //[sig]~| WARNING previously accepted
+}
+
+#[cfg(sig)]
+fn sig2(_: for<'a, 'b> fn(&'b i32) -> &'a i32) {
+    //[sig]~^ ERROR return type references lifetime `'a`
+    //[sig]~| WARNING previously accepted
+}
+
+#[cfg(local)]
+fn local1() {
+    let _: for<'a> fn() -> &'a i32 = loop { };
+    //[local]~^ ERROR return type references lifetime `'a`
+    //[local]~| WARNING previously accepted
+}
+
+#[cfg(structure)]
+struct Struct1 {
+    x: for<'a> fn() -> &'a i32
+    //[structure]~^ ERROR return type references lifetime `'a`
+    //[structure]~| WARNING previously accepted
+}
+
+#[cfg(elision)]
+fn elision(_: fn() -> &i32) {
+    //[elision]~^ ERROR E0106
+}
+
+struct Parameterized<'a> { x: &'a str }
+
+#[cfg(ok)]
+fn ok1(_: &for<'a> Fn(&Parameterized<'a>) -> &'a i32) {
+}
+
+#[cfg(ok)]
+fn ok2(_: &for<'a,'b> Fn<(&'b Parameterized<'a>,), Output=&'a i32>) {
+}
+
+#[rustc_error]
+fn main() { } //[ok]~ ERROR compilation successful


### PR DESCRIPTION
This is part 1 of a series of patches to produce "future compatiblity" warnings for #32330. I have the actual fix in a branch, but I am planning to first land some patches so that we issue warnings for all the cases that will break once the fix is in place. 

This particular PR issues a warning for fn types where a higher-ranked region appears only in the return type, such as `for<'a> fn() -> &'a i32`, as well as for where clauses where a HR region appears only in a binding, such as `for<'a> Fn() -> &'a i32` or `for<'a> Iterator<Item=&'a i32>`.

I also included some a general refactoring of projection that makes the "assembling candidate" phase side-effect free, as intended. This is useful for the work that @soltanmm and I have been doing on plumbing obligations around but is otherwise kind of orthogonal.

r? @aturon 
cc @arielb1 
