### PR TITLE
trans: Let the collector find drop-glue for all vtables, not just VTableImpl.

### DIFF
--- a/src/librustc_trans/collector.rs
+++ b/src/librustc_trans/collector.rs
@@ -497,7 +497,7 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirNeighborCollector<'a, 'tcx> {
                                                           self.output);
                 }
             }
-            mir::Rvalue::Box(_) => {
+            mir::Rvalue::Box(..) => {
                 let exchange_malloc_fn_def_id =
                     self.scx
                         .tcx()
@@ -1072,14 +1072,15 @@ fn create_trans_items_for_vtable_methods<'a, 'tcx>(scx: &SharedCrateContext<'a, 
                         });
 
                     output.extend(items);
-
-                    // Also add the destructor
-                    let dg_type = glue::get_drop_glue_type(scx.tcx(),
-                                                           trait_ref.self_ty());
-                    output.push(TransItem::DropGlue(DropGlueKind::Ty(dg_type)));
                 }
                 _ => { /* */ }
             }
+        }
+
+        // Also add the destructor
+        let dg_type = glue::get_drop_glue_type(scx.tcx(), impl_ty);
+        if glue::type_needs_drop(scx.tcx(), dg_type) {
+            output.push(TransItem::DropGlue(DropGlueKind::Ty(dg_type)));
         }
     }
 }

--- a/src/test/codegen-units/item-collection/instantiation-through-vtable.rs
+++ b/src/test/codegen-units/item-collection/instantiation-through-vtable.rs
@@ -40,5 +40,3 @@ fn main() {
     //~ TRANS_ITEM fn instantiation_through_vtable::{{impl}}[0]::bar[0]<u64>
     let _ = &s1 as &Trait;
 }
-
-//~ TRANS_ITEM drop-glue i8

--- a/src/test/codegen-units/item-collection/unsizing.rs
+++ b/src/test/codegen-units/item-collection/unsizing.rs
@@ -78,5 +78,3 @@ fn main()
     //~ TRANS_ITEM fn unsizing::{{impl}}[3]::foo[0]
     let _wrapper_sized = wrapper_sized as Wrapper<Trait>;
 }
-
-//~ TRANS_ITEM drop-glue i8

--- a/src/test/codegen-units/partitioning/vtable-through-const.rs
+++ b/src/test/codegen-units/partitioning/vtable-through-const.rs
@@ -89,5 +89,3 @@ fn main() {
     //~ TRANS_ITEM fn vtable_through_const::mod1[0]::id[0]<char> @@ vtable_through_const[Internal]
     mod1::ID_CHAR('x');
 }
-
-//~ TRANS_ITEM drop-glue i8

--- a/src/test/run-pass/issue36260.rs
+++ b/src/test/run-pass/issue36260.rs
@@ -1,0 +1,22 @@
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Make sure this compiles without getting a linker error because of missing
+// drop-glue because the collector missed adding drop-glue for the closure:
+
+fn create_fn() -> Box<Fn()> {
+    let text = String::new();
+
+    Box::new(move || { let _ = &text; })
+}
+
+fn main() {
+    let _ = create_fn();
+}


### PR DESCRIPTION
This fixes #36260. So far, the collector has only recorded drop-glue for insertion into a vtable if the vtable was for an impl. But there's actually no reason why it shouldn't do just the same for closure vtables, afaict.

r? @eddyb 
cc @rust-lang/compiler
