### PR TITLE
[MIR] Add Storage{Live,Dead} statements to emit llvm.lifetime.{start,end}.

### DIFF
--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -688,8 +688,17 @@ pub struct Statement<'tcx> {
 
 #[derive(Clone, Debug, RustcEncodable, RustcDecodable)]
 pub enum StatementKind<'tcx> {
+    /// Write the RHS Rvalue to the LHS Lvalue.
     Assign(Lvalue<'tcx>, Rvalue<'tcx>),
-    SetDiscriminant{ lvalue: Lvalue<'tcx>, variant_index: usize },
+
+    /// Write the discriminant for a variant to the enum Lvalue.
+    SetDiscriminant { lvalue: Lvalue<'tcx>, variant_index: usize },
+
+    /// Start a live range for the storage of the local.
+    StorageLive(Lvalue<'tcx>),
+
+    /// End the current live range for the storage of the local.
+    StorageDead(Lvalue<'tcx>),
 }
 
 impl<'tcx> Debug for Statement<'tcx> {
@@ -697,6 +706,8 @@ impl<'tcx> Debug for Statement<'tcx> {
         use self::StatementKind::*;
         match self.kind {
             Assign(ref lv, ref rv) => write!(fmt, "{:?} = {:?}", lv, rv),
+            StorageLive(ref lv) => write!(fmt, "StorageLive({:?})", lv),
+            StorageDead(ref lv) => write!(fmt, "StorageDead({:?})", lv),
             SetDiscriminant{lvalue: ref lv, variant_index: index} => {
                 write!(fmt, "discriminant({:?}) = {:?}", lv, index)
             }

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -326,6 +326,12 @@ macro_rules! make_mir_visitor {
                     StatementKind::SetDiscriminant{ ref $($mutability)* lvalue, .. } => {
                         self.visit_lvalue(lvalue, LvalueContext::Store);
                     }
+                    StatementKind::StorageLive(ref $($mutability)* lvalue) => {
+                        self.visit_lvalue(lvalue, LvalueContext::StorageLive);
+                    }
+                    StatementKind::StorageDead(ref $($mutability)* lvalue) => {
+                        self.visit_lvalue(lvalue, LvalueContext::StorageDead);
+                    }
                 }
             }
 
@@ -759,4 +765,8 @@ pub enum LvalueContext {
 
     // Consumed as part of an operand
     Consume,
+
+    // Starting and ending a storage live range
+    StorageLive,
+    StorageDead,
 }

--- a/src/librustc_borrowck/borrowck/mir/dataflow/impls.rs
+++ b/src/librustc_borrowck/borrowck/mir/dataflow/impls.rs
@@ -459,6 +459,8 @@ impl<'a, 'tcx> BitDenotation for MovingOutStatements<'a, 'tcx> {
                                          sets.kill_set.add(&moi);
                                      });
             }
+            repr::StatementKind::StorageLive(_) |
+            repr::StatementKind::StorageDead(_) => {}
         }
     }
 

--- a/src/librustc_borrowck/borrowck/mir/dataflow/sanity_check.rs
+++ b/src/librustc_borrowck/borrowck/mir/dataflow/sanity_check.rs
@@ -104,6 +104,8 @@ fn each_block<'a, 'tcx, O>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             repr::StatementKind::Assign(ref lvalue, ref rvalue) => {
                 (lvalue, rvalue)
             }
+            repr::StatementKind::StorageLive(_) |
+            repr::StatementKind::StorageDead(_) => continue,
             repr::StatementKind::SetDiscriminant{ .. } =>
                 span_bug!(stmt.source_info.span,
                           "sanity_check should run before Deaggregator inserts SetDiscriminant"),

--- a/src/librustc_borrowck/borrowck/mir/gather_moves.rs
+++ b/src/librustc_borrowck/borrowck/mir/gather_moves.rs
@@ -616,6 +616,8 @@ fn gather_moves<'a, 'tcx>(mir: &Mir<'tcx>, tcx: TyCtxt<'a, 'tcx, 'tcx>) -> MoveD
                         Rvalue::InlineAsm { .. } => {}
                     }
                 }
