### PR TITLE
Fix formatting generation for rustdoc code examples

### DIFF
--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -359,8 +359,14 @@ pub fn maketest(s: &str, cratename: Option<&str>, dont_insert_main: bool,
     if dont_insert_main || s.contains("fn main") {
         prog.push_str(&everything_else);
     } else {
-        prog.push_str("fn main() {\n    ");
-        prog.push_str(&everything_else);
+        prog.push_str("fn main() {\n");
+        for line in everything_else.split("\n") {
+            if line.len() > 0 {
+                prog.push_str(&format!("    {}\n", line));
+            } else {
+                prog.push_str("\n");
+            }
+        }
         prog = prog.trim().into();
         prog.push_str("\n}");
     }

--- a/src/test/rustdoc/issue-25944.rs
+++ b/src/test/rustdoc/issue-25944.rs
@@ -13,8 +13,9 @@
 /// ```
 /// let a = r#"
 /// foo
+///
 /// bar"#;
-/// let b = "\nfoo\nbar";
+/// let b = "\n    foo\n\n    bar";
 /// assert_eq!(a, b);
 /// ```
 pub fn main() {


### PR DESCRIPTION
Now, when clicking on the Run link in the docs, the code is indented if it is put in a main function (I couldn't stand the horrible output we currently have).

r? @steveklabnik 
