### PR TITLE
implement RFC 1521

### DIFF
--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -49,6 +49,11 @@ use marker::Sized;
 /// A common trait for cloning an object.
 ///
 /// This trait can be used with `#[derive]`.
+///
+/// Types that are `Copy` should have a trivial implementation of `Clone`. More formally:
+/// if `T: Copy`, `x: T`, and `y: &T`, then `let x = y.clone();` is equivalent to `let x = *y;`.
+/// Manual implementations should be careful to uphold this invariant; however, unsafe code
+/// must not rely on it to ensure memory safety.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Clone : Sized {
     /// Returns a copy of the value.


### PR DESCRIPTION
Adds documentation to Clone, specifying that Copy types should have a trivial Clone impl.

Fixes #33416.

I tried to use "should" and "must" as defined [here](https://tools.ietf.org/html/rfc2119).

cc @ubsan
