### PR TITLE
Expand is_uninhabited

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -178,8 +178,9 @@ enum Void {}
            issue = "0")]
 #[doc(hidden)]
 pub struct ArgumentV1<'a> {
-    value: &'a Void,
-    formatter: fn(&Void, &mut Formatter) -> Result,
+    _ph: PhantomData<&'a ()>,
+    value: *const Void,
+    formatter: fn(*const Void, &mut Formatter) -> Result,
 }
 
 #[unstable(feature = "fmt_internals", reason = "internal to format_args!",
@@ -203,6 +204,7 @@ impl<'a> ArgumentV1<'a> {
                       f: fn(&T, &mut Formatter) -> Result) -> ArgumentV1<'b> {
         unsafe {
             ArgumentV1 {
+                _ph: PhantomData,
                 formatter: mem::transmute(f),
                 value: mem::transmute(x)
             }
@@ -218,7 +220,7 @@ impl<'a> ArgumentV1<'a> {
 
     fn as_usize(&self) -> Option<usize> {
         if self.formatter as usize == ArgumentV1::show_usize as usize {
-            Some(unsafe { *(self.value as *const _ as *const usize) })
+            Some(unsafe { *(self.value as *const usize) })
         } else {
             None
         }

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -166,9 +166,7 @@ pub struct Formatter<'a> {
 // NB. Argument is essentially an optimized partially applied formatting function,
 // equivalent to `exists T.(&T, fn(&T, &mut Formatter) -> Result`.
 
-struct Void {
-    _private: (),
-}
+enum Void {}
 
 /// This struct represents the generic "argument" which is taken by the Xprintf
 /// family of functions. It contains a function to format the given value. At

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -1397,7 +1397,7 @@ impl<'a, 'gcx, 'tcx> AdtDefData<'tcx, 'static> {
                                   cx: TyCtxt<'a, 'gcx, 'tcx>,
                                   substs: &'tcx Substs<'tcx>) -> bool {
         match visited.entry((self.did, substs)) {
-            hash_map::Entry::Occupied(_) => return true,
+            hash_map::Entry::Occupied(_) => return false,
             hash_map::Entry::Vacant(ve) => ve.insert(()),
         };
         self.variants.iter().all(|v| v.is_uninhabited_recurse(visited, cx, substs, self.is_union()))

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -1393,7 +1393,7 @@ impl<'tcx> serialize::UseSpecializedDecodable for AdtDef<'tcx> {}
 impl<'a, 'gcx, 'tcx> AdtDefData<'tcx, 'static> {
     #[inline]
     pub fn is_uninhabited_recurse(&'tcx self,
-                                  visited: &mut HashMap<(DefId, &'tcx Substs<'tcx>), ()>, 
+                                  visited: &mut HashMap<(DefId, &'tcx Substs<'tcx>), ()>,
                                   cx: TyCtxt<'a, 'gcx, 'tcx>,
                                   substs: &'tcx Substs<'tcx>) -> bool {
         match visited.entry((self.did, substs)) {

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -929,16 +929,14 @@ impl<'a, 'gcx, 'tcx> TyS<'tcx> {
         }
     }
 
-    pub fn is_uninhabited(&self, _cx: TyCtxt) -> bool {
+    pub fn is_uninhabited(&self, cx: TyCtxt) -> bool {
         // FIXME(#24885): be smarter here, the AdtDefData::is_empty method could easily be made
         // more complete.
         match self.sty {
             TyAdt(def, _) => def.is_empty(),
 
-            // FIXME(canndrew): There's no reason why these can't be uncommented, they're tested
-            // and they don't break anything. But I'm keeping my changes small for now.
-            //TyNever => true,
-            //TyTuple(ref tys) => tys.iter().any(|ty| ty.is_uninhabited(cx)),
+            TyNever => true,
+            TyTuple(ref tys) => tys.iter().any(|ty| ty.is_uninhabited(cx)),
 
             // FIXME(canndrew): this line breaks core::fmt
             //TyRef(_, ref tm) => tm.ty.is_uninhabited(cx),

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -946,11 +946,10 @@ impl<'a, 'gcx, 'tcx> TyS<'tcx> {
             },
 
             TyNever => true,
-            TyTuple(ref tys) => tys.iter().any(|ty| ty.is_uninhabited(cx)),
-            TyArray(ty, len) => len > 0 && ty.is_uninhabited(cx),
+            TyTuple(ref tys) => tys.iter().any(|ty| ty.is_uninhabited_recurse(visited, cx)),
+            TyArray(ty, len) => len > 0 && ty.is_uninhabited_recurse(visited, cx),
+            TyRef(_, ref tm) => tm.ty.is_uninhabited_recurse(visited, cx),
 
-            // FIXME(canndrew): this line breaks core::fmt
-            //TyRef(_, ref tm) => tm.ty.is_uninhabited(cx),
             _ => false,
         }
     }

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -21,10 +21,10 @@ use util::common::ErrorReported;
 use collections::enum_set::{self, EnumSet, CLike};
 use std::fmt;
 use std::ops;
-use std::collections::HashMap;
 use syntax::abi;
 use syntax::ast::{self, Name, NodeId};
 use syntax::symbol::{keywords, InternedString};
+use util::nodemap::FxHashSet;
 
 use serialize;
 
@@ -933,12 +933,12 @@ impl<'a, 'gcx, 'tcx> TyS<'tcx> {
     /// Checks whether a type is uninhabited.
     /// If `block` is `Some(id)` it also checks that the uninhabited-ness is visible from `id`.
     pub fn is_uninhabited(&self, block: Option<NodeId>, cx: TyCtxt<'a, 'gcx, 'tcx>) -> bool {
-        let mut visited = HashMap::new();
+        let mut visited = FxHashSet::default();
         self.is_uninhabited_recurse(&mut visited, block, cx)
     }
 
     pub fn is_uninhabited_recurse(&self,
-                                  visited: &mut HashMap<(DefId, &'tcx Substs<'tcx>), ()>,
+                                  visited: &mut FxHashSet<(DefId, &'tcx Substs<'tcx>)>,
                                   block: Option<NodeId>,
                                   cx: TyCtxt<'a, 'gcx, 'tcx>) -> bool {
         match self.sty {

--- a/src/librustc_const_eval/check_match.rs
+++ b/src/librustc_const_eval/check_match.rs
@@ -204,7 +204,7 @@ impl<'a, 'tcx> MatchVisitor<'a, 'tcx> {
             // Check for empty enum, because is_useful only works on inhabited types.
             let pat_ty = self.tcx.tables().node_id_to_type(scrut.id);
             if inlined_arms.is_empty() {
-                if !pat_ty.is_uninhabited(self.tcx) {
+                if !pat_ty.is_uninhabited(Some(scrut.id), self.tcx) {
                     // We know the type is inhabited, so this must be wrong
                     let mut err = create_e0004(self.tcx.sess, span,
                                                format!("non-exhaustive patterns: type {} \


### PR DESCRIPTION
This allows code such as this to compile:

``` rust
let x: ! = ...;
match x {};

let y: (u32, !) = ...;
match y {};
```

@eddyb You were worried about making this change. Do you have any idea about what could break? Are there any special tests that need to be written for it?
