### PR TITLE
Simplify the macro hygiene algorithm

### DIFF
--- a/src/librustc_resolve/assign_ids.rs
+++ b/src/librustc_resolve/assign_ids.rs
@@ -1,0 +1,59 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use Resolver;
+use rustc::session::Session;
+use syntax::ast;
+use syntax::fold::Folder;
+use syntax::ptr::P;
+use syntax::util::move_map::MoveMap;
+
+impl<'a> Resolver<'a> {
+    pub fn assign_node_ids(&mut self, krate: ast::Crate) -> ast::Crate {
+        NodeIdAssigner {
+            sess: self.session,
+        }.fold_crate(krate)
+    }
+}
+
+struct NodeIdAssigner<'a> {
+    sess: &'a Session,
+}
+
+impl<'a> Folder for NodeIdAssigner<'a> {
+    fn new_id(&mut self, old_id: ast::NodeId) -> ast::NodeId {
+        assert_eq!(old_id, ast::DUMMY_NODE_ID);
+        self.sess.next_node_id()
+    }
+
+    fn fold_block(&mut self, block: P<ast::Block>) -> P<ast::Block> {
+        block.map(|mut block| {
+            block.id = self.new_id(block.id);
+
+            let stmt = block.stmts.pop();
+            block.stmts = block.stmts.move_flat_map(|s| self.fold_stmt(s).into_iter());
+            if let Some(ast::Stmt { node: ast::StmtKind::Expr(expr), span, .. }) = stmt {
+                // Avoid wasting a node id on a trailing expression statement,
+                // which shares a HIR node with the expression itself.
+                let expr = self.fold_expr(expr);
+                block.stmts.push(ast::Stmt {
+                    id: expr.id,
+                    node: ast::StmtKind::Expr(expr),
+                    span: span,
+                });
+            } else if let Some(stmt) = stmt {
+                block.stmts.extend(self.fold_stmt(stmt));
+            }
+
+            block
+        })
+    }
+}
+

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -83,6 +83,7 @@ mod diagnostics;
 mod check_unused;
 mod build_reduced_graph;
 mod resolve_imports;
+mod assign_ids;
 
 enum SuggestionType {
     Macro(String),

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -26,7 +26,6 @@ use tokenstream::{TokenTree};
 
 use std::fmt;
 use std::rc::Rc;
-use std::hash::{Hash, Hasher};
 use serialize::{Encodable, Decodable, Encoder, Decoder};
 
 /// A name is a part of an identifier, representing a string or gensym. It's
@@ -46,7 +45,7 @@ pub struct SyntaxContext(pub u32);
 /// An identifier contains a Name (index into the interner
 /// table) and a SyntaxContext to track renaming and
 /// macro expansion per Flatt et al., "Macros That Work Together"
-#[derive(Clone, Copy, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Ident {
     pub name: Name,
     pub ctxt: SyntaxContext
@@ -90,40 +89,6 @@ impl Ident {
     }
     pub const fn with_empty_ctxt(name: Name) -> Ident {
         Ident {name: name, ctxt: EMPTY_CTXT}
-    }
-}
-
-impl PartialEq for Ident {
-    fn eq(&self, other: &Ident) -> bool {
-        if self.ctxt != other.ctxt {
-            // There's no one true way to compare Idents. They can be compared
-            // non-hygienically `id1.name == id2.name`, hygienically
-            // `mtwt::resolve(id1) == mtwt::resolve(id2)`, or even member-wise
-            // `(id1.name, id1.ctxt) == (id2.name, id2.ctxt)` depending on the situation.
-            // Ideally, PartialEq should not be implemented for Ident at all, but that
-            // would be too impractical, because many larger structures (Token, in particular)
-            // including Idents as their parts derive PartialEq and use it for non-hygienic
-            // comparisons. That's why PartialEq is implemented and defaults to non-hygienic
-            // comparison. Hash is implemented too and is consistent with PartialEq, i.e. only
-            // the name of Ident is hashed. Still try to avoid comparing idents in your code
-            // (especially as keys in hash maps), use one of the three methods listed above
-            // explicitly.
-            //
-            // If you see this panic, then some idents from different contexts were compared
-            // non-hygienically. It's likely a bug. Use one of the three comparison methods
-            // listed above explicitly.
-
-            panic!("idents with different contexts are compared with operator `==`: \
-                {:?}, {:?}.", self, other);
-        }
-
-        self.name == other.name
-    }
-}
-
-impl Hash for Ident {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.name.hash(state)
     }
 }
 

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -26,7 +26,6 @@ use parse::token::{InternedString, intern, str_to_ident};
 use ptr::P;
 use util::small_vector::SmallVector;
 use util::lev_distance::find_best_match_for_name;
-use ext::mtwt;
 use fold::Folder;
 
 use std::collections::{HashMap, HashSet};
@@ -483,15 +482,12 @@ pub type NamedSyntaxExtension = (Name, SyntaxExtension);
 pub struct BlockInfo {
     /// Should macros escape from this scope?
     pub macros_escape: bool,
-    /// What are the pending renames?
-    pub pending_renames: mtwt::RenameList,
 }
 
 impl BlockInfo {
     pub fn new() -> BlockInfo {
         BlockInfo {
             macros_escape: false,
-            pending_renames: Vec::new(),
         }
     }
 }

--- a/src/libsyntax/ext/mtwt.rs
+++ b/src/libsyntax/ext/mtwt.rs
@@ -71,14 +71,6 @@ fn new_sctable_internal() -> SCTable {
     }
 }
 
