### PR TITLE
Fix build on DragonFly (unused function errno_location)

### DIFF
--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -37,6 +37,7 @@ static ENV_LOCK: Mutex = Mutex::new();
 
 
 extern {
+    #[cfg(not(target_os = "dragonfly"))]
     #[cfg_attr(any(target_os = "linux", target_os = "emscripten"),
                link_name = "__errno_location")]
     #[cfg_attr(any(target_os = "bitrig",


### PR DESCRIPTION
Function errno_location() is not used on DragonFly. As warnings are
errors, this breaks the build.
