### PR TITLE
Fix a variety of minor issues

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -131,7 +131,8 @@ def stage0_data(rust_root):
 def format_build_time(duration):
     return str(datetime.timedelta(seconds=int(duration)))
 
-class RustBuild:
+
+class RustBuild(object):
     def download_stage0(self):
         cache_dst = os.path.join(self.build_dir, "cache")
         rustc_cache = os.path.join(cache_dst, self.stage0_rustc_date())
@@ -142,7 +143,7 @@ class RustBuild:
             os.makedirs(cargo_cache)
 
         if self.rustc().startswith(self.bin_root()) and \
-           (not os.path.exists(self.rustc()) or self.rustc_out_of_date()):
+                (not os.path.exists(self.rustc()) or self.rustc_out_of_date()):
             if os.path.exists(self.bin_root()):
                 shutil.rmtree(self.bin_root())
             channel = self.stage0_rustc_channel()
@@ -165,7 +166,7 @@ class RustBuild:
                 f.write(self.stage0_rustc_date())
 
         if self.cargo().startswith(self.bin_root()) and \
-           (not os.path.exists(self.cargo()) or self.cargo_out_of_date()):
+                (not os.path.exists(self.cargo()) or self.cargo_out_of_date()):
             channel = self.stage0_cargo_channel()
             filename = "cargo-{}-{}.tar.gz".format(channel, self.build)
             url = "https://static.rust-lang.org/cargo-dist/" + self.stage0_cargo_date()
@@ -238,8 +239,8 @@ class RustBuild:
 
     def get_string(self, line):
         start = line.find('"')
-        end = start + 1 + line[start+1:].find('"')
-        return line[start+1:end]
+        end = start + 1 + line[start + 1:].find('"')
+        return line[start + 1:end]
 
     def exe_suffix(self):
         if sys.platform == 'win32':

