### PR TITLE
List possible keys of the -L rustc option.

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -889,8 +889,9 @@ pub fn rustc_short_optgroups() -> Vec<RustcOptGroup> {
     vec![
         opt::flag_s("h", "help", "Display this message"),
         opt::multi_s("", "cfg", "Configure the compilation environment", "SPEC"),
-        opt::multi_s("L", "",   "Add a directory to the library search path",
-                   "[KIND=]PATH"),
+        opt::multi_s("L", "",   "Add a directory to the library search path. The
+                             optional KIND can be one of dependency, crate, native,
+                             framework or all (the default).", "[KIND=]PATH"),
         opt::multi_s("l", "",   "Link the generated crate(s) to the specified native
                              library NAME. The optional KIND can be one of
                              static, dylib, or framework. If omitted, dylib is


### PR DESCRIPTION
Since `rustc --help -v` does not describe it, only _rustc.1_ man page, but there is no man for Windows.

r? @alexcrichton 
cc @steveklabnik 
