### PR TITLE
Use DWARF 5 value for DW_LANG_Rust

### DIFF
--- a/src/librustc_trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/debuginfo/metadata.rs
@@ -50,7 +50,9 @@ use syntax::{ast, codemap};
 use syntax::parse::token;
 
 
-const DW_LANG_RUST: c_uint = 0x9000;
+// From DWARF 5.
+// See http://www.dwarfstd.org/ShowIssue.php?issue=140129.1
+const DW_LANG_RUST: c_uint = 0x1c;
 #[allow(non_upper_case_globals)]
 const DW_ATE_boolean: c_uint = 0x02;
 #[allow(non_upper_case_globals)]


### PR DESCRIPTION
DWARF 5 has assigned a value for `DW_LANG_Rust`.  See [the relevant DWARF issue](http://www.dwarfstd.org/ShowIssue.php?issue=140129.1).  Although DWARF 5 is not yet released, it seems ok to use this value as both GCC and LLVM are already using other `DW_LANG_` constants assigned in this way.
