### PR TITLE
rustbuild: Fix dependencies of check-docs step

### DIFF
--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -524,7 +524,7 @@ impl<'a> Step<'a> {
                      self.target(compiler.host).tool_compiletest(compiler.stage)]
             }
             Source::CheckDocs { compiler } => {
-                vec![self.libstd(compiler)]
+                vec![self.libtest(compiler)]
             }
             Source::CheckErrorIndex { compiler } => {
                 vec![self.libstd(compiler),


### PR DESCRIPTION
Some of the doc tests depend on `extern crate test`, so depend on libtest
instead of libstd here.
