### PR TITLE
impl<T> From<T> for ()

### DIFF
--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -216,6 +216,13 @@ impl<T> From<T> for T {
     fn from(t: T) -> T { t }
 }
 
+// A (the) value of the unit type can be created from any value of any type.
+// This is useful for use with the `try!` macro or the `?` operator.
+#[stable(feature = "unit_from_anything", since = "1.10.0")]
+impl<T> From<T> for () {
+    fn from(t: T) -> () {}
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // CONCRETE IMPLS
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/libcoretest/tuple.rs
+++ b/src/libcoretest/tuple.rs
@@ -66,3 +66,13 @@ fn test_show() {
     let s = format!("{:?}", (1, "hi", true));
     assert_eq!(s, "(1, \"hi\", true)");
 }
+
+#[test]
+fn test_convert_unit_from_any() {
+    fn io() -> Result<u32, ::std::io::Error> { Ok(1) }
+    fn fmt() -> Result<u32, ::std::fmt::Error> { Ok(2) }
+    fn sum() -> Result<u32, ()> {
+        Ok(io()? + try!(fmt()))
+    }
+    assert_eq!(sum(), Ok(3))
+}


### PR DESCRIPTION
**Don’t try to merge this yet.**

At the moment this PR causes a compiler error:

``` rust
../src/libcore/convert.rs:222:1: 224:2 error: conflicting implementations of trait `convert::From<()>` for type `()`: [E0119]
../src/libcore/convert.rs:222 impl<T> From<T> for () {
../src/libcore/convert.rs:223     fn from(t: T) -> () {}
../src/libcore/convert.rs:224 }
../src/libcore/convert.rs:222:1: 224:2 help: run `rustc --explain E0119` to see a detailed explanation
../src/libcore/convert.rs:215:1: 217:2 note: conflicting implementation is here:
../src/libcore/convert.rs:215 impl<T> From<T> for T {
../src/libcore/convert.rs:216     fn from(t: T) -> T { t }
../src/libcore/convert.rs:217 }
```

The two impls overlap on `From<()> for ()`, even though they happen have equivalent behavior there.

Specialization may help with this, but:
- Only if [the lattice rule](https://github.com/rust-lang/rfcs/blob/master/text/1210-impl-specialization.md#the-lattice-rule) is implemented
- This would (I think?) also allow users outside of `libcore` to specialize further.

CC @aturon & libs team

---

I use the `try!` macro a lot, usually with `()` as the error type since I don’t care that much about tracking data about errors. When using some existing function or method that returns `Result`
with a different error type, I find myself using code like this:

``` rust
try!(foo.map_err(|_| ()))
```

… which is more verbose than I’d like.

The `try!` macro already uses the `From` trait to convert errors, some implementations like `impl From<std::num::ParseIntError> for ()` would help. But rather than adding them one by one to many error types, a generic solution would be nice.
