### PR TITLE
text-transform not guaranteed to not inherit for input

### DIFF
--- a/src/librustdoc/html/static/styles/main.css
+++ b/src/librustdoc/html/static/styles/main.css
@@ -122,6 +122,7 @@ a.test-arrow {
     color: #555;
     box-shadow: 0 0 0 1px #e0e0e0, 0 0 0 2px transparent;
     background-color: white;
+    text-transform: none;
 }
 
 em.stab.unstable { background: #FFF5D6; border-color: #FFC600; }


### PR DESCRIPTION
It seems to work in most browsers but perhaps not all. The standard doesn't guarantee that this will work.

Without these changes we get allcaps in the search box: https://github.com/servo/servo/issues/11362
