### PR TITLE
Methods `Fn(Mut,Once)::call(mut,once)` are gated with two feature gates, remove one of them

### DIFF
--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -49,7 +49,6 @@
 #![feature(specialization)]
 #![feature(staged_api)]
 #![feature(step_by)]
-#![feature(unboxed_closures)]
 #![feature(unicode)]
 #![feature(unique)]
 #![feature(unsafe_no_drop_flag)]

--- a/src/libcoretest/lib.rs
+++ b/src/libcoretest/lib.rs
@@ -31,7 +31,6 @@
 #![feature(step_by)]
 #![feature(test)]
 #![feature(try_from)]
-#![feature(unboxed_closures)]
 #![feature(unicode)]
 #![feature(unique)]
 

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -31,7 +31,6 @@
 #![feature(set_stdio)]
 #![feature(staged_api)]
 #![feature(question_mark)]
-#![feature(unboxed_closures)]
 
 extern crate arena;
 extern crate flate;

--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -27,33 +27,8 @@ use rustc::hir;
 /// to `trait_id` (this only cares about the trait, not the specific
 /// method that is called)
 pub fn check_legal_trait_for_method_call(ccx: &CrateCtxt, span: Span, trait_id: DefId) {
-    let tcx = ccx.tcx;
-    let did = Some(trait_id);
-    let li = &tcx.lang_items;
-
-    if did == li.drop_trait() {
-        span_err!(tcx.sess, span, E0040, "explicit use of destructor method");
-    } else if !tcx.sess.features.borrow().unboxed_closures {
-        // the #[feature(unboxed_closures)] feature isn't
-        // activated so we need to enforce the closure
-        // restrictions.
-
-        let method = if did == li.fn_trait() {
-            "call"
-        } else if did == li.fn_mut_trait() {
-            "call_mut"
-        } else if did == li.fn_once_trait() {
-            "call_once"
-        } else {
-            return // not a closure method, everything is OK.
-        };
-
-        struct_span_err!(tcx.sess, span, E0174,
-                         "explicit use of unboxed closure method `{}` is experimental",
-                         method)
-            .help("add `#![feature(unboxed_closures)]` to the crate \
-                  attributes to enable")
-            .emit();
+    if ccx.tcx.lang_items.drop_trait() == Some(trait_id) {
+        span_err!(ccx.tcx.sess, span, E0040, "explicit use of destructor method");
     }
 }
 

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -1944,89 +1944,6 @@ To learn more about traits, take a look at the Book:
 https://doc.rust-lang.org/book/traits.html
 "##,
 
-E0174: r##"
-This error occurs because of the explicit use of unboxed closure methods
-that are an experimental feature in current Rust version.
-
-Example of erroneous code:
-
-```compile_fail
-fn foo<F: Fn(&str)>(mut f: F) {
-    f.call(("call",));
-    // error: explicit use of unboxed closure method `call`
-    f.call_mut(("call_mut",));
-    // error: explicit use of unboxed closure method `call_mut`
-    f.call_once(("call_once",));
-    // error: explicit use of unboxed closure method `call_once`
-}
-
-fn bar(text: &str) {
-    println!("Calling {} it works!", text);
-}
-
-fn main() {
-    foo(bar);
-}
-```
-
-Rust's implementation of closures is a bit different than other languages.
-They are effectively syntax sugar for traits `Fn`, `FnMut` and `FnOnce`.
-To understand better how the closures are implemented see here:
-https://doc.rust-lang.org/book/closures.html#closure-implementation
-
-To fix this you can call them using parenthesis, like this: `foo()`.
-When you execute the closure with parenthesis, under the hood you are executing
-the method `call`, `call_mut` or `call_once`. However, using them explicitly is
-currently an experimental feature.
-
-Example of an implicit call:
-
-```
-fn foo<F: Fn(&str)>(f: F) {
-    f("using ()"); // Calling using () it works!
-}
-
-fn bar(text: &str) {
-    println!("Calling {} it works!", text);
-}
-
-fn main() {
-    foo(bar);
-}
-```
-
-To enable the explicit calls you need to add `#![feature(unboxed_closures)]`.
-
-This feature is still unstable so you will also need to add
-`#![feature(fn_traits)]`.
-More details about this issue here:
-https://github.com/rust-lang/rust/issues/29625
-
-Example of use:
-
-```
-#![feature(fn_traits)]
-#![feature(unboxed_closures)]
-
-fn foo<F: Fn(&str)>(mut f: F) {
-    f.call(("call",)); // Calling 'call' it works!
-    f.call_mut(("call_mut",)); // Calling 'call_mut' it works!
-    f.call_once(("call_once",)); // Calling 'call_once' it works!
-}
-
-fn bar(text: &str) {
-    println!("Calling '{}' it works!", text);
-}
-
-fn main() {
-    foo(bar);
-}
-```
-
-To see more about closures take a look here:
-https://doc.rust-lang.org/book/closures.html`
-"##,
-
 E0178: r##"
 In types, the `+` type operator has low precedence, so it is often necessary
 to use parentheses.
@@ -4049,6 +3966,7 @@ register_diagnostics! {
     E0167,
 //  E0168,
 //  E0173, // manual implementations of unboxed closure traits are experimental
+//  E0174,
     E0182,
     E0183,
 //  E0187, // can't infer the kind of the closure

--- a/src/test/compile-fail/associated-types/bound-lifetime-constrained.rs
+++ b/src/test/compile-fail/associated-types/bound-lifetime-constrained.rs
@@ -12,7 +12,6 @@
 
 #![allow(dead_code)]
 #![feature(rustc_attrs)]
-#![feature(unboxed_closures)]
 #![deny(hr_lifetime_in_assoc_type)]
 
 trait Foo<'a> {

--- a/src/test/compile-fail/associated-types/cache/wasm-issue-32330.rs
+++ b/src/test/compile-fail/associated-types/cache/wasm-issue-32330.rs
@@ -13,7 +13,6 @@
 
 #![allow(dead_code, unused_variables)]
 #![deny(hr_lifetime_in_assoc_type)]
-#![feature(unboxed_closures)]
 
 use std::str::Chars;
 

--- a/src/test/compile-fail/borrowck/borrowck-call-is-borrow-issue-12224.rs
+++ b/src/test/compile-fail/borrowck/borrowck-call-is-borrow-issue-12224.rs
@@ -10,8 +10,6 @@
 
 // Ensure that invoking a closure counts as a unique immutable borrow
 
-#![feature(unboxed_closures)]
-
 type Fn<'a> = Box<FnMut() + 'a>;
 
 struct Test<'a> {

--- a/src/test/compile-fail/borrowck/borrowck-unboxed-closures.rs
+++ b/src/test/compile-fail/borrowck/borrowck-unboxed-closures.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(overloaded_calls, unboxed_closures)]
-
 fn a<F:Fn(isize, isize) -> isize>(mut f: F) {
     let g = &mut f;
     f(1, 2);    //~ ERROR cannot borrow `f` as immutable

--- a/src/test/compile-fail/feature-gate-unboxed-closures-method-calls.rs
+++ b/src/test/compile-fail/feature-gate-unboxed-closures-method-calls.rs
@@ -11,9 +11,9 @@
 #![allow(dead_code)]
 
 fn foo<F: Fn()>(mut f: F) {
-    f.call(()); //~ ERROR explicit use of unboxed closure method `call`
-    f.call_mut(()); //~ ERROR explicit use of unboxed closure method `call_mut`
-    f.call_once(()); //~ ERROR explicit use of unboxed closure method `call_once`
+    f.call(()); //~ ERROR use of unstable library feature 'fn_traits'
+    f.call_mut(()); //~ ERROR use of unstable library feature 'fn_traits'
+    f.call_once(()); //~ ERROR use of unstable library feature 'fn_traits'
 }
 
 fn main() {}

--- a/src/test/compile-fail/feature-gate-unboxed-closures-ufcs-calls.rs
+++ b/src/test/compile-fail/feature-gate-unboxed-closures-ufcs-calls.rs
@@ -10,10 +10,10 @@
 
 #![allow(dead_code)]
 
-fn foo<F: Fn()>(mut f: F, mut g: F) {
-    Fn::call(&g, ()); //~ ERROR explicit use of unboxed closure method `call`
-    FnMut::call_mut(&mut g, ()); //~ ERROR explicit use of unboxed closure method `call_mut`
-    FnOnce::call_once(g, ()); //~ ERROR explicit use of unboxed closure method `call_once`
+fn foo<F: Fn()>(mut f: F) {
+    Fn::call(&f, ()); //~ ERROR use of unstable library feature 'fn_traits'
+    FnMut::call_mut(&mut f, ()); //~ ERROR use of unstable library feature 'fn_traits'
+    FnOnce::call_once(f, ()); //~ ERROR use of unstable library feature 'fn_traits'
 }
 
 fn main() {}

--- a/src/test/compile-fail/fn-trait-formatting.rs
+++ b/src/test/compile-fail/fn-trait-formatting.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(unboxed_closures)]
 #![feature(box_syntax)]
 
 fn needs_fn<F>(x: F) where F: Fn(isize) -> isize {}

--- a/src/test/compile-fail/issue-16939.rs
+++ b/src/test/compile-fail/issue-16939.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(overloaded_calls, unboxed_closures)]
-
 // Make sure we don't ICE when making an overloaded call with the
 // wrong arity.
 

--- a/src/test/compile-fail/issue-17033.rs
+++ b/src/test/compile-fail/issue-17033.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(overloaded_calls)]
-
 fn f<'r>(p: &'r mut fn(p: &mut ())) {
     (*p)(()) //~  ERROR mismatched types
              //~| expected type `&mut ()`

--- a/src/test/compile-fail/issue-17545.rs
+++ b/src/test/compile-fail/issue-17545.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(unboxed_closures)]
-
 pub fn foo<'a, F: Fn(&'a ())>(bar: F) {
     bar.call((
         &(), //~ ERROR borrowed value does not live long enough

--- a/src/test/compile-fail/issue-17551.rs
+++ b/src/test/compile-fail/issue-17551.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(unboxed_closures)]
-
 use std::marker;
 
 struct B<T>(marker::PhantomData<T>);

--- a/src/test/compile-fail/issue-18532.rs
+++ b/src/test/compile-fail/issue-18532.rs
@@ -12,8 +12,6 @@
 // when a type error or unconstrained type variable propagates
 // into it.
 
-#![feature(unboxed_closures)]
-
 fn main() {
     (return)((),());
     //~^ ERROR the type of this value must be known

--- a/src/test/compile-fail/issue-19521.rs
+++ b/src/test/compile-fail/issue-19521.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(unboxed_closures)]
-
 fn main() {
     "".homura()(); //~ ERROR no method named `homura` found
 }

--- a/src/test/compile-fail/issue-19707.rs
+++ b/src/test/compile-fail/issue-19707.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(unboxed_closures)]
 #![allow(dead_code)]
 
 type foo = fn(&u8, &u8) -> &u8; //~ ERROR missing lifetime specifier

--- a/src/test/compile-fail/issue-4335.rs
+++ b/src/test/compile-fail/issue-4335.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(unboxed_closures)]
-
 fn id<T>(t: T) -> T { t }
 
 fn f<'r, T>(v: &'r T) -> Box<FnMut() -> T + 'r> {

