### PR TITLE
Clarify the reference's status.

### DIFF
--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -17,7 +17,7 @@ the language.
 
 [**The Rust Reference**][ref]. While Rust does not have a
 specification, the reference tries to describe its working in
-detail. It tends to be out of date.
+detail. It is accurate, but not necessarily complete.
 
 [**Standard Library API Reference**][api]. Documentation for the
 standard library.


### PR DESCRIPTION
The former wording only gave part of the picture, we want to be crystal
clear about this.

/cc @petrochenkov, who had concerns about https://github.com/rust-lang/rust/pull/37820