### PR TITLE
Use symlink_metadata in tidy to avoid panicking on broken symlinks.

### DIFF
--- a/src/tools/tidy/src/bins.rs
+++ b/src/tools/tidy/src/bins.rs
@@ -35,7 +35,7 @@ pub fn check(path: &Path, bad: &mut bool) {
             return
         }
 
-        let metadata = t!(fs::metadata(&file), &file);
+        let metadata = t!(fs::symlink_metadata(&file), &file);
         if metadata.mode() & 0o111 != 0 {
             println!("binary checked into source: {}", file.display());
             *bad = true;


### PR DESCRIPTION
r? @alexcrichton
