### PR TITLE
Really avoid redundant downloads when bootstrapping

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -26,11 +26,15 @@ def get(url, path, verbose=False):
     sha_url = url + ".sha256"
     with tempfile.NamedTemporaryFile(delete=False) as temp_file:
         temp_path = temp_file.name
-    with tempfile.NamedTemporaryFile(suffix=".sha256", delete=False) as sha_file:
-        sha_path = sha_file.name
+    if os.path.exists(path + ".sha256"):
+        sha_path = path + ".sha256"
+    else:
+        with tempfile.NamedTemporaryFile(suffix=".sha256", delete=False) as sha_file:
+            sha_path = sha_file.name
 
     try:
-        download(sha_path, sha_url, verbose)
+        if not os.path.exists(path + ".sha256"):
+            download(sha_path, sha_url, verbose)
         if os.path.exists(path):
             if verify(path, sha_path, False):
                 print("using already-download file " + path)


### PR DESCRIPTION
Follow-up fix of ab5309e9e8467508766aee176dc121672d606524

This also fixes packaging for source distros that don't allow
fetching during build-time, which was unconditionally done for
the sha256 file.
