### PR TITLE
allow RUST_BACKTRACE=0 to act as if unset

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,8 @@ which includes important information about what platform you're on, what
 version of Rust you're using, etc.
 
 Sometimes, a backtrace is helpful, and so including that is nice. To get
-a backtrace, set the `RUST_BACKTRACE` environment variable. The easiest way
+a backtrace, set the `RUST_BACKTRACE` environment variable to a value
+other than `0`. The easiest way
 to do this is to invoke `rustc` like this:
 
 ```bash

--- a/man/rustc.1
+++ b/man/rustc.1
@@ -268,7 +268,7 @@ the maximum number of threads used for this purpose.
 
 .TP
 \fBRUST_TEST_NOCAPTURE\fR
-A synonym for the --nocapture flag.
+If set to a value other than "0", a synonym for the --nocapture flag.
 
 .TP
 \fBRUST_MIN_STACK\fR
@@ -276,7 +276,7 @@ Sets the minimum stack size for new threads.
 
 .TP
 \fBRUST_BACKTRACE\fR
-If set, produces a backtrace in the output of a program which panics.
+If set to a value different than "0", produces a backtrace in the output of a program which panics.
 
 .SH "EXAMPLES"
 To build an executable from a source file with a main function:

--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -263,7 +263,10 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
         logfile: config.logfile.clone(),
         run_tests: true,
         bench_benchmarks: true,
-        nocapture: env::var("RUST_TEST_NOCAPTURE").is_ok(),
+        nocapture: match env::var("RUST_TEST_NOCAPTURE") {
+            Ok(val) => &val != "0",
+            Err(_) => false
+        },
         color: test::AutoColor,
     }
 }

--- a/src/doc/book/functions.md
+++ b/src/doc/book/functions.md
@@ -246,6 +246,19 @@ stack backtrace:
   13:                0x0 - <unknown>
 ```
 
