### PR TITLE
Handle nested pairs in MIR trans.

### DIFF
--- a/src/librustc_trans/mir/operand.rs
+++ b/src/librustc_trans/mir/operand.rs
@@ -197,10 +197,13 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                         (OperandValue::Pair(a, b),
                          &mir::ProjectionElem::Field(ref f, ty)) => {
                             let llval = [a, b][f.index()];
-                            return OperandRef {
+                            let op = OperandRef {
                                 val: OperandValue::Immediate(llval),
                                 ty: bcx.monomorphize(&ty)
                             };
+
+                            // Handle nested pairs.
+                            return op.unpack_if_pair(bcx);
                         }
                         _ => {}
                     }

--- a/src/test/run-pass/mir_trans_calls.rs
+++ b/src/test/run-pass/mir_trans_calls.rs
@@ -171,6 +171,13 @@ fn test_fn_ignored_pair_named() -> (Foo, Foo) {
     id(ignored_pair_named())
 }
 
+#[rustc_mir]
+fn test_fn_nested_pair(x: &((f32, f32), u32)) -> (f32, f32) {
+    let y = *x;
+    let z = y.0;
+    (z.0, z.1)
+}
+
 fn main() {
     assert_eq!(test1(1, (2, 3), &[4, 5, 6]), (1, (2, 3), &[4, 5, 6][..]));
     assert_eq!(test2(98), 98);
@@ -196,4 +203,5 @@ fn main() {
 
     assert_eq!(test_fn_ignored_pair_0(), ());
     assert_eq!(test_fn_ignored_pair_named(), (Foo, Foo));
+    assert_eq!(test_fn_nested_pair(&((1.0, 2.0), 0)), (1.0, 2.0));
 }


### PR DESCRIPTION
Found while trying to compile the latest Servo master.

cc @shinglyu
