### PR TITLE
Carrier trait (third attempt)

### DIFF
--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -76,7 +76,6 @@ use cmp::PartialOrd;
 use fmt;
 use marker::{Sized, Unsize};
 use result::Result::{self, Ok, Err};
-use option::Option::{self, Some, None};
 
 /// The `Drop` trait is used to run some code when a value goes out of scope.
 /// This is sometimes called a 'destructor'.
@@ -2203,75 +2202,23 @@ impl<U, V> Carrier for Result<U, V> {
     }
 }
 
-#[unstable(feature = "question_mark_carrier", issue = "31436")]
-impl<U> Carrier for Option<U> {
-    type Success = U;
-    type Error = ();
+struct _DummyErrorType;
 
-    fn from_success(u: U) -> Option<U> {
-        Some(u)
-    }
-
-    fn from_error(_: ()) -> Option<U> {
-        None
-    }
-
-    fn translate<T>(self) -> T
-        where T: Carrier<Success=U, Error=()>
-    {
-        match self {
-            Some(u) => T::from_success(u),
-            None => T::from_error(()),
-        }
-    }
-}
-
-// Implementing Carrier for bools means it's easy to write short-circuiting
-// functions. E.g.,
-// ```
-// fn foo() -> bool {
-//     if !(f() || g()) {
-//         return false;
-//     }
-//
-//     some_computation();
-//     if h() {
-//         return false;
-//     }
-//
-//     more_computation();
-//     i()
-// }
-// ```
-// becomes
-// ```
-// fn foo() -> bool {
-//     (f() || g())?;
-//     some_computation();
-//     (!h())?;
-//     more_computation();
-//     i()
-// }
-// ```
-#[unstable(feature = "question_mark_carrier", issue = "31436")]
-impl Carrier for bool {
+impl Carrier for _DummyErrorType {
     type Success = ();
     type Error = ();
 
-    fn from_success(_: ()) -> bool {
-        true
+    fn from_success(_: ()) -> _DummyErrorType {
+        _DummyErrorType
     }
 
-    fn from_error(_: ()) -> bool {
-        false
+    fn from_error(_: ()) -> _DummyErrorType {
+        _DummyErrorType
     }
 
     fn translate<T>(self) -> T
         where T: Carrier<Success=(), Error=()>
     {
-        match self {
-            true => T::from_success(()),
-            false => T::from_error(()),
-        }
+        T::from_success(())
     }
 }

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -75,6 +75,8 @@
 use cmp::PartialOrd;
 use fmt;
 use marker::{Sized, Unsize};
+use result::Result::{self, Ok, Err};
+use option::Option::{self, Some, None};
 
 /// The `Drop` trait is used to run some code when a value goes out of scope.
 /// This is sometimes called a 'destructor'.
@@ -2149,4 +2151,127 @@ pub trait Boxed {
 pub trait BoxPlace<Data: ?Sized> : Place<Data> {
     /// Creates a globally fresh place.
     fn make_place() -> Self;
+}
+
+/// A trait for types which have success and error states and are meant to work
+/// with the question mark operator.
+/// When the `?` operator is used with a value, whether the value is in the
+/// success or error state is determined by calling `translate`.
+///
+/// This trait is **very** experimental, it will probably be iterated on heavily
+/// before it is stabilised. Implementors should expect change. Users of `?`
+/// should not rely on any implementations of `Carrier` other than `Result`,
+/// i.e., you should not expect `?` to continue to work with `Option`, etc.
+#[unstable(feature = "question_mark_carrier", issue = "31436")]
+pub trait Carrier {
+    /// The type of the value when computation succeeds.
+    type Success;
+    /// The type of the value when computation errors out.
+    type Error;
+
+    /// Create a `Carrier` from a success value.
+    fn from_success(Self::Success) -> Self;
+
+    /// Create a `Carrier` from an error value.
+    fn from_error(Self::Error) -> Self;
+
+    /// Translate this `Carrier` to another implementation of `Carrier` with the
+    /// same associated types.
+    fn translate<T>(self) -> T where T: Carrier<Success=Self::Success, Error=Self::Error>;
+}
+
+#[unstable(feature = "question_mark_carrier", issue = "31436")]
+impl<U, V> Carrier for Result<U, V> {
+    type Success = U;
+    type Error = V;
+
+    fn from_success(u: U) -> Result<U, V> {
+        Ok(u)
+    }
+
+    fn from_error(e: V) -> Result<U, V> {
+        Err(e)
+    }
+
+    fn translate<T>(self) -> T
+        where T: Carrier<Success=U, Error=V>
+    {
+        match self {
+            Ok(u) => T::from_success(u),
+            Err(e) => T::from_error(e),
+        }
+    }
+}
+
+#[unstable(feature = "question_mark_carrier", issue = "31436")]
+impl<U> Carrier for Option<U> {
+    type Success = U;
+    type Error = ();
+
+    fn from_success(u: U) -> Option<U> {
+        Some(u)
+    }
+
+    fn from_error(_: ()) -> Option<U> {
+        None
+    }
+
+    fn translate<T>(self) -> T
+        where T: Carrier<Success=U, Error=()>
+    {
+        match self {
+            Some(u) => T::from_success(u),
+            None => T::from_error(()),
+        }
+    }
+}
+
+// Implementing Carrier for bools means it's easy to write short-circuiting
+// functions. E.g.,
+// ```
+// fn foo() -> bool {
+//     if !(f() || g()) {
+//         return false;
+//     }
+//
+//     some_computation();
+//     if h() {
+//         return false;
+//     }
+//
+//     more_computation();
+//     i()
+// }
+// ```
+// becomes
+// ```
+// fn foo() -> bool {
+//     (f() || g())?;
+//     some_computation();
+//     (!h())?;
+//     more_computation();
+//     i()
+// }
+// ```
+#[unstable(feature = "question_mark_carrier", issue = "31436")]
+impl Carrier for bool {
+    type Success = ();
+    type Error = ();
+
+    fn from_success(_: ()) -> bool {
+        true
+    }
+
+    fn from_error(_: ()) -> bool {
+        false
+    }
+
+    fn translate<T>(self) -> T
+        where T: Carrier<Success=(), Error=()>
+    {
+        match self {
+            true => T::from_success(()),
+            false => T::from_error(()),
+        }
+    }
 }

--- a/src/librustc/ty/relate.rs
+++ b/src/librustc/ty/relate.rs
@@ -151,13 +151,13 @@ pub fn relate_substs<'a, 'gcx, 'tcx, R>(relation: &mut R,
         let b_ty = &b_subst.types[i];
         let variance = variances.map_or(ty::Invariant, |v| v.types[i]);
         relation.relate_with_variance(variance, a_ty, b_ty)
-    }).collect()?;
+    }).collect::<Result<_, _>>()?;
 
     let regions = a_subst.regions.iter().enumerate().map(|(i, a_r)| {
         let b_r = &b_subst.regions[i];
         let variance = variances.map_or(ty::Invariant, |v| v.regions[i]);
         relation.relate_with_variance(variance, a_r, b_r)
-    }).collect()?;
+    }).collect::<Result<_, _>>()?;
 
     Ok(Substs::new(tcx, types, regions))
 }

