### PR TITLE
Fix line stepping in debugger.

### DIFF
--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -176,8 +176,9 @@ pub fn construct_fn<'a, 'gcx, 'tcx, A>(hir: Cx<'a, 'gcx, 'tcx>,
         unpack!(block = builder.in_scope(arg_extent, block, |builder| {
             builder.args_and_body(block, return_ty, &arguments, arg_extent, ast_block)
         }));
-
-        let source_info = builder.source_info(span);
+        // Attribute epilogue to function's closing brace
+        let fn_end = Span { lo: span.hi, ..span };
+        let source_info = builder.source_info(fn_end);
         let return_block = builder.return_block();
         builder.cfg.terminate(block, source_info,
                               TerminatorKind::Goto { target: return_block });

--- a/src/librustc_mir/build/scope.rs
+++ b/src/librustc_mir/build/scope.rs
@@ -521,8 +521,12 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 if let DropKind::Value { .. } = drop_kind {
                     scope.needs_cleanup = true;
                 }
+                let tcx = self.hir.tcx();
+                let extent_span = extent.span(&tcx.region_maps, &tcx.map).unwrap();
+                // Attribute scope exit drops to scope's closing brace
+                let scope_end = Span { lo: extent_span.hi, .. extent_span};
                 scope.drops.push(DropData {
-                    span: span,
+                    span: scope_end,
                     location: lvalue.clone(),
                     kind: drop_kind
                 });

--- a/src/test/debuginfo/drop-locations.rs
+++ b/src/test/debuginfo/drop-locations.rs
@@ -1,0 +1,91 @@
+// Copyright 2013-2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-windows
+// ignore-android
+// min-lldb-version: 310
+
+#![allow(unused)]
+
+// compile-flags:-g
+
+// This test checks that drop glue code gets attributed to scope's closing brace,
+// and function epilogues - to function's closing brace.
+
+// === GDB TESTS ===================================================================================
+
+// gdb-command:run
+// gdb-command:next
+// gdb-command:frame
+// gdb-check:[...]#loc1[...]
+// gdb-command:next
+// gdb-command:frame
+// gdb-check:[...]#loc2[...]
+// gdb-command:next
+// gdb-command:frame
+// gdb-check:[...]#loc3[...]
+// gdb-command:next
+// gdb-command:frame
+// gdb-check:[...]#loc4[...]
+// gdb-command:next
+// gdb-command:frame
+// gdb-check:[...]#loc5[...]
+// gdb-command:next
+// gdb-command:frame
+// gdb-check:[...]#loc6[...]
+
+// === LLDB TESTS ==================================================================================
+
+// lldb-command:set set stop-line-count-before 0
+// lldb-command:set set stop-line-count-after 1
+// Can't set both to zero or lldb will stop printing source at all.  So it will output the current
+// line and the next.  We deal with this by having at least 2 lines between the #loc's
+
+// lldb-command:run
+// lldb-command:next
+// lldb-command:frame select
+// lldb-check:[...]#loc1[...]
+// lldb-command:next
+// lldb-command:frame select
+// lldb-check:[...]#loc2[...]
+// lldb-command:next
+// lldb-command:frame select
+// lldb-check:[...]#loc3[...]
+// lldb-command:next
+// lldb-command:frame select
+// lldb-check:[...]#loc4[...]
+// lldb-command:next
+// lldb-command:frame select
+// lldb-check:[...]#loc5[...]
+// lldb-command:next
+// lldb-command:frame select
+// lldb-check:[...]#loc6[...]
+
+fn main() {
+
+    foo();
+
+    zzz(); // #loc5
+
+} // #loc6
+
+fn foo() {
+    {
+        let s = String::from("s"); // #break
+
+        zzz(); // #loc1
+
+    } // #loc2
+
+    zzz(); // #loc3
+
+} // #loc4
+
+fn zzz() {()}


### PR DESCRIPTION
Attribute drop code to block's closing brace, instead of the line where the allocation was done.
Attribute function epilogues to function body's closing brace, rather than the function header.

Fixes #37032

r? @michaelwoerister 
