### PR TITLE
Change Substs to type alias for Slice<Kind> for interning

### DIFF
--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -25,7 +25,7 @@ use middle::mem_categorization as mc;
 use middle::mem_categorization::McResult;
 use middle::region::CodeExtent;
 use mir::tcx::LvalueTy;
-use ty::subst::{Subst, Substs};
+use ty::subst::{Kind, Subst, Substs};
 use ty::adjustment;
 use ty::{TyVid, IntVid, FloatVid};
 use ty::{self, Ty, TyCtxt};
@@ -1208,7 +1208,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     pub fn type_var_for_def(&self,
                             span: Span,
                             def: &ty::TypeParameterDef<'tcx>,
-                            substs: &Substs<'tcx>)
+                            substs: &[Kind<'tcx>])
                             -> Ty<'tcx> {
         let default = def.default.map(|default| {
             type_variable::Default {

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -521,7 +521,7 @@ pub type Ty<'tcx> = &'tcx TyS<'tcx>;
 impl<'tcx> serialize::UseSpecializedEncodable for Ty<'tcx> {}
 impl<'tcx> serialize::UseSpecializedDecodable for Ty<'tcx> {}
 
-/// A wrapper for slices with the additioanl invariant
+/// A wrapper for slices with the additional invariant
 /// that the slice is interned and no other slice with
 /// the same contents can exist in the same context.
 /// This means we can use pointer + length for both

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -11,7 +11,7 @@
 // Type substitutions.
 
 use hir::def_id::DefId;
-use ty::{self, Ty, TyCtxt};
+use ty::{self, Slice, Ty, TyCtxt};
 use ty::fold::{TypeFoldable, TypeFolder, TypeVisitor};
 
 use serialize::{self, Encodable, Encoder, Decodable, Decoder};
@@ -161,26 +161,19 @@ impl<'tcx> Decodable for Kind<'tcx> {
 }
 
 /// A substitution mapping type/region parameters to new values.
-#[derive(Clone, PartialEq, Eq, Debug, Hash, RustcEncodable, RustcDecodable)]
-pub struct Substs<'tcx> {
-    params: Vec<Kind<'tcx>>
-}
+pub type Substs<'tcx> = Slice<Kind<'tcx>>;
 
 impl<'a, 'gcx, 'tcx> Substs<'tcx> {
     pub fn new<I>(tcx: TyCtxt<'a, 'gcx, 'tcx>, params: I)
                   -> &'tcx Substs<'tcx>
     where I: IntoIterator<Item=Kind<'tcx>> {
-        tcx.mk_substs(Substs {
-            params: params.into_iter().collect()
-        })
+        tcx.mk_substs(params.into_iter().collect())
     }
 
     pub fn maybe_new<I, E>(tcx: TyCtxt<'a, 'gcx, 'tcx>, params: I)
                            -> Result<&'tcx Substs<'tcx>, E>
     where I: IntoIterator<Item=Result<Kind<'tcx>, E>> {
-        Ok(tcx.mk_substs(Substs {
-            params: params.into_iter().collect::<Result<_, _>>()?
-        }))
+        Ok(Substs::new(tcx, params.into_iter().collect::<Result<Vec<_>, _>>()?))
     }
 
     pub fn new_trait(tcx: TyCtxt<'a, 'gcx, 'tcx>,
@@ -193,7 +186,7 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
     }
 
     pub fn empty(tcx: TyCtxt<'a, 'gcx, 'tcx>) -> &'tcx Substs<'tcx> {
-        Substs::new(tcx, vec![])
+        Substs::new(tcx, iter::empty())
     }
 
     /// Creates a Substs for generic parameter definitions,
@@ -206,82 +199,81 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
                             mut mk_region: FR,
                             mut mk_type: FT)
                             -> &'tcx Substs<'tcx>
-    where FR: FnMut(&ty::RegionParameterDef, &Substs<'tcx>) -> &'tcx ty::Region,
-          FT: FnMut(&ty::TypeParameterDef<'tcx>, &Substs<'tcx>) -> Ty<'tcx> {
+    where FR: FnMut(&ty::RegionParameterDef, &[Kind<'tcx>]) -> &'tcx ty::Region,
+          FT: FnMut(&ty::TypeParameterDef<'tcx>, &[Kind<'tcx>]) -> Ty<'tcx> {
         let defs = tcx.lookup_generics(def_id);
-        let mut substs = Substs {
-            params: Vec::with_capacity(defs.count())
-        };
+        let mut substs = Vec::with_capacity(defs.count());
 
-        substs.fill_item(tcx, defs, &mut mk_region, &mut mk_type);
+        Substs::fill_item(&mut substs, tcx, defs, &mut mk_region, &mut mk_type);
 
-        tcx.mk_substs(substs)
+        Substs::new(tcx, substs)
     }
 
-    fn fill_item<FR, FT>(&mut self,
+    fn fill_item<FR, FT>(substs: &mut Vec<Kind<'tcx>>,
                          tcx: TyCtxt<'a, 'gcx, 'tcx>,
                          defs: &ty::Generics<'tcx>,
                          mk_region: &mut FR,
                          mk_type: &mut FT)
-    where FR: FnMut(&ty::RegionParameterDef, &Substs<'tcx>) -> &'tcx ty::Region,
-          FT: FnMut(&ty::TypeParameterDef<'tcx>, &Substs<'tcx>) -> Ty<'tcx> {
+    where FR: FnMut(&ty::RegionParameterDef, &[Kind<'tcx>]) -> &'tcx ty::Region,
+          FT: FnMut(&ty::TypeParameterDef<'tcx>, &[Kind<'tcx>]) -> Ty<'tcx> {
+
         if let Some(def_id) = defs.parent {
             let parent_defs = tcx.lookup_generics(def_id);
-            self.fill_item(tcx, parent_defs, mk_region, mk_type);
+            Substs::fill_item(substs, tcx, parent_defs, mk_region, mk_type);
         }
 
         // Handle Self first, before all regions.
         let mut types = defs.types.iter();
         if defs.parent.is_none() && defs.has_self {
             let def = types.next().unwrap();
-            let ty = mk_type(def, self);
-            assert_eq!(def.index as usize, self.params.len());
-            self.params.push(Kind::from(ty));
+            let ty = mk_type(def, substs);
+            assert_eq!(def.index as usize, substs.len());
+            substs.push(Kind::from(ty));
         }
 
         for def in &defs.regions {
-            let region = mk_region(def, self);
-            assert_eq!(def.index as usize, self.params.len());
-            self.params.push(Kind::from(region));
+            let region = mk_region(def, substs);
+            assert_eq!(def.index as usize, substs.len());
+            substs.push(Kind::from(region));
         }
 
         for def in types {
-            let ty = mk_type(def, self);
-            assert_eq!(def.index as usize, self.params.len());
-            self.params.push(Kind::from(ty));
+            let ty = mk_type(def, substs);
+            assert_eq!(def.index as usize, substs.len());
+            substs.push(Kind::from(ty));
         }
     }
 
     pub fn is_noop(&self) -> bool {
-        self.params.is_empty()
+        self.is_empty()
     }
 
     #[inline]
     pub fn params(&self) -> &[Kind<'tcx>] {
-        &self.params
+        &self
     }
 
     #[inline]
     pub fn types(&'a self) -> impl DoubleEndedIterator<Item=Ty<'tcx>> + 'a {
-        self.params.iter().filter_map(|k| k.as_type())
+        self.iter().filter_map(|k| k.as_type())
     }
 
     #[inline]
     pub fn regions(&'a self) -> impl DoubleEndedIterator<Item=&'tcx ty::Region> + 'a {
-        self.params.iter().filter_map(|k| k.as_region())
+        self.iter().filter_map(|k| k.as_region())
     }
 
     #[inline]
     pub fn type_at(&self, i: usize) -> Ty<'tcx> {
-        self.params[i].as_type().unwrap_or_else(|| {
-            bug!("expected type for param #{} in {:?}", i, self.params);
+        self[i].as_type().unwrap_or_else(|| {
+            bug!("expected type for param #{} in {:?}", i, self);
         })
     }
 
     #[inline]
     pub fn region_at(&self, i: usize) -> &'tcx ty::Region {
-        self.params[i].as_region().unwrap_or_else(|| {
-            bug!("expected region for param #{} in {:?}", i, self.params);
+        self[i].as_region().unwrap_or_else(|| {
+            bug!("expected region for param #{} in {:?}", i, self);
         })
     }
 
@@ -305,19 +297,14 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
                        target_substs: &Substs<'tcx>)
                        -> &'tcx Substs<'tcx> {
         let defs = tcx.lookup_generics(source_ancestor);
-        tcx.mk_substs(Substs {
-            params: target_substs.params.iter()
-                .chain(&self.params[defs.own_count()..]).cloned().collect()
-        })
+        Substs::new(tcx, target_substs.iter().chain(&self[defs.own_count()..]).cloned())
     }
 }
 
 impl<'tcx> TypeFoldable<'tcx> for &'tcx Substs<'tcx> {
     fn super_fold_with<'gcx: 'tcx, F: TypeFolder<'gcx, 'tcx>>(&self, folder: &mut F) -> Self {
-        let params = self.params.iter().map(|k| k.fold_with(folder)).collect();
-        folder.tcx().mk_substs(Substs {
-            params: params
-        })
+        let params = self.iter().map(|k| k.fold_with(folder)).collect();
+        folder.tcx().mk_substs(params)
     }
 
     fn fold_with<'gcx: 'tcx, F: TypeFolder<'gcx, 'tcx>>(&self, folder: &mut F) -> Self {
@@ -325,7 +312,7 @@ impl<'tcx> TypeFoldable<'tcx> for &'tcx Substs<'tcx> {
     }
 
     fn super_visit_with<V: TypeVisitor<'tcx>>(&self, visitor: &mut V) -> bool {
-        self.params.visit_with(visitor)
+        self.iter().any(|t| t.visit_with(visitor))
     }
 }
 
@@ -340,19 +327,19 @@ impl<'tcx> serialize::UseSpecializedDecodable for &'tcx Substs<'tcx> {}
 
 pub trait Subst<'tcx> : Sized {
     fn subst<'a, 'gcx>(&self, tcx: TyCtxt<'a, 'gcx, 'tcx>,
-                      substs: &Substs<'tcx>) -> Self {
+                      substs: &[Kind<'tcx>]) -> Self {
         self.subst_spanned(tcx, substs, None)
     }
 
     fn subst_spanned<'a, 'gcx>(&self, tcx: TyCtxt<'a, 'gcx, 'tcx>,
-                               substs: &Substs<'tcx>,
+                               substs: &[Kind<'tcx>],
                                span: Option<Span>)
                                -> Self;
 }
 
 impl<'tcx, T:TypeFoldable<'tcx>> Subst<'tcx> for T {
     fn subst_spanned<'a, 'gcx>(&self, tcx: TyCtxt<'a, 'gcx, 'tcx>,
-                               substs: &Substs<'tcx>,
+                               substs: &[Kind<'tcx>],
                                span: Option<Span>)
                                -> T
     {
@@ -371,7 +358,7 @@ impl<'tcx, T:TypeFoldable<'tcx>> Subst<'tcx> for T {
 
 struct SubstFolder<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
     tcx: TyCtxt<'a, 'gcx, 'tcx>,
-    substs: &'a Substs<'tcx>,
+    substs: &'a [Kind<'tcx>],
 
     // The location for which the substitution is performed, if available.
     span: Option<Span>,
@@ -404,7 +391,7 @@ impl<'a, 'gcx, 'tcx> TypeFolder<'gcx, 'tcx> for SubstFolder<'a, 'gcx, 'tcx> {
         // the specialized routine `ty::replace_late_regions()`.
         match *r {
             ty::ReEarlyBound(data) => {
-                let r = self.substs.params.get(data.index as usize)
+                let r = self.substs.get(data.index as usize)
                             .and_then(|k| k.as_region());
                 match r {
                     Some(r) => {
@@ -461,7 +448,7 @@ impl<'a, 'gcx, 'tcx> TypeFolder<'gcx, 'tcx> for SubstFolder<'a, 'gcx, 'tcx> {
 impl<'a, 'gcx, 'tcx> SubstFolder<'a, 'gcx, 'tcx> {
     fn ty_for_param(&self, p: ty::ParamTy, source_ty: Ty<'tcx>) -> Ty<'tcx> {
         // Look up the type in the substitutions. It really should be in there.
-        let opt_ty = self.substs.params.get(p.idx as usize)
+        let opt_ty = self.substs.get(p.idx as usize)
                          .and_then(|k| k.as_type());
         let ty = match opt_ty {
             Some(t) => t,
@@ -475,7 +462,7 @@ impl<'a, 'gcx, 'tcx> SubstFolder<'a, 'gcx, 'tcx> {
                     source_ty,
                     p.idx,
                     self.root_ty,
-                    self.substs.params);
+                    self.substs);
             }
         };
 
@@ -552,7 +539,7 @@ impl<'a, 'gcx, 'tcx> ty::TraitRef<'tcx> {
                        -> ty::TraitRef<'tcx> {
         let defs = tcx.lookup_generics(trait_id);
 
-        let params = substs.params[..defs.own_count()].iter().cloned();
+        let params = substs[..defs.own_count()].iter().cloned();
         ty::TraitRef {
             def_id: trait_id,
             substs: Substs::new(tcx, params)
@@ -567,7 +554,7 @@ impl<'a, 'gcx, 'tcx> ty::ExistentialTraitRef<'tcx> {
         // Assert there is a Self.
         trait_ref.substs.type_at(0);
 
-        let params = trait_ref.substs.params[1..].iter().cloned();
+        let params = trait_ref.substs[1..].iter().cloned();
         ty::ExistentialTraitRef {
             def_id: trait_ref.def_id,
             substs: Substs::new(tcx, params)
@@ -587,7 +574,7 @@ impl<'a, 'gcx, 'tcx> ty::PolyExistentialTraitRef<'tcx> {
         assert!(!self_ty.has_escaping_regions());
 
         self.map_bound(|trait_ref| {
-            let params = trait_ref.substs.params.iter().cloned();
+            let params = trait_ref.substs.iter().cloned();
             let params = iter::once(Kind::from(self_ty)).chain(params);
             ty::TraitRef {
                 def_id: trait_ref.def_id,

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -250,7 +250,8 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
 
     #[inline]
     pub fn params(&self) -> &[Kind<'tcx>] {
-        &self
+        // FIXME (dikaiosune) this should be removed, and corresponding compilation errors fixed
+        self
     }
 
     #[inline]

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -55,7 +55,7 @@ use hir::def_id::DefId;
 use hir::print as pprust;
 use middle::resolve_lifetime as rl;
 use rustc::lint;
-use rustc::ty::subst::{Subst, Substs};
+use rustc::ty::subst::{Kind, Subst, Substs};
 use rustc::traits;
 use rustc::ty::{self, Ty, TyCtxt, ToPredicate, TypeFoldable};
 use rustc::ty::wf::object_region_bounds;
@@ -124,7 +124,7 @@ pub trait AstConv<'gcx, 'tcx> {
     /// Same as ty_infer, but with a known type parameter definition.
     fn ty_infer_for_def(&self,
                         _def: &ty::TypeParameterDef<'tcx>,
-                        _substs: &Substs<'tcx>,
+                        _substs: &[Kind<'tcx>],
                         span: Span) -> Ty<'tcx> {
         self.ty_infer(span)
     }
@@ -620,7 +620,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
 
     fn convert_parenthesized_parameters(&self,
                                         rscope: &RegionScope,
-                                        region_substs: &Substs<'tcx>,
+                                        region_substs: &[Kind<'tcx>],
                                         data: &hir::ParenthesizedParameterData)
                                         -> (Ty<'tcx>, ConvertedBinding<'tcx>)
     {
@@ -1431,7 +1431,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
     fn ast_ty_arg_to_ty(&self,
                         rscope: &RegionScope,
                         def: Option<&ty::TypeParameterDef<'tcx>>,
-                        region_substs: &Substs<'tcx>,
+                        region_substs: &[Kind<'tcx>],
                         ast_ty: &hir::Ty)
                         -> Ty<'tcx>
     {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -87,7 +87,7 @@ use hir::def::{Def, CtorKind, PathResolution};
 use hir::def_id::{DefId, LOCAL_CRATE};
 use hir::pat_util;
 use rustc::infer::{self, InferCtxt, InferOk, TypeOrigin, TypeTrace, type_variable};
-use rustc::ty::subst::{Subst, Substs};
+use rustc::ty::subst::{Kind, Subst, Substs};
 use rustc::traits::{self, Reveal};
 use rustc::ty::{ParamTy, ParameterEnvironment};
 use rustc::ty::{LvaluePreference, NoPreference, PreferMutLvalue};
@@ -1361,7 +1361,7 @@ impl<'a, 'gcx, 'tcx> AstConv<'gcx, 'tcx> for FnCtxt<'a, 'gcx, 'tcx> {
 
     fn ty_infer_for_def(&self,
                         ty_param_def: &ty::TypeParameterDef<'tcx>,
-                        substs: &Substs<'tcx>,
+                        substs: &[Kind<'tcx>],
                         span: Span) -> Ty<'tcx> {
         self.type_var_for_def(span, ty_param_def, substs)
     }


### PR DESCRIPTION
This changes the definition of `librustc::ty::subst::Substs` to be a type alias to `Slice<Kind>`. `Substs` was already interned, but can now make use of the efficient `PartialEq` and `Hash` impls on `librustc::ty::Slice`.

I'm working on collecting some timing data for this, will update when it's done.

I chose to leave the impls on `Substs<'tcx>` even though it's now just a type alias to `Slice<Kind<'tcx>>` because it has the smallest footprint on other portions of the compiler which depend on its API. It turns out to be a pretty huge diff if you change where Substs's methods live :smile:. That said, I'm not necessarily sure it's the _best_ implementation but it's probably the easiest/smallest to review.

Many thanks to @eddyb for both suggesting this as a project for learning more about the compiler, and the tireless ~~handholding~~ mentorship he provided.
