### PR TITLE
Support for aarch64 architecture on Fuchsia

### DIFF
--- a/mk/cfg/aarch64-unknown-fuchsia.mk
+++ b/mk/cfg/aarch64-unknown-fuchsia.mk
@@ -1,0 +1,1 @@
+# rustbuild-only target

--- a/src/librustc_back/target/aarch64_unknown_fuchsia.rs
+++ b/src/librustc_back/target/aarch64_unknown_fuchsia.rs
@@ -1,0 +1,28 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use target::{Target, TargetResult};
+
+pub fn target() -> TargetResult {
+    let mut base = super::fuchsia_base::opts();
+    base.max_atomic_width = Some(128);
+
+    Ok(Target {
+        llvm_target: "aarch64-unknown-fuchsia".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "64".to_string(),
+        data_layout: "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128".to_string(),
+        arch: "aarch64".to_string(),
+        target_os: "fuchsia".to_string(),
+        target_env: "".to_string(),
+        target_vendor: "unknown".to_string(),
+        options: base,
+    })
+}

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -176,6 +176,7 @@ supported_targets! {
     ("x86_64-apple-darwin", x86_64_apple_darwin),
     ("i686-apple-darwin", i686_apple_darwin),
 
+    ("aarch64-unknown-fuchsia", aarch64_unknown_fuchsia),
     ("x86_64-unknown-fuchsia", x86_64_unknown_fuchsia),
 
     ("i386-apple-ios", i386_apple_ios),

--- a/src/libstd/os/raw.rs
+++ b/src/libstd/os/raw.rs
@@ -18,7 +18,8 @@
                                        target_arch = "arm",
                                        target_arch = "powerpc",
                                        target_arch = "powerpc64",
-                                       target_arch = "s390x"))))]
+                                       target_arch = "s390x")),
+          all(target_os = "fuchsia", target_arch = "aarch64")))]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_char = u8;
 #[cfg(not(any(target_os = "android",
               target_os = "emscripten",
@@ -26,7 +27,8 @@
                                            target_arch = "arm",
                                            target_arch = "powerpc",
                                            target_arch = "powerpc64",
-                                           target_arch = "s390x")))))]
+                                           target_arch = "s390x")),
+              all(target_os = "fuchsia", target_arch = "aarch64"))))]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_char = i8;
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_schar = i8;
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_uchar = u8;


### PR DESCRIPTION
This patch adds support for the aarch64-unknown-fuchsia target. Also
updates src/liblibc submodule to include required libc change.
