### PR TITLE
rustc: Flag all builtins functions as hidden

### DIFF
--- a/src/libcompiler_builtins/Cargo.toml
+++ b/src/libcompiler_builtins/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.0.0"
 [lib]
 name = "compiler_builtins"
 path = "lib.rs"
+test = false
 
 [dependencies]
 core = { path = "../libcore" }

--- a/src/librustc_llvm/ffi.rs
+++ b/src/librustc_llvm/ffi.rs
@@ -426,6 +426,14 @@ pub type OperandBundleDefRef = *mut OperandBundleDef_opaque;
 pub type DiagnosticHandler = unsafe extern "C" fn(DiagnosticInfoRef, *mut c_void);
 pub type InlineAsmDiagHandler = unsafe extern "C" fn(SMDiagnosticRef, *const c_void, c_uint);
 
+/// LLVMVisibility
+#[repr(C)]
+pub enum Visibility {
+    Default,
+    Hidden,
+    Protected,
+}
+
 pub mod debuginfo {
     pub use self::DIDescriptorFlags::*;
     use super::MetadataRef;
@@ -746,8 +754,8 @@ extern "C" {
     pub fn LLVMRustSetLinkage(Global: ValueRef, RustLinkage: Linkage);
     pub fn LLVMGetSection(Global: ValueRef) -> *const c_char;
     pub fn LLVMSetSection(Global: ValueRef, Section: *const c_char);
-    pub fn LLVMGetVisibility(Global: ValueRef) -> c_uint;
-    pub fn LLVMSetVisibility(Global: ValueRef, Viz: c_uint);
+    pub fn LLVMGetVisibility(Global: ValueRef) -> Visibility;
+    pub fn LLVMSetVisibility(Global: ValueRef, Viz: Visibility);
     pub fn LLVMGetAlignment(Global: ValueRef) -> c_uint;
     pub fn LLVMSetAlignment(Global: ValueRef, Bytes: c_uint);
     pub fn LLVMSetDLLStorageClass(V: ValueRef, C: DLLStorageClass);

--- a/src/librustc_trans/declare.rs
+++ b/src/librustc_trans/declare.rs
@@ -19,6 +19,7 @@
 //!   interested in defining the ValueRef they return.
 //! * Use define_* family of methods when you might be defining the ValueRef.
 //! * When in doubt, define.
+
 use llvm::{self, ValueRef};
 use llvm::AttributePlace::Function;
 use rustc::ty;
@@ -27,6 +28,7 @@ use attributes;
 use context::CrateContext;
 use type_::Type;
 use value::Value;
+use syntax::attr;
 
 use std::ffi::CString;
 
@@ -67,6 +69,16 @@ fn declare_raw_fn(ccx: &CrateContext, name: &str, callconv: llvm::CallConv, ty: 
     if ccx.tcx().sess.opts.cg.no_redzone
         .unwrap_or(ccx.tcx().sess.target.target.options.disable_redzone) {
         llvm::Attribute::NoRedZone.apply_llfn(Function, llfn);
+    }
+
+    // If we're compiling the compiler-builtins crate, e.g. the equivalent of
+    // compiler-rt, then we want to implicitly compile everything with hidden
+    // visibility as we're going to link this object all over the place but
+    // don't want the symbols to get exported.
+    if attr::contains_name(ccx.tcx().map.krate_attrs(), "compiler_builtins") {
+        unsafe {
+            llvm::LLVMSetVisibility(llfn, llvm::Visibility::Hidden);
+        }
     }
 
     match ccx.tcx().sess.opts.cg.opt_level.as_ref().map(String::as_ref) {


### PR DESCRIPTION
When compiling compiler-rt you typically compile with `-fvisibility=hidden`
which to ensure that all symbols are hidden in shared objects and don't show up
in symbol tables. This is important for these intrinsics being linked in every
crate to ensure that we're not unnecessarily bloating the public ABI of Rust
crates.

This should help allow the compiler-builtins project with Rust-defined builtins
start landing in-tree as well.