### PR TITLE
prevent other `encode` methods from breaking `derive(RustcEncodable)`

### DIFF
--- a/src/librustc_incremental/persist/data.rs
+++ b/src/librustc_incremental/persist/data.rs
@@ -11,8 +11,7 @@
 //! The data that we will serialize and deserialize.
 
 use rustc::dep_graph::DepNode;
-use rustc_serialize::{Decoder as RustcDecoder,
-                      Encodable as RustcEncodable, Encoder as RustcEncoder};
+use rustc_serialize::{Decoder as RustcDecoder, Encoder as RustcEncoder};
 
 use super::directory::DefPathIndex;
 
@@ -32,4 +31,3 @@ pub struct SerializedHash {
     /// the hash itself, computed by `calculate_item_hash`
     pub hash: u64,
 }
-

--- a/src/librustc_incremental/persist/directory.rs
+++ b/src/librustc_incremental/persist/directory.rs
@@ -18,8 +18,7 @@ use rustc::hir::map::DefPath;
 use rustc::hir::def_id::DefId;
 use rustc::ty;
 use rustc::util::nodemap::DefIdMap;
-use rustc_serialize::{Decoder as RustcDecoder,
-                      Encodable as RustcEncodable, Encoder as RustcEncoder};
+use rustc_serialize::{Decoder as RustcDecoder, Encoder as RustcEncoder};
 use std::fmt::{self, Debug};
 
 /// Index into the DefIdDirectory

--- a/src/test/run-pass-fulldeps/rustc_encodable_hygiene.rs
+++ b/src/test/run-pass-fulldeps/rustc_encodable_hygiene.rs
@@ -1,0 +1,32 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_private)]
+
+#[allow(dead_code)]
+
+extern crate serialize as rustc_serialize;
+
+#[derive(RustcDecodable, RustcEncodable,Debug)]
+struct A {
+    a: String,
+}
+
+trait Trait {
+    fn encode(&self);
+}
+
+impl<T> Trait for T {
+    fn encode(&self) {
+        unimplemented!()
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
fixes https://github.com/rust-lang-nursery/rustc-serialize/issues/151
