### PR TITLE
Show span for trait that doesn't implement Copy

### DIFF
--- a/src/librustc/hir/map/collector.rs
+++ b/src/librustc/hir/map/collector.rs
@@ -26,7 +26,7 @@ pub struct NodeCollector<'ast> {
     /// If true, completely ignore nested items. We set this when loading
     /// HIR from metadata, since in that case we only want the HIR for
     /// one specific item (and not the ones nested inside of it).
-    pub ignore_nested_items: bool
+    pub ignore_nested_items: bool,
 }
 
 impl<'ast> NodeCollector<'ast> {
@@ -35,7 +35,7 @@ impl<'ast> NodeCollector<'ast> {
             krate: krate,
             map: vec![],
             parent_node: CRATE_NODE_ID,
-            ignore_nested_items: false
+            ignore_nested_items: false,
         };
         collector.insert_entry(CRATE_NODE_ID, RootCrate);
 
@@ -51,7 +51,7 @@ impl<'ast> NodeCollector<'ast> {
             krate: krate,
             map: map,
             parent_node: parent_node,
-            ignore_nested_items: true
+            ignore_nested_items: true,
         };
 
         collector.insert_entry(parent_node, RootInlinedParent(parent));

--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -18,6 +18,7 @@ use hir::def_id::{CrateNum, DefId, DefIndex, LOCAL_CRATE};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::stable_hasher::StableHasher;
 use serialize::{Encodable, Decodable, Encoder, Decoder};
+use std::fmt;
 use std::fmt::Write;
 use std::hash::{Hash, Hasher};
 use syntax::ast;
@@ -217,6 +218,18 @@ impl DefPath {
         tcx.original_crate_name(self.krate).as_str().hash(state);
         tcx.crate_disambiguator(self.krate).as_str().hash(state);
         self.data.hash(state);
+    }
+}
+
+impl fmt::Display for DefPath {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for (i, component) in self.data.iter().enumerate() {
+            write!(f,
+                   "{}{}",
+                   if i == 0 { "" } else {"::"},
+                   component.data.as_interned_str())?;
+        }
+        Ok(())
     }
 }
 

--- a/src/librustc/ty/util.rs
+++ b/src/librustc/ty/util.rs
@@ -115,8 +115,8 @@ impl IntTypeExt for attr::IntType {
 
 #[derive(Copy, Clone)]
 pub enum CopyImplementationError {
-    InfrigingField(Name),
-    InfrigingVariant(Name),
+    InfrigingField(DefId, Name),
+    InfrigingVariant(DefId, Name),
     NotAnAdt,
     HasDestructor
 }
@@ -149,7 +149,7 @@ impl<'tcx> ParameterEnvironment<'tcx> {
                             let field_ty = field.ty(tcx, substs);
                             if infcx.type_moves_by_default(field_ty, span) {
                                 return Err(CopyImplementationError::InfrigingField(
-                                    field.name))
+                                    field.did, field.name))
                             }
                         }
                         adt
@@ -160,7 +160,7 @@ impl<'tcx> ParameterEnvironment<'tcx> {
                                 let field_ty = field.ty(tcx, substs);
                                 if infcx.type_moves_by_default(field_ty, span) {
                                     return Err(CopyImplementationError::InfrigingVariant(
-                                        variant.name))
+                                        variant.did, variant.name))
                                 }
                             }
                         }

--- a/src/test/compile-fail/E0204.rs
+++ b/src/test/compile-fail/E0204.rs
@@ -10,18 +10,20 @@
 
 struct Foo {
     foo: Vec<u32>,
+    //~^ this field doesn't implement `Copy`
 }
 
 impl Copy for Foo { }
 //~^ ERROR E0204
-//~| NOTE field `foo` does not implement `Copy`
+//~| NOTE field `foo` doesn't implement `Copy`
 
 #[derive(Copy)]
 //~^ ERROR E0204
-//~| NOTE field `ty` does not implement `Copy`
+//~| NOTE field `ty` doesn't implement `Copy`
 //~| NOTE in this expansion of #[derive(Copy)]
 struct Foo2<'a> {
     ty: &'a mut bool,
