### PR TITLE
Make it clear that the reference isn't normative

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -21,6 +21,11 @@ separately by extracting documentation attributes from their source code. Many
 of the features that one might expect to be language features are library
 features in Rust, so what you're looking for may be there, not here.
 
+Finally, this document is not normative. It may include details that are
+specific to `rustc` itself, and should not be taken as a specification for
+the Rust language. We intend to produce such a document someday, but this
+is what we have for now.
+
 You may also be interested in the [grammar].
 
 [book]: book/index.html


### PR DESCRIPTION
Any time someone edits the reference, it has to be taken very seriously,
since it's the closest thing we have to a specification. This commit
adds language which indicates that this is not a normative document,
which makes it easier to make tweaks without worrying about forever
harming the future of Rust by painting ourselves in a corner.

r? @aturon 
