### PR TITLE
Generalize and abstract `ThinAttributes` to `ThinVec<Attribute>`

### DIFF
--- a/src/librustc/hir/fold.rs
+++ b/src/librustc/hir/fold.rs
@@ -14,7 +14,6 @@
 use hir::*;
 use syntax::ast::{Name, NodeId, DUMMY_NODE_ID, Attribute, Attribute_, MetaItem};
 use syntax::ast::MetaItemKind;
-use syntax::attr::ThinAttributesExt;
 use hir;
 use syntax::codemap::{respan, Span, Spanned};
 use syntax::ptr::P;
@@ -292,8 +291,11 @@ pub fn noop_fold_view_path<T: Folder>(view_path: P<ViewPath>, fld: &mut T) -> P<
     })
 }
 
-pub fn fold_attrs<T: Folder>(attrs: HirVec<Attribute>, fld: &mut T) -> HirVec<Attribute> {
-    attrs.move_flat_map(|x| fld.fold_attribute(x))
+pub fn fold_attrs<T, F>(attrs: T, fld: &mut F) -> T
+    where T: Into<Vec<Attribute>> + From<Vec<Attribute>>,
+          F: Folder,
+{
+    attrs.into().move_flat_map(|x| fld.fold_attribute(x)).into()
 }
 
 pub fn noop_fold_arm<T: Folder>(Arm { attrs, pats, guard, body }: Arm, fld: &mut T) -> Arm {
@@ -461,7 +463,7 @@ pub fn noop_fold_local<T: Folder>(l: P<Local>, fld: &mut T) -> P<Local> {
             pat: fld.fold_pat(pat),
             init: init.map(|e| fld.fold_expr(e)),
             span: fld.new_span(span),
-            attrs: attrs.map_thin_attrs(|attrs| fold_attrs(attrs.into(), fld).into()),
+            attrs: fold_attrs(attrs, fld),
         }
     })
 }
@@ -1078,7 +1080,7 @@ pub fn noop_fold_expr<T: Folder>(Expr { id, node, span, attrs }: Expr, folder: &
             }
         },
         span: folder.new_span(span),
-        attrs: attrs.map_thin_attrs(|attrs| fold_attrs(attrs.into(), folder).into()),
+        attrs: fold_attrs(attrs, folder),
     }
 }
 

--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -27,7 +27,6 @@
 
 use syntax::abi::Abi;
 use syntax::ast::{NodeId, CRATE_NODE_ID, Name, Attribute};
-use syntax::attr::ThinAttributesExt;
 use syntax::codemap::{Span, Spanned};
 use hir::*;
 
@@ -756,7 +755,7 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
             walk_list!(visitor, visit_arm, arms);
         }
         ExprClosure(_, ref function_declaration, ref body, _fn_decl_span) => {
-            visitor.visit_fn(FnKind::Closure(expression.attrs.as_attr_slice()),
+            visitor.visit_fn(FnKind::Closure(&expression.attrs),
                              function_declaration,
                              body,
                              expression.span,

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -50,7 +50,6 @@ use session::Session;
 use std::collections::BTreeMap;
 use std::iter;
 use syntax::ast::*;
-use syntax::attr::{ThinAttributes, ThinAttributesExt};
 use syntax::ptr::P;
 use syntax::codemap::{respan, Spanned, Span};
 use syntax::parse::token;
@@ -962,16 +961,16 @@ impl<'a> LoweringContext<'a> {
 
                     let make_call = |this: &mut LoweringContext, p, args| {
                         let path = this.core_path(e.span, p);
-                        let path = this.expr_path(path, None);
-                        this.expr_call(e.span, path, args, None)
+                        let path = this.expr_path(path, ThinVec::new());
+                        this.expr_call(e.span, path, args)
                     };
 
                     let mk_stmt_let = |this: &mut LoweringContext, bind, expr| {
-                        this.stmt_let(e.span, false, bind, expr, None)
+                        this.stmt_let(e.span, false, bind, expr)
                     };
 
                     let mk_stmt_let_mut = |this: &mut LoweringContext, bind, expr| {
-                        this.stmt_let(e.span, true, bind, expr, None)
+                        this.stmt_let(e.span, true, bind, expr)
                     };
 
                     // let placer = <placer_expr> ;
@@ -980,21 +979,21 @@ impl<'a> LoweringContext<'a> {
                                                                  placer_expr,
                                                                  e.span,
                                                                  hir::PopUnstableBlock,
-                                                                 None);
+                                                                 ThinVec::new());
                         mk_stmt_let(self, placer_ident, placer_expr)
                     };
 
                     // let mut place = Placer::make_place(placer);
                     let (s2, place_binding) = {
-                        let placer = self.expr_ident(e.span, placer_ident, None, placer_binding);
+                        let placer = self.expr_ident(e.span, placer_ident, placer_binding);
                         let call = make_call(self, &make_place, hir_vec![placer]);
                         mk_stmt_let_mut(self, place_ident, call)
                     };
 
                     // let p_ptr = Place::pointer(&mut place);
                     let (s3, p_ptr_binding) = {
-                        let agent = self.expr_ident(e.span, place_ident, None, place_binding);
-                        let args = hir_vec![self.expr_mut_addr_of(e.span, agent, None)];
+                        let agent = self.expr_ident(e.span, place_ident, place_binding);
+                        let args = hir_vec![self.expr_mut_addr_of(e.span, agent)];
                         let call = make_call(self, &place_pointer, args);
                         mk_stmt_let(self, p_ptr_ident, call)
                     };
@@ -1005,11 +1004,12 @@ impl<'a> LoweringContext<'a> {
                                                                 value_expr,
                                                                 e.span,
                                                                 hir::PopUnstableBlock,
-                                                                None);
+                                                                ThinVec::new());
                         self.signal_block_expr(hir_vec![],
                                                value_expr,
                                                e.span,
-                                               hir::PopUnsafeBlock(hir::CompilerGenerated), None)
+                                               hir::PopUnsafeBlock(hir::CompilerGenerated),
+                                               ThinVec::new())
                     };
 
                     // push_unsafe!({
