### PR TITLE
Do not overwrite input file if it has no extension

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -399,6 +399,33 @@ impl OutputFilenames {
     pub fn filestem(&self) -> String {
         format!("{}{}", self.out_filestem, self.extra)
     }
+
+    pub fn is_path_used(&self, path: &PathBuf) -> bool {
+        fn eq(p1: &PathBuf, p2: &PathBuf) -> bool {
+            let p1 = match p1.canonicalize() {
+                Ok(p) => Some(p),
+                _ => None,
+            };
+            let p2 = match p2.canonicalize() {
+                Ok(p) => Some(p),
+                _ => None,
+            };
+            p1 == p2
+        }
+
+        match self.single_output_file {
+            Some(ref p) => eq(&p, path),
+            None => {
+                for k in self.outputs.keys() {
+                    let opath: PathBuf = self.path(k.to_owned());
+                    if eq(&opath, path) {
+                        return true;
+                    }
+                }
+                false
+            }
+        }
+    }
 }
 
 pub fn host_triple() -> &'static str {
@@ -454,6 +481,12 @@ impl Options {
     pub fn single_codegen_unit(&self) -> bool {
         self.incremental.is_none() ||
         self.cg.codegen_units == 1
+    }
+
+    /// True if there will be an output file generated
+    pub fn will_create_output_file(&self) -> bool {
+        !self.debugging_opts.parse_only ||  // we will generate an output file and
+            self.debugging_opts.ls          // we're not just querying an existing file
     }
 }
 

--- a/src/test/run-make/output-filename-overwrites-input/Makefile
+++ b/src/test/run-make/output-filename-overwrites-input/Makefile
@@ -1,0 +1,10 @@
+-include ../tools.mk
+
+all:
+	cp foo.rs $(TMPDIR)/foo
+	$(RUSTC) $(TMPDIR)/foo 2>&1 \
+		| grep "the input file \".*foo\" would be overwritten by the generated executable"
+	$(RUSTC) foo.rs 2>&1 && $(RUSTC) -Z ls $(TMPDIR)/foo 2>&1
+	cp foo.rs $(TMPDIR)/foo.rs
+	$(RUSTC) $(TMPDIR)/foo.rs -o $(TMPDIR)/foo.rs 2>&1 \
+		| grep "the input file \".*foo.rs\" would be overwritten by the generated executable"

--- a/src/test/run-make/output-filename-overwrites-input/foo.rs
+++ b/src/test/run-make/output-filename-overwrites-input/foo.rs
@@ -1,0 +1,11 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {}

--- a/src/test/run-make/weird-output-filenames/Makefile
+++ b/src/test/run-make/weird-output-filenames/Makefile
@@ -7,8 +7,8 @@ all:
 	cp foo.rs $(TMPDIR)/.foo.bar
 	$(RUSTC) $(TMPDIR)/.foo.bar 2>&1 \
 		| grep "invalid character.*in crate name:"
-	cp foo.rs $(TMPDIR)/+foo+bar
-	$(RUSTC) $(TMPDIR)/+foo+bar 2>&1 \
+	cp foo.rs $(TMPDIR)/+foo+bar.rs
+	$(RUSTC) $(TMPDIR)/+foo+bar.rs 2>&1 \
 		| grep "invalid character.*in crate name:"
 	cp foo.rs $(TMPDIR)/-foo.rs
 	$(RUSTC) $(TMPDIR)/-foo.rs 2>&1 \


### PR DESCRIPTION
Check wether the source file has the same path as the executable to be
generated and fail early if it would overwrite the source file with the
executable.

``` bash
% echo 'fn main(){}' > file && ./rustc file
error: the input file would be overwritten by the generated executable
error: aborting due to previous error
```

Fixes #13019
