### PR TITLE
impl<T> IntoIterator for [T; $N]

### DIFF
--- a/src/libcoretest/array.rs
+++ b/src/libcoretest/array.rs
@@ -26,3 +26,102 @@ fn fixed_size_array() {
     assert_eq!(FixedSizeArray::as_mut_slice(&mut empty_array).len(), 0);
     assert_eq!(FixedSizeArray::as_mut_slice(&mut empty_zero_sized).len(), 0);
 }
+
+#[test]
+fn test_iterator_nth() {
+    let v = [0, 1, 2, 3, 4];
+    for i in 0..v.len() {
+        assert_eq!(v.clone().into_iter().nth(i).unwrap(), v[i]);
+    }
+    assert_eq!(v.clone().into_iter().nth(v.len()), None);
+
+    let mut iter = v.into_iter();
+    assert_eq!(iter.nth(2).unwrap(), v[2]);
+    assert_eq!(iter.nth(1).unwrap(), v[4]);
+}
+
+#[test]
+fn test_iterator_last() {
+    let v = [0, 1, 2, 3, 4];
+    assert_eq!(v.into_iter().last().unwrap(), 4);
+    assert_eq!([0].into_iter().last().unwrap(), 0);
+}
+
+#[test]
+fn test_iterator_count() {
+    let v = [0, 1, 2, 3, 4];
+    assert_eq!(v.clone().into_iter().count(), 5);
+
+    let mut iter2 = v.into_iter();
+    iter2.next();
+    iter2.next();
+    assert_eq!(iter2.count(), 3);
+}
+
+#[test]
+fn test_iterator_flat_map() {
+    assert!((0..5).flat_map(|i| [2 * i, 2 * i + 1]).eq(0..10));
+}
+
+#[test]
+fn test_iterator_drops() {
+    use core::cell::Cell;
+
+    struct R<'a> {
+       i: &'a Cell<usize>,
+    }
+
+    impl<'a> Drop for R<'a> {
+       fn drop(&mut self) {
+            self.i.set(self.i.get() + 1);
+        }
+    }
+
+    fn r(i: &Cell<usize>) -> R {
+        R {
+            i: i
+        }
+    }
+
+    fn v(i: &Cell<usize>) -> [R; 5] {
+        [r(i), r(i), r(i), r(i), r(i)]
+    }
+
+    let i = Cell::new(0);
+    {
+        v(&i).into_iter();
+    }
+    assert_eq!(i.get(), 5);
+
+    let i = Cell::new(0);
+    {
+        let mut iter = v(&i).into_iter();
+        let _x = iter.next();
+        assert_eq!(i.get(), 0);
+        assert_eq!(iter.count(), 4);
+        assert_eq!(i.get(), 4);
+    }
+    assert_eq!(i.get(), 5);
+
+    let i = Cell::new(0);
+    {
+        let mut iter = v(&i).into_iter();
+        let _x = iter.nth(2);
+        assert_eq!(i.get(), 2);
+        let _y = iter.last();
+        assert_eq!(i.get(), 3);
+    }
+    assert_eq!(i.get(), 5);
+
+    let i = Cell::new(0);
+    for (index, _x) in v(&i).into_iter().enumerate() {
+        assert_eq!(i.get(), index);
+    }
+    assert_eq!(i.get(), 5);
+
+    let i = Cell::new(0);
+    for (index, _x) in v(&i).into_iter().rev().enumerate() {
+        assert_eq!(i.get(), index);
+    }
+    assert_eq!(i.get(), 5);
+}

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -378,7 +378,7 @@ fn init_ids() -> HashMap<String, usize> {
      "deref-methods",
      "implementations",
      "derived_implementations"
-     ].into_iter().map(|id| (String::from(*id), 1)).collect()
+     ].into_iter().map(|id| (String::from(id), 1)).collect()
 }
 
 /// This method resets the local table of used ID attributes. This is typically

--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -262,7 +262,7 @@ mod prim_pointer { }
 ///
 /// - `Clone` (only if `T: Copy`)
 /// - `Debug`
-/// - `IntoIterator` (implemented for `&[T; N]` and `&mut [T; N]`)
+/// - `IntoIterator` (implemented for `[T; N]`, `&[T; N]`, and `&mut [T; N]`)
 /// - `PartialEq`, `PartialOrd`, `Ord`, `Eq`
 /// - `Hash`
 /// - `AsRef`, `AsMut`


### PR DESCRIPTION
This allows an array to move its values out through iteration.  I find
this especially handy for `flat_map`, to expand one item into several
without having to allocate a `Vec`, like one of the new tests:

```
fn test_iterator_flat_map() {
    assert!((0..5).flat_map(|i| [2 * i, 2 * i + 1]).eq(0..10));
}
```

Note the array must be moved for the iterator to own it, so you probably
don't want this for large `T` or very many items.  But for small arrays,
it should be faster than bothering with a vector and the heap.
