### PR TITLE
Bit-magic for faster is_char_boundary

### DIFF
--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -1940,7 +1940,8 @@ impl StrExt for str {
         if index == 0 || index == self.len() { return true; }
         match self.as_bytes().get(index) {
             None => false,
-            Some(&b) => b < 128 || b >= 192,
+            // This is bit magic equivalent to: b < 128 || b >= 192
+            Some(&b) => (b as i8) >= -0x40,
         }
     }
 


### PR DESCRIPTION
The asm generated for b < 128 || b >= 192 is not ideal, as it computes
both sub-inequalities. This patch replaces it with bit magic.

Fixes #32471
