### PR TITLE
Implement RFC 1560 behind `#![feature(item_like_imports)]`

### DIFF
--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -26,6 +26,8 @@ use rustc::hir::def::*;
 use rustc::hir::def_id::{CRATE_DEF_INDEX, DefId};
 use rustc::ty::{self, VariantKind};
 
+use std::cell::Cell;
+
 use syntax::ast::Name;
 use syntax::attr;
 use syntax::parse::token;
@@ -176,7 +178,10 @@ impl<'b> Resolver<'b> {
                         }
                     }
                     ViewPathGlob(_) => {
-                        let subclass = GlobImport { is_prelude: is_prelude };
+                        let subclass = GlobImport {
+                            is_prelude: is_prelude,
+                            max_vis: Cell::new(ty::Visibility::PrivateExternal),
+                        };
                         let span = view_path.span;
                         self.add_import_directive(module_path, subclass, span, item.id, vis);
                     }

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -30,7 +30,7 @@ use syntax::ast::Name;
 use syntax::attr;
 use syntax::parse::token;
 
-use syntax::ast::{Block, Crate};
+use syntax::ast::{Block, Crate, DUMMY_NODE_ID};
 use syntax::ast::{ForeignItem, ForeignItemKind, Item, ItemKind};
 use syntax::ast::{Mutability, StmtKind, TraitItemKind};
 use syntax::ast::{Variant, ViewPathGlob, ViewPathList, ViewPathSimple};
