### PR TITLE
rustdoc: Only record the same impl once

### DIFF
--- a/src/etc/htmldocck.py
+++ b/src/etc/htmldocck.py
@@ -342,9 +342,9 @@ def check_tree_text(tree, path, pat, regexp):
     return ret
 
 
-def check_tree_count(tree, path, count):
+def get_tree_count(tree, path):
     path = normalize_xpath(path)
-    return len(tree.findall(path)) == count
+    return len(tree.findall(path))
 
 def stderr(*args):
     print(*args, file=sys.stderr)
@@ -393,7 +393,10 @@ def check_command(c, cache):
 
         elif c.cmd == 'count': # count test
             if len(c.args) == 3: # @count <path> <pat> <count> = count test
-                ret = check_tree_count(cache.get_tree(c.args[0]), c.args[1], int(c.args[2]))
+                expected = int(c.args[2])
+                found = get_tree_count(cache.get_tree(c.args[0]), c.args[1])
+                cerr = "Expected {} occurrences but found {}".format(expected, found)
+                ret = expected == found
             else:
                 raise InvalidCheck('Invalid number of @{} arguments'.format(c.cmd))
         elif c.cmd == 'valid-html':

--- a/src/test/rustdoc/duplicate_impls/impls.rs
+++ b/src/test/rustdoc/duplicate_impls/impls.rs
@@ -1,0 +1,22 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub struct Foo;
+
+// just so that `Foo` doesn't show up on `Bar`s sidebar
+pub mod bar {
+    pub trait Bar {}
+}
+
+impl Foo {
+    pub fn new() -> Foo { Foo }
+}
+
+impl bar::Bar for Foo {}

--- a/src/test/rustdoc/duplicate_impls/issue-33054.rs
+++ b/src/test/rustdoc/duplicate_impls/issue-33054.rs
@@ -1,0 +1,21 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// @has issue_33054/impls/struct.Foo.html
+// @has - '//code' 'impl Foo'
+// @has - '//code' 'impl Bar for Foo'
+// @count - '//*[@class="impl"]' 2
+// @has issue_33054/impls/bar/trait.Bar.html
+// @has - '//code' 'impl Bar for Foo'
+// @count - '//*[@class="struct"]' 1
+pub mod impls;
+
+#[doc(inline)]
+pub use impls as impls2;


### PR DESCRIPTION
Due to inlining it is possible to visit the same module multiple times during `<Cache as DocFolder>::fold_crate`, so we keep track of the modules we've already visited.

fixes #33054

r? @alexcrichton 
