### PR TITLE
accumulate into vector and assert, instead of printing

### DIFF
--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -295,7 +295,7 @@ impl<A: Step> ops::Range<A> {
     ///
     /// ```
     /// #![feature(step_by)]
-    /// let result: Vec<_> = (0..10).step_by(2).take(10).collect();
+    /// let result: Vec<_> = (0..10).step_by(2).collect();
     /// assert_eq!(result, vec![0, 2, 4, 6, 8]);
     /// ```
     #[unstable(feature = "step_by", reason = "recent addition",

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -295,20 +295,8 @@ impl<A: Step> ops::Range<A> {
     ///
     /// ```
     /// #![feature(step_by)]
-    ///
-    /// for i in (0..10).step_by(2) {
-    ///     println!("{}", i);
-    /// }
-    /// ```
-    ///
-    /// This prints:
-    ///
-    /// ```text
-    /// 0
-    /// 2
-    /// 4
-    /// 6
-    /// 8
+    /// let result: Vec<_> = (0..10).step_by(2).take(10).collect();
+    /// assert_eq!(result, vec![0, 2, 4, 6, 8]);
     /// ```
     #[unstable(feature = "step_by", reason = "recent addition",
                issue = "27741")]
@@ -650,4 +638,3 @@ impl<A: Step> DoubleEndedIterator for ops::RangeInclusive<A> where
         n
     }
 }
-


### PR DESCRIPTION
I'm only making this change in one place so that people can express
their preferences for this stylistic change. If/when this change is
approved I'll go ahead and translate the rest of the `std::ops`
examples.
