### PR TITLE
derive Hash (and not Copy) for ranges

### DIFF
--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -1475,7 +1475,7 @@ pub trait IndexMut<Idx: ?Sized>: Index<Idx> {
 ///     assert_eq!(arr[1..3], [  1,2  ]);
 /// }
 /// ```
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct RangeFull;
 
@@ -1506,7 +1506,7 @@ impl fmt::Debug for RangeFull {
 ///     assert_eq!(arr[1..3], [  1,2  ]);  // Range
 /// }
 /// ```
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Hash)]  // not Copy -- see #27186
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Range<Idx> {
     /// The lower bound of the range (inclusive).
@@ -1570,7 +1570,7 @@ impl<Idx: PartialOrd<Idx>> Range<Idx> {
 ///     assert_eq!(arr[1..3], [  1,2  ]);
 /// }
 /// ```
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Hash)]  // not Copy -- see #27186
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct RangeFrom<Idx> {
     /// The lower bound of the range (inclusive).
@@ -1619,7 +1619,7 @@ impl<Idx: PartialOrd<Idx>> RangeFrom<Idx> {
 ///     assert_eq!(arr[1..3], [  1,2  ]);
 /// }
 /// ```
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct RangeTo<Idx> {
     /// The upper bound of the range (exclusive).
@@ -1774,7 +1774,7 @@ impl<Idx: PartialOrd<Idx>> RangeInclusive<Idx> {
 ///     assert_eq!(arr[1...2], [  1,2  ]);
 /// }
 /// ```
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[unstable(feature = "inclusive_range", reason = "recently added, follows RFC", issue = "28237")]
 pub struct RangeToInclusive<Idx> {
     /// The upper bound of the range (inclusive)

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -1669,7 +1669,7 @@ impl<Idx: PartialOrd<Idx>> RangeTo<Idx> {
 ///     assert_eq!(arr[1...2], [  1,2  ]);  // RangeInclusive
 /// }
 /// ```
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Hash)]  // not Copy -- see #27186
 #[unstable(feature = "inclusive_range", reason = "recently added, follows RFC", issue = "28237")]
 pub enum RangeInclusive<Idx> {
     /// Empty range (iteration has finished)

--- a/src/test/compile-fail/range_traits-1.rs
+++ b/src/test/compile-fail/range_traits-1.rs
@@ -1,0 +1,92 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(inclusive_range)]
+
+use std::ops::*;
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+struct AllTheRanges {
+    a: Range<usize>,
+    //~^ ERROR PartialOrd
+    //~^^ ERROR PartialOrd
+    //~^^^ ERROR Ord
+    //~^^^^ ERROR binary operation
+    //~^^^^^ ERROR binary operation
+    //~^^^^^^ ERROR binary operation
+    //~^^^^^^^ ERROR binary operation
+    //~^^^^^^^^ ERROR binary operation
+    //~^^^^^^^^^ ERROR binary operation
+    //~^^^^^^^^^^ ERROR binary operation
+    //~^^^^^^^^^^^ ERROR binary operation
+    b: RangeTo<usize>,
+    //~^ ERROR PartialOrd
+    //~^^ ERROR PartialOrd
+    //~^^^ ERROR Ord
+    //~^^^^ ERROR binary operation
+    //~^^^^^ ERROR binary operation
+    //~^^^^^^ ERROR binary operation
+    //~^^^^^^^ ERROR binary operation
+    //~^^^^^^^^ ERROR binary operation
+    //~^^^^^^^^^ ERROR binary operation
+    //~^^^^^^^^^^ ERROR binary operation
+    //~^^^^^^^^^^^ ERROR binary operation
+    c: RangeFrom<usize>,
+    //~^ ERROR PartialOrd
+    //~^^ ERROR PartialOrd
+    //~^^^ ERROR Ord
+    //~^^^^ ERROR binary operation
+    //~^^^^^ ERROR binary operation
+    //~^^^^^^ ERROR binary operation
+    //~^^^^^^^ ERROR binary operation
+    //~^^^^^^^^ ERROR binary operation
+    //~^^^^^^^^^ ERROR binary operation
+    //~^^^^^^^^^^ ERROR binary operation
+    //~^^^^^^^^^^^ ERROR binary operation
+    d: RangeFull,
+    //~^ ERROR PartialOrd
+    //~^^ ERROR PartialOrd
+    //~^^^ ERROR Ord
+    //~^^^^ ERROR binary operation
+    //~^^^^^ ERROR binary operation
+    //~^^^^^^ ERROR binary operation
+    //~^^^^^^^ ERROR binary operation
+    //~^^^^^^^^ ERROR binary operation
+    //~^^^^^^^^^ ERROR binary operation
+    //~^^^^^^^^^^ ERROR binary operation
+    //~^^^^^^^^^^^ ERROR binary operation
+    e: RangeInclusive<usize>,
+    //~^ ERROR PartialOrd
+    //~^^ ERROR PartialOrd
+    //~^^^ ERROR Ord
+    //~^^^^ ERROR binary operation
+    //~^^^^^ ERROR binary operation
+    //~^^^^^^ ERROR binary operation
+    //~^^^^^^^ ERROR binary operation
+    //~^^^^^^^^ ERROR binary operation
+    //~^^^^^^^^^ ERROR binary operation
+    //~^^^^^^^^^^ ERROR binary operation
+    //~^^^^^^^^^^^ ERROR binary operation
+    f: RangeToInclusive<usize>,
+    //~^ ERROR PartialOrd
+    //~^^ ERROR PartialOrd
+    //~^^^ ERROR Ord
+    //~^^^^ ERROR binary operation
+    //~^^^^^ ERROR binary operation
+    //~^^^^^^ ERROR binary operation
+    //~^^^^^^^ ERROR binary operation
+    //~^^^^^^^^ ERROR binary operation
+    //~^^^^^^^^^ ERROR binary operation
+    //~^^^^^^^^^^ ERROR binary operation
+    //~^^^^^^^^^^^ ERROR binary operation
+}
+
+fn main() {}
+

--- a/src/test/compile-fail/range_traits-1.rs
+++ b/src/test/compile-fail/range_traits-1.rs
@@ -12,6 +12,7 @@
 
 use std::ops::*;
 
+// FIXME #34229 duplicated errors
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 struct AllTheRanges {
     a: Range<usize>,

--- a/src/test/compile-fail/range_traits-2.rs
+++ b/src/test/compile-fail/range_traits-2.rs
@@ -1,0 +1,17 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::ops::*;
+
+#[derive(Copy, Clone)] //~ ERROR Copy
+struct R(Range<usize>);
+
+fn main() {}
+

--- a/src/test/compile-fail/range_traits-3.rs
+++ b/src/test/compile-fail/range_traits-3.rs
@@ -1,0 +1,17 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::ops::*;
+
+#[derive(Copy, Clone)] //~ ERROR Copy
+struct R(RangeFrom<usize>);
+
+fn main() {}
+

--- a/src/test/compile-fail/range_traits-4.rs
+++ b/src/test/compile-fail/range_traits-4.rs
@@ -1,0 +1,20 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_attrs)]
+
+use std::ops::*;
+
+#[derive(Copy, Clone)]
+struct R(RangeTo<usize>);
+
+#[rustc_error]
+fn main() {} //~ ERROR success
+

--- a/src/test/compile-fail/range_traits-5.rs
+++ b/src/test/compile-fail/range_traits-5.rs
@@ -1,0 +1,20 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_attrs)]
+
+use std::ops::*;
+
+#[derive(Copy, Clone)]
+struct R(RangeFull);
+
+#[rustc_error]
+fn main() {} //~ ERROR success
+

--- a/src/test/compile-fail/range_traits-6.rs
+++ b/src/test/compile-fail/range_traits-6.rs
@@ -1,0 +1,19 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(inclusive_range)]
+
+use std::ops::*;
+
+#[derive(Copy, Clone)] //~ ERROR Copy
+struct R(RangeInclusive<usize>);
+
+fn main() {}
+

--- a/src/test/compile-fail/range_traits-7.rs
+++ b/src/test/compile-fail/range_traits-7.rs
@@ -1,0 +1,20 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_attrs, inclusive_range)]
+
+use std::ops::*;
+
+#[derive(Copy, Clone)]
+struct R(RangeToInclusive<usize>);
+
+#[rustc_error]
+fn main() {} //~ ERROR success
+


### PR DESCRIPTION
Fixes #34170.

Also, `RangeInclusive` was `Copy` by mistake -- fix that, which is a [breaking-change] to that unstable type.
