### PR TITLE
Implement `AsRef<[T]>` for `std::slice::Iter`.

### DIFF
--- a/src/libcollectionstest/slice.rs
+++ b/src/libcollectionstest/slice.rs
@@ -646,6 +646,15 @@ fn test_iter_size_hints() {
 }
 
 #[test]
+fn test_iter_as_ref() {
+    let xs = [1, 2, 5, 10, 11];
+    let mut iter = xs.iter();
+    assert_eq!(iter.as_ref(), &[1, 2, 5, 10, 11]);
+    iter.next();
+    assert_eq!(iter.as_ref(), &[2, 5, 10, 11]);
+}
+
+#[test]
 fn test_iter_clone() {
     let xs = [1, 2, 5];
     let mut it = xs.iter();

--- a/src/libcollectionstest/slice.rs
+++ b/src/libcollectionstest/slice.rs
@@ -646,6 +646,15 @@ fn test_iter_size_hints() {
 }
 
 #[test]
+fn test_iter_as_slice() {
+    let xs = [1, 2, 5, 10, 11];
+    let mut iter = xs.iter();
+    assert_eq!(iter.as_slice(), &[1, 2, 5, 10, 11]);
+    iter.next();
+    assert_eq!(iter.as_slice(), &[2, 5, 10, 11]);
+}
+
+#[test]
 fn test_iter_as_ref() {
     let xs = [1, 2, 5, 10, 11];
     let mut iter = xs.iter();

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -37,6 +37,7 @@ use clone::Clone;
 use cmp::{Ordering, PartialEq, PartialOrd, Eq, Ord};
 use cmp::Ordering::{Less, Equal, Greater};
 use cmp;
+use convert::AsRef;
 use default::Default;
 use fmt;
 use intrinsics::assume;
@@ -994,6 +995,13 @@ impl<'a, T> ExactSizeIterator for Iter<'a, T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> Clone for Iter<'a, T> {
     fn clone(&self) -> Iter<'a, T> { Iter { ptr: self.ptr, end: self.end, _marker: self._marker } }
+}
+
+#[stable(feature = "slice_iter_as_ref", since = "1.12.0")]
+impl<'a, T> AsRef<[T]> for Iter<'a, T> {
+    fn as_ref(&self) -> &[T] {
+        self.as_slice()
+    }
 }
 
 /// Mutable slice iterator.


### PR DESCRIPTION
`AsRef` is designed for conversions that are "cheap" (as per
the API docs). It is the case that retrieving the underlying
data of `std::slice::Iter` is cheap. In my opinion, there's no
ambiguity about what slice data will be returned, otherwise,
I would be more cautious about implementing `AsRef`.
