### PR TITLE
Get a file during bootstrap to a temp location first.

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -25,7 +25,8 @@ def get(url, path, verbose=False):
     temp_path = temp_file.name
     sha_file = tempfile.NamedTemporaryFile(suffix=".sha256", delete=True)
     sha_path = sha_file.name
-    download(sha_path, sha_url, temp_path, url, verbose)
+    download(sha_path, sha_url, verbose)
+    download(temp_path, url, verbose)
     verify(sha_path, temp_path, verbose)
     sha_file.close()
     print("moving " + temp_path + " to " + path)
@@ -33,17 +34,16 @@ def get(url, path, verbose=False):
     temp_file.close()
 
 
-def download(sha_path, sha_url, temp_path, url, verbose):
-    for _url, _path in ((url, temp_path), (sha_url, sha_path)):
-        print("downloading " + _url + " to " + _path)
-        # see http://serverfault.com/questions/301128/how-to-download
-        if sys.platform == 'win32':
-            run(["PowerShell.exe", "/nologo", "-Command",
-                 "(New-Object System.Net.WebClient)"
-                 ".DownloadFile('{}', '{}')".format(_url, _path)],
-                verbose=verbose)
-        else:
-            run(["curl", "-o", _path, _url], verbose=verbose)
+def download(path, url, verbose):
+    print("downloading " + url + " to " + path)
+    # see http://serverfault.com/questions/301128/how-to-download
+    if sys.platform == 'win32':
+        run(["PowerShell.exe", "/nologo", "-Command",
+             "(New-Object System.Net.WebClient)"
+             ".DownloadFile('{}', '{}')".format(url, path)],
+            verbose=verbose)
+    else:
+        run(["curl", "-o", path, url], verbose=verbose)
 
 
 def verify(sha_path, temp_path, verbose):

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -33,11 +33,14 @@ def get(url, path, verbose=False):
         print("moving " + temp_path + " to " + path)
         shutil.move(temp_path, path)
     finally:
-        print("removing " + sha_path)
-        os.unlink(sha_path)
-        if os.path.isfile(temp_path):
-            print("removing " + temp_path)
-            os.unlink(temp_path)
+        delete_if_present(sha_path)
+        delete_if_present(temp_path)
+
+
+def delete_if_present(path):
+    if os.path.isfile(path):
+        print("removing " + path)
+        os.unlink(path)
 
 
 def download(path, url, verbose):


### PR DESCRIPTION
When downloading a file in the bootstrap phase - get it to a temp
location first. Verify it there and only if downloaded properly move it
to the `cache` directory.

This should prevent `make` being stuck if the download was interrupted
or otherwise corrupted, as per discussion in #32834

The temporary files are deleted in case of an exception.

I was looking for some unit/integration tests around this and couldn't find any - presumably because this is being tested by just Travis launching it ? Let me know if it would be good to try to write tests around this. Thanks !
