### PR TITLE
Restore trait impl docs

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2489,7 +2489,7 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
     }
 
     fn doctraititem(w: &mut fmt::Formatter, cx: &Context, item: &clean::Item,
-                    link: AssocItemLink, render_static: bool,
+                    link: AssocItemLink, render_static: bool, is_default_item: bool,
                     outer_version: Option<&str>) -> fmt::Result {
         let shortty = shortty(item);
         let name = item.name.as_ref().unwrap();
@@ -2540,7 +2540,7 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
             _ => panic!("can't make docs for trait item with name {:?}", item.name)
         }
 
-        if !is_static || render_static {
+        if !is_default_item && (!is_static || render_static) {
             document(w, cx, item)
         } else {
             Ok(())
@@ -2549,7 +2549,7 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
 
     write!(w, "<div class='impl-items'>")?;
     for trait_item in &i.impl_.items {
-        doctraititem(w, cx, trait_item, link, render_header, outer_version)?;
+        doctraititem(w, cx, trait_item, link, render_header, false, outer_version)?;
     }
 
     fn render_default_items(w: &mut fmt::Formatter,
@@ -2566,7 +2566,7 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
             let did = i.trait_.as_ref().unwrap().def_id().unwrap();
             let assoc_link = AssocItemLink::GotoSource(did, &i.provided_trait_methods);
 
-            doctraititem(w, cx, trait_item, assoc_link, render_static,
+            doctraititem(w, cx, trait_item, assoc_link, render_static, true,
                          outer_version)?;
         }
         Ok(())

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2540,11 +2540,10 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
             _ => panic!("can't make docs for trait item with name {:?}", item.name)
         }
 
-        match link {
-            AssocItemLink::Anchor if !is_static || render_static => {
-                document(w, cx, item)
-            },
-            _ => Ok(()),
+        if !is_static || render_static {
+            document(w, cx, item)
+        } else {
+            Ok(())
         }
     }
 

--- a/src/test/rustdoc/manual_impl.rs
+++ b/src/test/rustdoc/manual_impl.rs
@@ -8,6 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// @has manual_impl/trait.T.html
+// @has  - '//*[@class="docblock"]' 'Docs associated with the trait definition.'
+// @has  - '//*[@class="docblock"]' 'Docs associated with the trait a_method definition.'
+// @has  - '//*[@class="docblock"]' 'Docs associated with the trait b_method definition.'
 /// Docs associated with the trait definition.
 pub trait T {
     /// Docs associated with the trait a_method definition.

--- a/src/test/rustdoc/manual_impl.rs
+++ b/src/test/rustdoc/manual_impl.rs
@@ -1,0 +1,26 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub trait T {
+    fn a_method(&self) -> usize;
+}
+
+// @has manual_impl/struct.S.html '//*[@class="trait"]' 'T'
+// @has - '//*[@class="docblock"]' 'Docs associated with the trait implementation.'
+// @has - '//*[@class="docblock"]' 'Docs associated with the trait method implementation.'
+pub struct S(usize);
+
+/// Docs associated with the trait implementation.
+impl T for S {
+    /// Docs associated with the trait method implementation.
+    fn a_method(&self) -> usize {
+        self.0
+    }
+}

--- a/src/test/rustdoc/manual_impl.rs
+++ b/src/test/rustdoc/manual_impl.rs
@@ -8,19 +8,67 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+/// Docs associated with the trait definition.
 pub trait T {
+    /// Docs associated with the trait a_method definition.
     fn a_method(&self) -> usize;
+
+    /// Docs associated with the trait b_method definition.
+    fn b_method(&self) -> usize {
+        self.a_method()
+    }
 }
 
-// @has manual_impl/struct.S.html '//*[@class="trait"]' 'T'
-// @has - '//*[@class="docblock"]' 'Docs associated with the trait implementation.'
-// @has - '//*[@class="docblock"]' 'Docs associated with the trait method implementation.'
-pub struct S(usize);
+// @has manual_impl/struct.S1.html '//*[@class="trait"]' 'T'
+// @has  - '//*[@class="docblock"]' 'Docs associated with the S1 trait implementation.'
+// @has  - '//*[@class="docblock"]' 'Docs associated with the S1 trait a_method implementation.'
+// @!has - '//*[@class="docblock"]' 'Docs associated with the trait a_method definition.'
+// @!has - '//*[@class="docblock"]' 'Docs associated with the trait b_method definition.'
+pub struct S1(usize);
 
-/// Docs associated with the trait implementation.
-impl T for S {
-    /// Docs associated with the trait method implementation.
+/// Docs associated with the S1 trait implementation.
+impl T for S1 {
+    /// Docs associated with the S1 trait a_method implementation.
     fn a_method(&self) -> usize {
         self.0
+    }
+}
+
+// @has manual_impl/struct.S2.html '//*[@class="trait"]' 'T'
+// @has  - '//*[@class="docblock"]' 'Docs associated with the S2 trait implementation.'
+// @has  - '//*[@class="docblock"]' 'Docs associated with the S2 trait a_method implementation.'
+// @has  - '//*[@class="docblock"]' 'Docs associated with the S2 trait b_method implementation.'
+// @!has - '//*[@class="docblock"]' 'Docs associated with the trait a_method definition.'
+// @!has - '//*[@class="docblock"]' 'Docs associated with the trait b_method definition.'
+pub struct S2(usize);
+
+/// Docs associated with the S2 trait implementation.
+impl T for S2 {
+    /// Docs associated with the S2 trait a_method implementation.
+    fn a_method(&self) -> usize {
+        self.0
+    }
+
+    /// Docs associated with the S2 trait b_method implementation.
+    fn b_method(&self) -> usize {
+        5
+    }
+}
+
+// @has manual_impl/struct.S3.html '//*[@class="trait"]' 'T'
+// @has  - '//*[@class="docblock"]' 'Docs associated with the S3 trait implementation.'
+// @has  - '//*[@class="docblock"]' 'Docs associated with the S3 trait b_method implementation.'
+// @!has - '//*[@class="docblock"]' 'Docs associated with the trait a_method definition.'
+pub struct S3(usize);
+
+/// Docs associated with the S3 trait implementation.
+impl T for S3 {
+    fn a_method(&self) -> usize {
+        self.0
+    }
+
+    /// Docs associated with the S3 trait b_method implementation.
+    fn b_method(&self) -> usize {
+        5
     }
 }


### PR DESCRIPTION
Currently, documentation on methods in trait implementations doesn't get rendered. This changes that;  trait implementations have all documentation associated with impl items displayed (documentation from the trait definition is ignored).

Fixes #24838
Fixes #26871
