### PR TITLE
Reword explanation of 'size' types.

### DIFF
--- a/src/doc/book/primitive-types.md
+++ b/src/doc/book/primitive-types.md
@@ -100,7 +100,7 @@ and `i64` is a signed, 64-bit integer.
 Rust also provides types whose particular size depends on the underlying machine
 architecture. Their range is sufficient to express the size of any collection, so
 these types have ‘size’ as the category. They come in signed and unsigned varieties
-which makes for two types: `isize` and `usize`.
+which account for two types: `isize` and `usize`.
 
 ## Floating-point types
 

--- a/src/doc/book/primitive-types.md
+++ b/src/doc/book/primitive-types.md
@@ -98,10 +98,9 @@ and `i64` is a signed, 64-bit integer.
 ## Variable sized types
 
 Rust also provides types whose particular size depends on the underlying machine
-architecture. Their range is sufficient to express sizes of collections and they
-are used to address items in a vector, for example. These types have ‘size’ as
-the category, and come in signed and unsigned varieties. This makes for two types:
-`isize` and `usize`.
+architecture. Their range is sufficient to express the size of any collection, so
+these types have ‘size’ as the category. They come in signed and unsigned varieties
+which makes for two types: `isize` and `usize`.
 
 ## Floating-point types
 

--- a/src/doc/book/primitive-types.md
+++ b/src/doc/book/primitive-types.md
@@ -97,9 +97,11 @@ and `i64` is a signed, 64-bit integer.
 
 ## Variable sized types
 
-Rust also provides types whose size depends on the size of a pointer of the
-underlying machine. These types have ‘size’ as the category, and come in signed
-and unsigned varieties. This makes for two types: `isize` and `usize`.
+Rust also provides types whose particular size depends on the underlying machine
+architecture. Their range is sufficient to express sizes of collections and they
+are used to address items in a vector, for example. These types have ‘size’ as
+the category, and come in signed and unsigned varieties. This makes for two types:
+`isize` and `usize`.
 
 ## Floating-point types
 


### PR DESCRIPTION
Do not reference machine 'pointers' in explanation of 'size' types.

I think the number of elements that can be directly addressed is a fundamental feature of a machine architecture in its own right. The fact that it coincides with the ‘size’ of a pointer should be viewed as an ‘implementation detail’ ;)
