### PR TITLE
Restructure metadata encoder to track deps precisely

### DIFF
--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -947,8 +947,9 @@ impl<'a, 'tcx, 'encoder> ItemContentBuilder<'a, 'tcx, 'encoder> {
 
                 // Encode all the items in self module.
                 for foreign_item in &fm.items {
-                    self.rbml_w.wr_tagged_u64(tag_mod_child,
-                                              def_to_u64(ecx.tcx.map.local_def_id(foreign_item.id)));
+                    self.rbml_w.wr_tagged_u64(
+                        tag_mod_child,
+                        def_to_u64(ecx.tcx.map.local_def_id(foreign_item.id)));
                 }
                 self.encode_visibility(vis);
                 encode_stability(self.rbml_w, stab);

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -767,10 +767,6 @@ impl<'a, 'tcx, 'encoder> ItemContentBuilder<'a, 'tcx, 'encoder> {
         if let Some(ii) = impl_item_opt {
             encode_attributes(self.rbml_w, &ii.attrs);
             encode_defaultness(self.rbml_w, ii.defaultness);
-        } else {
-            // TODO this looks bogus and unnecessary
-            self.encode_predicates(&ecx.tcx.lookup_predicates(associated_type.def_id),
-                                   tag_item_generics);
         }
 
         if let Some(ty) = associated_type.ty {

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -415,7 +415,7 @@ fn encode_item_sort(rbml_w: &mut Encoder, sort: char) {
 impl<'a, 'tcx, 'encoder> IndexBuilder<'a, 'tcx, 'encoder> {
     fn encode_fields(&mut self,
                      adt_def_id: DefId) {
-        let def = self.ecx.tcx.lookup_adt_def(adt_def_id);
+        let def = self.ecx().tcx.lookup_adt_def(adt_def_id);
         for (variant_index, variant) in def.variants.iter().enumerate() {
             for (field_index, field) in variant.fields.iter().enumerate() {
                 self.record(field.did,
@@ -1155,7 +1155,7 @@ impl<'a, 'tcx, 'encoder> IndexBuilder<'a, 'tcx, 'encoder> {
     /// normally in the visitor walk.
     fn encode_addl_info_for_item(&mut self,
                                  item: &hir::Item) {
-        let def_id = self.ecx.tcx.map.local_def_id(item.id);
+        let def_id = self.ecx().tcx.map.local_def_id(item.id);
         match item.node {
             hir::ItemStatic(..) |
             hir::ItemConst(..) |
@@ -1187,7 +1187,7 @@ impl<'a, 'tcx, 'encoder> IndexBuilder<'a, 'tcx, 'encoder> {
                                def_id: DefId,
                                struct_node_id: ast::NodeId,
                                item: &hir::Item) {
-        let ecx = self.ecx;
+        let ecx = self.ecx();
         let def = ecx.tcx.lookup_adt_def(def_id);
         let variant = def.struct_variant();
 
@@ -1213,7 +1213,7 @@ impl<'a, 'tcx, 'encoder> IndexBuilder<'a, 'tcx, 'encoder> {
                              def_id: DefId,
                              impl_id: ast::NodeId,
                              ast_items: &[hir::ImplItem]) {
-        let ecx = self.ecx;
+        let ecx = self.ecx();
         let impl_items = ecx.tcx.impl_items.borrow();
         let items = &impl_items[&def_id];
 
@@ -1240,7 +1240,7 @@ impl<'a, 'tcx, 'encoder> IndexBuilder<'a, 'tcx, 'encoder> {
                               def_id: DefId,
                               trait_items: &[hir::TraitItem]) {
         // Now output the trait item info for each trait item.
-        let tcx = self.ecx.tcx;
+        let tcx = self.ecx().tcx;
         let r = tcx.trait_item_def_ids(def_id);
         for (item_def_id, trait_item) in r.iter().zip(trait_items) {
             let item_def_id = item_def_id.def_id();
@@ -1311,7 +1311,7 @@ impl<'a, 'ecx, 'tcx, 'encoder> Visitor<'tcx> for EncodeVisitor<'a, 'ecx, 'tcx, '
     }
     fn visit_item(&mut self, item: &'tcx hir::Item) {
         intravisit::walk_item(self, item);
-        let def_id = self.index.ecx.tcx.map.local_def_id(item.id);
+        let def_id = self.index.ecx().tcx.map.local_def_id(item.id);
         match item.node {
             hir::ItemExternCrate(_) | hir::ItemUse(_) => (), // ignore these
             _ => self.index.record(def_id,
@@ -1322,7 +1322,7 @@ impl<'a, 'ecx, 'tcx, 'encoder> Visitor<'tcx> for EncodeVisitor<'a, 'ecx, 'tcx, '
     }
     fn visit_foreign_item(&mut self, ni: &'tcx hir::ForeignItem) {
         intravisit::walk_foreign_item(self, ni);
-        let def_id = self.index.ecx.tcx.map.local_def_id(ni.id);
+        let def_id = self.index.ecx().tcx.map.local_def_id(ni.id);
         self.index.record(def_id,
                           ItemContentBuilder::encode_info_for_foreign_item,
                           (def_id, ni));

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -54,7 +54,7 @@ use rustc::hir::intravisit::Visitor;
 use rustc::hir::intravisit;
 use rustc::hir::map::DefKey;
 
-use super::index_builder::{IndexBuilder, XRef};
+use super::index_builder::{IndexBuilder, ItemContentBuilder, XRef};
 
 pub struct EncodeContext<'a, 'tcx: 'a> {
     pub diag: &'a Handler,
@@ -132,7 +132,7 @@ fn encode_item_variances(rbml_w: &mut Encoder,
     rbml_w.end_tag();
 }
 
-impl<'a, 'tcx> IndexBuilder<'a, 'tcx> {
+impl<'a, 'tcx> ItemContentBuilder<'a, 'tcx> {
     fn encode_bounds_and_type_for_item(&mut self,
                                        rbml_w: &mut Encoder,
                                        id: NodeId) {
@@ -164,7 +164,7 @@ fn write_closure_type<'a, 'tcx>(ecx: &EncodeContext<'a, 'tcx>,
     rbml_w.mark_stable_position();
 }
 
-impl<'a, 'tcx> IndexBuilder<'a, 'tcx> {
+impl<'a, 'tcx> ItemContentBuilder<'a, 'tcx> {
     fn encode_type(&mut self,
                    rbml_w: &mut Encoder,
                    typ: Ty<'tcx>) {
@@ -200,7 +200,9 @@ impl<'a, 'tcx> IndexBuilder<'a, 'tcx> {
             rbml_w.end_tag();
         }
     }
+}
 
+impl<'a, 'tcx> IndexBuilder<'a, 'tcx> {
     fn encode_enum_variant_info(&mut self,
                                 rbml_w: &mut Encoder,
                                 did: DefId,
@@ -302,7 +304,7 @@ fn encode_reexports(ecx: &EncodeContext,
     }
 }
 
-impl<'a, 'tcx> IndexBuilder<'a, 'tcx> {
+impl<'a, 'tcx> ItemContentBuilder<'a, 'tcx> {
     fn encode_info_for_mod(&mut self,
                            rbml_w: &mut Encoder,
                            md: &hir::Mod,
@@ -487,7 +489,9 @@ impl<'a, 'tcx> IndexBuilder<'a, 'tcx> {
 
         rbml_w.end_tag();
     }
+}
 
+impl<'a, 'tcx> ItemContentBuilder<'a, 'tcx> {
     fn encode_generics(&mut self,
                        rbml_w: &mut Encoder,
                        generics: &ty::Generics<'tcx>,
@@ -532,7 +536,9 @@ impl<'a, 'tcx> IndexBuilder<'a, 'tcx> {
             _ => encode_family(rbml_w, METHOD_FAMILY)
         }
     }
+}
 
+impl<'a, 'tcx> IndexBuilder<'a, 'tcx> {
     fn encode_info_for_associated_const(&mut self,
                                         rbml_w: &mut Encoder,
                                         associated_const: &ty::AssociatedConst,
@@ -680,7 +686,9 @@ impl<'a, 'tcx> IndexBuilder<'a, 'tcx> {
         }
         rbml_w.end_tag();
     }
+}
 
+impl<'a, 'tcx> ItemContentBuilder<'a, 'tcx> {
     fn encode_repr_attrs(&mut self,
                          rbml_w: &mut Encoder,
                          attrs: &[ast::Attribute]) {
@@ -1237,9 +1245,7 @@ impl<'a, 'tcx> IndexBuilder<'a, 'tcx> {
             }
         }
     }
-}
 
-impl<'a, 'tcx> IndexBuilder<'a, 'tcx> {
     fn encode_info_for_foreign_item(&mut self,
                                     rbml_w: &mut Encoder,
                                     nitem: &hir::ForeignItem) {

--- a/src/librustc_metadata/index_builder.rs
+++ b/src/librustc_metadata/index_builder.rs
@@ -1,0 +1,59 @@
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use encoder::EncodeContext;
+use index::IndexData;
+use rbml::writer::Encoder;
+use rustc::dep_graph::{DepGraph, DepNode, DepTask};
+use rustc::hir::def_id::DefId;
+use rustc::ty;
+use rustc_data_structures::fnv::FnvHashMap;
+
+pub struct CrateIndex<'a, 'tcx> {
+    dep_graph: &'a DepGraph,
+    items: IndexData,
+    xrefs: FnvHashMap<XRef<'tcx>, u32>, // sequentially-assigned
+}
+
+/// "interned" entries referenced by id
+#[derive(PartialEq, Eq, Hash)]
+pub enum XRef<'tcx> { Predicate(ty::Predicate<'tcx>) }
+
+impl<'a, 'tcx> CrateIndex<'a, 'tcx> {
+    pub fn new(ecx: &EncodeContext<'a, 'tcx>) -> Self {
+        CrateIndex {
+            dep_graph: &ecx.tcx.dep_graph,
+            items: IndexData::new(ecx.tcx.map.num_local_def_ids()),
+            xrefs: FnvHashMap()
+        }
+    }
+
+    /// Records that `id` is being emitted at the current offset.
+    /// This data is later used to construct the item index in the
+    /// metadata so we can quickly find the data for a given item.
+    ///
+    /// Returns a dep-graph task that you should keep live as long as
+    /// the data for this item is being emitted.
+    pub fn record(&mut self, id: DefId, rbml_w: &mut Encoder) -> DepTask<'a> {
+        let position = rbml_w.mark_stable_position();
+        self.items.record(id, position);
+        self.dep_graph.in_task(DepNode::MetaData(id))
+    }
+
+    pub fn add_xref(&mut self, xref: XRef<'tcx>) -> u32 {
+        let old_len = self.xrefs.len() as u32;
+        *self.xrefs.entry(xref).or_insert(old_len)
+    }
+
+    pub fn into_fields(self) -> (IndexData, FnvHashMap<XRef<'tcx>, u32>) {
+        (self.items, self.xrefs)
+    }
+}
+

--- a/src/librustc_metadata/index_builder.rs
+++ b/src/librustc_metadata/index_builder.rs
@@ -11,12 +11,12 @@
 use encoder::EncodeContext;
 use index::IndexData;
 use rbml::writer::Encoder;
-use rustc::dep_graph::{DepGraph, DepNode, DepTask};
+use rustc::dep_graph::{DepNode, DepTask};
 use rustc::hir::def_id::DefId;
 use rustc::ty;
 use rustc_data_structures::fnv::FnvHashMap;
 
-pub struct IndexBuilder<'a, 'tcx> {
+pub struct IndexBuilder<'a, 'tcx: 'a> {
     ecx: &'a EncodeContext<'a, 'tcx>,
     items: IndexData,
     xrefs: FnvHashMap<XRef<'tcx>, u32>, // sequentially-assigned
@@ -27,7 +27,7 @@ pub struct IndexBuilder<'a, 'tcx> {
 pub enum XRef<'tcx> { Predicate(ty::Predicate<'tcx>) }
 
 impl<'a, 'tcx> IndexBuilder<'a, 'tcx> {
-    pub fn new(ecx: &EncodeContext<'a, 'tcx>) -> Self {
+    pub fn new(ecx: &'a EncodeContext<'a, 'tcx>) -> Self {
         IndexBuilder {
             ecx: ecx,
             items: IndexData::new(ecx.tcx.map.num_local_def_ids()),
@@ -35,7 +35,7 @@ impl<'a, 'tcx> IndexBuilder<'a, 'tcx> {
         }
     }
 
-    pub fn ecx(&self) {
+    pub fn ecx(&self) -> &'a EncodeContext<'a, 'tcx> {
         self.ecx
     }
 

--- a/src/librustc_metadata/index_builder.rs
+++ b/src/librustc_metadata/index_builder.rs
@@ -57,14 +57,16 @@ impl<'a, 'tcx, 'encoder> IndexBuilder<'a, 'tcx, 'encoder> {
     ///
     /// Returns a dep-graph task that you should keep live as long as
     /// the data for this item is being emitted.
-    pub fn record<OP>(&mut self, id: DefId, op: OP)
-        where OP: FnOnce(&mut ItemContentBuilder<'a, 'tcx, 'encoder>)
+    pub fn record<DATA>(&mut self,
+                        id: DefId,
+                        op: fn(&mut ItemContentBuilder<'a, 'tcx, 'encoder>, DATA),
+                        data: DATA)
     {
         let position = self.rbml_w.mark_stable_position();
         self.items.record(id, position);
         let _task = self.ecx.tcx.dep_graph.in_task(DepNode::MetaData(id));
         self.rbml_w.start_tag(tag_items_data_item).unwrap();
-        op(self);
+        op(self, data);
         self.rbml_w.end_tag().unwrap();
     }
 

--- a/src/librustc_metadata/index_builder.rs
+++ b/src/librustc_metadata/index_builder.rs
@@ -20,29 +20,33 @@ use std::ops::{Deref, DerefMut};
 
 /// Builder that can encode new items, adding them into the index.
 /// Item encoding cannot be nested.
-pub struct IndexBuilder<'a, 'tcx: 'a> {
+pub struct IndexBuilder<'a, 'tcx: 'a, 'encoder: 'a> {
     items: IndexData,
-    builder: ItemContentBuilder<'a, 'tcx>,
+    builder: ItemContentBuilder<'a, 'tcx, 'encoder>,
 }
 
 /// Builder that can encode the content of items, but can't start a
 /// new item itself. Most code is attached to here.
-pub struct ItemContentBuilder<'a, 'tcx: 'a> {
+pub struct ItemContentBuilder<'a, 'tcx: 'a, 'encoder: 'a> {
     xrefs: FnvHashMap<XRef<'tcx>, u32>, // sequentially-assigned
-    ecx: &'a EncodeContext<'a, 'tcx>,
+    pub ecx: &'a EncodeContext<'a, 'tcx>,
+    pub rbml_w: &'a mut Encoder<'encoder>,
 }
 
 /// "interned" entries referenced by id
 #[derive(PartialEq, Eq, Hash)]
 pub enum XRef<'tcx> { Predicate(ty::Predicate<'tcx>) }
 
-impl<'a, 'tcx> IndexBuilder<'a, 'tcx> {
-    pub fn new(ecx: &'a EncodeContext<'a, 'tcx>) -> Self {
+impl<'a, 'tcx, 'encoder> IndexBuilder<'a, 'tcx, 'encoder> {
+    pub fn new(ecx: &'a EncodeContext<'a, 'tcx>,
+               rbml_w: &'a mut Encoder<'encoder>)
+               -> Self {
         IndexBuilder {
             items: IndexData::new(ecx.tcx.map.num_local_def_ids()),
             builder: ItemContentBuilder {
                 ecx: ecx,
                 xrefs: FnvHashMap(),
+                rbml_w: rbml_w,
             },
         }
     }
@@ -53,15 +57,15 @@ impl<'a, 'tcx> IndexBuilder<'a, 'tcx> {
     ///
     /// Returns a dep-graph task that you should keep live as long as
     /// the data for this item is being emitted.
-    pub fn record<OP>(&mut self, id: DefId, rbml_w: &mut Encoder, op: OP)
-        where OP: FnOnce(&mut ItemContentBuilder<'a, 'tcx>, &mut Encoder)
+    pub fn record<OP>(&mut self, id: DefId, op: OP)
+        where OP: FnOnce(&mut ItemContentBuilder<'a, 'tcx, 'encoder>)
     {
-        let position = rbml_w.mark_stable_position();
+        let position = self.rbml_w.mark_stable_position();
         self.items.record(id, position);
         let _task = self.ecx.tcx.dep_graph.in_task(DepNode::MetaData(id));
-        rbml_w.start_tag(tag_items_data_item).unwrap();
-        op(self, rbml_w);
-        rbml_w.end_tag().unwrap();
+        self.rbml_w.start_tag(tag_items_data_item).unwrap();
+        op(self);
+        self.rbml_w.end_tag().unwrap();
     }
 
     pub fn into_fields(self) -> (IndexData, FnvHashMap<XRef<'tcx>, u32>) {
@@ -69,21 +73,21 @@ impl<'a, 'tcx> IndexBuilder<'a, 'tcx> {
     }
 }
 
-impl<'a, 'tcx> Deref for IndexBuilder<'a, 'tcx> {
-    type Target = ItemContentBuilder<'a, 'tcx>;
+impl<'a, 'tcx, 'encoder> Deref for IndexBuilder<'a, 'tcx, 'encoder> {
+    type Target = ItemContentBuilder<'a, 'tcx, 'encoder>;
 
     fn deref(&self) -> &Self::Target {
         &self.builder
     }
 }
 
-impl<'a, 'tcx> DerefMut for IndexBuilder<'a, 'tcx> {
+impl<'a, 'tcx, 'encoder> DerefMut for IndexBuilder<'a, 'tcx, 'encoder> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.builder
     }
 }
 
-impl<'a, 'tcx> ItemContentBuilder<'a, 'tcx> {
+impl<'a, 'tcx, 'encoder> ItemContentBuilder<'a, 'tcx, 'encoder> {
     pub fn ecx(&self) -> &'a EncodeContext<'a, 'tcx> {
         self.ecx
     }
@@ -93,3 +97,4 @@ impl<'a, 'tcx> ItemContentBuilder<'a, 'tcx> {
         *self.xrefs.entry(xref).or_insert(old_len)
     }
 }
+

--- a/src/librustc_metadata/index_builder.rs
+++ b/src/librustc_metadata/index_builder.rs
@@ -15,11 +15,20 @@ use rustc::dep_graph::{DepNode, DepTask};
 use rustc::hir::def_id::DefId;
 use rustc::ty;
 use rustc_data_structures::fnv::FnvHashMap;
+use std::ops::{Deref, DerefMut};
 
+/// Builder that can encode new items, adding them into the index.
+/// Item encoding cannot be nested.
 pub struct IndexBuilder<'a, 'tcx: 'a> {
-    ecx: &'a EncodeContext<'a, 'tcx>,
     items: IndexData,
+    builder: ItemContentBuilder<'a, 'tcx>,
+}
+
+/// Builder that can encode the content of items, but can't start a
+/// new item itself. Most code is attached to here.
+pub struct ItemContentBuilder<'a, 'tcx: 'a> {
     xrefs: FnvHashMap<XRef<'tcx>, u32>, // sequentially-assigned
+    ecx: &'a EncodeContext<'a, 'tcx>,
 }
 
 /// "interned" entries referenced by id
@@ -29,14 +38,12 @@ pub enum XRef<'tcx> { Predicate(ty::Predicate<'tcx>) }
 impl<'a, 'tcx> IndexBuilder<'a, 'tcx> {
     pub fn new(ecx: &'a EncodeContext<'a, 'tcx>) -> Self {
         IndexBuilder {
-            ecx: ecx,
             items: IndexData::new(ecx.tcx.map.num_local_def_ids()),
-            xrefs: FnvHashMap()
+            builder: ItemContentBuilder {
+                ecx: ecx,
+                xrefs: FnvHashMap(),
+            },
         }
-    }
-
-    pub fn ecx(&self) -> &'a EncodeContext<'a, 'tcx> {
-        self.ecx
     }
 
     /// Records that `id` is being emitted at the current offset.
@@ -51,13 +58,32 @@ impl<'a, 'tcx> IndexBuilder<'a, 'tcx> {
         self.ecx.tcx.dep_graph.in_task(DepNode::MetaData(id))
     }
 
+    pub fn into_fields(self) -> (IndexData, FnvHashMap<XRef<'tcx>, u32>) {
+        (self.items, self.builder.xrefs)
+    }
+}
+
+impl<'a, 'tcx> Deref for IndexBuilder<'a, 'tcx> {
+    type Target = ItemContentBuilder<'a, 'tcx>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.builder
+    }
+}
+
+impl<'a, 'tcx> DerefMut for IndexBuilder<'a, 'tcx> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.builder
+    }
+}
+
+impl<'a, 'tcx> ItemContentBuilder<'a, 'tcx> {
+    pub fn ecx(&self) -> &'a EncodeContext<'a, 'tcx> {
+        self.ecx
+    }
+
     pub fn add_xref(&mut self, xref: XRef<'tcx>) -> u32 {
         let old_len = self.xrefs.len() as u32;
         *self.xrefs.entry(xref).or_insert(old_len)
     }
-
-    pub fn into_fields(self) -> (IndexData, FnvHashMap<XRef<'tcx>, u32>) {
-        (self.items, self.xrefs)
-    }
 }
-

--- a/src/librustc_metadata/index_builder.rs
+++ b/src/librustc_metadata/index_builder.rs
@@ -16,7 +16,7 @@ use rustc::hir::def_id::DefId;
 use rustc::ty;
 use rustc_data_structures::fnv::FnvHashMap;
 
-pub struct CrateIndex<'a, 'tcx> {
+pub struct IndexBuilder<'a, 'tcx> {
     dep_graph: &'a DepGraph,
     items: IndexData,
     xrefs: FnvHashMap<XRef<'tcx>, u32>, // sequentially-assigned
@@ -26,9 +26,9 @@ pub struct CrateIndex<'a, 'tcx> {
 #[derive(PartialEq, Eq, Hash)]
 pub enum XRef<'tcx> { Predicate(ty::Predicate<'tcx>) }
 
-impl<'a, 'tcx> CrateIndex<'a, 'tcx> {
+impl<'a, 'tcx> IndexBuilder<'a, 'tcx> {
     pub fn new(ecx: &EncodeContext<'a, 'tcx>) -> Self {
-        CrateIndex {
+        IndexBuilder {
             dep_graph: &ecx.tcx.dep_graph,
             items: IndexData::new(ecx.tcx.map.num_local_def_ids()),
             xrefs: FnvHashMap()

--- a/src/librustc_metadata/lib.rs
+++ b/src/librustc_metadata/lib.rs
@@ -54,6 +54,7 @@ pub mod def_key;
 pub mod tyencode;
 pub mod tydecode;
 pub mod encoder;
+mod index_builder;
 pub mod decoder;
 pub mod creader;
 pub mod csearch;


### PR DESCRIPTION
This issue restructures meta-data encoding to track dependencies very precisely. It uses a cute technique I hope to spread elsewhere, where we can guard the data flowing into a new dep-graph task and ensure that it is not "leaking" information from the outside, which would result in missing edges. There are no tests because we don't know of any bugs in the old system, but it's clear that there was leaked data.

The commit series is standalone, but the refactorings are kind of "windy". It's a good idea to read the comment in `src/librustc_metadata/index_builder.rs` to get a feeling for the overall strategy I was aiming at.

In several cases, I wound up adding some extra hashtable lookups, I think primarily for looking up `AdtDef` instances. We could remove these by implementing `DepGraphRead` for an `AdtDef` and then having it register a read to the adt-defs table, I guess, but I doubt it is really noticeable. 

Eventually I think I'd like to extend this pattern to the dep-graph more generally, since it effectively guarantees that data cannot leak.

Fixes #35111.

r? @michaelwoerister 
