### PR TITLE
rustc_trans: don't lose the cross-crate DefId, MIR trans needs it.

### DIFF
--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -1918,9 +1918,9 @@ pub fn trans_closure<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
 }
 
 pub fn trans_instance<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, instance: Instance<'tcx>) {
-    let instance = inline::maybe_inline_instance(ccx, instance);
+    let local_instance = inline::maybe_inline_instance(ccx, instance);
 
-    let fn_node_id = ccx.tcx().map.as_local_node_id(instance.def).unwrap();
+    let fn_node_id = ccx.tcx().map.as_local_node_id(local_instance.def).unwrap();
 
     let _s = StatRecorder::new(ccx, ccx.tcx().node_path_str(fn_node_id));
     debug!("trans_instance(instance={:?})", instance);
@@ -1936,7 +1936,7 @@ pub fn trans_instance<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, instance: Instance
     let sig = ccx.tcx().normalize_associated_type(&sig);
     let abi = fn_ty.fn_abi();
 
-    let lldecl = match ccx.instances().borrow().get(&instance) {
+    let lldecl = match ccx.instances().borrow().get(&local_instance) {
         Some(&val) => val,
         None => bug!("Instance `{:?}` not already declared", instance)
     };

--- a/src/librustc_trans/debuginfo/mod.rs
+++ b/src/librustc_trans/debuginfo/mod.rs
@@ -32,6 +32,7 @@ use rustc::hir;
 
 use abi::Abi;
 use common::{NodeIdAndSpan, CrateContext, FunctionContext, Block, BlockAndBuilder};
+use inline;
 use monomorphize::{self, Instance};
 use rustc::ty::{self, Ty};
 use session::config::{self, FullDebugInfo, LimitedDebugInfo, NoDebugInfo};
@@ -238,6 +239,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
     // Do this here already, in case we do an early exit from this function.
     source_loc::set_debug_location(cx, None, UnknownLocation);
 
+    let instance = inline::maybe_inline_instance(cx, instance);
     let (containing_scope, span) = get_containing_scope_and_span(cx, instance);
 
     // This can be the case for functions inlined from another crate

--- a/src/test/run-pass/mir_cross_crate.rs
+++ b/src/test/run-pass/mir_cross_crate.rs
@@ -1,0 +1,28 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z orbit
+// Tests that -Z orbit affects functions from other crates.
+
+#![feature(unsafe_no_drop_flag)]
+
+#[unsafe_no_drop_flag]
+struct Foo;
+
+impl Drop for Foo {
+    fn drop(&mut self) {
+        panic!("MIR trans is not enabled for mem::forget");
+    }
+}
+
+fn main() {
+    let x = Foo;
+    std::mem::forget(x);
+}


### PR DESCRIPTION
We might have been missing out on some issues because MIR trans was never being used cross-crate.

cc @rust-lang/compiler
