### PR TITLE
Support `use`ing externally defined macros behind `#![feature(use_extern_macros)]`

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -755,8 +755,6 @@ pub fn phase_2_configure_and_expand<'a, F>(sess: &Session,
          || ast_validation::check_crate(sess, &krate));
 
     time(sess.time_passes(), "name resolution", || -> CompileResult {
-        resolver.resolve_imports();
-
         // Since import resolution will eventually happen in expansion,
         // don't perform `after_expand` until after import resolution.
         after_expand(&krate)?;

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -362,9 +362,11 @@ impl<'b> Resolver<'b> {
 
     // Constructs the reduced graph for one variant. Variants exist in the
     // type and value namespaces.
-    fn build_reduced_graph_for_variant(
-        &mut self, variant: &Variant, parent: Module<'b>, vis: ty::Visibility, expansion: Mark,
-    ) {
+    fn build_reduced_graph_for_variant(&mut self,
+                                       variant: &Variant,
+                                       parent: Module<'b>,
+                                       vis: ty::Visibility,
+                                       expansion: Mark) {
         let name = variant.node.name.name;
         let def_id = self.definitions.local_def_id(variant.node.data.id());
 
@@ -381,22 +383,20 @@ impl<'b> Resolver<'b> {
     }
 
     /// Constructs the reduced graph for one foreign item.
-    fn build_reduced_graph_for_foreign_item(
-        &mut self, foreign_item: &ForeignItem, expansion: Mark,
-    ) {
+    fn build_reduced_graph_for_foreign_item(&mut self, item: &ForeignItem, expansion: Mark) {
         let parent = self.current_module;
-        let name = foreign_item.ident.name;
+        let name = item.ident.name;
 
-        let def = match foreign_item.node {
+        let def = match item.node {
             ForeignItemKind::Fn(..) => {
-                Def::Fn(self.definitions.local_def_id(foreign_item.id))
+                Def::Fn(self.definitions.local_def_id(item.id))
             }
             ForeignItemKind::Static(_, m) => {
-                Def::Static(self.definitions.local_def_id(foreign_item.id), m)
+                Def::Static(self.definitions.local_def_id(item.id), m)
             }
         };
-        let vis = self.resolve_visibility(&foreign_item.vis);
-        self.define(parent, name, ValueNS, (def, vis, foreign_item.span, expansion));
+        let vis = self.resolve_visibility(&item.vis);
+        self.define(parent, name, ValueNS, (def, vis, item.span, expansion));
     }
 
     fn build_reduced_graph_for_block(&mut self, block: &Block) {
@@ -415,8 +415,7 @@ impl<'b> Resolver<'b> {
     }
 
     /// Builds the reduced graph for a single item in an external crate.
-    fn build_reduced_graph_for_external_crate_def(&mut self, parent: Module<'b>,
-                                                  child: Export) {
+    fn build_reduced_graph_for_external_crate_def(&mut self, parent: Module<'b>, child: Export) {
         let name = child.name;
         let def = child.def;
         let def_id = def.def_id();
@@ -545,9 +544,11 @@ impl<'b> Resolver<'b> {
         module.populated.set(true)
     }
 
-    fn legacy_import_macro(
-        &mut self, name: Name, binding: &'b NameBinding<'b>, span: Span, allow_shadowing: bool,
-    ) {
+    fn legacy_import_macro(&mut self,
+                           name: Name,
+                           binding: &'b NameBinding<'b>,
+                           span: Span,
+                           allow_shadowing: bool) {
         self.used_crates.insert(binding.def().def_id().krate);
         self.macro_names.insert(name);
         if self.builtin_macros.insert(name, binding).is_some() && !allow_shadowing {

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -638,7 +638,9 @@ pub struct BuildReducedGraphVisitor<'a, 'b: 'a> {
 
 impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
     fn visit_invoc(&mut self, id: ast::NodeId) -> &'b InvocationData<'b> {
-        let invocation = self.resolver.invocations[&Mark::from_placeholder_id(id)];
+        let mark = Mark::from_placeholder_id(id);
+        self.resolver.current_module.unresolved_invocations.borrow_mut().insert(mark);
+        let invocation = self.resolver.invocations[&mark];
         invocation.module.set(self.resolver.current_module);
         invocation.legacy_scope.set(self.legacy_scope);
         invocation

--- a/src/librustc_resolve/check_unused.rs
+++ b/src/librustc_resolve/check_unused.rs
@@ -22,7 +22,6 @@
 use std::ops::{Deref, DerefMut};
 
 use Resolver;
-use Namespace::{TypeNS, ValueNS};
 
 use rustc::lint;
 use rustc::util::nodemap::NodeMap;
@@ -56,8 +55,9 @@ impl<'a, 'b> UnusedImportCheckVisitor<'a, 'b> {
     // We have information about whether `use` (import) directives are actually
     // used now. If an import is not used at all, we signal a lint error.
     fn check_import(&mut self, item_id: ast::NodeId, id: ast::NodeId, span: Span) {
-        if !self.used_imports.contains(&(id, TypeNS)) &&
-           !self.used_imports.contains(&(id, ValueNS)) {
+        let mut used = false;
+        self.per_ns(|this, ns| used |= this.used_imports.contains(&(id, ns)));
+        if !used {
             if self.maybe_unused_trait_imports.contains(&id) {
                 // Check later.
                 return;

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -76,7 +76,7 @@ use std::fmt;
 use std::mem::replace;
 use std::rc::Rc;
 
-use resolve_imports::{ImportDirective, ImportDirectiveSubclass, NameResolution};
+use resolve_imports::{ImportDirective, ImportDirectiveSubclass, NameResolution, ImportResolver};
 use macros::{InvocationData, LegacyBinding, LegacyScope};
 
 // NB: This module needs to be declared first so diagnostics are
@@ -1335,6 +1335,7 @@ impl<'a> Resolver<'a> {
 
     /// Entry point to crate resolution.
     pub fn resolve_crate(&mut self, krate: &Crate) {
+        ImportResolver { resolver: self }.finalize_imports();
         self.current_module = self.graph_root;
         visit::walk_crate(self, krate);
 

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1115,7 +1115,7 @@ pub struct Resolver<'a> {
     pub exported_macros: Vec<ast::MacroDef>,
     crate_loader: &'a mut CrateLoader,
     macro_names: FxHashSet<Name>,
-    builtin_macros: FxHashMap<Name, DefId>,
+    builtin_macros: FxHashMap<Name, &'a NameBinding<'a>>,
     lexical_macro_resolutions: Vec<(Name, LegacyScope<'a>)>,
     macro_map: FxHashMap<DefId, Rc<SyntaxExtension>>,
     macro_exports: Vec<Export>,

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -799,6 +799,9 @@ pub struct ModuleS<'a> {
 
     resolutions: RefCell<FxHashMap<(Name, Namespace), &'a RefCell<NameResolution<'a>>>>,
 
+    // Macro invocations that can expand into items in this module.
+    unresolved_invocations: RefCell<FxHashSet<Mark>>,
+
     no_implicit_prelude: bool,
 
     glob_importers: RefCell<Vec<&'a ImportDirective<'a>>>,
@@ -822,6 +825,7 @@ impl<'a> ModuleS<'a> {
             kind: kind,
             normal_ancestor_id: None,
             resolutions: RefCell::new(FxHashMap()),
+            unresolved_invocations: RefCell::new(FxHashSet()),
             no_implicit_prelude: false,
             glob_importers: RefCell::new(Vec::new()),
             globs: RefCell::new((Vec::new())),

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -881,6 +881,7 @@ impl<'a> fmt::Debug for ModuleS<'a> {
 #[derive(Clone, Debug)]
 pub struct NameBinding<'a> {
     kind: NameBindingKind<'a>,
+    expansion: Mark,
     span: Span,
     vis: ty::Visibility,
 }
@@ -1304,6 +1305,7 @@ impl<'a> Resolver<'a> {
             arenas: arenas,
             dummy_binding: arenas.alloc_name_binding(NameBinding {
                 kind: NameBindingKind::Def(Def::Err),
+                expansion: Mark::root(),
                 span: DUMMY_SP,
                 vis: ty::Visibility::Public,
             }),

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -8,7 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use {Module, ModuleKind, NameBinding, NameBindingKind, Resolver};
+use {Module, ModuleKind, NameBinding, NameBindingKind, Resolver, AmbiguityError};
+use Namespace::{self, MacroNS};
+use ResolveResult::{Success, Indeterminate, Failed};
 use build_reduced_graph::BuildReducedGraphVisitor;
 use resolve_imports::ImportResolver;
 use rustc::hir::def_id::{DefId, BUILTIN_MACROS_CRATE, CRATE_DEF_INDEX, DefIndex};
@@ -17,7 +19,7 @@ use rustc::hir::map::{self, DefCollector};
 use rustc::ty;
 use std::cell::Cell;
 use std::rc::Rc;
-use syntax::ast;
+use syntax::ast::{self, Name};
 use syntax::errors::DiagnosticBuilder;
 use syntax::ext::base::{self, Determinacy, MultiModifier, MultiDecorator};
 use syntax::ext::base::{NormalTT, SyntaxExtension};
@@ -85,6 +87,11 @@ pub struct LegacyBinding<'a> {
     pub span: Span,
 }
 
+pub enum MacroBinding<'a> {
+    Legacy(&'a LegacyBinding<'a>),
+    Modern(&'a NameBinding<'a>),
+}
+
 impl<'a> base::Resolver for Resolver<'a> {
     fn next_node_id(&mut self) -> ast::NodeId {
         self.session.next_node_id()
@@ -140,6 +147,7 @@ impl<'a> base::Resolver for Resolver<'a> {
             expansion: mark,
         };
         expansion.visit_with(&mut visitor);
+        self.current_module.unresolved_invocations.borrow_mut().remove(&mark);
         invocation.expansion.set(visitor.legacy_scope);
     }
 
@@ -201,7 +209,7 @@ impl<'a> base::Resolver for Resolver<'a> {
         for i in 0..attrs.len() {
             let name = intern(&attrs[i].name());
             match self.builtin_macros.get(&name).cloned() {
-                Some(binding) => match *self.get_macro(binding.def()) {
+                Some(binding) => match *self.get_macro(binding) {
                     MultiModifier(..) | MultiDecorator(..) | SyntaxExtension::AttrProcMacro(..) => {
                         return Some(attrs.remove(i))
                     }
@@ -225,25 +233,77 @@ impl<'a> base::Resolver for Resolver<'a> {
         if let LegacyScope::Expansion(parent) = invocation.legacy_scope.get() {
             invocation.legacy_scope.set(LegacyScope::simplify_expansion(parent));
         }
-        self.resolve_macro_name(invocation.legacy_scope.get(), name).ok_or_else(|| {
-            if force {
-                let msg = format!("macro undefined: '{}!'", name);
-                let mut err = self.session.struct_span_err(path.span, &msg);
-                self.suggest_macro_name(&name.as_str(), &mut err);
-                err.emit();
-                Determinacy::Determined
-            } else {
-                Determinacy::Undetermined
-            }
-        })
+
+        self.current_module = invocation.module.get();
+        let result = match self.resolve_legacy_scope(invocation.legacy_scope.get(), name, false) {
+            Some(MacroBinding::Legacy(binding)) => Ok(binding.ext.clone()),
+            Some(MacroBinding::Modern(binding)) => Ok(self.get_macro(binding)),
+            None => match self.resolve_in_item_lexical_scope(name, MacroNS, None) {
+                Some(binding) => Ok(self.get_macro(binding)),
+                None => return Err(if force {
+                    let msg = format!("macro undefined: '{}!'", name);
+                    let mut err = self.session.struct_span_err(path.span, &msg);
+                    self.suggest_macro_name(&name.as_str(), &mut err);
+                    err.emit();
+                    Determinacy::Determined
+                } else {
+                    Determinacy::Undetermined
+                }),
+            },
+        };
+
+        if self.use_extern_macros {
+            self.current_module.legacy_macro_resolutions.borrow_mut()
+                .push((scope, name, path.span));
+        }
+        result
     }
 }
 
 impl<'a> Resolver<'a> {
-    pub fn resolve_macro_name(&mut self, mut scope: LegacyScope<'a>, name: ast::Name)
-                              -> Option<Rc<SyntaxExtension>> {
+    // Resolve the name in the module's lexical scope, excluding non-items.
+    fn resolve_in_item_lexical_scope(
+        &mut self, name: Name, ns: Namespace, record_used: Option<Span>,
+    ) -> Option<&'a NameBinding<'a>> {
+        let mut module = self.current_module;
+        let mut potential_expanded_shadower = None;
+        loop {
+            // Since expanded macros may not shadow the lexical scope (enforced below),
+            // we can ignore unresolved invocations (indicated by the penultimate argument).
+            match self.resolve_name_in_module(module, name, ns, true, true, record_used) {
+                Success(binding) => {
+                    let span = match record_used {
+                        Some(span) => span,
+                        None => return Some(binding),
+                    };
+                    if let Some(shadower) = potential_expanded_shadower {
+                        self.ambiguity_errors.push(AmbiguityError {
+                            span: span, name: name, b1: shadower, b2: binding, lexical: true,
+                        });
+                        return Some(shadower);
+                    } else if binding.expansion == Mark::root() {
+                        return Some(binding);
+                    } else {
+                        potential_expanded_shadower = Some(binding);
+                    }
+                },
+                Indeterminate => return None,
+                Failed(..) => {}
+            }
+
+            match module.kind {
+                ModuleKind::Block(..) => module = module.parent.unwrap(),
+                ModuleKind::Def(..) => return potential_expanded_shadower,
+            }
+        }
+    }
+
+    pub fn resolve_legacy_scope(
+        &mut self, mut scope: LegacyScope<'a>, name: ast::Name, record_used: bool,
+    ) -> Option<MacroBinding<'a>> {
         let mut possible_time_travel = None;
         let mut relative_depth: u32 = 0;
+        let mut binding = None;
         loop {
             scope = match scope {
                 LegacyScope::Empty => break,
@@ -262,25 +322,59 @@ impl<'a> Resolver<'a> {
                     relative_depth = relative_depth.saturating_sub(1);
                     invocation.legacy_scope.get()
                 }
-                LegacyScope::Binding(binding) => {
-                    if binding.name == name {
-                        if let Some(scope) = possible_time_travel {
-                            // Check for disallowed shadowing later
-                            self.lexical_macro_resolutions.push((name, scope));
-                        } else if relative_depth > 0 {
-                            self.disallowed_shadowing.push(binding);
+                LegacyScope::Binding(potential_binding) => {
+                    if potential_binding.name == name {
+                        if (!self.use_extern_macros || record_used) && relative_depth > 0 {
+                            self.disallowed_shadowing.push(potential_binding);
                         }
-                        return Some(binding.ext.clone());
+                        binding = Some(potential_binding);
+                        break
                     }
-                    binding.parent
+                    potential_binding.parent
                 }
             };
         }
 
-        if let Some(scope) = possible_time_travel {
-            self.lexical_macro_resolutions.push((name, scope));
+        let binding = match binding {
+            Some(binding) => MacroBinding::Legacy(binding),
+            None => match self.builtin_macros.get(&name).cloned() {
+                Some(binding) => MacroBinding::Modern(binding),
+                None => return None,
+            },
+        };
+
+        if !self.use_extern_macros {
+            if let Some(scope) = possible_time_travel {
+                // Check for disallowed shadowing later
+                self.lexical_macro_resolutions.push((name, scope));
+            }
         }
-        self.builtin_macros.get(&name).cloned().map(|binding| self.get_macro(binding.def()))
+
+        Some(binding)
+    }
+
+    pub fn finalize_current_module_macro_resolutions(&mut self) {
+        let module = self.current_module;
+        for &(mark, name, span) in module.legacy_macro_resolutions.borrow().iter() {
+            let legacy_scope = self.invocations[&mark].legacy_scope.get();
+            let legacy_resolution = self.resolve_legacy_scope(legacy_scope, name, true);
+            let resolution = self.resolve_in_item_lexical_scope(name, MacroNS, Some(span));
+            let (legacy_resolution, resolution) = match (legacy_resolution, resolution) {
+                (Some(legacy_resolution), Some(resolution)) => (legacy_resolution, resolution),
+                _ => continue,
+            };
+            let (legacy_span, participle) = match legacy_resolution {
+                MacroBinding::Modern(binding) if binding.def() == resolution.def() => continue,
+                MacroBinding::Modern(binding) => (binding.span, "imported"),
+                MacroBinding::Legacy(binding) => (binding.span, "defined"),
+            };
+            let msg1 = format!("`{}` could resolve to the macro {} here", name, participle);
+            let msg2 = format!("`{}` could also resolve to the macro imported here", name);
+            self.session.struct_span_err(span, &format!("`{}` is ambiguous", name))
+                .span_note(legacy_span, &msg1)
+                .span_note(resolution.span, &msg2)
+                .emit();
+        }
     }
 
     fn suggest_macro_name(&mut self, name: &str, err: &mut DiagnosticBuilder<'a>) {

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -262,9 +262,11 @@ impl<'a> base::Resolver for Resolver<'a> {
 
 impl<'a> Resolver<'a> {
     // Resolve the name in the module's lexical scope, excluding non-items.
-    fn resolve_in_item_lexical_scope(
-        &mut self, name: Name, ns: Namespace, record_used: Option<Span>,
-    ) -> Option<&'a NameBinding<'a>> {
+    fn resolve_in_item_lexical_scope(&mut self,
+                                     name: Name,
+                                     ns: Namespace,
+                                     record_used: Option<Span>)
+                                     -> Option<&'a NameBinding<'a>> {
         let mut module = self.current_module;
         let mut potential_expanded_shadower = None;
         loop {
@@ -298,9 +300,11 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    pub fn resolve_legacy_scope(
-        &mut self, mut scope: LegacyScope<'a>, name: ast::Name, record_used: bool,
-    ) -> Option<MacroBinding<'a>> {
+    pub fn resolve_legacy_scope(&mut self,
+                                mut scope: LegacyScope<'a>,
+                                name: Name,
+                                record_used: bool)
+                                -> Option<MacroBinding<'a>> {
         let mut possible_time_travel = None;
         let mut relative_depth: u32 = 0;
         let mut binding = None;

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -10,6 +10,7 @@
 
 use {Module, ModuleKind, Resolver};
 use build_reduced_graph::BuildReducedGraphVisitor;
+use resolve_imports::ImportResolver;
 use rustc::hir::def_id::{DefId, BUILTIN_MACROS_CRATE, CRATE_DEF_INDEX, DefIndex};
 use rustc::hir::def::{Def, Export};
 use rustc::hir::map::{self, DefCollector};
@@ -183,6 +184,10 @@ impl<'a> base::Resolver for Resolver<'a> {
 
     fn add_expansions_at_stmt(&mut self, id: ast::NodeId, macros: Vec<Mark>) {
         self.macros_at_scope.insert(id, macros);
+    }
+
+    fn resolve_imports(&mut self) {
+        ImportResolver { resolver: self }.resolve_imports()
     }
 
     fn find_attr_invoc(&mut self, attrs: &mut Vec<ast::Attribute>) -> Option<ast::Attribute> {

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -184,6 +184,7 @@ impl<'a> base::Resolver for Resolver<'a> {
             kind: NameBindingKind::Def(Def::Macro(def_id)),
             span: DUMMY_SP,
             vis: ty::Visibility::PrivateExternal,
+            expansion: Mark::root(),
         });
         self.builtin_macros.insert(ident.name, binding);
     }

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -131,6 +131,7 @@ impl<'a> base::Resolver for Resolver<'a> {
         self.collect_def_ids(invocation, expansion);
 
         self.current_module = invocation.module.get();
+        self.current_module.unresolved_invocations.borrow_mut().remove(&mark);
         let mut visitor = BuildReducedGraphVisitor {
             resolver: self,
             legacy_scope: LegacyScope::Invocation(invocation),

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -524,6 +524,7 @@ pub trait Resolver {
     fn add_ext(&mut self, ident: ast::Ident, ext: Rc<SyntaxExtension>);
     fn add_expansions_at_stmt(&mut self, id: ast::NodeId, macros: Vec<Mark>);
 
+    fn resolve_imports(&mut self);
     fn find_attr_invoc(&mut self, attrs: &mut Vec<Attribute>) -> Option<Attribute>;
     fn resolve_macro(&mut self, scope: Mark, path: &ast::Path, force: bool)
                      -> Result<Rc<SyntaxExtension>, Determinacy>;
@@ -547,6 +548,7 @@ impl Resolver for DummyResolver {
     fn add_ext(&mut self, _ident: ast::Ident, _ext: Rc<SyntaxExtension>) {}
     fn add_expansions_at_stmt(&mut self, _id: ast::NodeId, _macros: Vec<Mark>) {}
 
+    fn resolve_imports(&mut self) {}
     fn find_attr_invoc(&mut self, _attrs: &mut Vec<Attribute>) -> Option<Attribute> { None }
     fn resolve_macro(&mut self, _scope: Mark, _path: &ast::Path, _force: bool)
                      -> Result<Rc<SyntaxExtension>, Determinacy> {

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -314,6 +314,8 @@ declare_features! (
 
     // Allows #[link(..., cfg(..))]
     (active, link_cfg, "1.14.0", Some(37406)),
+
+    (active, use_extern_macros, "1.15.0", Some(35896)),
 );
 
 declare_features! (

--- a/src/test/compile-fail/blind-item-block-item-shadow.rs
+++ b/src/test/compile-fail/blind-item-block-item-shadow.rs
@@ -14,6 +14,6 @@ fn main() {
     {
         struct Bar;
         use foo::Bar;
-        //~^ ERROR a value named `Bar` has already been defined in this block
+        //~^ ERROR a type named `Bar` has already been defined in this block
     }
 }

--- a/src/test/compile-fail/double-type-import.rs
+++ b/src/test/compile-fail/double-type-import.rs
@@ -11,7 +11,7 @@
 mod foo {
     pub use self::bar::X;
     use self::bar::X;
-    //~^ ERROR a value named `X` has already been imported in this module
+    //~^ ERROR a type named `X` has already been imported in this module
 
     mod bar {
         pub struct X;

--- a/src/test/compile-fail/imports/auxiliary/two_macros.rs
+++ b/src/test/compile-fail/imports/auxiliary/two_macros.rs
@@ -1,0 +1,15 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_export]
+macro_rules! m { ($($t:tt)*) => { $($t)* } }
+
+#[macro_export]
+macro_rules! n { ($($t:tt)*) => { $($t)* } }

--- a/src/test/compile-fail/imports/duplicate.rs
+++ b/src/test/compile-fail/imports/duplicate.rs
@@ -46,9 +46,9 @@ mod g {
 fn main() {
     e::foo();
     f::foo(); //~ ERROR `foo` is ambiguous
-              //~| NOTE Consider adding an explicit import of `foo` to disambiguate
+              //~| NOTE consider adding an explicit import of `foo` to disambiguate
     g::foo(); //~ ERROR `foo` is ambiguous
-              //~| NOTE Consider adding an explicit import of `foo` to disambiguate
+              //~| NOTE consider adding an explicit import of `foo` to disambiguate
 }
 
 mod ambiguous_module_errors {

--- a/src/test/compile-fail/imports/macros.rs
+++ b/src/test/compile-fail/imports/macros.rs
@@ -1,0 +1,55 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:two_macros.rs
+
+#![feature(item_like_imports, use_extern_macros)]
+
+extern crate two_macros; // two identity macros `m` and `n`
+
+mod foo {
+    pub use two_macros::n as m;
+}
+
+mod m1 {
+    m!(use two_macros::*;);
+    use foo::m; // This shadows the glob import
+}
+
+mod m2 {
+    use two_macros::*; //~ NOTE could also resolve
+    m! { //~ ERROR ambiguous
+         //~| NOTE macro-expanded macro imports do not shadow
+        use foo::m; //~ NOTE could resolve to the name imported here
+                    //~^^^ NOTE in this expansion
+    }
+}
+
+mod m3 {
+    use two_macros::m; //~ NOTE could also resolve
+    fn f() {
+        use two_macros::n as m; // This shadows the above import
+        m!();
+    }
+
+    fn g() {
+        m! { //~ ERROR ambiguous
+             //~| NOTE macro-expanded macro imports do not shadow
+            use two_macros::n as m; //~ NOTE could resolve to the name imported here
+                                    //~^^^ NOTE in this expansion
+        }
+    }
+}
+
+mod m4 {
+    macro_rules! m { () => {} } //~ NOTE could resolve to the macro defined here
+    use two_macros::m; //~ NOTE could also resolve to the macro imported here
+    m!(); //~ ERROR ambiguous
+}


### PR DESCRIPTION
With `#![feature(use_extern_macros)]`,
 - A name collision between macros from different upstream crates is much less of an issue since we can `use` the macros in different submodules or rename with `as`.
 - We can reexport macros with `pub use`, so `#![feature(macro_reexport)]` is no longer needed.
 - These reexports are allowed in any module, so crates can expose a macro-modular interface.

If a macro invocation can resolve to both a `use` import and a `macro_rules!` or `#[macro_use]`, it is currently an ambiguity error.

r? @nrc 