### PR TITLE
Use .reserve() in HashMap and HashSet's extend methods

### DIFF
--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1906,7 +1906,10 @@ impl<K, V, S> FromIterator<(K, V)> for HashMap<K, V, S>
 impl<K, V, S> Extend<(K, V)> for HashMap<K, V, S>
     where K: Eq + Hash, S: BuildHasher
 {
-    fn extend<T: IntoIterator<Item=(K, V)>>(&mut self, iter: T) {
+    fn extend<T: IntoIterator<Item=(K, V)>>(&mut self, iterable: T) {
+        let iter = iterable.into_iter();
+        let (lower_bound, _) = iter.size_hint();
+        self.reserve(lower_bound);
         for (k, v) in iter {
             self.insert(k, v);
         }

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -643,7 +643,10 @@ impl<T, S> Extend<T> for HashSet<T, S>
     where T: Eq + Hash,
           S: BuildHasher,
 {
-    fn extend<I: IntoIterator<Item=T>>(&mut self, iter: I) {
+    fn extend<I: IntoIterator<Item=T>>(&mut self, iterable: I) {
+        let iter = iterable.into_iter();
+        let (lower_bound, _) = iter.size_hint();
+        self.reserve(lower_bound);
         for k in iter {
             self.insert(k);
         }


### PR DESCRIPTION
It was revealed that hashmaps perform very poorly in this example code:

``` rust
let first_map: HashMap<u64, _> = (0..900000).map(|i| (i, ())).collect();
let second_map: HashMap<u64, _> = (900000..1800000).map(|i| (i, ())).collect();

let mut merged = first_map;
merged.extend(second_map);
```

The explanation is that the iterators visit the keys in their bucket
order, and if both maps have the same hash function (including key),
that means that during .extend() the early buckets are overpopulated
long before the whole hashmap's fill level increases to the point that it
triggers it to grow its allocation.

Fixes #36579 
