### PR TITLE
Change error message for intrinsic signature.

### DIFF
--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -379,7 +379,7 @@ pub fn check_platform_intrinsic_type(ccx: &CrateCtxt,
                         span_err!(tcx.sess, it.span, E0444,
                                   "platform-specific intrinsic has invalid number of \
                                    arguments: found {}, expected {}",
-                                  intr.inputs.len(), sig.inputs.len());
+                                  sig.inputs.len(), intr.inputs.len());
                         return
                     }
                     let input_pairs = intr.inputs.iter().zip(&sig.inputs);

--- a/src/test/compile-fail/platform-intrinsic-params.rs
+++ b/src/test/compile-fail/platform-intrinsic-params.rs
@@ -1,0 +1,16 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(platform_intrinsics)]
+extern "platform-intrinsic" {
+    fn x86_mm_movemask_ps() -> i32; //~ERROR found 0, expected 1
+}
+
+fn main() { }


### PR DESCRIPTION
Makes it so the signature of the intrinsic in the user's code is
"found," while the signature that rustc knows about is "expected."

Before this patch, the code

```
#![feature(platform_intrinsics)]
extern "platform-intrinsic" {
    fn x86_mm_movemask_ps() -> i32;
}
```

would give the error

```
error[E0444]: platform-specific intrinsic has invalid number of arguments: found 1, expected 0
 --> test.rs:4:5
  |
4 |     fn x86_mm_movemask_ps() -> i32;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: aborting due to previous error
```

After this patch, it says "found 0, expected 1".
