### PR TITLE
Read::chars reform

### DIFF
--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -1076,14 +1076,14 @@ mod tests {
     fn read_char_buffered() {
         let buf = [195, 159];
         let reader = BufReader::with_capacity(1, &buf[..]);
-        assert_eq!(reader.chars().next().unwrap().unwrap(), 'ß');
+        assert_eq!(reader.utf8_chars().next().unwrap().unwrap(), 'ß');
     }
 
     #[test]
     fn test_chars() {
         let buf = [195, 159, b'a'];
         let reader = BufReader::with_capacity(1, &buf[..]);
-        let mut it = reader.chars();
+        let mut it = reader.utf8_chars();
         assert_eq!(it.next().unwrap().unwrap(), 'ß');
         assert_eq!(it.next().unwrap().unwrap(), 'a');
         assert!(it.next().is_none());

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -481,7 +481,7 @@ mod tests {
     #[test]
     fn test_read_char() {
         let b = &b"Vi\xE1\xBB\x87t"[..];
-        let mut c = Cursor::new(b).chars();
+        let mut c = Cursor::new(b).utf8_chars();
         assert_eq!(c.next().unwrap().unwrap(), 'V');
         assert_eq!(c.next().unwrap().unwrap(), 'i');
         assert_eq!(c.next().unwrap().unwrap(), 'ệ');
@@ -492,7 +492,7 @@ mod tests {
     #[test]
     fn test_read_bad_char() {
         let b = &b"\x80"[..];
-        let mut c = Cursor::new(b).chars();
+        let mut c = Cursor::new(b).utf8_chars();
         assert!(c.next().unwrap().is_err());
     }
 

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1569,7 +1569,7 @@ pub enum CharsError {
     NotUtf8,
 
     /// Variant representing that an I/O error occurred.
-    Other(Error),
+    Io(Error),
 }
 
 #[unstable(feature = "io", reason = "awaiting stability of Read::chars",
@@ -1587,7 +1587,7 @@ impl<R: Read> Iterator for Chars<R> {
                             Ok(0) => $on_eof,
                             Ok(..) => break,
                             Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
-                            Err(e) => return Some(Err(CharsError::Other(e))),
+                            Err(e) => return Some(Err(CharsError::Io(e))),
                         }
                     }
                     buf[0]
@@ -1657,13 +1657,13 @@ impl std_error::Error for CharsError {
     fn description(&self) -> &str {
         match *self {
             CharsError::NotUtf8 => "invalid utf8 encoding",
-            CharsError::Other(ref e) => std_error::Error::description(e),
+            CharsError::Io(ref e) => std_error::Error::description(e),
         }
     }
     fn cause(&self) -> Option<&std_error::Error> {
         match *self {
             CharsError::NotUtf8 => None,
-            CharsError::Other(ref e) => e.cause(),
+            CharsError::Io(ref e) => e.cause(),
         }
     }
 }
@@ -1676,7 +1676,7 @@ impl fmt::Display for CharsError {
             CharsError::NotUtf8 => {
                 "byte stream did not contain valid utf8".fmt(f)
             }
-            CharsError::Other(ref e) => e.fmt(f),
+            CharsError::Io(ref e) => e.fmt(f),
         }
     }
 }
@@ -1762,7 +1762,7 @@ mod tests {
         Cursor::new(bytes).chars().map(|result| match result {
             Ok(c) => c,
             Err(CharsError::NotUtf8) => '\u{FFFD}',
-            Err(CharsError::Other(e)) => panic!("{}", e),
+            Err(CharsError::Io(e)) => panic!("{}", e),
         }).collect()
     }
 


### PR DESCRIPTION
- Don’t swallow valid code point on UTF-8 decoding errors, as discussed in https://github.com/rust-lang/rust/issues/27802#issuecomment-172525439
- Rename/split error variants
- Rename the method to `utf8_chars`, as previously proposed and discussed in #33761.
- Add `Read::utf8_chars_lossy` which replaces UTF-8 errors with U+FFFD, leaving only I/O errors.
- **Edit 2016-05-25**: per discussion in #27802, move the methods to `BufRead`. `Read::chars` is now deprecated and returns `Utf8Chars<BufReader<Self>>` with a one-byte buffer to stay closer to the previous behavior.

Internally this duplicates the UTF-8 decoding logic from `String::from_utf8_lossy`, but let’s decide on the desired behavior first and we can refactor internals later.

With this, I’d like to propose the affected methods and types for stabilization (which would complete #27802).

r? @alexcrichton 
