### PR TITLE
Introduce max_by/min_by on iterators

### DIFF
--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -1664,6 +1664,31 @@ pub trait Iterator {
             .map(|(_, x)| x)
     }
 
+    /// Returns the element that gives the maximum value with respect to the
+    /// specified comparison function.
+    ///
+    /// Returns the rightmost element if the comparison determines two elements
+    /// to be equally maximum.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let a = [-3_i32, 0, 1, 5, -10];
+    /// assert_eq!(*a.iter().max_by(|x, y| x.cmp(y)).unwrap(), 5);
+    /// ```
+    #[inline]
+    #[unstable(feature = "iter_max_by", issue="1722")]
+    fn max_by<F>(self, mut compare: F) -> Option<Self::Item>
+        where Self: Sized, F: FnMut(&Self::Item, &Self::Item) -> Ordering,
+    {
+        select_fold1(self,
+                     |_| (),
+                     // switch to y even if it is only equal, to preserve
+                     // stability.
+                     |_, x, _, y| Ordering::Greater != compare(x, y))
+            .map(|(_, x)| x)
+    }
+
     /// Returns the element that gives the minimum value from the
     /// specified function.
     ///
@@ -1687,6 +1712,32 @@ pub trait Iterator {
                      |x_p, _, y_p, _| x_p > y_p)
             .map(|(_, x)| x)
     }
+
+    /// Returns the element that gives the minimum value with respect to the
+    /// specified comparison function.
+    ///
+    /// Returns the latest element if the comparison determines two elements
+    /// to be equally minimum.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let a = [-3_i32, 0, 1, 5, -10];
+    /// assert_eq!(*a.iter().min_by(|x, y| x.cmp(y)).unwrap(), -10);
+    /// ```
+    #[inline]
+    #[unstable(feature = "iter_min_by", issue="1722")]
+    fn min_by<F>(self, mut compare: F) -> Option<Self::Item>
+        where Self: Sized, F: FnMut(&Self::Item, &Self::Item) -> Ordering,
+    {
+        select_fold1(self,
+                     |_| (),
+                     // switch to y even if it is strictly smaller, to
+                     // preserve stability.
+                     |_, x, _, y| Ordering::Greater == compare(x, y))
+            .map(|(_, x)| x)
+    }
+
 
     /// Reverses an iterator's direction.
     ///

--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -1678,7 +1678,7 @@ pub trait Iterator {
     /// assert_eq!(*a.iter().max_by(|x, y| x.cmp(y)).unwrap(), 5);
     /// ```
     #[inline]
-    #[unstable(feature = "iter_max_by", issue="1722")]
+    #[unstable(feature = "iter_max_by", issue="36105")]
     fn max_by<F>(self, mut compare: F) -> Option<Self::Item>
         where Self: Sized, F: FnMut(&Self::Item, &Self::Item) -> Ordering,
     {
@@ -1728,7 +1728,7 @@ pub trait Iterator {
     /// assert_eq!(*a.iter().min_by(|x, y| x.cmp(y)).unwrap(), -10);
     /// ```
     #[inline]
-    #[unstable(feature = "iter_min_by", issue="1722")]
+    #[unstable(feature = "iter_min_by", issue="36105")]
     fn min_by<F>(self, mut compare: F) -> Option<Self::Item>
         where Self: Sized, F: FnMut(&Self::Item, &Self::Item) -> Ordering,
     {

--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -1673,6 +1673,7 @@ pub trait Iterator {
     /// # Examples
     ///
     /// ```
+    /// #![feature(iter_max_by)]
     /// let a = [-3_i32, 0, 1, 5, -10];
     /// assert_eq!(*a.iter().max_by(|x, y| x.cmp(y)).unwrap(), 5);
     /// ```
@@ -1722,6 +1723,7 @@ pub trait Iterator {
     /// # Examples
     ///
     /// ```
+    /// #![feature(iter_min_by)]
     /// let a = [-3_i32, 0, 1, 5, -10];
     /// assert_eq!(*a.iter().min_by(|x, y| x.cmp(y)).unwrap(), -10);
     /// ```

--- a/src/libcoretest/iter.rs
+++ b/src/libcoretest/iter.rs
@@ -665,9 +665,21 @@ fn test_max_by_key() {
 }
 
 #[test]
+fn test_max_by() {
+    let xs: &[isize] = &[-3, 0, 1, 5, -10];
+    assert_eq!(*xs.iter().max_by(|x, y| x.abs().cmp(&y.abs())).unwrap(), -10);
+}
+
+#[test]
 fn test_min_by_key() {
     let xs: &[isize] = &[-3, 0, 1, 5, -10];
     assert_eq!(*xs.iter().min_by_key(|x| x.abs()).unwrap(), 0);
+}
+
+#[test]
+fn test_min_by() {
+    let xs: &[isize] = &[-3, 0, 1, 5, -10];
+    assert_eq!(*xs.iter().min_by(|x, y| x.abs().cmp(&y.abs())).unwrap(), 0);
 }
 
 #[test]

--- a/src/libcoretest/lib.rs
+++ b/src/libcoretest/lib.rs
@@ -33,6 +33,8 @@
 #![feature(try_from)]
 #![feature(unicode)]
 #![feature(unique)]
+#![feature(iter_max_by)]
+#![feature(iter_min_by)]
 
 extern crate core;
 extern crate test;


### PR DESCRIPTION
See https://github.com/rust-lang/rfcs/issues/1722 for reference.

It seems that there is `min`, `max` (simple computation of min/max), `min_by_key`, `max_by_key` (min/max by comparing mapped values) but no `min_by` and `max_by` (min/max according to comparison function). However, e.g. on vectors or slices there is `sort`, `sort_by_key` and `sort_by`.
