### PR TITLE
resolve: cleanup and groundwork for resolving the AST

### DIFF
--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -290,12 +290,14 @@ pub trait NodeIdTree {
 impl<'a> NodeIdTree for ast_map::Map<'a> {
     fn is_descendant_of(&self, node: NodeId, ancestor: NodeId) -> bool {
         let mut node_ancestor = node;
-        loop {
-            if node_ancestor == ancestor { return true }
+        while node_ancestor != ancestor {
             let node_ancestor_parent = self.get_module_parent(node_ancestor);
-            if node_ancestor_parent == node_ancestor { return false }
+            if node_ancestor_parent == node_ancestor {
+                return false;
+            }
             node_ancestor = node_ancestor_parent;
         }
+        true
     }
 }
 

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -283,6 +283,22 @@ pub enum Visibility {
     PrivateExternal,
 }
 
+pub trait NodeIdTree {
+    fn is_descendant_of(&self, node: NodeId, ancestor: NodeId) -> bool;
+}
+
+impl<'a> NodeIdTree for ast_map::Map<'a> {
+    fn is_descendant_of(&self, node: NodeId, ancestor: NodeId) -> bool {
+        let mut node_ancestor = node;
+        loop {
+            if node_ancestor == ancestor { return true }
+            let node_ancestor_parent = self.get_module_parent(node_ancestor);
+            if node_ancestor_parent == node_ancestor { return false }
+            node_ancestor = node_ancestor_parent;
+        }
+    }
+}
+
 impl Visibility {
     pub fn from_hir(visibility: &hir::Visibility, id: NodeId, tcx: &TyCtxt) -> Self {
         match *visibility {
@@ -301,7 +317,7 @@ impl Visibility {
     }
 
     /// Returns true if an item with this visibility is accessible from the given block.
-    pub fn is_accessible_from(self, block: NodeId, map: &ast_map::Map) -> bool {
+    pub fn is_accessible_from<T: NodeIdTree>(self, block: NodeId, tree: &T) -> bool {
         let restriction = match self {
             // Public items are visible everywhere.
             Visibility::Public => return true,
@@ -311,24 +327,18 @@ impl Visibility {
             Visibility::Restricted(module) => module,
         };
 
-        let mut block_ancestor = block;
-        loop {
-            if block_ancestor == restriction { return true }
-            let block_ancestor_parent = map.get_module_parent(block_ancestor);
-            if block_ancestor_parent == block_ancestor { return false }
-            block_ancestor = block_ancestor_parent;
-        }
+        tree.is_descendant_of(block, restriction)
     }
 
     /// Returns true if this visibility is at least as accessible as the given visibility
-    pub fn is_at_least(self, vis: Visibility, map: &ast_map::Map) -> bool {
+    pub fn is_at_least<T: NodeIdTree>(self, vis: Visibility, tree: &T) -> bool {
         let vis_restriction = match vis {
             Visibility::Public => return self == Visibility::Public,
             Visibility::PrivateExternal => return true,
             Visibility::Restricted(module) => module,
         };
 
-        self.is_accessible_from(vis_restriction, map)
+        self.is_accessible_from(vis_restriction, tree)
     }
 }
 

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -48,13 +48,13 @@ trait ToNameBinding<'a> {
 
 impl<'a> ToNameBinding<'a> for (Module<'a>, Span, ty::Visibility) {
     fn to_name_binding(self) -> NameBinding<'a> {
-        NameBinding { kind: NameBindingKind::Module(self.0), span: Some(self.1), vis: self.2 }
+        NameBinding { kind: NameBindingKind::Module(self.0), span: self.1, vis: self.2 }
     }
 }
 
 impl<'a> ToNameBinding<'a> for (Def, Span, ty::Visibility) {
     fn to_name_binding(self) -> NameBinding<'a> {
-        NameBinding { kind: NameBindingKind::Def(self.0), span: Some(self.1), vis: self.2 }
+        NameBinding { kind: NameBindingKind::Def(self.0), span: self.1, vis: self.2 }
     }
 }
 

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1125,14 +1125,14 @@ impl<'a, 'tcx> ty::NodeIdTree for Resolver<'a, 'tcx> {
     fn is_descendant_of(&self, node: NodeId, ancestor: NodeId) -> bool {
         let ancestor = self.ast_map.local_def_id(ancestor);
         let mut module = *self.module_map.get(&node).unwrap();
-        loop {
-            if module.def_id() == Some(ancestor) { return true; }
+        while module.def_id() != Some(ancestor) {
             let module_parent = match self.get_nearest_normal_module_parent(module) {
                 Some(parent) => parent,
                 None => return false,
             };
             module = module_parent;
         }
+        true
     }
 }
 

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -26,7 +26,7 @@ use rustc::hir::def::*;
 
 use syntax::ast::{NodeId, Name};
 use syntax::attr::AttrMetaMethods;
-use syntax::codemap::Span;
+use syntax::codemap::{Span, DUMMY_SP};
 use syntax::util::lev_distance::find_best_match_for_name;
 
 use std::cell::{Cell, RefCell};
@@ -76,7 +76,7 @@ impl<'a> ImportDirective<'a> {
                 directive: self,
                 privacy_error: privacy_error,
             },
-            span: Some(self.span),
+            span: self.span,
             vis: self.vis,
         }
     }
@@ -412,7 +412,7 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
         if let SingleImport { target, .. } = e.import_directive.subclass {
             let dummy_binding = self.resolver.arenas.alloc_name_binding(NameBinding {
                 kind: NameBindingKind::Def(Def::Err),
-                span: None,
+                span: DUMMY_SP,
                 vis: ty::Visibility::Public,
             });
             let dummy_binding = e.import_directive.import(dummy_binding, None);
@@ -696,7 +696,7 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
                                        (error E0364), consider declaring its enum as `pub`",
                                       name);
                     let lint = lint::builtin::PRIVATE_IN_PUBLIC;
-                    self.resolver.session.add_lint(lint, directive.id, binding.span.unwrap(), msg);
+                    self.resolver.session.add_lint(lint, directive.id, binding.span, msg);
                 }
             }
         }

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -552,9 +552,9 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
             _ => (),
         }
 