--- a/src/test/compile-fail/moves-based-on-type-no-recursive-stack-closure.rs
+++ b/src/test/compile-fail/moves-based-on-type-no-recursive-stack-closure.rs
@@ -12,8 +12,6 @@
 // bound must be noncopyable. For details see
 // http://smallcultfollowing.com/babysteps/blog/2013/04/30/the-case-of-the-recurring-closure/
 
-#![feature(unboxed_closures)]
-
 struct R<'a> {
     // This struct is needed to create the
     // otherwise infinite type of a fn that

--- a/src/test/compile-fail/regionck-unboxed-closure-lifetimes.rs
+++ b/src/test/compile-fail/regionck-unboxed-closure-lifetimes.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(unboxed_closures, overloaded_calls)]
-
 use std::ops::FnMut;
 
 fn main() {

--- a/src/test/compile-fail/regions-escape-unboxed-closure.rs
+++ b/src/test/compile-fail/regions-escape-unboxed-closure.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(unboxed_closures)]
-
 fn with_int(f: &mut FnMut(&isize)) {
 }
 

--- a/src/test/compile-fail/regions-return-ref-to-upvar-issue-17403.rs
+++ b/src/test/compile-fail/regions-return-ref-to-upvar-issue-17403.rs
@@ -10,8 +10,6 @@
 
 // Test that closures cannot subvert aliasing restrictions
 
