### PR TITLE
rustbuild: Fix dist for non-host targets

### DIFF
--- a/src/bootstrap/build/doc.rs
+++ b/src/bootstrap/build/doc.rs
@@ -122,6 +122,22 @@ pub fn std(build: &Build, stage: u32, host: &str, out: &Path) {
     cp_r(&out_dir, out)
 }
 
+pub fn test(build: &Build, stage: u32, host: &str, out: &Path) {
+    println!("Documenting stage{} test ({})", stage, host);
+    let compiler = Compiler::new(stage, host);
+    let out_dir = build.stage_out(&compiler, Mode::Libtest)
+                       .join(host).join("doc");
+    let rustdoc = build.rustdoc(&compiler);
+
+    build.clear_if_dirty(&out_dir, &rustdoc);
+
+    let mut cargo = build.cargo(&compiler, Mode::Libtest, host, "doc");
+    cargo.arg("--manifest-path")
+         .arg(build.src.join("src/rustc/test_shim/Cargo.toml"));
+    build.run(&mut cargo);
+    cp_r(&out_dir, out)
+}
+
 pub fn rustc(build: &Build, stage: u32, host: &str, out: &Path) {
     println!("Documenting stage{} compiler ({})", stage, host);
     let compiler = Compiler::new(stage, host);

--- a/src/etc/tidy.py
+++ b/src/etc/tidy.py
@@ -31,6 +31,7 @@ stable_whitelist = {
     'src/libcore',
     'src/libstd',
     'src/rustc/std_shim',
+    'src/rustc/test_shim',
     'src/test'
 }
 

--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -12,7 +12,6 @@ crate-type = ["dylib"]
 arena = { path = "../libarena" }
 flate = { path = "../libflate" }
 fmt_macros = { path = "../libfmt_macros" }
-getopts = { path = "../libgetopts" }
 graphviz = { path = "../libgraphviz" }
 log = { path = "../liblog" }
 rbml = { path = "../librbml" }

--- a/src/librustc_driver/Cargo.toml
+++ b/src/librustc_driver/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["dylib"]
 [dependencies]
 arena = { path = "../libarena" }
 flate = { path = "../libflate" }
-getopts = { path = "../libgetopts" }
 graphviz = { path = "../libgraphviz" }
 log = { path = "../liblog" }
 rustc = { path = "../librustc" }

--- a/src/librustc_trans/Cargo.toml
+++ b/src/librustc_trans/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["dylib"]
 [dependencies]
 arena = { path = "../libarena" }
 flate = { path = "../libflate" }
-getopts = { path = "../libgetopts" }
 graphviz = { path = "../libgraphviz" }
 log = { path = "../liblog" }
 rustc = { path = "../librustc" }

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["dylib"]
 
 [dependencies]
 arena = { path = "../libarena" }
-getopts = { path = "../libgetopts" }
 rustc = { path = "../librustc" }
 rustc_back = { path = "../librustc_back" }
 rustc_driver = { path = "../librustc_driver" }
@@ -22,7 +21,6 @@ rustc_resolve = { path = "../librustc_resolve" }
 rustc_trans = { path = "../librustc_trans" }
 serialize = { path = "../libserialize" }
 syntax = { path = "../libsyntax" }
-test = { path = "../libtest" }
 log = { path = "../liblog" }
 
 [build-dependencies]

--- a/src/libsyntax/Cargo.toml
+++ b/src/libsyntax/Cargo.toml
@@ -10,6 +10,5 @@ crate-type = ["dylib"]
 
 [dependencies]
 serialize = { path = "../libserialize" }
-term = { path = "../libterm" }
 log = { path = "../liblog" }
 rustc_bitflags = { path = "../librustc_bitflags" }

--- a/src/rustc/Cargo.lock
+++ b/src/rustc/Cargo.lock
@@ -46,10 +46,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getopts"
-version = "0.0.0"
-
-[[package]]
 name = "graphviz"
 version = "0.0.0"
 
@@ -72,7 +68,6 @@ dependencies = [
  "arena 0.0.0",
  "flate 0.0.0",
  "fmt_macros 0.0.0",
- "getopts 0.0.0",
  "graphviz 0.0.0",
  "log 0.0.0",
  "rbml 0.0.0",
@@ -136,7 +131,6 @@ version = "0.0.0"
 dependencies = [
  "arena 0.0.0",
  "flate 0.0.0",
- "getopts 0.0.0",
  "graphviz 0.0.0",
  "log 0.0.0",
  "rustc 0.0.0",
@@ -151,6 +145,7 @@ dependencies = [
  "rustc_plugin 0.0.0",
  "rustc_privacy 0.0.0",
  "rustc_resolve 0.0.0",
+ "rustc_save_analysis 0.0.0",
  "rustc_trans 0.0.0",
  "rustc_typeck 0.0.0",
  "serialize 0.0.0",
@@ -274,12 +269,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_save_analysis"
+version = "0.0.0"
+dependencies = [
+ "log 0.0.0",
+ "rustc 0.0.0",
+ "rustc_front 0.0.0",
+ "syntax 0.0.0",
+]
+
+[[package]]
 name = "rustc_trans"
 version = "0.0.0"
 dependencies = [
  "arena 0.0.0",
  "flate 0.0.0",
- "getopts 0.0.0",
  "graphviz 0.0.0",
  "log 0.0.0",
  "rustc 0.0.0",
@@ -316,7 +320,6 @@ dependencies = [
  "arena 0.0.0",
  "build_helper 0.1.0",
  "gcc 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.0.0",
  "log 0.0.0",
  "rustc 0.0.0",
  "rustc_back 0.0.0",
@@ -328,7 +331,6 @@ dependencies = [
  "rustc_trans 0.0.0",
  "serialize 0.0.0",
  "syntax 0.0.0",
- "test 0.0.0",
 ]
 
 [[package]]
@@ -345,7 +347,6 @@ dependencies = [
  "log 0.0.0",
  "rustc_bitflags 0.0.0",
  "serialize 0.0.0",
- "term 0.0.0",
 ]
 
 [[package]]
@@ -353,19 +354,8 @@ name = "syntax_ext"
 version = "0.0.0"
 dependencies = [
  "fmt_macros 0.0.0",
+ "log 0.0.0",
  "syntax 0.0.0",
-]
-
-[[package]]
-name = "term"
-version = "0.0.0"
-
-[[package]]
-name = "test"
-version = "0.0.0"
-dependencies = [
- "getopts 0.0.0",
- "term 0.0.0",
 ]
 
 [[package]]

--- a/src/rustc/test_shim/Cargo.lock
+++ b/src/rustc/test_shim/Cargo.lock
@@ -1,0 +1,23 @@
+[root]
+name = "test_shim"
+version = "0.1.0"
+dependencies = [
+ "test 0.0.0",
+]
+
+[[package]]
+name = "getopts"
+version = "0.0.0"
+
+[[package]]
+name = "term"
+version = "0.0.0"
+
+[[package]]
+name = "test"
+version = "0.0.0"
+dependencies = [
+ "getopts 0.0.0",
+ "term 0.0.0",
+]
+

--- a/src/rustc/test_shim/Cargo.toml
+++ b/src/rustc/test_shim/Cargo.toml
@@ -1,0 +1,25 @@
+# This is a shim Cargo.toml which serves as a proxy for building libtest.
+#
+# The reason this shim exists is basically the same reason that `std_shim`
+# exists, and more documentation can be found in that `Cargo.toml` as to why.
+
+[package]
+name = "test_shim"
+version = "0.1.0"
+authors = ["The Rust Project Developers"]
+
+[lib]
+name = "test_shim"
+path = "lib.rs"
+
+[profile.release]
+opt-level = 2
+
+# These options are controlled from our rustc wrapper script, so turn them off
+# here and have them controlled elsewhere.
+[profile.dev]
+debug = false
+debug-assertions = false
+
+[dependencies]
+test = { path = "../../libtest" }

--- a/src/rustc/test_shim/lib.rs
+++ b/src/rustc/test_shim/lib.rs
@@ -1,0 +1,11 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// See comments in Cargo.toml for why this exists


### PR DESCRIPTION
The `rust-std` package that we produce is expected to have not only the standard
library but also libtest for compiling unit tests. Unfortunately this does not
currently happen due to the way rustbuild is structured.

There are currently two main stages of compilation in rustbuild, one for the
standard library and one for the compiler. This is primarily done to allow us to
fill in the sysroot right after the standard library has finished compiling to
continue compiling the rest of the crates. Consequently the entire compiler does
not have to explicitly depend on the standard library, and this also should
allow us to pull in crates.io dependencies into the build in the future because
they'll just naturally build against the std we just produced.

These phases, however, do not represent a cross-compiled build. Target-only
builds also require libtest, and libtest is currently part of the
all-encompassing "compiler build". There's unfortunately no way to learn about
just libtest and its dependencies (in a great and robust fashion) so to ensure
that we can copy the right artifacts over this commit introduces a new build
step, libtest.

The new libtest build step has documentation, dist, and link steps as std/rustc
already do. The compiler now depends on libtest instead of libstd, and all
compiler crates can now assume that test and its dependencies are implicitly
part of the sysroot (hence explicit dependencies being removed). This makes the
build a tad less parallel as in theory many rustc crates can be compiled in
parallel with libtest, but this likely isn't where we really need parallelism
either (all the time is still spent in the compiler).

All in all this allows the `dist-std` step to depend on both libstd and libtest,
so `rust-std` packages produced by rustbuild should start having both the
standard library and libtest.

Closes #32523
