### PR TITLE
Added a `rustdoc` shortcut for collapse/expand all

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -103,6 +103,8 @@ r##"<!DOCTYPE html>
                     <dd>Move down in search results</dd>
                     <dt>&#9166;</dt>
                     <dd>Go to active search result</dd>
+                    <dt>+</dt>
+                    <dd>Collapse/expand all sections</dd>
                 </dl>
             </div>
 

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -124,6 +124,10 @@
             focusSearchBar();
             break;
 
+        case "+":
+            toggleAllDocs();
+            break;
+
         case "?":
             if (ev.shiftKey && $("#help").hasClass("hidden")) {
                 ev.preventDefault();
@@ -931,7 +935,7 @@
         return "\u2212"; // "\u2212" is '−' minus sign
     }
 
-    $("#toggle-all-docs").on("click", function() {
+    function toggleAllDocs() {
         var toggle = $("#toggle-all-docs");
         if (toggle.hasClass("will-expand")) {
             toggle.removeClass("will-expand");
@@ -950,7 +954,9 @@
             $(".toggle-wrapper").addClass("collapsed");
             $(".collapse-toggle").children(".inner").text(labelForToggleButton(true));
         }
-    });
+    }
+
+    $("#toggle-all-docs").on("click", toggleAllDocs);
 
     $(document).on("click", ".collapse-toggle", function() {
         var toggle = $(this);

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -472,7 +472,7 @@ body.blur > :not(#help) {
     background: #e9e9e9;
     box-shadow: 0 0 6px rgba(0,0,0,.2);
     width: 550px;
-    height: 300px;
+    height: 330px;
     border: 1px solid #bfbfbf;
 }
 #help dt {


### PR DESCRIPTION
Now when the user presses the "+" key all sections will collapse/expand.

Also added a note to the help screen which describes this behavior.

This required increasing the height of the help screen.
