### PR TITLE
change `hir::ExprLit` to take a `ConstVal` instead of an `ast::Lit`

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -106,7 +106,7 @@ DEPS_rustc_driver := arena flate getopts graphviz libc rustc rustc_back rustc_bo
                      rustc_typeck rustc_mir rustc_resolve log syntax serialize rustc_llvm \
 	             rustc_trans rustc_privacy rustc_lint rustc_plugin \
                      rustc_metadata syntax_ext rustc_passes rustc_save_analysis rustc_const_eval
-DEPS_rustc_lint := rustc log syntax rustc_const_eval
+DEPS_rustc_lint := rustc log syntax rustc_const_eval rustc_const_math
 DEPS_rustc_llvm := native:rustllvm libc std rustc_bitflags
 DEPS_rustc_metadata := rustc syntax rbml rustc_const_math
 DEPS_rustc_passes := syntax rustc core rustc_const_eval

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -40,12 +40,14 @@ use util::nodemap::{NodeMap, FnvHashSet};
 use syntax::codemap::{self, Span, Spanned, DUMMY_SP, ExpnId};
 use syntax::abi::Abi;
 use syntax::ast::{Name, NodeId, DUMMY_NODE_ID, TokenTree, AsmDialect};
-use syntax::ast::{Attribute, Lit, StrStyle, FloatTy, IntTy, UintTy, MetaItem};
+use syntax::ast::{Attribute, StrStyle, FloatTy, IntTy, UintTy, MetaItem};
 use syntax::attr::{ThinAttributes, ThinAttributesExt};
 use syntax::parse::token::InternedString;
 use syntax::ptr::P;
 
 use std::collections::BTreeMap;
