### PR TITLE
Update nightly docs supported Windows versions to match Getting Started page

### DIFF
--- a/src/doc/book/nightly-rust.md
+++ b/src/doc/book/nightly-rust.md
@@ -54,7 +54,7 @@ binary downloads][install-page].
 
 Oh, we should also mention the officially supported platforms:
 
-* Windows (7, 8, Server 2008 R2)
+* Windows (7+)
 * Linux (2.6.18 or later, various distributions), x86 and x86-64
 * OSX 10.7 (Lion) or greater, x86 and x86-64
 


### PR DESCRIPTION
https://doc.rust-lang.org/book/getting-started.html#tier-1 shows that Windows 7+ is officially supported (implying, for example Windows 10), but the nightly page only listed 7, 8, and Server 2008 R2.
