### PR TITLE
Detect local-rebuild by just the MAJOR.MINOR version

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -53,11 +53,12 @@ endif
 # versions in the same place
 CFG_FILENAME_EXTRA=$(shell printf '%s' $(CFG_RELEASE)$(CFG_EXTRA_FILENAME) | $(CFG_HASH_COMMAND))
 
-# If local-rust is the same as the current version, then force a local-rebuild
+# If local-rust is the same major.minor as the current version, then force a local-rebuild
 ifdef CFG_ENABLE_LOCAL_RUST
-ifeq ($(CFG_RELEASE),\
-      $(shell $(S)src/etc/local_stage0.sh --print-rustc-release $(CFG_LOCAL_RUST_ROOT)))
-    CFG_INFO := $(info cfg: auto-detected local-rebuild $(CFG_RELEASE))
+SEMVER_PREFIX=$(shell echo $(CFG_RELEASE_NUM) | grep -E -o '^[[:digit:]]+\.[[:digit:]]+')
+LOCAL_RELEASE=$(shell $(S)src/etc/local_stage0.sh --print-rustc-release $(CFG_LOCAL_RUST_ROOT))
+ifneq (,$(filter $(SEMVER_PREFIX).%,$(LOCAL_RELEASE)))
+    CFG_INFO := $(info cfg: auto-detected local-rebuild using $(LOCAL_RELEASE))
     CFG_ENABLE_LOCAL_REBUILD = 1
 endif
 endif

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -220,14 +220,14 @@ impl Build {
         sanity::check(self);
         self.verbose("collecting channel variables");
         channel::collect(self);
-        // If local-rust is the same as the current version, then force a local-rebuild
+        // If local-rust is the same major.minor as the current version, then force a local-rebuild
         let local_version_verbose = output(
             Command::new(&self.rustc).arg("--version").arg("--verbose"));
         let local_release = local_version_verbose
             .lines().filter(|x| x.starts_with("release:"))
             .next().unwrap().trim_left_matches("release:").trim();
-        if local_release == self.release {
-            self.verbose(&format!("auto-detected local-rebuild {}", self.release));
+        if local_release.split('.').take(2).eq(self.release.split('.').take(2)) {
+            self.verbose(&format!("auto-detected local-rebuild {}", local_release));
             self.local_rebuild = true;
         }
         self.verbose("updating submodules");


### PR DESCRIPTION
A new point-release shouldn't change any language semantics, so a local
stage0 that matches MAJOR.MINOR version should still be considered a
local-rebuild as far as `--cfg stageN` features go.

e.g. `1.14.0` should be considered a local-rebuild for any `1.14.X`.

(Bootstrap keys used to be an issue too, until #37265.)
