### PR TITLE
always make at least one codegen-unit

### DIFF
--- a/src/librustc_trans/partitioning.rs
+++ b/src/librustc_trans/partitioning.rs
@@ -228,6 +228,17 @@ fn place_root_translation_items<'a, 'tcx, I>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         }
     }
 
+    // always ensure we have at least one CGO; otherwise, if we have a
+    // crate with just types (for example), we could wind up with no CGU
+    if codegen_units.is_empty() {
+        let codegen_unit_name = InternedString::new(FALLBACK_CODEGEN_UNIT);
+        codegen_units.entry(codegen_unit_name.clone())
+                     .or_insert_with(|| CodegenUnit {
+                         name: codegen_unit_name.clone(),
+                         items: FnvHashMap(),
+                     });
+    }
+
     PreInliningPartitioning {
         codegen_units: codegen_units.into_iter()
                                     .map(|(_, codegen_unit)| codegen_unit)

--- a/src/librustc_trans/partitioning.rs
+++ b/src/librustc_trans/partitioning.rs
@@ -228,7 +228,7 @@ fn place_root_translation_items<'a, 'tcx, I>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         }
     }
 
-    // always ensure we have at least one CGO; otherwise, if we have a
+    // always ensure we have at least one CGU; otherwise, if we have a
     // crate with just types (for example), we could wind up with no CGU
     if codegen_units.is_empty() {
         let codegen_unit_name = InternedString::new(FALLBACK_CODEGEN_UNIT);

--- a/src/test/incremental/type_alias_cross_crate/auxiliary/a.rs
+++ b/src/test/incremental/type_alias_cross_crate/auxiliary/a.rs
@@ -17,5 +17,3 @@ pub type X = u32;
 pub type X = i32;
 
 pub type Y = char;
-
-pub fn foo() { }


### PR DESCRIPTION
this allows us to remove the dummy `foo` fn

r? @michaelwoerister 
