### PR TITLE
Fixed issue where importing a trait method directly and then calling the method causes a compiler panic

### DIFF
--- a/src/test/compile-fail/import-trait-method.rs
+++ b/src/test/compile-fail/import-trait-method.rs
@@ -1,0 +1,17 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Foo {
+    fn foo();
+}
+
+use Foo::foo; //~ ERROR not directly importable
+
+fn main() { foo(); }


### PR DESCRIPTION
The code below triggers the panic, and is included in a new regression test.

``` rust
trait Foo {
    fn foo();
}

use Foo::foo;

fn main() {
    foo();
}
```

The bug is caused by `librustc_resolve` allowing the illegal binding to be imported even after displaying the error message above.

The fix amounts to importing a dummy binding (`rustc::hir::def::Def::Err`) instead of the actual trait method.
