### PR TITLE
mk: Switch rustbuild to the default build system 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: rust
+language: minimal
 sudo: required
 dist: trusty
 services:
@@ -20,7 +20,7 @@ matrix:
     - env: IMAGE=x86_64-gnu-cargotest
     - env: IMAGE=x86_64-gnu-debug
     - env: IMAGE=x86_64-gnu-nopt
-    - env: IMAGE=x86_64-gnu-rustbuild
+    - env: IMAGE=x86_64-gnu-make
     - env: IMAGE=x86_64-gnu-llvm-3.7 ALLOW_PR=1 RUST_BACKTRACE=1
     - env: IMAGE=x86_64-musl
 
@@ -39,7 +39,7 @@ matrix:
       install: brew install ccache
     - env: >
         RUST_CHECK_TARGET=check
-        RUST_CONFIGURE_ARGS=--target=x86_64-apple-darwin --enable-rustbuild
+        RUST_CONFIGURE_ARGS=--target=x86_64-apple-darwin --disable-rustbuild
         SRC=.
       os: osx
       install: brew install ccache
@@ -51,17 +51,16 @@ matrix:
       install: brew install ccache
 
 script:
-  - if [ -z "$ALLOW_PR" ] && [ "$TRAVIS_BRANCH" != "auto" ]; then
-        echo skipping, not a full build;
-    elif [ -z "$ENABLE_AUTO" ] then
-        echo skipping, not quite ready yet
-    elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
-        git submodule update --init;
-        src/ci/run.sh;
-    else
-        git submodule update --init;
-        src/ci/docker/run.sh $IMAGE;
-    fi
+  - >
+      if [ "$ALLOW_PR" = "" ] && [ "$TRAVIS_BRANCH" != "auto" ]; then
+          echo skipping, not a full build;
+      elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
+          git submodule update --init;
+          src/ci/run.sh;
+      else
+          git submodule update --init;
+          src/ci/docker/run.sh $IMAGE;
+      fi
 
 # Save tagged docker images we created and load them if they're available
 before_cache:

--- a/README.md
+++ b/README.md
@@ -36,16 +36,14 @@ Read ["Installing Rust"] from [The Book].
 
     ```sh
     $ ./configure
-    $ make && make install
+    $ make && sudo make install
     ```
 
-    > ***Note:*** You may need to use `sudo make install` if you do not
-    > normally have permission to modify the destination directory. The
-    > install locations can be adjusted by passing a `--prefix` argument
-    > to `configure`. Various other options are also supported – pass
+    > ***Note:*** Install locations can be adjusted by passing a `--prefix`
+    > argument to `configure`. Various other options are also supported – pass
     > `--help` for more information on them.
 
-    When complete, `make install` will place several programs into
+    When complete, `sudo make install` will place several programs into
     `/usr/local/bin`: `rustc`, the Rust compiler, and `rustdoc`, the
     API-documentation tool. This install does not include [Cargo],
     Rust's package manager, which you may also want to build.
@@ -108,30 +106,22 @@ MSVC builds of Rust additionally require an installation of Visual Studio 2013
 (or later) so `rustc` can use its linker. Make sure to check the “C++ tools”
 option.
 
-With these dependencies installed, the build takes two steps:
+With these dependencies installed, you can build the compiler in a `cmd.exe`
+shell with:
 
 ```sh
-$ ./configure
+> python x.py build
+```
+
+If you're running inside of an msys shell, however, you can run:
+
+```sh
+$ ./configure --build=x86_64-pc-windows-msvc
 $ make && make install
 ```
 
