### PR TITLE
rustdoc: Fix generating redirect pages for statics and consts

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1120,7 +1120,9 @@ impl DocFolder for Cache {
             clean::StructItem(..) | clean::EnumItem(..) |
             clean::TypedefItem(..) | clean::TraitItem(..) |
             clean::FunctionItem(..) | clean::ModuleItem(..) |
-            clean::ForeignFunctionItem(..) if !self.stripped_mod => {
+            clean::ForeignFunctionItem(..) | clean::ForeignStaticItem(..) |
+            clean::ConstantItem(..) | clean::StaticItem(..)
+            if !self.stripped_mod => {
                 // Reexported items mean that the same id can show up twice
                 // in the rustdoc ast that we're looking at. We know,
                 // however, that a reexported item doesn't show up in the

--- a/src/test/rustdoc/redirect-const.rs
+++ b/src/test/rustdoc/redirect-const.rs
@@ -1,0 +1,23 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name="foo"]
+
+pub use hidden::STATIC_FOO;
+pub use hidden::CONST_FOO;
+
+mod hidden {
+    // @has foo/hidden/static.STATIC_FOO.html
+    // @has - '//p/a' '../../foo/static.STATIC_FOO.html'
+    pub static STATIC_FOO: u64 = 0;
+    // @has foo/hidden/constant.CONST_FOO.html
+    // @has - '//p/a' '../../foo/constant.CONST_FOO.html'
+    pub const CONST_FOO: u64 = 0;
+}


### PR DESCRIPTION
These were missing from the cache for some reason meaning the redirect pages failed to render.
