### PR TITLE
borrowck: do not suggest to change "&mut self" to "&mut mut self"

### DIFF
--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -970,11 +970,13 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                         if let Categorization::Local(local_id) = err.cmt.cat {
                             let span = self.tcx.map.span(local_id);
                             if let Ok(snippet) = self.tcx.sess.codemap().span_to_snippet(span) {
-                                db.span_suggestion(
-                                    span,
-                                    &format!("to make the {} mutable, use `mut` as shown:",
-                                             self.cmt_to_string(&err.cmt)),
-                                    format!("mut {}", snippet));
+                                if snippet != "self" {
+                                    db.span_suggestion(
+                                        span,
+                                        &format!("to make the {} mutable, use `mut` as shown:",
+                                                 self.cmt_to_string(&err.cmt)),
+                                        format!("mut {}", snippet));
+                                }
                             }
                         }
                     }

--- a/src/test/compile-fail/issue-31424.rs
+++ b/src/test/compile-fail/issue-31424.rs
@@ -1,0 +1,30 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// forbid-output: &mut mut self
+
+struct Struct;
+
+impl Struct {
+    fn foo(&mut self) {
+        (&mut self).bar();
+        //~^ ERROR cannot borrow immutable argument `self` as mutable
+        // ... and no SUGGESTION that suggests `&mut mut self`
+    }
+
+    // In this case we could keep the suggestion, but to distinguish the
+    // two cases is pretty hard. It's an obscure case anyway.
+    fn bar(self: &mut Self) {
+        (&mut self).bar();
+        //~^ ERROR cannot borrow immutable argument `self` as mutable
+    }
+}
+
+fn main () {}


### PR DESCRIPTION
Matching the snippet string might not be the cleanest, but matching
the AST node instead seems to end in a lot of nested `if let`s, so I
don't know what's better.

Of course it's entirely possible that there is another API altogether
that I just don't know of?

Fixes #31424.