+                StatementKind::StorageLive(_) |
+                StatementKind::StorageDead(_) => {}
                 StatementKind::SetDiscriminant{ .. } => {
                     span_bug!(stmt.source_info.span,
                               "SetDiscriminant should not exist during borrowck");

--- a/src/librustc_borrowck/borrowck/mir/mod.rs
+++ b/src/librustc_borrowck/borrowck/mir/mod.rs
@@ -378,6 +378,8 @@ fn drop_flag_effects_for_location<'a, 'tcx, F>(
                                      move_data.rev_lookup.find(lvalue),
                                      |moi| callback(moi, DropFlagState::Present))
             }
+            repr::StatementKind::StorageLive(_) |
+            repr::StatementKind::StorageDead(_) => {}
         },
         None => {
             debug!("drop_flag_effects: replace {:?}", block.terminator());

--- a/src/librustc_metadata/loader.rs
+++ b/src/librustc_metadata/loader.rs
@@ -867,34 +867,29 @@ fn get_metadata_section_imp(target: &Target, flavor: CrateFlavor, filename: &Pat
 }
 
 pub fn meta_section_name(target: &Target) -> &'static str {
+    // Historical note:
+    //
+    // When using link.exe it was seen that the section name `.note.rustc`
+    // was getting shortened to `.note.ru`, and according to the PE and COFF
+    // specification:
+    //
+    // > Executable images do not use a string table and do not support
+    // > section names longer than 8 characters
+    //
+    // https://msdn.microsoft.com/en-us/library/windows/hardware/gg463119.aspx
+    //
+    // As a result, we choose a slightly shorter name! As to why
+    // `.note.rustc` works on MinGW, that's another good question...
+
     if target.options.is_like_osx {
-        "__DATA,__note.rustc"
-    } else if target.options.is_like_msvc {
-        // When using link.exe it was seen that the section name `.note.rustc`
-        // was getting shortened to `.note.ru`, and according to the PE and COFF
-        // specification:
-        //
-        // > Executable images do not use a string table and do not support
-        // > section names longer than 8 characters
-        //
-        // https://msdn.microsoft.com/en-us/library/windows/hardware/gg463119.aspx
-        //
-        // As a result, we choose a slightly shorter name! As to why
-        // `.note.rustc` works on MinGW, that's another good question...
-        ".rustc"
+        "__DATA,.rustc"
     } else {
-        ".note.rustc"
+        ".rustc"
     }
 }
 
-pub fn read_meta_section_name(target: &Target) -> &'static str {
-    if target.options.is_like_osx {
-        "__note.rustc"
-    } else if target.options.is_like_msvc {
-        ".rustc"
-    } else {
-        ".note.rustc"
-    }
+pub fn read_meta_section_name(_target: &Target) -> &'static str {
+    ".rustc"
 }
 
 // A diagnostic function for dumping crate metadata to an output stream

--- a/src/librustc_mir/build/block.rs
+++ b/src/librustc_mir/build/block.rs
@@ -68,6 +68,8 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                                 // FIXME #30046                              ^~~~
                                 this.expr_into_pattern(block, pattern, init)
                             }));
+                        } else {
+                            this.storage_live_for_bindings(block, &pattern);
                         }
 
                         // Enter the visibility scope, after evaluating the initializer.

--- a/src/librustc_mir/build/expr/as_temp.rs
+++ b/src/librustc_mir/build/expr/as_temp.rs
@@ -37,6 +37,14 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         let temp = this.temp(expr_ty.clone());
         let temp_lifetime = expr.temp_lifetime;
         let expr_span = expr.span;
+        let source_info = this.source_info(expr_span);
+
+        if temp_lifetime.is_some() {
+            this.cfg.push(block, Statement {
+                source_info: source_info,
+                kind: StatementKind::StorageLive(temp.clone())
+            });
+        }
 
         // Careful here not to cause an infinite cycle. If we always
         // called `into`, then for lvalues like `x.f`, it would
