### PR TITLE
improve const eval error reporting on "" and b"" casts

### DIFF
--- a/src/test/run-pass/const-byte-str-cast.rs
+++ b/src/test/run-pass/const-byte-str-cast.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -12,4 +12,7 @@
 
 pub fn main() {
     let _ = b"x" as &[u8];
+    let _ = b"y" as &[u8; 1];
+    let _ = b"z" as *const u8;
+    let _ = "ä" as *const str;
 }


### PR DESCRIPTION
r? @eddyb 

cc @ubsan 
