### PR TITLE
Resolved rustdoc crash (#33678) by aborting instead of unwrapping.

### DIFF
--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -172,9 +172,8 @@ pub fn run_core(search_paths: SearchPaths,
                                                      &arenas,
                                                      &name,
                                                      |tcx, _, analysis, result| {
-        // Return if the driver hit an err (in `result`)
         if let Err(_) = result {
-            return None
+            sess.fatal("Compilation failed, aborting rustdoc");
         }
 
         let _ignore = tcx.dep_graph.in_ignore();
@@ -206,6 +205,6 @@ pub fn run_core(search_paths: SearchPaths,
             v.clean(&ctxt)
         };
 
-        Some((krate, ctxt.renderinfo.into_inner()))
-    }), &sess).unwrap()
+        (krate, ctxt.renderinfo.into_inner())
+    }), &sess)
 }


### PR DESCRIPTION
Also removed Option use and comment to match.

Fixes https://github.com/rust-lang/rust/issues/33678
