### PR TITLE
Add Iterator trait TrustedLen to enable better FromIterator / Extend

### DIFF
--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -50,6 +50,7 @@
 #![feature(specialization)]
 #![feature(staged_api)]
 #![feature(step_by)]
+#![feature(trusted_len)]
 #![feature(unicode)]
 #![feature(unique)]
 #![cfg_attr(test, feature(rand, test))]

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -76,7 +76,6 @@ use core::ptr;
 use core::ptr::Shared;
 use core::slice;
 
-use super::SpecExtend;
 use super::range::RangeArgument;
 
 /// A contiguous growable array type, written `Vec<T>` but pronounced 'vector.'
@@ -1554,19 +1553,7 @@ impl<'a, T> IntoIterator for &'a mut Vec<T> {
 impl<T> Extend<T> for Vec<T> {
     #[inline]
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
-        <Self as SpecExtend<I>>::spec_extend(self, iter);
-    }
-}
-
-impl<I: IntoIterator> SpecExtend<I> for Vec<I::Item> {
-    default fn spec_extend(&mut self, iter: I) {
         self.extend_desugared(iter.into_iter())
-    }
-}
-
-impl<T> SpecExtend<Vec<T>> for Vec<T> {
-    fn spec_extend(&mut self, ref mut other: Vec<T>) {
-        self.append(other);
     }
 }
 

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1578,7 +1578,13 @@ impl<I> IsTrustedLen for I where I: Iterator { }
 impl<I> IsTrustedLen for I where I: TrustedLen
 {
     fn trusted_len(&self) -> Option<usize> {
-        self.size_hint().1
+        let (low, high) = self.size_hint();
+        if let Some(high_value) = high {
+            debug_assert_eq!(low, high_value,
+                             "TrustedLen iterator's size hint is not exact: {:?}",
+                             (low, high));
+        }
+        high
     }
 }
 

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1931,7 +1931,7 @@ impl<T> ExactSizeIterator for IntoIter<T> {}
 #[unstable(feature = "fused", issue = "35602")]
 impl<T> FusedIterator for IntoIter<T> {}
 
-#[unstable(feature = "trusted_len", issue = "0")]
+#[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<T> TrustedLen for IntoIter<T> {}
 
 #[stable(feature = "vec_into_iter_clone", since = "1.8.0")]

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1944,6 +1944,9 @@ impl<T> ExactSizeIterator for IntoIter<T> {}
 #[unstable(feature = "fused", issue = "35602")]
 impl<T> FusedIterator for IntoIter<T> {}
 
