### PR TITLE
Add some warnings to std::env::current_exe

### DIFF
--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -493,6 +493,21 @@ pub fn temp_dir() -> PathBuf {
 /// that can fail for a good number of reasons. Some errors can include, but not
 /// be limited to, filesystem operations failing or general syscall failures.
 ///
+/// # Security
+///
+/// This function should be used with care, as its incorrect usage can cause
+/// security problems. Specifically, as with many operations invovling files and
+/// paths, you can introduce a race condition. It goes like this:
+///
+/// 1. You get the path to the current executable using `current_exe()`, and
+///    store it in a variable binding.
+/// 2. Time passes. A malicious actor removes the current executable, and
+///    replaces it with a malicious one.
+/// 3. You then use the binding to try to open that file.
+///
+/// You expected to be opening the current executable, but you're now opening
+/// something completely different.
+///
 /// # Examples
 ///
 /// ```

--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -495,18 +495,41 @@ pub fn temp_dir() -> PathBuf {
 ///
 /// # Security
 ///
-/// This function should be used with care, as its incorrect usage can cause
-/// security problems. Specifically, as with many operations invovling files and
-/// paths, you can introduce a race condition. It goes like this:
+/// The output of this function should not be used in anything that might have
+/// security implications. For example:
 ///
-/// 1. You get the path to the current executable using `current_exe()`, and
-///    store it in a variable binding.
-/// 2. Time passes. A malicious actor removes the current executable, and
-///    replaces it with a malicious one.
-/// 3. You then use the binding to try to open that file.
+/// ```
+/// fn main() {
+///     println!("{:?}", std::env::current_exe());
+/// }
+/// ```
 ///
-/// You expected to be opening the current executable, but you're now opening
-/// something completely different.
+/// On Linux systems, if this is compiled as `foo`:
+///
+/// ```bash
+/// $ rustc foo.rs
+/// $ ./foo
+/// Ok("/home/alex/foo")
+/// ```
+///
+/// And you make a symbolic link of the program:
+///
+/// ```bash
+/// $ ln foo bar
+/// ```
+///
+/// When you run it, you won't get the original executable, you'll get the
+/// symlink:
+///
+/// ```bash
+/// $ ./bar
+/// Ok("/home/alex/bar")
+/// ```
+///
+/// This sort of behavior has been known to [lead to privledge escalation] when
+/// used incorrectly, for example.
+///
+/// [lead to privledge escalation]: http://securityvulns.com/Wdocument183.html
 ///
 /// # Examples
 ///


### PR DESCRIPTION
/cc #21889 @rust-lang/libs @semarie 

I started writing this up. I'm not sure if we want to go into other things and in what depth; we don't currently have a lot of security-specific documentation to model after.

Thoughts?
