### PR TITLE
Feature-gate #[derive_*] even when produced by macro expansion.

### DIFF
--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -724,9 +724,7 @@ impl<'a> Context<'a> {
                                with the prefix `rustc_` \
                                are reserved for internal compiler diagnostics");
         } else if name.starts_with("derive_") {
-            self.gate_feature("custom_derive", attr.span,
-                              "attributes of the form `#[derive_*]` are reserved \
-                               for the compiler");
+            self.gate_feature("custom_derive", attr.span, EXPLAIN_DERIVE_UNDERSCORE);
         } else {
             // Only run the custom attribute lint during regular
             // feature gate checking. Macro gating runs
@@ -801,6 +799,8 @@ pub const EXPLAIN_ALLOW_INTERNAL_UNSTABLE: &'static str =
 
 pub const EXPLAIN_CUSTOM_DERIVE: &'static str =
     "`#[derive]` for custom traits is not stable enough for use and is subject to change";
+pub const EXPLAIN_DERIVE_UNDERSCORE: &'static str =
+    "attributes of the form `#[derive_*]` are reserved for the compiler";
 
 struct MacroVisitor<'a> {
     context: &'a Context<'a>

--- a/src/test/compile-fail/single-derive-attr-2.rs
+++ b/src/test/compile-fail/single-derive-attr-2.rs
@@ -1,0 +1,21 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! expand_to_unstable {
+    () => {
+        #[derive_Clone]
+        //~^ ERROR attributes of the form `#[derive_*]` are reserved
+        struct Test;
+    }
+}
+
+expand_to_unstable!();
+
+pub fn main() {}

--- a/src/test/run-pass/single-derive-attr-allow-unstable.rs
+++ b/src/test/run-pass/single-derive-attr-allow-unstable.rs
@@ -1,0 +1,30 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-pretty : (#23623) problems when  ending with // comments
+
+#![feature(allow_internal_unstable)]
+
+#[allow_internal_unstable]
+macro_rules! expand_to_unstable {
+    () => {
+        // FIXME(eddyb) #[allow_internal_unstable]
+        // doesn't actually work for some reason.
+
+        #[derive(Clone)] //#[derive_Clone]
+        struct Test;
+    }
+}
+
+expand_to_unstable!();
+
+pub fn main() {
+    Test.clone();
+}


### PR DESCRIPTION
Fixes #32655 by marking `#[derive_Trait]` attributes produced by the compiler from the
user-friendly `#[derive(Trait)]` syntax to allow unstable features, and gating on that.
