### PR TITLE
rustbuild: Cross-compiled LLVM depens on host

### DIFF
--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -98,6 +98,13 @@ pub fn build_rules(build: &Build) -> Rules {
          .run(move |s| compile::assemble_rustc(build, s.stage, s.target));
     rules.build("llvm", "src/llvm")
          .host(true)
+         .dep(move |s| {
+             if s.target == build.config.build {
+                 dummy(s, build)
+             } else {
+                 s.target(&build.config.build)
+             }
+         })
          .run(move |s| native::llvm(build, s.target));
 
     // ========================================================================


### PR DESCRIPTION
We use the host's tblgen so we need to be sure to always build the host first.

Closes #38037