### PR TITLE
librustc_back: fix incorrect comment about RUST_TARGET_PATH

### DIFF
--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -27,8 +27,7 @@
 //! rustc will search each directory in the environment variable
 //! `RUST_TARGET_PATH` for a file named `TRIPLE.json`. The first one found will
 //! be loaded. If no file is found in any of those directories, a fatal error
-//! will be given.  `RUST_TARGET_PATH` includes `/etc/rustc` as its last entry,
-//! to be searched by default.
+//! will be given.
 //!
 //! Projects defining their own targets should use
 //! `--target=path/to/my-awesome-platform.json` instead of adding to


### PR DESCRIPTION
The path `/etc/rustc/` is not the default last entry in
RUST_TARGET_PATH. This was in RFC131 but was never implemented in rustc
so it was removed as part of #31117 and rust-lang/rfcs#1473.

Signed-off-by: Doug Goldstein cardoe@cardoe.com
