### PR TITLE
adt: Allow repr attribute on single variant enum.

### DIFF
--- a/src/librustc_trans/adt.rs
+++ b/src/librustc_trans/adt.rs
@@ -306,10 +306,8 @@ fn represent_type_uncached<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                      cx.tcx().item_path_str(def.did));
             }
 
-            if cases.len() == 1 {
+            if cases.len() == 1 && hint == attr::ReprAny {
                 // Equivalent to a struct/tuple/newtype.
-                // (Typechecking will reject discriminant-sizing attrs.)
-                assert_eq!(hint, attr::ReprAny);
                 let mut ftys = cases[0].tys.clone();
                 if dtor { ftys.push(cx.tcx().dtor_type()); }
                 return Univariant(mk_struct(cx, &ftys[..], false, t),

--- a/src/test/run-pass/issue-33202.rs
+++ b/src/test/run-pass/issue-33202.rs
@@ -1,0 +1,18 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[repr(C)]
+pub enum CPOption<T> {
+    PSome(T),
+}
+
+fn main() {
+  println!("sizeof CPOption<i32> {}", std::mem::size_of::<CPOption<i32>>());
+}


### PR DESCRIPTION
Fixes #33202.
