### PR TITLE
macros: allow attribute invocations at the crate root

### DIFF
--- a/src/test/compile-fail/issue-36617.rs
+++ b/src/test/compile-fail/issue-36617.rs
@@ -1,0 +1,11 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![derive(Copy)] //~ ERROR `derive` may only be applied to structs, enums and unions


### PR DESCRIPTION
Fixes #36617.
r? @nrc
