### PR TITLE
Fix run-pass/signal-exit-status to not trigger UB by writing to NULL.

### DIFF
--- a/src/test/run-pass/signal-exit-status.rs
+++ b/src/test/run-pass/signal-exit-status.rs
@@ -18,7 +18,7 @@ pub fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() >= 2 && args[1] == "signal" {
         // Raise a segfault.
-        unsafe { *(0 as *mut isize) = 0; }
+        unsafe { *(1 as *mut isize) = 0; }
     } else {
         let status = Command::new(&args[0]).arg("signal").status().unwrap();
         assert!(status.code().is_none());


### PR DESCRIPTION
`run-pass/signal-exit-status` has had UB (NULL dereference) since it was introduced in #10109.
Fixes the test failure found by @camlorn while running under Windows Subsystem for Linux.