@@ -1017,19 +1017,20 @@ impl<'a> LoweringContext<'a> {
                     //     InPlace::finalize(place)
                     // })
                     let expr = {
-                        let ptr = self.expr_ident(e.span, p_ptr_ident, None, p_ptr_binding);
+                        let ptr = self.expr_ident(e.span, p_ptr_ident, p_ptr_binding);
                         let call_move_val_init =
                             hir::StmtSemi(
                                 make_call(self, &move_val_init, hir_vec![ptr, pop_unsafe_expr]),
                                 self.next_id());
                         let call_move_val_init = respan(e.span, call_move_val_init);
 
-                        let place = self.expr_ident(e.span, place_ident, None, place_binding);
+                        let place = self.expr_ident(e.span, place_ident, place_binding);
                         let call = make_call(self, &inplace_finalize, hir_vec![place]);
                         self.signal_block_expr(hir_vec![call_move_val_init],
                                                call,
                                                e.span,
-                                               hir::PushUnsafeBlock(hir::CompilerGenerated), None)
+                                               hir::PushUnsafeBlock(hir::CompilerGenerated),
+                                               ThinVec::new())
                     };
 
                     return self.signal_block_expr(hir_vec![s1, s2, s3],
@@ -1101,7 +1102,7 @@ impl<'a> LoweringContext<'a> {
                                     rules: hir::DefaultBlock,
                                     span: span,
                                 });
-                                self.expr_block(blk, None)
+                                self.expr_block(blk, ThinVec::new())
                             }
                             _ => self.lower_expr(els),
                         }
@@ -1168,7 +1169,7 @@ impl<'a> LoweringContext<'a> {
                                                                           expr,
                                                                           e.span,
                                                                           hir::PopUnstableBlock,
-                                                                          None);
+                                                                          ThinVec::new());
                                 this.field(token::intern(s), signal_block, ast_expr.span)
                             }).collect();
                             let attrs = ast_expr.attrs.clone();
@@ -1180,7 +1181,7 @@ impl<'a> LoweringContext<'a> {
                                                hir_expr,
                                                ast_expr.span,
                                                hir::PushUnstableBlock,
-                                               None)
+                                               ThinVec::new())
                     }
 
                     use syntax::ast::RangeLimits::*;
@@ -1267,9 +1268,9 @@ impl<'a> LoweringContext<'a> {
                             ex.span = e.span;
                         }
                         // merge attributes into the inner expression.
-                        ex.attrs.update(|attrs| {
-                            attrs.prepend(e.attrs.clone())
-                        });
+                        let mut attrs = e.attrs.clone();
+                        attrs.extend::<Vec<_>>(ex.attrs.into());
+                        ex.attrs = attrs;
                         ex
                     });
                 }
@@ -1288,7 +1289,7 @@ impl<'a> LoweringContext<'a> {
                     // `<pat> => <body>`
                     let pat_arm = {
                         let body = self.lower_block(body);
-                        let body_expr = self.expr_block(body, None);
+                        let body_expr = self.expr_block(body, ThinVec::new());
                         let pat = self.lower_pat(pat);
                         self.arm(hir_vec![pat], body_expr)
                     };
@@ -1308,7 +1309,7 @@ impl<'a> LoweringContext<'a> {
                                                 attrs: hir_vec![],
                                                 pats: hir_vec![pat_under],
                                                 guard: Some(cond),
-                                                body: self.expr_block(then, None),
+                                                body: self.expr_block(then, ThinVec::new()),
                                             });
                                             else_opt.map(|else_opt| (else_opt, true))
                                         }
@@ -1339,7 +1340,7 @@ impl<'a> LoweringContext<'a> {
                     let else_arm = {
                         let pat_under = self.pat_wild(e.span);
                         let else_expr =
-                            else_opt.unwrap_or_else(|| self.expr_tuple(e.span, hir_vec![], None));
+                            else_opt.unwrap_or_else(|| self.expr_tuple(e.span, hir_vec![]));
                         self.arm(hir_vec![pat_under], else_expr)
                     };
 
@@ -1374,7 +1375,7 @@ impl<'a> LoweringContext<'a> {
                     // `<pat> => <body>`
                     let pat_arm = {
                         let body = self.lower_block(body);
-                        let body_expr = self.expr_block(body, None);
+                        let body_expr = self.expr_block(body, ThinVec::new());
                         let pat = self.lower_pat(pat);
                         self.arm(hir_vec![pat], body_expr)
                     };
@@ -1382,7 +1383,7 @@ impl<'a> LoweringContext<'a> {
                     // `_ => break`
                     let break_arm = {
                         let pat_under = self.pat_wild(e.span);
-                        let break_expr = self.expr_break(e.span, None);
+                        let break_expr = self.expr_break(e.span, ThinVec::new());
                         self.arm(hir_vec![pat_under], break_expr)
                     };
 
@@ -1393,7 +1394,7 @@ impl<'a> LoweringContext<'a> {
                                                hir::ExprMatch(sub_expr,
                                                               arms,
                                                               hir::MatchSource::WhileLetDesugar),
-                                               None);
+                                               ThinVec::new());
 
                     // `[opt_ident]: loop { ... }`
                     let loop_block = self.block_expr(match_expr);
@@ -1435,7 +1436,7 @@ impl<'a> LoweringContext<'a> {
                             id: self.next_id(),
                             node: hir::ExprBlock(body_block),
                             span: body_span,
-                            attrs: None,
+                            attrs: ThinVec::new(),
                         });
                         let pat = self.lower_pat(pat);
                         let some_pat = self.pat_some(e.span, pat);
@@ -1445,7 +1446,7 @@ impl<'a> LoweringContext<'a> {
 
                     // `::std::option::Option::None => break`
                     let break_arm = {
-                        let break_expr = self.expr_break(e.span, None);
+                        let break_expr = self.expr_break(e.span, ThinVec::new());
                         let pat = self.pat_none(e.span);
                         self.arm(hir_vec![pat], break_expr)
                     };
@@ -1461,25 +1462,26 @@ impl<'a> LoweringContext<'a> {
 
                             self.path_global(e.span, strs)
                         };
-                        let iter = self.expr_ident(e.span, iter, None, iter_pat.id);
-                        let ref_mut_iter = self.expr_mut_addr_of(e.span, iter, None);
-                        let next_path = self.expr_path(next_path, None);
-                        let next_expr = self.expr_call(e.span,
-                                                       next_path,
-                                                       hir_vec![ref_mut_iter],
-                                                       None);
+                        let iter = self.expr_ident(e.span, iter, iter_pat.id);
+                        let ref_mut_iter = self.expr_mut_addr_of(e.span, iter);
+                        let next_path = self.expr_path(next_path, ThinVec::new());
+                        let next_expr = self.expr_call(e.span, next_path, hir_vec![ref_mut_iter]);
                         let arms = hir_vec![pat_arm, break_arm];
 
                         self.expr(e.span,
                                   hir::ExprMatch(next_expr, arms, hir::MatchSource::ForLoopDesugar),
-                                  None)
+                                  ThinVec::new())
                     };
 
                     // `[opt_ident]: loop { ... }`
                     let loop_block = self.block_expr(match_expr);
                     let loop_expr = hir::ExprLoop(loop_block, self.lower_opt_sp_ident(opt_ident));
