### PR TITLE
Avoid unnecessary mk_ty calls in Ty::super_fold_with.

### DIFF
--- a/src/librustc/ty/structural_impls.rs
+++ b/src/librustc/ty/structural_impls.rs
@@ -482,7 +482,7 @@ impl<'tcx> TypeFoldable<'tcx> for Ty<'tcx> {
             ty::TyAnon(did, substs) => ty::TyAnon(did, substs.fold_with(folder)),
             ty::TyBool | ty::TyChar | ty::TyStr | ty::TyInt(_) |
             ty::TyUint(_) | ty::TyFloat(_) | ty::TyError | ty::TyInfer(_) |
-            ty::TyParam(..) | ty::TyNever => self.sty.clone(),
+            ty::TyParam(..) | ty::TyNever => return self
         };
         folder.tcx().mk_ty(sty)
     }


### PR DESCRIPTION
This speeds up compilation of several rustc-benchmarks by 1--2% and the workload in #36799 by 5%.

r? @eddyb 