### PR TITLE
Add -mrelax-relocations=no hacks to fix musl build

### DIFF
--- a/mk/cfg/x86_64-unknown-linux-musl.mk
+++ b/mk/cfg/x86_64-unknown-linux-musl.mk
@@ -7,8 +7,8 @@ CFG_INSTALL_ONLY_RLIB_x86_64-unknown-linux-musl = 1
 CFG_LIB_NAME_x86_64-unknown-linux-musl=lib$(1).so
 CFG_STATIC_LIB_NAME_x86_64-unknown-linux-musl=lib$(1).a
 CFG_LIB_GLOB_x86_64-unknown-linux-musl=lib$(1)-*.so
-CFG_JEMALLOC_CFLAGS_x86_64-unknown-linux-musl := -m64
-CFG_GCCISH_CFLAGS_x86_64-unknown-linux-musl :=  -g -fPIC -m64
+CFG_JEMALLOC_CFLAGS_x86_64-unknown-linux-musl := -m64 -Wa,-mrelax-relocations=no
+CFG_GCCISH_CFLAGS_x86_64-unknown-linux-musl :=  -g -fPIC -m64 -Wa,-mrelax-relocations=no
 CFG_GCCISH_CXXFLAGS_x86_64-unknown-linux-musl :=
 CFG_GCCISH_LINK_FLAGS_x86_64-unknown-linux-musl :=
 CFG_GCCISH_DEF_FLAG_x86_64-unknown-linux-musl :=

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -855,6 +855,12 @@ impl Build {
             base.push("-stdlib=libc++".into());
             base.push("-mmacosx-version-min=10.7".into());
         }
+        // This is a hack, because newer binutils broke things 
+        // on some vms/distros (i.e., linking against unknown relocs disabled by the following flag) 
+        // See: https://github.com/rust-lang/rust/issues/34978
+        if target == "x86_64-unknown-linux-musl" {
+            base.push("-Wa,-mrelax-relocations=no".into());
+        }
         return base
     }
 

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -855,8 +855,8 @@ impl Build {
             base.push("-stdlib=libc++".into());
             base.push("-mmacosx-version-min=10.7".into());
         }
-        // This is a hack, because newer binutils broke things 
-        // on some vms/distros (i.e., linking against unknown relocs disabled by the following flag) 
+        // This is a hack, because newer binutils broke things on some vms/distros
+        // (i.e., linking against unknown relocs disabled by the following flag)
         // See: https://github.com/rust-lang/rust/issues/34978
         if target == "x86_64-unknown-linux-musl" {
             base.push("-Wa,-mrelax-relocations=no".into());


### PR DESCRIPTION
- this is just a start, dunno if it will work, but I'll just push it out to get feedback (my rust is still building :cry:)
- I don't know much about rustbuild, so i just added that flag in there. it's a total hack, don't judge me
- I suspect the places in the musl .mk files are sufficient (but we may also need it present when building std), I'm not sure, needs more testing.
