### PR TITLE
Set the version number for stabilization of braced_empty_structs

### DIFF
--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -218,10 +218,10 @@ const KNOWN_FEATURES: &'static [(&'static str, &'static str, Option<u32>, Status
     ("naked_functions", "1.9.0", Some(32408), Active),
 
     // allow empty structs and enum variants with braces
-    ("braced_empty_structs", "1.5.0", Some(29720), Accepted),
+    ("braced_empty_structs", "1.8.0", Some(29720), Accepted),
 
     // allow overloading augmented assignment operations like `a += b`
-    ("augmented_assignments", "1.5.0", Some(28235), Accepted),
+    ("augmented_assignments", "1.8.0", Some(28235), Accepted),
 
     // allow `#[no_debug]`
     ("no_debug", "1.5.0", Some(29721), Active),


### PR DESCRIPTION
and augmented_assignment to 1.8.0.

Per the comments, the numbers in this table reflect the "current
status".

cc @rust-lang/libs @rust-lang/lang 

Discovered this while hunting for 1.8 features. I'm afraid there may be more of these that are incorrect and we may have created a mess.
