### PR TITLE
add -mrelax-relocations=no to i686-musl and i586-gnu

### DIFF
--- a/mk/cfg/i586-unknown-linux-gnu.mk
+++ b/mk/cfg/i586-unknown-linux-gnu.mk
@@ -7,8 +7,8 @@ CFG_LIB_NAME_i586-unknown-linux-gnu=lib$(1).so
 CFG_STATIC_LIB_NAME_i586-unknown-linux-gnu=lib$(1).a
 CFG_LIB_GLOB_i586-unknown-linux-gnu=lib$(1)-*.so
 CFG_LIB_DSYM_GLOB_i586-unknown-linux-gnu=lib$(1)-*.dylib.dSYM
-CFG_JEMALLOC_CFLAGS_i586-unknown-linux-gnu := -m32 $(CFLAGS) -march=pentium
-CFG_GCCISH_CFLAGS_i586-unknown-linux-gnu :=  -g -fPIC -m32 $(CFLAGS) -march=pentium
+CFG_JEMALLOC_CFLAGS_i586-unknown-linux-gnu := -m32 $(CFLAGS) -march=pentium -Wa,-mrelax-relocations=no
+CFG_GCCISH_CFLAGS_i586-unknown-linux-gnu :=  -g -fPIC -m32 $(CFLAGS) -march=pentium -Wa,-mrelax-relocations=no
 CFG_GCCISH_CXXFLAGS_i586-unknown-linux-gnu := -fno-rtti $(CXXFLAGS) -march=pentium
 CFG_GCCISH_LINK_FLAGS_i586-unknown-linux-gnu := -shared -fPIC -ldl -pthread  -lrt -g -m32
 CFG_GCCISH_DEF_FLAG_i586-unknown-linux-gnu := -Wl,--export-dynamic,--dynamic-list=

--- a/mk/cfg/i686-unknown-linux-musl.mk
+++ b/mk/cfg/i686-unknown-linux-musl.mk
@@ -7,8 +7,8 @@ CFG_INSTALL_ONLY_RLIB_i686-unknown-linux-musl = 1
 CFG_LIB_NAME_i686-unknown-linux-musl=lib$(1).so
 CFG_STATIC_LIB_NAME_i686-unknown-linux-musl=lib$(1).a
 CFG_LIB_GLOB_i686-unknown-linux-musl=lib$(1)-*.so
-CFG_JEMALLOC_CFLAGS_i686-unknown-linux-musl := -m32 -Wl,-melf_i386
-CFG_GCCISH_CFLAGS_i686-unknown-linux-musl :=  -g -fPIC -m32 -Wl,-melf_i386
+CFG_JEMALLOC_CFLAGS_i686-unknown-linux-musl := -m32 -Wl,-melf_i386 -Wa,-mrelax-relocations=no
+CFG_GCCISH_CFLAGS_i686-unknown-linux-musl :=  -g -fPIC -m32 -Wl,-melf_i386 -Wa,-mrelax-relocations=no
 CFG_GCCISH_CXXFLAGS_i686-unknown-linux-musl :=
 CFG_GCCISH_LINK_FLAGS_i686-unknown-linux-musl :=
 CFG_GCCISH_DEF_FLAG_i686-unknown-linux-musl :=

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -863,7 +863,8 @@ impl Build {
             "i686-unknown-linux-musl" |
             "x86_64-unknown-linux-musl" => {
                 base.push("-Wa,-mrelax-relocations=no".into());
-            }
+            },
+            _ => {},
         }
         return base
     }

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -858,8 +858,12 @@ impl Build {
         // This is a hack, because newer binutils broke things on some vms/distros
         // (i.e., linking against unknown relocs disabled by the following flag)
         // See: https://github.com/rust-lang/rust/issues/34978
-        if target == "x86_64-unknown-linux-musl" {
-            base.push("-Wa,-mrelax-relocations=no".into());
+        match target {
+            "i586-unknown-linux-gnu" |
+            "i686-unknown-linux-musl" |
+            "x86_64-unknown-linux-musl" => {
+                base.push("-Wa,-mrelax-relocations=no".into());
+            }
         }
         return base
     }


### PR DESCRIPTION
I've been experiencing #34978 with these two targets. This applies the
hack in #35178 to these targets as well.

r? @alexcrichton 
