### PR TITLE
rustbuild: Clean out tmp directory on `make clean`

### DIFF
--- a/src/bootstrap/build/clean.rs
+++ b/src/bootstrap/build/clean.rs
@@ -21,6 +21,9 @@ use std::path::Path;
 use build::Build;
 
 pub fn clean(build: &Build) {
+    rm_rf(build, "tmp".as_ref());
+    rm_rf(build, &build.out.join("tmp"));
+
     for host in build.config.host.iter() {
 
         let out = build.out.join(host);


### PR DESCRIPTION
Right now we generate error index information into this directory, but it's
never cleaned out. This means that if a build _bounces_ because of something in
this directory it'll continue to cause all future builds to fail because the
relevant files are never removed.
