### PR TITLE
Make version check in gdb_rust_pretty_printing.py more compatible.

### DIFF
--- a/src/etc/gdb_rust_pretty_printing.py
+++ b/src/etc/gdb_rust_pretty_printing.py
@@ -16,7 +16,7 @@ import debugger_pretty_printers_common as rustpp
 # We want a version of `range` which doesn't allocate an intermediate list,
 # specifically it should use a lazy iterator. In Python 2 this was `xrange`, but
 # if we're running with Python 3 then we need to use `range` instead.
-if sys.version_info.major >= 3:
+if sys.version_info[0] >= 3:
     xrange = range
 
 #===============================================================================


### PR DESCRIPTION
Some versions of Python don't support the `major` field on the object returned by `sys.version_info`.

Fixes #35724 

r? @brson 
