### PR TITLE
diagnostically note source of overruling outer forbid

### DIFF
--- a/src/test/compile-fail-fulldeps/lint-plugin-forbid-attrs.rs
+++ b/src/test/compile-fail-fulldeps/lint-plugin-forbid-attrs.rs
@@ -14,6 +14,8 @@
 #![feature(plugin)]
 #![plugin(lint_plugin_test)]
 #![forbid(test_lint)]
+//~^ NOTE lint level defined here
+//~| NOTE `forbid` lint level set here
 
 fn lintme() { } //~ ERROR item is named 'lintme'
 

--- a/src/test/compile-fail/lint-forbid-attr.rs
+++ b/src/test/compile-fail/lint-forbid-attr.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![forbid(deprecated)]
+//~^ NOTE `forbid` lint level set here
 
 #[allow(deprecated)] //~ ERROR allow(deprecated) overruled by outer forbid(deprecated)
 fn main() {


### PR DESCRIPTION
When we emit E0453 (lint level attribute overruled by outer `forbid`
lint level), it could be helpful to note where the `forbid` level was
set, for the convenience of users who, e.g., believe that the correct
fix is to weaken the `forbid` to `deny`.

![forbidden_on_whose_authority](https://cloud.githubusercontent.com/assets/1076988/15995312/2d847376-30ce-11e6-865e-b68cfebc0291.png)
