### PR TITLE
Peekable::peek(): Use Option::as_ref()

### DIFF
--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -1341,10 +1341,7 @@ impl<I: Iterator> Peekable<I> {
         if self.peeked.is_none() {
             self.peeked = self.iter.next();
         }
-        match self.peeked {
-            Some(ref value) => Some(value),
-            None => None,
-        }
+        self.peeked.as_ref()
     }
 }
 


### PR DESCRIPTION
Replace the match expression in .peek() with Option::as_ref() since it's the same functionality.