### PR TITLE
Temporary fix for metadata decoding for struct constructors

### DIFF
--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2323,7 +2323,11 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                 let enum_did = self.parent_def_id(did).unwrap();
                 self.lookup_adt_def(enum_did).variant_with_id(did)
             }
-            Def::Struct(did) | Def::StructCtor(did, ..) | Def::Union(did) => {
+            Def::Struct(did) | Def::Union(did) => {
+                self.lookup_adt_def(did).struct_variant()
+            }
+            Def::StructCtor(ctor_did, ..) => {
+                let did = self.parent_def_id(ctor_did).expect("struct ctor has no parent");
                 self.lookup_adt_def(did).struct_variant()
             }
             _ => bug!("expect_variant_def used with unexpected def {:?}", def)

--- a/src/test/compile-fail/issue-37026.rs
+++ b/src/test/compile-fail/issue-37026.rs
@@ -1,0 +1,18 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:empty-struct.rs
+
+extern crate empty_struct;
+
+fn main() {
+    let empty_struct::XEmpty2 = (); //~ ERROR mismatched types
+    let empty_struct::XEmpty6(..) = (); //~ ERROR mismatched types
+}


### PR DESCRIPTION
Same as https://github.com/rust-lang/rust/pull/37078, but for nightly.
Ideally, metadata lookup functions should "just work" for constructor ids, but this fixes the issue as well.

Fixes https://github.com/rust-lang/rust/issues/37026
r? @alexcrichton 
