### PR TITLE
Use "radices" instead of "radicum"

### DIFF
--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -238,7 +238,7 @@ impl fmt::Display for CharTryFromError {
 /// A 'radix' here is sometimes also called a 'base'. A radix of two
 /// indicates a binary number, a radix of ten, decimal, and a radix of
 /// sixteen, hexadecimal, to give some common values. Arbitrary
-/// radicum are supported.
+/// radices are supported.
 ///
 /// `from_digit()` will return `None` if the input is not a digit in
 /// the given radix.

--- a/src/librustc_unicode/char.rs
+++ b/src/librustc_unicode/char.rs
@@ -138,7 +138,7 @@ impl char {
     /// A 'radix' here is sometimes also called a 'base'. A radix of two
     /// indicates a binary number, a radix of ten, decimal, and a radix of
     /// sixteen, hexadecimal, to give some common values. Arbitrary
-    /// radicum are supported.
+    /// radices are supported.
     ///
     /// Compared to `is_numeric()`, this function only recognizes the characters
     /// `0-9`, `a-z` and `A-Z`.
@@ -190,7 +190,7 @@ impl char {
     /// A 'radix' here is sometimes also called a 'base'. A radix of two
     /// indicates a binary number, a radix of ten, decimal, and a radix of
     /// sixteen, hexadecimal, to give some common values. Arbitrary
-    /// radicum are supported.
+    /// radices are supported.
     ///
     /// 'Digit' is defined to be only the following characters:
     ///


### PR DESCRIPTION
The correct plural of "radix" is "radices" or "radixes", not "radicum".