### PR TITLE
syntax: Parse field/method access after type ascription and cast expressions

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3015,11 +3015,17 @@ impl<'a> Parser<'a> {
                 let rhs = self.parse_ty()?;
                 lhs = self.mk_expr(lhs_span.lo, rhs.span.hi,
                                    ExprKind::Cast(lhs, rhs), None);
+                if self.check(&token::Dot) {
+                    lhs = self.parse_dot_or_call_expr_with(lhs, lhs_span.lo, None)?;
+                }
                 continue
             } else if op == AssocOp::Colon {
                 let rhs = self.parse_ty()?;
                 lhs = self.mk_expr(lhs_span.lo, rhs.span.hi,
                                    ExprKind::Type(lhs, rhs), None);
+                if self.check(&token::Dot) {
+                    lhs = self.parse_dot_or_call_expr_with(lhs, lhs_span.lo, None)?;
+                }
                 continue
             } else if op == AssocOp::DotDot || op == AssocOp::DotDotDot {
                 // If we didn’t have to handle `x..`/`x...`, it would be pretty easy to

--- a/src/test/run-pass/type-ascription-dot.rs
+++ b/src/test/run-pass/type-ascription-dot.rs
@@ -1,0 +1,39 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Field/method access is parsed after type ascription or cast expressions
+
+#![feature(type_ascription)]
+
+trait Tr {
+    fn s(&self) -> String;
+}
+
+impl<T: std::fmt::Display> Tr for T {
+    fn s(&self) -> String {
+        self.to_string()
+    }
+}
+
+fn main() {
+    let a: u8 = 10;
+    let b = a as u16.s();
+    let c = a: u8.s();
+    let d = 11: u8.to_string();
+    assert_eq!(b, "10");
+    assert_eq!(c, "10");
+    assert_eq!(d, "11");
+
+    let v = [1, 2, 3];
+    let len = v.iter().
+                collect(): Vec<_>.
+                len();
+    assert_eq!(len, 3);
+}


### PR DESCRIPTION
Addresses https://github.com/rust-lang/rust/issues/23416#issuecomment-166678447 / https://github.com/rust-lang/rfcs/pull/1539#issuecomment-195570246

This patch allows type ascription (and cast expressions) to be followed by field/method access syntax.
Therefore it allows type ascription to be used in method chains like

```
let sv = v.iter().
           collect(): Vec<_>.
           into_sorted();
```

and also makes unsuffixed integer literals with type ascription almost as convenient as literal suffixes

```
let s = 10u8.to_string();
let s = 10: u8.to_string();
```

r? @nikomatsakis 
