### PR TITLE
Fix missing console output in `Barrier` example

### DIFF
--- a/src/libstd/sync/barrier.rs
+++ b/src/libstd/sync/barrier.rs
@@ -17,16 +17,21 @@ use sync::{Mutex, Condvar};
 /// use std::sync::{Arc, Barrier};
 /// use std::thread;
 ///
+/// let mut handles = Vec::with_capacity(10);
 /// let barrier = Arc::new(Barrier::new(10));
 /// for _ in 0..10 {
 ///     let c = barrier.clone();
 ///     // The same messages will be printed together.
 ///     // You will NOT see any interleaving.
-///     thread::spawn(move|| {
+///     handles.push(thread::spawn(move|| {
 ///         println!("before wait");
 ///         c.wait();
 ///         println!("after wait");
-///     });
+///     }));
+/// }
+/// // Wait for other threads to finish.
+/// for handle in handles {
+///     handle.join().unwrap();
 /// }
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
The `println!` calls in the previous version were never shown (at least
not in the playpen) because the main thread is finished before all the
spawned child threads were synchronized. This commit adds a join for
each thread handle to wait in the main thread until all child threads
are finished.

r? @steveklabnik
