### PR TITLE
On fmt string with unescaped `{` note how to escape

### DIFF
--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -756,8 +756,12 @@ pub fn expand_preparsed_format_args(ecx: &mut ExtCtxt,
     }
 
     if !parser.errors.is_empty() {
-        cx.ecx.span_err(cx.fmtsp,
-                        &format!("invalid format string: {}", parser.errors.remove(0)));
+        let (err, note) = parser.errors.remove(0);
+        let mut e = cx.ecx.struct_span_err(cx.fmtsp, &format!("invalid format string: {}", err));
+        if let Some(note) = note {
+            e.note(&note);
+        }
+        e.emit();
         return DummyResult::raw_expr(sp);
     }
     if !cx.literal.is_empty() {

--- a/src/test/ui/fmt/format-string-error.rs
+++ b/src/test/ui/fmt/format-string-error.rs
@@ -1,0 +1,16 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    println!("{");
+    println!("{{}}");
+    println!("}");
+}
+

--- a/src/test/ui/fmt/format-string-error.stderr
+++ b/src/test/ui/fmt/format-string-error.stderr
@@ -1,0 +1,20 @@
+error: invalid format string: expected `'}'` but string was terminated
+  --> $DIR/format-string-error.rs:12:5
+   |
+12 |     println!("{");
+   |     ^^^^^^^^^^^^^^
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+   = note: this error originates in a macro outside of the current crate
+
+error: invalid format string: unmatched `}` found
+  --> $DIR/format-string-error.rs:14:5
+   |
+14 |     println!("}");
+   |     ^^^^^^^^^^^^^^
+   |
+   = note: if you intended to print `}`, you can escape it using `}}`
+   = note: this error originates in a macro outside of the current crate
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
On cases of malformed format strings where a `{` hasn't been properly escaped, like `println!("{");`, present a NOTE explaining how to escape the `{` char.

Fix #34300.