### PR TITLE
Update e0017 to new format

### DIFF
--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -616,9 +616,12 @@ impl<'a, 'tcx> Visitor<'tcx> for Qualifier<'a, 'tcx, 'tcx> {
                     if !allow {
                         self.add(Qualif::NOT_CONST);
                         if self.mode != Mode::Fn {
-                            span_err!(self.tcx.sess, self.span, E0017,
-                                      "references in {}s may only refer \
-                                       to immutable values", self.mode);
+                            struct_span_err!(self.tcx.sess,  self.span, E0017,
+                                             "references in {}s may only refer \
+                                              to immutable values", self.mode)
+                                .span_label(self.span, &format!("{}s require immutable values",
+                                                                self.mode))
+                                .emit();
                         }
                     }
                 } else {

--- a/src/test/compile-fail/E0017.rs
+++ b/src/test/compile-fail/E0017.rs
@@ -12,11 +12,16 @@ static X: i32 = 1;
 const C: i32 = 2;
 
 const CR: &'static mut i32 = &mut C; //~ ERROR E0017
+                                     //~| NOTE constants require immutable values
                                      //~| ERROR E0017
+                                     //~| NOTE constants require immutable values
 static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0017
+                                              //~| NOTE statics require immutable values
                                               //~| ERROR E0017
+                                              //~| NOTE statics require immutable values
                                               //~| ERROR E0388
 static CONST_REF: &'static mut i32 = &mut C; //~ ERROR E0017
+                                             //~| NOTE statics require immutable values
                                              //~| ERROR E0017
-
+                                             //~| NOTE statics require immutable values
 fn main() {}


### PR DESCRIPTION
Updated `span_err!` to use `struct_span_err!` and provide a `span_label` that describes the error in context.

Updated the test to look for the `span_label`s that are provided now.
