### PR TITLE
add (missing) tar to list of packages to get under mingw

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ build.
    $ pacman -S git \
                make \
                diffutils \
+               tar \
                mingw-w64-x86_64-python2 \
                mingw-w64-x86_64-cmake \
                mingw-w64-x86_64-gcc


### PR DESCRIPTION
The distribution targets use tar, but the readme pacman invocation doesn't include the tar package.
