### PR TITLE
rustdoc: Add doc snippets for trait impls, with a read more link

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2565,8 +2565,9 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
     }
 
     fn doctraititem(w: &mut fmt::Formatter, cx: &Context, item: &clean::Item,
-                    link: AssocItemLink, render_static: bool, is_default_item: bool,
-                    outer_version: Option<&str>) -> fmt::Result {
+                    link: AssocItemLink, render_static: bool,
+                    is_default_item: bool, outer_version: Option<&str>,
+                    trait_: Option<&clean::Trait>) -> fmt::Result {
         let shortty = shortty(item);
         let name = item.name.as_ref().unwrap();
 
@@ -2618,16 +2619,33 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
         }
 
         if !is_default_item && (!is_static || render_static) {
-            document(w, cx, item)
+
+            if item.doc_value().is_some() {
+                document(w, cx, item)
+            } else {
+                // In case the item isn't documented,
+                // provide short documentation from the trait
+                if let Some(t) = trait_ {
+                    if let Some(it) = t.items.iter()
+                                       .find(|i| i.name == item.name) {
+                        document_short(w, it, link)?;
+                    }
+                }
+                Ok(())
+            }
         } else {
             document_short(w, item, link)?;
             Ok(())
         }
     }
 
+    let traits = &cache().traits;
+    let trait_ = i.trait_did().and_then(|did| traits.get(&did));
+
     write!(w, "<div class='impl-items'>")?;
     for trait_item in &i.inner_impl().items {
-        doctraititem(w, cx, trait_item, link, render_header, false, outer_version)?;
+        doctraititem(w, cx, trait_item, link, render_header,
+                     false, outer_version, trait_)?;
     }
 
     fn render_default_items(w: &mut fmt::Formatter,
@@ -2645,17 +2663,15 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
             let assoc_link = AssocItemLink::GotoSource(did, &i.provided_trait_methods);
 
             doctraititem(w, cx, trait_item, assoc_link, render_static, true,
-                         outer_version)?;
+                         outer_version, None)?;
         }
         Ok(())
     }
 
     // If we've implemented a trait, then also emit documentation for all
     // default items which weren't overridden in the implementation block.
-    if let Some(did) = i.trait_did() {
-        if let Some(t) = cache().traits.get(&did) {
-            render_default_items(w, cx, t, &i.inner_impl(), render_header, outer_version)?;
-        }
+    if let Some(t) = trait_ {
+        render_default_items(w, cx, t, &i.inner_impl(), render_header, outer_version)?;
     }
     write!(w, "</div>")?;
     Ok(())

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1659,11 +1659,12 @@ fn document(w: &mut fmt::Formatter, cx: &Context, item: &clean::Item) -> fmt::Re
 
 fn document_short(w: &mut fmt::Formatter, item: &clean::Item, link: AssocItemLink) -> fmt::Result {
     if let Some(s) = item.doc_value() {
-        write!(w, "<div class='docblock'>{}", Markdown(&plain_summary_line(Some(s))))?;
-        if s.contains('\n') {
-            write!(w, "<a href='{}'>Read more</a>", naive_assoc_href(item, link))?;
-        }
-        write!(w, "</div>")?;
+        let markdown = if s.contains('\n') {
+            format!("{} [Read more]({})", &plain_summary_line(Some(s)), naive_assoc_href(item, link))
+        } else {
+            format!("{}", &plain_summary_line(Some(s)))
+        };
+        write!(w, "<div class='docblock'>{}</div>", Markdown(&markdown))?;
     }
     Ok(())
 }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1657,6 +1657,17 @@ fn document(w: &mut fmt::Formatter, cx: &Context, item: &clean::Item) -> fmt::Re
     Ok(())
 }
 
