### PR TITLE
MIR: Do not require END_BLOCK to always exist

### DIFF
--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -213,13 +213,6 @@ impl BasicBlock {
         BasicBlock(index as u32)
     }
 
-    /// Returns a BasicBlock with index 1. This is actual end block (containing
-    /// the Return terminator) only during the building of MIR and should not be
-    /// used outside that.
-    pub const fn end_block() -> BasicBlock {
-        BasicBlock(1)
-    }
-
     /// Extract the index.
     pub fn index(self) -> usize {
         self.0 as usize

--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -59,9 +59,6 @@ pub struct Mir<'tcx> {
 /// where execution begins
 pub const START_BLOCK: BasicBlock = BasicBlock(0);
 
-/// where execution ends, on normal return
-pub const END_BLOCK: BasicBlock = BasicBlock(1);
-
 impl<'tcx> Mir<'tcx> {
     pub fn all_basic_blocks(&self) -> Vec<BasicBlock> {
         (0..self.basic_blocks.len())
@@ -216,6 +213,13 @@ impl BasicBlock {
         BasicBlock(index as u32)
     }
 
+    /// Returns a BasicBlock with index 1. This is actual end block (containing
+    /// the Return terminator) only during the building of MIR and should not be
+    /// used outside that.
+    pub const fn end_block() -> BasicBlock {
+        BasicBlock(1)
+    }
+
     /// Extract the index.
     pub fn index(self) -> usize {
         self.0 as usize
@@ -305,8 +309,7 @@ pub enum TerminatorKind<'tcx> {
     Resume,
 
     /// Indicates a normal return. The ReturnPointer lvalue should
-    /// have been filled in by now. This should only occur in the
-    /// `END_BLOCK`.
+    /// have been filled in by now. This should occur at most once.
     Return,
 
     /// Drop the Lvalue

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -262,7 +262,8 @@ impl<'a,'tcx> Builder<'a,'tcx> {
                     }
                 };
                 let extent = this.extent_of_return_scope();
-                this.exit_scope(expr_span, extent, block, BasicBlock::end_block());
+                let return_block = this.return_block();
+                this.exit_scope(expr_span, extent, block, return_block);
                 this.cfg.start_new_block().unit()
             }
             ExprKind::Call { ty, fun, args } => {

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -262,7 +262,7 @@ impl<'a,'tcx> Builder<'a,'tcx> {
                     }
                 };
                 let extent = this.extent_of_return_scope();
-                this.exit_scope(expr_span, extent, block, END_BLOCK);
+                this.exit_scope(expr_span, extent, block, BasicBlock::end_block());
                 this.cfg.start_new_block().unit()
             }
             ExprKind::Call { ty, fun, args } => {

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -183,7 +183,8 @@ pub fn construct<'a,'tcx>(hir: Cx<'a,'tcx>,
     };
 
     assert_eq!(builder.cfg.start_new_block(), START_BLOCK);
-    assert_eq!(builder.cfg.start_new_block(), END_BLOCK);
+    let end_block = builder.cfg.start_new_block();
+    assert_eq!(end_block, BasicBlock::end_block());
 
 
     let mut arg_decls = None; // assigned to `Some` in closures below
@@ -205,11 +206,10 @@ pub fn construct<'a,'tcx>(hir: Cx<'a,'tcx>,
         }));
 
         builder.cfg.terminate(block, call_site_scope_id, span,
-                              TerminatorKind::Goto { target: END_BLOCK });
-        builder.cfg.terminate(END_BLOCK, call_site_scope_id, span,
+                              TerminatorKind::Goto { target: end_block });
+        builder.cfg.terminate(end_block, call_site_scope_id, span,
                               TerminatorKind::Return);
-
-        END_BLOCK.unit()
+        end_block.unit()
     });
 
     assert!(

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -24,23 +24,23 @@ pub struct Builder<'a, 'tcx: 'a> {
 
     fn_span: Span,
 
-    // the current set of scopes, updated as we traverse;
-    // see the `scope` module for more details
+    /// the current set of scopes, updated as we traverse;
+    /// see the `scope` module for more details
     scopes: Vec<scope::Scope<'tcx>>,
 
-    // for each scope, a span of blocks that defines it;
-    // we track these for use in region and borrow checking,
-    // but these are liable to get out of date once optimization
-    // begins. They are also hopefully temporary, and will be
-    // no longer needed when we adopt graph-based regions.
+    ///  for each scope, a span of blocks that defines it;
+    ///  we track these for use in region and borrow checking,
+    ///  but these are liable to get out of date once optimization
+    ///  begins. They are also hopefully temporary, and will be
+    ///  no longer needed when we adopt graph-based regions.
     scope_auxiliary: ScopeAuxiliaryVec,
 
-    // the current set of loops; see the `scope` module for more
-    // details
+    /// the current set of loops; see the `scope` module for more
+    /// details
     loop_scopes: Vec<scope::LoopScope>,
 
-    // the vector of all scopes that we have created thus far;
-    // we track this for debuginfo later
+    /// the vector of all scopes that we have created thus far;
+    /// we track this for debuginfo later
     scope_datas: Vec<ScopeData>,
 
     var_decls: Vec<VarDecl<'tcx>>,
@@ -48,9 +48,11 @@ pub struct Builder<'a, 'tcx: 'a> {
     temp_decls: Vec<TempDecl<'tcx>>,
     unit_temp: Option<Lvalue<'tcx>>,
 
-    // cached block with a RESUME terminator; we create this at the
-    // first panic
+    /// cached block with the RESUME terminator; this is created
+    /// when first set of cleanups are built.
     cached_resume_block: Option<BasicBlock>,
+    /// cached block with the RETURN terminator
+    cached_return_block: Option<BasicBlock>,
 }
 
 struct CFG<'tcx> {
