### PR TITLE
[WIP] Macro rules backtracking

### DIFF
--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1276,8 +1276,8 @@ impl TokenTree {
     }
 
     /// Use this token tree as a matcher to parse given tts.
-    pub fn parse(cx: &base::ExtCtxt, mtch: &[TokenTree], tts: &[TokenTree])
-                 -> macro_parser::NamedParseResult {
+    pub fn parse<'a>(cx: &'a base::ExtCtxt, mtch: &[TokenTree], tts: &[TokenTree])
+                     -> macro_parser::NamedParseResult<'a> {
         // `None` is because we're not interpolating
         let arg_rdr = lexer::new_tt_reader_with_doc_flag(&cx.parse_sess().span_diagnostic,
                                                          None,

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -330,6 +330,10 @@ impl MultiSpan {
         &self.primary_spans
     }
 
+    pub fn primary_spans_mut(&mut self) -> &mut [Span] {
+        &mut self.primary_spans
+    }
+
     /// Returns the strings to highlight. We always ensure that there
     /// is an entry for each of the primary spans -- for each primary
     /// span P, if there is at least one label with span P, we return

--- a/src/libsyntax/errors/mod.rs
+++ b/src/libsyntax/errors/mod.rs
@@ -184,7 +184,7 @@ pub struct DiagnosticBuilder<'a> {
     level: Level,
     message: String,
     code: Option<String>,
-    span: MultiSpan,
+    pub span: MultiSpan,
     children: Vec<SubDiagnostic>,
 }
 
@@ -302,18 +302,9 @@ impl<'a> DiagnosticBuilder<'a> {
         self
     }
 
