### PR TITLE
Refactor layout to store offsets of fields, not offsets after fields

### DIFF
--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -738,7 +738,7 @@ impl LateLintPass for VariantSizeDifferences {
                         .zip(variants)
                         .map(|(variant, variant_layout)| {
                             // Subtract the size of the enum discriminant
-                            let bytes = variant_layout.min_size().bytes()
+                            let bytes = variant_layout.min_size.bytes()
                                                                  .saturating_sub(discr_size);
 
                             debug!("- variant `{}` is {} bytes large", variant.node.name, bytes);

--- a/src/librustc_trans/common.rs
+++ b/src/librustc_trans/common.rs
@@ -127,7 +127,7 @@ pub fn type_is_imm_pair<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, ty: Ty<'tcx>)
         Layout::FatPointer { .. } => true,
         Layout::Univariant { ref variant, .. } => {
             // There must be only 2 fields.
-            if variant.offset_after_field.len() != 2 {
+            if variant.offsets.len() != 2 {
                 return false;
             }
 

--- a/src/librustc_trans/glue.rs
+++ b/src/librustc_trans/glue.rs
@@ -335,20 +335,9 @@ pub fn size_and_align_of_dst<'blk, 'tcx>(bcx: &BlockAndBuilder<'blk, 'tcx>,
             let layout = ccx.layout_of(t);
             debug!("DST {} layout: {:?}", t, layout);
 
-            // Returns size in bytes of all fields except the last one
-            // (we will be recursing on the last one).
-            fn local_prefix_bytes(variant: &ty::layout::Struct) -> u64 {
-                let fields = variant.offset_after_field.len();
-                if fields > 1 {
-                    variant.offset_after_field[fields - 2].bytes()
-                } else {
-                    0
-                }
-            }
-
             let (sized_size, sized_align) = match *layout {
                 ty::layout::Layout::Univariant { ref variant, .. } => {
-                    (local_prefix_bytes(variant), variant.align.abi())
+                    (variant.offsets.last().map_or(0, |o| o.bytes()), variant.align.abi())
                 }
                 _ => {
                     bug!("size_and_align_of_dst: expcted Univariant for `{}`, found {:#?}",


### PR DESCRIPTION
This is the next PR moving us towards being able to reorder struct fields.

The old code implicitly stored the offset of the first field.  This is inadequate because the first field may no longer be offset 0 in future.  This PR refactors `layout` to use a `offsets` vector instead of a `offset_after_field` vector.
