### PR TITLE
only emit "lint level defined here" the first time

### DIFF
--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -462,7 +462,13 @@ pub fn raw_struct_lint<'a>(sess: &'a Session,
 
     if let Some(span) = def {
         let explanation = "lint level defined here";
-        err.span_note(span, &explanation);
+        let span_explanation = (span, explanation.to_owned());
+        let already_noted: bool = sess.one_time_diagnostics.borrow()
+            .contains(&span_explanation);
+        if !already_noted {
+            err.span_note(span, explanation);
+            sess.one_time_diagnostics.borrow_mut().insert(span_explanation);
+        }
     }
 
     err

--- a/src/test/compile-fail/lint-group-style.rs
+++ b/src/test/compile-fail/lint-group-style.rs
@@ -20,7 +20,6 @@ mod test {
 
     #[forbid(bad_style)]
     //~^ NOTE lint level defined here
-    //~^^ NOTE lint level defined here
     mod bad {
         fn CamelCase() {} //~ ERROR function `CamelCase` should have a snake case name
 
@@ -30,7 +29,6 @@ mod test {
     mod warn {
         #![warn(bad_style)]
         //~^ NOTE lint level defined here
-        //~| NOTE lint level defined here
 
         fn CamelCase() {} //~ WARN function `CamelCase` should have a snake case name
 

--- a/src/test/compile-fail/lint-no-drop-on-repr-extern.rs
+++ b/src/test/compile-fail/lint-no-drop-on-repr-extern.rs
@@ -16,7 +16,6 @@
 #![feature(unsafe_no_drop_flag)]
 #![deny(drop_with_repr_extern)]
 //~^ NOTE lint level defined here
-//~| NOTE lint level defined here
 
 #[repr(C)] struct As { x: Box<i8> }
 #[repr(C)] enum Ae { Ae(Box<i8>), _None }

--- a/src/test/compile-fail/lint-unconditional-recursion.rs
+++ b/src/test/compile-fail/lint-unconditional-recursion.rs
@@ -10,19 +10,7 @@
 
 #![deny(unconditional_recursion)]
 //~^ NOTE lint level defined here
-//~| NOTE lint level defined here
-//~| NOTE lint level defined here
-//~| NOTE lint level defined here
-//~| NOTE lint level defined here
-//~| NOTE lint level defined here
-//~| NOTE lint level defined here
-//~| NOTE lint level defined here
-//~| NOTE lint level defined here
-//~| NOTE lint level defined here
-//~| NOTE lint level defined here
-//~| NOTE lint level defined here
-//~| NOTE lint level defined here
-//~| NOTE lint level defined here
+
 #![allow(dead_code)]
 fn foo() { //~ ERROR function cannot return without recurring
     foo(); //~ NOTE recursive call site


### PR DESCRIPTION
We introduce a new `one_time_diagnostics` field on
`rustc::session::Session` to hold a hashset of diagnostic messages we've
set once but don't want to see again (as uniquified by span and message
text), "lint level defined here" being the motivating example dealt with
here. It is the responsibility of the caller setting a diagnostic to
decide whether to add to `one_time_diagnostics`; there are other
situations where we likely do want it to be possible for a note to
appear twice on the same span with the same message (e.g., "prior
assignment occurs here").

Fixes #24690.

---

I get 83 debuginfo-gdb failures when I run the tests locally, but I am given to understand that it's possible that this may be a problem with my environment rather than the proposed changes; our friend Travis can be trusted to let us know.

Thanks to @mitaa for [the pointer](https://github.com/rust-lang/rust/issues/24690#issuecomment-172858258) on where to get started and to @eddyb in `#rustc` for advice on `configure` options, CI, and my possible gdb problem.

---

r? @nikomatsakis 
