### PR TITLE
Improve .binary_search_by()

### DIFF
--- a/src/libcoretest/slice.rs
+++ b/src/libcoretest/slice.rs
@@ -30,6 +30,17 @@ fn test_binary_search() {
     assert!(b.binary_search_by(|v| v.cmp(&9)) == Err(6));
 }
 
+
+#[test]
+fn test_binary_search_zst() {
+    use core::cmp::Ordering;
+    // zero sized type
+    let b = [(); 14];
+    // All greater => find the start, all less => find the end
+    assert_eq!(b.binary_search_by(|_| Ordering::Greater), Err(0));
+    assert_eq!(b.binary_search_by(|_| Ordering::Less), Err(b.len()));
+}
+
 #[test]
 fn test_iterator_nth() {
     let v: &[_] = &[0, 1, 2, 3, 4];


### PR DESCRIPTION
Change binary_search_by to use the pointer offset computed from the
slice; this saves updating an extra counter just for that. This gives
a small but noticeable performance improvement.

For zero sized types, we have to keep the step variable around, but
the way this is written, that variable is compiled out for the regular
non-ZST case.

This was developed together with @arthurprs, and with aid of the
binary search framework crate indexing.