### PR TITLE
Fix handling of FFI arguments

### DIFF
--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -1683,10 +1683,8 @@ impl<'blk, 'tcx> FunctionContext<'blk, 'tcx> {
                         // And coerce the temporary into the type we expect.
                         b.pointercast(lltemp, arg.memory_ty(bcx.ccx()).ptr_to())
                     };
-
-                    // FIXME: hacky lol?
                     datum::Datum::new(lltmp, arg_ty,
-                                      datum::Lvalue::new("datum::lvalue_scratch_datum"))
+                                      datum::Lvalue::new("bind_args"))
                 }
             } else {
                 // FIXME(pcwalton): Reduce the amount of code bloat this is responsible for.

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -1660,8 +1660,8 @@ impl<'blk, 'tcx> FunctionContext<'blk, 'tcx> {
                     self.schedule_drop_mem(arg_scope_id, llarg, arg_ty, None);
 
                     datum::Datum::new(llarg,
-                                    arg_ty,
-                                    datum::Lvalue::new("FunctionContext::bind_args"))
+                                      arg_ty,
+                                      datum::Lvalue::new("FunctionContext::bind_args"))
                 } else {
                     let lltmp = if common::type_is_fat_ptr(bcx.tcx(), arg_ty) {
                         let lltemp = alloc_ty(bcx, arg_ty, "");
@@ -1683,6 +1683,7 @@ impl<'blk, 'tcx> FunctionContext<'blk, 'tcx> {
                         // And coerce the temporary into the type we expect.
                         b.pointercast(lltemp, arg.memory_ty(bcx.ccx()).ptr_to())
                     };
+                    bcx.fcx.schedule_drop_mem(arg_scope_id, lltmp, arg_ty, None);
                     datum::Datum::new(lltmp, arg_ty,
                                       datum::Lvalue::new("bind_args"))
                 }

--- a/src/test/codegen/stores.rs
+++ b/src/test/codegen/stores.rs
@@ -26,8 +26,8 @@ pub struct Bytes {
 #[no_mangle]
 #[rustc_no_mir] // FIXME #27840 MIR has different codegen.
 pub fn small_array_alignment(x: &mut [i8; 4], y: [i8; 4]) {
-// CHECK: [[VAR:%[0-9]+]] = bitcast [4 x i8]* %y to i32*
-// CHECK: store i32 %{{.*}}, i32* [[VAR]], align 1
+// CHECK: store i32 %{{.*}}, i32* %{{.*}}, align 1
+// CHECK: [[VAR:%[0-9]+]] = bitcast i32* %{{.*}} to [4 x i8]*
     *x = y;
 }
 
@@ -37,7 +37,7 @@ pub fn small_array_alignment(x: &mut [i8; 4], y: [i8; 4]) {
 #[no_mangle]
 #[rustc_no_mir] // FIXME #27840 MIR has different codegen.
 pub fn small_struct_alignment(x: &mut Bytes, y: Bytes) {
-// CHECK: [[VAR:%[0-9]+]] = bitcast %Bytes* %y to i32*
-// CHECK: store i32 %{{.*}}, i32* [[VAR]], align 1
+// CHECK: store i32 %{{.*}}, i32* %{{.*}}, align 1
+// CHECK: [[VAR:%[0-9]+]] = bitcast i32* %{{.*}} to %Bytes*
     *x = y;
 }

--- a/src/test/run-pass/foreign-truncated-arguments.rs
+++ b/src/test/run-pass/foreign-truncated-arguments.rs
@@ -1,0 +1,29 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -O
+// Regression test for https://github.com/rust-lang/rust/issues/33868
+
+#[repr(C)]
+pub struct S {
+    a: u32,
+    b: f32,
+    c: u32
+}
+
+#[no_mangle]
+#[inline(never)]
+pub extern "C" fn test(s: S) -> u32 {
+    s.c
+}
+
+fn main() {
+    assert_eq!(test(S{a: 0, b: 0.0, c: 42}), 42);
+}


### PR DESCRIPTION
r? @eddyb @nikomatsakis or whoever else.

cc @alexcrichton @rust-lang/core

The strategy employed here was to essentially change code we generate from

``` llvm
  %s = alloca %S ; potentially smaller than argument, but never larger
  %1 = bitcast %S* %s to { i64, i64 }*
  store { i64, i64 } %0, { i64, i64 }* %1, align 4
```

to 

``` llvm
  %1 = alloca { i64, i64 } ; the copy of argument itself
  store { i64, i64 } %0, { i64, i64 }* %1, align 4
  %s = bitcast { i64, i64 }* %1 to %S* ; potentially truncate by casting to a pointer of smaller type.
```
