### PR TITLE
rustbuild: Touch up some test suites

### DIFF
--- a/src/bootstrap/build/check.rs
+++ b/src/bootstrap/build/check.rs
@@ -105,9 +105,18 @@ pub fn compiletest(build: &Build,
     cmd.arg("--host").arg(compiler.host);
     cmd.arg("--llvm-filecheck").arg(build.llvm_filecheck(&build.config.build));
 
+    let mut flags = format!("-Crpath");
+    if build.config.rust_optimize_tests {
+        flags.push_str(" -O");
+    }
+    if build.config.rust_debuginfo_tests {
+        flags.push_str(" -g");
+    }
+
+    cmd.arg("--host-rustcflags").arg(&flags);
+
     let linkflag = format!("-Lnative={}", build.test_helpers_out(target).display());
-    cmd.arg("--host-rustcflags").arg("-Crpath");
-    cmd.arg("--target-rustcflags").arg(format!("-Crpath {}", linkflag));
+    cmd.arg("--target-rustcflags").arg(format!("{} {}", flags, linkflag));
 
     // FIXME: needs android support
     cmd.arg("--android-cross-path").arg("");

--- a/src/bootstrap/build/config.rs
+++ b/src/bootstrap/build/config.rs
@@ -59,6 +59,8 @@ pub struct Config {
     pub rust_rpath: bool,
     pub rustc_default_linker: Option<String>,
     pub rustc_default_ar: Option<String>,
+    pub rust_optimize_tests: bool,
+    pub rust_debuginfo_tests: bool,
 
     pub build: String,
     pub host: Vec<String>,
@@ -136,6 +138,8 @@ struct Rust {
     channel: Option<String>,
     musl_root: Option<String>,
     rpath: Option<bool>,
+    optimize_tests: Option<bool>,
+    debuginfo_tests: Option<bool>,
 }
 
 /// TOML representation of how each build target is configured.
@@ -154,6 +158,7 @@ impl Config {
         config.llvm_optimize = true;
         config.use_jemalloc = true;
         config.rust_optimize = true;
+        config.rust_optimize_tests = true;
         config.submodules = true;
         config.docs = true;
         config.rust_rpath = true;
@@ -219,6 +224,8 @@ impl Config {
             set(&mut config.rust_debug_assertions, rust.debug_assertions);
             set(&mut config.rust_debuginfo, rust.debuginfo);
             set(&mut config.rust_optimize, rust.optimize);
+            set(&mut config.rust_optimize_tests, rust.optimize_tests);
+            set(&mut config.rust_debuginfo_tests, rust.debuginfo_tests);
             set(&mut config.rust_rpath, rust.rpath);
             set(&mut config.debug_jemalloc, rust.debug_jemalloc);
             set(&mut config.use_jemalloc, rust.use_jemalloc);
@@ -306,6 +313,8 @@ impl Config {
                 ("JEMALLOC", self.use_jemalloc),
                 ("DEBUG_JEMALLOC", self.debug_jemalloc),
                 ("RPATH", self.rust_rpath),
+                ("OPTIMIZE_TESTS", self.rust_optimize_tests),
+                ("DEBUGINFO_TESTS", self.rust_debuginfo_tests),
             }
 
             match key {

--- a/src/bootstrap/build/mod.rs
+++ b/src/bootstrap/build/mod.rs
@@ -318,9 +318,17 @@ impl Build {
                     check::compiletest(self, &compiler, target.target,
                                        "run-pass", "run-pass");
                 }
+                CheckRPassFull { compiler } => {
+                    check::compiletest(self, &compiler, target.target,
+                                       "run-pass", "run-pass-fulldeps");
+                }
                 CheckCFail { compiler } => {
                     check::compiletest(self, &compiler, target.target,
                                        "compile-fail", "compile-fail");
+                }
+                CheckCFailFull { compiler } => {
+                    check::compiletest(self, &compiler, target.target,
+                                       "compile-fail", "compile-fail-fulldeps")
                 }
                 CheckPFail { compiler } => {
                     check::compiletest(self, &compiler, target.target,
@@ -330,9 +338,33 @@ impl Build {
                     check::compiletest(self, &compiler, target.target,
                                        "run-fail", "run-fail");
                 }
+                CheckRFailFull { compiler } => {
+                    check::compiletest(self, &compiler, target.target,
+                                       "run-fail", "run-fail-fulldeps");
+                }
                 CheckPretty { compiler } => {
                     check::compiletest(self, &compiler, target.target,
                                        "pretty", "pretty");
+                }
+                CheckPrettyRPass { compiler } => {
+                    check::compiletest(self, &compiler, target.target,
+                                       "pretty", "run-pass");
+                }
+                CheckPrettyRPassFull { compiler } => {
+                    check::compiletest(self, &compiler, target.target,
+                                       "pretty", "run-pass-fulldeps");
+                }
+                CheckPrettyRFail { compiler } => {
+                    check::compiletest(self, &compiler, target.target,
+                                       "pretty", "run-fail");
+                }
+                CheckPrettyRFailFull { compiler } => {
+                    check::compiletest(self, &compiler, target.target,
+                                       "pretty", "run-fail-fulldeps");
+                }
+                CheckPrettyRPassValgrind { compiler } => {
+                    check::compiletest(self, &compiler, target.target,
+                                       "pretty", "run-pass-valgrind");
                 }
                 CheckCodegen { compiler } => {
                     check::compiletest(self, &compiler, target.target,
@@ -369,14 +401,6 @@ impl Build {
                 CheckRPassValgrind { compiler } => {
                     check::compiletest(self, &compiler, target.target,
                                        "run-pass-valgrind", "run-pass-valgrind");
-                }
-                CheckRPassFull { compiler } => {
-                    check::compiletest(self, &compiler, target.target,
-                                       "run-pass", "run-pass-fulldeps");
-                }
-                CheckCFailFull { compiler } => {
-                    check::compiletest(self, &compiler, target.target,
-                                       "compile-fail", "compile-fail-fulldeps")
                 }
                 CheckDocs { compiler } => {
                     check::docs(self, &compiler);

--- a/src/bootstrap/build/step.rs
+++ b/src/bootstrap/build/step.rs
@@ -106,19 +106,25 @@ macro_rules! targets {
             (check_cargotest, CheckCargoTest { stage: u32 }),
             (check_tidy, CheckTidy { stage: u32 }),
             (check_rpass, CheckRPass { compiler: Compiler<'a> }),
+            (check_rpass_full, CheckRPassFull { compiler: Compiler<'a> }),
+            (check_rpass_valgrind, CheckRPassValgrind { compiler: Compiler<'a> }),
             (check_rfail, CheckRFail { compiler: Compiler<'a> }),
+            (check_rfail_full, CheckRFailFull { compiler: Compiler<'a> }),
             (check_cfail, CheckCFail { compiler: Compiler<'a> }),
+            (check_cfail_full, CheckCFailFull { compiler: Compiler<'a> }),
             (check_pfail, CheckPFail { compiler: Compiler<'a> }),
+            (check_pretty, CheckPretty { compiler: Compiler<'a> }),
+            (check_pretty_rpass, CheckPrettyRPass { compiler: Compiler<'a> }),
+            (check_pretty_rpass_full, CheckPrettyRPassFull { compiler: Compiler<'a> }),
+            (check_pretty_rfail, CheckPrettyRFail { compiler: Compiler<'a> }),
+            (check_pretty_rfail_full, CheckPrettyRFailFull { compiler: Compiler<'a> }),
+            (check_pretty_rpass_valgrind, CheckPrettyRPassValgrind { compiler: Compiler<'a> }),
             (check_codegen, CheckCodegen { compiler: Compiler<'a> }),
             (check_codegen_units, CheckCodegenUnits { compiler: Compiler<'a> }),
             (check_incremental, CheckIncremental { compiler: Compiler<'a> }),
             (check_ui, CheckUi { compiler: Compiler<'a> }),
             (check_debuginfo, CheckDebuginfo { compiler: Compiler<'a> }),
             (check_rustdoc, CheckRustdoc { compiler: Compiler<'a> }),
-            (check_pretty, CheckPretty { compiler: Compiler<'a> }),
-            (check_rpass_valgrind, CheckRPassValgrind { compiler: Compiler<'a> }),
-            (check_rpass_full, CheckRPassFull { compiler: Compiler<'a> }),
-            (check_cfail_full, CheckCFailFull { compiler: Compiler<'a> }),
             (check_docs, CheckDocs { compiler: Compiler<'a> }),
             (check_error_index, CheckErrorIndex { compiler: Compiler<'a> }),
             (check_rmake, CheckRMake { compiler: Compiler<'a> }),
@@ -378,8 +384,11 @@ impl<'a> Step<'a> {
             Source::Check { stage, compiler } => {
                 vec![
                     self.check_rpass(compiler),
-                    self.check_cfail(compiler),
+                    self.check_rpass_full(compiler),
                     self.check_rfail(compiler),
+                    self.check_rfail_full(compiler),
+                    self.check_cfail(compiler),
+                    self.check_cfail_full(compiler),
                     self.check_pfail(compiler),
                     self.check_incremental(compiler),
                     self.check_ui(compiler),
@@ -391,9 +400,12 @@ impl<'a> Step<'a> {
                     self.check_debuginfo(compiler),
                     self.check_rustdoc(compiler),
                     self.check_pretty(compiler),
+                    self.check_pretty_rpass(compiler),
+                    self.check_pretty_rpass_full(compiler),
+                    self.check_pretty_rfail(compiler),
+                    self.check_pretty_rfail_full(compiler),
+                    self.check_pretty_rpass_valgrind(compiler),
                     self.check_rpass_valgrind(compiler),
-                    self.check_rpass_full(compiler),
-                    self.check_cfail_full(compiler),
                     self.check_error_index(compiler),
                     self.check_docs(compiler),
                     self.check_rmake(compiler),
@@ -412,6 +424,8 @@ impl<'a> Step<'a> {
             Source::CheckTidy { stage } => {
                 vec![self.tool_tidy(stage)]
             }
+            Source::CheckPrettyRPass { compiler } |
+            Source::CheckPrettyRFail { compiler } |
             Source::CheckRFail { compiler } |
             Source::CheckPFail { compiler } |
             Source::CheckCodegen { compiler } |
@@ -438,7 +452,11 @@ impl<'a> Step<'a> {
                 ]
             }
             Source::CheckRPassFull { compiler } |
+            Source::CheckRFailFull { compiler } |
             Source::CheckCFailFull { compiler } |
+            Source::CheckPrettyRPassFull { compiler } |
+            Source::CheckPrettyRFailFull { compiler } |
+            Source::CheckPrettyRPassValgrind { compiler } |
             Source::CheckRMake { compiler } => {
                 vec![self.librustc(compiler),
                      self.tool_compiletest(compiler.stage)]

--- a/src/bootstrap/config.toml.example
+++ b/src/bootstrap/config.toml.example
@@ -122,6 +122,11 @@
 # desired in distributions, for example.
 #rpath = true
 
+# Flag indicating whether tests are compiled with optimizations (the -O flag) or
+# with debuginfo (the -g flag)
+#optimize-tests = true
+#debuginfo-tests = true
+
 # =============================================================================
 # Options for specific targets
 #

--- a/src/librustc_bitflags/Cargo.toml
+++ b/src/librustc_bitflags/Cargo.toml
@@ -6,5 +6,4 @@ version = "0.0.0"
 [lib]
 name = "rustc_bitflags"
 path = "lib.rs"
-test = false
 doctest = false

--- a/src/test/run-make/extern-multiple-copies2/Makefile
+++ b/src/test/run-make/extern-multiple-copies2/Makefile
@@ -1,0 +1,10 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) foo1.rs
+	$(RUSTC) foo2.rs
+	mkdir $(TMPDIR)/foo
+	cp $(TMPDIR)/libfoo1.rlib $(TMPDIR)/foo/libfoo1.rlib
+	$(RUSTC) bar.rs \
+		--extern foo1=$(TMPDIR)/foo/libfoo1.rlib \
+		--extern foo2=$(TMPDIR)/libfoo2.rlib

--- a/src/test/run-make/extern-multiple-copies2/bar.rs
+++ b/src/test/run-make/extern-multiple-copies2/bar.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate foo2; // foo2 first to exhibit the bug
+#[macro_use]
+extern crate foo1;
+
+fn main() {
+    foo2::foo2(foo1::A);
+}

--- a/src/test/run-make/extern-multiple-copies2/foo1.rs
+++ b/src/test/run-make/extern-multiple-copies2/foo1.rs
@@ -1,0 +1,17 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rlib"]
+
+pub struct A;
+
+pub fn foo1(a: A) {
+    drop(a);
+}

--- a/src/test/run-make/extern-multiple-copies2/foo2.rs
+++ b/src/test/run-make/extern-multiple-copies2/foo2.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rlib"]
+
+#[macro_use]
+extern crate foo1;
+
+pub fn foo2(a: foo1::A) {
+    foo1::foo1(a);
+}


### PR DESCRIPTION
This adds in some missing test suites, primarily a few pretty suites. It also starts optimizing tests by default as the current test suite does, but also recognizes `--disable-optimize-tests`.

Currently the optimization of tests isn't recognized by crate tests because Cargo doesn't support the ability to compile an unoptimized test suite against an optimized library. Perhaps a feature to add, though!
