### PR TITLE
Don't clone in UnificationTable::probe().

### DIFF
--- a/src/librustc_data_structures/unify/mod.rs
+++ b/src/librustc_data_structures/unify/mod.rs
@@ -344,7 +344,7 @@ impl<'tcx, K, V> UnificationTable<K>
     }
 
     pub fn probe(&mut self, a_id: K) -> Option<V> {
-        self.get(a_id).value.clone()
+        self.get(a_id).value
     }
 
     pub fn unsolved_variables(&mut self) -> Vec<K> {


### PR DESCRIPTION
This speeds up compilation of rustc-benchmarks/inflate-0.1.0 by 1%.