-                    let loop_expr =
-                        P(hir::Expr { id: e.id, node: loop_expr, span: e.span, attrs: None });
+                    let loop_expr = P(hir::Expr {
+                        id: e.id,
+                        node: loop_expr,
+                        span: e.span,
+                        attrs: ThinVec::new(),
+                    });
 
                     // `mut iter => { ... }`
                     let iter_arm = self.arm(hir_vec![iter_pat], loop_expr);
@@ -1492,23 +1494,22 @@ impl<'a> LoweringContext<'a> {
                             self.path_global(e.span, strs)
                         };
 
-                        let into_iter = self.expr_path(into_iter_path, None);
-                        self.expr_call(e.span, into_iter, hir_vec![head], None)
+                        let into_iter = self.expr_path(into_iter_path, ThinVec::new());
+                        self.expr_call(e.span, into_iter, hir_vec![head])
                     };
 
                     let match_expr = self.expr_match(e.span,
                                                      into_iter_expr,
                                                      hir_vec![iter_arm],
-                                                     hir::MatchSource::ForLoopDesugar,
-                                                     None);
+                                                     hir::MatchSource::ForLoopDesugar);
 
                     // `{ let _result = ...; _result }`
                     // underscore prevents an unused_variables lint if the head diverges
                     let result_ident = self.str_to_ident("_result");
                     let (let_stmt, let_stmt_binding) =
-                        self.stmt_let(e.span, false, result_ident, match_expr, None);
+                        self.stmt_let(e.span, false, result_ident, match_expr);
 
-                    let result = self.expr_ident(e.span, result_ident, None, let_stmt_binding);
+                    let result = self.expr_ident(e.span, result_ident, let_stmt_binding);
                     let block = self.block_all(e.span, hir_vec![let_stmt], Some(result));
                     // add the attributes to the outer returned expr node
                     return self.expr_block(block, e.attrs.clone());
@@ -1535,7 +1536,7 @@ impl<'a> LoweringContext<'a> {
                     let ok_arm = {
                         let val_ident = self.str_to_ident("val");
                         let val_pat = self.pat_ident(e.span, val_ident);
-                        let val_expr = self.expr_ident(e.span, val_ident, None, val_pat.id);
+                        let val_expr = self.expr_ident(e.span, val_ident, val_pat.id);
                         let ok_pat = self.pat_ok(e.span, val_pat);
 
                         self.arm(hir_vec![ok_pat], val_expr)
@@ -1548,26 +1549,26 @@ impl<'a> LoweringContext<'a> {
                         let from_expr = {
                             let path = self.std_path(&["convert", "From", "from"]);
                             let path = self.path_global(e.span, path);
-                            let from = self.expr_path(path, None);
-                            let err_expr = self.expr_ident(e.span, err_ident, None, err_local.id);
+                            let from = self.expr_path(path, ThinVec::new());
+                            let err_expr = self.expr_ident(e.span, err_ident, err_local.id);
 
-                            self.expr_call(e.span, from, hir_vec![err_expr], None)
+                            self.expr_call(e.span, from, hir_vec![err_expr])
                         };
                         let err_expr = {
                             let path = self.std_path(&["result", "Result", "Err"]);
                             let path = self.path_global(e.span, path);
-                            let err_ctor = self.expr_path(path, None);
-                            self.expr_call(e.span, err_ctor, hir_vec![from_expr], None)
+                            let err_ctor = self.expr_path(path, ThinVec::new());
+                            self.expr_call(e.span, err_ctor, hir_vec![from_expr])
                         };
                         let err_pat = self.pat_err(e.span, err_local);
                         let ret_expr = self.expr(e.span,
-                                                 hir::Expr_::ExprRet(Some(err_expr)), None);
-
+                                                 hir::Expr_::ExprRet(Some(err_expr)),
+                                                 ThinVec::new());
                         self.arm(hir_vec![err_pat], ret_expr)
                     };
 
                     return self.expr_match(e.span, sub_expr, hir_vec![err_arm, ok_arm],
-                                           hir::MatchSource::TryDesugar, None);
+                                           hir::MatchSource::TryDesugar);
                 }
 
                 ExprKind::Mac(_) => panic!("Shouldn't exist here"),
@@ -1682,23 +1683,18 @@ impl<'a> LoweringContext<'a> {
         }
     }
 
