### PR TITLE
Optimize Write::write_fmt for Vec<u8>/Sink

### DIFF
--- a/src/libstd/io/impls.rs
+++ b/src/libstd/io/impls.rs
@@ -230,6 +230,23 @@ impl Write for Vec<u8> {
     }
 
     #[inline]
+    fn write_fmt(&mut self, fmt: fmt::Arguments) -> io::Result<()> {
+        struct Adaptor<'a>(&'a mut Vec<u8>);
+
+        impl<'a> fmt::Write for Adaptor<'a> {
+            #[inline]
+            fn write_str(&mut self, s: &str) -> fmt::Result {
+                self.0.extend_from_slice(s.as_bytes());
+                Ok(())
+            }
+        }
+
+        let mut output = Adaptor(self);
+        fmt::write(&mut output, fmt)
+            .map_err(|_| Error::new(ErrorKind::Other, "formatter error"))
+    }
+
+    #[inline]
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
 }
 


### PR DESCRIPTION
A small optimization for formatted writing to `Vec<u8>`. This doesn't fix the issue, but benchmarks for https://github.com/rust-lang/rust/issues/10761#issuecomment-152373019 :

```
 name                default ns/iter  override ns/iter  diff ns/iter   diff % 
 bench_write_macro1  22,253           17,460                  -4,793  -21.54% 
 bench_write_macro2  33,725           29,363                  -4,362  -12.93% 
 bench_write_ref     2,303            2,228                      -75   -3.26% 
 bench_write_value   2,263            2,252                      -11   -0.49%
```