### PR TITLE
Provide more explicit example of wildcard version in guessing game doc.

### DIFF
--- a/src/doc/book/guessing-game.md
+++ b/src/doc/book/guessing-game.md
@@ -365,7 +365,7 @@ numbers. A bare number like above is actually shorthand for `^0.3.0`,
 meaning "anything compatible with 0.3.0".
 If we wanted to use only `0.3.0` exactly, we could say `rand="=0.3.0"`
 (note the two equal signs).
-And if we wanted to use the latest version we could use `*`.
+And if we wanted to use the latest version we could use `rand="*"`.
 We could also use a range of versions.
 [Cargo’s documentation][cargodoc] contains more details.
 


### PR DESCRIPTION
Beginners may try to adapt the tutorial to develop their own code.
When using different dependencies, they may use the wildcard for
versioning.  Since they are new to the language, they will not know
that the wildcard asterisk is a string, not a token.  Make the correct
format more explicit, to remove one potential source of frustration.
