### PR TITLE
Port libstd to "no operating system" target

### DIFF
--- a/src/libpanic_abort/Cargo.toml
+++ b/src/libpanic_abort/Cargo.toml
@@ -9,4 +9,6 @@ test = false
 
 [dependencies]
 core = { path = "../libcore" }
+
+[target.'cfg(all(unix,not(target_os="none")))'.dependencies]
 libc = { path = "../rustc/libc_shim" }

--- a/src/libpanic_abort/lib.rs
+++ b/src/libpanic_abort/lib.rs
@@ -27,8 +27,8 @@
 
 #![panic_runtime]
 #![feature(panic_runtime)]
-#![cfg_attr(unix, feature(libc))]
-#![cfg_attr(windows, feature(core_intrinsics))]
+#![cfg_attr(all(unix,not(target_os="none")), feature(libc))]
+#![cfg_attr(any(windows,target_os="none"), feature(core_intrinsics))]
 
 // Rust's "try" function, but if we're aborting on panics we just call the
 // function as there's nothing else we need to do here.
@@ -55,13 +55,13 @@ pub unsafe extern fn __rust_maybe_catch_panic(f: fn(*mut u8),
 pub unsafe extern fn __rust_start_panic(_data: usize, _vtable: usize) -> u32 {
     return abort();
 
-    #[cfg(unix)]
+    #[cfg(all(unix,not(target_os="none")))]
     unsafe fn abort() -> ! {
         extern crate libc;
         libc::abort();
     }
 
-    #[cfg(windows)]
+    #[cfg(any(windows,target_os="none"))]
     unsafe fn abort() -> ! {
         core::intrinsics::abort();
     }

--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -11,16 +11,18 @@ crate-type = ["dylib", "rlib"]
 
 [dependencies]
 alloc = { path = "../liballoc" }
-alloc_jemalloc = { path = "../liballoc_jemalloc", optional = true }
-alloc_system = { path = "../liballoc_system" }
-panic_unwind = { path = "../libpanic_unwind" }
 panic_abort = { path = "../libpanic_abort" }
 collections = { path = "../libcollections" }
 core = { path = "../libcore" }
-libc = { path = "../rustc/libc_shim" }
 rand = { path = "../librand" }
 compiler_builtins = { path = "../libcompiler_builtins" }
 rustc_unicode = { path = "../librustc_unicode" }
+
+[target.'cfg(not(target_os="none"))'.dependencies]
+libc = { path = "../rustc/libc_shim" }
+alloc_jemalloc = { path = "../liballoc_jemalloc", optional = true }
+alloc_system = { path = "../liballoc_system" }
+panic_unwind = { path = "../libpanic_unwind" }
 unwind = { path = "../libunwind" }
 
 [build-dependencies]

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -314,10 +314,14 @@ extern crate collections as core_collections;
 #[allow(deprecated)] extern crate rand as core_rand;
 extern crate alloc;
 extern crate rustc_unicode;
-extern crate libc;
+#[cfg(not(target_os="none"))] extern crate libc;
+#[cfg(target_os="none")] 
+mod libc {
+	pub use os::none::libc::*;
+}
 
 // We always need an unwinder currently for backtraces
-extern crate unwind;
+#[cfg(not(target_os="none"))] extern crate unwind;
 
 #[cfg(stage0)]
 extern crate alloc_system;
@@ -457,8 +461,10 @@ mod memchr;
 #[macro_use]
 #[path = "sys/common/mod.rs"] mod sys_common;
 
-#[cfg(unix)]
+#[cfg(all(unix,not(target_os="none")))]
 #[path = "sys/unix/mod.rs"] mod sys;
+#[cfg(target_os="none")]
+#[path = "sys/none/mod.rs"] mod sys;
 #[cfg(windows)]
 #[path = "sys/windows/mod.rs"] mod sys;
 

--- a/src/libstd/os/mod.rs
+++ b/src/libstd/os/mod.rs
@@ -33,5 +33,6 @@ pub use sys::ext as windows;
 #[cfg(target_os = "openbsd")]   pub mod openbsd;
 #[cfg(target_os = "solaris")]   pub mod solaris;
 #[cfg(target_os = "emscripten")] pub mod emscripten;
+#[cfg(target_os = "none")]      pub mod none;
 
 pub mod raw;

--- a/src/libstd/os/none/libc.rs
+++ b/src/libstd/os/none/libc.rs
@@ -1,0 +1,119 @@
+pub use os::raw::*;
+
+pub type size_t = usize;
+pub type ssize_t = isize;
+
+// Process/File definitions
+
+pub type mode_t = u32;
+pub type pid_t = u32;
+pub type gid_t = u32;
+pub type uid_t = u32;
+
+pub const S_IFBLK: mode_t = 0;
+pub const S_IFCHR: mode_t = 0;
+pub const S_IFIFO: mode_t = 0;
+pub const S_IFSOCK: mode_t = 0;
+
+// Threading
+
+#[derive(Copy,Clone)]
+pub struct pthread_t(());
+pub struct pthread_attr_t(());
+
+// Time definitions
+
+pub type time_t = i64;
+
+#[derive(Copy,Clone)]
+pub struct timespec {
+    pub tv_sec: time_t,
+    pub tv_nsec: c_long,
+}
+
+pub const CLOCK_MONOTONIC: c_int = 0;
+pub const CLOCK_REALTIME: c_int = 0;
+
+// Networking definitions
+
+pub type sa_family_t = u16;
+pub type in_port_t = u16;
+
+#[derive(Copy,Clone)]
+pub struct in_addr {
+    pub s_addr: u32,
+}
+
+#[derive(Copy,Clone)]
+pub struct sockaddr_in {
+    pub sin_family: sa_family_t,
+    pub sin_port: in_port_t,
+    pub sin_addr: in_addr,
+    pub sin_zero: [u8; 8],
+}
+
+#[derive(Copy,Clone)]
+pub struct ip_mreq {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
+}
+
+#[derive(Copy,Clone)]
+pub struct in6_addr {
+    pub s6_addr: [u8; 16],
+}
+
+#[derive(Copy,Clone)]
+pub struct sockaddr_in6 {
+    pub sin6_family: sa_family_t,
+    pub sin6_port: in_port_t,
+    pub sin6_flowinfo: u32,
+    pub sin6_addr: in6_addr,
+    pub sin6_scope_id: u32,
+}
+
+#[derive(Copy,Clone)]
+pub struct ipv6_mreq {
+    pub ipv6mr_multiaddr: in6_addr,
+    pub ipv6mr_interface: c_uint,
+}
+
+pub const AF_INET6: c_int = 0;
+pub const AF_INET: c_int = 0;
+pub const AF_UNIX: c_int = 0;
+pub const IPPROTO_IPV6: c_int = 0;
+pub const IPPROTO_IP: c_int = 0;
+pub const IPV6_ADD_MEMBERSHIP: c_int = 0;
+pub const IPV6_DROP_MEMBERSHIP: c_int = 0;
+pub const IPV6_MULTICAST_LOOP: c_int = 0;
+pub const IPV6_V6ONLY: c_int = 0;
+pub const IP_ADD_MEMBERSHIP: c_int = 0;
+pub const IP_DROP_MEMBERSHIP: c_int = 0;
+pub const IP_MULTICAST_LOOP: c_int = 0;
+pub const IP_MULTICAST_TTL: c_int = 0;
+pub const IP_TTL: c_int = 0;
+pub const SOCK_DGRAM: c_int = 0;
+pub const SOCK_STREAM: c_int = 0;
+pub const SOL_SOCKET: c_int = 0;
+pub const SO_BROADCAST: c_int = 0;
+pub const SO_RCVTIMEO: c_int = 0;
+pub const SO_REUSEADDR: c_int = 0;
+pub const SO_SNDTIMEO: c_int = 0;
+
+pub struct sockaddr(());
+#[derive(Clone)]
+pub struct sockaddr_un(());
+pub type socklen_t = u32;
+pub struct sockaddr_storage(());
+
+// C functions
+
+pub unsafe fn strlen(s: *const c_char) -> size_t {
+	let mut i=0isize;
+	loop {
+		if *s.offset(i)==0 {
+			return i as usize
+		}
+		i+=1;
+	}
+}

--- a/src/libstd/os/none/mod.rs
+++ b/src/libstd/os/none/mod.rs
@@ -1,0 +1,4 @@
+#![stable(feature = "raw_ext", since = "1.1.0")]
+
+#[unstable(reason = "not public", issue = "0", feature = "libc_shim")] pub mod libc;
+pub mod raw;

--- a/src/libstd/os/none/raw.rs
+++ b/src/libstd/os/none/raw.rs
@@ -1,0 +1,16 @@
+#![stable(feature = "raw_ext", since = "1.1.0")]
+#![rustc_deprecated(since = "1.8.0",
+                    reason = "these type aliases are no longer supported by \
+                              the standard library, the `libc` crate on \
+                              crates.io should be used instead for the correct \
+                              definitions")]
+
+#[stable(feature = "raw_ext", since = "1.1.0")] pub struct blkcnt_t;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub struct blksize_t;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub struct dev_t;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub struct ino_t;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub struct mode_t;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub struct nlink_t;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub struct off_t;
+#[stable(feature = "pthread_t", since = "1.8.0")]pub use super::libc::pthread_t;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub struct time_t;

