### PR TITLE
rustdoc: Fix panic caused by doc(hidden) trait methods

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2652,16 +2652,19 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
         if !is_static || render_static {
             if !is_default_item {
                 if let Some(t) = trait_ {
-                    let it = t.items.iter().find(|i| i.name == item.name).unwrap();
-                    // We need the stability of the item from the trait because
-                    // impls can't have a stability.
-                    document_stability(w, cx, it)?;
-                    if item.doc_value().is_some() {
-                        document_full(w, item)?;
-                    } else {
-                        // In case the item isn't documented,
-                        // provide short documentation from the trait.
-                        document_short(w, it, link)?;
+                    // The trait item may have been stripped so we might not
+                    // find any documentation or stability for it.
+                    if let Some(it) = t.items.iter().find(|i| i.name == item.name) {
+                        // We need the stability of the item from the trait
+                        // because impls can't have a stability.
+                        document_stability(w, cx, it)?;
+                        if item.doc_value().is_some() {
+                            document_full(w, item)?;
+                        } else {
+                            // In case the item isn't documented,
+                            // provide short documentation from the trait.
+                            document_short(w, it, link)?;
+                        }
                     }
                 } else {
                     document(w, cx, item)?;

--- a/src/test/rustdoc/issue-34423.rs
+++ b/src/test/rustdoc/issue-34423.rs
@@ -1,0 +1,20 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub struct Foo;
+
+pub trait Bar {
+    #[doc(hidden)]
+    fn bar() {}
+}
+
+impl Bar for Foo {
+    fn bar() {}
+}


### PR DESCRIPTION
Fixes: #34423

r? @alexcrichton
