### PR TITLE
Add armv7-linux-androideabi target

### DIFF
--- a/configure
+++ b/configure
@@ -632,6 +632,7 @@ valopt build "${DEFAULT_BUILD}" "GNUs ./configure syntax LLVM build triple"
 valopt android-cross-path "" "Android NDK standalone path (deprecated)"
 valopt i686-linux-android-ndk "" "i686-linux-android NDK standalone path"
 valopt arm-linux-androideabi-ndk "" "arm-linux-androideabi NDK standalone path"
+valopt armv7-linux-androideabi-ndk "" "armv7-linux-androideabi NDK standalone path"
 valopt aarch64-linux-android-ndk "" "aarch64-linux-android NDK standalone path"
 valopt nacl-cross-path  "" "NaCl SDK path (Pepper Canary is recommended). Must be absolute!"
 valopt release-channel "dev" "the name of the release channel to build"
@@ -1144,6 +1145,15 @@ do
 
     case $i in
         *android*)
+            case $i in
+                armv7-linux-androideabi)
+                    cmd_prefix="arm-linux-androideabi"
+                    ;;
+                *)
+                    cmd_prefix=$i
+                    ;;
+            esac
+
             upper_snake_target=$(echo "$i" | tr '[:lower:]' '[:upper:]' | tr '\-' '\_')
             eval ndk=\$"CFG_${upper_snake_target}_NDK"
             if [ -z "$ndk" ]
@@ -1154,7 +1164,7 @@ do
             fi
 
             # Perform a basic sanity check of the NDK
-            for android_ndk_tool in "$ndk/bin/$i-gcc" "$ndk/bin/$i-g++" "$ndk/bin/$i-ar"
+            for android_ndk_tool in "$ndk/bin/$cmd_prefix-gcc" "$ndk/bin/$cmd_prefix-g++" "$ndk/bin/$cmd_prefix-ar"
             do
                 if [ ! -f $android_ndk_tool ]
                 then
@@ -1786,6 +1796,7 @@ putvar CFG_LIBDIR_RELATIVE
 putvar CFG_DISABLE_MANAGE_SUBMODULES
 putvar CFG_AARCH64_LINUX_ANDROID_NDK
 putvar CFG_ARM_LINUX_ANDROIDEABI_NDK
+putvar CFG_ARMV7_LINUX_ANDROIDEABI_NDK
 putvar CFG_I686_LINUX_ANDROID_NDK
 putvar CFG_NACL_CROSS_PATH
 putvar CFG_MANDIR

--- a/mk/cfg/armv7-linux-androideabi.mk
+++ b/mk/cfg/armv7-linux-androideabi.mk
@@ -1,0 +1,25 @@
+# armv7-linux-androideabi configuration
+CC_armv7-linux-androideabi=$(CFG_ARMV7_LINUX_ANDROIDEABI_NDK)/bin/arm-linux-androideabi-gcc
+CXX_armv7-linux-androideabi=$(CFG_ARMV7_LINUX_ANDROIDEABI_NDK)/bin/arm-linux-androideabi-g++
+CPP_armv7-linux-androideabi=$(CFG_ARMV7_LINUX_ANDROIDEABI_NDK)/bin/arm-linux-androideabi-gcc -E
+AR_armv7-linux-androideabi=$(CFG_ARMV7_LINUX_ANDROIDEABI_NDK)/bin/arm-linux-androideabi-ar
+CFG_LIB_NAME_armv7-linux-androideabi=lib$(1).so
+CFG_STATIC_LIB_NAME_armv7-linux-androideabi=lib$(1).a
+CFG_LIB_GLOB_armv7-linux-androideabi=lib$(1)-*.so
+CFG_LIB_DSYM_GLOB_armv7-linux-androideabi=lib$(1)-*.dylib.dSYM
+CFG_JEMALLOC_CFLAGS_armv7-linux-androideabi := -D__arm__ -DANDROID -D__ANDROID__ $(CFLAGS)
+CFG_GCCISH_CFLAGS_armv7-linux-androideabi := -Wall -g -fPIC -D__arm__ -mfloat-abi=softfp -march=armv7-a -mfpu=vfpv3-d16 -DANDROID -D__ANDROID__ $(CFLAGS)
+CFG_GCCISH_CXXFLAGS_armv7-linux-androideabi := -fno-rtti $(CXXFLAGS)
+CFG_GCCISH_LINK_FLAGS_armv7-linux-androideabi := -shared -fPIC -ldl -g -lm -lsupc++
+CFG_GCCISH_DEF_FLAG_armv7-linux-androideabi := -Wl,--export-dynamic,--dynamic-list=
+CFG_LLC_FLAGS_armv7-linux-androideabi :=
+CFG_INSTALL_NAME_armv7-linux-androideabi =
+CFG_EXE_SUFFIX_armv7-linux-androideabi :=
+CFG_WINDOWSY_armv7-linux-androideabi :=
+CFG_UNIXY_armv7-linux-androideabi := 1
+CFG_LDPATH_armv7-linux-androideabi :=
+CFG_RUN_armv7-linux-androideabi=
+CFG_RUN_TARG_armv7-linux-androideabi=
+RUSTC_FLAGS_armv7-linux-androideabi :=
+RUSTC_CROSS_FLAGS_armv7-linux-androideabi :=
+CFG_GNU_TRIPLE_armv7-linux-androideabi := arm-linux-androideabi

