### PR TITLE
compile-test: allow overriding nodejs binary location

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -128,6 +128,7 @@ struct Build {
     submodules: Option<bool>,
     gdb: Option<String>,
     vendor: Option<bool>,
+    nodejs: Option<String>,
 }
 
 /// TOML representation of how the LLVM build is configured.
@@ -232,6 +233,7 @@ impl Config {
         }
         config.rustc = build.rustc.map(PathBuf::from);
         config.cargo = build.cargo.map(PathBuf::from);
+        config.nodejs = build.nodejs.map(PathBuf::from);
         config.gdb = build.gdb.map(PathBuf::from);
         set(&mut config.compiler_docs, build.compiler_docs);
         set(&mut config.docs, build.docs);

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -81,15 +81,16 @@ pub fn check(build: &mut Build) {
 
     need_cmd("python".as_ref());
 
-    // Look for the nodejs command, needed for emscripten testing
-    if let Some(node) = have_cmd("node".as_ref()) {
-        build.config.nodejs = Some(node);
-    } else if let Some(node) = have_cmd("nodejs".as_ref()) {
-        build.config.nodejs = Some(node);
-    }
 
     if let Some(ref s) = build.config.nodejs {
         need_cmd(s.as_ref());
+    } else {
+        // Look for the nodejs command, needed for emscripten testing
+        if let Some(node) = have_cmd("node".as_ref()) {
+            build.config.nodejs = Some(node);
+        } else if let Some(node) = have_cmd("nodejs".as_ref()) {
+            build.config.nodejs = Some(node);
+        }
     }
 
     if let Some(ref gdb) = build.config.gdb {

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1456,8 +1456,11 @@ actual:\n\
 
         // If this is emscripten, then run tests under nodejs
         if self.config.target.contains("emscripten") {
-            let nodejs = self.config.nodejs.clone().unwrap_or("nodejs".to_string());
-            args.push(nodejs);
+            if let Some(ref p) = self.config.nodejs {
+                args.push(p.clone());
+            } else {
+                self.fatal("no NodeJS binary found (--nodejs)");
+            }
         }
 
         let exe_file = self.make_exe_name();


### PR DESCRIPTION
Add a command-line argument to manually specify which nodejs binary should be used,
which disables the default search.

Original work done by @tari.

Fixes #34188.