### PR TITLE
Improved error reporting when target sysroot is missing.

### DIFF
--- a/src/librustc_metadata/locator.rs
+++ b/src/librustc_metadata/locator.rs
@@ -217,7 +217,7 @@ use creader::Library;
 use schema::{METADATA_HEADER, rustc_version};
 
 use rustc::hir::svh::Svh;
-use rustc::session::Session;
+use rustc::session::{config, Session};
 use rustc::session::filesearch::{FileSearch, FileMatches, FileDoesntMatch};
 use rustc::session::search_paths::PathKind;
 use rustc::util::common;
@@ -355,6 +355,11 @@ impl<'a> Context<'a> {
                                            "can't find crate for `{}`{}",
                                            self.ident,
                                            add);
+
+            if (self.ident == "std" || self.ident == "core")
+                && self.triple != config::host_triple() {
+                err.note(&format!("the `{}` target may not be installed", self.triple));
+            }
             err.span_label(self.span, &format!("can't find crate"));
             err
         };

--- a/src/test/compile-fail/issue-37131.rs
+++ b/src/test/compile-fail/issue-37131.rs
@@ -1,0 +1,18 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests that compiling for a target which is not installed will result in a helpful
+// error message.
+
+// compile-flags: --target=s390x-unknown-linux-gnu
+// ignore s390x
+
+// error-pattern:target may not be installed
+fn main() { }

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1334,8 +1334,18 @@ actual:\n\
         // FIXME (#9639): This needs to handle non-utf8 paths
         let mut args = vec![input_file.to_str().unwrap().to_owned(),
                             "-L".to_owned(),
-                            self.config.build_base.to_str().unwrap().to_owned(),
-                            format!("--target={}", target)];
+                            self.config.build_base.to_str().unwrap().to_owned()];
+
+        // Optionally prevent default --target if specified in test compile-flags.
+        let custom_target = self.props.compile_flags
+            .iter()
+            .fold(false, |acc, ref x| acc || x.starts_with("--target"));
+
+        if !custom_target {
+            args.extend(vec![
+                format!("--target={}", target),
+            ]);
+        }
 
         if let Some(revision) = self.revision {
             args.extend(vec![


### PR DESCRIPTION
Attempts to resolve #37131.
This is my first pull request on rust, so I would greatly appreciate any feedback you have on this.

Thanks! 
