### PR TITLE
[MIR] Implement overflow checking

### DIFF
--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -172,6 +172,7 @@ pub trait Iterator {
     /// assert_eq!(a.iter().count(), 5);
     /// ```
     #[inline]
+    #[rustc_inherit_overflow_checks]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn count(self) -> usize where Self: Sized {
         // Might overflow.

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -510,6 +510,7 @@ impl<A, B> Iterator for Chain<A, B> where
     }
 
     #[inline]
+    #[rustc_inherit_overflow_checks]
     fn count(self) -> usize {
         match self.state {
             ChainState::Both => self.a.count() + self.b.count(),
@@ -932,6 +933,7 @@ impl<I> Iterator for Enumerate<I> where I: Iterator {
     ///
     /// Might panic if the index of the element overflows a `usize`.
     #[inline]
+    #[rustc_inherit_overflow_checks]
     fn next(&mut self) -> Option<(usize, <I as Iterator>::Item)> {
         self.iter.next().map(|a| {
             let ret = (self.count, a);
@@ -947,6 +949,7 @@ impl<I> Iterator for Enumerate<I> where I: Iterator {
     }
 
     #[inline]
+    #[rustc_inherit_overflow_checks]
     fn nth(&mut self, n: usize) -> Option<(usize, I::Item)> {
         self.iter.nth(n).map(|a| {
             let i = self.count + n;
@@ -1008,6 +1011,7 @@ impl<I: Iterator> Iterator for Peekable<I> {
     }
 
     #[inline]
+    #[rustc_inherit_overflow_checks]
     fn count(self) -> usize {
         (if self.peeked.is_some() { 1 } else { 0 }) + self.iter.count()
     }

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1033,7 +1033,7 @@ macro_rules! int_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        #[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
+        #[rustc_inherit_overflow_checks]
         pub fn pow(self, mut exp: u32) -> Self {
             let mut base = self;
             let mut acc = Self::one();
@@ -1075,7 +1075,7 @@ macro_rules! int_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        #[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
+        #[rustc_inherit_overflow_checks]
         pub fn abs(self) -> Self {
             if self.is_negative() {
                 // Note that the #[inline] above means that the overflow
@@ -2061,7 +2061,7 @@ macro_rules! uint_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        #[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
+        #[rustc_inherit_overflow_checks]
         pub fn pow(self, mut exp: u32) -> Self {
             let mut base = self;
             let mut acc = Self::one();

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -208,6 +208,7 @@ macro_rules! add_impl {
             type Output = $t;
 
             #[inline]
+            #[rustc_inherit_overflow_checks]
             fn add(self, other: $t) -> $t { self + other }
         }
 
@@ -261,6 +262,7 @@ macro_rules! sub_impl {
             type Output = $t;
 
             #[inline]
+            #[rustc_inherit_overflow_checks]
             fn sub(self, other: $t) -> $t { self - other }
         }
 
@@ -314,6 +316,7 @@ macro_rules! mul_impl {
             type Output = $t;
 
             #[inline]
+            #[rustc_inherit_overflow_checks]
             fn mul(self, other: $t) -> $t { self * other }
         }
 
@@ -511,6 +514,7 @@ macro_rules! neg_impl_core {
             type Output = $t;
 
             #[inline]
+            #[rustc_inherit_overflow_checks]
             fn neg(self) -> $t { let $id = self; $body }
         }
 
@@ -788,6 +792,7 @@ macro_rules! shl_impl {
             type Output = $t;
 
             #[inline]
+            #[rustc_inherit_overflow_checks]
             fn shl(self, other: $f) -> $t {
                 self << other
             }
@@ -859,6 +864,7 @@ macro_rules! shr_impl {
             type Output = $t;
 
             #[inline]
+            #[rustc_inherit_overflow_checks]
             fn shr(self, other: $f) -> $t {
                 self >> other
             }
@@ -923,6 +929,7 @@ macro_rules! add_assign_impl {
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl AddAssign for $t {
             #[inline]
+            #[rustc_inherit_overflow_checks]
             fn add_assign(&mut self, other: $t) { *self += other }
         }
     )+)
@@ -967,6 +974,7 @@ macro_rules! sub_assign_impl {
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl SubAssign for $t {
             #[inline]
+            #[rustc_inherit_overflow_checks]
             fn sub_assign(&mut self, other: $t) { *self -= other }
         }
     )+)
@@ -1011,6 +1019,7 @@ macro_rules! mul_assign_impl {
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl MulAssign for $t {
             #[inline]
+            #[rustc_inherit_overflow_checks]
             fn mul_assign(&mut self, other: $t) { *self *= other }
         }
     )+)
@@ -1275,6 +1284,7 @@ macro_rules! shl_assign_impl {
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl ShlAssign<$f> for $t {
             #[inline]
+            #[rustc_inherit_overflow_checks]
             fn shl_assign(&mut self, other: $f) {
                 *self <<= other
             }
@@ -1337,6 +1347,7 @@ macro_rules! shr_assign_impl {
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl ShrAssign<$f> for $t {
             #[inline]
+            #[rustc_inherit_overflow_checks]
             fn shr_assign(&mut self, other: $f) {
                 *self >>= other
             }

--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -787,6 +787,7 @@ pub enum Rvalue<'tcx> {
     Cast(CastKind, Operand<'tcx>, Ty<'tcx>),
 
     BinaryOp(BinOp, Operand<'tcx>, Operand<'tcx>),
+    CheckedBinaryOp(BinOp, Operand<'tcx>, Operand<'tcx>),
 
     UnaryOp(UnOp, Operand<'tcx>),
 
@@ -880,6 +881,16 @@ pub enum BinOp {
     Gt,
 }
 
+impl BinOp {
+    pub fn is_checkable(self) -> bool {
+        use self::BinOp::*;
+        match self {
+            Add | Sub | Mul | Shl | Shr => true,
+            _ => false
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, RustcEncodable, RustcDecodable)]
 pub enum UnOp {
     /// The `!` operator for logical inversion
@@ -898,6 +909,9 @@ impl<'tcx> Debug for Rvalue<'tcx> {
             Len(ref a) => write!(fmt, "Len({:?})", a),
             Cast(ref kind, ref lv, ref ty) => write!(fmt, "{:?} as {:?} ({:?})", lv, ty, kind),
             BinaryOp(ref op, ref a, ref b) => write!(fmt, "{:?}({:?}, {:?})", op, a, b),
+            CheckedBinaryOp(ref op, ref a, ref b) => {
+                write!(fmt, "Checked{:?}({:?}, {:?})", op, a, b)
+            }
             UnaryOp(ref op, ref a) => write!(fmt, "{:?}({:?})", op, a),
             Box(ref t) => write!(fmt, "Box({:?})", t),
             InlineAsm { ref asm, ref outputs, ref inputs } => {

--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -10,7 +10,7 @@
 
 use graphviz::IntoCow;
 use middle::const_val::ConstVal;
-use rustc_const_math::{ConstUsize, ConstInt};
+use rustc_const_math::{ConstUsize, ConstInt, ConstMathErr};
 use hir::def_id::DefId;
 use ty::subst::Substs;
 use ty::{self, AdtDef, ClosureSubsts, FnOutput, Region, Ty};
@@ -354,6 +354,16 @@ pub enum TerminatorKind<'tcx> {
         /// Cleanups to be done if the call unwinds.
         cleanup: Option<BasicBlock>
     },
+
+    /// Jump to the target if the condition has the expected value,
+    /// otherwise panic with a message and a cleanup target.
+    Assert {
+        cond: Operand<'tcx>,
+        expected: bool,
+        msg: AssertMessage<'tcx>,
+        target: BasicBlock,
+        cleanup: Option<BasicBlock>
+    }
 }
 
 impl<'tcx> Terminator<'tcx> {
@@ -389,6 +399,8 @@ impl<'tcx> TerminatorKind<'tcx> {
             Drop { ref target, unwind: None, .. } => {
                 slice::ref_slice(target).into_cow()
             }
+            Assert { target, cleanup: Some(unwind), .. } => vec![target, unwind].into_cow(),
+            Assert { ref target, .. } => slice::ref_slice(target).into_cow(),
         }
     }
 
@@ -413,6 +425,8 @@ impl<'tcx> TerminatorKind<'tcx> {
             Drop { ref mut target, unwind: None, .. } => {
                 vec![target]
             }
+            Assert { ref mut target, cleanup: Some(ref mut unwind), .. } => vec![target, unwind],
+            Assert { ref mut target, .. } => vec![target]
         }
     }
 }
@@ -495,6 +509,26 @@ impl<'tcx> TerminatorKind<'tcx> {
                 }
                 write!(fmt, ")")
             }
+            Assert { ref cond, expected, ref msg, .. } => {
+                write!(fmt, "assert(")?;
+                if !expected {
+                    write!(fmt, "!")?;
+                }
+                write!(fmt, "{:?}, ", cond)?;
+
+                match *msg {
+                    AssertMessage::BoundsCheck { ref len, ref index } => {
+                        write!(fmt, "{:?}, {:?}, {:?}",
+                               "index out of bounds: the len is {} but the index is {}",
+                               len, index)?;
+                    }
+                    AssertMessage::Math(ref err) => {
+                        write!(fmt, "{:?}", err.description())?;
+                    }
+                }
+
+                write!(fmt, ")")
+            }
         }
     }
 
@@ -532,10 +566,21 @@ impl<'tcx> TerminatorKind<'tcx> {
             Drop { unwind: Some(_), .. } => {
                 vec!["return".into_cow(), "unwind".into_cow()]
             }
+            Assert { cleanup: None, .. } => vec!["".into()],
+            Assert { .. } =>
+                vec!["success".into_cow(), "unwind".into_cow()]
         }
     }
 }
 
+#[derive(Clone, Debug, RustcEncodable, RustcDecodable)]
+pub enum AssertMessage<'tcx> {
+    BoundsCheck {
+        len: Operand<'tcx>,
+        index: Operand<'tcx>
+    },
+    Math(ConstMathErr)
+}
 
 ///////////////////////////////////////////////////////////////////////////
 // Statements

--- a/src/librustc/mir/tcx.rs
+++ b/src/librustc/mir/tcx.rs
@@ -183,6 +183,13 @@ impl<'a, 'gcx, 'tcx> Mir<'tcx> {
                 let rhs_ty = self.operand_ty(tcx, rhs);
                 Some(self.binop_ty(tcx, op, lhs_ty, rhs_ty))
             }
+            Rvalue::CheckedBinaryOp(op, ref lhs, ref rhs) => {
+                let lhs_ty = self.operand_ty(tcx, lhs);
+                let rhs_ty = self.operand_ty(tcx, rhs);
+                let ty = self.binop_ty(tcx, op, lhs_ty, rhs_ty);
+                let ty = tcx.mk_tup(vec![ty, tcx.types.bool]);
+                Some(ty)
+            }
             Rvalue::UnaryOp(_, ref operand) => {
                 Some(self.operand_ty(tcx, operand))
             }

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -127,6 +127,11 @@ macro_rules! make_mir_visitor {
                 self.super_terminator_kind(block, kind);
             }
 
+            fn visit_assert_message(&mut self,
+                                    msg: & $($mutability)* AssertMessage<'tcx>) {
+                self.super_assert_message(msg);
+            }
+
             fn visit_rvalue(&mut self,
                             rvalue: & $($mutability)* Rvalue<'tcx>) {
                 self.super_rvalue(rvalue);
@@ -426,6 +431,31 @@ macro_rules! make_mir_visitor {
                         }
                         cleanup.map(|t| self.visit_branch(block, t));
                     }
+
+                    TerminatorKind::Assert { ref $($mutability)* cond,
+                                             expected: _,
+                                             ref $($mutability)* msg,
+                                             target,
+                                             cleanup } => {
+                        self.visit_operand(cond);
+                        self.visit_assert_message(msg);
+                        self.visit_branch(block, target);
+                        cleanup.map(|t| self.visit_branch(block, t));
+                    }
+                }
+            }
+
+            fn super_assert_message(&mut self,
+                                    msg: & $($mutability)* AssertMessage<'tcx>) {
+                match *msg {
+                    AssertMessage::BoundsCheck {
+                        ref $($mutability)* len,
+                        ref $($mutability)* index
+                    } => {
+                        self.visit_operand(len);
+                        self.visit_operand(index);
+                    }
+                    AssertMessage::Math(_) => {}
                 }
             }
 

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -462,6 +462,9 @@ macro_rules! make_mir_visitor {
 
                     Rvalue::BinaryOp(_bin_op,
                                      ref $($mutability)* lhs,
+                                     ref $($mutability)* rhs) |
+                    Rvalue::CheckedBinaryOp(_bin_op,
+                                     ref $($mutability)* lhs,
                                      ref $($mutability)* rhs) => {
                         self.visit_operand(lhs);
                         self.visit_operand(rhs);

--- a/src/librustc_borrowck/borrowck/mir/dataflow/mod.rs
+++ b/src/librustc_borrowck/borrowck/mir/dataflow/mod.rs
@@ -450,13 +450,14 @@ impl<'a, 'tcx: 'a, D> DataflowAnalysis<'a, 'tcx, D>
             repr::TerminatorKind::Return |
             repr::TerminatorKind::Resume => {}
             repr::TerminatorKind::Goto { ref target } |
+            repr::TerminatorKind::Assert { ref target, cleanup: None, .. } |
             repr::TerminatorKind::Drop { ref target, location: _, unwind: None } |
-
             repr::TerminatorKind::DropAndReplace {
                 ref target, value: _, location: _, unwind: None
             } => {
                 self.propagate_bits_into_entry_set_for(in_out, changed, target);
             }
+            repr::TerminatorKind::Assert { ref target, cleanup: Some(ref unwind), .. } |
             repr::TerminatorKind::Drop { ref target, location: _, unwind: Some(ref unwind) } |
             repr::TerminatorKind::DropAndReplace {
                 ref target, value: _, location: _, unwind: Some(ref unwind)

--- a/src/librustc_borrowck/borrowck/mir/gather_moves.rs
+++ b/src/librustc_borrowck/borrowck/mir/gather_moves.rs
@@ -663,6 +663,22 @@ fn gather_moves<'a, 'tcx>(mir: &Mir<'tcx>, tcx: TyCtxt<'a, 'tcx, 'tcx>) -> MoveD
                 bb_ctxt.on_operand(SK::If, cond, source);
             }
 
+            TerminatorKind::Assert {
+                ref cond, expected: _,
+                ref msg, target: _, cleanup: _
+            } => {
+                // The `cond` is always of (copyable) type `bool`,
+                // so there will never be anything to move.
+                let _ = cond;
+                match *msg {
+                    AssertMessage:: BoundsCheck { ref len, ref index } => {
+                        // Same for the usize length and index in bounds-checking.
+                        let _ = (len, index);
+                    }
+                    AssertMessage::Math(_) => {}
+                }
+            }
+
             TerminatorKind::SwitchInt { switch_ty: _, values: _, targets: _, ref discr } |
             TerminatorKind::Switch { adt_def: _, targets: _, ref discr } => {
                 // The `discr` is not consumed; that is instead

--- a/src/librustc_borrowck/borrowck/mir/gather_moves.rs
+++ b/src/librustc_borrowck/borrowck/mir/gather_moves.rs
@@ -595,7 +595,8 @@ fn gather_moves<'a, 'tcx>(mir: &Mir<'tcx>, tcx: TyCtxt<'a, 'tcx, 'tcx>) -> MoveD
                             bb_ctxt.on_operand(SK::Repeat, operand, source),
                         Rvalue::Cast(ref _kind, ref operand, ref _ty) =>
                             bb_ctxt.on_operand(SK::Cast, operand, source),
-                        Rvalue::BinaryOp(ref _binop, ref operand1, ref operand2) => {
+                        Rvalue::BinaryOp(ref _binop, ref operand1, ref operand2) |
+                        Rvalue::CheckedBinaryOp(ref _binop, ref operand1, ref operand2) => {
                             bb_ctxt.on_operand(SK::BinaryOp, operand1, source);
                             bb_ctxt.on_operand(SK::BinaryOp, operand2, source);
                         }

--- a/src/librustc_const_eval/eval.rs
+++ b/src/librustc_const_eval/eval.rs
@@ -380,12 +380,6 @@ pub enum ErrKind {
     NotOn(ConstVal),
     CallOn(ConstVal),
 
-    DivideByZero,
-    DivideWithOverflow,
-    ModuloByZero,
-    ModuloWithOverflow,
-    ShiftLeftWithOverflow,
-    ShiftRightWithOverflow,
     MissingStructField,
     NonConstPath,
     UnimplementedConstVal(&'static str),
@@ -436,12 +430,6 @@ impl ConstEvalErr {
             NotOn(ref const_val) => format!("not on {}", const_val.description()).into_cow(),
             CallOn(ref const_val) => format!("call on {}", const_val.description()).into_cow(),
 
-            DivideByZero         => "attempted to divide by zero".into_cow(),
-            DivideWithOverflow   => "attempted to divide with overflow".into_cow(),
-            ModuloByZero         => "attempted remainder with a divisor of zero".into_cow(),
-            ModuloWithOverflow   => "attempted remainder with overflow".into_cow(),
-            ShiftLeftWithOverflow => "attempted left shift with overflow".into_cow(),
-            ShiftRightWithOverflow => "attempted right shift with overflow".into_cow(),
             MissingStructField  => "nonexistent struct field".into_cow(),
             NonConstPath        => "non-constant path in constant expression".into_cow(),
             UnimplementedConstVal(what) =>

--- a/src/librustc_const_eval/eval.rs
+++ b/src/librustc_const_eval/eval.rs
@@ -856,9 +856,6 @@ pub fn eval_const_expr_partial<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 Integral(U8(data[idx as usize]))
             },
 
-            Str(ref s) if idx as usize >= s.len() => signal!(e, IndexOutOfBounds),
-            // FIXME: return a const char
-            Str(_) => signal!(e, UnimplementedConstVal("indexing into str")),
             _ => signal!(e, IndexedNonVec),
         }
       }

--- a/src/librustc_const_math/err.rs
+++ b/src/librustc_const_math/err.rs
@@ -10,7 +10,7 @@
 
 use syntax::ast;
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, RustcEncodable, RustcDecodable)]
 pub enum ConstMathErr {
     NotInRange,
     CmpBetweenUnequalTypes,
@@ -25,7 +25,7 @@ pub enum ConstMathErr {
 }
 pub use self::ConstMathErr::*;
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, RustcEncodable, RustcDecodable)]
 pub enum Op {
     Add,
     Sub,

--- a/src/librustc_mir/build/block.rs
+++ b/src/librustc_mir/build/block.rs
@@ -12,7 +12,6 @@ use build::{BlockAnd, BlockAndExtension, Builder};
 use hair::*;
 use rustc::mir::repr::*;
 use rustc::hir;
-use syntax::codemap::Span;
 
 impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     pub fn ast_block(&mut self,
@@ -81,23 +80,5 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             }
             block.unit()
         })
-    }
-
-    // Helper method for generating a conditional branch
-    // Returns (TrueBlock, FalseBlock)
-    pub fn build_cond_br(&mut self, block: BasicBlock, span: Span,
-                         cond: Operand<'tcx>) -> (BasicBlock, BasicBlock) {
-        let scope_id = self.innermost_scope_id();
-
-        let then_block = self.cfg.start_new_block();
-        let else_block = self.cfg.start_new_block();
-
-        self.cfg.terminate(block, scope_id, span,
-                           TerminatorKind::If {
-                               cond: cond,
-                               targets: (then_block, else_block)
-                           });
-
-        (then_block, else_block)
     }
 }

--- a/src/librustc_mir/build/cfg.rs
+++ b/src/librustc_mir/build/cfg.rs
@@ -86,17 +86,12 @@ impl<'tcx> CFG<'tcx> {
                      scope: ScopeId,
                      span: Span,
                      kind: TerminatorKind<'tcx>) {
-        debug_assert!(!self.terminated(block),
+        debug_assert!(self.block_data(block).terminator.is_none(),
                       "terminate: block {:?} already has a terminator set", block);
         self.block_data_mut(block).terminator = Some(Terminator {
             span: span,
             scope: scope,
             kind: kind,
         });
-    }
-
-    /// Returns whether or not the given block has been terminated or not
-    pub fn terminated(&self, block: BasicBlock) -> bool {
-        self.block_data(block).terminator.is_some()
     }
 }

--- a/src/librustc_mir/build/cfg.rs
+++ b/src/librustc_mir/build/cfg.rs
@@ -86,12 +86,17 @@ impl<'tcx> CFG<'tcx> {
                      scope: ScopeId,
                      span: Span,
                      kind: TerminatorKind<'tcx>) {
-        debug_assert!(self.block_data(block).terminator.is_none(),
+        debug_assert!(!self.terminated(block),
                       "terminate: block {:?} already has a terminator set", block);
         self.block_data_mut(block).terminator = Some(Terminator {
             span: span,
             scope: scope,
             kind: kind,
         });
+    }
+
+    /// Returns whether or not the given block has been terminated or not
+    pub fn terminated(&self, block: BasicBlock) -> bool {
+        self.block_data(block).terminator.is_some()
     }
 }

--- a/src/librustc_mir/build/expr/as_lvalue.rs
+++ b/src/librustc_mir/build/expr/as_lvalue.rs
@@ -66,15 +66,12 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                                                            idx.clone(),
                                                            Operand::Consume(len.clone())));
 
-                let (success, failure) = (this.cfg.start_new_block(), this.cfg.start_new_block());
-                this.cfg.terminate(block,
-                                   scope_id,
-                                   expr_span,
-                                   TerminatorKind::If {
-                                       cond: Operand::Consume(lt),
-                                       targets: (success, failure),
-                                   });
-                this.panic_bounds_check(failure, idx.clone(), Operand::Consume(len), expr_span);
+                let msg = AssertMessage::BoundsCheck {
+                    len: Operand::Consume(len),
+                    index: idx.clone()
+                };
+                let success = this.assert(block, Operand::Consume(lt), true,
+                                          msg, expr_span);
                 success.and(slice.index(idx))
             }
             ExprKind::SelfRef => {

--- a/src/librustc_mir/build/expr/as_rvalue.rs
+++ b/src/librustc_mir/build/expr/as_rvalue.rs
@@ -80,7 +80,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             ExprKind::Unary { op, arg } => {
                 let arg = unpack!(block = this.as_operand(block, arg));
                 // Check for -MIN on signed integers
-                if op == UnOp::Neg && expr.ty.is_signed() && this.check_overflow() {
+                if this.hir.check_overflow() && op == UnOp::Neg && expr.ty.is_signed() {
                     let bool_ty = this.hir.bool_ty();
 
                     let minval = this.minval_literal(expr_span, expr.ty);
@@ -247,7 +247,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                            lhs: Operand<'tcx>, rhs: Operand<'tcx>) -> BlockAnd<Rvalue<'tcx>> {
         let scope_id = self.innermost_scope_id();
         let bool_ty = self.hir.bool_ty();
-        if op.is_checkable() && ty.is_integral() && self.check_overflow() {
+        if self.hir.check_overflow() && op.is_checkable() && ty.is_integral() {
             let result_tup = self.hir.tcx().mk_tup(vec![ty, bool_ty]);
             let result_value = self.temp(result_tup);
 

--- a/src/librustc_mir/build/expr/as_rvalue.rs
+++ b/src/librustc_mir/build/expr/as_rvalue.rs
@@ -80,7 +80,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             ExprKind::Unary { op, arg } => {
                 let arg = unpack!(block = this.as_operand(block, arg));
                 // Check for -MIN on signed integers
-                if op == UnOp::Neg && this.check_overflow() && expr.ty.is_signed() {
+                if op == UnOp::Neg && expr.ty.is_signed() && this.check_overflow() {
                     let bool_ty = this.hir.bool_ty();
 
                     let minval = this.minval_literal(expr_span, expr.ty);
@@ -247,7 +247,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                            lhs: Operand<'tcx>, rhs: Operand<'tcx>) -> BlockAnd<Rvalue<'tcx>> {
         let scope_id = self.innermost_scope_id();
         let bool_ty = self.hir.bool_ty();
-        if self.check_overflow() && op.is_checkable() && ty.is_integral() {
+        if op.is_checkable() && ty.is_integral() && self.check_overflow() {
             let result_tup = self.hir.tcx().mk_tup(vec![ty, bool_ty]);
             let result_value = self.temp(result_tup);
 

--- a/src/librustc_mir/build/misc.rs
+++ b/src/librustc_mir/build/misc.rs
@@ -12,9 +12,14 @@
 //! kind of thing.
 
 use build::Builder;
-use rustc::ty::Ty;
+
+use rustc_const_math::{ConstInt, ConstUsize, ConstIsize};
+use rustc::middle::const_val::ConstVal;
+use rustc::ty::{self, Ty};
+
 use rustc::mir::repr::*;
 use std::u32;
+use syntax::ast;
 use syntax::codemap::Span;
 
 impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
@@ -48,6 +53,53 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
 
     pub fn unit_rvalue(&mut self) -> Rvalue<'tcx> {
         Rvalue::Aggregate(AggregateKind::Tuple, vec![])
+    }
+
+    // Returns a zero literal operand for the appropriate type, works for
+    // bool, char, integers and floats.
+    pub fn zero_literal(&mut self, span: Span, ty: Ty<'tcx>) -> Operand<'tcx> {
+        let literal = match ty.sty {
+            ty::TyBool => {
+                self.hir.false_literal()
+            }
+            ty::TyChar => Literal::Value { value: ConstVal::Char('\0') },
+            ty::TyUint(ity) => {
+                let val = match ity {
+                    ast::UintTy::U8  => ConstInt::U8(0),
+                    ast::UintTy::U16 => ConstInt::U16(0),
+                    ast::UintTy::U32 => ConstInt::U32(0),
+                    ast::UintTy::U64 => ConstInt::U64(0),
+                    ast::UintTy::Us => {
+                        let uint_ty = self.hir.tcx().sess.target.uint_type;
+                        let val = ConstUsize::new(0, uint_ty).unwrap();
+                        ConstInt::Usize(val)
+                    }
+                };
+
+                Literal::Value { value: ConstVal::Integral(val) }
+            }
+            ty::TyInt(ity) => {
+                let val = match ity {
+                    ast::IntTy::I8  => ConstInt::I8(0),
+                    ast::IntTy::I16 => ConstInt::I16(0),
+                    ast::IntTy::I32 => ConstInt::I32(0),
+                    ast::IntTy::I64 => ConstInt::I64(0),
+                    ast::IntTy::Is => {
+                        let int_ty = self.hir.tcx().sess.target.int_type;
+                        let val = ConstIsize::new(0, int_ty).unwrap();
+                        ConstInt::Isize(val)
+                    }
+                };
+
+                Literal::Value { value: ConstVal::Integral(val) }
+            }
+            ty::TyFloat(_) => Literal::Value { value: ConstVal::Float(0.0) },
+            _ => {
+                span_bug!(span, "Invalid type for zero_literal: `{:?}`", ty)
+            }
+        };
+
+        self.literal_operand(span, ty, literal)
     }
 
     pub fn push_usize(&mut self,

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -378,6 +378,11 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             }
         }
     }
+
+    pub fn check_overflow(&self) -> bool {
+        self.hir.tcx().sess.opts.debugging_opts.force_overflow_checks.unwrap_or(
+            self.hir.tcx().sess.opts.debug_assertions)
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -55,8 +55,6 @@ pub struct Builder<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
     cached_resume_block: Option<BasicBlock>,
     /// cached block with the RETURN terminator
     cached_return_block: Option<BasicBlock>,
-
-    has_warned_about_xcrate_overflows: bool
 }
 
 struct CFG<'tcx> {
@@ -275,8 +273,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             var_indices: FnvHashMap(),
             unit_temp: None,
             cached_resume_block: None,
-            cached_return_block: None,
-            has_warned_about_xcrate_overflows: false
+            cached_return_block: None
         };
 
         assert_eq!(builder.cfg.start_new_block(), START_BLOCK);
@@ -380,21 +377,6 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 rb
             }
         }
-    }
-
-    pub fn check_overflow(&mut self) -> bool {
-        let check = self.hir.tcx().sess.opts.debugging_opts.force_overflow_checks
-         .unwrap_or(self.hir.tcx().sess.opts.debug_assertions);
-
-        if !check && self.hir.may_be_inlined_cross_crate() {
-            if !self.has_warned_about_xcrate_overflows {
-                self.hir.tcx().sess.span_warn(self.fn_span,
-                    "overflow checks would be missing when used from another crate");
-                self.has_warned_about_xcrate_overflows = true;
-            }
-        }
-
-        check
     }
 }
 

--- a/src/librustc_mir/transform/no_landing_pads.rs
+++ b/src/librustc_mir/transform/no_landing_pads.rs
@@ -30,6 +30,7 @@ impl<'tcx> MutVisitor<'tcx> for NoLandingPads {
                 /* nothing to do */
             },
             TerminatorKind::Call { cleanup: ref mut unwind, .. } |
+            TerminatorKind::Assert { cleanup: ref mut unwind, .. } |
             TerminatorKind::DropAndReplace { ref mut unwind, .. } |
             TerminatorKind::Drop { ref mut unwind, .. } => {
                 unwind.take();

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -630,6 +630,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Qualifier<'a, 'tcx, 'tcx> {
             Rvalue::Use(_) |
             Rvalue::Repeat(..) |
             Rvalue::UnaryOp(..) |
+            Rvalue::CheckedBinaryOp(..) |
             Rvalue::Cast(CastKind::ReifyFnPointer, _, _) |
             Rvalue::Cast(CastKind::UnsafeFnPointer, _, _) |
             Rvalue::Cast(CastKind::Unsize, _, _) => {}

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -332,61 +332,6 @@ impl<'a, 'tcx> Qualifier<'a, 'tcx, 'tcx> {
         }
     }
 
-    /// Returns true if the block ends in a bounds check branch, i.e.:
-    /// len = Len(array);
-    /// cond = Lt(idx, len);
-    /// if cond {
-    ///     ...
-    /// } else {
-    ///     loc = (...);
-    ///     loc_ref = &loc;
-    ///     panic_bounds_check(loc_ref, idx, len);
-    /// }
-    fn is_bounds_check(&self, bb: BasicBlock,
-                       cond_op: &Operand<'tcx>,
-                       if_else: BasicBlock) -> bool {
-        use rustc::mir::repr::Lvalue::*;
-        use rustc::mir::repr::Operand::Consume;
-        use rustc::mir::repr::Rvalue::*;
-        use rustc::mir::repr::StatementKind::*;
-        use rustc::mir::repr::TerminatorKind::*;
-
-        let stmts = &self.mir[bb].statements;
-        let stmts_panic = &self.mir[if_else].statements;
-        if stmts.len() < 2 || stmts_panic.len() != 2 {
-            return false;
-        }
-
-        let all = (&stmts[stmts.len() - 2].kind,
-                   &stmts[stmts.len() - 1].kind,
-                   cond_op,
-                   &stmts_panic[0].kind,
-                   &stmts_panic[1].kind,
-                   &self.mir[if_else].terminator().kind);
-        match all {
-            (&Assign(Temp(len), Len(_)),
-             &Assign(Temp(cond), BinaryOp(BinOp::Lt, ref idx, Consume(Temp(len2)))),
-             /* if */ &Consume(Temp(cond2)), /* {...} else */
-             &Assign(Temp(loc), Aggregate(..)),
-             &Assign(Temp(loc_ref), Ref(_, _, Temp(loc2))),
-             &Call {
-                func: Operand::Constant(Constant {
-                    literal: Literal::Item { def_id, .. }, ..
-                }),
-                ref args,
-                destination: None,
-                ..
-            }) => {
-                len == len2 && cond == cond2 && loc == loc2 &&
-                args[0] == Consume(Temp(loc_ref)) &&
-                args[1] == *idx &&
-                args[2] == Consume(Temp(len)) &&
-                Some(def_id) == self.tcx.lang_items.panic_bounds_check_fn()
-            }
-            _ => false
-        }
-    }
-
     /// Qualify a whole const, static initializer or const fn.
     fn qualify_const(&mut self) -> Qualif {
         let mir = self.mir;
@@ -402,6 +347,7 @@ impl<'a, 'tcx> Qualifier<'a, 'tcx, 'tcx> {
                 TerminatorKind::Goto { target } |
                 // Drops are considered noops.
                 TerminatorKind::Drop { target, .. } |
+                TerminatorKind::Assert { target, .. } |
                 TerminatorKind::Call { destination: Some((_, target)), .. } => {
                     Some(target)
                 }
@@ -411,15 +357,7 @@ impl<'a, 'tcx> Qualifier<'a, 'tcx, 'tcx> {
                     return Qualif::empty();
                 }
 
-                // Need to allow bounds checking branches.
-                TerminatorKind::If { ref cond, targets: (if_true, if_else) } => {
-                    if self.is_bounds_check(bb, cond, if_else) {
-                        Some(if_true)
-                    } else {
-                        None
-                    }
-                }
-
+                TerminatorKind::If {..} |
                 TerminatorKind::Switch {..} |
                 TerminatorKind::SwitchInt {..} |
                 TerminatorKind::DropAndReplace { .. } |

--- a/src/librustc_mir/transform/simplify_cfg.rs
+++ b/src/librustc_mir/transform/simplify_cfg.rs
@@ -181,7 +181,17 @@ fn simplify_branches(mir: &mut Mir) {
                     }
                 }
 
+                TerminatorKind::Assert { target, cond: Operand::Constant(Constant {
+                    literal: Literal::Value {
+                        value: ConstVal::Bool(cond)
+                    }, ..
+                }), expected, .. } if cond == expected => {
+                    changed = true;
+                    TerminatorKind::Goto { target: target }
+                }
+
                 TerminatorKind::SwitchInt { ref targets, .. } if targets.len() == 1 => {
+                    changed = true;
                     TerminatorKind::Goto { target: targets[0] }
                 }
                 _ => continue

--- a/src/librustc_trans/_match.rs
+++ b/src/librustc_trans/_match.rs
@@ -880,7 +880,7 @@ fn compare_values<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
                                rhs_t: Ty<'tcx>,
                                debug_loc: DebugLoc)
                                -> Result<'blk, 'tcx> {
-        let did = langcall(bcx,
+        let did = langcall(bcx.tcx(),
                            None,
                            &format!("comparison of `{}`", rhs_t),
                            StrEqFnLangItem);

--- a/src/librustc_trans/common.rs
+++ b/src/librustc_trans/common.rs
@@ -39,6 +39,7 @@ use monomorphize;
 use type_::Type;
 use value::Value;
 use rustc::ty::{self, Ty, TyCtxt};
+use rustc::ty::layout::Layout;
 use rustc::traits::{self, SelectionContext, ProjectionMode};
 use rustc::ty::fold::TypeFoldable;
 use rustc::hir;
@@ -96,6 +97,63 @@ pub fn type_is_immediate<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, ty: Ty<'tcx>) -
             llsize_of_alloc(ccx, llty) <= llsize_of_alloc(ccx, ccx.int_type())
         }
         _ => type_is_zero_size(ccx, ty)
+    }
+}
+
+/// Returns Some([a, b]) if the type has a pair of fields with types a and b.
+pub fn type_pair_fields<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, ty: Ty<'tcx>)
+                                  -> Option<[Ty<'tcx>; 2]> {
+    match ty.sty {
+        ty::TyEnum(adt, substs) | ty::TyStruct(adt, substs) => {
+            assert_eq!(adt.variants.len(), 1);
+            let fields = &adt.variants[0].fields;
+            if fields.len() != 2 {
+                return None;
+            }
+            Some([monomorphize::field_ty(ccx.tcx(), substs, &fields[0]),
+                  monomorphize::field_ty(ccx.tcx(), substs, &fields[1])])
+        }
+        ty::TyClosure(_, ty::ClosureSubsts { upvar_tys: tys, .. }) |
+        ty::TyTuple(tys) => {
+            if tys.len() != 2 {
+                return None;
+            }
+            Some([tys[0], tys[1]])
+        }
+        _ => None
+    }
+}
+
+/// Returns true if the type is represented as a pair of immediates.
+pub fn type_is_imm_pair<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, ty: Ty<'tcx>)
+                                  -> bool {
+    let tcx = ccx.tcx();
+    let layout = tcx.normalizing_infer_ctxt(ProjectionMode::Any).enter(|infcx| {
+        match ty.layout(&infcx) {
+            Ok(layout) => layout,
+            Err(err) => {
+                bug!("type_is_imm_pair: layout for `{:?}` failed: {}",
+                     ty, err);
+            }
+        }
+    });
+
+    match *layout {
+        Layout::FatPointer { .. } => true,
+        Layout::Univariant { ref variant, .. } => {
+            // There must be only 2 fields.
+            if variant.offset_after_field.len() != 2 {
+                return false;
+            }
+
+            match type_pair_fields(ccx, ty) {
+                Some([a, b]) => {
+                    type_is_immediate(ccx, a) && type_is_immediate(ccx, b)
+                }
+                None => false
+            }
+        }
+        _ => false
     }
 }
 

--- a/src/librustc_trans/common.rs
+++ b/src/librustc_trans/common.rs
@@ -1165,18 +1165,18 @@ pub fn normalize_and_test_predicates<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     })
 }
 
