### PR TITLE
Allow --test to be used on proc-macro crates

### DIFF
--- a/src/libsyntax_ext/proc_macro_registrar.rs
+++ b/src/libsyntax_ext/proc_macro_registrar.rs
@@ -75,6 +75,10 @@ pub fn modify(sess: &ParseSess,
         handler.err("cannot mix `proc-macro` crate type with others");
     }
 
+    if is_test_crate {
+        return krate;
+    }
+
     krate.module.items.push(mk_registrar(&mut cx, &collect.derives));
 
     if krate.exported_macros.len() > 0 {
@@ -141,8 +145,6 @@ impl<'a> Visitor for CollectCustomDerives<'a> {
         }
 
         if self.is_test_crate {
-            self.handler.span_err(attr.span(),
-                                  "`--test` cannot be used with proc-macro crates");
             return;
         }
 

--- a/src/test/run-pass-fulldeps/proc-macro/derive-test.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/derive-test.rs
@@ -8,15 +8,23 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// no-prefer-dynamic
 // compile-flags: --test
 
 #![crate_type = "proc-macro"]
+#![feature(proc_macro)]
 #![feature(proc_macro, proc_macro_lib)]
 
 extern crate proc_macro;
 
-#[proc_macro_derive(A)]
-//~^ ERROR: `--test` cannot be used with proc-macro crates
-pub fn foo1(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+use proc_macro::TokenStream;
+
+#[proc_macro_derive(Foo)]
+pub fn derive_foo(_input: TokenStream) -> TokenStream {
     "".parse().unwrap()
+}
+
+#[test]
+pub fn test_derive() {
+    assert!(true);
 }


### PR DESCRIPTION
Fixes #37480 

This patch allows `--test` to work for proc-macro crates, removing the previous error.