### PR TITLE
collections: Add `shallow_copy` method to Cow which always reborrows data

### DIFF
--- a/src/libcollections/borrow.rs
+++ b/src/libcollections/borrow.rs
@@ -178,6 +178,27 @@ impl<'a, B: ?Sized> Cow<'a, B> where B: ToOwned {
             Owned(owned) => owned,
         }
     }
+
+    /// Makes a shallow copy of the data.
+    ///
+    /// Reborrows the data if it is already owned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(cow_shallow_copy)]
+    /// use std::borrow::Cow;
+    ///
+    /// let cow: Cow<[_]> = Cow::Owned(vec![1, 2, 3]);
+    /// match cow.shallow_copy() {
+    ///     Cow::Owned(_) => panic!("needless clone!"),
+    ///     Cow::Borrowed(vec) => assert_eq!(vec, &[1, 2, 3]),
+    /// }
+    /// ```
+    #[unstable(feature = "cow_shallow_copy", issue="0")]
+    pub fn shallow_copy(&self) -> Cow<B> {
+        Borrowed(&**self)
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
Found myself needing a method to unconditionally borrow the underlying data inside of a `Cow` (there by doing a "shallow copy" instead of a full clone), and I think it could be useful to others.

Its a small addition so I figured I'd start the discussion here instead of going through an RFC first.

Currently feature gated behind `cow_shallow_copy`.
