### PR TITLE
Add `must_use` to the Reference

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -2070,6 +2070,9 @@ macro scope.
    trait of the same name. `{Self}` will be replaced with the type that is supposed
    to implement the trait but doesn't. To use this, the `on_unimplemented` feature gate
    must be enabled.
+- `must_use` - on structs and enums, will warn if a value of this type isn't used or
+   assigned to a variable. You may also include an optional message by using
+   `#[must_use = "message"]` which will be given alongside the warning.
 
 ### Conditional compilation
 


### PR DESCRIPTION
I'm a bit uncertain about the exact phrasing, but having it mentioned at all is probably better than before.
