### PR TITLE
Update spans that live in std macros to their use sites

### DIFF
--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -221,6 +221,25 @@ impl MultiSpan {
         &self.primary_spans
     }
 
+    /// Replaces all occurances of one Span with another. Used to move Spans in areas that don't
+    /// display well (like std macros). Returns true of replacements occurred.
+    pub fn replace(&mut self, before: Span, after: Span) -> bool {
+        let mut replacements_occurred = false;
+        for i in 0..self.primary_spans.len() {
+            if self.primary_spans[i] == before {
+                self.primary_spans[i] = after;
+                replacements_occurred = true;
+            }
+        }
+        for i in 0..self.span_labels.len() {
+            if self.span_labels[i].0 == before {
+                self.span_labels[i].0 = after;
+                replacements_occurred = true;
+            }
+        }
+        replacements_occurred
+    }
+
     /// Returns the strings to highlight. We always ensure that there
     /// is an entry for each of the primary spans -- for each primary
     /// span P, if there is at least one label with span P, we return

--- a/src/test/ui/codemap_tests/bad-format-args.rs
+++ b/src/test/ui/codemap_tests/bad-format-args.rs
@@ -8,13 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: requires at least a format string argument
-// error-pattern: in this expansion
-
-// error-pattern: expected token: `,`
-// error-pattern: in this expansion
-// error-pattern: in this expansion
-
 fn main() {
     format!();
     format!("" 1);

--- a/src/test/ui/codemap_tests/bad-format-args.stderr
+++ b/src/test/ui/codemap_tests/bad-format-args.stderr
@@ -1,0 +1,26 @@
+error: requires at least a format string argument
+  --> $DIR/bad-format-args.rs:12:5
+   |
+12 |     format!();
+   |     ^^^^^^^^^^
+   |
+   = note: this error originates in a macro from the standard library
+
+error: expected token: `,`
+  --> $DIR/bad-format-args.rs:13:5
+   |
+13 |     format!("" 1);
+   |     ^^^^^^^^^^^^^^
+   |
+   = note: this error originates in a macro from the standard library
+
+error: expected token: `,`
+  --> $DIR/bad-format-args.rs:14:5
+   |
+14 |     format!("", 1 1);
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in a macro from the standard library
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/codemap_tests/issue-28308.rs
+++ b/src/test/ui/codemap_tests/issue-28308.rs
@@ -8,10 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// this error is dispayed in `<std macros>`
-// error-pattern:cannot apply unary operator `!` to type `&'static str`
-// error-pattern:in this expansion of assert!
-
 fn main() {
     assert!("foo");
 }

--- a/src/test/ui/codemap_tests/issue-28308.stderr
+++ b/src/test/ui/codemap_tests/issue-28308.stderr
@@ -1,7 +1,7 @@
 error: cannot apply unary operator `!` to type `&'static str`
-  --> $DIR/issue-28308.rs:13:5
+  --> $DIR/issue-28308.rs:12:5
    |
-13 |     assert!("foo");
+12 |     assert!("foo");
    |     ^^^^^^^^^^^^^^^
    |
    = note: this error originates in a macro from the standard library

--- a/src/test/ui/codemap_tests/issue-28308.stderr
+++ b/src/test/ui/codemap_tests/issue-28308.stderr
@@ -1,0 +1,10 @@
+error: cannot apply unary operator `!` to type `&'static str`
+  --> $DIR/issue-28308.rs:13:5
+   |
+13 |     assert!("foo");
+   |     ^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in a macro from the standard library
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This PR updates the error reporting to detect when a span used in the error message will be labeling a span in the `<std macros>`.  If it detects this, it will update it to the use site, if possible.

Before:

<img width="649" alt="screen shot 2016-08-15 at 10 20 33 am" src="https://cloud.githubusercontent.com/assets/547158/17675433/a04baaea-62de-11e6-9a66-65119d2d0c6c.png">

After:

<img width="490" alt="screen shot 2016-08-15 at 10 19 56 am" src="https://cloud.githubusercontent.com/assets/547158/17675401/7b3430f6-62de-11e6-9eb5-dc14db562301.png">

To help with the messages that may not become confusing because they will be referring to a definition inside of `<std macros>` we also add a note to help understand that we're using the use but the definition is in `<std macros>`

Another before:

<img width="827" alt="screen shot 2016-08-15 at 11 55 01 am" src="https://cloud.githubusercontent.com/assets/547158/17675567/211935ca-62df-11e6-9800-18da44d7c4ee.png">

And after:

<img width="497" alt="screen shot 2016-08-15 at 11 54 41 am" src="https://cloud.githubusercontent.com/assets/547158/17675578/2a42828c-62df-11e6-8896-25bf793e6a60.png">

r? @nikomatsakis 