-    pub fn set_span<S: Into<MultiSpan>>(&mut self, sp: S) -> &mut Self {
-        self.span = sp.into();
-        self
-    }
-
     pub fn code(&mut self, s: String) -> &mut Self {
         self.code = Some(s);
         self
-    }
-
-    pub fn span(&self) -> &MultiSpan {
-        &self.span
     }
 
     pub fn message(&self) -> &str {
@@ -425,7 +416,7 @@ impl Handler {
                                                     msg: &str)
                                                     -> DiagnosticBuilder<'a> {
         let mut result = DiagnosticBuilder::new(self, Level::Warning, msg);
-        result.set_span(sp);
+        result.span = sp.into();
         if !self.can_emit_warnings {
             result.cancel();
         }
@@ -437,7 +428,7 @@ impl Handler {
                                                               code: &str)
                                                               -> DiagnosticBuilder<'a> {
         let mut result = DiagnosticBuilder::new(self, Level::Warning, msg);
-        result.set_span(sp);
+        result.span = sp.into();
         result.code(code.to_owned());
         if !self.can_emit_warnings {
             result.cancel();
@@ -457,7 +448,7 @@ impl Handler {
                                                    -> DiagnosticBuilder<'a> {
         self.bump_err_count();
         let mut result = DiagnosticBuilder::new(self, Level::Error, msg);
-        result.set_span(sp);
+        result.span = sp.into();
         result
     }
     pub fn struct_span_err_with_code<'a, S: Into<MultiSpan>>(&'a self,
@@ -467,7 +458,7 @@ impl Handler {
                                                              -> DiagnosticBuilder<'a> {
         self.bump_err_count();
         let mut result = DiagnosticBuilder::new(self, Level::Error, msg);
-        result.set_span(sp);
+        result.span = sp.into();
         result.code(code.to_owned());
         result
     }
@@ -481,7 +472,7 @@ impl Handler {
                                                      -> DiagnosticBuilder<'a> {
         self.bump_err_count();
         let mut result = DiagnosticBuilder::new(self, Level::Fatal, msg);
-        result.set_span(sp);
+        result.span = sp.into();
         result
     }
     pub fn struct_span_fatal_with_code<'a, S: Into<MultiSpan>>(&'a self,
@@ -491,7 +482,7 @@ impl Handler {
                                                                -> DiagnosticBuilder<'a> {
         self.bump_err_count();
         let mut result = DiagnosticBuilder::new(self, Level::Fatal, msg);
-        result.set_span(sp);
+        result.span = sp.into();
         result.code(code.to_owned());
         result
     }

--- a/src/libsyntax/errors/mod.rs
+++ b/src/libsyntax/errors/mod.rs
@@ -499,7 +499,7 @@ impl Handler {
     pub fn cancel(&mut self, err: &mut DiagnosticBuilder) {
         if err.level == Level::Error || err.level == Level::Fatal {
             assert!(self.has_errors());
-            self.err_count.set(self.err_count.get() + 1);
+            self.err_count.set(self.err_count.get() - 1);
         }
         err.cancel();
     }

--- a/src/libsyntax/errors/mod.rs
+++ b/src/libsyntax/errors/mod.rs
@@ -496,7 +496,7 @@ impl Handler {
         DiagnosticBuilder::new(self, Level::Fatal, msg)
     }
 
-    pub fn cancel(&mut self, err: &mut DiagnosticBuilder) {
+    pub fn cancel(&self, err: &mut DiagnosticBuilder) {
         if err.level == Level::Error || err.level == Level::Fatal {
             assert!(self.has_errors());
             self.err_count.set(self.err_count.get() - 1);

--- a/src/libsyntax/errors/mod.rs
+++ b/src/libsyntax/errors/mod.rs
@@ -312,6 +312,10 @@ impl<'a> DiagnosticBuilder<'a> {
         self
     }
 
+    pub fn span(&self) -> &MultiSpan {
+        &self.span
+    }
+
     pub fn message(&self) -> &str {
         &self.message
     }

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -513,7 +513,7 @@ pub fn parse_nt<'a>(p: &mut Parser<'a>, sp: Span, name: &str) -> PResult<'a, Non
         "tt" => {
             p.quote_depth += 1; //but in theory, non-quoted tts might be useful
             let res: ::parse::PResult<'a, _> = p.parse_token_tree();
-            let res = token::NtTT(P(try!(res)));
+            let res = token::NtTT(P(res?));
             p.quote_depth -= 1;
             return Ok(res);
         }
@@ -522,18 +522,18 @@ pub fn parse_nt<'a>(p: &mut Parser<'a>, sp: Span, name: &str) -> PResult<'a, Non
     // check at the beginning and the parser checks after each bump
     p.check_unknown_macro_variable();
     match name {
-        "item" => match try!(p.parse_item()) {
+        "item" => match p.parse_item()? {
             Some(i) => Ok(token::NtItem(i)),
             None => Err(p.fatal("expected an item keyword"))
         },
-        "block" => Ok(token::NtBlock(try!(p.parse_block()))),
-        "stmt" => match try!(p.parse_stmt()) {
+        "block" => Ok(token::NtBlock(p.parse_block()?)),
+        "stmt" => match p.parse_stmt()? {
             Some(s) => Ok(token::NtStmt(P(s))),
             None => Err(p.fatal("expected a statement"))
         },
-        "pat" => Ok(token::NtPat(try!(p.parse_pat()))),
-        "expr" => Ok(token::NtExpr(try!(p.parse_expr()))),
-        "ty" => Ok(token::NtTy(try!(p.parse_ty()))),
+        "pat" => Ok(token::NtPat(p.parse_pat()?)),
+        "expr" => Ok(token::NtExpr(p.parse_expr()?)),
+        "ty" => Ok(token::NtTy(p.parse_ty()?)),
         // this could be handled like a token, since it is one
         "ident" => match p.token {
             token::Ident(sn) => {
@@ -545,8 +545,8 @@ pub fn parse_nt<'a>(p: &mut Parser<'a>, sp: Span, name: &str) -> PResult<'a, Non
                 Err(p.fatal(&format!("expected ident, found {}", &token_str[..])))
             }
         },
-        "path" => Ok(token::NtPath(Box::new(try!(p.parse_path(PathStyle::Type))))),
-        "meta" => Ok(token::NtMeta(try!(p.parse_meta_item()))),
+        "path" => Ok(token::NtPath(Box::new(p.parse_path(PathStyle::Type)?))),
+        "meta" => Ok(token::NtMeta(p.parse_meta_item()?)),
         // this is not supposed to happen, since it has been checked
         // when compiling the macro.
         _ => p.span_bug(sp, "invalid fragment specifier")

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -218,7 +218,7 @@ fn generic_extension<'cx>(cx: &'cx mut ExtCtxt,
                 })
             }
             Failure(diag) => {
-                let sp = diag.span().primary_span();
+                let sp = diag.span.primary_span();
                 let mut new_diag = Some(diag);
                 if let Some(sp) = sp {
                     if sp.lo >= best_fail_spot.lo {
@@ -238,11 +238,9 @@ fn generic_extension<'cx>(cx: &'cx mut ExtCtxt,
     match best_fail_diag {
         None => cx.span_bug(sp, "internal error: ran no matchers"),
         Some(mut diag) => {
-            let mut span = diag.span().clone();
-            for span in span.primary_spans_mut() {
+            for span in diag.span.primary_spans_mut() {
                 *span = span.substitute_dummy(sp);
             }
-            diag.set_span(span);
             diag.emit();
             panic!(FatalError);
         }
@@ -302,11 +300,9 @@ pub fn compile<'cx>(cx: &'cx mut ExtCtxt,
                                    &argument_gram) {
         Success(m) => m,
         Failure(mut diag) => {
-            let mut span = diag.span().clone();
-            for span in span.primary_spans_mut() {
+            for span in diag.span.primary_spans_mut() {
                 *span = span.substitute_dummy(def.span);
             }
-            diag.set_span(span);
             diag.emit();
             panic!(FatalError);
         }

--- a/src/test/run-pass-fulldeps/auxiliary/procedural_mbe_matching.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/procedural_mbe_matching.rs
@@ -56,8 +56,12 @@ fn expand_mbe_matches(cx: &mut ExtCtxt, sp: Span, args: &[TokenTree])
                 _ => unreachable!()
             }
         }
-        Failure(_, s) | Error(_, s) => {
-            panic!("expected Success, but got Error/Failure: {}", s);
+        Failure(diag) => {
+            diag.span_help(sp, "expected Success, but got Failure");
+            panic!(diag);
+        }
+        Error(_, s) => {
+            panic!("expected Success, but got Error: {}", s);
         }
     };
 

--- a/src/test/run-pass-fulldeps/auxiliary/procedural_mbe_matching.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/procedural_mbe_matching.rs
@@ -57,8 +57,8 @@ fn expand_mbe_matches(cx: &mut ExtCtxt, sp: Span, args: &[TokenTree])
             }
         }
         Failure(diag) => {
-            diag.span_help(sp, "expected Success, but got Failure");
-            panic!(diag);
+            diag.emit();
+            panic!("expected Success, but got Failure");
         }
         Error(_, s) => {
             panic!("expected Success, but got Error: {}", s);

--- a/src/test/run-pass/issue-27832.rs
+++ b/src/test/run-pass/issue-27832.rs
@@ -1,0 +1,20 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! m {
+    ( $i:ident ) => ();
+    ( $t:tt $j:tt ) => ();
+}
+
+fn main() {
+    m!(c);
+    m!(t 9);
+    m!(0 9);
+}


### PR DESCRIPTION
This fixes `macro_rules!` to implement the wanted backtracking semantics: if an arm fails to match, the next arm is tried, and so on.

This was previously not the case because of hard errors emitted during parsing of non-terminals. Now that the parser code has been fixed not to panic but to return a `DiagnosticBuilder` in case of error, it's easy to catch those errors and signal that the arm failed to match.

This PR probably contains a bit of hackery, so it's flagged as WIP so that people can review it.
