### PR TITLE
Inline read_{un,}signed_leb128 and opaque::Decoder functions.

### DIFF
--- a/src/libserialize/leb128.rs
+++ b/src/libserialize/leb128.rs
@@ -38,6 +38,7 @@ pub fn write_unsigned_leb128(out: &mut Vec<u8>, start_position: usize, mut value
     return position - start_position;
 }
 
+#[inline]
 pub fn read_unsigned_leb128(data: &[u8], start_position: usize) -> (u64, usize) {
     let mut result = 0;
     let mut shift = 0;
@@ -78,6 +79,7 @@ pub fn write_signed_leb128(out: &mut Vec<u8>, start_position: usize, mut value: 
     return position - start_position;
 }
 
+#[inline]
 pub fn read_signed_leb128(data: &[u8], start_position: usize) -> (i64, usize) {
     let mut result = 0;
     let mut shift = 0;

--- a/src/libserialize/opaque.rs
+++ b/src/libserialize/opaque.rs
@@ -179,74 +179,90 @@ macro_rules! read_sleb128 {
 impl<'a> serialize::Decoder for Decoder<'a> {
     type Error = String;
 
+    #[inline]
     fn read_nil(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }
 
+    #[inline]
     fn read_u64(&mut self) -> Result<u64, Self::Error> {
         read_uleb128!(self, u64)
     }
 
+    #[inline]
     fn read_u32(&mut self) -> Result<u32, Self::Error> {
         read_uleb128!(self, u32)
     }
 
+    #[inline]
     fn read_u16(&mut self) -> Result<u16, Self::Error> {
         read_uleb128!(self, u16)
     }
 
+    #[inline]
     fn read_u8(&mut self) -> Result<u8, Self::Error> {
         let value = self.data[self.position];
         self.position += 1;
         Ok(value)
     }
 
+    #[inline]
     fn read_usize(&mut self) -> Result<usize, Self::Error> {
         read_uleb128!(self, usize)
     }
 
+    #[inline]
     fn read_i64(&mut self) -> Result<i64, Self::Error> {
         read_sleb128!(self, i64)
     }
 
+    #[inline]
     fn read_i32(&mut self) -> Result<i32, Self::Error> {
         read_sleb128!(self, i32)
     }
 
+    #[inline]
     fn read_i16(&mut self) -> Result<i16, Self::Error> {
         read_sleb128!(self, i16)
     }
 
+    #[inline]
     fn read_i8(&mut self) -> Result<i8, Self::Error> {
         let as_u8 = self.data[self.position];
         self.position += 1;
         unsafe { Ok(::std::mem::transmute(as_u8)) }
     }
 
+    #[inline]
     fn read_isize(&mut self) -> Result<isize, Self::Error> {
         read_sleb128!(self, isize)
     }
 
+    #[inline]
     fn read_bool(&mut self) -> Result<bool, Self::Error> {
         let value = self.read_u8()?;
         Ok(value != 0)
     }
 
+    #[inline]
     fn read_f64(&mut self) -> Result<f64, Self::Error> {
         let bits = self.read_u64()?;
         Ok(unsafe { ::std::mem::transmute(bits) })
     }
 
+    #[inline]
     fn read_f32(&mut self) -> Result<f32, Self::Error> {
         let bits = self.read_u32()?;
         Ok(unsafe { ::std::mem::transmute(bits) })
     }
 
+    #[inline]
     fn read_char(&mut self) -> Result<char, Self::Error> {
         let bits = self.read_u32()?;
         Ok(::std::char::from_u32(bits).unwrap())
     }
 
+    #[inline]
     fn read_str(&mut self) -> Result<Cow<str>, Self::Error> {
         let len = self.read_usize()?;
         let s = ::std::str::from_utf8(&self.data[self.position..self.position + len]).unwrap();


### PR DESCRIPTION
`read_unsigned_leb128` is hot within rustc because it's heavily used
during the reading of crate metadata. This commit tweaks its signature
(and that of `read_signed_leb128`, for consistency) so it can increment
the buffer index directly instead of maintaining its own copy, the
change in which is then used by the caller to advance the index.

This reduces the instruction count (as measured by Cachegrind) for some
benchmarks a bit, e.g. hyper-0.5.0 by 0.7%.
