### PR TITLE
Some simple improvements to MIR pretty printing

### DIFF
--- a/src/librustc_mir/pretty.rs
+++ b/src/librustc_mir/pretty.rs
@@ -22,7 +22,7 @@ use syntax::codemap::Span;
 
 const INDENT: &'static str = "    ";
 /// Alignment for lining up comments following MIR statements
-const ALIGN: usize = 50;
+const ALIGN: usize = 40;
 
 /// If the session is properly configured, dumps a human-readable
 /// representation of the mir into:


### PR DESCRIPTION
In short, this PR changes the MIR printer so that it:
- places an empty line between the MIR for each item
- does _not_ write an empty line before the first BB when there are no
  var decls
- aligns the "// Scope" comments 50 chars in (makes the output more
  readable)
- prints the scope comments as "// scope N at ..." instead of "//
  Scope(N) at ..."
- prints a prettier scope tree:
  - no more unbalanced delimiters!
  - no more "Parent" entry (these convey no useful information)
  - drop the "Scope()" and just print scope IDs
  - no braces when the scope is empty

In action: https://gist.github.com/jonas-schievink/1c11226cbb112892a9470ce0f9870b65
