### PR TITLE
Fix inference for projections with associated traits with multiple bounds; fixes #34792

### DIFF
--- a/src/test/run-pass/issue-34792.rs
+++ b/src/test/run-pass/issue-34792.rs
@@ -1,0 +1,27 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test correct type inference for projections when the associated
+// type has multiple trait bounds
+
+struct A;
+struct B;
+
+trait Foo {
+    type T: PartialEq<A> + PartialEq<B>;
+}
+
+fn generic<F: Foo>(t: F::T, a: A, b: B) -> bool {
+    // Equivalent, but not as explicit: t == a && t == b
+    <<F as Foo>::T as PartialEq<_>>::eq(&t, &a) &&
+    <<F as Foo>::T as PartialEq<_>>::eq(&t, &b)
+}
+
+fn main() {}


### PR DESCRIPTION
The problem was due to the fact that no particular trait bound was specified when a projection was matched with a trait bound, even when multiple bounds existed. The compiler consistently picked the first bound on the associated type that it found that was able to match the type's obligation (which, in the regression test, is `<F as Foo>` or `<Self as Foo>`).

The fix involved modifying the `SelectionCandidate::ProjectionCandidate` variant to carry a trait ref to refer to its matching bound. And instead of stopping on the first match we find, we add all matching bounds to the `candidates` vector. Also in the winnowing step, a `ProjectionCandidate` cannot trump another `ProjectionCandidate` unless they are identical.
