### PR TITLE
Add tested uclibc target

### DIFF
--- a/mk/cfg/x86_64-unknown-linux-uclibc.mk
+++ b/mk/cfg/x86_64-unknown-linux-uclibc.mk
@@ -21,9 +21,9 @@ CFG_LDPATH_x86_64-unknown-linux-uclibc :=
 CFG_RUN_x86_64-unknown-linux-uclibc=$(2)
 CFG_RUN_TARG_x86_64-unknown-linux-uclibc=$(call CFG_RUN_x86_64-unknown-linux-uclibc,,$(2))
 CFG_GNU_TRIPLE_x86_64-unknown-linux-uclibc := x86_64-unknown-linux-uclibc
-CFG_THIRD_PARTY_OBJECTS_x86_64-unknown-linux-uclibc := crt1.o crti.o crtn.o
+#CFG_THIRD_PARTY_OBJECTS_x86_64-unknown-linux-uclibc := crt1.o crti.o crtn.o
 CFG_INSTALLED_OBJECTS_x86_64-unknown-linux-uclibc := crt1.o crti.o crtn.o
 
-NATIVE_DEPS_libc_T_x86_64-unknown-linux-uclibc += libc.a
+#NATIVE_DEPS_libc_T_x86_64-unknown-linux-uclibc += libc.a
 NATIVE_DEPS_std_T_x86_64-unknown-linux-uclibc += crt1.o crti.o crtn.o
-NATIVE_DEPS_unwind_T_x86_64-unknown-linux-uclibc += libunwind.a
+#NATIVE_DEPS_unwind_T_x86_64-unknown-linux-uclibc += libunwind.a

