### PR TITLE
core: fix `cargo build` for targets with "max-atomic-width": 0

### DIFF
--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -74,6 +74,8 @@
 //! ```
 
 #![stable(feature = "rust1", since = "1.0.0")]
+#![cfg_attr(not(target_has_atomic = "8"), allow(dead_code))]
+#![cfg_attr(not(target_has_atomic = "8"), allow(unused_imports))]
 
 use self::Ordering::*;
 


### PR DESCRIPTION
This crate was failing to compile due to dead_code/unused_imports
warnings. This commits disables these two lints for these targets.

---

r? @alexcrichton 
cc @Amanieu is `cfg(target_has_atomic = "8")` the right `cfg` to use? I think that all targets that support some form of atomics will at a minimum support byte level atomics.

FWIW, the only thing that's left in `sync::atomic` for these targets is `Ordering` and the `fence` function.
