### PR TITLE
Improve error message when failing to parse a block

### DIFF
--- a/src/test/compile-fail/missing-block-hint.rs
+++ b/src/test/compile-fail/missing-block-hint.rs
@@ -1,0 +1,20 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    {
+        if (foo) => {} //~ ERROR expected `{`, found `=>`
+    }
+    {
+        if (foo)
+            bar; //~ ERROR expected `{`, found `bar`
+                 //^ HELP try placing this code inside a block
+    }
+}


### PR DESCRIPTION
We want to catch this error:

```
if (foo)
    bar;
```

as it's valid syntax in other languages, and say how to fix it.
Unfortunately it didn't care if the suggestion made sense and just
highlighted the unexpected token.

Now it attempts to parse a statement, and if it succeeds, it shows the
help message.

Fixes #35907
