### PR TITLE
Fix README.md command consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ $ make && make install
 If you’d like to build the documentation, it’s almost the same:
 
 ```sh
-./configure
+$ ./configure
 $ make docs
 ```
 


### PR DESCRIPTION
The `./configure` command in README.md's Building Documentation section was missing the `$` prefix. Add the prefix to be consistent with other commands in the document.
