### PR TITLE
Make transmuting inhabited to uninhabited types an error

### DIFF
--- a/src/librustc/middle/intrinsicck.rs
+++ b/src/librustc/middle/intrinsicck.rs
@@ -62,9 +62,9 @@ impl<'a, 'gcx, 'tcx> ExprVisitor<'a, 'gcx, 'tcx> {
         let sk_from = SizeSkeleton::compute(from, self.infcx);
         let sk_to = SizeSkeleton::compute(to, self.infcx);
 
-        // Check for same size using the skeletons.
+        // Check for transmutable sizes using the skeletons.
         if let (Ok(sk_from), Ok(sk_to)) = (sk_from, sk_to) {
-            if sk_from.same_size(sk_to) {
+            if sk_from.transmutable(sk_to) {
                 return;
             }
 
@@ -86,6 +86,9 @@ impl<'a, 'gcx, 'tcx> ExprVisitor<'a, 'gcx, 'tcx> {
         // Try to display a sensible error with as much information as possible.
         let skeleton_string = |ty: Ty<'gcx>, sk| {
             match sk {
+                Ok(SizeSkeleton::Uninhabited) => {
+                    format!("uninhabited")
+                },
                 Ok(SizeSkeleton::Known(size)) => {
                     format!("{} bits", size.bits())
                 }


### PR DESCRIPTION
This changes the behaviour of the transmute intrinsic so that, for any
uninhabited type `Void` and any inhabited type `NonVoid`:
- `transmute::<Void, T>` is okay
- `transmute::<NonVoid, Void>` is an error
