### PR TITLE
Fix invalid inlining

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2258,8 +2258,8 @@ fn item_struct(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
         if fields.peek().is_some() {
             write!(w, "<h2 class='fields'>Fields</h2>")?;
             for (field, ty) in fields {
-                write!(w, "<span id='{shortty}.{name}'><code>{name}: {ty}</code></span>
-                           <span class='stab {stab}'></span>",
+                write!(w, "<span id='{shortty}.{name}' class='{shortty}'><code>{name}: {ty}</code>
+                           </span><span class='stab {stab}'></span>",
                        shortty = ItemType::StructField,
                        stab = field.stability_class(),
                        name = field.name.as_ref().unwrap(),

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -659,6 +659,10 @@ span.since {
     margin-bottom: 25px;
 }
 
+.variant, .structfield {
+    display: block;
+}
+
 :target > code {
    background: #FDFFD3;
 }


### PR DESCRIPTION
r? @steveklabnik 

So to put a context. @nox found an issue on the generated doc:

![screenshot from 2016-06-11 19-53-38](https://cloud.githubusercontent.com/assets/3050060/15987898/f7341de0-303b-11e6-9cd7-f2a6df423ee7.png)

So as you can see, the two variants are on the same where they shouldn't. I found out that the issue is also on structs:

![screenshot from 2016-06-11 19-53-31](https://cloud.githubusercontent.com/assets/3050060/15987900/0f66c5de-303c-11e6-90fc-5e49d11b6903.png)

And so such is the result of the PR:

![screenshot from 2016-06-12 01-15-21](https://cloud.githubusercontent.com/assets/3050060/15987904/19d9183c-303c-11e6-91c1-7c3f1163fbb0.png)
![screenshot from 2016-06-12 01-15-24](https://cloud.githubusercontent.com/assets/3050060/15987905/1b5d2db0-303c-11e6-8f43-9a8ad2371007.png)
