### PR TITLE
Implement `count` for `EscapeUnicode`

### DIFF
--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -483,6 +483,9 @@ impl Iterator for EscapeUnicode {
     }
 }
 
+#[stable(feature = "exact_size_escape", since = "1.11.0")]
+impl ExactSizeIterator for EscapeUnicode { }
+
 /// An iterator that yields the literal escape code of a `char`.
 ///
 /// This `struct` is created by the [`escape_default()`] method on [`char`]. See
@@ -577,6 +580,9 @@ impl Iterator for EscapeDefault {
         }
     }
 }
+
+#[stable(feature = "exact_size_escape", since = "1.11.0")]
+impl ExactSizeIterator for EscapeDefault { }
 
 /// An iterator over `u8` entries represending the UTF-8 encoding of a `char`
 /// value.

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -411,6 +411,9 @@ pub struct EscapeUnicode {
     hex_digit_idx: usize,
 }
 
+// The enum values are ordered so that their representation is the
+// same as the remaining length (besides the hexadecimal digits). This
+// likely makes `len()` a single load from memory) and inline-worth.
 #[derive(Clone, Debug)]
 enum EscapeUnicodeState {
     Done,

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -470,6 +470,11 @@ impl Iterator for EscapeUnicode {
         (n, Some(n))
     }
 
+    #[inline]
+    fn count(self) -> usize {
+        self.len()
+    }
+
     fn last(self) -> Option<char> {
         match self.state {
             EscapeUnicodeState::Done => None,
@@ -535,13 +540,9 @@ impl Iterator for EscapeDefault {
         }
     }
 
+    #[inline]
     fn count(self) -> usize {
-        match self.state {
-            EscapeDefaultState::Char(_) => 1,
-            EscapeDefaultState::Unicode(iter) => iter.count(),
-            EscapeDefaultState::Done => 0,
-            EscapeDefaultState::Backslash(_) => 2,
-        }
+        self.len()
     }
 
     fn nth(&mut self, n: usize) -> Option<char> {

--- a/src/libcoretest/char.rs
+++ b/src/libcoretest/char.rs
@@ -276,6 +276,12 @@ fn eu_iterator_specializations() {
             // Check last
             assert_eq!(iter.clone().last(), Some('}'));
 
+            // Check len
+            assert_eq!(iter.len(), len - offset);
+
+            // Check size_hint (= len in ExactSizeIterator)
+            assert_eq!(iter.size_hint(), (iter.len(), Some(iter.len())));
+
             // Check counting
             assert_eq!(iter.clone().count(), len - offset);
 


### PR DESCRIPTION
and cleanup the code for `count` for `EscapeDefault` (instead of repeating the `match` for `size_hint` and `count`).

This PR marks EscapeUnicode and EscapeDefault as ExactSizeIterator. The constraints for the trait implementations held even before this PR, but I am not sure if this is something we want to guarantee/expose (I would love feedback on this, especially on what would be the appropriate way to handle stabilisation, if needed).

Part of #24214, split from #31049.

The test for `count` was added in #33103.
