### PR TITLE
Make `private_in_public` compatibility lint warn-by-default again

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -114,7 +114,7 @@ declare_lint! {
 
 declare_lint! {
     pub PRIVATE_IN_PUBLIC,
-    Deny,
+    Warn,
     "detect private items in public interfaces not caught by the old implementation"
 }
 

--- a/src/librustc_privacy/diagnostics.rs
+++ b/src/librustc_privacy/diagnostics.rs
@@ -17,6 +17,8 @@ A private trait was used on a public type parameter bound. Erroneous code
 examples:
 
 ```compile_fail,E0445
+#![deny(private_in_public)]
+
 trait Foo {
     fn dummy(&self) { }
 }
@@ -45,6 +47,8 @@ E0446: r##"
 A private type was used in a public type signature. Erroneous code example:
 
 ```compile_fail,E0446
+#![deny(private_in_public)]
+
 mod Foo {
     struct Bar(u32);
 

--- a/src/test/compile-fail/issue-28514.rs
+++ b/src/test/compile-fail/issue-28514.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![deny(private_in_public)]
+
 pub use inner::C;
 
 mod inner {

--- a/src/test/compile-fail/issue-30079.rs
+++ b/src/test/compile-fail/issue-30079.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![deny(private_in_public)]
 #![allow(unused)]
 
 struct SemiPriv;

--- a/src/test/compile-fail/private-in-public-warn.rs
+++ b/src/test/compile-fail/private-in-public-warn.rs
@@ -13,8 +13,8 @@
 
 #![feature(associated_consts)]
 #![feature(associated_type_defaults)]
-#![allow(dead_code)]
-#![allow(unused_variables)]
+#![deny(private_in_public)]
+#![allow(unused)]
 #![allow(improper_ctypes)]
 
 mod types {

--- a/src/test/compile-fail/private-variant-and-crate-reexport.rs
+++ b/src/test/compile-fail/private-variant-and-crate-reexport.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![deny(private_in_public)]
 #![allow(dead_code)]
 
 extern crate core;


### PR DESCRIPTION
More details: https://internals.rust-lang.org/t/regression-report-stable-2016-08-16-vs-beta-2016-08-26/3930/10

r? @nikomatsakis 
