### PR TITLE
Parser: fix ICE on failure to parse token tree

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2807,14 +2807,14 @@ impl<'a> Parser<'a> {
                 let span = Span { hi: close_span.hi, ..pre_span };
 
                 match self.token {
-                    // Correct delmiter.
+                    // Correct delimiter.
                     token::CloseDelim(d) if d == delim => {
                         self.open_braces.pop().unwrap();
 
                         // Parse the close delimiter.
                         self.bump();
                     }
-                    // Incorect delimiter.
+                    // Incorrect delimiter.
                     token::CloseDelim(other) => {
                         let token_str = self.this_token_to_string();
                         let mut err = self.diagnostic().struct_span_err(self.span,
@@ -2829,9 +2829,9 @@ impl<'a> Parser<'a> {
 
                         self.open_braces.pop().unwrap();
 
-                        // If the incorrect delimter matches an earlier opening
+                        // If the incorrect delimiter matches an earlier opening
                         // delimiter, then don't consume it (it can be used to
-                        // close the earlier one)Otherwise, consume it.
+                        // close the earlier one). Otherwise, consume it.
                         // E.g., we try to recover from:
                         // fn foo() {
                         //     bar(baz(
@@ -2862,7 +2862,7 @@ impl<'a> Parser<'a> {
                 // invariants: the current token is not a left-delimiter,
                 // not an EOF, and not the desired right-delimiter (if
                 // it were, parse_seq_to_before_end would have prevented
-                // reaching this point.
+                // reaching this point).
                 maybe_whole!(deref self, NtTT);
                 match self.token {
                     token::CloseDelim(_) => {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2844,8 +2844,11 @@ impl<'a> Parser<'a> {
                         // Silently recover, the EOF token will be seen again
                         // and an error emitted then. Thus we don't pop from
                         // self.open_braces here.
-                    },
-                    _ => unreachable!(),
+                    }
+                    _ => {
+                        // Bad token: an error will already have been emitted; just skip it.
+                        self.bump();
+                    }
                 }
 
                 Ok(TokenTree::Delimited(span, Rc::new(Delimited {

--- a/src/test/parse-fail/issue-33569.rs
+++ b/src/test/parse-fail/issue-33569.rs
@@ -1,0 +1,15 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z no-analysis
+
+macro_rules! foo {
+  { $+ } => () //~ ERROR: expected identifier, found `+`
+}              //~^ ERROR: no rules expected the token `}`


### PR DESCRIPTION
Fix a compiler panic when the "token tree" parser encounters something unexpected.

A "token tree" is how the contents of a `macro_rules!` definition are parsed, before expanding it. This is a very permissive form of parsing.

Fixes #33569, fixes #33728.

Also fix some typos in comments.

Note: I'm very much a newb at Rust compiler hackery. Someone experienced definitely needs to sanity-check this :)
