### PR TITLE
Fix invalid "ref mut mut" sugestion

### DIFF
--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -997,16 +997,23 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                         if let Categorization::Local(local_id) = err.cmt.cat {
                             let span = self.tcx.map.span(local_id);
                             if let Ok(snippet) = self.tcx.sess.codemap().span_to_snippet(span) {
-                                if snippet.starts_with("ref ") {
-                                    db.span_label(span,
-                                        &format!("use `{}` here to make mutable",
-                                            snippet.replace("ref ", "ref mut ")));
-                                } else if snippet != "self" {
-                                    db.span_label(span,
-                                        &format!("use `mut {}` here to make mutable", snippet));
+                                if snippet.starts_with("ref mut ") || snippet.starts_with("&mut ") {
+                                    db.span_label(error_span, &format!("cannot reborrow mutably"));
+                                    db.span_label(error_span, &format!("try removing `&mut` here"));
+                                } else {
+                                    if snippet.starts_with("ref ") {
+                                        db.span_label(span,
+                                            &format!("use `{}` here to make mutable",
+                                                snippet.replace("ref ", "ref mut ")));
+                                    } else if snippet != "self" {
+                                        db.span_label(span,
+                                            &format!("use `mut {}` here to make mutable", snippet));
+                                    }
+                                    db.span_label(error_span, &format!("cannot borrow mutably"));
                                 }
+                            } else {
+                                db.span_label(error_span, &format!("cannot borrow mutably"));
                             }
-                            db.span_label(error_span, &format!("cannot borrow mutably"));
                         }
                     }
                 }

--- a/src/test/ui/did_you_mean/issue-31424.rs
+++ b/src/test/ui/did_you_mean/issue-31424.rs
@@ -15,15 +15,12 @@ struct Struct;
 impl Struct {
     fn foo(&mut self) {
         (&mut self).bar();
-        //~^ ERROR cannot borrow immutable argument `self` as mutable
-        // ... and no SUGGESTION that suggests `&mut mut self`
     }
 
     // In this case we could keep the suggestion, but to distinguish the
     // two cases is pretty hard. It's an obscure case anyway.
     fn bar(self: &mut Self) {
         (&mut self).bar();
-        //~^ ERROR cannot borrow immutable argument `self` as mutable
     }
 }
 

--- a/src/test/ui/did_you_mean/issue-31424.stderr
+++ b/src/test/ui/did_you_mean/issue-31424.stderr
@@ -1,0 +1,17 @@
+error: cannot borrow immutable argument `self` as mutable
+  --> $DIR/issue-31424.rs:17:15
+   |
+17 |         (&mut self).bar();
+   |               ^^^^
+   |               |
+   |               try removing `&mut` here
+   |               cannot reborrow mutably
+
+error: cannot borrow immutable argument `self` as mutable
+  --> $DIR/issue-31424.rs:23:15
+   |
+23 |         (&mut self).bar();
+   |               ^^^^ cannot borrow mutably
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/did_you_mean/issue-34126.rs
+++ b/src/test/ui/did_you_mean/issue-34126.rs
@@ -1,0 +1,23 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Z { }
+
+impl Z {
+    fn run(&self, z: &mut Z) { }
+    fn start(&mut self) {
+        self.run(&mut self);
+    }
+}
+
+fn main() {
+    let mut z = Z {};
+    z.start();
+}

--- a/src/test/ui/did_you_mean/issue-34126.stderr
+++ b/src/test/ui/did_you_mean/issue-34126.stderr
@@ -1,0 +1,11 @@
+error: cannot borrow immutable argument `self` as mutable
+  --> $DIR/issue-34126.rs:16:23
+   |
+16 |         self.run(&mut self);
+   |                       ^^^^
+   |                       |
+   |                       try removing `&mut` here
+   |                       cannot reborrow mutably
+
+error: aborting due to previous error
+

--- a/src/test/ui/did_you_mean/issue-34337.rs
+++ b/src/test/ui/did_you_mean/issue-34337.rs
@@ -1,0 +1,17 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn get(key: &mut String) { }
+
+fn main() {
+    let mut v: Vec<String> = Vec::new();
+    let ref mut key = v[0];
+    get(&mut key);
+}

--- a/src/test/ui/did_you_mean/issue-34337.stderr
+++ b/src/test/ui/did_you_mean/issue-34337.stderr
@@ -1,0 +1,11 @@
+error: cannot borrow immutable local variable `key` as mutable
+  --> $DIR/issue-34337.rs:16:14
+   |
+16 |     get(&mut key);
+   |              ^^^
+   |              |
+   |              try removing `&mut` here
+   |              cannot reborrow mutably
+
+error: aborting due to previous error
+

--- a/src/test/ui/did_you_mean/issue-37139.rs
+++ b/src/test/ui/did_you_mean/issue-37139.rs
@@ -1,0 +1,25 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum TestEnum {
+    Item(i32),
+}
+
+fn test(_: &mut i32) {
+}
+
+fn main() {
+    let mut x = TestEnum::Item(10);
+    match x {
+        TestEnum::Item(ref mut x) => {
+            test(&mut x);
+        }
+    }
+}

--- a/src/test/ui/did_you_mean/issue-37139.stderr
+++ b/src/test/ui/did_you_mean/issue-37139.stderr
@@ -1,0 +1,11 @@
+error: cannot borrow immutable local variable `x` as mutable
+  --> $DIR/issue-37139.rs:22:23
+   |
+22 |             test(&mut x);
+   |                       ^
+   |                       |
+   |                       try removing `&mut` here
+   |                       cannot reborrow mutably
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Change output from:

```nocode
error: cannot borrow immutable local variable `x` as mutable
  --> <anon>:12:23
   |
11 |         TestEnum::Item(ref mut x) => {
   |                        --------- use `ref mut mut x` here to make mutable
12 |             test(&mut x);
   |                       ^ cannot borrow mutably
```

to

```nocode
error: cannot borrow immutable local variable `x` as mutable
  --> <anon>:12:23
   |
12 |             test(&mut x);
   |                       ^
   |                       |
   |                       cannot reborrow mutably
   |                       try removing `&mut` here
```
Fixes #37139, #34337, #34126