### PR TITLE
Relax named argument restriction on varargs functions

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4557,7 +4557,6 @@ impl<'a> Parser<'a> {
 
     fn parse_fn_args(&mut self, named_args: bool, allow_variadic: bool)
                      -> PResult<'a, (Vec<Arg> , bool)> {
-        let sp = self.span;
         let mut variadic = false;
         let args: Vec<Option<Arg>> =
             self.parse_unspanned_seq(
@@ -4594,11 +4593,6 @@ impl<'a> Parser<'a> {
             )?;
 
         let args: Vec<_> = args.into_iter().filter_map(|x| x).collect();
-
-        if variadic && args.is_empty() {
-            self.span_err(sp,
-                          "variadic function must be declared with at least one named argument");
-        }
 
         Ok((args, variadic))
     }

--- a/src/test/codegen/extern-functions.rs
+++ b/src/test/codegen/extern-functions.rs
@@ -21,6 +21,9 @@ extern {
 // CHECK: declare void @unwinding_extern_fn
     #[unwind]
     fn unwinding_extern_fn();
+
+// CHECK: declare void @extern_varargs_fn(...)
+    fn extern_varargs_fn(...);
 }
 
 pub unsafe fn force_declare() {


### PR DESCRIPTION
Currently we don't allow varargs function with no explicit arguments.

For example:

``` rust
extern fn(...) -> i32 // rejected
extern fn(a: i32, ...) -> i32 // allowed
```

Both functions are valid C (and LLVM supports both). This PR relaxes this restriction so the compiler no longer requires at least one named parameter. An example of C code which uses this is in the [Ruby interpreter](https://github.com/ruby/ruby/blob/trunk/include/ruby/ruby.h#L1696).
