### PR TITLE
Fix panic when using debug in rustc

### DIFF
--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1031,7 +1031,7 @@ impl<'a> State<'a> {
                 try!(word(&mut self.s, "_"));
             }
             ast::TyKind::ImplicitSelf => {
-                unreachable!();
+                try!(word(&mut self.s, "Self"));
             }
             ast::TyKind::Mac(ref m) => {
                 try!(self.print_mac(m, token::Paren));


### PR DESCRIPTION
When I was using `println!("{:?}")` [here](https://github.com/rust-lang/rust/blob/master/src/librustc_resolve/lib.rs#L1610) and [here](https://github.com/rust-lang/rust/blob/master/src/librustc_typeck/collect.rs#L836), I was able to get into this `unreachache`.
