### PR TITLE
Plumb inference obligations through librustc/middle, take 3/2

### DIFF
--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -386,33 +386,6 @@ pub fn normalizing_infer_ctxt<'a, 'tcx>(tcx: &'a TyCtxt<'tcx>,
     infcx
 }
 
-/// Computes the least upper-bound of `a` and `b`. If this is not possible, reports an error and
-/// returns ty::err.
-pub fn common_supertype<'a, 'tcx>(cx: &InferCtxt<'a, 'tcx>,
-                                  origin: TypeOrigin,
-                                  a_is_expected: bool,
-                                  a: Ty<'tcx>,
-                                  b: Ty<'tcx>)
-                                  -> Ty<'tcx>
-{
-    debug!("common_supertype({:?}, {:?})",
-           a, b);
-
-    let trace = TypeTrace {
-        origin: origin,
-        values: Types(expected_found(a_is_expected, a, b))
-    };
-
-    let result = cx.commit_if_ok(|_| cx.lub(a_is_expected, trace.clone()).relate(&a, &b));
-    match result {
-        Ok(t) => t,
-        Err(ref err) => {
-            cx.report_and_explain_type_error(trace, err).emit();
-            cx.tcx.types.err
-        }
-    }
-}
-
 pub fn mk_subty<'a, 'tcx>(cx: &InferCtxt<'a, 'tcx>,
                           a_is_expected: bool,
                           origin: TypeOrigin,

--- a/src/librustc/traits/fulfill.rs
+++ b/src/librustc/traits/fulfill.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use dep_graph::DepGraph;
-use infer::InferCtxt;
+use infer::{InferCtxt, InferOk};
 use ty::{self, Ty, TyCtxt, TypeFoldable, ToPolyTraitRef};
 use rustc_data_structures::obligation_forest::{Backtrace, ObligationForest, Error};
 use std::iter;
@@ -526,7 +526,11 @@ fn process_predicate1<'a,'tcx>(selcx: &mut SelectionContext<'a,'tcx>,
 
         ty::Predicate::Equate(ref binder) => {
             match selcx.infcx().equality_predicate(obligation.cause.span, binder) {
-                Ok(()) => Ok(Some(Vec::new())),
+                Ok(InferOk { obligations }) => {
+                    // FIXME propagate obligations
+                    assert!(obligations.is_empty());
+                    Ok(Some(Vec::new()))
+                },
                 Err(_) => Err(CodeSelectionError(Unimplemented)),
             }
         }

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -2829,7 +2829,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                               -> bool
     {
         let mut matcher = ty::_match::Match::new(self.tcx());
-        matcher.relate(previous, current).is_ok()
+        matcher.relate(previous, current, &mut ()).is_ok()
     }
 
     fn push_stack<'o,'s:'o>(&mut self,

--- a/src/librustc_mir/transform/type_check.rs
+++ b/src/librustc_mir/transform/type_check.rs
@@ -12,7 +12,7 @@
 #![allow(unreachable_code)]
 
 use rustc::dep_graph::DepNode;
-use rustc::infer::{self, InferCtxt};
+use rustc::infer::{self, InferCtxt, InferOk};
 use rustc::traits::{self, ProjectionMode};
 use rustc::ty::fold::TypeFoldable;
 use rustc::ty::{self, Ty, TyCtxt};
@@ -336,15 +336,23 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
     fn mk_subty(&self, span: Span, sup: Ty<'tcx>, sub: Ty<'tcx>)
                 -> infer::UnitResult<'tcx>
     {
-        infer::mk_subty(self.infcx, false, infer::TypeOrigin::Misc(span),
-                        sup, sub)
+        infer::mk_subty(self.infcx, false, infer::TypeOrigin::Misc(span), sup, sub)
+            .map(|InferOk { obligations }| {
+                // FIXME propagate obligations
+                assert!(obligations.is_empty());
+                ()
+            })
     }
 
     fn mk_eqty(&self, span: Span, a: Ty<'tcx>, b: Ty<'tcx>)
                 -> infer::UnitResult<'tcx>
     {
-        infer::mk_eqty(self.infcx, false, infer::TypeOrigin::Misc(span),
-                       a, b)
+        infer::mk_eqty(self.infcx, false, infer::TypeOrigin::Misc(span), a, b)
+            .map(|InferOk { obligations }| {
+                // FIXME propagate obligations
+                assert!(obligations.is_empty());
+                ()
+            })
     }
 
     fn tcx(&self) -> &'a TyCtxt<'tcx> {

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use middle::free_region::FreeRegionMap;
-use rustc::infer::{self, TypeOrigin};
+use rustc::infer::{self, InferOk, TypeOrigin};
 use rustc::ty::{self, TyCtxt};
 use rustc::traits::{self, ProjectionMode};
 use rustc::ty::subst::{self, Subst, Substs, VecPerParamSpace};
@@ -475,7 +475,10 @@ pub fn compare_const_impl<'tcx>(tcx: &TyCtxt<'tcx>,
     });
 
     match err {
-        Ok(()) => { }
+        Ok(InferOk { obligations }) => {
+            // FIXME propagate obligations
+            assert!(obligations.is_empty());
+        }
         Err(terr) => {
             debug!("checking associated const for compatibility: impl ty {:?}, trait ty {:?}",
                    impl_ty,
@@ -485,7 +488,6 @@ pub fn compare_const_impl<'tcx>(tcx: &TyCtxt<'tcx>,
                       trait: {}",
                       trait_c.name,
                       terr);
-            return;
         }
     }
 }

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -16,12 +16,10 @@ use super::suggest;
 use check;
 use check::{FnCtxt, UnresolvedTypeAction};
 use middle::def_id::DefId;
-use rustc::ty::subst;
-use rustc::ty::subst::Subst;
+use rustc::ty::subst::{self, Subst};
 use rustc::traits;
 use rustc::ty::{self, NoPreference, Ty, TyCtxt, ToPolyTraitRef, TraitRef, TypeFoldable};
-use rustc::infer;
-use rustc::infer::{InferCtxt, TypeOrigin};
+use rustc::infer::{self, InferCtxt, InferOk, TypeOrigin};
 use syntax::ast;
 use syntax::codemap::{Span, DUMMY_SP};
 use rustc_front::hir;
@@ -1135,6 +1133,11 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
 
     fn make_sub_ty(&self, sub: Ty<'tcx>, sup: Ty<'tcx>) -> infer::UnitResult<'tcx> {
         self.infcx().sub_types(false, TypeOrigin::Misc(DUMMY_SP), sub, sup)
+            .map(|InferOk { obligations }| {
+                // FIXME propagate obligations
+                assert!(obligations.is_empty());
+                ()
+            })
     }
 
     fn has_applicable_self(&self, item: &ty::ImplOrTraitItem) -> bool {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -88,8 +88,7 @@ use middle::astconv_util::prohibit_type_params;
 use middle::cstore::LOCAL_CRATE;
 use middle::def::{self, Def};
 use middle::def_id::DefId;
-use rustc::infer;
-use rustc::infer::{TypeOrigin, TypeTrace, type_variable};
+use rustc::infer::{self, InferOk, TypeOrigin, TypeTrace, type_variable};
 use middle::pat_util::{self, pat_id_map};
 use rustc::traits::{self, report_fulfillment_errors, ProjectionMode, PredicateObligations};
 use rustc::ty::subst::{self, Subst, Substs, VecPerParamSpace, ParamSpace};
@@ -1629,6 +1628,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     sup: Ty<'tcx>)
                     -> Result<(), TypeError<'tcx>> {
         infer::mk_subty(self.infcx(), a_is_expected, origin, sub, sup)
+            .map(|InferOk { obligations }| {
+                // FIXME propagate obligations
+                assert!(obligations.is_empty());
+                ()
+            })
     }
 
     pub fn mk_eqty(&self,
@@ -1638,6 +1642,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                    sup: Ty<'tcx>)
                    -> Result<(), TypeError<'tcx>> {
         infer::mk_eqty(self.infcx(), a_is_expected, origin, sub, sup)
+            .map(|InferOk { obligations }| {
+                // FIXME propagate obligations
+                assert!(obligations.is_empty());
+                ()
+            })
     }
 
     pub fn mk_subr(&self,
@@ -1916,7 +1925,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                     match infer::mk_eqty(self.infcx(), false,
                                                          TypeOrigin::Misc(default.origin_span),
                                                          ty, default.ty) {
-                                        Ok(()) => {}
+                                        Ok(InferOk { obligations }) => {
+                                            // FIXME propagate obligations
+                                            assert!(obligations.is_empty());
+                                        }
                                         Err(_) => {
                                             conflicts.push((*ty, default));
                                         }
@@ -2009,7 +2021,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             match infer::mk_eqty(self.infcx(), false,
                                                  TypeOrigin::Misc(default.origin_span),
                                                  ty, default.ty) {
-                                Ok(()) => {}
+                                Ok(InferOk { obligations }) => {
+                                    // FIXME propagate obligations
+                                    assert!(obligations.is_empty());
+                                }
                                 Err(_) => {
                                     result = Some(default);
                                 }

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -92,7 +92,8 @@ use middle::region::{self, CodeExtent};
 use rustc::ty::subst::Substs;
 use rustc::traits;
 use rustc::ty::{self, Ty, TyCtxt, MethodCall, TypeFoldable};
-use rustc::infer::{self, GenericKind, InferCtxt, SubregionOrigin, TypeOrigin, VerifyBound};
+use rustc::infer::{self, GenericKind, InferCtxt, InferOk, SubregionOrigin, TypeOrigin,
+                   VerifyBound};
 use middle::pat_util;
 use rustc::ty::adjustment;
 use rustc::ty::wf::ImpliedBound;
@@ -1846,7 +1847,11 @@ fn declared_projection_bounds_from_trait<'a,'tcx>(rcx: &Rcx<'a, 'tcx>,
 
                 // check whether this predicate applies to our current projection
                 match infer::mk_eqty(infcx, false, TypeOrigin::Misc(span), ty, outlives.0) {
-                    Ok(()) => { Ok(outlives.1) }
+                    Ok(InferOk { obligations }) => {
+                        // FIXME propagate obligations
+                        assert!(obligations.is_empty());
+                        Ok(outlives.1)
+                    }
                     Err(_) => { Err(()) }
                 }
             });


### PR DESCRIPTION
This is a limited rewrite of #31867 due to its significant bitrot. Due to some recent work on master using `Lub` across multiple `commit_if_ok`s I plumbed type-relating side-effects through `relate.rs` instead of using internal state in individual `TypeRelation` implementors.

There's some miscellaneous clean-up and I'll admit to being lazy about using some old `try!`s instead of the `?` syntax, but IIRC that can be addressed by an automated tool taking a pass at the code again whenever.

Next up: replacing `consider_unification_despite_ambiguity` with a new obligation variant that's satisfied after a closure type has been determined.

cc @jroesch 
r? @nikomatsakis 
