### PR TITLE
Point macros 1.1 errors to the input item

### DIFF
--- a/src/libsyntax_ext/deriving/custom.rs
+++ b/src/libsyntax_ext/deriving/custom.rs
@@ -53,6 +53,7 @@ impl MultiItemModifier for CustomDerive {
             }
         }
 
+        let input_span = item.span;
         let input = __internal::new_token_stream(item);
         let res = __internal::set_parse_sess(&ecx.parse_sess, || {
             let inner = self.inner;
@@ -77,9 +78,9 @@ impl MultiItemModifier for CustomDerive {
 
         // Right now we have no knowledge of spans at all in custom derive
         // macros, everything is just parsed as a string. Reassign all spans to
-        // the #[derive] attribute for better errors here.
+        // the input `item` for better errors here.
         item.into_iter().flat_map(|item| {
-            ChangeSpan { span: span }.fold_item(item)
+            ChangeSpan { span: input_span }.fold_item(item)
         }).map(Annotatable::Item).collect()
     }
 }

--- a/src/test/compile-fail-fulldeps/rustc-macro/append-impl.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/append-impl.rs
@@ -23,8 +23,8 @@ trait Append {
 #[derive(PartialEq,
          Append,
          Eq)]
-//~^^ ERROR: the semantics of constant patterns is not yet settled
 struct A {
+//~^ ERROR: the semantics of constant patterns is not yet settled
     inner: u32,
 }
 

--- a/src/test/compile-fail-fulldeps/rustc-macro/expand-to-unstable-2.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/expand-to-unstable-2.rs
@@ -17,8 +17,8 @@
 extern crate derive_unstable_2;
 
 #[derive(Unstable)]
-//~^ ERROR: reserved for internal compiler
 struct A;
+//~^ ERROR: reserved for internal compiler
 
 fn main() {
     foo();

--- a/src/test/compile-fail-fulldeps/rustc-macro/expand-to-unstable.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/expand-to-unstable.rs
@@ -17,8 +17,8 @@
 extern crate derive_unstable;
 
 #[derive(Unstable)]
-//~^ ERROR: use of unstable library feature
 struct A;
+//~^ ERROR: use of unstable library feature
 
 fn main() {
     unsafe { foo(); }


### PR DESCRIPTION
Moved from https://github.com/alexcrichton/rust/pull/6 to continue discussion. Fixes #36218.

Before:

``` rust
error[E0106]: missing lifetime specifier
  --> src/main.rs:10:10
   |
10 | #[derive(Serialize, Deserialize)]
   |          ^ expected lifetime parameter

error[E0038]: the trait `T` cannot be made into an object
  --> src/main.rs:15:15
   |
15 | #[derive(Serialize, Deserialize)]
   |          ^^^^^^^^^^ the trait `T` cannot be made into an object
```

After:

``` rust
error[E0106]: missing lifetime specifier
  --> src/main.rs:11:1
   |
11 | struct A {
   | ^ expected lifetime parameter

error[E0038]: the trait `T` cannot be made into an object
  --> src/main.rs:16:1
   |
16 | struct B<'a> {
   | ^ the trait `T` cannot be made into an object
```
