### PR TITLE
typeck: use NoExpectation to check return type of diverging fn

### DIFF
--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1479,7 +1479,13 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
                 self.ir.tcx.region_maps.call_site_extent(id, body.id),
                 &self.fn_ret(id));
 
-        if self.live_on_entry(entry_ln, self.s.no_ret_var).is_some() {
+        if fn_ret.is_never() {
+            // FIXME(durka) this rejects code like `fn foo(x: !) -> ! { x }`
+            if self.live_on_entry(entry_ln, self.s.clean_exit_var).is_some() {
+                span_err!(self.ir.tcx.sess, sp, E0270,
+                          "computation may converge in a function marked as diverging");
+            }
+        } else if self.live_on_entry(entry_ln, self.s.no_ret_var).is_some() {
             let param_env = ParameterEnvironment::for_item(self.ir.tcx, id);
             let t_ret_subst = fn_ret.subst(self.ir.tcx, &param_env.free_substs);
             let is_nil = self.ir.tcx.infer_ctxt(None, Some(param_env),

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -708,7 +708,13 @@ fn check_fn<'a, 'gcx, 'tcx>(inherited: &'a Inherited<'a, 'gcx, 'tcx>,
 
     inherited.tables.borrow_mut().liberated_fn_sigs.insert(fn_id, fn_sig);
 
-    fcx.check_block_with_expected(body, ExpectHasType(fcx.ret_ty));
+    // FIXME(aburka) do we need this special case? and should it be is_uninhabited?
+    let expected = if fcx.ret_ty.is_never() {
+        NoExpectation
+    } else {
+        ExpectHasType(fcx.ret_ty)
+    };
+    fcx.check_block_with_expected(body, expected);
 
     fcx
 }

--- a/src/test/compile-fail/diverging-fn-tail-35849.rs
+++ b/src/test/compile-fail/diverging-fn-tail-35849.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,19 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Test that we can use a ! for an argument of type !
-
-// ignore-test FIXME(durka) can't be done with the current liveness code
-// error-pattern:wowzers!
-
-#![feature(never_type)]
-#![allow(unreachable_code)]
-
-fn foo(x: !) -> ! {
-    x
+fn _converge() -> ! { //~ ERROR computation may converge
+    42
 }
 
-fn main() {
-    foo(panic!("wowzers!"))
-}
+fn main() { }
 

--- a/src/test/run-pass/diverging-fn-tail-35849.rs
+++ b/src/test/run-pass/diverging-fn-tail-35849.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,19 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Test that we can use a ! for an argument of type !
-
-// ignore-test FIXME(durka) can't be done with the current liveness code
-// error-pattern:wowzers!
-
-#![feature(never_type)]
-#![allow(unreachable_code)]
-
-fn foo(x: !) -> ! {
-    x
+fn assert_sizeof() -> ! {
+    unsafe {
+        ::std::mem::transmute::<f64, [u8; 8]>(panic!())
+    }
 }
 
-fn main() {
-    foo(panic!("wowzers!"))
-}
+fn main() { }
 


### PR DESCRIPTION
Fixes #35849.

Thanks @eddyb.
