### PR TITLE
Implement Fn traits for Rc/Arc

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -936,6 +936,35 @@ impl<T: ?Sized + Hash> Hash for Arc<T> {
     }
 }
 
+#[stable(feature = "fn_smart_ptr", since = "1.11.0")]
+impl<I, F: ?Sized> Fn<I> for Arc<F>
+    where F: Fn<I>
+{
+    extern "rust-call" fn call(&self, args: I) -> Self::Output {
+        (&**self).call(args)
+    }
+}
+
+#[stable(feature = "fn_smart_ptr", since = "1.11.0")]
+impl<I, F: ?Sized> FnMut<I> for Arc<F>
+    where F: Fn<I>
+{
+    extern "rust-call" fn call_mut(&mut self, args: I) -> Self::Output {
+        self.call(args)
+    }
+}
+
+#[stable(feature = "fn_smart_ptr", since = "1.11.0")]
+impl<I, F: ?Sized> FnOnce<I> for Arc<F>
+    where F: Fn<I>
+{
+    type Output = F::Output;
+    extern "rust-call" fn call_once(self, args: I) -> Self::Output {
+        self.call(args)
+    }
+}
+
+
 #[stable(feature = "from_for_ptrs", since = "1.6.0")]
 impl<T> From<T> for Arc<T> {
     fn from(t: T) -> Self {
@@ -1170,6 +1199,12 @@ mod tests {
     fn show_arc() {
         let a = Arc::new(5);
         assert_eq!(format!("{:?}", a), "5");
+    }
+
+    #[test]
+    fn test_fn() {
+        let f = Arc::new(|i: i32| -> i32 { i + 1 });
+        assert_eq!(Some(1).map(f), Some(2));
     }
 
     // Make sure deriving works with Arc<T>

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -90,8 +90,9 @@
 #![feature(unique)]
 #![feature(unsafe_no_drop_flag, filling_drop)]
 #![feature(unsize)]
+#![feature(fn_traits)]
 
-#![cfg_attr(not(test), feature(raw, fn_traits, placement_new_protocol))]
+#![cfg_attr(not(test), feature(raw, placement_new_protocol))]
 #![cfg_attr(test, feature(test, box_heap))]
 
 // Allow testing this library

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -693,6 +693,34 @@ impl<T: ?Sized> fmt::Pointer for Rc<T> {
     }
 }
 
+#[stable(feature = "fn_smart_ptr", since = "1.11.0")]
+impl<I, F: ?Sized> Fn<I> for Rc<F>
+    where F: Fn<I>
+{
+    extern "rust-call" fn call(&self, args: I) -> Self::Output {
+        (&**self).call(args)
+    }
+}
+
+#[stable(feature = "fn_smart_ptr", since = "1.11.0")]
+impl<I, F: ?Sized> FnMut<I> for Rc<F>
+    where F: Fn<I>
+{
+    extern "rust-call" fn call_mut(&mut self, args: I) -> Self::Output {
+        self.call(args)
+    }
+}
+
+#[stable(feature = "fn_smart_ptr", since = "1.11.0")]
+impl<I, F: ?Sized> FnOnce<I> for Rc<F>
+    where F: Fn<I>
+{
+    type Output = F::Output;
+    extern "rust-call" fn call_once(self, args: I) -> Self::Output {
+        self.call(args)
+    }
+}
+
 #[stable(feature = "from_for_ptrs", since = "1.6.0")]
 impl<T> From<T> for Rc<T> {
     fn from(t: T) -> Self {
@@ -1135,6 +1163,12 @@ mod tests {
     fn test_show() {
         let foo = Rc::new(75);
         assert_eq!(format!("{:?}", foo), "75");
+    }
+
+    #[test]
+    fn test_fn() {
+        let f = Rc::new(|i: i32| -> i32 { i + 1 });
+        assert_eq!(Some(1).map(f), Some(2));
     }
 
     #[test]


### PR DESCRIPTION
This allows one to, e.g., use an `Rc` wrapped closure in `Iterator::map`. I would have implemented `Fn` and `FnMut` for `Box` as well but ran into coherence problems (see #33811).
