### PR TITLE
Don't enqueue onto a disabled dep_graph.

### DIFF
--- a/src/librustc/dep_graph/shadow.rs
+++ b/src/librustc/dep_graph/shadow.rs
@@ -64,6 +64,11 @@ impl ShadowGraph {
         }
     }
 
+    #[inline]
+    pub fn enabled(&self) -> bool {
+        ENABLED
+    }
+
     pub fn enqueue(&self, message: &DepMessage) {
         if ENABLED {
             match self.stack.borrow_state() {


### PR DESCRIPTION
This commit guards all calls to `DepGraphThreadData::enqueue` with a
check to make sure it is enabled. This avoids some useless allocation
and vector manipulations when it is disabled (i.e. when incremental
compilation is off) which improves speed by 1--2% on most of the
rustc-benchmarks.

This commit has an observable functional change: when the dep_graph is
disabled its `shadow_graph` will no longer receive messages. This should
be ok because these message are only used when debug assertions are
enabled.

r? @nikomatsakis 
