### PR TITLE
Add method str::repeat(self, usize) -> String

### DIFF
--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -1746,4 +1746,24 @@ impl str {
             String::from_utf8_unchecked(slice.into_vec())
         }
     }
+
+    /// Create a [`String`] by repeating a string `n` times.
+    ///
+    /// [`String`]: string/struct.String.html
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// #![feature(repeat_str)]
+    ///
+    /// assert_eq!("abc".repeat(4), String::from("abcabcabcabc"));
+    /// ```
+    #[unstable(feature = "repeat_str", issue = "37079")]
+    pub fn repeat(&self, n: usize) -> String {
+        let mut s = String::with_capacity(self.len() * n);
+        s.extend((0..n).map(|_| self));
+        s
+    }
 }

--- a/src/libcollectionstest/lib.rs
+++ b/src/libcollectionstest/lib.rs
@@ -19,6 +19,7 @@
 #![feature(enumset)]
 #![feature(pattern)]
 #![feature(rand)]
+#![feature(repeat_str)]
 #![feature(step_by)]
 #![feature(str_escape)]
 #![feature(test)]

--- a/src/libcollectionstest/str.rs
+++ b/src/libcollectionstest/str.rs
@@ -1272,6 +1272,13 @@ fn test_cow_from() {
     }
 }
 
+#[test]
+fn test_repeat() {
+    assert_eq!("".repeat(3), "");
+    assert_eq!("abc".repeat(0), "");
+    assert_eq!("α".repeat(3), "ααα");
+}
+
 mod pattern {
     use std::str::pattern::Pattern;
     use std::str::pattern::{Searcher, ReverseSearcher};


### PR DESCRIPTION
It is relatively simple to repeat a string n times:
`(0..n).map(|_| s).collect::<String>()`. It becomes slightly more
complicated to do it “right” (sizing the allocation up front), which
warrants a method that does it for us.

This method is useful in writing testcases, or when generating text.
`format!()` can be used to repeat single characters, but not repeating
strings like this.
