### PR TITLE
test: Don't write files into the source tree

### DIFF
--- a/src/test/run-make/dep-info-spaces/Makefile
+++ b/src/test/run-make/dep-info-spaces/Makefile
@@ -5,9 +5,12 @@
 ifneq ($(shell uname),FreeBSD)
 ifndef IS_WINDOWS
 all:
-	$(RUSTC) --emit link,dep-info --crate-type=lib lib.rs
+	cp lib.rs $(TMPDIR)/
+	cp 'foo foo.rs' $(TMPDIR)/
+	cp bar.rs $(TMPDIR)/
+	$(RUSTC) --emit link,dep-info --crate-type=lib $(TMPDIR)/lib.rs
 	sleep 1
-	touch 'foo foo.rs'
+	touch $(TMPDIR)/'foo foo.rs'
 	-rm -f $(TMPDIR)/done
 	$(MAKE) -drf Makefile.foo
 	rm $(TMPDIR)/done

--- a/src/test/run-make/dep-info-spaces/Makefile.foo
+++ b/src/test/run-make/dep-info-spaces/Makefile.foo
@@ -1,7 +1,7 @@
-LIB := $(shell $(RUSTC) --print file-names --crate-type=lib lib.rs)
+LIB := $(shell $(RUSTC) --print file-names --crate-type=lib $(TMPDIR)/lib.rs)
 
 $(TMPDIR)/$(LIB):
-	$(RUSTC) --emit link,dep-info --crate-type=lib lib.rs
+	$(RUSTC) --emit link,dep-info --crate-type=lib $(TMPDIR)/lib.rs
 	touch $(TMPDIR)/done
 
 -include $(TMPDIR)/lib.d

--- a/src/test/run-make/llvm-phase/test.rs
+++ b/src/test/run-make/llvm-phase/test.rs
@@ -22,6 +22,7 @@ use rustc_driver::driver::CompileController;
 use rustc_trans::ModuleSource;
 use rustc::session::Session;
 use syntax::codemap::FileLoader;
+use std::env;
 use std::io;
 use std::path::{PathBuf, Path};
 
@@ -75,9 +76,11 @@ fn main() {
     path.pop();
     path.pop();
 
-    let args: Vec<String> =
+    let mut args: Vec<String> =
         format!("_ _ --sysroot {} --crate-type dylib", path.to_str().unwrap())
         .split(' ').map(|s| s.to_string()).collect();
+    args.push("--out-dir".to_string());
+    args.push(env::var("TMPDIR").unwrap());
 
     let (result, _) = rustc_driver::run_compiler(
         &args, &mut JitCalls, Some(box JitLoader), None);


### PR DESCRIPTION
Tweak a few run-make tests to emit files in the output directories, not directly
in the source tree.
