### PR TITLE
[WIP] Fix incorrect LLVM Linkage enum

### DIFF
--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -104,13 +104,13 @@ pub enum Linkage {
     AvailableExternallyLinkage = 1,
     LinkOnceAnyLinkage = 2,
     LinkOnceODRLinkage = 3,
-    WeakAnyLinkage = 5,
-    WeakODRLinkage = 6,
-    AppendingLinkage = 7,
-    InternalLinkage = 8,
-    PrivateLinkage = 9,
-    ExternalWeakLinkage = 12,
-    CommonLinkage = 14,
+    WeakAnyLinkage = 4,
+    WeakODRLinkage = 5,
+    AppendingLinkage = 6,
+    InternalLinkage = 7,
+    PrivateLinkage = 8,
+    ExternalWeakLinkage = 9,
+    CommonLinkage = 10,
 }
 
 #[repr(C)]

--- a/src/test/run-pass/issue-33992.rs
+++ b/src/test/run-pass/issue-33992.rs
@@ -1,0 +1,49 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-windows
+// ignore-macos
+
+#![feature(linkage)]
+
+#[linkage = "appending"]
+pub static TEST1: bool = true;
+
+#[linkage = "available_externally"]
+pub static TEST2: bool = true;
+
+#[linkage = "common"]
+pub static TEST3: bool = true;
+
+#[linkage = "extern_weak"]
+pub static TEST4: bool = true;
+
+#[linkage = "external"]
+pub static TEST5: bool = true;
+
+#[linkage = "internal"]
+pub static TEST6: bool = true;
+
+#[linkage = "linkonce"]
+pub static TEST7: bool = true;
+
+#[linkage = "linkonce_odr"]
+pub static TEST8: bool = true;
+
+#[linkage = "private"]
+pub static TEST9: bool = true;
+
+#[linkage = "weak"]
+pub static TEST10: bool = true;
+
+#[linkage = "weak_odr"]
+pub static TEST11: bool = true;
+
+fn main() {}


### PR DESCRIPTION
The `Linkage` enum in librustc_llvm got out of sync with the version in LLVM and it caused two variants of the `#[linkage=""]` attribute to break.

Fixes #33992
