### PR TITLE
Perform `cfg` attribute processing during macro expansion and fix bugs

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -720,16 +720,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
         ret
     });
 
-    // JBC: make CFG processing part of expansion to avoid this problem:
-
-    // strip again, in case expansion added anything with a #[cfg].
     krate = sess.track_errors(|| {
-        let krate = time(time_passes, "configuration 2", || {
-            syntax::config::strip_unconfigured_items(sess.diagnostic(),
-                                                     krate,
-                                                     &mut feature_gated_cfgs)
-        });
-
         time(time_passes, "gated configuration checking", || {
             let features = sess.features.borrow();
             feature_gated_cfgs.sort();

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -15,7 +15,7 @@ pub use self::UnsafeSource::*;
 pub use self::ViewPath_::*;
 pub use self::PathParameters::*;
 
-use attr::ThinAttributes;
+use attr::{ThinAttributes, HasAttrs};
 use codemap::{mk_sp, respan, Span, Spanned, DUMMY_SP, ExpnId};
 use abi::Abi;
 use errors;
@@ -829,13 +829,7 @@ impl StmtKind {
     }
 
     pub fn attrs(&self) -> &[Attribute] {
-        match *self {
-            StmtKind::Decl(ref d, _) => d.attrs(),
-            StmtKind::Expr(ref e, _) |
-            StmtKind::Semi(ref e, _) => e.attrs(),
-            StmtKind::Mac(_, _, Some(ref b)) => b,
-            StmtKind::Mac(_, _, None) => &[],
-        }
+        HasAttrs::attrs(self)
     }
 }
 
@@ -868,10 +862,7 @@ pub struct Local {
 
 impl Local {
     pub fn attrs(&self) -> &[Attribute] {
-        match self.attrs {
-            Some(ref b) => b,
-            None => &[],
-        }
+        HasAttrs::attrs(self)
     }
 }
 
@@ -887,10 +878,7 @@ pub enum DeclKind {
 
 impl Decl {
     pub fn attrs(&self) -> &[Attribute] {
-        match self.node {
-            DeclKind::Local(ref l) => l.attrs(),
-            DeclKind::Item(ref i) => i.attrs(),
-        }
+        HasAttrs::attrs(self)
     }
 }
 
@@ -935,10 +923,7 @@ pub struct Expr {
 
 impl Expr {
     pub fn attrs(&self) -> &[Attribute] {
-        match self.attrs {
-            Some(ref b) => b,
-            None => &[],
-        }
+        HasAttrs::attrs(self)
     }
 }
 

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -1258,31 +1258,6 @@ impl CodeMap {
         return a;
     }
 
-    /// Check if the backtrace `subtrace` contains `suptrace` as a prefix.
-    pub fn more_specific_trace(&self,
-                              mut subtrace: ExpnId,
-                              suptrace: ExpnId)
-                              -> bool {
-        loop {
-            if subtrace == suptrace {
-                return true;
-            }
-
-            let stop = self.with_expn_info(subtrace, |opt_expn_info| {
-                if let Some(expn_info) = opt_expn_info {
-                    subtrace = expn_info.call_site.expn_id;
-                    false
-                } else {
-                    true
-                }
-            });
-
-            if stop {
-                return false;
-            }
-        }
-    }
-
     pub fn record_expansion(&self, expn_info: ExpnInfo) -> ExpnId {
         let mut expansions = self.expansions.borrow_mut();
         expansions.push(expn_info);

--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -13,7 +13,6 @@ use errors::Handler;
 use feature_gate::GatedCfgAttr;
 use fold::Folder;
 use {ast, fold, attr};
-use visit;
 use codemap::{Spanned, respan};
 use ptr::P;
 
@@ -21,6 +20,7 @@ use util::small_vector::SmallVector;
 
 pub trait CfgFolder: fold::Folder {
     fn configure<T: HasAttrs>(&mut self, node: T) -> Option<T>;
+    fn visit_stmt_or_expr_attrs(&mut self, _attrs: &[ast::Attribute]) {}
     fn visit_unconfigurable_expr(&mut self, _expr: &ast::Expr) {}
 }
 
@@ -31,12 +31,76 @@ pub struct StripUnconfigured<'a> {
     config: &'a ast::CrateConfig,
 }
 
-impl<'a> CfgFolder for StripUnconfigured<'a> {
-    fn configure<T: HasAttrs>(&mut self, node: T) -> Option<T> {
-        if in_cfg(self.config, node.attrs(), &mut self.diag) {
-            Some(node)
+impl<'a> StripUnconfigured<'a> {
+    // Determine if an item should be translated in the current crate
+    // configuration based on the item's attributes
+    fn in_cfg(&mut self, attrs: &[ast::Attribute]) -> bool {
+        attrs.iter().all(|attr| {
+            let mis = match attr.node.value.node {
+                ast::MetaItemKind::List(_, ref mis) if is_cfg(&attr) => mis,
+                _ => return true
+            };
+
+            if mis.len() != 1 {
+                self.diag.emit_error(|diagnostic| {
+                    diagnostic.span_err(attr.span, "expected 1 cfg-pattern");
+                });
+                return true;
+            }
+
+            attr::cfg_matches(self.config, &mis[0], &mut self.diag)
+        })
+    }
+
+    fn process_cfg_attrs(&mut self, attrs: Vec<ast::Attribute>) -> Vec<ast::Attribute> {
+        attrs.into_iter().filter_map(|attr| self.process_cfg_attr(attr)).collect()
+    }
+
+    fn process_cfg_attr(&mut self, attr: ast::Attribute) -> Option<ast::Attribute> {
+        if !attr.check_name("cfg_attr") {
+            return Some(attr);
+        }
+
+        let attr_list = match attr.meta_item_list() {
+            Some(attr_list) => attr_list,
+            None => {
+                let msg = "expected `#[cfg_attr(<cfg pattern>, <attr>)]`";
+                self.diag.diag.span_err(attr.span, msg);
+                return None;
+            }
+        };
+        let (cfg, mi) = match (attr_list.len(), attr_list.get(0), attr_list.get(1)) {
+            (2, Some(cfg), Some(mi)) => (cfg, mi),
+            _ => {
+                let msg = "expected `#[cfg_attr(<cfg pattern>, <attr>)]`";
+                self.diag.diag.span_err(attr.span, msg);
+                return None;
+            }
+        };
+
+        if attr::cfg_matches(self.config, &cfg, &mut self.diag) {
+            Some(respan(mi.span, ast::Attribute_ {
+                id: attr::mk_attr_id(),
+                style: attr.node.style,
+                value: mi.clone(),
+                is_sugared_doc: false,
+            }))
         } else {
             None
+        }
+    }
+}
+
+impl<'a> CfgFolder for StripUnconfigured<'a> {
+    fn configure<T: HasAttrs>(&mut self, node: T) -> Option<T> {
+        let node = node.map_attrs(|attrs| self.process_cfg_attrs(attrs));
+        if self.in_cfg(node.attrs()) { Some(node) } else { None }
+    }
+
+    fn visit_stmt_or_expr_attrs(&mut self, attrs: &[ast::Attribute]) {
+        // flag the offending attributes
+        for attr in attrs.iter() {
+            self.diag.feature_gated_cfgs.push(GatedCfgAttr::GatedAttr(attr.span));
         }
     }
 
@@ -54,11 +118,6 @@ pub fn strip_unconfigured_items(diagnostic: &Handler, krate: ast::Crate,
                                 feature_gated_cfgs: &mut Vec<GatedCfgAttr>)
                                 -> ast::Crate
 {
-    // Need to do this check here because cfg runs before feature_gates
-    check_for_gated_stmt_expr_attributes(&krate, feature_gated_cfgs);
-
-    let krate = process_cfg_attr(diagnostic, krate, feature_gated_cfgs);
-
     StripUnconfigured {
         config: &krate.config.clone(),
         diag: CfgDiagReal {
@@ -72,7 +131,9 @@ impl<T: CfgFolder> fold::Folder for T {
     fn fold_foreign_mod(&mut self, foreign_mod: ast::ForeignMod) -> ast::ForeignMod {
         ast::ForeignMod {
             abi: foreign_mod.abi,
-            items: foreign_mod.items.into_iter().filter_map(|item| self.configure(item)).collect(),
+            items: foreign_mod.items.into_iter().filter_map(|item| {
+                self.configure(item).map(|item| fold::noop_fold_foreign_item(item, self))
+            }).collect(),
         }
     }
 
@@ -126,6 +187,7 @@ impl<T: CfgFolder> fold::Folder for T {
     }
 
     fn fold_expr(&mut self, expr: P<ast::Expr>) -> P<ast::Expr> {
+        self.visit_stmt_or_expr_attrs(expr.attrs());
         // If an expr is valid to cfg away it will have been removed by the
         // outer stmt or expression folder before descending in here.
         // Anything else is always required, and thus has to error out
@@ -142,6 +204,19 @@ impl<T: CfgFolder> fold::Folder for T {
     }
 
     fn fold_stmt(&mut self, stmt: ast::Stmt) -> SmallVector<ast::Stmt> {
+        let is_item = match stmt.node {
+            ast::StmtKind::Decl(ref decl, _) => match decl.node {
+                ast::DeclKind::Item(_) => true,
+                _ => false,
+            },
+            _ => false,
+        };
+
+        // avoid calling `visit_stmt_or_expr_attrs` on items
+        if !is_item {
+            self.visit_stmt_or_expr_attrs(stmt.attrs());
+        }
+
         self.configure(stmt).map(|stmt| fold::noop_fold_stmt(stmt, self))
                             .unwrap_or(SmallVector::zero())
     }
@@ -178,205 +253,6 @@ fn is_cfg(attr: &ast::Attribute) -> bool {
     attr.check_name("cfg")
 }
 
-// Determine if an item should be translated in the current crate
-// configuration based on the item's attributes
-fn in_cfg<T: CfgDiag>(cfg: &[P<ast::MetaItem>],
-                      attrs: &[ast::Attribute],
-                      diag: &mut T) -> bool {
-    attrs.iter().all(|attr| {
-        let mis = match attr.node.value.node {
-            ast::MetaItemKind::List(_, ref mis) if is_cfg(&attr) => mis,
-            _ => return true
-        };
-
-        if mis.len() != 1 {
-            diag.emit_error(|diagnostic| {
-                diagnostic.span_err(attr.span, "expected 1 cfg-pattern");
-            });
-            return true;
-        }
-
-        attr::cfg_matches(cfg, &mis[0], diag)
-    })
-}
-
-struct CfgAttrFolder<'a, T> {
-    diag: T,
-    config: &'a ast::CrateConfig,
-}
-
-// Process `#[cfg_attr]`.
-fn process_cfg_attr(diagnostic: &Handler, krate: ast::Crate,
-                    feature_gated_cfgs: &mut Vec<GatedCfgAttr>) -> ast::Crate {
-    let mut fld = CfgAttrFolder {
-        diag: CfgDiagReal {
-            diag: diagnostic,
-            feature_gated_cfgs: feature_gated_cfgs,
-        },
-        config: &krate.config.clone(),
-    };
-    fld.fold_crate(krate)
-}
-
-impl<'a, T: CfgDiag> fold::Folder for CfgAttrFolder<'a, T> {
-    fn fold_attribute(&mut self, attr: ast::Attribute) -> Option<ast::Attribute> {
-        if !attr.check_name("cfg_attr") {
-            return fold::noop_fold_attribute(attr, self);
-        }
-
-        let attr_list = match attr.meta_item_list() {
-            Some(attr_list) => attr_list,
-            None => {
-                self.diag.emit_error(|diag| {
-                    diag.span_err(attr.span,
-                        "expected `#[cfg_attr(<cfg pattern>, <attr>)]`");
-                });
-                return None;
-            }
-        };
-        let (cfg, mi) = match (attr_list.len(), attr_list.get(0), attr_list.get(1)) {
-            (2, Some(cfg), Some(mi)) => (cfg, mi),
-            _ => {
-                self.diag.emit_error(|diag| {
-                    diag.span_err(attr.span,
-                        "expected `#[cfg_attr(<cfg pattern>, <attr>)]`");
-                });
-                return None;
-            }
-        };
-
-        if attr::cfg_matches(&self.config[..], &cfg, &mut self.diag) {
-            Some(respan(mi.span, ast::Attribute_ {
-                id: attr::mk_attr_id(),
-                style: attr.node.style,
-                value: mi.clone(),
-                is_sugared_doc: false,
-            }))
-        } else {
-            None
-        }
-    }
-
-    // Need the ability to run pre-expansion.
-    fn fold_mac(&mut self, mac: ast::Mac) -> ast::Mac {
-        fold::noop_fold_mac(mac, self)
-    }
-}
-
-fn check_for_gated_stmt_expr_attributes(krate: &ast::Crate,
-                                        discovered: &mut Vec<GatedCfgAttr>) {
-    let mut v = StmtExprAttrFeatureVisitor {
-        config: &krate.config,
-        discovered: discovered,
-    };
-    visit::walk_crate(&mut v, krate);
-}
-
-/// To cover this feature, we need to discover all attributes
-/// so we need to run before cfg.
-struct StmtExprAttrFeatureVisitor<'a, 'b> {
-    config: &'a ast::CrateConfig,
-    discovered: &'b mut Vec<GatedCfgAttr>,
-}
-
-// Runs the cfg_attr and cfg folders locally in "silent" mode
-// to discover attribute use on stmts or expressions ahead of time
-impl<'v, 'a, 'b> visit::Visitor<'v> for StmtExprAttrFeatureVisitor<'a, 'b> {
-    fn visit_stmt(&mut self, s: &'v ast::Stmt) {
-        // check if there even are any attributes on this node
-        let stmt_attrs = s.node.attrs();
-        if stmt_attrs.len() > 0 {
-            // attributes on items are fine
-            if let ast::StmtKind::Decl(ref decl, _) = s.node {
-                if let ast::DeclKind::Item(_) = decl.node {
-                    visit::walk_stmt(self, s);
-                    return;
-                }
-            }
-
-            // flag the offending attributes
-            for attr in stmt_attrs {
-                self.discovered.push(GatedCfgAttr::GatedAttr(attr.span));
-            }
-
-            // if the node does not end up being cfg-d away, walk down
-            if node_survives_cfg(stmt_attrs, self.config) {
-                visit::walk_stmt(self, s);
-            }
-        } else {
-            visit::walk_stmt(self, s);
-        }
-    }
-
-    fn visit_expr(&mut self, ex: &'v ast::Expr) {
-        // check if there even are any attributes on this node
-        let expr_attrs = ex.attrs();
-        if expr_attrs.len() > 0 {
-
-            // flag the offending attributes
-            for attr in expr_attrs {
-                self.discovered.push(GatedCfgAttr::GatedAttr(attr.span));
-            }
-
-            // if the node does not end up being cfg-d away, walk down
-            if node_survives_cfg(expr_attrs, self.config) {
-                visit::walk_expr(self, ex);
-            }
-        } else {
-            visit::walk_expr(self, ex);
-        }
-    }
-
-    fn visit_foreign_item(&mut self, i: &'v ast::ForeignItem) {
-        if node_survives_cfg(&i.attrs, self.config) {
-            visit::walk_foreign_item(self, i);
-        }
-    }
-
-    fn visit_item(&mut self, i: &'v ast::Item) {
-        if node_survives_cfg(&i.attrs, self.config) {
-            visit::walk_item(self, i);
-        }
-    }
-
-    fn visit_impl_item(&mut self, ii: &'v ast::ImplItem) {
-        if node_survives_cfg(&ii.attrs, self.config) {
-            visit::walk_impl_item(self, ii);
-        }
-    }
-
-    fn visit_trait_item(&mut self, ti: &'v ast::TraitItem) {
-        if node_survives_cfg(&ti.attrs, self.config) {
-            visit::walk_trait_item(self, ti);
-        }
-    }
-
-    fn visit_struct_field(&mut self, s: &'v ast::StructField) {
-        if node_survives_cfg(&s.attrs, self.config) {
-            visit::walk_struct_field(self, s);
-        }
-    }
-
-    fn visit_variant(&mut self, v: &'v ast::Variant,
-                     g: &'v ast::Generics, item_id: ast::NodeId) {
-        if node_survives_cfg(&v.node.attrs, self.config) {
-            visit::walk_variant(self, v, g, item_id);
-        }
-    }
-
-    fn visit_arm(&mut self, a: &'v ast::Arm) {
-        if node_survives_cfg(&a.attrs, self.config) {
-            visit::walk_arm(self, a);
-        }
-    }
-
-    // This visitor runs pre expansion, so we need to prevent
-    // the default panic here
-    fn visit_mac(&mut self, mac: &'v ast::Mac) {
-        visit::walk_mac(self, mac)
-    }
-}
-
 pub trait CfgDiag {
     fn emit_error<F>(&mut self, f: F) where F: FnMut(&Handler);
     fn flag_gated<F>(&mut self, f: F) where F: FnMut(&mut Vec<GatedCfgAttr>);
@@ -394,42 +270,4 @@ impl<'a, 'b> CfgDiag for CfgDiagReal<'a, 'b> {
     fn flag_gated<F>(&mut self, mut f: F) where F: FnMut(&mut Vec<GatedCfgAttr>) {
         f(self.feature_gated_cfgs)
     }
-}
-
-struct CfgDiagSilent {
-    error: bool,
-}
-
-impl CfgDiag for CfgDiagSilent {
-    fn emit_error<F>(&mut self, _: F) where F: FnMut(&Handler) {
-        self.error = true;
-    }
-    fn flag_gated<F>(&mut self, _: F) where F: FnMut(&mut Vec<GatedCfgAttr>) {}
-}
-
-fn node_survives_cfg(attrs: &[ast::Attribute],
-                     config: &ast::CrateConfig) -> bool {
-    let mut survives_cfg = true;
-
-    for attr in attrs {
-        let mut fld = CfgAttrFolder {
-            diag: CfgDiagSilent { error: false },
-            config: config,
-        };
-        let attr = fld.fold_attribute(attr.clone());
-
-        // In case of error we can just return true,
-        // since the actual cfg folders will end compilation anyway.
-
-        if fld.diag.error { return true; }
-
-        survives_cfg &= attr.map(|attr| {
-            let mut diag = CfgDiagSilent { error: false };
-            let r = in_cfg(config, &[attr], &mut diag);
-            if diag.error { return true; }
-            r
-        }).unwrap_or(true)
-    }
-
-    survives_cfg
 }

--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -19,9 +19,16 @@ use ptr::P;
 use util::small_vector::SmallVector;
 
 pub trait CfgFolder: fold::Folder {
+    // Check if a node with the given attributes is in this configuration.
     fn in_cfg(&mut self, attrs: &[ast::Attribute]) -> bool;
+
+    // Update a node before checking if it is in this configuration (used to implement `cfg_attr`).
     fn process_attrs<T: HasAttrs>(&mut self, node: T) -> T { node }
+
+    // Visit attributes on expression and statements (but not attributes on items in blocks).
     fn visit_stmt_or_expr_attrs(&mut self, _attrs: &[ast::Attribute]) {}
+
+    // Visit unremovable (non-optional) expressions -- c.f. `fold_expr` vs `fold_opt_expr`.
     fn visit_unremovable_expr(&mut self, _expr: &ast::Expr) {}
 
     fn configure<T: HasAttrs>(&mut self, node: T) -> Option<T> {

--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -38,6 +38,16 @@ pub struct StripUnconfigured<'a> {
 }
 
 impl<'a> StripUnconfigured<'a> {
+    pub fn new(config: &'a ast::CrateConfig,
+               diagnostic: &'a Handler,
+               feature_gated_cfgs: &'a mut Vec<GatedCfgAttr>)
+               -> Self {
+        StripUnconfigured {
+            config: config,
+            diag: CfgDiagReal { diag: diagnostic, feature_gated_cfgs: feature_gated_cfgs },
+        }
+    }
+
     fn process_cfg_attr(&mut self, attr: ast::Attribute) -> Option<ast::Attribute> {
         if !attr.check_name("cfg_attr") {
             return Some(attr);
@@ -121,13 +131,8 @@ pub fn strip_unconfigured_items(diagnostic: &Handler, krate: ast::Crate,
                                 feature_gated_cfgs: &mut Vec<GatedCfgAttr>)
                                 -> ast::Crate
 {
-    StripUnconfigured {
-        config: &krate.config.clone(),
-        diag: CfgDiagReal {
-            diag: diagnostic,
-            feature_gated_cfgs: feature_gated_cfgs,
-        },
-    }.fold_crate(krate)
+    let config = &krate.config.clone();
+    StripUnconfigured::new(config, diagnostic, feature_gated_cfgs).fold_crate(krate)
 }
 
 impl<T: CfgFolder> fold::Folder for T {

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -317,13 +317,8 @@ fn strip_test_functions(krate: ast::Crate) -> ast::Crate {
     // #[test] functions
     struct StripTests;
     impl config::CfgFolder for StripTests {
-        fn configure<T: attr::HasAttrs>(&mut self, node: T) -> Option<T> {
-            let strip_node = {
-                let attrs = node.attrs();
-                attr::contains_name(attrs, "test") || attr::contains_name(attrs, "bench")
-            };
-
-            if strip_node { None } else { Some(node) }
+        fn in_cfg(&mut self, attrs: &[ast::Attribute]) -> bool {
+            !attr::contains_name(attrs, "test") && !attr::contains_name(attrs, "bench")
         }
     }
 

--- a/src/test/compile-fail/expanded-cfg.rs
+++ b/src/test/compile-fail/expanded-cfg.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(rustc_attrs)]
+#![feature(custom_attribute, rustc_attrs)]
 
 macro_rules! mac {
     {} => {
@@ -16,6 +16,9 @@ macro_rules! mac {
         mod m {
             #[lang_item]
             fn f() {}
+
+            #[cfg_attr(target_thread_local, custom)]
+            fn g() {}
         }
     }
 }

--- a/src/test/compile-fail/expanded-cfg.rs
+++ b/src/test/compile-fail/expanded-cfg.rs
@@ -20,6 +20,9 @@ macro_rules! mac {
             #[cfg_attr(target_thread_local, custom)]
             fn g() {}
         }
+
+        #[cfg(attr)]
+        unconfigured_invocation!();
     }
 }
 


### PR DESCRIPTION
This PR refactors `cfg` attribute processing and fixes bugs. More specifically:
- It merges gated feature checking for stmt/expr attributes, `cfg_attr` processing, and `cfg` processing into a single fold.
  - This allows feature gated `cfg` variables to be used in `cfg_attr` on unconfigured items. All other feature gated attributes can already be used on unconfigured items.
- It performs `cfg` attribute processing during macro expansion instead of after expansion so that macro-expanded items are configured the same as ordinary items. In particular, to match their non-expanded counterparts,
  - macro-expanded unconfigured macro invocations are no longer expanded,
  - macro-expanded unconfigured macro definitions are no longer usable, and
  - feature gated `cfg` variables on macro-expanded macro definitions/invocations are now errors.

This is a [breaking-change]. For example, the following would break:

``` rust
macro_rules! m {
    () => {
        #[cfg(attr)]
        macro_rules! foo { () => {} }
        foo!(); // This will be an error

        macro_rules! bar { () => { fn f() {} } }
        #[cfg(attr)] bar!(); // This will no longer be expanded ...
        fn g() { f(); } // ... so that `f` will be unresolved.

        #[cfg(target_thread_local)] // This will be a gated feature error
        macro_rules! baz { () => {} }
    }
}

m!();
```

**EDIT:** fixes #22250, fixes #31369.

r? @nrc 
