### PR TITLE
[DoNotMerge][WIP] add support for thumb* (Cortex-M) targets

### DIFF
--- a/mk/cfg/thumbv6m-none-eabi.mk
+++ b/mk/cfg/thumbv6m-none-eabi.mk
@@ -1,0 +1,1 @@
+# rustbuild-only target

--- a/mk/cfg/thumbv7em-none-eabi.mk
+++ b/mk/cfg/thumbv7em-none-eabi.mk
@@ -1,0 +1,1 @@
+# rustbuild-only target

--- a/mk/cfg/thumbv7em-none-eabihf.mk
+++ b/mk/cfg/thumbv7em-none-eabihf.mk
@@ -1,0 +1,1 @@
+# rustbuild-only target

--- a/mk/cfg/thumbv7m-none-eabi.mk
+++ b/mk/cfg/thumbv7m-none-eabi.mk
@@ -1,0 +1,1 @@
+# rustbuild-only target

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -265,7 +265,7 @@ pub fn krate(build: &Build,
              target: &str,
              mode: Mode) {
     let (name, path, features) = match mode {
-        Mode::Libstd => ("libstd", "src/rustc/std_shim", build.std_features()),
+        Mode::Libstd => ("libstd", "src/rustc/std_shim", build.std_features(target)),
         Mode::Libtest => ("libtest", "src/rustc/test_shim", String::new()),
         Mode::Librustc => ("librustc", "src/rustc", build.rustc_features()),
         _ => panic!("can only test libraries"),

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -62,7 +62,7 @@ pub fn std<'a>(build: &'a Build, target: &str, compiler: &Compiler<'a>) {
     let out_dir = build.cargo_out(compiler, Mode::Libstd, target);
     build.clear_if_dirty(&out_dir, &build.compiler_path(compiler));
     let mut cargo = build.cargo(compiler, Mode::Libstd, target, "build");
-    cargo.arg("--features").arg(build.std_features())
+    cargo.arg("--features").arg(build.std_features(target))
          .arg("--manifest-path")
          .arg(build.src.join("src/rustc/std_shim/Cargo.toml"));
 

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -144,7 +144,7 @@ pub fn std(build: &Build, stage: u32, target: &str, out: &Path) {
     let mut cargo = build.cargo(&compiler, Mode::Libstd, target, "doc");
     cargo.arg("--manifest-path")
          .arg(build.src.join("src/rustc/std_shim/Cargo.toml"))
-         .arg("--features").arg(build.std_features());
+         .arg("--features").arg(build.std_features(target));
     build.run(&mut cargo);
     cp_r(&out_dir, out)
 }

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -712,17 +712,27 @@ impl Build {
 
     /// Get the space-separated set of activated features for the standard
     /// library.
-    fn std_features(&self) -> String {
+    fn std_features(&self, target: &str) -> String {
         let mut features = String::new();
-        if self.config.debug_jemalloc {
-            features.push_str(" debug-jemalloc");
+
+        if target.starts_with("thumbv6m") {
+            features.push_str(" thumb_no_atomics");
+        } else if target.starts_with("thumb") {
+            features.push_str(" thumb");
+        } else {
+            features.push_str("full");
+
+            if self.config.debug_jemalloc {
+                features.push_str(" debug-jemalloc");
+            }
+            if self.config.use_jemalloc {
+                features.push_str(" jemalloc");
+            }
+            if self.config.backtrace {
+                features.push_str(" backtrace");
+            }
         }
-        if self.config.use_jemalloc {
-            features.push_str(" jemalloc");
-        }
-        if self.config.backtrace {
-            features.push_str(" backtrace");
-        }
+
         return features
     }
 

--- a/src/libcompiler_builtins/Cargo.toml
+++ b/src/libcompiler_builtins/Cargo.toml
@@ -13,3 +13,4 @@ core = { path = "../libcore" }
 
 [build-dependencies]
 gcc = "0.3.27"
+rustc-cfg = { git = "https://github.com/japaric/rustc-cfg", branch = "llvm-target" }

--- a/src/libcompiler_builtins/build.rs
+++ b/src/libcompiler_builtins/build.rs
@@ -34,10 +34,13 @@
 //! far far less than working with compiler-rt's build system over time.
 
 extern crate gcc;
+extern crate rustc_cfg;
 
 use std::collections::BTreeMap;
 use std::env;
 use std::path::Path;
+
+use rustc_cfg::Cfg;
 
 struct Sources {
     // SYMBOL -> PATH TO SOURCE
@@ -73,9 +76,23 @@ impl Sources {
 
 fn main() {
     let target = env::var("TARGET").unwrap();
+    let Cfg {
+        ref llvm_target,
+        ref target_arch,
+        ref target_os,
+        ref target_env,
+        ref target_vendor,
+        ..
+    } = Cfg::new(&target).unwrap();
+    // TODO(stage0) use `unwrap` instead of `unwrap_or`
+    // NOTE in the latest stable/beta release, `rustc --print cfg` doesn't include `llvm_target` in
+    // its output. In those cases simply fallback to the target triple, which is usually similar to
+    // llvm-target, as a workaround.
+    let llvm_target = llvm_target.as_ref().unwrap_or(&target).split('-').collect::<Vec<_>>();
+    let target_vendor = target_vendor.as_ref().unwrap();
     let cfg = &mut gcc::Config::new();
 
-    if target.contains("msvc") {
+    if target_env == "msvc" {
         // Don't pull in extra libraries on MSVC
         cfg.flag("/Zl");
 
@@ -183,7 +200,7 @@ fn main() {
                      "umoddi3.c",
                      "umodsi3.c"]);
 
-    if !target.contains("ios") {
+    if target_os != "ios" {
         sources.extend(&["absvti2.c",
                          "addtf3.c",
                          "addvti3.c",
@@ -226,7 +243,7 @@ fn main() {
                          "umodti3.c"]);
     }
 
-    if target.contains("apple") {
+    if target_vendor == "apple" {
         sources.extend(&["atomic_flag_clear.c",
                          "atomic_flag_clear_explicit.c",
                          "atomic_flag_test_and_set.c",
@@ -235,20 +252,20 @@ fn main() {
                          "atomic_thread_fence.c"]);
     }
 
-    if !target.contains("windows") {
+    if target_os != "windows" {
         sources.extend(&["emutls.c"]);
     }
 
-    if target.contains("msvc") {
-        if target.contains("x86_64") {
+    if target_env == "msvc" {
+        if llvm_target[0] == "x86_64" {
             sources.extend(&["x86_64/floatdidf.c", "x86_64/floatdisf.c", "x86_64/floatdixf.c"]);
         }
     } else {
-        if !target.contains("freebsd") {
+        if target_os != "freebsd" {
             sources.extend(&["gcc_personality_v0.c"]);
         }
 
-        if target.contains("x86_64") {
+        if target_arch == "x86_64" {
             sources.extend(&["x86_64/chkstk.S",
                              "x86_64/chkstk2.S",
                              "x86_64/floatdidf.c",
@@ -259,7 +276,7 @@ fn main() {
                              "x86_64/floatundixf.S"]);
         }
 
-        if target.contains("i386") || target.contains("i586") || target.contains("i686") {
+        if llvm_target[0] == "i386" || llvm_target[0] == "i586" || llvm_target[0] == "i686" {
             sources.extend(&["i386/ashldi3.S",
                              "i386/ashrdi3.S",
                              "i386/chkstk.S",
@@ -279,7 +296,7 @@ fn main() {
         }
     }
 
-    if target.contains("arm") && !target.contains("ios") {
+    if target_arch == "arm" && target_os != "ios" {
         sources.extend(&["arm/aeabi_cdcmp.S",
                          "arm/aeabi_cdcmpeq_check_nan.c",
                          "arm/aeabi_cfcmp.S",
@@ -315,7 +332,7 @@ fn main() {
                          "arm/umodsi3.S"]);
     }
 
-    if target.contains("armv7") {
+    if llvm_target[0] == "armv7" {
         sources.extend(&["arm/sync_fetch_and_add_4.S",
                          "arm/sync_fetch_and_add_8.S",
                          "arm/sync_fetch_and_and_4.S",
@@ -338,7 +355,7 @@ fn main() {
                          "arm/sync_fetch_and_xor_8.S"]);
     }
 
-    if target.contains("eabihf") {
+    if llvm_target.last().unwrap().ends_with("eabihf") {
         sources.extend(&["arm/adddf3vfp.S",
                          "arm/addsf3vfp.S",
                          "arm/divdf3vfp.S",
@@ -377,7 +394,7 @@ fn main() {
                          "arm/unordsf2vfp.S"]);
     }
 
-    if target.contains("aarch64") {
+    if target_arch == "aarch64" {
         sources.extend(&["comparetf2.c",
                          "extenddftf2.c",
                          "extendsftf2.c",

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -930,6 +930,7 @@ pub fn default_configuration(sess: &Session) -> ast::CrateConfig {
     let os = &sess.target.target.target_os;
     let env = &sess.target.target.target_env;
     let vendor = &sess.target.target.target_vendor;
+    let llvm_target = &sess.target.target.llvm_target;
     let max_atomic_width = sess.target.target.options.max_atomic_width;
 
     let fam = if let Some(ref fam) = sess.target.target.options.target_family {
@@ -949,6 +950,7 @@ pub fn default_configuration(sess: &Session) -> ast::CrateConfig {
         mk(InternedString::new("target_pointer_width"), intern(wordsz)),
         mk(InternedString::new("target_env"), intern(env)),
         mk(InternedString::new("target_vendor"), intern(vendor)),
+        mk(InternedString::new("llvm_target"), intern(llvm_target)),
     ];
     match &fam[..] {
         "windows" | "unix" => ret.push(attr::mk_word_item(fam)),

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -397,12 +397,12 @@ impl Default for TargetOptions {
             allow_asm: true,
             has_elf_tls: false,
             obj_is_bitcode: false,
-            /// NOTE this is *not* the real default value. The default value of max_atomic_width is
-            /// actually the pointer width of the target. This default is injected in the
-            /// Target::from_json function. Still, we have to pick some value to put here. We'll pick
-            /// an impossible value: u64::max_value() because using a valid value like 0 or 8 as the
-            /// default would cause the max-atomic-width field to be "lost" (it would get replaced
-            /// by target_pointer_width) during the Target <-> JSON round trip
+            // NOTE this is *not* the real default value. The default value of max_atomic_width is
+            // actually the pointer width of the target. This default is injected in the
+            // Target::from_json function. Still, we have to pick some value to put here. We'll pick
+            // an impossible value: u64::max_value() because using a valid value like 0 or 8 as the
+            // default would cause the max-atomic-width field to be "lost" (it would get replaced
+            // by target_pointer_width) during the Target <-> JSON round trip
             max_atomic_width: u64::max_value(),
         }
     }

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -63,11 +63,12 @@ mod netbsd_base;
 mod solaris_base;
 mod windows_base;
 mod windows_msvc_base;
+mod thumb_base;
 
 pub type TargetResult = Result<Target, String>;
 
 macro_rules! supported_targets {
-    ( $(($triple:expr, $module:ident)),+ ) => (
+    ( $(($triple:expr, $module:ident)),+, ) => (
         $(mod $module;)*
 
         /// List of supported targets
@@ -184,7 +185,12 @@ supported_targets! {
     ("i586-pc-windows-msvc", i586_pc_windows_msvc),
 
     ("le32-unknown-nacl", le32_unknown_nacl),
-    ("asmjs-unknown-emscripten", asmjs_unknown_emscripten)
+    ("asmjs-unknown-emscripten", asmjs_unknown_emscripten),
+
+    ("thumbv6m-none-eabi", thumbv6m_none_eabi),
+    ("thumbv7m-none-eabi", thumbv7m_none_eabi),
+    ("thumbv7em-none-eabi", thumbv7em_none_eabi),
+    ("thumbv7em-none-eabihf", thumbv7em_none_eabihf),
 }
 
 /// Everything `rustc` knows about how to compile for a specific target.

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -397,7 +397,13 @@ impl Default for TargetOptions {
             allow_asm: true,
             has_elf_tls: false,
             obj_is_bitcode: false,
-            max_atomic_width: 0,
+            /// NOTE this is *not* the real default value. The default value of max_atomic_width is
+            /// actually the pointer width of the target. This default is injected in the
+            /// Target::from_json function. Still, we have to pick some value to put here. We'll pick
+            /// an impossible value: u64::max_value() because using a valid value like 0 or 8 as the
+            /// default would cause the max-atomic-width field to be "lost" (it would get replaced
+            /// by target_pointer_width) during the Target <-> JSON round trip
+            max_atomic_width: u64::max_value(),
         }
     }
 }

--- a/src/librustc_back/target/thumb_base.rs
+++ b/src/librustc_back/target/thumb_base.rs
@@ -1,0 +1,21 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use target::TargetOptions;
+use std::default::Default;
+
+pub fn opts() -> TargetOptions {
+    TargetOptions {
+        executables: true,
+        linker: "arm-none-eabi-gcc".to_string(),
+        max_atomic_width: 32,
+        .. Default::default()
+    }
+}

--- a/src/librustc_back/target/thumbv6m_none_eabi.rs
+++ b/src/librustc_back/target/thumbv6m_none_eabi.rs
@@ -1,0 +1,34 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use target::{Target, TargetOptions, TargetResult};
+
+pub fn target() -> TargetResult {
+    let mut base = super::thumb_base::opts();
+    // There are no atomic instructions in the ARMv6-M architecture
+    base.max_atomic_width = 0;
+    Ok(Target {
+        llvm_target: "thumbv6m-none-eabi".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "32".to_string(),
+        data_layout: "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
+        arch: "arm".to_string(),
+        target_os: "none".to_string(),
+        target_env: "".to_string(),
+        target_vendor: "".to_string(),
+
+        options: TargetOptions {
+            // NOTE prevents mis-optimizations of `ptr::copy_nonoverlapping` when unaligned loads
+            // are involved
+            features: "+strict-align".to_string(),
+            .. base
+        }
+    })
+}

--- a/src/librustc_back/target/thumbv7em_none_eabi.rs
+++ b/src/librustc_back/target/thumbv7em_none_eabi.rs
@@ -1,0 +1,27 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use target::{Target, TargetResult};
+
+pub fn target() -> TargetResult {
+    let base = super::thumb_base::opts();
+    Ok(Target {
+        llvm_target: "thumbv7em-none-eabi".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "32".to_string(),
+        data_layout: "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
+        arch: "arm".to_string(),
+        target_os: "none".to_string(),
+        target_env: "".to_string(),
+        target_vendor: "".to_string(),
+
+        options: base,
+    })
+}

--- a/src/librustc_back/target/thumbv7em_none_eabihf.rs
+++ b/src/librustc_back/target/thumbv7em_none_eabihf.rs
@@ -1,0 +1,31 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use target::{Target, TargetOptions, TargetResult};
+
+pub fn target() -> TargetResult {
+    let base = super::thumb_base::opts();
+    Ok(Target {
+        llvm_target: "thumbv7em-none-eabihf".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "32".to_string(),
+        data_layout: "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
+        arch: "arm".to_string(),
+        target_os: "none".to_string(),
+        target_env: "".to_string(),
+        target_vendor: "".to_string(),
+
+        options: TargetOptions {
+            // NOTE lowest common denominator between the Cortex-M4 (vfp4) and the Cortex-M7 (vfp5)
+            features: "+vfp4".to_string(),
+            .. base
+        }
+    })
+}

--- a/src/librustc_back/target/thumbv7m_none_eabi.rs
+++ b/src/librustc_back/target/thumbv7m_none_eabi.rs
@@ -1,0 +1,27 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use target::{Target, TargetResult};
+
+pub fn target() -> TargetResult {
+    let base = super::thumb_base::opts();
+    Ok(Target {
+        llvm_target: "thumbv7m-none-eabi".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "32".to_string(),
+        data_layout: "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
+        arch: "arm".to_string(),
+        target_os: "none".to_string(),
+        target_env: "".to_string(),
+        target_vendor: "".to_string(),
+
+        options: base,
+    })
+}

--- a/src/rustc/std_shim/Cargo.lock
+++ b/src/rustc/std_shim/Cargo.lock
@@ -2,7 +2,11 @@
 name = "std_shim"
 version = "0.1.0"
 dependencies = [
+ "collections 0.0.0",
+ "compiler_builtins 0.0.0",
  "core 0.0.0",
+ "rand 0.0.0",
+ "rustc_unicode 0.0.0",
  "std 0.0.0",
 ]
 

--- a/src/rustc/std_shim/Cargo.lock
+++ b/src/rustc/std_shim/Cargo.lock
@@ -50,6 +50,7 @@ version = "0.0.0"
 dependencies = [
  "core 0.0.0",
  "gcc 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-cfg 0.1.2 (git+https://github.com/japaric/rustc-cfg?branch=llvm-target)",
 ]
 
 [[package]]
@@ -94,6 +95,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-cfg"
+version = "0.1.2"
+source = "git+https://github.com/japaric/rustc-cfg?branch=llvm-target#7eb668fcf13e2730e9cf8b33389aadbcdfbb0abc"
+
+[[package]]
 name = "rustc_unicode"
 version = "0.0.0"
 dependencies = [
@@ -130,3 +136,4 @@ dependencies = [
 
 [metadata]
 "checksum gcc 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)" = "806e63121fbf30760b060a5fc2d1e9f47e1bd356d183e8870367c6c12cc9d5ed"
+"checksum rustc-cfg 0.1.2 (git+https://github.com/japaric/rustc-cfg?branch=llvm-target)" = "<none>"

--- a/src/rustc/std_shim/Cargo.toml
+++ b/src/rustc/std_shim/Cargo.toml
@@ -40,11 +40,23 @@ debug = false
 debug-assertions = false
 
 [dependencies]
-std = { path = "../../libstd" }
-core = { path = "../../libcore" }
+# full
+std = { path = "../../libstd", optional = true }
+
+# thumb
+compiler_builtins = { path = "../../libcompiler_builtins", optional = true }
+core = { path = "../../libcore", optional = true }
+rustc_unicode = { path = "../../librustc_unicode", optional = true }
+
+# thumb-no-atomics
+collections = { path = "../../libcollections", optional = true }
+rand = { path = "../../librand", optional = true }
 
 # Reexport features from std
 [features]
-jemalloc = ["std/jemalloc"]
-debug-jemalloc = ["std/debug-jemalloc"]
 backtrace = ["std/backtrace"]
+debug-jemalloc = ["std/debug-jemalloc"]
+jemalloc = ["std/jemalloc"]
+full = ["core", "std"]
+thumb_no_atomics  = ["compiler_builtins", "core", "rustc_unicode"]
+thumb = ["core", "compiler_builtins", "collections", "rand"]

--- a/src/rustc/std_shim/lib.rs
+++ b/src/rustc/std_shim/lib.rs
@@ -14,4 +14,3 @@
 // compiling then this doesn't work with `#[macro_use] extern crate std;`. Work
 // around this by not having `#[macro_use] extern crate std;`
 #![no_std]
-extern crate std;


### PR DESCRIPTION
**NOTE** Do not merge. rust-lang/rfcs#1645 must be approved first.

As specified in the ("less targets" alternative of the) RFC, this PR adds these new, baseline
targets to the compiler: 
- `thumbv6m-none-eabi`: Cortex-M0, Cortex-M0+, Cortex-M1
- `thumbv7m-none-eabi`: Cortex-M3
- `thumbv7em-none-eabi`: Cortex-M4, Cortex-M7 -- no FPU, soft float ABI
- `thumbv7em-none-eabihf`: Cortex-M4, Cortex-M7 -- SP FPU, hard float ABI

And tweaks the build script of compiler_builtins to support these targets as well.

With these changes it's possible to compile the following subsets of standard crates for each of
these targets:
- For `thumbv6m-none-eabi`: `compiler_builtins`, `core` and `rustc_unicode`. (*)
- For the other 3 targets: `collections`, `compiler_builtins`, `rand` and every other crate below
  them.

(*) This target doesn't support atomic operations so crates like `alloc`, which depend on atomics
(e.g. `Arc`), and crates above them can't be compiled for this target.

TODOs
- [ ] The corresponding RFC must be approved.
- [x] Teach rustbuild to not build the whole set of standard crates for these targets. Instead tell
  it that it must compile only the smaller set of crates that each target supports.
- [ ] This depends on rust-lang/rust#36512. That must land first.

cc @alexcrichton @brson
