### PR TITLE
borrowck: clearer error message for mutability violation

### DIFF
--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -873,7 +873,7 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
 
                 match err.cause {
                     MutabilityViolation => {
-                        format!("cannot assign to {}", descr)
+                        format!("cannot assign to immutable {}", descr)
                     }
                     BorrowViolation(euv::ClosureCapture(_)) => {
                         format!("closure cannot assign to {}", descr)

--- a/src/test/compile-fail/issue-31871.rs
+++ b/src/test/compile-fail/issue-31871.rs
@@ -1,0 +1,18 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let x = vec![()];
+
+    let mut closure = move |v| {
+        x = v;
+        //~^ ERROR cannot assign to immutable captured outer variable in an `FnMut` closure
+    };
+}


### PR DESCRIPTION
Because the X in "cannot assign to X" can be quite involved, it is easy for the user to assume that
`cannot assign to captured outer variable in an`FnMut`closure`
refers to a specialty of FnMut closures.  This change should make it clearer that the "immutable" is the key point here.

Note: I haven't checked in what other cases this message is emitted. It didn't seem to be covered by any existing borrowck compile-fail checks. But since the variant is called `MutabilityViolation` it seemed safe to add the "immutable".

Fixes: #31871
