### PR TITLE
Add error note to illegal code snippet

### DIFF
--- a/src/doc/book/structs.md
+++ b/src/doc/book/structs.md
@@ -61,7 +61,7 @@ write something like this:
 
 ```rust,ignore
 struct Point {
-    mut x: i32,
+    mut x: i32, // This causes an error.
     y: i32,
 }
 ```


### PR DESCRIPTION
Mark intentionally invalid code snippet in documentation as such with a comment. Similar comments used elsewhere in this file.

r? @steveklabnik 
