### PR TITLE
impl Sum/Product for more types, to avoid overflow/panic

### DIFF
--- a/src/libcore/iter/traits.rs
+++ b/src/libcore/iter/traits.rs
@@ -663,6 +663,79 @@ macro_rules! float_sum_product {
 integer_sum_product! { i8 i16 i32 i64 isize u8 u16 u32 u64 usize }
 float_sum_product! { f32 f64 }
 
+// $ret = $item + $item + ...
+// $ret = $item * $item * ...
+macro_rules! num_sum_product_ex {
+    ($(($ret:ty, $item:ty))*) => ($(
+        #[unstable(feature = "sum_product_ex", issue = "0")]
+        impl Sum<$item> for $ret {
+            fn sum<I: Iterator<Item=$item>>(iter: I) -> $ret {
+                iter.fold(0 as $ret, |a, b| Add::add(a, b as $ret))
+            }
+        }
+
+        #[unstable(feature = "sum_product_ex", issue = "0")]
+        impl Product<$item> for $ret {
+            fn product<I: Iterator<Item=$item>>(iter: I) -> $ret {
+                iter.fold(1 as $ret, |a, b| Mul::mul(a, b as $ret))
+            }
+        }
+
+        #[unstable(feature = "sum_product_ex", issue = "0")]
+        impl<'a> Sum<&'a $item> for $ret {
+            fn sum<I: Iterator<Item=&'a $item>>(iter: I) -> $ret {
+                iter.fold(0 as $ret, |a, b| Add::add(a, *b as $ret))
+            }
+        }
+
+        #[unstable(feature = "sum_product_ex", issue = "0")]
+        impl<'a> Product<&'a $item> for $ret {
+            fn product<I: Iterator<Item=&'a $item>>(iter: I) -> $ret {
+                iter.fold(1 as $ret, |a, b| Mul::mul(a, *b as $ret))
+            }
+        }
+    )*);
+}
+
+num_sum_product_ex!((f64,f32) (i64,i32) (i64,i16) (i64,i8) (u64,u32) (u64,u16) (u64,u8));
+
+// Wrapping<$ret> = Wrapping<$item> + Wrapping<$item> + ...
+// Wrapping<$ret> = Wrapping<$item> * Wrapping<$item> * ...
+macro_rules! num_sum_product_ex_wrapping {
+    ($(($ret:ty, $item:ty))*) => ($(
+        #[unstable(feature = "sum_product_ex", issue = "0")]
+        impl Sum<Wrapping<$item>> for Wrapping<$ret> {
+            fn sum<I: Iterator<Item=Wrapping<$item>>>(iter: I) -> Wrapping<$ret> {
+                iter.fold(Wrapping(0 as $ret), |a, b| Wrapping(a.0.wrapping_add(b.0 as $ret)))
+            }
+        }
+
+        #[unstable(feature = "sum_product_ex", issue = "0")]
+        impl Product<Wrapping<$item>> for Wrapping<$ret> {
+            fn product<I: Iterator<Item=Wrapping<$item>>>(iter: I) -> Wrapping<$ret> {
+                iter.fold(Wrapping(1 as $ret), |a, b| Wrapping(a.0.wrapping_mul(b.0 as $ret)))
+            }
+        }
+
+        #[unstable(feature = "sum_product_ex", issue = "0")]
+        impl<'a> Sum<&'a Wrapping<$item>> for Wrapping<$ret> {
+            fn sum<I: Iterator<Item=&'a Wrapping<$item>>>(iter: I) -> Wrapping<$ret> {
+                iter.fold(Wrapping(0 as $ret), |a, b| Wrapping(a.0.wrapping_add(b.0 as $ret)))
+            }
+        }
+
+        #[unstable(feature = "sum_product_ex", issue = "0")]
+        impl<'a> Product<&'a Wrapping<$item>> for Wrapping<$ret> {
+            fn product<I: Iterator<Item=&'a Wrapping<$item>>>(iter: I) -> Wrapping<$ret> {
+                iter.fold(Wrapping(1 as $ret), |a, b| Wrapping(a.0.wrapping_mul(b.0 as $ret)))
+            }
+        }
+    )*);
+}
+
+num_sum_product_ex_wrapping!((i64,i32) (i64,i16) (i64,i8) (u64,u32) (u64,u16) (u64,u8));
+
+
 /// An iterator that always continues to yield `None` when exhausted.
 ///
 /// Calling next on a fused iterator that has returned `None` once is guaranteed

