### PR TITLE
Support nested `cfg_attr` attributes

### DIFF
--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -78,7 +78,7 @@ impl<'a> StripUnconfigured<'a> {
         };
 
         if attr::cfg_matches(self.config, &cfg, &mut self.diag) {
-            Some(respan(mi.span, ast::Attribute_ {
+            self.process_cfg_attr(respan(mi.span, ast::Attribute_ {
                 id: attr::mk_attr_id(),
                 style: attr.node.style,
                 value: mi.clone(),

--- a/src/test/compile-fail/nested-cfg-attrs.rs
+++ b/src/test/compile-fail/nested-cfg-attrs.rs
@@ -1,0 +1,14 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[cfg_attr(all(), cfg_attr(all(), cfg(foo)))]
+fn f() {}
+
+fn main() { f() } //~ ERROR unresolved name `f`


### PR DESCRIPTION
Support arbitrarily deeply nested `cfg_attr` attributes (e.g. `#[cfg_attr(foo, cfg_attr(bar, baz))]`).
This makes configuration idempotent.

Currently, the nighties do not support any `cfg_attr` nesting. Stable and beta support just one level of `cfg_attr` nesting (expect for attributes on macro-expanded nodes, where no nesting is supported).

This is a [breaking-change]. For example, the following would break:

``` rust
macro_rules! m { () => {
    #[cfg_attr(all(), cfg_attr(all(), cfg(foo)))]
    fn f() {}
} }
m!();

fn main() { f() } //~ ERROR unresolved name `f`
```

r? @nrc
