### PR TITLE
RUST_NEW_ERROR_FORMAT is no more

### DIFF
--- a/src/test/ui/codemap_tests/empty_span.rs
+++ b/src/test/ui/codemap_tests/empty_span.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// rustc-env:RUST_NEW_ERROR_FORMAT
 #![feature(optin_builtin_traits)]
 fn main() {
     struct Foo;

--- a/src/test/ui/codemap_tests/empty_span.stderr
+++ b/src/test/ui/codemap_tests/empty_span.stderr
@@ -1,7 +1,7 @@
 error[E0321]: cross-crate traits with a default impl, like `std::marker::Send`, can only be implemented for a struct/enum type, not `&'static main::Foo`
-  --> $DIR/empty_span.rs:18:5
+  --> $DIR/empty_span.rs:17:5
    |
-18 |     unsafe impl Send for &'static Foo { }
+17 |     unsafe impl Send for &'static Foo { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error

--- a/src/test/ui/codemap_tests/huge_multispan_highlight.rs
+++ b/src/test/ui/codemap_tests/huge_multispan_highlight.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// rustc-env:RUST_NEW_ERROR_FORMAT
-
 fn main() {
     let x = "foo";
 
@@ -97,8 +95,7 @@ fn main() {
 
 
 
+
+
     let y = &mut x;
 }
-
-
-

--- a/src/test/ui/codemap_tests/huge_multispan_highlight.stderr
+++ b/src/test/ui/codemap_tests/huge_multispan_highlight.stderr
@@ -1,7 +1,7 @@
 error: cannot borrow immutable local variable `x` as mutable
    --> $DIR/huge_multispan_highlight.rs:100:18
     |
-14  |     let x = "foo";
+12  |     let x = "foo";
     |         - use `mut x` here to make mutable
 ...
 100 |     let y = &mut x;

--- a/src/test/ui/codemap_tests/issue-11715.rs
+++ b/src/test/ui/codemap_tests/issue-11715.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// rustc-env:RUST_NEW_ERROR_FORMAT
+
 
 
 
@@ -99,6 +99,3 @@ fn main() {
     let y = &mut x;
     let z = &mut x;
 }
-
-
-

--- a/src/test/ui/codemap_tests/one_line.rs
+++ b/src/test/ui/codemap_tests/one_line.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// rustc-env:RUST_NEW_ERROR_FORMAT
-
 fn main() {
     let mut v = vec![Some("foo"), Some("bar")];
     v.push(v.pop().unwrap());

--- a/src/test/ui/codemap_tests/one_line.stderr
+++ b/src/test/ui/codemap_tests/one_line.stderr
@@ -1,7 +1,7 @@
 error[E0499]: cannot borrow `v` as mutable more than once at a time
-  --> $DIR/one_line.rs:15:12
+  --> $DIR/one_line.rs:13:12
    |
-15 |     v.push(v.pop().unwrap());
+13 |     v.push(v.pop().unwrap());
    |     -      ^               - first borrow ends here
    |     |      |
    |     |      second mutable borrow occurs here

--- a/src/test/ui/codemap_tests/overlapping_spans.rs
+++ b/src/test/ui/codemap_tests/overlapping_spans.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// rustc-env:RUST_NEW_ERROR_FORMAT
 #[derive(Debug)]
 struct Foo { }
 

--- a/src/test/ui/codemap_tests/overlapping_spans.stderr
+++ b/src/test/ui/codemap_tests/overlapping_spans.stderr
@@ -1,7 +1,7 @@
 error[E0509]: cannot move out of type `S`, which implements the `Drop` trait
-  --> $DIR/overlapping_spans.rs:22:9
+  --> $DIR/overlapping_spans.rs:21:9
    |
-22 |         S {f:_s} => {}
+21 |         S {f:_s} => {}
    |         ^^^^^--^
    |         |    |
    |         |    hint: to prevent move, use `ref _s` or `ref mut _s`

--- a/src/test/ui/codemap_tests/tab.rs
+++ b/src/test/ui/codemap_tests/tab.rs
@@ -8,9 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// rustc-env:RUST_NEW_ERROR_FORMAT
 // ignore-tidy-tab
+
 fn main() {
 	bar;
 }
-

--- a/src/test/ui/codemap_tests/two_files.rs
+++ b/src/test/ui/codemap_tests/two_files.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// rustc-env:RUST_NEW_ERROR_FORMAT
 include!("two_files_data.rs");
 
 struct Baz { }

--- a/src/test/ui/codemap_tests/two_files.stderr
+++ b/src/test/ui/codemap_tests/two_files.stderr
@@ -1,7 +1,7 @@
 error[E0404]: `Bar` is not a trait
-  --> $DIR/two_files.rs:16:6
+  --> $DIR/two_files.rs:15:6
    |
-16 | impl Bar for Baz { }
+15 | impl Bar for Baz { }
    |      ^^^ not a trait
    |
    = note: type aliases cannot be used for traits

--- a/src/test/ui/codemap_tests/two_files_data.rs
+++ b/src/test/ui/codemap_tests/two_files_data.rs
@@ -8,9 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// rustc-env:RUST_NEW_ERROR_FORMAT
 // ignore-test
+
 trait Foo { }
 
 type Bar = Foo;
-

--- a/src/test/ui/codemap_tests/unicode.rs
+++ b/src/test/ui/codemap_tests/unicode.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// rustc-env:RUST_NEW_ERROR_FORMAT
 extern "路濫狼á́́" fn foo() {}
 
 fn main() { }

--- a/src/test/ui/codemap_tests/unicode.stderr
+++ b/src/test/ui/codemap_tests/unicode.stderr
@@ -1,7 +1,7 @@
 error: invalid ABI: expected one of [cdecl, stdcall, fastcall, vectorcall, aapcs, win64, Rust, C, system, rust-intrinsic, rust-call, platform-intrinsic], found `路濫狼á́́`
-  --> $DIR/unicode.rs:12:8
+  --> $DIR/unicode.rs:11:8
    |
-12 | extern "路濫狼á́́" fn foo() {}
+11 | extern "路濫狼á́́" fn foo() {}
    |        ^^^^^^^^
 
 error: aborting due to previous error

--- a/src/test/ui/mismatched_types/issue-26480.rs
+++ b/src/test/ui/mismatched_types/issue-26480.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// rustc-env:RUST_NEW_ERROR_FORMAT
 extern {
     fn write(fildes: i32, buf: *const i8, nbyte: u64) -> i64;
 }

--- a/src/test/ui/mismatched_types/issue-26480.stderr
+++ b/src/test/ui/mismatched_types/issue-26480.stderr
@@ -1,16 +1,16 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-26480.rs:27:19
+  --> $DIR/issue-26480.rs:26:19
    |
-27 |                   $arr.len() * size_of($arr[0]));
+26 |                   $arr.len() * size_of($arr[0]));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected u64, found usize
-$DIR/issue-26480.rs:38:5: 38:19 note: in this expansion of write! (defined in $DIR/issue-26480.rs)
+$DIR/issue-26480.rs:37:5: 37:19 note: in this expansion of write! (defined in $DIR/issue-26480.rs)
 
 error: non-scalar cast: `{integer}` as `()`
-  --> $DIR/issue-26480.rs:33:19
+  --> $DIR/issue-26480.rs:32:19
    |
-33 |     ($x:expr) => ($x as ())
+32 |     ($x:expr) => ($x as ())
    |                   ^^^^^^^^
-$DIR/issue-26480.rs:39:5: 39:14 note: in this expansion of cast! (defined in $DIR/issue-26480.rs)
+$DIR/issue-26480.rs:38:5: 38:14 note: in this expansion of cast! (defined in $DIR/issue-26480.rs)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/mismatched_types/main.rs
+++ b/src/test/ui/mismatched_types/main.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// rustc-env:RUST_NEW_ERROR_FORMAT
-
 fn main() {
     let x: u32 = (
     );

--- a/src/test/ui/mismatched_types/main.stderr
+++ b/src/test/ui/mismatched_types/main.stderr
@@ -1,7 +1,7 @@
 error[E0308]: mismatched types
-  --> $DIR/main.rs:14:18
+  --> $DIR/main.rs:12:18
    |
-14 |     let x: u32 = (
+12 |     let x: u32 = (
    |                  ^ expected u32, found ()
    |
    = note: expected type `u32`


### PR DESCRIPTION
So stop setting the environment variable.
