### PR TITLE
Specialize Vec::extend to Vec::extend_from_slice

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1571,7 +1571,24 @@ impl<T> Vec<T> {
 #[stable(feature = "extend_ref", since = "1.2.0")]
 impl<'a, T: 'a + Copy> Extend<&'a T> for Vec<T> {
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
-        self.extend(iter.into_iter().cloned());
+        <I as SpecExtendVec<T>>::extend_vec(iter, self);
+    }
+}
+
+// helper trait for specialization of Vec's Extend impl
+trait SpecExtendVec<T> {
+    fn extend_vec(self, vec: &mut Vec<T>);
+}
+
+impl <'a, T: 'a + Copy, I: IntoIterator<Item=&'a T>> SpecExtendVec<T> for I {
+    default fn extend_vec(self, vec: &mut Vec<T>) {
+        vec.extend(self.into_iter().cloned());
+    }
+}
+
+impl<'a, T: Copy> SpecExtendVec<T> for &'a [T] {
+    fn extend_vec(self, vec: &mut Vec<T>) {
+        vec.extend_from_slice(self);
     }
 }
 


### PR DESCRIPTION
I tried using the existing `SpecExtend` as a helper trait for this, but the instances would always conflict with the instances higher up in the file, so I created a new helper trait.

Benchmarking `extend` vs `extend_from_slice` with an slice of 1000 `u64`s gives the following results:

```
before:

running 2 tests
test tests::bench_extend_from_slice ... bench:         166 ns/iter (+/- 78)
test tests::bench_extend_trait      ... bench:       1,187 ns/iter (+/- 697)


after:
running 2 tests
test tests::bench_extend_from_slice ... bench:         149 ns/iter (+/- 87)
test tests::bench_extend_trait      ... bench:         138 ns/iter (+/- 70)
```
