### PR TITLE
Remove redundant `&mut ref mut` in doc for Result::as_mut()

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -402,8 +402,8 @@ impl<T, E> Result<T, E> {
     /// ```
     /// fn mutate(r: &mut Result<i32, i32>) {
     ///     match r.as_mut() {
-    ///         Ok(&mut ref mut v) => *v = 42,
-    ///         Err(&mut ref mut e) => *e = 0,
+    ///         Ok(v) => *v = 42,
+    ///         Err(e) => *e = 0,
     ///     }
     /// }
     ///


### PR DESCRIPTION
While a good example of how `&mut ref mut` is a no-op, I don't think we should show that here :)
See https://users.rust-lang.org/t/mnemonic-for-reading-qualifiers/6853

r? @steveklabnik 
