### PR TITLE
Forbid type parameters and global paths in macro invocations

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -214,7 +214,7 @@ fn expand_mac_invoc<T>(mac: ast::Mac, ident: Option<Ident>, attrs: Vec<ast::Attr
                                           &fld.cx.ecfg.features.unwrap());
         }
 
-        if path.segments.len() > 1 {
+        if path.segments.len() > 1 || path.global || !path.segments[0].parameters.is_empty() {
             fld.cx.span_err(path.span, "expected macro name without module separators");
             return None;
         }

--- a/src/test/compile-fail/macro-with-seps-err-msg.rs
+++ b/src/test/compile-fail/macro-with-seps-err-msg.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:expected macro name without module separators
-
 fn main() {
-    globnar::brotz!();
+    globnar::brotz!(); //~ ERROR expected macro name without module separators
+    ::foo!(); //~ ERROR expected macro name without module separators
+    foo::<T>!(); //~ ERROR expected macro name without module separators
 }


### PR DESCRIPTION
Fixes #28558.
This is a [breaking-change]. For example, the following would break:

``` rust
macro_rules! m { () => { () } }
fn main() {
    m::<T>!(); // Type parameters are no longer allowed in macro invocations
    ::m!(); // Global paths are no longer allowed in macro invocations
}
```

Any breakage can be fixed by removing the type parameters or the leading `::` (respectively).

r? @eddyb
