### PR TITLE
Add test case for #30276

### DIFF
--- a/src/test/run-pass/issue-30276.rs
+++ b/src/test/run-pass/issue-30276.rs
@@ -1,0 +1,14 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Test([i32]);
+fn main() {
+    let _x: fn(_) -> Test = Test;
+}


### PR DESCRIPTION
Make sure that treating a DST tuple constructor as a function doesn't ICE.

Closes #30276
