### PR TITLE
Accept a LHS formed of a single sequence TT in `macro_rules!`.

### DIFF
--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -179,6 +179,7 @@ fn generic_extension<'cx>(cx: &'cx ExtCtxt,
     for (i, lhs) in lhses.iter().enumerate() { // try each arm's matchers
         let lhs_tt = match *lhs {
             TokenTree::Delimited(_, ref delim) => &delim.tts[..],
+            TokenTree::Sequence(..) => ref_slice(lhs),
             _ => cx.span_fatal(sp, "malformed macro lhs")
         };
 

--- a/src/test/run-pass/macro-lhs-sequence.rs
+++ b/src/test/run-pass/macro-lhs-sequence.rs
@@ -1,0 +1,17 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! foo(
+    $($i:ident),+ => ()
+);
+
+fn main() {
+    foo!(bar, baz);
+}


### PR DESCRIPTION
This is already accepted when checking that a macro definition is well-formed but not handled during expansion.

There is no reason to reject that since a sequence TT is a single TT.

This does not apply to macro RHSes, though, which must still be formed of a delimited TT. It would be cool to have it too, for consistency, but the purpose of this PR was to fix the inconsistency between macro definition checking and macro expansion, which was obviously a bug. Since a single sequence TT RHS is rejected in both places, I think it would be better to do a separate PR.
