### PR TITLE
Inherit overflow checks for sum and product

### DIFF
--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -1867,7 +1867,8 @@ pub trait Iterator {
     /// # Panics
     ///
     /// When calling `sum` and a primitive integer type is being returned, this
-    /// method will panic if the computation overflows.
+    /// method will panic if the computation overflows and debug assertions are
+    /// enabled.
     ///
     /// # Examples
     ///
@@ -1894,7 +1895,8 @@ pub trait Iterator {
     /// # Panics
     ///
     /// When calling `product` and a primitive integer type is being returned,
-    /// this method will panic if the computation overflows.
+    /// method will panic if the computation overflows and debug assertions are
+    /// enabled.
     ///
     /// # Examples
     ///

--- a/src/libcore/iter/traits.rs
+++ b/src/libcore/iter/traits.rs
@@ -7,6 +7,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+use ops::{Mul, Add};
 
 /// Conversion from an `Iterator`.
 ///
@@ -581,41 +582,35 @@ pub trait Product<A = Self>: Sized {
     fn product<I: Iterator<Item=A>>(iter: I) -> Self;
 }
 
+// NB: explicitly use Add and Mul here to inherit overflow checks
 macro_rules! integer_sum_product {
     ($($a:ident)*) => ($(
         #[stable(feature = "iter_arith_traits", since = "1.12.0")]
         impl Sum for $a {
+            #[rustc_inherit_overflow_checks]
             fn sum<I: Iterator<Item=$a>>(iter: I) -> $a {
-                iter.fold(0, |a, b| {
-                    a.checked_add(b).expect("overflow in sum")
-                })
+                iter.fold(0, Add::add)
             }
         }
 
         #[stable(feature = "iter_arith_traits", since = "1.12.0")]
         impl Product for $a {
             fn product<I: Iterator<Item=$a>>(iter: I) -> $a {
-                iter.fold(1, |a, b| {
-                    a.checked_mul(b).expect("overflow in product")
-                })
+                iter.fold(1, Mul::mul)
             }
         }
 
         #[stable(feature = "iter_arith_traits", since = "1.12.0")]
         impl<'a> Sum<&'a $a> for $a {
             fn sum<I: Iterator<Item=&'a $a>>(iter: I) -> $a {
-                iter.fold(0, |a, b| {
-                    a.checked_add(*b).expect("overflow in sum")
-                })
+                iter.cloned().fold(0, Add::add)
             }
         }
 
         #[stable(feature = "iter_arith_traits", since = "1.12.0")]
         impl<'a> Product<&'a $a> for $a {
             fn product<I: Iterator<Item=&'a $a>>(iter: I) -> $a {
-                iter.fold(1, |a, b| {
-                    a.checked_mul(*b).expect("overflow in product")
-                })
+                iter.cloned().fold(1, Mul::mul)
             }
         }
     )*)

--- a/src/libcore/iter/traits.rs
+++ b/src/libcore/iter/traits.rs
@@ -587,7 +587,6 @@ macro_rules! integer_sum_product {
     ($($a:ident)*) => ($(
         #[stable(feature = "iter_arith_traits", since = "1.12.0")]
         impl Sum for $a {
-            #[rustc_inherit_overflow_checks]
             fn sum<I: Iterator<Item=$a>>(iter: I) -> $a {
                 iter.fold(0, Add::add)
             }

--- a/src/test/run-pass/iter-sum-overflow-debug.rs
+++ b/src/test/run-pass/iter-sum-overflow-debug.rs
@@ -1,0 +1,35 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -C debug_assertions=yes
+
+use std::panic;
+
+fn main() {
+    let r = panic::catch_unwind(|| {
+        [1, i32::max_value()].iter().sum::<i32>();
+    });
+    assert!(r.is_err());
+
+    let r = panic::catch_unwind(|| {
+        [2, i32::max_value()].iter().product::<i32>();
+    });
+    assert!(r.is_err());
+
+    let r = panic::catch_unwind(|| {
+        [1, i32::max_value()].iter().cloned().sum::<i32>();
+    });
+    assert!(r.is_err());
+
+    let r = panic::catch_unwind(|| {
+        [2, i32::max_value()].iter().cloned().product::<i32>();
+    });
+    assert!(r.is_err());
+}

--- a/src/test/run-pass/iter-sum-overflow-ndebug.rs
+++ b/src/test/run-pass/iter-sum-overflow-ndebug.rs
@@ -1,0 +1,23 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -C debug_assertions=no
+
+fn main() {
+    assert_eq!([1i32, i32::max_value()].iter().sum::<i32>(),
+               1i32.wrapping_add(i32::max_value()));
+    assert_eq!([2i32, i32::max_value()].iter().product::<i32>(),
+               2i32.wrapping_mul(i32::max_value()));
+
+    assert_eq!([1i32, i32::max_value()].iter().cloned().sum::<i32>(),
+               1i32.wrapping_add(i32::max_value()));
+    assert_eq!([2i32, i32::max_value()].iter().cloned().product::<i32>(),
+               2i32.wrapping_mul(i32::max_value()));
+}


### PR DESCRIPTION
We have previously documented the fact that these will panic on overflow, but I think this behavior is what people actually want/expect. `#[rustc_inherit_overflow_checks]` didn't exist when we discussed these for stabilization.

r? @alexcrichton 

Closes #35807
