### PR TITLE
rustdoc: Fix the strip-hidden `ImplStripper`

### DIFF
--- a/src/test/rustdoc/issue-33069.rs
+++ b/src/test/rustdoc/issue-33069.rs
@@ -1,0 +1,20 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub trait Bar {}
+
+#[doc(hidden)]
+pub mod hidden {
+    pub struct Foo;
+}
+
+// @has issue_33069/trait.Bar.html
+// @!has - '//code' 'impl Bar for Foo'
+impl Bar for hidden::Foo {}


### PR DESCRIPTION
Instead of stripping impls which reference _stripped_ items, we keep impls which reference _retained_ items. We do this because when we strip an item we immediately return, and do not recurse into it - leaving the contained items non-stripped from the point of view of the `ImplStripper`.

fixes #33069

r? @alexcrichton 
