### PR TITLE
Allow [] for macro invocation in `item` places

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1216,7 +1216,8 @@ impl<'a> Parser<'a> {
         } else if !self.token.is_any_keyword()
             && self.look_ahead(1, |t| *t == token::Not)
             && (self.look_ahead(2, |t| *t == token::OpenDelim(token::Paren))
-                || self.look_ahead(2, |t| *t == token::OpenDelim(token::Brace))) {
+                || self.look_ahead(2, |t| *t == token::OpenDelim(token::Brace))
+                || self.look_ahead(2, |t| *t == token::OpenDelim(token::Bracket))) {
                 // trait item macro.
                 // code copied from parse_macro_use_or_failure... abstraction!
                 let lo = self.span.lo;
@@ -4840,7 +4841,8 @@ impl<'a> Parser<'a> {
         if !self.token.is_any_keyword()
             && self.look_ahead(1, |t| *t == token::Not)
             && (self.look_ahead(2, |t| *t == token::OpenDelim(token::Paren))
-                || self.look_ahead(2, |t| *t == token::OpenDelim(token::Brace))) {
+                || self.look_ahead(2, |t| *t == token::OpenDelim(token::Brace))
+                || self.look_ahead(2, |t| *t == token::OpenDelim(token::Bracket))) {
             // method macro.
 
             let last_span = self.last_span;
@@ -5920,7 +5922,8 @@ impl<'a> Parser<'a> {
                 && self.look_ahead(1, |t| *t == token::Not)
                 && (self.look_ahead(2, |t| t.is_ident())
                     || self.look_ahead(2, |t| *t == token::OpenDelim(token::Paren))
-                    || self.look_ahead(2, |t| *t == token::OpenDelim(token::Brace))) {
+                    || self.look_ahead(2, |t| *t == token::OpenDelim(token::Brace))
+                    || self.look_ahead(2, |t| *t == token::OpenDelim(token::Bracket))) {
             // MACRO INVOCATION ITEM
 
             let last_span = self.last_span;

--- a/src/test/run-pass/macro-delimiters-in-item-position.rs
+++ b/src/test/run-pass/macro-delimiters-in-item-position.rs
@@ -1,0 +1,20 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! unit {
+    ($name:ident) => { struct $name; }
+}
+
+unit!(Parens);
+unit!{Braces}
+unit![Brackets];
+
+pub fn main() {
+}


### PR DESCRIPTION
The following code doesn't compile:

``` rust
macro_rules! unit {
    ($name:ident) => { struct $name; }
}

unit!(Parens);
unit!{Braces}
unit![Brackets];
```

With the following compliant:

```
src/test/run-pass/macro-delimiters-in-item-position.rs:17:1: 17:5 error: expected item, found `unit`
src/test/run-pass/macro-delimiters-in-item-position.rs:17 unit![Brackets];
                                                          ^~~~
error: aborting due to previous error
```

It seems that, unlike in `expr` position, `item` macros couldn't be invoked with `name![...]`.  This seems to be caused by a copy-paste issue, where the "could this be a macro" test is repeated in various places but with slightly different logic in each.
