### PR TITLE
DO NOT MERGE: experimental implementation of Entry API RFC

### DIFF
--- a/src/libcollections/borrow.rs
+++ b/src/libcollections/borrow.rs
@@ -69,6 +69,27 @@ impl<T> ToOwned for T where T: Clone {
     }
 }
 
+#[unstable(feature = "entry_into_owned", issue = "1")]
+pub trait AsBorrowOf<T, B: ?Sized>: Sized where T: Borrow<B> {
+    #[unstable(feature = "entry_into_owned", issue = "1")]
+    fn into_owned(self) -> T;
+
+    #[unstable(feature = "entry_into_owned", issue = "1")]
+    fn as_borrow_of(&self) -> &B;
+}
+
+#[unstable(feature = "entry_into_owned", issue = "1")]
+impl<T> AsBorrowOf<T, T> for T {
+    fn into_owned(self) -> T { self }
+    fn as_borrow_of(&self) -> &Self { self }
+}
+
+#[unstable(feature = "entry_into_owned", issue = "1")]
+impl<'a, B: ToOwned + ?Sized> AsBorrowOf<B::Owned, B> for &'a B {
+    fn into_owned(self) -> B::Owned { self.to_owned() }
+    fn as_borrow_of(&self) -> &B { *self }
+}
+
 /// A clone-on-write smart pointer.
 ///
 /// The type `Cow` is a smart pointer providing clone-on-write functionality: it

--- a/src/libcollections/borrow.rs
+++ b/src/libcollections/borrow.rs
@@ -80,8 +80,14 @@ pub trait AsBorrowOf<T, B: ?Sized>: Sized where T: Borrow<B> {
 
 #[unstable(feature = "entry_into_owned", issue = "1")]
 impl<T> AsBorrowOf<T, T> for T {
-    fn into_owned(self) -> T { self }
-    fn as_borrow_of(&self) -> &Self { self }
+    default fn into_owned(self) -> T { self }
+    default fn as_borrow_of(&self) -> &Self { self }
+}
+
+#[unstable(feature = "entry_into_owned", issue = "1")]
+impl<'a, T: Deref> AsBorrowOf<&'a T::Target, T::Target> for &'a T {
+    default fn into_owned(self) -> &'a T::Target { self.deref() }
+    default fn as_borrow_of(&self) -> &T::Target { self.deref() }
 }
 
 #[unstable(feature = "entry_into_owned", issue = "1")]

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -112,6 +112,7 @@ use self::Entry::*;
 /// // type inference lets us omit an explicit type signature (which
 /// // would be `BTreeMap<&str, u8>` in this example).
 /// let mut player_stats = BTreeMap::new();
+/// # {let __help_inference_out: &BTreeMap<&_, _> = &player_stats;}
 ///
 /// fn random_stat_buff() -> u8 {
 ///     // could actually return some random value here - let's just return

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -274,6 +274,7 @@ impl DefaultResizePolicy {
 /// // type inference lets us omit an explicit type signature (which
 /// // would be `HashMap<&str, u8>` in this example).
 /// let mut player_stats = HashMap::new();
+/// # {let __help_inference_out: &HashMap<&_, _> = &player_stats;}
 ///
 /// fn random_stat_buff() -> u8 {
 ///     // could actually return some random value here - let's just return

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -230,6 +230,7 @@
 #![feature(core_intrinsics)]
 #![feature(dotdot_in_tuple_patterns)]
 #![feature(dropck_parametricity)]
+#![feature(entry_into_owned)]
 #![feature(float_extras)]
 #![feature(float_from_str_radix)]
 #![feature(fn_traits)]


### PR DESCRIPTION
RFC: rust-lang/rfcs#1769
- Implements `Entry::key` and `VacantEntry::key` only when `Q=K`.
- Updates both `BTreeMap` and `HashMap`.
- The only inference breakage in the rustc codebase was due to #37138 . 
- Uses the single trait no specialisation version with `AsBorrowOf`.
  - Turns out the lack of an `IntoOwned<K>` trait ends being annoying requiring a `B` parameter added to `or_insert` and `or_insert_with`. 
  - Adding a `<B>` parameter to `or_insert_with` is, I think, a breaking change because writing `or_insert_with<_>` is not valid any more. In reality I imagine this never happens.
  - We may want to go back to the `IntoOwned`/`AsBorrowOf` separation.
