### PR TITLE
impl Debug for raw pointers to unsized data

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1566,11 +1566,11 @@ floating! { f64 }
 // Implementation of Display/Debug for various core types
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> Debug for *const T {
+impl<T: ?Sized> Debug for *const T {
     fn fmt(&self, f: &mut Formatter) -> Result { Pointer::fmt(self, f) }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> Debug for *mut T {
+impl<T: ?Sized> Debug for *mut T {
     fn fmt(&self, f: &mut Formatter) -> Result { Pointer::fmt(self, f) }
 }
 

--- a/src/test/run-pass/deriving-show.rs
+++ b/src/test/run-pass/deriving-show.rs
@@ -24,6 +24,9 @@ enum Enum {
     StructVariant { x: isize, y : usize }
 }
 
+#[derive(Debug)]
+struct Pointers(*const Send, *mut Sync);
+
 macro_rules! t {
     ($x:expr, $expected:expr) => {
         assert_eq!(format!("{:?}", $x), $expected.to_string())


### PR DESCRIPTION
`?Sized` was missing from these impls for seemingly no reason.

Fixes #36870.
