### PR TITLE
Allow bootstrapping without a key. Fixes #36548

### DIFF
--- a/mk/target.mk
+++ b/mk/target.mk
@@ -42,23 +42,6 @@ $(foreach host,$(CFG_HOST), \
    $(foreach crate,$(CRATES), \
     $(eval $(call RUST_CRATE_FULLDEPS,$(stage),$(target),$(host),$(crate)))))))
 
-# $(1) stage
-# $(2) target
-# $(3) host
-define DEFINE_BOOTSTRAP_KEY
-BOOTSTRAP_KEY$(1)_T_$(2)_H_$(3) := $$(CFG_BOOTSTRAP_KEY)
-ifeq ($(1),0)
-ifeq ($(3),$$(CFG_BUILD))
-BOOTSTRAP_KEY$(1)_T_$(2)_H_$(3) := $$(CFG_BOOTSTRAP_KEY_STAGE0)
-endif
-endif
-endef
-
-$(foreach host,$(CFG_TARGET), \
- $(foreach target,$(CFG_TARGET), \
-  $(foreach stage,$(STAGES), \
-   $(eval $(call DEFINE_BOOTSTRAP_KEY,$(stage),$(target),$(host))))))
-
 # RUST_TARGET_STAGE_N template: This defines how target artifacts are built
 # for all stage/target architecture combinations. This is one giant rule which
 # works as follows:
@@ -83,8 +66,6 @@ $(foreach host,$(CFG_TARGET), \
 define RUST_TARGET_STAGE_N
 
 $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$(4): CFG_COMPILER_HOST_TRIPLE = $(2)
-$$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$(4): \
-	export RUSTC_BOOTSTRAP_KEY := $$(BOOTSTRAP_KEY$(1)_T_$(2)_H_$(3))
 $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$(4): \
 		$$(CRATEFILE_$(4)) \
 		$$(CRATE_FULLDEPS_$(1)_T_$(2)_H_$(3)_$(4)) \
@@ -132,8 +113,6 @@ endef
 # $(4) - name of the tool being built
 define TARGET_TOOL
 
-$$(TBIN$(1)_T_$(2)_H_$(3))/$(4)$$(X_$(2)): \
-	export RUSTC_BOOTSTRAP_KEY := $$(BOOTSTRAP_KEY$(1)_T_$(2)_H_$(3))
 $$(TBIN$(1)_T_$(2)_H_$(3))/$(4)$$(X_$(2)): \
 		$$(TOOL_SOURCE_$(4)) \
 		$$(TOOL_INPUTS_$(4)) \

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -214,7 +214,7 @@ pub fn compiletest(build: &Build,
             }
         }
     }
-    build.add_bootstrap_key(compiler, &mut cmd);
+    build.add_bootstrap_key(&mut cmd);
 
     cmd.arg("--adb-path").arg("adb");
     cmd.arg("--adb-test-dir").arg(ADB_TEST_DIR);

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -119,7 +119,7 @@ fn build_startup_objects(build: &Build, target: &str, into: &Path) {
     for file in t!(fs::read_dir(build.src.join("src/rtstartup"))) {
         let file = t!(file);
         let mut cmd = Command::new(&compiler_path);
-        build.add_bootstrap_key(&compiler, &mut cmd);
+        build.add_bootstrap_key(&mut cmd);
         build.run(cmd.arg("--target").arg(target)
                      .arg("--emit=obj")
                      .arg("--out-dir").arg(into)
@@ -185,7 +185,6 @@ pub fn rustc<'a>(build: &'a Build, target: &str, compiler: &Compiler<'a>) {
     cargo.env("CFG_RELEASE", &build.release)
          .env("CFG_RELEASE_CHANNEL", &build.config.channel)
          .env("CFG_VERSION", &build.version)
-         .env("CFG_BOOTSTRAP_KEY", &build.bootstrap_key)
          .env("CFG_PREFIX", build.config.prefix.clone().unwrap_or(String::new()))
          .env("CFG_LIBDIR_RELATIVE", "lib");
 

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -662,7 +662,7 @@ impl Build {
              .env("RUSTDOC_REAL", self.rustdoc(compiler))
              .env("RUSTC_FLAGS", self.rustc_flags(target).join(" "));
 
-        self.add_bootstrap_key(compiler, &mut cargo);
+        self.add_bootstrap_key(&mut cargo);
 
         // Specify some various options for build scripts used throughout
         // the build.
@@ -871,16 +871,11 @@ impl Build {
     }
 
     /// Adds the compiler's bootstrap key to the environment of `cmd`.
-    fn add_bootstrap_key(&self, compiler: &Compiler, cmd: &mut Command) {
-        // In stage0 we're using a previously released stable compiler, so we
-        // use the stage0 bootstrap key. Otherwise we use our own build's
-        // bootstrap key.
-        let bootstrap_key = if compiler.is_snapshot(self) && !self.local_rebuild {
-            &self.bootstrap_key_stage0
-        } else {
-            &self.bootstrap_key
-        };
-        cmd.env("RUSTC_BOOTSTRAP_KEY", bootstrap_key);
+    fn add_bootstrap_key(&self, cmd: &mut Command) {
+        cmd.env("RUSTC_BOOTSTRAP", "");
+        // FIXME: Transitionary measure to bootstrap using the old bootstrap logic.
+        // Remove this once the bootstrap compiler uses the new login in Issue #36548.
+        cmd.env("RUSTC_BOOTSTRAP_KEY", "62b3e239");
     }
 
     /// Returns the compiler's libdir where it stores the dynamic libraries that

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -1317,15 +1317,12 @@ impl UnstableFeatures {
     pub fn from_environment() -> UnstableFeatures {
         // Whether this is a feature-staged build, i.e. on the beta or stable channel
         let disable_unstable_features = option_env!("CFG_DISABLE_UNSTABLE_FEATURES").is_some();
-        // The secret key needed to get through the rustc build itself by
-        // subverting the unstable features lints
-        let bootstrap_secret_key = option_env!("CFG_BOOTSTRAP_KEY");
-        // The matching key to the above, only known by the build system
-        let bootstrap_provided_key = env::var("RUSTC_BOOTSTRAP_KEY").ok();
-        match (disable_unstable_features, bootstrap_secret_key, bootstrap_provided_key) {
-            (_, Some(ref s), Some(ref p)) if s == p => UnstableFeatures::Cheat,
-            (true, _, _) => UnstableFeatures::Disallow,
-            (false, _, _) => UnstableFeatures::Allow
+        // Whether we should enable unstable features for bootstrapping
+        let bootstrap = env::var("RUSTC_BOOTSTRAP").is_ok();
+        match (disable_unstable_features, bootstrap) {
+            (_, true) => UnstableFeatures::Cheat,
+            (true, _) => UnstableFeatures::Disallow,
+            (false, _) => UnstableFeatures::Allow
         }
     }
 

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -13,5 +13,4 @@
 # released on `$date`
 
 rustc: beta-2016-09-28
-rustc_key: 62b3e239
 cargo: nightly-2016-09-26


### PR DESCRIPTION
This will make it easier for packagers to bootstrap rustc when they happen
to have a bootstrap compiler with a slightly different version number.

It's not ok for anything other than the build system to set this environment variable.

r? @alexcrichton 
