### PR TITLE
rustdoc: add cli argument `--playground-url`

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -469,10 +469,8 @@ pub fn run(mut krate: clean::Crate,
                 clean::NameValue(ref x, ref s)
                         if "html_playground_url" == *x => {
                     markdown::PLAYGROUND.with(|slot| {
-                        if slot.borrow().is_none() {
-                            let name = krate.name.clone();
-                            *slot.borrow_mut() = Some((Some(name), s.clone()));
-                        }
+                        let name = krate.name.clone();
+                        *slot.borrow_mut() = Some((Some(name), s.clone()));
                     });
                 }
                 clean::NameValue(ref x, ref s)

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -162,6 +162,10 @@ pub fn opts() -> Vec<RustcOptGroup> {
         unstable(optmulti("Z", "",
                           "internal and debugging options (only on nightly build)", "FLAG")),
         stable(optopt("", "sysroot", "Override the system root", "PATH")),
+        stable(optopt("", "playground-url",
+                      "URL to send code snippets to, may be reset by --markdown-playground-url \
+                       or `#![doc(html_playground_url=...)]`",
+                      "URL")),
     ]
 }
 
@@ -229,6 +233,10 @@ pub fn main_args(args: &[String]) -> isize {
             return 1;
         }
     };
+
+    if let Some(playground) = matches.opt_str("playground-url") {
+        html::markdown::PLAYGROUND.with(|s| { *s.borrow_mut() = Some((None, playground)); });
+    }
 
     let test_args = matches.opt_strs("test-args");
     let test_args: Vec<String> = test_args.iter()


### PR DESCRIPTION
Add a new cli argument `--playground-url` for rustdoc:

`rustdoc lib.rs --playground-url "https://play.rust-lang.org/"`

`rustdoc book.md --playground-url "https://play.rust-lang.org/"`

This makes it possible for tools like https://docs.rs to generate crate docs that can submit samples code to run at https://play.rust-lang.org, even if the crate's author *forgot* putting `#![doc(html_playground_url = "https://play.rust-lang.org/")]` to crate root. By the way, I'd like to say, many crate authors are not aware of existing of `#![doc(html_playground_url = "https://play.rust-lang.org/")]`.

`--playground-url` may be reset by `--markdown-playground-url` or `#![doc(html_playground_url=...)]`, so it's backward compatible.

@alexcrichton since you implemented playground-url related features.