### PR TITLE
Add error explanation for E0328.

### DIFF
--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -3091,7 +3091,7 @@ E0328: r##"
 The Unsize trait should not be implemented directly. All implementations of
 Unsize are provided automatically by the compiler.
 
-Here's an example of this error:
+Erroneous code example:
 
 ```compile_fail,E0328
 #![feature(unsize)]
@@ -3108,6 +3108,19 @@ conversion from a sized to an unsized type with the [DST coercion system]
 (https://github.com/rust-lang/rfcs/blob/master/text/0982-dst-coercion.md), use
 [`CoerceUnsized`](https://doc.rust-lang.org/std/ops/trait.CoerceUnsized.html)
 instead.
+
+```
+#![feature(coerce_unsized)]
+
+use std::ops::CoerceUnsized;
+
+pub struct MyType<T: ?Sized> {
+    field_with_unsized_type: T,
+}
+
+impl<T, U> CoerceUnsized<MyType<U>> for MyType<T>
+    where T: CoerceUnsized<U> {}
+```
 "##,
 
 E0329: r##"

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -3087,6 +3087,29 @@ impl Foo for Bar {
 ```
 "##,
 
+E0328: r##"
+The Unsize trait should not be implemented directly. All implementations of
+Unsize are provided automatically by the compiler.
+
+Here's an example of this error:
+
+```compile_fail,E0328
+#![feature(unsize)]
+
+use std::marker::Unsize;
+
+pub struct MyType;
+
+impl<T> Unsize<T> for MyType {}
+```
+
+If you are defining your own smart pointer type and would like to enable
+conversion from a sized to an unsized type with the [DST coercion system]
+(https://github.com/rust-lang/rfcs/blob/master/text/0982-dst-coercion.md), use
+[`CoerceUnsized`](https://doc.rust-lang.org/std/ops/trait.CoerceUnsized.html)
+instead.
+"##,
+
 E0329: r##"
 An attempt was made to access an associated constant through either a generic
 type parameter or `Self`. This is not supported yet. An example causing this
@@ -4195,7 +4218,6 @@ register_diagnostics! {
 //  E0249,
 //  E0319, // trait impls for defaulted traits allowed just for structs/enums
     E0320, // recursive overflow during dropck
-    E0328, // cannot implement Unsize explicitly
 //  E0372, // coherence not object safe
     E0377, // the trait `CoerceUnsized` may only be implemented for a coercion
            // between structures with the same definition


### PR DESCRIPTION
This PR adds an explanation for an error in the list in #32777.

I haven't used this feature myself, so I was piecing it together from the docs. Please let me know if any changes in wording should be made.

One problem: When I followed the instructions in CONTRIBUTING.md, it said to run `make check-stage1` before posting the PR. This reported failures, but they seemed to be intermittent. I got different numbers of failures on each run. Here's the output for the last run

```
failures:

---- [run-make] run-make/rustc-macro-dep-files stdout ----

error: make failed
status: exit code: 2
command: "make"
stdout:
------------------------------------------
DYLD_LIBRARY_PATH="/Users/lclark/Repos/rust/x86_64-apple-darwin/test/run-make/rustc-macro-dep-files.stage1-x86_64-apple-darwin:/Users/lclark/Repos/rust/x86_64-apple-darwin/stage1/lib:" '/Users/lclark/Repos/rust/x86_64-apple-darwin/stage1/bin/rustc' --out-dir /Users/lclark/Repos/rust/x86_64-apple-darwin/test/run-make/rustc-macro-dep-files.stage1-x86_64-apple-darwin -L /Users/lclark/Repos/rust/x86_64-apple-darwin/test/run-make/rustc-macro-dep-files.stage1-x86_64-apple-darwin  foo.rs
DYLD_LIBRARY_PATH="/Users/lclark/Repos/rust/x86_64-apple-darwin/test/run-make/rustc-macro-dep-files.stage1-x86_64-apple-darwin:/Users/lclark/Repos/rust/x86_64-apple-darwin/stage1/lib:" '/Users/lclark/Repos/rust/x86_64-apple-darwin/stage1/bin/rustc' --out-dir /Users/lclark/Repos/rust/x86_64-apple-darwin/test/run-make/rustc-macro-dep-files.stage1-x86_64-apple-darwin -L /Users/lclark/Repos/rust/x86_64-apple-darwin/test/run-make/rustc-macro-dep-files.stage1-x86_64-apple-darwin  bar.rs --emit dep-info

------------------------------------------
stderr:
------------------------------------------
dyld: lazy symbol binding failed: Symbol not found: __ZN4core3fmt5write17h2f7663117dd4fb40E
  Referenced from: /Users/lclark/Repos/rust/x86_64-apple-darwin/test/run-make/rustc-macro-dep-files.stage1-x86_64-apple-darwin/libfoo.dylib
  Expected in: /Users/lclark/Repos/rust/x86_64-apple-darwin/stage1/lib/libstd-fdb5dc8c.dylib

dyld: Symbol not found: __ZN4core3fmt5write17h2f7663117dd4fb40E
  Referenced from: /Users/lclark/Repos/rust/x86_64-apple-darwin/test/run-make/rustc-macro-dep-files.stage1-x86_64-apple-darwin/libfoo.dylib
  Expected in: /Users/lclark/Repos/rust/x86_64-apple-darwin/stage1/lib/libstd-fdb5dc8c.dylib

make[1]: *** [all] Trace/BPT trap: 5

------------------------------------------

thread '[run-make] run-make/rustc-macro-dep-files' panicked at 'explicit panic', /Users/lclark/Repos/rust/src/tools/compiletest/src/runtest.rs:2407
note: Run with `RUST_BACKTRACE=1` for a backtrace.


failures:
    [run-make] run-make/rustc-macro-dep-files

test result: FAILED. 136 passed; 1 failed; 0 ignored; 0 measured

thread 'main' panicked at 'Some tests failed', /Users/lclark/Repos/rust/src/tools/compiletest/src/main.rs:302
make: *** [tmp/check-stage1-T-x86_64-apple-darwin-H-x86_64-apple-darwin-rmake.ok] Error 101
```

r? @GuillaumeGomez

