### PR TITLE
run error index tests during `make check`

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -276,6 +276,7 @@ check-stage$(1)-T-$(2)-H-$(3)-exec: \
 	check-stage$(1)-T-$(2)-H-$(3)-incremental-exec \
 	check-stage$(1)-T-$(2)-H-$(3)-ui-exec \
 	check-stage$(1)-T-$(2)-H-$(3)-doc-exec \
+        check-stage$(1)-T-$(2)-H-$(3)-doc-error-index-exec
 	check-stage$(1)-T-$(2)-H-$(3)-pretty-exec
 
 ifndef CFG_DISABLE_CODEGEN_TESTS


### PR DESCRIPTION
I propose a change which will make error index tests run on `make check` (and variants).

Closes #31587.
r? @brson 
