### PR TITLE
resolve: Fix ICE and extra diagnostics happening when unresolved imports are used in patterns

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2274,7 +2274,7 @@ impl<'a> Resolver<'a> {
         let resolution = if let Some(resolution) = self.resolve_possibly_assoc_item(pat_id,
                                                                         qself, path, namespace) {
             if resolution.depth == 0 {
-                if expected_fn(resolution.base_def) {
+                if expected_fn(resolution.base_def) || resolution.base_def == Def::Err {
                     resolution
                 } else {
                     resolve_error(
@@ -2345,7 +2345,7 @@ impl<'a> Resolver<'a> {
                                 );
                                 None
                             }
-                            Def::Local(..) | Def::Upvar(..) | Def::Fn(..) => {
+                            Def::Local(..) | Def::Upvar(..) | Def::Fn(..) | Def::Err => {
                                 // These entities are explicitly allowed
                                 // to be shadowed by fresh bindings.
                                 None

--- a/src/test/compile-fail/unresolved-import-recovery.rs
+++ b/src/test/compile-fail/unresolved-import-recovery.rs
@@ -1,0 +1,27 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that unresolved imports do not create additional errors and ICEs
+
+mod m {
+    pub use unresolved; //~ ERROR unresolved import `unresolved`
+
+    fn f() {
+        let unresolved = 0; // OK
+    }
+}
+
+fn main() {
+    match 0u8 {
+        m::unresolved => {} // OK
+        m::unresolved(..) => {} // OK
+        m::unresolved{..} => {} // OK
+    }
+}


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/34933

r? @jseyfried 
