### PR TITLE
UB free test for CString Drop

### DIFF
--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -313,7 +313,7 @@ impl CString {
 #[stable(feature = "cstring_drop", since = "1.13.0")]
 impl Drop for CString {
     fn drop(&mut self) {
-        unsafe { *self.inner.get_unchecked_mut(0) = 0; }
+        unsafe { ptr::write_volatile(self.inner.as_mut_ptr(), 0u8) }
     }
 }
 

--- a/src/test/run-pass/auxiliary/allocator-leaking.rs
+++ b/src/test/run-pass/auxiliary/allocator-leaking.rs
@@ -1,0 +1,49 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![feature(allocator, core_intrinsics, libc)]
+#![allocator]
+#![crate_type = "rlib"]
+#![no_std]
+
+extern crate libc;
+
+#[no_mangle]
+pub extern fn __rust_allocate(size: usize, align: usize) -> *mut u8 {
+    unsafe {
+        libc::malloc(size as libc::size_t) as *mut u8
+    }
+}
+
+#[no_mangle]
+pub extern fn __rust_deallocate(ptr: *mut u8, old_size: usize, align: usize) {
+    // Do nothing at all.
+}
+
+#[no_mangle]
+pub extern fn __rust_reallocate(ptr: *mut u8, old_size: usize, size: usize,
+                                align: usize) -> *mut u8 {
+    unsafe {
+        libc::realloc(ptr as *mut _, size as libc::size_t) as *mut u8
+    }
+}
+
+#[no_mangle]
+pub extern fn __rust_reallocate_inplace(ptr: *mut u8, old_size: usize,
+                                        size: usize, align: usize) -> usize {
+    unsafe { core::intrinsics::abort() }
+}
+
+#[no_mangle]
+pub extern fn __rust_usable_size(size: usize, align: usize) -> usize {
+    unsafe { core::intrinsics::abort() }
+}


### PR DESCRIPTION
This implements an UB free (I hope :) ) test for #36264. Thanks to @petrochenkov and @nagisa for advice. 

It also switched to `volatile_write` for zeroing per @Amanieu suggestion, which should prevent LLVM from optimizing our efforts away. @nagisa could you re-run [your benchmark](https://github.com/rust-lang/rust/pull/36264#issuecomment-244945255) with this implementation to see if anything has changed? 
