### PR TITLE
Map entry API: add Entry::or_insert_with_result()

### DIFF
--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -1522,6 +1522,18 @@ impl<'a, K: Ord, V> Entry<'a, K, V> {
             Vacant(entry) => entry.insert(default()),
         }
     }
+
+    /// Like `or_insert_with`, but doesn't insert anything if the default function
+    /// fails with an `Err` result.
+    #[unstable(feature = "map_entry_insert_with_result", issue = "33126")]
+    pub fn or_insert_with_result<E, F>(self, default: F) -> Result<&'a mut V, E>
+        where F: FnOnce() -> Result<V, E>
+    {
+        match self {
+            Occupied(entry) => Ok(entry.into_mut()),
+            Vacant(entry) => Ok(entry.insert(try!(default()))),
+        }
+    }
 }
 
 impl<'a, K: Ord, V> VacantEntry<'a, K, V> {

--- a/src/libcollectionstest/btree/map.rs
+++ b/src/libcollectionstest/btree/map.rs
@@ -290,6 +290,16 @@ fn test_entry(){
     }
     assert_eq!(map.get(&10).unwrap(), &1000);
     assert_eq!(map.len(), 6);
+
+    // or_insert_with family
+    assert_eq!(map.entry(10).or_insert_with(|| 100), &1000);
+    assert_eq!(map.len(), 6);
+    assert_eq!(map.entry(20).or_insert_with(|| 200), &200);
+    assert_eq!(map.len(), 7);
+    assert_eq!(map.entry(30).or_insert_with_result(|| Ok::<_, &str>(300)), Ok(&mut 300));
+    assert_eq!(map.len(), 8);
+    assert_eq!(map.entry(31).or_insert_with_result(|| Err("nope")), Err("nope"));
+    assert_eq!(map.len(), 8);
 }
 
 #[test]

--- a/src/libcollectionstest/lib.rs
+++ b/src/libcollectionstest/lib.rs
@@ -32,6 +32,7 @@
 #![feature(unboxed_closures)]
 #![feature(unicode)]
 #![feature(vec_deque_contains)]
+#![feature(map_entry_insert_with_result)]
 
 extern crate collections;
 extern crate test;


### PR DESCRIPTION
Takes a default function that returns a Result, and bails out
on Err cases. Use case: caches where producing the value
to cache can fail.

To clarify:
- is this a useful addition?
- is the name ok?
- is the feature name ok?
