### PR TITLE
Create ISSUE_TEMPLATE

### DIFF
--- a/ISSUE_TEMPLATE
+++ b/ISSUE_TEMPLATE
@@ -1,0 +1,15 @@
+<short summary of the bug>
+
+I tried this code:
+
+<code sample that causes the bug>
+
+I expected to see this happen: <explanation>
+
+Instead, this happened: <explanation>
+
+## Meta
+
+`rustc --version --verbose`:
+
+Backtrace:


### PR DESCRIPTION
I was about to add a compiler error issue, but found no GitHub issue template!
To make it easier for people to use the issue template in CONTRIBUTING.md,
i added it to the ISSUE_TEMPLATE file which GitHub uses to pre-populate a new issue.
