### PR TITLE
Only export #[no_mangle] extern symbols during LTO

### DIFF
--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -55,7 +55,6 @@ use rustc_serialize::Decodable;
 use syntax::attr;
 use syntax::parse::token;
 use syntax::ast;
-use syntax::abi::Abi;
 use syntax::codemap;
 use syntax::print::pprust;
 use syntax::ptr::P;
@@ -1542,13 +1541,9 @@ pub fn is_extern_item<'a, 'tcx>(cdata: Cmd,
     let applicable = match item_family(item_doc) {
         ImmStatic | MutStatic => true,
         Fn => {
-            let ty::TypeScheme { generics, ty } = get_type(cdata, id, tcx);
+            let ty::TypeScheme { generics, .. } = get_type(cdata, id, tcx);
             let no_generics = generics.types.is_empty();
-            match ty.sty {
-                ty::TyFnDef(_, _, fn_ty) | ty::TyFnPtr(fn_ty)
-                    if fn_ty.abi != Abi::Rust => return no_generics,
-                _ => no_generics,
-            }
+            no_generics
         },
         _ => false,
     };


### PR DESCRIPTION
Fixes #34985
