### PR TITLE
std: make compilation of libpanic_unwind optional via a Cargo feature

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -507,7 +507,7 @@ impl Build {
     /// Get the space-separated set of activated features for the standard
     /// library.
     fn std_features(&self) -> String {
-        let mut features = String::new();
+        let mut features = "panic-unwind".to_string();
         if self.config.debug_jemalloc {
             features.push_str(" debug-jemalloc");
         }

--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["dylib", "rlib"]
 alloc = { path = "../liballoc" }
 alloc_jemalloc = { path = "../liballoc_jemalloc", optional = true }
 alloc_system = { path = "../liballoc_system" }
-panic_unwind = { path = "../libpanic_unwind" }
+panic_unwind = { path = "../libpanic_unwind", optional = true }
 panic_abort = { path = "../libpanic_abort" }
 collections = { path = "../libcollections" }
 core = { path = "../libcore" }
@@ -29,5 +29,6 @@ gcc = "0.3.27"
 
 [features]
 backtrace = []
-jemalloc = ["alloc_jemalloc"]
 debug-jemalloc = ["alloc_jemalloc/debug"]
+jemalloc = ["alloc_jemalloc"]
+panic-unwind = ["panic_unwind"]

--- a/src/rustc/std_shim/Cargo.toml
+++ b/src/rustc/std_shim/Cargo.toml
@@ -45,6 +45,7 @@ core = { path = "../../libcore" }
 
 # Reexport features from std
 [features]
-jemalloc = ["std/jemalloc"]
-debug-jemalloc = ["std/debug-jemalloc"]
 backtrace = ["std/backtrace"]
+debug-jemalloc = ["std/debug-jemalloc"]
+jemalloc = ["std/jemalloc"]
+panic-unwind = ["std/panic-unwind"]


### PR DESCRIPTION
with this feature disabled, you can (Cargo) compile std with
"panic=abort"

rustbuild will build std with this feature enabled, to maintain the
status quo

fixes #37252

r? @alexcrichton 