### PR TITLE
Changed OS X to macOS as that is now the name

### DIFF
--- a/man/rustc.1
+++ b/man/rustc.1
@@ -32,7 +32,7 @@ only lookup local `extern crate` directives here
 only lookup native libraries here
 .TP
 .B framework
-only look for OSX frameworks here
+only look for macOS frameworks here
 .TP
 .B all
 look for anything here (the default)


### PR DESCRIPTION
As of June 13, 2016 OS X has been rebranded as macOS.
