### PR TITLE
Implement PartialEq for std::io::Error

### DIFF
--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -279,6 +279,16 @@ impl Error {
     }
 }
 
+#[stable(feature = "error_partial_eq", since = "1.11.0")]
+impl PartialEq for Error {
+    fn eq(&self, other: &Error) -> bool {
+        match (&self.repr, &other.repr) {
+            (&Repr::Os(code), &Repr::Os(other)) => code == other,
+            _ => false,
+        }
+    }
+}
+
 impl fmt::Debug for Repr {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -353,6 +363,21 @@ mod test {
     use fmt;
     use sys::os::error_string;
 
+    #[derive(Debug)]
+    struct TestError;
+
+    impl fmt::Display for TestError {
+        fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
+            Ok(())
+        }
+    }
+
+    impl error::Error for TestError {
+        fn description(&self) -> &str {
+            "asdf"
+        }
+    }
+
     #[test]
     fn test_debug_error() {
         let code = 6;
@@ -363,22 +388,18 @@ mod test {
     }
 
     #[test]
+    fn test_partial_eq() {
+        let code = 6;
+        let err = Error { repr: super::Repr::Os(code) };
+        let err2 = Error { repr: super::Repr::Os(code) };
+        assert_eq!(err, err2);
+
+        let err = Error::new(ErrorKind::Other, TestError);
+        assert!(err != err);
+    }
+
+    #[test]
     fn test_downcasting() {
-        #[derive(Debug)]
-        struct TestError;
-
-        impl fmt::Display for TestError {
-            fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
-                Ok(())
-            }
-        }
-
-        impl error::Error for TestError {
-            fn description(&self) -> &str {
-                "asdf"
-            }
-        }
-
         // we have to call all of these UFCS style right now since method
         // resolution won't implicitly drop the Send+Sync bounds
         let mut err = Error::new(ErrorKind::Other, TestError);


### PR DESCRIPTION
It would be very useful to be able to write the following, in order to
be able to use `==`, `!=`, and `assert_eq!` for tesing if a particular
error corresponds to a given variant of our error type:

```
#[derive(Debug, PartialEq)]
enum MyError {
    Foo,
    Bar,
    Io(std::io::Error),
}
```

To do this, `PartialEq` needs to be implemented on `std::io::Error`.  We
can't derive `PartialEq` on std::io::Error itself, because it has a
`Custom` variant that contains a trait object which doesn't have the
`PartialEq` constraint.

However, `PartialEq` is a partial equality relation, so it doesn't need
to be able to compare all variants.  We can implement it only for the
`Os` variant, and simply return `false` for all `Custom` variants.

Closes #34158
