### PR TITLE
Add rustbuild option to use Ninja for LLVM build

### DIFF
--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -3,7 +3,7 @@ name = "bootstrap"
 version = "0.0.0"
 dependencies = [
  "build_helper 0.1.0",
- "cmake 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cmake 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -21,7 +21,7 @@ version = "0.1.0"
 
 [[package]]
 name = "cmake"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -21,7 +21,7 @@ path = "rustdoc.rs"
 
 [dependencies]
 build_helper = { path = "../build_helper" }
-cmake = "0.1.10"
+cmake = "0.1.17"
 filetime = "0.1"
 num_cpus = "0.2"
 toml = "0.1"

--- a/src/bootstrap/build/config.rs
+++ b/src/bootstrap/build/config.rs
@@ -205,7 +205,6 @@ impl Config {
             set(&mut config.ninja, llvm.ninja);
             set(&mut config.llvm_assertions, llvm.assertions);
             set(&mut config.llvm_optimize, llvm.optimize);
-            set(&mut config.llvm_optimize, llvm.optimize);
             set(&mut config.llvm_version_check, llvm.version_check);
             set(&mut config.llvm_static_stdcpp, llvm.static_libstdcpp);
         }

--- a/src/bootstrap/build/config.rs
+++ b/src/bootstrap/build/config.rs
@@ -31,6 +31,7 @@ use toml::{Parser, Decoder, Value};
 #[derive(Default)]
 pub struct Config {
     pub ccache: bool,
+    pub ninja: bool,
     pub verbose: bool,
     pub submodules: bool,
     pub compiler_docs: bool,
@@ -107,6 +108,7 @@ struct Build {
 #[derive(RustcDecodable, Default)]
 struct Llvm {
     ccache: Option<bool>,
+    ninja: Option<bool>,
     assertions: Option<bool>,
     optimize: Option<bool>,
     version_check: Option<bool>,
@@ -200,6 +202,7 @@ impl Config {
 
         if let Some(ref llvm) = toml.llvm {
             set(&mut config.ccache, llvm.ccache);
+            set(&mut config.ninja, llvm.ninja);
             set(&mut config.llvm_assertions, llvm.assertions);
             set(&mut config.llvm_optimize, llvm.optimize);
             set(&mut config.llvm_optimize, llvm.optimize);

--- a/src/bootstrap/build/native.rs
+++ b/src/bootstrap/build/native.rs
@@ -43,6 +43,9 @@ pub fn llvm(build: &Build, target: &str) {
 
     // http://llvm.org/docs/CMake.html
     let mut cfg = cmake::Config::new(build.src.join("src/llvm"));
+    if build.config.ninja {
+        cfg.generator("Ninja");
+    }
     cfg.target(target)
        .host(&build.config.build)
        .out_dir(&dst)

--- a/src/bootstrap/build/sanity.rs
+++ b/src/bootstrap/build/sanity.rs
@@ -48,6 +48,9 @@ pub fn check(build: &mut Build) {
             }
         }
         need_cmd("cmake".as_ref());
+        if build.config.ninja {
+            need_cmd("ninja".as_ref())
+        }
         break
     }
 


### PR DESCRIPTION
This change adds support for a `ninja` option in the `[llvm]` section of rustbuild's `config.toml`. When `true`, the option enables use of the Ninja build tool. Note that this change does not add support for Ninja to the old makefile based build system.

Closes https://github.com/rust-lang/rust/issues/32809

r? @alexcrichton 