--- a/mk/cfg/x86_64-unknown-linux-uclibc.mk
+++ b/mk/cfg/x86_64-unknown-linux-uclibc.mk
@@ -1,0 +1,29 @@
+# x86_64-unknown-linux-uclibc configuration
+CC_x86_64-unknown-linux-uclibc=$(CFG_UCLIBC_ROOT)/bin/uclibc-gcc
+CXX_x86_64-unknown-linux-uclibc=notaprogram
+CPP_x86_64-unknown-linux-uclibc=$(CFG_UCLIBC_ROOT)/bin/uclibc-gcc -E
+AR_x86_64-unknown-linux-uclibc=$(AR)
+CFG_INSTALL_ONLY_RLIB_x86_64-unknown-linux-uclibc = 1
+CFG_LIB_NAME_x86_64-unknown-linux-uclibc=lib$(1).so
+CFG_STATIC_LIB_NAME_x86_64-unknown-linux-uclibc=lib$(1).a
+CFG_LIB_GLOB_x86_64-unknown-linux-uclibc=lib$(1)-*.so
+CFG_JEMALLOC_CFLAGS_x86_64-unknown-linux-uclibc := -m64
+CFG_GCCISH_CFLAGS_x86_64-unknown-linux-uclibc := -Wall -Werror -g -fPIC -m64
+CFG_GCCISH_CXXFLAGS_x86_64-unknown-linux-uclibc :=
+CFG_GCCISH_LINK_FLAGS_x86_64-unknown-linux-uclibc :=
+CFG_GCCISH_DEF_FLAG_x86_64-unknown-linux-uclibc :=
+CFG_LLC_FLAGS_x86_64-unknown-linux-uclibc :=
+CFG_INSTALL_NAME_x86_64-unknown-linux-uclibc =
+CFG_EXE_SUFFIX_x86_64-unknown-linux-uclibc =
+CFG_WINDOWSY_x86_64-unknown-linux-uclibc :=
+CFG_UNIXY_x86_64-unknown-linux-uclibc := 1
+CFG_LDPATH_x86_64-unknown-linux-uclibc :=
+CFG_RUN_x86_64-unknown-linux-uclibc=$(2)
+CFG_RUN_TARG_x86_64-unknown-linux-uclibc=$(call CFG_RUN_x86_64-unknown-linux-uclibc,,$(2))
+CFG_GNU_TRIPLE_x86_64-unknown-linux-uclibc := x86_64-unknown-linux-uclibc
+CFG_THIRD_PARTY_OBJECTS_x86_64-unknown-linux-uclibc := crt1.o crti.o crtn.o
+CFG_INSTALLED_OBJECTS_x86_64-unknown-linux-uclibc := crt1.o crti.o crtn.o
+
+NATIVE_DEPS_libc_T_x86_64-unknown-linux-uclibc += libc.a
+NATIVE_DEPS_std_T_x86_64-unknown-linux-uclibc += crt1.o crti.o crtn.o
+NATIVE_DEPS_unwind_T_x86_64-unknown-linux-uclibc += libunwind.a

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -143,6 +143,7 @@ supported_targets! {
     ("i686-unknown-linux-musl", i686_unknown_linux_musl),
     ("mips-unknown-linux-musl", mips_unknown_linux_musl),
     ("mipsel-unknown-linux-musl", mipsel_unknown_linux_musl),
+    ("x86_64-unknown-linux-uclibc", x86_64_unknown_linux_uclibc),
 
     ("i686-linux-android", i686_linux_android),
     ("arm-linux-androideabi", arm_linux_androideabi),

--- a/src/librustc_back/target/x86_64_unknown_linux_uclibc.rs
+++ b/src/librustc_back/target/x86_64_unknown_linux_uclibc.rs
@@ -1,0 +1,19 @@
+use target::Target;
+
+pub fn target() -> Target {
+    let mut base = super::linux_base::opts();
+    base.cpu = "x86-64".to_string();
+    base.max_atomic_width = 64;
+    base.pre_link_args.push("-m64".to_string());
+    Target {
+        llvm_target: "x86_64-unknown-linux-uclibc".to_string(),
+        data_layout: "e-m:e-i64:64-f80:128-n8:16:32:64-S128".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "64".to_string(),
+        arch: "x86_64".to_string(),
+        target_os: "linux".to_string(),
+        target_env: "uclibc".to_string(),
+        target_vendor: "unknown".to_string(),
+        options: base,
+    }
+}

--- a/src/librustc_back/target/x86_64_unknown_linux_uclibc.rs
+++ b/src/librustc_back/target/x86_64_unknown_linux_uclibc.rs
@@ -22,7 +22,7 @@ pub fn target() -> Target {
         target_pointer_width: "64".to_string(),
         arch: "x86_64".to_string(),
         target_os: "linux".to_string(),
-        target_env: "uclibc".to_string(),
+        //target_env: "uclibc".to_string(),
         target_vendor: "unknown".to_string(),
         options: base,
     }

--- a/src/librustc_back/target/x86_64_unknown_linux_uclibc.rs
+++ b/src/librustc_back/target/x86_64_unknown_linux_uclibc.rs
@@ -8,14 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use target::Target;
+use target::{Target, TargetResult};
 
-pub fn target() -> Target {
+pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();
     base.cpu = "x86-64".to_string();
     base.max_atomic_width = 64;
     base.pre_link_args.push("-m64".to_string());
-    Target {
+    Ok(Target {
         llvm_target: "x86_64-unknown-linux-uclibc".to_string(),
         data_layout: "e-m:e-i64:64-f80:128-n8:16:32:64-S128".to_string(),
         target_endian: "little".to_string(),
@@ -25,5 +25,5 @@ pub fn target() -> Target {
         target_env: "uclibc".to_string(),
         target_vendor: "unknown".to_string(),
         options: base,
-    }
+    })
 }

--- a/src/librustc_back/target/x86_64_unknown_linux_uclibc.rs
+++ b/src/librustc_back/target/x86_64_unknown_linux_uclibc.rs
@@ -1,3 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 use target::Target;
 
 pub fn target() -> Target {

--- a/src/librustc_back/target/x86_64_unknown_linux_uclibc.rs
+++ b/src/librustc_back/target/x86_64_unknown_linux_uclibc.rs
@@ -22,7 +22,7 @@ pub fn target() -> Target {
         target_pointer_width: "64".to_string(),
         arch: "x86_64".to_string(),
         target_os: "linux".to_string(),
-        //target_env: "uclibc".to_string(),
+        target_env: "uclibc".to_string(),
         target_vendor: "unknown".to_string(),
         options: base,
     }


### PR DESCRIPTION
Hi

I've been working with [Japaric](https://github.com/japaric/) on a uclibc target, and I've tested it locally quite a bit, as he has, and used [his script](https://gist.github.com/japaric/634f873e15b97bead71d95dee29aa11a#file-rust-uclibc-md) to build a working rust cross compiler. The only difference in steps there and in this branch is that the environment variables exported need to be added to the `~/.bashrc` of the mentioned `rust` user. It's rather straight forward in fact.

If I am correct, I'll be asked to update the nightly build and travis configuration, which I am totally down for, but if I could please get acceptance requirements regarding that and any demands for further changes up front that would help. This way, I give what is wanted, and the travis build can be altered to add uclibc target testing; otherwise, the merge would go in build passing, but with this code untested in order that others can see verification of it working. Further, I think it beneficial that I add files for alternative uclibc architectures since I've already done this, I can test and replicate the targets quickly in order to deliver more for others. But before I do that, I need to test further with travis and rust-buildroot, so I want to leave those for later steps.
