### PR TITLE
Improve `No stdlib` and related Documentation

### DIFF
--- a/src/doc/book/lang-items.md
+++ b/src/doc/book/lang-items.md
@@ -57,8 +57,8 @@ fn main(argc: isize, argv: *const *const u8) -> isize {
     0
 }
 
-#[lang = "eh_personality"] extern fn eh_personality() {}
-#[lang = "panic_fmt"] fn panic_fmt() -> ! { loop {} }
+#[lang = "eh_personality"] extern fn rust_eh_personality() {}
+#[lang = "panic_fmt"] extern fn rust_begin_panic() -> ! { loop {} }
 # #[lang = "eh_unwind_resume"] extern fn rust_eh_unwind_resume() {}
 # #[no_mangle] pub extern fn rust_eh_register_frames () {}
 # #[no_mangle] pub extern fn rust_eh_unregister_frames () {}
@@ -73,8 +73,8 @@ Other features provided by lang items include:
   `==`, `<`, dereferencing (`*`) and `+` (etc.) operators are all
   marked with lang items; those specific four are `eq`, `ord`,
   `deref`, and `add` respectively.
-- stack unwinding and general failure; the `eh_personality`, `fail`
-  and `fail_bounds_checks` lang items.
+- stack unwinding and general failure; the `eh_personality`,
+  `eh_unwind_resume`, `fail` and `fail_bounds_checks` lang items.
 - the traits in `std::marker` used to indicate types of
   various kinds; lang items `send`, `sync` and `copy`.
 - the marker types and variance indicators found in

--- a/src/doc/book/no-stdlib.md
+++ b/src/doc/book/no-stdlib.md
@@ -55,7 +55,13 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
 // provided by libstd.
 #[lang = "eh_personality"]
 #[no_mangle]
-pub extern fn eh_personality() {
+pub extern fn rust_eh_personality() {
+}
+
+// This function may be needed based on the compilation target.
+#[lang = "eh_unwind_resume"]
+#[no_mangle]
+pub extern fn rust_eh_unwind_resume() {
 }
 
 #[lang = "panic_fmt"]
@@ -87,12 +93,18 @@ pub extern fn main(_argc: i32, _argv: *const *const u8) -> i32 {
     0
 }
 
-// These functions and traits are used by the compiler, but not
+// These functions are used by the compiler, but not
 // for a bare-bones hello world. These are normally
 // provided by libstd.
 #[lang = "eh_personality"]
 #[no_mangle]
-pub extern fn eh_personality() {
+pub extern fn rust_eh_personality() {
+}
+
+// This function may be needed based on the compilation target.
+#[lang = "eh_unwind_resume"]
+#[no_mangle]
+pub extern fn rust_eh_unwind_resume() {
 }
 
 #[lang = "panic_fmt"]
@@ -104,7 +116,7 @@ pub extern fn rust_begin_panic(_msg: core::fmt::Arguments,
 }
 ```
 
-## More about the langauge items
+## More about the language items
 
 The compiler currently makes a few assumptions about symbols which are
 available in the executable to call. Normally these functions are provided by
@@ -112,15 +124,20 @@ the standard library, but without it you must define your own. These symbols
 are called "language items", and they each have an internal name, and then a
 signature that an implementation must conform to.
 
-The first of these two functions, `eh_personality`, is used by the failure
+The first of these functions, `rust_eh_personality`, is used by the failure
 mechanisms of the compiler. This is often mapped to GCC's personality function
 (see the [libstd implementation][unwind] for more information), but crates
 which do not trigger a panic can be assured that this function is never
-called. Both the language item and the symbol name are `eh_personality`.
- 
+called. The language item's name is `eh_personality`.
+
 [unwind]: https://github.com/rust-lang/rust/blob/master/src/libpanic_unwind/gcc.rs
 
-The second function, `panic_fmt`, is also used by the failure mechanisms of the
+The second function, `rust_begin_panic`, is also used by the failure mechanisms of the
 compiler. When a panic happens, this controls the message that's displayed on
 the screen. While the language item's name is `panic_fmt`, the symbol name is
 `rust_begin_panic`.
+
+A third function, `rust_eh_unwind_resume`, is also needed if the `custom_unwind_resume`
+flag is set in the options of the compilation target. It allows customizing the
+process of resuming unwind at the end of the landing pads. The language item's name
+is `eh_unwind_resume`.

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -42,6 +42,11 @@
 //!   line. It is up to consumers of this core library to define this panic
 //!   function; it is only required to never return. This requires a `lang`
 //!   attribute named `panic_fmt`.
+//!
+//! * `rust_eh_personality` - is used by the failure mechanisms of the
+//!    compiler. This is often mapped to GCC's personality function, but crates
+//!    which do not trigger a panic can be assured that this function is never
+//!    called. The `lang` attribute is called `eh_personality`.
 
 // Since libcore defines many fundamental lang items, all tests live in a
 // separate crate, libcoretest, to avoid bizarre issues.


### PR DESCRIPTION
This renames all lang item function names to the ones used in `libstd` and `libpanic_unwind`. It also explains the `eh_unwind_resume` lang item in the `libcore` documentation, where it was missing. A third function is also needed on certain compilation targets, so this was also added to the `No stdlib` documentation.
