### PR TITLE
Add semicolon to "Maybe a missing `extern crate foo`" message

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1412,7 +1412,7 @@ impl<'a> Resolver<'a> {
 
                                 format!("Did you mean `{}{}`?", prefix, path_str)
                             }
-                            None => format!("Maybe a missing `extern crate {}`?", segment_name),
+                            None => format!("Maybe a missing `extern crate {};`?", segment_name),
                         }
                     } else {
                         format!("Could not find `{}` in `{}`", segment_name, module_name)

--- a/src/test/compile-fail/issue-12612.rs
+++ b/src/test/compile-fail/issue-12612.rs
@@ -16,7 +16,7 @@ use foo::bar;
 
 mod test {
     use bar::foo; //~ ERROR unresolved import `bar::foo` [E0432]
-                  //~^ Maybe a missing `extern crate bar`?
+                  //~^ Maybe a missing `extern crate bar;`?
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-1697.rs
+++ b/src/test/compile-fail/issue-1697.rs
@@ -11,6 +11,6 @@
 // Testing that we don't fail abnormally after hitting the errors
 
 use unresolved::*; //~ ERROR unresolved import `unresolved::*` [E0432]
-                   //~^ Maybe a missing `extern crate unresolved`?
+                   //~^ Maybe a missing `extern crate unresolved;`?
 
 fn main() {}

--- a/src/test/compile-fail/unresolved-import.rs
+++ b/src/test/compile-fail/unresolved-import.rs
@@ -11,7 +11,7 @@
 // ignore-tidy-linelength
 
 use foo::bar; //~ ERROR unresolved import `foo::bar` [E0432]
-              //~^ Maybe a missing `extern crate foo`?
+              //~^ Maybe a missing `extern crate foo;`?
 
 use bar::Baz as x; //~ ERROR unresolved import `bar::Baz` [E0432]
                    //~^ no `Baz` in `bar`. Did you mean to use `Bar`?


### PR DESCRIPTION
I had it a couple of times that I was missing the "extern crate" line
after I introduced a new dependency. So I copied the text from the
message and inserted it into the beginning of my code, only to find the
compiler complaining that I was missing the semicolon. (I forgot to add
it after the text that I had pasted.)

There's a similar message which does include the semicolon, namely
"help: you can import it into scope: `use foo::Bar;`". I think the two
messages should be consistent, so this change adds it for "extern
crate".
