### PR TITLE
Remove obsolete special case for windows

### DIFF
--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -213,16 +213,7 @@ pub fn stdin() -> Stdin {
             Ok(stdin) => Maybe::Real(stdin),
             _ => Maybe::Fake
         };
-
-        // The default buffer capacity is 64k, but apparently windows
-        // doesn't like 64k reads on stdin. See #13304 for details, but the
-        // idea is that on windows we use a slightly smaller buffer that's
-        // been seen to be acceptable.
-        Arc::new(Mutex::new(if cfg!(windows) {
-            BufReader::with_capacity(8 * 1024, stdin)
-        } else {
-            BufReader::new(stdin)
-        }))
+        Arc::new(Mutex::new(BufReader::new(stdin)))
     }
 }
 


### PR DESCRIPTION
DEFAULT_BUF_SIZE is now 8KB, so we don't need special handling for windows
