### PR TITLE
don't rebuild alloc_jemalloc if jemalloc's .git directory has changed

### DIFF
--- a/src/liballoc_jemalloc/build.rs
+++ b/src/liballoc_jemalloc/build.rs
@@ -69,6 +69,7 @@ fn main() {
         .read_dir()
         .unwrap()
         .map(|e| e.unwrap())
+        .filter(|e| &*e.file_name() != ".git")
         .collect::<Vec<_>>();
     while let Some(entry) = stack.pop() {
         let path = entry.path();


### PR DESCRIPTION
the .git directory is modified by `bootstrap` when it updates this git
submodule; this triggered rebuilds every time `bootstrap` was called.

likely fixes #38094

r? @alexcrichton