### PR TITLE
Autoupdate man page rev/date info upon git-archive

### DIFF
--- a/man/.gitattributes
+++ b/man/.gitattributes
@@ -1,0 +1,1 @@
+*.1 export-subst

--- a/man/rustc.1
+++ b/man/rustc.1
@@ -1,4 +1,4 @@
-.TH RUSTC "1" "August 2015" "rustc 1.2.0" "User Commands"
+.TH RUSTC "1" "$Format:%ci$" "At rev. $Format:%h$" "User Commands"
 .SH NAME
 rustc \- The Rust compiler
 .SH SYNOPSIS

--- a/man/rustdoc.1
+++ b/man/rustdoc.1
@@ -1,4 +1,4 @@
-.TH RUSTDOC "1" "August 2015" "rustdoc 1.2.0" "User Commands"
+.TH RUSTDOC "1" "$Format:%ci$" "At rev. $Format:%h$" "User Commands"
 .SH NAME
 rustdoc \- generate documentation from Rust source code
 .SH SYNOPSIS


### PR DESCRIPTION
See #25689, in particular [this comment](https://github.com/rust-lang/rust/issues/25689#issuecomment-225452461)
r? @brson

This PR ensures that version-related references in man pages coming with ‘non-working copies’ of the source tree are kept in sync automatically. For copies created with `git archive`, including tagged releases (as probably consumed by packagers), the bottom line of the man pages for `rustc` and `rustdoc` will automatically read something like in `man`:

```
At rev. a9d08eb                               2016-06-13 09:44:18 +0200                                     RUSTC(1)
```

Instead of (at Rust 1.9.0):

```
rustc 1.2.0                                          August 2015                                            RUSTC(1)
```

This solution isn't dependent on manual creation of man pages; that can be reconsidered and this trick can be reused or replaced with whatever future means of autoproduction of man pages. In my view, being precise and current in docs also encourages keeping them current, and increases user confidence that they are indeed reliable and current.

A limitation of the solution is that it doesn't translate the git revision and date to some more readily understood ‘discrete’ tag, such as a version triple. This is AFAICT only possible when you bundle such documentation as an extra release artifact built and added automatically upon tagging. I've done that before for another project, but that must be agreed on first ...
