### PR TITLE
Avoid redundant downloads when bootstrapping

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -32,14 +32,14 @@ def get(url, path, verbose=False):
     try:
         download(sha_path, sha_url, verbose)
         if os.path.exists(path):
-            if verify(path, sha_path, verbose):
+            if verify(path, sha_path, False):
                 print("using already-download file " + path)
                 return
             else:
                 print("ignoring already-download file " + path + " due to failed verification")
                 os.unlink(path)
         download(temp_path, url, verbose)
-        if not verify(temp_path, sha_path, verbose):
+        if not verify(temp_path, sha_path, True):
             raise RuntimeError("failed verification")
         print("moving {} to {}".format(temp_path, path))
         shutil.move(temp_path, path)

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -31,6 +31,14 @@ def get(url, path, verbose=False):
 
     try:
         download(sha_path, sha_url, verbose)
+        if os.path.exists(path):
+            try:
+                verify(path, sha_path, verbose)
+                print("using already-download file " + path)
+                return
+            except Exception as e:
+                print("failed verification for already-download file " + path)
+                os.unlink(path)
         download(temp_path, url, verbose)
         verify(temp_path, sha_path, verbose)
         print("moving {} to {}".format(temp_path, path))

--- a/src/etc/get-stage0.py
+++ b/src/etc/get-stage0.py
@@ -31,8 +31,6 @@ def main(triple):
     filename = 'rustc-{}-{}.tar.gz'.format(channel, triple)
     url = 'https://static.rust-lang.org/dist/{}/{}'.format(date, filename)
     dst = dl_dir + '/' + filename
-    if os.path.exists(dst):
-        os.unlink(dst)
     bootstrap.get(url, dst)
 
     stage0_dst = triple + '/stage0'


### PR DESCRIPTION
If the local file is available, then verify it against the hash we just
downloaded, and if it matches then we don't need to download it again.
