### PR TITLE
Warn when an import list is empty

### DIFF
--- a/src/librustc_resolve/check_unused.rs
+++ b/src/librustc_resolve/check_unused.rs
@@ -103,6 +103,12 @@ impl<'a, 'b> Visitor for UnusedImportCheckVisitor<'a, 'b> {
                     }
 
                     ViewPathList(_, ref list) => {
+                        if list.len() == 0 {
+                            self.unused_imports
+                                .entry(item.id)
+                                .or_insert_with(NodeMap)
+                                .insert(item.id, item.span);
+                        }
                         for i in list {
                             self.check_import(item.id, i.node.id, i.span);
                         }

--- a/src/test/compile-fail/issue-28388-1.rs
+++ b/src/test/compile-fail/issue-28388-1.rs
@@ -10,6 +10,8 @@
 
 // Prefix in imports with empty braces should be resolved and checked privacy, stability, etc.
 
-use foo::{}; //~ ERROR failed to resolve. Maybe a missing `extern crate foo;`?
+use foo::{};
+//~^ ERROR failed to resolve. Maybe a missing `extern crate foo;`?
+//~| NOTE foo
 
 fn main() {}

--- a/src/test/compile-fail/issue-28388-2.rs
+++ b/src/test/compile-fail/issue-28388-2.rs
@@ -14,6 +14,7 @@ mod m {
     mod n {}
 }
 
-use m::n::{}; //~ ERROR module `n` is private
+use m::n::{};
+//~^ ERROR module `n` is private
 
 fn main() {}

--- a/src/test/compile-fail/issue-28388-3.rs
+++ b/src/test/compile-fail/issue-28388-3.rs
@@ -14,7 +14,8 @@
 
 extern crate lint_stability;
 
-use lint_stability::UnstableStruct::{}; //~ ERROR use of unstable library feature 'test_feature'
+use lint_stability::UnstableStruct::{};
+//~^ ERROR use of unstable library feature 'test_feature'
 use lint_stability::StableStruct::{}; // OK
 
 fn main() {}

--- a/src/test/compile-fail/lint-unused-imports.rs
+++ b/src/test/compile-fail/lint-unused-imports.rs
@@ -15,6 +15,8 @@ use bar::c::cc as cal;
 
 use std::mem::*;            // shouldn't get errors for not using
                             // everything imported
+use std::fmt::{};
+//~^ ERROR unused import: `use std::fmt::{};`
 
 // Should get errors for both 'Some' and 'None'
 use std::option::Option::{Some, None};


### PR DESCRIPTION
For a given file

```rust
use std::*;
use std::{};
```

output the following warnings

```
warning: unused import: `use std::{};`, #[warn(unused_imports)] on by default
 --> file.rs:2:1
  |
2 | use std::{};
  | ^^^^^^^^^^^^

warning: unused import: `std::*;`, #[warn(unused_imports)] on by default
 --> file.rs:1:5
  |
1 | use std::*;
  |     ^^^^^^^
```