### PR TITLE
Clarify the workings of StringReader in the lexer

### DIFF
--- a/src/libsyntax/parse/lexer/comments.rs
+++ b/src/libsyntax/parse/lexer/comments.rs
@@ -155,7 +155,7 @@ fn push_blank_line_comment(rdr: &StringReader, comments: &mut Vec<Comment>) {
 
 fn consume_whitespace_counting_blank_lines(rdr: &mut StringReader, comments: &mut Vec<Comment>) {
     while is_pattern_whitespace(rdr.curr) && !rdr.is_eof() {
-        if rdr.col == CharPos(0) && rdr.curr_is('\n') {
+        if rdr.curr_col == CharPos(0) && rdr.curr_is('\n') {
             push_blank_line_comment(rdr, &mut *comments);
         }
         rdr.bump();
@@ -242,7 +242,7 @@ fn read_block_comment(rdr: &mut StringReader,
     debug!(">>> block comment");
     let p = rdr.curr_pos;
     let mut lines: Vec<String> = Vec::new();
-    let col = rdr.col;
+    let curr_col = rdr.curr_col;
     rdr.bump();
     rdr.bump();
 
@@ -272,7 +272,7 @@ fn read_block_comment(rdr: &mut StringReader,
                 panic!(rdr.fatal("unterminated block comment"));
             }
             if rdr.curr_is('\n') {
-                trim_whitespace_prefix_and_push_line(&mut lines, curr_line, col);
+                trim_whitespace_prefix_and_push_line(&mut lines, curr_line, curr_col);
                 curr_line = String::new();
                 rdr.bump();
             } else {
@@ -295,7 +295,7 @@ fn read_block_comment(rdr: &mut StringReader,
             }
         }
         if !curr_line.is_empty() {
-            trim_whitespace_prefix_and_push_line(&mut lines, curr_line, col);
+            trim_whitespace_prefix_and_push_line(&mut lines, curr_line, curr_col);
         }
     }
 

--- a/src/libsyntax/parse/lexer/comments.rs
+++ b/src/libsyntax/parse/lexer/comments.rs
@@ -149,7 +149,7 @@ fn push_blank_line_comment(rdr: &StringReader, comments: &mut Vec<Comment>) {
     comments.push(Comment {
         style: BlankLine,
         lines: Vec::new(),
-        pos: rdr.last_pos,
+        pos: rdr.curr_pos,
     });
 }
 
@@ -167,7 +167,7 @@ fn read_shebang_comment(rdr: &mut StringReader,
                         code_to_the_left: bool,
                         comments: &mut Vec<Comment>) {
     debug!(">>> shebang comment");
-    let p = rdr.last_pos;
+    let p = rdr.curr_pos;
     debug!("<<< shebang comment");
     comments.push(Comment {
         style: if code_to_the_left { Trailing } else { Isolated },
@@ -180,7 +180,7 @@ fn read_line_comments(rdr: &mut StringReader,
                       code_to_the_left: bool,
                       comments: &mut Vec<Comment>) {
     debug!(">>> line comments");
-    let p = rdr.last_pos;
+    let p = rdr.curr_pos;
     let mut lines: Vec<String> = Vec::new();
     while rdr.curr_is('/') && rdr.nextch_is('/') {
         let line = rdr.read_one_line_comment();
@@ -240,7 +240,7 @@ fn read_block_comment(rdr: &mut StringReader,
                       code_to_the_left: bool,
                       comments: &mut Vec<Comment>) {
     debug!(">>> block comment");
-    let p = rdr.last_pos;
+    let p = rdr.curr_pos;
     let mut lines: Vec<String> = Vec::new();
     let col = rdr.col;
     rdr.bump();
@@ -369,7 +369,7 @@ pub fn gather_comments_and_literals(span_diagnostic: &errors::Handler,
         }
 
 
-        let bstart = rdr.last_pos;
+        let bstart = rdr.curr_pos;
         rdr.next_token();
         // discard, and look ahead; we're working with internal state
         let TokenAndSpan { tok, sp } = rdr.peek();

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -396,11 +396,9 @@ impl<'a> StringReader<'a> {
         self.curr_pos = self.next_pos;
         let current_byte_offset = self.byte_offset(self.next_pos).to_usize();
         if current_byte_offset < self.source_text.len() {
-            assert!(self.curr.is_some());
             let last_char = self.curr.unwrap();
             let ch = char_at(&self.source_text, current_byte_offset);
-            let next = current_byte_offset + ch.len_utf8();
-            let byte_offset_diff = next - current_byte_offset;
+            let byte_offset_diff = ch.len_utf8();
             self.next_pos = self.next_pos + Pos::from_usize(byte_offset_diff);
             self.curr = Some(ch);
             self.curr_col = self.curr_col + CharPos(1);

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -80,8 +80,8 @@ pub struct StringReader<'a> {
     pub next_pos: BytePos,
     /// The absolute offset within the codemap of the current character
     pub curr_pos: BytePos,
-    /// The column of the next character to read
-    pub col: CharPos,
+    /// The column of the current character
+    pub curr_col: CharPos,
     /// The current character (which has been read from curr_pos)
     pub curr: Option<char>,
     pub filemap: Rc<syntax_pos::FileMap>,
@@ -176,7 +176,7 @@ impl<'a> StringReader<'a> {
             span_diagnostic: span_diagnostic,
             next_pos: filemap.start_pos,
             curr_pos: filemap.start_pos,
-            col: CharPos(0),
+            curr_col: CharPos(0),
             curr: Some('\n'),
             filemap: filemap,
             // dummy values; not read
@@ -403,10 +403,10 @@ impl<'a> StringReader<'a> {
             let byte_offset_diff = next - current_byte_offset;
             self.next_pos = self.next_pos + Pos::from_usize(byte_offset_diff);
             self.curr = Some(ch);
-            self.col = self.col + CharPos(1);
+            self.curr_col = self.curr_col + CharPos(1);
             if last_char == '\n' {
                 self.filemap.next_line(self.curr_pos);
-                self.col = CharPos(0);
+                self.curr_col = CharPos(0);
             }
 
             if byte_offset_diff > 1 {

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -489,11 +489,7 @@ impl<'a> StringReader<'a> {
 
                     // line comments starting with "///" or "//!" are doc-comments
                     let doc_comment = self.curr_is('/') || self.curr_is('!');
-                    let start_bpos = if doc_comment {
-                        self.next_pos - BytePos(3)
-                    } else {
-                        self.curr_pos - BytePos(2)
-                    };
+                    let start_bpos = self.curr_pos - BytePos(2);
 
                     while !self.is_eof() {
                         match self.curr.unwrap() {

--- a/src/libsyntax/parse/lexer/unicode_chars.rs
+++ b/src/libsyntax/parse/lexer/unicode_chars.rs
@@ -234,7 +234,7 @@ pub fn check_for_substitution<'a>(reader: &StringReader<'a>,
     .iter()
     .find(|&&(c, _, _)| c == ch)
     .map(|&(_, u_name, ascii_char)| {
-        let span = make_span(reader.curr_pos, reader.pos);
+        let span = make_span(reader.curr_pos, reader.next_pos);
         match ASCII_ARRAY.iter().find(|&&(c, _)| c == ascii_char) {
             Some(&(ascii_char, ascii_name)) => {
                 let msg =

--- a/src/libsyntax/parse/lexer/unicode_chars.rs
+++ b/src/libsyntax/parse/lexer/unicode_chars.rs
@@ -234,7 +234,7 @@ pub fn check_for_substitution<'a>(reader: &StringReader<'a>,
     .iter()
     .find(|&&(c, _, _)| c == ch)
     .map(|&(_, u_name, ascii_char)| {
-        let span = make_span(reader.last_pos, reader.pos);
+        let span = make_span(reader.curr_pos, reader.pos);
         match ASCII_ARRAY.iter().find(|&&(c, _)| c == ascii_char) {
             Some(&(ascii_char, ascii_name)) => {
                 let msg =


### PR DESCRIPTION
In a lexer you want it to be extremely clear what the current character is, as well as those before and after it. The current code and comments in StringReader don't achieve this: `curr` refers to the current character, but so does `last_pos`; `pos` refers to the next character; and `col` refers to the current character but its comment says it refers to the next character.

This PR renames some of these fields and does some related clean-ups. This makes the lexer code easier to understand and marginally faster.
