### PR TITLE
instantiate closures on demand

### DIFF
--- a/src/librustc_trans/common.rs
+++ b/src/librustc_trans/common.rs
@@ -18,6 +18,7 @@ use llvm::{ValueRef, BasicBlockRef, BuilderRef, ContextRef, TypeKind};
 use llvm::{True, False, Bool, OperandBundleDef};
 use rustc::hir::def::Def;
 use rustc::hir::def_id::DefId;
+use rustc::hir::map::DefPathData;
 use rustc::infer::TransNormalize;
 use rustc::mir::Mir;
 use rustc::util::common::MemoizationMap;
@@ -1099,4 +1100,8 @@ pub fn ty_fn_ty<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
         }
         _ => bug!("unexpected type {:?} to ty_fn_sig", ty)
     }
+}
+
+pub fn is_closure(tcx: TyCtxt, def_id: DefId) -> bool {
+    tcx.def_key(def_id).disambiguated_data.data == DefPathData::ClosureExpr
 }

--- a/src/librustc_trans/trans_item.rs
+++ b/src/librustc_trans/trans_item.rs
@@ -18,6 +18,7 @@ use attributes;
 use base;
 use consts;
 use context::{CrateContext, SharedCrateContext};
+use common;
 use declare;
 use glue::DropGlueKind;
 use llvm;
@@ -245,6 +246,7 @@ impl<'a, 'tcx> TransItem<'tcx> {
             TransItem::Fn(ref instance) => {
                 !instance.def.is_local() ||
                 instance.substs.types().next().is_some() ||
+                common::is_closure(tcx, instance.def) ||
                 attr::requests_inline(&tcx.get_attrs(instance.def)[..])
             }
             TransItem::DropGlue(..) => true,


### PR DESCRIPTION
this should fix compilation with `-C codegen-units=4` - tested locally
with `RUSTFLAGS='-C codegen-units=4' ../x.py test`

r? @michaelwoerister 