### PR TITLE
Changed 0 into '0'

### DIFF
--- a/src/libcollections/fmt.rs
+++ b/src/libcollections/fmt.rs
@@ -327,7 +327,7 @@
 //! format := '{' [ argument ] [ ':' format_spec ] '}'
 //! argument := integer | identifier
 //!
-//! format_spec := [[fill]align][sign]['#'][0][width]['.' precision][type]
+//! format_spec := [[fill]align][sign]['#']['0'][width]['.' precision][type]
 //! fill := character
 //! align := '<' | '^' | '>'
 //! sign := '+' | '-'


### PR DESCRIPTION
Currently `0` is an undefined production rule.
[Documentation following the grammar specification](https://doc.rust-lang.org/nightly/std/fmt/#sign0) strongly suggests `'0'` is meant as it is used as a character literal.

r? @steveklabnik
