### PR TITLE
debuginfo: Ignore macro-stepping test on aarch64

### DIFF
--- a/src/test/debuginfo/macro-stepping.rs
+++ b/src/test/debuginfo/macro-stepping.rs
@@ -10,6 +10,7 @@
 
 // ignore-windows
 // ignore-android
+// ignore-aarch64
 // min-lldb-version: 310
 
 // aux-build:macro-stepping.rs


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/37225.

r? @alexcrichton 