### PR TITLE
[beta] trans: pad const structs to aligned size

### DIFF
--- a/src/test/run-pass/issue-37222.rs
+++ b/src/test/run-pass/issue-37222.rs
@@ -1,0 +1,25 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[derive(Debug, PartialEq)]
+enum Bar {
+    A(i64),
+    B(i32),
+    C,
+}
+
+#[derive(Debug, PartialEq)]
+struct Foo(Bar, u8);
+
+static FOO: [Foo; 2] = [Foo(Bar::C, 0), Foo(Bar::C, 0xFF)];
+
+fn main() {
+    assert_eq!(&FOO[1],  &Foo(Bar::C, 0xFF));
+}


### PR DESCRIPTION
This fixes #37222 on beta.

As pointed out by @eddyb in https://github.com/rust-lang/rust/pull/37281#issuecomment-255233595, the nightly fix cannot be backported as-is due to other changes.

An alternative to this adapted fix would be to backport #36904 as well, in addition to #37281.

Also cc @rust-lang/compiler, since this is not a straight backport.
