### PR TITLE
fix build for clang 8.0

### DIFF
--- a/configure
+++ b/configure
@@ -1053,7 +1053,7 @@ then
         if [ -n "$CFG_OSX_CLANG_VERSION" ]
         then
             case $CFG_OSX_CLANG_VERSION in
-                (7.0* | 7.1* | 7.2* | 7.3*)
+                (7.0* | 7.1* | 7.2* | 7.3* | 8.0*)
                 step_msg "found ok version of APPLE CLANG: $CFG_OSX_CLANG_VERSION"
                 ;;
                 (*)


### PR DESCRIPTION
With 10.12 and XCode 8-beta we got clang 8.
Simple addition as clang 8 will build as well.
