### PR TITLE
Fixed small typo in `BufRead` comments

### DIFF
--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -231,7 +231,7 @@ impl<R: Seek> Seek for BufReader<R> {
         if let SeekFrom::Current(n) = pos {
             let remainder = (self.cap - self.pos) as i64;
             // it should be safe to assume that remainder fits within an i64 as the alternative
-            // means we managed to allocate 8 ebibytes and that's absurd.
+            // means we managed to allocate 8 exbibytes and that's absurd.
             // But it's not out of the realm of possibility for some weird underlying reader to
             // support seeking by i64::min_value() so we need to handle underflow when subtracting
             // remainder.


### PR DESCRIPTION
`BufRead` comments, in the `Seek` trait implementation, was talking about allocating 8 _ebibytes_. It was a typo, the correct unit is _exbibytes_, since _ebibytes_ don't even exist.   The calculation is correct, though.
