### PR TITLE
Make `String` implement `Extend<T: Display>`

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -1418,6 +1418,17 @@ impl FromIterator<String> for String {
     }
 }
 
+#[stable(feature = "extend_display", since = "1.11.0")]
+impl<T: fmt::Display> Extend<T> for String {
+    default fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        use fmt::Write;
+        for d in iter {
+            let _ = write!(self, "{}", d);
+        }
+    }
+}
+
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Extend<char> for String {
     fn extend<I: IntoIterator<Item = char>>(&mut self, iter: I) {

--- a/src/libcollectionstest/string.rs
+++ b/src/libcollectionstest/string.rs
@@ -375,6 +375,15 @@ fn test_extend_ref() {
 }
 
 #[test]
+fn test_extend_display() {
+    let mut a = "foo".to_string();
+    a.extend(&[1i32, 2, 3]);
+
+    assert_eq!(&a, "foo123");
+}
+
+
+#[test]
 fn test_into_boxed_str() {
     let xs = String::from("hello my name is bob");
     let ys = xs.into_boxed_str();


### PR DESCRIPTION
But keep the current implementations of `Extend` for `String` as specializations.
