### PR TITLE
compiletest: detect nodejs binary, allow override

### DIFF
--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -160,6 +160,9 @@ pub struct Config {
     // status whether android device available or not
     pub adb_device_status: bool,
 
+    // Name with which to invoke Node for asmjs targets
+    pub node_path: Option<String>,
+
     // the path containing LLDB's Python module
     pub lldb_python_dir: Option<String>,
 

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1405,7 +1405,11 @@ actual:\n\
 
         // If this is emscripten, then run tests under nodejs
         if self.config.target == "asmjs-unknown-emscripten" {
-            args.push("nodejs".to_owned());
+            if let Some(ref p) = self.config.node_path {
+                args.push(p.clone());
+            } else {
+                self.fatal("no Node binary found (--nodejs-executable)");
+            }
         }
 
         let exe_file = self.make_exe_name();


### PR DESCRIPTION
Rather than hardcoding the binary name for running asmjs tests, attempt
to detect the name that should be used; either `nodejs` or `node`. Also
add a command-line argument to manually specify what should be used,
suppressing probing.

Fixes #34188.
