### PR TITLE
Fix error explanation formatting

### DIFF
--- a/src/librustc_metadata/diagnostics.rs
+++ b/src/librustc_metadata/diagnostics.rs
@@ -57,9 +57,10 @@ An unknown "kind" was specified for a link attribute. Erroneous code example:
 
 Please specify a valid "kind" value, from one of the following:
 
- - static
- - dylib
- - framework
+ * static
+ * dylib
+ * framework
+
 "##,
 
 E0459: r##"

--- a/src/librustc_metadata/diagnostics.rs
+++ b/src/librustc_metadata/diagnostics.rs
@@ -56,9 +56,10 @@ An unknown "kind" was specified for a link attribute. Erroneous code example:
 ```
 
 Please specify a valid "kind" value, from one of the following:
- * static
- * dylib
- * framework
+
+ - static
+ - dylib
+ - framework
 "##,
 
 E0459: r##"

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -1377,8 +1377,9 @@ let x = |_| {}; // error: cannot determine a type for this expression
 ```
 
 You have two possibilities to solve this situation:
- * Give an explicit definition of the expression
- * Infer the expression
+
+ - Give an explicit definition of the expression
+ - Infer the expression
 
 Examples:
 

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -1378,8 +1378,8 @@ let x = |_| {}; // error: cannot determine a type for this expression
 
 You have two possibilities to solve this situation:
 
- - Give an explicit definition of the expression
- - Infer the expression
+ * Give an explicit definition of the expression
+ * Infer the expression
 
 Examples:
 

--- a/src/libsyntax/diagnostic_list.rs
+++ b/src/libsyntax/diagnostic_list.rs
@@ -65,8 +65,8 @@ fn main() {}
 
 The `inline` attribute only supports two arguments:
 
- - always
- - never
+ * always
+ * never
 
 All other arguments given to the `inline` attribute will return this error.
 Example:
@@ -121,9 +121,9 @@ pub fn main() {}
 
 The `cfg` attribute supports only three kinds of predicates:
 
- - any
- - all
- - not
+ * any
+ * all
+ * not
 
 Example:
 

--- a/src/libsyntax/diagnostic_list.rs
+++ b/src/libsyntax/diagnostic_list.rs
@@ -65,8 +65,8 @@ fn main() {}
 
 The `inline` attribute only supports two arguments:
 
- * always
- * never
+ - always
+ - never
 
 All other arguments given to the `inline` attribute will return this error.
 Example:
@@ -121,9 +121,9 @@ pub fn main() {}
 
 The `cfg` attribute supports only three kinds of predicates:
 
- * any
- * all
- * not
+ - any
+ - all
+ - not
 
 Example:
 


### PR DESCRIPTION
Errors E0101, E0458, E0535 and E0537 have incorrectly formatted bulleted lists in their explanations. As the result, they are not rendered as lists in the documentation.

The fix applies the correct formatting to those lists.
