### PR TITLE
Add a note about the replacement of `Vec::push_all`

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -969,7 +969,7 @@ impl<T: Clone> Vec<T> {
     #[allow(missing_docs)]
     #[inline]
     #[unstable(feature = "vec_push_all",
-               reason = "likely to be replaced by a more optimized extend",
+               reason = "renamed to extend_from_slice",
                issue = "27744")]
     #[rustc_deprecated(reason = "renamed to extend_from_slice",
                        since = "1.6.0")]


### PR DESCRIPTION
When compiling a crate using `Vec::push_all` using the stable compiler,
it does not suggest moving to `Vec::extend_from_slice` because the
unstable errors come first.
