### PR TITLE
doc(book/error-handling): Remove Docopt args from case study code

### DIFF
--- a/src/doc/book/error-handling.md
+++ b/src/doc/book/error-handling.md
@@ -2133,8 +2133,10 @@ Now we only need to implement our “quiet” functionality. This requires us to
 tweak the case analysis in `main`:
 
 ```rust,ignore
-match search(&args.arg_data_path, &args.arg_city) {
-    Err(CliError::NotFound) if args.flag_quiet => process::exit(1),
+let quiet = matches.opt_present("q");
+
+match search(data_file, city) {
+    Err(CliError::NotFound) if quiet => process::exit(1),
     Err(err) => panic!("{}", err),
     Ok(pops) => for pop in pops {
         println!("{}, {}: {:?}", pop.city, pop.country, pop.count);


### PR DESCRIPTION
In the Error Handling section, the final case study code which
demonstrates how to implement the "quiet" functionality references
command line arguments in Docopt style. This won't work with the project
code defined previously, which uses Getopts for command line option
parsing.

Modify the code to reference bindings defined earlier and create a new
binding for "quiet".

Apparently this was added when the Case Study section was first
introduced (e18122682b649a9bff8cbc7b7a4bc8e1f753fb30) even though the
example project used Getopts.

r? @steveklabnik
