### PR TITLE
libstd: correct the link to functions in io module documentation

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -195,7 +195,7 @@
 //!
 //! ## Functions
 //!
-//! There are a number of [functions][functions] that offer access to various
+//! There are a number of [functions][functions-list] that offer access to various
 //! features. For example, we can use three of these functions to copy everything
 //! from standard input to standard output:
 //!
@@ -208,7 +208,7 @@
 //! # }
 //! ```
 //!
-//! [functions]: #functions
+//! [functions-list]: #functions-1
 //!
 //! ## io::Result
 //!


### PR DESCRIPTION
Currently the link refers to it's own section of the documentation rather than the list of functions generated by rustdoc.

i.e. [this](http://doc.rust-lang.org/std/io/index.html#functions) should link to [this](http://doc.rust-lang.org/std/io/index.html#functions-1)
