### PR TITLE
Allow syntax extensions which modify and decorate

### DIFF
--- a/src/librustc_plugin/registry.rs
+++ b/src/librustc_plugin/registry.rs
@@ -16,7 +16,7 @@ use rustc::session::Session;
 use rustc::mir::transform::MirMapPass;
 
 use syntax::ext::base::{SyntaxExtension, NamedSyntaxExtension, NormalTT};
-use syntax::ext::base::{IdentTT, MultiModifier, MultiDecorator};
+use syntax::ext::base::{IdentTT, MultiModifier, MultiDecorator, Renovator};
 use syntax::ext::base::{MacroExpanderFn, MacroRulesTT};
 use syntax::codemap::Span;
 use syntax::parse::token;
@@ -112,6 +112,7 @@ impl<'a> Registry<'a> {
             }
             MultiDecorator(ext) => MultiDecorator(ext),
             MultiModifier(ext) => MultiModifier(ext),
+            Renovator(ext) => Renovator(ext),
             MacroRulesTT => {
                 self.sess.err("plugin tried to register a new MacroRulesTT");
                 return;

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -302,7 +302,7 @@ fn expand_mac_invoc<T>(mac: ast::Mac, ident: Option<Ident>, attrs: Vec<ast::Attr
                 None
             }
 
-            MultiDecorator(..) | MultiModifier(..) => {
+            Renovator(..) | MultiDecorator(..) | MultiModifier(..) => {
                 fld.cx.span_err(path.span,
                                 &format!("`{}` can only be used in attributes", extname));
                 None
@@ -718,14 +718,23 @@ impl<'a> Folder for PatIdentRenamer<'a> {
     }
 }
 
-fn expand_annotatable(a: Annotatable,
+fn expand_annotatable(original_item: Annotatable,
                       fld: &mut MacroExpander)
                       -> SmallVector<Annotatable> {
-    let a = expand_item_multi_modifier(a, fld);
+    let a = expand_item_multi_modifier(original_item, fld);
+
+    let mut renovated_items = expand_renovators(a.clone(), fld);
+
+    // Take the original item out (if any).
+    let a = if let Some(index) = renovated_items.iter().position(|i| is_original_item(i, &a)) {
+        renovated_items.remove(index)
+    } else {
+        return SmallVector::zero(); // The renovator ate the item.
+    };
 
     let mut decorator_items = SmallVector::zero();
     let mut new_attrs = Vec::new();
-    let a = expand_renovators_and_decorators(a, fld, &mut decorator_items, &mut new_attrs);
+    expand_decorators(a.clone(), fld, &mut decorator_items, &mut new_attrs);
 
     let mut new_items: SmallVector<Annotatable> = match a {
         Annotatable::Item(it) => match it.node {
@@ -789,7 +798,9 @@ fn expand_annotatable(a: Annotatable,
         }
     };
 
+    new_items.extend(renovated_items.into_iter());
     new_items.push_all(decorator_items);
+
     new_items
 }
 
@@ -816,63 +827,131 @@ macro_rules! partition {
 partition!(multi_modifiers, MultiModifier);
 
 
-fn expand_renovators_and_decorators(mut item: Annotatable,
-                                    fld: &mut MacroExpander,
-                                    decorator_items: &mut SmallVector<Annotatable>,
-                                    new_attrs: &mut Vec<ast::Attribute>) -> Annotatable
+fn expand_decorators(a: Annotatable,
+                     fld: &mut MacroExpander,
+                     decorator_items: &mut SmallVector<Annotatable>,
+                     new_attrs: &mut Vec<ast::Attribute>)
 {
-    let attrs: Vec<_> = item.attrs().iter().cloned().collect();
-
-    for attr in attrs {
+    for attr in a.attrs() {
         let mname = intern(&attr.name());
-
-        fld.cx.bt_push(ExpnInfo {
-            call_site: attr.span,
-            callee: NameAndSpan {
-                format: MacroAttribute(mname),
-                span: Some(attr.span),
-                // attributes can do whatever they like,
-                // for now.
-                allow_internal_unstable: true,
-            }
-        });
-
-        // we'd ideally decorator_items.push_all(expand_annotatable(ann, fld)),
-        // but that double-mut-borrows fld
-        let mut items: SmallVector<Annotatable> = SmallVector::zero();
-
         match fld.cx.syntax_env.find(mname) {
             Some(rc) => match *rc {
                 MultiDecorator(ref dec) => {
                     attr::mark_used(&attr);
 
+                    fld.cx.bt_push(ExpnInfo {
+                        call_site: attr.span,
+                        callee: NameAndSpan {
+                            format: MacroAttribute(mname),
+                            span: Some(attr.span),
+                            // attributes can do whatever they like,
+                            // for now.
+                            allow_internal_unstable: true,
+                        }
+                    });
+
+                    // we'd ideally decorator_items.push_all(expand_annotatable(ann, fld)),
+                    // but that double-mut-borrows fld
+                    let mut items: SmallVector<Annotatable> = SmallVector::zero();
                     dec.expand(fld.cx,
                                attr.span,
                                &attr.node.value,
-                               &item,
+                               &a,
                                &mut |ann| items.push(ann));
-                },
-                Renovator(ref ren) => {
+                    decorator_items.extend(items.into_iter()
+                        .flat_map(|ann| expand_annotatable(ann, fld).into_iter()));
+
+                    fld.cx.bt_pop();
+                }
+                _ => new_attrs.push((*attr).clone()),
+            },
+            _ => new_attrs.push((*attr).clone()),
+        }
+    }
+}
+
+fn is_original_item(item: &Annotatable, original: &Annotatable) -> bool {
+    item.node_id() == original.node_id()
+}
+
+fn expand_renovators(original_item: Annotatable,
+                     fld: &mut MacroExpander) -> Vec<Annotatable>
+{
+    let mut items = Vec::new();
+    items.push(original_item.clone());
+
+    let mut processed_attributes: Vec<ast::Attribute> = Vec::new();
+
+    'main_loop: loop {
+        let item_idx = items.iter().position(|i| is_original_item(i, &original_item));
+
+        let item = if let Some(idx) = item_idx {
+            items.remove(idx)
+        } else {
+            break 'main_loop;
+        };
+
+        // Find the first unprocessed attribute.
+        let attr = if let Some(attr) = item.attrs().iter().cloned().
+            find(|i| !processed_attributes.iter().any(|pi| i == pi)) {
+            attr
+        } else {
+            items.push(item); // put the item back.
+            break 'main_loop;
+        };
+
+        processed_attributes.push(attr.clone());
+
+        let macro_name = intern(&attr.name());
+
+        match fld.cx.syntax_env.find(macro_name) {
+            Some(rc) => match *rc {
+                Renovator(ref dec) => {
                     attr::mark_used(&attr);
 
-                    item = ren.expand(fld.cx,
-                                      attr.span,
-                                      &attr.node.value,
-                                      item,
-                                      &mut |ann| items.push(ann));
+                    fld.cx.bt_push(ExpnInfo {
+                        call_site: attr.span,
+                        callee: NameAndSpan {
+                            format: MacroAttribute(macro_name),
+                            span: Some(attr.span),
+                            // attributes can do whatever they like,
+                            // for now.
+                            allow_internal_unstable: true,
+                        }
+                    });
+
+                    let mut new_items: SmallVector<Annotatable> = SmallVector::zero();
+                    dec.expand(fld.cx,
+                               attr.span,
+                               &attr.node.value,
+                               item,
+                               &mut |ann| new_items.push(ann));
+
+                    let new_items = new_items.into_iter().map(|item| {
+                        // Remove all attributes that are already processed.
+                        let attrs: Vec<_> = item.attrs().iter().cloned().
+                            filter(|a| processed_attributes.iter().any(|pa| pa == a)).collect();
+
+                        item.fold_attrs(attrs)
+                    });
+
+                    for new_item in new_items {
+                        if is_original_item(&new_item, &original_item) {
+                            items.push(new_item);
+                        } else {
+                            items.extend(expand_annotatable(new_item, fld).into_iter());
+                        }
+                    }
+
+                    fld.cx.bt_pop();
                 },
-                _ => new_attrs.push(attr),
+                _ => items.push(item.clone()),
             },
-            _ => new_attrs.push(attr),
+            _ => items.push(item.clone()),
         }
-
-        decorator_items.extend(items.into_iter()
-            .flat_map(|ann| expand_annotatable(ann, fld).into_iter()));
-
-        fld.cx.bt_pop();
     }
 
-    item
+    items
 }
 
 fn expand_item_multi_modifier(mut it: Annotatable,

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -725,7 +725,7 @@ fn expand_annotatable(a: Annotatable,
 
     let mut decorator_items = SmallVector::zero();
     let mut new_attrs = Vec::new();
-    expand_decorators(a.clone(), fld, &mut decorator_items, &mut new_attrs);
+    let a = expand_renovators_and_decorators(a, fld, &mut decorator_items, &mut new_attrs);
 
     let mut new_items: SmallVector<Annotatable> = match a {
         Annotatable::Item(it) => match it.node {
@@ -816,47 +816,63 @@ macro_rules! partition {
 partition!(multi_modifiers, MultiModifier);
 
 
-fn expand_decorators(a: Annotatable,
-                     fld: &mut MacroExpander,
-                     decorator_items: &mut SmallVector<Annotatable>,
-                     new_attrs: &mut Vec<ast::Attribute>)
+fn expand_renovators_and_decorators(mut item: Annotatable,
+                                    fld: &mut MacroExpander,
+                                    decorator_items: &mut SmallVector<Annotatable>,
+                                    new_attrs: &mut Vec<ast::Attribute>) -> Annotatable
 {
-    for attr in a.attrs() {
+    let attrs: Vec<_> = item.attrs().iter().cloned().collect();
+
+    for attr in attrs {
         let mname = intern(&attr.name());
+
+        fld.cx.bt_push(ExpnInfo {
+            call_site: attr.span,
+            callee: NameAndSpan {
+                format: MacroAttribute(mname),
+                span: Some(attr.span),
+                // attributes can do whatever they like,
+                // for now.
+                allow_internal_unstable: true,
+            }
+        });
+
+        // we'd ideally decorator_items.push_all(expand_annotatable(ann, fld)),
+        // but that double-mut-borrows fld
+        let mut items: SmallVector<Annotatable> = SmallVector::zero();
+
         match fld.cx.syntax_env.find(mname) {
             Some(rc) => match *rc {
                 MultiDecorator(ref dec) => {
                     attr::mark_used(&attr);
 
-                    fld.cx.bt_push(ExpnInfo {
-                        call_site: attr.span,
-                        callee: NameAndSpan {
-                            format: MacroAttribute(mname),
-                            span: Some(attr.span),
-                            // attributes can do whatever they like,
-                            // for now.
-                            allow_internal_unstable: true,
-                        }
-                    });
-
-                    // we'd ideally decorator_items.push_all(expand_annotatable(ann, fld)),
-                    // but that double-mut-borrows fld
-                    let mut items: SmallVector<Annotatable> = SmallVector::zero();
                     dec.expand(fld.cx,
                                attr.span,
                                &attr.node.value,
-                               &a,
+                               &item,
                                &mut |ann| items.push(ann));
-                    decorator_items.extend(items.into_iter()
-                        .flat_map(|ann| expand_annotatable(ann, fld).into_iter()));
+                },
+                Renovator(ref ren) => {
+                    attr::mark_used(&attr);
 
-                    fld.cx.bt_pop();
-                }
-                _ => new_attrs.push((*attr).clone()),
+                    item = ren.expand(fld.cx,
+                                      attr.span,
+                                      &attr.node.value,
+                                      item,
+                                      &mut |ann| items.push(ann));
+                },
+                _ => new_attrs.push(attr),
             },
-            _ => new_attrs.push((*attr).clone()),
+            _ => new_attrs.push(attr),
         }
+
+        decorator_items.extend(items.into_iter()
+            .flat_map(|ann| expand_annotatable(ann, fld).into_iter()));
+
+        fld.cx.bt_pop();
     }
+
+    item
 }
 
 fn expand_item_multi_modifier(mut it: Annotatable,

--- a/src/test/run-pass-fulldeps/auxiliary/macro_crate_test.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/macro_crate_test.rs
@@ -39,6 +39,9 @@ pub fn plugin_registrar(reg: &mut Registry) {
         token::intern("duplicate"),
         // FIXME (#22405): Replace `Box::new` with `box` here when/if possible.
         MultiDecorator(Box::new(expand_duplicate)));
+    reg.register_syntax_extension(
+        token::intern("wrap"),
+        Renovator(Box::new(expand_wrap)));
 }
 
 fn expand_make_a_1(cx: &mut ExtCtxt, sp: Span, tts: &[TokenTree])
@@ -138,4 +141,25 @@ fn expand_duplicate(cx: &mut ExtCtxt,
     }
 }
 
+fn expand_wrap(cx: &mut ExtCtxt,
+               sp: Span,
+               meta_item: &MetaItem,
+               mut item: Annotatable,
+               push: &mut FnMut(Annotatable)) -> Annotatable
+{
+
+    match item {
+        Annotatable::Item(item) => {
+            push(Annotatable::Item(item.clone()));
+
+            Annotatable::Item(P(Item {
+                attrs: item.attrs.clone(),
+                ..(*quote_item!(cx, enum Foo2 { Bar2, Baz2 }).unwrap()).clone()
+            }))
+        },
+        _ => item,
+    }
+}
+
 pub fn foo() {}
+pub fn main() { }

--- a/src/test/run-pass-fulldeps/macro-crate.rs
+++ b/src/test/run-pass-fulldeps/macro-crate.rs
@@ -33,6 +33,14 @@ impl Qux for i32 {
 
 impl Qux for u8 {}
 
+#[wrap]
+struct Bar;
+
+impl Bar
+{
+    fn new() -> Self { Bar }
+}
+
 pub fn main() {
     assert_eq!(1, make_a_1!());
     assert_eq!(2, exported_macro!());

--- a/src/test/run-pass-fulldeps/macro-crate.rs
+++ b/src/test/run-pass-fulldeps/macro-crate.rs
@@ -33,7 +33,18 @@ impl Qux for i32 {
 
 impl Qux for u8 {}
 
-#[wrap]
+#[remove]
+struct TypeToBeRemoved
+{
+    foo: NonexistentType,
+    bar: Baz,
+}
+
+#[spawn]
+struct Baz {
+    n: u32,
+}
+
 struct Bar;
 
 impl Bar
@@ -52,6 +63,9 @@ pub fn main() {
     assert_eq!(x.foo(), 42);
     let x = 10u8;
     assert_eq!(x.foo(), 0);
+
+    let a = Baz4 { n: 15 };
+    assert_eq!(a.n, 15);
 }
 
 fn test<T: PartialEq+Clone>(_: Option<T>) {}


### PR DESCRIPTION
This adds a new `SyntaxExtension` type - `Renovator`.

A renovator is a syntax extension which can modify _and_ decorate the items it is attached to - the union of `MultiModifier` and `MultiDecorator`.

This allows things such as syntax extensions which modify existing methods for types, and implement traits all in one.

This shouldn't break any existing code, and it only touches unstable compiler internals.
