### PR TITLE
Give variant spans used in derives the correct expansion id

### DIFF
--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -166,6 +166,7 @@ impl<'l, 'tcx: 'l, 'll, D: Dump + 'll> DumpVisitor<'l, 'tcx, 'll, D> {
                        loc.file.name,
                        loc.line);
             }
+            error!("    master span: {:?}: `{}`", path.span, self.span.snippet(path.span));
             return vec!();
         }
 

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -1460,8 +1460,9 @@ impl<'a> MethodDef<'a> {
             .iter()
             .map(|v| {
                 let ident = v.node.name;
+                let sp = Span { expn_id: trait_.span.expn_id, ..v.span };
                 let summary = trait_.summarise_struct(cx, &v.node.data);
-                (ident, v.span, summary)
+                (ident, sp, summary)
             })
             .collect();
         self.call_substructure_method(cx,


### PR DESCRIPTION
This fixes a problem in save-analysis where it mistakes a path to a variant as the variant itself.

r? @petrochenkov 
