### PR TITLE
Add example with leading zeros

### DIFF
--- a/src/libcollections/fmt.rs
+++ b/src/libcollections/fmt.rs
@@ -28,6 +28,7 @@
 //! format!("{:?}", (3, 4));          // => "(3, 4)"
 //! format!("{value}", value=4);      // => "4"
 //! format!("{} {}", 1, 2);           // => "1 2"
+//! format!("{:04}", 42);             // => "0042" with leading zeros
 //! ```
 //!
 //! From these, you can see that the first argument is a format string. It is


### PR DESCRIPTION
I was searching for this format very long. So I added an example to the prominent section.

I was thinking of putting the keyword leading in the corresponding section as well, what do you think?

r? @steveklabnik
