### PR TITLE
[RFC accepted] add wrapper for discriminant_value intrinsic

### DIFF
--- a/src/test/run-pass/discriminant_value-wrapper.rs
+++ b/src/test/run-pass/discriminant_value-wrapper.rs
@@ -1,0 +1,28 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(discriminant_value)]
+
+use std::mem;
+
+enum ADT {
+    First(u32, u32),
+    Second(u64)
+}
+
+pub fn main() {
+    assert!(mem::discriminant(&ADT::First(0,0)) == mem::discriminant(&ADT::First(1,1)));
+    assert!(mem::discriminant(&ADT::Second(5))  == mem::discriminant(&ADT::Second(6)));
+    assert!(mem::discriminant(&ADT::First(2,2)) != mem::discriminant(&ADT::Second(2)));
+
+    let _ = mem::discriminant(&10);
+    let _ = mem::discriminant(&"test");
+}
+


### PR DESCRIPTION
add wrapper for discriminant_value intrinsic

Wraps the `discriminant_value` intrinsic under the name `std::mem::discriminant`. In order to avoid prematurely leaking information about the implementation of enums, the return value is an opaque type, generic over the enum type, which implements `Copy`, `Clone`, `PartialEq`, `Eq`, `Hash`, and `Debug` (notably not `PartialOrd`). There is currently no way to get the value out excepting printing the debug representation.

The wrapper is safe and can be stabilized soon as per discussion in #24263.

r? @brson
