### PR TITLE
Forbid user-defined macros named "macro_rules"

### DIFF
--- a/src/librustc_plugin/registry.rs
+++ b/src/librustc_plugin/registry.rs
@@ -101,6 +101,9 @@ impl<'a> Registry<'a> {
     ///
     /// This is the most general hook into `libsyntax`'s expansion behavior.
     pub fn register_syntax_extension(&mut self, name: ast::Name, extension: SyntaxExtension) {
+        if name.as_str() == "macro_rules" {
+            panic!("user-defined macros may not be named `macro_rules`");
+        }
         self.syntax_exts.push((name, match extension {
             NormalTT(ext, _, allow_internal_unstable) => {
                 NormalTT(ext, Some(self.krate_span), allow_internal_unstable)

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -53,6 +53,9 @@ impl<'a> base::Resolver for Resolver<'a> {
     }
 
     fn add_macro(&mut self, scope: Mark, mut def: ast::MacroDef) {
+        if &def.ident.name.as_str() == "macro_rules" {
+            self.session.span_err(def.span, "user-defined macros may not be named `macro_rules`");
+        }
         if def.use_locally {
             let ext = macro_rules::compile(&self.session.parse_sess, &def);
             self.add_ext(scope, def.ident, Rc::new(ext));

--- a/src/test/compile-fail/user-defined-macro-rules.rs
+++ b/src/test/compile-fail/user-defined-macro-rules.rs
@@ -1,0 +1,11 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! macro_rules { () => {} } //~ ERROR user-defined macros may not be named `macro_rules`


### PR DESCRIPTION
This is a [breaking-change].
r? @nrc 
