### PR TITLE
Remove useless doc comment for slice

### DIFF
--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -151,7 +151,6 @@ mod hack {
     }
 }
 
-/// Allocating extension methods for slices.
 #[lang = "slice"]
 #[cfg(not(test))]
 impl<T> [T] {


### PR DESCRIPTION
r? @steveklabnik 

This doc comment isn't useful so I removed it. It also "fixes" the weird rustdoc output.

Before:

![screenshot from 2016-07-08 02-04-59](https://cloud.githubusercontent.com/assets/3050060/16688164/fbb321d6-451c-11e6-8d98-53346bc6eb1e.png)

After:

![screenshot from 2016-07-08 02-05-31](https://cloud.githubusercontent.com/assets/3050060/16688166/00b174e4-451d-11e6-83dd-93ab2509f647.png)
