### PR TITLE
macros: clean up scopes of expanded `#[macro_use]` imports

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -95,13 +95,7 @@ pub fn lower_crate(sess: &Session,
     let _ignore = sess.dep_graph.in_ignore();
 
     LoweringContext {
-        crate_root: if std_inject::no_core(krate) {
-            None
-        } else if std_inject::no_std(krate) {
-            Some("core")
-        } else {
-            Some("std")
-        },
+        crate_root: std_inject::injected_crate_name(krate),
         sess: sess,
         parent_def: None,
         resolver: resolver,

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -649,7 +649,7 @@ pub fn phase_2_configure_and_expand<'a, F>(sess: &Session,
     let resolver_arenas = Resolver::arenas();
     let mut resolver =
         Resolver::new(sess, &krate, make_glob_map, &mut crate_loader, &resolver_arenas);
-    syntax_ext::register_builtins(&mut resolver, sess.features.borrow().quote);
+    syntax_ext::register_builtins(&mut resolver, syntax_exts, sess.features.borrow().quote);
 
     krate = time(time_passes, "expansion", || {
         // Windows dlls do not have rpaths, so they don't know how to find their
@@ -686,7 +686,7 @@ pub fn phase_2_configure_and_expand<'a, F>(sess: &Session,
             ..syntax::ext::expand::ExpansionConfig::default(crate_name.to_string())
         };
         let mut ecx = ExtCtxt::new(&sess.parse_sess, krate.config.clone(), cfg, &mut resolver);
-        let ret = syntax::ext::expand::expand_crate(&mut ecx, syntax_exts, krate);
+        let ret = syntax::ext::expand::expand_crate(&mut ecx, krate);
         if cfg!(windows) {
             env::set_var("PATH", &old_path);
         }

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -203,7 +203,7 @@ impl<'b> Resolver<'b> {
                                 let ext = macro_rules::compile(&self.session.parse_sess, &def);
                                 let shadowing =
                                     self.resolve_macro_name(Mark::root(), name, false).is_some();
-                                self.expansion_data[&Mark::root()].module.macros.borrow_mut()
+                                self.expansion_data[&Mark::root()].module.get().macros.borrow_mut()
                                     .insert(name, macros::NameBinding {
                                         ext: Rc::new(ext),
                                         expansion: expansion,
@@ -525,8 +525,8 @@ pub struct BuildReducedGraphVisitor<'a, 'b: 'a> {
 
 impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
     fn visit_invoc(&mut self, id: ast::NodeId) {
-        self.resolver.expansion_data.get_mut(&Mark::from_placeholder_id(id)).unwrap().module =
-            self.resolver.current_module;
+        let mark = Mark::from_placeholder_id(id);
+        self.resolver.expansion_data[&mark].module.set(self.resolver.current_module);
     }
 }
 

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -203,7 +203,7 @@ impl<'b> Resolver<'b> {
                                 let ext = macro_rules::compile(&self.session.parse_sess, &def);
                                 let shadowing =
                                     self.resolve_macro_name(Mark::root(), name, false).is_some();
-                                self.expansion_data[&Mark::root()].module.get().macros.borrow_mut()
+                                self.invocations[&Mark::root()].module.get().macros.borrow_mut()
                                     .insert(name, macros::NameBinding {
                                         ext: Rc::new(ext),
                                         expansion: expansion,
@@ -526,7 +526,7 @@ pub struct BuildReducedGraphVisitor<'a, 'b: 'a> {
 impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
     fn visit_invoc(&mut self, id: ast::NodeId) {
         let mark = Mark::from_placeholder_id(id);
-        self.resolver.expansion_data[&mark].module.set(self.resolver.current_module);
+        self.resolver.invocations[&mark].module.set(self.resolver.current_module);
     }
 }
 

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -13,7 +13,7 @@
 //! Here we build the "reduced graph": the graph of the module tree without
 //! any imports resolved.
 
-use macros;
+use macros::{InvocationData, LegacyImports, LegacyScope};
 use resolve_imports::ImportDirectiveSubclass::{self, GlobImport};
 use {Module, ModuleS, ModuleKind};
 use Namespace::{self, TypeNS, ValueNS};
@@ -84,7 +84,7 @@ impl<'b> Resolver<'b> {
     }
 
     /// Constructs the reduced graph for one item.
-    fn build_reduced_graph_for_item(&mut self, item: &Item, expansion: Mark) {
+    fn build_reduced_graph_for_item(&mut self, item: &Item, legacy_imports: &mut LegacyImports) {
         let parent = self.current_module;
         let name = item.ident.name;
         let sp = item.span;
@@ -200,16 +200,9 @@ impl<'b> Resolver<'b> {
                         LoadedMacroKind::Def(mut def) => {
                             let name = def.ident.name;
                             if def.use_locally {
-                                let ext = macro_rules::compile(&self.session.parse_sess, &def);
-                                let shadowing =
-                                    self.resolve_macro_name(Mark::root(), name, false).is_some();
-                                self.invocations[&Mark::root()].module.get().macros.borrow_mut()
-                                    .insert(name, macros::NameBinding {
-                                        ext: Rc::new(ext),
-                                        expansion: expansion,
-                                        shadowing: shadowing,
-                                        span: loaded_macro.import_site,
-                                    });
+                                let ext =
+                                    Rc::new(macro_rules::compile(&self.session.parse_sess, &def));
+                                legacy_imports.insert(name, (ext, loaded_macro.import_site));
                                 self.macro_names.insert(name);
                             }
                             if def.export {
@@ -250,7 +243,6 @@ impl<'b> Resolver<'b> {
                         attr::contains_name(&item.attrs, "no_implicit_prelude")
                     },
                     normal_ancestor_id: Some(item.id),
-                    macros_escape: self.contains_macro_use(&item.attrs),
                     ..ModuleS::new(Some(parent), ModuleKind::Def(def, name))
                 });
                 self.define(parent, name, TypeNS, (module, sp, vis));
@@ -520,22 +512,26 @@ impl<'b> Resolver<'b> {
 
 pub struct BuildReducedGraphVisitor<'a, 'b: 'a> {
     pub resolver: &'a mut Resolver<'b>,
-    pub expansion: Mark,
+    pub legacy_scope: LegacyScope<'b>,
+    pub legacy_imports: LegacyImports,
 }
 
 impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
-    fn visit_invoc(&mut self, id: ast::NodeId) {
-        let mark = Mark::from_placeholder_id(id);
-        self.resolver.invocations[&mark].module.set(self.resolver.current_module);
+    fn visit_invoc(&mut self, id: ast::NodeId) -> &'b InvocationData<'b> {
+        let invocation = self.resolver.invocations[&Mark::from_placeholder_id(id)];
+        invocation.module.set(self.resolver.current_module);
+        invocation.legacy_scope.set(self.legacy_scope);
+        invocation
     }
 }
 
 macro_rules! method {
     ($visit:ident: $ty:ty, $invoc:path, $walk:ident) => {
         fn $visit(&mut self, node: &$ty) {
-            match node.node {
-                $invoc(..) => self.visit_invoc(node.id),
-                _ => visit::$walk(self, node),
+            if let $invoc(..) = node.node {
+                self.visit_invoc(node.id);
+            } else {
+                visit::$walk(self, node);
             }
         }
     }
@@ -543,22 +539,35 @@ macro_rules! method {
 
 impl<'a, 'b> Visitor for BuildReducedGraphVisitor<'a, 'b> {
     method!(visit_impl_item: ast::ImplItem, ast::ImplItemKind::Macro, walk_impl_item);
-    method!(visit_stmt:      ast::Stmt,     ast::StmtKind::Mac,       walk_stmt);
     method!(visit_expr:      ast::Expr,     ast::ExprKind::Mac,       walk_expr);
     method!(visit_pat:       ast::Pat,      ast::PatKind::Mac,        walk_pat);
     method!(visit_ty:        ast::Ty,       ast::TyKind::Mac,         walk_ty);
 
     fn visit_item(&mut self, item: &Item) {
-        match item.node {
+        let macro_use = match item.node {
             ItemKind::Mac(..) if item.id == ast::DUMMY_NODE_ID => return, // Scope placeholder
-            ItemKind::Mac(..) => return self.visit_invoc(item.id),
-            _ => {}
-        }
+            ItemKind::Mac(..) => {
+                return self.legacy_scope = LegacyScope::Expansion(self.visit_invoc(item.id));
+            }
+            ItemKind::Mod(..) => self.resolver.contains_macro_use(&item.attrs),
+            _ => false,
+        };
 
-        let parent = self.resolver.current_module;
-        self.resolver.build_reduced_graph_for_item(item, self.expansion);
+        let (parent, legacy_scope) = (self.resolver.current_module, self.legacy_scope);
+        self.resolver.build_reduced_graph_for_item(item, &mut self.legacy_imports);
         visit::walk_item(self, item);
         self.resolver.current_module = parent;
+        if !macro_use {
+            self.legacy_scope = legacy_scope;
+        }
+    }
+
+    fn visit_stmt(&mut self, stmt: &ast::Stmt) {
+        if let ast::StmtKind::Mac(..) = stmt.node {
+            self.legacy_scope = LegacyScope::Expansion(self.visit_invoc(stmt.id));
+        } else {
+            visit::walk_stmt(self, stmt);
+        }
     }
 
     fn visit_foreign_item(&mut self, foreign_item: &ForeignItem) {
@@ -567,10 +576,11 @@ impl<'a, 'b> Visitor for BuildReducedGraphVisitor<'a, 'b> {
     }
 
     fn visit_block(&mut self, block: &Block) {
-        let parent = self.resolver.current_module;
+        let (parent, legacy_scope) = (self.resolver.current_module, self.legacy_scope);
         self.resolver.build_reduced_graph_for_block(block);
         visit::walk_block(self, block);
         self.resolver.current_module = parent;
+        self.legacy_scope = legacy_scope;
     }
 
     fn visit_trait_item(&mut self, item: &TraitItem) {
@@ -578,7 +588,8 @@ impl<'a, 'b> Visitor for BuildReducedGraphVisitor<'a, 'b> {
         let def_id = parent.def_id().unwrap();
 
         if let TraitItemKind::Macro(_) = item.node {
-            return self.visit_invoc(item.id);
+            self.visit_invoc(item.id);
+            return
         }
 
         // Add the item to the trait info.

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -77,6 +77,7 @@ use std::mem::replace;
 use std::rc::Rc;
 
 use resolve_imports::{ImportDirective, NameResolution};
+use macros::ExpansionData;
 
 // NB: This module needs to be declared first so diagnostics are
 // registered before they are used.
@@ -1088,7 +1089,7 @@ pub struct Resolver<'a> {
     macro_names: FnvHashSet<Name>,
 
     // Maps the `Mark` of an expansion to its containing module or block.
-    expansion_data: FnvHashMap<Mark, macros::ExpansionData<'a>>,
+    expansion_data: FnvHashMap<Mark, &'a ExpansionData<'a>>,
 }
 
 pub struct ResolverArenas<'a> {
@@ -1097,6 +1098,7 @@ pub struct ResolverArenas<'a> {
     name_bindings: arena::TypedArena<NameBinding<'a>>,
     import_directives: arena::TypedArena<ImportDirective<'a>>,
     name_resolutions: arena::TypedArena<RefCell<NameResolution<'a>>>,
+    expansion_data: arena::TypedArena<ExpansionData<'a>>,
 }
 
 impl<'a> ResolverArenas<'a> {
@@ -1119,6 +1121,9 @@ impl<'a> ResolverArenas<'a> {
     }
     fn alloc_name_resolution(&'a self) -> &'a RefCell<NameResolution<'a>> {
         self.name_resolutions.alloc(Default::default())
+    }
+    fn alloc_expansion_data(&'a self, expansion_data: ExpansionData<'a>) -> &'a ExpansionData<'a> {
+        self.expansion_data.alloc(expansion_data)
     }
 }
 
@@ -1206,7 +1211,8 @@ impl<'a> Resolver<'a> {
         DefCollector::new(&mut definitions).collect_root();
 
         let mut expansion_data = FnvHashMap();
-        expansion_data.insert(Mark::root(), macros::ExpansionData::root(graph_root));
+        expansion_data.insert(Mark::root(),
+                              arenas.alloc_expansion_data(ExpansionData::root(graph_root)));
 
         Resolver {
             session: session,
@@ -1277,6 +1283,7 @@ impl<'a> Resolver<'a> {
             name_bindings: arena::TypedArena::new(),
             import_directives: arena::TypedArena::new(),
             name_resolutions: arena::TypedArena::new(),
+            expansion_data: arena::TypedArena::new(),
         }
     }
 

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3389,8 +3389,8 @@ impl<'a> Resolver<'a> {
                reported_errors.insert((name, span)) {
                 let msg = format!("`{}` is already in scope", name);
                 self.session.struct_span_err(span, &msg)
-                    .note("macro-expanded `macro_rules!`s and `#[macro_use]`s \
-                           may not shadow existing macros (see RFC 1560)")
+                    .note("macro-expanded `macro_rules!`s may not shadow \
+                           existing macros (see RFC 1560)")
                     .emit();
             }
         }

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -207,20 +207,14 @@ impl<'a> base::Resolver for Resolver<'a> {
 }
 
 impl<'a> Resolver<'a> {
-    fn resolve_macro_name(&mut self,
-                          mut scope: LegacyScope<'a>,
-                          name: ast::Name,
-                          record_used: bool)
-                          -> Option<Rc<SyntaxExtension>> {
+    pub fn resolve_macro_name(&mut self,
+                              mut scope: LegacyScope<'a>,
+                              name: ast::Name,
+                              record_used: bool)
+                              -> Option<Rc<SyntaxExtension>> {
         let check_shadowing = |this: &mut Self, relative_depth, scope, span| {
-            if record_used && relative_depth > 0 &&
-               this.resolve_macro_name(scope, name, false).is_some() &&
-               this.macro_shadowing_errors.insert(span) {
-                let msg = format!("`{}` is already in scope", name);
-                this.session.struct_span_err(span, &msg)
-                    .note("macro-expanded `macro_rules!`s and `#[macro_use]`s \
-                           may not shadow existing macros (see RFC 1560)")
-                    .emit();
+            if record_used && relative_depth > 0 {
+                this.disallowed_shadowing.push((name, span, scope));
             }
         };
 

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -12,6 +12,7 @@ use {Module, Resolver};
 use build_reduced_graph::BuildReducedGraphVisitor;
 use rustc::hir::def_id::{CRATE_DEF_INDEX, DefIndex};
 use rustc::hir::map::{self, DefCollector};
+use rustc::util::nodemap::FnvHashMap;
 use std::cell::Cell;
 use std::rc::Rc;
 use syntax::ast;
@@ -19,40 +20,57 @@ use syntax::errors::DiagnosticBuilder;
 use syntax::ext::base::{self, MultiModifier, MultiDecorator, MultiItemModifier};
 use syntax::ext::base::{NormalTT, SyntaxExtension};
 use syntax::ext::expand::{Expansion, Invocation, InvocationKind};
-use syntax::ext::hygiene::{Mark, SyntaxContext};
+use syntax::ext::hygiene::Mark;
 use syntax::ext::tt::macro_rules;
 use syntax::parse::token::intern;
 use syntax::util::lev_distance::find_best_match_for_name;
-use syntax_pos::{Span, DUMMY_SP};
-
-// FIXME(jseyfried) Merge with `::NameBinding`.
-pub struct NameBinding {
-    pub ext: Rc<SyntaxExtension>,
-    pub expansion: Mark,
-    pub shadowing: bool,
-    pub span: Span,
-}
+use syntax_pos::Span;
 
 #[derive(Clone)]
 pub struct InvocationData<'a> {
-    backtrace: SyntaxContext,
     pub module: Cell<Module<'a>>,
     def_index: DefIndex,
     // True if this expansion is in a `const_integer` position, for example `[u32; m!()]`.
     // c.f. `DefCollector::visit_ast_const_integer`.
     const_integer: bool,
+    // The scope in which the invocation path is resolved.
+    pub legacy_scope: Cell<LegacyScope<'a>>,
+    // The smallest scope that includes this invocation's expansion,
+    // or `Empty` if this invocation has not been expanded yet.
+    pub expansion: Cell<LegacyScope<'a>>,
 }
 
 impl<'a> InvocationData<'a> {
     pub fn root(graph_root: Module<'a>) -> Self {
         InvocationData {
-            backtrace: SyntaxContext::empty(),
             module: Cell::new(graph_root),
             def_index: CRATE_DEF_INDEX,
             const_integer: false,
+            legacy_scope: Cell::new(LegacyScope::Empty),
+            expansion: Cell::new(LegacyScope::Empty),
         }
     }
 }
+
+#[derive(Copy, Clone)]
+pub enum LegacyScope<'a> {
+    Empty,
+    Invocation(&'a InvocationData<'a>), // The scope of the invocation, not including its expansion
+    Expansion(&'a InvocationData<'a>), // The scope of the invocation, including its expansion
+    Binding(&'a LegacyBinding<'a>),
+}
+
+pub struct LegacyBinding<'a> {
+    parent: LegacyScope<'a>,
+    kind: LegacyBindingKind,
+}
+
+pub enum LegacyBindingKind {
+    MacroRules(ast::Name, Rc<SyntaxExtension>, Span),
+    MacroUse(LegacyImports),
+}
+
+pub type LegacyImports = FnvHashMap<ast::Name, (Rc<SyntaxExtension>, Span)>;
 
 impl<'a> base::Resolver for Resolver<'a> {
     fn next_node_id(&mut self) -> ast::NodeId {
@@ -63,18 +81,36 @@ impl<'a> base::Resolver for Resolver<'a> {
         let mark = Mark::fresh();
         let module = self.module_map[&id];
         self.invocations.insert(mark, self.arenas.alloc_invocation_data(InvocationData {
-            backtrace: SyntaxContext::empty(),
             module: Cell::new(module),
             def_index: module.def_id().unwrap().index,
             const_integer: false,
+            legacy_scope: Cell::new(LegacyScope::Empty),
+            expansion: Cell::new(LegacyScope::Empty),
         }));
         mark
     }
 
     fn visit_expansion(&mut self, mark: Mark, expansion: &Expansion) {
-        self.collect_def_ids(mark, expansion);
-        self.current_module = self.invocations[&mark].module.get();
-        expansion.visit_with(&mut BuildReducedGraphVisitor { resolver: self, expansion: mark });
+        let invocation = self.invocations[&mark];
+        self.collect_def_ids(invocation, expansion);
+
+        self.current_module = invocation.module.get();
+        let mut visitor = BuildReducedGraphVisitor {
+            resolver: self,
+            legacy_scope: LegacyScope::Invocation(invocation),
+            legacy_imports: FnvHashMap(),
+        };
+        expansion.visit_with(&mut visitor);
+        invocation.expansion.set(visitor.legacy_scope);
+
+        if !visitor.legacy_imports.is_empty() {
+            invocation.legacy_scope.set({
+                LegacyScope::Binding(self.arenas.alloc_legacy_binding(LegacyBinding {
+                    parent: invocation.legacy_scope.get(),
+                    kind: LegacyBindingKind::MacroUse(visitor.legacy_imports),
+                }))
+            });
+        }
     }
 
     fn add_macro(&mut self, scope: Mark, mut def: ast::MacroDef) {
@@ -83,17 +119,12 @@ impl<'a> base::Resolver for Resolver<'a> {
         }
         if def.use_locally {
             let invocation = self.invocations[&scope];
-            let mut module = invocation.module.get();
-            while module.macros_escape {
-                module = module.parent.unwrap();
-            }
-            let binding = NameBinding {
-                ext: Rc::new(macro_rules::compile(&self.session.parse_sess, &def)),
-                expansion: invocation.backtrace.data().prev_ctxt.data().outer_mark,
-                shadowing: self.resolve_macro_name(scope, def.ident.name, false).is_some(),
-                span: def.span,
-            };
-            module.macros.borrow_mut().insert(def.ident.name, binding);
+            let ext = Rc::new(macro_rules::compile(&self.session.parse_sess, &def));
+            let binding = self.arenas.alloc_legacy_binding(LegacyBinding {
+                parent: invocation.legacy_scope.get(),
+                kind: LegacyBindingKind::MacroRules(def.ident.name, ext, def.span),
+            });
+            invocation.legacy_scope.set(LegacyScope::Binding(binding));
             self.macro_names.insert(def.ident.name);
         }
         if def.export {
@@ -106,12 +137,7 @@ impl<'a> base::Resolver for Resolver<'a> {
         if let NormalTT(..) = *ext {
             self.macro_names.insert(ident.name);
         }
-        self.graph_root.macros.borrow_mut().insert(ident.name, NameBinding {
-            ext: ext,
-            expansion: Mark::root(),
-            shadowing: false,
-            span: DUMMY_SP,
-        });
+        self.builtin_macros.insert(ident.name, ext);
     }
 
     fn add_expansions_at_stmt(&mut self, id: ast::NodeId, macros: Vec<Mark>) {
@@ -121,8 +147,8 @@ impl<'a> base::Resolver for Resolver<'a> {
     fn find_attr_invoc(&mut self, attrs: &mut Vec<ast::Attribute>) -> Option<ast::Attribute> {
         for i in 0..attrs.len() {
             let name = intern(&attrs[i].name());
-            match self.invocations[&Mark::root()].module.get().macros.borrow().get(&name) {
-                Some(binding) => match *binding.ext {
+            match self.builtin_macros.get(&name) {
+                Some(ext) => match **ext {
                     MultiModifier(..) | MultiDecorator(..) | SyntaxExtension::AttrProcMacro(..) => {
                         return Some(attrs.remove(i))
                     }
@@ -149,6 +175,7 @@ impl<'a> base::Resolver for Resolver<'a> {
             InvocationKind::Attr { ref attr, .. } => (intern(&*attr.name()), attr.span),
         };
 
+        let scope = self.invocations[&scope].legacy_scope.get();
         self.resolve_macro_name(scope, name, true).or_else(|| {
             let mut err =
                 self.session.struct_span_err(span, &format!("macro undefined: '{}!'", name));
@@ -164,37 +191,63 @@ impl<'a> base::Resolver for Resolver<'a> {
 }
 
 impl<'a> Resolver<'a> {
-    pub fn resolve_macro_name(&mut self, scope: Mark, name: ast::Name, record_used: bool)
-                              -> Option<Rc<SyntaxExtension>> {
-        let invocation = self.invocations[&scope];
-        let mut module = invocation.module.get();
-        loop {
-            if let Some(binding) = module.macros.borrow().get(&name) {
-                let mut backtrace = invocation.backtrace.data();
-                while binding.expansion != backtrace.outer_mark {
-                    if backtrace.outer_mark != Mark::root() {
-                        backtrace = backtrace.prev_ctxt.data();
-                        continue
-                    }
+    fn resolve_macro_name(&mut self,
+                          mut scope: LegacyScope<'a>,
+                          name: ast::Name,
+                          record_used: bool)
+                          -> Option<Rc<SyntaxExtension>> {
+        let check_shadowing = |this: &mut Self, relative_depth, scope, span| {
+            if record_used && relative_depth > 0 &&
+               this.resolve_macro_name(scope, name, false).is_some() &&
+               this.macro_shadowing_errors.insert(span) {
+                let msg = format!("`{}` is already in scope", name);
+                this.session.struct_span_err(span, &msg)
+                    .note("macro-expanded `macro_rules!`s and `#[macro_use]`s \
+                           may not shadow existing macros (see RFC 1560)")
+                    .emit();
+            }
+        };
 
-                    if record_used && binding.shadowing &&
-                       self.macro_shadowing_errors.insert(binding.span) {
-                        let msg = format!("`{}` is already in scope", name);
-                        self.session.struct_span_err(binding.span, &msg)
-                            .note("macro-expanded `macro_rules!`s and `#[macro_use]`s \
-                                   may not shadow existing macros (see RFC 1560)")
-                            .emit();
+        let mut relative_depth: u32 = 0;
+        loop {
+            scope = match scope {
+                LegacyScope::Empty => break,
+                LegacyScope::Expansion(invocation) => {
+                    if let LegacyScope::Empty = invocation.expansion.get() {
+                        invocation.legacy_scope.get()
+                    } else {
+                        relative_depth += 1;
+                        invocation.expansion.get()
                     }
-                    break
                 }
-                return Some(binding.ext.clone());
-            }
-            match module.parent {
-                Some(parent) => module = parent,
-                None => break,
-            }
+                LegacyScope::Invocation(invocation) => {
+                    let new_relative_depth = relative_depth.saturating_sub(1);
+                    let mut scope = invocation.legacy_scope.get();
+                    if let LegacyScope::Binding(binding) = scope {
+                        match binding.kind {
+                            LegacyBindingKind::MacroUse(ref imports) => {
+                                if let Some(&(ref ext, span)) = imports.get(&name) {
+                                    check_shadowing(self, relative_depth, binding.parent, span);
+                                    return Some(ext.clone());
+                                }
+                            },
+                            LegacyBindingKind::MacroRules(name_, ref ext, span) => {
+                                if name_ == name {
+                                    check_shadowing(self, new_relative_depth, binding.parent, span);
+                                    return Some(ext.clone());
+                                }
+                            }
+                        }
+                        scope = binding.parent
+                    }
+                    relative_depth = new_relative_depth;
+                    scope
+                }
+                _ => unreachable!(),
+            };
         }
-        None
+
+        self.builtin_macros.get(&name).cloned()
     }
 
     fn suggest_macro_name(&mut self, name: &str, err: &mut DiagnosticBuilder<'a>) {
@@ -207,17 +260,18 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    fn collect_def_ids(&mut self, mark: Mark, expansion: &Expansion) {
+    fn collect_def_ids(&mut self, invocation: &'a InvocationData<'a>, expansion: &Expansion) {
         let Resolver { ref mut invocations, arenas, graph_root, .. } = *self;
-        let InvocationData { def_index, const_integer, backtrace, .. } = invocations[&mark].clone();
+        let InvocationData { def_index, const_integer, .. } = *invocation;
 
         let visit_macro_invoc = &mut |invoc: map::MacroInvocationData| {
             invocations.entry(invoc.mark).or_insert_with(|| {
                 arenas.alloc_invocation_data(InvocationData {
-                    backtrace: backtrace.apply_mark(invoc.mark),
                     def_index: invoc.def_index,
                     const_integer: invoc.const_integer,
                     module: Cell::new(graph_root),
+                    expansion: Cell::new(LegacyScope::Empty),
+                    legacy_scope: Cell::new(LegacyScope::Empty),
                 })
             });
         };

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -34,7 +34,7 @@ pub struct NameBinding {
 }
 
 #[derive(Clone)]
-pub struct ExpansionData<'a> {
+pub struct InvocationData<'a> {
     backtrace: SyntaxContext,
     pub module: Cell<Module<'a>>,
     def_index: DefIndex,
@@ -43,9 +43,9 @@ pub struct ExpansionData<'a> {
     const_integer: bool,
 }
 
-impl<'a> ExpansionData<'a> {
+impl<'a> InvocationData<'a> {
     pub fn root(graph_root: Module<'a>) -> Self {
-        ExpansionData {
+        InvocationData {
             backtrace: SyntaxContext::empty(),
             module: Cell::new(graph_root),
             def_index: CRATE_DEF_INDEX,
@@ -62,7 +62,7 @@ impl<'a> base::Resolver for Resolver<'a> {
     fn get_module_scope(&mut self, id: ast::NodeId) -> Mark {
         let mark = Mark::fresh();
         let module = self.module_map[&id];
-        self.expansion_data.insert(mark, self.arenas.alloc_expansion_data(ExpansionData {
+        self.invocations.insert(mark, self.arenas.alloc_invocation_data(InvocationData {
             backtrace: SyntaxContext::empty(),
             module: Cell::new(module),
             def_index: module.def_id().unwrap().index,
@@ -73,7 +73,7 @@ impl<'a> base::Resolver for Resolver<'a> {
 
     fn visit_expansion(&mut self, mark: Mark, expansion: &Expansion) {
         self.collect_def_ids(mark, expansion);
-        self.current_module = self.expansion_data[&mark].module.get();
+        self.current_module = self.invocations[&mark].module.get();
         expansion.visit_with(&mut BuildReducedGraphVisitor { resolver: self, expansion: mark });
     }
 
@@ -82,14 +82,14 @@ impl<'a> base::Resolver for Resolver<'a> {
             self.session.span_err(def.span, "user-defined macros may not be named `macro_rules`");
         }
         if def.use_locally {
-            let expansion_data = self.expansion_data[&scope];
-            let mut module = expansion_data.module.get();
+            let invocation = self.invocations[&scope];
+            let mut module = invocation.module.get();
             while module.macros_escape {
                 module = module.parent.unwrap();
             }
             let binding = NameBinding {
                 ext: Rc::new(macro_rules::compile(&self.session.parse_sess, &def)),
-                expansion: expansion_data.backtrace.data().prev_ctxt.data().outer_mark,
+                expansion: invocation.backtrace.data().prev_ctxt.data().outer_mark,
                 shadowing: self.resolve_macro_name(scope, def.ident.name, false).is_some(),
                 span: def.span,
             };
@@ -121,7 +121,7 @@ impl<'a> base::Resolver for Resolver<'a> {
     fn find_attr_invoc(&mut self, attrs: &mut Vec<ast::Attribute>) -> Option<ast::Attribute> {
         for i in 0..attrs.len() {
             let name = intern(&attrs[i].name());
-            match self.expansion_data[&Mark::root()].module.get().macros.borrow().get(&name) {
+            match self.invocations[&Mark::root()].module.get().macros.borrow().get(&name) {
                 Some(binding) => match *binding.ext {
                     MultiModifier(..) | MultiDecorator(..) | SyntaxExtension::AttrProcMacro(..) => {
                         return Some(attrs.remove(i))
@@ -166,11 +166,11 @@ impl<'a> base::Resolver for Resolver<'a> {
 impl<'a> Resolver<'a> {
     pub fn resolve_macro_name(&mut self, scope: Mark, name: ast::Name, record_used: bool)
                               -> Option<Rc<SyntaxExtension>> {
-        let expansion_data = self.expansion_data[&scope];
-        let mut module = expansion_data.module.get();
+        let invocation = self.invocations[&scope];
+        let mut module = invocation.module.get();
         loop {
             if let Some(binding) = module.macros.borrow().get(&name) {
-                let mut backtrace = expansion_data.backtrace.data();
+                let mut backtrace = invocation.backtrace.data();
                 while binding.expansion != backtrace.outer_mark {
                     if backtrace.outer_mark != Mark::root() {
                         backtrace = backtrace.prev_ctxt.data();
@@ -208,13 +208,12 @@ impl<'a> Resolver<'a> {
     }
 
     fn collect_def_ids(&mut self, mark: Mark, expansion: &Expansion) {
-        let Resolver { ref mut expansion_data, arenas, graph_root, .. } = *self;
-        let ExpansionData { def_index, const_integer, backtrace, .. } =
-            expansion_data[&mark].clone();
+        let Resolver { ref mut invocations, arenas, graph_root, .. } = *self;
+        let InvocationData { def_index, const_integer, backtrace, .. } = invocations[&mark].clone();
 
         let visit_macro_invoc = &mut |invoc: map::MacroInvocationData| {
-            expansion_data.entry(invoc.mark).or_insert_with(|| {
-                arenas.alloc_expansion_data(ExpansionData {
+            invocations.entry(invoc.mark).or_insert_with(|| {
+                arenas.alloc_invocation_data(InvocationData {
                     backtrace: backtrace.apply_mark(invoc.mark),
                     def_index: invoc.def_index,
                     const_integer: invoc.const_integer,

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use self::Determinacy::*;
 use self::ImportDirectiveSubclass::*;
 
 use Module;
@@ -26,6 +25,7 @@ use rustc::lint::builtin::PRIVATE_IN_PUBLIC;
 use rustc::hir::def::*;
 
 use syntax::ast::{NodeId, Name};
+use syntax::ext::base::Determinacy::{self, Determined, Undetermined};
 use syntax::util::lev_distance::find_best_match_for_name;
 use syntax_pos::Span;
 
@@ -35,12 +35,6 @@ impl<'a> Resolver<'a> {
     pub fn resolve_imports(&mut self) {
         ImportResolver { resolver: self }.resolve_imports();
     }
-}
-
-#[derive(Copy, Clone, Debug)]
-pub enum Determinacy {
-    Determined,
-    Undetermined,
 }
 
 /// Contains data for specific types of import directives.

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -522,8 +522,15 @@ pub trait Resolver {
     fn add_expansions_at_stmt(&mut self, id: ast::NodeId, macros: Vec<Mark>);
 
     fn find_attr_invoc(&mut self, attrs: &mut Vec<Attribute>) -> Option<Attribute>;
-    fn resolve_invoc(&mut self, scope: Mark, invoc: &Invocation) -> Option<Rc<SyntaxExtension>>;
+    fn resolve_invoc(&mut self, scope: Mark, invoc: &Invocation, force: bool)
+                     -> Result<Rc<SyntaxExtension>, Determinacy>;
     fn resolve_derive_mode(&mut self, ident: ast::Ident) -> Option<Rc<MultiItemModifier>>;
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum Determinacy {
+    Determined,
+    Undetermined,
 }
 
 pub struct DummyResolver;
@@ -539,8 +546,9 @@ impl Resolver for DummyResolver {
 
     fn find_attr_invoc(&mut self, _attrs: &mut Vec<Attribute>) -> Option<Attribute> { None }
     fn resolve_derive_mode(&mut self, _ident: ast::Ident) -> Option<Rc<MultiItemModifier>> { None }
-    fn resolve_invoc(&mut self, _scope: Mark, _invoc: &Invocation) -> Option<Rc<SyntaxExtension>> {
-        None
+    fn resolve_invoc(&mut self, _scope: Mark, _invoc: &Invocation, _force: bool)
+                     -> Result<Rc<SyntaxExtension>, Determinacy> {
+        Err(Determinacy::Determined)
     }
 }
 

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -738,13 +738,8 @@ impl<'a> ExtCtxt<'a> {
         token::intern(st)
     }
 
-    pub fn initialize(&mut self, user_exts: Vec<NamedSyntaxExtension>, krate: &ast::Crate) {
+    pub fn initialize(&mut self, krate: &ast::Crate) {
         self.crate_root = std_inject::injected_crate_name(krate);
-
-        for (name, extension) in user_exts {
-            let ident = ast::Ident::with_empty_ctxt(name);
-            self.resolver.add_ext(ident, Rc::new(extension));
-        }
 
         let mut module = ModuleData {
             mod_path: vec![token::str_to_ident(&self.ecfg.crate_name)],

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -22,7 +22,6 @@ use parse::{self, parser};
 use parse::token;
 use parse::token::{InternedString, str_to_ident};
 use ptr::P;
-use std_inject;
 use util::small_vector::SmallVector;
 
 use std::path::PathBuf;
@@ -736,17 +735,6 @@ impl<'a> ExtCtxt<'a> {
     }
     pub fn name_of(&self, st: &str) -> ast::Name {
         token::intern(st)
-    }
-
-    pub fn initialize(&mut self, krate: &ast::Crate) {
-        self.crate_root = std_inject::injected_crate_name(krate);
-
-        let mut module = ModuleData {
-            mod_path: vec![token::str_to_ident(&self.ecfg.crate_name)],
-            directory: PathBuf::from(self.parse_sess.codemap().span_to_filename(krate.span)),
-        };
-        module.directory.pop();
-        self.current_expansion.module = Rc::new(module);
     }
 }
 

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -739,13 +739,7 @@ impl<'a> ExtCtxt<'a> {
     }
 
     pub fn initialize(&mut self, user_exts: Vec<NamedSyntaxExtension>, krate: &ast::Crate) {
-        if std_inject::no_core(&krate) {
-            self.crate_root = None;
-        } else if std_inject::no_std(&krate) {
-            self.crate_root = Some("core");
-        } else {
-            self.crate_root = Some("std");
-        }
+        self.crate_root = std_inject::injected_crate_name(krate);
 
         for (name, extension) in user_exts {
             let ident = ast::Ident::with_empty_ctxt(name);

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -866,19 +866,15 @@ impl<'feat> ExpansionConfig<'feat> {
     }
 }
 
-pub fn expand_crate(cx: &mut ExtCtxt,
-                    user_exts: Vec<NamedSyntaxExtension>,
-                    c: Crate) -> Crate {
-    cx.initialize(user_exts, &c);
+pub fn expand_crate(cx: &mut ExtCtxt, c: Crate) -> Crate {
+    cx.initialize(&c);
     cx.monotonic_expander().expand_crate(c)
 }
 
 // Expands crate using supplied MacroExpander - allows for
 // non-standard expansion behaviour (e.g. step-wise).
-pub fn expand_crate_with_expander(expander: &mut MacroExpander,
-                                  user_exts: Vec<NamedSyntaxExtension>,
-                                  c: Crate) -> Crate {
-    expander.cx.initialize(user_exts, &c);
+pub fn expand_crate_with_expander(expander: &mut MacroExpander, c: Crate) -> Crate {
+    expander.cx.initialize(&c);
     expander.expand_crate(c)
 }
 

--- a/src/libsyntax/ext/placeholders.rs
+++ b/src/libsyntax/ext/placeholders.rs
@@ -88,10 +88,11 @@ impl<'a, 'b> PlaceholderExpander<'a, 'b> {
     }
 
     pub fn add(&mut self, id: ast::NodeId, expansion: Expansion) {
+        let expansion = expansion.fold_with(self);
         self.expansions.insert(id, expansion);
     }
 
-    pub fn remove(&mut self, id: ast::NodeId) -> Expansion {
+    fn remove(&mut self, id: ast::NodeId) -> Expansion {
         self.expansions.remove(&id).unwrap()
     }
 }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -112,7 +112,7 @@ pub fn print_crate<'a>(cm: &'a CodeMap,
                                       out,
                                       ann,
                                       is_expanded);
-    if is_expanded && !std_inject::no_std(krate) {
+    if is_expanded && !std_inject::injected_crate_name(krate).is_none() {
         // We need to print `#![no_std]` (and its feature gate) so that
         // compiling pretty-printed source won't inject libstd again.
         // However we don't want these attributes in the AST because

--- a/src/libsyntax_ext/lib.rs
+++ b/src/libsyntax_ext/lib.rs
@@ -50,20 +50,23 @@ pub mod deriving;
 
 use std::rc::Rc;
 use syntax::ast;
-use syntax::ext::base::{MacroExpanderFn, NormalTT, IdentTT, MultiModifier};
+use syntax::ext::base::{MacroExpanderFn, NormalTT, IdentTT, MultiModifier, NamedSyntaxExtension};
 use syntax::ext::tt::macro_rules::MacroRulesExpander;
 use syntax::parse::token::intern;
 
-pub fn register_builtins(resolver: &mut syntax::ext::base::Resolver, enable_quotes: bool) {
+pub fn register_builtins(resolver: &mut syntax::ext::base::Resolver,
+                         user_exts: Vec<NamedSyntaxExtension>,
+                         enable_quotes: bool) {
     let mut register = |name, ext| {
-        resolver.add_ext(ast::Ident::with_empty_ctxt(intern(name)), Rc::new(ext));
+        resolver.add_ext(ast::Ident::with_empty_ctxt(name), Rc::new(ext));
     };
 
-    register("macro_rules", IdentTT(Box::new(MacroRulesExpander), None, false));
+    register(intern("macro_rules"), IdentTT(Box::new(MacroRulesExpander), None, false));
 
     macro_rules! register {
         ($( $name:ident: $f:expr, )*) => { $(
-            register(stringify!($name), NormalTT(Box::new($f as MacroExpanderFn), None, false));
+            register(intern(stringify!($name)),
+                     NormalTT(Box::new($f as MacroExpanderFn), None, false));
         )* }
     }
 
@@ -108,7 +111,11 @@ pub fn register_builtins(resolver: &mut syntax::ext::base::Resolver, enable_quot
     }
 
     // format_args uses `unstable` things internally.
-    register("format_args", NormalTT(Box::new(format::expand_format_args), None, true));
+    register(intern("format_args"), NormalTT(Box::new(format::expand_format_args), None, true));
 
-    register("derive", MultiModifier(Box::new(deriving::expand_derive)));
+    register(intern("derive"), MultiModifier(Box::new(deriving::expand_derive)));
+
+    for (name, ext) in user_exts {
+        register(name, ext);
+    }
 }

--- a/src/test/compile-fail/macro-shadowing.rs
+++ b/src/test/compile-fail/macro-shadowing.rs
@@ -12,31 +12,28 @@
 
 macro_rules! foo { () => {} }
 macro_rules! macro_one { () => {} }
+#[macro_use(macro_two)] extern crate two_macros;
 
 macro_rules! m1 { () => {
     macro_rules! foo { () => {} } //~ ERROR `foo` is already in scope
-    //~^ NOTE macro-expanded `macro_rules!`s and `#[macro_use]`s may not shadow existing macros
+    //~^ NOTE macro-expanded `macro_rules!`s may not shadow existing macros
 
-    #[macro_use] //~ ERROR `macro_one` is already in scope
-    //~^ NOTE macro-expanded `macro_rules!`s and `#[macro_use]`s may not shadow existing macros
-    extern crate two_macros;
+    #[macro_use] //~ ERROR `macro_two` is already in scope
+    //~^ NOTE macro-expanded `#[macro_use]`s may not shadow existing macros
+    extern crate two_macros as __;
 }}
 m1!(); //~ NOTE in this expansion
        //~| NOTE in this expansion
        //~| NOTE in this expansion
        //~| NOTE in this expansion
 
-fn f() { macro_one!(); }
 foo!();
 
 macro_rules! m2 { () => {
     macro_rules! foo { () => {} }
-    #[macro_use] extern crate two_macros as __;
-
-    fn g() { macro_one!(); }
     foo!();
 }}
 m2!();
-//^ Since `foo` and `macro_one` are not used outside this expansion, they are not shadowing errors.
+//^ Since `foo` is not used outside this expansion, it is not a shadowing error.
 
 fn main() {}

--- a/src/test/compile-fail/macro-use-scope.rs
+++ b/src/test/compile-fail/macro-use-scope.rs
@@ -19,10 +19,10 @@ fn f() {
 #[macro_use(macro_one)] // Check that this macro is usable in the above function
 extern crate two_macros;
 
+fn g() {
+    macro_two!();
+}
 macro_rules! m { () => {
-    fn g() {
-        macro_two!();
-    }
     #[macro_use(macro_two)] // Check that this macro is usable in the above function
     extern crate two_macros as _two_macros;
 } }


### PR DESCRIPTION
This PR changes the scope of macro-expanded `#[macro_use]` imports to match that of unexpanded `#[macro_use]` imports. For example, this would be allowed:

``` rust
example!();
macro_rules! m { () => { #[macro_use(example)] extern crate example_crate; } }
m!();
```

This PR also enforces the full shadowing restrictions from RFC 1560 on `#[macro_use]` imports (currently, we only enforce the weakened restrictions from #36767).

This is a [breaking-change], but I believe it is highly unlikely to cause breakage in practice.
r? @nrc 
