### PR TITLE
rustbuild: enable an initial local cargo

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -226,13 +226,16 @@ class RustBuild(object):
         config = self.get_toml('cargo')
         if config:
             return config
+        config = self.get_mk('CFG_LOCAL_RUST_ROOT')
+        if config:
+            return config + '/bin/cargo' + self.exe_suffix()
         return os.path.join(self.bin_root(), "bin/cargo" + self.exe_suffix())
 
     def rustc(self):
         config = self.get_toml('rustc')
         if config:
             return config
-        config = self.get_mk('CFG_LOCAL_RUST')
+        config = self.get_mk('CFG_LOCAL_RUST_ROOT')
         if config:
             return config + '/bin/rustc' + self.exe_suffix()
         return os.path.join(self.bin_root(), "bin/rustc" + self.exe_suffix())


### PR DESCRIPTION
This allows the initial build of src/bootstrap itself to use a local
cargo taken from `configure --local-rust-root`.  It was already finding
rustc this way, but was always downloading cargo since it didn't know
where to find it.

It now matches the same logic that `config.rs` will use for stage0,
where both rustc and cargo are taken from `CFG_LOCAL_RUST_ROOT`.