### PR TITLE
Add semicolon to "perhaps add a `use` for one of them" help

### DIFF
--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -308,7 +308,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
             let limit = if candidates.len() == 5 { 5 } else { 4 };
             for (i, trait_did) in candidates.iter().take(limit).enumerate() {
-                err.help(&format!("candidate #{}: `use {}`",
+                err.help(&format!("candidate #{}: `use {};`",
                                   i + 1,
                                   self.tcx.item_path_str(*trait_did)));
             }

--- a/src/test/compile-fail/no-method-suggested-traits.rs
+++ b/src/test/compile-fail/no-method-suggested-traits.rs
@@ -34,31 +34,31 @@ fn main() {
     1u32.method();
     //~^ HELP following traits are implemented but not in scope, perhaps add a `use` for one of them
     //~^^ ERROR no method named
-    //~^^^ HELP `use foo::Bar`
-    //~^^^^ HELP `use no_method_suggested_traits::foo::PubPub`
+    //~^^^ HELP `use foo::Bar;`
+    //~^^^^ HELP `use no_method_suggested_traits::foo::PubPub;`
     std::rc::Rc::new(&mut Box::new(&1u32)).method();
     //~^ HELP following traits are implemented but not in scope, perhaps add a `use` for one of them
     //~^^ ERROR no method named
-    //~^^^ HELP `use foo::Bar`
-    //~^^^^ HELP `use no_method_suggested_traits::foo::PubPub`
+    //~^^^ HELP `use foo::Bar;`
+    //~^^^^ HELP `use no_method_suggested_traits::foo::PubPub;`
 
     'a'.method();
     //~^ ERROR no method named
     //~^^ HELP the following trait is implemented but not in scope, perhaps add a `use` for it:
-    //~^^^ HELP `use foo::Bar`
+    //~^^^ HELP `use foo::Bar;`
     std::rc::Rc::new(&mut Box::new(&'a')).method();
     //~^ ERROR no method named
     //~^^ HELP the following trait is implemented but not in scope, perhaps add a `use` for it:
-    //~^^^ HELP `use foo::Bar`
+    //~^^^ HELP `use foo::Bar;`
 
     1i32.method();
     //~^ ERROR no method named
     //~^^ HELP the following trait is implemented but not in scope, perhaps add a `use` for it:
-    //~^^^ HELP `use no_method_suggested_traits::foo::PubPub`
+    //~^^^ HELP `use no_method_suggested_traits::foo::PubPub;`
     std::rc::Rc::new(&mut Box::new(&1i32)).method();
     //~^ ERROR no method named
     //~^^ HELP the following trait is implemented but not in scope, perhaps add a `use` for it:
-    //~^^^ HELP `use no_method_suggested_traits::foo::PubPub`
+    //~^^^ HELP `use no_method_suggested_traits::foo::PubPub;`
 
     Foo.method();
     //~^ ERROR no method named


### PR DESCRIPTION
Similar to pull request #37430, this makes the message more copy-paste
friendly and aligns it with other messages like:

    help: you can import it into scope: use foo::Bar;

r? @eddyb