### PR TITLE
Some preliminary work towards making trans "collector driven".

### DIFF
--- a/src/librustc_data_structures/bitvec.rs
+++ b/src/librustc_data_structures/bitvec.rs
@@ -52,9 +52,8 @@ impl BitVector {
 
     pub fn grow(&mut self, num_bits: usize) {
         let num_words = u64s(num_bits);
-        let extra_words = self.data.len() - num_words;
-        if extra_words > 0 {
-            self.data.extend((0..extra_words).map(|_| 0));
+        if self.data.len() < num_words {
+            self.data.resize(num_words, 0)
         }
     }
 
@@ -284,15 +283,27 @@ fn union_two_vecs() {
 #[test]
 fn grow() {
     let mut vec1 = BitVector::new(65);
-    assert!(vec1.insert(3));
-    assert!(!vec1.insert(3));
-    assert!(vec1.insert(5));
-    assert!(vec1.insert(64));
+    for index in 0 .. 65 {
+        assert!(vec1.insert(index));
+        assert!(!vec1.insert(index));
+    }
     vec1.grow(128);
-    assert!(vec1.contains(3));
-    assert!(vec1.contains(5));
-    assert!(vec1.contains(64));
-    assert!(!vec1.contains(126));
+
+    // Check if the bits set before growing are still set
+    for index in 0 .. 65 {
+        assert!(vec1.contains(index));
+    }
+
+    // Check if the new bits are all un-set
+    for index in 65 .. 128 {
+        assert!(!vec1.contains(index));
+    }
+
+    // Check that we can set all new bits without running out of bounds
+    for index in 65 .. 128 {
+        assert!(vec1.insert(index));
+        assert!(!vec1.insert(index));
+    }
 }
 
 #[test]

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -97,7 +97,7 @@ pub enum Visibility {
 // DLLExportLinkage, GhostLinkage and LinkOnceODRAutoHideLinkage.
 // LinkerPrivateLinkage and LinkerPrivateWeakLinkage are not included either;
 // they've been removed in upstream LLVM commit r203866.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum Linkage {
     ExternalLinkage = 0,
     AvailableExternallyLinkage = 1,

--- a/src/librustc_trans/partitioning.rs
+++ b/src/librustc_trans/partitioning.rs
@@ -304,7 +304,7 @@ fn characteristic_def_id_of_trans_item<'tcx>(tcx: &TyCtxt<'tcx>,
 
             Some(instance.def)
         }
-        TransItem::DropGlue(t) => characteristic_def_id_of_type(t),
+        TransItem::DropGlue(dg) => characteristic_def_id_of_type(dg.ty()),
         TransItem::Static(node_id) => Some(tcx.map.local_def_id(node_id)),
     }
 }

--- a/src/librustc_trans/partitioning.rs
+++ b/src/librustc_trans/partitioning.rs
@@ -116,8 +116,7 @@
 //! source-level module, functions from the same module will be available for
 //! inlining, even when they are not marked #[inline].
 
-use collector::{InliningMap, TransItem};
-use context::CrateContext;
+use collector::{TransItem, ReferenceMap};
 use monomorphize;
 use rustc::hir::def_id::DefId;
 use rustc::hir::map::DefPathData;
@@ -127,13 +126,27 @@ use llvm;
 use syntax::parse::token::{self, InternedString};
 use util::nodemap::{FnvHashMap, FnvHashSet};
 
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+pub enum InstantiationMode {
+    /// This variant indicates that a translation item should be placed in some
+    /// codegen unit as a definition and with the given linkage.
+    Def(llvm::Linkage),
+
+    /// This variant indicates that only a declaration of some translation item
+    /// should be placed in a given codegen unit.
+    Decl
+}
+
 pub struct CodegenUnit<'tcx> {
     pub name: InternedString,
-    pub items: FnvHashMap<TransItem<'tcx>, llvm::Linkage>,
+    pub items: FnvHashMap<TransItem<'tcx>, InstantiationMode>,
 }
 
 pub enum PartitioningStrategy {
+    /// Generate one codegen unit per source-level module.
     PerModule,
+
+    /// Partition the whole crate into a fixed number of codegen units.
     FixedUnitCount(usize)
 }
 
