### PR TITLE
macros: fix bug in `stmt` matchers

### DIFF
--- a/src/test/compile-fail/macro-stmt-matchers.rs
+++ b/src/test/compile-fail/macro-stmt-matchers.rs
@@ -1,0 +1,17 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_attrs)]
+
+#[rustc_error]
+fn main() { //~ ERROR compilation successful
+    macro_rules! m { ($s:stmt;) => { $s } }
+    m!(vec![].push(0););
+}


### PR DESCRIPTION
Today, `stmt` matchers stop too early when parsing expression statements that begin with non-braced macro invocations. For example,

``` rust
fn main() {
    macro_rules! m { ($s:stmt;) => { $s } }
    id!(vec![].push(0););
    //^ Before this PR, the `stmt` matcher only consumes "vec![]", so this is an error.
    //| After this PR, the `stmt` matcher consumes "vec![].push(0)", so this compiles.
}
```

This change is backwards compatible due to the follow set for `stmt`.

r? @eddyb 
