### PR TITLE
Add a distinct error code and description for "main function has wrong type"

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -1310,6 +1310,14 @@ error. To resolve it, add an `else` block having the same type as the `if`
 block.
 "##,
 
+E0330: r##"
+The `main` function is required to have the signature `fn main() { ... }`, with
+no arguments and a return type of `()`.
+
+To access command-line arguments, use `std::env::args`. To terminate the process
+with a specified exit code, use `std::process::exit`.
+"##,
+
 E0398: r##"
 In Rust 1.3, the default object lifetime bounds are expected to change, as
 described in RFC #1156 [1]. You are getting a warning because the compiler

--- a/src/librustc/infer/error_reporting.rs
+++ b/src/librustc/infer/error_reporting.rs
@@ -604,6 +604,9 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             TypeOrigin::IfExpressionWithNoElse(_) => {
                 struct_span_err!(self.tcx.sess, span, E0317, "{}", failure_str)
             },
+            TypeOrigin::MainFunctionType(_) => {
+                struct_span_err!(self.tcx.sess, span, E0330, "{}", failure_str)
+            },
             _ => {
                 struct_span_err!(self.tcx.sess, span, E0308, "{}", failure_str)
             },

--- a/src/test/compile-fail/E0308-3.rs
+++ b/src/test/compile-fail/E0308-3.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn main() -> i32 { 0 } //~ ERROR E0308
+fn main() -> i32 { 0 } //~ ERROR E0330

--- a/src/test/compile-fail/bad-main.rs
+++ b/src/test/compile-fail/bad-main.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn main(x: isize) { } //~ ERROR: main function has wrong type
+fn main(x: isize) { } //~ ERROR: main function has wrong type [E0330]

--- a/src/test/compile-fail/extern-main-fn.rs
+++ b/src/test/compile-fail/extern-main-fn.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern fn main() {} //~ ERROR: main function has wrong type
+extern fn main() {} //~ ERROR: main function has wrong type [E0330]

--- a/src/test/compile-fail/main-wrong-type-2.rs
+++ b/src/test/compile-fail/main-wrong-type-2.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 fn main() -> char {
-//~^ ERROR: main function has wrong type
+//~^ ERROR: main function has wrong type [E0330]
     ' '
 }

--- a/src/test/compile-fail/main-wrong-type.rs
+++ b/src/test/compile-fail/main-wrong-type.rs
@@ -14,5 +14,5 @@ struct S {
 }
 
 fn main(foo: S) {
-//~^ ERROR: main function has wrong type
+//~^ ERROR: main function has wrong type [E0330]
 }


### PR DESCRIPTION
Followup to #36915. Adds a distinct error code and description for the "main function has wrong type" variant of E0308.
