### PR TITLE
Normalize types before using them in debuginfo.

### DIFF
--- a/src/librustc_trans/debuginfo/mod.rs
+++ b/src/librustc_trans/debuginfo/mod.rs
@@ -34,6 +34,7 @@ use rustc::hir;
 use abi::Abi;
 use common::{NodeIdAndSpan, CrateContext, FunctionContext, Block, BlockAndBuilder};
 use monomorphize::Instance;
+use rustc::infer::normalize_associated_type;
 use rustc::ty::{self, Ty};
 use session::config::{self, FullDebugInfo, LimitedDebugInfo, NoDebugInfo};
 use util::nodemap::{DefIdMap, NodeMap, FnvHashMap, FnvHashSet};
@@ -368,6 +369,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
 
         name_to_append_suffix_to.push('<');
         for (i, &actual_type) in actual_types.iter().enumerate() {
+            let actual_type = normalize_associated_type(cx.tcx(), &actual_type);
             // Add actual type name to <...> clause of function name
             let actual_type_name = compute_debuginfo_type_name(cx,
                                                                actual_type,
@@ -383,7 +385,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
         // Again, only create type information if full debuginfo is enabled
         let template_params: Vec<_> = if cx.sess().opts.debuginfo == FullDebugInfo {
             generics.types.as_slice().iter().enumerate().map(|(i, param)| {
-                let actual_type = actual_types[i];
+                let actual_type = normalize_associated_type(cx.tcx(), &actual_types[i]);
                 let actual_type_metadata = type_metadata(cx, actual_type, codemap::DUMMY_SP);
                 let name = CString::new(param.name.as_str().as_bytes()).unwrap();
                 unsafe {

--- a/src/test/run-pass/issue-33096.rs
+++ b/src/test/run-pass/issue-33096.rs
@@ -1,0 +1,27 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -g
+
+use std::ops::Deref;
+
+trait Foo {
+    fn foo() {}
+}
+
+impl Foo for u8 {}
+
+fn bar<T: Deref>() where T::Target: Foo {
+    <<T as Deref>::Target as Foo>::foo()
+}
+
+fn main() {
+    bar::<&u8>();
+}


### PR DESCRIPTION
Small oversight, fixes #33096 - odd thing is that the old code doesn't look like it should've ever worked, although it wasn't using all of the type parameters, so maybe that's what changed.
