### PR TITLE
rustdoc: don't collapse `docblock-short`

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1834,7 +1834,7 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
                        <tr class='{stab} module-item'>
                            <td><a class='{class}' href='{href}'
                                   title='{title}'>{name}</a></td>
-                           <td class='docblock short'>
+                           <td class='docblock-short'>
                                {stab_docs} {docs}
                            </td>
                        </tr>",

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -239,23 +239,23 @@ nav.sub {
 }
 .line-numbers span { cursor: pointer; }
 
-.docblock.short p {
+.docblock-short p {
     display: inline;
 }
 
-.docblock.short.nowrap {
+.docblock-short.nowrap {
     display: block;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
 }
 
-.docblock.short p {
+.docblock-short p {
     overflow: hidden;
     text-overflow: ellipsis;
     margin: 0;
 }
-.docblock.short code { white-space: nowrap; }
+.docblock-short code { white-space: nowrap; }
 
 .docblock h1, .docblock h2, .docblock h3, .docblock h4, .docblock h5 {
     border-bottom: 1px solid;

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -130,11 +130,11 @@ code, pre {
     font-family: "Source Code Pro", Menlo, Monaco, Consolas, "DejaVu Sans Mono", Inconsolata, monospace;
     white-space: pre-wrap;
 }
-.docblock code {
+.docblock code, .docblock-short code {
     border-radius: 3px;
     padding: 0 0.2em;
 }
-.docblock pre code {
+.docblock pre code, .docblock-short pre code {
     padding: 0;
 }
 pre {
@@ -409,7 +409,7 @@ a {
     background: transparent;
 }
 
-.docblock a:hover, .stability a {
+.docblock a:hover, .docblock-short a:hover, .stability a {
     text-decoration: underline;
 }
 

--- a/src/librustdoc/html/static/styles/main.css
+++ b/src/librustdoc/html/static/styles/main.css
@@ -34,7 +34,7 @@ div.stability > em > code {
     background-color: initial;
 }
 
-.docblock code {
+.docblock code, .docblock-short code {
     background-color: #F5F5F5;
 }
 pre {
@@ -113,7 +113,7 @@ a {
     color: #000;
 }
 
-.docblock a, .stability a {
+.docblock a, .docblock-short a, .stability a {
     color: #3873AD;
 }
 

--- a/src/test/rustdoc/issue-32374.rs
+++ b/src/test/rustdoc/issue-32374.rs
@@ -13,7 +13,7 @@
 
 #![unstable(feature="test", issue = "32374")]
 
-// @has issue_32374/index.html '//*[@class="docblock short"]' \
+// @has issue_32374/index.html '//*[@class="docblock-short"]' \
 //      '[Deprecated] [Unstable]'
 
 // @has issue_32374/struct.T.html '//*[@class="stab deprecated"]' \


### PR DESCRIPTION
![docblock-short](https://cloud.githubusercontent.com/assets/346530/18267298/137d2542-7451-11e6-9c8e-dd4e1f1fea29.png)
