### PR TITLE
Fixed expand/collapse shortcut to not conflict with browser shortcuts

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -103,7 +103,7 @@ r##"<!DOCTYPE html>
                     <dd>Move down in search results</dd>
                     <dt>&#9166;</dt>
                     <dd>Go to active search result</dd>
-                    <dt>T</dt>
+                    <dt>+</dt>
                     <dd>Collapse/expand all sections</dd>
                 </dl>
             </div>

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -103,7 +103,7 @@ r##"<!DOCTYPE html>
                     <dd>Move down in search results</dd>
                     <dt>&#9166;</dt>
                     <dd>Go to active search result</dd>
-                    <dt>+</dt>
+                    <dt>T</dt>
                     <dd>Collapse/expand all sections</dd>
                 </dl>
             </div>

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -124,7 +124,8 @@
             focusSearchBar();
             break;
 
-        case "+":
+        case "t":
+        case "T":
             toggleAllDocs();
             break;
 

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -124,8 +124,8 @@
             focusSearchBar();
             break;
 
-        case "t":
-        case "T":
+        case "+":
+            ev.preventDefault();
             toggleAllDocs();
             break;
 


### PR DESCRIPTION
Allows both `T` and `t`.

It had been [Shift]+[+] before.

In response to #33791.

cc @Manishearth 
r? @GuillaumeGomez 
