### PR TITLE
Move LLVM cleanup so modules are accessible during `after_llvm` phase

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -225,6 +225,8 @@ pub fn compile_input(sess: &Session,
                             phase5_result);
     phase5_result?;
 
+    write::cleanup_llvm(&trans);
+
     phase_6_link_output(sess, &trans, &outputs);
 
     Ok(())

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -229,6 +229,11 @@ pub fn compile_input(sess: &Session,
 
     phase_6_link_output(sess, &trans, &outputs);
 
+    controller_entry_point!(after_compilation_done,
+                            sess,
+                            CompileState::state_after_compilation_done(input, sess, outdir, output),
+                            Ok(()));
+
     Ok(())
 }
 
@@ -276,6 +281,7 @@ pub struct CompileController<'a> {
     pub after_hir_lowering: PhaseController<'a>,
     pub after_analysis: PhaseController<'a>,
     pub after_llvm: PhaseController<'a>,
+    pub after_compilation_done: PhaseController<'a>,
 
     pub make_glob_map: MakeGlobMap,
 }
@@ -288,6 +294,7 @@ impl<'a> CompileController<'a> {
             after_hir_lowering: PhaseController::basic(),
             after_analysis: PhaseController::basic(),
             after_llvm: PhaseController::basic(),
+            after_compilation_done: PhaseController::basic(),
             make_glob_map: MakeGlobMap::No,
         }
     }
@@ -451,6 +458,17 @@ impl<'a, 'b, 'ast, 'tcx> CompileState<'a, 'b, 'ast, 'tcx> {
                         -> CompileState<'a, 'b, 'ast, 'tcx> {
         CompileState {
             trans: Some(trans),
+            out_file: out_file.as_ref().map(|s| &**s),
+            ..CompileState::empty(input, session, out_dir)
+        }
+    }
+
+    fn state_after_compilation_done(input: &'a Input,
+                                    session: &'ast Session,
+                                    out_dir: &'a Option<PathBuf>,
+                                    out_file: &'a Option<PathBuf>)
+                                    -> CompileState<'a, 'b, 'ast, 'tcx> {
+        CompileState {
             out_file: out_file.as_ref().map(|s| &**s),
             ..CompileState::empty(input, session, out_dir)
         }

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -229,9 +229,9 @@ pub fn compile_input(sess: &Session,
 
     phase_6_link_output(sess, &trans, &outputs);
 
-    controller_entry_point!(after_compilation_done,
+    controller_entry_point!(compilation_done,
                             sess,
-                            CompileState::state_after_compilation_done(input, sess, outdir, output),
+                            CompileState::state_when_compilation_done(input, sess, outdir, output),
                             Ok(()));
 
     Ok(())
@@ -281,7 +281,7 @@ pub struct CompileController<'a> {
     pub after_hir_lowering: PhaseController<'a>,
     pub after_analysis: PhaseController<'a>,
     pub after_llvm: PhaseController<'a>,
-    pub after_compilation_done: PhaseController<'a>,
+    pub compilation_done: PhaseController<'a>,
 
     pub make_glob_map: MakeGlobMap,
 }
@@ -294,7 +294,7 @@ impl<'a> CompileController<'a> {
             after_hir_lowering: PhaseController::basic(),
             after_analysis: PhaseController::basic(),
             after_llvm: PhaseController::basic(),
-            after_compilation_done: PhaseController::basic(),
+            compilation_done: PhaseController::basic(),
             make_glob_map: MakeGlobMap::No,
         }
     }
@@ -463,7 +463,7 @@ impl<'a, 'b, 'ast, 'tcx> CompileState<'a, 'b, 'ast, 'tcx> {
         }
     }
 
-    fn state_after_compilation_done(input: &'a Input,
+    fn state_when_compilation_done(input: &'a Input,
                                     session: &'ast Session,
                                     out_dir: &'a Option<PathBuf>,
                                     out_file: &'a Option<PathBuf>)

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -616,9 +616,17 @@ unsafe fn optimize_and_codegen(cgcx: &CodegenContext,
         }
     }
 
-    llvm::LLVMDisposeModule(llmod);
-    llvm::LLVMContextDispose(llcx);
     llvm::LLVMRustDisposeTargetMachine(tm);
+}
+
+
+pub fn cleanup_llvm(trans: &CrateTranslation) {
+    for module in trans.modules.iter() {
+        unsafe {
+            llvm::LLVMDisposeModule(module.llmod);
+            llvm::LLVMContextDispose(module.llcx);
+        }
+    }
 }
 
 pub fn run_passes(sess: &Session,

--- a/src/test/run-make/llvm-phase/Makefile
+++ b/src/test/run-make/llvm-phase/Makefile
@@ -1,0 +1,5 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) test.rs
+	$(call RUN,test $(RUSTC))

--- a/src/test/run-make/llvm-phase/test.rs
+++ b/src/test/run-make/llvm-phase/test.rs
@@ -1,0 +1,82 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(plugin, rustc_private, box_syntax)]
+
+extern crate rustc;
+extern crate rustc_driver;
+extern crate rustc_llvm;
+#[macro_use] extern crate syntax;
+extern crate getopts;
+
+use rustc_driver::{CompilerCalls, Compilation};
+use rustc_driver::driver::CompileController;
+use rustc::session::Session;
+use syntax::codemap::FileLoader;
+use std::io;
+use std::path::{PathBuf, Path};
+
+struct JitLoader;
+
+impl FileLoader for JitLoader {
+    fn file_exists(&self, _: &Path) -> bool { true }
+    fn abs_path(&self, _: &Path) -> Option<PathBuf> { None }
+    fn read_file(&self, _: &Path) -> io::Result<String> {
+        Ok(r#"
+#[no_mangle]
+pub fn test_add(a: i32, b: i32) -> i32 { a + b }
+"#.to_string())
+    }
+}
+
+#[derive(Copy, Clone)]
+struct JitCalls;
+
+impl<'a> CompilerCalls<'a> for JitCalls {
+    fn build_controller(&mut self,
+                        _: &Session,
+                        _: &getopts::Matches)
+                        -> CompileController<'a> {
+        let mut cc = CompileController::basic();
+        cc.after_llvm.stop = Compilation::Stop;
+        cc.after_llvm.run_callback_on_error = true;
+        cc.after_llvm.callback = Box::new(|state| {
+            state.session.abort_if_errors();
+            let trans = state.trans.unwrap();
+            assert_eq!(trans.modules.len(), 1);
+            let rs_llmod = trans.modules[0].llmod;
+            unsafe { rustc_llvm::LLVMDumpModule(rs_llmod) };
+        });
+        cc
+    }
+}
+
+fn main() {
+    use rustc_driver;
+
+    let mut path = match std::env::args().nth(2) {
+        Some(path) => PathBuf::from(&path),
+        None => panic!("missing rustc path")
+    };
+
+    // Remove two segments from rustc path to get sysroot.
+    path.pop();
+    path.pop();
+
+    let args: Vec<String> =
+        format!("_ _ --sysroot {} --crate-type dylib", path.to_str().unwrap())
+        .split(' ').map(|s| s.to_string()).collect();
+
+    let (result, _) = rustc_driver::run_compiler_with_file_loader(
+        &args, &mut JitCalls, box JitLoader);
+    if let Err(n) = result {
+        panic!("Error {}", n);
+    }
+}


### PR DESCRIPTION
Fix for #34432. Also added a new phase controller `after_compilation_done` that gets called at the very end (i.e. after linking) at the suggestion of @nrc. The added test will segfault if the modules get deallocated too early, so it ensures the LLVM is not prematurely cleaned up.

r? @nrc 
