### PR TITLE
Resolve the callee type in check_call before autoderef

### DIFF
--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -47,8 +47,9 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                       expected: Expectation<'tcx>) -> Ty<'tcx>
     {
         let original_callee_ty = self.check_expr(callee_expr);
+        let expr_ty = self.structurally_resolved_type(call_expr.span, original_callee_ty);
 
-        let mut autoderef = self.autoderef(callee_expr.span, original_callee_ty);
+        let mut autoderef = self.autoderef(callee_expr.span, expr_ty);
         let result = autoderef.by_ref().flat_map(|(adj_ty, idx)| {
             self.try_overloaded_call_step(call_expr, callee_expr, adj_ty, idx)
         }).next();

--- a/src/test/run-pass/issue-36786-resolve-call.rs
+++ b/src/test/run-pass/issue-36786-resolve-call.rs
@@ -1,0 +1,17 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Ensure that types that rely on obligations are autoderefed
+// correctly
+
+fn main() {
+    let x : Vec<Box<Fn()>> = vec![Box::new(|| ())];
+    x[0]()
+}


### PR DESCRIPTION
If the callee type is an associated type, then it needs to be normalized
before trying to deref it. This matches the behaviour of
`check_method_call` for autoderef behaviour in calls.

Fixes #36786
