### PR TITLE
DRY up FromIterator implementation for String

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -1391,27 +1391,11 @@ impl Clone for String {
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
-impl FromIterator<char> for String {
-    fn from_iter<I: IntoIterator<Item = char>>(iter: I) -> String {
-        let mut buf = String::new();
-        buf.extend(iter);
-        buf
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> FromIterator<&'a str> for String {
-    fn from_iter<I: IntoIterator<Item = &'a str>>(iter: I) -> String {
-        let mut buf = String::new();
-        buf.extend(iter);
-        buf
-    }
-}
-
-#[stable(feature = "extend_string", since = "1.4.0")]
-impl FromIterator<String> for String {
-    fn from_iter<I: IntoIterator<Item = String>>(iter: I) -> String {
+#[stable(feature = "from_iterator_dry", since = "1.11.0")]
+impl<T> FromIterator<T> for String
+    where String: Extend<T>
+{
+    default fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> String {
         let mut buf = String::new();
         buf.extend(iter);
         buf

--- a/src/test/run-pass/custom-extend.rs
+++ b/src/test/run-pass/custom-extend.rs
@@ -1,0 +1,33 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Ensure the blanket of FromIterator on String doesn't conflict with custom
+// implementations (even if specialization changes).
+// See: https://github.com/rust-lang/rust/pull/34389#issuecomment-227305533
+
+use std::iter::FromIterator;
+
+#[derive(Copy, Clone)]
+struct S;
+
+impl FromIterator<S> for String {
+    fn from_iter<T: IntoIterator<Item=S>>(iter: T) -> String {
+        let mut fin = String::new();
+        for _ in iter {
+            fin.push('a');
+        }
+        fin
+    }
+}
+
+fn main() {
+    let s: String = std::iter::repeat(S).take(5).collect();
+    assert_eq!("aaaaa", s);
+}


### PR DESCRIPTION
Instead of repeating the same implementation three times, `impl FromIterator<T>
for String where String: Extend<T>`.

Allow specialization to avoid breaking anything (otherwise, adding a blanket impl would be a breaking change).
