### PR TITLE
Fixed the `TAGS.rustc.emacs` and `TAGS.rustc.vi` make targets.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -277,7 +277,9 @@ endif
 
 # CTAGS building
 ifneq ($(strip $(findstring TAGS.emacs,$(MAKECMDGOALS)) \
-               $(findstring TAGS.vi,$(MAKECMDGOALS))),)
+               $(findstring TAGS.vi,$(MAKECMDGOALS)) \
+               $(findstring TAGS.rustc.emacs,$(MAKECMDGOALS)) \
+               $(findstring TAGS.rustc.vi,$(MAKECMDGOALS))),)
   CFG_INFO := $(info cfg: including ctags rules)
   include $(CFG_SRC_DIR)mk/ctags.mk
 endif


### PR DESCRIPTION
(They were added to `ctags.mk` in PR #33256, but I guess I must have
 only tested running `make TAGS.emacs TAGS.rustc.emacs` and not `make
 TAGS.rustc.emacs` on its own.)
