### PR TITLE
make field of `Binder` private

### DIFF
--- a/src/librustc/infer/bivariate.rs
+++ b/src/librustc/infer/bivariate.rs
@@ -112,6 +112,6 @@ impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Bivariate<'a, 'tcx> {
         let a1 = self.tcx().erase_late_bound_regions(a);
         let b1 = self.tcx().erase_late_bound_regions(b);
         let c = self.relate(&a1, &b1)?;
-        Ok(ty::Binder(c))
+        Ok(ty::Binder::new(c))
     }
 }

--- a/src/librustc/infer/higher_ranked/mod.rs
+++ b/src/librustc/infer/higher_ranked/mod.rs
@@ -97,7 +97,7 @@ impl<'a,'tcx> HigherRankedRelations<'a,'tcx> for CombineFields<'a,'tcx> {
             debug!("higher_ranked_sub: OK result={:?}",
                    result);
 
-            Ok(ty::Binder(result))
+            Ok(ty::Binder::new(result))
         });
     }
 
@@ -138,7 +138,7 @@ impl<'a,'tcx> HigherRankedRelations<'a,'tcx> for CombineFields<'a,'tcx> {
                    b,
                    result1);
 
-            Ok(ty::Binder(result1))
+            Ok(ty::Binder::new(result1))
         });
 
         fn generalize_region(infcx: &InferCtxt,
@@ -233,7 +233,7 @@ impl<'a,'tcx> HigherRankedRelations<'a,'tcx> for CombineFields<'a,'tcx> {
                    b,
                    result1);
 
-            Ok(ty::Binder(result1))
+            Ok(ty::Binder::new(result1))
         });
 
         fn generalize_region(infcx: &InferCtxt,

--- a/src/librustc/middle/free_region.rs
+++ b/src/librustc/middle/free_region.rs
@@ -62,7 +62,10 @@ impl FreeRegionMap {
                 ty::Predicate::TypeOutlives(..) => {
                     // No region bounds here
                 }
-                ty::Predicate::RegionOutlives(ty::Binder(ty::OutlivesPredicate(r_a, r_b))) => {
+                ty::Predicate::RegionOutlives(ref data) => {
+                    let &ty::OutlivesPredicate(r_a, r_b) = data.skip_binder(); // (*)
+                    // (*) OK to skip binder because the code below
+                    // ignores bound regions.
                     match (r_a, r_b) {
                         (ty::ReStatic, ty::ReFree(_)) => {},
                         (ty::ReFree(fr_a), ty::ReStatic) => self.relate_to_static(fr_a),

--- a/src/librustc/middle/intrinsicck.rs
+++ b/src/librustc/middle/intrinsicck.rs
@@ -239,8 +239,14 @@ impl<'a, 'tcx, 'v> Visitor<'v> for IntrinsicCheckingVisitor<'a, 'tcx> {
                     let typ = self.tcx.node_id_to_type(expr.id);
                     match typ.sty {
                         ty::TyFnDef(_, _, ref bare_fn_ty) if bare_fn_ty.abi == RustIntrinsic => {
-                            if let ty::FnConverging(to) = bare_fn_ty.sig.0.output {
-                                let from = bare_fn_ty.sig.0.inputs[0];
+                            let output =
+                                self.tcx.erase_late_bound_regions(
+                                    &bare_fn_ty.sig.output());
+
+                            if let ty::FnConverging(to) = output {
+                                let from =
+                                    self.tcx.erase_late_bound_regions(
+                                        &bare_fn_ty.sig.input(0));
                                 self.check_transmute(expr.span, from, to, expr.id);
                             }
                         }

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -843,7 +843,7 @@ fn note_obligation_cause_code<'a, 'tcx, T>(infcx: &InferCtxt<'a, 'tcx>,
             err.fileline_note(
                 cause_span,
                 &format!("required because it appears within the type `{}`",
-                         parent_trait_ref.0.self_ty()));
+                         parent_trait_ref.skip_binder().self_ty()));
             let parent_predicate = parent_trait_ref.to_predicate();
             note_obligation_cause_code(infcx,
                                        err,
@@ -857,7 +857,7 @@ fn note_obligation_cause_code<'a, 'tcx, T>(infcx: &InferCtxt<'a, 'tcx>,
                 cause_span,
                 &format!("required because of the requirements on the impl of `{}` for `{}`",
                          parent_trait_ref,
-                         parent_trait_ref.0.self_ty()));
+                         parent_trait_ref.skip_binder().self_ty()));
             let parent_predicate = parent_trait_ref.to_predicate();
             note_obligation_cause_code(infcx,
                                        err,

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -618,6 +618,6 @@ impl<'tcx> FulfillmentError<'tcx> {
 
 impl<'tcx> TraitObligation<'tcx> {
     fn self_ty(&self) -> ty::Binder<Ty<'tcx>> {
-        ty::Binder(self.predicate.skip_binder().self_ty())
+        self.predicate.map_bound_ref(|p| p.self_ty())
     }
 }

--- a/src/librustc/traits/util.rs
+++ b/src/librustc/traits/util.rs
@@ -495,14 +495,16 @@ pub fn closure_trait_ref_and_return_type<'tcx>(
     tuple_arguments: TupleArgumentsFlag)
     -> ty::Binder<(ty::TraitRef<'tcx>, Ty<'tcx>)>
 {
-    let arguments_tuple = match tuple_arguments {
-        TupleArgumentsFlag::No => sig.0.inputs[0],
-        TupleArgumentsFlag::Yes => tcx.mk_tup(sig.0.inputs.to_vec()),
-    };
-    let trait_substs = Substs::new_trait(vec![arguments_tuple], vec![], self_ty);
-    let trait_ref = ty::TraitRef {
-        def_id: fn_trait_def_id,
-        substs: tcx.mk_substs(trait_substs),
-    };
-    ty::Binder((trait_ref, sig.0.output.unwrap_or(tcx.mk_nil())))
+    sig.map_bound_ref(|sig| {
+        let arguments_tuple = match tuple_arguments {
+            TupleArgumentsFlag::No => sig.inputs[0],
+            TupleArgumentsFlag::Yes => tcx.mk_tup(sig.inputs.to_vec()),
+        };
+        let trait_substs = Substs::new_trait(vec![arguments_tuple], vec![], self_ty);
+        let trait_ref = ty::TraitRef {
+            def_id: fn_trait_def_id,
+            substs: tcx.mk_substs(trait_substs),
+        };
+        (trait_ref, sig.output.unwrap_or(tcx.mk_nil()))
+    })
 }

--- a/src/librustc/ty/_match.rs
+++ b/src/librustc/ty/_match.rs
@@ -91,6 +91,6 @@ impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Match<'a, 'tcx> {
                   -> RelateResult<'tcx, ty::Binder<T>>
         where T: Relate<'a,'tcx>
     {
-        Ok(ty::Binder(self.relate(a.skip_binder(), b.skip_binder())?))
+        Ok(ty::Binder::new(self.relate(a.skip_binder(), b.skip_binder())?))
     }
 }

--- a/src/librustc/ty/fast_reject.rs
+++ b/src/librustc/ty/fast_reject.rs
@@ -84,7 +84,7 @@ pub fn simplify_type(tcx: &TyCtxt,
             Some(TupleSimplifiedType(tys.len()))
         }
         ty::TyFnDef(_, _, ref f) | ty::TyFnPtr(ref f) => {
-            Some(FunctionSimplifiedType(f.sig.0.inputs.len()))
+            Some(FunctionSimplifiedType(f.sig.skip_binder().inputs.len()))
         }
         ty::TyProjection(_) | ty::TyParam(_) => {
             if can_simplify_params {

--- a/src/librustc/ty/flags.rs
+++ b/src/librustc/ty/flags.rs
@@ -106,10 +106,11 @@ impl FlagComputation {
 
             &ty::TyTrait(box ty::TraitTy { ref principal, ref bounds }) => {
                 let mut computation = FlagComputation::new();
-                computation.add_substs(principal.0.substs);
+                computation.add_substs(principal.skip_binder().substs);
                 for projection_bound in &bounds.projection_bounds {
                     let mut proj_computation = FlagComputation::new();
-                    proj_computation.add_projection_predicate(&projection_bound.0);
+                    proj_computation.add_projection_predicate(
+                        projection_bound.skip_binder());
                     self.add_bound_computation(&proj_computation);
                 }
                 self.add_bound_computation(&computation);
@@ -159,9 +160,9 @@ impl FlagComputation {
     fn add_fn_sig(&mut self, fn_sig: &ty::PolyFnSig) {
         let mut computation = FlagComputation::new();
 
-        computation.add_tys(&fn_sig.0.inputs);
+        computation.add_tys(&fn_sig.skip_binder().inputs);
 
-        if let ty::FnConverging(output) = fn_sig.0.output {
+        if let ty::FnConverging(output) = fn_sig.skip_binder().output {
             computation.add_ty(output);
         }
 

--- a/src/librustc/ty/fold.rs
+++ b/src/librustc/ty/fold.rs
@@ -369,16 +369,16 @@ impl<'tcx> TyCtxt<'tcx> {
                 }
             }
         });
-        Binder(value)
+        Binder::new(value)
     }
 
     pub fn no_late_bound_regions<T>(&self, value: &Binder<T>) -> Option<T>
         where T : TypeFoldable<'tcx>
     {
-        if value.0.has_escaping_regions() {
+        if value.skip_binder().has_escaping_regions() {
             None
         } else {
-            Some(value.0.clone())
+            Some(value.skip_binder().clone())
         }
     }
 
@@ -402,7 +402,7 @@ impl<'tcx> TyCtxt<'tcx> {
         where T : TypeFoldable<'tcx>,
     {
         let mut counter = 0;
-        Binder(self.replace_late_bound_regions(sig, |_| {
+        Binder::new(self.replace_late_bound_regions(sig, |_| {
             counter += 1;
             ty::ReLateBound(ty::DebruijnIndex::new(1), ty::BrAnon(counter))
         }).0)

--- a/src/librustc/ty/structural_impls.rs
+++ b/src/librustc/ty/structural_impls.rs
@@ -104,7 +104,7 @@ impl<'a, 'tcx> Lift<'tcx> for ty::ProjectionPredicate<'a> {
 impl<'tcx, T: Lift<'tcx>> Lift<'tcx> for ty::Binder<T> {
     type Lifted = ty::Binder<T::Lifted>;
     fn lift_to_tcx(&self, tcx: &TyCtxt<'tcx>) -> Option<Self::Lifted> {
-        tcx.lift(&self.0).map(|x| ty::Binder(x))
+        tcx.lift(self.skip_binder()).map(|x| ty::Binder::new(x))
     }
 }
 
@@ -190,7 +190,7 @@ impl<'tcx, T: TypeFoldable<'tcx>> TypeFoldable<'tcx> for Vec<T> {
 
 impl<'tcx, T:TypeFoldable<'tcx>> TypeFoldable<'tcx> for ty::Binder<T> {
     fn super_fold_with<F: TypeFolder<'tcx>>(&self, folder: &mut F) -> Self {
-        ty::Binder(self.0.fold_with(folder))
+        ty::Binder::new(self.skip_binder().fold_with(folder))
     }
 
     fn fold_with<F: TypeFolder<'tcx>>(&self, folder: &mut F) -> Self {
@@ -198,7 +198,7 @@ impl<'tcx, T:TypeFoldable<'tcx>> TypeFoldable<'tcx> for ty::Binder<T> {
     }
 
     fn super_visit_with<V: TypeVisitor<'tcx>>(&self, visitor: &mut V) -> bool {
-        self.0.visit_with(visitor)
+        self.skip_binder().visit_with(visitor)
     }
 
     fn visit_with<V: TypeVisitor<'tcx>>(&self, visitor: &mut V) -> bool {

--- a/src/librustc/ty/walk.rs
+++ b/src/librustc/ty/walk.rs
@@ -84,7 +84,7 @@ fn push_subtypes<'tcx>(stack: &mut Vec<Ty<'tcx>>, parent_ty: Ty<'tcx>) {
         ty::TyTrait(box ty::TraitTy { ref principal, ref bounds }) => {
             push_reversed(stack, principal.substs().types.as_slice());
             push_reversed(stack, &bounds.projection_bounds.iter().map(|pred| {
-                pred.0.ty
+                pred.skip_binder().ty // walk ignores LBR
             }).collect::<Vec<_>>());
         }
         ty::TyEnum(_, ref substs) |
@@ -109,11 +109,11 @@ fn push_subtypes<'tcx>(stack: &mut Vec<Ty<'tcx>>, parent_ty: Ty<'tcx>) {
 }
 
 fn push_sig_subtypes<'tcx>(stack: &mut Vec<Ty<'tcx>>, sig: &ty::PolyFnSig<'tcx>) {
-    match sig.0.output {
+    match sig.skip_binder().output {
         ty::FnConverging(output) => { stack.push(output); }
         ty::FnDiverging => { }
     }
-    push_reversed(stack, &sig.0.inputs);
+    push_reversed(stack, &sig.skip_binder().inputs);
 }
 
 fn push_reversed<'tcx>(stack: &mut Vec<Ty<'tcx>>, tys: &[Ty<'tcx>]) {

--- a/src/librustc_const_eval/eval.rs
+++ b/src/librustc_const_eval/eval.rs
@@ -990,7 +990,7 @@ fn resolve_trait_associated_const<'a, 'tcx: 'a>(tcx: &'a TyCtxt<'tcx>,
                                                 rcvr_substs: subst::Substs<'tcx>)
                                                 -> Option<(&'tcx Expr, Option<ty::Ty<'tcx>>)>
 {
-    let trait_ref = ty::Binder(
+    let trait_ref = ty::Binder::new(
         rcvr_substs.erase_regions().to_trait_ref(tcx, trait_id)
     );
     debug!("resolve_trait_associated_const: trait_ref={:?}",

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -269,7 +269,7 @@ impl<'a, 'tcx> Env<'a, 'tcx> {
         self.infcx.tcx.mk_fn_ptr(ty::BareFnTy {
             unsafety: hir::Unsafety::Normal,
             abi: Abi::Rust,
-            sig: ty::Binder(ty::FnSig {
+            sig: ty::Binder::new(ty::FnSig {
                 inputs: input_args,
                 output: ty::FnConverging(output_ty),
                 variadic: false,

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -858,7 +858,7 @@ impl LateLintPass for UnconditionalRecursion {
                 // Attempt to select a concrete impl before checking.
                 ty::TraitContainer(trait_def_id) => {
                     let trait_ref = callee_substs.to_trait_ref(tcx, trait_def_id);
-                    let trait_ref = ty::Binder(trait_ref);
+                    let trait_ref = ty::Binder::new(trait_ref);
                     let span = tcx.map.span(expr_id);
                     let obligation =
                         traits::Obligation::new(traits::ObligationCause::misc(span, expr_id),
@@ -1071,8 +1071,9 @@ impl LateLintPass for MutableTransmutes {
                 let typ = cx.tcx.node_id_to_type(expr.id);
                 match typ.sty {
                     ty::TyFnDef(_, _, ref bare_fn) if bare_fn.abi == RustIntrinsic => {
-                        if let ty::FnConverging(to) = bare_fn.sig.0.output {
-                            let from = bare_fn.sig.0.inputs[0];
+                        let sig = bare_fn.sig.skip_binder();
+                        if let ty::FnConverging(to) = sig.output {
+                            let from = sig.inputs[0];
                             return Some((&from.sty, &to.sty));
                         }
                     },

--- a/src/librustc_metadata/astencode.rs
+++ b/src/librustc_metadata/astencode.rs
@@ -948,7 +948,7 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
 
     fn read_poly_trait_ref<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>)
                                    -> ty::PolyTraitRef<'tcx> {
-        ty::Binder(self.read_ty_encoded(dcx, |decoder| decoder.parse_trait_ref()))
+        ty::Binder::new(self.read_ty_encoded(dcx, |decoder| decoder.parse_trait_ref()))
     }
 
     fn read_predicate<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>)

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -468,10 +468,9 @@ pub fn get_adt_def<'tcx>(intr: &IdentInterner,
                    variant.name,
                    ctor_ty);
             let field_tys = match ctor_ty.sty {
-                ty::TyFnDef(_, _, &ty::BareFnTy { sig: ty::Binder(ty::FnSig {
-                    ref inputs, ..
-                }), ..}) => {
+                ty::TyFnDef(_, _, &ty::BareFnTy { ref sig, .. }) => {
                     // tuple-struct constructors don't have escaping regions
+                    let inputs = &sig.skip_binder().inputs;
                     assert!(!inputs.has_escaping_regions());
                     inputs
                 },

--- a/src/librustc_metadata/tydecode.rs
+++ b/src/librustc_metadata/tydecode.rs
@@ -329,7 +329,7 @@ impl<'a,'tcx> TyDecoder<'a,'tcx> {
             }
             'x' => {
                 assert_eq!(self.next(), '[');
-                let trait_ref = ty::Binder(self.parse_trait_ref());
+                let trait_ref = ty::Binder::new(self.parse_trait_ref());
                 let bounds = self.parse_existential_bounds();
                 assert_eq!(self.next(), ']');
                 return tcx.mk_trait(trait_ref, bounds);
@@ -532,21 +532,21 @@ impl<'a,'tcx> TyDecoder<'a,'tcx> {
             }
             _ => ty::FnConverging(self.parse_ty())
         };
-        ty::Binder(ty::FnSig {inputs: inputs,
-                              output: output,
-                              variadic: variadic})
+        ty::Binder::new(ty::FnSig {inputs: inputs,
+                                   output: output,
+                                   variadic: variadic})
     }
 
     pub fn parse_predicate(&mut self) -> ty::Predicate<'tcx> {
         match self.next() {
-            't' => ty::Binder(self.parse_trait_ref()).to_predicate(),
-            'e' => ty::Binder(ty::EquatePredicate(self.parse_ty(),
-                                                  self.parse_ty())).to_predicate(),
-            'r' => ty::Binder(ty::OutlivesPredicate(self.parse_region(),
-                                                    self.parse_region())).to_predicate(),
-            'o' => ty::Binder(ty::OutlivesPredicate(self.parse_ty(),
-                                                    self.parse_region())).to_predicate(),
-            'p' => ty::Binder(self.parse_projection_predicate()).to_predicate(),
+            't' => ty::Binder::new(self.parse_trait_ref()).to_predicate(),
+            'e' => ty::Binder::new(ty::EquatePredicate(self.parse_ty(),
+                                                       self.parse_ty())).to_predicate(),
+            'r' => ty::Binder::new(ty::OutlivesPredicate(self.parse_region(),
+                                                         self.parse_region())).to_predicate(),
+            'o' => ty::Binder::new(ty::OutlivesPredicate(self.parse_ty(),
+                                                         self.parse_region())).to_predicate(),
+            'p' => ty::Binder::new(self.parse_projection_predicate()).to_predicate(),
             'w' => ty::Predicate::WellFormed(self.parse_ty()),
             'O' => {
                 let def_id = self.parse_def();
@@ -636,7 +636,7 @@ impl<'a,'tcx> TyDecoder<'a,'tcx> {
         loop {
             match self.next() {
                 'P' => {
-                    projection_bounds.push(ty::Binder(self.parse_projection_predicate()));
+                    projection_bounds.push(ty::Binder::new(self.parse_projection_predicate()));
                 }
                 '.' => { break; }
                 c => {

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -268,7 +268,7 @@ impl<'a,'tcx> Builder<'a,'tcx> {
             ExprKind::Call { ty, fun, args } => {
                 let diverges = match ty.sty {
                     ty::TyFnDef(_, _, ref f) | ty::TyFnPtr(ref f) => {
-                        f.sig.0.output.diverges()
+                        f.sig.diverges()
                     }
                     _ => false
                 };

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -565,11 +565,13 @@ pub fn unsized_info<'ccx, 'tcx>(ccx: &CrateContext<'ccx, 'tcx>,
         }
         (_, &ty::TyTrait(box ty::TraitTy { ref principal, .. })) => {
             // Note that we preserve binding levels here:
-            let substs = principal.0.substs.with_self_ty(source).erase_regions();
-            let substs = ccx.tcx().mk_substs(substs);
-            let trait_ref = ty::Binder(ty::TraitRef {
-                def_id: principal.def_id(),
-                substs: substs,
+            let trait_ref = principal.map_bound_ref(|p| {
+                let substs = p.substs.with_self_ty(source).erase_regions();
+                let substs = ccx.tcx().mk_substs(substs);
+                ty::TraitRef {
+                    def_id: principal.def_id(),
+                    substs: substs,
+                }
             });
             consts::ptrcast(meth::get_vtable(ccx, trait_ref),
                             Type::vtable_ptr(ccx))
@@ -675,7 +677,7 @@ pub fn custom_coerce_unsize_info<'ccx, 'tcx>(ccx: &CrateContext<'ccx, 'tcx>,
                                                                 Vec::new()),
                                    subst::VecPerParamSpace::empty());
 
-    let trait_ref = ty::Binder(ty::TraitRef {
+    let trait_ref = ty::Binder::new(ty::TraitRef {
         def_id: ccx.tcx().lang_items.coerce_unsized_trait().unwrap(),
         substs: ccx.tcx().mk_substs(trait_substs)
     });

--- a/src/librustc_trans/callee.rs
+++ b/src/librustc_trans/callee.rs
@@ -155,7 +155,7 @@ impl<'tcx> Callee<'tcx> {
 
         let method_item = tcx.impl_or_trait_item(def_id);
         let trait_id = method_item.container().id();
-        let trait_ref = ty::Binder(substs.to_trait_ref(tcx, trait_id));
+        let trait_ref = ty::Binder::new(substs.to_trait_ref(tcx, trait_id));
         match common::fulfill_obligation(ccx, DUMMY_SP, trait_ref) {
             traits::VtableImpl(vtable_impl) => {
                 let impl_did = vtable_impl.impl_def_id;
@@ -373,7 +373,7 @@ pub fn trans_fn_pointer_shim<'a, 'tcx>(
     let tuple_fn_ty = tcx.mk_fn_ptr(ty::BareFnTy {
         unsafety: hir::Unsafety::Normal,
         abi: Abi::RustCall,
-        sig: ty::Binder(sig)
+        sig: ty::Binder::new(sig)
     });
     debug!("tuple_fn_ty: {:?}", tuple_fn_ty);
 
@@ -624,7 +624,7 @@ fn trans_call_inner<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
 
     let extra_args = match args {
         ArgExprs(args) if abi != Abi::RustCall => {
-            args[sig.0.inputs.len()..].iter().map(|expr| {
+            args[sig.inputs_len()..].iter().map(|expr| {
                 common::expr_ty_adjusted(bcx, expr)
             }).collect()
         }

--- a/src/librustc_trans/collector.rs
+++ b/src/librustc_trans/collector.rs
@@ -733,7 +733,7 @@ fn do_static_trait_method_dispatch<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
                                                        param_substs,
                                                        callee_substs);
 
-    let trait_ref = ty::Binder(rcvr_substs.to_trait_ref(tcx, trait_id));
+    let trait_ref = ty::Binder::new(rcvr_substs.to_trait_ref(tcx, trait_id));
     let vtbl = fulfill_obligation(ccx, DUMMY_SP, trait_ref);
 
     // Now that we know which impl is being used, we can dispatch to

--- a/src/librustc_trans/common.rs
+++ b/src/librustc_trans/common.rs
@@ -500,7 +500,7 @@ impl<'a, 'tcx> FunctionContext<'a, 'tcx> {
         let ty = tcx.mk_fn_ptr(ty::BareFnTy {
             unsafety: hir::Unsafety::Unsafe,
             abi: Abi::C,
-            sig: ty::Binder(ty::FnSig {
+            sig: ty::Binder::new(ty::FnSig {
                 inputs: vec![tcx.mk_mut_ptr(tcx.types.u8)],
                 output: ty::FnDiverging,
                 variadic: false
@@ -1181,10 +1181,10 @@ pub fn inlined_variant_def<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     debug!("inlined_variant_def: ctor_ty={:?} inlined_vid={:?}", ctor_ty,
            inlined_vid);
     let adt_def = match ctor_ty.sty {
-        ty::TyFnDef(_, _, &ty::BareFnTy { sig: ty::Binder(ty::FnSig {
-            output: ty::FnConverging(ty), ..
-        }), ..}) => ty,
-        _ => ctor_ty
+        ty::TyFnDef(_, _, &ty::BareFnTy { ref sig, .. }) =>
+            ccx.tcx().no_late_bound_regions(&sig.output()).unwrap().unwrap(),
+        _ =>
+            ctor_ty,
     }.ty_adt_def().unwrap();
     let inlined_vid_def_id = ccx.tcx().map.local_def_id(inlined_vid);
     adt_def.variants.iter().find(|v| {

--- a/src/librustc_trans/glue.rs
+++ b/src/librustc_trans/glue.rs
@@ -361,7 +361,7 @@ fn trans_struct_drop<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         &unsized_args
     };
 
-    let trait_ref = ty::Binder(ty::TraitRef {
+    let trait_ref = ty::Binder::new(ty::TraitRef {
         def_id: tcx.lang_items.drop_trait().unwrap(),
         substs: tcx.mk_substs(Substs::empty().with_self_ty(t))
     });

--- a/src/librustc_trans/intrinsic.rs
+++ b/src/librustc_trans/intrinsic.rs
@@ -1316,7 +1316,7 @@ fn gen_fn<'a, 'tcx>(fcx: &FunctionContext<'a, 'tcx>,
     let rust_fn_ty = ccx.tcx().mk_fn_ptr(ty::BareFnTy {
         unsafety: hir::Unsafety::Unsafe,
         abi: Abi::Rust,
-        sig: ty::Binder(sig)
+        sig: ty::Binder::new(sig)
     });
     let llfn = declare::define_internal_fn(ccx, name, rust_fn_ty);
     let empty_substs = ccx.tcx().mk_substs(Substs::empty());
@@ -1347,7 +1347,7 @@ fn get_rust_try_fn<'a, 'tcx>(fcx: &FunctionContext<'a, 'tcx>,
     let fn_ty = tcx.mk_fn_ptr(ty::BareFnTy {
         unsafety: hir::Unsafety::Unsafe,
         abi: Abi::Rust,
-        sig: ty::Binder(ty::FnSig {
+        sig: ty::Binder::new(ty::FnSig {
             inputs: vec![i8p],
             output: ty::FnOutput::FnConverging(tcx.mk_nil()),
             variadic: false,

--- a/src/librustc_trans/mir/block.rs
+++ b/src/librustc_trans/mir/block.rs
@@ -215,7 +215,7 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                     return;
                 }
 
-                let extra_args = &args[sig.0.inputs.len()..];
+                let extra_args = &args[sig.inputs_len()..];
                 let extra_args = extra_args.iter().map(|op_arg| {
                     self.mir.operand_ty(bcx.tcx(), op_arg)
                 }).collect::<Vec<_>>();

--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -250,7 +250,7 @@ fn confirm_builtin_call<'a,'tcx>(fcx: &FnCtxt<'a,'tcx>,
             // This is the "default" function signature, used in case of error.
             // In that case, we check each argument against "error" in order to
             // set up all the node type bindings.
-            error_fn_sig = ty::Binder(ty::FnSig {
+            error_fn_sig = ty::Binder::new(ty::FnSig {
                 inputs: err_args(fcx.tcx(), arg_exprs.len()),
                 output: ty::FnConverging(fcx.tcx().types.err),
                 variadic: false

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -88,7 +88,8 @@ fn check_closure<'a,'tcx>(fcx: &FnCtxt<'a,'tcx>,
 
     // Tuple up the arguments and insert the resulting function type into
     // the `closures` table.
-    fn_ty.sig.0.inputs = vec![fcx.tcx().mk_tup(fn_ty.sig.0.inputs)];
+    fn_ty.sig.skip_binder_mut().inputs =
+        vec![fcx.tcx().mk_tup(fn_ty.sig.skip_binder().inputs.clone())];
 
     debug!("closure for {:?} --> sig={:?} opt_kind={:?}",
            expr_def_id,
@@ -227,7 +228,7 @@ fn deduce_sig_from_projection<'a,'tcx>(
     };
     debug!("deduce_sig_from_projection: input_tys {:?}", input_tys);
 
-    let ret_param_ty = projection.0.ty;
+    let ret_param_ty = projection.skip_binder().ty;
     let ret_param_ty = fcx.infcx().resolve_type_vars_if_possible(&ret_param_ty);
     debug!("deduce_sig_from_projection: ret_param_ty {:?}", ret_param_ty);
 

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -92,15 +92,15 @@ pub fn compare_impl_method<'tcx>(tcx: &TyCtxt<'tcx>,
         return;
     }
 
-    if impl_m.fty.sig.0.inputs.len() != trait_m.fty.sig.0.inputs.len() {
+    if impl_m.fty.sig.inputs_len() != trait_m.fty.sig.inputs_len() {
         span_err!(tcx.sess, impl_m_span, E0050,
             "method `{}` has {} parameter{} \
              but the declaration in trait `{}` has {}",
             trait_m.name,
-            impl_m.fty.sig.0.inputs.len(),
-            if impl_m.fty.sig.0.inputs.len() == 1 {""} else {"s"},
+            impl_m.fty.sig.inputs_len(),
+            if impl_m.fty.sig.inputs_len() == 1 {""} else {"s"},
             tcx.item_path_str(trait_m.def_id),
-            trait_m.fty.sig.0.inputs.len());
+            trait_m.fty.sig.inputs_len());
         return;
     }
 
@@ -208,7 +208,7 @@ pub fn compare_impl_method<'tcx>(tcx: &TyCtxt<'tcx>,
         infcx.replace_late_bound_regions_with_fresh_var(
             impl_m_span,
             infer::HigherRankedType,
-            &ty::Binder(impl_bounds));
+            &ty::Binder::new(impl_bounds));
     debug!("compare_impl_method: impl_bounds={:?}",
            impl_bounds);
 
@@ -299,7 +299,7 @@ pub fn compare_impl_method<'tcx>(tcx: &TyCtxt<'tcx>,
         let impl_fty = tcx.mk_fn_ptr(ty::BareFnTy {
             unsafety: impl_m.fty.unsafety,
             abi: impl_m.fty.abi,
-            sig: ty::Binder(impl_sig)
+            sig: ty::Binder::new(impl_sig)
         });
         debug!("compare_impl_method: impl_fty={:?}",
                impl_fty);
@@ -317,7 +317,7 @@ pub fn compare_impl_method<'tcx>(tcx: &TyCtxt<'tcx>,
         let trait_fty = tcx.mk_fn_ptr(ty::BareFnTy {
             unsafety: trait_m.fty.unsafety,
             abi: trait_m.fty.abi,
-            sig: ty::Binder(trait_sig)
+            sig: ty::Binder::new(trait_sig)
         });
 
         debug!("compare_impl_method: trait_fty={:?}",

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -42,7 +42,7 @@ fn equate_intrinsic_type<'a, 'tcx>(tcx: &TyCtxt<'tcx>, it: &hir::ForeignItem,
     let fty = tcx.mk_fn_def(def_id, tcx.mk_substs(substs), ty::BareFnTy {
         unsafety: hir::Unsafety::Unsafe,
         abi: abi,
-        sig: ty::Binder(FnSig {
+        sig: ty::Binder::new(FnSig {
             inputs: inputs,
             output: output,
             variadic: false,
@@ -293,7 +293,7 @@ pub fn check_intrinsic_type(ccx: &CrateCtxt, it: &hir::ForeignItem) {
                 let fn_ty = ty::BareFnTy {
                     unsafety: hir::Unsafety::Normal,
                     abi: Abi::Rust,
-                    sig: ty::Binder(FnSig {
+                    sig: ty::Binder::new(FnSig {
                         inputs: vec![mut_u8],
                         output: ty::FnOutput::FnConverging(tcx.mk_nil()),
                         variadic: false,

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -108,7 +108,7 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
         let def_id = pick.item.def_id();
         let method_ty = pick.item.as_opt_method().unwrap();
         let fty = self.tcx().mk_fn_def(def_id, all_substs, ty::BareFnTy {
-            sig: ty::Binder(method_sig),
+            sig: ty::Binder::new(method_sig),
             unsafety: method_ty.fty.unsafety,
             abi: method_ty.fty.abi.clone(),
         });
@@ -463,7 +463,7 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
             _ => return,
         };
 
-        match sig.0.inputs[0].sty {
+        match sig.skip_binder().inputs[0].sty {
             ty::TyRef(_, ty::TypeAndMut {
                 ty: _,
                 mutbl: hir::MutMutable,

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -236,7 +236,7 @@ pub fn lookup_in_trait_adjusted<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
     let transformed_self_ty = fn_sig.inputs[0];
     let def_id = method_item.def_id();
     let fty = tcx.mk_fn_def(def_id, trait_ref.substs, ty::BareFnTy {
-        sig: ty::Binder(fn_sig),
+        sig: ty::Binder::new(fn_sig),
         unsafety: method_ty.fty.unsafety,
         abi: method_ty.fty.abi.clone(),
     });

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -479,7 +479,7 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
             .filter_map(|predicate| {
                 match *predicate {
                     ty::Predicate::Trait(ref trait_predicate) => {
-                        match trait_predicate.0.trait_ref.self_ty().sty {
+                        match trait_predicate.skip_binder().trait_ref.self_ty().sty {
                             ty::TyParam(ref p) if *p == param_ty => {
                                 Some(trait_predicate.to_poly_trait_ref())
                             }
@@ -1097,7 +1097,8 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
                 if !selcx.evaluate_obligation(o) {
                     all_true = false;
                     if let &ty::Predicate::Trait(ref pred) = &o.predicate {
-                        possibly_unsatisfied_predicates.push(pred.0.trait_ref);
+                        possibly_unsatisfied_predicates.push(
+                            pred.skip_binder().trait_ref);
                     }
                 }
             }
@@ -1200,7 +1201,7 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
     {
         debug!("xform_self_ty(impl_ty={:?}, self_ty={:?}, substs={:?})",
                impl_ty,
-               method.fty.sig.0.inputs.get(0),
+               method.fty.sig.skip_binder().inputs.get(0),
                substs);
 
         assert!(!substs.has_escaping_regions());

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -411,7 +411,7 @@ impl<'ccx, 'tcx> CheckTypeWellFormedVisitor<'ccx, 'tcx> {
         };
         let rcvr_ty = fcx.instantiate_type_scheme(span, free_substs, &rcvr_ty);
         let rcvr_ty = fcx.tcx().liberate_late_bound_regions(free_id_outlive,
-                                                            &ty::Binder(rcvr_ty));
+                                                            &ty::Binder::new(rcvr_ty));
 
         debug!("check_method_receiver: receiver ty = {:?}", rcvr_ty);
 

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -931,7 +931,7 @@ fn convert_variant_ctor<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
             tcx.mk_fn_def(def_id, substs, ty::BareFnTy {
                 unsafety: hir::Unsafety::Normal,
                 abi: abi::Abi::Rust,
-                sig: ty::Binder(ty::FnSig {
+                sig: ty::Binder::new(ty::FnSig {
                     inputs: inputs,
                     output: ty::FnConverging(scheme.ty),
                     variadic: false
@@ -1775,7 +1775,7 @@ fn ty_generic_predicates<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
             });
         for bound in &param.bounds {
             let bound_region = ast_region_to_region(ccx.tcx, bound);
-            let outlives = ty::Binder(ty::OutlivesPredicate(region, bound_region));
+            let outlives = ty::Binder::new(ty::OutlivesPredicate(region, bound_region));
             result.predicates.push(space, outlives.to_predicate());
         }
     }
@@ -1809,7 +1809,7 @@ fn ty_generic_predicates<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
 
                         &hir::TyParamBound::RegionTyParamBound(ref lifetime) => {
                             let region = ast_region_to_region(tcx, lifetime);
-                            let pred = ty::Binder(ty::OutlivesPredicate(ty, region));
+                            let pred = ty::Binder::new(ty::OutlivesPredicate(ty, region));
                             result.predicates.push(space, ty::Predicate::TypeOutlives(pred))
                         }
                     }
@@ -1820,7 +1820,7 @@ fn ty_generic_predicates<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
                 let r1 = ast_region_to_region(tcx, &region_pred.lifetime);
                 for bound in &region_pred.bounds {
                     let r2 = ast_region_to_region(tcx, bound);
-                    let pred = ty::Binder(ty::OutlivesPredicate(r1, r2));
+                    let pred = ty::Binder::new(ty::OutlivesPredicate(r1, r2));
                     result.predicates.push(space, ty::Predicate::RegionOutlives(pred))
                 }
             }
@@ -2064,7 +2064,7 @@ fn predicates_from_bound<'tcx>(astconv: &AstConv<'tcx>,
         }
         hir::RegionTyParamBound(ref lifetime) => {
             let region = ast_region_to_region(astconv.tcx(), lifetime);
-            let pred = ty::Binder(ty::OutlivesPredicate(param_ty, region));
+            let pred = ty::Binder::new(ty::OutlivesPredicate(param_ty, region));
             vec![ty::Predicate::TypeOutlives(pred)]
         }
         hir::TraitTyParamBound(_, hir::TraitBoundModifier::Maybe) => {
@@ -2185,9 +2185,9 @@ fn compute_type_scheme_of_foreign_fn_decl<'a, 'tcx>(
     let t_fn = ccx.tcx.mk_fn_def(id, substs, ty::BareFnTy {
         abi: abi,
         unsafety: hir::Unsafety::Unsafe,
-        sig: ty::Binder(ty::FnSig {inputs: input_tys,
-                                    output: output,
-                                    variadic: decl.variadic}),
+        sig: ty::Binder::new(ty::FnSig {inputs: input_tys,
+                                        output: output,
+                                        variadic: decl.variadic}),
     });
 
     ty::TypeScheme {

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -242,7 +242,7 @@ fn check_main_fn_ty(ccx: &CrateCtxt,
             let se_ty = tcx.mk_fn_def(main_def_id, substs, ty::BareFnTy {
                 unsafety: hir::Unsafety::Normal,
                 abi: Abi::Rust,
-                sig: ty::Binder(ty::FnSig {
+                sig: ty::Binder::new(ty::FnSig {
                     inputs: Vec::new(),
                     output: ty::FnConverging(tcx.mk_nil()),
                     variadic: false
@@ -290,7 +290,7 @@ fn check_start_fn_ty(ccx: &CrateCtxt,
             let se_ty = tcx.mk_fn_def(start_def_id, substs, ty::BareFnTy {
                 unsafety: hir::Unsafety::Normal,
                 abi: Abi::Rust,
-                sig: ty::Binder(ty::FnSig {
+                sig: ty::Binder::new(ty::FnSig {
                     inputs: vec!(
                         tcx.types.isize,
                         tcx.mk_imm_ptr(tcx.mk_imm_ptr(tcx.types.u8))

--- a/src/librustc_typeck/variance/constraints.rs
+++ b/src/librustc_typeck/variance/constraints.rs
@@ -404,12 +404,16 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
                 self.add_constraints_from_region(generics, data.bounds.region_bound, contra);
 
                 // Ignore the SelfSpace, it is erased.
-                self.add_constraints_from_trait_ref(generics, poly_trait_ref.0, variance);
+                self.add_constraints_from_trait_ref(generics,
+                                                    *poly_trait_ref.skip_binder(),
+                                                    variance);
 
                 let projections = data.projection_bounds_with_self_ty(self.tcx(),
                                                                       self.tcx().types.err);
                 for projection in &projections {
-                    self.add_constraints_from_ty(generics, projection.0.ty, self.invariant);
+                    self.add_constraints_from_ty(generics,
+                                                 projection.skip_binder().ty,
+                                                 self.invariant);
                 }
             }
 
@@ -487,10 +491,10 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
                                 sig: &ty::PolyFnSig<'tcx>,
                                 variance: VarianceTermPtr<'a>) {
         let contra = self.contravariant(variance);
-        for &input in &sig.0.inputs {
+        for &input in &sig.skip_binder().inputs {
             self.add_constraints_from_ty(generics, input, contra);
         }
-        if let ty::FnConverging(result_type) = sig.0.output {
+        if let ty::FnConverging(result_type) = sig.skip_binder().output {
             self.add_constraints_from_ty(generics, result_type, variance);
         }
     }


### PR DESCRIPTION
It should never have been public. Call `skip_binder` instead and make
your intentions explicit. Where possible, I adopted `map_bound_ref`
and `map_bound` instead.

r? @eddyb 
