### PR TITLE
Remove ExplicitSelf from HIR

### DIFF
--- a/src/librustc/hir/fold.rs
+++ b/src/librustc/hir/fold.rs
@@ -158,14 +158,6 @@ pub trait Folder : Sized {
         noop_fold_local(l, self)
     }
 
-    fn fold_explicit_self(&mut self, es: ExplicitSelf) -> ExplicitSelf {
-        noop_fold_explicit_self(es, self)
-    }
-
-    fn fold_explicit_self_underscore(&mut self, es: ExplicitSelf_) -> ExplicitSelf_ {
-        noop_fold_explicit_self_underscore(es, self)
-    }
-
     fn fold_lifetime(&mut self, l: Lifetime) -> Lifetime {
         noop_fold_lifetime(l, self)
     }
@@ -493,29 +485,6 @@ pub fn noop_fold_attribute<T: Folder>(at: Attribute, fld: &mut T) -> Option<Attr
         },
         span: fld.new_span(span),
     })
-}
-
-pub fn noop_fold_explicit_self_underscore<T: Folder>(es: ExplicitSelf_,
-                                                     fld: &mut T)
-                                                     -> ExplicitSelf_ {
-    match es {
-        SelfStatic | SelfValue(_) => es,
-        SelfRegion(lifetime, m, name) => {
-            SelfRegion(fld.fold_opt_lifetime(lifetime), m, name)
-        }
-        SelfExplicit(typ, name) => {
-            SelfExplicit(fld.fold_ty(typ), name)
-        }
-    }
-}
-
-pub fn noop_fold_explicit_self<T: Folder>(Spanned { span, node }: ExplicitSelf,
-                                          fld: &mut T)
-                                          -> ExplicitSelf {
-    Spanned {
-        node: fld.fold_explicit_self_underscore(node),
-        span: fld.new_span(span),
-    }
 }
 
 pub fn noop_fold_meta_item<T: Folder>(mi: P<MetaItem>, fld: &mut T) -> P<MetaItem> {
@@ -941,7 +910,6 @@ pub fn noop_fold_method_sig<T: Folder>(sig: MethodSig, folder: &mut T) -> Method
     MethodSig {
         generics: folder.fold_generics(sig.generics),
         abi: sig.abi,
-        explicit_self: folder.fold_explicit_self(sig.explicit_self),
         unsafety: sig.unsafety,
         constness: sig.constness,
         decl: folder.fold_fn_decl(sig.decl),

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -388,32 +388,10 @@ impl<'a> LoweringContext<'a> {
         })
     }
 
-    fn lower_explicit_self_underscore(&mut self, es: &SelfKind) -> hir::ExplicitSelf_ {
-        match *es {
-            SelfKind::Static => hir::SelfStatic,
-            SelfKind::Value(v) => hir::SelfValue(v.name),
-            SelfKind::Region(ref lifetime, m, ident) => {
-                hir::SelfRegion(self.lower_opt_lifetime(lifetime),
-                                self.lower_mutability(m),
-                                ident.name)
-            }
-            SelfKind::Explicit(ref typ, ident) => {
-                hir::SelfExplicit(self.lower_ty(typ), ident.name)
-            }
-        }
-    }
-
     fn lower_mutability(&mut self, m: Mutability) -> hir::Mutability {
         match m {
             Mutability::Mutable => hir::MutMutable,
             Mutability::Immutable => hir::MutImmutable,
-        }
-    }
-
-    fn lower_explicit_self(&mut self, s: &ExplicitSelf) -> hir::ExplicitSelf {
-        Spanned {
-            node: self.lower_explicit_self_underscore(&s.node),
-            span: s.span,
         }
     }
 
