### PR TITLE
syntax: Extra diagnostics for `_` used in an identifier position

### DIFF
--- a/src/test/compile-fail/cfg-empty-codemap.rs
+++ b/src/test/compile-fail/cfg-empty-codemap.rs
@@ -12,7 +12,7 @@
 
 // compile-flags: --cfg ""
 
-// error-pattern: expected ident, found
+// error-pattern: expected identifier, found
 
 pub fn main() {
 }

--- a/src/test/compile-fail/issue-20616-8.rs
+++ b/src/test/compile-fail/issue-20616-8.rs
@@ -40,7 +40,7 @@ type Type_5_<'a> = Type_1_<'a, ()>;
 //type Type_7 = Box<(),,>; // error: expected type, found `,`
 
 
-type Type_8<'a,,> = &'a (); //~ error: expected ident, found `,`
+type Type_8<'a,,> = &'a (); //~ error: expected identifier, found `,`
 
 
-//type Type_9<T,,> = Box<T>; // error: expected ident, found `,`
+//type Type_9<T,,> = Box<T>; // error: expected identifier, found `,`

--- a/src/test/compile-fail/issue-20616-9.rs
+++ b/src/test/compile-fail/issue-20616-9.rs
@@ -40,7 +40,7 @@ type Type_5_<'a> = Type_1_<'a, ()>;
 //type Type_7 = Box<(),,>; // error: expected type, found `,`
 
 
-//type Type_8<'a,,> = &'a (); // error: expected ident, found `,`
+//type Type_8<'a,,> = &'a (); // error: expected identifier, found `,`
 
 
-type Type_9<T,,> = Box<T>; //~ error: expected ident, found `,`
+type Type_9<T,,> = Box<T>; //~ error: expected identifier, found `,`

--- a/src/test/parse-fail/issue-32501.rs
+++ b/src/test/parse-fail/issue-32501.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,8 +10,12 @@
 
 // compile-flags: -Z parse-only
 
-// http://phpsadness.com/sad/1
-
 fn main() {
-    ::; //~ ERROR expected identifier, found `;`
+    let a = 0;
+    let _b = 0;
+    let _ = 0;
+    let mut b = 0;
+    let mut _b = 0;
+    let mut _ = 0; //~ ERROR expected identifier, found `_`
+    //~^ NOTE `_` is a wildcard pattern, not an identifier
 }

--- a/src/test/parse-fail/unboxed-closure-sugar-used-on-struct-3.rs
+++ b/src/test/parse-fail/unboxed-closure-sugar-used-on-struct-3.rs
@@ -24,7 +24,7 @@ fn bar() {
     let b = Box::Bar::<isize,usize>::new(); // OK
 
     let b = Box::Bar::()::new();
-    //~^ ERROR expected ident, found `(`
+    //~^ ERROR expected identifier, found `(`
 }
 
 fn main() { }


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/32501
