### PR TITLE
rustdoc: display field types together with names in detailed docs

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2247,18 +2247,22 @@ fn item_struct(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
     }).peekable();
     if let doctree::Plain = s.struct_type {
         if fields.peek().is_some() {
-            write!(w, "<h2 class='fields'>Fields</h2>\n<table>")?;
+            write!(w, "<h2 class='fields'>Fields</h2>\n<dl>")?;
             for field in fields {
-                write!(w, "<tr class='stab {stab}'>
-                             <td id='{shortty}.{name}'>\
-                               <code>{name}</code></td><td>",
+                write!(w, "<dt class='stab {stab}' id='{shortty}.{name}'>\
+                             <code>{name}",
                        shortty = ItemType::StructField,
                        stab = field.stability_class(),
                        name = field.name.as_ref().unwrap())?;
+                if let clean::StructFieldItem(ref ty) = field.inner {
+                    write!(w, ": {}</code></dt><dd>", ty)?;
+                } else {
+                    write!(w, "</code></dt><dd>")?;
+                }
                 document(w, cx, field)?;
-                write!(w, "</td></tr>")?;
+                write!(w, "</dd>")?;
             }
-            write!(w, "</table>")?;
+            write!(w, "</dl>")?;
         }
     }
     render_assoc_items(w, cx, it, it.def_id, AssocItemRender::All)
@@ -2336,18 +2340,22 @@ fn item_enum(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                     }
                 });
                 write!(w, "<h3 class='fields'>Fields</h3>\n
-                           <table>")?;
+                           <dl>")?;
                 for field in fields {
-                    write!(w, "<tr><td \
-                               id='{shortty}.{v}.field.{f}'>\
-                               <code>{f}</code></td><td>",
+                    write!(w, "<dt id='{shortty}.{v}.field.{f}'>\
+                                 <code>{f}",
                            shortty = ItemType::Variant,
                            v = variant.name.as_ref().unwrap(),
                            f = field.name.as_ref().unwrap())?;
+                    if let clean::StructFieldItem(ref ty) = field.inner {
+                        write!(w, ": {}</code></dt><dd>", ty)?;
+                    } else {
+                        write!(w, "</code></dt><dd>")?;
+                    }
                     document(w, cx, field)?;
-                    write!(w, "</td></tr>")?;
+                    write!(w, "</dd>")?;
                 }
-                write!(w, "</table>")?;
+                write!(w, "</dl>")?;
             }
             write!(w, "</td><td>")?;
             render_stability_since(w, variant, it)?;

--- a/src/test/rustdoc/structfields.rs
+++ b/src/test/rustdoc/structfields.rs
@@ -32,8 +32,8 @@ pub struct Bar {
 // @has structfields/enum.Qux.html
 pub enum Qux {
     Quz {
-        // @has - //pre "a: ()"
-        a: (),
+        // @has - //pre "a: Option<Box<()>>"
+        a: Option<Box<()>>,
         // @!has - //pre "b: ()"
         #[doc(hidden)]
         b: (),
@@ -41,4 +41,20 @@ pub enum Qux {
         c: usize,
         // @has - //pre "// some fields omitted"
     },
+}
+
+pub struct FieldDoc {
+    // @has structfields/struct.FieldDoc.html '//dt[@id="structfield.a"]' "a: i32"
+    // @has - //dd "field a"
+    /// field a
+    pub a: i32,
+}
+
+pub enum EnumFieldDoc {
+    E {
+        // @has structfields/enum.EnumFieldDoc.html '//dt[@id="variant.E.field.a"]' "a: i32"
+        // @has - //dd "field a"
+        /// field a
+        a: i32,
+    }
 }


### PR DESCRIPTION
Is this desirable? The problem I can see is that the type names might get quite long.

Fixes: #32024
