### PR TITLE
Add `-Z hir-stats` for collecting statistics on HIR and AST

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -918,6 +918,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
           "the directory the MIR is dumped into"),
     perf_stats: bool = (false, parse_bool, [UNTRACKED],
           "print some performance-related statistics"),
+    hir_stats: bool = (false, parse_bool, [UNTRACKED],
+          "print some statistics about AST and HIR"),
 }
 
 pub fn default_lib_output() -> CrateType {

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -75,6 +75,26 @@ pub fn duration_to_secs_str(dur: Duration) -> String {
     format!("{:.3}", secs)
 }
 
+pub fn to_readable_str(mut val: usize) -> String {
+    let mut groups = vec![];
+    loop {
+        let group = val % 1000;
+
+        val /= 1000;
+
+        if val == 0 {
+            groups.push(format!("{}", group));
+            break
+        } else {
+            groups.push(format!("{:03}", group));
+        }
+    }
+
+    groups.reverse();
+
+    groups.join("_")
+}
+
 pub fn record_time<T, F>(accu: &Cell<Duration>, f: F) -> T where
     F: FnOnce() -> T,
 {
@@ -263,4 +283,18 @@ pub fn path2cstr(p: &Path) -> CString {
 #[cfg(windows)]
 pub fn path2cstr(p: &Path) -> CString {
     CString::new(p.to_str().unwrap()).unwrap()
+}
+
+
+#[test]
+fn test_to_readable_str() {
+    assert_eq!("0", to_readable_str(0));
+    assert_eq!("1", to_readable_str(1));
+    assert_eq!("99", to_readable_str(99));
+    assert_eq!("999", to_readable_str(999));
+    assert_eq!("1_000", to_readable_str(1_000));
+    assert_eq!("1_001", to_readable_str(1_001));
+    assert_eq!("999_999", to_readable_str(999_999));
+    assert_eq!("1_000_000", to_readable_str(1_000_000));
+    assert_eq!("1_234_567", to_readable_str(1_234_567));
 }

--- a/src/librustc_passes/hir_stats.rs
+++ b/src/librustc_passes/hir_stats.rs
@@ -1,0 +1,374 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// The visitors in this module collect sizes and counts of the most important
+// pieces of AST and HIR. The resulting numbers are good approximations but not
+// completely accurate (some things might be counted twice, others missed).
+
+use rustc::hir;
+use rustc::hir::intravisit as hir_visit;
+use rustc::util::common::to_readable_str;
+use rustc::util::nodemap::{FnvHashMap, FnvHashSet};
+use syntax::ast::{self, NodeId, AttrId};
+use syntax::visit as ast_visit;
+use syntax_pos::Span;
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+enum Id {
+    Node(NodeId),
+    Attr(AttrId),
+    None,
+}
+
+struct NodeData {
+    count: usize,
+    size: usize,
+}
+
+struct StatCollector<'k> {
+    krate: Option<&'k hir::Crate>,
+    data: FnvHashMap<&'static str, NodeData>,
+    seen: FnvHashSet<Id>,
+}
+
+pub fn print_hir_stats(krate: &hir::Crate) {
+    let mut collector = StatCollector {
+        krate: Some(krate),
+        data: FnvHashMap(),
+        seen: FnvHashSet(),
+    };
+    hir_visit::walk_crate(&mut collector, krate);
+    collector.print("HIR STATS");
+}
+
+pub fn print_ast_stats(krate: &ast::Crate, title: &str) {
+    let mut collector = StatCollector {
+        krate: None,
+        data: FnvHashMap(),
+        seen: FnvHashSet(),
+    };
+    ast_visit::walk_crate(&mut collector, krate);
+    collector.print(title);
+}
+
+impl<'k> StatCollector<'k> {
+
+    fn record<T>(&mut self, label: &'static str, id: Id, node: &T) {
+        if id != Id::None {
+            if !self.seen.insert(id) {
+                return
+            }
+        }
+
+        let entry = self.data.entry(label).or_insert(NodeData {
+            count: 0,
+            size: 0,
+        });
+
+        entry.count += 1;
+        entry.size = ::std::mem::size_of_val(node);
+    }
+
+    fn print(&self, title: &str) {
+        let mut stats: Vec<_> = self.data.iter().collect();
+
+        stats.sort_by_key(|&(_, ref d)| d.count * d.size);
+
+        let mut total_size = 0;
+
+        println!("\n{}\n", title);
+
+        println!("{:<18}{:>18}{:>14}{:>14}",
+            "Name", "Accumulated Size", "Count", "Item Size");
+        println!("----------------------------------------------------------------");
+
+        for (label, data) in stats {
+            println!("{:<18}{:>18}{:>14}{:>14}",
+                label,
+                to_readable_str(data.count * data.size),
+                to_readable_str(data.count),
+                to_readable_str(data.size));
+
+            total_size += data.count * data.size;
+        }
+        println!("----------------------------------------------------------------");
+        println!("{:<18}{:>18}\n",
+                "Total",
+                to_readable_str(total_size));
+    }
+}
+
+impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
+
+    fn visit_nested_item(&mut self, id: hir::ItemId) {
+        let nested_item = self.krate.unwrap().item(id.id);
+        self.visit_item(nested_item)
+    }
+
+    fn visit_item(&mut self, i: &'v hir::Item) {
+        self.record("Item", Id::Node(i.id), i);
+        hir_visit::walk_item(self, i)
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    fn visit_mod(&mut self, m: &'v hir::Mod, _s: Span, n: NodeId) {
+        self.record("Mod", Id::None, m);
+        hir_visit::walk_mod(self, m, n)
+    }
+    fn visit_foreign_item(&mut self, i: &'v hir::ForeignItem) {
+        self.record("ForeignItem", Id::Node(i.id), i);
+        hir_visit::walk_foreign_item(self, i)
+    }
+    fn visit_local(&mut self, l: &'v hir::Local) {
+        self.record("Local", Id::Node(l.id), l);
+        hir_visit::walk_local(self, l)
+    }
+    fn visit_block(&mut self, b: &'v hir::Block) {
+        self.record("Block", Id::Node(b.id), b);
+        hir_visit::walk_block(self, b)
+    }
+    fn visit_stmt(&mut self, s: &'v hir::Stmt) {
+        self.record("Stmt", Id::Node(s.node.id()), s);
+        hir_visit::walk_stmt(self, s)
+    }
+    fn visit_arm(&mut self, a: &'v hir::Arm) {
+        self.record("Arm", Id::None, a);
+        hir_visit::walk_arm(self, a)
+    }
+    fn visit_pat(&mut self, p: &'v hir::Pat) {
+        self.record("Pat", Id::Node(p.id), p);
+        hir_visit::walk_pat(self, p)
+    }
+    fn visit_decl(&mut self, d: &'v hir::Decl) {
+        self.record("Decl", Id::None, d);
+        hir_visit::walk_decl(self, d)
+    }
+    fn visit_expr(&mut self, ex: &'v hir::Expr) {
+        self.record("Expr", Id::Node(ex.id), ex);
+        hir_visit::walk_expr(self, ex)
+    }
+
+    fn visit_ty(&mut self, t: &'v hir::Ty) {
+        self.record("Ty", Id::Node(t.id), t);
+        hir_visit::walk_ty(self, t)
+    }
+
+    fn visit_fn(&mut self,
+                fk: hir_visit::FnKind<'v>,
+                fd: &'v hir::FnDecl,
+                b: &'v hir::Block,
+                s: Span,
+                id: NodeId) {
+        self.record("FnDecl", Id::None, fd);
+        hir_visit::walk_fn(self, fk, fd, b, s, id)
+    }
+
+    fn visit_where_predicate(&mut self, predicate: &'v hir::WherePredicate) {
+        self.record("WherePredicate", Id::None, predicate);
+        hir_visit::walk_where_predicate(self, predicate)
+    }
+
+    fn visit_trait_item(&mut self, ti: &'v hir::TraitItem) {
+        self.record("TraitItem", Id::Node(ti.id), ti);
+        hir_visit::walk_trait_item(self, ti)
+    }
+    fn visit_impl_item(&mut self, ii: &'v hir::ImplItem) {
+        self.record("ImplItem", Id::Node(ii.id), ii);
+        hir_visit::walk_impl_item(self, ii)
+    }
+
+    fn visit_ty_param_bound(&mut self, bounds: &'v hir::TyParamBound) {
+        self.record("TyParamBound", Id::None, bounds);
+        hir_visit::walk_ty_param_bound(self, bounds)
+    }
+
+    fn visit_struct_field(&mut self, s: &'v hir::StructField) {
+        self.record("StructField", Id::Node(s.id), s);
+        hir_visit::walk_struct_field(self, s)
+    }
+
+    fn visit_variant(&mut self,
+                     v: &'v hir::Variant,
+                     g: &'v hir::Generics,
+                     item_id: NodeId) {
+        self.record("Variant", Id::None, v);
+        hir_visit::walk_variant(self, v, g, item_id)
+    }
+    fn visit_lifetime(&mut self, lifetime: &'v hir::Lifetime) {
+        self.record("Lifetime", Id::Node(lifetime.id), lifetime);
+        hir_visit::walk_lifetime(self, lifetime)
+    }
+    fn visit_lifetime_def(&mut self, lifetime: &'v hir::LifetimeDef) {
+        self.record("LifetimeDef", Id::None, lifetime);
+        hir_visit::walk_lifetime_def(self, lifetime)
+    }
+    fn visit_path(&mut self, path: &'v hir::Path, _id: NodeId) {
+        self.record("Path", Id::None, path);
+        hir_visit::walk_path(self, path)
+    }
+    fn visit_path_list_item(&mut self,
+                            prefix: &'v hir::Path,
+                            item: &'v hir::PathListItem) {
+        self.record("PathListItem", Id::Node(item.node.id), item);
+        hir_visit::walk_path_list_item(self, prefix, item)
+    }
+    fn visit_path_segment(&mut self,
+                          path_span: Span,
+                          path_segment: &'v hir::PathSegment) {
+        self.record("PathSegment", Id::None, path_segment);
+        hir_visit::walk_path_segment(self, path_span, path_segment)
+    }
+
+    fn visit_assoc_type_binding(&mut self, type_binding: &'v hir::TypeBinding) {
+        self.record("TypeBinding", Id::Node(type_binding.id), type_binding);
+        hir_visit::walk_assoc_type_binding(self, type_binding)
+    }
+    fn visit_attribute(&mut self, attr: &'v ast::Attribute) {
+        self.record("Attribute", Id::Attr(attr.node.id), attr);
+    }
+    fn visit_macro_def(&mut self, macro_def: &'v hir::MacroDef) {
+        self.record("MacroDef", Id::Node(macro_def.id), macro_def);
+        hir_visit::walk_macro_def(self, macro_def)
+    }
+}
+
+impl<'v> ast_visit::Visitor for StatCollector<'v> {
+
+    fn visit_mod(&mut self, m: &ast::Mod, _s: Span, _n: NodeId) {
+        self.record("Mod", Id::None, m);
+        ast_visit::walk_mod(self, m)
+    }
+
+    fn visit_foreign_item(&mut self, i: &ast::ForeignItem) {
+        self.record("ForeignItem", Id::None, i);
+        ast_visit::walk_foreign_item(self, i)
+    }
+
+    fn visit_item(&mut self, i: &ast::Item) {
+        self.record("Item", Id::None, i);
+        ast_visit::walk_item(self, i)
+    }
+
+    fn visit_local(&mut self, l: &ast::Local) {
+        self.record("Local", Id::None, l);
+        ast_visit::walk_local(self, l)
+    }
+
+    fn visit_block(&mut self, b: &ast::Block) {
+        self.record("Block", Id::None, b);
+        ast_visit::walk_block(self, b)
+    }
+
+    fn visit_stmt(&mut self, s: &ast::Stmt) {
+        self.record("Stmt", Id::None, s);
+        ast_visit::walk_stmt(self, s)
+    }
+
+    fn visit_arm(&mut self, a: &ast::Arm) {
+        self.record("Arm", Id::None, a);
+        ast_visit::walk_arm(self, a)
+    }
+
+    fn visit_pat(&mut self, p: &ast::Pat) {
+        self.record("Pat", Id::None, p);
+        ast_visit::walk_pat(self, p)
+    }
+
+    fn visit_expr(&mut self, ex: &ast::Expr) {
+        self.record("Expr", Id::None, ex);
+        ast_visit::walk_expr(self, ex)
+    }
+
+    fn visit_ty(&mut self, t: &ast::Ty) {
+        self.record("Ty", Id::None, t);
+        ast_visit::walk_ty(self, t)
+    }
+
+    fn visit_fn(&mut self,
+                fk: ast_visit::FnKind,
+                fd: &ast::FnDecl,
+                b: &ast::Block,
+                s: Span,
+                _: NodeId) {
+        self.record("FnDecl", Id::None, fd);
+        ast_visit::walk_fn(self, fk, fd, b, s)
+    }
+
+    fn visit_trait_item(&mut self, ti: &ast::TraitItem) {
+        self.record("TraitItem", Id::None, ti);
+        ast_visit::walk_trait_item(self, ti)
+    }
+
+    fn visit_impl_item(&mut self, ii: &ast::ImplItem) {
+        self.record("ImplItem", Id::None, ii);
+        ast_visit::walk_impl_item(self, ii)
+    }
+
+    fn visit_ty_param_bound(&mut self, bounds: &ast::TyParamBound) {
+        self.record("TyParamBound", Id::None, bounds);
+        ast_visit::walk_ty_param_bound(self, bounds)
+    }
+
+    fn visit_struct_field(&mut self, s: &ast::StructField) {
+        self.record("StructField", Id::None, s);
+        ast_visit::walk_struct_field(self, s)
+    }
+
+    fn visit_variant(&mut self,
+                     v: &ast::Variant,
+                     g: &ast::Generics,
+                     item_id: NodeId) {
+        self.record("Variant", Id::None, v);
+        ast_visit::walk_variant(self, v, g, item_id)
+    }
+
+    fn visit_lifetime(&mut self, lifetime: &ast::Lifetime) {
+        self.record("Lifetime", Id::None, lifetime);
+        ast_visit::walk_lifetime(self, lifetime)
+    }
+
+    fn visit_lifetime_def(&mut self, lifetime: &ast::LifetimeDef) {
+        self.record("LifetimeDef", Id::None, lifetime);
+        ast_visit::walk_lifetime_def(self, lifetime)
+    }
+
+    fn visit_mac(&mut self, mac: &ast::Mac) {
+        self.record("Mac", Id::None, mac);
+    }
+
+    fn visit_path_list_item(&mut self,
+                            prefix: &ast::Path,
+                            item: &ast::PathListItem) {
+        self.record("PathListItem", Id::None, item);
+        ast_visit::walk_path_list_item(self, prefix, item)
+    }
+
+    fn visit_path_segment(&mut self,
+                          path_span: Span,
+                          path_segment: &ast::PathSegment) {
+        self.record("PathSegment", Id::None, path_segment);
+        ast_visit::walk_path_segment(self, path_span, path_segment)
+    }
+
+    fn visit_assoc_type_binding(&mut self, type_binding: &ast::TypeBinding) {
+        self.record("TypeBinding", Id::None, type_binding);
+        ast_visit::walk_assoc_type_binding(self, type_binding)
+    }
+
+    fn visit_attribute(&mut self, attr: &ast::Attribute) {
+        self.record("Attribute", Id::None, attr);
+    }
+
+    fn visit_macro_def(&mut self, macro_def: &ast::MacroDef) {
+        self.record("MacroDef", Id::None, macro_def);
+        ast_visit::walk_macro_def(self, macro_def)
+    }
+}

--- a/src/librustc_passes/lib.rs
+++ b/src/librustc_passes/lib.rs
@@ -45,6 +45,7 @@ pub mod diagnostics;
 
 pub mod ast_validation;
 pub mod consts;
+pub mod hir_stats;
 pub mod loops;
 pub mod no_asm;
 pub mod rvalues;


### PR DESCRIPTION
The data collected will be printed to the commandline and looks like the following:

```
// stats for libcore

PRE EXPANSION AST STATS

Name                Accumulated Size         Count     Item Size
----------------------------------------------------------------
TypeBinding                    2_280            57            40
Mod                            3_560            89            40
PathListItem                   6_516           181            36
Variant                        7_872            82            96
LifetimeDef                   21_280           380            56
StructField                   22_880           260            88
Lifetime                      23_800         1_190            20
Local                         30_192           629            48
ForeignItem                   31_504           179           176
Arm                           42_880           670            64
Mac                           46_960           587            80
FnDecl                        57_792         1_204            48
TraitItem                     69_504           362           192
TyParamBound                  98_280           945           104
Block                        108_384         2_258            48
Stmt                         144_720         3_618            40
ImplItem                     230_272         1_028           224
Item                         467_456         1_826           256
Pat                          517_776         4_623           112
Attribute                    745_680        15_535            48
Ty                         1_114_848         9_954           112
PathSegment                1_218_528        16_924            72
Expr                       3_082_408        20_279           152
----------------------------------------------------------------
Total                      8_095_372


POST EXPANSION AST STATS

Name                Accumulated Size         Count     Item Size
----------------------------------------------------------------
MacroDef                       1_056            12            88
Mod                            3_400            85            40
TypeBinding                    4_280           107            40
PathListItem                   6_516           181            36
Variant                        7_872            82            96
StructField                   24_904           283            88
ForeignItem                   31_504           179           176
TraitItem                     69_504           362           192
Local                         85_008         1_771            48
Arm                          100_288         1_567            64
Lifetime                     123_980         6_199            20
LifetimeDef                  126_728         2_263            56
TyParamBound                 297_128         2_857           104
FnDecl                       305_856         6_372            48
Block                        481_104        10_023            48
Stmt                         535_120        13_378            40
Item                       1_469_952         5_742           256
Attribute                  1_629_840        33_955            48
ImplItem                   1_732_864         7_736           224
Pat                        2_360_176        21_073           112
PathSegment                5_888_448        81_784            72
Ty                         6_237_168        55_689           112
Expr                      12_013_320        79_035           152
----------------------------------------------------------------
Total                     33_536_016


HIR STATS

Name                Accumulated Size         Count     Item Size
----------------------------------------------------------------
MacroDef                         864            12            72
Mod                            2_720            85            32
TypeBinding                    3_424           107            32
PathListItem                   5_068           181            28
Variant                        6_560            82            80
StructField                   20_376           283            72
ForeignItem                   27_208           179           152
WherePredicate                43_776           684            64
TraitItem                     52_128           362           144
Decl                          68_992         2_156            32
Local                         89_184         1_858            48
Arm                           94_368         1_966            48
LifetimeDef                  108_624         2_263            48
Lifetime                     123_980         6_199            20
Stmt                         168_000         4_200            40
TyParamBound                 251_416         2_857            88
FnDecl                       254_880         6_372            40
Block                        583_968        12_166            48
Item                       1_240_272         5_742           216
ImplItem                   1_361_536         7_736           176
Attribute                  1_620_480        33_760            48
Pat                        2_073_120        21_595            96
Path                       2_385_856        74_558            32
Ty                         4_455_040        55_688            80
PathSegment                5_587_904        87_311            64
Expr                       7_588_992        79_052            96
----------------------------------------------------------------
Total                     28_218_736
```