### PR TITLE
proc_macro_plugin: Wrap nonexistent filename in <>

### DIFF
--- a/src/libproc_macro_tokens/parse.rs
+++ b/src/libproc_macro_tokens/parse.rs
@@ -15,12 +15,12 @@ extern crate syntax;
 use syntax::parse::{ParseSess, filemap_to_tts};
 use syntax::tokenstream::TokenStream;
 
-/// Map a string to tts, using a made-up filename. For example, `lex(15)` will return a
+/// Map a string to tts, using a made-up filename. For example, `lex("15")` will return a
 /// TokenStream containing the literal 15.
 pub fn lex(source_str: &str) -> TokenStream {
     let ps = ParseSess::new();
     TokenStream::from_tts(filemap_to_tts(&ps,
-                                         ps.codemap().new_filemap("procmacro_lex".to_string(),
+                                         ps.codemap().new_filemap("<procmacro_lex>".to_string(),
                                                                   None,
                                                                   source_str.to_owned())))
 }


### PR DESCRIPTION
I'm not sure how big of an issue this can become in practice, but `FileMap`s made from something that's not a file are supposed to wrap the file name in `<>`.

For an example fix, see kevinmehall/rust-peg@332fd4dbae19b64fb2af4b9d565e37a3703e7576. There, it caused cargo to always recompile a crate using rust-peg, even when nothing was changed, because cargo sees that the dummy file doesn't exist.