--- a/src/test/compile-fail/question-mark-type-infer.rs
+++ b/src/test/compile-fail/question-mark-type-infer.rs
@@ -1,0 +1,27 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(question_mark, question_mark_carrier)]
+
+// Test that type inference fails where there are multiple possible return types
+// for the `?` operator.
+
+fn f(x: &i32) -> Result<i32, ()> {
+    Ok(*x)
+}
+
+fn g() -> Result<Vec<i32>, ()> {
+    let l = [1, 2, 3, 4];
+    l.iter().map(f).collect()? //~ ERROR type annotations required: cannot resolve
+}
+
+fn main() {
+    g();
+}

--- a/src/test/run-pass/try-operator-custom.rs
+++ b/src/test/run-pass/try-operator-custom.rs
@@ -1,0 +1,73 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(question_mark, question_mark_carrier)]
+
+use std::ops::Carrier;
+
+enum MyResult<T, U> {
+    Awesome(T),
+    Terrible(U)
+}
+
+impl<U, V> Carrier for MyResult<U, V> {
+    type Success = U;
+    type Error = V;
+
+    fn from_success(u: U) -> MyResult<U, V> {
+        MyResult::Awesome(u)
+    }
+
+    fn from_error(e: V) -> MyResult<U, V> {
+        MyResult::Terrible(e)
+    }
+
+    fn translate<T>(self) -> T
+        where T: Carrier<Success=U, Error=V>
+    {
+        match self {
+            MyResult::Awesome(u) => T::from_success(u),
+            MyResult::Terrible(e) => T::from_error(e),
+        }
+    }
+}
+
+fn f(x: i32) -> Result<i32, String> {
+    if x == 0 {
+        Ok(42)
+    } else {
+        let y = g(x)?;
+        Ok(y)
+    }
+}
+
+fn g(x: i32) -> MyResult<i32, String> {
+    let _y = f(x - 1)?;
+    MyResult::Terrible("Hello".to_owned())
+}
+
+fn h() -> MyResult<i32, String> {
+    let a: Result<i32, &'static str> = Err("Hello");
+    let b = a?;
+    MyResult::Awesome(b)
+}
+
+fn i() -> MyResult<i32, String> {
+    let a: MyResult<i32, &'static str> = MyResult::Terrible("Hello");
+    let b = a?;
+    MyResult::Awesome(b)
+}
+
+fn main() {
+    assert!(f(0) == Ok(42));
+    assert!(f(10) == Err("Hello".to_owned()));
+    let _ = h();
+    let _ = i();
+}

