### PR TITLE
test: Remove NOTE assertions from trace_macros-gate

### DIFF
--- a/src/test/compile-fail/trace_macros-gate.rs
+++ b/src/test/compile-fail/trace_macros-gate.rs
@@ -26,6 +26,5 @@ fn main() {
         ($x: ident) => { trace_macros!($x) } //~ ERROR `trace_macros` is not stable
     }
 
-    expando!(true); //~ NOTE in this expansion
-                    //~^ NOTE in this expansion
+    expando!(true);
 }


### PR DESCRIPTION
If no NOTE assertions are present I believe they aren't asserted at all, and it
looks like the number of NOTEs differs on distcheck vs `make check`, so let's
just remove them all.

Closes #34822
