### PR TITLE
add `default` docstrings for `String` and `AtomicBool`

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -1567,6 +1567,7 @@ impl_eq! { Cow<'a, str>, String }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Default for String {
+    /// Create an empty `String`.
     #[inline]
     fn default() -> String {
         String::new()

--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -95,6 +95,7 @@ pub struct AtomicBool {
 #[cfg(target_has_atomic = "8")]
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Default for AtomicBool {
+    /// Create an `AtomicBool` initialized to `false`.
     fn default() -> Self {
         Self::new(false)
     }


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/36265.

These are all the instances of `Default` in this repository that are of the form `impl Default for X`. The default for `i32`, for example, is not of this form.

r? @GuillaumeGomez
