### PR TITLE
Improve diagnostics for constants being used in irrefutable patterns

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -141,7 +141,7 @@ enum ResolutionError<'a> {
     /// error E0413: declaration shadows an enum variant or unit-like struct in scope
     DeclarationShadowsEnumVariantOrUnitLikeStruct(Name),
     /// error E0414: only irrefutable patterns allowed here
-    OnlyIrrefutablePatternsAllowedHere(Name),
+    ConstantForIrrefutableBinding(Name),
     /// error E0415: identifier is bound more than once in this parameter list
     IdentifierBoundMoreThanOnceInParameterList(&'a str),
     /// error E0416: identifier is bound more than once in the same pattern
@@ -323,11 +323,11 @@ fn resolve_struct_error<'b, 'a: 'b, 'tcx: 'a>(resolver: &'b Resolver<'a, 'tcx>,
                               or unit-like struct in scope",
                              name)
         }
-        ResolutionError::OnlyIrrefutablePatternsAllowedHere(name) => {
+        ResolutionError::ConstantForIrrefutableBinding(name) => {
             let mut err = struct_span_err!(resolver.session,
                                            span,
                                            E0414,
-                                           "only irrefutable patterns allowed here");
+                                           "variable bindings cannot shadow constants");
             err.span_note(span,
                           "there already is a constant in scope sharing the same \
                            name as this pattern");
@@ -2233,7 +2233,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                             resolve_error(
                                 self,
                                 pattern.span,
-                                ResolutionError::OnlyIrrefutablePatternsAllowedHere(name)
+                                ResolutionError::ConstantForIrrefutableBinding(name)
                             );
                             self.record_def(pattern.id, err_path_resolution());
                         }

--- a/src/test/compile-fail/const-pattern-irrefutable.rs
+++ b/src/test/compile-fail/const-pattern-irrefutable.rs
@@ -19,10 +19,10 @@ use foo::d; //~ NOTE constant imported here
 const a: u8 = 2; //~ NOTE constant defined here
 
 fn main() {
-    let a = 4; //~ ERROR only irrefutable
+    let a = 4; //~ ERROR variable bindings cannot
                //~^ NOTE there already is a constant in scope
-    let c = 4; //~ ERROR only irrefutable
+    let c = 4; //~ ERROR variable bindings cannot
                //~^ NOTE there already is a constant in scope
-    let d = 4; //~ ERROR only irrefutable
+    let d = 4; //~ ERROR variable bindings cannot
                //~^ NOTE there already is a constant in scope
 }

--- a/src/test/compile-fail/issue-27033.rs
+++ b/src/test/compile-fail/issue-27033.rs
@@ -14,7 +14,7 @@ fn main() {
     };
     const C: u8 = 1;
     match 1 {
-        C @ 2 => { //~ ERROR only irrefutable patterns allowed here
+        C @ 2 => { //~ ERROR variable bindings cannot shadow constants
             println!("{}", C);
         }
         _ => {}


### PR DESCRIPTION
It's pretty confusing and this error triggers in resolve only when "shadowing" a const, so let's make that clearer.

r? @steveklabnik
