### PR TITLE
rustdoc: Remove item types from some title pages

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1543,15 +1543,13 @@ impl<'a> fmt::Display for Item<'a> {
         // Write the breadcrumb trail header for the top
         write!(fmt, "\n<h1 class='fqn'><span class='in-band'>")?;
         match self.item.inner {
+            // Only add item type to the title for items without a definition
+            // on the page.
             clean::ModuleItem(ref m) => if m.is_crate {
                     write!(fmt, "Crate ")?;
                 } else {
                     write!(fmt, "Module ")?;
                 },
-            clean::FunctionItem(..) => write!(fmt, "Function ")?,
-            clean::TraitItem(..) => write!(fmt, "Trait ")?,
-            clean::StructItem(..) => write!(fmt, "Struct ")?,
-            clean::EnumItem(..) => write!(fmt, "Enum ")?,
             clean::PrimitiveItem(..) => write!(fmt, "Primitive Type ")?,
             _ => {}
         }

--- a/src/test/rustdoc/titles.rs
+++ b/src/test/rustdoc/titles.rs
@@ -1,0 +1,59 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "foo"]
+
+// @has 'foo/index.html' '//h1' 'Crate foo'
+
+// @has 'foo/foo_mod/index.html' '//h1' 'Module foo::foo_mod'
+pub mod foo_mod {
+    pub struct __Thing {}
+}
+
+extern {
+    // @has 'foo/fn.foo_ffn.html' '//h1' 'foo::foo_ffn'
+    pub fn foo_ffn();
+}
+
+// @has 'foo/fn.foo_fn.html' '//h1' 'foo::foo_fn'
+pub fn foo_fn() {}
+
+// @has 'foo/trait.FooTrait.html' '//h1' 'foo::FooTrait'
+pub trait FooTrait {}
+
+// @has 'foo/struct.FooStruct.html' '//h1' 'foo::FooStruct'
+pub struct FooStruct;
+
+// @has 'foo/enum.FooEnum.html' '//h1' 'foo::FooEnum'
+pub enum FooEnum {}
+
+// @has 'foo/type.FooType.html' '//h1' 'foo::FooType'
+pub type FooType = FooStruct;
+
+// @has 'foo/macro.foo_macro!.html' '//h1' 'foo::foo_macro!'
+#[macro_export]
+macro_rules! foo_macro {
+    () => ();
+}
+
+// @has 'foo/primitive.bool.html' '//h1' 'Primitive Type bool'
+#[doc(primitive = "bool")]
+mod bool {}
+
+// @has 'foo/static.FOO_STATIC.html' '//h1' 'foo::FOO_STATIC'
+pub static FOO_STATIC: FooStruct = FooStruct;
+
+extern {
+    // @has 'foo/static.FOO_FSTATIC.html' '//h1' 'foo::FOO_FSTATIC'
+    pub static FOO_FSTATIC: FooStruct;
+}
+
+// @has 'foo/constant.FOO_CONSTANT.html' '//h1' 'foo::FOO_CONSTANT'
+pub const FOO_CONSTANT: FooStruct = FooStruct;


### PR DESCRIPTION
On most pages like structs the title does not need to include
the word "Struct" because you can tell that from the definition.

Previous discussion: #34345
