### PR TITLE
str: Fix documentation typo

### DIFF
--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -132,7 +132,7 @@ impl Utf8Error {
     /// verified.
     ///
     /// It is the maximum index such that `from_utf8(input[..index])`
-    /// would return `Some(_)`.
+    /// would return `Ok(_)`.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
from_utf8 returns a Result, not an Option.

Signed-off-by: David Henningsson diwic@ubuntu.com
