### PR TITLE
Commented out final 'main' function in order to fit within pattern of…

### DIFF
--- a/src/doc/book/closures.md
+++ b/src/doc/book/closures.md
@@ -511,12 +511,10 @@ fn factory() -> Box<Fn(i32) -> i32> {
     Box::new(|x| x + num)
 }
 
-# fn main() {
 let f = factory();
 
 let answer = f(1);
 assert_eq!(6, answer);
-# }
 ```
 
 There’s just one last problem:
@@ -542,12 +540,10 @@ fn factory() -> Box<Fn(i32) -> i32> {
     Box::new(move |x| x + num)
 }
 
-# fn main() {
 let f = factory();
 
 let answer = f(1);
 assert_eq!(6, answer);
-# }
 ```
 
 By making the inner closure a `move Fn`, we create a new stack frame for our

--- a/src/doc/book/closures.md
+++ b/src/doc/book/closures.md
@@ -510,6 +510,7 @@ fn factory() -> Box<Fn(i32) -> i32> {
 
     Box::new(|x| x + num)
 }
+
 # fn main() {
 let f = factory();
 
@@ -540,12 +541,13 @@ fn factory() -> Box<Fn(i32) -> i32> {
 
     Box::new(move |x| x + num)
 }
-fn main() {
+
+# fn main() {
 let f = factory();
 
 let answer = f(1);
 assert_eq!(6, answer);
-}
+# }
 ```
 
 By making the inner closure a `move Fn`, we create a new stack frame for our


### PR DESCRIPTION
… other examples and prevent incorrect indentation