### PR TITLE
Fix conflicting link identifiers

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -130,7 +130,7 @@ Compatibility Notes
   numbers [no longer return platform-specific types][1.8r], but
   instead return widened integers. [RFC 1415].
 * [Modules sourced from the filesystem cannot appear within arbitrary
-  blocks, but only within other modules][1.8m].
+  blocks, but only within other modules][1.8mf].
 * [`--cfg` compiler flags are parsed strictly as identifiers][1.8c].
 * On Unix, [stack overflow triggers a runtime abort instead of a
   SIGSEGV][1.8so].
@@ -160,7 +160,7 @@ Compatibility Notes
 [1.8h]: https://github.com/rust-lang/rust/pull/31460
 [1.8l]: https://github.com/rust-lang/rust/pull/31668
 [1.8m]: https://github.com/rust-lang/rust/pull/31020
-[1.8m]: https://github.com/rust-lang/rust/pull/31534
+[1.8mf]: https://github.com/rust-lang/rust/pull/31534
 [1.8mp]: https://github.com/rust-lang/rust/pull/30894
 [1.8mr]: https://users.rust-lang.org/t/multirust-0-8-with-cross-std-installation/4901
 [1.8ms]: https://github.com/rust-lang/rust/pull/30448


### PR DESCRIPTION
Caused "Errors for non-exhaustive match patterns now list up to 3 missing variants while also indicating the total number of missing variants if more than 3." to link to "libsyntax: Restrict where non-inline modules can appear (fixes #29765)"
