### PR TITLE
trans: generalize immediate temporaries to all MIR locals.

### DIFF
--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -144,6 +144,40 @@ impl<'tcx> Mir<'tcx> {
     pub fn predecessors_for(&self, bb: BasicBlock) -> Ref<Vec<BasicBlock>> {
         Ref::map(self.predecessors(), |p| &p[bb])
     }
+
+    /// Maps locals (Arg's, Var's, Temp's and ReturnPointer, in that order)
+    /// to their index in the whole list of locals. This is useful if you
+    /// want to treat all locals the same instead of repeating yourself.
+    pub fn local_index(&self, lvalue: &Lvalue<'tcx>) -> Option<Local> {
+        let idx = match *lvalue {
+            Lvalue::Arg(arg) => arg.index(),
+            Lvalue::Var(var) => {
+                self.arg_decls.len() +
+                var.index()
+            }
+            Lvalue::Temp(temp) => {
+                self.arg_decls.len() +
+                self.var_decls.len() +
+                temp.index()
+            }
+            Lvalue::ReturnPointer => {
+                self.arg_decls.len() +
+                self.var_decls.len() +
+                self.temp_decls.len()
+            }
+            Lvalue::Static(_) |
+            Lvalue::Projection(_) => return None
+        };
+        Some(Local::new(idx))
+    }
+
+    /// Counts the number of locals, such that that local_index
+    /// will always return an index smaller than this count.
+    pub fn count_locals(&self) -> usize {
+        self.arg_decls.len() +
+        self.var_decls.len() +
+        self.temp_decls.len() + 1
+    }
 }
 
 impl<'tcx> Index<BasicBlock> for Mir<'tcx> {
@@ -663,6 +697,7 @@ impl<'tcx> Debug for Statement<'tcx> {
 newtype_index!(Var, "var");
 newtype_index!(Temp, "tmp");
 newtype_index!(Arg, "arg");
+newtype_index!(Local, "local");
 
 /// A path to a value; something that can be evaluated without
 /// changing or disturbing program state.

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -492,6 +492,13 @@ impl<'tcx> FnOutput<'tcx> {
             ty::FnDiverging => def
         }
     }
+
+    pub fn maybe_converging(self) -> Option<Ty<'tcx>> {
+        match self {
+            ty::FnConverging(t) => Some(t),
+            ty::FnDiverging => None
+        }
+    }
 }
 
 pub type PolyFnOutput<'tcx> = Binder<FnOutput<'tcx>>;

--- a/src/librustc_trans/mir/analyze.rs
+++ b/src/librustc_trans/mir/analyze.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! An analysis to determine which temporaries require allocas and
+//! An analysis to determine which locals require allocas and
 //! which do not.
 
 use rustc_data_structures::bitvec::BitVector;
@@ -21,16 +21,20 @@ use common::{self, Block, BlockAndBuilder};
 use glue;
 use super::rvalue;
 
