### PR TITLE
Increase spacing in error format for readability. 

### DIFF
--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -977,7 +977,11 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                         if let Categorization::Local(local_id) = err.cmt.cat {
                             let span = self.tcx.map.span(local_id);
                             if let Ok(snippet) = self.tcx.sess.codemap().span_to_snippet(span) {
-                                if snippet != "self" {
+                                if snippet.starts_with("ref ") {
+                                    db.span_label(span,
+                                        &format!("use `{}` here to make mutable",
+                                            snippet.replace("ref ", "ref mut ")));
+                                } else if snippet != "self" {
                                     db.span_label(span,
                                         &format!("use `mut {}` here to make mutable", snippet));
                                 }

--- a/src/libsyntax/errors/emitter.rs
+++ b/src/libsyntax/errors/emitter.rs
@@ -238,7 +238,7 @@ impl EmitterWriter {
                 self.first = false;
             } else {
                 if !self.old_school {
-                    write!(self.dst, "\n\n")?;
+                    write!(self.dst, "\n")?;
                 }
             }
         }
@@ -682,6 +682,7 @@ mod test {
         println!("r#\"\n{}\"#", str);
         assert_eq!(str, &r#"
   --> dummy.txt:11:1
+   |>
 11 |>         e-lä-vän
    |> ^
 "#[1..]);
@@ -746,6 +747,7 @@ mod test {
 
         let expect_start = &r#"
  --> dummy.txt:1:6
+  |>
 1 |> _____aaaaaa____bbbbbb__cccccdd_
   |>      ^^^^^^    ^^^^^^  ^^^^^^^
 "#[1..];
@@ -818,6 +820,7 @@ mod test {
 
         let expect0 = &r#"
    --> dummy.txt:5:1
+    |>
 5   |> ccccc
     |> ^
 ...
@@ -830,6 +833,7 @@ mod test {
 
         let expect = &r#"
    --> dummy.txt:1:1
+    |>
 1   |> aaaaa
     |> ^
 ...

--- a/src/libsyntax/errors/emitter.rs
+++ b/src/libsyntax/errors/emitter.rs
@@ -238,7 +238,7 @@ impl EmitterWriter {
                 self.first = false;
             } else {
                 if !self.old_school {
-                    write!(self.dst, "\n")?;
+                    write!(self.dst, "\n\n")?;
                 }
             }
         }

--- a/src/libsyntax/errors/snippet/mod.rs
+++ b/src/libsyntax/errors/snippet/mod.rs
@@ -494,6 +494,13 @@ impl FileInfo {
                         }],
                         kind: RenderedLineKind::OtherFileName,
                     });
+                    output.push(RenderedLine {
+                        text: vec![StyledString {
+                            text: "".to_string(),
+                            style: Style::FileNameStyle,
+                        }],
+                        kind: RenderedLineKind::Annotations,
+                    });
                 }
             }
         }

--- a/src/libsyntax/errors/snippet/mod.rs
+++ b/src/libsyntax/errors/snippet/mod.rs
@@ -478,6 +478,13 @@ impl FileInfo {
                         }],
                         kind: RenderedLineKind::PrimaryFileName,
                     });
