### PR TITLE
rustbuild: per target musl-root

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -59,8 +59,9 @@ pub fn std<'a>(build: &'a Build, target: &str, compiler: &Compiler<'a>) {
             cargo.env("JEMALLOC_OVERRIDE", jemalloc);
         }
     }
-    if let Some(ref p) = build.config.musl_root {
-        if target.contains("musl") {
+    if target.contains("musl") {
+        if let Some(p) = build.config.target_config[target].musl_root.as_ref()
+            .or(build.config.musl_root.as_ref()) {
             cargo.env("MUSL_ROOT", p);
         }
     }

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -60,8 +60,7 @@ pub fn std<'a>(build: &'a Build, target: &str, compiler: &Compiler<'a>) {
         }
     }
     if target.contains("musl") {
-        if let Some(p) = build.config.target_config[target].musl_root.as_ref()
-            .or(build.config.musl_root.as_ref()) {
+        if let Some(p) = build.musl_root(target) {
             cargo.env("MUSL_ROOT", p);
         }
     }

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -76,6 +76,7 @@ pub struct Config {
 
     // misc
     pub channel: String,
+    // Fallback musl-root for all targets
     pub musl_root: Option<PathBuf>,
     pub prefix: Option<String>,
     pub codegen_tests: bool,
@@ -89,6 +90,7 @@ pub struct Target {
     pub cc: Option<PathBuf>,
     pub cxx: Option<PathBuf>,
     pub ndk: Option<PathBuf>,
+    pub musl_root: Option<PathBuf>,
 }
 
 /// Structure of the `config.toml` file that configuration is read from.

--- a/src/bootstrap/config.toml.example
+++ b/src/bootstrap/config.toml.example
@@ -115,10 +115,6 @@
 # nightly features
 #channel = "dev"
 
-# The root location of the MUSL installation directory. The library directory
-# will also need to contain libunwind.a for an unwinding implementation.
-#musl-root = "..."
-
 # By default the `rustc` executable is built with `-Wl,-rpath` flags on Unix
 # platforms to ensure that the compiler is usable by default from the build
 # directory (as it links to a number of dynamic libraries). This may not be
@@ -160,3 +156,9 @@
 # the NDK for the target lives. This is used to find the C compiler to link and
 # build native code.
 #android-ndk = "/path/to/ndk"
+
+# The root location of the MUSL installation directory. The library directory
+# will also need to contain libunwind.a for an unwinding implementation. Note
+# that this option only makes sense for MUSL targets that produce statically
+# linked binaries
+#musl-root = "..."

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -977,6 +977,13 @@ impl Build {
         }
         return base
     }
+
+    /// Returns the "musl root" for this `target`, if defined
+    fn musl_root(&self, target: &str) -> Option<&Path> {
+        self.config.target_config[target].musl_root.as_ref()
+            .or(self.config.musl_root.as_ref())
+            .map(|p| &**p)
+    }
 }
 
 impl<'a> Compiler<'a> {

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -111,8 +111,7 @@ pub fn check(build: &mut Build) {
 
         // Make sure musl-root is valid if specified
         if target.contains("musl") && !target.contains("mips") {
-            match build.config.target_config[target].musl_root.as_ref()
-                .or(build.config.musl_root.as_ref()) {
+            match build.musl_root(target) {
                 Some(root) => {
                     if fs::metadata(root.join("lib/libc.a")).is_err() {
                         panic!("couldn't find libc.a in musl dir: {}",

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -111,8 +111,9 @@ pub fn check(build: &mut Build) {
 
         // Make sure musl-root is valid if specified
         if target.contains("musl") && !target.contains("mips") {
-            match build.config.musl_root {
-                Some(ref root) => {
+            match build.config.target_config[target].musl_root.as_ref()
+                .or(build.config.musl_root.as_ref()) {
+                Some(root) => {
                     if fs::metadata(root.join("lib/libc.a")).is_err() {
                         panic!("couldn't find libc.a in musl dir: {}",
                                root.join("lib").display());
@@ -123,8 +124,9 @@ pub fn check(build: &mut Build) {
                     }
                 }
                 None => {
-                    panic!("when targeting MUSL the build.musl-root option \
-                            must be specified in config.toml")
+                    panic!("when targeting MUSL either the build.musl-root \
+                            option or the target.$TARGET.musl-root one must \
+                            be specified in config.toml")
                 }
             }
         }


### PR DESCRIPTION
config.toml now accepts a target.$TARGET.musl-root key that lets you
override the "build" musl-root value, which is set via the --musl-root
flag or via the build.musl-root key.

With this change, it's now possible to compile std for several musl
targets at once. Here's are the sample commands to do such thing:

```
$ configure \
    --enable-rustbuild \
    --target=x86_64-unknown-linux-musl,arm-unknown-linux-musleabi \
    --musl-root=/musl/x86_64-unknown-linux-musl/

$ edit config.toml && tail config.toml
[target.arm-unknown-linux-musleabi]
musl-root = "/x-tools/arm-unknown-linux-musleabi/arm-unknown-linux-musleabi/sysroot/usr"

$ make
```

r? @alexcrichton 
With this we should be able to start producing releases of std for arm musl targets
