### PR TITLE
dep_graph: avoid panicking in thread when channel closed

### DIFF
--- a/src/librustc/dep_graph/thread.rs
+++ b/src/librustc/dep_graph/thread.rs
@@ -176,6 +176,9 @@ pub fn main(swap_in: Receiver<Vec<DepMessage>>,
                 DepMessage::Query => query_out.send(edges.query()).unwrap(),
             }
         }
-        swap_out.send(messages).unwrap();
+        if let Err(_) = swap_out.send(messages) {
+            // the receiver must have been dropped already
+            break;
+        }
     }
 }


### PR DESCRIPTION
On my system, when the processor is already loaded, and I try to
run the test suite, e.g. compile-fail/dep-graph-assoc-type-trans.rs
fails because of undecodable JSON.

Running the compiler manually, I can see that the dep graph thread
panics (and puts non-JSON on stderr) while `send`ing on `swap_out`,
presumably because the other end has already quit.  I think that in
this case, we can just gracefully exit the thread.
