### PR TITLE
Make E0243/E0244 message consistent with E0107

### DIFF
--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -2245,27 +2245,32 @@ fn check_type_argument_count(tcx: TyCtxt, span: Span, supplied: usize,
             "expected"
         };
         let arguments_plural = if required == 1 { "" } else { "s" };
-        struct_span_err!(tcx.sess, span, E0243, "wrong number of type arguments")
-            .span_label(
-                span,
-                &format!("{} {} type argument{}, found {}",
-                         expected, required, arguments_plural, supplied)
-            )
+
+        struct_span_err!(tcx.sess, span, E0243,
+                "wrong number of type arguments: {} {}, found {}",
+                expected, required, supplied)
+            .span_label(span,
+                &format!("{} {} type argument{}",
+                    expected,
+                    required,
+                    arguments_plural))
             .emit();
     } else if supplied > accepted {
-        let expected = if required == 0 {
-            "expected no".to_string()
-        } else if required < accepted {
+        let expected = if required < accepted {
             format!("expected at most {}", accepted)
         } else {
             format!("expected {}", accepted)
         };
         let arguments_plural = if accepted == 1 { "" } else { "s" };
 
-        struct_span_err!(tcx.sess, span, E0244, "wrong number of type arguments")
+        struct_span_err!(tcx.sess, span, E0244,
+                "wrong number of type arguments: {}, found {}",
+                expected, supplied)
             .span_label(
                 span,
-                &format!("{} type argument{}, found {}", expected, arguments_plural, supplied)
+                &format!("{} type argument{}",
+                    if accepted == 0 { "expected no" } else { &expected },
+                    arguments_plural)
             )
             .emit();
     }

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -1355,7 +1355,7 @@ extern "rust-intrinsic" {
 }
 ```
 
-Please check that you provided the right number of lifetime parameters
+Please check that you provided the right number of type parameters
 and verify with the function declaration in the Rust source code.
 Example:
 

--- a/src/test/compile-fail/E0243.rs
+++ b/src/test/compile-fail/E0243.rs
@@ -10,8 +10,8 @@
 
 struct Foo<T> { x: T }
 struct Bar { x: Foo }
-                //~^ ERROR E0243
-                //~| NOTE expected 1 type argument, found 0
+                //~^ ERROR wrong number of type arguments: expected 1, found 0 [E0243]
+                //~| NOTE expected 1 type argument
 
 fn main() {
 }

--- a/src/test/compile-fail/E0244.rs
+++ b/src/test/compile-fail/E0244.rs
@@ -10,8 +10,8 @@
 
 struct Foo { x: bool }
 struct Bar<S, T> { x: Foo<S, T> }
-                      //~^ ERROR E0244
-                      //~| NOTE expected no type arguments, found 2
+                      //~^ ERROR wrong number of type arguments: expected 0, found 2 [E0244]
+                      //~| NOTE expected no type arguments
 
 
 fn main() {

--- a/src/test/compile-fail/generic-type-less-params-with-defaults.rs
+++ b/src/test/compile-fail/generic-type-less-params-with-defaults.rs
@@ -17,6 +17,6 @@ struct Vec<T, A = Heap>(
 
 fn main() {
     let _: Vec;
-    //~^ ERROR E0243
-    //~| NOTE expected at least 1 type argument, found 0
+    //~^ ERROR wrong number of type arguments: expected at least 1, found 0 [E0243]
+    //~| NOTE expected at least 1 type argument
 }

--- a/src/test/compile-fail/generic-type-more-params-with-defaults.rs
+++ b/src/test/compile-fail/generic-type-more-params-with-defaults.rs
@@ -17,6 +17,6 @@ struct Vec<T, A = Heap>(
 
 fn main() {
     let _: Vec<isize, Heap, bool>;
-    //~^ ERROR E0244
-    //~| NOTE expected at most 2 type arguments, found 3
+    //~^ ERROR wrong number of type arguments: expected at most 2, found 3 [E0244]
+    //~| NOTE expected at most 2 type arguments
 }

--- a/src/test/compile-fail/issue-14092.rs
+++ b/src/test/compile-fail/issue-14092.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 fn fn1(0: Box) {}
-        //~^ ERROR E0243
-        //~| NOTE expected 1 type argument, found 0
+        //~^ ERROR wrong number of type arguments: expected 1, found 0 [E0243]
+        //~| NOTE expected 1 type argument
 
 fn main() {}

--- a/src/test/compile-fail/issue-23024.rs
+++ b/src/test/compile-fail/issue-23024.rs
@@ -18,6 +18,6 @@ fn main()
     vfnfer.push(box h);
     println!("{:?}",(vfnfer[0] as Fn)(3));
     //~^ ERROR the precise format of `Fn`-family traits'
-    //~| ERROR E0243
+    //~| ERROR wrong number of type arguments: expected 1, found 0 [E0243]
     //~| ERROR the value of the associated type `Output` (from the trait `std::ops::FnOnce`)
 }

--- a/src/test/compile-fail/typeck-builtin-bound-type-parameters.rs
+++ b/src/test/compile-fail/typeck-builtin-bound-type-parameters.rs
@@ -9,16 +9,16 @@
 // except according to those terms.
 
 fn foo1<T:Copy<U>, U>(x: T) {}
-//~^ ERROR E0244
-//~| NOTE expected no type arguments, found 1
+//~^ ERROR wrong number of type arguments: expected 0, found 1 [E0244]
+//~| NOTE expected no type arguments
 
 trait Trait: Copy<Send> {}
-//~^ ERROR E0244
-//~| NOTE expected no type arguments, found 1
+//~^ ERROR wrong number of type arguments: expected 0, found 1 [E0244]
+//~| NOTE expected no type arguments
 
 struct MyStruct1<T: Copy<T>>;
-//~^ ERROR E0244
-//~| NOTE expected no type arguments, found 1
+//~^ ERROR wrong number of type arguments: expected 0, found 1 [E0244]
+//~| NOTE expected no type arguments
 
 struct MyStruct2<'a, T: Copy<'a>>;
 //~^ ERROR: wrong number of lifetime parameters: expected 0, found 1
@@ -26,8 +26,8 @@ struct MyStruct2<'a, T: Copy<'a>>;
 
 
 fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
-//~^ ERROR E0244
-//~| NOTE expected no type arguments, found 1
+//~^ ERROR wrong number of type arguments: expected 0, found 1 [E0244]
+//~| NOTE expected no type arguments
 //~| ERROR: wrong number of lifetime parameters: expected 0, found 1
 //~| NOTE unexpected lifetime parameter
 

--- a/src/test/compile-fail/typeck_type_placeholder_lifetime_1.rs
+++ b/src/test/compile-fail/typeck_type_placeholder_lifetime_1.rs
@@ -17,6 +17,6 @@ struct Foo<'a, T:'a> {
 
 pub fn main() {
     let c: Foo<_, _> = Foo { r: &5 };
-    //~^ ERROR E0244
-    //~| NOTE expected 1 type argument, found 2
+    //~^ ERROR wrong number of type arguments: expected 1, found 2 [E0244]
+    //~| NOTE expected 1 type argument
 }

--- a/src/test/compile-fail/typeck_type_placeholder_lifetime_2.rs
+++ b/src/test/compile-fail/typeck_type_placeholder_lifetime_2.rs
@@ -17,6 +17,6 @@ struct Foo<'a, T:'a> {
 
 pub fn main() {
     let c: Foo<_, usize> = Foo { r: &5 };
-    //~^ ERROR E0244
-    //~| NOTE expected 1 type argument, found 2
+    //~^ ERROR wrong number of type arguments: expected 1, found 2 [E0244]
+    //~| NOTE expected 1 type argument
 }

--- a/src/test/compile-fail/unboxed-closure-sugar-wrong-trait.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-wrong-trait.rs
@@ -13,8 +13,8 @@
 trait Trait {}
 
 fn f<F:Trait(isize) -> isize>(x: F) {}
-//~^ ERROR E0244
-//~| NOTE expected no type arguments, found 1
+//~^ ERROR wrong number of type arguments: expected 0, found 1 [E0244]
+//~| NOTE expected no type arguments
 //~| ERROR E0220
 //~| NOTE associated type `Output` not found
 


### PR DESCRIPTION
E0243/E0233 prints `expected {}, found {}` on the span note, while E0107 prints it on the first line. This is confusing when both error occur simultaneously.

This PR makes E0243/E0233 print `expected {}, found {}` on the first line.

Code:

``` rust
struct Foo<'a, 'b> {
    s: &'a str,
    t: &'b str,
}

type Bar<T, U> = Foo<T, U>;
```

rustc output (before):

```
error[E0107]: wrong number of lifetime parameters: expected 2, found 0
 --> test.rs:6:18
  |
6 | type Bar<T, U> = Foo<T, U>;
  |                  ^^^^^^^^^ expected 2 lifetime parameters

error[E0244]: wrong number of type arguments
 --> test.rs:6:18
  |
6 | type Bar<T, U> = Foo<T, U>;
  |                  ^^^^^^^^^ expected no type arguments, found 2
```

rustc output (after):

```
error[E0107]: wrong number of lifetime parameters: expected 2, found 0
 --> /tmp/test.rs:6:18
  |
6 | type Bar<T, U> = Foo<T, U>;
  |                  ^^^^^^^^^ expected 2 lifetime parameters

error[E0244]: wrong number of type arguments: expected 0, found 2
 --> /tmp/test.rs:6:18
  |
6 | type Bar<T, U> = Foo<T, U>;
  |                  ^^^^^^^^^ expected no type arguments
```
