### PR TITLE
rustdoc: remove artificial indentation of doctest code

### DIFF
--- a/src/doc/book/strings.md
+++ b/src/doc/book/strings.md
@@ -32,7 +32,7 @@ include the newline and the leading spaces:
 let s = "foo
     bar";
 
-assert_eq!("foo\n        bar", s);
+assert_eq!("foo\n    bar", s);
 ```
 
 The second, with a `\`, trims the spaces and the newline:

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -340,7 +340,7 @@ pub fn maketest(s: &str, cratename: Option<&str>, dont_insert_main: bool,
         prog.push_str(&everything_else);
     } else {
         prog.push_str("fn main() {\n    ");
-        prog.push_str(&everything_else.replace("\n", "\n    "));
+        prog.push_str(&everything_else);
         prog = prog.trim().into();
         prog.push_str("\n}");
     }

--- a/src/test/rustdoc/issue-25944.rs
+++ b/src/test/rustdoc/issue-25944.rs
@@ -1,0 +1,21 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:--test
+
+/// ```
+/// let a = r#"
+/// foo
+/// bar"#;
+/// let b = "\nfoo\nbar";
+/// assert_eq!(a, b);
+/// ```
+pub fn main() {
+}


### PR DESCRIPTION
The indentation makes the examples look nicer when printed (when is this done?), but breaks tests using multi-line string literals.

Fixes: #25944
