### PR TITLE
test - Add missing ! to crate_type/crate_id attributes

### DIFF
--- a/src/test/run-pass/auxiliary/check_static_recursion_foreign_helper.rs
+++ b/src/test/run-pass/auxiliary/check_static_recursion_foreign_helper.rs
@@ -12,8 +12,8 @@
 
 #![feature(libc)]
 
-#[crate_id = "check_static_recursion_foreign_helper"]
-#[crate_type = "lib"]
+#![crate_name = "check_static_recursion_foreign_helper"]
+#![crate_type = "lib"]
 
 extern crate libc;
 


### PR DESCRIPTION
Fix some useless attributes in a test dependency.
