### PR TITLE
Fix ICE: inject bitcast if types mismatch for invokes/calls/stores

### DIFF
--- a/src/test/run-pass/issue-36744-bitcast-args-if-needed.rs
+++ b/src/test/run-pass/issue-36744-bitcast-args-if-needed.rs
@@ -1,0 +1,32 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This tests for an ICE (and, if ignored, subsequent LLVM abort) when
+// a lifetime-parametric fn is passed into a context whose expected
+// type has a differing lifetime parameterization.
+
+struct A<'a> {
+    _a: &'a i32,
+}
+
+fn call<T>(s: T, functions: &Vec<for <'n> fn(&'n T)>) {
+    for function in functions {
+        function(&s);
+    }
+}
+
+fn f(a: &A) { println!("a holds {}", a._a); }
+
+fn main() {
+    let a = A { _a: &10 };
+
+    let vec: Vec<for <'u,'v> fn(&'u A<'v>)> = vec![f];
+    call(a, &vec);
+}

--- a/src/test/run-pass/issue-36744-without-calls.rs
+++ b/src/test/run-pass/issue-36744-without-calls.rs
@@ -1,0 +1,22 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests for an LLVM abort when storing a lifetime-parametric fn into
+// context that is expecting one that is not lifetime-parametric
+// (i.e. has no `for <'_>`).
+
+pub struct A<'a>(&'a ());
+pub struct S<T>(T);
+
+pub fn bad<'s>(v: &mut S<fn(A<'s>)>, y: S<for<'b> fn(A<'b>)>) {
+    *v = y;
+}
+
+fn main() {}


### PR DESCRIPTION
Fix ICE: inject bitcast if types mismatch for invokes/calls

Partial fix for #36744 
