### PR TITLE
resolve: Suggest `use self` when import resolves

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -588,18 +588,16 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
             Success(module) => module,
             Indeterminate => return Indeterminate,
             Failed(err) => {
-                let self_module = self.current_module.clone();
+                let self_module = self.module_map[&self.current_module.normal_ancestor_id.unwrap()];
 
                 let resolve_from_self_result = self.resolve_module_path_from_root(
                     &self_module, &module_path, 0, Some(span));
 
-                return match resolve_from_self_result {
-                    Success(_) => {
-                        let msg = format!("Did you mean `self::{}`?",
-                                          &names_to_string(module_path));
-                        Failed(Some((span, msg)))
-                    },
-                    _ => Failed(err),
+                return if let Success(_) = resolve_from_self_result {
+                    let msg = format!("Did you mean `self::{}`?", &names_to_string(module_path));
+                    Failed(Some((span, msg)))
+                } else {
+                    Failed(err)
                 };
             },
         };

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -587,7 +587,21 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
         let module = match module_result {
             Success(module) => module,
             Indeterminate => return Indeterminate,
-            Failed(err) => return Failed(err),
+            Failed(err) => {
+                let self_module = self.current_module.clone();
+
+                let resolve_from_self_result = self.resolve_module_path_from_root(
+                    &self_module, &module_path, 0, Some(span));
+
+                return match resolve_from_self_result {
+                    Success(_) => {
+                        let msg = format!("Did you mean `self::{}`?",
+                                          &names_to_string(module_path));
+                        Failed(Some((span, msg)))
+                    },
+                    _ => Failed(err),
+                };
+            },
         };
 
         let (name, value_result, type_result) = match directive.subclass {

--- a/src/test/compile-fail/unresolved-import.rs
+++ b/src/test/compile-fail/unresolved-import.rs
@@ -35,3 +35,12 @@ mod food {
         }
     }
 }
+
+mod m {
+    enum MyEnum {
+        MyVariant
+    }
+
+    use MyEnum::*; //~ ERROR unresolved import `MyEnum::*` [E0432]
+                   //~^ Did you mean `self::MyEnum`?
+}

--- a/src/test/compile-fail/unresolved-import.rs
+++ b/src/test/compile-fail/unresolved-import.rs
@@ -44,3 +44,14 @@ mod m {
     use MyEnum::*; //~ ERROR unresolved import `MyEnum::*` [E0432]
                    //~^ Did you mean `self::MyEnum`?
 }
+
+mod items {
+    enum Enum {
+        Variant
+    }
+
+    use Enum::*; //~ ERROR unresolved import `Enum::*` [E0432]
+                 //~^ Did you mean `self::Enum`?
+
+    fn item() {}
+}


### PR DESCRIPTION
Improves errors messages by replacing "Maybe a missing `extern crate`" messages
with "Did you mean `self::...`" when the `self` import would succeed.

Fixes #34191.

Thank you for the help @jseyfried!
