### PR TITLE
Add the word generic to the output of incorrect types

### DIFF
--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -2263,7 +2263,7 @@ fn check_type_argument_count(tcx: TyCtxt, span: Span, supplied: usize,
             "expected"
         };
         span_err!(tcx.sess, span, E0243,
-                  "wrong number of type arguments: {} {}, found {}",
+                  "wrong number of generic type arguments: {} {}, found {}",
                   expected, required, supplied);
     } else if supplied > accepted {
         let expected = if required < accepted {
@@ -2272,7 +2272,7 @@ fn check_type_argument_count(tcx: TyCtxt, span: Span, supplied: usize,
             "expected"
         };
         span_err!(tcx.sess, span, E0244,
-                  "wrong number of type arguments: {} {}, found {}",
+                  "wrong number of generic type arguments: {} {}, found {}",
                   expected,
                   accepted,
                   supplied);

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -2953,12 +2953,13 @@ This error indicates that not enough type parameters were found in a type or
 trait.
 
 For example, the `Foo` struct below is defined to be generic in `T`, but the
-type parameter is missing in the definition of `Bar`:
+type parameter is missing in the definitions of `Bar` and `baz`:
 
 ```compile_fail
 struct Foo<T> { x: T }
 
 struct Bar { x: Foo }
+fn baz( x: Foo ) {}
 ```
 "##,
 

--- a/src/test/compile-fail/generic-impl-less-params-with-defaults.rs
+++ b/src/test/compile-fail/generic-impl-less-params-with-defaults.rs
@@ -19,5 +19,5 @@ impl<A, B, C = (A, B)> Foo<A, B, C> {
 
 fn main() {
     Foo::<isize>::new();
-    //~^ ERROR wrong number of type arguments
+    //~^ ERROR wrong number of generic type arguments
 }

--- a/src/test/compile-fail/generic-impl-more-params-with-defaults.rs
+++ b/src/test/compile-fail/generic-impl-more-params-with-defaults.rs
@@ -21,5 +21,5 @@ impl<T, A = Heap> Vec<T, A> {
 
 fn main() {
     Vec::<isize, Heap, bool>::new();
-    //~^ ERROR wrong number of type arguments
+    //~^ ERROR wrong number of generic type arguments
 }

--- a/src/test/compile-fail/generic-type-less-params-with-defaults.rs
+++ b/src/test/compile-fail/generic-type-less-params-with-defaults.rs
@@ -16,5 +16,5 @@ struct Vec<T, A = Heap>(
     marker::PhantomData<(T,A)>);
 
 fn main() {
-    let _: Vec; //~ ERROR wrong number of type arguments: expected at least 1, found 0
+    let _: Vec; //~ ERROR wrong number of generic type arguments: expected at least 1, found 0
 }

--- a/src/test/compile-fail/generic-type-more-params-with-defaults.rs
+++ b/src/test/compile-fail/generic-type-more-params-with-defaults.rs
@@ -17,5 +17,5 @@ struct Vec<T, A = Heap>(
 
 fn main() {
     let _: Vec<isize, Heap, bool>;
-    //~^ ERROR wrong number of type arguments: expected at most 2, found 3
+    //~^ ERROR wrong number of generic type arguments: expected at most 2, found 3
 }

--- a/src/test/compile-fail/issue-14092.rs
+++ b/src/test/compile-fail/issue-14092.rs
@@ -8,6 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn fn1(0: Box) {} //~ ERROR: wrong number of type arguments: expected 1, found 0
+fn fn1(0: Box) {} //~ ERROR: wrong number of generic type arguments: expected 1, found 0
 
 fn main() {}

--- a/src/test/compile-fail/issue-23024.rs
+++ b/src/test/compile-fail/issue-23024.rs
@@ -18,6 +18,6 @@ fn main()
     vfnfer.push(box h);
     println!("{:?}",(vfnfer[0] as Fn)(3));
     //~^ ERROR the precise format of `Fn`-family traits'
-    //~| ERROR wrong number of type arguments: expected 1, found 0
+    //~| ERROR wrong number of generic type arguments: expected 1, found 0
     //~| ERROR the value of the associated type `Output` (from the trait `std::ops::FnOnce`)
 }

--- a/src/test/compile-fail/issue-3214.rs
+++ b/src/test/compile-fail/issue-3214.rs
@@ -14,7 +14,7 @@ fn foo<T>() {
     }
 
     impl<T> Drop for foo<T> {
-        //~^ ERROR wrong number of type arguments
+        //~^ ERROR wrong number of generic type arguments
         //~^^ ERROR the type parameter `T` is not constrained
         fn drop(&mut self) {}
     }

--- a/src/test/compile-fail/seq-args.rs
+++ b/src/test/compile-fail/seq-args.rs
@@ -11,10 +11,10 @@
 fn main() {
 trait seq { }
 
-impl<T> seq<T> for Vec<T> { //~ ERROR wrong number of type arguments
+impl<T> seq<T> for Vec<T> { //~ ERROR wrong number of generic type arguments
     /* ... */
 }
-impl seq<bool> for u32 { //~ ERROR wrong number of type arguments
+impl seq<bool> for u32 { //~ ERROR wrong number of generic type arguments
    /* Treat the integer as a sequence of bits */
 }
 

--- a/src/test/compile-fail/structure-constructor-type-mismatch.rs
+++ b/src/test/compile-fail/structure-constructor-type-mismatch.rs
@@ -55,13 +55,13 @@ fn main() {
         y: 8,
     };
 
-    let pt3 = PointF::<i32> { //~ ERROR wrong number of type arguments
+    let pt3 = PointF::<i32> { //~ ERROR wrong number of generic type arguments
         x: 9,  //~ ERROR mismatched types
         y: 10, //~ ERROR mismatched types
     };
 
     match (Point { x: 1, y: 2 }) {
-        PointF::<u32> { .. } => {} //~ ERROR wrong number of type arguments
+        PointF::<u32> { .. } => {} //~ ERROR wrong number of generic type arguments
         //~^ ERROR mismatched types
     }
 

--- a/src/test/compile-fail/tag-type-args.rs
+++ b/src/test/compile-fail/tag-type-args.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:wrong number of type arguments
+// error-pattern:wrong number of generic type arguments
 
 enum quux<T> { bar }
 

--- a/src/test/compile-fail/typeck-builtin-bound-type-parameters.rs
+++ b/src/test/compile-fail/typeck-builtin-bound-type-parameters.rs
@@ -9,19 +9,19 @@
 // except according to those terms.
 
 fn foo1<T:Copy<U>, U>(x: T) {}
-//~^ ERROR: wrong number of type arguments: expected 0, found 1
+//~^ ERROR: wrong number of generic type arguments: expected 0, found 1
 
 trait Trait: Copy<Send> {}
-//~^ ERROR: wrong number of type arguments: expected 0, found 1
+//~^ ERROR: wrong number of generic type arguments: expected 0, found 1
 
 struct MyStruct1<T: Copy<T>>;
-//~^ ERROR wrong number of type arguments: expected 0, found 1
+//~^ ERROR wrong number of generic type arguments: expected 0, found 1
 
 struct MyStruct2<'a, T: Copy<'a>>;
 //~^ ERROR: wrong number of lifetime parameters: expected 0, found 1
 
 fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
-//~^ ERROR: wrong number of type arguments: expected 0, found 1
+//~^ ERROR: wrong number of generic type arguments: expected 0, found 1
 //~^^ ERROR: wrong number of lifetime parameters: expected 0, found 1
 
 fn main() {

--- a/src/test/compile-fail/typeck_type_placeholder_lifetime_1.rs
+++ b/src/test/compile-fail/typeck_type_placeholder_lifetime_1.rs
@@ -17,5 +17,5 @@ struct Foo<'a, T:'a> {
 
 pub fn main() {
     let c: Foo<_, _> = Foo { r: &5 };
-    //~^ ERROR wrong number of type arguments: expected 1, found 2
+    //~^ ERROR wrong number of generic type arguments: expected 1, found 2
 }

--- a/src/test/compile-fail/typeck_type_placeholder_lifetime_2.rs
+++ b/src/test/compile-fail/typeck_type_placeholder_lifetime_2.rs
@@ -17,5 +17,5 @@ struct Foo<'a, T:'a> {
 
 pub fn main() {
     let c: Foo<_, usize> = Foo { r: &5 };
-    //~^ ERROR wrong number of type arguments: expected 1, found 2
+    //~^ ERROR wrong number of generic type arguments: expected 1, found 2
 }

--- a/src/test/compile-fail/unboxed-closure-sugar-wrong-number-number-type-parameters-3.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-wrong-number-number-type-parameters-3.rs
@@ -13,7 +13,7 @@
 trait Three<A,B,C> { fn dummy(&self) -> (A,B,C); }
 
 fn foo(_: &Three())
-//~^ ERROR wrong number of type arguments
+//~^ ERROR wrong number of generic type arguments
 //~| ERROR associated type `Output` not found
 {}
 

--- a/src/test/compile-fail/unboxed-closure-sugar-wrong-number-number-type-parameters.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-wrong-number-number-type-parameters.rs
@@ -13,7 +13,7 @@
 trait Zero { fn dummy(&self); }
 
 fn foo(_: Zero())
-    //~^ ERROR wrong number of type arguments
+    //~^ ERROR wrong number of generic type arguments
     //~| ERROR associated type `Output` not found for `Zero`
 {}
 

--- a/src/test/compile-fail/unboxed-closure-sugar-wrong-trait.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-wrong-trait.rs
@@ -13,7 +13,7 @@
 trait Trait {}
 
 fn f<F:Trait(isize) -> isize>(x: F) {}
-//~^ ERROR wrong number of type arguments: expected 0, found 1
+//~^ ERROR wrong number of generic type arguments: expected 0, found 1
 //~| ERROR associated type `Output` not found
 
 fn main() {}


### PR DESCRIPTION
Based on "Missleading error message when defining function with template type by accident (#33901)"

What do you think?

Regards