-    fn expr_break(&mut self, span: Span, attrs: ThinAttributes) -> P<hir::Expr> {
+    fn expr_break(&mut self, span: Span, attrs: ThinVec<Attribute>) -> P<hir::Expr> {
         self.expr(span, hir::ExprBreak(None), attrs)
     }
 
-    fn expr_call(&mut self,
-                 span: Span,
-                 e: P<hir::Expr>,
-                 args: hir::HirVec<P<hir::Expr>>,
-                 attrs: ThinAttributes)
+    fn expr_call(&mut self, span: Span, e: P<hir::Expr>, args: hir::HirVec<P<hir::Expr>>)
                  -> P<hir::Expr> {
-        self.expr(span, hir::ExprCall(e, args), attrs)
+        self.expr(span, hir::ExprCall(e, args), ThinVec::new())
     }
 
-    fn expr_ident(&mut self, span: Span, id: Name, attrs: ThinAttributes, binding: NodeId)
-                  -> P<hir::Expr> {
+    fn expr_ident(&mut self, span: Span, id: Name, binding: NodeId) -> P<hir::Expr> {
         let expr_path = hir::ExprPath(None, self.path_ident(span, id));
-        let expr = self.expr(span, expr_path, attrs);
+        let expr = self.expr(span, expr_path, ThinVec::new());
 
         let def = self.resolver.definitions().map(|defs| {
             Def::Local(defs.local_def_id(binding), binding)
@@ -1708,12 +1704,11 @@ impl<'a> LoweringContext<'a> {
         expr
     }
 
-    fn expr_mut_addr_of(&mut self, span: Span, e: P<hir::Expr>, attrs: ThinAttributes)
-                        -> P<hir::Expr> {
-        self.expr(span, hir::ExprAddrOf(hir::MutMutable, e), attrs)
+    fn expr_mut_addr_of(&mut self, span: Span, e: P<hir::Expr>) -> P<hir::Expr> {
+        self.expr(span, hir::ExprAddrOf(hir::MutMutable, e), ThinVec::new())
     }
 
-    fn expr_path(&mut self, path: hir::Path, attrs: ThinAttributes) -> P<hir::Expr> {
+    fn expr_path(&mut self, path: hir::Path, attrs: ThinVec<Attribute>) -> P<hir::Expr> {
         let def = self.resolver.resolve_generated_global_path(&path, true);
         let expr = self.expr(path.span, hir::ExprPath(None, path), attrs);
         self.resolver.record_resolution(expr.id, def);
@@ -1724,19 +1719,17 @@ impl<'a> LoweringContext<'a> {
                   span: Span,
                   arg: P<hir::Expr>,
                   arms: hir::HirVec<hir::Arm>,
-                  source: hir::MatchSource,
-                  attrs: ThinAttributes)
+                  source: hir::MatchSource)
                   -> P<hir::Expr> {
-        self.expr(span, hir::ExprMatch(arg, arms, source), attrs)
+        self.expr(span, hir::ExprMatch(arg, arms, source), ThinVec::new())
     }
 
-    fn expr_block(&mut self, b: P<hir::Block>, attrs: ThinAttributes) -> P<hir::Expr> {
+    fn expr_block(&mut self, b: P<hir::Block>, attrs: ThinVec<Attribute>) -> P<hir::Expr> {
         self.expr(b.span, hir::ExprBlock(b), attrs)
     }
 
-    fn expr_tuple(&mut self, sp: Span, exprs: hir::HirVec<P<hir::Expr>>, attrs: ThinAttributes)
-                  -> P<hir::Expr> {
-        self.expr(sp, hir::ExprTup(exprs), attrs)
+    fn expr_tuple(&mut self, sp: Span, exprs: hir::HirVec<P<hir::Expr>>) -> P<hir::Expr> {
+        self.expr(sp, hir::ExprTup(exprs), ThinVec::new())
     }
 
     fn expr_struct(&mut self,
@@ -1744,14 +1737,14 @@ impl<'a> LoweringContext<'a> {
                    path: hir::Path,
                    fields: hir::HirVec<hir::Field>,
                    e: Option<P<hir::Expr>>,
-                   attrs: ThinAttributes) -> P<hir::Expr> {
+                   attrs: ThinVec<Attribute>) -> P<hir::Expr> {
         let def = self.resolver.resolve_generated_global_path(&path, false);
         let expr = self.expr(sp, hir::ExprStruct(path, fields, e), attrs);
         self.resolver.record_resolution(expr.id, def);
         expr
     }
 
-    fn expr(&mut self, span: Span, node: hir::Expr_, attrs: ThinAttributes) -> P<hir::Expr> {
+    fn expr(&mut self, span: Span, node: hir::Expr_, attrs: ThinVec<Attribute>) -> P<hir::Expr> {
         P(hir::Expr {
             id: self.next_id(),
             node: node,
@@ -1760,12 +1753,7 @@ impl<'a> LoweringContext<'a> {
         })
     }
 
-    fn stmt_let(&mut self,
-                sp: Span,
-                mutbl: bool,
-                ident: Name,
-                ex: P<hir::Expr>,
-                attrs: ThinAttributes)
+    fn stmt_let(&mut self, sp: Span, mutbl: bool, ident: Name, ex: P<hir::Expr>)
                 -> (hir::Stmt, NodeId) {
         let pat = if mutbl {
             self.pat_ident_binding_mode(sp, ident, hir::BindByValue(hir::MutMutable))
@@ -1779,7 +1767,7 @@ impl<'a> LoweringContext<'a> {
             init: Some(ex),
             id: self.next_id(),
             span: sp,
-            attrs: attrs,
+            attrs: ThinVec::new(),
         });
         let decl = respan(sp, hir::DeclLocal(local));
         (respan(sp, hir::StmtDecl(P(decl), self.next_id())), pat_id)
@@ -1939,7 +1927,7 @@ impl<'a> LoweringContext<'a> {
                          expr: P<hir::Expr>,
                          span: Span,
                          rule: hir::BlockCheckMode,
-                         attrs: ThinAttributes)
+                         attrs: ThinVec<Attribute>)
                          -> P<hir::Expr> {
         let id = self.next_id();
         let block = P(hir::Block {

--- a/src/librustc/hir/map/blocks.rs
+++ b/src/librustc/hir/map/blocks.rs
@@ -27,7 +27,6 @@ use hir::map::{self, Node};
 use syntax::abi;
 use hir::{Block, FnDecl};
 use syntax::ast::{Attribute, Name, NodeId};
-use syntax::attr::ThinAttributesExt;
 use hir as ast;
 use syntax::codemap::Span;
 use hir::intravisit::FnKind;
@@ -257,11 +256,7 @@ impl<'a> FnLikeNode<'a> {
             }
             map::NodeExpr(e) => match e.node {
                 ast::ExprClosure(_, ref decl, ref block, _fn_decl_span) =>
-                    closure(ClosureParts::new(&decl,
-                                              &block,
-                                              e.id,
-                                              e.span,
-                                              e.attrs.as_attr_slice())),
+                    closure(ClosureParts::new(&decl, &block, e.id, e.span, &e.attrs)),
                 _ => bug!("expr FnLikeNode that is not fn-like"),
             },
             _ => bug!("other FnLikeNode that is not fn-like"),

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -23,7 +23,6 @@ use hir::def_id::{CRATE_DEF_INDEX, DefId, DefIndex};
 
 use syntax::abi::Abi;
 use syntax::ast::{self, Name, NodeId, DUMMY_NODE_ID, };
-use syntax::attr::ThinAttributesExt;
 use syntax::codemap::{Span, Spanned};
 use syntax::visit;
 
@@ -577,7 +576,7 @@ impl<'ast> Map<'ast> {
             Some(NodeTraitItem(ref ti)) => Some(&ti.attrs[..]),
             Some(NodeImplItem(ref ii)) => Some(&ii.attrs[..]),
             Some(NodeVariant(ref v)) => Some(&v.node.attrs[..]),
-            Some(NodeExpr(ref e)) => Some(e.attrs.as_attr_slice()),
+            Some(NodeExpr(ref e)) => Some(&*e.attrs),
             Some(NodeStmt(ref s)) => Some(s.node.attrs()),
             // unit/tuple structs take the attributes straight from
             // the struct definition.

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -40,9 +40,9 @@ use syntax::codemap::{self, mk_sp, respan, Span, Spanned, ExpnId};
 use syntax::abi::Abi;
 use syntax::ast::{Name, NodeId, DUMMY_NODE_ID, TokenTree, AsmDialect};
 use syntax::ast::{Attribute, Lit, StrStyle, FloatTy, IntTy, UintTy, MetaItem};
-use syntax::attr::{ThinAttributes, ThinAttributesExt};
 use syntax::parse::token::{keywords, InternedString};
 use syntax::ptr::P;
+use syntax::util::ThinVec;
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -732,7 +732,7 @@ impl Stmt_ {
         match *self {
             StmtDecl(ref d, _) => d.node.attrs(),
             StmtExpr(ref e, _) |
-            StmtSemi(ref e, _) => e.attrs.as_attr_slice(),
+            StmtSemi(ref e, _) => &e.attrs,
         }
     }
 
@@ -756,7 +756,7 @@ pub struct Local {
     pub init: Option<P<Expr>>,
     pub id: NodeId,
     pub span: Span,
-    pub attrs: ThinAttributes,
+    pub attrs: ThinVec<Attribute>,
 }
 
 pub type Decl = Spanned<Decl_>;
@@ -772,7 +772,7 @@ pub enum Decl_ {
 impl Decl_ {
     pub fn attrs(&self) -> &[Attribute] {
         match *self {
-            DeclLocal(ref l) => l.attrs.as_attr_slice(),
+            DeclLocal(ref l) => &l.attrs,
             DeclItem(_) => &[]
         }
     }
@@ -817,7 +817,7 @@ pub struct Expr {
     pub id: NodeId,
     pub node: Expr_,
     pub span: Span,
-    pub attrs: ThinAttributes,
+    pub attrs: ThinVec<Attribute>,
 }
 
 impl fmt::Debug for Expr {

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -44,7 +44,6 @@ use syntax::codemap::Span;
 use syntax::errors::DiagnosticBuilder;
 use syntax::parse::token::InternedString;
 use syntax::ast;
-use syntax::attr::ThinAttributesExt;
 use hir;
 use hir::intravisit as hir_visit;
 use hir::intravisit::{IdVisitor, IdVisitingOperation};
@@ -767,7 +766,7 @@ impl<'a, 'tcx, 'v> hir_visit::Visitor<'v> for LateContext<'a, 'tcx> {
     }
 
     fn visit_expr(&mut self, e: &hir::Expr) {
-        self.with_lint_attrs(e.attrs.as_attr_slice(), |cx| {
+        self.with_lint_attrs(&e.attrs, |cx| {
             run_lints!(cx, check_expr, late_passes, e);
             hir_visit::walk_expr(cx, e);
         })
@@ -832,7 +831,7 @@ impl<'a, 'tcx, 'v> hir_visit::Visitor<'v> for LateContext<'a, 'tcx> {
     }
 
     fn visit_local(&mut self, l: &hir::Local) {
-        self.with_lint_attrs(l.attrs.as_attr_slice(), |cx| {
+        self.with_lint_attrs(&l.attrs, |cx| {
             run_lints!(cx, check_local, late_passes, l);
             hir_visit::walk_local(cx, l);
         })
@@ -928,7 +927,7 @@ impl<'a, 'v> ast_visit::Visitor<'v> for EarlyContext<'a> {
     }
 
     fn visit_expr(&mut self, e: &ast::Expr) {
-        self.with_lint_attrs(e.attrs.as_attr_slice(), |cx| {
+        self.with_lint_attrs(&e.attrs, |cx| {
             run_lints!(cx, check_expr, early_passes, e);
             ast_visit::walk_expr(cx, e);
         })
@@ -988,7 +987,7 @@ impl<'a, 'v> ast_visit::Visitor<'v> for EarlyContext<'a> {
     }
 
     fn visit_local(&mut self, l: &ast::Local) {
-        self.with_lint_attrs(l.attrs.as_attr_slice(), |cx| {
+        self.with_lint_attrs(&l.attrs, |cx| {
             run_lints!(cx, check_local, early_passes, l);
             ast_visit::walk_local(cx, l);
         })

--- a/src/librustc_const_eval/check_match.rs
+++ b/src/librustc_const_eval/check_match.rs
@@ -451,7 +451,7 @@ fn const_val_to_expr(value: &ConstVal) -> P<hir::Expr> {
         id: 0,
         node: hir::ExprLit(P(Spanned { node: node, span: DUMMY_SP })),
         span: DUMMY_SP,
-        attrs: None,
+        attrs: ast::ThinVec::new(),
     })
 }
 

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -672,7 +672,7 @@ impl fold::Folder for ReplaceBodyWithLoop {
                 node: ast::ExprKind::Loop(empty_block, None),
                 id: ast::DUMMY_NODE_ID,
                 span: codemap::DUMMY_SP,
-                attrs: None,
+                attrs: ast::ThinVec::new(),
             });
 
             expr_to_block(b.rules, Some(loop_expr))

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -14,8 +14,9 @@ pub use self::TyParamBound::*;
 pub use self::UnsafeSource::*;
 pub use self::ViewPath_::*;
 pub use self::PathParameters::*;
+pub use util::ThinVec;
 
-use attr::{ThinAttributes, HasAttrs};
+use attr::HasAttrs;
 use codemap::{mk_sp, respan, Span, Spanned, DUMMY_SP, ExpnId};
 use abi::Abi;
 use errors;
@@ -809,7 +810,7 @@ pub enum StmtKind {
     /// Expr with trailing semi-colon (may have any type):
     Semi(P<Expr>, NodeId),
 
-    Mac(P<Mac>, MacStmtStyle, ThinAttributes),
+    Mac(P<Mac>, MacStmtStyle, ThinVec<Attribute>),
 }
 
 impl StmtKind {
@@ -851,7 +852,7 @@ pub struct Local {
     pub init: Option<P<Expr>>,
     pub id: NodeId,
     pub span: Span,
-    pub attrs: ThinAttributes,
+    pub attrs: ThinVec<Attribute>,
 }
 
 impl Local {
@@ -912,7 +913,7 @@ pub struct Expr {
     pub id: NodeId,
     pub node: ExprKind,
     pub span: Span,
-    pub attrs: ThinAttributes
+    pub attrs: ThinVec<Attribute>
 }
 
 impl Expr {

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -26,6 +26,7 @@ use parse::lexer::comments::{doc_comment_style, strip_doc_comment_decoration};
 use parse::token::InternedString;
 use parse::{ParseSess, token};
 use ptr::P;
+use util::ThinVec;
 
 use std::cell::{RefCell, Cell};
 use std::collections::HashSet;
@@ -803,80 +804,6 @@ impl IntType {
     }
 }
 
-/// A list of attributes, behind a optional box as
-/// a space optimization.
-pub type ThinAttributes = Option<Box<Vec<Attribute>>>;
-
-pub trait ThinAttributesExt {
-    fn map_thin_attrs<F>(self, f: F) -> Self
-        where F: FnOnce(Vec<Attribute>) -> Vec<Attribute>;
-    fn prepend(mut self, attrs: Self) -> Self;
-    fn append(mut self, attrs: Self) -> Self;
-    fn update<F>(&mut self, f: F)
-        where Self: Sized,
-              F: FnOnce(Self) -> Self;
-    fn as_attr_slice(&self) -> &[Attribute];
-    fn into_attr_vec(self) -> Vec<Attribute>;
-}
-
-impl ThinAttributesExt for ThinAttributes {
-    fn map_thin_attrs<F>(self, f: F) -> Self
-        where F: FnOnce(Vec<Attribute>) -> Vec<Attribute>
-    {
-        f(self.map(|b| *b).unwrap_or(Vec::new())).into_thin_attrs()
-    }
-
-    fn prepend(self, attrs: ThinAttributes) -> Self {
-        attrs.map_thin_attrs(|mut attrs| {
-            attrs.extend(self.into_attr_vec());
-            attrs
-        })
-    }
-
-    fn append(self, attrs: ThinAttributes) -> Self {
-        self.map_thin_attrs(|mut self_| {
-            self_.extend(attrs.into_attr_vec());
-            self_
-        })
-    }
-
-    fn update<F>(&mut self, f: F)
-        where Self: Sized,
-              F: FnOnce(ThinAttributes) -> ThinAttributes
-    {
-        let self_ = f(self.take());
-        *self = self_;
-    }
-
-    fn as_attr_slice(&self) -> &[Attribute] {
-        match *self {
-            Some(ref b) => b,
-            None => &[],
-        }
-    }
-
-    fn into_attr_vec(self) -> Vec<Attribute> {
-        match self {
-            Some(b) => *b,
-            None => Vec::new(),
-        }
-    }
-}
-
-pub trait AttributesExt {
-    fn into_thin_attrs(self) -> ThinAttributes;
-}
-
-impl AttributesExt for Vec<Attribute> {
-    fn into_thin_attrs(self) -> ThinAttributes {
-        if self.len() == 0 {
-            None
-        } else {
-            Some(Box::new(self))
-        }
-    }
-}
-
 pub trait HasAttrs: Sized {
     fn attrs(&self) -> &[ast::Attribute];
     fn map_attrs<F: FnOnce(Vec<ast::Attribute>) -> Vec<ast::Attribute>>(self, f: F) -> Self;
@@ -885,13 +812,13 @@ pub trait HasAttrs: Sized {
 /// A cheap way to add Attributes to an AST node.
 pub trait WithAttrs {
     // FIXME: Could be extended to anything IntoIter<Item=Attribute>
-    fn with_attrs(self, attrs: ThinAttributes) -> Self;
+    fn with_attrs(self, attrs: ThinVec<Attribute>) -> Self;
 }
 
 impl<T: HasAttrs> WithAttrs for T {
-    fn with_attrs(self, attrs: ThinAttributes) -> Self {
+    fn with_attrs(self, attrs: ThinVec<Attribute>) -> Self {
         self.map_attrs(|mut orig_attrs| {
-            orig_attrs.extend(attrs.into_attr_vec());
+            orig_attrs.extend::<Vec<_>>(attrs.into());
             orig_attrs
         })
     }
@@ -906,12 +833,12 @@ impl HasAttrs for Vec<Attribute> {
     }
 }
 
-impl HasAttrs for ThinAttributes {
+impl HasAttrs for ThinVec<Attribute> {
     fn attrs(&self) -> &[Attribute] {
-        self.as_attr_slice()
+        &self
     }
     fn map_attrs<F: FnOnce(Vec<Attribute>) -> Vec<Attribute>>(self, f: F) -> Self {
-        self.map_thin_attrs(f)
+        f(self.into()).into()
     }
 }
 

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -350,7 +350,7 @@ impl DummyResult {
             id: ast::DUMMY_NODE_ID,
             node: ast::ExprKind::Lit(P(codemap::respan(sp, ast::LitKind::Bool(false)))),
             span: sp,
-            attrs: None,
+            attrs: ast::ThinVec::new(),
         })
     }
 

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -525,7 +525,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             init: Some(ex),
             id: ast::DUMMY_NODE_ID,
             span: sp,
-            attrs: None,
+            attrs: ast::ThinVec::new(),
         });
         let decl = respan(sp, ast::DeclKind::Local(local));
         respan(sp, ast::StmtKind::Decl(P(decl), ast::DUMMY_NODE_ID))
@@ -550,7 +550,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             init: Some(ex),
             id: ast::DUMMY_NODE_ID,
             span: sp,
-            attrs: None,
+            attrs: ast::ThinVec::new(),
         });
         let decl = respan(sp, ast::DeclKind::Local(local));
         P(respan(sp, ast::StmtKind::Decl(P(decl), ast::DUMMY_NODE_ID)))
@@ -587,7 +587,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             id: ast::DUMMY_NODE_ID,
             node: node,
             span: span,
-            attrs: None,
+            attrs: ast::ThinVec::new(),
         })
     }
 

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -16,7 +16,7 @@ use ast;
 use ext::mtwt;
 use ext::build::AstBuilder;
 use attr;
-use attr::{AttrMetaMethods, WithAttrs, ThinAttributesExt};
+use attr::{AttrMetaMethods, WithAttrs};
 use codemap;
 use codemap::{Span, Spanned, ExpnInfo, ExpnId, NameAndSpan, MacroBang, MacroAttribute};
 use config::StripUnconfigured;
@@ -104,7 +104,7 @@ pub fn expand_expr(expr: ast::Expr, fld: &mut MacroExpander) -> P<ast::Expr> {
         // expr_mac should really be expr_ext or something; it's the
         // entry-point for all syntax extensions.
         ast::ExprKind::Mac(mac) => {
-            expand_mac_invoc(mac, None, expr.attrs.into_attr_vec(), expr.span, fld)
+            expand_mac_invoc(mac, None, expr.attrs.into(), expr.span, fld)
         }
 
         ast::ExprKind::While(cond, body, opt_ident) => {
@@ -449,7 +449,7 @@ fn expand_stmt(stmt: Stmt, fld: &mut MacroExpander) -> SmallVector<Stmt> {
     };
 
     let mut fully_expanded: SmallVector<ast::Stmt> =
-        expand_mac_invoc(mac.unwrap(), None, attrs.into_attr_vec(), stmt.span, fld);
+        expand_mac_invoc(mac.unwrap(), None, attrs.into(), stmt.span, fld);
 
     // If this is a macro invocation with a semicolon, then apply that
     // semicolon to the final statement produced by expansion.
@@ -1054,7 +1054,7 @@ impl<'a, 'b> Folder for MacroExpander<'a, 'b> {
     fn fold_opt_expr(&mut self, expr: P<ast::Expr>) -> Option<P<ast::Expr>> {
         expr.and_then(|expr| match expr.node {
             ast::ExprKind::Mac(mac) =>
-                expand_mac_invoc(mac, None, expr.attrs.into_attr_vec(), expr.span, self),
+                expand_mac_invoc(mac, None, expr.attrs.into(), expr.span, self),
             _ => Some(expand_expr(expr, self)),
         })
     }

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -250,7 +250,7 @@ pub mod rt {
                 id: ast::DUMMY_NODE_ID,
                 node: ast::ExprKind::Lit(P(self.clone())),
                 span: DUMMY_SP,
-                attrs: None,
+                attrs: ast::ThinVec::new(),
             }).to_tokens(cx)
         }
     }
@@ -281,7 +281,7 @@ pub mod rt {
                         id: ast::DUMMY_NODE_ID,
                         node: ast::ExprKind::Lit(P(dummy_spanned(lit))),
                         span: DUMMY_SP,
-                        attrs: None,
+                        attrs: ast::ThinVec::new(),
                     });
                     if *self >= 0 {
                         return lit.to_tokens(cx);
@@ -290,7 +290,7 @@ pub mod rt {
                         id: ast::DUMMY_NODE_ID,
                         node: ast::ExprKind::Unary(ast::UnOp::Neg, lit),
                         span: DUMMY_SP,
-                        attrs: None,
+                        attrs: ast::ThinVec::new(),
                     }).to_tokens(cx)
                 }
             }

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -73,6 +73,9 @@ pub mod util {
     pub mod parser_testing;
     pub mod small_vector;
     pub mod move_map;
+
+    mod thin_vec;
+    pub use self::thin_vec::ThinVec;
 }
 
 pub mod diagnostics {

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -672,6 +672,7 @@ mod tests {
     use ptr::P;
     use util::parser_testing::{string_to_tts, string_to_parser};
     use util::parser_testing::{string_to_expr, string_to_item, string_to_stmt};
+    use util::ThinVec;
 
     // produce a codemap::span
     fn sp(a: u32, b: u32) -> Span {
@@ -693,7 +694,7 @@ mod tests {
                         ),
                     }),
                     span: sp(0, 1),
-                    attrs: None,
+                    attrs: ThinVec::new(),
                    }))
     }
 
@@ -716,7 +717,7 @@ mod tests {
                             )
                         }),
                     span: sp(0, 6),
-                    attrs: None,
+                    attrs: ThinVec::new(),
                    }))
     }
 
@@ -832,10 +833,10 @@ mod tests {
                             ),
                         }),
                         span:sp(7,8),
-                        attrs: None,
+                        attrs: ThinVec::new(),
                     }))),
                     span:sp(0,8),
-                    attrs: None,
+                    attrs: ThinVec::new(),
                    }))
     }
 
@@ -855,7 +856,7 @@ mod tests {
                                ),
                             }),
                            span: sp(0,1),
-                           attrs: None}),
+                           attrs: ThinVec::new()}),
                                            ast::DUMMY_NODE_ID),
                        span: sp(0,1)}))
 
