### PR TITLE
[stable] Backports for 1.12.1

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -13,7 +13,7 @@
 ######################################################################
 
 # The version number
-CFG_RELEASE_NUM=1.12.0
+CFG_RELEASE_NUM=1.12.1
 
 # An optional number to put after the label, e.g. '.2' -> '-beta.2'
 # NB Make sure it starts with a dot to conform to semver pre-release

--- a/src/librustc/ty/flags.rs
+++ b/src/librustc/ty/flags.rs
@@ -107,6 +107,11 @@ impl FlagComputation {
             }
 
             &ty::TyProjection(ref data) => {
+                // currently we can't normalize projections that
+                // include bound regions, so track those separately.
+                if !data.has_escaping_regions() {
+                    self.add_flags(TypeFlags::HAS_NORMALIZABLE_PROJECTION);
+                }
                 self.add_flags(TypeFlags::HAS_PROJECTION);
                 self.add_projection_ty(data);
             }

--- a/src/librustc/ty/fold.rs
+++ b/src/librustc/ty/fold.rs
@@ -105,7 +105,7 @@ pub trait TypeFoldable<'tcx>: fmt::Debug + Clone {
                              TypeFlags::HAS_FREE_REGIONS |
                              TypeFlags::HAS_TY_INFER |
                              TypeFlags::HAS_PARAMS |
-                             TypeFlags::HAS_PROJECTION |
+                             TypeFlags::HAS_NORMALIZABLE_PROJECTION |
                              TypeFlags::HAS_TY_ERR |
                              TypeFlags::HAS_SELF)
     }

--- a/src/librustc/ty/item_path.rs
+++ b/src/librustc/ty/item_path.rs
@@ -305,7 +305,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     /// Returns the def-id of `def_id`'s parent in the def tree. If
     /// this returns `None`, then `def_id` represents a crate root or
     /// inlined root.
