### PR TITLE
[Doc] Default cpu is "generic" (and not "default")

### DIFF
--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -201,7 +201,7 @@ pub struct TargetOptions {
     pub post_link_args: Vec<String>,
 
     /// Default CPU to pass to LLVM. Corresponds to `llc -mcpu=$cpu`. Defaults
-    /// to "default".
+    /// to "generic".
     pub cpu: String,
     /// Default target features to pass to LLVM. These features will *always* be
     /// passed, and cannot be disabled even via `-C`. Corresponds to `llc


### PR DESCRIPTION
See [line 305](https://github.com/phil-opp/rust/blob/a22ca2872ef6782306012e6817dc4b8b778c43e9/src/librustc_back/target/mod.rs#L305).
