### PR TITLE
Attempt to diagnose #33844

### DIFF
--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -692,7 +692,11 @@ fn link_natively(sess: &Session,
             info!("linker stdout:\n{}", escape_string(&prog.stdout[..]));
         },
         Err(e) => {
-            sess.fatal(&format!("could not exec the linker `{}`: {}", pname, e));
+            // Trying to diagnose https://github.com/rust-lang/rust/issues/33844
+            sess.struct_err(&format!("could not exec the linker `{}`: {}", pname, e))
+                .note(&format!("{:?}", &cmd))
+                .emit();
+            sess.abort_if_errors();
         }
     }
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/33844 is a spurious failure that causes builds to fail due to the linker command sometimes failing with error 206, which means that the command is too long. This PR makes rustc print out the linker arguments in that case so the reason for it being so long can be diagnosed and hopefully fixed.

r? @alexcrichton 
