### PR TITLE
Detect missing `;` on methods with return type `()`

### DIFF
--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -10,9 +10,11 @@
 
 
 use check::FnCtxt;
-use rustc::ty::Ty;
-use rustc::infer::{InferOk};
+use hir::map::Node;
+use rustc::infer::{InferOk, TypeTrace};
 use rustc::traits::ObligationCause;
+use rustc::ty::Ty;
+use rustc::ty::error::TypeError;
 
 use syntax_pos::Span;
 use rustc::hir;
@@ -57,7 +59,47 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         if let Err(e) = self.try_coerce(expr, checked_ty, expected) {
             let cause = self.misc(expr.span);
             let expr_ty = self.resolve_type_vars_with_obligations(checked_ty);
-            self.report_mismatched_types(&cause, expected, expr_ty, e);
+            let trace = TypeTrace::types(&cause, true, expected, expr_ty);
+            let mut diag = self.report_and_explain_type_error(trace, &e);
+
+            if let Node::NodeBlock(block) = self.tcx.map
+                .get(self.tcx.map.get_parent_node(expr.id))
+            {
+                if let TypeError::Sorts(ref values) = e {
+                    if values.expected.is_nil() {
+                        // An implicit return to a method with return type `()`
+                        diag.span_label(expr.span,
+                                        &"possibly missing `;` here?");
+                        // Get the current node's method definition
+                        if let Node::NodeExpr(item) = self.tcx.map
+                            .get(self.tcx.map.get_parent_node(block.id))
+                        {
+                            // The fn has a default return type of ()
+                            if let Node::NodeItem(&hir::Item {
+                                name,
+                                node: hir::ItemFn(ref decl, ..),
+                                ..
+                            }) = self.tcx.map.get(self.tcx.map.get_parent_node(item.id)) {
+                                // `main` *must* have return type ()
+                                if name.as_str() != "main" {
+                                    decl.clone().and_then(|decl| {
+                                        if let hir::FnDecl {
+                                            output: hir::FunctionRetTy::DefaultReturn(span),
+                                            ..
+                                        } = decl {
+                                            diag.span_label(span,
+                                                            &format!("possibly return type `{}` \
+                                                                      missing in this fn?",
+                                                                     values.found));
+                                        }
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+            diag.emit();
         }
     }
 }

--- a/src/test/compile-fail/block-must-not-have-result-do.rs
+++ b/src/test/compile-fail/block-must-not-have-result-do.rs
@@ -10,6 +10,14 @@
 
 fn main() {
     loop {
-        true //~  ERROR mismatched types
+        true
+        //~^ ERROR mismatched types
+        //~| ERROR mismatched types
+        //~| NOTE: possibly missing `;` here?
+        //~| NOTE: expected (), found bool
+        //~| NOTE: expected type `()`
+        //~| NOTE: expected type `()`
+        //~| NOTE:    found type `bool`
+        //~| NOTE:    found type `bool`
     }
 }

--- a/src/test/compile-fail/block-must-not-have-result-do.rs
+++ b/src/test/compile-fail/block-must-not-have-result-do.rs
@@ -12,12 +12,9 @@ fn main() {
     loop {
         true
         //~^ ERROR mismatched types
-        //~| ERROR mismatched types
-        //~| NOTE: possibly missing `;` here?
+        //~| NOTE: consider adding a semicolon here
         //~| NOTE: expected (), found bool
         //~| NOTE: expected type `()`
-        //~| NOTE: expected type `()`
-        //~| NOTE:    found type `bool`
         //~| NOTE:    found type `bool`
     }
 }

--- a/src/test/compile-fail/block-must-not-have-result-res.rs
+++ b/src/test/compile-fail/block-must-not-have-result-res.rs
@@ -14,12 +14,9 @@ impl Drop for r {
     fn drop(&mut self) {
         true
         //~^ ERROR: mismatched types
-        //~| ERROR: mismatched types
-        //~| NOTE: possibly missing `;` here?
+        //~| NOTE: consider adding a semicolon here
         //~| NOTE: expected (), found bool
         //~| NOTE: expected type `()`
-        //~| NOTE: expected type `()`
-        //~| NOTE:    found type `bool`
         //~| NOTE:    found type `bool`
     }
 }

--- a/src/test/compile-fail/block-must-not-have-result-res.rs
+++ b/src/test/compile-fail/block-must-not-have-result-res.rs
@@ -12,7 +12,15 @@ struct r;
 
 impl Drop for r {
     fn drop(&mut self) {
-        true //~  ERROR mismatched types
+        true
+        //~^ ERROR: mismatched types
+        //~| ERROR: mismatched types
+        //~| NOTE: possibly missing `;` here?
+        //~| NOTE: expected (), found bool
+        //~| NOTE: expected type `()`
+        //~| NOTE: expected type `()`
+        //~| NOTE:    found type `bool`
+        //~| NOTE:    found type `bool`
     }
 }
 

--- a/src/test/compile-fail/block-must-not-have-result-while.rs
+++ b/src/test/compile-fail/block-must-not-have-result-while.rs
@@ -12,12 +12,9 @@ fn main() {
     while true {
         true
         //~^ ERROR: mismatched types
-        //~| ERROR: mismatched types
-        //~| NOTE: possibly missing `;` here?
+        //~| NOTE: consider adding a semicolon here
         //~| NOTE: expected (), found bool
         //~| NOTE: expected type `()`
-        //~| NOTE: expected type `()`
-        //~| NOTE:    found type `bool`
         //~| NOTE:    found type `bool`
     }
 }

--- a/src/test/compile-fail/block-must-not-have-result-while.rs
+++ b/src/test/compile-fail/block-must-not-have-result-while.rs
@@ -10,9 +10,14 @@
 
 fn main() {
     while true {
-        true //~  ERROR mismatched types
-             //~| expected type `()`
-             //~| found type `bool`
-             //~| expected (), found bool
+        true
+        //~^ ERROR: mismatched types
+        //~| ERROR: mismatched types
+        //~| NOTE: possibly missing `;` here?
+        //~| NOTE: expected (), found bool
+        //~| NOTE: expected type `()`
+        //~| NOTE: expected type `()`
+        //~| NOTE:    found type `bool`
+        //~| NOTE:    found type `bool`
     }
 }

--- a/src/test/compile-fail/consider-removing-last-semi.rs
+++ b/src/test/compile-fail/consider-removing-last-semi.rs
@@ -8,14 +8,22 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn f() -> String {  //~ ERROR mismatched types
+fn f() -> String {
+    //~^ ERROR mismatched types
+    //~| NOTE expected struct `std::string::String`, found ()
+    //~| NOTE expected type `std::string::String`
+    //~| NOTE found type `()`
     0u8;
-    "bla".to_string();  //~ HELP consider removing this semicolon
+    "bla".to_string();  //~ NOTE consider removing this semicolon
 }
 
-fn g() -> String {  //~ ERROR mismatched types
+fn g() -> String {
+    //~^ ERROR mismatched types
+    //~| NOTE expected struct `std::string::String`, found ()
+    //~| NOTE expected type `std::string::String`
+    //~| NOTE found type `()`
     "this won't work".to_string();
-    "removeme".to_string(); //~ HELP consider removing this semicolon
+    "removeme".to_string(); //~ NOTE consider removing this semicolon
 }
 
 fn main() {}

--- a/src/test/compile-fail/expected-return-on-unit.rs
+++ b/src/test/compile-fail/expected-return-on-unit.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,14 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Test that we do some basic error correcton in the tokeniser (and don't spew
+// too many bogus errors).
+
 fn main() {
-    &panic!()
-    //~^ ERROR mismatched types
-    //~| ERROR mismatched types
-    //~| NOTE: possibly missing `;` here?
-    //~| NOTE: expected (), found reference
-    //~| NOTE: expected type `()`
-    //~| NOTE: expected type `()`
-    //~| NOTE:    found type `&_`
-    //~| NOTE:    found type `&_`
+    return 1;
+    //~^ mismatched types
+    //~| expected type `()`
+    //~| found type `{integer}`
 }

--- a/src/test/compile-fail/issue-11714.rs
+++ b/src/test/compile-fail/issue-11714.rs
@@ -8,10 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn blah() -> i32 { //~ ERROR mismatched types
+fn blah() -> i32 {
+    //~^ ERROR mismatched types
+    //~| NOTE expected i32, found ()
+    //~| NOTE expected type `i32`
+    //~| NOTE found type `()`
     1
 
-    ; //~ HELP consider removing this semicolon:
+    ; //~ NOTE consider removing this semicolon
 }
 
 fn main() { }

--- a/src/test/compile-fail/issue-13428.rs
+++ b/src/test/compile-fail/issue-13428.rs
@@ -10,17 +10,25 @@
 
 // Regression test for #13428
 
-fn foo() -> String {  //~ ERROR mismatched types
+fn foo() -> String {
+    //~^ ERROR mismatched types
+    //~| NOTE expected struct `std::string::String`, found ()
+    //~| NOTE expected type `std::string::String`
+    //~| NOTE found type `()`
     format!("Hello {}",
             "world")
     // Put the trailing semicolon on its own line to test that the
     // note message gets the offending semicolon exactly
-    ;   //~ HELP consider removing this semicolon
+    ;   //~ NOTE consider removing this semicolon
 }
 
-fn bar() -> String {  //~ ERROR mismatched types
+fn bar() -> String {
+    //~^ ERROR mismatched types
+    //~| NOTE expected struct `std::string::String`, found ()
+    //~| NOTE expected type `std::string::String`
+    //~| NOTE found type `()`
     "foobar".to_string()
-    ;   //~ HELP consider removing this semicolon
+    ;   //~ NOTE consider removing this semicolon
 }
 
 pub fn main() {}

--- a/src/test/compile-fail/issue-13624.rs
+++ b/src/test/compile-fail/issue-13624.rs
@@ -16,12 +16,9 @@ mod a {
   pub fn get_enum_struct_variant() -> () {
     Enum::EnumStructVariant { x: 1, y: 2, z: 3 }
     //~^ ERROR: mismatched types
-    //~| ERROR: mismatched types
-    //~| NOTE: possibly missing `;` here?
+    //~| NOTE: consider adding a semicolon here
     //~| NOTE: expected (), found enum `a::Enum`
     //~| NOTE: expected type `()`
-    //~| NOTE: expected type `()`
-    //~| NOTE:    found type `a::Enum`
     //~| NOTE:    found type `a::Enum`
   }
 }

--- a/src/test/compile-fail/issue-13624.rs
+++ b/src/test/compile-fail/issue-13624.rs
@@ -15,10 +15,14 @@ mod a {
 
   pub fn get_enum_struct_variant() -> () {
     Enum::EnumStructVariant { x: 1, y: 2, z: 3 }
-    //~^ ERROR mismatched types
-    //~| expected type `()`
-    //~| found type `a::Enum`
-    //~| expected (), found enum `a::Enum`
+    //~^ ERROR: mismatched types
+    //~| ERROR: mismatched types
+    //~| NOTE: possibly missing `;` here?
+    //~| NOTE: expected (), found enum `a::Enum`
+    //~| NOTE: expected type `()`
+    //~| NOTE: expected type `()`
+    //~| NOTE:    found type `a::Enum`
+    //~| NOTE:    found type `a::Enum`
   }
 }
 
@@ -30,10 +34,10 @@ mod b {
       let enum_struct_variant = ::a::get_enum_struct_variant();
       match enum_struct_variant {
         a::Enum::EnumStructVariant { x, y, z } => {
-        //~^ ERROR mismatched types
-        //~| expected type `()`
-        //~| found type `a::Enum`
-        //~| expected (), found enum `a::Enum`
+        //~^ ERROR: mismatched types
+        //~| NOTE: expected (), found enum `a::Enum`
+        //~| NOTE: expected type `()`
+        //~| NOTE:    found type `a::Enum`
         }
       }
     }

--- a/src/test/compile-fail/issue-19109.rs
+++ b/src/test/compile-fail/issue-19109.rs
@@ -11,11 +11,16 @@
 trait Trait { }
 
 fn function(t: &mut Trait) {
+    //~^ NOTE: possibly return type `*mut Trait` missing in this fn?
     t as *mut Trait
- //~^ ERROR: mismatched types
- //~| NOTE: expected type `()`
- //~| NOTE:    found type `*mut Trait`
- //~| NOTE: expected (), found *-ptr
+    //~^ ERROR: mismatched types
+    //~| ERROR: mismatched types
+    //~| NOTE: possibly missing `;` here?
+    //~| NOTE: expected (), found *-ptr
+    //~| NOTE: expected type `()`
+    //~| NOTE: expected type `()`
+    //~| NOTE:    found type `*mut Trait`
+    //~| NOTE:    found type `*mut Trait`
 }
 
 fn main() { }

--- a/src/test/compile-fail/issue-19109.rs
+++ b/src/test/compile-fail/issue-19109.rs
@@ -11,16 +11,13 @@
 trait Trait { }
 
 fn function(t: &mut Trait) {
-    //~^ NOTE: possibly return type `*mut Trait` missing in this fn?
+    //~^ NOTE possibly return type `*mut Trait` missing here
     t as *mut Trait
-    //~^ ERROR: mismatched types
-    //~| ERROR: mismatched types
-    //~| NOTE: possibly missing `;` here?
-    //~| NOTE: expected (), found *-ptr
-    //~| NOTE: expected type `()`
-    //~| NOTE: expected type `()`
-    //~| NOTE:    found type `*mut Trait`
-    //~| NOTE:    found type `*mut Trait`
+    //~^ ERROR mismatched types
+    //~| NOTE consider adding a semicolon here
+    //~| NOTE expected (), found *-ptr
+    //~| NOTE expected type `()`
+    //~| NOTE    found type `*mut Trait`
 }
 
 fn main() { }

--- a/src/test/compile-fail/issue-20862.rs
+++ b/src/test/compile-fail/issue-20862.rs
@@ -9,20 +9,17 @@
 // except according to those terms.
 
 fn foo(x: i32) {
-    //~^ NOTE: possibly return type
+    //~^ NOTE possibly return type
     |y| x + y
-    //~^ ERROR: mismatched types
-    //~| ERROR: mismatched types
-    //~| NOTE: possibly missing `;` here?
-    //~| NOTE: expected (), found closure
-    //~| NOTE: expected type `()`
-    //~| NOTE: expected type `()`
-    //~| NOTE:    found type
-    //~| NOTE:    found type
+    //~^ ERROR mismatched types
+    //~| NOTE consider adding a semicolon here
+    //~| NOTE expected (), found closure
+    //~| NOTE expected type `()`
+    //~| NOTE    found type
 }
 
 
 fn main() {
     let x = foo(5)(2);
-    //~^ ERROR: expected function, found `()`
+    //~^ ERROR expected function, found `()`
 }

--- a/src/test/compile-fail/issue-22645.rs
+++ b/src/test/compile-fail/issue-22645.rs
@@ -24,4 +24,13 @@ fn main() {
   let b = Bob + 3.5;
   b + 3 //~ ERROR E0277
   //~^ ERROR: mismatched types
+  //~| ERROR: mismatched types
+  //~| NOTE: possibly missing `;` here?
+  //~| NOTE: expected (), found
+  //~| NOTE: expected type `()`
+  //~| NOTE: expected type `()`
+  //~| NOTE:    found type
+  //~| NOTE:    found type
+  //~| NOTE: the trait `Scalar` is not implemented for `{integer}`
+  //~| NOTE: required because of the requirements on the impl of `std::ops::Add<{integer}>`
 }

--- a/src/test/compile-fail/issue-22645.rs
+++ b/src/test/compile-fail/issue-22645.rs
@@ -24,13 +24,10 @@ fn main() {
   let b = Bob + 3.5;
   b + 3 //~ ERROR E0277
   //~^ ERROR: mismatched types
-  //~| ERROR: mismatched types
-  //~| NOTE: possibly missing `;` here?
-  //~| NOTE: expected (), found
-  //~| NOTE: expected type `()`
-  //~| NOTE: expected type `()`
-  //~| NOTE:    found type
-  //~| NOTE:    found type
-  //~| NOTE: the trait `Scalar` is not implemented for `{integer}`
-  //~| NOTE: required because of the requirements on the impl of `std::ops::Add<{integer}>`
+  //~| NOTE consider adding a semicolon here
+  //~| NOTE expected (), found
+  //~| NOTE expected type `()`
+  //~| NOTE    found type
+  //~| NOTE the trait `Scalar` is not implemented for `{integer}`
+  //~| NOTE required because of the requirements on the impl of `std::ops::Add<{integer}>`
 }

--- a/src/test/compile-fail/issue-3563.rs
+++ b/src/test/compile-fail/issue-3563.rs
@@ -13,6 +13,13 @@ trait A {
         || self.b()
         //~^ ERROR no method named `b` found for type `&Self` in the current scope
         //~| ERROR mismatched types
+        //~| ERROR mismatched types
+        //~| NOTE: possibly missing `;` here?
+        //~| NOTE: expected (), found closure
+        //~| NOTE: expected type `()`
+        //~| NOTE: expected type `()`
+        //~| NOTE:    found type
+        //~| NOTE:    found type
     }
 }
 fn main() {}

--- a/src/test/compile-fail/issue-3563.rs
+++ b/src/test/compile-fail/issue-3563.rs
@@ -9,17 +9,14 @@
 // except according to those terms.
 
 trait A {
-    fn a(&self) {
+    fn a(&self) { //~ possibly return type
         || self.b()
         //~^ ERROR no method named `b` found for type `&Self` in the current scope
         //~| ERROR mismatched types
-        //~| ERROR mismatched types
-        //~| NOTE: possibly missing `;` here?
-        //~| NOTE: expected (), found closure
-        //~| NOTE: expected type `()`
-        //~| NOTE: expected type `()`
-        //~| NOTE:    found type
-        //~| NOTE:    found type
+        //~| NOTE consider adding a semicolon here
+        //~| NOTE expected (), found closure
+        //~| NOTE expected type `()`
+        //~| NOTE    found type
     }
 }
 fn main() {}

--- a/src/test/compile-fail/issue-5500.rs
+++ b/src/test/compile-fail/issue-5500.rs
@@ -11,11 +11,7 @@
 fn main() {
     &panic!()
     //~^ ERROR mismatched types
-    //~| ERROR mismatched types
-    //~| NOTE: possibly missing `;` here?
-    //~| NOTE: expected (), found reference
-    //~| NOTE: expected type `()`
-    //~| NOTE: expected type `()`
-    //~| NOTE:    found type `&_`
-    //~| NOTE:    found type `&_`
+    //~| NOTE expected (), found reference
+    //~| NOTE expected type `()`
+    //~| NOTE    found type `&_`
 }

--- a/src/test/compile-fail/issue-6458-4.rs
+++ b/src/test/compile-fail/issue-6458-4.rs
@@ -8,8 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn foo(b: bool) -> Result<bool,String> { //~ ERROR mismatched types
-    Err("bar".to_string()); //~ HELP consider removing this semicolon
+fn foo(b: bool) -> Result<bool,String> {
+    //~^ ERROR mismatched types
+    //~| NOTE expected enum `std::result::Result`, found ()
+    //~| NOTE expected type `std::result::Result<bool, std::string::String>`
+    //~| NOTE found type `()`
+    Err("bar".to_string()); //~ NOTE consider removing this semicolon
 }
 
 fn main() {

--- a/src/test/compile-fail/liveness-return-last-stmt-semi.rs
+++ b/src/test/compile-fail/liveness-return-last-stmt-semi.rs
@@ -11,19 +11,37 @@
 // regression test for #8005
 
 macro_rules! test { () => { fn foo() -> i32 { 1; } } }
-                                           //~^ ERROR mismatched types
-                                           //~| HELP consider removing this semicolon
+//~^ ERROR mismatched types
+//~| NOTE expected i32, found ()
+//~| NOTE expected type `i32`
+//~| NOTE found type `()`
+//~| NOTE consider removing this semicolon
 
-fn no_return() -> i32 {} //~ ERROR mismatched types
+fn no_return() -> i32 {}
+    //~^ ERROR mismatched types
+    //~| NOTE expected i32, found ()
+    //~| NOTE expected type `i32`
+    //~| NOTE found type `()`
 
-fn bar(x: u32) -> u32 { //~ ERROR mismatched types
-    x * 2; //~ HELP consider removing this semicolon
+fn bar(x: u32) -> u32 {
+    //~^ ERROR mismatched types
+    //~| NOTE expected u32, found ()
+    //~| NOTE expected type `u32`
+    //~| NOTE found type `()`
+    x * 2; //~ NOTE consider removing this semicolon
 }
 
-fn baz(x: u64) -> u32 { //~ ERROR mismatched types
+fn baz(x: u64) -> u32 {
+    //~^ ERROR mismatched types
+    //~| NOTE expected u32, found ()
+    //~| NOTE expected type `u32`
+    //~| NOTE found type `()`
     x * 2;
 }
 
 fn main() {
     test!();
+    //~^ NOTE in this expansion of test!
+    //~| NOTE in this expansion of test!
+    //~| NOTE in this expansion of test!
 }

--- a/src/test/compile-fail/specialization/specialization-default-projection.rs
+++ b/src/test/compile-fail/specialization/specialization-default-projection.rs
@@ -28,14 +28,26 @@ fn generic<T>() -> <T as Foo>::Assoc {
     // `T` could be some downstream crate type that specializes (or,
     // for that matter, `u8`).
 
-    () //~ ERROR mismatched types
+    ()
+    //~^ ERROR mismatched types
+    //~| NOTE: expected associated type, found ()
+    //~| NOTE: expected type `<T as Foo>::Assoc`
+    //~| NOTE:    found type `()`
 }
 
 fn monomorphic() -> () {
     // Even though we know that `()` is not specialized in a
     // downstream crate, typeck refuses to project here.
 
-    generic::<()>() //~ ERROR mismatched types
+    generic::<()>()
+    //~^ ERROR mismatched types
+    //~| ERROR mismatched types
+    //~| NOTE: possibly missing `;` here?
+    //~| NOTE: expected (), found associated type
+    //~| NOTE: expected type `()`
+    //~| NOTE: expected type `()`
+    //~| NOTE:    found type
+    //~| NOTE:    found type
 }
 
 fn main() {

--- a/src/test/compile-fail/specialization/specialization-default-projection.rs
+++ b/src/test/compile-fail/specialization/specialization-default-projection.rs
@@ -41,12 +41,9 @@ fn monomorphic() -> () {
 
     generic::<()>()
     //~^ ERROR mismatched types
-    //~| ERROR mismatched types
-    //~| NOTE: possibly missing `;` here?
+    //~| NOTE: consider adding a semicolon here
     //~| NOTE: expected (), found associated type
     //~| NOTE: expected type `()`
-    //~| NOTE: expected type `()`
-    //~| NOTE:    found type
     //~| NOTE:    found type
 }
 

--- a/src/test/compile-fail/token-error-correct-3.rs
+++ b/src/test/compile-fail/token-error-correct-3.rs
@@ -22,10 +22,15 @@ pub mod raw {
                                           //~| NOTE unresolved name
             callback(path.as_ref();  //~ NOTE: unclosed delimiter
                      //~^ ERROR: expected one of
-            fs::create_dir_all(path.as_ref()).map(|()| true) //~ ERROR: mismatched types
-            //~^ expected (), found enum `std::result::Result`
-            //~| expected type `()`
-            //~| found type `std::result::Result<bool, std::io::Error>`
+            fs::create_dir_all(path.as_ref()).map(|()| true)
+            //~^ ERROR mismatched types
+            //~| ERROR mismatched types
+            //~| NOTE: possibly missing `;` here?
+            //~| NOTE: expected (), found enum `std::result::Result`
+            //~| NOTE: expected type `()`
+            //~| NOTE: expected type `()`
+            //~| NOTE:    found type `std::result::Result<bool, std::io::Error>`
+            //~| NOTE:    found type `std::result::Result<bool, std::io::Error>`
         } else { //~ ERROR: incorrect close delimiter: `}`
             //~^ ERROR: expected one of
             Ok(false);

--- a/src/test/compile-fail/token-error-correct-3.rs
+++ b/src/test/compile-fail/token-error-correct-3.rs
@@ -24,12 +24,9 @@ pub mod raw {
                      //~^ ERROR: expected one of
             fs::create_dir_all(path.as_ref()).map(|()| true)
             //~^ ERROR mismatched types
-            //~| ERROR mismatched types
-            //~| NOTE: possibly missing `;` here?
+            //~| NOTE: consider adding a semicolon here
             //~| NOTE: expected (), found enum `std::result::Result`
             //~| NOTE: expected type `()`
-            //~| NOTE: expected type `()`
-            //~| NOTE:    found type `std::result::Result<bool, std::io::Error>`
             //~| NOTE:    found type `std::result::Result<bool, std::io::Error>`
         } else { //~ ERROR: incorrect close delimiter: `}`
             //~^ ERROR: expected one of

--- a/src/test/compile-fail/unexpected-return-on-unit.rs
+++ b/src/test/compile-fail/unexpected-return-on-unit.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,21 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn foo(x: i32) {
-    //~^ NOTE: possibly return type
-    |y| x + y
-    //~^ ERROR: mismatched types
-    //~| ERROR: mismatched types
-    //~| NOTE: possibly missing `;` here?
-    //~| NOTE: expected (), found closure
-    //~| NOTE: expected type `()`
-    //~| NOTE: expected type `()`
-    //~| NOTE:    found type
-    //~| NOTE:    found type
-}
-
+// Test that we do some basic error correcton in the tokeniser (and don't spew
+// too many bogus errors).
 
 fn main() {
-    let x = foo(5)(2);
-    //~^ ERROR: expected function, found `()`
+    1
+    //~^ ERROR mismatched types
+    //~| ERROR mismatched types
+    //~| NOTE: possibly missing `;` here?
+    //~| NOTE: expected (), found integral variable
+    //~| NOTE: expected type `()`
+    //~| NOTE: expected type `()`
+    //~| NOTE:    found type `{integer}`
+    //~| NOTE:    found type `{integer}`
 }

--- a/src/test/compile-fail/unexpected-return-on-unit.rs
+++ b/src/test/compile-fail/unexpected-return-on-unit.rs
@@ -14,11 +14,8 @@
 fn main() {
     1
     //~^ ERROR mismatched types
-    //~| ERROR mismatched types
-    //~| NOTE: possibly missing `;` here?
+    //~| NOTE: consider adding a semicolon here
     //~| NOTE: expected (), found integral variable
     //~| NOTE: expected type `()`
-    //~| NOTE: expected type `()`
-    //~| NOTE:    found type `{integer}`
     //~| NOTE:    found type `{integer}`
 }


### PR DESCRIPTION
On a given file `foo.rs`:

``` rust
fn foo() {
    return 1;
}

fn main() {
    3
}
```

Provide the following output:

``` bash
error[E0308]: mismatched types
 --> foo.rs:2:12
  |
2 |     return 1;
  |            ^ expected (), found integral variable
  |
  = note: expected type `()`
  = note:    found type `{integer}`

error[E0308]: mismatched types
 --> foo.rs:6:5
  |
6 |     3
  |     ^ expected (), found integral variable
  |
  = note: expected type `()`
  = note:    found type `{integer}`
help: maybe you meant to have a statement ending in `;` here
 --> foo.rs:6:6
  |
6 |     3
  |      ^

error: aborting due to 2 previous errors
```

Fixes: #25133