### PR TITLE
Allow for opt-level=s,z during bootstrap

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -131,7 +131,7 @@ ifdef CFG_DISABLE_OPTIMIZE
   CFG_JEMALLOC_FLAGS += --enable-debug
 else
   # The rtopt cfg turns off runtime sanity checks
-  CFG_RUSTC_FLAGS += -O --cfg rtopt
+  CFG_RUSTC_FLAGS += -C opt-level=2 --cfg rtopt
 endif
 
 CFG_JEMALLOC_FLAGS += $(JEMALLOC_FLAGS)


### PR DESCRIPTION
Until rustc starts accepting both `-O` and `-C opt-level` on the same command line (the last option given should take precedence, other flags are also affected) this change enables using e.g.:

`RUSTFLAGS=-Copt-level=z` during bootstrap, as multiple opt-level flags happen to be handled correctly.
