### PR TITLE
Add ThreadId for comparing threads

### DIFF
--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -1009,12 +1009,12 @@ mod tests {
 
     #[test]
     fn test_thread_id_equal() {
-        assert_eq!(ThreadId::current(), ThreadId::current());
+        assert!(thread::ThreadId::current() == thread::ThreadId::current());
     }
 
     #[test]
     fn test_thread_id_not_equal() {
-        assert!(ThreadId::current() != spawn(|| ThreadId::current()).join());
+        assert!(thread::ThreadId::current() != thread::spawn(|| thread::ThreadId::current()).join().unwrap());
     }
 
     // NOTE: the corresponding test for stderr is in run-pass/thread-stderr, due

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -550,6 +550,7 @@ impl ThreadId {
             // If we somehow use up all our bits, panic so that we're not
             // covering up subtle bugs of IDs being reused.
             if COUNTER == ::u64::MAX {
+                GUARD.unlock();
                 panic!("failed to generate unique thread ID: bitspace exhausted");
             }
 


### PR DESCRIPTION
This adds the capability to store and compare threads with the current calling thread via a new struct, `std::thread::ThreadId`. Addresses the need outlined in issue #21507.

This avoids the need to add any special checks to the existing thread structs and does not rely on the system to provide an identifier for a thread, since it seems that this approach is unreliable and undesirable. Instead, this simply uses a lazily-created, thread-local `usize` whose value is copied from a global atomic counter. The code should be simple enough that it should be as much reliable as the `#[thread_local]` attribute it uses (however much that is).

`ThreadId`s can be compared directly for equality and have copy semantics.

Also see these other attempts:
- rust-lang/rust#29457
- rust-lang/rust#29448
- rust-lang/rust#29447

And this in the RFC repo: rust-lang/rfcs#1435
