### PR TITLE
rustdoc: use btree map for where clauses

### DIFF
--- a/src/librustdoc/clean/simplify.rs
+++ b/src/librustdoc/clean/simplify.rs
@@ -27,7 +27,7 @@
 //! bounds by special casing scenarios such as these. Fun!
 
 use std::mem;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use rustc::hir::def_id::DefId;
 use rustc::ty::subst;
@@ -39,7 +39,7 @@ use core::DocContext;
 
 pub fn where_clauses(cx: &DocContext, clauses: Vec<WP>) -> Vec<WP> {
     // First, partition the where clause into its separate components
-    let mut params = HashMap::new();
+    let mut params = BTreeMap::new();
     let mut lifetimes = Vec::new();
     let mut equalities = Vec::new();
     let mut tybounds = Vec::new();
@@ -62,7 +62,7 @@ pub fn where_clauses(cx: &DocContext, clauses: Vec<WP>) -> Vec<WP> {
     // Simplify the type parameter bounds on all the generics
     let mut params = params.into_iter().map(|(k, v)| {
         (k, ty_bounds(v))
-    }).collect::<HashMap<_, _>>();
+    }).collect::<BTreeMap<_, _>>();
 
     // Look for equality predicates on associated types that can be merged into
     // general bound predicates


### PR DESCRIPTION
to get more reproducible output.

Fixes: #32555

I've looked at the other uses of HashMap in rustdoc, and they seem ok to (i.e. they use `iter()` and related only for constructing a new map, or when the output goes into independent files).

Not sure what the cause of #24473 is, it shouldn't be where clauses, but maybe it was also fixed inbetween since May 2015.
