### PR TITLE
alloc_system: Handle failure properly

### DIFF
--- a/src/liballoc_system/lib.rs
+++ b/src/liballoc_system/lib.rs
@@ -96,8 +96,10 @@ mod imp {
             libc::realloc(ptr as *mut libc::c_void, size as libc::size_t) as *mut u8
         } else {
             let new_ptr = allocate(size, align);
-            ptr::copy(ptr, new_ptr, cmp::min(size, old_size));
-            deallocate(ptr, old_size, align);
+            if !new_ptr.is_null() {
+                ptr::copy(ptr, new_ptr, cmp::min(size, old_size));
+                deallocate(ptr, old_size, align);
+            }
             new_ptr
         }
     }


### PR DESCRIPTION
The Unix implementation was incorrectly handling failure for reallocation of
over-aligned types by not checking for NULL.

Closes #32993
