### PR TITLE
changed E0067 to new error format

### DIFF
--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -41,7 +41,13 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
         let tcx = self.tcx;
         if !tcx.expr_is_lval(lhs_expr) {
-            span_err!(tcx.sess, lhs_expr.span, E0067, "invalid left-hand side expression");
+            struct_span_err!(
+                tcx.sess, lhs_expr.span,
+                E0067, "invalid left-hand side expression")
+            .span_label(
+                lhs_expr.span,
+                &format!("invalid expression for left-hand side"))
+            .emit();
         }
     }
 

--- a/src/test/compile-fail/E0067.rs
+++ b/src/test/compile-fail/E0067.rs
@@ -13,4 +13,6 @@ use std::collections::LinkedList;
 fn main() {
     LinkedList::new() += 1; //~ ERROR E0368
                             //~^ ERROR E0067
+                            //~^^ NOTE invalid expression for left-hand side
+                            //~| NOTE cannot use `+=` on type `std::collections::LinkedList<_>`
 }


### PR DESCRIPTION
Updated E0067 to new error format.
Part of #35233 
Fixes #35502 

Passes all the tests when running:
`python src/bootstrap/bootstrap.py --step check-cfail --stage 1`

**This seems strange, given that the format for E0067 has been changed.**
It feels like it should fail some unit tests maybe?

Let me know if I'm mistaken. Otherwise I can create a unit test for it.

Thanks for letting me help!

r? @jonathandturner
