### PR TITLE
Point to type argument span when used as trait

### DIFF
--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -399,6 +399,14 @@ impl Generics {
     pub fn is_parameterized(&self) -> bool {
         self.is_lt_parameterized() || self.is_type_parameterized()
     }
+    pub fn span_for_name(&self, name: &str) -> Option<Span> {
+        for t in &self.ty_params {
+            if t.ident.name.as_str() == name {
+                return Some(t.span);
+            }
+        }
+        None
+    }
 }
 
 impl Default for Generics {

--- a/src/test/compile-fail/issue-3907.rs
+++ b/src/test/compile-fail/issue-3907.rs
@@ -18,7 +18,7 @@ struct S {
 }
 
 impl Foo for S { //~ ERROR: `Foo` is not a trait
-                 //~| NOTE: not a trait
+                 //~| NOTE: expected trait, found type alias
                  //~| NOTE: type aliases cannot be used for traits
     fn bar() { }
 }

--- a/src/test/compile-fail/issue-5035.rs
+++ b/src/test/compile-fail/issue-5035.rs
@@ -11,7 +11,7 @@
 trait I {}
 type K = I;
 impl K for isize {} //~ ERROR: `K` is not a trait
-                    //~| NOTE: not a trait
+                    //~| NOTE: expected trait, found type alias
                     //~| NOTE: aliases cannot be used for traits
 
 use ImportError; //~ ERROR unresolved import `ImportError` [E0432]

--- a/src/test/ui/codemap_tests/two_files.stderr
+++ b/src/test/ui/codemap_tests/two_files.stderr
@@ -2,7 +2,7 @@ error[E0404]: `Bar` is not a trait
   --> $DIR/two_files.rs:15:6
    |
 15 | impl Bar for Baz { }
-   |      ^^^ not a trait
+   |      ^^^ expected trait, found type alias
    |
    = note: type aliases cannot be used for traits
 

--- a/src/test/ui/span/issue-35987.rs
+++ b/src/test/ui/span/issue-35987.rs
@@ -1,0 +1,21 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo<T: Clone>(T);
+
+use std::ops::Add;
+
+impl<T: Clone, Add> Add for Foo<T> {
+    type Output = usize;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        unimplemented!();
+    }
+}

--- a/src/test/ui/span/issue-35987.stderr
+++ b/src/test/ui/span/issue-35987.stderr
@@ -1,0 +1,12 @@
+error[E0404]: `Add` is not a trait
+  --> $DIR/issue-35987.rs:15:21
+   |
+15 | impl<T: Clone, Add> Add for Foo<T> {
+   |                ---  ^^^ expected trait, found type parameter
+   |                |
+   |                type parameter defined here
+
+error: main function not found
+
+error: cannot continue compilation due to previous error
+


### PR DESCRIPTION
Given the following code:

``` rust
struct Foo<T: Clone>(T);

use std::ops::Add;

impl<T: Clone, Add> Add for Foo<T> {
  type Output = usize;

  fn add(self, rhs: Self) -> Self::Output {
    unimplemented!();
  }
}
```

present the following output:

``` nocode
error[E0404]: `Add` is not a trait
 --> file3.rs:5:21
  |
5 | impl<T: Clone, Add> Add for Okok<T> {
  |                ---  ^^^ expected trait, found type parameter
  |                |
  |                type parameter defined here
```

Fixes #35987.
