### PR TITLE
force `i1` booleans to `i8` when comparing

### DIFF
--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -308,7 +308,16 @@ pub fn compare_scalar_types<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                 _ => bug!("compare_scalar_types: must be a comparison operator"),
             }
         }
-        ty::TyFnDef(..) | ty::TyFnPtr(_) | ty::TyBool | ty::TyUint(_) | ty::TyChar => {
+        ty::TyBool => {
+            // FIXME(#36856) -- using `from_immediate` forces these booleans into `i8`,
+            // which works around some LLVM bugs
+            ICmp(bcx,
+                 bin_op_to_icmp_predicate(op, false),
+                 from_immediate(bcx, lhs),
+                 from_immediate(bcx, rhs),
+                 debug_loc)
+        }
+        ty::TyFnDef(..) | ty::TyFnPtr(_) | ty::TyUint(_) | ty::TyChar => {
             ICmp(bcx,
                  bin_op_to_icmp_predicate(op, false),
                  lhs,

--- a/src/test/run-pass/issue-36856.rs
+++ b/src/test/run-pass/issue-36856.rs
@@ -1,0 +1,24 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for #36856.
+
+// compile-flags:-g
+
+fn g() -> bool {
+    false
+}
+
+pub fn main() {
+    let a = !g();
+    if a != !g() {
+        panic!();
+    }
+}


### PR DESCRIPTION
Work around LLVM bug.

cc #36856

r? @eddyb 