--- a/src/test/run-pass/try-operator.rs
+++ b/src/test/run-pass/try-operator.rs
@@ -144,23 +144,6 @@ fn merge_error() -> Result<i32, Error> {
     Ok(s.parse::<i32>()? + 1)
 }
 
-fn option() -> Option<i32> {
-    let x = Some(42);
-    let y = x?;
-    Some(y + 2)
-}
-
-fn bool() -> bool {
-    let x = true;
-    let y = false;
-    let z = true;
-
-    (x || y)?;
-    let a: () = z?;
-    x?;
-    true
-}
-
 fn main() {
     assert_eq!(Ok(3), on_method());
 

--- a/src/test/run-pass/try-operator.rs
+++ b/src/test/run-pass/try-operator.rs
@@ -144,6 +144,23 @@ fn merge_error() -> Result<i32, Error> {
     Ok(s.parse::<i32>()? + 1)
 }
 
+fn option() -> Option<i32> {
+    let x = Some(42);
+    let y = x?;
+    Some(y + 2)
+}
+
+fn bool() -> bool {
+    let x = true;
+    let y = false;
+    let z = true;
+
+    (x || y)?;
+    let a: () = z?;
+    x?;
+    true
+}
+
 fn main() {
     assert_eq!(Ok(3), on_method());
 


### PR DESCRIPTION
This adds a `Carrier` trait to operate with `?`. The only public implementation is for `Result`, so effectively the trait does not exist, however, it ensures future compatibility for the `?` operator. This is not intended to be used, nor is it intended to be a long-term solution.

Although this exact PR has not been through Crater, I do not expect it to be a breaking change based on putting numerous similar PRs though Crater in the past.

cc:
- [? tracking issue](https://github.com/rust-lang/rust/issues/31436)
- [previous PR](https://github.com/rust-lang/rust/pull/35056)
- [RFC issue](https://github.com/rust-lang/rfcs/issues/1718) for discussion of long-term Carrier trait solutions.

r? @nikomatsakis 
