### PR TITLE
Add rustc_on_unimplemented for Index implementation on slice

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -43,6 +43,7 @@
 // Since libcore defines many fundamental lang items, all tests live in a
 // separate crate, libcoretest, to avoid bizarre issues.
 
+#![cfg_attr(stage0, allow(unused_attributes))]
 #![crate_name = "core"]
 #![stable(feature = "core", since = "1.6.0")]
 #![crate_type = "rlib"]

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -523,6 +523,8 @@ impl<T> SliceExt for [T] {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(unused_attributes)]
+#[rustc_on_unimplemented = "a usize is required to index into a slice"]
 impl<T> ops::Index<usize> for [T] {
     type Output = T;
 
@@ -533,6 +535,8 @@ impl<T> ops::Index<usize> for [T] {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(unused_attributes)]
+#[rustc_on_unimplemented = "a usize is required to index into a slice"]
 impl<T> ops::IndexMut<usize> for [T] {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut T {

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -167,7 +167,7 @@ pub struct InferCtxt<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
 
 /// A map returned by `skolemize_late_bound_regions()` indicating the skolemized
 /// region that each late-bound region was replaced with.
-pub type SkolemizationMap = FnvHashMap<ty::BoundRegion,ty::Region>;
+pub type SkolemizationMap = FnvHashMap<ty::BoundRegion, ty::Region>;
 
 /// Why did we require that the two types be related?
 ///

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -136,7 +136,6 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
 }
 
 impl<'tcx> Encodable for Substs<'tcx> {
-
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         cstore::tls::with_encoding_context(s, |ecx, rbml_w| {
             ecx.encode_substs(rbml_w, self);

--- a/src/test/compile-fail/check_on_unimplemented.rs
+++ b/src/test/compile-fail/check_on_unimplemented.rs
@@ -31,4 +31,5 @@ impl Index<usize> for [i32] {
 fn main() {
     Index::<u32>::index(&[1, 2, 3] as &[i32], 2u32); //~ ERROR E0277
                                                      //~| NOTE a usize is required
+                                                     //~| NOTE required by
 }

--- a/src/test/compile-fail/check_on_unimplemented.rs
+++ b/src/test/compile-fail/check_on_unimplemented.rs
@@ -1,0 +1,34 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test if the on_unimplemented message override works
+
+#![feature(on_unimplemented)]
+#![feature(rustc_attrs)]
+
+#[rustc_on_unimplemented = "invalid"]
+trait Index<Idx: ?Sized> {
+    type Output: ?Sized;
+    fn index(&self, index: Idx) -> &Self::Output;
+}
+
+#[rustc_on_unimplemented = "a usize is required to index into a slice"]
+impl Index<usize> for [i32] {
+    type Output = i32;
+    fn index(&self, index: usize) -> &i32 {
+        &self[index]
+    }
+}
+
+#[rustc_error]
+fn main() {
+    Index::<u32>::index(&[1, 2, 3] as &[i32], 2u32); //~ ERROR E0277
+                                                     //~| NOTE a usize is required
+}

--- a/src/test/compile-fail/check_on_unimplemented_on_slice.rs
+++ b/src/test/compile-fail/check_on_unimplemented_on_slice.rs
@@ -1,0 +1,20 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test new Index error message for slices
+
+#![feature(rustc_attrs)]
+
+#[rustc_error]
+fn main() {
+    let x = &[1, 2, 3] as &[i32];
+    x[1i32]; //~ ERROR E0277
+             //~| NOTE a usize is required
+}

--- a/src/test/compile-fail/on_unimplemented.rs
+++ b/src/test/compile-fail/on_unimplemented.rs
@@ -1,0 +1,46 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test if the on_unimplemented message override works
+
+#![feature(on_unimplemented)]
+#![feature(rustc_attrs)]
+
+#[rustc_on_unimplemented = "invalid"]
+trait Index<Idx: ?Sized> {
+    type Output: ?Sized;
+    fn index(&self, index: Idx) -> &Self::Output;
+}
+
+struct Foo {
+    i: usize,
+}
+
+#[rustc_on_unimplemented = "a Foo is required to index into a slice"]
+impl Index<Foo> for [i32] {
+    type Output = i32;
+    fn index(&self, index: Foo) -> &i32 {
+        &self[index.i]
+    }
+}
+
+#[rustc_on_unimplemented = "a usize is required to index into a slice"]
+impl Index<usize> for [i32] {
+    type Output = i32;
+    fn index(&self, index: usize) -> &i32 {
+        &self[index]
+    }
+}
+
+#[rustc_error]
+fn main() {
+    Index::<u32>::index(&[1, 2, 3] as &[i32], 2u32); //~ ERROR E0277
+                                                     //~| NOTE a usize is required
+}

--- a/src/test/compile-fail/on_unimplemented.rs
+++ b/src/test/compile-fail/on_unimplemented.rs
@@ -19,15 +19,11 @@ trait Index<Idx: ?Sized> {
     fn index(&self, index: Idx) -> &Self::Output;
 }
 
-struct Foo {
-    i: usize,
-}
-
-#[rustc_on_unimplemented = "a Foo is required to index into a slice"]
-impl Index<Foo> for [i32] {
+#[rustc_on_unimplemented = "a isize is required to index into a slice"]
+impl Index<isize> for [i32] {
     type Output = i32;
-    fn index(&self, index: Foo) -> &i32 {
-        &self[index.i]
+    fn index(&self, index: isize) -> &i32 {
+        &self[index as usize]
     }
 }
 
@@ -39,8 +35,30 @@ impl Index<usize> for [i32] {
     }
 }
 
+trait Foo<A, B> {
+    fn f(&self, a: &A, b: &B);
+}
+
+#[rustc_on_unimplemented = "two i32 Foo trait takes"]
+impl Foo<i32, i32> for [i32] {
+    fn f(&self, a: &i32, b: &i32) {}
+}
+
+#[rustc_on_unimplemented = "two u32 Foo trait takes"]
+impl Foo<u32, u32> for [i32] {
+    fn f(&self, a: &u32, b: &u32) {}
+}
+
 #[rustc_error]
 fn main() {
     Index::<u32>::index(&[1, 2, 3] as &[i32], 2u32); //~ ERROR E0277
                                                      //~| NOTE a usize is required
+                                                     //~| NOTE required by
+    Index::<i32>::index(&[1, 2, 3] as &[i32], 2i32); //~ ERROR E0277
+                                                     //~| NOTE a isize is required
+                                                     //~| NOTE required by
+
+    Foo::<usize, usize>::f(&[1, 2, 3] as &[i32], &2usize, &2usize); //~ ERROR E0277
+                                                                    //~| NOTE two u32 Foo trait
+                                                                    //~| NOTE required by
 }


### PR DESCRIPTION
Reopening of #31071.

It also extends the possibility of `#[rustc_on_unimplemented]` by providing a small type filter in order to find the ones which corresponds the most.

r? @pnkfelix 
