### PR TITLE
Enable vfp3-d16 for ARMv7 Android target

### DIFF
--- a/src/librustc_back/target/arm_linux_androideabi.rs
+++ b/src/librustc_back/target/arm_linux_androideabi.rs
@@ -12,7 +12,7 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::android_base::opts();
-    base.features = "+v7".to_string();
+    base.features = "+v7,+vfp3,+d16".to_string();
 
     Target {
         llvm_target: "arm-linux-androideabi".to_string(),


### PR DESCRIPTION
Android's [armeabi-v7a ABI](https://developer.android.com/ndk/guides/abis.html) guarantees at least VFPv3-d16 hardware FPU support, so Rust should include this in the default features for the `arm-linux-androideabi` target.
