### PR TITLE
[LLVM 4.0] Don't assume llvm::StringRef is null terminated

### DIFF
--- a/src/librustc_llvm/ffi.rs
+++ b/src/librustc_llvm/ffi.rs
@@ -1820,7 +1820,7 @@ extern "C" {
                                            DiagnosticContext: *mut c_void);
 
     pub fn LLVMRustUnpackOptimizationDiagnostic(DI: DiagnosticInfoRef,
-                                                pass_name_out: *mut *const c_char,
+                                                pass_name_out: RustStringRef,
                                                 function_out: *mut ValueRef,
                                                 debugloc_out: *mut DebugLocRef,
                                                 message_out: RustStringRef);

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -530,9 +530,11 @@ LLVMRustPrintPasses() {
     struct MyListener : PassRegistrationListener {
         void passEnumerate(const PassInfo *info) {
 #if LLVM_VERSION_GE(4, 0)
-            if (!info->getPassArgument().empty()) {
-                printf("%15s - %s\n", info->getPassArgument().data(),
-                       info->getPassName().data());
+            StringRef PassArg = info->getPassArgument();
+            StringRef PassName = info->getPassName();
+            if (!PassArg.empty()) {
+                printf("%15.*s - %.*s\n", PassArg.size(), PassArg.data(),
+                       PassName.size(), PassName.data());
             }
 #else
             if (info->getPassArgument() && *info->getPassArgument()) {

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -872,7 +872,7 @@ LLVMRustWriteTwineToString(LLVMTwineRef T, RustStringRef str) {
 extern "C" void
 LLVMRustUnpackOptimizationDiagnostic(
     LLVMDiagnosticInfoRef di,
-    const char **pass_name_out,
+    RustStringRef pass_name_out,
     LLVMValueRef *function_out,
     LLVMDebugLocRef *debugloc_out,
     RustStringRef message_out)
@@ -881,15 +881,12 @@ LLVMRustUnpackOptimizationDiagnostic(
     llvm::DiagnosticInfoOptimizationBase *opt
         = static_cast<llvm::DiagnosticInfoOptimizationBase*>(unwrap(di));
 
-#if LLVM_VERSION_GE(4, 0)
-    *pass_name_out = opt->getPassName().data();
-#else
-    *pass_name_out = opt->getPassName();
-#endif
+    raw_rust_string_ostream pass_name_os(pass_name_out);
+    pass_name_os << opt->getPassName();
     *function_out = wrap(&opt->getFunction());
     *debugloc_out = wrap(&opt->getDebugLoc());
-    raw_rust_string_ostream os(message_out);
-    os << opt->getMsg();
+    raw_rust_string_ostream message_os(message_out);
+    message_os << opt->getMsg();
 }
 
 extern "C" void


### PR DESCRIPTION
StringRefs have a length and their contents are not usually null-terminated. The solution is to either copy the string data (in `rustc_llvm::diagnostic`) or take the size into account (in LLVMRustPrintPasses).

I couldn't trigger a bug caused by this (apparently all the strings returned in practice are actually null-terminated) but this is more correct and more future-proof.

cc #37609