### PR TITLE
Change build helper to modify suffix

### DIFF
--- a/src/build_helper/lib.rs
+++ b/src/build_helper/lib.rs
@@ -48,7 +48,7 @@ pub fn cc2ar(cc: &Path, target: &str) -> PathBuf {
         for suffix in &["gcc", "cc", "clang"] {
             if let Some(idx) = file.rfind(suffix) {
                 let mut file = file[..idx].to_owned();
-                file.push_str(suffix);
+                file.push_str("ar");
                 return parent.join(&file);
             }
         }

--- a/src/build_helper/lib.rs
+++ b/src/build_helper/lib.rs
@@ -43,10 +43,16 @@ pub fn cc2ar(cc: &Path, target: &str) -> PathBuf {
     if target.contains("musl") || target.contains("msvc") {
         PathBuf::from("ar")
     } else {
+        let parent = cc.parent().unwrap();
         let file = cc.file_name().unwrap().to_str().unwrap();
-        cc.parent().unwrap().join(file.replace("gcc", "ar")
-                                      .replace("cc", "ar")
-                                      .replace("clang", "ar"))
+        for suffix in &["gcc", "cc", "clang"] {
+            if let Some(idx) = file.rfind(suffix) {
+                let mut file = file[..idx].to_owned();
+                file.push_str(suffix);
+                return parent.join(&file);
+            }
+        }
+        parent.join(file)
     }
 }
 


### PR DESCRIPTION
The current implementation of [gcc](https://crates.io/crates/gcc) defaults to using the `CC` environment variable to determine the compiler. The current global-find-replace in `build_helper` causes issues for projects using tools like `ccache` if they try to integrate libstd into their build system.

Almost all cross-compiler toolchains have the tool name as a suffix of the filename, so changing this to suffix-replacement instead of global-replacement should be fine.
