### PR TITLE
implement AddAssign for String

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -1559,7 +1559,7 @@ impl<'a> Add<&'a str> for String {
     }
 }
 
-#[stable(feature = "rust1", since = "1.12.0")]
+#[stable(feature = "stringaddassign", since = "1.12.0")]
 impl<'a> AddAssign<&'a str> for String {
     #[inline]
     fn add_assign(&mut self, other: &str) {

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -59,7 +59,7 @@ use core::fmt;
 use core::hash;
 use core::iter::FromIterator;
 use core::mem;
-use core::ops::{self, Add, Index, IndexMut};
+use core::ops::{self, Add, AddAssign, Index, IndexMut};
 use core::ptr;
 use core::str::pattern::Pattern;
 use rustc_unicode::char::{decode_utf16, REPLACEMENT_CHARACTER};
@@ -1556,6 +1556,14 @@ impl<'a> Add<&'a str> for String {
     fn add(mut self, other: &str) -> String {
         self.push_str(other);
         self
+    }
+}
+
+#[stable(feature = "rust1", since = "1.11.0")]
+impl<'a> AddAssign<&'a str> for String {
+    #[inline]
+    fn add_assign(&mut self, other: &str) {
+        self.push_str(other);
     }
 }
 

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -1559,7 +1559,7 @@ impl<'a> Add<&'a str> for String {
     }
 }
 
-#[stable(feature = "rust1", since = "1.11.0")]
+#[stable(feature = "rust1", since = "1.12.0")]
 impl<'a> AddAssign<&'a str> for String {
     #[inline]
     fn add_assign(&mut self, other: &str) {


### PR DESCRIPTION
Currently `String` implements `Add` but not `AddAssign`. This PR fills in that gap.

I played around with having `AddAssign` (and `Add` and `push_str`) take `AsRef<str>` instead of `&str`, but it looks like that breaks arguments that implement `Deref<Target=str>` and not `AsRef<str>`. Comments in [`libcore/convert.rs`](https://github.com/rust-lang/rust/blob/master/src/libcore/convert.rs#L207-L213) make it sound like we could fix this with a blanket impl eventually. Does anyone know what's blocking that?
