### PR TITLE
Fixes for `-Z dump-mir`

### DIFF
--- a/src/librustc_mir/pretty.rs
+++ b/src/librustc_mir/pretty.rs
@@ -61,8 +61,13 @@ pub fn dump_mir<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         return;
     }
 
-    let file_name = format!("rustc.node{}.{}.{}.mir",
-                            node_id, pass_name, disambiguator);
+    let promotion_id = match src {
+        MirSource::Promoted(_, id) => format!("-promoted{}", id),
+        _ => String::new()
+    };
+
+    let file_name = format!("rustc.node{}{}.{}.{}.mir",
+                            node_id, promotion_id, pass_name, disambiguator);
     let _ = fs::File::create(&file_name).and_then(|mut file| {
         try!(writeln!(file, "// MIR for `{}`", node_path));
         try!(writeln!(file, "// node_id = {}", node_id));

--- a/src/librustc_mir/pretty.rs
+++ b/src/librustc_mir/pretty.rs
@@ -62,7 +62,7 @@ pub fn dump_mir<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     }
 
     let promotion_id = match src {
-        MirSource::Promoted(_, id) => format!("-promoted{}", id),
+        MirSource::Promoted(_, id) => format!("-{:?}", id),
         _ => String::new()
     };
 
@@ -98,7 +98,7 @@ pub fn write_mir_pretty<'a, 'b, 'tcx, I>(tcx: TyCtxt<'b, 'tcx, 'tcx>,
         let src = MirSource::from_node(tcx, id);
         write_mir_fn(tcx, src, mir, w, None)?;
 
-        for (i, mir) in mir.promoted.iter().enumerate() {
+        for (i, mir) in mir.promoted.iter_enumerated() {
             writeln!(w, "")?;
             write_mir_fn(tcx, MirSource::Promoted(id, i), mir, w, None)?;
         }
@@ -292,7 +292,7 @@ fn write_mir_sig(tcx: TyCtxt, src: MirSource, mir: &Mir, w: &mut Write)
         MirSource::Const(_) => write!(w, "const")?,
         MirSource::Static(_, hir::MutImmutable) => write!(w, "static")?,
         MirSource::Static(_, hir::MutMutable) => write!(w, "static mut")?,
-        MirSource::Promoted(_, i) => write!(w, "promoted{} in", i)?
+        MirSource::Promoted(_, i) => write!(w, "{:?} in", i)?
     }
 
     write!(w, " {}", tcx.node_path_str(src.item_id()))?;

--- a/src/librustc_mir/transform/add_call_guards.rs
+++ b/src/librustc_mir/transform/add_call_guards.rs
@@ -13,8 +13,6 @@ use rustc::mir::repr::*;
 use rustc::mir::transform::{MirPass, MirSource, Pass};
 use rustc_data_structures::indexed_vec::{Idx, IndexVec};
 
-use pretty;
-
 pub struct AddCallGuards;
 
 /**
@@ -38,7 +36,7 @@ pub struct AddCallGuards;
  */
 
 impl<'tcx> MirPass<'tcx> for AddCallGuards {
-    fn run_pass<'a>(&mut self, tcx: TyCtxt<'a, 'tcx, 'tcx>, src: MirSource, mir: &mut Mir<'tcx>) {
+    fn run_pass<'a>(&mut self, _tcx: TyCtxt<'a, 'tcx, 'tcx>, _src: MirSource, mir: &mut Mir<'tcx>) {
         let pred_count: IndexVec<_, _> =
             mir.predecessors().iter().map(|ps| ps.len()).collect();
 
@@ -75,7 +73,6 @@ impl<'tcx> MirPass<'tcx> for AddCallGuards {
             }
         }
 
-        pretty::dump_mir(tcx, "break_cleanup_edges", &0, src, mir, None);
         debug!("Broke {} N edges", new_blocks.len());
 
         mir.basic_blocks_mut().extend(new_blocks);

--- a/src/librustc_mir/transform/simplify_branches.rs
+++ b/src/librustc_mir/transform/simplify_branches.rs
@@ -60,4 +60,7 @@ impl<'l> Pass for SimplifyBranches<'l> {
     fn disambiguator<'a>(&'a self) -> Option<Box<fmt::Display+'a>> {
         Some(Box::new(self.label))
     }
+
+    // avoid calling `type_name` - it contains `<'static>`
+    fn name(&self) -> &str { "SimplifyBranches" }
 }

--- a/src/librustc_mir/transform/simplify_cfg.rs
+++ b/src/librustc_mir/transform/simplify_cfg.rs
@@ -62,6 +62,9 @@ impl<'l> Pass for SimplifyCfg<'l> {
     fn disambiguator<'a>(&'a self) -> Option<Box<fmt::Display+'a>> {
         Some(Box::new(self.label))
     }
+
+    // avoid calling `type_name` - it contains `<'static>`
+    fn name(&self) -> &str { "SimplifyCfg" }
 }
 
 pub struct CfgSimplifier<'a, 'tcx: 'a> {


### PR DESCRIPTION
Do not overwrite the parent MIR when dumping promoted MIR.

r? @eddyb 
