### PR TITLE
Fix ICE from #33364 by selectively skipping confirmation pass.

### DIFF
--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -1016,7 +1016,7 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                         ppaux::parameterized(fmt, substs, variant_def.did,
                                              ppaux::Ns::Value, &[],
                                              |tcx| {
-                            Some(tcx.lookup_item_type(variant_def.did).generics)
+                            tcx.opt_lookup_item_type(variant_def.did).map(|t|t.generics)
                         })?;
 
                         match variant_def.kind() {
@@ -1112,7 +1112,7 @@ impl<'tcx> Debug for Literal<'tcx> {
             Item { def_id, substs } => {
                 ppaux::parameterized(
                     fmt, substs, def_id, ppaux::Ns::Value, &[],
-                    |tcx| Some(tcx.lookup_item_type(def_id).generics))
+                    |tcx| tcx.opt_lookup_item_type(def_id).map(|t|t.generics))
             }
             Value { ref value } => {
                 write!(fmt, "const ")?;

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -2453,6 +2453,19 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
                                expected_trait_ref: ty::PolyTraitRef<'tcx>)
                                -> Result<(), SelectionError<'tcx>>
     {
+        if self.projection_mode().is_any() {
+            // Issue #33364: `ProjectionMode::Any` means trans. This
+            // method is not looking up a vtable, so its feasible to
+            // skip confirmation.
+            //
+            // (Skipping confirmation sidesteps ICE in #33364. Even if
+            // that were fixed by other means, skipping is still good
+            // since redundant confirmations wastes compile-time.)
+
+            debug!("confirm_poly_trait_refs skip confirm unconditionally");
+            return Ok(());
+        }
+
         let origin = TypeOrigin::RelateOutputImplTypes(obligation_cause.span);
 
         let obligation_trait_ref = obligation_trait_ref.clone();

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -1069,7 +1069,9 @@ impl<'tcx> ToPredicate<'tcx> for TraitRef<'tcx> {
         // we're about to add a binder, so let's check that we don't
         // accidentally capture anything, or else that might be some
         // weird debruijn accounting.
-        assert!(!self.has_escaping_regions());
+        if self.has_escaping_regions() {
+            bug!("TraitRef::to_predicate {:?} has escaping regions", self);
+        }
 
         ty::Predicate::Trait(ty::Binder(ty::TraitPredicate {
             trait_ref: self.clone()

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -563,6 +563,10 @@ pub struct TyS<'tcx> {
     region_depth: u32,
 }
 
+impl<'tcx> TyS<'tcx> {
+    pub fn region_depth(&self) -> u32 { self.region_depth }
+}
+
 impl<'tcx> PartialEq for TyS<'tcx> {
     #[inline]
     fn eq(&self, other: &TyS<'tcx>) -> bool {

--- a/src/test/run-pass/issue-33364-reduced.rs
+++ b/src/test/run-pass/issue-33364-reduced.rs
@@ -1,0 +1,55 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #33364: This is a reduced version of the reported code that
+// caused an ICE. The ICE was due to a confirmation step during trans
+// attempting (and failing) to match up the actual argument type to
+// the closure (in this case, `&u32`) with the Fn argument type, which
+// is a projection of the form `<T as Foo<'b>>::Item`.
+
+use std::marker::PhantomData;
+
+trait Foo<'a> {
+    type Item;
+    fn consume<F>(self, f: F) where F: Fn(Self::Item);
+}
+struct Consume<A>(PhantomData<A>);
+
+impl<'a, A:'a> Foo<'a> for Consume<A> {
+    type Item = &'a A;
+
+    fn consume<F>(self, _f: F) where F: Fn(Self::Item) {
+        if blackbox() {
+            _f(any());
+        }
+    }
+}
+
+#[derive(Clone)]
+struct Wrap<T> { foo: T }
+
+impl<T: for <'a> Foo<'a>> Wrap<T> {
+    fn consume<F>(self, f: F) where F: for <'b> Fn(<T as Foo<'b>>::Item) {
+        self.foo.consume(f);
+    }
+}
+
+fn main() {
+    // This works
+    Consume(PhantomData::<u32>).consume(|item| { let _a = item; });
+
+    // This used to not work (but would only be noticed if you call closure).
+    let _wrap = Wrap { foo: Consume(PhantomData::<u32>,) };
+    _wrap.consume(|item| { let _a = item; });
+}
+
+pub static mut FLAG: bool = false;
+fn blackbox() -> bool { unsafe { FLAG } }
+fn any<T>() -> T { loop { } }

--- a/src/test/run-pass/issue-33364-region-in-ret-type.rs
+++ b/src/test/run-pass/issue-33364-region-in-ret-type.rs
@@ -1,0 +1,25 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #33364: While working on the hack/fix to workaround an ICE, I
+// injected a new ICE that was not tested by our run-pass test suite
+// (but was exposed by attempting to bootstrap the compiler itself, as
+// well as our compile-fail tests). This test attempts to codify the
+// problem I encountered at that time, as a run-pass test.
+
+#![feature(unboxed_closures)]
+fn main()
+{
+    static X: u32 = 3;
+    fn lifetime_in_ret_type_alone<'a>() -> &'a u32 { &X }
+    fn apply_thunk<T: FnOnce<()>>(t: T, _x: T::Output) { t(); }
+
+    apply_thunk(lifetime_in_ret_type_alone, &3);
+}


### PR DESCRIPTION
Fix #33364: during trans, confirmation should never fail (because type check has already admitted the source code).

So skip confirmation in that context, unless there is some reason (i.e. unresolved unification variables, or a type undering a Binder for region variables) during projection of an associated item) that we still need to run it.
