### PR TITLE
Updated code sample in chapter on syntax extensions.

### DIFF
--- a/src/doc/book/compiler-plugins.md
+++ b/src/doc/book/compiler-plugins.md
@@ -46,10 +46,10 @@ extern crate rustc;
 extern crate rustc_plugin;
 
 use syntax::parse::token;
-use syntax::ast::TokenTree;
+use syntax::tokenstream::TokenTree;
 use syntax::ext::base::{ExtCtxt, MacResult, DummyResult, MacEager};
 use syntax::ext::build::AstBuilder;  // trait for expr_usize
-use syntax_pos::Span;
+use syntax::ext::quote::rt::Span;
 use rustc_plugin::Registry;
 
 fn expand_rn(cx: &mut ExtCtxt, sp: Span, args: &[TokenTree])
@@ -69,7 +69,7 @@ fn expand_rn(cx: &mut ExtCtxt, sp: Span, args: &[TokenTree])
     }
 
     let text = match args[0] {
-        TokenTree::Token(_, token::Ident(s, _)) => s.to_string(),
+        TokenTree::Token(_, token::Ident(s)) => s.to_string(),
         _ => {
             cx.span_err(sp, "argument should be a single identifier");
             return DummyResult::any(sp);


### PR DESCRIPTION
The affected API apparently had changed with commit d59accfb065843d12db9180a4f504664e3d23ef1.

---

Further more I had to add

``` toml
[lib]
name = "roman_numerals"
crate-type = ["dylib"]
```

to `Cargo.toml` as I otherwise got this compiler error (despite `#![crate_type="dylib"]`):

```
[E0457]: plugin `roman_numerals` only found in rlib format, but must be available in dylib format
```

Might be worth adding a note about that?
