### PR TITLE
Restore original meaning of std::fs::read_dir's example changed in #33958

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1341,8 +1341,9 @@ pub fn remove_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
 ///     if dir.is_dir() {
 ///         for entry in try!(fs::read_dir(dir)) {
 ///             let entry = try!(entry);
-///             if try!(entry.file_type()).is_dir() {
-///                 try!(visit_dirs(&entry.path(), cb));
+///             let path = entry.path();
+///             if path.is_dir() {
+///                 try!(visit_dirs(&path, cb));
 ///             } else {
 ///                 cb(&entry);
 ///             }


### PR DESCRIPTION
`DirEntry.file_type().is_dir()` will not follow symlinks, but the original example (`fs::metadata(&path).is_dir()`) does. Therefore the change in #33958 introduced a subtle difference that now it won't enter linked folders. To preserve the same behavior, we use `Path::is_dir()` instead, which does follow symlink.

(See discussion in the previous PR for detail.)
