### PR TITLE
rustc: Don't enable NEON by default on armv7 Linux

### DIFF
--- a/src/librustc_back/target/armv7_unknown_linux_gnueabihf.rs
+++ b/src/librustc_back/target/armv7_unknown_linux_gnueabihf.rs
@@ -23,8 +23,9 @@ pub fn target() -> TargetResult {
         target_vendor: "unknown".to_string(),
 
         options: TargetOptions {
-            features: "+v7,+vfp3,+neon".to_string(),
-            cpu: "cortex-a8".to_string(),
+            // Info about features at https://wiki.debian.org/ArmHardFloatPort
+            features: "+v7,+vfp3,+d16,+thumb2".to_string(),
+            cpu: "generic".to_string(),
             max_atomic_width: 64,
             .. base
         }


### PR DESCRIPTION
One of the primary platforms for the `armv7-unknown-linux-gnueabihf` target,
Linux distributions, do not enable NEON extensions by default. This PR disables
that feature by defualt but enables the `d16` feature which enables VFP3D16 that
distributions do enable.

Closes #35590
