### PR TITLE
Revert "skip double negation in const eval"

### DIFF
--- a/src/test/compile-fail/lint-type-overflow2.rs
+++ b/src/test/compile-fail/lint-type-overflow2.rs
@@ -15,6 +15,7 @@
 #[allow(unused_variables)]
 fn main() {
     let x2: i8 = --128; //~ error: literal out of range for i8
+    //~^ error: attempted to negate with overflow
 
     let x = -3.40282348e+38_f32; //~ error: literal out of range for f32
     let x =  3.40282348e+38_f32; //~ error: literal out of range for f32


### PR DESCRIPTION
This reverts commit 735c018974e5570ea13fd887aa70a011a5b8e7b8.

fixes #34395

The original commit was based on a mis-understanding of the overflowing literal lint.

This needs to be ported to beta.

r? @eddyb 
