### PR TITLE
Delay error reporting of filename mismatch.

### DIFF
--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -344,6 +344,7 @@ impl<'a> CrateLoader<'a> {
                 rejected_via_triple: vec![],
                 rejected_via_kind: vec![],
                 rejected_via_version: vec![],
+                rejected_via_filename: vec![],
                 should_match_name: true,
                 is_proc_macro: Some(false),
             };
@@ -359,6 +360,7 @@ impl<'a> CrateLoader<'a> {
                     rejected_via_triple: vec![],
                     rejected_via_kind: vec![],
                     rejected_via_version: vec![],
+                    rejected_via_filename: vec![],
                     is_proc_macro: Some(true),
                     ..locate_ctxt
                 };
@@ -502,6 +504,7 @@ impl<'a> CrateLoader<'a> {
             rejected_via_triple: vec![],
             rejected_via_kind: vec![],
             rejected_via_version: vec![],
+            rejected_via_filename: vec![],
             should_match_name: true,
             is_proc_macro: None,
         };


### PR DESCRIPTION
When cross compiling with procedural macros, the crate loader starts by
looking for a target crate, before trying with a host crate.

Rather than emitting an error immediately if the host and target
extension differ, the compiler should delay it until both attempts have
failed.

Fixes #37899