### PR TITLE
A disclaimer about keywords.

### DIFF
--- a/src/doc/grammar.md
+++ b/src/doc/grammar.md
@@ -172,6 +172,11 @@ token : simple_token | ident | literal | symbol | whitespace token ;
 Each of these keywords has special meaning in its grammar, and all of them are
 excluded from the `ident` rule.
 
+Not all of these keywords are used by the language. Some of them were used
+before Rust 1.0, and were left reserved once their implementations were
+removed. Some of them were reserved before 1.0 to make space for possible
+future features.
+
 ### Literals
 
 ```antlr


### PR DESCRIPTION
Some people cite this list as "zomg Rust has so many keywords," so make
it clear that these aren't all used by the language today.
