### PR TITLE
add a panic example to std::from_utf8_unchecked

### DIFF
--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -299,6 +299,20 @@ unsafe fn from_raw_parts_mut<'a>(p: *mut u8, len: usize) -> &'a mut str {
 ///
 /// assert_eq!("💖", sparkle_heart);
 /// ```
+///
+/// Incorrect bytes:
+///
+/// ```
+/// use std::str;
+///
+/// // some invalid bytes, in a vector
+/// let sparkle_heart = vec![0, 159, 146, 150];
+///
+/// unsafe {
+///     // panics at runtime
+///     println!("{}", str::from_utf8_unchecked(&sparkle_heart));
+/// }
+/// ```
 #[inline(always)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn from_utf8_unchecked(v: &[u8]) -> &str {

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -302,7 +302,7 @@ unsafe fn from_raw_parts_mut<'a>(p: *mut u8, len: usize) -> &'a mut str {
 ///
 /// Incorrect bytes:
 ///
-/// ```
+/// ```no_run
 /// use std::str;
 ///
 /// // some invalid bytes, in a vector

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -310,7 +310,7 @@ unsafe fn from_raw_parts_mut<'a>(p: *mut u8, len: usize) -> &'a mut str {
 ///
 /// unsafe {
 ///     let invalid_str = str::from_utf8_unchecked(&sparkle_heart);
-///     // panics at runtime
+///     // prints garbage (" ���") to stdout
 ///     println!("{}", invalid_str);
 /// }
 /// ```

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -310,7 +310,7 @@ unsafe fn from_raw_parts_mut<'a>(p: *mut u8, len: usize) -> &'a mut str {
 ///
 /// unsafe {
 ///     let invalid_str = str::from_utf8_unchecked(&sparkle_heart);
-///     // prints garbage (" ���") to stdout
+///     // prints undefined garbage to stdout
 ///     println!("{}", invalid_str);
 /// }
 /// ```

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -213,9 +213,9 @@ impl Utf8Error {
 /// use std::str;
 ///
 /// // some invalid bytes, in a vector
-/// let sparkle_heart = vec![0, 159, 146, 150];
+/// let invalid_bytes = vec![0, 159, 146, 150];
 ///
-/// assert!(str::from_utf8(&sparkle_heart).is_err());
+/// assert!(str::from_utf8(&invalid_bytes).is_err());
 /// ```
 ///
 /// See the docs for [`Utf8Error`][error] for more details on the kinds of
@@ -306,11 +306,11 @@ unsafe fn from_raw_parts_mut<'a>(p: *mut u8, len: usize) -> &'a mut str {
 /// use std::str;
 ///
 /// // some invalid bytes, in a vector
-/// let sparkle_heart = vec![0, 159, 146, 150];
+/// let invalid_bytes = vec![0, 159, 146, 150];
 ///
 /// unsafe {
-///     let invalid_str = str::from_utf8_unchecked(&sparkle_heart);
-///     // prints undefined garbage to stdout
+///     let invalid_str = str::from_utf8_unchecked(&invalid_bytes);
+///     // prints unknown garbage to stdout
 ///     println!("{}", invalid_str);
 /// }
 /// ```

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -309,8 +309,9 @@ unsafe fn from_raw_parts_mut<'a>(p: *mut u8, len: usize) -> &'a mut str {
 /// let sparkle_heart = vec![0, 159, 146, 150];
 ///
 /// unsafe {
+///     let invalid_str = str::from_utf8_unchecked(&sparkle_heart);
 ///     // panics at runtime
-///     println!("{}", str::from_utf8_unchecked(&sparkle_heart));
+///     println!("{}", invalid_str);
 /// }
 /// ```
 #[inline(always)]


### PR DESCRIPTION
Show that passing invalid bytes to `str::from_utf8_unchecked` is a runtime panic.

r? @steveklabnik 
