### PR TITLE
TRPL: guessing game: minor clarification

### DIFF
--- a/src/doc/book/guessing-game.md
+++ b/src/doc/book/guessing-game.md
@@ -276,7 +276,7 @@ displaying the message.
 [expect]: ../std/result/enum.Result.html#method.expect
 [panic]: error-handling.html
 
-If we leave off calling this method, our program will compile, but
+If we do not call `expect()`, our program will compile, but
 we’ll get a warning:
 
 ```bash


### PR DESCRIPTION
The original text is correct and exact, but might confuse a non-English speaker (at least I was confused), so I made it a bit more plain (see https://github.com/rust-lang/rust/issues/37307).

I know minor wording changes like these are affected by personal style, so I'd understand if you don't find this useful.

r? @steveklabnik 
