### PR TITLE
Use Docker for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: generic
 sudo: required
-dist: trusty
+services:
+  - docker
 
 # LLVM takes awhile to check out and otherwise we'll manage the submodules in
 # our configure script, so disable auto submodule management.
@@ -8,15 +9,15 @@ git:
   submodules: false
 
 before_install:
-  - echo 0 | sudo tee /proc/sys/net/ipv6/conf/lo/disable_ipv6
-  - echo 'deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.7 main' | sudo tee -a /etc/apt/sources.list
-  - echo 'deb-src http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.7 main' | sudo tee -a /etc/apt/sources.list
-  - sudo apt-get update
-  - sudo apt-get --force-yes install curl make g++ python2.7 git zlib1g-dev libedit-dev llvm-3.7-tools
+  - docker build -t rust -f src/etc/Dockerfile src/etc
 
 script:
-  - ./configure --llvm-root=/usr/lib/llvm-3.7
-  - make tidy && make check-notidy -j4
+  - docker run -v `pwd`:/build rust
+    sh -c "
+      ./configure --llvm-root=/usr/lib/llvm-3.7 &&
+      make tidy &&
+      make check-notidy -j4
+    "
 
 # Real testing happens on http://buildbot.rust-lang.org/
 #

--- a/src/etc/Dockerfile
+++ b/src/etc/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:xenial
+
+# curl
+#   Download stage0, see src/bootstrap/bootstrap.py
+# g++
+#   Compile LLVM binding in src/rustllvm
+# git
+#   Get commit hash and commit date in version string
+# make
+#   Run build scripts in mk
+# libedit-dev zlib1g-dev
+#   LLVM dependencies as packaged in Ubuntu
+#   (They are optional, but Ubuntu package enables them)
+# llvm-3.7-dev (installed by llvm-3.7-tools)
+#   LLVM
+# llvm-3.7-tools
+#   FileCheck is used to run tests in src/test/codegen
+
+RUN apt-get update && apt-get -y install \
+    curl g++ git make \
+    libedit-dev zlib1g-dev \
+    llvm-3.7-tools
+
+RUN mkdir /build
+WORKDIR /build


### PR DESCRIPTION
The primary motivtion is to use system LLVM from ubuntu.com, instead of llvm.org.

Travis provides two environments: Ubuntu 12.04 LTS aka precise by default, and Ubuntu 14.04 LTS aka trusty if you specify dist: trusty. According to travis-ci/travis-ci#5821, Ubuntu 16.04 LTS aka xenial is unlikely to be available this year, and Travis recommends to use Docker.

LLVM 3.7 binary for 12.04 and 14.04 is not available from ubuntu.com, that's why we used llvm.org. But LLVM 3.7 binary for 16.04 is available from ubuntu.com, and we can use Docker to run on 16.04.

Fix #34009.
