### PR TITLE
Print Rust target name, not LLVM target name, for `--print target-list`

### DIFF
--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -94,7 +94,7 @@ macro_rules! supported_targets {
         pub fn get_targets() -> Box<Iterator<Item=String>> {
             Box::new(TARGETS.iter().filter_map(|t| -> Option<String> {
                 load_specific(t)
-                    .map(|t| t.llvm_target)
+                    .and(Ok(t.to_string()))
                     .ok()
             }))
         }


### PR DESCRIPTION
Rust target name and LLVM target name are usually the same, but not always. For example, `arm-unknown-linux-musleabi` Rust target uses `arm-unknown-linux-gnueabi` LLVM target.

Fix #35481.
