### PR TITLE
Specialize methods on iter::Cloned<I> where I::Item: Copy.

### DIFF
--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -401,6 +401,23 @@ impl<'a, I, T: 'a> Iterator for Cloned<I>
     }
 }
 
+#[stable(feature = "iter_cloned_copy", since = "1.13.0")]
+impl<'a, I, T: 'a> Iterator for Cloned<I>
+    where I: Iterator<Item=&'a T>, T: Copy
+{
+    fn nth(&mut self, n: usize) -> Option<T> {
+        self.it.nth(n).cloned()
+    }
+
+    fn last(self) -> Option<T> {
+        self.it.last().cloned()
+    }
+
+    fn count(self) -> usize {
+        self.it.count()
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, I, T: 'a> DoubleEndedIterator for Cloned<I>
     where I: DoubleEndedIterator<Item=&'a T>, T: Clone


### PR DESCRIPTION
A common idiom when iterating over a collection of, e.g., `&str`s is to write `my_collection.iter().cloned().something_else()`. Unfortunately, because the call to `clone` might do something interesting, we can't specialize `count`, `last`, and `nth` as discussed in https://github.com/rust-lang/rust/pull/28125. However, now that https://github.com/rust-lang/rfcs/pull/1521 has been merged and we have specialization, we can specialize `count`, `last`, and `nth` for `iter::Cloned<I> where I::Item: Copy` (this also optimizes `skip`). Benchmarks below:

``` rust
extern crate test;
use test::Bencher;

pub struct Cloned<I> {
    it: I,
}

impl<'a, I, T: 'a> Iterator for Cloned<I>
    where I: Iterator<Item=&'a T>, T: Clone
{
    type Item = T;

    fn next(&mut self) -> Option<T> {
        self.it.next().cloned()
    }

    fn size_hint(&self) -> (usize, Option<usize>) {
        self.it.size_hint()
    }
}

impl<'a, I, T: 'a> Iterator for Cloned<I>
    where I: Iterator<Item=&'a T>, T: Copy
{
    fn nth(&mut self, n: usize) -> Option<T> {
        self.it.nth(n).cloned()
    }

    fn last(self) -> Option<T> {
        self.it.last().cloned()
    }

    fn count(self) -> usize {
        self.it.count()
    }
}

fn bench_cloned(b: &mut Bencher) {
    let numbers: Vec<_> = vec!["asfd"; 100];
    b.iter(|| {
        test::black_box(test::black_box(numbers.iter()).cloned().last())
    })
}

fn bench_my_cloned(b: &mut Bencher) {
    let numbers: Vec<_> = vec!["asfd"; 100];
    b.iter(|| {
        test::black_box(Cloned { it: test::black_box(numbers.iter()) }.last())
    })
}


fn bench_normal(b: &mut Bencher) {
    let numbers: Vec<_> = vec!["asfd"; 100];
    b.iter(|| {
        test::black_box(test::black_box(numbers.iter()).last())
    })
}


fn bench_cloned_long(b: &mut Bencher) {
    let numbers: Vec<_> = vec!["asfd"; 1000];
    b.iter(|| {
        test::black_box(test::black_box(numbers.iter()).cloned().last())
    })
}

fn bench_my_cloned_long(b: &mut Bencher) {
    let numbers: Vec<_> = vec!["asfd"; 1000];
    b.iter(|| {
        test::black_box(Cloned { it: test::black_box(numbers.iter()) }.last())
    })
}


fn bench_normal_long(b: &mut Bencher) {
    let numbers: Vec<_> = vec!["asfd"; 1000];
    b.iter(|| {
        test::black_box(test::black_box(numbers.iter()).last())
    })
}
```

Results:

``` rust
test bench_cloned         ... bench:          85 ns/iter (+/- 2)
test bench_cloned_long    ... bench:         774 ns/iter (+/- 20)
test bench_my_cloned      ... bench:           2 ns/iter (+/- 0)
test bench_my_cloned_long ... bench:           2 ns/iter (+/- 0)
test bench_normal         ... bench:           1 ns/iter (+/- 0)
test bench_normal_long    ... bench:           1 ns/iter (+/- 0)
```
