### PR TITLE
middle: reset loop labels while visiting closure

### DIFF
--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -193,7 +193,12 @@ impl<'a, 'v> Visitor<'v> for LifetimeContext<'a> {
                 })
             }
             FnKind::Closure(_) => {
-                self.add_scope_and_walk_fn(fk, fd, b, s, fn_id)
+                // Closures have their own set of labels, save labels just
+                // like for foreign items above.
+                let saved = replace(&mut self.labels_in_fn, vec![]);
+                let result = self.add_scope_and_walk_fn(fk, fd, b, s, fn_id);
+                replace(&mut self.labels_in_fn, saved);
+                result
             }
         }
     }

--- a/src/test/run-pass/issue-25343.rs
+++ b/src/test/run-pass/issue-25343.rs
@@ -8,9 +8,24 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(unused)]
 fn main() {
     || {
         'label: loop {
         }
     };
+
+    // More cases added from issue 31754
+
+    'label2: loop {
+        break;
+    }
+
+    let closure = || {
+        'label2: loop {}
+    };
+
+    fn inner_fn() {
+        'label2: loop {}
+    }
 }


### PR DESCRIPTION
This should fix #31754 and follow-up #25343.  Before the latter, the closure was visited twice in the context of the enclosing fn, which made even a single closure with a loop label emit a warning.

With this change, the closure is still visited within the context of the main fn (which is intended, since it is not a separate item) but resets the found loop labels while being visited.

Fixes: #31754

Note: I amended the test file from #25343, but I don't know if the original or amended test are effective, since as far as I could see, compiletest's run-pass tests do not check for zero warnings emitted?

/cc @Manishearth
