### PR TITLE
[breaking-batch] Simplify ast::StructField

### DIFF
--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -978,7 +978,7 @@ impl<'a, 'v> ast_visit::Visitor<'v> for EarlyContext<'a> {
     }
 
     fn visit_struct_field(&mut self, s: &ast::StructField) {
-        self.with_lint_attrs(&s.node.attrs, |cx| {
+        self.with_lint_attrs(&s.attrs, |cx| {
             run_lints!(cx, check_struct_field, early_passes, s);
             ast_visit::walk_struct_field(cx, s);
         })

--- a/src/librustc_front/lowering.rs
+++ b/src/librustc_front/lowering.rs
@@ -621,11 +621,11 @@ pub fn lower_struct_field(lctx: &LoweringContext,
                           -> hir::StructField {
     hir::StructField {
         span: f.span,
-        id: f.node.id,
-        name: f.node.ident.map(|ident| ident.name).unwrap_or(token::intern(&index.to_string())),
-        vis: lower_visibility(lctx, f.node.vis),
-        ty: lower_ty(lctx, &f.node.ty),
-        attrs: lower_attrs(lctx, &f.node.attrs),
+        id: f.id,
+        name: f.ident.map(|ident| ident.name).unwrap_or(token::intern(&index.to_string())),
+        vis: lower_visibility(lctx, &f.vis),
+        ty: lower_ty(lctx, &f.ty),
+        attrs: lower_attrs(lctx, &f.attrs),
     }
 }
 

--- a/src/librustc_front/lowering.rs
+++ b/src/librustc_front/lowering.rs
@@ -622,9 +622,8 @@ pub fn lower_struct_field(lctx: &LoweringContext,
     hir::StructField {
         span: f.span,
         id: f.node.id,
-        name: f.node.ident().map(|ident| ident.name)
-                            .unwrap_or(token::intern(&index.to_string())),
-        vis: lower_visibility(lctx, f.node.kind.visibility()),
+        name: f.node.ident.map(|ident| ident.name).unwrap_or(token::intern(&index.to_string())),
+        vis: lower_visibility(lctx, f.node.vis),
         ty: lower_ty(lctx, &f.node.ty),
         attrs: lower_attrs(lctx, &f.node.attrs),
     }

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -563,7 +563,7 @@ where D: Dump
         // fields
         for field in def.fields() {
             self.process_struct_field_def(field, item.id);
-            self.visit_ty(&field.node.ty);
+            self.visit_ty(&field.ty);
         }
 
         self.process_generic_params(ty_params, item.span, &qualname, item.id);
@@ -624,7 +624,7 @@ where D: Dump
 
             for field in variant.node.data.fields() {
                 self.process_struct_field_def(field, variant.node.data.id());
-                self.visit_ty(&field.node.ty);
+                self.visit_ty(&field.ty);
             }
         }
         self.process_generic_params(ty_params, item.span, &enum_data.qualname, enum_data.id);

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -246,13 +246,13 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
 
     pub fn get_field_data(&self, field: &ast::StructField,
                           scope: NodeId) -> Option<VariableData> {
-        if let Some(ident) = field.node.ident {
+        if let Some(ident) = field.ident {
             let qualname = format!("::{}::{}", self.tcx.map.path_to_string(scope), ident);
-            let typ = self.tcx.node_types().get(&field.node.id).unwrap().to_string();
+            let typ = self.tcx.node_types().get(&field.id).unwrap().to_string();
             let sub_span = self.span_utils.sub_span_before_token(field.span, token::Colon);
             filter!(self.span_utils, sub_span, field.span, None);
             Some(VariableData {
-                id: field.node.id,
+                id: field.id,
                 name: ident.to_string(),
                 qualname: qualname,
                 span: sub_span.unwrap(),

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -246,23 +246,22 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
 
     pub fn get_field_data(&self, field: &ast::StructField,
                           scope: NodeId) -> Option<VariableData> {
-        match field.node.kind {
-            ast::NamedField(ident, _) => {
-                let qualname = format!("::{}::{}", self.tcx.map.path_to_string(scope), ident);
-                let typ = self.tcx.node_types().get(&field.node.id).unwrap().to_string();
-                let sub_span = self.span_utils.sub_span_before_token(field.span, token::Colon);
-                filter!(self.span_utils, sub_span, field.span, None);
-                Some(VariableData {
-                    id: field.node.id,
-                    name: ident.to_string(),
-                    qualname: qualname,
-                    span: sub_span.unwrap(),
-                    scope: scope,
-                    value: "".to_owned(),
-                    type_value: typ,
-                })
-            }
-            _ => None,
+        if let Some(ident) = field.node.ident {
+            let qualname = format!("::{}::{}", self.tcx.map.path_to_string(scope), ident);
+            let typ = self.tcx.node_types().get(&field.node.id).unwrap().to_string();
+            let sub_span = self.span_utils.sub_span_before_token(field.span, token::Colon);
+            filter!(self.span_utils, sub_span, field.span, None);
+            Some(VariableData {
+                id: field.node.id,
+                name: ident.to_string(),
+                qualname: qualname,
+                span: sub_span.unwrap(),
+                scope: scope,
+                value: "".to_owned(),
+                type_value: typ,
+            })
+        } else {
+            None
         }
     }
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1876,15 +1876,14 @@ pub enum Visibility {
 }
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
-pub struct StructField_ {
+pub struct StructField {
+    pub span: Span,
     pub ident: Option<Ident>,
     pub vis: Visibility,
     pub id: NodeId,
     pub ty: P<Ty>,
     pub attrs: Vec<Attribute>,
 }
-
-pub type StructField = Spanned<StructField_>;
 
 /// Fields and Ids of enum variants and structs
 ///

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -10,7 +10,6 @@
 
 // The Rust abstract syntax tree.
 
-pub use self::StructFieldKind::*;
 pub use self::TyParamBound::*;
 pub use self::UnsafeSource::*;
 pub use self::ViewPath_::*;
@@ -1878,44 +1877,14 @@ pub enum Visibility {
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct StructField_ {
-    pub kind: StructFieldKind,
+    pub ident: Option<Ident>,
+    pub vis: Visibility,
     pub id: NodeId,
     pub ty: P<Ty>,
     pub attrs: Vec<Attribute>,
 }
 
-impl StructField_ {
-    pub fn ident(&self) -> Option<Ident> {
-        match self.kind {
-            NamedField(ref ident, _) => Some(ident.clone()),
-            UnnamedField(_) => None
-        }
-    }
-}
-
 pub type StructField = Spanned<StructField_>;
-
-#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
-pub enum StructFieldKind {
-    NamedField(Ident, Visibility),
-    /// Element of a tuple-like struct
-    UnnamedField(Visibility),
-}
-
-impl StructFieldKind {
-    pub fn is_unnamed(&self) -> bool {
-        match *self {
-            UnnamedField(..) => true,
-            NamedField(..) => false,
-        }
-    }
-
-    pub fn visibility(&self) -> &Visibility {
-        match *self {
-            NamedField(_, ref vis) | UnnamedField(ref vis) => vis
-        }
-    }
-}
 
 /// Fields and Ids of enum variants and structs
 ///

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -95,12 +95,6 @@ pub fn impl_pretty_name(trait_ref: &Option<TraitRef>, ty: Option<&Ty>) -> Ident 
     token::gensym_ident(&pretty[..])
 }
 
-pub fn struct_field_visibility(field: ast::StructField) -> Visibility {
-    match field.node.kind {
-        ast::NamedField(_, v) | ast::UnnamedField(v) => v
-    }
-}
-
 // ______________________________________________________________________
 // Enumerating the IDs which appear in an AST
 

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -263,7 +263,7 @@ impl<'a, 'v, O: IdVisitingOperation> Visitor<'v> for IdVisitor<'a, O> {
     }
 
     fn visit_struct_field(&mut self, struct_field: &StructField) {
-        self.operation.visit_id(struct_field.node.id);
+        self.operation.visit_id(struct_field.id);
         visit::walk_struct_field(self, struct_field)
     }
 

--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -180,12 +180,12 @@ fn fold_struct<F>(cx: &mut Context<F>, vdata: ast::VariantData) -> ast::VariantD
     match vdata {
         ast::VariantData::Struct(fields, id) => {
             ast::VariantData::Struct(fields.into_iter().filter(|m| {
-                (cx.in_cfg)(&m.node.attrs)
+                (cx.in_cfg)(&m.attrs)
             }).collect(), id)
         }
         ast::VariantData::Tuple(fields, id) => {
             ast::VariantData::Tuple(fields.into_iter().filter(|m| {
-                (cx.in_cfg)(&m.node.attrs)
+                (cx.in_cfg)(&m.attrs)
             }).collect(), id)
         }
         ast::VariantData::Unit(id) => ast::VariantData::Unit(id)
@@ -434,7 +434,7 @@ impl<'v, 'a, 'b> visit::Visitor<'v> for StmtExprAttrFeatureVisitor<'a, 'b> {
     }
 
     fn visit_struct_field(&mut self, s: &'v ast::StructField) {
-        if node_survives_cfg(&s.node.attrs, self.config) {
+        if node_survives_cfg(&s.attrs, self.config) {
             visit::walk_struct_field(self, s);
         }
     }

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -1009,7 +1009,8 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         let fields: Vec<_> = tys.into_iter().map(|ty| {
             Spanned { span: ty.span, node: ast::StructField_ {
                 ty: ty,
-                kind: ast::UnnamedField(ast::Visibility::Inherited),
+                ident: None,
+                vis: ast::Visibility::Inherited,
                 attrs: Vec::new(),
                 id: ast::DUMMY_NODE_ID,
             }}

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -1007,13 +1007,14 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
 
     fn variant(&self, span: Span, name: Ident, tys: Vec<P<ast::Ty>> ) -> ast::Variant {
         let fields: Vec<_> = tys.into_iter().map(|ty| {
-            Spanned { span: ty.span, node: ast::StructField_ {
+            ast::StructField {
+                span: ty.span,
                 ty: ty,
                 ident: None,
                 vis: ast::Visibility::Inherited,
                 attrs: Vec::new(),
                 id: ast::DUMMY_NODE_ID,
-            }}
+            }
         }).collect();
 
         let vdata = if fields.is_empty() {

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -847,15 +847,13 @@ pub fn noop_fold_poly_trait_ref<T: Folder>(p: PolyTraitRef, fld: &mut T) -> Poly
 }
 
 pub fn noop_fold_struct_field<T: Folder>(f: StructField, fld: &mut T) -> StructField {
-    Spanned {
-        node: StructField_ {
-            id: fld.new_id(f.node.id),
-            ident: f.node.ident.map(|ident| fld.fold_ident(ident)),
-            vis: f.node.vis,
-            ty: fld.fold_ty(f.node.ty),
-            attrs: fold_attrs(f.node.attrs, fld),
-        },
-        span: fld.new_span(f.span)
+    StructField {
+        span: fld.new_span(f.span),
+        id: fld.new_id(f.id),
+        ident: f.ident.map(|ident| fld.fold_ident(ident)),
+        vis: f.vis,
+        ty: fld.fold_ty(f.ty),
+        attrs: fold_attrs(f.attrs, fld),
     }
 }
 

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -847,15 +847,15 @@ pub fn noop_fold_poly_trait_ref<T: Folder>(p: PolyTraitRef, fld: &mut T) -> Poly
 }
 
 pub fn noop_fold_struct_field<T: Folder>(f: StructField, fld: &mut T) -> StructField {
-    let StructField {node: StructField_ {id, kind, ty, attrs}, span} = f;
     Spanned {
         node: StructField_ {
-            id: fld.new_id(id),
-            kind: kind,
-            ty: fld.fold_ty(ty),
-            attrs: fold_attrs(attrs, fld),
+            id: fld.new_id(f.node.id),
+            ident: f.node.ident.map(|ident| fld.fold_ident(ident)),
+            vis: f.node.vis,
+            ty: fld.fold_ty(f.node.ty),
+            attrs: fold_attrs(f.node.attrs, fld),
         },
-        span: fld.new_span(span)
+        span: fld.new_span(f.span)
     }
 }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -29,7 +29,6 @@ use ast::Local;
 use ast::MacStmtStyle;
 use ast::Mac_;
 use ast::{MutTy, Mutability};
-use ast::NamedField;
 use ast::{Pat, PatKind};
 use ast::{PolyTraitRef, QSelf};
 use ast::{Stmt, StmtKind};
@@ -38,7 +37,6 @@ use ast::StrStyle;
 use ast::SelfKind;
 use ast::{Delimited, SequenceRepetition, TokenTree, TraitItem, TraitRef};
 use ast::{Ty, TyKind, TypeBinding, TyParam, TyParamBounds};
-use ast::UnnamedField;
 use ast::{ViewPath, ViewPathGlob, ViewPathList, ViewPathSimple};
 use ast::{Visibility, WhereClause};
 use attr::{ThinAttributes, ThinAttributesExt, AttributesExt};
@@ -3848,7 +3846,8 @@ impl<'a> Parser<'a> {
         self.expect(&token::Colon)?;
         let ty = self.parse_ty_sum()?;
         Ok(spanned(lo, self.last_span.hi, ast::StructField_ {
-            kind: NamedField(name, pr),
+            ident: Some(name),
+            vis: pr,
             id: ast::DUMMY_NODE_ID,
             ty: ty,
             attrs: attrs,
@@ -5247,7 +5246,8 @@ impl<'a> Parser<'a> {
                 let attrs = p.parse_outer_attributes()?;
                 let lo = p.span.lo;
                 let struct_field_ = ast::StructField_ {
-                    kind: UnnamedField(p.parse_visibility()?),
+                    vis: p.parse_visibility()?,
+                    ident: None,
                     id: ast::DUMMY_NODE_ID,
                     ty: p.parse_ty_sum()?,
                     attrs: attrs,

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3845,13 +3845,14 @@ impl<'a> Parser<'a> {
         let name = self.parse_ident()?;
         self.expect(&token::Colon)?;
         let ty = self.parse_ty_sum()?;
-        Ok(spanned(lo, self.last_span.hi, ast::StructField_ {
+        Ok(StructField {
+            span: mk_sp(lo, self.last_span.hi),
             ident: Some(name),
             vis: pr,
             id: ast::DUMMY_NODE_ID,
             ty: ty,
             attrs: attrs,
-        }))
+        })
     }
 
     /// Emit an expected item after attributes error.
@@ -5245,14 +5246,16 @@ impl<'a> Parser<'a> {
             |p| {
                 let attrs = p.parse_outer_attributes()?;
                 let lo = p.span.lo;
-                let struct_field_ = ast::StructField_ {
-                    vis: p.parse_visibility()?,
+                let vis = p.parse_visibility()?;
+                let ty = p.parse_ty_sum()?;
+                Ok(StructField {
+                    span: mk_sp(lo, p.span.hi),
+                    vis: vis,
                     ident: None,
                     id: ast::DUMMY_NODE_ID,
-                    ty: p.parse_ty_sum()?,
+                    ty: ty,
                     attrs: attrs,
-                };
-                Ok(spanned(lo, p.span.hi, struct_field_))
+                })
             })?;
 
         Ok(fields)

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1407,9 +1407,9 @@ impl<'a> State<'a> {
                 self.commasep(
                     Inconsistent, struct_def.fields(),
                     |s, field| {
-                        s.print_visibility(field.node.vis)?;
+                        s.print_visibility(&field.vis)?;
                         s.maybe_print_comment(field.span.lo)?;
-                        s.print_type(&field.node.ty)
+                        s.print_type(&field.ty)
                     }
                 )?;
                 self.pclose()?;
@@ -1429,11 +1429,11 @@ impl<'a> State<'a> {
             for field in struct_def.fields() {
                 self.hardbreak_if_not_bol()?;
                 self.maybe_print_comment(field.span.lo)?;
-                self.print_outer_attributes(&field.node.attrs)?;
-                self.print_visibility(field.node.vis)?;
-                self.print_ident(field.node.ident.unwrap())?;
+                self.print_outer_attributes(&field.attrs)?;
+                self.print_visibility(&field.vis)?;
+                self.print_ident(field.ident.unwrap())?;
                 self.word_nbsp(":")?;
-                self.print_type(&field.node.ty)?;
+                self.print_type(&field.ty)?;
                 word(&mut self.s, ",")?;
             }
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1407,14 +1407,9 @@ impl<'a> State<'a> {
                 self.commasep(
                     Inconsistent, struct_def.fields(),
                     |s, field| {
-                        match field.node.kind {
-                            ast::NamedField(..) => panic!("unexpected named field"),
-                            ast::UnnamedField(ref vis) => {
-                                s.print_visibility(vis)?;
-                                s.maybe_print_comment(field.span.lo)?;
-                                s.print_type(&field.node.ty)
-                            }
-                        }
+                        s.print_visibility(field.node.vis)?;
+                        s.maybe_print_comment(field.span.lo)?;
+                        s.print_type(&field.node.ty)
                     }
                 )?;
                 self.pclose()?;
@@ -1432,19 +1427,14 @@ impl<'a> State<'a> {
             self.hardbreak_if_not_bol()?;
 
             for field in struct_def.fields() {
-                match field.node.kind {
-                    ast::UnnamedField(..) => panic!("unexpected unnamed field"),
-                    ast::NamedField(ident, ref visibility) => {
-                        self.hardbreak_if_not_bol()?;
-                        self.maybe_print_comment(field.span.lo)?;
-                        self.print_outer_attributes(&field.node.attrs)?;
-                        self.print_visibility(visibility)?;
-                        self.print_ident(ident)?;
-                        self.word_nbsp(":")?;
-                        self.print_type(&field.node.ty)?;
-                        word(&mut self.s, ",")?;
-                    }
-                }
+                self.hardbreak_if_not_bol()?;
+                self.maybe_print_comment(field.span.lo)?;
+                self.print_outer_attributes(&field.node.attrs)?;
+                self.print_visibility(field.node.vis)?;
+                self.print_ident(field.node.ident.unwrap())?;
+                self.word_nbsp(":")?;
+                self.print_type(&field.node.ty)?;
+                word(&mut self.s, ",")?;
             }
 
             self.bclose(span)

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -619,9 +619,9 @@ pub fn walk_struct_def<'v, V: Visitor<'v>>(visitor: &mut V,
 
 pub fn walk_struct_field<'v, V: Visitor<'v>>(visitor: &mut V,
                                              struct_field: &'v StructField) {
-    walk_opt_ident(visitor, struct_field.span, struct_field.node.ident);
-    visitor.visit_ty(&struct_field.node.ty);
-    walk_list!(visitor, visit_attribute, &struct_field.node.attrs);
+    walk_opt_ident(visitor, struct_field.span, struct_field.ident);
+    visitor.visit_ty(&struct_field.ty);
+    walk_list!(visitor, visit_attribute, &struct_field.attrs);
 }
 
 pub fn walk_block<'v, V: Visitor<'v>>(visitor: &mut V, block: &'v Block) {

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -619,7 +619,7 @@ pub fn walk_struct_def<'v, V: Visitor<'v>>(visitor: &mut V,
 
 pub fn walk_struct_field<'v, V: Visitor<'v>>(visitor: &mut V,
                                              struct_field: &'v StructField) {
-    walk_opt_ident(visitor, struct_field.span, struct_field.node.ident());
+    walk_opt_ident(visitor, struct_field.span, struct_field.node.ident);
     visitor.visit_ty(&struct_field.node.ty);
     walk_list!(visitor, visit_attribute, &struct_field.node.attrs);
 }

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -653,7 +653,7 @@ impl<'a> TraitDef<'a> {
                          type_ident: Ident,
                          generics: &Generics) -> P<ast::Item> {
         let field_tys: Vec<P<ast::Ty>> = struct_def.fields().iter()
-            .map(|field| field.node.ty.clone())
+            .map(|field| field.ty.clone())
             .collect();
 
         let methods = self.methods.iter().map(|method_def| {
@@ -701,7 +701,7 @@ impl<'a> TraitDef<'a> {
 
         for variant in &enum_def.variants {
             field_tys.extend(variant.node.data.fields().iter()
-                .map(|field| field.node.ty.clone()));
+                .map(|field| field.ty.clone()));
         }
 
         let methods = self.methods.iter().map(|method_def| {
@@ -1435,7 +1435,7 @@ impl<'a> TraitDef<'a> {
         let mut just_spans = Vec::new();
         for field in struct_def.fields(){
             let sp = self.set_expn_info(cx, field.span);
-            match field.node.ident {
+            match field.ident {
                 Some(ident) => named_idents.push((ident, sp)),
                 _ => just_spans.push(sp),
             }
@@ -1481,7 +1481,7 @@ impl<'a> TraitDef<'a> {
             paths.push(codemap::Spanned{span: sp, node: ident});
             let val = cx.expr_deref(sp, cx.expr_path(cx.path_ident(sp,ident)));
             let val = cx.expr(sp, ast::ExprKind::Paren(val));
-            ident_exprs.push((sp, struct_field.node.ident, val, &struct_field.node.attrs[..]));
+            ident_exprs.push((sp, struct_field.ident, val, &struct_field.attrs[..]));
         }
 
         let subpats = self.create_subpatterns(cx, paths, mutbl);


### PR DESCRIPTION
The AST part of https://github.com/rust-lang/rust/pull/31937

Unlike HIR, AST still uses `Option` for field names because parser can't know field indexes reliably due to constructions like

```
struct S(#[cfg(false)] u8, u8); // The index of the second field changes from 1 during parsing to 0 after expansion.
```

and I wouldn't like to put the burden of renaming fields on expansion passes and syntax extensions.

plugin-[breaking-change] cc https://github.com/rust-lang/rust/issues/31645
r? @Manishearth 
