### PR TITLE
Don't allow underflow when calculating spans

### DIFF
--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -549,7 +549,8 @@ impl Sub for BytePos {
     type Output = BytePos;
 
     fn sub(self, rhs: BytePos) -> BytePos {
-        BytePos((self.to_usize() - rhs.to_usize()) as u32)
+        let new_pos = self.to_usize().checked_sub(rhs.to_usize()).unwrap_or(0);
+        BytePos(new_post as u32)
     }
 }
 

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -549,7 +549,7 @@ impl Sub for BytePos {
     type Output = BytePos;
 
     fn sub(self, rhs: BytePos) -> BytePos {
-        let new_pos = self.to_usize().checked_sub(rhs.to_usize()).unwrap_or(0);
+        let new_pos = self.to_usize().saturating_sub(rhs.to_usize());
         BytePos(new_post as u32)
     }
 }

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -550,7 +550,7 @@ impl Sub for BytePos {
 
     fn sub(self, rhs: BytePos) -> BytePos {
         let new_pos = self.to_usize().saturating_sub(rhs.to_usize());
-        BytePos(new_post as u32)
+        BytePos(new_pos as u32)
     }
 }
 


### PR DESCRIPTION
This subtraction can take place when doing things like creating a [field
access expression through the AST builder](https://github.com/rust-lang/rust/blob/a5e5ea1646367b82864af3a2a508993d76b792af/src/libsyntax/ext/build.rs#L636-L645) (and in
fact, as best I can tell, that's the only place it occurs)

The assumption is that the given span starts and ends a the last byte of
the field access. However, when doing macro expansion such as custom
derive (or any other place the AST builder would manually be used), it's
quite common to use the site of expansion as the span, as there's no
other printable span to show. If that macro expansion is the first line
of a file, the compiler will panic from underflow.

Since byte positions are unsized, and performing this subtraction in a
situation for underflow pretty much universally means you want to remain
at 0, I've fixed this in the sub impl rather than the two problem cases
of the AST builder.
