### PR TITLE
Specific error message for missplaced doc comments

### DIFF
--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -564,6 +564,15 @@ impl Handler {
         self.bump_err_count();
         self.panic_if_treat_err_as_bug();
     }
+    pub fn mut_span_err<'a, S: Into<MultiSpan>>(&'a self,
+                                                sp: S,
+                                                msg: &str)
+                                                -> DiagnosticBuilder<'a> {
+        let mut result = DiagnosticBuilder::new(self, Level::Error, msg);
+        result.set_span(sp);
+        self.bump_err_count();
+        result
+    }
     pub fn span_err_with_code<S: Into<MultiSpan>>(&self, sp: S, msg: &str, code: &str) {
         self.emit_with_code(&sp.into(), msg, code, Error);
         self.bump_err_count();

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -202,7 +202,7 @@ impl Token {
     pub fn is_lit(&self) -> bool {
         match *self {
             Literal(_, _) => true,
-            _          => false,
+            _             => false,
         }
     }
 
@@ -211,6 +211,14 @@ impl Token {
         match *self {
             Ident(..)   => true,
             _           => false,
+        }
+    }
+
+    /// Returns `true` if the token is a documentation comment.
+    pub fn is_doc_comment(&self) -> bool {
+        match *self {
+            DocComment(..)   => true,
+            _                => false,
         }
     }
 

--- a/src/test/parse-fail/doc-after-struct-field.rs
+++ b/src/test/parse-fail/doc-after-struct-field.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,10 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only
-
-fn main() {
-    println!("Hi"); /// hi
+// compile-flags: -Z continue-parse-after-error
+struct X {
+    a: u8 /** document a */,
     //~^ ERROR found a documentation comment that doesn't document anything
     //~| HELP maybe a comment was intended
+}
+
+fn main() {
+    let y = X {a = 1};
 }

--- a/src/test/parse-fail/doc-before-extern-rbrace.rs
+++ b/src/test/parse-fail/doc-before-extern-rbrace.rs
@@ -12,5 +12,5 @@
 
 extern {
     /// hi
+    //~^ ERROR expected item after doc comment
 }
-//~^^ ERROR expected item after doc comment

--- a/src/test/parse-fail/doc-before-fn-rbrace.rs
+++ b/src/test/parse-fail/doc-before-fn-rbrace.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,10 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only
-
+// compile-flags: -Z continue-parse-after-error
 fn main() {
-    println!("Hi"); /// hi
+    /// document
     //~^ ERROR found a documentation comment that doesn't document anything
     //~| HELP maybe a comment was intended
 }

--- a/src/test/parse-fail/doc-before-identifier.rs
+++ b/src/test/parse-fail/doc-before-identifier.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,10 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only
+// compile-flags: -Z continue-parse-after-error
+fn /// document
+foo() {}
+//~^^ ERROR expected identifier, found `/// document`
 
 fn main() {
-    println!("Hi"); /// hi
-    //~^ ERROR found a documentation comment that doesn't document anything
-    //~| HELP maybe a comment was intended
+    foo();
 }

--- a/src/test/parse-fail/doc-before-mod-rbrace.rs
+++ b/src/test/parse-fail/doc-before-mod-rbrace.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,10 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only
-
-fn main() {
-    println!("Hi"); /// hi
-    //~^ ERROR found a documentation comment that doesn't document anything
-    //~| HELP maybe a comment was intended
+// compile-flags: -Z continue-parse-after-error
+mod Foo {
+    /// document
+    //~^ ERROR expected item after doc comment
 }

--- a/src/test/parse-fail/doc-before-semi.rs
+++ b/src/test/parse-fail/doc-before-semi.rs
@@ -12,6 +12,7 @@
 
 fn main() {
     /// hi
+    //~^ ERROR found a documentation comment that doesn't document anything
+    //~| HELP maybe a comment was intended
     ;
-    //~^ ERROR expected statement
 }

--- a/src/test/parse-fail/doc-before-struct-rbrace-1.rs
+++ b/src/test/parse-fail/doc-before-struct-rbrace-1.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,10 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only
-
-fn main() {
-    println!("Hi"); /// hi
+// compile-flags: -Z continue-parse-after-error
+struct X {
+    a: u8,
+    /// document
     //~^ ERROR found a documentation comment that doesn't document anything
     //~| HELP maybe a comment was intended
+}
+
+fn main() {
+    let y = X {a = 1};
 }

--- a/src/test/parse-fail/doc-before-struct-rbrace-2.rs
+++ b/src/test/parse-fail/doc-before-struct-rbrace-2.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,10 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only
-
-fn main() {
-    println!("Hi"); /// hi
+// compile-flags: -Z continue-parse-after-error
+struct X {
+    a: u8 /// document
     //~^ ERROR found a documentation comment that doesn't document anything
     //~| HELP maybe a comment was intended
+}
+
+fn main() {
+    let y = X {a = 1};
 }


### PR DESCRIPTION
Identify when documetation comments have been missplaced in the following places:
- After a struct element:
  
  ``` rust
  // file.rs:
  struct X {
      a: u8 /** document a */,
  }
  ```
  
  ``` bash
  $ rustc file.rs
  file.rs:2:11: 2:28 error: found documentation comment that doesn't
  document anything
  file.rs:2     a: u8 /** document a */,
                      ^~~~~~~~~~~~~~~~~
  file.rs:2:11: 2:28 help: doc comments must come before what they document,
  maybe a comment was intended with `//`?
  ```
- As the last line of a struct:
  
  ``` rust
  // file.rs:
  struct X {
      a: u8,
      /// incorrect documentation
  }
  ```
  
  ``` bash
  $ rustc file.rs
  file.rs:3:5: 3:27 error: found a documentation comment that doesn't
  document anything
  file.rs:3     /// incorrect documentation
                ^~~~~~~~~~~~~~~~~~~~~~
  file.rs:3:5: 3:27 help: doc comments must come before what they document,
  maybe a comment was intended with `//`?
  ```
- As the last line of a `fn`:
  
  ``` rust
  // file.rs:
  fn main() {
      let x = 1;
      /// incorrect documentation
  }
  ```
  
  ``` bash
  $ rustc file.rs
  file.rs:3:5: 3:27 error: found a documentation comment that doesn't
  document anything
  file.rs:3     /// incorrect documentation
                ^~~~~~~~~~~~~~~~~~~~~~
  file.rs:3:5: 3:27 help: doc comments must come before what they document,
  maybe a comment was intended with `//`?
  ```

Fix #27429, #30322
