### PR TITLE
Fix for nightlies

### DIFF
--- a/src/test/compile-fail/issue-23024.rs
+++ b/src/test/compile-fail/issue-23024.rs
@@ -19,10 +19,5 @@ fn main()
     println!("{:?}",(vfnfer[0] as Fn)(3));
     //~^ ERROR the precise format of `Fn`-family traits'
     //~| ERROR E0243
-    //~| NOTE expected 1 type arguments, found 0
     //~| ERROR the value of the associated type `Output` (from the trait `std::ops::FnOnce`)
-    //~| NOTE in this expansion of println!
-    //~| NOTE in this expansion of println!
-    //~| NOTE in this expansion of println!
-    //~| NOTE in this expansion of println!
 }


### PR DESCRIPTION
Remove the NOTE tests for now so that nightlies will pass. We'll move many of these tests to UI tests later, as this is a better place to check the notes.

cc @alexcrichton 
