### PR TITLE
tcp-stress-test: Pull out thread count as a constant

### DIFF
--- a/src/test/run-pass/tcp-stress.rs
+++ b/src/test/run-pass/tcp-stress.rs
@@ -21,6 +21,8 @@ use std::sync::mpsc::channel;
 use std::time::Duration;
 use std::thread::{self, Builder};
 
+const TARGET_CNT: usize = 1000;
+
 fn main() {
     // This test has a chance to time out, try to not let it time out
     thread::spawn(move|| -> () {
@@ -42,8 +44,9 @@ fn main() {
     });
 
     let (tx, rx) = channel();
+
     let mut spawned_cnt = 0;
-    for _ in 0..1000 {
+    for _ in 0..TARGET_CNT {
         let tx = tx.clone();
         let res = Builder::new().stack_size(64 * 1024).spawn(move|| {
             match TcpStream::connect(addr) {
@@ -66,6 +69,6 @@ fn main() {
     for _ in 0..spawned_cnt {
         rx.recv().unwrap();
     }
-    assert_eq!(spawned_cnt, 1000);
+    assert_eq!(spawned_cnt, TARGET_CNT);
     process::exit(0);
 }

--- a/src/test/run-pass/tcp-stress.rs
+++ b/src/test/run-pass/tcp-stress.rs
@@ -21,7 +21,7 @@ use std::sync::mpsc::channel;
 use std::time::Duration;
 use std::thread::{self, Builder};
 
-const TARGET_CNT: usize = 1000;
+const TARGET_CNT: usize = 200;
 
 fn main() {
     // This test has a chance to time out, try to not let it time out


### PR DESCRIPTION
This PR factors out the number of concurrent threads used in `tcp-stress-test.rs` to a constant at the top of the file.

We at @NixOS had to lower our thread count as the chrooted-builds don't allow that many threads. 

This change will make it easier to lower/increase the count in the future (I actually forgot to change the second `1000` when I was working on this). Another benefit is the removal of magic numbers in the test suite.

This is related to https://github.com/rust-lang/rust/issues/35107
