### PR TITLE
Don't build the lexer verifier during tidy

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -243,8 +243,7 @@ cleantestlibs:
 
 .PHONY: tidy
 tidy: $(HBIN0_H_$(CFG_BUILD))/tidy$(X_$(CFG_BUILD)) \
-		$(SNAPSHOT_RUSTC_POST_CLEANUP) \
-		check-build-lexer-verifier
+		$(SNAPSHOT_RUSTC_POST_CLEANUP)
 	$(TARGET_RPATH_VAR0_T_$(CFG_BUILD)_H_$(CFG_BUILD)) $< $(S)src
 
 $(HBIN0_H_$(CFG_BUILD))/tidy$(X_$(CFG_BUILD)): \


### PR DESCRIPTION
Tidy is not the right place to do this. Tidy is for running lints.
We should instead be running the lexer/grammar tests as part of the test
suite.

This may fix nightly breakage, but I don't understand why.

https://buildbot.rust-lang.org/builders/nightly-dist-rustc-linux/builds/715/steps/distcheck/logs/stdio

r? @alexcrichton 

cc @dns2utf8