### PR TITLE
Fix "consider removing this semicolon" help

### DIFF
--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1502,7 +1502,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
                 } else {
                     let ends_with_stmt = match body.expr {
                         None if !body.stmts.is_empty() =>
-                            match body.stmts.first().unwrap().node {
+                            match body.stmts.last().unwrap().node {
                                 hir::StmtSemi(ref e, _) => {
                                     self.ir.tcx.expr_ty(&e) == t_ret
                                 },
@@ -1515,7 +1515,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
                                                    E0269,
                                                    "not all control paths return a value");
                     if ends_with_stmt {
-                        let last_stmt = body.stmts.first().unwrap();
+                        let last_stmt = body.stmts.last().unwrap();
                         let original_span = original_sp(self.ir.tcx.sess.codemap(),
                                                         last_stmt.span, sp);
                         let span_semicolon = Span {

--- a/src/test/compile-fail/consider-removing-last-semi.rs
+++ b/src/test/compile-fail/consider-removing-last-semi.rs
@@ -1,0 +1,17 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn f() -> String {  //~ ERROR E0269
+                    //~^ HELP detailed explanation
+    0u8;
+    "bla".to_string();  //~ HELP consider removing this semicolon
+}
+
+fn main() {}

--- a/src/test/compile-fail/consider-removing-last-semi.rs
+++ b/src/test/compile-fail/consider-removing-last-semi.rs
@@ -14,4 +14,10 @@ fn f() -> String {  //~ ERROR E0269
     "bla".to_string();  //~ HELP consider removing this semicolon
 }
 
+fn g() -> String {  //~ ERROR E0269
+                    //~^ HELP detailed explanation
+    "this won't work".to_string();
+    "removeme".to_string(); //~ HELP consider removing this semicolon
+}
+
 fn main() {}


### PR DESCRIPTION
Check last statement in a block, not the first.

Example of current weirdness: http://is.gd/w80J9h

The help was only rarely emitted, and if so, often incorrectly (see above playpen). It was basically only useful with single-statement functions.
