### PR TITLE
Fix ICE in `resolve`

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -332,6 +332,7 @@ impl<'a> ::ModuleS<'a> {
 
     fn define_in_glob_importers(&self, name: Name, ns: Namespace, binding: &'a NameBinding<'a>) {
         if !binding.defined_with(DefModifiers::PUBLIC | DefModifiers::IMPORTABLE) { return }
+        let _resolutions = self.resolutions.borrow();
         for &(importer, directive) in self.glob_importers.borrow_mut().iter() {
             let _ = importer.try_define_child(name, ns, directive.import(binding, None));
         }

--- a/src/test/compile-fail/issue-32797.rs
+++ b/src/test/compile-fail/issue-32797.rs
@@ -1,0 +1,24 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_attrs)]
+
+pub use self::bar::*;
+mod bar {
+    pub use super::*;
+}
+
+pub use self::baz::*;
+mod baz {
+    pub use main as f;
+}
+
+#[rustc_error]
+pub fn main() {} //~ ERROR compilation successful


### PR DESCRIPTION
This fixes #32797, a regression caused by a bug in which we try to mutate a borrowed `RefCell`. The bug was introduced in #32328 (second to last commit).
r? @nikomatsakis 
