### PR TITLE
Improve &-ptr printing

### DIFF
--- a/src/librustc/ty/error.rs
+++ b/src/librustc/ty/error.rs
@@ -222,7 +222,24 @@ impl<'a, 'gcx, 'lcx, 'tcx> ty::TyS<'tcx> {
             ty::TyArray(_, n) => format!("array of {} elements", n),
             ty::TySlice(_) => "slice".to_string(),
             ty::TyRawPtr(_) => "*-ptr".to_string(),
-            ty::TyRef(_, _) => "&-ptr".to_string(),
+            ty::TyRef(region, tymut) => {
+                let tymut_string = tymut.to_string();
+                if tymut_string == "_" ||         //unknown type name,
+                   tymut_string.len() > 10 ||     //name longer than saying "reference",
+                   region.to_string() != ""       //... or a complex type
+                {
+                    match tymut {
+                        ty::TypeAndMut{mutbl, ..} => {
+                            format!("{}reference", match mutbl {
+                                hir::Mutability::MutMutable => "mutable ",
+                                _ => ""
+                            })
+                        }
+                    }
+                } else {
+                    format!("&{}", tymut_string)
+                }
+            }
             ty::TyFnDef(..) => format!("fn item"),
             ty::TyFnPtr(_) => "fn pointer".to_string(),
             ty::TyTrait(ref inner) => {

--- a/src/test/compile-fail/coercion-slice.rs
+++ b/src/test/compile-fail/coercion-slice.rs
@@ -15,5 +15,5 @@ fn main() {
     //~^ ERROR mismatched types
     //~| expected type `&[i32]`
     //~| found type `[{integer}; 1]`
-    //~| expected &-ptr, found array of 1 elements
+    //~| expected &[i32], found array of 1 elements
 }

--- a/src/test/compile-fail/cross-borrow-trait.rs
+++ b/src/test/compile-fail/cross-borrow-trait.rs
@@ -21,5 +21,5 @@ pub fn main() {
     let _y: &Trait = x; //~  ERROR mismatched types
                         //~| expected type `&Trait`
                         //~| found type `Box<Trait>`
-                        //~| expected &-ptr, found box
+                        //~| expected &Trait, found box
 }

--- a/src/test/compile-fail/destructure-trait-ref.rs
+++ b/src/test/compile-fail/destructure-trait-ref.rs
@@ -42,12 +42,12 @@ fn main() {
     //~^ ERROR mismatched types
     //~| expected type `T`
     //~| found type `&_`
-    //~| expected trait T, found &-ptr
+    //~| expected trait T, found reference
     let &&&x = &(&1isize as &T);
     //~^ ERROR mismatched types
     //~| expected type `T`
     //~| found type `&_`
-    //~| expected trait T, found &-ptr
+    //~| expected trait T, found reference
     let box box x = box 1isize as Box<T>;
     //~^ ERROR mismatched types
     //~| expected type `T`

--- a/src/test/compile-fail/dst-bad-coercions.rs
+++ b/src/test/compile-fail/dst-bad-coercions.rs
@@ -19,12 +19,12 @@ struct Foo<T: ?Sized> {
 }
 
 pub fn main() {
-    // Test that we cannot convert from *-ptr to &-ptr
+    // Test that we cannot convert from *-ptr to &S and &T
     let x: *const S = &S;
     let y: &S = x; //~ ERROR mismatched types
     let y: &T = x; //~ ERROR mismatched types
 
-    // Test that we cannot convert from *-ptr to &-ptr (mut version)
+    // Test that we cannot convert from *-ptr to &S and &T (mut version)
     let x: *mut S = &mut S;
     let y: &S = x; //~ ERROR mismatched types
     let y: &T = x; //~ ERROR mismatched types

--- a/src/test/compile-fail/issue-12997-2.rs
+++ b/src/test/compile-fail/issue-12997-2.rs
@@ -17,4 +17,4 @@ fn bar(x: isize) { }
 //~^ ERROR mismatched types
 //~| expected type `fn(&mut __test::test::Bencher)`
 //~| found type `fn(isize) {bar}`
-//~| expected &-ptr, found isize
+//~| expected mutable reference, found isize

--- a/src/test/compile-fail/issue-16338.rs
+++ b/src/test/compile-fail/issue-16338.rs
@@ -18,5 +18,5 @@ fn main() {
     //~^ ERROR mismatched types
     //~| expected type `&str`
     //~| found type `Slice<_>`
-    //~| expected &-ptr, found struct `Slice`
+    //~| expected &str, found struct `Slice`
 }

--- a/src/test/compile-fail/issue-17033.rs
+++ b/src/test/compile-fail/issue-17033.rs
@@ -12,7 +12,7 @@ fn f<'r>(p: &'r mut fn(p: &mut ())) {
     (*p)(()) //~  ERROR mismatched types
              //~| expected type `&mut ()`
              //~| found type `()`
-             //~| expected &-ptr, found ()
+             //~| expected &mut (), found ()
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-20225.rs
+++ b/src/test/compile-fail/issue-20225.rs
@@ -15,13 +15,13 @@ struct Foo;
 impl<'a, T> Fn<(&'a T,)> for Foo {
   extern "rust-call" fn call(&self, (_,): (T,)) {}
   //~^ ERROR: has an incompatible type for trait
-  //~| expected &-ptr
+  //~| expected reference
 }
 
 impl<'a, T> FnMut<(&'a T,)> for Foo {
   extern "rust-call" fn call_mut(&mut self, (_,): (T,)) {}
   //~^ ERROR: has an incompatible type for trait
-  //~| expected &-ptr
+  //~| expected reference
 }
 
 impl<'a, T> FnOnce<(&'a T,)> for Foo {
@@ -29,7 +29,7 @@ impl<'a, T> FnOnce<(&'a T,)> for Foo {
 
   extern "rust-call" fn call_once(self, (_,): (T,)) {}
   //~^ ERROR: has an incompatible type for trait
-  //~| expected &-ptr
+  //~| expected reference
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-29084.rs
+++ b/src/test/compile-fail/issue-29084.rs
@@ -13,7 +13,7 @@ macro_rules! foo {
         fn bar(d: u8) { }
         bar(&mut $d);
         //~^ ERROR mismatched types
-        //~| expected u8, found &-ptr
+        //~| expected u8, found &mut u8
         //~| expected type `u8`
         //~| found type `&mut u8`
     }}

