### PR TITLE
introduce a specializes cache

### DIFF
--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -38,6 +38,7 @@ pub use self::select::{EvaluationCache, SelectionContext, SelectionCache};
 pub use self::select::{MethodMatchResult, MethodMatched, MethodAmbiguous, MethodDidNotMatch};
 pub use self::select::{MethodMatchedData}; // intentionally don't export variants
 pub use self::specialize::{OverlapError, specialization_graph, specializes, translate_substs};
+pub use self::specialize::{SpecializesCache};
 pub use self::util::elaborate_predicates;
 pub use self::util::supertraits;
 pub use self::util::Supertraits;

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -291,6 +291,8 @@ impl<'a, 'gcx, 'tcx> Deref for TyCtxt<'a, 'gcx, 'tcx> {
 pub struct GlobalCtxt<'tcx> {
     global_interners: CtxtInterners<'tcx>,
 
+    pub specializes_cache: RefCell<traits::SpecializesCache>,
+
     pub dep_graph: DepGraph,
 
     /// Common types, pre-interned for your convenience.
@@ -637,6 +639,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         let dep_graph = map.dep_graph.clone();
         let fulfilled_predicates = traits::GlobalFulfilledPredicates::new(dep_graph.clone());
         tls::enter_global(GlobalCtxt {
+            specializes_cache: RefCell::new(traits::SpecializesCache::new()),
             global_interners: interners,
             dep_graph: dep_graph.clone(),
             types: common_types,


### PR DESCRIPTION
This query is frequently used during trait selection and caching the
result can be a reasonable performance win.

The one case I examined thus far was the mrusty package (v0.5.1), where I saw an improvement in "typeck item bodies" from ~8.3s to ~1.9s.

r? @aturon 
