### PR TITLE
Emscripten test fixes

### DIFF
--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -98,7 +98,8 @@ pub fn check(build: &mut Build) {
         if target.contains("rumprun") ||
            target.contains("bitrig") ||
            target.contains("openbsd") ||
-           target.contains("msvc") {
+           target.contains("msvc") ||
+           target.contains("emscripten") {
             build.config.use_jemalloc = false;
         }
 

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -83,11 +83,11 @@ pub fn init() {
         }
     }
 
-    #[cfg(not(target_os = "nacl"))]
+    #[cfg(not(any(target_os = "nacl", target_os = "emscripten")))]
     unsafe fn reset_sigpipe() {
         assert!(signal(libc::SIGPIPE, libc::SIG_IGN) != !0);
     }
-    #[cfg(target_os = "nacl")]
+    #[cfg(any(target_os = "nacl", target_os = "emscripten"))]
     unsafe fn reset_sigpipe() {}
 }
 

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -551,11 +551,13 @@ pub fn home_dir() -> Option<PathBuf> {
 
     #[cfg(any(target_os = "android",
               target_os = "ios",
-              target_os = "nacl"))]
+              target_os = "nacl",
+              target_os = "emscripten"))]
     unsafe fn fallback() -> Option<OsString> { None }
     #[cfg(not(any(target_os = "android",
                   target_os = "ios",
-                  target_os = "nacl")))]
+                  target_os = "nacl",
+                  target_os = "emscripten")))]
     unsafe fn fallback() -> Option<OsString> {
         #[cfg(not(target_os = "solaris"))]
         unsafe fn getpwduid_r(me: libc::uid_t, passwd: &mut libc::passwd,

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -81,8 +81,7 @@ impl Thread {
     }
 
     #[cfg(any(target_os = "linux",
-              target_os = "android",
-              target_os = "emscripten"))]
+              target_os = "android"))]
     pub fn set_name(name: &CStr) {
         const PR_SET_NAME: libc::c_int = 15;
         // pthread wrapper only appeared in glibc 2.12, so we use syscall
@@ -118,9 +117,9 @@ impl Thread {
                                      name.as_ptr() as *mut libc::c_void);
         }
     }
