### PR TITLE
rustbuild: Use src/rustc for assembled compilers

### DIFF
--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -148,6 +148,14 @@ pub fn build_rules(build: &Build) -> Rules {
              });
     }
     for (krate, path, default) in krates("rustc-main") {
+        // We hijacked the `src/rustc` path above for "build just the compiler"
+        // so let's not reinterpret it here as everything and redirect the
+        // `src/rustc` path to a nonexistent path.
+        let path = if path == "src/rustc" {
+            "path/to/nowhere"
+        } else {
+            path
+        };
         rules.build(&krate.build_step, path)
              .dep(|s| s.name("libtest"))
              .dep(move |s| s.name("llvm").host(&build.config.build).stage(0))


### PR DESCRIPTION
The `src/rustc` path is intended for assembling a compiler (e.g. the bare bones)
not actually compiling the whole compiler itself. This path was accidentally
getting hijacked to represent the whole compiler being compiled, so let's
redirect that elsewhere for that particular cargo project.

Closes #38039