### PR TITLE
Add note to docs for &str that example is to demo internals only

### DIFF
--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -385,6 +385,9 @@ mod prim_slice { }
 ///
 /// [`.as_ptr()`]: #method.as_ptr
 /// [`len()`]: #method.len
+///
+/// Note: This example shows the internals of `&str`. `unsafe` should not be
+/// used to get a string slice under normal circumstances.
 mod prim_str { }
 
 #[doc(primitive = "tuple")]

--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -387,7 +387,8 @@ mod prim_slice { }
 /// [`len()`]: #method.len
 ///
 /// Note: This example shows the internals of `&str`. `unsafe` should not be
-/// used to get a string slice under normal circumstances.
+/// used to get a string slice under normal circumstances. Use `.as_slice()`
+/// instead.
 mod prim_str { }
 
 #[doc(primitive = "tuple")]


### PR DESCRIPTION
r? @steveklabnik 

This adds a note below the &str representation example explaining that the example provided should not be used under normal circumstances..

Would it make sense to point people in the direction of the method(s) they should use instead?  I left it out in the interest of not complicating the documentation, but, there's definitely an argument to be made for adding a bit of guidance in there.
