### PR TITLE
doc/book/trait-objects: remove empty lines at start of examples

### DIFF
--- a/src/doc/book/trait-objects.md
+++ b/src/doc/book/trait-objects.md
@@ -123,7 +123,6 @@ dispatch with trait objects by casting:
 # trait Foo { fn method(&self) -> String; }
 # impl Foo for u8 { fn method(&self) -> String { format!("u8: {}", *self) } }
 # impl Foo for String { fn method(&self) -> String { format!("string: {}", *self) } }
-
 fn do_something(x: &Foo) {
     x.method();
 }
@@ -140,7 +139,6 @@ or by coercing:
 # trait Foo { fn method(&self) -> String; }
 # impl Foo for u8 { fn method(&self) -> String { format!("u8: {}", *self) } }
 # impl Foo for String { fn method(&self) -> String { format!("string: {}", *self) } }
-
 fn do_something(x: &Foo) {
     x.method();
 }


### PR DESCRIPTION
I think it looks better without them.