@@ -950,7 +951,7 @@ mod tests {
                                                         ),
                                                       }),
                                                 span: sp(17,18),
-                                                attrs: None,}),
+                                                attrs: ThinVec::new(),}),
                                                 ast::DUMMY_NODE_ID),
                                             span: sp(17,19)}),
                                         expr: None,

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -14,7 +14,6 @@ use abi::{self, Abi};
 use ast::{self, TokenTree, BlockCheckMode, PatKind};
 use ast::{SelfKind, RegionTyParamBound, TraitTyParamBound, TraitBoundModifier};
 use ast::Attribute;
-use attr::ThinAttributesExt;
 use util::parser::AssocOp;
 use attr;
 use attr::{AttrMetaMethods, AttributeMethods};
@@ -1606,7 +1605,7 @@ impl<'a> State<'a> {
             }
             ast::StmtKind::Mac(ref mac, style, ref attrs) => {
                 try!(self.space_if_not_bol());
-                try!(self.print_outer_attributes(attrs.as_attr_slice()));
+                try!(self.print_outer_attributes(&attrs));
                 let delim = match style {
                     ast::MacStmtStyle::Braces => token::Brace,
                     _ => token::Paren
@@ -1946,7 +1945,7 @@ impl<'a> State<'a> {
                                   is_inline: bool) -> io::Result<()> {
         try!(self.maybe_print_comment(expr.span.lo));
 
-        let attrs = expr.attrs.as_attr_slice();
+        let attrs = &expr.attrs;
         if is_inline {
             try!(self.print_outer_attributes_inline(attrs));
         } else {
@@ -2090,9 +2089,7 @@ impl<'a> State<'a> {
                     let i_expr = body.expr.as_ref().unwrap();
                     match i_expr.node {
                         ast::ExprKind::Block(ref blk) => {
-                            try!(self.print_block_unclosed_with_attrs(
-                                &blk,
-                                i_expr.attrs.as_attr_slice()));
+                            try!(self.print_block_unclosed_with_attrs(&blk, &i_expr.attrs));
                         }
                         _ => {
                             // this is a bare expression
@@ -2281,7 +2278,7 @@ impl<'a> State<'a> {
         try!(self.maybe_print_comment(decl.span.lo));
         match decl.node {
             ast::DeclKind::Local(ref loc) => {
-                try!(self.print_outer_attributes(loc.attrs.as_attr_slice()));
+                try!(self.print_outer_attributes(&loc.attrs));
                 try!(self.space_if_not_bol());
                 try!(self.ibox(INDENT_UNIT));
                 try!(self.word_nbsp("let"));

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -604,10 +604,10 @@ fn mk_test_descs(cx: &TestCtxt) -> P<ast::Expr> {
                     mk_test_desc_and_fn_rec(cx, test)
                 }).collect()),
                 span: DUMMY_SP,
-                attrs: None,
+                attrs: ast::ThinVec::new(),
             })),
         span: DUMMY_SP,
-        attrs: None,
+        attrs: ast::ThinVec::new(),
     })
 }
 

--- a/src/libsyntax/util/thin_vec.rs
+++ b/src/libsyntax/util/thin_vec.rs
@@ -1,0 +1,59 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// A vector type optimized for cases where this size is usually 0 (c.f. `SmallVector`).
+/// The `Option<Box<..>>` wrapping allows us to represent a zero sized vector with `None`,
+/// which uses only a single (null) pointer.
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct ThinVec<T>(Option<Box<Vec<T>>>);
+
+impl<T> ThinVec<T> {
+    pub fn new() -> Self {
+        ThinVec(None)
+    }
+}
+
+impl<T> From<Vec<T>> for ThinVec<T> {
+    fn from(vec: Vec<T>) -> Self {
+        if vec.is_empty() {
+            ThinVec(None)
+        } else {
+            ThinVec(Some(Box::new(vec)))
+        }
+    }
+}
+
+impl<T> Into<Vec<T>> for ThinVec<T> {
+    fn into(self) -> Vec<T> {
+        match self {
+            ThinVec(None) => Vec::new(),
+            ThinVec(Some(vec)) => *vec,
+        }
+    }
+}
+
+impl<T> ::std::ops::Deref for ThinVec<T> {
+    type Target = [T];
+    fn deref(&self) -> &[T] {
+        match *self {
+            ThinVec(None) => &[],
+            ThinVec(Some(ref vec)) => vec,
+        }
+    }
+}
+
+impl<T> Extend<T> for ThinVec<T> {
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        match *self {
+            ThinVec(Some(ref mut vec)) => vec.extend(iter),
+            ThinVec(None) => *self = iter.into_iter().collect::<Vec<_>>().into(),
+        }
+    }
+}

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -25,7 +25,6 @@
 
 use abi::Abi;
 use ast::*;
-use attr::ThinAttributesExt;
 use codemap::{Span, Spanned};
 
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -185,7 +184,7 @@ pub fn walk_mod<'v, V: Visitor<'v>>(visitor: &mut V, module: &'v Mod) {
 }
 
 pub fn walk_local<'v, V: Visitor<'v>>(visitor: &mut V, local: &'v Local) {
-    for attr in local.attrs.as_attr_slice() {
+    for attr in local.attrs.iter() {
         visitor.visit_attribute(attr);
     }
     visitor.visit_pat(&local.pat);
@@ -619,7 +618,7 @@ pub fn walk_stmt<'v, V: Visitor<'v>>(visitor: &mut V, statement: &'v Stmt) {
         }
         StmtKind::Mac(ref mac, _, ref attrs) => {
             visitor.visit_mac(mac);
-            for attr in attrs.as_attr_slice() {
+            for attr in attrs.iter() {
                 visitor.visit_attribute(attr);
             }
         }
@@ -638,7 +637,7 @@ pub fn walk_mac<'v, V: Visitor<'v>>(_: &mut V, _: &'v Mac) {
 }
 
 pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
-    for attr in expression.attrs.as_attr_slice() {
+    for attr in expression.attrs.iter() {
         visitor.visit_attribute(attr);
     }
     match expression.node {

--- a/src/libsyntax_ext/asm.rs
+++ b/src/libsyntax_ext/asm.rs
@@ -260,6 +260,6 @@ pub fn expand_asm<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
             expn_id: expn_id,
         }),
         span: sp,
-        attrs: None,
+        attrs: ast::ThinVec::new(),
     }))
 }

