### PR TITLE
Use impl obligations as initial environment for specialization

### DIFF
--- a/src/librustc/traits/specialize/mod.rs
+++ b/src/librustc/traits/specialize/mod.rs
@@ -148,6 +148,8 @@ pub fn find_method<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 pub fn specializes<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                              impl1_def_id: DefId,
                              impl2_def_id: DefId) -> bool {
+    debug!("specializes({:?}, {:?})", impl1_def_id, impl2_def_id);
+
     if let Some(r) = tcx.specializes_cache.borrow().check(impl1_def_id, impl2_def_id) {
         return r;
     }
@@ -177,21 +179,22 @@ pub fn specializes<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     }
 
     // create a parameter environment corresponding to a (skolemized) instantiation of impl1
-    let mut penv = tcx.construct_parameter_environment(DUMMY_SP,
-                                                       impl1_def_id,
-                                                       region::DUMMY_CODE_EXTENT);
+    let penv = tcx.construct_parameter_environment(DUMMY_SP,
+                                                   impl1_def_id,
+                                                   region::DUMMY_CODE_EXTENT);
     let impl1_trait_ref = tcx.impl_trait_ref(impl1_def_id)
                              .unwrap()
                              .subst(tcx, &penv.free_substs);
 
-    let result = tcx.infer_ctxt(None, None, Reveal::ExactMatch).enter(|mut infcx| {
+    // Create a infcx, taking the predicates of impl1 as assumptions:
+    let result = tcx.infer_ctxt(None, Some(penv), Reveal::ExactMatch).enter(|mut infcx| {
         // Normalize the trait reference, adding any obligations
         // that arise into the impl1 assumptions.
         let Normalized { value: impl1_trait_ref, obligations: normalization_obligations } = {
             let selcx = &mut SelectionContext::new(&infcx);
             traits::normalize(selcx, ObligationCause::dummy(), &impl1_trait_ref)
         };
-        penv.caller_bounds.extend(normalization_obligations.into_iter().map(|o| {
+        infcx.parameter_environment.caller_bounds.extend(normalization_obligations.into_iter().map(|o| {
             match tcx.lift_to_global(&o.predicate) {
                 Some(predicate) => predicate,
                 None => {
@@ -199,9 +202,6 @@ pub fn specializes<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 }
             }
         }));
-
-        // Install the parameter environment, taking the predicates of impl1 as assumptions:
-        infcx.parameter_environment = penv;
 
         // Attempt to prove that impl2 applies, given all of the above.
         fulfill_implication(&infcx, impl1_trait_ref, impl2_def_id).is_ok()

--- a/src/test/run-pass/issue-37291/auxiliary/lib.rs
+++ b/src/test/run-pass/issue-37291/auxiliary/lib.rs
@@ -1,0 +1,52 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "lib"]
+
+use std::ops::Mul;
+
+pub trait A {}
+pub trait B {
+    type AT: A;
+}
+pub trait C {
+    type BT: B;
+}
+
+pub struct AV;
+impl A for AV {}
+
+pub struct BV;
+impl B for BV {
+    type AT = AV;
+}
+
+pub struct CV;
+impl C for CV {
+    type BT = BV;
+}
+
+pub struct WrapperB<T>(pub T);
+pub struct WrapperC<T>(pub T);
+
+impl<C1> Mul<WrapperB<<C1::BT as B>::AT>> for WrapperC<C1>
+    where C1: C
+{
+    type Output = u8;
+    fn mul(self, _: WrapperB<<C1::BT as B>::AT>) -> Self::Output {
+        loop {}
+    }
+}
+impl<C1> Mul<WrapperC<C1>> for WrapperC<C1> {
+    type Output = u8;
+    fn mul(self, _: WrapperC<C1>) -> Self::Output {
+        loop {}
+    }
+}

--- a/src/test/run-pass/issue-37291/main.rs
+++ b/src/test/run-pass/issue-37291/main.rs
@@ -1,0 +1,29 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:lib.rs
+
+// Regression test for #37291. The problem was that the starting
+// environment for a specialization check was not including the
+// where-clauses from the impl when attempting to normalize the impl's
+// trait-ref, so things like `<C as Foo>::Item` could not resolve,
+// since the `C: Foo` trait bound was not included in the environment.
+
+extern crate lib;
+
+use lib::{CV, WrapperB, WrapperC};
+
+fn main() {
+    let a = WrapperC(CV);
+    let b = WrapperC(CV);
+    if false {
+        let _ = a * b;
+    }
+}


### PR DESCRIPTION
This corrects a small regression in specialization that crept in, I think as part of the refactoring to introduce arenas. I also made an experiment (in the last commit) to cleanup the code to be more aggressive about normalization. As the commit log notes, I am not 100% sure that this is correct, but it feels safer, and I think that at worst it yields *more* ICEs (as opposed to admitting faulty code). I'll schedule a crater run to check beyond the testbase.

Fixes #37291.

r? @aturon 