### PR TITLE
Do not report cast errors if an error had been previously detected

### DIFF
--- a/src/librustc_typeck/check/cast.rs
+++ b/src/librustc_typeck/check/cast.rs
@@ -302,7 +302,11 @@ impl<'a, 'gcx, 'tcx> CastCheck<'tcx> {
                 debug!(" -> {:?}", k);
                 fcx.tcx.cast_kinds.borrow_mut().insert(self.expr.id, k);
             }
-            Err(e) => self.report_cast_error(fcx, e)
+            Err(e) => {
+                if !fcx.inh.infcx.is_tainted_by_errors() {
+                    self.report_cast_error(fcx, e)
+                }
+            }
         };}
     }
 

--- a/src/test/compile-fail/issue-35772.rs
+++ b/src/test/compile-fail/issue-35772.rs
@@ -1,0 +1,14 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    error; //~ ERROR unresolved name `error`
+    1 as f32;
+}


### PR DESCRIPTION
If `InferCtxt` is tainted by errors, the result of `CastCheck::do_check` may fail even though the cast is valid. We don't want any wrong error messages in those cases so checking `is_tainted_by_errors()` before reporting cast errors.

Fixes #35772.
