### PR TITLE
Implement Error trait for fmt::Error type

### DIFF
--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -212,6 +212,13 @@ impl<T: Error> Error for Box<T> {
     }
 }
 
+#[stable(feature = "fmt_error", since = "1.11.0")]
+impl Error for fmt::Error {
+    fn description(&self) -> &str {
+        "an error occurred when formatting an argument"
+    }
+}
+
 // copied from any.rs
 impl Error + 'static {
     /// Returns true if the boxed type is the same as `T`


### PR DESCRIPTION
Fixes #33827.

r? @alexcrichton 

Just one last thing: I added a feature name, but don't hesitate to ask me to change it if you think it doesn't fit well.
