### PR TITLE
Fix RUSTC_VERSION for 'documenting' build stage.

### DIFF
--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -1288,7 +1288,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         let link_meta = self.link_meta;
         let is_rustc_macro = tcx.sess.crate_types.borrow().contains(&CrateTypeRustcMacro);
         let root = self.lazy(&CrateRoot {
-            rustc_version: RUSTC_VERSION.to_string(),
+            rustc_version: rustc_version(),
             name: link_meta.crate_name.clone(),
             triple: tcx.sess.opts.target_triple.clone(),
             hash: link_meta.crate_hash,

--- a/src/librustc_metadata/loader.rs
+++ b/src/librustc_metadata/loader.rs
@@ -213,7 +213,7 @@
 //! metadata::loader or metadata::creader for all the juicy details!
 
 use cstore::MetadataBlob;
-use schema::{METADATA_HEADER, RUSTC_VERSION};
+use schema::{METADATA_HEADER, rustc_version};
 
 use rustc::hir::svh::Svh;
 use rustc::session::Session;
@@ -382,7 +382,7 @@ impl<'a> Context<'a> {
         }
         if !self.rejected_via_version.is_empty() {
             err.help(&format!("please recompile that crate using this compiler ({})",
-                              RUSTC_VERSION));
+                              rustc_version()));
             let mismatches = self.rejected_via_version.iter();
             for (i, &CrateMismatch { ref path, ref got }) in mismatches.enumerate() {
                 err.note(&format!("crate `{}` path #{}: {} compiled by {:?}",
@@ -597,9 +597,10 @@ impl<'a> Context<'a> {
 
     fn crate_matches(&mut self, metadata: &MetadataBlob, libpath: &Path) -> Option<Svh> {
         let root = metadata.get_root();
-        if root.rustc_version != RUSTC_VERSION {
+        let rustc_version = rustc_version();
+        if root.rustc_version != rustc_version {
             info!("Rejecting via version: expected {} got {}",
-                  RUSTC_VERSION, root.rustc_version);
+                  rustc_version, root.rustc_version);
             self.rejected_via_version.push(CrateMismatch {
                 path: libpath.to_path_buf(),
                 got: root.rustc_version

--- a/src/librustc_metadata/schema.rs
+++ b/src/librustc_metadata/schema.rs
@@ -26,11 +26,9 @@ use syntax_pos::{self, Span};
 
 use std::marker::PhantomData;
 
-#[cfg(not(test))]
-pub const RUSTC_VERSION: &'static str = concat!("rustc ", env!("CFG_VERSION"));
-
-#[cfg(test)]
-pub const RUSTC_VERSION: &'static str = "rustc 0.0.0-unit-test";
+pub fn rustc_version() -> String {
+    format!("rustc {}", option_env!("CFG_VERSION").unwrap_or("unknown version"))
+}
 
 /// Metadata encoding version.
 /// NB: increment this if you change the format of metadata such that


### PR DESCRIPTION
Previously the `env!("RUSTC_VERSION")` requirement would break the "Documenting rustc_metadata" stage of the rustc build, since that environment variable is only defined during the main build.

r? @eddyb
