### PR TITLE
Update E0138 to new format

### DIFF
--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -132,8 +132,13 @@ fn find_item(item: &Item, ctxt: &mut EntryContext, at_root: bool) {
             if ctxt.start_fn.is_none() {
                 ctxt.start_fn = Some((item.id, item.span));
             } else {
-                span_err!(ctxt.session, item.span, E0138,
-                          "multiple 'start' functions");
+                struct_span_err!(
+                    ctxt.session, item.span, E0138,
+                    "multiple 'start' functions")
+                    .span_label(ctxt.start_fn.unwrap().1,
+                                &format!("previous `start` function here"))
+                    .span_label(item.span, &format!("multiple `start` functions"))
+                    .emit();
             }
         },
         EntryPointType::None => ()

--- a/src/test/compile-fail/E0138.rs
+++ b/src/test/compile-fail/E0138.rs
@@ -12,6 +12,9 @@
 
 #[start]
 fn foo(argc: isize, argv: *const *const u8) -> isize {}
+//~^ NOTE previous `start` function here
 
 #[start]
-fn f(argc: isize, argv: *const *const u8) -> isize {} //~ ERROR E0138
+fn f(argc: isize, argv: *const *const u8) -> isize {}
+//~^ ERROR E0138
+//~| NOTE multiple `start` functions


### PR DESCRIPTION
Part of #35233
Fix #35510 
r? @jonathandturner

![e0138](https://cloud.githubusercontent.com/assets/2716047/17562415/7200d93c-5f5d-11e6-98ff-e15c29f40e03.png)

Question: How can I only underline the function name ? I have observed the debug output and the struct of item, but I can't find the `Span` for function name. Should I modify the struct I get to save function name's position or there is another way to get it ? (I can only find `Span`s for function attributes, inputs, outputs, blocks)
