### PR TITLE
Book: Fix phrasing: “an associated type” → “an object with an associated type”.

### DIFF
--- a/src/doc/book/associated-types.md
+++ b/src/doc/book/associated-types.md
@@ -131,7 +131,7 @@ declarations.
 ## Trait objects with associated types
 
 There’s one more bit of syntax we should talk about: trait objects. If you
-try to create a trait object from an associated type, like this:
+try to create a trait object from a trait with an associated type, like this:
 
 ```rust,ignore
 # trait Graph {


### PR DESCRIPTION
From what I understood, `graph` is the object from which we create a trait object, and the associated types are `Graph::N` and `Graph::E`.
