### PR TITLE
Fix use of the `move` command in the Windows shell

### DIFF
--- a/src/doc/book/getting-started.md
+++ b/src/doc/book/getting-started.md
@@ -412,7 +412,7 @@ enter the following commands:
 
 ```bash
 $ mkdir src
-$ mv main.rs src/main.rs
+$ mv main.rs src/main.rs # or 'move main.rs src/main.rs' on Windows
 $ rm main  # or 'del main.exe' on Windows
 ```
 


### PR DESCRIPTION
`move` works both in `cmd` and in Powershell. `mv` works only in Powershell and the book says nothing about which shell is recommended so this could confuse beginners.

Closes #33219.
