### PR TITLE
Require `#[proc_macro_derive]` functions to be `pub`

### DIFF
--- a/src/test/compile-fail-fulldeps/proc-macro/pub-at-crate-root.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/pub-at-crate-root.rs
@@ -23,3 +23,8 @@ pub mod a { //~ `proc-macro` crate types cannot export any items
     }
 }
 
+#[proc_macro_derive(B)]
+fn bar(a: proc_macro::TokenStream) -> proc_macro::TokenStream {
+//~^ ERROR: functions tagged with `#[proc_macro_derive]` must be `pub`
+    a
+}

--- a/src/test/compile-fail-fulldeps/proc-macro/signature.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/signature.rs
@@ -15,7 +15,7 @@
 extern crate proc_macro;
 
 #[proc_macro_derive(A)]
-unsafe extern fn foo(a: i32, b: u32) -> u32 {
+pub unsafe extern fn foo(a: i32, b: u32) -> u32 {
     //~^ ERROR: mismatched types
     //~| NOTE: expected normal fn, found unsafe fn
     //~| NOTE: expected type `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`


### PR DESCRIPTION
r? @nrc 