### PR TITLE
Elide lifetimes in DerefMut documentation

### DIFF
--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -2484,13 +2484,13 @@ impl<'a, T: ?Sized> Deref for &'a mut T {
 /// impl<T> Deref for DerefMutExample<T> {
 ///     type Target = T;
 ///
-///     fn deref<'a>(&'a self) -> &'a T {
+///     fn deref(&self) -> &T {
 ///         &self.value
 ///     }
 /// }
 ///
 /// impl<T> DerefMut for DerefMutExample<T> {
-///     fn deref_mut<'a>(&'a mut self) -> &'a mut T {
+///     fn deref_mut(&mut self) -> &mut T {
 ///         &mut self.value
 ///     }
 /// }


### PR DESCRIPTION
 - Elide lifetimes to increase the readability of `DerefMut` examples