### PR TITLE
mk: Fix dependencies of unwind crate on musl

### DIFF
--- a/mk/cfg/i686-unknown-linux-musl.mk
+++ b/mk/cfg/i686-unknown-linux-musl.mk
@@ -25,4 +25,5 @@ CFG_THIRD_PARTY_OBJECTS_i686-unknown-linux-musl := crt1.o crti.o crtn.o
 CFG_INSTALLED_OBJECTS_i686-unknown-linux-musl := crt1.o crti.o crtn.o
 
 NATIVE_DEPS_libc_T_i686-unknown-linux-musl += libc.a
-NATIVE_DEPS_std_T_i686-unknown-linux-musl += libunwind.a crt1.o crti.o crtn.o
+NATIVE_DEPS_std_T_i686-unknown-linux-musl += crt1.o crti.o crtn.o
+NATIVE_DEPS_unwind_T_i686-unknown-linux-musl += libunwind.a

--- a/mk/cfg/x86_64-unknown-linux-musl.mk
+++ b/mk/cfg/x86_64-unknown-linux-musl.mk
@@ -25,4 +25,5 @@ CFG_THIRD_PARTY_OBJECTS_x86_64-unknown-linux-musl := crt1.o crti.o crtn.o
 CFG_INSTALLED_OBJECTS_x86_64-unknown-linux-musl := crt1.o crti.o crtn.o
 
 NATIVE_DEPS_libc_T_x86_64-unknown-linux-musl += libc.a
-NATIVE_DEPS_std_T_x86_64-unknown-linux-musl += libunwind.a crt1.o crti.o crtn.o
+NATIVE_DEPS_std_T_x86_64-unknown-linux-musl += crt1.o crti.o crtn.o
+NATIVE_DEPS_unwind_T_x86_64-unknown-linux-musl += libunwind.a


### PR DESCRIPTION
The libunwind.a library was accidentally only being included for the standard
library, not the new unwind crate which implements an unwinder.
