### PR TITLE
docs: Changed docs for `size_of` to describe size as a stride offset

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -192,11 +192,8 @@ extern "rust-intrinsic" {
 
     /// The size of a type in bytes.
     ///
-    /// This is the exact number of bytes in memory taken up by a
-    /// value of the given type. In other words, a memset of this size
-    /// would *exactly* overwrite a value. When laid out in vectors
-    /// and structures there may be additional padding between
-    /// elements.
+    /// More specifically, this is the offset in bytes between successive
+    /// items of the same type, including alignment padding.
     pub fn size_of<T>() -> usize;
 
     /// Moves a value to an uninitialized memory location.

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -117,6 +117,9 @@ pub fn forget<T>(t: T) {
 
 /// Returns the size of a type in bytes.
 ///
+/// More specifically, this is the offset in bytes between successive
+/// items of the same type, including alignment padding.
+///
 /// # Examples
 ///
 /// ```


### PR DESCRIPTION
Current documentation for `std::mem::size_of` is ambiguous, and the documentation for `std::intrinsics::size_of` incorrectly defines size.

This fix re-defines size as the offset in bytes between successive instances of a type, as described in LLVM's [getTypeAllocSize](http://llvm.org/docs/doxygen/html/classllvm_1_1DataLayout.html#a1d6fcc02e91ba24510aba42660c90e29).

Fixes: #33266
