### PR TITLE
Avoid gated feature checking unconfigured expanded items

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -647,19 +647,6 @@ pub fn phase_2_configure_and_expand(sess: &Session,
         krate
     })?;
 
-    // Needs to go *after* expansion to be able to check the results
-    // of macro expansion.
-    time(time_passes, "complete gated feature checking 1", || {
-        sess.track_errors(|| {
-            let features = syntax::feature_gate::check_crate(sess.codemap(),
-                                                             &sess.parse_sess.span_diagnostic,
-                                                             &krate,
-                                                             &attributes,
-                                                             sess.opts.unstable_features);
-            *sess.features.borrow_mut() = features;
-        })
-    })?;
-
     krate = time(time_passes, "maybe building test harness", || {
         syntax::test::modify_for_testing(&sess.parse_sess, &sess.opts.cfg, krate, sess.diagnostic())
     });
@@ -676,10 +663,8 @@ pub fn phase_2_configure_and_expand(sess: &Session,
          "checking for inline asm in case the target doesn't support it",
          || no_asm::check_crate(sess, &krate));
 
-    // One final feature gating of the true AST that gets compiled
-    // later, to make sure we've got everything (e.g. configuration
-    // can insert new attributes via `cfg_attr`)
-    time(time_passes, "complete gated feature checking 2", || {
+    // Needs to go *after* expansion to be able to check the results of macro expansion.
+    time(time_passes, "complete gated feature checking", || {
         sess.track_errors(|| {
             let features = syntax::feature_gate::check_crate(sess.codemap(),
                                                              &sess.parse_sess.span_diagnostic,

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -625,21 +625,6 @@ pub fn phase_2_configure_and_expand(sess: &Session,
         ret
     });
 
-    // Needs to go *after* expansion to be able to check the results
-    // of macro expansion.  This runs before #[cfg] to try to catch as
-    // much as possible (e.g. help the programmer avoid platform
-    // specific differences)
-    time(time_passes, "complete gated feature checking 1", || {
-        sess.track_errors(|| {
-            let features = syntax::feature_gate::check_crate(sess.codemap(),
-                                                             &sess.parse_sess.span_diagnostic,
-                                                             &krate,
-                                                             &attributes,
-                                                             sess.opts.unstable_features);
-            *sess.features.borrow_mut() = features;
-        })
-    })?;
-
     // JBC: make CFG processing part of expansion to avoid this problem:
 
     // strip again, in case expansion added anything with a #[cfg].
@@ -660,6 +645,19 @@ pub fn phase_2_configure_and_expand(sess: &Session,
         });
 
         krate
+    })?;
+
+    // Needs to go *after* expansion to be able to check the results
+    // of macro expansion.
+    time(time_passes, "complete gated feature checking 1", || {
+        sess.track_errors(|| {
+            let features = syntax::feature_gate::check_crate(sess.codemap(),
+                                                             &sess.parse_sess.span_diagnostic,
+                                                             &krate,
+                                                             &attributes,
+                                                             sess.opts.unstable_features);
+            *sess.features.borrow_mut() = features;
+        })
     })?;
 
     krate = time(time_passes, "maybe building test harness", || {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -309,9 +309,7 @@ macro_rules! with_exts_frame {
 // When we enter a module, record it, for the sake of `module!`
 pub fn expand_item(it: P<ast::Item>, fld: &mut MacroExpander)
                    -> SmallVector<P<ast::Item>> {
-    let it = expand_item_multi_modifier(Annotatable::Item(it), fld);
-
-    expand_annotatable(it, fld)
+    expand_annotatable(Annotatable::Item(it), fld)
         .into_iter().map(|i| i.expect_item()).collect()
 }
 

--- a/src/test/compile-fail/expanded-cfg.rs
+++ b/src/test/compile-fail/expanded-cfg.rs
@@ -1,0 +1,26 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_attrs)]
+
+macro_rules! mac {
+    {} => {
+        #[cfg(attr)]
+        mod m {
+            #[lang_item]
+            fn f() {}
+        }
+    }
+}
+
+mac! {}
+
+#[rustc_error]
+fn main() {} //~ ERROR compilation successful


### PR DESCRIPTION
Avoid gated feature checking unconfigured macro-expanded items (fixes #32840).
Unconfigured items that are not macro-expanded are already not gated feature checked.
r? @nrc
