### PR TITLE
Implement `Debug` for `std::vec::IntoIter`.

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1713,6 +1713,15 @@ pub struct IntoIter<T> {
     end: *const T,
 }
 
+#[stable(feature = "vec_intoiter_debug", since = "")]
+impl<T: fmt::Debug> fmt::Debug for IntoIter<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("IntoIter")
+            .field(&self.as_slice())
+            .finish()
+    }
+}
+
 impl<T> IntoIter<T> {
     /// Returns the remaining items of this iterator as a slice.
     ///

--- a/src/libcollectionstest/vec.rs
+++ b/src/libcollectionstest/vec.rs
@@ -502,6 +502,14 @@ fn test_into_iter_as_mut_slice() {
 }
 
 #[test]
+fn test_into_iter_debug() {
+    let vec = vec!['a', 'b', 'c'];
+    let into_iter = vec.into_iter();
+    let debug = format!("{:?}", into_iter);
+    assert_eq!(debug, "IntoIter(['a', 'b', 'c'])");
+}
+
+#[test]
 fn test_into_iter_count() {
     assert_eq!(vec![1, 2, 3].into_iter().count(), 3);
 }


### PR DESCRIPTION
Display all the remaining items of the iterator, similar to the `Debug`
implementation for `core::slice::Iter`:

https://github.com/rust-lang/rust/blob/f0bab98695f0a4877daabad9a5b0ba3e66121392/src/libcore/slice.rs#L930-L937

Using the `as_slice` method that was added in:

https://github.com/rust-lang/rust/pull/35447
