### PR TITLE
Remove unused type aliases

### DIFF
--- a/src/librustc_borrowck/borrowck/mir/abs_domain.rs
+++ b/src/librustc_borrowck/borrowck/mir/abs_domain.rs
@@ -21,13 +21,11 @@
 //! `a[x]` would still overlap them both. But that is not this
 //! representation does today.)
 
-use rustc::mir::{Lvalue, LvalueElem};
-use rustc::mir::{Operand, Projection, ProjectionElem};
+use rustc::mir::LvalueElem;
+use rustc::mir::{Operand, ProjectionElem};
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub struct AbstractOperand;
-pub type AbstractProjection<'tcx> =
-    Projection<'tcx, Lvalue<'tcx>, AbstractOperand>;
 pub type AbstractElem<'tcx> =
     ProjectionElem<'tcx, AbstractOperand>;
 

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -300,8 +300,6 @@ struct BorrowStats {
     guaranteed_paths: usize
 }
 
-pub type BckResult<'tcx, T> = Result<T, BckError<'tcx>>;
-
 ///////////////////////////////////////////////////////////////////////////
 // Loans and loan paths
 

--- a/src/librustc_incremental/persist/load.rs
+++ b/src/librustc_incremental/persist/load.rs
@@ -32,8 +32,6 @@ use super::file_format;
 
 pub type DirtyNodes = FnvHashSet<DepNode<DefPathIndex>>;
 
-type CleanEdges = Vec<(DepNode<DefId>, DepNode<DefId>)>;
-
 /// If we are in incremental mode, and a previous dep-graph exists,
 /// then load up those nodes/edges that are still valid into the
 /// dep-graph for this session. (This is assumed to be running very

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -12,7 +12,6 @@ use {Module, Resolver};
 use build_reduced_graph::BuildReducedGraphVisitor;
 use rustc::hir::def_id::{CRATE_DEF_INDEX, DefIndex};
 use rustc::hir::map::{self, DefCollector};
-use rustc::util::nodemap::FnvHashMap;
 use std::cell::Cell;
 use std::rc::Rc;
 use syntax::ast;
@@ -79,8 +78,6 @@ pub struct LegacyBinding<'a> {
     ext: Rc<SyntaxExtension>,
     span: Span,
 }
-
-pub type LegacyImports = FnvHashMap<ast::Name, (Rc<SyntaxExtension>, Span)>;
 
 impl<'a> base::Resolver for Resolver<'a> {
     fn next_node_id(&mut self) -> ast::NodeId {

--- a/src/librustc_trans/adt.rs
+++ b/src/librustc_trans/adt.rs
@@ -48,7 +48,6 @@ use std;
 use llvm::{ValueRef, True, IntEQ, IntNE};
 use rustc::ty::layout;
 use rustc::ty::{self, Ty, AdtKind};
-use syntax::attr;
 use build::*;
 use common::*;
 use debuginfo::DebugLoc;
@@ -65,8 +64,6 @@ pub enum BranchKind {
     Switch,
     Single
 }
-
-type Hint = attr::ReprAttr;
 
 #[derive(Copy, Clone)]
 pub struct MaybeSizedValue {
@@ -118,9 +115,6 @@ fn compute_fields<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>,
         _ => bug!("{} is not a type that can have fields.", t)
     }
 }
-
-/// This represents the (GEP) indices to follow to get to the discriminant field
-pub type DiscrField = Vec<usize>;
 
 /// LLVM-level types are a little complicated.
 ///

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -171,8 +171,6 @@ struct ConvertedBinding<'tcx> {
     span: Span,
 }
 
-type TraitAndProjections<'tcx> = (ty::PolyTraitRef<'tcx>, Vec<ty::PolyProjectionPredicate<'tcx>>);
-
 /// Dummy type used for the `Self` of a `TraitRef` created for converting
 /// a trait object, and which gets removed in `ExistentialTraitRef`.
 /// This type must not appear anywhere in other converted types.

--- a/src/libstd/collections/hash/table.rs
+++ b/src/libstd/collections/hash/table.rs
@@ -113,10 +113,6 @@ pub struct FullBucket<K, V, M> {
     table: M,
 }
 
-pub type EmptyBucketImm<'table, K, V> = EmptyBucket<K, V, &'table RawTable<K, V>>;
-pub type FullBucketImm<'table, K, V> = FullBucket<K, V, &'table RawTable<K, V>>;
-
-pub type EmptyBucketMut<'table, K, V> = EmptyBucket<K, V, &'table mut RawTable<K, V>>;
 pub type FullBucketMut<'table, K, V> = FullBucket<K, V, &'table mut RawTable<K, V>>;
 
 pub enum BucketState<K, V, M> {


### PR DESCRIPTION
Found by extending the dead code lint. The lint itself is work in progress because of false positives.

cc #37455.