### PR TITLE
Fix bugs in macro-expanded statement parsing

### DIFF
--- a/src/doc/book/macros.md
+++ b/src/doc/book/macros.md
@@ -328,7 +328,7 @@ invocation site. Code such as the following will not work:
 
 ```rust,ignore
 macro_rules! foo {
-    () => (let x = 3);
+    () => (let x = 3;);
 }
 
 fn main() {
@@ -342,7 +342,7 @@ tagged with the right syntax context.
 
 ```rust
 macro_rules! foo {
-    ($v:ident) => (let $v = 3);
+    ($v:ident) => (let $v = 3;);
 }
 
 fn main() {

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -57,7 +57,7 @@ macro_rules! down_cast_data {
             data
         } else {
             span_bug!($sp, "unexpected data kind: {:?}", $id);
-        }
+        };
     };
 }
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -804,6 +804,19 @@ pub struct Stmt {
     pub span: Span,
 }
 
+impl Stmt {
+    pub fn add_trailing_semicolon(mut self) -> Self {
+        self.node = match self.node {
+            StmtKind::Expr(expr) => StmtKind::Semi(expr),
+            StmtKind::Mac(mac) => StmtKind::Mac(mac.map(|(mac, _style, attrs)| {
+                (mac, MacStmtStyle::Semicolon, attrs)
+            })),
+            node @ _ => node,
+        };
+        self
+    }
+}
+
 impl fmt::Debug for Stmt {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "stmt({}: {})", self.id.to_string(), pprust::stmt_to_string(self))

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -444,14 +444,7 @@ fn expand_stmt(stmt: Stmt, fld: &mut MacroExpander) -> SmallVector<Stmt> {
     // semicolon to the final statement produced by expansion.
     if style == MacStmtStyle::Semicolon {
         if let Some(stmt) = fully_expanded.pop() {
-            fully_expanded.push(Stmt {
-                id: stmt.id,
-                node: match stmt.node {
-                    StmtKind::Expr(expr) => StmtKind::Semi(expr),
-                    _ => stmt.node /* might already have a semi */
-                },
-                span: stmt.span,
-            });
+            fully_expanded.push(stmt.add_trailing_semicolon());
         }
     }
 

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -118,12 +118,18 @@ impl<'a> MacResult for ParserAnyMacro<'a> {
 
     fn make_stmts(self: Box<ParserAnyMacro<'a>>)
                  -> Option<SmallVector<ast::Stmt>> {
+        let parse_stmt = |parser: &mut Parser<'a>| -> ::parse::PResult<'a, _> {
+            Ok(match parser.parse_stmt()? {
+                Some(stmt) => Some(parser.finish_parsing_statement(stmt)?),
+                None => None,
+            })
+        };
         let mut ret = SmallVector::zero();
         loop {
             let mut parser = self.parser.borrow_mut();
             match parser.token {
                 token::Eof => break,
-                _ => match parser.parse_stmt() {
+                _ => match parse_stmt(&mut parser) {
                     Ok(maybe_stmt) => match maybe_stmt {
                         Some(stmt) => ret.push(stmt),
                         None => (),

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -118,18 +118,12 @@ impl<'a> MacResult for ParserAnyMacro<'a> {
 
     fn make_stmts(self: Box<ParserAnyMacro<'a>>)
                  -> Option<SmallVector<ast::Stmt>> {
-        let parse_stmt = |parser: &mut Parser<'a>| -> ::parse::PResult<'a, _> {
-            Ok(match parser.parse_stmt()? {
-                Some(stmt) => Some(parser.finish_parsing_statement(stmt)?),
-                None => None,
-            })
-        };
         let mut ret = SmallVector::zero();
         loop {
             let mut parser = self.parser.borrow_mut();
             match parser.token {
                 token::Eof => break,
-                _ => match parse_stmt(&mut parser) {
+                _ => match parser.parse_full_stmt() {
                     Ok(maybe_stmt) => match maybe_stmt {
                         Some(stmt) => ret.push(stmt),
                         None => (),

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -123,7 +123,7 @@ impl<'a> MacResult for ParserAnyMacro<'a> {
             let mut parser = self.parser.borrow_mut();
             match parser.token {
                 token::Eof => break,
-                _ => match parser.parse_full_stmt() {
+                _ => match parser.parse_full_stmt(true) {
                     Ok(maybe_stmt) => match maybe_stmt {
                         Some(stmt) => ret.push(stmt),
                         None => (),

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4064,7 +4064,7 @@ impl<'a> Parser<'a> {
 
     /// Finish parsing expressions that start with macros and handle trailing semicolons
     /// (or the lack thereof) -- c.f. `parse_stmt`.
-    fn finish_parsing_statement(&mut self, mut stmt: Stmt) -> PResult<'a, Stmt> {
+    pub fn finish_parsing_statement(&mut self, mut stmt: Stmt) -> PResult<'a, Stmt> {
         if let StmtKind::Mac(mac) = stmt.node {
             if mac.1 != MacStmtStyle::NoBraces || self.token == token::Semi {
                 stmt.node = StmtKind::Mac(mac);
@@ -4082,7 +4082,7 @@ impl<'a> Parser<'a> {
 
     fn handle_trailing_semicolon(&mut self, mut stmt: Stmt) -> PResult<'a, Stmt> {
         match stmt.node {
-            StmtKind::Expr(ref expr) => {
+            StmtKind::Expr(ref expr) if self.token != token::Eof => {
                 // expression without semicolon
                 if classify::expr_requires_semi_to_be_stmt(expr) {
                     // Just check for errors and recover; do not eat semicolon yet.

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4066,7 +4066,8 @@ impl<'a> Parser<'a> {
     /// (or the lack thereof) -- c.f. `parse_stmt`.
     pub fn finish_parsing_statement(&mut self, mut stmt: Stmt) -> PResult<'a, Stmt> {
         if let StmtKind::Mac(mac) = stmt.node {
-            if mac.1 != MacStmtStyle::NoBraces || self.token == token::Semi {
+            if mac.1 != MacStmtStyle::NoBraces ||
+               self.token == token::Semi || self.token == token::Eof {
                 stmt.node = StmtKind::Mac(mac);
             } else {
                 let (mac, _style, attrs) = mac.unwrap();

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3789,7 +3789,13 @@ impl<'a> Parser<'a> {
         self.span_err(self.last_span, message);
     }
 
-    /// Parse a statement. may include decl.
+    /// Parse a statement. This stops just before trailing semicolons on everything but items.
+    /// e.g. a `StmtKind::Semi` parses to a `StmtKind::Expr`, leaving the trailing `;` unconsumed.
+    ///
+    /// Also, if a macro begins an expression statement, this only parses the macro. For example,
+    /// ```rust
+    /// vec![1].into_iter(); //< `parse_stmt` only parses the "vec![1]"
+    /// ```
     pub fn parse_stmt(&mut self) -> PResult<'a, Option<Stmt>> {
         Ok(self.parse_stmt_())
     }
@@ -4038,36 +4044,14 @@ impl<'a> Parser<'a> {
         let mut stmts = vec![];
 
         while !self.eat(&token::CloseDelim(token::Brace)) {
-            let Stmt {node, span, ..} = if let Some(s) = self.parse_stmt_() {
-                s
+            if let Some(stmt) = self.parse_stmt_() {
+                stmts.push(self.finish_parsing_statement(stmt)?);
             } else if self.token == token::Eof {
                 break;
             } else {
                 // Found only `;` or `}`.
                 continue;
             };
-
-            match node {
-                StmtKind::Expr(e) => {
-                    self.handle_expression_like_statement(e, span, &mut stmts)?;
-                }
-                StmtKind::Mac(mac) => {
-                    self.handle_macro_in_block(mac.unwrap(), span, &mut stmts)?;
-                }
-                _ => { // all other kinds of statements:
-                    let mut hi = span.hi;
-                    if classify::stmt_ends_with_semi(&node) {
-                        self.expect(&token::Semi)?;
-                        hi = self.last_span.hi;
-                    }
-
-                    stmts.push(Stmt {
-                        id: ast::DUMMY_NODE_ID,
-                        node: node,
-                        span: mk_sp(span.lo, hi)
-                    });
-                }
-            }
         }
 
         Ok(P(ast::Block {
@@ -4078,93 +4062,50 @@ impl<'a> Parser<'a> {
         }))
     }
 
-    fn handle_macro_in_block(&mut self,
-                             (mac, style, attrs): (ast::Mac, MacStmtStyle, ThinVec<Attribute>),
-                             span: Span,
-                             stmts: &mut Vec<Stmt>)
-                             -> PResult<'a, ()> {
-        if style == MacStmtStyle::NoBraces {
-            // statement macro without braces; might be an
-            // expr depending on whether a semicolon follows
-            match self.token {
-                token::Semi => {
-                    stmts.push(Stmt {
-                        id: ast::DUMMY_NODE_ID,
-                        node: StmtKind::Mac(P((mac, MacStmtStyle::Semicolon, attrs))),
-                        span: mk_sp(span.lo, self.span.hi),
-                    });
-                    self.bump();
-                }
-                _ => {
-                    let e = self.mk_mac_expr(span.lo, span.hi, mac.node, ThinVec::new());
-                    let lo = e.span.lo;
-                    let e = self.parse_dot_or_call_expr_with(e, lo, attrs)?;
-                    let e = self.parse_assoc_expr_with(0, LhsExpr::AlreadyParsed(e))?;
-                    self.handle_expression_like_statement(e, span, stmts)?;
-                }
-            }
-        } else {
-            // statement macro; might be an expr
-            match self.token {
-                token::Semi => {
-                    stmts.push(Stmt {
-                        id: ast::DUMMY_NODE_ID,
-                        node: StmtKind::Mac(P((mac, MacStmtStyle::Semicolon, attrs))),
-                        span: mk_sp(span.lo, self.span.hi),
-                    });
-                    self.bump();
-                }
-                _ => {
-                    stmts.push(Stmt {
-                        id: ast::DUMMY_NODE_ID,
-                        node: StmtKind::Mac(P((mac, style, attrs))),
-                        span: span
-                    });
-                }
+    /// Finish parsing expressions that start with macros and handle trailing semicolons
+    /// (or the lack thereof) -- c.f. `parse_stmt`.
+    fn finish_parsing_statement(&mut self, mut stmt: Stmt) -> PResult<'a, Stmt> {
+        if let StmtKind::Mac(mac) = stmt.node {
+            if mac.1 != MacStmtStyle::NoBraces || self.token == token::Semi {
+                stmt.node = StmtKind::Mac(mac);
+            } else {
+                let (mac, _style, attrs) = mac.unwrap();
+                let e = self.mk_mac_expr(stmt.span.lo, stmt.span.hi, mac.node, ThinVec::new());
+                let e = self.parse_dot_or_call_expr_with(e, stmt.span.lo, attrs)?;
+                let e = self.parse_assoc_expr_with(0, LhsExpr::AlreadyParsed(e))?;
+                stmt.node = StmtKind::Expr(e);
             }
         }
-        Ok(())
+
+        self.handle_trailing_semicolon(stmt)
     }
 
-    fn handle_expression_like_statement(&mut self,
-                                        e: P<Expr>,
-                                        span: Span,
-                                        stmts: &mut Vec<Stmt>)
-                                        -> PResult<'a, ()> {
-        // expression without semicolon
-        if classify::expr_requires_semi_to_be_stmt(&e) {
-            // Just check for errors and recover; do not eat semicolon yet.
-            if let Err(mut e) =
-                self.expect_one_of(&[], &[token::Semi, token::CloseDelim(token::Brace)])
-            {
-                e.emit();
-                self.recover_stmt();
+    fn handle_trailing_semicolon(&mut self, mut stmt: Stmt) -> PResult<'a, Stmt> {
+        match stmt.node {
+            StmtKind::Expr(ref expr) => {
+                // expression without semicolon
+                if classify::expr_requires_semi_to_be_stmt(expr) {
+                    // Just check for errors and recover; do not eat semicolon yet.
+                    if let Err(mut e) =
+                        self.expect_one_of(&[], &[token::Semi, token::CloseDelim(token::Brace)])
+                    {
+                        e.emit();
+                        self.recover_stmt();
+                    }
+                }
             }
+            StmtKind::Local(..) => {
+                self.expect_one_of(&[token::Semi], &[])?;
+            }
+            _ => {}
         }
 
-        match self.token {
-            token::Semi => {
-                self.bump();
-                let span_with_semi = Span {
-                    lo: span.lo,
-                    hi: self.last_span.hi,
-                    expn_id: span.expn_id,
-                };
-                stmts.push(Stmt {
-                    id: ast::DUMMY_NODE_ID,
-                    node: StmtKind::Semi(e),
-                    span: span_with_semi,
-                });
-            }
-            _ => {
-                stmts.push(Stmt {
-                    id: ast::DUMMY_NODE_ID,
-                    node: StmtKind::Expr(e),
-                    span: span
-                });
-            }
+        if self.eat(&token::Semi) {
+            stmt = stmt.add_trailing_semicolon();
         }
-        Ok(())
+
+        stmt.span.hi = self.last_span.hi;
+        Ok(stmt)
     }
 
     // Parses a sequence of bounds if a `:` is found,

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1638,9 +1638,8 @@ impl<'a> State<'a> {
                     _ => token::Paren
                 };
                 try!(self.print_mac(&mac, delim));
-                match style {
-                    ast::MacStmtStyle::Braces => {}
-                    _ => try!(word(&mut self.s, ";")),
+                if style == ast::MacStmtStyle::Semicolon {
+                    try!(word(&mut self.s, ";"));
                 }
             }
         }

--- a/src/test/compile-fail/macro-incomplete-parse.rs
+++ b/src/test/compile-fail/macro-incomplete-parse.rs
@@ -19,7 +19,7 @@ macro_rules! ignored_item {
 }
 
 macro_rules! ignored_expr {
-    () => ( 1,  //~ ERROR expected expression, found `,`
+    () => ( 1,  //~ ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found `,`
             2 )
 }
 

--- a/src/test/compile-fail/missing-semicolon-warning.rs
+++ b/src/test/compile-fail/missing-semicolon-warning.rs
@@ -1,0 +1,22 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_attrs)]
+#![allow(unused)]
+
+macro_rules! m {
+    ($($e1:expr),*; $($e2:expr),*) => {
+        $( let x = $e1 )*; //~ WARN expected `;`
+        $( println!("{}", $e2) )*; //~ WARN expected `;`
+    }
+}
+
+#[rustc_error]
+fn main() { m!(0, 0; 0, 0); } //~ ERROR compilation successful

--- a/src/test/run-pass/simd-intrinsic-generic-cast.rs
+++ b/src/test/run-pass/simd-intrinsic-generic-cast.rs
@@ -113,7 +113,7 @@ fn main() {
         // product macro
         ($from: ident $(, $from_: ident)*: $($to: ident),*) => {
             fn $from() { unsafe { $( test!($from, $to); )* } }
-            tests!($($from_),*: $($to),*);
+            tests!($($from_),*: $($to),*)
         };
         ($($types: ident),*) => {{
             tests!($($types),* : $($types),*);

--- a/src/test/run-pass/simd-intrinsic-generic-cast.rs
+++ b/src/test/run-pass/simd-intrinsic-generic-cast.rs
@@ -113,7 +113,7 @@ fn main() {
         // product macro
         ($from: ident $(, $from_: ident)*: $($to: ident),*) => {
             fn $from() { unsafe { $( test!($from, $to); )* } }
-            tests!($($from_),*: $($to),*)
+            tests!($($from_),*: $($to),*);
         };
         ($($types: ident),*) => {{
             tests!($($types),* : $($types),*);


### PR DESCRIPTION
Fixes #34543.

This is a [breaking-change].
The following would ~~break~~ be a warning (c.f. https://github.com/rust-lang/rust/pull/34660#issuecomment-230699973):

``` rust
macro_rules! m { () => {
    println!("") println!("")
    //^ Semicolons are now required on macro-expanded non-braced macro invocations
    //| in statement positions.
    let x = 0
    //^ Semicolons are now required on macro-expanded `let` statements
    //| that are followed by more statements, so this would break.
    let y = 0 //< (this would still be allowed to reduce breakage in the wild)
}
fn main() { m!() }
```

r? @eddyb
