### PR TITLE
doc: Mention that writeln! and println! always use LF

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -238,6 +238,8 @@ macro_rules! write {
 }
 
 /// Use the `format!` syntax to write data into a buffer, appending a newline.
+/// On all platforms, the newline is the LINE FEED character (`\n`/`U+000A`)
+/// alone (no additional CARRIAGE RETURN (`\r`/`U+000D`).
 ///
 /// This macro is typically used with a buffer of `&mut `[`Write`][write].
 ///

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -98,7 +98,9 @@ macro_rules! print {
     ($($arg:tt)*) => ($crate::io::_print(format_args!($($arg)*)));
 }
 
-/// Macro for printing to the standard output, with a newline.
+/// Macro for printing to the standard output, with a newline. On all
+/// platforms, the newline is the LINE FEED character (`\n`/`U+000A`) alone
+/// (no additional CARRIAGE RETURN (`\r`/`U+000D`).
 ///
 /// Use the `format!` syntax to write data to the standard output.
 /// See `std::fmt` for more information.


### PR DESCRIPTION
Fixes #34697 

I'm not really satisfied with the wording, but I didn't have a better idea. Suggestions welcome.
