### PR TITLE
Replace LLVM initialization with LLVMInitializeAll*

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -496,7 +496,13 @@ unsafe fn configure_llvm(sess: &Session) {
 
     llvm::LLVMInitializePasses();
 
-    llvm::initialize_available_targets();
+    llvm::LLVMRustInitializeAllTargetInfos();
+    llvm::LLVMRustInitializeAllTargets();
+    // FIXME: these could be delayed till just before-trans, potentially reducing peak memory
+    // usage.
+    llvm::LLVMRustInitializeAllTargetMCs();
+    llvm::LLVMRustInitializeAllAsmPrinters();
+    llvm::LLVMRustInitializeAllAsmParsers();
 
     llvm::LLVMRustSetLLVMOptions(llvm_args.len() as c_int,
                                  llvm_args.as_ptr());

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -2155,6 +2155,13 @@ extern {
 
     pub fn LLVMRustSetComdat(M: ModuleRef, V: ValueRef, Name: *const c_char);
     pub fn LLVMRustUnsetComdat(V: ValueRef);
+
+    // Target initialization
+    pub fn LLVMRustInitializeAllTargets();
+    pub fn LLVMRustInitializeAllTargetInfos();
+    pub fn LLVMRustInitializeAllTargetMCs();
+    pub fn LLVMRustInitializeAllAsmPrinters();
+    pub fn LLVMRustInitializeAllAsmParsers();
 }
 
 // LLVM requires symbols from this library, but apparently they're not printed
@@ -2364,59 +2371,6 @@ pub unsafe fn twine_to_string(tr: TwineRef) -> String {
 pub unsafe fn debug_loc_to_string(c: ContextRef, tr: DebugLocRef) -> String {
     build_string(|s| LLVMWriteDebugLocToString(c, tr, s))
         .expect("got a non-UTF8 DebugLoc from LLVM")
-}
-
-pub fn initialize_available_targets() {
-    macro_rules! init_target(
-        ($cfg:meta, $($method:ident),*) => { {
-            #[cfg($cfg)]
-            fn init() {
-                extern {
-                    $(fn $method();)*
-                }
-                unsafe {
-                    $($method();)*
-                }
-            }
-            #[cfg(not($cfg))]
-            fn init() { }
-            init();
-        } }
-    );
-    init_target!(llvm_component = "x86",
-                 LLVMInitializeX86TargetInfo,
-                 LLVMInitializeX86Target,
-                 LLVMInitializeX86TargetMC,
-                 LLVMInitializeX86AsmPrinter,
-                 LLVMInitializeX86AsmParser);
-    init_target!(llvm_component = "arm",
-                 LLVMInitializeARMTargetInfo,
-                 LLVMInitializeARMTarget,
-                 LLVMInitializeARMTargetMC,
-                 LLVMInitializeARMAsmPrinter,
-                 LLVMInitializeARMAsmParser);
-    init_target!(llvm_component = "aarch64",
-                 LLVMInitializeAArch64TargetInfo,
-                 LLVMInitializeAArch64Target,
-                 LLVMInitializeAArch64TargetMC,
-                 LLVMInitializeAArch64AsmPrinter,
-                 LLVMInitializeAArch64AsmParser);
-    init_target!(llvm_component = "mips",
-                 LLVMInitializeMipsTargetInfo,
-                 LLVMInitializeMipsTarget,
-                 LLVMInitializeMipsTargetMC,
-                 LLVMInitializeMipsAsmPrinter,
-                 LLVMInitializeMipsAsmParser);
-    init_target!(llvm_component = "powerpc",
-                 LLVMInitializePowerPCTargetInfo,
-                 LLVMInitializePowerPCTarget,
-                 LLVMInitializePowerPCTargetMC,
-                 LLVMInitializePowerPCAsmPrinter,
-                 LLVMInitializePowerPCAsmParser);
-    init_target!(llvm_component = "pnacl",
-                 LLVMInitializePNaClTargetInfo,
-                 LLVMInitializePNaClTarget,
-                 LLVMInitializePNaClTargetMC);
 }
 
 pub fn last_error() -> Option<String> {

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #include "rustllvm.h"
+#include "llvm-c/Target.h"
 #include "llvm/Object/Archive.h"
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/IR/DiagnosticInfo.h"
@@ -1064,4 +1065,25 @@ extern "C" void LLVMRustSetComdat(LLVMModuleRef M, LLVMValueRef V, const char *N
 extern "C" void LLVMRustUnsetComdat(LLVMValueRef V) {
     GlobalObject *GV = unwrap<GlobalObject>(V);
     GV->setComdat(nullptr);
+}
+
+// FIXME(#34962): should eventually use the functions directly once they become non-inline
+extern "C" void LLVMRustInitializeAllTargets() {
+    LLVMInitializeAllTargets();
+}
+
+extern "C" void LLVMRustInitializeAllTargetInfos() {
+    LLVMInitializeAllTargetInfos();
+}
+
+extern "C" void LLVMRustInitializeAllTargetMCs() {
+    LLVMInitializeAllTargetMCs();
+}
+
+extern "C" void LLVMRustInitializeAllAsmPrinters() {
+    LLVMInitializeAllAsmPrinters();
+}
+
+extern "C" void LLVMRustInitializeAllAsmParsers() {
+    LLVMInitializeAllAsmParsers();
 }


### PR DESCRIPTION
Primary benefit of this change is that Rust now can support all LLVM targets which the LLVM that
has been linked to supports. Namely, this if the system LLVM, which supports extra targets, is
used, then rustc could also build code for them.

That being said, the list of supported targets is still determined during rustc bootstrap. This will change once something like [this](https://reviews.llvm.org/D22736) lands.

Fixes #34962
