### PR TITLE
Renames "lets_do_this" macro more appropriately.

### DIFF
--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -37,7 +37,7 @@ use hir;
 
 // The actual lang items defined come at the end of this file in one handy table.
 // So you probably just want to nip down to the end.
-macro_rules! lets_do_this {
+macro_rules! language_item_table {
     (
         $( $variant:ident, $name:expr, $method:ident; )*
     ) => {
@@ -269,7 +269,7 @@ pub fn collect_language_items(session: &Session,
     }
 }
 
-lets_do_this! {
+language_item_table! {
 //  Variant name,                    Name,                      Method name;
     CharImplItem,                    "char",                    char_impl;
     StrImplItem,                     "str",                     str_impl;


### PR DESCRIPTION
The macro gets used to create a mapping of identifiers to names and their
associated functions. Since it creates a table of language items, let's rename
it in a similar manner to how vec! creates a vec.
