### PR TITLE
change the `box_free` lang item to accept pointers to unsized types

### DIFF
--- a/src/doc/book/lang-items.md
+++ b/src/doc/book/lang-items.md
@@ -46,8 +46,8 @@ unsafe fn deallocate(ptr: *mut u8, _size: usize, _align: usize) {
 }
 
 #[lang = "box_free"]
-unsafe fn box_free<T>(ptr: *mut T) {
-    deallocate(ptr as *mut u8, ::core::mem::size_of::<T>(), ::core::mem::align_of::<T>());
+unsafe fn box_free<T: ?Sized>(ptr: *mut T) {
+    deallocate(ptr as *mut u8, ::core::mem::size_of_val(&*ptr), ::core::mem::align_of_val(&*ptr));
 }
 
 #[start]

--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -17,7 +17,7 @@
 
 use core::{isize, usize};
 #[cfg(not(test))]
-use core::intrinsics::{min_align_of, size_of};
+use core::intrinsics::{min_align_of_val, size_of_val};
 
 #[allow(improper_ctypes)]
 extern "C" {
@@ -152,11 +152,12 @@ unsafe fn exchange_free(ptr: *mut u8, old_size: usize, align: usize) {
 #[cfg(not(test))]
 #[lang = "box_free"]
 #[inline]
-unsafe fn box_free<T>(ptr: *mut T) {
-    let size = size_of::<T>();
+unsafe fn box_free<T: ?Sized>(ptr: *mut T) {
+    let size = size_of_val(&*ptr);
+    let align = min_align_of_val(&*ptr);
     // We do not allocate for Box<T> when T is ZST, so deallocation is also not necessary.
     if size != 0 {
-        deallocate(ptr as *mut u8, size, min_align_of::<T>());
+        deallocate(ptr as *mut u8, size, align);
     }
 }
 


### PR DESCRIPTION
in miri we use the `box_free` lang item as the destructor for `Box` objects, since the function's api matches that of an `fn drop(&mut self)` in a hypothetical `impl<T: ?Sized> Drop for Box<T>` exactly.

This works fine except if we insert a check in the `size_of` intrinsic to ensure that it is only called with sized types, since the `box_free` lang item calls that intrinsic.

cc @eddyb 

no clue who to r? here, probably lang team?