### PR TITLE
typeck: if a private field exists, also check for a public method

### DIFF
--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -84,7 +84,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                          span: Span,
                          method_name: ast::Name,
                          self_ty: ty::Ty<'tcx>,
-                         call_expr_id: ast::NodeId)
+                         call_expr_id: ast::NodeId,
+                         allow_private: bool)
                          -> bool
     {
         let mode = probe::Mode::MethodCall;
@@ -93,7 +94,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             Err(NoMatch(..)) => false,
             Err(Ambiguity(..)) => true,
             Err(ClosureAmbiguity(..)) => true,
-            Err(PrivateMatch(..)) => true,
+            Err(PrivateMatch(..)) => allow_private,
         }
     }
 

--- a/src/test/compile-fail/issue-26472.rs
+++ b/src/test/compile-fail/issue-26472.rs
@@ -1,0 +1,24 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+mod sub {
+    pub struct S { len: usize }
+    impl S {
+        pub fn new() -> S { S { len: 0 } }
+        pub fn len(&self) -> usize { self.len }
+    }
+}
+
+fn main() {
+    let s = sub::S::new();
+    let v = s.len;
+    //~^ ERROR field `len` of struct `sub::S` is private
+    //~| NOTE a method `len` also exists, perhaps you wish to call it
+}


### PR DESCRIPTION
For example, `Vec::len` is both a field and a method, and usually encountering `vec.len` just means that the parens were forgotten.

Fixes: #26472

NOTE: I added the parameter `allow_private` to `method::exists` since I don't want to suggest inaccessible methods. For the second case, where only the method exists, I think it would make sense to set it to `false` as well, but I wanted to preserve compatibility for this case.
