### PR TITLE
book/ffi: nullable pointer cleanup

### DIFF
--- a/src/doc/book/ffi.md
+++ b/src/doc/book/ffi.md
@@ -581,9 +581,9 @@ However, the language provides a workaround.
 As a special case, an `enum` is eligible for the "nullable pointer optimization" if it
 contains exactly two variants, one of which contains no data and the other contains
 a field of one of the non-nullable types listed above (or a struct containing such a type).
-This means it is represented as a single pointer, and the non-data variant is represented as a
-null pointer. This is called an "optimization", but unlike other optimizations it is guaranteed
-to apply to eligible types.
+This means no extra space is required for a discriminant; rather, the empty variant is represented
+by putting a `null` value into the non-nullable field. This is called an "optimization", but unlike
+other optimizations it is guaranteed to apply to eligible types.
 
 The most common type that takes advantage of the nullable pointer optimization is `Option<T>`,
 where `None` corresponds to `null`. So `Option<extern "C" fn(c_int) -> c_int>` is a correct way

--- a/src/doc/book/ffi.md
+++ b/src/doc/book/ffi.md
@@ -580,10 +580,10 @@ However, the language provides a workaround.
 
 As a special case, an `enum` is eligible for the "nullable pointer optimization" if it
 contains exactly two variants, one of which contains no data and the other contains
-a single field of one of the non-nullable types listed above. This means it is represented
-as a single pointer, and the non-data variant is represented as the null pointer. This is
-called an "optimization", but unlike other optimizations it is guaranteed to apply to
-eligible types.
+a single field of one of the non-nullable types listed above (or a struct containing such a type).
+This means it is represented as a single pointer, and the non-data variant is represented as a
+null pointer. This is called an "optimization", but unlike other optimizations it is guaranteed
+to apply to eligible types.
 
 The most common type that takes advantage of the nullable pointer optimization is `Option<T>`,
 where `None` corresponds to `null`. So `Option<extern "C" fn(c_int) -> c_int>` is a correct way

--- a/src/doc/book/ffi.md
+++ b/src/doc/book/ffi.md
@@ -598,17 +598,21 @@ we have function pointers flying across the FFI boundary in both directions.
 ```rust
 use std::os::raw::c_int;
 
+# #[cfg(hidden)]
 extern "C" {
     /// Register the callback.
     fn register(cb: Option<extern "C" fn(Option<extern "C" fn(c_int) -> c_int>, c_int) -> c_int>);
 }
+# unsafe fn register(_: Option<extern "C" fn(Option<extern "C" fn(c_int) -> c_int>,
+#                                            c_int) -> c_int>)
+# {}
 
 /// This fairly useless function receives a function pointer and an integer
 /// from C, and returns the result of calling the function with the integer.
 /// In case no function is provided, it squares the integer by default.
 extern "C" fn apply(process: Option<extern "C" fn(c_int) -> c_int>, int: c_int) -> c_int {
     match process {
-        Some(f) => unsafe { f(int) },
+        Some(f) => f(int),
         None    => int * int
     }
 }

--- a/src/doc/book/ffi.md
+++ b/src/doc/book/ffi.md
@@ -581,12 +581,12 @@ interfacing with C, pointers that might be `null` are often used, which would se
 require some messy `transmute`s and/or unsafe code to handle conversions to/from Rust types.
 However, the language provides a workaround.
 
-As a special case, an `enum` is eligible for the "nullable pointer optimization" if it
-contains exactly two variants, one of which contains no data and the other contains
-a field of one of the non-nullable types listed above (or a struct containing such a type).
-This means no extra space is required for a discriminant; rather, the empty variant is represented
-by putting a `null` value into the non-nullable field. This is called an "optimization", but unlike
-other optimizations it is guaranteed to apply to eligible types.
+As a special case, an `enum` is eligible for the "nullable pointer optimization" if it contains
+exactly two variants, one of which contains no data and the other contains a field of one of the
+non-nullable types listed above.  This means no extra space is required for a discriminant; rather,
+the empty variant is represented by putting a `null` value into the non-nullable field. This is
+called an "optimization", but unlike other optimizations it is guaranteed to apply to eligible
+types.
 
 The most common type that takes advantage of the nullable pointer optimization is `Option<T>`,
 where `None` corresponds to `null`. So `Option<extern "C" fn(c_int) -> c_int>` is a correct way
@@ -599,7 +599,9 @@ and an integer and it is supposed to run the function with the integer as a para
 we have function pointers flying across the FFI boundary in both directions.
 
 ```rust
