### PR TITLE
std: link to liballoc_system if compiled without the jemalloc feature

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -172,6 +172,7 @@ TARGET_SPECIFIC_alloc_jemalloc := 1
 DOC_CRATES := std alloc collections core libc std_unicode
 
 ifeq ($(CFG_DISABLE_JEMALLOC),)
+RUSTFLAGS_std := --cfg 'feature="jemalloc"'
 RUSTFLAGS_rustc_back := --cfg 'feature="jemalloc"'
 endif
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -221,7 +221,7 @@
 
 // Always use alloc_system during stage0 since jemalloc might be unavailable or
 // disabled (Issue #30592)
-#![cfg_attr(stage0, feature(alloc_system))]
+#![cfg_attr(any(stage0, not(feature = "jemalloc")), feature(alloc_system))]
 
 // Turn warnings into errors, but only after stage0, where it can be useful for
 // code to emit warnings during language transitions
@@ -331,7 +331,7 @@ extern crate libc;
 // We always need an unwinder currently for backtraces
 extern crate unwind;
 
-#[cfg(stage0)]
+#[cfg(any(stage0, not(feature = "jemalloc")))]
 extern crate alloc_system;
 
 // compiler-rt intrinsics


### PR DESCRIPTION
fixes #36501

r? @alexcrichton 