+If you need to override an already set `RUST_BACKTRACE`, 
+in cases when you cannot just unset the variable, 
+then set it to `0` to avoid getting a backtrace. 
+Any other value(even no value at all) turns on backtrace.
+
+```text
+$ export RUST_BACKTRACE=1
+...
+$ RUST_BACKTRACE=0 ./diverges 
+thread '<main>' panicked at 'This function never returns!', hello.rs:2
+note: Run with `RUST_BACKTRACE=1` for a backtrace.
+```
+
 `RUST_BACKTRACE` also works with Cargo’s `run` command:
 
 ```text

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -1059,7 +1059,10 @@ pub fn monitor<F: FnOnce() + Send + 'static>(f: F) {
             for note in &xs {
                 emitter.emit(None, &note[..], None, errors::Level::Note)
             }
-            if let None = env::var_os("RUST_BACKTRACE") {
+            if match env::var_os("RUST_BACKTRACE") {
+                Some(val) => &val != "0",
+                None => false,
+            } {
                 emitter.emit(None,
                              "run with `RUST_BACKTRACE=1` for a backtrace",
                              None,

--- a/src/libstd/sys/common/backtrace.rs
+++ b/src/libstd/sys/common/backtrace.rs
@@ -36,7 +36,7 @@ pub fn log_enabled() -> bool {
     }
 
     let val = match env::var_os("RUST_BACKTRACE") {
-        Some(..) => 2,
+        Some(x) => if &x == "0" { 1 } else { 2 },
         None => 1,
     };
     ENABLED.store(val, Ordering::SeqCst);

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -349,8 +349,8 @@ By default, all tests are run in parallel. This can be altered with the
 RUST_TEST_THREADS environment variable when running tests (set it to 1).
 
 All tests have their standard output and standard error captured by default.
-This can be overridden with the --nocapture flag or the RUST_TEST_NOCAPTURE=1
-environment variable. Logging is not captured by default.
+This can be overridden with the --nocapture flag or setting RUST_TEST_NOCAPTURE
+environment variable to a value other than "0". Logging is not captured by default.
 
 Test Attributes:
 
@@ -399,7 +399,10 @@ pub fn parse_opts(args: &[String]) -> Option<OptRes> {
 
     let mut nocapture = matches.opt_present("nocapture");
     if !nocapture {
-        nocapture = env::var("RUST_TEST_NOCAPTURE").is_ok();
+        nocapture = match env::var("RUST_TEST_NOCAPTURE") {
+            Ok(val) => &val != "0",
+            Err(_) => false
+        };
     }
 
     let color = match matches.opt_str("color").as_ref().map(|s| &**s) {

--- a/src/test/run-pass/backtrace.rs
+++ b/src/test/run-pass/backtrace.rs
@@ -86,6 +86,16 @@ fn runtest(me: &str) {
     assert!(!s.contains("stack backtrace") && !s.contains(&expected("foo")),
             "bad output2: {}", s);
 
+    // Make sure the stack trace is *not* printed
+    // (RUST_BACKTRACE=0 acts as if it were unset from our own environment,
+    // in case developer is running `make check` with it set.)
+    let p = template(me).arg("fail").env("RUST_BACKTRACE","0").spawn().unwrap();
+    let out = p.wait_with_output().unwrap();
+    assert!(!out.status.success());
+    let s = str::from_utf8(&out.stderr).unwrap();
+    assert!(!s.contains("stack backtrace") && !s.contains(" - foo"),
+            "bad output3: {}", s);
+
     // Make sure a stack trace is printed
     let p = template(me).arg("double-fail").spawn().unwrap();
     let out = p.wait_with_output().unwrap();

--- a/src/test/run-pass/multi-panic.rs
+++ b/src/test/run-pass/multi-panic.rs
@@ -8,6 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+fn check_for_no_backtrace(test: std::process::Output) {
+    assert!(!test.status.success());
+    let err = String::from_utf8_lossy(&test.stderr);
+    let mut it = err.lines();
+
+    assert_eq!(it.next().map(|l| l.starts_with("thread '<unnamed>' panicked at")), Some(true));
+    assert_eq!(it.next(), Some("note: Run with `RUST_BACKTRACE=1` for a backtrace."));
+    assert_eq!(it.next().map(|l| l.starts_with("thread '<main>' panicked at")), Some(true));
+    assert_eq!(it.next(), None);
+}
+
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     if args.len() > 1 && args[1] == "run_test" {
@@ -21,13 +32,11 @@ fn main() {
                                                        .env_remove("RUST_BACKTRACE")
                                                        .output()
                                                        .unwrap();
-        assert!(!test.status.success());
-        let err = String::from_utf8_lossy(&test.stderr);
-        let mut it = err.lines();
-
-        assert_eq!(it.next().map(|l| l.starts_with("thread '<unnamed>' panicked at")), Some(true));
-        assert_eq!(it.next(), Some("note: Run with `RUST_BACKTRACE=1` for a backtrace."));
-        assert_eq!(it.next().map(|l| l.starts_with("thread '<main>' panicked at")), Some(true));
-        assert_eq!(it.next(), None);
+        check_for_no_backtrace(test);
+        let test = std::process::Command::new(&args[0]).arg("run_test")
+                                                       .env("RUST_BACKTRACE","0")
+                                                       .output()
+                                                       .unwrap();
+        check_for_no_backtrace(test);
     }
 }


### PR DESCRIPTION
**UPDATE:** `RUST_BACKTRACE=0` to act as if the env. var is unset! (now `0` is what `disabled` was for, below)

When RUST_BACKTRACE is set to "disabled" then this acts as if the env. var is unset. So, either make sure `RUST_BACKTRACE` is not set OR set it to `disabled` to achieve the same effect.

Sample usage:

``` bash
$ rustc -o /tmp/a.out -- <(echo 'fn main(){ panic!() }') && RUST_BACKTRACE=disabled /tmp/a.out
!! executing '/home/zazdxscf/build/1nonpkgs/rust/rust//x86_64-unknown-linux-gnu/stage2/bin//rustc' with args: '-o /tmp/a.out -- /dev/fd/63'
thread '<main>' panicked at 'explicit panic', /dev/fd/63:1
note: Run with `RUST_BACKTRACE=1` for a backtrace.

