### PR TITLE
Clarify type declaration language in Associated Types docs

### DIFF
--- a/src/doc/book/associated-types.md
+++ b/src/doc/book/associated-types.md
@@ -67,7 +67,7 @@ trait Graph {
 Simple enough. Associated types use the `type` keyword, and go inside the body
 of the trait, with the functions.
 
-These `type` declarations can have all the same thing as functions do. For example,
+These `type` declarations work in the same way as those for functions do. For example,
 if we wanted our `N` type to implement `Display`, so we can print the nodes out,
 we could do this:
 

--- a/src/doc/book/associated-types.md
+++ b/src/doc/book/associated-types.md
@@ -67,7 +67,7 @@ trait Graph {
 Simple enough. Associated types use the `type` keyword, and go inside the body
 of the trait, with the functions.
 
-These `type` declarations work in the same way as those for functions do. For example,
+These type declarations work the same way as those for functions. For example,
 if we wanted our `N` type to implement `Display`, so we can print the nodes out,
 we could do this:
 


### PR DESCRIPTION
A small fix for the Associated Types docs

r? @steveklabnik
