### PR TITLE
Test fixes for ARM64

### DIFF
--- a/src/doc/book/inline-assembly.md
+++ b/src/doc/book/inline-assembly.md
@@ -60,6 +60,8 @@ asm!("xor %eax, %eax"
     : "eax"
    );
 # } }
+# #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+# fn main() {}
 ```
 
 Whitespace also doesn't matter:
@@ -70,6 +72,8 @@ Whitespace also doesn't matter:
 # fn main() { unsafe {
 asm!("xor %eax, %eax" ::: "eax");
 # } }
+# #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+# fn main() {}
 ```
 
 ## Operands
@@ -129,6 +133,8 @@ stay valid.
 // Put the value 0x200 in eax
 asm!("mov $$0x200, %eax" : /* no outputs */ : /* no inputs */ : "eax");
 # } }
+# #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+# fn main() {}
 ```
 
 Input and output registers need not be listed since that information
@@ -164,6 +170,8 @@ unsafe {
 }
 println!("eax is currently {}", result);
 # }
+# #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+# fn main() {}
 ```
 
 ## More Information

--- a/src/test/debuginfo/type-names.rs
+++ b/src/test/debuginfo/type-names.rs
@@ -11,6 +11,8 @@
 // ignore-tidy-linelength
 // ignore-lldb
 // ignore-android: FIXME(#24958)
+// ignore-arm: FIXME(#24958)
+// ignore-aarch64: FIXME(#24958)
 
 // compile-flags:-g
 


### PR DESCRIPTION
When these changes are applied, rustc 1.10.0 tests pass successfully on [asachi.debian.org](https://db.debian.org/machines.cgi?host=asachi).
