### PR TITLE
Update aarch64-linux-android target to match android abi.

### DIFF
--- a/src/librustc_back/target/aarch64_linux_android.rs
+++ b/src/librustc_back/target/aarch64_linux_android.rs
@@ -13,6 +13,9 @@ use target::Target;
 pub fn target() -> Target {
     let mut base = super::android_base::opts();
     base.max_atomic_width = 128;
+    // As documented in http://developer.android.com/ndk/guides/cpu-features.html
+    // the neon (ASIMD) and FP must exist on all android aarch64 targets.
+    base.features = "+neon,+fp-armv8".to_string();
     Target {
         llvm_target: "aarch64-linux-android".to_string(),
         target_endian: "little".to_string(),

--- a/src/librustc_back/target/arm_linux_androideabi.rs
+++ b/src/librustc_back/target/arm_linux_androideabi.rs
@@ -22,7 +22,7 @@ pub fn target() -> Target {
         data_layout: "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
         arch: "arm".to_string(),
         target_os: "android".to_string(),
-        target_env: "gnu".to_string(),
+        target_env: "".to_string(),
         target_vendor: "unknown".to_string(),
         options: base,
     }

--- a/src/librustc_back/target/armv7_linux_androideabi.rs
+++ b/src/librustc_back/target/armv7_linux_androideabi.rs
@@ -13,6 +13,7 @@ use target::Target;
 pub fn target() -> Target {
     let mut base = super::android_base::opts();
     base.features = "+v7,+thumb2,+vfp3,+d16".to_string();
+    base.max_atomic_width = 64;
 
     Target {
         llvm_target: "armv7-none-linux-android".to_string(),

--- a/src/librustc_back/target/armv7_linux_androideabi.rs
+++ b/src/librustc_back/target/armv7_linux_androideabi.rs
@@ -21,7 +21,7 @@ pub fn target() -> Target {
         data_layout: "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
         arch: "arm".to_string(),
         target_os: "android".to_string(),
-        target_env: "gnu".to_string(),
+        target_env: "".to_string(),
         target_vendor: "unknown".to_string(),
         options: base,
     }

--- a/src/librustc_back/target/i686_linux_android.rs
+++ b/src/librustc_back/target/i686_linux_android.rs
@@ -22,7 +22,7 @@ pub fn target() -> Target {
         data_layout: "e-m:e-p:32:32-f64:32:64-f80:32-n8:16:32-S128".to_string(),
         arch: "x86".to_string(),
         target_os: "android".to_string(),
-        target_env: "gnu".to_string(),
+        target_env: "".to_string(),
         target_vendor: "unknown".to_string(),
         options: base,
     }


### PR DESCRIPTION
- Changed `target_env` to "gnu" to empty "" for all android targets because it does not matter for android.
- The PR #33048 added "max_atomic_width" for arm-android but missed recently added armv7-android. Add it there too.
- Added features `+neon,+fp-armv8` because they [must exist on `aarch64` android](http://developer.android.com/ndk/guides/cpu-features.html).
- Update libc to include https://github.com/rust-lang/libc/pull/282 so that rust's std lib works on android's aarch64 (the main issue there was incorrect structure alignment on 64-bit arm).

r? @alexcrichton 
