### PR TITLE
Revise wording in Rc documentation.

### DIFF
--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -10,7 +10,7 @@
 
 #![allow(deprecated)]
 
-//! Thread-local reference-counted boxes (the `Rc<T>` type).
+//! Unsynchronized reference-counted boxes (the `Rc<T>` type).
 //!
 //! The `Rc<T>` type provides shared ownership of an immutable value.
 //! Destruction is deterministic, and will occur as soon as the last owner is

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -10,7 +10,8 @@
 
 #![allow(deprecated)]
 
-//! Unsynchronized reference-counted boxes (the `Rc<T>` type).
+//! Unsynchronized reference-counted boxes (the `Rc<T>` type) which are usable
+//! only within a single thread.
 //!
 //! The `Rc<T>` type provides shared ownership of an immutable value.
 //! Destruction is deterministic, and will occur as soon as the last owner is


### PR DESCRIPTION
The term "thread-local" has a widely accepted meaning which is not
the meaning it's used for here.
