### PR TITLE
mk: Don't consider LLVM done until it's done

### DIFF
--- a/mk/llvm.mk
+++ b/mk/llvm.mk
@@ -37,8 +37,11 @@ endif
 ifeq ($(CFG_LLVM_ROOT),)
 
 LLVM_STAMP_$(1) = $$(CFG_LLVM_BUILD_DIR_$(1))/llvm-auto-clean-stamp
+LLVM_DONE_$(1) = $$(CFG_LLVM_BUILD_DIR_$(1))/llvm-finished-building
 
-$$(LLVM_CONFIG_$(1)): $$(LLVM_DEPS_TARGET_$(1)) $$(LLVM_STAMP_$(1))
+$$(LLVM_CONFIG_$(1)): $$(LLVM_DONE_$(1))
+
+$$(LLVM_DONE_$(1)): $$(LLVM_DEPS_TARGET_$(1)) $$(LLVM_STAMP_$(1))
 	@$$(call E, cmake: llvm)
 ifeq ($$(findstring msvc,$(1)),msvc)
 	$$(Q)$$(CFG_CMAKE) --build $$(CFG_LLVM_BUILD_DIR_$(1)) \
@@ -46,7 +49,7 @@ ifeq ($$(findstring msvc,$(1)),msvc)
 else
 	$$(Q)$$(MAKE) -C $$(CFG_LLVM_BUILD_DIR_$(1))
 endif
-	$$(Q)touch $$(LLVM_CONFIG_$(1))
+	$$(Q)touch $$@
 
 ifeq ($$(findstring msvc,$(1)),msvc)
 clean-llvm$(1):

--- a/src/bootstrap/build/native.rs
+++ b/src/bootstrap/build/native.rs
@@ -20,14 +20,14 @@
 
 use std::path::Path;
 use std::process::Command;
-use std::fs;
+use std::fs::{self, File};
 
 use build_helper::output;
 use cmake;
 use gcc;
 
 use build::Build;
-use build::util::{exe, staticlib, up_to_date};
+use build::util::{staticlib, up_to_date};
 
 /// Compile LLVM for `target`.
 pub fn llvm(build: &Build, target: &str) {
@@ -43,9 +43,9 @@ pub fn llvm(build: &Build, target: &str) {
     // artifacts are missing) then we keep going, otherwise we bail out.
     let dst = build.llvm_out(target);
     let stamp = build.src.join("src/rustllvm/llvm-auto-clean-trigger");
-    let llvm_config = dst.join("bin").join(exe("llvm-config", target));
+    let done_stamp = dst.join("llvm-finished-building");
     build.clear_if_dirty(&dst, &stamp);
-    if fs::metadata(llvm_config).is_ok() {
+    if fs::metadata(&done_stamp).is_ok() {
         return
     }
 
@@ -111,6 +111,8 @@ pub fn llvm(build: &Build, target: &str) {
     //        tools. Figure out how to filter them down and only build the right
     //        tools and libs on all platforms.
     cfg.build();
+
+    t!(File::create(&done_stamp));
 }
 
 fn check_llvm_version(build: &Build, llvm_config: &Path) {


### PR DESCRIPTION
Currently if an LLVM build is interrupted _after_ it creates the llvm-config
binary but before it's done it puts us in an inconsistent state where we think
LLVM is compiled but it's not actually. This tweaks our logic to only consider
LLVM done building once it's actually done building.

This should hopefully alleviate problems on the bots where if we interrupt at
the wrong time it doesn't corrupt the build directory.
