### PR TITLE
Fix backtraces on ARM EHABI.

### DIFF
--- a/src/libstd/sys/common/unwind/gcc.rs
+++ b/src/libstd/sys/common/unwind/gcc.rs
@@ -224,8 +224,13 @@ pub mod eabi {
         context: *mut uw::_Unwind_Context
     ) -> uw::_Unwind_Reason_Code
     {
+        // Backtraces on ARM will call the personality routine with
+        // state == _US_VIRTUAL_UNWIND_FRAME | _US_FORCE_UNWIND. In those cases
+        // we want to continue unwinding the stack, otherwise all our backtraces
+        // would end at __rust_try.
         if (state as c_int & uw::_US_ACTION_MASK as c_int)
-                           == uw::_US_VIRTUAL_UNWIND_FRAME as c_int { // search phase
+                           == uw::_US_VIRTUAL_UNWIND_FRAME as c_int
+               && (state as c_int & uw::_US_FORCE_UNWIND as c_int) == 0 { // search phase
             uw::_URC_HANDLER_FOUND // catch!
         }
         else { // cleanup phase


### PR DESCRIPTION
Before this patch, our `rust_eh_personality_catch` routine would cut
backtracing short at the `__rust_try` function, due to it not handling
the `_US_FORCE_UNWIND` bit properly, which is passed by libunwind
implementations on ARM EHABI.

Examples of where the `_US_FORCE_UNWIND` bit is passed to the PR:
- GCC's libunwind: https://github.com/gcc-mirror/gcc/blob/f1717362de1e56fe1ffab540289d7d0c6ed48b20/libgcc/unwind-arm-common.inc#L590
- LLVM's libunwind: https://github.com/llvm-mirror/libunwind/blob/61278584b5c84c422ff5da10f46c3235c54636c9/src/UnwindLevel1-gcc-ext.c#L153
