### PR TITLE
rustdoc: Remove paths from primitive page <title> tags

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -317,6 +317,9 @@ impl Item {
     pub fn is_ty_method(&self) -> bool {
         ItemType::from_item(self) == ItemType::TyMethod
     }
+    pub fn is_primitive(&self) -> bool {
+        ItemType::from_item(self) == ItemType::Primitive
+    }
     pub fn is_stripped(&self) -> bool {
         match self.inner { StrippedItem(..) => true, _ => false }
     }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1308,7 +1308,12 @@ impl Context {
                 *slot.borrow_mut() = cx.current.clone();
             });
 
-            let mut title = cx.current.join("::");
+            let mut title = if it.is_primitive() {
+                // No need to include the namespace for primitive types
+                String::new()
+            } else {
+                cx.current.join("::")
+            };
             if pushname {
                 if !title.is_empty() {
                     title.push_str("::");
@@ -1559,11 +1564,7 @@ impl<'a> fmt::Display for Item<'a> {
             clean::PrimitiveItem(..) => write!(fmt, "Primitive Type ")?,
             _ => {}
         }
-        let is_primitive = match self.item.inner {
-            clean::PrimitiveItem(..) => true,
-            _ => false,
-        };
-        if !is_primitive {
+        if !self.item.is_primitive() {
             let cur = &self.cx.current;
             let amt = if self.item.is_mod() { cur.len() - 1 } else { cur.len() };
             for (i, component) in cur.iter().enumerate().take(amt) {
@@ -1595,7 +1596,7 @@ impl<'a> fmt::Display for Item<'a> {
         // [src] link in the downstream documentation will actually come back to
         // this page, and this link will be auto-clicked. The `id` attribute is
         // used to find the link to auto-click.
-        if self.cx.shared.include_sources && !is_primitive {
+        if self.cx.shared.include_sources && !self.item.is_primitive() {
             if let Some(l) = self.href() {
                 write!(fmt, "<a id='src-{}' class='srclink' \
                               href='{}' title='{}'>[src]</a>",

--- a/src/test/rustdoc/prim-title.rs
+++ b/src/test/rustdoc/prim-title.rs
@@ -1,0 +1,17 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "foo"]
+
+// @has foo/primitive.u8.html '//head/title' 'u8 - Rust'
+// @!has - '//head/title' 'foo'
+#[doc(primitive = "u8")]
+/// `u8` docs
+mod u8 {}


### PR DESCRIPTION
Currently primitive pages have a title like "std::u8 - Rust" this changes
it to "u8 - Rust" as "std::u8" is the name of a module not a primitive
type.
