### PR TITLE
Update E0297 to new error format

### DIFF
--- a/src/librustc_const_eval/check_match.rs
+++ b/src/librustc_const_eval/check_match.rs
@@ -410,10 +410,13 @@ fn check_exhaustive<'a, 'tcx>(cx: &MatchCheckCtxt<'a, 'tcx>,
                         },
                         _ => bug!(),
                     };
-                    span_err!(cx.tcx.sess, sp, E0297,
+                    let pattern_string = pat_to_string(witness);
+                    struct_span_err!(cx.tcx.sess, sp, E0297,
                         "refutable pattern in `for` loop binding: \
                                 `{}` not covered",
-                                pat_to_string(witness));
+                                pattern_string)
+                        .span_label(sp, &format!("pattern `{}` not covered", pattern_string))
+                        .emit();
                 },
                 _ => {
                     let pattern_strings: Vec<_> = witnesses.iter().map(|w| {

--- a/src/test/compile-fail/E0297.rs
+++ b/src/test/compile-fail/E0297.rs
@@ -11,5 +11,7 @@
 fn main() {
     let xs : Vec<Option<i32>> = vec!(Some(1), None);
 
-    for Some(x) in xs {} //~ ERROR E0297
+    for Some(x) in xs {}
+    //~^ ERROR E0297
+    //~| NOTE pattern `None` not covered
 }


### PR DESCRIPTION
Fixes #35521.
Part of #35233.

I didn't attempt the bonus of narrowing the span to focus on the "for `<pattern>`" piece (it's my first time contributing), but I'm happy to do so given some hints.

r? @jonathandturner
