### PR TITLE
Update rc.rs

### DIFF
--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -271,7 +271,7 @@ impl<T> Rc<T> {
 }
 
 impl<T: ?Sized> Rc<T> {
-    /// Downgrades the `Rc<T>` to a `Weak<T>` reference.
+    /// Creates a new `Weak<T>` reference from this value.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
The original description suggests that the original `Rc<T>` itself is downgraded, which doesn't seem to be what the code does. At the same time, `Rc` is one of those types that can do weird things with only a shared reference, so I thought it would be good to be clear.
