### PR TITLE
syntax: Always parse `pub ( path_start` in tuple structs as visibility

### DIFF
--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -263,6 +263,11 @@ impl Token {
         self.is_keyword(keywords::Const)
     }
 
+    pub fn is_path_start(&self) -> bool {
+        self == &ModSep || self == &Lt || self.is_path() || self.is_ident() &&
+        !self.is_keyword(keywords::True) && !self.is_keyword(keywords::False)
+    }
+
     /// Maps a token to its corresponding binary operator.
     pub fn to_binop(&self) -> Option<BinOpKind> {
         match *self {

--- a/src/test/parse-fail/visibility-type-conflict.rs
+++ b/src/test/parse-fail/visibility-type-conflict.rs
@@ -1,0 +1,16 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z parse-only
+
+// Check that `pub ( path_start` parses as visibility
+
+struct S(pub (u8, u8)); //~ ERROR expected one of `)` or `::`, found `,`
+//~^ ERROR expected one of `::`, `;`, or `where`, found `,`

--- a/src/test/run-pass/visibility-type-conflict.rs
+++ b/src/test/run-pass/visibility-type-conflict.rs
@@ -1,0 +1,31 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// `pub ( path_start` parses as visibility, check that it doesn't
+// affect macros and workaround with parens works.
+
+#![feature(type_macros)]
+
+struct S(pub ((u8, u8)));
+struct K(pub ((u8)));
+struct U(pub (*const u8, usize));
+
+macro_rules! m {
+    ($t: ty) => ($t)
+}
+
+macro_rules! n {
+    ($t: ty) => (struct L(pub $t);)
+}
+
+struct Z(pub m!((u8, u8)));
+n! { (u8, u8) }
+
+fn main() {}


### PR DESCRIPTION
Addresses https://github.com/rust-lang/rust/issues/32409#issuecomment-204926186

Pros: Visibilities can be applied to tuple struct fields, only two symbols of look-ahead are required.

```
struct S(pub(foo::bar) u8);
```

parses as struct with a `pub(restricted)` field of type `u8`. 

Cons: Some tuple structs stop parsing

```
struct S(pub (foo::bar::<u8>, foo::baz));
```

We start parsing `pub (foo::bar` as a visibility and fail somewhere in the middle.

Why it is not so bad:
- The breakage seems to be rare, at least rustc itself doesn't contain any affected code, even in tests. Crater run is needed.
- The workaround is simple - surround the type with parentheses - `((foo, bar))`. `(` isn't a path start token, so `((foo, bar))` parses as a type. Alternatively, a type alias can be used for `(foo, bar)`.
- It doesn't affect macros. If a macro accept types we can pass a tuple `(foo::bar::<u8>, foo::baz)` to it without fear of syntactic conflicts even if it's preceeded by `pub` in the macro.

```
macro_rules! m {
    ($t: ty) => (struct S(pub $t);)
}

m! { (foo::bar::<u8>, foo::baz) } // OK
```

Alternatives:
- Parse `pub (path) TYPE` with hacks. Always parse what goes after `pub` as a type (but not `$ty` nonterminal) (unless it's `(crate)` or `$vis`) and try to reinterpret it as a visibility if it's not followed by `,` or `)`.
  Reinterpretation fails if the parsed path is not `TyKind::Path` wrapped into `TyKind::Paren` or contains type parameters.
- Use lookahead of arbitrary length, parse the whole path first and decide what to do after that. A path can be an actual visibility or a tuple's first element, or an operand of type sum, etc.
- Support only unambiguous `pub(crate)` (and `$vis` if https://github.com/rust-lang/rfcs/pull/1575 is accepted) in tuple structs. This is essentially this PR other way round - everything that starts like a type parses as a type. However workarounds are wordy if `pub(restricted)` is actually wanted.
- Use some other syntax until the current one is de-facto stabilized (I, personally, like `pub@path`, but would prefer to keep the current syntax).
- Do not support `pub(restricted)` in tuple structs. This just looks like a surrender.

[breaking-change], needs a crater run before proceeding.
r? @nikomatsakis 
