### PR TITLE
Fix wording for out-of-crate macro error

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -473,7 +473,8 @@ impl EmitterWriter {
         if spans_updated {
             children.push(SubDiagnostic {
                 level: Level::Note,
-                message: "this error originates in a macro from the standard library".to_string(),
+                message:"this error originates in a macro outside of the current \
+                         crate".to_string(),
                 span: MultiSpan::new(),
                 render_span: None
             });

--- a/src/test/ui/codemap_tests/bad-format-args.stderr
+++ b/src/test/ui/codemap_tests/bad-format-args.stderr
@@ -4,7 +4,7 @@ error: requires at least a format string argument
 12 |     format!();
    |     ^^^^^^^^^^
    |
-   = note: this error originates in a macro from the standard library
+   = note: this error originates in a macro outside of the current crate
 
 error: expected token: `,`
   --> $DIR/bad-format-args.rs:13:5
@@ -12,7 +12,7 @@ error: expected token: `,`
 13 |     format!("" 1);
    |     ^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro from the standard library
+   = note: this error originates in a macro outside of the current crate
 
 error: expected token: `,`
   --> $DIR/bad-format-args.rs:14:5
@@ -20,7 +20,7 @@ error: expected token: `,`
 14 |     format!("", 1 1);
    |     ^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro from the standard library
+   = note: this error originates in a macro outside of the current crate
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/codemap_tests/issue-28308.stderr
+++ b/src/test/ui/codemap_tests/issue-28308.stderr
@@ -4,7 +4,7 @@ error: cannot apply unary operator `!` to type `&'static str`
 12 |     assert!("foo");
    |     ^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro from the standard library
+   = note: this error originates in a macro outside of the current crate
 
 error: aborting due to previous error
 

--- a/src/test/ui/codemap_tests/repair_span_std_macros.stderr
+++ b/src/test/ui/codemap_tests/repair_span_std_macros.stderr
@@ -5,7 +5,7 @@ error[E0282]: unable to infer enough type information about `_`
    |             ^^^^^^ cannot infer type for `_`
    |
    = note: type annotations or generic parameter binding required
-   = note: this error originates in a macro from the standard library
+   = note: this error originates in a macro outside of the current crate
 
 error: aborting due to previous error
 

--- a/src/test/ui/cross-crate-macro-backtrace/main.stderr
+++ b/src/test/ui/cross-crate-macro-backtrace/main.stderr
@@ -4,7 +4,7 @@ error: invalid reference to argument `0` (no arguments given)
 16 |     myprintln!("{}"); //~ ERROR in this macro
    |     ^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro from the standard library
+   = note: this error originates in a macro outside of the current crate
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This fixes the wording of the note for out-of-crate macro errors to fix https://github.com/rust-lang/rust/issues/36469

The previous wording came from older logic in the PR that was replaced without updating the note.
