### PR TITLE
Fix issue #36036.

### DIFF
--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -856,10 +856,10 @@ impl<'a, 'gcx, 'tcx> Layout {
             ty::TyRef(_, ty::TypeAndMut { ty: pointee, .. }) |
             ty::TyRawPtr(ty::TypeAndMut { ty: pointee, .. }) => {
                 let non_zero = !ty.is_unsafe_ptr();
+                let pointee = normalize_associated_type(infcx, pointee);
                 if pointee.is_sized(tcx, &infcx.parameter_environment, DUMMY_SP) {
                     Scalar { value: Pointer, non_zero: non_zero }
                 } else {
-                    let pointee = normalize_associated_type(infcx, pointee);
                     let unsized_part = tcx.struct_tail(pointee);
                     let meta = match unsized_part.sty {
                         ty::TySlice(_) | ty::TyStr => {

--- a/src/test/run-pass/issue-36036-associated-type-layout.rs
+++ b/src/test/run-pass/issue-36036-associated-type-layout.rs
@@ -1,0 +1,36 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue 36036: computing the layout of a type composed from another
+// trait's associated type caused compiler to ICE when the associated
+// type was allowed to be unsized, even though the known instantiated
+// type is itself sized.
+
+#![allow(dead_code)]
+
+trait Context {
+    type Container: ?Sized;
+}
+
+impl Context for u16 {
+    type Container = u8;
+}
+
+struct Wrapper<C: Context+'static> {
+    container: &'static C::Container
+}
+
+fn foobar(_: Wrapper<u16>) {}
+
+static VALUE: u8 = 0;
+
+fn main() {
+    foobar(Wrapper { container: &VALUE });
+}


### PR DESCRIPTION
Fix #36036.

We were treating an associated type as unsized even when the concrete instantiation was actually sized. Fix is to normalize before checking if it is sized.
