### PR TITLE
Always statically link llvm

### DIFF
--- a/src/librustc_llvm/build.rs
+++ b/src/librustc_llvm/build.rs
@@ -128,7 +128,7 @@ fn main() {
     // we don't pick up system libs because unfortunately they're for the host
     // of llvm-config, not the target that we're attempting to link.
     let mut cmd = Command::new(&llvm_config);
-    cmd.arg("--libs");
+    cmd.args(&["--libs", "--link-static"]);
     if !is_crossed {
         cmd.arg("--system-libs");
     }


### PR DESCRIPTION
As suggested we basically always want to link LLVM statically.

Closes #36854
