### PR TITLE
generate MIR for constants and statics

### DIFF
--- a/src/librustc_mir/build/expr/as_temp.rs
+++ b/src/librustc_mir/build/expr/as_temp.rs
@@ -35,13 +35,11 @@ impl<'a,'tcx> Builder<'a,'tcx> {
 
         let expr_ty = expr.ty.clone();
         let temp = this.temp(expr_ty.clone());
-        let temp_lifetime = match expr.temp_lifetime {
-            Some(t) => t,
-            None => {
-                span_bug!(expr.span, "no temp_lifetime for expr");
-            }
-        };
-        this.schedule_drop(expr.span, temp_lifetime, &temp, expr_ty);
+        if let Some(temp_lifetime) = expr.temp_lifetime {
+            this.schedule_drop(expr.span, temp_lifetime, &temp, expr_ty);
+        }
+        // if expression is inside a constant then
+        // there's no temp_lifetime and no need to drop
 
         // Careful here not to cause an infinite cycle. If we always
         // called `into`, then for lvalues like `x.f`, it would

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -327,6 +327,7 @@ pub fn construct_expr<'a,'tcx>(hir: Cx<'a,'tcx>,
             var_decls: builder.var_decls,
             arg_decls: Vec::new(),
             temp_decls: builder.temp_decls,
+            upvar_decls: Vec::new(),
             return_ty: FnOutput::FnConverging(ty),
             span: span
         },

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -264,6 +264,76 @@ pub fn construct<'a,'tcx>(hir: Cx<'a,'tcx>,
     )
 }
 
+
+///////////////////////////////////////////////////////////////////////////
+/// the main entry point for building MIR for an arbitrary expression
+
+pub fn construct_expr<'a,'tcx>(hir: Cx<'a,'tcx>,
+                          id: ast::NodeId,
+                          span: Span,
+                          expr: &'tcx hir::Expr)
+                          -> (Mir<'tcx>, ScopeAuxiliaryVec) {
+    let tcx = hir.tcx();
+    let cfg = CFG { basic_blocks: vec![] };
+    let ty = tcx.node_id_to_type(id);
+
+    let mut builder = Builder {
+        hir: hir,
+        cfg: cfg,
+        fn_span: span,
+        scopes: vec![],
+        scope_datas: vec![],
+        scope_auxiliary: ScopeAuxiliaryVec { vec: vec![] },
+        loop_scopes: vec![],
+        temp_decls: vec![],
+        var_decls: vec![],
+        var_indices: FnvHashMap(),
+        unit_temp: None,
+        cached_resume_block: None,
+    };
+
+    assert_eq!(builder.cfg.start_new_block(), START_BLOCK);
+    assert_eq!(builder.cfg.start_new_block(), END_BLOCK);
+
+    let call_site_extent = tcx.region_maps.item_extent(id);
+    let _ = builder.in_scope(call_site_extent, START_BLOCK, |builder, call_site_scope_id| {
+        let mut block = START_BLOCK;
+        let expr = builder.hir.mirror(expr);
+        unpack!(block = builder.into(&Lvalue::ReturnPointer, block, expr));
+        builder.cfg.terminate(block, call_site_scope_id, span,
+                              TerminatorKind::Goto { target: END_BLOCK });
+        builder.cfg.terminate(END_BLOCK, call_site_scope_id, span,
+                              TerminatorKind::Return);
+
+        END_BLOCK.unit()
+    });
+
+    assert!(
+        builder.cfg.basic_blocks
+                   .iter()
+                   .enumerate()
+                   .all(|(index, block)| {
+                       if block.terminator.is_none() {
+                           bug!("no terminator on block {:?} in fn {:?}",
+                                index, id)
+                       }
+                       true
+                   }));
+
+    (
+        Mir {
+            basic_blocks: builder.cfg.basic_blocks,
+            scopes: builder.scope_datas,
+            var_decls: builder.var_decls,
+            arg_decls: Vec::new(),
+            temp_decls: builder.temp_decls,
+            return_ty: FnOutput::FnConverging(ty),
+            span: span
+        },
+        builder.scope_auxiliary,
+    )
+}
+
 impl<'a,'tcx> Builder<'a,'tcx> {
     fn args_and_body(&mut self,
                      mut block: BasicBlock,

--- a/src/test/run-pass/mir_constant.rs
+++ b/src/test/run-pass/mir_constant.rs
@@ -1,0 +1,24 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This test does nothing useful yet, it just generates MIR for constants
+
+#![feature(rustc_attrs)]
+
+#[rustc_mir]
+const C: i32 = 5 + 6;
+
+#[rustc_mir]
+const D: i32 = C - 3;
+
+fn main() {
+    assert_eq!(D, 8);
+    assert_eq!(C, 11);
+}


### PR DESCRIPTION
This doesn't generate MIR for associated constants

r? @eddyb 

cc @tsion 

Example MIR generated for the `C` constant in the test:

```
// MIR for `C`
// node_id = 4
// pass_name = mir_map
// disambiguator = 0

fn C() -> i32 {

    bb0: {
        // Enter Scope(0)
        // Enter Scope(1)
        // Enter Scope(2)
        // Exit Scope(2)
        // Enter Scope(3)
        // Exit Scope(3)
        return = Add(const 5i32, const 6i32); // Scope(1) at mir_constant.rs:16:16: 16:21
        goto -> bb1; // Scope(0) at mir_constant.rs:16:1: 16:22
    }

    bb1: {
        return; // Scope(0) at mir_constant.rs:16:1: 16:22
    }
    Scope(0) {
        Extent: DestructionScope(4)
        Scope(1) {
            Parent: Scope(0)
            Extent: Misc(6)
            Scope(2) {
                Parent: Scope(1)
                Extent: Misc(7)
            Scope(3) {
                Parent: Scope(1)
                Extent: Misc(8)
}
```

and simplified:

```
// MIR for `C`
// node_id = 4
// pass_name = simplify_cfg
// disambiguator = 0

fn C() -> i32 {

    bb0: {
        return = Add(const 5i32, const 6i32); // Scope(1) at mir_constant.rs:16:16: 16:21
        goto -> bb1; // Scope(0) at mir_constant.rs:16:1: 16:22
    }

    bb1: {
        return; // Scope(0) at mir_constant.rs:16:1: 16:22
    }
    Scope(0) {
        Scope(1) {
            Parent: Scope(0)
            Scope(2) {
                Parent: Scope(1)
            Scope(3) {
                Parent: Scope(1)
}
```
