### PR TITLE
Test Case for Incr. Comp. Hash for traits #36681.

### DIFF
--- a/src/test/incremental/hashes/trait_defs.rs
+++ b/src/test/incremental/hashes/trait_defs.rs
@@ -477,7 +477,7 @@ trait TraitAddSecondBuiltinBoundToMethodTypeParameter {
 // Add second lifetime bound to method type parameter -----------------------------
 #[cfg(cfail1)]
 trait TraitAddSecondLifetimeBoundToMethodTypeParameter {
-    fn method<'a, 'b, 'c: 'a>(a: &'a u32, b: &'b u32);
+    fn method<'a, 'b, 'c: 'a>(a: &'a u32, b: &'b u32, c: &'c u32);
 }
 
 #[cfg(not(cfail1))]

--- a/src/test/incremental/hashes/trait_defs.rs
+++ b/src/test/incremental/hashes/trait_defs.rs
@@ -1,0 +1,1117 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+// This test case tests the incremental compilation hash (ICH) implementation
+// for trait definitions.
+
+// The general pattern followed here is: Change one thing between rev1 and rev2
+// and make sure that the hash has changed, then change nothing between rev2 and
+// rev3 and make sure that the hash has not changed.
+
+// We also test the ICH for trait definitions exported in metadata. Same as
+// above, we want to make sure that the change between rev1 and rev2 also
+// results in a change of the ICH for the trait's metadata, and that it stays
+// the same between rev2 and rev3.
+
+// must-compile-successfully
+// revisions: cfail1 cfail2 cfail3
+// compile-flags: -Z query-dep-graph
+
+#![allow(warnings)]
+#![feature(rustc_attrs)]
+#![crate_type="rlib"]
+#![feature(associated_type_defaults)]
+#![feature(intrinsics)]
+#![feature(associated_consts)]
+
+
+// Change trait visibility --------------------------------------------------------
+#[cfg(cfail1)]
+trait TraitVisibility { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_clean(cfg="cfail3")]
+pub trait TraitVisibility { }
+
+
+
+// Change trait unsafety ----------------------------------------------------------
+// FIXME: this should work but doesn't yet.
+// #[cfg(cfail1)]
+// trait TraitUnsafety { }
+
+// #[cfg(not(cfail1))]
+// #[rustc_dirty(label="Hir", cfg="cfail2")]
+// #[rustc_clean(label="Hir", cfg="cfail3")]
+// #[rustc_metadata_dirty(cfg="cfail2")]
+// #[rustc_metadata_clean(cfg="cfail3")]
+// unsafe trait TraitUnsafety { }
+
+
+
+// Add method ---------------------------------------------------------------------
+#[cfg(cfail1)]
+trait TraitAddMethod {
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+pub trait TraitAddMethod {
+    fn method();
+}
+
+
+
+// Change name of method ----------------------------------------------------------
+#[cfg(cfail1)]
+trait TraitChangeMethodName {
+    fn method();
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitChangeMethodName {
+    fn methodChanged();
+}
+
+
+
+// Add return type to method ------------------------------------------------------
+#[cfg(cfail1)]
+trait TraitAddReturnType {
+    fn method();
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddReturnType {
+    fn method() -> u32;
+}
+
+
+
+// Change return type of method ---------------------------------------------------
+#[cfg(cfail1)]
+trait TraitChangeReturnType {
+    fn method() -> u32;
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitChangeReturnType {
+    fn method() -> u64;
+}
+
+
+
+// Add parameter to method --------------------------------------------------------
+#[cfg(cfail1)]
+trait TraitAddParameterToMethod {
+    fn method();
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddParameterToMethod {
+    fn method(a: u32);
+}
+
+
+
+// Change name of method parameter ------------------------------------------------
+#[cfg(cfail1)]
+trait TraitChangeMethodParameterName {
+    fn method(a: u32);
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitChangeMethodParameterName {
+    fn method(b: u32);
+}
+
+
+
+// Change type of method parameter (i32 => i64) -----------------------------------
+#[cfg(cfail1)]
+trait TraitChangeMethodParameterType {
+    fn method(a: i32);
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitChangeMethodParameterType {
+    fn method(a: i64);
+}
+
+
+
+// Change type of method parameter (&i32 => &mut i32) -----------------------------
+// FIXME: this should work but doesn't yet.
+// #[cfg(cfail1)]
+// trait TraitChangeMethodParameterTypeRef {
+//     fn method(a: &i32);
+// }
+
+// #[cfg(not(cfail1))]
+// #[rustc_dirty(label="Hir", cfg="cfail2")]
+// #[rustc_clean(label="Hir", cfg="cfail3")]
+// #[rustc_metadata_dirty(cfg="cfail2")]
+// #[rustc_metadata_clean(cfg="cfail3")]
+// trait TraitChangeMethodParameterTypeRef {
+//     fn method(a: &mut i32);
+// }
+
+
+
+// Change order of method parameters ----------------------------------------------
+#[cfg(cfail1)]
+trait TraitChangeMethodParametersOrder {
+    fn method(a: i32, b: i32);
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitChangeMethodParametersOrder {
+    fn method(b: i32, a: i32);
+}
+
+
+
+// Add default implementation to method -------------------------------------------
+#[cfg(cfail1)]
+trait TraitAddMethodDefaultImplementation {
+    fn method();
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddMethodDefaultImplementation {
+    fn method() { }
+}
+
+
+
+// Change order of methods --------------------------------------------------------
+#[cfg(cfail1)]
+trait TraitChangeOrderOfMethods {
+    fn method0();
+    fn method1();
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitChangeOrderOfMethods {
+    fn method1();
+    fn method0();
+}
+
+
+
+// Change mode of self parameter --------------------------------------------------
+// FIXME: this should work but doesn't yet.
+// #[cfg(cfail1)]
+// trait TraitChangeModeSelfRefToMut {
+//     fn method(&self);
+// }
+
+// #[cfg(not(cfail1))]
+// #[rustc_dirty(label="Hir", cfg="cfail2")]
+// #[rustc_clean(label="Hir", cfg="cfail3")]
+// #[rustc_metadata_dirty(cfg="cfail2")]
+// #[rustc_metadata_clean(cfg="cfail3")]
+// trait TraitChangeModeSelfRefToMut {
+//     fn method(&mut self);
+// }
+
+// FIXME: this should work but doesn't yet.
+// #[cfg(cfail1)]
+// trait TraitChangeModeSelfOwnToMut {
+//     fn method(self);
+// }
+
+// #[cfg(not(cfail1))]
+// #[rustc_dirty(label="Hir", cfg="cfail2")]
+// #[rustc_clean(label="Hir", cfg="cfail3")]
+// #[rustc_metadata_dirty(cfg="cfail2")]
+// #[rustc_metadata_clean(cfg="cfail3")]
+// trait TraitChangeModeSelfOwnToMut {
+//     fn method(mut self);
+// }
+
+
+
+#[cfg(cfail1)]
+trait TraitChangeModeSelfOwnToRef {
+    fn method(self);
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitChangeModeSelfOwnToRef {
+    fn method(&self);
+}
+
+
+
+// Add unsafe modifier to method --------------------------------------------------
+// FIXME: this should work but doesn't yet.
+// #[cfg(cfail1)]
+// trait TraitAddUnsafeModifier {
+//     fn method();
+// }
+
+// #[cfg(not(cfail1))]
+// #[rustc_dirty(label="Hir", cfg="cfail2")]
+// #[rustc_clean(label="Hir", cfg="cfail3")]
+// #[rustc_metadata_dirty(cfg="cfail2")]
+// #[rustc_metadata_clean(cfg="cfail3")]
+// trait TraitAddUnsafeModifier {
+//     unsafe fn method();
+// }
+
+
+
+// Add extern modifier to method --------------------------------------------------
+// FIXME: this should work but doesn't yet.
+// #[cfg(cfail1)]
+// trait TraitAddExternModifier {
+//     fn method();
+// }
+
+// #[cfg(not(cfail1))]
+// #[rustc_dirty(label="Hir", cfg="cfail2")]
+// #[rustc_clean(label="Hir", cfg="cfail3")]
+// #[rustc_metadata_dirty(cfg="cfail2")]
+// #[rustc_metadata_clean(cfg="cfail3")]
+// trait TraitAddExternModifier {
+//     extern fn method();
+// }
+
+
+
+// Change extern "C" to extern "rust-intrinsic" -----------------------------------
+// FIXME: this should work but doesn't yet.
+// #[cfg(cfail1)]
+// trait TraitChangeExternCToRustIntrinsic {
+//     extern "C" fn method();
+// }
+
+// #[cfg(not(cfail1))]
+// #[rustc_dirty(label="Hir", cfg="cfail2")]
+// #[rustc_clean(label="Hir", cfg="cfail3")]
+// #[rustc_metadata_dirty(cfg="cfail2")]
+// #[rustc_metadata_clean(cfg="cfail3")]
+// trait TraitChangeExternCToRustIntrinsic {
+//     extern "rust-intrinsic" fn method();
+// }
+
+
+
+// Add type parameter to method ---------------------------------------------------
+#[cfg(cfail1)]
+trait TraitAddTypeParameterToMethod {
+    fn method();
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddTypeParameterToMethod {
+    fn method<T>();
+}
+
+
+
+// Add lifetime parameter to method -----------------------------------------------
+#[cfg(cfail1)]
+trait TraitAddLifetimeParameterToMethod {
+    fn method();
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddLifetimeParameterToMethod {
+    fn method<'a>();
+}
+
+
+
+// dummy trait for bound
+trait ReferenceTrait0 { }
+trait ReferenceTrait1 { }
+
+// Add trait bound to method type parameter ---------------------------------------
+#[cfg(cfail1)]
+trait TraitAddTraitBoundToMethodTypeParameter {
+    fn method<T>();
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddTraitBoundToMethodTypeParameter {
+    fn method<T: ReferenceTrait0>();
+}
+
+
+
+// Add builtin bound to method type parameter -------------------------------------
+#[cfg(cfail1)]
+trait TraitAddBuiltinBoundToMethodTypeParameter {
+    fn method<T>();
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddBuiltinBoundToMethodTypeParameter {
+    fn method<T: Sized>();
+}
+
+
+
+// Add lifetime bound to method type parameter ------------------------------------
+#[cfg(cfail1)]
+trait TraitAddLifetimeBoundToMethodTypeParameter {
+    fn method<'a, 'b>(a: &'a u32, b: &'b u32);
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddLifetimeBoundToMethodTypeParameter {
+    fn method<'a, 'b: 'a>(a: &'a u32, b: &'b u32);
+}
+
+
+
+// Add second trait bound to method type parameter --------------------------------
+#[cfg(cfail1)]
+trait TraitAddSecondTraitBoundToMethodTypeParameter {
+    fn method<T: ReferenceTrait0>();
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddSecondTraitBoundToMethodTypeParameter {
+    fn method<T: ReferenceTrait0 + ReferenceTrait1>();
+}
+
+
+
+// Add second builtin bound to method type parameter ------------------------------
+#[cfg(cfail1)]
+trait TraitAddSecondBuiltinBoundToMethodTypeParameter {
+    fn method<T: Sized>();
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddSecondBuiltinBoundToMethodTypeParameter {
+    fn method<T: Sized + Sync>();
+}
+
+
+
+// Add second lifetime bound to method type parameter -----------------------------
+#[cfg(cfail1)]
+trait TraitAddSecondLifetimeBoundToMethodTypeParameter {
+    fn method<'a, 'b, 'c>(a: &'a u32, b: &'b u32);
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddSecondLifetimeBoundToMethodTypeParameter {
+    fn method<'a, 'b, 'c: 'a + 'b>(a: &'a u32, b: &'b u32, c: &'c u32);
+}
+
+
+
+// Add associated type ------------------------------------------------------------
+#[cfg(cfail1)]
+trait TraitAddAssociatedType {
+    fn mathod();
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddAssociatedType {
+    type Associated;
+
+    fn mathod();
+}
+
+
+
+// Add trait bound to associated type ---------------------------------------------
+#[cfg(cfail1)]
+trait TraitAddTraitBoundToAssociatedType {
+    type Associated;
+
+    fn mathod();
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddTraitBoundToAssociatedType {
+    type Associated: ReferenceTrait0;
+
+    fn mathod();
+}
+
+
+
+// Add lifetime bound to associated type ------------------------------------------
+#[cfg(cfail1)]
+trait TraitAddLifetimeBoundToAssociatedType<'a> {
+    type Associated;
+
+    fn mathod();
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddLifetimeBoundToAssociatedType<'a> {
+    type Associated: 'a;
+
+    fn mathod();
+}
+
+
+
+// Add default to associated type -------------------------------------------------
+#[cfg(cfail1)]
+trait TraitAddDefaultToAssociatedType {
+    type Associated;
+
+    fn mathod();
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddDefaultToAssociatedType {
+    type Associated = ReferenceType0;
+
+    fn mathod();
+}
+
+
+
+// Add associated constant --------------------------------------------------------
+#[cfg(cfail1)]
+trait TraitAddAssociatedConstant {
+    fn mathod();
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddAssociatedConstant {
+    const Value: u32;
+
+    fn mathod();
+}
+
+
+
+// Add initializer to associated constant -----------------------------------------
+#[cfg(cfail1)]
+trait TraitAddInitializerToAssociatedConstant {
+    const Value: u32;
+
+    fn mathod();
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddInitializerToAssociatedConstant {
+    const Value: u32 = 1;
+
+    fn mathod();
+}
+
+
+
+// Change type of associated constant ---------------------------------------------
+#[cfg(cfail1)]
+trait TraitChangeTypeOfAssociatedConstant {
+    const Value: u32;
+
+    fn mathod();
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitChangeTypeOfAssociatedConstant {
+    const Value: f64;
+
+    fn mathod();
+}
+
+
+
+// Add super trait ----------------------------------------------------------------
+#[cfg(cfail1)]
+trait TraitAddSuperTrait { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddSuperTrait : ReferenceTrait0 { }
+
+
+
+// Add builtin bound (Send or Copy) -----------------------------------------------
+#[cfg(cfail1)]
+trait TraitAddBuiltiBound { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddBuiltiBound : Send { }
+
+
+
+// Add 'static lifetime bound to trait --------------------------------------------
+#[cfg(cfail1)]
+trait TraitAddStaticLifetimeBound { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddStaticLifetimeBound : 'static { }
+
+
+
+// Add super trait as second bound ------------------------------------------------
+#[cfg(cfail1)]
+trait TraitAddTraitAsSecondBound : ReferenceTrait0 { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddTraitAsSecondBound : ReferenceTrait0 + ReferenceTrait1 { }
+
+#[cfg(cfail1)]
+trait TraitAddTraitAsSecondBoundFromBuiltin : Send { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddTraitAsSecondBoundFromBuiltin : Send + ReferenceTrait0 { }
+
+
+
+// Add builtin bound as second bound ----------------------------------------------
+#[cfg(cfail1)]
+trait TraitAddBuiltinBoundAsSecondBound : ReferenceTrait0 { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddBuiltinBoundAsSecondBound : ReferenceTrait0 + Send { }
+
+#[cfg(cfail1)]
+trait TraitAddBuiltinBoundAsSecondBoundFromBuiltin : Send { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddBuiltinBoundAsSecondBoundFromBuiltin: Send + Copy { }
+
+
+
+// Add 'static bounds as second bound ---------------------------------------------
+#[cfg(cfail1)]
+trait TraitAddStaticBoundAsSecondBound : ReferenceTrait0 { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddStaticBoundAsSecondBound : ReferenceTrait0 + 'static { }
+
+#[cfg(cfail1)]
+trait TraitAddStaticBoundAsSecondBoundFromBuiltin : Send { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddStaticBoundAsSecondBoundFromBuiltin : Send + 'static { }
+
+
+
+// Add type parameter to trait ----------------------------------------------------
+#[cfg(cfail1)]
+trait TraitAddTypeParameterToTrait { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddTypeParameterToTrait<T> { }
+
+
+
+// Add lifetime parameter to trait ------------------------------------------------
+#[cfg(cfail1)]
+trait TraitAddLifetimeParameterToTrait { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddLifetimeParameterToTrait<'a> { }
+
+
+
+// Add trait bound to type parameter of trait -------------------------------------
+#[cfg(cfail1)]
+trait TraitAddTraitBoundToTypeParameterOfTrait<T> { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddTraitBoundToTypeParameterOfTrait<T: ReferenceTrait0> { }
+
+
+
+// Add lifetime bound to type parameter of trait ----------------------------------
+#[cfg(cfail1)]
+trait TraitAddLifetimeBoundToTypeParameterOfTrait<'a, T> { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddLifetimeBoundToTypeParameterOfTrait<'a, T: 'a> { }
+
+
+
+// Add lifetime bound to lifetime parameter of trait ------------------------------
+#[cfg(cfail1)]
+trait TraitAddLifetimeBoundToLifetimeParameterOfTrait<'a, 'b> { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddLifetimeBoundToLifetimeParameterOfTrait<'a: 'b, 'b> { }
+
+
+
+// Add builtin bound to type parameter of trait -----------------------------------
+#[cfg(cfail1)]
+trait TraitAddBuiltinBoundToTypeParameterOfTrait<T> { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddBuiltinBoundToTypeParameterOfTrait<T: Send> { }
+
+
+
+// Add second type parameter to trait ---------------------------------------------
+#[cfg(cfail1)]
+trait TraitAddSecondTypeParameterToTrait<T> { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddSecondTypeParameterToTrait<T, S> { }
+
+
+
+// Add second lifetime parameter to trait -----------------------------------------
+#[cfg(cfail1)]
+trait TraitAddSecondLifetimeParameterToTrait<'a> { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddSecondLifetimeParameterToTrait<'a, 'b> { }
+
+
+
+// Add second trait bound to type parameter of trait ------------------------------
+#[cfg(cfail1)]
+trait TraitAddSecondTraitBoundToTypeParameterOfTrait<T: ReferenceTrait0> { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddSecondTraitBoundToTypeParameterOfTrait<T: ReferenceTrait0 + ReferenceTrait1> { }
+
+
+
+// Add second lifetime bound to type parameter of trait ---------------------------
+#[cfg(cfail1)]
+trait TraitAddSecondLifetimeBoundToTypeParameterOfTrait<'a, 'b, T: 'a> { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddSecondLifetimeBoundToTypeParameterOfTrait<'a, 'b, T: 'a + 'b> { }
+
+
+
+// Add second lifetime bound to lifetime parameter of trait------------------------
+#[cfg(cfail1)]
+trait TraitAddSecondLifetimeBoundToLifetimeParameterOfTrait<'a: 'b, 'b, 'c> { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddSecondLifetimeBoundToLifetimeParameterOfTrait<'a: 'b + 'c, 'b, 'c> { }
+
+
+
+// Add second builtin bound to type parameter of trait ----------------------------
+#[cfg(cfail1)]
+trait TraitAddSecondBuiltinBoundToTypeParameterOfTrait<T: Send> { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddSecondBuiltinBoundToTypeParameterOfTrait<T: Send + Sync> { }
+
+
+
+// --------------------------------------------------------------------------------
+struct ReferenceType0 {}
+struct ReferenceType1 {}
+
+
+
+// Add trait bound to type parameter of trait in where clause----------------------
+#[cfg(cfail1)]
+trait TraitAddTraitBoundToTypeParameterOfTraitWhere<T> { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddTraitBoundToTypeParameterOfTraitWhere<T> where T: ReferenceTrait0 { }
+
+
+
+// Add lifetime bound to type parameter of trait in where clause-------------------
+#[cfg(cfail1)]
+trait TraitAddLifetimeBoundToTypeParameterOfTraitWhere<'a, T> { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddLifetimeBoundToTypeParameterOfTraitWhere<'a, T> where T: 'a { }
+
+
+
+// Add lifetime bound to lifetime parameter of trait in where clause---------------
+#[cfg(cfail1)]
+trait TraitAddLifetimeBoundToLifetimeParameterOfTraitWhere<'a, 'b> { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddLifetimeBoundToLifetimeParameterOfTraitWhere<'a, 'b> where 'a: 'b { }
+
+
+
+// Add builtin bound to type parameter of trait in where clause--------------------
+#[cfg(cfail1)]
+trait TraitAddBuiltinBoundToTypeParameterOfTraitWhere<T> { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddBuiltinBoundToTypeParameterOfTraitWhere<T> where T: Send { }
+
+
+
+// Add second trait bound to type parameter of trait in where clause---------------
+#[cfg(cfail1)]
+trait TraitAddSecondTraitBoundToTypeParameterOfTraitWhere<T> where T: ReferenceTrait0 { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddSecondTraitBoundToTypeParameterOfTraitWhere<T> where T: ReferenceTrait0 + ReferenceTrait1 { }
+
+
+
+// Add second lifetime bound to type parameter of trait in where clause------------
+#[cfg(cfail1)]
+trait TraitAddSecondLifetimeBoundToTypeParameterOfTraitWhere<'a, 'b, T> where T: 'a { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddSecondLifetimeBoundToTypeParameterOfTraitWhere<'a, 'b, T> where T: 'a + 'b { }
+
+
+
+// Add second lifetime bound to lifetime parameter of trait in where clause--------
+#[cfg(cfail1)]
+trait TraitAddSecondLifetimeBoundToLifetimeParameterOfTraitWhere<'a, 'b, 'c> where 'a: 'b { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddSecondLifetimeBoundToLifetimeParameterOfTraitWhere<'a, 'b, 'c> where 'a: 'b + 'c { }
+
+
+
+// Add second builtin bound to type parameter of trait in where clause-------------
+#[cfg(cfail1)]
+trait TraitAddSecondBuiltinBoundToTypeParameterOfTraitWhere<T> where T: Send { }
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+trait TraitAddSecondBuiltinBoundToTypeParameterOfTraitWhere<T> where T: Send + Sync { }
+
+
+
+// EDIT: Some more cases ----------------------------------------------------------
+
+// Change return type of method indirectly by modifying a use statement------------
+mod change_return_type_of_method_indirectly_use {
+    #[cfg(cfail1)]
+    use super::ReferenceType0 as ReturnType;
+    #[cfg(not(cfail1))]
+    use super::ReferenceType1 as ReturnType;
+
+    #[rustc_dirty(label="Hir", cfg="cfail2")]
+    #[rustc_clean(label="Hir", cfg="cfail3")]
+    #[rustc_metadata_dirty(cfg="cfail2")]
+    #[rustc_metadata_clean(cfg="cfail3")]
+    trait TraitChangeReturnType {
+        fn method() -> ReturnType;
+    }
+}
+
+
+
+// Change type of method parameter indirectly by modifying a use statement---------
+mod change_method_parameter_type_indirectly_by_use {
+    #[cfg(cfail1)]
+    use super::ReferenceType0 as ArgType;
+    #[cfg(not(cfail1))]
+    use super::ReferenceType1 as ArgType;
+
+    #[rustc_dirty(label="Hir", cfg="cfail2")]
+    #[rustc_clean(label="Hir", cfg="cfail3")]
+    #[rustc_metadata_dirty(cfg="cfail2")]
+    #[rustc_metadata_clean(cfg="cfail3")]
+    trait TraitChangeArgType {
+        fn method(a: ArgType);
+    }
+}
+
+
+
+// Change trait bound of method type parameter indirectly by modifying a use statement
+mod change_method_parameter_type_bound_indirectly_by_use {
+    #[cfg(cfail1)]
+    use super::ReferenceTrait0 as Bound;
+    #[cfg(not(cfail1))]
+    use super::ReferenceTrait1 as Bound;
+
+    #[rustc_dirty(label="Hir", cfg="cfail2")]
+    #[rustc_clean(label="Hir", cfg="cfail3")]
+    #[rustc_metadata_dirty(cfg="cfail2")]
+    #[rustc_metadata_clean(cfg="cfail3")]
+    trait TraitChangeBoundOfMethodTypeParameter {
+        fn method<T: Bound>(a: T);
+    }
+}
+
+
+
+// Change trait bound of method type parameter in where clause indirectly by modifying a use statement
+mod change_method_parameter_type_bound_indirectly_by_use_where {
+    #[cfg(cfail1)]
+    use super::ReferenceTrait0 as Bound;
+    #[cfg(not(cfail1))]
+    use super::ReferenceTrait1 as Bound;
+
+    #[rustc_dirty(label="Hir", cfg="cfail2")]
+    #[rustc_clean(label="Hir", cfg="cfail3")]
+    #[rustc_metadata_dirty(cfg="cfail2")]
+    #[rustc_metadata_clean(cfg="cfail3")]
+    trait TraitChangeBoundOfMethodTypeParameterWhere {
+        fn method<T>(a: T) where T: Bound;
+    }
+}
+
+
+
+// Change trait bound of trait type parameter indirectly by modifying a use statement
+mod change_method_type_parameter_bound_indirectly {
+    #[cfg(cfail1)]
+    use super::ReferenceTrait0 as Bound;
+    #[cfg(not(cfail1))]
+    use super::ReferenceTrait1 as Bound;
+
+    #[rustc_dirty(label="Hir", cfg="cfail2")]
+    #[rustc_clean(label="Hir", cfg="cfail3")]
+    #[rustc_metadata_dirty(cfg="cfail2")]
+    #[rustc_metadata_clean(cfg="cfail3")]
+    trait TraitChangeTraitBound<T: Bound> {
+        fn method(a: T);
+    }
+}
+
+
+
+// Change trait bound of trait type parameter in where clause indirectly by modifying a use statement
+mod change_method_type_parameter_bound_indirectly_where {
+    #[cfg(cfail1)]
+    use super::ReferenceTrait0 as Bound;
+    #[cfg(not(cfail1))]
+    use super::ReferenceTrait1 as Bound;
+
+    #[rustc_dirty(label="Hir", cfg="cfail2")]
+    #[rustc_clean(label="Hir", cfg="cfail3")]
+    #[rustc_metadata_dirty(cfg="cfail2")]
+    #[rustc_metadata_clean(cfg="cfail3")]
+    trait TraitChangeTraitBoundWhere<T> where T: Bound {
+        fn method(a: T);
+    }
+}
+

--- a/src/test/incremental/hashes/trait_defs.rs
+++ b/src/test/incremental/hashes/trait_defs.rs
@@ -964,7 +964,8 @@ trait TraitAddSecondTraitBoundToTypeParameterOfTraitWhere<T> where T: ReferenceT
 #[rustc_clean(label="Hir", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
-trait TraitAddSecondTraitBoundToTypeParameterOfTraitWhere<T> where T: ReferenceTrait0 + ReferenceTrait1 { }
+trait TraitAddSecondTraitBoundToTypeParameterOfTraitWhere<T>
+    where T: ReferenceTrait0 + ReferenceTrait1 { }
 
 
 
@@ -1063,7 +1064,8 @@ mod change_method_parameter_type_bound_indirectly_by_use {
 
 
 
-// Change trait bound of method type parameter in where clause indirectly by modifying a use statement
+// Change trait bound of method type parameter in where clause indirectly
+// by modifying a use statement
 mod change_method_parameter_type_bound_indirectly_by_use_where {
     #[cfg(cfail1)]
     use super::ReferenceTrait0 as Bound;
@@ -1099,7 +1101,8 @@ mod change_method_type_parameter_bound_indirectly {
 
 
 
-// Change trait bound of trait type parameter in where clause indirectly by modifying a use statement
+// Change trait bound of trait type parameter in where clause indirectly
+// by modifying a use statement
 mod change_method_type_parameter_bound_indirectly_where {
     #[cfg(cfail1)]
     use super::ReferenceTrait0 as Bound;

--- a/src/test/incremental/hashes/trait_defs.rs
+++ b/src/test/incremental/hashes/trait_defs.rs
@@ -84,6 +84,7 @@ trait TraitChangeMethodName {
 #[cfg(not(cfail1))]
 #[rustc_dirty(label="Hir", cfg="cfail2")]
 #[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 trait TraitChangeMethodName {
     fn methodChanged();
@@ -197,7 +198,7 @@ trait TraitChangeMethodParameterType {
 // Change order of method parameters ----------------------------------------------
 #[cfg(cfail1)]
 trait TraitChangeMethodParametersOrder {
-    fn method(a: i32, b: i32);
+    fn method(a: i32, b: i64);
 }
 
 #[cfg(not(cfail1))]
@@ -206,7 +207,7 @@ trait TraitChangeMethodParametersOrder {
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 trait TraitChangeMethodParametersOrder {
-    fn method(b: i32, a: i32);
+    fn method(b: i64, a: i32);
 }
 
 
@@ -385,8 +386,8 @@ trait TraitAddLifetimeParameterToMethod {
 
 
 // dummy trait for bound
-trait ReferenceTrait0 { }
-trait ReferenceTrait1 { }
+trait ReferencedTrait0 { }
+trait ReferencedTrait1 { }
 
 // Add trait bound to method type parameter ---------------------------------------
 #[cfg(cfail1)]
@@ -400,7 +401,7 @@ trait TraitAddTraitBoundToMethodTypeParameter {
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 trait TraitAddTraitBoundToMethodTypeParameter {
-    fn method<T: ReferenceTrait0>();
+    fn method<T: ReferencedTrait0>();
 }
 
 
@@ -442,7 +443,7 @@ trait TraitAddLifetimeBoundToMethodTypeParameter {
 // Add second trait bound to method type parameter --------------------------------
 #[cfg(cfail1)]
 trait TraitAddSecondTraitBoundToMethodTypeParameter {
-    fn method<T: ReferenceTrait0>();
+    fn method<T: ReferencedTrait0>();
 }
 
 #[cfg(not(cfail1))]
@@ -451,7 +452,7 @@ trait TraitAddSecondTraitBoundToMethodTypeParameter {
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 trait TraitAddSecondTraitBoundToMethodTypeParameter {
-    fn method<T: ReferenceTrait0 + ReferenceTrait1>();
+    fn method<T: ReferencedTrait0 + ReferencedTrait1>();
 }
 
 
@@ -476,7 +477,7 @@ trait TraitAddSecondBuiltinBoundToMethodTypeParameter {
 // Add second lifetime bound to method type parameter -----------------------------
 #[cfg(cfail1)]
 trait TraitAddSecondLifetimeBoundToMethodTypeParameter {
-    fn method<'a, 'b, 'c>(a: &'a u32, b: &'b u32);
+    fn method<'a, 'b, 'c: 'a>(a: &'a u32, b: &'b u32);
 }
 
 #[cfg(not(cfail1))]
@@ -523,7 +524,7 @@ trait TraitAddTraitBoundToAssociatedType {
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 trait TraitAddTraitBoundToAssociatedType {
-    type Associated: ReferenceTrait0;
+    type Associated: ReferencedTrait0;
 
     fn mathod();
 }
@@ -642,7 +643,7 @@ trait TraitAddSuperTrait { }
 #[rustc_clean(label="Hir", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
-trait TraitAddSuperTrait : ReferenceTrait0 { }
+trait TraitAddSuperTrait : ReferencedTrait0 { }
 
 
 
@@ -674,14 +675,14 @@ trait TraitAddStaticLifetimeBound : 'static { }
 
 // Add super trait as second bound ------------------------------------------------
 #[cfg(cfail1)]
-trait TraitAddTraitAsSecondBound : ReferenceTrait0 { }
+trait TraitAddTraitAsSecondBound : ReferencedTrait0 { }
 
 #[cfg(not(cfail1))]
 #[rustc_dirty(label="Hir", cfg="cfail2")]
 #[rustc_clean(label="Hir", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
-trait TraitAddTraitAsSecondBound : ReferenceTrait0 + ReferenceTrait1 { }
+trait TraitAddTraitAsSecondBound : ReferencedTrait0 + ReferencedTrait1 { }
 
 #[cfg(cfail1)]
 trait TraitAddTraitAsSecondBoundFromBuiltin : Send { }
@@ -691,20 +692,20 @@ trait TraitAddTraitAsSecondBoundFromBuiltin : Send { }
 #[rustc_clean(label="Hir", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
-trait TraitAddTraitAsSecondBoundFromBuiltin : Send + ReferenceTrait0 { }
+trait TraitAddTraitAsSecondBoundFromBuiltin : Send + ReferencedTrait0 { }
 
 
 
 // Add builtin bound as second bound ----------------------------------------------
 #[cfg(cfail1)]
-trait TraitAddBuiltinBoundAsSecondBound : ReferenceTrait0 { }
+trait TraitAddBuiltinBoundAsSecondBound : ReferencedTrait0 { }
 
 #[cfg(not(cfail1))]
 #[rustc_dirty(label="Hir", cfg="cfail2")]
 #[rustc_clean(label="Hir", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
-trait TraitAddBuiltinBoundAsSecondBound : ReferenceTrait0 + Send { }
+trait TraitAddBuiltinBoundAsSecondBound : ReferencedTrait0 + Send { }
 
 #[cfg(cfail1)]
 trait TraitAddBuiltinBoundAsSecondBoundFromBuiltin : Send { }
@@ -720,14 +721,14 @@ trait TraitAddBuiltinBoundAsSecondBoundFromBuiltin: Send + Copy { }
 
 // Add 'static bounds as second bound ---------------------------------------------
 #[cfg(cfail1)]
-trait TraitAddStaticBoundAsSecondBound : ReferenceTrait0 { }
+trait TraitAddStaticBoundAsSecondBound : ReferencedTrait0 { }
 
 #[cfg(not(cfail1))]
 #[rustc_dirty(label="Hir", cfg="cfail2")]
 #[rustc_clean(label="Hir", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
-trait TraitAddStaticBoundAsSecondBound : ReferenceTrait0 + 'static { }
+trait TraitAddStaticBoundAsSecondBound : ReferencedTrait0 + 'static { }
 
 #[cfg(cfail1)]
 trait TraitAddStaticBoundAsSecondBoundFromBuiltin : Send { }
@@ -776,7 +777,7 @@ trait TraitAddTraitBoundToTypeParameterOfTrait<T> { }
 #[rustc_clean(label="Hir", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
-trait TraitAddTraitBoundToTypeParameterOfTrait<T: ReferenceTrait0> { }
+trait TraitAddTraitBoundToTypeParameterOfTrait<T: ReferencedTrait0> { }
 
 
 
@@ -847,14 +848,14 @@ trait TraitAddSecondLifetimeParameterToTrait<'a, 'b> { }
 
 // Add second trait bound to type parameter of trait ------------------------------
 #[cfg(cfail1)]
-trait TraitAddSecondTraitBoundToTypeParameterOfTrait<T: ReferenceTrait0> { }
+trait TraitAddSecondTraitBoundToTypeParameterOfTrait<T: ReferencedTrait0> { }
 
 #[cfg(not(cfail1))]
 #[rustc_dirty(label="Hir", cfg="cfail2")]
 #[rustc_clean(label="Hir", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
-trait TraitAddSecondTraitBoundToTypeParameterOfTrait<T: ReferenceTrait0 + ReferenceTrait1> { }
+trait TraitAddSecondTraitBoundToTypeParameterOfTrait<T: ReferencedTrait0 + ReferencedTrait1> { }
 
 
 
@@ -912,7 +913,7 @@ trait TraitAddTraitBoundToTypeParameterOfTraitWhere<T> { }
 #[rustc_clean(label="Hir", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
-trait TraitAddTraitBoundToTypeParameterOfTraitWhere<T> where T: ReferenceTrait0 { }
+trait TraitAddTraitBoundToTypeParameterOfTraitWhere<T> where T: ReferencedTrait0 { }
 
 
 
@@ -957,7 +958,7 @@ trait TraitAddBuiltinBoundToTypeParameterOfTraitWhere<T> where T: Send { }
 
 // Add second trait bound to type parameter of trait in where clause---------------
 #[cfg(cfail1)]
-trait TraitAddSecondTraitBoundToTypeParameterOfTraitWhere<T> where T: ReferenceTrait0 { }
+trait TraitAddSecondTraitBoundToTypeParameterOfTraitWhere<T> where T: ReferencedTrait0 { }
 
 #[cfg(not(cfail1))]
 #[rustc_dirty(label="Hir", cfg="cfail2")]
@@ -965,7 +966,7 @@ trait TraitAddSecondTraitBoundToTypeParameterOfTraitWhere<T> where T: ReferenceT
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
 trait TraitAddSecondTraitBoundToTypeParameterOfTraitWhere<T>
-    where T: ReferenceTrait0 + ReferenceTrait1 { }
+    where T: ReferencedTrait0 + ReferencedTrait1 { }
 
 
 
@@ -1049,9 +1050,9 @@ mod change_method_parameter_type_indirectly_by_use {
 // Change trait bound of method type parameter indirectly by modifying a use statement
 mod change_method_parameter_type_bound_indirectly_by_use {
     #[cfg(cfail1)]
-    use super::ReferenceTrait0 as Bound;
+    use super::ReferencedTrait0 as Bound;
     #[cfg(not(cfail1))]
-    use super::ReferenceTrait1 as Bound;
+    use super::ReferencedTrait1 as Bound;
 
     #[rustc_dirty(label="Hir", cfg="cfail2")]
     #[rustc_clean(label="Hir", cfg="cfail3")]
@@ -1068,9 +1069,9 @@ mod change_method_parameter_type_bound_indirectly_by_use {
 // by modifying a use statement
 mod change_method_parameter_type_bound_indirectly_by_use_where {
     #[cfg(cfail1)]
-    use super::ReferenceTrait0 as Bound;
+    use super::ReferencedTrait0 as Bound;
     #[cfg(not(cfail1))]
-    use super::ReferenceTrait1 as Bound;
+    use super::ReferencedTrait1 as Bound;
 
     #[rustc_dirty(label="Hir", cfg="cfail2")]
     #[rustc_clean(label="Hir", cfg="cfail3")]
@@ -1086,9 +1087,9 @@ mod change_method_parameter_type_bound_indirectly_by_use_where {
 // Change trait bound of trait type parameter indirectly by modifying a use statement
 mod change_method_type_parameter_bound_indirectly {
     #[cfg(cfail1)]
-    use super::ReferenceTrait0 as Bound;
+    use super::ReferencedTrait0 as Bound;
     #[cfg(not(cfail1))]
-    use super::ReferenceTrait1 as Bound;
+    use super::ReferencedTrait1 as Bound;
 
     #[rustc_dirty(label="Hir", cfg="cfail2")]
     #[rustc_clean(label="Hir", cfg="cfail3")]
@@ -1105,9 +1106,9 @@ mod change_method_type_parameter_bound_indirectly {
 // by modifying a use statement
 mod change_method_type_parameter_bound_indirectly_where {
     #[cfg(cfail1)]
-    use super::ReferenceTrait0 as Bound;
+    use super::ReferencedTrait0 as Bound;
     #[cfg(not(cfail1))]
-    use super::ReferenceTrait1 as Bound;
+    use super::ReferencedTrait1 as Bound;
 
     #[rustc_dirty(label="Hir", cfg="cfail2")]
     #[rustc_clean(label="Hir", cfg="cfail3")]

--- a/src/test/incremental/hashes/trait_defs.rs
+++ b/src/test/incremental/hashes/trait_defs.rs
@@ -423,9 +423,9 @@ trait TraitAddBuiltinBoundToMethodTypeParameter {
 
 
 
-// Add lifetime bound to method type parameter ------------------------------------
+// Add lifetime bound to method lifetime parameter ------------------------------------
 #[cfg(cfail1)]
-trait TraitAddLifetimeBoundToMethodTypeParameter {
+trait TraitAddLifetimeBoundToMethodLifetimeParameter {
     fn method<'a, 'b>(a: &'a u32, b: &'b u32);
 }
 
@@ -434,7 +434,7 @@ trait TraitAddLifetimeBoundToMethodTypeParameter {
 #[rustc_clean(label="Hir", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
-trait TraitAddLifetimeBoundToMethodTypeParameter {
+trait TraitAddLifetimeBoundToMethodLifetimeParameter {
     fn method<'a, 'b: 'a>(a: &'a u32, b: &'b u32);
 }
 
@@ -474,9 +474,9 @@ trait TraitAddSecondBuiltinBoundToMethodTypeParameter {
 
 
 
-// Add second lifetime bound to method type parameter -----------------------------
+// Add second lifetime bound to method lifetime parameter -----------------------------
 #[cfg(cfail1)]
-trait TraitAddSecondLifetimeBoundToMethodTypeParameter {
+trait TraitAddSecondLifetimeBoundToMethodLifetimeParameter {
     fn method<'a, 'b, 'c: 'a>(a: &'a u32, b: &'b u32, c: &'c u32);
 }
 
@@ -485,7 +485,7 @@ trait TraitAddSecondLifetimeBoundToMethodTypeParameter {
 #[rustc_clean(label="Hir", cfg="cfail3")]
 #[rustc_metadata_dirty(cfg="cfail2")]
 #[rustc_metadata_clean(cfg="cfail3")]
-trait TraitAddSecondLifetimeBoundToMethodTypeParameter {
+trait TraitAddSecondLifetimeBoundToMethodLifetimeParameter {
     fn method<'a, 'b, 'c: 'a + 'b>(a: &'a u32, b: &'b u32, c: &'c u32);
 }
 


### PR DESCRIPTION
Fixes #36681
Part of #36350

Currently, the following tests fail:

Unsafe modifier
Extern modifier
Extern c to rust-intrinsic
Trait unsafety
Change type of method parameter (&i32 => &mut i32)
Mode of self parameter

r? @michaelwoerister 
