### PR TITLE
Remove redundant assertion from Queue::pop().

### DIFF
--- a/src/libstd/sync/mpsc/mpsc_queue.rs
+++ b/src/libstd/sync/mpsc/mpsc_queue.rs
@@ -122,7 +122,6 @@ impl<T> Queue<T> {
             if !next.is_null() {
                 *self.tail.get() = next;
                 assert!((*tail).value.is_none());
-                assert!((*next).value.is_some());
                 let ret = (*next).value.take().unwrap();
                 let _: Box<Node<T>> = Box::from_raw(tail);
                 return Data(ret);


### PR DESCRIPTION
Unwrapping (*next).value.take() would already panic if it were to be
None, making the assertion before it unnecessary.
