### PR TITLE
Count and report time taken by MIR passes

### DIFF
--- a/src/librustc/mir/transform.rs
+++ b/src/librustc/mir/transform.rs
@@ -15,7 +15,9 @@ use mir::mir_map::MirMap;
 use mir::repr::{Mir, Promoted};
 use ty::TyCtxt;
 use syntax::ast::NodeId;
+use util::common::time;
 
+use std::borrow::Cow;
 use std::fmt;
 
 /// Where a specific Mir comes from.
@@ -72,12 +74,12 @@ impl<'a, 'tcx> MirSource {
 /// Various information about pass.
 pub trait Pass {
     // fn should_run(Session) to check if pass should run?
-    fn name(&self) -> &str {
+    fn name<'a>(&self) -> Cow<'static, str> {
         let name = unsafe { ::std::intrinsics::type_name::<Self>() };
         if let Some(tail) = name.rfind(":") {
-            &name[tail+1..]
+            Cow::from(&name[tail+1..])
         } else {
-            name
+            Cow::from(name)
         }
     }
     fn disambiguator<'a>(&'a self) -> Option<Box<fmt::Display+'a>> { None }
@@ -162,11 +164,10 @@ impl<'a, 'tcx> Passes {
     }
 
     pub fn run_passes(&mut self, tcx: TyCtxt<'a, 'tcx, 'tcx>, map: &mut MirMap<'tcx>) {
-        for pass in &mut self.plugin_passes {
-            pass.run_pass(tcx, map, &mut self.pass_hooks);
-        }
-        for pass in &mut self.passes {
-            pass.run_pass(tcx, map, &mut self.pass_hooks);
+        let Passes { ref mut passes, ref mut plugin_passes, ref mut pass_hooks } = *self;
+        for pass in plugin_passes.iter_mut().chain(passes.iter_mut()) {
+            time(tcx.sess.time_passes(), &*pass.name(),
+                 || pass.run_pass(tcx, map, pass_hooks));
         }
     }
 

--- a/src/librustc_mir/transform/dump_mir.rs
+++ b/src/librustc_mir/transform/dump_mir.rs
@@ -26,7 +26,7 @@ impl<'b, 'tcx> MirPass<'tcx> for Marker<'b> {
 }
 
 impl<'b> Pass for Marker<'b> {
-    fn name(&self) -> &str { self.0 }
+    fn name(&self) -> ::std::borrow::Cow<'static, str> { String::from(self.0).into() }
 }
 
 pub struct Disambiguator<'a> {
@@ -58,7 +58,7 @@ impl<'tcx> MirPassHook<'tcx> for DumpMir {
     {
         pretty::dump_mir(
             tcx,
-            pass.name(),
+            &*pass.name(),
             &Disambiguator {
                 pass: pass,
                 is_after: is_after

--- a/src/librustc_mir/transform/simplify_branches.rs
+++ b/src/librustc_mir/transform/simplify_branches.rs
@@ -62,5 +62,5 @@ impl<'l> Pass for SimplifyBranches<'l> {
     }
 
     // avoid calling `type_name` - it contains `<'static>`
-    fn name(&self) -> &str { "SimplifyBranches" }
+    fn name(&self) -> ::std::borrow::Cow<'static, str> { "SimplifyBranches".into() }
 }

--- a/src/librustc_mir/transform/simplify_cfg.rs
+++ b/src/librustc_mir/transform/simplify_cfg.rs
@@ -64,7 +64,7 @@ impl<'l> Pass for SimplifyCfg<'l> {
     }
 
     // avoid calling `type_name` - it contains `<'static>`
-    fn name(&self) -> &str { "SimplifyCfg" }
+    fn name(&self) -> ::std::borrow::Cow<'static, str> { "SimplifyCfg".into() }
 }
 
 pub struct CfgSimplifier<'a, 'tcx: 'a> {


### PR DESCRIPTION
There’s some desire for deeper introspectability into what MIR passes cost us.

-Z time-passes after this PR:

```
   Compiling test_shim v0.1.0 (file:///home/nagisa/Documents/rust/rust/src/rustc/test_shim)
time: 0.000; rss: 29MB  parsing
time: 0.000; rss: 29MB  configuration
time: 0.000; rss: 29MB  recursion limit
time: 0.000; rss: 29MB  crate injection
time: 0.000; rss: 29MB  plugin loading
time: 0.000; rss: 29MB  plugin registration
time: 0.032; rss: 54MB  expansion
time: 0.000; rss: 54MB  maybe building test harness
time: 0.000; rss: 54MB  assigning node ids
time: 0.000; rss: 54MB  checking for inline asm in case the target doesn't support it
time: 0.000; rss: 54MB  complete gated feature checking
time: 0.000; rss: 54MB  collecting defs
time: 0.004; rss: 54MB  external crate/lib resolution
time: 0.000; rss: 54MB  early lint checks
time: 0.000; rss: 54MB  AST validation
time: 0.001; rss: 54MB  name resolution
time: 0.000; rss: 54MB  lowering ast -> hir
time: 0.000; rss: 56MB  indexing hir
time: 0.000; rss: 56MB  attribute checking
time: 0.000; rss: 56MB  language item collection
time: 0.000; rss: 56MB  lifetime resolution
time: 0.000; rss: 56MB  looking for entry point
time: 0.000; rss: 56MB  looking for plugin registrar
time: 0.000; rss: 56MB  region resolution
time: 0.000; rss: 56MB  loop checking
time: 0.000; rss: 56MB  static item recursion checking
time: 0.000; rss: 56MB  compute_incremental_hashes_map
time: 0.000; rss: 56MB  load_dep_graph
time: 0.000; rss: 56MB  type collecting
time: 0.000; rss: 56MB  variance inference
time: 0.011; rss: 59MB  coherence checking
time: 0.000; rss: 59MB  wf checking
time: 0.000; rss: 59MB  item-types checking
time: 0.000; rss: 59MB  item-bodies checking
time: 0.000; rss: 59MB  drop-impl checking
time: 0.000; rss: 59MB  const checking
time: 0.000; rss: 59MB  privacy checking
time: 0.000; rss: 59MB  stability index
time: 0.000; rss: 59MB  intrinsic checking
time: 0.000; rss: 59MB  effect checking
time: 0.000; rss: 59MB  match checking
time: 0.000; rss: 59MB  liveness checking
time: 0.000; rss: 59MB  rvalue checking
time: 0.000; rss: 59MB  MIR dump
  time: 0.000; rss: 59MB    SimplifyCfg
  time: 0.000; rss: 59MB    QualifyAndPromoteConstants
  time: 0.000; rss: 59MB    TypeckMir
  time: 0.000; rss: 59MB    SimplifyBranches
  time: 0.000; rss: 59MB    SimplifyCfg
time: 0.000; rss: 59MB  MIR passes
time: 0.000; rss: 59MB  borrow checking
time: 0.000; rss: 59MB  reachability checking
time: 0.000; rss: 59MB  death checking
time: 0.000; rss: 59MB  stability checking
time: 0.000; rss: 59MB  unused lib feature checking
time: 0.000; rss: 59MB  lint checking
time: 0.000; rss: 59MB  resolving dependency formats
  time: 0.000; rss: 59MB    NoLandingPads
  time: 0.000; rss: 59MB    SimplifyCfg
  time: 0.000; rss: 59MB    EraseRegions
  time: 0.000; rss: 59MB    AddCallGuards
  time: 0.000; rss: 59MB    ElaborateDrops
  time: 0.000; rss: 59MB    NoLandingPads
  time: 0.000; rss: 59MB    SimplifyCfg
  time: 0.000; rss: 59MB    Deaggregator
  time: 0.000; rss: 59MB    AddCallGuards
  time: 0.000; rss: 59MB    PreTrans
time: 0.000; rss: 59MB  Prepare MIR codegen passes
  time: 0.000; rss: 59MB    write metadata
  time: 0.000; rss: 61MB    translation item collection
  time: 0.000; rss: 61MB    codegen unit partitioning
  time: 0.000; rss: 61MB    internalize symbols
time: 0.007; rss: 61MB  translation
time: 0.000; rss: 61MB  assert dep graph
time: 0.000; rss: 61MB  serialize dep graph
time: 0.000; rss: 61MB  llvm function passes [2]
time: 0.000; rss: 61MB  llvm function passes [3]
time: 0.000; rss: 61MB  llvm function passes [1]
time: 0.000; rss: 61MB  llvm function passes [0]
time: 0.000; rss: 61MB  llvm module passes [2]
time: 0.000; rss: 61MB  llvm module passes [1]
time: 0.000; rss: 61MB  llvm module passes [0]
time: 0.000; rss: 61MB  llvm module passes [3]
time: 0.001; rss: 62MB  codegen passes [1]
time: 0.001; rss: 62MB  codegen passes [2]
time: 0.001; rss: 62MB  codegen passes [0]
time: 0.001; rss: 62MB  codegen passes [3]
time: 0.001; rss: 63MB  codegen passes [1]
time: 0.005; rss: 63MB  LLVM passes
time: 0.000; rss: 63MB  serialize work products
time: 0.001; rss: 63MB  linking
```

r? @eddyb or @nikomatsakis 

cc @nrc, @Mark-Simulacrum 
