### PR TITLE
Add an option to emit the metadata for a crate.

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -69,6 +69,7 @@ pub enum OutputType {
     Object,
     Exe,
     DepInfo,
+    Metadata,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -87,6 +88,7 @@ impl OutputType {
     fn is_compatible_with_codegen_units_and_single_output_file(&self) -> bool {
         match *self {
             OutputType::Exe |
+            OutputType::Metadata |
             OutputType::DepInfo => true,
             OutputType::Bitcode |
             OutputType::Assembly |
@@ -103,6 +105,7 @@ impl OutputType {
             OutputType::Object => "obj",
             OutputType::Exe => "link",
             OutputType::DepInfo => "dep-info",
+            OutputType::Metadata => "metadata",
         }
     }
 
@@ -114,6 +117,7 @@ impl OutputType {
             OutputType::Object => "o",
             OutputType::DepInfo => "d",
             OutputType::Exe => "",
+            OutputType::Metadata => "metadata.o",
         }
     }
 }
@@ -991,7 +995,7 @@ pub fn rustc_short_optgroups() -> Vec<RustcOptGroup> {
                "NAME"),
         opt::multi_s("", "emit", "Comma separated list of types of output for \
                               the compiler to emit",
-                 "[asm|llvm-bc|llvm-ir|obj|link|dep-info]"),
+                 "[asm|llvm-bc|llvm-ir|obj|link|dep-info|metadata]"),
         opt::multi_s("", "print", "Comma separated list of compiler information to \
                                print on stdout",
                  "[crate-name|file-names|sysroot|cfg|target-list]"),
@@ -1161,6 +1165,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
                     "obj" => OutputType::Object,
                     "link" => OutputType::Exe,
                     "dep-info" => OutputType::DepInfo,
+                    "metadata" => OutputType::Metadata,
                     part => {
                         early_error(error_format, &format!("unknown emission type: `{}`",
                                                     part))

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -208,7 +208,14 @@ pub fn link_binary(sess: &Session,
         for obj in object_filenames(trans, outputs) {
             remove(sess, &obj);
         }
-        remove(sess, &outputs.with_extension("metadata.o"));
+
+        // Only remove the metadata if the user didn't request it, or it got
+        // saved somewhere else
+        let metadata_temp = outputs.with_extension("metadata.o");
+        if !outputs.outputs.contains_key(&OutputType::Metadata) ||
+            outputs.path(OutputType::Metadata) != metadata_temp {
+            remove(sess, &metadata_temp);
+        }
     }
 
     out_filenames

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -715,6 +715,9 @@ pub fn run_passes(sess: &Session,
                 modules_config.emit_obj = true;
                 metadata_config.emit_obj = true;
             },
+            OutputType::Metadata => {
+                metadata_config.emit_obj = true;
+            },
             OutputType::DepInfo => {}
         }
     }
@@ -779,8 +782,10 @@ pub fn run_passes(sess: &Session,
 
     // Produce final compile outputs.
     let copy_gracefully = |from: &Path, to: &Path| {
-        if let Err(e) = fs::copy(from, to) {
-            sess.err(&format!("could not copy {:?} to {:?}: {}", from, to, e));
+        if from != to {
+            if let Err(e) = fs::copy(from, to) {
+                sess.err(&format!("could not copy {:?} to {:?}: {}", from, to, e));
+            }
         }
     };
 
@@ -847,6 +852,10 @@ pub fn run_passes(sess: &Session,
                 user_wants_objects = true;
                 copy_if_one_unit(OutputType::Object, true);
             }
+            OutputType::Metadata => {
+                copy_gracefully(&crate_output.with_extension("metadata.o"),
+                                &crate_output.path(OutputType::Metadata));
+            },
             OutputType::Exe |
             OutputType::DepInfo => {}
         }
@@ -905,6 +914,17 @@ pub fn run_passes(sess: &Session,
             let path = crate_output.temp_path(OutputType::Bitcode,
                                               Some(&trans.metadata_module.name[..]));
             remove(sess, &path);
+        }
+
+        // If we don't plan on linking, then we remove the metadata object here.
+        // If the user requested metadata and specified an output path different to the default,
+        // then we can delete the original.
+        let metadata_temp = crate_output.temp_path(OutputType::Metadata, None);
+        if metadata_config.emit_obj &&
+            !needs_crate_object &&
+            crate_output.path(OutputType::Metadata) != metadata_temp {
+
+            remove(sess, &metadata_temp);
         }
     }
 

--- a/src/test/run-make/issue-30063/Makefile
+++ b/src/test/run-make/issue-30063/Makefile
@@ -29,6 +29,10 @@ all:
 	$(RUSTC) -C codegen-units=4 --emit=dep-info -o $(TMPDIR)/dep-output foo.rs
 	rm $(TMPDIR)/dep-output
 
+	rm -f $(TMPDIR)/metadata-output
+	$(RUSTC) -C codegen-units=4 --emit=metadata -o $(TMPDIR)/metadata-output foo.rs
+	rm $(TMPDIR)/metadata-output
+
 #	# (This case doesn't work yet, and may be fundamentally wrong-headed anyway.)
 #	rm -f $(TMPDIR)/multi-output
 #	$(RUSTC) -C codegen-units=4 --emit=asm,obj -o $(TMPDIR)/multi-output foo.rs

