### PR TITLE
Disallow Unsized Enums

### DIFF
--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -856,8 +856,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                              trait_name));
             }
             ObligationCauseCode::FieldSized => {
-                err.note("only the last field of a struct or enum variant \
-                          may have a dynamically sized type");
+                err.note("only the last field of a struct may have a dynamically sized type");
             }
             ObligationCauseCode::ConstSized => {
                 err.note("constant expressions must have a statically known size");

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -150,7 +150,7 @@ impl<'ccx, 'gcx> CheckTypeWellFormedVisitor<'ccx, 'gcx> {
                 self.check_variances_for_type_defn(item, ast_generics);
             }
             hir::ItemEnum(ref enum_def, ref ast_generics) => {
-                self.check_type_defn(item, false, |fcx| {
+                self.check_type_defn(item, true, |fcx| {
                     fcx.enum_variants(enum_def)
                 });
 

--- a/src/test/compile-fail/issue-17025.rs
+++ b/src/test/compile-fail/issue-17025.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test the unsized enum no longer compiles
+
 enum A {
     B(char),
     C([Box<A>]),

--- a/src/test/compile-fail/issue-5883.rs
+++ b/src/test/compile-fail/issue-5883.rs
@@ -20,6 +20,4 @@ fn new_struct(r: A+'static)
     Struct { r: r }
 }
 
-trait Curve {}
-enum E {X(Curve+'static)}
 fn main() {}

--- a/src/test/compile-fail/unsized-enum.rs
+++ b/src/test/compile-fail/unsized-enum.rs
@@ -19,11 +19,4 @@ fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
 //
 // Not OK: `T` is not sized.
 
-enum Bar<U: ?Sized> { BarSome(U), BarNone }
-fn bar1<T: ?Sized>() { not_sized::<Bar<T>>() }
-fn bar2<T: ?Sized>() { is_sized::<Bar<T>>() }
-//~^ ERROR `T: std::marker::Sized` is not satisfied
-//
-// Not OK: `Bar<T>` is not sized, but it should be.
-
 fn main() { }

--- a/src/test/compile-fail/unsized-enum2.rs
+++ b/src/test/compile-fail/unsized-enum2.rs
@@ -1,0 +1,68 @@
+// Copyright 206 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::ops::Deref;
+
+// Due to aggressive error message deduplication, we require 20 *different*
+// unsized types (even Path and [u8] are considered the "same").
+
+trait Foo {}
+trait Bar {}
+trait FooBar {}
+trait BarFoo {}
+
+trait PathHelper1 {}
+trait PathHelper2 {}
+trait PathHelper3 {}
+trait PathHelper4 {}
+
+struct Path1(PathHelper1);
+struct Path2(PathHelper2);
+struct Path3(PathHelper3);
+struct Path4(PathHelper4);
+
+enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
+    // parameter
+    VA(W), //~ ERROR `W: std::marker::Sized` is not satisfied
+    VB{x: X}, //~ ERROR `X: std::marker::Sized` is not satisfied
+    VC(isize, Y), //~ ERROR `Y: std::marker::Sized` is not satisfied
+    VD{u: isize, x: Z}, //~ ERROR `Z: std::marker::Sized` is not satisfied
+
+    // slice / str
+    VE([u8]), //~ ERROR `[u8]: std::marker::Sized` is not satisfied
+    VF{x: str}, //~ ERROR `str: std::marker::Sized` is not satisfied
+    VG(isize, [f32]), //~ ERROR `[f32]: std::marker::Sized` is not satisfied
+    VH{u: isize, x: [u32]}, //~ ERROR `[u32]: std::marker::Sized` is not satisfied
+
+    // unsized struct
+    VI(Path1), //~ ERROR `PathHelper1 + 'static: std::marker::Sized` is not satisfied
+    VJ{x: Path2}, //~ ERROR `PathHelper2 + 'static: std::marker::Sized` is not satisfied
+    VK(isize, Path3), //~ ERROR `PathHelper3 + 'static: std::marker::Sized` is not satisfied
+    VL{u: isize, x: Path4}, //~ ERROR `PathHelper4 + 'static: std::marker::Sized` is not satisfied
+
+    // plain trait
+    VM(Foo),  //~ ERROR `Foo + 'static: std::marker::Sized` is not satisfied
+    VN{x: Bar}, //~ ERROR `Bar + 'static: std::marker::Sized` is not satisfied
+    VO(isize, FooBar), //~ ERROR `FooBar + 'static: std::marker::Sized` is not satisfied
+    VP{u: isize, x: BarFoo}, //~ ERROR `BarFoo + 'static: std::marker::Sized` is not satisfied
+
+    // projected
+    VQ(<&'static [i8] as Deref>::Target), //~ ERROR `[i8]: std::marker::Sized` is not satisfied
+    VR{x: <&'static [char] as Deref>::Target},
+    //~^ ERROR `[char]: std::marker::Sized` is not satisfied
+    VS(isize, <&'static [f64] as Deref>::Target),
+    //~^ ERROR `[f64]: std::marker::Sized` is not satisfied
+    VT{u: isize, x: <&'static [i32] as Deref>::Target},
+    //~^ ERROR `[i32]: std::marker::Sized` is not satisfied
+}
+
+
+fn main() { }
+

--- a/src/test/compile-fail/unsized3.rs
+++ b/src/test/compile-fail/unsized3.rs
@@ -31,19 +31,8 @@ fn f3<X: ?Sized + T>(x: &X) {
 fn f4<X: T>(x: &X) {
 }
 
-// Test with unsized enum.
-enum E<X: ?Sized> {
-    V(X),
-}
-
 fn f5<Y>(x: &Y) {}
 fn f6<X: ?Sized>(x: &X) {}
-fn f7<X: ?Sized>(x1: &E<X>, x2: &E<X>) {
-    f5(x1);
-    //~^ ERROR `X: std::marker::Sized` is not satisfied
-    f6(x2); // ok
-}
-
 
 // Test with unsized struct.
 struct S<X: ?Sized> {
@@ -57,13 +46,13 @@ fn f8<X: ?Sized>(x1: &S<X>, x2: &S<X>) {
 }
 
 // Test some tuples.
-fn f9<X: ?Sized>(x1: Box<S<X>>, x2: Box<E<X>>) {
+fn f9<X: ?Sized>(x1: Box<S<X>>) {
     f5(&(*x1, 34));
     //~^ ERROR `X: std::marker::Sized` is not satisfied
 }
 
-fn f10<X: ?Sized>(x1: Box<S<X>>, x2: Box<E<X>>) {
-    f5(&(32, *x2));
+fn f10<X: ?Sized>(x1: Box<S<X>>) {
+    f5(&(32, *x1));
     //~^ ERROR `X: std::marker::Sized` is not satisfied
 }
 

--- a/src/test/run-pass/unsized2.rs
+++ b/src/test/run-pass/unsized2.rs
@@ -89,19 +89,13 @@ trait T7<X: ?Sized+T> {
     fn m2(&self, x: &T5<X>);
 }
 
-// The last field in a struct or variant may be unsized
+// The last field in a struct may be unsized
 struct S2<X: ?Sized> {
     f: X,
 }
 struct S3<X: ?Sized> {
     f1: isize,
     f2: X,
-}
-enum E<X: ?Sized> {
-    V1(X),
-    V2{x: X},
-    V3(isize, X),
-    V4{u: isize, x: X},
 }
 
 pub fn main() {


### PR DESCRIPTION
Fixes #16812.

This PR is a potential fix for #16812, an issue which is reported [again](https://github.com/rust-lang/rust/issues/36801) and [again](https://github.com/rust-lang/rust/issues/36975), with over a dozen duplicates by now.

This PR is mainly meant to promoted discussion about the issue and the correct way to fix it.

This is a [breaking-change] since the error is now reported during wfchecking, so that even the definition of a (potentially) unsized enum will cause an error (whereas it would previously cause an ICE at trans time if the enum was used in an unsized manner).
