### PR TITLE
Fix several -Z orbit crater blockers.

### DIFF
--- a/src/librustc_trans/mir/block.rs
+++ b/src/librustc_trans/mir/block.rs
@@ -213,7 +213,8 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
 
                 let extra_args = &args[sig.inputs.len()..];
                 let extra_args = extra_args.iter().map(|op_arg| {
-                    self.mir.operand_ty(bcx.tcx(), op_arg)
+                    let op_ty = self.mir.operand_ty(bcx.tcx(), op_arg);
+                    bcx.monomorphize(&op_ty)
                 }).collect::<Vec<_>>();
                 let fn_ty = callee.direct_fn_type(bcx.ccx(), &extra_args);
 

--- a/src/librustc_trans/mir/rvalue.rs
+++ b/src/librustc_trans/mir/rvalue.rs
@@ -55,6 +55,8 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
            }
 
             mir::Rvalue::Cast(mir::CastKind::Unsize, ref source, cast_ty) => {
+                let cast_ty = bcx.monomorphize(&cast_ty);
+
                 if common::type_is_fat_ptr(bcx.tcx(), cast_ty) {
                     // into-coerce of a thin pointer to a fat pointer - just
                     // use the operand path.

--- a/src/test/run-pass/mir_coercions.rs
+++ b/src/test/run-pass/mir_coercions.rs
@@ -55,6 +55,13 @@ fn coerce_fat_ptr_wrapper(p: PtrWrapper<Fn(u32) -> u32+Send>)
     p
 }
 
+#[rustc_mir]
+fn coerce_ptr_wrapper_poly<'a, T, Trait: ?Sized>(p: PtrWrapper<'a, T>)
+                                                 -> PtrWrapper<'a, Trait>
+    where PtrWrapper<'a, T>: CoerceUnsized<PtrWrapper<'a, Trait>>
+{
+    p
+}
 
 fn main() {
     let a = [0,1,2];
@@ -72,5 +79,9 @@ fn main() {
     assert_eq!(&w.0, &a);
 
     let z = coerce_fat_ptr_wrapper(PtrWrapper(2,3,(),&square_local));
+    assert_eq!((z.3)(6), 36);
+
+    let z: PtrWrapper<Fn(u32) -> u32> =
+        coerce_ptr_wrapper_poly(PtrWrapper(2,3,(),&square_local));
     assert_eq!((z.3)(6), 36);
 }

--- a/src/test/run-pass/mir_trans_calls.rs
+++ b/src/test/run-pass/mir_trans_calls.rs
@@ -138,6 +138,15 @@ fn test_fn_nil_call<F>(f: &F) -> i32
     f()
 }
 
+#[rustc_mir]
+fn test_fn_transmute_zst(x: ()) -> [(); 1] {
+    fn id<T>(x: T) -> T {x}
+
+    id(unsafe {
+        std::mem::transmute(x)
+    })
+}
+
 fn main() {
     assert_eq!(test1(1, (2, 3), &[4, 5, 6]), (1, (2, 3), &[4, 5, 6][..]));
     assert_eq!(test2(98), 98);
@@ -159,4 +168,5 @@ fn main() {
     assert_eq!(test_fn_direct_call(&closure, 100, 4), 324);
 
     assert_eq!(test_fn_nil_call(&(|| 42)), 42);
+    assert_eq!(test_fn_transmute_zst(()), [()]);
 }

--- a/src/test/run-pass/mir_trans_calls_variadic.rs
+++ b/src/test/run-pass/mir_trans_calls_variadic.rs
@@ -16,17 +16,17 @@ extern {
 }
 
 #[rustc_mir]
-fn test(a: i64, b: i64, c: i64, d: i64, e: i64, f: i64) -> i64 {
+fn test<T, U>(a: i64, b: i64, c: i64, d: i64, e: i64, f: T, g: U) -> i64 {
     unsafe {
         rust_interesting_average(6, a, a as f64,
                                     b, b as f64,
                                     c, c as f64,
                                     d, d as f64,
                                     e, e as f64,
-                                    f, f as f64) as i64
+                                    f, g) as i64
     }
 }
 
 fn main(){
-    assert_eq!(test(10, 20, 30, 40, 50, 60), 70);
+    assert_eq!(test(10, 20, 30, 40, 50, 60_i64, 60.0_f64), 70);
 }


### PR DESCRIPTION
Fixes 3 of the issues found by @nikomatsakis' crater run with `-Z orbit` forced on:
https://gist.github.com/nikomatsakis/6688c30a0e5d3fed07cc1ebd4efb1412

Two of the regressions seemed to be fixed by #33130 and the remaining two are timeouts.
