### PR TITLE
Build: Shows total time taken to build the compiler

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -10,6 +10,7 @@
 
 import argparse
 import contextlib
+import datetime
 import hashlib
 import os
 import shutil
@@ -17,6 +18,8 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+
+from time import time
 
 
 def get(url, path, verbose=False):
@@ -117,6 +120,9 @@ def stage0_data(rust_root):
             a, b = line.split(": ", 1)
             data[a] = b
     return data
+
+def format_build_time(duration):
+    return str(datetime.timedelta(seconds=int(duration)))
 
 class RustBuild:
     def download_stage0(self):
@@ -372,6 +378,8 @@ def main():
     rb._rustc_channel, rb._rustc_date = data['rustc'].split('-', 1)
     rb._cargo_channel, rb._cargo_date = data['cargo'].split('-', 1)
 
+    start_time = time()
+
     # Fetch/build the bootstrap
     rb.build = rb.build_triple()
     rb.download_stage0()
@@ -389,6 +397,10 @@ def main():
     env = os.environ.copy()
     env["BOOTSTRAP_PARENT_ID"] = str(os.getpid())
     rb.run(args, env)
+
+    end_time = time()
+
+    print("Build completed in %s" % format_build_time(end_time - start_time))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Fixes #34600 
Prints the total time taken to build rustc by executing `src/bootstrap/bootstrap.py`; also includes time taken to download `stage0` compiler and deps.

r? @alexcrichton 
