### PR TITLE
bmi_bextr needs 3 arguments

### DIFF
--- a/src/etc/platform-intrinsics/x86/bmi.json
+++ b/src/etc/platform-intrinsics/x86/bmi.json
@@ -7,7 +7,7 @@
             "width": ["0"],
             "llvm": "bextr.{0.bitwidth}",
             "ret": "S(32-64)u",
-            "args": ["0", "0"]
+            "args": ["0", "U32", "U32"]
         }
     ]
 }

--- a/src/librustc_platform_intrinsics/x86.rs
+++ b/src/librustc_platform_intrinsics/x86.rs
@@ -743,12 +743,12 @@ pub fn find(name: &str) -> Option<Intrinsic> {
             definition: Named("llvm.x86.bmi.pext.64")
         },
         "_bmi_bextr_32" => Intrinsic {
-            inputs: { static INPUTS: [&'static Type; 2] = [&::U32, &::U32]; &INPUTS },
+            inputs: { static INPUTS: [&'static Type; 3] = [&::U32, &::U32, &::U32]; &INPUTS },
             output: &::U32,
             definition: Named("llvm.x86.bmi.bextr.32")
         },
         "_bmi_bextr_64" => Intrinsic {
-            inputs: { static INPUTS: [&'static Type; 2] = [&::U64, &::U64]; &INPUTS },
+            inputs: { static INPUTS: [&'static Type; 3] = [&::U64, &::U32, &::U32]; &INPUTS },
             output: &::U64,
             definition: Named("llvm.x86.bmi.bextr.64")
         },


### PR DESCRIPTION
The second and thrid args are u32 for both the 32bit and 64bit instruction.

Also, worth noting that `python generator.py --format compiler-defs -i x86/info.json x86/avx* x86/bmi* x86/fma.json x86/sse* x86/tbm.json` generated code that was missing a bunch of intrinsics, so I ended up just `git add -p`.
