### PR TITLE
[Obligation Forest] Don't process cycles when stalled

### DIFF
--- a/src/librustc_data_structures/obligation_forest/mod.rs
+++ b/src/librustc_data_structures/obligation_forest/mod.rs
@@ -333,6 +333,7 @@ impl<O: ForestObligation> ObligationForest<O> {
                     }
                 }
                 Err(err) => {
+                    stalled = false;
                     let backtrace = self.error_at(index);
                     errors.push(Error {
                         error: err,

--- a/src/librustc_data_structures/obligation_forest/mod.rs
+++ b/src/librustc_data_structures/obligation_forest/mod.rs
@@ -342,6 +342,16 @@ impl<O: ForestObligation> ObligationForest<O> {
             }
         }
 
+        if stalled {
+            // There's no need to perform marking, cycle processing and compression when nothing
+            // changed.
+            return Outcome {
+                completed: vec![],
+                errors: errors,
+                stalled: stalled,
+            };
+        }
+
         self.mark_as_waiting();
         self.process_cycles(processor);
 


### PR DESCRIPTION
This improves the `inflate-0.1.0` benchmark by about 10% for me.

/me hopes this is sound
