### PR TITLE
Support `?Sized` in where clauses

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -46,6 +46,7 @@ use hir::map::definitions::DefPathData;
 use hir::def_id::{DefIndex, DefId};
 use hir::def::{Def, PathResolution};
 use session::Session;
+use util::nodemap::NodeMap;
 
 use std::collections::BTreeMap;
 use std::iter;
@@ -394,7 +395,7 @@ impl<'a> LoweringContext<'a> {
         }
     }
 
-    fn lower_ty_param(&mut self, tp: &TyParam) -> hir::TyParam {
+    fn lower_ty_param(&mut self, tp: &TyParam, add_bounds: &[TyParamBound]) -> hir::TyParam {
         let mut name = tp.ident.name;
 
         // Don't expose `Self` (recovered "keyword used as ident" parse error).
@@ -404,18 +405,26 @@ impl<'a> LoweringContext<'a> {
             name = Symbol::gensym("Self");
         }
 
+        let mut bounds = self.lower_bounds(&tp.bounds);
+        if !add_bounds.is_empty() {
+            bounds = bounds.into_iter().chain(self.lower_bounds(add_bounds).into_iter()).collect();
+        }
+
         hir::TyParam {
             id: tp.id,
             name: name,
-            bounds: self.lower_bounds(&tp.bounds),
+            bounds: bounds,
             default: tp.default.as_ref().map(|x| self.lower_ty(x)),
             span: tp.span,
             pure_wrt_drop: tp.attrs.iter().any(|attr| attr.check_name("may_dangle")),
         }
     }
 
-    fn lower_ty_params(&mut self, tps: &P<[TyParam]>) -> hir::HirVec<hir::TyParam> {
-        tps.iter().map(|tp| self.lower_ty_param(tp)).collect()
+    fn lower_ty_params(&mut self, tps: &P<[TyParam]>, add_bounds: &NodeMap<Vec<TyParamBound>>)
+                       -> hir::HirVec<hir::TyParam> {
+        tps.iter().map(|tp| {
+            self.lower_ty_param(tp, add_bounds.get(&tp.id).map_or(&[][..], |x| &x))
+        }).collect()
     }
 
     fn lower_lifetime(&mut self, l: &Lifetime) -> hir::Lifetime {
@@ -447,8 +456,47 @@ impl<'a> LoweringContext<'a> {
     }
 
     fn lower_generics(&mut self, g: &Generics) -> hir::Generics {
+        // Collect `?Trait` bounds in where clause and move them to parameter definitions.
+        let mut add_bounds = NodeMap();
+        for pred in &g.where_clause.predicates {
+            if let WherePredicate::BoundPredicate(ref bound_pred) = *pred {
+                'next_bound: for bound in &bound_pred.bounds {
+                    if let TraitTyParamBound(_, TraitBoundModifier::Maybe) = *bound {
+                        let report_error = |this: &mut Self| {
+                            this.diagnostic().span_err(bound_pred.bounded_ty.span,
+                                                       "`?Trait` bounds are only permitted at the \
+                                                        point where a type parameter is declared");
+                        };
+                        // Check if the where clause type is a plain type parameter.
+                        match bound_pred.bounded_ty.node {
+                            TyKind::Path(None, ref path)
+                                    if !path.global && path.segments.len() == 1 &&
+                                        bound_pred.bound_lifetimes.is_empty() => {
+                                if let Some(Def::TyParam(def_id)) =
+                                        self.resolver.get_resolution(bound_pred.bounded_ty.id)
+                                                     .map(|d| d.base_def) {
+                                    if let Some(node_id) =
+                                            self.resolver.definitions().as_local_node_id(def_id) {
+                                        for ty_param in &g.ty_params {
+                                            if node_id == ty_param.id {
+                                                add_bounds.entry(ty_param.id).or_insert(Vec::new())
+                                                                            .push(bound.clone());
+                                                continue 'next_bound;
+                                            }
+                                        }
+                                    }
+                                }
+                                report_error(self)
+                            }
+                            _ => report_error(self)
+                        }
+                    }
+                }
+            }
+        }
+
         hir::Generics {
-            ty_params: self.lower_ty_params(&g.ty_params),
+            ty_params: self.lower_ty_params(&g.ty_params, &add_bounds),
             lifetimes: self.lower_lifetime_defs(&g.lifetimes),
             where_clause: self.lower_where_clause(&g.where_clause),
             span: g.span,
@@ -474,7 +522,11 @@ impl<'a> LoweringContext<'a> {
                 hir::WherePredicate::BoundPredicate(hir::WhereBoundPredicate {
                     bound_lifetimes: self.lower_lifetime_defs(bound_lifetimes),
                     bounded_ty: self.lower_ty(bounded_ty),
-                    bounds: bounds.iter().map(|x| self.lower_ty_param_bound(x)).collect(),
+                    bounds: bounds.iter().filter_map(|bound| match *bound {
+                        // Ignore `?Trait` bounds, they were copied into type parameters already.
+                        TraitTyParamBound(_, TraitBoundModifier::Maybe) => None,
+                        _ => Some(self.lower_ty_param_bound(bound))
+                    }).collect(),
                     span: span,
                 })
             }
@@ -563,7 +615,7 @@ impl<'a> LoweringContext<'a> {
         }
     }
 
-    fn lower_bounds(&mut self, bounds: &TyParamBounds) -> hir::TyParamBounds {
+    fn lower_bounds(&mut self, bounds: &[TyParamBound]) -> hir::TyParamBounds {
         bounds.iter().map(|bound| self.lower_ty_param_bound(bound)).collect()
     }
 

--- a/src/test/compile-fail/maybe-bounds-where-cpass.rs
+++ b/src/test/compile-fail/maybe-bounds-where-cpass.rs
@@ -1,0 +1,19 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_attrs)]
+
+struct S<T>(*const T) where T: ?Sized;
+
+#[rustc_error]
+fn main() { //~ ERROR compilation successful
+    let u = vec![1, 2, 3];
+    let _s: S<[u8]> = S(&u[..]);
+}

--- a/src/test/compile-fail/maybe-bounds-where.rs
+++ b/src/test/compile-fail/maybe-bounds-where.rs
@@ -1,0 +1,37 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct S1<T>(T) where (T): ?Sized;
+//~^ ERROR `?Trait` bounds are only permitted at the point where a type parameter is declared
+
+struct S2<T>(T) where u8: ?Sized;
+//~^ ERROR `?Trait` bounds are only permitted at the point where a type parameter is declared
+
+struct S3<T>(T) where &'static T: ?Sized;
+//~^ ERROR `?Trait` bounds are only permitted at the point where a type parameter is declared
+
+trait Trait<'a> {}
+
+struct S4<T>(T) where for<'a> T: ?Trait<'a>;
+//~^ ERROR `?Trait` bounds are only permitted at the point where a type parameter is declared
+
+struct S5<T>(*const T) where T: ?Trait<'static> + ?Sized;
+//~^ ERROR type parameter has more than one relaxed default bound
+//~| WARN default bound relaxed for a type parameter
+
+impl<T> S1<T> {
+    fn f() where T: ?Sized {}
+    //~^ ERROR `?Trait` bounds are only permitted at the point where a type parameter is declared
+}
+
+fn main() {
+    let u = vec![1, 2, 3];
+    let _s: S5<[u8]> = S5(&u[..]); // OK
+}

--- a/src/test/compile-fail/maybe-bounds.rs
+++ b/src/test/compile-fail/maybe-bounds.rs
@@ -1,0 +1,17 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Tr: ?Sized {} //~ ERROR `?Trait` is not permitted in supertraits
+                    //~^ NOTE traits are `?Sized` by default
+
+type A1 = Tr + ?Sized; //~ ERROR `?Trait` is not permitted in trait object types
+type A2 = for<'a> Tr + ?Sized; //~ ERROR `?Trait` is not permitted in trait object types
+
+fn main() {}


### PR DESCRIPTION
Implemented as described in https://github.com/rust-lang/rust/issues/20503#issuecomment-258677026 - `?Trait` bounds are moved on type parameter definitions when possible, reported as errors otherwise.
(It'd be nice to unify bounds and where clauses in HIR, but this is mostly blocked by rustdoc now - it needs to render bounds in pleasant way and the best way to do it so far is to mirror what was written in source code.)

Fixes https://github.com/rust-lang/rust/issues/20503
r? @nikomatsakis 