### PR TITLE
Bump the bootstrap cargo to match the one paired with 1.13

### DIFF
--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -13,4 +13,4 @@
 # released on `$date`
 
 rustc: beta-2016-09-28
-cargo: nightly-2016-09-26
+cargo: nightly-2016-11-02


### PR DESCRIPTION
Now that 1.13 beta has a new cargo pairing, update the master bootstrap to use it.

r? @alexcrichton 