-        let ast_map = self.resolver.ast_map;
         match (&value_result, &type_result) {
-            (&Success(binding), _) if !binding.pseudo_vis().is_at_least(directive.vis, ast_map) &&
+            (&Success(binding), _) if !binding.pseudo_vis()
+                                              .is_at_least(directive.vis, self.resolver) &&
                                       self.resolver.is_accessible(binding.vis) => {
                 let msg = format!("`{}` is private, and cannot be reexported", source);
                 let note_msg = format!("consider marking `{}` as `pub` in the imported module",
@@ -564,7 +564,8 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
                     .emit();
             }
 
-            (_, &Success(binding)) if !binding.pseudo_vis().is_at_least(directive.vis, ast_map) &&
+            (_, &Success(binding)) if !binding.pseudo_vis()
+                                              .is_at_least(directive.vis, self.resolver) &&
                                       self.resolver.is_accessible(binding.vis) => {
                 if binding.is_extern_crate() {
                     let msg = format!("extern crate `{}` is private, and cannot be reexported \
@@ -691,7 +692,7 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
 
             if let NameBindingKind::Import { binding: orig_binding, directive, .. } = binding.kind {
                 if ns == TypeNS && orig_binding.is_variant() &&
-                   !orig_binding.vis.is_at_least(binding.vis, &self.resolver.ast_map) {
+                   !orig_binding.vis.is_at_least(binding.vis, self.resolver) {
                     let msg = format!("variant `{}` is private, and cannot be reexported \
                                        (error E0364), consider declaring its enum as `pub`",
                                       name);


### PR DESCRIPTION
Cleanup `resolve` and refactor away uses of the hir map (incorrectly named `ast_map`).
r? @nrc 
