### PR TITLE
rustc_save_analysis: fix a bug in which glob imports are not dumped

### DIFF
--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -1032,8 +1032,8 @@ impl<'v, 'l, 'tcx: 'l, 'll, D: Dump +'ll> Visitor<'v> for DumpVisitor<'l, 'tcx, 
                         }
 
                         let sub_span = self.span
-                                           .sub_span_of_token(path.span, token::BinOp(token::Star));
-                        if !self.span.filter_generated(sub_span, path.span) {
+                                           .sub_span_of_token(item.span, token::BinOp(token::Star));
+                        if !self.span.filter_generated(sub_span, item.span) {
                             self.dumper.use_glob(UseGlobData {
                                 span: sub_span.expect("No span found for use glob"),
                                 id: item.id,


### PR DESCRIPTION
This fixes #33213, a bug that prevents glob imports from being included in the save-analysis data.
r? @nrc