+fn document_short(w: &mut fmt::Formatter, item: &clean::Item, link: AssocItemLink) -> fmt::Result {
+    if let Some(s) = item.doc_value() {
+        write!(w, "<div class='docblock'>{}", Markdown(&plain_summary_line(Some(s))))?;
+        if s.contains('\n') {
+            write!(w, "<a href='{}'>Read more</a>", naive_assoc_href(item, link))?;
+        }
+        write!(w, "</div>")?;
+    }
+    Ok(())
+}
+
 fn item_module(w: &mut fmt::Formatter, cx: &Context,
                item: &clean::Item, items: &[clean::Item]) -> fmt::Result {
     document(w, cx, item)?;
@@ -2609,6 +2620,7 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
         if !is_default_item && (!is_static || render_static) {
             document(w, cx, item)
         } else {
+            document_short(w, item, link)?;
             Ok(())
         }
     }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1660,7 +1660,8 @@ fn document(w: &mut fmt::Formatter, cx: &Context, item: &clean::Item) -> fmt::Re
 fn document_short(w: &mut fmt::Formatter, item: &clean::Item, link: AssocItemLink) -> fmt::Result {
     if let Some(s) = item.doc_value() {
         let markdown = if s.contains('\n') {
-            format!("{} [Read more]({})", &plain_summary_line(Some(s)), naive_assoc_href(item, link))
+            format!("{} [Read more]({})",
+                    &plain_summary_line(Some(s)), naive_assoc_href(item, link))
         } else {
             format!("{}", &plain_summary_line(Some(s)))
         };
@@ -2619,25 +2620,26 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
             _ => panic!("can't make docs for trait item with name {:?}", item.name)
         }
 
-        if !is_default_item && (!is_static || render_static) {
+        if !is_static || render_static {
+            if !is_default_item {
 
-            if item.doc_value().is_some() {
-                document(w, cx, item)
-            } else {
-                // In case the item isn't documented,
-                // provide short documentation from the trait
-                if let Some(t) = trait_ {
-                    if let Some(it) = t.items.iter()
-                                       .find(|i| i.name == item.name) {
-                        document_short(w, it, link)?;
+                if item.doc_value().is_some() {
+                    document(w, cx, item)?;
+                } else {
+                    // In case the item isn't documented,
+                    // provide short documentation from the trait
+                    if let Some(t) = trait_ {
+                        if let Some(it) = t.items.iter()
+                                           .find(|i| i.name == item.name) {
+                            document_short(w, it, link)?;
+                        }
                     }
                 }
-                Ok(())
+            } else {
+                document_short(w, item, link)?;
             }
-        } else {
-            document_short(w, item, link)?;
-            Ok(())
         }
+        Ok(())
     }
 
     let traits = &cache().traits;

--- a/src/test/rustdoc/manual_impl.rs
+++ b/src/test/rustdoc/manual_impl.rs
@@ -21,13 +21,24 @@ pub trait T {
     fn b_method(&self) -> usize {
         self.a_method()
     }
+
+    /// Docs associated with the trait c_method definition.
+    ///
+    /// There is another line
+    fn c_method(&self) -> usize {
+        self.a_method()
+    }
 }
 
 // @has manual_impl/struct.S1.html '//*[@class="trait"]' 'T'
 // @has  - '//*[@class="docblock"]' 'Docs associated with the S1 trait implementation.'
 // @has  - '//*[@class="docblock"]' 'Docs associated with the S1 trait a_method implementation.'
 // @!has - '//*[@class="docblock"]' 'Docs associated with the trait a_method definition.'
-// @!has - '//*[@class="docblock"]' 'Docs associated with the trait b_method definition.'
+// @has - '//*[@class="docblock"]' 'Docs associated with the trait b_method definition.'
+// @has - '//*[@class="docblock"]' 'Docs associated with the trait b_method definition.'
+// @has - '//*[@class="docblock"]' 'Docs associated with the trait c_method definition.'
+// @!has - '//*[@class="docblock"]' 'There is another line'
+// @has - '//*[@class="docblock"]' 'Read more'
 pub struct S1(usize);
 
 /// Docs associated with the S1 trait implementation.
@@ -41,9 +52,11 @@ impl T for S1 {
 // @has manual_impl/struct.S2.html '//*[@class="trait"]' 'T'
 // @has  - '//*[@class="docblock"]' 'Docs associated with the S2 trait implementation.'
 // @has  - '//*[@class="docblock"]' 'Docs associated with the S2 trait a_method implementation.'
-// @has  - '//*[@class="docblock"]' 'Docs associated with the S2 trait b_method implementation.'
+// @has  - '//*[@class="docblock"]' 'Docs associated with the S2 trait c_method implementation.'
 // @!has - '//*[@class="docblock"]' 'Docs associated with the trait a_method definition.'
-// @!has - '//*[@class="docblock"]' 'Docs associated with the trait b_method definition.'
+// @!has - '//*[@class="docblock"]' 'Docs associated with the trait c_method definition.'
+// @has - '//*[@class="docblock"]' 'Docs associated with the trait b_method definition.'
+// @!has - '//*[@class="docblock"]' 'Read more'
 pub struct S2(usize);
 
 /// Docs associated with the S2 trait implementation.
@@ -53,8 +66,8 @@ impl T for S2 {
         self.0
     }
 
-    /// Docs associated with the S2 trait b_method implementation.
-    fn b_method(&self) -> usize {
+    /// Docs associated with the S2 trait c_method implementation.
+    fn c_method(&self) -> usize {
         5
     }
 }
@@ -62,7 +75,7 @@ impl T for S2 {
 // @has manual_impl/struct.S3.html '//*[@class="trait"]' 'T'
 // @has  - '//*[@class="docblock"]' 'Docs associated with the S3 trait implementation.'
 // @has  - '//*[@class="docblock"]' 'Docs associated with the S3 trait b_method implementation.'
-// @!has - '//*[@class="docblock"]' 'Docs associated with the trait a_method definition.'
+// @has - '//*[@class="docblock"]' 'Docs associated with the trait a_method definition.'
 pub struct S3(usize);
 
 /// Docs associated with the S3 trait implementation.


### PR DESCRIPTION
The read more link only appears if the documentation is more than one line long.

![screenshot from 2016-05-17 06 54 14](https://cloud.githubusercontent.com/assets/1617736/15308544/4c2ba0ce-1bfc-11e6-9add-29de8dc7ac6e.png)

It currently does not appear on non-defaulted methods, since you can document them directly. I could make it so that default documentation gets forwarded if regular docs don't exist.

Fixes #33672

r? @alexcrichton 

cc @steveklabnik 
