### PR TITLE
mk: Simplify boostrap key strategy

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -24,17 +24,6 @@ CFG_PRERELEASE_VERSION=.1
 # versions in the same place
 CFG_FILENAME_EXTRA=$(shell printf '%s' $(CFG_RELEASE)$(CFG_EXTRA_FILENAME) | $(CFG_HASH_COMMAND))
 
-# A magic value that allows the compiler to use unstable features during the
-# bootstrap even when doing so would normally be an error because of feature
-# staging or because the build turns on warnings-as-errors and unstable features
-# default to warnings. The build has to match this key in an env var.
-#
-# This value is keyed off the release to ensure that all compilers for one
-# particular release have the same bootstrap key. Note that this is
-# intentionally not "secure" by any definition, this is largely just a deterrent
-# from users enabling unstable features on the stable compiler.
-CFG_BOOTSTRAP_KEY=$(CFG_FILENAME_EXTRA)
-
 ifeq ($(CFG_RELEASE_CHANNEL),stable)
 # This is the normal semver version string, e.g. "0.12.0", "0.12.0-nightly"
 CFG_RELEASE=$(CFG_RELEASE_NUM)
@@ -374,9 +363,8 @@ CFG_INFO := $(info cfg: disabling unstable features (CFG_DISABLE_UNSTABLE_FEATUR
 # Turn on feature-staging
 export CFG_DISABLE_UNSTABLE_FEATURES
 # Subvert unstable feature lints to do the self-build
-export RUSTC_BOOTSTRAP_KEY:=$(CFG_BOOTSTRAP_KEY)
+export RUSTC_BOOTSTRAP
 endif
-export CFG_BOOTSTRAP_KEY
 ifdef CFG_MUSL_ROOT
 export CFG_MUSL_ROOT
 endif

--- a/src/bootstrap/build/channel.rs
+++ b/src/bootstrap/build/channel.rs
@@ -10,13 +10,11 @@
 
 use std::fs::{self, File};
 use std::io::prelude::*;
-use std::path::Path;
 use std::process::Command;
 
 use build_helper::output;
 
 use build::Build;
-use build::util::mtime;
 
 pub fn collect(build: &mut Build) {
     let mut main_mk = String::new();
@@ -79,8 +77,4 @@ pub fn collect(build: &mut Build) {
         build.ver_hash = Some(ver_hash);
         build.short_ver_hash = Some(short_ver_hash);
     }
-
-    build.bootstrap_key = mtime(Path::new("config.toml")).seconds()
-                                                        .to_string();
 }
-

--- a/src/bootstrap/build/compile.rs
+++ b/src/bootstrap/build/compile.rs
@@ -177,9 +177,8 @@ pub fn rustc<'a>(build: &'a Build, target: &str, compiler: &Compiler<'a>) {
     cargo.env("CFG_RELEASE", &build.release)
          .env("CFG_RELEASE_CHANNEL", &build.config.channel)
          .env("CFG_VERSION", &build.version)
-         .env("CFG_BOOTSTRAP_KEY", &build.bootstrap_key)
          .env("CFG_PREFIX", build.config.prefix.clone().unwrap_or(String::new()))
-         .env("RUSTC_BOOTSTRAP_KEY", &build.bootstrap_key)
+         .env("RUSTC_BOOTSTRAP", "")
          .env("CFG_LIBDIR_RELATIVE", "lib");
 
     if let Some(ref ver_date) = build.ver_date {

--- a/src/bootstrap/build/mod.rs
+++ b/src/bootstrap/build/mod.rs
@@ -78,7 +78,6 @@ pub struct Build {
     ver_date: Option<String>,
     version: String,
     package_vers: String,
-    bootstrap_key: String,
 
     // Runtime state filled in later on
     cc: HashMap<String, (gcc::Tool, PathBuf)>,
@@ -123,7 +122,6 @@ impl Build {
             short_ver_hash: None,
             ver_date: None,
             version: String::new(),
-            bootstrap_key: String::new(),
             package_vers: String::new(),
             cc: HashMap::new(),
             cxx: HashMap::new(),

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1256,15 +1256,12 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
 pub fn get_unstable_features_setting() -> UnstableFeatures {
     // Whether this is a feature-staged build, i.e. on the beta or stable channel
     let disable_unstable_features = option_env!("CFG_DISABLE_UNSTABLE_FEATURES").is_some();
-    // The secret key needed to get through the rustc build itself by
-    // subverting the unstable features lints
-    let bootstrap_secret_key = option_env!("CFG_BOOTSTRAP_KEY");
-    // The matching key to the above, only known by the build system
-    let bootstrap_provided_key = env::var("RUSTC_BOOTSTRAP_KEY").ok();
-    match (disable_unstable_features, bootstrap_secret_key, bootstrap_provided_key) {
-        (_, Some(ref s), Some(ref p)) if s == p => UnstableFeatures::Cheat,
-        (true, _, _) => UnstableFeatures::Disallow,
-        (false, _, _) => UnstableFeatures::Allow
+    // Check whether we want to circumvent the unstable feature kill-switch for bootstrap
+    let bootstrap_circumvent = env::var_os("RUSTC_BOOTSTRAP").is_some();
+    match (disable_unstable_features, bootstrap_circumvent) {
+        (_, true) => UnstableFeatures::Cheat,
+        (true, _) => UnstableFeatures::Disallow,
+        (false, _) => UnstableFeatures::Allow
     }
 }
 


### PR DESCRIPTION
Since PR #32731 we’re hardcoding the BOOTSTRAP_KEY to a well known value, so there’s no reason to have any key at all. Lets just use a regular environment switch instead.

Hooray for simpler code.

r? @alexcrichton 
