### PR TITLE
Use weak_odr linkage when reusing definitions across codegen units

### DIFF
--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -1189,3 +1189,16 @@ extern "C" void LLVMRustPositionBuilderAtStart(LLVMBuilderRef B, LLVMBasicBlockR
     auto point = unwrap(BB)->getFirstInsertionPt();
     unwrap(B)->SetInsertPoint(unwrap(BB), point);
 }
+
+extern "C" void LLVMRustSetComdat(LLVMModuleRef M, LLVMValueRef V, const char *Name) {
+    Triple TargetTriple(unwrap(M)->getTargetTriple());
+    GlobalObject *GV = unwrap<GlobalObject>(V);
+    if (!TargetTriple.isOSBinFormatMachO()) {
+        GV->setComdat(unwrap(M)->getOrInsertComdat(Name));
+    }
+}
+
+extern "C" void LLVMRustUnsetComdat(LLVMValueRef V) {
+    GlobalObject *GV = unwrap<GlobalObject>(V);
+    GV->setComdat(nullptr);
+}

--- a/src/test/auxiliary/cgu_test.rs
+++ b/src/test/auxiliary/cgu_test.rs
@@ -1,0 +1,16 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+// compile-flags: --crate-type=lib
+
+pub fn id<T>(t: T) -> T {
+  t
+}

--- a/src/test/auxiliary/cgu_test_a.rs
+++ b/src/test/auxiliary/cgu_test_a.rs
@@ -1,0 +1,25 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+// compile-flags: -Ccodegen-units=2 --crate-type=lib
+
+extern crate cgu_test;
+
+pub mod a {
+    pub fn a() {
+        ::cgu_test::id(0);
+    }
+}
+pub mod b {
+    pub fn a() {
+        ::cgu_test::id(0);
+    }
+}

--- a/src/test/auxiliary/cgu_test_b.rs
+++ b/src/test/auxiliary/cgu_test_b.rs
@@ -1,0 +1,25 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+// compile-flags: -Ccodegen-units=2 --crate-type=lib
+
+extern crate cgu_test;
+
+pub mod a {
+    pub fn a() {
+        ::cgu_test::id(0);
+    }
+}
+pub mod b {
+    pub fn a() {
+        ::cgu_test::id(0);
+    }
+}

--- a/src/test/run-pass/issue-32518.rs
+++ b/src/test/run-pass/issue-32518.rs
@@ -1,0 +1,22 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+// aux-build:cgu_test.rs
+// aux-build:cgu_test_a.rs
+// aux-build:cgu_test_b.rs
+
+extern crate cgu_test_a;
+extern crate cgu_test_b;
+
+fn main() {
+    cgu_test_a::a::a();
+    cgu_test_b::a::a();
+}


### PR DESCRIPTION
When reuing a definition across codegen units, we obviously cannot use
internal linkage, but using external linkage means that we can end up
with multiple conflicting definitions of a single symbol across
multiple crates. Since the definitions should all be equal
semantically, we can use weak_odr linkage to resolve the situation.

Fixes #32518

r? @nikomatsakis 
