### PR TITLE
rustdoc: Fix methods in seach results

### DIFF
--- a/src/test/rustdoc/auxiliary/extern-links.rs
+++ b/src/test/rustdoc/auxiliary/extern-links.rs
@@ -1,0 +1,11 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub struct Foo;

--- a/src/test/rustdoc/extern-links.rs
+++ b/src/test/rustdoc/extern-links.rs
@@ -1,0 +1,31 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:extern-links.rs
+// ignore-cross-compile
+
+#![crate_name = "foo"]
+
+extern crate extern_links;
+
+// @!has foo/index.html '//a' 'extern_links'
+#[doc(no_inline)]
+pub use extern_links as extern_links2;
+
+// @!has foo/index.html '//a' 'Foo'
+#[doc(no_inline)]
+pub use extern_links::Foo;
+
+#[doc(hidden)]
+pub mod hidden {
+    // @!has foo/hidden/extern_links/index.html
+    // @!has foo/hidden/extern_links/struct.Foo.html
+    pub use extern_links;
+}


### PR DESCRIPTION
Currently methods from extern crates are sometimes added to the search
index when they shouldn't be or added with the original path rather than
the reexported path. This fixes that by making sure `cache().paths` only
contains local paths like the description for it states. It also fixes a
few minor issues with link rendering and redirect generation which would
point to local crate docs even if the docs for that crate hadn't been
generated.

Also a bug with methods implemented on traits which caused wrong paths and
so dead links in the search results has been fixed.

For example:
[before](https://doc.rust-lang.org/nightly/std/?search=is_disjoint) [after](https://ollie27.github.io/rust_doc_test/std/?search=is_disjoint)
[before](https://doc.rust-lang.org/nightly/std/?search=map_or) [after](https://ollie27.github.io/rust_doc_test/std/?search=map_or)
[before](https://doc.rust-lang.org/nightly/std/?search=unsafecell%3A%3Anew) [after](https://ollie27.github.io/rust_doc_test/std/?search=unsafecell%3A%3Anew)
[before](https://doc.rust-lang.org/nightly/std/?search=rng%3A%3Agen_) [after](https://ollie27.github.io/rust_doc_test/std/?search=rng%3A%3Agen_)
[before](https://doc.rust-lang.org/nightly/std/?search=downcast_ref) [after](https://ollie27.github.io/rust_doc_test/std/?search=downcast_ref)

Fixes #20246
