### PR TITLE
Add rustbuild command `bench`

### DIFF
--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -49,6 +49,10 @@ pub enum Subcommand {
         paths: Vec<PathBuf>,
         test_args: Vec<String>,
     },
+    Bench {
+        paths: Vec<PathBuf>,
+        test_args: Vec<String>,
+    },
     Clean,
     Dist {
         install: bool,
@@ -141,6 +145,7 @@ Arguments:
                    command == "dist" ||
                    command == "doc" ||
                    command == "test" ||
+                   command == "bench" ||
                    command == "clean"  {
                     println!("Available invocations:");
                     if args.iter().any(|a| a == "-v") {
@@ -163,6 +168,7 @@ println!("\
 Subcommands:
     build       Compile either the compiler or libraries
     test        Build and run some test suites
+    bench       Build and run some benchmarks
     doc         Build documentation
     clean       Clean out build directories
     dist        Build and/or install distribution artifacts
@@ -206,6 +212,14 @@ To learn more about a subcommand, run `./x.py <command> -h`
                 opts.optmulti("", "test-args", "extra arguments", "ARGS");
                 m = parse(&opts);
                 Subcommand::Test {
+                    paths: remaining_as_path(&m),
+                    test_args: m.opt_strs("test-args"),
+                }
+            }
+            "bench" => {
+                opts.optmulti("", "test-args", "extra arguments", "ARGS");
+                m = parse(&opts);
+                Subcommand::Bench {
                     paths: remaining_as_path(&m),
                     test_args: m.opt_strs("test-args"),
                 }
@@ -259,7 +273,8 @@ To learn more about a subcommand, run `./x.py <command> -h`
 impl Subcommand {
     pub fn test_args(&self) -> Vec<&str> {
         match *self {
-            Subcommand::Test { ref test_args, .. } => {
+            Subcommand::Test { ref test_args, .. } |
+            Subcommand::Bench { ref test_args, .. } => {
                 test_args.iter().flat_map(|s| s.split_whitespace()).collect()
             }
             _ => Vec::new(),

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -141,6 +141,7 @@ struct Crate {
     doc_step: String,
     build_step: String,
     test_step: String,
+    bench_step: String,
 }
 
 /// The various "modes" of invoking Cargo.
@@ -457,7 +458,8 @@ impl Build {
         if self.config.verbose || self.flags.verbose {
             cargo.arg("-v");
         }
-        if self.config.rust_optimize {
+        // FIXME: cargo bench does not accept `--release`
+        if self.config.rust_optimize && cmd != "bench" {
             cargo.arg("--release");
         }
         if self.config.vendor {

--- a/src/bootstrap/metadata.rs
+++ b/src/bootstrap/metadata.rs
@@ -70,6 +70,7 @@ fn build_krate(build: &mut Build, krate: &str) {
                 build_step: format!("build-crate-{}", package.name),
                 doc_step: format!("doc-crate-{}", package.name),
                 test_step: format!("test-crate-{}", package.name),
+                bench_step: format!("bench-crate-{}", package.name),
                 name: package.name,
                 deps: Vec::new(),
                 path: path,

--- a/src/libcollections/Cargo.toml
+++ b/src/libcollections/Cargo.toml
@@ -15,3 +15,7 @@ rustc_unicode = { path = "../librustc_unicode" }
 [[test]]
 name = "collectionstest"
 path = "../libcollectionstest/lib.rs"
+
+[[bench]]
+name = "collectionstest"
+path = "../libcollectionstest/lib.rs"

--- a/src/libcompiler_builtins/Cargo.toml
+++ b/src/libcompiler_builtins/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.0.0"
 name = "compiler_builtins"
 path = "lib.rs"
 test = false
+bench = false
 
 [dependencies]
 core = { path = "../libcore" }

--- a/src/libcore/Cargo.toml
+++ b/src/libcore/Cargo.toml
@@ -7,7 +7,12 @@ version = "0.0.0"
 name = "core"
 path = "lib.rs"
 test = false
+bench = false
 
 [[test]]
+name = "coretest"
+path = "../libcoretest/lib.rs"
+
+[[bench]]
 name = "coretest"
 path = "../libcoretest/lib.rs"

--- a/src/libpanic_abort/Cargo.toml
+++ b/src/libpanic_abort/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.0.0"
 [lib]
 path = "lib.rs"
 test = false
+bench = false
 
 [dependencies]
 core = { path = "../libcore" }

--- a/src/libpanic_unwind/Cargo.toml
+++ b/src/libpanic_unwind/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.0.0"
 [lib]
 path = "lib.rs"
 test = false
+bench = false
 
 [dependencies]
 alloc = { path = "../liballoc" }

--- a/src/librustc_unicode/Cargo.toml
+++ b/src/librustc_unicode/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.0.0"
 name = "rustc_unicode"
 path = "lib.rs"
 test = false
+bench = false
 
 [dependencies]
 core = { path = "../libcore" }

--- a/src/libunwind/Cargo.toml
+++ b/src/libunwind/Cargo.toml
@@ -8,6 +8,7 @@ build = "build.rs"
 name = "unwind"
 path = "lib.rs"
 test = false
+bench = false
 
 [dependencies]
 core = { path = "../libcore" }

--- a/src/rustc/libc_shim/Cargo.toml
+++ b/src/rustc/libc_shim/Cargo.toml
@@ -16,6 +16,7 @@ build = "build.rs"
 name = "libc"
 path = "../../liblibc/src/lib.rs"
 test = false
+bench = false
 
 [dependencies]
 core = { path = "../../libcore" }


### PR DESCRIPTION
Add command bench to rustbuild, so that `./x.py bench <path>` can compile and run benchmarks.

`./x.py bench --stage 1 src/libcollections` and `./x.py bench --stage 1 src/libstd` should both compile well. Just `./x.py bench` runs all benchmarks for the libstd crates.

Fixes #37897 