### PR TITLE
Fix two small issues in iterator docs

### DIFF
--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -225,12 +225,12 @@
 //! often called 'iterator adapters', as they're a form of the 'adapter
 //! pattern'.
 //!
-//! Common iterator adapters include [`map()`], [`take()`], and [`collect()`].
+//! Common iterator adapters include [`map()`], [`take()`], and [`filter()`].
 //! For more, see their documentation.
 //!
 //! [`map()`]: trait.Iterator.html#method.map
 //! [`take()`]: trait.Iterator.html#method.take
-//! [`collect()`]: trait.Iterator.html#method.collect
+//! [`filter()`]: trait.Iterator.html#method.filter
 //!
 //! # Laziness
 //!
@@ -268,7 +268,7 @@
 //! [`map()`]: trait.Iterator.html#method.map
 //!
 //! The two most common ways to evaluate an iterator are to use a `for` loop
-//! like this, or using the [`collect()`] adapter to produce a new collection.
+//! like this, or using the [`collect()`] method to produce a new collection.
 //!
 //! [`collect()`]: trait.Iterator.html#method.collect
 //!

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -920,7 +920,7 @@ unsafe impl<A, B> TrustedLen for Zip<A, B>
 /// you can also [`map()`] backwards:
 ///
 /// ```rust
-/// let v: Vec<i32> = vec![1, 2, 3].into_iter().rev().map(|x| x + 1).collect();
+/// let v: Vec<i32> = vec![1, 2, 3].into_iter().map(|x| x + 1).rev().collect();
 ///
 /// assert_eq!(v, [4, 3, 2]);
 /// ```


### PR DESCRIPTION
- `collect()` is a regular method, not an adaptor (does not return an Iterator). I just randomly picked `filter` as a third common adaptor to mention instead.
- Fix example in `Map`'s docs so that it uses the DoubleEndedIterator implementation