### PR TITLE
syntax: Make codemap::get_filemap() return an Option

### DIFF
--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -757,6 +757,7 @@ fn get_source(input: &Input, sess: &Session) -> (Vec<u8>, String) {
     let src_name = driver::source_name(input);
     let src = sess.codemap()
                   .get_filemap(&src_name)
+                  .unwrap()
                   .src
                   .as_ref()
                   .unwrap()

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -1191,13 +1191,13 @@ impl CodeMap {
         }
     }
 
-    pub fn get_filemap(&self, filename: &str) -> Rc<FileMap> {
+    pub fn get_filemap(&self, filename: &str) -> Option<Rc<FileMap>> {
         for fm in self.files.borrow().iter() {
             if filename == fm.name {
-                return fm.clone();
+                return Some(fm.clone());
             }
         }
-        panic!("asking for {} which we don't know about", filename);
+        None
     }
 
     /// For a global BytePos compute the local offset within the containing FileMap


### PR DESCRIPTION
This is more idiomatic, putting the caller in charge of whether or not
to panic.