--- a/src/libstd/sys/common/io.rs
+++ b/src/libstd/sys/common/io.rs
@@ -7,6 +7,8 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+#![cfg(not(target_os = "none"))]
+
 use io;
 use io::ErrorKind;
 use io::Read;

--- a/src/libstd/sys/common/net.rs
+++ b/src/libstd/sys/common/net.rs
@@ -8,17 +8,30 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(not(target_os = "none"))]
 use cmp;
+#[cfg(not(target_os = "none"))]
 use ffi::CString;
 use fmt;
-use io::{self, Error, ErrorKind};
-use libc::{c_int, c_void};
+use io;
+#[cfg(not(target_os = "none"))]
+use io::{Error, ErrorKind};
+use libc::c_int;
+#[cfg(not(target_os = "none"))]
+use libc::c_void;
 use mem;
 use net::{SocketAddr, Shutdown, Ipv4Addr, Ipv6Addr};
+#[cfg(not(target_os = "none"))]
 use ptr;
-use sys::net::{cvt, cvt_r, cvt_gai, Socket, init, wrlen_t};
+use sys::net::Socket;
+#[cfg(not(target_os = "none"))]
+use sys::net::init;
+#[cfg(not(target_os="none"))]
+use sys::net::{cvt, cvt_r, cvt_gai, wrlen_t};
 use sys::net::netc as c;
-use sys_common::{AsInner, FromInner, IntoInner};
+use sys_common::{AsInner, FromInner};
+#[cfg(not(target_os = "none"))]
+use sys_common::IntoInner;
 use time::Duration;
 
 #[cfg(any(target_os = "dragonfly", target_os = "freebsd",
@@ -44,13 +57,14 @@ use sys::net::netc::IPV6_DROP_MEMBERSHIP;
 
 #[cfg(target_os = "linux")]
 use libc::MSG_NOSIGNAL;
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(not(target_os = "linux"), not(target_os = "none")))]
 const MSG_NOSIGNAL: c_int = 0x0; // unused dummy value
 
 ////////////////////////////////////////////////////////////////////////////////
 // sockaddr and misc bindings
 ////////////////////////////////////////////////////////////////////////////////
 
