### PR TITLE
Rust syntax coloring for some ignore, should-panic and no-run snippets.

### DIFF
--- a/src/doc/book/advanced-linking.md
+++ b/src/doc/book/advanced-linking.md
@@ -12,7 +12,7 @@ the `link_args` attribute. This attribute is applied to `extern` blocks and
 specifies raw flags which need to get passed to the linker when producing an
 artifact. An example usage would be:
 
-``` no_run
+```rust,no_run
 #![feature(link_args)]
 
 #[link_args = "-foo -bar -baz"]
@@ -52,7 +52,7 @@ By default, all Rust programs on Linux will link to the system `libc` along with
 a number of other libraries. Let's look at an example on a 64-bit Linux machine
 with GCC and `glibc` (by far the most common `libc` on Linux):
 
-``` text
+```text
 $ cat example.rs
 fn main() {}
 $ rustc example.rs

--- a/src/doc/book/closures.md
+++ b/src/doc/book/closures.md
@@ -344,7 +344,7 @@ assert_eq!(2, answer);
 In this example, we don’t strictly need the intermediate variable `f`,
 the name of the function works just fine too:
 
-```ignore
+```rust,ignore
 let answer = call_with_one(&add_one);
 ```
 

--- a/src/doc/book/compiler-plugins.md
+++ b/src/doc/book/compiler-plugins.md
@@ -37,7 +37,7 @@ Let's write a plugin
 [`roman_numerals.rs`](https://github.com/rust-lang/rust/tree/master/src/test/auxiliary/roman_numerals.rs)
 that implements Roman numeral integer literals.
 
-```ignore
+```rust,ignore
 #![crate_type="dylib"]
 #![feature(plugin_registrar, rustc_private)]
 
@@ -102,7 +102,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
 
 Then we can use `rn!()` like any other macro:
 
-```ignore
+```rust,ignore
 #![feature(plugin)]
 #![plugin(roman_numerals)]
 
@@ -132,7 +132,7 @@ Some of the [macro debugging tips](macros.html#debugging-macro-code) are applica
 You can use `syntax::parse` to turn token trees into
 higher-level syntax elements like expressions:
 
-```ignore
+```rust,ignore
 fn expand_foo(cx: &mut ExtCtxt, sp: Span, args: &[TokenTree])
         -> Box<MacResult+'static> {
 
@@ -169,7 +169,7 @@ infrastructure](../reference.html#lint-check-attributes) with additional checks 
 code style, safety, etc. Now let's write a plugin [`lint_plugin_test.rs`](https://github.com/rust-lang/rust/blob/master/src/test/auxiliary/lint_plugin_test.rs)
 that warns about any item named `lintme`.
 
-```ignore
+```rust,ignore
 #![feature(plugin_registrar)]
 #![feature(box_syntax, rustc_private)]
 
@@ -211,7 +211,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
 
 Then code like
 
-```ignore
+```rust,ignore
 #![plugin(lint_plugin_test)]
 
 fn lintme() { }

--- a/src/doc/book/concurrency.md
+++ b/src/doc/book/concurrency.md
@@ -165,7 +165,7 @@ concurrency bugs.
 As an example, here is a Rust program that would have a data race in many
 languages. It will not compile:
 
-```ignore
+```rust,ignore
 use std::thread;
 use std::time::Duration;
 
@@ -204,7 +204,7 @@ Calling `clone()` on an `Rc<T>` will return a new owned reference and bump the
 internal reference count. We create one of these for each thread:
 
 
-```ignore
+```rust,ignore
 use std::thread;
 use std::time::Duration;
 use std::rc::Rc;
@@ -250,7 +250,7 @@ In essence, `Arc<T>` is a type that lets us share ownership of data _across
 threads_.
 
 
-```ignore
+```rust,ignore
 use std::thread;
 use std::sync::Arc;
 use std::time::Duration;
@@ -336,7 +336,7 @@ The lock "release" here is implicit; when the result of the lock (in this case,
 Note that [`lock`](../std/sync/struct.Mutex.html#method.lock) method of
 [`Mutex`](../std/sync/struct.Mutex.html) has this signature:
 
-```ignore
+```rust,ignore
 fn lock(&self) -> LockResult<MutexGuard<T>>
 ```
 

