### PR TITLE
syntax_ext: format: fix ICE with bad named arguments

### DIFF
--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -406,7 +406,9 @@ impl<'a, 'b> Context<'a, 'b> {
                             let arg_idx = match arg_index_consumed.get_mut(i) {
                                 None => 0, // error already emitted elsewhere
                                 Some(offset) => {
-                                    let arg_idx = self.arg_index_map[i][*offset];
+                                    let ref idx_map = self.arg_index_map[i];
+                                    // unwrap_or branch: error already emitted elsewhere
+                                    let arg_idx = *idx_map.get(*offset).unwrap_or(&0);
                                     *offset += 1;
                                     arg_idx
                                 }

--- a/src/test/compile-fail/ifmt-bad-arg.rs
+++ b/src/test/compile-fail/ifmt-bad-arg.rs
@@ -41,6 +41,12 @@ fn main() {
     //~^ ERROR invalid reference to argument `0` (no arguments given)
     //~^^ ERROR invalid reference to argument `1` (no arguments given)
 
+    // bad named arguments, #35082
+
+    format!("{valuea} {valueb}", valuea=5, valuec=7);
+    //~^ ERROR there is no argument named `valueb`
+    //~^^ ERROR named argument never used
+
     // bad syntax of the format string
 
     format!("{"); //~ ERROR: expected `'}'` but string was terminated


### PR DESCRIPTION
Fixes #35082 by guarding against a new case of malformed invocation not previously covered.

r? @alexcrichton 
