### PR TITLE
rustc: Try again to disable NEON on armv7 linux

### DIFF
--- a/src/librustc_back/target/armv7_unknown_linux_gnueabihf.rs
+++ b/src/librustc_back/target/armv7_unknown_linux_gnueabihf.rs
@@ -24,7 +24,7 @@ pub fn target() -> TargetResult {
 
         options: TargetOptions {
             // Info about features at https://wiki.debian.org/ArmHardFloatPort
-            features: "+v7,+vfp3,+d16,+thumb2".to_string(),
+            features: "+v7,+vfp3,+d16,+thumb2,-neon".to_string(),
             cpu: "generic".to_string(),
             max_atomic_width: 64,
             .. base


### PR DESCRIPTION
This is a follow-up to #35814 which apparently didn't disable it hard enough. It
looks like LLVM's default armv7 target enables NEON so we'd otherwise have to
pass `-neon`, but we're already enabling armv7 with `+v7` supposedly, so let's
try just telling LLVM that the armv7 target is arm and then enable features
selectively.

Closes #36913