+use rustc_const_math::ConstVal;
+
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use serialize::{Encodable, Decodable, Encoder, Decoder};
@@ -930,7 +932,7 @@ pub enum Expr_ {
     /// A unary operation (For example: `!x`, `*x`)
     ExprUnary(UnOp, P<Expr>),
     /// A literal (For example: `1`, `"foo"`)
-    ExprLit(P<Lit>),
+    ExprLit(ConstVal),
     /// A cast (`foo as f64`)
     ExprCast(P<Expr>, P<Ty>),
     ExprType(P<Expr>, P<Ty>),

--- a/src/librustc/hir/svh.rs
+++ b/src/librustc/hir/svh.rs
@@ -138,6 +138,7 @@ mod svh_visitor {
     use hir::intravisit::{Visitor, FnKind};
     use hir::*;
     use hir;
+    use rustc_const_math::ConstVal;
 
     use std::hash::{Hash, SipHasher};
 
@@ -232,7 +233,7 @@ mod svh_visitor {
         SawExprTup,
         SawExprBinary(hir::BinOp_),
         SawExprUnary(hir::UnOp),
-        SawExprLit(ast::LitKind),
+        SawExprLit(ConstVal),
         SawExprCast,
         SawExprType,
         SawExprIf,
@@ -260,7 +261,7 @@ mod svh_visitor {
             ExprTup(..)              => SawExprTup,
             ExprBinary(op, _, _)     => SawExprBinary(op.node),
             ExprUnary(op, _)         => SawExprUnary(op),
-            ExprLit(ref lit)         => SawExprLit(lit.node.clone()),
+            ExprLit(ref lit)         => SawExprLit(lit.clone()),
             ExprCast(..)             => SawExprCast,
             ExprType(..)             => SawExprType,
             ExprIf(..)               => SawExprIf,

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -81,7 +81,6 @@ pub mod lint;
 pub mod middle {
     pub mod astconv_util;
     pub mod expr_use_visitor; // STAGE0: increase glitch immunity
-    pub mod const_val;
     pub mod const_qualif;
     pub mod cstore;
     pub mod dataflow;

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -8,12 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use middle::const_val::ConstVal;
 use hir::def_id::DefId;
 use ty::subst::Substs;
 use ty::{ClosureSubsts, FnOutput, Region, Ty};
 use mir::repr::*;
-use rustc_const_math::ConstUsize;
+use rustc_const_math::{ConstUsize, ConstVal};
 use rustc_data_structures::tuple_slice::TupleSlice;
 use syntax::codemap::Span;
 

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -337,6 +337,16 @@ impl NodeIdAssigner for Session {
     fn diagnostic(&self) -> &errors::Handler {
         self.diagnostic()
     }
+
+    fn target_bitwidth(&self) -> u32 {
+        match self.target.int_type {
+            ast::IntTy::Is => bug!("target int type defined as isize"),
+            ast::IntTy::I64 => 64,
+            ast::IntTy::I32 => 32,
+            ast::IntTy::I16 => unimplemented!(),
+            ast::IntTy::I8 => unimplemented!(),
+        }
+    }
 }
 
 fn split_msg_into_multilines(msg: &str) -> Option<String> {

--- a/src/librustc_const_eval/check_match.rs
+++ b/src/librustc_const_eval/check_match.rs
@@ -13,7 +13,7 @@ use self::Usefulness::*;
 use self::WitnessPreference::*;
 
 use rustc::dep_graph::DepNode;
-use rustc::middle::const_val::ConstVal;
+use rustc_const_math::ConstVal;
 use ::{eval_const_expr, eval_const_expr_partial, compare_const_vals};
 use ::{const_expr_to_pat, lookup_const_by_id};
 use ::EvalHint::ExprTypeChecked;
@@ -275,7 +275,7 @@ fn check_for_static_nan(cx: &MatchCheckCtxt, pat: &Pat) {
     pat.walk(|p| {
         if let PatKind::Lit(ref expr) = p.node {
             match eval_const_expr_partial(cx.tcx, &expr, ExprTypeChecked, None) {
-                Ok(ConstVal::Float(f)) if f.is_nan() => {
+                Ok(ConstVal::Float(f, _)) if f.is_nan() => {
                     span_warn!(cx.tcx.sess, p.span, E0003,
                                "unmatchable NaN in pattern, \
                                 use the is_nan method in a guard instead");

--- a/src/librustc_const_eval/check_match.rs
+++ b/src/librustc_const_eval/check_match.rs
@@ -37,7 +37,7 @@ use rustc::hir::{Pat, PatKind};
 use rustc::hir::intravisit::{self, IdVisitor, IdVisitingOperation, Visitor, FnKind};
 use rustc_back::slice;
 
-use syntax::ast::{self, DUMMY_NODE_ID, NodeId};
+use syntax::ast::{DUMMY_NODE_ID, NodeId};
 use syntax::codemap::{Span, Spanned, DUMMY_SP};
 use rustc::hir::fold::{Folder, noop_fold_pat};
 use rustc::hir::print::pat_to_string;
@@ -423,13 +423,9 @@ fn check_exhaustive(cx: &MatchCheckCtxt, sp: Span, matrix: &Matrix, source: hir:
 }
 
 fn const_val_to_expr(value: &ConstVal) -> P<hir::Expr> {
-    let node = match value {
-        &ConstVal::Bool(b) => ast::LitKind::Bool(b),
-        _ => bug!()
-    };
     P(hir::Expr {
         id: 0,
-        node: hir::ExprLit(P(Spanned { node: node, span: DUMMY_SP })),
+        node: hir::ExprLit(value.clone()),
         span: DUMMY_SP,
         attrs: None,
     })

--- a/src/librustc_const_eval/eval.rs
+++ b/src/librustc_const_eval/eval.rs
@@ -409,7 +409,6 @@ pub enum ErrKind {
     IndexOpFeatureGated,
     Math(ConstMathErr),
 
-    IntermediateUnsignedNegative,
     /// Expected, Got
     TypeMismatch(String, ConstInt),
     FloatTypeMismatch,
@@ -470,10 +469,6 @@ impl ConstEvalErr {
             MiscCatchAll => "unsupported constant expr".into_cow(),
             IndexOpFeatureGated => "the index operation on const values is unstable".into_cow(),
             Math(ref err) => err.description().into_cow(),
-
-            IntermediateUnsignedNegative => "during the computation of an unsigned a negative \
-                                             number was encountered. This is most likely a bug in\
-                                             the constant evaluator".into_cow(),
 
             TypeMismatch(ref expected, ref got) => {
                 format!("mismatched types: expected `{}`, found `{}`",
@@ -974,7 +969,7 @@ fn infer<'tcx>(
                 Err(_) => Ok(Usize(ConstUsize::Us32(i as u32))),
             }
         },
-        (&ty::TyUint(_), InferSigned(_)) => Err(err(IntermediateUnsignedNegative)),
+        (&ty::TyUint(_), InferSigned(_)) => Err(err(Math(ConstMathErr::UnsignedNegation))),
 
         (&ty::TyInt(ity), i) => Err(err(TypeMismatch(ity.to_string(), i))),
         (&ty::TyUint(ity), i) => Err(err(TypeMismatch(ity.to_string(), i))),

--- a/src/librustc_const_math/lib.rs
+++ b/src/librustc_const_math/lib.rs
@@ -36,8 +36,10 @@ mod int;
 mod us;
 mod is;
 mod err;
+mod val;
 
 pub use int::*;
 pub use us::*;
 pub use is::*;
 pub use err::ConstMathErr;
+pub use val::*;

--- a/src/librustc_lint/Cargo.toml
+++ b/src/librustc_lint/Cargo.toml
@@ -13,4 +13,5 @@ log = { path = "../liblog" }
 rustc = { path = "../librustc" }
 rustc_back = { path = "../librustc_back" }
 rustc_const_eval = { path = "../librustc_const_eval" }
+rustc_const_math = { path = "../librustc_const_math" }
 syntax = { path = "../libsyntax" }

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -38,6 +38,7 @@ use rustc::ty::{self, Ty, TyCtxt};
 use rustc::ty::adjustment;
 use rustc::traits::{self, ProjectionMode};
 use rustc::hir::map as hir_map;
+use rustc_const_math::ConstVal;
 use util::nodemap::{NodeSet};
 use lint::{Level, LateContext, LintContext, LintArray, Lint};
 use lint::{LintPass, LateLintPass};
@@ -74,11 +75,9 @@ impl LintPass for WhileTrue {
 impl LateLintPass for WhileTrue {
     fn check_expr(&mut self, cx: &LateContext, e: &hir::Expr) {
         if let hir::ExprWhile(ref cond, _, _) = e.node {
-            if let hir::ExprLit(ref lit) = cond.node {
-                if let ast::LitKind::Bool(true) = lit.node {
-                    cx.span_lint(WHILE_TRUE, e.span,
-                                 "denote infinite loops with loop { ... }");
-                }
+            if let hir::ExprLit(ConstVal::Bool(true)) = cond.node {
+                cx.span_lint(WHILE_TRUE, e.span,
+                             "denote infinite loops with loop { ... }");
             }
         }
     }

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -80,7 +80,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
     }
 
     macro_rules! add_early_builtin {
-        ($sess:ident, $($name:ident),*,) => (
+        ($sess:ident, $($name:expr),*,) => (
             {$(
                 store.register_early_pass($sess, false, box $name);
                 )*}
@@ -103,6 +103,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
 
     add_early_builtin!(sess,
                        UnusedParens,
+                       EarlyTypeLimits::new(),
                        );
 
     add_builtin!(sess,
@@ -130,10 +131,10 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
                  PluginAsLibrary,
                  DropWithReprExtern,
                  MutableTransmutes,
+                 TypeLimits,
                  );
 
     add_builtin_with_new!(sess,
-                          TypeLimits,
                           MissingDoc,
                           MissingDebugImplementations,
                           );

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -46,6 +46,7 @@ extern crate rustc;
 extern crate log;
 extern crate rustc_back;
 extern crate rustc_const_eval;
+extern crate rustc_const_math;
 
 pub use rustc::lint as lint;
 pub use rustc::middle as middle;

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -14,7 +14,7 @@ use rustc::hir::def_id::DefId;
 use rustc::infer;
 use rustc::ty::subst::Substs;
 use rustc::ty::{self, Ty, TyCtxt};
-use middle::const_val::ConstVal;
+use rustc_const_math::ConstVal;
 use rustc_const_eval::eval_const_expr_partial;
 use rustc_const_eval::EvalHint::ExprTypeChecked;
 use util::nodemap::{FnvHashSet};

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -12,6 +12,7 @@
 
 use rustc::hir::def_id::DefId;
 use rustc::infer;
+use rustc::session::Session;
 use rustc::ty::subst::Substs;
 use rustc::ty::{self, Ty, TyCtxt};
 use rustc_const_math::{ConstVal, ConstInt};
@@ -19,7 +20,7 @@ use rustc_const_eval::eval_const_expr_partial;
 use rustc_const_eval::EvalHint::ExprTypeChecked;
 use util::nodemap::{FnvHashSet};
 use lint::{LateContext, LintContext, LintArray};
-use lint::{LintPass, LateLintPass};
+use lint::{LintPass, LateLintPass, EarlyContext, EarlyLintPass};
 
 use std::cmp;
 use std::{i8, i16, i32, i64, u8, u16, u32, u64, f32, f64};
@@ -71,24 +72,19 @@ declare_lint! {
 }
 
 declare_lint! {
+    OVERFLOWING_SUFFIXED_LITERALS,
+    Warn,
+    "literal out of range for its type"
+}
+
+declare_lint! {
     EXCEEDING_BITSHIFTS,
     Deny,
     "shift exceeds the type's number of bits"
 }
 
 #[derive(Copy, Clone)]
-pub struct TypeLimits {
-    /// Id of the last visited negated expression
-    negated_expr_id: ast::NodeId,
-}
-
-impl TypeLimits {
-    pub fn new() -> TypeLimits {
-        TypeLimits {
-            negated_expr_id: !0,
-        }
-    }
-}
+pub struct TypeLimits;
 
 impl LintPass for TypeLimits {
     fn get_lints(&self) -> LintArray {
@@ -96,31 +92,115 @@ impl LintPass for TypeLimits {
     }
 }
 
+#[derive(Copy, Clone)]
+pub struct EarlyTypeLimits {
+    /// Id of the last visited negated expression
+    negated_expr_id: ast::NodeId,
+}
+
+impl EarlyTypeLimits {
+    pub fn new() -> EarlyTypeLimits {
+        EarlyTypeLimits {
+            negated_expr_id: !0,
+        }
+    }
+}
+
+impl LintPass for EarlyTypeLimits {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(OVERFLOWING_SUFFIXED_LITERALS)
+    }
+}
+
+impl EarlyLintPass for EarlyTypeLimits {
+    fn check_expr(&mut self, cx: &EarlyContext, e: &ast::Expr) {
+        match e.node {
+            ast::ExprKind::Unary(ast::UnOp::Neg, ref expr) => {
+                // propagate negation, if the negation itself isn't negated
+                if self.negated_expr_id != e.id {
+                    self.negated_expr_id = expr.id;
+                }
+            }
+            ast::ExprKind::Paren(ref expr) => {
+                // forward negation
+                if self.negated_expr_id == e.id {
+                    self.negated_expr_id = expr.id;
+                }
+            }
+            ast::ExprKind::Lit(ref lit) => {
+                use std::{i8, i16, i32, i64, u8, u16, u32, u64};
+                use syntax::ast::LitKind::*;
+                use syntax::ast::LitIntType::*;
+                use syntax::ast::IntTy::*;
+                use syntax::ast::UintTy::*;
+                const I8_MAX: u64 = i8::MAX as u64;
+                const I16_MAX: u64 = i16::MAX as u64;
+                const I32_MAX: u64 = i32::MAX as u64;
+                const I64_MAX: u64 = i64::MAX as u64;
+                const U8_MAX: u64 = u8::MAX as u64;
+                const U16_MAX: u64 = u16::MAX as u64;
+                const U32_MAX: u64 = u32::MAX as u64;
+                const U64_MAX: u64 = u64::MAX as u64;
+                const I8_OVERFLOW: u64 = I8_MAX + 1;
+                const I16_OVERFLOW: u64 = I16_MAX + 1;
+                const I32_OVERFLOW: u64 = I32_MAX + 1;
+                const I64_OVERFLOW: u64 = I64_MAX + 1;
+                const I64_DENY: u64 = I64_OVERFLOW + 1;
+                match (&lit.node, cx.sess.target.int_type, cx.sess.target.uint_type) {
+                    // The minimum value of a 2-complement type is -(max + 1)
+                    (&Int(I8_OVERFLOW, Signed(I8)), _, _) |
+                    (&Int(I16_OVERFLOW, Signed(I16)), _, _) |
+                    (&Int(I32_OVERFLOW, Signed(I32)), _, _) |
+                    (&Int(I64_OVERFLOW, Signed(I64)), _, _) |
+                    (&Int(I64_OVERFLOW, Signed(Is)), I64, _) |
+                    (&Int(I32_OVERFLOW, Signed(Is)), I32, _) if self.negated_expr_id == e.id => {},
+                    // Negating an unsigned suffixed literal
+                    (&Int(_, Unsigned(_)), _, _) if self.negated_expr_id == e.id => {
+                        forbid_unsigned_negation(cx.sess, e.span);
+                    }
+                    // unsuffixed values have a maximum when negating them
+                    (&Int(I64_DENY...U64_MAX, Unsuffixed), _, _) if self.negated_expr_id == e.id
+                    => {
+                        cx.span_lint(OVERFLOWING_LITERALS, e.span, "literal out of range for i64");
+                    }
+                    // ranges of the legal absolute value (-(max + 1) has been checked above)
+                    (&Int(0...I8_MAX, Signed(I8)), _, _) |
+                    (&Int(0...I16_MAX, Signed(I16)), _, _) |
+                    (&Int(0...I32_MAX, Signed(I32)), _, _) |
+                    (&Int(0...I64_MAX, Signed(I64)), _, _) |
+                    (&Int(0...I32_MAX, Signed(Is)), I32, _) |
+                    (&Int(0...I64_MAX, Signed(Is)), I64, _) |
+                    (&Int(0...U8_MAX, Unsigned(U8)), _, _) |
+                    (&Int(0...U16_MAX, Unsigned(U16)), _, _) |
+                    (&Int(0...U32_MAX, Unsigned(U32)), _, _) |
+                    (&Int(0...U64_MAX, Unsigned(U64)), _, _) |
+                    (&Int(0...U32_MAX, Unsigned(Us)), _, U32) |
+                    (&Int(0...U64_MAX, Unsigned(Us)), _, U64) |
+                    // can't say anything about unsuffixed values, gets caught in a HIR-lint
+                    (&Int(_, Unsuffixed), _, _) => {},
+                    // everything else is an overflow
+                    (&Int(_, Signed(t)), _, _) => {
+                        cx.span_lint(OVERFLOWING_LITERALS, e.span,
+                                     &format!("literal out of range for {:?}", t));
+                    }
+                    (&Int(_, Unsigned(t)), _, _) => {
+                        cx.span_lint(OVERFLOWING_LITERALS, e.span,
+                                     &format!("literal out of range for {:?}", t));
+                    }
+                    _ => {},
+                }
+            },
+            _ => {},
+        }
+    }
+}
+
 impl LateLintPass for TypeLimits {
     fn check_expr(&mut self, cx: &LateContext, e: &hir::Expr) {
         match e.node {
             hir::ExprUnary(hir::UnNeg, ref expr) => {
-                if let hir::ExprLit(ref lit) = expr.node {
-                    match lit.node {
-                        ast::LitKind::Int(_, ast::LitIntType::Unsigned(_)) => {
-                            forbid_unsigned_negation(cx, e.span);
-                        },
-                        ast::LitKind::Int(_, ast::LitIntType::Unsuffixed) => {
-                            if let ty::TyUint(_) = cx.tcx.node_id_to_type(e.id).sty {
-                                forbid_unsigned_negation(cx, e.span);
-                            }
-                        },
-                        _ => ()
-                    }
-                } else {
-                    let t = cx.tcx.node_id_to_type(expr.id);
-                    if let ty::TyUint(_) = t.sty {
-                        forbid_unsigned_negation(cx, e.span);
-                    }
-                }
-                // propagate negation, if the negation itself isn't negated
-                if self.negated_expr_id != e.id {
-                    self.negated_expr_id = expr.id;
+                if let ty::TyUint(_) = cx.tcx.node_id_to_type(expr.id).sty {
+                    forbid_unsigned_negation(cx.sess(), e.span);
                 }
             },
             hir::ExprBinary(binop, ref l, ref r) => {
@@ -186,6 +266,8 @@ impl LateLintPass for TypeLimits {
                                     return;
                                 }
                             },
+                            // concrete types have already been checked in the lowering step
+                            ConstVal::Integral(_) => return,
                             _ => bug!(),
                         }
                     },

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -15,7 +15,7 @@
 
 use build::{BlockAnd, BlockAndExtension, Builder};
 use rustc_data_structures::fnv::FnvHashMap;
-use rustc::middle::const_val::ConstVal;
+use rustc_const_math::ConstVal;
 use rustc::ty::{AdtDef, Ty};
 use rustc::mir::repr::*;
 use hair::*;

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -19,7 +19,7 @@ use build::Builder;
 use build::matches::{Candidate, MatchPair, Test, TestKind};
 use hair::*;
 use rustc_data_structures::fnv::FnvHashMap;
-use rustc::middle::const_val::ConstVal;
+use rustc_const_math::ConstVal;
 use rustc::ty::{self, Ty};
 use rustc::mir::repr::*;
 use syntax::codemap::Span;

--- a/src/librustc_mir/build/scope.rs
+++ b/src/librustc_mir/build/scope.rs
@@ -94,7 +94,7 @@ use rustc::ty::{self, Ty, TyCtxt};
 use rustc::mir::repr::*;
 use syntax::codemap::{Span, DUMMY_SP};
 use syntax::parse::token::intern_and_get_ident;
-use rustc::middle::const_val::ConstVal;
+use rustc_const_math::ConstVal;
 use rustc_const_math::ConstInt;
 
 pub struct Scope<'tcx> {

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -246,15 +246,9 @@ impl<'tcx> Mirror<'tcx> for &'tcx hir::Expr {
                                         PassArgs::ByValue, arg.to_ref(), vec![])
                 } else {
                     // FIXME runtime-overflow
-                    if let hir::ExprLit(_) = arg.node {
-                        ExprKind::Literal {
-                            literal: cx.const_eval_literal(self),
-                        }
-                    } else {
-                        ExprKind::Unary {
-                            op: UnOp::Neg,
-                            arg: arg.to_ref(),
-                        }
+                    ExprKind::Unary {
+                        op: UnOp::Neg,
+                        arg: arg.to_ref(),
                     }
                 }
             }

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -16,7 +16,7 @@ use hair::cx::block;
 use hair::cx::to_ref::ToRef;
 use rustc::hir::map;
 use rustc::hir::def::Def;
-use rustc::middle::const_val::ConstVal;
+use rustc_const_math::ConstVal;
 use rustc_const_eval as const_eval;
 use rustc::middle::region::CodeExtent;
 use rustc::hir::pat_util;

--- a/src/librustc_mir/hair/cx/mod.rs
+++ b/src/librustc_mir/hair/cx/mod.rs
@@ -18,7 +18,7 @@
 use hair::*;
 use rustc::mir::repr::*;
 
-use rustc::middle::const_val::ConstVal;
+use rustc_const_math::ConstVal;
 use rustc_const_eval as const_eval;
 use rustc::hir::def_id::DefId;
 use rustc::infer::InferCtxt;
@@ -91,7 +91,7 @@ impl<'a,'tcx:'a> Cx<'a, 'tcx> {
                 // All of these contain local IDs, unsuitable for storing in MIR.
                 ConstVal::Struct(_) | ConstVal::Tuple(_) |
                 ConstVal::Array(..) | ConstVal::Repeat(..) |
-                ConstVal::Function(_) => None,
+                ConstVal::Function { .. } => None,
 
                 _ => Some(Literal::Value { value: v })
             }

--- a/src/librustc_mir/hair/mod.rs
+++ b/src/librustc_mir/hair/mod.rs
@@ -16,7 +16,7 @@
 
 use rustc::mir::repr::{BinOp, BorrowKind, Field, Literal, Mutability, UnOp,
     TypedConstVal};
-use rustc::middle::const_val::ConstVal;
+use rustc_const_math::ConstVal;
 use rustc::hir::def_id::DefId;
 use rustc::middle::region::CodeExtent;
 use rustc::ty::subst::Substs;

--- a/src/librustc_mir/transform/simplify_cfg.rs
+++ b/src/librustc_mir/transform/simplify_cfg.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use rustc::middle::const_val::ConstVal;
+use rustc_const_math::ConstVal;
 use rustc::ty::TyCtxt;
 use rustc::mir::repr::*;
 use rustc::mir::transform::{MirPass, Pass};

--- a/src/librustc_trans/common.rs
+++ b/src/librustc_trans/common.rs
@@ -814,13 +814,6 @@ pub fn C_integral(t: Type, u: u64, sign_extend: bool) -> ValueRef {
     }
 }
 
-pub fn C_floating(s: &str, t: Type) -> ValueRef {
-    unsafe {
-        let s = CString::new(s).unwrap();
-        llvm::LLVMConstRealOfString(t.to_ref(), s.as_ptr())
-    }
-}
-
 pub fn C_floating_f64(f: f64, t: Type) -> ValueRef {
     unsafe {
         llvm::LLVMConstReal(t.to_ref(), f)

--- a/src/librustc_trans/mir/constant.rs
+++ b/src/librustc_trans/mir/constant.rs
@@ -10,7 +10,7 @@
 
 use llvm::ValueRef;
 use rustc::ty::{Ty, TypeFoldable};
-use rustc::middle::const_val::ConstVal;
+use rustc_const_math::ConstVal;
 use rustc_const_math::ConstInt::*;
 use rustc_const_eval::lookup_const_by_id;
 use rustc::mir::repr as mir;
@@ -64,7 +64,7 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
         let ccx = bcx.ccx();
         let llty = type_of::type_of(ccx, ty);
         match *cv {
-            ConstVal::Float(v) => C_floating_f64(v, llty),
+            ConstVal::Float(v, _) => C_floating_f64(v, llty),
             ConstVal::Bool(v) => C_bool(ccx, v),
             ConstVal::Integral(I8(v)) => C_integral(Type::i8(ccx), v as u64, true),
             ConstVal::Integral(I16(v)) => C_integral(Type::i16(ccx), v as u64, true),
@@ -88,7 +88,7 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
             ConstVal::ByteStr(ref v) => consts::addr_of(ccx, C_bytes(ccx, v), 1, "byte_str"),
             ConstVal::Struct(_) | ConstVal::Tuple(_) |
             ConstVal::Array(..) | ConstVal::Repeat(..) |
-            ConstVal::Function(_) => {
+            ConstVal::Function { .. } => {
                 bug!("MIR must not use {:?} (which refers to a local ID)", cv)
             }
             ConstVal::Char(c) => C_integral(Type::char(ccx), c as u64, false),

--- a/src/librustc_trans/mir/constant.rs
+++ b/src/librustc_trans/mir/constant.rs
@@ -82,7 +82,7 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                 let u = v.as_u64(ccx.tcx().sess.target.uint_type);
                 C_integral(Type::int(ccx), u, false)
             },
-            ConstVal::Integral(Infer(v)) => C_integral(llty, v as u64, false),
+            ConstVal::Integral(Infer(v)) => C_integral(llty, v, false),
             ConstVal::Integral(InferSigned(v)) => C_integral(llty, v as u64, true),
             ConstVal::Str(ref v) => C_str_slice(ccx, v.clone()),
             ConstVal::ByteStr(ref v) => consts::addr_of(ccx, C_bytes(ccx, v), 1, "byte_str"),

--- a/src/librustc_trans/mir/rvalue.rs
+++ b/src/librustc_trans/mir/rvalue.rs
@@ -11,8 +11,7 @@
 use llvm::ValueRef;
 use rustc::ty::{self, Ty};
 use rustc::ty::cast::{CastTy, IntTy};
-use middle::const_val::ConstVal;
-use rustc_const_math::ConstInt;
+use rustc_const_math::{ConstInt, ConstVal};
 use rustc::mir::repr as mir;
 
 use asm;

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -49,7 +49,6 @@
 //! an rptr (`&r.T`) use the region `r` that appears in the rptr.
 
 use middle::astconv_util::{prim_ty_to_ty, prohibit_type_params, prohibit_projection};
-use middle::const_val::ConstVal;
 use rustc_const_eval::eval_const_expr_partial;
 use rustc_const_eval::EvalHint::UncheckedExprHint;
 use hir::def::{self, Def};
@@ -66,7 +65,7 @@ use rscope::{self, UnelidableRscope, RegionScope, ElidableRscope,
 use util::common::{ErrorReported, FN_OUTPUT_NAME};
 use util::nodemap::FnvHashSet;
 
-use rustc_const_math::ConstInt;
+use rustc_const_math::{ConstInt, ConstVal};
 
 use syntax::{abi, ast};
 use syntax::codemap::{Span, Pos};

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -33,6 +33,8 @@ use syntax::ptr::P;
 use rustc::hir::{self, PatKind};
 use rustc::hir::print as pprust;
 
+use rustc_const_math::ConstVal;
+
 pub fn check_pat<'a, 'tcx>(pcx: &pat_ctxt<'a, 'tcx>,
                            pat: &'tcx hir::Pat,
                            expected: Ty<'tcx>)
@@ -55,14 +57,12 @@ pub fn check_pat<'a, 'tcx>(pcx: &pat_ctxt<'a, 'tcx>,
             // Byte string patterns behave the same way as array patterns
             // They can denote both statically and dynamically sized byte arrays
             let mut pat_ty = expr_ty;
-            if let hir::ExprLit(ref lt) = lt.node {
-                if let ast::LitKind::ByteStr(_) = lt.node {
-                    let expected_ty = structurally_resolved_type(fcx, pat.span, expected);
-                    if let ty::TyRef(_, mt) = expected_ty.sty {
-                        if let ty::TySlice(_) = mt.ty.sty {
-                            pat_ty = tcx.mk_imm_ref(tcx.mk_region(ty::ReStatic),
-                                                     tcx.mk_slice(tcx.types.u8))
-                        }
+            if let hir::ExprLit(ConstVal::ByteStr(_)) = lt.node {
+                let expected_ty = structurally_resolved_type(fcx, pat.span, expected);
+                if let ty::TyRef(_, mt) = expected_ty.sty {
+                    if let ty::TySlice(_) = mt.ty.sty {
+                        pat_ty = tcx.mk_imm_ref(tcx.mk_region(ty::ReStatic),
+                                                 tcx.mk_slice(tcx.types.u8))
                     }
                 }
             }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2676,6 +2676,8 @@ fn check_lit<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                 || tcx.mk_float_var(fcx.infcx().next_float_var_id()))
         }
         ConstVal::Bool(_) => tcx.types.bool,
+        // if a dummy is emitted, an error has already been reported
+        ConstVal::Dummy => tcx.types.err,
         _ => bug!(),
     }
 }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -130,6 +130,7 @@ use rustc::hir::{Visibility, PatKind};
 use rustc::hir::print as pprust;
 use rustc_back::slice;
 use rustc_const_eval::eval_repeat_count;
+use rustc_const_math::{ConstVal, ConstInt};
 
 mod assoc;
 pub mod dropck;
@@ -2626,23 +2627,31 @@ fn write_call<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
 
 // AST fragment checking
 fn check_lit<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
-                       lit: &ast::Lit,
+                       lit: &ConstVal,
                        expected: Expectation<'tcx>)
                        -> Ty<'tcx>
 {
     let tcx = fcx.ccx.tcx;
 
-    match lit.node {
-        ast::LitKind::Str(..) => tcx.mk_static_str(),
-        ast::LitKind::ByteStr(ref v) => {
+    match *lit {
+        ConstVal::Str(..) => tcx.mk_static_str(),
+        ConstVal::ByteStr(ref v) => {
             tcx.mk_imm_ref(tcx.mk_region(ty::ReStatic),
                             tcx.mk_array(tcx.types.u8, v.len()))
         }
-        ast::LitKind::Byte(_) => tcx.types.u8,
-        ast::LitKind::Char(_) => tcx.types.char,
-        ast::LitKind::Int(_, ast::LitIntType::Signed(t)) => tcx.mk_mach_int(t),
-        ast::LitKind::Int(_, ast::LitIntType::Unsigned(t)) => tcx.mk_mach_uint(t),
-        ast::LitKind::Int(_, ast::LitIntType::Unsuffixed) => {
+        ConstVal::Char(_) => tcx.types.char,
+        ConstVal::Integral(ConstInt::I8(_)) => tcx.types.i8,
+        ConstVal::Integral(ConstInt::I16(_)) => tcx.types.i16,
+        ConstVal::Integral(ConstInt::I32(_)) => tcx.types.i32,
+        ConstVal::Integral(ConstInt::I64(_)) => tcx.types.i64,
+        ConstVal::Integral(ConstInt::Isize(_)) => tcx.types.isize,
+        ConstVal::Integral(ConstInt::U8(_)) => tcx.types.u8,
+        ConstVal::Integral(ConstInt::U16(_)) => tcx.types.u16,
+        ConstVal::Integral(ConstInt::U32(_)) => tcx.types.u32,
+        ConstVal::Integral(ConstInt::U64(_)) => tcx.types.u64,
+        ConstVal::Integral(ConstInt::Usize(_)) => tcx.types.usize,
+        ConstVal::Integral(ConstInt::Infer(_)) |
+        ConstVal::Integral(ConstInt::InferSigned(_)) => {
             let opt_ty = expected.to_option(fcx).and_then(|ty| {
                 match ty.sty {
                     ty::TyInt(_) | ty::TyUint(_) => Some(ty),
@@ -2655,8 +2664,8 @@ fn check_lit<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
             opt_ty.unwrap_or_else(
                 || tcx.mk_int_var(fcx.infcx().next_int_var_id()))
         }
-        ast::LitKind::Float(_, t) => tcx.mk_mach_float(t),
-        ast::LitKind::FloatUnsuffixed(_) => {
+        ConstVal::Float(_, Some(t)) => tcx.mk_mach_float(t),
+        ConstVal::Float(_, None) => {
             let opt_ty = expected.to_option(fcx).and_then(|ty| {
                 match ty.sty {
                     ty::TyFloat(_) => Some(ty),
@@ -2666,7 +2675,8 @@ fn check_lit<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
             opt_ty.unwrap_or_else(
                 || tcx.mk_float_var(fcx.infcx().next_float_var_id()))
         }
-        ast::LitKind::Bool(_) => tcx.types.bool
+        ConstVal::Bool(_) => tcx.types.bool,
+        _ => bug!(),
     }
 }
 
@@ -3289,7 +3299,7 @@ fn check_expr_with_expectation_and_lvalue_pref<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
       }
 
       hir::ExprLit(ref lit) => {
-        let typ = check_lit(fcx, &lit, expected);
+        let typ = check_lit(fcx, lit, expected);
         fcx.write_ty(id, typ);
       }
       hir::ExprBinary(op, ref lhs, ref rhs) => {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -66,7 +66,6 @@ use constrained_type_params as ctp;
 use coherence;
 use middle::lang_items::SizedTraitLangItem;
 use middle::resolve_lifetime;
-use middle::const_val::ConstVal;
 use rustc_const_eval::EvalHint::UncheckedExprHint;
 use rustc_const_eval::eval_const_expr_partial;
 use rustc::ty::subst::{Substs, FnSpace, ParamSpace, SelfSpace, TypeSpace, VecPerParamSpace};
@@ -82,7 +81,7 @@ use util::common::{ErrorReported, MemoizationMap};
 use util::nodemap::{FnvHashMap, FnvHashSet};
 use write_ty_to_tcx;
 
-use rustc_const_math::ConstInt;
+use rustc_const_math::{ConstInt, ConstVal};
 
 use std::cell::RefCell;
 use std::collections::HashSet;

--- a/src/libsyntax/Cargo.toml
+++ b/src/libsyntax/Cargo.toml
@@ -12,3 +12,4 @@ crate-type = ["dylib"]
 serialize = { path = "../libserialize" }
 log = { path = "../liblog" }
 rustc_bitflags = { path = "../librustc_bitflags" }
+rustc_const_math = { path = "../librustc_const_math" }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -362,6 +362,10 @@ pub trait NodeIdAssigner {
     fn next_node_id(&self) -> NodeId;
     fn peek_node_id(&self) -> NodeId;
 
+    fn target_bitwidth(&self) -> u32 {
+        panic!("this ID assigner doesn't know the compilation target's bitwidth");
+    }
+
     fn diagnostic(&self) -> &errors::Handler {
         panic!("this ID assigner cannot emit diagnostics")
     }

--- a/src/test/auxiliary/dummy_mir_pass.rs
+++ b/src/test/auxiliary/dummy_mir_pass.rs
@@ -22,7 +22,7 @@ use rustc::mir::transform::{self, MirPass};
 use rustc::mir::repr::{Mir, Literal};
 use rustc::mir::visit::MutVisitor;
 use rustc::ty;
-use rustc::middle::const_val::ConstVal;
+use rustc_const_math::ConstVal;
 use rustc_const_math::ConstInt;
 use rustc_plugin::Registry;
 

--- a/src/test/compile-fail/feature-gate-negate-unsigned1.rs
+++ b/src/test/compile-fail/feature-gate-negate-unsigned1.rs
@@ -17,7 +17,11 @@ impl std::ops::Neg for S {
 }
 
 fn main() {
-    let _d = -1u8;
+    let a = -1;
+    //~^ ERROR unary negation of unsigned integer
+    let _b : u8 = a; // for infering variable a to u8.
+
+    for _ in -10..10u8 {}
     //~^ ERROR unary negation of unsigned integer
 
     -S; // should not trigger the gate; issue 26840

--- a/src/test/compile-fail/lint-type-overflow2.rs
+++ b/src/test/compile-fail/lint-type-overflow2.rs
@@ -19,4 +19,8 @@ fn main() {
     let x =  3.40282348e+38_f32; //~ error: literal out of range for f32
     let x = -1.7976931348623159e+308_f64; //~ error: literal out of range for f64
     let x =  1.7976931348623159e+308_f64; //~ error: literal out of range for f64
+    let x: f32 = -3.40282348e+38; //~ error: literal out of range for f32
+    let x: f32 =  3.40282348e+38; //~ error: literal out of range for f32
+    let x: f64 = -1.7976931348623159e+308; //~ error: literal out of range for f64
+    let x: f64 =  1.7976931348623159e+308; //~ error: literal out of range for f64
 }

--- a/src/test/compile-fail/lint-type-overflow_early.rs
+++ b/src/test/compile-fail/lint-type-overflow_early.rs
@@ -18,30 +18,31 @@ fn test(x: i8) {
 #[allow(unused_variables)]
 fn main() {
     let x1: u8 = 255; // should be OK
-    let x1: u8 = 256; //~ error: literal out of range for u8
 
     let x1 = 255_u8; // should be OK
+    let x1 = 256_u8; //~ error: literal out of range for u8
 
     let x2: i8 = -128; // should be OK
-    let x1: i8 = 128; //~ error: literal out of range for i8
 
-    let x3: i8 = -129; //~ error: literal out of range for i8
-    let x3: i8 = -(129); //~ error: literal out of range for i8
-    let x3: i8 = -{129}; //~ error: literal out of range for i8
-
-    test(1000); //~ error: literal out of range for i8
-
+    let x = 128_i8; //~ error: literal out of range for i8
     let x = 127_i8;
     let x = -128_i8;
     let x = -(128_i8);
+    let x = -{128_i8}; //~ error: literal out of range for i8
+    let x = -129_i8; //~ error: literal out of range for i8
+    let x = -(129_i8); //~ error: literal out of range for i8
+    let x = -{129_i8}; //~ error: literal out of range for i8
 
     let x: i32 = 2147483647; // should be OK
     let x = 2147483647_i32; // should be OK
-    let x: i32 = 2147483648; //~ error: literal out of range for i32
+    let x = 2147483648_i32; //~ error: literal out of range for i32
     let x: i32 = -2147483648; // should be OK
     let x = -2147483648_i32; // should be OK
-    let x: i32 = -2147483649; //~ error: literal out of range for i32
-    let x = 2147483648; //~ error: literal out of range for i32
+    let x = -2147483649_i32; //~ error: literal out of range for i32
 
+    let x = 9223372036854775808_i64; //~ error: literal out of range for i64
     let x = -9223372036854775808_i64; // should be OK
+    let x = 18446744073709551615_i64; //~ error: literal out of range for i64
+    let x = -9223372036854775809_i64; //~ error: literal out of range for i64
+    let x: i64 = -9223372036854775809; //~ error: literal out of range for i64
 }


### PR DESCRIPTION
This PR uses the lowering step to move from `ast::Lit` to `ConstVal`. Since suffixed literals (e.g. `42_u8`) are turned into concrete `ConstInt` variants, these literal overflow checks need to be done in the ast. This causes a little code duplication in the `rustc_lint/types` lints.

~~I don't know how immutable the HIR is, but if we can run a mutating pass after typeck, we could also lower all `ConstInt::Infer`/`ConstInt::InferSigned` variants to their concrete variants.~~

r? @eddyb 

As a next step I can remove some code-duplication between MIR-trans and normal trans (since MIR already uses `ConstVal` instead of literals).
