### PR TITLE
mk: Don't duplicate compiler-rt symbols

### DIFF
--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -272,14 +272,8 @@ COMPRT_OBJS_$(1) := \
   fixunsxfdi.o \
   fixunsxfsi.o \
   fixxfdi.o \
-  floatdidf.o \
-  floatdisf.o \
-  floatdixf.o \
   floatsidf.o \
   floatsisf.o \
-  floatundidf.o \
-  floatundisf.o \
-  floatundixf.o \
   floatunsidf.o \
   floatunsisf.o \
   int_util.o \
@@ -397,9 +391,7 @@ COMPRT_OBJS_$(1) += \
       x86_64/floatundidf.o \
       x86_64/floatundisf.o \
       x86_64/floatundixf.o
-endif
-
-ifeq ($$(findstring i686,$$(patsubts i%86,i686,$(1))),i686)
+else ifeq ($$(findstring i686,$$(patsubts i%86,i686,$(1))),i686)
 COMPRT_OBJS_$(1) += \
       i386/ashldi3.o \
       i386/ashrdi3.o \
@@ -417,6 +409,14 @@ COMPRT_OBJS_$(1) += \
       i386/muldi3.o \
       i386/udivdi3.o \
       i386/umoddi3.o
+else
+COMPRT_OBJS_$(1) += \
+  floatdidf.o \
+  floatdisf.o \
+  floatdixf.o \
+  floatundidf.o \
+  floatundisf.o \
+  floatundixf.o \
 endif
 
 else
@@ -425,7 +425,10 @@ ifeq ($$(findstring x86_64,$(1)),x86_64)
 COMPRT_OBJS_$(1) += \
       x86_64/floatdidf.o \
       x86_64/floatdisf.o \
-      x86_64/floatdixf.o
+      x86_64/floatdixf.o \
+      floatundidf.o \
+      floatundisf.o \
+      floatundixf.o \
 endif
 
 endif

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -226,14 +226,8 @@ pub fn compiler_rt(build: &Build, target: &str) {
         "fixunsxfdi.c",
         "fixunsxfsi.c",
         "fixxfdi.c",
-        "floatdidf.c",
-        "floatdisf.c",
-        "floatdixf.c",
         "floatsidf.c",
         "floatsisf.c",
-        "floatundidf.c",
-        "floatundisf.c",
-        "floatundixf.c",
         "floatunsidf.c",
         "floatunsisf.c",
         "int_util.c",
@@ -345,6 +339,18 @@ pub fn compiler_rt(build: &Build, target: &str) {
                 "x86_64/floatdidf.c",
                 "x86_64/floatdisf.c",
                 "x86_64/floatdixf.c",
+                "floatundidf.c",
+                "floatundisf.c",
+                "floatundixf.c",
+            ]);
+        } else {
+            sources.extend(vec![
+                "floatdidf.c",
+                "floatdisf.c",
+                "floatdixf.c",
+                "floatundidf.c",
+                "floatundisf.c",
+                "floatundixf.c",
             ]);
         }
     } else {
@@ -361,9 +367,7 @@ pub fn compiler_rt(build: &Build, target: &str) {
                 "x86_64/floatundisf.S",
                 "x86_64/floatundixf.S",
             ]);
-        }
-
-        if target.contains("i386") ||
+        } else if target.contains("i386") ||
            target.contains("i586") ||
            target.contains("i686") {
             sources.extend(vec![
@@ -383,6 +387,15 @@ pub fn compiler_rt(build: &Build, target: &str) {
                 "i386/muldi3.S",
                 "i386/udivdi3.S",
                 "i386/umoddi3.S",
+            ]);
+        } else {
+            sources.extend(vec![
+                "floatdidf.c",
+                "floatdisf.c",
+                "floatdixf.c",
+                "floatundidf.c",
+                "floatundisf.c",
+                "floatundixf.c",
             ]);
         }
     }


### PR DESCRIPTION
Now that we build compiler-rt ourselves, we have to deal with build system
weirdness. Looks like some intrinsics have multiple definitions and we want to
be sure to only include one copy for each architecture.
