### PR TITLE
Ergonomic format_args!

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -881,7 +881,7 @@ fn check_on_unimplemented<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                             }
                         },
                         // `{:1}` and `{}` are not to be used
-                        Position::ArgumentIs(_) | Position::ArgumentNext => {
+                        Position::ArgumentIs(_) => {
                             span_err!(ccx.tcx.sess, attr.span, E0231,
                                                   "only named substitution \
                                                    parameters are allowed");

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -651,21 +651,27 @@ pub fn expand_preparsed_format_args(ecx: &mut ExtCtxt, sp: Span,
     };
 
     let mut parser = parse::Parser::new(&fmt);
+    let mut pieces = vec![];
 
     loop {
         match parser.next() {
             Some(piece) => {
                 if !parser.errors.is_empty() { break }
                 cx.verify_piece(&piece);
-                if let Some(piece) = cx.trans_piece(&piece) {
-                    let s = cx.trans_literal_string();
-                    cx.str_pieces.push(s);
-                    cx.pieces.push(piece);
-                }
+                pieces.push(piece);
             }
             None => break
         }
     }
+
+    for piece in pieces {
+        if let Some(piece) = cx.trans_piece(&piece) {
+            let s = cx.trans_literal_string();
+            cx.str_pieces.push(s);
+            cx.pieces.push(piece);
+        }
+    }
+
     if !parser.errors.is_empty() {
         cx.ecx.span_err(cx.fmtsp, &format!("invalid format string: {}",
                                           parser.errors.remove(0)));

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -27,8 +27,8 @@ use std::collections::HashMap;
 
 #[derive(PartialEq)]
 enum ArgumentType {
-    Known(String),
-    Unsigned
+    Placeholder(String),
+    Count,
 }
 
 enum Position {
@@ -182,7 +182,7 @@ impl<'a, 'b> Context<'a, 'b> {
                     parse::ArgumentNamed(s) => Named(s.to_string()),
                 };
 
-                let ty = Known(arg.format.ty.to_string());
+                let ty = Placeholder(arg.format.ty.to_string());
                 self.verify_arg_type(pos, ty);
             }
         }
@@ -192,10 +192,10 @@ impl<'a, 'b> Context<'a, 'b> {
         match c {
             parse::CountImplied | parse::CountIs(..) => {}
             parse::CountIsParam(i) => {
-                self.verify_arg_type(Exact(i), Unsigned);
+                self.verify_arg_type(Exact(i), Count);
             }
             parse::CountIsName(s) => {
-                self.verify_arg_type(Named(s.to_string()), Unsigned);
+                self.verify_arg_type(Named(s.to_string()), Count);
             }
         }
     }
@@ -545,7 +545,7 @@ impl<'a, 'b> Context<'a, 'b> {
                   ty: &ArgumentType, arg: P<ast::Expr>)
                   -> P<ast::Expr> {
         let trait_ = match *ty {
-            Known(ref tyname) => {
+            Placeholder(ref tyname) => {
                 match &tyname[..] {
                     ""  => "Display",
                     "?" => "Debug",
@@ -564,7 +564,7 @@ impl<'a, 'b> Context<'a, 'b> {
                     }
                 }
             }
-            Unsigned => {
+            Count => {
                 let path = ecx.std_path(&["fmt", "ArgumentV1", "from_usize"]);
                 return ecx.expr_call_global(macsp, path, vec![arg])
             }

--- a/src/test/compile-fail/ifmt-bad-arg.rs
+++ b/src/test/compile-fail/ifmt-bad-arg.rs
@@ -23,9 +23,6 @@ fn main() {
     format!("{foo}", 1, foo=2);        //~ ERROR: argument never used
     format!("", foo=2);                //~ ERROR: named argument never used
 
-    format!("{0:x} {0:X}", 1);         //~ ERROR: redeclared with type `X`
-    format!("{foo:x} {foo:X}", foo=1); //~ ERROR: redeclared with type `X`
-
     format!("{foo}", foo=1, foo=2);    //~ ERROR: duplicate argument
     format!("", foo=1, 2);             //~ ERROR: positional arguments cannot follow
 


### PR DESCRIPTION
Fixes #9456 (at last).

Not a ground-up rewrite of the existing machinery, but more like an added intermediary layer between macro arguments and format placeholders. This is now implementing Rust RFC 1618!
