### PR TITLE
Remove `scope_auxiliary`.

### DIFF
--- a/src/librustc_mir/build/block.rs
+++ b/src/librustc_mir/build/block.rs
@@ -54,7 +54,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                         let tcx = this.hir.tcx();
 
                         // Enter the remainder scope, i.e. the bindings' destruction scope.
-                        this.push_scope(remainder_scope, block);
+                        this.push_scope(remainder_scope);
                         let_extent_stack.push(remainder_scope);
 
                         // Declare the bindings, which may create a visibility scope.

--- a/src/librustc_mir/build/cfg.rs
+++ b/src/librustc_mir/build/cfg.rs
@@ -40,11 +40,6 @@ impl<'tcx> CFG<'tcx> {
         self.block_data_mut(block).statements.push(statement);
     }
 
-    pub fn current_location(&mut self, block: BasicBlock) -> Location {
-        let index = self.block_data(block).statements.len();
-        Location { block: block, statement_index: index }
-    }
-
     pub fn push_assign(&mut self,
                        block: BasicBlock,
                        source_info: SourceInfo,

--- a/src/librustc_mir/mir_map.rs
+++ b/src/librustc_mir/mir_map.rs
@@ -103,11 +103,11 @@ impl<'a, 'gcx, 'tcx> BuildMir<'a, 'gcx> {
 
 impl<'a, 'gcx, 'tcx> CxBuilder<'a, 'gcx, 'tcx> {
     fn build<F>(&'tcx mut self, f: F)
-        where F: for<'b> FnOnce(Cx<'b, 'gcx, 'tcx>) -> (Mir<'tcx>, build::ScopeAuxiliaryVec)
+        where F: for<'b> FnOnce(Cx<'b, 'gcx, 'tcx>) -> Mir<'tcx>
     {
         let (src, def_id) = (self.src, self.def_id);
         self.infcx.enter(|infcx| {
-            let (mut mir, scope_auxiliary) = f(Cx::new(&infcx, src));
+            let mut mir = f(Cx::new(&infcx, src));
 
             // Convert the Mir to global types.
             let tcx = infcx.tcx.global_tcx();
@@ -120,7 +120,7 @@ impl<'a, 'gcx, 'tcx> CxBuilder<'a, 'gcx, 'tcx> {
                 mem::transmute::<Mir, Mir<'gcx>>(mir)
             };
 
-            pretty::dump_mir(tcx, "mir_map", &0, src, &mir, Some(&scope_auxiliary));
+            pretty::dump_mir(tcx, "mir_map", &0, src, &mir);
 
             let mir = tcx.alloc_mir(mir);
             assert!(tcx.mir_map.borrow_mut().insert(def_id, mir).is_none());

--- a/src/librustc_mir/pretty.rs
+++ b/src/librustc_mir/pretty.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use build::{ScopeAuxiliaryVec, ScopeId};
 use rustc::hir;
 use rustc::hir::def_id::DefId;
 use rustc::mir::*;
@@ -43,8 +42,7 @@ pub fn dump_mir<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                           pass_name: &str,
                           disambiguator: &Display,
                           src: MirSource,
-                          mir: &Mir<'tcx>,
-                          auxiliary: Option<&ScopeAuxiliaryVec>) {
+                          mir: &Mir<'tcx>) {
     let filters = match tcx.sess.opts.debugging_opts.dump_mir {
         None => return,
         Some(ref filters) => filters,
@@ -81,7 +79,7 @@ pub fn dump_mir<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         writeln!(file, "// pass_name = {}", pass_name)?;
         writeln!(file, "// disambiguator = {}", disambiguator)?;
         writeln!(file, "")?;
-        write_mir_fn(tcx, src, mir, &mut file, auxiliary)?;
+        write_mir_fn(tcx, src, mir, &mut file)?;
         Ok(())
     });
 }
@@ -106,52 +104,24 @@ pub fn write_mir_pretty<'a, 'b, 'tcx, I>(tcx: TyCtxt<'b, 'tcx, 'tcx>,
 
         let id = tcx.map.as_local_node_id(def_id).unwrap();
         let src = MirSource::from_node(tcx, id);
-        write_mir_fn(tcx, src, mir, w, None)?;
+        write_mir_fn(tcx, src, mir, w)?;
 
         for (i, mir) in mir.promoted.iter_enumerated() {
             writeln!(w, "")?;
-            write_mir_fn(tcx, MirSource::Promoted(id, i), mir, w, None)?;
+            write_mir_fn(tcx, MirSource::Promoted(id, i), mir, w)?;
         }
     }
     Ok(())
 }
 
-enum Annotation {
-    EnterScope(ScopeId),
-    ExitScope(ScopeId),
-}
-
-fn scope_entry_exit_annotations(auxiliary: Option<&ScopeAuxiliaryVec>)
-                                -> FxHashMap<Location, Vec<Annotation>>
-{
-    // compute scope/entry exit annotations
-    let mut annotations = FxHashMap();
-    if let Some(auxiliary) = auxiliary {
-        for (scope_id, auxiliary) in auxiliary.iter_enumerated() {
-            annotations.entry(auxiliary.dom)
-                       .or_insert(vec![])
-                       .push(Annotation::EnterScope(scope_id));
-
-            for &loc in &auxiliary.postdoms {
-                annotations.entry(loc)
-                           .or_insert(vec![])
-                           .push(Annotation::ExitScope(scope_id));
-            }
-        }
-    }
-    return annotations;
-}
-
 pub fn write_mir_fn<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                               src: MirSource,
                               mir: &Mir<'tcx>,
-                              w: &mut Write,
-                              auxiliary: Option<&ScopeAuxiliaryVec>)
+                              w: &mut Write)
                               -> io::Result<()> {
-    let annotations = scope_entry_exit_annotations(auxiliary);
     write_mir_intro(tcx, src, mir, w)?;
     for block in mir.basic_blocks().indices() {
-        write_basic_block(tcx, block, mir, w, &annotations)?;
+        write_basic_block(tcx, block, mir, w)?;
         if block.index() + 1 != mir.basic_blocks().len() {
             writeln!(w, "")?;
         }
@@ -165,8 +135,7 @@ pub fn write_mir_fn<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 fn write_basic_block(tcx: TyCtxt,
                      block: BasicBlock,
                      mir: &Mir,
-                     w: &mut Write,
-                     annotations: &FxHashMap<Location, Vec<Annotation>>)
+                     w: &mut Write)
                      -> io::Result<()> {
     let data = &mir[block];
 
@@ -176,19 +145,6 @@ fn write_basic_block(tcx: TyCtxt,
     // List of statements in the middle.
     let mut current_location = Location { block: block, statement_index: 0 };
     for statement in &data.statements {
-        if let Some(ref annotations) = annotations.get(&current_location) {
-            for annotation in annotations.iter() {
-                match *annotation {
-                    Annotation::EnterScope(id) =>
-                        writeln!(w, "{0}{0}// Enter Scope({1})",
-                                 INDENT, id.index())?,
-                    Annotation::ExitScope(id) =>
-                        writeln!(w, "{0}{0}// Exit Scope({1})",
-                                 INDENT, id.index())?,
-                }
-            }
-        }
-
         let indented_mir = format!("{0}{0}{1:?};", INDENT, statement);
         writeln!(w, "{0:1$} // {2}",
                  indented_mir,

--- a/src/librustc_mir/transform/dump_mir.rs
+++ b/src/librustc_mir/transform/dump_mir.rs
@@ -64,8 +64,7 @@ impl<'tcx> MirPassHook<'tcx> for DumpMir {
                 is_after: is_after
             },
             src,
-            mir,
-            None
+            mir
         );
     }
 }


### PR DESCRIPTION
`scope_auxiliary` is a big part of the high memory usage in #36799. It's only used for MIR dumping. I have taken a hubristic approach: I have assumed that particular use is unimportant and removed `scope_auxiliary` and related things. This reduces peak RSS by ~10% for a cut-down version of the program in #36799.

If that assumption is wrong perhaps we can avoid building `scope_auxiliary` unless MIR dumping is enabled.