+    //~^ this field doesn't implement `Copy`
 }
 
 fn main() {

--- a/src/test/compile-fail/E0205.rs
+++ b/src/test/compile-fail/E0205.rs
@@ -10,19 +10,21 @@
 
 enum Foo {
     Bar(Vec<u32>),
+    //~^ NOTE this variant doesn't implement `Copy`
     Baz,
 }
 
 impl Copy for Foo { }
-//~^ ERROR the trait `Copy` may not be implemented for this type
-//~| NOTE variant `Bar` does not implement `Copy`
+//~^ ERROR the trait `Copy` may not be implemented for type `Foo`
+//~| NOTE variant `Foo::Bar` doesn't implement `Copy`
 
 #[derive(Copy)]
-//~^ ERROR the trait `Copy` may not be implemented for this type
-//~| NOTE variant `Bar` does not implement `Copy`
+//~^ ERROR the trait `Copy` may not be implemented for type `Foo2<'a>`
+//~| NOTE variant `Foo2::Bar` doesn't implement `Copy`
 //~| NOTE in this expansion of #[derive(Copy)]
 enum Foo2<'a> {
     Bar(&'a mut bool),
+    //~^ NOTE this variant doesn't implement `Copy`
     Baz,
 }
 

--- a/src/test/compile-fail/issue-27340.rs
+++ b/src/test/compile-fail/issue-27340.rs
@@ -10,7 +10,7 @@
 
 struct Foo;
 #[derive(Copy, Clone)]
-//~^ ERROR the trait `Copy` may not be implemented for this type
+//~^ ERROR the trait `Copy` may not be implemented for type `Bar`
 struct Bar(Foo);
 
 fn main() {}

--- a/src/test/compile-fail/opt-in-copy.rs
+++ b/src/test/compile-fail/opt-in-copy.rs
@@ -15,7 +15,7 @@ struct IWantToCopyThis {
 }
 
 impl Copy for IWantToCopyThis {}
-//~^ ERROR the trait `Copy` may not be implemented for this type
+//~^ ERROR the trait `Copy` may not be implemented for type `IWantToCopyThis`
 
 enum CantCopyThisEither {
     A,
@@ -27,6 +27,6 @@ enum IWantToCopyThisToo {
 }
 
 impl Copy for IWantToCopyThisToo {}
-//~^ ERROR the trait `Copy` may not be implemented for this type
+//~^ ERROR the trait `Copy` may not be implemented for type `IWantToCopyThisToo`
 
 fn main() {}

--- a/src/test/ui/span/issue-19950-1.rs
+++ b/src/test/ui/span/issue-19950-1.rs
@@ -8,19 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
+struct NoCopy;
 
-#[derive(Clone)]
-union U {
-    a: u8
+struct Bar {
+    item: NoCopy,
 }
 
-#[derive(Clone)]
-union W {
-    a: String
-}
-
-impl Copy for U {} // OK
-impl Copy for W {} //~ ERROR the trait `Copy` may not be implemented for type `W`
+impl Copy for Bar {}
 
 fn main() {}

--- a/src/test/ui/span/issue-19950-1.stderr
+++ b/src/test/ui/span/issue-19950-1.stderr
@@ -1,0 +1,11 @@
+error[E0204]: the trait `Copy` may not be implemented for type `Bar`
+  --> $DIR/issue-19950-1.rs:17:1
+   |
+14 |     item: NoCopy,
+   |     ------------ this field doesn't implement `Copy`
+...
+17 | impl Copy for Bar {}
+   | ^^^^^^^^^^^^^^^^^^^^ field `item` doesn't implement `Copy`
+
+error: aborting due to previous error
+

--- a/src/test/ui/span/issue-19950-2.rs
+++ b/src/test/ui/span/issue-19950-2.rs
@@ -8,19 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(untagged_unions)]
+struct NoCopy;
 
-#[derive(Clone)]
-union U {
-    a: u8
+enum Foo {
+    MyVariant(NoCopy)
 }
 
-#[derive(Clone)]
-union W {
-    a: String
-}
-
-impl Copy for U {} // OK
-impl Copy for W {} //~ ERROR the trait `Copy` may not be implemented for type `W`
+impl Copy for Foo {}
 
 fn main() {}

--- a/src/test/ui/span/issue-19950-2.stderr
+++ b/src/test/ui/span/issue-19950-2.stderr
@@ -1,0 +1,11 @@
+error[E0205]: the trait `Copy` may not be implemented for type `Foo`
+  --> $DIR/issue-19950-2.rs:17:6
+   |
+14 |     MyVariant(NoCopy)
+   |     ----------------- this variant doesn't implement `Copy`
+...
+17 | impl Copy for Foo {}
+   |      ^^^^ variant `Foo::MyVariant` doesn't implement `Copy`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Point at span for trait that doesn't implement `Copy`.

Given the following code:

```rust
struct NoCopy;

enum Test {
    MyVariant(NoCopy)
}

impl Copy for Test {}

fn main() {}
```
show the following output:

```nocode
error[E0205]: the trait `Copy` may not be implemented for this type
 --> file.rs:7:6
  |
4 |     MyVariant(NoCopy)
  |     ----------------- `MyVariant` defined here
...
7 | impl Copy for Test {}
  |      ^^^^ variant `MyVariant` does not implement `Copy`

error: aborting due to previous error
```

Re: #19950.