### PR TITLE
Load extern crates in `resolve`

### DIFF
--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -51,7 +51,6 @@ pub enum DepNode<D: Clone + Debug> {
     WorkProduct(Arc<WorkProductId>),
 
     // Represents different phases in the compiler.
-    CrateReader,
     CollectLanguageItems,
     CheckStaticRecursion,
     ResolveLifetimes,
@@ -171,7 +170,6 @@ impl<D: Clone + Debug> DepNode<D> {
 
         match *self {
             Krate => Some(Krate),
-            CrateReader => Some(CrateReader),
             CollectLanguageItems => Some(CollectLanguageItems),
             CheckStaticRecursion => Some(CheckStaticRecursion),
             ResolveLifetimes => Some(ResolveLifetimes),

--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -25,7 +25,7 @@
 use hir::def::{self, Def};
 use hir::def_id::{CrateNum, DefId, DefIndex};
 use hir::map as hir_map;
-use hir::map::definitions::DefKey;
+use hir::map::definitions::{Definitions, DefKey};
 use hir::svh::Svh;
 use middle::lang_items;
 use ty::{self, Ty, TyCtxt};
@@ -422,6 +422,8 @@ impl<'tcx> CrateStore<'tcx> for DummyCrateStore {
     fn metadata_encoding_version(&self) -> &[u8] { bug!("metadata_encoding_version") }
 }
 
-pub trait MacroLoader {
-     fn load_crate(&mut self, extern_crate: &ast::Item, allows_macros: bool) -> Vec<LoadedMacro>;
+pub trait CrateLoader {
+    fn load_macros(&mut self, extern_crate: &ast::Item, allows_macros: bool) -> Vec<LoadedMacro>;
+    fn process_item(&mut self, item: &ast::Item, defs: &Definitions);
+    fn postprocess(&mut self, krate: &ast::Crate);
 }

--- a/src/librustc_metadata/macro_import.rs
+++ b/src/librustc_metadata/macro_import.rs
@@ -14,11 +14,9 @@ use std::collections::HashSet;
 use std::env;
 use std::mem;
 
-use creader::{CrateReader, Macros};
-use cstore::CStore;
+use creader::{CrateLoader, Macros};
 
 use rustc::hir::def_id::DefIndex;
-use rustc::middle;
 use rustc::session::Session;
 use rustc::util::nodemap::FnvHashMap;
 use rustc_back::dynamic_lib::DynamicLibrary;
@@ -31,31 +29,18 @@ use syntax::parse::token;
 use syntax_ext::deriving::custom::CustomDerive;
 use syntax_pos::Span;
 
-pub struct MacroLoader<'a> {
-    sess: &'a Session,
-    reader: CrateReader<'a>,
-}
-
-impl<'a> MacroLoader<'a> {
-    pub fn new(sess: &'a Session,
-               cstore: &'a CStore,
-               crate_name: &str,
-               crate_config: ast::CrateConfig)
-               -> MacroLoader<'a> {
-        MacroLoader {
-            sess: sess,
-            reader: CrateReader::new(sess, cstore, crate_name, crate_config),
-        }
-    }
-}
-
 pub fn call_bad_macro_reexport(a: &Session, b: Span) {
     span_err!(a, b, E0467, "bad macro reexport");
 }
 
 pub type MacroSelection = FnvHashMap<token::InternedString, Span>;
 
-impl<'a> middle::cstore::MacroLoader for MacroLoader<'a> {
+pub fn load_macros(loader: &mut CrateLoader, extern_crate: &ast::Item, allows_macros: bool)
+                   -> Vec<LoadedMacro> {
+    loader.load_crate(extern_crate, allows_macros)
+}
+
+impl<'a> CrateLoader<'a> {
     fn load_crate(&mut self,
                   extern_crate: &ast::Item,
                   allows_macros: bool) -> Vec<LoadedMacro> {
@@ -108,9 +93,7 @@ impl<'a> middle::cstore::MacroLoader for MacroLoader<'a> {
 
         self.load_macros(extern_crate, allows_macros, import, reexport)
     }
-}
 
-impl<'a> MacroLoader<'a> {
     fn load_macros<'b>(&mut self,
                        vi: &ast::Item,
                        allows_macros: bool,
@@ -129,7 +112,7 @@ impl<'a> MacroLoader<'a> {
             return Vec::new();
         }
 
-        let mut macros = self.reader.read_macros(vi);
+        let mut macros = self.creader.read_macros(vi);
         let mut ret = Vec::new();
         let mut seen = HashSet::new();
 

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -79,6 +79,8 @@ impl<'b> Resolver<'b> {
 
     /// Constructs the reduced graph for one item.
     fn build_reduced_graph_for_item(&mut self, item: &Item) {
+        self.crate_loader.process_item(item, &self.definitions);
+
         let parent = self.current_module;
         let name = item.ident.name;
         let sp = item.span;

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -38,7 +38,7 @@ struct ModuleData {
 
 impl<'a> base::Resolver for Resolver<'a> {
     fn load_crate(&mut self, extern_crate: &ast::Item, allows_macros: bool) -> Vec<LoadedMacro> {
-        self.macro_loader.load_crate(extern_crate, allows_macros)
+        self.crate_loader.load_macros(extern_crate, allows_macros)
     }
 
     fn next_node_id(&mut self) -> ast::NodeId {


### PR DESCRIPTION
This PR loads `extern crate`s in `resolve`'s `BuildReducedGraphVistor`.
It is groundwork for macro modularization (cc #35896).

r? @nikomatsakis 
