### PR TITLE
Update E0194 to new error format

### DIFF
--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -658,7 +658,9 @@ fn error_392<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>, span: Span, param_name: ast::N
 }
 
 fn error_194(tcx: TyCtxt, span: Span, name: ast::Name) {
-    span_err!(tcx.sess, span, E0194,
+    struct_span_err!(tcx.sess, span, E0194,
               "type parameter `{}` shadows another type parameter of the same name",
-              name);
+              name)
+        .span_label(span, &format!("`{}` shadows another type parameter", name))
+        .emit();
 }

--- a/src/test/compile-fail/E0194.rs
+++ b/src/test/compile-fail/E0194.rs
@@ -10,7 +10,9 @@
 
 trait Foo<T> {
     fn do_something(&self) -> T;
-    fn do_something_else<T: Clone>(&self, bar: T); //~ ERROR E0194
+    fn do_something_else<T: Clone>(&self, bar: T);
+    //~^ ERROR E0194
+    //~| NOTE `T` shadows another type parameter
 }
 
 fn main() {


### PR DESCRIPTION
Fixes #35280 to update E0194 to support new error message format. Part of #35233.

A separate Github issue #36057 tracks the bonus portion of the original ticket.

r? @jonathandturner 
