### PR TITLE
std::collections: Reexport libcollections's range module

### DIFF
--- a/src/libstd/collections/mod.rs
+++ b/src/libstd/collections/mod.rs
@@ -425,6 +425,9 @@ pub use self::hash_map::HashMap;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::hash_set::HashSet;
 
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use core_collections::range;
+
 mod hash;
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -224,6 +224,7 @@
 #![feature(char_internals)]
 #![feature(collections)]
 #![feature(collections_bound)]
+#![feature(collections_range)]
 #![feature(compiler_builtins_lib)]
 #![feature(const_fn)]
 #![feature(core_float)]


### PR DESCRIPTION
This is overdue, even if range and RangeArgument is still unstable.
The stability attributes are the same ones as the other unstable item
(Bound) here, they don't seem to matter.
