### PR TITLE
Fix panic_fmt in the Book

### DIFF
--- a/src/doc/book/no-stdlib.md
+++ b/src/doc/book/no-stdlib.md
@@ -38,7 +38,7 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
 // for a bare-bones hello world. These are normally
 // provided by libstd.
 #[lang = "eh_personality"] extern fn eh_personality() {}
-#[lang = "panic_fmt"] fn panic_fmt() -> ! { loop {} }
+#[lang = "panic_fmt"] extern fn panic_fmt() -> ! { loop {} }
 # #[lang = "eh_unwind_resume"] extern fn rust_eh_unwind_resume() {}
 # #[no_mangle] pub extern fn rust_eh_register_frames () {}
 # #[no_mangle] pub extern fn rust_eh_unregister_frames () {}
@@ -65,7 +65,7 @@ pub extern fn main(argc: i32, argv: *const *const u8) -> i32 {
 }
 
 #[lang = "eh_personality"] extern fn eh_personality() {}
-#[lang = "panic_fmt"] fn panic_fmt() -> ! { loop {} }
+#[lang = "panic_fmt"] extern fn panic_fmt() -> ! { loop {} }
 # #[lang = "eh_unwind_resume"] extern fn rust_eh_unwind_resume() {}
 # #[no_mangle] pub extern fn rust_eh_register_frames () {}
 # #[no_mangle] pub extern fn rust_eh_unregister_frames () {}


### PR DESCRIPTION
While implementing panic_fmt for the GameCube I noticed that the parameters given to it were completely broken. Turns out that panic_fmt requires the C ABI to work correctly. This should be fixed in the documentation, so that others don't make the same mistake. Thanks to mbrubeck in the IRC for helping me figure this out.

Not specifying extern for lang_items correctly should potentially also be a compiler error.
