### PR TITLE
Disable jemalloc on aarch64/powerpc

### DIFF
--- a/src/librustc_back/target/aarch64_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/aarch64_unknown_linux_gnu.rs
@@ -13,6 +13,10 @@ use target::{Target, TargetOptions, TargetResult};
 pub fn target() -> TargetResult {
     let mut base = super::linux_base::opts();
     base.max_atomic_width = Some(128);
+
+    // see #36994
+    base.exe_allocation_crate = "alloc_system".to_string();
+
     Ok(Target {
         llvm_target: "aarch64-unknown-linux-gnu".to_string(),
         target_endian: "little".to_string(),

--- a/src/librustc_back/target/mips64_unknown_linux_gnuabi64.rs
+++ b/src/librustc_back/target/mips64_unknown_linux_gnuabi64.rs
@@ -25,6 +25,10 @@ pub fn target() -> TargetResult {
             cpu: "mips64r2".to_string(),
             features: "+mips64r2".to_string(),
             max_atomic_width: Some(64),
+
+            // see #36994
+            exe_allocation_crate: "alloc_system".to_string(),
+
             ..super::linux_base::opts()
         },
     })

--- a/src/librustc_back/target/mips64el_unknown_linux_gnuabi64.rs
+++ b/src/librustc_back/target/mips64el_unknown_linux_gnuabi64.rs
@@ -25,6 +25,10 @@ pub fn target() -> TargetResult {
             cpu: "mips64r2".to_string(),
             features: "+mips64r2".to_string(),
             max_atomic_width: Some(64),
+
+            // see #36994
+            exe_allocation_crate: "alloc_system".to_string(),
+
             ..super::linux_base::opts()
         },
     })

--- a/src/librustc_back/target/mips_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/mips_unknown_linux_gnu.rs
@@ -24,6 +24,10 @@ pub fn target() -> TargetResult {
             cpu: "mips32r2".to_string(),
             features: "+mips32r2".to_string(),
             max_atomic_width: Some(32),
+
+            // see #36994
+            exe_allocation_crate: "alloc_system".to_string(),
+
             ..super::linux_base::opts()
         },
     })

--- a/src/librustc_back/target/mips_unknown_linux_musl.rs
+++ b/src/librustc_back/target/mips_unknown_linux_musl.rs
@@ -24,6 +24,10 @@ pub fn target() -> TargetResult {
             cpu: "mips32r2".to_string(),
             features: "+mips32r2,+soft-float".to_string(),
             max_atomic_width: Some(32),
+
+            // see #36994
+            exe_allocation_crate: "alloc_system".to_string(),
+
             ..super::linux_base::opts()
         }
     })

--- a/src/librustc_back/target/mips_unknown_linux_uclibc.rs
+++ b/src/librustc_back/target/mips_unknown_linux_uclibc.rs
@@ -24,6 +24,10 @@ pub fn target() -> TargetResult {
             cpu: "mips32r2".to_string(),
             features: "+mips32r2,+soft-float".to_string(),
             max_atomic_width: Some(32),
+
+            // see #36994
+            exe_allocation_crate: "alloc_system".to_string(),
+
             ..super::linux_base::opts()
         },
     })

--- a/src/librustc_back/target/mipsel_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/mipsel_unknown_linux_gnu.rs
@@ -25,6 +25,10 @@ pub fn target() -> TargetResult {
             cpu: "mips32".to_string(),
             features: "+mips32".to_string(),
             max_atomic_width: Some(32),
+
+            // see #36994
+            exe_allocation_crate: "alloc_system".to_string(),
+
             ..super::linux_base::opts()
         },
     })

--- a/src/librustc_back/target/mipsel_unknown_linux_musl.rs
+++ b/src/librustc_back/target/mipsel_unknown_linux_musl.rs
@@ -24,6 +24,10 @@ pub fn target() -> TargetResult {
             cpu: "mips32".to_string(),
             features: "+mips32,+soft-float".to_string(),
             max_atomic_width: Some(32),
+
+            // see #36994
+            exe_allocation_crate: "alloc_system".to_string(),
+
             ..super::linux_base::opts()
         }
     })

--- a/src/librustc_back/target/mipsel_unknown_linux_uclibc.rs
+++ b/src/librustc_back/target/mipsel_unknown_linux_uclibc.rs
@@ -25,6 +25,10 @@ pub fn target() -> TargetResult {
             cpu: "mips32".to_string(),
             features: "+mips32,+soft-float".to_string(),
             max_atomic_width: Some(32),
+
+            // see #36994
+            exe_allocation_crate: "alloc_system".to_string(),
+
             ..super::linux_base::opts()
         },
     })

--- a/src/librustc_back/target/powerpc64_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/powerpc64_unknown_linux_gnu.rs
@@ -16,6 +16,9 @@ pub fn target() -> TargetResult {
     base.pre_link_args.push("-m64".to_string());
     base.max_atomic_width = Some(64);
 
+    // see #36994
+    base.exe_allocation_crate = "alloc_system".to_string();
+
     Ok(Target {
         llvm_target: "powerpc64-unknown-linux-gnu".to_string(),
         target_endian: "big".to_string(),

--- a/src/librustc_back/target/powerpc64le_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/powerpc64le_unknown_linux_gnu.rs
@@ -16,6 +16,9 @@ pub fn target() -> TargetResult {
     base.pre_link_args.push("-m64".to_string());
     base.max_atomic_width = Some(64);
 
+    // see #36994
+    base.exe_allocation_crate = "alloc_system".to_string();
+
     Ok(Target {
         llvm_target: "powerpc64le-unknown-linux-gnu".to_string(),
         target_endian: "little".to_string(),

--- a/src/librustc_back/target/powerpc_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/powerpc_unknown_linux_gnu.rs
@@ -15,6 +15,9 @@ pub fn target() -> TargetResult {
     base.pre_link_args.push("-m32".to_string());
     base.max_atomic_width = Some(32);
 
+    // see #36994
+    base.exe_allocation_crate = "alloc_system".to_string();
+
     Ok(Target {
         llvm_target: "powerpc-unknown-linux-gnu".to_string(),
         target_endian: "big".to_string(),


### PR DESCRIPTION
Sounds like jemalloc is broken on systems which differ in page size than the
host it was compiled on (unless an option was passed). This unfortunately
reduces the portability of binaries created and can often make Rust segfault by
default. For now let's patch over this by disabling jemalloc until we can figure
out a better solution.

Closes #36994
Closes #37320
cc jemalloc/jemalloc#467