-#![feature(overloaded_calls, unboxed_closures)]
-
 fn main() {
     // Unboxed closure case
     {

--- a/src/test/compile-fail/regions-steal-closure.rs
+++ b/src/test/compile-fail/regions-steal-closure.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(unboxed_closures)]
-
 struct closure_box<'a> {
     cl: Box<FnMut() + 'a>,
 }

--- a/src/test/compile-fail/unboxed-closure-immutable-capture.rs
+++ b/src/test/compile-fail/unboxed-closure-immutable-capture.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(unboxed_closures)]
-
 // Test that even unboxed closures that are capable of mutating their
 // environment cannot mutate captured variables that have not been
 // declared mutable (#18335)

--- a/src/test/compile-fail/unboxed-closure-region.rs
+++ b/src/test/compile-fail/unboxed-closure-region.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(unboxed_closures)]
-
 // Test that an unboxed closure that captures a free variable by
 // reference cannot escape the region of that variable.
 fn main() {

--- a/src/test/compile-fail/unboxed-closure-sugar-nonexistent-trait.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-nonexistent-trait.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(unboxed_closures)]
-
 fn f<F:Nonexist(isize) -> isize>(x: F) {} //~ ERROR trait `Nonexist` is not in scope
 
 type Typedef = isize;

--- a/src/test/compile-fail/unboxed-closures-borrow-conflict.rs
+++ b/src/test/compile-fail/unboxed-closures-borrow-conflict.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(unboxed_closures)]
-
 // Test that an unboxed closure that mutates a free variable will
 // cause borrow conflicts.
 

--- a/src/test/compile-fail/unboxed-closures-infer-argument-types-two-region-pointers.rs
+++ b/src/test/compile-fail/unboxed-closures-infer-argument-types-two-region-pointers.rs
@@ -11,8 +11,6 @@
 // That a closure whose expected argument types include two distinct
 // bound regions.
 
