### PR TITLE
mk: Fix building with --enable-ccache

### DIFF
--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -169,7 +169,7 @@ ifdef CFG_CCACHE_BASEDIR
   export CCACHE_BASEDIR
 endif
 
-FIND_COMPILER = $(word 1,$(1:ccache=))
+FIND_COMPILER = $(strip $(1:ccache=))
 
 define CFG_MAKE_TOOLCHAIN
   # Prepend the tools with their prefix if cross compiling
@@ -187,7 +187,7 @@ define CFG_MAKE_TOOLCHAIN
     endif
   endif
 
-  CFG_COMPILE_C_$(1) = '$$(CC_$(1))' \
+  CFG_COMPILE_C_$(1) = '$$(call FIND_COMPILER,$$(CC_$(1)))' \
         $$(CFLAGS) \
         $$(CFG_GCCISH_CFLAGS) \
         $$(CFG_GCCISH_CFLAGS_$(1)) \
@@ -198,7 +198,7 @@ define CFG_MAKE_TOOLCHAIN
         $$(CFG_GCCISH_LINK_FLAGS_$(1)) \
         $$(CFG_GCCISH_DEF_FLAG_$(1))$$(3) $$(2) \
         $$(call CFG_INSTALL_NAME_$(1),$$(4))
-  CFG_COMPILE_CXX_$(1) = '$$(CXX_$(1))' \
+  CFG_COMPILE_CXX_$(1) = '$$(call FIND_COMPILER,$$(CXX_$(1)))' \
         $$(CXXFLAGS) \
         $$(CFG_GCCISH_CFLAGS) \
         $$(CFG_GCCISH_CXXFLAGS) \

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -636,8 +636,8 @@ CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3) := \
         --host-rustcflags "$(RUSTC_FLAGS_$(3)) $$(CTEST_RUSTC_FLAGS) -L $$(RT_OUTPUT_DIR_$(3))" \
         --lldb-python-dir=$(CFG_LLDB_PYTHON_DIR) \
         --target-rustcflags "$(RUSTC_FLAGS_$(2)) $$(CTEST_RUSTC_FLAGS) -L $$(RT_OUTPUT_DIR_$(2))" \
-	--cc '$$(CC_$(2))' \
-	--cxx '$$(CXX_$(2))' \
+	--cc '$$(call FIND_COMPILER,$$(CC_$(2)))' \
+	--cxx '$$(call FIND_COMPILER,$$(CXX_$(2)))' \
 	--cflags "$$(CFG_GCCISH_CFLAGS_$(2))" \
 	--llvm-components "$$(LLVM_ALL_COMPONENTS_$(2))" \
 	--llvm-cxxflags "$$(LLVM_CXXFLAGS_$(2))" \


### PR DESCRIPTION
We will no longer use `ccache` in the makefiles for our local dependencies like
miniz, but they're so small anyway it doesn't really matter.

Closes #33285
