### PR TITLE
Mutex and RwLock need RefUnwindSafe too

### DIFF
--- a/src/libstd/panic.rs
+++ b/src/libstd/panic.rs
@@ -227,10 +227,9 @@ impl<T: ?Sized> !RefUnwindSafe for UnsafeCell<T> {}
 #[stable(feature = "catch_unwind", since = "1.9.0")]
 impl<T> RefUnwindSafe for AssertUnwindSafe<T> {}
 
-// XXX: Obviously wrong, but what should it be?
-#[stable(feature = "catch_unwind", since = "1.9.0")]
+#[stable(feature = "unwind_safe_lock_refs", since = "1.12.0")]
 impl<T: ?Sized> RefUnwindSafe for Mutex<T> {}
-#[stable(feature = "catch_unwind", since = "1.9.0")]
+#[stable(feature = "unwind_safe_lock_refs", since = "1.12.0")]
 impl<T: ?Sized> RefUnwindSafe for RwLock<T> {}
 
 #[stable(feature = "catch_unwind", since = "1.9.0")]

--- a/src/libstd/panic.rs
+++ b/src/libstd/panic.rs
@@ -227,6 +227,12 @@ impl<T: ?Sized> !RefUnwindSafe for UnsafeCell<T> {}
 #[stable(feature = "catch_unwind", since = "1.9.0")]
 impl<T> RefUnwindSafe for AssertUnwindSafe<T> {}
 
+// XXX: Obviously wrong, but what should it be?
+#[stable(feature = "catch_unwind", since = "1.9.0")]
+impl<T: ?Sized> RefUnwindSafe for Mutex<T> {}
+#[stable(feature = "catch_unwind", since = "1.9.0")]
+impl<T: ?Sized> RefUnwindSafe for RwLock<T> {}
+
 #[stable(feature = "catch_unwind", since = "1.9.0")]
 impl<T> Deref for AssertUnwindSafe<T> {
     type Target = T;

--- a/src/test/run-pass/panic-safe.rs
+++ b/src/test/run-pass/panic-safe.rs
@@ -36,6 +36,8 @@ fn main() {
     assert::<Box<i32>>();
     assert::<Mutex<i32>>();
     assert::<RwLock<i32>>();
+    assert::<&Mutex<i32>>();
+    assert::<&RwLock<i32>>();
     assert::<Rc<i32>>();
     assert::<Arc<i32>>();
 


### PR DESCRIPTION
Incomplete, because I don't know what the appropriate stability annotation is here, but this is an attempt to bring the documentation for `std::panic` in line with reality. Right now, it says:

> Types like `&Mutex<T>`, however, are unwind safe because they implement poisoning by default.

But only `Mutex<T>`, not `&Mutex<T>`, is unwind-safe.
