### PR TITLE
Fix macro hygiene bug

### DIFF
--- a/src/test/compile-fail/issue-32922.rs
+++ b/src/test/compile-fail/issue-32922.rs
@@ -1,0 +1,20 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_attrs)]
+
+macro_rules! foo { () => {
+    let x = 1;
+    macro_rules! bar { () => {x} }
+    let _ = bar!();
+}}
+
+#[rustc_error]
+fn main() { foo! {}; } //~ ERROR compilation successful

--- a/src/test/compile-fail/issue-32922.rs
+++ b/src/test/compile-fail/issue-32922.rs
@@ -24,8 +24,18 @@ macro_rules! bar { // test issue #31856
     )
 }
 
+macro_rules! baz {
+    ($i:ident) => {
+        let mut $i = 2;
+        $i = $i + 1;
+    }
+}
+
 #[rustc_error]
 fn main() { //~ ERROR compilation successful
     foo! {};
     bar! {};
+
+    let mut a = true;
+    baz!(a);
 }

--- a/src/test/compile-fail/issue-32922.rs
+++ b/src/test/compile-fail/issue-32922.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(rustc_attrs)]
+#![allow(warnings)]
 
 macro_rules! foo { () => {
     let x = 1;
@@ -16,5 +17,15 @@ macro_rules! foo { () => {
     let _ = bar!();
 }}
 
+macro_rules! bar { // test issue #31856
+    ($n:ident) => (
+        let a = 1;
+        let $n = a;
+    )
+}
+
 #[rustc_error]
-fn main() { foo! {}; } //~ ERROR compilation successful
+fn main() { //~ ERROR compilation successful
+    foo! {};
+    bar! {};
+}


### PR DESCRIPTION
This fixes #32922 (EDIT: also #31856, #10681, and #26223), macro hygiene bugs.
It is a [breaking-change]. For example, the following would break:

``` rust
fn main() {
    let x = true;
    macro_rules! foo { () => {
        let x = 0;
        macro_rules! bar { () => {x} }
        let _: bool = bar!();
        //^ `bar!()` used to resolve the first `x` (a bool),
        //| but will now resolve to the second x (an i32).
    }}
    foo! {};
}
```

r? @nrc 
