### PR TITLE
fix "X is not a member of trait Y" span labels

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -247,7 +247,7 @@ fn resolve_struct_error<'b, 'a: 'b, 'c>(resolver: &'b Resolver<'a>,
                                            "method `{}` is not a member of trait `{}`",
                                            method,
                                            trait_);
-            err.span_label(span, &format!("not a member of `{}`", trait_));
+            err.span_label(span, &format!("not a member of trait `{}`", trait_));
             err
         }
         ResolutionError::TypeNotMemberOfTrait(type_, trait_) => {
@@ -257,7 +257,7 @@ fn resolve_struct_error<'b, 'a: 'b, 'c>(resolver: &'b Resolver<'a>,
                              "type `{}` is not a member of trait `{}`",
                              type_,
                              trait_);
-            err.span_label(span, &format!("not a member of trait `Foo`"));
+            err.span_label(span, &format!("not a member of trait `{}`", trait_));
             err
         }
         ResolutionError::ConstNotMemberOfTrait(const_, trait_) => {
@@ -267,7 +267,7 @@ fn resolve_struct_error<'b, 'a: 'b, 'c>(resolver: &'b Resolver<'a>,
                              "const `{}` is not a member of trait `{}`",
                              const_,
                              trait_);
-            err.span_label(span, &format!("not a member of trait `Foo`"));
+            err.span_label(span, &format!("not a member of trait `{}`", trait_));
             err
         }
         ResolutionError::VariableNotBoundInPattern(variable_name, from, to) => {

--- a/src/test/compile-fail/E0407.rs
+++ b/src/test/compile-fail/E0407.rs
@@ -18,7 +18,7 @@ impl Foo for Bar {
     fn a() {}
     fn b() {}
     //~^ ERROR E0407
-    //~| NOTE not a member of `Foo`
+    //~| NOTE not a member of trait `Foo`
 }
 
 fn main() {

--- a/src/test/compile-fail/E0438.rs
+++ b/src/test/compile-fail/E0438.rs
@@ -10,11 +10,11 @@
 
 #![feature(associated_consts)]
 
-trait Foo {}
+trait Bar {}
 
-impl Foo for i32 {
+impl Bar for i32 {
     const BAR: bool = true; //~ ERROR E0438
-        //~| NOTE not a member of trait `Foo`
+        //~| NOTE not a member of trait `Bar`
 }
 
 fn main () {


### PR DESCRIPTION
Fixes #36428.
