### PR TITLE
 [MIR] Fix double-rounding of float constants and ignore NaN sign in tests.

### DIFF
--- a/src/librustc/middle/const_val.rs
+++ b/src/librustc/middle/const_val.rs
@@ -12,14 +12,12 @@ use syntax::parse::token::InternedString;
 use syntax::ast;
 use std::rc::Rc;
 use hir::def_id::DefId;
-use std::hash;
-use std::mem::transmute;
 use rustc_const_math::*;
 use self::ConstVal::*;
 
-#[derive(Clone, Debug, RustcEncodable, RustcDecodable)]
+#[derive(Clone, Debug, Hash, RustcEncodable, RustcDecodable, Eq, PartialEq)]
 pub enum ConstVal {
-    Float(f64),
+    Float(ConstFloat),
     Integral(ConstInt),
     Str(InternedString),
     ByteStr(Rc<Vec<u8>>),
@@ -36,55 +34,10 @@ pub enum ConstVal {
     Dummy,
 }
 
-impl hash::Hash for ConstVal {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        match *self {
-            Float(a) => unsafe { transmute::<_,u64>(a) }.hash(state),
-            Integral(a) => a.hash(state),
-            Str(ref a) => a.hash(state),
-            ByteStr(ref a) => a.hash(state),
-            Bool(a) => a.hash(state),
-            Struct(a) => a.hash(state),
-            Tuple(a) => a.hash(state),
-            Function(a) => a.hash(state),
-            Array(a, n) => { a.hash(state); n.hash(state) },
-            Repeat(a, n) => { a.hash(state); n.hash(state) },
-            Char(c) => c.hash(state),
-            Dummy => ().hash(state),
-        }
-    }
-}
-
-/// Note that equality for `ConstVal` means that the it is the same
-/// constant, not that the rust values are equal. In particular, `NaN
-/// == NaN` (at least if it's the same NaN; distinct encodings for NaN
-/// are considering unequal).
-impl PartialEq for ConstVal {
-    fn eq(&self, other: &ConstVal) -> bool {
-        match (self, other) {
-            (&Float(a), &Float(b)) => unsafe{transmute::<_,u64>(a) == transmute::<_,u64>(b)},
-            (&Integral(a), &Integral(b)) => a == b,
-            (&Str(ref a), &Str(ref b)) => a == b,
-            (&ByteStr(ref a), &ByteStr(ref b)) => a == b,
-            (&Bool(a), &Bool(b)) => a == b,
-            (&Struct(a), &Struct(b)) => a == b,
-            (&Tuple(a), &Tuple(b)) => a == b,
-            (&Function(a), &Function(b)) => a == b,
-            (&Array(a, an), &Array(b, bn)) => (a == b) && (an == bn),
-            (&Repeat(a, an), &Repeat(b, bn)) => (a == b) && (an == bn),
-            (&Char(a), &Char(b)) => a == b,
-            (&Dummy, &Dummy) => true, // FIXME: should this be false?
-            _ => false,
-        }
-    }
-}
-
-impl Eq for ConstVal { }
-
 impl ConstVal {
     pub fn description(&self) -> &'static str {
         match *self {
-            Float(_) => "float",
+            Float(f) => f.description(),
             Integral(i) => i.description(),
             Str(_) => "string literal",
             ByteStr(_) => "byte string literal",

--- a/src/librustc_const_math/err.rs
+++ b/src/librustc_const_math/err.rs
@@ -45,17 +45,17 @@ impl ConstMathErr {
         use self::Op::*;
         match *self {
             NotInRange => "inferred value out of range",
-            CmpBetweenUnequalTypes => "compared two integrals of different types",
-            UnequalTypes(Add) => "tried to add two integrals of different types",
-            UnequalTypes(Sub) => "tried to subtract two integrals of different types",
-            UnequalTypes(Mul) => "tried to multiply two integrals of different types",
-            UnequalTypes(Div) => "tried to divide two integrals of different types",
+            CmpBetweenUnequalTypes => "compared two values of different types",
+            UnequalTypes(Add) => "tried to add two values of different types",
+            UnequalTypes(Sub) => "tried to subtract two values of different types",
+            UnequalTypes(Mul) => "tried to multiply two values of different types",
+            UnequalTypes(Div) => "tried to divide two values of different types",
             UnequalTypes(Rem) => {
-                "tried to calculate the remainder of two integrals of different types"
+                "tried to calculate the remainder of two values of different types"
             },
-            UnequalTypes(BitAnd) => "tried to bitand two integrals of different types",
-            UnequalTypes(BitOr) => "tried to bitor two integrals of different types",
-            UnequalTypes(BitXor) => "tried to xor two integrals of different types",
+            UnequalTypes(BitAnd) => "tried to bitand two values of different types",
+            UnequalTypes(BitOr) => "tried to bitor two values of different types",
+            UnequalTypes(BitXor) => "tried to xor two values of different types",
             UnequalTypes(_) => unreachable!(),
             Overflow(Add) => "attempted to add with overflow",
             Overflow(Sub) => "attempted to subtract with overflow",

--- a/src/librustc_const_math/float.rs
+++ b/src/librustc_const_math/float.rs
@@ -1,0 +1,173 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::cmp::Ordering;
+use std::hash;
+use std::mem::transmute;
+
+use super::err::*;
+
+#[derive(Copy, Clone, Debug, RustcEncodable, RustcDecodable)]
+pub enum ConstFloat {
+    F32(f32),
+    F64(f64),
+
+    // When the type isn't known, we have to operate on both possibilities.
+    FInfer {
+        f32: f32,
+        f64: f64
+    }
+}
+pub use self::ConstFloat::*;
+
+impl ConstFloat {
+    /// Description of the type, not the value
+    pub fn description(&self) -> &'static str {
+        match *self {
+            FInfer {..} => "float",
+            F32(_) => "f32",
+            F64(_) => "f64",
+        }
+    }
+
+    pub fn is_nan(&self) -> bool {
+        match *self {
+            F32(f) => f.is_nan(),
+            F64(f) => f.is_nan(),
+            FInfer { f32, f64 } => f32.is_nan() || f64.is_nan()
+        }
+    }
+
+    /// Compares the values if they are of the same type
+    pub fn try_cmp(self, rhs: Self) -> Result<Ordering, ConstMathErr> {
+        match (self, rhs) {
+            (F64(a), F64(b)) |
+            (F64(a), FInfer { f64: b, .. }) |
+            (FInfer { f64: a, .. }, F64(b)) |
+            (FInfer { f64: a, .. }, FInfer { f64: b, .. })  => {
+                // This is pretty bad but it is the existing behavior.
+                Ok(if a == b {
+                    Ordering::Equal
+                } else if a < b {
+                    Ordering::Less
+                } else {
+                    Ordering::Greater
+                })
+            }
+
+            (F32(a), F32(b)) |
+            (F32(a), FInfer { f32: b, .. }) |
+            (FInfer { f32: a, .. }, F32(b)) => {
+                Ok(if a == b {
+                    Ordering::Equal
+                } else if a < b {
+                    Ordering::Less
+                } else {
+                    Ordering::Greater
+                })
+            }
+
+            _ => Err(CmpBetweenUnequalTypes),
+        }
+    }
+}
+
+/// Note that equality for `ConstFloat` means that the it is the same
+/// constant, not that the rust values are equal. In particular, `NaN
+/// == NaN` (at least if it's the same NaN; distinct encodings for NaN
+/// are considering unequal).
+impl PartialEq for ConstFloat {
+    fn eq(&self, other: &Self) -> bool {
+        match (*self, *other) {
+            (F64(a), F64(b)) |
+            (F64(a), FInfer { f64: b, .. }) |
+            (FInfer { f64: a, .. }, F64(b)) |
+            (FInfer { f64: a, .. }, FInfer { f64: b, .. }) => {
+                unsafe{transmute::<_,u64>(a) == transmute::<_,u64>(b)}
+            }
+            (F32(a), F32(b)) => {
+                unsafe{transmute::<_,u32>(a) == transmute::<_,u32>(b)}
+            }
+            _ => false
+        }
+    }
+}
+
+impl Eq for ConstFloat {}
+
+impl hash::Hash for ConstFloat {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        match *self {
+            F64(a) | FInfer { f64: a, .. } => {
+                unsafe { transmute::<_,u64>(a) }.hash(state)
+            }
+            F32(a) => {
+                unsafe { transmute::<_,u32>(a) }.hash(state)
+            }
+        }
+    }
+}
+
+impl ::std::fmt::Display for ConstFloat {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+        match *self {
+            FInfer { f64, .. } => write!(fmt, "{}", f64),
+            F32(f) => write!(fmt, "{}f32", f),
+            F64(f) => write!(fmt, "{}f64", f),
+        }
+    }
+}
+
+macro_rules! derive_binop {
+    ($op:ident, $func:ident) => {
+        impl ::std::ops::$op for ConstFloat {
+            type Output = Result<Self, ConstMathErr>;
+            fn $func(self, rhs: Self) -> Result<Self, ConstMathErr> {
+                match (self, rhs) {
+                    (F32(a), F32(b)) |
+                    (F32(a), FInfer { f32: b, .. }) |
+                    (FInfer { f32: a, .. }, F32(b)) => Ok(F32(a.$func(b))),
+
+                    (F64(a), F64(b)) |
+                    (FInfer { f64: a, .. }, F64(b)) |
+                    (F64(a), FInfer { f64: b, .. }) => Ok(F64(a.$func(b))),
+
+                    (FInfer { f32: a32, f64: a64 },
+                     FInfer { f32: b32, f64: b64 }) => Ok(FInfer {
+                        f32: a32.$func(b32),
+                        f64: a64.$func(b64)
+                    }),
+
+                    _ => Err(UnequalTypes(Op::$op)),
+                }
+            }
+        }
+    }
+}
+
+derive_binop!(Add, add);
+derive_binop!(Sub, sub);
+derive_binop!(Mul, mul);
+derive_binop!(Div, div);
+derive_binop!(Rem, rem);
+
+impl ::std::ops::Neg for ConstFloat {
+    type Output = Self;
+    fn neg(self) -> Self {
+        match self {
+            F32(f) => F32(-f),
+            F64(f) => F64(-f),
+            FInfer { f32, f64 } => FInfer {
+                f32: -f32,
+                f64: -f64
+            }
+        }
+    }
+}

--- a/src/librustc_const_math/lib.rs
+++ b/src/librustc_const_math/lib.rs
@@ -32,11 +32,13 @@
 
 extern crate serialize as rustc_serialize; // used by deriving
 
+mod float;
 mod int;
 mod us;
 mod is;
 mod err;
 
+pub use float::*;
 pub use int::*;
 pub use us::*;
 pub use is::*;

--- a/src/librustc_mir/build/misc.rs
+++ b/src/librustc_mir/build/misc.rs
@@ -56,7 +56,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     }
 
     // Returns a zero literal operand for the appropriate type, works for
