### PR TITLE
Print out the error when HeapFree failures do occur

### DIFF
--- a/src/liballoc_system/lib.rs
+++ b/src/liballoc_system/lib.rs
@@ -166,6 +166,7 @@ mod imp {
         fn HeapAlloc(hHeap: HANDLE, dwFlags: DWORD, dwBytes: SIZE_T) -> LPVOID;
         fn HeapReAlloc(hHeap: HANDLE, dwFlags: DWORD, lpMem: LPVOID, dwBytes: SIZE_T) -> LPVOID;
         fn HeapFree(hHeap: HANDLE, dwFlags: DWORD, lpMem: LPVOID) -> BOOL;
+        fn GetLastError() -> DWORD;
     }
 
     #[repr(C)]
@@ -230,11 +231,11 @@ mod imp {
     pub unsafe fn deallocate(ptr: *mut u8, _old_size: usize, align: usize) {
         if align <= MIN_ALIGN {
             let err = HeapFree(GetProcessHeap(), 0, ptr as LPVOID);
-            debug_assert!(err != 0);
+            debug_assert!(err != 0, "Failed to free heap memory: {}", GetLastError());
         } else {
             let header = get_header(ptr);
             let err = HeapFree(GetProcessHeap(), 0, header.0 as LPVOID);
-            debug_assert!(err != 0);
+            debug_assert!(err != 0, "Failed to free heap memory: {}", GetLastError());
         }
     }
 


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/issues/37395

I'd prefer to use `assert!` instead of `debug_assert!` if the cost is acceptable.

r? @alexcrichton 