--- a/src/doc/book/documentation.md
+++ b/src/doc/book/documentation.md
@@ -362,7 +362,7 @@ Here’s an example of documenting a macro:
 /// # }
 /// ```
 ///
-/// ```should_panic
+/// ```rust,should_panic
 /// # #[macro_use] extern crate foo;
 /// # fn main() {
 /// panic_unless!(true == false, “I’m broken.”);
@@ -429,7 +429,7 @@ There are a few more annotations that are useful to help `rustdoc` do the right
 thing when testing your code:
 
 ```rust
-/// ```ignore
+/// ```rust,ignore
 /// fn foo() {
 /// ```
 # fn foo() {}
@@ -441,7 +441,7 @@ with `text` if it's not code, or using `#`s to get a working example that
 only shows the part you care about.
 
 ```rust
-/// ```should_panic
+/// ```rust,should_panic
 /// assert!(false);
 /// ```
 # fn foo() {}
@@ -451,7 +451,7 @@ only shows the part you care about.
 not actually pass as a test.
 
 ```rust
-/// ```no_run
+/// ```rust,no_run
 /// loop {
 ///     println!("Hello, world");
 /// }
@@ -563,7 +563,7 @@ can be useful when changing some options, or when writing a macro.
 
 `rustdoc` will show the documentation for a public re-export in both places:
 
-```ignore
+```rust,ignore
 extern crate foo;
 
 pub use foo::bar;
@@ -575,7 +575,7 @@ documentation in both places.
 
 This behavior can be suppressed with `no_inline`:
 
-```ignore
+```rust,ignore
 extern crate foo;
 
 #[doc(no_inline)]

--- a/src/doc/book/ffi.md
+++ b/src/doc/book/ffi.md
@@ -28,7 +28,7 @@ and add `extern crate libc;` to your crate root.
 The following is a minimal example of calling a foreign function which will
 compile if snappy is installed:
 
-```no_run
+```rust,no_run
 # #![feature(libc)]
 extern crate libc;
 use libc::size_t;
@@ -62,7 +62,7 @@ keeping the binding correct at runtime.
 
 The `extern` block can be extended to cover the entire snappy API:
 
-```no_run
+```rust,no_run
 # #![feature(libc)]
 extern crate libc;
 use libc::{c_int, size_t};
@@ -209,7 +209,7 @@ A basic example is:
 
 Rust code:
 
-```no_run
+```rust,no_run
 extern fn callback(a: i32) {
     println!("I'm called from C with value {0}", a);
 }
@@ -262,7 +262,7 @@ referenced Rust object.
 
 Rust code:
 
