### PR TITLE
remove `-Z input-stats`; replace with logging

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -823,8 +823,6 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
         "The output of `-Z time-llvm-passes` will only reflect timings of \
          re-translated modules when used with incremental compilation" )],
         "measure time of each LLVM pass"),
-    input_stats: bool = (false, parse_bool, [UNTRACKED],
-        "gather statistics about the input"),
     trans_stats: bool = (false, parse_bool, [UNTRACKED_WITH_WARNING(true,
         "The output of `-Z trans-stats` might not be accurate when incremental \
          compilation is enabled")],
@@ -2334,8 +2332,6 @@ mod tests {
         opts.debugging_opts.count_llvm_insns = true;
         assert_eq!(reference.dep_tracking_hash(), opts.dep_tracking_hash());
         opts.debugging_opts.time_llvm_passes = true;
-        assert_eq!(reference.dep_tracking_hash(), opts.dep_tracking_hash());
-        opts.debugging_opts.input_stats = true;
         assert_eq!(reference.dep_tracking_hash(), opts.dep_tracking_hash());
         opts.debugging_opts.trans_stats = true;
         assert_eq!(reference.dep_tracking_hash(), opts.dep_tracking_hash());

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -518,10 +518,8 @@ pub fn phase_1_parse_input<'a>(sess: &'a Session,
         println!("{}", json::as_json(&krate));
     }
 
-    if sess.opts.debugging_opts.input_stats {
-        println!("Lines of code:             {}", sess.codemap().count_lines());
-        println!("Pre-expansion node count:  {}", count_nodes(&krate));
-    }
+    info!("Lines of code:             {}", sess.codemap().count_lines());
+    info!("Pre-expansion node count:  {}", count_nodes(&krate));
 
     if let Some(ref s) = sess.opts.debugging_opts.show_span {
         syntax::show_span::run(sess.diagnostic(), s, &krate);
@@ -728,9 +726,7 @@ pub fn phase_2_configure_and_expand<'a, F>(sess: &Session,
         });
     }
 
-    if sess.opts.debugging_opts.input_stats {
-        println!("Post-expansion node count: {}", count_nodes(&krate));
-    }
+    info!("Post-expansion node count: {}", count_nodes(&krate));
 
     if sess.opts.debugging_opts.ast_json {
         println!("{}", json::as_json(&krate));


### PR DESCRIPTION
In Issue #34121, it was suggested that the `input-stats` debugging command-line flag could be replaced with logging.

**Before:**

```
$ rustc -Z input-stats scratch.rs
Lines of code:             5
Pre-expansion node count:  13
Post-expansion node count: 106
```

**After:**

```
$ RUST_LOG='rustc_driver=info' ./x86_64-unknown-linux-gnu/stage1/bin/rustc scratch.rs | grep ::
INFO:rustc_driver::driver: Lines of code:             5
INFO:rustc_driver::driver: Pre-expansion node count:  13
INFO:rustc_driver::driver: Post-expansion node count: 106
$ ./x86_64-unknown-linux-gnu/stage1/bin/rustc -Z input-stats scratch.rs
error: unknown debugging option: `input-stats`
```

---

You might wonder why the diff uses `info!` logging rather than `debug!` logging, as the issue suggested! It's because when I try to use `debug!`, it doesn't work: the messages don't get output even with `RUST_LOG=debug` or similar. I have no idea why this should be.
