### PR TITLE
Add short summaries to btree modules

### DIFF
--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -105,12 +105,14 @@ pub mod vec_deque;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod btree_map {
+    //! A map based on a B-Tree.
     #[stable(feature = "rust1", since = "1.0.0")]
     pub use btree::map::*;
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod btree_set {
+    //! A set based on a B-Tree.
     #[stable(feature = "rust1", since = "1.0.0")]
     pub use btree::set::*;
 }

--- a/src/libstd/collections/mod.rs
+++ b/src/libstd/collections/mod.rs
@@ -429,14 +429,16 @@ mod hash;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod hash_map {
-    //! A hashmap
+    //! A hash map implementation which uses linear probing with Robin
+    //! Hood bucket stealing.
     #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::hash::map::*;
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod hash_set {
-    //! A hashset
+    //! An implementation of a hash set using the underlying representation of a
+    //! HashMap where the value is ().
     #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::hash::set::*;
 }


### PR DESCRIPTION
Also improve hash_map and hash_set module short summaries.

These are missing from [here](https://doc.rust-lang.org/nightly/std/collections/#modules).

r? @steveklabnik 
