### PR TITLE
docs: add GitHub issue template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing to Rust
 
 Thank you for your interest in contributing to Rust! There are many ways to
-contribute, and we appreciate all of them. This document is a bit long, so here's
-links to the major sections:
+contribute, and we appreciate all of them. This document is a bit long, so
+here are links to its major sections:
 
 * [Feature Requests](#feature-requests)
 * [Issue and Bug Reports](#issue-and-bug-reports)
@@ -33,33 +33,73 @@ must go through the RFC process.
 
 While bugs are unfortunate, they're a reality in software. We can't fix what we
 don't know about, so please report liberally. If you're not sure if something
-is a bug or not, feel free to file a bug anyway.
+is a bug or not, feel free to file an issue anyway.
 
-**If you believe reporting your bug publicly represents a security risk to Rust users,
-please follow our [instructions for reporting security vulnerabilities](https://www.rust-lang.org/security.html)**.
+**If you believe reporting your bug publicly represents a security risk to Rust
+users, however, please follow our
+[instructions for reporting security vulnerabilities](https://www.rust-lang.org/security.html)**.
 
 If you have the chance, before reporting a bug, please [search existing
 issues](https://github.com/rust-lang/rust/search?q=&type=Issues&utf8=%E2%9C%93),
-as it's possible that someone else has already reported your error. This doesn't
-always work, and sometimes it's hard to know what to search for, so consider this
-extra credit. We won't mind if you accidentally file a duplicate report.
+as it's possible that someone else has already reported your issue. This doesn't
+always work, and sometimes it's hard to know what to search for, so consider
+this extra credit. We won't mind if you accidentally file a duplicate report.
 
 Opening an issue is as easy as following [this
-link](https://github.com/rust-lang/rust/issues/new) and filling out the fields.
-You'll notice we use [an issue template](ISSUE_TEMPLATE.md). It's advisable to
-try to follow it, of course depending on the kind of issue you have.
-All three components are important: what you did, what you expected, what
-happened instead. Please include the output of `rustc --version --verbose`,
-which includes important information about what platform you're on, what
-version of Rust you're using, etc.
+link](https://github.com/rust-lang/rust/issues/new) and optionally providing
+some specific information, depending on the kind of issue you're reporting.
 
-Sometimes, a backtrace is helpful, and so including that is nice. To get
-a backtrace, set the `RUST_BACKTRACE` environment variable to a value
-other than `0`. The easiest way
-to do this is to invoke `rustc` like this:
+### Compiler bugs
+If `rustc` incorrectly fails compile your code, and especially if compilation
+results in an ICE (_internal compiler error_), you may have a compiler bug at
+your hands.
 
-```bash
-$ RUST_BACKTRACE=1 rustc ...
+#### Code sample
+Please craft a minimal/simple and self-contained code example that (re)produces
+the issue. An example is very self-contained if you can run it on
+https://play.rust-lang.org/.
+<!---
+`main.rs`:
+```rust
+
+```
+--->
+
+#### Expected behavior
+Please concisely explain what you expected instead of encountering of the issue.
+Check if it's helpful to refer to some relevant externalities.
+* Did/does the issue not occur with past/other versions?
+* Are there very similar (perhaps informal) issue reports outside this issue
+  tracker?
+
+#### Actual behavior
+Please paste here any human readable output in full. Important information can
+be in the initial details, so please don't cut.
+
+#### Meta
+Please include the output of `rustc --version --verbose`, which includes
+important information about what platform you're on, what version of Rust you're
+using, etc.
+
+<!---
+`rustc --version --verbose`:
+```
+
+```
+--->
+
+#### Backtrace
+When compilation has completed but your executable exhibits unexpected errors in
+the form of panics, a backtrace is helpful. To produce a backtrace, reproduce
+the issue with your compiled minimal example code like so:
+
+On Windows, issue in PowerShell:
+```powershell
+$env:RUST_BACKTRACE=1; &".\problematic_executable.exe"
+```
+On other platforms, issue in your `sh` shell:
+```sh
+env RUST_BACKTRACE=1 ./problematic_executable
 ```
 
 ## The Build System

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ contribute, and we appreciate all of them. This document is a bit long, so here'
 links to the major sections:
 
 * [Feature Requests](#feature-requests)
-* [Bug Reports](#bug-reports)
+* [Issue and Bug Reports](#issue-and-bug-reports)
 * [The Build System](#the-build-system)
 * [Pull Requests](#pull-requests)
 * [Writing Documentation](#writing-documentation)
@@ -29,7 +29,7 @@ issue in the [RFCs repository](https://github.com/rust-lang/rfcs/issues/new)
 rather than this one. New features and other significant language changes
 must go through the RFC process.
 
-## Bug Reports
+## Issue and Bug Reports
 
 While bugs are unfortunate, they're a reality in software. We can't fix what we
 don't know about, so please report liberally. If you're not sure if something
@@ -46,25 +46,8 @@ extra credit. We won't mind if you accidentally file a duplicate report.
 
 Opening an issue is as easy as following [this
 link](https://github.com/rust-lang/rust/issues/new) and filling out the fields.
-Here's a template that you can use to file a bug, though it's not necessary to
-use it exactly:
-
-    <short summary of the bug>
-
-    I tried this code:
-
-    <code sample that causes the bug>
-
-    I expected to see this happen: <explanation>
-
-    Instead, this happened: <explanation>
-
-    ## Meta
-
-    `rustc --version --verbose`:
-
-    Backtrace:
-
+You'll notice we use [an issue template](ISSUE_TEMPLATE.md). It's advisable to
+try to follow it, of course depending on the kind of issue you have.
 All three components are important: what you did, what you expected, what
 happened instead. Please include the output of `rustc --version --verbose`,
 which includes important information about what platform you're on, what

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,45 @@
+<!---
+Hi! This template is here to help us collect optimal issue reports. Feel free to adapt it to your situation.
+First, check whether the issue has already been reported. If so, please add this report to that issue thread. If not, proceed to file this new issue.
+Next, please provide a one to four sentence summary of the issue. If you do your very best to be clear, concise and accurate here, other Rustaceans will be eager to assist. Also try to mention which GitHub labels this issue likely needs and/or what parts of Rust it relates to.
+--->
+
+## Code sample
+<!---
+Please craft a minimal/simple and self-contained code sample that (re)produces the issue. If you create a formal test case straight away, that'll be even more helpful.
+--->
+`main.rs`:
+```rust
+
+```
+
+## Expected behavior
+<!---
+Please concisely explain what you expected instead of encountering of the issue. Check if it's helpful to refer to some relevant externalities.
+* Could you refer to parts of official documentation, standards, comments in this codebase, etc.?
+* Did/does the issue not occur with past/other versions?
+* In case it's a correctness issue, then what's the relevant behavior of other implementations (for other languages)?.
+* Are there very similar (perhaps informal) issue reports outside this issue tracker?
+--->
+
+## Actual behavior
+<!---
+Please paste here any human readable output in full. Important information can be in the initial details, so don't cut.
+--->
+
+## Meta
+`rustc --version --verbose`:
+```
+
+```
+
+## Backtrace
+<!---
+Finally, if you haven't shared it yet, reproduce the issue with your minimal example code and share the backtrace you obtained.
+On Windows, issue in PowerShell:
+$env:RUST_BACKTRACE=1; &".\problematic_executable.exe"
+On other platforms, issue in your shell:
+env RUST_BACKTRACE=1 ./problematic_executable
+--->
+<!--- Thanks! --->
+

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,45 +1,7 @@
 <!---
 Hi! This template is here to help us collect optimal issue reports. Feel free to adapt it to your situation.
 First, check whether the issue has already been reported. If so, please add this report to that issue thread. If not, proceed to file this new issue.
-Next, please provide a one to four sentence summary of the issue. If you do your very best to be clear, concise and accurate here, other Rustaceans will be eager to assist. Also try to mention which GitHub labels this issue likely needs and/or what parts of Rust it relates to.
+Please provide a one to four sentence summary of the issue. If you do your very best to be clear, concise and accurate here, other Rustaceans will be eager to assist.
+Thanks!
 --->
-
-## Code sample
-<!---
-Please craft a minimal/simple and self-contained code sample that (re)produces the issue. If you create a formal test case straight away, that'll be even more helpful.
---->
-`main.rs`:
-```rust
-
-```
-
-## Expected behavior
-<!---
-Please concisely explain what you expected instead of encountering of the issue. Check if it's helpful to refer to some relevant externalities.
-* Could you refer to parts of official documentation, standards, comments in this codebase, etc.?
-* Did/does the issue not occur with past/other versions?
-* In case it's a correctness issue, then what's the relevant behavior of other implementations (for other languages)?.
-* Are there very similar (perhaps informal) issue reports outside this issue tracker?
---->
-
-## Actual behavior
-<!---
-Please paste here any human readable output in full. Important information can be in the initial details, so don't cut.
---->
-
-## Meta
-`rustc --version --verbose`:
-```
-
-```
-
-## Backtrace
-<!---
-Finally, if you haven't shared it yet, reproduce the issue with your minimal example code and share the backtrace you obtained.
-On Windows, issue in PowerShell:
-$env:RUST_BACKTRACE=1; &".\problematic_executable.exe"
-On other platforms, issue in your shell:
-env RUST_BACKTRACE=1 ./problematic_executable
---->
-<!--- Thanks! --->
 


### PR DESCRIPTION
Adding an [`issue template`](ISSUE_TEMPLATE.md) will encourage that everyone, even a novice, reports issues in the most informative manner. This solution is harder to miss than a section in [`CONTRIBUTING.md`](CONTRIBUTING.md) alone. For experienced Rustaceans, it's easy to disregard/overwrite the template, which is mostly commented out, and a good reminder of some points everyone can forget in a hurry.

Also, word more precisely what information to report
