### PR TITLE
limit the length of types in monomorphization

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -100,6 +100,9 @@ pub struct Session {
     /// operations such as auto-dereference and monomorphization.
     pub recursion_limit: Cell<usize>,
 
+    /// The maximum length of types during monomorphization.
+    pub type_length_limit: Cell<usize>,
+
     /// The metadata::creader module may inject an allocator/panic_runtime
     /// dependency if it didn't already find one, and this tracks what was
     /// injected.
@@ -620,6 +623,7 @@ pub fn build_session_(sopts: config::Options,
         crate_disambiguator: RefCell::new(Symbol::intern("")),
         features: RefCell::new(feature_gate::Features::new()),
         recursion_limit: Cell::new(64),
+        type_length_limit: Cell::new(1048576),
         next_node_id: Cell::new(NodeId::new(1)),
         injected_allocator: Cell::new(None),
         injected_panic_runtime: Cell::new(None),

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -566,7 +566,7 @@ pub fn phase_2_configure_and_expand<F>(sess: &Session,
     *sess.crate_disambiguator.borrow_mut() = Symbol::intern(&compute_crate_disambiguator(sess));
 
     time(time_passes, "recursion limit", || {
-        middle::recursion_limit::update_recursion_limit(sess, &krate);
+        middle::recursion_limit::update_limits(sess, &krate);
     });
 
     krate = time(time_passes, "crate injection", || {

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -738,6 +738,7 @@ pub const BUILTIN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeG
     ("no_main", CrateLevel, Ungated),
     ("no_builtins", CrateLevel, Ungated),
     ("recursion_limit", CrateLevel, Ungated),
+    ("type_length_limit", CrateLevel, Ungated),
 ];
 
 // cfg(...)'s that are feature gated

--- a/src/test/compile-fail/issue-22638.rs
+++ b/src/test/compile-fail/issue-22638.rs
@@ -10,7 +10,8 @@
 
 #![allow(unused)]
 
-#![recursion_limit = "32"]
+#![recursion_limit = "20"]
+#![type_length_limit = "20000000"]
 
 #[derive(Clone)]
 struct A (B);

--- a/src/test/compile-fail/type_length_limit.rs
+++ b/src/test/compile-fail/type_length_limit.rs
@@ -1,0 +1,35 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: reached the type-length limit while instantiating
+
+// Test that the type length limit can be changed.
+
+#![allow(dead_code)]
+#![type_length_limit="256"]
+
+macro_rules! link {
+    ($id:ident, $t:ty) => {
+        pub type $id = ($t, $t, $t);
+    }
+}
+
+link! { A, B }
+link! { B, C }
+link! { C, D }
+link! { D, E }
+link! { E, F }
+link! { F, G }
+
+pub struct G;
+
+fn main() {
+    drop::<Option<A>>(None);
+}

--- a/src/test/ui/issue-37311-type-length-limit/issue-37311.rs
+++ b/src/test/ui/issue-37311-type-length-limit/issue-37311.rs
@@ -1,0 +1,30 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Mirror {
+    type Image;
+}
+
+impl<T> Mirror for T { type Image = T; }
+
+trait Foo {
+    fn recurse(&self);
+}
+
+impl<T> Foo for T {
+    #[allow(unconditional_recursion)]
+    fn recurse(&self) {
+        (self, self).recurse();
+    }
+}
+
+fn main() {
+    ().recurse();
+}

--- a/src/test/ui/issue-37311-type-length-limit/issue-37311.stderr
+++ b/src/test/ui/issue-37311-type-length-limit/issue-37311.stderr
@@ -1,0 +1,13 @@
+error: reached the type-length limit while instantiating `<T as Foo><(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(&(), &()), &(&()...`
+  --> $DIR/issue-37311.rs:23:5
+   |
+23 |       fn recurse(&self) {
+   |  _____^ starting here...
+24 | |         (self, self).recurse();
+25 | |     }
+   | |_____^ ...ending here
+   |
+   = note: consider adding a `#![type_length_limit="2097152"]` attribute to your crate
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This adds the new insta-stable `#![type_size_limit]` crate attribute to control
the limit, and is obviously a [breaking-change] fixable by that.

Fixes #37311.

r? @nikomatsakis