### PR TITLE
rustdoc: Don't generate empty files for stripped items

### DIFF
--- a/src/test/rustdoc/issue-34025.rs
+++ b/src/test/rustdoc/issue-34025.rs
@@ -1,0 +1,22 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "foo"]
+
+// @!has 'foo/sys/index.html'
+// @!has 'foo/sys/sidebar-items.js'
+#[doc(hidden)]
+pub mod sys {
+    extern "C" {
+        // @!has 'foo/sys/fn.foo.html'
+        #[doc(hidden)]
+        pub fn foo();
+    }
+}


### PR DESCRIPTION
We need to traverse stripped modules to generate redirect pages, but we shouldn't generate
anything else for them.

This now renders the file contents to a Vec before writing it to a file in one go. I think
that's probably a better strategy anyway.

Fixes: #34025