@@ -49,7 +57,6 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             Category::Lvalue => {
                 let lvalue = unpack!(block = this.as_lvalue(block, expr));
                 let rvalue = Rvalue::Use(Operand::Consume(lvalue));
-                let source_info = this.source_info(expr_span);
                 this.cfg.push_assign(block, source_info, &temp, rvalue);
             }
             _ => {

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -238,7 +238,8 @@ pub fn construct_const<'a, 'gcx, 'tcx>(hir: Cx<'a, 'gcx, 'tcx>,
     let span = tcx.map.span(item_id);
     let mut builder = Builder::new(hir, span);
 
-    let extent = ROOT_CODE_EXTENT;
+    let extent = tcx.region_maps.temporary_scope(ast_expr.id)
+                    .unwrap_or(ROOT_CODE_EXTENT);
     let mut block = START_BLOCK;
     let _ = builder.in_scope(extent, block, |builder| {
         let expr = builder.hir.mirror(ast_expr);

--- a/src/librustc_mir/transform/deaggregator.rs
+++ b/src/librustc_mir/transform/deaggregator.rs
@@ -50,8 +50,7 @@ impl<'tcx> MirPass<'tcx> for Deaggregator {
             let orig_stmt = bb.statements.pop().unwrap();
             let (lhs, rhs) = match orig_stmt.kind {
                 StatementKind::Assign(ref lhs, ref rhs) => (lhs, rhs),
-                StatementKind::SetDiscriminant{ .. } =>
-                    span_bug!(src_info.span, "expected aggregate, not {:?}", orig_stmt.kind),
+                _ => span_bug!(src_info.span, "expected assign, not {:?}", orig_stmt),
             };
             let (agg_kind, operands) = match rhs {
                 &Rvalue::Aggregate(ref agg_kind, ref operands) => (agg_kind, operands),
@@ -114,7 +113,7 @@ fn get_aggregate_statement_index<'a, 'tcx, 'b>(start: usize,
         let ref statement = statements[i];
         let rhs = match statement.kind {
             StatementKind::Assign(_, ref rhs) => rhs,
-            StatementKind::SetDiscriminant{ .. } => continue,
+            _ => continue,
         };
         let (kind, operands) = match rhs {
             &Rvalue::Aggregate(ref kind, ref operands) => (kind, operands),

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -854,7 +854,17 @@ impl<'a, 'tcx> Visitor<'tcx> for Qualifier<'a, 'tcx, 'tcx> {
 
     fn visit_statement(&mut self, bb: BasicBlock, statement: &Statement<'tcx>) {
         assert_eq!(self.location.block, bb);
-        self.nest(|this| this.super_statement(bb, statement));
+        self.nest(|this| {
+            this.visit_source_info(&statement.source_info);
+            match statement.kind {
+                StatementKind::Assign(ref lvalue, ref rvalue) => {
+                    this.visit_assign(bb, lvalue, rvalue);
+                }
+                StatementKind::SetDiscriminant { .. } |
+                StatementKind::StorageLive(_) |
+                StatementKind::StorageDead(_) => {}
+            }
+        });
         self.location.statement_index += 1;
     }
 

--- a/src/librustc_mir/transform/type_check.rs
+++ b/src/librustc_mir/transform/type_check.rs
@@ -382,6 +382,15 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
                                variant_index);
                 };
             }
+            StatementKind::StorageLive(ref lv) |
+            StatementKind::StorageDead(ref lv) => {
+                match *lv {
+                    Lvalue::Temp(_) | Lvalue::Var(_) => {}
+                    _ => {
+                        span_mirbug!(self, stmt, "bad lvalue: expected temp or var");
+                    }
+                }
+            }
         }
     }
 

--- a/src/librustc_trans/mir/analyze.rs
+++ b/src/librustc_trans/mir/analyze.rs
@@ -161,8 +161,11 @@ impl<'mir, 'bcx, 'tcx> Visitor<'tcx> for LocalAnalyzer<'mir, 'bcx, 'tcx> {
                 LvalueContext::Call => {
                     self.mark_assigned(index);
                 }
-                LvalueContext::Consume => {
-                }
+
+                LvalueContext::StorageLive |
+                LvalueContext::StorageDead |
+                LvalueContext::Consume => {}
+
                 LvalueContext::Store |
                 LvalueContext::Inspect |
                 LvalueContext::Borrow { .. } |
@@ -170,6 +173,7 @@ impl<'mir, 'bcx, 'tcx> Visitor<'tcx> for LocalAnalyzer<'mir, 'bcx, 'tcx> {
                 LvalueContext::Projection => {
                     self.mark_as_lvalue(index);
                 }
+
                 LvalueContext::Drop => {
                     let ty = lvalue.ty(self.mir, self.bcx.tcx());
                     let ty = self.bcx.monomorphize(&ty.to_ty(self.bcx.tcx()));

--- a/src/librustc_trans/mir/constant.rs
+++ b/src/librustc_trans/mir/constant.rs
@@ -285,6 +285,8 @@ impl<'a, 'tcx> MirConstContext<'a, 'tcx> {
                             Err(err) => if failure.is_ok() { failure = Err(err); }
                         }
                     }
+                    mir::StatementKind::StorageLive(_) |
+                    mir::StatementKind::StorageDead(_) => {}
                     mir::StatementKind::SetDiscriminant{ .. } => {
                         span_bug!(span, "SetDiscriminant should not appear in constants?");
                     }

--- a/src/test/codegen/lifetime_start_end.rs
+++ b/src/test/codegen/lifetime_start_end.rs
@@ -1,0 +1,54 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -O -C no-prepopulate-passes
+
+#![crate_type = "lib"]
+#![feature(rustc_attrs)]
+
+// CHECK-LABEL: @test
+#[no_mangle]
+#[rustc_mir] // FIXME #27840 MIR has different codegen.
+pub fn test() {
+    let a = 0;
+    &a; // keep variable in an alloca
+
+// CHECK: [[S_a:%[0-9]+]] = bitcast i32* %a to i8*
+// CHECK: call void @llvm.lifetime.start(i{{[0-9 ]+}}, i8* [[S_a]])
+
+    {
+        let b = &Some(a);
+        &b; // keep variable in an alloca
+
+// CHECK: [[S_b:%[0-9]+]] = bitcast %"2.std::option::Option<i32>"** %b to i8*
+// CHECK: call void @llvm.lifetime.start(i{{[0-9 ]+}}, i8* [[S_b]])
+
+// CHECK: [[S_tmp2:%[0-9]+]] = bitcast %"2.std::option::Option<i32>"* %tmp2 to i8*
+// CHECK: call void @llvm.lifetime.start(i{{[0-9 ]+}}, i8* [[S_tmp2]])
+
+// CHECK: [[E_tmp2:%[0-9]+]] = bitcast %"2.std::option::Option<i32>"* %tmp2 to i8*
+// CHECK: call void @llvm.lifetime.end(i{{[0-9 ]+}}, i8* [[E_tmp2]])
+
+// CHECK: [[E_b:%[0-9]+]] = bitcast %"2.std::option::Option<i32>"** %b to i8*
+// CHECK: call void @llvm.lifetime.end(i{{[0-9 ]+}}, i8* [[E_b]])
+    }
+
+    let c = 1;
+    &c; // keep variable in an alloca
+
+// CHECK: [[S_c:%[0-9]+]] = bitcast i32* %c to i8*
+// CHECK: call void @llvm.lifetime.start(i{{[0-9 ]+}}, i8* [[S_c]])
+
+// CHECK: [[E_c:%[0-9]+]] = bitcast i32* %c to i8*
+// CHECK: call void @llvm.lifetime.end(i{{[0-9 ]+}}, i8* [[E_c]])
+
+// CHECK: [[E_a:%[0-9]+]] = bitcast i32* %a to i8*
+// CHECK: call void @llvm.lifetime.end(i{{[0-9 ]+}}, i8* [[E_a]])
+}

--- a/src/test/debuginfo/function-arg-initialization.rs
+++ b/src/test/debuginfo/function-arg-initialization.rs
@@ -288,8 +288,8 @@ fn while_expr(mut x: u64, y: u64, z: u64) -> u64 {
 }
 
 fn loop_expr(mut x: u64, y: u64, z: u64) -> u64 {
-    loop { // #break
-        x += z;
+    loop {
+        x += z; // #break
 
         if x + y > 1000 {
             return x;

--- a/src/test/mir-opt/storage_ranges.rs
+++ b/src/test/mir-opt/storage_ranges.rs
@@ -1,0 +1,45 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let a = 0;
+    {
+        let b = &Some(a);
+    }
+    let c = 1;
+}
+
+// END RUST SOURCE
+// START rustc.node4.PreTrans.after.mir
+//     bb0: {
+//         StorageLive(var0);               // scope 0 at storage_ranges.rs:12:9: 12:10
+//         var0 = const 0i32;               // scope 0 at storage_ranges.rs:12:13: 12:14
+//         StorageLive(var1);               // scope 1 at storage_ranges.rs:14:13: 14:14
+//         StorageLive(tmp1);               // scope 1 at storage_ranges.rs:14:18: 14:25
+//         StorageLive(tmp2);               // scope 1 at storage_ranges.rs:14:23: 14:24
+//         tmp2 = var0;                     // scope 1 at storage_ranges.rs:14:23: 14:24
+//         tmp1 = std::prelude::v1::Some<i32>(tmp2,); // scope 1 at storage_ranges.rs:14:18: 14:25
+//         var1 = &tmp1;                    // scope 1 at storage_ranges.rs:14:17: 14:25
+//         StorageDead(tmp2);               // scope 1 at storage_ranges.rs:14:23: 14:24
+//         tmp0 = ();                       // scope 2 at storage_ranges.rs:13:5: 15:6
+//         StorageDead(tmp1);               // scope 1 at storage_ranges.rs:14:18: 14:25
+//         StorageDead(var1);               // scope 1 at storage_ranges.rs:14:13: 14:14
+//         StorageLive(var2);               // scope 1 at storage_ranges.rs:16:9: 16:10
+//         var2 = const 1i32;               // scope 1 at storage_ranges.rs:16:13: 16:14
+//         return = ();                     // scope 3 at storage_ranges.rs:11:11: 17:2
+//         StorageDead(var2);               // scope 1 at storage_ranges.rs:16:9: 16:10
+//         StorageDead(var0);               // scope 0 at storage_ranges.rs:12:9: 12:10
+//         goto -> bb1;                     // scope 0 at storage_ranges.rs:11:1: 17:2
+//     }
+//
+//     bb1: {
+//         return;                          // scope 0 at storage_ranges.rs:11:1: 17:2
+//     }
+// END rustc.node4.PreTrans.after.mir


### PR DESCRIPTION
Storage live ranges are tracked for all MIR variables and temporaries with a drop scope.
`StorageLive` is lowered to `llvm.lifetime.start` and `StorageDead` to `llvm.lifetime.end`.

There are some improvements possible here, such as:
- pack multiple storage liveness statements by using the index of first local + `u64` bitset
- enforce that locals are not directly accessed outside their storage live range
- shrink storage live ranges for never-borrowed locals to initialization -> last use
- emit storage liveness statements for _all_ temporaries
  - however, the remaining ones are _always_ SSA immediates, so they'd be noop in MIR trans
  - could have a flag on the temporary that its storage is irrelevant (a la C's old `register`)
    - would also deny borrows if necessary
    - this seems like an overcompliation and with packing & optimizations it may be pointless

Even in the current state, it helps stage2 `rustc` compile `boiler` without overflowing (see #35408).

A later addition fixes #26764 and closes #27372 by emitting `.section` directives for dylib metadata to avoid them being allocated into memory or read as `.note`. For this PR, those bugs were tripping valgrind.
