### PR TITLE
Updated example code in the documentation

### DIFF
--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -209,7 +209,14 @@
 //! interesting implementation of [`IntoIterator`]:
 //!
 //! ```ignore
-//! impl<I: Iterator> IntoIterator for I
+//! impl<I: Iterator> IntoIterator for I {
+//!     type Item = I::Item;
+//!     type IntoIter = I;
+//! 
+//!     fn into_iter(self) -> I {
+//!         self
+//!     }
+//! }
 //! ```
 //!
 //! In other words, all [`Iterator`]s implement [`IntoIterator`], by just


### PR DESCRIPTION
An example code was truncated to only its first line. I went to find the missing part in the source code of Rust, and now the documentation makes sense.
