### PR TITLE
Remove DelimToken::NoDelim.

### DIFF
--- a/src/libproc_macro/qquote.rs
+++ b/src/libproc_macro/qquote.rs
@@ -342,7 +342,6 @@ mod int_build {
             token::DelimToken::Paren => lex("DelimToken::Paren"),
             token::DelimToken::Bracket => lex("DelimToken::Bracket"),
             token::DelimToken::Brace => lex("DelimToken::Brace"),
-            token::DelimToken::NoDelim => lex("DelimToken::NoDelim"),
         }
     }
 
@@ -380,7 +379,6 @@ mod int_build {
                     token::DelimToken::Paren => lex("Token::OpenDelim(DelimToken::Paren)"),
                     token::DelimToken::Bracket => lex("Token::OpenDelim(DelimToken::Bracket)"),
                     token::DelimToken::Brace => lex("Token::OpenDelim(DelimToken::Brace)"),
-                    token::DelimToken::NoDelim => lex("DelimToken::NoDelim"),
                 }
             }
             Token::CloseDelim(dt) => {
@@ -388,7 +386,6 @@ mod int_build {
                     token::DelimToken::Paren => lex("Token::CloseDelim(DelimToken::Paren)"),
                     token::DelimToken::Bracket => lex("Token::CloseDelim(DelimToken::Bracket)"),
                     token::DelimToken::Brace => lex("Token::CloseDelim(DelimToken::Brace)"),
-                    token::DelimToken::NoDelim => lex("DelimToken::NoDelim"),
                 }
             }
             Token::Underscore => lex("_"),

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -233,7 +233,6 @@ impl<'a> Classifier<'a> {
             token::Dot | token::DotDot | token::DotDotDot | token::Comma | token::Semi |
                 token::Colon | token::ModSep | token::LArrow | token::OpenDelim(_) |
                 token::CloseDelim(token::Brace) | token::CloseDelim(token::Paren) |
-                token::CloseDelim(token::NoDelim) |
                 token::Question => Class::None,
             token::Dollar => {
                 if self.lexer.peek().tok.is_ident() {

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -584,7 +584,6 @@ fn mk_delim(cx: &ExtCtxt, sp: Span, delim: token::DelimToken) -> P<ast::Expr> {
         token::Paren   => "Paren",
         token::Bracket => "Bracket",
         token::Brace   => "Brace",
-        token::NoDelim => "NoDelim",
     };
     mk_token_path(cx, sp, name)
 }

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -48,8 +48,6 @@ pub enum DelimToken {
     Bracket,
     /// A curly brace: `{` or `}`
     Brace,
-    /// An empty delimiter
-    NoDelim,
 }
 
 #[derive(Clone, RustcEncodable, RustcDecodable, PartialEq, Eq, Hash, Debug, Copy)]

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -241,8 +241,6 @@ pub fn token_to_string(tok: &Token) -> String {
         token::CloseDelim(token::Bracket) => "]".to_string(),
         token::OpenDelim(token::Brace) => "{".to_string(),
         token::CloseDelim(token::Brace) => "}".to_string(),
-        token::OpenDelim(token::NoDelim) => " ".to_string(),
-        token::CloseDelim(token::NoDelim) => " ".to_string(),
         token::Pound                => "#".to_string(),
         token::Dollar               => "$".to_string(),
         token::Question             => "?".to_string(),
@@ -1803,14 +1801,12 @@ impl<'a> State<'a> {
                 try!(self.head(""));
                 try!(self.bopen());
             }
-            token::NoDelim => {}
         }
         try!(self.print_tts(&m.node.tts));
         match delim {
             token::Paren => self.pclose(),
             token::Bracket => word(&mut self.s, "]"),
             token::Brace => self.bclose(m.span),
-            token::NoDelim => Ok(()),
         }
     }
 


### PR DESCRIPTION
It's handled in various places, but never produced. Perhaps it was needed in the past, but no longer?
