### PR TITLE
Fix ICE when querying DefId on Def::Err.

### DIFF
--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1724,16 +1724,15 @@ fn add_unsized_bound<'gcx: 'tcx, 'tcx>(astconv: &AstConv<'gcx, 'tcx>,
     match unbound {
         Some(ref tpb) => {
             // FIXME(#8559) currently requires the unbound to be built-in.
-            let trait_def_id = tcx.expect_def(tpb.ref_id).def_id();
-            match kind_id {
-                Ok(kind_id) if trait_def_id != kind_id => {
+            if let Ok(kind_id) = kind_id {
+                let trait_def = tcx.expect_def(tpb.ref_id);
+                if trait_def != Def::Trait(kind_id) {
                     tcx.sess.span_warn(span,
                                        "default bound relaxed for a type parameter, but \
                                        this does nothing because the given bound is not \
                                        a default. Only `?Sized` is supported");
                     tcx.try_add_builtin_trait(kind_id, bounds);
                 }
-                _ => {}
             }
         }
         _ if kind_id.is_ok() => {

--- a/src/test/compile-fail/issue-37534.rs
+++ b/src/test/compile-fail/issue-37534.rs
@@ -1,0 +1,16 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo<T: ?Hash> { }
+//~^ ERROR trait `Hash` is not in scope [E0405]
+//~^^ ERROR parameter `T` is never used [E0392]
+//~^^^ WARN default bound relaxed for a type parameter, but this does nothing
+
+fn main() { }


### PR DESCRIPTION
Also moves computations into check that `kind_id` is `Ok(_)`, which is in theory an optimization, though I expect it's minor.

Fixes #37534.

r? @eddyb.