### PR TITLE
Adjust example for error E0225

### DIFF
--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -2717,7 +2717,7 @@ Rust does not currently support this. A simple example that causes this error:
 
 ```compile_fail
 fn main() {
-    let _: Box<std::io::Read+std::io::Write>;
+    let _: Box<std::io::Read + std::io::Write>;
 }
 ```
 
@@ -2727,7 +2727,7 @@ following compiles correctly:
 
 ```
 fn main() {
-    let _: Box<std::io::Read+Copy+Sync>;
+    let _: Box<std::io::Read + Send + Sync>;
 }
 ```
 "##,


### PR DESCRIPTION
Adjust example for error E0225

It's using Copy as a trait object compatible trait, which is not
appropriate, change to use a more typical Read + Send + Sync example.

Also use whitespace around `+`.

This seems appropriate apropos issue #32963 
