### PR TITLE
Allow files to be replaced by text on stdin

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -915,6 +915,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
           "the directory the MIR is dumped into"),
     perf_stats: bool = (false, parse_bool, [UNTRACKED],
           "print some performance-related statistics"),
+    replace_files: bool = (false, parse_bool, [TRACKED],
+          "override reading files from disk with stdin"),
 }
 
 pub fn default_lib_output() -> CrateType {

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -41,7 +41,7 @@ use rustc_passes::{ast_validation, no_asm, loops, consts, rvalues, static_recurs
 use rustc_const_eval::check_match;
 use super::Compilation;
 
-use serialize::json;
+use rustc_serialize::json;
 
 use std::env;
 use std::ffi::{OsString, OsStr};

--- a/src/test/run-make/replace-files/Makefile
+++ b/src/test/run-make/replace-files/Makefile
@@ -1,0 +1,3 @@
+-include ../tools.mk
+all: main.rs
+	echo '[{"path": "/foo/foo.rs", "text": "pub fn foo() -> bool { true }\n"}]' | $(RUSTC) main.rs -Zreplace_files

--- a/src/test/run-make/replace-files/main.rs
+++ b/src/test/run-make/replace-files/main.rs
@@ -1,0 +1,23 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This test is run with -Zreplace-files and we pipe a replacement for
+// "/foo/foo.rs" to stdin. The compiler should read that and use the replacement
+// text when it sees the `path` attribute below.
+//
+// If we actually try and look up /foo/foo.rs (which presumably will cause a
+// missing file error), then the replace-files code is broken.
+
+#[path="/foo/foo.rs"]
+mod foo;
+
+fn main() {
+    assert!(foo::foo());
+}


### PR DESCRIPTION
Adds a flag -Zreplace-files. If that is set, then rustc reads a JSON array from stdin of files to replace with provided text.

r? @eddyb
