### PR TITLE
Give `ast::ExprKind::Paren` no-op expressions the same ids as their children.

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -553,10 +553,6 @@ impl<'a> Parser<'a> {
         self.expect_one_of(edible, inedible)
     }
 
-    pub fn commit_stmt_expecting(&mut self, edible: token::Token) -> PResult<'a, ()> {
-        self.commit_stmt(&[edible], &[])
-    }
-
     /// returns the span of expr, if it was not interpolated or the span of the interpolated token
     fn interpolated_or_expr_span(&self,
                                  expr: PResult<'a, P<Expr>>)
@@ -4122,7 +4118,7 @@ impl<'a> Parser<'a> {
                 _ => { // all other kinds of statements:
                     let mut hi = span.hi;
                     if classify::stmt_ends_with_semi(&node) {
-                        self.commit_stmt_expecting(token::Semi)?;
+                        self.commit_stmt(&[token::Semi], &[])?;
                         hi = self.last_span.hi;
                     }
 


### PR DESCRIPTION
Having `ast::ExprKind::Paren` expressions share ids with their children
- reduces the number of unused `NodeId`s in the hir map and
- guarantees that `tcx.map.expect_expr(ast_expr.id)` is the hir corresponding to `ast_expr`.

This fixes the bug from #34327, which was introduced in #33296 when I assumed the above guarantee.

r? @nrc 
