### PR TITLE
Avoid page reload upon hitting "S" when browsing documentation in local mode

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -742,8 +742,6 @@
                 if ($(this).val().length === 0) {
                     if (browserSupportsHistoryApi()) {
                         history.replaceState("", "std - Rust", "?search=");
-                    } else {
-                        location.replace("?search=");
                     }
                     $('#main.content').removeClass('hidden');
                     $('#search.content').addClass('hidden');


### PR DESCRIPTION
The problem seems to have been introduced with commit 2910c0020661304df237fb8ed646296304c8e0d2