-#### MSVC with rustbuild
-
-The old build system, based on makefiles, is currently being rewritten into a
-Rust-based build system called rustbuild. This can be used to bootstrap the
-compiler on MSVC without needing to install MSYS or MinGW. All you need are
-[Python 2](https://www.python.org/downloads/),
-[CMake](https://cmake.org/download/), and
-[Git](https://git-scm.com/downloads) in your PATH (make sure you do not use the
-ones from MSYS if you have it installed). You'll also need Visual Studio 2013 or
-newer with the C++ tools. Then all you need to do is to kick off rustbuild.
-
-```
-python x.py build
-```
-
-Currently rustbuild only works with some known versions of Visual Studio. If you
-have a more recent version installed that a part of rustbuild doesn't understand
+Currently building Rust only works with some known versions of Visual Studio. If
+you have a more recent version installed the build system doesn't understand
 then you may need to force rustbuild to use an older version. This can be done
 by manually calling the appropriate vcvars file before running the bootstrap.
 
@@ -148,16 +138,6 @@ If you’d like to build the documentation, it’s almost the same:
 $ ./configure
 $ make docs
 ```
-
-Building the documentation requires building the compiler, so the above
-details will apply. Once you have the compiler built, you can
-
-```sh
-$ make docs NO_REBUILD=1
-```
-
-To make sure you don’t re-build the compiler because you made a change
-to some documentation.
 
 The generated documentation will appear in a top-level `doc` directory,
 created by the `make` rule.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,25 +2,22 @@ environment:
   matrix:
   # 32/64 bit MSVC
   - MSYS_BITS: 64
-    TARGET: x86_64-pc-windows-msvc
-    CHECK: check
-    CONFIGURE_ARGS: --enable-llvm-assertions --enable-debug-assertions
+    RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc
+    RUST_CHECK_TARGET: check
   - MSYS_BITS: 32
-    TARGET: i686-pc-windows-msvc
-    CHECK: check
-    CONFIGURE_ARGS: --enable-llvm-assertions --enable-debug-assertions
+    RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc
+    RUST_CHECK_TARGET: check
 
-  # MSVC rustbuild
+  # MSVC makefiles
   - MSYS_BITS: 64
-    CONFIGURE_ARGS: --enable-rustbuild --enable-llvm-assertions --enable-debug-assertions
-    TARGET: x86_64-pc-windows-msvc
-    CHECK: check
+    RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --disable-rustbuild
+    RUST_CHECK_TARGET: check
 
   # MSVC cargotest
   - MSYS_BITS: 64
-    CONFIGURE_ARGS: --enable-rustbuild --enable-llvm-assertions --enable-debug-assertions
-    TARGET: x86_64-pc-windows-msvc
-    CHECK: check-cargotest
+    NO_VENDOR: 1
+    RUST_CHECK_TARGET: check-cargotest
+    RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc
 
   # 32/64-bit MinGW builds.
   #
@@ -47,24 +44,22 @@ environment:
   # *not* use debug assertions and llvm assertions. This is because they take
   # too long on appveyor and this is tested by rustbuild below.
   - MSYS_BITS: 32
-    TARGET: i686-pc-windows-gnu
-    CHECK: check
+    RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu
+    RUST_CHECK_TARGET: check
     MINGW_URL: https://s3.amazonaws.com/rust-lang-ci
     MINGW_ARCHIVE: i686-4.9.2-release-win32-dwarf-rt_v4-rev4.7z
     MINGW_DIR: mingw32
 
   - MSYS_BITS: 32
-    CONFIGURE_ARGS: --enable-rustbuild --enable-llvm-assertions --enable-debug-assertions
-    TARGET: i686-pc-windows-gnu
-    CHECK: check
+    RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu --disable-rustbuild
+    RUST_CHECK_TARGET: check
     MINGW_URL: https://s3.amazonaws.com/rust-lang-ci
     MINGW_ARCHIVE: i686-4.9.2-release-win32-dwarf-rt_v4-rev4.7z
     MINGW_DIR: mingw32
 
   - MSYS_BITS: 64
-    CONFIGURE_ARGS: --enable-llvm-assertions --enable-debug-assertions
-    TARGET: x86_64-pc-windows-gnu
-    CHECK: check
+    RUST_CHECK_TARGET: check
+    RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu
     MINGW_URL: https://s3.amazonaws.com/rust-lang-ci
     MINGW_ARCHIVE: x86_64-4.9.2-release-win32-seh-rt_v4-rev4.7z
     MINGW_DIR: mingw64
@@ -90,15 +85,20 @@ install:
   - if NOT defined MINGW_URL set PATH=C:\msys64\mingw%MSYS_BITS%\bin;C:\msys64\usr\bin;%PATH%
 
 test_script:
-  - sh ./configure
-          %CONFIGURE_ARGS%
-          --build=%TARGET%
-  - bash -c "make -j$(nproc)"
-  - bash -c "make %CHECK% -j$(nproc)"
+  - git submodule update --init
+  - set SRC=.
+  - set NO_CCACHE=1
+  - sh src/ci/run.sh
 
 cache:
-  - build/%TARGET%/llvm -> src/rustllvm/llvm-auto-clean-trigger
-  - "%TARGET%/llvm -> src/rustllvm/llvm-auto-clean-trigger"
+  - "build/i686-pc-windows-gnu/llvm -> src/rustllvm/llvm-auto-clean-trigger"
+  - "build/x86_64-pc-windows-gnu/llvm -> src/rustllvm/llvm-auto-clean-trigger"
+  - "build/i686-pc-windows-msvc/llvm -> src/rustllvm/llvm-auto-clean-trigger"
+  - "build/x86_64-pc-windows-msvc/llvm -> src/rustllvm/llvm-auto-clean-trigger"
+  - "i686-pc-windows-gnu/llvm -> src/rustllvm/llvm-auto-clean-trigger"
+  - "x86_64-pc-windows-gnu/llvm -> src/rustllvm/llvm-auto-clean-trigger"
+  - "i686-pc-windows-msvc/llvm -> src/rustllvm/llvm-auto-clean-trigger"
+  - "x86_64-pc-windows-msvc/llvm -> src/rustllvm/llvm-auto-clean-trigger"
 
 branches:
   only:

--- a/configure
+++ b/configure
@@ -631,7 +631,7 @@ opt stage0-landing-pads 1 "enable landing pads during bootstrap with stage0"
 opt dist-host-only 0 "only install bins for the host architecture"
 opt inject-std-version 1 "inject the current compiler version of libstd into programs"
 opt llvm-version-check 1 "check if the LLVM version is supported, build anyway"
-opt rustbuild 0 "use the rust and cargo based build system"
+opt rustbuild 1 "use the rust and cargo based build system"
 opt codegen-tests 1 "run the src/test/codegen tests"
 opt option-checking 1 "complain about unrecognized options in this configure script"
 opt ninja 0 "build LLVM using the Ninja generator (for MSVC, requires building in the correct environment)"
@@ -664,11 +664,11 @@ valopt armv7-linux-androideabi-ndk "" "armv7-linux-androideabi NDK standalone pa
 valopt aarch64-linux-android-ndk "" "aarch64-linux-android NDK standalone path"
 valopt nacl-cross-path  "" "NaCl SDK path (Pepper Canary is recommended). Must be absolute!"
 valopt musl-root "/usr/local" "MUSL root installation directory (deprecated)"
-valopt musl-root-x86_64 "/usr/local" "x86_64-unknown-linux-musl install directory"
-valopt musl-root-i686 "/usr/local" "i686-unknown-linux-musl install directory"
-valopt musl-root-arm "/usr/local" "arm-unknown-linux-musleabi install directory"
-valopt musl-root-armhf "/usr/local" "arm-unknown-linux-musleabihf install directory"
-valopt musl-root-armv7 "/usr/local" "armv7-unknown-linux-musleabihf install directory"
+valopt musl-root-x86_64 "" "x86_64-unknown-linux-musl install directory"
+valopt musl-root-i686 "" "i686-unknown-linux-musl install directory"
+valopt musl-root-arm "" "arm-unknown-linux-musleabi install directory"
+valopt musl-root-armhf "" "arm-unknown-linux-musleabihf install directory"
+valopt musl-root-armv7 "" "armv7-unknown-linux-musleabihf install directory"
 valopt extra-filename "" "Additional data that is hashed and passed to the -C extra-filename flag"
 
 if [ -e ${CFG_SRC_DIR}.git ]
@@ -1374,7 +1374,7 @@ then
     fi
 fi
 
-if [ -z "$CFG_ENABLE_RUSTBUILD" ]; then
+if [ -n "$CFG_DISABLE_RUSTBUILD" ]; then
 
   step_msg "making directories"
 
@@ -1474,7 +1474,7 @@ fi
 step_msg "configuring submodules"
 
 # Have to be in the top of src directory for this
-if [ -z "$CFG_DISABLE_MANAGE_SUBMODULES" ] && [ -z "$CFG_ENABLE_RUSTBUILD" ]
+if [ -z "$CFG_DISABLE_MANAGE_SUBMODULES" ] && [ -n "$CFG_DISABLE_RUSTBUILD" ]
 then
     cd ${CFG_SRC_DIR}
 
@@ -1546,7 +1546,7 @@ do
         ;;
     esac
 
-    if [ -n "$CFG_ENABLE_RUSTBUILD" ]
+    if [ -z "$CFG_DISABLE_RUSTBUILD" ]
     then
         msg "not configuring LLVM, rustbuild in use"
         do_reconfigure=0
@@ -1871,7 +1871,7 @@ do
     putvar $CFG_LLVM_INST_DIR
 done
 
-if [ -n "$CFG_ENABLE_RUSTBUILD" ]
+if [ -z "$CFG_DISABLE_RUSTBUILD" ]
 then
     INPUT_MAKEFILE=src/bootstrap/mk/Makefile.in
 else
@@ -1890,5 +1890,22 @@ else
     step_msg "complete"
 fi
 
-msg "run \`make help\`"
+if [ -z "$CFG_DISABLE_RUSTBUILD" ]; then
+    msg "NOTE you have now configured rust to use a rewritten build system"
+    msg "     called rustbuild, and as a result this may have bugs that "
+    msg "     you did not see before. If you experience any issues you can"
+    msg "     go back to the old build system with --disable-rustbuild and"
+    msg "     please feel free to report any bugs!"
+    msg ""
+    msg "run \`python x.py --help\`"
+else
+    warn "the makefile-based build system is deprecated in favor of rustbuild"
+    msg ""
+    msg "It is recommended you avoid passing --disable-rustbuild to get your"
+    msg "build working as the makefiles will be deleted on 2017-02-02. If you"
+    msg "encounter bugs with rustbuild please file issues against rust-lang/rust"
+    msg ""
+    msg "run \`make help\`"
+fi
+
 msg

--- a/src/bootstrap/README.md
+++ b/src/bootstrap/README.md
@@ -66,17 +66,6 @@ The script accepts commands, flags, and filters to determine what to do:
 * `doc` - a command for building documentation. Like above can take arguments
   for what to document.
 
-If you're more used to `./configure` and `make`, however, then you can also
-configure the build system to use rustbuild instead of the old makefiles:
-
-```
-./configure --enable-rustbuild
-make
-```
-
-Afterwards the `Makefile` which is generated will have a few commands like
-`make check`, `make tidy`, etc.
-
 ## Configuring rustbuild
 
 There are currently two primary methods for configuring the rustbuild build
@@ -89,6 +78,13 @@ file in the same location as `config.mk`. An example of this configuration can
 be found at `src/bootstrap/config.toml.example`, and the configuration file
 can also be passed as `--config path/to/config.toml` if the build system is
 being invoked manually (via the python script).
+
+Finally, rustbuild makes use of the [gcc-rs crate] which has [its own
+method][env-vars] of configuring C compilers and C flags via environment
+variables.
+
+[gcc-rs crate]: https://github.com/alexcrichton/gcc-rs
+[env-vars]: https://github.com/alexcrichton/gcc-rs#external-configuration-via-environment-variables
 
 ## Build stages
 
@@ -273,16 +269,17 @@ After that, each module in rustbuild should have enough documentation to keep
 you up and running. Some general areas that you may be interested in modifying
 are:
 
-* Adding a new build tool? Take a look at `build/step.rs` for examples of other
-  tools, as well as `build/mod.rs`.
+* Adding a new build tool? Take a look at `bootstrap/step.rs` for examples of
+  other tools.
 * Adding a new compiler crate? Look no further! Adding crates can be done by
   adding a new directory with `Cargo.toml` followed by configuring all
   `Cargo.toml` files accordingly.
 * Adding a new dependency from crates.io? We're still working on that, so hold
   off on that for now.
-* Adding a new configuration option? Take a look at `build/config.rs` or perhaps
-  `build/flags.rs` and then modify the build elsewhere to read that option.
-* Adding a sanity check? Take a look at `build/sanity.rs`.
+* Adding a new configuration option? Take a look at `bootstrap/config.rs` or
+  perhaps `bootstrap/flags.rs` and then modify the build elsewhere to read that
+  option.
+* Adding a sanity check? Take a look at `bootstrap/sanity.rs`.
 
 If you have any questions feel free to reach out on `#rust-internals` on IRC or
 open an issue in the bug tracker!

--- a/src/bootstrap/clean.rs
+++ b/src/bootstrap/clean.rs
@@ -46,6 +46,9 @@ fn rm_rf(build: &Build, path: &Path) {
     if !path.exists() {
         return
     }
+    if path.is_file() {
+        return do_op(path, "remove file", |p| fs::remove_file(p));
+    }
 
     for file in t!(fs::read_dir(path)) {
         let file = t!(file).path();

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -239,6 +239,7 @@ To learn more about a subcommand, run `./x.py <command> -h`
                     install: m.opt_present("install"),
                 }
             }
+            "--help" => usage(0, &opts),
             cmd => {
                 println!("unknown command: {}", cmd);
                 usage(1, &opts);

--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -23,9 +23,14 @@ all:
 	$(Q)$(BOOTSTRAP) build $(BOOTSTRAP_ARGS)
 	$(Q)$(BOOTSTRAP) doc $(BOOTSTRAP_ARGS)
 
-# Don’t use $(Q) here, always show how to invoke the bootstrap script directly
 help:
-	$(BOOTSTRAP) --help
+	$(Q)echo 'Welcome to the rustbuild build system!'
+	$(Q)echo
+	$(Q)echo This makefile is a thin veneer over the ./x.py script located
+	$(Q)echo in this directory. To get the full power of the build system
+	$(Q)echo you can run x.py directly.
+	$(Q)echo
+	$(Q)echo To learn more run \`./x.py --help\`
 
 clean:
 	$(Q)$(BOOTSTRAP) clean $(BOOTSTRAP_ARGS)
@@ -51,15 +56,14 @@ check-cargotest:
 dist:
 	$(Q)$(BOOTSTRAP) dist $(BOOTSTRAP_ARGS)
 install:
-ifeq (root user, $(USER) $(patsubst %,user,$(SUDO_USER)))
-	$(Q)echo "'sudo make install' is not supported currently."
-else
 	$(Q)$(BOOTSTRAP) dist --install $(BOOTSTRAP_ARGS)
-endif
 tidy:
 	$(Q)$(BOOTSTRAP) test src/tools/tidy $(BOOTSTRAP_ARGS) --stage 0
 
-check-stage2-android:
-	$(Q)$(BOOTSTRAP) --step check-target --target arm-linux-androideabi
+check-stage2-T-arm-linux-androideabi-H-x86_64-unknown-linux-gnu:
+	$(Q)$(BOOTSTRAP) test --target arm-linux-androideabi
+check-stage2-T-x86_64-unknown-linux-musl-H-x86_64-unknown-linux-gnu:
+	$(Q)$(BOOTSTRAP) test --target x86_64-unknown-linux-gnu
+
 
 .PHONY: dist

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -41,10 +41,14 @@ pub fn check(build: &mut Build) {
         }
     }
     let have_cmd = |cmd: &OsStr| {
-        for path in env::split_paths(&path).map(|p| p.join(cmd)) {
-            if fs::metadata(&path).is_ok() ||
-               fs::metadata(path.with_extension("exe")).is_ok() {
-                return Some(path);
+        for path in env::split_paths(&path) {
+            let target = path.join(cmd);
+            let mut cmd_alt = cmd.to_os_string();
+            cmd_alt.push(".exe");
+            if target.exists() ||
+               target.with_extension("exe").exists() ||
+               target.join(cmd_alt).exists() {
+                return Some(target);
             }
         }
         return None;

--- a/src/bootstrap/util.rs
+++ b/src/bootstrap/util.rs
@@ -18,6 +18,7 @@ use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Instant;
 
 use filetime::FileTime;
 
@@ -188,4 +189,20 @@ pub fn push_exe_path(mut buf: PathBuf, components: &[&str]) -> PathBuf {
     buf.push(file);
 
     buf
+}
+
+pub struct TimeIt(Instant);
+
+/// Returns an RAII structure that prints out how long it took to drop.
+pub fn timeit() -> TimeIt {
+    TimeIt(Instant::now())
+}
+
+impl Drop for TimeIt {
+    fn drop(&mut self) {
+        let time = self.0.elapsed();
+        println!("\tfinished in {}.{:03}",
+                 time.as_secs(),
+                 time.subsec_nanos() / 1_000_000);
+    }
 }

--- a/src/ci/docker/arm-android/Dockerfile
+++ b/src/ci/docker/arm-android/Dockerfile
@@ -9,7 +9,6 @@ RUN dpkg --add-architecture i386 && \
   curl \
   ca-certificates \
   python2.7 \
-  python-minimal \
   git \
   cmake \
   ccache \
@@ -39,8 +38,7 @@ ENV RUST_CONFIGURE_ARGS \
       --arm-linux-androideabi-ndk=/android/ndk-arm-9 \
       --armv7-linux-androideabi-ndk=/android/ndk-arm-9 \
       --i686-linux-android-ndk=/android/ndk-x86-9 \
-      --aarch64-linux-android-ndk=/android/ndk-aarch64 \
-      --enable-rustbuild
-ENV RUST_CHECK_TARGET check-stage2-android
+      --aarch64-linux-android-ndk=/android/ndk-aarch64
+ENV XPY_CHECK test --target arm-linux-androideabi
 RUN mkdir /tmp/obj
 RUN chmod 777 /tmp/obj

--- a/src/ci/docker/cross/Dockerfile
+++ b/src/ci/docker/cross/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   curl \
   ca-certificates \
   python2.7 \
-  python-minimal \
   git \
   cmake \
   ccache \

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -19,17 +19,21 @@ ci_dir="`dirname $docker_dir`"
 src_dir="`dirname $ci_dir`"
 root_dir="`dirname $src_dir`"
 
-docker build \
+docker \
+  build \
   --rm \
   -t rust-ci \
   "`dirname "$script"`/$image"
 
 mkdir -p $HOME/.ccache
 mkdir -p $HOME/.cargo
+mkdir -p $root_dir/obj
 
-exec docker run \
+exec docker \
+  run \
   --volume "$root_dir:/checkout:ro" \
-  --workdir /tmp/obj \
+  --volume "$root_dir/obj:/checkout/obj" \
+  --workdir /checkout/obj \
   --env SRC=/checkout \
   --env CCACHE_DIR=/ccache \
   --volume "$HOME/.ccache:/ccache" \

--- a/src/ci/docker/x86_64-freebsd/Dockerfile
+++ b/src/ci/docker/x86_64-freebsd/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   curl \
   ca-certificates \
   python2.7 \
-  python-minimal \
   git \
   cmake \
   ccache \
@@ -23,7 +22,7 @@ ENV \
     AR_x86_64_unknown_freebsd=x86_64-unknown-freebsd10-ar \
     CC_x86_64_unknown_freebsd=x86_64-unknown-freebsd10-gcc
 
-ENV RUST_CONFIGURE_ARGS --target=x86_64-unknown-freebsd --enable-rustbuild
+ENV RUST_CONFIGURE_ARGS --target=x86_64-unknown-freebsd
 ENV RUST_CHECK_TARGET ""
 RUN mkdir /tmp/obj
 RUN chmod 777 /tmp/obj

--- a/src/ci/docker/x86_64-gnu-cargotest/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-cargotest/Dockerfile
@@ -7,14 +7,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   curl \
   ca-certificates \
   python2.7 \
-  python-minimal \
   git \
   cmake \
   ccache \
   libssl-dev \
   sudo
 
-ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu --enable-rustbuild
+ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu
 ENV RUST_CHECK_TARGET check-cargotest
+ENV NO_VENDOR 1
 RUN mkdir /tmp/obj
 RUN chmod 777 /tmp/obj

--- a/src/ci/docker/x86_64-gnu-llvm-3.7/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-llvm-3.7/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   curl \
   ca-certificates \
   python2.7 \
-  python2.7-minimal \
   git \
   cmake \
   ccache \
@@ -19,7 +18,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV RUST_CONFIGURE_ARGS \
       --build=x86_64-unknown-linux-gnu \
-      --enable-rustbuild \
       --llvm-root=/usr/lib/llvm-3.7
 ENV RUST_CHECK_TARGET check
 RUN mkdir /tmp/obj

--- a/src/ci/docker/x86_64-gnu-make/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-make/Dockerfile
@@ -7,14 +7,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   curl \
   ca-certificates \
   python2.7 \
-  python-minimal \
   git \
   cmake \
   ccache \
   sudo \
   gdb
 
-ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu --enable-rustbuild
+ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu --disable-rustbuild
 ENV RUST_CHECK_TARGET check
 RUN mkdir /tmp/obj
 RUN chmod 777 /tmp/obj

--- a/src/ci/docker/x86_64-musl/Dockerfile
+++ b/src/ci/docker/x86_64-musl/Dockerfile
@@ -20,8 +20,10 @@ RUN sh /build/build-musl.sh && rm -rf /build
 
 ENV RUST_CONFIGURE_ARGS \
       --target=x86_64-unknown-linux-musl \
-      --musl-root=/musl-x86_64
+      --musl-root-x86_64=/musl-x86_64
 ENV RUST_CHECK_TARGET check-stage2-T-x86_64-unknown-linux-musl-H-x86_64-unknown-linux-gnu
+ENV PATH=$PATH:/musl-x86_64/bin
+ENV XPY_CHECK test --target x86_64-unknown-linux-musl
 
 RUN mkdir /tmp/obj
 RUN chmod 777 /tmp/obj

--- a/src/liballoc_jemalloc/build.rs
+++ b/src/liballoc_jemalloc/build.rs
@@ -151,11 +151,17 @@ fn main() {
     cmd.arg(format!("--build={}", build_helper::gnu_target(&host)));
 
     run(&mut cmd);
-    run(Command::new("make")
-        .current_dir(&build_dir)
-        .arg("build_lib_static")
-        .arg("-j")
-        .arg(env::var("NUM_JOBS").expect("NUM_JOBS was not set")));
+    let mut make = Command::new("make");
+    make.current_dir(&build_dir)
+        .arg("build_lib_static");
+
+    // mingw make seems... buggy? unclear...
+    if !host.contains("windows") {
+        make.arg("-j")
+            .arg(env::var("NUM_JOBS").expect("NUM_JOBS was not set"));
+    }
+
+    run(&mut make);
 
     if target.contains("windows") {
         println!("cargo:rustc-link-lib=static=jemalloc");

--- a/src/rustllvm/llvm-auto-clean-trigger
+++ b/src/rustllvm/llvm-auto-clean-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be forcibly cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2016-12-01
+2016-12-06

--- a/src/test/run-pass/no-stdio.rs
+++ b/src/test/run-pass/no-stdio.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-emscripten
+// ignore-android
 
 #![feature(libc)]
 


### PR DESCRIPTION
This commit switches the default build system for Rust from the makefiles to
rustbuild. The rustbuild build system has been in development for almost a year
now and has become quite mature over time. This commit is an implementation of
the proposal on [internals] which slates deletion of the makefiles on
2017-02-02.

[internals]: https://internals.rust-lang.org/t/proposal-for-promoting-rustbuild-to-official-status/4368

This commit also updates various documentation in `README.md`,
`CONTRIBUTING.md`, `src/bootstrap/README.md`, and throughout the source code of
rustbuild itself.