### PR TITLE
Remove mention of mipsel target_arch

### DIFF
--- a/src/libpanic_unwind/gcc.rs
+++ b/src/libpanic_unwind/gcc.rs
@@ -124,7 +124,7 @@ const UNWIND_DATA_REG: (i32, i32) = (0, 1); // RAX, RDX
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 const UNWIND_DATA_REG: (i32, i32) = (0, 1); // R0, R1 / X0, X1
 
-#[cfg(any(target_arch = "mips", target_arch = "mipsel", target_arch = "mips64"))]
+#[cfg(any(target_arch = "mips", target_arch = "mips64"))]
 const UNWIND_DATA_REG: (i32, i32) = (4, 5); // A0, A1
 
 #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]


### PR DESCRIPTION
This is the only remaining instance in rustc. All others were in the libc repo, removed with rust-lang/libc#445.

Actually there's more to clean in `libsyntax/abi.rs`, but let's save that for another commit...