### PR TITLE
Workaround #34427 by using memset of 0 on ARM to set the discriminant.

### DIFF
--- a/src/librustc_trans/adt.rs
+++ b/src/librustc_trans/adt.rs
@@ -54,6 +54,7 @@ use syntax::ast;
 use syntax::attr;
 use syntax::attr::IntType;
 use abi::FAT_PTR_ADDR;
+use base;
 use build::*;
 use common::*;
 use debuginfo::DebugLoc;
@@ -963,14 +964,30 @@ pub fn trans_set_discr<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, r: &Repr<'tcx>,
                 Store(bcx, C_null(llptrty), val);
             }
         }
-        StructWrappedNullablePointer { nndiscr, ref discrfield, .. } => {
+        StructWrappedNullablePointer { nndiscr, ref discrfield, ref nonnull, .. } => {
             if discr != nndiscr {
-                let llptrptr = GEPi(bcx, val, &discrfield[..]);
-                let llptrty = val_ty(llptrptr).element_type();
-                Store(bcx, C_null(llptrty), llptrptr);
+                if target_sets_discr_via_memset(bcx) {
+                    // Issue #34427: As workaround for LLVM bug on
+                    // ARM, use memset of 0 on whole struct rather
+                    // than storing null to single target field.
+                    let b = B(bcx);
+                    let llptr = b.pointercast(val, Type::i8(b.ccx).ptr_to());
+                    let fill_byte = C_u8(b.ccx, 0);
+                    let size = C_uint(b.ccx, nonnull.size);
+                    let align = C_i32(b.ccx, nonnull.align as i32);
+                    base::call_memset(&b, llptr, fill_byte, size, align, false);
+                } else {
+                    let llptrptr = GEPi(bcx, val, &discrfield[..]);
+                    let llptrty = val_ty(llptrptr).element_type();
+                    Store(bcx, C_null(llptrty), llptrptr);
+                }
             }
         }
     }
+}
+
+fn target_sets_discr_via_memset<'blk, 'tcx>(bcx: Block<'blk, 'tcx>) -> bool {
+    bcx.sess().target.target.arch == "arm" || bcx.sess().target.target.arch == "aarch64"
 }
 
 fn assert_discr_in_range(ity: IntType, min: Disr, max: Disr, discr: Disr) {

--- a/src/test/run-pass/issue-34427.rs
+++ b/src/test/run-pass/issue-34427.rs
@@ -1,0 +1,26 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #34427: On ARM, the code in `foo` at one time was generating
+// a machine code instruction of the form: `str r0, [r0, rN]!` (for
+// some N), which is not legal because the source register and base
+// register cannot be identical in the preindexed form signalled by
+// the `!`.
+//
+// See LLVM bug: https://llvm.org/bugs/show_bug.cgi?id=28809
+
+#[inline(never)]
+fn foo(n: usize) -> Vec<Option<(*mut (), &'static ())>> {
+    (0..n).map(|_| None).collect()
+}
+
+fn main() {
+    let _ = (foo(10), foo(32));
+}


### PR DESCRIPTION
Workaround #34427 by using memset of 0 on ARM to set the discriminant.
