### PR TITLE
rustdoc: Fix const background color

### DIFF
--- a/src/librustdoc/html/static/styles/main.css
+++ b/src/librustdoc/html/static/styles/main.css
@@ -26,13 +26,6 @@ h1.fqn {
 h2, h3:not(.impl):not(.method):not(.type):not(.tymethod), h4:not(.method):not(.type):not(.tymethod) {
     border-bottom-color: #DDDDDD;
 }
-.in-band, code {
-    background-color: white;
-}
-
-div.stability > em > code {
-    background-color: initial;
-}
 
 .docblock code {
     background-color: #F5F5F5;


### PR DESCRIPTION
Also delete a couple of rules which are no longer needed.

[before](https://doc.rust-lang.org/nightly/std/char/constant.UNICODE_VERSION.html) [after](https://ollie27.github.io/rust_doc_test/std/char/constant.UNICODE_VERSION.html)

cc @GuillaumeGomez (who added this CSS)
