### PR TITLE
Fix a typo in error messages in std::fs tests

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1543,7 +1543,7 @@ mod tests {
         let result = File::open(filename);
 
         if cfg!(unix) {
-            error!(result, "o such file or directory");
+            error!(result, "No such file or directory");
         }
         if cfg!(windows) {
             error!(result, "The system cannot find the file specified");
@@ -1558,7 +1558,7 @@ mod tests {
         let result = fs::remove_file(filename);
 
         if cfg!(unix) {
-            error!(result, "o such file or directory");
+            error!(result, "No such file or directory");
         }
         if cfg!(windows) {
             error!(result, "The system cannot find the file specified");


### PR DESCRIPTION
Just a small correction to fix a typo in an error message in std::fs tests
