### PR TITLE
Mark Ipv4Addr is_unspecified as stable and provide reference.

### DIFF
--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -83,6 +83,10 @@ impl Ipv4Addr {
     }
 
     /// Returns true for the special 'unspecified' address (0.0.0.0).
+    ///
+    /// This property is defined in _UNIX Network Programming, Second Edition_,
+    /// W. Richard Stevens, p. 891; see also [ip7]
+    /// [ip7][http://man7.org/linux/man-pages/man7/ip.7.html]
     pub fn is_unspecified(&self) -> bool {
         self.inner.s_addr == 0
     }


### PR DESCRIPTION
Per [#27709 (comment)](https://github.com/rust-lang/rust/issues/27709#issuecomment-231280999), no RFC is needed here.

IPv4 "unspecified" has been defined in [Stevens], and has been part of the IPv4 stack for quite some time.  This property should become stable, since this use of 0.0.0.0 is not going anywhere.

[Stevens][_UNIX Network Programming Volume 1, Second Edition_.  Stevens, W. Richard.  Prentice-Hall, 1998.  p. 891]

Please let me know if I got the rustdoc wrong or something.  I tried to be as terse as possible while still conveying the appropriate information.

This also has a slight impact on PR #34694, but that one came first, so this shouldn't block it, IMO.
