### PR TITLE
Bonus format for E0194

### DIFF
--- a/src/test/compile-fail/E0194.rs
+++ b/src/test/compile-fail/E0194.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-trait Foo<T> {
+trait Foo<T> { //~ NOTE first `T` declared here
     fn do_something(&self) -> T;
     fn do_something_else<T: Clone>(&self, bar: T);
     //~^ ERROR E0194
-    //~| NOTE `T` shadows another type parameter
+    //~| NOTE shadows another type parameter
 }
 
 fn main() {


### PR DESCRIPTION
Bonus fix for #35280. Part of #35233. Fixes #36057. Adding expanded notes/context for what trait a parameter shadows as part of E0194 error messages.

Errors for E0194 now look like this:

```
$> ./build/x86_64-apple-darwin/stage1/bin/rustc src/test/compile-fail/E0194.rs 
error[E0194]: type parameter `T` shadows another type parameter of the same name
  --> src/test/compile-fail/E0194.rs:13:26
   |
11 | trait Foo<T> { //~ NOTE first `T` declared here
   |           - first `T` declared here
12 |     fn do_something(&self) -> T;
13 |     fn do_something_else<T: Clone>(&self, bar: T);
   |                          ^ shadows another type parameter

error: aborting due to previous error
```

r? @jonathandturner 
