### PR TITLE
rustdoc: get back missing crate-name when --playground-url is used

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -428,6 +428,7 @@ pub fn derive_id(candidate: String) -> String {
 /// Generates the documentation for `crate` into the directory `dst`
 pub fn run(mut krate: clean::Crate,
            external_html: &ExternalHtml,
+           playground_url: Option<String>,
            dst: PathBuf,
            passes: FxHashSet<String>,
            css_file_extension: Option<PathBuf>,
@@ -452,12 +453,11 @@ pub fn run(mut krate: clean::Crate,
     };
 
     // If user passed in `--playground-url` arg, we fill in crate name here
-    markdown::PLAYGROUND.with(|slot| {
-        if slot.borrow().is_some() {
-            let url = slot.borrow().as_ref().unwrap().1.clone();
+    if let Some(url) = playground_url {
+        markdown::PLAYGROUND.with(|slot| {
             *slot.borrow_mut() = Some((Some(krate.name.clone()), url));
-        }
-    });
+        });
+    }
 
     // Crawl the crate attributes looking for attributes which control how we're
     // going to emit HTML

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -451,6 +451,14 @@ pub fn run(mut krate: clean::Crate,
         css_file_extension: css_file_extension.clone(),
     };
 
+    // If user passed in `--playground-url` arg, we fill in crate name here
+    markdown::PLAYGROUND.with(|slot| {
+        if slot.borrow().is_some() {
+            let url = slot.borrow().as_ref().unwrap().1.clone();
+            *slot.borrow_mut() = Some((Some(krate.name.clone()), url));
+        }
+    });
+
     // Crawl the crate attributes looking for attributes which control how we're
     // going to emit HTML
     if let Some(attrs) = krate.module.as_ref().map(|m| &m.attrs) {

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -162,10 +162,10 @@ pub fn opts() -> Vec<RustcOptGroup> {
         unstable(optmulti("Z", "",
                           "internal and debugging options (only on nightly build)", "FLAG")),
         stable(optopt("", "sysroot", "Override the system root", "PATH")),
-        stable(optopt("", "playground-url",
-                      "URL to send code snippets to, may be reset by --markdown-playground-url \
-                       or `#![doc(html_playground_url=...)]`",
-                      "URL")),
+        unstable(optopt("", "playground-url",
+                        "URL to send code snippets to, may be reset by --markdown-playground-url \
+                         or `#![doc(html_playground_url=...)]`",
+                        "URL")),
     ]
 }
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -234,10 +234,6 @@ pub fn main_args(args: &[String]) -> isize {
         }
     };
 
-    if let Some(playground) = matches.opt_str("playground-url") {
-        html::markdown::PLAYGROUND.with(|s| { *s.borrow_mut() = Some((None, playground)); });
-    }
-
     let test_args = matches.opt_strs("test-args");
     let test_args: Vec<String> = test_args.iter()
                                           .flat_map(|s| s.split_whitespace())
@@ -266,6 +262,7 @@ pub fn main_args(args: &[String]) -> isize {
         None => return 3
     };
     let crate_name = matches.opt_str("crate-name");
+    let playground_url = matches.opt_str("playground-url");
 
     match (should_test, markdown_input) {
         (true, true) => {
@@ -287,7 +284,7 @@ pub fn main_args(args: &[String]) -> isize {
         info!("going to format");
         match output_format.as_ref().map(|s| &**s) {
             Some("html") | None => {
-                html::render::run(krate, &external_html,
+                html::render::run(krate, &external_html, playground_url,
                                   output.unwrap_or(PathBuf::from("doc")),
                                   passes.into_iter().collect(),
                                   css_file_extension,

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -63,7 +63,8 @@ pub fn render(input: &str, mut output: PathBuf, matches: &getopts::Matches,
         Err(LoadStringError::ReadFail) => return 1,
         Err(LoadStringError::BadUtf8) => return 2,
     };
-    if let Some(playground) = matches.opt_str("markdown-playground-url") {
+    if let Some(playground) = matches.opt_str("markdown-playground-url").or(
+                              matches.opt_str("playground-url")) {
         markdown::PLAYGROUND.with(|s| { *s.borrow_mut() = Some((None, playground)); });
     }
 

--- a/src/test/rustdoc/playground-arg.rs
+++ b/src/test/rustdoc/playground-arg.rs
@@ -1,0 +1,24 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --playground-url=https://example.com/ -Z unstable-options
+// ignore-tidy-linelength
+
+#![crate_name = "foo"]
+
+//! ```
+//! use foo::dummy;
+//! dummy();
+//! ```
+
+pub fn dummy() {}
+
+// ensure that `extern crate foo;` was inserted into code snips automatically:
+// @matches foo/index.html '//a[@class="test-arrow"][@href="https://example.com/?code=extern%20crate%20foo%3B%0Afn%20main()%20%7B%0Ause%20foo%3A%3Adummy%3B%0Adummy()%3B%0A%7D"]' "Run"


### PR DESCRIPTION
follow up PR #37763
r? @alexcrichton (since you r+ed to #37763 )

----

Edit: When `#![doc(html_playground_url="")]` is used, the current crate name is saved to `PLAYGROUND`, so rustdoc may generate `extern crate NAME;` into code snips automatically. But when `--playground-url` was introduced in PR #37763, I forgot saving crate name to `PLAYGROUND`. This PR fix that.

----

Update: 
- add test
- unstable `--playground-url`