### PR TITLE
Mention initial year of publication only for the documentation copyright

### DIFF
--- a/src/doc/footer.inc
+++ b/src/doc/footer.inc
@@ -1,5 +1,5 @@
 <footer><p>
-Copyright &copy; 2011-2016 The Rust Project Developers. Licensed under the
+Copyright &copy; 2011 The Rust Project Developers. Licensed under the
 <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>
 or the <a href="http://opensource.org/licenses/MIT">MIT license</a>, at your option.
 </p><p>

--- a/src/doc/footer.inc
+++ b/src/doc/footer.inc
@@ -1,5 +1,5 @@
 <footer><p>
-Copyright &copy; 2011-2015 The Rust Project Developers. Licensed under the
+Copyright &copy; 2011-2016 The Rust Project Developers. Licensed under the
 <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>
 or the <a href="http://opensource.org/licenses/MIT">MIT license</a>, at your option.
 </p><p>


### PR DESCRIPTION
I have corrected the "copyright expiration year" that was still 2015 in the documentation copyright notice.

According to #31007 it seems that we could go one step further and simplify the copyright notice to only mention the year of original publication ("Copyright &copy; 2011" in this case).

Let me know if you would prefer this copyright notice to only mention the year of original publication (please make sure that it is really 2011 as stated in the current version of the documentation, and not 2010 like Rust's code) and I'll make the simplification.
