### PR TITLE
Allow lifetimes to be passed to macros

### DIFF
--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -179,6 +179,13 @@ pub mod rt {
         }
     }
 
+    impl ToTokens for ast::Lifetime {
+        fn to_tokens(&self, _cx: &ExtCtxt) -> Vec<TokenTree> {
+            let lifetime_ident = ast::Ident::with_empty_ctxt(self.name);
+            vec![TokenTree::Token(DUMMY_SP, token::Lifetime(lifetime_ident))]
+        }
+    }
+
     macro_rules! impl_to_tokens_slice {
         ($t: ty, $sep: expr) => {
             impl ToTokens for [$t] {

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -549,12 +549,13 @@ pub fn parse_nt<'a>(p: &mut Parser<'a>, sp: Span, name: &str) -> Nonterminal {
             token::NtPath(Box::new(panictry!(p.parse_path(LifetimeAndTypesWithoutColons))))
         },
         "meta" => token::NtMeta(panictry!(p.parse_meta_item())),
+        "lifetime" => token::NtLifetime(panictry!(p.parse_lifetime())),
         _ => {
             p.span_fatal_help(sp,
                               &format!("invalid fragment specifier `{}`", name),
                               "valid fragment specifiers are `ident`, `block`, \
-                               `stmt`, `expr`, `pat`, `ty`, `path`, `meta`, `tt` \
-                               and `item`").emit();
+                               `stmt`, `expr`, `pat`, `ty`, `path`, `meta`, `tt`, \
+                               `lifetime`, and `item`").emit();
             panic!(FatalError);
         }
     }

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -941,6 +941,7 @@ fn frag_can_be_followed_by_any(frag: &str) -> bool {
         "block" | // exactly one token tree
         "ident" | // exactly one token tree
         "meta" |  // exactly one token tree
+        "lifetime" | // exactly one token tree
         "tt" =>    // exactly one token tree
             true,
 
@@ -963,6 +964,7 @@ fn can_be_followed_by_any(frag: &str) -> bool {
         "block" | // exactly one token tree
         "ident" | // exactly one token tree
         "meta" |  // exactly one token tree
+        "lifetime" | // exactly one token tree
         "tt" =>    // exactly one token tree
             true,
 
@@ -1020,8 +1022,8 @@ fn is_in_follow(_: &ExtCtxt, tok: &Token, frag: &str) -> Result<bool, String> {
                     _ => Ok(false)
                 }
             },
-            "ident" => {
-                // being a single token, idents are harmless
+            "ident" | "lifetime" => {
+                // being a single token, idents and lifetimes are harmless
                 Ok(true)
             },
             "meta" | "tt" => {
@@ -1048,7 +1050,7 @@ fn has_legal_fragment_specifier(tok: &Token) -> Result<(), String> {
 fn is_legal_fragment_specifier(frag: &str) -> bool {
     match frag {
         "item" | "block" | "stmt" | "expr" | "pat" |
-        "path" | "ty" | "ident" | "meta" | "tt" => true,
+        "path" | "ty" | "ident" | "meta" | "tt" | "lifetime" => true,
         _ => false,
     }
 }

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -15,7 +15,7 @@ use codemap::{Span, DUMMY_SP};
 use errors::Handler;
 use ext::tt::macro_parser::{NamedMatch, MatchedSeq, MatchedNonterminal};
 use parse::token::{DocComment, MatchNt, SubstNt};
-use parse::token::{Token, NtIdent, SpecialMacroVar};
+use parse::token::{Token, NtIdent, NtLifetime, SpecialMacroVar};
 use parse::token;
 use parse::lexer::TokenAndSpan;
 
@@ -295,6 +295,13 @@ pub fn tt_next_token(r: &mut TtReader) -> TokenAndSpan {
                             MatchedNonterminal(NtIdent(ref sn, b)) => {
                                 r.cur_span = sn.span;
                                 r.cur_tok = token::Ident(sn.node, b);
+                                return ret_val;
+                            }
+                            // interpolate lifetimes as well for the same reasons as
+                            // idents
+                            MatchedNonterminal(NtLifetime(ref lt)) => {
+                                r.cur_span = lt.span;
+                                r.cur_tok = token::Lifetime(ast::Ident::with_empty_ctxt(lt.name));
                                 return ret_val;
                             }
                             MatchedNonterminal(ref other_whole_nt) => {

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -681,6 +681,7 @@ pub fn noop_fold_interpolated<T: Folder>(nt: token::Nonterminal, fld: &mut T)
         token::NtWhereClause(where_clause) =>
             token::NtWhereClause(fld.fold_where_clause(where_clause)),
         token::NtArg(arg) => token::NtArg(fld.fold_arg(arg)),
+        token::NtLifetime(lifetime) => token::NtLifetime(fld.fold_lifetime(lifetime)),
     }
 }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1955,6 +1955,9 @@ impl<'a> Parser<'a> {
                     name: i.name
                 });
             }
+            token::Interpolated(token::NtLifetime(..)) => {
+                self.bug("lifetime interpolation not converted to real token");
+            }
             _ => {
                 return Err(self.fatal("expected a lifetime name"));
             }

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -397,6 +397,7 @@ pub enum Nonterminal {
     NtGenerics(ast::Generics),
     NtWhereClause(ast::WhereClause),
     NtArg(ast::Arg),
+    NtLifetime(ast::Lifetime),
 }
 
 impl fmt::Debug for Nonterminal {
@@ -418,6 +419,7 @@ impl fmt::Debug for Nonterminal {
             NtGenerics(..) => f.pad("NtGenerics(..)"),
             NtWhereClause(..) => f.pad("NtWhereClause(..)"),
             NtArg(..) => f.pad("NtArg(..)"),
+            NtLifetime(..) => f.pad("NtLifetime(..)"),
         }
     }
 }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -302,6 +302,7 @@ pub fn token_to_string(tok: &Token) -> String {
             token::NtGenerics(ref e)    => generics_to_string(&e),
             token::NtWhereClause(ref e) => where_clause_to_string(&e),
             token::NtArg(ref e)         => arg_to_string(&e),
+            token::NtLifetime(ref e)    => lifetime_to_string(&e),
         }
     }
 }

