### PR TITLE
Fixed: conflicting spelling of "Jon Snow"

### DIFF
--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -1185,7 +1185,7 @@ two solutions. Either you add variants in your enum:
 ```
 #[repr(i32)]
 enum NightWatch {
-    JohnSnow,
+    JonSnow,
     Commander,
 }
 ```

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -1174,7 +1174,7 @@ Erroneous code example:
 
 ```compile_fail
 #[repr(i32)]
-enum NightWatch {} // error: unsupported representation for zero-variant enum
+enum NightsWatch {} // error: unsupported representation for zero-variant enum
 ```
 
 It is impossible to define an integer type to be used to represent zero-variant
@@ -1184,7 +1184,7 @@ two solutions. Either you add variants in your enum:
 
 ```
 #[repr(i32)]
-enum NightWatch {
+enum NightsWatch {
     JonSnow,
     Commander,
 }
@@ -1193,7 +1193,7 @@ enum NightWatch {
 or you remove the integer represention of your enum:
 
 ```
-enum NightWatch {}
+enum NightsWatch {}
 ```
 "##,
 


### PR DESCRIPTION
I probably had not even noticed, if there hadn't been a different spelling in the [error index](http://doc.rust-lang.org/nightly/error-index.html#E0500).

Cheers
Winter is Coming!
