### PR TITLE
Use literal 5 instead of five in book section 4.1

### DIFF
--- a/src/doc/book/variable-bindings.md
+++ b/src/doc/book/variable-bindings.md
@@ -47,7 +47,7 @@ let x: i32 = 5;
 ```
 
 If I asked you to read this out loud to the rest of the class, you’d say “`x`
-is a binding with the type `i32` and the value `five`.”
+is a binding with the type `i32` and the value `5`.”
 
 In this case we chose to represent `x` as a 32-bit signed integer. Rust has
 many different primitive integer types. They begin with `i` for signed integers


### PR DESCRIPTION
The other two code snippets in this sentence are valid code, so it makes more sense to use the literal `5` rather than the invalid symbol `five`.