### PR TITLE
Makefile: there is only one tidy target now

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -59,9 +59,8 @@
 #   * check-stage$(stage)-$(crate) - Test a crate in a specific stage
 #   * check-stage$(stage)-{rpass,rfail,cfail,rmake,...} - Run tests in src/test/
 #   * check-stage1-T-$(target)-H-$(host) - Run cross-compiled-tests
-#   * tidy-basic - show file / line stats
-#   * tidy-errors - show the highest rustc error code
-#   * tidy-features - show the status of language and lib features
+#   * tidy - Basic style check, show highest rustc error code and
+#     the status of language and lib features
 #   * rustc-stage$(stage) - Only build up to a specific stage
 #
 # Then mix in some of these environment variables to harness the

--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -73,7 +73,7 @@ pub fn check(path: &Path, bad: &mut bool) {
             if line.contains("\r") && !skip_cr {
                 err("CR character");
             }
-            if filename != "style.rs" && filename != "tidy.py" {
+            if filename != "style.rs" {
                 if line.contains("TODO") {
                     err("TODO is deprecated; use FIXME")
                 }


### PR DESCRIPTION
Also removes mention of tidy.py from the tidy sources.
