### PR TITLE
Rename main thread from "<main>" to "main".

### DIFF
--- a/src/doc/book/advanced-linking.md
+++ b/src/doc/book/advanced-linking.md
@@ -134,7 +134,7 @@ $ ldd example
         not a dynamic executable
 $ ./example
 hi!
-thread '<main>' panicked at 'failed', example.rs:1
+thread 'main' panicked at 'failed', example.rs:1
 ```
 
 Success! This binary can be copied to almost any Linux machine with the same

--- a/src/doc/book/error-handling.md
+++ b/src/doc/book/error-handling.md
@@ -81,7 +81,7 @@ fn main() {
 If you try running this code, the program will crash with a message like this:
 
 ```text
-thread '<main>' panicked at 'Invalid number: 11', src/bin/panic-simple.rs:5
+thread 'main' panicked at 'Invalid number: 11', src/bin/panic-simple.rs:5
 ```
 
 Here's another example that is slightly less contrived. A program that accepts
@@ -498,7 +498,7 @@ At this point, you should be skeptical of calling `unwrap`. For example, if
 the string doesn't parse as a number, you'll get a panic:
 
 ```text
-thread '<main>' panicked at 'called `Result::unwrap()` on an `Err` value: ParseIntError { kind: InvalidDigit }', /home/rustbuild/src/rust-buildbot/slave/beta-dist-rustc-linux/build/src/libcore/result.rs:729
+thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ParseIntError { kind: InvalidDigit }', /home/rustbuild/src/rust-buildbot/slave/beta-dist-rustc-linux/build/src/libcore/result.rs:729
 ```
 
 This is rather unsightly, and if this happened inside a library you're

--- a/src/doc/book/functions.md
+++ b/src/doc/book/functions.md
@@ -221,7 +221,7 @@ If you add a main function that calls `diverges()` and run it, you’ll get
 some output that looks like this:
 
 ```text
-thread ‘<main>’ panicked at ‘This function never returns!’, hello.rs:2
+thread ‘main’ panicked at ‘This function never returns!’, hello.rs:2
 ```
 
 If you want more information, you can get a backtrace by setting the
@@ -229,7 +229,7 @@ If you want more information, you can get a backtrace by setting the
 
 ```text
 $ RUST_BACKTRACE=1 ./diverges
-thread '<main>' panicked at 'This function never returns!', hello.rs:2
+thread 'main' panicked at 'This function never returns!', hello.rs:2
 stack backtrace:
    1:     0x7f402773a829 - sys::backtrace::write::h0942de78b6c02817K8r
    2:     0x7f402773d7fc - panicking::on_panic::h3f23f9d0b5f4c91bu9w
@@ -255,7 +255,7 @@ Any other value(even no value at all) turns on backtrace.
 $ export RUST_BACKTRACE=1
 ...
 $ RUST_BACKTRACE=0 ./diverges 
-thread '<main>' panicked at 'This function never returns!', hello.rs:2
+thread 'main' panicked at 'This function never returns!', hello.rs:2
 note: Run with `RUST_BACKTRACE=1` for a backtrace.
 ```
 
@@ -264,7 +264,7 @@ note: Run with `RUST_BACKTRACE=1` for a backtrace.
 ```text
 $ RUST_BACKTRACE=1 cargo run
      Running `target/debug/diverges`
-thread '<main>' panicked at 'This function never returns!', hello.rs:2
+thread 'main' panicked at 'This function never returns!', hello.rs:2
 stack backtrace:
    1:     0x7f402773a829 - sys::backtrace::write::h0942de78b6c02817K8r
    2:     0x7f402773d7fc - panicking::on_panic::h3f23f9d0b5f4c91bu9w

--- a/src/doc/book/guessing-game.md
+++ b/src/doc/book/guessing-game.md
@@ -806,7 +806,7 @@ You guessed: 59
 You win!
 Please input your guess.
 quit
-thread '<main>' panicked at 'Please type a number!'
+thread 'main' panicked at 'Please type a number!'
 ```
 
 Ha! `quit` actually quits. As does any other non-number input. Well, this is

--- a/src/doc/book/strings.md
+++ b/src/doc/book/strings.md
@@ -163,7 +163,7 @@ let hachi = &dog[0..2];
 with this error:
 
 ```text
