### PR TITLE
refactor autoderef to avoid prematurely registering obligations

### DIFF
--- a/src/librustc/traits/fulfill.rs
+++ b/src/librustc/traits/fulfill.rs
@@ -171,6 +171,8 @@ impl<'a, 'gcx, 'tcx> FulfillmentContext<'tcx> {
         // debug output much nicer to read and so on.
         let obligation = infcx.resolve_type_vars_if_possible(&obligation);
 
+        infcx.obligations_in_snapshot.set(true);
+
         if infcx.tcx.fulfilled_predicates.borrow().check_duplicate(&obligation.predicate)
         {
             return

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -31,7 +31,7 @@ pub use self::coherence::overlapping_impls;
 pub use self::coherence::OrphanCheckErr;
 pub use self::fulfill::{FulfillmentContext, GlobalFulfilledPredicates, RegionObligation};
 pub use self::project::{MismatchedProjectionTypes, ProjectionMode};
-pub use self::project::{normalize, Normalized};
+pub use self::project::{normalize, normalize_projection_type, Normalized};
 pub use self::object_safety::ObjectSafetyViolation;
 pub use self::object_safety::MethodViolationCode;
 pub use self::select::{EvaluationCache, SelectionContext, SelectionCache};

--- a/src/librustc/ty/adjustment.rs
+++ b/src/librustc/ty/adjustment.rs
@@ -235,8 +235,9 @@ impl<'a, 'gcx, 'tcx> ty::TyS<'tcx> {
             None => {
                 span_bug!(
                     expr_span,
-                    "the {}th autoderef failed: {}",
+                    "the {}th autoderef for {} failed: {}",
                     autoderef,
+                    expr_id,
                     adjusted_ty);
             }
         }

--- a/src/librustc_typeck/check/autoderef.rs
+++ b/src/librustc_typeck/check/autoderef.rs
@@ -1,0 +1,210 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use astconv::AstConv;
+
+use super::FnCtxt;
+
+use rustc::traits;
+use rustc::ty::{self, Ty, TraitRef};
+use rustc::ty::{ToPredicate, TypeFoldable};
+use rustc::ty::{MethodCall, MethodCallee};
+use rustc::ty::subst::Substs;
+use rustc::ty::{LvaluePreference, NoPreference, PreferMutLvalue};
+use rustc::hir;
+
+use syntax::codemap::Span;
+use syntax::parse::token;
+
+#[derive(Copy, Clone, Debug)]
+enum AutoderefKind {
+    Builtin,
+    Overloaded
+}
+
+pub struct Autoderef<'a, 'gcx: 'tcx, 'tcx: 'a> {
+    fcx: &'a FnCtxt<'a, 'gcx, 'tcx>,
+    steps: Vec<(Ty<'tcx>, AutoderefKind)>,
+    cur_ty: Ty<'tcx>,
+    obligations: Vec<traits::PredicateObligation<'tcx>>,
+    at_start: bool,
+    span: Span
+}
+
+impl<'a, 'gcx, 'tcx> Iterator for Autoderef<'a, 'gcx, 'tcx> {
+    type Item = (Ty<'tcx>, usize);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let tcx = self.fcx.tcx;
+
+        debug!("autoderef: steps={:?}, cur_ty={:?}",
+               self.steps, self.cur_ty);
+        if self.at_start {
+            self.at_start = false;
+            debug!("autoderef stage #0 is {:?}", self.cur_ty);
+            return Some((self.cur_ty, 0));
+        }
+
+        if self.steps.len() == tcx.sess.recursion_limit.get() {
+            // We've reached the recursion limit, error gracefully.
+            span_err!(tcx.sess, self.span, E0055,
+                      "reached the recursion limit while auto-dereferencing {:?}",
+                      self.cur_ty);
+            return None;
+        }
+
+        if self.cur_ty.is_ty_var() {
+            return None;
+        }
+
+        // Otherwise, deref if type is derefable:
+        let (kind, new_ty) = if let Some(mt) = self.cur_ty.builtin_deref(false, NoPreference) {
+            (AutoderefKind::Builtin, mt.ty)
+        } else {
+            match self.overloaded_deref_ty(self.cur_ty) {
+                Some(ty) => (AutoderefKind::Overloaded, ty),
+                _ => return None
+            }
+        };
+
+        if new_ty.references_error() {
+            return None;
+        }
+
+        self.steps.push((self.cur_ty, kind));
+        debug!("autoderef stage #{:?} is {:?} from {:?}", self.steps.len(),
+               new_ty, (self.cur_ty, kind));
+        self.cur_ty = new_ty;
+
+        Some((self.cur_ty, self.steps.len()))
+    }
+}
+
+impl<'a, 'gcx, 'tcx> Autoderef<'a, 'gcx, 'tcx> {
+    fn overloaded_deref_ty(&mut self, ty: Ty<'tcx>) -> Option<Ty<'tcx>> {
+        debug!("overloaded_deref_ty({:?})", ty);
+
+        let tcx = self.fcx.tcx();
+
+        // <cur_ty as Deref>
+        let trait_ref = TraitRef {
+            def_id: match tcx.lang_items.deref_trait() {
+                Some(f) => f,
+                None => return None
+            },
+            substs: tcx.mk_substs(Substs::new_trait(vec![], vec![], self.cur_ty))
+        };
+
+        let cause = traits::ObligationCause::misc(self.span, self.fcx.body_id);
+
+        let mut selcx = traits::SelectionContext::new(self.fcx);
+        let obligation = traits::Obligation::new(cause.clone(), trait_ref.to_predicate());
+        if !selcx.evaluate_obligation(&obligation) {
+            debug!("overloaded_deref_ty: cannot match obligation");
+            return None;
+        }
+
+        let normalized = traits::normalize_projection_type(
+            &mut selcx,
+            ty::ProjectionTy {
+                trait_ref: trait_ref,
+                item_name: token::intern("Target")
+            },
+            cause,
+            0
+        );
+
+        debug!("overloaded_deref_ty({:?}) = {:?}", ty, normalized);
+        self.obligations.extend(normalized.obligations);
+
+        Some(self.fcx.resolve_type_vars_if_possible(&normalized.value))
+    }
+
+    pub fn unambiguous_final_ty(&self) -> Ty<'tcx> {
+        self.fcx.structurally_resolved_type(self.span, self.cur_ty)
+    }
+
+    pub fn finalize<'b, I>(self, pref: LvaluePreference, exprs: I)
+        where I: IntoIterator<Item=&'b hir::Expr>
+    {
+        let methods : Vec<_> = self.steps.iter().map(|&(ty, kind)| {
+            if let AutoderefKind::Overloaded = kind {
+                self.fcx.try_overloaded_deref(self.span, None, ty, pref)
+            } else {
+                None
+            }
+        }).collect();
+
+        debug!("finalize({:?}) - {:?},{:?}", pref, methods, self.obligations);
+
+        for expr in exprs {
+            debug!("finalize - finalizing #{} - {:?}", expr.id, expr);
+            for (n, method) in methods.iter().enumerate() {
+                if let &Some(method) = method {
+                    let method_call = MethodCall::autoderef(expr.id, n as u32);
+                    self.fcx.tables.borrow_mut().method_map.insert(method_call, method);
+                }
+            }
+        }
+
+        for obligation in self.obligations {
+            self.fcx.register_predicate(obligation);
+        }
+    }
+}
+
+impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
+    pub fn autoderef(&'a self,
+                     span: Span,
+                     base_ty: Ty<'tcx>)
+                     -> Autoderef<'a, 'gcx, 'tcx>
+    {
+        Autoderef {
+            fcx: self,
+            steps: vec![],
+            cur_ty: self.resolve_type_vars_if_possible(&base_ty),
+            obligations: vec![],
+            at_start: true,
+            span: span
+        }
+    }
+
+    pub fn try_overloaded_deref(&self,
+                                span: Span,
+                                base_expr: Option<&hir::Expr>,
+                                base_ty: Ty<'tcx>,
+                                lvalue_pref: LvaluePreference)
+                                -> Option<MethodCallee<'tcx>>
+    {
+        debug!("try_overloaded_deref({:?},{:?},{:?},{:?})",
+               span, base_expr, base_ty, lvalue_pref);
+        // Try DerefMut first, if preferred.
+        let method = match (lvalue_pref, self.tcx.lang_items.deref_mut_trait()) {
+            (PreferMutLvalue, Some(trait_did)) => {
+                self.lookup_method_in_trait(span, base_expr,
+                                            token::intern("deref_mut"), trait_did,
+                                            base_ty, None)
+            }
+            _ => None
+        };
+
+        // Otherwise, fall back to Deref.
+        let method = match (method, self.tcx.lang_items.deref_trait()) {
+            (None, Some(trait_did)) => {
+                self.lookup_method_in_trait(span, base_expr,
+                                            token::intern("deref"), trait_did,
+                                            base_ty, None)
+            }
+            (method, _) => method
+        };
+
+        method
+    }
+}

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -363,6 +363,8 @@ impl<'f, 'gcx, 'tcx> Coerce<'f, 'gcx, 'tcx> {
             }
         };
 
+        // This commits the obligations to the fulfillcx. After this succeeds,
+        // this snapshot can't be rolled back.
         autoderef.finalize(LvaluePreference::from_mutbl(mt_b.mutbl), exprs());
 
         // Now apply the autoref. We have to extract the region out of

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -60,7 +60,7 @@
 //! sort of a minor point so I've opted to leave it for later---after all
 //! we may want to adjust precisely when coercions occur.
 
-use check::{FnCtxt, UnresolvedTypeAction};
+use check::{FnCtxt};
 
 use rustc::hir;
 use rustc::infer::{Coercion, InferOk, TypeOrigin, TypeTrace};
@@ -220,7 +220,8 @@ impl<'f, 'gcx, 'tcx> Coerce<'f, 'gcx, 'tcx> {
                                          -> CoerceResult<'tcx>
         // FIXME(eddyb) use copyable iterators when that becomes ergonomic.
         where E: Fn() -> I,
-              I: IntoIterator<Item=&'a hir::Expr> {
+              I: IntoIterator<Item=&'a hir::Expr>
+    {
 
         debug!("coerce_borrowed_pointer(a={:?}, b={:?})", a, b);
 
@@ -240,18 +241,16 @@ impl<'f, 'gcx, 'tcx> Coerce<'f, 'gcx, 'tcx> {
 
         let span = self.origin.span();
 
-        let lvalue_pref = LvaluePreference::from_mutbl(mt_b.mutbl);
         let mut first_error = None;
         let mut r_borrow_var = None;
-        let (_, autoderefs, success) = self.autoderef(span, a, exprs,
-                                                      UnresolvedTypeAction::Ignore,
-                                                      lvalue_pref,
-                                                      |referent_ty, autoderef|
-        {
-            if autoderef == 0 {
+        let mut autoderef = self.autoderef(span, a);
+        let mut success = None;
+
+        for (referent_ty, autoderefs) in autoderef.by_ref() {
+            if autoderefs == 0 {
                 // Don't let this pass, otherwise it would cause
                 // &T to autoref to &&T.
-                return None;
+                continue
             }
 
             // At this point, we have deref'd `a` to `referent_ty`.  So
@@ -326,7 +325,7 @@ impl<'f, 'gcx, 'tcx> Coerce<'f, 'gcx, 'tcx> {
             //     and let regionck figure it out.
             let r = if !self.use_lub {
                 r_b // [2] above
-            } else if autoderef == 1 {
+            } else if autoderefs == 1 {
                 r_a // [3] above
             } else {
                 if r_borrow_var.is_none() { // create var lazilly, at most once
@@ -341,29 +340,30 @@ impl<'f, 'gcx, 'tcx> Coerce<'f, 'gcx, 'tcx> {
                 mutbl: mt_b.mutbl // [1] above
             });
             match self.unify(derefd_ty_a, b) {
-                Ok(ty) => Some(ty),
+                Ok(ty) => { success = Some((ty, autoderefs)); break },
                 Err(err) => {
                     if first_error.is_none() {
                         first_error = Some(err);
                     }
-                    None
                 }
             }
-        });
+        }
 
         // Extract type or return an error. We return the first error
         // we got, which should be from relating the "base" type
         // (e.g., in example above, the failure from relating `Vec<T>`
         // to the target type), since that should be the least
         // confusing.
-        let ty = match success {
-            Some(ty) => ty,
+        let (ty, autoderefs) = match success {
+            Some(d) => d,
             None => {
                 let err = first_error.expect("coerce_borrowed_pointer had no error");
                 debug!("coerce_borrowed_pointer: failed with err = {:?}", err);
                 return Err(err);
             }
         };
+
+        autoderef.finalize(LvaluePreference::from_mutbl(mt_b.mutbl), exprs());
 
         // Now apply the autoref. We have to extract the region out of
         // the final ref type we got.

--- a/src/test/compile-fail/borrowck/borrowck-borrow-overloaded-auto-deref-mut.rs
+++ b/src/test/compile-fail/borrowck/borrowck-borrow-overloaded-auto-deref-mut.rs
@@ -99,7 +99,7 @@ fn assign_field1<'a>(x: Own<Point>) {
 }
 
 fn assign_field2<'a>(x: &'a Own<Point>) {
-    x.y = 3; //~ ERROR cannot assign
+    x.y = 3; //~ ERROR cannot borrow
 }
 
 fn assign_field3<'a>(x: &'a mut Own<Point>) {

--- a/src/test/compile-fail/issue-24819.rs
+++ b/src/test/compile-fail/issue-24819.rs
@@ -8,15 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![recursion_limit="2"]
-struct Foo;
-
-impl Foo {
-    fn foo(&self) {}
-}
+use std::collections::HashSet;
 
 fn main() {
-    let foo = Foo;
-    let ref_foo = &&Foo;
-    ref_foo.foo(); //~ ERROR E0055
+    let mut v = Vec::new();
+    foo(&mut v);
+    //~^ ERROR mismatched types
+    //~| expected struct `std::collections::HashSet`, found struct `std::vec::Vec`
+}
+
+fn foo(h: &mut HashSet<u32>) {
 }

--- a/src/test/compile-fail/regions-bound-missing-bound-in-impl.rs
+++ b/src/test/compile-fail/regions-bound-missing-bound-in-impl.rs
@@ -34,7 +34,8 @@ impl<'a, 't> Foo<'a, 't> for &'a isize {
     }
 
     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
-        //~^ ERROR method `wrong_bound1` has an incompatible type for trait
+        //~^ ERROR method not compatible with trait
+        //~^^ ERROR method not compatible with trait
         //
         // Note: This is a terrible error message. It is caused
         // because, in the trait, 'b is early bound, and in the impl,

--- a/src/test/compile-fail/regions-trait-1.rs
+++ b/src/test/compile-fail/regions-trait-1.rs
@@ -23,7 +23,7 @@ impl<'a> get_ctxt for has_ctxt<'a> {
 
     // Here an error occurs because we used `&self` but
     // the definition used `&`:
-    fn get_ctxt(&self) -> &'a ctxt { //~ ERROR method `get_ctxt` has an incompatible type
+    fn get_ctxt(&self) -> &'a ctxt { //~ ERROR method not compatible with trait
         self.c
     }
 


### PR DESCRIPTION
Refactor `FnCtxt::autoderef` to use an external iterator and to not
register any obligation from the main autoderef loop, but rather to
register them after (and if) the loop successfully completes.

Fixes #24819
Fixes #25801
Fixes #27631
Fixes #31258
Fixes #31964
Fixes #32320
Fixes #33515
Fixes #33755 

r? @eddyb 
