### PR TITLE
Document RFC 1623: static lifetime elision.

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -1356,7 +1356,7 @@ unsafe fn bump_levels_unsafe2() -> u32 {
 Mutable statics have the same restrictions as normal statics, except that the
 type of the value is not required to ascribe to `Sync`.
 
-#### `'static` lifetime elision
+#### `'static` lifetime elision [unstable]
 
 Both constant and static declarations of reference types have *implicit*
 `'static` lifetimes unless an explicit lifetime is specified. As such, the
@@ -1364,6 +1364,7 @@ constant declarations involving `'static` above may be written without the
 lifetimes. Returning to our previous example:
 
 ```rust
+#[feature(static_in_const)]
 const BIT1: u32 = 1 << 0;
 const BIT2: u32 = 1 << 1;
 

--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -1356,12 +1356,12 @@ unsafe fn bump_levels_unsafe2() -> u32 {
 Mutable statics have the same restrictions as normal statics, except that the
 type of the value is not required to ascribe to `Sync`.
 
-#### `'static` lifetime elision [unstable]
+#### `'static` lifetime elision
 
-Both constant and static declarations of reference types have *implicit*
-`'static` lifetimes unless an explicit lifetime is specified. As such, the
-constant declarations involving `'static` above may be written without the
-lifetimes. Returning to our previous example:
+[Unstable] Both constant and static declarations of reference types have
+*implicit* `'static` lifetimes unless an explicit lifetime is specified. As
+such, the constant declarations involving `'static` above may be written
+without the lifetimes. Returning to our previous example:
 
 ```rust
 #[feature(static_in_const)]


### PR DESCRIPTION
This should be the last item required for stabilizing RFC 1623 (#35897).