### PR TITLE
llvm: backport "[SimplifyCFG] Hoisting invalidates metadata".

### DIFF
--- a/src/rustllvm/llvm-auto-clean-trigger
+++ b/src/rustllvm/llvm-auto-clean-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be forcibly cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2016-08-17
+2016-08-23

--- a/src/test/run-pass/issue-36023.rs
+++ b/src/test/run-pass/issue-36023.rs
@@ -1,0 +1,32 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::ops::Deref;
+
+fn main() {
+    if env_var("FOOBAR").as_ref().map(Deref::deref).ok() == Some("yes") {
+        panic!()
+    }
+
+    let env_home: Result<String, ()> = Ok("foo-bar-baz".to_string());
+    let env_home = env_home.as_ref().map(Deref::deref).ok();
+
+    if env_home == Some("") { panic!() }
+}
+
+#[inline(never)]
+fn env_var(s: &str) -> Result<String, VarError> {
+    Err(VarError::NotPresent)
+}
+
+pub enum VarError {
+    NotPresent,
+    NotUnicode(String),
+}


### PR DESCRIPTION
Fixes #36023 by backporting @majnemer's LLVM patch fixing [the LLVM bug](https://llvm.org/bugs/show_bug.cgi?id=29163.) where SimplifyCFG hoisted instructions andkept their metadata (conditional `!nonnull` loads could kill a null check later if hoisted).

r? @alexcrichton
