### PR TITLE
rustc: Change target_env for ARM targets to `gnu`

### DIFF
--- a/src/librustc_back/target/arm_unknown_linux_gnueabi.rs
+++ b/src/librustc_back/target/arm_unknown_linux_gnueabi.rs
@@ -19,7 +19,7 @@ pub fn target() -> Target {
         data_layout: "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
         arch: "arm".to_string(),
         target_os: "linux".to_string(),
-        target_env: "gnueabi".to_string(),
+        target_env: "gnu".to_string(),
         target_vendor: "unknown".to_string(),
 
         options: TargetOptions {

--- a/src/librustc_back/target/arm_unknown_linux_gnueabihf.rs
+++ b/src/librustc_back/target/arm_unknown_linux_gnueabihf.rs
@@ -19,7 +19,7 @@ pub fn target() -> Target {
         data_layout: "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
         arch: "arm".to_string(),
         target_os: "linux".to_string(),
-        target_env: "gnueabihf".to_string(),
+        target_env: "gnu".to_string(),
         target_vendor: "unknown".to_string(),
 
         options: TargetOptions {

--- a/src/librustc_back/target/armv7_unknown_linux_gnueabihf.rs
+++ b/src/librustc_back/target/armv7_unknown_linux_gnueabihf.rs
@@ -19,7 +19,7 @@ pub fn target() -> Target {
         data_layout: "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
         arch: "arm".to_string(),
         target_os: "linux".to_string(),
-        target_env: "gnueabihf".to_string(),
+        target_env: "gnu".to_string(),
         target_vendor: "unknown".to_string(),
 
         options: TargetOptions {


### PR DESCRIPTION
Right now they're `gnueabihf` and `gnueabi`, but when adding new platforms like
musl on ARM it's unfortunate to have to test for all three (`musl`, `musleabi`,
and `musleabihf`). This PR switches everything currently to `gnu`, and the new
musl targets can also use `musl` when they land.

Closes #33244
