### PR TITLE
Fix make check-stage1 by conditionally activating question_mark feature for compiletest tool.

### DIFF
--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -15,6 +15,8 @@
 #![feature(test)]
 #![feature(libc)]
 
+#![cfg_attr(stage0, feature(question_mark))]
+
 #![deny(warnings)]
 
 extern crate libc;


### PR DESCRIPTION
r? @alexcrichton 