$ rustc -o /tmp/a.out -- <(echo 'fn main(){ panic!() }') && RUST_BACKTRACE=1 /tmp/a.out
!! executing '/home/zazdxscf/build/1nonpkgs/rust/rust//x86_64-unknown-linux-gnu/stage2/bin//rustc' with args: '-o /tmp/a.out -- /dev/fd/63'
thread '<main>' panicked at 'explicit panic', /dev/fd/63:1
stack backtrace:
   1:     0x55709e8148c0 - sys::backtrace::tracing::imp::write::h140f24a0cfc189b98Ru
   2:     0x55709e816a5b - panicking::default_hook::_$u7b$$u7b$closure$u7d$$u7d$::closure.45165
   3:     0x55709e8166e8 - panicking::default_hook::hed419823688cb82aXoA
   4:     0x55709e810fff - sys_common::unwind::begin_unwind_inner::hbb9642f6e212d56fmHt
   5:     0x55709e810513 - sys_common::unwind::begin_unwind::h16232867470678019594
   6:     0x55709e810489 - main::hb524f9576270962feaa
   7:     0x55709e816314 - sys_common::unwind::try::try_fn::h1274188004693518534
   8:     0x55709e813dfb - __rust_try
   9:     0x55709e815dab - rt::lang_start::h712b1cd650781872ahA
  10:     0x55709e810679 - main
  11:     0x7efd1026859f - __libc_start_main
  12:     0x55709e810348 - _start
  13:                0x0 - <unknown>
```

Some programs(eg. [vim's syntactic](https://github.com/scrooloose/syntastic) used by [rust.vim](https://github.com/rust-lang/rust.vim)) cannot unset the env. var RUST_BACKTRACE if it's already set(eg. in .bashrc) but [they can set it to some value](https://github.com/respeccing/gentooskyline/blob/cb5533e1598f871d3fdf7c3d8248ce767b5b9360/system/Z575/OSes/gentoo/on_baremetal/filesystem_now/gentoo/home/zazdxscf/build/1nonpkgs/rust.vim/upd#L17), and I needed to ensure the env. var is unset in order to avoid this issue: https://github.com/rust-lang/rust/issues/29293

**EDIT:** Sample usage 2:

``` bash
$ export RUST_BACKTRACE=1

$ rustc -o /tmp/a.out -- <(echo 'fn main(){ panic!() }') && /tmp/a.out
!! executing '/home/zazdxscf/build/1nonpkgs/rust/rust//x86_64-unknown-linux-gnu/stage2/bin//rustc' with args: '-o /tmp/a.out -- /dev/fd/63'
thread '<main>' panicked at 'explicit panic', /dev/fd/63:1
stack backtrace:
   1:     0x55c2696738c0 - sys::backtrace::tracing::imp::write::h140f24a0cfc189b98Ru
   2:     0x55c269675a5b - panicking::default_hook::_$u7b$$u7b$closure$u7d$$u7d$::closure.45165
   3:     0x55c2696756e8 - panicking::default_hook::hed419823688cb82aXoA
   4:     0x55c26966ffff - sys_common::unwind::begin_unwind_inner::hbb9642f6e212d56fmHt
   5:     0x55c26966f513 - sys_common::unwind::begin_unwind::h16023941661074805588
   6:     0x55c26966f489 - main::hb524f9576270962feaa
   7:     0x55c269675314 - sys_common::unwind::try::try_fn::h1274188004693518534
   8:     0x55c269672dfb - __rust_try
   9:     0x55c269674dab - rt::lang_start::h712b1cd650781872ahA
  10:     0x55c26966f679 - main
  11:     0x7f593d58459f - __libc_start_main
  12:     0x55c26966f348 - _start
  13:                0x0 - <unknown>

$ rustc -o /tmp/a.out -- <(echo 'fn main(){ panic!() }') && RUST_BACKTRACE=disabled /tmp/a.out
!! executing '/home/zazdxscf/build/1nonpkgs/rust/rust//x86_64-unknown-linux-gnu/stage2/bin//rustc' with args: '-o /tmp/a.out -- /dev/fd/63'
thread '<main>' panicked at 'explicit panic', /dev/fd/63:1
note: Run with `RUST_BACKTRACE=1` for a backtrace.

```
