### PR TITLE
[WIP][MIR] Generic lattice-based DF framework

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -24,6 +24,7 @@
 #![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(associated_consts)]
+#![feature(inclusive_range_syntax)]
 #![feature(box_patterns)]
 #![feature(box_syntax)]
 #![feature(collections)]
@@ -108,6 +109,8 @@ pub mod mir {
     pub mod visit;
     pub mod transform;
     pub mod mir_map;
+    pub mod cfg;
+    pub mod traversal;
 }
 
 pub mod session;

--- a/src/librustc/mir/cfg.rs
+++ b/src/librustc/mir/cfg.rs
@@ -1,0 +1,146 @@
+use mir::repr::*;
+
+use std::ops::{Index, IndexMut};
+use syntax::codemap::Span;
+
+#[derive(Clone, RustcEncodable, RustcDecodable)]
+pub struct CFG<'tcx> {
+    pub basic_blocks: Vec<BasicBlockData<'tcx>>,
+}
+
+pub struct PredecessorIter(::std::vec::IntoIter<BasicBlock>);
+impl Iterator for PredecessorIter {
+    type Item = BasicBlock;
+    fn next(&mut self) -> Option<BasicBlock> {
+        self.0.next()
+    }
+}
+
+pub struct SuccessorIter(::std::vec::IntoIter<BasicBlock>);
+impl<'a> Iterator for SuccessorIter {
+    type Item = BasicBlock;
+    fn next(&mut self) -> Option<BasicBlock> {
+        self.0.next()
+    }
+}
+
+pub struct SuccessorIterMut<'a>(::std::vec::IntoIter<&'a mut BasicBlock>);
+impl<'a> Iterator for SuccessorIterMut<'a> {
+    type Item = &'a mut BasicBlock;
+    fn next(&mut self) -> Option<&'a mut BasicBlock> {
+        self.0.next()
+    }
+}
+
+impl<'tcx> CFG<'tcx> {
+    pub fn len(&self) -> usize {
+        self.basic_blocks.len()
+    }
+
+    pub fn predecessors(&self, b: BasicBlock) -> PredecessorIter {
+        let mut preds = vec![];
+        for idx in 0..self.len() {
+            let bb = BasicBlock::new(idx);
+            if let Some(_) = self.successors(bb).find(|&x| x == b) {
+                preds.push(bb)
+            }
+        }
+        PredecessorIter(preds.into_iter())
+    }
+
+    pub fn successors(&self, b: BasicBlock) -> SuccessorIter {
+        let v: Vec<BasicBlock> = self[b].terminator().kind.successors().into_owned();
+        SuccessorIter(v.into_iter())
+    }
+
+    pub fn successors_mut(&mut self, b: BasicBlock) -> SuccessorIterMut {
+        SuccessorIterMut(self[b].terminator_mut().kind.successors_mut().into_iter())
+    }
+
+
+    pub fn swap(&mut self, b1: BasicBlock, b2: BasicBlock) {
+        // TODO: find all the branches to b2 from subgraph starting at b2 and replace them with b1.
+        self.basic_blocks.swap(b1.index(), b2.index());
+    }
+
+    pub fn start_new_block(&mut self) -> BasicBlock {
+        let node_index = self.basic_blocks.len();
+        self.basic_blocks.push(BasicBlockData::new(None));
+        BasicBlock::new(node_index)
+    }
+
+    pub fn start_new_cleanup_block(&mut self) -> BasicBlock {
+        let bb = self.start_new_block();
+        self[bb].is_cleanup = true;
+        bb
+    }
+
+    pub fn push(&mut self, block: BasicBlock, statement: Statement<'tcx>) {
+        debug!("push({:?}, {:?})", block, statement);
+        self[block].statements.push(statement);
+    }
+
+    pub fn terminate(&mut self,
+                     block: BasicBlock,
+                     scope: ScopeId,
+                     span: Span,
+                     kind: TerminatorKind<'tcx>) {
+        debug_assert!(self[block].terminator.is_none(),
+                      "terminate: block {:?} already has a terminator set", block);
+        self[block].terminator = Some(Terminator {
+            span: span,
+            scope: scope,
+            kind: kind,
+        });
+    }
+
+    pub fn push_assign(&mut self,
+                       block: BasicBlock,
+                       scope: ScopeId,
+                       span: Span,
+                       lvalue: &Lvalue<'tcx>,
+                       rvalue: Rvalue<'tcx>) {
+        self.push(block, Statement {
+            scope: scope,
+            span: span,
+            kind: StatementKind::Assign(lvalue.clone(), rvalue)
+        });
+    }
+
+    pub fn push_assign_constant(&mut self,
+                                block: BasicBlock,
+                                scope: ScopeId,
+                                span: Span,
+                                temp: &Lvalue<'tcx>,
+                                constant: Constant<'tcx>) {
+        self.push_assign(block, scope, span, temp,
+                         Rvalue::Use(Operand::Constant(constant)));
+    }
+
+    pub fn push_assign_unit(&mut self,
+                            block: BasicBlock,
+                            scope: ScopeId,
+                            span: Span,
+                            lvalue: &Lvalue<'tcx>) {
+        self.push_assign(block, scope, span, lvalue, Rvalue::Aggregate(
+            AggregateKind::Tuple, vec![]
+        ));
+    }
+}
+
+impl<'tcx> Index<BasicBlock> for CFG<'tcx> {
+    type Output = BasicBlockData<'tcx>;
+
+    #[inline]
+    fn index(&self, index: BasicBlock) -> &BasicBlockData<'tcx> {
+        &self.basic_blocks[index.index()]
+    }
+}
+
+impl<'tcx> IndexMut<BasicBlock> for CFG<'tcx> {
+    #[inline]
+    fn index_mut(&mut self, index: BasicBlock) -> &mut BasicBlockData<'tcx> {
+        &mut self.basic_blocks[index.index()]
+    }
+}
+

--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+pub use mir::cfg::*;
+
 use graphviz::IntoCow;
 use middle::const_val::ConstVal;
 use rustc_const_math::{ConstUsize, ConstInt};
@@ -30,7 +32,7 @@ use syntax::codemap::Span;
 pub struct Mir<'tcx> {
     /// List of basic blocks. References to basic block use a newtyped index type `BasicBlock`
     /// that indexes into this vector.
-    pub basic_blocks: Vec<BasicBlockData<'tcx>>,
+    pub cfg: CFG<'tcx>,
 
     /// List of lexical scopes; these are referenced by statements and
     /// used (eventually) for debuginfo. Indexed by a `ScopeId`.
@@ -70,17 +72,17 @@ pub const START_BLOCK: BasicBlock = BasicBlock(0);
 
 impl<'tcx> Mir<'tcx> {
     pub fn all_basic_blocks(&self) -> Vec<BasicBlock> {
-        (0..self.basic_blocks.len())
+        (0..self.cfg.len())
             .map(|i| BasicBlock::new(i))
             .collect()
     }
 
     pub fn basic_block_data(&self, bb: BasicBlock) -> &BasicBlockData<'tcx> {
-        &self.basic_blocks[bb.index()]
+        &self.cfg[bb]
     }
 
     pub fn basic_block_data_mut(&mut self, bb: BasicBlock) -> &mut BasicBlockData<'tcx> {
-        &mut self.basic_blocks[bb.index()]
+        &mut self.cfg[bb]
     }
 }
 