-    // bool, char, integers and floats.
+    // bool, char and integers.
     pub fn zero_literal(&mut self, span: Span, ty: Ty<'tcx>) -> Operand<'tcx> {
         let literal = match ty.sty {
             ty::TyBool => {
@@ -93,7 +93,6 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
 
                 Literal::Value { value: ConstVal::Integral(val) }
             }
-            ty::TyFloat(_) => Literal::Value { value: ConstVal::Float(0.0) },
             _ => {
                 span_bug!(span, "Invalid type for zero_literal: `{:?}`", ty)
             }

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -1382,7 +1382,6 @@ mod tests {
     }
 
     #[test]
-    #[rustc_no_mir] // FIXME #27840 MIR NAN ends up negative.
     fn test_integer_decode() {
         assert_eq!(3.14159265359f32.integer_decode(), (13176795, -22, 1));
         assert_eq!((-8573.5918555f32).integer_decode(), (8779358, -10, -1));
@@ -1391,7 +1390,11 @@ mod tests {
         assert_eq!((-0f32).integer_decode(), (0, -150, -1));
         assert_eq!(INFINITY.integer_decode(), (8388608, 105, 1));
         assert_eq!(NEG_INFINITY.integer_decode(), (8388608, 105, -1));
-        assert_eq!(NAN.integer_decode(), (12582912, 105, 1));
+
+        // Ignore the "sign" (quiet / signalling flag) of NAN.
+        // It can vary between runtime operations and LLVM folding.
+        let (nan_m, nan_e, _nan_s) = NAN.integer_decode();
+        assert_eq!((nan_m, nan_e), (12582912, 105));
     }
 
     #[test]

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -1277,7 +1277,6 @@ mod tests {
     }
 
     #[test]
-    #[rustc_no_mir] // FIXME #27840 MIR NAN ends up negative.
     fn test_integer_decode() {
         assert_eq!(3.14159265359f64.integer_decode(), (7074237752028906, -51, 1));
         assert_eq!((-8573.5918555f64).integer_decode(), (4713381968463931, -39, -1));
@@ -1286,7 +1285,11 @@ mod tests {
         assert_eq!((-0f64).integer_decode(), (0, -1075, -1));
         assert_eq!(INFINITY.integer_decode(), (4503599627370496, 972, 1));
         assert_eq!(NEG_INFINITY.integer_decode(), (4503599627370496, 972, -1));
-        assert_eq!(NAN.integer_decode(), (6755399441055744, 972, 1));
+
+        // Ignore the "sign" (quiet / signalling flag) of NAN.
+        // It can vary between runtime operations and LLVM folding.
+        let (nan_m, nan_e, _nan_s) = NAN.integer_decode();
+        assert_eq!((nan_m, nan_e), (6755399441055744, 972));
     }
 
     #[test]

--- a/src/test/run-pass/issue-32805.rs
+++ b/src/test/run-pass/issue-32805.rs
@@ -1,0 +1,26 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_attrs)]
+
+#[rustc_mir]
+fn const_mir() -> f32 { 9007199791611905.0 }
+
+#[rustc_no_mir]
+fn const_old() -> f32 { 9007199791611905.0 }
+
+fn main() {
+    let original = "9007199791611905.0"; // (1<<53)+(1<<29)+1
+    let expected = "9007200000000000";
+
+    assert_eq!(const_mir().to_string(), expected);
+    assert_eq!(const_old().to_string(), expected);
+    assert_eq!(original.parse::<f32>().unwrap().to_string(), expected);
+}


### PR DESCRIPTION
Fixes #32805 by handling f32 and f64 separately in rustc_const_eval.

Also removes `#[rustc_no_mir]` from a couple libstd tests by ignoring NaN sign.
Turns out that runtime evaluation of `0.0 / 0.0` produces a NaN with the sign bit set,
whereas LLVM constant folds it to a NaN with the sign bit unset, which we were testing for.
