### PR TITLE
Add `contains` to `VecDeque` and `LinkedList` (+ tests)

### DIFF
--- a/src/libcollections/linked_list.rs
+++ b/src/libcollections/linked_list.rs
@@ -401,6 +401,16 @@ impl<T> LinkedList<T> {
         *self = LinkedList::new()
     }
 
+    /// Returns `true` if the `LinkedList` contains an element equal to the
+    /// given value.
+    #[unstable(feature = "linked_list_contains", reason = "recently added",
+               issue = "32630")]
+    pub fn contains(&self, x: &T) -> bool
+        where T: PartialEq<T>
+    {
+        self.iter().any(|e| e == x)
+    }
+
     /// Provides a reference to the front element, or `None` if the list is
     /// empty.
     ///

--- a/src/libcollections/vec_deque.rs
+++ b/src/libcollections/vec_deque.rs
@@ -872,6 +872,17 @@ impl<T> VecDeque<T> {
         self.drain(..);
     }
 
+    /// Returns `true` if the `VecDeque` contains an element equal to the
+    /// given value.
+    #[unstable(feature = "vec_deque_contains", reason = "recently added",
+               issue = "32630")]
+    pub fn contains(&self, x: &T) -> bool
+        where T: PartialEq<T>
+    {
+        let (a, b) = self.as_slices();
+        a.contains(x) || b.contains(x)
+    }
+
     /// Provides a reference to the front element, or `None` if the sequence is
     /// empty.
     ///

--- a/src/libcollectionstest/lib.rs
+++ b/src/libcollectionstest/lib.rs
@@ -21,6 +21,7 @@
 #![feature(fn_traits)]
 #![feature(enumset)]
 #![feature(iter_arith)]
+#![feature(linked_list_contains)]
 #![feature(map_entry_keys)]
 #![feature(map_values_mut)]
 #![feature(pattern)]
@@ -32,6 +33,7 @@
 #![feature(test)]
 #![feature(unboxed_closures)]
 #![feature(unicode)]
+#![feature(vec_deque_contains)]
 
 extern crate collections;
 extern crate test;

--- a/src/libcollectionstest/linked_list.rs
+++ b/src/libcollectionstest/linked_list.rs
@@ -413,3 +413,16 @@ fn bench_iter_mut_rev(b: &mut test::Bencher) {
         assert!(m.iter_mut().rev().count() == 128);
     })
 }
+
+#[test]
+fn test_contains() {
+    let mut l = LinkedList::new();
+    l.extend(&[2, 3, 4]);
+
+    assert!(l.contains(&3));
+    assert!(!l.contains(&1));
+
+    l.clear();
+
+    assert!(!l.contains(&3));
+}

--- a/src/libcollectionstest/vec_deque.rs
+++ b/src/libcollectionstest/vec_deque.rs
@@ -959,3 +959,16 @@ fn test_extend_ref() {
     assert_eq!(v[4], 5);
     assert_eq!(v[5], 6);
 }
+
+#[test]
+fn test_contains() {
+    let mut v = VecDeque::new();
+    v.extend(&[2, 3, 4]);
+
+    assert!(v.contains(&3));
+    assert!(!v.contains(&1));
+
+    v.clear();
+
+    assert!(!v.contains(&3));
+}


### PR DESCRIPTION
This implements [RFC 1552](https://github.com/rust-lang/rfcs/blob/master/text/1552-contains-method-for-various-collections.md). Tracking issue: #32630 

Sorry for the late response. This is my first contribution, so please tell me if anything isn't optimal!
