### PR TITLE
make HR_LIFETIME_IN_ASSOC_TYPE deny-by-default

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -157,7 +157,7 @@ declare_lint! {
 
 declare_lint! {
     pub HR_LIFETIME_IN_ASSOC_TYPE,
-    Warn,
+    Deny,
     "binding for associated type references higher-ranked lifetime \
      that does not appear in the trait input types"
 }


### PR DESCRIPTION
It's time to fix issue #32330.

cc #33685 
cc @arielb1 