### PR TITLE
librustc: remove outdated workaround

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -535,9 +535,6 @@ unsafe fn configure_llvm(sess: &Session) {
         if sess.time_llvm_passes() { add("-time-passes"); }
         if sess.print_llvm_passes() { add("-debug-pass=Structure"); }
 
-        // FIXME #21627 disable faulty FastISel on AArch64 (even for -O0)
-        if sess.target.target.arch == "aarch64" { add("-fast-isel=0"); }
-
         for arg in &sess.opts.cg.llvm_args {
             add(&(*arg));
         }


### PR DESCRIPTION
Fixed upstream: https://github.com/llvm-mirror/llvm/commit/ca07e256f62f

@alexcrichton following up from https://github.com/rust-lang/rust/pull/31709#discussion_r59125612

cc @ranma42 
