### PR TITLE
Show one error for duplicated type definitions

### DIFF
--- a/src/test/compile-fail/E0428.rs
+++ b/src/test/compile-fail/E0428.rs
@@ -9,10 +9,7 @@
 // except according to those terms.
 
 struct Bar; //~ previous definition of `Bar` here
-            //~| previous definition of `Bar` here
 struct Bar; //~ ERROR E0428
-            //~| NOTE already defined
-            //~| ERROR E0428
             //~| NOTE already defined
 
 fn main () {

--- a/src/test/compile-fail/blind-item-block-item-shadow.rs
+++ b/src/test/compile-fail/blind-item-block-item-shadow.rs
@@ -14,7 +14,6 @@ fn main() {
     {
         struct Bar;
         use foo::Bar;
-        //~^ ERROR a type named `Bar` has already been defined in this block
-        //~^^ ERROR a value named `Bar` has already been defined in this block
+        //~^ ERROR a value named `Bar` has already been defined in this block
     }
 }

--- a/src/test/compile-fail/double-type-import.rs
+++ b/src/test/compile-fail/double-type-import.rs
@@ -12,7 +12,6 @@ mod foo {
     pub use self::bar::X;
     use self::bar::X;
     //~^ ERROR a value named `X` has already been imported in this module
-    //~| ERROR a type named `X` has already been imported in this module
 
     mod bar {
         pub struct X;

--- a/src/test/compile-fail/variant-namespacing.rs
+++ b/src/test/compile-fail/variant-namespacing.rs
@@ -33,17 +33,11 @@ const XUnit: u8 = 0;
 extern crate variant_namespacing;
 pub use variant_namespacing::XE::*;
 //~^ ERROR `XStruct` has already been defined
-//~| ERROR `XStruct` has already been defined
 //~| ERROR `XTuple` has already been defined
-//~| ERROR `XTuple` has already been defined
-//~| ERROR `XUnit` has already been defined
 //~| ERROR `XUnit` has already been defined
 pub use E::*;
 //~^ ERROR `Struct` has already been defined
-//~| ERROR `Struct` has already been defined
 //~| ERROR `Tuple` has already been defined
-//~| ERROR `Tuple` has already been defined
-//~| ERROR `Unit` has already been defined
 //~| ERROR `Unit` has already been defined
 
 fn main() {}


### PR DESCRIPTION
For the following code:

``` rustc
struct Bar;
struct Bar;

fn main () {
}
```

show

``` nocode
error[E0428]: a type named `Bar` has already been defined in this module
  --> src/test/compile-fail/E0428.rs:12:1
   |
11 | struct Bar;
   | ----------- previous definition of `Bar` here
12 | struct Bar;
   | ^^^^^^^^^^^

error: aborting due to previous error
```

instead of

``` nocode
error[E0428]: a type named `Bar` has already been defined in this module
  --> src/test/compile-fail/E0428.rs:12:1
   |
11 | struct Bar;
   | ----------- previous definition of `Bar` here
12 | struct Bar;
   | ^^^^^^^^^^^

error[E0428]: a value named `Bar` has already been defined in this module
  --> src/test/compile-fail/E0428.rs:12:1
   |
11 | struct Bar;
   | ----------- previous definition of `Bar` here
12 | struct Bar;
   | ^^^^^^^^^^^

error: aborting due to 2 previous errors
```

Fixes #35767.
