### PR TITLE
Wording fixes in error messages

### DIFF
--- a/src/librustc/ty/error.rs
+++ b/src/librustc/ty/error.rs
@@ -98,9 +98,9 @@ impl<'tcx> fmt::Display for TypeError<'tcx> {
                        values.expected,
                        values.found)
             }
-            Mutability => write!(f, "values differ in mutability"),
+            Mutability => write!(f, "types differ in mutability"),
             BoxMutability => {
-                write!(f, "boxed values differ in mutability")
+                write!(f, "boxed types differ in mutability")
             }
             VecMutability => write!(f, "vectors differ in mutability"),
             PtrMutability => write!(f, "pointers differ in mutability"),

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -426,7 +426,9 @@ impl EmitterWriter {
                             continue;
                         }
                         // Check to make sure we're not in any <*macros>
-                        if !cm.span_to_filename(def_site).contains("macros>") {
+                        if !cm.span_to_filename(def_site).contains("macros>") &&
+                            !trace.macro_decl_name.starts_with("#[")
+                        {
                             new_labels.push((trace.call_site,
                                              "in this macro invocation".to_string()));
                             break;

--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -29,7 +29,7 @@ use rustc::hir;
 pub fn check_legal_trait_for_method_call(ccx: &CrateCtxt, span: Span, trait_id: DefId) {
     if ccx.tcx.lang_items.drop_trait() == Some(trait_id) {
         struct_span_err!(ccx.tcx.sess, span, E0040, "explicit use of destructor method")
-            .span_label(span, &format!("call to destructor method"))
+            .span_label(span, &format!("explicit destructor calls not allowed"))
             .emit();
     }
 }

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -402,7 +402,7 @@ pub fn compare_impl_method<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
             infcx.note_type_err(
                 &mut diag,
                 origin,
-                trait_err_span.map(|sp| (sp, format!("original trait requirement"))),
+                trait_err_span.map(|sp| (sp, format!("type in trait"))),
                 Some(infer::ValuePairs::Types(ExpectedFound {
                      expected: trait_fty,
                      found: impl_fty
@@ -575,7 +575,7 @@ pub fn compare_const_impl<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
             infcx.note_type_err(
                 &mut diag,
                 origin,
-                Some((trait_c_span, format!("original trait requirement"))),
+                Some((trait_c_span, format!("type in trait"))),
                 Some(infer::ValuePairs::Types(ExpectedFound {
                     expected: trait_ty,
                     found: impl_ty

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1013,7 +1013,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                          // We can only get the spans from local trait definition
                          // Same for E0324 and E0325
                          if let Some(trait_span) = tcx.map.span_if_local(ty_trait_item.def_id()) {
-                            err.span_label(trait_span, &format!("original trait requirement"));
+                            err.span_label(trait_span, &format!("item in trait"));
                          }
                          err.emit()
                     }
@@ -1041,7 +1041,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                   impl_trait_ref);
                          err.span_label(impl_item.span, &format!("does not match trait"));
                          if let Some(trait_span) = tcx.map.span_if_local(ty_trait_item.def_id()) {
-                            err.span_label(trait_span, &format!("original trait requirement"));
+                            err.span_label(trait_span, &format!("item in trait"));
                          }
                          err.emit()
                     }
@@ -1064,7 +1064,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                   impl_trait_ref);
                          err.span_label(impl_item.span, &format!("does not match trait"));
                          if let Some(trait_span) = tcx.map.span_if_local(ty_trait_item.def_id()) {
-                            err.span_label(trait_span, &format!("original trait requirement"));
+                            err.span_label(trait_span, &format!("item in trait"));
                          }
                          err.emit()
                     }
@@ -4408,8 +4408,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                               expected at most {}, found {}",
                              count(type_defs.len()),
                              count(types.len()))
-                .span_label(span, &format!("expected {}",
-                            count(type_defs.len()))).emit();
+                .span_label(span, &format!("too many type parameters")).emit();
 
             // To prevent derived errors to accumulate due to extra
             // type parameters, we force instantiate_value_path to

--- a/src/librustc_typeck/coherence/orphan.rs
+++ b/src/librustc_typeck/coherence/orphan.rs
@@ -37,7 +37,7 @@ impl<'cx, 'tcx> OrphanChecker<'cx, 'tcx> {
                       "cannot define inherent `impl` for a type outside of the \
                        crate where the type is defined")
                 .span_label(item.span, &format!("impl for type defined outside of crate."))
-                .span_note(item.span, &format!("define and implement a trait or new type instead"))
+                .note("define and implement a trait or new type instead")
                 .emit();
         }
     }

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -572,7 +572,7 @@ impl Foo for Bar {
     // error, expected u16, found i16
     fn foo(x: i16) { }
 
-    // error, values differ in mutability
+    // error, types differ in mutability
     fn bar(&mut self) { }
 }
 ```

--- a/src/test/compile-fail/E0040.rs
+++ b/src/test/compile-fail/E0040.rs
@@ -22,5 +22,5 @@ fn main() {
     let mut x = Foo { x: -7 };
     x.drop();
     //~^ ERROR E0040
-    //~| NOTE call to destructor method
+    //~| NOTE explicit destructor calls not allowed
 }

--- a/src/test/compile-fail/E0053.rs
+++ b/src/test/compile-fail/E0053.rs
@@ -9,8 +9,8 @@
 // except according to those terms.
 
 trait Foo {
-    fn foo(x: u16); //~ NOTE original trait requirement
-    fn bar(&self); //~ NOTE original trait requirement
+    fn foo(x: u16); //~ NOTE type in trait
+    fn bar(&self); //~ NOTE type in trait
 }
 
 struct Bar;
@@ -21,7 +21,7 @@ impl Foo for Bar {
     //~| NOTE expected u16
     fn bar(&mut self) { }
     //~^ ERROR method `bar` has an incompatible type for trait
-    //~| NOTE values differ in mutability
+    //~| NOTE types differ in mutability
     //~| NOTE expected type `fn(&Bar)`
     //~| NOTE found type `fn(&mut Bar)`
 }

--- a/src/test/compile-fail/E0087.rs
+++ b/src/test/compile-fail/E0087.rs
@@ -12,5 +12,5 @@ fn foo<T>() {}
 
 fn main() {
     foo::<f64, bool>(); //~ ERROR E0087
-    //~^ NOTE expected
+    //~^ NOTE too many type parameters
 }

--- a/src/test/compile-fail/associated-const-impl-wrong-type.rs
+++ b/src/test/compile-fail/associated-const-impl-wrong-type.rs
@@ -11,7 +11,7 @@
 #![feature(associated_consts)]
 
 trait Foo {
-    const BAR: u32; //~ NOTE original trait requirement
+    const BAR: u32; //~ NOTE type in trait
 }
 
 struct SignedBar;

--- a/src/test/compile-fail/coerce-mut.rs
+++ b/src/test/compile-fail/coerce-mut.rs
@@ -16,5 +16,5 @@ fn main() {
     //~^ ERROR mismatched types
     //~| expected type `&mut i32`
     //~| found type `&{integer}`
-    //~| values differ in mutability
+    //~| types differ in mutability
 }

--- a/src/test/compile-fail/fn-variance-1.rs
+++ b/src/test/compile-fail/fn-variance-1.rs
@@ -19,9 +19,9 @@ fn apply<T, F>(t: T, f: F) where F: FnOnce(T) {
 fn main() {
     apply(&3, takes_imm);
     apply(&3, takes_mut);
-    //~^ ERROR (values differ in mutability)
+    //~^ ERROR (types differ in mutability)
 
     apply(&mut 3, takes_mut);
     apply(&mut 3, takes_imm);
-    //~^ ERROR (values differ in mutability)
+    //~^ ERROR (types differ in mutability)
 }

--- a/src/test/compile-fail/impl-wrong-item-for-trait.rs
+++ b/src/test/compile-fail/impl-wrong-item-for-trait.rs
@@ -12,9 +12,9 @@
 
 trait Foo {
     fn bar(&self);
-    //~^ NOTE original trait requirement
-    //~| NOTE original trait requirement
-    const MY_CONST: u32; //~ NOTE original trait requirement
+    //~^ NOTE item in trait
+    //~| NOTE item in trait
+    const MY_CONST: u32; //~ NOTE item in trait
 }
 
 pub struct FooConstForMethod;

--- a/src/test/compile-fail/mut-pattern-mismatched.rs
+++ b/src/test/compile-fail/mut-pattern-mismatched.rs
@@ -16,7 +16,7 @@ fn main() {
      let &_ //~  ERROR mismatched types
             //~| expected type `&mut {integer}`
             //~| found type `&_`
-            //~| values differ in mutability
+            //~| types differ in mutability
         = foo;
     let &mut _ = foo;
 
@@ -25,6 +25,6 @@ fn main() {
     let &mut _ //~  ERROR mismatched types
                //~| expected type `&{integer}`
                //~| found type `&mut _`
-               //~| values differ in mutability
+               //~| types differ in mutability
          = bar;
 }

--- a/src/test/compile-fail/ptr-coercion.rs
+++ b/src/test/compile-fail/ptr-coercion.rs
@@ -17,17 +17,17 @@ pub fn main() {
     let x: *mut isize = x; //~  ERROR mismatched types
                            //~| expected type `*mut isize`
                            //~| found type `*const isize`
-                           //~| values differ in mutability
+                           //~| types differ in mutability
 
     // & -> *mut
     let x: *mut isize = &42; //~  ERROR mismatched types
                              //~| expected type `*mut isize`
                              //~| found type `&isize`
-                             //~| values differ in mutability
+                             //~| types differ in mutability
 
     let x: *const isize = &42;
     let x: *mut isize = x; //~  ERROR mismatched types
                            //~| expected type `*mut isize`
                            //~| found type `*const isize`
-                           //~| values differ in mutability
+                           //~| types differ in mutability
 }

--- a/src/test/compile-fail/slice-mut.rs
+++ b/src/test/compile-fail/slice-mut.rs
@@ -18,5 +18,5 @@ fn main() {
     //~^ ERROR mismatched types
     //~| expected type `&mut [_]`
     //~| found type `&[isize]`
-    //~| values differ in mutability
+    //~| types differ in mutability
 }

--- a/src/test/ui/mismatched_types/trait-impl-fn-incompatibility.stderr
+++ b/src/test/ui/mismatched_types/trait-impl-fn-incompatibility.stderr
@@ -2,7 +2,7 @@ error[E0053]: method `foo` has an incompatible type for trait
   --> $DIR/trait-impl-fn-incompatibility.rs:21:15
    |
 14 |     fn foo(x: u16);
-   |               --- original trait requirement
+   |               --- type in trait
 ...
 21 |     fn foo(x: i16) { }
    |               ^^^ expected u16, found i16
@@ -11,10 +11,10 @@ error[E0053]: method `bar` has an incompatible type for trait
   --> $DIR/trait-impl-fn-incompatibility.rs:22:28
    |
 15 |     fn bar(&mut self, bar: &mut Bar);
-   |                            -------- original trait requirement
+   |                            -------- type in trait
 ...
 22 |     fn bar(&mut self, bar: &Bar) { }
-   |                            ^^^^ values differ in mutability
+   |                            ^^^^ types differ in mutability
    |
    = note: expected type `fn(&mut Bar, &mut Bar)`
    = note:    found type `fn(&mut Bar, &Bar)`


### PR DESCRIPTION
This PR is largely wording fixes to existing PRs that I found going back through the ones that have already been updated.  Sometimes seeing the message in context made me think "oh there's a better wording!"

There's one additional fix.  This will also prevent the secondary underlining of derive call (since they look like macros to the system in the way I was using):

```
error[E0184]: the trait `Copy` may not be implemented for this type; the type has a destructor
  --> src/test/compile-fail/E0184.rs:11:10
   |
11 | #[derive(Copy)] //~ ERROR E0184
   |          ^^^^
   |          |
   |          in this macro invocation
```

Is now just:

```
error[E0184]: the trait `Copy` may not be implemented for this type; the type has a destructor
  --> src/test/compile-fail/E0184.rs:11:10
   |
11 | #[derive(Copy)] //~ ERROR E0184
   |          ^^^^
```
