### PR TITLE
Improve performance of str::to_lowercase and str::to_uppercase

### DIFF
--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -1634,18 +1634,40 @@ impl str {
     #[stable(feature = "unicode_case_mapping", since = "1.2.0")]
     pub fn to_lowercase(&self) -> String {
         let mut s = String::with_capacity(self.len());
-        for (i, c) in self[..].char_indices() {
-            if c == 'Σ' {
-                // Σ maps to σ, except at the end of a word where it maps to ς.
-                // This is the only conditional (contextual) but language-independent mapping
-                // in `SpecialCasing.txt`,
-                // so hard-code it rather than have a generic "condition" mechanism.
-                // See https://github.com/rust-lang/rust/issues/26035
-                map_uppercase_sigma(self, i, &mut s)
-            } else {
-                s.extend(c.to_lowercase());
+        let mut left = None;
+
+        // Try to collect slices of lower case characters to push into the
+        // result or extend with the lower case version if an upper case
+        // character is found.
+        for (i, ch) in self.char_indices() {
+            if ch.is_uppercase() {
+                if let Some(offset) = left.take() {
+                    s.push_str(&self[offset..i]);
+                }
+
+                if ch == 'Σ' {
+                    // Σ maps to σ, except at the end of a word where it maps to ς.
+                    // This is the only conditional (contextual) but language-independent mapping
+                    // in `SpecialCasing.txt`,
+                    // so hard-code it rather than have a generic "condition" mechanism.
+                    // See https://github.com/rust-lang/rust/issues/26035
+
+                    map_uppercase_sigma(self, i, &mut s);
+                }
+                else {
+                    s.extend(ch.to_lowercase());
+                }
+            }
+            else if left.is_none() {
+                left = Some(i);
             }
         }
+
+        // Append any leftover upper case characters.
+        if let Some(offset) = left.take() {
+            s.push_str(&self[offset..]);
+        }
+
         return s;
 
         fn map_uppercase_sigma(from: &str, i: usize, to: &mut String) {
@@ -1653,11 +1675,12 @@ impl str {
             // for the definition of `Final_Sigma`.
             debug_assert!('Σ'.len_utf8() == 2);
             let is_word_final = case_ignoreable_then_cased(from[..i].chars().rev()) &&
-                                !case_ignoreable_then_cased(from[i + 2..].chars());
-            to.push_str(if is_word_final {
-                "ς"
+                               !case_ignoreable_then_cased(from[i + 2..].chars());
+
+            to.push(if is_word_final {
+                'ς'
             } else {
-                "σ"
+                'σ'
             });
         }
 
@@ -1697,7 +1720,29 @@ impl str {
     #[stable(feature = "unicode_case_mapping", since = "1.2.0")]
     pub fn to_uppercase(&self) -> String {
         let mut s = String::with_capacity(self.len());
-        s.extend(self.chars().flat_map(|c| c.to_uppercase()));
+        let mut left = None;
+
+        // Try to collect slices of upper case characters to push into the
+        // result or extend with the upper case version if a lower case
+        // character is found.
+        for (i, ch) in self.char_indices() {
+            if ch.is_lowercase() {
+                if let Some(offset) = left.take() {
+                    s.push_str(&self[offset..i]);
+                }
+
+                s.extend(ch.to_uppercase());
+            }
+            else if left.is_none() {
+                left = Some(i);
+            }
+        }
+
+        // Append any leftover upper case characters.
+        if let Some(offset) = left.take() {
+            s.push_str(&self[offset..]);
+        }
+
         return s;
     }
 

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -1640,7 +1640,7 @@ impl str {
         // result or extend with the lower case version if an upper case
         // character is found.
         for (i, ch) in self.char_indices() {
-            if ch.is_uppercase() {
+            if !ch.is_lowercase() {
                 if let Some(offset) = left.take() {
                     s.push_str(&self[offset..i]);
                 }
@@ -1726,7 +1726,7 @@ impl str {
         // result or extend with the upper case version if a lower case
         // character is found.
         for (i, ch) in self.char_indices() {
-            if ch.is_lowercase() {
+            if !ch.is_uppercase() {
                 if let Some(offset) = left.take() {
                     s.push_str(&self[offset..i]);
                 }

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -1640,7 +1640,7 @@ impl str {
         // result or extend with the lower case version if an upper case
         // character is found.
         for (i, ch) in self.char_indices() {
-            if !ch.is_lowercase() {
+            if !ch.is_lowercase() && ch.is_alphabetic() {
                 if let Some(offset) = left.take() {
                     s.push_str(&self[offset..i]);
                 }
@@ -1726,7 +1726,7 @@ impl str {
         // result or extend with the upper case version if a lower case
         // character is found.
         for (i, ch) in self.char_indices() {
-            if !ch.is_uppercase() {
+            if !ch.is_uppercase() && ch.is_alphabetic() {
                 if let Some(offset) = left.take() {
                     s.push_str(&self[offset..i]);
                 }


### PR DESCRIPTION
I was working on a crate to handle string casing and it seems the `to_lowercase` and `to_uppercase` implementations I came up with (excluding the fact the stuff in my crate returns `Cow<Self>`) is faster than the one in libstd in most cases, and a little slower in the worst case (i.e. all uppercase when calling `to_lowercase` or the other way around).

I ran the libstd tests and it was all green locally, but it doesn't look like there any test cases for these two functions, unless I'm blind :panda_face:  

Below are the benchmarks (which probably aren't testing any real world scenario cases) I ran locally, and the code to run them.

```
test lower_new_best     ... bench:         208 ns/iter (+/- 14)
test lower_new_mixed    ... bench:       1,216 ns/iter (+/- 77)
test lower_new_unicode  ... bench:         644 ns/iter (+/- 49)
test lower_new_unicode2 ... bench:       1,642 ns/iter (+/- 218)
test lower_new_worst    ... bench:       1,821 ns/iter (+/- 149)
test lower_std_best     ... bench:       1,840 ns/iter (+/- 263)
test lower_std_mixed    ... bench:       1,808 ns/iter (+/- 256)
test lower_std_unicode  ... bench:       1,941 ns/iter (+/- 106)
test lower_std_unicode2 ... bench:       1,918 ns/iter (+/- 94)
test lower_std_worst    ... bench:       1,798 ns/iter (+/- 143)
test upper_new_best     ... bench:         231 ns/iter (+/- 47)
test upper_new_mixed    ... bench:       1,206 ns/iter (+/- 65)
test upper_new_unicode  ... bench:         724 ns/iter (+/- 164)
test upper_new_unicode2 ... bench:       1,566 ns/iter (+/- 128)
test upper_new_worst    ... bench:       1,838 ns/iter (+/- 120)
test upper_std_best     ... bench:       1,669 ns/iter (+/- 155)
test upper_std_mixed    ... bench:       1,720 ns/iter (+/- 166)
test upper_std_unicode  ... bench:       1,820 ns/iter (+/- 133)
test upper_std_unicode2 ... bench:       1,797 ns/iter (+/- 146)
test upper_std_worst    ... bench:       1,669 ns/iter (+/- 110)
```

``` rust
#![feature(test, unicode)]
extern crate test;
use test::Bencher;

extern crate rustc_unicode;

fn main() {
    println!("Hello, world!");
}

fn to_uppercase(this: &str) -> String {
    let mut s = String::with_capacity(this.len());
    let mut left = None;

    // Try to collect slices of upper case characters to push into the
    // result or extend with the upper case version if a lower case
    // character is found.
    for (i, ch) in this.char_indices() {
        if ch.is_lowercase() {
            if let Some(offset) = left.take() {
                s.push_str(&this[offset..i]);
            }

            s.extend(ch.to_uppercase());
        }
        else if left.is_none() {
            left = Some(i);
        }
    }

    // Append any leftover upper case characters.
    if let Some(offset) = left.take() {
        s.push_str(&this[offset..]);
    }

    s
}

fn to_lowercase(this: &str) -> String {
    let mut s = String::with_capacity(this.len());
    let mut left = None;

    // Try to collect slices of lower case characters to push into the
    // result or extend with the lower case version if an upper case
    // character is found.
    for (i, ch) in this.char_indices() {
        if ch.is_uppercase() {
            if let Some(offset) = left.take() {
                s.push_str(&this[offset..i]);
            }

            if ch == 'Σ' {
                // Σ maps to σ, except at the end of a word where it maps to ς.
                // This is the only conditional (contextual) but language-independent mapping
                // in `SpecialCasing.txt`,
                // so hard-code it rather than have a generic "condition" mechanism.
                // See https://github.com/rust-lang/rust/issues/26035

                map_uppercase_sigma(this, i, &mut s);
            }
            else {
                s.extend(ch.to_lowercase());
            }
        }
        else if left.is_none() {
            left = Some(i);
        }
    }

    // Append any leftover upper case characters.
    if let Some(offset) = left.take() {
        s.push_str(&this[offset..]);
    }

    return s;

    fn map_uppercase_sigma(from: &str, i: usize, to: &mut String) {
        // See http://www.unicode.org/versions/Unicode7.0.0/ch03.pdf#G33992
        // for the definition of `Final_Sigma`.
        debug_assert!('Σ'.len_utf8() == 2);
        let is_word_final = case_ignoreable_then_cased(from[..i].chars().rev()) &&
                           !case_ignoreable_then_cased(from[i + 2..].chars());

        to.push(if is_word_final {
                'ς'
        } else {
                'σ'
        });
    }

    fn case_ignoreable_then_cased<I: Iterator<Item = char>>(iter: I) -> bool {
        use rustc_unicode::derived_property::{Cased, Case_Ignorable};
        match iter.skip_while(|&c| Case_Ignorable(c)).next() {
            Some(c) => Cased(c),
            None => false,
        }
    }
}

#[bench]
fn upper_new_worst(b: &mut Bencher) {
    b.iter(|| to_uppercase("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
}

#[bench]
fn upper_new_mixed(b: &mut Bencher) {
    b.iter(|| to_uppercase("AAAaaaaaaaaaaaaAAAAAAAAAaaaaAaaaAAAAaaaaAAaaaaaaaAAAAaaaaa"));
}

#[bench]
fn upper_new_best(b: &mut Bencher) {
    b.iter(|| to_uppercase("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
}

#[bench]
fn upper_new_unicode(b: &mut Bencher) {
    b.iter(|| to_uppercase("AAAßAAAAðAAAAAAæææææAAßAAððððAAAAAAAAAæAÆæAAAAAAAAAAAAAAAA"));
}

#[bench]
fn upper_new_unicode2(b: &mut Bencher) {
    b.iter(|| to_uppercase("aaaßaaaaÐaaaaaaÆÆÆÆÆaaßaaÐÐÐÐaaaaaaaaaÆaæÆaaaaaaaaaaaaaaaa"));
}

#[bench]
fn upper_std_worst(b: &mut Bencher) {
    b.iter(|| "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_uppercase());
}

#[bench]
fn upper_std_mixed(b: &mut Bencher) {
    b.iter(|| "AAAaaaaaaaaaaaaAAAAAAAAAaaaaAaaaAAAAaaaaAAaaaaaaaAAAAaaaaa".to_uppercase());
}

#[bench]
fn upper_std_unicode(b: &mut Bencher) {
    b.iter(|| "AAAßAAAAðAAAAAAæææææAAßAAððððAAAAAAAAAæAÆæAAAAAAAAAAAAAAAA".to_uppercase());
}

#[bench]
fn upper_std_unicode2(b: &mut Bencher) {
    b.iter(|| "aaaßaaaaÐaaaaaaÆÆÆÆÆaaßaaÐÐÐÐaaaaaaaaaÆaæÆaaaaaaaaaaaaaaaa".to_uppercase());
}

#[bench]
fn upper_std_best(b: &mut Bencher) {
    b.iter(|| "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_uppercase());
}

#[bench]
fn lower_new_worst(b: &mut Bencher) {
    b.iter(|| to_lowercase("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
}

#[bench]
fn lower_new_mixed(b: &mut Bencher) {
    b.iter(|| to_lowercase("aaaAAAAAAAAAAAAaaaaaaaaaAAAAaAAAaaaaAAAAaaAAAAAAAaaaaAAAAA"));
}

#[bench]
fn lower_new_best(b: &mut Bencher) {
    b.iter(|| to_lowercase("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
}

#[bench]
fn lower_new_unicode(b: &mut Bencher) {
    b.iter(|| to_lowercase("aaaßaaaaÐaaaaaaÆÆÆÆÆaaßaaÐÐÐÐaaaaaaaaaÆaæÆaaaaaaaaaaaaaaaa"));
}

#[bench]
fn lower_new_unicode2(b: &mut Bencher) {
    b.iter(|| to_lowercase("AAAÐªAAAAðAAAAAAæææææAAßAAððððAAAAAAAAAÆAÆÆAAAAAAAAAAAAAAAA"));
}

#[bench]
fn lower_std_worst(b: &mut Bencher) {
    b.iter(|| "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_lowercase());
}

#[bench]
fn lower_std_mixed(b: &mut Bencher) {
    b.iter(|| "aaaAAAAAAAAAAAAaaaaaaaaaAAAAaAAAaaaaAAAAaaAAAAAAAaaaaAAAAA".to_lowercase());
}

#[bench]
fn lower_std_unicode(b: &mut Bencher) {
    b.iter(|| "aaaßaaaaÐaaaaaaÆÆÆÆÆaaßaaÐÐÐÐaaaaaaaaaÆaæÆaaaaaaaaaaaaaaaa".to_lowercase());
}

#[bench]
fn lower_std_unicode2(b: &mut Bencher) {
    b.iter(|| "AAAÐªAAAAðAAAAAAæææææAAßAAððððAAAAAAAAAÆAÆÆAAAAAAAAAAAAAAAA".to_lowercase());
}

#[bench]
fn lower_std_best(b: &mut Bencher) {
    b.iter(|| "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_lowercase());
}
```
