### PR TITLE
Improvements to the #[should_panic] feature

### DIFF
--- a/src/test/run-fail/test-should-panic-bad-message.rs
+++ b/src/test/run-fail/test-should-panic-bad-message.rs
@@ -1,0 +1,19 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --test
+
+// error-pattern:panicked at 'bar'
+// check-stdout
+#[test]
+#[should_panic(expected = "foo")]
+pub fn test_bar() {
+    panic!("bar")
+}

--- a/src/test/run-fail/test-should-panic-no-message.rs
+++ b/src/test/run-fail/test-should-panic-no-message.rs
@@ -1,0 +1,19 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --test
+
+// error-pattern:panicked at 'explicit panic'
+// check-stdout
+#[test]
+#[should_panic(expected = "foo")]
+pub fn test_explicit() {
+    panic!()
+}

--- a/src/test/run-pass/test-should-panic-attr.rs
+++ b/src/test/run-pass/test-should-panic-attr.rs
@@ -1,0 +1,46 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --test
+
+#[test]
+#[should_panic = "foo"]
+//~^ WARN: attribute must be of the form:
+fn test1() {
+    panic!();
+}
+
+#[test]
+#[should_panic(expected)]
+//~^ WARN: argument must be of the form:
+fn test2() {
+    panic!();
+}
+
+#[test]
+#[should_panic(expect)]
+//~^ WARN: argument must be of the form:
+fn test3() {
+    panic!();
+}
+
+#[test]
+#[should_panic(expected(foo, bar))]
+//~^ WARN: argument must be of the form:
+fn test4() {
+    panic!();
+}
+
+#[test]
+#[should_panic(expected = "foo", bar)]
+//~^ WARN: argument must be of the form:
+fn test5() {
+    panic!();
+}


### PR DESCRIPTION
Add more error checking for the `#[should_panic]` attribute, and print the expected panic string when it does not match.

Fixes https://github.com/rust-lang/rust/issues/29000

Eg:
```running 3 tests
test test2 ... ok
test test1 ... FAILED
: Panic did not include expected string 'foo'
test test3 ... FAILED

failures:

---- test1 stdout ----
	thread 'test1' panicked at 'bar', test.rs:7
note: Run with `RUST_BACKTRACE=1` for a backtrace.

---- test3 stdout ----
	thread 'test3' panicked at 'bar', test.rs:18

```