### PR TITLE
gdb: Fix pretty-printing special-cased Rust types

### DIFF
--- a/src/etc/debugger_pretty_printers_common.py
+++ b/src/etc/debugger_pretty_printers_common.py
@@ -324,3 +324,20 @@ def extract_length_and_ptr_from_slice(slice_val):
 
     assert data_ptr.type.get_dwarf_type_kind() == DWARF_TYPE_CODE_PTR
     return (length, data_ptr)
+
+UNQUALIFIED_TYPE_MARKERS = frozenset(["(", "[", "&", "*"])
+
+def extract_type_name(qualified_type_name):
+    '''Extracts the type name from a fully qualified path'''
+    if qualified_type_name[0] in UNQUALIFIED_TYPE_MARKERS:
+        return qualified_type_name
+
+    end_of_search = qualified_type_name.find("<")
+    if end_of_search < 0:
+        end_of_search = len(qualified_type_name)
+
+    index = qualified_type_name.rfind("::", 0, end_of_search)
+    if index < 0:
+        return qualified_type_name
+    else:
+        return qualified_type_name[index + 2:]

--- a/src/etc/gdb_rust_pretty_printing.py
+++ b/src/etc/gdb_rust_pretty_printing.py
@@ -36,7 +36,7 @@ class GdbType(rustpp.Type):
         if tag is None:
             return tag
 
-        return tag.replace("&'static ", "&")
+        return rustpp.extract_type_name(tag).replace("&'static ", "&")
 
     def get_dwarf_type_kind(self):
         if self.ty.code == gdb.TYPE_CODE_STRUCT:

--- a/src/etc/lldb_rust_formatters.py
+++ b/src/etc/lldb_rust_formatters.py
@@ -29,7 +29,7 @@ class LldbType(rustpp.Type):
         if qualified_name is None:
             return qualified_name
 
-        return extract_type_name(qualified_name).replace("&'static ", "&")
+        return rustpp.extract_type_name(qualified_name).replace("&'static ", "&")
 
     def get_dwarf_type_kind(self):
         type_class = self.ty.GetTypeClass()
@@ -204,7 +204,7 @@ def print_struct_val(val, internal_dict, omit_first_field, omit_type_name, is_tu
             # LLDB is not good at handling zero-sized values, so we have to help
             # it a little
             if field.GetType().GetByteSize() == 0:
-                return this + extract_type_name(field.GetType().GetName())
+                return this + rustpp.extract_type_name(field.GetType().GetName())
             else:
                 return this + "<invalid value>"
 
@@ -273,23 +273,6 @@ def print_std_string_val(val, internal_dict):
 #=--------------------------------------------------------------------------------------------------
 # Helper Functions
 #=--------------------------------------------------------------------------------------------------
-
-UNQUALIFIED_TYPE_MARKERS = frozenset(["(", "[", "&", "*"])
-
-def extract_type_name(qualified_type_name):
-    '''Extracts the type name from a fully qualified path'''
-    if qualified_type_name[0] in UNQUALIFIED_TYPE_MARKERS:
-        return qualified_type_name
-
-    end_of_search = qualified_type_name.find("<")
-    if end_of_search < 0:
-        end_of_search = len(qualified_type_name)
-
-    index = qualified_type_name.rfind("::", 0, end_of_search)
-    if index < 0:
-        return qualified_type_name
-    else:
-        return qualified_type_name[index + 2:]
 
 def print_array_of_values(array_name, data_ptr_val, length, internal_dict):
     '''Prints a contigous memory range, interpreting it as values of the


### PR DESCRIPTION
gdb trunk now reports fully qualified type names, just like lldb. Move lldb code for extracting unqualified names to shared file.

For current releases of gdb, `extract_type_name` should just be a no-op.

Fixes #35155
