### PR TITLE
rustdoc css: Put `where` in trait listings on a new line

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -378,6 +378,11 @@ h4 > code, h3 > code, invisible > code {
     font-size: 90%;
 }
 
+/* Shift where in trait listing down a line */
+pre.trait .where::before {
+    content: '\a         ';
+}
+
 nav {
     border-bottom: 1px solid;
     padding-bottom: 10px;


### PR DESCRIPTION
This is about the gray area at the top of a trait's documentation page,
that lists all methods and their signatures. A big trait page like
Iterator is very crowded without this tweak.
