### PR TITLE
Less unused argument spew

### DIFF
--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -794,8 +794,11 @@ pub fn expand_preparsed_format_args(ecx: &mut ExtCtxt,
             } else {
                 let mut diag = cx.ecx.struct_span_err(cx.fmtsp,
                     "multiple unused formatting arguments");
-                for (sp, msg) in errs {
-                    diag.span_note(sp, msg);
+                for (sp, _) in errs {
+                    // Ignore the specific message, and use something terser; otherwise, the error
+                    // message starts to sound a little repetitive.  A little repetitive.  A little
+                    // repetitive.
+                    diag.span_label(sp, &"unused");
                 }
                 diag
             }

--- a/src/test/ui/macros/format-foreign.rs
+++ b/src/test/ui/macros/format-foreign.rs
@@ -17,4 +17,9 @@ fn main() {
     println!("{} %f", "one", 2.0);
 
     println!("Hi there, $NAME.", NAME="Tim");
+
+    println!("%*2$.*1$s",
+             "Some text",
+             20,
+             8);
 }

--- a/src/test/ui/macros/format-foreign.stderr
+++ b/src/test/ui/macros/format-foreign.stderr
@@ -2,23 +2,12 @@ error: multiple unused formatting arguments
   --> $DIR/format-foreign.rs:12:5
    |
 12 |     println!("%.*3$s %s!/n", "Hello,", "World", 4);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^--------^^-------^^-^^
+   |                              |         |        |
+   |                              |         |        unused
+   |                              |         unused
+   |                              unused
    |
-note: argument never used
-  --> $DIR/format-foreign.rs:12:30
-   |
-12 |     println!("%.*3$s %s!/n", "Hello,", "World", 4);
-   |                              ^^^^^^^^
-note: argument never used
-  --> $DIR/format-foreign.rs:12:40
-   |
-12 |     println!("%.*3$s %s!/n", "Hello,", "World", 4);
-   |                                        ^^^^^^^
-note: argument never used
-  --> $DIR/format-foreign.rs:12:49
-   |
-12 |     println!("%.*3$s %s!/n", "Hello,", "World", 4);
-   |                                                 ^
    = help: `%.*3$s` should be written as `{:.2$}`
    = help: `%s` should be written as `{}`
    = note: printf formatting not supported; see the documentation for `std::fmt`
@@ -48,5 +37,21 @@ error: named argument never used
    = help: `$NAME` should be written as `{NAME}`
    = note: shell formatting not supported; see the documentation for `std::fmt`
 
-error: aborting due to 4 previous errors
+error: multiple unused formatting arguments
+  --> $DIR/format-foreign.rs:21:5
+   |
+21 |     println!("%*2$.*1$s",
+   |     ^
+22 |              "Some text",
+   |              ----------- unused
+23 |              20,
+   |              -- unused
+24 |              8);
+   |              - unused
+   |
+   = help: `%*2$.*1$s` should be written as `{:>1$.0$}`
+   = note: printf formatting not supported; see the documentation for `std::fmt`
+   = note: this error originates in a macro outside of the current crate
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Unused arguments are attached to the main error as labels.  This drops
the traditional named/positional message split (except in the case of a
*single* unused argument) for "unused" in interest of terseness.

Closes rust-lang/rust#37718.

---

I tried using `MultiSpan` with `struct_err_span`, but *none* of the spans were emitted.  This was *also* the case with trying to attach a `MultiSpan` to the `Diagnostic` as a note.  `span_label` was the only seemingly relevant method I found that would actually display.

It feels a bit ugly, but *works.*

I also chose to merge the two branches for how to display the error for the sake of simplifying and unifying the diagnostic construction a little.