### PR TITLE
Fix proc macro def ids

### DIFF
--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -356,7 +356,7 @@ impl<'tcx> CrateStore<'tcx> for cstore::CStore {
     fn load_macro(&self, id: DefId, sess: &Session) -> LoadedMacro {
         let data = self.get_crate_data(id.krate);
         if let Some(ref proc_macros) = data.proc_macros {
-            return LoadedMacro::ProcMacro(proc_macros[id.index.as_usize()].1.clone());
+            return LoadedMacro::ProcMacro(proc_macros[id.index.as_usize() - 1].1.clone());
         }
 
         let (name, def) = data.get_macro(id.index);

--- a/src/test/compile-fail-fulldeps/proc-macro/auxiliary/derive-a-b.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/auxiliary/derive-a-b.rs
@@ -1,0 +1,28 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// force-host
+// no-prefer-dynamic
+
+#![feature(proc_macro, proc_macro_lib)]
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[proc_macro_derive(A)]
+pub fn derive_a(_: TokenStream) -> TokenStream {
+    "".parse().unwrap()
+}
+
+#[proc_macro_derive(B)]
+pub fn derive_b(_: TokenStream) -> TokenStream {
+    "".parse().unwrap()
+}

--- a/src/test/compile-fail-fulldeps/proc-macro/issue-37788.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/issue-37788.rs
@@ -1,0 +1,21 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:derive-a-b.rs
+
+#![feature(proc_macro)]
+
+#[macro_use]
+extern crate derive_a_b;
+
+fn main() {
+    // Test that constructing the `visible_parent_map` (in `cstore_impl.rs`) does not ICE.
+    std::cell::Cell::new(0) //~ ERROR mismatched types
+}


### PR DESCRIPTION
Update some `CStore` methods to also work correctly with proc macro def ids.
Fixes #37788.
r? @nrc 