### PR TITLE
Add a `PanicInfo::payload_as_str(&self) -> Option<&str>` method.

### DIFF
--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -149,6 +149,18 @@ impl<'a> PanicInfo<'a> {
         self.payload
     }
 
+    /// Returns the payload as a slice if it is a `&'static str` or `String`.
+    #[unstable(feature = "panic_handler", issue = "30449")]
+    pub fn payload_as_str(&self) -> Option<&str> {
+        match self.payload.downcast_ref::<&'static str>() {
+            Some(s) => Some(*s),
+            None => match self.payload.downcast_ref::<String>() {
+                Some(s) => Some(&s[..]),
+                None => None,
+            }
+        }
+    }
+
     /// Returns information about the location from which the panic originated,
     /// if available.
     ///
@@ -191,13 +203,7 @@ fn default_hook(info: &PanicInfo) {
     let file = info.location.file;
     let line = info.location.line;
 
-    let msg = match info.payload.downcast_ref::<&'static str>() {
-        Some(s) => *s,
-        None => match info.payload.downcast_ref::<String>() {
-            Some(s) => &s[..],
-            None => "Box<Any>",
-        }
-    };
+    let msg = info.payload_as_str().unwrap_or("Box<Any>");
     let mut err = Stderr::new().ok();
     let thread = thread_info::current_thread();
     let name = thread.as_ref().and_then(|t| t.name()).unwrap_or("<unnamed>");


### PR DESCRIPTION
The existing `payload` method returns `&(Any + Send)`, which needs to be downcasted into a user-chosen type to do anything with it. Users typically don’t know what the actual type is, but the most common ones are `&'static str` (from the `panic!` macro with a single argument) and `String` (fromatted from `panic!` with multiple arguments), so a user may want to try both. This is in fact what the default panic hook does, in order to print some information about the panic to stderr.

Since other panic hooks might want to do the same and it takes a few non-obvious lines to do, let’s provide this as new a method.

I considered adding this to `impl Any {}` and `impl Any+Send {}` directly instead, but `Any` is defined in libcore where `String` doesn’t exist.
