### PR TITLE
Reflect supporting only LLVM 3.7+ in the LLVM wrappers

### DIFF
--- a/src/rustllvm/ArchiveWrapper.cpp
+++ b/src/rustllvm/ArchiveWrapper.cpp
@@ -32,7 +32,6 @@ struct LLVMRustArchiveMember {
 };
 
 typedef OwningBinary<Archive> RustArchive;
-#define GET_ARCHIVE(a) ((a)->getBinary())
 
 extern "C" void*
 LLVMRustOpenArchive(char *path) {
@@ -70,7 +69,7 @@ struct RustArchiveIterator {
 
 extern "C" RustArchiveIterator*
 LLVMRustArchiveIteratorNew(RustArchive *ra) {
-    Archive *ar = GET_ARCHIVE(ra);
+    Archive *ar = ra->getBinary();
     RustArchiveIterator *rai = new RustArchiveIterator();
     rai->cur = ar->child_begin();
     rai->end = ar->child_end();

--- a/src/rustllvm/ExecutionEngineWrapper.cpp
+++ b/src/rustllvm/ExecutionEngineWrapper.cpp
@@ -90,13 +90,8 @@ extern "C" LLVMExecutionEngineRef LLVMBuildExecutionEngine(LLVMModuleRef mod)
     RustJITMemoryManager *mm = new RustJITMemoryManager;
 
     ExecutionEngine *ee =
-    #if LLVM_VERSION_MINOR >= 6
         EngineBuilder(std::unique_ptr<Module>(unwrap(mod)))
             .setMCJITMemoryManager(std::unique_ptr<RustJITMemoryManager>(mm))
-    #else
-        EngineBuilder(unwrap(mod))
-            .setMCJITMemoryManager(mm)
-    #endif
             .setEngineKind(EngineKind::JIT)
             .setErrorStr(&error_str)
             .setTargetOptions(options)


### PR DESCRIPTION
Based on 12abddb06b681f5c1cb389074b5a35d3e260698f, it appears we can drop support for these older LLVM versions. Hopefully, this will make it slightly easier to support the changes needed for LLVM 3.9.

r? @nagisa 

/cc @brson 
