### PR TITLE
Allow setting --docdir

### DIFF
--- a/configure
+++ b/configure
@@ -671,6 +671,7 @@ valopt_nosave local-rust-root "/usr/local" "set prefix for local rust binary"
 valopt_nosave host "${CFG_BUILD}" "GNUs ./configure syntax LLVM host triples"
 valopt_nosave target "${CFG_HOST}" "GNUs ./configure syntax LLVM target triples"
 valopt_nosave mandir "${CFG_PREFIX}/share/man" "install man pages in PATH"
+valopt_nosave docdir "${CFG_PREFIX}/share/doc/rust" "install man pages in PATH"
 
 # On Windows this determines root of the subtree for target libraries.
 # Host runtime libs always go to 'bin'.
@@ -1116,6 +1117,7 @@ putvar CFG_STDCPP_NAME
 # a little post-processing of various config values
 CFG_PREFIX=${CFG_PREFIX%/}
 CFG_MANDIR=${CFG_MANDIR%/}
+CFG_DOCDIR=${CFG_DOCDIR%/}
 CFG_HOST="$(echo $CFG_HOST | tr ',' ' ')"
 CFG_TARGET="$(echo $CFG_TARGET | tr ',' ' ')"
 CFG_SUPPORTED_TARGET=""
@@ -1797,6 +1799,7 @@ putvar CFG_ARMV7_LINUX_ANDROIDEABI_NDK
 putvar CFG_I686_LINUX_ANDROID_NDK
 putvar CFG_NACL_CROSS_PATH
 putvar CFG_MANDIR
+putvar CFG_DOCDIR
 putvar CFG_USING_LIBCPP
 
 # Avoid spurious warnings from clang by feeding it original source on

--- a/mk/install.mk
+++ b/mk/install.mk
@@ -12,7 +12,8 @@ RUN_INSTALLER = cd tmp/empty_dir && \
 	sh ../../tmp/dist/$(1)/install.sh \
 		--prefix="$(DESTDIR)$(CFG_PREFIX)" \
 		--libdir="$(DESTDIR)$(CFG_LIBDIR)" \
-		--mandir="$(DESTDIR)$(CFG_MANDIR)"
+		--mandir="$(DESTDIR)$(CFG_MANDIR)" \
+		--docdir="$(DESTDIR)$(CFG_DOCDIR)"
 
 install:
 ifeq (root user, $(USER) $(patsubst %,user,$(SUDO_USER)))


### PR DESCRIPTION
This will allow setting `--docdir` during configure, this is useful because not all linux distributions install documentation to `/usr/share/doc`.  For example in Slackware documentation is installed to `/usr/doc/$PRGNAM-$VERSION` and `/usr/share/doc` is a symlink to `/usr/doc`.

To use this `./configure --docdir=/usr/doc/$PRGNAM-$VERSION` can be used.
