### PR TITLE
rustbuild: skip filecheck check if codegen tests are disabled

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -78,6 +78,7 @@ pub struct Config {
     pub channel: String,
     pub musl_root: Option<PathBuf>,
     pub prefix: Option<String>,
+    pub codegen_tests: bool,
 }
 
 /// Per-target configuration stored in the global configuration structure.
@@ -169,6 +170,7 @@ impl Config {
         config.rust_codegen_units = 1;
         config.build = build.to_string();
         config.channel = "dev".to_string();
+        config.codegen_tests = true;
 
         let toml = file.map(|file| {
             let mut f = t!(File::open(&file));
@@ -322,6 +324,7 @@ impl Config {
                 ("DEBUGINFO_TESTS", self.rust_debuginfo_tests),
                 ("LOCAL_REBUILD", self.local_rebuild),
                 ("NINJA", self.ninja),
+                ("CODEGEN_TESTS", self.codegen_tests),
             }
 
             match key {

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -390,8 +390,10 @@ impl Build {
                                        "mir-opt", "mir-opt");
                 }
                 CheckCodegen { compiler } => {
-                    check::compiletest(self, &compiler, target.target,
-                                       "codegen", "codegen");
+                    if self.config.codegen_tests {
+                        check::compiletest(self, &compiler, target.target,
+                                           "codegen", "codegen");
+                    }
                 }
                 CheckCodegenUnits { compiler } => {
                     check::compiletest(self, &compiler, target.target,

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -89,7 +89,7 @@ pub fn check(build: &mut Build) {
 
     // Externally configured LLVM requires FileCheck to exist
     let filecheck = build.llvm_filecheck(&build.config.build);
-    if !filecheck.starts_with(&build.out) && !filecheck.exists() {
+    if !filecheck.starts_with(&build.out) && !filecheck.exists() && build.config.codegen_tests {
         panic!("filecheck executable {:?} does not exist", filecheck);
     }
 


### PR DESCRIPTION
to match the behavior of the old Makefile-based build system

closes #35752

r? @alexcrichton 
