### PR TITLE
parser: do not try to continue with `unsafe` on foreign fns

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -6025,7 +6025,7 @@ impl<'a> Parser<'a> {
             // FOREIGN STATIC ITEM
             return Ok(Some(self.parse_item_foreign_static(visibility, lo, attrs)?));
         }
-        if self.check_keyword(keywords::Fn) || self.check_keyword(keywords::Unsafe) {
+        if self.check_keyword(keywords::Fn) {
             // FOREIGN FUNCTION ITEM
             return Ok(Some(self.parse_item_foreign_fn(visibility, lo, attrs)?));
         }

--- a/src/test/parse-fail/extern-no-fn.rs
+++ b/src/test/parse-fail/extern-no-fn.rs
@@ -11,7 +11,7 @@
 // compile-flags: -Z parse-only
 
 extern {
-    f(); //~ ERROR expected one of `fn`, `pub`, `static`, `unsafe`, or `}`, found `f`
+    f(); //~ ERROR expected one of `fn`, `pub`, `static`, or `}`, found `f`
 }
 
 fn main() {

--- a/src/test/parse-fail/removed-syntax-extern-const.rs
+++ b/src/test/parse-fail/removed-syntax-extern-const.rs
@@ -12,5 +12,5 @@
 
 extern {
     const i: isize;
-    //~^ ERROR expected one of `fn`, `pub`, `static`, `unsafe`, or `}`, found `const`
+    //~^ ERROR expected one of `fn`, `pub`, `static`, or `}`, found `const`
 }


### PR DESCRIPTION
The changed line makes it look like `unsafe` is allowed, but the first statement of `parse_item_foreign_fn` is:

```
self.expect_keyword(keywords::Fn)?;
```

So we get the strange "expected one of `fn`, `pub`, `static`, or `unsafe`, found `unsafe`".

Fixes: #27361
