### PR TITLE
std: Derive `Default` for `Duration`.

### DIFF
--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -39,7 +39,7 @@ const MILLIS_PER_SEC: u64 = 1_000;
 /// let ten_millis = Duration::from_millis(10);
 /// ```
 #[stable(feature = "duration", since = "1.3.0")]
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Default)]
 pub struct Duration {
     secs: u64,
     nanos: u32, // Always 0 <= nanos < NANOS_PER_SEC


### PR DESCRIPTION
Discussed in #37546 the libs team reached the conclusion that a default zero
duration seems like a reasonable implementation of the `Default` trait.

Closes #37546