### PR TITLE
Remove invalid CSS rule for doc titles

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -572,14 +572,6 @@ a.test-arrow {
     right: 5px;
 }
 
-.methods .section-header {
-    /* Override parent class attributes. */
-    border-bottom: none !important;
-    font-size: 1.1em !important;
-    margin: 0 0 -5px;
-    padding: 0;
-}
-
 .section-header:hover a:after {
     content: '\2002\00a7\2002';
 }


### PR DESCRIPTION
r? @steveklabnik 

Before:

![issue](https://cloud.githubusercontent.com/assets/3050060/16625595/a2f65914-43a5-11e6-9ff2-bcdf11b68cc3.png)

After:

![fixed](https://cloud.githubusercontent.com/assets/3050060/16625602/a9b635ee-43a5-11e6-9f9d-853137eb4e6b.png)
