### PR TITLE
print option to dump target spec as JSON

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1138,6 +1138,10 @@ mod opt {
 /// including metadata for each option, such as whether the option is
 /// part of the stable long-term interface for rustc.
 pub fn rustc_short_optgroups() -> Vec<RustcOptGroup> {
+    let mut print_opts = vec!["crate-name", "file-names", "sysroot", "cfg",
+                              "target-list", "target-cpus", "target-features",
+                              "relocation-models", "code-models"];
+
     vec![
         opt::flag_s("h", "help", "Display this message"),
         opt::multi_s("", "cfg", "Configure the compilation environment", "SPEC"),
@@ -1157,9 +1161,7 @@ pub fn rustc_short_optgroups() -> Vec<RustcOptGroup> {
                               the compiler to emit",
                  "[asm|llvm-bc|llvm-ir|obj|link|dep-info]"),
         opt::multi_s("", "print", "Comma separated list of compiler information to \
-                               print on stdout",
-                 "[crate-name|file-names|sysroot|cfg|target-list|target-cpus|\
-                   target-features|relocation-models|code-models]"),
+                               print on stdout", &print_opts.join("|")),
         opt::flagmulti_s("g",  "",  "Equivalent to -C debuginfo=2"),
         opt::flagmulti_s("O", "", "Equivalent to -C opt-level=2"),
         opt::opt_s("o", "", "Write output to <filename>", "FILENAME"),

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -308,6 +308,7 @@ pub enum PrintRequest {
     TargetFeatures,
     RelocationModels,
     CodeModels,
+    TargetSpec,
 }
 
 pub enum Input {
@@ -1141,6 +1142,9 @@ pub fn rustc_short_optgroups() -> Vec<RustcOptGroup> {
     let mut print_opts = vec!["crate-name", "file-names", "sysroot", "cfg",
                               "target-list", "target-cpus", "target-features",
                               "relocation-models", "code-models"];
+    if nightly_options::is_nightly_build() {
+        print_opts.push("target-spec-json");
+    }
 
     vec![
         opt::flag_s("h", "help", "Display this message"),
@@ -1471,6 +1475,8 @@ pub fn build_session_options_and_crate_config(matches: &getopts::Matches)
             "target-features" => PrintRequest::TargetFeatures,
             "relocation-models" => PrintRequest::RelocationModels,
             "code-models" => PrintRequest::CodeModels,
+            "target-spec-json" if nightly_options::is_unstable_enabled(matches)
+                => PrintRequest::TargetSpec,
             req => {
                 early_error(error_format, &format!("unknown print request `{}`", req))
             }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -80,6 +80,8 @@ use rustc_metadata::locator;
 use rustc_metadata::cstore::CStore;
 use rustc::util::common::time;
 
+use serialize::json::ToJson;
+
 use std::cmp::max;
 use std::cmp::Ordering::Equal;
 use std::default::Default;
@@ -584,6 +586,7 @@ impl RustcDefaultCalls {
                     println!("{}", targets.join("\n"));
                 },
                 PrintRequest::Sysroot => println!("{}", sess.sysroot().display()),
+                PrintRequest::TargetSpec => println!("{}", sess.target.target.to_json().pretty()),
                 PrintRequest::FileNames |
                 PrintRequest::CrateName => {
                     let input = match input {

--- a/src/test/run-make/target-specs/Makefile
+++ b/src/test/run-make/target-specs/Makefile
@@ -6,3 +6,4 @@ all:
 	$(RUSTC) foo.rs --target=my-incomplete-platform.json 2>&1 | grep 'Field llvm-target'
 	RUST_TARGET_PATH=. $(RUSTC) foo.rs --target=my-awesome-platform --crate-type=lib --emit=asm
 	RUST_TARGET_PATH=. $(RUSTC) foo.rs --target=x86_64-unknown-linux-gnu --crate-type=lib --emit=asm
+	$(RUSTC) -Z unstable-options --target=my-awesome-platform.json --print target-spec-json > $(TMPDIR)/test-platform.json && $(RUSTC) -Z unstable-options --target=$(TMPDIR)/test-platform.json --print target-spec-json | diff -q $(TMPDIR)/test-platform.json -


### PR DESCRIPTION
This lets the user dump out the target spec that the compiler is using. This is useful to people defining their own target.json to compare it against existing targets or understand how different targets change internal settings. It is also potentially useful for Cargo to determine if something has changed with a target and it needs to rebuild things.