### PR TITLE
add println!() macro with out any arguments

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -112,12 +112,14 @@ macro_rules! print {
 /// # Examples
 ///
 /// ```
+/// println!();
 /// println!("hello there!");
 /// println!("format {} arguments", "some");
 /// ```
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
 macro_rules! println {
+    () => (print!("\n"));
     ($fmt:expr) => (print!(concat!($fmt, "\n")));
     ($fmt:expr, $($arg:tt)*) => (print!(concat!($fmt, "\n"), $($arg)*));
 }

--- a/src/test/compile-fail/empty-comment.rs
+++ b/src/test/compile-fail/empty-comment.rs
@@ -12,6 +12,10 @@
 // This could break some internal logic that assumes the length of a doc comment is at least 5,
 // leading to an ICE.
 
+macro_rules! one_arg_macro {
+    ($fmt:expr) => (print!(concat!($fmt, "\n")));
+}
+
 fn main() {
-    println!(/**/); //~ ERROR unexpected end
+    one_arg_macro!(/**/); //~ ERROR unexpected end
 }

--- a/src/test/compile-fail/issue-7970a.rs
+++ b/src/test/compile-fail/issue-7970a.rs
@@ -8,7 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+macro_rules! one_arg_macro {
+    ($fmt:expr) => (print!(concat!($fmt, "\n")));
+}
+
 fn main() {
-    println!();
+    one_arg_macro!();
     //~^ ERROR unexpected end of macro invocation
 }


### PR DESCRIPTION
lets add println!() to write "\n".
like java https://docs.oracle.com/javase/7/docs/api/java/io/PrintStream.html#println()
