### PR TITLE
Fix some pretty printing tests

### DIFF
--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -545,15 +545,12 @@ pub trait PrintState<'a> {
     }
 
     fn maybe_print_comment(&mut self, pos: BytePos) -> io::Result<()> {
-        loop {
-            match self.next_comment() {
-                Some(ref cmnt) => {
-                    if (*cmnt).pos < pos {
-                        try!(self.print_comment(cmnt));
-                        self.cur_cmnt_and_lit().cur_cmnt += 1;
-                    } else { break; }
-                }
-                _ => break
+        while let Some(ref cmnt) = self.next_comment() {
+            if cmnt.pos < pos {
+                try!(self.print_comment(cmnt));
+                self.cur_cmnt_and_lit().cur_cmnt += 1;
+            } else {
+                break
             }
         }
         Ok(())
@@ -581,7 +578,9 @@ pub trait PrintState<'a> {
                 Ok(())
             }
             comments::Trailing => {
-                try!(word(self.writer(), " "));
+                if !self.is_bol() {
+                    try!(word(self.writer(), " "));
+                }
                 if cmnt.lines.len() == 1 {
                     try!(word(self.writer(), &cmnt.lines[0]));
                     hardbreak(self.writer())
@@ -1715,6 +1714,7 @@ impl<'a> State<'a> {
         for (i, st) in blk.stmts.iter().enumerate() {
             match st.node {
                 ast::StmtKind::Expr(ref expr) if i == blk.stmts.len() - 1 => {
+                    try!(self.maybe_print_comment(st.span.lo));
                     try!(self.space_if_not_bol());
                     try!(self.print_expr_outer_attr_style(&expr, false));
                     try!(self.maybe_print_trailing_comment(expr.span, Some(blk.span.hi)));
@@ -2604,6 +2604,7 @@ impl<'a> State<'a> {
         }
         try!(self.cbox(INDENT_UNIT));
         try!(self.ibox(0));
+        try!(self.maybe_print_comment(arm.pats[0].span.lo));
         try!(self.print_outer_attributes(&arm.attrs));
         let mut first = true;
         for p in &arm.pats {
@@ -3007,15 +3008,11 @@ impl<'a> State<'a> {
             _ => return Ok(())
         };
         if let Some(ref cmnt) = self.next_comment() {
-            if (*cmnt).style != comments::Trailing { return Ok(()) }
+            if cmnt.style != comments::Trailing { return Ok(()) }
             let span_line = cm.lookup_char_pos(span.hi);
-            let comment_line = cm.lookup_char_pos((*cmnt).pos);
-            let mut next = (*cmnt).pos + BytePos(1);
-            if let Some(p) = next_pos {
-                next = p;
-            }
-            if span.hi < (*cmnt).pos && (*cmnt).pos < next &&
-               span_line.line == comment_line.line {
+            let comment_line = cm.lookup_char_pos(cmnt.pos);
+            let next = next_pos.unwrap_or(cmnt.pos + BytePos(1));
+            if span.hi < cmnt.pos && cmnt.pos < next && span_line.line == comment_line.line {
                 self.print_comment(cmnt)?;
                 self.cur_cmnt_and_lit.cur_cmnt += 1;
             }

--- a/src/test/compile-fail/borrowck/borrowck-use-uninitialized-in-cast.rs
+++ b/src/test/compile-fail/borrowck/borrowck-use-uninitialized-in-cast.rs
@@ -12,8 +12,6 @@
 // The problem was specified to casting to `*`, as creating unsafe
 // pointers was not being fully checked. Issue #20791.
 
-// pretty-expanded FIXME #23616
-
 fn main() {
     let x: &i32;
     let y = x as *const i32; //~ ERROR use of possibly uninitialized variable: `*x`

--- a/src/test/compile-fail/coherence-cow.rs
+++ b/src/test/compile-fail/coherence-cow.rs
@@ -12,8 +12,6 @@
 
 // aux-build:coherence_lib.rs
 
-// pretty-expanded FIXME #23616
-
 // Test that the `Pair` type reports an error if it contains type
 // parameters, even when they are covered by local types. This test
 // was originally intended to test the opposite, but the rules changed

--- a/src/test/compile-fail/coherence-vec-local-2.rs
+++ b/src/test/compile-fail/coherence-vec-local-2.rs
@@ -13,8 +13,6 @@
 
 // aux-build:coherence_lib.rs
 
-// pretty-expanded FIXME #23616
-
 extern crate coherence_lib as lib;
 use lib::Remote;
 

--- a/src/test/compile-fail/coherence-vec-local.rs
+++ b/src/test/compile-fail/coherence-vec-local.rs
@@ -13,8 +13,6 @@
 
 // aux-build:coherence_lib.rs
 
-// pretty-expanded FIXME #23616
-
 extern crate coherence_lib as lib;
 use lib::Remote;
 

--- a/src/test/compile-fail/issue-13352.rs
+++ b/src/test/compile-fail/issue-13352.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
-
 fn foo(_: Box<FnMut()>) {}
 
 fn main() {

--- a/src/test/compile-fail/issue-19482.rs
+++ b/src/test/compile-fail/issue-19482.rs
@@ -11,8 +11,6 @@
 // Test that a partially specified trait object with unspecified associated
 // type does not type-check.
 
-// pretty-expanded FIXME #23616
-
 trait Foo {
     type A;
 

--- a/src/test/compile-fail/meta-expected-error-correct-rev.rs
+++ b/src/test/compile-fail/meta-expected-error-correct-rev.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 // revisions: a
-// pretty-expanded FIXME #23616
 
 // Counterpart to `meta-expected-error-wrong-rev.rs`
 

--- a/src/test/compile-fail/meta-expected-error-wrong-rev.rs
+++ b/src/test/compile-fail/meta-expected-error-wrong-rev.rs
@@ -10,7 +10,6 @@
 
 // revisions: a
 // should-fail
-// pretty-expanded FIXME #23616
 
 // This is a "meta-test" of the compilertest framework itself.  In
 // particular, it includes the right error message, but the message

--- a/src/test/compile-fail/object-lifetime-default-from-rptr-box-error.rs
+++ b/src/test/compile-fail/object-lifetime-default-from-rptr-box-error.rs
@@ -11,8 +11,6 @@
 // Test that the lifetime from the enclosing `&` is "inherited"
 // through the `Box` struct.
 
-// pretty-expanded FIXME #23616
-
 #![allow(dead_code)]
 
 trait Test {

--- a/src/test/compile-fail/object-lifetime-default-from-rptr-struct-error.rs
+++ b/src/test/compile-fail/object-lifetime-default-from-rptr-struct-error.rs
@@ -11,8 +11,6 @@
 // Test that the lifetime from the enclosing `&` is "inherited"
 // through the `MyBox` struct.
 
-// pretty-expanded FIXME #23616
-
 #![allow(dead_code)]
 #![feature(rustc_error)]
 

--- a/src/test/compile-fail/variance-trait-matching.rs
+++ b/src/test/compile-fail/variance-trait-matching.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
-
 #![allow(dead_code)]
 
 // Get<T> is covariant in T

--- a/src/test/pretty/for-comment.rs
+++ b/src/test/pretty/for-comment.rs
@@ -17,6 +17,5 @@ fn f(v: &[isize]) -> isize {
     for e in v {
         n = *e; // This comment once triggered pretty printer bug
     }
-
     n
 }

--- a/src/test/run-fail/divide-by-zero.rs
+++ b/src/test/run-fail/divide-by-zero.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty : (#23623) problems when  ending with // comments
-
 // error-pattern:attempt to divide by zero
 
 fn main() {

--- a/src/test/run-fail/glob-use-std.rs
+++ b/src/test/run-fail/glob-use-std.rs
@@ -10,10 +10,6 @@
 
 // Issue #7580
 
-// ignore-pretty
-//
-// Expanded pretty printing causes resolve conflicts.
-
 // error-pattern:panic works
 
 use std::*;

--- a/src/test/run-fail/mod-zero.rs
+++ b/src/test/run-fail/mod-zero.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty : (#23623) problems when  ending with // comments
-
 // error-pattern:attempt to calculate the remainder with a divisor of zero
 
 fn main() {

--- a/src/test/run-fail/overflowing-add.rs
+++ b/src/test/run-fail/overflowing-add.rs
@@ -8,11 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty : (#23623) problems when  ending with // comments
-
 // error-pattern:thread 'main' panicked at 'attempt to add with overflow'
 // compile-flags: -C debug-assertions
-
 
 fn main() {
     let _x = 200u8 + 200u8 + 200u8;

--- a/src/test/run-fail/overflowing-lsh-1.rs
+++ b/src/test/run-fail/overflowing-lsh-1.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty : (#23623) problems when  ending with // comments
-
 // error-pattern:thread 'main' panicked at 'attempt to shift left with overflow'
 // compile-flags: -C debug-assertions
 

--- a/src/test/run-fail/overflowing-lsh-2.rs
+++ b/src/test/run-fail/overflowing-lsh-2.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty : (#23623) problems when  ending with // comments
-
 // error-pattern:thread 'main' panicked at 'attempt to shift left with overflow'
 // compile-flags: -C debug-assertions
 

--- a/src/test/run-fail/overflowing-lsh-3.rs
+++ b/src/test/run-fail/overflowing-lsh-3.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty : (#23623) problems when  ending with // comments
-
 // error-pattern:thread 'main' panicked at 'attempt to shift left with overflow'
 // compile-flags: -C debug-assertions
 

--- a/src/test/run-fail/overflowing-lsh-4.rs
+++ b/src/test/run-fail/overflowing-lsh-4.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty : (#23623) problems when  ending with // comments
-
 // error-pattern:thread 'main' panicked at 'attempt to shift left with overflow'
 // compile-flags: -C debug-assertions
 

--- a/src/test/run-fail/overflowing-mul.rs
+++ b/src/test/run-fail/overflowing-mul.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty : (#23623) problems when  ending with // comments
-
 // error-pattern:thread 'main' panicked at 'attempt to multiply with overflow'
 // compile-flags: -C debug-assertions
 

--- a/src/test/run-fail/overflowing-neg.rs
+++ b/src/test/run-fail/overflowing-neg.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty : (#23623) problems when  ending with // comments
-
 // error-pattern:thread 'main' panicked at 'attempt to negate with overflow'
 // compile-flags: -C debug-assertions
 

--- a/src/test/run-fail/overflowing-rsh-1.rs
+++ b/src/test/run-fail/overflowing-rsh-1.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty : (#23623) problems when  ending with // comments
-
 // error-pattern:thread 'main' panicked at 'attempt to shift right with overflow'
 // compile-flags: -C debug-assertions
 

--- a/src/test/run-fail/overflowing-rsh-2.rs
+++ b/src/test/run-fail/overflowing-rsh-2.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty : (#23623) problems when  ending with // comments
-
 // error-pattern:thread 'main' panicked at 'attempt to shift right with overflow'
 // compile-flags: -C debug-assertions
 

--- a/src/test/run-fail/overflowing-rsh-3.rs
+++ b/src/test/run-fail/overflowing-rsh-3.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty : (#23623) problems when  ending with // comments
-
 // error-pattern:thread 'main' panicked at 'attempt to shift right with overflow'
 // compile-flags: -C debug-assertions
 

--- a/src/test/run-fail/overflowing-rsh-4.rs
+++ b/src/test/run-fail/overflowing-rsh-4.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty : (#23623) problems when  ending with // comments
-
 // error-pattern:thread 'main' panicked at 'attempt to shift right with overflow'
 // compile-flags: -C debug-assertions
 

--- a/src/test/run-fail/overflowing-rsh-5.rs
+++ b/src/test/run-fail/overflowing-rsh-5.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty : (#23623) problems when  ending with // comments
-
 // error-pattern:thread 'main' panicked at 'attempt to shift right with overflow'
 // compile-flags: -C debug-assertions
 

--- a/src/test/run-fail/overflowing-rsh-6.rs
+++ b/src/test/run-fail/overflowing-rsh-6.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty : (#23623) problems when  ending with // comments
-
 // error-pattern:thread 'main' panicked at 'attempt to shift right with overflow'
 // compile-flags: -C debug-assertions
 

--- a/src/test/run-fail/overflowing-sub.rs
+++ b/src/test/run-fail/overflowing-sub.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty : (#23623) problems when  ending with // comments
-
 // error-pattern:thread 'main' panicked at 'attempt to subtract with overflow'
 // compile-flags: -C debug-assertions
 

--- a/src/test/run-fail/run-unexported-tests.rs
+++ b/src/test/run-fail/run-unexported-tests.rs
@@ -11,7 +11,6 @@
 // error-pattern:runned an unexported test
 // compile-flags:--test
 // check-stdout
-// ignore-pretty: does not work well with `--test`
 
 mod m {
     pub fn exported() {}

--- a/src/test/run-fail/test-panic.rs
+++ b/src/test/run-fail/test-panic.rs
@@ -11,7 +11,6 @@
 // check-stdout
 // error-pattern:thread 'test_foo' panicked at
 // compile-flags: --test
-// ignore-pretty: does not work well with `--test`
 // ignore-emscripten
 
 #[test]

--- a/src/test/run-fail/test-should-fail-bad-message.rs
+++ b/src/test/run-fail/test-should-fail-bad-message.rs
@@ -11,7 +11,6 @@
 // check-stdout
 // error-pattern:thread 'test_foo' panicked at
 // compile-flags: --test
-// ignore-pretty: does not work well with `--test`
 // ignore-emscripten
 
 #[test]

--- a/src/test/run-fail/test-tasks-invalid-value.rs
+++ b/src/test/run-fail/test-tasks-invalid-value.rs
@@ -14,7 +14,6 @@
 // error-pattern:should be a positive integer
 // compile-flags: --test
 // exec-env:RUST_TEST_THREADS=foo
-// ignore-pretty: does not work well with `--test`
 // ignore-emscripten
 
 #[test]

--- a/src/test/run-pass-fulldeps/custom-derive-partial-eq.rs
+++ b/src/test/run-pass-fulldeps/custom-derive-partial-eq.rs
@@ -10,8 +10,6 @@
 
 // aux-build:custom_derive_partial_eq.rs
 // ignore-stage1
-// ignore-pretty : (#23623) problems when  ending with // comments
-
 #![feature(plugin, custom_derive)]
 #![plugin(custom_derive_partial_eq)]
 #![allow(unused)]

--- a/src/test/run-pass-fulldeps/issue-16992.rs
+++ b/src/test/run-pass-fulldeps/issue-16992.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
 // ignore-cross-compile
 
 #![feature(quote, rustc_private)]

--- a/src/test/run-pass-fulldeps/issue-18763-quote-token-tree.rs
+++ b/src/test/run-pass-fulldeps/issue-18763-quote-token-tree.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 // ignore-cross-compile
-// ignore-pretty: does not work well with `--test`
-
 #![feature(quote, rustc_private)]
 
 extern crate syntax;

--- a/src/test/run-pass-fulldeps/lint-group-plugin.rs
+++ b/src/test/run-pass-fulldeps/lint-group-plugin.rs
@@ -10,8 +10,6 @@
 
 // aux-build:lint_group_plugin_test.rs
 // ignore-stage1
-// ignore-pretty
-
 #![feature(plugin)]
 #![plugin(lint_group_plugin_test)]
 #![allow(dead_code)]

--- a/src/test/run-pass-fulldeps/lint-plugin-cmdline-load.rs
+++ b/src/test/run-pass-fulldeps/lint-plugin-cmdline-load.rs
@@ -10,7 +10,6 @@
 
 // aux-build:lint_plugin_test.rs
 // ignore-stage1
-// ignore-pretty: Random space appears with the pretty test
 // compile-flags: -Z extra-plugins=lint_plugin_test
 
 #![allow(dead_code)]

--- a/src/test/run-pass-fulldeps/lint-plugin.rs
+++ b/src/test/run-pass-fulldeps/lint-plugin.rs
@@ -10,8 +10,6 @@
 
 // aux-build:lint_plugin_test.rs
 // ignore-stage1
-// ignore-pretty
-
 #![feature(plugin)]
 #![plugin(lint_plugin_test)]
 #![allow(dead_code)]

--- a/src/test/run-pass-fulldeps/quote-tokens.rs
+++ b/src/test/run-pass-fulldeps/quote-tokens.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 // ignore-cross-compile
-// ignore-pretty: does not work well with `--test`
-
 #![feature(quote, rustc_private)]
 
 extern crate syntax;

--- a/src/test/run-pass-fulldeps/quote-unused-sp-no-warning.rs
+++ b/src/test/run-pass-fulldeps/quote-unused-sp-no-warning.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 // ignore-cross-compile
-// ignore-pretty: does not work well with `--test`
-
 #![feature(quote, rustc_private)]
 #![deny(unused_variables)]
 

--- a/src/test/run-pass-valgrind/cast-enum-with-dtor.rs
+++ b/src/test/run-pass-valgrind/cast-enum-with-dtor.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty : (#23623) problems when  ending with // comments
-
 // no-prefer-dynamic
 
 #![allow(dead_code)]

--- a/src/test/run-pass/backtrace-debuginfo.rs
+++ b/src/test/run-pass/backtrace-debuginfo.rs
@@ -16,7 +16,7 @@
 // "enable" to 0 instead.
 
 // compile-flags:-g -Cllvm-args=-enable-tail-merge=0
-// ignore-pretty as this critically relies on line numbers
+// ignore-pretty issue #37195
 // ignore-emscripten spawning processes is not supported
 
 use std::io;

--- a/src/test/run-pass/backtrace.rs
+++ b/src/test/run-pass/backtrace.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// no-pretty-expanded FIXME #15189
 // ignore-android FIXME #17520
 // ignore-emscripten spawning processes is not supported
 // compile-flags:-g

--- a/src/test/run-pass/borrowck/borrowck-pat-enum.rs
+++ b/src/test/run-pass/borrowck/borrowck-pat-enum.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
+// ignore-pretty issue #37199
 
 fn match_ref(v: Option<isize>) -> isize {
     match v {

--- a/src/test/run-pass/cfg-in-crate-1.rs
+++ b/src/test/run-pass/cfg-in-crate-1.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 // compile-flags: --cfg bar -D warnings
-// ignore-pretty
-
 #![cfg(bar)]
 
 fn main() {}

--- a/src/test/run-pass/command-exec.rs
+++ b/src/test/run-pass/command-exec.rs
@@ -9,9 +9,8 @@
 // except according to those terms.
 
 // ignore-windows - this is a unix-specific test
+// ignore-pretty issue #37199
 // ignore-emscripten
-// ignore-pretty
-
 #![feature(process_exec)]
 
 use std::env;

--- a/src/test/run-pass/core-run-destroy.rs
+++ b/src/test/run-pass/core-run-destroy.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
 // compile-flags:--test
 // ignore-emscripten
 

--- a/src/test/run-pass/deprecated-macro_escape-inner.rs
+++ b/src/test/run-pass/deprecated-macro_escape-inner.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
-
 mod foo {
     #![macro_escape] //~ WARNING macro_escape is a deprecated synonym for macro_use
     //~^ HELP consider an outer attribute

--- a/src/test/run-pass/deprecated-macro_escape.rs
+++ b/src/test/run-pass/deprecated-macro_escape.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
-
 #[macro_escape] //~ WARNING macro_escape is a deprecated synonym for macro_use
 mod foo {
 }

--- a/src/test/run-pass/deriving-cmp-generic-enum.rs
+++ b/src/test/run-pass/deriving-cmp-generic-enum.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// no-pretty-expanded FIXME #15189
-
-
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 enum E<T> {
     E0,

--- a/src/test/run-pass/deriving-meta-empty-trait-list.rs
+++ b/src/test/run-pass/deriving-meta-empty-trait-list.rs
@@ -1,5 +1,3 @@
-// ignore-pretty
-
 // Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.

--- a/src/test/run-pass/enum-size-variance.rs
+++ b/src/test/run-pass/enum-size-variance.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 //
-// ignore-pretty
-
 #![warn(variant_size_differences)]
 #![allow(dead_code)]
 

--- a/src/test/run-pass/hygienic-labels-in-let.rs
+++ b/src/test/run-pass/hygienic-labels-in-let.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty: pprust doesn't print hygiene output
-
 // Test that labels injected by macros do not break hygiene.  This
 // checks cases where the macros invocations are under the rhs of a
 // let statement.

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// no-pretty-expanded unnecessary unsafe block generated
-
 #![deny(warnings)]
 #![allow(unused_must_use)]
 #![allow(unused_features)]

--- a/src/test/run-pass/imports.rs
+++ b/src/test/run-pass/imports.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty : (#23623) problems when ending with // comments
-
 #![feature(item_like_imports)]
 #![allow(unused)]
 

--- a/src/test/run-pass/issue-11709.rs
+++ b/src/test/run-pass/issue-11709.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
+// ignore-pretty issue #37199
 
 // Don't panic on blocks without results
 // There are several tests in this run-pass that raised

--- a/src/test/run-pass/issue-15189.rs
+++ b/src/test/run-pass/issue-15189.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
-
 macro_rules! third {
     ($e:expr) => ({let x = 2; $e[x]})
 }

--- a/src/test/run-pass/issue-16492.rs
+++ b/src/test/run-pass/issue-16492.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
-
 use std::rc::Rc;
 use std::cell::Cell;
 

--- a/src/test/run-pass/issue-16597-empty.rs
+++ b/src/test/run-pass/issue-16597-empty.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 // compile-flags:--test
-// no-pretty-expanded
 
 // This verifies that the test generation doesn't crash when we have
 // no tests - for more information, see PR #16892.

--- a/src/test/run-pass/issue-16597.rs
+++ b/src/test/run-pass/issue-16597.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 // compile-flags:--test
-// ignore-pretty turns out the pretty-printer doesn't handle gensym'd things...
 
 mod tests {
     use super::*;

--- a/src/test/run-pass/issue-16668.rs
+++ b/src/test/run-pass/issue-16668.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
-
 #![allow(unknown_features)]
 
 struct Parser<'a, I, O> {

--- a/src/test/run-pass/issue-18464.rs
+++ b/src/test/run-pass/issue-18464.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
-
 #![deny(dead_code)]
 
 const LOW_RANGE: char = '0';

--- a/src/test/run-pass/issue-20427.rs
+++ b/src/test/run-pass/issue-20427.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:i8.rs
-// ignore-pretty (#23623)
+// ignore-pretty issue #37201
 
 extern crate i8;
 use std::string as i16;

--- a/src/test/run-pass/issue-20823.rs
+++ b/src/test/run-pass/issue-20823.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 // compile-flags: --test
-// no-pretty-expanded
 
 #![deny(unstable)]
 

--- a/src/test/run-pass/issue-22992.rs
+++ b/src/test/run-pass/issue-22992.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
+// ignore-pretty issue #37201
 
 struct X { val: i32 }
 impl std::ops::Deref for X {

--- a/src/test/run-pass/issue-23338-ensure-param-drop-order.rs
+++ b/src/test/run-pass/issue-23338-ensure-param-drop-order.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty : (#23623) problems when  ending with // comments
+// ignore-pretty issue #37201
 
 // This test is ensuring that parameters are indeed dropped after
 // temporaries in a fn body.

--- a/src/test/run-pass/issue-26873-multifile.rs
+++ b/src/test/run-pass/issue-26873-multifile.rs
@@ -7,10 +7,9 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-//
-// ignore-pretty
+
+// ignore-pretty issue #37195
 
 mod issue_26873_multifile;
 
 fn main() {}
-

--- a/src/test/run-pass/issue-27401-dropflag-reinit.rs
+++ b/src/test/run-pass/issue-27401-dropflag-reinit.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty #27582
+// ignore-pretty issue #37201
 
 // Check that when a `let`-binding occurs in a loop, its associated
 // drop-flag is reinitialized (to indicate "needs-drop" at the end of

--- a/src/test/run-pass/issue-27639.rs
+++ b/src/test/run-pass/issue-27639.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
-
 fn main() {
     const iter: i32 = 0;
 

--- a/src/test/run-pass/issue-28839.rs
+++ b/src/test/run-pass/issue-28839.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty : (#23623) problems with newlines before // comments
+// ignore-pretty issue #37199
 
 pub struct Foo;
 

--- a/src/test/run-pass/issue-29740.rs
+++ b/src/test/run-pass/issue-29740.rs
@@ -11,8 +11,6 @@
 // Regression test for #29740. Inefficient MIR matching algorithms
 // generated way too much code for this sort of case, leading to OOM.
 
-// ignore-pretty
-
 pub mod KeyboardEventConstants {
     pub const DOM_KEY_LOCATION_STANDARD: u32 = 0;
     pub const DOM_KEY_LOCATION_LEFT: u32 = 1;

--- a/src/test/run-pass/issue-34932.rs
+++ b/src/test/run-pass/issue-34932.rs
@@ -10,8 +10,6 @@
 
 // compile-flags:--test
 // rustc-env:RUSTC_BOOTSTRAP_KEY=
-// ignore-pretty : (#23623) problems when  ending with // comments
-
 #![cfg(any())] // This test should be configured away
 #![feature(rustc_attrs)] // Test that this is allowed on stable/beta
 #![feature(iter_arith_traits)] // Test that this is not unused

--- a/src/test/run-pass/issue-7911.rs
+++ b/src/test/run-pass/issue-7911.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
-
 // (Closes #7911) Test that we can use the same self expression
 // with different mutability in macro in two methods
 

--- a/src/test/run-pass/issue-8460.rs
+++ b/src/test/run-pass/issue-8460.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 // ignore-emscripten no threads support
-// ignore-pretty : (#23623) problems when  ending with // comments
-
 #![feature(rustc_attrs, zero_one)]
 
 use std::num::Zero;

--- a/src/test/run-pass/issue-9129.rs
+++ b/src/test/run-pass/issue-9129.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
+// ignore-pretty unreported
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/lexer-crlf-line-endings-string-literal-doc-comment.rs
+++ b/src/test/run-pass/lexer-crlf-line-endings-string-literal-doc-comment.rs
@@ -15,7 +15,7 @@
 // NB: this file needs CRLF line endings. The .gitattributes file in
 // this directory should enforce it.
 
-// ignore-pretty
+// ignore-pretty issue #37195
 
 /// Doc comment that ends in CRLF
 pub fn foo() {}

--- a/src/test/run-pass/linear-for-loop.rs
+++ b/src/test/run-pass/linear-for-loop.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// no-pretty-expanded FIXME #15189
-
 pub fn main() {
     let x = vec!(1, 2, 3);
     let mut y = 0;

--- a/src/test/run-pass/macro-2.rs
+++ b/src/test/run-pass/macro-2.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty - token trees can't pretty print
-
 pub fn main() {
 
     macro_rules! mylambda_tt {

--- a/src/test/run-pass/macro-attribute-expansion.rs
+++ b/src/test/run-pass/macro-attribute-expansion.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty - token trees can't pretty print
-
 macro_rules! descriptions {
     ($name:ident is $desc:expr) => {
         // Check that we will correctly expand attributes

--- a/src/test/run-pass/macro-attributes.rs
+++ b/src/test/run-pass/macro-attributes.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty - token trees can't pretty print
-
 #![feature(custom_attribute)]
 
 macro_rules! compiles_fine {

--- a/src/test/run-pass/macro-include-items.rs
+++ b/src/test/run-pass/macro-include-items.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
+// ignore-pretty issue #37195
 
 fn bar() {}
 

--- a/src/test/run-pass/macro-meta-items.rs
+++ b/src/test/run-pass/macro-meta-items.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty - token trees can't pretty print
 // compile-flags: --cfg foo
 
 macro_rules! compiles_fine {

--- a/src/test/run-pass/macro-multiple-items.rs
+++ b/src/test/run-pass/macro-multiple-items.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty - token trees can't pretty print
-
 macro_rules! make_foo {
     () => (
         struct Foo;

--- a/src/test/run-pass/macro-stmt.rs
+++ b/src/test/run-pass/macro-stmt.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty - token trees can't pretty print
-
 macro_rules! myfn {
     ( $f:ident, ( $( $x:ident ),* ), $body:block ) => (
         fn $f( $( $x : isize),* ) -> isize $body

--- a/src/test/run-pass/mir_raw_fat_ptr.rs
+++ b/src/test/run-pass/mir_raw_fat_ptr.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty : (#23623) problems when  ending with // comments
-
 // check raw fat pointer ops in mir
 // FIXME: please improve this when we get monomorphization support
 

--- a/src/test/run-pass/mod_dir_implicit.rs
+++ b/src/test/run-pass/mod_dir_implicit.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
+// ignore-pretty issue #37195
 
 mod mod_dir_implicit_aux;
 

--- a/src/test/run-pass/mod_dir_path.rs
+++ b/src/test/run-pass/mod_dir_path.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
+// ignore-pretty issue #37195
 
 mod mod_dir_simple {
     #[path = "test.rs"]

--- a/src/test/run-pass/mod_dir_path2.rs
+++ b/src/test/run-pass/mod_dir_path2.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
+// ignore-pretty issue #37195
 
 #[path = "mod_dir_simple"]
 mod pancakes {

--- a/src/test/run-pass/mod_dir_path3.rs
+++ b/src/test/run-pass/mod_dir_path3.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
+// ignore-pretty issue #37195
 
 #[path = "mod_dir_simple"]
 mod pancakes {

--- a/src/test/run-pass/mod_dir_path_multi.rs
+++ b/src/test/run-pass/mod_dir_path_multi.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
+// ignore-pretty issue #37195
 
 #[path = "mod_dir_simple"]
 mod biscuits {

--- a/src/test/run-pass/mod_dir_recursive.rs
+++ b/src/test/run-pass/mod_dir_recursive.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
+// ignore-pretty issue #37195
 
 // Testing that the parser for each file tracks its modules
 // and paths independently. The load_another_mod module should

--- a/src/test/run-pass/mod_dir_simple.rs
+++ b/src/test/run-pass/mod_dir_simple.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
+// ignore-pretty issue #37195
 
 mod mod_dir_simple {
     pub mod test;

--- a/src/test/run-pass/mod_file.rs
+++ b/src/test/run-pass/mod_file.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
+// ignore-pretty issue #37195
 
 // Testing that a plain .rs file can load modules from other source files
 

--- a/src/test/run-pass/mod_file_with_path_attr.rs
+++ b/src/test/run-pass/mod_file_with_path_attr.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
+// ignore-pretty issue #37195
 
 // Testing that a plain .rs file can load modules from other source files
 

--- a/src/test/run-pass/numeric-method-autoexport.rs
+++ b/src/test/run-pass/numeric-method-autoexport.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// no-pretty-expanded
-
 // This file is intended to test only that methods are automatically
 // reachable for each numeric type, for each exported impl, with no imports
 // necessary. Testing the methods of the impls is done within the source

--- a/src/test/run-pass/reexport-test-harness-main.rs
+++ b/src/test/run-pass/reexport-test-harness-main.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
 // compile-flags:--test
 
 #![reexport_test_harness_main = "test_main"]

--- a/src/test/run-pass/regions-bound-lists-feature-gate-2.rs
+++ b/src/test/run-pass/regions-bound-lists-feature-gate-2.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
-
 #![feature(issue_5723_bootstrap)]
 
 trait Foo {

--- a/src/test/run-pass/regions-bound-lists-feature-gate.rs
+++ b/src/test/run-pass/regions-bound-lists-feature-gate.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
-
 #![feature(issue_5723_bootstrap)]
 
 trait Foo {

--- a/src/test/run-pass/shebang.rs
+++ b/src/test/run-pass/shebang.rs
@@ -9,7 +9,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty: `expand` adds some preludes before shebang
-//
-
 pub fn main() { println!("Hello World"); }

--- a/src/test/run-pass/simd-intrinsic-generic-elements.rs
+++ b/src/test/run-pass/simd-intrinsic-generic-elements.rs
@@ -10,8 +10,6 @@
 
 #![feature(repr_simd, platform_intrinsics)]
 
-// ignore-pretty : (#23623) problems when  ending with // comments
-
 #[repr(simd)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(non_camel_case_types)]

--- a/src/test/run-pass/super-fast-paren-parsing.rs
+++ b/src/test/run-pass/super-fast-paren-parsing.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
-//
 // exec-env:RUST_MIN_STACK=16000000
 // rustc-env:RUST_MIN_STACK=16000000
 //

--- a/src/test/run-pass/syntax-extension-source-utils.rs
+++ b/src/test/run-pass/syntax-extension-source-utils.rs
@@ -8,10 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(core)]
-
-// This test is brittle!
-// ignore-pretty - the pretty tests lose path information, breaking include!
+// ignore-pretty issue #37195
 
 pub mod m1 {
     pub mod m2 {
@@ -24,9 +21,9 @@ pub mod m1 {
 macro_rules! indirect_line { () => ( line!() ) }
 
 pub fn main() {
-    assert_eq!(line!(), 27);
+    assert_eq!(line!(), 24);
     assert_eq!(column!(), 4);
-    assert_eq!(indirect_line!(), 29);
+    assert_eq!(indirect_line!(), 26);
     assert!((file!().ends_with("syntax-extension-source-utils.rs")));
     assert_eq!(stringify!((2*3) + 5).to_string(), "( 2 * 3 ) + 5".to_string());
     assert!(include!("syntax-extension-source-utils-files/includeme.\
@@ -43,5 +40,5 @@ pub fn main() {
     // The Windows tests are wrapped in an extra module for some reason
     assert!((m1::m2::where_am_i().ends_with("m1::m2")));
 
-    assert_eq!((46, "( 2 * 3 ) + 5"), (line!(), stringify!((2*3) + 5)));
+    assert_eq!((43, "( 2 * 3 ) + 5"), (line!(), stringify!((2*3) + 5)));
 }

--- a/src/test/run-pass/task-comm-3.rs
+++ b/src/test/run-pass/task-comm-3.rs
@@ -11,7 +11,6 @@
 #![feature(std_misc)]
 
 // ignore-emscripten no threads support
-// no-pretty-expanded FIXME #15189
 
 use std::thread;
 use std::sync::mpsc::{channel, Sender};

--- a/src/test/run-pass/test-fn-signature-verification-for-explicit-return-type.rs
+++ b/src/test/run-pass/test-fn-signature-verification-for-explicit-return-type.rs
@@ -11,7 +11,6 @@
 #![feature(test)]
 
 // compile-flags: --test
-// no-pretty-expanded
 extern crate test;
 
 #[bench]

--- a/src/test/run-pass/test-runner-hides-main.rs
+++ b/src/test/run-pass/test-runner-hides-main.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 // compile-flags:--test
-// ignore-pretty: does not work well with `--test`
-
 // Building as a test runner means that a synthetic main will be run,
 // not ours
 pub fn main() { panic!(); }

--- a/src/test/run-pass/test-should-fail-good-message.rs
+++ b/src/test/run-pass/test-should-fail-good-message.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 // compile-flags: --test
-// ignore-pretty: does not work well with `--test`
-
 #[test]
 #[should_panic(expected = "foo")]
 pub fn test_foo() {

--- a/src/test/run-pass/trait-bounds-in-arc.rs
+++ b/src/test/run-pass/trait-bounds-in-arc.rs
@@ -12,8 +12,6 @@
 // and shared between threads as long as all types fulfill Send.
 
 // ignore-emscripten no threads support
-// ignore-pretty
-
 #![allow(unknown_features)]
 #![feature(box_syntax, std_misc)]
 

--- a/src/test/run-pass/union/union-with-drop-fields-lint.rs
+++ b/src/test/run-pass/union/union-with-drop-fields-lint.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty
-
 #![feature(untagged_unions)]
 #![allow(dead_code)]
 #![allow(unions_with_drop_fields)]


### PR DESCRIPTION
Many pretty-printing tests are un-ignored.
Some issues in classification of comments (trailing/isolated) and blank line counting are fixed.
Some comments are printed more carefully.
Some minor refactoring in pprust.rs
`no-pretty-expanded` annotations are removed because this is the default now.
`pretty-expanded` annotations are removed from compile-fail tests, they are not tested with pretty-printer.

Closes https://github.com/rust-lang/rust/issues/23623 in favor of more specific https://github.com/rust-lang/rust/issues/37201 and https://github.com/rust-lang/rust/issues/37199
r? @nrc 
