### PR TITLE
Document the question mark operator in reference and the book's syntax index

### DIFF
--- a/src/doc/book/syntax-index.md
+++ b/src/doc/book/syntax-index.md
@@ -94,6 +94,7 @@
 * `|=` (`var |= expr`): bitwise or & assignment. Overloadable (`BitOrAssign`).
 * `||` (`expr || expr`): logical or.
 * `_`: "ignored" pattern binding (see [Patterns (Ignoring bindings)]). Also used to make integer-literals readable (see [Reference (Integer literals)]).
+* `?` (`expr?`): Error propagation. Returns early when `Err(_)` is encountered, unwraps otherwise. Similar to the [`try!` macro].
 
 ## Other Syntax
 
@@ -210,6 +211,7 @@
 [Functions]: functions.html
 [Generics]: generics.html
 [Iterators]: iterators.html
+[`try!` macro]: error-handling.html#the-try-macro
 [Lifetimes]: lifetimes.html
 [Loops (`for`)]: loops.html#for
 [Loops (`loop`)]: loops.html#loop

--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -2860,8 +2860,8 @@ assert_eq!(x, y);
 
 ### Unary operator expressions
 
-Rust defines the following unary operators. They are all written as prefix operators,
-before the expression they apply to.
+Rust defines the following unary operators. With the exception of `?`, they are
+all written as prefix operators, before the expression they apply to.
 
 * `-`
   : Negation. Signed integer types and floating-point types support negation. It
@@ -2890,6 +2890,10 @@ before the expression they apply to.
     If the `&` or `&mut` operators are applied to an rvalue, a
     temporary value is created; the lifetime of this temporary value
     is defined by [syntactic rules](#temporary-lifetimes).
+* `?`
+  : Propagating errors if applied to `Err(_)` and unwrapping if
+    applied to `Ok(_)`. Only works on the `Result<T, E>` type,
+    and written in postfix notation.
 
 ### Binary operator expressions
 


### PR DESCRIPTION
The question mark operator will be stabilized for the Rust 1.13 release (unfortunately). Even though I don't like the operator, it still should be documented in the syntax index in the book and in the reference.

Maybe there are people who also want to change the book's chapters on error handling, depending on their views of what idiomatic error handling is, now that the operator is stable, but I don't want to and I'd prefer to keep this PR focused on the reference and syntax index only.

Please also apply this PR to the beta branch of rust.