### PR TITLE
configure: Remove clang version checks

### DIFF
--- a/configure
+++ b/configure
@@ -1040,37 +1040,6 @@ if [ -n "$CFG_ENABLE_CLANG" ]
 then
     case "$CC" in
         (''|*clang)
-        CFG_CLANG_REPORTED_VERSION=$($CFG_CC --version | grep version)
-
-        if echo $CFG_CLANG_REPORTED_VERSION | grep -q "(based on LLVM "; then
-            CFG_CLANG_VERSION=$(echo $CFG_CLANG_REPORTED_VERSION | sed 's/.*(based on LLVM \(.*\))/\1/')
-        elif echo $CFG_CLANG_REPORTED_VERSION | grep -q "Apple LLVM"; then
-            CFG_OSX_CLANG_VERSION=$(echo $CFG_CLANG_REPORTED_VERSION | sed 's/.*version \(.*\) .*/\1/')
-        else
-            CFG_CLANG_VERSION=$(echo $CFG_CLANG_REPORTED_VERSION | sed 's/.*version \(.*\) .*/\1/')
-        fi
-
-        if [ -n "$CFG_OSX_CLANG_VERSION" ]
-        then
-            case $CFG_OSX_CLANG_VERSION in
-                (7.0* | 7.1* | 7.2* | 7.3* | 8.0*)
-                step_msg "found ok version of APPLE CLANG: $CFG_OSX_CLANG_VERSION"
-                ;;
-                (*)
-                err "bad APPLE CLANG version: $CFG_OSX_CLANG_VERSION, need >=7.0"
-                ;;
-            esac
-        else
-            case $CFG_CLANG_VERSION in
-                (3.2* | 3.3* | 3.4* | 3.5* | 3.6* | 3.7* | 3.8* | 3.9*)
-                step_msg "found ok version of CLANG: $CFG_CLANG_VERSION"
-                ;;
-                (*)
-                err "bad CLANG version: $CFG_CLANG_VERSION, need >=3.0svn"
-                ;;
-            esac
-        fi
-
         if [ -z "$CC" ]
         then
             CFG_CC="clang"


### PR DESCRIPTION
We no C++ and an incredibly small amount of C code as part of the build, so
there's not really much need for us to strictly check the version of compilers
as we're not really stressing anything. LLVM is a pretty huge chunk of C++ but
it should be the responsibility of LLVM to ensure that it can build with a
particular clang/gcc version, not ours (as this logic changes over time).

These version checks seem to basically just by us a regular stream of PRs every
six weeks or so when a new version is releases, so they're not really buying us
much. As a result, remove them and we can add then back piecemeal perhaps as a
blacklist if we really need to.
