### PR TITLE
rustc: always suggests #[macro_use] for undefined macros

### DIFF
--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -393,10 +393,9 @@ impl<'a> Resolver<'a> {
         if let Some(suggestion) = find_best_match_for_name(self.macro_names.iter(), name, None) {
             if suggestion != name {
                 err.help(&format!("did you mean `{}!`?", suggestion));
-            } else {
-                err.help(&format!("have you added the `#[macro_use]` on the module/import?"));
             }
         }
+        err.help(&format!("have you added the `#[macro_use]` on the module/import?"));
     }
 
     fn collect_def_ids(&mut self, invocation: &'a InvocationData<'a>, expansion: &Expansion) {

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -393,9 +393,16 @@ impl<'a> Resolver<'a> {
         if let Some(suggestion) = find_best_match_for_name(self.macro_names.iter(), name, None) {
             if suggestion != name {
                 err.help(&format!("did you mean `{}!`?", suggestion));
+            } else {
+                err.help(&format!("have you added the `#[macro_use]` on the module?"));
             }
         }
-        err.help(&format!("have you added the `#[macro_use]` on the module/import?"));
+
+        let is_macro = |def| match def { Def::Macro(..) => true, _ => false };
+        let candidates = self.lookup_import_candidates(name, MacroNS, is_macro);
+        if candidates.len() > 0 {
+            err.help(&format!("have you added the `#[macro_use]` on the `extern crate`?"));
+        }
     }
 
     fn collect_def_ids(&mut self, invocation: &'a InvocationData<'a>, expansion: &Expansion) {

--- a/src/test/compile-fail/macro-name-typo.rs
+++ b/src/test/compile-fail/macro-name-typo.rs
@@ -11,4 +11,5 @@
 fn main() {
     printlx!("oh noes!"); //~ ERROR macro undefined
     //~^ HELP did you mean `println!`?
+    //~^^ HELP have you added the `#[macro_use]` on the module/import?
 }

--- a/src/test/compile-fail/macro_undefined.rs
+++ b/src/test/compile-fail/macro_undefined.rs
@@ -20,6 +20,7 @@ mod m {
 fn main() {
     k!(); //~ ERROR macro undefined: 'k!'
           //~^ HELP did you mean `kl!`?
+          //~^^ HELP have you added the `#[macro_use]` on the module/import?
     kl!(); //~ ERROR macro undefined: 'kl!'
            //~^ HELP have you added the `#[macro_use]` on the module/import?
 }


### PR DESCRIPTION
# Work in progress. Don't merge.

If people forget adding `#[macro_use]` (or even don't know about it), give them a suggestion.

```rust
// missing `#[macro_use]`
extern crate log;
fn main() {
    info!("hello");
}
```
play link: https://is.gd/nwB6ty