### PR TITLE
Move `::std::error` to `::core::error`

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -152,5 +152,7 @@ pub mod str;
 pub mod hash;
 pub mod fmt;
 
+pub mod error;
+
 // note: does not need to be public
 mod tuple;

--- a/src/librustc_unicode/char.rs
+++ b/src/librustc_unicode/char.rs
@@ -754,6 +754,13 @@ pub struct DecodeUtf16Error {
     code: u16,
 }
 
+#[stable(feature = "decode_utf16", since = "1.9.0")]
+impl ::core::error::Error for DecodeUtf16Error {
+    fn description(&self) -> &str {
+        "unpaired surrogate found"
+    }
+}
+
 /// Create an iterator over the UTF-16 encoded code points in `iter`,
 /// returning unpaired surrogates as `Err`s.
 ///

--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -10,7 +10,7 @@
 
 use boxed::Box;
 use convert::Into;
-use error;
+use core::error;
 use fmt;
 use marker::{Send, Sync};
 use option::Option::{self, Some, None};

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -341,12 +341,13 @@ pub use core::result;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::option;
 
-pub mod error;
-
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use alloc::boxed;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use alloc::rc;
+
+#[stable(feature = "rust1", since = "1.10.0")]
+pub use core::error;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::borrow;

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -346,7 +346,7 @@ pub use alloc::boxed;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use alloc::rc;
 
-#[stable(feature = "rust1", since = "1.10.0")]
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use core::error;
 
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
The idea of this is to move the `Error` trait into `libcore`, where it can be used by more code, particularly `no_std` code.

It however has a few possibly breaking changes in it. The first is that the `downcast` methods were moved from being on `Error` (the unsized type) to being on `Box<Error>`. This changes the UFCS paths, but doesn't change the method-call usage.

Secondly, the `Error` trait has been marked with `#[fundamental]` to allow the `From<&str> for Box<Error>` impls to work. When raised on IRC, the tentative conclusion was that being an error is not an incidental aspect of a type, so this is acceptable.

Feel free to reject this PR if it breaks existing code, it's more of a "nice to have" feature.
