### PR TITLE
[LLVM 4.0] OptimizationDiagnostic FFI forward compatibility

### DIFF
--- a/src/librustc_llvm/ffi.rs
+++ b/src/librustc_llvm/ffi.rs
@@ -1823,7 +1823,7 @@ extern "C" {
                                                 pass_name_out: *mut *const c_char,
                                                 function_out: *mut ValueRef,
                                                 debugloc_out: *mut DebugLocRef,
-                                                message_out: *mut TwineRef);
+                                                message_out: RustStringRef);
     pub fn LLVMRustUnpackInlineAsmDiagnostic(DI: DiagnosticInfoRef,
                                              cookie_out: *mut c_uint,
                                              message_out: *mut TwineRef,

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -417,7 +417,7 @@ unsafe extern "C" fn diagnostic_handler(info: DiagnosticInfoRef, user: *mut c_vo
                                                 opt.kind.describe(),
                                                 pass_name,
                                                 if loc.is_empty() { "[unknown]" } else { &*loc },
-                                                llvm::twine_to_string(opt.message)));
+                                                opt.message));
             }
         }
 

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -871,16 +871,21 @@ LLVMRustUnpackOptimizationDiagnostic(
     const char **pass_name_out,
     LLVMValueRef *function_out,
     LLVMDebugLocRef *debugloc_out,
-    LLVMTwineRef *message_out)
+    RustStringRef message_out)
 {
     // Undefined to call this not on an optimization diagnostic!
     llvm::DiagnosticInfoOptimizationBase *opt
         = static_cast<llvm::DiagnosticInfoOptimizationBase*>(unwrap(di));
 
+#if LLVM_VERSION_GE(4, 0)
+    *pass_name_out = opt->getPassName().data();
+#else
     *pass_name_out = opt->getPassName();
+#endif
     *function_out = wrap(&opt->getFunction());
     *debugloc_out = wrap(&opt->getDebugLoc());
-    *message_out = wrap(&opt->getMsg());
+    raw_rust_string_ostream os(message_out);
+    os << opt->getMsg();
 }
 
 extern "C" void


### PR DESCRIPTION
- getMsg() changed to return std::string by-value. Fix: copy the data to a rust String during unpacking.
- getPassName() changed to return StringRef

cc #37609