### PR TITLE
test: Ignore pretty-huge-vec.rs to fix nightlies

### DIFF
--- a/src/test/debuginfo/pretty-huge-vec.rs
+++ b/src/test/debuginfo/pretty-huge-vec.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test: FIXME(#34639)
 // ignore-windows failing on win32 bot
 // ignore-freebsd: gdb package too new
 // ignore-android: FIXME(#10381)


### PR DESCRIPTION
This ignores a test added in #34639 because unfortunately the nightly bots are
now broken, but this is now tracked in #34662.
