### PR TITLE
rustdoc: print non-self arguments of bare functions and struct methods on their own line

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -618,11 +618,15 @@ pub fn fmt_impl_for_trait_page(i: &clean::Impl, f: &mut fmt::Formatter) -> fmt::
 impl fmt::Display for clean::Arguments {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for (i, input) in self.values.iter().enumerate() {
-            if i > 0 { write!(f, ", ")?; }
+            write!(f, "\n    ")?;
             if !input.name.is_empty() {
                 write!(f, "{}: ", input.name)?;
             }
             write!(f, "{}", input.type_)?;
+            if i + 1 < self.values.len() { write!(f, ",")?; }
+        }
+        if !self.values.is_empty() {
+            write!(f, "\n")?;
         }
         Ok(())
     }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -565,7 +565,7 @@ impl fmt::Display for clean::Type {
                         primitive_link(f, PrimitiveType::Tuple, "(")?;
                         //carry f.alternate() into this display w/o branching manually
                         fmt::Display::fmt(one, f)?;
-                        primitive_link(f, PrimitiveType::Tuple, ")")
+                        primitive_link(f, PrimitiveType::Tuple, ",)")
                     }
                     many => {
                         primitive_link(f, PrimitiveType::Tuple, "(")?;

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -657,7 +657,6 @@ impl<'a> fmt::Display for Method<'a> {
         let decl = self.0;
         let mut args = String::new();
         for (i, input) in decl.inputs.values.iter().enumerate() {
-            if i > 0 || !args.is_empty() { args.push_str(", "); }
             if let Some(selfty) = input.to_self() {
                 match selfty {
                     clean::SelfValue => args.push_str("self"),
@@ -672,11 +671,16 @@ impl<'a> fmt::Display for Method<'a> {
                     }
                 }
             } else {
+                args.push_str("\n    ");
                 if !input.name.is_empty() {
                     args.push_str(&format!("{}: ", input.name));
                 }
                 args.push_str(&format!("{}", input.type_));
             }
+            if i + 1 < decl.inputs.values.len() { args.push_str(","); }
+        }
+        if let Some(None) = decl.inputs.values.iter().last().map(|val| val.to_self()) {
+            args.push_str("\n");
         }
         write!(f, "({args}){arrow}", args = args, arrow = decl.output)
     }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1975,13 +1975,13 @@ fn item_function(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
         UnstableFeatures::Allow => f.constness,
         _ => hir::Constness::NotConst
     };
-    let prefix = format!("{vis}{constness}{unsafety}{abi:#}fn {name}{generics:#}",
-                         vis = VisSpace(&it.visibility),
-                         constness = ConstnessSpace(vis_constness),
-                         unsafety = UnsafetySpace(f.unsafety),
-                         abi = AbiSpace(f.abi),
-                         name = it.name.as_ref().unwrap(),
-                         generics = f.generics)?;
+    let prefix = format!("{}{}{}{:#}fn {}{:#}",
+                         VisSpace(&it.visibility),
+                         ConstnessSpace(vis_constness),
+                         UnsafetySpace(f.unsafety),
+                         AbiSpace(f.abi),
+                         it.name.as_ref().unwrap(),
+                         f.generics);
     let indent = repeat("&nbsp;").take(prefix.len()).collect::<String>();
     write!(w, "<pre class='rust fn'>{vis}{constness}{unsafety}{abi}fn \
                {name}{generics}{decl}{where_clause}</pre>",
@@ -1992,7 +1992,7 @@ fn item_function(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
            name = it.name.as_ref().unwrap(),
            generics = f.generics,
            where_clause = WhereClause(&f.generics),
-           decl = f.decl)?;
+           decl = Method(&f.decl, &indent))?;
     document(w, cx, it)
 }
 

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1975,6 +1975,14 @@ fn item_function(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
         UnstableFeatures::Allow => f.constness,
         _ => hir::Constness::NotConst
     };
+    let prefix = format!("{vis}{constness}{unsafety}{abi:#}fn {name}{generics:#}",
+                         vis = VisSpace(&it.visibility),
+                         constness = ConstnessSpace(vis_constness),
+                         unsafety = UnsafetySpace(f.unsafety),
+                         abi = AbiSpace(f.abi),
+                         name = it.name.as_ref().unwrap(),
+                         generics = f.generics)?;
+    let indent = repeat("&nbsp;").take(prefix.len()).collect::<String>();
     write!(w, "<pre class='rust fn'>{vis}{constness}{unsafety}{abi}fn \
                {name}{generics}{decl}{where_clause}</pre>",
            vis = VisSpace(&it.visibility),
@@ -2254,6 +2262,13 @@ fn render_assoc_item(w: &mut fmt::Formatter,
             UnstableFeatures::Allow => constness,
             _ => hir::Constness::NotConst
         };
+        let prefix = format!("{}{}{:#}fn {}{:#}",
+                             ConstnessSpace(vis_constness),
+                             UnsafetySpace(unsafety),
+                             AbiSpace(abi),
+                             name,
+                             *g);
+        let indent = repeat("&nbsp;").take(prefix.len()).collect::<String>();
         write!(w, "{}{}{}fn <a href='{href}' class='fnname'>{name}</a>\
                    {generics}{decl}{where_clause}",
                ConstnessSpace(vis_constness),
@@ -2262,7 +2277,7 @@ fn render_assoc_item(w: &mut fmt::Formatter,
                href = href,
                name = name,
                generics = *g,
-               decl = Method(d),
+               decl = Method(d, &indent),
                where_clause = WhereClause(g))
     }
     match item.inner {

--- a/src/test/rustdoc/line-breaks.rs
+++ b/src/test/rustdoc/line-breaks.rs
@@ -1,0 +1,21 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "foo"]
+
+//@count foo/fn.function_with_a_really_long_name.html //pre/br 2
+pub fn function_with_a_really_long_name(parameter_one: i32,
+                                        parameter_two: i32)
+                                        -> Option<i32> {
+    Some(parameter_one + parameter_two)
+}
+
+//@count foo/fn.short_name.html //pre/br 0
+pub fn short_name(param: i32) -> i32 { param + 1 }


### PR DESCRIPTION
This change alters the formatting rustdoc uses when it creates function and struct method documentation. For bare functions, each argument is printed on its own line. For struct methods, non-self arguments are printed on their own line. In both cases, no line breaks are introduced if there are no arguments, and for struct methods, no line breaks are introduced if there is only a single self argument. This should aid readability of long function signatures and allow for greater comprehension of these functions.

I've run rustdoc with these changes on my crate egg-mode and its set of dependencies and put the result [on my server](https://shiva.icesoldier.me/doc-custom/egg_mode/). Of note, here are a few shortcut links that highlight the changes:
- [Bare function with a long signature](https://shiva.icesoldier.me/doc-custom/egg_mode/place/fn.reverse_geocode.html)
- [Struct methods, with single self argument and with self and non-self arguments](https://shiva.icesoldier.me/doc-custom/egg_mode/tweet/struct.Timeline.html#method.reset)
- [Bare functions with no arguments](https://shiva.icesoldier.me/doc-custom/rand/fn.thread_rng.html) and [struct methods with no arguments](https://shiva.icesoldier.me/doc-custom/hyper/client/struct.Client.html#method.new) are left unchanged.

This PR consists of two commits: one for bare functions and one for struct methods.
