### PR TITLE
Move 'doesn't live long enough' errors to labels

### DIFF
--- a/src/librustc_borrowck/borrowck/gather_loans/lifetime.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/lifetime.rs
@@ -96,7 +96,7 @@ impl<'a, 'tcx> GuaranteeLifetimeContext<'a, 'tcx> {
         //! Reports an error if `loan_region` is larger than `max_scope`
 
         if !self.bccx.is_subregion_of(self.loan_region, max_scope) {
-            Err(self.report_error(err_out_of_scope(max_scope, self.loan_region)))
+            Err(self.report_error(err_out_of_scope(max_scope, self.loan_region, self.cause)))
         } else {
             Ok(())
         }

--- a/src/test/compile-fail/borrowck/borrowck-let-suggestion-suffixes.rs
+++ b/src/test/compile-fail/borrowck/borrowck-let-suggestion-suffixes.rs
@@ -13,47 +13,48 @@ fn f() {
     let mut v1 = Vec::new(); // statement 1
 
     let mut v2 = Vec::new(); // statement 2
-    //~^ NOTE reference must be valid for the block suffix following statement 2
 
     let young = ['y'];       // statement 3
-    //~^ NOTE ...but borrowed value is only valid for the block suffix following statement 3
 
     v2.push(&young[0]);      // statement 4
     //~^ ERROR `young[..]` does not live long enough
+    //~| NOTE does not live long enough
+    //~| NOTE values in a scope are dropped in the opposite order they are created
 
     let mut v3 = Vec::new(); // statement 5
-    //~^ NOTE reference must be valid for the block suffix following statement 5
 
     v3.push(&'x');           // statement 6
     //~^ ERROR borrowed value does not live long enough
-    //~| does not live long enough
-    //~| NOTE ...but borrowed value is only valid for the statement
+    //~| NOTE does not live long enough
+    //~| NOTE borrowed value only valid until here
     //~| HELP consider using a `let` binding to increase its lifetime
 
     {
 
         let mut v4 = Vec::new(); // (sub) statement 0
-        //~^ NOTE reference must be valid for the block suffix following statement 0
 
         v4.push(&'y');
         //~^ ERROR borrowed value does not live long enough
-        //~| does not live long enough
-        //~| NOTE ...but borrowed value is only valid for the statement
+        //~| NOTE does not live long enough
+        //~| NOTE borrowed value only valid until here
         //~| HELP consider using a `let` binding to increase its lifetime
 
     }                       // (statement 7)
+    //~^ NOTE borrowed value must be valid until here
 
     let mut v5 = Vec::new(); // statement 8
-    //~^ NOTE reference must be valid for the block suffix following statement 8
 
     v5.push(&'z');
     //~^ ERROR borrowed value does not live long enough
-    //~| does not live long enough
-    //~| NOTE ...but borrowed value is only valid for the statement
+    //~| NOTE does not live long enough
+    //~| NOTE borrowed value only valid until here
     //~| HELP consider using a `let` binding to increase its lifetime
 
     v1.push(&old[0]);
 }
+//~^ NOTE borrowed value dropped before borrower
+//~| NOTE borrowed value must be valid until here
+//~| NOTE borrowed value must be valid until here
 
 fn main() {
     f();

--- a/src/test/compile-fail/borrowck/borrowck-let-suggestion.rs
+++ b/src/test/compile-fail/borrowck/borrowck-let-suggestion.rs
@@ -11,11 +11,11 @@
 fn f() {
     let x = [1].iter();
     //~^ ERROR borrowed value does not live long enough
-    //~|does not live long enough
-    //~| NOTE reference must be valid for the block suffix following statement
+    //~| NOTE does not live long enough
+    //~| NOTE borrowed value only valid until here
     //~| HELP consider using a `let` binding to increase its lifetime
-    //~| NOTE ...but borrowed value is only valid for the statement at 12:4
 }
+//~^ borrowed value must be valid until here
 
 fn main() {
     f();

--- a/src/test/compile-fail/impl-trait/loan-extend.rs
+++ b/src/test/compile-fail/impl-trait/loan-extend.rs
@@ -14,10 +14,10 @@
 fn borrow<'a, T>(_: &'a mut T) -> impl Copy { () }
 
 fn main() {
-    //~^ NOTE reference must be valid for the block
     let long;
     let mut short = 0;
-    //~^ NOTE but borrowed value is only valid for the block suffix following statement 1
     long = borrow(&mut short);
     //~^ ERROR `short` does not live long enough
-}
+    //~| NOTE does not live long enough
+    //~| NOTE values in a scope are dropped in the opposite order they are created
+} //~ borrowed value dropped before borrower

--- a/src/test/compile-fail/region-borrow-params-issue-29793-small.rs
+++ b/src/test/compile-fail/region-borrow-params-issue-29793-small.rs
@@ -16,15 +16,19 @@
 
 fn escaping_borrow_of_closure_params_1() {
     let g = |x: usize, y:usize| {
-        //~^ NOTE reference must be valid for the scope of call-site for function
-        //~| NOTE ...but borrowed value is only valid for the scope of function body
-        //~| NOTE reference must be valid for the scope of call-site for function
-        //~| NOTE ...but borrowed value is only valid for the scope of function body
         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
         //~^ ERROR `x` does not live long enough
         //~| ERROR `y` does not live long enough
+        //~| NOTE capture occurs here
+        //~| NOTE capture occurs here
+        //~| NOTE does not live long enough
+        //~| NOTE does not live long enough
+        //~| NOTE values in a scope are dropped in the opposite order they are created
+        //~| NOTE values in a scope are dropped in the opposite order they are created
         return f;
     };
+    //~^ NOTE borrowed value dropped before borrower 
+    //~| NOTE borrowed value dropped before borrower 
 
     // We delberately do not call `g`; this small version of the test,
     // after adding such a call, was (properly) rejected even when the
@@ -35,15 +39,19 @@ fn escaping_borrow_of_closure_params_1() {
 
 fn escaping_borrow_of_closure_params_2() {
     let g = |x: usize, y:usize| {
-        //~^ NOTE reference must be valid for the scope of call-site for function
-        //~| NOTE ...but borrowed value is only valid for the scope of function body
-        //~| NOTE reference must be valid for the scope of call-site for function
-        //~| NOTE ...but borrowed value is only valid for the scope of function body
         let f = |t: bool| if t { x } else { y }; // (separate errors for `x` vs `y`)
         //~^ ERROR `x` does not live long enough
         //~| ERROR `y` does not live long enough
+        //~| NOTE capture occurs here
+        //~| NOTE capture occurs here
+        //~| NOTE does not live long enough
+        //~| NOTE does not live long enough
+        //~| NOTE values in a scope are dropped in the opposite order they are created
+        //~| NOTE values in a scope are dropped in the opposite order they are created
         f
     };
+    //~^ NOTE borrowed value dropped before borrower 
+    //~| NOTE borrowed value dropped before borrower 
 
     // (we don't call `g`; see above)
 }

--- a/src/test/compile-fail/region-borrow-params-issue-29793-small.rs
+++ b/src/test/compile-fail/region-borrow-params-issue-29793-small.rs
@@ -27,8 +27,8 @@ fn escaping_borrow_of_closure_params_1() {
         //~| NOTE values in a scope are dropped in the opposite order they are created
         return f;
     };
-    //~^ NOTE borrowed value dropped before borrower 
-    //~| NOTE borrowed value dropped before borrower 
+    //~^ NOTE borrowed value dropped before borrower
+    //~| NOTE borrowed value dropped before borrower
 
     // We delberately do not call `g`; this small version of the test,
     // after adding such a call, was (properly) rejected even when the
@@ -50,8 +50,8 @@ fn escaping_borrow_of_closure_params_2() {
         //~| NOTE values in a scope are dropped in the opposite order they are created
         f
     };
-    //~^ NOTE borrowed value dropped before borrower 
-    //~| NOTE borrowed value dropped before borrower 
+    //~^ NOTE borrowed value dropped before borrower
+    //~| NOTE borrowed value dropped before borrower
 
     // (we don't call `g`; see above)
 }

--- a/src/test/compile-fail/send-is-not-static-ensures-scoping.rs
+++ b/src/test/compile-fail/send-is-not-static-ensures-scoping.rs
@@ -26,8 +26,8 @@ fn main() {
         let y = &x; //~ ERROR `x` does not live long enough
 
         scoped(|| {
-            //~^ ERROR `y` does not live long enough
             let _z = y;
+            //~^ ERROR `y` does not live long enough
         })
     };
 

--- a/src/test/compile-fail/unboxed-closures-failed-recursive-fn-1.rs
+++ b/src/test/compile-fail/unboxed-closures-failed-recursive-fn-1.rs
@@ -22,8 +22,8 @@ fn a() {
     let mut factorial: Option<Box<Fn(u32) -> u32>> = None;
 
     let f = |x: u32| -> u32 {
-        //~^ ERROR `factorial` does not live long enough
         let g = factorial.as_ref().unwrap();
+        //~^ ERROR `factorial` does not live long enough
         if x == 0 {1} else {x * g(x-1)}
     };
 

--- a/src/test/ui/span/issue-11925.rs
+++ b/src/test/ui/span/issue-11925.rs
@@ -15,7 +15,7 @@ fn to_fn_once<A,F:FnOnce<A>>(f: F) -> F { f }
 fn main() {
     let r = {
         let x: Box<_> = box 42;
-        let f = to_fn_once(move|| &x); //~ ERROR: `x` does not live long enough
+        let f = to_fn_once(move|| &x);
         f()
     };
 

--- a/src/test/ui/span/issue-11925.stderr
+++ b/src/test/ui/span/issue-11925.stderr
@@ -1,0 +1,14 @@
+error: `x` does not live long enough
+  --> $DIR/issue-11925.rs:18:36
+   |
+18 |         let f = to_fn_once(move|| &x);
+   |                                    ^
+   |                                    |
+   |                                    does not live long enough
+   |                                    borrowed value only valid until here
+...
+23 | }
+   | - borrowed value must be valid until here
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This patch moves the "doesn't live long enough" region-style errors to instead use labels.

An example follows.

Before:

```
error: `x` does not live long enough
  --> src/test/compile-fail/send-is-not-static-ensures-scoping.rs:26:18
   |
26 |         let y = &x;
   |                  ^
   |
note: reference must be valid for the block at 23:10...
  --> src/test/compile-fail/send-is-not-static-ensures-scoping.rs:23:11
   |
23 | fn main() {
   |           ^
note: ...but borrowed value is only valid for the block suffix following statement 0 at 25:18
  --> src/test/compile-fail/send-is-not-static-ensures-scoping.rs:25:19
   |
25 |         let x = 1;
   |                   ^
```

After:

```
error: `x` does not live long enough
  --> src/test/compile-fail/send-is-not-static-ensures-scoping.rs:26:18
   |
26 |         let y = &x;
   |                  ^ does not live long enough
...
32 |     };
   |     - borrowed value only valid until here
...
35 | }
   | - borrowed value must be valid until here
```

r? @nikomatsakis 
