### PR TITLE
E0131 updated to new format

### DIFF
--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -211,11 +211,15 @@ fn check_main_fn_ty(ccx: &CrateCtxt,
             match tcx.map.find(main_id) {
                 Some(hir_map::NodeItem(it)) => {
                     match it.node {
-                        hir::ItemFn(_, _, _, _, ref ps, _)
-                        if ps.is_parameterized() => {
-                            span_err!(ccx.tcx.sess, main_span, E0131,
-                                      "main function is not allowed to have type parameters");
-                            return;
+                        hir::ItemFn(_, _, _, _, ref generics, _) => {
+                            if let Some(gen_span) = generics.span() {
+                                struct_span_err!(ccx.tcx.sess, gen_span, E0131,
+                                         "main function is not allowed to have type parameters")
+                                    .span_label(gen_span,
+                                                &format!("main cannot have type parameters"))
+                                    .emit();
+                                return;
+                            }
                         }
                         _ => ()
                     }

--- a/src/test/compile-fail/E0131.rs
+++ b/src/test/compile-fail/E0131.rs
@@ -8,5 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn main<T>() { //~ ERROR E0131
+fn main<T>() {
+    //~^ ERROR E0131
+    //~| NOTE main cannot have type parameters
 }


### PR DESCRIPTION
Changes

```
error[E0131]: main function is not allowed to have type parameters
  --> src/test/compile-fail/E0131.rs:11:1
   |
11 | fn main<T>() { //~ ERROR E0131
   | ^
```

to

```
error[E0131]: main function is not allowed to have type parameters
  --> src/test/compile-fail/E0131.rs:11:1
   |
11 | fn main<T>() { //~ ERROR E0131
   |        ^^^ main cannot have type parameters
```

Fixes #35257. Part of #35233.
r? @jonathandturner 
