### PR TITLE
[3/n] rustc: unify and simplify managing associated items.

### DIFF
--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -103,11 +103,11 @@ pub enum DepNode<D: Clone + Debug> {
     // nodes. Often we map multiple tables to the same node if there
     // is no point in distinguishing them (e.g., both the type and
     // predicates for an item wind up in `ItemSignature`).
-    ImplOrTraitItems(D),
+    AssociatedItems(D),
     ItemSignature(D),
     FieldTy(D),
     SizedConstraint(D),
-    ImplOrTraitItemDefIds(D),
+    AssociatedItemDefIds(D),
     InherentImpls(D),
 
     // The set of impls for a given trait. Ultimately, it would be
@@ -153,10 +153,10 @@ impl<D: Clone + Debug> DepNode<D> {
             TransCrateItem,
             TypeckItemType,
             TypeckItemBody,
-            ImplOrTraitItems,
+            AssociatedItems,
             ItemSignature,
             FieldTy,
-            ImplOrTraitItemDefIds,
+            AssociatedItemDefIds,
             InherentImpls,
             TraitImpls,
             ReprHints,
@@ -219,11 +219,11 @@ impl<D: Clone + Debug> DepNode<D> {
             RvalueCheck(ref d) => op(d).map(RvalueCheck),
             TransCrateItem(ref d) => op(d).map(TransCrateItem),
             TransInlinedItem(ref d) => op(d).map(TransInlinedItem),
-            ImplOrTraitItems(ref d) => op(d).map(ImplOrTraitItems),
+            AssociatedItems(ref d) => op(d).map(AssociatedItems),
             ItemSignature(ref d) => op(d).map(ItemSignature),
             FieldTy(ref d) => op(d).map(FieldTy),
             SizedConstraint(ref d) => op(d).map(SizedConstraint),
-            ImplOrTraitItemDefIds(ref d) => op(d).map(ImplOrTraitItemDefIds),
+            AssociatedItemDefIds(ref d) => op(d).map(AssociatedItemDefIds),
             InherentImpls(ref d) => op(d).map(InherentImpls),
             TraitImpls(ref d) => op(d).map(TraitImpls),
             TraitItems(ref d) => op(d).map(TraitItems),

--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -147,7 +147,7 @@ pub trait CrateStore<'tcx> {
     fn implementations_of_trait(&self, filter: Option<DefId>) -> Vec<DefId>;
 
     // impl info
-    fn impl_or_trait_items(&self, def_id: DefId) -> Vec<DefId>;
+    fn associated_item_def_ids(&self, def_id: DefId) -> Vec<DefId>;
     fn impl_trait_ref<'a>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>, def: DefId)
                           -> Option<ty::TraitRef<'tcx>>;
     fn impl_polarity(&self, def: DefId) -> hir::ImplPolarity;
@@ -157,8 +157,8 @@ pub trait CrateStore<'tcx> {
 
     // trait/impl-item info
     fn trait_of_item(&self, def_id: DefId) -> Option<DefId>;
-    fn impl_or_trait_item<'a>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>, def: DefId)
-                              -> Option<ty::ImplOrTraitItem<'tcx>>;
+    fn associated_item<'a>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>, def: DefId)
+                           -> Option<ty::AssociatedItem>;
 
     // flags
     fn is_const_fn(&self, did: DefId) -> bool;
@@ -311,8 +311,8 @@ impl<'tcx> CrateStore<'tcx> for DummyCrateStore {
     }
 
     // impl info
-    fn impl_or_trait_items(&self, def_id: DefId) -> Vec<DefId>
-        { bug!("impl_or_trait_items") }
+    fn associated_item_def_ids(&self, def_id: DefId) -> Vec<DefId>
+        { bug!("associated_items") }
     fn impl_trait_ref<'a>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>, def: DefId)
                           -> Option<ty::TraitRef<'tcx>> { bug!("impl_trait_ref") }
     fn impl_polarity(&self, def: DefId) -> hir::ImplPolarity { bug!("impl_polarity") }
@@ -323,8 +323,8 @@ impl<'tcx> CrateStore<'tcx> for DummyCrateStore {
 
     // trait/impl-item info
     fn trait_of_item(&self, def_id: DefId) -> Option<DefId> { bug!("trait_of_item") }
-    fn impl_or_trait_item<'a>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>, def: DefId)
-                              -> Option<ty::ImplOrTraitItem<'tcx>> { bug!("impl_or_trait_item") }
+    fn associated_item<'a>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>, def: DefId)
+                           -> Option<ty::AssociatedItem> { bug!("associated_item") }
 
     // flags
     fn is_const_fn(&self, did: DefId) -> bool { bug!("is_const_fn") }

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -471,11 +471,10 @@ impl<'a, 'tcx> DeadVisitor<'a, 'tcx> {
         // This is done to handle the case where, for example, the static
         // method of a private type is used, but the type itself is never
         // called directly.
-        let impl_items = self.tcx.impl_or_trait_item_def_ids.borrow();
         if let Some(impl_list) =
                 self.tcx.inherent_impls.borrow().get(&self.tcx.map.local_def_id(id)) {
-            for impl_did in impl_list.iter() {
-                for &item_did in &impl_items[impl_did][..] {
+            for &impl_did in impl_list.iter() {
+                for &item_did in &self.tcx.associated_item_def_ids(impl_did)[..] {
                     if let Some(item_node_id) = self.tcx.map.as_local_node_id(item_did) {
                         if self.live_symbols.contains(&item_node_id) {
                             return true;

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -227,8 +227,8 @@ impl OverloadedCallType {
     }
 
     fn from_method_id(tcx: TyCtxt, method_id: DefId) -> OverloadedCallType {
-        let method = tcx.impl_or_trait_item(method_id);
-        OverloadedCallType::from_trait_id(tcx, method.container().id())
+        let method = tcx.associated_item(method_id);
+        OverloadedCallType::from_trait_id(tcx, method.container.id())
     }
 }
 

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -663,25 +663,23 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                          in the supertrait listing"
                 }
 
-                ObjectSafetyViolation::Method(method,
+                ObjectSafetyViolation::Method(name,
                                               MethodViolationCode::StaticMethod) => {
-                    buf = format!("method `{}` has no receiver",
-                                  method.name);
+                    buf = format!("method `{}` has no receiver", name);
                     &buf
                 }
 
-                ObjectSafetyViolation::Method(method,
+                ObjectSafetyViolation::Method(name,
                                               MethodViolationCode::ReferencesSelf) => {
                     buf = format!("method `{}` references the `Self` type \
                                        in its arguments or return type",
-                                  method.name);
+                                  name);
                     &buf
                 }
 
-                ObjectSafetyViolation::Method(method,
+                ObjectSafetyViolation::Method(name,
                                               MethodViolationCode::Generic) => {
-                    buf = format!("method `{}` has generic type parameters",
-                                  method.name);
+                    buf = format!("method `{}` has generic type parameters", name);
                     &buf
                 }
             };

--- a/src/librustc/traits/specialize/mod.rs
+++ b/src/librustc/traits/specialize/mod.rs
@@ -120,7 +120,8 @@ pub fn find_method<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let trait_def_id = tcx.trait_id_of_impl(impl_data.impl_def_id).unwrap();
     let trait_def = tcx.lookup_trait_def(trait_def_id);
 
-    match trait_def.ancestors(impl_data.impl_def_id).fn_defs(tcx, name).next() {
+    let ancestors = trait_def.ancestors(impl_data.impl_def_id);
+    match ancestors.defs(tcx, name, ty::AssociatedKind::Method).next() {
         Some(node_item) => {
             let substs = tcx.infer_ctxt(None, None, Reveal::All).enter(|infcx| {
                 let substs = substs.rebase_onto(tcx, trait_def_id, impl_data.substs);

--- a/src/librustc/traits/util.rs
+++ b/src/librustc/traits/util.rs
@@ -477,8 +477,8 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         let mut entries = 0;
         // Count number of methods and add them to the total offset.
         // Skip over associated types and constants.
-        for trait_item in &self.trait_items(trait_ref.def_id())[..] {
-            if let ty::MethodTraitItem(_) = *trait_item {
+        for trait_item in self.associated_items(trait_ref.def_id()) {
+            if trait_item.kind == ty::AssociatedKind::Method {
                 entries += 1;
             }
         }
@@ -495,17 +495,13 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         // add them to the total offset.
         // Skip over associated types and constants.
         let mut entries = object.vtable_base;
-        for trait_item in &self.trait_items(object.upcast_trait_ref.def_id())[..] {
-            if trait_item.def_id() == method_def_id {
+        for trait_item in self.associated_items(object.upcast_trait_ref.def_id()) {
+            if trait_item.def_id == method_def_id {
                 // The item with the ID we were given really ought to be a method.
-                assert!(match *trait_item {
-                    ty::MethodTraitItem(_) => true,
-                    _ => false
-                });
-
+                assert_eq!(trait_item.kind, ty::AssociatedKind::Method);
                 return entries;
             }
-            if let ty::MethodTraitItem(_) = *trait_item {
+            if trait_item.kind == ty::AssociatedKind::Method {
                 entries += 1;
             }
         }

--- a/src/librustc/ty/maps.rs
+++ b/src/librustc/ty/maps.rs
@@ -16,7 +16,7 @@ use ty::{self, Ty};
 use std::cell::RefCell;
 use std::marker::PhantomData;
 use std::rc::Rc;
-use syntax::{attr, ast};
+use syntax::attr;
 
 macro_rules! dep_map_ty {
     ($ty_name:ident : $node_name:ident ($key:ty) -> $value:ty) => {
@@ -32,18 +32,16 @@ macro_rules! dep_map_ty {
     }
 }
 
-dep_map_ty! { ImplOrTraitItems: ImplOrTraitItems(DefId) -> ty::ImplOrTraitItem<'tcx> }
+dep_map_ty! { AssociatedItems: AssociatedItems(DefId) -> ty::AssociatedItem }
 dep_map_ty! { Tcache: ItemSignature(DefId) -> Ty<'tcx> }
 dep_map_ty! { Generics: ItemSignature(DefId) -> &'tcx ty::Generics<'tcx> }
 dep_map_ty! { Predicates: ItemSignature(DefId) -> ty::GenericPredicates<'tcx> }
 dep_map_ty! { SuperPredicates: ItemSignature(DefId) -> ty::GenericPredicates<'tcx> }
-dep_map_ty! { ImplOrTraitItemDefIds: ImplOrTraitItemDefIds(DefId) -> Rc<Vec<DefId>> }
+dep_map_ty! { AssociatedItemDefIds: AssociatedItemDefIds(DefId) -> Rc<Vec<DefId>> }
 dep_map_ty! { ImplTraitRefs: ItemSignature(DefId) -> Option<ty::TraitRef<'tcx>> }
 dep_map_ty! { TraitDefs: ItemSignature(DefId) -> &'tcx ty::TraitDef<'tcx> }
 dep_map_ty! { AdtDefs: ItemSignature(DefId) -> ty::AdtDefMaster<'tcx> }
 dep_map_ty! { ItemVariances: ItemSignature(DefId) -> Rc<Vec<ty::Variance>> }
 dep_map_ty! { InherentImpls: InherentImpls(DefId) -> Vec<DefId> }
-dep_map_ty! { TraitItems: TraitItems(DefId) -> Rc<Vec<ty::ImplOrTraitItem<'tcx>>> }
 dep_map_ty! { ReprHints: ReprHints(DefId) -> Rc<Vec<attr::ReprAttr>> }
-dep_map_ty! { InlinedClosures: Hir(DefId) -> ast::NodeId }
 dep_map_ty! { Mir: Mir(DefId) -> &'tcx RefCell<mir::Mir<'tcx>> }

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -10,9 +10,8 @@
 
 pub use self::Variance::*;
 pub use self::DtorKind::*;
-pub use self::ImplOrTraitItemContainer::*;
+pub use self::AssociatedItemContainer::*;
 pub use self::BorrowKind::*;
-pub use self::ImplOrTraitItem::*;
 pub use self::IntVarValue::*;
 pub use self::LvaluePreference::*;
 pub use self::fold::TypeFoldable;
@@ -135,12 +134,12 @@ impl DtorKind {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum ImplOrTraitItemContainer {
+pub enum AssociatedItemContainer {
     TraitContainer(DefId),
     ImplContainer(DefId),
 }
 
-impl ImplOrTraitItemContainer {
+impl AssociatedItemContainer {
     pub fn id(&self) -> DefId {
         match *self {
             TraitContainer(id) => id,
@@ -183,58 +182,34 @@ impl<'a, 'gcx, 'tcx> ImplHeader<'tcx> {
     }
 }
 
-#[derive(Clone)]
-pub enum ImplOrTraitItem<'tcx> {
-    ConstTraitItem(Rc<AssociatedConst<'tcx>>),
-    MethodTraitItem(Rc<Method<'tcx>>),
-    TypeTraitItem(Rc<AssociatedType<'tcx>>),
+#[derive(Copy, Clone, Debug)]
+pub struct AssociatedItem {
+    pub def_id: DefId,
+    pub name: Name,
+    pub kind: AssociatedKind,
+    pub vis: Visibility,
+    pub defaultness: hir::Defaultness,
+    pub has_value: bool,
+    pub container: AssociatedItemContainer,
+
+    /// Whether this is a method with an explicit self
+    /// as its first argument, allowing method calls.
+    pub method_has_self_argument: bool,
 }
 
-impl<'tcx> ImplOrTraitItem<'tcx> {
+#[derive(Copy, Clone, PartialEq, Eq, Debug, RustcEncodable, RustcDecodable)]
+pub enum AssociatedKind {
+    Const,
+    Method,
+    Type
+}
+
+impl AssociatedItem {
     pub fn def(&self) -> Def {
-        match *self {
-            ConstTraitItem(ref associated_const) => Def::AssociatedConst(associated_const.def_id),
-            MethodTraitItem(ref method) => Def::Method(method.def_id),
-            TypeTraitItem(ref ty) => Def::AssociatedTy(ty.def_id),
-        }
-    }
-
-    pub fn def_id(&self) -> DefId {
-        match *self {
-            ConstTraitItem(ref associated_const) => associated_const.def_id,
-            MethodTraitItem(ref method) => method.def_id,
-            TypeTraitItem(ref associated_type) => associated_type.def_id,
-        }
-    }
-
-    pub fn name(&self) -> Name {
-        match *self {
-            ConstTraitItem(ref associated_const) => associated_const.name,
-            MethodTraitItem(ref method) => method.name,
-            TypeTraitItem(ref associated_type) => associated_type.name,
-        }
-    }
-
-    pub fn vis(&self) -> Visibility {
-        match *self {
-            ConstTraitItem(ref associated_const) => associated_const.vis,
-            MethodTraitItem(ref method) => method.vis,
-            TypeTraitItem(ref associated_type) => associated_type.vis,
-        }
-    }
-
-    pub fn container(&self) -> ImplOrTraitItemContainer {
-        match *self {
-            ConstTraitItem(ref associated_const) => associated_const.container,
-            MethodTraitItem(ref method) => method.container,
-            TypeTraitItem(ref associated_type) => associated_type.container,
-        }
-    }
-
-    pub fn as_opt_method(&self) -> Option<Rc<Method<'tcx>>> {
-        match *self {
-            MethodTraitItem(ref m) => Some((*m).clone()),
-            _ => None,
+        match self.kind {
+            AssociatedKind::Const => Def::AssociatedConst(self.def_id),
+            AssociatedKind::Method => Def::Method(self.def_id),
+            AssociatedKind::Type => Def::AssociatedTy(self.def_id),
         }
     }
 }
@@ -306,64 +281,6 @@ impl Visibility {
 
         self.is_accessible_from(vis_restriction, tree)
     }
-}
-
-#[derive(Clone, Debug)]
-pub struct Method<'tcx> {
-    pub name: Name,
-    pub generics: &'tcx Generics<'tcx>,
-    pub predicates: GenericPredicates<'tcx>,
-    pub fty: &'tcx BareFnTy<'tcx>,
-    pub explicit_self: ExplicitSelfCategory<'tcx>,
-    pub vis: Visibility,
-    pub defaultness: hir::Defaultness,
-    pub has_body: bool,
-    pub def_id: DefId,
-    pub container: ImplOrTraitItemContainer,
-}
-
-impl<'tcx> Method<'tcx> {
-    pub fn container_id(&self) -> DefId {
-        match self.container {
-            TraitContainer(id) => id,
-            ImplContainer(id) => id,
-        }
-    }
-}
-
-impl<'tcx> PartialEq for Method<'tcx> {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool { self.def_id == other.def_id }
-}
-
-impl<'tcx> Eq for Method<'tcx> {}
-
-impl<'tcx> Hash for Method<'tcx> {
-    #[inline]
-    fn hash<H: Hasher>(&self, s: &mut H) {
-        self.def_id.hash(s)
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct AssociatedConst<'tcx> {
-    pub name: Name,
-    pub ty: Ty<'tcx>,
-    pub vis: Visibility,
-    pub defaultness: hir::Defaultness,
-    pub def_id: DefId,
-    pub container: ImplOrTraitItemContainer,
-    pub has_value: bool
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct AssociatedType<'tcx> {
-    pub name: Name,
-    pub ty: Option<Ty<'tcx>>,
-    pub vis: Visibility,
-    pub defaultness: hir::Defaultness,
-    pub def_id: DefId,
-    pub container: ImplOrTraitItemContainer,
 }
 
 #[derive(Clone, PartialEq, RustcDecodable, RustcEncodable, Copy)]
@@ -1288,19 +1205,10 @@ impl<'a, 'tcx> ParameterEnvironment<'tcx> {
                                                             tcx.region_maps.item_extent(id))
                     }
                     hir::ImplItemKind::Method(_, ref body) => {
-                        let method_def_id = tcx.map.local_def_id(id);
-                        match tcx.impl_or_trait_item(method_def_id) {
-                            MethodTraitItem(ref method_ty) => {
-                                tcx.construct_parameter_environment(
-                                    impl_item.span,
-                                    method_ty.def_id,
-                                    tcx.region_maps.call_site_extent(id, body.id))
-                            }
-                            _ => {
-                                bug!("ParameterEnvironment::for_item(): \
-                                      got non-method item from impl method?!")
-                            }
-                        }
+                        tcx.construct_parameter_environment(
+                            impl_item.span,
+                            tcx.map.local_def_id(id),
+                            tcx.region_maps.call_site_extent(id, body.id))
                     }
                 }
             }
@@ -1319,27 +1227,17 @@ impl<'a, 'tcx> ParameterEnvironment<'tcx> {
                         // Use call-site for extent (unless this is a
                         // trait method with no default; then fallback
                         // to the method id).
-                        let method_def_id = tcx.map.local_def_id(id);
-                        match tcx.impl_or_trait_item(method_def_id) {
-                            MethodTraitItem(ref method_ty) => {
-                                let extent = if let Some(ref body) = *body {
-                                    // default impl: use call_site extent as free_id_outlive bound.
-                                    tcx.region_maps.call_site_extent(id, body.id)
-                                } else {
-                                    // no default impl: use item extent as free_id_outlive bound.
-                                    tcx.region_maps.item_extent(id)
-                                };
-                                tcx.construct_parameter_environment(
-                                    trait_item.span,
-                                    method_ty.def_id,
-                                    extent)
-                            }
-                            _ => {
-                                bug!("ParameterEnvironment::for_item(): \
-                                      got non-method item from provided \
-                                      method?!")
-                            }
-                        }
+                        let extent = if let Some(ref body) = *body {
+                            // default impl: use call_site extent as free_id_outlive bound.
+                            tcx.region_maps.call_site_extent(id, body.id)
+                        } else {
+                            // no default impl: use item extent as free_id_outlive bound.
+                            tcx.region_maps.item_extent(id)
+                        };
+                        tcx.construct_parameter_environment(
+                            trait_item.span,
+                            tcx.map.local_def_id(id),
+                            extent)
                     }
                 }
             }
@@ -2065,7 +1963,7 @@ impl LvaluePreference {
 }
 
 /// Helper for looking things up in the various maps that are populated during
-/// typeck::collect (e.g., `tcx.impl_or_trait_items`, `tcx.tcache`, etc).  All of
+/// typeck::collect (e.g., `tcx.associated_items`, `tcx.tcache`, etc).  All of
 /// these share the pattern that if the id is local, it should have been loaded
 /// into the map by the `typeck::collect` phase.  If the def-id is external,
 /// then we have to go consult the crate loading code (and cache the result for
@@ -2204,13 +2102,10 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         }
     }
 
-    pub fn provided_trait_methods(self, id: DefId) -> Vec<Rc<Method<'gcx>>> {
-        self.impl_or_trait_items(id).iter().filter_map(|&def_id| {
-            match self.impl_or_trait_item(def_id) {
-                MethodTraitItem(ref m) if m.has_body => Some(m.clone()),
-                _ => None
-            }
-        }).collect()
+    pub fn provided_trait_methods(self, id: DefId) -> Vec<AssociatedItem> {
+        self.associated_items(id)
+            .filter(|item| item.kind == AssociatedKind::Method && item.has_value)
+            .collect()
     }
 
     pub fn trait_impl_polarity(self, id: DefId) -> hir::ImplPolarity {
@@ -2243,17 +2138,105 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         })
     }
 
-    pub fn impl_or_trait_item(self, id: DefId) -> ImplOrTraitItem<'gcx> {
-        lookup_locally_or_in_crate_store(
-            "impl_or_trait_items", id, &self.impl_or_trait_items,
-            || self.sess.cstore.impl_or_trait_item(self.global_tcx(), id)
-                   .expect("missing ImplOrTraitItem in metadata"))
+    pub fn associated_item(self, def_id: DefId) -> AssociatedItem {
+        self.associated_items.memoize(def_id, || {
+            if !def_id.is_local() {
+                return self.sess.cstore.associated_item(self.global_tcx(), def_id)
+                           .expect("missing AssociatedItem in metadata");
+            }
+
+            let id = self.map.as_local_node_id(def_id).unwrap();
+            let parent_id = self.map.get_parent(id);
+            let parent_def_id = self.map.local_def_id(parent_id);
+            match self.map.get(id) {
+                ast_map::NodeTraitItem(trait_item) => {
+                    let (kind, has_self, has_value) = match trait_item.node {
+                        hir::MethodTraitItem(ref sig, ref body) => {
+                            (AssociatedKind::Method, sig.decl.get_self().is_some(),
+                             body.is_some())
+                        }
+                        hir::ConstTraitItem(_, ref value) => {
+                            (AssociatedKind::Const, false, value.is_some())
+                        }
+                        hir::TypeTraitItem(_, ref ty) => {
+                            (AssociatedKind::Type, false, ty.is_some())
+                        }
+                    };
+
+                    AssociatedItem {
+                        name: trait_item.name,
+                        kind: kind,
+                        vis: Visibility::from_hir(&hir::Inherited, id, self),
+                        defaultness: hir::Defaultness::Default,
+                        has_value: has_value,
+                        def_id: def_id,
+                        container: TraitContainer(parent_def_id),
+                        method_has_self_argument: has_self
+                    }
+                }
+                ast_map::NodeImplItem(impl_item) => {
+                    let (kind, has_self) = match impl_item.node {
+                        hir::ImplItemKind::Method(ref sig, _) => {
+                            (AssociatedKind::Method, sig.decl.get_self().is_some())
+                        }
+                        hir::ImplItemKind::Const(..) => (AssociatedKind::Const, false),
+                        hir::ImplItemKind::Type(..) => (AssociatedKind::Type, false)
+                    };
+
+                    // Trait impl items are always public.
+                    let public = hir::Public;
+                    let parent_item = self.map.expect_item(parent_id);
+                    let vis = if let hir::ItemImpl(.., Some(_), _, _) = parent_item.node {
+                        &public
+                    } else {
+                        &impl_item.vis
+                    };
+
+                    AssociatedItem {
+                        name: impl_item.name,
+                        kind: kind,
+                        vis: Visibility::from_hir(vis, id, self),
+                        defaultness: impl_item.defaultness,
+                        has_value: true,
+                        def_id: def_id,
+                        container: ImplContainer(parent_def_id),
+                        method_has_self_argument: has_self
+                    }
+                }
+                item => bug!("associated_item: {:?} not an associated item", item)
+            }
+        })
     }
 
-    pub fn impl_or_trait_items(self, id: DefId) -> Rc<Vec<DefId>> {
-        lookup_locally_or_in_crate_store(
-            "impl_or_trait_items", id, &self.impl_or_trait_item_def_ids,
-            || Rc::new(self.sess.cstore.impl_or_trait_items(id)))
+    pub fn associated_item_def_ids(self, def_id: DefId) -> Rc<Vec<DefId>> {
+        self.associated_item_def_ids.memoize(def_id, || {
+            if !def_id.is_local() {
+                return Rc::new(self.sess.cstore.associated_item_def_ids(def_id));
+            }
+
+            let id = self.map.as_local_node_id(def_id).unwrap();
+            let item = self.map.expect_item(id);
+            match item.node {
+                hir::ItemTrait(.., ref trait_items) => {
+                    Rc::new(trait_items.iter().map(|trait_item| {
+                        self.map.local_def_id(trait_item.id)
+                    }).collect())
+                }
+                hir::ItemImpl(.., ref impl_items) => {
+                    Rc::new(impl_items.iter().map(|impl_item| {
+                        self.map.local_def_id(impl_item.id)
+                    }).collect())
+                }
+                _ => span_bug!(item.span, "associated_item_def_ids: not impl or trait")
+            }
+        })
+    }
+
+    #[inline] // FIXME(#35870) Avoid closures being unexported due to impl Trait.
+    pub fn associated_items(self, def_id: DefId)
+                            -> impl Iterator<Item = ty::AssociatedItem> + 'a {
+        let def_ids = self.associated_item_def_ids(def_id);
+        (0..def_ids.len()).map(move |i| self.associated_item(def_ids[i]))
     }
 
     /// Returns the trait-ref corresponding to a given impl, or None if it is
@@ -2539,31 +2522,6 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         def.flags.set(def.flags.get() | TraitFlags::HAS_DEFAULT_IMPL)
     }
 
-    /// Load primitive inherent implementations if necessary
-    pub fn populate_implementations_for_primitive_if_necessary(self,
-                                                               primitive_def_id: DefId) {
-        if primitive_def_id.is_local() {
-            return
-        }
-
-        // The primitive is not local, hence we are reading this out
-        // of metadata.
-        let _ignore = self.dep_graph.in_ignore();
-
-        if self.populated_external_primitive_impls.borrow().contains(&primitive_def_id) {
-            return
-        }
-
-        debug!("populate_implementations_for_primitive_if_necessary: searching for {:?}",
-               primitive_def_id);
-
-        let impl_items = self.sess.cstore.impl_or_trait_items(primitive_def_id);
-
-        // Store the implementation info.
-        self.impl_or_trait_item_def_ids.borrow_mut().insert(primitive_def_id, Rc::new(impl_items));
-        self.populated_external_primitive_impls.borrow_mut().insert(primitive_def_id);
-    }
-
     /// Populates the type context with all the inherent implementations for
     /// the given type if necessary.
     pub fn populate_inherent_implementations_for_type_if_necessary(self,
@@ -2584,11 +2542,6 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                type_id);
 
         let inherent_impls = self.sess.cstore.inherent_implementations_for_type(type_id);
-        for &impl_def_id in &inherent_impls {
-            // Store the implementation info.
-            let impl_items = self.sess.cstore.impl_or_trait_items(impl_def_id);
-            self.impl_or_trait_item_def_ids.borrow_mut().insert(impl_def_id, Rc::new(impl_items));
-        }
 
         self.inherent_impls.borrow_mut().insert(type_id, inherent_impls);
         self.populated_external_types.borrow_mut().insert(type_id);
@@ -2617,23 +2570,11 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         }
 
         for impl_def_id in self.sess.cstore.implementations_of_trait(Some(trait_id)) {
-            let impl_items = self.sess.cstore.impl_or_trait_items(impl_def_id);
             let trait_ref = self.impl_trait_ref(impl_def_id).unwrap();
 
             // Record the trait->implementation mapping.
             let parent = self.sess.cstore.impl_parent(impl_def_id).unwrap_or(trait_id);
             def.record_remote_impl(self, impl_def_id, trait_ref, parent);
-
-            // For any methods that use a default implementation, add them to
-            // the map. This is a bit unfortunate.
-            for &impl_item_def_id in &impl_items {
-                // load impl items eagerly for convenience
-                // FIXME: we may want to load these lazily
-                self.impl_or_trait_item(impl_item_def_id);
-            }
-
-            // Store the implementation info.
-            self.impl_or_trait_item_def_ids.borrow_mut().insert(impl_def_id, Rc::new(impl_items));
         }
 
         def.flags.set(def.flags.get() | TraitFlags::IMPLS_VALID);
@@ -2679,17 +2620,17 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     /// ID of the impl that the method belongs to. Otherwise, return `None`.
     pub fn impl_of_method(self, def_id: DefId) -> Option<DefId> {
         if def_id.krate != LOCAL_CRATE {
-            return self.sess.cstore.impl_or_trait_item(self.global_tcx(), def_id)
+            return self.sess.cstore.associated_item(self.global_tcx(), def_id)
                        .and_then(|item| {
-                match item.container() {
+                match item.container {
                     TraitContainer(_) => None,
                     ImplContainer(def_id) => Some(def_id),
                 }
             });
         }
-        match self.impl_or_trait_items.borrow().get(&def_id).cloned() {
+        match self.associated_items.borrow().get(&def_id).cloned() {
             Some(trait_item) => {
-                match trait_item.container() {
+                match trait_item.container {
                     TraitContainer(_) => None,
                     ImplContainer(def_id) => Some(def_id),
                 }
@@ -2705,38 +2646,14 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         if def_id.krate != LOCAL_CRATE {
             return self.sess.cstore.trait_of_item(def_id);
         }
-        match self.impl_or_trait_items.borrow().get(&def_id) {
-            Some(impl_or_trait_item) => {
-                match impl_or_trait_item.container() {
+        match self.associated_items.borrow().get(&def_id) {
+            Some(associated_item) => {
+                match associated_item.container {
                     TraitContainer(def_id) => Some(def_id),
                     ImplContainer(_) => None
                 }
             }
             None => None
-        }
-    }
-
-    /// If the given def ID describes an item belonging to a trait, (either a
-    /// default method or an implementation of a trait method), return the ID of
-    /// the method inside trait definition (this means that if the given def ID
-    /// is already that of the original trait method, then the return value is
-    /// the same).
-    /// Otherwise, return `None`.
-    pub fn trait_item_of_item(self, def_id: DefId) -> Option<DefId> {
-        let impl_or_trait_item = match self.impl_or_trait_items.borrow().get(&def_id) {
-            Some(m) => m.clone(),
-            None => return None,
-        };
-        match impl_or_trait_item.container() {
-            TraitContainer(_) => Some(impl_or_trait_item.def_id()),
-            ImplContainer(def_id) => {
-                self.trait_id_of_impl(def_id).and_then(|trait_did| {
-                    let name = impl_or_trait_item.name();
-                    self.trait_items(trait_did).iter()
-                        .find(|item| item.name() == name)
-                        .map(|item| item.def_id())
-                })
-            }
         }
     }
 
@@ -2854,15 +2771,6 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             Err(self.sess.cstore.crate_name(impl_did.krate))
         }
     }
-}
-
-/// The category of explicit self.
-#[derive(Clone, Copy, Eq, PartialEq, Debug, RustcEncodable, RustcDecodable)]
-pub enum ExplicitSelfCategory<'tcx> {
-    Static,
-    ByValue,
-    ByReference(&'tcx Region, hir::Mutability),
-    ByBox,
 }
 
 impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -670,18 +670,6 @@ impl<'tcx> fmt::Debug for ty::InstantiatedPredicates<'tcx> {
     }
 }
 
-impl<'tcx> fmt::Debug for ty::ImplOrTraitItem<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "ImplOrTraitItem(")?;
-        match *self {
-            ty::ImplOrTraitItem::MethodTraitItem(ref i) => write!(f, "{:?}", i),
-            ty::ImplOrTraitItem::ConstTraitItem(ref i) => write!(f, "{:?}", i),
-            ty::ImplOrTraitItem::TypeTraitItem(ref i) => write!(f, "{:?}", i),
-        }?;
-        write!(f, ")")
-    }
-}
-
 impl<'tcx> fmt::Display for ty::FnSig<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "fn")?;
@@ -992,20 +980,6 @@ impl fmt::Display for ty::InferTy {
             ty::FreshIntTy(v) => write!(f, "FreshIntTy({})", v),
             ty::FreshFloatTy(v) => write!(f, "FreshFloatTy({})", v)
         }
-    }
-}
-
-impl<'tcx> fmt::Display for ty::ExplicitSelfCategory<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(match *self {
-            ty::ExplicitSelfCategory::Static => "static",
-            ty::ExplicitSelfCategory::ByValue => "self",
-            ty::ExplicitSelfCategory::ByReference(_, hir::MutMutable) => {
-                "&mut self"
-            }
-            ty::ExplicitSelfCategory::ByReference(_, hir::MutImmutable) => "&self",
-            ty::ExplicitSelfCategory::ByBox => "Box<self>",
-        })
     }
 }
 

--- a/src/librustc_const_eval/eval.rs
+++ b/src/librustc_const_eval/eval.rs
@@ -1091,13 +1091,8 @@ fn resolve_trait_associated_const<'a, 'tcx: 'a>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         // when constructing the inference context above.
         match selection {
             traits::VtableImpl(ref impl_data) => {
-                let ac = tcx.impl_or_trait_items(impl_data.impl_def_id)
-                    .iter().filter_map(|&def_id| {
-                        match tcx.impl_or_trait_item(def_id) {
-                            ty::ConstTraitItem(ic) => Some(ic),
-                            _ => None
-                        }
-                    }).find(|ic| ic.name == ti.name);
+                let ac = tcx.associated_items(impl_data.impl_def_id)
+                    .find(|item| item.kind == ty::AssociatedKind::Const && item.name == ti.name);
                 match ac {
                     Some(ic) => lookup_const_by_id(tcx, ic.def_id, None),
                     None => match ti.node {

--- a/src/librustc_lint/bad_style.rs
+++ b/src/librustc_lint/bad_style.rs
@@ -29,10 +29,10 @@ pub enum MethodLateContext {
 
 pub fn method_context(cx: &LateContext, id: ast::NodeId, span: Span) -> MethodLateContext {
     let def_id = cx.tcx.map.local_def_id(id);
-    match cx.tcx.impl_or_trait_items.borrow().get(&def_id) {
+    match cx.tcx.associated_items.borrow().get(&def_id) {
         None => span_bug!(span, "missing method descriptor?!"),
         Some(item) => {
-            match item.container() {
+            match item.container {
                 ty::TraitContainer(..) => MethodLateContext::TraitDefaultImpl,
                 ty::ImplContainer(cid) => {
                     match cx.tcx.impl_trait_ref(cid) {

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -818,7 +818,7 @@ impl LateLintPass for UnconditionalRecursion {
         let method = match fn_kind {
             FnKind::ItemFn(..) => None,
             FnKind::Method(..) => {
-                cx.tcx.impl_or_trait_item(cx.tcx.map.local_def_id(id)).as_opt_method()
+                Some(cx.tcx.associated_item(cx.tcx.map.local_def_id(id)))
             }
             // closures can't recur, so they don't matter.
             FnKind::Closure(_) => return,
@@ -937,7 +937,7 @@ impl LateLintPass for UnconditionalRecursion {
 
         // Check if the expression `id` performs a call to `method`.
         fn expr_refers_to_this_method<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                                                method: &ty::Method,
+                                                method: &ty::AssociatedItem,
                                                 id: ast::NodeId)
                                                 -> bool {
             use rustc::ty::adjustment::*;
@@ -986,14 +986,14 @@ impl LateLintPass for UnconditionalRecursion {
         // Check if the method call to the method with the ID `callee_id`
         // and instantiated with `callee_substs` refers to method `method`.
         fn method_call_refers_to_method<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                                                  method: &ty::Method,
+                                                  method: &ty::AssociatedItem,
                                                   callee_id: DefId,
                                                   callee_substs: &Substs<'tcx>,
                                                   expr_id: ast::NodeId)
                                                   -> bool {
-            let callee_item = tcx.impl_or_trait_item(callee_id);
+            let callee_item = tcx.associated_item(callee_id);
 
-            match callee_item.container() {
+            match callee_item.container {
                 // This is an inherent method, so the `def_id` refers
                 // directly to the method definition.
                 ty::ImplContainer(_) => callee_id == method.def_id,
@@ -1034,7 +1034,7 @@ impl LateLintPass for UnconditionalRecursion {
                                 let container = ty::ImplContainer(vtable_impl.impl_def_id);
                                 // It matches if it comes from the same impl,
                                 // and has the same method name.
-                                container == method.container && callee_item.name() == method.name
+                                container == method.container && callee_item.name == method.name
                             }
 
                             // There's no way to know if this call is

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -144,7 +144,7 @@ impl<'tcx> CrateStore<'tcx> for cstore::CStore {
         result
     }
 
-    fn impl_or_trait_items(&self, def_id: DefId) -> Vec<DefId> {
+    fn associated_item_def_ids(&self, def_id: DefId) -> Vec<DefId> {
         self.dep_graph.read(DepNode::MetaData(def_id));
         let mut result = vec![];
         self.get_crate_data(def_id.krate)
@@ -182,11 +182,11 @@ impl<'tcx> CrateStore<'tcx> for cstore::CStore {
         self.get_crate_data(def_id.krate).get_trait_of_item(def_id.index)
     }
 
-    fn impl_or_trait_item<'a>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>, def: DefId)
-                              -> Option<ty::ImplOrTraitItem<'tcx>>
+    fn associated_item<'a>(&self, _tcx: TyCtxt<'a, 'tcx, 'tcx>, def: DefId)
+                           -> Option<ty::AssociatedItem>
     {
         self.dep_graph.read(DepNode::MetaData(def));
-        self.get_crate_data(def.krate).get_impl_or_trait_item(def.index, tcx)
+        self.get_crate_data(def.krate).get_associated_item(def.index)
     }
 
     fn is_const_fn(&self, did: DefId) -> bool
@@ -427,9 +427,9 @@ impl<'tcx> CrateStore<'tcx> for cstore::CStore {
                 // the logic to do that already exists in `middle`. In order to
                 // reuse that code, it needs to be able to look up the traits for
                 // inlined items.
-                let ty_trait_item = tcx.impl_or_trait_item(def_id).clone();
+                let ty_trait_item = tcx.associated_item(def_id).clone();
                 let trait_item_def_id = tcx.map.local_def_id(trait_item.id);
-                tcx.impl_or_trait_items.borrow_mut()
+                tcx.associated_items.borrow_mut()
                    .insert(trait_item_def_id, ty_trait_item);
             }
             Some(&InlinedItem::ImplItem(_, ref impl_item)) => {

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -457,19 +457,17 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
 
         let node_id = tcx.map.as_local_node_id(def_id).unwrap();
         let ast_item = tcx.map.expect_trait_item(node_id);
-        let trait_item = tcx.impl_or_trait_item(def_id);
+        let trait_item = tcx.associated_item(def_id);
 
-        let container = |has_body| if has_body {
+        let container = if trait_item.has_value {
             AssociatedContainer::TraitWithDefault
         } else {
             AssociatedContainer::TraitRequired
         };
 
-        let kind = match trait_item {
-            ty::ConstTraitItem(ref associated_const) => {
-                EntryKind::AssociatedConst(container(associated_const.has_value))
-            }
-            ty::MethodTraitItem(ref method_ty) => {
+        let kind = match trait_item.kind {
+            ty::AssociatedKind::Const => EntryKind::AssociatedConst(container),
+            ty::AssociatedKind::Method => {
                 let fn_data = if let hir::MethodTraitItem(ref sig, _) = ast_item.node {
                     FnData {
                         constness: hir::Constness::NotConst,
@@ -478,30 +476,35 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                 } else {
                     bug!()
                 };
-                let data = MethodData {
+                EntryKind::Method(self.lazy(&MethodData {
                     fn_data: fn_data,
-                    container: container(method_ty.has_body),
-                    explicit_self: self.lazy(&method_ty.explicit_self),
-                };
-                EntryKind::Method(self.lazy(&data))
+                    container: container,
+                    has_self: trait_item.method_has_self_argument,
+                }))
             }
-            ty::TypeTraitItem(_) => EntryKind::AssociatedType(container(false)),
+            ty::AssociatedKind::Type => EntryKind::AssociatedType(container),
         };
 
         Entry {
             kind: kind,
-            visibility: trait_item.vis().simplify(),
+            visibility: trait_item.vis.simplify(),
             def_key: self.encode_def_key(def_id),
             attributes: self.encode_attributes(&ast_item.attrs),
             children: LazySeq::empty(),
             stability: self.encode_stability(def_id),
             deprecation: self.encode_deprecation(def_id),
 
-            ty: match trait_item {
-                ty::ConstTraitItem(_) |
-                ty::MethodTraitItem(_) => Some(self.encode_item_type(def_id)),
-                ty::TypeTraitItem(ref associated_type) => {
-                    associated_type.ty.map(|ty| self.lazy(&ty))
+            ty: match trait_item.kind {
+                ty::AssociatedKind::Const |
+                ty::AssociatedKind::Method => {
+                    Some(self.encode_item_type(def_id))
+                }
+                ty::AssociatedKind::Type => {
+                    if trait_item.has_value {
+                        Some(self.encode_item_type(def_id))
+                    } else {
+                        None
+                    }
                 }
             },
             inherent_impls: LazySeq::empty(),
@@ -509,8 +512,8 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             generics: Some(self.encode_generics(def_id)),
             predicates: Some(self.encode_predicates(def_id)),
 
-            ast: if let ty::ConstTraitItem(_) = trait_item {
-                let trait_def_id = trait_item.container().id();
+            ast: if trait_item.kind == ty::AssociatedKind::Const {
+                let trait_def_id = trait_item.container.id();
                 Some(self.encode_inlined_item(InlinedItemRef::TraitItem(trait_def_id, ast_item)))
             } else {
                 None
@@ -522,17 +525,17 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
     fn encode_info_for_impl_item(&mut self, def_id: DefId) -> Entry<'tcx> {
         let node_id = self.tcx.map.as_local_node_id(def_id).unwrap();
         let ast_item = self.tcx.map.expect_impl_item(node_id);
-        let impl_item = self.tcx.impl_or_trait_item(def_id);
-        let impl_def_id = impl_item.container().id();
+        let impl_item = self.tcx.associated_item(def_id);
+        let impl_def_id = impl_item.container.id();
 
-        let container = match ast_item.defaultness {
+        let container = match impl_item.defaultness {
             hir::Defaultness::Default => AssociatedContainer::ImplDefault,
             hir::Defaultness::Final => AssociatedContainer::ImplFinal,
         };
 
-        let kind = match impl_item {
-            ty::ConstTraitItem(_) => EntryKind::AssociatedConst(container),
-            ty::MethodTraitItem(ref method_ty) => {
+        let kind = match impl_item.kind {
+            ty::AssociatedKind::Const => EntryKind::AssociatedConst(container),
+            ty::AssociatedKind::Method => {
                 let fn_data = if let hir::ImplItemKind::Method(ref sig, _) = ast_item.node {
                     FnData {
                         constness: sig.constness,
@@ -541,17 +544,16 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                 } else {
                     bug!()
                 };
-                let data = MethodData {
+                EntryKind::Method(self.lazy(&MethodData {
                     fn_data: fn_data,
                     container: container,
-                    explicit_self: self.lazy(&method_ty.explicit_self),
-                };
-                EntryKind::Method(self.lazy(&data))
+                    has_self: impl_item.method_has_self_argument,
+                }))
             }
-            ty::TypeTraitItem(_) => EntryKind::AssociatedType(container),
+            ty::AssociatedKind::Type => EntryKind::AssociatedType(container)
         };
 
-        let (ast, mir) = if let ty::ConstTraitItem(_) = impl_item {
+        let (ast, mir) = if impl_item.kind == ty::AssociatedKind::Const {
             (true, true)
         } else if let hir::ImplItemKind::Method(ref sig, _) = ast_item.node {
             let generics = self.tcx.lookup_generics(def_id);
@@ -565,20 +567,14 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
 
         Entry {
             kind: kind,
-            visibility: impl_item.vis().simplify(),
+            visibility: impl_item.vis.simplify(),
             def_key: self.encode_def_key(def_id),
             attributes: self.encode_attributes(&ast_item.attrs),
             children: LazySeq::empty(),
             stability: self.encode_stability(def_id),
             deprecation: self.encode_deprecation(def_id),
 
-            ty: match impl_item {
-                ty::ConstTraitItem(_) |
-                ty::MethodTraitItem(_) => Some(self.encode_item_type(def_id)),
-                ty::TypeTraitItem(ref associated_type) => {
-                    associated_type.ty.map(|ty| self.lazy(&ty))
-                }
-            },
+            ty: Some(self.encode_item_type(def_id)),
             inherent_impls: LazySeq::empty(),
             variances: LazySeq::empty(),
             generics: Some(self.encode_generics(def_id)),
@@ -758,7 +754,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                 }
                 hir::ItemImpl(..) |
                 hir::ItemTrait(..) => {
-                    self.lazy_seq(tcx.impl_or_trait_items(def_id).iter().map(|&def_id| {
+                    self.lazy_seq(tcx.associated_item_def_ids(def_id).iter().map(|&def_id| {
                         assert!(def_id.is_local());
                         def_id.index
                     }))
@@ -880,14 +876,14 @@ impl<'a, 'b, 'tcx> IndexBuilder<'a, 'b, 'tcx> {
                 self.encode_fields(def_id);
             }
             hir::ItemImpl(..) => {
-                for &trait_item_def_id in &self.tcx.impl_or_trait_items(def_id)[..] {
+                for &trait_item_def_id in &self.tcx.associated_item_def_ids(def_id)[..] {
                     self.record(trait_item_def_id,
                                 EncodeContext::encode_info_for_impl_item,
                                 trait_item_def_id);
                 }
             }
             hir::ItemTrait(..) => {
-                for &item_def_id in &self.tcx.impl_or_trait_items(def_id)[..] {
+                for &item_def_id in &self.tcx.associated_item_def_ids(def_id)[..] {
                     self.record(item_def_id,
                                 EncodeContext::encode_info_for_trait_item,
                                 item_def_id);

--- a/src/librustc_metadata/schema.rs
+++ b/src/librustc_metadata/schema.rs
@@ -245,7 +245,7 @@ pub enum EntryKind<'tcx> {
     Trait(Lazy<TraitData<'tcx>>),
     Impl(Lazy<ImplData<'tcx>>),
     DefaultImpl(Lazy<ImplData<'tcx>>),
-    Method(Lazy<MethodData<'tcx>>),
+    Method(Lazy<MethodData>),
     AssociatedType(AssociatedContainer),
     AssociatedConst(AssociatedContainer),
 }
@@ -300,7 +300,7 @@ pub enum AssociatedContainer {
 }
 
 impl AssociatedContainer {
-    pub fn with_def_id(&self, def_id: DefId) -> ty::ImplOrTraitItemContainer {
+    pub fn with_def_id(&self, def_id: DefId) -> ty::AssociatedItemContainer {
         match *self {
             AssociatedContainer::TraitRequired |
             AssociatedContainer::TraitWithDefault => ty::TraitContainer(def_id),
@@ -310,7 +310,7 @@ impl AssociatedContainer {
         }
     }
 
-    pub fn has_body(&self) -> bool {
+    pub fn has_value(&self) -> bool {
         match *self {
             AssociatedContainer::TraitRequired => false,
 
@@ -332,10 +332,10 @@ impl AssociatedContainer {
 }
 
 #[derive(RustcEncodable, RustcDecodable)]
-pub struct MethodData<'tcx> {
+pub struct MethodData {
     pub fn_data: FnData,
     pub container: AssociatedContainer,
-    pub explicit_self: Lazy<ty::ExplicitSelfCategory<'tcx>>,
+    pub has_self: bool,
 }
 
 #[derive(RustcEncodable, RustcDecodable)]

--- a/src/librustc_mir/hair/cx/mod.rs
+++ b/src/librustc_mir/hair/cx/mod.rs
@@ -147,20 +147,14 @@ impl<'a, 'gcx, 'tcx> Cx<'a, 'gcx, 'tcx> {
                         -> (Ty<'tcx>, Literal<'tcx>) {
         let method_name = token::intern(method_name);
         let substs = self.tcx.mk_substs_trait(self_ty, params);
-        for trait_item in self.tcx.trait_items(trait_def_id).iter() {
-            match *trait_item {
-                ty::ImplOrTraitItem::MethodTraitItem(ref method) => {
-                    if method.name == method_name {
-                        let method_ty = self.tcx.lookup_item_type(method.def_id);
-                        let method_ty = method_ty.ty.subst(self.tcx, substs);
-                        return (method_ty, Literal::Item {
-                            def_id: method.def_id,
-                            substs: substs,
-                        });
-                    }
-                }
-                ty::ImplOrTraitItem::ConstTraitItem(..) |
-                ty::ImplOrTraitItem::TypeTraitItem(..) => {}
+        for item in self.tcx.associated_items(trait_def_id) {
+            if item.kind == ty::AssociatedKind::Method && item.name == method_name {
+                let method_ty = self.tcx.lookup_item_type(item.def_id);
+                let method_ty = method_ty.ty.subst(self.tcx, substs);
+                return (method_ty, Literal::Item {
+                    def_id: item.def_id,
+                    substs: substs,
+                });
             }
         }
 

--- a/src/librustc_passes/consts.rs
+++ b/src/librustc_passes/consts.rs
@@ -542,7 +542,7 @@ fn check_expr<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>, e: &hir::Expr, node
                     v.handle_const_fn_call(e, did, node_ty)
                 }
                 Some(Def::Method(did)) => {
-                    match v.tcx.impl_or_trait_item(did).container() {
+                    match v.tcx.associated_item(did).container {
                         ty::ImplContainer(_) => {
                             v.handle_const_fn_call(e, did, node_ty)
                         }
@@ -557,7 +557,7 @@ fn check_expr<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>, e: &hir::Expr, node
         }
         hir::ExprMethodCall(..) => {
             let method = v.tcx.tables().method_map[&method_call];
-            let is_const = match v.tcx.impl_or_trait_item(method.def_id).container() {
+            let is_const = match v.tcx.associated_item(method.def_id).container {
                 ty::ImplContainer(_) => v.handle_const_fn_call(e, method.def_id, node_ty),
                 ty::TraitContainer(_) => false
             };

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -399,7 +399,7 @@ impl<'a, 'tcx> PrivacyVisitor<'a, 'tcx> {
 
     // Checks that a method is in scope.
     fn check_method(&mut self, span: Span, method_def_id: DefId) {
-        match self.tcx.impl_or_trait_item(method_def_id).container() {
+        match self.tcx.associated_item(method_def_id).container {
             // Trait methods are always all public. The only controlling factor
             // is whether the trait itself is accessible or not.
             ty::TraitContainer(trait_def_id) if !self.item_is_accessible(trait_def_id) => {

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -456,7 +456,7 @@ impl<'b> Resolver<'b> {
                 self.define(parent, name, TypeNS, (module, DUMMY_SP, vis));
 
                 // If this is a trait, add all the trait item names to the trait info.
-                let trait_item_def_ids = self.session.cstore.impl_or_trait_items(def_id);
+                let trait_item_def_ids = self.session.cstore.associated_item_def_ids(def_id);
                 for trait_item_def_id in trait_item_def_ids {
                     let trait_item_name = self.session.cstore.def_key(trait_item_def_id)
                                               .disambiguated_data.data.get_opt_name()

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -32,7 +32,7 @@ use rustc::hir::def::Def;
 use rustc::hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use rustc::hir::map::{Node, NodeItem};
 use rustc::session::Session;
-use rustc::ty::{self, TyCtxt, ImplOrTraitItem, ImplOrTraitItemContainer};
+use rustc::ty::{self, TyCtxt, AssociatedItemContainer};
 
 use std::collections::HashSet;
 use std::collections::hash_map::DefaultHasher;
@@ -402,19 +402,19 @@ impl<'l, 'tcx: 'l, 'll, D: Dump + 'll> DumpVisitor<'l, 'tcx, 'll, D> {
             // with the right name.
             if !self.span.filter_generated(Some(method_data.span), span) {
                 let container =
-                    self.tcx.impl_or_trait_item(self.tcx.map.local_def_id(id)).container();
+                    self.tcx.associated_item(self.tcx.map.local_def_id(id)).container;
                 let mut trait_id;
                 let mut decl_id = None;
                 match container {
-                    ImplOrTraitItemContainer::ImplContainer(id) => {
+                    AssociatedItemContainer::ImplContainer(id) => {
                         trait_id = self.tcx.trait_id_of_impl(id);
 
                         match trait_id {
                             Some(id) => {
-                                for item in &**self.tcx.trait_items(id) {
-                                    if let &ImplOrTraitItem::MethodTraitItem(ref m) = item {
-                                        if m.name == name {
-                                            decl_id = Some(m.def_id);
+                                for item in self.tcx.associated_items(id) {
+                                    if item.kind == ty::AssociatedKind::Method {
+                                        if item.name == name {
+                                            decl_id = Some(item.def_id);
                                             break;
                                         }
                                     }
@@ -429,7 +429,7 @@ impl<'l, 'tcx: 'l, 'll, D: Dump + 'll> DumpVisitor<'l, 'tcx, 'll, D> {
                             }
                         }
                     }
-                    ImplOrTraitItemContainer::TraitContainer(id) => {
+                    AssociatedItemContainer::TraitContainer(id) => {
                         trait_id = Some(id);
                     }
                 }
@@ -916,11 +916,9 @@ impl<'l, 'tcx: 'l, 'll, D: Dump + 'll> DumpVisitor<'l, 'tcx, 'll, D> {
         // Modules or types in the path prefix.
         match self.tcx.expect_def(id) {
             Def::Method(did) => {
-                let ti = self.tcx.impl_or_trait_item(did);
-                if let ty::MethodTraitItem(m) = ti {
-                    if m.explicit_self == ty::ExplicitSelfCategory::Static {
-                        self.write_sub_path_trait_truncated(path);
-                    }
+                let ti = self.tcx.associated_item(did);
+                if ti.kind == ty::AssociatedKind::Method && ti.method_has_self_argument {
+                    self.write_sub_path_trait_truncated(path);
                 }
             }
             Def::Fn(..) |

--- a/src/librustc_trans/collector.rs
+++ b/src/librustc_trans/collector.rs
@@ -844,17 +844,12 @@ fn do_static_dispatch<'a, 'tcx>(scx: &SharedCrateContext<'a, 'tcx>,
            param_substs);
 
     if let Some(trait_def_id) = scx.tcx().trait_of_item(fn_def_id) {
-        match scx.tcx().impl_or_trait_item(fn_def_id) {
-            ty::MethodTraitItem(ref method) => {
-                debug!(" => trait method, attempting to find impl");
-                do_static_trait_method_dispatch(scx,
-                                                method,
-                                                trait_def_id,
-                                                fn_substs,
-                                                param_substs)
-            }
-            _ => bug!()
-        }
+        debug!(" => trait method, attempting to find impl");
+        do_static_trait_method_dispatch(scx,
+                                        &scx.tcx().associated_item(fn_def_id),
+                                        trait_def_id,
+                                        fn_substs,
+                                        param_substs)
     } else {
         debug!(" => regular function");
         // The function is not part of an impl or trait, no dispatching
@@ -866,7 +861,7 @@ fn do_static_dispatch<'a, 'tcx>(scx: &SharedCrateContext<'a, 'tcx>,
 // Given a trait-method and substitution information, find out the actual
 // implementation of the trait method.
 fn do_static_trait_method_dispatch<'a, 'tcx>(scx: &SharedCrateContext<'a, 'tcx>,
-                                             trait_method: &ty::Method,
+                                             trait_method: &ty::AssociatedItem,
                                              trait_id: DefId,
                                              callee_substs: &'tcx Substs<'tcx>,
                                              param_substs: &'tcx Substs<'tcx>)
@@ -1187,7 +1182,7 @@ fn create_trans_items_for_default_impls<'a, 'tcx>(scx: &SharedCrateContext<'a, '
                         continue;
                     }
 
-                    if !method.generics.types.is_empty() {
+                    if !tcx.lookup_generics(method.def_id).types.is_empty() {
                         continue;
                     }
 

--- a/src/librustc_trans/mir/constant.rs
+++ b/src/librustc_trans/mir/constant.rs
@@ -248,13 +248,8 @@ impl<'a, 'tcx> MirConstContext<'a, 'tcx> {
             let vtable = common::fulfill_obligation(ccx.shared(), DUMMY_SP, trait_ref);
             if let traits::VtableImpl(vtable_impl) = vtable {
                 let name = ccx.tcx().item_name(instance.def);
-                let ac = ccx.tcx().impl_or_trait_items(vtable_impl.impl_def_id)
-                    .iter().filter_map(|&def_id| {
-                        match ccx.tcx().impl_or_trait_item(def_id) {
-                            ty::ConstTraitItem(ac) => Some(ac),
-                            _ => None
-                        }
-                    }).find(|ic| ic.name == name);
+                let ac = ccx.tcx().associated_items(vtable_impl.impl_def_id)
+                    .find(|item| item.kind == ty::AssociatedKind::Const && item.name == name);
                 if let Some(ac) = ac {
                     instance = Instance::new(ac.def_id, vtable_impl.substs);
                 }

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -107,11 +107,6 @@ pub trait AstConv<'gcx, 'tcx> {
     fn get_type_parameter_bounds(&self, span: Span, def_id: ast::NodeId)
                                  -> Result<Vec<ty::PolyTraitRef<'tcx>>, ErrorReported>;
 
-    /// Returns true if the trait with id `trait_def_id` defines an
-    /// associated type with the name `name`.
-    fn trait_defines_associated_type_named(&self, trait_def_id: DefId, name: ast::Name)
-                                           -> bool;
-
     /// Return an (optional) substitution to convert bound type parameters that
     /// are in scope into free ones. This function should only return Some
     /// within a fn body.
@@ -831,6 +826,16 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
                                         Some(self_ty))
     }
 
+    fn trait_defines_associated_type_named(&self,
+                                           trait_def_id: DefId,
+                                           assoc_name: ast::Name)
+                                           -> bool
+    {
+        self.tcx().associated_items(trait_def_id).any(|item| {
+            item.kind == ty::AssociatedKind::Type && item.name == assoc_name
+        })
+    }
+
     fn ast_type_binding_to_poly_projection_predicate(
         &self,
         path_id: ast::NodeId,
@@ -1144,20 +1149,9 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
 
         let mut associated_types = FxHashSet::default();
         for tr in traits::supertraits(tcx, principal) {
-            if let Some(trait_id) = tcx.map.as_local_node_id(tr.def_id()) {
-                use collect::trait_associated_type_names;
-
-                associated_types.extend(trait_associated_type_names(tcx, trait_id)
-                    .map(|name| (tr.def_id(), name)))
-            } else {
-                let trait_items = tcx.impl_or_trait_items(tr.def_id());
-                associated_types.extend(trait_items.iter().filter_map(|&def_id| {
-                    match tcx.impl_or_trait_item(def_id) {
-                        ty::TypeTraitItem(ref item) => Some(item.name),
-                        _ => None
-                    }
-                }).map(|name| (tr.def_id(), name)));
-            }
+            associated_types.extend(tcx.associated_items(tr.def_id())
+                .filter(|item| item.kind == ty::AssociatedKind::Type)
+                .map(|item| (tr.def_id(), item.name)));
         }
 
         for projection_bound in &projection_bounds {
@@ -1260,14 +1254,10 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
 
         if bounds.len() > 1 {
             let spans = bounds.iter().map(|b| {
-                self.tcx().impl_or_trait_items(b.def_id()).iter()
-                .find(|&&def_id| {
-                    match self.tcx().impl_or_trait_item(def_id) {
-                        ty::TypeTraitItem(ref item) => item.name.as_str() == assoc_name,
-                        _ => false
-                    }
+                self.tcx().associated_items(b.def_id()).find(|item| {
+                    item.kind == ty::AssociatedKind::Type && item.name.as_str() == assoc_name
                 })
-                .and_then(|&def_id| self.tcx().map.as_local_node_id(def_id))
+                .and_then(|item| self.tcx().map.as_local_node_id(item.def_id))
                 .and_then(|node_id| self.tcx().map.opt_span(node_id))
             });
 
@@ -1383,25 +1373,8 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
         let trait_did = bound.0.def_id;
         let ty = self.projected_ty_from_poly_trait_ref(span, bound, assoc_name);
 
-        let item_did = if let Some(trait_id) = tcx.map.as_local_node_id(trait_did) {
-            // `ty::trait_items` used below requires information generated
-            // by type collection, which may be in progress at this point.
-            match tcx.map.expect_item(trait_id).node {
-                hir::ItemTrait(.., ref trait_items) => {
-                    let item = trait_items.iter()
-                                          .find(|i| i.name == assoc_name)
-                                          .expect("missing associated type");
-                    tcx.map.local_def_id(item.id)
-                }
-                _ => bug!()
-            }
-        } else {
-            let trait_items = tcx.trait_items(trait_did);
-            let item = trait_items.iter().find(|i| i.name() == assoc_name);
-            item.expect("missing associated type").def_id()
-        };
-
-        (ty, Def::AssociatedTy(item_did))
+        let item = tcx.associated_items(trait_did).find(|i| i.name == assoc_name);
+        (ty, Def::AssociatedTy(item.expect("missing associated type").def_id))
     }
 
     fn qpath_to_ty(&self,
@@ -1694,13 +1667,12 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
             hir::TyBareFn(ref bf) => {
                 require_c_abi_if_variadic(tcx, &bf.decl, bf.abi, ast_ty.span);
                 let anon_scope = rscope.anon_type_scope();
-                let (bare_fn_ty, _) =
-                    self.ty_of_method_or_bare_fn(bf.unsafety,
-                                                 bf.abi,
-                                                 None,
-                                                 &bf.decl,
-                                                 anon_scope,
-                                                 anon_scope);
+                let bare_fn_ty = self.ty_of_method_or_bare_fn(bf.unsafety,
+                                                              bf.abi,
+                                                              None,
+                                                              &bf.decl,
+                                                              anon_scope,
+                                                              anon_scope);
 
                 // Find any late-bound regions declared in return type that do
                 // not appear in the arguments. These are not wellformed.
@@ -1842,7 +1814,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
                         sig: &hir::MethodSig,
                         untransformed_self_ty: Ty<'tcx>,
                         anon_scope: Option<AnonTypeScope>)
-                        -> (&'tcx ty::BareFnTy<'tcx>, ty::ExplicitSelfCategory<'tcx>) {
+                        -> &'tcx ty::BareFnTy<'tcx> {
         self.ty_of_method_or_bare_fn(sig.unsafety,
                                      sig.abi,
                                      Some(untransformed_self_ty),
@@ -1857,7 +1829,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
                          decl: &hir::FnDecl,
                          anon_scope: Option<AnonTypeScope>)
                          -> &'tcx ty::BareFnTy<'tcx> {
-        self.ty_of_method_or_bare_fn(unsafety, abi, None, decl, None, anon_scope).0
+        self.ty_of_method_or_bare_fn(unsafety, abi, None, decl, None, anon_scope)
     }
 
     fn ty_of_method_or_bare_fn(&self,
@@ -1867,7 +1839,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
                                decl: &hir::FnDecl,
                                arg_anon_scope: Option<AnonTypeScope>,
                                ret_anon_scope: Option<AnonTypeScope>)
-                               -> (&'tcx ty::BareFnTy<'tcx>, ty::ExplicitSelfCategory<'tcx>)
+                               -> &'tcx ty::BareFnTy<'tcx>
     {
         debug!("ty_of_method_or_bare_fn");
 
@@ -1880,13 +1852,13 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
         // lifetime elision, we can determine it in two ways. First (determined
         // here), if self is by-reference, then the implied output region is the
         // region of the self parameter.
-        let (self_ty, explicit_self_category) = match (opt_untransformed_self_ty, decl.get_self()) {
+        let (self_ty, explicit_self) = match (opt_untransformed_self_ty, decl.get_self()) {
             (Some(untransformed_self_ty), Some(explicit_self)) => {
                 let self_type = self.determine_self_type(&rb, untransformed_self_ty,
                                                          &explicit_self);
-                (Some(self_type.0), self_type.1)
+                (Some(self_type), Some(ExplicitSelf::determine(untransformed_self_ty, self_type)))
             }
-            _ => (None, ty::ExplicitSelfCategory::Static),
+            _ => (None, None),
         };
 
         // HACK(eddyb) replace the fake self type in the AST with the actual type.
@@ -1901,8 +1873,8 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
         // Second, if there was exactly one lifetime (either a substitution or a
         // reference) in the arguments, then any anonymous regions in the output
         // have that lifetime.
-        let implied_output_region = match explicit_self_category {
-            ty::ExplicitSelfCategory::ByReference(region, _) => Ok(*region),
+        let implied_output_region = match explicit_self {
+            Some(ExplicitSelf::ByReference(region, _)) => Ok(*region),
             _ => {
                 // `pat_to_string` is expensive and
                 // `find_implied_output_region` only needs its result when
@@ -1928,7 +1900,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
         debug!("ty_of_method_or_bare_fn: input_tys={:?}", input_tys);
         debug!("ty_of_method_or_bare_fn: output_ty={:?}", output_ty);
 
-        (self.tcx().mk_bare_fn(ty::BareFnTy {
+        self.tcx().mk_bare_fn(ty::BareFnTy {
             unsafety: unsafety,
             abi: abi,
             sig: ty::Binder(ty::FnSig {
@@ -1936,95 +1908,30 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
                 output: output_ty,
                 variadic: decl.variadic
             }),
-        }), explicit_self_category)
+        })
     }
 
     fn determine_self_type<'a>(&self,
                                rscope: &RegionScope,
                                untransformed_self_ty: Ty<'tcx>,
                                explicit_self: &hir::ExplicitSelf)
-                               -> (Ty<'tcx>, ty::ExplicitSelfCategory<'tcx>)
+                               -> Ty<'tcx>
     {
-        return match explicit_self.node {
-            SelfKind::Value(..) => {
-                (untransformed_self_ty, ty::ExplicitSelfCategory::ByValue)
-            }
+        match explicit_self.node {
+            SelfKind::Value(..) => untransformed_self_ty,
             SelfKind::Region(ref lifetime, mutability) => {
                 let region =
                     self.opt_ast_region_to_region(
                                              rscope,
                                              explicit_self.span,
                                              lifetime);
-                (self.tcx().mk_ref(region,
+                self.tcx().mk_ref(region,
                     ty::TypeAndMut {
                         ty: untransformed_self_ty,
                         mutbl: mutability
-                    }),
-                 ty::ExplicitSelfCategory::ByReference(region, mutability))
+                    })
             }
-            SelfKind::Explicit(ref ast_type, _) => {
-                let explicit_type = self.ast_ty_to_ty(rscope, &ast_type);
-
-                // We wish to (for now) categorize an explicit self
-                // declaration like `self: SomeType` into either `self`,
-                // `&self`, `&mut self`, or `Box<self>`. We do this here
-                // by some simple pattern matching. A more precise check
-                // is done later in `check_method_self_type()`.
-                //
-                // Examples:
-                //
-                // ```
-                // impl Foo for &T {
-                //     // Legal declarations:
-                //     fn method1(self: &&T); // ExplicitSelfCategory::ByReference
-                //     fn method2(self: &T); // ExplicitSelfCategory::ByValue
-                //     fn method3(self: Box<&T>); // ExplicitSelfCategory::ByBox
-                //
-                //     // Invalid cases will be caught later by `check_method_self_type`:
-                //     fn method_err1(self: &mut T); // ExplicitSelfCategory::ByReference
-                // }
-                // ```
-                //
-                // To do the check we just count the number of "modifiers"
-                // on each type and compare them. If they are the same or
-                // the impl has more, we call it "by value". Otherwise, we
-                // look at the outermost modifier on the method decl and
-                // call it by-ref, by-box as appropriate. For method1, for
-                // example, the impl type has one modifier, but the method
-                // type has two, so we end up with
-                // ExplicitSelfCategory::ByReference.
-
-                let impl_modifiers = count_modifiers(untransformed_self_ty);
-                let method_modifiers = count_modifiers(explicit_type);
-
-                debug!("determine_explicit_self_category(self_info.untransformed_self_ty={:?} \
-                       explicit_type={:?} \
-                       modifiers=({},{})",
-                       untransformed_self_ty,
-                       explicit_type,
-                       impl_modifiers,
-                       method_modifiers);
-
-                let category = if impl_modifiers >= method_modifiers {
-                    ty::ExplicitSelfCategory::ByValue
-                } else {
-                    match explicit_type.sty {
-                        ty::TyRef(r, mt) => ty::ExplicitSelfCategory::ByReference(r, mt.mutbl),
-                        ty::TyBox(_) => ty::ExplicitSelfCategory::ByBox,
-                        _ => ty::ExplicitSelfCategory::ByValue,
-                    }
-                };
-
-                (explicit_type, category)
-            }
-        };
-
-        fn count_modifiers(ty: Ty) -> usize {
-            match ty.sty {
-                ty::TyRef(_, mt) => count_modifiers(mt.ty) + 1,
-                ty::TyBox(t) => count_modifiers(t) + 1,
-                _ => 0,
-            }
+            SelfKind::Explicit(ref ast_type, _) => self.ast_ty_to_ty(rscope, &ast_type)
         }
     }
 
@@ -2332,5 +2239,66 @@ impl<'a, 'gcx, 'tcx> Bounds<'tcx> {
         }
 
         vec
+    }
+}
+
+pub enum ExplicitSelf<'tcx> {
+    ByValue,
+    ByReference(&'tcx ty::Region, hir::Mutability),
+    ByBox
+}
+
+impl<'tcx> ExplicitSelf<'tcx> {
+    /// We wish to (for now) categorize an explicit self
+    /// declaration like `self: SomeType` into either `self`,
+    /// `&self`, `&mut self`, or `Box<self>`. We do this here
+    /// by some simple pattern matching. A more precise check
+    /// is done later in `check_method_self_type()`.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// impl Foo for &T {
+    ///     // Legal declarations:
+    ///     fn method1(self: &&T); // ExplicitSelf::ByReference
+    ///     fn method2(self: &T); // ExplicitSelf::ByValue
+    ///     fn method3(self: Box<&T>); // ExplicitSelf::ByBox
+    ///
+    ///     // Invalid cases will be caught later by `check_method_self_type`:
+    ///     fn method_err1(self: &mut T); // ExplicitSelf::ByReference
+    /// }
+    /// ```
+    ///
+    /// To do the check we just count the number of "modifiers"
+    /// on each type and compare them. If they are the same or
+    /// the impl has more, we call it "by value". Otherwise, we
+    /// look at the outermost modifier on the method decl and
+    /// call it by-ref, by-box as appropriate. For method1, for
+    /// example, the impl type has one modifier, but the method
+    /// type has two, so we end up with
+    /// ExplicitSelf::ByReference.
+    pub fn determine(untransformed_self_ty: Ty<'tcx>,
+                     self_arg_ty: Ty<'tcx>)
+                     -> ExplicitSelf<'tcx> {
+        fn count_modifiers(ty: Ty) -> usize {
+            match ty.sty {
+                ty::TyRef(_, mt) => count_modifiers(mt.ty) + 1,
+                ty::TyBox(t) => count_modifiers(t) + 1,
+                _ => 0,
+            }
+        }
+
+        let impl_modifiers = count_modifiers(untransformed_self_ty);
+        let method_modifiers = count_modifiers(self_arg_ty);
+
+        if impl_modifiers >= method_modifiers {
+            ExplicitSelf::ByValue
+        } else {
+            match self_arg_ty.sty {
+                ty::TyRef(r, mt) => ExplicitSelf::ByReference(r, mt.mutbl),
+                ty::TyBox(_) => ExplicitSelf::ByBox,
+                _ => ExplicitSelf::ByValue,
+            }
+        }
     }
 }

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use rustc::hir;
 use rustc::infer::{self, InferOk, TypeOrigin};
 use rustc::middle::free_region::FreeRegionMap;
 use rustc::ty;
@@ -23,6 +24,7 @@ use syntax_pos::Span;
 use CrateCtxt;
 use super::assoc;
 use super::{Inherited, FnCtxt};
+use astconv::ExplicitSelf;
 
 /// Checks that a method from an impl conforms to the signature of
 /// the same method as declared in the trait.
@@ -36,11 +38,11 @@ use super::{Inherited, FnCtxt};
 /// - impl_trait_ref: the TraitRef corresponding to the trait implementation
 
 pub fn compare_impl_method<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
-                                     impl_m: &ty::Method<'tcx>,
+                                     impl_m: &ty::AssociatedItem,
                                      impl_m_span: Span,
                                      impl_m_body_id: ast::NodeId,
-                                     trait_m: &ty::Method<'tcx>,
-                                     impl_trait_ref: &ty::TraitRef<'tcx>,
+                                     trait_m: &ty::AssociatedItem,
+                                     impl_trait_ref: ty::TraitRef<'tcx>,
                                      trait_item_span: Option<Span>,
                                      old_broken_mode: bool) {
     debug!("compare_impl_method(impl_trait_ref={:?})",
@@ -49,7 +51,8 @@ pub fn compare_impl_method<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
     if let Err(ErrorReported) = compare_self_type(ccx,
                                                   impl_m,
                                                   impl_m_span,
-                                                  trait_m) {
+                                                  trait_m,
+                                                  impl_trait_ref) {
         return;
     }
 
@@ -81,16 +84,16 @@ pub fn compare_impl_method<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
 }
 
 fn compare_predicate_entailment<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
-                                          impl_m: &ty::Method<'tcx>,
+                                          impl_m: &ty::AssociatedItem,
                                           impl_m_span: Span,
                                           impl_m_body_id: ast::NodeId,
-                                          trait_m: &ty::Method<'tcx>,
-                                          impl_trait_ref: &ty::TraitRef<'tcx>,
+                                          trait_m: &ty::AssociatedItem,
+                                          impl_trait_ref: ty::TraitRef<'tcx>,
                                           old_broken_mode: bool)
                                           -> Result<(), ErrorReported> {
     let tcx = ccx.tcx;
 
-    let trait_to_impl_substs = &impl_trait_ref.substs;
+    let trait_to_impl_substs = impl_trait_ref.substs;
 
     // This code is best explained by example. Consider a trait:
     //
@@ -165,18 +168,23 @@ fn compare_predicate_entailment<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
 
     // Create mapping from trait to skolemized.
     let trait_to_skol_substs = impl_to_skol_substs.rebase_onto(tcx,
-                                                               impl_m.container_id(),
+                                                               impl_m.container.id(),
                                                                trait_to_impl_substs.subst(tcx,
                                                                           impl_to_skol_substs));
     debug!("compare_impl_method: trait_to_skol_substs={:?}",
            trait_to_skol_substs);
 
+    let impl_m_generics = tcx.lookup_generics(impl_m.def_id);
+    let trait_m_generics = tcx.lookup_generics(trait_m.def_id);
+    let impl_m_predicates = tcx.lookup_predicates(impl_m.def_id);
+    let trait_m_predicates = tcx.lookup_predicates(trait_m.def_id);
+
     // Check region bounds.
     check_region_bounds_on_impl_method(ccx,
                                        impl_m_span,
                                        impl_m,
-                                       &trait_m.generics,
-                                       &impl_m.generics,
+                                       &trait_m_generics,
+                                       &impl_m_generics,
                                        trait_to_skol_substs,
                                        impl_to_skol_substs)?;
 
@@ -185,7 +193,7 @@ fn compare_predicate_entailment<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
     // environment. We can't just use `impl_env.caller_bounds`,
     // however, because we want to replace all late-bound regions with
     // region variables.
-    let impl_predicates = tcx.lookup_predicates(impl_m.predicates.parent.unwrap());
+    let impl_predicates = tcx.lookup_predicates(impl_m_predicates.parent.unwrap());
     let mut hybrid_preds = impl_predicates.instantiate(tcx, impl_to_skol_substs);
 
     debug!("compare_impl_method: impl_bounds={:?}", hybrid_preds);
@@ -198,7 +206,7 @@ fn compare_predicate_entailment<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
     // We then register the obligations from the impl_m and check to see
     // if all constraints hold.
     hybrid_preds.predicates
-                .extend(trait_m.predicates.instantiate_own(tcx, trait_to_skol_substs).predicates);
+                .extend(trait_m_predicates.instantiate_own(tcx, trait_to_skol_substs).predicates);
 
     // Construct trait parameter environment and then shift it into the skolemized viewpoint.
     // The key step here is to update the caller_bounds's predicates to be
@@ -219,7 +227,7 @@ fn compare_predicate_entailment<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
 
         let mut selcx = traits::SelectionContext::new(&infcx);
 
-        let impl_m_own_bounds = impl_m.predicates.instantiate_own(tcx, impl_to_skol_substs);
+        let impl_m_own_bounds = impl_m_predicates.instantiate_own(tcx, impl_to_skol_substs);
         let (impl_m_own_bounds, _) = infcx.replace_late_bound_regions_with_fresh_var(impl_m_span,
                                                        infer::HigherRankedType,
                                                        &ty::Binder(impl_m_own_bounds.predicates));
@@ -260,10 +268,19 @@ fn compare_predicate_entailment<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
         let tcx = infcx.tcx;
         let origin = TypeOrigin::MethodCompatCheck(impl_m_span);
 
+        let m_fty = |method: &ty::AssociatedItem| {
+            match tcx.lookup_item_type(method.def_id).ty.sty {
+                ty::TyFnDef(_, _, f) => f,
+                _ => bug!()
+            }
+        };
+        let impl_m_fty = m_fty(impl_m);
+        let trait_m_fty = m_fty(trait_m);
+
         let (impl_sig, _) =
             infcx.replace_late_bound_regions_with_fresh_var(impl_m_span,
                                                             infer::HigherRankedType,
-                                                            &impl_m.fty.sig);
+                                                            &impl_m_fty.sig);
         let impl_sig =
             impl_sig.subst(tcx, impl_to_skol_substs);
         let impl_sig =
@@ -273,15 +290,15 @@ fn compare_predicate_entailment<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                                  impl_m_body_id,
                                                  &impl_sig);
         let impl_fty = tcx.mk_fn_ptr(tcx.mk_bare_fn(ty::BareFnTy {
-            unsafety: impl_m.fty.unsafety,
-            abi: impl_m.fty.abi,
+            unsafety: impl_m_fty.unsafety,
+            abi: impl_m_fty.abi,
             sig: ty::Binder(impl_sig.clone()),
         }));
         debug!("compare_impl_method: impl_fty={:?}", impl_fty);
 
         let trait_sig = tcx.liberate_late_bound_regions(
             infcx.parameter_environment.free_id_outlive,
-            &trait_m.fty.sig);
+            &trait_m_fty.sig);
         let trait_sig =
             trait_sig.subst(tcx, trait_to_skol_substs);
         let trait_sig =
@@ -291,8 +308,8 @@ fn compare_predicate_entailment<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                                  impl_m_body_id,
                                                  &trait_sig);
         let trait_fty = tcx.mk_fn_ptr(tcx.mk_bare_fn(ty::BareFnTy {
-            unsafety: trait_m.fty.unsafety,
-            abi: trait_m.fty.abi,
+            unsafety: trait_m_fty.unsafety,
+            abi: trait_m_fty.abi,
             sig: ty::Binder(trait_sig.clone()),
         }));
 
@@ -367,7 +384,7 @@ fn compare_predicate_entailment<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
 
 fn check_region_bounds_on_impl_method<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                                 span: Span,
-                                                impl_m: &ty::Method<'tcx>,
+                                                impl_m: &ty::AssociatedItem,
                                                 trait_generics: &ty::Generics<'tcx>,
                                                 impl_generics: &ty::Generics<'tcx>,
                                                 trait_to_skol_substs: &Substs<'tcx>,
@@ -413,9 +430,9 @@ fn check_region_bounds_on_impl_method<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
 fn extract_spans_for_error_reporting<'a, 'gcx, 'tcx>(infcx: &infer::InferCtxt<'a, 'gcx, 'tcx>,
                                                      terr: &TypeError,
                                                      origin: TypeOrigin,
-                                                     impl_m: &ty::Method,
+                                                     impl_m: &ty::AssociatedItem,
                                                      impl_sig: ty::FnSig<'tcx>,
-                                                     trait_m: &ty::Method,
+                                                     trait_m: &ty::AssociatedItem,
                                                      trait_sig: ty::FnSig<'tcx>)
                                                      -> (Span, Option<Span>) {
     let tcx = infcx.tcx;
@@ -505,9 +522,10 @@ fn extract_spans_for_error_reporting<'a, 'gcx, 'tcx>(infcx: &infer::InferCtxt<'a
 }
 
 fn compare_self_type<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
-                               impl_m: &ty::Method<'tcx>,
+                               impl_m: &ty::AssociatedItem,
                                impl_m_span: Span,
-                               trait_m: &ty::Method<'tcx>)
+                               trait_m: &ty::AssociatedItem,
+                               impl_trait_ref: ty::TraitRef<'tcx>)
                                -> Result<(), ErrorReported>
 {
     let tcx = ccx.tcx;
@@ -518,43 +536,58 @@ fn compare_self_type<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
     // that the error messages you get out of this code are a bit more
     // inscrutable, particularly for cases where one method has no
     // self.
-    match (&trait_m.explicit_self, &impl_m.explicit_self) {
-        (&ty::ExplicitSelfCategory::Static, &ty::ExplicitSelfCategory::Static) => {}
-        (&ty::ExplicitSelfCategory::Static, _) => {
+
+    let self_string = |method: &ty::AssociatedItem| {
+        let untransformed_self_ty = match method.container {
+            ty::ImplContainer(_) => impl_trait_ref.self_ty(),
+            ty::TraitContainer(_) => tcx.mk_self_type()
+        };
+        let method_ty = tcx.lookup_item_type(method.def_id).ty;
+        let self_arg_ty = *method_ty.fn_sig().input(0).skip_binder();
+        match ExplicitSelf::determine(untransformed_self_ty, self_arg_ty) {
+            ExplicitSelf::ByValue => "self".to_string(),
+            ExplicitSelf::ByReference(_, hir::MutImmutable) => "&self".to_string(),
+            ExplicitSelf::ByReference(_, hir::MutMutable) => "&mut self".to_string(),
+            _ => format!("self: {}", self_arg_ty)
+        }
+    };
+
+    match (trait_m.method_has_self_argument, impl_m.method_has_self_argument) {
+        (false, false) | (true, true) => {}
+
+        (false, true) => {
+            let self_descr = self_string(impl_m);
             let mut err = struct_span_err!(tcx.sess,
                                            impl_m_span,
                                            E0185,
                                            "method `{}` has a `{}` declaration in the impl, but \
                                             not in the trait",
                                            trait_m.name,
-                                           impl_m.explicit_self);
-            err.span_label(impl_m_span,
-                           &format!("`{}` used in impl", impl_m.explicit_self));
+                                           self_descr);
+            err.span_label(impl_m_span, &format!("`{}` used in impl", self_descr));
             if let Some(span) = tcx.map.span_if_local(trait_m.def_id) {
-                err.span_label(span,
-                               &format!("trait declared without `{}`", impl_m.explicit_self));
+                err.span_label(span, &format!("trait declared without `{}`", self_descr));
             }
             err.emit();
             return Err(ErrorReported);
         }
-        (_, &ty::ExplicitSelfCategory::Static) => {
+
+        (true, false) => {
+            let self_descr = self_string(trait_m);
             let mut err = struct_span_err!(tcx.sess,
                                            impl_m_span,
                                            E0186,
                                            "method `{}` has a `{}` declaration in the trait, but \
                                             not in the impl",
                                            trait_m.name,
-                                           trait_m.explicit_self);
+                                           self_descr);
             err.span_label(impl_m_span,
-                           &format!("expected `{}` in impl", trait_m.explicit_self));
+                           &format!("expected `{}` in impl", self_descr));
             if let Some(span) = tcx.map.span_if_local(trait_m.def_id) {
-                err.span_label(span, &format!("`{}` used in trait", trait_m.explicit_self));
+                err.span_label(span, &format!("`{}` used in trait", self_descr));
             }
             err.emit();
             return Err(ErrorReported);
-        }
-        _ => {
-            // Let the type checker catch other errors below
         }
     }
 
@@ -562,14 +595,16 @@ fn compare_self_type<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
 }
 
 fn compare_number_of_generics<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
-                                        impl_m: &ty::Method<'tcx>,
+                                        impl_m: &ty::AssociatedItem,
                                         impl_m_span: Span,
-                                        trait_m: &ty::Method<'tcx>,
+                                        trait_m: &ty::AssociatedItem,
                                         trait_item_span: Option<Span>)
                                         -> Result<(), ErrorReported> {
     let tcx = ccx.tcx;
-    let num_impl_m_type_params = impl_m.generics.types.len();
-    let num_trait_m_type_params = trait_m.generics.types.len();
+    let impl_m_generics = tcx.lookup_generics(impl_m.def_id);
+    let trait_m_generics = tcx.lookup_generics(trait_m.def_id);
+    let num_impl_m_type_params = impl_m_generics.types.len();
+    let num_trait_m_type_params = trait_m_generics.types.len();
     if num_impl_m_type_params != num_trait_m_type_params {
         let impl_m_node_id = tcx.map.as_local_node_id(impl_m.def_id).unwrap();
         let span = match tcx.map.expect_impl_item(impl_m_node_id).node {
@@ -630,15 +665,23 @@ fn compare_number_of_generics<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
 }
 
 fn compare_number_of_method_arguments<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
-                                                impl_m: &ty::Method<'tcx>,
+                                                impl_m: &ty::AssociatedItem,
                                                 impl_m_span: Span,
-                                                trait_m: &ty::Method<'tcx>,
+                                                trait_m: &ty::AssociatedItem,
                                                 trait_item_span: Option<Span>)
                                                 -> Result<(), ErrorReported> {
     let tcx = ccx.tcx;
-    if impl_m.fty.sig.0.inputs.len() != trait_m.fty.sig.0.inputs.len() {
-        let trait_number_args = trait_m.fty.sig.0.inputs.len();
-        let impl_number_args = impl_m.fty.sig.0.inputs.len();
+    let m_fty = |method: &ty::AssociatedItem| {
+        match tcx.lookup_item_type(method.def_id).ty.sty {
+            ty::TyFnDef(_, _, f) => f,
+            _ => bug!()
+        }
+    };
+    let impl_m_fty = m_fty(impl_m);
+    let trait_m_fty = m_fty(trait_m);
+    if impl_m_fty.sig.0.inputs.len() != trait_m_fty.sig.0.inputs.len() {
+        let trait_number_args = trait_m_fty.sig.0.inputs.len();
+        let impl_number_args = impl_m_fty.sig.0.inputs.len();
         let trait_m_node_id = tcx.map.as_local_node_id(trait_m.def_id);
         let trait_span = if let Some(trait_id) = trait_m_node_id {
             match tcx.map.expect_trait_item(trait_id).node {
@@ -708,10 +751,10 @@ fn compare_number_of_method_arguments<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
 }
 
 pub fn compare_const_impl<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
-                                    impl_c: &ty::AssociatedConst<'tcx>,
+                                    impl_c: &ty::AssociatedItem,
                                     impl_c_span: Span,
-                                    trait_c: &ty::AssociatedConst<'tcx>,
-                                    impl_trait_ref: &ty::TraitRef<'tcx>) {
+                                    trait_c: &ty::AssociatedItem,
+                                    impl_trait_ref: ty::TraitRef<'tcx>) {
     debug!("compare_const_impl(impl_trait_ref={:?})", impl_trait_ref);
 
     let tcx = ccx.tcx;
@@ -723,7 +766,7 @@ pub fn compare_const_impl<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
         // because we shouldn't really have to deal with lifetimes or
         // predicates. In fact some of this should probably be put into
         // shared functions because of DRY violations...
-        let trait_to_impl_substs = &impl_trait_ref.substs;
+        let trait_to_impl_substs = impl_trait_ref.substs;
 
         // Create a parameter environment that represents the implementation's
         // method.
@@ -742,8 +785,8 @@ pub fn compare_const_impl<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                trait_to_skol_substs);
 
         // Compute skolemized form of impl and trait const tys.
-        let impl_ty = impl_c.ty.subst(tcx, impl_to_skol_substs);
-        let trait_ty = trait_c.ty.subst(tcx, trait_to_skol_substs);
+        let impl_ty = tcx.lookup_item_type(impl_c.def_id).ty.subst(tcx, impl_to_skol_substs);
+        let trait_ty = tcx.lookup_item_type(trait_c.def_id).ty.subst(tcx, trait_to_skol_substs);
         let mut origin = TypeOrigin::Misc(impl_c_span);
 
         let err = infcx.commit_if_ok(|_| {

--- a/src/librustc_typeck/check/dropck.rs
+++ b/src/librustc_typeck/check/dropck.rs
@@ -553,9 +553,9 @@ fn has_dtor_of_interest<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
             // attributes attached to the impl's generics.
             let dtor_method = adt_def.destructor()
                 .expect("dtorck type without destructor impossible");
-            let method = tcx.impl_or_trait_item(dtor_method);
-            let impl_id: DefId = method.container().id();
-            let revised_ty = revise_self_ty(tcx, adt_def, impl_id, substs);
+            let method = tcx.associated_item(dtor_method);
+            let impl_def_id = method.container.id();
+            let revised_ty = revise_self_ty(tcx, adt_def, impl_def_id, substs);
             return DropckKind::RevisedSelf(revised_ty);
         }
         ty::TyTrait(..) | ty::TyProjection(..) | ty::TyAnon(..) => {

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -8,9 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use astconv::ExplicitSelf;
 use check::FnCtxt;
 use constrained_type_params::{identify_constrained_type_params, Parameter};
 use CrateCtxt;
+
 use hir::def_id::DefId;
 use middle::region::{CodeExtent};
 use rustc::infer::TypeOrigin;
@@ -156,8 +158,8 @@ impl<'ccx, 'gcx> CheckTypeWellFormedVisitor<'ccx, 'gcx> {
 
                 self.check_variances_for_type_defn(item, ast_generics);
             }
-            hir::ItemTrait(.., ref items) => {
-                self.check_trait(item, items);
+            hir::ItemTrait(..) => {
+                self.check_trait(item);
             }
             _ => {}
         }
@@ -172,32 +174,39 @@ impl<'ccx, 'gcx> CheckTypeWellFormedVisitor<'ccx, 'gcx> {
             let free_substs = &fcx.parameter_environment.free_substs;
             let free_id_outlive = fcx.parameter_environment.free_id_outlive;
 
-            let item = fcx.tcx.impl_or_trait_item(fcx.tcx.map.local_def_id(item_id));
+            let item = fcx.tcx.associated_item(fcx.tcx.map.local_def_id(item_id));
 
-            let (mut implied_bounds, self_ty) = match item.container() {
+            let (mut implied_bounds, self_ty) = match item.container {
                 ty::TraitContainer(_) => (vec![], fcx.tcx.mk_self_type()),
                 ty::ImplContainer(def_id) => (fcx.impl_implied_bounds(def_id, span),
                                               fcx.tcx.lookup_item_type(def_id).ty)
             };
 
-            match item {
-                ty::ConstTraitItem(assoc_const) => {
-                    let ty = fcx.instantiate_type_scheme(span, free_substs, &assoc_const.ty);
+            match item.kind {
+                ty::AssociatedKind::Const => {
+                    let ty = fcx.tcx.lookup_item_type(item.def_id).ty;
+                    let ty = fcx.instantiate_type_scheme(span, free_substs, &ty);
                     fcx.register_wf_obligation(ty, span, code.clone());
                 }
-                ty::MethodTraitItem(method) => {
-                    reject_shadowing_type_parameters(fcx.tcx, span, &method.generics);
-                    let method_ty = fcx.instantiate_type_scheme(span, free_substs, &method.fty);
-                    let predicates = fcx.instantiate_bounds(span, free_substs, &method.predicates);
-                    this.check_fn_or_method(fcx, span, &method_ty, &predicates,
+                ty::AssociatedKind::Method => {
+                    reject_shadowing_type_parameters(fcx.tcx, span, item.def_id);
+                    let method_ty = fcx.tcx.lookup_item_type(item.def_id).ty;
+                    let method_ty = fcx.instantiate_type_scheme(span, free_substs, &method_ty);
+                    let predicates = fcx.instantiate_bounds(span, item.def_id, free_substs);
+                    let fty = match method_ty.sty {
+                        ty::TyFnDef(_, _, f) => f,
+                        _ => bug!()
+                    };
+                    this.check_fn_or_method(fcx, span, fty, &predicates,
                                             free_id_outlive, &mut implied_bounds);
                     let sig_if_method = sig_if_method.expect("bad signature for method");
-                    this.check_method_receiver(fcx, sig_if_method, &method,
+                    this.check_method_receiver(fcx, sig_if_method, &item,
                                                free_id_outlive, self_ty);
                 }
-                ty::TypeTraitItem(assoc_type) => {
-                    if let Some(ref ty) = assoc_type.ty {
-                        let ty = fcx.instantiate_type_scheme(span, free_substs, ty);
+                ty::AssociatedKind::Type => {
+                    if item.has_value {
+                        let ty = fcx.tcx.lookup_item_type(item.def_id).ty;
+                        let ty = fcx.instantiate_type_scheme(span, free_substs, &ty);
                         fcx.register_wf_obligation(ty, span, code.clone());
                     }
                 }
@@ -248,19 +257,15 @@ impl<'ccx, 'gcx> CheckTypeWellFormedVisitor<'ccx, 'gcx> {
             }
 
             let free_substs = &fcx.parameter_environment.free_substs;
-            let predicates = fcx.tcx.lookup_predicates(fcx.tcx.map.local_def_id(item.id));
-            let predicates = fcx.instantiate_bounds(item.span, free_substs, &predicates);
+            let def_id = fcx.tcx.map.local_def_id(item.id);
+            let predicates = fcx.instantiate_bounds(item.span, def_id, free_substs);
             this.check_where_clauses(fcx, item.span, &predicates);
 
             vec![] // no implied bounds in a struct def'n
         });
     }
 
-    fn check_auto_trait(&mut self,
-                        trait_def_id: DefId,
-                        items: &[hir::TraitItem],
-                        span: Span)
-    {
+    fn check_auto_trait(&mut self, trait_def_id: DefId, span: Span) {
         // We want to ensure:
         //
         // 1) that there are no items contained within
@@ -302,7 +307,7 @@ impl<'ccx, 'gcx> CheckTypeWellFormedVisitor<'ccx, 'gcx> {
         // extraneous predicates created by things like
         // an associated type inside the trait.
         let mut err = None;
-        if !items.is_empty() {
+        if !self.tcx().associated_item_def_ids(trait_def_id).is_empty() {
             error_380(self.ccx, span);
         } else if has_ty_params {
             err = Some(struct_span_err!(self.tcx().sess, span, E0567,
@@ -326,20 +331,16 @@ impl<'ccx, 'gcx> CheckTypeWellFormedVisitor<'ccx, 'gcx> {
         }
     }
 
-    fn check_trait(&mut self,
-                   item: &hir::Item,
-                   items: &[hir::TraitItem])
-    {
+    fn check_trait(&mut self, item: &hir::Item) {
         let trait_def_id = self.tcx().map.local_def_id(item.id);
 
         if self.tcx().trait_has_default_impl(trait_def_id) {
-            self.check_auto_trait(trait_def_id, items, item.span);
+            self.check_auto_trait(trait_def_id, item.span);
         }
 
         self.for_item(item).with_fcx(|fcx, this| {
             let free_substs = &fcx.parameter_environment.free_substs;
-            let predicates = fcx.tcx.lookup_predicates(trait_def_id);
-            let predicates = fcx.instantiate_bounds(item.span, free_substs, &predicates);
+            let predicates = fcx.instantiate_bounds(item.span, trait_def_id, free_substs);
             this.check_where_clauses(fcx, item.span, &predicates);
             vec![]
         });
@@ -351,7 +352,8 @@ impl<'ccx, 'gcx> CheckTypeWellFormedVisitor<'ccx, 'gcx> {
     {
         self.for_item(item).with_fcx(|fcx, this| {
             let free_substs = &fcx.parameter_environment.free_substs;
-            let type_scheme = fcx.tcx.lookup_item_type(fcx.tcx.map.local_def_id(item.id));
+            let def_id = fcx.tcx.map.local_def_id(item.id);
+            let type_scheme = fcx.tcx.lookup_item_type(def_id);
             let item_ty = fcx.instantiate_type_scheme(item.span, free_substs, &type_scheme.ty);
             let bare_fn_ty = match item_ty.sty {
                 ty::TyFnDef(.., ref bare_fn_ty) => bare_fn_ty,
@@ -360,8 +362,7 @@ impl<'ccx, 'gcx> CheckTypeWellFormedVisitor<'ccx, 'gcx> {
                 }
             };
 
-            let predicates = fcx.tcx.lookup_predicates(fcx.tcx.map.local_def_id(item.id));
-            let predicates = fcx.instantiate_bounds(item.span, free_substs, &predicates);
+            let predicates = fcx.instantiate_bounds(item.span, def_id, free_substs);
 
             let mut implied_bounds = vec![];
             let free_id_outlive = fcx.tcx.region_maps.call_site_extent(item.id, body.id);
@@ -422,8 +423,7 @@ impl<'ccx, 'gcx> CheckTypeWellFormedVisitor<'ccx, 'gcx> {
                 }
             }
 
-            let predicates = fcx.tcx.lookup_predicates(item_def_id);
-            let predicates = fcx.instantiate_bounds(item.span, free_substs, &predicates);
+            let predicates = fcx.instantiate_bounds(item.span, item_def_id, free_substs);
             this.check_where_clauses(fcx, item.span, &predicates);
 
             fcx.impl_implied_bounds(fcx.tcx.map.local_def_id(item.id), item.span)
@@ -476,35 +476,39 @@ impl<'ccx, 'gcx> CheckTypeWellFormedVisitor<'ccx, 'gcx> {
     fn check_method_receiver<'fcx, 'tcx>(&mut self,
                                          fcx: &FnCtxt<'fcx, 'gcx, 'tcx>,
                                          method_sig: &hir::MethodSig,
-                                         method: &ty::Method<'tcx>,
+                                         method: &ty::AssociatedItem,
                                          free_id_outlive: CodeExtent,
                                          self_ty: ty::Ty<'tcx>)
     {
         // check that the type of the method's receiver matches the
         // method's first parameter.
-        debug!("check_method_receiver({:?},cat={:?},self_ty={:?})",
-               method.name, method.explicit_self, self_ty);
+        debug!("check_method_receiver({:?}, self_ty={:?})",
+               method, self_ty);
 
-        let rcvr_ty = match method.explicit_self {
-            ty::ExplicitSelfCategory::Static => return,
-            ty::ExplicitSelfCategory::ByValue => self_ty,
-            ty::ExplicitSelfCategory::ByReference(region, mutability) => {
-                fcx.tcx.mk_ref(region, ty::TypeAndMut {
-                    ty: self_ty,
-                    mutbl: mutability
-                })
-            }
-            ty::ExplicitSelfCategory::ByBox => fcx.tcx.mk_box(self_ty)
-        };
+        if !method.method_has_self_argument {
+            return;
+        }
 
         let span = method_sig.decl.inputs[0].pat.span;
 
         let free_substs = &fcx.parameter_environment.free_substs;
-        let fty = fcx.instantiate_type_scheme(span, free_substs, &method.fty);
-        let sig = fcx.tcx.liberate_late_bound_regions(free_id_outlive, &fty.sig);
+        let method_ty = fcx.tcx.lookup_item_type(method.def_id).ty;
+        let fty = fcx.instantiate_type_scheme(span, free_substs, &method_ty);
+        let sig = fcx.tcx.liberate_late_bound_regions(free_id_outlive, &fty.fn_sig());
 
         debug!("check_method_receiver: sig={:?}", sig);
 
+        let self_arg_ty = sig.inputs[0];
+        let rcvr_ty = match ExplicitSelf::determine(self_ty, self_arg_ty) {
+            ExplicitSelf::ByValue => self_ty,
+            ExplicitSelf::ByReference(region, mutbl) => {
+                fcx.tcx.mk_ref(region, ty::TypeAndMut {
+                    ty: self_ty,
+                    mutbl: mutbl
+                })
+            }
+            ExplicitSelf::ByBox => fcx.tcx.mk_box(self_ty)
+        };
         let rcvr_ty = fcx.instantiate_type_scheme(span, free_substs, &rcvr_ty);
         let rcvr_ty = fcx.tcx.liberate_late_bound_regions(free_id_outlive,
                                                           &ty::Binder(rcvr_ty));
@@ -512,7 +516,7 @@ impl<'ccx, 'gcx> CheckTypeWellFormedVisitor<'ccx, 'gcx> {
         debug!("check_method_receiver: receiver ty = {:?}", rcvr_ty);
 
         let origin = TypeOrigin::MethodReceiver(span);
-        fcx.demand_eqtype_with_origin(origin, rcvr_ty, sig.inputs[0]);
+        fcx.demand_eqtype_with_origin(origin, rcvr_ty, self_arg_ty);
     }
 
     fn check_variances_for_type_defn(&self,
@@ -578,7 +582,8 @@ impl<'ccx, 'gcx> CheckTypeWellFormedVisitor<'ccx, 'gcx> {
     }
 }
 
-fn reject_shadowing_type_parameters(tcx: TyCtxt, span: Span, generics: &ty::Generics) {
+fn reject_shadowing_type_parameters(tcx: TyCtxt, span: Span, def_id: DefId) {
+    let generics = tcx.lookup_generics(def_id);
     let parent = tcx.lookup_generics(generics.parent.unwrap());
     let impl_params: FxHashMap<_, _> = parent.types
                                        .iter()

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -66,7 +66,7 @@ use middle::const_val::ConstVal;
 use rustc_const_eval::EvalHint::UncheckedExprHint;
 use rustc_const_eval::{eval_const_expr_partial, report_const_eval_err};
 use rustc::ty::subst::Substs;
-use rustc::ty::{ToPredicate, ImplContainer, ImplOrTraitItemContainer, TraitContainer};
+use rustc::ty::{ToPredicate, ImplContainer, AssociatedItemContainer, TraitContainer};
 use rustc::ty::{self, AdtKind, ToPolyTraitRef, Ty, TyCtxt, TypeScheme};
 use rustc::ty::util::IntTypeExt;
 use rscope::*;
@@ -79,7 +79,6 @@ use rustc_const_math::ConstInt;
 
 use std::cell::RefCell;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
-use std::rc::Rc;
 
 use syntax::{abi, ast, attr};
 use syntax::parse::token::keywords;
@@ -351,24 +350,6 @@ impl<'a, 'tcx> AstConv<'tcx, 'tcx> for ItemCtxt<'a, 'tcx> {
         })
     }
 
-    fn trait_defines_associated_type_named(&self,
-                                           trait_def_id: DefId,
-                                           assoc_name: ast::Name)
-                                           -> bool
-    {
-        if let Some(trait_id) = self.tcx().map.as_local_node_id(trait_def_id) {
-            trait_associated_type_names(self.tcx(), trait_id)
-                .any(|name| name == assoc_name)
-        } else {
-            self.tcx().impl_or_trait_items(trait_def_id).iter().any(|&def_id| {
-                match self.tcx().impl_or_trait_item(def_id) {
-                    ty::TypeTraitItem(ref item) => item.name == assoc_name,
-                    _ => false
-                }
-            })
-        }
-    }
-
     fn get_free_substs(&self) -> Option<&Substs<'tcx>> {
         None
     }
@@ -557,60 +538,6 @@ fn is_param<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     }
 }
 
-fn convert_method<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
-                            container: ImplOrTraitItemContainer,
-                            name: ast::Name,
-                            id: ast::NodeId,
-                            vis: &hir::Visibility,
-                            sig: &hir::MethodSig,
-                            defaultness: hir::Defaultness,
-                            has_body: bool,
-                            untransformed_rcvr_ty: Ty<'tcx>,
-                            rcvr_ty_predicates: &ty::GenericPredicates<'tcx>) {
-    let def_id = ccx.tcx.map.local_def_id(id);
-    let ty_generics = generics_of_def_id(ccx, def_id);
-
-    let ty_generic_predicates =
-        ty_generic_predicates(ccx, &sig.generics, ty_generics.parent, vec![], false);
-
-    let (fty, explicit_self_category) = {
-        let anon_scope = match container {
-            ImplContainer(_) => Some(AnonTypeScope::new(def_id)),
-            TraitContainer(_) => None
-        };
-        AstConv::ty_of_method(&ccx.icx(&(rcvr_ty_predicates, &sig.generics)),
-                              sig, untransformed_rcvr_ty, anon_scope)
-    };
-
-    let ty_method = ty::Method {
-        name: name,
-        generics: ty_generics,
-        predicates: ty_generic_predicates,
-        fty: fty,
-        explicit_self: explicit_self_category,
-        vis: ty::Visibility::from_hir(vis, id, ccx.tcx),
-        defaultness: defaultness,
-        has_body: has_body,
-        def_id: def_id,
-        container: container,
-    };
-
-    let substs = mk_item_substs(&ccx.icx(&(rcvr_ty_predicates, &sig.generics)),
-                                ccx.tcx.map.span(id), def_id);
-    let fty = ccx.tcx.mk_fn_def(def_id, substs, ty_method.fty);
-    debug!("method {} (id {}) has type {:?}",
-            name, id, fty);
-    ccx.tcx.tcache.borrow_mut().insert(def_id, fty);
-    write_ty_to_tcx(ccx, id, fty);
-    ccx.tcx.predicates.borrow_mut().insert(def_id, ty_method.predicates.clone());
-
-    debug!("writing method type: def_id={:?} mty={:?}",
-            def_id, ty_method);
-
-    ccx.tcx.impl_or_trait_items.borrow_mut().insert(def_id,
-        ty::MethodTraitItem(Rc::new(ty_method)));
-}
-
 fn convert_field<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                            struct_generics: &'tcx ty::Generics<'tcx>,
                            struct_predicates: &ty::GenericPredicates<'tcx>,
@@ -631,62 +558,65 @@ fn convert_field<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                            struct_predicates.clone());
 }
 
+fn convert_method<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
+                            container: AssociatedItemContainer,
+                            id: ast::NodeId,
+                            sig: &hir::MethodSig,
+                            untransformed_rcvr_ty: Ty<'tcx>,
+                            rcvr_ty_predicates: &ty::GenericPredicates<'tcx>) {
+    let def_id = ccx.tcx.map.local_def_id(id);
+    let ty_generics = generics_of_def_id(ccx, def_id);
+
+    let ty_generic_predicates =
+        ty_generic_predicates(ccx, &sig.generics, ty_generics.parent, vec![], false);
+
+    let anon_scope = match container {
+        ImplContainer(_) => Some(AnonTypeScope::new(def_id)),
+        TraitContainer(_) => None
+    };
+    let fty = AstConv::ty_of_method(&ccx.icx(&(rcvr_ty_predicates, &sig.generics)),
+                                    sig, untransformed_rcvr_ty, anon_scope);
+
+    let substs = mk_item_substs(&ccx.icx(&(rcvr_ty_predicates, &sig.generics)),
+                                ccx.tcx.map.span(id), def_id);
+    let fty = ccx.tcx.mk_fn_def(def_id, substs, fty);
+    ccx.tcx.tcache.borrow_mut().insert(def_id, fty);
+    write_ty_to_tcx(ccx, id, fty);
+    ccx.tcx.predicates.borrow_mut().insert(def_id, ty_generic_predicates);
+}
+
 fn convert_associated_const<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
-                                      container: ImplOrTraitItemContainer,
-                                      name: ast::Name,
+                                      container: AssociatedItemContainer,
                                       id: ast::NodeId,
-                                      vis: &hir::Visibility,
-                                      defaultness: hir::Defaultness,
-                                      ty: ty::Ty<'tcx>,
-                                      has_value: bool)
+                                      ty: ty::Ty<'tcx>)
 {
     let predicates = ty::GenericPredicates {
         parent: Some(container.id()),
         predicates: vec![]
     };
-    ccx.tcx.predicates.borrow_mut().insert(ccx.tcx.map.local_def_id(id),
-                                           predicates);
+    let def_id = ccx.tcx.map.local_def_id(id);
+    ccx.tcx.predicates.borrow_mut().insert(def_id, predicates);
+    ccx.tcx.tcache.borrow_mut().insert(def_id, ty);
 
     write_ty_to_tcx(ccx, id, ty);
-
-    let associated_const = Rc::new(ty::AssociatedConst {
-        name: name,
-        vis: ty::Visibility::from_hir(vis, id, ccx.tcx),
-        defaultness: defaultness,
-        def_id: ccx.tcx.map.local_def_id(id),
-        container: container,
-        ty: ty,
-        has_value: has_value
-    });
-    ccx.tcx.impl_or_trait_items.borrow_mut()
-       .insert(ccx.tcx.map.local_def_id(id), ty::ConstTraitItem(associated_const));
 }
 
 fn convert_associated_type<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
-                                     container: ImplOrTraitItemContainer,
-                                     name: ast::Name,
+                                     container: AssociatedItemContainer,
                                      id: ast::NodeId,
-                                     vis: &hir::Visibility,
-                                     defaultness: hir::Defaultness,
                                      ty: Option<Ty<'tcx>>)
 {
     let predicates = ty::GenericPredicates {
         parent: Some(container.id()),
         predicates: vec![]
     };
-    ccx.tcx.predicates.borrow_mut().insert(ccx.tcx.map.local_def_id(id),
-                                           predicates);
+    let def_id = ccx.tcx.map.local_def_id(id);
+    ccx.tcx.predicates.borrow_mut().insert(def_id, predicates);
 
-    let associated_type = Rc::new(ty::AssociatedType {
-        name: name,
-        vis: ty::Visibility::from_hir(vis, id, ccx.tcx),
-        defaultness: defaultness,
-        ty: ty,
-        def_id: ccx.tcx.map.local_def_id(id),
-        container: container
-    });
-    ccx.tcx.impl_or_trait_items.borrow_mut()
-       .insert(ccx.tcx.map.local_def_id(id), ty::TypeTraitItem(associated_type));
+    if let Some(ty) = ty {
+        ccx.tcx.tcache.borrow_mut().insert(def_id, ty);
+        write_ty_to_tcx(ccx, id, ty);
+    }
 }
 
 fn ensure_no_ty_param_bounds(ccx: &CrateCtxt,
@@ -820,14 +750,8 @@ fn convert_item(ccx: &CrateCtxt, it: &hir::Item) {
                                                generics: ty_generics,
                                                ty: ty,
                                            });
-                    // Trait-associated constants are always public.
-                    let public = &hir::Public;
-                    let visibility = if opt_trait_ref.is_some() { public } else { &impl_item.vis };
                     convert_associated_const(ccx, ImplContainer(def_id),
-                                             impl_item.name, impl_item.id,
-                                             visibility,
-                                             impl_item.defaultness,
-                                             ty, true /* has_value */);
+                                             impl_item.id, ty);
                 }
             }
 
@@ -844,21 +768,14 @@ fn convert_item(ccx: &CrateCtxt, it: &hir::Item) {
 
                     let typ = ccx.icx(&ty_predicates).to_ty(&ExplicitRscope, ty);
 
-                    convert_associated_type(ccx, ImplContainer(def_id),
-                                            impl_item.name, impl_item.id, &impl_item.vis,
-                                            impl_item.defaultness, Some(typ));
+                    convert_associated_type(ccx, ImplContainer(def_id), impl_item.id, Some(typ));
                 }
             }
 
             for impl_item in impl_items {
                 if let hir::ImplItemKind::Method(ref sig, _) = impl_item.node {
-                    // Trait methods are always public.
-                    let public = &hir::Public;
-                    let method_vis = if opt_trait_ref.is_some() { public } else { &impl_item.vis };
-
                     convert_method(ccx, ImplContainer(def_id),
-                                   impl_item.name, impl_item.id, method_vis,
-                                   sig, impl_item.defaultness, true, selfty,
+                                   impl_item.id, sig, selfty,
                                    &ty_predicates);
                 }
             }
@@ -880,7 +797,7 @@ fn convert_item(ccx: &CrateCtxt, it: &hir::Item) {
 
             // Convert all the associated constants.
             for trait_item in trait_items {
-                if let hir::ConstTraitItem(ref ty, ref default) = trait_item.node {
+                if let hir::ConstTraitItem(ref ty, _) = trait_item.node {
                     let const_def_id = ccx.tcx.map.local_def_id(trait_item.id);
                     let ty_generics = generics_of_def_id(ccx, const_def_id);
                     let ty = ccx.icx(&trait_predicates)
@@ -890,14 +807,7 @@ fn convert_item(ccx: &CrateCtxt, it: &hir::Item) {
                                                generics: ty_generics,
                                                ty: ty,
                                            });
-                    convert_associated_const(ccx,
-                                             container,
-                                             trait_item.name,
-                                             trait_item.id,
-                                             &hir::Public,
-                                             hir::Defaultness::Default,
-                                             ty,
-                                             default.is_some())
+                    convert_associated_const(ccx, container, trait_item.id, ty)
                 }
             }
 
@@ -911,39 +821,21 @@ fn convert_item(ccx: &CrateCtxt, it: &hir::Item) {
                         |ty| ccx.icx(&trait_predicates).to_ty(&ExplicitRscope, &ty)
                     });
 
-                    convert_associated_type(ccx,
-                                            container,
-                                            trait_item.name,
-                                            trait_item.id,
-                                            &hir::Public,
-                                            hir::Defaultness::Default,
-                                            typ);
+                    convert_associated_type(ccx, container, trait_item.id, typ);
                 }
             }
 
             // Convert all the methods
             for trait_item in trait_items {
-                if let hir::MethodTraitItem(ref sig, ref body) = trait_item.node {
+                if let hir::MethodTraitItem(ref sig, _) = trait_item.node {
                     convert_method(ccx,
                                    container,
-                                   trait_item.name,
                                    trait_item.id,
-                                   &hir::Inherited,
                                    sig,
-                                   hir::Defaultness::Default,
-                                   body.is_some(),
                                    tcx.mk_self_type(),
                                    &trait_predicates);
-
                 }
             }
-
-            // Add an entry mapping
-            let trait_item_def_ids = Rc::new(trait_items.iter().map(|trait_item| {
-                ccx.tcx.map.local_def_id(trait_item.id)
-            }).collect());
-            tcx.impl_or_trait_item_def_ids.borrow_mut().insert(ccx.tcx.map.local_def_id(it.id),
-                                                               trait_item_def_ids);
         },
         hir::ItemStruct(ref struct_def, _) |
         hir::ItemUnion(ref struct_def, _) => {
@@ -1306,28 +1198,6 @@ fn trait_def_of_item<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                       def_path_hash);
 
     tcx.intern_trait_def(trait_def)
-}
-
-pub fn trait_associated_type_names<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
-                                                   trait_node_id: ast::NodeId)
-                                                   -> impl Iterator<Item=ast::Name> + 'a
-{
-    let item = match tcx.map.get(trait_node_id) {
-        hir_map::NodeItem(item) => item,
-        _ => bug!("trait_node_id {} is not an item", trait_node_id)
-    };
-
-    let trait_items = match item.node {
-        hir::ItemTrait(.., ref trait_items) => trait_items,
-        _ => bug!("trait_node_id {} is not a trait", trait_node_id)
-    };
-
-    trait_items.iter().filter_map(|trait_item| {
-        match trait_item.node {
-            hir::TypeTraitItem(..) => Some(trait_item.name),
-            _ => None,
-        }
-    })
 }
 
 fn convert_trait_predicates<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>, it: &hir::Item) {
@@ -2209,13 +2079,14 @@ fn enforce_impl_lifetimes_are_constrained<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
         &impl_predicates.predicates.as_slice(), impl_trait_ref, &mut input_parameters);
 
     let lifetimes_in_associated_types: FxHashSet<_> = impl_items.iter()
-        .map(|item| ccx.tcx.impl_or_trait_item(ccx.tcx.map.local_def_id(item.id)))
-        .filter_map(|item| match item {
-            ty::TypeTraitItem(ref assoc_ty) => assoc_ty.ty,
-            ty::ConstTraitItem(..) | ty::MethodTraitItem(..) => None
+        .map(|item|  ccx.tcx.map.local_def_id(item.id))
+        .filter(|&def_id| {
+            let item = ccx.tcx.associated_item(def_id);
+            item.kind == ty::AssociatedKind::Type && item.has_value
         })
-        .flat_map(|ty| ctp::parameters_for(&ty, true))
-        .collect();
+        .flat_map(|def_id| {
+            ctp::parameters_for(&ccx.tcx.lookup_item_type(def_id).ty, true)
+        }).collect();
 
     for (ty_lifetime, lifetime) in impl_scheme.generics.regions.iter()
         .zip(&ast_generics.lifetimes)


### PR DESCRIPTION
_This is part of a series ([prev](https://github.com/rust-lang/rust/pull/37401) | [next](https://github.com/rust-lang/rust/pull/37404)) of patches designed to rework rustc into an out-of-order on-demand pipeline model for both better feature support (e.g. [MIR-based](https://github.com/solson/miri) early constant evaluation) and incremental execution of compiler passes (e.g. type-checking), with beneficial consequences to IDE support as well.
If any motivation is unclear, please ask for additional PR description clarifications or code comments._

<hr>

`ImplOrTraitItem`/`impl_or_trait_item` have been renamed to `AssociatedItem`/`associated_item`.

The common fields from (what used to be) `ty::ImplOrTraitItem`'s variants have been pulled out, leaving only an `AssociatedKind` C-like enum to distinguish between methods, constants and types.

The type information has been removed from `AssociatedItem`, and as such the latter can now be computed on-demand from the local HIR map, i.e. an extern-crate-enabled `TraitItem | ImplItem`.
It may be moved to HIR in the future, if we intend to start using HIR types cross-crate.

`ty::ExplicitSelfCategory` has been moved to `rustc_typeck` and is produced on-demand from the signature of the method, and a `method_has_self_argument` field on `AssociatedItem`, which is used to indicate that the first argument is a sugary "method receiver" and as such, method call syntax can be used.
