### PR TITLE
Mark panicking::panicking() with #[inline]

### DIFF
--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -274,6 +274,7 @@ pub unsafe fn try<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<Any + Send>> {
 }
 
 /// Determines whether the current thread is unwinding because of panic.
+#[inline]
 pub fn panicking() -> bool {
     PANIC_COUNT.with(|c| c.get() != 0)
 }


### PR DESCRIPTION
This function is used by the mutex poisoning logic, and inlining it can improve the performance of mutexes.
