### PR TITLE
Fix a regression in the configuration folder

### DIFF
--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -166,14 +166,6 @@ impl<T: CfgFolder> fold::Folder for T {
         };
 
         let item = match item {
-            ast::ItemKind::Impl(u, o, a, b, c, items) => {
-                let items = items.into_iter().filter_map(|item| self.configure(item)).collect();
-                ast::ItemKind::Impl(u, o, a, b, c, items)
-            }
-            ast::ItemKind::Trait(u, a, b, items) => {
-                let items = items.into_iter().filter_map(|item| self.configure(item)).collect();
-                ast::ItemKind::Trait(u, a, b, items)
-            }
             ast::ItemKind::Struct(def, generics) => {
                 ast::ItemKind::Struct(fold_struct(self, def), generics)
             }
@@ -242,7 +234,17 @@ impl<T: CfgFolder> fold::Folder for T {
     }
 
     fn fold_item(&mut self, item: P<ast::Item>) -> SmallVector<P<ast::Item>> {
-        self.configure(item).map(|item| SmallVector::one(item.map(|i| self.fold_item_simple(i))))
+        self.configure(item).map(|item| fold::noop_fold_item(item, self))
+                            .unwrap_or(SmallVector::zero())
+    }
+
+    fn fold_impl_item(&mut self, item: ast::ImplItem) -> SmallVector<ast::ImplItem> {
+        self.configure(item).map(|item| fold::noop_fold_impl_item(item, self))
+                            .unwrap_or(SmallVector::zero())
+    }
+
+    fn fold_trait_item(&mut self, item: ast::TraitItem) -> SmallVector<ast::TraitItem> {
+        self.configure(item).map(|item| fold::noop_fold_trait_item(item, self))
                             .unwrap_or(SmallVector::zero())
     }
 }

--- a/src/test/compile-fail/issue-34028.rs
+++ b/src/test/compile-fail/issue-34028.rs
@@ -1,0 +1,21 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_attrs)]
+
+macro_rules! m {
+    () => { #[cfg(any())] fn f() {} }
+}
+
+trait T {}
+impl T for () { m!(); }
+
+#[rustc_error]
+fn main() {} //~ ERROR compilation successful


### PR DESCRIPTION
This fixes #34028, a regression caused by #33706 in which unconfigured impl items generated by a macro in an impl item position are not removed.
r? @nrc 
