### PR TITLE
prohibit splitting literal patterns

### DIFF
--- a/src/test/compile-fail/issue-35044.rs
+++ b/src/test/compile-fail/issue-35044.rs
@@ -1,0 +1,46 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[derive(Debug, PartialEq)]
+enum Reg {
+    EAX,
+    EBX,
+    ECX,
+    EDX,
+    ESP,
+    EBP,
+    ISP,
+}
+
+fn string_to_reg(_s:&str) -> Reg {
+    match _s.as_ref() {
+        "EAX" => Reg::EAX,
+        "EBX" => Reg::EBX,
+        "ECX" => Reg::ECX,
+        "EDX" => Reg::EDX,
+        "EBP" => Reg::EBP,
+        "ESP" => Reg::ESP,
+        "ISP" => Reg::ISP, //~ NOTE split literal here
+        &_    => panic!("bla bla bla"), //~ ERROR see issue #35044
+    }
+}
+
+fn main() {
+    let vec = vec!["EAX", "EBX", "ECX", "EDX", "ESP", "EBP", "ISP"];
+    let mut iter = vec.iter();
+    println!("{:?}", string_to_reg(""));
+    println!("{:?}", string_to_reg(iter.next().unwrap()));
+    println!("{:?}", string_to_reg(iter.next().unwrap()));
+    println!("{:?}", string_to_reg(iter.next().unwrap()));
+    println!("{:?}", string_to_reg(iter.next().unwrap()));
+    println!("{:?}",  string_to_reg(iter.next().unwrap()));
+    println!("{:?}", string_to_reg(iter.next().unwrap()));
+    println!("{:?}",  string_to_reg(iter.next().unwrap()));
+}


### PR DESCRIPTION
Before PR #32202, `check_match` tended to report bogus errors or ICE
when encountering a pattern that split a literal, e.g.

``` Rust
match foo {
    "bar" => {},
    &_ => {}
}
```

That PR fixed these issues, but `trans::_match` generates bad code
when it encounters these matches. MIR trans has that fixed, but
it is waiting for 6 weeks in beta. Report an error when encountering
these instead.

Fixes issue #35044.
