### PR TITLE
rustdoc: Fix some local inlining issues

### DIFF
--- a/src/test/rustdoc/inline_local/glob-extern-no-defaults.rs
+++ b/src/test/rustdoc/inline_local/glob-extern-no-defaults.rs
@@ -1,0 +1,35 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --no-defaults
+
+#![crate_name = "foo"]
+
+mod mod1 {
+    extern {
+        pub fn public_fn();
+        fn private_fn();
+    }
+}
+
+pub use mod1::*;
+
+// @has foo/index.html
+// @has - "mod1"
+// @has - "public_fn"
+// @!has - "private_fn"
+// @has foo/fn.public_fn.html
+// @!has foo/fn.private_fn.html
+
+// @has foo/mod1/index.html
+// @has - "public_fn"
+// @has - "private_fn"
+// @has foo/mod1/fn.public_fn.html
+// @has foo/mod1/fn.private_fn.html

--- a/src/test/rustdoc/inline_local/glob-extern.rs
+++ b/src/test/rustdoc/inline_local/glob-extern.rs
@@ -1,0 +1,31 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "foo"]
+
+mod mod1 {
+    extern {
+        pub fn public_fn();
+        fn private_fn();
+    }
+}
+
+pub use mod1::*;
+
+// @has foo/index.html
+// @!has - "mod1"
+// @has - "public_fn"
+// @!has - "private_fn"
+// @has foo/fn.public_fn.html
+// @!has foo/fn.private_fn.html
+
+// @!has foo/mod1/index.html
+// @has foo/mod1/fn.public_fn.html
+// @!has foo/mod1/fn.private_fn.html

--- a/src/test/rustdoc/inline_local/glob-private-no-defaults.rs
+++ b/src/test/rustdoc/inline_local/glob-private-no-defaults.rs
@@ -1,0 +1,58 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --no-defaults
+
+#![crate_name = "foo"]
+
+mod mod1 {
+    mod mod2 {
+        pub struct Mod2Public;
+        struct Mod2Private;
+    }
+    pub use self::mod2::*;
+
+    pub struct Mod1Public;
+    struct Mod1Private;
+}
+pub use mod1::*;
+
+// @has foo/index.html
+// @has - "mod1"
+// @has - "Mod1Public"
+// @!has - "Mod1Private"
+// @!has - "mod2"
+// @has - "Mod2Public"
+// @!has - "Mod2Private"
+// @has foo/struct.Mod1Public.html
+// @!has foo/struct.Mod1Private.html
+// @has foo/struct.Mod2Public.html
+// @!has foo/struct.Mod2Private.html
+
+// @has foo/mod1/index.html
+// @has - "mod2"
+// @has - "Mod1Public"
+// @has - "Mod1Private"
+// @!has - "Mod2Public"
+// @!has - "Mod2Private"
+// @has foo/mod1/struct.Mod1Public.html
+// @has foo/mod1/struct.Mod1Private.html
+// @!has foo/mod1/struct.Mod2Public.html
+// @!has foo/mod1/struct.Mod2Private.html
+
+// @has foo/mod1/mod2/index.html
+// @has - "Mod2Public"
+// @has - "Mod2Private"
+// @has foo/mod1/mod2/struct.Mod2Public.html
+// @has foo/mod1/mod2/struct.Mod2Private.html
+
+// @!has foo/mod2/index.html
+// @!has foo/mod2/struct.Mod2Public.html
+// @!has foo/mod2/struct.Mod2Private.html

--- a/src/test/rustdoc/inline_local/glob-private.rs
+++ b/src/test/rustdoc/inline_local/glob-private.rs
@@ -1,0 +1,49 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "foo"]
+
+mod mod1 {
+    mod mod2 {
+        pub struct Mod2Public;
+        struct Mod2Private;
+    }
+    pub use self::mod2::*;
+
+    pub struct Mod1Public;
+    struct Mod1Private;
+}
+pub use mod1::*;
+
+// @has foo/index.html
+// @!has - "mod1"
+// @has - "Mod1Public"
+// @!has - "Mod1Private"
+// @!has - "mod2"
+// @has - "Mod2Public"
+// @!has - "Mod2Private"
+// @has foo/struct.Mod1Public.html
+// @!has foo/struct.Mod1Private.html
+// @has foo/struct.Mod2Public.html
+// @!has foo/struct.Mod2Private.html
+
+// @!has foo/mod1/index.html
+// @has foo/mod1/struct.Mod1Public.html
+// @!has foo/mod1/struct.Mod1Private.html
+// @!has foo/mod1/struct.Mod2Public.html
+// @!has foo/mod1/struct.Mod2Private.html
+
+// @!has foo/mod1/mod2/index.html
+// @has foo/mod1/mod2/struct.Mod2Public.html
+// @!has foo/mod1/mod2/struct.Mod2Private.html
+
+// @!has foo/mod2/index.html
+// @!has foo/mod2/struct.Mod2Public.html
+// @!has foo/mod2/struct.Mod2Private.html


### PR DESCRIPTION
* Only inline public items when inlining glob imports.
* Never inline while in a private module or a child of a private module.
* Never inline impls. This allowed the removal of a workaround in the
rendering code.