### PR TITLE
Check that `self` can be used in a macro without having to be specified as an argument.

### DIFF
--- a/src/test/run-pass/self-unhygienic.rs
+++ b/src/test/run-pass/self-unhygienic.rs
@@ -28,4 +28,5 @@ pretty!(A, v);
 
 fn main() {
     assert_eq!(format!("Pretty: {}", A { v: 3 }.pretty()), "Pretty: <A:3>");
+    println!("{}", A{ v: 42 }.pretty());
 }

--- a/src/test/run-pass/self-unhygienic.rs
+++ b/src/test/run-pass/self-unhygienic.rs
@@ -1,0 +1,31 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that `self` is unhygienic
+
+struct A {
+    pub v: i64
+}
+
+macro_rules! pretty {
+    ( $t:ty, $field:ident ) => (
+        impl $t {
+            pub fn pretty(&self) -> String {
+                format!("<A:{}>", self.$field)
+            }
+        }
+    )
+}
+
+pretty!(A, v);
+
+fn main() {
+    assert_eq!(format!("Pretty: {}", A { v: 3 }.pretty()), "Pretty: <A:3>");
+}


### PR DESCRIPTION
Or in other words: check that `self` is allowed to be 'unhygienic'.  I don't like that word because it has such a negative connotation where this change breaks nothing, but makes method-making macros so much more sensible. Without it you have to tell users to always place `self` right there, no matter what. You cannot put any other variable there ever or you'll get a cryptic error message. I've already had [one user stumble over this](https://gitter.im/Geal/nom?at=574311d8e675315635f925ec).

Better arguments have been made, I'll let them speak for themselves: #1606, #33485.

I was in the process of making the change to make `self` 'unhygienic' when I discovered that it has already been done. So here's a test that verifies that `self` is ~~reasonable~~ unhygienic. If the change was intentional then you should merge it.

cc @jseyfried
r? @nrc
