### PR TITLE
loosen assertion against proj in collector

### DIFF
--- a/src/librustc/ty/flags.rs
+++ b/src/librustc/ty/flags.rs
@@ -107,6 +107,11 @@ impl FlagComputation {
             }
 
             &ty::TyProjection(ref data) => {
+                // currently we can't normalize projections that
+                // include bound regions, so track those separately.
+                if !data.has_escaping_regions() {
+                    self.add_flags(TypeFlags::HAS_NORMALIZABLE_PROJECTION);
+                }
                 self.add_flags(TypeFlags::HAS_PROJECTION);
                 self.add_projection_ty(data);
             }

--- a/src/librustc/ty/fold.rs
+++ b/src/librustc/ty/fold.rs
@@ -105,7 +105,7 @@ pub trait TypeFoldable<'tcx>: fmt::Debug + Clone {
                              TypeFlags::HAS_FREE_REGIONS |
                              TypeFlags::HAS_TY_INFER |
                              TypeFlags::HAS_PARAMS |
-                             TypeFlags::HAS_PROJECTION |
+                             TypeFlags::HAS_NORMALIZABLE_PROJECTION |
                              TypeFlags::HAS_TY_ERR |
                              TypeFlags::HAS_SELF)
     }

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -462,6 +462,10 @@ bitflags! {
         // Only set for TyInfer other than Fresh.
         const KEEP_IN_LOCAL_TCX  = 1 << 11,
 
+        // Is there a projection that does not involve a bound region?
+        // Currently we can't normalize projections w/ bound regions.
+        const HAS_NORMALIZABLE_PROJECTION = 1 << 12,
+
         const NEEDS_SUBST        = TypeFlags::HAS_PARAMS.bits |
                                    TypeFlags::HAS_SELF.bits |
                                    TypeFlags::HAS_RE_EARLY_BOUND.bits,

--- a/src/librustc_trans/collector.rs
+++ b/src/librustc_trans/collector.rs
@@ -1019,7 +1019,9 @@ fn create_fn_trans_item<'a, 'tcx>(scx: &SharedCrateContext<'a, 'tcx>,
     let concrete_substs = monomorphize::apply_param_substs(scx,
                                                            param_substs,
                                                            &fn_substs);
-    assert!(concrete_substs.is_normalized_for_trans());
+    assert!(concrete_substs.is_normalized_for_trans(),
+            "concrete_substs not normalized for trans: {:?}",
+            concrete_substs);
     TransItem::Fn(Instance::new(def_id, concrete_substs))
 }
 

--- a/src/test/run-pass/issue-36381.rs
+++ b/src/test/run-pass/issue-36381.rs
@@ -1,0 +1,34 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for #36381. The trans collector was asserting that
+// there are no projection types, but the `<&str as
+// StreamOnce>::Position` projection contained a late-bound region,
+// and we don't currently normalize in that case until the function is
+// actually invoked.
+
+pub trait StreamOnce {
+    type Position;
+}
+
+impl<'a> StreamOnce for &'a str {
+    type Position = usize;
+}
+
+pub fn parser<F>(_: F) {
+}
+
+fn follow(_: &str) -> <&str as StreamOnce>::Position {
+    panic!()
+}
+
+fn main() {
+    parser(follow);
+}


### PR DESCRIPTION
The collector was asserting a total absence of projections, but some projections are expected, even in trans: in particular, projections containing higher-ranked regions, which we don't currently normalize.

r? @pnkfelix 

Fixes #36381 
