### PR TITLE
Don't use length in Slice::hash().

### DIFF
--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -443,8 +443,8 @@ impl<'tcx> serialize::UseSpecializedDecodable for Ty<'tcx> {}
 /// A wrapper for slices with the additional invariant
 /// that the slice is interned and no other slice with
 /// the same contents can exist in the same context.
-/// This means we can use pointer + length for both
-/// equality comparisons and hashing.
+/// This means we can use pointer alone for both equality
+/// comparisons and hashing.
 #[derive(Debug, RustcEncodable)]
 pub struct Slice<T>([T]);
 
@@ -458,7 +458,7 @@ impl<T> Eq for Slice<T> {}
 
 impl<T> Hash for Slice<T> {
     fn hash<H: Hasher>(&self, s: &mut H) {
-        (self.as_ptr(), self.len()).hash(s)
+        self.as_ptr().hash(s)
     }
 }
 


### PR DESCRIPTION
This doesn't provide a measurable speed-up the way I hoped it would, but
it can't hurt and it also makes `hash()` consistent with `eq()` in
ignoring the length.

r? @eddyb 