### PR TITLE
Remove un-rendered ticks from "const and static" doc title

### DIFF
--- a/src/doc/book/const-and-static.md
+++ b/src/doc/book/const-and-static.md
@@ -1,4 +1,4 @@
-% `const` and `static`
+% const and static
 
 Rust has a way of defining constants with the `const` keyword:
 


### PR DESCRIPTION
Related to #37116 and #37119.

Ticks in the titles are not correctly rendered

![const-static-render](https://cloud.githubusercontent.com/assets/10340167/19412643/63e385a2-92e8-11e6-81f1-16802f803aad.png)
