### PR TITLE
Fix UB in transmute

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -227,6 +227,7 @@
 #![feature(core_float)]
 #![feature(core_intrinsics)]
 #![feature(dropck_parametricity)]
+#![feature(drop_types_in_const)]
 #![feature(float_extras)]
 #![feature(float_from_str_radix)]
 #![feature(fnbox)]

--- a/src/libstd/sys/common/args.rs
+++ b/src/libstd/sys/common/args.rs
@@ -82,7 +82,7 @@ mod imp {
     }
 
     fn get_global_ptr() -> *mut Option<Box<Vec<Vec<u8>>>> {
-        unsafe { mem::transmute(&GLOBAL_ARGS_PTR) }
+        unsafe { mem::transmute(&mut GLOBAL_ARGS_PTR) }
     }
 
 }


### PR DESCRIPTION
The current code mutates through a `&` reference, this fixed that.

We could remove `get_global_ptr` and `transmute` entirely by using `#![feature(drop_types_in_const)]`, I'm not sure if this would be preferred.
