### PR TITLE
prefer `if let` to match with `None => { }` arm in some places

### DIFF
--- a/src/librustc/infer/freshen.rs
+++ b/src/librustc/infer/freshen.rs
@@ -61,9 +61,8 @@ impl<'a, 'gcx, 'tcx> TypeFreshener<'a, 'gcx, 'tcx> {
                   -> Ty<'tcx> where
         F: FnOnce(u32) -> ty::InferTy,
     {
-        match opt_ty {
-            Some(ty) => { return ty.fold_with(self); }
-            None => { }
+        if let Some(ty) = opt_ty {
+            return ty.fold_with(self);
         }
 
         match self.freshen_map.entry(key) {

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -478,12 +478,9 @@ impl RegionMaps {
         //! Returns the scope when temp created by expr_id will be cleaned up
 
         // check for a designated rvalue scope
-        match self.rvalue_scopes.borrow().get(&expr_id) {
-            Some(&s) => {
-                debug!("temporary_scope({:?}) = {:?} [custom]", expr_id, s);
-                return Some(s);
-            }
-            None => { }
+        if let Some(&s) = self.rvalue_scopes.borrow().get(&expr_id) {
+            debug!("temporary_scope({:?}) = {:?} [custom]", expr_id, s);
+            return Some(s);
         }
 
         let scope_map : &[CodeExtent] = &self.scope_map.borrow();
@@ -928,19 +925,15 @@ fn resolve_local(visitor: &mut RegionResolutionVisitor, local: &hir::Local) {
     //
     // FIXME(#6308) -- Note that `[]` patterns work more smoothly post-DST.
 
-    match local.init {
-        Some(ref expr) => {
-            record_rvalue_scope_if_borrow_expr(visitor, &expr, blk_scope);
+    if let Some(ref expr) = local.init {
+        record_rvalue_scope_if_borrow_expr(visitor, &expr, blk_scope);
 
-            let is_borrow =
-                if let Some(ref ty) = local.ty { is_borrowed_ty(&ty) } else { false };
+        let is_borrow =
+            if let Some(ref ty) = local.ty { is_borrowed_ty(&ty) } else { false };
 
-            if is_binding_pat(&local.pat) || is_borrow {
-                record_rvalue_scope(visitor, &expr, blk_scope);
-            }
+        if is_binding_pat(&local.pat) || is_borrow {
+            record_rvalue_scope(visitor, &expr, blk_scope);
         }
-
-        None => { }
     }
 
     intravisit::walk_local(visitor, local);
@@ -1023,16 +1016,12 @@ fn resolve_local(visitor: &mut RegionResolutionVisitor, local: &hir::Local) {
                 record_rvalue_scope_if_borrow_expr(visitor, &subexpr, blk_id)
             }
             hir::ExprBlock(ref block) => {
-                match block.expr {
-                    Some(ref subexpr) => {
-                        record_rvalue_scope_if_borrow_expr(
-                            visitor, &subexpr, blk_id);
-                    }
-                    None => { }
+                if let Some(ref subexpr) = block.expr {
+                    record_rvalue_scope_if_borrow_expr(
+                        visitor, &subexpr, blk_id);
                 }
             }
-            _ => {
-            }
+            _ => {}
         }
     }
 

--- a/src/librustc/traits/project.rs
+++ b/src/librustc/traits/project.rs
@@ -1405,9 +1405,8 @@ impl<'tcx> ProjectionCache<'tcx> {
     /// cache hit, so it's actually a good thing).
     fn try_start(&mut self, key: ty::ProjectionTy<'tcx>)
                  -> Result<(), ProjectionCacheEntry<'tcx>> {
-        match self.map.get(&key) {
-            Some(entry) => return Err(entry.clone()),
-            None => { }
+        if let Some(entry) = self.map.get(&key) {
+            return Err(entry.clone());
         }
 
         self.map.insert(key, ProjectionCacheEntry::InProgress);

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -788,14 +788,11 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
                stack);
         assert!(!stack.obligation.predicate.has_escaping_regions());
 
-        match self.check_candidate_cache(&cache_fresh_trait_pred) {
-            Some(c) => {
-                debug!("CACHE HIT: SELECT({:?})={:?}",
-                       cache_fresh_trait_pred,
-                       c);
-                return c;
-            }
-            None => { }
+        if let Some(c) = self.check_candidate_cache(&cache_fresh_trait_pred) {
+            debug!("CACHE HIT: SELECT({:?})={:?}",
+                   cache_fresh_trait_pred,
+                   c);
+            return c;
         }
 
         // If no match, compute result and insert into cache.

--- a/src/librustc_trans/callee.rs
+++ b/src/librustc_trans/callee.rs
@@ -302,9 +302,8 @@ fn trans_fn_pointer_shim<'a, 'tcx>(
     };
 
     // Check if we already trans'd this shim.
-    match ccx.fn_pointer_shims().borrow().get(&bare_fn_ty_maybe_ref) {
-        Some(&llval) => { return llval; }
-        None => { }
+    if let Some(&llval) = ccx.fn_pointer_shims().borrow().get(&bare_fn_ty_maybe_ref) {
+        return llval;
     }
 
     debug!("trans_fn_pointer_shim(bare_fn_ty={:?})",

--- a/src/librustc_trans/meth.rs
+++ b/src/librustc_trans/meth.rs
@@ -119,9 +119,8 @@ pub fn get_vtable<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     debug!("get_vtable(trait_ref={:?})", trait_ref);
 
     // Check the cache.
-    match ccx.vtables().borrow().get(&trait_ref) {
-        Some(&val) => { return val }
-        None => { }
+    if let Some(&val) = ccx.vtables().borrow().get(&trait_ref) {
+        return val;
     }
 
     // Not in the cache. Build it.

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1629,9 +1629,8 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
         let tcx = self.tcx();
 
         let cache = self.ast_ty_to_ty_cache();
-        match cache.borrow().get(&ast_ty.id) {
-            Some(ty) => { return ty; }
-            None => { }
+        if let Some(ty) = cache.borrow().get(&ast_ty.id) {
+            return ty;
         }
 
         let result_ty = match ast_ty.node {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -742,17 +742,14 @@ pub fn check_item_type<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx hir::Item) {
       hir::ItemImpl(.., ref impl_items) => {
           debug!("ItemImpl {} with id {}", it.name, it.id);
           let impl_def_id = ccx.tcx.map.local_def_id(it.id);
-          match ccx.tcx.impl_trait_ref(impl_def_id) {
-              Some(impl_trait_ref) => {
-                  check_impl_items_against_trait(ccx,
-                                                 it.span,
-                                                 impl_def_id,
-                                                 &impl_trait_ref,
-                                                 impl_items);
-                  let trait_def_id = impl_trait_ref.def_id;
-                  check_on_unimplemented(ccx, trait_def_id, it);
-              }
-              None => { }
+          if let Some(impl_trait_ref) = ccx.tcx.impl_trait_ref(impl_def_id) {
+              check_impl_items_against_trait(ccx,
+                                             it.span,
+                                             impl_def_id,
+                                             &impl_trait_ref,
+                                             impl_items);
+              let trait_def_id = impl_trait_ref.def_id;
+              check_on_unimplemented(ccx, trait_def_id, it);
           }
       }
       hir::ItemTrait(..) => {
@@ -1812,9 +1809,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                  f: F) where
         F: FnOnce(&ty::ItemSubsts<'tcx>),
     {
-        match self.tables.borrow().item_substs.get(&id) {
-            Some(s) => { f(s) }
-            None => { }
+        if let Some(s) = self.tables.borrow().item_substs.get(&id) {
+            f(s);
         }
     }
 

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -156,13 +156,10 @@ impl<'a,'tcx> CrateCtxt<'a,'tcx> {
     {
         {
             let mut stack = self.stack.borrow_mut();
-            match stack.iter().enumerate().rev().find(|&(_, r)| *r == request) {
-                None => { }
-                Some((i, _)) => {
-                    let cycle = &stack[i..];
-                    self.report_cycle(span, cycle);
-                    return Err(ErrorReported);
-                }
+            if let Some((i, _)) = stack.iter().enumerate().rev().find(|&(_, r)| *r == request) {
+                let cycle = &stack[i..];
+                self.report_cycle(span, cycle);
+                return Err(ErrorReported);
             }
             stack.push(request);
         }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2450,13 +2450,10 @@ impl<'a> State<'a> {
                     |s, ty| s.print_type(&ty)));
                 try!(word(&mut self.s, ")"));
 
-                match data.output {
-                    None => { }
-                    Some(ref ty) => {
-                        try!(self.space_if_not_bol());
-                        try!(self.word_space("->"));
-                        try!(self.print_type(&ty));
-                    }
+                if let Some(ref ty) = data.output {
+                    try!(self.space_if_not_bol());
+                    try!(self.word_space("->"));
+                    try!(self.print_type(&ty));
                 }
             }
         }


### PR DESCRIPTION
In #34268 (8531d581), we replaced matches of None to the unit value `()`
with `if let`s in places where it was deemed that this made the code
unambiguously clearer and more idiomatic. In #34638 (d37edef9), we did
the same for matches of None to the empty block `{}`.

A casual observer, upon seeing these commits fly by, might suppose that
the matter was then settled, that no further pull requests on this
utterly trivial point of style could or would be made. Unless ...

It turns out that sometimes people write the empty block with a space in
between the braces. Who knew?
