### PR TITLE
Add an LLVM fatal error handler

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -1014,6 +1014,9 @@ pub fn monitor<F: FnOnce() + Send + 'static>(f: F) {
         }
     }
 
+    // Install LLVM fatal error handler
+    ::llvm::install_default_llvm_error_handler();
+
     let data = Arc::new(Mutex::new(Vec::new()));
     let err = Sink(data.clone());
 

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -1754,6 +1754,12 @@ extern {
     /// Returns a string describing the last error caused by an LLVMRust* call.
     pub fn LLVMRustGetLastError() -> *const c_char;
 
+    pub fn LLVMInstallFatalErrorHandler(handler: extern fn(*const c_char) -> c_void) -> c_void;
+
+    pub fn LLVMRemoveFatalErrorHandler() -> c_void;
+
+    pub fn LLVMSysRunInterruptHandlers() -> c_void;
+
     /// Print the pass timings since static dtors aren't picking them up.
     pub fn LLVMRustPrintPassTimings();
 
@@ -2416,6 +2422,24 @@ pub fn last_error() -> Option<String> {
             Some(err)
         }
     }
+}
+
+// The default behaviour of llvm's report fatal error method outputs to
+// stderr, runs interrupt handlers, and then call's `exit(1)`.
+// This alters this slightly, and calls panic! instead.
+extern "C" fn handle_llvm_error(reason: *const c_char) -> c_void {
+    let reason = unsafe {
+        CStr::from_ptr(reason).to_string_lossy()
+    };
+
+    unsafe { LLVMSysRunInterruptHandlers() };
+    panic!("{}", reason);
+}
+
+pub fn install_default_llvm_error_handler() {
+    unsafe {
+        LLVMInstallFatalErrorHandler(handle_llvm_error)
+    };
 }
 
 pub struct OperandBundleDef {

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -16,6 +16,9 @@
 
 #include "llvm/IR/CallSite.h"
 
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/Signals.h"
+
 //===----------------------------------------------------------------------===
 //
 // This file defines alternate interfaces to core functions that are more
@@ -39,6 +42,10 @@ LLVMRustCreateMemoryBufferWithContentsOfFile(const char *Path) {
       return nullptr;
   }
   return wrap(buf_or.get().release());
+}
+
+extern "C" void LLVMRemoveFatalErrorHandler() {
+    llvm::remove_fatal_error_handler();
 }
 
 extern "C" char *LLVMRustGetLastError(void) {
@@ -75,6 +82,10 @@ extern "C" LLVMValueRef LLVMRustConstInt(LLVMTypeRef IntTy,
 extern "C" void LLVMRustPrintPassTimings() {
   raw_fd_ostream OS (2, false); // stderr.
   TimerGroup::printAll(OS);
+}
+
+extern "C" void LLVMSysRunInterruptHandlers() {
+    sys::RunInterruptHandlers();
 }
 
 extern "C" LLVMValueRef LLVMGetNamedValue(LLVMModuleRef M,


### PR DESCRIPTION
Catches internal LLVM fatal errors and turns them into rust panics.  This gives us a backtrace using `RUST_BACKTRACE` and the usual useful output regarding the ICE.

Before this addition, the internal error handler would output something like `LLVM ERROR: Cannot select: intrinsic %llvm.x86.sse41.dpps` and then call `exit` - not caught in rust land.

I've added `LLVMRemoveFatalErrorHandler` for completeness, but I haven't called this anywhere.