@@ -81,7 +81,6 @@ impl<'b> Resolver<'b> {
     /// Constructs the reduced graph for one item.
     fn build_reduced_graph_for_item(&mut self, item: &Item) {
         let parent = self.current_module;
-        let parent_vis = self.current_vis;
         let name = item.ident.name;
         let sp = item.span;
         let vis = self.resolve_visibility(&item.vis);
@@ -204,7 +203,7 @@ impl<'b> Resolver<'b> {
             ItemKind::Mod(..) => {
                 let parent_link = ModuleParentLink(parent, name);
                 let def = Def::Mod(self.definitions.local_def_id(item.id));
-                let module = self.new_module(parent_link, Some(def), false);
+                let module = self.new_module(parent_link, Some(def), item.id);
                 module.no_implicit_prelude.set({
                     parent.no_implicit_prelude.get() ||
                         attr::contains_name(&item.attrs, "no_implicit_prelude")
@@ -214,7 +213,6 @@ impl<'b> Resolver<'b> {
 
                 // Descend into the module.
                 self.current_module = module;
-                self.current_vis = ty::Visibility::Restricted(item.id);
             }
 
             ItemKind::ForeignMod(..) => {}
@@ -243,7 +241,7 @@ impl<'b> Resolver<'b> {
             ItemKind::Enum(ref enum_definition, _) => {
                 let parent_link = ModuleParentLink(parent, name);
                 let def = Def::Enum(self.definitions.local_def_id(item.id));
-                let module = self.new_module(parent_link, Some(def), false);
+                let module = self.new_module(parent_link, Some(def), parent.normal_ancestor_id);
                 self.define(parent, name, TypeNS, (module, sp, vis));
 
                 for variant in &(*enum_definition).variants {
@@ -285,7 +283,8 @@ impl<'b> Resolver<'b> {
                 // Add all the items within to a new module.
                 let parent_link = ModuleParentLink(parent, name);
                 let def = Def::Trait(def_id);
-                let module_parent = self.new_module(parent_link, Some(def), false);
+                let module_parent =
+                    self.new_module(parent_link, Some(def), parent.normal_ancestor_id);
                 self.define(parent, name, TypeNS, (module_parent, sp, vis));
 
                 // Add the names of all the items to the trait info.
@@ -312,7 +311,6 @@ impl<'b> Resolver<'b> {
 
         visit::walk_item(&mut BuildReducedGraphVisitor { resolver: self }, item);
         self.current_module = parent;
-        self.current_vis = parent_vis;
     }
 
     // Constructs the reduced graph for one variant. Variants exist in the
@@ -363,7 +361,7 @@ impl<'b> Resolver<'b> {
                    block_id);
 
             let parent_link = BlockParentLink(parent, block_id);
-            let new_module = self.new_module(parent_link, None, false);
+            let new_module = self.new_module(parent_link, None, parent.normal_ancestor_id);
             self.module_map.insert(block_id, new_module);
             self.current_module = new_module; // Descend into the block.
         }
@@ -395,7 +393,7 @@ impl<'b> Resolver<'b> {
                 debug!("(building reduced graph for external crate) building module {} {:?}",
                        name, vis);
                 let parent_link = ModuleParentLink(parent, name);
-                let module = self.new_module(parent_link, Some(def), true);
+                let module = self.new_module(parent_link, Some(def), DUMMY_NODE_ID);
                 let _ = self.try_define(parent, name, TypeNS, (module, DUMMY_SP, vis));
             }
             Def::Variant(_, variant_id) => {
@@ -437,7 +435,7 @@ impl<'b> Resolver<'b> {
                 }
 
                 let parent_link = ModuleParentLink(parent, name);
-                let module = self.new_module(parent_link, Some(def), true);
+                let module = self.new_module(parent_link, Some(def), DUMMY_NODE_ID);
                 let _ = self.try_define(parent, name, TypeNS, (module, DUMMY_SP, vis));
             }
             Def::TyAlias(..) | Def::AssociatedTy(..) => {

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -32,7 +32,7 @@ use syntax::ast::Name;
 use syntax::attr;
 use syntax::parse::token;
 
-use syntax::ast::{Block, Crate, DUMMY_NODE_ID};
+use syntax::ast::{Block, Crate};
 use syntax::ast::{ForeignItem, ForeignItemKind, Item, ItemKind};
 use syntax::ast::{Mutability, StmtKind, TraitItemKind};
 use syntax::ast::{Variant, ViewPathGlob, ViewPathList, ViewPathSimple};
@@ -208,7 +208,7 @@ impl<'b> Resolver<'b> {
             ItemKind::Mod(..) => {
                 let parent_link = ModuleParentLink(parent, name);
                 let def = Def::Mod(self.definitions.local_def_id(item.id));
-                let module = self.new_module(parent_link, Some(def), item.id);
+                let module = self.new_module(parent_link, Some(def), Some(item.id));
                 module.no_implicit_prelude.set({
                     parent.no_implicit_prelude.get() ||
                         attr::contains_name(&item.attrs, "no_implicit_prelude")
@@ -398,7 +398,7 @@ impl<'b> Resolver<'b> {
                 debug!("(building reduced graph for external crate) building module {} {:?}",
                        name, vis);
                 let parent_link = ModuleParentLink(parent, name);
-                let module = self.new_module(parent_link, Some(def), DUMMY_NODE_ID);
+                let module = self.new_module(parent_link, Some(def), None);
                 let _ = self.try_define(parent, name, TypeNS, (module, DUMMY_SP, vis));
             }
             Def::Variant(_, variant_id) => {
@@ -440,7 +440,7 @@ impl<'b> Resolver<'b> {
                 }
 
                 let parent_link = ModuleParentLink(parent, name);
-                let module = self.new_module(parent_link, Some(def), DUMMY_NODE_ID);
+                let module = self.new_module(parent_link, Some(def), None);
                 let _ = self.try_define(parent, name, TypeNS, (module, DUMMY_SP, vis));
             }
             Def::TyAlias(..) | Def::AssociatedTy(..) => {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3255,6 +3255,10 @@ impl<'a> Resolver<'a> {
         vis.is_accessible_from(self.current_module.normal_ancestor_id, self)
     }
 
+    fn is_accessible_from(&self, vis: ty::Visibility, module: Module<'a>) -> bool {
+        vis.is_accessible_from(module.normal_ancestor_id, self)
+    }
+
     fn report_privacy_errors(&self) {
         if self.privacy_errors.len() == 0 { return }
         let mut reported_spans = FnvHashSet();

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -885,10 +885,6 @@ impl<'a> NameBinding<'a> {
         }
     }
 
-    fn is_pseudo_public(&self) -> bool {
-        self.pseudo_vis() == ty::Visibility::Public
-    }
-
     // We sometimes need to treat variants as `pub` for backwards compatibility
     fn pseudo_vis(&self) -> ty::Visibility {
         if self.is_variant() { ty::Visibility::Public } else { self.vis }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1053,6 +1053,7 @@ pub struct Resolver<'a> {
 
     arenas: &'a ResolverArenas<'a>,
     dummy_binding: &'a NameBinding<'a>,
+    new_import_semantics: bool, // true if `#![feature(item_like_imports)]`
 }
 
 pub struct ResolverArenas<'a> {
@@ -1209,6 +1210,7 @@ impl<'a> Resolver<'a> {
                 span: DUMMY_SP,
                 vis: ty::Visibility::Public,
             }),
+            new_import_semantics: session.features.borrow().item_like_imports,
         }
     }
 

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -65,7 +65,7 @@ use syntax::ast::{Item, ItemKind, ImplItem, ImplItemKind};
 use syntax::ast::{Local, Mutability, Pat, PatKind, Path};
 use syntax::ast::{PathSegment, PathParameters, QSelf, TraitItemKind, TraitRef, Ty, TyKind};
 
-use syntax_pos::Span;
+use syntax_pos::{Span, DUMMY_SP};
 use errors::DiagnosticBuilder;
 
 use std::cell::{Cell, RefCell};
@@ -1052,6 +1052,7 @@ pub struct Resolver<'a> {
     privacy_errors: Vec<PrivacyError<'a>>,
 
     arenas: &'a ResolverArenas<'a>,
+    dummy_binding: &'a NameBinding<'a>,
 }
 
 pub struct ResolverArenas<'a> {
@@ -1203,6 +1204,11 @@ impl<'a> Resolver<'a> {
             privacy_errors: Vec::new(),
 
             arenas: arenas,
+            dummy_binding: arenas.alloc_name_binding(NameBinding {
+                kind: NameBindingKind::Def(Def::Err),
+                span: DUMMY_SP,
+                vis: ty::Visibility::Public,
+            }),
         }
     }
 

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -27,7 +27,7 @@ use rustc::hir::def::*;
 
 use syntax::ast::{NodeId, Name};
 use syntax::util::lev_distance::find_best_match_for_name;
-use syntax_pos::{Span, DUMMY_SP};
+use syntax_pos::Span;
 
 use std::cell::{Cell, RefCell};
 
@@ -442,13 +442,8 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
     // failed resolution
     fn import_dummy_binding(&mut self, directive: &'b ImportDirective<'b>) {
         if let SingleImport { target, .. } = directive.subclass {
-            let dummy_binding = self.arenas.alloc_name_binding(NameBinding {
-                kind: NameBindingKind::Def(Def::Err),
-                span: DUMMY_SP,
-                vis: ty::Visibility::Public,
-            });
+            let dummy_binding = self.dummy_binding;
             let dummy_binding = self.import(dummy_binding, directive);
-
             let _ = self.try_define(directive.parent, target, ValueNS, dummy_binding.clone());
             let _ = self.try_define(directive.parent, target, TypeNS, dummy_binding);
         }

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -460,7 +460,7 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
                 errors = true;
                 let (span, help) = match err {
                     Some((span, msg)) => (span, msg),
-                    None => (import.span, String::new()),
+                    None => continue,
                 };
 
                 // If the error is a single failed import then create a "fake" import

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -381,14 +381,6 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
     // remain or unsuccessfully when no forward progress in resolving imports
     // is made.
 
-    fn set_current_module(&mut self, module: Module<'b>) {
-        self.current_module = module;
-        self.current_vis = ty::Visibility::Restricted({
-            let normal_module = self.get_nearest_normal_module_parent_or_self(module);
-            self.definitions.as_local_node_id(normal_module.def_id().unwrap()).unwrap()
-        });
-    }
-
     /// Resolves all imports for the crate. This method performs the fixed-
     /// point iteration.
     fn resolve_imports(&mut self) {
@@ -472,7 +464,7 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
                names_to_string(&directive.module_path),
                module_to_string(self.current_module));
 
-        self.set_current_module(directive.parent);
+        self.current_module = directive.parent;
 
         let module = if let Some(module) = directive.imported_module.get() {
             module
@@ -548,7 +540,7 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
     }
 
     fn finalize_import(&mut self, directive: &'b ImportDirective<'b>) -> ResolveResult<()> {
-        self.set_current_module(directive.parent);
+        self.current_module = directive.parent;
 
         let ImportDirective { ref module_path, span, .. } = *directive;
         let module_result = self.resolve_module_path(&module_path, DontUseLexicalScope, Some(span));

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -324,7 +324,7 @@ impl<'a> Resolver<'a> {
     {
         // Ensure that `resolution` isn't borrowed when defining in the module's glob importers,
         // during which the resolution might end up getting re-defined via a glob cycle.
-        let (new_binding, t) = {
+        let (binding, t) = {
             let mut resolution = &mut *self.resolution(module, name, ns).borrow_mut();
             let was_known = resolution.binding().is_some();
 
@@ -337,10 +337,10 @@ impl<'a> Resolver<'a> {
             }
         };
 
-        // Define `new_binding` in `module`s glob importers.
-        if new_binding.vis == ty::Visibility::Public {
+        // Define `binding` in `module`s glob importers.
+        if binding.vis == ty::Visibility::Public {
             for directive in module.glob_importers.borrow_mut().iter() {
-                let imported_binding = self.import(new_binding, directive);
+                let imported_binding = self.import(binding, directive);
                 let _ = self.try_define(directive.parent, name, ns, imported_binding);
             }
         }

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -167,8 +167,10 @@ impl<'a> Resolver<'a> {
             _ => return Failed(None), // This happens when there is a cycle of imports
         };
 
+        let new_import_semantics = self.new_import_semantics;
         let is_disallowed_private_import = |binding: &NameBinding| {
-            !allow_private_imports && binding.vis != ty::Visibility::Public && binding.is_import()
+            !new_import_semantics && !allow_private_imports && // disallowed
+            binding.vis != ty::Visibility::Public && binding.is_import() // non-`pub` import
         };
 
         if let Some(span) = record_used {

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -55,6 +55,7 @@ pub enum ImportDirectiveSubclass<'a> {
     GlobImport {
         is_prelude: bool,
         max_vis: Cell<ty::Visibility>, // The visibility of the greatest reexport.
+        // n.b. `max_vis` is only used in `finalize_import` to check for reexport errors.
     },
 }
 

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -639,9 +639,9 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
         // Record what this import resolves to for later uses in documentation,
         // this may resolve to either a value or a type, but for documentation
         // purposes it's good enough to just favor one over the other.
-        let def = match type_result.ok().and_then(NameBinding::def) {
+        let def = match type_result.ok().map(NameBinding::def) {
             Some(def) => def,
-            None => value_result.ok().and_then(NameBinding::def).unwrap(),
+            None => value_result.ok().map(NameBinding::def).unwrap(),
         };
         let path_resolution = PathResolution::new(def);
         self.def_map.insert(directive.id, path_resolution);
@@ -714,9 +714,7 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
 
             if binding.vis == ty::Visibility::Public &&
                (binding.is_import() || binding.is_extern_crate()) {
-                if let Some(def) = binding.def() {
-                    reexports.push(Export { name: name, def_id: def.def_id() });
-                }
+                reexports.push(Export { name: name, def_id: binding.def().def_id() });
             }
 
             if let NameBindingKind::Import { binding: orig_binding, directive, .. } = binding.kind {

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -285,7 +285,10 @@ declare_features! (
 
     // Allows the sysV64 ABI to be specified on all platforms
     // instead of just the platforms on which it is the C ABI
-    (active, abi_sysv64, "1.13.0", Some(36167))
+    (active, abi_sysv64, "1.13.0", Some(36167)),
+
+    // Use the import semantics from RFC 1560.
+    (active, item_like_imports, "1.13.0", Some(35120))
 );
 
 declare_features! (

--- a/src/test/compile-fail/bad-module.rs
+++ b/src/test/compile-fail/bad-module.rs
@@ -8,6 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: failed to resolve. Use of undeclared type or module `thing`
+fn main() {
+    let foo = thing::len(Vec::new());
+    //~^ ERROR failed to resolve. Use of undeclared type or module `thing`
 
-fn main() { let foo = thing::len(Vec::new()); }
+    let foo = foo::bar::baz();
+    //~^ ERROR failed to resolve. Use of undeclared type or module `foo`
+}

--- a/src/test/compile-fail/imports/duplicate.rs
+++ b/src/test/compile-fail/imports/duplicate.rs
@@ -33,6 +33,20 @@ mod e {
     pub use c::*; // ok
 }
 
+mod f {
+    pub use a::*; //~ NOTE `foo` could resolve to the name imported here
+    pub use b::*; //~ NOTE `foo` could also resolve to the name imported here
+}
+
+mod g {
+    pub use a::*; //~ NOTE `foo` could resolve to the name imported here
+    pub use f::*; //~ NOTE `foo` could also resolve to the name imported here
+}
+
 fn main() {
     e::foo();
+    f::foo(); //~ ERROR `foo` is ambiguous
+              //~| NOTE Consider adding an explicit import of `foo` to disambiguate
+    g::foo(); //~ ERROR `foo` is ambiguous
+              //~| NOTE Consider adding an explicit import of `foo` to disambiguate
 }

--- a/src/test/compile-fail/imports/duplicate.rs
+++ b/src/test/compile-fail/imports/duplicate.rs
@@ -1,0 +1,38 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(item_like_imports)]
+
+mod a {
+    pub fn foo() {}
+}
+
+mod b {
+    pub fn foo() {}
+}
+
+mod c {
+    pub use a::foo;
+}
+
+mod d {
+    use a::foo; //~ NOTE previous import
+    use a::foo; //~ ERROR `foo` has already been imported
+                //~| NOTE already imported
+}
+
+mod e {
+    pub use a::*;
+    pub use c::*; // ok
+}
+
+fn main() {
+    e::foo();
+}

--- a/src/test/compile-fail/imports/duplicate.rs
+++ b/src/test/compile-fail/imports/duplicate.rs
@@ -56,7 +56,12 @@ mod ambiguous_module_errors {
     pub mod m2 { pub use super::m2 as foo; }
 
     use self::m1::*; //~ NOTE
+                     //~| NOTE
     use self::m2::*; //~ NOTE
+                     //~| NOTE
+
+    use self::foo::bar; //~ ERROR `foo` is ambiguous
+                        //~| NOTE
 
     fn f() {
         foo::bar(); //~ ERROR `foo` is ambiguous

--- a/src/test/compile-fail/imports/duplicate.rs
+++ b/src/test/compile-fail/imports/duplicate.rs
@@ -50,3 +50,16 @@ fn main() {
     g::foo(); //~ ERROR `foo` is ambiguous
               //~| NOTE Consider adding an explicit import of `foo` to disambiguate
 }
+
+mod ambiguous_module_errors {
+    pub mod m1 { pub use super::m1 as foo; }
+    pub mod m2 { pub use super::m2 as foo; }
+
+    use self::m1::*; //~ NOTE
+    use self::m2::*; //~ NOTE
+
+    fn f() {
+        foo::bar(); //~ ERROR `foo` is ambiguous
+                    //~| NOTE
+    }
+}

--- a/src/test/compile-fail/imports/reexports.rs
+++ b/src/test/compile-fail/imports/reexports.rs
@@ -1,0 +1,37 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(item_like_imports)]
+
+mod a {
+    fn foo() {}
+    mod foo {}
+
+    mod a {
+        pub use super::foo; //~ ERROR cannot be reexported
+    }
+}
+
+mod b {
+    pub fn foo() {}
+    mod foo { pub struct S; }
+
+    pub mod a {
+        pub use super::foo; // This is OK since the value `foo` is visible enough.
+        fn f(_: foo::S) {} // `foo` is imported in the type namespace (but not `pub` reexported).
+    }
+}
+
+mod c {
+    // Test that `foo` is not reexported.
+    use b::a::foo::S; //~ ERROR `foo`
+}
+
+fn main() {}

--- a/src/test/compile-fail/imports/reexports.rs
+++ b/src/test/compile-fail/imports/reexports.rs
@@ -16,6 +16,7 @@ mod a {
 
     mod a {
         pub use super::foo; //~ ERROR cannot be reexported
+        pub use super::*; //~ ERROR must import something with the glob's visibility
     }
 }
 
@@ -27,11 +28,17 @@ mod b {
         pub use super::foo; // This is OK since the value `foo` is visible enough.
         fn f(_: foo::S) {} // `foo` is imported in the type namespace (but not `pub` reexported).
     }
+
+    pub mod b {
+        pub use super::*; // This is also OK since the value `foo` is visible enough.
+        fn f(_: foo::S) {} // Again, the module `foo` is imported (but not `pub` reexported).
+    }
 }
 
 mod c {
     // Test that `foo` is not reexported.
     use b::a::foo::S; //~ ERROR `foo`
+    use b::b::foo::S as T; //~ ERROR `foo`
 }
 
 fn main() {}

--- a/src/test/compile-fail/task-rng-isnt-sendable.rs
+++ b/src/test/compile-fail/task-rng-isnt-sendable.rs
@@ -10,10 +10,10 @@
 
 // ensure that the ThreadRng isn't/doesn't become accidentally sendable.
 
-use std::rand; //~ ERROR: module `rand` is private
+use std::__rand::ThreadRng;
 
 fn test_send<S: Send>() {}
 
 pub fn main() {
-    test_send::<rand::ThreadRng>();
+    test_send::<ThreadRng>(); //~ ERROR std::marker::Send` is not satisfied
 }

--- a/src/test/run-pass/imports.rs
+++ b/src/test/run-pass/imports.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-pretty : (#23623) problems when ending with // comments
+
 #![feature(item_like_imports)]
 #![allow(unused)]
 

--- a/src/test/run-pass/imports.rs
+++ b/src/test/run-pass/imports.rs
@@ -63,4 +63,14 @@ mod c {
     }
 }
 
+// Unused names can be ambiguous.
+mod d {
+    pub use foo::*; // This imports `f` in the value namespace.
+    pub use bar::*; // This also imports `f` in the value namespace.
+}
+
+mod e {
+    pub use d::*; // n.b. Since `e::f` is not used, this is not considered to be a use of `d::f`.
+}
+
 fn main() {}

--- a/src/test/run-pass/imports.rs
+++ b/src/test/run-pass/imports.rs
@@ -1,0 +1,24 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(item_like_imports)]
+#![allow(unused)]
+
+// Like other items, private imports can be imported and used non-lexically in paths.
+mod a {
+    use a as foo;
+    use self::foo::foo as bar;
+
+    mod b {
+        use super::bar;
+    }
+}
+
+fn main() {}

--- a/src/test/run-pass/imports.rs
+++ b/src/test/run-pass/imports.rs
@@ -21,4 +21,46 @@ mod a {
     }
 }
 
+mod foo { pub fn f() {} }
+mod bar { pub fn f() {} }
+
+pub fn f() -> bool { true }
+
+// Items and explicit imports shadow globs.
+fn g() {
+    use foo::*;
+    use bar::*;
+    fn f() -> bool { true }
+    let _: bool = f();
+}
+
+fn h() {
+    use foo::*;
+    use bar::*;
+    use f;
+    let _: bool = f();
+}
+
+// Here, there appears to be shadowing but isn't because of namespaces.
+mod b {
+    use foo::*; // This imports `f` in the value namespace.
+    use super::b as f; // This imports `f` only in the type namespace,
+    fn test() { self::f(); } // so the glob isn't shadowed.
+}
+
+// Here, there is shadowing in one namespace, but not the other.
+mod c {
+    mod test {
+        pub fn f() {}
+        pub mod f {}
+    }
+    use self::test::*; // This glob-imports `f` in both namespaces.
+    mod f { pub fn f() {} } // This shadows the glob only in the value namespace.
+
+    fn test() {
+        self::f(); // Check that the glob-imported value isn't shadowed.
+        self::f::f(); // Check that the glob-imported module is shadowed.
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
This implements https://github.com/rust-lang/rfcs/pull/1560 (cc #35120) behind the `item_like_imports` feature gate.

The [RFC text](https://github.com/rust-lang/rfcs/blob/master/text/1560-name-resolution.md#changes-to-name-resolution-rules) describes the changes to name resolution enabled by `#![feature(item_like_imports)` in detail. To summarize,
- Items and named imports shadow glob imports.
- Multiple globs can import the same name if the name is unused or the imports are shadowed.
- Multiple globs can import the same name if the imports are of the same item (following re-exports).
  - The visibility of such a name is the maximum visibility of the imports.
  - Equivalently, adding a glob import will never reduce the visibility of a name, nor will removing one increase it.
- Non-prelude private imports can be used wherever we currently allow private items to be used.
  - Prelude-imported names are unaffected, i.e. they continue to be usable only in lexical scopes.
- Globs import all visible names, not just public names.
  - Equivalently, glob importing from an ancestor module imports all of the ancestor's names, and glob importing from other modules is unchanged.

r? @nrc 
