### PR TITLE
E0526: Disallow 'start' feature on nested function

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -1758,6 +1758,33 @@ To understand better how closures work in Rust, read:
 https://doc.rust-lang.org/book/closures.html
 "##,
 
+E0571: r##"
+A nested function was declared with the `#[start]` attribute.
+
+Erroneous code example:
+
+```compile_fail,E0571
+#![feature(start)]
+
+fn foo() {
+    #[start]
+    fn bar(_: isize, _: *const *const u8) -> isize { foo(); 0 }
+    // error: the 'start' function feature can't be set to a nested function
+}
+```
+
+This error indicates that the compiler found a function with the `#[start]`
+attribute nested within another function. Nesting this function is forbidden
+outside of modules to avoid confusion. Example:
+
+```
+#![feature(start)]
+
+#[start]
+fn foo(argc: isize, argv: *const *const u8) -> isize { 0 } // ok!
+```
+"##,
+
 }
 
 

--- a/src/test/compile-fail/feature-gate-start-nested.rs
+++ b/src/test/compile-fail/feature-gate-start-nested.rs
@@ -1,0 +1,18 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(start)]
+
+fn foo() {
+//~^ NOTE `start` function is nested inside this function
+    #[start]
+    fn bar(_: isize, _: *const *const u8) -> isize { foo(); 0 }
+    //~^ ERROR E0571
+}


### PR DESCRIPTION
Introduce a new error code, E0526, disallowing the tagging of a nested nested function with the 'start' feature to avoid confusion and recursive calls:

```rust

fn foo() {
    #[start]
    fn bar(_: isize, _: *const *const u8) -> isize { foo(); 0 }
    //~^ error
}
```

Functions inside of a nested `mod`s are still allowed:

```rust

mod X {
    #[start]
    fn foo(argc: isize, argv: *const *const u8) -> isize { 0 }
}
```

Fixes #14129.