### PR TITLE
Updated README to account for changes in MSYS2

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ installing from pacman should be just fine.
 
 3. Run `mingw32_shell.bat` or `mingw64_shell.bat` from wherever you installed
    MSYS2 (i.e. `C:\msys`), depending on whether you want 32-bit or 64-bit Rust.
+   (As of the latest version of MSYS2 you have to run `msys2_shell.cmd -mingw32`
+   or `msys2_shell.cmd -mingw64` from the command line instead)
 
 4. Navigate to Rust's source code, configure and build it:
 


### PR DESCRIPTION
One of the newest versions of MSYS2 now only has one .cmd file which replaces the old bat files. It has to be used to launch the mingw32/64 shell.
