### PR TITLE
Make the `Iterator::enumerate` doc example more clear

### DIFF
--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -598,13 +598,13 @@ pub trait Iterator {
     /// # Examples
     ///
     /// ```
-    /// let a = [1, 2, 3];
+    /// let a = ['a', 'b', 'c'];
     ///
     /// let mut iter = a.iter().enumerate();
     ///
-    /// assert_eq!(iter.next(), Some((0, &1)));
-    /// assert_eq!(iter.next(), Some((1, &2)));
-    /// assert_eq!(iter.next(), Some((2, &3)));
+    /// assert_eq!(iter.next(), Some((0, &'a')));
+    /// assert_eq!(iter.next(), Some((1, &'b')));
+    /// assert_eq!(iter.next(), Some((2, &'c')));
     /// assert_eq!(iter.next(), None);
     /// ```
     #[inline]
@@ -2109,4 +2109,3 @@ impl<'a, I: Iterator + ?Sized> Iterator for &'a mut I {
     fn next(&mut self) -> Option<I::Item> { (**self).next() }
     fn size_hint(&self) -> (usize, Option<usize>) { (**self).size_hint() }
 }
-


### PR DESCRIPTION
The example uses integers for the value being iterated over, but the indices
added by `enumerate` are also integers, so I always end up double taking and
thinking harder than I should when parsing the documentation. I also always
forget which order the index and value are in the tuple so I frequently hit this
stumbling block. This commit changes the documentation to iterate over
characters so that it is immediately obvious which part of the tuple is the
index and which is the value.
