### PR TITLE
Document code with variable from macro

### DIFF
--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -764,9 +764,9 @@ macro_rules! atomic_int {
             /// # Examples
             ///
             /// ```
-            /// use std::sync::atomic::AtomicIsize;
+            /// use std::sync::atomic::$atomic_type;
             ///
-            /// let atomic_forty_two  = AtomicIsize::new(42);
+            /// let atomic_forty_two = $atomic_type::new(42);
             /// ```
             #[inline]
             #[$stable]
@@ -786,11 +786,11 @@ macro_rules! atomic_int {
             /// # Examples
             ///
             /// ```
-            /// use std::sync::atomic::{AtomicIsize, Ordering};
+            /// use std::sync::atomic::{$atomic_type, Ordering};
             ///
-            /// let some_isize = AtomicIsize::new(5);
+            /// let an_atomic = $atomic_type::new(5);
             ///
-            /// assert_eq!(some_isize.load(Ordering::Relaxed), 5);
+            /// assert_eq!(an_atomic.load(Ordering::Relaxed), 5);
             /// ```
             #[inline]
             #[$stable]


### PR DESCRIPTION
Hi all

I started to convert the examples in the comments to $atomic_type from the macro, but the compiler does not evaluate it.

I am currently not sure if it should work this way or if this change would need an RFC.

What do you think?

EDIT: I expect the build to fail, so this is more an idea currently.
