### PR TITLE
rustdoc: Remove Derived Implementations title

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -425,7 +425,6 @@ pub fn build_impl<'a, 'tcx>(cx: &DocContext,
     ret.push(clean::Item {
         inner: clean::ImplItem(clean::Impl {
             unsafety: hir::Unsafety::Normal, // FIXME: this should be decoded
-            derived: clean::detect_derived(&attrs),
             provided_trait_methods: provided,
             trait_: trait_,
             for_: for_,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2239,12 +2239,7 @@ pub struct Impl {
     pub trait_: Option<Type>,
     pub for_: Type,
     pub items: Vec<Item>,
-    pub derived: bool,
     pub polarity: Option<ImplPolarity>,
-}
-
-fn detect_derived<M: AttrMetaMethods>(attrs: &[M]) -> bool {
-    attr::contains_name(attrs, "automatically_derived")
 }
 
 impl Clean<Vec<Item>> for doctree::Impl {
@@ -2283,7 +2278,6 @@ impl Clean<Vec<Item>> for doctree::Impl {
                 trait_: trait_,
                 for_: self.for_.clean(cx),
                 items: items,
-                derived: detect_derived(&self.attrs),
                 polarity: Some(self.polarity.clean(cx)),
             }),
         });

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -399,7 +399,6 @@ fn init_ids() -> HashMap<String, usize> {
      "methods",
      "deref-methods",
      "implementations",
-     "derived_implementations"
      ].into_iter().map(|id| (String::from(*id), 1)).collect()
 }
 
@@ -2501,24 +2500,10 @@ fn render_assoc_items(w: &mut fmt::Formatter,
         }
         write!(w, "<h2 id='implementations'>Trait \
                    Implementations</h2>")?;
-        let (derived, manual): (Vec<_>, Vec<&Impl>) = traits.iter().partition(|i| {
-            i.inner_impl().derived
-        });
-        for i in &manual {
+        for i in &traits {
             let did = i.trait_did().unwrap();
             let assoc_link = AssocItemLink::GotoSource(did, &i.inner_impl().provided_trait_methods);
             render_impl(w, cx, i, assoc_link, true, containing_item.stable_since())?;
-        }
-        if !derived.is_empty() {
-            write!(w, "<h3 id='derived_implementations'>\
-                           Derived Implementations \
-                       </h3>")?;
-            for i in &derived {
-                let did = i.trait_did().unwrap();
-                let assoc_link = AssocItemLink::GotoSource(did,
-                                                           &i.inner_impl().provided_trait_methods);
-                render_impl(w, cx, i, assoc_link, true, containing_item.stable_since())?;
-            }
         }
     }
     Ok(())


### PR DESCRIPTION
As far as I know whether a trait was derived or not does not change the
public API so there is no need to include this information in the docs.

This title currently just adds an extra divide in the list of trait
implementations which I don't think needs to be there.
