### PR TITLE
rustbuild: support MIPS host builds

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -344,6 +344,22 @@ class RustBuild(object):
             ostype += 'eabihf'
         elif cputype == 'aarch64':
             cputype = 'aarch64'
+        elif cputype == 'mips':
+            if sys.byteorder == 'big':
+                cputype = 'mips'
+            elif sys.byteorder == 'little':
+                cputype = 'mipsel'
+            else:
+                raise ValueError('unknown byteorder: ' + sys.byteorder)
+        elif cputype == 'mips64':
+            if sys.byteorder == 'big':
+                cputype = 'mips64'
+            elif sys.byteorder == 'little':
+                cputype = 'mips64el'
+            else:
+                raise ValueError('unknown byteorder: ' + sys.byteorder)
+            # only the n64 ABI is supported, indicate it
+            ostype += 'abi64'
         elif cputype in {'powerpc', 'ppc', 'ppc64'}:
             cputype = 'powerpc'
         elif cputype in {'amd64', 'x86_64', 'x86-64', 'x64'}:


### PR DESCRIPTION
There is a *little* code duplication, but primarily for sake of "match exhaustiveness". Let's blame Linux/MIPS for not exposing endianness explicitly in `uname -m` (that's user-space interface and as such is frozen).

Currently the build won't work as we have to wait for a new stage0 for the MIPS host compilers, but this paves the way to self-hosted Rust on MIPS. The cross-compiled MIPS binaries are confirmed to work on the Loongson 3A2000 (MIPS64r2-compatible) so we have plenty of confidence that they'll work on other MIPS platforms too, as Linux/MIPS user-space ABI is consistent across machines of the same bitness.

r? @alexcrichton 