### PR TITLE
Fix broken links due to multiple mod paths for the same doc string

### DIFF
--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -35,9 +35,9 @@ use Bound;
 /// normally only possible through [`Cell`], [`RefCell`], global state, I/O, or unsafe code.
 ///
 /// [`BTreeMap`]: struct.BTreeMap.html
-/// [`Ord`]: ../../std/cmp/trait.Ord.html
-/// [`Cell`]: ../../std/cell/struct.Cell.html
-/// [`RefCell`]: ../../std/cell/struct.RefCell.html
+/// [`Ord`]: /std/cmp/trait.Ord.html
+/// [`Cell`]: /std/cell/struct.Cell.html
+/// [`RefCell`]: /std/cell/struct.RefCell.html
 ///
 /// # Examples
 ///

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -35,9 +35,9 @@ use Bound;
 /// normally only possible through [`Cell`], [`RefCell`], global state, I/O, or unsafe code.
 ///
 /// [`BTreeMap`]: struct.BTreeMap.html
-/// [`Ord`]: /std/cmp/trait.Ord.html
-/// [`Cell`]: /std/cell/struct.Cell.html
-/// [`RefCell`]: /std/cell/struct.RefCell.html
+/// [`Ord`]: ::/std/cmp/trait.Ord.html
+/// [`Cell`]: ::/std/cell/struct.Cell.html
+/// [`RefCell`]: ::/std/cell/struct.RefCell.html
 ///
 /// # Examples
 ///

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -10,7 +10,7 @@
 
 //! Unicode string slices.
 //!
-//! *[See also the `str` primitive type](../../std/primitive.str.html).*
+//! *[See also the `str` primitive type](::/std/primitive.str.html).*
 
 
 #![stable(feature = "rust1", since = "1.0.0")]
