### PR TITLE
parser: change warning into an error on `T<A=B, C>`

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4420,11 +4420,7 @@ impl<'a> Parser<'a> {
                 p.forbid_lifetime()?;
                 let lo = p.span.lo;
                 let ident = p.parse_ident()?;
-                let found_eq = p.eat(&token::Eq);
-                if !found_eq {
-                    let span = p.span;
-                    p.span_warn(span, "whoops, no =?");
-                }
+                p.expect(&token::Eq)?;
                 let ty = p.parse_ty()?;
                 let hi = ty.span.hi;
                 let span = mk_sp(lo, hi);

--- a/src/test/parse-fail/issue-32214.rs
+++ b/src/test/parse-fail/issue-32214.rs
@@ -1,0 +1,17 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z parse-only -Z continue-parse-after-error
+
+pub fn test<W, I: Iterator<Item=(), W> >() {
+    //~^ ERROR expected `=`, found `>`
+}
+
+fn main() { }


### PR DESCRIPTION
part of #32214

This seems to be the obvious fix, and the error message is consistent with all the other parser errors ("expected x, found y").
