### PR TITLE
fix `extern "aapcs" fn`

### DIFF
--- a/src/librustc_llvm/ffi.rs
+++ b/src/librustc_llvm/ffi.rs
@@ -41,6 +41,7 @@ pub enum CallConv {
     ColdCallConv = 9,
     X86StdcallCallConv = 64,
     X86FastcallCallConv = 65,
+    ArmAapcsCallConv = 67,
     X86_64_SysV = 78,
     X86_64_Win64 = 79,
     X86_VectorCall = 80,

--- a/src/librustc_trans/abi.rs
+++ b/src/librustc_trans/abi.rs
@@ -274,10 +274,10 @@ impl FnType {
             C => llvm::CCallConv,
             Win64 => llvm::X86_64_Win64,
             SysV64 => llvm::X86_64_SysV,
+            Aapcs => llvm::ArmAapcsCallConv,
 
             // These API constants ought to be more specific...
             Cdecl => llvm::CCallConv,
-            Aapcs => llvm::CCallConv,
         };
 
         let mut inputs = &sig.inputs[..];


### PR DESCRIPTION
to actually use the AAPCS calling convention

closes #37810

This is technically a [breaking-change] because it changes the ABI of
`extern "aapcs"` functions that (a) involve `f32`/`f64` arguments/return
values and (b) are compiled for arm-eabihf targets from
"aapcs-vfp" (wrong) to "aapcs" (correct).

Appendix:

What these ABIs mean?

- In the "aapcs-vfp" ABI or "hard float" calling convention: Floating
point values are passed/returned through FPU registers (s0, s1, d0, etc.)

- Whereas, in the "aapcs" ABI or "soft float" calling convention:
Floating point values are passed/returned through general purpose
registers (r0, r1, etc.)

Mixing these ABIs can cause problems if the caller assumes that the
routine is using one of these ABIs but it's actually using the other
one.

---

r? @alexcrichton We are going this `extern "aapcs" fn` thing to implement some intrinsics (floatundidf) for the eabihf targets in order to comply with LLVM's calling convention of intrinsics.

Oh, and the value of the enum came from [here](http://llvm.org/docs/doxygen/html/namespacellvm_1_1CallingConv.html).

cc @TimNN @parched 