### PR TITLE
Emit "no-frame-pointer-elim" attribute for closures, shims, and glue.

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -15,7 +15,7 @@ use lint;
 use middle::cstore::CrateStore;
 use middle::dependency_format;
 use session::search_paths::PathKind;
-use session::config::PanicStrategy;
+use session::config::{DebugInfoLevel, PanicStrategy};
 use ty::tls;
 use util::nodemap::{NodeMap, FnvHashMap};
 use mir::transform as mir_pass;
@@ -313,6 +313,11 @@ impl Session {
     }
     pub fn nonzeroing_move_hints(&self) -> bool {
         self.opts.debugging_opts.enable_nonzeroing_move_hints
+    }
+
+    pub fn must_not_eliminate_frame_pointers(&self) -> bool {
+        self.opts.debuginfo != DebugInfoLevel::NoDebugInfo ||
+        !self.target.target.options.eliminate_frame_pointer
     }
 
     /// Returns the symbol name for the registrar function,

--- a/src/librustc_trans/callee.rs
+++ b/src/librustc_trans/callee.rs
@@ -381,7 +381,7 @@ pub fn trans_fn_pointer_shim<'a, 'tcx>(
                                                          bare_fn_ty,
                                                          "fn_pointer_shim");
     let llfn = declare::define_internal_fn(ccx, &function_name, tuple_fn_ty);
-
+    attributes::set_frame_pointer_elimination(ccx, llfn);
     //
     let (block_arena, fcx): (TypedArena<_>, FunctionContext);
     block_arena = TypedArena::new();

--- a/src/librustc_trans/closure.rs
+++ b/src/librustc_trans/closure.rs
@@ -171,6 +171,7 @@ fn get_or_create_closure_declaration<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
 
     // set an inline hint for all closures
     attributes::inline(llfn, attributes::InlineAttr::Hint);
+    attributes::set_frame_pointer_elimination(ccx, llfn);
 
     debug!("get_or_create_declaration_if_closure(): inserting new \
             closure {:?}: {:?}",
@@ -377,6 +378,7 @@ fn trans_fn_once_adapter_shim<'a, 'tcx>(
     let function_name =
         symbol_names::internal_name_from_type_and_suffix(ccx, llonce_fn_ty, "once_shim");
     let lloncefn = declare::define_internal_fn(ccx, &function_name, llonce_fn_ty);
+    attributes::set_frame_pointer_elimination(ccx, lloncefn);
 
     let (block_arena, fcx): (TypedArena<_>, FunctionContext);
     block_arena = TypedArena::new();

--- a/src/librustc_trans/glue.rs
+++ b/src/librustc_trans/glue.rs
@@ -14,6 +14,7 @@
 
 use std;
 
+use attributes;
 use back::symbol_names;
 use llvm;
 use llvm::{ValueRef, get_param};
@@ -272,6 +273,7 @@ fn get_drop_glue_core<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     let fn_nm = symbol_names::internal_name_from_type_and_suffix(ccx, t, suffix);
     assert!(declare::get_defined_value(ccx, &fn_nm).is_none());
     let llfn = declare::declare_cfn(ccx, &fn_nm, llfnty);
+    attributes::set_frame_pointer_elimination(ccx, llfn);
     ccx.available_drop_glues().borrow_mut().insert(g, fn_nm);
     ccx.drop_glues().borrow_mut().insert(g, llfn);
 

--- a/src/librustc_trans/meth.rs
+++ b/src/librustc_trans/meth.rs
@@ -10,6 +10,7 @@
 
 use std::rc::Rc;
 
+use attributes;
 use arena::TypedArena;
 use back::symbol_names;
 use llvm::{ValueRef, get_params};
@@ -91,6 +92,7 @@ pub fn trans_object_shim<'a, 'tcx>(ccx: &'a CrateContext<'a, 'tcx>,
     let function_name =
         symbol_names::internal_name_from_type_and_suffix(ccx, method_ty, "object_shim");
     let llfn = declare::define_internal_fn(ccx, &function_name, method_ty);
+    attributes::set_frame_pointer_elimination(ccx, llfn);
 
     let (block_arena, fcx): (TypedArena<_>, FunctionContext);
     block_arena = TypedArena::new();

--- a/src/librustc_trans/monomorphize.rs
+++ b/src/librustc_trans/monomorphize.rs
@@ -151,6 +151,7 @@ pub fn monomorphic_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
                 _ => bug!()
             };
             attributes::inline(lldecl, attributes::InlineAttr::Hint);
+            attributes::set_frame_pointer_elimination(ccx, lldecl);
             base::trans_ctor_shim(ccx, fn_node_id, disr, psubsts, lldecl);
         }
 


### PR DESCRIPTION
This will hopefully let `perf` give better backtraces.
r? @nikomatsakis 