-#![feature(unboxed_closures)]
-
 use std::cell::Cell;
 
 fn doit<T,F>(val: T, f: &F)

--- a/src/test/compile-fail/unboxed-closures-infer-explicit-call-too-early.rs
+++ b/src/test/compile-fail/unboxed-closures-infer-explicit-call-too-early.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(unboxed_closures)]
-
 fn main() {
     let mut zero = || {};
     let () = zero.call_mut(());

--- a/src/test/compile-fail/unboxed-closures-type-mismatch.rs
+++ b/src/test/compile-fail/unboxed-closures-type-mismatch.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(unboxed_closures)]
-
 use std::ops::FnMut;
 
 pub fn main() {

--- a/src/test/compile-fail/unboxed-closures-unsafe-extern-fn.rs
+++ b/src/test/compile-fail/unboxed-closures-unsafe-extern-fn.rs
@@ -10,8 +10,6 @@
 
 // Tests that unsafe extern fn pointers do not implement any Fn traits.
 
-#![feature(unboxed_closures)]
-
 use std::ops::{Fn,FnMut,FnOnce};
 
 unsafe fn square(x: &isize) -> isize { (*x) * (*x) }

--- a/src/test/compile-fail/unboxed-closures-wrong-abi.rs
+++ b/src/test/compile-fail/unboxed-closures-wrong-abi.rs
@@ -10,8 +10,6 @@
 
 // Tests that unsafe extern fn pointers do not implement any Fn traits.
 
-#![feature(unboxed_closures)]
-
 use std::ops::{Fn,FnMut,FnOnce};
 
 extern "C" fn square(x: &isize) -> isize { (*x) * (*x) }

--- a/src/test/compile-fail/unboxed-closures-wrong-arg-type-extern-fn.rs
+++ b/src/test/compile-fail/unboxed-closures-wrong-arg-type-extern-fn.rs
@@ -10,8 +10,6 @@
 
 // Tests that unsafe extern fn pointers do not implement any Fn traits.
 
-#![feature(unboxed_closures)]
-
 use std::ops::{Fn,FnMut,FnOnce};
 
 unsafe fn square(x: isize) -> isize { x * x }

--- a/src/test/debuginfo/var-captured-in-sendable-closure.rs
+++ b/src/test/debuginfo/var-captured-in-sendable-closure.rs
@@ -40,7 +40,7 @@
 // lldb-check:[...]$2 = 5
 
 #![allow(unused_variables)]
-#![feature(unboxed_closures, box_syntax)]
+#![feature(box_syntax)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 

--- a/src/test/debuginfo/var-captured-in-stack-closure.rs
+++ b/src/test/debuginfo/var-captured-in-stack-closure.rs
@@ -69,7 +69,7 @@
 // lldb-command:print *owned
 // lldb-check:[...]$9 = 6
 
-#![feature(unboxed_closures, box_syntax)]
+#![feature(box_syntax)]
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]

--- a/src/test/run-pass/assignability-trait.rs
+++ b/src/test/run-pass/assignability-trait.rs
@@ -12,9 +12,6 @@
 // making method calls, but only if there aren't any matches without
 // it.
 
-
-#![feature(unboxed_closures)]
-
 trait iterable<A> {
     fn iterate<F>(&self, blk: F) -> bool where F: FnMut(&A) -> bool;
 }

--- a/src/test/run-pass/associated-types-impl-redirect.rs
+++ b/src/test/run-pass/associated-types-impl-redirect.rs
@@ -14,7 +14,7 @@
 // for `ByRef`. The right answer was to consider the result ambiguous
 // until more type information was available.
 
-#![feature(lang_items, unboxed_closures)]
+#![feature(lang_items)]
 #![no_implicit_prelude]
 
 use std::marker::Sized;

--- a/src/test/run-pass/associated-types-where-clause-impl-ambiguity.rs
+++ b/src/test/run-pass/associated-types-where-clause-impl-ambiguity.rs
@@ -14,7 +14,7 @@
 // for `ByRef`. The right answer was to consider the result ambiguous
 // until more type information was available.
 
-#![feature(lang_items, unboxed_closures)]
+#![feature(lang_items)]
 #![no_implicit_prelude]
 
 use std::marker::Sized;

--- a/src/test/run-pass/auxiliary/issue-18711.rs
+++ b/src/test/run-pass/auxiliary/issue-18711.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(unboxed_closures)]
 #![crate_type = "rlib"]
 
 pub fn inner<F>(f: F) -> F {

--- a/src/test/run-pass/auxiliary/unboxed-closures-cross-crate.rs
+++ b/src/test/run-pass/auxiliary/unboxed-closures-cross-crate.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(unboxed_closures)]
-
 use std::ops::Add;
 
 #[inline]

