### PR TITLE
Perform `cfg` attribute processing on decorator-generated items

### DIFF
--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -95,6 +95,16 @@ impl Annotatable {
             _ => panic!("expected Item")
         }
     }
+
+    pub fn fold_with<F: Folder>(self, folder: &mut F) -> SmallVector<Self> {
+        match self {
+            Annotatable::Item(item) => folder.fold_item(item).map(Annotatable::Item),
+            Annotatable::ImplItem(item) =>
+                folder.fold_impl_item(item.unwrap()).map(|item| Annotatable::ImplItem(P(item))),
+            Annotatable::TraitItem(item) =>
+                folder.fold_trait_item(item.unwrap()).map(|item| Annotatable::TraitItem(P(item))),
+        }
+    }
 }
 
 // A more flexible ItemDecorator.

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -787,8 +787,6 @@ fn decorate(a: Annotatable, fld: &mut MacroExpander) -> SmallVector<Annotatable>
     let mut decorator_items = SmallVector::zero();
     let mut new_attrs = Vec::new();
     expand_decorators(a.clone(), fld, &mut decorator_items, &mut new_attrs);
-    let decorator_items =
-        decorator_items.into_iter().flat_map(|a| expand_annotatable(a, fld)).collect();
 
     let mut new_items = SmallVector::one(a.fold_attrs(new_attrs));
     new_items.push_all(decorator_items);

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -839,16 +839,18 @@ fn expand_decorators(a: Annotatable,
                         }
                     });
 
-                    // we'd ideally decorator_items.push_all(expand_annotatable(ann, fld)),
-                    // but that double-mut-borrows fld
                     let mut items: SmallVector<Annotatable> = SmallVector::zero();
                     dec.expand(fld.cx,
                                attr.span,
                                &attr.node.value,
                                &a,
                                &mut |ann| items.push(ann));
-                    decorator_items.extend(items.into_iter()
-                        .flat_map(|ann| expand_annotatable(ann, fld).into_iter()));
+
+                    for item in items {
+                        for configured_item in item.fold_with(&mut fld.strip_unconfigured()) {
+                            decorator_items.extend(expand_annotatable(configured_item, fld));
+                        }
+                    }
 
                     fld.cx.bt_pop();
                 }

--- a/src/libsyntax/util/small_vector.rs
+++ b/src/libsyntax/util/small_vector.rs
@@ -136,6 +136,15 @@ impl<T> SmallVector<T> {
     }
 
     pub fn is_empty(&self) -> bool { self.len() == 0 }
+
+    pub fn map<U, F: FnMut(T) -> U>(self, mut f: F) -> SmallVector<U> {
+        let repr = match self.repr {
+            Zero => Zero,
+            One(t) => One(f(t)),
+            Many(vec) => Many(vec.into_iter().map(f).collect()),
+        };
+        SmallVector { repr: repr }
+    }
 }
 
 impl<T> IntoIterator for SmallVector<T> {


### PR DESCRIPTION
Fixes https://users.rust-lang.org/t/unused-attribute-warning-for-custom-derive-attribute/6180.
r? @nrc
