### PR TITLE
Support more python 2.7 versions in bootstrap.py

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -265,7 +265,7 @@ class RustBuild:
         try:
             ostype = subprocess.check_output(['uname', '-s']).strip()
             cputype = subprocess.check_output(['uname', '-m']).strip()
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, WindowsError):
             if sys.platform == 'win32':
                 return 'x86_64-pc-windows-msvc'
             err = "uname not found"


### PR DESCRIPTION
It seems python broke compatability between 2.7.9  and 2.7.12 as on the former a WindowsError was raised while on the latter a subprocess.CalledProcessError was raised while testing for the existence of uname.

As a WindowsError being thrown obviously indicates we're running on windows, this should probably be accepted too.