+                    output.push(RenderedLine {
+                        text: vec![StyledString {
+                            text: "".to_string(),
+                            style: Style::FileNameStyle,
+                        }],
+                        kind: RenderedLineKind::Annotations,
+                    });
                 }
                 None => {
                     output.push(RenderedLine {

--- a/src/libsyntax/errors/snippet/test.rs
+++ b/src/libsyntax/errors/snippet/test.rs
@@ -98,6 +98,7 @@ fn foo() {
     let text = make_string(&lines);
     assert_eq!(&text[..], &"
  --> foo.rs:3:2
+  |>
 3 |> \tbar;
   |> \t^^^
 "[1..]);
@@ -130,6 +131,7 @@ fn foo() {
     println!("text=\n{}", text);
     assert_eq!(&text[..], &r#"
  ::: foo.rs
+  |>
 3 |>     vec.push(vec.pop().unwrap());
   |>     ---      ---                - previous borrow ends here
   |>     |        |
@@ -199,12 +201,14 @@ fn bar() {
     // Note that the `|>` remain aligned across both files:
     assert_eq!(&text[..], &r#"
    --> foo.rs:3:14
+    |>
 3   |>     vec.push(vec.pop().unwrap());
     |>     ---      ^^^                - c
     |>     |        |
     |>     |        b
     |>     a
    ::: bar.rs
+    |>
 17  |>     vec.push();
     |>     ---       - f
     |>     |
@@ -249,6 +253,7 @@ fn foo() {
     println!("text=\n{}", text);
     assert_eq!(&text[..], &r#"
    ::: foo.rs
+    |>
 3   |>     let name = find_id(&data, 22).unwrap();
     |>                         ---- immutable borrow begins here
 ...
@@ -288,6 +293,7 @@ fn foo() {
     println!("text=r#\"\n{}\".trim_left()", text);
     assert_eq!(&text[..], &r#"
  ::: foo.rs
+  |>
 3 |>     vec.push(vec.pop().unwrap());
   |>     --------           ------ D
   |>     ||
@@ -324,6 +330,7 @@ fn foo() {
     println!("text=r#\"\n{}\".trim_left()", text);
     assert_eq!(&text[..], &r#"
  ::: foo.rs
+  |>
 3 |>     vec.push(vec.pop().unwrap());
   |>     ---      ---                - previous borrow ends here
   |>     |        |
@@ -362,6 +369,7 @@ fn foo() {
     println!("text=r#\"\n{}\".trim_left()", text);
     assert_eq!(&text[..], &r#"
    ::: foo.rs
+    |>
 4   |>     let mut vec2 = vec;
     |>                    --- `vec` moved here because it has type `collections::vec::Vec<i32>`
 ...
@@ -398,6 +406,7 @@ fn foo() {
     println!("text=&r#\"\n{}\n\"#[1..]", text);
     assert_eq!(text, &r#"
  ::: foo.rs
+  |>
 3 |>     let mut vec = vec![0, 1, 2];
   |>             ---   ---
 4 |>     let mut vec2 = vec;
@@ -429,6 +438,7 @@ impl SomeTrait for () {
     println!("r#\"\n{}\"", text);
     assert_eq!(text, &r#"
  ::: foo.rs
+  |>
 3 |>     fn foo(x: u32) {
   |>     -
 "#[1..]);
@@ -458,6 +468,7 @@ fn span_overlap_label() {
     println!("r#\"\n{}\"", text);
     assert_eq!(text, &r#"
  ::: foo.rs
+  |>
 2 |>     fn foo(x: u32) {
   |>     --------------
   |>     |      |
@@ -492,6 +503,7 @@ fn span_overlap_label2() {
     println!("r#\"\n{}\"", text);
     assert_eq!(text, &r#"
  ::: foo.rs
+  |>
 2 |>     fn foo(x: u32) {
   |>     --------------
   |>     |      |
@@ -537,6 +549,7 @@ fn span_overlap_label3() {
     println!("r#\"\n{}\"", text);
     assert_eq!(text, &r#"
  ::: foo.rs
+  |>
 3 |>        let closure = || {
   |>                      - foo
 4 |>            inner
@@ -577,6 +590,7 @@ fn main() {
     println!("r#\"\n{}\"", text);
     assert_eq!(text, &r#"
   --> foo.rs:11:2
+   |>
 11 |> }
    |>  -
 "#[1..]);

--- a/src/test/compile-fail/issue-33819.rs
+++ b/src/test/compile-fail/issue-33819.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let mut op = Some(2);
+    match op {
+        Some(ref v) => { let a = &mut v; },
+        //~^ ERROR:cannot borrow immutable
+        //~| use `ref mut v` here to make mutable
+        None => {},
+    }
+}

--- a/src/test/compile-fail/issue-33819.rs
+++ b/src/test/compile-fail/issue-33819.rs
@@ -1,3 +1,12 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
 fn main() {
     let mut op = Some(2);
     match op {

--- a/src/test/ui/mismatched_types/issue-26480.rs
+++ b/src/test/ui/mismatched_types/issue-26480.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// rustc-env:RUST_NEW_ERROR_FORMAT
 extern {
     fn write(fildes: i32, buf: *const i8, nbyte: u64) -> i64;
 }
@@ -24,25 +25,16 @@ macro_rules! write {
         unsafe {
             write(stdout, $arr.as_ptr() as *const i8,
                   $arr.len() * size_of($arr[0]));
-            //~^ ERROR mismatched types
-            //~| expected u64, found usize
-            //~| expected type
-            //~| found type
         }
     }}
 }
 
 macro_rules! cast {
-    ($x:expr) => ($x as ()) //~ ERROR non-scalar cast
+    ($x:expr) => ($x as ()) 
 }
 
 fn main() {
     let hello = ['H', 'e', 'y'];
     write!(hello);
-    //~^ NOTE in this expansion of write!
-    //~| NOTE in this expansion of write!
-    //~| NOTE in this expansion of write!
-
     cast!(2);
-    //~^ NOTE in this expansion of cast!
 }

--- a/src/test/ui/mismatched_types/issue-26480.rs
+++ b/src/test/ui/mismatched_types/issue-26480.rs
@@ -30,7 +30,7 @@ macro_rules! write {
 }
 
 macro_rules! cast {
-    ($x:expr) => ($x as ()) 
+    ($x:expr) => ($x as ())
 }
 
 fn main() {

--- a/src/test/ui/mismatched_types/issue-26480.stderr
+++ b/src/test/ui/mismatched_types/issue-26480.stderr
@@ -5,13 +5,11 @@ error: mismatched types [--explain E0308]
    |>                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected u64, found usize
 $DIR/issue-26480.rs:38:5: 38:19: note: in this expansion of write! (defined in $DIR/issue-26480.rs)
 
-
 error: non-scalar cast: `_` as `()`
   --> $DIR/issue-26480.rs:33:19
    |>
 33 |>     ($x:expr) => ($x as ())
    |>                   ^^^^^^^^
 $DIR/issue-26480.rs:39:5: 39:14: note: in this expansion of cast! (defined in $DIR/issue-26480.rs)
-
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/mismatched_types/issue-26480.stderr
+++ b/src/test/ui/mismatched_types/issue-26480.stderr
@@ -1,0 +1,17 @@
+error: mismatched types [--explain E0308]
+  --> $DIR/issue-26480.rs:27:19
+   |>
+27 |>                   $arr.len() * size_of($arr[0]));
+   |>                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected u64, found usize
+$DIR/issue-26480.rs:38:5: 38:19: note: in this expansion of write! (defined in $DIR/issue-26480.rs)
+
+
+error: non-scalar cast: `_` as `()`
+  --> $DIR/issue-26480.rs:33:19
+   |>
+33 |>     ($x:expr) => ($x as ())
+   |>                   ^^^^^^^^
+$DIR/issue-26480.rs:39:5: 39:14: note: in this expansion of cast! (defined in $DIR/issue-26480.rs)
+
+
+error: aborting due to 2 previous errors

--- a/src/test/ui/mismatched_types/main.stderr
+++ b/src/test/ui/mismatched_types/main.stderr
@@ -1,8 +1,10 @@
 error: mismatched types [--explain E0308]
   --> $DIR/main.rs:14:18
+   |>
 14 |>     let x: u32 = (
    |>                  ^ expected u32, found ()
 note: expected type `u32`
 note:    found type `()`
+
 
 error: aborting due to previous error

--- a/src/test/ui/mismatched_types/main.stderr
+++ b/src/test/ui/mismatched_types/main.stderr
@@ -6,5 +6,4 @@ error: mismatched types [--explain E0308]
 note: expected type `u32`
 note:    found type `()`
 
-
 error: aborting due to previous error


### PR DESCRIPTION
Two small tweaks that seem to help readability quite a bit:
- Add spacing header<->snippet, but use the |> on the side for visual consistency
- Fix #33819 
- Fix #33763
- Move format-sensitive test (issue-26480 in cfail) to ui test

r? @nikomatsakis 
