### PR TITLE
Make BTreeSet::Insert docs more consistent

### DIFF
--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -477,9 +477,9 @@ impl<T: Ord> BTreeSet<T> {
 
     /// Adds a value to the set.
     ///
-    /// If the set did not have a value present, `true` is returned.
+    /// If the set did not have this value present, `true` is returned.
     ///
-    /// If the set did have this key present, `false` is returned, and the
+    /// If the set did have this value present, `false` is returned, and the
     /// entry is not updated. See the [module-level documentation] for more.
     ///
     /// [module-level documentation]: index.html#insert-and-complex-keys


### PR DESCRIPTION
Made the BTreeSet::Insert documentation consistent with the HashSet::Insert documentation by using the term 'value' instead of 'key'. 

r? @steveklabnik
