### PR TITLE
Book: in beginner guide change irc channel #rust → #rust-beginners

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,11 @@ To contribute to Rust, please see [CONTRIBUTING](CONTRIBUTING.md).
 Rust has an [IRC] culture and most real-time collaboration happens in a
 variety of channels on Mozilla's IRC network, irc.mozilla.org. The
 most popular channel is [#rust], a venue for general discussion about
-Rust, and a good place to ask for help.
+Rust. And a good place to ask for help would be [#rust-beginners].
 
 [IRC]: https://en.wikipedia.org/wiki/Internet_Relay_Chat
 [#rust]: irc://irc.mozilla.org/rust
+[#rust-beginners]: irc://irc.mozilla.org/rust-beginners
 
 ## License
 

--- a/src/doc/book/getting-started.md
+++ b/src/doc/book/getting-started.md
@@ -169,7 +169,7 @@ If not, there are a number of places where we can get help. The easiest is
 (a silly nickname we call ourselves) who can help us out. Other great resources
 include [the user’s forum][users], and [Stack Overflow][stackoverflow].
 
-[irc]: irc://irc.mozilla.org/#rust-begginers
+[irc]: irc://irc.mozilla.org/#rust-beginners
 [mibbit]: http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
 [users]: https://users.rust-lang.org/
 [stackoverflow]: http://stackoverflow.com/questions/tagged/rust

--- a/src/doc/book/getting-started.md
+++ b/src/doc/book/getting-started.md
@@ -164,17 +164,15 @@ installed. Doing so will depend on your specific system, consult its
 documentation for more details.
 
 If not, there are a number of places where we can get help. The easiest is
-[the #rust-beginners IRC channel on irc.mozilla.org][irc-beginners], which we
-can access through [Mibbit][mibbit-beginners] and for general discussion
-[the #rust IRC channel on irc.mozilla.org][irc], which we can access through
-[Mibbit][mibbit]. Then we'll be chatting with other Rustaceans (a silly
-nickname we call ourselves) who can help us out. Other great resources include
-[the user’s forum][users], and [Stack Overflow][stackoverflow].
+[the #rust-beginners IRC channel on irc.mozilla.org][irc-beginners] and for
+general discussion [the #rust IRC channel on irc.mozilla.org][irc], which we
+can access through [Mibbit][mibbit]. Then we'll be chatting with other
+Rustaceans (a silly nickname we call ourselves) who can help us out. Other great
+resources include [the user’s forum][users] and [Stack Overflow][stackoverflow].
 
 [irc-beginners]: irc://irc.mozilla.org/#rust-beginners
-[mibbit-beginners]: http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
 [irc]: irc://irc.mozilla.org/#rust
-[mibbit]: http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust
+[mibbit]: http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners,%23rust
 [users]: https://users.rust-lang.org/
 [stackoverflow]: http://stackoverflow.com/questions/tagged/rust
 

--- a/src/doc/book/getting-started.md
+++ b/src/doc/book/getting-started.md
@@ -164,13 +164,13 @@ installed. Doing so will depend on your specific system, consult its
 documentation for more details.
 
 If not, there are a number of places where we can get help. The easiest is
-[the #rust IRC channel on irc.mozilla.org][irc], which we can access through
+[the #rust-beginners IRC channel on irc.mozilla.org][irc], which we can access through
 [Mibbit][mibbit]. Click that link, and we'll be chatting with other Rustaceans
 (a silly nickname we call ourselves) who can help us out. Other great resources
 include [the user’s forum][users], and [Stack Overflow][stackoverflow].
 
-[irc]: irc://irc.mozilla.org/#rust
-[mibbit]: http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust
+[irc]: irc://irc.mozilla.org/#rust-begginers
+[mibbit]: http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
 [users]: https://users.rust-lang.org/
 [stackoverflow]: http://stackoverflow.com/questions/tagged/rust
 

--- a/src/doc/book/getting-started.md
+++ b/src/doc/book/getting-started.md
@@ -164,13 +164,17 @@ installed. Doing so will depend on your specific system, consult its
 documentation for more details.
 
 If not, there are a number of places where we can get help. The easiest is
-[the #rust-beginners IRC channel on irc.mozilla.org][irc], which we can access through
-[Mibbit][mibbit]. Click that link, and we'll be chatting with other Rustaceans
-(a silly nickname we call ourselves) who can help us out. Other great resources
-include [the user’s forum][users], and [Stack Overflow][stackoverflow].
+[the #rust-beginners IRC channel on irc.mozilla.org][irc-beginners], which we
+can access through [Mibbit][mibbit-beginners] and for general discussion
+[the #rust IRC channel on irc.mozilla.org][irc], which we can access through
+[Mibbit][mibbit]. Then we'll be chatting with other Rustaceans (a silly
+nickname we call ourselves) who can help us out. Other great resources include
+[the user’s forum][users], and [Stack Overflow][stackoverflow].
 
-[irc]: irc://irc.mozilla.org/#rust-beginners
-[mibbit]: http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
+[irc-beginners]: irc://irc.mozilla.org/#rust-beginners
+[mibbit-beginners]: http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners
+[irc]: irc://irc.mozilla.org/#rust
+[mibbit]: http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust
 [users]: https://users.rust-lang.org/
 [stackoverflow]: http://stackoverflow.com/questions/tagged/rust
 


### PR DESCRIPTION
#32585 r? @alexcrichton

I also would like to add the reference on the first README.md

Some like

```
 most popular channel is [#rust], a venue for general discussion about
-Rust, and a good place to ask for help.
+Rust. And a good place to ask for help would be [#rust-beginners].

 [IRC]: https://en.wikipedia.org/wiki/Internet_Relay_Chat
 [#rust]: irc://irc.mozilla.org/rust
+[#rust-beginners]: irc://irc.mozilla.org/rust-beginners
```

So In the first page would be the two options for #rust or #rust-beginners
