### PR TITLE
stable features lint warning mentions version stabilized

### DIFF
--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -59,8 +59,8 @@ macro_rules! declare_features {
 
         /// A set of features to be used by later passes.
         pub struct Features {
-            /// spans of #![feature] attrs for stable language features. for error reporting
-            pub declared_stable_lang_features: Vec<Span>,
+            /// #![feature] attrs for stable language features, for error reporting
+            pub declared_stable_lang_features: Vec<(InternedString, Span)>,
             /// #![feature] attrs for non-language (library) features
             pub declared_lib_features: Vec<(InternedString, Span)>,
             $(pub $feature: bool),+
@@ -753,6 +753,10 @@ pub fn check_attribute(attr: &ast::Attribute, handler: &Handler,
     cx.check_attribute(attr, true);
 }
 
+pub fn find_lang_feature_accepted_version(feature: &str) -> Option<&'static str> {
+    ACCEPTED_FEATURES.iter().find(|t| t.0 == feature).map(|t| t.1)
+}
+
 fn find_lang_feature_issue(feature: &str) -> Option<u32> {
     if let Some(info) = ACTIVE_FEATURES.iter().find(|t| t.0 == feature) {
         let issue = info.2;
@@ -1191,7 +1195,7 @@ pub fn get_features(span_handler: &Handler, krate: &ast::Crate) -> Features {
                     }
                     else if let Some(&(_, _, _)) = ACCEPTED_FEATURES.iter()
                         .find(|& &(n, _, _)| name == n) {
-                        features.declared_stable_lang_features.push(mi.span);
+                        features.declared_stable_lang_features.push((name, mi.span));
                     } else {
                         features.declared_lib_features.push((name, mi.span));
                     }

--- a/src/test/compile-fail/stable-features.rs
+++ b/src/test/compile-fail/stable-features.rs
@@ -12,8 +12,8 @@
 // language and lib features.
 
 #![deny(stable_features)]
-#![feature(test_accepted_feature)] //~ ERROR this feature is stable
-#![feature(rust1)] //~ ERROR this feature is stable
+#![feature(test_accepted_feature)] //~ ERROR this feature has been stable since 1.0.0
+#![feature(rust1)] //~ ERROR this feature has been stable since 1.0.0
 
 fn main() {
     let _foo: Vec<()> = Vec::new();


### PR DESCRIPTION
To accomplish this, we alter the checks in `rustc::middle::stability` to
use the `StabilityLevel` defined in `syntax::attr` (which includes the
version in which the feature was stabilized) rather than the local
`StabilityLevel` in the same module, and make the
`declared_stable_lang_features` field of
`syntax::feature_gate::Features` hold a Vec of feature-name, span
tuples (in analogy to the `declared_lib_features` field) rather than
just spans.

Fixes #33394.

![stable_features_version_lint_before_and_after](https://cloud.githubusercontent.com/assets/1076988/15659237/5d952a3a-267c-11e6-9181-c9e612eefd7d.png)

r? @brson (tagging Brian because he [wrote](https://github.com/rust-lang/rust/pull/21958) the lint)
