### PR TITLE
mk: Update the powerpc64 cross-compile prefix

### DIFF
--- a/mk/cfg/powerpc64-unknown-linux-gnu.mk
+++ b/mk/cfg/powerpc64-unknown-linux-gnu.mk
@@ -1,5 +1,5 @@
 # powerpc64-unknown-linux-gnu configuration
-CROSS_PREFIX_powerpc64-unknown-linux-gnu=powerpc-linux-gnu-
+CROSS_PREFIX_powerpc64-unknown-linux-gnu=powerpc64-linux-gnu-
 CC_powerpc64-unknown-linux-gnu=$(CC)
 CXX_powerpc64-unknown-linux-gnu=$(CXX)
 CPP_powerpc64-unknown-linux-gnu=$(CPP)


### PR DESCRIPTION
The image changed, so we need to use a different prefix.
