### PR TITLE
resolve: Make `self` unhygienic

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -53,7 +53,7 @@ use syntax::errors::Handler;
 use syntax::ext::mtwt;
 use syntax::ptr::P;
 use syntax::codemap::{respan, Spanned, Span};
-use syntax::parse::token;
+use syntax::parse::token::{self, keywords};
 use syntax::std_inject;
 use syntax::visit::{self, Visitor};
 
@@ -141,7 +141,11 @@ impl<'a, 'hir> LoweringContext<'a> {
 
 pub fn lower_ident(_lctx: &LoweringContext, ident: Ident) -> hir::Ident {
     hir::Ident {
-        name: mtwt::resolve(ident),
+        name: if ident.name != keywords::SelfValue.name() {
+            mtwt::resolve(ident)
+        } else {
+            ident.name
+        },
         unhygienic_name: ident.name,
     }
 }

--- a/src/test/run-pass/self-unhygienic.rs
+++ b/src/test/run-pass/self-unhygienic.rs
@@ -1,0 +1,31 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that `self` is unhygienic
+
+struct A {
+    pub v: i64
+}
+
+macro_rules! pretty {
+    ( $t:ty => $body:block ) => (
+        impl $t {
+            pub fn pretty(&self) -> String $body
+        }
+    )
+}
+
+pretty! (A => {
+    format!("<A:{}>", self.v)
+});
+
+fn main() {
+    assert_eq!(format!("Pretty: {}", A { v: 3 }.pretty()), "Pretty: <A:3>");
+}


### PR DESCRIPTION
Currently `self` behaves exactly like any other function parameter name, so hygiene rules apply to it.
This patch makes it unhygienic and therefore behaving less like an usual function parameter and more like a special entity (which it already is in many other aspects).
See https://github.com/rust-lang/rust/issues/15682 and https://github.com/rust-lang/rfcs/issues/1606 for the motivation.

---

Why this is not a breaking change and why making `self` unhygienic is not so bad from the name resolution / hygene point of view.

`self` in value namespace<sup>1</sup> can _only_ be defined as a function-local binding in a function parameter.
(**EDIT:** but see the discussion about closures below):

```
fn f(mut self: Self, a: u8) {}
         ^^^^
```

As a local binding it's available only in the function it's defined in. Nested items, including methods with their own `self`, can't refer to it.
So, one `self` can never shadow another `self` or create ambiguity, at any point in the code the set of scopes contains either 1 `self` or 0.
Basically, this means that `self` either resolves correctly or not resolves at all, but it can't be resolved incorrectly.
In this circumstances hygiene makes much less sense than for other local bindings.

Some part of the motivation for `self` hygiene still stays though, for example in this function

```
fn f(&mut self) {
    m!();
}
```

macro `m!()` can sneakily modify contents of `self` without user passing it explicitly, i.e. unhygienic `self` gives macros more abilities to create "side effects".
In addition, if in the future `self` is used for something else than it is used today, the argumentation above may be invalidated.
So, this needs a decision from the lang team.

<sup>1</sup>`self` in type namespace is already unhygienic and resolves to the current module.

cc @jseyfried
r? @nrc
