### PR TITLE
Fix `asm-misplaced-option` on ARM/AArch64

### DIFF
--- a/src/test/compile-fail/asm-misplaced-option.rs
+++ b/src/test/compile-fail/asm-misplaced-option.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 // ignore-android
+// ignore-arm
+// ignore-aarch64
 
 #![feature(asm, rustc_attrs)]
 


### PR DESCRIPTION
This fixes rust-lang/rust#33737. Of course, since we don't run `make check` for ARM cross builds, you probably won't notice it.
