### PR TITLE
std: Change String::truncate to panic less

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -992,10 +992,12 @@ impl String {
 
     /// Shortens this `String` to the specified length.
     ///
+    /// If `new_len` is greater than the string's current length, this has no
+    /// effect.
+    ///
     /// # Panics
     ///
-    /// Panics if `new_len` > current length, or if `new_len` does not lie on a
-    /// [`char`] boundary.
+    /// Panics if `new_len` does not lie on a [`char`] boundary.
     ///
     /// [`char`]: ../../std/primitive.char.html
     ///
@@ -1013,8 +1015,10 @@ impl String {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn truncate(&mut self, new_len: usize) {
-        assert!(self.is_char_boundary(new_len));
-        self.vec.truncate(new_len)
+        if new_len <= self.len() {
+            assert!(self.is_char_boundary(new_len));
+            self.vec.truncate(new_len)
+        }
     }
 
     /// Removes the last character from the string buffer and returns it.

--- a/src/libcollectionstest/string.rs
+++ b/src/libcollectionstest/string.rs
@@ -248,10 +248,10 @@ fn test_str_truncate() {
 }
 
 #[test]
-#[should_panic]
 fn test_str_truncate_invalid_len() {
     let mut s = String::from("12345");
     s.truncate(6);
+    assert_eq!(s, "12345");
 }
 
 #[test]


### PR DESCRIPTION
The `Vec::truncate` method does not panic if the length argument is greater than
the vector's current length, but `String::truncate` will indeed panic. This
semantic difference can be a bit jarring (e.g. #32717), and after some
discussion the libs team concluded that although this can technically be a
breaking change it is almost undoubtedly not so in practice.

This commit changes the semantics of `String::truncate` to be a noop if
`new_len` is greater than the length of the current string.

Closes #32717
