### PR TITLE
Make `private_in_public` compatibility lint deny-by-default

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -114,7 +114,7 @@ declare_lint! {
 
 declare_lint! {
     pub PRIVATE_IN_PUBLIC,
-    Warn,
+    Deny,
     "detect private items in public interfaces not caught by the old implementation"
 }
 

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -157,7 +157,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
     store.register_future_incompatible(sess, vec![
         FutureIncompatibleInfo {
             id: LintId::of(PRIVATE_IN_PUBLIC),
-            reference: "the explanation for E0446 (`--explain E0446`)",
+            reference: "issue #34537 <https://github.com/rust-lang/rust/issues/34537>",
         },
         FutureIncompatibleInfo {
             id: LintId::of(INACCESSIBLE_EXTERN_CRATE),

--- a/src/librustc_privacy/diagnostics.rs
+++ b/src/librustc_privacy/diagnostics.rs
@@ -17,8 +17,6 @@ A private trait was used on a public type parameter bound. Erroneous code
 examples:
 
 ```compile_fail,E0445
-#![deny(private_in_public)]
-
 trait Foo {
     fn dummy(&self) { }
 }
@@ -47,8 +45,6 @@ E0446: r##"
 A private type was used in a public type signature. Erroneous code example:
 
 ```compile_fail,E0446
-#![deny(private_in_public)]
-
 mod Foo {
     struct Bar(u32);
 

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -938,7 +938,8 @@ impl<'a, 'tcx: 'a, 'v> Visitor<'v> for SearchInterfaceForPrivateItemsVisitor<'a,
                                 self.tcx.sess.add_lint(lint::builtin::PRIVATE_IN_PUBLIC,
                                                        node_id,
                                                        ty.span,
-                                                       format!("private type in public interface"));
+                                                       format!("private type in public \
+                                                                interface (error E0446)"));
                             }
                         }
                     }

--- a/src/test/compile-fail/issue-28514.rs
+++ b/src/test/compile-fail/issue-28514.rs
@@ -1,0 +1,45 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub use inner::C;
+
+mod inner {
+    trait A {
+        fn a(&self) { }
+    }
+
+    pub trait B {
+        fn b(&self) { }
+    }
+
+    pub trait C: A + B { //~ ERROR private trait in public interface
+                         //~^ WARN will become a hard error
+        fn c(&self) { }
+    }
+
+    impl A for i32 {}
+    impl B for i32 {}
+    impl C for i32 {}
+
+}
+
+fn main() {
+    // A is private
+    // B is pub, not reexported
+    // C : A + B is pub, reexported
+
+    // 0.a(); // can't call
+    // 0.b(); // can't call
+    0.c(); // ok
+
+    C::a(&0); // can call
+    C::b(&0); // can call
+    C::c(&0); // ok
+}

--- a/src/test/compile-fail/issue-30079.rs
+++ b/src/test/compile-fail/issue-30079.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(rustc_attrs)]
 #![allow(unused)]
 
 struct SemiPriv;