@@ -800,7 +778,6 @@ impl<'a> LoweringContext<'a> {
         hir::MethodSig {
             generics: self.lower_generics(&sig.generics),
             abi: sig.abi,
-            explicit_self: self.lower_explicit_self(&sig.explicit_self),
             unsafety: self.lower_unsafety(sig.unsafety),
             constness: self.lower_constness(sig.constness),
             decl: self.lower_fn_decl(&sig.decl),

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -889,11 +889,6 @@ impl<'a, 'tcx, 'v> hir_visit::Visitor<'v> for LateContext<'a, 'tcx> {
         run_lints!(self, check_lifetime_def, late_passes, lt);
     }
 
-    fn visit_explicit_self(&mut self, es: &hir::ExplicitSelf) {
-        run_lints!(self, check_explicit_self, late_passes, es);
-        hir_visit::walk_explicit_self(self, es);
-    }
-
     fn visit_path(&mut self, p: &hir::Path, id: ast::NodeId) {
         run_lints!(self, check_path, late_passes, p, id);
         hir_visit::walk_path(self, p);

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -483,7 +483,6 @@ impl<'a> LifetimeContext<'a> {
             FnKind::Method(_, sig, _, _) => {
                 intravisit::walk_fn_decl(self, fd);
                 self.visit_generics(&sig.generics);
-                self.visit_explicit_self(&sig.explicit_self);
             }
             FnKind::Closure(_) => {
                 intravisit::walk_fn_decl(self, fd);

--- a/src/librustc_incremental/calculate_svh.rs
+++ b/src/librustc_incremental/calculate_svh.rs
@@ -172,7 +172,6 @@ mod svh_visitor {
         SawImplItem,
         SawStructField,
         SawVariant,
-        SawExplicitSelf,
         SawPath,
         SawBlock,
         SawPat,
@@ -389,10 +388,6 @@ mod svh_visitor {
 
         fn visit_struct_field(&mut self, s: &'a StructField) {
             SawStructField.hash(self.st); visit::walk_struct_field(self, s)
-        }
-
-        fn visit_explicit_self(&mut self, es: &'a ExplicitSelf) {
-            SawExplicitSelf.hash(self.st); visit::walk_explicit_self(self, es)
         }
 
         fn visit_path(&mut self, path: &'a Path, _: ast::NodeId) {

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -831,8 +831,8 @@ impl<'a, 'tcx, 'v> Visitor<'v> for ObsoleteVisiblePrivateTypesVisitor<'a, 'tcx> 
                                 }
                             }
                             hir::ImplItemKind::Method(ref sig, _) => {
-                                if sig.explicit_self.node == hir::SelfStatic &&
-                                      self.item_is_public(&impl_item.id, &impl_item.vis) {
+                                if !sig.decl.has_self() &&
+                                        self.item_is_public(&impl_item.id, &impl_item.vis) {
                                     found_pub_static = true;
                                     intravisit::walk_impl_item(self, impl_item);
                                 }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -582,7 +582,6 @@ impl<'a, 'v> Visitor<'v> for Resolver<'a> {
             }
             FnKind::Method(_, sig, _) => {
                 self.visit_generics(&sig.generics);
-                self.visit_explicit_self(&sig.explicit_self);
                 MethodRibKind
             }
             FnKind::Closure => ClosureRibKind(node_id),

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -361,7 +361,7 @@ pub fn build_impl<'a, 'tcx>(cx: &DocContext,
                 let mut item = method.clean(cx);
                 item.inner = match item.inner.clone() {
                     clean::TyMethodItem(clean::TyMethod {
-                        unsafety, decl, self_, generics, abi
+                        unsafety, decl, generics, abi
                     }) => {
                         let constness = if tcx.sess.cstore.is_const_fn(did) {
                             hir::Constness::Const
@@ -373,7 +373,6 @@ pub fn build_impl<'a, 'tcx>(cx: &DocContext,
                             unsafety: unsafety,
                             constness: constness,
                             decl: decl,
-                            self_: self_,
                             generics: generics,
                             abi: abi
                         })

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -43,7 +43,7 @@ pub struct UnsafetySpace(pub hir::Unsafety);
 #[derive(Copy, Clone)]
 pub struct ConstnessSpace(pub hir::Constness);
 /// Wrapper struct for properly emitting a method declaration.
-pub struct Method<'a>(pub &'a clean::SelfTy, pub &'a clean::FnDecl);
+pub struct Method<'a>(pub &'a clean::FnDecl);
 /// Similar to VisSpace, but used for mutability
 #[derive(Copy, Clone)]
 pub struct MutableSpace(pub clean::Mutability);
@@ -642,29 +642,31 @@ impl fmt::Display for clean::FnDecl {
 
 impl<'a> fmt::Display for Method<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let Method(selfty, d) = *self;
+        let decl = self.0;
         let mut args = String::new();
-        match *selfty {
-            clean::SelfStatic => {},
-            clean::SelfValue => args.push_str("self"),
-            clean::SelfBorrowed(Some(ref lt), mtbl) => {
-                args.push_str(&format!("&amp;{} {}self", *lt, MutableSpace(mtbl)));
-            }
-            clean::SelfBorrowed(None, mtbl) => {
-                args.push_str(&format!("&amp;{}self", MutableSpace(mtbl)));
-            }
-            clean::SelfExplicit(ref typ) => {
-                args.push_str(&format!("self: {}", *typ));
-            }
-        }
-        for (i, input) in d.inputs.values.iter().enumerate() {
+        for (i, input) in decl.inputs.values.iter().enumerate() {
             if i > 0 || !args.is_empty() { args.push_str(", "); }
-            if !input.name.is_empty() {
-                args.push_str(&format!("{}: ", input.name));
+            if let Some(selfty) = input.to_self() {
+                match selfty {
+                    clean::SelfValue => args.push_str("self"),
+                    clean::SelfBorrowed(Some(ref lt), mtbl) => {
+                        args.push_str(&format!("&amp;{} {}self", *lt, MutableSpace(mtbl)));
+                    }
+                    clean::SelfBorrowed(None, mtbl) => {
+                        args.push_str(&format!("&amp;{}self", MutableSpace(mtbl)));
+                    }
+                    clean::SelfExplicit(ref typ) => {
+                        args.push_str(&format!("self: {}", *typ));
+                    }
+                }
+            } else {
+                if !input.name.is_empty() {
+                    args.push_str(&format!("{}: ", input.name));
+                }
+                args.push_str(&format!("{}", input.type_));
             }
-            args.push_str(&format!("{}", input.type_));
         }
-        write!(f, "({args}){arrow}", args = args, arrow = d.output)
+        write!(f, "({args}){arrow}", args = args, arrow = decl.output)
     }
 }
 

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -864,9 +864,8 @@ impl<'a> MethodDef<'a> {
         let self_arg = match explicit_self.node {
             ast::SelfKind::Static => None,
             // creating fresh self id
-            _ => Some(ast::Arg::new_self(trait_.span,
-                                         ast::Mutability::Immutable,
-                                         keywords::SelfValue.ident()))
+            _ => Some(ast::Arg::from_self(explicit_self.clone(), trait_.span,
+                                          ast::Mutability::Immutable)),
         };
         let args = {
             let args = arg_types.into_iter().map(|(name, ty)| {

--- a/src/test/compile-fail/self-infer.rs
+++ b/src/test/compile-fail/self-infer.rs
@@ -1,0 +1,18 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct S;
+
+impl S {
+    fn f(self: _) {} //~ERROR the type placeholder `_` is not allowed within types on item sig
+    fn g(self: &_) {} //~ERROR the type placeholder `_` is not allowed within types on item sig
+}
+
+fn main() {}

--- a/src/test/parse-fail/issue-33413.rs
+++ b/src/test/parse-fail/issue-33413.rs
@@ -1,0 +1,16 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z parse-only
+
+impl S {
+    fn f(*, a: u8) -> u8 {} //~ ERROR expected pattern, found `*`
+    //~^ ERROR expected one of `)`, `-`, `box`, `false`, `mut`, `ref`, or `true`, found `*`
+}

--- a/src/test/parse-fail/no-unsafe-self.rs
+++ b/src/test/parse-fail/no-unsafe-self.rs
@@ -11,14 +11,16 @@
 // compile-flags: -Z parse-only -Z continue-parse-after-error
 
 trait A {
-    fn foo(*mut self); //~ ERROR cannot pass self by raw pointer
-    fn bar(*self); //~ ERROR cannot pass self by raw pointer
+    fn foo(*mut self); //~ ERROR cannot pass `self` by raw pointer
+    fn baz(*const self); //~ ERROR cannot pass `self` by raw pointer
+    fn bar(*self); //~ ERROR cannot pass `self` by raw pointer
 }
 
 struct X;
 impl A for X {
-    fn foo(*mut self) { } //~ ERROR cannot pass self by raw pointer
-    fn bar(*self) { } //~ ERROR cannot pass self by raw pointer
+    fn foo(*mut self) { } //~ ERROR cannot pass `self` by raw pointer
+    fn baz(*const self) { } //~ ERROR cannot pass `self` by raw pointer
+    fn bar(*self) { } //~ ERROR cannot pass `self` by raw pointer
 }
 
 fn main() { }


### PR DESCRIPTION
`self` argument is already kept in the argument list and can be retrieved from there if necessary, so there's no need for the duplication.
The same changes can be applied to AST, I'll make them in the next breaking batch. 
The first commit also improves parsing of method declarations and fixes https://github.com/rust-lang/rust/issues/33413.

r? @eddyb