-```no_run
+```rust,no_run
 #[repr(C)]
 struct RustObject {
     a: i32,
@@ -406,7 +406,7 @@ Foreign APIs often export a global variable which could do something like track
 global state. In order to access these variables, you declare them in `extern`
 blocks with the `static` keyword:
 
-```no_run
+```rust,no_run
 # #![feature(libc)]
 extern crate libc;
 
@@ -425,7 +425,7 @@ Alternatively, you may need to alter global state provided by a foreign
 interface. To do this, statics can be declared with `mut` so we can mutate
 them.
 
-```no_run
+```rust,no_run
 # #![feature(libc)]
 extern crate libc;
 

--- a/src/doc/book/functions.md
+++ b/src/doc/book/functions.md
@@ -134,7 +134,7 @@ x = y = 5
 In Rust, however, using `let` to introduce a binding is _not_ an expression. The
 following will produce a compile-time error:
 
-```ignore
+```rust,ignore
 let x = (let y = 5); // expected identifier, found keyword `let`
 ```
 
@@ -283,7 +283,7 @@ stack backtrace:
 
 A diverging function can be used as any type:
 
-```should_panic
+```rust,should_panic
 # fn diverges() -> ! {
 #    panic!("This function never returns!");
 # }

--- a/src/doc/book/inline-assembly.md
+++ b/src/doc/book/inline-assembly.md
@@ -4,7 +4,7 @@ For extremely low-level manipulations and performance reasons, one
 might wish to control the CPU directly. Rust supports using inline
 assembly to do this via the `asm!` macro.
 
-```ignore
+```rust,ignore
 asm!(assembly template
    : output operands
    : input operands

--- a/src/doc/book/loops.md
+++ b/src/doc/book/loops.md
@@ -74,7 +74,7 @@ for x in 0..10 {
 
 In slightly more abstract terms,
 
-```ignore
+```rust,ignore
 for var in expression {
     code
 }

--- a/src/doc/book/macros.md
+++ b/src/doc/book/macros.md
@@ -78,7 +78,7 @@ macro_rules! vec {
 
 Whoa, that’s a lot of new syntax! Let’s break it down.
 
-```ignore
+```rust,ignore
 macro_rules! vec { ... }
 ```
 
@@ -92,7 +92,7 @@ syntax and serves to distinguish a macro from an ordinary function.
 The macro is defined through a series of rules, which are pattern-matching
 cases. Above, we had
 
-```ignore
+```rust,ignore
 ( $( $x:expr ),* ) => { ... };
 ```
 
@@ -112,7 +112,7 @@ separated by commas.
 Aside from the special matcher syntax, any Rust tokens that appear in a matcher
 must match exactly. For example,
 
-```rust
+```rust,ignore
 macro_rules! foo {
     (x => $e:expr) => (println!("mode X: {}", $e));
     (y => $e:expr) => (println!("mode Y: {}", $e));
@@ -147,7 +147,7 @@ The right-hand side of a macro rule is ordinary Rust syntax, for the most part.
 But we can splice in bits of syntax captured by the matcher. From the original
 example:
 
-```ignore
+```rust,ignore
 $(
     temp_vec.push($x);
 )*
@@ -165,7 +165,7 @@ within the repeated block.
 Another detail: the `vec!` macro has *two* pairs of braces on the right-hand
 side. They are often combined like so:
 
-```ignore
+```rust,ignore
 macro_rules! foo {
     () => {{
         ...

--- a/src/doc/book/operators-and-overloading.md
+++ b/src/doc/book/operators-and-overloading.md
@@ -123,7 +123,7 @@ fn main() {
 For `HasArea` and `Square`, we declare a type parameter `T` and replace
 `f64` with it. The `impl` needs more involved modifications:
 
-```ignore
+```rust,ignore
 impl<T> HasArea<T> for Square<T>
         where T: Mul<Output=T> + Copy { ... }
 ```

--- a/src/doc/book/trait-objects.md
+++ b/src/doc/book/trait-objects.md
@@ -306,7 +306,7 @@ let y = TraitObject {
 Not every trait can be used to make a trait object. For example, vectors implement
 `Clone`, but if we try to make a trait object:
 
-```ignore
+```rust,ignore
 let v = vec![1, 2, 3];
 let o = &v as &Clone;
 ```

--- a/src/doc/book/traits.md
+++ b/src/doc/book/traits.md
@@ -195,7 +195,7 @@ fn main() {
 `is_square()` needs to check that the sides are equal, so the sides must be of
 a type that implements the [`core::cmp::PartialEq`][PartialEq] trait:
 
-```ignore
+```rust,ignore
 impl<T: PartialEq> Rectangle<T> { ... }
 ```
 

--- a/src/doc/book/vectors.md
+++ b/src/doc/book/vectors.md
@@ -40,7 +40,7 @@ The indices count from `0`, so the third element is `v[2]`.
 
 It’s also important to note that you must index with the `usize` type:
 
-```ignore
+```rust,ignore
 let v = vec![1, 2, 3, 4, 5];
 
 let i: usize = 0;
@@ -71,7 +71,7 @@ you cannot index with an `i32`.
 
 If you try to access an index that doesn’t exist:
 
-```ignore
+```rust,ignore
 let v = vec![1, 2, 3];
 println!("Item 7 is {}", v[7]);
 ```


### PR DESCRIPTION
In the book, some code blocks were missing the `rust` specifier which is needed for them to highlight correctly.
