### PR TITLE
llvm, rt: build using the Ninja generator if available

### DIFF
--- a/configure
+++ b/configure
@@ -612,6 +612,7 @@ opt rustbuild 0 "use the rust and cargo based build system"
 opt orbit 0 "get MIR where it belongs - everywhere; most importantly, in orbit"
 opt codegen-tests 1 "run the src/test/codegen tests"
 opt option-checking 1 "complain about unrecognized options in this configure script"
+opt ninja 0 "build LLVM using the Ninja generator (for MSVC, requires building in the correct environment)"
 
 # Optimization and debugging options. These may be overridden by the release channel, etc.
 opt_nosave optimize 1 "build optimized rust code"
@@ -774,6 +775,17 @@ probe CFG_FLEX             flex
 probe CFG_BISON            bison
 probe CFG_GDB              gdb
 probe CFG_LLDB             lldb
+
+if [ -n "$CFG_ENABLE_NINJA" ]
+then
+  probe CFG_NINJA            ninja
+  if [ -z "$CFG_NINJA" ]
+  then
+    # On Debian and Fedora, the `ninja` binary is an IRC bot, so the build tool was
+    # renamed. Handle this case.
+    probe CFG_NINJA            ninja-build
+  fi
+fi
 
 # For building LLVM
 probe_need CFG_CMAKE cmake
@@ -1524,7 +1536,10 @@ do
     fi
 
     # We need the generator later on for compiler-rt even if LLVM's not built
-    if [ ${is_msvc} -ne 0 ]
+    if [ -n "$CFG_NINJA" ]
+    then
+        generator="Ninja"
+    elif [ ${is_msvc} -ne 0 ]
     then
         case "$CFG_MSVC_ROOT" in
             *14.0*)

--- a/mk/llvm.mk
+++ b/mk/llvm.mk
@@ -43,7 +43,9 @@ $$(LLVM_CONFIG_$(1)): $$(LLVM_DONE_$(1))
 
 $$(LLVM_DONE_$(1)): $$(LLVM_DEPS_TARGET_$(1)) $$(LLVM_STAMP_$(1))
 	@$$(call E, cmake: llvm)
-ifeq ($$(findstring msvc,$(1)),msvc)
+ifneq ($$(CFG_NINJA),)
+	$$(Q)$$(CFG_NINJA) -C $$(CFG_LLVM_BUILD_DIR_$(1))
+else ifeq ($$(findstring msvc,$(1)),msvc)
 	$$(Q)$$(CFG_CMAKE) --build $$(CFG_LLVM_BUILD_DIR_$(1)) \
 		--config $$(LLVM_BUILD_CONFIG_MODE)
 else
@@ -51,7 +53,11 @@ else
 endif
 	$$(Q)touch $$@
 
-ifeq ($$(findstring msvc,$(1)),msvc)
+ifneq ($$(CFG_NINJA),)
+clean-llvm$(1):
+	@$$(call E, clean: llvm)
+	$$(Q)$$(CFG_NINJA) -C $$(CFG_LLVM_BUILD_DIR_$(1)) -t clean
+else ifeq ($$(findstring msvc,$(1)),msvc)
 clean-llvm$(1):
 else
 clean-llvm$(1):

--- a/mk/llvm.mk
+++ b/mk/llvm.mk
@@ -59,6 +59,10 @@ clean-llvm$(1):
 	$$(Q)$$(CFG_NINJA) -C $$(CFG_LLVM_BUILD_DIR_$(1)) -t clean
 else ifeq ($$(findstring msvc,$(1)),msvc)
 clean-llvm$(1):
+	@$$(call E, clean: llvm)
+	$$(Q)$$(CFG_CMAKE) --build $$(CFG_LLVM_BUILD_DIR_$(1)) \
+		--config $$(LLVM_BUILD_CONFIG_MODE) \
+		--target clean
 else
 clean-llvm$(1):
 	@$$(call E, clean: llvm)

--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -350,10 +350,17 @@ $$(COMPRT_LIB_$(1)): $$(COMPRT_DEPS) $$(MKFILE_DEPS) $$(LLVM_CONFIG_$$(CFG_BUILD
 		$$(COMPRT_DEFINES_$(1)) \
 		$$(COMPRT_BUILD_CC_$(1)) \
 		-G"$$(CFG_CMAKE_GENERATOR)"
+ifneq ($$(CFG_NINJA),)
+	$$(CFG_CMAKE) --build "$$(COMPRT_BUILD_DIR_$(1))" \
+		--target $$(COMPRT_BUILD_TARGET_$(1)) \
+		--config $$(LLVM_BUILD_CONFIG_MODE) \
+		-- $$(COMPRT_BUILD_ARGS_$(1))
+else
 	$$(Q)$$(CFG_CMAKE) --build "$$(COMPRT_BUILD_DIR_$(1))" \
 		--target $$(COMPRT_BUILD_TARGET_$(1)) \
 		--config $$(LLVM_BUILD_CONFIG_MODE) \
 		-- $$(COMPRT_BUILD_ARGS_$(1)) $$(MFLAGS)
+endif
 	$$(Q)cp "$$(COMPRT_OUTPUT_$(1))" $$@
 
 endif

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -317,6 +317,7 @@ impl Config {
                 ("OPTIMIZE_TESTS", self.rust_optimize_tests),
                 ("DEBUGINFO_TESTS", self.rust_debuginfo_tests),
                 ("LOCAL_REBUILD", self.local_rebuild),
+                ("NINJA", self.ninja),
             }
 
             match key {


### PR DESCRIPTION
The Ninja generator generally builds much faster than make. It may also
be used on Windows to have a vast speed improvement over the Visual
Studio generators.

Currently hidden behind an `--enable-ninja` flag because it does not
obey the top-level `-j` or `-l` flags given to `make`.
