### PR TITLE
Remove remark about poor code style

### DIFF
--- a/src/doc/book/traits.md
+++ b/src/doc/book/traits.md
@@ -243,7 +243,21 @@ to know more about [operator traits][operators-and-overloading].
 # Rules for implementing traits
 
 So far, we’ve only added trait implementations to structs, but you can
-implement a trait for any type such as `i32`.
+implement a trait for any type such as `f32`:
+
+```rust
+trait ApproxEqual {
+    fn approx_equal(&self, other: &Self) -> bool;
+}
+impl ApproxEqual for f32 {
+    fn approx_equal(&self, other: &Self) -> bool {
+        // Appropriate for `self` and `other` being close to 1.0.
+        (self - other).abs() <= ::std::f32::EPSILON
+    }
+}
+
+println!("{}", 1.0.approx_equal(&1.00000001));
+```
 
 This may seem like the Wild West, but there are two restrictions around
 implementing traits that prevent this from getting out of hand. The first is

--- a/src/doc/book/traits.md
+++ b/src/doc/book/traits.md
@@ -243,27 +243,7 @@ to know more about [operator traits][operators-and-overloading].
 # Rules for implementing traits
 
 So far, we’ve only added trait implementations to structs, but you can
-implement a trait for any type. So technically, we _could_ implement `HasArea`
-for `i32`:
-
-```rust
-trait HasArea {
-    fn area(&self) -> f64;
-}
-
-impl HasArea for i32 {
-    fn area(&self) -> f64 {
-        println!("this is silly");
-
-        *self as f64
-    }
-}
-
-5.area();
-```
-
-It is considered poor style to implement methods on such primitive types, even
-though it is possible.
+implement a trait for any type such as `i32`.
 
 This may seem like the Wild West, but there are two restrictions around
 implementing traits that prevent this from getting out of hand. The first is


### PR DESCRIPTION
The current wording [seems to be confusing](https://www.reddit.com/r/rust/comments/5aat03/why_is_implementing_traits_on_primitive_types/). As an explanation when and why this could be considered as poor style would go beyond of the scope of this chapter I suggest to remove this remark.