### PR TITLE
Generalize `contains` method on `SliceExt`

### DIFF
--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -869,7 +869,7 @@ impl<T> [T] {
     /// assert!(!v.contains(&50));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn contains<U>(&self, x: &U) -> bool
+    pub fn contains<U: ?Sized>(&self, x: &U) -> bool
         where T: PartialEq<U>
     {
         core_slice::SliceExt::contains(self, x)

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -869,8 +869,8 @@ impl<T> [T] {
     /// assert!(!v.contains(&50));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn contains(&self, x: &T) -> bool
-        where T: PartialEq
+    pub fn contains<U>(&self, x: &U) -> bool
+        where T: PartialEq<U>
     {
         core_slice::SliceExt::contains(self, x)
     }

--- a/src/libcollectionstest/slice.rs
+++ b/src/libcollectionstest/slice.rs
@@ -984,9 +984,9 @@ fn test_contains() {
     let baz_string = "baz".to_string();
 
     let mut v = vec![foo_string.clone(), bar_string.clone(), baz_string.clone()];
-    assert!(v.contains(foo_string));
-    assert!(v.contains(bar_string));
-    assert!(v.contains(baz_string));
+    assert!(v.contains(&foo_string));
+    assert!(v.contains(&bar_string));
+    assert!(v.contains(&baz_string));
 
 
     assert!(v.contains("foo"));

--- a/src/libcollectionstest/slice.rs
+++ b/src/libcollectionstest/slice.rs
@@ -978,6 +978,23 @@ fn test_shrink_to_fit() {
 }
 
 #[test]
+fn test_contains() {
+    let foo_string = "foo".to_string();
+    let bar_string = "bar".to_string();
+    let baz_string = "baz".to_string();
+
+    let mut v = vec![foo_string.clone(), bar_string.clone(), baz_string.clone()];
+    assert!(v.contains(foo_string));
+    assert!(v.contains(bar_string));
+    assert!(v.contains(baz_string));
+
+
+    assert!(v.contains("foo"));
+    assert!(v.contains("bar"));
+    assert!(v.contains("baz"));
+}
+
+#[test]
 fn test_starts_with() {
     assert!(b"foobar".starts_with(b"foo"));
     assert!(!b"foobar".starts_with(b"oob"));

--- a/src/libcollectionstest/slice.rs
+++ b/src/libcollectionstest/slice.rs
@@ -983,7 +983,7 @@ fn test_contains() {
     let bar_string = "bar".to_string();
     let baz_string = "baz".to_string();
 
-    let mut v = vec![foo_string.clone(), bar_string.clone(), baz_string.clone()];
+    let v = &[foo_string.clone(), bar_string.clone(), baz_string.clone()];
     assert!(v.contains(&foo_string));
     assert!(v.contains(&bar_string));
     assert!(v.contains(&baz_string));

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -150,7 +150,7 @@ pub trait SliceExt {
     fn as_mut_ptr(&mut self) -> *mut Self::Item;
 
     #[stable(feature = "core", since = "1.6.0")]
-    fn contains(&self, x: &Self::Item) -> bool where Self::Item: PartialEq;
+    fn contains<U>(&self, x: &U) -> bool where Self::Item: PartialEq<U>;
 
     #[stable(feature = "core", since = "1.6.0")]
     fn starts_with(&self, needle: &[Self::Item]) -> bool where Self::Item: PartialEq;
@@ -469,8 +469,8 @@ impl<T> SliceExt for [T] {
     }
 
     #[inline]
-    fn contains(&self, x: &T) -> bool where T: PartialEq {
-        self.iter().any(|elt| *x == *elt)
+    fn contains<U>(&self, x: &U) -> bool where T: PartialEq<U> {
+        self.iter().any(|elt| *elt == *x)
     }
 
     #[inline]

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -49,7 +49,7 @@ use result::Result;
 use result::Result::{Ok, Err};
 use ptr;
 use mem;
-use marker::{Copy, Send, Sync, self};
+use marker::{Copy, Send, Sync, Sized, self};
 use iter_private::TrustedRandomAccess;
 
 #[repr(C)]
@@ -150,7 +150,7 @@ pub trait SliceExt {
     fn as_mut_ptr(&mut self) -> *mut Self::Item;
 
     #[stable(feature = "core", since = "1.6.0")]
-    fn contains<U>(&self, x: &U) -> bool where Self::Item: PartialEq<U>;
+    fn contains<U: ?Sized>(&self, x: &U) -> bool where Self::Item: PartialEq<U>;
 
     #[stable(feature = "core", since = "1.6.0")]
     fn starts_with(&self, needle: &[Self::Item]) -> bool where Self::Item: PartialEq;
@@ -469,7 +469,7 @@ impl<T> SliceExt for [T] {
     }
 
     #[inline]
-    fn contains<U>(&self, x: &U) -> bool where T: PartialEq<U> {
+    fn contains<U: ?Sized>(&self, x: &U) -> bool where T: PartialEq<U> {
         self.iter().any(|elt| *elt == *x)
     }
 


### PR DESCRIPTION
These commits modify the `contains` method(s) such that one can determine if a slice `&[T]` contains an element "equal" to some value of type `U` for any `T` and `U` that satisfy `T: PartialEq<U>`.  Specifically, the signature of `contains` is changed from

``` rust
fn contains(&self, &T) -> bool where T: PartialEq<T>
```

to

``` rust
fn contains<U>(&self, &U) -> bool where T: PartialEq<U>
```

A test function has been added to libcollectionstest under "slice.rs";  although the most "extensive" changes were in libcore, the use case described below (where `T` is `String` and `U` is `&str`) requires `std`.
### Motivation

Currently the `contains` method on slices supports only a slice's own item type as an argument;  this leads to confusion when the item type is semantically equivalent to another, as in the case of `String`/`&str`.

I have been asked twice in as many days --- by different people --- how to check for a certain string literal in a `Vec<String>` without allocating; the obvious method (`contains`) doesn't work and instead we resort to the less-than-ergonomic `my_vec.iter().any(|s| s == "my literal value")` instead of `my_vec.contains("my literal value")`.
### Misc

This is my first pull request, so I've probably done something wrong. :sweat_smile:  Let me know if you figure out what that is.
- All stage 1 tests pass, but it's not entirely clear to me whether or not the newly-added test was picked up by the build system; I assume CI will be able to do a properly-cleaned build quicker than I would.
- Intuition says this probably deserves a crater run, since it changes the signature of a highly-used function.
