### PR TITLE
Add a comment to `Arc::MAX_REFCOUNT`

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -36,6 +36,10 @@ use core::{isize, usize};
 use core::convert::From;
 use heap::deallocate;
 
+/// A soft limit on the amount of references that may be made to an `Arc`.
+///
+/// Going above this limit will abort your program (although not
+/// necessarily) at _exactly_ `MAX_REFCOUNT + 1` references.
 const MAX_REFCOUNT: usize = (isize::MAX) as usize;
 
 /// A thread-safe reference-counting pointer.


### PR DESCRIPTION
Before, the strong count of an `Arc` could be set to
`MAX_REFCOUNT + 1`, because when this happened, `old_size` would
be exactly `MAX_REFCOUNT`. `Arc::clone()` would not abort.

This commit changes the check in `Arc::clone()` to also abort if
the old value is equal to `MAX_REFCOUNT`, because then the new
value will be equal to `MAX_REFCOUNT + 1`.

A test would require allocating memory for `isize::MAX` pointers.
This would probably crash any machine, so no test is submitted
with this commit.