### PR TITLE
Fixed wrong link in release notes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -148,7 +148,7 @@ Libraries
   (https://github.com/rust-lang/rust/pull/34946)
 * [`hash_map::Entry`, `hash_map::VacantEntry` and `hash_map::OccupiedEntry`
   implement `Debug`]
-  (https://github.com/rust-lang/rust/pull/34946)
+  (https://github.com/rust-lang/rust/pull/34937)
 * [`btree_map::Entry`, `btree_map::VacantEntry` and `btree_map::OccupiedEntry`
   implement `Debug`]
   (https://github.com/rust-lang/rust/pull/34885)
@@ -885,7 +885,7 @@ Cargo
 Performance
 -----------
 
-* [The time complexity of comparing variables for equivalence during type 
+* [The time complexity of comparing variables for equivalence during type
   unification is reduced from _O_(_n_!) to _O_(_n_)][1.9tu]. This leads
   to major compilation time improvement in some scenarios.
 * [`ToString` is specialized for `str`, giving it the same performance


### PR DESCRIPTION
The link for the pull request updating hash_map to implement Debug was a copy of the previous link, this changes the link to the correct PR.
