### PR TITLE
Add custom message parameter to `assert_eq!`

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -94,7 +94,18 @@ macro_rules! assert_eq {
                 }
             }
         }
-    })
+    });
+    ($left:expr , $right:expr, $($arg:tt)*) => ({
+        match (&($left), &($right)) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    panic!("assertion failed: `(left == right)` \
+                           (left: `{:?}`, right: `{:?}`): {}", left_val, right_val,
+                           format_args!($($arg)*))
+                }
+            }
+        }
+    });
 }
 
 /// Ensure that a boolean expression is `true` at runtime.

--- a/src/test/run-pass/assert-eq-macro-success.rs
+++ b/src/test/run-pass/assert-eq-macro-success.rs
@@ -16,4 +16,7 @@ pub fn main() {
     assert_eq!("abc".to_string(),"abc".to_string());
     assert_eq!(Box::new(Point{x:34}),Box::new(Point{x:34}));
     assert_eq!(&Point{x:34},&Point{x:34});
+    assert_eq!(42, 42, "foo bar");
+    assert_eq!(42, 42, "a {} c", "b");
+    assert_eq!(42, 42, "{x}, {y}, {z}", x = 1, y = 2, z = 3);
 }


### PR DESCRIPTION
`assert!` macro accepts a custom message parameter and it's sometimes useful. But `assert_eq!` doesn't have it and users need to use `assert!` instead of `assert_eq!` when they want to output a custom message even if the assertion just compares two values. This pull request will resolve those cases.
