### PR TITLE
Don't translate vtable methods with Self: Sized bounds.

### DIFF
--- a/src/librustc/traits/object_safety.rs
+++ b/src/librustc/traits/object_safety.rs
@@ -228,9 +228,14 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     /// otherwise ensure that they cannot be used when `Self=Trait`.
     pub fn is_vtable_safe_method(self,
                                  trait_def_id: DefId,
-                                 method: &ty::Method<'tcx>)
+                                 method: &ty::Method<'gcx>)
                                  -> bool
     {
+        // Any method that has a `Self : Sized` requisite can't be called.
+        if self.generics_require_sized_self(&method.generics, &method.predicates) {
+            return false;
+        }
+
         self.virtual_call_violation_for_method(trait_def_id, method).is_none()
     }
 

--- a/src/test/run-pass/trait-object-exclusion.rs
+++ b/src/test/run-pass/trait-object-exclusion.rs
@@ -1,0 +1,28 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Future: 'static {
+    // The requirement for Self: Sized must prevent instantiation of
+    // Future::forget in vtables, otherwise there's an infinite type
+    // recursion through <Map<...> as Future>::forget.
+    fn forget(self) where Self: Sized {
+        Box::new(Map(self)) as Box<Future>;
+    }
+}
+
+struct Map<A>(A);
+impl<A: Future> Future for Map<A> {}
+
+pub struct Promise;
+impl Future for Promise {}
+
+fn main() {
+    Promise.forget();
+}


### PR DESCRIPTION
Fixes #34416.
