### PR TITLE
rustdoc: Fix testing no_run code blocks

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -193,7 +193,7 @@ pub fn compile_input(sess: &Session,
                 (control.after_analysis.callback)(state);
 
                 if control.after_analysis.stop == Compilation::Stop {
-                    return Err(0usize);
+                    return result.and_then(|_| Err(0usize));
                 }
             }
 

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -632,7 +632,7 @@ recursion limit (which can be set via the `recursion_limit` attribute).
 
 For a somewhat artificial example:
 
-```compile_fail
+```compile_fail,ignore
 #![recursion_limit="2"]
 
 struct Foo;

--- a/src/test/run-pass/coerce-expect-unsized.rs
+++ b/src/test/run-pass/coerce-expect-unsized.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
-
 #![allow(unknown_features)]
 #![feature(box_syntax)]
 

--- a/src/test/run-pass/foreign-dupe.rs
+++ b/src/test/run-pass/foreign-dupe.rs
@@ -10,8 +10,6 @@
 
 // calling pin_thread and that's having weird side-effects.
 
-// pretty-expanded FIXME #23616
-
 #![feature(libc)]
 
 mod rustrt1 {

--- a/src/test/rustdoc/no-run-still-checks-lints.rs
+++ b/src/test/rustdoc/no-run-still-checks-lints.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,18 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[derive(Hash)]
-enum Foo {
-    Bar(isize, char),
-    Baz(char, isize)
-}
+// compile-flags:--test
+// should-fail
 
-#[derive(Hash)]
-enum A {
-    B,
-    C,
-    D,
-    E
-}
+#![doc(test(attr(deny(warnings))))]
 
-pub fn main(){}
+/// ```no_run
+/// let a = 3;
+/// ```
+pub fn foo() {}


### PR DESCRIPTION
This was a regression introduced by #31250 where the compiler deferred returning
the results of compilation a little too late (after the `Stop` check was looked
at). This commit alters the stop point to first try to return an erroneous
`result` and only if it was successful return the sentinel `Err(0)`.

Closes #31576
