### PR TITLE
Fix build of compiler-rt on FreeBSD

### DIFF
--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -384,7 +384,11 @@ COMPRT_OBJS_$(1) += emutls.o
 endif
 
 ifeq ($$(findstring msvc,$(1)),)
+
+ifeq ($$(findstring freebsd,$(1)),)
 COMPRT_OBJS_$(1) += gcc_personality_v0.o
+endif
+
 COMPRT_OBJS_$(1) += emutls.o
 
 ifeq ($$(findstring x86_64,$(1)),x86_64)

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -348,7 +348,9 @@ pub fn compiler_rt(build: &Build, target: &str) {
             ]);
         }
     } else {
-        sources.push("gcc_personality_v0.c");
+        if !target.contains("freebsd") {
+            sources.push("gcc_personality_v0.c");
+        }
 
         if target.contains("x86_64") {
             sources.extend(vec![


### PR DESCRIPTION
Broken since ee6011fc71e02485f2dffcc25be64631c2008775 removed cmake from the
process.  There are likely other platforms still broken, but I didn't test on them.
