### PR TITLE
[Beta] Change `html_root_url` to point to the latest beta documentation

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -65,7 +65,7 @@
             issue = "27783")]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+       html_root_url = "https://doc.rust-lang.org/beta/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
        test(no_crate_inject, attr(allow(unused_variables), deny(warnings))))]
 #![no_std]

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -25,7 +25,7 @@
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+       html_root_url = "https://doc.rust-lang.org/beta/",
        test(no_crate_inject, attr(deny(warnings))))]
 #![cfg_attr(not(stage0), deny(warnings))]
 

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -21,7 +21,7 @@
             issue = "27783")]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+       html_root_url = "https://doc.rust-lang.org/beta/",
        html_playground_url = "https://play.rust-lang.org/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
        test(no_crate_inject, attr(allow(unused_variables), deny(warnings))))]

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -48,7 +48,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+       html_root_url = "https://doc.rust-lang.org/beta/",
        html_playground_url = "https://play.rust-lang.org/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
        test(no_crate_inject, attr(deny(warnings))),

--- a/src/libflate/lib.rs
+++ b/src/libflate/lib.rs
@@ -20,7 +20,7 @@
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+       html_root_url = "https://doc.rust-lang.org/beta/",
        test(attr(deny(warnings))))]
 #![cfg_attr(not(stage0), deny(warnings))]
 

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -20,7 +20,7 @@
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+       html_root_url = "https://doc.rust-lang.org/beta/",
        html_playground_url = "https://play.rust-lang.org/",
        test(attr(deny(warnings))))]
 #![cfg_attr(not(stage0), deny(warnings))]

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -85,7 +85,7 @@
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+       html_root_url = "https://doc.rust-lang.org/beta/",
        html_playground_url = "https://play.rust-lang.org/",
        test(attr(deny(warnings))))]
 

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -290,7 +290,7 @@
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+       html_root_url = "https://doc.rust-lang.org/beta/",
        test(attr(allow(unused_variables), deny(warnings))))]
 #![cfg_attr(not(stage0), deny(warnings))]
 

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -164,7 +164,7 @@
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+       html_root_url = "https://doc.rust-lang.org/beta/",
        html_playground_url = "https://play.rust-lang.org/",
        test(attr(deny(warnings))))]
 #![deny(missing_docs)]

--- a/src/libpanic_abort/lib.rs
+++ b/src/libpanic_abort/lib.rs
@@ -19,7 +19,7 @@
 #![unstable(feature = "panic_abort", issue = "32837")]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+       html_root_url = "https://doc.rust-lang.org/beta/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 

--- a/src/libpanic_unwind/lib.rs
+++ b/src/libpanic_unwind/lib.rs
@@ -28,7 +28,7 @@
 #![unstable(feature = "panic_unwind", issue = "32837")]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+       html_root_url = "https://doc.rust-lang.org/beta/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -20,7 +20,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+       html_root_url = "https://doc.rust-lang.org/beta/",
        html_playground_url = "https://play.rust-lang.org/",
        test(attr(deny(warnings))))]
 #![cfg_attr(not(stage0), deny(warnings))]

--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -117,7 +117,7 @@
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+       html_root_url = "https://doc.rust-lang.org/beta/",
        html_playground_url = "https://play.rust-lang.org/",
        test(attr(deny(warnings))))]
 #![cfg_attr(not(stage0), deny(warnings))]

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -20,7 +20,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/")]
+       html_root_url = "https://doc.rust-lang.org/beta/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(associated_consts)]

--- a/src/librustc_back/lib.rs
+++ b/src/librustc_back/lib.rs
@@ -27,7 +27,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+      html_root_url = "https://doc.rust-lang.org/beta/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(box_syntax)]

--- a/src/librustc_borrowck/lib.rs
+++ b/src/librustc_borrowck/lib.rs
@@ -14,7 +14,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+      html_root_url = "https://doc.rust-lang.org/beta/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 
 #![allow(non_camel_case_types)]

--- a/src/librustc_const_eval/lib.rs
+++ b/src/librustc_const_eval/lib.rs
@@ -20,7 +20,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+      html_root_url = "https://doc.rust-lang.org/beta/")]
 
 
 #![feature(rustc_private)]

--- a/src/librustc_const_math/lib.rs
+++ b/src/librustc_const_math/lib.rs
@@ -20,7 +20,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+      html_root_url = "https://doc.rust-lang.org/beta/")]
 
 
 #![feature(rustc_private)]

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -22,7 +22,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+      html_root_url = "https://doc.rust-lang.org/beta/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(nonzero)]

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -20,7 +20,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+      html_root_url = "https://doc.rust-lang.org/beta/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(box_syntax)]

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -14,7 +14,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+      html_root_url = "https://doc.rust-lang.org/beta/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(custom_attribute)]

