### PR TITLE
Check error index in `make check`

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -276,6 +276,7 @@ check-stage$(1)-T-$(2)-H-$(3)-exec: \
 	check-stage$(1)-T-$(2)-H-$(3)-incremental-exec \
 	check-stage$(1)-T-$(2)-H-$(3)-ui-exec \
 	check-stage$(1)-T-$(2)-H-$(3)-doc-exec \
+	check-stage$(1)-T-$(2)-H-$(3)-doc-error-index-exec \
 	check-stage$(1)-T-$(2)-H-$(3)-pretty-exec
 
 ifndef CFG_DISABLE_CODEGEN_TESTS


### PR DESCRIPTION
This was checked in rustbuild but not in `make check`, causing passed-Travis-but-failed-Buildbot.