-pub fn langcall(bcx: Block,
+pub fn langcall(tcx: TyCtxt,
                 span: Option<Span>,
                 msg: &str,
                 li: LangItem)
                 -> DefId {
-    match bcx.tcx().lang_items.require(li) {
+    match tcx.lang_items.require(li) {
         Ok(id) => id,
         Err(s) => {
             let msg = format!("{} {}", msg, s);
             match span {
-                Some(span) => bcx.tcx().sess.span_fatal(span, &msg[..]),
-                None => bcx.tcx().sess.fatal(&msg[..]),
+                Some(span) => tcx.sess.span_fatal(span, &msg[..]),
+                None => tcx.sess.fatal(&msg[..]),
             }
         }
     }

--- a/src/librustc_trans/consts.rs
+++ b/src/librustc_trans/consts.rs
@@ -716,7 +716,10 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             if iv >= len {
                 // FIXME #3170: report this earlier on in the const-eval
                 // pass. Reporting here is a bit late.
-                const_err(cx, e.span, Err(ErrKind::IndexOutOfBounds), trueconst)?;
+                const_err(cx, e.span, Err(ErrKind::IndexOutOfBounds {
+                    len: len,
+                    index: iv
+                }), trueconst)?;
                 C_undef(val_ty(arr).element_type())
             } else {
                 const_get_elt(arr, &[iv as c_uint])

--- a/src/librustc_trans/controlflow.rs
+++ b/src/librustc_trans/controlflow.rs
@@ -400,7 +400,7 @@ pub fn trans_fail<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let align = machine::llalign_of_min(ccx, val_ty(expr_file_line_const));
     let expr_file_line = consts::addr_of(ccx, expr_file_line_const, align, "panic_loc");
     let args = vec!(expr_file_line);
-    let did = langcall(bcx, Some(call_info.span), "", PanicFnLangItem);
+    let did = langcall(bcx.tcx(), Some(call_info.span), "", PanicFnLangItem);
     Callee::def(ccx, did, ccx.tcx().mk_substs(Substs::empty()))
         .call(bcx, call_info.debug_loc(), ArgVals(&args), None).bcx
 }
@@ -428,7 +428,7 @@ pub fn trans_fail_bounds_check<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let align = machine::llalign_of_min(ccx, val_ty(file_line_const));
     let file_line = consts::addr_of(ccx, file_line_const, align, "panic_bounds_check_loc");
     let args = vec!(file_line, index, len);
-    let did = langcall(bcx, Some(call_info.span), "", PanicBoundsCheckFnLangItem);
+    let did = langcall(bcx.tcx(), Some(call_info.span), "", PanicBoundsCheckFnLangItem);
     Callee::def(ccx, did, ccx.tcx().mk_substs(Substs::empty()))
         .call(bcx, call_info.debug_loc(), ArgVals(&args), None).bcx
 }

--- a/src/librustc_trans/expr.rs
+++ b/src/librustc_trans/expr.rs
@@ -2230,11 +2230,11 @@ impl OverflowOpViaIntrinsic {
                         binop_debug_loc);
 
         let expect = bcx.ccx().get_intrinsic(&"llvm.expect.i1");
-        Call(bcx, expect, &[cond, C_integral(Type::i1(bcx.ccx()), 0, false)],
-             binop_debug_loc);
+        let expected = Call(bcx, expect, &[cond, C_bool(bcx.ccx(), false)],
+                            binop_debug_loc);
 
         let bcx =
-            base::with_cond(bcx, cond, |bcx|
+            base::with_cond(bcx, expected, |bcx|
                 controlflow::trans_fail(bcx, info,
                     InternedString::new("arithmetic operation overflowed")));
 

--- a/src/librustc_trans/expr.rs
+++ b/src/librustc_trans/expr.rs
@@ -2220,6 +2220,8 @@ impl OverflowOpViaIntrinsic {
                                         rhs: ValueRef,
                                         binop_debug_loc: DebugLoc)
                                         -> (Block<'blk, 'tcx>, ValueRef) {
+        use rustc_const_math::{ConstMathErr, Op};
+
         let llfn = self.to_intrinsic(bcx, lhs_t);
 
         let val = Call(bcx, llfn, &[lhs, rhs], binop_debug_loc);
@@ -2233,10 +2235,16 @@ impl OverflowOpViaIntrinsic {
         let expected = Call(bcx, expect, &[cond, C_bool(bcx.ccx(), false)],
                             binop_debug_loc);
 
+        let op = match *self {
+            OverflowOpViaIntrinsic::Add => Op::Add,
+            OverflowOpViaIntrinsic::Sub => Op::Sub,
+            OverflowOpViaIntrinsic::Mul => Op::Mul
+        };
+
         let bcx =
             base::with_cond(bcx, expected, |bcx|
                 controlflow::trans_fail(bcx, info,
-                    InternedString::new("arithmetic operation overflowed")));
+                    InternedString::new(ConstMathErr::Overflow(op).description())));
 
         (bcx, result)
     }
@@ -2252,6 +2260,8 @@ impl OverflowOpViaInputCheck {
                                           binop_debug_loc: DebugLoc)
                                           -> (Block<'blk, 'tcx>, ValueRef)
     {
+        use rustc_const_math::{ConstMathErr, Op};
+
         let lhs_llty = val_ty(lhs);
         let rhs_llty = val_ty(rhs);
 
@@ -2266,16 +2276,16 @@ impl OverflowOpViaInputCheck {
 
         let outer_bits = And(bcx, rhs, invert_mask, binop_debug_loc);
         let cond = build_nonzero_check(bcx, outer_bits, binop_debug_loc);
-        let result = match *self {
+        let (result, op) = match *self {
             OverflowOpViaInputCheck::Shl =>
-                build_unchecked_lshift(bcx, lhs, rhs, binop_debug_loc),
+                (build_unchecked_lshift(bcx, lhs, rhs, binop_debug_loc), Op::Shl),
             OverflowOpViaInputCheck::Shr =>
-                build_unchecked_rshift(bcx, lhs_t, lhs, rhs, binop_debug_loc),
+                (build_unchecked_rshift(bcx, lhs_t, lhs, rhs, binop_debug_loc), Op::Shr)
         };
         let bcx =
             base::with_cond(bcx, cond, |bcx|
                 controlflow::trans_fail(bcx, info,
-                    InternedString::new("shift operation overflowed")));
+                    InternedString::new(ConstMathErr::Overflow(op).description())));
 
         (bcx, result)
     }

--- a/src/librustc_trans/glue.rs
+++ b/src/librustc_trans/glue.rs
@@ -53,7 +53,7 @@ pub fn trans_exchange_free_dyn<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                            -> Block<'blk, 'tcx> {
     let _icx = push_ctxt("trans_exchange_free");
 
-    let def_id = langcall(bcx, None, "", ExchangeFreeFnLangItem);
+    let def_id = langcall(bcx.tcx(), None, "", ExchangeFreeFnLangItem);
     let args = [PointerCast(bcx, v, Type::i8p(bcx.ccx())), size, align];
     Callee::def(bcx.ccx(), def_id, bcx.tcx().mk_substs(Substs::empty()))
         .call(bcx, debug_loc, ArgVals(&args), None).bcx

--- a/src/librustc_trans/mir/analyze.rs
+++ b/src/librustc_trans/mir/analyze.rs
@@ -161,6 +161,7 @@ pub fn cleanup_kinds<'bcx,'tcx>(_bcx: Block<'bcx,'tcx>,
                     /* nothing to do */
                 }
                 TerminatorKind::Call { cleanup: unwind, .. } |
+                TerminatorKind::Assert { cleanup: unwind, .. } |
                 TerminatorKind::DropAndReplace { unwind, .. } |
                 TerminatorKind::Drop { unwind, .. } => {
                     if let Some(unwind) = unwind {

--- a/src/librustc_trans/mir/block.rs
+++ b/src/librustc_trans/mir/block.rs
@@ -852,63 +852,74 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                     op: OperandRef<'tcx>) {
         use self::ReturnDest::*;
 
-        match dest {
-            Nothing => (),
+        // Handle the simple cases that don't require casts, first.
+        let llcast_ty = match dest {
+            Nothing => return,
             Store(dst) => {
                 if let Some(llcast_ty) = ret_ty.cast {
-                    let ccx = bcx.ccx();
-                    // The actual return type is a struct, but the ABI
-                    // adaptation code has cast it into some scalar type.  The
-                    // code that follows is the only reliable way I have
-                    // found to do a transform like i64 -> {i32,i32}.
-                    // Basically we dump the data onto the stack then memcpy it.
-                    //
-                    // Other approaches I tried:
-                    // - Casting rust ret pointer to the foreign type and using Store
-                    //   is (a) unsafe if size of foreign type > size of rust type and
-                    //   (b) runs afoul of strict aliasing rules, yielding invalid
-                    //   assembly under -O (specifically, the store gets removed).
-                    // - Truncating foreign type to correct integral type and then
-                    //   bitcasting to the struct type yields invalid cast errors.
-
-                    // We instead thus allocate some scratch space...
-                    let llscratch = bcx.alloca(llcast_ty, "fn_ret_cast");
-                    bcx.with_block(|bcx| base::call_lifetime_start(bcx, llscratch));
-
-                    // ...where we first store the value...
-                    bcx.store(op.immediate(), llscratch);
-
-                    // ...and then memcpy it to the intended destination.
-                    base::call_memcpy(bcx,
-                                      bcx.pointercast(dst, Type::i8p(ccx)),
-                                      bcx.pointercast(llscratch, Type::i8p(ccx)),
-                                      C_uint(ccx, llsize_of_store(ccx, ret_ty.original_ty)),
-                                      cmp::min(llalign_of_min(ccx, ret_ty.original_ty),
-                                               llalign_of_min(ccx, llcast_ty)) as u32);
-
-                    bcx.with_block(|bcx| base::call_lifetime_end(bcx, llscratch));
+                    llcast_ty
                 } else {
                     ret_ty.store(bcx, op.immediate(), dst);
+                    return;
                 }
             }
             IndirectOperand(tmp, idx) => {
                 let op = self.trans_load(bcx, tmp, op.ty);
                 self.temps[idx as usize] = TempRef::Operand(Some(op));
+                return;
             }
             DirectOperand(idx) => {
-                // If there is a cast, we have to store and reload.
-                let op = if ret_ty.cast.is_some() {
-                    let tmp = bcx.with_block(|bcx| {
-                        base::alloc_ty(bcx, op.ty, "tmp_ret")
-                    });
-                    ret_ty.store(bcx, op.immediate(), tmp);
-                    self.trans_load(bcx, tmp, op.ty)
+                if let Some(llcast_ty) = ret_ty.cast {
+                    llcast_ty
                 } else {
-                    op.unpack_if_pair(bcx)
-                };
+                    let op = op.unpack_if_pair(bcx);
+                    self.temps[idx as usize] = TempRef::Operand(Some(op));
+                    return;
+                }
+            }
+        };
+
+        // The actual return type is a struct, but the ABI
+        // adaptation code has cast it into some scalar type.  The
+        // code that follows is the only reliable way I have
+        // found to do a transform like i64 -> {i32,i32}.
+        // Basically we dump the data onto the stack then memcpy it.
+        //
+        // Other approaches I tried:
+        // - Casting rust ret pointer to the foreign type and using Store
+        //   is (a) unsafe if size of foreign type > size of rust type and
+        //   (b) runs afoul of strict aliasing rules, yielding invalid
+        //   assembly under -O (specifically, the store gets removed).
+        // - Truncating foreign type to correct integral type and then
+        //   bitcasting to the struct type yields invalid cast errors.
+
+        // We instead thus allocate some scratch space...
+        let llscratch = bcx.alloca(llcast_ty, "fn_ret_cast");
+        bcx.with_block(|bcx| base::call_lifetime_start(bcx, llscratch));
+
+        // ...where we first store the value...
+        bcx.store(op.immediate(), llscratch);
+
+        let ccx = bcx.ccx();
+        match dest {
+            Store(dst) => {
+                // ...and then memcpy it to the intended destination.
+                base::call_memcpy(bcx,
+                                  bcx.pointercast(dst, Type::i8p(ccx)),
+                                  bcx.pointercast(llscratch, Type::i8p(ccx)),
+                                  C_uint(ccx, llsize_of_store(ccx, ret_ty.original_ty)),
+                                  cmp::min(llalign_of_min(ccx, ret_ty.original_ty),
+                                           llalign_of_min(ccx, llcast_ty)) as u32);
+            }
+            DirectOperand(idx) => {
+                let llptr = bcx.pointercast(llscratch, ret_ty.original_ty.ptr_to());
+                let op = self.trans_load(bcx, llptr, op.ty);
                 self.temps[idx as usize] = TempRef::Operand(Some(op));
             }
+            Nothing | IndirectOperand(_, _) => bug!()
         }
+
+        bcx.with_block(|bcx| base::call_lifetime_end(bcx, llscratch));
     }
 }
 

--- a/src/librustc_trans/mir/constant.rs
+++ b/src/librustc_trans/mir/constant.rs
@@ -298,8 +298,13 @@ impl<'a, 'tcx> MirConstContext<'a, 'tcx> {
                     let cond_bool = common::const_to_uint(cond.llval) != 0;
                     if cond_bool != expected {
                         let err = match *msg {
-                            mir::AssertMessage::BoundsCheck {..} => {
-                                ErrKind::IndexOutOfBounds
+                            mir::AssertMessage::BoundsCheck { ref len, ref index } => {
+                                let len = self.const_operand(len, span)?;
+                                let index = self.const_operand(index, span)?;
+                                ErrKind::IndexOutOfBounds {
+                                    len: common::const_to_uint(len.llval),
+                                    index: common::const_to_uint(index.llval)
+                                }
                             }
                             mir::AssertMessage::Math(ref err) => {
                                 ErrKind::Math(err.clone())

--- a/src/librustc_trans/mir/operand.rs
+++ b/src/librustc_trans/mir/operand.rs
@@ -13,12 +13,12 @@ use rustc::ty::Ty;
 use rustc::mir::repr as mir;
 use base;
 use common::{self, Block, BlockAndBuilder};
-use datum;
 use value::Value;
+use type_of;
+use type_::Type;
 
 use std::fmt;
 
-use super::lvalue::load_fat_ptr;
 use super::{MirContext, TempRef};
 
 /// The representation of a Rust value. The enum variant is in fact
@@ -31,9 +31,8 @@ pub enum OperandValue {
     Ref(ValueRef),
     /// A single LLVM value.
     Immediate(ValueRef),
-    /// A fat pointer. The first ValueRef is the data and the second
-    /// is the extra.
-    FatPtr(ValueRef, ValueRef)
+    /// A pair of immediate LLVM values. Used by fat pointers too.
+    Pair(ValueRef, ValueRef)
 }
 
 /// An `OperandRef` is an "SSA" reference to a Rust value, along with
@@ -64,15 +63,15 @@ impl<'tcx> fmt::Debug for OperandRef<'tcx> {
                 write!(f, "OperandRef(Immediate({:?}) @ {:?})",
                        Value(i), self.ty)
             }
-            OperandValue::FatPtr(a, d) => {
-                write!(f, "OperandRef(FatPtr({:?}, {:?}) @ {:?})",
-                       Value(a), Value(d), self.ty)
+            OperandValue::Pair(a, b) => {
+                write!(f, "OperandRef(Pair({:?}, {:?}) @ {:?})",
+                       Value(a), Value(b), self.ty)
             }
         }
     }
 }
 
-impl<'tcx> OperandRef<'tcx> {
+impl<'bcx, 'tcx> OperandRef<'tcx> {
     /// Asserts that this operand refers to a scalar and returns
     /// a reference to its value.
     pub fn immediate(self) -> ValueRef {
@@ -80,6 +79,54 @@ impl<'tcx> OperandRef<'tcx> {
             OperandValue::Immediate(s) => s,
             _ => bug!()
         }
+    }
+
+    /// If this operand is a Pair, we return an
+    /// Immediate aggregate with the two values.
+    pub fn pack_if_pair(mut self, bcx: &BlockAndBuilder<'bcx, 'tcx>)
+                        -> OperandRef<'tcx> {
+        if let OperandValue::Pair(a, b) = self.val {
+            // Reconstruct the immediate aggregate.
+            let llty = type_of::type_of(bcx.ccx(), self.ty);
+            let mut llpair = common::C_undef(llty);
+            let elems = [a, b];
+            for i in 0..2 {
+                let mut elem = elems[i];
+                // Extend boolean i1's to i8.
+                if common::val_ty(elem) == Type::i1(bcx.ccx()) {
+                    elem = bcx.zext(elem, Type::i8(bcx.ccx()));
+                }
+                llpair = bcx.insert_value(llpair, elem, i);
+            }
+            self.val = OperandValue::Immediate(llpair);
+        }
+        self
+    }
+
+    /// If this operand is a pair in an Immediate,
+    /// we return a Pair with the two halves.
+    pub fn unpack_if_pair(mut self, bcx: &BlockAndBuilder<'bcx, 'tcx>)
+                          -> OperandRef<'tcx> {
+        if let OperandValue::Immediate(llval) = self.val {
+            // Deconstruct the immediate aggregate.
+            if common::type_is_imm_pair(bcx.ccx(), self.ty) {
+                let mut a = bcx.extract_value(llval, 0);
+                let mut b = bcx.extract_value(llval, 1);
+
+                let pair_fields = common::type_pair_fields(bcx.ccx(), self.ty);
+                if let Some([a_ty, b_ty]) = pair_fields {
+                    if a_ty.is_bool() {
+                        a = bcx.trunc(a, Type::i1(bcx.ccx()));
+                    }
+                    if b_ty.is_bool() {
+                        b = bcx.trunc(b, Type::i1(bcx.ccx()));
+                    }
+                }
+
+                self.val = OperandValue::Pair(a, b);
+            }
+        }
+        self
     }
 }
 
@@ -92,15 +139,24 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
     {
         debug!("trans_load: {:?} @ {:?}", Value(llval), ty);
 
-        let val = match datum::appropriate_rvalue_mode(bcx.ccx(), ty) {
-            datum::ByValue => {
-                OperandValue::Immediate(base::load_ty_builder(bcx, llval, ty))
-            }
-            datum::ByRef if common::type_is_fat_ptr(bcx.tcx(), ty) => {
-                let (lldata, llextra) = load_fat_ptr(bcx, llval);
-                OperandValue::FatPtr(lldata, llextra)
-            }
-            datum::ByRef => OperandValue::Ref(llval)
+        let val = if common::type_is_imm_pair(bcx.ccx(), ty) {
+            let a_ptr = bcx.struct_gep(llval, 0);
+            let b_ptr = bcx.struct_gep(llval, 1);
+
+            // This is None only for fat pointers, which don't
+            // need any special load-time behavior anyway.
+            let pair_fields = common::type_pair_fields(bcx.ccx(), ty);
+            let (a, b) = if let Some([a_ty, b_ty]) = pair_fields {
+                (base::load_ty_builder(bcx, a_ptr, a_ty),
+                 base::load_ty_builder(bcx, b_ptr, b_ty))
+            } else {
+                (bcx.load(a_ptr), bcx.load(b_ptr))
+            };
+            OperandValue::Pair(a, b)
+        } else if common::type_is_immediate(bcx.ccx(), ty) {
+            OperandValue::Immediate(base::load_ty_builder(bcx, llval, ty))
+        } else {
+            OperandValue::Ref(llval)
         };
 
         OperandRef { val: val, ty: ty }
@@ -173,8 +229,12 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
         match operand.val {
             OperandValue::Ref(r) => base::memcpy_ty(bcx, lldest, r, operand.ty),
             OperandValue::Immediate(s) => base::store_ty(bcx, s, lldest, operand.ty),
-            OperandValue::FatPtr(data, extra) => {
-                base::store_fat_ptr(bcx, data, extra, lldest, operand.ty);
+            OperandValue::Pair(a, b) => {
+                use build::*;
+                let a = base::from_immediate(bcx, a);
+                let b = base::from_immediate(bcx, b);
+                Store(bcx, a, StructGEP(bcx, lldest, 0));
+                Store(bcx, b, StructGEP(bcx, lldest, 1));
             }
         }
     }

--- a/src/librustc_trans/mir/rvalue.rs
+++ b/src/librustc_trans/mir/rvalue.rs
@@ -17,13 +17,13 @@ use asm;
 use base;
 use callee::Callee;
 use common::{self, val_ty,
-             C_null,
-             C_uint, C_undef, C_u8, BlockAndBuilder, Result};
+             C_null, C_uint, C_undef, BlockAndBuilder, Result};
 use datum::{Datum, Lvalue};
 use debuginfo::DebugLoc;
 use adt;
 use machine;
 use type_of;
+use type_::Type;
 use tvec;
 use value::Value;
 use Disr;
@@ -611,9 +611,7 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                 (val, bcx.zext(of, Type::bool(bcx.ccx())))
             }
             _ => {
-                // Fall back to regular translation with a constant-false overflow flag
-                (self.trans_scalar_binop(bcx, op, lhs, rhs, input_ty),
-                 C_u8(bcx.ccx(), 0))
+                bug!("Operator `{:?}` is not a checkable operator", op)
             }
         };
 

--- a/src/librustc_trans/mir/rvalue.rs
+++ b/src/librustc_trans/mir/rvalue.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use llvm::ValueRef;
+use llvm::{self, ValueRef};
 use rustc::ty::{self, Ty};
 use rustc::ty::cast::{CastTy, IntTy};
 use rustc::mir::repr as mir;
@@ -16,7 +16,9 @@ use rustc::mir::repr as mir;
 use asm;
 use base;
 use callee::Callee;
-use common::{self, C_uint, BlockAndBuilder, Result};
+use common::{self, val_ty,
+             C_null,
+             C_uint, C_undef, C_u8, BlockAndBuilder, Result};
 use datum::{Datum, Lvalue};
 use debuginfo::DebugLoc;
 use adt;
@@ -430,6 +432,21 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                 };
                 (bcx, operand)
             }
+            mir::Rvalue::CheckedBinaryOp(op, ref lhs, ref rhs) => {
+                let lhs = self.trans_operand(&bcx, lhs);
+                let rhs = self.trans_operand(&bcx, rhs);
+                let result = self.trans_scalar_checked_binop(&bcx, op,
+                                                             lhs.immediate(), rhs.immediate(),
+                                                             lhs.ty);
+                let val_ty = self.mir.binop_ty(bcx.tcx(), op, lhs.ty, rhs.ty);
+                let operand_ty = bcx.tcx().mk_tup(vec![val_ty, bcx.tcx().types.bool]);
+                let operand = OperandRef {
+                    val: OperandValue::Immediate(result),
+                    ty: operand_ty
+                };
+
+                (bcx, operand)
+            }
 
             mir::Rvalue::UnaryOp(op, ref operand) => {
                 let operand = self.trans_operand(&bcx, operand);
@@ -556,6 +573,57 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
             }
         }
     }
