### PR TITLE
resolve: print location of static for "static in pattern" error

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -158,7 +158,7 @@ enum ResolutionError<'a> {
     /// error E0416: identifier is bound more than once in the same pattern
     IdentifierBoundMoreThanOnceInSamePattern(&'a str),
     /// error E0417: static variables cannot be referenced in a pattern
-    StaticVariableReference,
+    StaticVariableReference(DefId, Option<Name>),
     /// error E0418: is not an enum variant, struct or const
     NotAnEnumVariantStructOrConst(&'a str),
     /// error E0419: unresolved enum variant, struct or const
@@ -367,12 +367,24 @@ fn resolve_struct_error<'b, 'a: 'b, 'tcx: 'a>(resolver: &'b Resolver<'a, 'tcx>,
                              "identifier `{}` is bound more than once in the same pattern",
                              identifier)
         }
-        ResolutionError::StaticVariableReference => {
-            struct_span_err!(resolver.session,
-                             span,
-                             E0417,
-                             "static variables cannot be referenced in a pattern, use a \
-                              `const` instead")
+        ResolutionError::StaticVariableReference(did, name) => {
+            let mut err = struct_span_err!(resolver.session,
+                                           span,
+                                           E0417,
+                                           "static variables cannot be referenced in a \
+                                            pattern, use a `const` instead");
+            if let Some(sp) = resolver.ast_map.span_if_local(did) {
+                err.span_note(sp, "static variable defined here");
+            }
+            if let Some(name) = name {
+                if let Some(binding) = resolver.current_module
+                                               .resolve_name_in_lexical_scope(name, ValueNS) {
+                    if binding.is_import() {
+                        err.span_note(binding.span, "static variable imported here");
+                    }
+                }
+            }
+            err
         }
         ResolutionError::NotAnEnumVariantStructOrConst(name) => {
             struct_span_err!(resolver.session,
@@ -2374,10 +2386,11 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                             Def::Variant(..) | Def::Const(..) => {
                                 self.record_def(pattern.id, path_res);
                             }
-                            Def::Static(..) => {
+                            Def::Static(did, _) => {
                                 resolve_error(&self,
                                               path.span,
-                                              ResolutionError::StaticVariableReference);
+                                              ResolutionError::StaticVariableReference(
+                                                  did, None));
                                 self.record_def(pattern.id, err_path_resolution());
                             }
                             _ => {
@@ -2517,8 +2530,9 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             Some(def @ Def::Const(..)) | Some(def @ Def::AssociatedConst(..)) => {
                 FoundConst(def, ident.unhygienic_name)
             }
-            Some(Def::Static(..)) => {
-                resolve_error(self, span, ResolutionError::StaticVariableReference);
+            Some(Def::Static(did, _)) => {
+                resolve_error(self, span, ResolutionError::StaticVariableReference(
+                    did, Some(ident.unhygienic_name)));
                 BareIdentifierPatternUnresolved
             }
             _ => BareIdentifierPatternUnresolved,

--- a/src/test/compile-fail/issue-23716.rs
+++ b/src/test/compile-fail/issue-23716.rs
@@ -1,0 +1,29 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+static foo: i32 = 0;
+//~^ NOTE static variable defined here
+
+fn bar(foo: i32) {}
+//~^ ERROR static variables cannot be referenced in a pattern, use a `const` instead
+
+mod submod {
+    pub static answer: i32 = 42;
+    //~^ NOTE static variable defined here
+}
+
+use self::submod::answer;
+//~^ NOTE static variable imported here
+
+fn question(answer: i32) {}
+//~^ ERROR static variables cannot be referenced in a pattern, use a `const` instead
+
+fn main() {
+}


### PR DESCRIPTION
The implementation mirrors the one for "constant defined here" annotation used for constant patterns in the irrefutable-pattern case.

Fixes: #23716
