### PR TITLE
parser: fix suppression of syntax errors in range RHS

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3029,15 +3029,8 @@ impl<'a> Parser<'a> {
                 // We have 2 alternatives here: `x..y`/`x...y` and `x..`/`x...` The other
                 // two variants are handled with `parse_prefix_range_expr` call above.
                 let rhs = if self.is_at_start_of_range_notation_rhs() {
-                    let rhs = self.parse_assoc_expr_with(op.precedence() + 1,
-                                                         LhsExpr::NotYetParsed);
-                    match rhs {
-                        Ok(e) => Some(e),
-                        Err(mut e) => {
-                            e.cancel();
-                            None
-                        }
-                    }
+                    Some(self.parse_assoc_expr_with(op.precedence() + 1,
+                                                    LhsExpr::NotYetParsed)?)
                 } else {
                     None
                 };

--- a/src/test/parse-fail/issue-33262.rs
+++ b/src/test/parse-fail/issue-33262.rs
@@ -1,0 +1,18 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z parse-only
+
+// Issue #33262
+
+pub fn main() {
+    for i in 0..a as { }
+    //~^ ERROR expected type, found `{`
+}


### PR DESCRIPTION
Invalid expressions on the RHS were just swallowed without generating an error.  The new version more closely mirrors the code for parsing `..x` in the `parse_prefix_range_expr` method below, where no cancel is done either.

Fixes #33262.
