### PR TITLE
Implement Sync for lock guards

### DIFF
--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -179,6 +179,9 @@ pub struct MutexGuard<'a, T: ?Sized + 'a> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T: ?Sized> !marker::Send for MutexGuard<'a, T> {}
 
+#[stable(feature = "sync_lock_guards", since = "1.10.0")]
+unsafe impl<'a, T: ?Sized + Sync> Sync for MutexGuard<'a, T> {}
+
 /// Static initialization of a mutex. This constant can be used to initialize
 /// other mutex constants.
 #[unstable(feature = "static_mutex",

--- a/src/libstd/sync/rwlock.rs
+++ b/src/libstd/sync/rwlock.rs
@@ -127,6 +127,9 @@ pub struct RwLockReadGuard<'a, T: ?Sized + 'a> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T: ?Sized> !marker::Send for RwLockReadGuard<'a, T> {}
 
+#[stable(feature = "sync_lock_guards", since = "1.10.0")]
+unsafe impl<'a, T: ?Sized + Sync> Sync for RwLockReadGuard<'a, T> {}
+
 /// RAII structure used to release the exclusive write access of a lock when
 /// dropped.
 #[must_use]
@@ -139,6 +142,9 @@ pub struct RwLockWriteGuard<'a, T: ?Sized + 'a> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T: ?Sized> !marker::Send for RwLockWriteGuard<'a, T> {}
+
+#[stable(feature = "sync_lock_guards", since="1.10.0")]
+unsafe impl<'a, T: ?Sized + Sync> Sync for RwLockWriteGuard<'a, T> {}
 
 impl<T> RwLock<T> {
     /// Creates a new instance of an `RwLock<T>` which is unlocked.


### PR DESCRIPTION
On IRC we thought this may have been an oversight, since having these guards be `Sync` seems relatively harmless.
