### PR TITLE
Export OnceState from libstd

### DIFF
--- a/src/libstd/sync/mod.rs
+++ b/src/libstd/sync/mod.rs
@@ -31,7 +31,7 @@ pub use self::mutex::MUTEX_INIT;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::mutex::{Mutex, MutexGuard, StaticMutex};
 #[stable(feature = "rust1", since = "1.0.0")]
-pub use self::once::{Once, ONCE_INIT};
+pub use self::once::{Once, OnceState, ONCE_INIT};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use sys_common::poison::{PoisonError, TryLockError, TryLockResult, LockResult};
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
This type is used in the signature of `call_once_force` but isn't exported from libstd.

r? @alexcrichton 
