### PR TITLE
Optimize signed integer saturating_mul

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -686,13 +686,15 @@ macro_rules! int_impl {
         #[stable(feature = "wrapping", since = "1.7.0")]
         #[inline]
         pub fn saturating_mul(self, other: Self) -> Self {
-            self.checked_mul(other).unwrap_or_else(|| {
-                if (self < 0 && other < 0) || (self > 0 && other > 0) {
-                    Self::max_value()
-                } else {
-                    Self::min_value()
-                }
-            })
+            // Result of exclusive or of two values has the same sign
+            // as infinite precision multiplication.
+            let overflow_value = if (self ^ other).is_negative() {
+                Self::min_value()
+            } else {
+                Self::max_value()
+            };
+
+            self.checked_mul(other).unwrap_or(overflow_value)
         }
 
         /// Wrapping (modular) addition. Computes `self + other`,

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -688,13 +688,11 @@ macro_rules! int_impl {
         pub fn saturating_mul(self, other: Self) -> Self {
             // Result of exclusive or of two values has the same sign
             // as infinite precision multiplication.
-            let overflow_value = if (self ^ other).is_negative() {
+            self.checked_mul(other).unwrap_or_else(|| if (self ^ other).is_negative() {
                 Self::min_value()
             } else {
                 Self::max_value()
-            };
-
-            self.checked_mul(other).unwrap_or(overflow_value)
+            })
         }
 
         /// Wrapping (modular) addition. Computes `self + other`,

--- a/src/libstd/num.rs
+++ b/src/libstd/num.rs
@@ -95,6 +95,14 @@ mod tests {
     }
 
     #[test]
+    fn test_saturating_mul_int() {
+        use isize::{MIN, MAX};
+        assert_eq!(2i32.saturating_mul(-2), -4);
+        assert_eq!(MIN.saturating_mul(MIN), MAX);
+        assert_eq!(MAX.saturating_mul(MIN), MIN);
+    }
+
+    #[test]
     fn test_checked_add() {
         let five_less = usize::MAX - 5;
         assert_eq!(five_less.checked_add(0), Some(usize::MAX - 5));


### PR DESCRIPTION
Previous version of saturating_mul was poorly optimized by LLVM, and had lots of branches (which are slow if CPU mispredicts them). That also had a side-effect of needlessly making code larger.

```asm
    mov     eax, edi
    imul    eax, esi
    jno     .LBB1_6
    mov     eax, -2147483648
    test    edi, edi
    js      .LBB1_4
    je      .LBB1_6
    test    esi, esi
    jg      .LBB1_5
    jmp     .LBB1_6
.LBB1_4:
    test    esi, esi
    jns     .LBB1_6
.LBB1_5:
    mov     eax, 2147483647
.LBB1_6:
    ret
```

However, it's possible to have branch-less saturating integer multiplication by using the fact that sign of exclusive xor is the same as infinite precision multiplication. This simplifies a complex number comparison function into a one simple test that can be easily implemented in assembly as a conditional move.

This assembly does also use the fact that minimal value is just one bigger than maximal value in signed representation. This wasn't done in the code, because LLVM can optimize that.

```asm
    mov     eax, esi
    xor     eax, edi
    shr     eax, 31
    add     eax, 2147483647
    imul    edi, esi
    cmovo   edi, eax
    mov     eax, edi
    ret
```