### PR TITLE
Pretty-print attributes on tuple structs and add tests

### DIFF
--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -911,8 +911,9 @@ impl<'a> State<'a> {
             if struct_def.is_tuple() {
                 self.popen()?;
                 self.commasep(Inconsistent, struct_def.fields(), |s, field| {
-                    s.print_visibility(&field.vis)?;
                     s.maybe_print_comment(field.span.lo)?;
+                    s.print_outer_attributes(&field.attrs)?;
+                    s.print_visibility(&field.vis)?;
                     s.print_type(&field.ty)
                 })?;
                 self.pclose()?;

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1403,8 +1403,9 @@ impl<'a> State<'a> {
                 try!(self.commasep(
                     Inconsistent, struct_def.fields(),
                     |s, field| {
-                        try!(s.print_visibility(&field.vis));
                         try!(s.maybe_print_comment(field.span.lo));
+                        try!(s.print_outer_attributes(&field.attrs));
+                        try!(s.print_visibility(&field.vis));
                         s.print_type(&field.ty)
                     }
                 ));

--- a/src/test/pretty/attr-variant-data.rs
+++ b/src/test/pretty/attr-variant-data.rs
@@ -1,0 +1,51 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// pp-exact
+// Testing that both the inner item and next outer item are
+// preserved, and that the first outer item parsed in main is not
+// accidentally carried over to each inner function
+
+#![feature(custom_attribute)]
+#![feature(custom_derive)]
+
+#[derive(Serialize, Deserialize)]
+struct X;
+
+#[derive(Serialize, Deserialize)]
+struct WithRef<'a, T: 'a> {
+    #[serde(skip_deserializing)]
+    t: Option<&'a T>,
+    #[serde(serialize_with = "ser_x", deserialize_with = "de_x")]
+    x: X,
+}
+
+#[derive(Serialize, Deserialize)]
+enum EnumWith<T> {
+    Unit,
+    Newtype(
+            #[serde(serialize_with = "ser_x", deserialize_with = "de_x")]
+            X),
+    Tuple(T,
+          #[serde(serialize_with = "ser_x", deserialize_with = "de_x")]
+          X),
+    Struct {
+        t: T,
+        #[serde(serialize_with = "ser_x", deserialize_with = "de_x")]
+        x: X,
+    },
+}
+
+#[derive(Serialize, Deserialize)]
+struct Tuple<T>(T,
+                #[serde(serialize_with = "ser_x", deserialize_with = "de_x")]
+                X);
+
+fn main() { }


### PR DESCRIPTION
This adds support to the pretty printer to print attributes added to tuple struct elements.  Furthermore, it adds a test that makes sure we will print attributes on all variant data types.
