### PR TITLE
Add `is_empty` function to `ExactSizeIterator`

### DIFF
--- a/src/libcore/iter/traits.rs
+++ b/src/libcore/iter/traits.rs
@@ -520,7 +520,6 @@ pub trait ExactSizeIterator: Iterator {
         lower
     }
 
-    ///
     /// Returns whether the iterator is empty.
     ///
     /// This method has a default implementation using `self.len()`, so you

--- a/src/libcore/iter/traits.rs
+++ b/src/libcore/iter/traits.rs
@@ -530,7 +530,9 @@ pub trait ExactSizeIterator: Iterator {
     /// Basic usage:
     ///
     /// ```
-    /// let mut one_element = [0].iter();
+    /// #![feature(exact_size_is_empty)]
+    ///
+    /// let mut one_element = 0..1;
     /// assert!(!one_element.is_empty());
     ///
     /// assert_eq!(one_element.next(), Some(0));

--- a/src/libcore/iter/traits.rs
+++ b/src/libcore/iter/traits.rs
@@ -485,8 +485,6 @@ impl<'a, I: DoubleEndedIterator + ?Sized> DoubleEndedIterator for &'a mut I {
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait ExactSizeIterator: Iterator {
-    #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
     /// Returns the exact number of times the iterator will iterate.
     ///
     /// This method has a default implementation, so you usually should not
@@ -510,6 +508,8 @@ pub trait ExactSizeIterator: Iterator {
     ///
     /// assert_eq!(5, five.len());
     /// ```
+    #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
     fn len(&self) -> usize {
         let (lower, upper) = self.size_hint();
         // Note: This assertion is overly defensive, but it checks the invariant
@@ -518,6 +518,31 @@ pub trait ExactSizeIterator: Iterator {
         // implementations too.
         assert_eq!(upper, Some(lower));
         lower
+    }
+
+    ///
+    /// Returns whether the iterator is empty.
+    ///
+    /// This method has a default implementation using `self.len()`, so you
+    /// don't need to implement it yourself.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// let mut one_element = [0].iter();
+    /// assert!(!one_element.is_empty());
+    ///
+    /// assert_eq!(one_element.next(), Some(0));
+    /// assert!(one_element.is_empty());
+    ///
+    /// assert_eq!(one_element.next(), None);
+    /// ```
+    #[inline]
+    #[unstable(feature = "exact_size_is_empty", issue = "0")]
+    fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 }
 

--- a/src/test/compile-fail/method-suggestion-no-duplication.rs
+++ b/src/test/compile-fail/method-suggestion-no-duplication.rs
@@ -18,7 +18,8 @@ fn foo<F>(f: F) where F: FnMut(Foo) {}
 fn main() {
     foo(|s| s.is_empty());
     //~^ ERROR no method named `is_empty` found
-    //~^^ HELP #1: `core::slice::SliceExt`
-    //~^^^ HELP #2: `core::str::StrExt`
-    //~^^^^ HELP items from traits can only be used if the trait is implemented and in scope; the following traits define an item `is_empty`, perhaps you need to implement one of them:
+    //~^^ HELP #1: `std::iter::ExactSizeIterator`
+    //~^^^ HELP #2: `core::slice::SliceExt`
+    //~^^^^ HELP #3: `core::str::StrExt`
+    //~^^^^^ HELP items from traits can only be used if the trait is implemented and in scope; the following traits define an item `is_empty`, perhaps you need to implement one of them:
 }


### PR DESCRIPTION
All other types implementing a `len` functions have `is_empty` already.
