### PR TITLE
rustdoc: Add more types to the sidebar

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -884,12 +884,16 @@
             sidebar.append(div);
         }
 
+        block("primitive", "Primitive Types");
         block("mod", "Modules");
+        block("macro", "Macros");
         block("struct", "Structs");
         block("enum", "Enums");
+        block("constant", "Constants");
+        block("static", "Statics");
         block("trait", "Traits");
         block("fn", "Functions");
-        block("macro", "Macros");
+        block("type", "Type Definitions");
     }
 
     window.initSidebarItems = initSidebarItems;


### PR DESCRIPTION
They're displayed in the same order as they are on modules pages.

You can test [here](https://ollie27.github.io/rust_doc_test/std/).
For example:
[before](https://doc.rust-lang.org/nightly/std/char/constant.MAX.html) [after](https://ollie27.github.io/rust_doc_test/std/char/constant.MAX.html)
[before](https://doc.rust-lang.org/nightly/std/os/raw/type.c_char.html) [after](https://ollie27.github.io/rust_doc_test/std/os/raw/type.c_char.html)
