### PR TITLE
librustc_mir: Propagate constants during copy propagation.

### DIFF
--- a/src/librustc_mir/def_use.rs
+++ b/src/librustc_mir/def_use.rs
@@ -165,14 +165,14 @@ impl<'tcx, F> MutVisitor<'tcx> for MutateUseVisitor<'tcx, F>
 /// A small structure that enables various metadata of the MIR to be queried
 /// without a reference to the MIR itself.
 #[derive(Clone, Copy)]
-struct MirSummary {
+pub struct MirSummary {
     arg_count: usize,
     var_count: usize,
     temp_count: usize,
 }
 
 impl MirSummary {
-    fn new(mir: &Mir) -> MirSummary {
+    pub fn new(mir: &Mir) -> MirSummary {
         MirSummary {
             arg_count: mir.arg_decls.len(),
             var_count: mir.var_decls.len(),
@@ -180,7 +180,7 @@ impl MirSummary {
         }
     }
 
-    fn local_index<'tcx>(&self, lvalue: &Lvalue<'tcx>) -> Option<Local> {
+    pub fn local_index<'tcx>(&self, lvalue: &Lvalue<'tcx>) -> Option<Local> {
         match *lvalue {
             Lvalue::Arg(arg) => Some(Local::new(arg.index())),
             Lvalue::Var(var) => Some(Local::new(var.index() + self.arg_count)),

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -116,7 +116,7 @@ impl fmt::Display for Mode {
     }
 }
 
-fn is_const_fn(tcx: TyCtxt, def_id: DefId) -> bool {
+pub fn is_const_fn(tcx: TyCtxt, def_id: DefId) -> bool {
     if let Some(node_id) = tcx.map.as_local_node_id(def_id) {
         let fn_like = FnLikeNode::from_node(tcx.map.get(node_id));
         match fn_like.map(|f| f.kind()) {

--- a/src/test/codegen/refs.rs
+++ b/src/test/codegen/refs.rs
@@ -23,9 +23,9 @@ fn helper(_: usize) {
 pub fn ref_dst(s: &[u8]) {
     // We used to generate an extra alloca and memcpy to ref the dst, so check that we copy
     // directly to the alloca for "x"
-// CHECK: [[X0:%[0-9]+]] = getelementptr {{.*}} { i8*, [[USIZE]] }* %s, i32 0, i32 0
+// CHECK: [[X0:%[0-9]+]] = getelementptr {{.*}} { i8*, [[USIZE]] }* %x, i32 0, i32 0
 // CHECK: store i8* %0, i8** [[X0]]
-// CHECK: [[X1:%[0-9]+]] = getelementptr {{.*}} { i8*, [[USIZE]] }* %s, i32 0, i32 1
+// CHECK: [[X1:%[0-9]+]] = getelementptr {{.*}} { i8*, [[USIZE]] }* %x, i32 0, i32 1
 // CHECK: store [[USIZE]] %1, [[USIZE]]* [[X1]]
 
     let x = &*s;

--- a/src/test/mir-opt/storage_ranges.rs
+++ b/src/test/mir-opt/storage_ranges.rs
@@ -19,17 +19,17 @@ fn main() {
 }
 
 // END RUST SOURCE
-// START rustc.node4.PreTrans.after.mir
+// START rustc.node4.TypeckMir.before.mir
 //     bb0: {
-//         nop;                             // scope 0 at storage_ranges.rs:14:9: 14:10
+//         StorageLive(var0);               // scope 0 at storage_ranges.rs:14:9: 14:10
 //         var0 = const 0i32;               // scope 0 at storage_ranges.rs:14:13: 14:14
 //         StorageLive(var1);               // scope 1 at storage_ranges.rs:16:13: 16:14
 //         StorageLive(tmp1);               // scope 1 at storage_ranges.rs:16:18: 16:25
-//         nop;                             // scope 1 at storage_ranges.rs:16:23: 16:24
-//         nop;                             // scope 1 at storage_ranges.rs:16:23: 16:24
-//         tmp1 = std::option::Option<i32>::Some(var0,); // scope 1 at storage_ranges.rs:16:18: 16:25
+//         StorageLive(tmp2);               // scope 1 at storage_ranges.rs:16:23: 16:24
+//         tmp2 = var0;                     // scope 1 at storage_ranges.rs:16:23: 16:24
+//         tmp1 = std::option::Option<i32>::Some(tmp2,); // scope 1 at storage_ranges.rs:16:18: 16:25
 //         var1 = &tmp1;                    // scope 1 at storage_ranges.rs:16:17: 16:25
-//         nop;                             // scope 1 at storage_ranges.rs:16:23: 16:24
+//         StorageDead(tmp2);               // scope 1 at storage_ranges.rs:16:23: 16:24
 //         tmp0 = ();                       // scope 2 at storage_ranges.rs:15:5: 17:6
 //         StorageDead(tmp1);               // scope 1 at storage_ranges.rs:16:18: 16:25
 //         StorageDead(var1);               // scope 1 at storage_ranges.rs:16:13: 16:14
@@ -37,11 +37,11 @@ fn main() {
 //         var2 = const 1i32;               // scope 1 at storage_ranges.rs:18:13: 18:14
 //         return = ();                     // scope 3 at storage_ranges.rs:13:11: 19:2
 //         StorageDead(var2);               // scope 1 at storage_ranges.rs:18:9: 18:10
-//         nop;                             // scope 0 at storage_ranges.rs:14:9: 14:10
+//         StorageDead(var0);               // scope 0 at storage_ranges.rs:14:9: 14:10
 //         goto -> bb1;                     // scope 0 at storage_ranges.rs:13:1: 19:2
 //     }
 //
 //     bb1: {
 //         return;                          // scope 0 at storage_ranges.rs:13:1: 19:2
 //     }
-// END rustc.node4.PreTrans.after.mir
+// END rustc.node4.TypeckMir.before.mir


### PR DESCRIPTION
This optimization kicks in a lot when bootstrapping the compiler.

r? @eddyb
