### PR TITLE
std: Backport a libbacktrace soundness fix

### DIFF
--- a/src/libbacktrace/ChangeLog
+++ b/src/libbacktrace/ChangeLog
@@ -1,15 +1,33 @@
+2016-05-18  Uros Bizjak  <ubizjak@gmail.com>
+
+	PR target/71161
+	* elf.c (phdr_callback) [__i386__]: Add
+	__attribute__((__force_align_arg_pointer__)).
+
+2016-03-02  Maxim Ostapenko  <m.ostapenko@partner.samsung.com>
+
+	* elf.c (backtrace_initialize): Properly initialize elf_fileline_fn to
+	avoid possible crash.
+	(elf_add): Don't set *fileline_fn to elf_nodebug value in case of
+	missing debug info anymore.
+
+2016-02-06  John David Anglin  <danglin@gcc.gnu.org>
+
+	* mmap.c (MAP_FAILED): Define if not defined.
+
 2016-01-04  Jakub Jelinek  <jakub@redhat.com>
 
 	Update copyright years.
 
 2015-12-18  Andris Pavenis  <andris.pavenis@iki.fi>
 
-	* configure.ac: Specify that DJGPP do not have mmap even when sys/mman.h exists
+	* configure.ac: Specify that DJGPP do not have mmap
+	even when sys/mman.h exists.
 	* configure: Regenerate
 
 2015-12-09  John David Anglin  <danglin@gcc.gnu.org>
 
-	PR 68115/libfortran
+	PR libgfortran/68115
 	* configure.ac: Set libbacktrace_cv_sys_sync to no on hppa*-*-hpux*.
 	* configure: Regenerate.
 	* elf.c (backtrace_initialize): Cast __sync_bool_compare_and_swap call

--- a/src/libbacktrace/elf.c
+++ b/src/libbacktrace/elf.c
@@ -791,7 +791,6 @@ elf_add (struct backtrace_state *state, int descriptor, uintptr_t base_address,
     {
       if (!backtrace_close (descriptor, error_callback, data))
 	goto fail;
-      *fileline_fn = elf_nodebug;
       return 1;
     }
 
@@ -867,6 +866,9 @@ struct phdr_data
    libraries.  */
 
 static int
+#ifdef __i386__
+__attribute__ ((__force_align_arg_pointer__))
+#endif
 phdr_callback (struct dl_phdr_info *info, size_t size ATTRIBUTE_UNUSED,
 	       void *pdata)
 {
@@ -925,7 +927,7 @@ backtrace_initialize (struct backtrace_state *state, int descriptor,
   int ret;
   int found_sym;
   int found_dwarf;
-  fileline elf_fileline_fn;
+  fileline elf_fileline_fn = elf_nodebug;
   struct phdr_data pd;
 
   ret = elf_add (state, descriptor, 0, error_callback, data, &elf_fileline_fn,

--- a/src/libbacktrace/mmap.c
+++ b/src/libbacktrace/mmap.c
@@ -50,6 +50,10 @@ POSSIBILITY OF SUCH DAMAGE.  */
 #define MAP_ANONYMOUS MAP_ANON
 #endif
 
+#ifndef MAP_FAILED
+#define MAP_FAILED ((void *)-1)
+#endif
+
 /* A list of free memory blocks.  */
 
 struct backtrace_freelist_struct

--- a/src/libbacktrace/pecoff.c
+++ b/src/libbacktrace/pecoff.c
@@ -602,6 +602,9 @@ coff_add (struct backtrace_state *state, int descriptor,
   const b_coff_section_header *sects;
   struct backtrace_view str_view;
   int str_view_valid;
+  // NOTE: upstream this is a `size_t` but this was fixed in Rust commit
+  //       55e2b7e1b, see #33729 for more info. If you see this in a diff
+  //       against the upstream libbacktrace, that's what's going on.
   uint32_t str_size;
   off_t str_off;
   struct backtrace_view syms_view;


### PR DESCRIPTION
This is a backport of gcc-mirror/gcc@047a1c2f which is a soundness fix for when
a backtrace is generated on executables that do not have debug information.
