### PR TITLE
E0072 update error format

### DIFF
--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -654,6 +654,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         let mut err = struct_span_err!(self.sess, span, E0072,
                                        "recursive type `{}` has infinite size",
                                        self.item_path_str(type_def_id));
+        err.span_label(span, &format!("recursive type has infinite size"));
         err.help(&format!("insert indirection (e.g., a `Box`, `Rc`, or `&`) \
                            at some point to make `{}` representable",
                           self.item_path_str(type_def_id)));

--- a/src/test/compile-fail/E0072.rs
+++ b/src/test/compile-fail/E0072.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 struct ListNode { //~ ERROR E0072
+                  //~| NOTE recursive type has infinite size
     head: u8,
     tail: Option<ListNode>,
 }

--- a/src/test/compile-fail/issue-3008-2.rs
+++ b/src/test/compile-fail/issue-3008-2.rs
@@ -13,6 +13,7 @@
 enum foo { foo_(bar) }
 struct bar { x: bar }
 //~^ ERROR E0072
+//~| NOTE recursive type has infinite size
 
 fn main() {
 }

--- a/src/test/compile-fail/issue-32326.rs
+++ b/src/test/compile-fail/issue-32326.rs
@@ -13,6 +13,7 @@
 // too big.
 
 enum Expr { //~ ERROR E0072
+            //~| NOTE recursive type has infinite size
     Plus(Expr, Expr),
     Literal(i64),
 }

--- a/src/test/compile-fail/issue-3779.rs
+++ b/src/test/compile-fail/issue-3779.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 struct S { //~ ERROR E0072
+           //~| NOTE recursive type has infinite size
     element: Option<S>
 }
 

--- a/src/test/compile-fail/type-recursive.rs
+++ b/src/test/compile-fail/type-recursive.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 struct t1 { //~ ERROR E0072
+            //~| NOTE recursive type has infinite size
     foo: isize,
     foolish: t1
 }


### PR DESCRIPTION
Part of  #35233 

Fixes #35506 

r? @jonathandturner 

The bonus for this issue currently seems to be impossible to do reliably, as the compiler seems to lack span information for item names alone, like `Foo` in `struct Foo { ... }`. It would be possible to hack something together by computing span offsets, but that seems like a solution that would be begging for trouble.

A proper solution to this would, of course, be to add span information to the right place (seems to be `rustc::hir::Item::name` but I may be wrong).
