### PR TITLE
Fix ICE on parsing a bad metavariable in a macro definition

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2702,7 +2702,10 @@ impl<'a> Parser<'a> {
                     return Ok(TokenTree::Token(sp, SpecialVarNt(SpecialMacroVar::CrateMacroVar)));
                 } else {
                     sp = mk_sp(sp.lo, self.span.hi);
-                    self.parse_ident()?
+                    self.parse_ident().unwrap_or_else(|mut e| {
+                        e.emit();
+                        keywords::Invalid.ident()
+                    })
                 }
             }
             token::SubstNt(name) => {
@@ -2845,7 +2848,7 @@ impl<'a> Parser<'a> {
                         // and an error emitted then. Thus we don't pop from
                         // self.open_braces here.
                     },
-                    _ => unreachable!(),
+                    _ => {}
                 }
 
                 Ok(TokenTree::Delimited(span, Rc::new(Delimited {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2807,14 +2807,14 @@ impl<'a> Parser<'a> {
                 let span = Span { hi: close_span.hi, ..pre_span };
 
                 match self.token {
-                    // Correct delmiter.
+                    // Correct delimiter.
                     token::CloseDelim(d) if d == delim => {
                         self.open_braces.pop().unwrap();
 
                         // Parse the close delimiter.
                         self.bump();
                     }
-                    // Incorect delimiter.
+                    // Incorrect delimiter.
                     token::CloseDelim(other) => {
                         let token_str = self.this_token_to_string();
                         let mut err = self.diagnostic().struct_span_err(self.span,
@@ -2829,9 +2829,9 @@ impl<'a> Parser<'a> {
 
                         self.open_braces.pop().unwrap();
 
-                        // If the incorrect delimter matches an earlier opening
+                        // If the incorrect delimiter matches an earlier opening
                         // delimiter, then don't consume it (it can be used to
-                        // close the earlier one)Otherwise, consume it.
+                        // close the earlier one). Otherwise, consume it.
                         // E.g., we try to recover from:
                         // fn foo() {
                         //     bar(baz(
@@ -2859,7 +2859,7 @@ impl<'a> Parser<'a> {
                 // invariants: the current token is not a left-delimiter,
                 // not an EOF, and not the desired right-delimiter (if
                 // it were, parse_seq_to_before_end would have prevented
-                // reaching this point.
+                // reaching this point).
                 maybe_whole!(deref self, NtTT);
                 match self.token {
                     token::CloseDelim(_) => {

--- a/src/test/parse-fail/issue-33569.rs
+++ b/src/test/parse-fail/issue-33569.rs
@@ -1,0 +1,18 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z no-analysis
+
+macro_rules! foo {
+    { $+ } => { //~ ERROR expected identifier, found `+`
+        $(x)(y) //~ ERROR expected `*` or `+`
+                //~^ ERROR no rules expected the token `y`
+    }
+}


### PR DESCRIPTION
Fixes #33569, fixes #33728.
r? @pnkfelix 
