### PR TITLE
Include type of missing trait methods in error

### DIFF
--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -60,6 +60,27 @@ pub enum Node<'ast> {
     NodeTyParam(&'ast TyParam)
 }
 
+impl<'ast> Node<'ast> {
+    pub fn span(&self) -> Option<Span> {
+        match *self {
+            NodeItem(item) => Some(item.span),
+            NodeForeignItem(item) => Some(item.span),
+            NodeTraitItem(item) => Some(item.span),
+            NodeImplItem(item) => Some(item.span),
+            NodeVariant(_) => None,
+            NodeExpr(item) => Some(item.span),
+            NodeStmt(_) => None,
+            NodeTy(ty) => Some(ty.span),
+            NodeLocal(pat) => Some(pat.span),
+            NodePat(pat) => Some(pat.span),
+            NodeBlock(block) => Some(block.span),
+            NodeStructCtor(_) => None,
+            NodeLifetime(lifetime) => Some(lifetime.span),
+            NodeTyParam(ty) => Some(ty.span),
+        }
+    }
+}
+
 /// Represents an entry and its parent NodeID.
 /// The odd layout is to bring down the total size.
 #[derive(Copy, Debug)]

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -388,8 +388,8 @@ impl<'tcx> Method<'tcx> {
         };
 
         // unsafe fn name<'a, T>(args) -> ReturnType
-        //format!("{}fn {}{}({}){};", unsafety, name, type_args, args, return_signature)
-        format!("{}fn {}", unsafety, self.fty.sig.0)//name, type_args, args, return_signature)
+        format!("{}fn {}{}({}){};", unsafety, name, type_args, args, return_signature)
+        //format!("{}fn {}", unsafety, self.fty.sig.0)//name, type_args, args, return_signature)
     }
 }
 

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -244,27 +244,27 @@ impl<'tcx> ImplOrTraitItem<'tcx> {
                         match node.span() {
                             Some(span) => match tcx.sess.codemap().span_to_oneline_snippet(span) {
                                 Ok(snippet) => snippet,
-                                Err(_) => item.signature(),
+                                Err(_) => item.signature(tcx),
                             },
-                            None => item.signature(),
+                            None => item.signature(tcx),
                         }
                     }
-                    None => item.signature(),
+                    None => item.signature(tcx),
                 }
             }
-            TypeTraitItem(ref item) => item.signature(),
+            TypeTraitItem(ref item) => item.signature(tcx),
             ConstTraitItem(ref item) => {
                 match tcx.map.get_if_local(item.def_id) {
                     Some(node) => {
                         match node.span() {
                             Some(span) => match tcx.sess.codemap().span_to_oneline_snippet(span) {
                                 Ok(snippet) => snippet,
-                                Err(_) => item.signature(),
+                                Err(_) => item.signature(tcx),
                             },
-                            None => item.signature(),
+                            None => item.signature(tcx),
                         }
                     }
-                    None => item.signature(),
+                    None => item.signature(tcx),
                 }
             }
         }
@@ -362,7 +362,7 @@ impl<'tcx> Method<'tcx> {
         }
     }
 
-    pub fn signature(&self) -> String {
+    pub fn signature<'a>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>) -> String {
         let name = self.name.to_string();
         let unsafety = match self.fty.unsafety {
             hir::Unsafety::Unsafe => "unsafe ",
@@ -379,6 +379,7 @@ impl<'tcx> Method<'tcx> {
         };
         let args = self.fty.sig.inputs().0.iter()
             .map(|t| format!("{:?}", t)).collect::<Vec<_>>().join(", ");
+        //let return_type = format!("{}", tcx.item_name(self.fty.sig.output().0.def_id).as_str());
         let return_type = format!("{:?}", self.fty.sig.output().0);
         let return_signature = if &return_type == "()" {
             "".to_string()
@@ -387,7 +388,8 @@ impl<'tcx> Method<'tcx> {
         };
 
         // unsafe fn name<'a, T>(args) -> ReturnType
-        format!("{}fn {}{}({}){};", unsafety, name, type_args, args, return_signature)
+        //format!("{}fn {}{}({}){};", unsafety, name, type_args, args, return_signature)
+        format!("{}fn {}", unsafety, self.fty.sig.0)//name, type_args, args, return_signature)
     }
 }
 
@@ -417,13 +419,14 @@ pub struct AssociatedConst<'tcx> {
 }
 
 impl<'tcx> AssociatedConst<'tcx> {
-    pub fn signature(&self) -> String {
+    pub fn signature<'a>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>) -> String {
         // const FOO: Type = DEFAULT;
         let value = if self.has_value {
             " = <DEFAULT>"
         } else {
             ""
         };
+        //format!("const {}: {}{};", self.name.to_string(), tcx.item_name(self.ty.def_id).as_str(), value)
         format!("const {}: {:?}{};", self.name.to_string(), self.ty, value)
     }
 }
