### PR TITLE
Use an existing constant name as an example.

### DIFF
--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -32,7 +32,7 @@
 //! atomically-reference-counted shared pointer).
 //!
 //! Most atomic types may be stored in static variables, initialized using
-//! the provided static initializers like `INIT_ATOMIC_BOOL`. Atomic statics
+//! the provided static initializers like `ATOMIC_BOOL_INIT`. Atomic statics
 //! are often used for lazy global initialization.
 //!
 //!


### PR DESCRIPTION
By reading atomics documentation I tried to use `INIT_ATOMIC_BOOL`, which I couldn't find. Turns out it was renamed to `ATOMIC_BOOL_INIT`.
