### PR TITLE
lexer: do not display char confusingly in error message

### DIFF
--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -931,11 +931,10 @@ impl<'a> StringReader<'a> {
             _ => {
                 if ascii_only && first_source_char > '\x7F' {
                     let last_pos = self.last_pos;
-                    self.err_span_char(start,
-                                       last_pos,
-                                       "byte constant must be ASCII. Use a \\xHH escape for a \
-                                        non-ASCII byte",
-                                       first_source_char);
+                    self.err_span_(start,
+                                   last_pos,
+                                   "byte constant must be ASCII. Use a \\xHH escape for a \
+                                    non-ASCII byte");
                     return false;
                 }
             }


### PR DESCRIPTION
Current code leads to messages like `... use a \xHH escape: \u{e4}` which is confusing.

The printed span already points to the offending character, which should be enough to identify the non-ASCII problem.

Fixes: #29088
