### PR TITLE
rustbuild: add config.toml option to disable codegen tests

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -144,6 +144,7 @@ struct Rust {
     rpath: Option<bool>,
     optimize_tests: Option<bool>,
     debuginfo_tests: Option<bool>,
+    codegen_tests: Option<bool>,
 }
 
 /// TOML representation of how each build target is configured.
@@ -232,6 +233,7 @@ impl Config {
             set(&mut config.rust_optimize, rust.optimize);
             set(&mut config.rust_optimize_tests, rust.optimize_tests);
             set(&mut config.rust_debuginfo_tests, rust.debuginfo_tests);
+            set(&mut config.codegen_tests, rust.codegen_tests);
             set(&mut config.rust_rpath, rust.rpath);
             set(&mut config.debug_jemalloc, rust.debug_jemalloc);
             set(&mut config.use_jemalloc, rust.use_jemalloc);

--- a/src/bootstrap/config.toml.example
+++ b/src/bootstrap/config.toml.example
@@ -130,6 +130,10 @@
 #optimize-tests = true
 #debuginfo-tests = true
 
+# Flag indicating whether codegen tests will be run or not. If you get an error
+# saying that the FileCheck executable is missing, you may want to disable this.
+#codegen-tests = true
+
 # =============================================================================
 # Options for specific targets
 #


### PR DESCRIPTION
Fixes #36232.

I think it worked? Here's a build log where I tried to bootstrap, it crashed, then I added the setting to config.toml and it continued: https://gist.github.com/durka/cbf97cf04b8e065f1a2cfda4c1b6bf95

r? @alexcrichton 
