### PR TITLE
resolve: do not modify span of non-importable name

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -57,7 +57,7 @@ use rustc::util::nodemap::{NodeMap, NodeSet, FnvHashMap, FnvHashSet};
 
 use syntax::ast::{self, FloatTy};
 use syntax::ast::{CRATE_NODE_ID, Name, NodeId, CrateNum, IntTy, UintTy};
-use syntax::codemap::{self, Span, Pos};
+use syntax::codemap::{self, Span};
 use syntax::errors::DiagnosticBuilder;
 use syntax::parse::token::{self, keywords};
 use syntax::util::lev_distance::find_best_match_for_name;
@@ -1244,10 +1244,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 Failed(None) => {
                     let segment_name = name.as_str();
                     let module_name = module_to_string(search_module);
-                    let mut span = span;
                     let msg = if "???" == &module_name {
-                        span.hi = span.lo + Pos::from_usize(segment_name.len());
-
                         match search_parent_externals(name, &self.current_module) {
                             Some(module) => {
                                 let path_str = names_to_string(module_path);

--- a/src/test/compile-fail/issue-33464.rs
+++ b/src/test/compile-fail/issue-33464.rs
@@ -1,0 +1,23 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Make sure that the spans of import errors are correct.
+
+use abc::one_el;
+//~^ ERROR 13:5: 13:16
+use abc::{a, bbb, cccccc};
+//~^ ERROR 15:11: 15:12
+//~^^ ERROR 15:14: 15:17
+//~^^^ ERROR 15:19: 15:25
+use a_very_long_name::{el, el2};
+//~^ ERROR 19:24: 19:26
+//~^^ ERROR 19:28: 19:31
+
+fn main() {}


### PR DESCRIPTION
This span modification is probably leftover from a time when import spans were assigned differently.

With this change, error spans for the following are properly reported:

```
use abc::one_el;
use abc::{a, bbb, cccccc};
use a_very_long_name::{el, el2};
```

before (spans only):

```
x.rs:3 use abc::one_el;
           ^~~
x.rs:4 use abc::{a, bbb, cccccc};
                 ^~~
x.rs:4 use abc::{a, bbb, cccccc};
                    ^~~
x.rs:4 use abc::{a, bbb, cccccc};
                         ^~~
(internal compiler error: unprintable span)
(internal compiler error: unprintable span)
```

after:

```
x.rs:3 use abc::one_el;
           ^~~~~~~~~~~
x.rs:4 use abc::{a, bbb, cccccc};
                 ^
x.rs:4 use abc::{a, bbb, cccccc};
                    ^~~
x.rs:4 use abc::{a, bbb, cccccc};
                         ^~~~~~
x.rs:5 use a_very_long_name::{el, el2};
                              ^~
x.rs:5 use a_very_long_name::{el, el2};
                                  ^~~
```

Fixes: #33464
