### PR TITLE
Remove IPV6_V6ONLY functionality

### DIFF
--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -221,29 +221,6 @@ impl TcpStream {
         self.0.ttl()
     }
 
-    /// Sets the value for the `IPV6_V6ONLY` option on this socket.
-    ///
-    /// If this is set to `true` then the socket is restricted to sending and
-    /// receiving IPv6 packets only. If this is the case, an IPv4 and an IPv6
-    /// application can each bind the same port at the same time.
-    ///
-    /// If this is set to `false` then the socket can be used to send and
-    /// receive packets from an IPv4-mapped IPv6 address.
-    #[stable(feature = "net2_mutators", since = "1.9.0")]
-    pub fn set_only_v6(&self, only_v6: bool) -> io::Result<()> {
-        self.0.set_only_v6(only_v6)
-    }
-
-    /// Gets the value of the `IPV6_V6ONLY` option for this socket.
-    ///
-    /// For more information about this option, see [`set_only_v6`][link].
-    ///
-    /// [link]: #method.set_only_v6
-    #[stable(feature = "net2_mutators", since = "1.9.0")]
-    pub fn only_v6(&self) -> io::Result<bool> {
-        self.0.only_v6()
-    }
-
     /// Get the value of the `SO_ERROR` option on this socket.
     ///
     /// This will retrieve the stored error in the underlying socket, clearing

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -243,29 +243,6 @@ impl UdpSocket {
         self.0.ttl()
     }
 
-    /// Sets the value for the `IPV6_V6ONLY` option on this socket.
-    ///
-    /// If this is set to `true` then the socket is restricted to sending and
-    /// receiving IPv6 packets only. If this is the case, an IPv4 and an IPv6
-    /// application can each bind the same port at the same time.
-    ///
-    /// If this is set to `false` then the socket can be used to send and
-    /// receive packets from an IPv4-mapped IPv6 address.
-    #[stable(feature = "net2_mutators", since = "1.9.0")]
-    pub fn set_only_v6(&self, only_v6: bool) -> io::Result<()> {
-        self.0.set_only_v6(only_v6)
-    }
-
-    /// Gets the value of the `IPV6_V6ONLY` option for this socket.
-    ///
-    /// For more information about this option, see [`set_only_v6`][link].
-    ///
-    /// [link]: #method.set_only_v6
-    #[stable(feature = "net2_mutators", since = "1.9.0")]
-    pub fn only_v6(&self) -> io::Result<bool> {
-        self.0.only_v6()
-    }
-
     /// Executes an operation of the `IP_ADD_MEMBERSHIP` type.
     ///
     /// This function specifies a new multicast group for this socket to join.

--- a/src/libstd/sys/common/net.rs
+++ b/src/libstd/sys/common/net.rs
@@ -247,15 +247,6 @@ impl TcpStream {
         Ok(raw as u32)
     }
 
-    pub fn set_only_v6(&self, only_v6: bool) -> io::Result<()> {
-        setsockopt(&self.inner, c::IPPROTO_IPV6, c::IPV6_V6ONLY, only_v6 as c_int)
-    }
-
-    pub fn only_v6(&self) -> io::Result<bool> {
-        let raw: c_int = getsockopt(&self.inner, c::IPPROTO_IPV6, c::IPV6_V6ONLY)?;
-        Ok(raw != 0)
-    }
-
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
         self.inner.take_error()
     }
@@ -542,15 +533,6 @@ impl UdpSocket {
     pub fn ttl(&self) -> io::Result<u32> {
         let raw: c_int = getsockopt(&self.inner, c::IPPROTO_IP, c::IP_TTL)?;
         Ok(raw as u32)
-    }
-
-    pub fn set_only_v6(&self, only_v6: bool) -> io::Result<()> {
-        setsockopt(&self.inner, c::IPPROTO_IPV6, c::IPV6_V6ONLY, only_v6 as c_int)
-    }
-
-    pub fn only_v6(&self) -> io::Result<bool> {
-        let raw: c_int = getsockopt(&self.inner, c::IPPROTO_IPV6, c::IPV6_V6ONLY)?;
-        Ok(raw != 0)
     }
 
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {


### PR DESCRIPTION
These settings can only be adjusted before bind time, which doesn't make
sense in the current set of functionality. These methods are stable, but
haven't hit a stable release yet.

Closes #33052

[breaking-change]

(cherry picked from commit c6480e8b6b13401030c52f3c2b4fcc4e80c14481)

r? @alexcrichton 
