### PR TITLE
const_fn: Check the terminating expression of a block for blocks in a const initializer

### DIFF
--- a/src/test/compile-fail/issue32829.rs
+++ b/src/test/compile-fail/issue32829.rs
@@ -1,0 +1,88 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![feature(const_fn)]
+
+const bad : u32 = {
+    {
+        5; //~ ERROR: blocks in constants are limited to items and tail expressions
+        0
+    }
+};
+
+const bad_two : u32 = {
+    {
+        invalid();
+        //~^ ERROR: blocks in constants are limited to items and tail expressions
+        //~^^ ERROR: calls in constants are limited to constant functions, struct and enum
+        0
+    }
+};
+
+const bad_three : u32 = {
+    {
+        valid();
+        //~^ ERROR: blocks in constants are limited to items and tail expressions
+        0
+    }
+};
+
+static bad_four : u32 = {
+    {
+        5; //~ ERROR: blocks in statics are limited to items and tail expressions
+        0
+    }
+};
+
+static bad_five : u32 = {
+    {
+        invalid();
+        //~^ ERROR: blocks in statics are limited to items and tail expressions
+        //~^^ ERROR: calls in statics are limited to constant functions, struct and enum
+        0
+    }
+};
+
+static bad_six : u32 = {
+    {
+        valid();
+        //~^ ERROR: blocks in statics are limited to items and tail expressions
+        0
+    }
+};
+
+static mut bad_seven : u32 = {
+    {
+        5; //~ ERROR: blocks in statics are limited to items and tail expressions
+        0
+    }
+};
+
+static mut bad_eight : u32 = {
+    {
+        invalid();
+        //~^ ERROR: blocks in statics are limited to items and tail expressions
+        //~^^ ERROR: calls in statics are limited to constant functions, struct and enum
+        0
+    }
+};
+
+static mut bad_nine : u32 = {
+    {
+        valid();
+        //~^ ERROR: blocks in statics are limited to items and tail expressions
+        0
+    }
+};
+
+
+fn invalid() {}
+const fn valid() {}
+
+fn main() {}


### PR DESCRIPTION
In a const or static initializer, the `CheckBlock` check ensures that blocks in the initializer expression are only in tail positions or in items. In this case, it didn't check the terminating expression of a block, which resulted in an ICE later in the compiler pipeline if the trailing expression was itself a block. This change fixes the ICE and ensures that the proper error is emitted. This fixes the ICE in #32829 .
