### PR TITLE
save_analysis: Dump data only if get_path_data doesn't fail to resolve a path.

### DIFF
--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -854,9 +854,7 @@ impl<'l, 'tcx: 'l, 'll, D: Dump + 'll> DumpVisitor<'l, 'tcx, 'll, D> {
         let path_data = match path_data {
             Some(pd) => pd,
             None => {
-                span_bug!(path.span,
-                          "Unexpected def kind while looking up path in `{}`",
-                          self.span.snippet(path.span))
+                return;
             }
         };
 


### PR DESCRIPTION
Solves #37126

Dump data only if `get_path_data` doesn't fail to resolve a path.
`get_path_data` returns `None` when it have to deals with `Def::Err`, which is used as placeholder for a failed resolution.

Tell me if this is good enough, maybe I have to add some tests ?

r? @nrc 
