### PR TITLE
Don't let a type parameter named "Self" unchanged past HIR lowering.

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -391,9 +391,18 @@ impl<'a> LoweringContext<'a> {
     }
 
     fn lower_ty_param(&mut self, tp: &TyParam) -> hir::TyParam {
+        let mut name = tp.ident.name;
+
+        // Don't expose `Self` (recovered "keyword used as ident" parse error).
+        // `rustc::ty` expects `Self` to be only used for a trait's `Self`.
+        // Instead, use gensym("Self") to create a distinct name that looks the same.
+        if name == token::keywords::SelfType.name() {
+            name = token::gensym("Self");
+        }
+
         hir::TyParam {
             id: tp.id,
-            name: tp.ident.name,
+            name: name,
             bounds: self.lower_bounds(&tp.bounds),
             default: tp.default.as_ref().map(|x| self.lower_ty(x)),
             span: tp.span,

--- a/src/test/compile-fail/issue-36638.rs
+++ b/src/test/compile-fail/issue-36638.rs
@@ -1,0 +1,19 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z continue-parse-after-error
+
+struct Foo<Self>(Self);
+//~^ ERROR expected identifier, found keyword `Self`
+
+trait Bar<Self> {}
+//~^ ERROR expected identifier, found keyword `Self`
+
+fn main() {}


### PR DESCRIPTION
Fixes #36638 by rewriting `Self` type parameters (which are a parse error) to a `gensym("Self")`.

Background: #35605 introduced code across rustc that determines `Self` by its keyword name.
Reverting the sanity checks around that would inadvertently cause confusion between the true `Self` of a `trait` and other type parameters named `Self` (which have caused parse errors already).

I do not like to use `gensym`, and we may do something different here in the future, but this should work.
