### PR TITLE
Implement `replace_with`, a function similar to the one provided by the `take_mut` crate.

### DIFF
--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -426,7 +426,7 @@ impl Drop for ExitGuard {
     fn drop(&mut self) {
         // To avoid unwinding, we abort (we panic, which is equivalent to abort inside an unwinding
         // destructor) the program, which ensures that the destructor of the invalidated value
-        // isn't runned, since this destructor ought to be called only if unwinding happens.
+        // isn't run, since this destructor ought to be called only if unwinding happens.
         panic!("`replace_with` closure unwinded. For safety reasons, this will \
                 abort your program. Check the documentation");
     }
@@ -452,7 +452,7 @@ impl Drop for ExitGuard {
 /// let mut bx: Box<i32> = Box::new(200);
 ///
 /// // Temporarily steal ownership.
-/// mem::replace(&mut bx, |mut owned| {
+/// mem::replace_with(&mut bx, |mut owned| {
 ///     owner = 5;
 ///
 ///     // The returned value is placed back in `&mut bx`.
@@ -461,7 +461,7 @@ impl Drop for ExitGuard {
 /// ```
 #[inline]
 #[unstable(feature = "replace_with", issue = "...")]
-pub fn replace_with<T, F>(val: &mut T, replace: F)
+pub fn replace_with<T, F>(val: &mut T, closure: F)
     where F: FnOnce(T) -> T {
     // Guard against unwinding. Note that this is critical to safety, to avoid the value behind the
     // reference `val` is not dropped twice during unwinding.

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -422,9 +422,10 @@ struct ExitGuard;
 
 impl Drop for ExitGuard {
     fn drop(&mut self) {
-        // To avoid unwinding, we abort the program, which ensures that the destructor of the
-        // invalidated value isn't runned.
-        unsafe { intrinsics::abort(); }
+        // To avoid unwinding, we abort (we panic, which is equivalent to abort inside a
+        // destructor, which we are currently in) the program, which ensures that the destructor of
+        // the invalidated value isn't runned.
+        panic!();
     }
 }
 
@@ -436,7 +437,8 @@ impl Drop for ExitGuard {
 ///
 /// # An important note
 ///
-/// The behavior on panic (or to be more precise, unwinding) is unspecified (but not undefined).
+/// The behavior on panic (or to be more precise, unwinding) is specified to match the behavior of
+/// panicking inside a destructor, which itself is simply specified to not unwind.
 ///
 /// # Example
 ///

--- a/src/libcoretest/mem.rs
+++ b/src/libcoretest/mem.rs
@@ -117,7 +117,10 @@ fn test_replace_with_2() {
 fn test_replace_with_3() {
     let is_called = Cell::new(false);
     let mut x = 2;
-    replace_with(&mut x, |_| is_called.set(true));
+    replace_with(&mut x, |_| {
+        is_called.set(true);
+        3
+    });
     assert!(is_called.get());
 }
 

--- a/src/libcoretest/mem.rs
+++ b/src/libcoretest/mem.rs
@@ -100,6 +100,28 @@ fn test_replace() {
 }
 
 #[test]
+fn test_replace_with() {
+    let mut x = Some("test".to_string());
+    replace_with(&mut x, |_| None);
+    assert!(x.is_none());
+}
+
+#[test]
+fn test_replace_with_2() {
+    let mut x = Box::new(21);
+    replace_with(&mut x, |x| Box::new(x + 5));
+    assert_eq!(*x, 26);
+}
+
+#[test]
+fn test_replace_with_3() {
+    let is_called = Cell::new(false);
+    let mut x = 2;
+    replace_with(&mut x, |_| is_called.set(true));
+    assert!(is_called.get());
+}
+
+#[test]
 fn test_transmute_copy() {
     assert_eq!(1, unsafe { transmute_copy(&1) });
 }


### PR DESCRIPTION
`replace_with` invokes a closure that will temporarily move out of
reference and later place back the value.

This is a part of a RFC. I'm closing it so it can be reopened later.
