### PR TITLE
std: Funnel all aborts through rtabort! cc #31519

### DIFF
--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -14,7 +14,6 @@ use io::prelude::*;
 use any::Any;
 use cell::Cell;
 use cell::RefCell;
-use intrinsics;
 use sync::StaticRwLock;
 use sync::atomic::{AtomicBool, Ordering};
 use sys::stdio::Stderr;
@@ -208,9 +207,8 @@ pub fn on_panic(obj: &(Any+Send), file: &'static str, line: u32) {
     // abort immediately to avoid infinite recursion, so that attaching a
     // debugger provides a useable stacktrace.
     if panics >= 3 {
-        util::dumb_print(format_args!("thread panicked while processing \
-                                       panic. aborting.\n"));
-        unsafe { intrinsics::abort() }
+        rtabort!("thread panicked while processing \
+                  panic. aborting.");
     }
 
     let info = PanicInfo {
@@ -234,8 +232,7 @@ pub fn on_panic(obj: &(Any+Send), file: &'static str, line: u32) {
         // have limited options. Currently our preference is to
         // just abort. In the future we may consider resuming
         // unwinding or otherwise exiting the thread cleanly.
-        util::dumb_print(format_args!("thread panicked while panicking. \
-                                       aborting.\n"));
-        unsafe { intrinsics::abort() }
+        rtabort!("thread panicked while panicking. \
+                  aborting.");
     }
 }

--- a/src/libstd/sys/common/unwind/seh.rs
+++ b/src/libstd/sys/common/unwind/seh.rs
@@ -149,5 +149,5 @@ mod imp {
 #[lang = "eh_personality"]
 #[cfg(not(test))]
 fn rust_eh_personality() {
-    unsafe { ::intrinsics::abort() }
+    rtabort!()
 }

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -73,13 +73,12 @@ pub fn init() {
     // errors are ignored while printing since there's nothing we can do about
     // them and we are about to exit anyways.
     fn oom_handler() -> ! {
-        use intrinsics;
         let msg = "fatal runtime error: out of memory\n";
         unsafe {
             libc::write(libc::STDERR_FILENO,
                         msg.as_ptr() as *const libc::c_void,
                         msg.len() as libc::size_t);
-            intrinsics::abort();
+            rtabort!();
         }
     }
 

--- a/src/libstd/sys/windows/mod.rs
+++ b/src/libstd/sys/windows/mod.rs
@@ -48,7 +48,6 @@ pub fn init() {
 
     // See comment in sys/unix/mod.rs
     fn oom_handler() -> ! {
-        use intrinsics;
         use ptr;
         let msg = "fatal runtime error: out of memory\n";
         unsafe {
@@ -59,7 +58,7 @@ pub fn init() {
                          msg.len() as c::DWORD,
                          ptr::null_mut(),
                          ptr::null_mut());
-            intrinsics::abort();
+            rtabort!();
         }
     }
 }


### PR DESCRIPTION
The abort strategy isn't necessarily as simple as intrinsics::abort. For example on windows we may want to instead use `__failfast`. All aborts should use the same code.
