### PR TITLE
Add note to type mismatch errors related to specialization.

### DIFF
--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -244,6 +244,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                                                predicate,
                                                error.err);
                 self.note_obligation_cause(&mut err, obligation);
+                self.tcx.note_and_explain_type_err(&mut err, &error.err, obligation.cause.span);
                 err.emit();
             }
         }

--- a/src/librustc/traits/project.rs
+++ b/src/librustc/traits/project.rs
@@ -87,8 +87,9 @@ pub enum ProjectionMode {
     /// }
     ///
     /// fn main() {
-    ///     let <() as Assoc>::Output = true;
+    ///     let x: <() as Assoc>::Output = true;
     /// }
+    /// ```
     AnyFinal,
 
     /// At trans time, all projections will succeed.
@@ -697,7 +698,7 @@ fn project_type<'cx, 'gcx, 'tcx>(
                         return None;
                     }
                 } else {
-                    // Normally this situation could only arise througha
+                    // Normally this situation could only arise through a
                     // compiler bug, but at coherence-checking time we only look
                     // at the topmost impl (we don't even consider the trait
                     // itself) for the definition -- so we can fail to find a
@@ -721,8 +722,6 @@ fn project_type<'cx, 'gcx, 'tcx>(
                     // trait Foo {}
                     // impl Foo for <u8 as Assoc>::Output {}
                     // impl Foo for <u16 as Assoc>::Output {}
-                    //     return None;
-                    // }
                     // ```
                     //
                     // The essential problem here is that the projection fails,

--- a/src/librustc/traits/specialize/mod.rs
+++ b/src/librustc/traits/specialize/mod.rs
@@ -93,7 +93,7 @@ pub fn translate_substs<'a, 'gcx, 'tcx>(infcx: &InferCtxt<'a, 'gcx, 'tcx>,
 
             fulfill_implication(infcx, source_trait_ref, target_impl).unwrap_or_else(|_| {
                 bug!("When translating substitutions for specialization, the expected \
-                      specializaiton failed to hold")
+                      specialization failed to hold")
             })
         }
         specialization_graph::Node::Trait(..) => source_trait_ref.substs,

--- a/src/librustc/ty/relate.rs
+++ b/src/librustc/ty/relate.rs
@@ -582,6 +582,11 @@ pub fn super_relate_tys<'a, 'gcx, 'tcx, R>(relation: &mut R,
             Ok(tcx.mk_projection(projection_ty.trait_ref, projection_ty.item_name))
         }
 
+        (&ty::TyProjection(_), _) | (_, &ty::TyProjection(_)) =>
+        {
+            Err(TypeError::UnnormalizedProjectionMismatch(expected_found(relation, &a, &b)))
+        }
+
         _ =>
         {
             Err(TypeError::Sorts(expected_found(relation, &a, &b)))

--- a/src/librustc/ty/structural_impls.rs
+++ b/src/librustc/ty/structural_impls.rs
@@ -317,6 +317,9 @@ impl<'a, 'tcx> Lift<'tcx> for ty::error::TypeError<'a> {
             TyParamDefaultMismatch(ref x) => {
                 return tcx.lift(x).map(TyParamDefaultMismatch)
             }
+            UnnormalizedProjectionMismatch(ref x) =>  {
+                return tcx.lift(x).map(UnnormalizedProjectionMismatch)
+            }
         })
     }
 }


### PR DESCRIPTION
Specifically, default associated types cannot be projected as specific types.

This is the same as #33492, but rebased onto the latest master and in a different local branch.

Fixes #33481
