### PR TITLE
Allow configure script to accept LLVM version 4

### DIFF
--- a/configure
+++ b/configure
@@ -1052,6 +1052,9 @@ then
     LLVM_VERSION=$($LLVM_CONFIG --version)
 
     case $LLVM_VERSION in
+        (4.[0-9]*)
+            msg "found ok version of LLVM: $LLVM_VERSION"
+            ;;
         (3.[7-9]*)
             msg "found ok version of LLVM: $LLVM_VERSION"
             ;;


### PR DESCRIPTION
LLVM has moved to version 4.0.0, 
Configure script still expect LLVM version 3.7 to 3.9.
With this small change "--llvm-root" can work with latest upstream LLVM.