### PR TITLE
Fix alloc_jemalloc on windows gnu targets

### DIFF
--- a/src/liballoc_jemalloc/lib.rs
+++ b/src/liballoc_jemalloc/lib.rs
@@ -41,28 +41,28 @@ use libc::{c_int, c_void, size_t};
 #[cfg(not(cargobuild))]
 extern {}
 
-// Note that the symbols here are prefixed by default on OSX (we don't
-// explicitly request it), and on Android and DragonFly we explicitly request
-// it as unprefixing cause segfaults (mismatches in allocators).
+// Note that the symbols here are prefixed by default on OSX and Windows (we
+// don't explicitly request it), and on Android and DragonFly we explicitly
+// request it as unprefixing cause segfaults (mismatches in allocators).
 extern {
     #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios",
-                   target_os = "dragonfly"),
+                   target_os = "dragonfly", target_os = "windows"),
                link_name = "je_mallocx")]
     fn mallocx(size: size_t, flags: c_int) -> *mut c_void;
     #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios",
-                   target_os = "dragonfly"),
+                   target_os = "dragonfly", target_os = "windows"),
                link_name = "je_rallocx")]
     fn rallocx(ptr: *mut c_void, size: size_t, flags: c_int) -> *mut c_void;
     #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios",
-                   target_os = "dragonfly"),
+                   target_os = "dragonfly", target_os = "windows"),
                link_name = "je_xallocx")]
     fn xallocx(ptr: *mut c_void, size: size_t, extra: size_t, flags: c_int) -> size_t;
     #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios",
-                   target_os = "dragonfly"),
+                   target_os = "dragonfly", target_os = "windows"),
                link_name = "je_sdallocx")]
     fn sdallocx(ptr: *mut c_void, size: size_t, flags: c_int);
     #[cfg_attr(any(target_os = "macos", target_os = "android", target_os = "ios",
-                   target_os = "dragonfly"),
+                   target_os = "dragonfly", target_os = "windows"),
                link_name = "je_nallocx")]
     fn nallocx(size: size_t, flags: c_int) -> size_t;
 }


### PR DESCRIPTION
jemalloc prefixes the symbols by default on Windows so we need to account
for that to avoid link errors such as: `undefined reference to 'mallocx'`
when using alloc_jemalloc.
