### PR TITLE
Skip binary tidy check when on Windows Linux Subsystem

### DIFF
--- a/src/tools/tidy/src/bins.rs
+++ b/src/tools/tidy/src/bins.rs
@@ -24,8 +24,19 @@ pub fn check(_path: &Path, _bad: &mut bool) {}
 #[cfg(unix)]
 pub fn check(path: &Path, bad: &mut bool) {
     use std::fs;
+    use std::io::Read;
     use std::process::{Command, Stdio};
     use std::os::unix::prelude::*;
+
+    if let Ok(mut file) = fs::File::open("/proc/version") {
+        let mut contents = String::new();
+        file.read_to_string(&mut contents).unwrap();
+        // Probably on Windows Linux Subsystem, all files will be marked as
+        // executable, so skip checking.
+        if contents.contains("Microsoft") {
+            return;
+        }
+    }
 
     super::walk(path,
                 &mut |path| super::filter_dirs(path) || path.ends_with("src/etc"),


### PR DESCRIPTION
While it's possible that other linux systems will include "Microsoft" in
their /proc/version, this is deemed unlikely, and since this is a tidy
check, will likely be caught by buildbot/travis either way.

Fixes #36706.
