### PR TITLE
Update error format for E0062

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3063,6 +3063,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             remaining_fields.insert(field.name, field);
         }
 
+        let mut seen_fields = FnvHashMap();
+
         let mut error_happened = false;
 
         // Typecheck each field.
@@ -3071,13 +3073,25 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
             if let Some(v_field) = remaining_fields.remove(&field.name.node) {
                 expected_field_type = self.field_ty(field.span, v_field, substs);
+
+                seen_fields.insert(field.name.node, field.span);
             } else {
                 error_happened = true;
                 expected_field_type = tcx.types.err;
                 if let Some(_) = variant.find_field_named(field.name.node) {
-                    span_err!(self.tcx.sess, field.name.span, E0062,
-                        "field `{}` specified more than once",
-                        field.name.node);
+                    let mut err = struct_span_err!(self.tcx.sess,
+                                                field.name.span,
+                                                E0062,
+                                                "field `{}` specified more than once",
+                                                field.name.node);
+
+                    err.span_label(field.name.span, &format!("used more than once"));
+
+                    if let Some(prev_span) = seen_fields.get(&field.name.node) {
+                        err.span_label(*prev_span, &format!("first use of `{}`", field.name.node));
+                    }
+
+                    err.emit();
                 } else {
                     self.report_unknown_field(adt_ty, variant, field, ast_fields);
                 }

--- a/src/test/compile-fail/E0062.rs
+++ b/src/test/compile-fail/E0062.rs
@@ -14,7 +14,9 @@ struct Foo {
 
 fn main() {
     let x = Foo {
+        x: 0, //~ NOTE first use of `x`
         x: 0,
-        x: 0, //~ ERROR E0062
+        //~^ ERROR E0062
+        //~| NOTE used more than once
     };
 }


### PR DESCRIPTION
Fixes #35217 as part of #35233 

There seems to be an issue with the old format ignoring the labels which results in the incorrect line being rendered in the old format. I spoke with @jonathandturner about this and it seems to be a bug. Pertinent information [here](https://gist.github.com/trixnz/ad11e68687529e164427df8f8eb63116).

r? @jonathandturner
