### PR TITLE
fix built-in target detection

### DIFF
--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -71,10 +71,9 @@ macro_rules! supported_targets {
 
         // this would use a match if stringify! were allowed in pattern position
         fn load_specific(target: &str) -> Option<Target> {
-            let target = target.replace("-", "_");
             if false { }
             $(
-                else if target == stringify!($module) {
+                else if target == $triple {
                     let mut t = $module::target();
                     t.options.is_builtin = true;
                     debug!("Got builtin target: {:?}", t);

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -69,19 +69,18 @@ macro_rules! supported_targets {
         /// List of supported targets
         pub const TARGETS: &'static [&'static str] = &[$($triple),*];
 
-        // this would use a match if stringify! were allowed in pattern position
         fn load_specific(target: &str) -> Option<Target> {
-            if false { }
-            $(
-                else if target == $triple {
-                    let mut t = $module::target();
-                    t.options.is_builtin = true;
-                    debug!("Got builtin target: {:?}", t);
-                    return Some(t);
-                }
-            )*
-
-            None
+            match target {
+                $(
+                    $triple => {
+                        let mut t = $module::target();
+                        t.options.is_builtin = true;
+                        debug!("Got builtin target: {:?}", t);
+                        Some(t)
+                    },
+                )+
+                _ => None
+            }
         }
     )
 }

--- a/src/test/run-make/issue-33329/Makefile
+++ b/src/test/run-make/issue-33329/Makefile
@@ -1,0 +1,3 @@
+all:
+	$(RUSTC) --target x86_64_unknown-linux-musl main.rs 2>&1 | \
+		grep "error: Error loading target specification: Could not find specification for target"

--- a/src/test/run-make/issue-33329/Makefile
+++ b/src/test/run-make/issue-33329/Makefile
@@ -1,3 +1,5 @@
+-include ../tools.mk
+
 all:
 	$(RUSTC) --target x86_64_unknown-linux-musl main.rs 2>&1 | \
 		grep "error: Error loading target specification: Could not find specification for target"

--- a/src/test/run-make/issue-33329/main.rs
+++ b/src/test/run-make/issue-33329/main.rs
@@ -1,0 +1,11 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {}


### PR DESCRIPTION
previously the logic was accepting wrong triples (like
`x86_64_unknown-linux-musl`) as valid ones (like `x86_64-unknown-linux-musl`) if
they contained an underscore instead of a dash.

fixes #33329

---

r? @brson 

I wanted to use a compile-fail test at first. But, you can't pass an extra `--target` flag to `rustc` for those because they already call `rustc --target $HOST` so you get a `error: Option 'target' given more than once.`. The run-make test used here works fine though.