-pub fn lvalue_temps<'bcx,'tcx>(bcx: Block<'bcx,'tcx>,
-                               mir: &mir::Mir<'tcx>) -> BitVector {
+pub fn lvalue_locals<'bcx, 'tcx>(bcx: Block<'bcx,'tcx>,
+                                 mir: &mir::Mir<'tcx>) -> BitVector {
     let bcx = bcx.build();
-    let mut analyzer = TempAnalyzer::new(mir, &bcx, mir.temp_decls.len());
+    let mut analyzer = LocalAnalyzer::new(mir, &bcx);
 
     analyzer.visit_mir(mir);
 
-    for (index, temp_decl) in mir.temp_decls.iter().enumerate() {
-        let ty = bcx.monomorphize(&temp_decl.ty);
-        debug!("temp {:?} has type {:?}", index, ty);
+    let local_types = mir.arg_decls.iter().map(|a| a.ty)
+               .chain(mir.var_decls.iter().map(|v| v.ty))
+               .chain(mir.temp_decls.iter().map(|t| t.ty))
+               .chain(mir.return_ty.maybe_converging());
+    for (index, ty) in local_types.enumerate() {
+        let ty = bcx.monomorphize(&ty);
+        debug!("local {} has type {:?}", index, ty);
         if ty.is_scalar() ||
             ty.is_unique() ||
             ty.is_region_ptr() ||
@@ -50,64 +54,85 @@ pub fn lvalue_temps<'bcx,'tcx>(bcx: Block<'bcx,'tcx>,
             // (e.g. structs) into an alloca unconditionally, just so
             // that we don't have to deal with having two pathways
             // (gep vs extractvalue etc).
-            analyzer.mark_as_lvalue(index);
+            analyzer.mark_as_lvalue(mir::Local::new(index));
         }
     }
 
-    analyzer.lvalue_temps
+    analyzer.lvalue_locals
 }
 
-struct TempAnalyzer<'mir, 'bcx: 'mir, 'tcx: 'bcx> {
+struct LocalAnalyzer<'mir, 'bcx: 'mir, 'tcx: 'bcx> {
     mir: &'mir mir::Mir<'tcx>,
     bcx: &'mir BlockAndBuilder<'bcx, 'tcx>,
-    lvalue_temps: BitVector,
+    lvalue_locals: BitVector,
     seen_assigned: BitVector
 }
 
-impl<'mir, 'bcx, 'tcx> TempAnalyzer<'mir, 'bcx, 'tcx> {
+impl<'mir, 'bcx, 'tcx> LocalAnalyzer<'mir, 'bcx, 'tcx> {
     fn new(mir: &'mir mir::Mir<'tcx>,
-           bcx: &'mir BlockAndBuilder<'bcx, 'tcx>,
-           temp_count: usize) -> TempAnalyzer<'mir, 'bcx, 'tcx> {
-        TempAnalyzer {
+           bcx: &'mir BlockAndBuilder<'bcx, 'tcx>)
+           -> LocalAnalyzer<'mir, 'bcx, 'tcx> {
+        let local_count = mir.count_locals();
+        LocalAnalyzer {
             mir: mir,
             bcx: bcx,
-            lvalue_temps: BitVector::new(temp_count),
-            seen_assigned: BitVector::new(temp_count)
+            lvalue_locals: BitVector::new(local_count),
+            seen_assigned: BitVector::new(local_count)
         }
     }
 
-    fn mark_as_lvalue(&mut self, temp: usize) {
-        debug!("marking temp {} as lvalue", temp);
-        self.lvalue_temps.insert(temp);
+    fn mark_as_lvalue(&mut self, local: mir::Local) {
+        debug!("marking {:?} as lvalue", local);
+        self.lvalue_locals.insert(local.index());
     }
 
-    fn mark_assigned(&mut self, temp: usize) {
-        if !self.seen_assigned.insert(temp) {
-            self.mark_as_lvalue(temp);
+    fn mark_assigned(&mut self, local: mir::Local) {
+        if !self.seen_assigned.insert(local.index()) {
+            self.mark_as_lvalue(local);
         }
     }
 }
 
-impl<'mir, 'bcx, 'tcx> Visitor<'tcx> for TempAnalyzer<'mir, 'bcx, 'tcx> {
+impl<'mir, 'bcx, 'tcx> Visitor<'tcx> for LocalAnalyzer<'mir, 'bcx, 'tcx> {
     fn visit_assign(&mut self,
                     block: mir::BasicBlock,
                     lvalue: &mir::Lvalue<'tcx>,
                     rvalue: &mir::Rvalue<'tcx>) {
         debug!("visit_assign(block={:?}, lvalue={:?}, rvalue={:?})", block, lvalue, rvalue);
 
-        match *lvalue {
-            mir::Lvalue::Temp(temp) => {
-                self.mark_assigned(temp.index());
-                if !rvalue::rvalue_creates_operand(self.mir, self.bcx, rvalue) {
-                    self.mark_as_lvalue(temp.index());
-                }
+        if let Some(index) = self.mir.local_index(lvalue) {
+            self.mark_assigned(index);
+            if !rvalue::rvalue_creates_operand(self.mir, self.bcx, rvalue) {
+                self.mark_as_lvalue(index);
             }
-            _ => {
-                self.visit_lvalue(lvalue, LvalueContext::Store);
-            }
+        } else {
+            self.visit_lvalue(lvalue, LvalueContext::Store);
         }
 
         self.visit_rvalue(rvalue);
+    }
+
+    fn visit_terminator_kind(&mut self,
+                             block: mir::BasicBlock,
+                             kind: &mir::TerminatorKind<'tcx>) {
+        match *kind {
+            mir::TerminatorKind::Call {
+                func: mir::Operand::Constant(mir::Constant {
+                    literal: mir::Literal::Item { def_id, .. }, ..
+                }),
+                ref args, ..
+            } if Some(def_id) == self.bcx.tcx().lang_items.box_free_fn() => {
+                // box_free(x) shares with `drop x` the property that it
+                // is not guaranteed to be statically dominated by the
+                // definition of x, so x must always be in an alloca.
+                if let mir::Operand::Consume(ref lvalue) = args[0] {
+                    self.visit_lvalue(lvalue, LvalueContext::Drop);
+                }
+            }
+            _ => {}
+        }
+
+        self.super_terminator_kind(block, kind);
     }
 
     fn visit_lvalue(&mut self,
@@ -117,9 +142,9 @@ impl<'mir, 'bcx, 'tcx> Visitor<'tcx> for TempAnalyzer<'mir, 'bcx, 'tcx> {
 
         // Allow uses of projections of immediate pair fields.
         if let mir::Lvalue::Projection(ref proj) = *lvalue {
-            if let mir::Lvalue::Temp(temp) = proj.base {
-                let ty = self.mir.temp_decls[temp].ty;
-                let ty = self.bcx.monomorphize(&ty);
+            if self.mir.local_index(&proj.base).is_some() {
+                let ty = self.mir.lvalue_ty(self.bcx.tcx(), &proj.base);
+                let ty = self.bcx.monomorphize(&ty.to_ty(self.bcx.tcx()));
                 if common::type_is_imm_pair(self.bcx.ccx(), ty) {
                     if let mir::ProjectionElem::Field(..) = proj.elem {
                         if let LvalueContext::Consume = context {
@@ -130,33 +155,29 @@ impl<'mir, 'bcx, 'tcx> Visitor<'tcx> for TempAnalyzer<'mir, 'bcx, 'tcx> {
             }
         }
 
-        match *lvalue {
-            mir::Lvalue::Temp(temp) => {
-                match context {
-                    LvalueContext::Call => {
-                        self.mark_assigned(temp.index());
-                    }
-                    LvalueContext::Consume => {
-                    }
-                    LvalueContext::Store |
-                    LvalueContext::Inspect |
-                    LvalueContext::Borrow { .. } |
-                    LvalueContext::Slice { .. } |
-                    LvalueContext::Projection => {
-                        self.mark_as_lvalue(temp.index());
-                    }
-                    LvalueContext::Drop => {
-                        let ty = self.mir.temp_decls[index as usize].ty;
-                        let ty = self.bcx.monomorphize(&ty);
+        if let Some(index) = self.mir.local_index(lvalue) {
+            match context {
+                LvalueContext::Call => {
+                    self.mark_assigned(index);
+                }
+                LvalueContext::Consume => {
+                }
+                LvalueContext::Store |
+                LvalueContext::Inspect |
+                LvalueContext::Borrow { .. } |
+                LvalueContext::Slice { .. } |
+                LvalueContext::Projection => {
+                    self.mark_as_lvalue(index);
+                }
+                LvalueContext::Drop => {
+                    let ty = self.mir.lvalue_ty(self.bcx.tcx(), lvalue);
+                    let ty = self.bcx.monomorphize(&ty.to_ty(self.bcx.tcx()));
 
-                        // Only need the lvalue if we're actually dropping it.
-                        if glue::type_needs_drop(self.bcx.tcx(), ty) {
-                            self.mark_as_lvalue(index as usize);
-                        }
+                    // Only need the lvalue if we're actually dropping it.
+                    if glue::type_needs_drop(self.bcx.tcx(), ty) {
+                        self.mark_as_lvalue(index);
                     }
                 }
-            }
-            _ => {
             }
         }
 

--- a/src/librustc_trans/mir/analyze.rs
+++ b/src/librustc_trans/mir/analyze.rs
@@ -151,6 +151,13 @@ impl<'mir, 'bcx, 'tcx> Visitor<'tcx> for TempAnalyzer<'mir, 'bcx, 'tcx> {
             }
         }
 
+        // A deref projection only reads the pointer, never needs the lvalue.
+        if let mir::Lvalue::Projection(ref proj) = *lvalue {
+            if let mir::ProjectionElem::Deref = proj.elem {
+                return self.visit_lvalue(&proj.base, LvalueContext::Consume);
+            }
+        }
+
         self.super_lvalue(lvalue, context);
     }
 }

--- a/src/librustc_trans/mir/block.rs
+++ b/src/librustc_trans/mir/block.rs
@@ -32,7 +32,7 @@ use type_::Type;
 use rustc_data_structures::fnv::FnvHashMap;
 use syntax::parse::token;
 
-use super::{MirContext, TempRef};
+use super::{MirContext, LocalRef};
 use super::analyze::CleanupKind;
 use super::constant::Const;
 use super::lvalue::{LvalueRef, load_fat_ptr};
@@ -186,9 +186,43 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
             }
 
             mir::TerminatorKind::Return => {
-                bcx.with_block(|bcx| {
-                    self.fcx.build_return_block(bcx, debug_loc);
-                })
+                let ret = bcx.fcx().fn_ty.ret;
+                if ret.is_ignore() || ret.is_indirect() {
+                    bcx.ret_void();
+                    return;
+                }
+
+                let llval = if let Some(cast_ty) = ret.cast {
+                    let index = mir.local_index(&mir::Lvalue::ReturnPointer).unwrap();
+                    let op = match self.locals[index] {
+                        LocalRef::Operand(Some(op)) => op,
+                        LocalRef::Operand(None) => bug!("use of return before def"),
+                        LocalRef::Lvalue(tr_lvalue) => {
+                            OperandRef {
+                                val: Ref(tr_lvalue.llval),
+                                ty: tr_lvalue.ty.to_ty(bcx.tcx())
+                            }
+                        }
+                    };
+                    let llslot = match op.val {
+                        Immediate(_) | Pair(..) => {
+                            let llscratch = build::AllocaFcx(bcx.fcx(), ret.original_ty, "ret");
+                            self.store_operand(&bcx, llscratch, op);
+                            llscratch
+                        }
+                        Ref(llval) => llval
+                    };
+                    let load = bcx.load(bcx.pointercast(llslot, cast_ty.ptr_to()));
+                    let llalign = llalign_of_min(bcx.ccx(), ret.ty);
+                    unsafe {
+                        llvm::LLVMSetAlignment(load, llalign);
+                    }
+                    load
+                } else {
+                    let op = self.trans_consume(&bcx, &mir::Lvalue::ReturnPointer);
+                    op.pack_if_pair(&bcx).immediate()
+                };
+                bcx.ret(llval);
             }
 
             mir::TerminatorKind::Unreachable => {
@@ -537,7 +571,7 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
 
     fn trans_argument(&mut self,
                       bcx: &BlockAndBuilder<'bcx, 'tcx>,
-                      mut op: OperandRef<'tcx>,
+                      op: OperandRef<'tcx>,
                       llargs: &mut Vec<ValueRef>,
                       fn_ty: &FnType,
                       next_idx: &mut usize,
@@ -565,8 +599,6 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                 self.trans_argument(bcx, imm_op(meta), llargs, fn_ty, next_idx, callee);
                 return;
             }
-
-            op = op.pack_if_pair(bcx);
         }
 
         let arg = &fn_ty.args[*next_idx];
@@ -583,14 +615,16 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
 
         // Force by-ref if we have to load through a cast pointer.
         let (mut llval, by_ref) = match op.val {
-            Immediate(llval) if arg.is_indirect() || arg.cast.is_some() => {
-                let llscratch = build::AllocaFcx(bcx.fcx(), arg.original_ty, "arg");
-                bcx.store(llval, llscratch);
-                (llscratch, true)
+            Immediate(_) | Pair(..) => {
+                if arg.is_indirect() || arg.cast.is_some() {
+                    let llscratch = build::AllocaFcx(bcx.fcx(), arg.original_ty, "arg");
+                    self.store_operand(bcx, llscratch, op);
+                    (llscratch, true)
+                } else {
+                    (op.pack_if_pair(bcx).immediate(), false)
+                }
             }
-            Immediate(llval) => (llval, false),
-            Ref(llval) => (llval, true),
-            Pair(..) => bug!("pairs handled above")
+            Ref(llval) => (llval, true)
         };
 
         if by_ref && !arg.is_indirect() {
@@ -776,40 +810,39 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
         if fn_ret_ty.is_ignore() {
             return ReturnDest::Nothing;
         }
-        let dest = match *dest {
-            mir::Lvalue::Temp(idx) => {
-                let ret_ty = self.lvalue_ty(dest);
-                match self.temps[idx] {
-                    TempRef::Lvalue(dest) => dest,
-                    TempRef::Operand(None) => {
-                        // Handle temporary lvalues, specifically Operand ones, as
-                        // they don't have allocas
-                        return if fn_ret_ty.is_indirect() {
-                            // Odd, but possible, case, we have an operand temporary,
-                            // but the calling convention has an indirect return.
-                            let tmp = bcx.with_block(|bcx| {
-                                base::alloc_ty(bcx, ret_ty, "tmp_ret")
-                            });
-                            llargs.push(tmp);
-                            ReturnDest::IndirectOperand(tmp, idx)
-                        } else if is_intrinsic {
-                            // Currently, intrinsics always need a location to store
-                            // the result. so we create a temporary alloca for the
-                            // result
-                            let tmp = bcx.with_block(|bcx| {
-                                base::alloc_ty(bcx, ret_ty, "tmp_ret")
-                            });
-                            ReturnDest::IndirectOperand(tmp, idx)
-                        } else {
-                            ReturnDest::DirectOperand(idx)
-                        };
-                    }
-                    TempRef::Operand(Some(_)) => {
-                        bug!("lvalue temp already assigned to");
-                    }
+        let dest = if let Some(index) = self.mir.local_index(dest) {
+            let ret_ty = self.lvalue_ty(dest);
+            match self.locals[index] {
+                LocalRef::Lvalue(dest) => dest,
+                LocalRef::Operand(None) => {
+                    // Handle temporary lvalues, specifically Operand ones, as
+                    // they don't have allocas
+                    return if fn_ret_ty.is_indirect() {
+                        // Odd, but possible, case, we have an operand temporary,
+                        // but the calling convention has an indirect return.
+                        let tmp = bcx.with_block(|bcx| {
+                            base::alloc_ty(bcx, ret_ty, "tmp_ret")
+                        });
+                        llargs.push(tmp);
+                        ReturnDest::IndirectOperand(tmp, index)
+                    } else if is_intrinsic {
+                        // Currently, intrinsics always need a location to store
+                        // the result. so we create a temporary alloca for the
+                        // result
+                        let tmp = bcx.with_block(|bcx| {
+                            base::alloc_ty(bcx, ret_ty, "tmp_ret")
+                        });
+                        ReturnDest::IndirectOperand(tmp, index)
+                    } else {
+                        ReturnDest::DirectOperand(index)
+                    };
+                }
+                LocalRef::Operand(Some(_)) => {
+                    bug!("lvalue local already assigned to");
                 }
             }
-            _ => self.trans_lvalue(bcx, dest)
+        } else {
+            self.trans_lvalue(bcx, dest)
         };
         if fn_ret_ty.is_indirect() {
             llargs.push(dest.llval);
@@ -853,11 +886,11 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
         match dest {
             Nothing => (),
             Store(dst) => ret_ty.store(bcx, op.immediate(), dst),
-            IndirectOperand(tmp, idx) => {
+            IndirectOperand(tmp, index) => {
                 let op = self.trans_load(bcx, tmp, op.ty);
-                self.temps[idx] = TempRef::Operand(Some(op));
+                self.locals[index] = LocalRef::Operand(Some(op));
             }
-            DirectOperand(idx) => {
+            DirectOperand(index) => {
                 // If there is a cast, we have to store and reload.
                 let op = if ret_ty.cast.is_some() {
                     let tmp = bcx.with_block(|bcx| {
@@ -868,7 +901,7 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                 } else {
                     op.unpack_if_pair(bcx)
                 };
-                self.temps[idx] = TempRef::Operand(Some(op));
+                self.locals[index] = LocalRef::Operand(Some(op));
             }
         }
     }
@@ -879,8 +912,8 @@ enum ReturnDest {
     Nothing,
     // Store the return value to the pointer
     Store(ValueRef),
-    // Stores an indirect return value to an operand temporary lvalue
-    IndirectOperand(ValueRef, mir::Temp),
-    // Stores a direct return value to an operand temporary lvalue
-    DirectOperand(mir::Temp)
+    // Stores an indirect return value to an operand local lvalue
+    IndirectOperand(ValueRef, mir::Local),
+    // Stores a direct return value to an operand local lvalue
+    DirectOperand(mir::Local)
 }

--- a/src/librustc_trans/mir/operand.rs
+++ b/src/librustc_trans/mir/operand.rs
@@ -21,7 +21,7 @@ use type_::Type;
 
 use std::fmt;
 
-use super::{MirContext, TempRef};
+use super::{MirContext, LocalRef};
 
 /// The representation of a Rust value. The enum variant is in fact
 /// uniquely determined by the value's type, but is kept as a
@@ -112,6 +112,8 @@ impl<'bcx, 'tcx> OperandRef<'tcx> {
         if let OperandValue::Immediate(llval) = self.val {
             // Deconstruct the immediate aggregate.
             if common::type_is_imm_pair(bcx.ccx(), self.ty) {
+                debug!("Operand::unpack_if_pair: unpacking {:?}", self);
+
                 let mut a = bcx.extract_value(llval, 0);
                 let mut b = bcx.extract_value(llval, 1);
 
@@ -171,17 +173,17 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
     {
         debug!("trans_consume(lvalue={:?})", lvalue);
 
-        // watch out for temporaries that do not have an
+        // watch out for locals that do not have an
         // alloca; they are handled somewhat differently
-        if let &mir::Lvalue::Temp(index) = lvalue {
-            match self.temps[index] {
-                TempRef::Operand(Some(o)) => {
+        if let Some(index) = self.mir.local_index(lvalue) {
+            match self.locals[index] {
+                LocalRef::Operand(Some(o)) => {
                     return o;
                 }
-                TempRef::Operand(None) => {
+                LocalRef::Operand(None) => {
                     bug!("use of {:?} before def", lvalue);
                 }
-                TempRef::Lvalue(..) => {
+                LocalRef::Lvalue(..) => {
                     // use path below
                 }
             }
@@ -189,9 +191,8 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
 
         // Moves out of pair fields are trivial.
         if let &mir::Lvalue::Projection(ref proj) = lvalue {
-            if let mir::Lvalue::Temp(index) = proj.base {
-                let temp_ref = &self.temps[index];
-                if let &TempRef::Operand(Some(o)) = temp_ref {
+            if let Some(index) = self.mir.local_index(&proj.base) {
+                if let LocalRef::Operand(Some(o)) = self.locals[index] {
                     match (o.val, &proj.elem) {
                         (OperandValue::Pair(a, b),
                          &mir::ProjectionElem::Field(ref f, ty)) => {

--- a/src/librustc_trans/mir/operand.rs
+++ b/src/librustc_trans/mir/operand.rs
@@ -164,6 +164,56 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
         OperandRef { val: val, ty: ty }
     }
 
+    pub fn trans_consume(&mut self,
+                         bcx: &BlockAndBuilder<'bcx, 'tcx>,
+                         lvalue: &mir::Lvalue<'tcx>)
+                         -> OperandRef<'tcx>
+    {
+        debug!("trans_consume(lvalue={:?})", lvalue);
+
+        // watch out for temporaries that do not have an
+        // alloca; they are handled somewhat differently
+        if let &mir::Lvalue::Temp(index) = lvalue {
+            match self.temps[index] {
+                TempRef::Operand(Some(o)) => {
+                    return o;
+                }
+                TempRef::Operand(None) => {
+                    bug!("use of {:?} before def", lvalue);
+                }
+                TempRef::Lvalue(..) => {
+                    // use path below
+                }
+            }
+        }
+
+        // Moves out of pair fields are trivial.
+        if let &mir::Lvalue::Projection(ref proj) = lvalue {
+            if let mir::Lvalue::Temp(index) = proj.base {
+                let temp_ref = &self.temps[index];
+                if let &TempRef::Operand(Some(o)) = temp_ref {
+                    match (o.val, &proj.elem) {
+                        (OperandValue::Pair(a, b),
+                         &mir::ProjectionElem::Field(ref f, ty)) => {
+                            let llval = [a, b][f.index()];
+                            return OperandRef {
+                                val: OperandValue::Immediate(llval),
+                                ty: bcx.monomorphize(&ty)
+                            };
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        // for most lvalues, to consume them we just load them
+        // out from their home
+        let tr_lvalue = self.trans_lvalue(bcx, lvalue);
+        let ty = tr_lvalue.ty.to_ty(bcx.tcx());
+        self.trans_load(bcx, tr_lvalue.llval, ty)
+    }
+
     pub fn trans_operand(&mut self,
                          bcx: &BlockAndBuilder<'bcx, 'tcx>,
                          operand: &mir::Operand<'tcx>)
@@ -173,47 +223,7 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
 
         match *operand {
             mir::Operand::Consume(ref lvalue) => {
-                // watch out for temporaries that do not have an
-                // alloca; they are handled somewhat differently
-                if let &mir::Lvalue::Temp(index) = lvalue {
-                    match self.temps[index] {
-                        TempRef::Operand(Some(o)) => {
-                            return o;
-                        }
-                        TempRef::Operand(None) => {
-                            bug!("use of {:?} before def", lvalue);
-                        }
-                        TempRef::Lvalue(..) => {
-                            // use path below
-                        }
-                    }
-                }
-
-                // Moves out of pair fields are trivial.
-                if let &mir::Lvalue::Projection(ref proj) = lvalue {
-                    if let mir::Lvalue::Temp(index) = proj.base {
-                        let temp_ref = &self.temps[index];
-                        if let &TempRef::Operand(Some(o)) = temp_ref {
-                            match (o.val, &proj.elem) {
-                                (OperandValue::Pair(a, b),
-                                 &mir::ProjectionElem::Field(ref f, ty)) => {
-                                    let llval = [a, b][f.index()];
-                                    return OperandRef {
-                                        val: OperandValue::Immediate(llval),
-                                        ty: bcx.monomorphize(&ty)
-                                    };
-                                }
-                                _ => {}
-                            }
-                        }
-                    }
-                }
-
-                // for most lvalues, to consume them we just load them
-                // out from their home
-                let tr_lvalue = self.trans_lvalue(bcx, lvalue);
-                let ty = tr_lvalue.ty.to_ty(bcx.tcx());
-                self.trans_load(bcx, tr_lvalue.llval, ty)
+                self.trans_consume(bcx, lvalue)
             }
 
             mir::Operand::Constant(ref constant) => {

--- a/src/librustc_trans/mir/statement.rs
+++ b/src/librustc_trans/mir/statement.rs
@@ -13,7 +13,7 @@ use rustc::mir::repr as mir;
 use common::{self, BlockAndBuilder};
 
 use super::MirContext;
-use super::TempRef;
+use super::LocalRef;
 
 impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
     pub fn trans_statement(&mut self,
@@ -27,37 +27,34 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
         debug_loc.apply(bcx.fcx());
         match statement.kind {
             mir::StatementKind::Assign(ref lvalue, ref rvalue) => {
-                match *lvalue {
-                    mir::Lvalue::Temp(index) => {
-                        match self.temps[index] {
-                            TempRef::Lvalue(tr_dest) => {
-                                self.trans_rvalue(bcx, tr_dest, rvalue, debug_loc)
-                            }
-                            TempRef::Operand(None) => {
-                                let (bcx, operand) = self.trans_rvalue_operand(bcx, rvalue,
-                                                                               debug_loc);
-                                self.temps[index] = TempRef::Operand(Some(operand));
-                                bcx
-                            }
-                            TempRef::Operand(Some(_)) => {
-                                let ty = self.lvalue_ty(lvalue);
+                if let Some(index) = self.mir.local_index(lvalue) {
+                    match self.locals[index] {
+                        LocalRef::Lvalue(tr_dest) => {
+                            self.trans_rvalue(bcx, tr_dest, rvalue, debug_loc)
+                        }
+                        LocalRef::Operand(None) => {
+                            let (bcx, operand) = self.trans_rvalue_operand(bcx, rvalue,
+                                                                           debug_loc);
+                            self.locals[index] = LocalRef::Operand(Some(operand));
+                            bcx
+                        }
+                        LocalRef::Operand(Some(_)) => {
+                            let ty = self.lvalue_ty(lvalue);
 
-                                if !common::type_is_zero_size(bcx.ccx(), ty) {
-                                    span_bug!(statement.source_info.span,
-                                              "operand {:?} already assigned",
-                                              rvalue);
-                                } else {
-                                    // If the type is zero-sized, it's already been set here,
-                                    // but we still need to make sure we translate the operand
-                                    self.trans_rvalue_operand(bcx, rvalue, debug_loc).0
-                                }
+                            if !common::type_is_zero_size(bcx.ccx(), ty) {
+                                span_bug!(statement.source_info.span,
+                                          "operand {:?} already assigned",
+                                          rvalue);
+                            } else {
+                                // If the type is zero-sized, it's already been set here,
+                                // but we still need to make sure we translate the operand
+                                self.trans_rvalue_operand(bcx, rvalue, debug_loc).0
                             }
                         }
                     }
-                    _ => {
-                        let tr_dest = self.trans_lvalue(&bcx, lvalue);
-                        self.trans_rvalue(bcx, tr_dest, rvalue, debug_loc)
-                    }
+                } else {
+                    let tr_dest = self.trans_lvalue(&bcx, lvalue);
+                    self.trans_rvalue(bcx, tr_dest, rvalue, debug_loc)
                 }
             }
         }

--- a/src/test/codegen/loads.rs
+++ b/src/test/codegen/loads.rs
@@ -11,6 +11,7 @@
 // compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
+#![feature(rustc_attrs)]
 
 pub struct Bytes {
   a: u8,
@@ -21,6 +22,7 @@ pub struct Bytes {
 
 // CHECK-LABEL: @borrow
 #[no_mangle]
+#[rustc_no_mir] // FIXME #27840 MIR has different codegen.
 pub fn borrow(x: &i32) -> &i32 {
 // CHECK: load {{(i32\*, )?}}i32** %x{{.*}}, !nonnull
     x
@@ -28,6 +30,7 @@ pub fn borrow(x: &i32) -> &i32 {
 
 // CHECK-LABEL: @_box
 #[no_mangle]
+#[rustc_no_mir] // FIXME #27840 MIR has different codegen.
 pub fn _box(x: Box<i32>) -> i32 {
 // CHECK: load {{(i32\*, )?}}i32** %x{{.*}}, !nonnull
     *x

--- a/src/test/codegen/naked-functions.rs
+++ b/src/test/codegen/naked-functions.rs
@@ -13,7 +13,7 @@
 // compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-#![feature(naked_functions)]
+#![feature(naked_functions, rustc_attrs)]
 
 // CHECK: Function Attrs: naked uwtable
 // CHECK-NEXT: define internal void @naked_empty()
@@ -26,6 +26,7 @@ fn naked_empty() {
 // CHECK: Function Attrs: naked uwtable
 #[no_mangle]
 #[naked]
+#[rustc_no_mir] // FIXME #27840 MIR has different codegen.
 // CHECK-NEXT: define internal void @naked_with_args(i{{[0-9]+}})
 fn naked_with_args(a: isize) {
     // CHECK: %a = alloca i{{[0-9]+}}
@@ -45,6 +46,7 @@ fn naked_with_return() -> isize {
 // CHECK-NEXT: define internal i{{[0-9]+}} @naked_with_args_and_return(i{{[0-9]+}})
 #[no_mangle]
 #[naked]
+#[rustc_no_mir] // FIXME #27840 MIR has different codegen.
 fn naked_with_args_and_return(a: isize) -> isize {
     // CHECK: %a = alloca i{{[0-9]+}}
     // CHECK: ret i{{[0-9]+}} %{{[0-9]+}}

--- a/src/test/compile-fail/issue-26548.rs
+++ b/src/test/compile-fail/issue-26548.rs
@@ -10,10 +10,13 @@
 
 // error-pattern: overflow representing the type `S`
 
+#![feature(rustc_attrs)]
+
 trait Mirror { type It: ?Sized; }
 impl<T: ?Sized> Mirror for T { type It = Self; }
 struct S(Option<<S as Mirror>::It>);
 
+#[rustc_no_mir] // FIXME #27840 MIR tries to represent `std::option::Option<S>` first.
 fn main() {
     let _s = S(None);
 }


### PR DESCRIPTION
Added `Mir::local_index` which gives you an unified index for `Arg`, `Var`, `Temp` and `ReturnPointer`.
Also available is `Mir::count_locals` which returns the total number of the above locals.
This simplifies a lot of the code which can treat all of the local lvalues in the same manner.
If we had `-> impl Iterator`, I could have added a bunch of useful `Ty` or `Lvalue` iterators for all locals.
We could of course manually write such iterators as they are needed.

The only place which currently takes advantage of unified locals is trans' alloca elision.
Currently it's not as good as it could be, due to our usage of `llvm.dbg.declare` in debug mode.
But passing some arguments and variables as immediates has some effect on release-mode `libsyntax`:

Old trans:

```
time: 11.500; rss: 710MB        translation
time: 0.002; rss: 710MB assert dep graph
time: 0.000; rss: 710MB serialize dep graph
  time: 4.410; rss: 628MB       llvm function passes [0]
  time: 84.485; rss: 633MB      llvm module passes [0]
  time: 23.898; rss: 634MB      codegen passes [0]
  time: 0.002; rss: 634MB       codegen passes [0]
time: 113.408; rss: 634MB       LLVM passes
```

`-Z orbit`, previously:

```
time: 12.588; rss: 723MB        translation
time: 0.002; rss: 723MB assert dep graph
time: 0.000; rss: 723MB serialize dep graph
  time: 4.597; rss: 642MB       llvm function passes [0]
  time: 77.347; rss: 646MB      llvm module passes [0]
  time: 24.703; rss: 648MB      codegen passes [0]
  time: 0.002; rss: 615MB       codegen passes [0]
time: 107.233; rss: 615MB       LLVM passes
```

`-Z orbit`, after this PR:

```
time: 13.820; rss: 672MB        translation
time: 0.002; rss: 672MB assert dep graph
time: 0.000; rss: 672MB serialize dep graph
  time: 3.969; rss: 591MB       llvm function passes [0]
  time: 72.294; rss: 595MB      llvm module passes [0]
  time: 24.610; rss: 597MB      codegen passes [0]
  time: 0.002; rss: 597MB       codegen passes [0]
time: 101.439; rss: 597MB       LLVM passes
```
