### PR TITLE
rustbuild: Clean more as part of `make clean`

### DIFF
--- a/src/bootstrap/build/clean.rs
+++ b/src/bootstrap/build/clean.rs
@@ -19,11 +19,14 @@ pub fn clean(build: &Build) {
         let out = build.out.join(host);
 
         rm_rf(build, &out.join("compiler-rt"));
+        rm_rf(build, &out.join("doc"));
 
         for stage in 0..4 {
             rm_rf(build, &out.join(format!("stage{}", stage)));
             rm_rf(build, &out.join(format!("stage{}-std", stage)));
             rm_rf(build, &out.join(format!("stage{}-rustc", stage)));
+            rm_rf(build, &out.join(format!("stage{}-test", stage)));
+            rm_rf(build, &out.join(format!("stage{}-tools", stage)));
         }
     }
 }


### PR DESCRIPTION
Clean out old documentation as well as the new test/tools directories. Should
prevent a problem that happened this morning where a PR bounced and then it left
docs with "broken links" so all future PRs bounced.
