### PR TITLE
typeck: remove confusing suggestion for calling a fn type

### DIFF
--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -158,10 +158,6 @@ pub fn report_error<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                 if let Some(expr) = rcvr_expr {
                     if let Ok (expr_string) = cx.sess.codemap().span_to_snippet(expr.span) {
                         report_function!(expr.span, expr_string);
-                        err.span_suggestion(expr.span,
-                                            "try calling the base function:",
-                                            format!("{}()",
-                                                    expr_string));
                     }
                     else if let Expr_::ExprPath(_, path) = expr.node.clone() {
                         if let Some(segment) = path.segments.last() {

--- a/src/test/compile-fail/issue-29124.rs
+++ b/src/test/compile-fail/issue-29124.rs
@@ -25,11 +25,7 @@ fn main() {
     obj::func.x();
     //~^ ERROR no method named `x` found for type `fn() -> ret {obj::func}` in the current scope
     //~^^ NOTE obj::func is a function, perhaps you wish to call it
-    //~^^^ HELP try calling the base function:
-    //~| SUGGESTION obj::func().x();
     func.x();
     //~^ ERROR no method named `x` found for type `fn() -> ret {func}` in the current scope
     //~^^ NOTE func is a function, perhaps you wish to call it
-    //~^^^ HELP try calling the base function:
-    //~| SUGGESTION func().x();
 }


### PR DESCRIPTION
- It is not clear what a "base function" is.
- The suggestion just adds parens, so suggests calling without args.

The second point could be fixed with e.g. `(...)` instead of `()`,
but the preceding "note: X is a function, perhaps you wish to call it"
should already be clear enough.

Fixes: #31341
