### PR TITLE
Markdown formatting fix

### DIFF
--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -1608,6 +1608,7 @@ impl<Idx: PartialOrd<Idx>> RangeFrom<Idx> {
 /// See the [`contains()`](#method.contains) method for its characterization.
 ///
 /// It cannot serve as an iterator because it doesn't have a starting point.
+///
 /// ```
 /// fn main() {
 ///     assert_eq!((..5), std::ops::RangeTo{ end: 5 });


### PR DESCRIPTION
This pull request fixes some bad markdown formatting in the[ `std::ops::RangeTo` documentation](https://doc.rust-lang.org/std/ops/struct.RangeTo.html):

![screenshot from 2016-06-19 14 29 21](https://cloud.githubusercontent.com/assets/439973/16177354/5439a9bc-362a-11e6-97e5-374fd0bcf5a2.png)
