### PR TITLE
Pretty print error value on Result.unwrap() panic

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -782,7 +782,7 @@ impl<T: fmt::Debug, E> Result<T, E> {
 #[inline(never)]
 #[cold]
 fn unwrap_failed<E: fmt::Debug>(msg: &str, error: E) -> ! {
-    panic!("{}: {:?}", msg, error)
+    panic!("{}: {:#?}", msg, error)
 }
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Old (one long line, hard to read):

```
thread '<main>' panicked at 'called `Result::unwrap()` on an `Err` value: Error { repr: Os { code: 2, message: "No such file or directory" } }', ../src/libcore/result.rs:746
```

New (pretty readable):

```
thread '<main>' panicked at 'called `Result::unwrap()` on an `Err` value: Error {
    repr: Os { 
        code: 2, 
        message: "No such file or directory" 
    } 
}', ../src/libcore/result.rs:746
```
