### PR TITLE
[RFC] Add flag for Unicode based Frontend support

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -30,7 +30,7 @@ use syntax::parse;
 use syntax::parse::token::InternedString;
 use syntax::feature_gate::UnstableFeatures;
 
-use errors::{ColorConfig, FatalError, Handler};
+use errors::{ColorConfig, Drawing, EmitterConfig, FatalError, Handler};
 
 use getopts;
 use std::collections::{BTreeMap, BTreeSet};
@@ -80,13 +80,13 @@ pub enum OutputType {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ErrorOutputType {
-    HumanReadable(ColorConfig),
+    HumanReadable(EmitterConfig),
     Json,
 }
 
 impl Default for ErrorOutputType {
     fn default() -> ErrorOutputType {
-        ErrorOutputType::HumanReadable(ColorConfig::Auto)
+        ErrorOutputType::HumanReadable(EmitterConfig::default())
     }
 }
 
@@ -1204,11 +1204,18 @@ pub fn rustc_optgroups() -> Vec<RustcOptGroup> {
         opt::opt_s("", "error-format",
                       "How errors and other messages are produced",
                       "human|json"),
-        opt::opt_s("", "color", "Configure coloring of output:
-                                 auto   = colorize, if output goes to a tty (default);
-                                 always = always colorize output;
-                                 never  = never colorize output", "auto|always|never"),
-
+        opt::opt_s("", "color",
+                   "Configure coloring of output:
+                    auto   = colorize, if output goes to a tty (default);
+                    always = always colorize output;
+                    never  = never colorize output",
+                   "auto|always|never"),
+        opt::opt_s("", "unicode",
+                   "Configure characters used on output:
+                    ascii  = ascii safe characters (default)
+                    style1 = unicode
+                    style2 = unicode box drawing characters",
+                   "ascii|style1|style2"),
         opt::flagopt_ubnr("", "pretty",
                           "Pretty-print the input instead of compiling;
                            valid types are: `normal` (un-annotated source),
@@ -1269,26 +1276,43 @@ pub fn build_session_options_and_crate_config(matches: &getopts::Matches)
         }
     };
 
+    let drawing = match matches.opt_str("unicode").as_ref().map(|s| &s[..]) {
+        Some("style1") => Drawing::unicode(),
+        Some("style2") => Drawing::unicode_2(),
+        Some("ascii")  => Drawing::ascii(),
+        None           => Drawing::ascii(),
+        Some(arg) => {
+            early_error(ErrorOutputType::default(), &format!("argument for --unicode must be style1, \
+                                                              style2 or ascii (instead was `{}`)",
+                                                            arg))
+        }
+    };
+
+    let config = EmitterConfig {
+        color: color,
+        drawing: drawing,
+    };
+
     // We need the opts_present check because the driver will send us Matches
     // with only stable options if no unstable options are used. Since error-format
     // is unstable, it will not be present. We have to use opts_present not
     // opt_present because the latter will panic.
     let error_format = if matches.opts_present(&["error-format".to_owned()]) {
         match matches.opt_str("error-format").as_ref().map(|s| &s[..]) {
-            Some("human")   => ErrorOutputType::HumanReadable(color),
+            Some("human")   => ErrorOutputType::HumanReadable(config),
             Some("json") => ErrorOutputType::Json,
 
-            None => ErrorOutputType::HumanReadable(color),
+            None => ErrorOutputType::HumanReadable(config),
 
             Some(arg) => {
-                early_error(ErrorOutputType::HumanReadable(color),
+                early_error(ErrorOutputType::HumanReadable(config),
                             &format!("argument for --error-format must be human or json (instead \
                                       was `{}`)",
                                      arg))
             }
         }
     } else {
-        ErrorOutputType::HumanReadable(color)
+        ErrorOutputType::HumanReadable(config)
     };
 
     let unparsed_crate_types = matches.opt_strs("crate-type");

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -23,7 +23,7 @@ use mir::transform as mir_pass;
 
 use syntax::ast::NodeId;
 use errors::{self, DiagnosticBuilder};
-use errors::emitter::{Emitter, EmitterWriter};
+use errors::emitter::{Emitter, EmitterConfig, EmitterWriter};
 use syntax::json::JsonEmitter;
 use syntax::feature_gate;
 use syntax::parse;
@@ -528,13 +528,14 @@ pub fn build_session_with_codemap(sopts: config::Options,
     let treat_err_as_bug = sopts.debugging_opts.treat_err_as_bug;
 
     let emitter: Box<Emitter> = match (sopts.error_format, emitter_dest) {
-        (config::ErrorOutputType::HumanReadable(color_config), None) => {
-            Box::new(EmitterWriter::stderr(color_config,
+        (config::ErrorOutputType::HumanReadable(config), None) => {
+            Box::new(EmitterWriter::stderr(config,
                                            Some(codemap.clone())))
         }
         (config::ErrorOutputType::HumanReadable(_), Some(dst)) => {
             Box::new(EmitterWriter::new(dst,
-                                        Some(codemap.clone())))
+                                        Some(codemap.clone()),
+                                        EmitterConfig::default()))
         }
         (config::ErrorOutputType::Json, None) => {
             Box::new(JsonEmitter::stderr(Some(registry), codemap.clone()))
@@ -707,8 +708,8 @@ unsafe fn configure_llvm(sess: &Session) {
 
 pub fn early_error(output: config::ErrorOutputType, msg: &str) -> ! {
     let emitter: Box<Emitter> = match output {
-        config::ErrorOutputType::HumanReadable(color_config) => {
-            Box::new(EmitterWriter::stderr(color_config,
+        config::ErrorOutputType::HumanReadable(config) => {
+            Box::new(EmitterWriter::stderr(config,
                                            None))
         }
         config::ErrorOutputType::Json => Box::new(JsonEmitter::basic()),
@@ -720,8 +721,8 @@ pub fn early_error(output: config::ErrorOutputType, msg: &str) -> ! {
 
 pub fn early_warn(output: config::ErrorOutputType, msg: &str) {
     let emitter: Box<Emitter> = match output {
-        config::ErrorOutputType::HumanReadable(color_config) => {
-            Box::new(EmitterWriter::stderr(color_config,
+        config::ErrorOutputType::HumanReadable(config) => {
+            Box::new(EmitterWriter::stderr(config,
                                            None))
         }
         config::ErrorOutputType::Json => Box::new(JsonEmitter::basic()),

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -142,7 +142,7 @@ pub fn run<F>(run_compiler: F) -> isize
                     Some(sess) => sess.fatal(&abort_msg(err_count)),
                     None => {
                         let emitter =
-                            errors::emitter::EmitterWriter::stderr(errors::ColorConfig::Auto, None);
+                            errors::emitter::EmitterWriter::stderr(errors::EmitterConfig::default(), None);
                         let handler = errors::Handler::with_emitter(true, false, Box::new(emitter));
                         handler.emit(&MultiSpan::new(),
                                      &abort_msg(err_count),
@@ -1081,7 +1081,7 @@ pub fn monitor<F: FnOnce() + Send + 'static>(f: F) {
         // Thread panicked without emitting a fatal diagnostic
         if !value.is::<errors::FatalError>() {
             let emitter =
-                Box::new(errors::emitter::EmitterWriter::stderr(errors::ColorConfig::Auto, None));
+                Box::new(errors::emitter::EmitterWriter::stderr(errors::EmitterConfig::default(), None));
             let handler = errors::Handler::with_emitter(true, false, emitter);
 
             // a .span_bug or .bug call has already printed what

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -36,7 +36,7 @@ extern crate rustc_unicode;
 extern crate serialize as rustc_serialize; // used by deriving
 extern crate syntax_pos;
 
-pub use emitter::ColorConfig;
+pub use emitter::{ColorConfig, Drawing, EmitterConfig};
 
 use self::Level::*;
 
@@ -227,12 +227,12 @@ pub struct Handler {
 }
 
 impl Handler {
-    pub fn with_tty_emitter(color_config: ColorConfig,
+    pub fn with_tty_emitter(config: EmitterConfig,
                             can_emit_warnings: bool,
                             treat_err_as_bug: bool,
                             cm: Option<Rc<CodeMapper>>)
                             -> Handler {
-        let emitter = Box::new(EmitterWriter::stderr(color_config, cm));
+        let emitter = Box::new(EmitterWriter::stderr(config, cm));
         Handler::with_emitter(can_emit_warnings, treat_err_as_bug, emitter)
     }
 

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -13,7 +13,7 @@
 use ast::{self, CrateConfig};
 use codemap::CodeMap;
 use syntax_pos::{self, Span, FileMap};
-use errors::{Handler, ColorConfig, DiagnosticBuilder};
+use errors::{Handler, EmitterConfig, DiagnosticBuilder};
 use feature_gate::UnstableFeatures;
 use parse::parser::Parser;
 use parse::token::InternedString;
@@ -53,7 +53,7 @@ pub struct ParseSess {
 impl ParseSess {
     pub fn new() -> Self {
         let cm = Rc::new(CodeMap::new());
-        let handler = Handler::with_tty_emitter(ColorConfig::Auto,
+        let handler = Handler::with_tty_emitter(EmitterConfig::default(),
                                                 true,
                                                 false,
                                                 Some(cm.clone()));


### PR DESCRIPTION
Using PR #21406 as a base, I took a stab at #24387.

It currently looks like this:
<img width="648" alt="screen shot 2016-11-10 at 20 21 24" src="https://cloud.githubusercontent.com/assets/1606434/20204351/d7eca726-a783-11e6-885f-21582b1bd777.png">

As you can see, there's still some work left to do in order for the different combinations of underlines to look right, but the basic logic is already all there.