### PR TITLE
trivial tweaks to documentation (book)

### DIFF
--- a/src/doc/book/crates-and-modules.md
+++ b/src/doc/book/crates-and-modules.md
@@ -115,7 +115,7 @@ $ ls target/debug
 build  deps  examples  libphrases-a7448e02a0468eaa.rlib  native
 ```
 
-`libphrases-hash.rlib` is the compiled crate. Before we see how to use this
+`libphrases-<hash>.rlib` is the compiled crate. Before we see how to use this
 crate from another crate, let’s break it up into multiple files.
 
 # Multiple File Crates

--- a/src/doc/book/error-handling.md
+++ b/src/doc/book/error-handling.md
@@ -225,7 +225,7 @@ sense to put it into a function:
 ```rust
 # fn find(_: &str, _: char) -> Option<usize> { None }
 // Returns the extension of the given file name, where the extension is defined
-// as all characters proceeding the first `.`.
+// as all characters following the first `.`.
 // If `file_name` has no `.`, then `None` is returned.
 fn extension_explicit(file_name: &str) -> Option<&str> {
     match find(file_name, '.') {
@@ -274,7 +274,7 @@ to get rid of the case analysis:
 ```rust
 # fn find(_: &str, _: char) -> Option<usize> { None }
 // Returns the extension of the given file name, where the extension is defined
-// as all characters proceeding the first `.`.
+// as all characters following the first `.`.
 // If `file_name` has no `.`, then `None` is returned.
 fn extension(file_name: &str) -> Option<&str> {
     find(file_name, '.').map(|i| &file_name[i+1..])

--- a/src/doc/book/testing.md
+++ b/src/doc/book/testing.md
@@ -84,8 +84,8 @@ fn it_works() {
 ```
 
 `assert!` is a macro provided by Rust which takes one argument: if the argument
-is `true`, nothing happens. If the argument is `false`, it `panic!`s. Let's run
-our tests again:
+is `true`, nothing happens. If the argument is `false`, it will `panic!`. Let's
+run our tests again:
 
 ```bash
 $ cargo test


### PR DESCRIPTION
These are small things I found while reading through The Book. The `<hash>` and `panic!` lines are simply to improve readability, while I believe the proceeding/following distinction is a bug (but might be a English dialect distinction?).

I've read `rust/CONTRIBUTING`, i'm not sure if there is anything I need to do other than submit this PR.

r? @steveklabnik 
