### PR TITLE
Avoid introducing `run` twice in the Rust book

### DIFF
--- a/src/doc/book/getting-started.md
+++ b/src/doc/book/getting-started.md
@@ -505,6 +505,9 @@ $ cargo run
 Hello, world!
 ```
 
+The `run` command comes in handy when you need to rapidly iterate on a
+project.
+
 Notice that this example didn’t re-build the project. Cargo figured out that
 the file hasn’t changed, and so it just ran the binary. If you'd modified your
 source code, Cargo would have rebuilt the project before running it, and you

--- a/src/doc/book/guessing-game.md
+++ b/src/doc/book/guessing-game.md
@@ -56,9 +56,7 @@ $ cargo build
 Excellent! Open up your `src/main.rs` again. We’ll be writing all of
 our code in this file.
 
-Before we move on, let me show you one more Cargo command: `run`. `cargo run`
-is kind of like `cargo build`, but it also then runs the produced executable.
-Try it out:
+Remember the `run` command from last chapter? Try it out again here:
 
 ```bash
 $ cargo run
@@ -67,9 +65,8 @@ $ cargo run
 Hello, world!
 ```
 
-Great! The `run` command comes in handy when you need to rapidly iterate on a
-project. Our game is such a project, we need to quickly test each
-iteration before moving on to the next one.
+Great! Our game is just the kind of project `run` is good for: we need
+to quickly test each iteration before moving on to the next one.
 
 # Processing a Guess
 


### PR DESCRIPTION
As it stands, getting-started.md and guessing-game.md both introduce `run` as a new command. I switched it so that the 2nd refers back to the first introduction, rather than re-introducing the command.

(First ever FOSS PR, sorry if I screwed up anything obvious :) )

r? @steveklabnik
