### PR TITLE
Implement `fold` on hash::table::{Iter,IterMut}.

### DIFF
--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1518,6 +1518,12 @@ impl<'a, K, V> Iterator for Iter<'a, K, V> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
+    #[inline]
+    fn fold<B, F>(self, init: B, f: F) -> B where
+        Self: Sized, F: FnMut(B, Self::Item) -> B,
+    {
+        self.inner.fold(init, f)
+    }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, K, V> ExactSizeIterator for Iter<'a, K, V> {
@@ -1541,6 +1547,12 @@ impl<'a, K, V> Iterator for IterMut<'a, K, V> {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
+    }
+    #[inline]
+    fn fold<B, F>(self, init: B, f: F) -> B where
+        Self: Sized, F: FnMut(B, Self::Item) -> B,
+    {
+        self.inner.fold(init, f)
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1588,6 +1600,12 @@ impl<'a, K, V> Iterator for Keys<'a, K, V> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
+    #[inline]
+    fn fold<B, F>(self, init: B, mut f: F) -> B where
+        Self: Sized, F: FnMut(B, Self::Item) -> B,
+    {
+        self.inner.fold(init, move |acc, (k, _)| f(acc, k))
+    }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, K, V> ExactSizeIterator for Keys<'a, K, V> {
@@ -1611,6 +1629,12 @@ impl<'a, K, V> Iterator for Values<'a, K, V> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
+    #[inline]
+    fn fold<B, F>(self, init: B, mut f: F) -> B where
+        Self: Sized, F: FnMut(B, Self::Item) -> B,
+    {
+        self.inner.fold(init, move |acc, (_, v)| f(acc, v))
+    }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, K, V> ExactSizeIterator for Values<'a, K, V> {
@@ -1633,6 +1657,12 @@ impl<'a, K, V> Iterator for ValuesMut<'a, K, V> {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
+    }
+    #[inline]
+    fn fold<B, F>(self, init: B, mut f: F) -> B where
+        Self: Sized, F: FnMut(B, Self::Item) -> B,
+    {
+        self.inner.fold(init, move |acc, (_, v)| f(acc, v))
     }
 }
 #[stable(feature = "map_values_mut", since = "1.10.0")]

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -942,6 +942,12 @@ impl<'a, K> Iterator for Iter<'a, K> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
+    #[inline]
+    fn fold<B, F>(self, init: B, f: F) -> B where
+        Self: Sized, F: FnMut(B, Self::Item) -> B,
+    {
+        self.iter.fold(init, f)
+    }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, K> ExactSizeIterator for Iter<'a, K> {


### PR DESCRIPTION
Also forwards `fold` to the wrapped iterator for `HashMap` and `HashSet` iterators to actually gain something from the change.

There are more places where this could be applied (eg. `Drain`, `IntoIter`), but I wanted to first decide whether this is a good idea or not. This PR could also do with some additional tests. A simple benchmark which sums up 1000, 10000, 100000 elements in a `HashSet` sees the following gains:

Before:

``` bash
fl•~» ~/e/master_compiler/stage2/bin/rustc --test -C opt-level=3 x.rs && ./x --bench

running 3 tests
test large_set  ... bench:     340,945 ns/iter (+/- 10,672)
test medium_set ... bench:      54,366 ns/iter (+/- 1,998)
test small_set  ... bench:       1,965 ns/iter (+/- 68)

test result: ok. 0 passed; 0 failed; 0 ignored; 3 measured
```

After:

``` bash
fl•~» ~/e/fold_all_compiler/stage2/bin/rustc --test -C opt-level=3 x.rs && ./x --bench

running 3 tests
test large_set  ... bench:     313,788 ns/iter (+/- 11,935)
test medium_set ... bench:      45,260 ns/iter (+/- 1,631)
test small_set  ... bench:       1,748 ns/iter (+/- 34)

test result: ok. 0 passed; 0 failed; 0 ignored; 3 measured
```

Note that these gains only work if you explicitly call `fold`. Calling `sum` calls `cloned` which doesn't forward the `fold` call to the inner iterator (but will after #37315).

<details>
<summary>

Benchmark code</summary>



``` rust

extern crate test;

use test::Bencher;
use std::collections::HashSet;

fn small_set(b: &mut Bencher) {
    let set: HashSet<u32> = (1..1000).collect();
    b.iter(|| {
        test::black_box(set.iter().fold(0u32, |a, &b| a.wrapping_add(b)));
    });
}

fn medium_set(b: &mut Bencher) {
    let set: HashSet<u32> = (1..10000).collect();
    b.iter(|| {
        test::black_box(set.iter().fold(0u32, |a, &b| a.wrapping_add(b)));
    });
}

fn large_set(b: &mut Bencher) {
    let set: HashSet<u32> = (1..100000).collect();
    b.iter(|| {
        test::black_box(set.iter().fold(0u32, |a, &b| a.wrapping_add(b)));
    });
}

fn main() {}
```

</details>
