### PR TITLE
grammar: fix

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -140,9 +140,9 @@ Cargo
 Performance
 -----------
 
-* [During type unification, the complexity of comparing variables for
-  equivalance was reduced from `O(n!)` to `O(n)`][1.9tu]. This leads
-  to major compile-time improvements in some scenarios.
+* [The complexity of comparing variables for equivalence during type 
+  unification is reduced from O(n!) to O(n)[1.9tu]. This leads
+  to major compilation time improvement in some scenarios.
 * [`ToString` is specialized for `str`, giving it the same performance
   as `to_owned`][1.9ts].
 * [Spawning processes with `Command::output` no longer creates extra

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -141,7 +141,7 @@ Performance
 -----------
 
 * [The complexity of comparing variables for equivalence during type 
-  unification is reduced from O(n!) to O(n)[1.9tu]. This leads
+  unification is reduced from _O_(_n_!) to _O_(_n_)][1.9tu]. This leads
   to major compilation time improvement in some scenarios.
 * [`ToString` is specialized for `str`, giving it the same performance
   as `to_owned`][1.9ts].

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -140,7 +140,7 @@ Cargo
 Performance
 -----------
 
-* [The complexity of comparing variables for equivalence during type 
+* [The time complexity of comparing variables for equivalence during type 
   unification is reduced from _O_(_n_!) to _O_(_n_)][1.9tu]. This leads
   to major compilation time improvement in some scenarios.
 * [`ToString` is specialized for `str`, giving it the same performance


### PR DESCRIPTION
Reading this, one item stood out a bit. Small improvements here.
1. ‘Compile-time’ is not a noun, ‘compilation time’ was meant;
2. Mathematical formulas are best not rendered as code;
3. Use the same tense as in other items.
