### PR TITLE
Don't spin expanding stmt macros.

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -536,7 +536,9 @@ impl<'a> Parser<'a> {
             }
             ExpansionKind::Stmts => {
                 let mut stmts = SmallVector::zero();
-                while self.token != token::Eof {
+                while self.token != token::Eof &&
+                      // won't make progress on a `}`
+                      self.token != token::CloseDelim(token::Brace) {
                     if let Some(stmt) = self.parse_full_stmt(macro_legacy_warnings)? {
                         stmts.push(stmt);
                     }

--- a/src/test/parse-fail/issue-37234.rs
+++ b/src/test/parse-fail/issue-37234.rs
@@ -1,0 +1,19 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! failed {
+    () => {{
+        let x = 5 ""; //~ ERROR found `""`
+    }} //~ ERROR macro expansion ignores token `}`
+}
+
+fn main() {
+    failed!();
+}


### PR DESCRIPTION
If we can't make progress when parsing a macro expansion as a statement then we should just bail.

This alleviates the symptoms shown in e.g. #37113 and #37234 but it doesn't fix the problem that parsing invalid enum bodies (and others) leaves the parser in a crappy state.

I'm not sold on this strategy (checking `tokens_consumed`), so if anyone has a better idea, I'm all ears!
