### PR TITLE
macros: Future proof `#[no_link]`

### DIFF
--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -250,7 +250,7 @@ impl<'b> Resolver<'b> {
                     self.define(parent, name, TypeNS, (module, sp, vis));
 
                     self.populate_module_if_necessary(module);
-                } else if custom_derive_crate {
+                } else {
                     // Define an empty module
                     let def = Def::Mod(self.definitions.local_def_id(item.id));
                     let module = ModuleS::new(Some(parent), ModuleKind::Def(def, name));

--- a/src/test/compile-fail-fulldeps/macro-crate-doesnt-resolve.rs
+++ b/src/test/compile-fail-fulldeps/macro-crate-doesnt-resolve.rs
@@ -14,6 +14,5 @@
 extern crate macro_crate_test;
 
 fn main() {
-    macro_crate_test::foo();
-    //~^ ERROR failed to resolve. Use of undeclared type or module `macro_crate_test`
+    macro_crate_test::foo(); //~ ERROR unresolved name
 }

--- a/src/test/compile-fail-fulldeps/no-link-unknown-crate.rs
+++ b/src/test/compile-fail-fulldeps/no-link-unknown-crate.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[macro_use] #[no_link]
+#[no_link]
 extern crate doesnt_exist; //~ ERROR can't find crate
 
 fn main() {}

--- a/src/test/compile-fail/no-link.rs
+++ b/src/test/compile-fail/no-link.rs
@@ -13,6 +13,6 @@ extern crate libc;
 
 fn main() {
     unsafe {
-        libc::abs(0);  //~ ERROR Use of undeclared type or module `libc`
+        libc::abs(0);  //~ ERROR unresolved name
     }
 }


### PR DESCRIPTION
This PR future proofs `#[no_link]` for macro modularization (cc #35896).

First, we resolve all `#[no_link] extern crate`s. `#[no_link]` crates without `#[macro_use]` or `#[macro_reexport]` are not resolved today, this is a [breaking-change]. For example,

``` rust
#[no_link] extern crate non_existent_crate; //< this becomes a `crate not found` error.
```

Any breakage can be fixed by simply removing the `#[no_link] extern crate`.

Second, `#[no_link] extern crate`s will define an empty module in type namespace to eventually allow importing the crate's macros with `use`. This is a [breaking-change], for example:

``` rust
#[macro_use] #[no_link] extern crate syntax;
mod syntax {} //< This becomes a duplicate error.
```

r? @nrc
