### PR TITLE
mk: add a all-no-docs target to build everything except docs

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -630,7 +630,8 @@ ALL_TARGET_RULES = $(foreach target,$(CFG_TARGET), \
 	$(foreach host,$(CFG_HOST), \
  all-target-$(target)-host-$(host)))
 
-all: $(ALL_TARGET_RULES) $(GENERATED) docs
+all-no-docs: $(ALL_TARGET_RULES) $(GENERATED)
+all: all-no-docs docs
 
 ######################################################################
 # Build system documentation


### PR DESCRIPTION
This makes things slightly more efficient for Debian's auto-builders where the
docs can be built on just one architecture, and distributed to users of all
other architectures as well.