--- a/src/test/run-make/metadata/Makefile
+++ b/src/test/run-make/metadata/Makefile
@@ -1,0 +1,28 @@
+-include ../tools.mk
+
+# Linking the object and the metadata externally should produce a usable library
+all: $(call RUN_BINFILE,baz)
+
+$(TMPDIR)/foo.o: foo.rs
+	$(RUSTC) -C prefer-dynamic --emit=obj $<
+
+$(TMPDIR)/foo.metadata.o: foo.rs
+	$(RUSTC) -C prefer-dynamic --emit=metadata $<
+
+	# Make sure the output only contains metadata.
+	nm "$(TMPDIR)/foo.metadata.o" | grep -vq bar
+	nm "$(TMPDIR)/foo.metadata.o" | grep -q metadata
+
+ifeq ($(UNAME),Darwin)
+$(call DYLIB,foo): $(TMPDIR)/foo.o $(TMPDIR)/foo.metadata.o
+	$(CC) -dynamiclib -Wl,dylib -o $@ $^
+else ifdef IS_MSVC
+$(call DYLIB,foo): $(TMPDIR)/foo.o $(TMPDIR)/foo.metadata.o
+	$(CC) $^ -link -dll -out:`cygpath -w $@`
+else
+$(call DYLIB,foo): $(TMPDIR)/foo.o $(TMPDIR)/foo.metadata.o
+	$(CC) -shared -o $@ $^
+endif
+
+$(call RUN_BINFILE,baz): baz.rs $(call DYLIB,foo)
+	$(RUSTC) $<

--- a/src/test/run-make/metadata/baz.rs
+++ b/src/test/run-make/metadata/baz.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type="bin"]
+
+extern crate foo;
+
+pub fn main() {
+    foo::bar();
+}

--- a/src/test/run-make/metadata/foo.rs
+++ b/src/test/run-make/metadata/foo.rs
@@ -1,0 +1,13 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type="dylib"]
+
+pub fn bar() {}

--- a/src/test/run-make/output-type-permutations/Makefile
+++ b/src/test/run-make/output-type-permutations/Makefile
@@ -14,10 +14,11 @@ all:
 	rm -f $(TMPDIR)/bar.pdb
 	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
 
-	$(RUSTC) foo.rs --emit=asm,llvm-ir,llvm-bc,obj,link
+	$(RUSTC) foo.rs --emit=asm,llvm-ir,llvm-bc,metadata,obj,link
 	rm $(TMPDIR)/bar.ll
 	rm $(TMPDIR)/bar.bc
 	rm $(TMPDIR)/bar.s
+	rm $(TMPDIR)/bar.metadata.o
 	rm $(TMPDIR)/bar.o
 	rm $(TMPDIR)/$(call BIN,bar)
 	rm -f $(TMPDIR)/bar.pdb
@@ -44,6 +45,14 @@ all:
 	$(RUSTC) foo.rs --emit llvm-ir=$(TMPDIR)/foo
 	rm $(TMPDIR)/foo
 	$(RUSTC) foo.rs --emit=llvm-ir=$(TMPDIR)/foo
+	rm $(TMPDIR)/foo
+	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
+
+	$(RUSTC) foo.rs --emit metadata -o $(TMPDIR)/foo
+	rm $(TMPDIR)/foo
+	$(RUSTC) foo.rs --emit metadata=$(TMPDIR)/foo
+	rm $(TMPDIR)/foo
+	$(RUSTC) foo.rs --emit=metadata=$(TMPDIR)/foo
 	rm $(TMPDIR)/foo
 	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
 
@@ -108,30 +117,35 @@ all:
 	$(RUSTC) foo.rs --emit asm=$(TMPDIR)/asm \
 			--emit llvm-ir=$(TMPDIR)/ir \
 			--emit llvm-bc=$(TMPDIR)/bc \
+		        --emit metadata=$(TMPDIR)/metadata \
 		        --emit obj=$(TMPDIR)/obj \
 			--emit link=$(TMPDIR)/link \
 			--crate-type=staticlib
 	rm $(TMPDIR)/asm
 	rm $(TMPDIR)/ir
 	rm $(TMPDIR)/bc
+	rm $(TMPDIR)/metadata
 	rm $(TMPDIR)/obj
 	rm $(TMPDIR)/link
 	$(RUSTC) foo.rs --emit=asm=$(TMPDIR)/asm \
 			--emit llvm-ir=$(TMPDIR)/ir \
 			--emit=llvm-bc=$(TMPDIR)/bc \
-		        --emit obj=$(TMPDIR)/obj \
-			--emit=link=$(TMPDIR)/link \
+		        --emit metadata=$(TMPDIR)/metadata \
+		        --emit=obj=$(TMPDIR)/obj \
+			--emit link=$(TMPDIR)/link \
 			--crate-type=staticlib
 	rm $(TMPDIR)/asm
 	rm $(TMPDIR)/ir
 	rm $(TMPDIR)/bc
+	rm $(TMPDIR)/metadata
 	rm $(TMPDIR)/obj
 	rm $(TMPDIR)/link
 	[ "$$(ls -1 $(TMPDIR) | wc -l)" -eq "0" ]
 
-	$(RUSTC) foo.rs --emit=asm,llvm-ir,llvm-bc,obj,link --crate-type=staticlib
+	$(RUSTC) foo.rs --emit=asm,llvm-ir,llvm-bc,metadata,obj,link --crate-type=staticlib
 	rm $(TMPDIR)/bar.ll
 	rm $(TMPDIR)/bar.s
+	rm $(TMPDIR)/bar.metadata.o
 	rm $(TMPDIR)/bar.o
 	rm $(call STATICLIB,bar)
 	mv $(TMPDIR)/bar.bc $(TMPDIR)/foo.bc


### PR DESCRIPTION
This, combined with `--emit obj` allows external linking of dylibs,
while still being able to use them as rust libraries or plugins.
