### PR TITLE
rustdoc: HTML-escape Rust code (from constants)

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -26,6 +26,7 @@ use rustc::hir;
 use clean;
 use core::DocAccessLevels;
 use html::item_type::ItemType;
+use html::escape::Escape;
 use html::render;
 use html::render::{cache, CURRENT_LOCATION_KEY};
 
@@ -496,7 +497,7 @@ impl fmt::Display for clean::Type {
                 primitive_link(f, clean::PrimitiveType::Array, "[")?;
                 write!(f, "{}", t)?;
                 primitive_link(f, clean::PrimitiveType::Array,
-                               &format!("; {}]", *s))
+                               &format!("; {}]", Escape(s)))
             }
             clean::Bottom => f.write_str("!"),
             clean::RawPointer(m, ref t) => {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1866,7 +1866,7 @@ impl<'a> fmt::Display for Initializer<'a> {
         let Initializer(s) = *self;
         if s.is_empty() { return Ok(()); }
         write!(f, "<code> = </code>")?;
-        write!(f, "<code>{}</code>", s)
+        write!(f, "<code>{}</code>", Escape(s))
     }
 }
 
@@ -2106,7 +2106,7 @@ fn assoc_const(w: &mut fmt::Formatter,
 
     write!(w, ": {}", ty)?;
     if let Some(default) = default {
-        write!(w, " = {}", default)?;
+        write!(w, " = {}", Escape(default))?;
     }
     Ok(())
 }

--- a/src/test/rustdoc/escape-rust-expr.rs
+++ b/src/test/rustdoc/escape-rust-expr.rs
@@ -1,0 +1,15 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that we HTML-escape Rust expressions, where HTML special chars
+// can occur, and we know it's definitely not markup.
+
+// @has escape_rust_expr/constant.CONST_S.html '//pre[@class="rust const"]' '"<script>"'
+pub const CONST_S: &'static str = "<script>";


### PR DESCRIPTION
Especially in cases like the one in the test file, this can blow up the rendering big time if string constants in the code contain HTML.

But also other constants can contain special chars (e.g. `&` as an operator in constant expressions).
