### PR TITLE
Fix link to BtreeMap doc

### DIFF
--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -33,8 +33,7 @@ use Bound;
 /// It is a logic error for an item to be modified in such a way that the item's ordering relative
 /// to any other item, as determined by the [`Ord`] trait, changes while it is in the set. This is
 /// normally only possible through [`Cell`], [`RefCell`], global state, I/O, or unsafe code.
-///
-/// [`BTreeMap`]: struct.BTreeMap.html
+/// [`BTreeMap`]: ../struct.BTreeMap.html
 /// [`Ord`]: ../../std/cmp/trait.Ord.html
 /// [`Cell`]: ../../std/cell/struct.Cell.html
 /// [`RefCell`]: ../../std/cell/struct.RefCell.html


### PR DESCRIPTION
Currently the link to BtreeMap on
http://doc.rust-lang.org/std/collections/struct.BTreeSet.html is broken

I think this is due to a missing `./`

However, I have been unable to test if this change solves the problem.
running `rustdoc` on this file generates a ton of compiler errors. And
running `make doc` results in `make: *** No rule to make target`doc'.
Stop.`

I'm likely doing something wrong, but those are the two ways that the
Contributing doc suggests that I build the docs.