--- a/src/test/compile-fail/issue-5100.rs
+++ b/src/test/compile-fail/issue-5100.rs
@@ -52,7 +52,7 @@ fn main() {
 //~^ ERROR mismatched types
 //~| expected type `(bool, bool)`
 //~| found type `&_`
-//~| expected tuple, found &-ptr
+//~| expected tuple, found reference
     }
 
 

--- a/src/test/compile-fail/issue-5500.rs
+++ b/src/test/compile-fail/issue-5500.rs
@@ -13,5 +13,5 @@ fn main() {
     //~^ ERROR mismatched types
     //~| expected type `()`
     //~| found type `&_`
-    //~| expected (), found &-ptr
+    //~| expected (), found reference
 }

--- a/src/test/compile-fail/issue-7061.rs
+++ b/src/test/compile-fail/issue-7061.rs
@@ -15,7 +15,7 @@ impl<'a> BarStruct {
     //~^ ERROR mismatched types
     //~| expected type `Box<BarStruct>`
     //~| found type `&'a mut BarStruct`
-    //~| expected box, found &-ptr
+    //~| expected box, found mutable reference
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-7867.rs
+++ b/src/test/compile-fail/issue-7867.rs
@@ -27,11 +27,11 @@ fn main() {
         //~^ ERROR mismatched types
         //~| expected type `&std::option::Option<{integer}>`
         //~| found type `std::option::Option<_>`
-        //~| expected &-ptr, found enum `std::option::Option`
+        //~| expected reference, found enum `std::option::Option`
         None => ()
         //~^ ERROR mismatched types
         //~| expected type `&std::option::Option<{integer}>`
         //~| found type `std::option::Option<_>`
-        //~| expected &-ptr, found enum `std::option::Option`
+        //~| expected reference, found enum `std::option::Option`
     }
 }

--- a/src/test/compile-fail/method-self-arg-1.rs
+++ b/src/test/compile-fail/method-self-arg-1.rs
@@ -21,7 +21,7 @@ fn main() {
     Foo::bar(x); //~  ERROR mismatched types
                  //~| expected type `&Foo`
                  //~| found type `Foo`
-                 //~| expected &-ptr, found struct `Foo`
+                 //~| expected &Foo, found struct `Foo`
     Foo::bar(&42); //~  ERROR mismatched types
                       //~| expected type `&Foo`
                       //~| found type `&{integer}`

--- a/src/test/compile-fail/overloaded-calls-bad.rs
+++ b/src/test/compile-fail/overloaded-calls-bad.rs
@@ -36,7 +36,7 @@ fn main() {
         y: 3,
     };
     let ans = s("what");    //~ ERROR mismatched types
-    //~^ NOTE expected isize, found &-ptr
+    //~^ NOTE expected isize, found reference
     //~| NOTE expected type
     //~| NOTE found type
     let ans = s();

--- a/src/test/compile-fail/repeat_count.rs
+++ b/src/test/compile-fail/repeat_count.rs
@@ -38,7 +38,7 @@ fn main() {
     //~^ ERROR mismatched types
     //~| expected type `usize`
     //~| found type `&'static str`
-    //~| expected usize, found &-ptr
+    //~| expected usize, found reference
     //~| ERROR expected `usize` for repeat count, found string literal [E0306]
     //~| expected `usize`
     let f = [0; -4_isize];


### PR DESCRIPTION
This PR replaces printing `&-ptr` with a more readable description.  To do so it uses a few heuristics.

If the name of the type is unknown, too long (longer than just saying "reference"), or too complex (a type with explicit lifetime annotations), it will instead opt to print either "reference" or "mutable reference", depending on the mutability of the type.

Before:

```
error[E0308]: mismatched types
  --> src/test/compile-fail/issue-7061.rs:14:46
   |
14 |     fn foo(&'a mut self) -> Box<BarStruct> { self }
   |                                              ^^^^ expected box, found &-ptr
   |
   = note: expected type `Box<BarStruct>`
   = note:    found type `&'a mut BarStruct`

error: aborting due to previous error
```

After:

```
error[E0308]: mismatched types
  --> src/test/compile-fail/issue-7061.rs:14:46
   |
14 |     fn foo(&'a mut self) -> Box<BarStruct> { self }
   |                                              ^^^^ expected box, found mutable reference
   |
   = note: expected type `Box<BarStruct>`
   = note:    found type `&'a mut BarStruct`

error: aborting due to previous error
```
