### PR TITLE
Add back feature accidentally removed

### DIFF
--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -305,6 +305,7 @@ declare_features! (
     (removed, struct_inherit, "1.0.0", None),
     (removed, test_removed_feature, "1.0.0", None),
     (removed, visible_private_types, "1.0.0", None),
+    (removed, unsafe_no_drop_flag, "1.0.0", None),
 );
 
 declare_features! (


### PR DESCRIPTION
This feature was accidentally removed in
https://github.com/rust-lang/rust/pull/35957.
