### PR TITLE
Fix rustbuild per-target musl root

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -90,16 +90,16 @@ pub fn std_link(build: &Build,
     add_to_sysroot(&out_dir, &libdir);
 
     if target.contains("musl") && !target.contains("mips") {
-        copy_musl_third_party_objects(build, &libdir);
+        copy_musl_third_party_objects(build, target, &libdir);
     }
 }
 
 /// Copies the crt(1,i,n).o startup objects
 ///
 /// Only required for musl targets that statically link to libc
-fn copy_musl_third_party_objects(build: &Build, into: &Path) {
+fn copy_musl_third_party_objects(build: &Build, target: &str, into: &Path) {
     for &obj in &["crt1.o", "crti.o", "crtn.o"] {
-        copy(&build.config.musl_root.as_ref().unwrap().join("lib").join(obj), &into.join(obj));
+        copy(&build.musl_root(target).unwrap().join("lib").join(obj), &into.join(obj));
     }
 }
 

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -158,6 +158,7 @@ struct TomlTarget {
     cc: Option<String>,
     cxx: Option<String>,
     android_ndk: Option<String>,
+    musl_root: Option<String>,
 }
 
 impl Config {
@@ -268,6 +269,7 @@ impl Config {
                 }
                 target.cxx = cfg.cxx.clone().map(PathBuf::from);
                 target.cc = cfg.cc.clone().map(PathBuf::from);
+                target.musl_root = cfg.musl_root.clone().map(PathBuf::from);
 
                 config.target_config.insert(triple.clone(), target);
             }

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -146,8 +146,8 @@ pub fn check(build: &mut Build) {
                     }
                 }
                 None => {
-                    panic!("when targeting MUSL either the build.musl-root \
-                            option or the target.$TARGET.musl-root one must \
+                    panic!("when targeting MUSL either the rust.musl-root \
+                            option or the target.$TARGET.musl-root option must \
                             be specified in config.toml")
                 }
             }


### PR DESCRIPTION
In #36292, support was added to target musl libc for ARM targets using rustbuild. Specifically, that change allowed the addition of per-target `musl-root` options in the rustbuild `config.toml` so that multiple targets depending on musl could be built. However, that implementation contained a couple of omissions: the `musl-root` option was added to the config, but was never added to the TOML parsing, and therefore was not actually being loaded from `config.toml`. This PR rectifies that.

Using these changes and a heavily modified version of the buildbot Docker container, I have been able to build rust targeting `armv7-unknown-linux-musleabihf` and have successfully run the binaries on a Raspberry Pi 3. I'm also planning to test `arm-unknown-linux-musleabi` and `arm-unknown-linux-musleabihf` systems, but have no reason to believe that this change would not simply work on those targets.
