### PR TITLE
rustc: Use a special filename for macros 1.1

### DIFF
--- a/src/librustc_macro/lib.rs
+++ b/src/librustc_macro/lib.rs
@@ -139,7 +139,7 @@ impl FromStr for TokenStream {
         __internal::with_parse_sess(|sess| {
             let src = src.to_string();
             let cfg = Vec::new();
-            let name = "rustc-macro source code".to_string();
+            let name = "<rustc-macro source code>".to_string();
             let mut parser = parse::new_parser_from_source_str(sess, cfg, name,
                                                                src);
             let mut ret = TokenStream { inner: Vec::new() };

--- a/src/test/run-make/rustc-macro-dep-files/Makefile
+++ b/src/test/run-make/rustc-macro-dep-files/Makefile
@@ -1,0 +1,6 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) foo.rs
+	$(RUSTC) bar.rs --emit dep-info
+	grep "rustc-macro source" $(TMPDIR)/bar.d && exit 1 || exit 0

--- a/src/test/run-make/rustc-macro-dep-files/bar.rs
+++ b/src/test/run-make/rustc-macro-dep-files/bar.rs
@@ -1,0 +1,21 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_macro)]
+
+#[macro_use]
+extern crate foo;
+
+#[derive(A)]
+struct A;
+
+fn main() {
+    let _b = B;
+}

--- a/src/test/run-make/rustc-macro-dep-files/foo.rs
+++ b/src/test/run-make/rustc-macro-dep-files/foo.rs
@@ -1,0 +1,24 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rustc-macro"]
+#![feature(rustc_macro)]
+#![feature(rustc_macro_lib)]
+
+extern crate rustc_macro;
+
+use rustc_macro::TokenStream;
+
+#[rustc_macro_derive(A)]
+pub fn derive(input: TokenStream) -> TokenStream {
+    let input = input.to_string();
+    assert!(input.contains("struct A;"));
+    "struct B;".parse().unwrap()
+}


### PR DESCRIPTION
This "special filename" is surrounded by `<>` to ensure that
`FileMap::is_real_file` returns `false`. This way the "files" parsed here aren't
emitted as dep info `.d` files and don't confuse Cargo about non-existent files.

Closes #36625