-    #[cfg(any(target_env = "newlib", target_os = "solaris"))]
+    #[cfg(any(target_env = "newlib", target_os = "solaris", target_os = "emscripten"))]
     pub fn set_name(_name: &CStr) {
-        // Newlib and Illumos has no way to set a thread name.
+        // Newlib, Illumos and Emscripten have no way to set a thread name.
     }
 
     pub fn sleep(dur: Duration) {

--- a/src/libunwind/libunwind.rs
+++ b/src/libunwind/libunwind.rs
@@ -60,7 +60,6 @@ pub const unwinder_private_data_size: usize = 2;
 pub const unwinder_private_data_size: usize = 2;
 
 #[cfg(target_arch = "asmjs")]
-// FIXME: Copied from arm. Need to confirm.
 pub const unwinder_private_data_size: usize = 20;
 
 #[repr(C)]

--- a/src/test/run-pass-fulldeps/linkage-visibility.rs
+++ b/src/test/run-pass-fulldeps/linkage-visibility.rs
@@ -12,6 +12,7 @@
 // ignore-android: FIXME(#10356)
 // ignore-windows: std::dynamic_lib does not work on Windows well
 // ignore-musl
+// ignore-emscripten no dynamic linking
 
 extern crate linkage_visibility as foo;
 

--- a/src/test/run-pass-fulldeps/logging-enabled.rs
+++ b/src/test/run-pass-fulldeps/logging-enabled.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // exec-env:RUST_LOG=logging_enabled=info
+// ignore-emscripten: FIXME(#31622)
 
 
 #![feature(rustc_private)]

--- a/src/test/run-pass-fulldeps/logging-separate-lines.rs
+++ b/src/test/run-pass-fulldeps/logging-separate-lines.rs
@@ -11,6 +11,7 @@
 // ignore-windows
 // exec-env:RUST_LOG=debug
 // compile-flags:-C debug-assertions=y
+// ignore-emscripten: FIXME(#31622)
 
 #![feature(rustc_private)]
 

--- a/src/test/run-pass/backtrace-debuginfo.rs
+++ b/src/test/run-pass/backtrace-debuginfo.rs
@@ -17,6 +17,7 @@
 
 // compile-flags:-g -Cllvm-args=-enable-tail-merge=0
 // ignore-pretty as this critically relies on line numbers
+// ignore-emscripten spawning processes is not supported
 
 use std::io;
 use std::io::prelude::*;

--- a/src/test/run-pass/backtrace.rs
+++ b/src/test/run-pass/backtrace.rs
@@ -10,6 +10,7 @@
 
 // no-pretty-expanded FIXME #15189
 // ignore-android FIXME #17520
+// ignore-emscripten spawning processes is not supported
 // compile-flags:-g
 
 use std::env;

--- a/src/test/run-pass/command-before-exec.rs
+++ b/src/test/run-pass/command-before-exec.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-windows - this is a unix-specific test
+// ignore-emscripten
 
 #![feature(process_exec, libc)]
 

--- a/src/test/run-pass/command-exec.rs
+++ b/src/test/run-pass/command-exec.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-windows - this is a unix-specific test
+// ignore-emscripten
 // ignore-pretty
 
 #![feature(process_exec)]

--- a/src/test/run-pass/drop-flag-sanity-check.rs
+++ b/src/test/run-pass/drop-flag-sanity-check.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // compile-flags: -Z force-dropflag-checks=on
+// ignore-emscripten
 
 // Quick-and-dirty test to ensure -Z force-dropflag-checks=on works as
 // expected. Note that the inlined drop-flag is slated for removal

--- a/src/test/run-pass/drop-trait-enum.rs
+++ b/src/test/run-pass/drop-trait-enum.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 #![allow(unknown_features)]
 #![feature(box_syntax)]
 

--- a/src/test/run-pass/env-args-reverse-iterator.rs
+++ b/src/test/run-pass/env-args-reverse-iterator.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
+
 use std::env::args;
 use std::process::Command;
 

--- a/src/test/run-pass/env-home-dir.rs
+++ b/src/test/run-pass/env-home-dir.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
 
 #![feature(path)]
 

--- a/src/test/run-pass/exec-env.rs
+++ b/src/test/run-pass/exec-env.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // exec-env:TEST_EXEC_ENV=22
-
+// ignore-emscripten FIXME: issue #31622
 
 use std::env;
 

--- a/src/test/run-pass/hashmap-memory.rs
+++ b/src/test/run-pass/hashmap-memory.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten No support for threads
+
 #![allow(unknown_features)]
 #![feature(std_misc)]
 

--- a/src/test/run-pass/intrinsic-alignment.rs
+++ b/src/test/run-pass/intrinsic-alignment.rs
@@ -24,7 +24,8 @@ mod rusti {
           target_os = "dragonfly",
           target_os = "netbsd",
           target_os = "openbsd",
-          target_os = "solaris"))]
+          target_os = "solaris",
+          target_os = "emscripten"))]
 mod m {
     #[main]
     #[cfg(target_arch = "x86")]

--- a/src/test/run-pass/issue-10626.rs
+++ b/src/test/run-pass/issue-10626.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
 
 // Make sure that if a process doesn't have its stdio/stderr descriptors set up
 // that we don't die in a large ball of fire

--- a/src/test/run-pass/issue-12133-3.rs
+++ b/src/test/run-pass/issue-12133-3.rs
@@ -12,6 +12,7 @@
 // aux-build:issue-12133-dylib.rs
 // aux-build:issue-12133-dylib2.rs
 // ignore-musl
+// ignore-emscripten no dylib support
 
 // pretty-expanded FIXME #23616
 

--- a/src/test/run-pass/issue-13304.rs
+++ b/src/test/run-pass/issue-13304.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-aarch64
+// ignore-emscripten
 #![feature(io, process_capture)]
 
 use std::env;

--- a/src/test/run-pass/issue-14456.rs
+++ b/src/test/run-pass/issue-14456.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
 
 #![feature(io, process_capture)]
 

--- a/src/test/run-pass/issue-14940.rs
+++ b/src/test/run-pass/issue-14940.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
 
 use std::env;
 use std::process::Command;

--- a/src/test/run-pass/issue-16272.rs
+++ b/src/test/run-pass/issue-16272.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-aarch64
+// ignore-emscripten
 
 use std::process::Command;
 use std::env;

--- a/src/test/run-pass/issue-20091.rs
+++ b/src/test/run-pass/issue-20091.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-aarch64
+// ignore-emscripten
 #![feature(std_misc, os)]
 
 #[cfg(unix)]

--- a/src/test/run-pass/issue-2190-1.rs
+++ b/src/test/run-pass/issue-2190-1.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // pretty-expanded FIXME #23616
+// ignore-emscripten
 
 use std::thread::Builder;
 

--- a/src/test/run-pass/issue-24313.rs
+++ b/src/test/run-pass/issue-24313.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
+
 use std::thread;
 use std::env;
 use std::process::Command;

--- a/src/test/run-pass/issue-28950.rs
+++ b/src/test/run-pass/issue-28950.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
 // compile-flags: -Z orbit=off
 // (blows the stack with MIR trans and no optimizations)
 

--- a/src/test/run-pass/issue-29485.rs
+++ b/src/test/run-pass/issue-29485.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:issue-29485.rs
+// ignore-emscripten
 
 #[feature(recover)]
 

--- a/src/test/run-pass/issue-30490.rs
+++ b/src/test/run-pass/issue-30490.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
+
 // Previously libstd would set stdio descriptors of a child process
 // by `dup`ing the requested descriptors to inherit directly into the
 // stdio descriptors. This, however, would incorrectly handle cases

--- a/src/test/run-pass/issue-33770.rs
+++ b/src/test/run-pass/issue-33770.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
+
 use std::process::{Command, Stdio};
 use std::env;
 use std::sync::{Mutex, RwLock};

--- a/src/test/run-pass/linkage1.rs
+++ b/src/test/run-pass/linkage1.rs
@@ -10,6 +10,7 @@
 
 // ignore-windows
 // ignore-macos
+// ignore-emscripten
 // aux-build:linkage1.rs
 
 #![feature(linkage)]

--- a/src/test/run-pass/multi-panic.rs
+++ b/src/test/run-pass/multi-panic.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
+
 fn check_for_no_backtrace(test: std::process::Output) {
     assert!(!test.status.success());
     let err = String::from_utf8_lossy(&test.stderr);

--- a/src/test/run-pass/no-stdio.rs
+++ b/src/test/run-pass/no-stdio.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
+
 #![feature(libc)]
 
 extern crate libc;

--- a/src/test/run-pass/panic-handler-chain.rs
+++ b/src/test/run-pass/panic-handler-chain.rs
@@ -7,6 +7,9 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
+// ignore-emscripten no threads support
+
 #![feature(panic_handler, const_fn, std_panic)]
 
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/src/test/run-pass/process-exit.rs
+++ b/src/test/run-pass/process-exit.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
+
 use std::env;
 use std::process::{self, Command, Stdio};
 

--- a/src/test/run-pass/process-remove-from-env.rs
+++ b/src/test/run-pass/process-remove-from-env.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
 
 use std::process::Command;
 use std::env;

--- a/src/test/run-pass/process-spawn-with-unicode-params.rs
+++ b/src/test/run-pass/process-spawn-with-unicode-params.rs
@@ -17,6 +17,7 @@
 // intact.
 
 // ignore-aarch64
+// ignore-emscripten
 
 use std::io::prelude::*;
 use std::io;

--- a/src/test/run-pass/rec-align-u64.rs
+++ b/src/test/run-pass/rec-align-u64.rs
@@ -42,7 +42,8 @@ struct Outer {
           target_os = "dragonfly",
           target_os = "netbsd",
           target_os = "openbsd",
-          target_os = "solaris"))]
+          target_os = "solaris",
+          target_os = "emscripten"))]
 mod m {
     #[cfg(target_arch = "x86")]
     pub mod m {

--- a/src/test/run-pass/running-with-no-runtime.rs
+++ b/src/test/run-pass/running-with-no-runtime.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
+
 #![feature(start)]
 
 use std::ffi::CStr;

--- a/src/test/run-pass/segfault-no-out-of-stack.rs
+++ b/src/test/run-pass/segfault-no-out-of-stack.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten can't run commands
+
 #![feature(libc)]
 
 extern crate libc;

--- a/src/test/run-pass/signal-exit-status.rs
+++ b/src/test/run-pass/signal-exit-status.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-windows
+// ignore-emscripten
 
 use std::env;
 use std::process::Command;

--- a/src/test/run-pass/sigpipe-should-be-ignored.rs
+++ b/src/test/run-pass/sigpipe-should-be-ignored.rs
@@ -12,6 +12,7 @@
 // doesn't die in a ball of fire, but rather it's gracefully handled.
 
 // ignore-aarch64
+// ignore-emscripten
 
 use std::env;
 use std::io::prelude::*;

--- a/src/test/run-pass/sleep.rs
+++ b/src/test/run-pass/sleep.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten no threads support
+
 use std::thread::{self, sleep};
 use std::time::Duration;
 use std::sync::{Arc, Mutex};

--- a/src/test/run-pass/wait-forked-but-failed-child.rs
+++ b/src/test/run-pass/wait-forked-but-failed-child.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
 
 #![feature(libc)]
 


### PR DESCRIPTION
This picks up parts of #31623 to disable certain tests that emscripten can't run, as threads/processes are not supported. 
I re-applied @tomaka's changes manually, I can rebase those commits with his credentials if he wants.

It also disables jemalloc for emscripten (at least in Rustbuild, I have to check if there is another setting for the same thing in the old makefile approach).

This should not impact anything for normal builds.
