### PR TITLE
Improve error message about regions of function body

### DIFF
--- a/src/librustc/infer/error_reporting.rs
+++ b/src/librustc/infer/error_reporting.rs
@@ -158,7 +158,7 @@ impl<'tcx> TyCtxt<'tcx> {
                         "scope of call-site for function"
                     }
                     region::CodeExtentData::ParameterScope { .. } => {
-                        "scope of parameters for function"
+                        "scope of function body"
                     }
                     region::CodeExtentData::DestructionScope(_) => {
                         new_string = format!("destruction scope surrounding {}", tag);


### PR DESCRIPTION
"scope of parameters for functions" is harder for me to read than "scope of function body", I hope others feel the same, as in https://play.rust-lang.org/?gist=b4df68b395b807698bd2ba98cf3d5ce3&version=stable&backtrace=0&run=1
 Thank @Aatch for the help :)
