### PR TITLE
trans: pad const structs to aligned size

### DIFF
--- a/src/librustc_trans/adt.rs
+++ b/src/librustc_trans/adt.rs
@@ -777,8 +777,8 @@ fn build_const_struct<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
         offset += machine::llsize_of_alloc(ccx, val_ty(val));
     }
 
-    if offset < st.min_size.bytes() {
-        cfields.push(padding(ccx, st.min_size.bytes() - offset));
+    if offset < st.stride().bytes() {
+        cfields.push(padding(ccx, st.stride().bytes() - offset));
     }
 
     cfields

--- a/src/test/run-pass/issue-37222.rs
+++ b/src/test/run-pass/issue-37222.rs
@@ -1,0 +1,25 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[derive(Debug, PartialEq)]
+enum Bar {
+    A(i64),
+    B(i32),
+    C,
+}
+
+#[derive(Debug, PartialEq)]
+struct Foo(Bar, u8);
+
+static FOO: [Foo; 2] = [Foo(Bar::C, 0), Foo(Bar::C, 0xFF)];
+
+fn main() {
+    assert_eq!(&FOO[1],  &Foo(Bar::C, 0xFF));
+}


### PR DESCRIPTION
Fixes #37222.

I'm not sure if that is the _correct_ way to fix this, but it _does_ work.
