### PR TITLE
Fix typo in TxCtxt::crate_disambiguator() and add test case.

### DIFF
--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -434,7 +434,7 @@ impl<'tcx> TyCtxt<'tcx> {
         if cnum == LOCAL_CRATE {
             self.sess.crate_disambiguator.get().as_str()
         } else {
-            self.sess.cstore.crate_name(cnum)
+            self.sess.cstore.crate_disambiguator(cnum)
         }
     }
 

--- a/src/test/run-make/stable-symbol-names/Makefile
+++ b/src/test/run-make/stable-symbol-names/Makefile
@@ -1,0 +1,18 @@
+-include ../tools.mk
+
+# This test case makes sure that monomorphizations of the same function with the
+# same set of generic arguments will have the same symbol names when
+# instantiated in different crates.
+
+dump-symbols = nm "$(TMPDIR)/lib$(1).rlib" \
+             |  grep "some_test_function" \
+             | sed "s/^[0-9a-f]\{8,16\}/00000000/" \
+             | sort \
+             > "$(TMPDIR)/$(1).nm"
+
+all:
+	$(RUSTC) stable-symbol-names1.rs
+	$(RUSTC) stable-symbol-names2.rs
+	$(call dump-symbols,stable_symbol_names1)
+	$(call dump-symbols,stable_symbol_names2)
+	cmp "$(TMPDIR)/stable_symbol_names1.nm" "$(TMPDIR)/stable_symbol_names2.nm"

--- a/src/test/run-make/stable-symbol-names/stable-symbol-names1.rs
+++ b/src/test/run-make/stable-symbol-names/stable-symbol-names1.rs
@@ -1,0 +1,22 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type="rlib"]
+
+pub fn some_test_function<T>(t: T) -> T {
+  t
+}
+
+pub fn user() {
+  some_test_function(0u32);
+  some_test_function("abc");
+  let x = 2u64;
+  some_test_function(&x);
+}

--- a/src/test/run-make/stable-symbol-names/stable-symbol-names2.rs
+++ b/src/test/run-make/stable-symbol-names/stable-symbol-names2.rs
@@ -1,0 +1,20 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type="rlib"]
+
+extern crate stable_symbol_names1;
+
+pub fn user() {
+  stable_symbol_names1::some_test_function(1u32);
+  stable_symbol_names1::some_test_function("def");
+  let x = 2u64;
+  stable_symbol_names1::some_test_function(&x);
+}


### PR DESCRIPTION
r? @nikomatsakis 

Fixes #32554
