### PR TITLE
Add E0532 error explanation

### DIFF
--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -1461,6 +1461,47 @@ match r {
 ```
 "##,
 
+E0532: r##"
+Pattern arm did not match expected kind.
+
+Erroneous code example:
+
+```compile_fail,E0532
+enum State {
+    Succeeded,
+    Failed(String),
+}
+
+fn print_on_failure(state: &State) {
+    match *state {
+        // error: expected unit struct/variant or constant, found tuple
+        //        variant `State::Failed`
+        State::Failed => println!("Failed"),
+        _ => ()
+    }
+}
+```
+
+To fix this error, ensure the match arm kind is the same as the expression
+matched.
+
+Fixed example:
+
+```
+enum State {
+    Succeeded,
+    Failed(String),
+}
+
+fn print_on_failure(state: &State) {
+    match *state {
+        State::Failed(ref msg) => println!("Failed with {}", msg),
+        _ => ()
+    }
+}
+```
+"##,
+
 }
 
 register_diagnostics! {
@@ -1480,6 +1521,5 @@ register_diagnostics! {
 //  E0421, merged into 531
 //  E0422, merged into 531/532
     E0531, // unresolved pattern path kind `name`
-    E0532, // expected pattern path kind, found another pattern path kind
 //  E0427, merged into 530
 }


### PR DESCRIPTION
This resolves one of the error list in https://github.com/rust-lang/rust/issues/35347 - just because I stumbled over it today.

I assumed the error code should be removed from `register_diagnostics!` because it's now defined above.

Since that is my first code contribution, please check that all is in order. It would be helpful to know how to run the test for the `compile_fail,E0532` part. I did `make check-stage1-cfail NO_REBUILD=1` but that doesn't test the inlined example.

r? @GuillaumeGomez 
