### PR TITLE
rustbuild: Fix compile on OSX for 10.7

### DIFF
--- a/src/bootstrap/build/mod.rs
+++ b/src/bootstrap/build/mod.rs
@@ -312,7 +312,13 @@ impl Build {
         if !target.contains("msvc") {
             cargo.env(format!("CC_{}", target), self.cc(target))
                  .env(format!("AR_{}", target), self.ar(target))
-                 .env(format!("CFLAGS_{}", target), self.cflags(target));
+                 .env(format!("CFLAGS_{}", target), self.cflags(target).join(" "));
+        }
+
+        // If we're building for OSX, inform the compiler and the linker that
+        // we want to build a compiler runnable on 10.7
+        if target.contains("apple-darwin") {
+            cargo.env("MACOSX_DEPLOYMENT_TARGET", "10.7");
         }
 
         // Environment variables *required* needed throughout the build
@@ -481,11 +487,20 @@ impl Build {
         self.cc[target].0.path()
     }
 
-    fn cflags(&self, target: &str) -> String {
-        self.cc[target].0.args().iter()
-            .map(|s| s.to_string_lossy())
-            .collect::<Vec<_>>()
-            .join(" ")
+    fn cflags(&self, target: &str) -> Vec<String> {
+        let mut base = self.cc[target].0.args().iter()
+                           .map(|s| s.to_string_lossy().into_owned())
+                           .collect::<Vec<_>>();
+
+        // If we're compiling on OSX then we add a few unconditional flags
+        // indicating that we want libc++ (more filled out than libstdc++) and
+        // we want to compile for 10.7. This way we can ensure that
+        // LLVM/jemalloc/etc are all properly compiled.
+        if target.contains("apple-darwin") {
+            base.push("-stdlib=libc++".into());
+            base.push("-mmacosx-version-min=10.7".into());
+        }
+        return base
     }
 
     fn ar(&self, target: &str) -> &Path {

--- a/src/bootstrap/build/native.rs
+++ b/src/bootstrap/build/native.rs
@@ -86,6 +86,9 @@ pub fn llvm(build: &Build, target: &str) {
               .define("CMAKE_CXX_COMPILER", build.cxx(target));
         }
         cfg.build_arg("-j").build_arg(build.jobs().to_string());
+
+        cfg.define("CMAKE_C_FLAGS", build.cflags(target).join(" "));
+        cfg.define("CMAKE_CXX_FLAGS", build.cflags(target).join(" "));
     }
 
     // FIXME: we don't actually need to build all LLVM tools and all LLVM

--- a/src/rustc/Cargo.lock
+++ b/src/rustc/Cargo.lock
@@ -81,7 +81,6 @@ dependencies = [
  "rustc_const_eval 0.0.0",
  "rustc_data_structures 0.0.0",
  "rustc_front 0.0.0",
- "rustc_llvm 0.0.0",
  "serialize 0.0.0",
  "syntax 0.0.0",
 ]
@@ -92,7 +91,6 @@ version = "0.0.0"
 dependencies = [
  "log 0.0.0",
  "rustc_front 0.0.0",
- "rustc_llvm 0.0.0",
  "serialize 0.0.0",
  "syntax 0.0.0",
 ]
@@ -151,6 +149,7 @@ dependencies = [
  "rustc_plugin 0.0.0",
  "rustc_privacy 0.0.0",
  "rustc_resolve 0.0.0",
+ "rustc_save_analysis 0.0.0",
  "rustc_trans 0.0.0",
  "rustc_typeck 0.0.0",
  "serialize 0.0.0",
@@ -232,10 +231,6 @@ dependencies = [
 [[package]]
 name = "rustc_platform_intrinsics"
 version = "0.0.0"
-dependencies = [
- "rustc 0.0.0",
- "rustc_llvm 0.0.0",
-]
 
 [[package]]
 name = "rustc_plugin"
@@ -269,6 +264,16 @@ dependencies = [
  "log 0.0.0",
  "rustc 0.0.0",
  "rustc_bitflags 0.0.0",
+ "rustc_front 0.0.0",
+ "syntax 0.0.0",
+]
+
+[[package]]
+name = "rustc_save_analysis"
+version = "0.0.0"
+dependencies = [
+ "log 0.0.0",
+ "rustc 0.0.0",
  "rustc_front 0.0.0",
  "syntax 0.0.0",
 ]
@@ -353,6 +358,7 @@ name = "syntax_ext"
 version = "0.0.0"
 dependencies = [
  "fmt_macros 0.0.0",
+ "log 0.0.0",
  "syntax 0.0.0",
 ]
 


### PR DESCRIPTION
This commit should help configure our OSX rustbuild builder for targeting 10.7.
A key part of this is using `libc++` instead of `libstdc++` as apparently it's
more filled out and otherwise LLVM's cmake configuration would fail.
