### PR TITLE
Use `SmallVector` in `CombineFields::instantiate`.

### DIFF
--- a/src/librustc/infer/combine.rs
+++ b/src/librustc/infer/combine.rs
@@ -49,6 +49,7 @@ use ty::relate::{RelateResult, TypeRelation};
 use traits::PredicateObligations;
 
 use syntax::ast;
+use syntax::util::small_vector::SmallVector;
 use syntax_pos::Span;
 
 #[derive(Clone)]
@@ -181,7 +182,9 @@ impl<'infcx, 'gcx, 'tcx> CombineFields<'infcx, 'gcx, 'tcx> {
                        a_is_expected: bool)
                        -> RelateResult<'tcx, ()>
     {
-        let mut stack = Vec::new();
+        // We use SmallVector here instead of Vec because this code is hot and
+        // it's rare that the stack length exceeds 1.
+        let mut stack = SmallVector::zero();
         stack.push((a_ty, dir, b_vid));
         loop {
             // For each turn of the loop, we extract a tuple

--- a/src/librustc/infer/type_variable.rs
+++ b/src/librustc/infer/type_variable.rs
@@ -12,8 +12,9 @@ pub use self::RelationDir::*;
 use self::TypeVariableValue::*;
 use self::UndoEntry::*;
 use hir::def_id::{DefId};
-use ty::{self, Ty};
+use syntax::util::small_vector::SmallVector;
 use syntax_pos::Span;
+use ty::{self, Ty};
 
 use std::cmp::min;
 use std::marker::PhantomData;
@@ -149,7 +150,7 @@ impl<'tcx> TypeVariableTable<'tcx> {
         &mut self,
         vid: ty::TyVid,
         ty: Ty<'tcx>,
-        stack: &mut Vec<(Ty<'tcx>, RelationDir, ty::TyVid)>)
+        stack: &mut SmallVector<(Ty<'tcx>, RelationDir, ty::TyVid)>)
     {
         debug_assert!(self.root_var(vid) == vid);
         let old_value = {


### PR DESCRIPTION
This avoids 4% of malloc calls when compiling
rustc-benchmarks/issue-32278-big-array-of-strings, and 1--2% for other
benchmarks. A small win, but an easy one.
