### PR TITLE
Prevent overflows by increasing ring buffer size

### DIFF
--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -159,9 +159,9 @@ pub struct PrintStackElem {
 const SIZE_INFINITY: isize = 0xffff;
 
 pub fn mk_printer<'a>(out: Box<io::Write+'a>, linewidth: usize) -> Printer<'a> {
-    // Yes 3, it makes the ring buffers big enough to never
+    // Yes 55, it makes the ring buffers big enough to never
     // fall behind.
-    let n: usize = 3 * linewidth;
+    let n: usize = 55 * linewidth;
     debug!("mk_printer {}", linewidth);
     let token = vec![Token::Eof; n];
     let size = vec![0; n];


### PR DESCRIPTION
Please note that this change is just done to prevent
issues as currently seen by syntex_syntax in future.
See https://github.com/serde-rs/syntex/pull/47 for details.

As shown in https://github.com/serde-rs/syntex/issues/33,
complex code can easily overflow the ring-buffer and
cause an assertion error.
