### PR TITLE
Added missing refcell ref/refmut coercions to unsized

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -147,8 +147,8 @@
 use clone::Clone;
 use cmp::{PartialEq, Eq};
 use default::Default;
-use marker::{Copy, Send, Sync, Sized};
-use ops::{Deref, DerefMut, Drop, FnOnce};
+use marker::{Copy, Send, Sync, Sized, Unsize};
+use ops::{Deref, DerefMut, Drop, FnOnce, CoerceUnsized};
 use option::Option;
 use option::Option::{None, Some};
 
@@ -638,6 +638,9 @@ impl<'b, T: ?Sized> Ref<'b, T> {
     }
 }
 
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+impl<'b, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Ref<'b, U>> for Ref<'b, T> {}
+
 impl<'b, T: ?Sized> RefMut<'b, T> {
     /// Make a new `RefMut` for a component of the borrowed data, e.g. an enum
     /// variant.
@@ -769,6 +772,9 @@ impl<'b, T: ?Sized> DerefMut for RefMut<'b, T> {
         self._value
     }
 }
+
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+impl<'b, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<RefMut<'b, U>> for RefMut<'b, T> {}
 
 /// The core primitive for interior mutability in Rust.
 ///

--- a/src/libcoretest/cell.rs
+++ b/src/libcoretest/cell.rs
@@ -261,3 +261,23 @@ fn refcell_unsized() {
     let comp: &mut [i32] = &mut [4, 2, 5];
     assert_eq!(&*cell.borrow(), comp);
 }
+
+#[test]
+fn refcell_ref_coercion() {
+    let cell: RefCell<[i32; 3]> = RefCell::new([1, 2, 3]);
+    {
+        let mut cellref: RefMut<[i32; 3]> = cell.borrow_mut();
+        cellref[0] = 4;
+        let mut coerced: RefMut<[i32]> = cellref;
+        coerced[2] = 5;
+    }
+    {
+        let comp: &mut [i32] = &mut [4, 2, 5];
+        let cellref: Ref<[i32; 3]> = cell.borrow();
+        assert_eq!(&*cellref, comp);
+        let coerced: Ref<[i32]> = cellref;
+        assert_eq!(&*coerced, comp);
+    }
+}
+
+


### PR DESCRIPTION
Ref/RefMut should be coercible to unsized.
This commit adds a unit test and two missing CoerceUnsized implementations.
