### PR TITLE
Enable line number debuginfo in releases

### DIFF
--- a/configure
+++ b/configure
@@ -636,6 +636,7 @@ opt_nosave optimize-llvm 1 "build optimized LLVM"
 opt_nosave llvm-assertions 0 "build LLVM with assertions"
 opt_nosave debug-assertions 0 "build with debugging assertions"
 opt_nosave debuginfo 0 "build with debugger metadata"
+opt_nosave debuginfo-lines 0 "build with line number debugger metadata"
 opt_nosave debug-jemalloc 0 "build jemalloc with --enable-debug --enable-fill"
 
 valopt localstatedir "/var/lib" "local state directory"
@@ -721,8 +722,13 @@ case "$CFG_RELEASE_CHANNEL" in
     nightly )
 	msg "overriding settings for $CFG_RELEASE_CHANNEL"
 	CFG_ENABLE_LLVM_ASSERTIONS=1
+	CFG_ENABLE_DEBUGINFO_LINES=1
 	;;
-    dev | beta | stable)
+    beta | stable)
+	msg "overriding settings for $CFG_RELEASE_CHANNEL"
+	CFG_ENABLE_DEBUGINFO_LINES=1
+	;;
+    dev)
 	;;
     *)
         err "release channel must be 'dev', 'nightly', 'beta' or 'stable'"
@@ -752,6 +758,7 @@ if [ -n "$CFG_DISABLE_OPTIMIZE_LLVM" ]; then putvar CFG_DISABLE_OPTIMIZE_LLVM; f
 if [ -n "$CFG_ENABLE_LLVM_ASSERTIONS" ]; then putvar CFG_ENABLE_LLVM_ASSERTIONS; fi
 if [ -n "$CFG_ENABLE_DEBUG_ASSERTIONS" ]; then putvar CFG_ENABLE_DEBUG_ASSERTIONS; fi
 if [ -n "$CFG_ENABLE_DEBUGINFO" ]; then putvar CFG_ENABLE_DEBUGINFO; fi
+if [ -n "$CFG_ENABLE_DEBUGINFO_LINES" ]; then putvar CFG_ENABLE_DEBUGINFO_LINES; fi
 if [ -n "$CFG_ENABLE_DEBUG_JEMALLOC" ]; then putvar CFG_ENABLE_DEBUG_JEMALLOC; fi
 
 step_msg "looking for build programs"

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -141,6 +141,9 @@ endif
 ifdef CFG_ENABLE_DEBUGINFO
   $(info cfg: enabling debuginfo (CFG_ENABLE_DEBUGINFO))
   CFG_RUSTC_FLAGS += -g
+else ifdef CFG_ENABLE_DEBUGINFO_LINES
+  $(info cfg: enabling line number debuginfo (CFG_ENABLE_DEBUGINFO_LINES))
+  CFG_RUSTC_FLAGS += -C debuginfo=1
 endif
 
 ifdef SAVE_TEMPS

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -112,6 +112,8 @@ fn main() {
         // code.
         if env::var("RUSTC_DEBUGINFO") == Ok("true".to_string()) {
             cmd.arg("-g");
+        } else if env::var("RUSTC_DEBUGINFO_LINES") == Ok("true".to_string()) {
+            cmd.arg("-Cdebuginfo=1");
         }
         let debug_assertions = match env::var("RUSTC_DEBUG_ASSERTIONS") {
             Ok(s) => if s == "true" {"y"} else {"n"},

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -56,6 +56,7 @@ pub struct Config {
     pub rust_codegen_units: u32,
     pub rust_debug_assertions: bool,
     pub rust_debuginfo: bool,
+    pub rust_debuginfo_lines: bool,
     pub rust_rpath: bool,
     pub rustc_default_linker: Option<String>,
     pub rustc_default_ar: Option<String>,
@@ -141,6 +142,7 @@ struct Rust {
     codegen_units: Option<u32>,
     debug_assertions: Option<bool>,
     debuginfo: Option<bool>,
+    debuginfo_lines: Option<bool>,
     debug_jemalloc: Option<bool>,
     use_jemalloc: Option<bool>,
     backtrace: Option<bool>,
@@ -239,6 +241,7 @@ impl Config {
         if let Some(ref rust) = toml.rust {
             set(&mut config.rust_debug_assertions, rust.debug_assertions);
             set(&mut config.rust_debuginfo, rust.debuginfo);
+            set(&mut config.rust_debuginfo_lines, rust.debuginfo_lines);
             set(&mut config.rust_optimize, rust.optimize);
             set(&mut config.rust_optimize_tests, rust.optimize_tests);
             set(&mut config.rust_debuginfo_tests, rust.debuginfo_tests);
@@ -329,6 +332,7 @@ impl Config {
                 ("OPTIMIZE", self.rust_optimize),
                 ("DEBUG_ASSERTIONS", self.rust_debug_assertions),
                 ("DEBUGINFO", self.rust_debuginfo),
+                ("DEBUGINFO_LINES", self.rust_debuginfo_lines),
                 ("JEMALLOC", self.use_jemalloc),
                 ("DEBUG_JEMALLOC", self.debug_jemalloc),
                 ("RPATH", self.rust_rpath),

--- a/src/bootstrap/config.toml.example
+++ b/src/bootstrap/config.toml.example
@@ -99,6 +99,9 @@
 # Whether or not debuginfo is emitted
 #debuginfo = false
 
+# Whether or not line number debug information is emitted
+#debuginfo-lines = false
+
 # Whether or not jemalloc is built and enabled
 #use-jemalloc = true
 

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -649,6 +649,7 @@ impl Build {
              .env("RUSTC_REAL", self.compiler_path(compiler))
              .env("RUSTC_STAGE", stage.to_string())
              .env("RUSTC_DEBUGINFO", self.config.rust_debuginfo.to_string())
+             .env("RUSTC_DEBUGINFO_LINES", self.config.rust_debuginfo_lines.to_string())
              .env("RUSTC_CODEGEN_UNITS",
                   self.config.rust_codegen_units.to_string())
              .env("RUSTC_DEBUG_ASSERTIONS",


### PR DESCRIPTION
This commit enables by default passing the `-C debuginfo=1` argument to the
compiler for the stable, beta, and nightly release channels. A new configure
option was also added, `--enable-debuginfo-lines`, to enable this behavior in
developer builds as well.

Closes #36452
