### PR TITLE
book: use abort() over loop {} for panic

### DIFF
--- a/src/doc/book/lang-items.md
+++ b/src/doc/book/lang-items.md
@@ -16,14 +16,11 @@ and one for deallocation. A freestanding program that uses the `Box`
 sugar for dynamic allocations via `malloc` and `free`:
 
 ```rust,ignore
-#![feature(lang_items, box_syntax, start, libc)]
+#![feature(lang_items, box_syntax, start, libc, core_intrinsics)]
 #![no_std]
+use core::intrinsics;
 
 extern crate libc;
-
-extern {
-    fn abort() -> !;
-}
 
 #[lang = "owned_box"]
 pub struct Box<T>(*mut T);
@@ -34,7 +31,7 @@ unsafe fn allocate(size: usize, _align: usize) -> *mut u8 {
 
     // Check if `malloc` failed:
     if p as usize == 0 {
-        abort();
+        intrinsics::abort();
     }
 
     p
@@ -58,7 +55,7 @@ fn main(argc: isize, argv: *const *const u8) -> isize {
 }
 
 #[lang = "eh_personality"] extern fn rust_eh_personality() {}
-#[lang = "panic_fmt"] extern fn rust_begin_panic() -> ! { loop {} }
+#[lang = "panic_fmt"] extern fn rust_begin_panic() -> ! { unsafe { intrinsics::abort() } }
 # #[lang = "eh_unwind_resume"] extern fn rust_eh_unwind_resume() {}
 # #[no_mangle] pub extern fn rust_eh_register_frames () {}
 # #[no_mangle] pub extern fn rust_eh_unregister_frames () {}

--- a/src/doc/book/no-stdlib.md
+++ b/src/doc/book/no-stdlib.md
@@ -37,9 +37,10 @@ The function marked `#[start]` is passed the command line parameters
 in the same format as C:
 
 ```rust,ignore
-#![feature(lang_items)]
+#![feature(lang_items, core_intrinsics)]
 #![feature(start)]
 #![no_std]
+use core::intrinsics;
 
 // Pull in the system libc library for what crt0.o likely requires.
 extern crate libc;
@@ -69,7 +70,7 @@ pub extern fn rust_eh_unwind_resume() {
 pub extern fn rust_begin_panic(_msg: core::fmt::Arguments,
                                _file: &'static str,
                                _line: u32) -> ! {
-    loop {}
+    unsafe { intrinsics::abort() }
 }
 ```
 
@@ -79,10 +80,11 @@ correct ABI and the correct name, which requires overriding the
 compiler's name mangling too:
 
 ```rust,ignore
-#![feature(lang_items)]
+#![feature(lang_items, core_intrinsics)]
 #![feature(start)]
 #![no_std]
 #![no_main]
+use core::intrinsics;
 
 // Pull in the system libc library for what crt0.o likely requires.
 extern crate libc;
@@ -112,7 +114,7 @@ pub extern fn rust_eh_unwind_resume() {
 pub extern fn rust_begin_panic(_msg: core::fmt::Arguments,
                                _file: &'static str,
                                _line: u32) -> ! {
-    loop {}
+    unsafe { intrinsics::abort() }
 }
 ```
 


### PR DESCRIPTION
Due to #28728 `loop {}` is very risky and can lead to fun debugging experiences such as #38136. Besides, aborting is probably better behavior than an infinite loop.

r? @steveklabnik 