### PR TITLE
Fix spacing in for loop enumeration example

### DIFF
--- a/src/doc/book/loops.md
+++ b/src/doc/book/loops.md
@@ -105,7 +105,7 @@ When you need to keep track of how many times you already looped, you can use th
 #### On ranges:
 
 ```rust
-for (i,j) in (5..10).enumerate() {
+for (i, j) in (5..10).enumerate() {
     println!("i = {} and j = {}", i, j);
 }
 ```


### PR DESCRIPTION
Add a space between the comma and j in (i, j) to make it look nice.

This addresses my recent issue #34624.

😀
