### PR TITLE
Warn unused type parameters

### DIFF
--- a/src/libcore/num/dec2flt/algorithm.rs
+++ b/src/libcore/num/dec2flt/algorithm.rs
@@ -35,7 +35,7 @@ fn power_of_ten(e: i16) -> Fp {
 // precision of the computation is determined on a per-operation basis.
 #[cfg(any(not(target_arch="x86"), target_feature="sse2"))]
 mod fpu_precision {
-    pub fn set_precision<T>() { }
+    pub fn set_precision<_T>() { }
 }
 
 // On x86, the x87 FPU is used for float operations if the SSE/SSE2 extensions are not available.

--- a/src/libcoretest/any.rs
+++ b/src/libcoretest/any.rs
@@ -121,7 +121,7 @@ fn any_fixed_vec() {
 
 #[test]
 fn any_unsized() {
-    fn is_any<T: Any + ?Sized>() {}
+    fn is_any<_T: Any + ?Sized>() {}
     is_any::<[i32]>();
 }
 

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -29,6 +29,12 @@ declare_lint! {
 }
 
 declare_lint! {
+    pub UNUSED_TYPE_PARAMETERS,
+    Warn,
+    "type parameters that are never used"
+}
+
+declare_lint! {
     pub UNUSED_EXTERN_CRATES,
     Allow,
     "extern crates that are never used"
@@ -226,6 +232,7 @@ impl LintPass for HardwiredLints {
     fn get_lints(&self) -> LintArray {
         lint_array!(
             UNUSED_IMPORTS,
+            UNUSED_TYPE_PARAMETERS,
             UNUSED_EXTERN_CRATES,
             UNUSED_QUALIFICATIONS,
             UNKNOWN_LINTS,

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -158,6 +158,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
     add_lint_group!(sess,
                     "unused",
                     UNUSED_IMPORTS,
+                    UNUSED_TYPE_PARAMETERS,
                     UNUSED_VARIABLES,
                     UNUSED_ASSIGNMENTS,
                     DEAD_CODE,

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -49,6 +49,7 @@ use rustc::ty;
 use rustc::hir::{Freevar, FreevarMap, TraitCandidate, TraitMap, GlobMap};
 use rustc::util::nodemap::{NodeMap, NodeSet, FxHashMap, FxHashSet};
 
+use syntax::abi::Abi;
 use syntax::ext::hygiene::{Mark, SyntaxContext};
 use syntax::ast::{self, FloatTy};
 use syntax::ast::{CRATE_NODE_ID, Name, NodeId, Ident, SpannedIdent, IntTy, UintTy};
@@ -559,7 +560,14 @@ impl<T> ::std::ops::IndexMut<Namespace> for PerNS<T> {
 
 impl<'a, 'tcx> Visitor<'tcx> for Resolver<'a> {
     fn visit_item(&mut self, item: &'tcx Item) {
+        let is_lang_item = item.attrs.iter().any(|attr| attr.name() == "lang");
+        if is_lang_item {
+            self.check_unused_type_parameters = false;
+        }
+
         self.resolve_item(item);
+
+        self.check_unused_type_parameters = true;
     }
     fn visit_arm(&mut self, arm: &'tcx Arm) {
         self.resolve_arm(arm);
@@ -722,6 +730,8 @@ enum RibKind<'a> {
 struct Rib<'a> {
     bindings: FxHashMap<Ident, Def>,
     kind: RibKind<'a>,
+    sources: FxHashMap<Ident, (NodeId, Span)>,
+    used_names: RefCell<FxHashSet<Ident>>,
 }
 
 impl<'a> Rib<'a> {
@@ -729,7 +739,25 @@ impl<'a> Rib<'a> {
         Rib {
             bindings: FxHashMap(),
             kind: kind,
+            sources: FxHashMap(),
+            used_names: RefCell::new(FxHashSet()),
         }
+    }
+
+    fn insert(&mut self, ident: Ident, def: Def) {
+        self.bindings.insert(ident, def);
+    }
+
+    fn insert_with_source(&mut self, ident: Ident, id: NodeId, span: Span, def: Def) {
+        self.bindings.insert(ident, def);
+        self.sources.insert(ident, (id, span));
+    }
+
+    fn get(&self, ident: Ident) -> Option<Def> {
+        self.bindings.get(&ident).map(|def| {
+            self.used_names.borrow_mut().insert(ident);
+            def.clone()
+        })
     }
 }
 
@@ -1114,6 +1142,10 @@ pub struct Resolver<'a> {
 
     // Avoid duplicated errors for "name already defined".
     name_already_seen: FxHashMap<Name, Span>,
+
+    // Whether unused type parameters should be warned. Default true,
+    // false for intrinsics and lang items.
+    check_unused_type_parameters: bool,
 }
 
 pub struct ResolverArenas<'a> {
@@ -1289,6 +1321,7 @@ impl<'a> Resolver<'a> {
             macro_exports: Vec::new(),
             invocations: invocations,
             name_already_seen: FxHashMap(),
+            check_unused_type_parameters: true,
         }
     }
 
@@ -1394,7 +1427,7 @@ impl<'a> Resolver<'a> {
 
         // Walk backwards up the ribs in scope.
         for i in (0 .. self.ribs[ns].len()).rev() {
-            if let Some(def) = self.ribs[ns][i].bindings.get(&ident).cloned() {
+            if let Some(def) = self.ribs[ns][i].get(ident) {
                 // The ident resolves to a type parameter or local variable.
                 return Some(LexicalScopeBinding::Def(if let Some(span) = record_used {
                     self.adjust_local_def(LocalDef { ribs: Some((ns, i)), def: def }, span)
@@ -1502,7 +1535,7 @@ impl<'a> Resolver<'a> {
                     return None;
                 }
             }
-            let result = rib.bindings.get(&ident).cloned();
+            let result = rib.get(ident);
             if result.is_some() {
                 return result;
             }
@@ -1577,10 +1610,22 @@ impl<'a> Resolver<'a> {
                 });
             }
 
-            ItemKind::Mod(_) | ItemKind::ForeignMod(_) => {
+            ItemKind::Mod(_) => {
                 self.with_scope(item.id, |this| {
                     visit::walk_item(this, item);
                 });
+            }
+
+            ItemKind::ForeignMod(ref m) => {
+                if m.abi == Abi::RustIntrinsic {
+                    self.check_unused_type_parameters = false;
+                }
+
+                self.with_scope(item.id, |this| {
+                    visit::walk_item(this, item);
+                });
+
+                self.check_unused_type_parameters = true;
             }
 
             ItemKind::Const(..) | ItemKind::Static(..) => {
@@ -1637,7 +1682,7 @@ impl<'a> Resolver<'a> {
     {
         match type_parameters {
             HasTypeParameters(generics, rib_kind) => {
-                let mut function_type_rib = Rib::new(rib_kind);
+                let mut type_rib = Rib::new(rib_kind);
                 let mut seen_bindings = FxHashMap();
                 for type_parameter in &generics.ty_params {
                     let name = type_parameter.ident.name;
@@ -1653,12 +1698,13 @@ impl<'a> Resolver<'a> {
                     seen_bindings.entry(name).or_insert(type_parameter.span);
 
                     // plain insert (no renaming)
+                    let ident = Ident::with_empty_ctxt(name);
                     let def_id = self.definitions.local_def_id(type_parameter.id);
                     let def = Def::TyParam(def_id);
-                    function_type_rib.bindings.insert(Ident::with_empty_ctxt(name), def);
+                    type_rib.insert_with_source(ident, type_parameter.id, type_parameter.span, def);
                     self.record_def(type_parameter.id, PathResolution::new(def));
                 }
-                self.ribs[TypeNS].push(function_type_rib);
+                self.ribs[TypeNS].push(type_rib);
             }
 
             NoTypeParameters => {
@@ -1669,6 +1715,20 @@ impl<'a> Resolver<'a> {
         f(self);
 
         if let HasTypeParameters(..) = type_parameters {
+            if self.check_unused_type_parameters {
+                let type_rib = self.ribs[TypeNS].last().unwrap();
+                for (&name, &(id, span)) in &type_rib.sources {
+                    if name.to_string().starts_with('_') {
+                        continue;
+                    }
+                    if !type_rib.used_names.borrow().contains(&name) {
+                        self.session.add_lint(lint::builtin::UNUSED_TYPE_PARAMETERS,
+                                              id, span,
+                                              "unused type parameter".to_string());
+                    }
+                }
+            }
+
             self.ribs[TypeNS].pop();
         }
     }
@@ -1784,7 +1844,7 @@ impl<'a> Resolver<'a> {
         let mut self_type_rib = Rib::new(NormalRibKind);
 
         // plain insert (no renaming, types are not currently hygienic....)
-        self_type_rib.bindings.insert(keywords::SelfType.ident(), self_def);
+        self_type_rib.insert(keywords::SelfType.ident(), self_def);
         self.ribs[TypeNS].push(self_type_rib);
         f(self);
         self.ribs[TypeNS].pop();
@@ -2098,7 +2158,7 @@ impl<'a> Resolver<'a> {
                 // A completely fresh binding, add to the lists if it's valid.
                 if ident.node.name != keywords::Invalid.name() {
                     bindings.insert(ident.node, outer_pat_id);
-                    self.ribs[ValueNS].last_mut().unwrap().bindings.insert(ident.node, def);
+                    self.ribs[ValueNS].last_mut().unwrap().insert(ident.node, def);
                 }
             }
         }
@@ -2605,7 +2665,7 @@ impl<'a> Resolver<'a> {
         if let Some(label) = label {
             let def = Def::Label(id);
             self.with_label_rib(|this| {
-                this.label_ribs.last_mut().unwrap().bindings.insert(label.node, def);
+                this.label_ribs.last_mut().unwrap().insert(label.node, def);
                 this.visit_block(block);
             });
         } else {

--- a/src/libserialize/serialize.rs
+++ b/src/libserialize/serialize.rs
@@ -674,8 +674,8 @@ pub trait SpecializationError {
     /// `T` is the type being encoded/decoded, and
     /// the arguments are the names of the trait
     /// and method that should've been overriden.
-    fn not_found<S, T: ?Sized>(trait_name: &'static str,
-                               method_name: &'static str) -> Self;
+    fn not_found<_S, _T: ?Sized>(trait_name: &'static str,
+                                 method_name: &'static str) -> Self;
 }
 
 impl<E> SpecializationError for E {

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -2684,7 +2684,7 @@ mod tests {
 
     #[test]
     fn _assert_send_sync() {
-        fn _assert_send_sync<T: Send + Sync>() {}
+        fn _assert_send_sync<_T: Send + Sync>() {}
         _assert_send_sync::<OpenOptions>();
     }
 

--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -545,7 +545,7 @@ impl error::Error for Error {
 }
 
 fn _assert_error_is_sync_send() {
-    fn _is_sync_send<T: Sync+Send>() {}
+    fn _is_sync_send<_T: Sync+Send>() {}
     _is_sync_send::<Error>();
 }
 

--- a/src/libstd/sys_common/thread_local.rs
+++ b/src/libstd/sys_common/thread_local.rs
@@ -235,8 +235,8 @@ impl Drop for Key {
 mod tests {
     use super::{Key, StaticKey};
 
-    fn assert_sync<T: Sync>() {}
-    fn assert_send<T: Send>() {}
+    fn assert_sync<_T: Sync>() {}
+    fn assert_send<_T: Send>() {}
 
     #[test]
     fn smoke() {

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -789,7 +789,7 @@ impl<T> IntoInner<imp::Thread> for JoinHandle<T> {
 }
 
 fn _assert_sync_and_send() {
-    fn _assert_both<T: Send + Sync>() {}
+    fn _assert_both<_T: Send + Sync>() {}
     _assert_both::<JoinHandle<()>>();
     _assert_both::<Thread>();
 }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1981,7 +1981,7 @@ mod tests {
     // are ASTs encodable?
     #[test]
     fn check_asts_encodable() {
-        fn assert_encodable<T: serialize::Encodable>() {}
+        fn assert_encodable<_T: serialize::Encodable>() {}
         assert_encodable::<Crate>();
     }
 }

--- a/src/test/compile-fail/associated-types/bound-lifetime-in-binding-only.rs
+++ b/src/test/compile-fail/associated-types/bound-lifetime-in-binding-only.rs
@@ -11,6 +11,7 @@
 // revisions: angle paren ok elision
 
 #![allow(dead_code)]
+#![allow(unused_type_parameters)]
 #![feature(rustc_attrs)]
 #![feature(unboxed_closures)]
 #![deny(hr_lifetime_in_assoc_type)]

--- a/src/test/compile-fail/associated-types/cache/wasm-issue-32330.rs
+++ b/src/test/compile-fail/associated-types/cache/wasm-issue-32330.rs
@@ -16,10 +16,6 @@
 
 use std::str::Chars;
 
-pub trait HasOutput<Ch, Str> {
-    type Output;
-}
-
 #[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd, Debug)]
 pub enum Token<'a> {
     Begin(&'a str)

--- a/src/test/compile-fail/coherence-projection-ok-orphan.rs
+++ b/src/test/compile-fail/coherence-projection-ok-orphan.rs
@@ -10,6 +10,7 @@
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]
+#![allow(unused_type_parameters)]
 
 // Here we do not get a coherence conflict because `Baz: Iterator`
 // does not hold and (due to the orphan rules), we can rely on that.

--- a/src/test/compile-fail/coherence-projection-ok.rs
+++ b/src/test/compile-fail/coherence-projection-ok.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(rustc_attrs)]
+#![allow(unused_type_parameters)]
 
 pub trait Foo<P> {}
 

--- a/src/test/compile-fail/generic-no-mangle.rs
+++ b/src/test/compile-fail/generic-no-mangle.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unused_type_parameters)]
 #![deny(no_mangle_generic_items)]
 
 #[no_mangle]

--- a/src/test/compile-fail/issue-29857.rs
+++ b/src/test/compile-fail/issue-29857.rs
@@ -10,6 +10,7 @@
 
 
 #![feature(rustc_attrs)]
+#![allow(unused_type_parameters)]
 
 use std::marker::PhantomData;
 

--- a/src/test/compile-fail/lint-dead-code-1.rs
+++ b/src/test/compile-fail/lint-dead-code-1.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![no_std]
+#![allow(unused_type_parameters)]
 #![allow(unused_variables)]
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]

--- a/src/test/compile-fail/lint-unused-type-parameters.rs
+++ b/src/test/compile-fail/lint-unused-type-parameters.rs
@@ -1,0 +1,42 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(unused_type_parameters)]
+
+pub fn f<T>() {} //~ ERROR unused type parameter
+
+pub struct S;
+impl S {
+    pub fn m<T>() {} //~ ERROR unused type parameter
+}
+
+trait Trait {
+    fn m<T>() {} //~ ERROR unused type parameter
+}
+
+// Now test allow attributes
+
+pub mod allow {
+    #[allow(unused_type_parameters)]
+    pub fn f<T>() {}
+
+    pub struct S;
+    impl S {
+        #[allow(unused_type_parameters)]
+        pub fn m<T>() {}
+    }
+
+    trait Trait {
+        #[allow(unused_type_parameters)]
+        fn m<T>() {}
+    }
+}
+
+fn main() {}

--- a/src/test/compile-fail/object-safety-phantom-fn.rs
+++ b/src/test/compile-fail/object-safety-phantom-fn.rs
@@ -12,6 +12,7 @@
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]
+#![allow(unused_type_parameters)]
 
 trait Baz {
 }

--- a/src/test/compile-fail/regions-implied-bounds-projection-gap-2.rs
+++ b/src/test/compile-fail/regions-implied-bounds-projection-gap-2.rs
@@ -14,6 +14,7 @@
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]
+#![allow(unused_type_parameters)]
 #![allow(unused_variables)]
 
 trait Trait1<'x> {

--- a/src/test/compile-fail/regions-implied-bounds-projection-gap-3.rs
+++ b/src/test/compile-fail/regions-implied-bounds-projection-gap-3.rs
@@ -14,6 +14,7 @@
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]
+#![allow(unused_type_parameters)]
 #![allow(unused_variables)]
 
 trait Trait1<'x> {

--- a/src/test/compile-fail/regions-implied-bounds-projection-gap-4.rs
+++ b/src/test/compile-fail/regions-implied-bounds-projection-gap-4.rs
@@ -14,6 +14,7 @@
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]
+#![allow(unused_type_parameters)]
 #![allow(unused_variables)]
 
 trait Trait1<'x> {

--- a/src/test/compile-fail/regions-outlives-projection-hrtype.rs
+++ b/src/test/compile-fail/regions-outlives-projection-hrtype.rs
@@ -17,6 +17,7 @@
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]
+#![allow(unused_type_parameters)]
 
 trait TheTrait {
     type TheType;

--- a/src/test/ui/compare-method/proj-outlives-region.rs
+++ b/src/test/ui/compare-method/proj-outlives-region.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![allow(dead_code)]
+#![allow(unused_type_parameters)]
 #![deny(extra_requirement_in_impl)]
 
 // Test that we elaborate `Type: 'region` constraints and infer various important things.

--- a/src/test/ui/compare-method/proj-outlives-region.stderr
+++ b/src/test/ui/compare-method/proj-outlives-region.stderr
@@ -1,18 +1,18 @@
 error[E0276]: impl has stricter requirements than trait
-  --> $DIR/proj-outlives-region.rs:22:5
+  --> $DIR/proj-outlives-region.rs:23:5
    |
-17 |     fn foo() where T: 'a;
+18 |     fn foo() where T: 'a;
    |     --------------------- definition of `foo` from trait
 ...
-22 |     fn foo() where U: 'a { } //~ ERROR E0276
+23 |     fn foo() where U: 'a { } //~ ERROR E0276
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ impl has extra requirement `U: 'a`
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #37166 <https://github.com/rust-lang/rust/issues/37166>
 note: lint level defined here
-  --> $DIR/proj-outlives-region.rs:12:9
+  --> $DIR/proj-outlives-region.rs:13:9
    |
-12 | #![deny(extra_requirement_in_impl)]
+13 | #![deny(extra_requirement_in_impl)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error

--- a/src/test/ui/compare-method/region-unrelated.rs
+++ b/src/test/ui/compare-method/region-unrelated.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![allow(dead_code)]
+#![allow(unused_type_parameters)]
 #![deny(extra_requirement_in_impl)]
 
 // Test that we elaborate `Type: 'region` constraints and infer various important things.

--- a/src/test/ui/compare-method/region-unrelated.stderr
+++ b/src/test/ui/compare-method/region-unrelated.stderr
@@ -1,18 +1,18 @@
 error[E0276]: impl has stricter requirements than trait
-  --> $DIR/region-unrelated.rs:22:5
+  --> $DIR/region-unrelated.rs:23:5
    |
-17 |     fn foo() where T: 'a;
+18 |     fn foo() where T: 'a;
    |     --------------------- definition of `foo` from trait
 ...
-22 |     fn foo() where V: 'a { }
+23 |     fn foo() where V: 'a { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ impl has extra requirement `V: 'a`
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #37166 <https://github.com/rust-lang/rust/issues/37166>
 note: lint level defined here
-  --> $DIR/region-unrelated.rs:12:9
+  --> $DIR/region-unrelated.rs:13:9
    |
-12 | #![deny(extra_requirement_in_impl)]
+13 | #![deny(extra_requirement_in_impl)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error


### PR DESCRIPTION
Rebase of #26684. Fix #25871.

Following @huonw's suggestion, warning is disabled for intrinsics and lang items. An example of unused but not incorrect type parameters is `core::intrinsics::size_of` for intrinsics and `core::marker::PhantomData` for lang items.

Following @nikomatsakis's suggestion, warning can be silenced by prefixing the underscore as in `_T`. As pointed out, `fn _is_sync_send<_T: Sync+Send>() {}` is analogous to `fn drop<T>(_x: T) {}` for unused variables.