### PR TITLE
Add some more repos to cargotest

### DIFF
--- a/src/tools/cargotest/main.rs
+++ b/src/tools/cargotest/main.rs
@@ -21,48 +21,44 @@ struct Test {
     lock: Option<&'static str>,
 }
 
-const TEST_REPOS: &'static [Test] = &[Test {
-                                          name: "bins",
-                                          repo: "https://github.com/jkcclemens/bins",
-                                          sha: "378da8f7d78df6e3ff0b234063de50619b16648e",
-                                          lock: None,
-                                      },
-                                      Test {
-                                          name: "cargo",
-                                          repo: "https://github.com/rust-lang/cargo",
-                                          sha: "b7be4f2ef2cf743492edc6dfb55d087ed88f2d76",
-                                          lock: None,
-                                      },
-                                      Test {
-                                          name: "iron",
-                                          repo: "https://github.com/iron/iron",
-                                          sha: "16c858ec2901e2992fe5e529780f59fa8ed12903",
-                                          lock: Some(include_str!("lockfiles/iron-Cargo.lock")),
-                                      },
-                                      Test {
-                                          name: "ripgrep",
-                                          repo: "https://github.com/BurntSushi/ripgrep",
-                                          sha: "5487dffefaa34e5fc04321335aa716f415082977",
-                                          lock: None,
-                                      },
-                                      Test {
-                                          name: "tokei",
-                                          repo: "https://github.com/Aaronepower/tokei",
-                                          sha: "9faa8d4210ba19ad76d736e46e4963cfcef329d6",
-                                          lock: None,
-                                      },
-                                      Test {
-                                          name: "treeify",
-                                          repo: "https://github.com/dzamlo/treeify",
-                                          sha: "999001b223152441198f117a68fb81f57bc086dd",
-                                          lock: None,
-                                      },
-                                      Test {
-                                          name: "xsv",
-                                          repo: "https://github.com/BurntSushi/xsv",
-                                          sha: "5ec4fff4a3f507eda887049469897f02c6fae036",
-                                          lock: None,
-                                      }];
+const TEST_REPOS: &'static [Test] = &[
+    Test {
+        name: "cargo",
+        repo: "https://github.com/rust-lang/cargo",
+        sha: "b7be4f2ef2cf743492edc6dfb55d087ed88f2d76",
+        lock: None,
+    },
+    Test {
+        name: "iron",
+        repo: "https://github.com/iron/iron",
+        sha: "16c858ec2901e2992fe5e529780f59fa8ed12903",
+        lock: Some(include_str!("lockfiles/iron-Cargo.lock")),
+    },
+    Test {
+        name: "ripgrep",
+        repo: "https://github.com/BurntSushi/ripgrep",
+        sha: "b65bb37b14655e1a89c7cd19c8b011ef3e312791",
+        lock: None,
+    },
+    Test {
+        name: "tokei",
+        repo: "https://github.com/Aaronepower/tokei",
+        sha: "5e11c4852fe4aa086b0e4fe5885822fbe57ba928",
+        lock: None,
+    },
+    Test {
+        name: "treeify",
+        repo: "https://github.com/dzamlo/treeify",
+        sha: "999001b223152441198f117a68fb81f57bc086dd",
+        lock: None,
+    },
+    Test {
+        name: "xsv",
+        repo: "https://github.com/BurntSushi/xsv",
+        sha: "5ec4fff4a3f507eda887049469897f02c6fae036",
+        lock: None,
+    },
+];
 
 fn main() {
     // One of the projects being tested here is Cargo, and when being tested

--- a/src/tools/cargotest/main.rs
+++ b/src/tools/cargotest/main.rs
@@ -22,6 +22,12 @@ struct Test {
 }
 
 const TEST_REPOS: &'static [Test] = &[Test {
+                                          name: "bins",
+                                          repo: "https://github.com/jkcclemens/bins",
+                                          sha: "378da8f7d78df6e3ff0b234063de50619b16648e",
+                                          lock: None,
+                                      },
+                                      Test {
                                           name: "cargo",
                                           repo: "https://github.com/rust-lang/cargo",
                                           sha: "b7be4f2ef2cf743492edc6dfb55d087ed88f2d76",
@@ -32,8 +38,31 @@ const TEST_REPOS: &'static [Test] = &[Test {
                                           repo: "https://github.com/iron/iron",
                                           sha: "16c858ec2901e2992fe5e529780f59fa8ed12903",
                                           lock: Some(include_str!("lockfiles/iron-Cargo.lock")),
+                                      },
+                                      Test {
+                                          name: "ripgrep",
+                                          repo: "https://github.com/BurntSushi/ripgrep",
+                                          sha: "5487dffefaa34e5fc04321335aa716f415082977",
+                                          lock: None,
+                                      },
+                                      Test {
+                                          name: "tokei",
+                                          repo: "https://github.com/Aaronepower/tokei",
+                                          sha: "9faa8d4210ba19ad76d736e46e4963cfcef329d6",
+                                          lock: None,
+                                      },
+                                      Test {
+                                          name: "treeify",
+                                          repo: "https://github.com/dzamlo/treeify",
+                                          sha: "999001b223152441198f117a68fb81f57bc086dd",
+                                          lock: None,
+                                      },
+                                      Test {
+                                          name: "xsv",
+                                          repo: "https://github.com/BurntSushi/xsv",
+                                          sha: "5ec4fff4a3f507eda887049469897f02c6fae036",
+                                          lock: None,
                                       }];
-
 
 fn main() {
     // One of the projects being tested here is Cargo, and when being tested


### PR DESCRIPTION
From suggestions at https://users.rust-lang.org/t/what-stable-rust-applications-do-you-use-frequently/7618

This adds some applications which use stable Rust and come with their own lockfiles in their respective trees.

ripgrep, xsv, and bins have 33 unique dependencies between them.

I alphabetized the list by project name because that seems tidier.

r? @brson 
