### PR TITLE
Make sufficiently old or low-impact compatibility lints deny-by-default

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -120,25 +120,25 @@ declare_lint! {
 
 declare_lint! {
     pub INACCESSIBLE_EXTERN_CRATE,
-    Warn,
+    Deny,
     "use of inaccessible extern crate erroneously allowed"
 }
 
 declare_lint! {
     pub INVALID_TYPE_PARAM_DEFAULT,
-    Warn,
+    Deny,
     "type parameter default erroneously allowed in invalid location"
 }
 
 declare_lint! {
     pub ILLEGAL_FLOATING_POINT_CONSTANT_PATTERN,
-    Warn,
+    Deny,
     "floating-point constants cannot be used in patterns"
 }
 
 declare_lint! {
     pub ILLEGAL_STRUCT_OR_ENUM_CONSTANT_PATTERN,
-    Warn,
+    Deny,
     "constants of struct or enum type can only be used in a pattern if \
      the struct or enum has `#[derive(PartialEq, Eq)]`"
 }
@@ -164,7 +164,7 @@ declare_lint! {
 
 declare_lint! {
     pub OVERLAPPING_INHERENT_IMPLS,
-    Warn,
+    Deny,
     "two overlapping inherent impls define an item with the same name were erroneously allowed"
 }
 
@@ -176,13 +176,13 @@ declare_lint! {
 
 declare_lint! {
     pub SUPER_OR_SELF_IN_GLOBAL_PATH,
-    Warn,
+    Deny,
     "detects super or self keywords at the beginning of global path"
 }
 
 declare_lint! {
     pub LIFETIME_UNDERSCORE,
-    Warn,
+    Deny,
     "lifetimes or labels named `'_` were erroneously allowed"
 }
 

--- a/src/librustc_const_eval/diagnostics.rs
+++ b/src/librustc_const_eval/diagnostics.rs
@@ -76,8 +76,6 @@ Not-a-Number (NaN) values cannot be compared for equality and hence can never
 match the input to a match expression. So, the following will not compile:
 
 ```compile_fail
-#![deny(illegal_floating_point_constant_pattern)]
-
 const NAN: f32 = 0.0 / 0.0;
 
 let number = 0.1f32;

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -174,15 +174,15 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
         },
         FutureIncompatibleInfo {
             id: LintId::of(INACCESSIBLE_EXTERN_CRATE),
-            reference: "PR 31362 <https://github.com/rust-lang/rust/pull/31362>",
+            reference: "issue #36886 <https://github.com/rust-lang/rust/issues/36886>",
         },
         FutureIncompatibleInfo {
             id: LintId::of(INVALID_TYPE_PARAM_DEFAULT),
-            reference: "PR 30724 <https://github.com/rust-lang/rust/pull/30724>",
+            reference: "issue #36887 <https://github.com/rust-lang/rust/issues/36887>",
         },
         FutureIncompatibleInfo {
             id: LintId::of(SUPER_OR_SELF_IN_GLOBAL_PATH),
-            reference: "PR #32403 <https://github.com/rust-lang/rust/pull/32403>",
+            reference: "issue #36888 <https://github.com/rust-lang/rust/issues/36888>",
         },
         FutureIncompatibleInfo {
             id: LintId::of(TRANSMUTE_FROM_FN_ITEM_TYPES),
@@ -190,15 +190,15 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
         },
         FutureIncompatibleInfo {
             id: LintId::of(OVERLAPPING_INHERENT_IMPLS),
-            reference: "issue #22889 <https://github.com/rust-lang/rust/issues/22889>",
+            reference: "issue #36889 <https://github.com/rust-lang/rust/issues/36889>",
         },
         FutureIncompatibleInfo {
             id: LintId::of(ILLEGAL_FLOATING_POINT_CONSTANT_PATTERN),
-            reference: "RFC 1445 <https://github.com/rust-lang/rfcs/pull/1445>",
+            reference: "issue #36890 <https://github.com/rust-lang/rust/issues/36890>",
         },
         FutureIncompatibleInfo {
             id: LintId::of(ILLEGAL_STRUCT_OR_ENUM_CONSTANT_PATTERN),
-            reference: "RFC 1445 <https://github.com/rust-lang/rfcs/pull/1445>",
+            reference: "issue #36891 <https://github.com/rust-lang/rust/issues/36891>",
         },
         FutureIncompatibleInfo {
             id: LintId::of(HR_LIFETIME_IN_ASSOC_TYPE),
@@ -206,11 +206,11 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
         },
         FutureIncompatibleInfo {
             id: LintId::of(LIFETIME_UNDERSCORE),
-            reference: "RFC 1177 <https://github.com/rust-lang/rfcs/pull/1177>",
+            reference: "issue #36892 <https://github.com/rust-lang/rust/issues/36892>",
         },
         FutureIncompatibleInfo {
             id: LintId::of(SAFE_EXTERN_STATICS),
-            reference: "issue 36247 <https://github.com/rust-lang/rust/issues/35112>",
+            reference: "issue #36247 <https://github.com/rust-lang/rust/issues/35112>",
         },
         ]);
 

--- a/src/test/compile-fail/extern-crate-visibility.rs
+++ b/src/test/compile-fail/extern-crate-visibility.rs
@@ -8,9 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(rustc_attrs)]
-#![allow(dead_code)]
-#![allow(unused_imports)]
+#![allow(unused)]
 
 mod foo {
     extern crate core;
@@ -19,11 +17,11 @@ mod foo {
 // Check that private crates can be used from outside their modules, albeit with warnings
 use foo::core; //~ WARN extern crate `core` is private
 //~^ WARN this was previously accepted by the compiler but is being phased out
-use foo::core::cell; //~ WARN extern crate `core` is private
+use foo::core::cell; //~ ERROR extern crate `core` is private
 //~^ WARN this was previously accepted by the compiler but is being phased out
 
 fn f() {
-    foo::core::cell::Cell::new(0); //~ WARN extern crate `core` is private
+    foo::core::cell::Cell::new(0); //~ ERROR extern crate `core` is private
     //~^ WARN this was previously accepted by the compiler but is being phased out
 
     use foo::*;
@@ -39,5 +37,4 @@ mod baz {
     use self::core::cell; // Check that public extern crates are glob imported
 }
 
-#[rustc_error]
-fn main() {} //~ ERROR compilation successful
+fn main() {}

--- a/src/test/compile-fail/inherent-overlap.rs
+++ b/src/test/compile-fail/inherent-overlap.rs
@@ -11,13 +11,12 @@
 // Test that you cannot define items with the same name in overlapping inherent
 // impl blocks.
 
-#![feature(rustc_attrs)]
-#![allow(dead_code)]
+#![allow(unused)]
 
 struct Foo;
 
 impl Foo {
-    fn id() {} //~ WARN duplicate definitions
+    fn id() {} //~ ERROR duplicate definitions
     //~^ WARN previously accepted
 }
 
@@ -28,7 +27,7 @@ impl Foo {
 struct Bar<T>(T);
 
 impl<T> Bar<T> {
-    fn bar(&self) {} //~ WARN duplicate definitions
+    fn bar(&self) {} //~ ERROR duplicate definitions
     //~^ WARN previously accepted
 }
 
@@ -39,7 +38,7 @@ impl Bar<u32> {
 struct Baz<T>(T);
 
 impl<T: Copy> Baz<T> {
-    fn baz(&self) {} //~ WARN duplicate definitions
+    fn baz(&self) {} //~ ERROR duplicate definitions
     //~^ WARN previously accepted
 }
 
@@ -47,5 +46,4 @@ impl<T> Baz<Vec<T>> {
     fn baz(&self) {}
 }
 
-#[rustc_error]
-fn main() {} //~ ERROR compilation successful
+fn main() {}

--- a/src/test/compile-fail/issue-6804.rs
+++ b/src/test/compile-fail/issue-6804.rs
@@ -8,16 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(rustc_attrs)]
-#![feature(slice_patterns)]
-#![allow(dead_code)]
-#![deny(illegal_floating_point_constant_pattern)]
-
 // Matching against NaN should result in a warning
+
+#![feature(slice_patterns)]
+#![allow(unused)]
 
 use std::f64::NAN;
 
-#[rustc_error]
 fn main() {
     let x = NAN;
     match x {

--- a/src/test/compile-fail/lifetime-underscore.rs
+++ b/src/test/compile-fail/lifetime-underscore.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![deny(lifetime_underscore)]
-
 fn _f<'_>() //~ ERROR invalid lifetime name `'_`
 //~^ WARN this was previously accepted
     -> &'_ u8 //~ ERROR invalid lifetime name `'_`

--- a/src/test/compile-fail/use-super-global-path.rs
+++ b/src/test/compile-fail/use-super-global-path.rs
@@ -8,22 +8,20 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(rustc_attrs)]
-#![allow(unused_imports, dead_code)]
+#![allow(unused)]
 
 struct S;
 struct Z;
 
 mod foo {
-    use ::super::{S, Z}; //~ WARN global paths cannot start with `super`
+    use ::super::{S, Z}; //~ ERROR global paths cannot start with `super`
     //~^ WARN this was previously accepted by the compiler but is being phased out
 
     pub fn g() {
-        use ::super::main; //~ WARN global paths cannot start with `super`
+        use ::super::main; //~ ERROR global paths cannot start with `super`
         //~^ WARN this was previously accepted by the compiler but is being phased out
         main();
     }
 }
 
-#[rustc_error]
-fn main() { foo::g(); } //~ ERROR compilation successful
+fn main() { foo::g(); }

--- a/src/test/run-pass/type-macros-simple.rs
+++ b/src/test/run-pass/type-macros-simple.rs
@@ -23,7 +23,7 @@ fn issue_36540() {
 
     let x: m!() = m!();
     std::cell::Cell::<m!()>::new(m!());
-    impl<T = m!()> std::ops::Index<m!()> for Trait<(m!(), T)>
+    impl<T> std::ops::Index<m!()> for Trait<(m!(), T)>
         where T: Trait<m!()>
     {
         type Output = m!();


### PR DESCRIPTION
Tracking issues are updated/created when necessary.
Needs crater run before proceeding.

r? @nikomatsakis 
