### PR TITLE
don't report errors in constants at every use site

### DIFF
--- a/src/librustc_const_eval/lib.rs
+++ b/src/librustc_const_eval/lib.rs
@@ -29,6 +29,8 @@
 #![feature(slice_patterns)]
 #![feature(iter_arith)]
 #![feature(question_mark)]
+#![feature(box_patterns)]
+#![feature(box_syntax)]
 
 #[macro_use] extern crate syntax;
 #[macro_use] extern crate log;

--- a/src/librustc_passes/consts.rs
+++ b/src/librustc_passes/consts.rs
@@ -29,6 +29,7 @@ use rustc::ty::cast::{CastKind};
 use rustc_const_eval::{ConstEvalErr, lookup_const_fn_by_id, compare_lit_exprs};
 use rustc_const_eval::{eval_const_expr_partial, lookup_const_by_id};
 use rustc_const_eval::ErrKind::{IndexOpFeatureGated, UnimplementedConstVal};
+use rustc_const_eval::ErrKind::ErroneousReferencedConstant;
 use rustc_const_eval::EvalHint::ExprTypeChecked;
 use rustc::hir::def::Def;
 use rustc::hir::def_id::DefId;
@@ -114,6 +115,7 @@ impl<'a, 'tcx> CheckCrateVisitor<'a, 'tcx> {
             match err.kind {
                 UnimplementedConstVal(_) => {},
                 IndexOpFeatureGated => {},
+                ErroneousReferencedConstant(_) => {},
                 _ => self.tcx.sess.add_lint(CONST_ERR, expr.id, expr.span,
                                          format!("constant evaluation error: {}. This will \
                                                  become a HARD ERROR in the future",

--- a/src/test/compile-fail/const-err-multi.rs
+++ b/src/test/compile-fail/const-err-multi.rs
@@ -1,0 +1,19 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(const_err)]
+
+pub const A: i8 = -std::i8::MIN; //~ ERROR attempted to negate with overflow
+pub const B: i8 = A;
+pub const C: u8 = A as u8;
+pub const D: i8 = 50 - A;
+
+fn main() {
+}


### PR DESCRIPTION
partially fixes #32842

r? @arielb1 
cc @retep998  

I chose this way of implementing it, because the alternative (checking if the error span is inside the constant's expressions's span) would get confusing when combined with expression generating macros.

A next step would be to re-enable the re-reporting of errors if the original erroneous constant is in another crate.
