### PR TITLE
refactor range examples

### DIFF
--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -1906,7 +1906,7 @@ pub trait IndexMut<Idx: ?Sized>: Index<Idx> {
 ///
 /// See the [module examples] for the behavior of other range structs.
 ///
-/// [module examples]: ../#Examples
+/// [module examples]: ../index.html#examples
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct RangeFull;
@@ -1937,7 +1937,7 @@ impl fmt::Debug for RangeFull {
 ///
 /// See the [module examples] for the behavior of other range structs.
 ///
-/// [module examples]: ../#Examples
+/// [module examples]: ../index.html#examples
 #[derive(Clone, PartialEq, Eq, Hash)]  // not Copy -- see #27186
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Range<Idx> {
@@ -2001,7 +2001,7 @@ impl<Idx: PartialOrd<Idx>> Range<Idx> {
 ///
 /// See the [module examples] for the behavior of other range structs.
 ///
-/// [module examples]: ../#Examples
+/// [module examples]: ../index.html#examples
 #[derive(Clone, PartialEq, Eq, Hash)]  // not Copy -- see #27186
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct RangeFrom<Idx> {
@@ -2068,7 +2068,7 @@ impl<Idx: PartialOrd<Idx>> RangeFrom<Idx> {
 ///
 /// See the [module examples] for the behavior of other range structs.
 ///
-/// [module examples]: ../#Examples
+/// [module examples]: ../index.html#examples
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct RangeTo<Idx> {
@@ -2121,7 +2121,7 @@ impl<Idx: PartialOrd<Idx>> RangeTo<Idx> {
 ///
 /// See the [module examples] for the behavior of other range structs.
 ///
-/// [module examples]: ../#Examples
+/// [module examples]: ../index.html#examples
 #[derive(Clone, PartialEq, Eq, Hash)]  // not Copy -- see #27186
 #[unstable(feature = "inclusive_range", reason = "recently added, follows RFC", issue = "28237")]
 pub enum RangeInclusive<Idx> {
@@ -2226,7 +2226,7 @@ impl<Idx: PartialOrd<Idx>> RangeInclusive<Idx> {
 ///
 /// See the [module examples] for the behavior of other range structs.
 ///
-/// [module examples]: ../#Examples
+/// [module examples]: ../index.html#examples
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[unstable(feature = "inclusive_range", reason = "recently added, follows RFC", issue = "28237")]
 pub struct RangeToInclusive<Idx> {

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -140,6 +140,22 @@
 //!
 //! // `consume_and_return_x` can no longer be invoked at this point
 //! ```
+//!
+//! This example shows the behavior of the various `Range*` structs.
+//!
+//! ```rust
+//! #![feature(inclusive_range_syntax)]
+//!
+//! let arr = [0, 1, 2, 3, 4];
+//!
+//! assert_eq!(arr[ .. ], [0,1,2,3,4]); // RangeFull
+//! assert_eq!(arr[ ..3], [0,1,2    ]); // RangeTo
+//! assert_eq!(arr[1.. ], [  1,2,3,4]); // RangeFrom
+//! assert_eq!(arr[1..3], [  1,2    ]); // Range
+//!
+//! assert_eq!(arr[ ...3], [0,1,2,3 ]); // RangeToIncusive
+//! assert_eq!(arr[1...3], [  1,2,3 ]); // RangeInclusive
+//! ```
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -1881,11 +1897,12 @@ pub trait IndexMut<Idx: ?Sized>: Index<Idx> {
 ///
 /// ```
 /// let arr = [0, 1, 2, 3];
-/// assert_eq!(arr[ .. ], [0,1,2,3]);  // RangeFull
-/// assert_eq!(arr[ ..3], [0,1,2  ]);
-/// assert_eq!(arr[1.. ], [  1,2,3]);
-/// assert_eq!(arr[1..3], [  1,2  ]);
+/// assert_eq!(arr[ .. ], [0, 1, 2, 3]);
 /// ```
+///
+/// See the [module examples] for the behavior of other range structs.
+///
+/// [module examples]: ../#Examples
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct RangeFull;
@@ -1910,12 +1927,13 @@ impl fmt::Debug for RangeFull {
 ///     assert_eq!(3+4+5, (3..6).sum());
 ///
 ///     let arr = [0, 1, 2, 3];
-///     assert_eq!(arr[ .. ], [0,1,2,3]);
-///     assert_eq!(arr[ ..3], [0,1,2  ]);
-///     assert_eq!(arr[1.. ], [  1,2,3]);
-///     assert_eq!(arr[1..3], [  1,2  ]);  // Range
+///     assert_eq!(arr[1..3], [1, 2]);
 /// }
 /// ```
+///
+/// See the [module examples] for the behavior of other range structs.
+///
+/// [module examples]: ../#Examples
 #[derive(Clone, PartialEq, Eq, Hash)]  // not Copy -- see #27186
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Range<Idx> {
@@ -1973,12 +1991,13 @@ impl<Idx: PartialOrd<Idx>> Range<Idx> {
 ///     assert_eq!(2+3+4, (2..).take(3).sum());
 ///
 ///     let arr = [0, 1, 2, 3];
-///     assert_eq!(arr[ .. ], [0,1,2,3]);
-///     assert_eq!(arr[ ..3], [0,1,2  ]);
-///     assert_eq!(arr[1.. ], [  1,2,3]);  // RangeFrom
-///     assert_eq!(arr[1..3], [  1,2  ]);
+///     assert_eq!(arr[1.. ], [1, 2, 3]);
 /// }
 /// ```
+///
+/// See the [module examples] for the behavior of other range structs.
+///
+/// [module examples]: ../#Examples
 #[derive(Clone, PartialEq, Eq, Hash)]  // not Copy -- see #27186
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct RangeFrom<Idx> {
@@ -2040,11 +2059,12 @@ impl<Idx: PartialOrd<Idx>> RangeFrom<Idx> {
 ///
 /// ```
 /// let arr = [0, 1, 2, 3];
-/// assert_eq!(arr[ .. ], [0,1,2,3]);
-/// assert_eq!(arr[ ..3], [0,1,2  ]);  // RangeTo
-/// assert_eq!(arr[1.. ], [  1,2,3]);
-/// assert_eq!(arr[1..3], [  1,2  ]);
+/// assert_eq!(arr[ ..3], [0, 1, 2]);
 /// ```
+///
+/// See the [module examples] for the behavior of other range structs.
+///
+/// [module examples]: ../#Examples
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct RangeTo<Idx> {
@@ -2091,10 +2111,13 @@ impl<Idx: PartialOrd<Idx>> RangeTo<Idx> {
 ///     assert_eq!(3+4+5, (3...5).sum());
 ///
 ///     let arr = [0, 1, 2, 3];
-///     assert_eq!(arr[ ...2], [0,1,2  ]);
-///     assert_eq!(arr[1...2], [  1,2  ]);  // RangeInclusive
+///     assert_eq!(arr[1...2], [1, 2]);
 /// }
 /// ```
+///
+/// See the [module examples] for the behavior of other range structs.
+///
+/// [module examples]: ../#Examples
 #[derive(Clone, PartialEq, Eq, Hash)]  // not Copy -- see #27186
 #[unstable(feature = "inclusive_range", reason = "recently added, follows RFC", issue = "28237")]
 pub enum RangeInclusive<Idx> {
@@ -2192,11 +2215,13 @@ impl<Idx: PartialOrd<Idx>> RangeInclusive<Idx> {
 /// array elements up to and including the index indicated by `end`.
 ///
 /// ```
-/// #![feature(inclusive_range_syntax)]
 /// let arr = [0, 1, 2, 3];
-/// assert_eq!(arr[ ...2], [0,1,2  ]);  // RangeToInclusive
-/// assert_eq!(arr[1...2], [  1,2  ]);
+/// assert_eq!(arr[ ...2], [0, 1, 2]);
 /// ```
+///
+/// See the [module examples] for the behavior of other range structs.
+///
+/// [module examples]: ../#Examples
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[unstable(feature = "inclusive_range", reason = "recently added, follows RFC", issue = "28237")]
 pub struct RangeToInclusive<Idx> {

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -2219,6 +2219,7 @@ impl<Idx: PartialOrd<Idx>> RangeInclusive<Idx> {
 /// array elements up to and including the index indicated by `end`.
 ///
 /// ```
+/// #![feature(inclusive_range_syntax)]
 /// let arr = [0, 1, 2, 3];
 /// assert_eq!(arr[ ...2], [0, 1, 2]);
 /// ```

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -157,6 +157,9 @@
 //!     assert_eq!(arr[1...3], [  1,2,3 ]); // RangeInclusive
 //! }
 //! ```
+//!
+//! Note: whitespace alignment is not idiomatic Rust. An exception is made in
+//! this case to facilitate comparison.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -145,16 +145,17 @@
 //!
 //! ```rust
 //! #![feature(inclusive_range_syntax)]
+//! fn main() {
+//!     let arr = [0, 1, 2, 3, 4];
 //!
-//! let arr = [0, 1, 2, 3, 4];
+//!     assert_eq!(arr[ .. ], [0,1,2,3,4]); // RangeFull
+//!     assert_eq!(arr[ ..3], [0,1,2    ]); // RangeTo
+//!     assert_eq!(arr[1.. ], [  1,2,3,4]); // RangeFrom
+//!     assert_eq!(arr[1..3], [  1,2    ]); // Range
 //!
-//! assert_eq!(arr[ .. ], [0,1,2,3,4]); // RangeFull
-//! assert_eq!(arr[ ..3], [0,1,2    ]); // RangeTo
-//! assert_eq!(arr[1.. ], [  1,2,3,4]); // RangeFrom
-//! assert_eq!(arr[1..3], [  1,2    ]); // Range
-//!
-//! assert_eq!(arr[ ...3], [0,1,2,3 ]); // RangeToIncusive
-//! assert_eq!(arr[1...3], [  1,2,3 ]); // RangeInclusive
+//!     assert_eq!(arr[ ...3], [0,1,2,3 ]); // RangeToIncusive
+//!     assert_eq!(arr[1...3], [  1,2,3 ]); // RangeInclusive
+//! }
 //! ```
 
 #![stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
This pull request adds a module-level example of how all the range operators work. It also slims down struct-level examples in lieu of a link to module examples.
