### PR TITLE
Update i686-linux-android features to match android x86 ABI.

### DIFF
--- a/src/librustc_back/target/i686_linux_android.rs
+++ b/src/librustc_back/target/i686_linux_android.rs
@@ -12,8 +12,12 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::android_base::opts();
-    base.cpu = "pentium4".to_string();
+
     base.max_atomic_width = 64;
+
+    // http://developer.android.com/ndk/guides/abis.html#x86
+    base.cpu = "pentiumpro".to_string();
+    base.features = "+mmx,+sse,+sse2,+sse3,+ssse3".to_string();
 
     Target {
         llvm_target: "i686-linux-android".to_string(),


### PR DESCRIPTION
Based on [android's official x86 ABI info](http://developer.android.com/ndk/guides/abis.html#x86), the x86 baseline CPU can be safely updated to `pentiumpro`, with the addition of `MMX`, `SSE`, `SSE2`, `SSE3`, `SSSE3` features.

r? @alexcrichton
