### PR TITLE
Use --release-channel=stable by default on releases

### DIFF
--- a/configure
+++ b/configure
@@ -637,9 +637,19 @@ valopt arm-linux-androideabi-ndk "" "arm-linux-androideabi NDK standalone path"
 valopt armv7-linux-androideabi-ndk "" "armv7-linux-androideabi NDK standalone path"
 valopt aarch64-linux-android-ndk "" "aarch64-linux-android NDK standalone path"
 valopt nacl-cross-path  "" "NaCl SDK path (Pepper Canary is recommended). Must be absolute!"
-valopt release-channel "dev" "the name of the release channel to build"
 valopt musl-root "/usr/local" "MUSL root installation directory"
 valopt extra-filename "" "Additional data that is hashed and passed to the -C extra-filename flag"
+
+if [ -e ${CFG_SRC_DIR}.git ]
+then
+    valopt release-channel "dev" "the name of the release channel to build"
+else
+    # If we have no git directory then we are probably a tarball distribution
+    # and should default to stable channel - Issue 28322
+    probe CFG_GIT          git
+    msg "git: no git directory. Changing default release channel to stable"
+    valopt release-channel "stable" "the name of the release channel to build"
+fi
 
 # Used on systems where "cc" and "ar" are unavailable
 valopt default-linker "cc" "the default linker"


### PR DESCRIPTION
> Release tarballs should be compilable with just basic ./configure ;
> make ; sudo make install without having to pass special flags to
> configure. This is the case of the --release-channel option, that must
> be changed in the releases.

This commit detects the presence of .git, as it happens on other parts
of `configure` to assume it is a tarball. Then it changes the default
value stored, before parsing the arguments, while still allowing it to
be overriden before any action verifying the flag is done.

Closes #28322
