### PR TITLE
Revert a change in the scope of macros imported from crates to fix a regression

### DIFF
--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -944,6 +944,6 @@ impl SyntaxEnv {
     pub fn is_crate_root(&mut self) -> bool {
         // The first frame is pushed in `SyntaxEnv::new()` and the second frame is
         // pushed when folding the crate root pseudo-module (c.f. noop_fold_crate).
-        self.chain.len() == 2
+        self.chain.len() <= 2
     }
 }

--- a/src/libsyntax/util/small_vector.rs
+++ b/src/libsyntax/util/small_vector.rs
@@ -29,6 +29,16 @@ enum SmallVectorRepr<T> {
     Many(Vec<T>),
 }
 
+impl<T> Into<Vec<T>> for SmallVector<T> {
+    fn into(self) -> Vec<T> {
+        match self.repr {
+            Zero => Vec::new(),
+            One(t) => vec![t],
+            Many(vec) => vec,
+        }
+    }
+}
+
 impl<T> FromIterator<T> for SmallVector<T> {
     fn from_iter<I: IntoIterator<Item=T>>(iter: I) -> SmallVector<T> {
         let mut v = SmallVector::zero();

--- a/src/test/compile-fail/macro-use-scope.rs
+++ b/src/test/compile-fail/macro-use-scope.rs
@@ -8,12 +8,25 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(rustc_private)]
-macro_rules! m {
-    () => { #[macro_use] extern crate syntax; }
+// aux-build:two_macros.rs
+
+#![feature(rustc_attrs)]
+#![allow(unused)]
+
+fn f() {
+    let _ = macro_one!();
 }
+#[macro_use(macro_one)] // Check that this macro is usable in the above function
+extern crate two_macros;
+
+macro_rules! m { () => {
+    fn g() {
+        macro_two!();
+    }
+    #[macro_use(macro_two)] // Check that this macro is usable in the above function
+    extern crate two_macros as _two_macros;
+} }
 m!();
 
-fn main() {
-    help!(); //~ ERROR unexpected end of macro invocation
-}
+#[rustc_error]
+fn main() {} //~ ERROR compilation successful


### PR DESCRIPTION
Fixes #34212.
The regression was caused by #34032, which changed the scope of macros imported from extern crates to match the scope of macros imported from modules.
r? @nrc