@@ -439,7 +442,7 @@ pub struct AssociatedType<'tcx> {
 }
 
 impl<'tcx> AssociatedType<'tcx> {
-    pub fn signature(&self) -> String {
+    pub fn signature<'a>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>) -> String {
         //// type Type;
         format!("type {};", self.name.to_string())
     }

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -151,6 +151,8 @@ impl EmitterWriter {
                 let mut hi = cm.lookup_char_pos(span_label.span.hi);
                 let mut is_minimized = false;
 
+                let start = lo.line;
+                let end = hi.line + 1;
                 // If the span is multi-line, simplify down to the span of one character
                 if lo.line != hi.line {
                     hi.line = lo.line;
@@ -167,16 +169,18 @@ impl EmitterWriter {
                     hi.col = CharPos(lo.col.0 + 1);
                 }
 
-                add_annotation_to_file(&mut output,
-                                        lo.file,
-                                        lo.line,
-                                        Annotation {
-                                            start_col: lo.col.0,
-                                            end_col: hi.col.0,
-                                            is_primary: span_label.is_primary,
-                                            is_minimized: is_minimized,
-                                            label: span_label.label.clone(),
-                                        });
+                for line in start..end {
+                    add_annotation_to_file(&mut output,
+                                            lo.file.clone(),
+                                            line,
+                                            Annotation {
+                                                start_col: lo.col.0,
+                                                end_col: hi.col.0,
+                                                is_primary: span_label.is_primary,
+                                                is_minimized: is_minimized,
+                                                label: span_label.label.clone(),
+                                            });
+                }
             }
         }
         output

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -109,22 +109,26 @@ impl EmitterWriter {
         fn add_annotation_to_file(file_vec: &mut Vec<FileWithAnnotatedLines>,
                                     file: Rc<FileMap>,
                                     line_index: usize,
-                                    ann: Annotation) {
+                                    annotation: Option<Annotation>) {
 
+            let ann = match annotation {
+                Some(ref ann) => vec![ann.clone()],
+                None => vec![]
+            };
             for slot in file_vec.iter_mut() {
                 // Look through each of our files for the one we're adding to
                 if slot.file.name == file.name {
                     // See if we already have a line for it
                     for line_slot in &mut slot.lines {
-                        if line_slot.line_index == line_index {
-                            line_slot.annotations.push(ann);
+                        if line_slot.line_index == line_index && annotation.is_some() {
+                            line_slot.annotations.push(annotation.unwrap());
                             return;
                         }
                     }
                     // We don't have a line yet, create one
                     slot.lines.push(Line {
                         line_index: line_index,
-                        annotations: vec![ann],
+                        annotations: ann,
                     });
                     slot.lines.sort();
                     return;
@@ -135,7 +139,7 @@ impl EmitterWriter {
                 file: file,
                 lines: vec![Line {
                                 line_index: line_index,
-                                annotations: vec![ann],
+                                annotations: ann,
                             }],
             });
         }
@@ -169,17 +173,24 @@ impl EmitterWriter {
                     hi.col = CharPos(lo.col.0 + 1);
                 }
 
-                for line in start..end {
-                    add_annotation_to_file(&mut output,
-                                            lo.file.clone(),
-                                            line,
-                                            Annotation {
-                                                start_col: lo.col.0,
-                                                end_col: hi.col.0,
-                                                is_primary: span_label.is_primary,
-                                                is_minimized: is_minimized,
-                                                label: span_label.label.clone(),
-                                            });
+                add_annotation_to_file(&mut output,
+                                        lo.file.clone(),
+                                        lo.line,
+                                        Some(Annotation {
+                                            start_col: lo.col.0,
+                                            end_col: hi.col.0,
+                                            is_primary: span_label.is_primary,
+                                            is_minimized: is_minimized,
+                                            label: span_label.label.clone(),
+                                        }));
+                if start != end {
+                    // Add the rest of the lines, without any annotation
+                    for line in start+1..end {
+                        add_annotation_to_file(&mut output,
+                                                lo.file.clone(),
+                                                line,
+                                                None);
+                    }
                 }
             }
         }

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -52,7 +52,7 @@ pub mod registry;
 pub mod styled_buffer;
 mod lock;
 
-use syntax_pos::{BytePos, Loc, FileLinesResult, FileName, MultiSpan, Span, NO_EXPANSION };
+use syntax_pos::{BytePos, Loc, FileLinesResult, FileName, MultiSpan, Span, NO_EXPANSION};
 use syntax_pos::{MacroBacktrace};
 
 #[derive(Clone)]

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -87,8 +87,7 @@ pub fn compare_impl_method<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                 err.span_label(span, & format!("`{}` used in trait",
                                                trait_m.explicit_self));
             }
-            err.note(&format!("Expected signature: {}", trait_m.signature()));
-            err.note(&format!("   Found signature: {}", impl_m.signature()));
+
             err.emit();
             return;
         }

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -87,6 +87,8 @@ pub fn compare_impl_method<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                 err.span_label(span, & format!("`{}` used in trait",
                                                trait_m.explicit_self));
             }
