### PR TITLE
Fix markdown formatting error of E0277, E0310 and E0502.

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -1112,6 +1112,7 @@ fn main() {
 ```
 
 Or in a generic context, an erroneous code example would look like:
+
 ```compile_fail
 fn some_func<T>(foo: T) {
     println!("{:?}", foo); // error: the trait `core::fmt::Debug` is not
@@ -1130,6 +1131,7 @@ we only call it with a parameter that does implement `Debug`, the compiler
 still rejects the function: It must work with all possible input types. In
 order to make this example compile, we need to restrict the generic type we're
 accepting:
+
 ```
 use std::fmt;
 
@@ -1146,11 +1148,10 @@ fn main() {
     // struct WithoutDebug;
     // some_func(WithoutDebug);
 }
+```
 
 Rust only looks at the signature of the called function, as such it must
 already specify all requirements that will be used for every type parameter.
-```
-
 "##,
 
 E0281: r##"
@@ -1381,6 +1382,7 @@ denotes this will cause this error.
 struct Foo<T> {
     foo: &'static T
 }
+```
 
 This will compile, because it has the constraint on the type parameter:
 

--- a/src/librustc_borrowck/diagnostics.rs
+++ b/src/librustc_borrowck/diagnostics.rs
@@ -516,8 +516,10 @@ fn foo(a: &mut i32) {
             //        as immutable
 }
 ```
+
 To fix this error, ensure that you don't have any other references to the
 variable before trying to access it mutably:
+
 ```
 fn bar(x: &mut i32) {}
 fn foo(a: &mut i32) {
@@ -525,6 +527,7 @@ fn foo(a: &mut i32) {
     let ref y = a; // ok!
 }
 ```
+
 For more information on the rust ownership system, take a look at
 https://doc.rust-lang.org/stable/book/references-and-borrowing.html.
 "##,


### PR DESCRIPTION
Fix bad format we see in https://doc.rust-lang.org/nightly/error-index.html#E0277.