+#[cfg(not(target_os="none"))]
 pub fn setsockopt<T>(sock: &Socket, opt: c_int, val: c_int,
                      payload: T) -> io::Result<()> {
     unsafe {
@@ -61,6 +75,7 @@ pub fn setsockopt<T>(sock: &Socket, opt: c_int, val: c_int,
     }
 }
 
+#[cfg(not(target_os="none"))]
 pub fn getsockopt<T: Copy>(sock: &Socket, opt: c_int,
                        val: c_int) -> io::Result<T> {
     unsafe {
@@ -74,6 +89,7 @@ pub fn getsockopt<T: Copy>(sock: &Socket, opt: c_int,
     }
 }
 
+#[cfg(not(target_os="none"))]
 fn sockname<F>(f: F) -> io::Result<SocketAddr>
     where F: FnOnce(*mut c::sockaddr, *mut c::socklen_t) -> c_int
 {
@@ -85,6 +101,7 @@ fn sockname<F>(f: F) -> io::Result<SocketAddr>
     }
 }
 
+#[cfg(not(target_os="none"))]
 fn sockaddr_to_addr(storage: &c::sockaddr_storage,
                     len: usize) -> io::Result<SocketAddr> {
     match storage.ss_family as c_int {
@@ -106,6 +123,24 @@ fn sockaddr_to_addr(storage: &c::sockaddr_storage,
     }
 }
 
+#[cfg(target_os="none")]
+pub fn setsockopt<T>(_sock: &Socket, _opt: c_int, _val: c_int,
+                     _payload: T) -> io::Result<()> {
+    Err(::sys::net::generic_error())
+}
+
+#[cfg(target_os="none")]
+pub fn getsockopt<T: Copy>(_sock: &Socket, _opt: c_int,
+                       _val: c_int) -> io::Result<T> {
+    Err(::sys::net::generic_error())
+}
+
+#[cfg(target_os="none")]
+fn sockaddr_to_addr(_storage: &c::sockaddr_storage,
+                    _len: usize) -> io::Result<SocketAddr> {
+    Err(::sys::net::generic_error())
+}
+
 #[cfg(target_os = "android")]
 fn to_ipv6mr_interface(value: u32) -> c_int {
     value as c_int
@@ -120,13 +155,18 @@ fn to_ipv6mr_interface(value: u32) -> ::libc::c_uint {
 // get_host_addresses
 ////////////////////////////////////////////////////////////////////////////////
 
+#[cfg(not(target_os="none"))]
 pub struct LookupHost {
     original: *mut c::addrinfo,
     cur: *mut c::addrinfo,
 }
+#[cfg(target_os="none")]
+pub struct LookupHost;
 
 impl Iterator for LookupHost {
     type Item = SocketAddr;
+
+    #[cfg(not(target_os="none"))]
     fn next(&mut self) -> Option<SocketAddr> {
         loop {
             unsafe {
@@ -144,17 +184,27 @@ impl Iterator for LookupHost {
             }
         }
     }
+
+    #[cfg(target_os="none")]
+    fn next(&mut self) -> Option<SocketAddr> {
+        None
+    }
 }
 
 unsafe impl Sync for LookupHost {}
 unsafe impl Send for LookupHost {}
 
 impl Drop for LookupHost {
+    #[cfg(not(target_os="none"))]
     fn drop(&mut self) {
         unsafe { c::freeaddrinfo(self.original) }
     }
+
+    #[cfg(target_os="none")]
+    fn drop(&mut self) {}
 }
 
+#[cfg(not(target_os="none"))]
 pub fn lookup_host(host: &str) -> io::Result<LookupHost> {
     init();
 
@@ -177,6 +227,12 @@ pub fn lookup_host(host: &str) -> io::Result<LookupHost> {
     }
 }
 
+#[cfg(target_os="none")]
+pub fn lookup_host(_host: &str) -> io::Result<LookupHost> {
+    Err(::sys::net::generic_error())
+}
+
+
 ////////////////////////////////////////////////////////////////////////////////
 // TCP streams
 ////////////////////////////////////////////////////////////////////////////////
@@ -186,6 +242,7 @@ pub struct TcpStream {
 }
 
 impl TcpStream {
+    #[cfg(not(target_os="none"))]
     pub fn connect(addr: &SocketAddr) -> io::Result<TcpStream> {
         init();
 
@@ -194,6 +251,11 @@ impl TcpStream {
         let (addrp, len) = addr.into_inner();
         cvt_r(|| unsafe { c::connect(*sock.as_inner(), addrp, len) })?;
         Ok(TcpStream { inner: sock })
+    }
+
+    #[cfg(target_os="none")]
+    pub fn connect(_addr: &SocketAddr) -> io::Result<TcpStream> {
+        Err(::sys::net::generic_error())
     }
 
     pub fn socket(&self) -> &Socket { &self.inner }
@@ -224,6 +286,7 @@ impl TcpStream {
         self.inner.read_to_end(buf)
     }
 
+    #[cfg(not(target_os="none"))]
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
         let len = cmp::min(buf.len(), <wrlen_t>::max_value() as usize) as wrlen_t;
         let ret = cvt(unsafe {
@@ -235,16 +298,33 @@ impl TcpStream {
         Ok(ret as usize)
     }
 
+    #[cfg(target_os="none")]
+    pub fn write(&self, _buf: &[u8]) -> io::Result<usize> {
+        Err(::sys::net::generic_error())
+    }
+
+    #[cfg(not(target_os="none"))]
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
         sockname(|buf, len| unsafe {
             c::getpeername(*self.inner.as_inner(), buf, len)
         })
     }
 
+    #[cfg(target_os="none")]
+    pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+        Err(::sys::net::generic_error())
+    }
+
+    #[cfg(not(target_os="none"))]
     pub fn socket_addr(&self) -> io::Result<SocketAddr> {
         sockname(|buf, len| unsafe {
             c::getsockname(*self.inner.as_inner(), buf, len)
         })
+    }
+
+    #[cfg(target_os="none")]
+    pub fn socket_addr(&self) -> io::Result<SocketAddr> {
+        Err(::sys::net::generic_error())
     }
 
     pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {
@@ -314,6 +394,7 @@ pub struct TcpListener {
 }
 
 impl TcpListener {
+    #[cfg(not(target_os="none"))]
     pub fn bind(addr: &SocketAddr) -> io::Result<TcpListener> {
         init();
 
@@ -336,14 +417,25 @@ impl TcpListener {
         Ok(TcpListener { inner: sock })
     }
 
+    #[cfg(target_os="none")]
+    pub fn bind(_addr: &SocketAddr) -> io::Result<TcpListener> {
+        Err(::sys::net::generic_error())
+    }
+
     pub fn socket(&self) -> &Socket { &self.inner }
 
     pub fn into_socket(self) -> Socket { self.inner }
 
+    #[cfg(not(target_os="none"))]
     pub fn socket_addr(&self) -> io::Result<SocketAddr> {
         sockname(|buf, len| unsafe {
             c::getsockname(*self.inner.as_inner(), buf, len)
         })
+    }
+
+    #[cfg(target_os="none")]
+    pub fn socket_addr(&self) -> io::Result<SocketAddr> {
+        Err(::sys::net::generic_error())
     }
 
     pub fn accept(&self) -> io::Result<(TcpStream, SocketAddr)> {
@@ -415,6 +507,7 @@ pub struct UdpSocket {
 }
 
 impl UdpSocket {
+    #[cfg(not(target_os="none"))]
     pub fn bind(addr: &SocketAddr) -> io::Result<UdpSocket> {
         init();
 
@@ -424,16 +517,28 @@ impl UdpSocket {
         Ok(UdpSocket { inner: sock })
     }
 
+    #[cfg(target_os="none")]
+    pub fn bind(_addr: &SocketAddr) -> io::Result<UdpSocket> {
+        Err(::sys::net::generic_error())
+    }
+
     pub fn socket(&self) -> &Socket { &self.inner }
 
     pub fn into_socket(self) -> Socket { self.inner }
 
+    #[cfg(not(target_os="none"))]
     pub fn socket_addr(&self) -> io::Result<SocketAddr> {
         sockname(|buf, len| unsafe {
             c::getsockname(*self.inner.as_inner(), buf, len)
         })
     }
 
+    #[cfg(target_os="none")]
+    pub fn socket_addr(&self) -> io::Result<SocketAddr> {
+        Err(::sys::net::generic_error())
+    }
+
+    #[cfg(not(target_os="none"))]
     pub fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
         let mut storage: c::sockaddr_storage = unsafe { mem::zeroed() };
         let mut addrlen = mem::size_of_val(&storage) as c::socklen_t;
@@ -448,6 +553,12 @@ impl UdpSocket {
         Ok((n as usize, sockaddr_to_addr(&storage, addrlen as usize)?))
     }
 
+    #[cfg(target_os="none")]
+    pub fn recv_from(&self, _buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+        Err(::sys::net::generic_error())
+    }
+
+    #[cfg(not(target_os="none"))]
     pub fn send_to(&self, buf: &[u8], dst: &SocketAddr) -> io::Result<usize> {
         let len = cmp::min(buf.len(), <wrlen_t>::max_value() as usize) as wrlen_t;
         let (dstp, dstlen) = dst.into_inner();
@@ -457,6 +568,11 @@ impl UdpSocket {
                       MSG_NOSIGNAL, dstp, dstlen)
         })?;
         Ok(ret as usize)
+    }
+
+    #[cfg(target_os="none")]
+    pub fn send_to(&self, _buf: &[u8], _dst: &SocketAddr) -> io::Result<usize> {
+        Err(::sys::net::generic_error())
     }
 
     pub fn duplicate(&self) -> io::Result<UdpSocket> {
@@ -572,6 +688,7 @@ impl UdpSocket {
         self.inner.read(buf)
     }
 
+    #[cfg(not(target_os="none"))]
     pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
         let len = cmp::min(buf.len(), <wrlen_t>::max_value() as usize) as wrlen_t;
         let ret = cvt(unsafe {
@@ -583,9 +700,20 @@ impl UdpSocket {
         Ok(ret as usize)
     }
 
+    #[cfg(target_os="none")]
+    pub fn send(&self, _buf: &[u8]) -> io::Result<usize> {
+        Err(::sys::net::generic_error())
+    }
+
+    #[cfg(not(target_os="none"))]
     pub fn connect(&self, addr: &SocketAddr) -> io::Result<()> {
         let (addrp, len) = addr.into_inner();
         cvt_r(|| unsafe { c::connect(*self.inner.as_inner(), addrp, len) }).map(|_| ())
+    }
+
+    #[cfg(target_os="none")]
+    pub fn connect(&self, _addr: &SocketAddr) -> io::Result<()> {
+        Err(::sys::net::generic_error())
     }
 }
 

--- a/src/libstd/sys/common/thread.rs
+++ b/src/libstd/sys/common/thread.rs
@@ -8,10 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(not(target_os = "none"))]
 use alloc::boxed::FnBox;
+#[cfg(not(target_os = "none"))]
 use libc;
+#[cfg(not(target_os = "none"))]
 use sys::stack_overflow;
 
+#[cfg(not(target_os = "none"))]
 pub unsafe fn start_thread(main: *mut libc::c_void) {
     // Next, set up our stack overflow handler which may get triggered if we run
     // out of stack.

--- a/src/libstd/sys/common/util.rs
+++ b/src/libstd/sys/common/util.rs
@@ -40,9 +40,14 @@ pub fn dumb_print(args: fmt::Arguments) {
 // understandable error message like "Abort trap" rather than "Illegal
 // instruction" that intrinsics::abort would cause, as intrinsics::abort is
 // implemented as an illegal instruction.
-#[cfg(unix)]
+#[cfg(all(unix,not(target_os = "none")))]
 unsafe fn abort_internal() -> ! {
     ::libc::abort()
+}
+
+#[cfg(target_os = "none")]
+unsafe fn abort_internal() -> ! {
+    ::intrinsics::abort()
 }
 
 // On Windows, use the processor-specific __fastfail mechanism.  In Windows 8

--- a/src/libstd/sys/none/condvar.rs
+++ b/src/libstd/sys/none/condvar.rs
@@ -1,0 +1,17 @@
+use sys::mutex::Mutex;
+use time::Duration;
+
+pub struct Condvar(());
+
+unsafe impl Send for Condvar {}
+unsafe impl Sync for Condvar {}
+
+impl Condvar {
+    #[inline] pub const fn new() -> Condvar { Condvar(()) }
+    #[inline] pub unsafe fn init(&mut self) {}
+    #[inline] pub unsafe fn notify_one(&self) {}
+    #[inline] pub unsafe fn notify_all(&self) {}
+    #[inline] pub unsafe fn wait(&self, _mutex: &Mutex) {}
+    #[inline] pub unsafe fn wait_timeout(&self, _mutex: &Mutex, _dur: Duration) -> bool { true }
+    #[inline] pub unsafe fn destroy(&self) {}
+}

--- a/src/libstd/sys/none/env.rs
+++ b/src/libstd/sys/none/env.rs
@@ -1,0 +1,15 @@
+use io;
+
+pub fn generic_error() -> io::Error {
+    io::Error::new(io::ErrorKind::Other, "environment variables not supported on this platform")
+}
+
+pub mod os {
+    pub const FAMILY: &'static str = "unix";
+    pub const OS: &'static str = "none";
+    pub const DLL_PREFIX: &'static str = "lib";
+    pub const DLL_SUFFIX: &'static str = ".so";
+    pub const DLL_EXTENSION: &'static str = "so";
+    pub const EXE_SUFFIX: &'static str = "";
+    pub const EXE_EXTENSION: &'static str = "";
+}

--- a/src/libstd/sys/none/fd.rs
+++ b/src/libstd/sys/none/fd.rs
@@ -1,0 +1,40 @@
+#![unstable(reason = "not public", issue = "0", feature = "fd")]
+
+use io::{self, Read};
+use libc::c_int;
+use sys::fs::generic_error;
+use sys_common::AsInner;
+
+#[derive(Debug)]
+pub struct FileDesc {
+    fd: c_int,
+}
+
+impl FileDesc {
+    pub fn new(fd: c_int) -> FileDesc {
+        FileDesc { fd: fd }
+    }
+
+    pub fn raw(&self) -> c_int { self.fd }
+    pub fn into_raw(self) -> c_int { self.fd}
+
+    pub fn read(&self, _buf: &mut [u8]) -> io::Result<usize> { Err(generic_error()) }
+    pub fn read_to_end(&self, _buf: &mut Vec<u8>) -> io::Result<usize> { Err(generic_error()) }
+    pub fn write(&self, _buf: &[u8]) -> io::Result<usize> { Err(generic_error()) }
+    pub fn set_cloexec(&self) -> io::Result<()> { Err(generic_error()) }
+    pub fn set_nonblocking(&self, _nonblocking: bool) -> io::Result<()> { Err(generic_error()) }
+    pub fn duplicate(&self) -> io::Result<FileDesc> { Err(generic_error()) }
+}
+
+impl<'a> Read for &'a FileDesc {
+    fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> { Err(generic_error()) }
+    fn read_to_end(&mut self, _buf: &mut Vec<u8>) -> io::Result<usize> { Err(generic_error()) }
+}
+
+impl AsInner<c_int> for FileDesc {
+    fn as_inner(&self) -> &c_int { &self.fd }
+}
+
+impl Drop for FileDesc {
+    fn drop(&mut self) {}
+}

--- a/src/libstd/sys/none/fs.rs
+++ b/src/libstd/sys/none/fs.rs
@@ -1,0 +1,180 @@
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use io;
+use libc::{c_int,mode_t};
+use ffi::OsString;
+use path::{Path,PathBuf};
+use sys::fd::FileDesc;
+use sys::time::SystemTime;
+use sys_common::FromInner;
+
+#[derive(Debug)]
+pub struct File(FileDesc);
+#[derive(Clone)]
+pub struct FileAttr(());
+pub struct ReadDir(());
+pub struct DirEntry(());
+#[derive(Clone)]
+pub struct OpenOptions(());
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct FilePermissions(());
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub struct FileType(());
+pub struct DirBuilder(());
+
+pub fn generic_error() -> io::Error {
+    io::Error::new(io::ErrorKind::Other, "filesystem not supported on this platform")
+}
+
+impl FileAttr {
+    pub fn size(&self) -> u64 { unimplemented!() }
+    pub fn perm(&self) -> FilePermissions { unimplemented!() }
+    pub fn file_type(&self) -> FileType { unimplemented!() }
+    pub fn modified(&self) -> io::Result<SystemTime> { Err(generic_error()) }
+    pub fn accessed(&self) -> io::Result<SystemTime> { Err(generic_error()) }
+    pub fn created(&self) -> io::Result<SystemTime> { Err(generic_error()) }
+}
+
+/*
+impl AsInner<stat64> for FileAttr {
+    fn as_inner(&self) -> &stat64 { ... }
+}
+*/
+
+impl FilePermissions {
+    pub fn readonly(&self) -> bool { unimplemented!() }
+    pub fn set_readonly(&mut self, _readonly: bool) { unimplemented!() }
+    pub fn mode(&self) -> u32 { unimplemented!() }
+}
+
+impl FromInner<u32> for FilePermissions {
+    fn from_inner(_mode: u32) -> FilePermissions {
+        FilePermissions(())
+    }
+}
+
+impl FileType {
+    pub fn is_dir(&self) -> bool { false }
+    pub fn is_file(&self) -> bool { false }
+    pub fn is_symlink(&self) -> bool { false }
+    pub fn is(&self, _mode: mode_t) -> bool { false }
+}
+
+impl Iterator for ReadDir {
+    type Item = io::Result<DirEntry>;
+    fn next(&mut self) -> Option<io::Result<DirEntry>> { Some(Err(generic_error())) }
+}
+
+impl DirEntry {
+    pub fn path(&self) -> PathBuf { unimplemented!() }
+    pub fn file_name(&self) -> OsString { unimplemented!() }
+    pub fn metadata(&self) -> io::Result<FileAttr> { Err(generic_error()) }
+
+    pub fn file_type(&self) -> io::Result<FileType> { Err(generic_error()) }
+
+    pub fn ino(&self) -> u64 { unimplemented!() }
+}
+
+impl OpenOptions {
+    pub fn new() -> OpenOptions { OpenOptions(()) }
+
+    pub fn read(&mut self, _read: bool) {}
+    pub fn write(&mut self, _write: bool) {}
+    pub fn append(&mut self, _append: bool) {}
+    pub fn truncate(&mut self, _truncate: bool) {}
+    pub fn create(&mut self, _create: bool) {}
+    pub fn create_new(&mut self, _create_new: bool) {}
+
+    pub fn custom_flags(&mut self, _flags: i32) {}
+    pub fn mode(&mut self, _mode: u32) {}
+}
+
+impl File {
+    pub fn open(_path: &Path, _opts: &OpenOptions) -> io::Result<File> { Err(generic_error()) }
+    pub fn file_attr(&self) -> io::Result<FileAttr> { Err(generic_error()) }
+    pub fn fsync(&self) -> io::Result<()> { Err(generic_error()) }
+    pub fn datasync(&self) -> io::Result<()> { Err(generic_error()) }
+    pub fn truncate(&self, _size: u64) -> io::Result<()> { Err(generic_error()) }
+    pub fn read(&self, _buf: &mut [u8]) -> io::Result<usize> { Err(generic_error()) }
+    pub fn read_to_end(&self, _buf: &mut Vec<u8>) -> io::Result<usize> { Err(generic_error()) }
+    pub fn write(&self, _buf: &[u8]) -> io::Result<usize> { Err(generic_error()) }
+    pub fn flush(&self) -> io::Result<()> { Err(generic_error()) }
+    pub fn seek(&self, _pos: io::SeekFrom) -> io::Result<u64> { Err(generic_error()) }
+    pub fn duplicate(&self) -> io::Result<File> { Err(generic_error()) }
+
+    pub fn fd(&self) -> &FileDesc { &self.0 }
+
+    pub fn into_fd(self) -> FileDesc { self.0 }
+}
+
+impl FromInner<c_int> for File {
+    fn from_inner(fd: c_int) -> File {
+        File(FileDesc::new(fd))
+    }
+}
+
+impl DirBuilder {
+    pub fn new() -> DirBuilder { DirBuilder(()) }
+    pub fn mkdir(&self, _p: &Path) -> io::Result<()> { Err(generic_error()) }
+    pub fn set_mode(&mut self, _mode: u32) {}
+}
+
+pub fn readdir(_p: &Path) -> io::Result<ReadDir> { Err(generic_error()) }
+pub fn unlink(_p: &Path) -> io::Result<()> { Err(generic_error()) }
+pub fn rename(_old: &Path, _new: &Path) -> io::Result<()> { Err(generic_error()) }
+pub fn set_perm(_p: &Path, _perm: FilePermissions) -> io::Result<()> { Err(generic_error()) }
+pub fn rmdir(_p: &Path) -> io::Result<()> { Err(generic_error()) }
+pub fn remove_dir_all(_path: &Path) -> io::Result<()> { Err(generic_error()) }
+pub fn readlink(_p: &Path) -> io::Result<PathBuf> { Err(generic_error()) }
+pub fn symlink(_src: &Path, _dst: &Path) -> io::Result<()> { Err(generic_error()) }
+pub fn link(_src: &Path, _dst: &Path) -> io::Result<()> { Err(generic_error()) }
+pub fn stat(_p: &Path) -> io::Result<FileAttr> { Err(generic_error()) }
+pub fn lstat(_p: &Path) -> io::Result<FileAttr> { Err(generic_error()) }
+pub fn canonicalize(_p: &Path) -> io::Result<PathBuf> { Err(generic_error()) }
+pub fn copy(_from: &Path, _to: &Path) -> io::Result<u64> { Err(generic_error()) }
+
+pub trait MetadataExt {
+    fn st_dev(&self) -> u64;
+    fn st_ino(&self) -> u64;
+    fn st_mode(&self) -> u32;
+    fn st_nlink(&self) -> u64;
+    fn st_uid(&self) -> u32;
+    fn st_gid(&self) -> u32;
+    fn st_rdev(&self) -> u64;
+    fn st_size(&self) -> u64;
+    fn st_atime(&self) -> i64;
+    fn st_atime_nsec(&self) -> i64;
+    fn st_mtime(&self) -> i64;
+    fn st_mtime_nsec(&self) -> i64;
+    fn st_ctime(&self) -> i64;
+    fn st_ctime_nsec(&self) -> i64;
+    fn st_blksize(&self) -> u64;
+    fn st_blocks(&self) -> u64;
+}
+
+impl MetadataExt for ::fs::Metadata {
+    fn st_dev(&self) -> u64 { unimplemented!() }
+    fn st_ino(&self) -> u64 { unimplemented!() }
+    fn st_mode(&self) -> u32 { unimplemented!() }
+    fn st_nlink(&self) -> u64 { unimplemented!() }
+    fn st_uid(&self) -> u32 { unimplemented!() }
+    fn st_gid(&self) -> u32 { unimplemented!() }
+    fn st_rdev(&self) -> u64 { unimplemented!() }
+    fn st_size(&self) -> u64 { unimplemented!() }
+    fn st_atime(&self) -> i64 { unimplemented!() }
+    fn st_atime_nsec(&self) -> i64 { unimplemented!() }
+    fn st_mtime(&self) -> i64 { unimplemented!() }
+    fn st_mtime_nsec(&self) -> i64 { unimplemented!() }
+    fn st_ctime(&self) -> i64 { unimplemented!() }
+    fn st_ctime_nsec(&self) -> i64 { unimplemented!() }
+    fn st_blksize(&self) -> u64 { unimplemented!() }
+    fn st_blocks(&self) -> u64 { unimplemented!() }
+}

--- a/src/libstd/sys/none/mod.rs
+++ b/src/libstd/sys/none/mod.rs
@@ -1,0 +1,47 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(missing_docs, bad_style)]
+
+use io::ErrorKind;
+
+pub use os::none as platform;
+
+#[path = "../unix/args.rs"]           pub mod args;
+#[path = "../unix/android.rs"]        pub mod android;
+#[cfg(any(not(cargobuild), feature = "backtrace"))]
+#[path = "../unix/backtrace/mod.rs"]  pub mod backtrace;
+#[path = "../unix/ext/mod.rs"]        pub mod ext;
+#[path = "../unix/memchr.rs"]         pub mod memchr;
+#[path = "../unix/os.rs"]             pub mod os;
+#[path = "../unix/os_str.rs"]         pub mod os_str;
+#[path = "../unix/path.rs"]           pub mod path;
+#[path = "../unix/pipe.rs"]           pub mod pipe;
+#[path = "../unix/process.rs"]        pub mod process;
+#[path = "../unix/rand.rs"]           pub mod rand;
+#[path = "../unix/stack_overflow.rs"] pub mod stack_overflow;
+#[path = "../unix/time.rs"]           pub mod time;
+                                      pub mod env;
+                                      pub mod fd;
+                                      pub mod fs;
+                                      pub mod net;
+                                      pub mod stdio;
+                                      pub mod condvar;
+                                      pub mod mutex;
+                                      pub mod rwlock;
+#[path = "../unix/thread.rs"]         pub mod thread;
+                                      pub mod thread_local;
+
+#[cfg(not(test))]
+pub fn init() {}
+
+pub fn decode_error_kind(_errno: i32) -> ErrorKind {
+    ErrorKind::Other
+}

--- a/src/libstd/sys/none/mutex.rs
+++ b/src/libstd/sys/none/mutex.rs
@@ -1,0 +1,51 @@
+use cell::Cell;
+
+pub struct Mutex { locked: Cell<bool> }
+
+unsafe impl Send for Mutex {}
+unsafe impl Sync for Mutex {}
+
+impl Mutex {
+    pub const fn new() -> Mutex {
+        Mutex { locked: Cell::new(false) }
+    }
+    #[inline]
+    pub unsafe fn init(&mut self) {}
+    #[inline]
+    pub unsafe fn lock(&self) {
+        // Panic if trying to re-obtain lock
+        debug_assert!(!self.locked.get());
+        self.locked.set(true);
+    }
+    #[inline]
+    pub unsafe fn unlock(&self) {
+        debug_assert!(self.locked.get());
+        self.locked.set(false);
+    }
+    #[inline]
+    pub unsafe fn try_lock(&self) -> bool {
+        let already_locked=self.locked.get();
+        if !already_locked {
+            self.lock()
+        }
+        !already_locked
+    }
+    #[inline]
+    pub unsafe fn destroy(&self) {
+        self.lock()
+    }
+}
+
+pub struct ReentrantMutex(());
+
+unsafe impl Send for ReentrantMutex {}
+unsafe impl Sync for ReentrantMutex {}
+
+impl ReentrantMutex {
+    #[inline] pub unsafe fn uninitialized() -> ReentrantMutex { ReentrantMutex(()) }
+    #[inline] pub unsafe fn init(&mut self) {}
+    #[inline] pub unsafe fn lock(&self) {}
+    #[inline] pub unsafe fn unlock(&self) {}
+    #[inline] pub unsafe fn try_lock(&self) -> bool { true }
+    #[inline] pub unsafe fn destroy(&self) {}
+}

--- a/src/libstd/sys/none/net.rs
+++ b/src/libstd/sys/none/net.rs
@@ -1,0 +1,48 @@
+use io;
+
+use libc::{c_int, sockaddr, socklen_t};
+use net::Shutdown;
+use time::Duration;
+use sys::fd::FileDesc;
+use sys_common::{AsInner, FromInner, IntoInner};
+
+pub mod netc {
+    pub use os::none::libc::*;
+}
+
+pub struct Socket(FileDesc);
+
+pub fn generic_error() -> io::Error {
+    io::Error::new(io::ErrorKind::Other, "networking not supported on this platform")
+}
+
+impl Socket {
+    pub fn new_raw(_fam: c_int, _ty: c_int) -> io::Result<Socket> { Err(generic_error()) }
+    pub fn new_pair(_fam: c_int, _ty: c_int) -> io::Result<(Socket, Socket)> { Err(generic_error()) }
+    pub fn accept(&self, _storage: *mut sockaddr, _len: *mut socklen_t)
+                  -> io::Result<Socket> { Err(generic_error()) }
+    pub fn duplicate(&self) -> io::Result<Socket> { Err(generic_error()) }
+    pub fn read(&self, _buf: &mut [u8]) -> io::Result<usize> { Err(generic_error()) }
+    pub fn read_to_end(&self, _buf: &mut Vec<u8>) -> io::Result<usize> { Err(generic_error()) }
+    pub fn write(&self, _buf: &[u8]) -> io::Result<usize> { Err(generic_error()) }
+    pub fn set_timeout(&self, _dur: Option<Duration>, _kind: c_int) -> io::Result<()> { Err(generic_error()) }
+    pub fn timeout(&self, _kind: c_int) -> io::Result<Option<Duration>> { Err(generic_error()) }
+    pub fn shutdown(&self, _how: Shutdown) -> io::Result<()> { Err(generic_error()) }
+    pub fn set_nodelay(&self, _nodelay: bool) -> io::Result<()> { Err(generic_error()) }
+    pub fn nodelay(&self) -> io::Result<bool> { Err(generic_error()) }
+    pub fn set_nonblocking(&self, _nonblocking: bool) -> io::Result<()> { Err(generic_error()) }
+    pub fn take_error(&self) -> io::Result<Option<io::Error>> { Err(generic_error()) }
+}
+
+
+impl AsInner<c_int> for Socket {
+    fn as_inner(&self) -> &c_int { self.0.as_inner() }
+}
+
+impl FromInner<c_int> for Socket {
+    fn from_inner(fd: c_int) -> Socket { Socket(FileDesc::new(fd)) }
+}
+
+impl IntoInner<c_int> for Socket {
+    fn into_inner(self) -> c_int { self.0.into_raw() }
+}

--- a/src/libstd/sys/none/rwlock.rs
+++ b/src/libstd/sys/none/rwlock.rs
@@ -1,0 +1,59 @@
+use cell::Cell;
+
+pub struct RWLock {
+    write_locked: Cell<bool>,
+    num_readers: Cell<usize>,
+}
+
+unsafe impl Send for RWLock {}
+unsafe impl Sync for RWLock {}
+
+impl RWLock {
+    pub const fn new() -> RWLock {
+        RWLock {
+            write_locked: Cell::new(false),
+            num_readers: Cell::new(0),
+        }
+    }
+    #[inline]
+    pub unsafe fn read(&self) {
+        debug_assert!(!self.write_locked.get());
+        self.num_readers.set(self.num_readers.get()+1)
+    }
+    #[inline]
+    pub unsafe fn try_read(&self) -> bool {
+        let already_locked=self.write_locked.get();
+        if !already_locked {
+            self.read()
+        }
+        !already_locked
+    }
+    #[inline]
+    pub unsafe fn write(&self) {
+        debug_assert!(!self.write_locked.get());
+        debug_assert_eq!(self.num_readers.get(),0);
+        self.write_locked.set(true)
+    }
+    #[inline]
+    pub unsafe fn try_write(&self) -> bool {
+        let already_locked=self.write_locked.get() || self.num_readers.get()==0;
+        if !already_locked {
+            self.write()
+        }
+        !already_locked
+    }
+    #[inline]
+    pub unsafe fn read_unlock(&self) {
+        debug_assert!(self.num_readers.get()>0);
+        self.num_readers.set(self.num_readers.get()-1);
+    }
+    #[inline]
+    pub unsafe fn write_unlock(&self) {
+        debug_assert!(self.write_locked.get());
+        self.write_locked.set(false)
+    }
+    #[inline]
+    pub unsafe fn destroy(&self) {
+        self.write()
+    }
+}

--- a/src/libstd/sys/none/stdio.rs
+++ b/src/libstd/sys/none/stdio.rs
@@ -1,0 +1,35 @@
+use io;
+
+pub struct Stdin(());
+pub struct Stdout(());
+pub struct Stderr(());
+
+fn generic_error() -> io::Error {
+    io::Error::new(io::ErrorKind::Other, "standard I/O not supported on this platform")
+}
+
+impl Stdin {
+    pub fn new() -> io::Result<Stdin> { Err(generic_error()) }
+    pub fn read(&self, _data: &mut [u8]) -> io::Result<usize> { Err(generic_error()) }
+    pub fn read_to_end(&self, _buf: &mut Vec<u8>) -> io::Result<usize> { Err(generic_error()) }
+}
+
+impl Stdout {
+    pub fn new() -> io::Result<Stdout> { Err(generic_error()) }
+    pub fn write(&self, _data: &[u8]) -> io::Result<usize> { Err(generic_error()) }
+}
+
+impl Stderr {
+    pub fn new() -> io::Result<Stderr> { Err(generic_error()) }
+    pub fn write(&self, _data: &[u8]) -> io::Result<usize> { Err(generic_error()) }
+}
+
+// FIXME: right now this raw stderr handle is used in a few places because
+//        std::io::stderr_raw isn't exposed, but once that's exposed this impl
+//        should go away
+impl io::Write for Stderr {
+    fn write(&mut self, _data: &[u8]) -> io::Result<usize> { Err(generic_error()) }
+    fn flush(&mut self) -> io::Result<()> { Err(generic_error()) }
+}
+
+pub const EBADF_ERR: i32 = 0;

--- a/src/libstd/sys/none/thread_local.rs
+++ b/src/libstd/sys/none/thread_local.rs
@@ -1,0 +1,47 @@
+use alloc::boxed::Box;
+
+struct TlsKey {
+	value: *mut u8,
+	dtor: Option<unsafe extern fn(*mut u8)>,
+}
+
+pub type Key = usize;
+
+impl From<TlsKey> for Key {
+	fn from(k: TlsKey) -> Key {
+		Box::into_raw(Box::new(k)) as usize
+	}
+}
+
+impl From<Key> for TlsKey {
+	fn from(k: Key) -> TlsKey {
+		unsafe { *Box::from_raw(k as *mut TlsKey) }
+	}
+}
+
+fn borrow_key(k: &Key) -> &mut TlsKey {
+	unsafe { &mut*(*k as *mut TlsKey) }
+}
+
+#[inline]
+pub unsafe fn create(dtor: Option<unsafe extern fn(*mut u8)>) -> Key {
+	TlsKey { value: ::ptr::null_mut(), dtor: dtor }.into()
+}
+
+#[inline]
+pub unsafe fn set(key: Key, value: *mut u8) {
+	borrow_key(&key).value=value
+}
+
+#[inline]
+pub unsafe fn get(key: Key) -> *mut u8 {
+    borrow_key(&key).value
+}
+
+#[inline]
+pub unsafe fn destroy(key: Key) {
+	match TlsKey::from(key) {
+		TlsKey{value, dtor: Some(dtor)} if value!=::ptr::null_mut() => dtor(value),
+		_ => {},
+	}
+}

--- a/src/libstd/sys/unix/args.rs
+++ b/src/libstd/sys/unix/args.rs
@@ -209,3 +209,17 @@ mod imp {
         Args { iter: res.into_iter(), _dont_send_or_sync_me: PhantomData }
     }
 }
+
+#[cfg(target_os = "none")]
+mod imp {
+    use super::Args;
+    use marker::PhantomData;
+
+    pub unsafe fn init(_argc: isize, _argv: *const *const u8) {}
+
+    pub unsafe fn cleanup() {}
+
+    pub fn args() -> Args {
+        Args { iter: Vec::with_capacity(0).into_iter(), _dont_send_or_sync_me: PhantomData }
+    }
+}

--- a/src/libstd/sys/unix/ext/fs.rs
+++ b/src/libstd/sys/unix/ext/fs.rs
@@ -18,7 +18,8 @@ use libc;
 use path::Path;
 use sys;
 use sys_common::{FromInner, AsInner, AsInnerMut};
-use sys::platform::fs::MetadataExt as UnixMetadataExt;
+#[cfg(not(target_os="none"))] use sys::platform::fs::MetadataExt as UnixMetadataExt;
+#[cfg(target_os="none")] use sys::fs::MetadataExt as UnixMetadataExt;
 
 /// Unix-specific extensions to `Permissions`
 #[stable(feature = "fs_ext", since = "1.1.0")]

--- a/src/libstd/sys/unix/memchr.rs
+++ b/src/libstd/sys/unix/memchr.rs
@@ -12,19 +12,29 @@
 // Copyright 2015 Andrew Gallant, bluss and Nicolas Koch
 
 pub fn memchr(needle: u8, haystack: &[u8]) -> Option<usize> {
-    use libc;
+    #[cfg(not(target_os = "none"))]
+    fn memchr_specific(needle: u8, haystack: &[u8]) -> Option<usize> {
+        use libc;
 
-    let p = unsafe {
-        libc::memchr(
-            haystack.as_ptr() as *const libc::c_void,
-            needle as libc::c_int,
-            haystack.len() as libc::size_t)
-    };
-    if p.is_null() {
-        None
-    } else {
-        Some(p as usize - (haystack.as_ptr() as usize))
+        let p = unsafe {
+            libc::memchr(
+                haystack.as_ptr() as *const libc::c_void,
+                needle as libc::c_int,
+                haystack.len() as libc::size_t)
+        };
+        if p.is_null() {
+            None
+        } else {
+            Some(p as usize - (haystack.as_ptr() as usize))
+        }
     }
+
+    #[cfg(target_os = "none")]
+    fn memchr_specific(needle: u8, haystack: &[u8]) -> Option<usize> {
+        ::sys_common::memchr::fallback::memchr(needle, haystack)
+    }
+
+    memchr_specific(needle, haystack)
 }
 
 pub fn memrchr(needle: u8, haystack: &[u8]) -> Option<usize> {

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -26,6 +26,7 @@ use libc;
 #[cfg(target_os = "openbsd")]   pub use os::openbsd as platform;
 #[cfg(target_os = "solaris")]   pub use os::solaris as platform;
 #[cfg(target_os = "emscripten")] pub use os::emscripten as platform;
+#[cfg(target_os = "none")]      pub use os::none as platform;
 
 #[macro_use]
 pub mod weak;

--- a/src/libstd/sys/unix/pipe.rs
+++ b/src/libstd/sys/unix/pipe.rs
@@ -8,12 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(not(target_os = "none"))]
 use cmp;
 use io;
+#[cfg(not(target_os = "none"))]
 use libc::{self, c_int};
+#[cfg(not(target_os = "none"))]
 use mem;
+#[cfg(not(target_os = "none"))]
 use ptr;
-use sys::cvt_r;
+#[cfg(not(target_os="none"))] use sys::cvt_r;
 use sys::fd::FileDesc;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -22,6 +26,7 @@ use sys::fd::FileDesc;
 
 pub struct AnonPipe(FileDesc);
 
+#[cfg(not(target_os="none"))]
 pub fn anon_pipe() -> io::Result<(AnonPipe, AnonPipe)> {
     let mut fds = [0; 2];
 
@@ -52,6 +57,7 @@ pub fn anon_pipe() -> io::Result<(AnonPipe, AnonPipe)> {
 }
 
 impl AnonPipe {
+    #[cfg(not(target_os = "none"))]
     pub fn from_fd(fd: FileDesc) -> io::Result<AnonPipe> {
         fd.set_cloexec()?;
         Ok(AnonPipe(fd))
@@ -73,6 +79,7 @@ impl AnonPipe {
     pub fn into_fd(self) -> FileDesc { self.0 }
 }
 
+#[cfg(not(target_os="none"))]
 pub fn read2(p1: AnonPipe,
              v1: &mut Vec<u8>,
              p2: AnonPipe,
@@ -122,4 +129,12 @@ pub fn read2(p1: AnonPipe,
             return p1.read_to_end(v1).map(|_| ());
         }
     }
+}
+
+#[cfg(target_os="none")]
+pub fn read2(_p1: AnonPipe,
+             _v1: &mut Vec<u8>,
+             _p2: AnonPipe,
+             _v2: &mut Vec<u8>) -> io::Result<()> {
+    Err(::sys::process::generic_error())
 }

--- a/src/libstd/sys/unix/rand.rs
+++ b/src/libstd/sys/unix/rand.rs
@@ -25,6 +25,7 @@ fn next_u64(mut fill_buf: &mut FnMut(&mut [u8])) -> u64 {
 }
 
 #[cfg(all(unix,
+          not(target_os = "none"),
           not(target_os = "ios"),
           not(target_os = "openbsd"),
           not(target_os = "freebsd")))]
@@ -336,6 +337,43 @@ mod imp {
                            ret, s.len(), s_len);
                 }
             }
+        }
+    }
+}
+
+#[cfg(target_os = "none")]
+mod imp {
+    use super::{next_u32, next_u64};
+
+    use io;
+    use rand::Rng;
+
+    pub struct OsRng {
+        // dummy field to ensure that this struct cannot be constructed outside
+        // of this module
+        _dummy: (),
+    }
+
+    impl OsRng {
+        /// Create a new `OsRng`.
+        pub fn new() -> io::Result<OsRng> {
+            Ok(OsRng { _dummy: () })
+        }
+    }
+
+    impl Rng for OsRng {
+        fn next_u32(&mut self) -> u32 {
+            next_u32(&mut |v| self.fill_bytes(v))
+        }
+        fn next_u64(&mut self) -> u64 {
+            next_u64(&mut |v| self.fill_bytes(v))
+        }
+        fn fill_bytes(&mut self, v: &mut [u8]) {
+            extern {
+                fn getrandom(buf: *mut u8, len: usize);
+            }
+
+            unsafe { getrandom(v.as_mut_ptr(), v.len()) }
         }
     }
 }

--- a/src/libstd/sys/unix/stack_overflow.rs
+++ b/src/libstd/sys/unix/stack_overflow.rs
@@ -21,6 +21,7 @@ pub struct Handler {
 }
 
 impl Handler {
+    #[cfg_attr(target_os="none",allow(dead_code))]
     pub unsafe fn new() -> Handler {
         make_handler()
     }

--- a/src/libstd/sys/unix/time.rs
+++ b/src/libstd/sys/unix/time.rs
@@ -242,7 +242,7 @@ mod inner {
 mod inner {
     use fmt;
     use libc;
-    use sys::cvt;
+    #[cfg(not(target_os="none"))] use sys::cvt;
     use time::Duration;
 
     use super::Timespec;
@@ -334,6 +334,7 @@ mod inner {
     #[cfg(target_os = "dragonfly")]
     pub type clock_t = libc::c_ulong;
 
+    #[cfg(not(target_os = "none"))]
     fn now(clock: clock_t) -> Timespec {
         let mut t = Timespec {
             t: libc::timespec {
@@ -345,5 +346,11 @@ mod inner {
             libc::clock_gettime(clock, &mut t.t)
         }).unwrap();
         t
+    }
+
+
+    #[cfg(target_os = "none")]
+    fn now(_clock: clock_t) -> Timespec {
+        panic!("time not supported on this platform")
     }
 }


### PR DESCRIPTION
This is an attempt to "port" libstd to run in unconventional environments. Unconventional here means: no networking, no filesystem, no environment and in general no system calls. Think OS kernel but different: you do want allocation and collections, you do want floating point numbers, you do want standard Rust abstractions such as `io::Write`, etc. Using `no_std` is really inconvenient in these situations because a lot of std is missing. Examples of such environments are emscripten¹ and [Intel SGX](https://software.intel.com/en-us/sgx).

This PR adds a `target_os = "none"` configuration. The approach I've taken is to base everything of off the `unix` base, removing the dependency on `libc`, and returning errors from all functions that used libc. I've borrowed some ideas from the Linux and emscripten implementations here and there.

In some places the existing unix code needed only minor modifications and `#[cfg()]` additions, in these cases I've modified the files inline. In other cases, it made more sense to reimplement the sys API in a new file. See [libstd/sys/none/mod.rs](https://github.com/jethrogb/rust/blob/no_os/src/libstd/sys/none/mod.rs).

In general these areas have been modified:
- `fs` just mostly return io::Error. UNIX-compatible Path/OsString handling is still supported
- `net` just mostly return io::Error. Addressing structures are still supported
- `process` just mostly return io::Error
- `env` just mostly return io::Error
- `thread` just mostly return io::Error (note `std::thread::spawn` calls unwrap internally...)
- `stdio` use "fake stdio" as is used on Windows when there is no console
- `sync` replace all primitives with single-threaded primitives without any locking. If you do somehow end up in a multi-threaded environment, this means things are totally and utterly racy and unsafe.
- `time` `SystemTime` is like the Linux version and you can do time math, but calling `now` will panic.

I'm aware that the current state of the PR is nowhere near merging. I just want to announce my plans and solicit feedback. I already know that the following things need work:
- tests. I have not tried to run any tests yet. It's not even clear how to run tests as there is no generic way to run binaries compiled for this target. Even if there were, I imagine many tests are going to fail. What would be a good approach to handling this?
- formatting. I'm pretty sure that I'm not adhering to proper style everywhere
- copyright headers for new files. These will be added later
- librustc_back target. For now you need to use the [JSON target file](https://github.com/jethrogb/rust/blob/x86_64-unknown-none-gnu/x86_64-unknown-none-gnu.json).

Rather, I'm looking for technical feedback.

You can build this branch like so:

```
RUST_TARGET_PATH=/somewhere cargo rustc --lib --release --target x86_64-unknown-none-gnu --manifest-path src/rustc/std_shim/Cargo.toml
```

You can then link the `deps` directory to the approriate `lib/rustlib` in your rust installation to test building with this target. Here's what you need to supply to make it link:
- an allocator crate
- `rlibc` or similar
- an implementation for `extern fn getrandom(buf: *mut u8, len: usize);`

I made a [sample application](https://github.com/jethrogb/rust/tree/x86_64-unknown-none-gnu) that takes this std and adds some Linux system calls around it, it works.

¹: If I understand the state of the emscripten port correctly based on discussions with @brson, if you're trying to use functionality that doesn't exist on the platform you'll just get linker errors. That's of course not very ergonomic.

r? @brson
