### PR TITLE
make docs for clone_from_slice consistent with copy_from_slice

### DIFF
--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -848,7 +848,7 @@ impl<T> [T] {
 
     /// Copies the elements from `src` into `self`.
     ///
-    /// The length of this slice must be the same as the slice passed in.
+    /// The length of `src` must be the same as `self`.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
What 'this slice' refers to is not intuitive, given this method can appear in other places, e.g. in docs for Vec.
