### PR TITLE
Deny (by default) transmuting from fn item types to pointer-sized types.

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -157,7 +157,7 @@ declare_lint! {
 
 declare_lint! {
     pub TRANSMUTE_FROM_FN_ITEM_TYPES,
-    Warn,
+    Deny,
     "transmute from function item type to pointer-sized type erroneously allowed"
 }
 


### PR DESCRIPTION
This sets the #19925 lint (transmute from zero-sized fn item type) to `deny` by default.
Technically a `[breaking-change]`, but will not affect dependent crates because of `--cap-lints`.
