### PR TITLE
resolve: record pattern def when `resolve_pattern` returns `Err(true)`

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2422,13 +2422,16 @@ impl<'a> Resolver<'a> {
                                 }
                             }
                         }
-                    } else if let Err(false) = self.resolve_path(pat_id, &path, 0, ValueNS) {
-                        resolve_error(
-                            self,
-                            path.span,
-                            ResolutionError::UnresolvedEnumVariantStructOrConst(
-                                &path.segments.last().unwrap().identifier.name.as_str())
-                        );
+                    } else {
+                        if let Err(false) = self.resolve_path(pat_id, &path, 0, ValueNS) {
+                            // No error has been reported, so we need to do this ourselves.
+                            resolve_error(
+                                self,
+                                path.span,
+                                ResolutionError::UnresolvedEnumVariantStructOrConst(
+                                    &path.segments.last().unwrap().identifier.name.as_str())
+                            );
+                        }
                         self.record_def(pattern.id, err_path_resolution());
                     }
                     visit::walk_path(self, path);


### PR DESCRIPTION
I propose a fix for issue #33293.

In 1a374b8, (pr #33046) fixed the error reporting of a specific case, but the change that was introduced did not make sure that `record_def` was called in all cases, which lead to an ICE in [1].
This change restores the original `else` case, but keeps the changes that were committed in 1a374b8.

[1] `rustc::middle::mem_categorization::MemCategorizationContext::cat_pattern_`