--- a/src/libcore/iter/traits.rs
+++ b/src/libcore/iter/traits.rs
@@ -699,43 +699,6 @@ macro_rules! num_sum_product_ex {
 
 num_sum_product_ex!((f64,f32) (i64,i32) (i64,i16) (i64,i8) (u64,u32) (u64,u16) (u64,u8));
 
-// Wrapping<$ret> = Wrapping<$item> + Wrapping<$item> + ...
-// Wrapping<$ret> = Wrapping<$item> * Wrapping<$item> * ...
-macro_rules! num_sum_product_ex_wrapping {
-    ($(($ret:ty, $item:ty))*) => ($(
-        #[unstable(feature = "sum_product_ex", issue = "0")]
-        impl Sum<Wrapping<$item>> for Wrapping<$ret> {
-            fn sum<I: Iterator<Item=Wrapping<$item>>>(iter: I) -> Wrapping<$ret> {
-                iter.fold(Wrapping(0 as $ret), |a, b| Wrapping(a.0.wrapping_add(b.0 as $ret)))
-            }
-        }
-
-        #[unstable(feature = "sum_product_ex", issue = "0")]
-        impl Product<Wrapping<$item>> for Wrapping<$ret> {
-            fn product<I: Iterator<Item=Wrapping<$item>>>(iter: I) -> Wrapping<$ret> {
-                iter.fold(Wrapping(1 as $ret), |a, b| Wrapping(a.0.wrapping_mul(b.0 as $ret)))
-            }
-        }
-
-        #[unstable(feature = "sum_product_ex", issue = "0")]
-        impl<'a> Sum<&'a Wrapping<$item>> for Wrapping<$ret> {
-            fn sum<I: Iterator<Item=&'a Wrapping<$item>>>(iter: I) -> Wrapping<$ret> {
-                iter.fold(Wrapping(0 as $ret), |a, b| Wrapping(a.0.wrapping_add(b.0 as $ret)))
-            }
-        }
-
-        #[unstable(feature = "sum_product_ex", issue = "0")]
-        impl<'a> Product<&'a Wrapping<$item>> for Wrapping<$ret> {
-            fn product<I: Iterator<Item=&'a Wrapping<$item>>>(iter: I) -> Wrapping<$ret> {
-                iter.fold(Wrapping(1 as $ret), |a, b| Wrapping(a.0.wrapping_mul(b.0 as $ret)))
-            }
-        }
-    )*);
-}
-
-num_sum_product_ex_wrapping!((i64,i32) (i64,i16) (i64,i8) (u64,u32) (u64,u16) (u64,u8));
-
-
 /// An iterator that always continues to yield `None` when exhausted.
 ///
 /// Calling next on a fused iterator that has returned `None` once is guaranteed

--- a/src/libcoretest/iter.rs
+++ b/src/libcoretest/iter.rs
@@ -10,7 +10,6 @@
 
 use core::iter::*;
 use core::{i8, i16, u16, i32, u32, f32, isize, usize};
-use core::num::Wrapping;
 
 use test::Bencher;
 use test::black_box;
@@ -578,15 +577,6 @@ fn test_iterator_sum() {
     let v = vec![n as f32, n, n];
     assert_eq!(v.iter().sum::<f64>(), (n as f64) * 3.0);
     assert_eq!(v.into_iter().sum::<f64>(), (n as f64) * 3.0);
-
-    // wrapping
-    let v = vec![Wrapping(100i8), Wrapping(50i8)];
-    assert_eq!(v.iter().sum::<Wrapping<i64>>(), Wrapping(150i64));
-    assert_eq!(v.into_iter().sum::<Wrapping<i64>>(), Wrapping(150i64));
-
-    let v = vec![Wrapping(100u8), Wrapping(200u8)];
-    assert_eq!(v.iter().sum::<Wrapping<u64>>(), Wrapping(300u64));
-    assert_eq!(v.into_iter().sum::<Wrapping<u64>>(), Wrapping(300u64));
 }
 
 #[test]
