### PR TITLE
Issue #34076: Removing reference to removed path.prefix() function

### DIFF
--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1443,8 +1443,7 @@ impl Path {
     /// `is_absolute` and `has_root` are equivalent.
     ///
     /// * On Windows, a path is absolute if it has a prefix and starts with the
-    /// root: `c:\windows` is absolute, while `c:temp` and `\temp` are not. In
-    /// other words, `path.is_absolute() == path.prefix().is_some() && path.has_root()`.
+    /// root: `c:\windows` is absolute, while `c:temp` and `\temp` are not.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
In the documentation for `std::path::Path`, there is a [reference](https://doc.rust-lang.org/std/path/struct.Path.html#method.is_absolute) to the `path.prefix()` function which has since been removed. The offending reference is now also removed. 

First pull request, feedback welcome!

r? @steveklabnik
