### PR TITLE
Make HashSet::Insert documentation more consistent

### DIFF
--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -535,9 +535,9 @@ impl<T, S> HashSet<T, S>
 
     /// Adds a value to the set.
     ///
-    /// If the set did not have a value present, `true` is returned.
+    /// If the set did not have this value present, `true` is returned.
     ///
-    /// If the set did have this key present, `false` is returned.
+    /// If the set did have this value present, `false` is returned.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
I have made the HashSet::Insert documentation more consistent in the use of the term 'value' vs 'key'. Also clarified that if _this_ value is present true is returned, instead of the ambiguous 'a value present'. 

r? @steveklabnik
