### PR TITLE
RFC: Change max line length to 120

### DIFF
--- a/src/doc/style/style/whitespace.md
+++ b/src/doc/style/style/whitespace.md
@@ -1,6 +1,6 @@
 % Whitespace [FIXME: needs RFC]
 
-* Lines must not exceed 99 characters.
+* Lines must not exceed 120 characters.
 * Use 4 spaces for indentation, _not_ tabs.
 * No trailing whitespace at the end of lines or files.
 


### PR DESCRIPTION
99 characters seems a bit uncommon; I think we should add a motivation if we want to keep that. To me, it feels like a very arbitrary number (greater than 80, but... why 99?)

Servo has chosen [120 characters](https://github.com/servo/servo/blob/master/python/tidy/servo_tidy_tests/test_tidy.py#L37) as its limit. I think it's a more reasonable default.
