### PR TITLE
Makefile.in: dont use unnecessary escapes in echo

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -272,7 +272,9 @@ ifneq ($(strip $(findstring TAGS.emacs,$(MAKECMDGOALS)) \
 endif
 
 .DEFAULT:
-	@echo "\n======================================================"
+	@echo
+	@echo "======================================================"
 	@echo "== If you need help, run 'make help' or 'make tips' =="
-	@echo "======================================================\n"
+	@echo "======================================================"
+	@echo
 	exit 1


### PR DESCRIPTION
I don't know if `echo` allows escapes without `-e` on other systems, but on a GNU userland this outputs literal `\n` on the terminal. In this case there's an easy way to write this without escapes anyway.

r? @GuillaumeGomez 
