### PR TITLE
Mark the thread_local! initializer with #[cold]

### DIFF
--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -215,6 +215,7 @@ impl<T: 'static> LocalKey<T> {
         }
     }
 
+    #[cold]
     unsafe fn init(&self, slot: &UnsafeCell<Option<T>>) -> &T {
         // Execute the initialization up front, *then* move it into our slot,
         // just in case initialization fails.


### PR DESCRIPTION
The hot path in thread-local storage is to fetch an existing value, not initialize a new one.
