### PR TITLE
Do not rely on file extensions after path canonicalization.

### DIFF
--- a/src/test/run-make/symlinked-rlib/Makefile
+++ b/src/test/run-make/symlinked-rlib/Makefile
@@ -1,0 +1,14 @@
+-include ../tools.mk
+
+# ignore windows: `ln` is actually `cp` on msys.
+ifndef IS_WINDOWS
+
+all:
+	$(RUSTC) foo.rs --crate-type=rlib -o $(TMPDIR)/foo.xxx
+	ln -nsf $(TMPDIR)/foo.xxx $(TMPDIR)/libfoo.rlib
+	$(RUSTC) bar.rs -L $(TMPDIR)
+
+else
+all:
+
+endif

--- a/src/test/run-make/symlinked-rlib/bar.rs
+++ b/src/test/run-make/symlinked-rlib/bar.rs
@@ -1,0 +1,15 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate foo;
+
+fn main() {
+    foo::bar();
+}

--- a/src/test/run-make/symlinked-rlib/foo.rs
+++ b/src/test/run-make/symlinked-rlib/foo.rs
@@ -1,0 +1,11 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn bar() {}


### PR DESCRIPTION
Rustc does not recognize libraries which are symlinked to files having extension other than .rlib. The problem is that find_library_crate calls fs::canonicalize on found library paths, but then the resulting path is passed to get_metadata_section, which assumes it will end in ".rlib" if it's an rlib (from https://internals.rust-lang.org/t/is-library-path-canonicalization-worth-it/3206).

cc #29433
