### PR TITLE
rustdoc: Fix missing *mut T impl

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -301,8 +301,8 @@ pub fn build_impls<'a, 'tcx>(cx: &DocContext,
         tcx.lang_items.char_impl(),
         tcx.lang_items.str_impl(),
         tcx.lang_items.slice_impl(),
-        tcx.lang_items.slice_impl(),
-        tcx.lang_items.const_ptr_impl()
+        tcx.lang_items.const_ptr_impl(),
+        tcx.lang_items.mut_ptr_impl(),
     ];
 
     for def_id in primitive_impls.iter().filter_map(|&def_id| def_id) {


### PR DESCRIPTION
`impl<T> *mut T` is currently missing from
https://doc.rust-lang.org/nightly/std/primitive.pointer.html and this adds
it back.