@@ -143,7 +156,7 @@ const FALLBACK_CODEGEN_UNIT: &'static str = "__rustc_fallback_codegen_unit";
 pub fn partition<'tcx, I>(tcx: &TyCtxt<'tcx>,
                           trans_items: I,
                           strategy: PartitioningStrategy,
-                          inlining_map: &InliningMap<'tcx>)
+                          reference_map: &ReferenceMap<'tcx>)
                           -> Vec<CodegenUnit<'tcx>>
     where I: Iterator<Item = TransItem<'tcx>>
 {
@@ -152,6 +165,8 @@ pub fn partition<'tcx, I>(tcx: &TyCtxt<'tcx>,
     // functions and statics defined in the local crate.
     let mut initial_partitioning = place_root_translation_items(tcx, trans_items);
 
+    // If the partitioning should produce a fixed count of codegen units, merge
+    // until that count is reached.
     if let PartitioningStrategy::FixedUnitCount(count) = strategy {
         merge_codegen_units(&mut initial_partitioning, count, &tcx.crate_name[..]);
     }
@@ -160,17 +175,27 @@ pub fn partition<'tcx, I>(tcx: &TyCtxt<'tcx>,
     // translation items have to go into each codegen unit. These additional
     // translation items can be drop-glue, functions from external crates, and
     // local functions the definition of which is marked with #[inline].
-    place_inlined_translation_items(initial_partitioning, inlining_map)
+    let post_inlining = place_inlined_translation_items(initial_partitioning,
+                                                        reference_map);
+
+    // Now we know all *definitions* within all codegen units, thus we can
+    // easily determine which declarations need to be placed within each one.
+    let post_declarations = place_declarations(post_inlining, reference_map);
+
+    post_declarations.0
 }
 
-struct InitialPartitioning<'tcx> {
+struct PreInliningPartitioning<'tcx> {
     codegen_units: Vec<CodegenUnit<'tcx>>,
     roots: FnvHashSet<TransItem<'tcx>>,
 }
 
+struct PostInliningPartitioning<'tcx>(Vec<CodegenUnit<'tcx>>);
+struct PostDeclarationsPartitioning<'tcx>(Vec<CodegenUnit<'tcx>>);
+
 fn place_root_translation_items<'tcx, I>(tcx: &TyCtxt<'tcx>,
                                          trans_items: I)
-                                         -> InitialPartitioning<'tcx>
+                                         -> PreInliningPartitioning<'tcx>
     where I: Iterator<Item = TransItem<'tcx>>
 {
     let mut roots = FnvHashSet();
@@ -214,12 +239,13 @@ fn place_root_translation_items<'tcx, I>(tcx: &TyCtxt<'tcx>,
                 }
             };
 
-            codegen_unit.items.insert(trans_item, linkage);
+            codegen_unit.items.insert(trans_item,
+                                      InstantiationMode::Def(linkage));
             roots.insert(trans_item);
         }
     }
 
-    InitialPartitioning {
+    PreInliningPartitioning {
         codegen_units: codegen_units.into_iter()
                                     .map(|(_, codegen_unit)| codegen_unit)
                                     .collect(),
@@ -227,7 +253,7 @@ fn place_root_translation_items<'tcx, I>(tcx: &TyCtxt<'tcx>,
     }
 }
 
