### PR TITLE
Add comparison operators to boolean const eval.

### DIFF
--- a/src/librustc_const_eval/eval.rs
+++ b/src/librustc_const_eval/eval.rs
@@ -732,6 +732,10 @@ pub fn eval_const_expr_partial<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
               hir::BiBitOr => a | b,
               hir::BiEq => a == b,
               hir::BiNe => a != b,
+              hir::BiLt => a < b,
+              hir::BiLe => a <= b,
+              hir::BiGe => a >= b,
+              hir::BiGt => a > b,
               _ => signal!(e, InvalidOpForBools(op.node)),
              })
           }

--- a/src/test/run-pass/const-err.rs
+++ b/src/test/run-pass/const-err.rs
@@ -17,4 +17,8 @@ const X: *const u8 = b"" as _;
 fn main() {
     let _ = ((-1 as i8) << 8 - 1) as f32;
     let _ = 0u8 as char;
+    let _ = true > false;
+    let _ = true >= false;
+    let _ = true < false;
+    let _ = true >= false;
 }


### PR DESCRIPTION
I think it might be worth adding tests here, but since I don't know how or where to do that, I have not done so yet. Willing to do so if asked and given an explanation as to how.

Fixes #37047.
