### PR TITLE
Fix bug in macro expression spans

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -70,15 +70,9 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
 
             // Keep going, outside-in.
             let fully_expanded = fld.fold_expr(expanded_expr);
-            let span = fld.new_span(span);
             fld.cx.bt_pop();
 
-            fully_expanded.map(|e| ast::Expr {
-                id: ast::DUMMY_NODE_ID,
-                node: e.node,
-                span: span,
-                attrs: e.attrs,
-            })
+            fully_expanded
         }
 
         ast::ExprKind::InPlace(placer, value_expr) => {

--- a/src/test/compile-fail/borrowck/borrowck-borrowed-uniq-rvalue-2.rs
+++ b/src/test/compile-fail/borrowck/borrowck-borrowed-uniq-rvalue-2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// error-pattern: borrowed value does not live long enough
+
 struct defer<'a> {
     x: &'a [&'a str],
 }
@@ -28,6 +30,5 @@ fn defer<'r>(x: &'r [&'r str]) -> defer<'r> {
 
 fn main() {
     let x = defer(&vec!("Goodbye", "world!"));
-    //~^ ERROR borrowed value does not live long enough
     x.x[0];
 }

--- a/src/test/compile-fail/issue-15167.rs
+++ b/src/test/compile-fail/issue-15167.rs
@@ -11,22 +11,26 @@
 // macro f should not be able to inject a reference to 'n'.
 
 macro_rules! f { () => (n) }
+//~^ ERROR unresolved name `n`
+//~| ERROR unresolved name `n`
+//~| ERROR unresolved name `n`
+//~| ERROR unresolved name `n`
 
 fn main() -> (){
     for n in 0..1 {
-        println!("{}", f!()); //~ ERROR unresolved name `n`
+        println!("{}", f!());
     }
 
     if let Some(n) = None {
-        println!("{}", f!()); //~ ERROR unresolved name `n`
+        println!("{}", f!());
     }
 
     if false {
     } else if let Some(n) = None {
-        println!("{}", f!()); //~ ERROR unresolved name `n`
+        println!("{}", f!());
     }
 
     while let Some(n) = None {
-        println!("{}", f!()); //~ ERROR unresolved name `n`
+        println!("{}", f!());
     }
 }

--- a/src/test/compile-fail/macro-backtrace-invalid-internals.rs
+++ b/src/test/compile-fail/macro-backtrace-invalid-internals.rs
@@ -36,13 +36,13 @@ macro_rules! fake_method_expr {
 
 macro_rules! fake_field_expr {
      () => {
-          1.fake
+          1.fake //~ ERROR no field with that name
      }
 }
 
 macro_rules! fake_anon_field_expr {
      () => {
-          (1).0
+          (1).0 //~ ERROR type was not a tuple
      }
 }
 
@@ -52,8 +52,6 @@ fn main() {
     fake_anon_field_stmt!(); //~ NOTE in this expansion of
 
     let _ = fake_method_expr!(); //~ NOTE in this expansion of
-    let _ = fake_field_expr!(); //~ ERROR no field with that name
-                                //~^ NOTE in this expansion of
-    let _ = fake_anon_field_expr!(); //~ ERROR type was not a tuple
-                                     //~^ NOTE in this expansion of
+    let _ = fake_field_expr!(); //~ NOTE in this expansion of
+    let _ = fake_anon_field_expr!(); //~ NOTE in this expansion of
 }

--- a/src/test/compile-fail/macro-backtrace-nested.rs
+++ b/src/test/compile-fail/macro-backtrace-nested.rs
@@ -12,20 +12,19 @@
 // we replace the span of the expanded expression with that of the call site.
 
 macro_rules! nested_expr {
-    () => (fake)
+    () => (fake) //~ ERROR unresolved name
+                 //~^ ERROR unresolved name
 }
 
 macro_rules! call_nested_expr {
-    () => (nested_expr!())
+    () => (nested_expr!()) //~ NOTE in this expansion of nested_expr!
 }
 
 macro_rules! call_nested_expr_sum {
-    () => { 1 + nested_expr!(); } //~ ERROR unresolved name
-                                  //~^ NOTE in this expansion of nested_expr!
+    () => { 1 + nested_expr!(); } //~ NOTE in this expansion of nested_expr!
 }
 
 fn main() {
-    1 + call_nested_expr!(); //~ ERROR unresolved name
-                             //~^ NOTE in this expansion of call_nested_expr!
+    1 + call_nested_expr!(); //~ NOTE in this expansion of call_nested_expr!
     call_nested_expr_sum!(); //~ NOTE in this expansion of
 }

--- a/src/test/compile-fail/macro-backtrace-println.rs
+++ b/src/test/compile-fail/macro-backtrace-println.rs
@@ -21,11 +21,11 @@ macro_rules! myprint {
 }
 
 macro_rules! myprintln {
-    ($fmt:expr) => (myprint!(concat!($fmt, "\n"))); //~ ERROR invalid reference to argument `0`
-                                                    //~^ NOTE in this expansion of myprint!
-                                                    //~^^ NOTE in this expansion of concat!
+    ($fmt:expr) => (myprint!(concat!($fmt, "\n"))); //~ NOTE in this expansion of myprint!
+                                                    //~^ NOTE in this expansion of concat!
 }
 
 fn main() {
-    myprintln!("{}"); //~ NOTE in this expansion of
+    myprintln!("{}"); //~ ERROR invalid reference to argument `0`
+                      //~^ NOTE in this expansion of
 }


### PR DESCRIPTION
Fix a bug in macro expression spans.
r? @nrc 
