### PR TITLE
implement RFC amendment 1494

### DIFF
--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -1014,6 +1014,7 @@ fn is_in_follow(_: &ExtCtxt, tok: &Token, frag: &str) -> Result<bool, String> {
                 match *tok {
                     OpenDelim(token::DelimToken::Brace) | OpenDelim(token::DelimToken::Bracket) |
                     Comma | FatArrow | Colon | Eq | Gt | Semi | BinOp(token::Or) => Ok(true),
+                    MatchNt(_, ref frag, _, _) if frag.name.as_str() == "block" => Ok(true),
                     Ident(i, _) if (i.name.as_str() == "as" ||
                                     i.name.as_str() == "where") => Ok(true),
                     _ => Ok(false)

--- a/src/test/compile-fail/macro-follow.rs
+++ b/src/test/compile-fail/macro-follow.rs
@@ -55,7 +55,7 @@ macro_rules! follow_expr {
     ($e:expr $m:meta) => {};  //~ERROR `$e:expr` is followed by `$m:meta`
 }
 // FOLLOW(ty) = {OpenDelim(Brace), Comma, FatArrow, Colon, Eq, Gt, Semi, Or,
-//               Ident(as), Ident(where), OpenDelim(Bracket)}
+//               Ident(as), Ident(where), OpenDelim(Bracket), Nonterminal(Block)}
 macro_rules! follow_ty {
     ($t:ty ()) => {};       //~WARN  `$t:ty` is followed by `(`
     ($t:ty []) => {};       // ok (RFC 1462)
@@ -67,7 +67,7 @@ macro_rules! follow_ty {
     ($t:ty $t:ty) => {};    //~ERROR `$t:ty` is followed by `$t:ty`
     ($t:ty $s:stmt) => {};  //~ERROR `$t:ty` is followed by `$s:stmt`
     ($t:ty $p:path) => {};  //~ERROR `$t:ty` is followed by `$p:path`
-    ($t:ty $b:block) => {}; //~ERROR `$t:ty` is followed by `$b:block`
+    ($t:ty $b:block) => {}; // ok (RFC 1494)
     ($t:ty $i:ident) => {}; //~ERROR `$t:ty` is followed by `$i:ident`
     ($t:ty $t:tt) => {};    //~ERROR `$t:ty` is followed by `$t:tt`
     ($t:ty $i:item) => {};  //~ERROR `$t:ty` is followed by `$i:item`
@@ -109,7 +109,7 @@ macro_rules! follow_path {
     ($p:path $t:ty) => {};    //~ERROR `$p:path` is followed by `$t:ty`
     ($p:path $s:stmt) => {};  //~ERROR `$p:path` is followed by `$s:stmt`
     ($p:path $p:path) => {};  //~ERROR `$p:path` is followed by `$p:path`
-    ($p:path $b:block) => {}; //~ERROR `$p:path` is followed by `$b:block`
+    ($p:path $b:block) => {}; // ok (RFC 1494)
     ($p:path $i:ident) => {}; //~ERROR `$p:path` is followed by `$i:ident`
     ($p:path $t:tt) => {};    //~ERROR `$p:path` is followed by `$t:tt`
     ($p:path $i:item) => {};  //~ERROR `$p:path` is followed by `$i:item`

--- a/src/test/run-pass/macro-follow.rs
+++ b/src/test/run-pass/macro-follow.rs
@@ -26,7 +26,7 @@ macro_rules! follow_expr {
     ($e:expr ;) => {};
 }
 // FOLLOW(ty) = {OpenDelim(Brace), Comma, FatArrow, Colon, Eq, Gt, Semi, Or,
-//               Ident(as), Ident(where), OpenDelim(Bracket)}
+//               Ident(as), Ident(where), OpenDelim(Bracket), Nonterminal(Block)}
 macro_rules! follow_ty {
     ($t:ty {}) => {};
     ($t:ty ,) => {};
@@ -39,6 +39,7 @@ macro_rules! follow_ty {
     ($t:ty as) => {};
     ($t:ty where) => {};
     ($t:ty []) => {};
+    ($t:ty $b:block) => {};
 }
 // FOLLOW(stmt) = FOLLOW(expr)
 macro_rules! follow_stmt {
@@ -59,6 +60,7 @@ macro_rules! follow_path {
     ($p:path as) => {};
     ($p:path where) => {};
     ($p:path []) => {};
+    ($p:path $b:block) => {};
 }
 // FOLLOW(block) = any token
 macro_rules! follow_block {


### PR DESCRIPTION
Adds `:block` to the follow set for `:ty` and `:path`. See rust-lang/rfcs#1494.
