### PR TITLE
Parser backports for beta

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -138,6 +138,7 @@ pub struct Options {
     pub no_trans: bool,
     pub error_format: ErrorOutputType,
     pub treat_err_as_bug: bool,
+    pub continue_parse_after_error: bool,
     pub mir_opt_level: usize,
 
     /// if true, build up the dep-graph
@@ -255,6 +256,7 @@ pub fn basic_options() -> Options {
         parse_only: false,
         no_trans: false,
         treat_err_as_bug: false,
+        continue_parse_after_error: false,
         mir_opt_level: 1,
         build_dep_graph: false,
         dump_dep_graph: false,
@@ -629,6 +631,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
           "run all passes except translation; no output"),
     treat_err_as_bug: bool = (false, parse_bool,
           "treat all errors that occur as bugs"),
+    continue_parse_after_error: bool = (false, parse_bool,
+          "attempt to recover from parse errors (experimental)"),
     incr_comp: bool = (false, parse_bool,
           "enable incremental compilation (experimental)"),
     dump_dep_graph: bool = (false, parse_bool,
@@ -1039,6 +1043,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
     let parse_only = debugging_opts.parse_only;
     let no_trans = debugging_opts.no_trans;
     let treat_err_as_bug = debugging_opts.treat_err_as_bug;
+    let continue_parse_after_error = debugging_opts.continue_parse_after_error;
     let mir_opt_level = debugging_opts.mir_opt_level.unwrap_or(1);
     let incremental_compilation = debugging_opts.incr_comp;
     let dump_dep_graph = debugging_opts.dump_dep_graph;
@@ -1218,6 +1223,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
         parse_only: parse_only,
         no_trans: no_trans,
         treat_err_as_bug: treat_err_as_bug,
+        continue_parse_after_error: continue_parse_after_error,
         mir_opt_level: mir_opt_level,
         build_dep_graph: incremental_compilation || dump_dep_graph,
         dump_dep_graph: dump_dep_graph,

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -421,6 +421,8 @@ pub fn phase_1_parse_input(sess: &Session, cfg: ast::CrateConfig, input: &Input)
     // memory, but they do not restore the initial state.
     syntax::ext::mtwt::reset_tables();
     token::reset_ident_interner();
+    let continue_after_error = sess.opts.continue_parse_after_error;
+    sess.diagnostic().set_continue_after_error(continue_after_error);
 
     let krate = time(sess.time_passes(), "parsing", || {
         match *input {
@@ -435,6 +437,8 @@ pub fn phase_1_parse_input(sess: &Session, cfg: ast::CrateConfig, input: &Input)
             }
         }
     });
+
+    sess.diagnostic().set_continue_after_error(true);
 
     if sess.opts.debugging_opts.ast_json_noexpand {
         println!("{}", json::as_json(&krate));

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -261,6 +261,7 @@ pub struct Parser<'a> {
     /// the previous token or None (only stashed sometimes).
     pub last_token: Option<Box<token::Token>>,
     last_token_interpolated: bool,
+    last_token_eof: bool,
     pub buffer: [TokenAndSpan; 4],
     pub buffer_start: isize,
     pub buffer_end: isize,
@@ -369,6 +370,7 @@ impl<'a> Parser<'a> {
             last_span: span,
             last_token: None,
             last_token_interpolated: false,
+            last_token_eof: false,
             buffer: [
                 placeholder.clone(),
                 placeholder.clone(),
@@ -982,6 +984,15 @@ impl<'a> Parser<'a> {
 
     /// Advance the parser by one token
     pub fn bump(&mut self) {
+        if self.last_token_eof {
+            // Bumping after EOF is a bad sign, usually an infinite loop.
+            self.bug("attempted to bump the parser past EOF (may be stuck in a loop)");
+        }
+
+        if self.token == token::Eof {
+            self.last_token_eof = true;
+        }
+
         self.last_span = self.span;
         // Stash token for error recovery (sometimes; clone is not necessarily cheap).
         self.last_token = if self.token.is_ident() ||

--- a/src/test/compile-fail/issue-12560-2.rs
+++ b/src/test/compile-fail/issue-12560-2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z continue-parse-after-error
+
 // For style and consistency reasons, non-parametrized enum variants must
 // be used simply as `ident` instead of `ident ()`.
 // This test-case covers enum matching.

--- a/src/test/compile-fail/issue-28433.rs
+++ b/src/test/compile-fail/issue-28433.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z continue-parse-after-error
+
 enum bird {
     pub duck,
     //~^ ERROR: expected identifier, found keyword `pub`

--- a/src/test/compile-fail/issue-30715.rs
+++ b/src/test/compile-fail/issue-30715.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z continue-parse-after-error
+
 macro_rules! parallel {
     (
         // If future has `pred`/`moelarry` fragments (where "pred" is

--- a/src/test/compile-fail/macro-incomplete-parse.rs
+++ b/src/test/compile-fail/macro-incomplete-parse.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z continue-parse-after-error
+
 macro_rules! ignored_item {
     () => {
         fn foo() {}

--- a/src/test/compile-fail/parse-error-correct.rs
+++ b/src/test/compile-fail/parse-error-correct.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z continue-parse-after-error
+
 // Test that the parser is error correcting missing idents. Despite a parsing
 // error (or two), we still run type checking (and don't get extra errors there).
 

--- a/src/test/compile-fail/parser-recovery-1.rs
+++ b/src/test/compile-fail/parser-recovery-1.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z continue-parse-after-error
+
 // Test that we can recover from missing braces in the parser.
 
 trait Foo {

--- a/src/test/compile-fail/parser-recovery-2.rs
+++ b/src/test/compile-fail/parser-recovery-2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z continue-parse-after-error
+
 // Test that we can recover from mismatched braces in the parser.
 
 trait Foo {

--- a/src/test/compile-fail/self_type_keyword.rs
+++ b/src/test/compile-fail/self_type_keyword.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z continue-parse-after-error
+
 struct Self;
 //~^ ERROR expected identifier, found keyword `Self`
 

--- a/src/test/parse-fail/ascii-only-character-escape.rs
+++ b/src/test/parse-fail/ascii-only-character-escape.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only
+// compile-flags: -Z parse-only -Z continue-parse-after-error
 
 fn main() {
     let x = "\x80"; //~ ERROR may only be used

--- a/src/test/parse-fail/bad-char-literals.rs
+++ b/src/test/parse-fail/bad-char-literals.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only
+// compile-flags: -Z parse-only -Z continue-parse-after-error
 
 // ignore-tidy-cr
 // ignore-tidy-tab

--- a/src/test/parse-fail/bad-lit-suffixes.rs
+++ b/src/test/parse-fail/bad-lit-suffixes.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only
+// compile-flags: -Z parse-only -Z continue-parse-after-error
 
 
 extern

--- a/src/test/parse-fail/byte-literals.rs
+++ b/src/test/parse-fail/byte-literals.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only
+// compile-flags: -Z parse-only -Z continue-parse-after-error
 
 
 // ignore-tidy-tab

--- a/src/test/parse-fail/byte-string-literals.rs
+++ b/src/test/parse-fail/byte-string-literals.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only
+// compile-flags: -Z parse-only -Z continue-parse-after-error
 
 
 // ignore-tidy-tab

--- a/src/test/parse-fail/issue-10412.rs
+++ b/src/test/parse-fail/issue-10412.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only
+// compile-flags: -Z parse-only -Z continue-parse-after-error
 
 
 trait Serializable<'self, T> { //~ ERROR no longer a special lifetime

--- a/src/test/parse-fail/issue-10636-2.rs
+++ b/src/test/parse-fail/issue-10636-2.rs
@@ -17,5 +17,4 @@ pub fn trace_option(option: Option<isize>) { //~ HELP did you mean to close this
     option.map(|some| 42; //~ NOTE: unclosed delimiter
                           //~^ ERROR: expected one of
 } //~ ERROR: incorrect close delimiter
-//~^ ERROR: expected one of
-//~ ERROR: this file contains an un-closed delimiter
+//~^ ERROR: unexpected token

--- a/src/test/parse-fail/issue-23620-invalid-escapes.rs
+++ b/src/test/parse-fail/issue-23620-invalid-escapes.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only -Z continue-parse-after-error
+
 fn main() {
     let _ = b"\u{a66e}";
     //~^ ERROR unicode escape sequences cannot be used as a byte or in a byte string

--- a/src/test/parse-fail/issue-32446.rs
+++ b/src/test/parse-fail/issue-32446.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,7 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn main() {
-    for thing(x[]) in foo {} //~ error: expected one of `,` or `@`, found `[`
-    //~^ ERROR expected one of `@` or `in`, found `[`
-}
+// compile-flags: -Z parse-only
+
+fn main() {}
+
+// This used to end up in an infite loop trying to bump past EOF.
+trait T { ... } //~ ERROR

--- a/src/test/parse-fail/lex-bad-binary-literal.rs
+++ b/src/test/parse-fail/lex-bad-binary-literal.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only -Z continue-parse-after-error
+
 fn main() {
     0b121; //~ ERROR invalid digit for a base 2 literal
     0b10_10301; //~ ERROR invalid digit for a base 2 literal

--- a/src/test/parse-fail/lex-bad-char-literals-1.rs
+++ b/src/test/parse-fail/lex-bad-char-literals-1.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only
+// compile-flags: -Z parse-only -Z continue-parse-after-error
 static c3: char =
     '\x1' //~ ERROR: numeric character escape is too short
 ;

--- a/src/test/parse-fail/lex-bad-numeric-literals.rs
+++ b/src/test/parse-fail/lex-bad-numeric-literals.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only
+// compile-flags: -Z parse-only -Z continue-parse-after-error
 
 fn main() {
     0o1.0; //~ ERROR: octal float literal is not supported

--- a/src/test/parse-fail/lex-bare-cr-string-literal-doc-comment.rs
+++ b/src/test/parse-fail/lex-bare-cr-string-literal-doc-comment.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only
+// compile-flags: -Z parse-only -Z continue-parse-after-error
 
 // ignore-tidy-cr
 

--- a/src/test/parse-fail/new-unicode-escapes-4.rs
+++ b/src/test/parse-fail/new-unicode-escapes-4.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only
+// compile-flags: -Z parse-only -Z continue-parse-after-error
 
 pub fn main() {
     let s = "\u{lol}";

--- a/src/test/parse-fail/no-unsafe-self.rs
+++ b/src/test/parse-fail/no-unsafe-self.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only
+// compile-flags: -Z parse-only -Z continue-parse-after-error
 
 trait A {
     fn foo(*mut self); //~ ERROR cannot pass self by raw pointer

--- a/src/test/parse-fail/pat-lt-bracket-6.rs
+++ b/src/test/parse-fail/pat-lt-bracket-6.rs
@@ -10,5 +10,5 @@
 
 fn main() {
     let Test(&desc[..]) = x; //~ error: expected one of `,` or `@`, found `[`
-    //~^ ERROR expected one of `:`, `;`, or `=`, found `..`
+    //~^ ERROR expected one of `:`, `;`, `=`, or `@`, found `[`
 }


### PR DESCRIPTION
Backports of various T-compiler tickets for the parser to be applied to the beta branch.

Remove label:beta-nominated from #32435, #32479, and #32494.

r? @nikomatsakis 
