### PR TITLE
Fix transmute::<T, U> where T requires a bigger alignment than U

### DIFF
--- a/src/librustc_trans/intrinsic.rs
+++ b/src/librustc_trans/intrinsic.rs
@@ -227,7 +227,28 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
                         expr::SaveIn(d) => expr::SaveIn(PointerCast(bcx, d, llintype.ptr_to())),
                         expr::Ignore => expr::Ignore
                     };
-                    bcx = expr::trans_into(bcx, &arg_exprs[0], dest);
+                    let in_align = type_of::align_of(ccx, in_type);
+                    let out_align = type_of::align_of(ccx, out_type);
+                    if out_align >= in_align {
+                        bcx = expr::trans_into(bcx, &arg_exprs[0], dest);
+                    } else {
+                        let datum = unpack_datum!(bcx, expr::trans(bcx, &arg_exprs[0]));
+                        let datum = unpack_datum!(bcx, datum.to_rvalue_datum(bcx, "transmute"));
+                        match dest {
+                            expr::SaveIn(d) => {
+                                if datum.kind.is_by_ref() {
+                                    let llsz = machine::llsize_of(bcx.ccx(), llouttype);
+                                    call_memcpy(&B(bcx), d, datum.val, llsz, out_align as u32);
+                                } else {
+                                    let store = Store(bcx, datum.val, d);
+                                    unsafe {
+                                        llvm::LLVMSetAlignment(store, out_align);
+                                    }
+                                }
+                            }
+                            expr::Ignore => {}
+                        }
+                    }
                     dest
                 };
 

--- a/src/test/run-pass/issue-32947.rs
+++ b/src/test/run-pass/issue-32947.rs
@@ -1,0 +1,36 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(repr_simd, test)]
+
+extern crate test;
+
+#[repr(simd)]
+pub struct Mu64(pub u64, pub u64, pub u64, pub u64);
+
+#[inline(never)]
+fn new(x: u64) -> Mu64 {
+    Mu64(x, x, x, x)
+}
+
+#[inline(never)]
+fn invoke_doom(x: &u8) -> [u8; 32] {
+    // This transmute used to directly store the SIMD vector into a location
+    // that isn't necessarily properly aligned
+    unsafe { std::mem::transmute(new(*x as u64)) }
+}
+
+fn main() {
+    // Try to get the dest for the invoke_doom calls to be misaligned even in optimized builds
+    let x = 0;
+    test::black_box(invoke_doom(&x));
+    let y = 1;
+    test::black_box(invoke_doom(&y));
+}


### PR DESCRIPTION
For types that are not bitcast-compatible, transmute tries to avoid
generating a temporary by translating its source expression directly
into its destination, but when the source type has a bigger alignment
requirement than the destination, this can lead to code that breaks due
to misaligned stores. So in that case we need to generate a temporary
for the source expression and then copy that into the destination,
setting the proper alignment information on the memcpy/store.

Fixes #32947
