### PR TITLE
Improve Option::cloned method to allow mutable references

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -141,6 +141,7 @@
 
 use iter::{FromIterator, FusedIterator};
 use mem;
+use ops::Deref;
 
 // Note that this is not a lang item per se, but it has a hidden dependency on
 // `Iterator`, which is one. The compiler assumes that the `next` method of
@@ -642,7 +643,7 @@ impl<T> Option<T> {
     }
 }
 
-impl<'a, T: Clone> Option<&'a T> {
+impl<T: Clone, D: Deref<Target = T>> Option<D> {
     /// Maps an `Option<&T>` to an `Option<T>` by cloning the contents of the
     /// option.
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcoretest/option.rs
+++ b/src/libcoretest/option.rs
@@ -254,6 +254,8 @@ fn test_cloned() {
     let val = 1;
     let val_ref = &val;
     let opt_none: Option<&'static u32> = None;
+    let mut opt_mut = Some(val);
+    let opt_box: Option<Box<u32>> = Some(Box::new(val));
     let opt_ref = Some(&val);
     let opt_ref_ref = Some(&val_ref);
 
@@ -269,4 +271,10 @@ fn test_cloned() {
     assert_eq!(opt_ref_ref.clone(), Some(&val_ref));
     assert_eq!(opt_ref_ref.clone().cloned(), Some(&val));
     assert_eq!(opt_ref_ref.cloned().cloned(), Some(1));
+
+    // Mutable ref works
+    assert_eq!(opt_mut.as_mut().cloned(), Some(1));
+
+    // Deep Deref works
+    assert_eq!(opt_box.cloned(), Some(1));
 }


### PR DESCRIPTION
Old behavior:

``` rust
--> main.rs:7:17
  |
7 |     Option::cloned(u.as_mut());
  |                    ^^^^^^^^^^ values differ in mutability
  |
  = note: expected type `std::option::Option<&_>`
  = note:    found type `std::option::Option<&mut U>`

--> main.rs:8:17
  |
8 |     Option::cloned(None::<Box<U>>);
  |                    ^^^^^^^^^^^^^^ expected reference, found box
  |
  = note: expected type `std::option::Option<&_>`
  = note:    found type `std::option::Option<Box<U>>`
```

This PR makes possible to use options with mutable references or boxes:

``` rust
fn main() {
    // Works
    let val = 1;
    let val_ref = &val;
    let opt_none: Option<&'static u32> = None;
    let opt_ref = Some(&val);
    let opt_ref_ref = Some(&val_ref);
    assert_eq!(opt_none.clone(), None);
    assert_eq!(opt_none.cloned(), None);
    assert_eq!(opt_ref.clone(), Some(&val));
    assert_eq!(opt_ref.cloned(), Some(1));
    assert_eq!(opt_ref_ref.clone(), Some(&val_ref));
    assert_eq!(opt_ref_ref.clone().cloned(), Some(&val));
    assert_eq!(opt_ref_ref.cloned().cloned(), Some(1));

    // Didn't work before
    let mut opt_mut = Some(val);
    let opt_box: Option<Box<u32>> = Some(Box::new(val));
    assert_eq!(opt_mut.as_mut().cloned(), Some(1));
    assert_eq!(opt_box.cloned(), Some(1));
}
```

At playground: https://play.rust-lang.org/?gist=06be36d6106550ce782b6841e902a732&version=nightly&backtrace=0
Reason: https://users.rust-lang.org/t/option-cloned-disowns-mut/7080
