### PR TITLE
Don't mention "*" dependency version in guessing game example

### DIFF
--- a/src/doc/book/guessing-game.md
+++ b/src/doc/book/guessing-game.md
@@ -362,7 +362,6 @@ numbers. A bare number like above is actually shorthand for `^0.3.0`,
 meaning "anything compatible with 0.3.0".
 If we wanted to use only `0.3.0` exactly, we could say `rand="=0.3.0"`
 (note the two equal signs).
-And if we wanted to use the latest version we could use `rand="*"`.
 We could also use a range of versions.
 [Cargo’s documentation][cargodoc] contains more details.
 


### PR DESCRIPTION
It's a bad practice as far [RFC 1241](https://github.com/rust-lang/rfcs/blob/master/text/1241-no-wildcard-deps.md) is concerned, and introducing it in early tutorial may as well make it feel legitimate.
