### PR TITLE
add a fastpath to match_impl for the non-HRTB case

### DIFF
--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -2668,6 +2668,49 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
         }
     }
 
+    fn match_impl_fastpath(&mut self,
+                           impl_def_id: DefId,
+                           impl_trait_ref: ty::TraitRef<'tcx>,
+                           obligation: &TraitObligation<'tcx>)
+                           -> Option<Result<&'tcx Substs<'tcx>, ()>>
+    {
+        debug!("match_impl_fastpath({:?}={:?}, {:?}) entry",
+               impl_def_id, impl_trait_ref, obligation);
+
+        if impl_trait_ref.has_projection_types() {
+            return None;
+        }
+
+        let obligation_predicate = self.tcx().no_late_bound_regions(&obligation.predicate);
+        let obligation_trait_ref = match obligation_predicate {
+            Some(predicate) => predicate.trait_ref,
+            _ => return None
+        };
+
+        let impl_substs = self.infcx.fresh_substs_for_item(obligation.cause.span,
+                                                           impl_def_id);
+        let impl_trait_ref = impl_trait_ref.subst(self.tcx(), impl_substs);
+
+        debug!("match_impl(impl_def_id={:?}, obligation={:?}, \
+               impl_trait_ref={:?}, skol_obligation_trait_ref={:?}) fastpath",
+               impl_def_id,
+               obligation,
+               impl_trait_ref,
+               obligation_trait_ref);
+
+        let origin = TypeOrigin::RelateOutputImplTypes(obligation.cause.span);
+        match self.infcx.eq_trait_refs(false, origin, impl_trait_ref, obligation_trait_ref) {
+            Ok(InferOk { obligations, .. }) => {
+                self.inferred_obligations.extend(obligations);
+                Some(Ok(impl_substs))
+            }
+            Err(e) => {
+                debug!("match_impl_fastpath: failed eq_trait_refs due to `{}`", e);
+                Some(Err(()))
+            }
+        }
+    }
+
     fn match_impl(&mut self,
                   impl_def_id: DefId,
                   obligation: &TraitObligation<'tcx>,
@@ -2682,6 +2725,13 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
         // and so forth that we need to.
         if self.fast_reject_trait_refs(obligation, &impl_trait_ref) {
             return Err(());
+        }
+
+        if let Some(result) = self.match_impl_fastpath(impl_def_id, impl_trait_ref, obligation) {
+            return result.map(|substs| (
+                Normalized { value: substs, obligations: vec![] },
+                FnvHashMap()
+            ));
         }
 
         let (skol_obligation, skol_map) = self.infcx().skolemize_late_bound_regions(
@@ -2702,7 +2752,7 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
                                           &impl_trait_ref);
 
         debug!("match_impl(impl_def_id={:?}, obligation={:?}, \
-               impl_trait_ref={:?}, skol_obligation_trait_ref={:?})",
+               impl_trait_ref={:?}, skol_obligation_trait_ref={:?}) slowpath",
                impl_def_id,
                obligation,
                impl_trait_ref,

--- a/src/librustc/ty/fast_reject.rs
+++ b/src/librustc/ty/fast_reject.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use hir;
 use hir::def_id::DefId;
 use ty::{self, Ty, TyCtxt};
 use syntax::ast;
@@ -24,8 +25,9 @@ pub enum SimplifiedType {
     FloatSimplifiedType(ast::FloatTy),
     AdtSimplifiedType(DefId),
     StrSimplifiedType,
-    ArraySimplifiedType,
-    PtrSimplifiedType,
+    ArraySimplifiedType(usize),
+    SliceSimplifiedType,
+    PtrSimplifiedType(hir::Mutability),
     NeverSimplifiedType,
     TupleSimplifiedType(usize),
     TraitSimplifiedType(DefId),
@@ -57,8 +59,9 @@ pub fn simplify_type<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
         ty::TyFloat(float_type) => Some(FloatSimplifiedType(float_type)),
         ty::TyAdt(def, _) => Some(AdtSimplifiedType(def.did)),
         ty::TyStr => Some(StrSimplifiedType),
-        ty::TyArray(..) | ty::TySlice(_) => Some(ArraySimplifiedType),
-        ty::TyRawPtr(_) => Some(PtrSimplifiedType),
+        ty::TyArray(_, n) => Some(ArraySimplifiedType(n)),
+        ty::TySlice(_) => Some(SliceSimplifiedType),
+        ty::TyRawPtr(mt) => Some(PtrSimplifiedType(mt.mutbl)),
         ty::TyTrait(ref trait_info) => {
             Some(TraitSimplifiedType(trait_info.principal.def_id()))
         }


### PR DESCRIPTION
This leads to a 2.5% all-around typeck time improvement.

e.g. librustc times before:

```
time: 0.233; rss: 89MB  parsing
time: 0.000; rss: 89MB  recursion limit
time: 0.000; rss: 89MB  crate injection
time: 0.000; rss: 89MB  plugin loading
time: 0.000; rss: 89MB  plugin registration
time: 0.715; rss: 240MB expansion
time: 0.000; rss: 240MB maybe building test harness
time: 0.016; rss: 240MB maybe creating a macro crate
time: 0.000; rss: 240MB checking for inline asm in case the target doesn't support it
time: 0.033; rss: 240MB complete gated feature checking
time: 0.055; rss: 240MB early lint checks
time: 0.019; rss: 240MB AST validation
time: 0.210; rss: 261MB name resolution
time: 0.133; rss: 349MB lowering ast -> hir
time: 0.025; rss: 357MB indexing hir
time: 0.016; rss: 357MB attribute checking
time: 0.016; rss: 357MB language item collection
time: 0.034; rss: 357MB lifetime resolution
time: 0.000; rss: 357MB looking for entry point
time: 0.000; rss: 357MB looking for plugin registrar
time: 0.115; rss: 377MB region resolution
time: 0.015; rss: 377MB loop checking
time: 0.015; rss: 377MB static item recursion checking
time: 0.221; rss: 378MB compute_incremental_hashes_map
time: 0.000; rss: 378MB load_dep_graph
time: 0.192; rss: 384MB type collecting
time: 0.004; rss: 384MB variance inference
time: 0.078; rss: 385MB coherence checking
time: 0.359; rss: 391MB wf checking
time: 0.248; rss: 394MB item-types checking
time: 8.445; rss: 476MB item-bodies checking
time: 0.000; rss: 476MB drop-impl checking
time: 0.858; rss: 484MB const checking
time: 0.131; rss: 484MB privacy checking
time: 0.023; rss: 484MB stability index
time: 0.055; rss: 484MB intrinsic checking
time: 0.042; rss: 484MB effect checking
time: 0.154; rss: 484MB match checking
time: 0.118; rss: 484MB liveness checking
time: 0.763; rss: 484MB rvalue checking
time: 1.144; rss: 696MB MIR dump
  time: 0.122; rss: 696MB       SimplifyCfg
  time: 0.245; rss: 697MB       QualifyAndPromoteConstants
  time: 0.299; rss: 697MB       TypeckMir
  time: 0.011; rss: 697MB       SimplifyBranches
  time: 0.080; rss: 697MB       SimplifyCfg
time: 0.756; rss: 697MB MIR passes
time: 1.831; rss: 699MB borrow checking
time: 0.080; rss: 699MB reachability checking
time: 0.108; rss: 699MB death checking
time: 0.097; rss: 701MB stability checking
time: 0.000; rss: 701MB unused lib feature checking
time: 0.597; rss: 701MB lint checking
time: 0.003; rss: 701MB resolving dependency formats
  time: 0.008; rss: 701MB       NoLandingPads
  time: 0.055; rss: 701MB       SimplifyCfg
  time: 0.192; rss: 714MB       EraseRegions
  time: 0.030; rss: 714MB       AddCallGuards
  time: 2.457; rss: 719MB       ElaborateDrops
  time: 0.008; rss: 719MB       NoLandingPads
  time: 0.089; rss: 720MB       SimplifyCfg
  time: 0.070; rss: 720MB       InstCombine
  time: 0.037; rss: 720MB       Deaggregator
  time: 0.009; rss: 720MB       CopyPropagation
  time: 0.027; rss: 720MB       AddCallGuards
  time: 0.008; rss: 720MB       PreTrans
time: 2.989; rss: 720MB Prepare MIR codegen passes
  time: 0.578; rss: 734MB       write metadata
  time: 2.018; rss: 756MB       translation item collection
  time: 0.587; rss: 765MB       codegen unit partitioning
  time: 0.255; rss: 1151MB      internalize symbols
time: 14.005; rss: 1151MB       translation
```

at the first commit:

```
time: 0.233; rss: 89MB  parsing
time: 0.000; rss: 89MB  recursion limit
time: 0.000; rss: 89MB  crate injection
time: 0.000; rss: 89MB  plugin loading
time: 0.000; rss: 89MB  plugin registration
time: 0.710; rss: 239MB expansion
time: 0.000; rss: 239MB maybe building test harness
time: 0.016; rss: 239MB maybe creating a macro crate
time: 0.000; rss: 239MB checking for inline asm in case the target doesn't support it
time: 0.033; rss: 239MB complete gated feature checking
time: 0.055; rss: 239MB early lint checks
time: 0.019; rss: 239MB AST validation
time: 0.213; rss: 261MB name resolution
time: 0.134; rss: 349MB lowering ast -> hir
time: 0.026; rss: 357MB indexing hir
time: 0.016; rss: 357MB attribute checking
time: 0.016; rss: 357MB language item collection
time: 0.035; rss: 357MB lifetime resolution
time: 0.000; rss: 357MB looking for entry point
time: 0.000; rss: 357MB looking for plugin registrar
time: 0.114; rss: 377MB region resolution
time: 0.015; rss: 377MB loop checking
time: 0.015; rss: 377MB static item recursion checking
time: 0.224; rss: 377MB compute_incremental_hashes_map
time: 0.000; rss: 377MB load_dep_graph
time: 0.199; rss: 383MB type collecting
time: 0.004; rss: 383MB variance inference
time: 0.078; rss: 385MB coherence checking
time: 0.354; rss: 390MB wf checking
time: 0.245; rss: 394MB item-types checking
time: 8.271; rss: 476MB item-bodies checking
time: 0.000; rss: 476MB drop-impl checking
time: 0.848; rss: 483MB const checking
time: 0.132; rss: 483MB privacy checking
time: 0.024; rss: 483MB stability index
time: 0.056; rss: 483MB intrinsic checking
time: 0.043; rss: 483MB effect checking
time: 0.156; rss: 483MB match checking
time: 0.119; rss: 484MB liveness checking
time: 0.749; rss: 484MB rvalue checking
time: 1.149; rss: 696MB MIR dump
  time: 0.122; rss: 696MB       SimplifyCfg
  time: 0.247; rss: 697MB       QualifyAndPromoteConstants
  time: 0.310; rss: 697MB       TypeckMir
  time: 0.011; rss: 697MB       SimplifyBranches
  time: 0.080; rss: 697MB       SimplifyCfg
time: 0.770; rss: 697MB MIR passes
time: 1.782; rss: 698MB borrow checking
time: 0.080; rss: 699MB reachability checking
time: 0.109; rss: 699MB death checking
time: 0.097; rss: 700MB stability checking
time: 0.000; rss: 700MB unused lib feature checking
time: 0.591; rss: 700MB lint checking
time: 0.003; rss: 700MB resolving dependency formats
  time: 0.008; rss: 700MB       NoLandingPads
  time: 0.055; rss: 700MB       SimplifyCfg
  time: 0.193; rss: 714MB       EraseRegions
  time: 0.030; rss: 714MB       AddCallGuards
  time: 2.369; rss: 719MB       ElaborateDrops
  time: 0.008; rss: 719MB       NoLandingPads
  time: 0.090; rss: 719MB       SimplifyCfg
  time: 0.070; rss: 719MB       InstCombine
  time: 0.034; rss: 719MB       Deaggregator
  time: 0.009; rss: 719MB       CopyPropagation
  time: 0.027; rss: 719MB       AddCallGuards
  time: 0.008; rss: 719MB       PreTrans
time: 2.900; rss: 719MB Prepare MIR codegen passes
  time: 0.578; rss: 733MB       write metadata
  time: 1.953; rss: 756MB       translation item collection
  time: 0.597; rss: 764MB       codegen unit partitioning
  time: 0.250; rss: 1151MB      internalize symbols
time: 14.108; rss: 1151MB       translation
```

at the third commit:

```
x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc
time: 0.233; rss: 89MB  parsing
time: 0.000; rss: 89MB  recursion limit
time: 0.000; rss: 89MB  crate injection
time: 0.000; rss: 89MB  plugin loading
time: 0.000; rss: 89MB  plugin registration
time: 0.711; rss: 240MB expansion
time: 0.000; rss: 240MB maybe building test harness
time: 0.016; rss: 240MB maybe creating a macro crate
time: 0.000; rss: 240MB checking for inline asm in case the target doesn't support it
time: 0.033; rss: 240MB complete gated feature checking
time: 0.055; rss: 240MB early lint checks
time: 0.019; rss: 240MB AST validation
time: 0.211; rss: 262MB name resolution
time: 0.133; rss: 350MB lowering ast -> hir
time: 0.026; rss: 358MB indexing hir
time: 0.016; rss: 358MB attribute checking
time: 0.016; rss: 358MB language item collection
time: 0.034; rss: 358MB lifetime resolution
time: 0.000; rss: 358MB looking for entry point
time: 0.000; rss: 358MB looking for plugin registrar
time: 0.115; rss: 378MB region resolution
time: 0.015; rss: 378MB loop checking
time: 0.015; rss: 378MB static item recursion checking
time: 0.222; rss: 379MB compute_incremental_hashes_map
time: 0.000; rss: 379MB load_dep_graph
time: 0.194; rss: 384MB type collecting
time: 0.004; rss: 384MB variance inference
time: 0.079; rss: 386MB coherence checking
time: 0.353; rss: 391MB wf checking
time: 0.242; rss: 395MB item-types checking
time: 8.239; rss: 477MB item-bodies checking
time: 0.000; rss: 477MB drop-impl checking
time: 0.869; rss: 484MB const checking
time: 0.132; rss: 484MB privacy checking
time: 0.023; rss: 484MB stability index
time: 0.055; rss: 484MB intrinsic checking
time: 0.043; rss: 484MB effect checking
time: 0.154; rss: 484MB match checking
time: 0.118; rss: 485MB liveness checking
time: 0.770; rss: 485MB rvalue checking
time: 1.149; rss: 697MB MIR dump
  time: 0.122; rss: 697MB       SimplifyCfg
  time: 0.246; rss: 698MB       QualifyAndPromoteConstants
  time: 0.311; rss: 698MB       TypeckMir
  time: 0.011; rss: 698MB       SimplifyBranches
  time: 0.082; rss: 698MB       SimplifyCfg
time: 0.771; rss: 698MB MIR passes
time: 1.829; rss: 700MB borrow checking
time: 0.076; rss: 700MB reachability checking
time: 0.109; rss: 700MB death checking
time: 0.098; rss: 702MB stability checking
time: 0.000; rss: 702MB unused lib feature checking
time: 0.599; rss: 702MB lint checking
time: 0.003; rss: 702MB resolving dependency formats
  time: 0.009; rss: 702MB       NoLandingPads
  time: 0.055; rss: 702MB       SimplifyCfg
  time: 0.193; rss: 716MB       EraseRegions
  time: 0.030; rss: 716MB       AddCallGuards
  time: 2.421; rss: 720MB       ElaborateDrops
  time: 0.008; rss: 720MB       NoLandingPads
  time: 0.090; rss: 721MB       SimplifyCfg
  time: 0.070; rss: 721MB       InstCombine
  time: 0.036; rss: 721MB       Deaggregator
  time: 0.008; rss: 721MB       CopyPropagation
  time: 0.027; rss: 721MB       AddCallGuards
  time: 0.008; rss: 721MB       PreTrans
time: 2.956; rss: 721MB Prepare MIR codegen passes
  time: 0.580; rss: 735MB       write metadata
  time: 1.971; rss: 757MB       translation item collection
  time: 0.607; rss: 766MB       codegen unit partitioning
  time: 0.247; rss: 1153MB      internalize symbols
time: 13.953; rss: 1153MB       translation
```

r? @nikomatsakis 
