### PR TITLE
rustbuild: make backtraces (RUST_BACKTRACE) optional

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -72,6 +72,7 @@ pub struct Config {
     // libstd features
     pub debug_jemalloc: bool,
     pub use_jemalloc: bool,
+    pub backtrace: bool, // support for RUST_BACKTRACE
 
     // misc
     pub channel: String,
@@ -134,6 +135,7 @@ struct Rust {
     debuginfo: Option<bool>,
     debug_jemalloc: Option<bool>,
     use_jemalloc: Option<bool>,
+    backtrace: Option<bool>,
     default_linker: Option<String>,
     default_ar: Option<String>,
     channel: Option<String>,
@@ -158,6 +160,7 @@ impl Config {
         let mut config = Config::default();
         config.llvm_optimize = true;
         config.use_jemalloc = true;
+        config.backtrace = true;
         config.rust_optimize = true;
         config.rust_optimize_tests = true;
         config.submodules = true;
@@ -230,6 +233,7 @@ impl Config {
             set(&mut config.rust_rpath, rust.rpath);
             set(&mut config.debug_jemalloc, rust.debug_jemalloc);
             set(&mut config.use_jemalloc, rust.use_jemalloc);
+            set(&mut config.backtrace, rust.backtrace);
             set(&mut config.channel, rust.channel.clone());
             config.rustc_default_linker = rust.default_linker.clone();
             config.rustc_default_ar = rust.default_ar.clone();

--- a/src/bootstrap/config.toml.example
+++ b/src/bootstrap/config.toml.example
@@ -99,6 +99,9 @@
 # Whether or not jemalloc is built with its debug option set
 #debug-jemalloc = false
 
+# Whether or not `panic!`s generate backtraces (RUST_BACKTRACE)
+#backtrace = true
+
 # The default linker that will be used by the generated compiler. Note that this
 # is not the linker used to link said compiler.
 #default-linker = "cc"

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -652,6 +652,9 @@ impl Build {
         if self.config.use_jemalloc {
             features.push_str(" jemalloc");
         }
+        if self.config.backtrace {
+            features.push_str(" backtrace");
+        }
         return features
     }
 

--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -27,5 +27,6 @@ build_helper = { path = "../build_helper" }
 gcc = "0.3"
 
 [features]
+backtrace = []
 jemalloc = ["alloc_jemalloc"]
 debug-jemalloc = ["alloc_jemalloc/debug"]

--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -25,7 +25,8 @@ fn main() {
 
     let target = env::var("TARGET").unwrap();
     let host = env::var("HOST").unwrap();
-    if !target.contains("apple") && !target.contains("msvc") && !target.contains("emscripten"){
+    if cfg!(feature = "backtrace") && !target.contains("apple") && !target.contains("msvc") &&
+        !target.contains("emscripten") {
         build_libbacktrace(&host, &target);
     }
 

--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -28,11 +28,7 @@ use intrinsics;
 use mem;
 use raw;
 use sys_common::rwlock::RWLock;
-#[cfg(feature = "backtrace")]
-use sync::atomic::{AtomicBool, Ordering};
 use sys::stdio::Stderr;
-#[cfg(feature = "backtrace")]
-use sys_common::backtrace;
 use sys_common::thread_info;
 use sys_common::util;
 use thread;
@@ -73,8 +69,6 @@ enum Hook {
 
 static HOOK_LOCK: RWLock = RWLock::new();
 static mut HOOK: Hook = Hook::Default;
-#[cfg(feature = "backtrace")]
-static FIRST_PANIC: AtomicBool = AtomicBool::new(true);
 
 /// Registers a custom panic hook, replacing any that was previously registered.
 ///
@@ -186,13 +180,17 @@ impl<'a> Location<'a> {
 }
 
 fn default_hook(info: &PanicInfo) {
-    #[cfg(feature = "backtrace")]
-    let panics = PANIC_COUNT.with(|c| c.get());
+    #[cfg(any(not(cargobuild), feature = "backtrace"))]
+    use sys_common::backtrace;
 
     // If this is a double panic, make sure that we print a backtrace
     // for this panic. Otherwise only print it if logging is enabled.
-    #[cfg(feature = "backtrace")]
-    let log_backtrace = panics >= 2 || backtrace::log_enabled();
+    #[cfg(any(not(cargobuild), feature = "backtrace"))]
+    let log_backtrace = {
+        let panics = PANIC_COUNT.with(|c| c.get());
+
+        panics >= 2 || backtrace::log_enabled()
+    };
 
     let file = info.location.file;
     let line = info.location.line;
@@ -212,8 +210,12 @@ fn default_hook(info: &PanicInfo) {
         let _ = writeln!(err, "thread '{}' panicked at '{}', {}:{}",
                          name, msg, file, line);
 
-        #[cfg(feature = "backtrace")]
+        #[cfg(any(not(cargobuild), feature = "backtrace"))]
         {
+            use sync::atomic::{AtomicBool, Ordering};
+
+            static FIRST_PANIC: AtomicBool = AtomicBool::new(true);
+
             if log_backtrace {
                 let _ = backtrace::write(err);
             } else if FIRST_PANIC.compare_and_swap(true, false, Ordering::SeqCst) {

--- a/src/libstd/sys/common/mod.rs
+++ b/src/libstd/sys/common/mod.rs
@@ -28,6 +28,7 @@ macro_rules! rtassert {
 
 pub mod args;
 pub mod at_exit_imp;
+#[cfg(feature = "backtrace")]
 pub mod backtrace;
 pub mod condvar;
 pub mod io;
@@ -42,6 +43,7 @@ pub mod thread_local;
 pub mod util;
 pub mod wtf8;
 
+#[cfg(feature = "backtrace")]
 #[cfg(any(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "emscripten"))),
           all(windows, target_env = "gnu")))]
 pub mod gnu;

--- a/src/libstd/sys/common/mod.rs
+++ b/src/libstd/sys/common/mod.rs
@@ -28,7 +28,7 @@ macro_rules! rtassert {
 
 pub mod args;
 pub mod at_exit_imp;
-#[cfg(feature = "backtrace")]
+#[cfg(any(not(cargobuild), feature = "backtrace"))]
 pub mod backtrace;
 pub mod condvar;
 pub mod io;
@@ -43,7 +43,7 @@ pub mod thread_local;
 pub mod util;
 pub mod wtf8;
 
-#[cfg(feature = "backtrace")]
+#[cfg(any(not(cargobuild), feature = "backtrace"))]
 #[cfg(any(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "emscripten"))),
           all(windows, target_env = "gnu")))]
 pub mod gnu;

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -30,6 +30,7 @@ use libc;
 pub mod weak;
 
 pub mod android;
+#[cfg(feature = "backtrace")]
 pub mod backtrace;
 pub mod condvar;
 pub mod ext;

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -30,7 +30,7 @@ use libc;
 pub mod weak;
 
 pub mod android;
-#[cfg(feature = "backtrace")]
+#[cfg(any(not(cargobuild), feature = "backtrace"))]
 pub mod backtrace;
 pub mod condvar;
 pub mod ext;

--- a/src/rustc/std_shim/Cargo.toml
+++ b/src/rustc/std_shim/Cargo.toml
@@ -46,3 +46,4 @@ std = { path = "../../libstd" }
 [features]
 jemalloc = ["std/jemalloc"]
 debug-jemalloc = ["std/debug-jemalloc"]
+backtrace = ["std/backtrace"]


### PR DESCRIPTION
but keep them enabled by default to maintain the status quo.

When disabled shaves ~56KB off every x86_64-unknown-linux-gnu
binary.

To disable backtraces you have to use a config.toml (see
src/bootstrap/config.toml.example for details) when building rustc/std:

$ python bootstrap.py --config=config.toml

---

r? @alexcrichton 
cc rust-lang/rfcs#1417
