### PR TITLE
Change Arc to use compare_exchange instead of compare_and_swap

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -90,6 +90,7 @@
 #![feature(unique)]
 #![feature(unsafe_no_drop_flag, filling_drop)]
 #![feature(unsize)]
+#![feature(extended_compare_and_swap)]
 
 #![cfg_attr(not(test), feature(raw, fn_traits, placement_new_protocol))]
 #![cfg_attr(test, feature(test, box_heap))]


### PR DESCRIPTION
This should slightly improve code generation on architectures with a weak memory model like ARM.
