### PR TITLE
Remove recursive call from Cow::to_mut

### DIFF
--- a/src/libcollections/borrow.rs
+++ b/src/libcollections/borrow.rs
@@ -159,7 +159,10 @@ impl<'a, B: ?Sized> Cow<'a, B> where B: ToOwned {
         match *self {
             Borrowed(borrowed) => {
                 *self = Owned(borrowed.to_owned());
-                self.to_mut()
+                match *self {
+                    Borrowed(..) => unreachable!(),
+                    Owned(ref mut owned) => owned,
+                }
             }
             Owned(ref mut owned) => owned,
         }


### PR DESCRIPTION
It seems to prevent it from being inlined.