### PR TITLE
configure: Fix gcc detection for LLVM

### DIFF
--- a/configure
+++ b/configure
@@ -1638,8 +1638,8 @@ do
         ("ccache gcc")
             LLVM_CXX_32="ccache"
             LLVM_CC_32="ccache"
-            LLVM_CXX_32_ARG1="clang++"
-            LLVM_CC_32_ARG1="clang"
+            LLVM_CXX_32_ARG1="g++"
+            LLVM_CC_32_ARG1="gcc"
 
             LLVM_CXX_64="ccache"
             LLVM_CC_64="ccache"


### PR DESCRIPTION
We have a case where 32-bit compilation accidentally requested clang when gcc
was the only one available.