--- a/src/test/run-pass/macro-lifetime-used-with-bound.rs
+++ b/src/test/run-pass/macro-lifetime-used-with-bound.rs
@@ -1,0 +1,23 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! foo {
+    ($l:lifetime, $l2:lifetime) => {
+        fn f<$l: $l2, $l2>(arg: &$l str, arg2: &$l2 str) -> &$l str {
+            arg
+        }
+    }
+}
+
+pub fn main() {
+    foo!('a, 'b);
+    let x: &'static str = f("hi", "there");
+    assert_eq!("hi", x);
+}

--- a/src/test/run-pass/macro-lifetime-used-with-static.rs
+++ b/src/test/run-pass/macro-lifetime-used-with-static.rs
@@ -1,0 +1,23 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! foo {
+    ($l:lifetime) => {
+        fn f(arg: &$l str) -> &$l str {
+            arg
+        }
+    }
+}
+
+pub fn main() {
+    foo!('static);
+    let x: &'static str = f("hi");
+    assert_eq!("hi", x);
+}

--- a/src/test/run-pass/macro-lifetime.rs
+++ b/src/test/run-pass/macro-lifetime.rs
@@ -1,0 +1,23 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! foo {
+    ($l:lifetime) => {
+        fn f<$l>(arg: &$l str) -> &$l str {
+            arg
+        }
+    }
+}
+
+pub fn main() {
+    foo!('a);
+    let x: &'static str = f("hi");
+    assert_eq!("hi", x);
+}


### PR DESCRIPTION
Partially fixes #10413. This only handles lifetimes, as they're much
more "obvious" than the type parameter list would be, as that implies
that we probably want to mirror `ast::Generics` as well as all of the
individual pieces. That should probably have an RFC.

These are essentially just treated the same as idents. They're a single
token, and are quite pervasive, so we interpolate them back into a real
token rather than handling `NtLifetime` all over the parser.

This change is specifically needed in Diesel in order for us to provide
a "normal macro" alternative to some of our syntax extensions. With this
change, we'd be able to have a decent stable story without syntex.
