### PR TITLE
debuginfo: Remove some outdated stuff from LLVM DIBuilder binding.

### DIFF
--- a/src/librustc_llvm/ffi.rs
+++ b/src/librustc_llvm/ffi.rs
@@ -1817,8 +1817,6 @@ extern {
                                            Ty: DIType,
                                            AlwaysPreserve: bool,
                                            Flags: c_uint,
-                                           AddrOps: *const i64,
-                                           AddrOpsCount: c_uint,
                                            ArgNo: c_uint)
                                            -> DIVariable;
 
@@ -1854,15 +1852,6 @@ extern {
                                                DL: ValueRef,
                                                InsertAtEnd: BasicBlockRef)
                                                -> ValueRef;
-
-    pub fn LLVMRustDIBuilderInsertDeclareBefore(Builder: DIBuilderRef,
-                                                Val: ValueRef,
-                                                VarInfo: DIVariable,
-                                                AddrOps: *const i64,
-                                                AddrOpsCount: c_uint,
-                                                DL: ValueRef,
-                                                InsertBefore: ValueRef)
-                                                -> ValueRef;
 
     pub fn LLVMRustDIBuilderCreateEnumerator(Builder: DIBuilderRef,
                                              Name: *const c_char,

--- a/src/librustc_trans/debuginfo/mod.rs
+++ b/src/librustc_trans/debuginfo/mod.rs
@@ -482,8 +482,6 @@ pub fn declare_local<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                     type_metadata,
                     cx.sess().opts.optimize != config::OptLevel::No,
                     0,
-                    address_operations.as_ptr(),
-                    address_operations.len() as c_uint,
                     argument_index)
             };
             source_loc::set_debug_location(cx, None,

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -562,8 +562,6 @@ extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreateVariable(
     LLVMRustMetadataRef Ty,
     bool AlwaysPreserve,
     unsigned Flags,
-    int64_t* AddrOps,
-    unsigned AddrOpsCount,
     unsigned ArgNo) {
 #if LLVM_VERSION_GE(3, 8)
     if (Tag == 0x100) { // DW_TAG_auto_variable
@@ -643,23 +641,6 @@ extern "C" LLVMValueRef LLVMRustDIBuilderInsertDeclareAtEnd(
           llvm::ArrayRef<int64_t>(AddrOps, AddrOpsCount)),
         DebugLoc(cast<MDNode>(unwrap<MetadataAsValue>(DL)->getMetadata())),
         unwrap(InsertAtEnd)));
-}
-
-extern "C" LLVMValueRef LLVMRustDIBuilderInsertDeclareBefore(
-    LLVMRustDIBuilderRef Builder,
-    LLVMValueRef Val,
-    LLVMRustMetadataRef VarInfo,
-    int64_t* AddrOps,
-    unsigned AddrOpsCount,
-    LLVMValueRef DL,
-    LLVMValueRef InsertBefore) {
-    return wrap(Builder->insertDeclare(
-        unwrap(Val),
-        unwrap<DILocalVariable>(VarInfo),
-        Builder->createExpression(
-          llvm::ArrayRef<int64_t>(AddrOps, AddrOpsCount)),
-        DebugLoc(cast<MDNode>(unwrap<MetadataAsValue>(DL)->getMetadata())),
-        unwrap<Instruction>(InsertBefore)));
 }
 
 extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreateEnumerator(
@@ -1302,7 +1283,7 @@ static LLVMLinkage from_rust(LLVMRustLinkage linkage) {
             return LLVMCommonLinkage;
         default:
             llvm_unreachable("Invalid LLVMRustLinkage value!");
-    } 
+    }
 }
 
 extern "C" LLVMRustLinkage LLVMRustGetLinkage(LLVMValueRef V) {


### PR DESCRIPTION
These seem to be leftovers from various adaptations to changes in LLVM over time.
Perfect for a rollup.

r? @eddyb 
