### PR TITLE
Update E0379 to new format #35338

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -847,7 +847,9 @@ fn check_trait_fn_not_const<'a,'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
             // good
         }
         hir::Constness::Const => {
-            span_err!(ccx.tcx.sess, span, E0379, "trait fns cannot be declared const");
+            struct_span_err!(ccx.tcx.sess, span, E0379, "trait fns cannot be declared const")
+                .span_label(span, &format!("trait fns cannot be const"))
+                .emit()
         }
     }
 }

--- a/src/test/compile-fail/const-fn-mismatch.rs
+++ b/src/test/compile-fail/const-fn-mismatch.rs
@@ -20,7 +20,9 @@ trait Foo {
 }
 
 impl Foo for u32 {
-    const fn f() -> u32 { 22 } //~ ERROR E0379
+    const fn f() -> u32 { 22 }
+    //~^ ERROR E0379
+    //~| NOTE trait fns cannot be const
 }
 
 fn main() { }


### PR DESCRIPTION
Fixes #35338, as part of #35233.

But this does not include the bonus. From my understanding a Span is defined by a `hi` and a `lo` position within some context. A naive way would be to mutate the span so that `hi` is 5 positions from `lo` which corresponds to the `const` keyword. But this methods feels a bit rigid. Is there another way to do this?

r? @jonathandturner
