### PR TITLE
Fix "Furthermore" Typo in String Docs

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -132,7 +132,7 @@ use boxed::Box;
 /// [`OsString`]: ../../std/ffi/struct.OsString.html
 ///
 /// Indexing is intended to be a constant-time operation, but UTF-8 encoding
-/// does not allow us to do this. Furtheremore, it's not clear what sort of
+/// does not allow us to do this. Furthermore, it's not clear what sort of
 /// thing the index should return: a byte, a codepoint, or a grapheme cluster.
 /// The [`as_bytes()`] and [`chars()`] methods return iterators over the first
 /// two, respectively.


### PR DESCRIPTION
It used to say "Furtheremore" instead of "Furthermore".
