### PR TITLE
mk: Prepare for a new stage0 compiler

### DIFF
--- a/src/etc/get-stage0.py
+++ b/src/etc/get-stage0.py
@@ -35,8 +35,9 @@ def main(argv):
     filename = filename_base + '.tar.gz'
     url = 'https://static.rust-lang.org/dist/' + date + '/' + filename
     dst = dl_dir + '/' + filename
-    if not os.path.exists(dst):
-        bootstrap.get(url, dst)
+    if os.path.exists(dst):
+        os.unlink(dst)
+    bootstrap.get(url, dst)
 
     stage0_dst = triple + '/stage0'
     if os.path.exists(stage0_dst):

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -43,7 +43,6 @@
 // Since libcore defines many fundamental lang items, all tests live in a
 // separate crate, libcoretest, to avoid bizarre issues.
 
-#![cfg_attr(stage0, allow(unused_attributes))]
 #![crate_name = "core"]
 #![stable(feature = "core", since = "1.6.0")]
 #![crate_type = "rlib"]

--- a/src/libcore/num/int_macros.rs
+++ b/src/libcore/num/int_macros.rs
@@ -10,24 +10,6 @@
 
 #![doc(hidden)]
 
-#[cfg(stage0)]
-macro_rules! int_module { ($T:ty, $bits:expr) => (
-
-// FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
-// calling the `Bounded::min_value` function.
-#[stable(feature = "rust1", since = "1.0.0")]
-#[allow(missing_docs)]
-pub const MIN: $T = (-1 as $T) << ($bits - 1);
-// FIXME(#9837): Compute MIN like this so the high bits that shouldn't exist are 0.
-// FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
-// calling the `Bounded::max_value` function.
-#[stable(feature = "rust1", since = "1.0.0")]
-#[allow(missing_docs)]
-pub const MAX: $T = !MIN;
-
-) }
-
-#[cfg(not(stage0))]
 macro_rules! int_module { ($T:ident, $bits:expr) => (
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/num/uint_macros.rs
+++ b/src/libcore/num/uint_macros.rs
@@ -10,19 +10,6 @@
 
 #![doc(hidden)]
 
-#[cfg(stage0)]
-macro_rules! uint_module { ($T:ty, $bits:expr) => (
-
-#[stable(feature = "rust1", since = "1.0.0")]
-#[allow(missing_docs)]
-pub const MIN: $T = 0 as $T;
-#[stable(feature = "rust1", since = "1.0.0")]
-#[allow(missing_docs)]
-pub const MAX: $T = !0 as $T;
-
-) }
-
-#[cfg(not(stage0))]
 macro_rules! uint_module { ($T:ident, $bits:expr) => (
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -88,13 +88,13 @@ use default::Default;
 use fmt;
 
 /// A boolean type which can be safely shared between threads.
-#[cfg(any(stage0, target_has_atomic = "8"))]
+#[cfg(target_has_atomic = "8")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct AtomicBool {
     v: UnsafeCell<u8>,
 }
 
-#[cfg(any(stage0, target_has_atomic = "8"))]
+#[cfg(target_has_atomic = "8")]
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Default for AtomicBool {
     fn default() -> Self {
@@ -103,18 +103,18 @@ impl Default for AtomicBool {
 }
 
 // Send is implicitly implemented for AtomicBool.
-#[cfg(any(stage0, target_has_atomic = "8"))]
+#[cfg(target_has_atomic = "8")]
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl Sync for AtomicBool {}
 
 /// A raw pointer type which can be safely shared between threads.
-#[cfg(any(stage0, target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct AtomicPtr<T> {
     p: UnsafeCell<*mut T>,
 }
 
-#[cfg(any(stage0, target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> Default for AtomicPtr<T> {
     fn default() -> AtomicPtr<T> {
@@ -122,10 +122,10 @@ impl<T> Default for AtomicPtr<T> {
     }
 }
 
-#[cfg(any(stage0, target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T> Send for AtomicPtr<T> {}
-#[cfg(any(stage0, target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T> Sync for AtomicPtr<T> {}
 
@@ -167,11 +167,11 @@ pub enum Ordering {
 }
 
 /// An `AtomicBool` initialized to `false`.
-#[cfg(any(stage0, target_has_atomic = "8"))]
+#[cfg(target_has_atomic = "8")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const ATOMIC_BOOL_INIT: AtomicBool = AtomicBool::new(false);
 
-#[cfg(any(stage0, target_has_atomic = "8"))]
+#[cfg(target_has_atomic = "8")]
 impl AtomicBool {
     /// Creates a new `AtomicBool`.
     ///
@@ -508,7 +508,7 @@ impl AtomicBool {
     }
 }
 
-#[cfg(any(stage0, target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 impl<T> AtomicPtr<T> {
     /// Creates a new `AtomicPtr`.
     ///
@@ -1106,14 +1106,14 @@ atomic_int! {
     unstable(feature = "integer_atomics", issue = "32976"),
     u64 AtomicU64 ATOMIC_U64_INIT
 }
-#[cfg(any(stage0, target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 atomic_int!{
     stable(feature = "rust1", since = "1.0.0"),
     stable(feature = "extended_compare_and_swap", since = "1.10.0"),
     stable(feature = "atomic_debug", since = "1.3.0"),
     isize AtomicIsize ATOMIC_ISIZE_INIT
 }
-#[cfg(any(stage0, target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 atomic_int!{
     stable(feature = "rust1", since = "1.0.0"),
     stable(feature = "extended_compare_and_swap", since = "1.10.0"),
@@ -1311,7 +1311,7 @@ pub fn fence(order: Ordering) {
 }
 
 
-#[cfg(any(stage0, target_has_atomic = "8"))]
+#[cfg(target_has_atomic = "8")]
 #[stable(feature = "atomic_debug", since = "1.3.0")]
 impl fmt::Debug for AtomicBool {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -1319,7 +1319,7 @@ impl fmt::Debug for AtomicBool {
     }
 }
 
-#[cfg(any(stage0, target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[stable(feature = "atomic_debug", since = "1.3.0")]
 impl<T> fmt::Debug for AtomicPtr<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/libpanic_abort/lib.rs
+++ b/src/libpanic_abort/lib.rs
@@ -25,8 +25,8 @@
 
 #![feature(staged_api)]
 
-#![cfg_attr(not(stage0), panic_runtime)]
-#![cfg_attr(not(stage0), feature(panic_runtime))]
+#![panic_runtime]
+#![feature(panic_runtime)]
 #![cfg_attr(unix, feature(libc))]
 #![cfg_attr(windows, feature(core_intrinsics))]
 
@@ -93,7 +93,6 @@ pub unsafe extern fn __rust_start_panic(_data: usize, _vtable: usize) -> u32 {
 // Essentially this symbol is just defined to get wired up to libcore/libstd
 // binaries, but it should never be called as we don't link in an unwinding
 // runtime at all.
-#[cfg(not(stage0))]
 pub mod personalities {
 
     #[no_mangle]

--- a/src/libpanic_unwind/lib.rs
+++ b/src/libpanic_unwind/lib.rs
@@ -42,8 +42,8 @@
 #![feature(unwind_attributes)]
 #![cfg_attr(target_env = "msvc", feature(raw))]
 
-#![cfg_attr(not(stage0), panic_runtime)]
-#![cfg_attr(not(stage0), feature(panic_runtime))]
+#![panic_runtime]
+#![feature(panic_runtime)]
 
 extern crate alloc;
 extern crate libc;

--- a/src/libpanic_unwind/seh.rs
+++ b/src/libpanic_unwind/seh.rs
@@ -233,8 +233,7 @@ extern {
 // an argument to the C++ personality function.
 //
 // Again, I'm not entirely sure what this is describing, it just seems to work.
-#[cfg_attr(all(not(test), not(stage0)),
-           lang = "msvc_try_filter")]
+#[cfg_attr(not(test), lang = "msvc_try_filter")]
 static mut TYPE_DESCRIPTOR1: _TypeDescriptor = _TypeDescriptor {
     pVFTable: &TYPE_INFO_VTABLE as *const _ as *const _,
     spare: 0 as *mut _,
@@ -306,13 +305,6 @@ pub unsafe fn cleanup(payload: [u64; 2]) -> Box<Any + Send> {
         data: payload[0] as *mut _,
         vtable: payload[1] as *mut _,
     })
-}
-
-#[lang = "msvc_try_filter"]
-#[cfg(stage0)]
-unsafe extern fn __rust_try_filter(_eh_ptrs: *mut u8,
-                                   _payload: *mut u8) -> i32 {
-    return 0
 }
 
 // This is required by the compiler to exist (e.g. it's a lang item), but

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -210,6 +210,8 @@
        test(no_crate_inject, attr(deny(warnings))),
        test(attr(allow(dead_code, deprecated, unused_variables, unused_mut))))]
 
+#![needs_panic_runtime]
+
 #![feature(alloc)]
 #![feature(allow_internal_unstable)]
 #![feature(asm)]
@@ -272,6 +274,7 @@
 #![feature(zero_one)]
 #![feature(question_mark)]
 #![feature(try_from)]
+#![feature(needs_panic_runtime)]
 
 // Issue# 30592: Systematically use alloc_system during stage0 since jemalloc
 // might be unavailable or disabled
@@ -283,13 +286,6 @@
 #![deny(missing_docs)]
 #![allow(unused_features)] // std may use features in a platform-specific way
 #![cfg_attr(not(stage0), deny(warnings))]
-
-// FIXME(stage0): after a snapshot, move needs_panic_runtime up above and remove
-//                this `extern crate` declaration and feature(panic_unwind)
-#![cfg_attr(not(stage0), needs_panic_runtime)]
-#![cfg_attr(not(stage0), feature(needs_panic_runtime))]
-#[cfg(stage0)]
-extern crate panic_unwind as __please_just_link_me_dont_reference_me;
 
 #[cfg(test)] extern crate test;
 

--- a/src/libstd/rt.rs
+++ b/src/libstd/rt.rs
@@ -27,9 +27,6 @@
 // Reexport some of our utilities which are expected by other crates.
 pub use panicking::{begin_panic, begin_panic_fmt};
 
-#[cfg(stage0)]
-pub use panicking::begin_panic as begin_unwind;
-
 #[cfg(not(test))]
 #[lang = "start"]
 fn lang_start(main: *const u8, argc: isize, argv: *const *const u8) -> isize {

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,6 +12,6 @@
 # tarball for a stable release you'll likely see `1.x.0-$date` where `1.x.0` was
 # released on `$date`
 
-rustc: beta-2016-04-13
-rustc_key: c2743eb4
-cargo: nightly-2016-04-10
+rustc: beta-2016-05-24
+rustc_key: a4922355
+cargo: nightly-2016-05-22

--- a/src/tools/tidy/src/cargo.rs
+++ b/src/tools/tidy/src/cargo.rs
@@ -81,11 +81,10 @@ fn verify(tomlfile: &Path, libfile: &Path, bad: &mut bool) {
         }
 
         // This is intentional, this dependency just makes the crate available
-        // for others later on.
-        if krate == "alloc_jemalloc" && toml.contains("name = \"std\"") {
-            continue
-        }
-        if krate == "panic_abort" && toml.contains("name = \"std\"") {
+        // for others later on. Cover cases
+        let whitelisted = krate == "alloc_jemalloc";
+        let whitelisted = whitelisted || krate.starts_with("panic");
+        if toml.contains("name = \"std\"") && whitelisted {
             continue
         }
 


### PR DESCRIPTION
This commit prepares the source for a new stage0 compiler, the 1.10.0 beta
compiler. These artifacts are hot off the bots and should be ready to go.
