### PR TITLE
Revert "Remove unused methods from MultiSpan"

### DIFF
--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -193,6 +193,20 @@ impl MultiSpan {
         }
     }
 
+    pub fn from_span(primary_span: Span) -> MultiSpan {
+        MultiSpan {
+            primary_spans: vec![primary_span],
+            span_labels: vec![]
+        }
+    }
+
+    pub fn from_spans(vec: Vec<Span>) -> MultiSpan {
+        MultiSpan {
+            primary_spans: vec,
+            span_labels: vec![]
+        }
+    }
+
     pub fn push_span_label(&mut self, span: Span, label: String) {
         self.span_labels.push((span, label));
     }
@@ -240,10 +254,7 @@ impl MultiSpan {
 
 impl From<Span> for MultiSpan {
     fn from(span: Span) -> MultiSpan {
-        MultiSpan {
-            primary_spans: vec![span],
-            span_labels: vec![]
-        }
+        MultiSpan::from_span(span)
     }
 }
 


### PR DESCRIPTION
This reverts commit f7019a4e2f80577d38ec35fcebd64d5970b15f78.

That commit removed the only way to make a suggestion with more than one substitute. That feature is not used directly by rustc but exists and is used by Clippy. Bring it back until we come up with a better solution (suggestions don't use span labels, so it would make sense for them to use their own type).
Rational there: https://github.com/Manishearth/rust-clippy/pull/1119.

r? @jonathandturner
Cc @Manishearth