+            err.note(&format!("Expected signature: {}", trait_m.signature()));
+            err.note(&format!("   Found signature: {}", impl_m.signature()));
             err.emit();
             return;
         }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1124,7 +1124,12 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                     .collect::<Vec<_>>().join("`, `"))
             );
         for trait_item in missing_items {
-            err.note(&(trait_item.signature(tcx)));
+            err.note(&format!("definition {}", trait_item.signature(tcx)));
+            //err.note(&format!("node {:?}", tcx.map.trait_item.signature(tcx)));
+            if let Some(span) = tcx.map.span_if_local(trait_item.def_id()) {
+                //struct_span_err!(tcx.sess, span, E0046, "definition").emit();
+                err.span_note(span, "definition");//.emit();
+            }
         }
         err.emit();
     }

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -670,6 +670,63 @@ impl CodeMap {
         }
     }
 
+    /// Reformat `sp`'s snippet to oneline if it is available
+    ///
+    /// Given a snippet like:
+    ///
+    /// ```text
+    /// fn foo< 'lifetime, T >(
+    ///     &self,
+    ///     bar : &Type< 'lifetime, T>)
+    ///     -> std::result::Result<(),
+    ///         Error>;
+    /// ```
+    ///
+    /// it'll return:
+    ///
+    /// ```text
+    /// fn foo<'lifetime, T>(&self, bar: &Type<'lifetime, T>) -> std::result::Result<(), Error>;
+    /// ```
+    pub fn span_to_oneline_snippet(&self, sp: Span) -> Result<String, SpanSnippetError> {
+        let no_space_after = ["<", "("];
+        let no_space_before = [">", ")", ",", ":", ";"];
+
+        let snippet = self.span_to_snippet(sp);
+        match snippet {
+            Ok(snippet) => {
+                let mut it = snippet.split_whitespace();
+                let mut next = it.next();
+                let mut result = String::new();
+
+                loop {  // Remove spaces after `<` and `(` and before `>`, `)` `:` and `,`
+                    match next {
+                        Some(c) => {
+                            let peek = it.next();
+                            match peek {
+                                Some(n) => {
+                                    result.push_str(c);
+
+                                    if !(no_space_after.into_iter().any(|x| c.ends_with(x)) ||
+                                         no_space_before.into_iter().any(|x| n.starts_with(x))) {
+                                        result.push_str(" ");
+                                    }
+                                    next = peek;
+                                }
+                                None => {  // last item, don't skip
+                                    result.push_str(c);
+                                    next = peek;
+                                }
+                            }
+                        }
+                        None => break,  // end of iter
+                    }
+                }
+                Ok(result)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
     pub fn get_filemap(&self, filename: &str) -> Option<Rc<FileMap>> {
         for fm in self.files.borrow().iter() {
             if filename == fm.name {

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -342,7 +342,7 @@ impl CodeMap {
     }
 
     // If the relevant filemap is empty, we don't return a line number.
-    fn lookup_line(&self, pos: BytePos) -> Result<FileMapAndLine, Rc<FileMap>> {
+    pub fn lookup_line(&self, pos: BytePos) -> Result<FileMapAndLine, Rc<FileMap>> {
         let idx = self.lookup_filemap_idx(pos);
 
         let files = self.files.borrow();

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -80,6 +80,12 @@ impl Span {
         Span { lo: BytePos(lo), hi: self.hi, expn_id: self.expn_id}
     }
 
+    /// Returns a new span representing just the start-point of this span
+    pub fn start_point(self) -> Span {
+        let lo = cmp::min(self.lo.0, self.hi.0 - 1);
+        Span { lo: BytePos(lo), hi: BytePos(lo), expn_id: self.expn_id}
+    }
+
     /// Returns `self` if `self` is not the dummy span, and `other` otherwise.
     pub fn substitute_dummy(self, other: Span) -> Span {
         if self.source_equal(&DUMMY_SP) { other } else { self }

--- a/src/test/compile-fail/E0046.rs
+++ b/src/test/compile-fail/E0046.rs
@@ -17,6 +17,7 @@ struct Bar;
 impl Foo for Bar {}
 //~^ ERROR E0046
 //~| NOTE missing `foo` in implementation
+//~| NOTE fn foo();
 
 fn main() {
 }

--- a/src/test/compile-fail/impl-missing-items.rs
+++ b/src/test/compile-fail/impl-missing-items.rs
@@ -1,0 +1,48 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(associated_consts)]
+
+use std::str::FromStr;
+
+struct A {}
+
+trait X<T> {
+    type Foo;
+    const BAR: u32 = 128;
+
+    fn foo() -> T;
+    fn bar();
+    fn    bay<
+        'lifetime,    TypeParameterA
+            >(  a   : usize,
+                b: u8  );
+}
+
+impl std::fmt::Display for A {
+//~^ ERROR not all trait items implemented, missing: `fmt`
+//~| NOTE missing `fmt` in implementation
+//~| NOTE fn fmt(&Self, &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error>;
+
+}
+impl FromStr for A{}
+//~^ ERROR not all trait items implemented, missing: `Err`, `from_str`
+//~| NOTE missing `Err`, `from_str` in implementation
+//~| NOTE type Err;
+//~| NOTE fn from_str(&str) -> std::result::Result<Self, <Self as std::str::FromStr>::Err>;
+
+impl X<usize> for A {
+//~^ ERROR not all trait items implemented, missing: `Foo`, `foo`, `bar`, `bay`
+//~| NOTE missing `Foo`, `foo`, `bar`, `bay` in implementation
+//~| NOTE type Foo;
+//~| NOTE fn foo() -> T;
+//~| NOTE fn bar();
+//~| NOTE fn bay<'lifetime, TypeParameterA>(a: usize, b: u8);
+}

--- a/src/test/compile-fail/impl-wrong-item-for-trait.rs
+++ b/src/test/compile-fail/impl-wrong-item-for-trait.rs
@@ -22,6 +22,7 @@ pub struct FooConstForMethod;
 impl Foo for FooConstForMethod {
     //~^ ERROR E0046
     //~| NOTE missing `bar` in implementation
+    //~| NOTE fn bar(&self);
     const bar: u64 = 1;
     //~^ ERROR E0323
     //~| NOTE does not match trait
@@ -33,6 +34,7 @@ pub struct FooMethodForConst;
 impl Foo for FooMethodForConst {
     //~^ ERROR E0046
     //~| NOTE missing `MY_CONST` in implementation
+    //~| NOTE const MY_CONST: u32;
     fn bar(&self) {}
     fn MY_CONST() {}
     //~^ ERROR E0324
@@ -44,6 +46,7 @@ pub struct FooTypeForMethod;
 impl Foo for FooTypeForMethod {
     //~^ ERROR E0046
     //~| NOTE missing `bar` in implementation
+    //~| NOTE fn bar(&self);
     type bar = u64;
     //~^ ERROR E0325
     //~| NOTE does not match trait

--- a/src/test/compile-fail/issue-23729.rs
+++ b/src/test/compile-fail/issue-23729.rs
@@ -20,6 +20,7 @@ fn main() {
         impl Iterator for Recurrence {
             //~^ ERROR E0046
             //~| NOTE missing `Item` in implementation
+            //~| NOTE type Item;
             #[inline]
             fn next(&mut self) -> Option<u64> {
                 if self.pos < 2 {

--- a/src/test/compile-fail/issue-23827.rs
+++ b/src/test/compile-fail/issue-23827.rs
@@ -36,6 +36,7 @@ impl<C: Component> FnMut<(C,)> for Prototype {
 impl<C: Component> FnOnce<(C,)> for Prototype {
     //~^ ERROR E0046
     //~| NOTE missing `Output` in implementation
+    //~| NOTE type Output;
     extern "rust-call" fn call_once(self, (comp,): (C,)) -> Prototype {
         Fn::call(&self, (comp,))
     }

--- a/src/test/compile-fail/issue-24356.rs
+++ b/src/test/compile-fail/issue-24356.rs
@@ -30,6 +30,7 @@ fn main() {
         impl Deref for Thing {
             //~^ ERROR E0046
             //~| NOTE missing `Target` in implementation
+            //~| NOTE type Target;
             fn deref(&self) -> i8 { self.0 }
         }
 


### PR DESCRIPTION
For a given file `foo.rs`:

``` rust
use std::str::FromStr;

struct A {}

trait X<T> {
    type Foo;
    const BAR: u32 = 128;

    fn foo() -> T;
    fn bar();
    fn    bay<
        'lifetime,    TypeParameterA
            >(  a   : usize,
                b: u8  );
}

impl std::fmt::Display for A {
}
impl FromStr for A{}

impl X<usize> for A {
}
```

Provide the following output:

``` bash
error: main function not found

error[E0046]: not all trait items implemented, missing: `fmt`
  --> file2.rs:18:1
   |
18 | impl std::fmt::Display for A {
   | ^ missing `fmt` in implementation
   |
   = note: fn fmt(&Self, &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error>;

error[E0046]: not all trait items implemented, missing: `Err`, `from_str`
  --> file2.rs:20:1
   |
20 | impl FromStr for A{}
   | ^^^^^^^^^^^^^^^^^^^^ missing `Err`, `from_str` in implementation
   |
   = note: type Err;
   = note: fn from_str(&str) -> std::result::Result<Self, <Self as std::str::FromStr>::Err>;

error[E0046]: not all trait items implemented, missing: `Foo`, `foo`, `bar`, `bay`
  --> file2.rs:22:1
   |
22 | impl X<usize> for A {
   | ^ missing `Foo`, `foo`, `bar`, `bay` in implementation
   |
   = note: type Foo;
   = note: fn foo() -> T;
   = note: fn bar();
   = note: fn bay<'lifetime, TypeParameterA>(a: usize, b: u8);

error: aborting due to 3 previous errors
```

Fixes #24626

For a given file `foo.rs`:

``` rust
struct A {}

impl std::fmt::Display for A {
    fn fmt() -> () {}
}
```

provide the expected method signature:

``` bash
error: main function not found

error[E0186]: method `fmt` has a `&self` declaration in the trait, but not in the impl
 --> foo.rs:4:5
  |
4 |     fn fmt() -> () {}
  |     ^^^^^^^^^^^^^^^^^ expected `&self` in impl
  |
  = note: Expected signature: fn fmt(&Self, &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error>;
  = note:    Found signature: fn fmt();

error: aborting due to previous error
```

Fixes #28011
