### PR TITLE
core: check pointer equality when comparing byte slices

### DIFF
--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -1831,6 +1831,9 @@ impl<A> SlicePartialEq<A> for [A]
         if self.len() != other.len() {
             return false;
         }
+        if self.as_ptr() == other.as_ptr() {
+            return true;
+        }
         unsafe {
             let size = mem::size_of_val(self);
             memcmp(self.as_ptr() as *const u8,


### PR DESCRIPTION
If pointer address and length are the same, it should be the same slice.

In experiments, I've seen that this doesn't happen as often in debug builds, but release builds seem to optimize to using a single pointer more often.
