### PR TITLE
mk: Add `-C metadata` for compiling crates we ship

### DIFF
--- a/mk/target.mk
+++ b/mk/target.mk
@@ -89,6 +89,7 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$(4): \
 		$$(RUSTFLAGS$(1)_$(4)_T_$(2)) \
 		--out-dir $$(@D) \
 		-C extra-filename=-$$(CFG_FILENAME_EXTRA) \
+		-C metadata=$$(CFG_FILENAME_EXTRA) \
 		$$<
 	@touch -r $$@.start_time $$@ && rm $$@.start_time
 	$$(call LIST_ALL_OLD_GLOB_MATCHES, \


### PR DESCRIPTION
This should re-enable all external builds of crates with the same name. Right
now Cargo doesn't pass `-C metadata` for the top-level library being compiled,
so if that library is called `libc`, for example, then it won't be able to link
to the standard library which _also_ has a `libc` library compiled without `-C
metadata`. This can result in naming conflicts which need to be resolved.

By passing `-C metadata` to the in-tree crates we ship it should add some extra
salt to all symbol names to ensure that they don't collide.

Closes #32532
