### PR TITLE
rustbuild: Tweak default rule inclusion

### DIFF
--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -565,7 +565,8 @@ impl<'a> Rules<'a> {
             for dep in rule.deps.iter() {
                 let dep = dep(&self.sbuild.name(rule.name));
                 if self.rules.contains_key(&dep.name) || dep.name.starts_with("default:") {
-                    continue }
+                    continue
+                }
                 panic!("\
 
 invalid rule dependency graph detected, was a rule added and maybe typo'd?
@@ -686,8 +687,9 @@ invalid rule dependency graph detected, was a rule added and maybe typo'd?
                     "dist" => Kind::Dist,
                     kind => panic!("unknown kind: `{}`", kind),
                 };
+                let host = self.build.config.host.iter().any(|h| h == dep.target);
                 let rules = self.rules.values().filter(|r| r.default);
-                for rule in rules.filter(|r| r.kind == kind) {
+                for rule in rules.filter(|r| r.kind == kind && (!r.host || host)) {
                     self.fill(dep.name(rule.name), order, added);
                 }
             } else {


### PR DESCRIPTION
If a rule is flagged with `default(true)` then the pseudo-rule `default:foo`
will include that. If a rule is also flagged with `.host(true)`, however, then
the rule shouldn't be included for targets that aren't in the host array. This
adds a filter to ensure we don't pull in host rules for targets by accident.