-fn merge_codegen_units<'tcx>(initial_partitioning: &mut InitialPartitioning<'tcx>,
+fn merge_codegen_units<'tcx>(initial_partitioning: &mut PreInliningPartitioning<'tcx>,
                              target_cgu_count: usize,
                              crate_name: &str) {
     if target_cgu_count >= initial_partitioning.codegen_units.len() {
@@ -237,7 +263,9 @@ fn merge_codegen_units<'tcx>(initial_partitioning: &mut InitialPartitioning<'tcx
     assert!(target_cgu_count >= 1);
     let codegen_units = &mut initial_partitioning.codegen_units;
 
-    // Merge the two smallest codegen units until the target size is reached
+    // Merge the two smallest codegen units until the target size is reached.
+    // Note that "size" is estimated here rather inaccurately as the number of
+    // translation items in a given unit. This could be improved on.
     while codegen_units.len() > target_cgu_count {
         // Sort small cgus to the back
         codegen_units.as_mut_slice().sort_by_key(|cgu| -(cgu.items.len() as i64));
@@ -254,61 +282,86 @@ fn merge_codegen_units<'tcx>(initial_partitioning: &mut InitialPartitioning<'tcx
     }
 }
 
-fn place_inlined_translation_items<'tcx>(initial_partitioning: InitialPartitioning<'tcx>,
-                                         inlining_map: &InliningMap<'tcx>)
-                                         -> Vec<CodegenUnit<'tcx>> {
-    let mut final_partitioning = Vec::new();
+fn place_inlined_translation_items<'tcx>(initial_partitioning: PreInliningPartitioning<'tcx>,
+                                         reference_map: &ReferenceMap<'tcx>)
+                                         -> PostInliningPartitioning<'tcx> {
+    let mut new_partitioning = Vec::new();
 
     for codegen_unit in &initial_partitioning.codegen_units[..] {
         // Collect all items that need to be available in this codegen unit
         let mut reachable = FnvHashSet();
         for root in codegen_unit.items.keys() {
-            follow_inlining(*root, inlining_map, &mut reachable);
+            follow_inlining(*root, reference_map, &mut reachable);
         }
 
-        let mut final_codegen_unit = CodegenUnit {
+        let mut new_codegen_unit = CodegenUnit {
             name: codegen_unit.name.clone(),
             items: FnvHashMap(),
         };
 
         // Add all translation items that are not already there
         for trans_item in reachable {
-            if let Some(linkage) = codegen_unit.items.get(&trans_item) {
+            if let Some(instantiation_mode) = codegen_unit.items.get(&trans_item) {
                 // This is a root, just copy it over
-                final_codegen_unit.items.insert(trans_item, *linkage);
+                new_codegen_unit.items.insert(trans_item, *instantiation_mode);
             } else {
                 if initial_partitioning.roots.contains(&trans_item) {
                     // This item will be instantiated in some other codegen unit,
                     // so we just add it here with AvailableExternallyLinkage
-                    final_codegen_unit.items.insert(trans_item, llvm::AvailableExternallyLinkage);
+                    new_codegen_unit.items.insert(trans_item,
+                        InstantiationMode::Def(llvm::AvailableExternallyLinkage));
                 } else {
                     // We can't be sure if this will also be instantiated
                     // somewhere else, so we add an instance here with
                     // LinkOnceODRLinkage. That way the item can be discarded if
                     // it's not needed (inlined) after all.
-                    final_codegen_unit.items.insert(trans_item, llvm::LinkOnceODRLinkage);
+                    new_codegen_unit.items.insert(trans_item,
+                        InstantiationMode::Def(llvm::LinkOnceODRLinkage));
                 }
             }
         }
 
-        final_partitioning.push(final_codegen_unit);
+        new_partitioning.push(new_codegen_unit);
     }
 
-    return final_partitioning;
+    return PostInliningPartitioning(new_partitioning);
 
     fn follow_inlining<'tcx>(trans_item: TransItem<'tcx>,
-                             inlining_map: &InliningMap<'tcx>,
+                             reference_map: &ReferenceMap<'tcx>,
                              visited: &mut FnvHashSet<TransItem<'tcx>>) {
         if !visited.insert(trans_item) {
             return;
         }
 
-        if let Some(inlined_items) = inlining_map.get(&trans_item) {
-            for &inlined_item in inlined_items {
-                follow_inlining(inlined_item, inlining_map, visited);
+        reference_map.with_inlining_candidates(trans_item, |target| {
+            follow_inlining(target, reference_map, visited);
+        });
+    }
+}
+
+fn place_declarations<'tcx>(codegen_units: PostInliningPartitioning<'tcx>,
+                            reference_map: &ReferenceMap<'tcx>)
+                            -> PostDeclarationsPartitioning<'tcx> {
+    let PostInliningPartitioning(mut codegen_units) = codegen_units;
+
+    for codegen_unit in codegen_units.iter_mut() {
+        let mut declarations = FnvHashSet();
+
+        for (trans_item, _) in &codegen_unit.items {
+            for referenced_item in reference_map.get_direct_references_from(*trans_item) {
+                if !codegen_unit.items.contains_key(referenced_item) {
+                    declarations.insert(*referenced_item);
+                }
             }
         }
+
+        codegen_unit.items
+                    .extend(declarations.iter()
+                                        .map(|trans_item| (*trans_item,
+                                                           InstantiationMode::Decl)));
     }
+
+    PostDeclarationsPartitioning(codegen_units)
 }
 
 fn characteristic_def_id_of_trans_item<'tcx>(tcx: &TyCtxt<'tcx>,
@@ -376,25 +429,4 @@ fn compute_codegen_unit_name<'tcx>(tcx: &TyCtxt<'tcx>,
     }
 
     return token::intern_and_get_ident(&mod_path[..]);
-}
-
-impl<'tcx> CodegenUnit<'tcx> {
-    pub fn _dump<'a>(&self, ccx: &CrateContext<'a, 'tcx>) {
-        println!("CodegenUnit {} (", self.name);
-
-        let mut items: Vec<_> = self.items
-                                    .iter()
-                                    .map(|(trans_item, inst)| {
-                                        format!("{} -- ({:?})", trans_item.to_string(ccx), inst)
-                                    })
-                                    .collect();
-
-        items.as_mut_slice().sort();
-
-        for s in items {
-            println!("  {}", s);
-        }
-
-        println!(")");
-    }
 }

