### PR TITLE
Mark concat_idents! unstable

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -276,7 +276,7 @@ pub mod builtin {
     /// // fn concat_idents!(new, fun, name) { } // not usable in this way!
     /// # }
     /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
+    #[unstable(feature = "concat_idents", issue = "29599")]
     #[macro_export]
     macro_rules! concat_idents {
         ($($e:ident),*) => ({ /* compiler built-in */ })


### PR DESCRIPTION
This is mostly just a documentation fix as I don't think stability
attributes have any effect on macros.

[before](https://doc.rust-lang.org/nightly/std/macro.concat_idents!.html) [after](https://ollie27.github.io/rust_doc_test/std/macro.concat_idents!.html)
