### PR TITLE
Shrink Expr_::ExprInlineAsm.

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1218,7 +1218,7 @@ impl<'a> LoweringContext<'a> {
                         alignstack,
                         dialect,
                         expn_id,
-                    }) => hir::ExprInlineAsm(hir::InlineAsm {
+                    }) => hir::ExprInlineAsm(P(hir::InlineAsm {
                     inputs: inputs.iter().map(|&(ref c, _)| c.clone()).collect(),
                     outputs: outputs.iter()
                                     .map(|out| {
@@ -1236,7 +1236,7 @@ impl<'a> LoweringContext<'a> {
                     alignstack: alignstack,
                     dialect: dialect,
                     expn_id: expn_id,
-                }, outputs.iter().map(|out| self.lower_expr(&out.expr)).collect(),
+                }), outputs.iter().map(|out| self.lower_expr(&out.expr)).collect(),
                    inputs.iter().map(|&(_, ref input)| self.lower_expr(input)).collect()),
                 ExprKind::Struct(ref path, ref fields, ref maybe_expr) => {
                     hir::ExprStruct(self.lower_path(path),

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -940,7 +940,7 @@ pub enum Expr_ {
     ExprRet(Option<P<Expr>>),
 
     /// Inline assembly (from `asm!`), with its outputs and inputs.
-    ExprInlineAsm(InlineAsm, Vec<P<Expr>>, Vec<P<Expr>>),
+    ExprInlineAsm(P<InlineAsm>, HirVec<P<Expr>>, HirVec<P<Expr>>),
 
     /// A struct or struct-like variant literal expression.
     ///


### PR DESCRIPTION
On 64-bit this reduces the size of `Expr_` from 144 to 64 bytes, and
reduces the size of `Expr` from 176 to 96 bytes.

For the workload in #36799 this reduces the RSS for the "lowering ast -> hir" phase and all subsequent phases by 50 MiB, which reduces the peak RSS for that workload by about 1%. Not huge, but it's a very easy improvement.

r? @eddyb 
