### PR TITLE
debuginfo: Don't emit DW_LANG_RUST unless it's explicitly demanded

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -676,6 +676,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
           "dump MIR state at various points in translation"),
     orbit: bool = (false, parse_bool,
           "get MIR where it belongs - everywhere; most importantly, in orbit"),
+    rust_debuginfo: bool = (false, parse_bool,
+          "emit Rust-specific debuginfo instead of fallback encoding"),
 }
 
 pub fn default_lib_output() -> CrateType {

--- a/src/librustc_trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/debuginfo/metadata.rs
@@ -53,6 +53,8 @@ use syntax::parse::token;
 // From DWARF 5.
 // See http://www.dwarfstd.org/ShowIssue.php?issue=140129.1
 const DW_LANG_RUST: c_uint = 0x1c;
+const DW_LANG_UNKNOWN: c_uint = 0x0;
+
 #[allow(non_upper_case_globals)]
 const DW_ATE_boolean: c_uint = 0x02;
 #[allow(non_upper_case_globals)]
@@ -1013,10 +1015,17 @@ pub fn compile_unit_metadata(cx: &CrateContext) -> DIDescriptor {
     let producer = CString::new(producer).unwrap();
     let flags = "\0";
     let split_name = "\0";
+
+    let language = if cx.sess().opts.debugging_opts.rust_debuginfo {
+        DW_LANG_RUST
+    } else {
+        DW_LANG_UNKNOWN
+    };
+
     return unsafe {
         llvm::LLVMDIBuilderCreateCompileUnit(
             debug_context(cx).builder,
-            DW_LANG_RUST,
+            language,
             compile_unit_name,
             work_dir.as_ptr(),
             producer.as_ptr(),


### PR DESCRIPTION
It turns out that LLDB can't handle DW_LANG_RUST and that GDB has problems with DW_LANG_C_PLUS_PLUS. Setting the language to `0x0` is the only value that will make both debuggers happy enough. I want proper debuginfo `:(`

This will hopefully take care of #33062 and #32520.

Heads up, @tromey! You'll still want the compiler to emit DW_LANG_RUST as the language, so you'll have to pass `-Z rust-debuginfo` to it.
