### PR TITLE
Don't apply msvc link opts for non-opt build

### DIFF
--- a/src/librustc_trans/back/linker.rs
+++ b/src/librustc_trans/back/linker.rs
@@ -320,7 +320,16 @@ impl<'a> Linker for MsvcLinker<'a> {
     }
 
     fn gc_sections(&mut self, _keep_metadata: bool) {
-        self.cmd.arg("/OPT:REF,ICF");
+        // MSVC's ICF (Identical COMDAT Folding) link optimization is
+        // slow for Rust and thus we disable it by default when not in
+        // optimization build.
+        if self.sess.opts.optimize != config::OptLevel::No {
+            self.cmd.arg("/OPT:REF,ICF");
+        } else {
+            // It is necessary to specify NOICF here, because /OPT:REF
+            // implies ICF by default.
+            self.cmd.arg("/OPT:REF,NOICF");
+        }
     }
 
     fn link_dylib(&mut self, lib: &str) {

--- a/src/test/run-make/codegen-options-parsing/Makefile
+++ b/src/test/run-make/codegen-options-parsing/Makefile
@@ -25,7 +25,7 @@ all:
 
 	# Should not link dead code...
 	$(RUSTC) -Z print-link-args dummy.rs 2>&1 | \
-		grep -e '--gc-sections' -e '-dead_strip' -e '/OPT:REF,ICF'
+		grep -e '--gc-sections' -e '-dead_strip' -e '/OPT:REF'
 	# ... unless you specifically ask to keep it
 	$(RUSTC) -Z print-link-args -C link-dead-code dummy.rs 2>&1 | \
-		(! grep -e '--gc-sections' -e '-dead_strip' -e '/OPT:REF,ICF')
+		(! grep -e '--gc-sections' -e '-dead_strip' -e '/OPT:REF')


### PR DESCRIPTION
`/OPT:REF,ICF` sometimes takes lots of time. It makes no sense to apply them when doing debug build. MSVC's linker by default disables these optimizations when `/DEBUG` is specified, unless they are explicitly passed.