### PR TITLE
Optimize `Substs::super_fold_with`.

### DIFF
--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -304,8 +304,15 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
 
 impl<'tcx> TypeFoldable<'tcx> for &'tcx Substs<'tcx> {
     fn super_fold_with<'gcx: 'tcx, F: TypeFolder<'gcx, 'tcx>>(&self, folder: &mut F) -> Self {
-        let params = self.iter().map(|k| k.fold_with(folder)).collect();
-        folder.tcx().mk_substs(params)
+        let params: Vec<_> = self.iter().map(|k| k.fold_with(folder)).collect();
+
+        // If folding doesn't change the substs, it's faster to avoid calling
+        // `mk_substs` and instead reuse the existing substs.
+        if params[..] == self[..] {
+            self
+        } else {
+            folder.tcx().mk_substs(params)
+        }
     }
 
     fn fold_with<'gcx: 'tcx, F: TypeFolder<'gcx, 'tcx>>(&self, folder: &mut F) -> Self {

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -306,8 +306,8 @@ impl<'tcx> TypeFoldable<'tcx> for &'tcx Substs<'tcx> {
     fn super_fold_with<'gcx: 'tcx, F: TypeFolder<'gcx, 'tcx>>(&self, folder: &mut F) -> Self {
         let params: Vec<_> = self.iter().map(|k| k.fold_with(folder)).collect();
 
-        // If folding doesn't change the substs, it's faster to avoid calling
-        // `mk_substs` and instead reuse the existing substs.
+        // If folding doesn't change the substs, it's faster to avoid
+        // calling `mk_substs` and instead reuse the existing substs.
         if params[..] == self[..] {
             self
         } else {


### PR DESCRIPTION
This speeds up some of the rustc-benchmarks by up to ~4%.

```
futures-rs-test  4.467s vs  4.387s --> 1.018x faster (variance: 1.001x, 1.006x)
helloworld       0.242s vs  0.246s --> 0.980x faster (variance: 1.007x, 1.013x)
html5ever-2016-  7.664s vs  7.630s --> 1.004x faster (variance: 1.008x, 1.006x)
hyper.0.5.0      5.218s vs  5.133s --> 1.016x faster (variance: 1.013x, 1.008x)
inflate-0.1.0    5.040s vs  5.103s --> 0.988x faster (variance: 1.005x, 1.008x)
issue-32062-equ  0.361s vs  0.345s --> 1.047x faster (variance: 1.008x, 1.019x)
issue-32278-big  1.874s vs  1.850s --> 1.013x faster (variance: 1.020x, 1.018x)
jld-day15-parse  1.569s vs  1.508s --> 1.040x faster (variance: 1.009x, 1.003x)
piston-image-0. 12.210s vs 11.903s --> 1.026x faster (variance: 1.045x, 1.010x)
regex.0.1.30     2.568s vs  2.555s --> 1.005x faster (variance: 1.018x, 1.044x)
rust-encoding-0  2.139s vs  2.135s --> 1.001x faster (variance: 1.012x, 1.005x)
syntex-0.42.2   33.099s vs 32.353s --> 1.023x faster (variance: 1.003x, 1.028x)
syntex-0.42.2-i 17.989s vs 17.431s --> 1.032x faster (variance: 1.009x, 1.018x)
```

r? @eddyb. I don't know how this interacts with the changes that dikaiosune has been working on.
