### PR TITLE
correct erroneous pluralization of '1 type argument' error messages

### DIFF
--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -2218,10 +2218,12 @@ fn check_type_argument_count(tcx: TyCtxt, span: Span, supplied: usize,
         } else {
             "expected"
         };
+        let arguments_plural = if required == 1 { "" } else { "s" };
         struct_span_err!(tcx.sess, span, E0243, "wrong number of type arguments")
             .span_label(
                 span,
-                &format!("{} {} type arguments, found {}", expected, required, supplied)
+                &format!("{} {} type argument{}, found {}",
+                         expected, required, arguments_plural, supplied)
             )
             .emit();
     } else if supplied > accepted {
@@ -2232,11 +2234,12 @@ fn check_type_argument_count(tcx: TyCtxt, span: Span, supplied: usize,
         } else {
             format!("expected {}", accepted)
         };
+        let arguments_plural = if accepted == 1 { "" } else { "s" };
 
         struct_span_err!(tcx.sess, span, E0244, "wrong number of type arguments")
             .span_label(
                 span,
-                &format!("{} type arguments, found {}", expected, supplied)
+                &format!("{} type argument{}, found {}", expected, arguments_plural, supplied)
             )
             .emit();
     }

--- a/src/test/compile-fail/E0243.rs
+++ b/src/test/compile-fail/E0243.rs
@@ -11,7 +11,7 @@
 struct Foo<T> { x: T }
 struct Bar { x: Foo }
                 //~^ ERROR E0243
-                //~| NOTE expected 1 type arguments, found 0
+                //~| NOTE expected 1 type argument, found 0
 
 fn main() {
 }

--- a/src/test/compile-fail/generic-type-less-params-with-defaults.rs
+++ b/src/test/compile-fail/generic-type-less-params-with-defaults.rs
@@ -18,5 +18,5 @@ struct Vec<T, A = Heap>(
 fn main() {
     let _: Vec;
     //~^ ERROR E0243
-    //~| NOTE expected at least 1 type arguments, found 0
+    //~| NOTE expected at least 1 type argument, found 0
 }

--- a/src/test/compile-fail/issue-14092.rs
+++ b/src/test/compile-fail/issue-14092.rs
@@ -10,6 +10,6 @@
 
 fn fn1(0: Box) {}
         //~^ ERROR E0243
-        //~| NOTE expected 1 type arguments, found 0
+        //~| NOTE expected 1 type argument, found 0
 
 fn main() {}

--- a/src/test/compile-fail/typeck_type_placeholder_lifetime_1.rs
+++ b/src/test/compile-fail/typeck_type_placeholder_lifetime_1.rs
@@ -18,5 +18,5 @@ struct Foo<'a, T:'a> {
 pub fn main() {
     let c: Foo<_, _> = Foo { r: &5 };
     //~^ ERROR E0244
-    //~| NOTE expected 1 type arguments, found 2
+    //~| NOTE expected 1 type argument, found 2
 }

--- a/src/test/compile-fail/typeck_type_placeholder_lifetime_2.rs
+++ b/src/test/compile-fail/typeck_type_placeholder_lifetime_2.rs
@@ -18,5 +18,5 @@ struct Foo<'a, T:'a> {
 pub fn main() {
     let c: Foo<_, usize> = Foo { r: &5 };
     //~^ ERROR E0244
-    //~| NOTE expected 1 type arguments, found 2
+    //~| NOTE expected 1 type argument, found 2
 }


### PR DESCRIPTION
This is in the matter of #37042.
