### PR TITLE
add GNU make files for arm-unknown-linux-musleabi

### DIFF
--- a/mk/cfg/arm-unknown-linux-musleabi.mk
+++ b/mk/cfg/arm-unknown-linux-musleabi.mk
@@ -8,8 +8,8 @@ CFG_LIB_NAME_arm-unknown-linux-musleabi=lib$(1).so
 CFG_STATIC_LIB_NAME_arm-unknown-linux-musleabi=lib$(1).a
 CFG_LIB_GLOB_arm-unknown-linux-musleabi=lib$(1)-*.so
 CFG_LIB_DSYM_GLOB_arm-unknown-linux-musleabi=lib$(1)-*.dylib.dSYM
-CFG_JEMALLOC_CFLAGS_arm-unknown-linux-musleabi := -D__arm__ $(CFLAGS)
-CFG_GCCISH_CFLAGS_arm-unknown-linux-musleabi := -Wall -g -fPIC -D__arm__ $(CFLAGS)
+CFG_JEMALLOC_CFLAGS_arm-unknown-linux-musleabi := -D__arm__ -mfloat-abi=soft $(CFLAGS) -march=armv6 -marm
+CFG_GCCISH_CFLAGS_arm-unknown-linux-musleabi := -Wall -g -fPIC -D__arm__ -mfloat-abi=soft $(CFLAGS) -march=armv6 -marm
 CFG_GCCISH_CXXFLAGS_arm-unknown-linux-musleabi := -fno-rtti $(CXXFLAGS)
 CFG_GCCISH_LINK_FLAGS_arm-unknown-linux-musleabi := -shared -fPIC -g
 CFG_GCCISH_DEF_FLAG_arm-unknown-linux-musleabi := -Wl,--export-dynamic,--dynamic-list=
@@ -24,6 +24,3 @@ CFG_RUN_TARG_arm-unknown-linux-musleabi=$(call CFG_RUN_arm-unknown-linux-musleab
 RUSTC_FLAGS_arm-unknown-linux-musleabi :=
 RUSTC_CROSS_FLAGS_arm-unknown-linux-musleabi :=
 CFG_GNU_TRIPLE_arm-unknown-linux-musleabi := arm-unknown-linux-musleabi
-# This file is intentially left empty to indicate that, while this target is
-# supported, it's not supported using plain GNU Make builds. Use a --rustbuild
-# instead.

--- a/mk/cfg/arm-unknown-linux-musleabi.mk
+++ b/mk/cfg/arm-unknown-linux-musleabi.mk
@@ -1,3 +1,29 @@
+# arm-unknown-linux-musleabi configuration
+CROSS_PREFIX_arm-unknown-linux-musleabi=arm-linux-musleabi-
+CC_arm-unknown-linux-musleabi=gcc
+CXX_arm-unknown-linux-musleabi=g++
+CPP_arm-unknown-linux-musleabi=gcc -E
+AR_arm-unknown-linux-musleabi=ar
+CFG_LIB_NAME_arm-unknown-linux-musleabi=lib$(1).so
+CFG_STATIC_LIB_NAME_arm-unknown-linux-musleabi=lib$(1).a
+CFG_LIB_GLOB_arm-unknown-linux-musleabi=lib$(1)-*.so
+CFG_LIB_DSYM_GLOB_arm-unknown-linux-musleabi=lib$(1)-*.dylib.dSYM
+CFG_JEMALLOC_CFLAGS_arm-unknown-linux-musleabi := -D__arm__ $(CFLAGS)
+CFG_GCCISH_CFLAGS_arm-unknown-linux-musleabi := -Wall -g -fPIC -D__arm__ $(CFLAGS)
+CFG_GCCISH_CXXFLAGS_arm-unknown-linux-musleabi := -fno-rtti $(CXXFLAGS)
+CFG_GCCISH_LINK_FLAGS_arm-unknown-linux-musleabi := -shared -fPIC -g
+CFG_GCCISH_DEF_FLAG_arm-unknown-linux-musleabi := -Wl,--export-dynamic,--dynamic-list=
+CFG_LLC_FLAGS_arm-unknown-linux-musleabi :=
+CFG_INSTALL_NAME_arm-unknown-linux-musleabi =
+CFG_EXE_SUFFIX_arm-unknown-linux-musleabi :=
+CFG_WINDOWSY_arm-unknown-linux-musleabi :=
+CFG_UNIXY_arm-unknown-linux-musleabi := 1
+CFG_LDPATH_arm-unknown-linux-musleabi :=
+CFG_RUN_arm-unknown-linux-musleabi=$(2)
+CFG_RUN_TARG_arm-unknown-linux-musleabi=$(call CFG_RUN_arm-unknown-linux-musleabi,,$(2))
+RUSTC_FLAGS_arm-unknown-linux-musleabi :=
+RUSTC_CROSS_FLAGS_arm-unknown-linux-musleabi :=
+CFG_GNU_TRIPLE_arm-unknown-linux-musleabi := arm-unknown-linux-musleabi
 # This file is intentially left empty to indicate that, while this target is
 # supported, it's not supported using plain GNU Make builds. Use a --rustbuild
 # instead.


### PR DESCRIPTION
For Yocto (Embedded Linux meta distro) Rust is provided via the [meta-rust layer](https://github.com/meta-rust/meta-rust). In this project there have been patches to add `arm-unknown-linux-musleabi`. Rust recently acquired that support via #35060 but only for rustbuild. meta-rust is currently only able to build Rust support with the existing GNU Makefiles. This adds `arm-unknown-linux-musleabi` support to Rust for the GNU Makefiles until meta-rust is able to sort out why using rustbuild does not work for it.

/cc @srwalter @derekstraka @jmesmon @japaric 
