### PR TITLE
Updated E0071 to new format.

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3147,9 +3147,12 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         };
         if variant.is_none() || variant.unwrap().kind == ty::VariantKind::Tuple {
             // Reject tuple structs for now, braced and unit structs are allowed.
-            span_err!(self.tcx.sess, span, E0071,
-                      "`{}` does not name a struct or a struct variant",
-                      pprust::path_to_string(path));
+            struct_span_err!(self.tcx.sess, path.span, E0071,
+                             "`{}` does not name a struct or a struct variant",
+                             pprust::path_to_string(path))
+                .span_label(path.span, &format!("not a struct"))
+                .emit();
+
             return None;
         }
 

--- a/src/test/compile-fail/E0071.rs
+++ b/src/test/compile-fail/E0071.rs
@@ -11,6 +11,11 @@
 enum Foo { FirstValue(i32) }
 
 fn main() {
-    let u = Foo::FirstValue { value: 0 }; //~ ERROR E0071
-    let t = u32 { value: 4 }; //~ ERROR E0071
+    let u = Foo::FirstValue { value: 0 };
+    //~^ ERROR `Foo::FirstValue` does not name a struct or a struct variant [E0071]
+    //~| NOTE not a struct
+
+    let t = u32 { value: 4 };
+    //~^ ERROR `u32` does not name a struct or a struct variant [E0071]
+    //~| NOTE not a struct
 }

--- a/src/test/compile-fail/trait-as-struct-constructor.rs
+++ b/src/test/compile-fail/trait-as-struct-constructor.rs
@@ -13,4 +13,5 @@ trait TraitNotAStruct {}
 fn main() {
     TraitNotAStruct{ value: 0 };
     //~^ ERROR: `TraitNotAStruct` does not name a struct or a struct variant [E0071]
+    //~| NOTE not a struct
 }


### PR DESCRIPTION
Bonus: the span underlines only the name of the thing that's not a struct rather than the whole expression.

Part of #35233.
Fixes #35220.

r? @jonathandturner 