@@ -629,15 +619,6 @@ fn test_iterator_product() {
     let v = vec![n as f32, n];
     assert_eq!(v.iter().product::<f64>(), (n as f64).powi(2));
     assert_eq!(v.into_iter().product::<f64>(), (n as f64).powi(2));
-
-    // wrapping
-    let v = vec![Wrapping(100i8), Wrapping(50i8)];
-    assert_eq!(v.iter().product::<Wrapping<i64>>(), Wrapping(5000i64));
-    assert_eq!(v.into_iter().product::<Wrapping<i64>>(), Wrapping(5000i64));
-
-    let v = vec![Wrapping(100u8), Wrapping(200u8)];
-    assert_eq!(v.iter().product::<Wrapping<u64>>(), Wrapping(20000u64));
-    assert_eq!(v.into_iter().product::<Wrapping<u64>>(), Wrapping(20000u64));
 }
 
 #[test]

--- a/src/libcoretest/iter.rs
+++ b/src/libcoretest/iter.rs
@@ -9,8 +9,8 @@
 // except according to those terms.
 
 use core::iter::*;
-use core::{i8, i16, isize};
-use core::usize;
+use core::{i8, i16, u16, i32, u32, f32, isize, usize};
+use core::num::Wrapping;
 
 use test::Bencher;
 use test::black_box;
@@ -544,6 +544,49 @@ fn test_iterator_sum() {
     assert_eq!(v[..4].iter().cloned().sum::<i32>(), 6);
     assert_eq!(v.iter().cloned().sum::<i32>(), 55);
     assert_eq!(v[..0].iter().cloned().sum::<i32>(), 0);
+
+    // sum values of type i8, get a result of type i64
+    let v = vec![100i8, 50];
+    assert_eq!(v.iter().sum::<i64>(), 150);
+    assert_eq!(v.into_iter().sum::<i64>(), 150);
+
+    let v = vec![200u8, 100];
+    assert_eq!(v.iter().sum::<u64>(), 300);
+    assert_eq!(v.into_iter().sum::<u64>(), 300);
+
+    let n = i16::MAX;
+    let v = vec![n as i16, n, n];
+    assert_eq!(v.iter().sum::<i64>(), (n as i64) * 3);
+    assert_eq!(v.into_iter().sum::<i64>(), (n as i64) * 3);
+
+    let n = u16::MAX;
+    let v = vec![n as u16, n, n];
+    assert_eq!(v.iter().sum::<u64>(), (n as u64) * 3);
+    assert_eq!(v.into_iter().sum::<u64>(), (n as u64) * 3);
+
+    let n = i32::MAX;
+    let v = vec![n as i32, n, n];
+    assert_eq!(v.iter().sum::<i64>(), (n as i64) * 3);
+    assert_eq!(v.into_iter().sum::<i64>(), (n as i64) * 3);
+
+    let n = u32::MAX;
+    let v = vec![n as u32, n, n];
+    assert_eq!(v.iter().sum::<u64>(), (n as u64) * 3);
+    assert_eq!(v.into_iter().sum::<u64>(), (n as u64) * 3);
+
+    let n = f32::MAX;
+    let v = vec![n as f32, n, n];
+    assert_eq!(v.iter().sum::<f64>(), (n as f64) * 3.0);
+    assert_eq!(v.into_iter().sum::<f64>(), (n as f64) * 3.0);
+
+    // wrapping
+    let v = vec![Wrapping(100i8), Wrapping(50i8)];
+    assert_eq!(v.iter().sum::<Wrapping<i64>>(), Wrapping(150i64));
+    assert_eq!(v.into_iter().sum::<Wrapping<i64>>(), Wrapping(150i64));
+
+    let v = vec![Wrapping(100u8), Wrapping(200u8)];
+    assert_eq!(v.iter().sum::<Wrapping<u64>>(), Wrapping(300u64));
+    assert_eq!(v.into_iter().sum::<Wrapping<u64>>(), Wrapping(300u64));
 }
 
 #[test]
