### PR TITLE
Add support for kernel randomness for Fuchsia

### DIFF
--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -58,6 +58,8 @@ fn main() {
         println!("cargo:rustc-link-lib=ws2_32");
         println!("cargo:rustc-link-lib=userenv");
         println!("cargo:rustc-link-lib=shell32");
+    } else if target.contains("fuchsia") {
+        println!("cargo:rustc-link-lib=magenta");
     }
 }
 


### PR DESCRIPTION
Wire up cprng syscall as provider for rand::os::OsRng on Fuchsia.
