### PR TITLE
rustdoc: fix doctests with non-feature crate attrs

### DIFF
--- a/src/doc/book/documentation.md
+++ b/src/doc/book/documentation.md
@@ -600,7 +600,7 @@ is documented, especially when you are working on a library. Rust allows you to
 to generate warnings or errors, when an item is missing documentation.
 To generate warnings you use `warn`:
 
-```rust
+```rust,ignore
 #![warn(missing_docs)]
 ```
 
@@ -630,7 +630,7 @@ struct Hidden;
 You can control a few aspects of the HTML that `rustdoc` generates through the
 `#![doc]` version of the attribute:
 
-```rust
+```rust,ignore
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/")]

--- a/src/doc/book/using-rust-without-the-standard-library.md
+++ b/src/doc/book/using-rust-without-the-standard-library.md
@@ -13,7 +13,7 @@ don’t want to use the standard library via an attribute: `#![no_std]`.
 
 To use `#![no_std]`, add it to your crate root:
 
-```rust
+```rust,ignore
 #![no_std]
 
 fn plus_one(x: i32) -> i32 {
@@ -29,7 +29,7 @@ use its features without an explicit import. By the same token, when using
 prelude](../core/prelude/v1/index.html). This means that a lot of code will Just
 Work:
 
-```rust
+```rust,ignore
 #![no_std]
 
 fn may_fail(failure: bool) -> Result<(), &'static str> {

--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -557,7 +557,7 @@ them yourself.
 You can build a free-standing crate by adding `#![no_std]` to the crate
 attributes:
 
-```
+```ignore
 #![no_std]
 ```
 

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -344,6 +344,7 @@ pub fn maketest(s: &str, cratename: Option<&str>, dont_insert_main: bool,
     prog
 }
 
+// FIXME(aburka): use a real parser to deal with multiline attributes
 fn partition_source(s: &str) -> (String, String) {
     use rustc_unicode::str::UnicodeStr;
 
@@ -354,7 +355,7 @@ fn partition_source(s: &str) -> (String, String) {
     for line in s.lines() {
         let trimline = line.trim();
         let header = trimline.is_whitespace() ||
-            trimline.starts_with("#![feature");
+            trimline.starts_with("#![");
         if !header || after_header {
             after_header = true;
             after.push_str(line);

--- a/src/test/rustdoc/issue-38129.rs
+++ b/src/test/rustdoc/issue-38129.rs
@@ -1,0 +1,110 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:--test
+
+// This file tests the source-partitioning behavior of rustdoc.
+// Each test contains some code that should be put into the generated
+// `fn main` and some attributes should be left outside (except the first
+// one, which has no attributes).
+// If the #![recursion_limit] attribute is incorrectly left inside,
+// then the tests will fail because the macro recurses 128 times.
+
+/// ```
+/// assert_eq!(1 + 1, 2);
+/// ```
+pub fn simple() {}
+
+/// ```
+/// #![recursion_limit = "1024"]
+/// macro_rules! recurse {
+///     (()) => {};
+///     (() $($rest:tt)*) => { recurse!($($rest)*); }
+/// }
+/// recurse!(() () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ());
+/// assert_eq!(1 + 1, 2);
+/// ```
+pub fn non_feature_attr() {}
+
+/// ```
+/// #![feature(core_intrinsics)]
+/// assert_eq!(1 + 1, 2);
+/// ```
+pub fn feature_attr() {}
+
+/// ```
+/// #![feature(core_intrinsics)]
+/// #![recursion_limit = "1024"]
+/// macro_rules! recurse {
+///     (()) => {};
+///     (() $($rest:tt)*) => { recurse!($($rest)*); }
+/// }
+/// recurse!(() () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ());
+/// assert_eq!(1 + 1, 2);
+/// ```
+pub fn both_attrs() {}
+
+/// ```
+/// #![recursion_limit = "1024"]
+/// #![feature(core_intrinsics)]
+/// macro_rules! recurse {
+///     (()) => {};
+///     (() $($rest:tt)*) => { recurse!($($rest)*); }
+/// }
+/// recurse!(() () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ()
+///          () () () () () () () ());
+/// assert_eq!(1 + 1, 2);
+/// ```
+pub fn both_attrs_reverse() {}
+


### PR DESCRIPTION
Fixes #38129.

The book says that any top-level crate attributes at the beginning of a doctest are moved outside the generated `fn main`, but it was only checking for `#![feature`, not `#![`.

These attributes previously caused warnings but were then ignored, so in theory this could change the behavior of doctests in the wild.