### PR TITLE
Special case a few colors for Windows

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -883,7 +883,11 @@ impl Destination {
             Style::FileNameStyle | Style::LineAndColumn => {}
             Style::LineNumber => {
                 try!(self.start_attr(term::Attr::Bold));
-                try!(self.start_attr(term::Attr::ForegroundColor(term::color::BRIGHT_BLUE)));
+                if cfg!(windows) {
+                    try!(self.start_attr(term::Attr::ForegroundColor(term::color::BRIGHT_CYAN)));
+                } else {
+                    try!(self.start_attr(term::Attr::ForegroundColor(term::color::BRIGHT_BLUE)));
+                }
             }
             Style::ErrorCode => {
                 try!(self.start_attr(term::Attr::Bold));
@@ -896,6 +900,9 @@ impl Destination {
             }
             Style::OldSchoolNoteText | Style::HeaderMsg => {
                 try!(self.start_attr(term::Attr::Bold));
+                if cfg!(windows) {
+                    try!(self.start_attr(term::Attr::ForegroundColor(term::color::BRIGHT_WHITE)));
+                }
             }
             Style::UnderlinePrimary | Style::LabelPrimary => {
                 try!(self.start_attr(term::Attr::Bold));
@@ -904,7 +911,11 @@ impl Destination {
             Style::UnderlineSecondary |
             Style::LabelSecondary => {
                 try!(self.start_attr(term::Attr::Bold));
-                try!(self.start_attr(term::Attr::ForegroundColor(term::color::BRIGHT_BLUE)));
+                if cfg!(windows) {
+                    try!(self.start_attr(term::Attr::ForegroundColor(term::color::BRIGHT_CYAN)));
+                } else {
+                    try!(self.start_attr(term::Attr::ForegroundColor(term::color::BRIGHT_BLUE)));
+                }
             }
             Style::NoStyle => {}
             Style::Level(l) => {

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -732,7 +732,13 @@ impl Level {
     pub fn color(self) -> term::color::Color {
         match self {
             Bug | Fatal | PhaseFatal | Error => term::color::BRIGHT_RED,
-            Warning => term::color::YELLOW,
+            Warning => {
+                if cfg!(windows) {
+                    term::color::BRIGHT_YELLOW
+                } else {
+                    term::color::YELLOW
+                }
+            },
             Note => term::color::BRIGHT_GREEN,
             Help => term::color::BRIGHT_CYAN,
             Cancelled => unreachable!(),


### PR DESCRIPTION
As brought up on [this thread](https://github.com/rust-lang/rust/issues/33240#issuecomment-243310067) the colors used in error messages on Windows can be difficult to read because of the lack of bold.

This PR makes a few changes to improve readability, namely:
- Rather than using BRIGHT_BLUE, on Windows we now use BRIGHT_CYAN, which is easier to read on black when you do not have bold
- We used BRIGHT_YELLOW rather than YELLOW, for the same reason
- Titles will be BRIGHT_WHITE now, to give the illusion of being bold

Some examples:

![warning](https://cloud.githubusercontent.com/assets/547158/18148466/9aa9bbe2-6f8e-11e6-927f-d0eec53cac32.PNG)

![error](https://cloud.githubusercontent.com/assets/547158/18148488/ba9fb186-6f8e-11e6-8d8e-e93d569f61de.PNG)

r? @nikomatsakis 

cc @retep998
