### PR TITLE
Implement `Default` for more types in the standard library

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -863,3 +863,10 @@ impl<T: ?Sized> UnsafeCell<T> {
         &self.value as *const T as *mut T
     }
 }
+
+#[stable(feature = "unsafe_cell_default", since = "1.9.0")]
+impl<T: Default> Default for UnsafeCell<T> {
+    fn default() -> UnsafeCell<T> {
+        UnsafeCell::new(Default::default())
+    }
+}

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -128,7 +128,7 @@ pub trait Eq: PartialEq<Self> {
 /// let result = 2.cmp(&1);
 /// assert_eq!(Ordering::Greater, result);
 /// ```
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Hash)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub enum Ordering {
     /// An ordering where a compared value is less [than another].

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -60,7 +60,7 @@ pub type Result = result::Result<(), Error>;
 /// occurred. Any extra information must be arranged to be transmitted through
 /// some other means.
 #[stable(feature = "rust1", since = "1.0.0")]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Error;
 
 /// A collection of methods that are required to format a message into a stream.

--- a/src/libstd/sync/condvar.rs
+++ b/src/libstd/sync/condvar.rs
@@ -220,6 +220,13 @@ impl Condvar {
     pub fn notify_all(&self) { unsafe { self.inner.inner.notify_all() } }
 }
 
+#[stable(feature = "condvar_default", since = "1.9.0")]
+impl Default for Condvar {
+    fn default() -> Condvar {
+        Condvar::new()
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Drop for Condvar {
     fn drop(&mut self) {

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -310,6 +310,13 @@ impl<T: ?Sized> Drop for Mutex<T> {
     }
 }
 
+#[stable(feature = "mutex_default", since = "1.9.0")]
+impl<T: ?Sized + Default> Default for Mutex<T> {
+    fn default() -> Mutex<T> {
+        Mutex::new(Default::default())
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized + fmt::Debug> fmt::Debug for Mutex<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/libstd/sync/rwlock.rs
+++ b/src/libstd/sync/rwlock.rs
@@ -346,6 +346,13 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for RwLock<T> {
     }
 }
 
+#[stable(feature = "rw_lock_default", since = "1.9.0")]
+impl<T: Default> Default for RwLock<T> {
+    fn default() -> RwLock<T> {
+        RwLock::new(Default::default())
+    }
+}
+
 struct Dummy(UnsafeCell<()>);
 unsafe impl Sync for Dummy {}
 static DUMMY: Dummy = Dummy(UnsafeCell::new(()));


### PR DESCRIPTION
Also add `Hash` to `std::cmp::Ordering` and most possible traits to
`fmt::Error`.