--- a/src/libsyntax_ext/concat_idents.rs
+++ b/src/libsyntax_ext/concat_idents.rs
@@ -70,7 +70,7 @@ pub fn expand_syntax_ext<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[TokenTree])
                 id: ast::DUMMY_NODE_ID,
                 node: ast::ExprKind::Path(None, self.path()),
                 span: self.span,
-                attrs: None,
+                attrs: ast::ThinVec::new(),
             }))
         }
 

--- a/src/libsyntax_ext/deriving/debug.rs
+++ b/src/libsyntax_ext/deriving/debug.rs
@@ -149,7 +149,7 @@ fn stmt_let_undescore(cx: &mut ExtCtxt,
         init: Some(expr),
         id: ast::DUMMY_NODE_ID,
         span: sp,
-        attrs: None,
+        attrs: ast::ThinVec::new(),
     });
     let decl = respan(sp, ast::DeclKind::Local(local));
     respan(sp, ast::StmtKind::Decl(P(decl), ast::DUMMY_NODE_ID))

--- a/src/test/run-pass-fulldeps/ast_stmt_expr_attr.rs
+++ b/src/test/run-pass-fulldeps/ast_stmt_expr_attr.rs
@@ -86,7 +86,7 @@ fn check_expr_attrs(es: &str, expected: &[&str]) {
     let actual = &e.attrs;
     str_compare(es,
                 &expected.iter().map(|r| attr(r, &ps).unwrap()).collect::<Vec<_>>(),
-                actual.as_attr_slice(),
+                &actual,
                 pprust::attribute_to_string);
 }
 


### PR DESCRIPTION
**syntax-[breaking-change] cc #31645**
r? @Manishearth 
