### PR TITLE
macros 1.1: Allow proc_macro functions to declare attributes to be mark as used

### DIFF
--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -95,7 +95,8 @@ pub mod __internal {
     pub trait Registry {
         fn register_custom_derive(&mut self,
                                   trait_name: &str,
-                                  expand: fn(TokenStream) -> TokenStream);
+                                  expand: fn(TokenStream) -> TokenStream,
+                                  attributes: &[&'static str]);
     }
 
     // Emulate scoped_thread_local!() here essentially

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -19,7 +19,7 @@ use std::collections::hash_map::Entry::{Occupied, Vacant};
 
 use syntax::ast;
 use syntax::attr;
-use syntax::feature_gate::{KNOWN_ATTRIBUTES, AttributeType};
+use syntax::feature_gate::{BUILTIN_ATTRIBUTES, AttributeType};
 use syntax::parse::token::keywords;
 use syntax::ptr::P;
 use syntax_pos::Span;
@@ -245,7 +245,7 @@ impl LateLintPass for UnusedAttributes {
         debug!("checking attribute: {:?}", attr);
 
         // Note that check_name() marks the attribute as used if it matches.
-        for &(ref name, ty, _) in KNOWN_ATTRIBUTES {
+        for &(ref name, ty, _) in BUILTIN_ATTRIBUTES {
             match ty {
                 AttributeType::Whitelisted if attr.check_name(name) => {
                     debug!("{:?} is Whitelisted", name);
@@ -267,7 +267,7 @@ impl LateLintPass for UnusedAttributes {
             debug!("Emitting warning for: {:?}", attr);
             cx.span_lint(UNUSED_ATTRIBUTES, attr.span, "unused attribute");
             // Is it a builtin attribute that must be used at the crate level?
-            let known_crate = KNOWN_ATTRIBUTES.iter()
+            let known_crate = BUILTIN_ATTRIBUTES.iter()
                 .find(|&&(name, ty, _)| attr.name() == name && ty == AttributeType::CrateLevel)
                 .is_some();
 

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -624,8 +624,12 @@ impl<'a> CrateLoader<'a> {
         impl Registry for MyRegistrar {
             fn register_custom_derive(&mut self,
                                       trait_name: &str,
-                                      expand: fn(TokenStream) -> TokenStream) {
-                let derive = SyntaxExtension::CustomDerive(Box::new(CustomDerive::new(expand)));
+                                      expand: fn(TokenStream) -> TokenStream,
+                                      attributes: &[&'static str]) {
+                let attrs = attributes.iter().map(|s| InternedString::new(s)).collect();
+                let derive = SyntaxExtension::CustomDerive(
+                    Box::new(CustomDerive::new(expand, attrs))
+                );
                 self.0.push((intern(trait_name), derive));
             }
         }

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -32,7 +32,8 @@ use std::cell::{RefCell, Cell};
 use std::collections::HashSet;
 
 thread_local! {
-    static USED_ATTRS: RefCell<Vec<u64>> = RefCell::new(Vec::new())
+    static USED_ATTRS: RefCell<Vec<u64>> = RefCell::new(Vec::new());
+    static KNOWN_ATTRS: RefCell<Vec<u64>> = RefCell::new(Vec::new());
 }
 
 enum AttrError {
@@ -74,6 +75,29 @@ pub fn mark_used(attr: &Attribute) {
 pub fn is_used(attr: &Attribute) -> bool {
     let AttrId(id) = attr.node.id;
     USED_ATTRS.with(|slot| {
+        let idx = (id / 64) as usize;
+        let shift = id % 64;
+        slot.borrow().get(idx).map(|bits| bits & (1 << shift) != 0)
+            .unwrap_or(false)
+    })
+}
+
+pub fn mark_known(attr: &Attribute) {
+    debug!("Marking {:?} as known.", attr);
+    let AttrId(id) = attr.node.id;
+    KNOWN_ATTRS.with(|slot| {
+        let idx = (id / 64) as usize;
+        let shift = id % 64;
+        if slot.borrow().len() <= idx {
+            slot.borrow_mut().resize(idx + 1, 0);
+        }
+        slot.borrow_mut()[idx] |= 1 << shift;
+    });
+}
+
+pub fn is_known(attr: &Attribute) -> bool {
+    let AttrId(id) = attr.node.id;
+    KNOWN_ATTRS.with(|slot| {
         let idx = (id / 64) as usize;
         let shift = id % 64;
         slot.borrow().get(idx).map(|bits| bits & (1 << shift) != 0)

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -417,11 +417,11 @@ macro_rules! cfg_fn {
 }
 
 pub fn deprecated_attributes() -> Vec<&'static (&'static str, AttributeType, AttributeGate)> {
-    KNOWN_ATTRIBUTES.iter().filter(|a| a.2.is_deprecated()).collect()
+    BUILTIN_ATTRIBUTES.iter().filter(|a| a.2.is_deprecated()).collect()
 }
 
 // Attributes that have a special meaning to rustc or rustdoc
-pub const KNOWN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeGate)] = &[
+pub const BUILTIN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeGate)] = &[
     // Normal attributes
 
     ("warn", Normal, Ungated),
@@ -790,12 +790,12 @@ impl<'a> Context<'a> {
     fn check_attribute(&self, attr: &ast::Attribute, is_macro: bool) {
         debug!("check_attribute(attr = {:?})", attr);
         let name = &*attr.name();
-        for &(n, ty, ref gateage) in KNOWN_ATTRIBUTES {
+        for &(n, ty, ref gateage) in BUILTIN_ATTRIBUTES {
             if n == name {
                 if let &Gated(_, ref name, ref desc, ref has_feature) = gateage {
                     gate_feature_fn!(self, has_feature, attr.span, name, desc);
                 }
-                debug!("check_attribute: {:?} is known, {:?}, {:?}", name, ty, gateage);
+                debug!("check_attribute: {:?} is builtin, {:?}, {:?}", name, ty, gateage);
                 return;
             }
         }
@@ -815,6 +815,8 @@ impl<'a> Context<'a> {
                            are reserved for internal compiler diagnostics");
         } else if name.starts_with("derive_") {
             gate_feature!(self, custom_derive, attr.span, EXPLAIN_DERIVE_UNDERSCORE);
+        } else if attr::is_known(attr) {
+            debug!("check_attribute: {:?} is known", name);
         } else {
             // Only run the custom attribute lint during regular
             // feature gate checking. Macro gating runs

--- a/src/libsyntax_ext/proc_macro_registrar.rs
+++ b/src/libsyntax_ext/proc_macro_registrar.rs
@@ -30,6 +30,7 @@ struct CustomDerive {
     trait_name: InternedString,
     function_name: Ident,
     span: Span,
+    attrs: Vec<InternedString>,
 }
 
 struct CollectCustomDerives<'a> {
@@ -133,7 +134,8 @@ impl<'a> Visitor for CollectCustomDerives<'a> {
         }
 
         // Once we've located the `#[proc_macro_derive]` attribute, verify
-        // that it's of the form `#[proc_macro_derive(Foo)]`
+        // that it's of the form `#[proc_macro_derive(Foo)]` or
+        // `#[proc_macro_derive(Foo, attributes(A, ..))]`
         let list = match attr.meta_item_list() {
             Some(list) => list,
             None => {
@@ -143,38 +145,69 @@ impl<'a> Visitor for CollectCustomDerives<'a> {
                 return
             }
         };
-        if list.len() != 1 {
+        if list.len() != 1 && list.len() != 2 {
             self.handler.span_err(attr.span(),
-                                  "attribute must only have one argument");
+                                  "attribute must have either one or two arguments");
             return
         }
-        let attr = &list[0];
-        let trait_name = match attr.name() {
+        let trait_attr = &list[0];
+        let attributes_attr = list.get(1);
+        let trait_name = match trait_attr.name() {
             Some(name) => name,
             _ => {
-                self.handler.span_err(attr.span(), "not a meta item");
+                self.handler.span_err(trait_attr.span(), "not a meta item");
                 return
             }
         };
-        if !attr.is_word() {
-            self.handler.span_err(attr.span(), "must only be one word");
+        if !trait_attr.is_word() {
+            self.handler.span_err(trait_attr.span(), "must only be one word");
         }
 
         if deriving::is_builtin_trait(&trait_name) {
-            self.handler.span_err(attr.span(),
+            self.handler.span_err(trait_attr.span(),
                                   "cannot override a built-in #[derive] mode");
         }
 
         if self.derives.iter().any(|d| d.trait_name == trait_name) {
-            self.handler.span_err(attr.span(),
+            self.handler.span_err(trait_attr.span(),
                                   "derive mode defined twice in this crate");
         }
+
+        let proc_attrs: Vec<_> = if let Some(attr) = attributes_attr {
+            if !attr.check_name("attributes") {
+                self.handler.span_err(attr.span(), "second argument must be `attributes`")
+            }
+            attr.meta_item_list().unwrap_or_else(|| {
+                self.handler.span_err(attr.span(),
+                                      "attribute must be of form: \
+                                       `attributes(foo, bar)`");
+                &[]
+            }).into_iter().filter_map(|attr| {
+                let name = match attr.name() {
+                    Some(name) => name,
+                    _ => {
+                        self.handler.span_err(attr.span(), "not a meta item");
+                        return None;
+                    },
+                };
+
+                if !attr.is_word() {
+                    self.handler.span_err(attr.span(), "must only be one word");
+                    return None;
+                }
+
+                Some(name)
+            }).collect()
+        } else {
+            Vec::new()
+        };
 
         if self.in_root {
             self.derives.push(CustomDerive {
                 span: item.span,
                 trait_name: trait_name,
                 function_name: item.ident,
+                attrs: proc_attrs,
             });
         } else {
             let msg = "functions tagged with `#[proc_macro_derive]` must \
@@ -208,8 +241,8 @@ impl<'a> Visitor for CollectCustomDerives<'a> {
 //
 //          #[plugin_registrar]
 //          fn registrar(registrar: &mut Registry) {
-//              registrar.register_custom_derive($name_trait1, ::$name1);
-//              registrar.register_custom_derive($name_trait2, ::$name2);
+//              registrar.register_custom_derive($name_trait1, ::$name1, &[]);
+//              registrar.register_custom_derive($name_trait2, ::$name2, &["attribute_name"]);
 //              // ...
 //          }
 //      }
@@ -238,14 +271,18 @@ fn mk_registrar(cx: &mut ExtCtxt,
     let stmts = custom_derives.iter().map(|cd| {
         let path = cx.path_global(cd.span, vec![cd.function_name]);
         let trait_name = cx.expr_str(cd.span, cd.trait_name.clone());
-        (path, trait_name)
-    }).map(|(path, trait_name)| {
+        let attrs = cx.expr_vec_slice(
+            span,
+            cd.attrs.iter().map(|s| cx.expr_str(cd.span, s.clone())).collect::<Vec<_>>()
+        );
+        (path, trait_name, attrs)
+    }).map(|(path, trait_name, attrs)| {
         let registrar = cx.expr_ident(span, registrar);
         let ufcs_path = cx.path(span, vec![proc_macro, __internal, registry,
                                            register_custom_derive]);
         cx.expr_call(span,
                      cx.expr_path(ufcs_path),
-                     vec![registrar, trait_name, cx.expr_path(path)])
+                     vec![registrar, trait_name, cx.expr_path(path), attrs])
     }).map(|expr| {
         cx.stmt_expr(expr)
     }).collect::<Vec<_>>();

--- a/src/test/compile-fail-fulldeps/proc-macro/attribute.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/attribute.rs
@@ -33,8 +33,8 @@ pub fn foo3(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     input
 }
 
-#[proc_macro_derive(b, c)]
-//~^ ERROR: attribute must only have one argument
+#[proc_macro_derive(b, c, d)]
+//~^ ERROR: attribute must have either one or two arguments
 pub fn foo4(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     input
 }
@@ -42,5 +42,23 @@ pub fn foo4(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 #[proc_macro_derive(d(e))]
 //~^ ERROR: must only be one word
 pub fn foo5(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    input
+}
+
+#[proc_macro_derive(f, attributes(g = "h"))]
+//~^ ERROR: must only be one word
+pub fn foo6(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    input
+}
+
+#[proc_macro_derive(i, attributes(j(k)))]
+//~^ ERROR: must only be one word
+pub fn foo7(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    input
+}
+
+#[proc_macro_derive(l, attributes(m), n)]
+//~^ ERROR: attribute must have either one or two arguments
+pub fn foo8(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     input
 }

--- a/src/test/compile-fail-fulldeps/proc-macro/auxiliary/derive-b.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/auxiliary/derive-b.rs
@@ -8,25 +8,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// force-host
 // no-prefer-dynamic
 
-#![crate_type = "proc-macro"]
 #![feature(proc_macro)]
 #![feature(proc_macro_lib)]
+#![crate_type = "proc-macro"]
 
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
 
-#[proc_macro_derive(AddImpl)]
-// #[cfg(proc_macro)]
-pub fn derive(input: TokenStream) -> TokenStream {
-    "impl B {
-            fn foo(&self) {}
-        }
-
-        fn foo() {}
-
-        mod bar { pub fn foo() {} }
-    ".parse().unwrap()
+#[proc_macro_derive(B, attributes(B))]
+pub fn derive_b(input: TokenStream) -> TokenStream {
+    "".parse().unwrap()
 }

--- a/src/test/compile-fail-fulldeps/proc-macro/expand-to-unstable-2.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/expand-to-unstable-2.rs
@@ -17,8 +17,8 @@
 extern crate derive_unstable_2;
 
 #[derive(Unstable)]
-struct A;
 //~^ ERROR: reserved for internal compiler
+struct A;
 
 fn main() {
     foo();

--- a/src/test/compile-fail-fulldeps/proc-macro/expand-to-unstable.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/expand-to-unstable.rs
@@ -17,8 +17,8 @@
 extern crate derive_unstable;
 
 #[derive(Unstable)]
-struct A;
 //~^ ERROR: use of unstable library feature
+struct A;
 
 fn main() {
     unsafe { foo(); }

--- a/src/test/compile-fail-fulldeps/proc-macro/item-error.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/item-error.rs
@@ -8,25 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// no-prefer-dynamic
+// aux-build:derive-b.rs
 
-#![crate_type = "proc-macro"]
 #![feature(proc_macro)]
-#![feature(proc_macro_lib)]
+#![allow(warnings)]
 
-extern crate proc_macro;
+#[macro_use]
+extern crate derive_b;
 
-use proc_macro::TokenStream;
+#[derive(B)]
+struct A {
+    a: &u64
+//~^ ERROR: missing lifetime specifier
+}
 
-#[proc_macro_derive(AddImpl)]
-// #[cfg(proc_macro)]
-pub fn derive(input: TokenStream) -> TokenStream {
-    "impl B {
-            fn foo(&self) {}
-        }
-
-        fn foo() {}
-
-        mod bar { pub fn foo() {} }
-    ".parse().unwrap()
+fn main() {
 }

--- a/src/test/compile-fail-fulldeps/proc-macro/proc-macro-attributes.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/proc-macro-attributes.rs
@@ -8,25 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// no-prefer-dynamic
+// aux-build:derive-b.rs
 
-#![crate_type = "proc-macro"]
 #![feature(proc_macro)]
-#![feature(proc_macro_lib)]
+#![allow(warnings)]
 
-extern crate proc_macro;
+#[macro_use]
+extern crate derive_b;
 
-use proc_macro::TokenStream;
+#[derive(B)]
+#[B]
+#[C] //~ ERROR: The attribute `C` is currently unknown to the compiler
+#[B(D)]
+#[B(E = "foo")]
+struct B;
 
-#[proc_macro_derive(AddImpl)]
-// #[cfg(proc_macro)]
-pub fn derive(input: TokenStream) -> TokenStream {
-    "impl B {
-            fn foo(&self) {}
-        }
-
-        fn foo() {}
-
-        mod bar { pub fn foo() {} }
-    ".parse().unwrap()
-}
+fn main() {}

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/append-impl.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/append-impl.rs
@@ -21,11 +21,8 @@ use proc_macro::TokenStream;
 
 #[proc_macro_derive(Append)]
 pub fn derive_a(input: TokenStream) -> TokenStream {
-    let mut input = input.to_string();
-    input.push_str("
-        impl Append for A {
-            fn foo(&self) {}
-        }
-    ");
-    input.parse().unwrap()
+    "impl Append for A {
+         fn foo(&self) {}
+     }
+    ".parse().unwrap()
 }

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/derive-a.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/derive-a.rs
@@ -23,5 +23,5 @@ pub fn derive(input: TokenStream) -> TokenStream {
     let input = input.to_string();
     assert!(input.contains("struct A;"));
     assert!(input.contains("#[derive(Debug, PartialEq, Eq, Copy, Clone)]"));
-    "#[derive(Debug, PartialEq, Eq, Copy, Clone)] struct A;".parse().unwrap()
+    "".parse().unwrap()
 }

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/derive-b.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/derive-b.rs
@@ -18,15 +18,12 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 
-#[proc_macro_derive(AddImpl)]
-// #[cfg(proc_macro)]
+#[proc_macro_derive(B, attributes(B, C))]
 pub fn derive(input: TokenStream) -> TokenStream {
-    "impl B {
-            fn foo(&self) {}
-        }
-
-        fn foo() {}
-
-        mod bar { pub fn foo() {} }
-    ".parse().unwrap()
+    let input = input.to_string();
+    assert!(input.contains("#[B]"));
+    assert!(input.contains("struct B {"));
+    assert!(input.contains("#[C]"));
+    assert!(input.contains("#[derive(Debug, PartialEq, Eq, Copy, Clone)]"));
+    "".parse().unwrap()
 }

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/derive-same-struct.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/derive-same-struct.rs
@@ -21,7 +21,7 @@ use proc_macro::TokenStream;
 #[proc_macro_derive(AToB)]
 pub fn derive1(input: TokenStream) -> TokenStream {
     println!("input1: {:?}", input.to_string());
-    assert_eq!(input.to_string(), "#[derive(BToC)]\nstruct A;\n");
+    assert_eq!(input.to_string(), "struct A;\n");
     "#[derive(BToC)] struct B;".parse().unwrap()
 }
 

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/expand-with-a-macro.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/expand-with-a-macro.rs
@@ -24,8 +24,6 @@ pub fn derive(input: TokenStream) -> TokenStream {
     let input = input.to_string();
     assert!(input.contains("struct A;"));
     r#"
-        struct A;
-
         impl A {
             fn a(&self) {
                 panic!("hello");

--- a/src/test/run-pass-fulldeps/proc-macro/derive-b.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/derive-b.rs
@@ -8,25 +8,25 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// no-prefer-dynamic
+// aux-build:derive-b.rs
+// ignore-stage1
 
-#![crate_type = "proc-macro"]
 #![feature(proc_macro)]
-#![feature(proc_macro_lib)]
 
-extern crate proc_macro;
+#[macro_use]
+extern crate derive_b;
 
-use proc_macro::TokenStream;
+#[derive(Debug, PartialEq, B, Eq, Copy, Clone)]
+#[B]
+struct B {
+    #[C]
+    a: u64
+}
 
-#[proc_macro_derive(AddImpl)]
-// #[cfg(proc_macro)]
-pub fn derive(input: TokenStream) -> TokenStream {
-    "impl B {
-            fn foo(&self) {}
-        }
-
-        fn foo() {}
-
-        mod bar { pub fn foo() {} }
-    ".parse().unwrap()
+fn main() {
+    B { a: 3 };
+    assert_eq!(B { a: 3 }, B { a: 3 });
+    let b = B { a: 3 };
+    let _d = b;
+    let _e = b;
 }

--- a/src/test/run-pass-fulldeps/proc-macro/derive-same-struct.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/derive-same-struct.rs
@@ -15,7 +15,7 @@
 #[macro_use]
 extern crate derive_same_struct;
 
-#[derive(AToB, BToC)]
+#[derive(AToB)]
 struct A;
 
 fn main() {


### PR DESCRIPTION
This PR allows proc macro functions to declare attribute names that should be marked as used when attached to the deriving item. There are a few questions for this PR.

- Currently this uses a separate attribute named `#[proc_macro_attributes(..)]`, is this the best choice?
- In order to make this work, the `check_attribute` function had to be modified to not error on attributes marked as used. This is a pretty large change in semantics, is there a better way to do this?
- I've got a few clones where I don't know if I need them (like turning `item` into a `TokenStream`), can these be avoided?
- Is switching to `MultiItemDecorator` the right thing here?

Also fixes https://github.com/rust-lang/rust/issues/37563.