### PR TITLE
Prefix jemalloc on DragonFly to prevent segfaults.

### DIFF
--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -157,6 +157,8 @@ else ifeq ($(findstring android, $(OSTYPE_$(1))), android)
   # If the test suite passes, however, without symbol prefixes then we should be
   # good to go!
   JEMALLOC_ARGS_$(1) := --disable-tls --with-jemalloc-prefix=je_
+else ifeq ($(findstring dragonfly, $(OSTYPE_$(1))), dragonfly)
+  JEMALLOC_ARGS_$(1) := --with-jemalloc-prefix=je_
 endif
 
 ifdef CFG_ENABLE_DEBUG_JEMALLOC

--- a/src/liballoc_jemalloc/build.rs
+++ b/src/liballoc_jemalloc/build.rs
@@ -86,6 +86,8 @@ fn main() {
         // should be good to go!
         cmd.arg("--with-jemalloc-prefix=je_");
         cmd.arg("--disable-tls");
+    } else if target.contains("dragonfly") {
+        cmd.arg("--with-jemalloc-prefix=je_");
     }
 
     if cfg!(feature = "debug-jemalloc") {

--- a/src/liballoc_jemalloc/lib.rs
+++ b/src/liballoc_jemalloc/lib.rs
@@ -42,22 +42,27 @@ use libc::{c_int, c_void, size_t};
 extern {}
 
 // Note that the symbols here are prefixed by default on OSX (we don't
-// explicitly request it), and on Android we explicitly request it as
-// unprefixing cause segfaults (mismatches in allocators).
+// explicitly request it), and on Android and DragonFly we explicitly request
+// it as unprefixing cause segfaults (mismatches in allocators).
 extern {
-    #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios"),
+    #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios",
+                   target_os = "dragonfly"),
                link_name = "je_mallocx")]
     fn mallocx(size: size_t, flags: c_int) -> *mut c_void;
-    #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios"),
+    #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios",
+                   target_os = "dragonfly"),
                link_name = "je_rallocx")]
     fn rallocx(ptr: *mut c_void, size: size_t, flags: c_int) -> *mut c_void;
-    #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios"),
+    #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios",
+                   target_os = "dragonfly"),
                link_name = "je_xallocx")]
     fn xallocx(ptr: *mut c_void, size: size_t, extra: size_t, flags: c_int) -> size_t;
-    #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios"),
+    #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios",
+                   target_os = "dragonfly"),
                link_name = "je_sdallocx")]
     fn sdallocx(ptr: *mut c_void, size: size_t, flags: c_int);
-    #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios"),
+    #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios",
+                   target_os = "dragonfly"),
                link_name = "je_nallocx")]
     fn nallocx(size: size_t, flags: c_int) -> size_t;
 }


### PR DESCRIPTION
Similar to commits ed015456a114ae907a36af80c06f81ea93182a24 (iOS)
and e3b414d8612314e74e2b0ebde1ed5c6997d28e8d (Android)
