### PR TITLE
Fix ICE on some macros in const integer positions (e.g. `[u8; m!()]`)

### DIFF
--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -172,10 +172,13 @@ impl<'a> Resolver<'a> {
 
         let mut def_collector = DefCollector::new(&mut self.definitions);
         def_collector.visit_macro_invoc = Some(visit_macro_invoc);
-        def_collector.with_parent(def_index, |def_collector| if !const_integer {
+        def_collector.with_parent(def_index, |def_collector| {
+            if const_integer {
+                if let Expansion::Expr(ref expr) = *expansion {
+                    def_collector.visit_ast_const_integer(expr);
+                }
+            }
             expansion.visit_with(def_collector)
-        } else if let Expansion::Expr(ref expr) = *expansion {
-            def_collector.visit_ast_const_integer(expr);
         });
     }
 }

--- a/src/test/run-pass/issue-36816.rs
+++ b/src/test/run-pass/issue-36816.rs
@@ -1,0 +1,16 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! m { () => { 1 } }
+macro_rules! n { () => { 1 + m!() } }
+
+fn main() {
+    let _: [u32; n!()] = [0, 0];
+}


### PR DESCRIPTION
Fixes #36816 (**EDIT**: and fixes #36834).
r? @nrc 
