### PR TITLE
Implement RangeArgument for RangeInclusive and RangeInclusiveTo

### DIFF
--- a/src/libcollections/range.rs
+++ b/src/libcollections/range.rs
@@ -23,14 +23,14 @@ pub trait RangeArgument<T> {
     /// Start index (inclusive)
     ///
     /// Return start value if present, else `None`.
-    fn start(&self) -> Option<&T> {
+    fn start(&self) -> Option<T> {
         None
     }
 
     /// End index (exclusive)
     ///
     /// Return end value if present, else `None`.
-    fn end(&self) -> Option<&T> {
+    fn end(&self) -> Option<T> {
         None
     }
 }
@@ -39,23 +39,23 @@ pub trait RangeArgument<T> {
 
 impl<T> RangeArgument<T> for RangeFull {}
 
-impl<T> RangeArgument<T> for RangeFrom<T> {
-    fn start(&self) -> Option<&T> {
-        Some(&self.start)
+impl<T: Copy> RangeArgument<T> for RangeFrom<T> {
+    fn start(&self) -> Option<T> {
+        Some(self.start)
     }
 }
 
-impl<T> RangeArgument<T> for RangeTo<T> {
-    fn end(&self) -> Option<&T> {
-        Some(&self.end)
+impl<T: Copy> RangeArgument<T> for RangeTo<T> {
+    fn end(&self) -> Option<T> {
+        Some(self.end)
     }
 }
 
-impl<T> RangeArgument<T> for Range<T> {
-    fn start(&self) -> Option<&T> {
-        Some(&self.start)
+impl<T: Copy> RangeArgument<T> for Range<T> {
+    fn start(&self) -> Option<T> {
+        Some(self.start)
     }
-    fn end(&self) -> Option<&T> {
-        Some(&self.end)
+    fn end(&self) -> Option<T> {
+        Some(self.end)
     }
 }

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -1269,8 +1269,8 @@ impl String {
         // Because the range removal happens in Drop, if the Drain iterator is leaked,
         // the removal will not happen.
         let len = self.len();
-        let start = *range.start().unwrap_or(&0);
-        let end = *range.end().unwrap_or(&len);
+        let start = range.start().unwrap_or(0);
+        let end = range.end().unwrap_or(len);
 
         // Take out two simultaneous borrows. The &mut String won't be accessed
         // until iteration is over, in Drop.

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -805,8 +805,8 @@ impl<T> Vec<T> {
         // the hole, and the vector length is restored to the new length.
         //
         let len = self.len();
-        let start = *range.start().unwrap_or(&0);
-        let end = *range.end().unwrap_or(&len);
+        let start = range.start().unwrap_or(0);
+        let end = range.end().unwrap_or(len);
         assert!(start <= end);
         assert!(end <= len);
 

--- a/src/libcollections/vec_deque.rs
+++ b/src/libcollections/vec_deque.rs
@@ -813,8 +813,8 @@ impl<T> VecDeque<T> {
         // and the head/tail values will be restored correctly.
         //
         let len = self.len();
-        let start = *range.start().unwrap_or(&0);
-        let end = *range.end().unwrap_or(&len);
+        let start = range.start().unwrap_or(0);
+        let end = range.end().unwrap_or(len);
         assert!(start <= end, "drain lower bound was too large");
         assert!(end <= len, "drain upper bound was too large");
 

--- a/src/libcollectionstest/lib.rs
+++ b/src/libcollectionstest/lib.rs
@@ -20,6 +20,7 @@
 #![feature(const_fn)]
 #![feature(fn_traits)]
 #![feature(enumset)]
+#![feature(inclusive_range_syntax)]
 #![feature(iter_arith)]
 #![feature(map_entry_keys)]
 #![feature(pattern)]

--- a/src/libcollectionstest/vec.rs
+++ b/src/libcollectionstest/vec.rs
@@ -439,6 +439,25 @@ fn test_drain_range() {
 }
 
 #[test]
+fn test_drain_range_inclusive() {
+    let mut vec = vec![1, 2, 3, 4, 5];
+    let mut vec2 = vec![];
+    for i in vec.drain(1...3) {
+        vec2.push(i);
+    }
+    assert_eq!(vec, [1, 5]);
+    assert_eq!(vec2, [2, 3, 4]);
+
+    let mut vec = vec![1, 2, 3, 4, 5];
+    let mut vec2 = vec![];
+    for i in vec.drain(...3) {
+        vec2.push(i);
+    }
+    assert_eq!(vec, [5]);
+    assert_eq!(vec2, [1, 2, 3, 4]);
+}
+
+#[test]
 fn test_into_boxed_slice() {
     let xs = vec![1, 2, 3];
     let ys = xs.into_boxed_slice();

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -534,8 +534,6 @@ fn slice_index_order_fail(index: usize, end: usize) -> ! {
     panic!("slice index starts at {} but ends at {}", index, end);
 }
 
-// FIXME implement indexing with inclusive ranges
-
 /// Implements slicing with syntax `&self[begin .. end]`.
 ///
 /// Returns a slice of self for the index range [`begin`..`end`).


### PR DESCRIPTION
This preserves the semantics of `RangeArgument::end` being exclusive, and converts inclusive ranges to exclusive ones the same way `impl<T> ops::Index<ops::RangeInclusive<usize>> for [T]` (7eb7c56bd43b2ae12ef8b92e7258d520099a5347) does: add one to the end bound and panic on overflow.

This required one change and one limitation:
- Since the result of that addition is not stored somewhere we can reference, `RangeArgument::end` (and `RangeArgument::start` for consistency) was changed to return a copy rather than a reference. This effectively removes some impls where `T: !Copy`.
- Since there is no trait with the `checked_add` method, `RangeArgument` is implemented for inclusive ranges of each primitive integer types rather than generically.

I think both these points are OK since the only usage of `RangeArgument` in `std` is with ranges of `usize`.

If this change is accepted I’d like to nominate `RangeArgument` / #30877 for FCP and stabilization. I believe this can happen even if the inclusive range syntax and types are still unstable.

For what it’s worth, I just copied `RangeArgument` into rust-url to be able to use it there.

CC @alexcrichton & libs team
