### PR TITLE
[beta] Set RUSTC_BOOTSTRAP to some value.

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -368,7 +368,7 @@ CFG_INFO := $(info cfg: disabling unstable features (CFG_DISABLE_UNSTABLE_FEATUR
 # Turn on feature-staging
 export CFG_DISABLE_UNSTABLE_FEATURES
 # Subvert unstable feature lints to do the self-build
-export RUSTC_BOOTSTRAP
+export RUSTC_BOOTSTRAP=1
 endif
 ifdef CFG_MUSL_ROOT
 export CFG_MUSL_ROOT

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -863,7 +863,7 @@ impl Build {
 
     /// Adds the compiler's bootstrap key to the environment of `cmd`.
     fn add_bootstrap_key(&self, cmd: &mut Command) {
-        cmd.env("RUSTC_BOOTSTRAP", "");
+        cmd.env("RUSTC_BOOTSTRAP", "1");
         // FIXME: Transitionary measure to bootstrap using the old bootstrap logic.
         // Remove this once the bootstrap compiler uses the new login in Issue #36548.
         cmd.env("RUSTC_BOOTSTRAP_KEY", "5c6cf767");


### PR DESCRIPTION
Environment variables on windows can't be empty.

Backport of https://github.com/rust-lang/rust/pull/37566.

Untested.

r? @alexcrichton 