### PR TITLE
[8/n] rustc: clean up lookup_item_type and remove TypeScheme.

### DIFF
--- a/src/librustc/dep_graph/dep_tracking_map.rs
+++ b/src/librustc/dep_graph/dep_tracking_map.rs
@@ -112,15 +112,15 @@ impl<M: DepTrackingMapConfig> MemoizationMap for RefCell<DepTrackingMap<M>> {
     /// switched to `Map(key)`. Therefore, if `op` makes use of any
     /// HIR nodes or shared state accessed through its closure
     /// environment, it must explicitly register a read of that
-    /// state. As an example, see `type_scheme_of_item` in `collect`,
+    /// state. As an example, see `type_of_item` in `collect`,
     /// which looks something like this:
     ///
     /// ```
-    /// fn type_scheme_of_item(..., item: &hir::Item) -> ty::TypeScheme<'tcx> {
+    /// fn type_of_item(..., item: &hir::Item) -> Ty<'tcx> {
     ///     let item_def_id = ccx.tcx.map.local_def_id(it.id);
-    ///     ccx.tcx.tcache.memoized(item_def_id, || {
+    ///     ccx.tcx.item_types.memoized(item_def_id, || {
     ///         ccx.tcx.dep_graph.read(DepNode::Hir(item_def_id)); // (*)
-    ///         compute_type_scheme_of_item(ccx, item)
+    ///         compute_type_of_item(ccx, item)
     ///     });
     /// }
     /// ```

--- a/src/librustc/infer/error_reporting.rs
+++ b/src/librustc/infer/error_reporting.rs
@@ -1436,7 +1436,7 @@ impl<'a, 'gcx, 'tcx> Rebuilder<'a, 'gcx, 'tcx> {
                     match self.tcx.expect_def(cur_ty.id) {
                         Def::Enum(did) | Def::TyAlias(did) |
                         Def::Struct(did) | Def::Union(did) => {
-                            let generics = self.tcx.lookup_generics(did);
+                            let generics = self.tcx.item_generics(did);
 
                             let expected =
                                 generics.regions.len() as u32;

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -433,7 +433,7 @@ impl<'a, 'tcx> DeadVisitor<'a, 'tcx> {
     }
 
     fn should_warn_about_field(&mut self, field: &hir::StructField) -> bool {
-        let field_type = self.tcx.tables().node_id_to_type(field.id);
+        let field_type = self.tcx.item_type(self.tcx.map.local_def_id(field.id));
         let is_marker_field = match field_type.ty_to_def_id() {
             Some(def_id) => self.tcx.lang_items.items().iter().any(|item| *item == Some(def_id)),
             _ => false

--- a/src/librustc/middle/intrinsicck.rs
+++ b/src/librustc/middle/intrinsicck.rs
@@ -51,7 +51,7 @@ struct ExprVisitor<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
 
 impl<'a, 'gcx, 'tcx> ExprVisitor<'a, 'gcx, 'tcx> {
     fn def_id_is_transmute(&self, def_id: DefId) -> bool {
-        let intrinsic = match self.infcx.tcx.lookup_item_type(def_id).ty.sty {
+        let intrinsic = match self.infcx.tcx.item_type(def_id).sty {
             ty::TyFnDef(.., ref bfty) => bfty.abi == RustIntrinsic,
             _ => return false
         };

--- a/src/librustc/mir/tcx.rs
+++ b/src/librustc/mir/tcx.rs
@@ -125,7 +125,7 @@ impl<'tcx> Lvalue<'tcx> {
             Lvalue::Local(index) =>
                 LvalueTy::Ty { ty: mir.local_decls[index].ty },
             Lvalue::Static(def_id) =>
-                LvalueTy::Ty { ty: tcx.lookup_item_type(def_id).ty },
+                LvalueTy::Ty { ty: tcx.item_type(def_id) },
             Lvalue::Projection(ref proj) =>
                 proj.base.ty(mir, tcx).projection_ty(tcx, &proj.elem),
         }
@@ -188,7 +188,7 @@ impl<'tcx> Rvalue<'tcx> {
                         ))
                     }
                     AggregateKind::Adt(def, _, substs, _) => {
-                        Some(tcx.lookup_item_type(def.did).ty.subst(tcx, substs))
+                        Some(tcx.item_type(def.did).subst(tcx, substs))
                     }
                     AggregateKind::Closure(did, substs) => {
                         Some(tcx.mk_closure_from_closure_substs(did, substs))

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -603,7 +603,7 @@ pub fn get_vtable_methods<'a, 'tcx>(
             // do not hold for this particular set of type parameters.
             // Note that this method could then never be called, so we
             // do not want to try and trans it, in that case (see #23435).
-            let predicates = tcx.lookup_predicates(def_id).instantiate_own(tcx, substs);
+            let predicates = tcx.item_predicates(def_id).instantiate_own(tcx, substs);
             if !normalize_and_test_predicates(tcx, predicates.predicates) {
                 debug!("get_vtable_methods: predicates do not hold");
                 return None;

--- a/src/librustc/traits/object_safety.rs
+++ b/src/librustc/traits/object_safety.rs
@@ -129,7 +129,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         let trait_def = self.lookup_trait_def(trait_def_id);
         let trait_ref = trait_def.trait_ref.clone();
         let trait_ref = trait_ref.to_poly_trait_ref();
-        let predicates = self.lookup_super_predicates(trait_def_id);
+        let predicates = self.item_super_predicates(trait_def_id);
         predicates
             .predicates
             .into_iter()
@@ -166,7 +166,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         // Search for a predicate like `Self : Sized` amongst the trait bounds.
         let free_substs = self.construct_free_substs(def_id,
             self.region_maps.node_extent(ast::DUMMY_NODE_ID));
-        let predicates = self.lookup_predicates(def_id);
+        let predicates = self.item_predicates(def_id);
         let predicates = predicates.instantiate(self, free_substs).predicates;
         elaborate_predicates(self, predicates)
             .any(|predicate| {
@@ -238,7 +238,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
 
         // The `Self` type is erased, so it should not appear in list of
         // arguments or return type apart from the receiver.
-        let ref sig = self.lookup_item_type(method.def_id).ty.fn_sig();
+        let ref sig = self.item_type(method.def_id).fn_sig();
         for &input_ty in &sig.0.inputs[1..] {
             if self.contains_illegal_self_type_reference(trait_def_id, input_ty) {
                 return Some(MethodViolationCode::ReferencesSelf);
@@ -249,7 +249,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         }
 
         // We can't monomorphize things like `fn foo<A>(...)`.
-        if !self.lookup_generics(method.def_id).types.is_empty() {
+        if !self.item_generics(method.def_id).types.is_empty() {
             return Some(MethodViolationCode::Generic);
         }
 

--- a/src/librustc/traits/project.rs
+++ b/src/librustc/traits/project.rs
@@ -311,7 +311,7 @@ impl<'a, 'b, 'gcx, 'tcx> TypeFolder<'gcx, 'tcx> for AssociatedTypeNormalizer<'a,
             ty::TyAnon(def_id, substs) if !substs.has_escaping_regions() => { // (*)
                 // Only normalize `impl Trait` after type-checking, usually in trans.
                 if self.selcx.projection_mode() == Reveal::All {
-                    let generic_ty = self.tcx().lookup_item_type(def_id).ty;
+                    let generic_ty = self.tcx().item_type(def_id);
                     let concrete_ty = generic_ty.subst(self.tcx(), substs);
                     self.fold_ty(concrete_ty)
                 } else {
@@ -809,7 +809,7 @@ fn assemble_candidates_from_trait_def<'cx, 'gcx, 'tcx>(
     };
 
     // If so, extract what we know from the trait and try to come up with a good answer.
-    let trait_predicates = selcx.tcx().lookup_predicates(def_id);
+    let trait_predicates = selcx.tcx().item_predicates(def_id);
     let bounds = trait_predicates.instantiate(selcx.tcx(), substs);
     let bounds = elaborate_predicates(selcx.tcx(), bounds.predicates);
     assemble_candidates_from_predicates(selcx,
@@ -1313,7 +1313,7 @@ fn confirm_impl_candidate<'cx, 'gcx, 'tcx>(
                        obligation.predicate.trait_ref);
                 tcx.types.err
             } else {
-                tcx.lookup_item_type(node_item.item.def_id).ty
+                tcx.item_type(node_item.item.def_id)
             };
             let substs = translate_substs(selcx.infcx(), impl_def_id, substs, node_item.node);
             Progress {

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -1200,7 +1200,7 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
                 def_id={:?}, substs={:?}",
                def_id, substs);
 
-        let item_predicates = self.tcx().lookup_predicates(def_id);
+        let item_predicates = self.tcx().item_predicates(def_id);
         let bounds = item_predicates.instantiate(self.tcx(), substs);
         debug!("match_projection_obligation_against_definition_bounds: \
                 bounds={:?}",
@@ -2884,7 +2884,7 @@ impl<'cx, 'gcx, 'tcx> SelectionContext<'cx, 'gcx, 'tcx> {
         // obligation will normalize to `<$0 as Iterator>::Item = $1` and
         // `$1: Copy`, so we must ensure the obligations are emitted in
         // that order.
-        let predicates = tcx.lookup_predicates(def_id);
+        let predicates = tcx.item_predicates(def_id);
         assert_eq!(predicates.parent, None);
         let predicates = predicates.predicates.iter().flat_map(|predicate| {
             let predicate = normalize_with_depth(self, cause.clone(), recursion_depth,

--- a/src/librustc/traits/util.rs
+++ b/src/librustc/traits/util.rs
@@ -128,7 +128,7 @@ impl<'cx, 'gcx, 'tcx> Elaborator<'cx, 'gcx, 'tcx> {
         match *predicate {
             ty::Predicate::Trait(ref data) => {
                 // Predicates declared on the trait.
-                let predicates = tcx.lookup_super_predicates(data.def_id());
+                let predicates = tcx.item_super_predicates(data.def_id());
 
                 let mut predicates: Vec<_> =
                     predicates.predicates
@@ -295,7 +295,7 @@ impl<'cx, 'gcx, 'tcx> Iterator for SupertraitDefIds<'cx, 'gcx, 'tcx> {
             None => { return None; }
         };
 
-        let predicates = self.tcx.lookup_super_predicates(def_id);
+        let predicates = self.tcx.item_super_predicates(def_id);
         let visited = &mut self.visited;
         self.stack.extend(
             predicates.predicates
@@ -362,7 +362,7 @@ pub fn impl_trait_ref_and_oblig<'a, 'gcx, 'tcx>(selcx: &mut SelectionContext<'a,
     let Normalized { value: impl_trait_ref, obligations: normalization_obligations1 } =
         super::normalize(selcx, ObligationCause::dummy(), &impl_trait_ref);
 
-    let predicates = selcx.tcx().lookup_predicates(impl_def_id);
+    let predicates = selcx.tcx().item_predicates(impl_def_id);
     let predicates = predicates.instantiate(selcx.tcx(), impl_substs);
     let Normalized { value: predicates, obligations: normalization_obligations2 } =
         super::normalize(selcx, ObligationCause::dummy(), &predicates);

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -444,7 +444,7 @@ pub struct GlobalCtxt<'tcx> {
     pub maybe_unused_trait_imports: NodeSet,
 
     // Records the type of every item.
-    pub tcache: RefCell<DepTrackingMap<maps::Tcache<'tcx>>>,
+    pub item_types: RefCell<DepTrackingMap<maps::Types<'tcx>>>,
 
     // Internal cache for metadata decoding. No need to track deps on this.
     pub rcache: RefCell<FxHashMap<ty::CReaderCacheKey, Ty<'tcx>>>,
@@ -665,10 +665,6 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         self.ty_param_defs.borrow().get(&node_id).unwrap().clone()
     }
 
-    pub fn node_type_insert(self, id: NodeId, ty: Ty<'gcx>) {
-        self.tables.borrow_mut().node_types.insert(id, ty);
-    }
-
     pub fn alloc_generics(self, generics: ty::Generics<'gcx>)
                           -> &'gcx ty::Generics<'gcx> {
         self.global_interners.arenas.generics.alloc(generics)
@@ -815,7 +811,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             mir_map: RefCell::new(DepTrackingMap::new(dep_graph.clone())),
             freevars: RefCell::new(freevars),
             maybe_unused_trait_imports: maybe_unused_trait_imports,
-            tcache: RefCell::new(DepTrackingMap::new(dep_graph.clone())),
+            item_types: RefCell::new(DepTrackingMap::new(dep_graph.clone())),
             rcache: RefCell::new(FxHashMap()),
             tc_cache: RefCell::new(FxHashMap()),
             associated_items: RefCell::new(DepTrackingMap::new(dep_graph.clone())),

--- a/src/librustc/ty/item_path.rs
+++ b/src/librustc/ty/item_path.rs
@@ -218,7 +218,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         // users may find it useful. Currently, we omit the parent if
         // the impl is either in the same module as the self-type or
         // as the trait.
-        let self_ty = self.lookup_item_type(impl_def_id).ty;
+        let self_ty = self.item_type(impl_def_id);
         let in_self_mod = match characteristic_def_id_of_type(self_ty) {
             None => false,
             Some(ty_def_id) => self.parent_def_id(ty_def_id) == Some(parent_def_id),

--- a/src/librustc/ty/maps.rs
+++ b/src/librustc/ty/maps.rs
@@ -33,7 +33,7 @@ macro_rules! dep_map_ty {
 }
 
 dep_map_ty! { AssociatedItems: AssociatedItems(DefId) -> ty::AssociatedItem }
-dep_map_ty! { Tcache: ItemSignature(DefId) -> Ty<'tcx> }
+dep_map_ty! { Types: ItemSignature(DefId) -> Ty<'tcx> }
 dep_map_ty! { Generics: ItemSignature(DefId) -> &'tcx ty::Generics<'tcx> }
 dep_map_ty! { Predicates: ItemSignature(DefId) -> ty::GenericPredicates<'tcx> }
 dep_map_ty! { SuperPredicates: ItemSignature(DefId) -> ty::GenericPredicates<'tcx> }

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -164,7 +164,7 @@ pub enum TypeVariants<'tcx> {
     /// Anonymized (`impl Trait`) type found in a return type.
     /// The DefId comes from the `impl Trait` ast::Ty node, and the
     /// substitutions are for the generics of the function in question.
-    /// After typeck, the concrete type can be found in the `tcache` map.
+    /// After typeck, the concrete type can be found in the `types` map.
     TyAnon(DefId, &'tcx Substs<'tcx>),
 
     /// A type parameter; for example, `T` in `fn f<T>(x: T) {}
@@ -556,7 +556,7 @@ pub struct DebruijnIndex {
 ///
 /// These are regions that are stored behind a binder and must be substituted
 /// with some concrete region before being used. There are 2 kind of
-/// bound regions: early-bound, which are bound in a TypeScheme/TraitDef,
+/// bound regions: early-bound, which are bound in an item's Generics,
 /// and are substituted by a Substs,  and late-bound, which are part of
 /// higher-ranked types (e.g. `for<'a> fn(&'a ())`) and are substituted by
 /// the likes of `liberate_late_bound_regions`. The distinction exists

--- a/src/librustc/ty/subst.rs
+++ b/src/librustc/ty/subst.rs
@@ -177,7 +177,7 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
                             -> &'tcx Substs<'tcx>
     where FR: FnMut(&ty::RegionParameterDef, &[Kind<'tcx>]) -> &'tcx ty::Region,
           FT: FnMut(&ty::TypeParameterDef<'tcx>, &[Kind<'tcx>]) -> Ty<'tcx> {
-        let defs = tcx.lookup_generics(def_id);
+        let defs = tcx.item_generics(def_id);
         let mut substs = Vec::with_capacity(defs.count());
         Substs::fill_item(&mut substs, tcx, defs, &mut mk_region, &mut mk_type);
         tcx.intern_substs(&substs)
@@ -192,7 +192,7 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
           FT: FnMut(&ty::TypeParameterDef<'tcx>, &[Kind<'tcx>]) -> Ty<'tcx> {
 
         if let Some(def_id) = defs.parent {
-            let parent_defs = tcx.lookup_generics(def_id);
+            let parent_defs = tcx.item_generics(def_id);
             Substs::fill_item(substs, tcx, parent_defs, mk_region, mk_type);
         }
 
@@ -271,7 +271,7 @@ impl<'a, 'gcx, 'tcx> Substs<'tcx> {
                        source_ancestor: DefId,
                        target_substs: &Substs<'tcx>)
                        -> &'tcx Substs<'tcx> {
-        let defs = tcx.lookup_generics(source_ancestor);
+        let defs = tcx.item_generics(source_ancestor);
         tcx.mk_substs(target_substs.iter().chain(&self[defs.own_count()..]).cloned())
     }
 }
@@ -519,7 +519,7 @@ impl<'a, 'gcx, 'tcx> ty::TraitRef<'tcx> {
                        trait_id: DefId,
                        substs: &Substs<'tcx>)
                        -> ty::TraitRef<'tcx> {
-        let defs = tcx.lookup_generics(trait_id);
+        let defs = tcx.item_generics(trait_id);
 
         ty::TraitRef {
             def_id: trait_id,

--- a/src/librustc/ty/trait_def.rs
+++ b/src/librustc/ty/trait_def.rs
@@ -18,7 +18,7 @@ use std::cell::{Cell, RefCell};
 use hir;
 use util::nodemap::FxHashMap;
 
-/// As `TypeScheme` but for a trait ref.
+/// A trait's definition with type information.
 pub struct TraitDef<'tcx> {
     pub unsafety: hir::Unsafety,
 

--- a/src/librustc/ty/wf.rs
+++ b/src/librustc/ty/wf.rs
@@ -446,7 +446,7 @@ impl<'a, 'gcx, 'tcx> WfPredicates<'a, 'gcx, 'tcx> {
                            -> Vec<traits::PredicateObligation<'tcx>>
     {
         let predicates =
-            self.infcx.tcx.lookup_predicates(def_id)
+            self.infcx.tcx.item_predicates(def_id)
                           .instantiate(self.infcx.tcx, substs);
         let cause = self.cause(traits::ItemObligation(def_id));
         predicates.predicates

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -105,7 +105,7 @@ pub fn parameterized(f: &mut fmt::Formatter,
                 }
             }
         }
-        let mut generics = tcx.lookup_generics(item_def_id);
+        let mut generics = tcx.item_generics(item_def_id);
         let mut path_def_id = did;
         verbose = tcx.sess.verbose();
         has_self = generics.has_self;
@@ -115,7 +115,7 @@ pub fn parameterized(f: &mut fmt::Formatter,
             // Methods.
             assert!(is_value_path);
             child_types = generics.types.len();
-            generics = tcx.lookup_generics(def_id);
+            generics = tcx.item_generics(def_id);
             num_regions = generics.regions.len();
             num_types = generics.types.len();
 
@@ -865,7 +865,7 @@ impl<'tcx> fmt::Display for ty::TypeVariants<'tcx> {
             TyAdt(def, substs) => {
                 ty::tls::with(|tcx| {
                     if def.did.is_local() &&
-                          !tcx.tcache.borrow().contains_key(&def.did) {
+                          !tcx.item_types.borrow().contains_key(&def.did) {
                         write!(f, "{}<..>", tcx.item_path_str(def.did))
                     } else {
                         parameterized(f, substs, def.did, &[])
@@ -878,7 +878,7 @@ impl<'tcx> fmt::Display for ty::TypeVariants<'tcx> {
                 ty::tls::with(|tcx| {
                     // Grab the "TraitA + TraitB" from `impl TraitA + TraitB`,
                     // by looking up the projections associated with the def_id.
-                    let item_predicates = tcx.lookup_predicates(def_id);
+                    let item_predicates = tcx.item_predicates(def_id);
                     let substs = tcx.lift(&substs).unwrap_or_else(|| {
                         tcx.intern_substs(&[])
                     });

--- a/src/librustc_borrowck/borrowck/mir/elaborate_drops.rs
+++ b/src/librustc_borrowck/borrowck/mir/elaborate_drops.rs
@@ -858,7 +858,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
         let free_func = tcx.lang_items.require(lang_items::BoxFreeFnLangItem)
             .unwrap_or_else(|e| tcx.sess.fatal(&e));
         let substs = tcx.mk_substs(iter::once(Kind::from(ty)));
-        let fty = tcx.lookup_item_type(free_func).ty.subst(tcx, substs);
+        let fty = tcx.item_type(free_func).subst(tcx, substs);
 
         self.patch.new_block(BasicBlockData {
             statements: statements,

--- a/src/librustc_metadata/astencode.rs
+++ b/src/librustc_metadata/astencode.rs
@@ -133,7 +133,10 @@ pub fn decode_inlined_item<'a, 'tcx>(cdata: &CrateMetadata,
         &InlinedItem::ImplItem(_, ref ii) => ii.id,
     };
     let inlined_did = tcx.map.local_def_id(item_node_id);
-    tcx.register_item_type(inlined_did, tcx.lookup_item_type(orig_did));
+    let ty = tcx.item_type(orig_did);
+    let generics = tcx.item_generics(orig_did);
+    tcx.item_types.borrow_mut().insert(inlined_did, ty);
+    tcx.generics.borrow_mut().insert(inlined_did, generics);
 
     for (id, entry) in ast.side_tables.decode((cdata, tcx, id_ranges)) {
         match entry {
@@ -141,7 +144,7 @@ pub fn decode_inlined_item<'a, 'tcx>(cdata: &CrateMetadata,
                 tcx.def_map.borrow_mut().insert(id, def::PathResolution::new(def));
             }
             TableEntry::NodeType(ty) => {
-                tcx.node_type_insert(id, ty);
+                tcx.tables.borrow_mut().node_types.insert(id, ty);
             }
             TableEntry::ItemSubsts(item_substs) => {
                 tcx.tables.borrow_mut().item_substs.insert(id, item_substs);

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -526,7 +526,7 @@ impl<'a, 'tcx> CrateMetadata {
 
         ty::TraitDef::new(data.unsafety,
                           data.paren_sugar,
-                          tcx.lookup_generics(self.local_def_id(item_id)),
+                          tcx.item_generics(self.local_def_id(item_id)),
                           data.trait_ref.decode((self, tcx)),
                           self.def_path(item_id).unwrap().deterministic_hash(tcx))
     }

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -246,7 +246,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
 
     fn encode_item_type(&mut self, def_id: DefId) -> Lazy<Ty<'tcx>> {
         let tcx = self.tcx;
-        self.lazy(&tcx.lookup_item_type(def_id).ty)
+        self.lazy(&tcx.item_type(def_id))
     }
 
     /// Encode data for the given variant of the given ADT. The
@@ -444,12 +444,12 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
 
     fn encode_generics(&mut self, def_id: DefId) -> Lazy<ty::Generics<'tcx>> {
         let tcx = self.tcx;
-        self.lazy(tcx.lookup_generics(def_id))
+        self.lazy(tcx.item_generics(def_id))
     }
 
     fn encode_predicates(&mut self, def_id: DefId) -> Lazy<ty::GenericPredicates<'tcx>> {
         let tcx = self.tcx;
-        self.lazy(&tcx.lookup_predicates(def_id))
+        self.lazy(&tcx.item_predicates(def_id))
     }
 
     fn encode_info_for_trait_item(&mut self, def_id: DefId) -> Entry<'tcx> {
@@ -556,7 +556,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         let (ast, mir) = if impl_item.kind == ty::AssociatedKind::Const {
             (true, true)
         } else if let hir::ImplItemKind::Method(ref sig, _) = ast_item.node {
-            let generics = self.tcx.lookup_generics(def_id);
+            let generics = self.tcx.item_generics(def_id);
             let types = generics.parent_types as usize + generics.types.len();
             let needs_inline = types > 0 || attr::requests_inline(&ast_item.attrs);
             let is_const_fn = sig.constness == hir::Constness::Const;
@@ -717,7 +717,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                     paren_sugar: trait_def.paren_sugar,
                     has_default_impl: tcx.trait_has_default_impl(def_id),
                     trait_ref: self.lazy(&trait_def.trait_ref),
-                    super_predicates: self.lazy(&tcx.lookup_super_predicates(def_id)),
+                    super_predicates: self.lazy(&tcx.item_super_predicates(def_id)),
                 };
 
                 EntryKind::Trait(self.lazy(&data))

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -155,6 +155,7 @@ macro_rules! unpack {
 pub fn construct_fn<'a, 'gcx, 'tcx, A>(hir: Cx<'a, 'gcx, 'tcx>,
                                        fn_id: ast::NodeId,
                                        arguments: A,
+                                       abi: Abi,
                                        return_ty: Ty<'gcx>,
                                        ast_body: &'gcx hir::Expr)
                                        -> (Mir<'tcx>, ScopeAuxiliaryVec)
@@ -191,12 +192,9 @@ pub fn construct_fn<'a, 'gcx, 'tcx, A>(hir: Cx<'a, 'gcx, 'tcx>,
     assert_eq!(block, builder.return_block());
 
     let mut spread_arg = None;
-    match tcx.tables().node_id_to_type(fn_id).sty {
-        ty::TyFnDef(_, _, f) if f.abi == Abi::RustCall => {
-            // RustCall pseudo-ABI untuples the last argument.
-            spread_arg = Some(Local::new(arguments.len()));
-        }
-        _ => {}
+    if abi == Abi::RustCall {
+        // RustCall pseudo-ABI untuples the last argument.
+        spread_arg = Some(Local::new(arguments.len()));
     }
 
     // Gather the upvars of a closure, if any.

--- a/src/librustc_mir/build/scope.rs
+++ b/src/librustc_mir/build/scope.rs
@@ -806,7 +806,7 @@ fn build_free<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
     TerminatorKind::Call {
         func: Operand::Constant(Constant {
             span: data.span,
-            ty: tcx.lookup_item_type(free_func).ty.subst(tcx, substs),
+            ty: tcx.item_type(free_func).subst(tcx, substs),
             literal: Literal::Item {
                 def_id: free_func,
                 substs: substs

--- a/src/librustc_mir/hair/cx/mod.rs
+++ b/src/librustc_mir/hair/cx/mod.rs
@@ -149,8 +149,8 @@ impl<'a, 'gcx, 'tcx> Cx<'a, 'gcx, 'tcx> {
         let substs = self.tcx.mk_substs_trait(self_ty, params);
         for item in self.tcx.associated_items(trait_def_id) {
             if item.kind == ty::AssociatedKind::Method && item.name == method_name {
-                let method_ty = self.tcx.lookup_item_type(item.def_id);
-                let method_ty = method_ty.ty.subst(self.tcx, substs);
+                let method_ty = self.tcx.item_type(item.def_id);
+                let method_ty = method_ty.subst(self.tcx, substs);
                 return (method_ty, Literal::Item {
                     def_id: item.def_id,
                     substs: substs,

--- a/src/librustc_mir/transform/type_check.rs
+++ b/src/librustc_mir/transform/type_check.rs
@@ -127,7 +127,7 @@ impl<'a, 'b, 'gcx, 'tcx> TypeVerifier<'a, 'b, 'gcx, 'tcx> {
         match *lvalue {
             Lvalue::Local(index) => LvalueTy::Ty { ty: self.mir.local_decls[index].ty },
             Lvalue::Static(def_id) =>
-                LvalueTy::Ty { ty: self.tcx().lookup_item_type(def_id).ty },
+                LvalueTy::Ty { ty: self.tcx().item_type(def_id) },
             Lvalue::Projection(ref proj) => {
                 let base_ty = self.sanitize_lvalue(&proj.base, location);
                 if let LvalueTy::Ty { ty } = base_ty {

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -286,7 +286,8 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
                           scope: NodeId) -> Option<VariableData> {
         if let Some(ident) = field.ident {
             let qualname = format!("::{}::{}", self.tcx.node_path_str(scope), ident);
-            let typ = self.tcx.tables().node_types.get(&field.id).unwrap().to_string();
+            let def_id = self.tcx.map.local_def_id(field.id);
+            let typ = self.tcx.item_type(def_id).to_string();
             let sub_span = self.span_utils.sub_span_before_token(field.span, token::Colon);
             filter!(self.span_utils, sub_span, field.span, None);
             Some(VariableData {

--- a/src/librustc_trans/back/symbol_names.rs
+++ b/src/librustc_trans/back/symbol_names.rs
@@ -231,7 +231,7 @@ impl<'a, 'tcx> Instance<'tcx> {
             match key.disambiguated_data.data {
                 DefPathData::TypeNs(_) |
                 DefPathData::ValueNs(_) => {
-                    instance_ty = scx.tcx().lookup_item_type(ty_def_id);
+                    instance_ty = scx.tcx().item_type(ty_def_id);
                     break;
                 }
                 _ => {
@@ -248,7 +248,7 @@ impl<'a, 'tcx> Instance<'tcx> {
 
         // Erase regions because they may not be deterministic when hashed
         // and should not matter anyhow.
-        let instance_ty = scx.tcx().erase_regions(&instance_ty.ty);
+        let instance_ty = scx.tcx().erase_regions(&instance_ty);
 
         let hash = get_symbol_hash(scx, &def_path, instance_ty, Some(substs));
 

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -1045,7 +1045,7 @@ pub fn trans_instance<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, instance: Instance
     debug!("trans_instance(instance={:?})", instance);
     let _icx = push_ctxt("trans_instance");
 
-    let fn_ty = ccx.tcx().lookup_item_type(instance.def).ty;
+    let fn_ty = ccx.tcx().item_type(instance.def);
     let fn_ty = ccx.tcx().erase_regions(&fn_ty);
     let fn_ty = monomorphize::apply_param_substs(ccx.shared(), instance.substs, &fn_ty);
 
@@ -1068,7 +1068,7 @@ pub fn trans_ctor_shim<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     attributes::inline(llfndecl, attributes::InlineAttr::Hint);
     attributes::set_frame_pointer_elimination(ccx, llfndecl);
 
-    let ctor_ty = ccx.tcx().lookup_item_type(def_id).ty;
+    let ctor_ty = ccx.tcx().item_type(def_id);
     let ctor_ty = monomorphize::apply_param_substs(ccx.shared(), substs, &ctor_ty);
 
     let sig = ccx.tcx().erase_late_bound_regions_and_normalize(&ctor_ty.fn_sig());
@@ -1514,7 +1514,7 @@ pub fn filter_reachable_ids(tcx: TyCtxt, reachable: NodeSet) -> NodeSet {
             hir_map::NodeImplItem(&hir::ImplItem {
                 node: hir::ImplItemKind::Method(..), .. }) => {
                 let def_id = tcx.map.local_def_id(id);
-                let generics = tcx.lookup_generics(def_id);
+                let generics = tcx.item_generics(def_id);
                 let attributes = tcx.get_attrs(def_id);
                 (generics.parent_types == 0 && generics.types.is_empty()) &&
                 // Functions marked with #[inline] are only ever translated
@@ -1719,7 +1719,7 @@ pub fn trans_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             let applicable = match sess.cstore.describe_def(def_id) {
                 Some(Def::Static(..)) => true,
                 Some(Def::Fn(_)) => {
-                    shared_ccx.tcx().lookup_generics(def_id).types.is_empty()
+                    shared_ccx.tcx().item_generics(def_id).types.is_empty()
                 }
                 _ => false
             };

--- a/src/librustc_trans/callee.rs
+++ b/src/librustc_trans/callee.rs
@@ -246,7 +246,7 @@ fn def_ty<'a, 'tcx>(shared: &SharedCrateContext<'a, 'tcx>,
                     def_id: DefId,
                     substs: &'tcx Substs<'tcx>)
                     -> Ty<'tcx> {
-    let ty = shared.tcx().lookup_item_type(def_id).ty;
+    let ty = shared.tcx().item_type(def_id);
     monomorphize::apply_param_substs(shared, substs, &ty)
 }
 
@@ -400,7 +400,7 @@ fn get_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
 
     let substs = tcx.normalize_associated_type(&substs);
     let instance = Instance::new(def_id, substs);
-    let item_ty = ccx.tcx().lookup_item_type(def_id).ty;
+    let item_ty = ccx.tcx().item_type(def_id);
     let fn_ty = monomorphize::apply_param_substs(ccx.shared(), substs, &item_ty);
 
     if let Some(&llfn) = ccx.instances().borrow().get(&instance) {

--- a/src/librustc_trans/consts.rs
+++ b/src/librustc_trans/consts.rs
@@ -84,7 +84,7 @@ pub fn get_static(ccx: &CrateContext, def_id: DefId) -> ValueRef {
         return g;
     }
 
-    let ty = ccx.tcx().lookup_item_type(def_id).ty;
+    let ty = ccx.tcx().item_type(def_id);
     let g = if let Some(id) = ccx.tcx().map.as_local_node_id(def_id) {
 
         let llty = type_of::type_of(ccx, ty);
@@ -226,7 +226,7 @@ pub fn trans_static(ccx: &CrateContext,
             v
         };
 
-        let ty = ccx.tcx().lookup_item_type(def_id).ty;
+        let ty = ccx.tcx().item_type(def_id);
         let llty = type_of::type_of(ccx, ty);
         let g = if val_llty == llty {
             g

--- a/src/librustc_trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/debuginfo/metadata.rs
@@ -1765,7 +1765,7 @@ pub fn create_global_var_metadata(cx: &CrateContext,
     };
 
     let is_local_to_unit = is_node_local_to_unit(cx, node_id);
-    let variable_type = tcx.erase_regions(&tcx.tables().node_id_to_type(node_id));
+    let variable_type = tcx.erase_regions(&tcx.item_type(node_def_id));
     let type_metadata = type_metadata(cx, variable_type, span);
     let var_name = tcx.item_name(node_def_id).to_string();
     let linkage_name = mangled_name_of_item(cx, node_def_id, "");

--- a/src/librustc_trans/debuginfo/mod.rs
+++ b/src/librustc_trans/debuginfo/mod.rs
@@ -259,7 +259,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
 
     // Get_template_parameters() will append a `<...>` clause to the function
     // name if necessary.
-    let generics = cx.tcx().lookup_generics(fn_def_id);
+    let generics = cx.tcx().item_generics(fn_def_id);
     let template_parameters = get_template_parameters(cx,
                                                       &generics,
                                                       instance.substs,
@@ -397,7 +397,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                                           generics: &ty::Generics<'tcx>)
                                           -> Vec<ast::Name> {
         let mut names = generics.parent.map_or(vec![], |def_id| {
-            get_type_parameter_names(cx, cx.tcx().lookup_generics(def_id))
+            get_type_parameter_names(cx, cx.tcx().item_generics(def_id))
         });
         names.extend(generics.types.iter().map(|param| param.name));
         names
@@ -412,7 +412,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
         let self_type = cx.tcx().impl_of_method(instance.def).and_then(|impl_def_id| {
             // If the method does *not* belong to a trait, proceed
             if cx.tcx().trait_id_of_impl(impl_def_id).is_none() {
-                let impl_self_ty = cx.tcx().lookup_item_type(impl_def_id).ty;
+                let impl_self_ty = cx.tcx().item_type(impl_def_id);
                 let impl_self_ty = cx.tcx().erase_regions(&impl_self_ty);
                 let impl_self_ty = monomorphize::apply_param_substs(cx.shared(),
                                                                     instance.substs,

--- a/src/librustc_trans/partitioning.rs
+++ b/src/librustc_trans/partitioning.rs
@@ -495,7 +495,7 @@ fn characteristic_def_id_of_trans_item<'a, 'tcx>(scx: &SharedCrateContext<'a, 't
             if let Some(impl_def_id) = tcx.impl_of_method(instance.def) {
                 // This is a method within an inherent impl, find out what the
                 // self-type is:
-                let impl_self_ty = tcx.lookup_item_type(impl_def_id).ty;
+                let impl_self_ty = tcx.item_type(impl_def_id);
                 let impl_self_ty = tcx.erase_regions(&impl_self_ty);
                 let impl_self_ty = monomorphize::apply_param_substs(scx,
                                                                     instance.substs,

--- a/src/librustc_trans/trans_item.rs
+++ b/src/librustc_trans/trans_item.rs
@@ -131,7 +131,7 @@ impl<'a, 'tcx> TransItem<'tcx> {
                         linkage: llvm::Linkage,
                         symbol_name: &str) {
         let def_id = ccx.tcx().map.local_def_id(node_id);
-        let ty = ccx.tcx().lookup_item_type(def_id).ty;
+        let ty = ccx.tcx().item_type(def_id);
         let llty = type_of::type_of(ccx, ty);
 
         let g = declare::define_global(ccx, symbol_name, llty).unwrap_or_else(|| {
@@ -153,7 +153,7 @@ impl<'a, 'tcx> TransItem<'tcx> {
         assert!(!instance.substs.needs_infer() &&
                 !instance.substs.has_param_types());
 
-        let item_ty = ccx.tcx().lookup_item_type(instance.def).ty;
+        let item_ty = ccx.tcx().item_type(instance.def);
         let item_ty = ccx.tcx().erase_regions(&item_ty);
         let mono_ty = monomorphize::apply_param_substs(ccx.shared(), instance.substs, &item_ty);
 

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -16,12 +16,12 @@
 //! somewhat differently during the collect and check phases,
 //! particularly with respect to looking up the types of top-level
 //! items.  In the collect phase, the crate context is used as the
-//! `AstConv` instance; in this phase, the `get_item_type_scheme()`
-//! function triggers a recursive call to `type_scheme_of_item()`
+//! `AstConv` instance; in this phase, the `get_item_type()`
+//! function triggers a recursive call to `type_of_item()`
 //! (note that `ast_ty_to_ty()` will detect recursive types and report
 //! an error).  In the check phase, when the FnCtxt is used as the
-//! `AstConv`, `get_item_type_scheme()` just looks up the item type in
-//! `tcx.tcache` (using `ty::lookup_item_type`).
+//! `AstConv`, `get_item_type()` just looks up the item type in
+//! `tcx.types` (using `TyCtxt::item_type`).
 //!
 //! The `RegionScope` trait controls what happens when the user does
 //! not specify a region in some location where a region is required
@@ -85,11 +85,8 @@ pub trait AstConv<'gcx, 'tcx> {
     fn get_generics(&self, span: Span, id: DefId)
                     -> Result<&'tcx ty::Generics<'tcx>, ErrorReported>;
 
-    /// Identify the type scheme for an item with a type, like a type
-    /// alias, fn, or struct. This allows you to figure out the set of
-    /// type parameters defined on the item.
-    fn get_item_type_scheme(&self, span: Span, id: DefId)
-                            -> Result<ty::TypeScheme<'tcx>, ErrorReported>;
+    /// Identify the type for an item, like a type alias, fn, or struct.
+    fn get_item_type(&self, span: Span, id: DefId) -> Result<Ty<'tcx>, ErrorReported>;
 
     /// Returns the `TraitDef` for a given trait. This allows you to
     /// figure out the set of type parameters defined on the trait.
@@ -938,8 +935,8 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
         -> Ty<'tcx>
     {
         let tcx = self.tcx();
-        let decl_ty = match self.get_item_type_scheme(span, did) {
-            Ok(type_scheme) => type_scheme.ty,
+        let decl_ty = match self.get_item_type(span, did) {
+            Ok(ty) => ty,
             Err(ErrorReported) => {
                 return tcx.types.err;
             }
@@ -1521,8 +1518,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> AstConv<'gcx, 'tcx>+'o {
                 // Self in impl (we know the concrete type).
 
                 tcx.prohibit_type_params(base_segments);
-                let impl_id = tcx.map.as_local_node_id(def_id).unwrap();
-                let ty = tcx.tables().node_id_to_type(impl_id);
+                let ty = tcx.item_type(def_id);
                 if let Some(free_substs) = self.get_free_substs() {
                     ty.subst(tcx, free_substs)
                 } else {

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -174,10 +174,10 @@ fn compare_predicate_entailment<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
     debug!("compare_impl_method: trait_to_skol_substs={:?}",
            trait_to_skol_substs);
 
-    let impl_m_generics = tcx.lookup_generics(impl_m.def_id);
-    let trait_m_generics = tcx.lookup_generics(trait_m.def_id);
-    let impl_m_predicates = tcx.lookup_predicates(impl_m.def_id);
-    let trait_m_predicates = tcx.lookup_predicates(trait_m.def_id);
+    let impl_m_generics = tcx.item_generics(impl_m.def_id);
+    let trait_m_generics = tcx.item_generics(trait_m.def_id);
+    let impl_m_predicates = tcx.item_predicates(impl_m.def_id);
+    let trait_m_predicates = tcx.item_predicates(trait_m.def_id);
 
     // Check region bounds.
     check_region_bounds_on_impl_method(ccx,
@@ -193,7 +193,7 @@ fn compare_predicate_entailment<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
     // environment. We can't just use `impl_env.caller_bounds`,
     // however, because we want to replace all late-bound regions with
     // region variables.
-    let impl_predicates = tcx.lookup_predicates(impl_m_predicates.parent.unwrap());
+    let impl_predicates = tcx.item_predicates(impl_m_predicates.parent.unwrap());
     let mut hybrid_preds = impl_predicates.instantiate(tcx, impl_to_skol_substs);
 
     debug!("compare_impl_method: impl_bounds={:?}", hybrid_preds);
@@ -269,7 +269,7 @@ fn compare_predicate_entailment<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
         let origin = TypeOrigin::MethodCompatCheck(impl_m_span);
 
         let m_fty = |method: &ty::AssociatedItem| {
-            match tcx.lookup_item_type(method.def_id).ty.sty {
+            match tcx.item_type(method.def_id).sty {
                 ty::TyFnDef(_, _, f) => f,
                 _ => bug!()
             }
@@ -542,7 +542,7 @@ fn compare_self_type<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
             ty::ImplContainer(_) => impl_trait_ref.self_ty(),
             ty::TraitContainer(_) => tcx.mk_self_type()
         };
-        let method_ty = tcx.lookup_item_type(method.def_id).ty;
+        let method_ty = tcx.item_type(method.def_id);
         let self_arg_ty = *method_ty.fn_sig().input(0).skip_binder();
         match ExplicitSelf::determine(untransformed_self_ty, self_arg_ty) {
             ExplicitSelf::ByValue => "self".to_string(),
@@ -601,8 +601,8 @@ fn compare_number_of_generics<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                         trait_item_span: Option<Span>)
                                         -> Result<(), ErrorReported> {
     let tcx = ccx.tcx;
-    let impl_m_generics = tcx.lookup_generics(impl_m.def_id);
-    let trait_m_generics = tcx.lookup_generics(trait_m.def_id);
+    let impl_m_generics = tcx.item_generics(impl_m.def_id);
+    let trait_m_generics = tcx.item_generics(trait_m.def_id);
     let num_impl_m_type_params = impl_m_generics.types.len();
     let num_trait_m_type_params = trait_m_generics.types.len();
     if num_impl_m_type_params != num_trait_m_type_params {
@@ -672,7 +672,7 @@ fn compare_number_of_method_arguments<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                                 -> Result<(), ErrorReported> {
     let tcx = ccx.tcx;
     let m_fty = |method: &ty::AssociatedItem| {
-        match tcx.lookup_item_type(method.def_id).ty.sty {
+        match tcx.item_type(method.def_id).sty {
             ty::TyFnDef(_, _, f) => f,
             _ => bug!()
         }
@@ -785,8 +785,8 @@ pub fn compare_const_impl<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                trait_to_skol_substs);
 
         // Compute skolemized form of impl and trait const tys.
-        let impl_ty = tcx.lookup_item_type(impl_c.def_id).ty.subst(tcx, impl_to_skol_substs);
-        let trait_ty = tcx.lookup_item_type(trait_c.def_id).ty.subst(tcx, trait_to_skol_substs);
+        let impl_ty = tcx.item_type(impl_c.def_id).subst(tcx, impl_to_skol_substs);
+        let trait_ty = tcx.item_type(trait_c.def_id).subst(tcx, trait_to_skol_substs);
         let mut origin = TypeOrigin::Misc(impl_c_span);
 
         let err = infcx.commit_if_ok(|_| {

--- a/src/librustc_typeck/check/dropck.rs
+++ b/src/librustc_typeck/check/dropck.rs
@@ -41,8 +41,8 @@ use syntax_pos::{self, Span};
 ///    cannot do `struct S<T>; impl<T:Clone> Drop for S<T> { ... }`).
 ///
 pub fn check_drop_impl(ccx: &CrateCtxt, drop_impl_did: DefId) -> Result<(), ()> {
-    let dtor_self_type = ccx.tcx.lookup_item_type(drop_impl_did).ty;
-    let dtor_predicates = ccx.tcx.lookup_predicates(drop_impl_did);
+    let dtor_self_type = ccx.tcx.item_type(drop_impl_did);
+    let dtor_predicates = ccx.tcx.item_predicates(drop_impl_did);
     match dtor_self_type.sty {
         ty::TyAdt(adt_def, self_to_impl_substs) => {
             ensure_drop_params_and_item_params_correspond(ccx,
@@ -85,7 +85,7 @@ fn ensure_drop_params_and_item_params_correspond<'a, 'tcx>(
         let tcx = infcx.tcx;
         let mut fulfillment_cx = traits::FulfillmentContext::new();
 
-        let named_type = tcx.lookup_item_type(self_type_did).ty;
+        let named_type = tcx.item_type(self_type_did);
         let named_type = named_type.subst(tcx, &infcx.parameter_environment.free_substs);
 
         let drop_impl_span = tcx.map.def_id_span(drop_impl_did, syntax_pos::DUMMY_SP);
@@ -177,7 +177,7 @@ fn ensure_drop_predicates_are_implied_by_item_defn<'a, 'tcx>(
 
     // We can assume the predicates attached to struct/enum definition
     // hold.
-    let generic_assumptions = tcx.lookup_predicates(self_type_did);
+    let generic_assumptions = tcx.item_predicates(self_type_did);
 
     let assumptions_in_impl_context = generic_assumptions.instantiate(tcx, &self_to_impl_substs);
     let assumptions_in_impl_context = assumptions_in_impl_context.predicates;
@@ -570,30 +570,30 @@ fn has_dtor_of_interest<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
 
 // Constructs new Ty just like the type defined by `adt_def` coupled
 // with `substs`, except each type and lifetime parameter marked as
-// `#[may_dangle]` in the Drop impl (identified by `impl_id`) is
+// `#[may_dangle]` in the Drop impl (identified by `impl_def_id`) is
 // respectively mapped to `()` or `'static`.
 //
 // For example: If the `adt_def` maps to:
 //
 //   enum Foo<'a, X, Y> { ... }
 //
-// and the `impl_id` maps to:
+// and the `impl_def_id` maps to:
 //
 //   impl<#[may_dangle] 'a, X, #[may_dangle] Y> Drop for Foo<'a, X, Y> { ... }
 //
 // then revises input: `Foo<'r,i64,&'r i64>` to: `Foo<'static,i64,()>`
 fn revise_self_ty<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
                                   adt_def: ty::AdtDef<'tcx>,
-                                  impl_id: DefId,
+                                  impl_def_id: DefId,
                                   substs: &Substs<'tcx>)
                                   -> Ty<'tcx> {
     // Get generics for `impl Drop` to query for `#[may_dangle]` attr.
-    let impl_bindings = tcx.lookup_generics(impl_id);
+    let impl_bindings = tcx.item_generics(impl_def_id);
 
     // Get Substs attached to Self on `impl Drop`; process in parallel
     // with `substs`, replacing dangling entries as appropriate.
     let self_substs = {
-        let impl_self_ty: Ty<'tcx> = tcx.lookup_item_type(impl_id).ty;
+        let impl_self_ty: Ty<'tcx> = tcx.item_type(impl_def_id);
         if let ty::TyAdt(self_adt_def, self_substs) = impl_self_ty.sty {
             assert_eq!(adt_def, self_adt_def);
             self_substs
@@ -648,5 +648,5 @@ fn revise_self_ty<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
             t
         });
 
-    return tcx.mk_adt(adt_def, &substs);
+    tcx.mk_adt(adt_def, &substs)
 }

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -276,7 +276,7 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
         // If they were not explicitly supplied, just construct fresh
         // variables.
         let num_supplied_types = supplied_method_types.len();
-        let method_generics = self.tcx.lookup_generics(pick.item.def_id);
+        let method_generics = self.tcx.item_generics(pick.item.def_id);
         let num_method_types = method_generics.types.len();
 
         if num_supplied_types > 0 && num_supplied_types != num_method_types {
@@ -359,14 +359,14 @@ impl<'a, 'gcx, 'tcx> ConfirmContext<'a, 'gcx, 'tcx> {
         // type/early-bound-regions substitutions performed. There can
         // be no late-bound regions appearing here.
         let def_id = pick.item.def_id;
-        let method_predicates = self.tcx.lookup_predicates(def_id)
+        let method_predicates = self.tcx.item_predicates(def_id)
                                     .instantiate(self.tcx, all_substs);
         let method_predicates = self.normalize_associated_types_in(self.span,
                                                                    &method_predicates);
 
         debug!("method_predicates after subst = {:?}", method_predicates);
 
-        let fty = match self.tcx.lookup_item_type(def_id).ty.sty {
+        let fty = match self.tcx.item_type(def_id).sty {
             ty::TyFnDef(_, _, f) => f,
             _ => bug!()
         };

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -230,7 +230,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         let tcx = self.tcx;
         let method_item = self.associated_item(trait_def_id, m_name).unwrap();
         let def_id = method_item.def_id;
-        let generics = tcx.lookup_generics(def_id);
+        let generics = tcx.item_generics(def_id);
         assert_eq!(generics.types.len(), 0);
         assert_eq!(generics.regions.len(), 0);
 
@@ -242,7 +242,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         // NB: Instantiate late-bound regions first so that
         // `instantiate_type_scheme` can normalize associated types that
         // may reference those regions.
-        let original_method_ty = tcx.lookup_item_type(def_id).ty;
+        let original_method_ty = tcx.item_type(def_id);
         let fty = match original_method_ty.sty {
             ty::TyFnDef(_, _, f) => f,
             _ => bug!()

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -672,9 +672,9 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
             }
         };
 
-        let impl_type = self.tcx.lookup_item_type(impl_def_id);
+        let impl_type = self.tcx.item_type(impl_def_id);
         let impl_simplified_type =
-            match ty::fast_reject::simplify_type(self.tcx, impl_type.ty, false) {
+            match ty::fast_reject::simplify_type(self.tcx, impl_type, false) {
                 Some(simplified_type) => simplified_type,
                 None => {
                     return true;
@@ -771,7 +771,7 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
                    def_id,
                    substs);
 
-            let trait_predicates = self.tcx.lookup_predicates(def_id);
+            let trait_predicates = self.tcx.item_predicates(def_id);
             let bounds = trait_predicates.instantiate(self.tcx, substs);
             let predicates = bounds.predicates;
             debug!("assemble_projection_candidates: predicates={:?}",
@@ -1070,7 +1070,7 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
             let cause = traits::ObligationCause::misc(self.span, self.body_id);
 
             // Check whether the impl imposes obligations we have to worry about.
-            let impl_bounds = self.tcx.lookup_predicates(impl_def_id);
+            let impl_bounds = self.tcx.item_predicates(impl_def_id);
             let impl_bounds = impl_bounds.instantiate(self.tcx, substs);
             let traits::Normalized { value: impl_bounds, obligations: norm_obligations } =
                 traits::normalize(selcx, cause.clone(), &impl_bounds);
@@ -1171,7 +1171,7 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
                             impl_ty: Ty<'tcx>,
                             substs: &Substs<'tcx>)
                             -> Ty<'tcx> {
-        let self_ty = self.tcx.lookup_item_type(method).ty.fn_sig().input(0);
+        let self_ty = self.tcx.item_type(method).fn_sig().input(0);
         debug!("xform_self_ty(impl_ty={:?}, self_ty={:?}, substs={:?})",
                impl_ty,
                self_ty,
@@ -1184,7 +1184,7 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
         // are given do not include type/lifetime parameters for the
         // method yet. So create fresh variables here for those too,
         // if there are any.
-        let generics = self.tcx.lookup_generics(method);
+        let generics = self.tcx.item_generics(method);
         assert_eq!(substs.types().count(), generics.parent_types as usize);
         assert_eq!(substs.regions().count(), generics.parent_regions as usize);
 
@@ -1218,7 +1218,7 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
 
     /// Get the type of an impl and generate substitutions with placeholders.
     fn impl_ty_and_substs(&self, impl_def_id: DefId) -> (Ty<'tcx>, &'tcx Substs<'tcx>) {
-        let impl_ty = self.tcx.lookup_item_type(impl_def_id).ty;
+        let impl_ty = self.tcx.item_type(impl_def_id);
 
         let substs = Substs::for_item(self.tcx,
                                       impl_def_id,

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -597,7 +597,7 @@ fn check_bare_fn<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                            body: &'tcx hir::Expr,
                            fn_id: ast::NodeId,
                            span: Span) {
-    let raw_fty = ccx.tcx.lookup_item_type(ccx.tcx.map.local_def_id(fn_id)).ty;
+    let raw_fty = ccx.tcx.item_type(ccx.tcx.map.local_def_id(fn_id));
     let fn_ty = match raw_fty.sty {
         ty::TyFnDef(.., f) => f,
         _ => span_bug!(body.span, "check_bare_fn: function type expected")
@@ -780,15 +780,16 @@ fn check_fn<'a, 'gcx, 'tcx>(inherited: &'a Inherited<'a, 'gcx, 'tcx>,
 }
 
 fn check_struct(ccx: &CrateCtxt, id: ast::NodeId, span: Span) {
-    check_representable(ccx.tcx, span, id);
+    let def_id = ccx.tcx.map.local_def_id(id);
+    check_representable(ccx.tcx, span, def_id);
 
-    if ccx.tcx.lookup_simd(ccx.tcx.map.local_def_id(id)) {
-        check_simd(ccx.tcx, span, id);
+    if ccx.tcx.lookup_simd(def_id) {
+        check_simd(ccx.tcx, span, def_id);
     }
 }
 
 fn check_union(ccx: &CrateCtxt, id: ast::NodeId, span: Span) {
-    check_representable(ccx.tcx, span, id);
+    check_representable(ccx.tcx, span, ccx.tcx.map.local_def_id(id));
 }
 
 pub fn check_item_type<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx hir::Item) {
@@ -831,7 +832,8 @@ pub fn check_item_type<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx hir::Item) {
         check_union(ccx, it.id, it.span);
       }
       hir::ItemTy(_, ref generics) => {
-        let pty_ty = ccx.tcx.tables().node_id_to_type(it.id);
+        let def_id = ccx.tcx.map.local_def_id(it.id);
+        let pty_ty = ccx.tcx.item_type(def_id);
         check_bounds_are_used(ccx, generics, pty_ty);
       }
       hir::ItemForeignMod(ref m) => {
@@ -847,8 +849,8 @@ pub fn check_item_type<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx hir::Item) {
             }
         } else {
             for item in &m.items {
-                let pty = ccx.tcx.lookup_item_type(ccx.tcx.map.local_def_id(item.id));
-                if !pty.generics.types.is_empty() {
+                let generics = ccx.tcx.item_generics(ccx.tcx.map.local_def_id(item.id));
+                if !generics.types.is_empty() {
                     let mut err = struct_span_err!(ccx.tcx.sess, item.span, E0044,
                         "foreign items may not have type parameters");
                     span_help!(&mut err, item.span,
@@ -917,7 +919,7 @@ pub fn check_item_body<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx hir::Item) {
 fn check_on_unimplemented<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                     def_id: DefId,
                                     item: &hir::Item) {
-    let generics = ccx.tcx.lookup_generics(def_id);
+    let generics = ccx.tcx.item_generics(def_id);
     if let Some(ref attr) = item.attrs.iter().find(|a| {
         a.check_name("rustc_on_unimplemented")
     }) {
@@ -1143,12 +1145,11 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
     let signature = |item: &ty::AssociatedItem| {
         match item.kind {
             ty::AssociatedKind::Method => {
-                format!("{}", tcx.lookup_item_type(item.def_id).ty.fn_sig().0)
+                format!("{}", tcx.item_type(item.def_id).fn_sig().0)
             }
             ty::AssociatedKind::Type => format!("type {};", item.name.to_string()),
             ty::AssociatedKind::Const => {
-                format!("const {}: {:?};", item.name.to_string(),
-                        tcx.lookup_item_type(item.def_id).ty)
+                format!("const {}: {:?};", item.name.to_string(), tcx.item_type(item.def_id))
             }
         }
     };
@@ -1218,7 +1219,7 @@ fn check_const_with_type<'a, 'tcx>(ccx: &'a CrateCtxt<'a, 'tcx>,
 fn check_const<'a, 'tcx>(ccx: &CrateCtxt<'a,'tcx>,
                          expr: &'tcx hir::Expr,
                          id: ast::NodeId) {
-    let decl_ty = ccx.tcx.lookup_item_type(ccx.tcx.map.local_def_id(id)).ty;
+    let decl_ty = ccx.tcx.item_type(ccx.tcx.map.local_def_id(id));
     check_const_with_type(ccx, expr, decl_ty, id);
 }
 
@@ -1227,9 +1228,9 @@ fn check_const<'a, 'tcx>(ccx: &CrateCtxt<'a,'tcx>,
 /// pointer, which would mean their size is unbounded.
 fn check_representable<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                  sp: Span,
-                                 item_id: ast::NodeId)
+                                 item_def_id: DefId)
                                  -> bool {
-    let rty = tcx.tables().node_id_to_type(item_id);
+    let rty = tcx.item_type(item_def_id);
 
     // Check that it is possible to represent this type. This call identifies
     // (1) types that contain themselves and (2) types that contain a different
@@ -1238,7 +1239,6 @@ fn check_representable<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     // caught by case 1.
     match rty.is_representable(tcx, sp) {
         Representability::SelfRecursive => {
-            let item_def_id = tcx.map.local_def_id(item_id);
             tcx.recursive_type_with_infinite_size_error(item_def_id).emit();
             return false
         }
@@ -1247,8 +1247,8 @@ fn check_representable<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     return true
 }
 
-pub fn check_simd<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, sp: Span, id: ast::NodeId) {
-    let t = tcx.tables().node_id_to_type(id);
+pub fn check_simd<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, sp: Span, def_id: DefId) {
+    let t = tcx.item_type(def_id);
     match t.sty {
         ty::TyAdt(def, substs) if def.is_struct() => {
             let fields = &def.struct_variant().fields;
@@ -1328,7 +1328,7 @@ pub fn check_enum_variants<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
         disr_vals.push(current_disr_val);
     }
 
-    check_representable(ccx.tcx, sp, id);
+    check_representable(ccx.tcx, sp, def_id);
 }
 
 impl<'a, 'gcx, 'tcx> AstConv<'gcx, 'tcx> for FnCtxt<'a, 'gcx, 'tcx> {
@@ -1341,13 +1341,12 @@ impl<'a, 'gcx, 'tcx> AstConv<'gcx, 'tcx> for FnCtxt<'a, 'gcx, 'tcx> {
     fn get_generics(&self, _: Span, id: DefId)
                     -> Result<&'tcx ty::Generics<'tcx>, ErrorReported>
     {
-        Ok(self.tcx().lookup_generics(id))
+        Ok(self.tcx().item_generics(id))
     }
 
-    fn get_item_type_scheme(&self, _: Span, id: DefId)
-                            -> Result<ty::TypeScheme<'tcx>, ErrorReported>
+    fn get_item_type(&self, _: Span, id: DefId) -> Result<Ty<'tcx>, ErrorReported>
     {
-        Ok(self.tcx().lookup_item_type(id))
+        Ok(self.tcx().item_type(id))
     }
 
     fn get_trait_def(&self, _: Span, id: DefId)
@@ -1662,7 +1661,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
     /// generic type scheme.
     fn instantiate_bounds(&self, span: Span, def_id: DefId, substs: &Substs<'tcx>)
                           -> ty::InstantiatedPredicates<'tcx> {
-        let bounds = self.tcx.lookup_predicates(def_id);
+        let bounds = self.tcx.item_predicates(def_id);
         let result = bounds.instantiate(self.tcx, substs);
         let result = self.normalize_associated_types_in(span, &result.predicates);
         debug!("instantiate_bounds(bounds={:?}, substs={:?}) = {:?}",
@@ -1687,7 +1686,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 let ty_var = self.next_ty_var();
                 self.anon_types.borrow_mut().insert(def_id, ty_var);
 
-                let item_predicates = self.tcx.lookup_predicates(def_id);
+                let item_predicates = self.tcx.item_predicates(def_id);
                 let bounds = item_predicates.instantiate(self.tcx, substs);
 
                 let span = self.tcx.map.def_id_span(def_id, codemap::DUMMY_SP);
@@ -2742,11 +2741,11 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         span: Span, // (potential) receiver for this impl
                         did: DefId)
                         -> TypeAndSubsts<'tcx> {
-        let ity = self.tcx.lookup_item_type(did);
+        let ity = self.tcx.item_type(did);
         debug!("impl_self_ty: ity={:?}", ity);
 
         let substs = self.fresh_substs_for_item(span, did);
-        let substd_ty = self.instantiate_type_scheme(span, &substs, &ity.ty);
+        let substd_ty = self.instantiate_type_scheme(span, &substs, &ity);
 
         TypeAndSubsts { substs: substs, ty: substd_ty }
     }
@@ -4184,11 +4183,11 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             Def::VariantCtor(def_id, ..) => {
                 // Everything but the final segment should have no
                 // parameters at all.
-                let mut generics = self.tcx.lookup_generics(def_id);
+                let mut generics = self.tcx.item_generics(def_id);
                 if let Some(def_id) = generics.parent {
                     // Variant and struct constructors use the
                     // generics of their parent type definition.
-                    generics = self.tcx.lookup_generics(def_id);
+                    generics = self.tcx.item_generics(def_id);
                 }
                 type_segment = Some((segments.last().unwrap(), generics));
             }
@@ -4198,7 +4197,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             Def::Const(def_id) |
             Def::Static(def_id, _) => {
                 fn_segment = Some((segments.last().unwrap(),
-                                   self.tcx.lookup_generics(def_id)));
+                                   self.tcx.item_generics(def_id)));
             }
 
             // Case 3. Reference to a method or associated const.
@@ -4212,9 +4211,9 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     ty::ImplContainer(_) => {}
                 }
 
-                let generics = self.tcx.lookup_generics(def_id);
+                let generics = self.tcx.item_generics(def_id);
                 if segments.len() >= 2 {
-                    let parent_generics = self.tcx.lookup_generics(generics.parent.unwrap());
+                    let parent_generics = self.tcx.item_generics(generics.parent.unwrap());
                     type_segment = Some((&segments[segments.len() - 2], parent_generics));
                 } else {
                     // `<T>::assoc` will end up here, and so can `T::assoc`.
@@ -4344,9 +4343,9 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
         // The things we are substituting into the type should not contain
         // escaping late-bound regions, and nor should the base type scheme.
-        let scheme = self.tcx.lookup_item_type(def.def_id());
+        let ty = self.tcx.item_type(def.def_id());
         assert!(!substs.has_escaping_regions());
-        assert!(!scheme.ty.has_escaping_regions());
+        assert!(!ty.has_escaping_regions());
 
         // Add all the obligations that are required, substituting and
         // normalized appropriately.
@@ -4357,16 +4356,16 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
         // Substitute the values for the type parameters into the type of
         // the referenced item.
-        let ty_substituted = self.instantiate_type_scheme(span, &substs, &scheme.ty);
+        let ty_substituted = self.instantiate_type_scheme(span, &substs, &ty);
 
         if let Some((ty::ImplContainer(impl_def_id), self_ty)) = ufcs_associated {
             // In the case of `Foo<T>::method` and `<Foo<T>>::method`, if `method`
             // is inherent, there is no `Self` parameter, instead, the impl needs
             // type parameters, which we can infer by unifying the provided `Self`
             // with the substituted impl type.
-            let impl_scheme = self.tcx.lookup_item_type(impl_def_id);
+            let ty = self.tcx.item_type(impl_def_id);
 
-            let impl_ty = self.instantiate_type_scheme(span, &substs, &impl_scheme.ty);
+            let impl_ty = self.instantiate_type_scheme(span, &substs, &ty);
             match self.sub_types(false, TypeOrigin::Misc(span), self_ty, impl_ty) {
                 Ok(InferOk { obligations, .. }) => {
                     // FIXME(#32730) propagate obligations

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -1729,7 +1729,7 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
         // ```
         //
         // we can thus deduce that `<T as SomeTrait<'a>>::SomeType : 'a`.
-        let trait_predicates = self.tcx.lookup_predicates(projection_ty.trait_ref.def_id);
+        let trait_predicates = self.tcx.item_predicates(projection_ty.trait_ref.def_id);
         assert_eq!(trait_predicates.parent, None);
         let predicates = trait_predicates.predicates.as_slice().to_vec();
         traits::elaborate_predicates(self.tcx, predicates)

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -106,7 +106,7 @@ impl<'a, 'gcx, 'tcx> CoherenceChecker<'a, 'gcx, 'tcx> {
     fn check_implementation(&self, item: &Item) {
         let tcx = self.crate_context.tcx;
         let impl_did = tcx.map.local_def_id(item.id);
-        let self_type = tcx.lookup_item_type(impl_did);
+        let self_type = tcx.item_type(impl_did);
 
         // If there are no traits, then this implementation must have a
         // base type.
@@ -129,14 +129,14 @@ impl<'a, 'gcx, 'tcx> CoherenceChecker<'a, 'gcx, 'tcx> {
         } else {
             // Skip inherent impls where the self type is an error
             // type. This occurs with e.g. resolve failures (#30589).
-            if self_type.ty.references_error() {
+            if self_type.references_error() {
                 return;
             }
 
             // Add the implementation to the mapping from implementation to base
             // type def ID, if there is a base type for this implementation and
             // the implementation does not have any associated traits.
-            if let Some(base_def_id) = self.get_base_type_def_id(item.span, self_type.ty) {
+            if let Some(base_def_id) = self.get_base_type_def_id(item.span, self_type) {
                 self.add_inherent_impl(base_def_id, impl_did);
             }
         }
@@ -175,8 +175,8 @@ impl<'a, 'gcx, 'tcx> CoherenceChecker<'a, 'gcx, 'tcx> {
             }
             let method_def_id = items[0];
 
-            let self_type = tcx.lookup_item_type(impl_did);
-            match self_type.ty.sty {
+            let self_type = tcx.item_type(impl_did);
+            match self_type.sty {
                 ty::TyAdt(type_def, _) => {
                     type_def.set_destructor(method_def_id);
                 }
@@ -232,13 +232,13 @@ impl<'a, 'gcx, 'tcx> CoherenceChecker<'a, 'gcx, 'tcx> {
                 return;
             };
 
-            let self_type = tcx.lookup_item_type(impl_did);
+            let self_type = tcx.item_type(impl_did);
             debug!("check_implementations_of_copy: self_type={:?} (bound)",
                    self_type);
 
             let span = tcx.map.span(impl_node_id);
             let param_env = ParameterEnvironment::for_item(tcx, impl_node_id);
-            let self_type = self_type.ty.subst(tcx, &param_env.free_substs);
+            let self_type = self_type.subst(tcx, &param_env.free_substs);
             assert!(!self_type.has_escaping_regions());
 
             debug!("check_implementations_of_copy: self_type={:?} (free)",
@@ -326,7 +326,7 @@ impl<'a, 'gcx, 'tcx> CoherenceChecker<'a, 'gcx, 'tcx> {
                 return;
             };
 
-            let source = tcx.lookup_item_type(impl_did).ty;
+            let source = tcx.item_type(impl_did);
             let trait_ref = self.crate_context.tcx.impl_trait_ref(impl_did).unwrap();
             let target = trait_ref.substs.type_at(1);
             debug!("check_implementations_of_coerce_unsized: {:?} -> {:?} (bound)",

--- a/src/librustc_typeck/coherence/orphan.rs
+++ b/src/librustc_typeck/coherence/orphan.rs
@@ -81,7 +81,7 @@ impl<'cx, 'tcx> OrphanChecker<'cx, 'tcx> {
                 // defined in this crate.
                 debug!("coherence2::orphan check: inherent impl {}",
                        self.tcx.map.node_to_string(item.id));
-                let self_ty = self.tcx.lookup_item_type(def_id).ty;
+                let self_ty = self.tcx.item_type(def_id);
                 match self_ty.sty {
                     ty::TyAdt(def, _) => {
                         self.check_def_id(item, def.did);

--- a/src/librustc_typeck/variance/constraints.rs
+++ b/src/librustc_typeck/variance/constraints.rs
@@ -82,16 +82,16 @@ impl<'a, 'tcx, 'v> Visitor<'v> for ConstraintContext<'a, 'tcx> {
             hir::ItemEnum(..) |
             hir::ItemStruct(..) |
             hir::ItemUnion(..) => {
-                let scheme = tcx.lookup_item_type(did);
+                let generics = tcx.item_generics(did);
 
                 // Not entirely obvious: constraints on structs/enums do not
                 // affect the variance of their type parameters. See discussion
                 // in comment at top of module.
                 //
-                // self.add_constraints_from_generics(&scheme.generics);
+                // self.add_constraints_from_generics(generics);
 
                 for field in tcx.lookup_adt_def(did).all_fields() {
-                    self.add_constraints_from_ty(&scheme.generics,
+                    self.add_constraints_from_ty(generics,
                                                  field.unsubst_ty(),
                                                  self.covariant);
                 }
@@ -336,7 +336,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
             }
 
             ty::TyAdt(def, substs) => {
-                let item_type = self.tcx().lookup_item_type(def.did);
+                let adt_generics = self.tcx().item_generics(def.did);
 
                 // This edge is actually implied by the call to
                 // `lookup_trait_def`, but I'm trying to be future-proof. See
@@ -345,8 +345,8 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
 
                 self.add_constraints_from_substs(generics,
                                                  def.did,
-                                                 &item_type.generics.types,
-                                                 &item_type.generics.regions,
+                                                 &adt_generics.types,
+                                                 &adt_generics.regions,
                                                  substs,
                                                  variance);
             }

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -164,7 +164,7 @@ pub fn build_external_trait<'a, 'tcx>(cx: &DocContext, tcx: TyCtxt<'a, 'tcx, 'tc
                                       did: DefId) -> clean::Trait {
     let def = tcx.lookup_trait_def(did);
     let trait_items = tcx.associated_items(did).map(|item| item.clean(cx)).collect();
-    let predicates = tcx.lookup_predicates(did);
+    let predicates = tcx.item_predicates(did);
     let generics = (def.generics, &predicates).clean(cx);
     let generics = filter_non_trait_generics(did, generics);
     let (generics, supertrait_bounds) = separate_supertrait_bounds(generics);
@@ -178,8 +178,8 @@ pub fn build_external_trait<'a, 'tcx>(cx: &DocContext, tcx: TyCtxt<'a, 'tcx, 'tc
 
 fn build_external_function<'a, 'tcx>(cx: &DocContext, tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                      did: DefId) -> clean::Function {
-    let t = tcx.lookup_item_type(did);
-    let (decl, style, abi) = match t.ty.sty {
+    let ty = tcx.item_type(did);
+    let (decl, style, abi) = match ty.sty {
         ty::TyFnDef(.., ref f) => ((did, &f.sig).clean(cx), f.unsafety, f.abi),
         _ => panic!("bad function"),
     };
@@ -190,10 +190,10 @@ fn build_external_function<'a, 'tcx>(cx: &DocContext, tcx: TyCtxt<'a, 'tcx, 'tcx
         hir::Constness::NotConst
     };
 
-    let predicates = tcx.lookup_predicates(did);
+    let predicates = tcx.item_predicates(did);
     clean::Function {
         decl: decl,
-        generics: (t.generics, &predicates).clean(cx),
+        generics: (tcx.item_generics(did), &predicates).clean(cx),
         unsafety: style,
         constness: constness,
         abi: abi,
@@ -202,11 +202,10 @@ fn build_external_function<'a, 'tcx>(cx: &DocContext, tcx: TyCtxt<'a, 'tcx, 'tcx
 
 fn build_enum<'a, 'tcx>(cx: &DocContext, tcx: TyCtxt<'a, 'tcx, 'tcx>,
                         did: DefId) -> clean::Enum {
-    let t = tcx.lookup_item_type(did);
-    let predicates = tcx.lookup_predicates(did);
+    let predicates = tcx.item_predicates(did);
 
     clean::Enum {
-        generics: (t.generics, &predicates).clean(cx),
+        generics: (tcx.item_generics(did), &predicates).clean(cx),
         variants_stripped: false,
         variants: tcx.lookup_adt_def(did).variants.clean(cx),
     }
@@ -214,8 +213,7 @@ fn build_enum<'a, 'tcx>(cx: &DocContext, tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
 fn build_struct<'a, 'tcx>(cx: &DocContext, tcx: TyCtxt<'a, 'tcx, 'tcx>,
                           did: DefId) -> clean::Struct {
-    let t = tcx.lookup_item_type(did);
-    let predicates = tcx.lookup_predicates(did);
+    let predicates = tcx.item_predicates(did);
     let variant = tcx.lookup_adt_def(did).struct_variant();
 
     clean::Struct {
@@ -224,7 +222,7 @@ fn build_struct<'a, 'tcx>(cx: &DocContext, tcx: TyCtxt<'a, 'tcx, 'tcx>,
             CtorKind::Fn => doctree::Tuple,
             CtorKind::Const => doctree::Unit,
         },
-        generics: (t.generics, &predicates).clean(cx),
+        generics: (tcx.item_generics(did), &predicates).clean(cx),
         fields: variant.fields.clean(cx),
         fields_stripped: false,
     }
@@ -232,13 +230,12 @@ fn build_struct<'a, 'tcx>(cx: &DocContext, tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
 fn build_union<'a, 'tcx>(cx: &DocContext, tcx: TyCtxt<'a, 'tcx, 'tcx>,
                           did: DefId) -> clean::Union {
-    let t = tcx.lookup_item_type(did);
-    let predicates = tcx.lookup_predicates(did);
+    let predicates = tcx.item_predicates(did);
     let variant = tcx.lookup_adt_def(did).struct_variant();
 
     clean::Union {
         struct_type: doctree::Plain,
-        generics: (t.generics, &predicates).clean(cx),
+        generics: (tcx.item_generics(did), &predicates).clean(cx),
         fields: variant.fields.clean(cx),
         fields_stripped: false,
     }
@@ -246,12 +243,11 @@ fn build_union<'a, 'tcx>(cx: &DocContext, tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
 fn build_type_alias<'a, 'tcx>(cx: &DocContext, tcx: TyCtxt<'a, 'tcx, 'tcx>,
                               did: DefId) -> clean::Typedef {
-    let t = tcx.lookup_item_type(did);
-    let predicates = tcx.lookup_predicates(did);
+    let predicates = tcx.item_predicates(did);
 
     clean::Typedef {
-        type_: t.ty.clean(cx),
-        generics: (t.generics, &predicates).clean(cx),
+        type_: tcx.item_type(did).clean(cx),
+        generics: (tcx.item_generics(did), &predicates).clean(cx),
     }
 }
 
@@ -354,8 +350,7 @@ pub fn build_impl<'a, 'tcx>(cx: &DocContext,
         });
     }
 
-    let ty = tcx.lookup_item_type(did);
-    let for_ = ty.ty.clean(cx);
+    let for_ = tcx.item_type(did).clean(cx);
 
     // Only inline impl if the implementing type is
     // reachable in rustdoc generated documentation
@@ -365,11 +360,10 @@ pub fn build_impl<'a, 'tcx>(cx: &DocContext,
         }
     }
 
-    let predicates = tcx.lookup_predicates(did);
+    let predicates = tcx.item_predicates(did);
     let trait_items = tcx.associated_items(did).filter_map(|item| {
         match item.kind {
             ty::AssociatedKind::Const => {
-                let type_scheme = tcx.lookup_item_type(item.def_id);
                 let default = if item.has_value {
                     Some(pprust::expr_to_string(
                         lookup_const_by_id(tcx, item.def_id, None).unwrap().0))
@@ -379,7 +373,7 @@ pub fn build_impl<'a, 'tcx>(cx: &DocContext,
                 Some(clean::Item {
                     name: Some(item.name.clean(cx)),
                     inner: clean::AssociatedConstItem(
-                        type_scheme.ty.clean(cx),
+                        tcx.item_type(item.def_id).clean(cx),
                         default,
                     ),
                     source: clean::Span::empty(),
@@ -419,7 +413,7 @@ pub fn build_impl<'a, 'tcx>(cx: &DocContext,
             }
             ty::AssociatedKind::Type => {
                 let typedef = clean::Typedef {
-                    type_: tcx.lookup_item_type(item.def_id).ty.clean(cx),
+                    type_: tcx.item_type(item.def_id).clean(cx),
                     generics: clean::Generics {
                         lifetimes: vec![],
                         type_params: vec![],
@@ -463,7 +457,7 @@ pub fn build_impl<'a, 'tcx>(cx: &DocContext,
             provided_trait_methods: provided,
             trait_: trait_,
             for_: for_,
-            generics: (ty.generics, &predicates).clean(cx),
+            generics: (tcx.item_generics(did), &predicates).clean(cx),
             items: trait_items,
             polarity: Some(polarity.clean(cx)),
         }),
@@ -514,7 +508,7 @@ fn build_const<'a, 'tcx>(cx: &DocContext, tcx: TyCtxt<'a, 'tcx, 'tcx>,
     debug!("got snippet {}", sn);
 
     clean::Constant {
-        type_: ty.map(|t| t.clean(cx)).unwrap_or_else(|| tcx.lookup_item_type(did).ty.clean(cx)),
+        type_: ty.map(|t| t.clean(cx)).unwrap_or_else(|| tcx.item_type(did).clean(cx)),
         expr: sn
     }
 }
@@ -523,7 +517,7 @@ fn build_static<'a, 'tcx>(cx: &DocContext, tcx: TyCtxt<'a, 'tcx, 'tcx>,
                           did: DefId,
                           mutable: bool) -> clean::Static {
     clean::Static {
-        type_: tcx.lookup_item_type(did).ty.clean(cx),
+        type_: tcx.item_type(did).clean(cx),
         mutability: if mutable {clean::Mutable} else {clean::Immutable},
         expr: "\n\n\n".to_string(), // trigger the "[definition]" links
     }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1342,13 +1342,13 @@ impl<'tcx> Clean<Item> for ty::AssociatedItem {
     fn clean(&self, cx: &DocContext) -> Item {
         let inner = match self.kind {
             ty::AssociatedKind::Const => {
-                let ty = cx.tcx().lookup_item_type(self.def_id).ty;
+                let ty = cx.tcx().item_type(self.def_id);
                 AssociatedConstItem(ty.clean(cx), None)
             }
             ty::AssociatedKind::Method => {
-                let generics = (cx.tcx().lookup_generics(self.def_id),
-                                &cx.tcx().lookup_predicates(self.def_id)).clean(cx);
-                let fty = match cx.tcx().lookup_item_type(self.def_id).ty.sty {
+                let generics = (cx.tcx().item_generics(self.def_id),
+                                &cx.tcx().item_predicates(self.def_id)).clean(cx);
+                let fty = match cx.tcx().item_type(self.def_id).sty {
                     ty::TyFnDef(_, _, f) => f,
                     _ => unreachable!()
                 };
@@ -1357,7 +1357,7 @@ impl<'tcx> Clean<Item> for ty::AssociatedItem {
                 if self.method_has_self_argument {
                     let self_ty = match self.container {
                         ty::ImplContainer(def_id) => {
-                            cx.tcx().lookup_item_type(def_id).ty
+                            cx.tcx().item_type(def_id)
                         }
                         ty::TraitContainer(_) => cx.tcx().mk_self_type()
                     };
@@ -1405,7 +1405,7 @@ impl<'tcx> Clean<Item> for ty::AssociatedItem {
                     // all of the generics from there and then look for bounds that are
                     // applied to this associated type in question.
                     let def = cx.tcx().lookup_trait_def(did);
-                    let predicates = cx.tcx().lookup_predicates(did);
+                    let predicates = cx.tcx().item_predicates(did);
                     let generics = (def.generics, &predicates).clean(cx);
                     generics.where_predicates.iter().filter_map(|pred| {
                         let (name, self_type, trait_, bounds) = match *pred {
@@ -1441,7 +1441,7 @@ impl<'tcx> Clean<Item> for ty::AssociatedItem {
                 }
 
                 let ty = if self.has_value {
-                    Some(cx.tcx().lookup_item_type(self.def_id).ty)
+                    Some(cx.tcx().item_type(self.def_id))
                 } else {
                     None
                 };
@@ -1901,7 +1901,7 @@ impl<'tcx> Clean<Type> for ty::Ty<'tcx> {
             ty::TyAnon(def_id, substs) => {
                 // Grab the "TraitA + TraitB" from `impl TraitA + TraitB`,
                 // by looking up the projections associated with the def_id.
-                let item_predicates = cx.tcx().lookup_predicates(def_id);
+                let item_predicates = cx.tcx().item_predicates(def_id);
                 let substs = cx.tcx().lift(&substs).unwrap();
                 let bounds = item_predicates.instantiate(cx.tcx(), substs);
                 ImplTrait(bounds.predicates.into_iter().filter_map(|predicate| {

--- a/src/librustdoc/clean/simplify.rs
+++ b/src/librustdoc/clean/simplify.rs
@@ -153,7 +153,7 @@ fn trait_is_same_or_supertrait(cx: &DocContext, child: DefId,
     if child == trait_ {
         return true
     }
-    let predicates = cx.tcx().lookup_super_predicates(child).predicates;
+    let predicates = cx.tcx().item_super_predicates(child).predicates;
     predicates.iter().filter_map(|pred| {
         if let ty::Predicate::Trait(ref pred) = *pred {
             if pred.0.trait_ref.self_ty().is_self() {


### PR DESCRIPTION
_This is part of a series ([prev](https://github.com/rust-lang/rust/pull/37676) | [next](https://github.com/rust-lang/rust/pull/38053)) of patches designed to rework rustc into an out-of-order on-demand pipeline model for both better feature support (e.g. [MIR-based](https://github.com/solson/miri) early constant evaluation) and incremental execution of compiler passes (e.g. type-checking), with beneficial consequences to IDE support as well.
If any motivation is unclear, please ask for additional PR description clarifications or code comments._

<hr>

#35605 introduced an uniform `lookup_generics` but didn't clean up everything. This PR changes:
* `tcx.tcache` -> `tcx.item_types`
* `TypeScheme` (grouping `Ty` and `ty::Generics`) is removed
* `tcx.item_types` entries no longer duplicated in `tcx.tables.node_types`
* `tcx.lookup_item_type(def_id).ty` -> `tcx.item_type(def_id)`
* `tcx.lookup_item_type(def_id).generics` -> `tcx.item_generics(def_id)`
* `tcx.lookup_generics(def_id)` -> `tcx.item_generics(def_id)`
* `tcx.lookup_{super_,}predicates(def_id)` -> `tcx.item_{super_,}predicates(def_id)`