### PR TITLE
Update link to license

### DIFF
--- a/src/doc/footer.inc
+++ b/src/doc/footer.inc
@@ -1,7 +1,7 @@
 <footer><p>
 Copyright &copy; 2011-2015 The Rust Project Developers. Licensed under the
 <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>
-or the <a href="http://opensource.org/licenses/MIT">MIT license</a>, at your option.
+or the <a href="https://opensource.org/licenses/MIT">MIT license</a>, at your option.
 </p><p>
 This file may not be copied, modified, or distributed except according to those terms.
 </p></footer>


### PR DESCRIPTION
Permanent redirect (301). The link should be updated.
