### PR TITLE
Add identifier to unused import warnings

### DIFF
--- a/src/librustc_resolve/check_unused.rs
+++ b/src/librustc_resolve/check_unused.rs
@@ -59,10 +59,12 @@ impl<'a, 'b> UnusedImportCheckVisitor<'a, 'b> {
                 // Check later.
                 return;
             }
-            self.session.add_lint(lint::builtin::UNUSED_IMPORTS,
-                                  id,
-                                  span,
-                                  "unused import".to_string());
+            let msg = if let Ok(snippet) = self.session.codemap().span_to_snippet(span) {
+                format!("unused import: `{}`", snippet)
+            } else {
+                "unused import".to_string()
+            };
+            self.session.add_lint(lint::builtin::UNUSED_IMPORTS, id, span, msg);
         } else {
             // This trait import is definitely used, in a way other than
             // method resolution.

--- a/src/librustc_typeck/check_unused.rs
+++ b/src/librustc_typeck/check_unused.rs
@@ -30,10 +30,13 @@ impl<'a, 'tcx> UnusedTraitImportVisitor<'a, 'tcx> {
         if self.tcx.used_trait_imports.borrow().contains(&id) {
             return;
         }
-        self.tcx.sess.add_lint(lint::builtin::UNUSED_IMPORTS,
-                               id,
-                               span,
-                               "unused import".to_string());
+
+        let msg = if let Ok(snippet) = self.tcx.sess.codemap().span_to_snippet(span) {
+            format!("unused import: `{}`", snippet)
+        } else {
+            "unused import".to_string()
+        };
+        self.tcx.sess.add_lint(lint::builtin::UNUSED_IMPORTS, id, span, msg);
     }
 }
 

--- a/src/test/compile-fail/lint-unused-imports.rs
+++ b/src/test/compile-fail/lint-unused-imports.rs
@@ -17,19 +17,19 @@ use std::mem::*;            // shouldn't get errors for not using
                             // everything imported
 
 // Should get errors for both 'Some' and 'None'
-use std::option::Option::{Some, None}; //~ ERROR unused import
-                                     //~^ ERROR unused import
+use std::option::Option::{Some, None}; //~ ERROR unused import: `Some`
+                                    //~^ ERROR unused import: `None`
 
-use test::A;       //~ ERROR unused import
+use test::A;       //~ ERROR unused import: `test::A`
 // Be sure that if we just bring some methods into scope that they're also
 // counted as being used.
 use test::B;
 // But only when actually used: do not get confused by the method with the same name.
-use test::B2; //~ ERROR unused import
+use test::B2; //~ ERROR unused import: `test::B2`
 
 // Make sure this import is warned about when at least one of its imported names
 // is unused
-use test2::{foo, bar}; //~ ERROR unused import
+use test2::{foo, bar}; //~ ERROR unused import: `bar`
 
 mod test2 {
     pub fn foo() {}
@@ -57,7 +57,7 @@ mod bar {
 
     pub mod c {
         use foo::Point;
-        use foo::Square; //~ ERROR unused import
+        use foo::Square; //~ ERROR unused import: `foo::Square`
         pub fn cc(_p: Point) -> super::Square {
             fn f() -> super::Square {
                 super::Square
@@ -73,7 +73,7 @@ mod bar {
 }
 
 fn g() {
-    use self::g; //~ ERROR unused import
+    use self::g; //~ ERROR unused import: `self::g`
     fn f() {
         self::g();
     }
@@ -82,7 +82,7 @@ fn g() {
 // c.f. issue #35135
 #[allow(unused_variables)]
 fn h() {
-    use test2::foo; //~ ERROR unused import
+    use test2::foo; //~ ERROR unused import: `test2::foo`
     let foo = 0;
 }
 


### PR DESCRIPTION
Fix #37376.

For some reason, though, I'm getting warnings with messages like "76:9: 76:16: unused import: `self::g`" instead of "unused import: `self::g`". @pnkfelix Any ideas what might be causing this?
