### PR TITLE
Support CMake installations in paths containing spaces

### DIFF
--- a/configure
+++ b/configure
@@ -1725,7 +1725,7 @@ do
         msg "configuring LLVM with:"
         msg "$CMAKE_ARGS"
 
-        (cd $LLVM_BUILD_DIR && eval "$CFG_CMAKE" $CMAKE_ARGS)
+        (cd $LLVM_BUILD_DIR && eval "\"$CFG_CMAKE\"" $CMAKE_ARGS)
         need_ok "LLVM cmake configure failed"
     fi
 


### PR DESCRIPTION
This solves #34490
