### PR TITLE
Use primitive indexing in slice's Index/IndexMut

### DIFF
--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -520,8 +520,8 @@ impl<T> ops::Index<usize> for [T] {
     type Output = T;
 
     fn index(&self, index: usize) -> &T {
-        assert!(index < self.len());
-        unsafe { self.get_unchecked(index) }
+        // NB built-in indexing
+        &(*self)[index]
     }
 }
 
@@ -530,8 +530,8 @@ impl<T> ops::Index<usize> for [T] {
 impl<T> ops::IndexMut<usize> for [T] {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut T {
-        assert!(index < self.len());
-        unsafe { self.get_unchecked_mut(index) }
+        // NB built-in indexing
+        &mut (*self)[index]
     }
 }
 

--- a/src/test/run-fail/bounds-check-no-overflow.rs
+++ b/src/test/run-fail/bounds-check-no-overflow.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:assertion failed: index < self.len()
+// error-pattern:index out of bounds
 
 use std::usize;
 use std::mem::size_of;


### PR DESCRIPTION
[T]'s Index implementation is normally not used for indexing, instead
the compiler supplied indexing is used.

Use the compiler supplied version in Index/IndexMut.

This removes an inconsistency:

Compiler supplied bound check failures look like this:

thread 'main' panicked at 'index out of bounds: the len is 3 but the index is 4'

If you convince Rust to use the Index impl for slices, bounds check
failure looks like this instead:

thread 'main' panicked at 'assertion failed: index < self.len()'

The latter is used if you for example use Index generically:

``` rust
use std::ops::Index;
fn foo<T: ?Sized>(x: &T) where T: Index<usize> { &x[4]; }

foo(&[1, 2, 3][..])
```
