### PR TITLE
Misc fixes for configure

### DIFF
--- a/configure
+++ b/configure
@@ -508,7 +508,7 @@ case $CFG_CPUTYPE in
         ;;
 
     armv7l)
-        CFG_CPUTYPE=arm
+        CFG_CPUTYPE=armv7
         CFG_OSTYPE="${CFG_OSTYPE}eabihf"
         ;;
 

--- a/configure
+++ b/configure
@@ -507,6 +507,11 @@ case $CFG_CPUTYPE in
         CFG_CPUTYPE=arm
         ;;
 
+    armv6l)
+        CFG_CPUTYPE=arm
+        CFG_OSTYPE="${CFG_OSTYPE}eabihf"
+        ;;
+
     armv7l)
         CFG_CPUTYPE=armv7
         CFG_OSTYPE="${CFG_OSTYPE}eabihf"


### PR DESCRIPTION
Currently,
`./configure` at armv6 machines ends up with

```
configure: error: unknown CPU type: armv6l
```

`./configure` at armv7 machines **silently** produces build for armv6 (compatible, but suboptimal)

```
configure: CFG_BUILD            := arm-unknown-linux-gnueabihf
```
