### PR TITLE
infer: remove distinction for "simple type errors"

### DIFF
--- a/src/librustc/infer/error_reporting.rs
+++ b/src/librustc/infer/error_reporting.rs
@@ -542,21 +542,13 @@ impl<'a, 'tcx> ErrorReporting<'tcx> for InferCtxt<'a, 'tcx> {
             }
         };
 
-        let is_simple_error = if let &TypeError::Sorts(ref values) = terr {
-            values.expected.is_primitive() && values.found.is_primitive()
-        } else {
-            false
-        };
-
         let mut err = struct_span_err!(self.tcx.sess,
                                        trace.origin.span(),
                                        E0308,
                                        "{}",
                                        trace.origin);
 
-        if !is_simple_error {
-            err = err.note_expected_found(&"type", &expected, &found);
-        }
+        err = err.note_expected_found(&"type", &expected, &found);
 
         err = err.span_label(trace.origin.span(), &terr);
 


### PR DESCRIPTION
Previously, the second "expected X, found Y" in parens was omitted for simple errors because it added no information.

Now that this is always omitted, there is no need for a distinction anymore.  This change restores the "expected, found" message for such errors.

Fixes: #33366
