### PR TITLE
rustdoc: fold fields for enum struct variants into a docblock

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2467,8 +2467,13 @@ fn item_enum(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
             if let clean::VariantItem(Variant {
                 kind: VariantKind::Struct(ref s)
             }) = variant.inner {
-                write!(w, "<h3 class='fields'>Fields</h3>\n
-                           <table>")?;
+                let variant_id = derive_id(format!("{}.{}.fields",
+                                                   ItemType::Variant,
+                                                   variant.name.as_ref().unwrap()));
+                write!(w, "<span class='docblock autohide sub-variant' id='{id}'>",
+                       id = variant_id)?;
+                write!(w, "<h3 class='fields'>Fields of <code>{name}</code></h3>\n
+                           <table>", name = variant.name.as_ref().unwrap())?;
                 for field in &s.fields {
                     use clean::StructFieldItem;
                     if let StructFieldItem(ref ty) = field.inner {
@@ -2492,7 +2497,7 @@ fn item_enum(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                         write!(w, "</td></tr>")?;
                     }
                 }
-                write!(w, "</table>")?;
+                write!(w, "</table></span>")?;
             }
             render_stability_since(w, variant, it)?;
         }

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1013,6 +1013,22 @@
                     .html('&nbsp;Expand&nbsp;description'));
         var wrapper = $("<div class='toggle-wrapper'>").append(mainToggle);
         $("#main > .docblock").before(wrapper);
+
+        $(".docblock.autohide").each(function() {
+            var wrap = $(this).prev();
+            if (wrap.is(".toggle-wrapper")) {
+                var toggle = wrap.children().first();
+                if ($(this).children().first().is("h3")) {
+                    toggle.children(".toggle-label")
+                          .text(" Show " + $(this).children().first().text());
+                }
+                $(this).hide();
+                wrap.addClass("collapsed");
+                toggle.children(".inner").text(labelForToggleButton(true));
+                toggle.children(".toggle-label").show();
+            }
+        });
+
         var mainToggle =
             $(toggle).append(
                 $('<span/>', {'class': 'toggle-label'})

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -339,6 +339,10 @@ h4 > code, h3 > code, .invisible > code {
 	border-bottom: 1px solid;
 }
 
+.fields + table {
+	margin-bottom: 1em;
+}
+
 .content .item-list {
 	list-style-type: none;
 	padding: 0;
@@ -661,6 +665,10 @@ span.since {
 
 .variant + .toggle-wrapper > a {
 	margin-top: 5px;
+}
+
+.sub-variant, .sub-variant > h3 {
+	margin-top: 0 !important;
 }
 
 .enum > .toggle-wrapper + .docblock, .struct > .toggle-wrapper + .docblock {


### PR DESCRIPTION
Per discussion in #37500, this PR updates the enum rendering code to wrap variants with named struct fields in a `docblock` span that is hidden automatically upon load of the page. This gives struct variant fields a clean separation from other enum variants, giving a boost to the readability of such documentation. Preview output is available [on the issue page](https://github.com/rust-lang/rust/issues/37500#issuecomment-260069269), but for the sake of completeness I'll include the images here again.

![rustdoc struct enum variant 4 part 1](https://cloud.githubusercontent.com/assets/5217170/20231925/96160b7e-a82a-11e6-945b-bbba95c5e4bc.PNG)

When you initially load the page, there's a line under variants with struct fields letting you know you can click to expand the listing.

![rustdoc struct enum variant 4 part 2](https://cloud.githubusercontent.com/assets/3050060/20232067/1dc63266-a866-11e6-9555-8fb1c8afdcec.png)

If you click to expand, the header and table unfold into a nicely-indented listing.

If you want to take a look in your own browser and screen size, [I've got this version hosted on my server](https://shiva.icesoldier.me/doctest/doctest/enum.OldTopicRemoval.html).

Fixes #37500 

r? @GuillaumeGomez