### PR TITLE
Remove long diagnostic for E0002

### DIFF
--- a/src/librustc_const_eval/diagnostics.rs
+++ b/src/librustc_const_eval/diagnostics.rs
@@ -40,37 +40,6 @@ Ensure the ordering of the match arm is correct and remove any superfluous
 arms.
 "##,
 
-E0002: r##"
-This error indicates that an empty match expression is invalid because the type
-it is matching on is non-empty (there exist values of this type). In safe code
-it is impossible to create an instance of an empty type, so empty match
-expressions are almost never desired. This error is typically fixed by adding
-one or more cases to the match expression.
-
-An example of an empty type is `enum Empty { }`. So, the following will work:
-
-```
-enum Empty {}
-
-fn foo(x: Empty) {
-    match x {
-        // empty
-    }
-}
-```
-
-However, this won't:
-
-```compile_fail
-fn foo(x: Option<String>) {
-    match x {
-        // empty
-    }
-}
-```
-"##,
-
-
 E0003: r##"
 Not-a-Number (NaN) values cannot be compared for equality and hence can never
 match the input to a match expression. So, the following will not compile:


### PR DESCRIPTION
E0002 was merged into E0004 in #36909, and the long diagnostic for E0004 is sufficient to cover empty match expressions.

cc @GuillaumeGomez

r? @jonathandturner
