### PR TITLE
Track errors from resolving the crate.

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -766,8 +766,7 @@ pub fn phase_2_configure_and_expand<'a, F>(sess: &Session,
         // don't perform `after_expand` until after import resolution.
         after_expand(&krate)?;
 
-        resolver.resolve_crate(&krate);
-        Ok(())
+        sess.track_errors(|| resolver.resolve_crate(&krate))
     })?;
 
     // Lower ast -> hir.


### PR DESCRIPTION
Technically fixes the specific error case in #33525, but in an indirect way. I'm guessing this isn't the right fix and/or is an incomplete fix, but I hope that this will spur discussion/comments from @nrc (at least) to help me figure out what the best way of solving this sort of issue is, so I can apply it elsewhere when and if I encounter similar code to this in the driver.

With this, the output is:

```
error[E0425]: unresolved name `a`
 --> /tmp/t.rs:2:5
  |
2 |     a;
  |     ^ unresolved name
```

r? @nrc 
