### PR TITLE
Set EH personality when resuming stack unwinding

### DIFF
--- a/src/librustc_trans/mir/block.rs
+++ b/src/librustc_trans/mir/block.rs
@@ -115,6 +115,9 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                 if let Some(cleanup_pad) = cleanup_pad {
                     bcx.cleanup_ret(cleanup_pad, None);
                 } else {
+                    let llpersonality = bcx.fcx.eh_personality();
+                    bcx.set_personality_fn(llpersonality);
+
                     let ps = self.get_personality_slot(&bcx);
                     let lp = bcx.load(ps);
                     bcx.with_block(|bcx| {


### PR DESCRIPTION
To resume stack unwinding, the LLVM `resume` instruction must be used.

In order to use this instruction, the calling function must have an
exception handling personality set.

LLVM 4.0 adds a new IR validation check to ensure a personality is
always set in these cases.

This was introduced in [r277360](https://reviews.llvm.org/rL277360).
