### PR TITLE
Mention the crate type cdylib in rustc's usage

### DIFF
--- a/man/rustc.1
+++ b/man/rustc.1
@@ -44,7 +44,7 @@ The optional \fIKIND\fR can be one of \fIstatic\fR, \fIdylib\fR, or
 \fIframework\fR.
 If omitted, \fIdylib\fR is assumed.
 .TP
-\fB\-\-crate\-type\fR [bin|lib|rlib|dylib|staticlib]
+\fB\-\-crate\-type\fR [bin|lib|rlib|dylib|cdylib|staticlib]
 Comma separated list of types of crates for the compiler to emit.
 .TP
 \fB\-\-crate\-name\fR \fINAME\fR

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -981,7 +981,7 @@ pub fn rustc_short_optgroups() -> Vec<RustcOptGroup> {
                              assumed.", "[KIND=]NAME"),
         opt::multi_s("", "crate-type", "Comma separated list of types of crates
                                     for the compiler to emit",
-                   "[bin|lib|rlib|dylib|staticlib]"),
+                   "[bin|lib|rlib|dylib|cdylib|staticlib]"),
         opt::opt_s("", "crate-name", "Specify the name of the crate being built",
                "NAME"),
         opt::multi_s("", "emit", "Comma separated list of types of output for \


### PR DESCRIPTION
Hello,

I just tried to build a `cdylib` with the latest stable release, I've been passively waiting for this for quite some time now. Tested successfully on my machine, although it doesn't appear in `rustc`'s usage it seems to work like a charm so far. :grinning:

Thanks!