@@ -16,7 +15,7 @@ struct SemiPriv;
 mod m1 {
     struct Priv;
     impl ::SemiPriv {
-        pub fn f(_: Priv) {} //~ WARN private type in public interface
+        pub fn f(_: Priv) {} //~ ERROR private type in public interface
         //~^ WARNING hard error
     }
 
@@ -28,7 +27,7 @@ mod m1 {
 mod m2 {
     struct Priv;
     impl ::std::ops::Deref for ::SemiPriv {
-        type Target = Priv; //~ WARN private type in public interface
+        type Target = Priv; //~ ERROR private type in public interface
         //~^ WARNING hard error
         fn deref(&self) -> &Self::Target { unimplemented!() }
     }
@@ -46,10 +45,9 @@ trait SemiPrivTrait {
 mod m3 {
     struct Priv;
     impl ::SemiPrivTrait for () {
-        type Assoc = Priv; //~ WARN private type in public interface
+        type Assoc = Priv; //~ ERROR private type in public interface
         //~^ WARNING hard error
     }
 }
 
-#[rustc_error]
-fn main() {} //~ ERROR compilation successful
+fn main() {}

--- a/src/test/compile-fail/private-in-public-lint.rs
+++ b/src/test/compile-fail/private-in-public-lint.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 mod m1 {
-    #![deny(private_in_public)]
-
     pub struct Pub;
     struct Priv;
 

--- a/src/test/compile-fail/private-in-public-warn.rs
+++ b/src/test/compile-fail/private-in-public-warn.rs
@@ -11,7 +11,6 @@
 // Private types and traits are not allowed in public interfaces.
 // This test also ensures that the checks are performed even inside private modules.
 
-#![feature(rustc_attrs)]
 #![feature(associated_consts)]
 #![feature(associated_type_defaults)]
 #![allow(dead_code)]
@@ -25,34 +24,34 @@ mod types {
         type Alias;
     }
 
-    pub type Alias = Priv; //~ WARN private type in public interface
+    pub type Alias = Priv; //~ ERROR private type in public interface
     //~^ WARNING hard error
     pub enum E {
-        V1(Priv), //~ WARN private type in public interface
+        V1(Priv), //~ ERROR private type in public interface
         //~^ WARNING hard error
-        V2 { field: Priv }, //~ WARN private type in public interface
+        V2 { field: Priv }, //~ ERROR private type in public interface
         //~^ WARNING hard error
     }
     pub trait Tr {
-        const C: Priv = Priv; //~ WARN private type in public interface
+        const C: Priv = Priv; //~ ERROR private type in public interface
         //~^ WARNING hard error
-        type Alias = Priv; //~ WARN private type in public interface
+        type Alias = Priv; //~ ERROR private type in public interface
         //~^ WARNING hard error
-        fn f1(arg: Priv) {} //~ WARN private type in public interface
+        fn f1(arg: Priv) {} //~ ERROR private type in public interface
         //~^ WARNING hard error
-        fn f2() -> Priv { panic!() } //~ WARN private type in public interface
+        fn f2() -> Priv { panic!() } //~ ERROR private type in public interface
         //~^ WARNING hard error
     }
     extern {
-        pub static ES: Priv; //~ WARN private type in public interface
+        pub static ES: Priv; //~ ERROR private type in public interface
         //~^ WARNING hard error
-        pub fn ef1(arg: Priv); //~ WARN private type in public interface
+        pub fn ef1(arg: Priv); //~ ERROR private type in public interface
         //~^ WARNING hard error
-        pub fn ef2() -> Priv; //~ WARN private type in public interface
+        pub fn ef2() -> Priv; //~ ERROR private type in public interface
         //~^ WARNING hard error
     }
     impl PubTr for Pub {
-        type Alias = Priv; //~ WARN private type in public interface
+        type Alias = Priv; //~ ERROR private type in public interface
         //~^ WARNING hard error
     }
 }
@@ -62,22 +61,22 @@ mod traits {
     pub struct Pub<T>(T);
     pub trait PubTr {}
 
-    pub type Alias<T: PrivTr> = T; //~ WARN private trait in public interface
+    pub type Alias<T: PrivTr> = T; //~ ERROR private trait in public interface
     //~^ WARN trait bounds are not (yet) enforced in type definitions
     //~| WARNING hard error
-    pub trait Tr1: PrivTr {} //~ WARN private trait in public interface
+    pub trait Tr1: PrivTr {} //~ ERROR private trait in public interface
     //~^ WARNING hard error
-    pub trait Tr2<T: PrivTr> {} //~ WARN private trait in public interface
+    pub trait Tr2<T: PrivTr> {} //~ ERROR private trait in public interface
         //~^ WARNING hard error
     pub trait Tr3 {
-        type Alias: PrivTr; //~ WARN private trait in public interface
+        type Alias: PrivTr; //~ ERROR private trait in public interface
         //~^ WARNING hard error
-        fn f<T: PrivTr>(arg: T) {} //~ WARN private trait in public interface
+        fn f<T: PrivTr>(arg: T) {} //~ ERROR private trait in public interface
         //~^ WARNING hard error
     }
-    impl<T: PrivTr> Pub<T> {} //~ WARN private trait in public interface
+    impl<T: PrivTr> Pub<T> {} //~ ERROR private trait in public interface
         //~^ WARNING hard error
-    impl<T: PrivTr> PubTr for Pub<T> {} //~ WARN private trait in public interface
+    impl<T: PrivTr> PubTr for Pub<T> {} //~ ERROR private trait in public interface
         //~^ WARNING hard error
 }
 
@@ -86,17 +85,17 @@ mod traits_where {
     pub struct Pub<T>(T);
     pub trait PubTr {}
 
-    pub type Alias<T> where T: PrivTr = T; //~ WARN private trait in public interface
+    pub type Alias<T> where T: PrivTr = T; //~ ERROR private trait in public interface
         //~^ WARNING hard error
-    pub trait Tr2<T> where T: PrivTr {} //~ WARN private trait in public interface
+    pub trait Tr2<T> where T: PrivTr {} //~ ERROR private trait in public interface
         //~^ WARNING hard error
     pub trait Tr3 {
-        fn f<T>(arg: T) where T: PrivTr {} //~ WARN private trait in public interface
+        fn f<T>(arg: T) where T: PrivTr {} //~ ERROR private trait in public interface
         //~^ WARNING hard error
     }
-    impl<T> Pub<T> where T: PrivTr {} //~ WARN private trait in public interface
+    impl<T> Pub<T> where T: PrivTr {} //~ ERROR private trait in public interface
         //~^ WARNING hard error
-    impl<T> PubTr for Pub<T> where T: PrivTr {} //~ WARN private trait in public interface
+    impl<T> PubTr for Pub<T> where T: PrivTr {} //~ ERROR private trait in public interface
         //~^ WARNING hard error
 }
 
@@ -106,13 +105,13 @@ mod generics {
     trait PrivTr<T> {}
     pub trait PubTr<T> {}
 
-    pub trait Tr1: PrivTr<Pub> {} //~ WARN private trait in public interface
+    pub trait Tr1: PrivTr<Pub> {} //~ ERROR private trait in public interface
         //~^ WARNING hard error
-    pub trait Tr2: PubTr<Priv> {} //~ WARN private type in public interface
+    pub trait Tr2: PubTr<Priv> {} //~ ERROR private type in public interface
         //~^ WARNING hard error
-    pub trait Tr3: PubTr<[Priv; 1]> {} //~ WARN private type in public interface
+    pub trait Tr3: PubTr<[Priv; 1]> {} //~ ERROR private type in public interface
         //~^ WARNING hard error
-    pub trait Tr4: PubTr<Pub<Priv>> {} //~ WARN private type in public interface
+    pub trait Tr4: PubTr<Pub<Priv>> {} //~ ERROR private type in public interface
         //~^ WARNING hard error
 }
 
@@ -139,7 +138,7 @@ mod impls {
         type Alias = Priv; // OK
     }
     impl PubTr for Pub {
-        type Alias = Priv; //~ WARN private type in public interface
+        type Alias = Priv; //~ ERROR private type in public interface
         //~^ WARNING hard error
     }
 }
@@ -211,23 +210,23 @@ mod aliases_pub {
     pub trait Tr2: PrivUseAliasTr<PrivAlias> {} // OK
 
     impl PrivAlias {
-        pub fn f(arg: Priv) {} //~ WARN private type in public interface
+        pub fn f(arg: Priv) {} //~ ERROR private type in public interface
         //~^ WARNING hard error
     }
     // This doesn't even parse
     // impl <Priv as PrivTr>::AssocAlias {
-    //     pub fn f(arg: Priv) {} // WARN private type in public interface
+    //     pub fn f(arg: Priv) {} // ERROR private type in public interface
     // }
     impl PrivUseAliasTr for PrivUseAlias {
-        type Check = Priv; //~ WARN private type in public interface
+        type Check = Priv; //~ ERROR private type in public interface
         //~^ WARNING hard error
     }
     impl PrivUseAliasTr for PrivAlias {
-        type Check = Priv; //~ WARN private type in public interface
+        type Check = Priv; //~ ERROR private type in public interface
         //~^ WARNING hard error
     }
     impl PrivUseAliasTr for <Priv as PrivTr>::AssocAlias {
-        type Check = Priv; //~ WARN private type in public interface
+        type Check = Priv; //~ ERROR private type in public interface
         //~^ WARNING hard error
     }
 }
@@ -252,10 +251,10 @@ mod aliases_priv {
         type AssocAlias = Priv3;
     }
 
-    pub trait Tr1: PrivUseAliasTr {} //~ WARN private trait in public interface
+    pub trait Tr1: PrivUseAliasTr {} //~ ERROR private trait in public interface
         //~^ WARNING hard error
-    pub trait Tr2: PrivUseAliasTr<PrivAlias> {} //~ WARN private trait in public interface
-     //~^ WARN private type in public interface
+    pub trait Tr2: PrivUseAliasTr<PrivAlias> {} //~ ERROR private trait in public interface
+     //~^ ERROR private type in public interface
         //~| WARNING hard error
         //~| WARNING hard error
 
@@ -288,5 +287,4 @@ mod aliases_params {
     pub fn f1(arg: PrivAliasGeneric<u8>) {} // OK, not an error
 }
 
-#[rustc_error]
-fn main() {} //~ ERROR compilation successful
+fn main() {}

--- a/src/test/compile-fail/private-variant-and-crate-reexport.rs
+++ b/src/test/compile-fail/private-variant-and-crate-reexport.rs
@@ -8,34 +8,32 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(rustc_attrs)]
 #![allow(dead_code)]
 
 extern crate core;
-pub use core as reexported_core; //~ WARN extern crate `core` is private, and cannot be reexported
+pub use core as reexported_core; //~ ERROR extern crate `core` is private, and cannot be reexported
 //~^ WARNING hard error
 
 mod m1 {
-    pub use ::E::V; //~ WARN variant `V` is private, and cannot be reexported
+    pub use ::E::V; //~ ERROR variant `V` is private, and cannot be reexported
     //~^ WARNING hard error
 }
 
 mod m2 {
-    pub use ::E::{V}; //~ WARN variant `V` is private, and cannot be reexported
+    pub use ::E::{V}; //~ ERROR variant `V` is private, and cannot be reexported
     //~^ WARNING hard error
 }
 
 mod m3 {
-    pub use ::E::V::{self}; //~ WARN variant `V` is private, and cannot be reexported
+    pub use ::E::V::{self}; //~ ERROR variant `V` is private, and cannot be reexported
     //~^ WARNING hard error
 }
 
 mod m4 {
-    pub use ::E::*; //~ WARN variant `V` is private, and cannot be reexported
+    pub use ::E::*; //~ ERROR variant `V` is private, and cannot be reexported
     //~^ WARNING hard error
 }
 
 enum E { V }
 
-#[rustc_error]
-fn main() {} //~ ERROR compilation successful
+fn main() {}

--- a/src/test/run-pass/issue-31776.rs
+++ b/src/test/run-pass/issue-31776.rs
@@ -45,7 +45,7 @@ struct S2;
 
 mod m1 {
     fn f() {
-        struct Z {
+        pub struct Z {
             pub field: u8
         }
 

--- a/src/test/rustdoc/auxiliary/issue-28927-1.rs
+++ b/src/test/rustdoc/auxiliary/issue-28927-1.rs
@@ -8,5 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate issue_28927_2 as inner2;
-pub use inner2 as bar;
+mod detail {
+    pub extern crate issue_28927_2 as inner2;
+}
+pub use detail::inner2 as bar;


### PR DESCRIPTION
In accordance with the [plan](https://internals.rust-lang.org/t/fcp-for-various-future-compatibility-warnings/3590/5?u=petrochenkov).

r? @nikomatsakis 
