### PR TITLE
Increase AppVeyor clone depth

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,7 +69,7 @@ environment:
     MINGW_ARCHIVE: x86_64-4.9.2-release-win32-seh-rt_v4-rev4.7z
     MINGW_DIR: mingw64
 
-clone_depth: 1
+clone_depth: 7
 build: false
 
 install:


### PR DESCRIPTION
Sometimes builds fail, due to top commit changing before AppVeyor starting testing a commit (rollup merges involve many commits, in particular). Increasing depth to 7 gives about two days of a buffer (checked by manually cloning `auto` branch to various depths), while not increasing size of .git directory noticeably.