### PR TITLE
Require LLVM 3.7

### DIFF
--- a/configure
+++ b/configure
@@ -987,11 +987,11 @@ then
     LLVM_VERSION=$($LLVM_CONFIG --version)
 
     case $LLVM_VERSION in
-        (3.[6-8]*)
+        (3.[7-8]*)
             msg "found ok version of LLVM: $LLVM_VERSION"
             ;;
         (*)
-            err "bad LLVM version: $LLVM_VERSION, need >=3.6"
+            err "bad LLVM version: $LLVM_VERSION, need >=3.7"
             ;;
     esac
 fi


### PR DESCRIPTION
We are using getMCTargetInfo which is 3.7+. I’m not sure whether 3.7 works though.

Fixes https://github.com/rust-lang/rust/issues/34103

r? @alexcrichton 
