### PR TITLE
Changed warning when number of output types is more than 1 and 1 outp…

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -1275,9 +1275,10 @@ pub fn build_output_filenames(input: &Input,
                                            .values()
                                            .filter(|a| a.is_none())
                                            .count();
-            let ofile = if unnamed_output_types > 1 && sess.opts.output_types.get(&OutputType::Exe).is_none() {
-                sess.warn("warning: ignoring output name requested with -o for \"link\" output because \
-                           multiple outputs were requested");
+            let ofile = if unnamed_output_types > 1 &&
+            sess.opts.output_types.get(&OutputType::Exe).is_none() {
+                sess.warn("warning: ignoring output name requested with -o for \"link\" \
+                           output because multiple outputs were requested");
                 None
             } else {
                 Some(out_file.clone())

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -1276,7 +1276,7 @@ pub fn build_output_filenames(input: &Input,
                                            .filter(|a| a.is_none())
                                            .count();
             let ofile = if unnamed_output_types > 1 &&
-                        !sess.opts.output_types.contains_key(&OutputType::Exe) {
+                        sess.opts.output_types.contains_key(&OutputType::Exe) {
                 sess.warn("warning: ignoring output name requested with -o for \"link\" \
                            output because multiple outputs were requested");
                 None

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -1275,9 +1275,9 @@ pub fn build_output_filenames(input: &Input,
                                            .values()
                                            .filter(|a| a.is_none())
                                            .count();
-            let ofile = if unnamed_output_types > 1 {
-                sess.warn("ignoring specified output filename because multiple outputs were \
-                           requested");
+            let ofile = if unnamed_output_types > 1 && sess.opts.output_types.get(&OutputType::Exe).is_none() {
+                sess.warn("warning: ignoring output name requested with -o for \"link\" output because
+                           multiple outputs were requested");
                 None
             } else {
                 Some(out_file.clone())

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -1276,7 +1276,7 @@ pub fn build_output_filenames(input: &Input,
                                            .filter(|a| a.is_none())
                                            .count();
             let ofile = if unnamed_output_types > 1 &&
-            sess.opts.output_types.get(&OutputType::Exe).is_none() {
+                        !sess.opts.output_types.contains_key(&OutputType::Exe) {
                 sess.warn("warning: ignoring output name requested with -o for \"link\" \
                            output because multiple outputs were requested");
                 None

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -1276,7 +1276,7 @@ pub fn build_output_filenames(input: &Input,
                                            .filter(|a| a.is_none())
                                            .count();
             let ofile = if unnamed_output_types > 1 && sess.opts.output_types.get(&OutputType::Exe).is_none() {
-                sess.warn("warning: ignoring output name requested with -o for \"link\" output because
+                sess.warn("warning: ignoring output name requested with -o for \"link\" output because \
                            multiple outputs were requested");
                 None
             } else {


### PR DESCRIPTION
7 tests failed when I ran `$ make -j8 rustc-stage1 && make check-stage1`, not really sure if it's related to my stuff...I got the latest an hour ago but the build froze on `Cloning into '/home/me/rust/src/llvm'...` I cancelled it and now /src/llvm doesn't exist so I can't run the tests again. 

r? @Manishearth 

The tests:

[compile-fail] compile-fail/changing-crates.rs
    [compile-fail] compile-fail/svh-change-lit.rs
    [compile-fail] compile-fail/svh-change-significant-cfg.rs
    [compile-fail] compile-fail/svh-change-trait-bound.rs
    [compile-fail] compile-fail/svh-change-type-arg.rs
    [compile-fail] compile-fail/svh-change-type-ret.rs
    [compile-fail] compile-fail/svh-change-type-static.rs

Fixes #20130
