### PR TITLE
rustbuild: doc fixes

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -181,7 +181,7 @@ pub fn rustc(build: &Build, stage: u32, target: &str, out: &Path) {
     let out_dir = build.stage_out(&compiler, Mode::Librustc)
                        .join(target).join("doc");
     let rustdoc = build.rustdoc(&compiler);
-    if !up_to_date(&rustdoc, &out_dir.join("rustc/index.html")) {
+    if !up_to_date(&rustdoc, &out_dir.join("rustc/index.html")) && out_dir.exists() {
         t!(fs::remove_dir_all(&out_dir));
     }
     let mut cargo = build.cargo(&compiler, Mode::Librustc, target, "doc");

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -155,6 +155,7 @@ pub fn std(build: &Build, stage: u32, target: &str, out: &Path) {
 /// is largely just a wrapper around `cargo doc`.
 pub fn test(build: &Build, stage: u32, target: &str, out: &Path) {
     println!("Documenting stage{} test ({})", stage, target);
+    t!(fs::create_dir_all(out));
     let compiler = Compiler::new(stage, &build.config.build);
     let out_dir = build.stage_out(&compiler, Mode::Libtest)
                        .join(target).join("doc");
@@ -175,6 +176,7 @@ pub fn test(build: &Build, stage: u32, target: &str, out: &Path) {
 /// dependencies. This is largely just a wrapper around `cargo doc`.
 pub fn rustc(build: &Build, stage: u32, target: &str, out: &Path) {
     println!("Documenting stage{} compiler ({})", stage, target);
+    t!(fs::create_dir_all(out));
     let compiler = Compiler::new(stage, &build.config.build);
     let out_dir = build.stage_out(&compiler, Mode::Librustc)
                        .join(target).join("doc");

--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -380,10 +380,18 @@ impl<'a> Step<'a> {
                 vec![self.doc_test(stage)]
             }
             Source::Doc { stage } => {
-                vec![self.doc_book(stage), self.doc_nomicon(stage),
-                     self.doc_style(stage), self.doc_standalone(stage),
-                     self.doc_std(stage),
-                     self.doc_error_index(stage)]
+                let mut deps = vec![
+                    self.doc_book(stage), self.doc_nomicon(stage),
+                    self.doc_style(stage), self.doc_standalone(stage),
+                    self.doc_std(stage),
+                    self.doc_error_index(stage),
+                ];
+
+                if build.config.compiler_docs {
+                    deps.push(self.doc_rustc(stage));
+                }
+
+                deps
             }
             Source::Check { stage, compiler } => {
                 // Check is just a pseudo step which means check all targets,


### PR DESCRIPTION
This fixes two issues rustbuild currently has when building documentation:
1. It fixes standalone builds of `doc-test` and `doc-rustc`.
2. It actually builds the compiler docs if requested in the config.

Closes #34275.
