### PR TITLE
ICH: Hash expression spans if their source location is captured for panics.

### DIFF
--- a/src/test/incremental/hashes/panic_exprs.rs
+++ b/src/test/incremental/hashes/panic_exprs.rs
@@ -1,0 +1,173 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This test case tests the incremental compilation hash (ICH) implementation
+// for exprs that can panic at runtime (e.g. because of bounds checking). For
+// these expressions an error message containing their source location is
+// generated, so their hash must always depend on their location in the source
+// code, not just when debuginfo is enabled.
+
+// The general pattern followed here is: Change one thing between rev1 and rev2
+// and make sure that the hash has changed, then change nothing between rev2 and
+// rev3 and make sure that the hash has not changed.
+
+// must-compile-successfully
+// revisions: cfail1 cfail2 cfail3
+// compile-flags: -Z query-dep-graph -C debug-assertions
+
+#![allow(warnings)]
+#![feature(rustc_attrs)]
+#![crate_type="rlib"]
+
+
+// Indexing expression ---------------------------------------------------------
+#[cfg(cfail1)]
+pub fn indexing(slice: &[u8]) -> u8 {
+    slice[100]
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+pub fn indexing(slice: &[u8]) -> u8 {
+    slice[100]
+}
+
+
+// Arithmetic overflow plus ----------------------------------------------------
+#[cfg(cfail1)]
+pub fn arithmetic_overflow_plus(val: i32) -> i32 {
+    val + 1
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+pub fn arithmetic_overflow_plus(val: i32) -> i32 {
+    val + 1
+}
+
+
+// Arithmetic overflow minus ----------------------------------------------------
+#[cfg(cfail1)]
+pub fn arithmetic_overflow_minus(val: i32) -> i32 {
+    val - 1
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+pub fn arithmetic_overflow_minus(val: i32) -> i32 {
+    val - 1
+}
+
+
+// Arithmetic overflow mult ----------------------------------------------------
+#[cfg(cfail1)]
+pub fn arithmetic_overflow_mult(val: i32) -> i32 {
+    val * 2
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+pub fn arithmetic_overflow_mult(val: i32) -> i32 {
+    val * 2
+}
+
+
+// Arithmetic overflow negation ------------------------------------------------
+#[cfg(cfail1)]
+pub fn arithmetic_overflow_negation(val: i32) -> i32 {
+    -val
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+pub fn arithmetic_overflow_negation(val: i32) -> i32 {
+    -val
+}
+
+
+// Division by zero ------------------------------------------------------------
+#[cfg(cfail1)]
+pub fn division_by_zero(val: i32) -> i32 {
+    2 / val
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+pub fn division_by_zero(val: i32) -> i32 {
+    2 / val
+}
+
+// Division by zero ------------------------------------------------------------
+#[cfg(cfail1)]
+pub fn mod_by_zero(val: i32) -> i32 {
+    2 % val
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+pub fn mod_by_zero(val: i32) -> i32 {
+    2 % val
+}
+
+
+
+// THE FOLLOWING ITEMS SHOULD NOT BE INFLUENCED BY THEIR SOURCE LOCATION
+
+// bitwise ---------------------------------------------------------------------
+#[cfg(cfail1)]
+pub fn bitwise(val: i32) -> i32 {
+    !val & 0x101010101 | 0x45689 ^ 0x2372382 << 1 >> 1
+}
+
+#[cfg(not(cfail1))]
+#[rustc_clean(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_clean(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+pub fn bitwise(val: i32) -> i32 {
+    !val & 0x101010101 | 0x45689 ^ 0x2372382 << 1 >> 1
+}
+
+
+// logical ---------------------------------------------------------------------
+#[cfg(cfail1)]
+pub fn logical(val1: bool, val2: bool, val3: bool) -> bool {
+    val1 && val2 || val3
+}
+
+#[cfg(not(cfail1))]
+#[rustc_clean(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_clean(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+pub fn logical(val1: bool, val2: bool, val3: bool) -> bool {
+    val1 && val2 || val3
+}

--- a/src/test/incremental/hashes/panic_exprs_no_overflow_checks.rs
+++ b/src/test/incremental/hashes/panic_exprs_no_overflow_checks.rs
@@ -1,0 +1,251 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This test case tests the incremental compilation hash (ICH) implementation
+// for exprs that can panic at runtime (e.g. because of bounds checking). For
+// these expressions an error message containing their source location is
+// generated, so their hash must always depend on their location in the source
+// code, not just when debuginfo is enabled.
+
+// As opposed to the panic_exprs.rs test case, this test case checks that things
+// behave as expected when overflow checks are off:
+//
+// - Addition, subtraction, and multiplication do not change the ICH, unless
+//   the function containing them is marked with rustc_inherit_overflow_checks.
+// - Division by zero and bounds checks always influence the ICH
+
+// The general pattern followed here is: Change one thing between rev1 and rev2
+// and make sure that the hash has changed, then change nothing between rev2 and
+// rev3 and make sure that the hash has not changed.
+
+// must-compile-successfully
+// revisions: cfail1 cfail2 cfail3
+// compile-flags: -Z query-dep-graph -Z force-overflow-checks=off
+
+#![allow(warnings)]
+#![feature(rustc_attrs)]
+#![crate_type="rlib"]
+
+
+// Indexing expression ---------------------------------------------------------
+#[cfg(cfail1)]
+pub fn indexing(slice: &[u8]) -> u8 {
+    slice[100]
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+pub fn indexing(slice: &[u8]) -> u8 {
+    slice[100]
+}
+
+
+// Arithmetic overflow plus ----------------------------------------------------
+#[cfg(cfail1)]
+#[rustc_inherit_overflow_checks]
+pub fn arithmetic_overflow_plus_inherit(val: i32) -> i32 {
+    val + 1
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+#[rustc_inherit_overflow_checks]
+pub fn arithmetic_overflow_plus_inherit(val: i32) -> i32 {
+    val + 1
+}
+
+
+// Arithmetic overflow minus ----------------------------------------------------
+#[cfg(cfail1)]
+#[rustc_inherit_overflow_checks]
+pub fn arithmetic_overflow_minus_inherit(val: i32) -> i32 {
+    val - 1
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+#[rustc_inherit_overflow_checks]
+pub fn arithmetic_overflow_minus_inherit(val: i32) -> i32 {
+    val - 1
+}
+
+
+// Arithmetic overflow mult ----------------------------------------------------
+#[cfg(cfail1)]
+#[rustc_inherit_overflow_checks]
+pub fn arithmetic_overflow_mult_inherit(val: i32) -> i32 {
+    val * 2
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+#[rustc_inherit_overflow_checks]
+pub fn arithmetic_overflow_mult_inherit(val: i32) -> i32 {
+    val * 2
+}
+
+
+// Arithmetic overflow negation ------------------------------------------------
+#[cfg(cfail1)]
+#[rustc_inherit_overflow_checks]
+pub fn arithmetic_overflow_negation_inherit(val: i32) -> i32 {
+    -val
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+#[rustc_inherit_overflow_checks]
+pub fn arithmetic_overflow_negation_inherit(val: i32) -> i32 {
+    -val
+}
+
+
+// Division by zero ------------------------------------------------------------
+#[cfg(cfail1)]
+pub fn division_by_zero(val: i32) -> i32 {
+    2 / val
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+pub fn division_by_zero(val: i32) -> i32 {
+    2 / val
+}
+
+// Division by zero ------------------------------------------------------------
+#[cfg(cfail1)]
+pub fn mod_by_zero(val: i32) -> i32 {
+    2 % val
+}
+
+#[cfg(not(cfail1))]
+#[rustc_dirty(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_dirty(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+pub fn mod_by_zero(val: i32) -> i32 {
+    2 % val
+}
+
+
+
+// THE FOLLOWING ITEMS SHOULD NOT BE INFLUENCED BY THEIR SOURCE LOCATION
+
+// bitwise ---------------------------------------------------------------------
+#[cfg(cfail1)]
+pub fn bitwise(val: i32) -> i32 {
+    !val & 0x101010101 | 0x45689 ^ 0x2372382 << 1 >> 1
+}
+
+#[cfg(not(cfail1))]
+#[rustc_clean(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_clean(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+pub fn bitwise(val: i32) -> i32 {
+    !val & 0x101010101 | 0x45689 ^ 0x2372382 << 1 >> 1
+}
+
+
+// logical ---------------------------------------------------------------------
+#[cfg(cfail1)]
+pub fn logical(val1: bool, val2: bool, val3: bool) -> bool {
+    val1 && val2 || val3
+}
+
+#[cfg(not(cfail1))]
+#[rustc_clean(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_clean(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+pub fn logical(val1: bool, val2: bool, val3: bool) -> bool {
+    val1 && val2 || val3
+}
+
+// Arithmetic overflow plus ----------------------------------------------------
+#[cfg(cfail1)]
+pub fn arithmetic_overflow_plus(val: i32) -> i32 {
+    val + 1
+}
+
+#[cfg(not(cfail1))]
+#[rustc_clean(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_clean(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+pub fn arithmetic_overflow_plus(val: i32) -> i32 {
+    val + 1
+}
+
+
+// Arithmetic overflow minus ----------------------------------------------------
+#[cfg(cfail1)]
+pub fn arithmetic_overflow_minus(val: i32) -> i32 {
+    val - 1
+}
+
+#[cfg(not(cfail1))]
+#[rustc_clean(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_clean(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+pub fn arithmetic_overflow_minus(val: i32) -> i32 {
+    val - 1
+}
+
+
+// Arithmetic overflow mult ----------------------------------------------------
+#[cfg(cfail1)]
+pub fn arithmetic_overflow_mult(val: i32) -> i32 {
+    val * 2
+}
+
+#[cfg(not(cfail1))]
+#[rustc_clean(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_clean(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+pub fn arithmetic_overflow_mult(val: i32) -> i32 {
+    val * 2
+}
+
+
+// Arithmetic overflow negation ------------------------------------------------
+#[cfg(cfail1)]
+pub fn arithmetic_overflow_negation(val: i32) -> i32 {
+    -val
+}
+
+#[cfg(not(cfail1))]
+#[rustc_clean(label="Hir", cfg="cfail2")]
+#[rustc_clean(label="Hir", cfg="cfail3")]
+#[rustc_metadata_clean(cfg="cfail2")]
+#[rustc_metadata_clean(cfg="cfail3")]
+pub fn arithmetic_overflow_negation(val: i32) -> i32 {
+    -val
+}


### PR DESCRIPTION
Since the location of some expressions is captured in error message constants, it has an influence on machine code and consequently we need to take them into account by the incr. comp. hash. This PR makes this happen for `+, -, *, /, %` and for array indexing -- let me know if I forgot anything.

In the future we might want to change the codegen strategy for those error messages, so that they are stored in a separate object file with a stable symbol name, so that only this object file has to be regenerated when source locations change. This strategy would also eliminate unnecessary duplications due  to monomorphization, as @arielb1 has pointed out on IRC. I opened https://github.com/rust-lang/rust/issues/37512, so we don't forget about this.

r? @nikomatsakis 