### PR TITLE
rustbuild: Package librustc & co for cross-hosts

### DIFF
--- a/src/bootstrap/build/step.rs
+++ b/src/bootstrap/build/step.rs
@@ -343,7 +343,14 @@ impl<'a> Step<'a> {
                 vec![self.rustc(stage)]
             }
             Source::DistStd { compiler } => {
-                vec![self.libtest(compiler)]
+                // We want to package up as many target libraries as possible
+                // for the `rust-std` package, so if this is a host target we
+                // depend on librustc and otherwise we just depend on libtest.
+                if build.config.host.iter().any(|t| t == self.target) {
+                    vec![self.librustc(compiler)]
+                } else {
+                    vec![self.libtest(compiler)]
+                }
             }
 
             Source::Dist { stage } => {


### PR DESCRIPTION
Currently the `rust-std` package produced by rustbuild only contains the
standard library plus libtest, but the makefiles actually produce a `rust-std`
package with all known target libraries (including libsyntax, librustc, etc).
Tweak the behavior so the dependencies of the `dist-docs` step in rustbuild
depend on the compiler libraries as well (so that they're all packaged).

Closes #32984
