### PR TITLE
Book: small improvement to a table to make it clearer

### DIFF
--- a/src/doc/book/the-stack-and-the-heap.md
+++ b/src/doc/book/the-stack-and-the-heap.md
@@ -175,6 +175,7 @@ And then `bold()` calls `italic()`:
 | **2**   | **b**|**100**|
 | **1**   | **a**| **5** |
 | 0       | x    | 42    |
+
 Whew! Our stack is growing tall.
 
 After `italic()` is over, its frame is deallocated, leaving only `bold()` and
@@ -260,8 +261,7 @@ layout of a program which has been running for a while now:
 | (2<sup>30</sup>) - 3 |      |                        |
 | (2<sup>30</sup>) - 4 |      | 42                     |
 | ...                  | ...  | ...                    |
-| 3                    | y    | → (2<sup>30</sup>) - 4 |
-| 2                    | y    | 42                     |
+| 2                    | z    | → (2<sup>30</sup>) - 4 |
 | 1                    | y    | 42                     |
 | 0                    | x    | → (2<sup>30</sup>) - 1 |
 


### PR DESCRIPTION
This table is used as an example of four heap values where two of them got deallocated leaving a gap.
It also has stack variables.
Instead of four stack variables I propose three, that way there's no misleading connection between the number of stack variables and heap variables.
But more importantly: three of the four stack variables had the same name (**y**) which could be confusing to a beginner, I changed this as well.
