### PR TITLE
expand rustdoc --help for --markdown-playground-url

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -184,7 +184,10 @@ pub fn opts() -> Vec<getopts::OptGroup> {
                  Markdown file or generated documentation",
                  "FILES"),
         optopt("", "markdown-playground-url",
-               "URL to send code snippets to", "URL"),
+               "URL to send code snippets to. \
+                In effect only when <input> file has .md or .markdown extension! \
+                For .rs files(eg. via `cargo doc`) use an inner attribute: \
+                #![doc(html_playground_url = \"https://play.rust-lang.org/\")]", "URL"),
         optflag("", "markdown-no-toc", "don't include table of contents")
     )
 }


### PR DESCRIPTION
Hopefully this will save someone else some time, 
if they, like me, expected `--markdown-playground-url` to work for `.rs` files too.

Relevant PR: https://github.com/rust-lang/rust/pull/14700/files#diff-3f13e5874e2b666556367d0f173cc0f7R88

**EDIT:**Looks like this:
![screenshot_2016-04-05_16-38-11](https://cloud.githubusercontent.com/assets/17984080/14285719/e37d66e0-fb4c-11e5-9a1a-54e5fcf22602.png)
