### PR TITLE
build.rs: don't build libbacktrace when SKIP_BACKTRACE is set

### DIFF
--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -62,6 +62,10 @@ fn main() {
 }
 
 fn build_libbacktrace(host: &str, target: &str) {
+    match env::var("SKIP_LIBBACKTRACE") {
+        Ok(_) => return,
+        _ => (),
+    };
     let src_dir = env::current_dir().unwrap().join("../libbacktrace");
     let build_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 


### PR DESCRIPTION
When cross-compiling libstd for an embedded environment, such as with
bitbake, we want to build libbacktrace ourselves for maximum
flexibility.  Since libbacktrace will already exist, we don't want cargo
to try and build it itself.