+#[unstable(feature = "trusted_len", issue = "0")]
+unsafe impl<T> TrustedLen for IntoIter<T> {}
+
 #[stable(feature = "vec_into_iter_clone", since = "1.8.0")]
 impl<T: Clone> Clone for IntoIter<T> {
     fn clone(&self) -> IntoIter<T> {

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -328,7 +328,7 @@ pub use self::traits::{FromIterator, IntoIterator, DoubleEndedIterator, Extend};
 pub use self::traits::{ExactSizeIterator, Sum, Product};
 #[unstable(feature = "fused", issue = "35602")]
 pub use self::traits::FusedIterator;
-#[unstable(feature = "trusted_len", issue = "0")]
+#[unstable(feature = "trusted_len", issue = "37572")]
 pub use self::traits::TrustedLen;
 
 mod iterator;
@@ -374,7 +374,7 @@ impl<I> ExactSizeIterator for Rev<I>
 impl<I> FusedIterator for Rev<I>
     where I: FusedIterator + DoubleEndedIterator {}
 
-#[unstable(feature = "trusted_len", issue = "0")]
+#[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<I> TrustedLen for Rev<I>
     where I: TrustedLen + DoubleEndedIterator {}
 
@@ -438,7 +438,7 @@ unsafe impl<'a, I, T: 'a> TrustedRandomAccess for Cloned<I>
     fn may_have_side_effect() -> bool { true }
 }
 
-#[unstable(feature = "trusted_len", issue = "0")]
+#[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<'a, I, T: 'a> TrustedLen for Cloned<I>
     where I: TrustedLen<Item=&'a T>,
           T: Clone
@@ -654,7 +654,7 @@ impl<A, B> FusedIterator for Chain<A, B>
           B: FusedIterator<Item=A::Item>,
 {}
 
-#[unstable(feature = "trusted_len", issue = "0")]
+#[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<A, B> TrustedLen for Chain<A, B>
     where A: TrustedLen, B: TrustedLen<Item=A::Item>,
 {}
@@ -876,7 +876,7 @@ unsafe impl<A, B> TrustedRandomAccess for Zip<A, B>
 impl<A, B> FusedIterator for Zip<A, B>
     where A: FusedIterator, B: FusedIterator, {}
 
-#[unstable(feature = "trusted_len", issue = "0")]
+#[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<A, B> TrustedLen for Zip<A, B>
     where A: TrustedLen, B: TrustedLen,
 {}
@@ -981,7 +981,7 @@ impl<B, I: ExactSizeIterator, F> ExactSizeIterator for Map<I, F>
 impl<B, I: FusedIterator, F> FusedIterator for Map<I, F>
     where F: FnMut(I::Item) -> B {}
 
-#[unstable(feature = "trusted_len", issue = "0")]
+#[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<B, I, F> TrustedLen for Map<I, F>
     where I: TrustedLen,
           F: FnMut(I::Item) -> B {}
@@ -1222,7 +1222,7 @@ unsafe impl<I> TrustedRandomAccess for Enumerate<I>
 #[unstable(feature = "fused", issue = "35602")]
 impl<I> FusedIterator for Enumerate<I> where I: FusedIterator {}
 
-#[unstable(feature = "trusted_len", issue = "0")]
+#[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<I> TrustedLen for Enumerate<I>
     where I: TrustedLen,
 {}

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -328,6 +328,8 @@ pub use self::traits::{FromIterator, IntoIterator, DoubleEndedIterator, Extend};
 pub use self::traits::{ExactSizeIterator, Sum, Product};
 #[unstable(feature = "fused", issue = "35602")]
 pub use self::traits::FusedIterator;
+#[unstable(feature = "trusted_len", issue = "0")]
+pub use self::traits::TrustedLen;
 
 mod iterator;
 mod range;
@@ -371,6 +373,10 @@ impl<I> ExactSizeIterator for Rev<I>
 #[unstable(feature = "fused", issue = "35602")]
 impl<I> FusedIterator for Rev<I>
     where I: FusedIterator + DoubleEndedIterator {}
+
+#[unstable(feature = "trusted_len", issue = "0")]
+unsafe impl<I> TrustedLen for Rev<I>
+    where I: TrustedLen + DoubleEndedIterator {}
 
 /// An iterator that clones the elements of an underlying iterator.
 ///
@@ -431,6 +437,12 @@ unsafe impl<'a, I, T: 'a> TrustedRandomAccess for Cloned<I>
     #[inline]
     fn may_have_side_effect() -> bool { true }
 }
+
+#[unstable(feature = "trusted_len", issue = "0")]
+unsafe impl<'a, I, T: 'a> TrustedLen for Cloned<I>
+    where I: TrustedLen<Item=&'a T>,
+          T: Clone
+{}
 
 /// An iterator that repeats endlessly.
 ///
@@ -640,6 +652,11 @@ impl<A, B> DoubleEndedIterator for Chain<A, B> where
 impl<A, B> FusedIterator for Chain<A, B>
     where A: FusedIterator,
           B: FusedIterator<Item=A::Item>,
+{}
+
+#[unstable(feature = "trusted_len", issue = "0")]
+unsafe impl<A, B> TrustedLen for Chain<A, B>
+    where A: TrustedLen, B: TrustedLen<Item=A::Item>,
 {}
 
 /// An iterator that iterates two other iterators simultaneously.
@@ -859,6 +876,11 @@ unsafe impl<A, B> TrustedRandomAccess for Zip<A, B>
 impl<A, B> FusedIterator for Zip<A, B>
     where A: FusedIterator, B: FusedIterator, {}
 
