### PR TITLE
Add example using Self to reference

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -3756,6 +3756,21 @@ to an implicit type parameter representing the "implementing" type. In an impl,
 it is an alias for the implementing type. For example, in:
 
 ```
+pub trait From<T> {
+    fn from(T) -> Self;
+}
+
+impl From<i32> for String {
+    fn from(x: i32) -> Self {
+        x.to_string()
+    }
+}
+```
+
+The notation `Self` in the impl refers to the implementing type: `String`. In another 
+example:
+
+```
 trait Printable {
     fn make_string(&self) -> String;
 }


### PR DESCRIPTION
When I first came across `Self` I had a hard time finding references to it in the docs (and it's also been asked about on [StackOverflow](http://stackoverflow.com/questions/32304595/whats-the-difference-between-self-and-self).

I hope this example provides someone who comes across it for the first time a little more help.  If there is a better way to show an example actually using `Self`, I'm happy to modify this.  It was just the simplest place to start I could see.
