### PR TITLE
rustbuild: Allow configuration of python interpreter

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -130,9 +130,7 @@ pub fn compiletest(build: &Build,
                              build.test_helpers_out(target).display()));
     cmd.arg("--target-rustcflags").arg(targetflags.join(" "));
 
-    // FIXME: CFG_PYTHON should probably be detected more robustly elsewhere
-    let python_default = "python";
-    cmd.arg("--docck-python").arg(python_default);
+    cmd.arg("--docck-python").arg(build.python());
 
     if build.config.build.ends_with("apple-darwin") {
         // Force /usr/bin/python on OSX for LLDB tests because we're loading the
@@ -140,7 +138,7 @@ pub fn compiletest(build: &Build,
         // (namely not Homebrew-installed python)
         cmd.arg("--lldb-python").arg("/usr/bin/python");
     } else {
-        cmd.arg("--lldb-python").arg(python_default);
+        cmd.arg("--lldb-python").arg(build.python());
     }
 
     if let Some(ref gdb) = build.config.gdb {

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -90,6 +90,7 @@ pub struct Config {
     pub codegen_tests: bool,
     pub nodejs: Option<PathBuf>,
     pub gdb: Option<PathBuf>,
+    pub python: Option<PathBuf>,
 }
 
 /// Per-target configuration stored in the global configuration structure.
@@ -130,6 +131,7 @@ struct Build {
     gdb: Option<String>,
     vendor: Option<bool>,
     nodejs: Option<String>,
+    python: Option<String>,
 }
 
 /// TOML representation of how the LLVM build is configured.
@@ -237,6 +239,7 @@ impl Config {
         config.cargo = build.cargo.map(PathBuf::from);
         config.nodejs = build.nodejs.map(PathBuf::from);
         config.gdb = build.gdb.map(PathBuf::from);
+        config.python = build.python.map(PathBuf::from);
         set(&mut config.compiler_docs, build.compiler_docs);
         set(&mut config.docs, build.docs);
         set(&mut config.submodules, build.submodules);
@@ -464,6 +467,10 @@ impl Config {
                     let path = parse_configure_path(value);
                     self.rustc = Some(push_exe_path(path.clone(), &["bin", "rustc"]));
                     self.cargo = Some(push_exe_path(path, &["bin", "cargo"]));
+                }
+                "CFG_PYTHON" if value.len() > 0 => {
+                    let path = parse_configure_path(value);
+                    self.python = Some(path);
                 }
                 _ => {}
             }

--- a/src/bootstrap/config.toml.example
+++ b/src/bootstrap/config.toml.example
@@ -82,8 +82,18 @@
 # Indicate whether submodules are managed and updated automatically.
 #submodules = true
 
-# The path to (or name of) the GDB executable to use
+# The path to (or name of) the GDB executable to use. This is only used for
+# executing the debuginfo test suite.
 #gdb = "gdb"
+
+# The node.js executable to use. Note that this is only used for the emscripten
+# target when running tests, otherwise this can be omitted.
+#nodejs = "node"
+
+# Python interpreter to use for various tasks throughout the build, notably
+# rustdoc tests, the lldb python interpreter, and some dist bits and pieces.
+# Note that Python 2 is currently required.
+#python = "python2.7"
 
 # Indicate whether the vendored sources are used for Rust dependencies or not
 #vendor = false

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -99,7 +99,7 @@ pub fn mingw(build: &Build, host: &str) {
     // (which is what we want).
     //
     // FIXME: this script should be rewritten into Rust
-    let mut cmd = Command::new("python");
+    let mut cmd = Command::new(build.python());
     cmd.arg(build.src.join("src/etc/make-win-dist.py"))
        .arg(tmpdir(build))
        .arg(&image)
@@ -159,7 +159,7 @@ pub fn rustc(build: &Build, stage: u32, host: &str) {
     //
     // FIXME: this script should be rewritten into Rust
     if host.contains("pc-windows-gnu") {
-        let mut cmd = Command::new("python");
+        let mut cmd = Command::new(build.python());
         cmd.arg(build.src.join("src/etc/make-win-dist.py"))
            .arg(&image)
            .arg(tmpdir(build))

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -774,6 +774,11 @@ impl Build {
             .or(self.config.musl_root.as_ref())
             .map(|p| &**p)
     }
+
+    /// Path to the python interpreter to use
+    fn python(&self) -> &Path {
+        self.config.python.as_ref().unwrap()
+    }
 }
 
 impl<'a> Compiler<'a> {

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -79,7 +79,17 @@ pub fn check(build: &mut Build) {
         break
     }
 
-    need_cmd("python".as_ref());
+    if build.config.python.is_none() {
+        build.config.python = have_cmd("python2.7".as_ref());
+    }
+    if build.config.python.is_none() {
+        build.config.python = have_cmd("python2".as_ref());
+    }
+    if build.config.python.is_none() {
+        need_cmd("python".as_ref());
+        build.config.python = Some("python".into());
+    }
+    need_cmd(build.config.python.as_ref().unwrap().as_ref());
 
 
     if let Some(ref s) = build.config.nodejs {


### PR DESCRIPTION
Add a configuration key to `config.toml`, read it from `./configure`, and add
auto-detection if none of those were specified.

Closes #35760