### PR TITLE
Demangle curly braces

### DIFF
--- a/src/libstd/sys/common/backtrace.rs
+++ b/src/libstd/sys/common/backtrace.rs
@@ -170,7 +170,9 @@ pub fn demangle(writer: &mut Write, s: &str) -> io::Result<()> {
                         "$u20$", => b" ",
                         "$u27$", => b"'",
                         "$u5b$", => b"[",
-                        "$u5d$", => b"]"
+                        "$u5d$", => b"]",
+                        "$u7b$", => b"{",
+                        "$u7d$", => b"}"
                     )
                 } else {
                     let idx = match rest.find('$') {


### PR DESCRIPTION
They show up in things like
fn(&std..panic..PanicInfo<'_>) $u7b$hook$u7d$::fn_pointer_shim.8352::h01f889b2277c719d

r? @alexcrichton 
