### PR TITLE
Balance the debug output of Lvalue Subslice

### DIFF
--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -923,7 +923,7 @@ impl<'tcx> Debug for Lvalue<'tcx> {
                     ProjectionElem::ConstantIndex { offset, min_length, from_end: true } =>
                         write!(fmt, "{:?}[-{:?} of {:?}]", data.base, offset, min_length),
                     ProjectionElem::Subslice { from, to } if to == 0 =>
-                        write!(fmt, "{:?}[{:?}:", data.base, from),
+                        write!(fmt, "{:?}[{:?}:]", data.base, from),
                     ProjectionElem::Subslice { from, to } if from == 0 =>
                         write!(fmt, "{:?}[:-{:?}]", data.base, to),
                     ProjectionElem::Subslice { from, to } =>


### PR DESCRIPTION
The current debug output for Lvalue Subslice is not balanced and does not respect the comment[1], which indicates that we use `slice[from:-to] in Python terms.`.  In python terms slices which have a start but no end are written as `a[start:]`, so following the comment, I fixed the output accordingly.

Grep-ing over the sources, I did not found any test cases checking this subslice debug output.
Note, I have not yet tested this change yet, as I am still waiting for the end of LLVM compilation.

[1] https://manishearth.github.io/rust-internals-docs/rustc/mir/enum.ProjectionElem.html