### PR TITLE
rustdoc: inject `#[macro_use] extern crate` in doctests for macros

### DIFF
--- a/src/doc/book/documentation.md
+++ b/src/doc/book/documentation.md
@@ -241,17 +241,16 @@ Here's the full algorithm rustdoc uses to preprocess examples:
    `unused_variables`, `unused_assignments`, `unused_mut`,
    `unused_attributes`, and `dead_code`. Small examples often trigger
    these lints.
-3. If the example does not contain `extern crate`, then `extern crate
-   <mycrate>;` is inserted (note the lack of `#[macro_use]`).
+3. If the example does not contain `extern crate`, then `#[macro_use]
+   extern crate <mycrate>;` is inserted if the example is either for
+   a macro definition, or contains the crate name.
 4. Finally, if the example does not contain `fn main`, the remainder of the
    text is wrapped in `fn main() { your_code }`.
 
 This generated `fn main` can be a problem! If you have `extern crate` or a `mod`
 statements in the example code that are referred to by `use` statements, they will
 fail to resolve unless you include at least `fn main() {}` to inhibit step 4.
-`#[macro_use] extern crate` also does not work except at the crate root, so when
-testing macros an explicit `main` is always required. It doesn't have to clutter
-up your docs, though -- keep reading!
+These additions don't have to clutter up your docs, though -- keep reading!
 
 Sometimes this algorithm isn't enough, though. For example, all of these code samples
 with `///` we've been talking about? The raw text:
@@ -356,17 +355,11 @@ Here’s an example of documenting a macro:
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate foo;
-/// # fn main() {
 /// panic_unless!(1 + 1 == 2, “Math is broken.”);
-/// # }
 /// ```
 ///
 /// ```should_panic
-/// # #[macro_use] extern crate foo;
-/// # fn main() {
 /// panic_unless!(true == false, “I’m broken.”);
-/// # }
 /// ```
 #[macro_export]
 macro_rules! panic_unless {
@@ -374,11 +367,6 @@ macro_rules! panic_unless {
 }
 # fn main() {}
 ```
-
-You’ll note three things: we need to add our own `extern crate` line, so that
-we can add the `#[macro_use]` attribute. Second, we’ll need to add our own
-`main()` as well (for reasons discussed above). Finally, a judicious use of
-`#` to comment out those two things, so they don’t show up in the output.
 
 Another case where the use of `#` is handy is when you want to ignore
 error handling. Lets say you want the following,

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -258,7 +258,7 @@ pub fn render(w: &mut fmt::Formatter, s: &str, print_toc: bool) -> fmt::Result {
                         stripped_filtered_line(l).unwrap_or(l)
                     }).collect::<Vec<&str>>().join("\n");
                     let krate = krate.as_ref().map(|s| &**s);
-                    let test = test::maketest(&test, krate, false,
+                    let test = test::maketest(&test, krate, false, false,
                                               &Default::default());
                     s.push_str(&format!("<span class='rusttest'>{}</span>", Escape(&test)));
                 });

--- a/src/test/run-make/rustdoc-doctests/Makefile
+++ b/src/test/run-make/rustdoc-doctests/Makefile
@@ -3,5 +3,4 @@
 all: foo.rs
 	$(RUSTC) --cfg 'feature="bar"' --crate-type lib foo.rs
 	$(HOST_RPATH_ENV) '$(RUSTDOC)' --test --cfg 'feature="bar"' \
-		-L $(TMPDIR) foo.rs |\
-		grep -q 'test foo_0 ... ok'
+		-L $(TMPDIR) foo.rs

--- a/src/test/run-make/rustdoc-doctests/foo.rs
+++ b/src/test/run-make/rustdoc-doctests/foo.rs
@@ -13,3 +13,18 @@
 /// ```
 #[cfg(feature = "bar")]
 pub fn foo() -> i32 { 1 }
+
+/// ```
+/// assert_eq!(mymacro!(), 5);
+/// ```
+#[macro_export]
+macro_rules! mymacro {
+    () => { 5 };
+}
+
+/// ```
+/// assert_eq!(foo::foo2(), 5);
+/// ```
+pub fn foo2() -> i32 {
+    5
+}


### PR DESCRIPTION
Fixes: #29286

Note: I tried to add a test to `src/test/rustdoc`, but the way in which these tests are called doesn't seem to allow `extern crate testname;` to work at all...
