### PR TITLE
Drop the default buffer size to 8K

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -292,7 +292,7 @@ mod lazy;
 mod util;
 mod stdio;
 
-const DEFAULT_BUF_SIZE: usize = 64 * 1024;
+const DEFAULT_BUF_SIZE: usize = 8 * 1024;
 
 // A few methods below (read_to_string, read_line) will append data into a
 // `String` buffer, but we need to be pretty careful when doing this. The


### PR DESCRIPTION
The 64k capacity was picked by me a couple of years ago in the initial
implementation of buffered IO adaptors:
https://github.com/rust-lang/rust/pull/9091/files#diff-b131eeef531ad098b32f49695a031008R62.
64K was picked for symmetry with libuv, which we no longer use.

64K is _way_ larger than the default size of any other language that I
can find. C, C++, and Java default to 8K, and Go defaults to 4K. There
have been a variety of issues filed relating to this such as #31885.

Closes #31885
