### PR TITLE
rustdoc: mark unsafe fns in module page with superscript icons

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1828,11 +1828,19 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
                 } else {
                     String::new()
                 };
+
+                let mut unsafety_flag = "";
+                if let clean::FunctionItem(ref func) = myitem.inner {
+                    if func.unsafety == hir::Unsafety::Unsafe {
+                        unsafety_flag = "<a title='unsafe function' href='#'><sup>⚠</sup></a>";
+                    }
+                }
+
                 let doc_value = myitem.doc_value().unwrap_or("");
                 write!(w, "
                        <tr class='{stab} module-item'>
                            <td><a class='{class}' href='{href}'
-                                  title='{title}'>{name}</a></td>
+                                  title='{title}'>{name}</a>{unsafety_flag}</td>
                            <td class='docblock-short'>
                                {stab_docs} {docs}
                            </td>
@@ -1842,6 +1850,7 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
                        docs = shorter(Some(&Markdown(doc_value).to_string())),
                        class = myitem.type_(),
                        stab = myitem.stability_class(),
+                       unsafety_flag = unsafety_flag,
                        href = item_path(myitem.type_(), myitem.name.as_ref().unwrap()),
                        title = full_path(cx, myitem))?;
             }


### PR DESCRIPTION
Note: I'v changed the mark style. Now use superscript ⚠(U+26A0) (the old one is '[Unsafe]' literal).
Basically per https://botbot.me/mozilla/rust-docs/2016-10-19/?msg=75112017&page=1
# New: mark with superscript icon

![unsafe-fn-icon](https://cloud.githubusercontent.com/assets/346530/19633650/7f6e1eea-99e6-11e6-8d09-31aec83e46a5.png)
# Old: mark with literal '[Unsafe]'

![unsafe-fn](https://cloud.githubusercontent.com/assets/346530/19472050/39daded2-9558-11e6-9148-3cb12afd1c9a.png)
