### PR TITLE
trans: Make names of internal symbols independent of CGU translation order

### DIFF
--- a/src/librustc_trans/common.rs
+++ b/src/librustc_trans/common.rs
@@ -799,9 +799,7 @@ pub fn C_cstr(cx: &CrateContext, s: InternedString, null_terminated: bool) -> Va
                                                 s.as_ptr() as *const c_char,
                                                 s.len() as c_uint,
                                                 !null_terminated as Bool);
-
-        let gsym = token::gensym("str");
-        let sym = format!("str{}", gsym.0);
+        let sym = cx.generate_local_symbol_name("str");
         let g = declare::define_global(cx, &sym[..], val_ty(sc)).unwrap_or_else(||{
             bug!("symbol `{}` is already defined", sym);
         });

--- a/src/librustc_trans/consts.rs
+++ b/src/librustc_trans/consts.rs
@@ -30,7 +30,6 @@ use rustc::hir;
 use std::ffi::{CStr, CString};
 use syntax::ast;
 use syntax::attr;
-use syntax::parse::token;
 
 pub fn ptrcast(val: ValueRef, ty: Type) -> ValueRef {
     unsafe {
@@ -44,10 +43,7 @@ pub fn addr_of_mut(ccx: &CrateContext,
                    kind: &str)
                     -> ValueRef {
     unsafe {
-        // FIXME: this totally needs a better name generation scheme, perhaps a simple global
-        // counter? Also most other uses of gensym in trans.
-        let gsym = token::gensym("_");
-        let name = format!("{}{}", kind, gsym.0);
+        let name = ccx.generate_local_symbol_name(kind);
         let gv = declare::define_global(ccx, &name[..], val_ty(cv)).unwrap_or_else(||{
             bug!("symbol `{}` is already defined", name);
         });

--- a/src/test/codegen/consts.rs
+++ b/src/test/codegen/consts.rs
@@ -19,12 +19,12 @@
 // CHECK: @STATIC = {{.*}}, align 4
 
 // This checks the constants from inline_enum_const
-// CHECK: @ref{{[0-9]+}} = {{.*}}, align 2
+// CHECK: @ref.{{[0-9]+}} = {{.*}}, align 2
 
 // This checks the constants from {low,high}_align_const, they share the same
 // constant, but the alignment differs, so the higher one should be used
-// CHECK: [[LOW_HIGH:@ref[0-9]+]] = {{.*}}, align 4
-// CHECK: [[LOW_HIGH_REF:@const[0-9]+]] = {{.*}} [[LOW_HIGH]]
+// CHECK: [[LOW_HIGH:@ref.[0-9]+]] = {{.*}}, align 4
+// CHECK: [[LOW_HIGH_REF:@const.[0-9]+]] = {{.*}} [[LOW_HIGH]]
 
 #[derive(Copy, Clone)]
 

--- a/src/test/run-make/symbols-are-reasonable/Makefile
+++ b/src/test/run-make/symbols-are-reasonable/Makefile
@@ -1,7 +1,7 @@
 -include ../tools.mk
 
 # check that the compile generated symbols for strings, binaries,
-# vtables, etc. have semisane names (e.g. `str1234`); it's relatively
+# vtables, etc. have semisane names (e.g. `str.1234`); it's relatively
 # easy to accidentally modify the compiler internals to make them
 # become things like `str"str"(1234)`.
 
@@ -10,6 +10,6 @@ OUT=$(TMPDIR)/lib.s
 all:
 	$(RUSTC) lib.rs --emit=asm --crate-type=staticlib
 	# just check for symbol declarations with the names we're expecting.
-	grep 'str[0-9][0-9]*:' $(OUT)
-	grep 'byte_str[0-9][0-9]*:' $(OUT)
-	grep 'vtable[0-9][0-9]*' $(OUT)
+	grep 'str.[0-9][0-9]*:' $(OUT)
+	grep 'byte_str.[0-9][0-9]*:' $(OUT)
+	grep 'vtable.[0-9][0-9]*' $(OUT)


### PR DESCRIPTION
Every codegen unit gets its own local counter for generating new symbol names. This makes bitcode and object files reproducible at the binary level even when incremental compilation is used.

The PR also solves a rare ICE resulting from a naming conflict between a user defined name and a generated one. E.g. try compiling the following program with 1.12.1 stable:

``` rust
#![crate_type="lib"]

#[no_mangle]
pub fn str7233() -> &'static str { "foo" }
```

This results in:

> error: internal compiler error: ../src/librustc_trans/common.rs:979: symbol `str7233` is already defined

Running into this is not very likely but it's also easily avoidable. 
