### PR TITLE
Fix LLVM assert when handling bad intrinsic monomorphizations

### DIFF
--- a/src/librustc_trans/intrinsic.rs
+++ b/src/librustc_trans/intrinsic.rs
@@ -658,7 +658,7 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
                         tcx.sess, span,
                         &format!("invalid monomorphization of `{}` intrinsic: \
                                   expected basic integer type, found `{}`", name, sty));
-                        C_null(llret_ty)
+                        C_nil(ccx)
                 }
             }
 
@@ -681,7 +681,7 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
                         tcx.sess, span,
                         &format!("invalid monomorphization of `{}` intrinsic: \
                                   expected basic float type, found `{}`", name, sty));
-                        C_null(llret_ty)
+                        C_nil(ccx)
                 }
             }
 
@@ -1454,7 +1454,7 @@ fn generic_simd_intrinsic<'blk, 'tcx, 'a>
         ($cond: expr, $($fmt: tt)*) => {
             if !$cond {
                 emit_error!($($fmt)*);
-                return C_null(llret_ty)
+                return C_nil(bcx.ccx())
             }
         }
     }

--- a/src/test/compile-fail/bad-intrinsic-monomorphization.rs
+++ b/src/test/compile-fail/bad-intrinsic-monomorphization.rs
@@ -1,0 +1,44 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(repr_simd, platform_intrinsics, rustc_attrs, core_intrinsics)]
+#![allow(warnings)]
+
+// Bad monomorphizations could previously cause LLVM asserts even though the
+// error was caught in the compiler.
+
+extern "platform-intrinsic" {
+    fn simd_add<T>(x: T, y: T) -> T;
+}
+
+use std::intrinsics;
+
+#[derive(Copy, Clone)]
+struct Foo(i64);
+
+#[rustc_no_mir] // FIXME #27840 MIR doesn't provide precise spans for calls.
+unsafe fn test_cttz(v: Foo) -> Foo {
+    intrinsics::cttz(v)
+    //~^ ERROR `cttz` intrinsic: expected basic integer type, found `Foo`
+}
+
+#[rustc_no_mir] // FIXME #27840 MIR doesn't provide precise spans for calls.
+unsafe fn test_fadd_fast(a: Foo, b: Foo) -> Foo {
+    intrinsics::fadd_fast(a, b)
+    //~^ ERROR `fadd_fast` intrinsic: expected basic float type, found `Foo`
+}
+
+#[rustc_no_mir] // FIXME #27840 MIR doesn't provide precise spans for calls.
+unsafe fn test_simd_add(a: Foo, b: Foo) -> Foo {
+    simd_add(a, b)
+    //~^ ERROR `simd_add` intrinsic: expected SIMD input type, found non-SIMD `Foo`
+}
+
+fn main() {}


### PR DESCRIPTION
Passing an invalid type to certain intrinsics would trigger an LLVM assert even though the invalid type was caught by the compiler.

r? @eddyb 
