### PR TITLE
Do not encode name when encoding DefKey

### DIFF
--- a/src/librustc_metadata/astencode.rs
+++ b/src/librustc_metadata/astencode.rs
@@ -49,9 +49,9 @@ use std::fmt::Debug;
 use rbml::reader;
 use rbml::writer::Encoder;
 use rbml;
-use serialize;
-use serialize::{Decodable, Decoder, DecoderHelpers, Encodable};
-use serialize::EncoderHelpers;
+use rustc_serialize as serialize;
+use rustc_serialize::{Decodable, Decoder, DecoderHelpers};
+use rustc_serialize::{Encodable, EncoderHelpers};
 
 #[cfg(test)] use std::io::Cursor;
 #[cfg(test)] use syntax::parse;
@@ -445,7 +445,7 @@ fn encode_method_callee<'a, 'tcx>(ecx: &e::EncodeContext<'a, 'tcx>,
                                   rbml_w: &mut Encoder,
                                   autoderef: u32,
                                   method: &ty::MethodCallee<'tcx>) {
-    use serialize::Encoder;
+    use rustc_serialize::Encoder;
 
     rbml_w.emit_struct("MethodCallee", 4, |rbml_w| {
         rbml_w.emit_struct_field("autoderef", 0, |rbml_w| {
@@ -561,7 +561,7 @@ impl<'a, 'tcx> rbml_writer_helpers<'tcx> for Encoder<'a> {
     }
 
     fn emit_upvar_capture(&mut self, ecx: &e::EncodeContext, capture: &ty::UpvarCapture) {
-        use serialize::Encoder;
+        use rustc_serialize::Encoder;
 
         self.emit_enum("UpvarCapture", |this| {
             match *capture {
@@ -589,7 +589,7 @@ impl<'a, 'tcx> rbml_writer_helpers<'tcx> for Encoder<'a> {
 
     fn emit_auto_adjustment<'b>(&mut self, ecx: &e::EncodeContext<'b, 'tcx>,
                                 adj: &adjustment::AutoAdjustment<'tcx>) {
-        use serialize::Encoder;
+        use rustc_serialize::Encoder;
 
         self.emit_enum("AutoAdjustment", |this| {
             match *adj {
@@ -621,7 +621,7 @@ impl<'a, 'tcx> rbml_writer_helpers<'tcx> for Encoder<'a> {
 
     fn emit_autoref<'b>(&mut self, ecx: &e::EncodeContext<'b, 'tcx>,
                         autoref: &adjustment::AutoRef<'tcx>) {
-        use serialize::Encoder;
+        use rustc_serialize::Encoder;
 
         self.emit_enum("AutoRef", |this| {
             match autoref {
@@ -643,7 +643,7 @@ impl<'a, 'tcx> rbml_writer_helpers<'tcx> for Encoder<'a> {
 
     fn emit_auto_deref_ref<'b>(&mut self, ecx: &e::EncodeContext<'b, 'tcx>,
                                auto_deref_ref: &adjustment::AutoDerefRef<'tcx>) {
-        use serialize::Encoder;
+        use rustc_serialize::Encoder;
 
         self.emit_struct("AutoDerefRef", 2, |this| {
             this.emit_struct_field("autoderefs", 0, |this| auto_deref_ref.autoderefs.encode(this));

--- a/src/librustc_metadata/def_key.rs
+++ b/src/librustc_metadata/def_key.rs
@@ -1,0 +1,104 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use rustc::hir::def_id::DefIndex;
+use rustc::hir::map as hir_map;
+use syntax::ast::Name;
+
+#[derive(RustcEncodable, RustcDecodable)]
+pub struct DefKey {
+    pub parent: Option<DefIndex>,
+    pub disambiguated_data: DisambiguatedDefPathData,
+}
+
+#[derive(RustcEncodable, RustcDecodable)]
+pub struct DisambiguatedDefPathData {
+    pub data: DefPathData,
+    pub disambiguator: u32,
+}
+
+#[derive(RustcEncodable, RustcDecodable)]
+pub enum DefPathData {
+    CrateRoot,
+    Misc,
+    Impl,
+    TypeNs,
+    ValueNs,
+    MacroDef,
+    ClosureExpr,
+    TypeParam,
+    LifetimeDef,
+    EnumVariant,
+    Field,
+    StructCtor,
+    Initializer,
+    Binding,
+}
+
+pub fn simplify_def_key(key: hir_map::DefKey) -> DefKey {
+    let data = DisambiguatedDefPathData {
+        data: simplify_def_path_data(key.disambiguated_data.data),
+        disambiguator: key.disambiguated_data.disambiguator,
+    };
+    DefKey {
+        parent: key.parent,
+        disambiguated_data: data,
+    }
+}
+
+fn simplify_def_path_data(data: hir_map::DefPathData) -> DefPathData {
+    match data {
+        hir_map::DefPathData::CrateRoot => DefPathData::CrateRoot,
+        hir_map::DefPathData::InlinedRoot(_) => bug!("unexpected DefPathData"),
+        hir_map::DefPathData::Misc => DefPathData::Misc,
+        hir_map::DefPathData::Impl => DefPathData::Impl,
+        hir_map::DefPathData::TypeNs(_) => DefPathData::TypeNs,
+        hir_map::DefPathData::ValueNs(_) => DefPathData::ValueNs,
+        hir_map::DefPathData::MacroDef(_) => DefPathData::MacroDef,
+        hir_map::DefPathData::ClosureExpr => DefPathData::ClosureExpr,
+        hir_map::DefPathData::TypeParam(_) => DefPathData::TypeParam,
+        hir_map::DefPathData::LifetimeDef(_) => DefPathData::LifetimeDef,
+        hir_map::DefPathData::EnumVariant(_) => DefPathData::EnumVariant,
+        hir_map::DefPathData::Field(_) => DefPathData::Field,
+        hir_map::DefPathData::StructCtor => DefPathData::StructCtor,
+        hir_map::DefPathData::Initializer => DefPathData::Initializer,
+        hir_map::DefPathData::Binding(_) => DefPathData::Binding,
+    }
+}
+
+pub fn recover_def_key(key: DefKey, name: Option<Name>) -> hir_map::DefKey {
+    let data = hir_map::DisambiguatedDefPathData {
+        data: recover_def_path_data(key.disambiguated_data.data, name),
+        disambiguator: key.disambiguated_data.disambiguator,
+    };
+    hir_map::DefKey {
+        parent: key.parent,
+        disambiguated_data: data,
+    }
+}
+
+fn recover_def_path_data(data: DefPathData, name: Option<Name>) -> hir_map::DefPathData {
+    match data {
+        DefPathData::CrateRoot => hir_map::DefPathData::CrateRoot,
+        DefPathData::Misc => hir_map::DefPathData::Misc,
+        DefPathData::Impl => hir_map::DefPathData::Impl,
+        DefPathData::TypeNs => hir_map::DefPathData::TypeNs(name.unwrap()),
+        DefPathData::ValueNs => hir_map::DefPathData::ValueNs(name.unwrap()),
+        DefPathData::MacroDef => hir_map::DefPathData::MacroDef(name.unwrap()),
+        DefPathData::ClosureExpr => hir_map::DefPathData::ClosureExpr,
+        DefPathData::TypeParam => hir_map::DefPathData::TypeParam(name.unwrap()),
+        DefPathData::LifetimeDef => hir_map::DefPathData::LifetimeDef(name.unwrap()),
+        DefPathData::EnumVariant => hir_map::DefPathData::EnumVariant(name.unwrap()),
+        DefPathData::Field => hir_map::DefPathData::Field(name.unwrap()),
+        DefPathData::StructCtor => hir_map::DefPathData::StructCtor,
+        DefPathData::Initializer => hir_map::DefPathData::Initializer,
+        DefPathData::Binding => hir_map::DefPathData::Binding(name.unwrap()),
+    }
+}

--- a/src/librustc_metadata/lib.rs
+++ b/src/librustc_metadata/lib.rs
@@ -31,7 +31,7 @@
 
 extern crate flate;
 extern crate rbml;
-extern crate serialize;
+extern crate serialize as rustc_serialize; // used by deriving
 
 #[macro_use]
 extern crate rustc;
@@ -48,6 +48,7 @@ pub mod diagnostics;
 
 pub mod astencode;
 pub mod common;
+pub mod def_key;
 pub mod tyencode;
 pub mod tydecode;
 pub mod encoder;


### PR DESCRIPTION
Since name is encoded anyway, name in DefKey is redundant.

cc #32719.