-thread '<main>' panicked at 'index 0 and/or 2 in `忠犬ハチ公` do not lie on
+thread 'main' panicked at 'index 0 and/or 2 in `忠犬ハチ公` do not lie on
 character boundary'
 ```
 

--- a/src/doc/book/testing.md
+++ b/src/doc/book/testing.md
@@ -107,7 +107,7 @@ failures:
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured
 
-thread '<main>' panicked at 'Some tests failed', /home/steve/src/rust/src/libtest/lib.rs:247
+thread 'main' panicked at 'Some tests failed', /home/steve/src/rust/src/libtest/lib.rs:247
 ```
 
 Rust indicates that our test failed:

--- a/src/doc/book/vectors.md
+++ b/src/doc/book/vectors.md
@@ -79,7 +79,7 @@ println!("Item 7 is {}", v[7]);
 then the current thread will [panic] with a message like this:
 
 ```text
-thread '<main>' panicked at 'index out of bounds: the len is 3 but the index is 7'
+thread 'main' panicked at 'index out of bounds: the len is 3 but the index is 7'
 ```
 
 If you want to handle out-of-bounds errors without panicking, you can use

--- a/src/libstd/rt.rs
+++ b/src/libstd/rt.rs
@@ -51,7 +51,7 @@ fn lang_start(main: *const u8, argc: isize, argv: *const *const u8) -> isize {
         // created. Note that this isn't necessary in general for new threads,
         // but we just do this to name the main thread and to give it correct
         // info about the stack bounds.
-        let thread: Thread = NewThread::new(Some("<main>".to_owned()));
+        let thread: Thread = NewThread::new(Some("main".to_owned()));
         thread_info::set(main_guard, thread);
 
         // Store our args if necessary in a squirreled away location

--- a/src/test/run-fail/main-panic.rs
+++ b/src/test/run-fail/main-panic.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:thread '<main>' panicked at
+// error-pattern:thread 'main' panicked at
 
 fn main() {
     panic!()

--- a/src/test/run-fail/overflowing-add.rs
+++ b/src/test/run-fail/overflowing-add.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread '<main>' panicked at 'arithmetic operation overflowed'
+// error-pattern:thread 'main' panicked at 'arithmetic operation overflowed'
 // compile-flags: -C debug-assertions
 
 

--- a/src/test/run-fail/overflowing-lsh-1.rs
+++ b/src/test/run-fail/overflowing-lsh-1.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread '<main>' panicked at 'shift operation overflowed'
+// error-pattern:thread 'main' panicked at 'shift operation overflowed'
 // compile-flags: -C debug-assertions
 
 #![warn(exceeding_bitshifts)]

--- a/src/test/run-fail/overflowing-lsh-2.rs
+++ b/src/test/run-fail/overflowing-lsh-2.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread '<main>' panicked at 'shift operation overflowed'
+// error-pattern:thread 'main' panicked at 'shift operation overflowed'
 // compile-flags: -C debug-assertions
 
 #![warn(exceeding_bitshifts)]

--- a/src/test/run-fail/overflowing-lsh-3.rs
+++ b/src/test/run-fail/overflowing-lsh-3.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread '<main>' panicked at 'shift operation overflowed'
+// error-pattern:thread 'main' panicked at 'shift operation overflowed'
 // compile-flags: -C debug-assertions
 
 #![warn(exceeding_bitshifts)]

--- a/src/test/run-fail/overflowing-lsh-4.rs
+++ b/src/test/run-fail/overflowing-lsh-4.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread '<main>' panicked at 'shift operation overflowed'
+// error-pattern:thread 'main' panicked at 'shift operation overflowed'
 // compile-flags: -C debug-assertions
 
 // This function is checking that our automatic truncation does not

--- a/src/test/run-fail/overflowing-mul.rs
+++ b/src/test/run-fail/overflowing-mul.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread '<main>' panicked at 'arithmetic operation overflowed'
+// error-pattern:thread 'main' panicked at 'arithmetic operation overflowed'
 // compile-flags: -C debug-assertions
 
 #![feature(rustc_attrs)]

--- a/src/test/run-fail/overflowing-neg.rs
+++ b/src/test/run-fail/overflowing-neg.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread '<main>' panicked at 'attempted to negate with overflow'
+// error-pattern:thread 'main' panicked at 'attempted to negate with overflow'
 // compile-flags: -C debug-assertions
 
 #![feature(rustc_attrs)]

--- a/src/test/run-fail/overflowing-pow.rs
+++ b/src/test/run-fail/overflowing-pow.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:thread '<main>' panicked at 'arithmetic operation overflowed'
+// error-pattern:thread 'main' panicked at 'arithmetic operation overflowed'
 // compile-flags: -C debug-assertions
 
 fn main() {

--- a/src/test/run-fail/overflowing-rsh-1.rs
+++ b/src/test/run-fail/overflowing-rsh-1.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread '<main>' panicked at 'shift operation overflowed'
+// error-pattern:thread 'main' panicked at 'shift operation overflowed'
 // compile-flags: -C debug-assertions
 
 #![warn(exceeding_bitshifts)]

--- a/src/test/run-fail/overflowing-rsh-2.rs
+++ b/src/test/run-fail/overflowing-rsh-2.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread '<main>' panicked at 'shift operation overflowed'
+// error-pattern:thread 'main' panicked at 'shift operation overflowed'
 // compile-flags: -C debug-assertions
 
 #![warn(exceeding_bitshifts)]

--- a/src/test/run-fail/overflowing-rsh-3.rs
+++ b/src/test/run-fail/overflowing-rsh-3.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread '<main>' panicked at 'shift operation overflowed'
+// error-pattern:thread 'main' panicked at 'shift operation overflowed'
 // compile-flags: -C debug-assertions
 
 #![warn(exceeding_bitshifts)]

--- a/src/test/run-fail/overflowing-rsh-4.rs
+++ b/src/test/run-fail/overflowing-rsh-4.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread '<main>' panicked at 'shift operation overflowed'
+// error-pattern:thread 'main' panicked at 'shift operation overflowed'
 // compile-flags: -C debug-assertions
 
 // This function is checking that our (type-based) automatic

--- a/src/test/run-fail/overflowing-rsh-5.rs
+++ b/src/test/run-fail/overflowing-rsh-5.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread '<main>' panicked at 'shift operation overflowed'
+// error-pattern:thread 'main' panicked at 'shift operation overflowed'
 // compile-flags: -C debug-assertions
 
 #![warn(exceeding_bitshifts)]

--- a/src/test/run-fail/overflowing-rsh-6.rs
+++ b/src/test/run-fail/overflowing-rsh-6.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread '<main>' panicked at 'shift operation overflowed'
+// error-pattern:thread 'main' panicked at 'shift operation overflowed'
 // compile-flags: -C debug-assertions
 
 #![warn(exceeding_bitshifts)]

--- a/src/test/run-fail/overflowing-sub.rs
+++ b/src/test/run-fail/overflowing-sub.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread '<main>' panicked at 'arithmetic operation overflowed'
+// error-pattern:thread 'main' panicked at 'arithmetic operation overflowed'
 // compile-flags: -C debug-assertions
 
 #![feature(rustc_attrs)]

--- a/src/test/run-fail/panic-set-unset-handler.rs
+++ b/src/test/run-fail/panic-set-unset-handler.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:thread '<main>' panicked at 'foobar'
+// error-pattern:thread 'main' panicked at 'foobar'
 
 #![feature(std_panic, panic_handler)]
 use std::panic;

--- a/src/test/run-fail/panic-take-handler-nop.rs
+++ b/src/test/run-fail/panic-take-handler-nop.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:thread '<main>' panicked at 'foobar'
+// error-pattern:thread 'main' panicked at 'foobar'
 
 #![feature(std_panic, panic_handler)]
 use std::panic;

--- a/src/test/run-pass/multi-panic.rs
+++ b/src/test/run-pass/multi-panic.rs
@@ -15,7 +15,7 @@ fn check_for_no_backtrace(test: std::process::Output) {
 
     assert_eq!(it.next().map(|l| l.starts_with("thread '<unnamed>' panicked at")), Some(true));
     assert_eq!(it.next(), Some("note: Run with `RUST_BACKTRACE=1` for a backtrace."));
-    assert_eq!(it.next().map(|l| l.starts_with("thread '<main>' panicked at")), Some(true));
+    assert_eq!(it.next().map(|l| l.starts_with("thread 'main' panicked at")), Some(true));
     assert_eq!(it.next(), None);
 }
 

--- a/src/tools/cargotest/main.rs
+++ b/src/tools/cargotest/main.rs
@@ -25,7 +25,7 @@ const TEST_REPOS: &'static [Test] = &[
     Test {
         name: "cargo",
         repo: "https://github.com/rust-lang/cargo",
-        sha: "26288f799427f9cc6e8bdddd782a17a8156ebc64",
+        sha: "7d79da08238e3d47e0bc4406155bdcc45ccb8c82",
         lock: None,
     },
     Test {


### PR DESCRIPTION
Fix issue #33789 

We may need to discuss whether this counts as a breaking change since code may check the main thread name against "<main>". Discussion is in #33789 
