### PR TITLE
Clarify the English translation of `?Sized`

### DIFF
--- a/src/doc/book/unsized-types.md
+++ b/src/doc/book/unsized-types.md
@@ -47,7 +47,7 @@ pointers, can use this `impl`.
 # ?Sized
 
 If you want to write a function that accepts a dynamically sized type, you
-can use the special bound, `?Sized`:
+can use the special syntax, `?Sized`:
 
 ```rust
 struct Foo<T: ?Sized> {
@@ -55,6 +55,5 @@ struct Foo<T: ?Sized> {
 }
 ```
 
-This `?`, read as “T may be `Sized`”,  means that this bound is special: it
-lets us match more kinds, not less. It’s almost like every `T` implicitly has
-`T: Sized`, and the `?` undoes this default.
+This `?Sized`, read as “T may or may not be `Sized`”, allowing us to match both constant size and unsized types.
+All generic type parameters implicitly have the `Sized` bound, so `?Sized` can be used to opt-out of the implicit bound.

--- a/src/doc/book/unsized-types.md
+++ b/src/doc/book/unsized-types.md
@@ -55,5 +55,6 @@ struct Foo<T: ?Sized> {
 }
 ```
 
-This `?Sized`, read as “T may or may not be `Sized`”, allowing us to match both constant size and unsized types.
-All generic type parameters implicitly have the `Sized` bound, so `?Sized` can be used to opt-out of the implicit bound.
+This `?Sized`, read as “T may or may not be `Sized`”, allowing us to match both
+constant size and unsized types. All generic type parameters implicitly have
+the `Sized` bound, so `?Sized` can be used to opt-out of the implicit bound.

--- a/src/doc/book/unsized-types.md
+++ b/src/doc/book/unsized-types.md
@@ -55,6 +55,7 @@ struct Foo<T: ?Sized> {
 }
 ```
 
-This `?Sized`, read as “T may or may not be `Sized`”, allowing us to match both
-constant size and unsized types. All generic type parameters implicitly have
-the `Sized` bound, so `?Sized` can be used to opt-out of the implicit bound.
+This `?Sized`, read as “T may or may not be `Sized`”, which allows us to match
+both constant size and unsized types. All generic type parameters implicitly
+have the `Sized` bound, so `?Sized` can be used to opt-out of the implicit
+bound.

--- a/src/doc/book/unsized-types.md
+++ b/src/doc/book/unsized-types.md
@@ -47,7 +47,7 @@ pointers, can use this `impl`.
 # ?Sized
 
 If you want to write a function that accepts a dynamically sized type, you
-can use the special syntax, `?Sized`:
+can use the special bound syntax, `?Sized`:
 
 ```rust
 struct Foo<T: ?Sized> {
@@ -56,6 +56,6 @@ struct Foo<T: ?Sized> {
 ```
 
 This `?Sized`, read as “T may or may not be `Sized`”, which allows us to match
-both constant size and unsized types. All generic type parameters implicitly
-have the `Sized` bound, so `?Sized` can be used to opt-out of the implicit
+both sized and unsized types. All generic type parameters implicitly
+have the `Sized` bound, so the `?Sized` can be used to opt-out of the implicit
 bound.


### PR DESCRIPTION
- It wasn't clear whether `?Sized` meant "not `Sized`" or "`Sized` or not `Sized`". According to #rust IRC, it does indeed mean "`Sized` or not `Sized`".
- Use the same language as [Trait std::marker::Sized](https://doc.rust-lang.org/std/marker/trait.Sized.html) about how `Sized` is implicitly bound.
- Refer to the syntax as `?Sized`, since it's currently the only allowed trait that can follow `?`.
