### PR TITLE
removed unwanted message

### DIFF
--- a/src/doc/book/getting-started.md
+++ b/src/doc/book/getting-started.md
@@ -126,8 +126,6 @@ you’ll see this appear:
 Rust is ready to roll.
 ```
 
-From here, press `y` for ‘yes’, and then follow the rest of the prompts.
-
 ## Installing on Windows
 
 If you're on Windows, please download the appropriate [installer][install-page].


### PR DESCRIPTION
After installing, rustup.sh doesn't ask for any yes or no questions. It is unnecessary to have "From here, press `y` for ‘yes’, and then follow the rest of the prompts." in the book.
