### PR TITLE
Follow our own recommendations in the examples

### DIFF
--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -109,7 +109,7 @@ pub trait Error: Debug + Display {
     ///
     /// impl Error for SuperError {
     ///     fn description(&self) -> &str {
-    ///         "I'm the superhero of errors!"
+    ///         "I'm the superhero of errors"
     ///     }
     ///
     ///     fn cause(&self) -> Option<&Error> {
@@ -128,7 +128,7 @@ pub trait Error: Debug + Display {
     ///
     /// impl Error for SuperErrorSideKick {
     ///     fn description(&self) -> &str {
-    ///         "I'm SuperError side kick!"
+    ///         "I'm SuperError side kick"
     ///     }
     /// }
     ///


### PR DESCRIPTION
Remove exclamation marks from the the example error descriptions:
> The description [...] should not contain newlines or sentence-ending punctuation