### PR TITLE
Fix optimization regressions for operations on [x; n]-initialized arrays.

### DIFF
--- a/src/librustc_trans/tvec.rs
+++ b/src/librustc_trans/tvec.rs
@@ -52,7 +52,7 @@ pub fn slice_for_each<'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
     let current = Phi(header_bcx, val_ty(start), &[start], &[bcx.llbb]);
 
     let keep_going =
-        ICmp(header_bcx, llvm::IntULT, current, end, DebugLoc::None);
+        ICmp(header_bcx, llvm::IntNE, current, end, DebugLoc::None);
     CondBr(header_bcx, keep_going, body_bcx.llbb, next_bcx.llbb, DebugLoc::None);
 
     let body_bcx = f(body_bcx, if zst { data_ptr } else { current });

--- a/src/rustllvm/llvm-auto-clean-trigger
+++ b/src/rustllvm/llvm-auto-clean-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be forcibly cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2016-08-23
+2016-08-30


### PR DESCRIPTION
Fixes #35662 by using `!=` instead of `<` as the stop condition for `[x; n]` initialization loops.
Also included is https://github.com/eddyb/llvm/commit/cc2009f02d3b9a3c05be939978212e832310b3d6, a hack to run the GVN pass twice, another time after InstCombine.
This hack results in removal of redundant `memset` and `memcpy` calls (from loops over arrays).

cc @nrc Can we get performance numbers on this? Not sure if it regresses anything else.
