### PR TITLE
Get all (but one) of debuginfo tests to pass with MIR codegen.

### DIFF
--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -52,6 +52,10 @@ pub struct Mir<'tcx> {
     /// through the resulting reference.
     pub temp_decls: Vec<TempDecl<'tcx>>,
 
+    /// Names and capture modes of all the closure upvars, assuming
+    /// the first argument is either the closure or a reference to it.
+    pub upvar_decls: Vec<UpvarDecl>,
+
     /// A span representing this MIR, for error reporting
     pub span: Span,
 }
@@ -197,7 +201,20 @@ pub struct ArgDecl<'tcx> {
 
     /// If true, this argument is a tuple after monomorphization,
     /// and has to be collected from multiple actual arguments.
-    pub spread: bool
+    pub spread: bool,
+
+    /// Either special_idents::invalid or the name of a single-binding
+    /// pattern associated with this argument. Useful for debuginfo.
+    pub debug_name: Name
+}
+
+/// A closure capture, with its name and mode.
+#[derive(Clone, Debug, RustcEncodable, RustcDecodable)]
+pub struct UpvarDecl {
+    pub debug_name: Name,
+
+    /// If true, the capture is behind a reference.
+    pub by_ref: bool
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -248,6 +248,7 @@ macro_rules! make_mir_visitor {
                     ref $($mutability)* var_decls,
                     ref $($mutability)* arg_decls,
                     ref $($mutability)* temp_decls,
+                    upvar_decls: _,
                     ref $($mutability)* span,
                 } = *mir;
 
@@ -599,7 +600,8 @@ macro_rules! make_mir_visitor {
                               arg_decl: & $($mutability)* ArgDecl<'tcx>) {
                 let ArgDecl {
                     ref $($mutability)* ty,
-                    spread: _
+                    spread: _,
+                    debug_name: _
                 } = *arg_decl;
 
                 self.visit_ty(ty);

--- a/src/test/debuginfo/associated-types.rs
+++ b/src/test/debuginfo/associated-types.rs
@@ -80,7 +80,7 @@
 
 #![allow(unused_variables)]
 #![allow(dead_code)]
-#![feature(omit_gdb_pretty_printer_section, rustc_attrs)]
+#![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
 trait TraitWithAssocType {
@@ -127,7 +127,6 @@ fn assoc_tuple<T: TraitWithAssocType>(arg: (T, T::Type)) {
     zzz(); // #break
 }
 
-#[rustc_no_mir] // FIXME(#32790) MIR reuses scopes for match arms.
 fn assoc_enum<T: TraitWithAssocType>(arg: Enum<T>) {
 
     match arg {

--- a/src/test/debuginfo/function-prologue-stepping-no-stack-check.rs
+++ b/src/test/debuginfo/function-prologue-stepping-no-stack-check.rs
@@ -251,7 +251,7 @@
 #![omit_gdb_pretty_printer_section]
 
 #[no_stack_check]
-#[rustc_no_mir] // FIXME(#31005) MIR debuginfo is missing argument names.
+#[rustc_no_mir] // FIXME(#32949) MIR debuginfo shadows arguments with uninit vars.
 fn immediate_args(a: isize, b: bool, c: f64) {
     println!("");
 }
@@ -268,51 +268,51 @@ struct BigStruct {
 }
 
 #[no_stack_check]
-#[rustc_no_mir] // FIXME(#31005) MIR debuginfo is missing argument names.
+#[rustc_no_mir] // FIXME(#32949) MIR debuginfo shadows arguments with uninit vars.
 fn non_immediate_args(a: BigStruct, b: BigStruct) {
     println!("");
 }
 
 #[no_stack_check]
-#[rustc_no_mir] // FIXME(#31005) MIR debuginfo is missing argument names.
+#[rustc_no_mir] // FIXME(#32949) MIR debuginfo shadows arguments with uninit vars.
 fn binding(a: i64, b: u64, c: f64) {
     let x = 0;
     println!("");
 }
 
 #[no_stack_check]
-#[rustc_no_mir] // FIXME(#31005) MIR debuginfo is missing argument names.
+#[rustc_no_mir] // FIXME(#32949) MIR debuginfo shadows arguments with uninit vars.
 fn assignment(mut a: u64, b: u64, c: f64) {
     a = b;
     println!("");
 }
 
 #[no_stack_check]
-#[rustc_no_mir] // FIXME(#31005) MIR debuginfo is missing argument names.
+#[rustc_no_mir] // FIXME(#32949) MIR debuginfo shadows arguments with uninit vars.
 fn function_call(x: u64, y: u64, z: f64) {
     println!("Hi!")
 }
 
 #[no_stack_check]
-#[rustc_no_mir] // FIXME(#31005) MIR debuginfo is missing argument names.
+#[rustc_no_mir] // FIXME(#32949) MIR debuginfo shadows arguments with uninit vars.
 fn identifier(x: u64, y: u64, z: f64) -> u64 {
     x
 }
 
 #[no_stack_check]
-#[rustc_no_mir] // FIXME(#31005) MIR debuginfo is missing argument names.
+#[rustc_no_mir] // FIXME(#32949) MIR debuginfo shadows arguments with uninit vars.
 fn return_expr(x: u64, y: u64, z: f64) -> u64 {
     return x;
 }
 
 #[no_stack_check]
-#[rustc_no_mir] // FIXME(#31005) MIR debuginfo is missing argument names.
+#[rustc_no_mir] // FIXME(#32949) MIR debuginfo shadows arguments with uninit vars.
 fn arithmetic_expr(x: u64, y: u64, z: f64) -> u64 {
     x + y
 }
 
 #[no_stack_check]
-#[rustc_no_mir] // FIXME(#31005) MIR debuginfo is missing argument names.
+#[rustc_no_mir] // FIXME(#32949) MIR debuginfo shadows arguments with uninit vars.
 fn if_expr(x: u64, y: u64, z: f64) -> u64 {
     if x + y < 1000 {
         x
@@ -322,7 +322,7 @@ fn if_expr(x: u64, y: u64, z: f64) -> u64 {
 }
 
 #[no_stack_check]
-#[rustc_no_mir] // FIXME(#31005) MIR debuginfo is missing argument names.
+#[rustc_no_mir] // FIXME(#32949) MIR debuginfo shadows arguments with uninit vars.
 fn while_expr(mut x: u64, y: u64, z: u64) -> u64 {
     while x + y < 1000 {
         x += z
@@ -331,7 +331,7 @@ fn while_expr(mut x: u64, y: u64, z: u64) -> u64 {
 }
 
 #[no_stack_check]
-#[rustc_no_mir] // FIXME(#31005) MIR debuginfo is missing argument names.
+#[rustc_no_mir] // FIXME(#32949) MIR debuginfo shadows arguments with uninit vars.
 fn loop_expr(mut x: u64, y: u64, z: u64) -> u64 {
     loop {
         x += z;

--- a/src/test/debuginfo/no-debug-attribute.rs
+++ b/src/test/debuginfo/no-debug-attribute.rs
@@ -23,20 +23,22 @@
 // gdb-command:continue
 
 #![allow(unused_variables)]
-#![feature(no_debug, rustc_attrs)]
+#![feature(no_debug)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
-#[rustc_no_mir] // FIXME(#31005) MIR debuginfo is inaccurate for returns.
+#[inline(never)]
+fn id<T>(x: T) -> T {x}
+
 fn function_with_debuginfo() {
     let abc = 10_usize;
-    return (); // #break
+    id(abc); // #break
 }
 
 #[no_debug]
 fn function_without_debuginfo() {
     let abc = -57i32;
-    return (); // #break
+    id(abc); // #break
 }
 
 fn main() {

--- a/src/test/debuginfo/var-captured-in-nested-closure.rs
+++ b/src/test/debuginfo/var-captured-in-nested-closure.rs
@@ -78,7 +78,7 @@
 // lldb-command:continue
 
 #![allow(unused_variables)]
-#![feature(box_syntax, rustc_attrs, stmt_expr_attributes)]
+#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
@@ -88,7 +88,6 @@ struct Struct {
     c: usize
 }
 
-#[rustc_no_mir] // FIXME(#31005) MIR debuginfo is missing captures.
 fn main() {
     let mut variable = 1;
     let constant = 2;
@@ -102,14 +101,10 @@ fn main() {
     let struct_ref = &a_struct;
     let owned: Box<_> = box 6;
 
-    let mut closure =
-    #[rustc_no_mir] // FIXME(#31005) MIR debuginfo is missing captures.
-    || {
+    let mut closure = || {
         let closure_local = 8;
 
-        let mut nested_closure =
-        #[rustc_no_mir] // FIXME(#31005) MIR debuginfo is missing captures.
-        || {
+        let mut nested_closure = || {
             zzz(); // #break
             variable = constant + a_struct.a + struct_ref.a + *owned + closure_local;
         };

--- a/src/test/debuginfo/var-captured-in-sendable-closure.rs
+++ b/src/test/debuginfo/var-captured-in-sendable-closure.rs
@@ -40,7 +40,7 @@
 // lldb-check:[...]$2 = 5
 
 #![allow(unused_variables)]
-#![feature(unboxed_closures, box_syntax, rustc_attrs, stmt_expr_attributes)]
+#![feature(unboxed_closures, box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
@@ -50,7 +50,6 @@ struct Struct {
     c: usize
 }
 
-#[rustc_no_mir] // FIXME(#31005) MIR debuginfo is missing captures.
 fn main() {
     let constant = 1;
 
@@ -62,9 +61,7 @@ fn main() {
 
     let owned: Box<_> = box 5;
 
-    let closure =
-    #[rustc_no_mir] // FIXME(#31005) MIR debuginfo is missing captures.
-    move || {
+    let closure = move || {
         zzz(); // #break
         do_something(&constant, &a_struct.a, &*owned);
     };
@@ -76,9 +73,7 @@ fn main() {
     // The `self` argument of the following closure should be passed by value
     // to FnOnce::call_once(self, args), which gets translated a bit differently
     // than the regular case. Let's make sure this is supported too.
-    let immedate_env =
-    #[rustc_no_mir] // FIXME(#31005) MIR debuginfo is missing captures.
-    move || {
+    let immedate_env = move || {
         zzz(); // #break
         return constant2;
     };

--- a/src/test/debuginfo/var-captured-in-stack-closure.rs
+++ b/src/test/debuginfo/var-captured-in-stack-closure.rs
@@ -69,7 +69,7 @@
 // lldb-command:print *owned
 // lldb-check:[...]$9 = 6
 
-#![feature(unboxed_closures, box_syntax, rustc_attrs, stmt_expr_attributes)]
+#![feature(unboxed_closures, box_syntax)]
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
@@ -80,7 +80,6 @@ struct Struct {
     c: usize
 }
 
-#[rustc_no_mir] // FIXME(#31005) MIR debuginfo is missing captures.
 fn main() {
     let mut variable = 1;
     let constant = 2;
@@ -95,9 +94,7 @@ fn main() {
     let owned: Box<_> = box 6;
 
     {
-        let mut first_closure =
-        #[rustc_no_mir] // FIXME(#31005) MIR debuginfo is missing captures.
-        || {
+        let mut first_closure = || {
             zzz(); // #break
             variable = constant + a_struct.a + struct_ref.a + *owned;
         };
@@ -106,9 +103,7 @@ fn main() {
     }
 
     {
-        let mut second_closure =
-        #[rustc_no_mir] // FIXME(#31005) MIR debuginfo is missing captures.
-        || {
+        let mut second_closure = || {
             zzz(); // #break
             variable = constant + a_struct.a + struct_ref.a + *owned;
         };


### PR DESCRIPTION
I didn't get much feedback in #31005 so I went ahead and implemented something simple.
Closes #31005, as MIR debuginfo should work now for most usecases.
#32949 tracks remaining shadowing problems that break `function-prologue-stepping-no-stack-check`.

The `no-debug-attribute` test no longer assumes variables are in scope of `return`.
We might also want to revisit that in #32949, but the test is more reliable now either way.

In order to get one last function in the `associated-type` test pass, this PR also fixes #32790.
