### PR TITLE
Update E0038 to the new error format

### DIFF
--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -670,10 +670,15 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         let mut err = match warning_node_id {
             Some(_) => None,
             None => {
-                Some(struct_span_err!(
-                    self.sess, span, E0038,
-                    "the trait `{}` cannot be made into an object",
-                    self.item_path_str(trait_def_id)))
+                let trait_str = self.item_path_str(trait_def_id);
+                let mut db = struct_span_err!(
+                            self.sess, span, E0038,
+                            "the trait `{}` cannot be made into an object",
+                            trait_str);
+                db.span_label(span,
+                              &format!("the trait `{}` cannot be made \
+                              into an object", trait_str));
+                Some(db)
             }
         };
 

--- a/src/test/compile-fail/E0038.rs
+++ b/src/test/compile-fail/E0038.rs
@@ -12,7 +12,10 @@ trait Trait {
     fn foo(&self) -> Self;
 }
 
-fn call_foo(x: Box<Trait>) { //~ ERROR E0038
+fn call_foo(x: Box<Trait>) {
+    //~^ ERROR E0038
+    //~| NOTE the trait `Trait` cannot be made into an object
+    //~| NOTE method `foo` references the `Self` type in its arguments or return type
     let y = x.foo();
 }
 

--- a/src/test/compile-fail/issue-20692.rs
+++ b/src/test/compile-fail/issue-20692.rs
@@ -15,10 +15,12 @@ fn f<T: Array>(x: &T) {
     //~^ ERROR `Array` cannot be made into an object
     //~| NOTE the trait cannot require that `Self : Sized`
     //~| NOTE requirements on the impl of `std::ops::CoerceUnsized<&Array>`
+    //~| NOTE the trait `Array` cannot be made into an object
     as
     &Array;
     //~^ ERROR `Array` cannot be made into an object
     //~| NOTE the trait cannot require that `Self : Sized`
+    //~| NOTE the trait `Array` cannot be made into an object
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-26056.rs
+++ b/src/test/compile-fail/issue-26056.rs
@@ -28,6 +28,7 @@ impl<K> Map for K {
 fn main() {
     let _ = &()
         as &Map<Key=u32,MapValue=u32>;
-    //~^ ERROR the trait `Map` cannot be made into an object
+    //~^ ERROR E0038
     //~| NOTE the trait cannot use `Self` as a type parameter
+    //~| NOTE the trait `Map` cannot be made into an object
 }

--- a/src/test/compile-fail/object-safety-generics.rs
+++ b/src/test/compile-fail/object-safety-generics.rs
@@ -24,12 +24,14 @@ trait Quux {
 fn make_bar<T:Bar>(t: &T) -> &Bar {
         //~^ ERROR E0038
         //~| NOTE method `bar` has generic type parameters
+        //~| NOTE the trait `Bar` cannot be made into an object
     t
 }
 
 fn make_bar_explicit<T:Bar>(t: &T) -> &Bar {
     //~^ ERROR E0038
-    //~^^ NOTE method `bar` has generic type parameters
+    //~| NOTE method `bar` has generic type parameters
+    //~| NOTE the trait `Bar` cannot be made into an object
     t as &Bar
 }
 

--- a/src/test/compile-fail/object-safety-mentions-Self.rs
+++ b/src/test/compile-fail/object-safety-mentions-Self.rs
@@ -27,12 +27,14 @@ trait Quux {
 fn make_bar<T:Bar>(t: &T) -> &Bar {
         //~^ ERROR E0038
         //~| NOTE method `bar` references the `Self` type in its arguments or return type
+        //~| NOTE the trait `Bar` cannot be made into an object
     loop { }
 }
 
 fn make_baz<T:Baz>(t: &T) -> &Baz {
         //~^ ERROR E0038
         //~| NOTE method `bar` references the `Self` type in its arguments or return type
+        //~| NOTE the trait `Baz` cannot be made into an object
     t
 }
 

--- a/src/test/compile-fail/object-safety-sized.rs
+++ b/src/test/compile-fail/object-safety-sized.rs
@@ -18,6 +18,7 @@ trait Bar : Sized {
 fn make_bar<T:Bar>(t: &T) -> &Bar {
         //~^ ERROR E0038
         //~| NOTE the trait cannot require that `Self : Sized`
+        //~| NOTE the trait `Bar` cannot be made into an object
     t
 }
 

--- a/src/test/compile-fail/object-safety-supertrait-mentions-Self.rs
+++ b/src/test/compile-fail/object-safety-supertrait-mentions-Self.rs
@@ -25,6 +25,7 @@ fn make_bar<T:Bar<u32>>(t: &T) -> &Bar<u32> {
 fn make_baz<T:Baz>(t: &T) -> &Baz {
     //~^ ERROR E0038
     //~| NOTE the trait cannot use `Self` as a type parameter in the supertrait listing
+    //~| NOTE the trait `Baz` cannot be made into an object
     t
 }
 


### PR DESCRIPTION
Part of #35233

Addresses #35500
"r? @jonathandturner

This doesn't compile yet, and I need help. In my naive solution, adding the span label makes our error message a mutable `errors::DiagnosticBuilder` pointer.

``` bash
python src/bootstrap/bootstrap.py --step check-cfail E0038 --stage 1
```

```
Building stage0 std artifacts (x86_64-unknown-linux-gnu -> x86_64-unknown-linux-gnu)
Building stage0 test artifacts (x86_64-unknown-linux-gnu -> x86_64-unknown-linux-gnu)
Building stage0 compiler artifacts (x86_64-unknown-linux-gnu -> x86_64-unknown-linux-gnu)
   Compiling rustc v0.0.0 (file:///home/nash/code/rust/src/librustc)
src/librustc/traits/error_reporting.rs:735:9: 735:12 error: mismatched types [E0308]
src/librustc/traits/error_reporting.rs:735         err
                                                   ^~~
src/librustc/traits/error_reporting.rs:735:9: 735:12 help: run `rustc --explain E0308` to see a detailed explanation
src/librustc/traits/error_reporting.rs:735:9: 735:12 note: expected type `core::option::Option<errors::DiagnosticBuilder<'tcx>>`
src/librustc/traits/error_reporting.rs:735:9: 735:12 note:    found type `core::option::Option<&mut errors::DiagnosticBuilder<'_>>`
error: aborting due to previous error
error: Could not compile `rustc`.

To learn more, run the command again with --verbose.


command did not execute successfully: "/home/nash/code/rust/build/x86_64-unknown-linux-gnu/stage0/bin/cargo" "build" "-j" "4" "--target" "x86_64-unknown-linux-gnu" "--release" "--features" " jemalloc" "--manifest-path" "/home/nash/code/rust/src/rustc/Cargo.toml"
expected success, got: exit code: 101
```
