### PR TITLE
Remove last traces of identifier hygiene from HIR

### DIFF
--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1138,7 +1138,7 @@ pub type ExplicitSelf = Spanned<SelfKind>;
 impl Arg {
     pub fn to_self(&self) -> Option<ExplicitSelf> {
         if let PatKind::Binding(BindByValue(mutbl), name, _) = self.pat.node {
-            if name.node.unhygienize() == keywords::SelfValue.name() {
+            if name.node == keywords::SelfValue.name() {
                 return match self.ty.node {
                     TyInfer => Some(respan(self.pat.span, SelfKind::Value(mutbl))),
                     TyRptr(lt, MutTy{ref ty, mutbl}) if ty.node == TyInfer => {
@@ -1154,7 +1154,7 @@ impl Arg {
 
     pub fn is_self(&self) -> bool {
         if let PatKind::Binding(_, name, _) = self.pat.node {
-            name.node.unhygienize() == keywords::SelfValue.name()
+            name.node == keywords::SelfValue.name()
         } else {
             false
         }

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -456,8 +456,7 @@ fn extract_labels(ctxt: &mut LifetimeContext, b: &hir::Block) {
     fn expression_label(ex: &hir::Expr) -> Option<(ast::Name, Span)> {
         match ex.node {
             hir::ExprWhile(_, _, Some(label)) |
-            hir::ExprLoop(_, Some(label)) => Some((label.node.unhygienize(),
-                                                   label.span)),
+            hir::ExprLoop(_, Some(label)) => Some((label.node, label.span)),
             _ => None,
         }
     }

--- a/src/librustc_const_eval/check_match.rs
+++ b/src/librustc_const_eval/check_match.rs
@@ -247,8 +247,7 @@ fn check_for_bindings_named_the_same_as_variants(cx: &MatchCheckCtxt, pat: &Pat)
             if let ty::TyEnum(edef, _) = pat_ty.sty {
                 if let Def::Local(..) = cx.tcx.expect_def(p.id) {
                     if edef.variants.iter().any(|variant|
-                        variant.name == name.node.unhygienize()
-                            && variant.kind() == VariantKind::Unit
+                        variant.name == name.node && variant.kind() == VariantKind::Unit
                     ) {
                         let ty_path = cx.tcx.item_path_str(edef.did);
                         let mut err = struct_span_warn!(cx.tcx.sess, p.span, E0170,

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -163,7 +163,7 @@ impl LateLintPass for NonShorthandFieldPatterns {
                     continue;
                 }
                 if let PatKind::Binding(_, ident, None) = fieldpat.node.pat.node {
-                    if ident.node.unhygienize() == fieldpat.node.name {
+                    if ident.node == fieldpat.node.name {
                         cx.span_lint(NON_SHORTHAND_FIELD_PATTERNS, fieldpat.span,
                                      &format!("the `{}:` in this pattern is redundant and can \
                                               be removed", ident.node))

--- a/src/librustc_trans/debuginfo/create_scope_map.rs
+++ b/src/librustc_trans/debuginfo/create_scope_map.rs
@@ -51,7 +51,7 @@ pub fn create_scope_map(cx: &CrateContext,
     for arg in args {
         pat_util::pat_bindings(&arg.pat, |_, node_id, _, path1| {
             scope_stack.push(ScopeStackEntry { scope_metadata: fn_metadata,
-                                               name: Some(path1.node.unhygienize()) });
+                                               name: Some(path1.node) });
             scope_map.insert(node_id, fn_metadata);
         })
     }
@@ -260,7 +260,7 @@ fn walk_pattern(cx: &CrateContext,
             // N.B.: this comparison must be UNhygienic... because
             // gdb knows nothing about the context, so any two
             // variables with the same name will cause the problem.
-            let name = path1.node.unhygienize();
+            let name = path1.node;
             let need_new_scope = scope_stack
                 .iter()
                 .any(|entry| entry.name == Some(name));

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -60,10 +60,6 @@ impl Name {
     pub fn as_str(self) -> token::InternedString {
         token::InternedString::new_from_name(self)
     }
-
-    pub fn unhygienize(self) -> Name {
-        token::intern(&self.as_str())
-    }
 }
 
 impl fmt::Debug for Name {


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/34095/commits/e783a0a5e39d5ae2fa147508197d09a51530fae8 removed the [last](https://github.com/rust-lang/rust/pull/33654#discussion_r63415218) [use](https://github.com/rust-lang/rust/pull/33654#discussion_r63416284) of hygiene at post-resolve compilation stages, so we can avoid renaming during lowering to HIR and just keep original names.

r? @nrc 