+#[unstable(feature = "trusted_len", issue = "0")]
+unsafe impl<A, B> TrustedLen for Zip<A, B>
+    where A: TrustedLen, B: TrustedLen,
+{}
+
 /// An iterator that maps the values of `iter` with `f`.
 ///
 /// This `struct` is created by the [`map()`] method on [`Iterator`]. See its
@@ -958,6 +980,11 @@ impl<B, I: ExactSizeIterator, F> ExactSizeIterator for Map<I, F>
 #[unstable(feature = "fused", issue = "35602")]
 impl<B, I: FusedIterator, F> FusedIterator for Map<I, F>
     where F: FnMut(I::Item) -> B {}
+
+#[unstable(feature = "trusted_len", issue = "0")]
+unsafe impl<B, I, F> TrustedLen for Map<I, F>
+    where I: TrustedLen,
+          F: FnMut(I::Item) -> B {}
 
 #[doc(hidden)]
 unsafe impl<B, I, F> TrustedRandomAccess for Map<I, F>
@@ -1194,6 +1221,12 @@ unsafe impl<I> TrustedRandomAccess for Enumerate<I>
 
 #[unstable(feature = "fused", issue = "35602")]
 impl<I> FusedIterator for Enumerate<I> where I: FusedIterator {}
+
+#[unstable(feature = "trusted_len", issue = "0")]
+unsafe impl<I> TrustedLen for Enumerate<I>
+    where I: TrustedLen,
+{}
+
 
 /// An iterator with a `peek()` that returns an optional reference to the next
 /// element.

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -482,7 +482,7 @@ macro_rules! range_incl_exact_iter_impl {
 
 macro_rules! range_trusted_len_impl {
     ($($t:ty)*) => ($(
-        #[unstable(feature = "trusted_len", issue = "0")]
+        #[unstable(feature = "trusted_len", issue = "37572")]
         unsafe impl TrustedLen for ops::Range<$t> { }
     )*)
 }

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -480,6 +480,22 @@ macro_rules! range_incl_exact_iter_impl {
     )*)
 }
 
+macro_rules! range_trusted_len_impl {
+    ($($t:ty)*) => ($(
+        #[unstable(feature = "trusted_len", issue = "0")]
+        unsafe impl TrustedLen for ops::Range<$t> { }
+    )*)
+}
+
+macro_rules! range_incl_trusted_len_impl {
+    ($($t:ty)*) => ($(
+        #[unstable(feature = "inclusive_range",
+                   reason = "recently added, follows RFC",
+                   issue = "28237")]
+        unsafe impl TrustedLen for ops::RangeInclusive<$t> { }
+    )*)
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A: Step> Iterator for ops::Range<A> where
     for<'a> &'a A: Add<&'a A, Output = A>
@@ -513,6 +529,13 @@ impl<A: Step> Iterator for ops::Range<A> where
 range_exact_iter_impl!(usize u8 u16 u32 isize i8 i16 i32);
 range_incl_exact_iter_impl!(u8 u16 i8 i16);
 
+// These macros generate `TrustedLen` impls.
+//
+// They need to guarantee that .size_hint() is either exact, or that
+// the upper bound is None when it does not fit the type limits.
+range_trusted_len_impl!(usize isize u8 i8 u16 i16 u32 i32 i64 u64);
+range_incl_trusted_len_impl!(usize isize u8 i8 u16 i16 u32 i32 i64 u64);
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A: Step + Clone> DoubleEndedIterator for ops::Range<A> where
     for<'a> &'a A: Add<&'a A, Output = A>,
@@ -532,9 +555,6 @@ impl<A: Step + Clone> DoubleEndedIterator for ops::Range<A> where
 #[unstable(feature = "fused", issue = "35602")]
 impl<A> FusedIterator for ops::Range<A>
     where A: Step, for<'a> &'a A: Add<&'a A, Output = A> {}
-
-#[unstable(feature = "trusted_len", issue = "0")]
-unsafe impl TrustedLen for ops::Range<usize> { }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A: Step> Iterator for ops::RangeFrom<A> where

--- a/src/libcore/iter/range.rs
+++ b/src/libcore/iter/range.rs
@@ -12,7 +12,7 @@ use mem;
 use ops::{self, Add, Sub};
 use usize;
 
