### PR TITLE
rustdoc: Add stability notices to impl items

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1658,12 +1658,8 @@ fn plain_summary_line(s: Option<&str>) -> String {
 }
 
 fn document(w: &mut fmt::Formatter, cx: &Context, item: &clean::Item) -> fmt::Result {
-    for stability in short_stability(item, cx, true) {
-        write!(w, "<div class='stability'>{}</div>", stability)?;
-    }
-    if let Some(s) = item.doc_value() {
-        write!(w, "<div class='docblock'>{}</div>", Markdown(s))?;
-    }
+    document_stability(w, cx, item)?;
+    document_full(w, item)?;
     Ok(())
 }
 
@@ -1676,6 +1672,20 @@ fn document_short(w: &mut fmt::Formatter, item: &clean::Item, link: AssocItemLin
             format!("{}", &plain_summary_line(Some(s)))
         };
         write!(w, "<div class='docblock'>{}</div>", Markdown(&markdown))?;
+    }
+    Ok(())
+}
+
+fn document_full(w: &mut fmt::Formatter, item: &clean::Item) -> fmt::Result {
+    if let Some(s) = item.doc_value() {
+        write!(w, "<div class='docblock'>{}</div>", Markdown(s))?;
+    }
+    Ok(())
+}
+
+fn document_stability(w: &mut fmt::Formatter, cx: &Context, item: &clean::Item) -> fmt::Result {
+    for stability in short_stability(item, cx, true) {
+        write!(w, "<div class='stability'>{}</div>", stability)?;
     }
     Ok(())
 }
@@ -2640,20 +2650,23 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
 
         if !is_static || render_static {
             if !is_default_item {
-
-                if item.doc_value().is_some() {
-                    document(w, cx, item)?;
-                } else {
-                    // In case the item isn't documented,
-                    // provide short documentation from the trait
-                    if let Some(t) = trait_ {
-                        if let Some(it) = t.items.iter()
-                                           .find(|i| i.name == item.name) {
-                            document_short(w, it, link)?;
-                        }
+                if let Some(t) = trait_ {
+                    let it = t.items.iter().find(|i| i.name == item.name).unwrap();
+                    // We need the stability of the item from the trait because
+                    // impls can't have a stability.
+                    document_stability(w, cx, it)?;
+                    if item.doc_value().is_some() {
+                        document_full(w, item)?;
+                    } else {
+                        // In case the item isn't documented,
+                        // provide short documentation from the trait.
+                        document_short(w, it, link)?;
                     }
+                } else {
+                    document(w, cx, item)?;
                 }
             } else {
+                document_stability(w, cx, item)?;
                 document_short(w, item, link)?;
             }
         }

--- a/src/test/rustdoc/deprecated-impls.rs
+++ b/src/test/rustdoc/deprecated-impls.rs
@@ -1,0 +1,128 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "foo"]
+
+// @has foo/struct.Foo0.html
+pub struct Foo0;
+
+impl Foo0 {
+    // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.1: fn_with_doc'
+    // @has - 'fn_with_doc short'
+    // @has - 'fn_with_doc full'
+    /// fn_with_doc short
+    ///
+    /// fn_with_doc full
+    #[deprecated(since = "1.0.1", note = "fn_with_doc")]
+    pub fn fn_with_doc() {}
+
+    // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.2: fn_without_doc'
+    #[deprecated(since = "1.0.2", note = "fn_without_doc")]
+    pub fn fn_without_doc() {}
+}
+
+pub trait Bar {
+    /// fn_empty_with_doc short
+    ///
+    /// fn_empty_with_doc full
+    #[deprecated(since = "1.0.3", note = "fn_empty_with_doc")]
+    fn fn_empty_with_doc();
+
+    #[deprecated(since = "1.0.4", note = "fn_empty_without_doc")]
+    fn fn_empty_without_doc();
+
+    /// fn_def_with_doc short
+    ///
+    /// fn_def_with_doc full
+    #[deprecated(since = "1.0.5", note = "fn_def_with_doc")]
+    fn fn_def_with_doc() {}
+
+    #[deprecated(since = "1.0.6", note = "fn_def_without_doc")]
+    fn fn_def_without_doc() {}
+
+    /// fn_def_def_with_doc short
+    ///
+    /// fn_def_def_with_doc full
+    #[deprecated(since = "1.0.7", note = "fn_def_def_with_doc")]
+    fn fn_def_def_with_doc() {}
+
+    #[deprecated(since = "1.0.8", note = "fn_def_def_without_doc")]
+    fn fn_def_def_without_doc() {}
+}
+
+// @has foo/struct.Foo1.html
+pub struct Foo1;
+
+impl Bar for Foo1 {
+    // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.3: fn_empty_with_doc'
+    // @has - 'fn_empty_with_doc_impl short'
+    // @has - 'fn_empty_with_doc_impl full'
+    /// fn_empty_with_doc_impl short
+    ///
+    /// fn_empty_with_doc_impl full
+    fn fn_empty_with_doc() {}
+
+    // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.4: fn_empty_without_doc'
+    fn fn_empty_without_doc() {}
+
+    // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.5: fn_def_with_doc'
+    // @has - 'fn_def_with_doc_impl short'
+    // @has - 'fn_def_with_doc_impl full'
+    /// fn_def_with_doc_impl short
+    ///
+    /// fn_def_with_doc_impl full
+    fn fn_def_with_doc() {}
+
+    // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.6: fn_def_without_doc'
+    fn fn_def_without_doc() {}
+
+    // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.7: fn_def_def_with_doc'
+    // @has - 'fn_def_def_with_doc short'
+    // @!has - 'fn_def_def_with_doc full'
+
+    // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.8: fn_def_def_without_doc'
+}
+
+// @has foo/struct.Foo2.html
+pub struct Foo2;
+
+impl Bar for Foo2 {
+    // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.3: fn_empty_with_doc'
+    // @has - 'fn_empty_with_doc short'
+    // @!has - 'fn_empty_with_doc full'
+    fn fn_empty_with_doc() {}
+
+    // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.4: fn_empty_without_doc'
+    // @has - 'fn_empty_without_doc_impl short'
+    // @has - 'fn_empty_without_doc_impl full'
+    /// fn_empty_without_doc_impl short
+    ///
+    /// fn_empty_without_doc_impl full
+    fn fn_empty_without_doc() {}
+
+    // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.5: fn_def_with_doc'
+    // @has - 'fn_def_with_doc short'
+    // @!has - 'fn_def_with full'
+    fn fn_def_with_doc() {}
+
+    // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.6: fn_def_without_doc'
+    // @has - 'fn_def_without_doc_impl short'
+    // @has - 'fn_def_without_doc_impl full'
+    /// fn_def_without_doc_impl short
+    ///
+    /// fn_def_without_doc_impl full
+    fn fn_def_without_doc() {}
+
+    // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.7: fn_def_def_with_doc'
+    // @has - 'fn_def_def_with_doc short'
+    // @!has - 'fn_def_def_with_doc full'
+
+    // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.8: fn_def_def_without_doc'
+}


### PR DESCRIPTION
Also fixes missing stability notices on methods with no docs.

For example [`f64::is_positive`](https://doc.rust-lang.org/nightly/std/primitive.f64.html#method.is_positive) is missing its deprecation message.
