### PR TITLE
Update E0393 to new error format

### DIFF
--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -515,12 +515,13 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
                 // defaults. This will lead to an ICE if we are not
                 // careful!
                 if default_needs_object_self(def) {
-                    span_err!(tcx.sess, span, E0393,
-                              "the type parameter `{}` must be explicitly specified \
-                               in an object type because its default value `{}` references \
-                               the type `Self`",
-                              def.name,
-                              default);
+                    struct_span_err!(tcx.sess, span, E0393,
+                                     "the type parameter `{}` must be explicitly specified",
+                                     def.name)
+                        .span_label(span, &format!("missing reference to `{}`", def.name))
+                        .note(&format!("because of the default `Self` reference, \
+                                        type parameters must be specified on object types"))
+                        .emit();
                     tcx.types.err
                 } else {
                     // This is a default type parameter.

--- a/src/test/compile-fail/E0393.rs
+++ b/src/test/compile-fail/E0393.rs
@@ -10,7 +10,10 @@
 
 trait A<T=Self> {}
 
-fn together_we_will_rule_the_galaxy(son: &A) {} //~ ERROR E0393
+fn together_we_will_rule_the_galaxy(son: &A) {}
+//~^ ERROR E0393
+//~| NOTE missing reference to `T`
+//~| NOTE because of the default `Self` reference, type parameters must be specified on object types
 
 fn main() {
 }

--- a/src/test/compile-fail/issue-21950.rs
+++ b/src/test/compile-fail/issue-21950.rs
@@ -15,6 +15,9 @@ use std::ops::Add;
 fn main() {
     let x = &10 as
             &Add;
-            //~^ ERROR the type parameter `RHS` must be explicitly specified in an object type because its default value `Self` references the type `Self`
-            //~| ERROR the value of the associated type `Output` (from the trait `std::ops::Add`) must be specified
+            //~^ ERROR E0393
+            //~| NOTE missing reference to `RHS`
+            //~| NOTE because of the default `Self` reference, type parameters must be specified on object types
+            //~| ERROR E0191
+            //~| NOTE missing associated type `Output` value
 }

--- a/src/test/compile-fail/issue-22370.rs
+++ b/src/test/compile-fail/issue-22370.rs
@@ -13,6 +13,8 @@
 trait A<T=Self> {}
 
 fn f(a: &A) {}
-//~^ ERROR the type parameter `T` must be explicitly specified in an object type because its default value `Self` references the type `Self`
+//~^ ERROR E0393
+//~| NOTE missing reference to `T`
+//~| NOTE because of the default `Self` reference, type parameters must be specified on object types
 
 fn main() {}

--- a/src/test/compile-fail/issue-22560.rs
+++ b/src/test/compile-fail/issue-22560.rs
@@ -13,9 +13,13 @@
 use std::ops::{Add, Sub};
 
 type Test = Add +
-            //~^ ERROR the type parameter `RHS` must be explicitly specified in an object type because its default value `Self` references the type `Self`
-            //~^^ ERROR the value of the associated type `Output` (from the trait `std::ops::Add`) must be specified [E0191]
+            //~^ ERROR E0393
+            //~| NOTE missing reference to `RHS`
+            //~| NOTE because of the default `Self` reference, type parameters must be specified on object types
+            //~| ERROR E0191
+            //~| NOTE missing associated type `Output` value
             Sub;
-            //~^ ERROR only the builtin traits can be used as closure or object bounds
+            //~^ ERROR E0225
+            //~| NOTE non-builtin trait used as bounds
 
 fn main() { }


### PR DESCRIPTION
Fixes #35632.
Part of #35233.

r? @jonathandturner

and a wired thing is that if i add another label

``` rust
.span_label(span, &format!("missing reference to `{}`", def.name))
.span_label(span, &format!("because of the default `Self` reference, type parameters must be specified on object types"))
```

and add a new note in the test case like 

``` rust
trait A<T=Self> {}

fn together_we_will_rule_the_galaxy(son: &A) {}
//~^ ERROR E0393
//~| NOTE missing reference to `T`
//~| NOTE because of the default `Self` reference, type parameters must be specified on object types
```

it will complain that 

```
running 1 test
test [compile-fail] compile-fail/E0393.rs ... FAILED

failures:

---- [compile-fail] compile-fail/E0393.rs stdout ----

error: /Users/zjh/Documents/rustspace/rust/src/test/compile-fail/E0393.rs:13: unexpected "error": '13:43: 13:44: the type parameter `T` must be explicitly specified [E0393]'

unexpected errors (from JSON output): [
    Error {
        line_num: 13,
        kind: Some(
            Error
        ),
        msg: "13:43: 13:44: the type parameter `T` must be explicitly specified [E0393]"
    }
]
```

it is a little bit confusing and through the blog post we can use `//~^` and `//~|` to support multiple notes, @jonathandturner am i missing something here?
