### PR TITLE
Distribute both rust-lldb and rust-gdb everywhere

### DIFF
--- a/mk/debuggers.mk
+++ b/mk/debuggers.mk
@@ -41,10 +41,13 @@ DEBUGGER_BIN_SCRIPTS_LLDB_ABS=\
 
 
 ## ALL ##
-DEBUGGER_RUSTLIB_ETC_SCRIPTS_ALL=$(DEBUGGER_RUSTLIB_ETC_SCRIPTS_GDB) \
-                                 $(DEBUGGER_RUSTLIB_ETC_SCRIPTS_LLDB)
-DEBUGGER_RUSTLIB_ETC_SCRIPTS_ALL_ABS=$(DEBUGGER_RUSTLIB_ETC_SCRIPTS_GDB_ABS) \
-                                     $(DEBUGGER_RUSTLIB_ETC_SCRIPTS_LLDB_ABS)
+DEBUGGER_RUSTLIB_ETC_SCRIPTS_ALL=gdb_load_rust_pretty_printers.py \
+                                 gdb_rust_pretty_printing.py \
+                                 lldb_rust_formatters.py \
+                                 debugger_pretty_printers_common.py
+DEBUGGER_RUSTLIB_ETC_SCRIPTS_ALL_ABS=\
+    $(foreach script,$(DEBUGGER_RUSTLIB_ETC_SCRIPTS_ALL), \
+        $(CFG_SRC_DIR)src/etc/$(script))
 DEBUGGER_BIN_SCRIPTS_ALL=$(DEBUGGER_BIN_SCRIPTS_GDB) \
                          $(DEBUGGER_BIN_SCRIPTS_LLDB)
 DEBUGGER_BIN_SCRIPTS_ALL_ABS=$(DEBUGGER_BIN_SCRIPTS_GDB_ABS) \

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -390,7 +390,7 @@ endif
 # This 'function' will determine which debugger scripts to copy based on a
 # target triple. See debuggers.mk for more information.
 TRIPLE_TO_DEBUGGER_SCRIPT_SETTING=\
- $(if $(findstring windows,$(1)),none,$(if $(findstring darwin,$(1)),lldb,gdb))
+ $(if $(findstring windows-msvc,$(1)),none,all)
 
 STAGES = 0 1 2 3
 

--- a/src/bootstrap/build/dist.rs
+++ b/src/bootstrap/build/dist.rs
@@ -217,23 +217,23 @@ pub fn debugger_scripts(build: &Build,
         t!(fs::create_dir_all(&dst));
         install(&build.src.join("src/etc/").join(file), &dst, 0o644);
     };
-    if host.contains("windows") {
+    if host.contains("windows-msvc") {
         // no debugger scripts
-    } else if host.contains("darwin") {
-        // lldb debugger scripts
-        install(&build.src.join("src/etc/rust-lldb"), &sysroot.join("bin"),
-                0o755);
-
-        cp_debugger_script("lldb_rust_formatters.py");
-        cp_debugger_script("debugger_pretty_printers_common.py");
     } else {
+        cp_debugger_script("debugger_pretty_printers_common.py");
+
         // gdb debugger scripts
         install(&build.src.join("src/etc/rust-gdb"), &sysroot.join("bin"),
                 0o755);
 
         cp_debugger_script("gdb_load_rust_pretty_printers.py");
         cp_debugger_script("gdb_rust_pretty_printing.py");
-        cp_debugger_script("debugger_pretty_printers_common.py");
+
+        // lldb debugger scripts
+        install(&build.src.join("src/etc/rust-lldb"), &sysroot.join("bin"),
+                0o755);
+
+        cp_debugger_script("lldb_rust_formatters.py");
     }
 }
 


### PR DESCRIPTION
Both debuggers are viable in some capacity on all tier-1 platforms,
and people often ask for rust-lldb on Linux or rust-gdb on OS X.

r? @michaelwoerister 

I'm still testing locally, but this _looks_ like the right thing to change.