--- a/src/doc/rust.css
+++ b/src/doc/rust.css
@@ -159,7 +159,7 @@ em {
 
 footer {
     border-top: 1px solid #ddd;
-    font-size: 14.3px;
+    font-size: 14px;
     font-style: italic;
     padding-top: 5px;
     margin-top: 3em;

--- a/src/etc/debugger_pretty_printers_common.py
+++ b/src/etc/debugger_pretty_printers_common.py
@@ -328,7 +328,7 @@ def extract_length_and_ptr_from_slice(slice_val):
 UNQUALIFIED_TYPE_MARKERS = frozenset(["(", "[", "&", "*"])
 
 def extract_type_name(qualified_type_name):
-    '''Extracts the type name from a fully qualified path'''
+    """Extracts the type name from a fully qualified path"""
     if qualified_type_name[0] in UNQUALIFIED_TYPE_MARKERS:
         return qualified_type_name
 

--- a/src/etc/gdb_rust_pretty_printing.py
+++ b/src/etc/gdb_rust_pretty_printing.py
@@ -209,7 +209,8 @@ class RustSlicePrinter:
     def __init__(self, val):
         self.__val = val
 
-    def display_hint(self):
+    @staticmethod
+    def display_hint():
         return "array"
 
     def to_string(self):
@@ -240,7 +241,8 @@ class RustStdVecPrinter:
     def __init__(self, val):
         self.__val = val
 
-    def display_hint(self):
+    @staticmethod
+    def display_hint():
         return "array"
 
     def to_string(self):

--- a/src/etc/gdb_rust_pretty_printing.py
+++ b/src/etc/gdb_rust_pretty_printing.py
@@ -170,7 +170,7 @@ def rust_pretty_printer_lookup_function(gdb_val):
 #=------------------------------------------------------------------------------
 # Pretty Printer Classes
 #=------------------------------------------------------------------------------
-class RustStructPrinter:
+class RustStructPrinter(object):
     def __init__(self, val, omit_first_field, omit_type_name, is_tuple_like):
         self.__val = val
         self.__omit_first_field = omit_first_field
@@ -205,7 +205,7 @@ class RustStructPrinter:
             return ""
 
 
-class RustSlicePrinter:
+class RustSlicePrinter(object):
     def __init__(self, val):
         self.__val = val
 
@@ -227,7 +227,7 @@ class RustSlicePrinter:
             yield (str(index), (raw_ptr + index).dereference())
 
 
-class RustStringSlicePrinter:
+class RustStringSlicePrinter(object):
     def __init__(self, val):
         self.__val = val
 
@@ -237,7 +237,7 @@ class RustStringSlicePrinter:
         return '"%s"' % raw_ptr.string(encoding="utf-8", length=length)
 
 
-class RustStdVecPrinter:
+class RustStdVecPrinter(object):
     def __init__(self, val):
         self.__val = val
 
@@ -257,7 +257,7 @@ class RustStdVecPrinter:
             yield (str(index), (gdb_ptr + index).dereference())
 
 
-class RustStdStringPrinter:
+class RustStdStringPrinter(object):
     def __init__(self, val):
         self.__val = val
 
@@ -268,7 +268,7 @@ class RustStdStringPrinter:
                                                             length=length)
 
 
-class RustCStyleVariantPrinter:
+class RustCStyleVariantPrinter(object):
     def __init__(self, val):
         assert val.type.get_dwarf_type_kind() == rustpp.DWARF_TYPE_CODE_ENUM
         self.__val = val
@@ -277,7 +277,7 @@ class RustCStyleVariantPrinter:
         return str(self.__val.get_wrapped_value())
 
 
-class IdentityPrinter:
+class IdentityPrinter(object):
     def __init__(self, string):
         self.string = string
 

--- a/src/etc/lldb_batchmode.py
+++ b/src/etc/lldb_batchmode.py
@@ -37,14 +37,14 @@ DEBUG_OUTPUT = False
 
 
 def print_debug(s):
-    "Print something if DEBUG_OUTPUT is True"
+    """Print something if DEBUG_OUTPUT is True"""
     global DEBUG_OUTPUT
     if DEBUG_OUTPUT:
         print("DEBUG: " + str(s))
 
 
 def normalize_whitespace(s):
-    "Replace newlines, tabs, multiple spaces, etc with exactly one space"
+    """Replace newlines, tabs, multiple spaces, etc with exactly one space"""
     return re.sub("\s+", " ", s)
 
 
@@ -71,7 +71,7 @@ registered_breakpoints = set()
 
 
 def execute_command(command_interpreter, command):
-    "Executes a single CLI command"
+    """Executes a single CLI command"""
     global new_breakpoints
     global registered_breakpoints
 

--- a/src/etc/lldb_rust_formatters.py
+++ b/src/etc/lldb_rust_formatters.py
@@ -171,10 +171,10 @@ def print_val(lldb_val, internal_dict):
 #=--------------------------------------------------------------------------------------------------
 
 def print_struct_val(val, internal_dict, omit_first_field, omit_type_name, is_tuple_like):
-    '''
+    """
     Prints a struct, tuple, or tuple struct value with Rust syntax.
     Ignores any fields before field_start_index.
-    '''
+    """
     assert val.type.get_dwarf_type_kind() == rustpp.DWARF_TYPE_CODE_STRUCT
 
     if omit_type_name:
@@ -221,7 +221,7 @@ def print_struct_val(val, internal_dict, omit_first_field, omit_type_name, is_tu
                        "body": body}
 
 def print_pointer_val(val, internal_dict):
-    '''Prints a pointer value with Rust syntax'''
+    """Prints a pointer value with Rust syntax"""
     assert val.type.get_dwarf_type_kind() == rustpp.DWARF_TYPE_CODE_PTR
     sigil = "&"
     type_name = val.type.get_unqualified_type_name()
@@ -275,8 +275,8 @@ def print_std_string_val(val, internal_dict):
 #=--------------------------------------------------------------------------------------------------
 
 def print_array_of_values(array_name, data_ptr_val, length, internal_dict):
-    '''Prints a contigous memory range, interpreting it as values of the
-       pointee-type of data_ptr_val.'''
+    """Prints a contigous memory range, interpreting it as values of the
+       pointee-type of data_ptr_val."""
 
     data_ptr_type = data_ptr_val.type
     assert data_ptr_type.get_dwarf_type_kind() == rustpp.DWARF_TYPE_CODE_PTR

--- a/src/etc/platform-intrinsics/generator.py
+++ b/src/etc/platform-intrinsics/generator.py
@@ -119,16 +119,19 @@ class Void(Type):
     def __init__(self):
         Type.__init__(self, 0)
 
-    def compiler_ctor(self):
+    @staticmethod
+    def compiler_ctor():
         return '::VOID'
 
     def compiler_ctor_ref(self):
         return '&' + self.compiler_ctor()
 
-    def rust_name(self):
+    @staticmethod
+    def rust_name():
         return '()'
 
-    def type_info(self, platform_info):
+    @staticmethod
+    def type_info(platform_info):
         return None
 
     def __eq__(self, other):
@@ -756,22 +759,26 @@ class ExternBlock(object):
     def __init__(self):
         pass
 
-    def open(self, platform):
+    @staticmethod
+    def open(platform):
         return 'extern "platform-intrinsic" {'
 
-    def render(self, mono):
+    @staticmethod
+    def render(mono):
         return '    fn {}{}{};'.format(mono.platform_prefix(),
                                        mono.intrinsic_name(),
                                        mono.intrinsic_signature())
 
-    def close(self):
+    @staticmethod
+    def close():
         return '}'
 
 class CompilerDefs(object):
     def __init__(self):
         pass
 
-    def open(self, platform):
+    @staticmethod
+    def open(platform):
         return '''\
 // Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
@@ -798,7 +805,8 @@ pub fn find(name: &str) -> Option<Intrinsic> {{
     if !name.starts_with("{0}") {{ return None }}
     Some(match &name["{0}".len()..] {{'''.format(platform.platform_prefix())
 
-    def render(self, mono):
+    @staticmethod
+    def render(mono):
         return '''\
         "{}" => Intrinsic {{
             inputs: {{ static INPUTS: [&'static Type; {}] = [{}]; &INPUTS }},
@@ -810,7 +818,8 @@ pub fn find(name: &str) -> Option<Intrinsic> {{
                       mono.compiler_ret(),
                       mono.llvm_name())
 
-    def close(self):
+    @staticmethod
+    def close():
         return '''\
         _ => return None,
     })

--- a/src/etc/platform-intrinsics/generator.py
+++ b/src/etc/platform-intrinsics/generator.py
@@ -285,7 +285,7 @@ class Vector(Type):
 
 class Pointer(Type):
     def __init__(self, elem, llvm_elem, const):
-        self._elem = elem;
+        self._elem = elem
         self._llvm_elem = llvm_elem
         self._const = const
         Type.__init__(self, BITWIDTH_POINTER)

--- a/src/etc/platform-intrinsics/generator.py
+++ b/src/etc/platform-intrinsics/generator.py
@@ -503,7 +503,7 @@ class GenericIntrinsic(object):
             # must be a power of two
             assert width & (width - 1) == 0
             def recur(processed, untouched):
-                if untouched == []:
+                if not untouched:
                     ret = processed[0]
                     args = processed[1:]
                     yield MonomorphicIntrinsic(self._platform, self.intrinsic, width,

--- a/src/etc/test-float-parse/runtests.py
+++ b/src/etc/test-float-parse/runtests.py
@@ -177,7 +177,6 @@ def run(test):
 
 
 def interact(proc, queue):
-    line = ""
     n = 0
     while proc.poll() is None:
         line = proc.stdout.readline()
@@ -185,7 +184,6 @@ def interact(proc, queue):
             continue
         assert line.endswith('\n'), "incomplete line: " + repr(line)
         queue.put(line)
-        line = ""
         n += 1
         if n % UPDATE_EVERY_N == 0:
             msg("got", str(n // 1000) + "k", "records")

--- a/src/etc/unicode.py
+++ b/src/etc/unicode.py
@@ -101,9 +101,9 @@ def load_unicode_data(f):
         udict[cp] = data;
 
     for code in udict:
-        [code_org, name, gencat, combine, bidi,
+        (code_org, name, gencat, combine, bidi,
          decomp, deci, digit, num, mirror,
-         old, iso, upcase, lowcase, titlecase ] = udict[code];
+         old, iso, upcase, lowcase, titlecase) = udict[code];
 
         # generate char to char direct common and simple conversions
         # uppercase to lowercase

--- a/src/etc/unicode.py
+++ b/src/etc/unicode.py
@@ -82,28 +82,28 @@ def load_unicode_data(f):
     canon_decomp = {}
     compat_decomp = {}
 
-    udict = {};
-    range_start = -1;
+    udict = {}
+    range_start = -1
     for line in fileinput.input(f):
-        data = line.split(';');
+        data = line.split(';')
         if len(data) != 15:
             continue
-        cp = int(data[0], 16);
+        cp = int(data[0], 16)
         if is_surrogate(cp):
             continue
         if range_start >= 0:
             for i in xrange(range_start, cp):
-                udict[i] = data;
-            range_start = -1;
+                udict[i] = data
+            range_start = -1
         if data[1].endswith(", First>"):
-            range_start = cp;
-            continue;
-        udict[cp] = data;
+            range_start = cp
+            continue
+        udict[cp] = data
 
     for code in udict:
         (code_org, name, gencat, combine, bidi,
          decomp, deci, digit, num, mirror,
-         old, iso, upcase, lowcase, titlecase) = udict[code];
+         old, iso, upcase, lowcase, titlecase) = udict[code]
 
         # generate char to char direct common and simple conversions
         # uppercase to lowercase
@@ -382,7 +382,7 @@ def emit_bool_trie(f, name, t_data, is_pub=True):
     global bytes_old, bytes_new
     bytes_old += 8 * len(t_data)
     CHUNK = 64
-    rawdata = [False] * 0x110000;
+    rawdata = [False] * 0x110000
     for (lo, hi) in t_data:
         for cp in range(lo, hi + 1):
             rawdata[cp] = True

--- a/src/librustc/mir/repr.rs
+++ b/src/librustc/mir/repr.rs
@@ -180,7 +180,7 @@ impl<'tcx> Mir<'tcx> {
         Some(Local::new(idx))
     }
 
-    /// Counts the number of locals, such that that local_index
+    /// Counts the number of locals, such that local_index
     /// will always return an index smaller than this count.
     pub fn count_locals(&self) -> usize {
         self.arg_decls.len() +

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2913,7 +2913,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
 
     /// See `ParameterEnvironment` struct def'n for details.
     /// If you were using `free_id: NodeId`, you might try `self.region_maps.item_extent(free_id)`
-    /// for the `free_id_outlive` parameter. (But note that that is not always quite right.)
+    /// for the `free_id_outlive` parameter. (But note that is not always quite right.)
     pub fn construct_parameter_environment(self,
                                            span: Span,
                                            def_id: DefId,

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2913,7 +2913,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
 
     /// See `ParameterEnvironment` struct def'n for details.
     /// If you were using `free_id: NodeId`, you might try `self.region_maps.item_extent(free_id)`
-    /// for the `free_id_outlive` parameter. (But note that is not always quite right.)
+    /// for the `free_id_outlive` parameter. (But note that this is not always quite right.)
     pub fn construct_parameter_environment(self,
                                            span: Span,
                                            def_id: DefId,

--- a/src/librustc_trans/collector.rs
+++ b/src/librustc_trans/collector.rs
@@ -153,7 +153,7 @@
 //! The collection algorithm handles this more or less transparently. If it is
 //! about to create a translation item for something with an external `DefId`,
 //! it will take a look if the MIR for that item is available, and if so just
-//! proceed normally. If the MIR is not available, it assumes that that item is
+//! proceed normally. If the MIR is not available, it assumes that the item is
 //! just linked to and no node is created; which is exactly what we want, since
 //! no machine code should be generated in the current crate for such an item.
 //!

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -17,7 +17,7 @@
 //! the `render_inner_with_highlighting` or `render_with_highlighting`
 //! functions. For more advanced use cases (if you want to supply your own css
 //! classes or control how the HTML is generated, or even generate something
-//! other then HTML), then you should implement the the `Writer` trait and use a
+//! other then HTML), then you should implement the `Writer` trait and use a
 //! `Classifier`.
 
 use html::escape::Escape;

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -459,7 +459,8 @@ a {
 .content .search-results td:first-child { padding-right: 0; }
 .content .search-results td:first-child a { padding-right: 10px; }
 
-tr.result span.primitive::after { content: ' (primitive type)'; font-style: italic; color: black}
+tr.result span.primitive::after { content: ' (primitive type)'; font-style: italic; color: black;
+}
 
 body.blur > :not(#help) {
     filter: blur(8px);

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1,3 +1,5 @@
+@import "normalize.css";
+
 /**
  * Copyright 2013 The Rust Project Developers. See the COPYRIGHT
  * file at the top-level directory of this distribution and at
@@ -58,8 +60,6 @@
     font-weight: 600;
     src: local('Source Code Pro Semibold'), url("SourceCodePro-Semibold.woff") format('woff');
 }
-
-@import "normalize.css";
 
 * {
   -webkit-box-sizing: border-box;

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -284,7 +284,7 @@ h3.impl > .out-of-band {
     font-size: 21px;
 }
 
-h4 > code, h3 > code, invisible > code {
+h4 > code, h3 > code, .invisible > code {
     position: inherit;
 }
 

--- a/src/librustdoc/html/static/styles/main.css
+++ b/src/librustdoc/html/static/styles/main.css
@@ -107,7 +107,7 @@ nav.main .current {
     border-bottom-color: #000;
 }
 nav.main .separator {
-    border-color: 1px solid #000;
+    border: 1px solid #000;
 }
 a {
     color: #000;


### PR DESCRIPTION
CSS:
- use integer values for font-size in CSS
- use correct ordering of @import 
- "invisible" isn't a tag - presume its a class
- "border-color" defines the complete border

python:
- use "not" instead of == "[]" for python
- prefer triple quoted docstrings
- prefer static functions where possible
- prefer modern style classes where possible
- remove semicolons;

global:
- remove duplicated words words