-    fn parent_def_id(&self, def_id: DefId) -> Option<DefId> {
+    pub fn parent_def_id(&self, def_id: DefId) -> Option<DefId> {
         let key = self.def_key(def_id);
         key.parent.map(|index| DefId { krate: def_id.krate, index: index })
     }

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -527,6 +527,10 @@ bitflags! {
         // Only set for TyInfer other than Fresh.
         const KEEP_IN_LOCAL_TCX  = 1 << 11,
 
+        // Is there a projection that does not involve a bound region?
+        // Currently we can't normalize projections w/ bound regions.
+        const HAS_NORMALIZABLE_PROJECTION = 1 << 12,
+
         const NEEDS_SUBST        = TypeFlags::HAS_PARAMS.bits |
                                    TypeFlags::HAS_SELF.bits |
                                    TypeFlags::HAS_RE_EARLY_BOUND.bits,

--- a/src/librustc_mir/build/expr/as_lvalue.rs
+++ b/src/librustc_mir/build/expr/as_lvalue.rs
@@ -96,6 +96,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             ExprKind::LogicalOp { .. } |
             ExprKind::Box { .. } |
             ExprKind::Cast { .. } |
+            ExprKind::Use { .. } |
             ExprKind::NeverToAny { .. } |
             ExprKind::ReifyFnPointer { .. } |
             ExprKind::UnsafeFnPointer { .. } |

--- a/src/librustc_mir/build/expr/as_rvalue.rs
+++ b/src/librustc_mir/build/expr/as_rvalue.rs
@@ -115,6 +115,10 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 let source = unpack!(block = this.as_operand(block, source));
                 block.and(Rvalue::Cast(CastKind::Misc, source, expr.ty))
             }
+            ExprKind::Use { source } => {
+                let source = unpack!(block = this.as_operand(block, source));
+                block.and(Rvalue::Use(source))
+            }
             ExprKind::ReifyFnPointer { source } => {
                 let source = unpack!(block = this.as_operand(block, source));
                 block.and(Rvalue::Cast(CastKind::ReifyFnPointer, source, expr.ty))

--- a/src/librustc_mir/build/expr/category.rs
+++ b/src/librustc_mir/build/expr/category.rs
@@ -68,6 +68,7 @@ impl Category {
             ExprKind::Binary { .. } |
             ExprKind::Box { .. } |
             ExprKind::Cast { .. } |
+            ExprKind::Use { .. } |
             ExprKind::ReifyFnPointer { .. } |
             ExprKind::UnsafeFnPointer { .. } |
             ExprKind::Unsize { .. } |

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -249,6 +249,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             ExprKind::Binary { .. } |
             ExprKind::Box { .. } |
             ExprKind::Cast { .. } |
+            ExprKind::Use { .. } |
             ExprKind::ReifyFnPointer { .. } |
             ExprKind::UnsafeFnPointer { .. } |
             ExprKind::Unsize { .. } |

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -602,8 +602,8 @@ fn make_mirror_unadjusted<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
             // Check to see if this cast is a "coercion cast", where the cast is actually done
             // using a coercion (or is a no-op).
             if let Some(&TyCastKind::CoercionCast) = cx.tcx.cast_kinds.borrow().get(&source.id) {
-                // Skip the actual cast itexpr, as it's now a no-op.
-                return source.make_mirror(cx);
+                // Convert the lexpr to a vexpr.
+                ExprKind::Use { source: source.to_ref() }
             } else {
                 ExprKind::Cast { source: source.to_ref() }
             }

--- a/src/librustc_mir/hair/mod.rs
+++ b/src/librustc_mir/hair/mod.rs
@@ -139,6 +139,9 @@ pub enum ExprKind<'tcx> {
     Cast {
         source: ExprRef<'tcx>,
     },
+    Use {
+        source: ExprRef<'tcx>,
+    }, // Use a lexpr to get a vexpr.
     NeverToAny {
         source: ExprRef<'tcx>,
     },

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -320,7 +320,16 @@ pub fn compare_scalar_types<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                 _ => bug!("compare_scalar_types: must be a comparison operator"),
             }
         }
-        ty::TyFnDef(..) | ty::TyFnPtr(_) | ty::TyBool | ty::TyUint(_) | ty::TyChar => {
+        ty::TyBool => {
+            // FIXME(#36856) -- using `from_immediate` forces these booleans into `i8`,
+            // which works around some LLVM bugs
+            ICmp(bcx,
+                 bin_op_to_icmp_predicate(op, false),
+                 from_immediate(bcx, lhs),
+                 from_immediate(bcx, rhs),
+                 debug_loc)
+        }
+        ty::TyFnDef(..) | ty::TyFnPtr(_) | ty::TyUint(_) | ty::TyChar => {
             ICmp(bcx,
                  bin_op_to_icmp_predicate(op, false),
                  lhs,

--- a/src/librustc_trans/collector.rs
+++ b/src/librustc_trans/collector.rs
@@ -1042,7 +1042,9 @@ fn create_fn_trans_item<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let concrete_substs = monomorphize::apply_param_substs(tcx,
                                                            param_substs,
                                                            &fn_substs);
-    assert!(concrete_substs.is_normalized_for_trans());
+    assert!(concrete_substs.is_normalized_for_trans(),
+            "concrete_substs not normalized for trans: {:?}",
+            concrete_substs);
     TransItem::Fn(Instance::new(def_id, concrete_substs))
 }
 

--- a/src/rustllvm/llvm-auto-clean-trigger
+++ b/src/rustllvm/llvm-auto-clean-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be forcibly cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2016-09-17
+2016-10-10

--- a/src/test/run-pass/issue-36381.rs
+++ b/src/test/run-pass/issue-36381.rs
@@ -1,0 +1,34 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for #36381. The trans collector was asserting that
+// there are no projection types, but the `<&str as
+// StreamOnce>::Position` projection contained a late-bound region,
+// and we don't currently normalize in that case until the function is
+// actually invoked.
+
+pub trait StreamOnce {
+    type Position;
+}
+
+impl<'a> StreamOnce for &'a str {
+    type Position = usize;
+}
+
+pub fn parser<F>(_: F) {
+}
+
+fn follow(_: &str) -> <&str as StreamOnce>::Position {
+    panic!()
+}
+
+fn main() {
+    parser(follow);
+}

--- a/src/test/run-pass/issue-36744-bitcast-args-if-needed.rs
+++ b/src/test/run-pass/issue-36744-bitcast-args-if-needed.rs
@@ -1,0 +1,32 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This tests for an ICE (and, if ignored, subsequent LLVM abort) when
+// a lifetime-parametric fn is passed into a context whose expected
+// type has a differing lifetime parameterization.
+
+struct A<'a> {
+    _a: &'a i32,
+}
+
+fn call<T>(s: T, functions: &Vec<for <'n> fn(&'n T)>) {
+    for function in functions {
+        function(&s);
+    }
+}
+
+fn f(a: &A) { println!("a holds {}", a._a); }
+
+fn main() {
+    let a = A { _a: &10 };
+
+    let vec: Vec<for <'u,'v> fn(&'u A<'v>)> = vec![f];
+    call(a, &vec);
+}

--- a/src/test/run-pass/issue-36744-without-calls.rs
+++ b/src/test/run-pass/issue-36744-without-calls.rs
@@ -1,0 +1,22 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests for an LLVM abort when storing a lifetime-parametric fn into
+// context that is expecting one that is not lifetime-parametric
+// (i.e. has no `for <'_>`).
+
+pub struct A<'a>(&'a ());
+pub struct S<T>(T);
+
+pub fn bad<'s>(v: &mut S<fn(A<'s>)>, y: S<for<'b> fn(A<'b>)>) {
+    *v = y;
+}
+
+fn main() {}

