### PR TITLE
rustdoc: Don't add extra newlines for fully opaque structs

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2509,19 +2509,28 @@ fn render_struct(w: &mut fmt::Formatter, it: &clean::Item,
             if let Some(g) = g {
                 write!(w, "{}", WhereClause(g))?
             }
-            write!(w, " {{\n{}", tab)?;
+            let mut has_visible_fields = false;
+            write!(w, " {{")?;
             for field in fields {
                 if let clean::StructFieldItem(ref ty) = field.inner {
-                    write!(w, "    {}{}: {},\n{}",
+                    write!(w, "\n{}    {}{}: {},",
+                           tab,
                            VisSpace(&field.visibility),
                            field.name.as_ref().unwrap(),
-                           *ty,
-                           tab)?;
+                           *ty)?;
+                    has_visible_fields = true;
                 }
             }
 
-            if it.has_stripped_fields().unwrap() {
-                write!(w, "    // some fields omitted\n{}", tab)?;
+            if has_visible_fields {
+                if it.has_stripped_fields().unwrap() {
+                    write!(w, "\n{}    // some fields omitted", tab)?;
+                }
+                write!(w, "\n{}", tab)?;
+            } else if it.has_stripped_fields().unwrap() {
+                // If there are no visible fields we can just display
+                // `{ /* fields omitted */ }` to save space.
+                write!(w, " /* fields omitted */ ")?;
             }
             write!(w, "}}")?;
         }

--- a/src/test/rustdoc/structfields.rs
+++ b/src/test/rustdoc/structfields.rs
@@ -48,3 +48,13 @@ pub enum Qux {
         // @has - //pre "// some fields omitted"
     },
 }
+
+// @has structfields/struct.Baz.html //pre "pub struct Baz { /* fields omitted */ }"
+pub struct Baz {
+    x: u8,
+    #[doc(hidden)]
+    pub y: u8,
+}
+
+// @has structfields/struct.Quux.html //pre "pub struct Quux {}"
+pub struct Quux {}


### PR DESCRIPTION
Changes the definition for braced structs with only private or hidden fields to save space on the page.

Before:

```
pub struct Vec<T> {
    // some fields omitted
}
```

After:

```
pub struct Vec<T> { /* fields omitted */ }
```

This also cleans up empty braced structs.

Before:

```
pub struct Foo {
}
```

After:

```
pub struct Foo {}
```

[before](https://doc.rust-lang.org/nightly/std/vec/struct.Vec.html) [after](https://ollie27.github.io/rust_doc_test/std/vec/struct.Vec.html)

cc #34713