--- a/src/test/run-pass/bare-fn-implements-fn-mut.rs
+++ b/src/test/run-pass/bare-fn-implements-fn-mut.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(unboxed_closures)]
-
 use std::ops::FnMut;
 
 fn call_f<F:FnMut()>(mut f: F) {

--- a/src/test/run-pass/borrowck/borrowck-move-by-capture-ok.rs
+++ b/src/test/run-pass/borrowck/borrowck-move-by-capture-ok.rs
@@ -11,7 +11,6 @@
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]
-#![feature(unboxed_closures)]
 
 pub fn main() {
     let bar: Box<_> = box 3;

--- a/src/test/run-pass/capture-clauses-unboxed-closures.rs
+++ b/src/test/run-pass/capture-clauses-unboxed-closures.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
-#![feature(unboxed_closures)]
-
 fn each<'a,T,F:FnMut(&'a T)>(x: &'a [T], mut f: F) {
     for val in x {
         f(val)

--- a/src/test/run-pass/closure-bounds-can-capture-chan.rs
+++ b/src/test/run-pass/closure-bounds-can-capture-chan.rs
@@ -10,8 +10,6 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(unboxed_closures)]
-
 use std::sync::mpsc::channel;
 
 fn foo<F:FnOnce()+Send>(blk: F) {

--- a/src/test/run-pass/closure-reform.rs
+++ b/src/test/run-pass/closure-reform.rs
@@ -11,8 +11,6 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
-#![feature(unboxed_closures)]
-
 fn call_it<F>(f: F)
     where F : FnOnce(String) -> String
 {

--- a/src/test/run-pass/hashmap-memory.rs
+++ b/src/test/run-pass/hashmap-memory.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #![allow(unknown_features)]
-#![feature(unboxed_closures, std_misc)]
+#![feature(std_misc)]
 
 /**
    A somewhat reduced test case to expose some Valgrind issues.

--- a/src/test/run-pass/hrtb-parse.rs
+++ b/src/test/run-pass/hrtb-parse.rs
@@ -13,7 +13,6 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(unboxed_closures)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
 

--- a/src/test/run-pass/hrtb-precedence-of-plus-where-clause.rs
+++ b/src/test/run-pass/hrtb-precedence-of-plus-where-clause.rs
@@ -10,8 +10,6 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(unboxed_closures)]
-
 // Test that `F : Fn(isize) -> isize + Send` is interpreted as two
 // distinct bounds on `F`.
 

--- a/src/test/run-pass/hrtb-precedence-of-plus.rs
+++ b/src/test/run-pass/hrtb-precedence-of-plus.rs
@@ -11,7 +11,6 @@
 // pretty-expanded FIXME #23616
 
 #![allow(unknown_features)]
-#![feature(unboxed_closures)]
 
 // Test that `Fn(isize) -> isize + 'static` parses as `(Fn(isize) -> isize) +
 // 'static` and not `Fn(isize) -> (isize + 'static)`. The latter would

--- a/src/test/run-pass/hrtb-trait-object-paren-notation.rs
+++ b/src/test/run-pass/hrtb-trait-object-paren-notation.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
-#![feature(unboxed_closures)]
-
 // A basic test of using a higher-ranked trait bound.
 
 trait FnLike<A,R> {

--- a/src/test/run-pass/hrtb-unboxed-closure-trait.rs
+++ b/src/test/run-pass/hrtb-unboxed-closure-trait.rs
@@ -10,8 +10,6 @@
 
 // Test HRTB used with the `Fn` trait.
 
-#![feature(unboxed_closures)]
-
 fn foo<F:Fn(&isize)>(f: F) {
     let x = 22;
     f(&x);

--- a/src/test/run-pass/issue-10718.rs
+++ b/src/test/run-pass/issue-10718.rs
@@ -10,8 +10,6 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(unboxed_closures)]
-
 fn f<F:FnOnce()>(p: F) {
     p();
 }

--- a/src/test/run-pass/issue-16560.rs
+++ b/src/test/run-pass/issue-16560.rs
@@ -10,8 +10,6 @@
 
 // ignore-emscripten no threads support
 
-#![feature(unboxed_closures)]
-
 use std::thread;
 use std::mem;
 

--- a/src/test/run-pass/issue-16668.rs
+++ b/src/test/run-pass/issue-16668.rs
@@ -11,7 +11,6 @@
 // ignore-pretty
 
 #![allow(unknown_features)]
-#![feature(unboxed_closures)]
 
 struct Parser<'a, I, O> {
     parse: Box<FnMut(I) -> Result<O, String> + 'a>

--- a/src/test/run-pass/issue-16774.rs
+++ b/src/test/run-pass/issue-16774.rs
@@ -12,7 +12,6 @@
 #![allow(unknown_features)]
 #![feature(box_syntax)]
 #![feature(box_patterns)]
-#![feature(unboxed_closures)]
 
 use std::ops::{Deref, DerefMut};
 

--- a/src/test/run-pass/issue-17816.rs
+++ b/src/test/run-pass/issue-17816.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(unboxed_closures)]
-
 use std::marker::PhantomData;
 
 fn main() {

--- a/src/test/run-pass/issue-18652.rs
+++ b/src/test/run-pass/issue-18652.rs
@@ -12,9 +12,6 @@
 // once closure as an optimization by trans.  This used to hit an
 // incorrect assert.
 
-
-#![feature(unboxed_closures)]
-
 fn main() {
     let x = 2u8;
     let y = 3u8;

--- a/src/test/run-pass/issue-18685.rs
+++ b/src/test/run-pass/issue-18685.rs
@@ -13,8 +13,6 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(unboxed_closures)]
-
 trait Tr {
     fn foo(&self);
 

--- a/src/test/run-pass/issue-18711.rs
+++ b/src/test/run-pass/issue-18711.rs
@@ -13,8 +13,6 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(unboxed_closures)]
-
 // aux-build:issue-18711.rs
 extern crate issue_18711 as issue;
 

--- a/src/test/run-pass/issue-19127.rs
+++ b/src/test/run-pass/issue-19127.rs
@@ -10,8 +10,6 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(unboxed_closures)]
-
 fn foo<T, F: FnOnce(T) -> T>(f: F) {}
 fn id<'a>(input: &'a u8) -> &'a u8 { input }
 

--- a/src/test/run-pass/issue-19135.rs
+++ b/src/test/run-pass/issue-19135.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(unboxed_closures)]
-
 use std::marker::PhantomData;
 
 #[derive(Debug)]

--- a/src/test/run-pass/mir_trans_calls.rs
+++ b/src/test/run-pass/mir_trans_calls.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(rustc_attrs, unboxed_closures, fn_traits)]
+#![feature(rustc_attrs, fn_traits)]
 
 #[rustc_mir]
 fn test1(a: isize, b: (i32, i32), c: &[i32]) -> (isize, (i32, i32), &[i32]) {

--- a/src/test/run-pass/trait-bounds-in-arc.rs
+++ b/src/test/run-pass/trait-bounds-in-arc.rs
@@ -16,7 +16,6 @@
 
 #![allow(unknown_features)]
 #![feature(box_syntax, std_misc)]
-#![feature(unboxed_closures)]
 
 use std::sync::Arc;
 use std::sync::mpsc::channel;

--- a/src/test/run-pass/type-id-higher-rank.rs
+++ b/src/test/run-pass/type-id-higher-rank.rs
@@ -12,7 +12,7 @@
 // Also acts as a regression test for an ICE (issue #19791)
 
 
-#![feature(unboxed_closures, core)]
+#![feature(core)]
 
 use std::any::{Any, TypeId};
 

--- a/src/test/run-pass/unboxed-closures-all-traits.rs
+++ b/src/test/run-pass/unboxed-closures-all-traits.rs
@@ -8,8 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
-#![feature(lang_items, unboxed_closures)]
+#![feature(lang_items)]
 
 fn a<F:Fn(isize, isize) -> isize>(f: F) -> isize {
     f(1, 2)

--- a/src/test/run-pass/unboxed-closures-blanket-fn-mut.rs
+++ b/src/test/run-pass/unboxed-closures-blanket-fn-mut.rs
@@ -10,8 +10,7 @@
 
 // Test that you can supply `&F` where `F: FnMut()`.
 
-
-#![feature(lang_items, unboxed_closures)]
+#![feature(lang_items)]
 
 fn a<F:FnMut() -> i32>(mut f: F) -> i32 {
     f()

--- a/src/test/run-pass/unboxed-closures-blanket-fn.rs
+++ b/src/test/run-pass/unboxed-closures-blanket-fn.rs
@@ -10,8 +10,7 @@
 
 // Test that you can supply `&F` where `F: Fn()`.
 
-
-#![feature(lang_items, unboxed_closures)]
+#![feature(lang_items)]
 
 fn a<F:Fn() -> i32>(f: F) -> i32 {
     f()

--- a/src/test/run-pass/unboxed-closures-boxed.rs
+++ b/src/test/run-pass/unboxed-closures-boxed.rs
@@ -10,7 +10,6 @@
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]
-#![feature(unboxed_closures)]
 
 use std::ops::FnMut;
 

--- a/src/test/run-pass/unboxed-closures-by-ref.rs
+++ b/src/test/run-pass/unboxed-closures-by-ref.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
-#![feature(unboxed_closures)]
-
 // Test by-ref capture of environment in unboxed closure types
 
 fn call_fn<F: Fn()>(f: F) {

--- a/src/test/run-pass/unboxed-closures-call-fn-autoderef.rs
+++ b/src/test/run-pass/unboxed-closures-call-fn-autoderef.rs
@@ -10,9 +10,6 @@
 
 // Test that the call operator autoderefs when calling a bounded type parameter.
 
-
-#![feature(unboxed_closures)]
-
 use std::ops::FnMut;
 
 fn call_with_2(x: &fn(isize) -> isize) -> isize

--- a/src/test/run-pass/unboxed-closures-call-sugar-autoderef.rs
+++ b/src/test/run-pass/unboxed-closures-call-sugar-autoderef.rs
@@ -10,9 +10,6 @@
 
 // Test that the call operator autoderefs when calling a bounded type parameter.
 
-
-#![feature(unboxed_closures)]
-
 use std::ops::FnMut;
 
 fn call_with_2<F>(x: &mut F) -> isize

--- a/src/test/run-pass/unboxed-closures-call-sugar-object-autoderef.rs
+++ b/src/test/run-pass/unboxed-closures-call-sugar-object-autoderef.rs
@@ -11,7 +11,6 @@
 // Test that the call operator autoderefs when calling to an object type.
 
 #![allow(unknown_features)]
-#![feature(unboxed_closures)]
 
 use std::ops::FnMut;
 

--- a/src/test/run-pass/unboxed-closures-call-sugar-object.rs
+++ b/src/test/run-pass/unboxed-closures-call-sugar-object.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 #![allow(unknown_features)]
-#![feature(unboxed_closures)]
 
 use std::ops::FnMut;
 

--- a/src/test/run-pass/unboxed-closures-counter-not-moved.rs
+++ b/src/test/run-pass/unboxed-closures-counter-not-moved.rs
@@ -10,7 +10,6 @@
 
 // Test that we mutate a counter on the stack only when we expect to.
 
-
 fn call<F>(f: F) where F : FnOnce() {
     f();
 }

--- a/src/test/run-pass/unboxed-closures-direct-sugary-call.rs
+++ b/src/test/run-pass/unboxed-closures-direct-sugary-call.rs
@@ -10,8 +10,6 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(unboxed_closures)]
-
 fn main() {
     let mut unboxed = || {};
     unboxed();

--- a/src/test/run-pass/unboxed-closures-drop.rs
+++ b/src/test/run-pass/unboxed-closures-drop.rs
@@ -11,9 +11,6 @@
 // A battery of tests to ensure destructors of unboxed closure environments
 // run at the right times.
 
-
-#![feature(unboxed_closures)]
-
 static mut DROP_COUNT: usize = 0;
 
 fn drop_count() -> usize {

--- a/src/test/run-pass/unboxed-closures-extern-fn.rs
+++ b/src/test/run-pass/unboxed-closures-extern-fn.rs
@@ -10,10 +10,6 @@
 
 // Checks that extern fn pointers implement the full range of Fn traits.
 
-
-#![feature(unboxed_closures)]
-#![feature(unboxed_closures)]
-
 use std::ops::{Fn,FnMut,FnOnce};
 
 fn square(x: isize) -> isize { x * x }

--- a/src/test/run-pass/unboxed-closures-fn-as-fnmut-and-fnonce.rs
+++ b/src/test/run-pass/unboxed-closures-fn-as-fnmut-and-fnonce.rs
@@ -11,7 +11,6 @@
 // Checks that the Fn trait hierarchy rules permit
 // any Fn trait to be used where Fn is implemented.
 
-
 #![feature(unboxed_closures, fn_traits)]
 
 use std::ops::{Fn,FnMut,FnOnce};

--- a/src/test/run-pass/unboxed-closures-fnmut-as-fnonce.rs
+++ b/src/test/run-pass/unboxed-closures-fnmut-as-fnonce.rs
@@ -11,7 +11,6 @@
 // Checks that the Fn trait hierarchy rules permit
 // FnMut or FnOnce to be used where FnMut is implemented.
 
-
 #![feature(unboxed_closures, fn_traits)]
 
 struct S;

--- a/src/test/run-pass/unboxed-closures-generic.rs
+++ b/src/test/run-pass/unboxed-closures-generic.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(unboxed_closures)]
-
 use std::ops::FnMut;
 
 fn call_it<F:FnMut(i32,i32)->i32>(y: i32, mut f: F) -> i32 {

--- a/src/test/run-pass/unboxed-closures-infer-fnmut-calling-fnmut.rs
+++ b/src/test/run-pass/unboxed-closures-infer-fnmut-calling-fnmut.rs
@@ -11,7 +11,6 @@
 // Test that we are able to infer a suitable kind for this closure
 // that is just called (`FnMut`).
 
-
 fn main() {
     let mut counter = 0;
 

--- a/src/test/run-pass/unboxed-closures-infer-fnmut-move.rs
+++ b/src/test/run-pass/unboxed-closures-infer-fnmut-move.rs
@@ -11,7 +11,6 @@
 // Test that we are able to infer a suitable kind for this `move`
 // closure that is just called (`FnMut`).
 
-
 fn main() {
     let mut counter = 0;
 

--- a/src/test/run-pass/unboxed-closures-infer-fnmut.rs
+++ b/src/test/run-pass/unboxed-closures-infer-fnmut.rs
@@ -11,7 +11,6 @@
 // Test that we are able to infer a suitable kind for this closure
 // that is just called (`FnMut`).
 
-
 fn main() {
     let mut counter = 0;
 

--- a/src/test/run-pass/unboxed-closures-infer-kind.rs
+++ b/src/test/run-pass/unboxed-closures-infer-kind.rs
@@ -11,9 +11,6 @@
 // Test that we can infer the "kind" of an unboxed closure based on
 // the expected type.
 
-
-#![feature(unboxed_closures)]
-
 // Test by-ref capture of environment in unboxed closure types
 
 fn call_fn<F: Fn()>(f: F) {

--- a/src/test/run-pass/unboxed-closures-infer-upvar.rs
+++ b/src/test/run-pass/unboxed-closures-infer-upvar.rs
@@ -11,7 +11,6 @@
 // Test that the type variable in the type(`Vec<_>`) of a closed over
 // variable does not interfere with type inference.
 
-
 fn f<F: FnMut()>(mut f: F) {
     f();
 }

--- a/src/test/run-pass/unboxed-closures-move-mutable.rs
+++ b/src/test/run-pass/unboxed-closures-move-mutable.rs
@@ -10,7 +10,6 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(unboxed_closures)]
 #![deny(unused_mut)]
 
 // Test that mutating a mutable upvar in a capture-by-value unboxed

--- a/src/test/run-pass/unboxed-closures-move-some-upvars-in-by-ref-closure.rs
+++ b/src/test/run-pass/unboxed-closures-move-some-upvars-in-by-ref-closure.rs
@@ -11,7 +11,6 @@
 // Test that in a by-ref once closure we move some variables even as
 // we capture others by mutable reference.
 
-
 fn call<F>(f: F) where F : FnOnce() {
     f();
 }

--- a/src/test/run-pass/unboxed-closures-simple.rs
+++ b/src/test/run-pass/unboxed-closures-simple.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
-#![feature(unboxed_closures)]
-
 use std::ops::FnMut;
 
 pub fn main() {

--- a/src/test/run-pass/unboxed-closures-single-word-env.rs
+++ b/src/test/run-pass/unboxed-closures-single-word-env.rs
@@ -11,9 +11,6 @@
 // Ensures that single-word environments work right in unboxed closures.
 // These take a different path in codegen.
 
-
-#![feature(unboxed_closures)]
-
 fn a<F:Fn(isize, isize) -> isize>(f: F) -> isize {
     f(1, 2)
 }

--- a/src/test/run-pass/unboxed-closures-static-call-fn-once.rs
+++ b/src/test/run-pass/unboxed-closures-static-call-fn-once.rs
@@ -10,8 +10,6 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(unboxed_closures)]
-
 fn main() {
     let onetime = |x| x;
     onetime(0);

--- a/src/test/run-pass/unboxed-closures-sugar-object.rs
+++ b/src/test/run-pass/unboxed-closures-sugar-object.rs
@@ -10,9 +10,7 @@
 
 // Test unboxed closure sugar used in object types.
 
-
 #![allow(dead_code)]
-#![feature(unboxed_closures)]
 
 struct Foo<T,U> {
     t: T, u: U

--- a/src/test/run-pass/unboxed-closures-unique-type-id.rs
+++ b/src/test/run-pass/unboxed-closures-unique-type-id.rs
@@ -19,9 +19,6 @@
 //
 // compile-flags: -g
 
-
-#![feature(unboxed_closures)]
-
 use std::ptr;
 
 pub fn replace_map<'a, T, F>(src: &mut T, prod: F) where F: FnOnce(T) -> T {

--- a/src/test/run-pass/unboxed-closures-zero-args.rs
+++ b/src/test/run-pass/unboxed-closures-zero-args.rs
@@ -10,8 +10,6 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(unboxed_closures)]
-
 fn main() {
     let mut zero = || {};
     let () = zero();

--- a/src/test/run-pass/where-clauses-unboxed-closures.rs
+++ b/src/test/run-pass/where-clauses-unboxed-closures.rs
@@ -10,8 +10,6 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(unboxed_closures)]
-
 struct Bencher;
 
 // ICE


### PR DESCRIPTION
Methods `Fn::call`, `FnMut::call_mut` and `FnOnce::call_once` are gated with usual library feature `fn_traits` and also hardcoded in the compiler and gated once more with feature `unboxed_closures`
This patch removes the `unboxed_closures`feature gate from these methods (`unboxed_closures` is still used for other things though), now they are gated only with `fn_traits`.

All unnecessary `#![feature(unboxed_closures)]`s are removed, many of them are old and were already unnecessary before the change this PR does.
