### PR TITLE
do not use deprecated text for unstable docs

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2890,7 +2890,8 @@ pub struct Stability {
     pub feature: String,
     pub since: String,
     pub deprecated_since: String,
-    pub reason: String,
+    pub deprecated_reason: String,
+    pub unstable_reason: String,
     pub issue: Option<u32>
 }
 
@@ -2913,12 +2914,13 @@ impl Clean<Stability> for attr::Stability {
                 Some(attr::RustcDeprecation {ref since, ..}) => since.to_string(),
                 _=> "".to_string(),
             },
-            reason: {
-                match (&self.rustc_depr, &self.level) {
-                    (&Some(ref depr), _) => depr.reason.to_string(),
-                    (&None, &attr::Unstable {reason: Some(ref reason), ..}) => reason.to_string(),
-                    _ => "".to_string(),
-                }
+            deprecated_reason: match self.rustc_depr {
+                Some(ref depr) => depr.reason.to_string(),
+                _ => "".to_string(),
+            },
+            unstable_reason: match self.level {
+                attr::Unstable { reason: Some(ref reason), .. } => reason.to_string(),
+                _ => "".to_string(),
             },
             issue: match self.level {
                 attr::Unstable {issue, ..} => Some(issue),

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1878,8 +1878,8 @@ fn short_stability(item: &clean::Item, cx: &Context, show_reason: bool) -> Vec<S
     let mut stability = vec![];
 
     if let Some(stab) = item.stability.as_ref() {
-        let reason = if show_reason && !stab.reason.is_empty() {
-            format!(": {}", stab.reason)
+        let deprecated_reason = if show_reason && !stab.deprecated_reason.is_empty() {
+            format!(": {}", stab.deprecated_reason)
         } else {
             String::new()
         };
@@ -1889,7 +1889,7 @@ fn short_stability(item: &clean::Item, cx: &Context, show_reason: bool) -> Vec<S
             } else {
                 String::new()
             };
-            let text = format!("Deprecated{}{}", since, Markdown(&reason));
+            let text = format!("Deprecated{}{}", since, Markdown(&deprecated_reason));
             stability.push(format!("<em class='stab deprecated'>{}</em>", text))
         };
 
@@ -1909,7 +1909,12 @@ fn short_stability(item: &clean::Item, cx: &Context, show_reason: bool) -> Vec<S
             } else {
                 String::new()
             };
-            let text = format!("Unstable{}{}", unstable_extra, Markdown(&reason));
+            let unstable_reason = if show_reason && !stab.unstable_reason.is_empty() {
+                format!(": {}", stab.unstable_reason)
+            } else {
+                String::new()
+            };
+            let text = format!("Unstable{}{}", unstable_extra, Markdown(&unstable_reason));
             stability.push(format!("<em class='stab unstable'>{}</em>", text))
         };
     } else if let Some(depr) = item.deprecation.as_ref() {

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -789,9 +789,6 @@ fn find_stability_generic<'a, I>(diagnostic: &Handler,
     // Merge the deprecation info into the stability info
     if let Some(rustc_depr) = rustc_depr {
         if let Some(ref mut stab) = stab {
-            if let Unstable {reason: ref mut reason @ None, ..} = stab.level {
-                *reason = Some(rustc_depr.reason.clone())
-            }
             stab.rustc_depr = Some(rustc_depr);
         } else {
             span_err!(diagnostic, item_sp, E0549,

--- a/src/test/rustdoc/issue-32374.rs
+++ b/src/test/rustdoc/issue-32374.rs
@@ -20,6 +20,16 @@
 //      'Deprecated since 1.0.0: text'
 // @has - '<code>test</code>'
 // @has - '<a href="http://issue_url/32374">#32374</a>'
+// @matches issue_32374/struct.T.html '//*[@class="stab unstable"]' \
+//      'Unstable \(test #32374\)$'
 #[rustc_deprecated(since = "1.0.0", reason = "text")]
 #[unstable(feature = "test", issue = "32374")]
 pub struct T;
+
+// @has issue_32374/struct.U.html '//*[@class="stab deprecated"]' \
+//      'Deprecated since 1.0.0: deprecated'
+// @has issue_32374/struct.U.html '//*[@class="stab unstable"]' \
+//      'Unstable (test #32374): unstable'
+#[rustc_deprecated(since = "1.0.0", reason = "deprecated")]
+#[unstable(feature = "test", issue = "32374", reason = "unstable")]
+pub struct U;


### PR DESCRIPTION
# Before

![2016-11-13-18 55 23](https://cloud.githubusercontent.com/assets/1372438/20249943/d7f684a2-a9d2-11e6-8c5a-a2bfe354b9aa.png)
![2016-11-13-18 55 12](https://cloud.githubusercontent.com/assets/1372438/20249942/d7f6595a-a9d2-11e6-9240-07f5a89367f4.png)

# After
![2016-11-13-18 54 00](https://cloud.githubusercontent.com/assets/1372438/20249946/da176d46-a9d2-11e6-8f34-c09cff9bcc15.png)
![2016-11-13-18 54 45](https://cloud.githubusercontent.com/assets/1372438/20249941/d7d9837a-a9d2-11e6-99f4-e4bf8807b1c9.png)