### PR TITLE
enable macro visits in deriving

### DIFF
--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -192,7 +192,7 @@ use std::collections::HashSet;
 use std::vec;
 
 use syntax::abi::Abi;
-use syntax::ast::{self, EnumDef, Expr, Ident, Generics, VariantData, BinOpKind, PatKind};
+use syntax::ast::{self, EnumDef, Expr, Ident, Generics, Mac, VariantData, BinOpKind, PatKind};
 use syntax::attr;
 use syntax::attr::AttrMetaMethods;
 use syntax::ext::base::{ExtCtxt, Annotatable};
@@ -370,6 +370,10 @@ fn find_type_parameters(ty: &ast::Ty, ty_param_names: &[ast::Name]) -> Vec<P<ast
             }
 
             visit::walk_ty(self, ty)
+        }
+
+        fn visit_mac(&mut self, mac: &'a Mac) {
+            visit::walk_mac(self, mac)
         }
     }
 

--- a/src/test/run-pass/derive-type-macros.rs
+++ b/src/test/run-pass/derive-type-macros.rs
@@ -1,0 +1,28 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+// regression test for #32950
+
+#![feature(type_macros)]
+
+macro_rules! passthru {
+    ($t:ty) => { $t }
+}
+
+#[derive(Debug)]
+struct Thing<T> {
+    thing: passthru!(T)
+}
+
+fn main() {
+    let t: passthru!(Thing<passthru!(i32)>) = Thing { thing: 42 };
+    println!("{:?}", t);
+}
+

--- a/src/test/run-pass/derive-type-macros.rs
+++ b/src/test/run-pass/derive-type-macros.rs
@@ -16,13 +16,26 @@ macro_rules! passthru {
     ($t:ty) => { $t }
 }
 
+macro_rules! useassoc {
+    ($t:ident, $assoc:ident) => { ($t, $t::$assoc) }
+}
+
+trait HasAssoc { type Type; }
+
+impl HasAssoc for i32 { type Type = i32; }
+
 #[derive(Debug)]
-struct Thing<T> {
-    thing: passthru!(T)
+struct Thing1<T: HasAssoc> {
+    thing: useassoc!(T, Type)
+}
+#[derive(Debug)]
+struct Thing2<T: HasAssoc> {
+    thing: (T, T::Type)
 }
 
 fn main() {
-    let t: passthru!(Thing<passthru!(i32)>) = Thing { thing: 42 };
-    println!("{:?}", t);
+    let t1: passthru!(Thing1<passthru!(i32)>) = Thing1 { thing: (42, 42) };
+    let t2: passthru!(Thing2<passthru!(i32)>) = Thing2 { thing: (42, 42) };
+    println!("{:?} {:?}", t1, t2);
 }
 


### PR DESCRIPTION
Fixes #32950.

There's a warning [in src/libsyntax/visit.rs](https://github.com/rust-lang/rust/blob/master/src/libsyntax/visit.rs#L105-L112) saying not to do this, but it seems to fix the ICE and the other deriving tests survive. The "note about macros above" seems to be [this](https://github.com/rust-lang/rust/blob/master/src/libsyntax/visit.rs#L22-24), but deriving is just kinda pasting stuff around, like a macro, so it seems okay.

cc #27245
