### PR TITLE
Make IPv6 sockets bind to IPv6 addresses only

### DIFF
--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -628,4 +628,14 @@ mod tests {
         t!(stream.set_nonblocking(true));
         t!(stream.set_nonblocking(false));
     }
+
+    #[test]
+    fn both_ipv4_and_ipv6() {
+        let port = next_test_ip6().port();
+        let addr_v4 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port);
+        let addr_v6 = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)), port);
+
+        let _v4 = t!(UdpSocket::bind(&addr_v4));
+        let _v6 = t!(UdpSocket::bind(&addr_v6));
+    }
 }

--- a/src/libstd/sys/unix/net.rs
+++ b/src/libstd/sys/unix/net.rs
@@ -61,6 +61,15 @@ impl Socket {
     }
 
     pub fn new_raw(fam: c_int, ty: c_int) -> io::Result<Socket> {
+        Socket::new_raw_impl(fam, ty).and_then(|s| {
+            if fam == libc::AF_INET6 {
+                setsockopt(&s, libc::IPPROTO_IPV6, libc::IPV6_V6ONLY, true as c_int)?;
+            }
+            Ok(s)
+        })
+    }
+
+    fn new_raw_impl(fam: c_int, ty: c_int) -> io::Result<Socket> {
         unsafe {
             // On linux we first attempt to pass the SOCK_CLOEXEC flag to
             // atomically create the socket and set it as CLOEXEC. Support for


### PR DESCRIPTION
On Windows, this has been the behavior before[1](https://msdn.microsoft.com/en-us/library/windows/desktop/ms738574%28v=vs.85%29.aspx), on Linux, it hasn't.
This unifies the behavior across operating systems.
