### PR TITLE
[CSS] Fix unwanted top margin for toggle wrapper

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -636,8 +636,11 @@ span.since {
     margin-right: 5px;
 }
 
-.enum > .toggle-wrapper > .collapse-toggle, .struct > .toggle-wrapper > .collapse-toggle {
+.toggle-wrapper > .collapse-toggle {
     left: 0;
+}
+
+.variant + .toggle-wrapper > a {
     margin-top: 5px;
 }
 


### PR DESCRIPTION
Fixes top margin.

Before:

![before](https://cloud.githubusercontent.com/assets/3050060/16950833/72b2b956-4dc2-11e6-9d27-24507871b5a8.png)

After (check "A view into a single entry in map" toggle wrapper more precisely):

![after](https://cloud.githubusercontent.com/assets/3050060/16950839/7835c6fc-4dc2-11e6-901a-ae8c4191baca.png)

r? @steveklabnik 
