### PR TITLE
typeck: suggest (x.field)(...) to call struct fields even when x is a reference

### DIFF
--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -178,28 +178,43 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     rcvr_ty,
                     None);
 
-                // If the item has the name of a field, give a help note
-                if let (&ty::TyStruct(def, substs), Some(expr)) = (&rcvr_ty.sty, rcvr_expr) {
-                    if let Some(field) = def.struct_variant().find_field_named(item_name) {
-                        let expr_string = match tcx.sess.codemap().span_to_snippet(expr.span) {
-                            Ok(expr_string) => expr_string,
-                            _ => "s".into() // Default to a generic placeholder for the
-                                            // expression when we can't generate a string
-                                            // snippet
-                        };
+                // If the method name is the name of a field with a function or closure type,
+                // give a helping note that it has to be called as (x.f)(...).
+                if let Some(expr) = rcvr_expr {
+                    self.autoderef(
+                        span,
+                        rcvr_ty,
+                        || None,
+                        UnresolvedTypeAction::Ignore,
+                        LvaluePreference::NoPreference,
+                        |ty, _| {
+                            if let ty::TyStruct(def, substs) = ty.sty {
+                                if let Some(field) = def.struct_variant()
+                                                        .find_field_named(item_name) {
+                                    let snippet = tcx.sess.codemap().span_to_snippet(expr.span);
+                                    let expr_string = match snippet {
+                                        Ok(expr_string) => expr_string,
+                                        _ => "s".into() // Default to a generic placeholder for the
+                                                        // expression when we can't generate a
+                                                        // string snippet
+                                    };
 
-                        let field_ty = field.ty(tcx, substs);
+                                    let field_ty = field.ty(tcx, substs);
 
-                        if self.is_fn_ty(&field_ty, span) {
-                            err.span_note(span,
-                                          &format!("use `({0}.{1})(...)` if you meant to call \
-                                                   the function stored in the `{1}` field",
-                                                   expr_string, item_name));
-                        } else {
-                            err.span_note(span, &format!("did you mean to write `{0}.{1}`?",
-                                                         expr_string, item_name));
-                        }
-                    }
+                                    if self.is_fn_ty(&field_ty, span) {
+                                        err.note(&format!("use `({0}.{1})(...)` if you meant to \
+                                                           call the function stored in the `{1}` \
+                                                           field",
+                                                          expr_string, item_name));
+                                    } else {
+                                        err.note(&format!("did you mean to write `{0}.{1}`?",
+                                                          expr_string, item_name));
+                                    }
+                                    return Some(());
+                                }
+                            }
+                            None
+                        });
                 }
 
                 if self.is_fn_ty(&rcvr_ty, span) {

--- a/src/test/compile-fail/issue-33784.rs
+++ b/src/test/compile-fail/issue-33784.rs
@@ -1,0 +1,46 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::ops::Deref;
+
+struct Obj<F> where F: FnMut() -> u32 {
+    fn_ptr: fn() -> (),
+    closure: F,
+}
+
+struct C {
+    c_fn_ptr: fn() -> (),
+}
+
+struct D(C);
+
+impl Deref for D {
+    type Target = C;
+    fn deref(&self) -> &C {
+        &self.0
+    }
+}
+
+
+fn empty() {}
+
+fn main() {
+    let o = Obj { fn_ptr: empty, closure: || 42 };
+    let p = &o;
+    p.closure(); //~ ERROR no method named `closure` found
+    //~^ NOTE use `(p.closure)(...)` if you meant to call the function stored in the `closure` field
+    let q = &p;
+    q.fn_ptr(); //~ ERROR no method named `fn_ptr` found
+    //~^ NOTE use `(q.fn_ptr)(...)` if you meant to call the function stored in the `fn_ptr` field
+    let r = D(C { c_fn_ptr: empty });
+    let s = &r;
+    s.c_fn_ptr(); //~ ERROR no method named `c_fn_ptr` found
+    //~^ NOTE use `(s.c_fn_ptr)(...)` if you meant to call the function stored in the `c_fn_ptr`
+}


### PR DESCRIPTION
Fixes: #33784 

I also removed the unnecessary span for the note.

Reviewers: is this the right way to get at the deref'd type(s)? I tried `expr_ty_adjusted`, but it claimed "no type for node `expr self`"...