-use super::FusedIterator;
+use super::{FusedIterator, TrustedLen};
 
 /// Objects that can be stepped over in both directions.
 ///
@@ -532,6 +532,9 @@ impl<A: Step + Clone> DoubleEndedIterator for ops::Range<A> where
 #[unstable(feature = "fused", issue = "35602")]
 impl<A> FusedIterator for ops::Range<A>
     where A: Step, for<'a> &'a A: Add<&'a A, Output = A> {}
+
+#[unstable(feature = "trusted_len", issue = "0")]
+unsafe impl TrustedLen for ops::Range<usize> { }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A: Step> Iterator for ops::RangeFrom<A> where

--- a/src/libcore/iter/traits.rs
+++ b/src/libcore/iter/traits.rs
@@ -666,7 +666,19 @@ pub trait FusedIterator: Iterator {}
 #[unstable(feature = "fused", issue = "35602")]
 impl<'a, I: FusedIterator + ?Sized> FusedIterator for &'a mut I {}
 
-/// An iterator that has correct length
+/// An iterator that reports an accurate length using size_hint.
+///
+/// The iterator reports a size hint where it is either exact
+/// (lower bound is equal to upper bound), or the upper bound is `None`.
+/// The upper bound must only be `None` if the actual iterator length is
+/// larger than `usize::MAX`.
+///
+/// The iterator must produce exactly the number of elements it reported.
+///
+/// # Safety
+///
+/// This trait must only be implemented when the contract is upheld.
+/// Consumers of this trait must inspect `.size_hint()`’s upper bound.
 #[unstable(feature = "trusted_len", issue = "0")]
 pub unsafe trait TrustedLen : Iterator {}
 

--- a/src/libcore/iter/traits.rs
+++ b/src/libcore/iter/traits.rs
@@ -679,8 +679,8 @@ impl<'a, I: FusedIterator + ?Sized> FusedIterator for &'a mut I {}
 ///
 /// This trait must only be implemented when the contract is upheld.
 /// Consumers of this trait must inspect `.size_hint()`’s upper bound.
-#[unstable(feature = "trusted_len", issue = "0")]
+#[unstable(feature = "trusted_len", issue = "37572")]
 pub unsafe trait TrustedLen : Iterator {}
 
-#[unstable(feature = "trusted_len", issue = "0")]
+#[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<'a, I: TrustedLen + ?Sized> TrustedLen for &'a mut I {}

--- a/src/libcore/iter/traits.rs
+++ b/src/libcore/iter/traits.rs
@@ -665,3 +665,10 @@ pub trait FusedIterator: Iterator {}
 
 #[unstable(feature = "fused", issue = "35602")]
 impl<'a, I: FusedIterator + ?Sized> FusedIterator for &'a mut I {}
+
+/// An iterator that has correct length
+#[unstable(feature = "trusted_len", issue = "0")]
+pub unsafe trait TrustedLen : Iterator {}
+
+#[unstable(feature = "trusted_len", issue = "0")]
+unsafe impl<'a, I: TrustedLen + ?Sized> TrustedLen for &'a mut I {}

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -145,7 +145,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use iter::{FromIterator, FusedIterator};
+use iter::{FromIterator, FusedIterator, TrustedLen};
 use mem;
 
 // Note that this is not a lang item per se, but it has a hidden dependency on
