### PR TITLE
make `alloc` and `collections` compilable for thumbv6m-none-eabi

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -74,6 +74,7 @@
 
 #![feature(allocator)]
 #![feature(box_syntax)]
+#![feature(cfg_target_has_atomic)]
 #![feature(coerce_unsized)]
 #![feature(const_fn)]
 #![feature(core_intrinsics)]
@@ -117,6 +118,7 @@ mod boxed {
 }
 #[cfg(test)]
 mod boxed_test;
+#[cfg(target_has_atomic = "ptr")]
 pub mod arc;
 pub mod rc;
 pub mod raw_vec;

--- a/src/liballoc/oom.rs
+++ b/src/liballoc/oom.rs
@@ -50,7 +50,6 @@ mod imp {
     pub fn set_oom_handler(handler: fn() -> !) {
         OOM_HANDLER.store(handler as *mut (), Ordering::SeqCst);
     }
-
 }
 
 #[cfg(not(target_has_atomic = "ptr"))]

--- a/src/liballoc/oom.rs
+++ b/src/liballoc/oom.rs
@@ -9,13 +9,8 @@
 // except according to those terms.
 
 #[cfg(target_has_atomic = "ptr")]
-use core::sync::atomic::{AtomicPtr, Ordering};
-#[cfg(target_has_atomic = "ptr")]
-use core::mem;
+pub use self::imp::set_oom_handler;
 use core::intrinsics;
-
-#[cfg(target_has_atomic = "ptr")]
-static OOM_HANDLER: AtomicPtr<()> = AtomicPtr::new(default_oom_handler as *mut ());
 
 fn default_oom_handler() -> ! {
     // The default handler can't do much more since we can't assume the presence
@@ -24,34 +19,44 @@ fn default_oom_handler() -> ! {
 }
 
 /// Common out-of-memory routine
-#[cfg(target_has_atomic = "ptr")]
 #[cold]
 #[inline(never)]
 #[unstable(feature = "oom", reason = "not a scrutinized interface",
            issue = "27700")]
 pub fn oom() -> ! {
-    let value = OOM_HANDLER.load(Ordering::SeqCst);
-    let handler: fn() -> ! = unsafe { mem::transmute(value) };
-    handler();
+    self::imp::oom()
 }
 
-/// Common out-of-memory routine
+#[cfg(target_has_atomic = "ptr")]
+mod imp {
+    use core::mem;
+    use core::sync::atomic::{AtomicPtr, Ordering};
+
+    static OOM_HANDLER: AtomicPtr<()> = AtomicPtr::new(super::default_oom_handler as *mut ());
+
+    #[inline(always)]
+    pub fn oom() -> ! {
+        let value = OOM_HANDLER.load(Ordering::SeqCst);
+        let handler: fn() -> ! = unsafe { mem::transmute(value) };
+        handler();
+    }
+
+    /// Set a custom handler for out-of-memory conditions
+    ///
+    /// To avoid recursive OOM failures, it is critical that the OOM handler does
+    /// not allocate any memory itself.
+    #[unstable(feature = "oom", reason = "not a scrutinized interface",
+               issue = "27700")]
+    pub fn set_oom_handler(handler: fn() -> !) {
+        OOM_HANDLER.store(handler as *mut (), Ordering::SeqCst);
+    }
+
+}
+
 #[cfg(not(target_has_atomic = "ptr"))]
-#[cold]
-#[inline(never)]
-#[unstable(feature = "oom", reason = "not a scrutinized interface",
-           issue = "27700")]
-pub fn oom() -> ! {
-    default_oom_handler()
-}
-
-/// Set a custom handler for out-of-memory conditions
-///
-/// To avoid recursive OOM failures, it is critical that the OOM handler does
-/// not allocate any memory itself.
-#[cfg(target_has_atomic = "ptr")]
-#[unstable(feature = "oom", reason = "not a scrutinized interface",
-           issue = "27700")]
-pub fn set_oom_handler(handler: fn() -> !) {
-    OOM_HANDLER.store(handler as *mut (), Ordering::SeqCst);
+mod imp {
+    #[inline(always)]
+    pub fn oom() -> ! {
+        super::default_oom_handler()
+    }
 }

--- a/src/liballoc/oom.rs
+++ b/src/liballoc/oom.rs
@@ -8,10 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(target_has_atomic = "ptr")]
 use core::sync::atomic::{AtomicPtr, Ordering};
+#[cfg(target_has_atomic = "ptr")]
 use core::mem;
 use core::intrinsics;
 
+#[cfg(target_has_atomic = "ptr")]
 static OOM_HANDLER: AtomicPtr<()> = AtomicPtr::new(default_oom_handler as *mut ());
 
 fn default_oom_handler() -> ! {
@@ -21,6 +24,7 @@ fn default_oom_handler() -> ! {
 }
 
 /// Common out-of-memory routine
+#[cfg(target_has_atomic = "ptr")]
 #[cold]
 #[inline(never)]
 #[unstable(feature = "oom", reason = "not a scrutinized interface",
@@ -31,10 +35,21 @@ pub fn oom() -> ! {
     handler();
 }
 
+/// Common out-of-memory routine
+#[cfg(not(target_has_atomic = "ptr"))]
+#[cold]
+#[inline(never)]
+#[unstable(feature = "oom", reason = "not a scrutinized interface",
+           issue = "27700")]
+pub fn oom() -> ! {
+    default_oom_handler()
+}
+
 /// Set a custom handler for out-of-memory conditions
 ///
 /// To avoid recursive OOM failures, it is critical that the OOM handler does
 /// not allocate any memory itself.
+#[cfg(target_has_atomic = "ptr")]
 #[unstable(feature = "oom", reason = "not a scrutinized interface",
            issue = "27700")]
 pub fn set_oom_handler(handler: fn() -> !) {


### PR DESCRIPTION
by cfging away `alloc::Arc` and changing OOM to abort for this target

r? @alexcrichton 
cc @thejpster