### PR TITLE
Revert "implement `From<Vec<char>>` and `From<&'a [char]>` for `String`"

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -1902,26 +1902,6 @@ impl Into<Vec<u8>> for String {
     }
 }
 
-#[stable(feature = "stringfromchars", since = "1.12.0")]
-impl<'a> From<&'a [char]> for String {
-    #[inline]
-    fn from(v: &'a [char]) -> String {
-        let mut s = String::with_capacity(v.len());
-        for c in v {
-            s.push(*c);
-        }
-        s
-    }
-}
-
-#[stable(feature = "stringfromchars", since = "1.12.0")]
-impl From<Vec<char>> for String {
-    #[inline]
-    fn from(v: Vec<char>) -> String {
-        String::from(v.as_slice())
-    }
-}
-
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Write for String {
     #[inline]


### PR DESCRIPTION
This reverts commit ac73335f2f5421c914fa3900567696cc6dc73d8d.

This is a revert of https://github.com/rust-lang/rust/pull/35054, which resulted in at least 7 known regressions, reported [here](https://internals.rust-lang.org/t/regression-report-stable-2016-08-16-vs-beta-2016-09-21/4119) and [here](https://github.com/rust-lang/rust/issues/36352), which will hit stable next week.

I think this breakage was somewhat unanticipated, and we did not realize so many crates were broken until this week, so reverting is the conservative thing to do until we figure out how not to cause so much breakage. I've run crater on the revert and did not find any new breakage from the revert.

Fixes https://github.com/rust-lang/rust/issues/36352

cc @pwoolcoc @rust-lang/libs