--- a/src/bootstrap/build/config.rs
+++ b/src/bootstrap/build/config.rs
@@ -338,6 +338,12 @@ impl Config {
                                      .or_insert(Target::default());
                     target.ndk = Some(PathBuf::from(value));
                 }
+                "CFG_ARMV7_LINUX_ANDROIDEABI_NDK" if value.len() > 0 => {
+                    let target = "armv7-linux-androideabi".to_string();
+                    let target = self.target_config.entry(target)
+                                     .or_insert(Target::default());
+                    target.ndk = Some(PathBuf::from(value));
+                }
                 "CFG_I686_LINUX_ANDROID_NDK" if value.len() > 0 => {
                     let target = "i686-linux-androideabi".to_string();
                     let target = self.target_config.entry(target)

--- a/src/doc/book/getting-started.md
+++ b/src/doc/book/getting-started.md
@@ -98,6 +98,7 @@ unofficial locations.
 |  Target                       | std |rustc|cargo| notes                      |
 |-------------------------------|-----|-----|-----|----------------------------|
 | `aarch64-linux-android`       |  ✓  |     |     | ARM64 Android              |
+| `armv7-linux-androideabi`     |  ✓  |     |     | ARM-v7a Android            |
 | `i686-linux-android`          |  ✓  |     |     | 32-bit x86 Android         |
 | `i686-pc-windows-msvc` (XP)   |  ✓  |     |     | Windows XP support         |
 | `i686-unknown-freebsd`        |  ✓  |  ✓  |  ✓  | 32-bit FreeBSD             |

--- a/src/librustc_back/target/armv7_linux_androideabi.rs
+++ b/src/librustc_back/target/armv7_linux_androideabi.rs
@@ -1,0 +1,28 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use target::Target;
+
+pub fn target() -> Target {
+    let mut base = super::android_base::opts();
+    base.features = "+v7,+thumb2,+vfp3,+d16".to_string();
+
+    Target {
+        llvm_target: "armv7-none-linux-android".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "32".to_string(),
+        data_layout: "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
+        arch: "arm".to_string(),
+        target_os: "android".to_string(),
+        target_env: "gnu".to_string(),
+        target_vendor: "unknown".to_string(),
+        options: base,
+    }
+}

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -107,6 +107,7 @@ supported_targets! {
 
     ("i686-linux-android", i686_linux_android),
     ("arm-linux-androideabi", arm_linux_androideabi),
+    ("armv7-linux-androideabi", armv7_linux_androideabi),
     ("aarch64-linux-android", aarch64_linux_android),
 
     ("i686-unknown-freebsd", i686_unknown_freebsd),

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -33,7 +33,7 @@ use std::process::{Command, Output, ExitStatus};
 pub fn run(config: Config, testpaths: &TestPaths) {
     match &*config.target {
 
-        "arm-linux-androideabi" | "aarch64-linux-android" => {
+        "arm-linux-androideabi" | "armv7-linux-androideabi" | "aarch64-linux-android" => {
             if !config.adb_device_status {
                 panic!("android device not available");
             }
@@ -424,7 +424,7 @@ actual:\n\
 
         let debugger_run_result;
         match &*self.config.target {
-            "arm-linux-androideabi" | "aarch64-linux-android" => {
+            "arm-linux-androideabi" | "armv7-linux-androideabi" | "aarch64-linux-android" => {
 
                 cmds = cmds.replace("run", "continue");
 
@@ -1132,7 +1132,7 @@ actual:\n\
 
         match &*self.config.target {
 
-            "arm-linux-androideabi" | "aarch64-linux-android" => {
+            "arm-linux-androideabi" | "armv7-linux-androideabi" | "aarch64-linux-android" => {
                 self._arm_exec_compiled_test(env)
             }
 
@@ -1230,7 +1230,7 @@ actual:\n\
             }
 
             match &*self.config.target {
-                "arm-linux-androideabi"  | "aarch64-linux-android" => {
+                "arm-linux-androideabi" | "armv7-linux-androideabi" | "aarch64-linux-android" => {
                     self._arm_push_aux_shared_library();
                 }
                 _ => {}


### PR DESCRIPTION
This PR adds `armv7-linux-androideabi` target that matches `armeabi-v7a` Android ABI, ~~downscales `arm-linux-androideabi` target to match `armeabi` Android ABI~~ (TBD later if needed).

This should allow us to get the best performance from every [Android ABI level](http://developer.android.com/ndk/guides/abis.html).

Currently existing target `arm-linux-androideabi` started gaining features out of the supported range of [android `armeabi`](http://developer.android.com/ndk/guides/abis.html). While android compiler does not use a different target for later supported `armv7` architecture, it has distinct ABI name `armeabi-v7a`. We decided to add rust target `armv7-linux-androideabi` to match it.

Note that `NEON`, `VFPv3-D32`, and `ThumbEE` instruction sets are not added, because not all android devices are guaranteed to support all or some of these, and [their availability should be checked at runtime](http://developer.android.com/ndk/guides/abis.html#v7a).

~~This reduces performance of existing `arm-linux-androideabi` and may make it _much_ slower (we are talking more than order of magnitude in some random ad-hoc fp benchmark that I did).~~

Part of #33278.