-use std::os::raw::c_int;
+# #![feature(libc)]
+extern crate libc;
+use libc::c_int;
 
 # #[cfg(hidden)]
 extern "C" {

--- a/src/doc/book/ffi.md
+++ b/src/doc/book/ffi.md
@@ -593,7 +593,7 @@ to represent a nullable function pointer using the C ABI (corresponding to the C
 Here is a contrived example. Let's say some C library has a facility for registering a
 callback, which gets called in certain situations. The callback is passed a function pointer
 and an integer and it is supposed to run the function with the integer as a parameter. So
-we have function pointers flying across the FFI interface in both directions.
+we have function pointers flying across the FFI boundary in both directions.
 
 ```rust
 use std::os::raw::c_int;

--- a/src/doc/book/ffi.md
+++ b/src/doc/book/ffi.md
@@ -580,7 +580,7 @@ However, the language provides a workaround.
 
 As a special case, an `enum` is eligible for the "nullable pointer optimization" if it
 contains exactly two variants, one of which contains no data and the other contains
-a single field of one of the non-nullable types listed above (or a struct containing such a type).
+a field of one of the non-nullable types listed above (or a struct containing such a type).
 This means it is represented as a single pointer, and the non-data variant is represented as a
 null pointer. This is called an "optimization", but unlike other optimizations it is guaranteed
 to apply to eligible types.

--- a/src/doc/book/ffi.md
+++ b/src/doc/book/ffi.md
@@ -635,7 +635,7 @@ void register(void (*f)(void (*)(int), int)) {
 }
 ```
 
-No `tranmsute` required!
+No `transmute` required!
 
 # Calling Rust code from C
 

--- a/src/doc/book/ffi.md
+++ b/src/doc/book/ffi.md
@@ -578,19 +578,17 @@ interfacing with C, pointers that might be `null` are often used, which would se
 require some messy `transmute`s and/or unsafe code to handle conversions to/from Rust types.
 However, the language provides a workaround.
 
-As a special case, an `enum` that contains exactly two variants, one of
-which contains no data and the other containing a single field, is eligible
-for the "nullable pointer optimization". When such an enum is instantiated
-with one of the non-nullable types listed above, it is represented as a single pointer,
-and the non-data variant is represented as the null pointer. This is called an
-"optimization", but unlike other optimizations it is guaranteed to apply to
+As a special case, an `enum` is eligible for the "nullable pointer optimization" if it
+contains exactly two variants, one of which contains no data and the other contains
+a single field of one of the non-nullable types listed above. This means it is represented
+as a single pointer, and the non-data variant is represented as the null pointer. This is
+called an "optimization", but unlike other optimizations it is guaranteed to apply to
 eligible types.
 
 The most common type that takes advantage of the nullable pointer optimization is `Option<T>`,
 where `None` corresponds to `null`. So `Option<extern "C" fn(c_int) -> c_int>` is a correct way
 to represent a nullable function pointer using the C ABI (corresponding to the C type
-`int (*)(int)`). (However, generics are not required to get the optimization. A simple
-`enum NullableIntRef { Int(Box<i32>), NotInt }` is also represented as a single pointer.)
+`int (*)(int)`).
 
 Here is an example:
 

--- a/src/doc/book/ffi.md
+++ b/src/doc/book/ffi.md
@@ -461,11 +461,12 @@ global state. In order to access these variables, you declare them in `extern`
 blocks with the `static` keyword:
 
 ```rust,no_run
-use std::os::raw::c_int;
+# #![feature(libc)]
+extern crate libc;
 
 #[link(name = "readline")]
 extern {
-    static rl_readline_version: c_int;
+    static rl_readline_version: libc::c_int;
 }
 
 fn main() {
@@ -479,14 +480,15 @@ interface. To do this, statics can be declared with `mut` so we can mutate
 them.
 
 ```rust,no_run
+# #![feature(libc)]
+extern crate libc;
 
 use std::ffi::CString;
-use std::os::raw::c_char;
 use std::ptr;
 
 #[link(name = "readline")]
 extern {
-    static mut rl_prompt: *const c_char;
+    static mut rl_prompt: *const libc::c_char;
 }
 
 fn main() {
@@ -511,13 +513,14 @@ calling foreign functions. Some foreign functions, most notably the Windows API,
 conventions. Rust provides a way to tell the compiler which convention to use:
 
 ```rust
-use std::os::raw::c_int;
+# #![feature(libc)]
+extern crate libc;
 
 #[cfg(all(target_os = "win32", target_arch = "x86"))]
 #[link(name = "kernel32")]
 #[allow(non_snake_case)]
 extern "stdcall" {
-    fn SetEnvironmentVariableA(n: *const u8, v: *const u8) -> c_int;
+    fn SetEnvironmentVariableA(n: *const u8, v: *const u8) -> libc::c_int;
 }
 # fn main() { }
 ```
@@ -690,11 +693,12 @@ void bar(void *arg);
 We can represent this in Rust with the `c_void` type:
 
 ```rust
-use std::os::raw::c_void;
+# #![feature(libc)]
+extern crate libc;
 
 extern "C" {
-    pub fn foo(arg: *mut c_void);
-    pub fn bar(arg: *mut c_void);
+    pub fn foo(arg: *mut libc::c_void);
+    pub fn bar(arg: *mut libc::c_void);
 }
 # fn main() {}
 ```

--- a/src/doc/book/ffi.md
+++ b/src/doc/book/ffi.md
@@ -600,7 +600,7 @@ use std::os::raw::c_int;
 
 extern "C" {
     /// Register the callback.
-    fn register(Option<extern "C" fn(Option<extern "C" fn(c_int) -> c_int>, c_int) -> c_int>);
+    fn register(cb: Option<extern "C" fn(Option<extern "C" fn(c_int) -> c_int>, c_int) -> c_int>);
 }
 
 /// This fairly useless function receives a function pointer and an integer


### PR DESCRIPTION
Expand the "nullable pointer optimization" section with a code example. Fixes #34250.

I also noticed that many of the examples use the libc crate just for types such as `c_char` and `c_int`, which are now available through `std::os::raw`. I changed the ones that don't need to rely on libc. I'm glad to revert that part of the commit if it's unwanted churn.
