### PR TITLE
rustdoc: Fix search result layout for enum variants and struct fields

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -659,7 +659,7 @@ span.since {
     margin-bottom: 25px;
 }
 
-.variant, .structfield {
+.enum .variant, .struct .structfield {
     display: block;
 }
 


### PR DESCRIPTION
This was broken in #34234.

For example:
[before](https://doc.rust-lang.org/nightly/std/?search=cow%3A%3Aborrowed) [after](https://ollie27.github.io/rust_doc_test/std/?search=cow%3A%3Aborrowed)
[before](https://doc.rust-lang.org/nightly/std/?search=range%3A%3Astart) [after](https://ollie27.github.io/rust_doc_test/std/?search=range%3A%3Astart)

cc @GuillaumeGomez