--- a/src/librustc_incremental/lib.rs
+++ b/src/librustc_incremental/lib.rs
@@ -16,7 +16,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+      html_root_url = "https://doc.rust-lang.org/beta/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(rustc_private)]

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -25,7 +25,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+      html_root_url = "https://doc.rust-lang.org/beta/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 
 #![cfg_attr(test, feature(test))]

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -19,7 +19,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/")]
+       html_root_url = "https://doc.rust-lang.org/beta/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(associated_consts)]

--- a/src/librustc_metadata/lib.rs
+++ b/src/librustc_metadata/lib.rs
@@ -14,7 +14,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/")]
+       html_root_url = "https://doc.rust-lang.org/beta/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(box_patterns)]

--- a/src/librustc_passes/lib.rs
+++ b/src/librustc_passes/lib.rs
@@ -20,7 +20,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/")]
+       html_root_url = "https://doc.rust-lang.org/beta/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(rustc_diagnostic_macros)]

--- a/src/librustc_plugin/lib.rs
+++ b/src/librustc_plugin/lib.rs
@@ -56,7 +56,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/")]
+       html_root_url = "https://doc.rust-lang.org/beta/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(staged_api)]

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -14,7 +14,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+      html_root_url = "https://doc.rust-lang.org/beta/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(rustc_diagnostic_macros)]

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -14,7 +14,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+      html_root_url = "https://doc.rust-lang.org/beta/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(associated_consts)]

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -14,7 +14,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+      html_root_url = "https://doc.rust-lang.org/beta/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(custom_attribute)]

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -20,7 +20,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+      html_root_url = "https://doc.rust-lang.org/beta/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(box_patterns)]

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -69,7 +69,7 @@ This API is completely unstable and subject to change.
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+      html_root_url = "https://doc.rust-lang.org/beta/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 
 #![allow(non_camel_case_types)]

--- a/src/librustc_unicode/lib.rs
+++ b/src/librustc_unicode/lib.rs
@@ -25,7 +25,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+       html_root_url = "https://doc.rust-lang.org/beta/",
        html_playground_url = "https://play.rust-lang.org/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
        test(no_crate_inject, attr(allow(unused_variables), deny(warnings))))]

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -14,7 +14,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+       html_root_url = "https://doc.rust-lang.org/beta/",
        html_playground_url = "https://play.rust-lang.org/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -22,7 +22,7 @@ Core encoding and decoding interfaces.
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+       html_root_url = "https://doc.rust-lang.org/beta/",
        html_playground_url = "https://play.rust-lang.org/",
        test(attr(allow(unused_variables), deny(warnings))))]
 #![cfg_attr(not(stage0), deny(warnings))]

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -204,7 +204,7 @@
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+       html_root_url = "https://doc.rust-lang.org/beta/",
        html_playground_url = "https://play.rust-lang.org/",
        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
        test(no_crate_inject, attr(deny(warnings))),

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -20,7 +20,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+       html_root_url = "https://doc.rust-lang.org/beta/",
        test(attr(deny(warnings))))]
 #![cfg_attr(not(stage0), deny(warnings))]
 

--- a/src/libsyntax_ext/lib.rs
+++ b/src/libsyntax_ext/lib.rs
@@ -16,7 +16,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/")]
+       html_root_url = "https://doc.rust-lang.org/beta/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(rustc_private)]

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -20,7 +20,7 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
       html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-      html_root_url = "https://doc.rust-lang.org/nightly/")]
+      html_root_url = "https://doc.rust-lang.org/beta/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 
 #![feature(custom_attribute)]

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -48,7 +48,7 @@
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+       html_root_url = "https://doc.rust-lang.org/beta/",
        html_playground_url = "https://play.rust-lang.org/",
        test(attr(deny(warnings))))]
 #![deny(missing_docs)]

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -29,7 +29,7 @@
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://doc.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/nightly/",
+       html_root_url = "https://doc.rust-lang.org/beta/",
        test(attr(deny(warnings))))]
 #![cfg_attr(not(stage0), deny(warnings))]
 


### PR DESCRIPTION
Partially addresses #30693 by changing `html_root_url` on all relevant crates to point to the latest beta docs instead of nightly. Fully addressing the issue would also involve updating `html_root_url` on stable to point to the current stable docs.