-/// Print out an SCTable for debugging
-pub fn display_sctable(table: &SCTable) {
-    error!("SC table:");
-    for (idx,val) in table.table.borrow().iter().enumerate() {
-        error!("{:4} : {:?}",idx,val);
-    }
-}
-
 /// Clear the tables from TLD to reclaim memory.
 pub fn clear_tables() {
     with_sctable(|table| {
@@ -128,13 +120,8 @@ pub fn source(ident: Ident) -> Option<(Ident /* source ident */, Mrk /* source m
 
 #[cfg(test)]
 mod tests {
-    use ast::{EMPTY_CTXT, Ident, Mrk, Name, SyntaxContext};
-    use super::{resolve, apply_mark_internal, new_sctable_internal};
-    use super::{SCTable, Mark};
-
-    fn id(n: u32, s: SyntaxContext) -> Ident {
-        Ident::new(Name(n), s)
-    }
+    use ast::{EMPTY_CTXT, Mrk, SyntaxContext};
+    use super::{apply_mark_internal, new_sctable_internal, Mark, SCTable};
 
     // extend a syntax context with a sequence of marks given
     // in a vector. v[0] will be the outermost mark.
@@ -153,12 +140,6 @@ mod tests {
             assert!((*table)[1] == Mark(7,EMPTY_CTXT));
             assert!((*table)[2] == Mark(3,SyntaxContext(1)));
         }
-    }
-
-    #[test]
-    fn mtwt_resolve_test(){
-        let a = 40;
-        assert_eq!(resolve(id(a,EMPTY_CTXT)),Name(a));
     }
 
     #[test]

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -637,21 +637,3 @@ pub fn fresh_name(src: ast::Ident) -> ast::Name {
 pub fn fresh_mark() -> ast::Mrk {
     gensym("mark").0
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use ast;
-    use ext::mtwt;
-
-    fn mark_ident(id : ast::Ident, m : ast::Mrk) -> ast::Ident {
-        ast::Ident::new(id.name, mtwt::apply_mark(m, id.ctxt))
-    }
-
-    #[test] fn mtwt_token_eq_test() {
-        assert!(Gt.mtwt_eq(&Gt));
-        let a = str_to_ident("bac");
-        let a1 = mark_ident(a,92);
-        assert!(Ident(a).mtwt_eq(&Ident(a1)));
-    }
-}

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -15,7 +15,6 @@ pub use self::Lit::*;
 pub use self::Token::*;
 
 use ast::{self, BinOpKind};
-use ext::mtwt;
 use ptr::P;
 use util::interner::{RcStr, StrInterner};
 use util::interner;
@@ -311,17 +310,6 @@ impl Token {
             Ident(id) => id.name >= keywords::Abstract.name() &&
                          id.name <= keywords::Yield.name(),
             _ => false,
-        }
-    }
-
-    /// Hygienic identifier equality comparison.
-    ///
-    /// See `styntax::ext::mtwt`.
-    pub fn mtwt_eq(&self, other : &Token) -> bool {
-        match (self, other) {
-            (&Ident(id1), &Ident(id2)) | (&Lifetime(id1), &Lifetime(id2)) =>
-                mtwt::resolve(id1) == mtwt::resolve(id2),
-            _ => *self == *other
         }
     }
 }

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -185,6 +185,8 @@ impl<'a> fold::Folder for TestHarnessGenerator<'a> {
 
         mod_folded
     }
+
+    fn fold_mac(&mut self, mac: ast::Mac) -> ast::Mac { mac }
 }
 
 struct EntryPointCleaner {
@@ -234,6 +236,8 @@ impl fold::Folder for EntryPointCleaner {
 
         SmallVector::one(folded)
     }
+
+    fn fold_mac(&mut self, mac: ast::Mac) -> ast::Mac { mac }
 }
 
 fn mk_reexport_mod(cx: &mut TestCtxt, tests: Vec<ast::Ident>,

--- a/src/test/run-pass/hygiene.rs
+++ b/src/test/run-pass/hygiene.rs
@@ -106,6 +106,13 @@ fn match_hygiene() {
     m!(Ok(x), x);
 }
 
+fn label_hygiene() {
+    'a: loop {
+        macro_rules! m { () => { break 'a; } }
+        m!();
+    }
+}
+
 fn main() {
     f();
     g();


### PR DESCRIPTION
This PR removes renaming from the hygiene algorithm and treats differently marked identifiers as unequal.

This change makes the scope of identifiers in `macro_rules!` items empty. That is, identifiers in `macro_rules!` definitions do not inherit any semantics from the `macro_rules!`'s scope.

Since `macro_rules!` macros are items, the scope of their identifiers "should" be the same as that of other items; in particular, the scope should contain only items. Since all items are unhygienic today, this would mean the scope should be empty.

However, the scope of an identifier in a `macro_rules!` statement today is the scope that the identifier would have if it replaced the `macro_rules!` (excluding anything unhygienic, i.e. locals only).

To continue to support this, this PR tracks the scope of each `macro_rules!` and uses it in `resolve` to ensure that an identifier expanded from a `macro_rules!` gets a chance to resolve to the locals in the `macro_rules!`'s scope.

This PR is a pure refactoring. After this PR,
- `syntax::ext::expand` is much simpler.
- We can expand macros in any order without causing problems for hygiene (needed for macro modularization).
- We can deprecate or remove today's `macro_rules!` scope easily.
- Expansion performance improves by 25%, post-expansion memory usage decreases by ~5%.
- Expanding a block is no longer quadratic in the number of `let` statements (fixes #10607).

r? @nrc