@@ -715,7 +715,7 @@ impl str {
     /// a character matches.
     ///
     /// [`char`]: primitive.char.html
-    /// [`None`]: /std/option/enum.Option.html#variant.None
+    /// [`None`]: ::/std/option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -760,7 +760,7 @@ impl str {
     /// a character matches.
     ///
     /// [`char`]: primitive.char.html
-    /// [`None`]: /std/option/enum.Option.html#variant.None
+    /// [`None`]: ::/std/option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -809,7 +809,7 @@ impl str {
     /// allows a reverse search and forward/reverse search yields the same
     /// elements. This is true for, eg, [`char`] but not for `&str`.
     ///
-    /// [`DoubleEndedIterator`]: /std/iter/trait.DoubleEndedIterator.html
+    /// [`DoubleEndedIterator`]: ::/std/iter/trait.DoubleEndedIterator.html
     ///
     /// If the pattern allows a reverse search but its results might differ
     /// from a forward search, the [`rsplit()`] method can be used.
@@ -922,7 +922,7 @@ impl str {
     /// search, and it will be a [`DoubleEndedIterator`] if a forward/reverse
     /// search yields the same elements.
     ///
-    /// [`DoubleEndedIterator`]: /std/iter/trait.DoubleEndedIterator.html
+    /// [`DoubleEndedIterator`]: ::/std/iter/trait.DoubleEndedIterator.html
     ///
     /// For iterating from the front, the [`split()`] method can be used.
     ///
@@ -979,7 +979,7 @@ impl str {
     /// allows a reverse search and forward/reverse search yields the same
     /// elements. This is true for, eg, [`char`] but not for `&str`.
     ///
-    /// [`DoubleEndedIterator`]: /std/iter/trait.DoubleEndedIterator.html
+    /// [`DoubleEndedIterator`]: ::/std/iter/trait.DoubleEndedIterator.html
     /// [`char`]: primitive.char.html
     ///
     /// If the pattern allows a reverse search but its results might differ
@@ -1161,7 +1161,7 @@ impl str {
     /// allows a reverse search and forward/reverse search yields the same
     /// elements. This is true for, eg, [`char`] but not for `&str`.
     ///
-    /// [`DoubleEndedIterator`]: /std/iter/trait.DoubleEndedIterator.html
+    /// [`DoubleEndedIterator`]: ::/std/iter/trait.DoubleEndedIterator.html
     /// [`char`]: primitive.char.html
     ///
     /// If the pattern allows a reverse search but its results might differ
@@ -1199,7 +1199,7 @@ impl str {
     /// search, and it will be a [`DoubleEndedIterator`] if a forward/reverse
     /// search yields the same elements.
     ///
-    /// [`DoubleEndedIterator`]: /std/iter/trait.DoubleEndedIterator.html
+    /// [`DoubleEndedIterator`]: ::/std/iter/trait.DoubleEndedIterator.html
     ///
     /// For iterating from the front, the [`matches()`] method can be used.
     ///
@@ -1240,7 +1240,7 @@ impl str {
     /// allows a reverse search and forward/reverse search yields the same
     /// elements. This is true for, eg, [`char`] but not for `&str`.
     ///
-    /// [`DoubleEndedIterator`]: /std/iter/trait.DoubleEndedIterator.html
+    /// [`DoubleEndedIterator`]: ::/std/iter/trait.DoubleEndedIterator.html
     ///
     /// If the pattern allows a reverse search but its results might differ
     /// from a forward search, the [`rmatch_indices()`] method can be used.
@@ -1283,7 +1283,7 @@ impl str {
     /// search, and it will be a [`DoubleEndedIterator`] if a forward/reverse
     /// search yields the same elements.
     ///
-    /// [`DoubleEndedIterator`]: /std/iter/trait.DoubleEndedIterator.html
+    /// [`DoubleEndedIterator`]: ::/std/iter/trait.DoubleEndedIterator.html
     ///
     /// For iterating from the front, the [`match_indices()`] method can be used.
     ///
@@ -1513,14 +1513,14 @@ impl str {
     ///
     /// `parse()` can parse any type that implements the [`FromStr`] trait.
     ///
-    /// [`FromStr`]: /std/str/trait.FromStr.html
+    /// [`FromStr`]: ::/std/str/trait.FromStr.html
     ///
     /// # Errors
     ///
     /// Will return [`Err`] if it's not possible to parse this string slice into
     /// the desired type.
     ///
-    /// [`Err`]: /std/str/trait.FromStr.html#associatedtype.Err
+    /// [`Err`]: ::/std/str/trait.FromStr.html#associatedtype.Err
     ///
     /// # Example
     ///
@@ -1559,7 +1559,7 @@ impl str {
     /// While doing so, it attempts to find matches of a pattern. If it finds any, it
     /// replaces them with the replacement string slice.
     ///
-    /// [`String`]: /std/string/struct.String.html
+    /// [`String`]: ::/std/string/struct.String.html
     ///
     /// # Examples
     ///
@@ -1595,7 +1595,7 @@ impl str {
     /// 'Lowercase' is defined according to the terms of the Unicode Derived Core Property
     /// `Lowercase`.
     ///
-    /// [`String`]: /std/string/struct.String.html
+    /// [`String`]: ::/std/string/struct.String.html
     ///
     /// # Examples
     ///
@@ -1671,7 +1671,7 @@ impl str {
     /// 'Uppercase' is defined according to the terms of the Unicode Derived Core Property
     /// `Uppercase`.
     ///
-    /// [`String`]: /std/string/struct.String.html
+    /// [`String`]: ::/std/string/struct.String.html
     ///
     /// # Examples
     ///
@@ -1715,7 +1715,7 @@ impl str {
 
     /// Converts a `Box<str>` into a [`String`] without copying or allocating.
     ///
-    /// [`String`]: /std/string/struct.String.html
+    /// [`String`]: ::/std/string/struct.String.html
     ///
     /// # Examples
     ///

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -715,7 +715,7 @@ impl str {
     /// a character matches.
     ///
     /// [`char`]: primitive.char.html
-    /// [`None`]: option/enum.Option.html#variant.None
+    /// [`None`]: /std/option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -760,7 +760,7 @@ impl str {
     /// a character matches.
     ///
     /// [`char`]: primitive.char.html
-    /// [`None`]: option/enum.Option.html#variant.None
+    /// [`None`]: /std/option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -809,7 +809,7 @@ impl str {
     /// allows a reverse search and forward/reverse search yields the same
     /// elements. This is true for, eg, [`char`] but not for `&str`.
     ///
-    /// [`DoubleEndedIterator`]: iter/trait.DoubleEndedIterator.html
+    /// [`DoubleEndedIterator`]: /std/iter/trait.DoubleEndedIterator.html
     ///
     /// If the pattern allows a reverse search but its results might differ
     /// from a forward search, the [`rsplit()`] method can be used.
@@ -922,7 +922,7 @@ impl str {
     /// search, and it will be a [`DoubleEndedIterator`] if a forward/reverse
     /// search yields the same elements.
     ///
-    /// [`DoubleEndedIterator`]: iter/trait.DoubleEndedIterator.html
+    /// [`DoubleEndedIterator`]: /std/iter/trait.DoubleEndedIterator.html
     ///
     /// For iterating from the front, the [`split()`] method can be used.
     ///
@@ -979,7 +979,7 @@ impl str {
     /// allows a reverse search and forward/reverse search yields the same
     /// elements. This is true for, eg, [`char`] but not for `&str`.
     ///
-    /// [`DoubleEndedIterator`]: iter/trait.DoubleEndedIterator.html
+    /// [`DoubleEndedIterator`]: /std/iter/trait.DoubleEndedIterator.html
     /// [`char`]: primitive.char.html
     ///
     /// If the pattern allows a reverse search but its results might differ
@@ -1161,7 +1161,7 @@ impl str {
     /// allows a reverse search and forward/reverse search yields the same
     /// elements. This is true for, eg, [`char`] but not for `&str`.
     ///
-    /// [`DoubleEndedIterator`]: iter/trait.DoubleEndedIterator.html
+    /// [`DoubleEndedIterator`]: /std/iter/trait.DoubleEndedIterator.html
     /// [`char`]: primitive.char.html
     ///
     /// If the pattern allows a reverse search but its results might differ
@@ -1199,7 +1199,7 @@ impl str {
     /// search, and it will be a [`DoubleEndedIterator`] if a forward/reverse
     /// search yields the same elements.
     ///
-    /// [`DoubleEndedIterator`]: iter/trait.DoubleEndedIterator.html
+    /// [`DoubleEndedIterator`]: /std/iter/trait.DoubleEndedIterator.html
     ///
     /// For iterating from the front, the [`matches()`] method can be used.
     ///
@@ -1240,7 +1240,7 @@ impl str {
     /// allows a reverse search and forward/reverse search yields the same
     /// elements. This is true for, eg, [`char`] but not for `&str`.
     ///
-    /// [`DoubleEndedIterator`]: iter/trait.DoubleEndedIterator.html
+    /// [`DoubleEndedIterator`]: /std/iter/trait.DoubleEndedIterator.html
     ///
     /// If the pattern allows a reverse search but its results might differ
     /// from a forward search, the [`rmatch_indices()`] method can be used.
@@ -1283,7 +1283,7 @@ impl str {
     /// search, and it will be a [`DoubleEndedIterator`] if a forward/reverse
     /// search yields the same elements.
     ///
-    /// [`DoubleEndedIterator`]: iter/trait.DoubleEndedIterator.html
+    /// [`DoubleEndedIterator`]: /std/iter/trait.DoubleEndedIterator.html
     ///
     /// For iterating from the front, the [`match_indices()`] method can be used.
     ///
@@ -1513,14 +1513,14 @@ impl str {
     ///
     /// `parse()` can parse any type that implements the [`FromStr`] trait.
     ///
-    /// [`FromStr`]: str/trait.FromStr.html
+    /// [`FromStr`]: /std/str/trait.FromStr.html
     ///
     /// # Errors
     ///
     /// Will return [`Err`] if it's not possible to parse this string slice into
     /// the desired type.
     ///
-    /// [`Err`]: str/trait.FromStr.html#associatedtype.Err
+    /// [`Err`]: /std/str/trait.FromStr.html#associatedtype.Err
     ///
     /// # Example
     ///
@@ -1559,7 +1559,7 @@ impl str {
     /// While doing so, it attempts to find matches of a pattern. If it finds any, it
     /// replaces them with the replacement string slice.
     ///
-    /// [`String`]: string/struct.String.html
+    /// [`String`]: /std/string/struct.String.html
     ///
     /// # Examples
     ///
@@ -1595,7 +1595,7 @@ impl str {
     /// 'Lowercase' is defined according to the terms of the Unicode Derived Core Property
     /// `Lowercase`.
     ///
-    /// [`String`]: string/struct.String.html
+    /// [`String`]: /std/string/struct.String.html
     ///
     /// # Examples
     ///
@@ -1671,7 +1671,7 @@ impl str {
     /// 'Uppercase' is defined according to the terms of the Unicode Derived Core Property
     /// `Uppercase`.
     ///
-    /// [`String`]: string/struct.String.html
+    /// [`String`]: /std/string/struct.String.html
     ///
     /// # Examples
     ///
@@ -1715,7 +1715,7 @@ impl str {
 
     /// Converts a `Box<str>` into a [`String`] without copying or allocating.
     ///
-    /// [`String`]: string/struct.String.html
+    /// [`String`]: /std/string/struct.String.html
     ///
     /// # Examples
     ///

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -71,7 +71,7 @@ use html::format::{TyParamBounds, WhereClause, href, AbiSpace};
 use html::format::{VisSpace, Method, UnsafetySpace, MutableSpace};
 use html::format::fmt_impl_for_trait_page;
 use html::item_type::ItemType;
-use html::markdown::{self, Markdown};
+use html::markdown::{self, MarkdownRelative};
 use html::{highlight, layout};
 
 /// A pair of name and its optional document.
@@ -1660,11 +1660,12 @@ fn plain_summary_line(s: Option<&str>) -> String {
 
 fn document(w: &mut fmt::Formatter, cx: &Context, item: &clean::Item) -> fmt::Result {
     document_stability(w, cx, item)?;
-    document_full(w, item)?;
+    document_full(w, cx, item)?;
     Ok(())
 }
 
-fn document_short(w: &mut fmt::Formatter, item: &clean::Item, link: AssocItemLink) -> fmt::Result {
+fn document_short(w: &mut fmt::Formatter, cx: &Context, item: &clean::Item, link: AssocItemLink)
+    -> fmt::Result {
     if let Some(s) = item.doc_value() {
         let markdown = if s.contains('\n') {
             format!("{} [Read more]({})",
@@ -1672,14 +1673,14 @@ fn document_short(w: &mut fmt::Formatter, item: &clean::Item, link: AssocItemLin
         } else {
             format!("{}", &plain_summary_line(Some(s)))
         };
-        write!(w, "<div class='docblock'>{}</div>", Markdown(&markdown))?;
+        write!(w, "<div class='docblock'>{}</div>", MarkdownRelative(&markdown, &cx.root_path))?;
     }
     Ok(())
 }
 
-fn document_full(w: &mut fmt::Formatter, item: &clean::Item) -> fmt::Result {
+fn document_full(w: &mut fmt::Formatter, cx: &Context, item: &clean::Item) -> fmt::Result {
     if let Some(s) = item.doc_value() {
-        write!(w, "<div class='docblock'>{}</div>", Markdown(s))?;
+        write!(w, "<div class='docblock'>{}</div>", MarkdownRelative(s, &cx.root_path))?;
     }
     Ok(())
 }
@@ -1829,7 +1830,9 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
                        </tr>",
                        name = *myitem.name.as_ref().unwrap(),
                        stab_docs = stab_docs,
-                       docs = shorter(Some(&Markdown(doc_value).to_string())),
+                       docs = shorter(
+                          Some(&MarkdownRelative(doc_value, &cx.root_path).to_string())
+                       ),
                        class = shortty(myitem),
                        stab = myitem.stability_class(),
                        href = item_path(shortty(myitem), myitem.name.as_ref().unwrap()),
@@ -1859,7 +1862,7 @@ fn short_stability(item: &clean::Item, cx: &Context, show_reason: bool) -> Vec<S
             } else {
                 String::new()
             };
-            let text = format!("Deprecated{}{}", since, Markdown(&reason));
+            let text = format!("Deprecated{}{}", since, MarkdownRelative(&reason, &cx.root_path));
             stability.push(format!("<em class='stab deprecated'>{}</em>", text))
         };
 
@@ -1879,7 +1882,8 @@ fn short_stability(item: &clean::Item, cx: &Context, show_reason: bool) -> Vec<S
             } else {
                 String::new()
             };
-            let text = format!("Unstable{}{}", unstable_extra, Markdown(&reason));
+            let text = format!("Unstable{}{}", unstable_extra,
+                MarkdownRelative(&reason, &cx.root_path));
             stability.push(format!("<em class='stab unstable'>{}</em>", text))
         };
     } else if let Some(depr) = item.deprecation.as_ref() {
@@ -1894,7 +1898,7 @@ fn short_stability(item: &clean::Item, cx: &Context, show_reason: bool) -> Vec<S
             String::new()
         };
 
-        let text = format!("Deprecated{}{}", since, Markdown(&note));
+        let text = format!("Deprecated{}{}", since, MarkdownRelative(&note, &cx.root_path));
         stability.push(format!("<em class='stab deprecated'>{}</em>", text))
     }
 
@@ -2591,7 +2595,7 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
         write!(w, "</span>")?;
         write!(w, "</h3>\n")?;
         if let Some(ref dox) = i.impl_item.attrs.value("doc") {
-            write!(w, "<div class='docblock'>{}</div>", Markdown(dox))?;
+            write!(w, "<div class='docblock'>{}</div>", MarkdownRelative(dox, &cx.root_path))?;
         }
     }
 
@@ -2657,18 +2661,18 @@ fn render_impl(w: &mut fmt::Formatter, cx: &Context, i: &Impl, link: AssocItemLi
                     // impls can't have a stability.
                     document_stability(w, cx, it)?;
                     if item.doc_value().is_some() {
-                        document_full(w, item)?;
+                        document_full(w, cx, item)?;
                     } else {
                         // In case the item isn't documented,
                         // provide short documentation from the trait.
-                        document_short(w, it, link)?;
+                        document_short(w, cx, it, link)?;
                     }
                 } else {
                     document(w, cx, item)?;
                 }
             } else {
                 document_stability(w, cx, item)?;
-                document_short(w, item, link)?;
+                document_short(w, cx, item, link)?;
             }
         }
         Ok(())

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -86,7 +86,7 @@ pub fn render(input: &str, mut output: PathBuf, matches: &getopts::Matches,
     reset_ids(false);
 
     let rendered = if include_toc {
-        format!("{}", MarkdownWithToc(text))
+        format!("{}", MarkdownWithToc(text, ""))
     } else {
         format!("{}", Markdown(text))
     };


### PR DESCRIPTION
Fixes broken links for items documented at multiple module levels, like the DoubleEndedIterator links here:

https://doc.rust-lang.org/std/string/struct.String.html (broken currently)
vs.
https://doc.rust-lang.org/std/primitive.str.html (working)

This will completely break these links on doc sites hosted at non-root paths, but doc.rust-lang.org hosts at root.

r? @steveklabnik
