### PR TITLE
A late diplomatic recognition that most primitive types impl `Copy`.

### DIFF
--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -261,6 +261,16 @@ pub trait Copy : Clone {
     // Empty.
 }
 
+macro_rules! copy_impl {
+    ($($t:ty)*) => ($(
+        #[stable(feature = "rust1", since = "1.0.0")]
+        impl Copy for $t { }
+    )*)
+}
+
+copy_impl! { i8 u8 i16 u16 i32 u32 i64 u64 isize usize f32 f64 bool char }
+copy_impl! { () }
+
 /// Types for which it is safe to share references between threads.
 ///
 /// This trait is automatically implemented when the compiler determines


### PR DESCRIPTION
For types i8 u8 i16 u16 i32 u32 i64 u64 isize usize f32 f64 bool char,
and (), they already implemented `Copy` _implicitly_ since Rust 1.0.
But why not make things explicit?
