### PR TITLE
Recover out of an enum or struct's braced block.

### DIFF
--- a/src/test/parse-fail/issue-37113.rs
+++ b/src/test/parse-fail/issue-37113.rs
@@ -1,0 +1,21 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! test_macro {
+    ( $( $t:ty ),* $(),*) => {
+        enum SomeEnum {
+            $( $t, )* //~ ERROR expected identifier, found `String`
+        };
+    };
+}
+
+fn main() {
+    test_macro!(String,);
+}

--- a/src/test/parse-fail/recover-enum.rs
+++ b/src/test/parse-fail/recover-enum.rs
@@ -1,0 +1,19 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z parse-only -Z continue-parse-after-error
+
+fn main() {
+    enum Test {
+        Very
+        Bad //~ ERROR found `Bad`
+        Stuff
+    }
+}

--- a/src/test/parse-fail/recover-enum2.rs
+++ b/src/test/parse-fail/recover-enum2.rs
@@ -1,0 +1,43 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z parse-only -Z continue-parse-after-error
+
+fn main() {
+    enum Test {
+        Var1,
+        Var2(String),
+        Var3 {
+            abc: {}, //~ ERROR: expected type, found `{`
+        },
+    }
+
+    // recover...
+    let a = 1;
+    enum Test2 {
+        Fine,
+    }
+
+    enum Test3 {
+        StillFine {
+            def: i32,
+        },
+    }
+
+    {
+        // fail again
+        enum Test4 {
+            Nope(i32 {}) //~ ERROR: found `{`
+                         //~^ ERROR: found `{`
+        }
+    }
+    // still recover later
+    let bad_syntax = _; //~ ERROR: found `_`
+}

--- a/src/test/parse-fail/recover-struct.rs
+++ b/src/test/parse-fail/recover-struct.rs
@@ -1,0 +1,19 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z parse-only -Z continue-parse-after-error
+
+fn main() {
+    struct Test {
+        Very
+        Bad //~ ERROR found `Bad`
+        Stuff
+    }
+}


### PR DESCRIPTION
If we encounter a syntax error inside of a braced block, then we should
fail by consuming the rest of the block if possible.
This implements such recovery for enums and structs.

Fixes #37113.
