### PR TITLE
Add /obj/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@
 /stage3/
 /test/
 /tmp/
+/obj/
 TAGS
 TAGS.emacs
 TAGS.vi


### PR DESCRIPTION
This is the build directory our buildbots use, and right now the bots are
running `git clean -f -f -d` to remove all untracked files between runs and this
is accidentally deleting `obj`, so we're building LLVM a lot.

Hopefully this keeps the bots caching `obj` so we can clean it out manually and
leave LLVM around.
