### PR TITLE
[WIP] Improve E0495

### DIFF
--- a/src/librustc/infer/error_reporting.rs
+++ b/src/librustc/infer/error_reporting.rs
@@ -954,16 +954,16 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         let mut err = self.report_inference_failure(var_origin);
 
         self.tcx.note_and_explain_region(&mut err,
-            "first, the lifetime cannot outlive ",
+            "the lifetime cannot outlive ",
             sup_region,
-            "...");
+            "");
 
         self.note_region_origin(&mut err, &sup_origin);
 
         self.tcx.note_and_explain_region(&mut err,
-            "but, the lifetime must be valid for ",
+            "the lifetime must be valid for ",
             sub_region,
-            "...");
+            "");
 
         self.note_region_origin(&mut err, &sub_origin);
         err.emit();

--- a/src/test/compile-fail/issue-16922.rs
+++ b/src/test/compile-fail/issue-16922.rs
@@ -11,15 +11,15 @@
 use std::any::Any;
 
 fn foo<T: Any>(value: &T) -> Box<Any> {
-    //~^ NOTE first, the lifetime cannot outlive the anonymous lifetime #1 defined on the block
+    //~^ NOTE the lifetime cannot outlive the anonymous lifetime #1 defined on the block
     Box::new(value) as Box<Any>
     //~^ ERROR: cannot infer an appropriate lifetime due to conflicting requirements
     //~| ERROR: cannot infer an appropriate lifetime due to conflicting requirements
     //~| NOTE cannot infer an appropriate lifetime
-    //~| NOTE ...so that expression is assignable (expected &T, found &T)
-    //~| NOTE ...so that the type `&T` will meet its required lifetime bounds
-    //~| NOTE but, the lifetime must be valid for the static lifetime
-    //~| NOTE but, the lifetime must be valid for the static lifetime
+    //~| NOTE so that expression is assignable (expected &T, found &T)
+    //~| NOTE so that the type `&T` will meet its required lifetime bounds
+    //~| NOTE the lifetime must be valid for the static lifetime
+    //~| NOTE the lifetime must be valid for the static lifetime
 }
 
 fn main() {

--- a/src/test/compile-fail/issue-16922.rs
+++ b/src/test/compile-fail/issue-16922.rs
@@ -11,8 +11,15 @@
 use std::any::Any;
 
 fn foo<T: Any>(value: &T) -> Box<Any> {
+    //~^ NOTE first, the lifetime cannot outlive the anonymous lifetime #1 defined on the block
     Box::new(value) as Box<Any>
-    //~^ ERROR: cannot infer an appropriate lifetime
+    //~^ ERROR: cannot infer an appropriate lifetime due to conflicting requirements
+    //~| ERROR: cannot infer an appropriate lifetime due to conflicting requirements
+    //~| NOTE cannot infer an appropriate lifetime
+    //~| NOTE ...so that expression is assignable (expected &T, found &T)
+    //~| NOTE ...so that the type `&T` will meet its required lifetime bounds
+    //~| NOTE but, the lifetime must be valid for the static lifetime
+    //~| NOTE but, the lifetime must be valid for the static lifetime
 }
 
 fn main() {

--- a/src/test/compile-fail/issue-17728.rs
+++ b/src/test/compile-fail/issue-17728.rs
@@ -22,6 +22,7 @@ trait TraversesWorld {
         let direction = str_to_direction(directionStr);
         let maybe_room = room.direction_to_room.get(&direction);
         //~^ ERROR cannot infer an appropriate lifetime for autoref due to conflicting requirements
+        //~| NOTE cannot infer an appropriate lifetime
         match maybe_room {
             Some(entry) => Ok(entry),
             _ => Err("Direction does not exist in room.")

--- a/src/test/compile-fail/region-object-lifetime-in-coercion.rs
+++ b/src/test/compile-fail/region-object-lifetime-in-coercion.rs
@@ -17,26 +17,48 @@ impl<'a> Foo for &'a [u8] {}
 // FIXME (#22405): Replace `Box::new` with `box` here when/if possible.
 
 fn a(v: &[u8]) -> Box<Foo + 'static> {
+    //~^ first, the lifetime cannot outlive the anonymous lifetime #1 defined on the block
     let x: Box<Foo + 'static> = Box::new(v);
     //~^ ERROR cannot infer an appropriate lifetime due to conflicting
+    //~| ERROR cannot infer an appropriate lifetime due to conflicting
+    //~| NOTE cannot infer an appropriate lifetime
+    //~| NOTE ...so that expression is assignable (expected &[u8], found &[u8])
+    //~| NOTE ...so that the type `&[u8]` will meet its required lifetime bounds
+    //~| NOTE but, the lifetime must be valid for the static lifetime...
+    //~| NOTE but, the lifetime must be valid for the static lifetime...
     x
 }
 
 fn b(v: &[u8]) -> Box<Foo + 'static> {
+    //~^ first, the lifetime cannot outlive the anonymous lifetime #1 defined on the block
     Box::new(v)
         //~^ ERROR cannot infer an appropriate lifetime due to conflicting
+        //~| ERROR cannot infer an appropriate lifetime due to conflicting
+        //~| NOTE cannot infer an appropriate lifetime
+        //~| NOTE ...so that expression is assignable (expected &[u8], found &[u8])
+        //~| NOTE ...so that the type `&[u8]` will meet its required lifetime bounds
+        //~| NOTE but, the lifetime must be valid for the static lifetime...
+        //~| NOTE but, the lifetime must be valid for the static lifetime...
 }
 
 fn c(v: &[u8]) -> Box<Foo> {
+    //~^ first, the lifetime cannot outlive the anonymous lifetime #1 defined on the block
     // same as previous case due to RFC 599
 
     Box::new(v)
         //~^ ERROR cannot infer an appropriate lifetime due to conflicting
+        //~| ERROR cannot infer an appropriate lifetime due to conflicting
+        //~| NOTE cannot infer an appropriate lifetime
+        //~| NOTE ...so that expression is assignable (expected &[u8], found &[u8])
+        //~| NOTE ...so that the type `&[u8]` will meet its required lifetime bounds
+        //~| NOTE but, the lifetime must be valid for the static lifetime...
+        //~| NOTE but, the lifetime must be valid for the static lifetime...
 }
 
 fn d<'a,'b>(v: &'a [u8]) -> Box<Foo+'b> {
     Box::new(v)
         //~^ ERROR cannot infer an appropriate lifetime due to conflicting
+        //~| NOTE cannot infer an appropriate lifetime
 }
 
 fn e<'a:'b,'b>(v: &'a [u8]) -> Box<Foo+'b> {

--- a/src/test/compile-fail/region-object-lifetime-in-coercion.rs
+++ b/src/test/compile-fail/region-object-lifetime-in-coercion.rs
@@ -17,42 +17,42 @@ impl<'a> Foo for &'a [u8] {}
 // FIXME (#22405): Replace `Box::new` with `box` here when/if possible.
 
 fn a(v: &[u8]) -> Box<Foo + 'static> {
-    //~^ first, the lifetime cannot outlive the anonymous lifetime #1 defined on the block
+    //~^ the lifetime cannot outlive the anonymous lifetime #1 defined on the block
     let x: Box<Foo + 'static> = Box::new(v);
     //~^ ERROR cannot infer an appropriate lifetime due to conflicting
     //~| ERROR cannot infer an appropriate lifetime due to conflicting
     //~| NOTE cannot infer an appropriate lifetime
-    //~| NOTE ...so that expression is assignable (expected &[u8], found &[u8])
-    //~| NOTE ...so that the type `&[u8]` will meet its required lifetime bounds
-    //~| NOTE but, the lifetime must be valid for the static lifetime...
-    //~| NOTE but, the lifetime must be valid for the static lifetime...
+    //~| NOTE so that expression is assignable (expected &[u8], found &[u8])
+    //~| NOTE so that the type `&[u8]` will meet its required lifetime bounds
+    //~| NOTE the lifetime must be valid for the static lifetime
+    //~| NOTE the lifetime must be valid for the static lifetime
     x
 }
 
 fn b(v: &[u8]) -> Box<Foo + 'static> {
-    //~^ first, the lifetime cannot outlive the anonymous lifetime #1 defined on the block
+    //~^ the lifetime cannot outlive the anonymous lifetime #1 defined on the block
     Box::new(v)
         //~^ ERROR cannot infer an appropriate lifetime due to conflicting
         //~| ERROR cannot infer an appropriate lifetime due to conflicting
         //~| NOTE cannot infer an appropriate lifetime
-        //~| NOTE ...so that expression is assignable (expected &[u8], found &[u8])
-        //~| NOTE ...so that the type `&[u8]` will meet its required lifetime bounds
-        //~| NOTE but, the lifetime must be valid for the static lifetime...
-        //~| NOTE but, the lifetime must be valid for the static lifetime...
+        //~| NOTE so that expression is assignable (expected &[u8], found &[u8])
+        //~| NOTE so that the type `&[u8]` will meet its required lifetime bounds
+        //~| NOTE the lifetime must be valid for the static lifetime
+        //~| NOTE the lifetime must be valid for the static lifetime
 }
 
 fn c(v: &[u8]) -> Box<Foo> {
-    //~^ first, the lifetime cannot outlive the anonymous lifetime #1 defined on the block
+    //~^ the lifetime cannot outlive the anonymous lifetime #1 defined on the block
     // same as previous case due to RFC 599
 
     Box::new(v)
         //~^ ERROR cannot infer an appropriate lifetime due to conflicting
         //~| ERROR cannot infer an appropriate lifetime due to conflicting
         //~| NOTE cannot infer an appropriate lifetime
-        //~| NOTE ...so that expression is assignable (expected &[u8], found &[u8])
-        //~| NOTE ...so that the type `&[u8]` will meet its required lifetime bounds
-        //~| NOTE but, the lifetime must be valid for the static lifetime...
-        //~| NOTE but, the lifetime must be valid for the static lifetime...
+        //~| NOTE so that expression is assignable (expected &[u8], found &[u8])
+        //~| NOTE so that the type `&[u8]` will meet its required lifetime bounds
+        //~| NOTE the lifetime must be valid for the static lifetime
+        //~| NOTE the lifetime must be valid for the static lifetime
 }
 
 fn d<'a,'b>(v: &'a [u8]) -> Box<Foo+'b> {

--- a/src/test/compile-fail/regions-addr-of-self.rs
+++ b/src/test/compile-fail/regions-addr-of-self.rs
@@ -14,17 +14,17 @@ struct dog {
 
 impl dog {
     pub fn chase_cat(&mut self) {
-        //~^ NOTE first, the lifetime cannot outlive the anonymous lifetime #1 defined on the block
+        //~^ NOTE the lifetime cannot outlive the anonymous lifetime #1 defined on the block
         let p: &'static mut usize = &mut self.cats_chased;
         //~^ ERROR cannot infer an appropriate lifetime for borrow expression due to conflicting
         //~| ERROR cannot infer an appropriate lifetime for borrow expression due to conflicting
         //~| ERROR cannot infer an appropriate lifetime for borrow expression due to conflicting
         //~| NOTE cannot infer an appropriate lifetime
-        //~| NOTE ...so that reference does not outlive borrowed content
-        //~| NOTE ...so that reference does not outlive borrowed content
-        //~| NOTE but, the lifetime must be valid for the static lifetime...
-        //~| NOTE but, the lifetime must be valid for the static lifetime...
-        //~| NOTE but, the lifetime must be valid for the static lifetime...
+        //~| NOTE so that reference does not outlive borrowed content
+        //~| NOTE so that reference does not outlive borrowed content
+        //~| NOTE the lifetime must be valid for the static lifetime
+        //~| NOTE the lifetime must be valid for the static lifetime
+        //~| NOTE the lifetime must be valid for the static lifetime
         *p += 1;
     }
 

--- a/src/test/compile-fail/regions-addr-of-self.rs
+++ b/src/test/compile-fail/regions-addr-of-self.rs
@@ -14,7 +14,17 @@ struct dog {
 
 impl dog {
     pub fn chase_cat(&mut self) {
-        let p: &'static mut usize = &mut self.cats_chased; //~ ERROR cannot infer
+        //~^ NOTE first, the lifetime cannot outlive the anonymous lifetime #1 defined on the block
+        let p: &'static mut usize = &mut self.cats_chased;
+        //~^ ERROR cannot infer an appropriate lifetime for borrow expression due to conflicting
+        //~| ERROR cannot infer an appropriate lifetime for borrow expression due to conflicting
+        //~| ERROR cannot infer an appropriate lifetime for borrow expression due to conflicting
+        //~| NOTE cannot infer an appropriate lifetime
+        //~| NOTE ...so that reference does not outlive borrowed content
+        //~| NOTE ...so that reference does not outlive borrowed content
+        //~| NOTE but, the lifetime must be valid for the static lifetime...
+        //~| NOTE but, the lifetime must be valid for the static lifetime...
+        //~| NOTE but, the lifetime must be valid for the static lifetime...
         *p += 1;
     }
 

--- a/src/test/compile-fail/regions-addr-of-upvar-self.rs
+++ b/src/test/compile-fail/regions-addr-of-upvar-self.rs
@@ -17,17 +17,17 @@ struct dog {
 impl dog {
     pub fn chase_cat(&mut self) {
         let _f = || {
-            //~^ first, the lifetime cannot outlive the lifetime  as defined on the block
+            //~^ the lifetime cannot outlive the lifetime  as defined on the block
             let p: &'static mut usize = &mut self.food;
             //~^ ERROR cannot infer an appropriate lifetime for borrow expression due to conflicting
             //~| ERROR cannot infer an appropriate lifetime for borrow expression due to conflicting
             //~| ERROR cannot infer an appropriate lifetime for borrow expression due to conflicting
             //~| NOTE cannot infer an appropriate lifetime
-            //~| NOTE ...so that closure can access `self`
-            //~| NOTE ...so that reference does not outlive borrowed content
-            //~| NOTE but, the lifetime must be valid for the static lifetime...
-            //~| NOTE but, the lifetime must be valid for the static lifetime...
-            //~| NOTE but, the lifetime must be valid for the static lifetime...
+            //~| NOTE so that closure can access `self`
+            //~| NOTE so that reference does not outlive borrowed content
+            //~| NOTE the lifetime must be valid for the static lifetime
+            //~| NOTE the lifetime must be valid for the static lifetime
+            //~| NOTE the lifetime must be valid for the static lifetime
             *p = 3;
         };
     }

--- a/src/test/compile-fail/regions-addr-of-upvar-self.rs
+++ b/src/test/compile-fail/regions-addr-of-upvar-self.rs
@@ -17,7 +17,17 @@ struct dog {
 impl dog {
     pub fn chase_cat(&mut self) {
         let _f = || {
-            let p: &'static mut usize = &mut self.food; //~ ERROR cannot infer
+            //~^ first, the lifetime cannot outlive the lifetime  as defined on the block
+            let p: &'static mut usize = &mut self.food;
+            //~^ ERROR cannot infer an appropriate lifetime for borrow expression due to conflicting
+            //~| ERROR cannot infer an appropriate lifetime for borrow expression due to conflicting
+            //~| ERROR cannot infer an appropriate lifetime for borrow expression due to conflicting
+            //~| NOTE cannot infer an appropriate lifetime
+            //~| NOTE ...so that closure can access `self`
+            //~| NOTE ...so that reference does not outlive borrowed content
+            //~| NOTE but, the lifetime must be valid for the static lifetime...
+            //~| NOTE but, the lifetime must be valid for the static lifetime...
+            //~| NOTE but, the lifetime must be valid for the static lifetime...
             *p = 3;
         };
     }

--- a/src/test/compile-fail/regions-assoc-type-region-bound-in-trait-not-met.rs
+++ b/src/test/compile-fail/regions-assoc-type-region-bound-in-trait-not-met.rs
@@ -26,12 +26,12 @@ impl<'a> Foo<'static> for &'a i32 {
     //~| ERROR cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting
     //~| ERROR cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting
     //~| NOTE cannot infer an appropriate lifetime
-    //~| NOTE first, the lifetime cannot outlive the lifetime 'a as defined on the impl
-    //~| NOTE ...so that trait type parameters matches those specified on the impl
-    //~| NOTE ...so that the type `&i32` will meet its required lifetime bounds
-    //~| NOTE but, the lifetime must be valid for the static lifetime
-    //~| NOTE but, the lifetime must be valid for the static lifetime
-    //~| NOTE but, the lifetime must be valid for the static lifetime
+    //~| NOTE the lifetime cannot outlive the lifetime 'a as defined on the impl
+    //~| NOTE so that trait type parameters matches those specified on the impl
+    //~| NOTE so that the type `&i32` will meet its required lifetime bounds
+    //~| NOTE the lifetime must be valid for the static lifetime
+    //~| NOTE the lifetime must be valid for the static lifetime
+    //~| NOTE the lifetime must be valid for the static lifetime
     type Value = &'a i32;
 }
 
@@ -40,10 +40,10 @@ impl<'a,'b> Foo<'b> for &'a i64 {
     //~| ERROR cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting
     //~| ERROR cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting
     //~| NOTE cannot infer an appropriate lifetime
-    //~| NOTE first, the lifetime cannot outlive the lifetime 'a as defined on the impl
-    //~| NOTE ...so that trait type parameters matches those specified on the impl
-    //~| NOTE but, the lifetime must be valid for the lifetime 'b as defined on the impl
-    //~| NOTE ...so that the type `&i32` will meet its required lifetime bounds
+    //~| NOTE the lifetime cannot outlive the lifetime 'a as defined on the impl
+    //~| NOTE so that trait type parameters matches those specified on the impl
+    //~| NOTE the lifetime must be valid for the lifetime 'b as defined on the impl
+    //~| NOTE so that the type `&i32` will meet its required lifetime bounds
     type Value = &'a i32;
 }
 

--- a/src/test/compile-fail/regions-assoc-type-region-bound-in-trait-not-met.rs
+++ b/src/test/compile-fail/regions-assoc-type-region-bound-in-trait-not-met.rs
@@ -22,12 +22,28 @@ impl<'a> Foo<'a> for &'a i16 {
 }
 
 impl<'a> Foo<'static> for &'a i32 {
-    //~^ ERROR cannot infer
+    //~^ ERROR cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting
+    //~| ERROR cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting
+    //~| ERROR cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting
+    //~| NOTE cannot infer an appropriate lifetime
+    //~| NOTE first, the lifetime cannot outlive the lifetime 'a as defined on the impl
+    //~| NOTE ...so that trait type parameters matches those specified on the impl
+    //~| NOTE ...so that the type `&i32` will meet its required lifetime bounds
+    //~| NOTE but, the lifetime must be valid for the static lifetime
+    //~| NOTE but, the lifetime must be valid for the static lifetime
+    //~| NOTE but, the lifetime must be valid for the static lifetime
     type Value = &'a i32;
 }
 
 impl<'a,'b> Foo<'b> for &'a i64 {
-    //~^ ERROR cannot infer
+    //~^ ERROR cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting
+    //~| ERROR cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting
+    //~| ERROR cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting
+    //~| NOTE cannot infer an appropriate lifetime
+    //~| NOTE first, the lifetime cannot outlive the lifetime 'a as defined on the impl
+    //~| NOTE ...so that trait type parameters matches those specified on the impl
+    //~| NOTE but, the lifetime must be valid for the lifetime 'b as defined on the impl
+    //~| NOTE ...so that the type `&i32` will meet its required lifetime bounds
     type Value = &'a i32;
 }
 

--- a/src/test/compile-fail/regions-assoc-type-static-bound-in-trait-not-met.rs
+++ b/src/test/compile-fail/regions-assoc-type-static-bound-in-trait-not-met.rs
@@ -17,7 +17,16 @@ trait Foo {
 }
 
 impl<'a> Foo for &'a i32 {
-    //~^ ERROR cannot infer
+    //~^ ERROR cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting
+    //~| ERROR cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting
+    //~| ERROR cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting
+    //~| NOTE cannot infer an appropriate lifetime
+    //~| NOTE first, the lifetime cannot outlive the lifetime 'a as defined on the impl
+    //~| NOTE ...so that trait type parameters matches those specified on the impl
+    //~| NOTE ...so that the type `&i32` will meet its required lifetime bounds
+    //~| NOTE but, the lifetime must be valid for the static lifetime
+    //~| NOTE but, the lifetime must be valid for the static lifetime
+    //~| NOTE but, the lifetime must be valid for the static lifetime
     type Value = &'a i32;
 }
 

--- a/src/test/compile-fail/regions-assoc-type-static-bound-in-trait-not-met.rs
+++ b/src/test/compile-fail/regions-assoc-type-static-bound-in-trait-not-met.rs
@@ -21,12 +21,12 @@ impl<'a> Foo for &'a i32 {
     //~| ERROR cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting
     //~| ERROR cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting
     //~| NOTE cannot infer an appropriate lifetime
-    //~| NOTE first, the lifetime cannot outlive the lifetime 'a as defined on the impl
+    //~| NOTE the lifetime cannot outlive the lifetime 'a as defined on the impl
     //~| NOTE ...so that trait type parameters matches those specified on the impl
     //~| NOTE ...so that the type `&i32` will meet its required lifetime bounds
-    //~| NOTE but, the lifetime must be valid for the static lifetime
-    //~| NOTE but, the lifetime must be valid for the static lifetime
-    //~| NOTE but, the lifetime must be valid for the static lifetime
+    //~| NOTE the lifetime must be valid for the static lifetime
+    //~| NOTE the lifetime must be valid for the static lifetime
+    //~| NOTE the lifetime must be valid for the static lifetime
     type Value = &'a i32;
 }
 

--- a/src/test/compile-fail/regions-escape-bound-fn-2.rs
+++ b/src/test/compile-fail/regions-escape-bound-fn-2.rs
@@ -16,5 +16,11 @@ fn with_int<F>(f: F) where F: FnOnce(&isize) {
 fn main() {
     let mut x = None;
     with_int(|y| x = Some(y));
-         //~^ ERROR cannot infer
+         //~^ ERROR cannot infer an appropriate lifetime due to conflicting requirements
+         //~| ERROR cannot infer an appropriate lifetime due to conflicting requirements
+         //~| NOTE cannot infer an appropriate lifetime
+         //~| NOTE first, the lifetime cannot outlive the anonymous lifetime #1
+         //~| NOTE ...so that expression is assignable (expected &isize, found &isize)
+         //~| NOTE but, the lifetime must be valid for the expression at
+         //~| NOTE ...so that a type/lifetime parameter is in scope here
 }

--- a/src/test/compile-fail/regions-escape-bound-fn-2.rs
+++ b/src/test/compile-fail/regions-escape-bound-fn-2.rs
@@ -19,8 +19,8 @@ fn main() {
          //~^ ERROR cannot infer an appropriate lifetime due to conflicting requirements
          //~| ERROR cannot infer an appropriate lifetime due to conflicting requirements
          //~| NOTE cannot infer an appropriate lifetime
-         //~| NOTE first, the lifetime cannot outlive the anonymous lifetime #1
+         //~| NOTE the lifetime cannot outlive the anonymous lifetime #1
          //~| NOTE ...so that expression is assignable (expected &isize, found &isize)
-         //~| NOTE but, the lifetime must be valid for the expression at
+         //~| NOTE the lifetime must be valid for the expression at
          //~| NOTE ...so that a type/lifetime parameter is in scope here
 }

--- a/src/test/compile-fail/regions-escape-method.rs
+++ b/src/test/compile-fail/regions-escape-method.rs
@@ -27,8 +27,8 @@ fn main() {
     //~| ERROR cannot infer an appropriate lifetime due to conflicting requirements
     //~| ERROR cannot infer an appropriate lifetime due to conflicting requirements
     //~| NOTE cannot infer an appropriate lifetime
-    //~| NOTE first, the lifetime cannot outlive the anonymous lifetime #1 defined on the block
+    //~| NOTE the lifetime cannot outlive the anonymous lifetime #1 defined on the block
     //~| NOTE ...so that expression is assignable (expected &i32, found &i32)
-    //~| NOTE but, the lifetime must be valid for the method call at 25:4
+    //~| NOTE the lifetime must be valid for the method call at 25:4
     //~| NOTE ...so type
 }

--- a/src/test/compile-fail/regions-escape-method.rs
+++ b/src/test/compile-fail/regions-escape-method.rs
@@ -22,5 +22,13 @@ impl S {
 
 fn main() {
     let s = S;
-    s.f(|p| p) //~ ERROR cannot infer
+    s.f(|p| p)
+    //~^ ERROR cannot infer an appropriate lifetime due to conflicting requirements
+    //~| ERROR cannot infer an appropriate lifetime due to conflicting requirements
+    //~| ERROR cannot infer an appropriate lifetime due to conflicting requirements
+    //~| NOTE cannot infer an appropriate lifetime
+    //~| NOTE first, the lifetime cannot outlive the anonymous lifetime #1 defined on the block
+    //~| NOTE ...so that expression is assignable (expected &i32, found &i32)
+    //~| NOTE but, the lifetime must be valid for the method call at 25:4
+    //~| NOTE ...so type
 }

--- a/src/test/compile-fail/regions-escape-via-trait-or-not.rs
+++ b/src/test/compile-fail/regions-escape-via-trait-or-not.rs
@@ -25,7 +25,15 @@ fn with<R:Deref, F>(f: F) -> isize where F: FnOnce(&isize) -> R {
 }
 
 fn return_it() -> isize {
-    with(|o| o) //~ ERROR cannot infer
+    with(|o| o)
+        //~^ ERROR cannot infer an appropriate lifetime due to conflicting requirements
+        //~| ERROR cannot infer an appropriate lifetime due to conflicting requirements
+        //~| ERROR cannot infer an appropriate lifetime due to conflicting requirements
+        //~| NOTE cannot infer an appropriate lifetime
+        //~| NOTE first, the lifetime cannot outlive the anonymous lifetime #1 defined on the block
+        //~| NOTE ...so that expression is assignable (expected &isize, found &isize)
+        //~| NOTE but, the lifetime must be valid for the expression
+        //~| NOTE ...so that a type/lifetime parameter is in scope here
 }
 
 fn main() {

--- a/src/test/compile-fail/regions-escape-via-trait-or-not.rs
+++ b/src/test/compile-fail/regions-escape-via-trait-or-not.rs
@@ -30,9 +30,9 @@ fn return_it() -> isize {
         //~| ERROR cannot infer an appropriate lifetime due to conflicting requirements
         //~| ERROR cannot infer an appropriate lifetime due to conflicting requirements
         //~| NOTE cannot infer an appropriate lifetime
-        //~| NOTE first, the lifetime cannot outlive the anonymous lifetime #1 defined on the block
+        //~| NOTE the lifetime cannot outlive the anonymous lifetime #1 defined on the block
         //~| NOTE ...so that expression is assignable (expected &isize, found &isize)
-        //~| NOTE but, the lifetime must be valid for the expression
+        //~| NOTE the lifetime must be valid for the expression
         //~| NOTE ...so that a type/lifetime parameter is in scope here
 }
 

--- a/src/test/compile-fail/regions-ret-borrowed-1.rs
+++ b/src/test/compile-fail/regions-ret-borrowed-1.rs
@@ -17,12 +17,12 @@ fn with<R, F>(f: F) -> R where F: for<'a> FnOnce(&'a isize) -> R {
 }
 
 fn return_it<'a>() -> &'a isize {
-    //~^ NOTE but, the lifetime must be valid for the lifetime 'a as defined on the block
+    //~^ NOTE the lifetime must be valid for the lifetime 'a as defined on the block
     with(|o| o)
         //~^ ERROR cannot infer an appropriate lifetime due to conflicting requirements
         //~| ERROR cannot infer an appropriate lifetime due to conflicting requirements
         //~| ERROR cannot infer an appropriate lifetime due to conflicting requirements
-        //~| NOTE first, the lifetime cannot outlive the lifetime 'a as defined on the block
+        //~| NOTE the lifetime cannot outlive the lifetime 'a as defined on the block
         //~| NOTE ...so that expression is assignable (expected &isize, found &'a isize)
         //~| NOTE ...so that reference does not outlive borrowed content
         //~| NOTE cannot infer an appropriate lifetime

--- a/src/test/compile-fail/regions-ret-borrowed-1.rs
+++ b/src/test/compile-fail/regions-ret-borrowed-1.rs
@@ -17,8 +17,15 @@ fn with<R, F>(f: F) -> R where F: for<'a> FnOnce(&'a isize) -> R {
 }
 
 fn return_it<'a>() -> &'a isize {
+    //~^ NOTE but, the lifetime must be valid for the lifetime 'a as defined on the block
     with(|o| o)
-        //~^ ERROR cannot infer
+        //~^ ERROR cannot infer an appropriate lifetime due to conflicting requirements
+        //~| ERROR cannot infer an appropriate lifetime due to conflicting requirements
+        //~| ERROR cannot infer an appropriate lifetime due to conflicting requirements
+        //~| NOTE first, the lifetime cannot outlive the lifetime 'a as defined on the block
+        //~| NOTE ...so that expression is assignable (expected &isize, found &'a isize)
+        //~| NOTE ...so that reference does not outlive borrowed content
+        //~| NOTE cannot infer an appropriate lifetime
 }
 
 fn main() {

--- a/src/test/compile-fail/regions-ret-borrowed.rs
+++ b/src/test/compile-fail/regions-ret-borrowed.rs
@@ -20,8 +20,15 @@ fn with<R, F>(f: F) -> R where F: FnOnce(&isize) -> R {
 }
 
 fn return_it<'a>() -> &'a isize {
+    //~^ NOTE but, the lifetime must be valid for the lifetime 'a as defined on the block
     with(|o| o)
-        //~^ ERROR cannot infer
+        //~^ ERROR cannot infer an appropriate lifetime due to conflicting requirements
+        //~| ERROR cannot infer an appropriate lifetime due to conflicting requirements
+        //~| ERROR cannot infer an appropriate lifetime due to conflicting requirements
+        //~| NOTE cannot infer an appropriate lifetime
+        //~| NOTE first, the lifetime cannot outlive the anonymous lifetime #1 defined on the block
+        //~| NOTE ...so that expression is assignable (expected &isize, found &isize)
+        //~| NOTE ...so that reference does not outlive borrowed content
 }
 
 fn main() {

--- a/src/test/compile-fail/regions-ret-borrowed.rs
+++ b/src/test/compile-fail/regions-ret-borrowed.rs
@@ -20,13 +20,13 @@ fn with<R, F>(f: F) -> R where F: FnOnce(&isize) -> R {
 }
 
 fn return_it<'a>() -> &'a isize {
-    //~^ NOTE but, the lifetime must be valid for the lifetime 'a as defined on the block
+    //~^ NOTE the lifetime must be valid for the lifetime 'a as defined on the block
     with(|o| o)
         //~^ ERROR cannot infer an appropriate lifetime due to conflicting requirements
         //~| ERROR cannot infer an appropriate lifetime due to conflicting requirements
         //~| ERROR cannot infer an appropriate lifetime due to conflicting requirements
         //~| NOTE cannot infer an appropriate lifetime
-        //~| NOTE first, the lifetime cannot outlive the anonymous lifetime #1 defined on the block
+        //~| NOTE the lifetime cannot outlive the anonymous lifetime #1 defined on the block
         //~| NOTE ...so that expression is assignable (expected &isize, found &isize)
         //~| NOTE ...so that reference does not outlive borrowed content
 }

--- a/src/test/compile-fail/regions-return-ref-to-upvar-issue-17403.rs
+++ b/src/test/compile-fail/regions-return-ref-to-upvar-issue-17403.rs
@@ -19,11 +19,11 @@ fn main() {
         //~| ERROR cannot infer an appropriate lifetime for borrow expression
         //~| ERROR cannot infer an appropriate lifetime for borrow expression
         //~| NOTE cannot infer an appropriate lifetime
-        //~| NOTE first, the lifetime cannot outlive the lifetime  as defined on the block
+        //~| NOTE the lifetime cannot outlive the lifetime  as defined on the block
         //~| NOTE ...so that closure can access `x`
         let x = f();
         let y = f();
-        //~^ NOTE but, the lifetime must be valid for the call
+        //~^ NOTE the lifetime must be valid for the call
         //~| NOTE ...so type
     }
 }

--- a/src/test/compile-fail/regions-return-ref-to-upvar-issue-17403.rs
+++ b/src/test/compile-fail/regions-return-ref-to-upvar-issue-17403.rs
@@ -14,8 +14,16 @@ fn main() {
     // Unboxed closure case
     {
         let mut x = 0;
-        let mut f = || &mut x; //~ ERROR cannot infer
+        let mut f = || &mut x;
+        //~^ ERROR cannot infer an appropriate lifetime for borrow expression
+        //~| ERROR cannot infer an appropriate lifetime for borrow expression
+        //~| ERROR cannot infer an appropriate lifetime for borrow expression
+        //~| NOTE cannot infer an appropriate lifetime
+        //~| NOTE first, the lifetime cannot outlive the lifetime  as defined on the block
+        //~| NOTE ...so that closure can access `x`
         let x = f();
         let y = f();
+        //~^ NOTE but, the lifetime must be valid for the call
+        //~| NOTE ...so type
     }
 }

--- a/src/test/compile-fail/regions-static-bound.rs
+++ b/src/test/compile-fail/regions-static-bound.rs
@@ -13,12 +13,30 @@ fn static_id<'a,'b>(t: &'a ()) -> &'static ()
 fn static_id_indirect<'a,'b>(t: &'a ()) -> &'static ()
     where 'a: 'b, 'b: 'static { t }
 fn static_id_wrong_way<'a>(t: &'a ()) -> &'static () where 'static: 'a {
+    //~^ NOTE ...but the borrowed content is only valid for the lifetime 'a
     t //~ ERROR E0312
+    //~^ NOTE ...the reference is valid for the static lifetime...
 }
 
 fn error(u: &(), v: &()) {
-    static_id(&u); //~ ERROR cannot infer an appropriate lifetime
-    static_id_indirect(&v); //~ ERROR cannot infer an appropriate lifetime
+    //~^ NOTE first, the lifetime cannot outlive the anonymous lifetime #1 defined on the block
+    //~| NOTE first, the lifetime cannot outlive the anonymous lifetime #2 defined on the block
+    static_id(&u);
+    //~^ ERROR cannot infer an appropriate lifetime for lifetime parameter
+    //~| ERROR cannot infer an appropriate lifetime for lifetime parameter
+    //~| NOTE cannot infer an appropriate lifetime
+    //~| NOTE ...so that reference does not outlive borrowed content
+    //~| NOTE ...so that the declared lifetime parameter bounds are satisfied
+    //~| NOTE but, the lifetime must be valid for the static lifetime...
+    //~| NOTE but, the lifetime must be valid for the static lifetime...
+    static_id_indirect(&v);
+    //~^ ERROR cannot infer an appropriate lifetime
+    //~| ERROR cannot infer an appropriate lifetime
+    //~| NOTE cannot infer an appropriate lifetime
+    //~| NOTE ...so that reference does not outlive borrowed content
+    //~| NOTE ...so that the declared lifetime parameter bounds are satisfied
+    //~| NOTE but, the lifetime must be valid for the static lifetime
+    //~| NOTE but, the lifetime must be valid for the static lifetime
 }
 
 fn main() {}

--- a/src/test/compile-fail/regions-static-bound.rs
+++ b/src/test/compile-fail/regions-static-bound.rs
@@ -19,24 +19,24 @@ fn static_id_wrong_way<'a>(t: &'a ()) -> &'static () where 'static: 'a {
 }
 
 fn error(u: &(), v: &()) {
-    //~^ NOTE first, the lifetime cannot outlive the anonymous lifetime #1 defined on the block
-    //~| NOTE first, the lifetime cannot outlive the anonymous lifetime #2 defined on the block
+    //~^ NOTE the lifetime cannot outlive the anonymous lifetime #1 defined on the block
+    //~| NOTE the lifetime cannot outlive the anonymous lifetime #2 defined on the block
     static_id(&u);
     //~^ ERROR cannot infer an appropriate lifetime for lifetime parameter
     //~| ERROR cannot infer an appropriate lifetime for lifetime parameter
     //~| NOTE cannot infer an appropriate lifetime
     //~| NOTE ...so that reference does not outlive borrowed content
     //~| NOTE ...so that the declared lifetime parameter bounds are satisfied
-    //~| NOTE but, the lifetime must be valid for the static lifetime...
-    //~| NOTE but, the lifetime must be valid for the static lifetime...
+    //~| NOTE the lifetime must be valid for the static lifetime
+    //~| NOTE the lifetime must be valid for the static lifetime
     static_id_indirect(&v);
     //~^ ERROR cannot infer an appropriate lifetime
     //~| ERROR cannot infer an appropriate lifetime
     //~| NOTE cannot infer an appropriate lifetime
     //~| NOTE ...so that reference does not outlive borrowed content
     //~| NOTE ...so that the declared lifetime parameter bounds are satisfied
-    //~| NOTE but, the lifetime must be valid for the static lifetime
-    //~| NOTE but, the lifetime must be valid for the static lifetime
+    //~| NOTE the lifetime must be valid for the static lifetime
+    //~| NOTE the lifetime must be valid for the static lifetime
 }
 
 fn main() {}

--- a/src/test/compile-fail/reject-specialized-drops-8142.rs
+++ b/src/test/compile-fail/reject-specialized-drops-8142.rs
@@ -13,18 +13,27 @@
 
 trait Bound { fn foo(&self) { } }
 struct K<'l1,'l2> { x: &'l1 i8, y: &'l2 u8 }
+//~^ NOTE The same requirement must be part of the struct/enum definition
 struct L<'l1,'l2> { x: &'l1 i8, y: &'l2 u8 }
+//~^ NOTE The same requirement must be part of the struct/enum definition
 struct M<'m> { x: &'m i8 }
 struct N<'n> { x: &'n i8 }
+//~^ NOTE the lifetime 'n as defined on the struct
 struct O<To> { x: *const To }
 struct P<Tp> { x: *const Tp }
+//~^ NOTE Use same sequence of generic type and region parameters that is on the struct/enum
 struct Q<Tq> { x: *const Tq }
+//~^ NOTE The same requirement must be part of the struct/enum definition
 struct R<Tr> { x: *const Tr }
+//~^ NOTE The same requirement must be part of the struct/enum definition
 struct S<Ts:Bound> { x: *const Ts }
 struct T<'t,Ts:'t> { x: &'t Ts }
 struct U;
 struct V<Tva, Tvb> { x: *const Tva, y: *const Tvb }
+//~^ NOTE Use same sequence of generic type and region parameters that is on the struct/enum
 struct W<'l1, 'l2> { x: &'l1 i8, y: &'l2 u8 }
+//~^ NOTE first, the lifetime cannot outlive the lifetime 'l2 as defined on the struct
+//~| NOTE but, the lifetime must be valid for the lifetime 'l1 as defined on the struct
 
 impl<'al,'adds_bnd:'al> Drop for K<'al,'adds_bnd> {                        // REJECT
     //~^ ERROR The requirement `'adds_bnd : 'al` is added only by the Drop impl.
@@ -40,6 +49,8 @@ impl                    Drop for N<'static>     { fn drop(&mut self) { } } // RE
 //~^ ERROR mismatched types
 //~| expected type `N<'n>`
 //~|    found type `N<'static>`
+//~| NOTE lifetime mismatch
+//~| NOTE ..does not necessarily outlive the static lifetime
 
 impl<Cok_nobound> Drop for O<Cok_nobound> { fn drop(&mut self) { } } // ACCEPT
 
@@ -62,6 +73,11 @@ impl<One>         Drop for V<One,One>     { fn drop(&mut self) { } } // REJECT
 //~^ ERROR Implementations of Drop cannot be specialized
 
 impl<'lw>         Drop for W<'lw,'lw>     { fn drop(&mut self) { } } // REJECT
-//~^ ERROR cannot infer an appropriate lifetime
+//~^ ERROR cannot infer an appropriate lifetime for lifetime parameter `'lw` due to conflicting
+//~| ERROR cannot infer an appropriate lifetime for lifetime parameter `'lw` due to conflicting
+//~| ERROR cannot infer an appropriate lifetime for lifetime parameter `'lw` due to conflicting
+//~| NOTE cannot infer an appropriate lifetime
+//~| NOTE ...so that types are compatible (expected W<'l1, 'l2>, found W<'_, '_>)
+//~| NOTE ...so that types are compatible (expected W<'l1, 'l2>, found W<'_, '_>)
 
 pub fn main() { }

--- a/src/test/compile-fail/reject-specialized-drops-8142.rs
+++ b/src/test/compile-fail/reject-specialized-drops-8142.rs
@@ -32,8 +32,8 @@ struct U;
 struct V<Tva, Tvb> { x: *const Tva, y: *const Tvb }
 //~^ NOTE Use same sequence of generic type and region parameters that is on the struct/enum
 struct W<'l1, 'l2> { x: &'l1 i8, y: &'l2 u8 }
-//~^ NOTE first, the lifetime cannot outlive the lifetime 'l2 as defined on the struct
-//~| NOTE but, the lifetime must be valid for the lifetime 'l1 as defined on the struct
+//~^ NOTE the lifetime cannot outlive the lifetime 'l2 as defined on the struct
+//~| NOTE the lifetime must be valid for the lifetime 'l1 as defined on the struct
 
 impl<'al,'adds_bnd:'al> Drop for K<'al,'adds_bnd> {                        // REJECT
     //~^ ERROR The requirement `'adds_bnd : 'al` is added only by the Drop impl.

--- a/src/test/compile-fail/trait-impl-of-supertrait-has-wrong-lifetime-parameters.rs
+++ b/src/test/compile-fail/trait-impl-of-supertrait-has-wrong-lifetime-parameters.rs
@@ -31,7 +31,15 @@ impl<'a,'b> T1<'b> for S<'a, 'b> {
     }
 }
 
-impl<'a,'b> T2<'a, 'b> for S<'a, 'b> { //~ ERROR cannot infer an appropriate lifetime
+impl<'a,'b> T2<'a, 'b> for S<'a, 'b> {
+    //~^ ERROR cannot infer an appropriate lifetime for lifetime parameter `'b` due to conflicting
+    //~| ERROR cannot infer an appropriate lifetime for lifetime parameter `'b` due to conflicting
+    //~| ERROR cannot infer an appropriate lifetime for lifetime parameter `'b` due to conflicting
+    //~| NOTE cannot infer an appropriate lifetime
+    //~| NOTE first, the lifetime cannot outlive the lifetime 'b as defined on the impl
+    //~| NOTE ...so that trait type parameters matches those specified on the impl
+    //~| NOTE but, the lifetime must be valid for the lifetime 'a as defined on the impl
+    //~| NOTE ...so that trait type parameters matches those specified on the impl
     fn y(&self) -> &'b isize {
         self.b
     }

--- a/src/test/compile-fail/trait-impl-of-supertrait-has-wrong-lifetime-parameters.rs
+++ b/src/test/compile-fail/trait-impl-of-supertrait-has-wrong-lifetime-parameters.rs
@@ -36,9 +36,9 @@ impl<'a,'b> T2<'a, 'b> for S<'a, 'b> {
     //~| ERROR cannot infer an appropriate lifetime for lifetime parameter `'b` due to conflicting
     //~| ERROR cannot infer an appropriate lifetime for lifetime parameter `'b` due to conflicting
     //~| NOTE cannot infer an appropriate lifetime
-    //~| NOTE first, the lifetime cannot outlive the lifetime 'b as defined on the impl
+    //~| NOTE the lifetime cannot outlive the lifetime 'b as defined on the impl
     //~| NOTE ...so that trait type parameters matches those specified on the impl
-    //~| NOTE but, the lifetime must be valid for the lifetime 'a as defined on the impl
+    //~| NOTE the lifetime must be valid for the lifetime 'a as defined on the impl
     //~| NOTE ...so that trait type parameters matches those specified on the impl
     fn y(&self) -> &'b isize {
         self.b


### PR DESCRIPTION
Update E0495 to use the new error reporting format. In most cases, I think this makes the errors easier to understand and certainly more compact. Below are before and after screenshots for the changed tests. 

At this point, I'd like some feedback on what other tweaks could be done to make the errors better. Here's a few I've thought of:
- [x] Consider removing the various `...`s in the hints
- [x] Consider removing the `first` and `but` from some of the hints since they don't always show up top to bottom now
- [ ] Consider removing the `at nn:nn` bits since the labels now point to the relevant spans
- [ ] Others?

Improved test cases:
<img width="1725" alt="screen shot 2016-08-29 at 11 12 32 pm" src="https://cloud.githubusercontent.com/assets/831192/18151763/93882e6c-6fbf-11e6-8e68-905f3ed6cb18.png">
<img width="1686" alt="screen shot 2016-08-29 at 11 18 40 pm" src="https://cloud.githubusercontent.com/assets/831192/18151764/938d07fc-6fbf-11e6-8c8d-e89fc83ce4a4.png">
<img width="1556" alt="screen shot 2016-08-29 at 11 22 10 pm" src="https://cloud.githubusercontent.com/assets/831192/18151766/938db01c-6fbf-11e6-80c4-a7e36ad6b55e.png">
<img width="1685" alt="screen shot 2016-08-29 at 11 23 37 pm" src="https://cloud.githubusercontent.com/assets/831192/18151767/938dbdf0-6fbf-11e6-919c-133be9549fd0.png">
<img width="1685" alt="screen shot 2016-08-29 at 11 25 14 pm" src="https://cloud.githubusercontent.com/assets/831192/18151765/938d1026-6fbf-11e6-9137-0de558bb710f.png">
<img width="1916" alt="screen shot 2016-08-29 at 11 35 20 pm" src="https://cloud.githubusercontent.com/assets/831192/18151824/f3bb8fd6-6fbf-11e6-9828-6551b1b70be2.png">
<img width="1722" alt="screen shot 2016-08-29 at 11 37 07 pm" src="https://cloud.githubusercontent.com/assets/831192/18151825/f432f134-6fbf-11e6-83bc-d8edf03fb2b8.png">

Test cases with awkward wording:
<img width="1588" alt="screen shot 2016-08-29 at 11 26 20 pm" src="https://cloud.githubusercontent.com/assets/831192/18151842/169d8324-6fc0-11e6-8088-ff59639c329e.png">
<img width="1917" alt="screen shot 2016-08-29 at 11 27 16 pm" src="https://cloud.githubusercontent.com/assets/831192/18151844/16a22604-6fc0-11e6-85e9-75f0ab000052.png">
<img width="1582" alt="screen shot 2016-08-29 at 11 30 20 pm" src="https://cloud.githubusercontent.com/assets/831192/18151846/16a341b0-6fc0-11e6-86aa-217a1176538e.png">
<img width="1650" alt="screen shot 2016-08-29 at 11 31 21 pm" src="https://cloud.githubusercontent.com/assets/831192/18151845/16a254da-6fc0-11e6-9749-569bf585af80.png">
<img width="1656" alt="screen shot 2016-08-29 at 11 32 37 pm" src="https://cloud.githubusercontent.com/assets/831192/18151847/16a5bc24-6fc0-11e6-907b-831c1d9e30f6.png">
<img width="1920" alt="screen shot 2016-08-29 at 11 33 26 pm" src="https://cloud.githubusercontent.com/assets/831192/18151843/16a21966-6fc0-11e6-8e1c-12ede4f20d60.png">
