### PR TITLE
resolve: Exclude inaccessible names from single imports

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -825,8 +825,6 @@ enum NameBindingKind<'a> {
     Import {
         binding: &'a NameBinding<'a>,
         directive: &'a ImportDirective<'a>,
-        // Some(error) if using this imported name causes the import to be a privacy error
-        privacy_error: Option<Box<PrivacyError<'a>>>,
     },
 }
 
@@ -1206,15 +1204,10 @@ impl<'a> Resolver<'a> {
             self.used_crates.insert(krate);
         }
 
-        let (directive, privacy_error) = match binding.kind {
-            NameBindingKind::Import { directive, ref privacy_error, .. } =>
-                (directive, privacy_error),
+        let directive = match binding.kind {
+            NameBindingKind::Import { directive, .. } => directive,
             _ => return,
         };
-
-        if let Some(error) = privacy_error.as_ref() {
-            self.privacy_errors.push((**error).clone());
-        }
 
         if !self.make_glob_map {
             return;

--- a/src/test/compile-fail/privacy-ns2.rs
+++ b/src/test/compile-fail/privacy-ns2.rs
@@ -25,15 +25,15 @@ pub mod foo1 {
 }
 
 fn test_single1() {
-    use foo1::Bar;  //~ ERROR function `Bar` is private
+    use foo1::Bar;
 
-    Bar();
+    Bar(); //~ ERROR unresolved name `Bar`
 }
 
 fn test_list1() {
-    use foo1::{Bar,Baz};  //~ ERROR `Bar` is private
+    use foo1::{Bar,Baz};
 
-    Bar();
+    Bar(); //~ ERROR unresolved name `Bar`
 }
 
 // private type, public value
@@ -46,15 +46,15 @@ pub mod foo2 {
 }
 
 fn test_single2() {
-    use foo2::Bar;  //~ ERROR trait `Bar` is private
+    use foo2::Bar;
 
-    let _x : Box<Bar>;
+    let _x : Box<Bar>; //~ ERROR type name `Bar` is undefined
 }
 
 fn test_list2() {
-    use foo2::{Bar,Baz};  //~ ERROR `Bar` is private
+    use foo2::{Bar,Baz};
 
-    let _x: Box<Bar>;
+    let _x: Box<Bar>; //~ ERROR type name `Bar` is undefined
 }
 
 // neither public


### PR DESCRIPTION
If a single import resolves to an inaccessible name in some but not all namespaces, avoid importing the name in the inaccessible namespaces (per https://github.com/rust-lang/rfcs/pull/1560, cc #35120).

Currently, the inaccessible namespaces are imported but cause a privacy error when used.

r? @nrc 
