### PR TITLE
fix stack overflow by enum and cont issue #36163

### DIFF
--- a/src/test/compile-fail/issue-36163.rs
+++ b/src/test/compile-fail/issue-36163.rs
@@ -1,0 +1,26 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+const A: i32 = Foo::B; //~ ERROR E0265
+                       //~^ NOTE recursion not allowed in constant
+
+enum Foo {
+    B = A, //~ ERROR E0265
+           //~^ NOTE recursion not allowed in constant
+}
+
+enum Bar {
+    C = Bar::C, //~ ERROR E0265
+                //~^ NOTE recursion not allowed in constant
+}
+
+const D: i32 = A;
+
+fn main() {}


### PR DESCRIPTION
some paths were skipped while checking for recursion.

I fixed bug reproduces on win64 cargo test. In previous PR #36458 time complexity was exponential in case of linked const values. Now it's linear.

r? @alexcrichton 