### PR TITLE
Make --emit dep-info work correctly with -Z no-analysis again.

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -188,9 +188,9 @@ pub fn compile_input(sess: &Session,
 
         {
             let _ignore = hir_map.dep_graph.in_ignore();
-            controller_entry_point!(after_ast,
+            controller_entry_point!(after_hir_lowering,
                                     sess,
-                                    CompileState::state_after_ast(input,
+                                    CompileState::state_after_hir_lowering(input,
                                                                   sess,
                                                                   outdir,
                                                                   output,
@@ -321,7 +321,7 @@ pub struct CompileController<'a> {
     pub after_parse: PhaseController<'a>,
     pub after_expand: PhaseController<'a>,
     pub after_write_deps: PhaseController<'a>,
-    pub after_ast: PhaseController<'a>,
+    pub after_hir_lowering: PhaseController<'a>,
     pub after_analysis: PhaseController<'a>,
     pub after_llvm: PhaseController<'a>,
 
@@ -334,7 +334,7 @@ impl<'a> CompileController<'a> {
             after_parse: PhaseController::basic(),
             after_expand: PhaseController::basic(),
             after_write_deps: PhaseController::basic(),
-            after_ast: PhaseController::basic(),
+            after_hir_lowering: PhaseController::basic(),
             after_analysis: PhaseController::basic(),
             after_llvm: PhaseController::basic(),
             make_glob_map: resolve::MakeGlobMap::No,
@@ -458,19 +458,19 @@ impl<'a, 'b, 'ast, 'tcx> CompileState<'a, 'b, 'ast, 'tcx> {
         }
     }
 
-    fn state_after_ast(input: &'a Input,
-                              session: &'ast Session,
-                              out_dir: &'a Option<PathBuf>,
-                              out_file: &'a Option<PathBuf>,
-                              arenas: &'ast ty::CtxtArenas<'ast>,
-                              cstore: &'a CStore,
-                              hir_map: &'a hir_map::Map<'ast>,
-                              analysis: &'a ty::CrateAnalysis,
-                              resolutions: &'a Resolutions,
-                              krate: &'a ast::Crate,
-                              hir_crate: &'a hir::Crate,
-                              crate_name: &'a str)
-                              -> CompileState<'a, 'b, 'ast, 'tcx> {
+    fn state_after_hir_lowering(input: &'a Input,
+                                session: &'ast Session,
+                                out_dir: &'a Option<PathBuf>,
+                                out_file: &'a Option<PathBuf>,
+                                arenas: &'ast ty::CtxtArenas<'ast>,
+                                cstore: &'a CStore,
+                                hir_map: &'a hir_map::Map<'ast>,
+                                analysis: &'a ty::CrateAnalysis,
+                                resolutions: &'a Resolutions,
+                                krate: &'a ast::Crate,
+                                hir_crate: &'a hir::Crate,
+                                crate_name: &'a str)
+                                -> CompileState<'a, 'b, 'ast, 'tcx> {
         CompileState {
             crate_name: Some(crate_name),
             arenas: Some(arenas),

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -140,17 +140,16 @@ pub fn compile_input(sess: &Session,
 
         write_out_deps(sess, &outputs, &id);
 
-        {            controller_entry_point!(after_write_deps,
-                                    sess,
-                                    CompileState::state_after_write_deps(input,
-                                                                         sess,
-                                                                         outdir,
-                                                                         output,
-                                                                         &cstore,
-                                                                         &expanded_crate,
-                                                                         &id),
-                                    Ok(()));
-        }
+        controller_entry_point!(after_write_deps,
+                                sess,
+                                CompileState::state_after_write_deps(input,
+                                                                     sess,
+                                                                     outdir,
+                                                                     output,
+                                                                     &cstore,
+                                                                     &expanded_crate,
+                                                                     &id),
+                                Ok(()));
 
         let expanded_crate = assign_node_ids(sess, expanded_crate);
         let dep_graph = DepGraph::new(sess.opts.build_dep_graph());

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -467,17 +467,17 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
                     state.krate = Some(pretty::fold_crate(state.krate.take().unwrap(), ppm));
                 };
                 control.after_hir_lowering.callback = box move |state| {
-                    pretty::print_after_ast(state.session,
-                                            state.ast_map.unwrap(),
-                                            state.analysis.unwrap(),
-                                            state.resolutions.unwrap(),
-                                            state.input,
-                                            &state.expanded_crate.take().unwrap(),
-                                            state.crate_name.unwrap(),
-                                            ppm,
-                                            state.arenas.unwrap(),
-                                            opt_uii.clone(),
-                                            state.out_file);
+                    pretty::print_after_hir_lowering(state.session,
+                                                     state.ast_map.unwrap(),
+                                                     state.analysis.unwrap(),
+                                                     state.resolutions.unwrap(),
+                                                     state.input,
+                                                     &state.expanded_crate.take().unwrap(),
+                                                     state.crate_name.unwrap(),
+                                                     ppm,
+                                                     state.arenas.unwrap(),
+                                                     opt_uii.clone(),
+                                                     state.out_file);
                 };
             } else {
                 control.after_parse.stop = Compilation::Stop;

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -461,12 +461,12 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
 
         if let Some((ppm, opt_uii)) = parse_pretty(sess, matches) {
             if ppm.needs_ast_map(&opt_uii) {
-                control.after_ast.stop = Compilation::Stop;
+                control.after_hir_lowering.stop = Compilation::Stop;
 
                 control.after_parse.callback = box move |state| {
                     state.krate = Some(pretty::fold_crate(state.krate.take().unwrap(), ppm));
                 };
-                control.after_ast.callback = box move |state| {
+                control.after_hir_lowering.callback = box move |state| {
                     pretty::print_after_ast(state.session,
                                             state.ast_map.unwrap(),
                                             state.analysis.unwrap(),

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -461,23 +461,23 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
 
         if let Some((ppm, opt_uii)) = parse_pretty(sess, matches) {
             if ppm.needs_ast_map(&opt_uii) {
-                control.after_write_deps.stop = Compilation::Stop;
+                control.after_ast.stop = Compilation::Stop;
 
                 control.after_parse.callback = box move |state| {
                     state.krate = Some(pretty::fold_crate(state.krate.take().unwrap(), ppm));
                 };
-                control.after_write_deps.callback = box move |state| {
-                    pretty::print_after_write_deps(state.session,
-                                                   state.ast_map.unwrap(),
-                                                   state.analysis.unwrap(),
-                                                   state.resolutions.unwrap(),
-                                                   state.input,
-                                                   &state.expanded_crate.take().unwrap(),
-                                                   state.crate_name.unwrap(),
-                                                   ppm,
-                                                   state.arenas.unwrap(),
-                                                   opt_uii.clone(),
-                                                   state.out_file);
+                control.after_ast.callback = box move |state| {
+                    pretty::print_after_ast(state.session,
+                                            state.ast_map.unwrap(),
+                                            state.analysis.unwrap(),
+                                            state.resolutions.unwrap(),
+                                            state.input,
+                                            &state.expanded_crate.take().unwrap(),
+                                            state.crate_name.unwrap(),
+                                            ppm,
+                                            state.arenas.unwrap(),
+                                            opt_uii.clone(),
+                                            state.out_file);
                 };
             } else {
                 control.after_parse.stop = Compilation::Stop;

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -812,17 +812,17 @@ pub fn print_after_parsing(sess: &Session,
     write_output(out, ofile);
 }
 
-pub fn print_after_write_deps<'tcx, 'a: 'tcx>(sess: &'a Session,
-                                              ast_map: &hir_map::Map<'tcx>,
-                                              analysis: &ty::CrateAnalysis,
-                                              resolutions: &Resolutions,
-                                              input: &Input,
-                                              krate: &ast::Crate,
-                                              crate_name: &str,
-                                              ppm: PpMode,
-                                              arenas: &'tcx ty::CtxtArenas<'tcx>,
-                                              opt_uii: Option<UserIdentifiedItem>,
-                                              ofile: Option<&Path>) {
+pub fn print_after_ast<'tcx, 'a: 'tcx>(sess: &'a Session,
+                                       ast_map: &hir_map::Map<'tcx>,
+                                       analysis: &ty::CrateAnalysis,
+                                       resolutions: &Resolutions,
+                                       input: &Input,
+                                       krate: &ast::Crate,
+                                       crate_name: &str,
+                                       ppm: PpMode,
+                                       arenas: &'tcx ty::CtxtArenas<'tcx>,
+                                       opt_uii: Option<UserIdentifiedItem>,
+                                       ofile: Option<&Path>) {
     let dep_graph = DepGraph::new(false);
     let _ignore = dep_graph.in_ignore();
 

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -812,17 +812,17 @@ pub fn print_after_parsing(sess: &Session,
     write_output(out, ofile);
 }
 
-pub fn print_after_ast<'tcx, 'a: 'tcx>(sess: &'a Session,
-                                       ast_map: &hir_map::Map<'tcx>,
-                                       analysis: &ty::CrateAnalysis,
-                                       resolutions: &Resolutions,
-                                       input: &Input,
-                                       krate: &ast::Crate,
-                                       crate_name: &str,
-                                       ppm: PpMode,
-                                       arenas: &'tcx ty::CtxtArenas<'tcx>,
-                                       opt_uii: Option<UserIdentifiedItem>,
-                                       ofile: Option<&Path>) {
+pub fn print_after_hir_lowering<'tcx, 'a: 'tcx>(sess: &'a Session,
+                                                ast_map: &hir_map::Map<'tcx>,
+                                                analysis: &ty::CrateAnalysis,
+                                                resolutions: &Resolutions,
+                                                input: &Input,
+                                                krate: &ast::Crate,
+                                                crate_name: &str,
+                                                ppm: PpMode,
+                                                arenas: &'tcx ty::CtxtArenas<'tcx>,
+                                                opt_uii: Option<UserIdentifiedItem>,
+                                                ofile: Option<&Path>) {
     let dep_graph = DepGraph::new(false);
     let _ignore = dep_graph.in_ignore();
 

--- a/src/test/run-make/dep-info-no-analysis/Makefile
+++ b/src/test/run-make/dep-info-no-analysis/Makefile
@@ -2,5 +2,5 @@
 
 all:
 	$(RUSTC) -o $(TMPDIR)/input.dd -Z no-analysis --emit dep-info input.rs
-	sed -i "s/^.*input.dd/input.dd/g" $(TMPDIR)/input.dd
+	sed -i'.bak' 's/^.*input.dd/input.dd/g' $(TMPDIR)/input.dd
 	diff -u $(TMPDIR)/input.dd input.dd

--- a/src/test/run-make/dep-info-no-analysis/Makefile
+++ b/src/test/run-make/dep-info-no-analysis/Makefile
@@ -2,5 +2,5 @@
 
 all:
 	$(RUSTC) -o $(TMPDIR)/input.dd -Z no-analysis --emit dep-info input.rs
-	sed -i "s@$(TMPDIR)/@@g" $(TMPDIR)/input.dd
+	sed -i "s/^.*input.dd/input.dd/g" $(TMPDIR)/input.dd
 	diff -u $(TMPDIR)/input.dd input.dd

--- a/src/test/run-make/dep-info-no-analysis/Makefile
+++ b/src/test/run-make/dep-info-no-analysis/Makefile
@@ -1,0 +1,6 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) -o $(TMPDIR)/input.dd -Z no-analysis --emit dep-info input.rs
+	sed -i "s@$(TMPDIR)/@@g" $(TMPDIR)/input.dd
+	diff -u $(TMPDIR)/input.dd input.dd

--- a/src/test/run-make/dep-info-no-analysis/input.dd
+++ b/src/test/run-make/dep-info-no-analysis/input.dd
@@ -1,0 +1,3 @@
+input.dd: input.rs
+
+input.rs:

--- a/src/test/run-make/dep-info-no-analysis/input.rs
+++ b/src/test/run-make/dep-info-no-analysis/input.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests that dep info can be emitted without resolving external crates.
+extern crate not_there;
+
+fn main() {}


### PR DESCRIPTION
Previously, it would attempt to resolve some external crates that weren't necessary for dep-info output.

Fixes #33231.
