### PR TITLE
Avoid instaiblity errors in code generated by `syntax_ext::deriving::call_intrinsic()`

### DIFF
--- a/src/libsyntax_ext/deriving/mod.rs
+++ b/src/libsyntax_ext/deriving/mod.rs
@@ -338,10 +338,19 @@ fn hygienic_type_parameter(item: &Annotatable, base: &str) -> String {
 
 /// Constructs an expression that calls an intrinsic
 fn call_intrinsic(cx: &ExtCtxt,
-                  span: Span,
+                  mut span: Span,
                   intrinsic: &str,
                   args: Vec<P<ast::Expr>>)
                   -> P<ast::Expr> {
+    span.expn_id = cx.codemap().record_expansion(codemap::ExpnInfo {
+        call_site: span,
+        callee: codemap::NameAndSpan {
+            format: codemap::MacroAttribute(intern("derive")),
+            span: Some(span),
+            allow_internal_unstable: true,
+        },
+    });
+
     let path = cx.std_path(&["intrinsics", intrinsic]);
     let call = cx.expr_call_global(span, path, args);
 

--- a/src/test/run-pass-fulldeps/auxiliary/custom_derive_partial_eq.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/custom_derive_partial_eq.rs
@@ -1,0 +1,81 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// force-host
+
+#![feature(plugin_registrar, rustc_private, item_like_imports)]
+
+extern crate syntax;
+extern crate syntax_ext;
+extern crate rustc_plugin;
+
+use syntax_ext::deriving;
+use deriving::generic::*;
+use deriving::generic::ty::*;
+
+use rustc_plugin::Registry;
+use syntax::ast::*;
+use syntax::codemap::Span;
+use syntax::ext::base::*;
+use syntax::ext::build::AstBuilder;
+use syntax::parse::token::{intern, InternedString};
+use syntax::ptr::P;
+
+#[plugin_registrar]
+pub fn plugin_registrar(reg: &mut Registry) {
+    reg.register_syntax_extension(intern("derive_CustomPartialEq"),
+                                  MultiDecorator(Box::new(expand_deriving_partial_eq)));
+}
+
+fn expand_deriving_partial_eq(cx: &mut ExtCtxt, span: Span, mitem: &MetaItem, item: &Annotatable,
+                              push: &mut FnMut(Annotatable)) {
+    // structures are equal if all fields are equal, and non equal, if
+    // any fields are not equal or if the enum variants are different
+    fn cs_eq(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> P<Expr> {
+        cs_fold(true,
+                |cx, span, subexpr, self_f, other_fs| {
+                    let other_f = (other_fs.len(), other_fs.get(0)).1.unwrap();
+                    let eq = cx.expr_binary(span, BinOpKind::Eq, self_f, other_f.clone());
+                    cx.expr_binary(span, BinOpKind::And, subexpr, eq)
+                },
+                cx.expr_bool(span, true),
+                Box::new(|cx, span, _, _| cx.expr_bool(span, false)),
+                cx,
+                span,
+                substr)
+    }
+
+    let inline = cx.meta_word(span, InternedString::new("inline"));
+    let attrs = vec!(cx.attribute(span, inline));
+    let methods = vec![MethodDef {
+        name: "eq",
+        generics: LifetimeBounds::empty(),
+        explicit_self: borrowed_explicit_self(),
+        args: vec!(borrowed_self()),
+        ret_ty: Literal(deriving::generic::ty::Path::new_local("bool")),
+        attributes: attrs,
+        is_unsafe: false,
+        unify_fieldless_variants: true,
+        combine_substructure: combine_substructure(Box::new(cs_eq)),
+    }];
+
+    let trait_def = TraitDef {
+        span: span,
+        attributes: Vec::new(),
+        path: deriving::generic::ty::Path::new(vec!["std", "cmp", "PartialEq"]),
+        additional_bounds: Vec::new(),
+        generics: LifetimeBounds::empty(),
+        is_unsafe: false,
+        supports_unions: false,
+        methods: methods,
+        associated_types: Vec::new(),
+    };
+    trait_def.expand(cx, mitem, item, push)
+}

--- a/src/test/run-pass-fulldeps/custom-derive-partial-eq.rs
+++ b/src/test/run-pass-fulldeps/custom-derive-partial-eq.rs
@@ -1,0 +1,22 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:custom_derive_partial_eq.rs
+// ignore-stage1
+// ignore-pretty : (#23623) problems when  ending with // comments
+
+#![feature(plugin, custom_derive)]
+#![plugin(custom_derive_partial_eq)]
+#![allow(unused)]
+
+#[derive(CustomPartialEq)] // Check that this is not a stability error.
+enum E { V1, V2 }
+
+fn main() {}


### PR DESCRIPTION
#35957 made old-style attribute syntax extensions no longer allow internal instability.

r? @eddyb 
