### PR TITLE
Prepare ConstVal for constant propagators and reduce `eval_const_expr` in MIR

### DIFF
--- a/src/librustc/middle/const_val.rs
+++ b/src/librustc/middle/const_val.rs
@@ -27,7 +27,9 @@ pub enum ConstVal {
     ByteStr(Rc<Vec<u8>>),
     Bool(bool),
     Struct(DefId, BTreeMap<ast::Name, ConstVal>),
+    /// Tuple or Tuple structs
     Tuple(Option<DefId>, Vec<ConstVal>),
+    /// A function pointer
     Function(DefId),
     Array(Vec<ConstVal>),
     Repeat(Box<ConstVal>, u64),

--- a/src/librustc/middle/const_val.rs
+++ b/src/librustc/middle/const_val.rs
@@ -17,6 +17,8 @@ use std::mem::transmute;
 use rustc_const_math::*;
 use self::ConstVal::*;
 
+use std::collections::BTreeMap;
+
 #[derive(Clone, Debug, RustcEncodable, RustcDecodable)]
 pub enum ConstVal {
     Float(f64),
@@ -24,11 +26,11 @@ pub enum ConstVal {
     Str(InternedString),
     ByteStr(Rc<Vec<u8>>),
     Bool(bool),
-    Struct(ast::NodeId),
-    Tuple(ast::NodeId),
+    Struct(DefId, BTreeMap<ast::Name, ConstVal>),
+    Tuple(Option<DefId>, Vec<ConstVal>),
     Function(DefId),
-    Array(ast::NodeId, u64),
-    Repeat(ast::NodeId, u64),
+    Array(Vec<ConstVal>),
+    Repeat(Box<ConstVal>, u64),
     Char(char),
     /// A value that only occurs in case `eval_const_expr` reported an error. You should never
     /// handle this case. Its sole purpose is to allow more errors to be reported instead of
@@ -44,11 +46,26 @@ impl hash::Hash for ConstVal {
             Str(ref a) => a.hash(state),
             ByteStr(ref a) => a.hash(state),
             Bool(a) => a.hash(state),
-            Struct(a) => a.hash(state),
-            Tuple(a) => a.hash(state),
+            Struct(did, ref tree) => {
+                did.hash(state);
+                for (name, val) in tree {
+                    name.hash(state);
+                    val.hash(state);
+                }
+            },
+            Tuple(did, ref v) => {
+                did.hash(state);
+                for elem in v {
+                    elem.hash(state);
+                }
+            },
             Function(a) => a.hash(state),
-            Array(a, n) => { a.hash(state); n.hash(state) },
-            Repeat(a, n) => { a.hash(state); n.hash(state) },
+            Array(ref v) => {
+                for elem in v {
+                    elem.hash(state);
+                }
+            }
+            Repeat(ref a, n) => { a.hash(state); n.hash(state) },
             Char(c) => c.hash(state),
             Dummy => ().hash(state),
         }
@@ -67,11 +84,11 @@ impl PartialEq for ConstVal {
             (&Str(ref a), &Str(ref b)) => a == b,
             (&ByteStr(ref a), &ByteStr(ref b)) => a == b,
             (&Bool(a), &Bool(b)) => a == b,
-            (&Struct(a), &Struct(b)) => a == b,
-            (&Tuple(a), &Tuple(b)) => a == b,
+            (&Struct(a_did, ref a), &Struct(b_did, ref b)) => (a == b) && (a_did == b_did),
+            (&Tuple(ref a_did, ref a), &Tuple(ref b_did, ref b)) => (a == b) && (a_did == b_did),
             (&Function(a), &Function(b)) => a == b,
-            (&Array(a, an), &Array(b, bn)) => (a == b) && (an == bn),
-            (&Repeat(a, an), &Repeat(b, bn)) => (a == b) && (an == bn),
+            (&Array(ref a), &Array(ref b)) => a == b,
+            (&Repeat(ref a, an), &Repeat(ref b, bn)) => (a == b) && (an == bn),
             (&Char(a), &Char(b)) => a == b,
             (&Dummy, &Dummy) => true, // FIXME: should this be false?
             _ => false,
@@ -89,8 +106,8 @@ impl ConstVal {
             Str(_) => "string literal",
             ByteStr(_) => "byte string literal",
             Bool(_) => "boolean",
-            Struct(_) => "struct",
-            Tuple(_) => "tuple",
+            Struct(..) => "struct",
+            Tuple(..) => "tuple",
             Function(_) => "function definition",
             Array(..) => "array",
             Repeat(..) => "repeat",

--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -22,7 +22,7 @@ use std::borrow::{Cow};
 use std::fmt::{self, Debug, Formatter, Write};
 use std::{iter, u32};
 use std::ops::{Index, IndexMut};
-use syntax::ast::{self, Name};
+use syntax::ast::Name;
 use syntax::codemap::Span;
 
 /// Lowered representation of a single function.
@@ -1039,15 +1039,46 @@ fn fmt_const_val<W: Write>(fmt: &mut W, const_val: &ConstVal) -> fmt::Result {
         }
         Bool(b) => write!(fmt, "{:?}", b),
         Function(def_id) => write!(fmt, "{}", item_path_str(def_id)),
-        Struct(node_id) | Tuple(node_id) | Array(node_id, _) | Repeat(node_id, _) =>
-            write!(fmt, "{}", node_to_string(node_id)),
+        Struct(def_id, ref tree) => {
+            write!(fmt, "{}", item_path_str(def_id))?;
+            if !tree.is_empty() {
+                write!(fmt, "{{")?;
+                for (name, val) in tree {
+                    write!(fmt, "{}:", name)?;
+                    fmt_const_val(fmt, val)?;
+                    write!(fmt, ",")?;
+                }
+                write!(fmt, "}}")?;
+            }
+            Ok(())
+        },
+        Tuple(def_id, ref v) => {
+            if let Some(def_id) = def_id {
+                write!(fmt, "{}", item_path_str(def_id))?;
+            }
+            write!(fmt, "(")?;
+            for val in v {
+                fmt_const_val(fmt, val)?;
+                write!(fmt, ",")?;
+            }
+            write!(fmt, ")")
+        },
+        Array(ref v) => {
+            write!(fmt, "[")?;
+            for val in v {
+                fmt_const_val(fmt, val)?;
+                write!(fmt, ",")?;
+            }
+            write!(fmt, "]")
+        },
+        Repeat(ref v, n) => {
+            write!(fmt, "[")?;
+            fmt_const_val(fmt, v)?;
+            write!(fmt, ";{}]", n)
+        },
         Char(c) => write!(fmt, "{:?}", c),
         Dummy => bug!(),
     }
-}
-
-fn node_to_string(node_id: ast::NodeId) -> String {
-    ty::tls::with(|tcx| tcx.map.node_to_user_string(node_id))
 }
 
 fn item_path_str(def_id: DefId) -> String {

--- a/src/librustc_const_eval/eval.rs
+++ b/src/librustc_const_eval/eval.rs
@@ -827,7 +827,7 @@ pub fn eval_const_expr_partial<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
       hir::ExprBlock(ref block) => {
         match block.expr {
             Some(ref expr) => eval_const_expr_partial(tcx, &expr, ty_hint, fn_args)?,
-            None => signal!(e, UnimplementedConstVal("empty block")),
+            None => Tuple(None, Vec::new()), // unit value
         }
       }
       hir::ExprType(ref e, _) => eval_const_expr_partial(tcx, &e, ty_hint, fn_args)?,

--- a/src/librustc_const_eval/eval.rs
+++ b/src/librustc_const_eval/eval.rs
@@ -801,7 +801,6 @@ pub fn eval_const_expr_partial<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
           } else {
               signal!(e, NonConstPath)
           };
-          let result = result.as_ref().expect("const fn has no result expression");
           assert_eq!(decl.inputs.len(), args.len());
 
           let mut call_args = NodeMap();
@@ -818,7 +817,11 @@ pub fn eval_const_expr_partial<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
               assert!(old.is_none());
           }
           debug!("const call({:?})", call_args);
-          eval_const_expr_partial(tcx, &result, ty_hint, Some(&call_args))?
+          if let &Some(ref result) = result {
+              eval_const_expr_partial(tcx, &result, ty_hint, Some(&call_args))?
+          } else {
+              Tuple(None, Vec::new())
+          }
       },
       hir::ExprLit(ref lit) => match lit_to_const(&lit.node, tcx, ety, lit.span) {
           Ok(val) => val,

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -712,19 +712,7 @@ fn convert_path_expr<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
             ref sty => bug!("unexpected sty: {:?}", sty)
         },
         Def::Const(def_id) |
-        Def::AssociatedConst(def_id) => {
-            let substs = Some(cx.tcx.node_id_item_substs(expr.id).substs);
-            let tcx = cx.tcx.global_tcx();
-            if let Some((e, _)) = const_eval::lookup_const_by_id(tcx, def_id, substs) {
-                // FIXME ConstVal can't be yet used with adjustments, as they would be lost.
-                if !cx.tcx.tables.borrow().adjustments.contains_key(&e.id) {
-                    if let Some(v) = cx.try_const_eval_literal(e) {
-                        return ExprKind::Literal { literal: v };
-                    }
-                }
-            }
-            def_id
-        }
+        Def::AssociatedConst(def_id) => def_id,
 
         Def::Static(node_id, _) => return ExprKind::StaticRef {
             id: node_id,

--- a/src/librustc_mir/hair/cx/mod.rs
+++ b/src/librustc_mir/hair/cx/mod.rs
@@ -90,21 +90,6 @@ impl<'a, 'gcx, 'tcx> Cx<'a, 'gcx, 'tcx> {
         }
     }
 
-    pub fn try_const_eval_literal(&mut self, e: &hir::Expr) -> Option<Literal<'tcx>> {
-        let hint = const_eval::EvalHint::ExprTypeChecked;
-        let tcx = self.tcx.global_tcx();
-        const_eval::eval_const_expr_partial(tcx, e, hint, None).ok().and_then(|v| {
-            match v {
-                // All of these contain local IDs, unsuitable for storing in MIR.
-                ConstVal::Struct(_) | ConstVal::Tuple(_) |
-                ConstVal::Array(..) | ConstVal::Repeat(..) |
-                ConstVal::Function(_) => None,
-
-                _ => Some(Literal::Value { value: v })
-            }
-        })
-    }
-
     pub fn trait_method(&mut self,
                         trait_def_id: DefId,
                         method_name: &str,

--- a/src/librustc_trans/mir/constant.rs
+++ b/src/librustc_trans/mir/constant.rs
@@ -17,14 +17,14 @@ use rustc::infer::TransNormalize;
 use rustc::mir::repr as mir;
 use rustc::mir::tcx::LvalueTy;
 use rustc::traits;
-use rustc::ty::{self, Ty, TypeFoldable};
+use rustc::ty::{self, Ty, TypeFoldable, TyStruct, TyTuple};
 use rustc::ty::cast::{CastTy, IntTy};
 use rustc::ty::subst::Substs;
 use {abi, adt, base, Disr};
 use callee::Callee;
 use common::{self, BlockAndBuilder, CrateContext, const_get_elt, val_ty};
 use common::{C_array, C_bool, C_bytes, C_floating_f64, C_integral};
-use common::{C_null, C_struct, C_str_slice, C_undef, C_uint};
+use common::{C_null, C_struct, C_str_slice, C_undef, C_uint, C_vector};
 use consts::{self, ConstEvalFailure, TrueConst, to_const_int};
 use monomorphize::{self, Instance};
 use type_of;
@@ -84,8 +84,64 @@ impl<'tcx> Const<'tcx> {
             ConstVal::Integral(InferSigned(v)) => C_integral(llty, v as u64, true),
             ConstVal::Str(ref v) => C_str_slice(ccx, v.clone()),
             ConstVal::ByteStr(ref v) => consts::addr_of(ccx, C_bytes(ccx, v), 1, "byte_str"),
-            ConstVal::Struct(_) | ConstVal::Tuple(_) |
-            ConstVal::Array(..) | ConstVal::Repeat(..) |
+            ConstVal::Struct(did, mut field_values) => {
+                let repr = adt::represent_type(ccx, ty);
+                let substs = match ty.sty {
+                    TyStruct(_, substs) => substs,
+                    _ => bug!(),
+                };
+                let mut trans_fields = Vec::with_capacity(field_values.len());
+                let adt_def = ty.ty_adt_def().unwrap().struct_variant();
+                assert_eq!(adt_def.did, did);
+                for field in &adt_def.fields {
+                    if let Some(value) = field_values.remove(&field.name) {
+                        let field_ty = field.ty(ccx.tcx(), substs);
+                        let value = Self::from_constval(ccx, value, field_ty);
+                        trans_fields.push(value.llval);
+                    } else {
+                        bug!("trans knows struct fields that const doesn't");
+                    }
+                }
+                // FIXME: check that all elements of `field_values` have been translated
+                if ty.is_simd() {
+                    C_vector(&trans_fields)
+                } else {
+                    adt::trans_const(ccx, &*repr, adt_def.disr_val.into(), &trans_fields)
+                }
+            },
+            ConstVal::Tuple(Some(_), _) => unimplemented!(),
+            ConstVal::Tuple(None, field_values) => {
+                let repr = adt::represent_type(ccx, ty);
+                let field_types = match ty.sty {
+                    TyTuple(ref types) => types,
+                    _ => bug!(),
+                };
+                let mut trans_fields = Vec::with_capacity(field_values.len());
+                for (f_val, f_ty) in field_values.into_iter().zip(field_types) {
+                    let value = Self::from_constval(ccx, f_val, f_ty);
+                    trans_fields.push(value.llval);
+                }
+                if ty.is_simd() {
+                    C_vector(&trans_fields)
+                } else {
+                    adt::trans_const(ccx, &*repr, Disr(0), &trans_fields)
+                }
+            },
+            ConstVal::Repeat(val, n) => {
+                let val_ty = ty.sequence_element_type(ccx.tcx());
+                let ll_val_ty = type_of::type_of(ccx, val_ty);
+                assert_eq!(n as usize as u64, n);
+                let trans_fields = vec![Self::from_constval(ccx, *val, val_ty).llval; n as usize];
+                C_array(ll_val_ty, &trans_fields)
+            },
+            ConstVal::Array(vals) => {
+                let val_ty = ty.sequence_element_type(ccx.tcx());
+                let ll_val_ty = type_of::type_of(ccx, val_ty);
+                let trans_fields = vals.into_iter()
+                                       .map(|val| Self::from_constval(ccx, val, val_ty).llval)
+                                       .collect::<Vec<_>>();
+                C_array(ll_val_ty, &trans_fields)
+            },
             ConstVal::Function(_) => {
                 bug!("MIR must not use {:?} (which refers to a local ID)", cv)
             }

--- a/src/librustc_trans/mir/constant.rs
+++ b/src/librustc_trans/mir/constant.rs
@@ -113,7 +113,7 @@ impl<'tcx> Const<'tcx> {
             ConstVal::Tuple(None, field_values) => {
                 let repr = adt::represent_type(ccx, ty);
                 let field_types = match ty.sty {
-                    TyTuple(ref types) => types,
+                    TyTuple(types) => types,
                     _ => bug!(),
                 };
                 let mut trans_fields = Vec::with_capacity(field_values.len());

--- a/src/librustc_trans/mir/constant.rs
+++ b/src/librustc_trans/mir/constant.rs
@@ -82,7 +82,7 @@ impl<'tcx> Const<'tcx> {
             },
             ConstVal::Integral(Infer(v)) => C_integral(llty, v as u64, false),
             ConstVal::Integral(InferSigned(v)) => C_integral(llty, v as u64, true),
-            ConstVal::Str(ref v) => C_str_slice(ccx, v.clone()),
+            ConstVal::Str(v) => C_str_slice(ccx, v),
             ConstVal::ByteStr(ref v) => consts::addr_of(ccx, C_bytes(ccx, v), 1, "byte_str"),
             ConstVal::Struct(did, mut field_values) => {
                 let repr = adt::represent_type(ccx, ty);

--- a/src/test/compile-fail/const-eval-overflow.rs
+++ b/src/test/compile-fail/const-eval-overflow.rs
@@ -10,6 +10,7 @@
 
 #![feature(rustc_attrs)]
 #![allow(unused_imports)]
+#![allow(const_err)]
 
 // Note: the relevant lint pass here runs before some of the constant
 // evaluation below (e.g. that performed by trans and llvm), so if you

--- a/src/test/compile-fail/const-eval-overflow0.rs
+++ b/src/test/compile-fail/const-eval-overflow0.rs
@@ -20,67 +20,67 @@ use std::{i8, i16, i32, i64, isize};
 use std::{u8, u16, u32, u64, usize};
 
 const VALS_I8: (i8, i8, i8, i8) =
-    (-i8::MIN,
-     i8::MIN - 1,
-     i8::MAX + 1,
-     i8::MIN * 2,
+    (-i8::MIN, //~WARN const_err
+     i8::MIN - 1, //~WARN const_err
+     i8::MAX + 1, //~WARN const_err
+     i8::MIN * 2, //~WARN const_err
      );
 
 const VALS_I16: (i16, i16, i16, i16) =
-    (-i16::MIN,
-     i16::MIN - 1,
-     i16::MAX + 1,
-     i16::MIN * 2,
+    (-i16::MIN, //~WARN const_err
+     i16::MIN - 1, //~WARN const_err
+     i16::MAX + 1, //~WARN const_err
+     i16::MIN * 2, //~WARN const_err
      );
 
 const VALS_I32: (i32, i32, i32, i32) =
-    (-i32::MIN,
-     i32::MIN - 1,
-     i32::MAX + 1,
-     i32::MIN * 2,
+    (-i32::MIN, //~WARN const_err
+     i32::MIN - 1, //~WARN const_err
+     i32::MAX + 1, //~WARN const_err
+     i32::MIN * 2, //~WARN const_err
      );
 
 const VALS_I64: (i64, i64, i64, i64) =
-    (-i64::MIN,
-     i64::MIN - 1,
-     i64::MAX + 1,
-     i64::MAX * 2,
+    (-i64::MIN, //~WARN const_err
+     i64::MIN - 1, //~WARN const_err
+     i64::MAX + 1, //~WARN const_err
+     i64::MAX * 2, //~WARN const_err
      );
 
 const VALS_U8: (u8, u8, u8, u8) =
     (-u8::MIN,
      //~^ ERROR unary negation of unsigned integer
      //~| HELP use a cast or the `!` operator
-     u8::MIN - 1,
-     u8::MAX + 1,
-     u8::MAX * 2,
+     u8::MIN - 1, //~WARN const_err
+     u8::MAX + 1, //~WARN const_err
+     u8::MAX * 2, //~WARN const_err
      );
 
 const VALS_U16: (u16, u16, u16, u16) =
     (-u16::MIN,
      //~^ ERROR unary negation of unsigned integer
      //~| HELP use a cast or the `!` operator
-     u16::MIN - 1,
-     u16::MAX + 1,
-     u16::MAX * 2,
+     u16::MIN - 1, //~WARN const_err
+     u16::MAX + 1, //~WARN const_err
+     u16::MAX * 2, //~WARN const_err
      );
 
 const VALS_U32: (u32, u32, u32, u32) =
     (-u32::MIN,
      //~^ ERROR unary negation of unsigned integer
      //~| HELP use a cast or the `!` operator
-     u32::MIN - 1,
-     u32::MAX + 1,
-     u32::MAX * 2,
+     u32::MIN - 1, //~WARN const_err
+     u32::MAX + 1, //~WARN const_err
+     u32::MAX * 2, //~WARN const_err
      );
 
 const VALS_U64: (u64, u64, u64, u64) =
     (-u64::MIN,
      //~^ ERROR unary negation of unsigned integer
      //~| HELP use a cast or the `!` operator
-     u64::MIN - 1,
-     u64::MAX + 1,
-     u64::MAX * 2,
+     u64::MIN - 1, //~WARN const_err
+     u64::MAX + 1, //~WARN const_err
+     u64::MAX * 2, //~WARN const_err
      );
 
 fn main() {

--- a/src/test/compile-fail/const-pattern-not-const-evaluable.rs
+++ b/src/test/compile-fail/const-pattern-not-const-evaluable.rs
@@ -17,8 +17,7 @@ enum Cake {
 use Cake::*;
 
 const BOO: (Cake, Cake) = (Marmor, BlackForest);
-//~^ ERROR: constant evaluation error: unimplemented constant expression: enum variants [E0471]
-const FOO: Cake = BOO.1;
+const FOO: Cake = BOO.1; //~ERROR could not evaluate referenced constant
 
 const fn foo() -> Cake {
     Marmor //~ ERROR: constant evaluation error: unimplemented constant expression: enum variants

--- a/src/test/compile-fail/issue-17718-const-borrow.rs
+++ b/src/test/compile-fail/issue-17718-const-borrow.rs
@@ -23,4 +23,7 @@ const E: &'static UnsafeCell<usize> = &D.a;
 const F: &'static C = &D;
 //~^ ERROR: cannot borrow a constant which contains interior mutability
 
+const G: &'static UnsafeCell<usize> = &UnsafeCell::new(42);
+//~^ ERROR: cannot borrow a constant which contains interior mutability
+
 fn main() {}

--- a/src/test/run-pass/const-fn.rs
+++ b/src/test/run-pass/const-fn.rs
@@ -33,6 +33,9 @@ const fn generic_arr<T: Copy>(t: [T; 1]) -> T {
     t[0]
 }
 
+pub const fn test() {}
+const X: () = test();
+
 const fn f(_: ()) -> usize { 1 }
 
 const SUM: u32 = add(44, 22);
@@ -50,4 +53,5 @@ fn main() {
     let _: [&'static str; generic(1)] = ["hi"];
     let _: [&'static str; generic_arr([1])] = ["hi"];
     let _: [&'static str; f({})] = ["hi"];
+    let _ = [0; g(5).field];
 }

--- a/src/test/run-pass/const-fn.rs
+++ b/src/test/run-pass/const-fn.rs
@@ -11,6 +11,7 @@
 // A very basic test of const fn functionality.
 
 #![feature(const_fn, const_indexing)]
+#![deny(const_err)]
 
 const fn add(x: u32, y: u32) -> u32 {
     x + y
@@ -32,6 +33,8 @@ const fn generic_arr<T: Copy>(t: [T; 1]) -> T {
     t[0]
 }
 
+const fn f(_: ()) -> usize { 1 }
+
 const SUM: u32 = add(44, 22);
 const DIFF: u32 = sub(44, 22);
 const DIV: u32 = unsafe{div(44, 22)};
@@ -46,4 +49,5 @@ fn main() {
     let _: [&'static str; sub(100, 99) as usize] = ["hi"];
     let _: [&'static str; generic(1)] = ["hi"];
     let _: [&'static str; generic_arr([1])] = ["hi"];
+    let _: [&'static str; f({})] = ["hi"];
 }

--- a/src/test/run-pass/const-fn.rs
+++ b/src/test/run-pass/const-fn.rs
@@ -38,6 +38,13 @@ const X: () = test();
 
 const fn f(_: ()) -> usize { 1 }
 
+const fn g(x: usize) -> A {
+    A { field: x }
+}
+struct A {
+    field: usize,
+}
+
 const SUM: u32 = add(44, 22);
 const DIFF: u32 = sub(44, 22);
 const DIV: u32 = unsafe{div(44, 22)};

--- a/src/test/run-pass/issue-28189.rs
+++ b/src/test/run-pass/issue-28189.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct S<T>(T) where [T; (||{}, 1).1]: Copy;
+struct S<T>(T) where [T; ((), 1).1]: Copy;
 
 fn main() {
 


### PR DESCRIPTION
rebased eager const eval over @eddyb 's MIR-constants PR #33130

fixes #29928
fixes #33252
1. MIR creation now only calls `eval_const_expr` on literals and negated literals
   - previously all const/static definitions were attempted to be translated, but could fail due to the fact that `eval_const_expr` can't eval all kinds of constants
   - since "unevaluable" constants are translated from MIR now, there was no reason to keep evaluating constants that aren't needed for array lengths or patterns
   - a next step would be to convert literals manually to MIR constants instead of using `eval_const_expr_partial`
2. `ConstVal` contains owned versions of struct fields, tuple fields, array elements and the repeat value
   - this will allow a hypothetical const propagator to munch an `Rvalue::Aggregate` into a constant
   - MIR construction can now generate constant aggregates in https://github.com/rust-lang/rust/blob/master/src/librustc_mir/build/scope.rs#L544-L546 and https://github.com/rust-lang/rust/blob/master/src/librustc_mir/build/scope.rs#L586-L588
3. drive-by fixes for #33252, #33031, #31384 + tests

r? @eddyb 
