### PR TITLE
include LLVM version in `--version --verbose`

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -729,6 +729,10 @@ pub fn version(binary: &str, matches: &getopts::Matches) {
         println!("commit-date: {}", unw(commit_date_str()));
         println!("host: {}", config::host_triple());
         println!("release: {}", unw(release_str()));
+        unsafe {
+            println!("LLVM version: {}.{}",
+                     llvm::LLVMRustVersionMajor(), llvm::LLVMRustVersionMinor());
+        }
     }
 }
 


### PR DESCRIPTION
This is in the matter of #28405.

```
$ ./x86_64-unknown-linux-gnu/stage1/bin/rustc --version --verbose
rustc 1.14.0-dev (8e05e7ee3 2016-10-15)
binary: rustc
commit-hash: 8e05e7ee3c19a5594b79d67c8390cef78970be7c
commit-date: 2016-10-15
host: x86_64-unknown-linux-gnu
release: 1.14.0-dev
LLVM version: 3.9
```
