### PR TITLE
rustdoc: do not strip blanket impls in crate of origin

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1540,6 +1540,13 @@ impl Type {
             _ => None,
         }
     }
+
+    pub fn is_generic(&self) -> bool {
+        match *self {
+            ResolvedPath { is_generic, .. } => is_generic,
+            _ => false,
+        }
+    }
 }
 
 impl GetDefId for Type {

--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -115,9 +115,9 @@ impl<'a> fold::DocFolder for Stripper<'a> {
 
             // trait impls for private items should be stripped
             clean::ImplItem(clean::Impl{
-                for_: clean::ResolvedPath{ did, .. }, ..
+                for_: clean::ResolvedPath{ did, is_generic, .. }, ..
             }) => {
-                if did.is_local() && !self.access_levels.is_exported(did) {
+                if did.is_local() && !is_generic && !self.access_levels.is_exported(did) {
                     return None;
                 }
             }
@@ -183,7 +183,9 @@ impl<'a> fold::DocFolder for ImplStripper<'a> {
     fn fold_item(&mut self, i: Item) -> Option<Item> {
         if let clean::ImplItem(ref imp) = i.inner {
             if let Some(did) = imp.for_.def_id() {
-                if did.is_local() && !self.retained.contains(&did) {
+                if did.is_local() && !imp.for_.is_generic() &&
+                    !self.retained.contains(&did)
+                {
                     return None;
                 }
             }

--- a/src/test/rustdoc/issue-29503.rs
+++ b/src/test/rustdoc/issue-29503.rs
@@ -1,0 +1,26 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::fmt;
+
+// @has issue_29503/trait.MyTrait.html
+pub trait MyTrait {
+    fn my_string(&self) -> String;
+}
+
+// @has - "//ul[@id='implementors-list']/li" "impl<T> MyTrait for T where T: Debug"
+impl<T> MyTrait for T where T: fmt::Debug {
+    fn my_string(&self) -> String {
+        format!("{:?}", self)
+    }
+}
+
+pub fn main() {
+}


### PR DESCRIPTION
In `impl<T> Trait for T`, the blanket type parameters `T` were recognized as "local" and "not exported", so these impls were thrown out.

Now we check if they are generic, and keep them in that case.

Fixes: #29503
