### PR TITLE
Print out the output line that fails json parsing

### DIFF
--- a/src/tools/compiletest/src/json.rs
+++ b/src/tools/compiletest/src/json.rs
@@ -57,11 +57,11 @@ struct DiagnosticCode {
 
 pub fn parse_output(file_name: &str, output: &str) -> Vec<Error> {
     output.lines()
-          .flat_map(|line| parse_line(file_name, line))
+          .flat_map(|line| parse_line(file_name, line, output))
           .collect()
 }
 
-fn parse_line(file_name: &str, line: &str) -> Vec<Error> {
+fn parse_line(file_name: &str, line: &str, output: &str) -> Vec<Error> {
     // The compiler sometimes intermingles non-JSON stuff into the
     // output.  This hack just skips over such lines. Yuck.
     if line.chars().next() == Some('{') {
@@ -72,8 +72,8 @@ fn parse_line(file_name: &str, line: &str) -> Vec<Error> {
                 expected_errors
             }
             Err(error) => {
-                panic!("failed to decode compiler output as json: `{}` when parsing: {}", error,
-                    line);
+                panic!("failed to decode compiler output as json: `{}`\noutput: {}\nline: {}",
+                    error, line, output);
             }
         }
     } else {

--- a/src/tools/compiletest/src/json.rs
+++ b/src/tools/compiletest/src/json.rs
@@ -72,7 +72,8 @@ fn parse_line(file_name: &str, line: &str) -> Vec<Error> {
                 expected_errors
             }
             Err(error) => {
-                panic!("failed to decode compiler output as json: `{}`", error);
+                panic!("failed to decode compiler output as json: `{}` when parsing: {}", error,
+                    line);
             }
         }
     } else {

--- a/src/tools/compiletest/src/json.rs
+++ b/src/tools/compiletest/src/json.rs
@@ -12,6 +12,7 @@ use errors::{Error, ErrorKind};
 use rustc_serialize::json;
 use std::str::FromStr;
 use std::path::Path;
+use runtest::{fatal_proc_rec, ProcRes};
 
 // These structs are a subset of the ones found in
 // `syntax::errors::json`.
@@ -55,13 +56,13 @@ struct DiagnosticCode {
     explanation: Option<String>,
 }
 
-pub fn parse_output(file_name: &str, output: &str) -> Vec<Error> {
+pub fn parse_output(file_name: &str, output: &str, proc_res: &ProcRes) -> Vec<Error> {
     output.lines()
-          .flat_map(|line| parse_line(file_name, line, output))
+          .flat_map(|line| parse_line(file_name, line, output, proc_res))
           .collect()
 }
 
-fn parse_line(file_name: &str, line: &str, output: &str) -> Vec<Error> {
+fn parse_line(file_name: &str, line: &str, output: &str, proc_res: &ProcRes) -> Vec<Error> {
     // The compiler sometimes intermingles non-JSON stuff into the
     // output.  This hack just skips over such lines. Yuck.
     if line.chars().next() == Some('{') {
@@ -72,8 +73,9 @@ fn parse_line(file_name: &str, line: &str, output: &str) -> Vec<Error> {
                 expected_errors
             }
             Err(error) => {
-                panic!("failed to decode compiler output as json: `{}`\noutput: {}\nline: {}",
-                    error, line, output);
+                fatal_proc_rec(None, &format!(
+                    "failed to decode compiler output as json: `{}`\noutput: {}\nline: {}",
+                    error, line, output), proc_res);
             }
         }
     } else {

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1019,7 +1019,7 @@ fn check_expected_errors(revision: Option<&str>,
     let expect_note = expected_errors.iter().any(|ee| ee.kind == Some(ErrorKind::Note));
 
     // Parse the JSON output from the compiler and extract out the messages.
-    let actual_errors = json::parse_output(&file_name, &proc_res.stderr);
+    let actual_errors = json::parse_output(&file_name, &proc_res.stderr, &proc_res);
     let mut unexpected = 0;
     let mut not_found = 0;
     let mut found = vec![false; expected_errors.len()];
@@ -1111,7 +1111,7 @@ struct ProcArgs {
     args: Vec<String>,
 }
 
-struct ProcRes {
+pub struct ProcRes {
     status: Status,
     stdout: String,
     stderr: String,
@@ -1576,7 +1576,7 @@ fn fatal(revision: Option<&str>, err: &str) -> ! {
     error(revision, err); panic!();
 }
 
-fn fatal_proc_rec(revision: Option<&str>, err: &str, proc_res: &ProcRes) -> ! {
+pub fn fatal_proc_rec(revision: Option<&str>, err: &str, proc_res: &ProcRes) -> ! {
     error(revision, err);
     print!("\
 status: {}\n\


### PR DESCRIPTION
To help with debugging issues with some of the unit tests on various platforms, go ahead and print out the output line that fails a json parse.

Should help with tracking down #33390.  

cc @alexcrichton 
