### PR TITLE
Remove width limit for docs

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -170,8 +170,6 @@ nav.sub {
     min-height: 100%;
 }
 
-.content, nav { max-width: 960px; }
-
 /* Everything else */
 
 .js-only, .hidden { display: none !important; }


### PR DESCRIPTION
r? @steveklabnik 

And a screenshot to see the result:

![full-width](https://cloud.githubusercontent.com/assets/3050060/17663609/0b9467e2-62ee-11e6-8425-21b40c4b5f22.png)
