### PR TITLE
mk: Try to fix nightlies again

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -616,7 +616,7 @@ ifdef CFG_ENABLE_DEBUGINFO_TESTS
 CTEST_RUSTC_FLAGS += -g
 endif
 
-CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3) := \
+CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3) = \
 		--compile-lib-path $$(HLIB$(1)_H_$(3)) \
         --run-lib-path $$(TLIB$(1)_T_$(2)_H_$(3)) \
         --rustc-path $$(HBIN$(1)_H_$(3))/rustc$$(X_$(3)) \
@@ -686,7 +686,7 @@ $(foreach host,$(CFG_HOST), \
 
 define DEF_RUN_COMPILETEST
 
-CTEST_ARGS$(1)-T-$(2)-H-$(3)-$(4) := \
+CTEST_ARGS$(1)-T-$(2)-H-$(3)-$(4) = \
         $$(CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3)) \
         --src-base $$(S)src/test/$$(CTEST_SRC_BASE_$(4))/ \
         --build-base $(3)/test/$$(CTEST_BUILD_BASE_$(4))/ \
@@ -779,7 +779,7 @@ $(foreach host,$(CFG_HOST), \
 
 define DEF_RUN_PRETTY_TEST
 
-PRETTY_ARGS$(1)-T-$(2)-H-$(3)-$(4) := \
+PRETTY_ARGS$(1)-T-$(2)-H-$(3)-$(4) = \
 		$$(CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3)) \
         --src-base $$(S)src/test/$$(PRETTY_DIRNAME_$(4))/ \
         --build-base $(3)/test/$$(PRETTY_DIRNAME_$(4))/ \


### PR DESCRIPTION
Looks like the real bug on nightlies is that the `llvm-pass` run-make test is
not actually getting the value of `LLVM_CXXFLAGS` correct. Namely, it's blank!
Now the only change #33093 which actually affected this is that the argument
`$(LLVM_CXXFLAGS_$(2))` was moved up from a makefile rule into the definition of
a variable. Sounds innocuous?

Turns out the variable this was moved into is defined with `:=`, which means
that it's not recursively expanded, which basically means that it's expanded
immediately. Unfortunately part of this expansion involves running
`llvm-config`, which doesn't exist at the start of distcheck build!

This didn't show up on the bots because they run `make` _then_ `make check`, and
the first step builds llvm-config so the next time `make` is loaded everything
is available. The distcheck bots, however, run just a plain `distcheck` so
`make` doesn't exist ahead of time. You can see this in action where the
distcheck bots start out with a bunch of "llvm-config not found" error messages.

This commit just changes a few variables to be defined with `=` which
essentially means they're lazily expanded. I did not run a full distcheck
locally, but this makes the initial "llvm-config not found" error messages go
away so I suspect that this is the fix.

Closes #33379 (hopefully)
