### PR TITLE
Treat `#[test]` like `#[cfg(test)]` in non-test builds

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -582,6 +582,7 @@ pub fn phase_2_configure_and_expand<'a>(sess: &Session,
         sess.track_errors(|| {
             syntax::config::strip_unconfigured_items(sess.diagnostic(),
                                                      krate,
+                                                     sess.opts.test,
                                                      &mut feature_gated_cfgs)
         })
     })?;
@@ -692,6 +693,7 @@ pub fn phase_2_configure_and_expand<'a>(sess: &Session,
             features: Some(&features),
             recursion_limit: sess.recursion_limit.get(),
             trace_mac: sess.opts.debugging_opts.trace_macros,
+            should_test: sess.opts.test,
         };
         let mut loader = macro_import::MacroLoader::new(sess, &cstore, crate_name);
         let mut ecx = syntax::ext::base::ExtCtxt::new(&sess.parse_sess,

--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -134,7 +134,7 @@ impl<'a> CfgFolder for StripUnconfigured<'a> {
     }
 
     fn visit_unremovable_expr(&mut self, expr: &ast::Expr) {
-        if let Some(attr) = expr.attrs().iter().find(|a| is_cfg(a)) {
+        if let Some(attr) = expr.attrs().iter().find(|a| is_cfg(a) || is_test_or_bench(a)) {
             let msg = "removing an expression is not supported in this position";
             self.diag.diag.span_err(attr.span, msg);
         }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1001,6 +1001,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
 
     fn strip_unconfigured(&mut self) -> StripUnconfigured {
         StripUnconfigured::new(&self.cx.cfg,
+                               self.cx.ecfg.should_test,
                                &self.cx.parse_sess.span_diagnostic,
                                self.cx.feature_gated_cfgs)
     }
@@ -1106,6 +1107,7 @@ pub struct ExpansionConfig<'feat> {
     pub features: Option<&'feat Features>,
     pub recursion_limit: usize,
     pub trace_mac: bool,
+    pub should_test: bool, // If false, strip `#[test]` nodes
 }
 
 macro_rules! feature_tests {
@@ -1128,6 +1130,7 @@ impl<'feat> ExpansionConfig<'feat> {
             features: None,
             recursion_limit: 64,
             trace_mac: false,
+            should_test: false,
         }
     }
 

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -81,7 +81,7 @@ pub fn modify_for_testing(sess: &ParseSess,
     if should_test {
         generate_test_harness(sess, reexport_test_harness_main, krate, span_diagnostic)
     } else {
-        strip_test_functions(krate)
+        krate
     }
 }
 
@@ -304,19 +304,6 @@ fn generate_test_harness(sess: &ParseSess,
     let res = fold.fold_crate(krate);
     fold.cx.ext_cx.bt_pop();
     return res;
-}
-
-fn strip_test_functions(krate: ast::Crate) -> ast::Crate {
-    // When not compiling with --test we should not compile the
-    // #[test] functions
-    struct StripTests;
-    impl config::CfgFolder for StripTests {
-        fn in_cfg(&mut self, attrs: &[ast::Attribute]) -> bool {
-            !attr::contains_name(attrs, "test") && !attr::contains_name(attrs, "bench")
-        }
-    }
-
-    StripTests.fold_crate(krate)
 }
 
 /// Craft a span that will be ignored by the stability lint's

--- a/src/test/compile-fail/cfg-non-opt-expr.rs
+++ b/src/test/compile-fail/cfg-non-opt-expr.rs
@@ -17,4 +17,6 @@ fn main() {
     //~^ ERROR removing an expression is not supported in this position
     let _ = [1, 2, 3][#[cfg(unset)] 1];
     //~^ ERROR removing an expression is not supported in this position
+    let _ = #[test] ();
+    //~^ ERROR removing an expression is not supported in this position
 }


### PR DESCRIPTION
This PR treats `#[test]` like `#[cfg(test)]` in non-test builds. In particular, like `#[cfg(test)]`,
- `#[test]` nodes are stripped during `cfg` processing, and
- `#[test]` is disallowed on non-optional expressions.

Closes #33946.
r? @nrc
