### PR TITLE
mk: A few build fixes for i586-pc-windows-msvc

### DIFF
--- a/configure
+++ b/configure
@@ -1252,7 +1252,7 @@ $ pacman -R cmake && pacman -S mingw-w64-x86_64-cmake
                     bits=x86_64
                     msvc_part=amd64
                     ;;
-                i686-*)
+                i*86-*)
                     bits=i386
                     msvc_part=
                     ;;

--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -236,11 +236,11 @@ COMPRT_LIB_$(1) := $$(RT_OUTPUT_DIR_$(1))/$$(COMPRT_NAME_$(1))
 COMPRT_BUILD_DIR_$(1) := $$(RT_OUTPUT_DIR_$(1))/compiler-rt
 
 ifeq ($$(findstring msvc,$(1)),msvc)
-$$(COMPRT_LIB_$(1)): $$(COMPRT_DEPS) $$(MKFILE_DEPS) $$(LLVM_CONFIG_$(1))
+$$(COMPRT_LIB_$(1)): $$(COMPRT_DEPS) $$(MKFILE_DEPS) $$(LLVM_CONFIG_$$(CFG_BUILD))
 	@$$(call E, cmake: compiler-rt)
 	$$(Q)cd "$$(COMPRT_BUILD_DIR_$(1))"; $$(CFG_CMAKE) "$(S)src/compiler-rt" \
 		-DCMAKE_BUILD_TYPE=$$(LLVM_BUILD_CONFIG_MODE) \
-		-DLLVM_CONFIG_PATH=$$(LLVM_CONFIG_$(1)) \
+		-DLLVM_CONFIG_PATH=$$(LLVM_CONFIG_$$(CFG_BUILD)) \
 		-G"$$(CFG_CMAKE_GENERATOR)"
 	$$(Q)$$(CFG_CMAKE) --build "$$(COMPRT_BUILD_DIR_$(1))" \
 		--target lib/builtins/builtins \


### PR DESCRIPTION
Detect the triple in the configure script for probing MSVC shenanigans and also
be sure to use `llvm-config` from the build host and not the target when
configuring compiler-rt.
