### PR TITLE
Remove unzip() SizeHint hack

### DIFF
--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -11,7 +11,6 @@
 use clone::Clone;
 use cmp::{Ord, PartialOrd, PartialEq, Ordering};
 use default::Default;
-use marker;
 use num::{Zero, One};
 use ops::{Add, FnMut, Mul};
 use option::Option::{self, Some, None};
@@ -1747,22 +1746,8 @@ pub trait Iterator {
         FromB: Default + Extend<B>,
         Self: Sized + Iterator<Item=(A, B)>,
     {
-        struct SizeHint<A>(usize, Option<usize>, marker::PhantomData<A>);
-        impl<A> Iterator for SizeHint<A> {
-            type Item = A;
-
-            fn next(&mut self) -> Option<A> { None }
-            fn size_hint(&self) -> (usize, Option<usize>) {
-                (self.0, self.1)
-            }
-        }
-
-        let (lo, hi) = self.size_hint();
         let mut ts: FromA = Default::default();
         let mut us: FromB = Default::default();
-
-        ts.extend(SizeHint(lo, hi, marker::PhantomData));
-        us.extend(SizeHint(lo, hi, marker::PhantomData));
 
         for (t, u) in self {
             ts.extend(Some(t));


### PR DESCRIPTION
This was using an invalid iterator so is likely to end with buggy
behaviour.

It also doesn't even benefit many type in std including Vec so removing it
shouldn't cause any problems.

Fixes: #33468
