### PR TITLE
rustdoc: do not panic all the way when lexing a source snippet fails

### DIFF
--- a/src/test/rustdoc/issue-30032.rs
+++ b/src/test/rustdoc/issue-30032.rs
@@ -1,0 +1,18 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This used to panic due to the invalid source, so just checking for
+// existence of the output file is enough.
+
+// @has issue_30032/fn.main.html
+/// ```ignore
+/// let invalid = 'abc';
+/// ```
+pub fn main() {}


### PR DESCRIPTION
Currently, the libsyntax lexer panics on invalid source, which makes rustdoc panic when trying to highlight it.

I assume there are efforts underway to make the lexer panic-free, but until this is done this should be an acceptable workaround.

Note that the panic is still printed like normal as "thread X panicked, run with RUST_BACKTRACE=1 ...", so I added the printout below to make it seem less like a fatal error.

I didn't touch `render_inner_with_highlighting` below, as it is currently unused.  It returns a Result whose Err type would have to be changed if it was to support lexer errors.

Fixes: #30032
