### PR TITLE
resolve: fix incorrect code in `module_to_string`

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3534,7 +3534,7 @@ fn module_to_string(module: Module) -> String {
         } else {
             // danger, shouldn't be ident?
             names.push(token::intern("<opaque>"));
-            collect_mod(names, module);
+            collect_mod(names, module.parent.unwrap());
         }
     }
     collect_mod(&mut names, module);

--- a/src/test/compile-fail/issue-36881.rs
+++ b/src/test/compile-fail/issue-36881.rs
@@ -1,0 +1,14 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    extern crate rand;
+    use rand::Rng; //~ ERROR unresolved import
+}


### PR DESCRIPTION
Fixes #36881.
r? @nrc or @eddyb 
