### PR TITLE
std: Minor cleanup to libtest

### DIFF
--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -443,7 +443,7 @@ impl Collector {
                 // compiler failures are test failures
                 should_panic: testing::ShouldPanic::No,
             },
-            testfn: testing::DynTestFn(box move|| {
+            testfn: testing::DynTestFn(box move |()| {
                 runtest(&test,
                         &cratename,
                         cfgs,

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -464,7 +464,7 @@ pub fn make_test_name(config: &Config, testpaths: &TestPaths) -> test::TestName 
 pub fn make_test_closure(config: &Config, testpaths: &TestPaths) -> test::TestFn {
     let config = config.clone();
     let testpaths = testpaths.clone();
-    test::DynTestFn(Box::new(move || {
+    test::DynTestFn(Box::new(move |()| {
         runtest::run(config, &testpaths)
     }))
 }


### PR DESCRIPTION
- Don't spawn two threads for all tests, just one now that `catch_unwind` is
  stable.
- Remove usage of the unstable `box` keyword
- Remove usage of the unstable `FnBox` trait
