### PR TITLE
Fix typo that resulted in comparison-to-self

### DIFF
--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -1614,7 +1614,7 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
                 //
                 // We always upcast when we can because of reason
                 // #2 (region bounds).
-                data_a.principal.def_id() == data_a.principal.def_id() &&
+                data_a.principal.def_id() == data_b.principal.def_id() &&
                 data_a.builtin_bounds.is_superset(&data_b.builtin_bounds)
             }
 


### PR DESCRIPTION
This line was introduced in commit 843db01bd925279da0a56efde532c9e3ecf73610, rebased from eddyb's c5f6f84d59b853b6a3485380721b71b479ece337.

I don't know whether this fixes anything in practice, but it seems like the changed version was what was intended originally.

r? @eddyb
