### PR TITLE
trans: callee: normalize trait_ref before use

### DIFF
--- a/src/librustc_trans/callee.rs
+++ b/src/librustc_trans/callee.rs
@@ -155,6 +155,7 @@ impl<'tcx> Callee<'tcx> {
         let method_item = tcx.impl_or_trait_item(def_id);
         let trait_id = method_item.container().id();
         let trait_ref = ty::Binder(substs.to_trait_ref(tcx, trait_id));
+        let trait_ref = infer::normalize_associated_type(tcx, &trait_ref);
         match common::fulfill_obligation(ccx, DUMMY_SP, trait_ref) {
             traits::VtableImpl(vtable_impl) => {
                 let impl_did = vtable_impl.impl_def_id;

--- a/src/test/run-pass/issue-33461.rs
+++ b/src/test/run-pass/issue-33461.rs
@@ -1,0 +1,36 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::marker::PhantomData;
+
+struct TheType<T> {
+    t: PhantomData<T>
+}
+
+pub trait TheTrait {
+    type TheAssociatedType;
+}
+
+impl TheTrait for () {
+    type TheAssociatedType = ();
+}
+
+pub trait Shape<P: TheTrait> {
+    fn doit(&self) {
+    }
+}
+
+impl<P: TheTrait> Shape<P> for TheType<P::TheAssociatedType> {
+}
+
+fn main() {
+    let ball = TheType { t: PhantomData };
+    let handle: &Shape<()> = &ball;
+}


### PR DESCRIPTION
This fixes #33436 and #33461. Ran the tests and nothing else seems to be affected.

P.S. How to write the regression test for this fix? Does this qualify as run-pass or run-make, as the test only needs to be successfully compiled to be considered passed? Will add the testcase (the minimal example in #33461 seems fit) after clarifying this.
