### PR TITLE
Add regression tests for error message when using enum variant as a type

### DIFF
--- a/src/test/compile-fail/variant-used-as-type.rs
+++ b/src/test/compile-fail/variant-used-as-type.rs
@@ -1,0 +1,30 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test error message when enum variants are used as types
+
+
+// issue 21225
+enum Ty {
+    A,
+    B(Ty::A),
+    //~^ ERROR: found value `Ty::A` used as a type
+}
+
+
+// issue 19197
+enum E {
+    A
+}
+
+impl E::A {}
+//~^ ERROR: found value `E::A` used as a type
+
+fn main() {}


### PR DESCRIPTION
I'm guessing these were actually fixed with PR #27085.

Closes #21225
Closes #19197
