### PR TITLE
Add testcase for issue-32948

### DIFF
--- a/src/test/run-make/stable-symbol-names/Makefile
+++ b/src/test/run-make/stable-symbol-names/Makefile
@@ -1,12 +1,16 @@
 -include ../tools.mk
 
-# This test case makes sure that monomorphizations of the same function with the
-# same set of generic arguments will have the same symbol names when
-# instantiated in different crates.
+# The following command will:
+#  1. dump the symbols of a library using `nm`
+#  2. extract only those lines that we are interested in via `grep`
+#  3. from those lines, extract just the symbol name via `sed`
+#     (symbol names always start with "_ZN" and end with "E")
+#  4. sort those symbol names for deterministic comparison
+#  5. write the result into a file
 
 dump-symbols = nm "$(TMPDIR)/lib$(1).rlib" \
-             |  grep "some_test_function" \
-             | sed "s/^[0-9a-f]\{8,16\}/00000000/" \
+             | grep -E "some_test_function|Bar|bar" \
+             | sed "s/.*\(_ZN.*E\).*/\1/" \
              | sort \
              > "$(TMPDIR)/$(1).nm"
 

--- a/src/test/run-make/stable-symbol-names/stable-symbol-names1.rs
+++ b/src/test/run-make/stable-symbol-names/stable-symbol-names1.rs
@@ -10,6 +10,20 @@
 
 #![crate_type="rlib"]
 
+pub trait Foo {
+  fn foo<T>();
+}
+
+pub struct Bar;
+
+impl Foo for Bar {
+  fn foo<T>() {}
+}
+
+pub fn bar() {
+  Bar::foo::<Bar>();
+}
+
 pub fn some_test_function<T>(t: T) -> T {
   t
 }

--- a/src/test/run-make/stable-symbol-names/stable-symbol-names2.rs
+++ b/src/test/run-make/stable-symbol-names/stable-symbol-names2.rs
@@ -18,3 +18,9 @@ pub fn user() {
   let x = 2u64;
   stable_symbol_names1::some_test_function(&x);
 }
+
+pub fn trait_impl_test_function() {
+  use stable_symbol_names1::*;
+  Bar::foo::<Bar>();
+  bar();
+}


### PR DESCRIPTION
#32948

issue-32948 is similar to issue-32554.

issue-32948 : Symbol names for monomorphized trait impls are not stable across crates
issue-32554 : Symbol names for generics are not stable across crates

so, I append issue-32948's testcase to issue-32554's testcase.
thanks!
