### PR TITLE
add Thumbs to the compiler

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -926,7 +926,7 @@ pub fn default_configuration(sess: &Session) -> ast::CrateConfig {
     let os = &sess.target.target.target_os;
     let env = &sess.target.target.target_env;
     let vendor = &sess.target.target.target_vendor;
-    let max_atomic_width = sess.target.target.options.max_atomic_width;
+    let max_atomic_width = sess.target.target.max_atomic_width();
 
     let fam = if let Some(ref fam) = sess.target.target.options.target_family {
         intern(fam)

--- a/src/librustc_back/target/aarch64_apple_ios.rs
+++ b/src/librustc_back/target/aarch64_apple_ios.rs
@@ -25,7 +25,7 @@ pub fn target() -> TargetResult {
         options: TargetOptions {
             features: "+neon,+fp-armv8,+cyclone".to_string(),
             eliminate_frame_pointer: false,
-            max_atomic_width: 128,
+            max_atomic_width: Some(128),
             .. base
         },
     })

--- a/src/librustc_back/target/aarch64_linux_android.rs
+++ b/src/librustc_back/target/aarch64_linux_android.rs
@@ -12,7 +12,7 @@ use target::{Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::android_base::opts();
-    base.max_atomic_width = 128;
+    base.max_atomic_width = Some(128);
     // As documented in http://developer.android.com/ndk/guides/cpu-features.html
     // the neon (ASIMD) and FP must exist on all android aarch64 targets.
     base.features = "+neon,+fp-armv8".to_string();

--- a/src/librustc_back/target/aarch64_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/aarch64_unknown_linux_gnu.rs
@@ -12,7 +12,7 @@ use target::{Target, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();
-    base.max_atomic_width = 128;
+    base.max_atomic_width = Some(128);
     Ok(Target {
         llvm_target: "aarch64-unknown-linux-gnu".to_string(),
         target_endian: "little".to_string(),

--- a/src/librustc_back/target/arm_linux_androideabi.rs
+++ b/src/librustc_back/target/arm_linux_androideabi.rs
@@ -13,7 +13,7 @@ use target::{Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::android_base::opts();
     base.features = "+v7,+vfp3,+d16".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
 
     Ok(Target {
         llvm_target: "arm-linux-androideabi".to_string(),

--- a/src/librustc_back/target/arm_unknown_linux_gnueabi.rs
+++ b/src/librustc_back/target/arm_unknown_linux_gnueabi.rs
@@ -12,7 +12,7 @@ use target::{Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
     Ok(Target {
         llvm_target: "arm-unknown-linux-gnueabi".to_string(),
         target_endian: "little".to_string(),

--- a/src/librustc_back/target/arm_unknown_linux_gnueabihf.rs
+++ b/src/librustc_back/target/arm_unknown_linux_gnueabihf.rs
@@ -12,7 +12,7 @@ use target::{Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
     Ok(Target {
         llvm_target: "arm-unknown-linux-gnueabihf".to_string(),
         target_endian: "little".to_string(),

--- a/src/librustc_back/target/arm_unknown_linux_musleabi.rs
+++ b/src/librustc_back/target/arm_unknown_linux_musleabi.rs
@@ -16,7 +16,7 @@ pub fn target() -> TargetResult {
     // Most of these settings are copied from the arm_unknown_linux_gnueabi
     // target.
     base.features = "+v6".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
     Ok(Target {
         // It's important we use "gnueabi" and not "musleabi" here. LLVM uses it
         // to determine the calling convention and float ABI, and it doesn't

--- a/src/librustc_back/target/arm_unknown_linux_musleabihf.rs
+++ b/src/librustc_back/target/arm_unknown_linux_musleabihf.rs
@@ -16,7 +16,7 @@ pub fn target() -> TargetResult {
     // Most of these settings are copied from the arm_unknown_linux_gnueabihf
     // target.
     base.features = "+v6,+vfp2".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
     Ok(Target {
         // It's important we use "gnueabihf" and not "musleabihf" here. LLVM
         // uses it to determine the calling convention and float ABI, and it

--- a/src/librustc_back/target/armv7_apple_ios.rs
+++ b/src/librustc_back/target/armv7_apple_ios.rs
@@ -24,7 +24,7 @@ pub fn target() -> TargetResult {
         target_vendor: "apple".to_string(),
         options: TargetOptions {
             features: "+v7,+vfp3,+neon".to_string(),
-            max_atomic_width: 64,
+            max_atomic_width: Some(64),
             .. base
         }
     })

--- a/src/librustc_back/target/armv7_linux_androideabi.rs
+++ b/src/librustc_back/target/armv7_linux_androideabi.rs
@@ -13,7 +13,7 @@ use target::{Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::android_base::opts();
     base.features = "+v7,+thumb2,+vfp3,+d16".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
 
     Ok(Target {
         llvm_target: "armv7-none-linux-android".to_string(),

--- a/src/librustc_back/target/armv7_unknown_linux_gnueabihf.rs
+++ b/src/librustc_back/target/armv7_unknown_linux_gnueabihf.rs
@@ -26,7 +26,7 @@ pub fn target() -> TargetResult {
             // Info about features at https://wiki.debian.org/ArmHardFloatPort
             features: "+v7,+vfp3,+d16,+thumb2".to_string(),
             cpu: "generic".to_string(),
-            max_atomic_width: 64,
+            max_atomic_width: Some(64),
             .. base
         }
     })

--- a/src/librustc_back/target/armv7_unknown_linux_musleabihf.rs
+++ b/src/librustc_back/target/armv7_unknown_linux_musleabihf.rs
@@ -17,7 +17,7 @@ pub fn target() -> TargetResult {
     // target.
     base.features = "+v7,+vfp3,+neon".to_string();
     base.cpu = "cortex-a8".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
     Ok(Target {
         // It's important we use "gnueabihf" and not "musleabihf" here. LLVM
         // uses it to determine the calling convention and float ABI, and LLVM

--- a/src/librustc_back/target/armv7s_apple_ios.rs
+++ b/src/librustc_back/target/armv7s_apple_ios.rs
@@ -24,7 +24,7 @@ pub fn target() -> TargetResult {
         target_vendor: "apple".to_string(),
         options: TargetOptions {
             features: "+v7,+vfp4,+neon".to_string(),
-            max_atomic_width: 64,
+            max_atomic_width: Some(64),
             .. base
         }
     })

--- a/src/librustc_back/target/asmjs_unknown_emscripten.rs
+++ b/src/librustc_back/target/asmjs_unknown_emscripten.rs
@@ -21,7 +21,7 @@ pub fn target() -> Result<Target, String> {
         linker_is_gnu: true,
         allow_asm: false,
         obj_is_bitcode: true,
-        max_atomic_width: 32,
+        max_atomic_width: Some(32),
         post_link_args: vec!["-s".to_string(), "ERROR_ON_UNDEFINED_SYMBOLS=1".to_string()],
         .. Default::default()
     };

--- a/src/librustc_back/target/i386_apple_ios.rs
+++ b/src/librustc_back/target/i386_apple_ios.rs
@@ -23,7 +23,7 @@ pub fn target() -> TargetResult {
         target_env: "".to_string(),
         target_vendor: "apple".to_string(),
         options: TargetOptions {
-            max_atomic_width: 64,
+            max_atomic_width: Some(64),
             .. base
         }
     })

--- a/src/librustc_back/target/i686_apple_darwin.rs
+++ b/src/librustc_back/target/i686_apple_darwin.rs
@@ -13,7 +13,7 @@ use target::{Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::apple_base::opts();
     base.cpu = "yonah".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
     base.pre_link_args.push("-m32".to_string());
 
     Ok(Target {

--- a/src/librustc_back/target/i686_linux_android.rs
+++ b/src/librustc_back/target/i686_linux_android.rs
@@ -13,7 +13,7 @@ use target::{Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::android_base::opts();
 
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
 
     // http://developer.android.com/ndk/guides/abis.html#x86
     base.cpu = "pentiumpro".to_string();

--- a/src/librustc_back/target/i686_pc_windows_gnu.rs
+++ b/src/librustc_back/target/i686_pc_windows_gnu.rs
@@ -13,7 +13,7 @@ use target::{Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::windows_base::opts();
     base.cpu = "pentium4".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
 
     // Mark all dynamic libraries and executables as compatible with the larger 4GiB address
     // space available to x86 Windows binaries on x86_64.

--- a/src/librustc_back/target/i686_pc_windows_msvc.rs
+++ b/src/librustc_back/target/i686_pc_windows_msvc.rs
@@ -13,7 +13,7 @@ use target::{Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::windows_msvc_base::opts();
     base.cpu = "pentium4".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
 
     // Mark all dynamic libraries and executables as compatible with the larger 4GiB address
     // space available to x86 Windows binaries on x86_64.

--- a/src/librustc_back/target/i686_unknown_dragonfly.rs
+++ b/src/librustc_back/target/i686_unknown_dragonfly.rs
@@ -13,7 +13,7 @@ use target::{Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::dragonfly_base::opts();
     base.cpu = "pentium4".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
     base.pre_link_args.push("-m32".to_string());
 
     Ok(Target {

--- a/src/librustc_back/target/i686_unknown_freebsd.rs
+++ b/src/librustc_back/target/i686_unknown_freebsd.rs
@@ -13,7 +13,7 @@ use target::{Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::freebsd_base::opts();
     base.cpu = "pentium4".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
     base.pre_link_args.push("-m32".to_string());
 
     Ok(Target {

--- a/src/librustc_back/target/i686_unknown_haiku.rs
+++ b/src/librustc_back/target/i686_unknown_haiku.rs
@@ -13,7 +13,7 @@ use target::{Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::haiku_base::opts();
     base.cpu = "pentium4".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
     base.pre_link_args.push("-m32".to_string());
 
     Ok(Target {

--- a/src/librustc_back/target/i686_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/i686_unknown_linux_gnu.rs
@@ -13,7 +13,7 @@ use target::{Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();
     base.cpu = "pentium4".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
     base.pre_link_args.push("-m32".to_string());
 
     Ok(Target {

--- a/src/librustc_back/target/i686_unknown_linux_musl.rs
+++ b/src/librustc_back/target/i686_unknown_linux_musl.rs
@@ -13,7 +13,7 @@ use target::{Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::linux_musl_base::opts();
     base.cpu = "pentium4".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
     base.pre_link_args.push("-m32".to_string());
     base.pre_link_args.push("-Wl,-melf_i386".to_string());
 

--- a/src/librustc_back/target/le32_unknown_nacl.rs
+++ b/src/librustc_back/target/le32_unknown_nacl.rs
@@ -24,7 +24,7 @@ pub fn target() -> TargetResult {
         exe_suffix: ".pexe".to_string(),
         linker_is_gnu: true,
         allow_asm: false,
-        max_atomic_width: 32,
+        max_atomic_width: Some(32),
         .. Default::default()
     };
     Ok(Target {

--- a/src/librustc_back/target/mips64_unknown_linux_gnuabi64.rs
+++ b/src/librustc_back/target/mips64_unknown_linux_gnuabi64.rs
@@ -24,7 +24,7 @@ pub fn target() -> TargetResult {
             // NOTE(mips64r2) matches C toolchain
             cpu: "mips64r2".to_string(),
             features: "+mips64r2".to_string(),
-            max_atomic_width: 64,
+            max_atomic_width: Some(64),
             ..super::linux_base::opts()
         },
     })

--- a/src/librustc_back/target/mips64el_unknown_linux_gnuabi64.rs
+++ b/src/librustc_back/target/mips64el_unknown_linux_gnuabi64.rs
@@ -24,7 +24,7 @@ pub fn target() -> TargetResult {
             // NOTE(mips64r2) matches C toolchain
             cpu: "mips64r2".to_string(),
             features: "+mips64r2".to_string(),
-            max_atomic_width: 64,
+            max_atomic_width: Some(64),
             ..super::linux_base::opts()
         },
     })

--- a/src/librustc_back/target/mips_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/mips_unknown_linux_gnu.rs
@@ -23,7 +23,7 @@ pub fn target() -> TargetResult {
         options: TargetOptions {
             cpu: "mips32r2".to_string(),
             features: "+mips32r2".to_string(),
-            max_atomic_width: 32,
+            max_atomic_width: Some(32),
             ..super::linux_base::opts()
         },
     })

--- a/src/librustc_back/target/mips_unknown_linux_musl.rs
+++ b/src/librustc_back/target/mips_unknown_linux_musl.rs
@@ -23,7 +23,7 @@ pub fn target() -> TargetResult {
         options: TargetOptions {
             cpu: "mips32r2".to_string(),
             features: "+mips32r2,+soft-float".to_string(),
-            max_atomic_width: 32,
+            max_atomic_width: Some(32),
             ..super::linux_base::opts()
         }
     })

--- a/src/librustc_back/target/mips_unknown_linux_uclibc.rs
+++ b/src/librustc_back/target/mips_unknown_linux_uclibc.rs
@@ -23,7 +23,7 @@ pub fn target() -> TargetResult {
         options: TargetOptions {
             cpu: "mips32r2".to_string(),
             features: "+mips32r2,+soft-float".to_string(),
-            max_atomic_width: 32,
+            max_atomic_width: Some(32),
             ..super::linux_base::opts()
         },
     })

--- a/src/librustc_back/target/mipsel_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/mipsel_unknown_linux_gnu.rs
@@ -24,7 +24,7 @@ pub fn target() -> TargetResult {
         options: TargetOptions {
             cpu: "mips32".to_string(),
             features: "+mips32".to_string(),
-            max_atomic_width: 32,
+            max_atomic_width: Some(32),
             ..super::linux_base::opts()
         },
     })

--- a/src/librustc_back/target/mipsel_unknown_linux_musl.rs
+++ b/src/librustc_back/target/mipsel_unknown_linux_musl.rs
@@ -23,7 +23,7 @@ pub fn target() -> TargetResult {
         options: TargetOptions {
             cpu: "mips32".to_string(),
             features: "+mips32,+soft-float".to_string(),
-            max_atomic_width: 32,
+            max_atomic_width: Some(32),
             ..super::linux_base::opts()
         }
     })

--- a/src/librustc_back/target/mipsel_unknown_linux_uclibc.rs
+++ b/src/librustc_back/target/mipsel_unknown_linux_uclibc.rs
@@ -24,7 +24,7 @@ pub fn target() -> TargetResult {
         options: TargetOptions {
             cpu: "mips32".to_string(),
             features: "+mips32,+soft-float".to_string(),
-            max_atomic_width: 32,
+            max_atomic_width: Some(32),
             ..super::linux_base::opts()
         },
     })

--- a/src/librustc_back/target/powerpc64_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/powerpc64_unknown_linux_gnu.rs
@@ -14,7 +14,7 @@ pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();
     base.cpu = "ppc64".to_string();
     base.pre_link_args.push("-m64".to_string());
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
 
     Ok(Target {
         llvm_target: "powerpc64-unknown-linux-gnu".to_string(),

--- a/src/librustc_back/target/powerpc64le_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/powerpc64le_unknown_linux_gnu.rs
@@ -14,7 +14,7 @@ pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();
     base.cpu = "ppc64le".to_string();
     base.pre_link_args.push("-m64".to_string());
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
 
     Ok(Target {
         llvm_target: "powerpc64le-unknown-linux-gnu".to_string(),

--- a/src/librustc_back/target/powerpc_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/powerpc_unknown_linux_gnu.rs
@@ -13,7 +13,7 @@ use target::{Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();
     base.pre_link_args.push("-m32".to_string());
-    base.max_atomic_width = 32;
+    base.max_atomic_width = Some(32);
 
     Ok(Target {
         llvm_target: "powerpc-unknown-linux-gnu".to_string(),

--- a/src/librustc_back/target/s390x_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/s390x_unknown_linux_gnu.rs
@@ -18,7 +18,7 @@ pub fn target() -> TargetResult {
     // cabi_s390x.rs are for now hard-coded to assume the no-vector ABI.
     // Pass the -vector feature string to LLVM to respect this assumption.
     base.features = "-vector".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
 
     Ok(Target {
         llvm_target: "s390x-unknown-linux-gnu".to_string(),

--- a/src/librustc_back/target/thumb_base.rs
+++ b/src/librustc_back/target/thumb_base.rs
@@ -8,14 +8,48 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// These 4 `thumbv*` targets cover the ARM Cortex-M family of processors which are widely used in
+// microcontrollers. Namely, all these processors:
+//
+// - Cortex-M0
+// - Cortex-M0+
+// - Cortex-M1
+// - Cortex-M3
+// - Cortex-M4(F)
+// - Cortex-M7(F)
+//
+// We have opted for 4 targets instead of one target per processor (e.g. `cortex-m0`, `cortex-m3`,
+// etc) because the differences between some processors like the cortex-m0 and cortex-m1 are almost
+// non-existent from the POV of codegen so it doesn't make sense to have separate targets for them.
+// And if differences exist between two processors under the same target, rustc flags can be used to
+// optimize for one processor or the other.
+//
+// Also, we have not chosen a single target (`arm-none-eabi`) like GCC does because this makes
+// difficult to integrate Rust code and C code. Targeting the Cortex-M4 requires different gcc flags
+// than the ones you would use for the Cortex-M0 and with a single target it'd be impossible to
+// differentiate one processor from the other.
+//
+// About arm vs thumb in the name. The Cortex-M devices only support the Thumb instruction set,
+// which is more compact (higher code density), and not the ARM instruction set. That's why LLVM
+// triples use thumb instead of arm. We follow suit because having thumb in the name let us
+// differentiate these targets from our other `arm(v7)-*-*-gnueabi(hf)` targets in the context of
+// build scripts / gcc flags.
+
 use target::TargetOptions;
 use std::default::Default;
 
 pub fn opts() -> TargetOptions {
+    // See rust-lang/rfcs#1645 for a discussion about these defaults
     TargetOptions {
         executables: true,
+        // In 99%+ of cases, we want to use the `arm-none-eabi-gcc` compiler (there aren't many
+        // options around)
         linker: "arm-none-eabi-gcc".to_string(),
+        // Because these devices have very little resources having an unwinder is too onerous so we
+        // default to "abort" because the "unwind" strategy is very rare.
         panic_strategy: "abort".to_string(),
+        // Similarly, one almost always never wants to use relocatable code because of the extra
+        // costs it involves.
         relocation_model: "static".to_string(),
         .. Default::default()
     }

--- a/src/librustc_back/target/thumb_base.rs
+++ b/src/librustc_back/target/thumb_base.rs
@@ -1,0 +1,20 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use target::TargetOptions;
+use std::default::Default;
+
+pub fn opts() -> TargetOptions {
+    TargetOptions {
+        executables: true,
+        linker: "arm-none-eabi-gcc".to_string(),
+        .. Default::default()
+    }
+}

--- a/src/librustc_back/target/thumb_base.rs
+++ b/src/librustc_back/target/thumb_base.rs
@@ -15,6 +15,7 @@ pub fn opts() -> TargetOptions {
     TargetOptions {
         executables: true,
         linker: "arm-none-eabi-gcc".to_string(),
+        relocation_model: "static".to_string(),
         .. Default::default()
     }
 }

--- a/src/librustc_back/target/thumb_base.rs
+++ b/src/librustc_back/target/thumb_base.rs
@@ -35,8 +35,9 @@
 // differentiate these targets from our other `arm(v7)-*-*-gnueabi(hf)` targets in the context of
 // build scripts / gcc flags.
 
-use target::TargetOptions;
+use PanicStrategy;
 use std::default::Default;
+use target::TargetOptions;
 
 pub fn opts() -> TargetOptions {
     // See rust-lang/rfcs#1645 for a discussion about these defaults
@@ -47,7 +48,7 @@ pub fn opts() -> TargetOptions {
         linker: "arm-none-eabi-gcc".to_string(),
         // Because these devices have very little resources having an unwinder is too onerous so we
         // default to "abort" because the "unwind" strategy is very rare.
-        panic_strategy: "abort".to_string(),
+        panic_strategy: PanicStrategy::Abort,
         // Similarly, one almost always never wants to use relocatable code because of the extra
         // costs it involves.
         relocation_model: "static".to_string(),

--- a/src/librustc_back/target/thumb_base.rs
+++ b/src/librustc_back/target/thumb_base.rs
@@ -15,6 +15,7 @@ pub fn opts() -> TargetOptions {
     TargetOptions {
         executables: true,
         linker: "arm-none-eabi-gcc".to_string(),
+        panic_strategy: "abort".to_string(),
         relocation_model: "static".to_string(),
         .. Default::default()
     }

--- a/src/librustc_back/target/thumbv6m_none_eabi.rs
+++ b/src/librustc_back/target/thumbv6m_none_eabi.rs
@@ -1,0 +1,34 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use target::{Target, TargetOptions, TargetResult};
+
+pub fn target() -> TargetResult {
+    Ok(Target {
+        llvm_target: "thumbv6m-none-eabi".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "32".to_string(),
+        data_layout: "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
+        arch: "arm".to_string(),
+        target_os: "none".to_string(),
+        target_env: "".to_string(),
+        target_vendor: "".to_string(),
+
+        options: TargetOptions {
+            // The ARMv6-M architecture doesn't support unaligned loads/stores so we disable them
+            // with +strict-align.
+            features: "+strict-align".to_string(),
+            // There are no atomic instructions available in the instruction set of the ARMv6-M
+            // architecture
+            max_atomic_width: 0,
+            .. super::thumb_base::opts()
+        }
+    })
+}

--- a/src/librustc_back/target/thumbv6m_none_eabi.rs
+++ b/src/librustc_back/target/thumbv6m_none_eabi.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Targets the Cortex-M0, Cortex-M0+ and Cortex-M1 processors (ARMv6-M architecture)
+
 use target::{Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {

--- a/src/librustc_back/target/thumbv6m_none_eabi.rs
+++ b/src/librustc_back/target/thumbv6m_none_eabi.rs
@@ -29,7 +29,7 @@ pub fn target() -> TargetResult {
             features: "+strict-align".to_string(),
             // There are no atomic instructions available in the instruction set of the ARMv6-M
             // architecture
-            max_atomic_width: 0,
+            max_atomic_width: Some(0),
             .. super::thumb_base::opts()
         }
     })

--- a/src/librustc_back/target/thumbv7em_none_eabi.rs
+++ b/src/librustc_back/target/thumbv7em_none_eabi.rs
@@ -1,0 +1,29 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use target::{Target, TargetOptions, TargetResult};
+
+pub fn target() -> TargetResult {
+    Ok(Target {
+        llvm_target: "thumbv7em-none-eabi".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "32".to_string(),
+        data_layout: "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
+        arch: "arm".to_string(),
+        target_os: "none".to_string(),
+        target_env: "".to_string(),
+        target_vendor: "".to_string(),
+
+        options: TargetOptions {
+            max_atomic_width: 32,
+            .. super::thumb_base::opts()
+        },
+    })
+}

--- a/src/librustc_back/target/thumbv7em_none_eabi.rs
+++ b/src/librustc_back/target/thumbv7em_none_eabi.rs
@@ -8,6 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Targets the Cortex-M4 and Cortex-M7 processors (ARMv7E-M)
+//
+// This target assumes that the device doesn't have a FPU (Floating Point Unit) and lowers all the
+// floating point operations to software routines (intrinsics).
+//
+// As such, this target uses the "soft" calling convention (ABI) where floating point values are
+// passed to/from subroutines via general purpose registers (R0, R1, etc.).
+//
+// To opt-in to hardware accelerated floating point operations, you can use, for example,
+// `-C target-feature=+vfp4` or `-C target-cpu=cortex-m4`.
+
 use target::{Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {

--- a/src/librustc_back/target/thumbv7em_none_eabi.rs
+++ b/src/librustc_back/target/thumbv7em_none_eabi.rs
@@ -33,7 +33,7 @@ pub fn target() -> TargetResult {
         target_vendor: "".to_string(),
 
         options: TargetOptions {
-            max_atomic_width: 32,
+            max_atomic_width: Some(32),
             .. super::thumb_base::opts()
         },
     })

--- a/src/librustc_back/target/thumbv7em_none_eabihf.rs
+++ b/src/librustc_back/target/thumbv7em_none_eabihf.rs
@@ -42,7 +42,7 @@ pub fn target() -> TargetResult {
             // Reference:
             // ARMv7-M Architecture Reference Manual - A2.5 The optional floating-point extension
             features: "+vfp4,+d16,+fp-only-sp".to_string(),
-            max_atomic_width: 32,
+            max_atomic_width: Some(32),
             .. super::thumb_base::opts()
         }
     })

--- a/src/librustc_back/target/thumbv7em_none_eabihf.rs
+++ b/src/librustc_back/target/thumbv7em_none_eabihf.rs
@@ -8,6 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Targets the Cortex-M4F and Cortex-M7F processors (ARMv7E-M)
+//
+// This target assumes that the device does have a FPU (Floating Point Unit) and lowers all (single
+// precision) floating point operations to hardware instructions.
+//
+// Additionally, this target uses the "hard" floating convention (ABI) where floating point values
+// are passed to/from subroutines via FPU registers (S0, S1, D0, D1, etc.).
+//
+// To opt into double precision hardware support, use the `-C target-feature=-fp-only-sp` flag.
+
 use target::{Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
@@ -22,8 +32,13 @@ pub fn target() -> TargetResult {
         target_vendor: "".to_string(),
 
         options: TargetOptions {
-            // vfp4 lowest common denominator between the Cortex-M4 (vfp4) and the Cortex-M7 (vfp5)
-            features: "+vfp4".to_string(),
+            // `+vfp4` is the lowest common denominator between the Cortex-M4 (vfp4-16) and the
+            // Cortex-M7 (vfp5)
+            // `+d16` both the Cortex-M4 and the Cortex-M7 only have 16 double-precision registers
+            // available
+            // `+fp-only-sp` The Cortex-M4 only supports single precision floating point operations
+            // whereas in the Cortex-M7 double precision is optional
+            features: "+vfp4,+d16,+fp-only-sp".to_string(),
             max_atomic_width: 32,
             .. super::thumb_base::opts()
         }

--- a/src/librustc_back/target/thumbv7em_none_eabihf.rs
+++ b/src/librustc_back/target/thumbv7em_none_eabihf.rs
@@ -38,6 +38,9 @@ pub fn target() -> TargetResult {
             // available
             // `+fp-only-sp` The Cortex-M4 only supports single precision floating point operations
             // whereas in the Cortex-M7 double precision is optional
+            //
+            // Reference:
+            // ARMv7-M Architecture Reference Manual - A2.5 The optional floating-point extension
             features: "+vfp4,+d16,+fp-only-sp".to_string(),
             max_atomic_width: 32,
             .. super::thumb_base::opts()

--- a/src/librustc_back/target/thumbv7em_none_eabihf.rs
+++ b/src/librustc_back/target/thumbv7em_none_eabihf.rs
@@ -1,0 +1,31 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use target::{Target, TargetOptions, TargetResult};
+
+pub fn target() -> TargetResult {
+    Ok(Target {
+        llvm_target: "thumbv7em-none-eabihf".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "32".to_string(),
+        data_layout: "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
+        arch: "arm".to_string(),
+        target_os: "none".to_string(),
+        target_env: "".to_string(),
+        target_vendor: "".to_string(),
+
+        options: TargetOptions {
+            // vfp4 lowest common denominator between the Cortex-M4 (vfp4) and the Cortex-M7 (vfp5)
+            features: "+vfp4".to_string(),
+            max_atomic_width: 32,
+            .. super::thumb_base::opts()
+        }
+    })
+}

--- a/src/librustc_back/target/thumbv7m_none_eabi.rs
+++ b/src/librustc_back/target/thumbv7m_none_eabi.rs
@@ -24,7 +24,7 @@ pub fn target() -> TargetResult {
         target_vendor: "".to_string(),
 
         options: TargetOptions {
-            max_atomic_width: 32,
+            max_atomic_width: Some(32),
             .. super::thumb_base::opts()
         },
     })

--- a/src/librustc_back/target/thumbv7m_none_eabi.rs
+++ b/src/librustc_back/target/thumbv7m_none_eabi.rs
@@ -1,0 +1,29 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use target::{Target, TargetOptions, TargetResult};
+
+pub fn target() -> TargetResult {
+    Ok(Target {
+        llvm_target: "thumbv7m-none-eabi".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "32".to_string(),
+        data_layout: "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
+        arch: "arm".to_string(),
+        target_os: "none".to_string(),
+        target_env: "".to_string(),
+        target_vendor: "".to_string(),
+
+        options: TargetOptions {
+            max_atomic_width: 32,
+            .. super::thumb_base::opts()
+        },
+    })
+}

--- a/src/librustc_back/target/thumbv7m_none_eabi.rs
+++ b/src/librustc_back/target/thumbv7m_none_eabi.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Targets the Cortex-M3 processor (ARMv7-M)
+
 use target::{Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {

--- a/src/librustc_back/target/wasm32_unknown_emscripten.rs
+++ b/src/librustc_back/target/wasm32_unknown_emscripten.rs
@@ -23,7 +23,7 @@ pub fn target() -> Result<Target, String> {
         linker_is_gnu: true,
         allow_asm: false,
         obj_is_bitcode: true,
-        max_atomic_width: 32,
+        max_atomic_width: Some(32),
         post_link_args: vec!["-s".to_string(), "BINARYEN=1".to_string(),
                              "-s".to_string(), "ERROR_ON_UNDEFINED_SYMBOLS=1".to_string()],
         .. Default::default()

--- a/src/librustc_back/target/x86_64_apple_darwin.rs
+++ b/src/librustc_back/target/x86_64_apple_darwin.rs
@@ -13,7 +13,7 @@ use target::{Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::apple_base::opts();
     base.cpu = "core2".to_string();
-    base.max_atomic_width = 128; // core2 support cmpxchg16b
+    base.max_atomic_width = Some(128); // core2 support cmpxchg16b
     base.eliminate_frame_pointer = false;
     base.pre_link_args.push("-m64".to_string());
 

--- a/src/librustc_back/target/x86_64_apple_ios.rs
+++ b/src/librustc_back/target/x86_64_apple_ios.rs
@@ -23,7 +23,7 @@ pub fn target() -> TargetResult {
         target_env: "".to_string(),
         target_vendor: "apple".to_string(),
         options: TargetOptions {
-            max_atomic_width: 64,
+            max_atomic_width: Some(64),
             .. base
         }
     })

--- a/src/librustc_back/target/x86_64_pc_windows_gnu.rs
+++ b/src/librustc_back/target/x86_64_pc_windows_gnu.rs
@@ -14,7 +14,7 @@ pub fn target() -> TargetResult {
     let mut base = super::windows_base::opts();
     base.cpu = "x86-64".to_string();
     base.pre_link_args.push("-m64".to_string());
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
 
     Ok(Target {
         llvm_target: "x86_64-pc-windows-gnu".to_string(),

--- a/src/librustc_back/target/x86_64_pc_windows_msvc.rs
+++ b/src/librustc_back/target/x86_64_pc_windows_msvc.rs
@@ -13,7 +13,7 @@ use target::{Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::windows_msvc_base::opts();
     base.cpu = "x86-64".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
 
     Ok(Target {
         llvm_target: "x86_64-pc-windows-msvc".to_string(),

--- a/src/librustc_back/target/x86_64_rumprun_netbsd.rs
+++ b/src/librustc_back/target/x86_64_rumprun_netbsd.rs
@@ -16,7 +16,7 @@ pub fn target() -> TargetResult {
     base.pre_link_args.push("-m64".to_string());
     base.linker = "x86_64-rumprun-netbsd-gcc".to_string();
     base.ar = "x86_64-rumprun-netbsd-ar".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
 
     base.dynamic_linking = false;
     base.has_rpath = false;

--- a/src/librustc_back/target/x86_64_sun_solaris.rs
+++ b/src/librustc_back/target/x86_64_sun_solaris.rs
@@ -14,7 +14,7 @@ pub fn target() -> TargetResult {
     let mut base = super::solaris_base::opts();
     base.pre_link_args.push("-m64".to_string());
     base.cpu = "x86-64".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
 
     Ok(Target {
         llvm_target: "x86_64-pc-solaris".to_string(),

--- a/src/librustc_back/target/x86_64_unknown_bitrig.rs
+++ b/src/librustc_back/target/x86_64_unknown_bitrig.rs
@@ -13,7 +13,7 @@ use target::{Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::bitrig_base::opts();
     base.cpu = "x86-64".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
     base.pre_link_args.push("-m64".to_string());
 
     Ok(Target {

--- a/src/librustc_back/target/x86_64_unknown_dragonfly.rs
+++ b/src/librustc_back/target/x86_64_unknown_dragonfly.rs
@@ -13,7 +13,7 @@ use target::{Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::dragonfly_base::opts();
     base.cpu = "x86-64".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
     base.pre_link_args.push("-m64".to_string());
 
     Ok(Target {

--- a/src/librustc_back/target/x86_64_unknown_freebsd.rs
+++ b/src/librustc_back/target/x86_64_unknown_freebsd.rs
@@ -13,7 +13,7 @@ use target::{Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::freebsd_base::opts();
     base.cpu = "x86-64".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
     base.pre_link_args.push("-m64".to_string());
 
     Ok(Target {

--- a/src/librustc_back/target/x86_64_unknown_haiku.rs
+++ b/src/librustc_back/target/x86_64_unknown_haiku.rs
@@ -13,7 +13,7 @@ use target::{Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::haiku_base::opts();
     base.cpu = "x86-64".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
     base.pre_link_args.push("-m64".to_string());
 
     Ok(Target {

--- a/src/librustc_back/target/x86_64_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/x86_64_unknown_linux_gnu.rs
@@ -13,7 +13,7 @@ use target::{Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();
     base.cpu = "x86-64".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
     base.pre_link_args.push("-m64".to_string());
 
     Ok(Target {

--- a/src/librustc_back/target/x86_64_unknown_linux_musl.rs
+++ b/src/librustc_back/target/x86_64_unknown_linux_musl.rs
@@ -13,7 +13,7 @@ use target::{Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::linux_musl_base::opts();
     base.cpu = "x86-64".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
     base.pre_link_args.push("-m64".to_string());
 
     Ok(Target {

--- a/src/librustc_back/target/x86_64_unknown_netbsd.rs
+++ b/src/librustc_back/target/x86_64_unknown_netbsd.rs
@@ -13,7 +13,7 @@ use target::{Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::netbsd_base::opts();
     base.cpu = "x86-64".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
     base.pre_link_args.push("-m64".to_string());
 
     Ok(Target {

--- a/src/librustc_back/target/x86_64_unknown_openbsd.rs
+++ b/src/librustc_back/target/x86_64_unknown_openbsd.rs
@@ -13,7 +13,7 @@ use target::{Target, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::openbsd_base::opts();
     base.cpu = "x86-64".to_string();
-    base.max_atomic_width = 64;
+    base.max_atomic_width = Some(64);
     base.pre_link_args.push("-m64".to_string());
 
     Ok(Target {

--- a/src/test/run-make/target-without-atomics/Makefile
+++ b/src/test/run-make/target-without-atomics/Makefile
@@ -2,4 +2,4 @@
 
 # The target used below doesn't support atomic operations. Verify that's the case
 all:
-	rustc --print cfg --target thumbv6m-none-eabi | grep -qv target_has_atomic
+	$(RUSTC) --print cfg --target thumbv6m-none-eabi | grep -qv target_has_atomic

--- a/src/test/run-make/target-without-atomics/Makefile
+++ b/src/test/run-make/target-without-atomics/Makefile
@@ -1,0 +1,5 @@
+-include ../tools.mk
+
+# The target used below doesn't support atomic operations. Verify that's the case
+all:
+	rustc --print cfg --target thumbv6m-none-eabi | grep -qv target_has_atomic


### PR DESCRIPTION
this commit adds 4 new target definitions to the compiler for easier
cross compilation to ARM Cortex-M devices.
- `thumbv6m-none-eabi`
  - For the Cortex-M0, Cortex-M0+ and Cortex-M1
  - This architecture doesn't have hardware support (instructions) for
    atomics. Hence, the `Atomic*` structs are not available for this
    target.
- `thumbv7m-none-eabi`
  - For the Cortex-M3
- `thumbv7em-none-eabi`
  - For the FPU-less variants of the Cortex-M4 and Cortex-M7
  - On this target, all the floating point operations will be lowered
    software routines (intrinsics)
- `thumbv7em-none-eabihf`
  - For the variants of the Cortex-M4 and Cortex-M7 that do have a FPU.
  - On this target, all the floating point operations will be lowered
    to hardware instructions

No binary releases of standard crates, like `core`, are planned for
these targets because Cargo, in the future, will compile e.g. the `core`
crate on the fly as part of the `cargo build` process. In the meantime,
you'll have to compile the `core` crate yourself. [Xargo](https://crates.io/crates/xargo) is the easiest
way to do that as in handles the compilation of `core` automatically and
can be used just like Cargo: `xargo build --target thumbv6m-none-eabi`
is all that's needed.

---

cc @brson @alexcrichton 
