### PR TITLE
resolve: import resolution diagnostics

### DIFF
--- a/src/test/compile-fail/issue-32833.rs
+++ b/src/test/compile-fail/issue-32833.rs
@@ -1,0 +1,16 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use bar::Foo; //~ ERROR There is no `Foo` in `bar` [E0432]
+mod bar {
+    use Foo; //~ ERROR There is no `Foo` in the crate root [E0432]
+}
+
+fn main() {}

--- a/src/test/compile-fail/use-mod-2.rs
+++ b/src/test/compile-fail/use-mod-2.rs
@@ -10,10 +10,10 @@
 
 mod foo {
     use self::{self};
-    //~^ ERROR unresolved import `self`. There is no `self` in `???`
+    //~^ ERROR unresolved import `self`. There is no `self` in the crate root
 
     use super::{self};
-    //~^ ERROR unresolved import `super`. There is no `super` in `???`
+    //~^ ERROR unresolved import `super`. There is no `super` in the crate root
 }
 
 fn main() {}


### PR DESCRIPTION
This improves the diagnostics for failing import resolutions (fixes #32833).
r? @eddyb 
