### PR TITLE
bootstrap: rust-docs is a default package

### DIFF
--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -424,6 +424,7 @@ pub fn build_rules(build: &Build) -> Rules {
          .host(true)
          .run(move |_| dist::rust_src(build));
     rules.dist("dist-docs", "src/doc")
+         .default(true)
          .dep(|s| s.name("default:doc"))
          .run(move |s| dist::docs(build, s.stage, s.target));
     rules.dist("install", "src")


### PR DESCRIPTION
This will cause it to be built as part of `make dist`.

This is blocking betas and nightlies.

r? @alexcrichton 