### PR TITLE
trans: always use a memcpy for ABI argument/return casts.

### DIFF
--- a/src/librustc_trans/mir/mod.rs
+++ b/src/librustc_trans/mir/mod.rs
@@ -348,10 +348,10 @@ fn arg_value_refs<'bcx, 'tcx>(bcx: &BlockAndBuilder<'bcx, 'tcx>,
             llarg_idx += 1;
             llarg
         } else {
+            let lltemp = bcx.with_block(|bcx| {
+                base::alloc_ty(bcx, arg_ty, &format!("arg{}", arg_index))
+            });
             if common::type_is_fat_ptr(tcx, arg_ty) {
-                let lltemp = bcx.with_block(|bcx| {
-                    base::alloc_ty(bcx, arg_ty, &format!("arg{}", arg_index))
-                });
                 // we pass fat pointers as two words, but we want to
                 // represent them internally as a pointer to two words,
                 // so make an alloca to store them in.
@@ -359,17 +359,12 @@ fn arg_value_refs<'bcx, 'tcx>(bcx: &BlockAndBuilder<'bcx, 'tcx>,
                 idx += 1;
                 arg.store_fn_arg(bcx, &mut llarg_idx, get_dataptr(bcx, lltemp));
                 meta.store_fn_arg(bcx, &mut llarg_idx, get_meta(bcx, lltemp));
-                lltemp
             } else  {
-                // otherwise, arg is passed by value, so store it into a temporary.
-                let llarg_ty = arg.cast.unwrap_or(arg.memory_ty(bcx.ccx()));
-                let lltemp = bcx.with_block(|bcx| {
-                    base::alloca(bcx, llarg_ty, &format!("arg{}", arg_index))
-                });
+                // otherwise, arg is passed by value, so make a
+                // temporary and store it there
                 arg.store_fn_arg(bcx, &mut llarg_idx, lltemp);
-                // And coerce the temporary into the type we expect.
-                bcx.pointercast(lltemp, arg.memory_ty(bcx.ccx()).ptr_to())
             }
+            lltemp
         };
         bcx.with_block(|bcx| arg_scope.map(|scope| {
             // Is this a regular argument?

--- a/src/test/codegen/stores.rs
+++ b/src/test/codegen/stores.rs
@@ -26,8 +26,12 @@ pub struct Bytes {
 #[no_mangle]
 #[rustc_no_mir] // FIXME #27840 MIR has different codegen.
 pub fn small_array_alignment(x: &mut [i8; 4], y: [i8; 4]) {
-// CHECK: store i32 %{{.*}}, i32* %{{.*}}, align 1
-// CHECK: [[VAR:%[0-9]+]] = bitcast i32* %{{.*}} to [4 x i8]*
+// CHECK: %y = alloca [4 x i8]
+// CHECK: [[TMP:%.+]] = alloca i32
+// CHECK: store i32 %1, i32* [[TMP]]
+// CHECK: [[Y8:%[0-9]+]] = bitcast [4 x i8]* %y to i8*
+// CHECK: [[TMP8:%[0-9]+]] = bitcast i32* [[TMP]] to i8*
+// CHECK: call void @llvm.memcpy.{{.*}}(i8* [[Y8]], i8* [[TMP8]], i{{[0-9]+}} 4, i32 1, i1 false)
     *x = y;
 }
 
@@ -37,7 +41,11 @@ pub fn small_array_alignment(x: &mut [i8; 4], y: [i8; 4]) {
 #[no_mangle]
 #[rustc_no_mir] // FIXME #27840 MIR has different codegen.
 pub fn small_struct_alignment(x: &mut Bytes, y: Bytes) {
-// CHECK: store i32 %{{.*}}, i32* %{{.*}}, align 1
-// CHECK: [[VAR:%[0-9]+]] = bitcast i32* %{{.*}} to %Bytes*
+// CHECK: %y = alloca %Bytes
+// CHECK: [[TMP:%.+]] = alloca i32
+// CHECK: store i32 %1, i32* [[TMP]]
+// CHECK: [[Y8:%[0-9]+]] = bitcast %Bytes* %y to i8*
+// CHECK: [[TMP8:%[0-9]+]] = bitcast i32* [[TMP]] to i8*
+// CHECK: call void @llvm.memcpy.{{.*}}(i8* [[Y8]], i8* [[TMP8]], i{{[0-9]+}} 4, i32 1, i1 false)
     *x = y;
 }


### PR DESCRIPTION
When storing incoming arguments or values returned by call/invoke, always do a `memcpy` from a temporary of the cast type, if there is an ABI cast.
While Clang has gotten smarter ([store](https://godbolt.org/g/EphFuK) vs [memcpy](https://godbolt.org/g/5dikH9)), a `memcpy` will always work.
This is what @dotdash has wanted to do all along, and it fixes #32049.
