### PR TITLE
Speed up read_to_end helper function using buffer capacity for read size

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -345,7 +345,11 @@ fn append_to_string<F>(buf: &mut String, f: F) -> Result<usize>
 fn read_to_end<R: Read + ?Sized>(r: &mut R, buf: &mut Vec<u8>) -> Result<usize> {
     let start_len = buf.len();
     let mut len = start_len;
-    let mut new_write_size = 16;
+    let mut new_write_size = if buf.capacity() > 16 {
+        buf.capacity() - buf.len()
+    } else {
+        16
+    };
     let ret;
     loop {
         if len == buf.len() {


### PR DESCRIPTION
The buffer's capacity or 16 bytes, whichever is larger, is the minimum start read size, but it will get twice as large with each read.

Fixes #35823.
