### PR TITLE
explicitly show how iterating over `..` fails

### DIFF
--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -1462,13 +1462,24 @@ pub trait IndexMut<Idx: ?Sized>: Index<Idx> {
 ///
 /// # Examples
 ///
+/// The `..` syntax is a `RangeFull`:
+///
 /// ```
 /// assert_eq!((..), std::ops::RangeFull);
+/// ```
 ///
-/// // for i in .. {
-/// //     println!("This errors because .. has no IntoIterator impl");
-/// // }
+/// It does not have an `IntoIterator` implementation, so you can't use it in a
+/// `for` loop directly. This won't compile:
 ///
+/// ```ignore
+/// for i in .. {
+///    // ...
+/// }
+/// ```
+///
+/// Used as a slicing index, `RangeFull` produces the full array as a slice.
+///
+/// ```
 /// let arr = [0, 1, 2, 3];
 /// assert_eq!(arr[ .. ], [0,1,2,3]);  // RangeFull
 /// assert_eq!(arr[ ..3], [0,1,2  ]);

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -1463,15 +1463,17 @@ pub trait IndexMut<Idx: ?Sized>: Index<Idx> {
 /// # Examples
 ///
 /// ```
-/// fn main() {
-///     assert_eq!((..), std::ops::RangeFull);
+/// assert_eq!((..), std::ops::RangeFull);
 ///
-///     let arr = [0, 1, 2, 3];
-///     assert_eq!(arr[ .. ], [0,1,2,3]);  // RangeFull
-///     assert_eq!(arr[ ..3], [0,1,2  ]);
-///     assert_eq!(arr[1.. ], [  1,2,3]);
-///     assert_eq!(arr[1..3], [  1,2  ]);
-/// }
+/// // for i in .. {
+/// //     println!("This errors because .. has no Iterator impl");
+/// // }
+///
+/// let arr = [0, 1, 2, 3];
+/// assert_eq!(arr[ .. ], [0,1,2,3]);  // RangeFull
+/// assert_eq!(arr[ ..3], [0,1,2  ]);
+/// assert_eq!(arr[1.. ], [  1,2,3]);
+/// assert_eq!(arr[1..3], [  1,2  ]);
 /// ```
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -1466,7 +1466,7 @@ pub trait IndexMut<Idx: ?Sized>: Index<Idx> {
 /// assert_eq!((..), std::ops::RangeFull);
 ///
 /// // for i in .. {
-/// //     println!("This errors because .. has no Iterator impl");
+/// //     println!("This errors because .. has no IntoIterator impl");
 /// // }
 ///
 /// let arr = [0, 1, 2, 3];


### PR DESCRIPTION
I've also removed the `main()` wrapper, which I believe is extraneous.
LMK if that's incorrect.
