### PR TITLE
Don't ever emit "aborting due to previous error"

### DIFF
--- a/src/doc/book/crates-and-modules.md
+++ b/src/doc/book/crates-and-modules.md
@@ -427,7 +427,6 @@ Rust will give us a compile-time error:
 src/main.rs:4:5: 4:40 error: a value named `hello` has already been imported in this module [E0252]
 src/main.rs:4 use phrases::japanese::greetings::hello;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-error: aborting due to previous error
 Could not compile `phrases`.
 ```
 

--- a/src/doc/book/guessing-game.md
+++ b/src/doc/book/guessing-game.md
@@ -629,7 +629,6 @@ src/main.rs:28:21: 28:35 error: mismatched types:
     found integral variable) [E0308]
 src/main.rs:28     match guess.cmp(&secret_number) {
                                    ^~~~~~~~~~~~~~
-error: aborting due to previous error
 Could not compile `guessing_game`.
 ```
 

--- a/src/doc/book/variable-bindings.md
+++ b/src/doc/book/variable-bindings.md
@@ -155,7 +155,6 @@ note: in expansion of format_args!
 <std macros>:2:23: 2:77 note: expansion site
 <std macros>:1:1: 3:2 note: in expansion of println!
 src/main.rs:4:5: 4:42 note: expansion site
-error: aborting due to previous error
 Could not compile `hello_world`.
 ```
 
@@ -215,7 +214,6 @@ note: in expansion of format_args!
 <std macros>:1:1: 3:58 note: in expansion of println!
 main.rs:7:5: 7:65 note: expansion site
 main.rs:7:62: 7:63 help: run `rustc --explain E0425` to see a detailed explanation
-error: aborting due to previous error
 Could not compile `hello`.
 
 To learn more, run the command again with --verbose.

--- a/src/doc/book/vectors.md
+++ b/src/doc/book/vectors.md
@@ -61,7 +61,6 @@ error: the trait `core::ops::Index<i32>` is not implemented for the type
 v[j];
 ^~~~
 note: the type `collections::vec::Vec<_>` cannot be indexed by `i32`
-error: aborting due to previous error
 ```
 
 There’s a lot of punctuation in that message, but the core of it makes sense:

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -158,6 +158,9 @@ impl Session {
     pub fn fatal(&self, msg: &str) -> ! {
         panic!(self.diagnostic().fatal(msg))
     }
+    pub fn fatal_panic_only(&self) -> ! {
+        panic!(errors::FatalError)
+    }
     pub fn span_err_or_warn<S: Into<MultiSpan>>(&self, is_warning: bool, sp: S, msg: &str) {
         if is_warning {
             self.span_warn(sp, msg);

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -271,7 +271,7 @@ fn runtest(test: &str, cratename: &str, cfgs: Vec<String>, libs: SearchPaths,
         Ok(r) => {
             match r {
                 Err(count) if count > 0 && compile_fail == false => {
-                    sess.fatal("aborting due to previous error(s)")
+                    panic!("couldn't compile the test");
                 }
                 Ok(()) if compile_fail => panic!("test compiled while it wasn't supposed to"),
                 _ => {}

--- a/src/libsyntax/errors/mod.rs
+++ b/src/libsyntax/errors/mod.rs
@@ -603,14 +603,18 @@ impl Handler {
 
                 return;
             }
-            1 => s = "aborting due to previous error".to_string(),
+            1 => s = None,
             _  => {
-                s = format!("aborting due to {} previous errors",
-                            self.err_count.get());
+                s = Some(format!("aborting due to {} previous errors",
+                                 self.err_count.get()));
             }
         }
 
-        panic!(self.fatal(&s));
+        if let Some(s) = s {
+            panic!(self.fatal(&s));
+        } else {
+            panic!(FatalError);
+        }
     }
     pub fn emit(&self,
                 msp: Option<&MultiSpan>,


### PR DESCRIPTION
This adds very little information. The only thing I can think
it accomplishes is guarantee that the last line of output contains
the word 'error'. In a cursory look at how test cases in the docs
were effected by this removal I thought it was purely better
not to emit this error as the real error had been emitted only
a few lines earlier.

Furthermore, when run under cargo, cargo itself prints something
like "compilation failed".

This doesn't change the output when multiple errors are emitted
since that contains a semi-useful count of the errors.

cc @nikomatsakis 
