### PR TITLE
trans: always register an item's symbol, even if duplicated.

### DIFF
--- a/src/librustc_trans/callee.rs
+++ b/src/librustc_trans/callee.rs
@@ -582,14 +582,18 @@ fn get_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
         debug!("get_fn: not casting pointer!");
 
         attributes::from_fn_attrs(ccx, attrs, llfn);
-        if let Some(id) = local_item {
+        if local_item.is_some() {
             // FIXME(eddyb) Doubt all extern fn should allow unwinding.
             attributes::unwind(llfn, true);
-            ccx.item_symbols().borrow_mut().insert(id, sym);
         }
 
         llfn
     };
+
+    // Always insert into item_symbols, in case this item is exported.
+    if let Some(id) = local_item {
+        ccx.item_symbols().borrow_mut().insert(id, sym);
+    }
 
     ccx.instances().borrow_mut().insert(instance, llfn);
 

--- a/src/test/auxiliary/foreign_lib.rs
+++ b/src/test/auxiliary/foreign_lib.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![crate_name="foreign_lib"]
+
 #![feature(libc)]
 
 pub mod rustrt {
@@ -17,5 +18,31 @@ pub mod rustrt {
     #[link(name = "rust_test_helpers")]
     extern {
         pub fn rust_get_test_int() -> libc::intptr_t;
+    }
+}
+
+pub mod rustrt2 {
+    extern crate libc;
+
+    extern {
+        pub fn rust_get_test_int() -> libc::intptr_t;
+    }
+}
+
+pub mod rustrt3 {
+    // Different type, but same ABI (on all supported platforms).
+    // Ensures that we don't ICE or trigger LLVM asserts when
+    // importing the same symbol under different types.
+    // See https://github.com/rust-lang/rust/issues/32740.
+    extern {
+        pub fn rust_get_test_int() -> *const u8;
+    }
+}
+
+pub fn local_uses() {
+    unsafe {
+        let x = rustrt::rust_get_test_int();
+        assert_eq!(x, rustrt2::rust_get_test_int());
+        assert_eq!(x as *const _, rustrt3::rust_get_test_int());
     }
 }

--- a/src/test/run-pass/foreign-dupe.rs
+++ b/src/test/run-pass/foreign-dupe.rs
@@ -8,41 +8,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// calling pin_thread and that's having weird side-effects.
+// aux-build:foreign_lib.rs
 
-#![feature(libc)]
+// Check that we can still call duplicated extern (imported) functions
+// which were declared in another crate. See issues #32740 and #32783.
 
-mod rustrt1 {
-    extern crate libc;
 
-    #[link(name = "rust_test_helpers")]
-    extern {
-        pub fn rust_get_test_int() -> libc::intptr_t;
-    }
-}
-
-mod rustrt2 {
-    extern crate libc;
-
-    extern {
-        pub fn rust_get_test_int() -> libc::intptr_t;
-    }
-}
-
-mod rustrt3 {
-    // Different type, but same ABI (on all supported platforms).
-    // Ensures that we don't ICE or trigger LLVM asserts when
-    // importing the same symbol under different types.
-    // See https://github.com/rust-lang/rust/issues/32740.
-    extern {
-        pub fn rust_get_test_int() -> *const u8;
-    }
-}
+extern crate foreign_lib;
 
 pub fn main() {
     unsafe {
-        let x = rustrt1::rust_get_test_int();
-        assert_eq!(x, rustrt2::rust_get_test_int());
-        assert_eq!(x as *const _, rustrt3::rust_get_test_int());
+        let x = foreign_lib::rustrt::rust_get_test_int();
+        assert_eq!(x, foreign_lib::rustrt2::rust_get_test_int());
+        assert_eq!(x as *const _, foreign_lib::rustrt3::rust_get_test_int());
     }
 }


### PR DESCRIPTION
Fixes #32783 which was introduced by not always registering item symbols in #32742.
