### PR TITLE
Create newtype for platform triple in bootstrap.

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -22,7 +22,7 @@ use std::io::prelude::*;
 use std::path::Path;
 use std::process::Command;
 
-use {Build, Compiler, Mode};
+use {Build, Compiler, Mode, Triple};
 use util::{up_to_date, cp_r};
 
 /// Invoke `rustbook` as compiled in `stage` for `target` for the doc book
@@ -30,7 +30,8 @@ use util::{up_to_date, cp_r};
 ///
 /// This will not actually generate any documentation if the documentation has
 /// already been generated.
-pub fn rustbook(build: &Build, stage: u32, target: &str, name: &str, out: &Path) {
+pub fn rustbook(build: &Build, stage: u32, target: &Triple, name: &str,
+                out: &Path) {
     t!(fs::create_dir_all(out));
 
     let out = out.join(name);
@@ -57,7 +58,7 @@ pub fn rustbook(build: &Build, stage: u32, target: &str, name: &str, out: &Path)
 /// `STAMP` alongw ith providing the various header/footer HTML we've cutomized.
 ///
 /// In the end, this is just a glorified wrapper around rustdoc!
-pub fn standalone(build: &Build, stage: u32, target: &str, out: &Path) {
+pub fn standalone(build: &Build, stage: u32, target: &Triple, out: &Path) {
     println!("Documenting stage{} standalone ({})", stage, target);
     t!(fs::create_dir_all(out));
 
@@ -131,7 +132,7 @@ pub fn standalone(build: &Build, stage: u32, target: &str, out: &Path) {
 ///
 /// This will generate all documentation for the standard library and its
 /// dependencies. This is largely just a wrapper around `cargo doc`.
-pub fn std(build: &Build, stage: u32, target: &str, out: &Path) {
+pub fn std(build: &Build, stage: u32, target: &Triple, out: &Path) {
     println!("Documenting stage{} std ({})", stage, target);
     t!(fs::create_dir_all(out));
     let compiler = Compiler::new(stage, &build.config.build);
@@ -153,7 +154,7 @@ pub fn std(build: &Build, stage: u32, target: &str, out: &Path) {
 ///
 /// This will generate all documentation for libtest and its dependencies. This
 /// is largely just a wrapper around `cargo doc`.
-pub fn test(build: &Build, stage: u32, target: &str, out: &Path) {
+pub fn test(build: &Build, stage: u32, target: &Triple, out: &Path) {
     println!("Documenting stage{} test ({})", stage, target);
     t!(fs::create_dir_all(out));
     let compiler = Compiler::new(stage, &build.config.build);
@@ -174,7 +175,7 @@ pub fn test(build: &Build, stage: u32, target: &str, out: &Path) {
 ///
 /// This will generate all documentation for the compiler libraries and their
 /// dependencies. This is largely just a wrapper around `cargo doc`.
-pub fn rustc(build: &Build, stage: u32, target: &str, out: &Path) {
+pub fn rustc(build: &Build, stage: u32, target: &Triple, out: &Path) {
     println!("Documenting stage{} compiler ({})", stage, target);
     t!(fs::create_dir_all(out));
     let compiler = Compiler::new(stage, &build.config.build);
@@ -194,7 +195,7 @@ pub fn rustc(build: &Build, stage: u32, target: &str, out: &Path) {
 
 /// Generates the HTML rendered error-index by running the
 /// `error_index_generator` tool.
-pub fn error_index(build: &Build, stage: u32, target: &str, out: &Path) {
+pub fn error_index(build: &Build, stage: u32, target: &Triple, out: &Path) {
     println!("Documenting stage{} error index ({})", stage, target);
     t!(fs::create_dir_all(out));
     let compiler = Compiler::new(stage, &build.config.build);

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -20,6 +20,8 @@ use std::slice;
 
 use getopts::Options;
 
+use Triple;
+
 /// Deserialized version of all flags for this compile.
 pub struct Flags {
     pub verbose: bool,
@@ -36,7 +38,7 @@ pub struct Flags {
 }
 
 pub struct Filter {
-    values: Vec<String>,
+    values: Vec<Triple>,
 }
 
 impl Flags {
@@ -81,8 +83,18 @@ impl Flags {
             clean: m.opt_present("clean"),
             stage: m.opt_str("stage").map(|j| j.parse().unwrap()),
             build: m.opt_str("build").unwrap(),
-            host: Filter { values: m.opt_strs("host") },
-            target: Filter { values: m.opt_strs("target") },
+            host: Filter {
+                values: m.opt_strs("host")
+                         .into_iter()
+                         .map(|s| s.into())
+                         .collect()
+            },
+            target: Filter {
+                values: m.opt_strs("target")
+                         .into_iter()
+                         .map(|s| s.into())
+                         .collect()
+            },
             step: m.opt_strs("step"),
             config: cfg_file,
             src: m.opt_str("src").map(PathBuf::from),
@@ -93,11 +105,11 @@ impl Flags {
 }
 
 impl Filter {
-    pub fn contains(&self, name: &str) -> bool {
+    pub fn contains(&self, name: &Triple) -> bool {
         self.values.len() == 0 || self.values.iter().any(|s| s == name)
     }
 
-    pub fn iter(&self) -> slice::Iter<String> {
+    pub fn iter(&self) -> slice::Iter<Triple> {
         self.values.iter()
     }
 }

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -65,6 +65,7 @@ mod flags;
 mod native;
 mod sanity;
 mod step;
+mod triple;
 pub mod util;
 
 #[cfg(windows)]
@@ -77,6 +78,7 @@ mod job {
 
 pub use config::Config;
 pub use flags::Flags;
+pub use triple::Triple;
 
 /// A structure representing a Rust compiler.
 ///
@@ -86,7 +88,7 @@ pub use flags::Flags;
 #[derive(Eq, PartialEq, Clone, Copy, Hash, Debug)]
 pub struct Compiler<'a> {
     stage: u32,
-    host: &'a str,
+    host: &'a Triple,
 }
 
 /// Global configuration for the build system.
@@ -128,8 +130,8 @@ pub struct Build {
     lldb_python_dir: Option<String>,
 
     // Runtime state filled in later on
-    cc: HashMap<String, (gcc::Tool, Option<PathBuf>)>,
-    cxx: HashMap<String, gcc::Tool>,
+    cc: HashMap<Triple, (gcc::Tool, Option<PathBuf>)>,
+    cxx: HashMap<Triple, gcc::Tool>,
 }
 
 /// The various "modes" of invoking Cargo.
@@ -402,9 +404,9 @@ impl Build {
                                        "ui", "ui");
                 }
                 CheckDebuginfo { compiler } => {
-                    if target.target.contains("msvc") {
+                    if target.target.is_msvc() {
                         // nothing to do
-                    } else if target.target.contains("apple") {
+                    } else if target.target.is_apple() {
                         check::compiletest(self, &compiler, target.target,
                                            "debuginfo-lldb", "debuginfo");
                     } else {
@@ -596,7 +598,7 @@ impl Build {
     fn cargo(&self,
              compiler: &Compiler,
              mode: Mode,
-             target: &str,
+             target: &Triple,
              cmd: &str) -> Command {
         let mut cargo = Command::new(&self.cargo);
         let out_dir = self.stage_out(compiler, mode);
@@ -646,7 +648,7 @@ impl Build {
         // the build.
         //
         // FIXME: the guard against msvc shouldn't need to be here
-        if !target.contains("msvc") {
+        if !target.is_msvc() {
             cargo.env(format!("CC_{}", target), self.cc(target))
                  .env(format!("AR_{}", target), self.ar(target).unwrap()) // only msvc is None
                  .env(format!("CFLAGS_{}", target), self.cflags(target).join(" "));
@@ -654,7 +656,7 @@ impl Build {
 
         // If we're building for OSX, inform the compiler and the linker that
         // we want to build a compiler runnable on 10.7
-        if target.contains("apple-darwin") {
+        if target.is_apple_darwin() {
             cargo.env("MACOSX_DEPLOYMENT_TARGET", "10.7");
         }
 
@@ -757,7 +759,7 @@ impl Build {
 
     /// Returns the libdir where the standard library and other artifacts are
     /// found for a compiler's sysroot.
-    fn sysroot_libdir(&self, compiler: &Compiler, target: &str) -> PathBuf {
+    fn sysroot_libdir(&self, compiler: &Compiler, target: &Triple) -> PathBuf {
         self.sysroot(compiler).join("lib").join("rustlib")
             .join(target).join("lib")
     }
@@ -783,7 +785,7 @@ impl Build {
     fn cargo_out(&self,
                  compiler: &Compiler,
                  mode: Mode,
-                 target: &str) -> PathBuf {
+                 target: &Triple) -> PathBuf {
         self.stage_out(compiler, mode).join(target).join(self.cargo_dir())
     }
 
@@ -791,14 +793,14 @@ impl Build {
     ///
     /// Note that if LLVM is configured externally then the directory returned
     /// will likely be empty.
-    fn llvm_out(&self, target: &str) -> PathBuf {
+    fn llvm_out(&self, target: &Triple) -> PathBuf {
         self.out.join(target).join("llvm")
     }
 
     /// Returns true if no custom `llvm-config` is set for the specified target.
     ///
     /// If no custom `llvm-config` was specified then Rust's llvm will be used.
-    fn is_rust_llvm(&self, target: &str) -> bool {
+    fn is_rust_llvm(&self, target: &Triple) -> bool {
         match self.config.target_config.get(target) {
             Some(ref c) => c.llvm_config.is_none(),
             None => true
@@ -809,7 +811,7 @@ impl Build {
     ///
     /// If a custom `llvm-config` was specified for target then that's returned
     /// instead.
-    fn llvm_config(&self, target: &str) -> PathBuf {
+    fn llvm_config(&self, target: &Triple) -> PathBuf {
         let target_config = self.config.target_config.get(target);
         if let Some(s) = target_config.and_then(|c| c.llvm_config.as_ref()) {
             s.clone()
@@ -820,14 +822,14 @@ impl Build {
     }
 
     /// Returns the path to `FileCheck` binary for the specified target
-    fn llvm_filecheck(&self, target: &str) -> PathBuf {
+    fn llvm_filecheck(&self, target: &Triple) -> PathBuf {
         let target_config = self.config.target_config.get(target);
         if let Some(s) = target_config.and_then(|c| c.llvm_config.as_ref()) {
             s.parent().unwrap().join(exe("FileCheck", target))
         } else {
             let base = self.llvm_out(&self.config.build).join("build");
             let exe = exe("FileCheck", target);
-            if self.config.build.contains("msvc") {
+            if self.config.build.is_msvc() {
                 base.join("Release/bin").join(exe)
             } else {
                 base.join("bin").join(exe)
@@ -837,7 +839,7 @@ impl Build {
 
     /// Root output directory for rust_test_helpers library compiled for
     /// `target`
-    fn test_helpers_out(&self, target: &str) -> PathBuf {
+    fn test_helpers_out(&self, target: &Triple) -> PathBuf {
         self.out.join(target).join("rust-test-helpers")
     }
 
@@ -906,13 +908,13 @@ impl Build {
     }
 
     /// Returns the path to the C compiler for the target specified.
-    fn cc(&self, target: &str) -> &Path {
+    fn cc(&self, target: &Triple) -> &Path {
         self.cc[target].0.path()
     }
 
     /// Returns a list of flags to pass to the C compiler for the target
     /// specified.
-    fn cflags(&self, target: &str) -> Vec<String> {
+    fn cflags(&self, target: &Triple) -> Vec<String> {
         // Filter out -O and /O (the optimization flags) that we picked up from
         // gcc-rs because the build scripts will determine that for themselves.
         let mut base = self.cc[target].0.args().iter()
@@ -924,14 +926,14 @@ impl Build {
         // indicating that we want libc++ (more filled out than libstdc++) and
         // we want to compile for 10.7. This way we can ensure that
         // LLVM/jemalloc/etc are all properly compiled.
-        if target.contains("apple-darwin") {
+        if target.is_apple_darwin() {
             base.push("-stdlib=libc++".into());
             base.push("-mmacosx-version-min=10.7".into());
         }
         // This is a hack, because newer binutils broke things on some vms/distros
         // (i.e., linking against unknown relocs disabled by the following flag)
         // See: https://github.com/rust-lang/rust/issues/34978
-        match target {
+        match &target.0 as &str {
             "i586-unknown-linux-gnu" |
             "i686-unknown-linux-musl" |
             "x86_64-unknown-linux-musl" => {
@@ -943,13 +945,13 @@ impl Build {
     }
 
     /// Returns the path to the `ar` archive utility for the target specified.
-    fn ar(&self, target: &str) -> Option<&Path> {
+    fn ar(&self, target: &Triple) -> Option<&Path> {
         self.cc[target].1.as_ref().map(|p| &**p)
     }
 
     /// Returns the path to the C++ compiler for the target specified, may panic
     /// if no C++ compiler was configured for the target.
-    fn cxx(&self, target: &str) -> &Path {
+    fn cxx(&self, target: &Triple) -> &Path {
         match self.cxx.get(target) {
             Some(p) => p.path(),
             None => panic!("\n\ntarget `{}` is not configured as a host,
@@ -958,7 +960,7 @@ impl Build {
     }
 
     /// Returns flags to pass to the compiler to generate code for `target`.
-    fn rustc_flags(&self, target: &str) -> Vec<String> {
+    fn rustc_flags(&self, target: &Triple) -> Vec<String> {
         // New flags should be added here with great caution!
         //
         // It's quite unfortunate to **require** flags to generate code for a
@@ -967,14 +969,14 @@ impl Build {
         // than an entry here.
 
         let mut base = Vec::new();
-        if target != self.config.build && !target.contains("msvc") {
+        if target != &self.config.build && !target.is_msvc() {
             base.push(format!("-Clinker={}", self.cc(target).display()));
         }
         return base
     }
 
     /// Returns the "musl root" for this `target`, if defined
-    fn musl_root(&self, target: &str) -> Option<&Path> {
+    fn musl_root(&self, target: &Triple) -> Option<&Path> {
         self.config.target_config[target].musl_root.as_ref()
             .or(self.config.musl_root.as_ref())
             .map(|p| &**p)
@@ -983,12 +985,12 @@ impl Build {
 
 impl<'a> Compiler<'a> {
     /// Creates a new complier for the specified stage/host
-    fn new(stage: u32, host: &'a str) -> Compiler<'a> {
+    fn new(stage: u32, host: &'a Triple) -> Compiler<'a> {
         Compiler { stage: stage, host: host }
     }
 
     /// Returns whether this is a snapshot compiler for `build`'s configuration
     fn is_snapshot(&self, build: &Build) -> bool {
-        self.stage == 0 && self.host == build.config.build
+        self.stage == 0 && self.host == &build.config.build
     }
 }

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -101,22 +101,22 @@ pub fn check(build: &mut Build) {
 
     for target in build.config.target.iter() {
         // Either can't build or don't want to run jemalloc on these targets
-        if target.contains("rumprun") ||
-           target.contains("bitrig") ||
-           target.contains("openbsd") ||
-           target.contains("msvc") ||
-           target.contains("emscripten") {
+        if target.is_rumprun() ||
+           target.is_bitrig() ||
+           target.is_openbsd() ||
+           target.is_msvc() ||
+           target.is_emscripten() {
             build.config.use_jemalloc = false;
         }
 
         // Can't compile for iOS unless we're on OSX
-        if target.contains("apple-ios") &&
-           !build.config.build.contains("apple-darwin") {
+        if target.is_apple_ios() &&
+           !build.config.build.is_apple_darwin() {
             panic!("the iOS target is only supported on OSX");
         }
 
         // Make sure musl-root is valid if specified
-        if target.contains("musl") && !target.contains("mips") {
+        if target.is_musl() && !target.is_mips() {
             match build.musl_root(target) {
                 Some(root) => {
                     if fs::metadata(root.join("lib/libc.a")).is_err() {
@@ -136,7 +136,7 @@ pub fn check(build: &mut Build) {
             }
         }
 
-        if target.contains("msvc") {
+        if target.is_msvc() {
             // There are three builds of cmake on windows: MSVC, MinGW, and
             // Cygwin. The Cygwin build does not have generators for Visual
             // Studio, so detect that here and error.
@@ -157,7 +157,7 @@ $ pacman -R cmake && pacman -S mingw-w64-x86_64-cmake
             }
         }
 
-        if target.contains("arm-linux-android") {
+        if target.is_arm_linux_android() {
             need_cmd("adb".as_ref());
         }
     }

--- a/src/bootstrap/triple.rs
+++ b/src/bootstrap/triple.rs
@@ -1,0 +1,126 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::convert;
+use std::ffi;
+use std::fmt;
+use std::path;
+
+/// Platform represented by a hyphen-delimited string. Does not
+/// necessarily consist of three items. e.g.:
+///
+/// * `i686-apple-darwin`
+/// * `powerpc-unknown-linux-gnu`
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, RustcDecodable)]
+pub struct Triple(pub String);
+
+impl Triple {
+    pub fn arch(&self) -> &str {
+        self.0.split('-').next().unwrap()
+    }
+
+    pub fn is_msvc(&self) -> bool {
+        self.0.contains("msvc")
+    }
+
+    pub fn is_windows(&self) -> bool {
+        self.0.contains("windows")
+    }
+
+    pub fn is_windows_msvc(&self) -> bool {
+        self.0.contains("windows-msvc")
+    }
+
+    pub fn is_apple(&self) -> bool {
+        self.0.contains("apple")
+    }
+
+    pub fn is_apple_darwin(&self) -> bool {
+        self.0.contains("apple-darwin")
+    }
+
+    pub fn is_android(&self) -> bool {
+        self.0.contains("android")
+    }
+
+    pub fn is_rumprun(&self) -> bool {
+        self.0.contains("rumprun")
+    }
+
+    pub fn is_bitrig(&self) -> bool {
+        self.0.contains("bitrig")
+    }
+
+    pub fn is_openbsd(&self) -> bool {
+        self.0.contains("openbsd")
+    }
+
+    pub fn is_emscripten(&self) -> bool {
+        self.0.contains("emscripten")
+    }
+
+    pub fn is_arm_linux_android(&self) -> bool {
+        self.0.contains("arm-linux-android")
+    }
+
+    pub fn is_pc_windows_gnu(&self) -> bool {
+        self.0.contains("pc-windows-gnu")
+    }
+
+    pub fn is_windows_gnu(&self) -> bool {
+        self.0.contains("windows-gnu")
+    }
+
+    pub fn is_mips(&self) -> bool {
+        self.0.contains("mips")
+    }
+
+    pub fn is_musl(&self) -> bool {
+        self.0.contains("musl")
+    }
+
+    pub fn is_apple_ios(&self) -> bool {
+        self.0.contains("musl")
+    }
+
+    pub fn is_i686(&self) -> bool {
+        self.0.starts_with("i686")
+    }
+}
+
+impl fmt::Display for Triple {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl convert::AsRef<path::Path> for Triple {
+    fn as_ref(&self) -> &path::Path {
+        self.0.as_ref()
+    }
+}
+
+impl convert::AsRef<ffi::OsStr> for Triple {
+    fn as_ref(&self) -> &ffi::OsStr {
+        self.0.as_ref()
+    }
+}
+
+impl<'a> convert::From<String> for Triple {
+    fn from(s: String) -> Triple {
+        Triple(s)
+    }
+}
+
+impl<'a> convert::From<&'a str> for Triple {
+    fn from(s: &'a str) -> Triple {
+        Triple(s.into())
+    }
+}

--- a/src/bootstrap/util.rs
+++ b/src/bootstrap/util.rs
@@ -20,10 +20,11 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use filetime::FileTime;
+use Triple;
 
 /// Returns the `name` as the filename of a static library for `target`.
-pub fn staticlib(name: &str, target: &str) -> String {
-    if target.contains("windows") {
+pub fn staticlib(name: &str, target: &Triple) -> String {
+    if target.is_windows() {
         format!("{}.lib", name)
     } else {
         format!("lib{}.a", name)
@@ -98,8 +99,8 @@ pub fn cp_filtered<F: Fn(&Path) -> bool>(src: &Path, dst: &Path, filter: &F) {
 
 /// Given an executable called `name`, return the filename for the
 /// executable for a particular target.
-pub fn exe(name: &str, target: &str) -> String {
-    if target.contains("windows") {
+pub fn exe(name: &str, target: &Triple) -> String {
+    if target.is_windows() {
         format!("{}.exe", name)
     } else {
         name.to_string()
@@ -113,8 +114,8 @@ pub fn is_dylib(name: &str) -> bool {
 
 /// Returns the corresponding relative library directory that the compiler's
 /// dylibs will be found in.
-pub fn libdir(target: &str) -> &'static str {
-    if target.contains("windows") {"bin"} else {"lib"}
+pub fn libdir(target: &Triple) -> &'static str {
+    if target.is_windows() {"bin"} else {"lib"}
 }
 
 /// Adds a list of lookup paths to `cmd`'s dynamic library lookup path.


### PR DESCRIPTION
As I was reading through the bootstrap code, I noticed myself getting
lost at times trying to find out what the value of each `&str` is. I
also noticed there's quite a few platform-checking conditionals checking
the contents of these strings. In an attempt to clarify and cleanup
these cases, I created a 'newtype' `Triple` that represents a platform
triple and moved the platform-checking logic to methods on the new
struct.
