### PR TITLE
rustc_borrowck: Don't hash types in loan paths

### DIFF
--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -41,6 +41,7 @@ use rustc::ty::{self, TyCtxt};
 use std::fmt;
 use std::mem;
 use std::rc::Rc;
+use std::hash::{Hash, Hasher};
 use syntax::ast;
 use syntax::attr::AttrMetaMethods;
 use syntax_pos::{MultiSpan, Span};
@@ -345,7 +346,7 @@ impl<'tcx> Loan<'tcx> {
     }
 }
 
-#[derive(Eq, Hash)]
+#[derive(Eq)]
 pub struct LoanPath<'tcx> {
     kind: LoanPathKind<'tcx>,
     ty: ty::Ty<'tcx>,
@@ -353,10 +354,13 @@ pub struct LoanPath<'tcx> {
 
 impl<'tcx> PartialEq for LoanPath<'tcx> {
     fn eq(&self, that: &LoanPath<'tcx>) -> bool {
-        let r = self.kind == that.kind;
-        debug_assert!(self.ty == that.ty || !r,
-                      "Somehow loan paths are equal though their tys are not.");
-        r
+        self.kind == that.kind
+    }
+}
+
+impl<'tcx> Hash for LoanPath<'tcx> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.kind.hash(state);
     }
 }
 


### PR DESCRIPTION
1) Types for equal loan paths are not always equal, they can sometimes differ in lifetimes, making equal loan paths hash differently.

Example:
https://github.com/rust-lang/rust/blob/71bdeea561355ba5adbc9a1f44f4f866a75a15c4/src/libcollections/linked_list.rs#L835-L856

One of `self.list`s has type

```
&ReFree(CodeExtent(15013/CallSiteScope { fn_id: 18907, body_id: 18912 }), BrNamed(0:DefIndex(3066), 'a(397), WontChange)) mut linked_list::LinkedList<T>
```

and other has type

```
&ReScope(CodeExtent(15018/Remainder(BlockRemainder { block: 18912, first_statement_index: 0 }))) mut linked_list::LinkedList<T>
```

(... but I'm not sure it's not a bug actually.)

2) Not hashing types is faster than hashing types.

r? @arielb1 
