### PR TITLE
Clarified that `let(mut x, y) =` only makes x mutable, not y

### DIFF
--- a/src/doc/book/mutability.md
+++ b/src/doc/book/mutability.md
@@ -55,6 +55,8 @@ fn foo(mut x: i32) {
 # }
 ```
 
+Note that here, the `x` is mutable, but not the `y`.
+
 [pattern]: patterns.html
 
 # Interior vs. Exterior Mutability


### PR DESCRIPTION
Closes #33716 
