### PR TITLE
x86_64-musl: allow building dylibs with -crt-static

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -35,6 +35,7 @@ use syntax::symbol::Symbol;
 use syntax::{ast, codemap};
 use syntax::feature_gate::AttributeType;
 use syntax_pos::{Span, MultiSpan};
+use syntax::feature_gate::UnstableFeatures;
 
 use rustc_back::PanicStrategy;
 use rustc_back::target::Target;
@@ -503,7 +504,7 @@ impl Session {
     /// Checks if the target is going to be statically linked to the C runtime
     pub fn target_is_crt_static(&self) -> bool {
         let requested_features = self.opts.cg.target_feature.split(',');
-        let unstable_options = sess.opts.debugging_opts.unstable_options;
+        let unstable_options = self.opts.debugging_opts.unstable_options;
         let is_nightly = UnstableFeatures::from_environment().is_nightly_build();
         let found_negative = requested_features.clone().any(|r| r == "-crt-static");
         let found_positive = requested_features.clone().any(|r| r == "+crt-static");
@@ -511,7 +512,7 @@ impl Session {
         // If we switched from the default then that's only allowed on nightly, so
         // gate that here.
         if (found_positive || found_negative) && (!is_nightly || !unstable_options) {
-            sess.fatal("specifying the `crt-static` target feature is only allowed \
+            self.fatal("specifying the `crt-static` target feature is only allowed \
                         on the nightly channel with `-Z unstable-options` passed \
                         as well");
         }

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -499,6 +499,18 @@ impl Session {
         println!("Total time spent computing symbol hashes:      {}",
                  duration_to_secs_str(self.perf_stats.symbol_hash_time.get()));
     }
+
+    /// Checks if the target is going to be statically linked to the C runtime
+    pub fn target_is_crt_static(&self) -> bool {
+        let requested_features = self.opts.cg.target_feature.split(',');
+        let found_negative = requested_features.clone().any(|r| r == "-crt-static");
+        let found_positive = requested_features.clone().any(|r| r == "+crt-static");
+        if self.target.target.options.crt_static_default {
+            !found_negative
+        } else {
+            found_positive
+        }
+    }
 }
 
 pub fn build_session(sopts: config::Options,

--- a/src/librustc_back/target/linux_musl_base.rs
+++ b/src/librustc_back/target/linux_musl_base.rs
@@ -55,16 +55,19 @@ pub fn opts() -> TargetOptions {
     //
     // Each target directory for musl has these object files included in it so
     // they'll be included from there.
+    //
+    // Note that when linking dynamically, these won't be passed to the linker
     base.pre_link_objects_exe.push("crt1.o".to_string());
     base.pre_link_objects_exe.push("crti.o".to_string());
     base.post_link_objects.push("crtn.o".to_string());
 
-    // MUSL support doesn't currently include dynamic linking, so there's no
-    // need for dylibs or rpath business. Additionally `-pie` is incompatible
-    // with `-static`, so we can't pass `-pie`.
+    // Dynamically linking to MUSL is opt-in (via the -crt-static target
+    // feature). The `true`s here are not ultimate and depend on whether one is
+    // actually linking to MUSL dynamically.
     base.dynamic_linking = true;
     base.has_rpath = false;
-    base.position_independent_executables = false;
+    // actually only true if linking dynamically
+    base.position_independent_executables = true;
 
     // These targets statically link libc by default
     base.crt_static_default = true;

--- a/src/librustc_back/target/linux_musl_base.rs
+++ b/src/librustc_back/target/linux_musl_base.rs
@@ -62,7 +62,7 @@ pub fn opts() -> TargetOptions {
     // MUSL support doesn't currently include dynamic linking, so there's no
     // need for dylibs or rpath business. Additionally `-pie` is incompatible
     // with `-static`, so we can't pass `-pie`.
-    base.dynamic_linking = false;
+    base.dynamic_linking = true;
     base.has_rpath = false;
     base.position_independent_executables = false;
 

--- a/src/librustc_driver/target_features.rs
+++ b/src/librustc_driver/target_features.rs
@@ -12,7 +12,6 @@ use syntax::ast;
 use llvm::LLVMRustHasFeature;
 use rustc::session::Session;
 use rustc_trans::back::write::create_target_machine;
-use syntax::feature_gate::UnstableFeatures;
 use syntax::symbol::Symbol;
 use libc::c_char;
 

--- a/src/librustc_driver/target_features.rs
+++ b/src/librustc_driver/target_features.rs
@@ -48,31 +48,7 @@ pub fn add_configuration(cfg: &mut ast::CrateConfig, sess: &Session) {
         }
     }
 
-    let requested_features = sess.opts.cg.target_feature.split(',');
-    let unstable_options = sess.opts.debugging_opts.unstable_options;
-    let is_nightly = UnstableFeatures::from_environment().is_nightly_build();
-    let found_negative = requested_features.clone().any(|r| r == "-crt-static");
-    let found_positive = requested_features.clone().any(|r| r == "+crt-static");
-
-    // If the target we're compiling for requests a static crt by default,
-    // then see if the `-crt-static` feature was passed to disable that.
-    // Otherwise if we don't have a static crt by default then see if the
-    // `+crt-static` feature was passed.
-    let crt_static = if sess.target.target.options.crt_static_default {
-        !found_negative
-    } else {
-        found_positive
-    };
-
-    // If we switched from the default then that's only allowed on nightly, so
-    // gate that here.
-    if (found_positive || found_negative) && (!is_nightly || !unstable_options) {
-        sess.fatal("specifying the `crt-static` target feature is only allowed \
-                    on the nightly channel with `-Z unstable-options` passed \
-                    as well");
-    }
-
-    if crt_static {
+    if sess.target_is_crt_static() {
         cfg.insert((tf, Some(Symbol::intern("crt-static"))));
     }
 }

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -237,7 +237,16 @@ pub fn default_output_for_target(sess: &Session) -> config::CrateType {
 /// Checks if target supports crate_type as output
 pub fn invalid_output_for_target(sess: &Session,
                                  crate_type: config::CrateType) -> bool {
-    match (sess.target.target.options.dynamic_linking,
+    let requested_features = sess.opts.cg.target_feature.split(',');
+    let found_negative = requested_features.clone().any(|r| r == "-crt-static");
+    let found_positive = requested_features.clone().any(|r| r == "+crt-static");
+    let crt_static = if sess.target.target.options.crt_static_default {
+        !found_negative
+    } else {
+        found_positive
+    };
+
+    match (sess.target.target.options.dynamic_linking && !crt_static,
            sess.target.target.options.executables, crate_type) {
         (false, _, config::CrateTypeCdylib) |
         (false, _, config::CrateTypeProcMacro) |


### PR DESCRIPTION
Tested with:

```
$ rustc src/lib.rs --crate-type dylib --target x86_64-unknown-linux-musl -C target-feature=-crt-static -Z unstable-options -Z print-link-args -C linker=x86_64-unknown-linux-musl-gcc
"x86_64-unknown-linux-musl-gcc" "-Wl,--as-needed" "-Wl,-z,noexecstack" "-nostdlib" "-Wl,--eh-frame-hdr" "-Wl,-(" "-m64" "-L" "/home/japaric/build/build/x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-musl/lib" "lib.0.o" "-o" "liblib.so" "lib.metadata.o" "-nodefaultlibs" "-L" "/home/japaric/build/build/x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-musl/lib" "-Wl,-Bstatic" "-Wl,-Bdynamic" "-Wl,--whole-archive" "/tmp/rustc.EYGJnMT6jBmB/libstd-ce5d590d9ad4e1f6.rlib" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "/tmp/rustc.EYGJnMT6jBmB/librand-3b2d8065d4b3f8de.rlib" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "/tmp/rustc.EYGJnMT6jBmB/libcollections-14fd7ed60480d5fa.rlib" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "/tmp/rustc.EYGJnMT6jBmB/librustc_unicode-0457dfc409106094.rlib" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "/tmp/rustc.EYGJnMT6jBmB/libpanic_unwind-9e5638684273e062.rlib" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "/tmp/rustc.EYGJnMT6jBmB/libunwind-bc88660fb5e3bcdf.rlib""-Wl,--no-whole-archive" "-Wl,--whole-archive" "/tmp/rustc.EYGJnMT6jBmB/liballoc-f1d94131b8ae5efd.rlib" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "/tmp/rustc.EYGJnMT6jBmB/liballoc_system-e7e82202710773f4.rlib" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "/tmp/rustc.EYGJnMT6jBmB/liblibc-585bea47151a8284.rlib" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "/tmp/rustc.EYGJnMT6jBmB/libcore-a68d02603096f00e.rlib" "-Wl,--no-whole-archive" "/tmp/rustc.EYGJnMT6jBmB/libcompiler_builtins-de1e72abeff6232c.rlib" "-l" "c" "-shared" "/home/japaric/build/build/x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-musl/lib/crtn.o" "-Wl,-)"
```

Note that `x86_64-unknown-linux-musl-gcc` is a "real" MUSL toolchain unlike the `musl-gcc` wrapper that Ubuntu provides. The former provides a MUSL libc.so; the latter doesn't because it's just a wrapper around `gcc` with some extra flags (`-static`, etc.).

Also this made me realize that when using `-crt-static` with MUSL targets:

- We shouldn't be passing `crt*.o` objects; the MUSL toolchain will provide those.

- With that ^ change, we should be able to enable PIE for these dynamically linked MUSL binaries.

- We probably can drop the `-Wl,-(` and `-Wl,-)` as well.

Also, with this change, Cargo still refuses to compile dylibs:

```
$ cargo rustc --target x86_64-unknown-linux-musl -- -C target-feature=-crt-static -Z unstable-options
error: cannot produce dylib for `bar v0.1.0 (file:///home/japaric/build/bar)` as the target `x86_64-unknown-linux-musl` does not support these crate types
```

r? @alexcrichton 