@@ -803,6 +803,7 @@ impl<A> DoubleEndedIterator for Item<A> {
 
 impl<A> ExactSizeIterator for Item<A> {}
 impl<A> FusedIterator for Item<A> {}
+unsafe impl<A> TrustedLen for Item<A> {}
 
 /// An iterator over a reference of the contained item in an [`Option`].
 ///
@@ -832,6 +833,9 @@ impl<'a, A> ExactSizeIterator for Iter<'a, A> {}
 
 #[unstable(feature = "fused", issue = "35602")]
 impl<'a, A> FusedIterator for Iter<'a, A> {}
+
+#[unstable(feature = "trusted_len", issue = "0")]
+unsafe impl<'a, A> TrustedLen for Iter<'a, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, A> Clone for Iter<'a, A> {
@@ -868,6 +872,8 @@ impl<'a, A> ExactSizeIterator for IterMut<'a, A> {}
 
 #[unstable(feature = "fused", issue = "35602")]
 impl<'a, A> FusedIterator for IterMut<'a, A> {}
+#[unstable(feature = "trusted_len", issue = "0")]
+unsafe impl<'a, A> TrustedLen for IterMut<'a, A> {}
 
 /// An iterator over the item contained inside an [`Option`].
 ///
@@ -897,6 +903,9 @@ impl<A> ExactSizeIterator for IntoIter<A> {}
 
 #[unstable(feature = "fused", issue = "35602")]
 impl<A> FusedIterator for IntoIter<A> {}
+
+#[unstable(feature = "trusted_len", issue = "0")]
+unsafe impl<A> TrustedLen for IntoIter<A> {}
 
 /////////////////////////////////////////////////////////////////////////////
 // FromIterator

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -834,7 +834,7 @@ impl<'a, A> ExactSizeIterator for Iter<'a, A> {}
 #[unstable(feature = "fused", issue = "35602")]
 impl<'a, A> FusedIterator for Iter<'a, A> {}
 
-#[unstable(feature = "trusted_len", issue = "0")]
+#[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<'a, A> TrustedLen for Iter<'a, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -872,7 +872,7 @@ impl<'a, A> ExactSizeIterator for IterMut<'a, A> {}
 
 #[unstable(feature = "fused", issue = "35602")]
 impl<'a, A> FusedIterator for IterMut<'a, A> {}
-#[unstable(feature = "trusted_len", issue = "0")]
+#[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<'a, A> TrustedLen for IterMut<'a, A> {}
 
 /// An iterator over the item contained inside an [`Option`].
@@ -904,7 +904,7 @@ impl<A> ExactSizeIterator for IntoIter<A> {}
 #[unstable(feature = "fused", issue = "35602")]
 impl<A> FusedIterator for IntoIter<A> {}
 
-#[unstable(feature = "trusted_len", issue = "0")]
+#[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<A> TrustedLen for IntoIter<A> {}
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -886,7 +886,7 @@ impl<'a, T> ExactSizeIterator for Iter<'a, T> {}
 #[unstable(feature = "fused", issue = "35602")]
 impl<'a, T> FusedIterator for Iter<'a, T> {}
 
-#[unstable(feature = "trusted_len", issue = "0")]
+#[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<'a, A> TrustedLen for Iter<'a, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -927,7 +927,7 @@ impl<'a, T> ExactSizeIterator for IterMut<'a, T> {}
 #[unstable(feature = "fused", issue = "35602")]
 impl<'a, T> FusedIterator for IterMut<'a, T> {}
 
-#[unstable(feature = "trusted_len", issue = "0")]
+#[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<'a, A> TrustedLen for IterMut<'a, A> {}
 
 /// An iterator over the value in a [`Ok`] variant of a [`Result`]. This struct is
@@ -967,7 +967,7 @@ impl<T> ExactSizeIterator for IntoIter<T> {}
 #[unstable(feature = "fused", issue = "35602")]
 impl<T> FusedIterator for IntoIter<T> {}
 
-#[unstable(feature = "trusted_len", issue = "0")]
+#[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<A> TrustedLen for IntoIter<A> {}
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -249,7 +249,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use fmt;
-use iter::{FromIterator, FusedIterator};
+use iter::{FromIterator, FusedIterator, TrustedLen};
 
 /// `Result` is a type that represents either success (`Ok`) or failure (`Err`).
 ///
@@ -886,6 +886,9 @@ impl<'a, T> ExactSizeIterator for Iter<'a, T> {}
 #[unstable(feature = "fused", issue = "35602")]
 impl<'a, T> FusedIterator for Iter<'a, T> {}
 
+#[unstable(feature = "trusted_len", issue = "0")]
+unsafe impl<'a, A> TrustedLen for Iter<'a, A> {}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> Clone for Iter<'a, T> {
     fn clone(&self) -> Iter<'a, T> { Iter { inner: self.inner } }
@@ -924,6 +927,9 @@ impl<'a, T> ExactSizeIterator for IterMut<'a, T> {}
 #[unstable(feature = "fused", issue = "35602")]
 impl<'a, T> FusedIterator for IterMut<'a, T> {}
 
+#[unstable(feature = "trusted_len", issue = "0")]
+unsafe impl<'a, A> TrustedLen for IterMut<'a, A> {}
+
 /// An iterator over the value in a [`Ok`] variant of a [`Result`]. This struct is
 /// created by the [`into_iter`] method on [`Result`][`Result`] (provided by
 /// the [`IntoIterator`] trait).
@@ -960,6 +966,9 @@ impl<T> ExactSizeIterator for IntoIter<T> {}
 
 #[unstable(feature = "fused", issue = "35602")]
 impl<T> FusedIterator for IntoIter<T> {}
+
+#[unstable(feature = "trusted_len", issue = "0")]
+unsafe impl<A> TrustedLen for IntoIter<A> {}
 
 /////////////////////////////////////////////////////////////////////////////
 // FromIterator

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -988,7 +988,7 @@ impl<'a, T> ExactSizeIterator for Iter<'a, T> {}
 #[unstable(feature = "fused", issue = "35602")]
 impl<'a, T> FusedIterator for Iter<'a, T> {}
 
-#[unstable(feature = "trusted_len", issue = "0")]
+#[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<'a, T> TrustedLen for Iter<'a, T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1112,7 +1112,7 @@ impl<'a, T> ExactSizeIterator for IterMut<'a, T> {}
 #[unstable(feature = "fused", issue = "35602")]
 impl<'a, T> FusedIterator for IterMut<'a, T> {}
 
-#[unstable(feature = "trusted_len", issue = "0")]
+#[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<'a, T> TrustedLen for IterMut<'a, T> {}
 
 /// An internal abstraction over the splitting iterators, so that

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -988,6 +988,9 @@ impl<'a, T> ExactSizeIterator for Iter<'a, T> {}
 #[unstable(feature = "fused", issue = "35602")]
 impl<'a, T> FusedIterator for Iter<'a, T> {}
 
+#[unstable(feature = "trusted_len", issue = "0")]
+unsafe impl<'a, T> TrustedLen for Iter<'a, T> {}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> Clone for Iter<'a, T> {
     fn clone(&self) -> Iter<'a, T> { Iter { ptr: self.ptr, end: self.end, _marker: self._marker } }
@@ -1108,6 +1111,9 @@ impl<'a, T> ExactSizeIterator for IterMut<'a, T> {}
 
 #[unstable(feature = "fused", issue = "35602")]
 impl<'a, T> FusedIterator for IterMut<'a, T> {}
+
+#[unstable(feature = "trusted_len", issue = "0")]
+unsafe impl<'a, T> TrustedLen for IterMut<'a, T> {}
 
 /// An internal abstraction over the splitting iterators, so that
 /// splitn, splitn_mut etc can be implemented once.


### PR DESCRIPTION
This trait attempts to improve FromIterator / Extend code by enabling it to trust the iterator to produce an exact number of elements, which means that reallocation needs to happen only once and is moved out of the loop.

`TrustedLen` differs from `ExactSizeIterator` in that it attempts to include _more_ iterators by allowing for the case that the iterator's len does not fit in `usize`. Consumers must check for this case (for example they could panic, since they can't allocate a collection of that size).

For example, chain can be TrustedLen and all numerical ranges can be TrustedLen. All they need to do is to report an exact size if it fits in `usize`, and `None` as the upper bound otherwise.

The trait describes its contract like this:

```
An iterator that reports an accurate length using size_hint.

The iterator reports a size hint where it is either exact
(lower bound is equal to upper bound), or the upper bound is `None`.
The upper bound must only be `None` if the actual iterator length is
larger than `usize::MAX`.

The iterator must produce exactly the number of elements it reported.

# Safety

This trait must only be implemented when the contract is upheld.
Consumers of this trait must inspect `.size_hint()`’s upper bound.
```

Fixes #37232 
