### PR TITLE
Fix ios / compiler-rt condition in makefile

### DIFF
--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -320,7 +320,7 @@ endif
 COMPRT_BUILD_CC_$(1) := -DCMAKE_C_COMPILER=$$(call FIND_COMPILER,$$(CC_$(1))) \
 			-DCMAKE_CXX_COMPILER=$$(call FIND_COMPILER,$$(CXX_$(1)))
 
-ifeq ($$(findstring ios,$(1)),)
+ifeq ($$(findstring ios,$(1)),ios)
 COMPRT_BUILD_CC_$(1) := $$(COMPRT_BUILD_CC_$(1)) \
 			-DCMAKE_C_FLAGS="$$(CFG_GCCISH_CFLAGS_$(1)) -Wno-error"
 endif


### PR DESCRIPTION
This was introduced in #34055 and caused a regression in the ios builds.

Closes #34617.

I'm currently running a local build to verify that this fixes the regression but preliminary tests indicate that the `GCCISH_CFLAGS` are now properly forwarded to `cmake` which they previously were not (which was the cause of the regression as far as I can tell).
