### PR TITLE
coherence: skip impls with an erroneous trait ref

### DIFF
--- a/src/librustc_typeck/coherence/overlap.rs
+++ b/src/librustc_typeck/coherence/overlap.rs
@@ -14,7 +14,7 @@
 
 use hir::def_id::DefId;
 use rustc::traits::{self, Reveal};
-use rustc::ty::{self, TyCtxt};
+use rustc::ty::{self, TyCtxt, TypeFoldable};
 use syntax::ast;
 use rustc::dep_graph::DepNode;
 use rustc::hir;
@@ -133,6 +133,12 @@ impl<'cx, 'tcx, 'v> intravisit::Visitor<'v> for OverlapChecker<'cx, 'tcx> {
                 let impl_def_id = self.tcx.map.local_def_id(item.id);
                 let trait_ref = self.tcx.impl_trait_ref(impl_def_id).unwrap();
                 let trait_def_id = trait_ref.def_id;
+
+                if trait_ref.references_error() {
+                    debug!("coherence: skipping impl {:?} with error {:?}",
+                           impl_def_id, trait_ref);
+                    return
+                }
 
                 let _task =
                     self.tcx.dep_graph.in_task(DepNode::CoherenceOverlapCheck(trait_def_id));

--- a/src/test/compile-fail/coherence-error-suppression.rs
+++ b/src/test/compile-fail/coherence-error-suppression.rs
@@ -1,0 +1,25 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// check that error types in coherence do not cause error cascades.
+
+trait Foo {}
+
+impl Foo for i8 {}
+impl Foo for i16 {}
+impl Foo for i32 {}
+impl Foo for i64 {}
+impl Foo for DoesNotExist {} //~ ERROR `DoesNotExist` is undefined
+impl Foo for u8 {}
+impl Foo for u16 {}
+impl Foo for u32 {}
+impl Foo for u64 {}
+
+fn main() {}


### PR DESCRIPTION
Impls with a erroneous trait ref are already ignored in the first part
of coherence, so ignore them in the second part too. This avoids
cascading coherence errors when 1 impl of a trait has an error.

r? @nikomatsakis 