--- a/src/test/run-pass/issue-36856.rs
+++ b/src/test/run-pass/issue-36856.rs
@@ -1,0 +1,24 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for #36856.
+
+// compile-flags:-g
+
+fn g() -> bool {
+    false
+}
+
+pub fn main() {
+    let a = !g();
+    if a != !g() {
+        panic!();
+    }
+}

--- a/src/test/run-pass/issue-36936.rs
+++ b/src/test/run-pass/issue-36936.rs
@@ -1,0 +1,35 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// check that casts are not being treated as lexprs.
+
+fn main() {
+    let mut a = 0i32;
+    let b = &(a as i32);
+    a = 1;
+    assert!((&a as *const i32) != (b as *const i32));
+    assert_eq!(*b, 0);
+
+    assert_eq!(issue_36936(), 1);
+}
+
+
+struct A(u32);
+
+impl Drop for A {
+    fn drop(&mut self) {
+        self.0 = 0;
+    }
+}
+
+fn issue_36936() -> u32 {
+    let a = &(A(1) as A);
+    a.0
+}


### PR DESCRIPTION
This bumps the stable version to 1.12.1 and backports fixes for the
following regressions, all of which have additionally been backported
to beta:
- https://github.com/rust-lang/rust/issues/36381
  - ICE: 'rustc' panicked at 'assertion failed:
    concrete_substs.is_normalized_for_trans()'
  - master PR: https://github.com/rust-lang/rust/pull/36876
- https://github.com/rust-lang/rust/issues/36856
  - Confusion with double negation and booleans
  - master PR: https://github.com/rust-lang/rust/pull/36958
- https://github.com/rust-lang/rust/issues/36875
  - rustc 1.12.0 fails with SIGSEGV in release mode (syn crate 0.8.0)
  - fixed by build environment
- https://github.com/rust-lang/rust/issues/36924
  - Rustc 1.12.0 Windows build of `ethcore` crate fails with LLVM error
  - master PR: https://github.com/rust-lang/rust/pull/37030
- https://github.com/rust-lang/rust/issues/36926
  - 1.12.0: High memory usage when linking in release mode with debug info
  - master PR: https://github.com/rust-lang/rust/pull/37030
- https://github.com/rust-lang/rust/issues/36936
  - Corrupted memory after updated to 1.12
  - master PR: https://github.com/rust-lang/rust/pull/36942
- https://github.com/rust-lang/rust/issues/37026
  - “Let NullaryConstructor = something;” causes internal compiler error: “tried
    to overwrite interned AdtDef”
  - master PR: https://github.com/rust-lang/rust/pull/37095
  - beta PR: https://github.com/rust-lang/rust/pull/37078
- https://github.com/rust-lang/rust/issues/37112
  - Fix ICE: inject bitcast if types mismatch for invokes/calls/stores
  - master PR: https://github.com/rust-lang/rust/pull/37112
- https://github.com/rust-lang/rust/pull/37153
  - fixes cargo opt+debug build, used by fedora, requested by @cuviper 

It does not include fixes for these regressions, either because they
are unfixed or the fixes aren't merged into master:
- https://github.com/rust-lang/rust/issues/36325
  - ICE, possibly related to associated types of associated types?
- https://github.com/rust-lang/rust/issues/36799
  - Compilation of a crate using a large static map fails on latest
    i686-pc-windows-gnu Beta
- https://github.com/rust-lang/rust/issues/37154
  - Regression: "no method found" error when calling same method twice, with
    HRTB impl
- https://github.com/rust-lang/rust/issues/37109
  - ICE: fictitious type <i32 as ToRef>::Ref in sizing_type_of()
  - master PR: https://github.com/rust-lang/rust/issues/37129

If you can, please see if there's anything you do to advance the above unfixed
regressions.

Two things to be aware of. The fix for #36875 is due to unknown changes in the
docker container used by the builders. So there's some risk that there are other
changes in that container that could introduce further regressions. The fix for
#36924 and #36925 also picks up the LLVM JS target definitions, and while they

will mostly be inert on the stable branch, it does contain two [minor
changes](https://github.com/rust-lang/llvm/commit/3e03f7374169cd41547d75e62ac2ab8a103a913c) to common transformations, in ConstantMerge.cpp and
InstCombineCompares.cpp.

I'm not sure yet whether we should wait for further fixes before issuing a point
release. I'm inclined not to wait further, except to pick up #37109 since it
isn't blocked on anything.

I'll run this branch through the test suite on various platforms and against
crater before doing a build.

I think the procedure here is that at least a few members of the compiler team
need to sign off on these, then we can merge into stable. At that point we're
still not committed to anything yet. Then I'll do a build, and probably ask
people to manually verify some of the fixes. Then we'll issue the release like
any other.

cc @rust-lang/compiler