@@ -541,7 +543,7 @@ impl<'tcx> Debug for Statement<'tcx> {
 
 /// A path to a value; something that can be evaluated without
 /// changing or disturbing program state.
-#[derive(Clone, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Clone, PartialEq, Eq, Hash, RustcEncodable, RustcDecodable)]
 pub enum Lvalue<'tcx> {
     /// local variable declared by the user
     Var(u32),
@@ -726,7 +728,7 @@ pub struct ScopeData {
 /// These are values that can appear inside an rvalue (or an index
 /// lvalue). They are intentionally limited to prevent rvalues from
 /// being nested in one another.
-#[derive(Clone, PartialEq, RustcEncodable, RustcDecodable)]
+#[derive(Clone, PartialEq, Eq, Hash, RustcEncodable, RustcDecodable)]
 pub enum Operand<'tcx> {
     Consume(Lvalue<'tcx>),
     Constant(Constant<'tcx>),

--- a/src/librustc/mir/transform/dataflow.rs
+++ b/src/librustc/mir/transform/dataflow.rs
@@ -1,0 +1,419 @@
+use mir::repr as mir;
+use mir::cfg::CFG;
+use mir::repr::BasicBlock;
+use rustc_data_structures::bitvec::BitVector;
+
+use mir::transform::lattice::Lattice;
+
+
+pub trait DataflowPass<'tcx> {
+    type Lattice: Lattice;
+    type Rewrite: Rewrite<'tcx, Self::Lattice>;
+    type Transfer: Transfer<'tcx, Self::Lattice>;
+}
+
+pub trait Rewrite<'tcx, L: Lattice> {
+    /// The rewrite function which given a statement optionally produces an alternative graph to be
+    /// placed in place of the original statement.
+    ///
+    /// The 2nd BasicBlock *MUST NOT* have the terminator set.
+    ///
+    /// Correctness precondition:
+    /// * transfer_stmt(statement, fact) == transfer_stmt(rewrite_stmt(statement, fact))
+    /// that is, given some fact `fact` true before both the statement and relacement graph, and
+    /// a fact `fact2` which is true after the statement, the same `fact2` must be true after the
+    /// replacement graph too.
+    fn stmt(&mir::Statement<'tcx>, &L, &mut CFG<'tcx>) -> StatementChange<'tcx>;
+
+    /// The rewrite function which given a terminator optionally produces an alternative graph to
+    /// be placed in place of the original statement.
+    ///
+    /// The 2nd BasicBlock *MUST* have the terminator set.
+    ///
+    /// Correctness precondition:
+    /// * transfer_stmt(terminator, fact) == transfer_stmt(rewrite_term(terminator, fact))
+    /// that is, given some fact `fact` true before both the terminator and relacement graph, and
+    /// a fact `fact2` which is true after the statement, the same `fact2` must be true after the
+    /// replacement graph too.
+    fn term(&mir::Terminator<'tcx>, &L, &mut CFG<'tcx>) -> TerminatorChange<'tcx>;
+}
+
+/// This combinator has the following behaviour:
+///
+/// * Rewrite the node with the first rewriter.
+///   * if the first rewriter replaced the node, 2nd rewriter is used to rewrite the replacement.
+///   * otherwise 2nd rewriter is used to rewrite the original node.
+pub struct RewriteAndThen<'tcx, R1, R2>(::std::marker::PhantomData<(&'tcx (), R1, R2)>);
+impl<'tcx, L, R1, R2> Rewrite<'tcx, L> for RewriteAndThen<'tcx, R1, R2>
+where L: Lattice, R1: Rewrite<'tcx, L>, R2: Rewrite<'tcx, L> {
+    fn stmt(s: &mir::Statement<'tcx>, l: &L, c: &mut CFG<'tcx>) -> StatementChange<'tcx> {
+        let rs = <R1 as Rewrite<L>>::stmt(s, l, c);
+        match rs {
+            StatementChange::None => <R2 as Rewrite<L>>::stmt(s, l, c),
+            StatementChange::Remove => StatementChange::Remove,
+            StatementChange::Statement(ns) =>
+                match <R2 as Rewrite<L>>::stmt(&ns, l, c) {
+                    StatementChange::None => StatementChange::Statement(ns),
+                    x => x
+                },
+            StatementChange::Statements(nss) => {
+                // We expect the common case of all statements in this vector being replaced/not
+                // replaced by other statements 1:1
+                let mut new_new_stmts = Vec::with_capacity(nss.len());
+                for s in nss {
+                    match <R2 as Rewrite<L>>::stmt(&s, l, c) {
+                        StatementChange::None => new_new_stmts.push(s),
+                        StatementChange::Remove => {},
+                        StatementChange::Statement(ns) => new_new_stmts.push(ns),
+                        StatementChange::Statements(nss) => new_new_stmts.extend(nss)
+                    }
+                }
+                StatementChange::Statements(new_new_stmts)
+            }
+        }
+    }
+
+    fn term(t: &mir::Terminator<'tcx>, l: &L, c: &mut CFG<'tcx>) -> TerminatorChange<'tcx> {
+        let rt = <R1 as Rewrite<L>>::term(t, l, c);
+        match rt {
+            TerminatorChange::None => <R2 as Rewrite<L>>::term(t, l, c),
+            TerminatorChange::Terminator(nt) => match <R2 as Rewrite<L>>::term(&nt, l, c) {
+                TerminatorChange::None => TerminatorChange::Terminator(nt),
+                x => x
+            }
+        }
+    }
+}
+
+pub enum TerminatorChange<'tcx> {
+    /// No change
+    None,
+    /// Replace with another terminator
+    Terminator(mir::Terminator<'tcx>),
+}
+
+pub enum StatementChange<'tcx> {
+    /// No change
+    None,
+    /// Remove the statement
+    Remove,
+    /// Replace with another single statement
+    Statement(mir::Statement<'tcx>),
+    /// Replace with a list of statements
+    Statements(Vec<mir::Statement<'tcx>>),
+}
+
+impl<'tcx> StatementChange<'tcx> {
+    fn normalise(&mut self) {
+        let old = ::std::mem::replace(self, StatementChange::None);
+        *self = match old {
+            StatementChange::Statements(mut stmts) => {
+                match stmts.len() {
+                    0 => StatementChange::Remove,
+                    1 => StatementChange::Statement(stmts.pop().unwrap()),
+                    _ => StatementChange::Statements(stmts)
+                }
+            }
+            o => o
+        }
+    }
+}
+
+pub trait Transfer<'tcx, L: Lattice> {
+    type TerminatorOut;
+    /// The transfer function which given a statement and a fact produces a fact which is true
+    /// after the statement.
+    fn stmt(&mir::Statement<'tcx>, L) -> L;
+
+    /// The transfer function which given a terminator and a fact produces a fact for each
+    /// successor of the terminator.
+    ///
+    /// Corectness precondtition:
+    /// * The list of facts produced should only contain the facts for blocks which are successors
+    /// of the terminator being transfered.
+    fn term(&mir::Terminator<'tcx>, L) -> Self::TerminatorOut;
+}
+
+
+/// Facts is a mapping from basic block label (index) to the fact which is true about the first
+/// statement in the block.
+pub struct Facts<F>(Vec<F>);
+
+impl<F: Lattice> Facts<F> {
+    pub fn new() -> Facts<F> {
+        Facts(vec![])
+    }
+
+    fn put(&mut self, index: BasicBlock, value: F) {
+        let len = self.0.len();
+        self.0.extend((len...index.index()).map(|_| <F as Lattice>::bottom()));
+        self.0[index.index()] = value;
+    }
+}
+
+impl<F: Lattice> ::std::ops::Index<BasicBlock> for Facts<F> {
+    type Output = F;
+    fn index(&self, index: BasicBlock) -> &F {
+        &self.0.get(index.index()).expect("facts indexed immutably and the user is buggy!")
+    }
+}
+
+impl<F: Lattice> ::std::ops::IndexMut<BasicBlock> for Facts<F> {
+    fn index_mut(&mut self, index: BasicBlock) -> &mut F {
+        if let None = self.0.get_mut(index.index()) {
+            self.put(index, <F as Lattice>::bottom());
+        }
+        self.0.get_mut(index.index()).unwrap()
+    }
+}
+
+/// Analyse and rewrite using dataflow in the forward direction
+pub fn ar_forward<'tcx, T, P>(cfg: &CFG<'tcx>, fs: Facts<P::Lattice>, mut queue: BitVector)
+-> (CFG<'tcx>, Facts<P::Lattice>)
+// FIXME: shouldn’t need that T generic.
+where T: Transfer<'tcx, P::Lattice, TerminatorOut=Vec<P::Lattice>>,
+      P: DataflowPass<'tcx, Transfer=T>
+{
+    fixpoint(cfg, Direction::Forward, |bb, fact, cfg| {
+        let new_graph = cfg.start_new_block();
+        let mut fact = fact.clone();
+        let mut changed = false;
+        // Swap out the vector of old statements for a duration of statement inspection.
+        let old_statements = ::std::mem::replace(&mut cfg[bb].statements, Vec::new());
+        for stmt in &old_statements {
+            // Given a fact and statement produce a new fact and optionally a replacement
+            // graph.
+            let mut new_repl = P::Rewrite::stmt(&stmt, &fact, cfg);
+            new_repl.normalise();
+            match new_repl {
+                StatementChange::None => {
+                    fact = P::Transfer::stmt(stmt, fact);
+                    cfg.push(new_graph, stmt.clone());
+                }
+                StatementChange::Remove => changed = true,
+                StatementChange::Statement(stmt) => {
+                    changed = true;
+                    fact = P::Transfer::stmt(&stmt, fact);
+                    cfg.push(new_graph, stmt);
+                }
+                StatementChange::Statements(stmts) => {
+                    changed = true;
+                    for stmt in &stmts { fact = P::Transfer::stmt(stmt, fact); }
+                    cfg[new_graph].statements.extend(stmts);
+                }
+
+            }
+        }
+        // Swap the statements back in.
+        ::std::mem::replace(&mut cfg[bb].statements, old_statements);
+
+        // Handle the terminator replacement and transfer.
+        let terminator = ::std::mem::replace(&mut cfg[bb].terminator, None).unwrap();
+        let repl = P::Rewrite::term(&terminator, &fact, cfg);
+        match repl {
+            TerminatorChange::None => {
+                cfg[new_graph].terminator = Some(terminator.clone());
+            }
+            TerminatorChange::Terminator(t) => {
+                changed = true;
+                cfg[new_graph].terminator = Some(t);
+            }
+        }
+        let new_facts = P::Transfer::term(cfg[new_graph].terminator(), fact);
+        ::std::mem::replace(&mut cfg[bb].terminator, Some(terminator));
+
+        (if changed { Some(new_graph) } else { None }, new_facts)
+    }, &mut queue, fs)
+}
+
+// /// The implementation of forward dataflow.
+// pub struct ForwardDataflow<F>(::std::marker::PhantomData<F>);
+//
+// impl<F> ForwardDataflow<F> {
+//     pub fn new() -> ForwardDataflow<F> {
+//         ForwardDataflow(::std::marker::PhantomData)
+//     }
+// }
+//
+// impl<F> Pass for ForwardDataflow<F> {}
+//
+// impl<'tcx, P> MirPass<'tcx> for ForwardDataflow<P>
+// where P: DataflowPass<'tcx> {
+//     fn run_pass<'a>(&mut self, _: TyCtxt<'a, 'tcx, 'tcx>, _: MirSource, mir: &mut mir::Mir<'tcx>) {
+//         let facts: Facts<<P as DataflowPass<'tcx>>::Lattice> =
+//             Facts::new(<P as DataflowPass<'tcx>>::input_fact());
+//         let (new_cfg, _) = self.arf_body(&mir.cfg, facts, mir::START_BLOCK);
+//         mir.cfg = new_cfg;
+//     }
+// }
+//
+// impl<'tcx, P> ForwardDataflow<P>
+// where P: DataflowPass<'tcx> {
+//
+//
+// /// The implementation of backward dataflow.
+// pub struct BackwardDataflow<F>(::std::marker::PhantomData<F>);
+//
+// impl<F> BackwardDataflow<F> {
+//     pub fn new() -> BackwardDataflow<F> {
+//         BackwardDataflow(::std::marker::PhantomData)
+//     }
+// }
+//
+// impl<F> Pass for BackwardDataflow<F> {}
+//
+// impl<'tcx, P> MirPass<'tcx> for BackwardDataflow<P>
+// where P: DataflowPass<'tcx> {
+//     fn run_pass<'a>(&mut self, _: TyCtxt<'a, 'tcx, 'tcx>, _: MirSource, mir: &mut mir::Mir<'tcx>) {
+//         let mut facts: Facts<<P as DataflowPass<'tcx>>::Lattice> =
+//             Facts::new(<P as DataflowPass<'tcx>>::input_fact());
+//         // The desired effect here is that we should begin flowing from the blocks which terminate
+//         // the control flow (return, resume, calls of diverging functions, non-terminating loops
+//         // etc), but finding them all is a pain, so we just get the list of graph nodes postorder
+//         // and inspect them all! Perhaps not very effective, but certainly correct.
+//         let start_at = postorder(mir).filter(|&(_, d)| !d.is_cleanup).map(|(bb, _)| {
+//             facts.put(bb, <P as DataflowPass<'tcx>>::Lattice::bottom());
+//             (bb, ())
+//         }).collect();
+//         let (new_cfg, _) = self.arb_body(&mir.cfg, facts, start_at);
+//         mir.cfg = new_cfg;
+//     }
+// }
+//
+// impl<'tcx, P> BackwardDataflow<P>
+// where P: DataflowPass<'tcx> {
+//     fn arb_body(&self, cfg: &CFG<'tcx>,
+//                 facts: Facts<<P as DataflowPass<'tcx>>::Lattice>, mut map: HashMap<BasicBlock, ()>)
+//     -> (CFG<'tcx>, Facts<<P as DataflowPass<'tcx>>::Lattice>){
+//         fixpoint(cfg, Direction::Backward, |bb, fact, cfg| {
+//             let new_graph = cfg.start_new_block();
+//             let mut fact = fact.clone();
+//             // This is a reverse thing so we inspect the terminator first and statements in reverse
+//             // order later.
+//             //
+//             // Handle the terminator replacement and transfer.
+//             let terminator = ::std::mem::replace(&mut cfg[bb].terminator, None).unwrap();
+//             let repl = P::rewrite_term(&terminator, &fact, cfg);
+//             // TODO: this really needs to get factored out
+//             let mut new_facts = match repl {
+//                 TerminatorReplacement::Terminator(t) => {
+//                     cfg[new_graph].terminator = Some(t);
+//                     P::transfer_term(cfg[new_graph].terminator(), fact)
+//                 }
+//                 TerminatorReplacement::Graph(from, _) => {
+//                     // FIXME: a more optimal approach would be to copy the from to the tail of our
+//                     // new_graph. (1 less extra block). However there’s a problem with inspecting
+//                     // the statements of the merged block, because we just did the statements
+//                     // for this block already.
+//                     cfg.terminate(new_graph, terminator.scope, terminator.span,
+//                                   mir::TerminatorKind::Goto { target: from });
+//                     P::transfer_term(&cfg[new_graph].terminator(), fact)
+//                 }
+//             };
+//             // FIXME: this should just have a different API.
+//             assert!(new_facts.len() == 1, "transfer_term function is incorrect");
+//             fact = new_facts.pop().unwrap().1;
+//             ::std::mem::replace(&mut cfg[bb].terminator, Some(terminator));
+//
+//             // Swap out the vector of old statements for a duration of statement inspection.
+//             let old_statements = ::std::mem::replace(&mut cfg[bb].statements, Vec::new());
+//             for stmt in old_statements.iter().rev() {
+//                 // Given a fact and statement produce a new fact and optionally a replacement
+//                 // graph.
+//                 let mut new_repl = P::rewrite_stmt(&stmt, &fact, cfg);
+//                 new_repl.normalise();
+//                 match new_repl {
+//                     StatementReplacement::None => {}
+//                     StatementReplacement::Statement(nstmt) => {
+//                         fact = P::transfer_stmt(&nstmt, fact);
+//                         cfg.push(new_graph, nstmt)
+//                     }
+//                     StatementReplacement::Statements(stmts) => {
+//                         for stmt in &stmts {
+//                             fact = P::transfer_stmt(stmt, fact);
+//                         }
+//                         cfg[new_graph].statements.extend(stmts)
+//                     }
+//                     StatementReplacement::Graph(..) => unimplemented!(),
+//                     // debug_assert!(cfg[replacement.1].terminator.is_none(),
+//                     //               "buggy pass: replacement tail has a terminator set!");
+//                 };
+//             }
+//             // Reverse the statements, because we were analysing bottom-top but pusshing
+//             // top-bottom.
+//             cfg[new_graph].statements.reverse();
+//             ::std::mem::replace(&mut cfg[bb].statements, old_statements);
+//             (Some(new_graph), vec![(mir::START_BLOCK, fact)])
+//         }, &mut map, facts)
+//     }
+// }
+
+enum Direction {
+    Forward,
+    Backward
+}
+
+/// The fixpoint function is the engine of this whole thing. Important part of it is the `f: BF`
+/// callback. This for each basic block and its facts has to produce a replacement graph and a
+/// bunch of facts which are to be joined with the facts in the graph elsewhere.
+fn fixpoint<'tcx, F: Lattice, BF>(cfg: &CFG<'tcx>,
+                                  direction: Direction,
+                                  f: BF,
+                                  to_visit: &mut BitVector,
+                                  mut init_facts: Facts<F>) -> (CFG<'tcx>, Facts<F>)
+// TODO: we probably want to pass in a list of basicblocks as successors (predecessors in backward
+// fixpoing) and let BF return just a list of F.
+where BF: Fn(BasicBlock, &F, &mut CFG<'tcx>) -> (Option<BasicBlock>, Vec<F>),
+      // ^~ This function given a single block and fact before it optionally produces a replacement
+      // graph (if not, the original block is the “replacement graph”) for the block and a list of
+      // facts for arbitrary blocks (most likely for the blocks in the replacement graph and blocks
+      // into which data flows from the replacement graph)
+      //
+      // Invariant:
+      // * None of the already existing blocks in CFG may be modified;
+{
+    let mut cfg = cfg.clone();
+
+    while let Some(block) = to_visit.iter().next() {
+        to_visit.remove(block);
+        let block = BasicBlock::new(block);
+
+        let (new_target, new_facts) = {
+            let fact = &mut init_facts[block];
+            f(block, fact, &mut cfg)
+        };
+
+        // First of all, we merge in the replacement graph, if any.
+        if let Some(replacement_bb) = new_target {
+            cfg.swap(replacement_bb, block);
+        }
+
+        // Then we record the facts in the correct direction.
+        if let Direction::Forward = direction {
+            for (f, &target) in new_facts.into_iter()
+                                        .zip(cfg[block].terminator().successors().iter()) {
+                let facts_changed = Lattice::join(&mut init_facts[target], &f);
+                if facts_changed {
+                    to_visit.insert(target.index());
+                }
+            }
+        } else {
+            unimplemented!()
+            // let mut new_facts = new_facts;
+            // let fact = new_facts.pop().unwrap().1;
+            // for pred in cfg.predecessors(block) {
+            //     if init_facts.exists(pred) {
+            //         let old_fact = &mut init_facts[pred];
+            //         let facts_changed = Lattice::join(old_fact, &fact);
+            //         if facts_changed {
+            //             to_visit.insert(pred, ());
+            //         }
+            //     } else {
+            //         init_facts.put(pred, fact.clone());
+            //         to_visit.insert(pred, ());
+            //     }
+            // }
+        }
+    }
+    (cfg, init_facts)
+}

--- a/src/librustc/mir/transform/lattice.rs
+++ b/src/librustc/mir/transform/lattice.rs
@@ -1,0 +1,115 @@
+use std::fmt::{Debug, Formatter};
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+
+pub trait Lattice: Clone {
+    fn bottom() -> Self;
+    fn join(&mut self, other: &Self) -> bool;
+}
+
+/// Extend the type with a Top point.
+#[derive(Clone, PartialEq)]
+pub enum WTop<T> {
+    Top,
+    Value(T)
+}
+
+impl<T: Lattice> Lattice for WTop<T> {
+    fn bottom() -> Self {
+        WTop::Value(<T as Lattice>::bottom())
+    }
+
+    /// V + V = join(v, v)
+    /// ⊤ + V = ⊤ (no change)
+    /// V + ⊤ = ⊤
+    /// ⊤ + ⊤ = ⊤ (no change)
+    default fn join(&mut self, other: &Self) -> bool {
+        match (self, other) {
+            (&mut WTop::Value(ref mut this), &WTop::Value(ref o)) => <T as Lattice>::join(this, o),
+            (&mut WTop::Top, _) => false,
+            (this, &WTop::Top) => {
+                *this = WTop::Top;
+                true
+            }
+        }
+    }
+}
+
+impl<T: Debug> Debug for WTop<T> {
+    fn fmt(&self, f: &mut Formatter) -> ::std::fmt::Result {
+        match *self {
+            WTop::Top => f.write_str("⊤"),
+            WTop::Value(ref t) => <T as Debug>::fmt(t, f)
+        }
+    }
+}
+
+/// Extend the type with a bottom point
+///
+/// This guarantees the bottom() of the underlying lattice won’t get called so it may be
+/// implemented as a `panic!()` or something.
+#[derive(Clone, PartialEq)]
+pub enum WBottom<T> {
+    Bottom,
+    Value(T)
+}
+
+impl<T: Lattice> Lattice for WBottom<T> {
+    fn bottom() -> Self {
+        WBottom::Bottom
+    }
+
+    /// V + V = join(v, v)
+    /// ⊥ + V = V
+    /// V + ⊥ = V (no change)
+    /// ⊥ + ⊥ = ⊥ (no change)
+    fn join(&mut self, other: &Self) -> bool {
+        match (self, other) {
+            (&mut WBottom::Value(ref mut this), &WBottom::Value(ref o)) =>
+                <T as Lattice>::join(this, o),
+            (_, &WBottom::Bottom) => false,
+            (this, o) => {
+                *this = o.clone();
+                true
+            }
+        }
+    }
+
+}
+
+impl<T: Debug> Debug for WBottom<T> {
+    fn fmt(&self, f: &mut Formatter) -> ::std::fmt::Result {
+        match *self {
+            WBottom::Bottom => f.write_str("⊥"),
+            WBottom::Value(ref t) => <T as Debug>::fmt(t, f)
+        }
+    }
+}
+
+/// Extend the type with both bottom and top points.
+type WTopBottom<T> = WTop<WBottom<T>>;
+
+impl<K, T, H> Lattice for HashMap<K, T, H>
+where K: Clone + Eq + ::std::hash::Hash,
+      T: Lattice,
+      H: Clone + ::std::hash::BuildHasher + ::std::default::Default
+{
+    fn bottom() -> Self {
+        HashMap::default()
+    }
+    fn join(&mut self, other: &Self) -> bool {
+        let mut changed = false;
+        for (key, val) in other.iter() {
+            match self.entry(key.clone()) {
+                Entry::Vacant(e) => {
+                    e.insert(val.clone());
+                    changed = true
+                }
+                Entry::Occupied(mut e) => changed |= e.get_mut().join(val)
+            }
+        }
+        changed
+    }
+}
+
+

--- a/src/librustc/mir/transform/mod.rs
+++ b/src/librustc/mir/transform/mod.rs
@@ -8,6 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+pub mod lattice;
+pub mod dataflow;
+
+pub use self::dataflow::*;
+
 use dep_graph::DepNode;
 use hir;
 use hir::map::DefPathData;

--- a/src/librustc/mir/traversal.rs
+++ b/src/librustc/mir/traversal.rs
@@ -12,7 +12,7 @@ use std::vec;
 
 use rustc_data_structures::bitvec::BitVector;
 
-use rustc::mir::repr::*;
+use mir::repr::*;
 
 /// Preorder traversal of a graph.
 ///
@@ -44,7 +44,7 @@ impl<'a, 'tcx> Preorder<'a, 'tcx> {
 
         Preorder {
             mir: mir,
-            visited: BitVector::new(mir.basic_blocks.len()),
+            visited: BitVector::new(mir.cfg.basic_blocks.len()),
             worklist: worklist
         }
     }
@@ -106,7 +106,7 @@ impl<'a, 'tcx> Postorder<'a, 'tcx> {
     pub fn new(mir: &'a Mir<'tcx>, root: BasicBlock) -> Postorder<'a, 'tcx> {
         let mut po = Postorder {
             mir: mir,
-            visited: BitVector::new(mir.basic_blocks.len()),
+            visited: BitVector::new(mir.cfg.basic_blocks.len()),
             visit_stack: Vec::new()
         };
 

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -242,7 +242,7 @@ macro_rules! make_mir_visitor {
             fn super_mir(&mut self,
                          mir: & $($mutability)* Mir<'tcx>) {
                 let Mir {
-                    ref $($mutability)* basic_blocks,
+                    ref $($mutability)* cfg,
                     ref $($mutability)* scopes,
                     promoted: _, // Visited by passes separately.
                     ref $($mutability)* return_ty,
@@ -252,6 +252,10 @@ macro_rules! make_mir_visitor {
                     upvar_decls: _,
                     ref $($mutability)* span,
                 } = *mir;
+
+                let CFG {
+                    ref $($mutability)* basic_blocks
+                } = *cfg;
 
                 for (index, data) in basic_blocks.into_iter().enumerate() {
                     let block = BasicBlock::new(index);

--- a/src/librustc_borrowck/borrowck/mir/dataflow.rs
+++ b/src/librustc_borrowck/borrowck/mir/dataflow.rs
@@ -167,7 +167,7 @@ impl<'c, 'b: 'c, 'a: 'b, 'tcx: 'a, OnReturn> PropagationContext<'c, 'b, 'a, 'tcx
 
     fn walk_cfg(&mut self, in_out: &mut [usize]) {
         let &mut MirBorrowckCtxt { ref mir, ref mut flow_state, .. } = self.mbcx;
-        for (idx, bb) in mir.basic_blocks.iter().enumerate() {
+        for (idx, bb) in mir.cfg.basic_blocks.iter().enumerate() {
             {
                 let sets = flow_state.sets.for_block(idx);
                 debug_assert!(in_out.len() == sets.on_entry.len());
@@ -371,7 +371,7 @@ impl<D: BitDenotation> DataflowState<D> {
         let bits_per_block = denotation.bits_per_block();
         let usize_bits = mem::size_of::<usize>() * 8;
         let words_per_block = (bits_per_block + usize_bits - 1) / usize_bits;
-        let num_blocks = mir.basic_blocks.len();
+        let num_blocks = mir.cfg.basic_blocks.len();
         let num_words = num_blocks * words_per_block;
 
         let entry = if denotation.initial_value() { usize::MAX } else {0};

--- a/src/librustc_data_structures/bitvec.rs
+++ b/src/librustc_data_structures/bitvec.rs
@@ -27,12 +27,28 @@ impl BitVector {
         (self.data[word] & mask) != 0
     }
 
+    pub fn clear(&mut self) {
+        for datum in &mut self.data {
+            *datum = 0;
+        }
+    }
+
     /// Returns true if the bit has changed.
     pub fn insert(&mut self, bit: usize) -> bool {
         let (word, mask) = word_mask(bit);
         let data = &mut self.data[word];
         let value = *data;
         let new_value = value | mask;
+        *data = new_value;
+        new_value != value
+    }
+
+    /// Returns true if the bit has changed.
+    pub fn remove(&mut self, bit: usize) -> bool {
+        let (word, mask) = word_mask(bit);
+        let data = &mut self.data[word];
+        let value = *data;
+        let new_value = value & !mask;
         *data = new_value;
         new_value != value
     }

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -939,7 +939,8 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
             passes.push_pass(box mir::transform::remove_dead_blocks::RemoveDeadBlocks);
             passes.push_pass(box mir::transform::qualify_consts::QualifyAndPromoteConstants);
             passes.push_pass(box mir::transform::type_check::TypeckMir);
-            passes.push_pass(box mir::transform::simplify_cfg::SimplifyCfg);
+            passes.push_pass(box mir::transform::acs_propagate::ACSPropagate);
+            // passes.push_pass(box mir::transform::simplify_cfg::SimplifyCfg);
             passes.push_pass(box mir::transform::remove_dead_blocks::RemoveDeadBlocks);
             // And run everything.
             passes.run_passes(tcx, &mut mir_map);

--- a/src/librustc_mir/build/cfg.rs
+++ b/src/librustc_mir/build/cfg.rs
@@ -8,90 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
-
-
 //! Routines for manipulating the control-flow graph.
 
-use build::{CFG, Location};
+use build::Location;
 use rustc::mir::repr::*;
-use syntax::codemap::Span;
 
-impl<'tcx> CFG<'tcx> {
-    pub fn block_data(&self, blk: BasicBlock) -> &BasicBlockData<'tcx> {
-        &self.basic_blocks[blk.index()]
-    }
+pub trait CfgExt<'tcx> {
+    fn current_location(&mut self, block: BasicBlock) -> Location;
 
-    pub fn block_data_mut(&mut self, blk: BasicBlock) -> &mut BasicBlockData<'tcx> {
-        &mut self.basic_blocks[blk.index()]
-    }
+}
 
-    pub fn start_new_block(&mut self) -> BasicBlock {
-        let node_index = self.basic_blocks.len();
-        self.basic_blocks.push(BasicBlockData::new(None));
-        BasicBlock::new(node_index)
-    }
-
-    pub fn start_new_cleanup_block(&mut self) -> BasicBlock {
-        let bb = self.start_new_block();
-        self.block_data_mut(bb).is_cleanup = true;
-        bb
-    }
-
-    pub fn push(&mut self, block: BasicBlock, statement: Statement<'tcx>) {
-        debug!("push({:?}, {:?})", block, statement);
-        self.block_data_mut(block).statements.push(statement);
-    }
-
-    pub fn current_location(&mut self, block: BasicBlock) -> Location {
-        let index = self.block_data(block).statements.len();
+impl<'tcx> CfgExt<'tcx> for CFG<'tcx> {
+    fn current_location(&mut self, block: BasicBlock) -> Location {
+        let index = self[block].statements.len();
         Location { block: block, statement_index: index }
-    }
-
-    pub fn push_assign(&mut self,
-                       block: BasicBlock,
-                       scope: ScopeId,
-                       span: Span,
-                       lvalue: &Lvalue<'tcx>,
-                       rvalue: Rvalue<'tcx>) {
-        self.push(block, Statement {
-            scope: scope,
-            span: span,
-            kind: StatementKind::Assign(lvalue.clone(), rvalue)
-        });
-    }
-
-    pub fn push_assign_constant(&mut self,
-                                block: BasicBlock,
-                                scope: ScopeId,
-                                span: Span,
-                                temp: &Lvalue<'tcx>,
-                                constant: Constant<'tcx>) {
-        self.push_assign(block, scope, span, temp,
-                         Rvalue::Use(Operand::Constant(constant)));
-    }
-
-    pub fn push_assign_unit(&mut self,
-                            block: BasicBlock,
-                            scope: ScopeId,
-                            span: Span,
-                            lvalue: &Lvalue<'tcx>) {
-        self.push_assign(block, scope, span, lvalue, Rvalue::Aggregate(
-            AggregateKind::Tuple, vec![]
-        ));
-    }
-
-    pub fn terminate(&mut self,
-                     block: BasicBlock,
-                     scope: ScopeId,
-                     span: Span,
-                     kind: TerminatorKind<'tcx>) {
-        debug_assert!(self.block_data(block).terminator.is_none(),
-                      "terminate: block {:?} already has a terminator set", block);
-        self.block_data_mut(block).terminator = Some(Terminator {
-            span: span,
-            scope: scope,
-            kind: kind,
-        });
     }
 }

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -58,10 +58,6 @@ pub struct Builder<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
     cached_return_block: Option<BasicBlock>,
 }
 
-struct CFG<'tcx> {
-    basic_blocks: Vec<BasicBlockData<'tcx>>,
-}
-
 /// For each scope, we track the extent (from the HIR) and a
 /// single-entry-multiple-exit subgraph that contains all the
 /// statements/terminators within it.
@@ -294,7 +290,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         }
 
         (Mir {
-            basic_blocks: self.cfg.basic_blocks,
+            cfg: self.cfg,
             scopes: self.scope_datas,
             promoted: vec![],
             var_decls: self.var_decls,

--- a/src/librustc_mir/build/scope.rs
+++ b/src/librustc_mir/build/scope.rs
@@ -86,7 +86,8 @@ should go to.
 
 */
 
-use build::{BlockAnd, BlockAndExtension, Builder, CFG, ScopeAuxiliary};
+use build::{BlockAnd, BlockAndExtension, Builder, ScopeAuxiliary};
+use build::cfg::CfgExt;
 use rustc::middle::region::{CodeExtent, CodeExtentData};
 use rustc::middle::lang_items;
 use rustc::ty::subst::{Substs, Subst, VecPerParamSpace};

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -49,4 +49,3 @@ mod hair;
 pub mod mir_map;
 pub mod pretty;
 pub mod transform;
-pub mod traversal;

--- a/src/librustc_mir/transform/acs_propagate.rs
+++ b/src/librustc_mir/transform/acs_propagate.rs
@@ -1,0 +1,224 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! This is Alias-Constant-Simplify propagation pass. This is a composition of three distinct
+//! dataflow passes: alias-propagation, constant-propagation and terminator simplification.
+//!
+//! All these are very similar in their nature:
+//!
+//!                 | Constant  |  Alias   | Simplify  |
+//!|----------------|-----------|----------|-----------|
+//!| Lattice Domain | Lvalue    | Lvalue   | Lvalue    |
+//!| Lattice Value  | Constant  | Lvalue   | Constant  |
+//!| Transfer       | x = const | x = lval | x = const |
+//!| Rewrite        | x → const | x → lval | T(x) → T' |
+//!| Bottom         | {}        | {}       | {}        |
+//!
+//! For all of them we will be using a lattice of Hashmap from Lvalue to
+//! WTop<Either<Lvalue, Constant>>
+//!
+//! My personal believ is that it should be possible to make a way to compose two hashmap lattices
+//! into one, but I can’t seem to get it just right yet, so we do the composing and decomposing
+//! manually here.
+
+use rustc_data_structures::fnv::FnvHashMap;
+use rustc_data_structures::bitvec::BitVector;
+use rustc::mir::repr::*;
+use rustc::mir::visit::{MutVisitor, LvalueContext};
+use rustc::mir::transform::lattice::Lattice;
+use rustc::mir::transform::dataflow::*;
+use rustc::mir::transform::{Pass, MirPass, MirSource};
+use rustc::ty::TyCtxt;
+use rustc::middle::const_val::ConstVal;
+use pretty;
+
+#[derive(PartialEq, Debug, Eq, Clone)]
+pub enum Either<'tcx> {
+    Top,
+    Lvalue(Lvalue<'tcx>),
+    Const(Constant<'tcx>),
+}
+
+impl<'tcx> Lattice for Either<'tcx> {
+    fn bottom() -> Self { unimplemented!() }
+    fn join(&mut self, other: &Self) -> bool {
+        if self == other {
+            false
+        } else {
+            *self = Either::Top;
+            true
+        }
+    }
+}
+
+pub type ACSLattice<'a> = FnvHashMap<Lvalue<'a>, Either<'a>>;
+
+pub struct ACSPropagate;
+
+impl Pass for ACSPropagate {}
+
+impl<'tcx> MirPass<'tcx> for ACSPropagate {
+    fn run_pass<'a>(&mut self, tcx: TyCtxt<'a, 'tcx, 'tcx>, src: MirSource, mir: &mut Mir<'tcx>) {
+        let mut q = BitVector::new(mir.cfg.len());
+        q.insert(START_BLOCK.index());
+        let ret = ar_forward::<ACSPropagateTransfer, ACSPropagate>(&mut mir.cfg, Facts::new(), q);
+        mir.cfg = ret.0;
+        pretty::dump_mir(tcx, "acs_propagate", &0, src, mir, None);
+    }
+
+}
+
+impl<'tcx> DataflowPass<'tcx> for ACSPropagate {
+    type Lattice = ACSLattice<'tcx>;
+    type Rewrite = RewriteAndThen<'tcx, AliasRewrite,
+                                  RewriteAndThen<'tcx, ConstRewrite, SimplifyRewrite>>;
+    type Transfer = ACSPropagateTransfer;
+}
+
+pub struct ACSPropagateTransfer;
+
+impl<'tcx> Transfer<'tcx, ACSLattice<'tcx>> for ACSPropagateTransfer {
+    type TerminatorOut = Vec<ACSLattice<'tcx>>;
+    fn stmt(s: &Statement<'tcx>, mut lat: ACSLattice<'tcx>) -> ACSLattice<'tcx> {
+        let StatementKind::Assign(ref lval, ref rval) = s.kind;
+        match *rval {
+            Rvalue::Use(Operand::Consume(ref nlval)) =>
+                lat.insert(lval.clone(), Either::Lvalue(nlval.clone())),
+            Rvalue::Use(Operand::Constant(ref c)) =>
+                lat.insert(lval.clone(), Either::Const(c.clone())),
+            _ => lat.insert(lval.clone(), Either::Top)
+        };
+        lat
+    }
+    fn term(t: &Terminator<'tcx>, lat: ACSLattice<'tcx>) -> Self::TerminatorOut {
+        // FIXME: this should inspect the terminators and set their known values to constants. Esp.
+        // for the if: in the truthy branch the operand is known to be true and in the falsy branch
+        // the operand is known to be false. Now we just ignore the potential here.
+        let mut ret = vec![];
+        ret.resize(t.successors().len(), lat);
+        ret
+    }
+}
+
+pub struct AliasRewrite;
+
+impl<'tcx> Rewrite<'tcx, ACSLattice<'tcx>> for AliasRewrite {
+    fn stmt(s: &Statement<'tcx>, l: &ACSLattice<'tcx>, cfg: &mut CFG<'tcx>)
+    -> StatementChange<'tcx> {
+        let mut ns = s.clone();
+        let mut vis = RewriteAliasVisitor(&l, false);
+        vis.visit_statement(START_BLOCK, &mut ns);
+        if vis.1 { StatementChange::Statement(ns) } else { StatementChange::None }
+    }
+    fn term(t: &Terminator<'tcx>, l: &ACSLattice<'tcx>, cfg: &mut CFG<'tcx>)
+    -> TerminatorChange<'tcx> {
+        let mut nt = t.clone();
+        let mut vis = RewriteAliasVisitor(&l, false);
+        vis.visit_terminator(START_BLOCK, &mut nt);
+        if vis.1 { TerminatorChange::Terminator(nt) } else { TerminatorChange::None }
+    }
+}
+
+struct RewriteAliasVisitor<'a, 'tcx: 'a>(pub &'a ACSLattice<'tcx>, pub bool);
+impl<'a, 'tcx> MutVisitor<'tcx> for RewriteAliasVisitor<'a, 'tcx> {
+    fn visit_lvalue(&mut self, lvalue: &mut Lvalue<'tcx>, context: LvalueContext) {
+        match context {
+            LvalueContext::Store | LvalueContext::Call => {}
+            _ => {
+                let replacement = self.0.get(lvalue);
+                match replacement {
+                    Some(&Either::Lvalue(ref nlval)) => {
+                        self.1 = true;
+                        *lvalue = nlval.clone();
+                    }
+                    _ => {}
+                }
+            }
+        }
+        self.super_lvalue(lvalue, context);
+    }
+}
+
+pub struct ConstRewrite;
+
+impl<'tcx> Rewrite<'tcx, ACSLattice<'tcx>> for ConstRewrite {
+    fn stmt(s: &Statement<'tcx>, l: &ACSLattice<'tcx>, cfg: &mut CFG<'tcx>)
+    -> StatementChange<'tcx> {
+        let mut ns = s.clone();
+        let mut vis = RewriteConstVisitor(&l, false);
+        vis.visit_statement(START_BLOCK, &mut ns);
+        if vis.1 { StatementChange::Statement(ns) } else { StatementChange::None }
+    }
+    fn term(t: &Terminator<'tcx>, l: &ACSLattice<'tcx>, cfg: &mut CFG<'tcx>)
+    -> TerminatorChange<'tcx> {
+        let mut nt = t.clone();
+        let mut vis = RewriteConstVisitor(&l, false);
+        vis.visit_terminator(START_BLOCK, &mut nt);
+        if vis.1 { TerminatorChange::Terminator(nt) } else { TerminatorChange::None }
+    }
+}
+
+struct RewriteConstVisitor<'a, 'tcx: 'a>(pub &'a ACSLattice<'tcx>, pub bool);
+impl<'a, 'tcx> MutVisitor<'tcx> for RewriteConstVisitor<'a, 'tcx> {
+    fn visit_operand(&mut self, op: &mut Operand<'tcx>) {
+        let repl = if let Operand::Consume(ref lval) = *op {
+            if let Some(&Either::Const(ref c)) = self.0.get(lval) {
+                Some(c.clone())
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        if let Some(c) = repl {
+            *op = Operand::Constant(c);
+        }
+        self.super_operand(op);
+    }
+}
+
+
+pub struct SimplifyRewrite;
+
+impl<'tcx> Rewrite<'tcx, ACSLattice<'tcx>> for SimplifyRewrite {
+    fn stmt(s: &Statement<'tcx>, l: &ACSLattice<'tcx>, cfg: &mut CFG<'tcx>)
+    -> StatementChange<'tcx> {
+        StatementChange::None
+    }
+    fn term(t: &Terminator<'tcx>, l: &ACSLattice<'tcx>, cfg: &mut CFG<'tcx>)
+    -> TerminatorChange<'tcx> {
+        match t.kind {
+            TerminatorKind::If { ref targets, .. } if targets.0 == targets.1 => {
+                let mut nt = t.clone();
+                nt.kind = TerminatorKind::Goto { target: targets.0 };
+                TerminatorChange::Terminator(nt)
+            }
+            TerminatorKind::If { ref targets, cond: Operand::Constant(Constant {
+                literal: Literal::Value {
+                    value: ConstVal::Bool(cond)
+                }, ..
+            }) } => {
+                let mut nt = t.clone();
+                if cond {
+                    nt.kind = TerminatorKind::Goto { target: targets.0 };
+                } else {
+                    nt.kind = TerminatorKind::Goto { target: targets.1 };
+                }
+                TerminatorChange::Terminator(nt)
+            }
+            TerminatorKind::SwitchInt { ref targets, .. } if targets.len() == 1 => {
+                let mut nt = t.clone();
+                nt.kind = TerminatorKind::Goto { target: targets[0] };
+                TerminatorChange::Terminator(nt)
+            }
+            _ => TerminatorChange::None
+        }
+    }
+}

--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -16,3 +16,4 @@ pub mod type_check;
 pub mod break_critical_edges;
 pub mod promote_consts;
 pub mod qualify_consts;
+pub mod acs_propagate;

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -26,6 +26,7 @@ use rustc::mir::repr::*;
 use rustc::mir::mir_map::MirMap;
 use rustc::mir::transform::{Pass, MirMapPass, MirSource};
 use rustc::mir::visit::{LvalueContext, Visitor};
+use rustc::mir::traversal::{self, ReversePostorder};
 use rustc::util::nodemap::DefIdMap;
 use syntax::abi::Abi;
 use syntax::codemap::Span;
@@ -35,7 +36,6 @@ use std::collections::hash_map::Entry;
 use std::fmt;
 
 use build::Location;
-use traversal::{self, ReversePostorder};
 
 use super::promote_consts::{self, Candidate, TempState};
 
@@ -386,7 +386,7 @@ impl<'a, 'tcx> Qualifier<'a, 'tcx, 'tcx> {
     fn qualify_const(&mut self) -> Qualif {
         let mir = self.mir;
 
-        let mut seen_blocks = BitVector::new(mir.basic_blocks.len());
+        let mut seen_blocks = BitVector::new(mir.cfg.basic_blocks.len());
         let mut bb = START_BLOCK;
         loop {
             seen_blocks.insert(bb.index());

--- a/src/librustc_mir/transform/simplify_cfg.rs
+++ b/src/librustc_mir/transform/simplify_cfg.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use rustc::middle::const_val::ConstVal;
 use rustc::ty::TyCtxt;
 use rustc::mir::repr::*;
 use rustc::mir::transform::{MirPass, MirSource, Pass};
@@ -74,40 +73,6 @@ impl SimplifyCfg {
         changed
     }
 
-    fn simplify_branches(&self, mir: &mut Mir) -> bool {
-        let mut changed = false;
-
-        for bb in mir.all_basic_blocks() {
-            let basic_block = mir.basic_block_data_mut(bb);
-            let mut terminator = basic_block.terminator_mut();
-            terminator.kind = match terminator.kind {
-                TerminatorKind::If { ref targets, .. } if targets.0 == targets.1 => {
-                    changed = true;
-                    TerminatorKind::Goto { target: targets.0 }
-                }
-
-                TerminatorKind::If { ref targets, cond: Operand::Constant(Constant {
-                    literal: Literal::Value {
-                        value: ConstVal::Bool(cond)
-                    }, ..
-                }) } => {
-                    changed = true;
-                    if cond {
-                        TerminatorKind::Goto { target: targets.0 }
-                    } else {
-                        TerminatorKind::Goto { target: targets.1 }
-                    }
-                }
-
-                TerminatorKind::SwitchInt { ref targets, .. } if targets.len() == 1 => {
-                    TerminatorKind::Goto { target: targets[0] }
-                }
-                _ => continue
-            }
-        }
-
-        changed
-    }
 }
 
 impl<'tcx> MirPass<'tcx> for SimplifyCfg {
@@ -118,7 +83,6 @@ impl<'tcx> MirPass<'tcx> for SimplifyCfg {
         while changed {
             pretty::dump_mir(tcx, "simplify_cfg", &counter, src, mir, None);
             counter += 1;
-            changed = self.simplify_branches(mir);
             changed |= self.remove_goto_chains(mir);
             RemoveDeadBlocks.run_pass(tcx, src, mir);
         }

--- a/src/librustc_mir/transform/simplify_cfg.rs
+++ b/src/librustc_mir/transform/simplify_cfg.rs
@@ -123,7 +123,7 @@ impl<'tcx> MirPass<'tcx> for SimplifyCfg {
             RemoveDeadBlocks.run_pass(tcx, src, mir);
         }
         // FIXME: Should probably be moved into some kind of pass manager
-        mir.basic_blocks.shrink_to_fit();
+        mir.cfg.basic_blocks.shrink_to_fit();
     }
 }
 

--- a/src/librustc_mir/transform/type_check.rs
+++ b/src/librustc_mir/transform/type_check.rs
@@ -544,7 +544,7 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
     fn typeck_mir(&mut self, mir: &Mir<'tcx>) {
         self.last_span = mir.span;
         debug!("run_on_mir: {:?}", mir.span);
-        for block in &mir.basic_blocks {
+        for block in &mir.cfg.basic_blocks {
             for stmt in &block.statements {
                 if stmt.span != DUMMY_SP {
                     self.last_span = stmt.span;

--- a/src/librustc_trans/mir/mod.rs
+++ b/src/librustc_trans/mir/mod.rs
@@ -14,6 +14,7 @@ use llvm::debuginfo::DIScope;
 use rustc::ty;
 use rustc::mir::repr as mir;
 use rustc::mir::tcx::LvalueTy;
+use rustc::mir::traversal;
 use session::config::FullDebugInfo;
 use base;
 use common::{self, Block, BlockAndBuilder, CrateContext, FunctionContext};
@@ -34,7 +35,6 @@ use rustc_data_structures::bitvec::BitVector;
 pub use self::constant::trans_static_initializer;
 
 use self::lvalue::{LvalueRef, get_dataptr, get_meta};
-use rustc_mir::traversal;
 
 use self::operand::{OperandRef, OperandValue};
 


### PR DESCRIPTION
This PR at its current state has only the implementation of forward dataflow analysis and a accompanying alias-constant-simplify propagation pass.

The lattice-based dataflow framework is greatly inspired by the [Hoopl](https://github.com/haskell/hoopl) and its [paper](http://research.microsoft.com/en-us/um/people/simonpj/Papers/c--/hoopl-haskell10.pdf). The framework besides just being yet another dataflow engine allows for interleaving transformations and analysis + composition of the passes. These are something the gen-kill-set-based dataflow engines aren’t quite suited for. Those features are showcased by the accompanying ACS pass and without them the ACS pass wouldn‘t be otherwise possible (at least not within 200 lines).

Some notes: this is not yet complete: I expect to expand the framework to gain some more useful combinators (or at least those described in the paper) as well as some more other niceties to simplify production of dataflow-reliant passes and backwards analysis capabilities and so on and on.

Some results:

For following pieces of code this MIR (with dead variables removed by yours truly) gets produced:

```
fn a(x: (bool, bool)) -> u32{
    let z = x.0;
    let v = x.1;
    let y = if z || v {
        10
    } else {
        20
    };
    y
}
```

```
fn a(arg0: (bool, bool)) -> u32 {
    let var0: (bool, bool); // x in Scope(1) at test.rs:1:6: 1:7
    let var1: bool; // z in Scope(3) at test.rs:2:9: 2:10
    let var2: bool; // v in Scope(7) at test.rs:3:9: 3:10
    let var3: u32; // y in Scope(11) at test.rs:4:9: 4:10
    let mut tmp0: bool;
    let mut tmp1: bool;
    let mut tmp2: bool;
    let mut tmp3: bool;
    let mut tmp4: bool;
    let mut tmp5: u32;

    bb0: {
        if((arg0.0: bool)) -> [true: bb1, false: bb3]; // Scope(14) at test.rs:4:16: 4:22
    }

    bb1: {
        goto -> bb4; // Scope(14) at test.rs:4:16: 4:22
    }

    bb2: {
        goto -> bb4; // Scope(14) at test.rs:4:16: 4:22
    }

    bb3: {
        if((arg0.1: bool)) -> [true: bb1, false: bb2]; // Scope(14) at test.rs:4:16: 4:22
    }

    bb4: {
        if(tmp2) -> [true: bb5, false: bb6]; // Scope(13) at test.rs:4:13: 8:6
    }

    bb5: {
        var3 = const 10u32; // Scope(19) at test.rs:5:9: 5:11
        goto -> bb7; // Scope(13) at test.rs:4:13: 8:6
    }

    bb6: {
        var3 = const 20u32; // Scope(23) at test.rs:7:9: 7:11
        goto -> bb7; // Scope(13) at test.rs:4:13: 8:6
    }

    bb7: {
        return = var3; // Scope(24) at test.rs:9:5: 9:6
        goto -> bb8; // Scope(0) at test.rs:1:1: 10:2
    }

    bb8: {
        return; // Scope(0) at test.rs:1:1: 10:2
    }
```

``` rust
fn a() -> u32{
    let x = false;
    let z = x;
    let y = if z {
        10
    } else {
        10
    };
    y
}
```

```
fn a() -> u32 {
    let var0: bool; // x in Scope(3) at test.rs:2:9: 2:10
    let var1: bool; // z in Scope(6) at test.rs:3:9: 3:10
    let var2: u32; // y in Scope(9) at test.rs:4:9: 4:10
    let mut tmp0: bool;
    let mut tmp1: bool;
    let mut tmp2: u32;

    bb0: {
        goto -> bb2; // Scope(11) at test.rs:4:13: 8:6
    }

    bb1: {
        var2 = const 10u32; // Scope(14) at test.rs:5:9: 5:11
        goto -> bb3; // Scope(11) at test.rs:4:13: 8:6
    }

    bb2: {
        goto -> bb3; // Scope(11) at test.rs:4:13: 8:6
    }

    bb3: {
        return = const 10u32; // Scope(19) at test.rs:9:5: 9:6
        goto -> bb4; // Scope(0) at test.rs:1:1: 10:2
    }

    bb4: {
        return; // Scope(0) at test.rs:1:1: 10:2
    }
}
```