+
+    pub fn trans_scalar_checked_binop(&mut self,
+                                      bcx: &BlockAndBuilder<'bcx, 'tcx>,
+                                      op: mir::BinOp,
+                                      lhs: ValueRef,
+                                      rhs: ValueRef,
+                                      input_ty: Ty<'tcx>) -> ValueRef {
+        let (val, of) = match op {
+            // These are checked using intrinsics
+            mir::BinOp::Add | mir::BinOp::Sub | mir::BinOp::Mul => {
+                let oop = match op {
+                    mir::BinOp::Add => OverflowOp::Add,
+                    mir::BinOp::Sub => OverflowOp::Sub,
+                    mir::BinOp::Mul => OverflowOp::Mul,
+                    _ => unreachable!()
+                };
+                let intrinsic = get_overflow_intrinsic(oop, bcx, input_ty);
+                let res = bcx.call(intrinsic, &[lhs, rhs], None);
+
+                let val = bcx.extract_value(res, 0);
+                let of = bcx.extract_value(res, 1);
+
+                (val, bcx.zext(of, Type::bool(bcx.ccx())))
+            }
+            mir::BinOp::Shl | mir::BinOp::Shr => {
+                let lhs_llty = val_ty(lhs);
+                let rhs_llty = val_ty(rhs);
+                let invert_mask = bcx.with_block(|bcx| {
+                    common::shift_mask_val(bcx, lhs_llty, rhs_llty, true)
+                });
+                let outer_bits = bcx.and(rhs, invert_mask);
+
+                let of = bcx.icmp(llvm::IntNE, outer_bits, C_null(rhs_llty));
+                let val = self.trans_scalar_binop(bcx, op, lhs, rhs, input_ty);
+
+                (val, bcx.zext(of, Type::bool(bcx.ccx())))
+            }
+            _ => {
+                // Fall back to regular translation with a constant-false overflow flag
+                (self.trans_scalar_binop(bcx, op, lhs, rhs, input_ty),
+                 C_u8(bcx.ccx(), 0))
+            }
+        };
+
+        let val_ty = val_ty(val);
+        let res_ty = Type::struct_(bcx.ccx(), &[val_ty, Type::bool(bcx.ccx())], false);
+
+        let mut res_val = C_undef(res_ty);
+        res_val = bcx.insert_value(res_val, val, 0);
+        bcx.insert_value(res_val, of, 1)
+    }
 }
 
 pub fn rvalue_creates_operand<'bcx, 'tcx>(_mir: &mir::Mir<'tcx>,
@@ -566,6 +634,7 @@ pub fn rvalue_creates_operand<'bcx, 'tcx>(_mir: &mir::Mir<'tcx>,
         mir::Rvalue::Len(..) |
         mir::Rvalue::Cast(..) | // (*)
         mir::Rvalue::BinaryOp(..) |
+        mir::Rvalue::CheckedBinaryOp(..) |
         mir::Rvalue::UnaryOp(..) |
         mir::Rvalue::Box(..) |
         mir::Rvalue::Use(..) =>
@@ -578,4 +647,76 @@ pub fn rvalue_creates_operand<'bcx, 'tcx>(_mir: &mir::Mir<'tcx>,
     }
 
     // (*) this is only true if the type is suitable
+}
+
+#[derive(Copy, Clone)]
+enum OverflowOp {
+    Add, Sub, Mul
+}
+
+fn get_overflow_intrinsic(oop: OverflowOp, bcx: &BlockAndBuilder, ty: Ty) -> ValueRef {
+    use syntax::ast::IntTy::*;
+    use syntax::ast::UintTy::*;
+    use rustc::ty::{TyInt, TyUint};
+
+    let tcx = bcx.tcx();
+
+    let new_sty = match ty.sty {
+        TyInt(Is) => match &tcx.sess.target.target.target_pointer_width[..] {
+            "32" => TyInt(I32),
+            "64" => TyInt(I64),
+            _ => panic!("unsupported target word size")
+        },
+        TyUint(Us) => match &tcx.sess.target.target.target_pointer_width[..] {
+            "32" => TyUint(U32),
+            "64" => TyUint(U64),
+            _ => panic!("unsupported target word size")
+        },
+        ref t @ TyUint(_) | ref t @ TyInt(_) => t.clone(),
+        _ => panic!("tried to get overflow intrinsic for op applied to non-int type")
+    };
+
+    let name = match oop {
+        OverflowOp::Add => match new_sty {
+            TyInt(I8) => "llvm.sadd.with.overflow.i8",
+            TyInt(I16) => "llvm.sadd.with.overflow.i16",
+            TyInt(I32) => "llvm.sadd.with.overflow.i32",
+            TyInt(I64) => "llvm.sadd.with.overflow.i64",
+
+            TyUint(U8) => "llvm.uadd.with.overflow.i8",
+            TyUint(U16) => "llvm.uadd.with.overflow.i16",
+            TyUint(U32) => "llvm.uadd.with.overflow.i32",
+            TyUint(U64) => "llvm.uadd.with.overflow.i64",
+
+            _ => unreachable!(),
+        },
+        OverflowOp::Sub => match new_sty {
+            TyInt(I8) => "llvm.ssub.with.overflow.i8",
+            TyInt(I16) => "llvm.ssub.with.overflow.i16",
+            TyInt(I32) => "llvm.ssub.with.overflow.i32",
+            TyInt(I64) => "llvm.ssub.with.overflow.i64",
+
+            TyUint(U8) => "llvm.usub.with.overflow.i8",
+            TyUint(U16) => "llvm.usub.with.overflow.i16",
+            TyUint(U32) => "llvm.usub.with.overflow.i32",
+            TyUint(U64) => "llvm.usub.with.overflow.i64",
+
+            _ => unreachable!(),
+        },
+        OverflowOp::Mul => match new_sty {
+            TyInt(I8) => "llvm.smul.with.overflow.i8",
+            TyInt(I16) => "llvm.smul.with.overflow.i16",
+            TyInt(I32) => "llvm.smul.with.overflow.i32",
+            TyInt(I64) => "llvm.smul.with.overflow.i64",
+
+            TyUint(U8) => "llvm.umul.with.overflow.i8",
+            TyUint(U16) => "llvm.umul.with.overflow.i16",
+            TyUint(U32) => "llvm.umul.with.overflow.i32",
+            TyUint(U64) => "llvm.umul.with.overflow.i64",
+
+            _ => unreachable!(),
+        },
+    };
+
+    bcx.ccx().get_intrinsic(&name)
 }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -502,6 +502,13 @@ pub const KNOWN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeGat
                                          is just used to make tests pass \
                                          and will never be stable",
                                         cfg_fn!(rustc_attrs))),
