### PR TITLE
modify fds-are-cloexec test to open a file that exists

### DIFF
--- a/src/test/run-pass/fds-are-cloexec.rs
+++ b/src/test/run-pass/fds-are-cloexec.rs
@@ -34,7 +34,7 @@ fn main() {
 }
 
 fn parent() {
-    let file = File::open("Makefile").unwrap();
+    let file = File::open("src/test/run-pass/fds-are-cloexec.rs").unwrap();
     let tcp1 = TcpListener::bind("127.0.0.1:0").unwrap();
     let tcp2 = tcp1.try_clone().unwrap();
     let addr = tcp1.local_addr().unwrap();

--- a/src/test/run-pass/fds-are-cloexec.rs
+++ b/src/test/run-pass/fds-are-cloexec.rs
@@ -34,7 +34,7 @@ fn main() {
 }
 
 fn parent() {
-    let file = File::open("src/test/run-pass/fds-are-cloexec.rs").unwrap();
+    let file = File::open(file!()).unwrap();
     let tcp1 = TcpListener::bind("127.0.0.1:0").unwrap();
     let tcp2 = tcp1.try_clone().unwrap();
     let addr = tcp1.local_addr().unwrap();


### PR DESCRIPTION
Fixes #35753.

Is it a valid assumption that the current directory is always the root of the repo when the tests are run?

r? @nagisa
