### PR TITLE
Remove accidental `println!`

### DIFF
--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -41,7 +41,6 @@ use super::probe::Mode;
 
 fn is_fn_ty<'a, 'tcx>(ty: &Ty<'tcx>, fcx: &FnCtxt<'a, 'tcx>, span: Span) -> bool {
     let cx = fcx.tcx();
-    println!("{:?}", ty);
     match ty.sty {
         // Not all of these (e.g. unsafe fns) implement FnOnce
         // so we look for these beforehand


### PR DESCRIPTION
This removes a use of `println!` added in #32358 that appears to accidental.
r? @Manishearth 