+    ("rustc_inherit_overflow_checks", Whitelisted, Gated("rustc_attrs",
+                                                         "the `#[rustc_inherit_overflow_checks]` \
+                                                          attribute is just used to control \
+                                                          overflow checking behavior of several \
+                                                          libcore functions that are inlined \
+                                                          across crates and will never be stable",
+                                                          cfg_fn!(rustc_attrs))),
 
     ("allow_internal_unstable", Normal, Gated("allow_internal_unstable",
                                               EXPLAIN_ALLOW_INTERNAL_UNSTABLE,

--- a/src/test/compile-fail/array_const_index-0.rs
+++ b/src/test/compile-fail/array_const_index-0.rs
@@ -10,7 +10,7 @@
 
 const A: &'static [i32] = &[];
 const B: i32 = (&A)[1];
-//~^ ERROR: array index out of bounds
+//~^ ERROR index out of bounds: the len is 0 but the index is 1
 
 fn main() {
     let _ = B;

--- a/src/test/compile-fail/array_const_index-1.rs
+++ b/src/test/compile-fail/array_const_index-1.rs
@@ -9,7 +9,8 @@
 // except according to those terms.
 
 const A: [i32; 0] = [];
-const B: i32 = A[1]; //~ ERROR: array index out of bounds
+const B: i32 = A[1];
+//~^ ERROR index out of bounds: the len is 0 but the index is 1
 
 fn main() {
     let _ = B;

--- a/src/test/compile-fail/const-array-oob.rs
+++ b/src/test/compile-fail/const-array-oob.rs
@@ -8,13 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-tidy-linelength
+
 #![feature(const_indexing)]
 
 const FOO: [u32; 3] = [1, 2, 3];
 const BAR: u32 = FOO[5]; // no error, because the error below occurs before regular const eval
 
 const BLUB: [u32; FOO[4]] = [5, 6];
-//~^ ERROR array length constant evaluation error: array index out of bounds [E0250]
+//~^ ERROR array length constant evaluation error: index out of bounds: the len is 3 but the index is 4 [E0250]
 
 fn main() {
     let _ = BAR;

--- a/src/test/compile-fail/const-err-early.rs
+++ b/src/test/compile-fail/const-err-early.rs
@@ -15,8 +15,10 @@ pub const A: i8 = -std::i8::MIN; //~ ERROR attempted to negate with overflow
 pub const B: u8 = 200u8 + 200u8; //~ ERROR attempted to add with overflow
 pub const C: u8 = 200u8 * 4; //~ ERROR attempted to multiply with overflow
 pub const D: u8 = 42u8 - (42u8 + 1); //~ ERROR attempted to subtract with overflow
-pub const E: u8 = [5u8][1]; //~ ERROR index out of bounds
+pub const E: u8 = [5u8][1];
+//~^ ERROR index out of bounds: the len is 1 but the index is 1
 
 fn main() {
-    let _e = [6u8][1]; //~ ERROR: array index out of bounds
+    let _e = [6u8][1];
+    //~^ ERROR index out of bounds: the len is 1 but the index is 1
 }

--- a/src/test/compile-fail/const-err.rs
+++ b/src/test/compile-fail/const-err.rs
@@ -20,8 +20,8 @@ fn black_box<T>(_: T) {
 
 // Make sure that the two uses get two errors.
 const FOO: u8 = [5u8][1];
-//~^ ERROR array index out of bounds
-//~^^ ERROR array index out of bounds
+//~^ ERROR index out of bounds: the len is 1 but the index is 1
+//~^^ ERROR index out of bounds: the len is 1 but the index is 1
 
 fn main() {
     let a = -std::i8::MIN;
@@ -34,7 +34,7 @@ fn main() {
     let d = 42u8 - (42u8 + 1);
     //~^ WARN attempted to subtract with overflow
     let _e = [5u8][1];
-    //~^ WARN array index out of bounds
+    //~^ WARN index out of bounds: the len is 1 but the index is 1
     black_box(a);
     black_box(b);
     black_box(c);

--- a/src/test/compile-fail/const-err.rs
+++ b/src/test/compile-fail/const-err.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Zforce-overflow-checks=on
+
 // these errors are not actually "const_err", they occur in trans/consts
 // and are unconditional warnings that can't be denied or allowed
 

--- a/src/test/compile-fail/const-err.rs
+++ b/src/test/compile-fail/const-err.rs
@@ -11,7 +11,6 @@
 // these errors are not actually "const_err", they occur in trans/consts
 // and are unconditional warnings that can't be denied or allowed
 
-#![feature(rustc_attrs)]
 #![allow(exceeding_bitshifts)]
 #![allow(const_err)]
 
@@ -24,7 +23,6 @@ const FOO: u8 = [5u8][1];
 //~^ ERROR array index out of bounds
 //~^^ ERROR array index out of bounds
 
-#[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
 fn main() {
     let a = -std::i8::MIN;
     //~^ WARN attempted to negate with overflow

--- a/src/test/compile-fail/const-eval-overflow.rs
+++ b/src/test/compile-fail/const-eval-overflow.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(rustc_attrs)]
 #![allow(unused_imports)]
 
 // Note: the relevant lint pass here runs before some of the constant
@@ -104,7 +103,6 @@ const VALS_U64: (u64, u64, u64, u64) =
      //~^ ERROR attempted to multiply with overflow
      );
 
-#[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
 fn main() {
     foo(VALS_I8);
     foo(VALS_I16);

--- a/src/test/compile-fail/const-slice-oob.rs
+++ b/src/test/compile-fail/const-slice-oob.rs
@@ -9,7 +9,8 @@
 // except according to those terms.
 
 const FOO: &'static[u32] = &[1, 2, 3];
-const BAR: u32 = FOO[5]; //~ ERROR array index out of bounds
+const BAR: u32 = FOO[5];
+//~^ ERROR index out of bounds: the len is 3 but the index is 5
 
 fn main() {
     let _ = BAR;

--- a/src/test/run-fail/divide-by-zero.rs
+++ b/src/test/run-fail/divide-by-zero.rs
@@ -12,8 +12,6 @@
 
 // error-pattern:attempted to divide by zero
 
-#![feature(rustc_attrs)]
-#[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
 fn main() {
     let y = 0;
     let _z = 1 / y;

--- a/src/test/run-fail/mod-zero.rs
+++ b/src/test/run-fail/mod-zero.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:attempted remainder with a divisor of zero
+// error-pattern:attempted to calculate the remainder with a divisor of zero
 
 fn main() {
     let y = 0;

--- a/src/test/run-fail/mod-zero.rs
+++ b/src/test/run-fail/mod-zero.rs
@@ -12,8 +12,6 @@
 
 // error-pattern:attempted remainder with a divisor of zero
 
-#![feature(rustc_attrs)]
-#[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
 fn main() {
     let y = 0;
     let _z = 1 % y;

--- a/src/test/run-fail/overflowing-add.rs
+++ b/src/test/run-fail/overflowing-add.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread 'main' panicked at 'arithmetic operation overflowed'
+// error-pattern:thread 'main' panicked at 'attempted to add with overflow'
 // compile-flags: -C debug-assertions
 
 

--- a/src/test/run-fail/overflowing-add.rs
+++ b/src/test/run-fail/overflowing-add.rs
@@ -14,8 +14,6 @@
 // compile-flags: -C debug-assertions
 
 
-#![feature(rustc_attrs)]
-#[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
 fn main() {
     let _x = 200u8 + 200u8 + 200u8;
 }

--- a/src/test/run-fail/overflowing-lsh-1.rs
+++ b/src/test/run-fail/overflowing-lsh-1.rs
@@ -15,8 +15,6 @@
 
 #![warn(exceeding_bitshifts)]
 
-#![feature(rustc_attrs)]
-#[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
 fn main() {
     let _x = 1_i32 << 32;
 }

--- a/src/test/run-fail/overflowing-lsh-1.rs
+++ b/src/test/run-fail/overflowing-lsh-1.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread 'main' panicked at 'shift operation overflowed'
+// error-pattern:thread 'main' panicked at 'attempted to shift left with overflow'
 // compile-flags: -C debug-assertions
 
 #![warn(exceeding_bitshifts)]

--- a/src/test/run-fail/overflowing-lsh-2.rs
+++ b/src/test/run-fail/overflowing-lsh-2.rs
@@ -15,8 +15,6 @@
 
 #![warn(exceeding_bitshifts)]
 
-#![feature(rustc_attrs)]
-#[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
 fn main() {
     let _x = 1 << -1;
 }

--- a/src/test/run-fail/overflowing-lsh-2.rs
+++ b/src/test/run-fail/overflowing-lsh-2.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread 'main' panicked at 'shift operation overflowed'
+// error-pattern:thread 'main' panicked at 'attempted to shift left with overflow'
 // compile-flags: -C debug-assertions
 
 #![warn(exceeding_bitshifts)]

--- a/src/test/run-fail/overflowing-lsh-3.rs
+++ b/src/test/run-fail/overflowing-lsh-3.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread 'main' panicked at 'shift operation overflowed'
+// error-pattern:thread 'main' panicked at 'attempted to shift left with overflow'
 // compile-flags: -C debug-assertions
 
 #![warn(exceeding_bitshifts)]

--- a/src/test/run-fail/overflowing-lsh-3.rs
+++ b/src/test/run-fail/overflowing-lsh-3.rs
@@ -15,8 +15,6 @@
 
 #![warn(exceeding_bitshifts)]
 
-#![feature(rustc_attrs)]
-#[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
 fn main() {
     let _x = 1_u64 << 64;
 }

--- a/src/test/run-fail/overflowing-lsh-4.rs
+++ b/src/test/run-fail/overflowing-lsh-4.rs
@@ -18,8 +18,6 @@
 
 #![warn(exceeding_bitshifts)]
 
-#![feature(rustc_attrs)]
-#[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
 fn main() {
     // this signals overflow when checking is on
     let x = 1_i8 << 17;

--- a/src/test/run-fail/overflowing-lsh-4.rs
+++ b/src/test/run-fail/overflowing-lsh-4.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread 'main' panicked at 'shift operation overflowed'
+// error-pattern:thread 'main' panicked at 'attempted to shift left with overflow'
 // compile-flags: -C debug-assertions
 
 // This function is checking that our automatic truncation does not

--- a/src/test/run-fail/overflowing-mul.rs
+++ b/src/test/run-fail/overflowing-mul.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread 'main' panicked at 'arithmetic operation overflowed'
+// error-pattern:thread 'main' panicked at 'attempted to multiply with overflow'
 // compile-flags: -C debug-assertions
 
 fn main() {

--- a/src/test/run-fail/overflowing-mul.rs
+++ b/src/test/run-fail/overflowing-mul.rs
@@ -13,8 +13,6 @@
 // error-pattern:thread 'main' panicked at 'arithmetic operation overflowed'
 // compile-flags: -C debug-assertions
 
-#![feature(rustc_attrs)]
-#[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
 fn main() {
     let x = 200u8 * 4;
 }

--- a/src/test/run-fail/overflowing-neg.rs
+++ b/src/test/run-fail/overflowing-neg.rs
@@ -13,8 +13,6 @@
 // error-pattern:thread 'main' panicked at 'attempted to negate with overflow'
 // compile-flags: -C debug-assertions
 
-#![feature(rustc_attrs)]
-#[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
 fn main() {
     let _x = -std::i8::MIN;
 }

--- a/src/test/run-fail/overflowing-pow.rs
+++ b/src/test/run-fail/overflowing-pow.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:thread 'main' panicked at 'arithmetic operation overflowed'
+// error-pattern:thread 'main' panicked at 'attempted to multiply with overflow'
 // compile-flags: -C debug-assertions
 
 fn main() {

--- a/src/test/run-fail/overflowing-rsh-1.rs
+++ b/src/test/run-fail/overflowing-rsh-1.rs
@@ -15,8 +15,6 @@
 
 #![warn(exceeding_bitshifts)]
 
-#![feature(rustc_attrs)]
-#[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
 fn main() {
     let _x = -1_i32 >> 32;
 }

--- a/src/test/run-fail/overflowing-rsh-1.rs
+++ b/src/test/run-fail/overflowing-rsh-1.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread 'main' panicked at 'shift operation overflowed'
+// error-pattern:thread 'main' panicked at 'attempted to shift right with overflow'
 // compile-flags: -C debug-assertions
 
 #![warn(exceeding_bitshifts)]

--- a/src/test/run-fail/overflowing-rsh-2.rs
+++ b/src/test/run-fail/overflowing-rsh-2.rs
@@ -15,8 +15,6 @@
 
 #![warn(exceeding_bitshifts)]
 
-#![feature(rustc_attrs)]
-#[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
 fn main() {
     let _x = -1_i32 >> -1;
 }

--- a/src/test/run-fail/overflowing-rsh-2.rs
+++ b/src/test/run-fail/overflowing-rsh-2.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread 'main' panicked at 'shift operation overflowed'
+// error-pattern:thread 'main' panicked at 'attempted to shift right with overflow'
 // compile-flags: -C debug-assertions
 
 #![warn(exceeding_bitshifts)]

--- a/src/test/run-fail/overflowing-rsh-3.rs
+++ b/src/test/run-fail/overflowing-rsh-3.rs
@@ -15,8 +15,6 @@
 
 #![warn(exceeding_bitshifts)]
 
-#![feature(rustc_attrs)]
-#[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
 fn main() {
     let _x = -1_i64 >> 64;
 }

--- a/src/test/run-fail/overflowing-rsh-3.rs
+++ b/src/test/run-fail/overflowing-rsh-3.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread 'main' panicked at 'shift operation overflowed'
+// error-pattern:thread 'main' panicked at 'attempted to shift right with overflow'
 // compile-flags: -C debug-assertions
 
 #![warn(exceeding_bitshifts)]

--- a/src/test/run-fail/overflowing-rsh-4.rs
+++ b/src/test/run-fail/overflowing-rsh-4.rs
@@ -18,8 +18,6 @@
 
 #![warn(exceeding_bitshifts)]
 
-#![feature(rustc_attrs)]
-#[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
 fn main() {
     // this signals overflow when checking is on
     let x = 2_i8 >> 17;

--- a/src/test/run-fail/overflowing-rsh-4.rs
+++ b/src/test/run-fail/overflowing-rsh-4.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread 'main' panicked at 'shift operation overflowed'
+// error-pattern:thread 'main' panicked at 'attempted to shift right with overflow'
 // compile-flags: -C debug-assertions
 
 // This function is checking that our (type-based) automatic

--- a/src/test/run-fail/overflowing-rsh-5.rs
+++ b/src/test/run-fail/overflowing-rsh-5.rs
@@ -15,8 +15,6 @@
 
 #![warn(exceeding_bitshifts)]
 
-#![feature(rustc_attrs)]
-#[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
 fn main() {
     let _n = 1i64 >> [64][0];
 }

--- a/src/test/run-fail/overflowing-rsh-5.rs
+++ b/src/test/run-fail/overflowing-rsh-5.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread 'main' panicked at 'shift operation overflowed'
+// error-pattern:thread 'main' panicked at 'attempted to shift right with overflow'
 // compile-flags: -C debug-assertions
 
 #![warn(exceeding_bitshifts)]

--- a/src/test/run-fail/overflowing-rsh-6.rs
+++ b/src/test/run-fail/overflowing-rsh-6.rs
@@ -16,8 +16,6 @@
 #![warn(exceeding_bitshifts)]
 #![feature(const_indexing)]
 
-#![feature(rustc_attrs)]
-#[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
 fn main() {
     let _n = 1i64 >> [64][0];
 }

--- a/src/test/run-fail/overflowing-rsh-6.rs
+++ b/src/test/run-fail/overflowing-rsh-6.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread 'main' panicked at 'shift operation overflowed'
+// error-pattern:thread 'main' panicked at 'attempted to shift right with overflow'
 // compile-flags: -C debug-assertions
 
 #![warn(exceeding_bitshifts)]

--- a/src/test/run-fail/overflowing-sub.rs
+++ b/src/test/run-fail/overflowing-sub.rs
@@ -13,8 +13,6 @@
 // error-pattern:thread 'main' panicked at 'arithmetic operation overflowed'
 // compile-flags: -C debug-assertions
 
-#![feature(rustc_attrs)]
-#[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
 fn main() {
     let _x = 42u8 - (42u8 + 1);
 }

--- a/src/test/run-fail/overflowing-sub.rs
+++ b/src/test/run-fail/overflowing-sub.rs
@@ -10,7 +10,7 @@
 
 // ignore-pretty : (#23623) problems when  ending with // comments
 
-// error-pattern:thread 'main' panicked at 'arithmetic operation overflowed'
+// error-pattern:thread 'main' panicked at 'attempted to subtract with overflow'
 // compile-flags: -C debug-assertions
 
 fn main() {

--- a/src/test/run-make/debug-assertions/debug.rs
+++ b/src/test/run-make/debug-assertions/debug.rs
@@ -37,7 +37,6 @@ fn debug_assert() {
 }
 
 fn overflow() {
-    #[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
     fn add(a: u8, b: u8) -> u8 { a + b }
 
     add(200u8, 200u8);

--- a/src/test/run-pass/issue-8460.rs
+++ b/src/test/run-pass/issue-8460.rs
@@ -19,13 +19,11 @@ use std::thread;
 macro_rules! check {
     ($($e:expr),*) => {
         $(assert!(thread::spawn({
-            #[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
             move|| { $e; }
         }).join().is_err());)*
     }
 }
 
-#[rustc_no_mir] // FIXME #29769 MIR overflow checking is TBD.
 fn main() {
     check![
         isize::min_value() / -1,

--- a/src/test/run-pass/mir_cast_fn_ret.rs
+++ b/src/test/run-pass/mir_cast_fn_ret.rs
@@ -10,15 +10,25 @@
 
 #![feature(rustc_attrs)]
 
-pub extern "C" fn foo() -> (u8, u8, u8) {
+pub extern "C" fn tuple2() -> (u16, u8) {
+    (1, 2)
+}
+
+pub extern "C" fn tuple3() -> (u8, u8, u8) {
     (1, 2, 3)
 }
 
 #[rustc_mir]
-pub fn bar() -> u8 {
-    foo().2
+pub fn test2() -> u8 {
+    tuple2().1
+}
+
+#[rustc_mir]
+pub fn test3() -> u8 {
+    tuple3().2
 }
 
 fn main() {
-    assert_eq!(bar(), 3);
+    assert_eq!(test2(), 2);
+    assert_eq!(test3(), 3);
 }

--- a/src/test/run-pass/mir_cast_fn_ret.rs
+++ b/src/test/run-pass/mir_cast_fn_ret.rs
@@ -1,0 +1,24 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_attrs)]
+
+pub extern "C" fn foo() -> (u8, u8, u8) {
+    (1, 2, 3)
+}
+
+#[rustc_mir]
+pub fn bar() -> u8 {
+    foo().2
+}
+
+fn main() {
+    assert_eq!(bar(), 3);
+}


### PR DESCRIPTION
The initial set of changes is from @Aatch's #33255 PR, rebased on master, plus:

Added an `Assert` terminator to MIR, to simplify working with overflow and bounds checks.
With this terminator, error cases can be accounted for directly, instead of looking for lang item calls.
It also keeps the MIR slimmer, with no extra explicit blocks for the actual panic calls.

Warnings can be produced when the `Assert` is known to always panic at runtime, e.g.:

``` rust
warning: index out of bounds: the len is 1 but the index is 3
 --> <anon>:1:14
1 |> fn main() { &[std::io::stdout()][3]; }
  |>              ^^^^^^^^^^^^^^^^^^^^^^
```

Generalized the `OperandValue::FatPtr` optimization to any aggregate pair of immediates.
This allows us to generate the same IR for overflow checks as old trans, not something worse.
For example, addition on `i16` calls `llvm.sadd.with.overflow.i16`, which returns `{i16, i1}`.
However, the Rust type `(i16, bool)`, has to be `{i16, i8}`, only an immediate `bool` is `i1`.
But if we split the pair into an `i16` and an `i1`, we can pass them around as such for free.

The latest addition is a rebase of #34054, updated to work for pairs too. Closes #34054, fixes #33873.

Last but not least, the `#[rustc_inherit_overflow_checks]` attribute was introduced to control the
overflow checking behavior of generic or `#[inline]` functions, when translated in another crate.

It is **not** intended to be used by crates other than `libcore`, which is in the unusual position of
being distributed as only an optimized build with no checks, even when used from debug mode.
Before MIR-based translation, this worked out fine, as the decision for overflow was made at
translation time, in the crate being compiled, but MIR stored in `rlib` has to contain the checks.

To avoid always generating the checks and slowing everything down, a decision was made to
use an attribute in the few spots of `libcore` that need it (see #33255 for previous discussion):
- `core::ops::{Add, Sub, Mul, Neg, Shl, Shr}` implementations for integers, which have `#[inline]` methods and can be used in generic abstractions from other crates
- `core::ops::{Add, Sub, Mul, Neg, Shl, Shr}Assign` same as above, for augmented assignment
- `pow` and `abs` methods on integers, which intentionally piggy-back on built-in multiplication and negation, respectively, to get overflow checks
- `core::iter::{Iterator, Chain, Peek}::count` and `core::iter::Enumerate::{next, nth}`, also documented as panicking on overflow, from addition, counting elements of an iterator in an `usize`
