### PR TITLE
Fix `$crate`-related regressions

### DIFF
--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -130,14 +130,27 @@ impl<'b> Resolver<'b> {
 
                 match view_path.node {
                     ViewPathSimple(binding, ref full_path) => {
-                        let source_name = full_path.segments.last().unwrap().identifier.name;
-                        if source_name.as_str() == "mod" || source_name.as_str() == "self" {
+                        let mut source = full_path.segments.last().unwrap().identifier;
+                        let source_name = source.name.as_str();
+                        if source_name == "mod" || source_name == "self" {
                             resolve_error(self,
                                           view_path.span,
                                           ResolutionError::SelfImportsOnlyAllowedWithin);
+                        } else if source_name == "$crate" && full_path.segments.len() == 1 {
+                            let crate_root = self.resolve_crate_var(source.ctxt);
+                            let crate_name = match crate_root.kind {
+                                ModuleKind::Def(_, name) => name,
+                                ModuleKind::Block(..) => unreachable!(),
+                            };
+                            source.name = crate_name;
+
+                            self.session.struct_span_warn(item.span, "`$crate` may not be imported")
+                                .note("`use $crate;` was erroneously allowed and \
+                                       will become a hard error in a future release")
+                                .emit();
                         }
 
-                        let subclass = ImportDirectiveSubclass::single(binding.name, source_name);
+                        let subclass = ImportDirectiveSubclass::single(binding.name, source.name);
                         let span = view_path.span;
                         self.add_import_directive(module_path, subclass, span, item.id, vis);
                     }

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -513,6 +513,7 @@ impl<'b> Resolver<'b> {
                                   legacy_imports: LegacyMacroImports,
                                   allow_shadowing: bool) {
         let import_macro = |this: &mut Self, name, ext: Rc<_>, span| {
+            this.used_crates.insert(module.def_id().unwrap().krate);
             if let SyntaxExtension::NormalTT(..) = *ext {
                 this.macro_names.insert(name);
             }

--- a/src/test/compile-fail/auxiliary/import_crate_var.rs
+++ b/src/test/compile-fail/auxiliary/import_crate_var.rs
@@ -1,0 +1,12 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_export]
+macro_rules! m { () => { use $crate; } }

--- a/src/test/compile-fail/import-crate-var.rs
+++ b/src/test/compile-fail/import-crate-var.rs
@@ -1,0 +1,21 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:import_crate_var.rs
+// error-pattern: `$crate` may not be imported
+// error-pattern: `use $crate;` was erroneously allowed and will become a hard error
+
+#![feature(rustc_attrs)]
+
+#[macro_use] extern crate import_crate_var;
+m!();
+
+#[rustc_error]
+fn main() {}

--- a/src/test/compile-fail/lint-qualification.rs
+++ b/src/test/compile-fail/lint-qualification.rs
@@ -18,4 +18,11 @@ fn main() {
     use foo::bar;
     foo::bar(); //~ ERROR: unnecessary qualification
     bar();
+
+    let _ = || -> Result<(), ()> { try!(Ok(())); Ok(()) }; // issue #37345
+
+    macro_rules! m {
+        () => { $crate::foo::bar(); }
+    }
+    m!(); // issue #37357
 }

--- a/src/test/compile-fail/lint-unused-extern-crate.rs
+++ b/src/test/compile-fail/lint-unused-extern-crate.rs
@@ -26,6 +26,8 @@ extern crate rand; // no error, the use marks it as used
 
 extern crate lint_unused_extern_crate as other; // no error, the use * marks it as used
 
+#[macro_use] extern crate core; // no error, the `#[macro_use]` marks it as used
+
 #[allow(unused_imports)]
 use rand::isaac::IsaacRng;
 


### PR DESCRIPTION
Fixes #37345, fixes #37357, fixes #37352, and improves the `unused_extern_crates` lint.
r? @nrc 
