### PR TITLE
librustc_llvm: encapsulate "as" cast from/to a bool

### DIFF
--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -73,6 +73,11 @@ pub type Bool = c_uint;
 pub const True: Bool = 1 as Bool;
 pub const False: Bool = 0 as Bool;
 
+#[inline(always)]
+pub fn as_bool(b: Bool) -> bool { False != b }
+#[inline(always)]
+pub fn as_llvm_bool(b: bool) -> Bool { b as Bool }
+
 // Consts for the LLVM CallConv type, pre-cast to usize.
 
 #[derive(Copy, Clone, PartialEq)]
@@ -2178,13 +2183,13 @@ pub fn SetDLLStorageClass(global: ValueRef, class: DLLStorageClassTypes) {
 
 pub fn SetUnnamedAddr(global: ValueRef, unnamed: bool) {
     unsafe {
-        LLVMSetUnnamedAddr(global, unnamed as Bool);
+        LLVMSetUnnamedAddr(global, as_llvm_bool(unnamed));
     }
 }
 
 pub fn set_thread_local(global: ValueRef, is_thread_local: bool) {
     unsafe {
-        LLVMSetThreadLocal(global, is_thread_local as Bool);
+        LLVMSetThreadLocal(global, as_llvm_bool(is_thread_local));
     }
 }
 
@@ -2442,4 +2447,19 @@ impl Drop for OperandBundleDef {
 #[cfg(not(cargobuild))]
 mod llvmdeps {
     include! { env!("CFG_LLVM_LINKAGE_FILE") }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{True, False};
+
+    #[test]
+    fn test_bool_cast() {
+        assert_eq!( True, super::as_llvm_bool(true));
+        assert_eq!(False, super::as_llvm_bool(false));
+
+        assert!( super::as_bool(True));
+        assert!( super::as_bool(12345));
+        assert!(!super::as_bool(False));
+    }
 }

--- a/src/librustc_metadata/loader.rs
+++ b/src/librustc_metadata/loader.rs
@@ -223,7 +223,7 @@ use rustc::session::search_paths::PathKind;
 use rustc::util::common;
 
 use rustc_llvm as llvm;
-use rustc_llvm::{False, ObjectFile, mk_section_iter};
+use rustc_llvm::{ObjectFile, mk_section_iter};
 use rustc_llvm::archive_ro::ArchiveRO;
 use syntax::codemap::Span;
 use syntax::errors::DiagnosticBuilder;
@@ -793,7 +793,7 @@ fn get_metadata_section_imp(target: &Target, filename: &Path)
             }
         };
         let si = mk_section_iter(of.llof);
