### PR TITLE
Enable function-sections for ARM Thumb targets

### DIFF
--- a/src/librustc_back/target/thumb_base.rs
+++ b/src/librustc_back/target/thumb_base.rs
@@ -42,6 +42,7 @@ use target::TargetOptions;
 pub fn opts() -> TargetOptions {
     // See rust-lang/rfcs#1645 for a discussion about these defaults
     TargetOptions {
+        function_sections: true,
         executables: true,
         // In 99%+ of cases, we want to use the `arm-none-eabi-gcc` compiler (there aren't many
         // options around)


### PR DESCRIPTION
For the ARM thumb targets, I think users would want `function-sections` enabled more often then not, given the importance of code size for these targets.  

Due to https://github.com/rust-lang/rust/issues/26338 there doesn't appear to be a way to pass `-function-sections` and `-data-sections` on the command line for `rustc`.