### PR TITLE
rustdoc: Fix missing type parameters on impls

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1534,13 +1534,6 @@ impl Type {
         }
     }
 
-    pub fn trait_name(&self) -> Option<String> {
-        match *self {
-            ResolvedPath { ref path, .. } => Some(path.last_name()),
-            _ => None,
-        }
-    }
-
     pub fn is_generic(&self) -> bool {
         match *self {
             ResolvedPath { is_generic, .. } => is_generic,

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -587,7 +587,13 @@ fn fmt_impl(i: &clean::Impl, f: &mut fmt::Formatter, link_trait: bool) -> fmt::R
         if link_trait {
             write!(f, "{}", *ty)?;
         } else {
-            write!(f, "{}", ty.trait_name().unwrap())?;
+            match *ty {
+                clean::ResolvedPath{ typarams: None, ref path, is_generic: false, .. } => {
+                    let last = path.segments.last().unwrap();
+                    write!(f, "{}{}", last.name, last.params)?;
+                }
+                _ => unreachable!(),
+            }
         }
         write!(f, " for ")?;
     }

--- a/src/test/rustdoc/issue-33592.rs
+++ b/src/test/rustdoc/issue-33592.rs
@@ -1,0 +1,23 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "foo"]
+
+pub trait Foo<T> {}
+
+pub struct Bar;
+
+pub struct Baz;
+
+// @has foo/trait.Foo.html '//code' 'impl Foo<i32> for Bar'
+impl Foo<i32> for Bar {}
+
+// @has foo/trait.Foo.html '//code' 'impl<T> Foo<T> for Baz'
+impl<T> Foo<T> for Baz {}


### PR DESCRIPTION
They were broken by #32558.

Fixes: #33592
