### PR TITLE
rustdoc: simplify URLs

### DIFF
--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -68,7 +68,7 @@ const MAX_THREE_B: u32 =  0x10000;
 /// Point], but only ones within a certain range. `MAX` is the highest valid
 /// code point that's a valid [Unicode Scalar Value].
 ///
-/// [`char`]: ../../std/primitive.char.html
+/// [`char`]: ../../std/char.t.html
 /// [Unicode Scalar Value]: http://www.unicode.org/glossary/#unicode_scalar_value
 /// [Code Point]: http://www.unicode.org/glossary/#code_point
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -90,8 +90,8 @@ pub const MAX: char = '\u{10ffff}';
 /// [`char`]s. `from_u32()` will return `None` if the input is not a valid value
 /// for a [`char`].
 ///
-/// [`char`]: ../../std/primitive.char.html
-/// [`u32`]: ../../std/primitive.u32.html
+/// [`char`]: ../../std/char.t.html
+/// [`u32`]: ../../std/u32.t.html
 /// [`as`]: ../../book/casting-between-types.html#as
 ///
 /// For an unsafe version of this function which ignores these checks, see
@@ -147,8 +147,8 @@ pub fn from_u32(i: u32) -> Option<char> {
 /// [`char`]s. `from_u32_unchecked()` will ignore this, and blindly cast to
 /// [`char`], possibly creating an invalid one.
 ///
-/// [`char`]: ../../std/primitive.char.html
-/// [`u32`]: ../../std/primitive.u32.html
+/// [`char`]: ../../std/char.t.html
+/// [`u32`]: ../../std/u32.t.html
 /// [`as`]: ../../book/casting-between-types.html#as
 ///
 /// # Safety
@@ -413,8 +413,8 @@ impl CharExt for char {
 /// This `struct` is created by the [`escape_unicode()`] method on [`char`]. See
 /// its documentation for more.
 ///
-/// [`escape_unicode()`]: ../../std/primitive.char.html#method.escape_unicode
-/// [`char`]: ../../std/primitive.char.html
+/// [`escape_unicode()`]: ../../std/char.t.html#method.escape_unicode
+/// [`char`]: ../../std/char.t.html
 #[derive(Clone, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct EscapeUnicode {
@@ -521,8 +521,8 @@ impl ExactSizeIterator for EscapeUnicode {
 /// This `struct` is created by the [`escape_default()`] method on [`char`]. See
 /// its documentation for more.
 ///
-/// [`escape_default()`]: ../../std/primitive.char.html#method.escape_default
-/// [`char`]: ../../std/primitive.char.html
+/// [`escape_default()`]: ../../std/char.t.html#method.escape_default
+/// [`char`]: ../../std/char.t.html
 #[derive(Clone, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct EscapeDefault {

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 //! Operations and constants for 32-bits floats (`f32` type)
+//!
+//! *[See also the `f32` primitive type](../../std/f32.t.html).*
 
 // FIXME: MIN_VALUE and MAX_VALUE literals are parsed as -inf and inf #14353
 #![allow(overflowing_literals)]

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 //! Operations and constants for 64-bits floats (`f64` type)
+//!
+//! *[See also the `f64` primitive type](../../std/f64.t.html).*
 
 // FIXME: MIN_VALUE and MAX_VALUE literals are parsed as -inf and inf #14353
 #![allow(overflowing_literals)]

--- a/src/libcore/num/i16.rs
+++ b/src/libcore/num/i16.rs
@@ -10,7 +10,7 @@
 
 //! The 16-bit signed integer type.
 //!
-//! *[See also the `i16` primitive type](../../std/primitive.i16.html).*
+//! *[See also the `i16` primitive type](../../std/i16.t.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/num/i32.rs
+++ b/src/libcore/num/i32.rs
@@ -10,7 +10,7 @@
 
 //! The 32-bit signed integer type.
 //!
-//! *[See also the `i32` primitive type](../../std/primitive.i32.html).*
+//! *[See also the `i32` primitive type](../../std/i32.t.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/num/i64.rs
+++ b/src/libcore/num/i64.rs
@@ -10,7 +10,7 @@
 
 //! The 64-bit signed integer type.
 //!
-//! *[See also the `i64` primitive type](../../std/primitive.i64.html).*
+//! *[See also the `i64` primitive type](../../std/i64.t.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/num/i8.rs
+++ b/src/libcore/num/i8.rs
@@ -10,7 +10,7 @@
 
 //! The 8-bit signed integer type.
 //!
-//! *[See also the `i8` primitive type](../../std/primitive.i8.html).*
+//! *[See also the `i8` primitive type](../../std/i8.t.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/num/isize.rs
+++ b/src/libcore/num/isize.rs
@@ -10,7 +10,7 @@
 
 //! The pointer-sized signed integer type.
 //!
-//! *[See also the `isize` primitive type](../../std/primitive.isize.html).*
+//! *[See also the `isize` primitive type](../../std/isize.t.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/num/u16.rs
+++ b/src/libcore/num/u16.rs
@@ -10,7 +10,7 @@
 
 //! The 16-bit unsigned integer type.
 //!
-//! *[See also the `u16` primitive type](../../std/primitive.u16.html).*
+//! *[See also the `u16` primitive type](../../std/u16.t.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/num/u32.rs
+++ b/src/libcore/num/u32.rs
@@ -10,7 +10,7 @@
 
 //! The 32-bit unsigned integer type.
 //!
-//! *[See also the `u32` primitive type](../../std/primitive.u32.html).*
+//! *[See also the `u32` primitive type](../../std/u32.t.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/num/u64.rs
+++ b/src/libcore/num/u64.rs
@@ -10,7 +10,7 @@
 
 //! The 64-bit unsigned integer type.
 //!
-//! *[See also the `u64` primitive type](../../std/primitive.u64.html).*
+//! *[See also the `u64` primitive type](../../std/u64.t.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/num/u8.rs
+++ b/src/libcore/num/u8.rs
@@ -10,7 +10,7 @@
 
 //! The 8-bit unsigned integer type.
 //!
-//! *[See also the `u8` primitive type](../../std/primitive.u8.html).*
+//! *[See also the `u8` primitive type](../../std/u8.t.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/num/usize.rs
+++ b/src/libcore/num/usize.rs
@@ -10,7 +10,7 @@
 
 //! The pointer-sized unsigned integer type.
 //!
-//! *[See also the `usize` primitive type](../../std/primitive.usize.html).*
+//! *[See also the `usize` primitive type](../../std/usize.t.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2727,7 +2727,7 @@ pub struct Macro {
 
 impl Clean<Item> for doctree::Macro {
     fn clean(&self, cx: &DocContext) -> Item {
-        let name = format!("{}!", self.name.clean(cx));
+        let name = self.name.clean(cx);
         Item {
             name: Some(name.clone()),
             attrs: self.attrs.clean(cx),
@@ -2738,8 +2738,10 @@ impl Clean<Item> for doctree::Macro {
             def_id: cx.map.local_def_id(self.id),
             inner: MacroItem(Macro {
                 source: format!("macro_rules! {} {{\n{}}}",
-                    name.trim_right_matches('!'), self.matchers.iter().map(|span|
-                        format!("    {} => {{ ... }};\n", span.to_src(cx))).collect::<String>()),
+                                name,
+                                self.matchers.iter().map(|span| {
+                                    format!("    {} => {{ ... }};\n", span.to_src(cx))
+                                }).collect::<String>()),
                 imported_from: self.imported_from.clean(cx),
             }),
         }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -326,9 +326,9 @@ pub fn href(did: DefId) -> Option<(String, ItemType, Vec<String>)> {
             url.push_str("/index.html");
         }
         _ => {
-            url.push_str(shortty.to_static_str());
-            url.push_str(".");
             url.push_str(fqp.last().unwrap());
+            url.push_str(".");
+            url.push_str(shortty.name_space().to_static_str());
             url.push_str(".html");
         }
     }
@@ -382,7 +382,7 @@ fn primitive_link(f: &mut fmt::Formatter,
         Some(&LOCAL_CRATE) => {
             let len = CURRENT_LOCATION_KEY.with(|s| s.borrow().len());
             let len = if len == 0 {0} else {len - 1};
-            write!(f, "<a class='primitive' href='{}primitive.{}.html'>",
+            write!(f, "<a class='primitive' href='{}{}.t.html'>",
                    repeat("../").take(len).collect::<String>(),
                    prim.to_url_str())?;
             needs_termination = true;
@@ -397,7 +397,7 @@ fn primitive_link(f: &mut fmt::Formatter,
                 (_, render::Unknown) => None,
             };
             if let Some((cname, root)) = loc {
-                write!(f, "<a class='primitive' href='{}{}/primitive.{}.html'>",
+                write!(f, "<a class='primitive' href='{}{}/{}.t.html'>",
                        root,
                        cname,
                        prim.to_url_str())?;
@@ -439,7 +439,7 @@ impl<'a> fmt::Display for HRef<'a> {
         match href(self.did) {
             Some((url, shortty, fqp)) => {
                 write!(f, "<a class='{}' href='{}' title='{}'>{}</a>",
-                       shortty, url, fqp.join("::"), self.text)
+                       shortty.css_class(), url, fqp.join("::"), self.text)
             }
             _ => write!(f, "{}", self.text),
         }

--- a/src/librustdoc/html/item_type.rs
+++ b/src/librustdoc/html/item_type.rs
@@ -42,6 +42,13 @@ pub enum ItemType {
     AssociatedConst = 18,
 }
 
+#[derive(Copy, Eq, PartialEq, Clone)]
+pub enum NameSpace {
+    Type,
+    Value,
+    Macro,
+}
+
 impl ItemType {
     pub fn from_item(item: &clean::Item) -> ItemType {
         let inner = match item.inner {
@@ -90,7 +97,7 @@ impl ItemType {
         }
     }
 
-    pub fn to_static_str(&self) -> &'static str {
+    pub fn css_class(&self) -> &'static str {
         match *self {
             ItemType::Module          => "mod",
             ItemType::ExternCrate     => "externcrate",
@@ -113,9 +120,49 @@ impl ItemType {
             ItemType::AssociatedConst => "associatedconstant",
         }
     }
+
+    pub fn name_space(&self) -> NameSpace {
+        match *self {
+            ItemType::Struct |
+            ItemType::Enum |
+            ItemType::Module |
+            ItemType::Typedef |
+            ItemType::Trait |
+            ItemType::Primitive |
+            ItemType::AssociatedType => NameSpace::Type,
+
+            ItemType::ExternCrate |
+            ItemType::Import |
+            ItemType::Function |
+            ItemType::Static |
+            ItemType::Impl |
+            ItemType::TyMethod |
+            ItemType::Method |
+            ItemType::StructField |
+            ItemType::Variant |
+            ItemType::Constant |
+            ItemType::AssociatedConst => NameSpace::Value,
+
+            ItemType::Macro => NameSpace::Macro,
+        }
+    }
 }
 
-impl fmt::Display for ItemType {
+pub const NAMESPACE_TYPE: &'static str = "t";
+pub const NAMESPACE_VALUE: &'static str = "v";
+pub const NAMESPACE_MACRO: &'static str = "m";
+
+impl NameSpace {
+    pub fn to_static_str(&self) -> &'static str {
+        match *self {
+            NameSpace::Type => NAMESPACE_TYPE,
+            NameSpace::Value => NAMESPACE_VALUE,
+            NameSpace::Macro => NAMESPACE_MACRO,
+        }
+    }
+}
+
+impl fmt::Display for NameSpace {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.to_static_str().fmt(f)
     }

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -24,7 +24,7 @@ pub struct Layout {
 
 pub struct Page<'a> {
     pub title: &'a str,
-    pub ty: &'a str,
+    pub css_class: &'a str,
     pub root_path: &'a str,
     pub description: &'a str,
     pub keywords: &'a str,
@@ -80,7 +80,7 @@ r##"<!DOCTYPE html>
         </form>
     </nav>
 
-    <section id='main' class="content {ty}">{content}</section>
+    <section id='main' class="content {css_class}">{content}</section>
     <section id='search' class="content hidden"></section>
 
     <section class="footer"></section>
@@ -152,7 +152,7 @@ r##"<!DOCTYPE html>
     },
     content   = *t,
     root_path = page.root_path,
-    ty        = page.ty,
+    css_class = page.css_class,
     logo      = if layout.logo.is_empty() {
         "".to_string()
     } else {

--- a/src/test/rustdoc/assoc-consts.rs
+++ b/src/test/rustdoc/assoc-consts.rs
@@ -11,16 +11,16 @@
 #![feature(associated_consts)]
 
 pub trait Foo {
-    // @has assoc_consts/trait.Foo.html '//*[@class="rust trait"]' \
+    // @has assoc_consts/Foo.t.html '//*[@class="rust trait"]' \
     //      'const FOO: usize;'
-    // @has - '//*[@id="associatedconstant.FOO"]' 'const FOO'
+    // @has - '//*[@id="FOO.v"]' 'const FOO'
     const FOO: usize;
 }
 
 pub struct Bar;
 
 impl Bar {
-    // @has assoc_consts/struct.Bar.html '//*[@id="associatedconstant.BAR"]' \
+    // @has assoc_consts/Bar.t.html '//*[@id="BAR.v"]' \
     //      'const BAR: usize = 3'
     pub const BAR: usize = 3;
 }

--- a/src/test/rustdoc/assoc-types.rs
+++ b/src/test/rustdoc/assoc-types.rs
@@ -10,16 +10,16 @@
 
 #![crate_type="lib"]
 
-// @has assoc_types/trait.Index.html
+// @has assoc_types/Index.t.html
 pub trait Index<I: ?Sized> {
-    // @has - '//*[@id="associatedtype.Output"]//code' 'type Output: ?Sized'
+    // @has - '//*[@id="Output.t"]//code' 'type Output: ?Sized'
     type Output: ?Sized;
-    // @has - '//*[@id="tymethod.index"]//code' \
+    // @has - '//*[@id="index.v"]//code' \
     //      "fn index<'a>(&'a self, index: I) -> &'a Self::Output"
     fn index<'a>(&'a self, index: I) -> &'a Self::Output;
 }
 
-// @has assoc_types/fn.use_output.html
+// @has assoc_types/use_output.v.html
 // @has - '//*[@class="rust fn"]' '-> &T::Output'
 pub fn use_output<T: Index<usize>>(obj: &T, index: usize) -> &T::Output {
     obj.index(index)
@@ -29,11 +29,11 @@ pub trait Feed {
     type Input;
 }
 
-// @has assoc_types/fn.use_input.html
+// @has assoc_types/use_input.v.html
 // @has - '//*[@class="rust fn"]' 'T::Input'
 pub fn use_input<T: Feed>(_feed: &T, _element: T::Input) { }
 
-// @has assoc_types/fn.cmp_input.html
+// @has assoc_types/cmp_input.v.html
 // @has - '//*[@class="rust fn"]' 'where T::Input: PartialEq<U::Input>'
 pub fn cmp_input<T: Feed, U: Feed>(a: &T::Input, b: &U::Input) -> bool
     where T::Input: PartialEq<U::Input>

--- a/src/test/rustdoc/cap-lints.rs
+++ b/src/test/rustdoc/cap-lints.rs
@@ -13,7 +13,7 @@
 // therefore should not concern itself with the lints.
 #[deny(warnings)]
 
-// @has cap_lints/struct.foo.html //pre '#[must_use]'
+// @has cap_lints/foo.t.html //pre '#[must_use]'
 #[must_use]
 pub struct foo {
     field: i32,

--- a/src/test/rustdoc/deprecated-impls.rs
+++ b/src/test/rustdoc/deprecated-impls.rs
@@ -10,7 +10,7 @@
 
 #![crate_name = "foo"]
 
-// @has foo/struct.Foo0.html
+// @has foo/Foo0.t.html
 pub struct Foo0;
 
 impl Foo0 {
@@ -57,7 +57,7 @@ pub trait Bar {
     fn fn_def_def_without_doc() {}
 }
 
-// @has foo/struct.Foo1.html
+// @has foo/Foo1.t.html
 pub struct Foo1;
 
 impl Bar for Foo1 {
@@ -90,7 +90,7 @@ impl Bar for Foo1 {
     // @has - '//*[@class="stab deprecated"]' 'Deprecated since 1.0.8: fn_def_def_without_doc'
 }
 
-// @has foo/struct.Foo2.html
+// @has foo/Foo2.t.html
 pub struct Foo2;
 
 impl Bar for Foo2 {

--- a/src/test/rustdoc/deprecated.rs
+++ b/src/test/rustdoc/deprecated.rs
@@ -10,7 +10,7 @@
 
 #![feature(deprecated)]
 
-// @has deprecated/struct.S.html '//*[@class="stab deprecated"]' \
+// @has deprecated/S.t.html '//*[@class="stab deprecated"]' \
 //      'Deprecated since 1.0.0: text'
 #[deprecated(since = "1.0.0", note = "text")]
 pub struct S;

--- a/src/test/rustdoc/duplicate_impls/issue-33054.rs
+++ b/src/test/rustdoc/duplicate_impls/issue-33054.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// @has issue_33054/impls/struct.Foo.html
+// @has issue_33054/impls/Foo.t.html
 // @has - '//code' 'impl Foo'
 // @has - '//code' 'impl Bar for Foo'
 // @count - '//*[@class="impl"]' 2
-// @has issue_33054/impls/bar/trait.Bar.html
+// @has issue_33054/impls/bar/Bar.t.html
 // @has - '//code' 'impl Bar for Foo'
 // @count - '//*[@class="struct"]' 1
 pub mod impls;

--- a/src/test/rustdoc/escape-rust-expr.rs
+++ b/src/test/rustdoc/escape-rust-expr.rs
@@ -11,5 +11,5 @@
 // Test that we HTML-escape Rust expressions, where HTML special chars
 // can occur, and we know it's definitely not markup.
 
-// @has escape_rust_expr/constant.CONST_S.html '//pre[@class="rust const"]' '"<script>"'
+// @has escape_rust_expr/CONST_S.v.html '//pre[@class="rust const"]' '"<script>"'
 pub const CONST_S: &'static str = "<script>";

--- a/src/test/rustdoc/extern-default-method.rs
+++ b/src/test/rustdoc/extern-default-method.rs
@@ -13,5 +13,5 @@
 
 extern crate rustdoc_extern_default_method as ext;
 
-// @count extern_default_method/struct.Struct.html '//*[@id="method.provided"]' 1
+// @count extern_default_method/Struct.t.html '//*[@id="provided.v"]' 1
 pub use ext::Struct;

--- a/src/test/rustdoc/extern-impl.rs
+++ b/src/test/rustdoc/extern-impl.rs
@@ -10,7 +10,7 @@
 
 #![crate_name = "foo"]
 
-// @has foo/struct.Foo.html
+// @has foo/Foo.t.html
 pub struct Foo;
 
 impl Foo {
@@ -26,7 +26,7 @@ impl Foo {
     pub extern "system" fn system0() {}
 }
 
-// @has foo/trait.Bar.html
+// @has foo/Bar.t.html
 pub trait Bar {}
 
 // @has - '//code' 'impl Bar for fn()'

--- a/src/test/rustdoc/extern-method.rs
+++ b/src/test/rustdoc/extern-method.rs
@@ -15,15 +15,15 @@
 
 extern crate rustdoc_extern_method as foo;
 
-// @has extern_method/trait.Foo.html //pre "pub trait Foo"
-// @has - '//*[@id="tymethod.foo"]//code' 'extern "rust-call" fn foo'
-// @has - '//*[@id="method.foo_"]//code' 'extern "rust-call" fn foo_'
+// @has extern_method/Foo.t.html //pre "pub trait Foo"
+// @has - '//*[@id="foo.v"]//code' 'extern "rust-call" fn foo'
+// @has - '//*[@id="foo_.v"]//code' 'extern "rust-call" fn foo_'
 pub use foo::Foo;
 
-// @has extern_method/trait.Bar.html //pre "pub trait Bar"
+// @has extern_method/Bar.t.html //pre "pub trait Bar"
 pub trait Bar {
-    // @has - '//*[@id="tymethod.bar"]//code' 'extern "rust-call" fn bar'
+    // @has - '//*[@id="bar.v"]//code' 'extern "rust-call" fn bar'
     extern "rust-call" fn bar(&self, _: ());
-    // @has - '//*[@id="method.bar_"]//code' 'extern "rust-call" fn bar_'
+    // @has - '//*[@id="bar_.v"]//code' 'extern "rust-call" fn bar_'
     extern "rust-call" fn bar_(&self, _: ()) { }
 }

--- a/src/test/rustdoc/ffi.rs
+++ b/src/test/rustdoc/ffi.rs
@@ -13,10 +13,10 @@
 
 extern crate rustdoc_ffi as lib;
 
-// @has ffi/fn.foreigner.html //pre 'pub unsafe extern fn foreigner(cold_as_ice: u32)'
+// @has ffi/foreigner.v.html //pre 'pub unsafe extern fn foreigner(cold_as_ice: u32)'
 pub use lib::foreigner;
 
 extern "C" {
-    // @has ffi/fn.another.html //pre 'pub unsafe extern fn another(cold_as_ice: u32)'
+    // @has ffi/another.v.html //pre 'pub unsafe extern fn another(cold_as_ice: u32)'
     pub fn another(cold_as_ice: u32);
 }

--- a/src/test/rustdoc/hidden-impls.rs
+++ b/src/test/rustdoc/hidden-impls.rs
@@ -20,8 +20,8 @@ pub mod __hidden {
     pub use hidden::Foo;
 }
 
-// @has foo/trait.Clone.html
+// @has foo/Clone.t.html
 // @!has - 'Foo'
-// @has implementors/foo/trait.Clone.js
+// @has implementors/foo/Clone.t.js
 // @!has - 'Foo'
 pub use std::clone::Clone;

--- a/src/test/rustdoc/hidden-line.rs
+++ b/src/test/rustdoc/hidden-line.rs
@@ -25,5 +25,5 @@
 /// ```
 pub fn foo() {}
 
-// @!has hidden_line/fn.foo.html invisible
+// @!has hidden_line/foo.v.html invisible
 // @matches - //pre "#\[derive\(PartialEq\)\] // Bar"

--- a/src/test/rustdoc/impl-parts-crosscrate.rs
+++ b/src/test/rustdoc/impl-parts-crosscrate.rs
@@ -22,7 +22,7 @@ pub struct Bar<T> { t: T }
 // full impl string.  Instead, just make sure something from each part
 // is mentioned.
 
-// @has implementors/rustdoc_impl_parts_crosscrate/trait.AnOibit.js Bar
+// @has implementors/rustdoc_impl_parts_crosscrate/AnOibit.t.js Bar
 // @has - Send
 // @has - !AnOibit
 // @has - Copy

--- a/src/test/rustdoc/impl-parts.rs
+++ b/src/test/rustdoc/impl-parts.rs
@@ -16,8 +16,8 @@ impl AnOibit for .. {}
 
 pub struct Foo<T> { field: T }
 
-// @has impl_parts/struct.Foo.html '//*[@class="impl"]//code' \
+// @has impl_parts/Foo.t.html '//*[@class="impl"]//code' \
 //     "impl<T: Clone> !AnOibit for Foo<T> where T: Sync"
-// @has impl_parts/trait.AnOibit.html '//*[@class="item-list"]//code' \
+// @has impl_parts/AnOibit.t.html '//*[@class="item-list"]//code' \
 //     "impl<T: Clone> !AnOibit for Foo<T> where T: Sync"
 impl<T: Clone> !AnOibit for Foo<T> where T: Sync {}

--- a/src/test/rustdoc/inline-default-methods.rs
+++ b/src/test/rustdoc/inline-default-methods.rs
@@ -13,7 +13,7 @@
 
 extern crate inline_default_methods;
 
-// @has inline_default_methods/trait.Foo.html
+// @has inline_default_methods/Foo.t.html
 // @has - '//*[@class="rust trait"]' 'fn bar(&self);'
 // @has - '//*[@class="rust trait"]' 'fn foo(&mut self) { ... }'
 pub use inline_default_methods::Foo;

--- a/src/test/rustdoc/inline_cross/inline_hidden.rs
+++ b/src/test/rustdoc/inline_cross/inline_hidden.rs
@@ -17,6 +17,6 @@ extern crate rustdoc_hidden;
 #[doc(no_inline)]
 pub use rustdoc_hidden::Foo;
 
-// @has inline_hidden/fn.foo.html
+// @has inline_hidden/foo.v.html
 // @!has - '//a/@title' 'Foo'
 pub fn foo(_: Foo) {}

--- a/src/test/rustdoc/inline_cross/issue-28480.rs
+++ b/src/test/rustdoc/inline_cross/issue-28480.rs
@@ -12,12 +12,12 @@
 // build-aux-docs
 // ignore-cross-compile
 
-// @has rustdoc_hidden_sig/struct.Bar.html
+// @has rustdoc_hidden_sig/Bar.t.html
 // @!has -  '//a/@title' 'Hidden'
 // @has -  '//a' 'u8'
 extern crate rustdoc_hidden_sig;
 
-// @has issue_28480/struct.Bar.html
+// @has issue_28480/Bar.t.html
 // @!has -  '//a/@title' 'Hidden'
 // @has -  '//a' 'u8'
 pub use rustdoc_hidden_sig::Bar;

--- a/src/test/rustdoc/inline_cross/issue-31948-1.rs
+++ b/src/test/rustdoc/inline_cross/issue-31948-1.rs
@@ -14,24 +14,24 @@
 
 extern crate rustdoc_nonreachable_impls;
 
-// @has issue_31948_1/struct.Wobble.html
+// @has issue_31948_1/Wobble.t.html
 // @has - '//*[@class="impl"]//code' 'Bark for'
 // @has - '//*[@class="impl"]//code' 'Woof for'
 // @!has - '//*[@class="impl"]//code' 'Bar for'
 // @!has - '//*[@class="impl"]//code' 'Qux for'
 pub use rustdoc_nonreachable_impls::hidden::Wobble;
 
-// @has issue_31948_1/trait.Bark.html
+// @has issue_31948_1/Bark.t.html
 // FIXME(33025): has - '//code' 'for Foo'
 // @has - '//code' 'for Wobble'
 // @!has - '//code' 'for Wibble'
 pub use rustdoc_nonreachable_impls::Bark;
 
-// @has issue_31948_1/trait.Woof.html
+// @has issue_31948_1/Woof.t.html
 // FIXME(33025): has - '//code' 'for Foo'
 // @has - '//code' 'for Wobble'
 // @!has - '//code' 'for Wibble'
 pub use rustdoc_nonreachable_impls::Woof;
 
-// @!has issue_31948_1/trait.Bar.html
-// @!has issue_31948_1/trait.Qux.html
+// @!has issue_31948_1/Bar.t.html
+// @!has issue_31948_1/Qux.t.html

--- a/src/test/rustdoc/inline_cross/issue-31948-2.rs
+++ b/src/test/rustdoc/inline_cross/issue-31948-2.rs
@@ -14,18 +14,18 @@
 
 extern crate rustdoc_nonreachable_impls;
 
-// @has issue_31948_2/struct.Wobble.html
+// @has issue_31948_2/Wobble.t.html
 // @has - '//*[@class="impl"]//code' 'Qux for'
 // @has - '//*[@class="impl"]//code' 'Bark for'
 // @has - '//*[@class="impl"]//code' 'Woof for'
 // @!has - '//*[@class="impl"]//code' 'Bar for'
 pub use rustdoc_nonreachable_impls::hidden::Wobble;
 
-// @has issue_31948_2/trait.Qux.html
+// @has issue_31948_2/Qux.t.html
 // FIXME(33025): has - '//code' 'for Foo'
 // @has - '//code' 'for Wobble'
 pub use rustdoc_nonreachable_impls::hidden::Qux;
 
-// @!has issue_31948_2/trait.Bar.html
-// @!has issue_31948_2/trait.Woof.html
-// @!has issue_31948_2/trait.Bark.html
+// @!has issue_31948_2/Bar.t.html
+// @!has issue_31948_2/Woof.t.html
+// @!has issue_31948_2/Bark.t.html

--- a/src/test/rustdoc/inline_cross/issue-31948.rs
+++ b/src/test/rustdoc/inline_cross/issue-31948.rs
@@ -14,26 +14,26 @@
 
 extern crate rustdoc_nonreachable_impls;
 
-// @has issue_31948/struct.Foo.html
+// @has issue_31948/Foo.t.html
 // @has - '//*[@class="impl"]//code' 'Bark for'
 // @has - '//*[@class="impl"]//code' 'Woof for'
 // @!has - '//*[@class="impl"]//code' 'Bar for'
 // @!has - '//*[@class="impl"]//code' 'Qux for'
 pub use rustdoc_nonreachable_impls::Foo;
 
-// @has issue_31948/trait.Bark.html
+// @has issue_31948/Bark.t.html
 // @has - '//code' 'for Foo'
 // @!has - '//code' 'for Wibble'
 // @!has - '//code' 'for Wobble'
 pub use rustdoc_nonreachable_impls::Bark;
 
-// @has issue_31948/trait.Woof.html
+// @has issue_31948/Woof.t.html
 // @has - '//code' 'for Foo'
 // @!has - '//code' 'for Wibble'
 // @!has - '//code' 'for Wobble'
 pub use rustdoc_nonreachable_impls::Woof;
 
-// @!has issue_31948/trait.Bar.html
-// @!has issue_31948/trait.Qux.html
-// @!has issue_31948/struct.Wibble.html
-// @!has issue_31948/struct.Wobble.html
+// @!has issue_31948/Bar.t.html
+// @!has issue_31948/Qux.t.html
+// @!has issue_31948/Wibble.t.html
+// @!has issue_31948/Wobble.t.html

--- a/src/test/rustdoc/inline_cross/issue-32881.rs
+++ b/src/test/rustdoc/inline_cross/issue-32881.rs
@@ -14,7 +14,7 @@
 
 extern crate rustdoc_trait_object_impl;
 
-// @has issue_32881/trait.Bar.html
+// @has issue_32881/Bar.t.html
 // @has - '//code' "impl<'a> Bar"
 // @has - '//code' "impl<'a> Debug for Bar"
 

--- a/src/test/rustdoc/inline_cross/issue-33113.rs
+++ b/src/test/rustdoc/inline_cross/issue-33113.rs
@@ -14,7 +14,7 @@
 
 extern crate bar;
 
-// @has issue_33113/trait.Bar.html
+// @has issue_33113/Bar.t.html
 // @has - '//code' "for &'a char"
 // @has - '//code' "for Foo"
 pub use bar::Bar;

--- a/src/test/rustdoc/inline_local/issue-28537.rs
+++ b/src/test/rustdoc/inline_local/issue-28537.rs
@@ -20,8 +20,8 @@ mod bar {
     }
 }
 
-// @has issue_28537/struct.Foo.html
+// @has issue_28537/Foo.t.html
 pub use foo::Foo;
 
-// @has issue_28537/struct.Bar.html
+// @has issue_28537/Bar.t.html
 pub use self::bar::Bar;

--- a/src/test/rustdoc/inline_local/issue-32343.rs
+++ b/src/test/rustdoc/inline_local/issue-32343.rs
@@ -8,14 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// @!has issue_32343/struct.Foo.html
+// @!has issue_32343/Foo.t.html
 // @has issue_32343/index.html
 // @has - '//code' 'pub use foo::Foo'
 // @!has - '//code/a' 'Foo'
 #[doc(no_inline)]
 pub use foo::Foo;
 
-// @!has issue_32343/struct.Bar.html
+// @!has issue_32343/Bar.t.html
 // @has issue_32343/index.html
 // @has - '//code' 'pub use foo::Bar'
 // @has - '//code/a' 'Bar'
@@ -27,7 +27,7 @@ mod foo {
     pub struct Bar;
 }
 
-pub mod bar {
-    // @has issue_32343/bar/struct.Bar.html
+pub mod baz {
+    // @has issue_32343/baz/Bar.t.html
     pub use ::foo::Bar;
 }

--- a/src/test/rustdoc/inline_local/please_inline.rs
+++ b/src/test/rustdoc/inline_local/please_inline.rs
@@ -15,7 +15,7 @@ pub mod foo {
 // @has please_inline/a/index.html
 pub mod a {
     // @!has - 'pub use foo::'
-    // @has please_inline/a/struct.Foo.html
+    // @has please_inline/a/Foo.t.html
     #[doc(inline)]
     pub use foo::Foo;
 }
@@ -23,7 +23,7 @@ pub mod a {
 // @has please_inline/b/index.html
 pub mod b {
     // @has - 'pub use foo::'
-    // @!has please_inline/b/struct.Foo.html
+    // @!has please_inline/b/Foo.t.html
     #[feature(inline)]
     pub use foo::Foo;
 }

--- a/src/test/rustdoc/issue-12834.rs
+++ b/src/test/rustdoc/issue-12834.rs
@@ -12,7 +12,7 @@
 // rustdoc to fail, while still rendering the code-block (without highlighting).
 
 
-// @has issue_12834/fn.foo.html
+// @has issue_12834/foo.v.html
 // @has - //pre 'a + b '
 
 /// ```

--- a/src/test/rustdoc/issue-13698.rs
+++ b/src/test/rustdoc/issue-13698.rs
@@ -14,7 +14,7 @@
 extern crate issue_13698;
 
 pub struct Foo;
-// @!has issue_13698/struct.Foo.html '//*[@id="method.foo"]' 'fn foo'
+// @!has issue_13698/Foo.t.html '//*[@id="foo.v"]' 'fn foo'
 impl issue_13698::Foo for Foo {}
 
 pub trait Bar {
@@ -22,5 +22,5 @@ pub trait Bar {
     fn bar(&self) {}
 }
 
-// @!has issue_13698/struct.Foo.html '//*[@id="method.foo"]' 'fn bar'
+// @!has issue_13698/Foo.t.html '//*[@id="foo.v"]' 'fn bar'
 impl Bar for Foo {}

--- a/src/test/rustdoc/issue-15169.rs
+++ b/src/test/rustdoc/issue-15169.rs
@@ -8,6 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// @has issue_15169/struct.Foo.html '//*[@id="method.eq"]' 'fn eq'
+// @has issue_15169/Foo.t.html '//*[@id="eq.v"]' 'fn eq'
 #[derive(PartialEq)]
 pub struct Foo;

--- a/src/test/rustdoc/issue-15318-2.rs
+++ b/src/test/rustdoc/issue-15318-2.rs
@@ -15,8 +15,8 @@ extern crate issue_15318;
 
 pub use issue_15318::ptr;
 
-// @has issue_15318_2/fn.bar.html \
-//          '//*[@href="primitive.pointer.html"]' \
+// @has issue_15318_2/bar.v.html \
+//          '//*[@href="pointer.t.html"]' \
 //          '*mut T'
 pub fn bar<T>(ptr: *mut T) {}
 

--- a/src/test/rustdoc/issue-15318-3.rs
+++ b/src/test/rustdoc/issue-15318-3.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// @has issue_15318_3/primitive.pointer.html
+// @has issue_15318_3/pointer.t.html
 
 /// dox
 #[doc(primitive = "pointer")]

--- a/src/test/rustdoc/issue-15318.rs
+++ b/src/test/rustdoc/issue-15318.rs
@@ -15,7 +15,7 @@
 
 extern crate issue_15318;
 
-// @has issue_15318/fn.bar.html \
-//      '//*[@href="http://example.com/issue_15318/primitive.pointer.html"]' \
+// @has issue_15318/bar.v.html \
+//      '//*[@href="http://example.com/issue_15318/pointer.t.html"]' \
 //      '*mut T'
 pub fn bar<T>(ptr: *mut T) {}

--- a/src/test/rustdoc/issue-15347.rs
+++ b/src/test/rustdoc/issue-15347.rs
@@ -10,6 +10,6 @@
 
 // compile-flags:--no-defaults --passes collapse-docs --passes unindent-comments
 
-// @has issue_15347/fn.foo.html
+// @has issue_15347/foo.v.html
 #[doc(hidden)]
 pub fn foo() {}

--- a/src/test/rustdoc/issue-17476.rs
+++ b/src/test/rustdoc/issue-17476.rs
@@ -15,7 +15,7 @@ extern crate issue_17476;
 
 pub struct Foo;
 
-// @has issue_17476/struct.Foo.html \
-//      '//*[@href="http://example.com/issue_17476/trait.Foo.html#method.foo"]' \
+// @has issue_17476/Foo.t.html \
+//      '//*[@href="http://example.com/issue_17476/Foo.t.html#foo.v"]' \
 //      'foo'
 impl issue_17476::Foo for Foo {}

--- a/src/test/rustdoc/issue-19055.rs
+++ b/src/test/rustdoc/issue-19055.rs
@@ -8,17 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// @has issue_19055/trait.Any.html
+// @has issue_19055/Any.t.html
 pub trait Any {}
 
 impl<'any> Any + 'any {
-    // @has - '//*[@id="method.is"]' 'fn is'
+    // @has - '//*[@id="is.v"]' 'fn is'
     pub fn is<T: 'static>(&self) -> bool { loop {} }
 
-    // @has - '//*[@id="method.downcast_ref"]' 'fn downcast_ref'
+    // @has - '//*[@id="downcast_ref.v"]' 'fn downcast_ref'
     pub fn downcast_ref<T: 'static>(&self) -> Option<&T> { loop {} }
 
-    // @has - '//*[@id="method.downcast_mut"]' 'fn downcast_mut'
+    // @has - '//*[@id="downcast_mut.v"]' 'fn downcast_mut'
     pub fn downcast_mut<T: 'static>(&mut self) -> Option<&mut T> { loop {} }
 }
 
@@ -26,5 +26,5 @@ pub trait Foo {
     fn foo(&self) {}
 }
 
-// @has - '//*[@id="method.foo"]' 'fn foo'
+// @has - '//*[@id="foo.v"]' 'fn foo'
 impl Foo for Any {}

--- a/src/test/rustdoc/issue-19190-2.rs
+++ b/src/test/rustdoc/issue-19190-2.rs
@@ -17,6 +17,6 @@ impl Deref for Bar {
     fn deref(&self) -> &i32 { loop {} }
 }
 
-// @has issue_19190_2/struct.Bar.html
-// @has - '//*[@id="method.count_ones"]' 'fn count_ones(self) -> u32'
-// @!has - '//*[@id="method.min_value"]' 'fn min_value() -> i32'
+// @has issue_19190_2/Bar.t.html
+// @has - '//*[@id="count_ones.v"]' 'fn count_ones(self) -> u32'
+// @!has - '//*[@id="min_value.v"]' 'fn min_value() -> i32'

--- a/src/test/rustdoc/issue-19190-3.rs
+++ b/src/test/rustdoc/issue-19190-3.rs
@@ -16,19 +16,19 @@ extern crate issue_19190_3;
 use std::ops::Deref;
 use issue_19190_3::Baz;
 
-// @has issue_19190_3/struct.Foo.html
-// @has - '//*[@id="method.count_ones"]' 'fn count_ones(self) -> u32'
-// @!has - '//*[@id="method.min_value"]' 'fn min_value() -> i32'
+// @has issue_19190_3/Foo.t.html
+// @has - '//*[@id="count_ones.v"]' 'fn count_ones(self) -> u32'
+// @!has - '//*[@id="min_value.v"]' 'fn min_value() -> i32'
 pub use issue_19190_3::Foo;
 
-// @has issue_19190_3/struct.Bar.html
-// @has - '//*[@id="method.baz"]' 'fn baz(&self)'
-// @!has - '//*[@id="method.static_baz"]' 'fn static_baz()'
+// @has issue_19190_3/Bar.t.html
+// @has - '//*[@id="baz.v"]' 'fn baz(&self)'
+// @!has - '//*[@id="static_baz.v"]' 'fn static_baz()'
 pub use issue_19190_3::Bar;
 
-// @has issue_19190_3/struct.MyBar.html
-// @has - '//*[@id="method.baz"]' 'fn baz(&self)'
-// @!has - '//*[@id="method.static_baz"]' 'fn static_baz()'
+// @has issue_19190_3/MyBar.t.html
+// @has - '//*[@id="baz.v"]' 'fn baz(&self)'
+// @!has - '//*[@id="static_baz.v"]' 'fn static_baz()'
 pub struct MyBar;
 
 impl Deref for MyBar {

--- a/src/test/rustdoc/issue-19190.rs
+++ b/src/test/rustdoc/issue-19190.rs
@@ -23,6 +23,6 @@ impl Deref for Bar {
     fn deref(&self) -> &Foo { loop {} }
 }
 
-// @has issue_19190/struct.Bar.html
-// @has - '//*[@id="method.foo"]' 'fn foo(&self)'
-// @!has - '//*[@id="method.static_foo"]' 'fn static_foo()'
+// @has issue_19190/Bar.t.html
+// @has - '//*[@id="foo.v"]' 'fn foo(&self)'
+// @!has - '//*[@id="static_foo.v"]' 'fn static_foo()'

--- a/src/test/rustdoc/issue-20175.rs
+++ b/src/test/rustdoc/issue-20175.rs
@@ -14,7 +14,7 @@ pub trait Foo {
 
 pub struct Bar;
 
-// @has issue_20175/struct.Bar.html \
-//      '//*[@id="method.foo"]' \
+// @has issue_20175/Bar.t.html \
+//      '//*[@id="foo.v"]' \
 //      'fn foo'
 impl<'a> Foo for &'a Bar {}

--- a/src/test/rustdoc/issue-20646.rs
+++ b/src/test/rustdoc/issue-20646.rs
@@ -15,22 +15,22 @@
 
 extern crate issue_20646;
 
-// @has issue_20646/trait.Trait.html \
-//      '//*[@id="associatedtype.Output"]' \
+// @has issue_20646/Trait.t.html \
+//      '//*[@id="Output.t"]' \
 //      'type Output'
 pub trait Trait {
     type Output;
 }
 
-// @has issue_20646/fn.fun.html \
+// @has issue_20646/fun.v.html \
 //      '//*[@class="rust fn"]' 'where T: Trait<Output=i32>'
 pub fn fun<T>(_: T) where T: Trait<Output=i32> {}
 
 pub mod reexport {
-    // @has issue_20646/reexport/trait.Trait.html \
-    //      '//*[@id="associatedtype.Output"]' \
+    // @has issue_20646/reexport/Trait.t.html \
+    //      '//*[@id="Output.t"]' \
     //      'type Output'
-    // @has issue_20646/reexport/fn.fun.html \
+    // @has issue_20646/reexport/fun.v.html \
     //      '//*[@class="rust fn"]' 'where T: Trait<Output=i32>'
     pub use issue_20646::{Trait, fun};
 }

--- a/src/test/rustdoc/issue-20727-2.rs
+++ b/src/test/rustdoc/issue-20727-2.rs
@@ -13,7 +13,7 @@
 
 extern crate issue_20727;
 
-// @has issue_20727_2/trait.Add.html
+// @has issue_20727_2/Add.t.html
 pub trait Add<RHS = Self> {
     // @has - '//*[@class="rust trait"]' 'trait Add<RHS = Self> {'
     // @has - '//*[@class="rust trait"]' 'type Output;'
@@ -23,7 +23,7 @@ pub trait Add<RHS = Self> {
     fn add(self, rhs: RHS) -> Self::Output;
 }
 
-// @has issue_20727_2/reexport/trait.Add.html
+// @has issue_20727_2/reexport/Add.t.html
 pub mod reexport {
     // @has - '//*[@class="rust trait"]' 'trait Add<RHS = Self> {'
     // @has - '//*[@class="rust trait"]' 'type Output;'

--- a/src/test/rustdoc/issue-20727-3.rs
+++ b/src/test/rustdoc/issue-20727-3.rs
@@ -15,7 +15,7 @@ extern crate issue_20727;
 
 pub trait Bar {}
 
-// @has issue_20727_3/trait.Deref2.html
+// @has issue_20727_3/Deref2.t.html
 pub trait Deref2 {
     // @has - '//*[@class="rust trait"]' 'trait Deref2 {'
     // @has - '//*[@class="rust trait"]' 'type Target: Bar;'
@@ -25,7 +25,7 @@ pub trait Deref2 {
     fn deref(&self) -> Self::Target;
 }
 
-// @has issue_20727_3/reexport/trait.Deref2.html
+// @has issue_20727_3/reexport/Deref2.t.html
 pub mod reexport {
     // @has - '//*[@class="rust trait"]' 'trait Deref2 {'
     // @has - '//*[@class="rust trait"]' 'type Target: Bar;'

--- a/src/test/rustdoc/issue-20727-4.rs
+++ b/src/test/rustdoc/issue-20727-4.rs
@@ -13,7 +13,7 @@
 
 extern crate issue_20727;
 
-// @has issue_20727_4/trait.Index.html
+// @has issue_20727_4/Index.t.html
 pub trait Index<Idx: ?Sized> {
     // @has - '//*[@class="rust trait"]' 'trait Index<Idx: ?Sized> {'
     // @has - '//*[@class="rust trait"]' 'type Output: ?Sized'
@@ -24,7 +24,7 @@ pub trait Index<Idx: ?Sized> {
     fn index(&self, index: Idx) -> &Self::Output;
 }
 
-// @has issue_20727_4/trait.IndexMut.html
+// @has issue_20727_4/IndexMut.t.html
 pub trait IndexMut<Idx: ?Sized>: Index<Idx> {
     // @has - '//*[@class="rust trait"]' \
     //        'trait IndexMut<Idx: ?Sized>: Index<Idx> {'
@@ -34,14 +34,14 @@ pub trait IndexMut<Idx: ?Sized>: Index<Idx> {
 }
 
 pub mod reexport {
-    // @has issue_20727_4/reexport/trait.Index.html
+    // @has issue_20727_4/reexport/Index.t.html
     // @has - '//*[@class="rust trait"]' 'trait Index<Idx> where Idx: ?Sized {'
     // @has - '//*[@class="rust trait"]' 'type Output: ?Sized'
     // @has - '//*[@class="rust trait"]' \
     //        'fn index(&self, index: Idx) -> &Self::Output'
     pub use issue_20727::Index;
 
-    // @has issue_20727_4/reexport/trait.IndexMut.html
+    // @has issue_20727_4/reexport/IndexMut.t.html
     // @has - '//*[@class="rust trait"]' \
     //        'trait IndexMut<Idx>: Index<Idx> where Idx: ?Sized {'
     // @has - '//*[@class="rust trait"]' \

--- a/src/test/rustdoc/issue-20727.rs
+++ b/src/test/rustdoc/issue-20727.rs
@@ -13,7 +13,7 @@
 
 extern crate issue_20727;
 
-// @has issue_20727/trait.Deref.html
+// @has issue_20727/Deref.t.html
 pub trait Deref {
     // @has - '//*[@class="rust trait"]' 'trait Deref {'
     // @has - '//*[@class="rust trait"]' 'type Target: ?Sized;'
@@ -24,7 +24,7 @@ pub trait Deref {
     fn deref<'a>(&'a self) -> &'a Self::Target;
 }
 
-// @has issue_20727/reexport/trait.Deref.html
+// @has issue_20727/reexport/Deref.t.html
 pub mod reexport {
     // @has - '//*[@class="rust trait"]' 'trait Deref {'
     // @has - '//*[@class="rust trait"]' 'type Target: ?Sized;'

--- a/src/test/rustdoc/issue-21092.rs
+++ b/src/test/rustdoc/issue-21092.rs
@@ -13,6 +13,6 @@
 
 extern crate issue_21092;
 
-// @has issue_21092/struct.Bar.html
-// @has - '//*[@id="associatedtype.Bar"]' 'type Bar = i32'
+// @has issue_21092/Bar.t.html
+// @has - '//*[@id="Bar.t"]' 'type Bar = i32'
 pub use issue_21092::{Foo, Bar};

--- a/src/test/rustdoc/issue-21474.rs
+++ b/src/test/rustdoc/issue-21474.rs
@@ -16,6 +16,6 @@ mod inner {
 
 pub trait Blah { }
 
-// @count issue_21474/struct.What.html \
+// @count issue_21474/What.t.html \
 //        '//*[@class="impl"]' 1
 pub struct What;

--- a/src/test/rustdoc/issue-21801.rs
+++ b/src/test/rustdoc/issue-21801.rs
@@ -13,7 +13,7 @@
 
 extern crate issue_21801;
 
-// @has issue_21801/struct.Foo.html
-// @has - '//*[@id="method.new"]' \
+// @has issue_21801/Foo.t.html
+// @has - '//*[@id="new.v"]' \
 //        'fn new<F>(f: F) -> Foo where F: FnMut() -> i32'
 pub use issue_21801::Foo;

--- a/src/test/rustdoc/issue-22038.rs
+++ b/src/test/rustdoc/issue-22038.rs
@@ -9,21 +9,21 @@
 // except according to those terms.
 
 extern {
-    // @has issue_22038/fn.foo1.html \
+    // @has issue_22038/foo1.v.html \
     //      '//*[@class="rust fn"]' 'pub unsafe extern fn foo1()'
     pub fn foo1();
 }
 
 extern "system" {
-    // @has issue_22038/fn.foo2.html \
+    // @has issue_22038/foo2.v.html \
     //      '//*[@class="rust fn"]' 'pub unsafe extern "system" fn foo2()'
     pub fn foo2();
 }
 
-// @has issue_22038/fn.bar.html \
+// @has issue_22038/bar.v.html \
 //      '//*[@class="rust fn"]' 'pub extern fn bar()'
 pub extern fn bar() {}
 
-// @has issue_22038/fn.baz.html \
+// @has issue_22038/baz.v.html \
 //      '//*[@class="rust fn"]' 'pub extern "system" fn baz()'
 pub extern "system" fn baz() {}

--- a/src/test/rustdoc/issue-25001.rs
+++ b/src/test/rustdoc/issue-25001.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// @has issue_25001/struct.Foo.html
+// @has issue_25001/Foo.t.html
 pub struct Foo<T>(T);
 
 pub trait Bar {
@@ -18,36 +18,36 @@ pub trait Bar {
 }
 
 impl Foo<u8> {
-    // @has - '//*[@id="method.pass"]//code' 'fn pass()'
+    // @has - '//*[@id="pass.v"]//code' 'fn pass()'
     pub fn pass() {}
 }
 impl Foo<u16> {
-    // @has - '//*[@id="method.pass-1"]//code' 'fn pass() -> usize'
+    // @has - '//*[@id="pass.v-1"]//code' 'fn pass() -> usize'
     pub fn pass() -> usize { 42 }
 }
 impl Foo<u32> {
-    // @has - '//*[@id="method.pass-2"]//code' 'fn pass() -> isize'
+    // @has - '//*[@id="pass.v-2"]//code' 'fn pass() -> isize'
     pub fn pass() -> isize { 42 }
 }
 
 impl<T> Bar for Foo<T> {
-    // @has - '//*[@id="associatedtype.Item"]//code' 'type Item = T'
+    // @has - '//*[@id="Item.t"]//code' 'type Item = T'
     type Item=T;
 
-    // @has - '//*[@id="method.quux"]//code' 'fn quux(self)'
+    // @has - '//*[@id="quux.v"]//code' 'fn quux(self)'
     fn quux(self) {}
 }
 impl<'a, T> Bar for &'a Foo<T> {
-    // @has - '//*[@id="associatedtype.Item-1"]//code' "type Item = &'a T"
+    // @has - '//*[@id="Item.t-1"]//code' "type Item = &'a T"
     type Item=&'a T;
 
-    // @has - '//*[@id="method.quux-1"]//code' 'fn quux(self)'
+    // @has - '//*[@id="quux.v-1"]//code' 'fn quux(self)'
     fn quux(self) {}
 }
 impl<'a, T> Bar for &'a mut Foo<T> {
-    // @has - '//*[@id="associatedtype.Item-2"]//code' "type Item = &'a mut T"
+    // @has - '//*[@id="Item.t-2"]//code' "type Item = &'a mut T"
     type Item=&'a mut T;
 
-    // @has - '//*[@id="method.quux-2"]//code' 'fn quux(self)'
+    // @has - '//*[@id="quux.v-2"]//code' 'fn quux(self)'
     fn quux(self) {}
 }

--- a/src/test/rustdoc/issue-26606.rs
+++ b/src/test/rustdoc/issue-26606.rs
@@ -12,10 +12,10 @@
 // ignore-cross-compile
 // build-aux-docs
 
-// @has issue_26606_macro/macro.make_item!.html
+// @has issue_26606_macro/make_item.m.html
 #[macro_use]
 extern crate issue_26606_macro;
 
-// @has issue_26606/constant.FOO.html
+// @has issue_26606/FOO.v.html
 // @!has - '//a/@href' '../src/'
 make_item!(FOO);

--- a/src/test/rustdoc/issue-27759.rs
+++ b/src/test/rustdoc/issue-27759.rs
@@ -18,7 +18,7 @@
 // @has - '<a href="http://issue_url/27759">#27759</a>'
 #[unstable(feature="test", issue="27759")]
 pub mod unstable {
-    // @has issue_27759/unstable/fn.issue.html
+    // @has issue_27759/unstable/issue.v.html
     // @has - '<code>test_function</code>'
     // @has - '<a href="http://issue_url/1234567890">#1234567890</a>'
     #[unstable(feature="test_function", issue="1234567890")]

--- a/src/test/rustdoc/issue-27862.rs
+++ b/src/test/rustdoc/issue-27862.rs
@@ -12,4 +12,4 @@
 /// Test  | Table
 /// ------|-------------
 /// t = b | id = \|x\| x
-pub struct Foo; // @has issue_27862/struct.Foo.html //td 'id = |x| x'
+pub struct Foo; // @has issue_27862/Foo.t.html //td 'id = |x| x'

--- a/src/test/rustdoc/issue-28478.rs
+++ b/src/test/rustdoc/issue-28478.rs
@@ -11,32 +11,32 @@
 #![feature(associated_type_defaults)]
 #![feature(associated_consts)]
 
-// @has issue_28478/trait.Bar.html
+// @has issue_28478/Bar.t.html
 pub trait Bar {
-    // @has - '//*[@id="associatedtype.Bar"]' 'type Bar = ()'
-    // @has - '//*[@href="#associatedtype.Bar"]' 'Bar'
+    // @has - '//*[@id="Bar.t"]' 'type Bar = ()'
+    // @has - '//*[@href="#Bar.t"]' 'Bar'
     type Bar = ();
-    // @has - '//*[@id="associatedconstant.Baz"]' 'const Baz: usize = 7'
-    // @has - '//*[@href="#associatedconstant.Baz"]' 'Baz'
+    // @has - '//*[@id="Baz.v"]' 'const Baz: usize = 7'
+    // @has - '//*[@href="#Baz.v"]' 'Baz'
     const Baz: usize = 7;
-    // @has - '//*[@id="tymethod.bar"]' 'fn bar'
+    // @has - '//*[@id="bar.v"]' 'fn bar'
     fn bar();
-    // @has - '//*[@id="method.baz"]' 'fn baz'
+    // @has - '//*[@id="baz.v"]' 'fn baz'
     fn baz() { }
 }
 
-// @has issue_28478/struct.Foo.html
+// @has issue_28478/Foo.t.html
 pub struct Foo;
 
 impl Foo {
-    // @has - '//*[@href="#method.foo"]' 'foo'
+    // @has - '//*[@href="#foo.v"]' 'foo'
     pub fn foo() {}
 }
 
 impl Bar for Foo {
-    // @has - '//*[@href="../issue_28478/trait.Bar.html#associatedtype.Bar"]' 'Bar'
-    // @has - '//*[@href="../issue_28478/trait.Bar.html#associatedconstant.Baz"]' 'Baz'
-    // @has - '//*[@href="../issue_28478/trait.Bar.html#tymethod.bar"]' 'bar'
+    // @has - '//*[@href="../issue_28478/Bar.t.html#Bar.t"]' 'Bar'
+    // @has - '//*[@href="../issue_28478/Bar.t.html#Baz.v"]' 'Baz'
+    // @has - '//*[@href="../issue_28478/Bar.t.html#bar.v"]' 'bar'
     fn bar() {}
-    // @has - '//*[@href="../issue_28478/trait.Bar.html#method.baz"]' 'baz'
+    // @has - '//*[@href="../issue_28478/Bar.t.html#baz.v"]' 'baz'
 }

--- a/src/test/rustdoc/issue-29449.rs
+++ b/src/test/rustdoc/issue-29449.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// @has issue_29449/struct.Foo.html
+// @has issue_29449/Foo.t.html
 pub struct Foo;
 
 impl Foo {

--- a/src/test/rustdoc/issue-29503.rs
+++ b/src/test/rustdoc/issue-29503.rs
@@ -10,7 +10,7 @@
 
 use std::fmt;
 
-// @has issue_29503/trait.MyTrait.html
+// @has issue_29503/MyTrait.t.html
 pub trait MyTrait {
     fn my_string(&self) -> String;
 }

--- a/src/test/rustdoc/issue-29584.rs
+++ b/src/test/rustdoc/issue-29584.rs
@@ -13,6 +13,6 @@
 
 extern crate issue_29584;
 
-// @has issue_29584/struct.Foo.html
+// @has issue_29584/Foo.t.html
 // @!has - 'impl Bar for'
 pub use issue_29584::Foo;

--- a/src/test/rustdoc/issue-30109.rs
+++ b/src/test/rustdoc/issue-30109.rs
@@ -18,7 +18,7 @@ pub mod quux {
 
     pub trait Foo {}
 
-    // @has issue_30109/quux/trait.Foo.html \
-    //          '//a/@href' '../issue_30109_1/struct.Bar.html'
+    // @has issue_30109/quux/Foo.t.html \
+    //          '//a/@href' '../issue_30109_1/Bar.t.html'
     impl Foo for Bar {}
 }

--- a/src/test/rustdoc/issue-32374.rs
+++ b/src/test/rustdoc/issue-32374.rs
@@ -16,7 +16,7 @@
 // @has issue_32374/index.html '//*[@class="docblock short"]' \
 //      '[Deprecated] [Unstable]'
 
-// @has issue_32374/struct.T.html '//*[@class="stab deprecated"]' \
+// @has issue_32374/T.t.html '//*[@class="stab deprecated"]' \
 //      'Deprecated since 1.0.0: text'
 // @has - '<code>test</code>'
 // @has - '<a href="http://issue_url/32374">#32374</a>'

--- a/src/test/rustdoc/issue-32395.rs
+++ b/src/test/rustdoc/issue-32395.rs
@@ -12,12 +12,12 @@
 // build-aux-docs
 // ignore-cross-compile
 
-// @has variant_struct/enum.Foo.html
+// @has variant_struct/Foo.t.html
 // @!has - 'pub qux'
 // @!has - 'pub Bar'
 extern crate variant_struct;
 
-// @has issue_32395/enum.Foo.html
+// @has issue_32395/Foo.t.html
 // @!has - 'pub qux'
 // @!has - 'pub Bar'
 pub use variant_struct::Foo;

--- a/src/test/rustdoc/issue-32890.rs
+++ b/src/test/rustdoc/issue-32890.rs
@@ -1,3 +1,4 @@
+
 // Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
@@ -8,20 +9,20 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// @has issue_32890/struct.Foo.html
+// @has issue_32890/Foo.t.html
 pub struct Foo<T>(T);
 
 impl Foo<u8> {
-    // @has - '//a[@href="#method.pass"]' 'pass'
+    // @has - '//a[@href="#pass.v"]' 'pass'
     pub fn pass() {}
 }
 
 impl Foo<u16> {
-    // @has - '//a[@href="#method.pass-1"]' 'pass'
+    // @has - '//a[@href="#pass.v-1"]' 'pass'
     pub fn pass() {}
 }
 
 impl Foo<u32> {
-    // @has - '//a[@href="#method.pass-2"]' 'pass'
+    // @has - '//a[@href="#pass.v-2"]' 'pass'
     pub fn pass() {}
 }

--- a/src/test/rustdoc/issue-33069.rs
+++ b/src/test/rustdoc/issue-33069.rs
@@ -15,6 +15,6 @@ pub mod hidden {
     pub struct Foo;
 }
 
-// @has issue_33069/trait.Bar.html
+// @has issue_33069/Bar.t.html
 // @!has - '//code' 'impl Bar for Foo'
 impl Bar for hidden::Foo {}

--- a/src/test/rustdoc/issue-33302.rs
+++ b/src/test/rustdoc/issue-33302.rs
@@ -17,26 +17,26 @@ macro_rules! make {
     ($n:expr) => {
         pub struct S;
 
-        // @has issue_33302/constant.CST.html \
+        // @has issue_33302/CST.v.html \
         //        '//pre[@class="rust const"]' 'pub const CST: i32 = 4 * 4'
         pub const CST: i32 = ($n * $n);
-        // @has issue_33302/static.ST.html \
+        // @has issue_33302/ST.v.html \
         //        '//pre[@class="rust static"]' 'pub static ST: i32 = 4 * 4'
         pub static ST: i32 = ($n * $n);
 
         pub trait T<X> {
             fn ignore(_: &X) {}
             const C: X;
-            // @has issue_33302/trait.T.html \
+            // @has issue_33302/T.t.html \
             //        '//*[@class="rust trait"]' 'const D: i32 = 4 * 4;'
-            // @has - '//*[@id="associatedconstant.D"]' 'const D: i32 = 4 * 4'
+            // @has - '//*[@id="D.v"]' 'const D: i32 = 4 * 4'
             const D: i32 = ($n * $n);
         }
 
-        // @has issue_33302/struct.S.html \
+        // @has issue_33302/S.t.html \
         //        '//h3[@class="impl"]' 'impl T<[i32; 16]> for S'
-        // @has - '//*[@id="associatedconstant.C"]' 'const C: [i32; 16] = [0; 4 * 4]'
-        // @has - '//*[@id="associatedconstant.D"]' 'const D: i32 = 4 * 4'
+        // @has - '//*[@id="C.v"]' 'const C: [i32; 16] = [0; 4 * 4]'
+        // @has - '//*[@id="D.v"]' 'const D: i32 = 4 * 4'
         impl T<[i32; ($n * $n)]> for S {
             const C: [i32; ($n * $n)] = [0; ($n * $n)];
         }

--- a/src/test/rustdoc/issue-33592.rs
+++ b/src/test/rustdoc/issue-33592.rs
@@ -16,8 +16,8 @@ pub struct Bar;
 
 pub struct Baz;
 
-// @has foo/trait.Foo.html '//code' 'impl Foo<i32> for Bar'
+// @has foo/Foo.t.html '//code' 'impl Foo<i32> for Bar'
 impl Foo<i32> for Bar {}
 
-// @has foo/trait.Foo.html '//code' 'impl<T> Foo<T> for Baz'
+// @has foo/Foo.t.html '//code' 'impl<T> Foo<T> for Baz'
 impl<T> Foo<T> for Baz {}

--- a/src/test/rustdoc/issue-34274.rs
+++ b/src/test/rustdoc/issue-34274.rs
@@ -16,5 +16,5 @@
 
 extern crate issue_34274;
 
-// @has foo/fn.extern_c_fn.html '//a/@href' '../issue_34274/fn.extern_c_fn.html?gotosrc='
+// @has foo/extern_c_fn.v.html '//a/@href' '../issue_34274/extern_c_fn.v.html?gotosrc='
 pub use issue_34274::extern_c_fn;

--- a/src/test/rustdoc/issue-34928.rs
+++ b/src/test/rustdoc/issue-34928.rs
@@ -12,5 +12,5 @@
 
 pub trait Bar {}
 
-// @has foo/struct.Foo.html '//pre' 'pub struct Foo<T>(pub T) where T: Bar;'
+// @has foo/Foo.t.html '//pre' 'pub struct Foo<T>(pub T) where T: Bar;'
 pub struct Foo<T>(pub T) where T: Bar;

--- a/src/test/rustdoc/macros.rs
+++ b/src/test/rustdoc/macros.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// @has macros/macro.my_macro!.html //pre 'macro_rules! my_macro {'
+// @has macros/my_macro.m.html //pre 'macro_rules! my_macro {'
 // @has - //pre '() => { ... };'
 // @has - //pre '($a:tt) => { ... };'
 // @has - //pre '($e:expr) => { ... };'

--- a/src/test/rustdoc/manual_impl.rs
+++ b/src/test/rustdoc/manual_impl.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// @has manual_impl/trait.T.html
+// @has manual_impl/T.t.html
 // @has  - '//*[@class="docblock"]' 'Docs associated with the trait definition.'
 // @has  - '//*[@class="docblock"]' 'Docs associated with the trait a_method definition.'
 // @has  - '//*[@class="docblock"]' 'Docs associated with the trait b_method definition.'
@@ -30,7 +30,7 @@ pub trait T {
     }
 }
 
-// @has manual_impl/struct.S1.html '//*[@class="trait"]' 'T'
+// @has manual_impl/S1.t.html '//*[@class="trait"]' 'T'
 // @has  - '//*[@class="docblock"]' 'Docs associated with the S1 trait implementation.'
 // @has  - '//*[@class="docblock"]' 'Docs associated with the S1 trait a_method implementation.'
 // @!has - '//*[@class="docblock"]' 'Docs associated with the trait a_method definition.'
@@ -49,7 +49,7 @@ impl T for S1 {
     }
 }
 
-// @has manual_impl/struct.S2.html '//*[@class="trait"]' 'T'
+// @has manual_impl/S2.t.html '//*[@class="trait"]' 'T'
 // @has  - '//*[@class="docblock"]' 'Docs associated with the S2 trait implementation.'
 // @has  - '//*[@class="docblock"]' 'Docs associated with the S2 trait a_method implementation.'
 // @has  - '//*[@class="docblock"]' 'Docs associated with the S2 trait c_method implementation.'
@@ -72,7 +72,7 @@ impl T for S2 {
     }
 }
 
-// @has manual_impl/struct.S3.html '//*[@class="trait"]' 'T'
+// @has manual_impl/S3.t.html '//*[@class="trait"]' 'T'
 // @has  - '//*[@class="docblock"]' 'Docs associated with the S3 trait implementation.'
 // @has  - '//*[@class="docblock"]' 'Docs associated with the S3 trait b_method implementation.'
 // @has - '//*[@class="docblock"]' 'Docs associated with the trait a_method definition.'

--- a/src/test/rustdoc/must-use.rs
+++ b/src/test/rustdoc/must-use.rs
@@ -8,13 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// @has must_use/struct.Struct.html //pre '#[must_use]'
+// @has must_use/Struct.t.html //pre '#[must_use]'
 #[must_use]
 pub struct Struct {
     field: i32,
 }
 
-// @has must_use/enum.Enum.html //pre '#[must_use = "message"]'
+// @has must_use/Enum.t.html //pre '#[must_use = "message"]'
 #[must_use = "message"]
 pub enum Enum {
     Variant(i32),

--- a/src/test/rustdoc/negative-impl.rs
+++ b/src/test/rustdoc/negative-impl.rs
@@ -10,13 +10,13 @@
 
 #![feature(optin_builtin_traits)]
 
-// @matches negative_impl/struct.Alpha.html '//pre' "pub struct Alpha"
+// @matches negative_impl/Alpha.t.html '//pre' "pub struct Alpha"
 pub struct Alpha;
-// @matches negative_impl/struct.Bravo.html '//pre' "pub struct Bravo<B>"
+// @matches negative_impl/Bravo.t.html '//pre' "pub struct Bravo<B>"
 pub struct Bravo<B>(B);
 
-// @matches negative_impl/struct.Alpha.html '//*[@class="impl"]//code' "impl !Send for Alpha"
+// @matches negative_impl/Alpha.t.html '//*[@class="impl"]//code' "impl !Send for Alpha"
 impl !Send for Alpha {}
 
-// @matches negative_impl/struct.Bravo.html '//*[@class="impl"]//code' "impl<B> !Send for Bravo<B>"
+// @matches negative_impl/Bravo.t.html '//*[@class="impl"]//code' "impl<B> !Send for Bravo<B>"
 impl<B> !Send for Bravo<B> {}

--- a/src/test/rustdoc/prim-title.rs
+++ b/src/test/rustdoc/prim-title.rs
@@ -10,7 +10,7 @@
 
 #![crate_name = "foo"]
 
-// @has foo/primitive.u8.html '//head/title' 'u8 - Rust'
+// @has foo/u8.t.html '//head/title' 'u8 - Rust'
 // @!has - '//head/title' 'foo'
 #[doc(primitive = "u8")]
 /// `u8` docs

--- a/src/test/rustdoc/redirect-const.rs
+++ b/src/test/rustdoc/redirect-const.rs
@@ -14,10 +14,10 @@ pub use hidden::STATIC_FOO;
 pub use hidden::CONST_FOO;
 
 mod hidden {
-    // @has foo/hidden/static.STATIC_FOO.html
-    // @has - '//p/a' '../../foo/static.STATIC_FOO.html'
+    // @has foo/hidden/STATIC_FOO.v.html
+    // @has - '//p/a' '../../foo/STATIC_FOO.v.html'
     pub static STATIC_FOO: u64 = 0;
-    // @has foo/hidden/constant.CONST_FOO.html
-    // @has - '//p/a' '../../foo/constant.CONST_FOO.html'
+    // @has foo/hidden/CONST_FOO.v.html
+    // @has - '//p/a' '../../foo/CONST_FOO.v.html'
     pub const CONST_FOO: u64 = 0;
 }

--- a/src/test/rustdoc/redirect-rename.rs
+++ b/src/test/rustdoc/redirect-rename.rs
@@ -11,22 +11,22 @@
 #![crate_name = "foo"]
 
 mod hidden {
-    // @has foo/hidden/struct.Foo.html
-    // @has - '//p/a' '../../foo/struct.FooBar.html'
+    // @has foo/hidden/Foo.t.html
+    // @has - '//p/a' '../../foo/FooBar.t.html'
     pub struct Foo {}
 
     // @has foo/hidden/bar/index.html
     // @has - '//p/a' '../../foo/baz/index.html'
     pub mod bar {
-        // @has foo/hidden/bar/struct.Thing.html
-        // @has - '//p/a' '../../foo/baz/struct.Thing.html'
+        // @has foo/hidden/bar/Thing.t.html
+        // @has - '//p/a' '../../foo/baz/Thing.t.html'
         pub struct Thing {}
     }
 }
 
-// @has foo/struct.FooBar.html
+// @has foo/FooBar.t.html
 pub use hidden::Foo as FooBar;
 
 // @has foo/baz/index.html
-// @has foo/baz/struct.Thing.html
+// @has foo/baz/Thing.t.html
 pub use hidden::bar as baz;

--- a/src/test/rustdoc/redirect.rs
+++ b/src/test/rustdoc/redirect.rs
@@ -19,9 +19,9 @@ pub trait Foo {}
 // @has redirect/index.html
 // @has - '//code' 'pub use reexp_stripped::Bar'
 // @has - '//code/a' 'Bar'
-// @has reexp_stripped/hidden/struct.Bar.html
-// @has - '//p/a' '../../reexp_stripped/struct.Bar.html'
-// @has 'reexp_stripped/struct.Bar.html'
+// @has reexp_stripped/hidden/Bar.t.html
+// @has - '//p/a' '../../reexp_stripped/Bar.t.html'
+// @has 'reexp_stripped/Bar.t.html'
 #[doc(no_inline)]
 pub use reexp_stripped::Bar;
 impl Foo for Bar {}
@@ -29,9 +29,9 @@ impl Foo for Bar {}
 // @has redirect/index.html
 // @has - '//code' 'pub use reexp_stripped::Quz'
 // @has - '//code/a' 'Quz'
-// @has reexp_stripped/private/struct.Quz.html
-// @has - '//p/a' '../../reexp_stripped/struct.Quz.html'
-// @has 'reexp_stripped/struct.Quz.html'
+// @has reexp_stripped/private/Quz.t.html
+// @has - '//p/a' '../../reexp_stripped/Quz.t.html'
+// @has 'reexp_stripped/Quz.t.html'
 #[doc(no_inline)]
 pub use reexp_stripped::Quz;
 impl Foo for Quz {}

--- a/src/test/rustdoc/smoke.rs
+++ b/src/test/rustdoc/smoke.rs
@@ -19,17 +19,17 @@ pub mod bar {
     // @has smoke/bar/baz/index.html
     pub mod baz {
         /// Much detail
-        // @has smoke/bar/baz/fn.baz.html
+        // @has smoke/bar/baz/baz.v.html
         pub fn baz() { }
     }
 
     /// *wow*
-    // @has smoke/bar/trait.Doge.html
+    // @has smoke/bar/Doge.t.html
     pub trait Doge { fn dummy(&self) { } }
 
-    // @has smoke/bar/struct.Foo.html
+    // @has smoke/bar/Foo.t.html
     pub struct Foo { x: isize, y: usize }
 
-    // @has smoke/bar/fn.prawns.html
+    // @has smoke/bar/prawns.v.html
     pub fn prawns((a, b): (isize, usize), Foo { x, y }: Foo) { }
 }

--- a/src/test/rustdoc/src-links-external.rs
+++ b/src/test/rustdoc/src-links-external.rs
@@ -19,4 +19,4 @@ extern crate src_links_external;
 // @has foo/bar/index.html '//a/@href' '../src_links_external/index.html?gotosrc='
 pub use src_links_external as bar;
 
-// @has foo/bar/struct.Foo.html '//a/@href' '../src_links_external/struct.Foo.html?gotosrc='
+// @has foo/bar/Foo.t.html '//a/@href' '../src_links_external/Foo.t.html?gotosrc='

--- a/src/test/rustdoc/src-links.rs
+++ b/src/test/rustdoc/src-links.rs
@@ -24,23 +24,23 @@ pub mod bar {
     // @has foo/bar/baz/index.html '//a/@href' '../../../src/foo/src-links.rs.html'
     pub mod baz {
         /// Dox
-        // @has foo/bar/baz/fn.baz.html '//a/@href' '../../../src/foo/src-links.rs.html'
+        // @has foo/bar/baz/baz.v.html '//a/@href' '../../../src/foo/src-links.rs.html'
         pub fn baz() { }
     }
 
     /// Dox
-    // @has foo/bar/trait.Foobar.html '//a/@href' '../../src/foo/src-links.rs.html'
+    // @has foo/bar/Foobar.t.html '//a/@href' '../../src/foo/src-links.rs.html'
     pub trait Foobar { fn dummy(&self) { } }
 
-    // @has foo/bar/struct.Foo.html '//a/@href' '../../src/foo/src-links.rs.html'
+    // @has foo/bar/Foo.t.html '//a/@href' '../../src/foo/src-links.rs.html'
     pub struct Foo { x: i32, y: u32 }
 
-    // @has foo/bar/fn.prawns.html '//a/@href' '../../src/foo/src-links.rs.html'
+    // @has foo/bar/prawns.v.html '//a/@href' '../../src/foo/src-links.rs.html'
     pub fn prawns((a, b): (i32, u32), Foo { x, y }: Foo) { }
 }
 
 /// Dox
-// @has foo/fn.modfn.html '//a/@href' '../src/foo/src-links.rs.html'
+// @has foo/modfn.v.html '//a/@href' '../src/foo/src-links.rs.html'
 pub fn modfn() { }
 
 // same hierarchy as above, but just for the submodule
@@ -49,8 +49,8 @@ pub fn modfn() { }
 // @has foo/qux/index.html '//a/@href' '../../src/foo/src-links/mod.rs.html'
 // @has foo/qux/bar/index.html '//a/@href' '../../../src/foo/src-links/mod.rs.html'
 // @has foo/qux/bar/baz/index.html '//a/@href' '../../../../src/foo/src-links/mod.rs.html'
-// @has foo/qux/bar/baz/fn.baz.html '//a/@href' '../../../../src/foo/src-links/mod.rs.html'
-// @has foo/qux/bar/trait.Foobar.html '//a/@href' '../../../src/foo/src-links/mod.rs.html'
-// @has foo/qux/bar/struct.Foo.html '//a/@href' '../../../src/foo/src-links/mod.rs.html'
-// @has foo/qux/bar/fn.prawns.html '//a/@href' '../../../src/foo/src-links/mod.rs.html'
-// @has foo/qux/fn.modfn.html '//a/@href' '../../src/foo/src-links/mod.rs.html'
+// @has foo/qux/bar/baz/baz.v.html '//a/@href' '../../../../src/foo/src-links/mod.rs.html'
+// @has foo/qux/bar/Foobar.t.html '//a/@href' '../../../src/foo/src-links/mod.rs.html'
+// @has foo/qux/bar/Foo.t.html '//a/@href' '../../../src/foo/src-links/mod.rs.html'
+// @has foo/qux/bar/prawns.v.html '//a/@href' '../../../src/foo/src-links/mod.rs.html'
+// @has foo/qux/modfn.v.html '//a/@href' '../../src/foo/src-links/mod.rs.html'

--- a/src/test/rustdoc/structfields.rs
+++ b/src/test/rustdoc/structfields.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// @has structfields/struct.Foo.html
+// @has structfields/Foo.t.html
 pub struct Foo {
     // @has - //pre "pub a: ()"
     pub a: (),
@@ -22,14 +22,14 @@ pub struct Foo {
     pub d: usize,
 }
 
-// @has structfields/struct.Bar.html
+// @has structfields/Bar.t.html
 pub struct Bar {
     // @has - //pre "pub a: ()"
     pub a: (),
     // @!has - //pre "// some fields omitted"
 }
 
-// @has structfields/enum.Qux.html
+// @has structfields/Qux.t.html
 pub enum Qux {
     Quz {
         // @has - //pre "a: ()"

--- a/src/test/rustdoc/trait-self-link.rs
+++ b/src/test/rustdoc/trait-self-link.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// @!has trait_self_link/trait.Foo.html //a/@href ../trait_self_link/trait.Foo.html
+// @!has trait_self_link/Foo.t.html //a/@href ../trait_self_link/Foo.t.html
 pub trait Foo {}
 
 pub struct Bar;

--- a/src/test/rustdoc/tuples.rs
+++ b/src/test/rustdoc/tuples.rs
@@ -10,9 +10,9 @@
 
 #![crate_name = "foo"]
 
-// @has foo/fn.tuple0.html //pre 'pub fn tuple0(x: ())'
+// @has foo/tuple0.v.html //pre 'pub fn tuple0(x: ())'
 pub fn tuple0(x: ()) -> () { x }
-// @has foo/fn.tuple1.html //pre 'pub fn tuple1(x: (i32,)) -> (i32,)'
+// @has foo/tuple1.v.html //pre 'pub fn tuple1(x: (i32,)) -> (i32,)'
 pub fn tuple1(x: (i32,)) -> (i32,) { x }
-// @has foo/fn.tuple2.html //pre 'pub fn tuple2(x: (i32, i32)) -> (i32, i32)'
+// @has foo/tuple2.v.html //pre 'pub fn tuple2(x: (i32, i32)) -> (i32, i32)'
 pub fn tuple2(x: (i32, i32)) -> (i32, i32) { x }

--- a/src/test/rustdoc/variadic.rs
+++ b/src/test/rustdoc/variadic.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 extern "C" {
-    // @has variadic/fn.foo.html //pre 'pub unsafe extern fn foo(x: i32, ...)'
+    // @has variadic/foo.v.html //pre 'pub unsafe extern fn foo(x: i32, ...)'
     pub fn foo(x: i32, ...);
 }

--- a/src/test/rustdoc/where.rs
+++ b/src/test/rustdoc/where.rs
@@ -12,16 +12,16 @@
 
 pub trait MyTrait { fn dummy(&self) { } }
 
-// @has foo/struct.Alpha.html '//pre' "pub struct Alpha<A>(_) where A: MyTrait"
+// @has foo/Alpha.t.html '//pre' "pub struct Alpha<A>(_) where A: MyTrait"
 pub struct Alpha<A>(A) where A: MyTrait;
-// @has foo/trait.Bravo.html '//pre' "pub trait Bravo<B> where B: MyTrait"
+// @has foo/Bravo.t.html '//pre' "pub trait Bravo<B> where B: MyTrait"
 pub trait Bravo<B> where B: MyTrait { fn get(&self, B: B); }
-// @has foo/fn.charlie.html '//pre' "pub fn charlie<C>() where C: MyTrait"
+// @has foo/charlie.v.html '//pre' "pub fn charlie<C>() where C: MyTrait"
 pub fn charlie<C>() where C: MyTrait {}
 
 pub struct Delta<D>(D);
 
-// @has foo/struct.Delta.html '//*[@class="impl"]//code' \
+// @has foo/Delta.t.html '//*[@class="impl"]//code' \
 //          "impl<D> Delta<D> where D: MyTrait"
 impl<D> Delta<D> where D: MyTrait {
     pub fn delta() {}
@@ -29,20 +29,20 @@ impl<D> Delta<D> where D: MyTrait {
 
 pub struct Echo<E>(E);
 
-// @has foo/struct.Echo.html '//*[@class="impl"]//code' \
+// @has foo/Echo.t.html '//*[@class="impl"]//code' \
 //          "impl<E> MyTrait for Echo<E> where E: MyTrait"
-// @has foo/trait.MyTrait.html '//*[@id="implementors-list"]//code' \
+// @has foo/MyTrait.t.html '//*[@id="implementors-list"]//code' \
 //          "impl<E> MyTrait for Echo<E> where E: MyTrait"
 impl<E> MyTrait for Echo<E> where E: MyTrait {}
 
 pub enum Foxtrot<F> { Foxtrot1(F) }
 
-// @has foo/enum.Foxtrot.html '//*[@class="impl"]//code' \
+// @has foo/Foxtrot.t.html '//*[@class="impl"]//code' \
 //          "impl<F> MyTrait for Foxtrot<F> where F: MyTrait"
-// @has foo/trait.MyTrait.html '//*[@id="implementors-list"]//code' \
+// @has foo/MyTrait.t.html '//*[@id="implementors-list"]//code' \
 //          "impl<F> MyTrait for Foxtrot<F> where F: MyTrait"
 impl<F> MyTrait for Foxtrot<F> where F: MyTrait {}
 
-// @has foo/type.Golf.html '//pre[@class="rust typedef"]' \
+// @has foo/Golf.t.html '//pre[@class="rust typedef"]' \
 //          "type Golf<T> where T: Clone = (T, T)"
 pub type Golf<T> where T: Clone = (T, T);


### PR DESCRIPTION
Changes rustdoc URLs to name.namespace.html, e.g., Foo.t.html. These are easier for clients to guess since they only need to know the namespace, not the kind of item.

Old URLs are preserved as redirects to the new ones.

I also add redirects for modules, e.g.,
foo/bar/baz.t.html to foo/bar/baz/index.html, so modules are not an exception to the URL rule.

And removes the ! from macro URLs.

Closes #34271

r? @alexcrichton 

cc @steveklabnik 
