### PR TITLE
Implement `nth` for `EscapeUnicode`

### DIFF
--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -446,6 +446,23 @@ impl Iterator for EscapeUnicode {
         self.len()
     }
 
+    fn nth(&mut self, n: usize) -> Option<char> {
+        let remaining = self.len().saturating_sub(n);
+
+        // hex_digit_idx = (number of hex digits still to be emitted) - 1
+        // It can be computed from the remaining number of items by keeping
+        // into account that:
+        // - hex_digit_idx can never increase
+        // - the last 2 items (last hex digit, '}') are not counted in hex_digit_idx
+        let hex_digit_idx = ::cmp::min(self.hex_digit_idx, remaining.saturating_sub(2));
+
+        // state = number of items to be emitted for the state (as per state_len())
+        // It can be computed because (remaining number of items) = state + hex_digit_idx
+        let state = remaining - hex_digit_idx;
+
+        self.step(state, hex_digit_idx)
+    }
+
     fn last(self) -> Option<char> {
         match self.state {
             EscapeUnicodeState::Done => None,

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -551,7 +551,7 @@ pub struct EscapeDefault {
 
 #[derive(Clone, Debug)]
 enum EscapeDefaultState {
-    Done,
+    Done(char),
     Char(char),
     Backslash(char),
     Unicode(EscapeUnicode),
@@ -568,10 +568,10 @@ impl Iterator for EscapeDefault {
                 Some('\\')
             }
             EscapeDefaultState::Char(c) => {
-                self.state = EscapeDefaultState::Done;
+                self.state = EscapeDefaultState::Done(c);
                 Some(c)
             }
-            EscapeDefaultState::Done => None,
+            EscapeDefaultState::Done(_) => None,
             EscapeDefaultState::Unicode(ref mut iter) => iter.next(),
         }
     }
@@ -594,15 +594,15 @@ impl Iterator for EscapeDefault {
                 Some('\\')
             },
             EscapeDefaultState::Backslash(c) if n == 1 => {
-                self.state = EscapeDefaultState::Done;
+                self.state = EscapeDefaultState::Done(c);
                 Some(c)
             },
-            EscapeDefaultState::Backslash(_) => {
-                self.state = EscapeDefaultState::Done;
+            EscapeDefaultState::Backslash(c) => {
+                self.state = EscapeDefaultState::Done(c);
                 None
             },
             EscapeDefaultState::Char(c) => {
-                self.state = EscapeDefaultState::Done;
+                self.state = EscapeDefaultState::Done(c);
 
                 if n == 0 {
                     Some(c)
@@ -610,7 +610,7 @@ impl Iterator for EscapeDefault {
                     None
                 }
             },
-            EscapeDefaultState::Done => return None,
+            EscapeDefaultState::Done(_) => return None,
             EscapeDefaultState::Unicode(ref mut i) => return i.nth(n),
         }
     }
@@ -618,7 +618,7 @@ impl Iterator for EscapeDefault {
     fn last(self) -> Option<char> {
         match self.state {
             EscapeDefaultState::Unicode(iter) => iter.last(),
-            EscapeDefaultState::Done => None,
+            EscapeDefaultState::Done(_) => None,
             EscapeDefaultState::Backslash(c) | EscapeDefaultState::Char(c) => Some(c),
         }
     }
@@ -628,7 +628,7 @@ impl Iterator for EscapeDefault {
 impl ExactSizeIterator for EscapeDefault {
     fn len(&self) -> usize {
         match self.state {
-            EscapeDefaultState::Done => 0,
+            EscapeDefaultState::Done(_) => 0,
             EscapeDefaultState::Char(_) => 1,
             EscapeDefaultState::Backslash(_) => 2,
             EscapeDefaultState::Unicode(ref iter) => iter.len(),

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -562,17 +562,10 @@ impl Iterator for EscapeDefault {
     type Item = char;
 
     fn next(&mut self) -> Option<char> {
-        match self.state {
-            EscapeDefaultState::Backslash(c) => {
-                self.state = EscapeDefaultState::Char(c);
-                Some('\\')
-            }
-            EscapeDefaultState::Char(c) => {
-                self.state = EscapeDefaultState::Done(c);
-                Some(c)
-            }
-            EscapeDefaultState::Done(_) => None,
-            EscapeDefaultState::Unicode(ref mut iter) => iter.next(),
+        if let EscapeDefaultState::Unicode(ref mut iter) = self.state {
+            iter.next()
+        } else {
+            self.step(0)
         }
     }
 
@@ -588,31 +581,7 @@ impl Iterator for EscapeDefault {
     }
 
     fn nth(&mut self, n: usize) -> Option<char> {
-        match self.state {
-            EscapeDefaultState::Backslash(c) if n == 0 => {
-                self.state = EscapeDefaultState::Char(c);
-                Some('\\')
-            },
-            EscapeDefaultState::Backslash(c) if n == 1 => {
-                self.state = EscapeDefaultState::Done(c);
-                Some(c)
-            },
-            EscapeDefaultState::Backslash(c) => {
-                self.state = EscapeDefaultState::Done(c);
-                None
-            },
-            EscapeDefaultState::Char(c) => {
-                self.state = EscapeDefaultState::Done(c);
-
-                if n == 0 {
-                    Some(c)
-                } else {
-                    None
-                }
-            },
-            EscapeDefaultState::Done(_) => return None,
-            EscapeDefaultState::Unicode(ref mut i) => return i.nth(n),
-        }
+        self.step(n)
     }
 
     fn last(self) -> Option<char> {
@@ -632,6 +601,33 @@ impl ExactSizeIterator for EscapeDefault {
             EscapeDefaultState::Char(_) => 1,
             EscapeDefaultState::Backslash(_) => 2,
             EscapeDefaultState::Unicode(ref iter) => iter.len(),
+        }
+    }
+}
+
+impl EscapeDefault {
+    #[inline]
+    fn step(&mut self, n: usize) -> Option<char> {
+        let (remaining, c) = match self.state {
+            EscapeDefaultState::Done(c) => (0usize, c),
+            EscapeDefaultState::Char(c) => (1, c),
+            EscapeDefaultState::Backslash(c) => (2, c),
+            EscapeDefaultState::Unicode(ref mut iter) => return iter.nth(n),
+        };
+
+        match remaining.saturating_sub(n) {
+            2 => {
+                self.state = EscapeDefaultState::Char(c);
+                Some('\\')
+            }
+            1 => {
+                self.state = EscapeDefaultState::Done(c);
+                Some(c)
+            }
+            _ => {
+                self.state = EscapeDefaultState::Done(c);
+                None
+            }
         }
     }
 }


### PR DESCRIPTION
and cleanup the code for `nth` for `EscapeDefault` by sharing the stepping logic between `nth` and `next`.

Part of #24214, split from #31049 (last part! :) ).

The test for `nth` was added in #33103.
