### PR TITLE
Changes the source of llvm-3.7 temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ git:
 
 before_install:
   - echo 0 | sudo tee /proc/sys/net/ipv6/conf/lo/disable_ipv6
-  - echo 'deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.7 main' | sudo tee -a /etc/apt/sources.list
-  - echo 'deb-src http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.7 main' | sudo tee -a /etc/apt/sources.list
+  - echo 'deb http://mirrors.kernel.org/ubuntu wily main universe' | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update
   - sudo apt-get --force-yes install curl make g++ python2.7 git zlib1g-dev libedit-dev llvm-3.7-tools
 


### PR DESCRIPTION
There is an announcement on the LLVM list that the APT source has been
disabled temporarily
http://lists.llvm.org/pipermail/llvm-dev/2016-May/100303.html

This mean that every Travis CI build on Pull Requests will fail until
the repo is back online.

As a short term solution, this commit changes the source repository to
point to Ubuntu Wily 15.10, which has the `llvm-3.7-tools` available.

There is a risk of adding many other updated packages that is not
compatible to Trusty, and this change could be reverted when the LLVM
apt repo is back online.

There are a few warnings caused by unrelated packages not supporting the
arch, like `compiz` and some php libs.
