### PR TITLE
Rename _ to {integer} and {float} for unknown numeric types

### DIFF
--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -975,7 +975,8 @@ impl fmt::Display for ty::InferTy {
             ty::IntVar(ref vid) if print_var_ids => write!(f, "{:?}", vid),
             ty::FloatVar(ref vid) if print_var_ids => write!(f, "{:?}", vid),
             ty::TyVar(_) => write!(f, "_"),
-            ty::IntVar(_) | ty::FloatVar(_) => write!(f, "{}", "{numeric}"),
+            ty::IntVar(_) => write!(f, "{}", "{integer}"),
+            ty::FloatVar(_) => write!(f, "{}", "{float}"),
             ty::FreshTy(v) => write!(f, "FreshTy({})", v),
             ty::FreshIntTy(v) => write!(f, "FreshIntTy({})", v),
             ty::FreshFloatTy(v) => write!(f, "FreshFloatTy({})", v)

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -974,7 +974,8 @@ impl fmt::Display for ty::InferTy {
             ty::TyVar(ref vid) if print_var_ids => write!(f, "{:?}", vid),
             ty::IntVar(ref vid) if print_var_ids => write!(f, "{:?}", vid),
             ty::FloatVar(ref vid) if print_var_ids => write!(f, "{:?}", vid),
-            ty::TyVar(_) | ty::IntVar(_) | ty::FloatVar(_) => write!(f, "_"),
+            ty::TyVar(_) => write!(f, "_"),
+            ty::IntVar(_) | ty::FloatVar(_) => write!(f, "{}", "{numeric}"),
             ty::FreshTy(v) => write!(f, "FreshTy({})", v),
             ty::FreshIntTy(v) => write!(f, "FreshIntTy({})", v),
             ty::FreshFloatTy(v) => write!(f, "FreshFloatTy({})", v)

--- a/src/test/compile-fail/array-not-vector.rs
+++ b/src/test/compile-fail/array-not-vector.rs
@@ -12,7 +12,7 @@ fn main() {
     let _x: i32 = [1, 2, 3];
     //~^ ERROR mismatched types
     //~| expected type `i32`
-    //~| found type `[{numeric}; 3]`
+    //~| found type `[{integer}; 3]`
     //~| expected i32, found array of 3 elements
 
     let x: &[i32] = &[1, 2, 3];

--- a/src/test/compile-fail/array-not-vector.rs
+++ b/src/test/compile-fail/array-not-vector.rs
@@ -12,7 +12,7 @@ fn main() {
     let _x: i32 = [1, 2, 3];
     //~^ ERROR mismatched types
     //~| expected type `i32`
-    //~| found type `[_; 3]`
+    //~| found type `[{numeric}; 3]`
     //~| expected i32, found array of 3 elements
 
     let x: &[i32] = &[1, 2, 3];

--- a/src/test/compile-fail/bad-const-type.rs
+++ b/src/test/compile-fail/bad-const-type.rs
@@ -11,6 +11,6 @@
 static i: String = 10;
 //~^ ERROR mismatched types
 //~| expected type `std::string::String`
-//~| found type `_`
+//~| found type `{numeric}`
 //~| expected struct `std::string::String`, found integral variable
 fn main() { println!("{}", i); }

--- a/src/test/compile-fail/bad-const-type.rs
+++ b/src/test/compile-fail/bad-const-type.rs
@@ -11,6 +11,6 @@
 static i: String = 10;
 //~^ ERROR mismatched types
 //~| expected type `std::string::String`
-//~| found type `{numeric}`
+//~| found type `{integer}`
 //~| expected struct `std::string::String`, found integral variable
 fn main() { println!("{}", i); }

--- a/src/test/compile-fail/coerce-mut.rs
+++ b/src/test/compile-fail/coerce-mut.rs
@@ -15,6 +15,6 @@ fn main() {
     f(&x);
     //~^ ERROR mismatched types
     //~| expected type `&mut i32`
-    //~| found type `&_`
+    //~| found type `&{numeric}`
     //~| values differ in mutability
 }

--- a/src/test/compile-fail/coerce-mut.rs
+++ b/src/test/compile-fail/coerce-mut.rs
@@ -15,6 +15,6 @@ fn main() {
     f(&x);
     //~^ ERROR mismatched types
     //~| expected type `&mut i32`
-    //~| found type `&{numeric}`
+    //~| found type `&{integer}`
     //~| values differ in mutability
 }

--- a/src/test/compile-fail/coercion-slice.rs
+++ b/src/test/compile-fail/coercion-slice.rs
@@ -14,6 +14,6 @@ fn main() {
     let _: &[i32] = [0];
     //~^ ERROR mismatched types
     //~| expected type `&[i32]`
-    //~| found type `[{numeric}; 1]`
+    //~| found type `[{integer}; 1]`
     //~| expected &-ptr, found array of 1 elements
 }

--- a/src/test/compile-fail/coercion-slice.rs
+++ b/src/test/compile-fail/coercion-slice.rs
@@ -14,6 +14,6 @@ fn main() {
     let _: &[i32] = [0];
     //~^ ERROR mismatched types
     //~| expected type `&[i32]`
-    //~| found type `[_; 1]`
+    //~| found type `[{numeric}; 1]`
     //~| expected &-ptr, found array of 1 elements
 }

--- a/src/test/compile-fail/fully-qualified-type-name1.rs
+++ b/src/test/compile-fail/fully-qualified-type-name1.rs
@@ -15,6 +15,6 @@ fn main() {
     x = 5;
     //~^ ERROR mismatched types
     //~| expected type `std::option::Option<usize>`
-    //~| found type `_`
+    //~| found type `{numeric}`
     //~| expected enum `std::option::Option`, found integral variable
 }

--- a/src/test/compile-fail/fully-qualified-type-name1.rs
+++ b/src/test/compile-fail/fully-qualified-type-name1.rs
@@ -15,6 +15,6 @@ fn main() {
     x = 5;
     //~^ ERROR mismatched types
     //~| expected type `std::option::Option<usize>`
-    //~| found type `{numeric}`
+    //~| found type `{integer}`
     //~| expected enum `std::option::Option`, found integral variable
 }

--- a/src/test/compile-fail/if-let-arm-types.rs
+++ b/src/test/compile-fail/if-let-arm-types.rs
@@ -12,7 +12,7 @@ fn main() {
     if let Some(b) = None { //~ ERROR: `if let` arms have incompatible types
         //~^ expected (), found integral variable
         //~| expected type `()`
-        //~| found type `_`
+        //~| found type `{numeric}`
         ()
     } else {                //~ NOTE: `if let` arm with an incompatible type
         1

--- a/src/test/compile-fail/if-let-arm-types.rs
+++ b/src/test/compile-fail/if-let-arm-types.rs
@@ -12,7 +12,7 @@ fn main() {
     if let Some(b) = None { //~ ERROR: `if let` arms have incompatible types
         //~^ expected (), found integral variable
         //~| expected type `()`
-        //~| found type `{numeric}`
+        //~| found type `{integer}`
         ()
     } else {                //~ NOTE: `if let` arm with an incompatible type
         1

--- a/src/test/compile-fail/indexing-requires-a-uint.rs
+++ b/src/test/compile-fail/indexing-requires-a-uint.rs
@@ -13,7 +13,7 @@
 
 fn main() {
     fn bar<T>(_: T) {}
-    [0][0u8]; //~ ERROR: `[_]: std::ops::Index<u8>` is not satisfied
+    [0][0u8]; //~ ERROR: `[{numeric}]: std::ops::Index<u8>` is not satisfied
 
     [0][0]; // should infer to be a usize
 

--- a/src/test/compile-fail/indexing-requires-a-uint.rs
+++ b/src/test/compile-fail/indexing-requires-a-uint.rs
@@ -13,7 +13,7 @@
 
 fn main() {
     fn bar<T>(_: T) {}
-    [0][0u8]; //~ ERROR: `[{numeric}]: std::ops::Index<u8>` is not satisfied
+    [0][0u8]; //~ ERROR: `[{integer}]: std::ops::Index<u8>` is not satisfied
 
     [0][0]; // should infer to be a usize
 

--- a/src/test/compile-fail/integral-variable-unification-error.rs
+++ b/src/test/compile-fail/integral-variable-unification-error.rs
@@ -12,7 +12,7 @@ fn main() {
     let mut x = 2;
     x = 5.0;
     //~^ ERROR mismatched types
-    //~| expected type `{numeric}`
-    //~| found type `{numeric}`
+    //~| expected type `{integer}`
+    //~| found type `{float}`
     //~| expected integral variable, found floating-point variable
 }

--- a/src/test/compile-fail/integral-variable-unification-error.rs
+++ b/src/test/compile-fail/integral-variable-unification-error.rs
@@ -12,7 +12,7 @@ fn main() {
     let mut x = 2;
     x = 5.0;
     //~^ ERROR mismatched types
-    //~| expected type `_`
-    //~| found type `_`
+    //~| expected type `{numeric}`
+    //~| found type `{numeric}`
     //~| expected integral variable, found floating-point variable
 }

--- a/src/test/compile-fail/issue-13466.rs
+++ b/src/test/compile-fail/issue-13466.rs
@@ -17,13 +17,13 @@ pub fn main() {
     let _x: usize = match Some(1) {
         Ok(u) => u,
         //~^ ERROR mismatched types
-        //~| expected type `std::option::Option<_>`
+        //~| expected type `std::option::Option<{numeric}>`
         //~| found type `std::result::Result<_, _>`
         //~| expected enum `std::option::Option`, found enum `std::result::Result`
 
         Err(e) => panic!(e)
         //~^ ERROR mismatched types
-        //~| expected type `std::option::Option<_>`
+        //~| expected type `std::option::Option<{numeric}>`
         //~| found type `std::result::Result<_, _>`
         //~| expected enum `std::option::Option`, found enum `std::result::Result`
     };

--- a/src/test/compile-fail/issue-13466.rs
+++ b/src/test/compile-fail/issue-13466.rs
@@ -17,13 +17,13 @@ pub fn main() {
     let _x: usize = match Some(1) {
         Ok(u) => u,
         //~^ ERROR mismatched types
-        //~| expected type `std::option::Option<{numeric}>`
+        //~| expected type `std::option::Option<{integer}>`
         //~| found type `std::result::Result<_, _>`
         //~| expected enum `std::option::Option`, found enum `std::result::Result`
 
         Err(e) => panic!(e)
         //~^ ERROR mismatched types
-        //~| expected type `std::option::Option<{numeric}>`
+        //~| expected type `std::option::Option<{integer}>`
         //~| found type `std::result::Result<_, _>`
         //~| expected enum `std::option::Option`, found enum `std::result::Result`
     };

--- a/src/test/compile-fail/issue-17651.rs
+++ b/src/test/compile-fail/issue-17651.rs
@@ -14,5 +14,5 @@
 fn main() {
     // FIXME (#22405): Replace `Box::new` with `box` here when/if possible.
     (|| Box::new(*(&[0][..])))();
-    //~^ ERROR `[{numeric}]: std::marker::Sized` is not satisfied
+    //~^ ERROR `[{integer}]: std::marker::Sized` is not satisfied
 }

--- a/src/test/compile-fail/issue-17651.rs
+++ b/src/test/compile-fail/issue-17651.rs
@@ -14,5 +14,5 @@
 fn main() {
     // FIXME (#22405): Replace `Box::new` with `box` here when/if possible.
     (|| Box::new(*(&[0][..])))();
-    //~^ ERROR `[_]: std::marker::Sized` is not satisfied
+    //~^ ERROR `[{numeric}]: std::marker::Sized` is not satisfied
 }

--- a/src/test/compile-fail/issue-19991.rs
+++ b/src/test/compile-fail/issue-19991.rs
@@ -14,7 +14,7 @@
 fn main() {
     if let Some(homura) = Some("madoka") { //~  ERROR missing an else clause
                                            //~| expected type `()`
-                                           //~| found type `_`
+                                           //~| found type `{numeric}`
                                            //~| expected (), found integral variable
         765
     };

--- a/src/test/compile-fail/issue-19991.rs
+++ b/src/test/compile-fail/issue-19991.rs
@@ -14,7 +14,7 @@
 fn main() {
     if let Some(homura) = Some("madoka") { //~  ERROR missing an else clause
                                            //~| expected type `()`
-                                           //~| found type `{numeric}`
+                                           //~| found type `{integer}`
                                            //~| expected (), found integral variable
         765
     };

--- a/src/test/compile-fail/issue-26237.rs
+++ b/src/test/compile-fail/issue-26237.rs
@@ -11,7 +11,7 @@
 macro_rules! macro_panic {
     ($not_a_function:expr, $some_argument:ident) => {
         $not_a_function($some_argument)
-        //~^ ERROR expected function, found `_`
+        //~^ ERROR expected function, found `{numeric}`
     }
 }
 

--- a/src/test/compile-fail/issue-26237.rs
+++ b/src/test/compile-fail/issue-26237.rs
@@ -11,7 +11,7 @@
 macro_rules! macro_panic {
     ($not_a_function:expr, $some_argument:ident) => {
         $not_a_function($some_argument)
-        //~^ ERROR expected function, found `{numeric}`
+        //~^ ERROR expected function, found `{integer}`
     }
 }
 

--- a/src/test/compile-fail/issue-4201.rs
+++ b/src/test/compile-fail/issue-4201.rs
@@ -14,7 +14,7 @@ fn main() {
     } else if false {
 //~^ ERROR if may be missing an else clause
 //~| expected type `()`
-//~| found type `{numeric}`
+//~| found type `{integer}`
 //~| expected (), found integral variable
         1
     };

--- a/src/test/compile-fail/issue-4201.rs
+++ b/src/test/compile-fail/issue-4201.rs
@@ -14,7 +14,7 @@ fn main() {
     } else if false {
 //~^ ERROR if may be missing an else clause
 //~| expected type `()`
-//~| found type `_`
+//~| found type `{numeric}`
 //~| expected (), found integral variable
         1
     };

--- a/src/test/compile-fail/issue-4968.rs
+++ b/src/test/compile-fail/issue-4968.rs
@@ -14,7 +14,7 @@ const A: (isize,isize) = (4,2);
 fn main() {
     match 42 { A => () }
     //~^ ERROR mismatched types
-    //~| expected type `{numeric}`
+    //~| expected type `{integer}`
     //~| found type `(isize, isize)`
     //~| expected integral variable, found tuple
 }

--- a/src/test/compile-fail/issue-4968.rs
+++ b/src/test/compile-fail/issue-4968.rs
@@ -14,7 +14,7 @@ const A: (isize,isize) = (4,2);
 fn main() {
     match 42 { A => () }
     //~^ ERROR mismatched types
-    //~| expected type `_`
+    //~| expected type `{numeric}`
     //~| found type `(isize, isize)`
     //~| expected integral variable, found tuple
 }

--- a/src/test/compile-fail/issue-7867.rs
+++ b/src/test/compile-fail/issue-7867.rs
@@ -25,12 +25,12 @@ fn main() {
     match &Some(42) {
         Some(x) => (),
         //~^ ERROR mismatched types
-        //~| expected type `&std::option::Option<_>`
+        //~| expected type `&std::option::Option<{numeric}>`
         //~| found type `std::option::Option<_>`
         //~| expected &-ptr, found enum `std::option::Option`
         None => ()
         //~^ ERROR mismatched types
-        //~| expected type `&std::option::Option<_>`
+        //~| expected type `&std::option::Option<{numeric}>`
         //~| found type `std::option::Option<_>`
         //~| expected &-ptr, found enum `std::option::Option`
     }

--- a/src/test/compile-fail/issue-7867.rs
+++ b/src/test/compile-fail/issue-7867.rs
@@ -25,12 +25,12 @@ fn main() {
     match &Some(42) {
         Some(x) => (),
         //~^ ERROR mismatched types
-        //~| expected type `&std::option::Option<{numeric}>`
+        //~| expected type `&std::option::Option<{integer}>`
         //~| found type `std::option::Option<_>`
         //~| expected &-ptr, found enum `std::option::Option`
         None => ()
         //~^ ERROR mismatched types
-        //~| expected type `&std::option::Option<{numeric}>`
+        //~| expected type `&std::option::Option<{integer}>`
         //~| found type `std::option::Option<_>`
         //~| expected &-ptr, found enum `std::option::Option`
     }

--- a/src/test/compile-fail/kindck-impl-type-params-2.rs
+++ b/src/test/compile-fail/kindck-impl-type-params-2.rs
@@ -21,5 +21,5 @@ fn take_param<T:Foo>(foo: &T) { }
 fn main() {
     let x: Box<_> = box 3;
     take_param(&x);
-    //~^ ERROR `Box<_>: std::marker::Copy` is not satisfied
+    //~^ ERROR `Box<{numeric}>: std::marker::Copy` is not satisfied
 }

--- a/src/test/compile-fail/kindck-impl-type-params-2.rs
+++ b/src/test/compile-fail/kindck-impl-type-params-2.rs
@@ -21,5 +21,5 @@ fn take_param<T:Foo>(foo: &T) { }
 fn main() {
     let x: Box<_> = box 3;
     take_param(&x);
-    //~^ ERROR `Box<{numeric}>: std::marker::Copy` is not satisfied
+    //~^ ERROR `Box<{integer}>: std::marker::Copy` is not satisfied
 }

--- a/src/test/compile-fail/match-range-fail.rs
+++ b/src/test/compile-fail/match-range-fail.rs
@@ -20,7 +20,7 @@ fn main() {
         10 ... "what" => ()
     };
     //~^^ ERROR only char and numeric types are allowed in range
-    //~| start type: _
+    //~| start type: {numeric}
     //~| end type: &'static str
 
     match 5 {

--- a/src/test/compile-fail/match-range-fail.rs
+++ b/src/test/compile-fail/match-range-fail.rs
@@ -20,7 +20,7 @@ fn main() {
         10 ... "what" => ()
     };
     //~^^ ERROR only char and numeric types are allowed in range
-    //~| start type: {numeric}
+    //~| start type: {integer}
     //~| end type: &'static str
 
     match 5 {
@@ -28,6 +28,6 @@ fn main() {
         _ => { }
     };
     //~^^^ ERROR mismatched types
-    //~| expected type `_`
+    //~| expected type `{integer}`
     //~| found type `char`
 }

--- a/src/test/compile-fail/match-vec-mismatch.rs
+++ b/src/test/compile-fail/match-vec-mismatch.rs
@@ -18,7 +18,7 @@ fn main() {
     };
 
     match &[0, 1, 2] {
-        [..] => {} //~ ERROR expected an array or slice, found `&[{numeric}; 3]`
+        [..] => {} //~ ERROR expected an array or slice, found `&[{integer}; 3]`
     };
 
     match &[0, 1, 2] {

--- a/src/test/compile-fail/match-vec-mismatch.rs
+++ b/src/test/compile-fail/match-vec-mismatch.rs
@@ -18,7 +18,7 @@ fn main() {
     };
 
     match &[0, 1, 2] {
-        [..] => {} //~ ERROR expected an array or slice, found `&[_; 3]`
+        [..] => {} //~ ERROR expected an array or slice, found `&[{numeric}; 3]`
     };
 
     match &[0, 1, 2] {

--- a/src/test/compile-fail/method-self-arg-1.rs
+++ b/src/test/compile-fail/method-self-arg-1.rs
@@ -24,6 +24,6 @@ fn main() {
                  //~| expected &-ptr, found struct `Foo`
     Foo::bar(&42); //~  ERROR mismatched types
                       //~| expected type `&Foo`
-                      //~| found type `&_`
+                      //~| found type `&{numeric}`
                       //~| expected struct `Foo`, found integral variable
 }

--- a/src/test/compile-fail/method-self-arg-1.rs
+++ b/src/test/compile-fail/method-self-arg-1.rs
@@ -24,6 +24,6 @@ fn main() {
                  //~| expected &-ptr, found struct `Foo`
     Foo::bar(&42); //~  ERROR mismatched types
                       //~| expected type `&Foo`
-                      //~| found type `&{numeric}`
+                      //~| found type `&{integer}`
                       //~| expected struct `Foo`, found integral variable
 }

--- a/src/test/compile-fail/mut-pattern-mismatched.rs
+++ b/src/test/compile-fail/mut-pattern-mismatched.rs
@@ -14,7 +14,7 @@ fn main() {
     // (separate lines to ensure the spans are accurate)
 
      let &_ //~  ERROR mismatched types
-            //~| expected type `&mut {numeric}`
+            //~| expected type `&mut {integer}`
             //~| found type `&_`
             //~| values differ in mutability
         = foo;
@@ -23,7 +23,7 @@ fn main() {
     let bar = &1;
     let &_ = bar;
     let &mut _ //~  ERROR mismatched types
-               //~| expected type `&{numeric}`
+               //~| expected type `&{integer}`
                //~| found type `&mut _`
                //~| values differ in mutability
          = bar;

--- a/src/test/compile-fail/mut-pattern-mismatched.rs
+++ b/src/test/compile-fail/mut-pattern-mismatched.rs
@@ -14,7 +14,7 @@ fn main() {
     // (separate lines to ensure the spans are accurate)
 
      let &_ //~  ERROR mismatched types
-            //~| expected type `&mut _`
+            //~| expected type `&mut {numeric}`
             //~| found type `&_`
             //~| values differ in mutability
         = foo;
@@ -23,7 +23,7 @@ fn main() {
     let bar = &1;
     let &_ = bar;
     let &mut _ //~  ERROR mismatched types
-               //~| expected type `&_`
+               //~| expected type `&{numeric}`
                //~| found type `&mut _`
                //~| values differ in mutability
          = bar;

--- a/src/test/compile-fail/no_send-rc.rs
+++ b/src/test/compile-fail/no_send-rc.rs
@@ -15,5 +15,5 @@ fn bar<T: Send>(_: T) {}
 fn main() {
     let x = Rc::new(5);
     bar(x);
-    //~^ ERROR `std::rc::Rc<{numeric}>: std::marker::Send` is not satisfied
+    //~^ ERROR `std::rc::Rc<{integer}>: std::marker::Send` is not satisfied
 }

--- a/src/test/compile-fail/no_send-rc.rs
+++ b/src/test/compile-fail/no_send-rc.rs
@@ -15,5 +15,5 @@ fn bar<T: Send>(_: T) {}
 fn main() {
     let x = Rc::new(5);
     bar(x);
-    //~^ ERROR `std::rc::Rc<_>: std::marker::Send` is not satisfied
+    //~^ ERROR `std::rc::Rc<{numeric}>: std::marker::Send` is not satisfied
 }

--- a/src/test/compile-fail/range-1.rs
+++ b/src/test/compile-fail/range-1.rs
@@ -23,5 +23,5 @@ pub fn main() {
     // Unsized type.
     let arr: &[_] = &[1, 2, 3];
     let range = *arr..;
-    //~^ ERROR `[_]: std::marker::Sized` is not satisfied
+    //~^ ERROR `[{numeric}]: std::marker::Sized` is not satisfied
 }

--- a/src/test/compile-fail/range-1.rs
+++ b/src/test/compile-fail/range-1.rs
@@ -23,5 +23,5 @@ pub fn main() {
     // Unsized type.
     let arr: &[_] = &[1, 2, 3];
     let range = *arr..;
-    //~^ ERROR `[{numeric}]: std::marker::Sized` is not satisfied
+    //~^ ERROR `[{integer}]: std::marker::Sized` is not satisfied
 }

--- a/src/test/compile-fail/repeat_count.rs
+++ b/src/test/compile-fail/repeat_count.rs
@@ -28,7 +28,7 @@ fn main() {
     let d = [0; 0.5];
     //~^ ERROR mismatched types
     //~| expected type `usize`
-    //~| found type `{numeric}`
+    //~| found type `{float}`
     //~| expected usize, found floating-point variable
     //~| ERROR expected usize for repeat count, found float [E0306]
     let e = [0; "foo"];

--- a/src/test/compile-fail/repeat_count.rs
+++ b/src/test/compile-fail/repeat_count.rs
@@ -28,7 +28,7 @@ fn main() {
     let d = [0; 0.5];
     //~^ ERROR mismatched types
     //~| expected type `usize`
-    //~| found type `_`
+    //~| found type `{numeric}`
     //~| expected usize, found floating-point variable
     //~| ERROR expected usize for repeat count, found float [E0306]
     let e = [0; "foo"];

--- a/src/test/compile-fail/slightly-nice-generic-literal-messages.rs
+++ b/src/test/compile-fail/slightly-nice-generic-literal-messages.rs
@@ -16,8 +16,8 @@ fn main() {
     match Foo(1.1, marker::PhantomData) {
         1 => {}
     //~^ ERROR mismatched types
-    //~| expected type `Foo<{numeric}, _>`
-    //~| found type `{numeric}`
+    //~| expected type `Foo<{float}, _>`
+    //~| found type `{integer}`
     //~| expected struct `Foo`, found integral variable
     }
 

--- a/src/test/compile-fail/slightly-nice-generic-literal-messages.rs
+++ b/src/test/compile-fail/slightly-nice-generic-literal-messages.rs
@@ -16,8 +16,8 @@ fn main() {
     match Foo(1.1, marker::PhantomData) {
         1 => {}
     //~^ ERROR mismatched types
-    //~| expected type `Foo<_, _>`
-    //~| found type `_`
+    //~| expected type `Foo<{numeric}, _>`
+    //~| found type `{numeric}`
     //~| expected struct `Foo`, found integral variable
     }
 

--- a/src/test/compile-fail/str-idx.rs
+++ b/src/test/compile-fail/str-idx.rs
@@ -10,5 +10,5 @@
 
 pub fn main() {
     let s: &str = "hello";
-    let c: u8 = s[4]; //~ ERROR `str: std::ops::Index<_>` is not satisfied
+    let c: u8 = s[4]; //~ ERROR `str: std::ops::Index<{numeric}>` is not satisfied
 }

--- a/src/test/compile-fail/str-idx.rs
+++ b/src/test/compile-fail/str-idx.rs
@@ -10,5 +10,5 @@
 
 pub fn main() {
     let s: &str = "hello";
-    let c: u8 = s[4]; //~ ERROR `str: std::ops::Index<{numeric}>` is not satisfied
+    let c: u8 = s[4]; //~ ERROR `str: std::ops::Index<{integer}>` is not satisfied
 }

--- a/src/test/compile-fail/struct-base-wrong-type-2.rs
+++ b/src/test/compile-fail/struct-base-wrong-type-2.rs
@@ -24,6 +24,6 @@ fn main() {
                                //~| expected struct `Foo`, found struct `Bar`
     let f__isize = Foo { a: 2, ..4 }; //~  ERROR mismatched types
                                  //~| expected type `Foo`
-                                 //~| found type `{numeric}`
+                                 //~| found type `{integer}`
                                  //~| expected struct `Foo`, found integral variable
 }

--- a/src/test/compile-fail/struct-base-wrong-type-2.rs
+++ b/src/test/compile-fail/struct-base-wrong-type-2.rs
@@ -24,6 +24,6 @@ fn main() {
                                //~| expected struct `Foo`, found struct `Bar`
     let f__isize = Foo { a: 2, ..4 }; //~  ERROR mismatched types
                                  //~| expected type `Foo`
-                                 //~| found type `_`
+                                 //~| found type `{numeric}`
                                  //~| expected struct `Foo`, found integral variable
 }

--- a/src/test/compile-fail/struct-base-wrong-type.rs
+++ b/src/test/compile-fail/struct-base-wrong-type.rs
@@ -23,7 +23,7 @@ static foo: Foo = Foo { a: 2, ..bar }; //~  ERROR mismatched types
                                        //~| expected struct `Foo`, found struct `Bar`
 static foo_i: Foo = Foo { a: 2, ..4 }; //~  ERROR mismatched types
                                        //~| expected type `Foo`
-                                       //~| found type `{numeric}`
+                                       //~| found type `{integer}`
                                        //~| expected struct `Foo`, found integral variable
 
 fn main() {

--- a/src/test/compile-fail/struct-base-wrong-type.rs
+++ b/src/test/compile-fail/struct-base-wrong-type.rs
@@ -23,7 +23,7 @@ static foo: Foo = Foo { a: 2, ..bar }; //~  ERROR mismatched types
                                        //~| expected struct `Foo`, found struct `Bar`
 static foo_i: Foo = Foo { a: 2, ..4 }; //~  ERROR mismatched types
                                        //~| expected type `Foo`
-                                       //~| found type `_`
+                                       //~| found type `{numeric}`
                                        //~| expected struct `Foo`, found integral variable
 
 fn main() {

--- a/src/test/compile-fail/traits-inductive-overflow-simultaneous.rs
+++ b/src/test/compile-fail/traits-inductive-overflow-simultaneous.rs
@@ -26,5 +26,5 @@ fn is_ee<T: Combo>(t: T) {
 
 fn main() {
     is_ee(4);
-    //~^ ERROR overflow evaluating the requirement `{numeric}: Tweedle
+    //~^ ERROR overflow evaluating the requirement `{integer}: Tweedle
 }

--- a/src/test/compile-fail/traits-inductive-overflow-simultaneous.rs
+++ b/src/test/compile-fail/traits-inductive-overflow-simultaneous.rs
@@ -26,5 +26,5 @@ fn is_ee<T: Combo>(t: T) {
 
 fn main() {
     is_ee(4);
-    //~^ ERROR overflow evaluating the requirement `_: Tweedle
+    //~^ ERROR overflow evaluating the requirement `{numeric}: Tweedle
 }

--- a/src/test/compile-fail/tuple-arity-mismatch.rs
+++ b/src/test/compile-fail/tuple-arity-mismatch.rs
@@ -16,7 +16,7 @@ fn main() {
     let y = first ((1,2.0,3));
     //~^ ERROR mismatched types
     //~| expected type `(isize, f64)`
-    //~| found type `(isize, f64, {numeric})`
+    //~| found type `(isize, f64, {integer})`
     //~| expected a tuple with 2 elements, found one with 3 elements
 
     let y = first ((1,));

--- a/src/test/compile-fail/tuple-arity-mismatch.rs
+++ b/src/test/compile-fail/tuple-arity-mismatch.rs
@@ -16,7 +16,7 @@ fn main() {
     let y = first ((1,2.0,3));
     //~^ ERROR mismatched types
     //~| expected type `(isize, f64)`
-    //~| found type `(isize, f64, _)`
+    //~| found type `(isize, f64, {numeric})`
     //~| expected a tuple with 2 elements, found one with 3 elements
 
     let y = first ((1,));

--- a/src/test/compile-fail/tuple-index-out-of-bounds.rs
+++ b/src/test/compile-fail/tuple-index-out-of-bounds.rs
@@ -20,5 +20,5 @@ fn main() {
     tuple.0;
     tuple.1;
     tuple.2;
-    //~^ ERROR attempted out-of-bounds tuple index `2` on type `({numeric}, {numeric})`
+    //~^ ERROR attempted out-of-bounds tuple index `2` on type `({integer}, {integer})`
 }

--- a/src/test/compile-fail/tuple-index-out-of-bounds.rs
+++ b/src/test/compile-fail/tuple-index-out-of-bounds.rs
@@ -20,5 +20,5 @@ fn main() {
     tuple.0;
     tuple.1;
     tuple.2;
-    //~^ ERROR attempted out-of-bounds tuple index `2` on type `(_, _)`
+    //~^ ERROR attempted out-of-bounds tuple index `2` on type `({numeric}, {numeric})`
 }

--- a/src/test/compile-fail/type-mismatch-multiple.rs
+++ b/src/test/compile-fail/type-mismatch-multiple.rs
@@ -13,7 +13,7 @@
 fn main() { let a: bool = 1; let b: i32 = true; }
 //~^ ERROR mismatched types
 //~| expected type `bool`
-//~| found type `{numeric}`
+//~| found type `{integer}`
 //~| expected bool, found integral variable
 //~| ERROR mismatched types
 //~| expected i32, found bool

--- a/src/test/compile-fail/type-mismatch-multiple.rs
+++ b/src/test/compile-fail/type-mismatch-multiple.rs
@@ -13,7 +13,7 @@
 fn main() { let a: bool = 1; let b: i32 = true; }
 //~^ ERROR mismatched types
 //~| expected type `bool`
-//~| found type `_`
+//~| found type `{numeric}`
 //~| expected bool, found integral variable
 //~| ERROR mismatched types
 //~| expected i32, found bool

--- a/src/test/compile-fail/typeck-unsafe-always-share.rs
+++ b/src/test/compile-fail/typeck-unsafe-always-share.rs
@@ -27,7 +27,7 @@ fn test<T: Sync>(s: T) {}
 fn main() {
     let us = UnsafeCell::new(MySync{u: UnsafeCell::new(0)});
     test(us);
-    //~^ ERROR `std::cell::UnsafeCell<MySync<{numeric}>>: std::marker::Sync` is not satisfied
+    //~^ ERROR `std::cell::UnsafeCell<MySync<{integer}>>: std::marker::Sync` is not satisfied
 
     let uns = UnsafeCell::new(NoSync);
     test(uns);

--- a/src/test/compile-fail/typeck-unsafe-always-share.rs
+++ b/src/test/compile-fail/typeck-unsafe-always-share.rs
@@ -27,7 +27,7 @@ fn test<T: Sync>(s: T) {}
 fn main() {
     let us = UnsafeCell::new(MySync{u: UnsafeCell::new(0)});
     test(us);
-    //~^ ERROR `std::cell::UnsafeCell<MySync<_>>: std::marker::Sync` is not satisfied
+    //~^ ERROR `std::cell::UnsafeCell<MySync<{numeric}>>: std::marker::Sync` is not satisfied
 
     let uns = UnsafeCell::new(NoSync);
     test(uns);

--- a/src/test/compile-fail/vtable-res-trait-param.rs
+++ b/src/test/compile-fail/vtable-res-trait-param.rs
@@ -24,7 +24,7 @@ impl TraitB for isize {
 
 fn call_it<B:TraitB>(b: B)  -> isize {
     let y = 4;
-    b.gimme_an_a(y) //~ ERROR `_: TraitA` is not satisfied
+    b.gimme_an_a(y) //~ ERROR `{numeric}: TraitA` is not satisfied
 }
 
 fn main() {

--- a/src/test/compile-fail/vtable-res-trait-param.rs
+++ b/src/test/compile-fail/vtable-res-trait-param.rs
@@ -24,7 +24,7 @@ impl TraitB for isize {
 
 fn call_it<B:TraitB>(b: B)  -> isize {
     let y = 4;
-    b.gimme_an_a(y) //~ ERROR `{numeric}: TraitA` is not satisfied
+    b.gimme_an_a(y) //~ ERROR `{integer}: TraitA` is not satisfied
 }
 
 fn main() {

--- a/src/test/ui/mismatched_types/issue-26480.stderr
+++ b/src/test/ui/mismatched_types/issue-26480.stderr
@@ -5,7 +5,7 @@ error[E0308]: mismatched types
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected u64, found usize
 $DIR/issue-26480.rs:38:5: 38:19 note: in this expansion of write! (defined in $DIR/issue-26480.rs)
 
-error: non-scalar cast: `{numeric}` as `()`
+error: non-scalar cast: `{integer}` as `()`
   --> $DIR/issue-26480.rs:33:19
    |
 33 |     ($x:expr) => ($x as ())

--- a/src/test/ui/mismatched_types/issue-26480.stderr
+++ b/src/test/ui/mismatched_types/issue-26480.stderr
@@ -5,7 +5,7 @@ error[E0308]: mismatched types
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected u64, found usize
 $DIR/issue-26480.rs:38:5: 38:19 note: in this expansion of write! (defined in $DIR/issue-26480.rs)
 
-error: non-scalar cast: `_` as `()`
+error: non-scalar cast: `{numeric}` as `()`
   --> $DIR/issue-26480.rs:33:19
    |
 33 |     ($x:expr) => ($x as ())


### PR DESCRIPTION
This PR renames _ to {integer} or {float} for unknown numeric types, to help people parse error messages that have numeric types that haven't been nailed down.

Example:

``` rust
fn main() {
    let x: String = 4;
}
```

Before:

```
error[E0308]: mismatched types
 --> quicktest.rs:2:21
  |
2 |     let x: String = 4;
  |                     ^ expected struct `std::string::String`, found integral variable
  |
  = note: expected type `std::string::String`
  = note:    found type `_`

error: aborting due to previous error
```

after:

```
error[E0308]: mismatched types
 --> quicktest.rs:2:21
  |
2 |     let x: String = 4;
  |                     ^ expected struct `std::string::String`, found integral variable
  |
  = note: expected type `std::string::String`
  = note:    found type `{integer}`

error: aborting due to previous error
```

```
```
