### PR TITLE
Fix incorrect 'memory leak' example for `Vec::set_len`.

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -593,11 +593,12 @@ impl<T> Vec<T> {
     /// ```
     ///
     /// In this example, there is a memory leak since the memory locations
-    /// owned by the vector were not freed prior to the `set_len` call:
+    /// owned by the inner vectors were not freed prior to the `set_len` call:
     ///
     /// ```
-    /// let mut vec = vec!['r', 'u', 's', 't'];
-    ///
+    /// let mut vec = vec![vec![1, 0, 0],
+    ///                    vec![0, 1, 0],
+    ///                    vec![0, 0, 1]];
     /// unsafe {
     ///     vec.set_len(0);
     /// }


### PR DESCRIPTION
Example was written in https://github.com/rust-lang/rust/pull/34911

Issue was brought up in this comment:

https://github.com/rust-lang/rust/commit/a005b2cd2ac679da7393e537aa05e2b7d32d36d5#commitcomment-18346958
