### PR TITLE
Fix `include!()`s inside `asm!()` invocations

### DIFF
--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -820,6 +820,12 @@ impl<'a> ExtCtxt<'a> {
 /// compilation on error, merely emits a non-fatal error and returns None.
 pub fn expr_to_string(cx: &mut ExtCtxt, expr: P<ast::Expr>, err_msg: &str)
                       -> Option<(InternedString, ast::StrStyle)> {
+    // Update `expr.span`'s expn_id now in case expr is an `include!` macro invocation.
+    let expr = expr.map(|mut expr| {
+        expr.span.expn_id = cx.backtrace;
+        expr
+    });
+
     // we want to be able to handle e.g. concat("foo", "bar")
     let expr = cx.expander().fold_expr(expr);
     match expr.node {

--- a/src/test/compile-fail/macro-expanded-include/foo/mod.rs
+++ b/src/test/compile-fail/macro-expanded-include/foo/mod.rs
@@ -13,3 +13,7 @@
 macro_rules! m {
     () => { include!("file.txt"); }
 }
+
+macro_rules! n {
+    () => { unsafe { asm!(include_str!("file.txt")); } }
+}

--- a/src/test/compile-fail/macro-expanded-include/test.rs
+++ b/src/test/compile-fail/macro-expanded-include/test.rs
@@ -8,12 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(rustc_attrs)]
+#![feature(asm, rustc_attrs)]
+#![allow(unused)]
 
 #[macro_use]
 mod foo;
 
 m!();
+fn f() { n!(); }
 
 #[rustc_error]
 fn main() {} //~ ERROR compilation successful


### PR DESCRIPTION
Fixes #34812, a regression caused by #33749 that was not fixed in #34450.
r? @nrc 
