### PR TITLE
[beta] Temporary fix for metadata decoding for struct constructors

### DIFF
--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -534,8 +534,16 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 report_unexpected_def();
                 return tcx.types.err;
             }
-            Def::Variant(..) | Def::Struct(..) => {
+            Def::Variant(..) => {
                 let variant = tcx.expect_variant_def(def);
+                if variant.kind != VariantKind::Unit {
+                    report_unexpected_def();
+                    return tcx.types.err;
+                }
+            }
+            Def::Struct(ctor_did) => {
+                let did = tcx.parent_def_id(ctor_did).expect("struct ctor has no parent");
+                let variant = tcx.lookup_adt_def(did).struct_variant();
                 if variant.kind != VariantKind::Unit {
                     report_unexpected_def();
                     return tcx.types.err;
@@ -589,8 +597,12 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 report_unexpected_def(false);
                 return tcx.types.err;
             }
-            Def::Variant(..) | Def::Struct(..) => {
+            Def::Variant(..) => {
                 tcx.expect_variant_def(def)
+            }
+            Def::Struct(ctor_did) => {
+                let did = tcx.parent_def_id(ctor_did).expect("struct ctor has no parent");
+                tcx.lookup_adt_def(did).struct_variant()
             }
             _ => bug!("unexpected pattern definition {:?}", def)
         };


### PR DESCRIPTION
I'll try to do something better for nightly. Ideally, metadata lookup functions should "just work" for constructor ids.

cc https://github.com/rust-lang/rust/issues/37026
r? @brson 

Backport of https://github.com/rust-lang/rust/pull/37095
