### PR TITLE
Syntax coloring and more compact diagram

### DIFF
--- a/src/doc/book/closures.md
+++ b/src/doc/book/closures.md
@@ -322,7 +322,7 @@ to our closure when we pass it to `call_with_one`, so we use `&||`.
 A quick note about closures that use explicit lifetimes. Sometimes you might have a closure
 that takes a reference like so:
 
-```
+```rust
 fn call_with_ref<F>(some_closure:F) -> i32
     where F: Fn(&i32) -> i32 {
 
@@ -334,8 +334,8 @@ fn call_with_ref<F>(some_closure:F) -> i32
 Normally you can specify the lifetime of the parameter to our closure. We
 could annotate it on the function declaration:
 
-```ignore
-fn call_with_ref<'a, F>(some_closure:F) -> i32 
+```rust,ignore
+fn call_with_ref<'a, F>(some_closure:F) -> i32
     where F: Fn(&'a 32) -> i32 {
 ```
 
@@ -353,11 +353,11 @@ fn call_with_ref<F>(some_closure:F) -> i32
     where F: for<'a> Fn(&'a 32) -> i32 {
 ```
 
-This lets the Rust compiler find the minimum lifetime to invoke our closure and 
+This lets the Rust compiler find the minimum lifetime to invoke our closure and
 satisfy the borrow checker's rules. Our function then compiles and excutes as we
 expect.
 
-```
+```rust
 fn call_with_ref<F>(some_closure:F) -> i32
     where F: for<'a> Fn(&'a i32) -> i32 {
 

--- a/src/doc/book/crates-and-modules.md
+++ b/src/doc/book/crates-and-modules.md
@@ -22,12 +22,10 @@ As an example, let’s make a *phrases* crate, which will give us various phrase
 in different languages. To keep things simple, we’ll stick to ‘greetings’ and
 ‘farewells’ as two kinds of phrases, and use English and Japanese (日本語) as
 two languages for those phrases to be in. We’ll use this module layout:
-
 ```text
                                     +-----------+
                                 +---| greetings |
-                                |   +-----------+
-                  +---------+   |
+                  +---------+   |   +-----------+
               +---| english |---+
               |   +---------+   |   +-----------+
               |                 +---| farewells |
@@ -37,8 +35,7 @@ two languages for those phrases to be in. We’ll use this module layout:
               |                 +---| greetings |
               |   +----------+  |   +-----------+
               +---| japanese |--+
-                  +----------+  |
-                                |   +-----------+
+                  +----------+  |   +-----------+
                                 +---| farewells |
                                     +-----------+
 ```


### PR DESCRIPTION
Two cosmetic improvements:
- New content was added a few days ago to the **Closures** chapter but it was missing rust's syntax coloring.
- Also, in the **Crates and Modules** chapter, a diagram was improved to be more symmetric and to take less space.
