### PR TITLE
Fix "field is never used" warning to take unions into account

### DIFF
--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -548,7 +548,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for DeadVisitor<'a, 'tcx> {
     fn visit_struct_field(&mut self, field: &hir::StructField) {
         if self.should_warn_about_field(&field) {
             self.warn_dead_code(field.id, field.span,
-                                field.name, "struct field");
+                                field.name, "field");
         }
 
         intravisit::walk_struct_field(self, field);

--- a/src/test/compile-fail/lint-dead-code-4.rs
+++ b/src/test/compile-fail/lint-dead-code-4.rs
@@ -14,7 +14,7 @@
 
 struct Foo {
     x: usize,
-    b: bool, //~ ERROR: struct field is never used
+    b: bool, //~ ERROR: field is never used
 }
 
 fn field_read(f: Foo) -> usize {
@@ -46,8 +46,8 @@ enum IJK {
     I, //~ ERROR variant is never used
     J {
         a: String,
-        b: i32, //~ ERROR struct field is never used
-        c: i32, //~ ERROR struct field is never used
+        b: i32, //~ ERROR field is never used
+        c: i32, //~ ERROR field is never used
     },
     K //~ ERROR variant is never used
 
@@ -68,9 +68,9 @@ fn field_match_in_patterns(b: XYZ) -> String {
 }
 
 struct Bar {
-    x: usize, //~ ERROR: struct field is never used
+    x: usize, //~ ERROR: field is never used
     b: bool,
-    c: bool, //~ ERROR: struct field is never used
+    c: bool, //~ ERROR: field is never used
     _guard: ()
 }
 

--- a/src/test/compile-fail/union/union-lint-dead-code.rs
+++ b/src/test/compile-fail/union/union-lint-dead-code.rs
@@ -1,0 +1,26 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(untagged_unions)]
+#![deny(dead_code)]
+
+union Foo {
+    x: usize,
+    b: bool, //~ ERROR: field is never used
+    _unused: u16,
+}
+
+fn field_read(f: Foo) -> usize {
+    unsafe { f.x }
+}
+
+fn main() {
+    let _ = field_read(Foo { x: 2 });
+}


### PR DESCRIPTION
When compiling code containing a union with an unused field, rustc says
"struct field is never used".

Rather than saying "struct or union", or adding logic to determine the
type of the item, just change the message to "field is never used",
dropping the "struct".

Update tests accordingly.
