### PR TITLE
casting `&[u8]` to `* const u8` doesn't work in const_eval

### DIFF
--- a/src/librustc_const_eval/eval.rs
+++ b/src/librustc_const_eval/eval.rs
@@ -1117,6 +1117,12 @@ fn cast_const<'tcx>(tcx: &TyCtxt<'tcx>, val: ConstVal, ty: ty::Ty) -> CastResult
         Float(f) => cast_const_float(tcx, f, ty),
         Char(c) => cast_const_int(tcx, Infer(c as u64), ty),
         Function(_) => Err(UnimplementedConstVal("casting fn pointers")),
+        ByteStr(_) => match ty.sty {
+            ty::TyRawPtr(_) => {
+                Err(ErrKind::UnimplementedConstVal("casting a bytestr to a raw ptr"))
+            },
+            _ => Err(CannotCast),
+        },
         _ => Err(CannotCast),
     }
 }

--- a/src/test/run-pass/const-err.rs
+++ b/src/test/run-pass/const-err.rs
@@ -12,6 +12,7 @@
 
 #![deny(const_err)]
 
+const X: *const u8 = b"" as _;
 
 fn main() {
     let _ = ((-1 as i8) << 8 - 1) as f32;


### PR DESCRIPTION
fixes #33452

r? @eddyb 

cc @Ms2ger 