-        while llvm::LLVMIsSectionIteratorAtEnd(of.llof, si.llsi) == False {
+        while !llvm::as_bool(llvm::LLVMIsSectionIteratorAtEnd(of.llof, si.llsi)) {
             let mut name_buf = ptr::null();
             let name_len = llvm::LLVMRustGetSectionName(si.llsi, &mut name_buf);
             let name = slice::from_raw_parts(name_buf as *const u8,

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -922,7 +922,7 @@ pub fn load_ty_builder<'a, 'tcx>(b: &Builder<'a, 'tcx>, ptr: ValueRef, t: Ty<'tc
 
     unsafe {
         let global = llvm::LLVMIsAGlobalVariable(ptr);
-        if !global.is_null() && llvm::LLVMIsGlobalConstant(global) == llvm::True {
+        if !global.is_null() && llvm::as_bool(llvm::LLVMIsGlobalConstant(global)) {
             let val = llvm::LLVMGetInitializer(global);
             if !val.is_null() {
                 if t.is_bool() {
@@ -2530,7 +2530,7 @@ fn internalize_symbols(cx: &SharedCrateContext, reachable: &HashSet<&str>) {
                 // We only care about external declarations (not definitions)
                 // and available_externally definitions.
                 if !(linkage == llvm::ExternalLinkage as c_uint &&
-                     llvm::LLVMIsDeclaration(val) != 0) &&
+                     llvm::as_bool(llvm::LLVMIsDeclaration(val))) &&
                    !(linkage == llvm::AvailableExternallyLinkage as c_uint) {
                     continue;
                 }
@@ -2551,7 +2551,7 @@ fn internalize_symbols(cx: &SharedCrateContext, reachable: &HashSet<&str>) {
                 // We only care about external definitions.
                 if !((linkage == llvm::ExternalLinkage as c_uint ||
                       linkage == llvm::WeakODRLinkage as c_uint) &&
-                     llvm::LLVMIsDeclaration(val) == 0) {
+                     !llvm::as_bool(llvm::LLVMIsDeclaration(val))) {
                     continue;
                 }
 
@@ -2590,7 +2590,7 @@ fn create_imps(cx: &SharedCrateContext) {
                                        .filter(|&val| {
                                            llvm::LLVMGetLinkage(val) ==
                                            llvm::ExternalLinkage as c_uint &&
-                                           llvm::LLVMIsDeclaration(val) == 0
+                                           !llvm::as_bool(llvm::LLVMIsDeclaration(val))
                                        })
                                        .collect();
 
@@ -2715,7 +2715,7 @@ pub fn trans_crate<'tcx>(tcx: &TyCtxt<'tcx>,
         static INIT: Once = Once::new();
         static mut POISONED: bool = false;
         INIT.call_once(|| {
-            if llvm::LLVMStartMultithreaded() != 1 {
+            if !llvm::as_bool(llvm::LLVMStartMultithreaded()) {
                 // use an extra bool to make sure that all future usage of LLVM
                 // cannot proceed despite the Once not running more than once.
                 POISONED = true;

--- a/src/librustc_trans/build.rs
+++ b/src/librustc_trans/build.rs
@@ -116,7 +116,7 @@ pub fn Switch(cx: Block, v: ValueRef, else_: BasicBlockRef, num_cases: usize)
 
 pub fn AddCase(s: ValueRef, on_val: ValueRef, dest: BasicBlockRef) {
     unsafe {
-        if llvm::LLVMIsUndef(s) == llvm::True { return; }
+        if llvm::as_bool(llvm::LLVMIsUndef(s)) { return; }
         llvm::LLVMAddCase(s, on_val, dest);
     }
 }
@@ -933,7 +933,7 @@ pub fn Phi(cx: Block, ty: Type, vals: &[ValueRef],
 
 pub fn AddIncomingToPhi(phi: ValueRef, val: ValueRef, bb: BasicBlockRef) {
     unsafe {
-        if llvm::LLVMIsUndef(phi) == llvm::True { return; }
+        if llvm::as_bool(llvm::LLVMIsUndef(phi)) { return; }
         llvm::LLVMAddIncoming(phi, &val, &bb, 1 as c_uint);
     }
 }

--- a/src/librustc_trans/consts.rs
+++ b/src/librustc_trans/consts.rs
@@ -11,7 +11,7 @@
 
 use llvm;
 use llvm::{ConstFCmp, ConstICmp, SetLinkage, SetUnnamedAddr};
-use llvm::{InternalLinkage, ValueRef, Bool, True};
+use llvm::{InternalLinkage, ValueRef, True};
 use middle::const_qualif::ConstQualif;
 use rustc_const_eval::{ConstEvalErr, lookup_const_fn_by_id, lookup_const_by_id, ErrKind};
 use rustc_const_eval::eval_repeat_count;
@@ -756,11 +756,11 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                     let repr = adt::represent_type(cx, t_expr);
                     let discr = adt::const_get_discrim(&repr, v);
                     let iv = C_integral(cx.int_type(), discr.0, false);
-                    let s = adt::is_discr_signed(&repr) as Bool;
+                    let s = llvm::as_llvm_bool(adt::is_discr_signed(&repr));
                     llvm::LLVMConstIntCast(iv, llty.to_ref(), s)
                 },
                 (CastTy::Int(_), CastTy::Int(_)) => {
-                    let s = t_expr.is_signed() as Bool;
+                    let s = llvm::as_llvm_bool(t_expr.is_signed());
                     llvm::LLVMConstIntCast(v, llty.to_ref(), s)
                 },
                 (CastTy::Int(_), CastTy::Float) => {

--- a/src/librustc_trans/declare.rs
+++ b/src/librustc_trans/declare.rs
@@ -168,7 +168,7 @@ pub fn get_declared_value(ccx: &CrateContext, name: &str) -> Option<ValueRef> {
 pub fn get_defined_value(ccx: &CrateContext, name: &str) -> Option<ValueRef> {
     get_declared_value(ccx, name).and_then(|val|{
         let declaration = unsafe {
-            llvm::LLVMIsDeclaration(val) != 0
+            llvm::as_bool(llvm::LLVMIsDeclaration(val))
         };
         if !declaration {
             Some(val)

--- a/src/librustc_trans/type_.rs
+++ b/src/librustc_trans/type_.rs
@@ -11,7 +11,7 @@
 #![allow(non_upper_case_globals)]
 
 use llvm;
-use llvm::{TypeRef, Bool, False, True, TypeKind};
+use llvm::{TypeRef, False, True, TypeKind};
 use llvm::{Float, Double, X86_FP80, PPC_FP128, FP128};
 
 use context::CrateContext;
@@ -171,7 +171,7 @@ impl Type {
         let els: &[TypeRef] = Type::to_ref_slice(els);
         ty!(llvm::LLVMStructTypeInContext(ccx.llcx(), els.as_ptr(),
                                           els.len() as c_uint,
-                                          packed as Bool))
+                                          llvm::as_llvm_bool(packed)))
     }
 
     pub fn named_struct(ccx: &CrateContext, name: &str) -> Type {
@@ -215,7 +215,7 @@ impl Type {
         let slice: &[TypeRef] = Type::to_ref_slice(els);
         unsafe {
             llvm::LLVMStructSetBody(self.to_ref(), slice.as_ptr(),
-                                    els.len() as c_uint, packed as Bool)
+                                    els.len() as c_uint, llvm::as_llvm_bool(packed))
         }
     }
 
@@ -231,9 +231,11 @@ impl Type {
     }
 
     pub fn is_packed(&self) -> bool {
-        unsafe {
-            llvm::LLVMIsPackedStruct(self.to_ref()) == True
-        }
+        llvm::as_bool(
+            unsafe {
+                llvm::LLVMIsPackedStruct(self.to_ref())
+            }
+        )
     }
 
     pub fn element_type(&self) -> Type {

--- a/src/test/run-make/execution-engine/test.rs
+++ b/src/test/run-make/execution-engine/test.rs
@@ -172,7 +172,7 @@ impl ExecutionEngine {
 
             let res = unsafe { llvm::LLVMRustLoadDynamicLibrary(cs.as_ptr()) };
 
-            if res == 0 {
+            if !llvm::as_bool(res) {
                 panic!("Failed to load crate {:?}: {}",
                     path.display(), llvm_error());
             }


### PR DESCRIPTION
When the trueness is defined as "!= 0" rather than "== 1", it's error prone to write such a comparison for each occurrence.
