### PR TITLE
Remove mutability from LocalDecl

### DIFF
--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -175,18 +175,12 @@ impl<'tcx> Mir<'tcx> {
     pub fn local_kind(&self, local: Local) -> LocalKind {
         let index = local.0 as usize;
         if index == 0 {
-            debug_assert!(self.local_decls[local].mutability == Mutability::Mut,
-                          "return pointer should be mutable");
-
             LocalKind::ReturnPointer
         } else if index < self.arg_count + 1 {
             LocalKind::Arg
         } else if self.local_decls[local].name.is_some() {
             LocalKind::Var
         } else {
-            debug_assert!(self.local_decls[local].mutability == Mutability::Mut,
-                          "temp should be mutable");
-
             LocalKind::Temp
         }
     }
@@ -351,11 +345,6 @@ pub enum LocalKind {
 /// argument, or the return pointer.
 #[derive(Clone, Debug, RustcEncodable, RustcDecodable)]
 pub struct LocalDecl<'tcx> {
-    /// `let mut x` vs `let x`.
-    ///
-    /// Temporaries and the return pointer are always mutable.
-    pub mutability: Mutability,
-
     /// Type of this local.
     pub ty: Ty<'tcx>,
 
@@ -379,7 +368,6 @@ impl<'tcx> LocalDecl<'tcx> {
     #[inline]
     pub fn new_temp(ty: Ty<'tcx>) -> Self {
         LocalDecl {
-            mutability: Mutability::Mut,
             ty: ty,
             name: None,
             source_info: None,
@@ -392,7 +380,6 @@ impl<'tcx> LocalDecl<'tcx> {
     #[inline]
     pub fn new_return_pointer(return_ty: Ty) -> LocalDecl {
         LocalDecl {
-            mutability: Mutability::Mut,
             ty: return_ty,
             source_info: None,
             name: None,     // FIXME maybe we do want some name here?

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -621,7 +621,6 @@ macro_rules! make_mir_visitor {
             fn super_local_decl(&mut self,
                                 local_decl: & $($mutability)* LocalDecl<'tcx>) {
                 let LocalDecl {
-                    mutability: _,
                     ref $($mutability)* ty,
                     name: _,
                     ref $($mutability)* source_info,

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -174,7 +174,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                             pattern: &Pattern<'tcx>)
                             -> Option<VisibilityScope> {
         match *pattern.kind {
-            PatternKind::Binding { mutability, name, mode: _, var, ty, ref subpattern } => {
+            PatternKind::Binding { mutability: _, name, mode: _, var, ty, ref subpattern } => {
                 if var_scope.is_none() {
                     var_scope = Some(self.new_visibility_scope(scope_span));
                 }
@@ -182,7 +182,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                     span: pattern.span,
                     scope: var_scope.unwrap()
                 };
-                self.declare_binding(source_info, mutability, name, var, ty);
+                self.declare_binding(source_info, name, var, ty);
                 if let Some(subpattern) = subpattern.as_ref() {
                     var_scope = self.declare_bindings(var_scope, scope_span, subpattern);
                 }
@@ -714,7 +714,6 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
 
     fn declare_binding(&mut self,
                        source_info: SourceInfo,
-                       mutability: Mutability,
                        name: Name,
                        var_id: NodeId,
                        var_ty: Ty<'tcx>)
@@ -724,7 +723,6 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                var_id, name, var_ty, source_info);
 
         let var = self.local_decls.push(LocalDecl::<'tcx> {
-            mutability: mutability,
             ty: var_ty.clone(),
             name: Some(name),
             source_info: Some(source_info),

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -327,7 +327,6 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             }
 
             self.local_decls.push(LocalDecl {
-                mutability: Mutability::Not,
                 ty: ty,
                 source_info: None,
                 name: name,

--- a/src/librustc_mir/graphviz.rs
+++ b/src/librustc_mir/graphviz.rs
@@ -148,10 +148,6 @@ fn write_graph_label<'a, 'tcx, W: Write>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         let decl = &mir.local_decls[local];
 
         write!(w, "let ")?;
-        if decl.mutability == Mutability::Mut {
-            write!(w, "mut ")?;
-        }
-
         if let Some(name) = decl.name {
             write!(w, r#"{:?}: {}; // {}<br align="left"/>"#,
                    Lvalue::Local(local), escape(&decl.ty), name)?;

--- a/src/librustc_mir/pretty.rs
+++ b/src/librustc_mir/pretty.rs
@@ -244,17 +244,10 @@ fn write_scope_tree(tcx: TyCtxt,
                 continue;
             };
 
-            let mut_str = if var.mutability == Mutability::Mut {
-                "mut "
-            } else {
-                ""
-            };
-
             let indent = indent + INDENT.len();
-            let indented_var = format!("{0:1$}let {2}{3:?}: {4};",
+            let indented_var = format!("{0:1$}let {2:?}: {3};",
                                        INDENT,
                                        indent,
-                                       mut_str,
                                        local,
                                        var.ty);
             writeln!(w, "{0:1$} // \"{2}\" in {3}",


### PR DESCRIPTION
MIR needs not to contain mutability (as perceived in source) information, because:

1) Locals are all conceptually mutable, MIR does not really have mutability distinction;
2) It is very likely for passes to update MIR in such a way which mutates a variable despite it
   being marked as immutable;
3) This information is never used anywhere, which suggests that this information is indeed very
   useless.