### PR TITLE
trans: don't misuse C_nil for ZSTs other than ().

### DIFF
--- a/src/librustc_trans/mir/mod.rs
+++ b/src/librustc_trans/mir/mod.rs
@@ -16,7 +16,7 @@ use rustc::mir::repr as mir;
 use rustc::mir::tcx::LvalueTy;
 use session::config::FullDebugInfo;
 use base;
-use common::{self, Block, BlockAndBuilder, CrateContext, FunctionContext};
+use common::{self, Block, BlockAndBuilder, CrateContext, FunctionContext, C_null};
 use debuginfo::{self, declare_local, DebugLoc, VariableAccess, VariableKind};
 use machine;
 use type_of;
@@ -124,11 +124,12 @@ impl<'tcx> TempRef<'tcx> {
             // Zero-size temporaries aren't always initialized, which
             // doesn't matter because they don't contain data, but
             // we need something in the operand.
-            let nil = common::C_nil(ccx);
+            let llty = type_of::type_of(ccx, ty);
             let val = if common::type_is_imm_pair(ccx, ty) {
-                OperandValue::Pair(nil, nil)
+                let fields = llty.field_types();
+                OperandValue::Pair(C_null(fields[0]), C_null(fields[1]))
             } else {
-                OperandValue::Immediate(nil)
+                OperandValue::Immediate(C_null(llty))
             };
             let op = OperandRef {
                 val: val,

--- a/src/test/run-pass/mir_trans_calls.rs
+++ b/src/test/run-pass/mir_trans_calls.rs
@@ -30,6 +30,7 @@ fn test2(a: isize) -> isize {
     callee(a)
 }
 
+#[derive(PartialEq, Eq, Debug)]
 struct Foo;
 impl Foo {
     fn inherent_method(&self, a: isize) -> isize { a }
@@ -157,6 +158,19 @@ fn test_fn_ignored_pair_0() {
     test_fn_ignored_pair().0
 }
 
+#[rustc_mir]
+fn id<T>(x: T) -> T { x }
+
+#[rustc_mir]
+fn ignored_pair_named() -> (Foo, Foo) {
+    (Foo, Foo)
+}
+
+#[rustc_mir]
+fn test_fn_ignored_pair_named() -> (Foo, Foo) {
+    id(ignored_pair_named())
+}
+
 fn main() {
     assert_eq!(test1(1, (2, 3), &[4, 5, 6]), (1, (2, 3), &[4, 5, 6][..]));
     assert_eq!(test2(98), 98);
@@ -181,4 +195,5 @@ fn main() {
     assert_eq!(test_fn_transmute_zst(()), [()]);
 
     assert_eq!(test_fn_ignored_pair_0(), ());
+    assert_eq!(test_fn_ignored_pair_named(), (Foo, Foo));
 }


### PR DESCRIPTION
`C_nil` is actually `C_null` for `()` so `TempRef::new_operand` was treating all ZSTs as `()`.
This should allow running Servo with `RUSTFLAGS=-Zorbit`, assuming there are no other bugs.
