### PR TITLE
cargotest: Put output in build directory

### DIFF
--- a/src/bootstrap/build/check.rs
+++ b/src/bootstrap/build/check.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::fs;
+
 use build::{Build, Compiler};
 
 pub fn linkcheck(build: &Build, stage: u32, host: &str) {
@@ -29,9 +31,16 @@ pub fn cargotest(build: &Build, stage: u32, host: &str) {
     let sep = if cfg!(windows) { ";" } else {":" };
     let ref newpath = format!("{}{}{}", path.display(), sep, old_path);
 
+    // Note that this is a short, cryptic, and not scoped directory name. This
+    // is currently to minimize the length of path on Windows where we otherwise
+    // quickly run into path name limit constraints.
+    let out_dir = build.out.join("ct");
+    t!(fs::create_dir_all(&out_dir));
+
     build.run(build.tool_cmd(compiler, "cargotest")
-              .env("PATH", newpath)
-              .arg(&build.cargo));
+                   .env("PATH", newpath)
+                   .arg(&build.cargo)
+                   .arg(&out_dir));
 }
 
 pub fn tidy(build: &Build, stage: u32, host: &str) {

--- a/src/bootstrap/build/step.rs
+++ b/src/bootstrap/build/step.rs
@@ -318,7 +318,8 @@ impl<'a> Step<'a> {
                 vec![self.tool_linkchecker(stage), self.doc(stage)]
             }
             Source::CheckCargoTest { stage } => {
-                vec![self.tool_cargotest(stage)]
+                vec![self.tool_cargotest(stage),
+                     self.librustc(self.compiler(stage))]
             }
             Source::CheckTidy { stage } => {
                 vec![self.tool_tidy(stage)]
@@ -333,7 +334,7 @@ impl<'a> Step<'a> {
                 vec![self.librustc(self.compiler(stage))]
             }
             Source::ToolCargoTest { stage } => {
-                vec![self.librustc(self.compiler(stage))]
+                vec![self.libstd(self.compiler(stage))]
             }
 
             Source::DistDocs { stage } => vec![self.doc(stage)],

--- a/src/rustc/Cargo.lock
+++ b/src/rustc/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
  "rbml 0.0.0",
  "rustc_back 0.0.0",
  "rustc_bitflags 0.0.0",
- "rustc_const_eval 0.0.0",
+ "rustc_const_math 0.0.0",
  "rustc_data_structures 0.0.0",
  "serialize 0.0.0",
  "syntax 0.0.0",
@@ -107,6 +107,19 @@ dependencies = [
 name = "rustc_const_eval"
 version = "0.0.0"
 dependencies = [
+ "graphviz 0.0.0",
+ "log 0.0.0",
+ "rustc 0.0.0",
+ "rustc_back 0.0.0",
+ "rustc_const_math 0.0.0",
+ "serialize 0.0.0",
+ "syntax 0.0.0",
+]
+
+[[package]]
+name = "rustc_const_math"
+version = "0.0.0"
+dependencies = [
  "log 0.0.0",
  "serialize 0.0.0",
  "syntax 0.0.0",
@@ -131,6 +144,8 @@ dependencies = [
  "rustc 0.0.0",
  "rustc_back 0.0.0",
  "rustc_borrowck 0.0.0",
+ "rustc_const_eval 0.0.0",
+ "rustc_incremental 0.0.0",
  "rustc_lint 0.0.0",
  "rustc_llvm 0.0.0",
  "rustc_metadata 0.0.0",
@@ -148,12 +163,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_incremental"
+version = "0.0.0"
+dependencies = [
+ "graphviz 0.0.0",
+ "log 0.0.0",
+ "rbml 0.0.0",
+ "rustc 0.0.0",
+ "rustc_data_structures 0.0.0",
+ "serialize 0.0.0",
+ "syntax 0.0.0",
+]
+
+[[package]]
 name = "rustc_lint"
 version = "0.0.0"
 dependencies = [
  "log 0.0.0",
  "rustc 0.0.0",
  "rustc_back 0.0.0",
+ "rustc_const_eval 0.0.0",
  "syntax 0.0.0",
 ]
 
@@ -176,7 +205,7 @@ dependencies = [
  "rustc 0.0.0",
  "rustc_back 0.0.0",
  "rustc_bitflags 0.0.0",
- "rustc_const_eval 0.0.0",
+ "rustc_const_math 0.0.0",
  "rustc_llvm 0.0.0",
  "serialize 0.0.0",
  "syntax 0.0.0",
@@ -191,6 +220,7 @@ dependencies = [
  "rustc 0.0.0",
  "rustc_back 0.0.0",
  "rustc_const_eval 0.0.0",
+ "rustc_const_math 0.0.0",
  "rustc_data_structures 0.0.0",
  "syntax 0.0.0",
 ]
@@ -201,6 +231,7 @@ version = "0.0.0"
 dependencies = [
  "log 0.0.0",
  "rustc 0.0.0",
+ "rustc_const_eval 0.0.0",
  "syntax 0.0.0",
 ]
 
@@ -247,7 +278,6 @@ version = "0.0.0"
 dependencies = [
  "log 0.0.0",
  "rustc 0.0.0",
- "rustc_front 0.0.0",
  "syntax 0.0.0",
 ]
 
@@ -262,7 +292,9 @@ dependencies = [
  "rustc 0.0.0",
  "rustc_back 0.0.0",
  "rustc_const_eval 0.0.0",
+ "rustc_const_math 0.0.0",
  "rustc_data_structures 0.0.0",
+ "rustc_incremental 0.0.0",
  "rustc_llvm 0.0.0",
  "rustc_mir 0.0.0",
  "rustc_platform_intrinsics 0.0.0",
@@ -280,6 +312,7 @@ dependencies = [
  "rustc 0.0.0",
  "rustc_back 0.0.0",
  "rustc_const_eval 0.0.0",
+ "rustc_const_math 0.0.0",
  "rustc_platform_intrinsics 0.0.0",
  "syntax 0.0.0",
 ]
@@ -294,6 +327,7 @@ dependencies = [
  "log 0.0.0",
  "rustc 0.0.0",
  "rustc_back 0.0.0",
+ "rustc_const_eval 0.0.0",
  "rustc_driver 0.0.0",
  "rustc_lint 0.0.0",
  "rustc_metadata 0.0.0",

--- a/src/tools/cargotest/Cargo.lock
+++ b/src/tools/cargotest/Cargo.lock
@@ -1,28 +1,4 @@
 [root]
 name = "cargotest"
 version = "0.1.0"
-dependencies = [
- "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "libc"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "rand"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 

--- a/src/tools/cargotest/Cargo.toml
+++ b/src/tools/cargotest/Cargo.toml
@@ -3,9 +3,6 @@ name = "cargotest"
 version = "0.1.0"
 authors = ["Brian Anderson <banderson@mozilla.com>"]
 
-[dependencies]
-tempdir = "0.3.4"
-
 [[bin]]
 name = "cargotest"
 path = "main.rs"


### PR DESCRIPTION
Right now cargotest uses `TempDir` to place output into the system temp
directory, but unfortunately this means that if the process is interrupted then
it'll leak the directory and that'll never get cleaned up. One of our bots
filled up its disk space and there were 20 cargotest directories lying around so
seems prudent to clean them up!

By putting the output in the build directory it should ensure that we don't leak
too many extra builds.
