### PR TITLE
Expose target options via JSON

### DIFF
--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -169,6 +169,7 @@ pub struct Target {
 ///
 /// This has an implementation of `Default`, see each field for what the default is. In general,
 /// these try to take "minimal defaults" that don't assume anything about the runtime they run in.
+/// Fields added here must be added to `Target::from_json()`
 #[derive(Clone, Debug)]
 pub struct TargetOptions {
     /// [Data layout](http://llvm.org/docs/LangRef.html#data-layout) to pass to LLVM.

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -415,36 +415,47 @@ impl Target {
             } );
         }
 
-        key!(cpu);
-        key!(ar);
+        key!(data_layout, optional);
         key!(linker);
+        key!(ar);
+        key!(pre_link_args, list);
+        key!(post_link_args, list);
+        key!(cpu);
+        key!(features);
+        key!(dynamic_linking, bool);
+        key!(executables, bool);
         key!(relocation_model);
         key!(code_model);
+        key!(disable_redzone, bool);
+        key!(eliminate_frame_pointer, bool);
+        key!(function_sections, bool);
         key!(dll_prefix);
         key!(dll_suffix);
         key!(exe_suffix);
         key!(staticlib_prefix);
         key!(staticlib_suffix);
-        key!(features);
-        key!(data_layout, optional);
-        key!(dynamic_linking, bool);
-        key!(executables, bool);
-        key!(disable_redzone, bool);
-        key!(eliminate_frame_pointer, bool);
-        key!(function_sections, bool);
         key!(target_family, optional);
         key!(is_like_osx, bool);
+        key!(is_like_solaris, bool);
         key!(is_like_windows, bool);
+        key!(is_like_android, bool);
         key!(is_like_msvc, bool);
         key!(linker_is_gnu, bool);
         key!(has_rpath, bool);
         key!(no_compiler_rt, bool);
         key!(no_default_libraries, bool);
-        key!(pre_link_args, list);
-        key!(post_link_args, list);
+        key!(position_independent_executables, bool);
+        key!(pre_link_objects_exe, list);
+        key!(pre_link_objects_dll, list);
+        key!(post_link_objects, list);
+        key!(late_link_args, list);
         key!(archive_format);
-        key!(allow_asm, bool);
         key!(custom_unwind_resume, bool);
+        key!(lib_allocation_crate);
+        key!(exe_allocation_crate);
+        key!(allow_asm, bool);
+        key!(has_elf_tls, bool);
+        key!(obj_is_bitcode, bool);
 
         base
     }


### PR DESCRIPTION
A number of target options are not exposed via JSON. This updates the code to keep it in sync and re-orders the list to match the default implementation to hopefully make it easier for people to inspect to make sure items are not missing.
