### PR TITLE
Change 'rustc::plugin' to 'rustc_plugin' in doc comment

### DIFF
--- a/src/librustc_plugin/lib.rs
+++ b/src/librustc_plugin/lib.rs
@@ -27,7 +27,7 @@
 //!
 //! extern crate rustc;
 //!
-//! use rustc::plugin::Registry;
+//! use rustc_plugin::Registry;
 //!
 //! #[plugin_registrar]
 //! pub fn plugin_registrar(reg: &mut Registry) {


### PR DESCRIPTION
It looks like there is a missing one.
