### PR TITLE
book: remove backticks in Type Aliases header

### DIFF
--- a/src/doc/book/type-aliases.md
+++ b/src/doc/book/type-aliases.md
@@ -1,4 +1,4 @@
-% `type` Aliases
+% Type Aliases
 
 The `type` keyword lets you declare an alias of another type:
 


### PR DESCRIPTION
Fix #37116.
