### PR TITLE
libtest: add --list option to list tests and benchmarks

### DIFF
--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -325,6 +325,7 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
         color: test::AutoColor,
         test_threads: None,
         skip: vec![],
+        list: false,
     }
 }
 


### PR DESCRIPTION
This option lists all the tests and benchmarks a binary provides without running any of them. 
By default the listing is sent to stdout (intended for human consumption), but if `--logfile` is also specified, it is also written there in an easily parsable form.

If filters are specified, they're applied before the output is emitted. The human output will also include a summary unless `-q` is specified.