### PR TITLE
Support `cfg_attr` on `path` attributes

### DIFF
--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -33,7 +33,7 @@ impl<'a> StripUnconfigured<'a> {
         if self.in_cfg(node.attrs()) { Some(node) } else { None }
     }
 
-    fn process_cfg_attrs<T: HasAttrs>(&mut self, node: T) -> T {
+    pub fn process_cfg_attrs<T: HasAttrs>(&mut self, node: T) -> T {
         node.map_attrs(|attrs| {
             attrs.into_iter().filter_map(|attr| self.process_cfg_attr(attr)).collect()
         })

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -5301,15 +5301,22 @@ impl<'a> Parser<'a> {
 
     /// Parse a `mod <foo> { ... }` or `mod <foo>;` item
     fn parse_item_mod(&mut self, outer_attrs: &[Attribute]) -> PResult<'a, ItemInfo> {
+        let outer_attrs = ::config::StripUnconfigured {
+            config: &self.cfg,
+            sess: self.sess,
+            should_test: false, // irrelevant
+            features: None, // don't perform gated feature checking
+        }.process_cfg_attrs(outer_attrs.to_owned());
+
         let id_span = self.span;
         let id = self.parse_ident()?;
         if self.check(&token::Semi) {
             self.bump();
             // This mod is in an external file. Let's go get it!
-            let (m, attrs) = self.eval_src_mod(id, outer_attrs, id_span)?;
+            let (m, attrs) = self.eval_src_mod(id, &outer_attrs, id_span)?;
             Ok((id, m, Some(attrs)))
         } else {
-            self.push_mod_path(id, outer_attrs);
+            self.push_mod_path(id, &outer_attrs);
             self.expect(&token::OpenDelim(token::Brace))?;
             let mod_inner_lo = self.span.lo;
             let attrs = self.parse_inner_attributes()?;

--- a/src/test/compile-fail/cfg_attr_path.rs
+++ b/src/test/compile-fail/cfg_attr_path.rs
@@ -1,0 +1,12 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[cfg_attr(all(), path = "nonexistent_file.rs")] mod foo;
+//~^ ERROR nonexistent_file.rs


### PR DESCRIPTION
Fixes #25544.
This is technically a [breaking-change]. For example, the following would break:

``` rust
#[cfg_attr(all(), path = "nonsense.rs")]
mod foo; // Suppose `foo.rs` existed in the appropriate location
```