@@ -180,12 +182,10 @@ pub fn construct<'a,'tcx>(hir: Cx<'a,'tcx>,
         var_indices: FnvHashMap(),
         unit_temp: None,
         cached_resume_block: None,
+        cached_return_block: None
     };
 
     assert_eq!(builder.cfg.start_new_block(), START_BLOCK);
-    let end_block = builder.cfg.start_new_block();
-    assert_eq!(end_block, BasicBlock::end_block());
-
 
     let mut arg_decls = None; // assigned to `Some` in closures below
     let call_site_extent =
@@ -205,11 +205,12 @@ pub fn construct<'a,'tcx>(hir: Cx<'a,'tcx>,
             block.unit()
         }));
 
+        let return_block = builder.return_block();
         builder.cfg.terminate(block, call_site_scope_id, span,
-                              TerminatorKind::Goto { target: end_block });
-        builder.cfg.terminate(end_block, call_site_scope_id, span,
+                              TerminatorKind::Goto { target: return_block });
+        builder.cfg.terminate(return_block, call_site_scope_id, span,
                               TerminatorKind::Return);
-        end_block.unit()
+        return_block.unit()
     });
 
     assert!(
@@ -287,6 +288,17 @@ impl<'a,'tcx> Builder<'a,'tcx> {
                 let tmp = self.temp(ty);
                 self.unit_temp = Some(tmp.clone());
                 tmp
+            }
+        }
+    }
+
+    fn return_block(&mut self) -> BasicBlock {
+        match self.cached_return_block {
+            Some(rb) => rb,
+            None => {
+                let rb = self.cfg.start_new_block();
+                self.cached_return_block = Some(rb);
+                rb
             }
         }
     }

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -21,7 +21,6 @@ Rust MIR: a lowered representation of Rust. Also: an experiment!
 #![unstable(feature = "rustc_private", issue = "27812")]
 
 #![feature(box_patterns)]
-#![feature(const_fn)]
 #![feature(rustc_private)]
 #![feature(staged_api)]
 #![feature(question_mark)]

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -21,6 +21,7 @@ Rust MIR: a lowered representation of Rust. Also: an experiment!
 #![unstable(feature = "rustc_private", issue = "27812")]
 
 #![feature(box_patterns)]
+#![feature(const_fn)]
 #![feature(rustc_private)]
 #![feature(staged_api)]
 #![feature(question_mark)]

--- a/src/librustc_mir/transform/remove_dead_blocks.rs
+++ b/src/librustc_mir/transform/remove_dead_blocks.rs
@@ -43,9 +43,8 @@ pub struct RemoveDeadBlocks;
 impl<'tcx> MirPass<'tcx> for RemoveDeadBlocks {
     fn run_pass(&mut self, _: &TyCtxt<'tcx>, _: NodeId, mir: &mut Mir<'tcx>) {
         let mut seen = BitVector::new(mir.basic_blocks.len());
-        // These blocks are always required.
+        // This block is always required.
         seen.insert(START_BLOCK.index());
-        seen.insert(END_BLOCK.index());
 
         let mut worklist = Vec::with_capacity(4);
         worklist.push(START_BLOCK);

--- a/src/librustc_trans/mir/mod.rs
+++ b/src/librustc_trans/mir/mod.rs
@@ -164,8 +164,6 @@ pub fn trans_mir<'blk, 'tcx: 'blk>(fcx: &'blk FunctionContext<'blk, 'tcx>) {
                   .map(|&bb|{
                       if bb == mir::START_BLOCK {
                           fcx.new_block("start", None)
-                      } else if bb == mir::END_BLOCK {
-                          fcx.new_block("end", None)
                       } else {
                           fcx.new_block(&format!("{:?}", bb), None)
                       }


### PR DESCRIPTION
Basically, all this does, is removing restriction for END_BLOCK to exist past the first invocation of RemoveDeadBlocks pass. This way for functions whose CFG does not reach the `END_BLOCK` end up not containing the block.

As far as the implementation goes, I’m not entirely satisfied with the `BasicBlock::end_block`. I had hoped to make `new` a `const fn` and then just have a `const END_BLOCK` private to mir::build, but it turns out that constant functions don’t yet support conditionals nor a way to assert.
