### PR TITLE
resolve: improve diagnostics and lay groundwork for resolving before ast->hir

### DIFF
--- a/src/test/compile-fail/const-pattern-irrefutable.rs
+++ b/src/test/compile-fail/const-pattern-irrefutable.rs
@@ -9,8 +9,8 @@
 // except according to those terms.
 
 mod foo {
-    pub const b: u8 = 2; //~ NOTE constant defined here
-    pub const d: u8 = 2; //~ NOTE constant defined here
+    pub const b: u8 = 2;
+    pub const d: u8 = 2;
 }
 
 use foo::b as c; //~ NOTE constant imported here

--- a/src/test/compile-fail/suggest-path-instead-of-mod-dot-item.rs
+++ b/src/test/compile-fail/suggest-path-instead-of-mod-dot-item.rs
@@ -47,10 +47,14 @@ fn h4() -> i32 {
         //~| HELP To reference an item from the `a::b` module, use `a::b::J`
 }
 
-fn h5() -> i32 {
-    a.b.f()
+fn h5() {
+    a.b.f();
         //~^ ERROR E0425
         //~| HELP To reference an item from the `a` module, use `a::b`
+    let v = Vec::new();
+    v.push(a::b);
+        //~^ ERROR E0425
+        //~| HELP Module `a::b` cannot be used as an expression
 }
 
 fn h6() -> i32 {
@@ -62,11 +66,11 @@ fn h6() -> i32 {
 fn h7() {
     a::b
         //~^ ERROR E0425
-        //~| HELP Module `a::b` cannot be the value of an expression
+        //~| HELP Module `a::b` cannot be used as an expression
 }
 
 fn h8() -> i32 {
     a::b()
         //~^ ERROR E0425
-        //~| HELP No function corresponds to `a::b(..)`
+        //~| HELP Module `a::b` cannot be used as an expression
 }


### PR DESCRIPTION
This PR improves diagnostics in `resolve` and lays some groundwork for resolving before ast->hir.

More specifically,
- It removes an API in `resolve` intended for external refactoring tools (see #27493) that appears not to be in active use. The API is incompatible with resolving before ast->hir, but could be rewritten in a more compatible and less intrusive way.
- It improves the diagnostics for pattern bindings that conflict with `const`s.
- It improves the diagnostics for modules used as expressions (fixes #33186).
- It refactors away some uses of the hir map, which is unavavailable before ast->hir lowering.

r? @eddyb
