### PR TITLE
Rename std::io::Read::chars to utf8_chars.

### DIFF
--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -1076,14 +1076,14 @@ mod tests {
     fn read_char_buffered() {
         let buf = [195, 159];
         let reader = BufReader::with_capacity(1, &buf[..]);
-        assert_eq!(reader.chars().next().unwrap().unwrap(), 'ß');
+        assert_eq!(reader.utf8_chars().next().unwrap().unwrap(), 'ß');
     }
 
     #[test]
     fn test_chars() {
         let buf = [195, 159, b'a'];
         let reader = BufReader::with_capacity(1, &buf[..]);
-        let mut it = reader.chars();
+        let mut it = reader.utf8_chars();
         assert_eq!(it.next().unwrap().unwrap(), 'ß');
         assert_eq!(it.next().unwrap().unwrap(), 'a');
         assert!(it.next().is_none());

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -481,7 +481,7 @@ mod tests {
     #[test]
     fn test_read_char() {
         let b = &b"Vi\xE1\xBB\x87t"[..];
-        let mut c = Cursor::new(b).chars();
+        let mut c = Cursor::new(b).utf8_chars();
         assert_eq!(c.next().unwrap().unwrap(), 'V');
         assert_eq!(c.next().unwrap().unwrap(), 'i');
         assert_eq!(c.next().unwrap().unwrap(), 'ệ');
@@ -492,7 +492,7 @@ mod tests {
     #[test]
     fn test_read_bad_char() {
         let b = &b"\x80"[..];
-        let mut c = Cursor::new(b).chars();
+        let mut c = Cursor::new(b).utf8_chars();
         assert!(c.next().unwrap().is_err());
     }
 


### PR DESCRIPTION
Unlike `str::chars` where UTF-8 is implied since that’s always the encoding of `str` (whose contents is guaranteed to be well-formed), the bytes read from `io::Read` are arbitrary.
