### PR TITLE
check constants even if they are not used in the current crate

### DIFF
--- a/src/test/compile-fail/const-err-early.rs
+++ b/src/test/compile-fail/const-err-early.rs
@@ -1,0 +1,22 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(const_indexing)]
+#![deny(const_err)]
+
+pub const A: i8 = -std::i8::MIN; //~ ERROR attempted to negate with overflow
+pub const B: u8 = 200u8 + 200u8; //~ ERROR attempted to add with overflow
+pub const C: u8 = 200u8 * 4; //~ ERROR attempted to multiply with overflow
+pub const D: u8 = 42u8 - (42u8 + 1); //~ ERROR attempted to subtract with overflow
+pub const E: u8 = [5u8][1]; //~ ERROR index out of bounds
+
+fn main() {
+    let _e = [6u8][1];
+}

--- a/src/test/compile-fail/const-err.rs
+++ b/src/test/compile-fail/const-err.rs
@@ -10,14 +10,10 @@
 
 #![feature(rustc_attrs)]
 #![allow(exceeding_bitshifts)]
-#![deny(const_err)]
 
 fn black_box<T>(_: T) {
     unimplemented!()
 }
-
-const BLA: u8 = 200u8 + 200u8;
-//~^ ERROR attempted to add with overflow
 
 #[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
 fn main() {
@@ -30,7 +26,8 @@ fn main() {
     //~^ WARN attempted to multiply with overflow
     let d = 42u8 - (42u8 + 1);
     //~^ WARN attempted to subtract with overflow
-    let _e = BLA;
+    let _e = [5u8][1];
+    //~^ ERROR const index-expr is out of bounds
     black_box(a);
     black_box(b);
     black_box(c);

--- a/src/test/compile-fail/const-eval-span.rs
+++ b/src/test/compile-fail/const-eval-span.rs
@@ -14,7 +14,7 @@
 struct S(i32);
 
 const CONSTANT: S = S(0);
-//~^ ERROR: constant evaluation error: call on struct [E0080]
+//~^ ERROR: unimplemented constant expression: tuple struct constructors [E0080]
 
 enum E {
     V = CONSTANT,

--- a/src/test/compile-fail/const-pattern-not-const-evaluable.rs
+++ b/src/test/compile-fail/const-pattern-not-const-evaluable.rs
@@ -17,12 +17,12 @@ enum Cake {
 use Cake::*;
 
 const BOO: (Cake, Cake) = (Marmor, BlackForest);
-//~^ ERROR: constant evaluation error: non-constant path in constant expression [E0471]
+//~^ ERROR: constant evaluation error: unimplemented constant expression: enum variants [E0471]
 const FOO: Cake = BOO.1;
 
 const fn foo() -> Cake {
-    Marmor //~ ERROR: constant evaluation error: non-constant path in constant expression [E0471]
-    //~^ ERROR: non-constant path in constant expression
+    Marmor //~ ERROR: constant evaluation error: unimplemented constant expression: enum variants
+    //~^ ERROR: unimplemented constant expression: enum variants
 }
 
 const WORKS: Cake = Marmor;

--- a/src/test/compile-fail/feature-gate-negate-unsigned.rs
+++ b/src/test/compile-fail/feature-gate-negate-unsigned.rs
@@ -17,7 +17,8 @@ impl std::ops::Neg for S {
 }
 
 const _MAX: usize = -1;
-//~^ ERROR unary negation of unsigned integer
+//~^ WARN unary negation of unsigned integer
+//~| ERROR unary negation of unsigned integer
 //~| HELP use a cast or the `!` operator
 
 fn main() {

--- a/src/test/compile-fail/non-constant-enum-for-vec-repeat.rs
+++ b/src/test/compile-fail/non-constant-enum-for-vec-repeat.rs
@@ -15,5 +15,5 @@ enum State { ST_NULL, ST_WHITESPACE }
 
 fn main() {
     [State::ST_NULL; (State::ST_WHITESPACE as usize)];
-    //~^ ERROR expected constant integer for repeat count, but non-constant path
+    //~^ ERROR expected constant integer for repeat count, but unimplemented constant expression
 }


### PR DESCRIPTION
For now this is just a `warn`-by-default lint. I suggest to make it a `deny`-by-default lint in the next release cycle (so no dependencies break), and then in another release cycle move to an error.

cc #19265
cc #3170
