### PR TITLE
Fix precedence table in reference

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -3049,7 +3049,8 @@ as
 == != < > <= >=
 &&
 ||
-= ..
+.. ...
+=
 ```
 
 Operators at the same precedence level are evaluated left-to-right. [Unary


### PR DESCRIPTION
Adds `..` and `...` and puts them above `=`

r? @steveklabnik 
