### PR TITLE
Add docs for last undocumented `Default` `impl`.

### DIFF
--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -2108,6 +2108,10 @@ impl DefaultHasher {
 
 #[stable(feature = "hashmap_default_hasher", since = "1.13.0")]
 impl Default for DefaultHasher {
+    /// Creates a new `DefaultHasher` using [`DefaultHasher::new`]. See
+    /// [`DefaultHasher::new`] documentation for more information.
+    ///
+    /// [`DefaultHasher::new`]: #method.new
     fn default() -> DefaultHasher {
         DefaultHasher::new()
     }


### PR DESCRIPTION
Add doc comment for `Default` `impl` on `DefaultHasher`.

Fixes https://github.com/rust-lang/rust/issues/36265.