@@ -552,6 +595,49 @@ fn test_iterator_product() {
     assert_eq!(v[..4].iter().cloned().product::<i32>(), 0);
     assert_eq!(v[1..5].iter().cloned().product::<i32>(), 24);
     assert_eq!(v[..0].iter().cloned().product::<i32>(), 1);
+
+    // product values of type i8, get a result of type i64
+    let v = vec![100i8, 50];
+    assert_eq!(v.iter().product::<i64>(), 5000);
+    assert_eq!(v.into_iter().product::<i64>(), 5000);
+
+    let v = vec![200u8, 100];
+    assert_eq!(v.iter().product::<u64>(), 20000);
+    assert_eq!(v.into_iter().product::<u64>(), 20000);
+
+    let n = i16::MAX;
+    let v = vec![n as i16, n, n];
+    assert_eq!(v.iter().product::<i64>(), (n as i64).pow(3));
+    assert_eq!(v.into_iter().product::<i64>(), (n as i64).pow(3));
+
+    let n = u16::MAX;
+    let v = vec![n as u16, n, n];
+    assert_eq!(v.iter().product::<u64>(), (n as u64).pow(3));
+    assert_eq!(v.into_iter().product::<u64>(), (n as u64).pow(3));
+
+    let n = i32::MAX;
+    let v = vec![n as i32, n];
+    assert_eq!(v.iter().product::<i64>(), (n as i64).pow(2));
+    assert_eq!(v.into_iter().product::<i64>(), (n as i64).pow(2));
+
+    let n = u32::MAX;
+    let v = vec![n as u32, n];
+    assert_eq!(v.iter().product::<u64>(), (n as u64).pow(2));
+    assert_eq!(v.into_iter().product::<u64>(), (n as u64).pow(2));
+
+    let n = f32::MAX;
+    let v = vec![n as f32, n];
+    assert_eq!(v.iter().product::<f64>(), (n as f64).powi(2));
+    assert_eq!(v.into_iter().product::<f64>(), (n as f64).powi(2));
+
+    // wrapping
+    let v = vec![Wrapping(100i8), Wrapping(50i8)];
+    assert_eq!(v.iter().product::<Wrapping<i64>>(), Wrapping(5000i64));
+    assert_eq!(v.into_iter().product::<Wrapping<i64>>(), Wrapping(5000i64));
+
+    let v = vec![Wrapping(100u8), Wrapping(200u8)];
+    assert_eq!(v.iter().product::<Wrapping<u64>>(), Wrapping(20000u64));
+    assert_eq!(v.into_iter().product::<Wrapping<u64>>(), Wrapping(20000u64));
 }
 
 #[test]


### PR DESCRIPTION
Currently, `Iterator::sum()` maybe likely overflow, and panic:

```rust
    let values = [126u8, 127, 128];
    let sum: u8 = values.iter().sum(); // panicked at 'attempt to add with overflow'
    println!("sum = {}", sum);
```

That is, the sum of `u8` values, may be likely out of range of type `u8`.

----

One of the possible solutions is, giving users the chance of selecting the return-type of `Iterator::sum()` and/or `Sum::sum()`:
```rust
let sum: u64 = values.iter().sum(); // returns `u64`, no overflow/panic
```
or
```rust
let sum = values.iter().sum::<u64>(); // returns `u64`, no overflow/panic
```

That's what this PR does.

- Implements `Sum<u64>` for `u8` `u16` `u32` and their borrowed and wrapping types
- Implements `Sum<i64>` for `i8` `i16` `i32` and their borrowed and wrapping types
- Implements `Sum<f64>` for `f32` and `&f32`

The same occurs to `Product<_>`.

By doing this, we may avoid most (but not all) overflow/panic.

----

Drawbacks: add many more trait-impls to libcore/libstd.
Unresolved questions: add more impls about `usize` `isize`?