--- a/src/test/codegen-units/item-collection/generic-drop-glue.rs
+++ b/src/test/codegen-units/item-collection/generic-drop-glue.rs
@@ -46,19 +46,22 @@ struct NonGenericNoDrop(i32);
 
 struct NonGenericWithDrop(i32);
 //~ TRANS_ITEM drop-glue generic_drop_glue::NonGenericWithDrop[0]
+//~ TRANS_ITEM drop-glue-contents generic_drop_glue::NonGenericWithDrop[0]
 
 impl Drop for NonGenericWithDrop {
+    //~ TRANS_ITEM fn generic_drop_glue::{{impl}}[2]::drop[0]
     fn drop(&mut self) {}
-//~ TRANS_ITEM fn generic_drop_glue::{{impl}}[2]::drop[0]
 }
 
 //~ TRANS_ITEM fn generic_drop_glue::main[0]
 fn main() {
     //~ TRANS_ITEM drop-glue generic_drop_glue::StructWithDrop[0]<i8, char>
+    //~ TRANS_ITEM drop-glue-contents generic_drop_glue::StructWithDrop[0]<i8, char>
     //~ TRANS_ITEM fn generic_drop_glue::{{impl}}[0]::drop[0]<i8, char>
     let _ = StructWithDrop { x: 0i8, y: 'a' }.x;
 
     //~ TRANS_ITEM drop-glue generic_drop_glue::StructWithDrop[0]<&str, generic_drop_glue::NonGenericNoDrop[0]>
+    //~ TRANS_ITEM drop-glue-contents generic_drop_glue::StructWithDrop[0]<&str, generic_drop_glue::NonGenericNoDrop[0]>
     //~ TRANS_ITEM fn generic_drop_glue::{{impl}}[0]::drop[0]<&str, generic_drop_glue::NonGenericNoDrop[0]>
     let _ = StructWithDrop { x: "&str", y: NonGenericNoDrop(0) }.y;
 
@@ -71,6 +74,7 @@ fn main() {
     let _ = StructNoDrop { x: NonGenericWithDrop(0), y: 0f64 }.y;
 
     //~ TRANS_ITEM drop-glue generic_drop_glue::EnumWithDrop[0]<i32, i64>
+    //~ TRANS_ITEM drop-glue-contents generic_drop_glue::EnumWithDrop[0]<i32, i64>
     //~ TRANS_ITEM fn generic_drop_glue::{{impl}}[1]::drop[0]<i32, i64>
     let _ = match EnumWithDrop::A::<i32, i64>(0) {
         EnumWithDrop::A(x) => x,
@@ -78,6 +82,7 @@ fn main() {
     };
 
     //~ TRANS_ITEM drop-glue generic_drop_glue::EnumWithDrop[0]<f64, f32>
+    //~ TRANS_ITEM drop-glue-contents generic_drop_glue::EnumWithDrop[0]<f64, f32>
     //~ TRANS_ITEM fn generic_drop_glue::{{impl}}[1]::drop[0]<f64, f32>
     let _ = match EnumWithDrop::B::<f64, f32>(1.0) {
         EnumWithDrop::A(x) => x,

--- a/src/test/codegen-units/item-collection/non-generic-drop-glue.rs
+++ b/src/test/codegen-units/item-collection/non-generic-drop-glue.rs
@@ -14,6 +14,7 @@
 #![deny(dead_code)]
 
 //~ TRANS_ITEM drop-glue non_generic_drop_glue::StructWithDrop[0]
+//~ TRANS_ITEM drop-glue-contents non_generic_drop_glue::StructWithDrop[0]
 struct StructWithDrop {
     x: i32
 }
@@ -28,6 +29,7 @@ struct StructNoDrop {
 }
 
 //~ TRANS_ITEM drop-glue non_generic_drop_glue::EnumWithDrop[0]
+//~ TRANS_ITEM drop-glue-contents non_generic_drop_glue::EnumWithDrop[0]
 enum EnumWithDrop {
     A(i32)
 }

--- a/src/test/codegen-units/item-collection/transitive-drop-glue.rs
+++ b/src/test/codegen-units/item-collection/transitive-drop-glue.rs
@@ -18,6 +18,7 @@ struct Root(Intermediate);
 //~ TRANS_ITEM drop-glue transitive_drop_glue::Intermediate[0]
 struct Intermediate(Leaf);
 //~ TRANS_ITEM drop-glue transitive_drop_glue::Leaf[0]
+//~ TRANS_ITEM drop-glue-contents transitive_drop_glue::Leaf[0]
 struct Leaf;
 
 impl Drop for Leaf {
@@ -25,11 +26,8 @@ impl Drop for Leaf {
     fn drop(&mut self) {}
 }
 
-//~ TRANS_ITEM drop-glue transitive_drop_glue::Root[0]
 struct RootGen<T>(IntermediateGen<T>);
-//~ TRANS_ITEM drop-glue transitive_drop_glue::Root[0]
 struct IntermediateGen<T>(LeafGen<T>);
-//~ TRANS_ITEM drop-glue transitive_drop_glue::Root[0]
 struct LeafGen<T>(T);
 
 impl<T> Drop for LeafGen<T> {
@@ -44,12 +42,14 @@ fn main() {
     //~ TRANS_ITEM drop-glue transitive_drop_glue::RootGen[0]<u32>
     //~ TRANS_ITEM drop-glue transitive_drop_glue::IntermediateGen[0]<u32>
     //~ TRANS_ITEM drop-glue transitive_drop_glue::LeafGen[0]<u32>
+    //~ TRANS_ITEM drop-glue-contents transitive_drop_glue::LeafGen[0]<u32>
     //~ TRANS_ITEM fn transitive_drop_glue::{{impl}}[1]::drop[0]<u32>
     let _ = RootGen(IntermediateGen(LeafGen(0u32)));
 
     //~ TRANS_ITEM drop-glue transitive_drop_glue::RootGen[0]<i16>
     //~ TRANS_ITEM drop-glue transitive_drop_glue::IntermediateGen[0]<i16>
     //~ TRANS_ITEM drop-glue transitive_drop_glue::LeafGen[0]<i16>
+    //~ TRANS_ITEM drop-glue-contents transitive_drop_glue::LeafGen[0]<i16>
     //~ TRANS_ITEM fn transitive_drop_glue::{{impl}}[1]::drop[0]<i16>
     let _ = RootGen(IntermediateGen(LeafGen(0i16)));
 }

--- a/src/test/codegen-units/item-collection/tuple-drop-glue.rs
+++ b/src/test/codegen-units/item-collection/tuple-drop-glue.rs
@@ -14,6 +14,7 @@
 #![deny(dead_code)]
 
 //~ TRANS_ITEM drop-glue tuple_drop_glue::Dropped[0]
+//~ TRANS_ITEM drop-glue-contents tuple_drop_glue::Dropped[0]
 struct Dropped;
 
 impl Drop for Dropped {

--- a/src/test/codegen-units/partitioning/extern-drop-glue.rs
+++ b/src/test/codegen-units/partitioning/extern-drop-glue.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags:-Zprint-trans-items=lazy -Zincremental=""
+// compile-flags:-Zprint-trans-items=lazy -Zincremental=tmp
 
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/extern-drop-glue.rs
+++ b/src/test/codegen-units/partitioning/extern-drop-glue.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags:-Zprint-trans-items=lazy
+// compile-flags:-Zprint-trans-items=lazy -Zincremental=""
 
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/extern-drop-glue.rs
+++ b/src/test/codegen-units/partitioning/extern-drop-glue.rs
@@ -18,6 +18,7 @@
 extern crate cgu_extern_drop_glue;
 
 //~ TRANS_ITEM drop-glue cgu_extern_drop_glue::Struct[0] @@ extern_drop_glue[OnceODR] extern_drop_glue-mod1[OnceODR]
+//~ TRANS_ITEM drop-glue-contents cgu_extern_drop_glue::Struct[0] @@ extern_drop_glue[OnceODR] extern_drop_glue-mod1[OnceODR]
 
 struct LocalStruct(cgu_extern_drop_glue::Struct);
 
@@ -40,4 +41,3 @@ mod mod1 {
         let _ = LocalStruct(cgu_extern_drop_glue::Struct(0));
     }
 }
-

--- a/src/test/codegen-units/partitioning/extern-generic.rs
+++ b/src/test/codegen-units/partitioning/extern-generic.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags:-Zprint-trans-items=eager
+// compile-flags:-Zprint-trans-items=eager -Zincremental=""
 
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/extern-generic.rs
+++ b/src/test/codegen-units/partitioning/extern-generic.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags:-Zprint-trans-items=eager -Zincremental=""
+// compile-flags:-Zprint-trans-items=eager -Zincremental=tmp
 
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/inlining-from-extern-crate.rs
+++ b/src/test/codegen-units/partitioning/inlining-from-extern-crate.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags:-Zprint-trans-items=lazy
+// compile-flags:-Zprint-trans-items=lazy -Zincremental=""
 
 #![crate_type="lib"]
 

--- a/src/test/codegen-units/partitioning/inlining-from-extern-crate.rs
+++ b/src/test/codegen-units/partitioning/inlining-from-extern-crate.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags:-Zprint-trans-items=lazy -Zincremental=""
+// compile-flags:-Zprint-trans-items=lazy -Zincremental=tmp
 
 #![crate_type="lib"]
 

--- a/src/test/codegen-units/partitioning/local-drop-glue.rs
+++ b/src/test/codegen-units/partitioning/local-drop-glue.rs
@@ -15,6 +15,7 @@
 #![crate_type="lib"]
 
 //~ TRANS_ITEM drop-glue local_drop_glue::Struct[0] @@ local_drop_glue[OnceODR] local_drop_glue-mod1[OnceODR]
+//~ TRANS_ITEM drop-glue-contents local_drop_glue::Struct[0] @@ local_drop_glue[OnceODR] local_drop_glue-mod1[OnceODR]
 struct Struct {
     _a: u32
 }

--- a/src/test/codegen-units/partitioning/local-drop-glue.rs
+++ b/src/test/codegen-units/partitioning/local-drop-glue.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags:-Zprint-trans-items=lazy
+// compile-flags:-Zprint-trans-items=lazy -Zincremental=""
 
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/local-drop-glue.rs
+++ b/src/test/codegen-units/partitioning/local-drop-glue.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags:-Zprint-trans-items=lazy -Zincremental=""
+// compile-flags:-Zprint-trans-items=lazy -Zincremental=tmp
 
 #![allow(dead_code)]
 #![crate_type="lib"]
@@ -21,7 +21,7 @@ struct Struct {
 }
 
 impl Drop for Struct {
-    //~ TRANS_ITEM fn local_drop_glue::{{impl}}[0]::drop[0] @@ local_drop_glue[WeakODR]
+    //~ TRANS_ITEM fn local_drop_glue::{{impl}}[0]::drop[0] @@ local_drop_glue[WeakODR] local_drop_glue-mod1[Declaration]
     fn drop(&mut self) {}
 }
 

--- a/src/test/codegen-units/partitioning/local-generic.rs
+++ b/src/test/codegen-units/partitioning/local-generic.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags:-Zprint-trans-items=eager -Zincremental=""
+// compile-flags:-Zprint-trans-items=eager -Zincremental=tmp
 
 #![allow(dead_code)]
 #![crate_type="lib"]
@@ -17,10 +17,10 @@
 // Used in different modules/codegen units but always instantiated in the same
 // codegen unit.
 
-//~ TRANS_ITEM fn local_generic::generic[0]<u32> @@ local_generic.volatile[WeakODR]
-//~ TRANS_ITEM fn local_generic::generic[0]<u64> @@ local_generic.volatile[WeakODR]
-//~ TRANS_ITEM fn local_generic::generic[0]<char> @@ local_generic.volatile[WeakODR]
-//~ TRANS_ITEM fn local_generic::generic[0]<&str> @@ local_generic.volatile[WeakODR]
+//~ TRANS_ITEM fn local_generic::generic[0]<u32> @@ local_generic.volatile[WeakODR] local_generic[Declaration]
+//~ TRANS_ITEM fn local_generic::generic[0]<u64> @@ local_generic.volatile[WeakODR] local_generic-mod1[Declaration]
+//~ TRANS_ITEM fn local_generic::generic[0]<char> @@ local_generic.volatile[WeakODR] local_generic-mod1-mod1[Declaration]
+//~ TRANS_ITEM fn local_generic::generic[0]<&str> @@ local_generic.volatile[WeakODR] local_generic-mod2[Declaration]
 pub fn generic<T>(x: T) -> T { x }
 
 //~ TRANS_ITEM fn local_generic::user[0] @@ local_generic[WeakODR]

--- a/src/test/codegen-units/partitioning/local-generic.rs
+++ b/src/test/codegen-units/partitioning/local-generic.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags:-Zprint-trans-items=eager
+// compile-flags:-Zprint-trans-items=eager -Zincremental=""
 
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/local-inlining.rs
+++ b/src/test/codegen-units/partitioning/local-inlining.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags:-Zprint-trans-items=lazy -Zincremental=""
+// compile-flags:-Zprint-trans-items=lazy -Zincremental=tmp
 
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/local-inlining.rs
+++ b/src/test/codegen-units/partitioning/local-inlining.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags:-Zprint-trans-items=lazy
+// compile-flags:-Zprint-trans-items=lazy -Zincremental=""
 
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/local-transitive-inlining.rs
+++ b/src/test/codegen-units/partitioning/local-transitive-inlining.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags:-Zprint-trans-items=lazy -Zincremental=""
+// compile-flags:-Zprint-trans-items=lazy -Zincremental=tmp
 
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/local-transitive-inlining.rs
+++ b/src/test/codegen-units/partitioning/local-transitive-inlining.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags:-Zprint-trans-items=lazy
+// compile-flags:-Zprint-trans-items=lazy -Zincremental=""
 
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/methods-are-with-self-type.rs
+++ b/src/test/codegen-units/partitioning/methods-are-with-self-type.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags:-Zprint-trans-items=lazy -Zincremental=""
+// compile-flags:-Zprint-trans-items=lazy -Zincremental=tmp
 
 #![allow(dead_code)]
 
@@ -59,19 +59,19 @@ mod type2 {
 //~ TRANS_ITEM fn methods_are_with_self_type::main[0]
 fn main()
 {
-    //~ TRANS_ITEM fn methods_are_with_self_type::mod1[0]::{{impl}}[1]::method[0]<u32, u64> @@ methods_are_with_self_type.volatile[WeakODR]
+    //~ TRANS_ITEM fn methods_are_with_self_type::mod1[0]::{{impl}}[1]::method[0]<u32, u64> @@ methods_are_with_self_type.volatile[WeakODR] methods_are_with_self_type[Declaration]
     SomeGenericType(0u32, 0u64).method();
-    //~ TRANS_ITEM fn methods_are_with_self_type::mod1[0]::{{impl}}[1]::associated_fn[0]<char, &str> @@ methods_are_with_self_type.volatile[WeakODR]
+    //~ TRANS_ITEM fn methods_are_with_self_type::mod1[0]::{{impl}}[1]::associated_fn[0]<char, &str> @@ methods_are_with_self_type.volatile[WeakODR] methods_are_with_self_type[Declaration]
     SomeGenericType::associated_fn('c', "&str");
 
-    //~ TRANS_ITEM fn methods_are_with_self_type::{{impl}}[0]::foo[0]<methods_are_with_self_type::type1[0]::Struct[0]> @@ methods_are_with_self_type-type1.volatile[WeakODR]
+    //~ TRANS_ITEM fn methods_are_with_self_type::{{impl}}[0]::foo[0]<methods_are_with_self_type::type1[0]::Struct[0]> @@ methods_are_with_self_type-type1.volatile[WeakODR] methods_are_with_self_type[Declaration]
     type1::Struct.foo();
-    //~ TRANS_ITEM fn methods_are_with_self_type::{{impl}}[0]::foo[0]<methods_are_with_self_type::type2[0]::Struct[0]> @@ methods_are_with_self_type-type2.volatile[WeakODR]
+    //~ TRANS_ITEM fn methods_are_with_self_type::{{impl}}[0]::foo[0]<methods_are_with_self_type::type2[0]::Struct[0]> @@ methods_are_with_self_type-type2.volatile[WeakODR] methods_are_with_self_type[Declaration]
     type2::Struct.foo();
 
-    //~ TRANS_ITEM fn methods_are_with_self_type::Trait[0]::default[0]<methods_are_with_self_type::type1[0]::Struct[0]> @@ methods_are_with_self_type-type1.volatile[WeakODR]
+    //~ TRANS_ITEM fn methods_are_with_self_type::Trait[0]::default[0]<methods_are_with_self_type::type1[0]::Struct[0]> @@ methods_are_with_self_type-type1.volatile[WeakODR] methods_are_with_self_type[Declaration]
     type1::Struct.default();
-    //~ TRANS_ITEM fn methods_are_with_self_type::Trait[0]::default[0]<methods_are_with_self_type::type2[0]::Struct[0]> @@ methods_are_with_self_type-type2.volatile[WeakODR]
+    //~ TRANS_ITEM fn methods_are_with_self_type::Trait[0]::default[0]<methods_are_with_self_type::type2[0]::Struct[0]> @@ methods_are_with_self_type-type2.volatile[WeakODR] methods_are_with_self_type[Declaration]
     type2::Struct.default();
 }
 

--- a/src/test/codegen-units/partitioning/methods-are-with-self-type.rs
+++ b/src/test/codegen-units/partitioning/methods-are-with-self-type.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags:-Zprint-trans-items=lazy
+// compile-flags:-Zprint-trans-items=lazy -Zincremental=""
 
 #![allow(dead_code)]
 

--- a/src/test/codegen-units/partitioning/regular-modules.rs
+++ b/src/test/codegen-units/partitioning/regular-modules.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags:-Zprint-trans-items=eager
+// compile-flags:-Zprint-trans-items=eager -Z incremental=""
 
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/regular-modules.rs
+++ b/src/test/codegen-units/partitioning/regular-modules.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags:-Zprint-trans-items=eager -Z incremental=""
+// compile-flags:-Zprint-trans-items=eager -Z incremental=tmp
 
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/statics.rs
+++ b/src/test/codegen-units/partitioning/statics.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags:-Zprint-trans-items=lazy
+// compile-flags:-Zprint-trans-items=lazy -Zincremental=""
 
 #![crate_type="lib"]
 

--- a/src/test/codegen-units/partitioning/statics.rs
+++ b/src/test/codegen-units/partitioning/statics.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// compile-flags:-Zprint-trans-items=lazy -Zincremental=""
+// compile-flags:-Zprint-trans-items=lazy -Zincremental=tmp
 
 #![crate_type="lib"]
 


### PR DESCRIPTION
The `trans::collector` already collects all translation items and `trans::partitioning` distributes these translation items into codegen units. The changes in this PR provide the following extensions to this functionality:
1. Drop-glue is handled more accurately now, knowing about the difference between `DropGlueKind::Ty` and `DropGlueKind::TyContents`.
2. The partitioning module now supports the `FixedUnitCount` strategy which more or less corresponds to the partitioning one gets via supplying `-Ccodegen-units` today.
3. The partitioning scheme also takes care of assigned LLVM declarations to codegen units, not just definitions (declarations for external items not yet implemented).

It's debatable whether declarations should be handled by the partitioning scheme or whether they should just be emitted on demand.
