### PR TITLE
Finish fixing the operator precedence tables

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -3039,7 +3039,7 @@ The precedence of Rust binary operators is ordered as follows, going from
 strong to weak:
 
 ```{.text .precedence}
-as
+as :
 * / %
 + -
 << >>
@@ -3050,6 +3050,7 @@ as
 &&
 ||
 .. ...
+<-
 =
 ```
 


### PR DESCRIPTION
Add the unstable `:` colon and `<-` inplace operators.

r? @steveklabnik
