### PR TITLE
annotate stricter lifetimes on LateLintPass methods to allow them to forward to a Visitor

### DIFF
--- a/src/librustc/hir/check_attr.rs
+++ b/src/librustc/hir/check_attr.rs
@@ -129,8 +129,8 @@ impl<'a> CheckAttrVisitor<'a> {
     }
 }
 
-impl<'a> Visitor for CheckAttrVisitor<'a> {
-    fn visit_item(&mut self, item: &ast::Item) {
+impl<'a> Visitor<'a> for CheckAttrVisitor<'a> {
+    fn visit_item(&mut self, item: &'a ast::Item) {
         let target = Target::from_item(item);
         for attr in &item.attrs {
             self.check_attribute(attr, target);

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -143,14 +143,14 @@ impl<'a> LoweringContext<'a> {
             lctx: &'lcx mut LoweringContext<'interner>,
         }
 
-        impl<'lcx, 'interner> Visitor for ItemLowerer<'lcx, 'interner> {
-            fn visit_item(&mut self, item: &Item) {
+        impl<'lcx, 'interner> Visitor<'lcx> for ItemLowerer<'lcx, 'interner> {
+            fn visit_item(&mut self, item: &'lcx Item) {
                 let hir_item = self.lctx.lower_item(item);
                 self.lctx.items.insert(item.id, hir_item);
                 visit::walk_item(self, item);
             }
 
-            fn visit_impl_item(&mut self, item: &ImplItem) {
+            fn visit_impl_item(&mut self, item: &'lcx ImplItem) {
                 let id = self.lctx.lower_impl_item_ref(item).id;
                 let hir_item = self.lctx.lower_impl_item(item);
                 self.lctx.impl_items.insert(id, hir_item);

--- a/src/librustc/hir/map/def_collector.rs
+++ b/src/librustc/hir/map/def_collector.rs
@@ -135,8 +135,8 @@ impl<'a> DefCollector<'a> {
     }
 }
 
-impl<'a> visit::Visitor for DefCollector<'a> {
-    fn visit_item(&mut self, i: &Item) {
+impl<'a> visit::Visitor<'a> for DefCollector<'a> {
+    fn visit_item(&mut self, i: &'a Item) {
         debug!("visit_item: {:?}", i);
 
         // Pick the def data. This need not be unique, but the more
@@ -211,7 +211,7 @@ impl<'a> visit::Visitor for DefCollector<'a> {
         });
     }
 
-    fn visit_foreign_item(&mut self, foreign_item: &ForeignItem) {
+    fn visit_foreign_item(&mut self, foreign_item: &'a ForeignItem) {
         let def = self.create_def(foreign_item.id,
                                   DefPathData::ValueNs(foreign_item.ident.name.as_str()));
 
@@ -220,7 +220,7 @@ impl<'a> visit::Visitor for DefCollector<'a> {
         });
     }
 
-    fn visit_generics(&mut self, generics: &Generics) {
+    fn visit_generics(&mut self, generics: &'a Generics) {
         for ty_param in generics.ty_params.iter() {
             self.create_def(ty_param.id, DefPathData::TypeParam(ty_param.ident.name.as_str()));
         }
@@ -228,7 +228,7 @@ impl<'a> visit::Visitor for DefCollector<'a> {
         visit::walk_generics(self, generics);
     }
 
-    fn visit_trait_item(&mut self, ti: &TraitItem) {
+    fn visit_trait_item(&mut self, ti: &'a TraitItem) {
         let def_data = match ti.node {
             TraitItemKind::Method(..) | TraitItemKind::Const(..) =>
                 DefPathData::ValueNs(ti.ident.name.as_str()),
@@ -246,7 +246,7 @@ impl<'a> visit::Visitor for DefCollector<'a> {
         });
     }
 
-    fn visit_impl_item(&mut self, ii: &ImplItem) {
+    fn visit_impl_item(&mut self, ii: &'a ImplItem) {
         let def_data = match ii.node {
             ImplItemKind::Method(..) | ImplItemKind::Const(..) =>
                 DefPathData::ValueNs(ii.ident.name.as_str()),
@@ -264,7 +264,7 @@ impl<'a> visit::Visitor for DefCollector<'a> {
         });
     }
 
-    fn visit_pat(&mut self, pat: &Pat) {
+    fn visit_pat(&mut self, pat: &'a Pat) {
         let parent_def = self.parent_def;
 
         match pat.node {
@@ -280,7 +280,7 @@ impl<'a> visit::Visitor for DefCollector<'a> {
         self.parent_def = parent_def;
     }
 
-    fn visit_expr(&mut self, expr: &Expr) {
+    fn visit_expr(&mut self, expr: &'a Expr) {
         let parent_def = self.parent_def;
 
         match expr.node {
@@ -297,7 +297,7 @@ impl<'a> visit::Visitor for DefCollector<'a> {
         self.parent_def = parent_def;
     }
 
-    fn visit_ty(&mut self, ty: &Ty) {
+    fn visit_ty(&mut self, ty: &'a Ty) {
         match ty.node {
             TyKind::Mac(..) => return self.visit_macro_invoc(ty.id, false),
             TyKind::Array(_, ref length) => self.visit_ast_const_integer(length),
@@ -309,15 +309,15 @@ impl<'a> visit::Visitor for DefCollector<'a> {
         visit::walk_ty(self, ty);
     }
 
-    fn visit_lifetime_def(&mut self, def: &LifetimeDef) {
+    fn visit_lifetime_def(&mut self, def: &'a LifetimeDef) {
         self.create_def(def.lifetime.id, DefPathData::LifetimeDef(def.lifetime.name.as_str()));
     }
 
-    fn visit_macro_def(&mut self, macro_def: &MacroDef) {
+    fn visit_macro_def(&mut self, macro_def: &'a MacroDef) {
         self.create_def(macro_def.id, DefPathData::MacroDef(macro_def.ident.name.as_str()));
     }
 
-    fn visit_stmt(&mut self, stmt: &Stmt) {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
         match stmt.node {
             StmtKind::Mac(..) => self.visit_macro_invoc(stmt.id, false),
             _ => visit::walk_stmt(self, stmt),

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -262,4 +262,4 @@ impl LintPass for HardwiredLints {
     }
 }
 
-impl LateLintPass for HardwiredLints {}
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for HardwiredLints {}

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -496,13 +496,13 @@ pub fn raw_struct_lint<'a, S>(sess: &'a Session,
     err
 }
 
-pub trait LintContext: Sized {
+pub trait LintContext<'tcx>: Sized {
     fn sess(&self) -> &Session;
     fn lints(&self) -> &LintStore;
     fn mut_lints(&mut self) -> &mut LintStore;
     fn level_stack(&mut self) -> &mut Vec<(LintId, LevelSource)>;
-    fn enter_attrs(&mut self, attrs: &[ast::Attribute]);
-    fn exit_attrs(&mut self, attrs: &[ast::Attribute]);
+    fn enter_attrs(&mut self, attrs: &'tcx [ast::Attribute]);
+    fn exit_attrs(&mut self, attrs: &'tcx [ast::Attribute]);
 
     /// Get the level of `lint` at the current position of the lint
     /// traversal.
@@ -606,7 +606,7 @@ pub trait LintContext: Sized {
     /// current lint context, call the provided function, then reset the
     /// lints in effect to their previous state.
     fn with_lint_attrs<F>(&mut self,
-                          attrs: &[ast::Attribute],
+                          attrs: &'tcx [ast::Attribute],
                           f: F)
         where F: FnOnce(&mut Self),
     {
@@ -729,7 +729,7 @@ impl<'a, 'tcx> LateContext<'a, 'tcx> {
     }
 }
 
-impl<'a, 'tcx> LintContext for LateContext<'a, 'tcx> {
+impl<'a, 'tcx> LintContext<'tcx> for LateContext<'a, 'tcx> {
     /// Get the overall compiler `Session` object.
     fn sess(&self) -> &Session {
         &self.tcx.sess
@@ -747,18 +747,18 @@ impl<'a, 'tcx> LintContext for LateContext<'a, 'tcx> {
         &mut self.level_stack
     }
 
-    fn enter_attrs(&mut self, attrs: &[ast::Attribute]) {
+    fn enter_attrs(&mut self, attrs: &'tcx [ast::Attribute]) {
         debug!("late context: enter_attrs({:?})", attrs);
         run_lints!(self, enter_lint_attrs, late_passes, attrs);
     }
 
-    fn exit_attrs(&mut self, attrs: &[ast::Attribute]) {
+    fn exit_attrs(&mut self, attrs: &'tcx [ast::Attribute]) {
         debug!("late context: exit_attrs({:?})", attrs);
         run_lints!(self, exit_lint_attrs, late_passes, attrs);
     }
 }
 
-impl<'a> LintContext for EarlyContext<'a> {
+impl<'a> LintContext<'a> for EarlyContext<'a> {
     /// Get the overall compiler `Session` object.
     fn sess(&self) -> &Session {
         &self.sess
@@ -776,12 +776,12 @@ impl<'a> LintContext for EarlyContext<'a> {
         &mut self.level_stack
     }
 
-    fn enter_attrs(&mut self, attrs: &[ast::Attribute]) {
+    fn enter_attrs(&mut self, attrs: &'a [ast::Attribute]) {
         debug!("early context: enter_attrs({:?})", attrs);
         run_lints!(self, enter_lint_attrs, early_passes, attrs);
     }
 
-    fn exit_attrs(&mut self, attrs: &[ast::Attribute]) {
+    fn exit_attrs(&mut self, attrs: &'a [ast::Attribute]) {
         debug!("early context: exit_attrs({:?})", attrs);
         run_lints!(self, exit_lint_attrs, early_passes, attrs);
     }
@@ -949,14 +949,14 @@ impl<'a, 'tcx> hir_visit::Visitor<'tcx> for LateContext<'a, 'tcx> {
         hir_visit::walk_path(self, p);
     }
 
-    fn visit_attribute(&mut self, attr: &ast::Attribute) {
+    fn visit_attribute(&mut self, attr: &'tcx ast::Attribute) {
         check_lint_name_attribute(self, attr);
         run_lints!(self, check_attribute, late_passes, attr);
     }
 }
 
-impl<'a> ast_visit::Visitor for EarlyContext<'a> {
-    fn visit_item(&mut self, it: &ast::Item) {
+impl<'a> ast_visit::Visitor<'a> for EarlyContext<'a> {
+    fn visit_item(&mut self, it: &'a ast::Item) {
         self.with_lint_attrs(&it.attrs, |cx| {
             run_lints!(cx, check_item, early_passes, it);
             ast_visit::walk_item(cx, it);
@@ -964,7 +964,7 @@ impl<'a> ast_visit::Visitor for EarlyContext<'a> {
         })
     }
 
-    fn visit_foreign_item(&mut self, it: &ast::ForeignItem) {
+    fn visit_foreign_item(&mut self, it: &'a ast::ForeignItem) {
         self.with_lint_attrs(&it.attrs, |cx| {
             run_lints!(cx, check_foreign_item, early_passes, it);
             ast_visit::walk_foreign_item(cx, it);
@@ -972,24 +972,24 @@ impl<'a> ast_visit::Visitor for EarlyContext<'a> {
         })
     }
 
-    fn visit_pat(&mut self, p: &ast::Pat) {
+    fn visit_pat(&mut self, p: &'a ast::Pat) {
         run_lints!(self, check_pat, early_passes, p);
         ast_visit::walk_pat(self, p);
     }
 
-    fn visit_expr(&mut self, e: &ast::Expr) {
+    fn visit_expr(&mut self, e: &'a ast::Expr) {
         self.with_lint_attrs(&e.attrs, |cx| {
             run_lints!(cx, check_expr, early_passes, e);
             ast_visit::walk_expr(cx, e);
         })
     }
 
-    fn visit_stmt(&mut self, s: &ast::Stmt) {
+    fn visit_stmt(&mut self, s: &'a ast::Stmt) {
         run_lints!(self, check_stmt, early_passes, s);
         ast_visit::walk_stmt(self, s);
     }
 
-    fn visit_fn(&mut self, fk: ast_visit::FnKind, decl: &ast::FnDecl,
+    fn visit_fn(&mut self, fk: ast_visit::FnKind<'a>, decl: &'a ast::FnDecl,
                 span: Span, id: ast::NodeId) {
         run_lints!(self, check_fn, early_passes, fk, decl, span, id);
         ast_visit::walk_fn(self, fk, decl, span);
@@ -997,9 +997,9 @@ impl<'a> ast_visit::Visitor for EarlyContext<'a> {
     }
 
     fn visit_variant_data(&mut self,
-                        s: &ast::VariantData,
+                        s: &'a ast::VariantData,
                         ident: ast::Ident,
-                        g: &ast::Generics,
+                        g: &'a ast::Generics,
                         item_id: ast::NodeId,
                         _: Span) {
         run_lints!(self, check_struct_def, early_passes, s, ident, g, item_id);
@@ -1007,14 +1007,14 @@ impl<'a> ast_visit::Visitor for EarlyContext<'a> {
         run_lints!(self, check_struct_def_post, early_passes, s, ident, g, item_id);
     }
 
-    fn visit_struct_field(&mut self, s: &ast::StructField) {
+    fn visit_struct_field(&mut self, s: &'a ast::StructField) {
         self.with_lint_attrs(&s.attrs, |cx| {
             run_lints!(cx, check_struct_field, early_passes, s);
             ast_visit::walk_struct_field(cx, s);
         })
     }
 
-    fn visit_variant(&mut self, v: &ast::Variant, g: &ast::Generics, item_id: ast::NodeId) {
+    fn visit_variant(&mut self, v: &'a ast::Variant, g: &'a ast::Generics, item_id: ast::NodeId) {
         self.with_lint_attrs(&v.node.attrs, |cx| {
             run_lints!(cx, check_variant, early_passes, v, g);
             ast_visit::walk_variant(cx, v, g, item_id);
@@ -1022,7 +1022,7 @@ impl<'a> ast_visit::Visitor for EarlyContext<'a> {
         })
     }
 
-    fn visit_ty(&mut self, t: &ast::Ty) {
+    fn visit_ty(&mut self, t: &'a ast::Ty) {
         run_lints!(self, check_ty, early_passes, t);
         ast_visit::walk_ty(self, t);
     }
@@ -1031,40 +1031,40 @@ impl<'a> ast_visit::Visitor for EarlyContext<'a> {
         run_lints!(self, check_ident, early_passes, sp, id);
     }
 
-    fn visit_mod(&mut self, m: &ast::Mod, s: Span, n: ast::NodeId) {
+    fn visit_mod(&mut self, m: &'a ast::Mod, s: Span, n: ast::NodeId) {
         run_lints!(self, check_mod, early_passes, m, s, n);
         ast_visit::walk_mod(self, m);
         run_lints!(self, check_mod_post, early_passes, m, s, n);
     }
 
-    fn visit_local(&mut self, l: &ast::Local) {
+    fn visit_local(&mut self, l: &'a ast::Local) {
         self.with_lint_attrs(&l.attrs, |cx| {
             run_lints!(cx, check_local, early_passes, l);
             ast_visit::walk_local(cx, l);
         })
     }
 
-    fn visit_block(&mut self, b: &ast::Block) {
+    fn visit_block(&mut self, b: &'a ast::Block) {
         run_lints!(self, check_block, early_passes, b);
         ast_visit::walk_block(self, b);
         run_lints!(self, check_block_post, early_passes, b);
     }
 
-    fn visit_arm(&mut self, a: &ast::Arm) {
+    fn visit_arm(&mut self, a: &'a ast::Arm) {
         run_lints!(self, check_arm, early_passes, a);
         ast_visit::walk_arm(self, a);
     }
 
-    fn visit_expr_post(&mut self, e: &ast::Expr) {
+    fn visit_expr_post(&mut self, e: &'a ast::Expr) {
         run_lints!(self, check_expr_post, early_passes, e);
     }
 
-    fn visit_generics(&mut self, g: &ast::Generics) {
+    fn visit_generics(&mut self, g: &'a ast::Generics) {
         run_lints!(self, check_generics, early_passes, g);
         ast_visit::walk_generics(self, g);
     }
 
-    fn visit_trait_item(&mut self, trait_item: &ast::TraitItem) {
+    fn visit_trait_item(&mut self, trait_item: &'a ast::TraitItem) {
         self.with_lint_attrs(&trait_item.attrs, |cx| {
             run_lints!(cx, check_trait_item, early_passes, trait_item);
             ast_visit::walk_trait_item(cx, trait_item);
@@ -1072,7 +1072,7 @@ impl<'a> ast_visit::Visitor for EarlyContext<'a> {
         });
     }
 
-    fn visit_impl_item(&mut self, impl_item: &ast::ImplItem) {
+    fn visit_impl_item(&mut self, impl_item: &'a ast::ImplItem) {
         self.with_lint_attrs(&impl_item.attrs, |cx| {
             run_lints!(cx, check_impl_item, early_passes, impl_item);
             ast_visit::walk_impl_item(cx, impl_item);
@@ -1080,25 +1080,25 @@ impl<'a> ast_visit::Visitor for EarlyContext<'a> {
         });
     }
 
-    fn visit_lifetime(&mut self, lt: &ast::Lifetime) {
+    fn visit_lifetime(&mut self, lt: &'a ast::Lifetime) {
         run_lints!(self, check_lifetime, early_passes, lt);
     }
 
-    fn visit_lifetime_def(&mut self, lt: &ast::LifetimeDef) {
+    fn visit_lifetime_def(&mut self, lt: &'a ast::LifetimeDef) {
         run_lints!(self, check_lifetime_def, early_passes, lt);
     }
 
-    fn visit_path(&mut self, p: &ast::Path, id: ast::NodeId) {
+    fn visit_path(&mut self, p: &'a ast::Path, id: ast::NodeId) {
         run_lints!(self, check_path, early_passes, p, id);
         ast_visit::walk_path(self, p);
     }
 
-    fn visit_path_list_item(&mut self, prefix: &ast::Path, item: &ast::PathListItem) {
+    fn visit_path_list_item(&mut self, prefix: &'a ast::Path, item: &'a ast::PathListItem) {
         run_lints!(self, check_path_list_item, early_passes, item);
         ast_visit::walk_path_list_item(self, prefix, item);
     }
 
-    fn visit_attribute(&mut self, attr: &ast::Attribute) {
+    fn visit_attribute(&mut self, attr: &'a ast::Attribute) {
         run_lints!(self, check_attribute, early_passes, attr);
     }
 }

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -131,51 +131,104 @@ pub trait LintPass {
 // contains a few lint-specific methods with no equivalent in `Visitor`.
 pub trait LateLintPass: LintPass {
     fn check_name(&mut self, _: &LateContext, _: Span, _: ast::Name) { }
-    fn check_crate(&mut self, _: &LateContext, _: &hir::Crate) { }
-    fn check_crate_post(&mut self, _: &LateContext, _: &hir::Crate) { }
-    fn check_mod(&mut self, _: &LateContext, _: &hir::Mod, _: Span, _: ast::NodeId) { }
-    fn check_mod_post(&mut self, _: &LateContext, _: &hir::Mod, _: Span, _: ast::NodeId) { }
-    fn check_foreign_item(&mut self, _: &LateContext, _: &hir::ForeignItem) { }
-    fn check_foreign_item_post(&mut self, _: &LateContext, _: &hir::ForeignItem) { }
-    fn check_item(&mut self, _: &LateContext, _: &hir::Item) { }
-    fn check_item_post(&mut self, _: &LateContext, _: &hir::Item) { }
-    fn check_local(&mut self, _: &LateContext, _: &hir::Local) { }
-    fn check_block(&mut self, _: &LateContext, _: &hir::Block) { }
-    fn check_block_post(&mut self, _: &LateContext, _: &hir::Block) { }
-    fn check_stmt(&mut self, _: &LateContext, _: &hir::Stmt) { }
-    fn check_arm(&mut self, _: &LateContext, _: &hir::Arm) { }
-    fn check_pat(&mut self, _: &LateContext, _: &hir::Pat) { }
-    fn check_decl(&mut self, _: &LateContext, _: &hir::Decl) { }
-    fn check_expr(&mut self, _: &LateContext, _: &hir::Expr) { }
-    fn check_expr_post(&mut self, _: &LateContext, _: &hir::Expr) { }
-    fn check_ty(&mut self, _: &LateContext, _: &hir::Ty) { }
-    fn check_generics(&mut self, _: &LateContext, _: &hir::Generics) { }
-    fn check_fn(&mut self, _: &LateContext,
-        _: FnKind, _: &hir::FnDecl, _: &hir::Expr, _: Span, _: ast::NodeId) { }
-    fn check_fn_post(&mut self, _: &LateContext,
-        _: FnKind, _: &hir::FnDecl, _: &hir::Expr, _: Span, _: ast::NodeId) { }
-    fn check_trait_item(&mut self, _: &LateContext, _: &hir::TraitItem) { }
-    fn check_trait_item_post(&mut self, _: &LateContext, _: &hir::TraitItem) { }
-    fn check_impl_item(&mut self, _: &LateContext, _: &hir::ImplItem) { }
-    fn check_impl_item_post(&mut self, _: &LateContext, _: &hir::ImplItem) { }
-    fn check_struct_def(&mut self, _: &LateContext,
-        _: &hir::VariantData, _: ast::Name, _: &hir::Generics, _: ast::NodeId) { }
-    fn check_struct_def_post(&mut self, _: &LateContext,
-        _: &hir::VariantData, _: ast::Name, _: &hir::Generics, _: ast::NodeId) { }
-    fn check_struct_field(&mut self, _: &LateContext, _: &hir::StructField) { }
-    fn check_variant(&mut self, _: &LateContext, _: &hir::Variant, _: &hir::Generics) { }
-    fn check_variant_post(&mut self, _: &LateContext, _: &hir::Variant, _: &hir::Generics) { }
-    fn check_lifetime(&mut self, _: &LateContext, _: &hir::Lifetime) { }
-    fn check_lifetime_def(&mut self, _: &LateContext, _: &hir::LifetimeDef) { }
-    fn check_path(&mut self, _: &LateContext, _: &hir::Path, _: ast::NodeId) { }
-    fn check_attribute(&mut self, _: &LateContext, _: &ast::Attribute) { }
+    fn check_crate<'a, 'tcx:'a >(&mut self, _: &'a LateContext<'a, 'tcx>, _: &'tcx hir::Crate) { }
+    fn check_crate_post<'a, 'tcx: 'a>(&mut self,
+                                      _: &'a LateContext<'a, 'tcx>,
+                                      _: &'tcx hir::Crate) { }
+    fn check_mod<'a, 'tcx: 'a>(&mut self,
+                               _: &'a LateContext<'a, 'tcx>,
+                               _: &'tcx hir::Mod,
+                               _: Span,
+                               _: ast::NodeId) { }
+    fn check_mod_post<'a, 'tcx: 'a>(&mut self,
+                                    _: &'a LateContext<'a, 'tcx>,
+                                    _: &'tcx hir::Mod,
+                                    _: Span,
+                                    _: ast::NodeId) { }
+    fn check_foreign_item<'a, 'tcx: 'a>(&mut self,
+                                        _: &'a LateContext<'a, 'tcx>,
+                                        _: &'tcx hir::ForeignItem) { }
+    fn check_foreign_item_post<'a, 'tcx: 'a>(&mut self,
+                                             _: &'a LateContext<'a, 'tcx>,
+                                             _: &'tcx hir::ForeignItem) { }
+    fn check_item<'a, 'tcx: 'a>(&mut self,
+                                _: &'a LateContext<'a, 'tcx>,
+                                _: &'tcx hir::Item) { }
+    fn check_item_post<'a, 'tcx: 'a>(&mut self,
+                                     _: &'a LateContext<'a, 'tcx>,
+                                     _: &'tcx hir::Item) { }
+    fn check_local<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>, _: &'tcx hir::Local) { }
+    fn check_block<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>, _: &'tcx hir::Block) { }
+    fn check_block_post<'a, 'tcx: 'a>(&mut self,
+                                      _: &'a LateContext<'a, 'tcx>,
+                                      _: &'tcx hir::Block) { }
+    fn check_stmt<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>, _: &'tcx hir::Stmt) { }
+    fn check_arm<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>, _: &'tcx hir::Arm) { }
+    fn check_pat<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>, _: &'tcx hir::Pat) { }
+    fn check_decl<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>, _: &'tcx hir::Decl) { }
+    fn check_expr<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>, _: &'tcx hir::Expr) { }
+    fn check_expr_post<'a, 'tcx: 'a>(&mut self,
+                                     _: &'a LateContext<'a, 'tcx>,
+                                     _: &'tcx hir::Expr) { }
+    fn check_ty<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>, _: &'tcx hir::Ty) { }
+    fn check_generics<'a, 'tcx: 'a>(&mut self,
+                                    _: &'a LateContext<'a, 'tcx>,
+                                    _: &'tcx hir::Generics) { }
+    fn check_fn<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>,
+        _: FnKind<'tcx>, _: &'tcx hir::FnDecl, _: &'tcx hir::Expr, _: Span, _: ast::NodeId) { }
+    fn check_fn_post<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>,
+        _: FnKind<'tcx>, _: &'tcx hir::FnDecl, _: &'tcx hir::Expr, _: Span, _: ast::NodeId) { }
+    fn check_trait_item<'a, 'tcx: 'a>(&mut self,
+                                      _: &'a LateContext<'a, 'tcx>,
+                                      _: &'tcx hir::TraitItem) { }
+    fn check_trait_item_post<'a, 'tcx: 'a>(&mut self,
+                                           _: &'a LateContext<'a, 'tcx>,
+                                           _: &'tcx hir::TraitItem) { }
+    fn check_impl_item<'a, 'tcx: 'a>(&mut self,
+                                     _: &'a LateContext<'a, 'tcx>,
+                                     _: &'tcx hir::ImplItem) { }
+    fn check_impl_item_post<'a, 'tcx: 'a>(&mut self,
+                                          _: &'a LateContext<'a, 'tcx>,
+                                          _: &'tcx hir::ImplItem) { }
+    fn check_struct_def<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>,
+        _: &'tcx hir::VariantData, _: ast::Name, _: &'tcx hir::Generics, _: ast::NodeId) { }
+    fn check_struct_def_post<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>,
+        _: &'tcx hir::VariantData, _: ast::Name, _: &'tcx hir::Generics, _: ast::NodeId) { }
+    fn check_struct_field<'a, 'tcx: 'a>(&mut self,
+                                        _: &'a LateContext<'a, 'tcx>,
+                                        _: &'tcx hir::StructField) { }
+    fn check_variant<'a, 'tcx: 'a>(&mut self,
+                                   _: &'a LateContext<'a, 'tcx>,
+                                   _: &'tcx hir::Variant,
+                                   _: &'tcx hir::Generics) { }
+    fn check_variant_post<'a, 'tcx: 'a>(&mut self,
+                                        _: &'a LateContext<'a, 'tcx>,
+                                        _: &'tcx hir::Variant,
+                                        _: &'tcx hir::Generics) { }
+    fn check_lifetime<'a, 'tcx: 'a>(&mut self,
+                                    _: &'a LateContext<'a, 'tcx>,
+                                    _: &'tcx hir::Lifetime) { }
+    fn check_lifetime_def<'a, 'tcx: 'a>(&mut self,
+                                        _: &'a LateContext<'a, 'tcx>,
+                                        _: &'tcx hir::LifetimeDef) { }
+    fn check_path<'a, 'tcx: 'a>(&mut self,
+                                _: &'a LateContext<'a, 'tcx>,
+                                _: &'tcx hir::Path,
+                                _: ast::NodeId) { }
+    fn check_attribute<'a, 'tcx: 'a>(&mut self,
+                                     _: &'a LateContext<'a, 'tcx>,
+                                     _: &'tcx ast::Attribute) { }
 
     /// Called when entering a syntax node that can have lint attributes such
     /// as `#[allow(...)]`. Called with *all* the attributes of that node.
-    fn enter_lint_attrs(&mut self, _: &LateContext, _: &[ast::Attribute]) { }
+    fn enter_lint_attrs<'a, 'tcx: 'a>(&mut self,
+                                      _: &'a LateContext<'a, 'tcx>,
+                                      _: &'tcx [ast::Attribute]) { }
 
     /// Counterpart to `enter_lint_attrs`.
-    fn exit_lint_attrs(&mut self, _: &LateContext, _: &[ast::Attribute]) { }
+    fn exit_lint_attrs<'a, 'tcx: 'a>(&mut self,
+                                     _: &'a LateContext<'a, 'tcx>,
+                                     _: &'tcx [ast::Attribute]) { }
 }
 
 pub trait EarlyLintPass: LintPass {

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -129,106 +129,85 @@ pub trait LintPass {
 //
 // FIXME: eliminate the duplication with `Visitor`. But this also
 // contains a few lint-specific methods with no equivalent in `Visitor`.
-pub trait LateLintPass: LintPass {
+pub trait LateLintPass<'a, 'tcx>: LintPass {
     fn check_name(&mut self, _: &LateContext, _: Span, _: ast::Name) { }
-    fn check_crate<'a, 'tcx:'a >(&mut self, _: &'a LateContext<'a, 'tcx>, _: &'tcx hir::Crate) { }
-    fn check_crate_post<'a, 'tcx: 'a>(&mut self,
-                                      _: &'a LateContext<'a, 'tcx>,
-                                      _: &'tcx hir::Crate) { }
-    fn check_mod<'a, 'tcx: 'a>(&mut self,
-                               _: &'a LateContext<'a, 'tcx>,
-                               _: &'tcx hir::Mod,
-                               _: Span,
-                               _: ast::NodeId) { }
-    fn check_mod_post<'a, 'tcx: 'a>(&mut self,
-                                    _: &'a LateContext<'a, 'tcx>,
-                                    _: &'tcx hir::Mod,
-                                    _: Span,
-                                    _: ast::NodeId) { }
-    fn check_foreign_item<'a, 'tcx: 'a>(&mut self,
-                                        _: &'a LateContext<'a, 'tcx>,
-                                        _: &'tcx hir::ForeignItem) { }
-    fn check_foreign_item_post<'a, 'tcx: 'a>(&mut self,
-                                             _: &'a LateContext<'a, 'tcx>,
-                                             _: &'tcx hir::ForeignItem) { }
-    fn check_item<'a, 'tcx: 'a>(&mut self,
-                                _: &'a LateContext<'a, 'tcx>,
-                                _: &'tcx hir::Item) { }
-    fn check_item_post<'a, 'tcx: 'a>(&mut self,
-                                     _: &'a LateContext<'a, 'tcx>,
-                                     _: &'tcx hir::Item) { }
-    fn check_local<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>, _: &'tcx hir::Local) { }
-    fn check_block<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>, _: &'tcx hir::Block) { }
-    fn check_block_post<'a, 'tcx: 'a>(&mut self,
-                                      _: &'a LateContext<'a, 'tcx>,
-                                      _: &'tcx hir::Block) { }
-    fn check_stmt<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>, _: &'tcx hir::Stmt) { }
-    fn check_arm<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>, _: &'tcx hir::Arm) { }
-    fn check_pat<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>, _: &'tcx hir::Pat) { }
-    fn check_decl<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>, _: &'tcx hir::Decl) { }
-    fn check_expr<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>, _: &'tcx hir::Expr) { }
-    fn check_expr_post<'a, 'tcx: 'a>(&mut self,
-                                     _: &'a LateContext<'a, 'tcx>,
-                                     _: &'tcx hir::Expr) { }
-    fn check_ty<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>, _: &'tcx hir::Ty) { }
-    fn check_generics<'a, 'tcx: 'a>(&mut self,
-                                    _: &'a LateContext<'a, 'tcx>,
-                                    _: &'tcx hir::Generics) { }
-    fn check_fn<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>,
-        _: FnKind<'tcx>, _: &'tcx hir::FnDecl, _: &'tcx hir::Expr, _: Span, _: ast::NodeId) { }
-    fn check_fn_post<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>,
-        _: FnKind<'tcx>, _: &'tcx hir::FnDecl, _: &'tcx hir::Expr, _: Span, _: ast::NodeId) { }
-    fn check_trait_item<'a, 'tcx: 'a>(&mut self,
-                                      _: &'a LateContext<'a, 'tcx>,
-                                      _: &'tcx hir::TraitItem) { }
-    fn check_trait_item_post<'a, 'tcx: 'a>(&mut self,
-                                           _: &'a LateContext<'a, 'tcx>,
-                                           _: &'tcx hir::TraitItem) { }
-    fn check_impl_item<'a, 'tcx: 'a>(&mut self,
-                                     _: &'a LateContext<'a, 'tcx>,
-                                     _: &'tcx hir::ImplItem) { }
-    fn check_impl_item_post<'a, 'tcx: 'a>(&mut self,
-                                          _: &'a LateContext<'a, 'tcx>,
-                                          _: &'tcx hir::ImplItem) { }
-    fn check_struct_def<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>,
-        _: &'tcx hir::VariantData, _: ast::Name, _: &'tcx hir::Generics, _: ast::NodeId) { }
-    fn check_struct_def_post<'a, 'tcx: 'a>(&mut self, _: &'a LateContext<'a, 'tcx>,
-        _: &'tcx hir::VariantData, _: ast::Name, _: &'tcx hir::Generics, _: ast::NodeId) { }
-    fn check_struct_field<'a, 'tcx: 'a>(&mut self,
-                                        _: &'a LateContext<'a, 'tcx>,
-                                        _: &'tcx hir::StructField) { }
-    fn check_variant<'a, 'tcx: 'a>(&mut self,
-                                   _: &'a LateContext<'a, 'tcx>,
-                                   _: &'tcx hir::Variant,
-                                   _: &'tcx hir::Generics) { }
-    fn check_variant_post<'a, 'tcx: 'a>(&mut self,
-                                        _: &'a LateContext<'a, 'tcx>,
-                                        _: &'tcx hir::Variant,
-                                        _: &'tcx hir::Generics) { }
-    fn check_lifetime<'a, 'tcx: 'a>(&mut self,
-                                    _: &'a LateContext<'a, 'tcx>,
-                                    _: &'tcx hir::Lifetime) { }
-    fn check_lifetime_def<'a, 'tcx: 'a>(&mut self,
-                                        _: &'a LateContext<'a, 'tcx>,
-                                        _: &'tcx hir::LifetimeDef) { }
-    fn check_path<'a, 'tcx: 'a>(&mut self,
-                                _: &'a LateContext<'a, 'tcx>,
-                                _: &'tcx hir::Path,
-                                _: ast::NodeId) { }
-    fn check_attribute<'a, 'tcx: 'a>(&mut self,
-                                     _: &'a LateContext<'a, 'tcx>,
-                                     _: &'tcx ast::Attribute) { }
+    fn check_crate(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::Crate) { }
+    fn check_crate_post(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::Crate) { }
+    fn check_mod(&mut self,
+                 _: &LateContext<'a, 'tcx>,
+                 _: &'tcx hir::Mod,
+                 _: Span,
+                 _: ast::NodeId) { }
+    fn check_mod_post(&mut self,
+                      _: &LateContext<'a, 'tcx>,
+                      _: &'tcx hir::Mod,
+                      _: Span,
+                      _: ast::NodeId) { }
+    fn check_foreign_item(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::ForeignItem) { }
+    fn check_foreign_item_post(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::ForeignItem) { }
+    fn check_item(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::Item) { }
+    fn check_item_post(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::Item) { }
+    fn check_local(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::Local) { }
+    fn check_block(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::Block) { }
+    fn check_block_post(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::Block) { }
+    fn check_stmt(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::Stmt) { }
+    fn check_arm(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::Arm) { }
+    fn check_pat(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::Pat) { }
+    fn check_decl(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::Decl) { }
+    fn check_expr(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::Expr) { }
+    fn check_expr_post(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::Expr) { }
+    fn check_ty(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::Ty) { }
+    fn check_generics(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::Generics) { }
+    fn check_fn(&mut self,
+                _: &LateContext<'a, 'tcx>,
+                _: FnKind<'tcx>,
+                _: &'tcx hir::FnDecl,
+                _: &'tcx hir::Expr,
+                _: Span,
+                _: ast::NodeId) { }
+    fn check_fn_post(&mut self,
+                     _: &LateContext<'a, 'tcx>,
+                     _: FnKind<'tcx>,
+                     _: &'tcx hir::FnDecl,
+                     _: &'tcx hir::Expr,
+                     _: Span,
+                     _: ast::NodeId) { }
+    fn check_trait_item(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::TraitItem) { }
+    fn check_trait_item_post(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::TraitItem) { }
+    fn check_impl_item(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::ImplItem) { }
+    fn check_impl_item_post(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::ImplItem) { }
+    fn check_struct_def(&mut self,
+                        _: &LateContext<'a, 'tcx>,
+                        _: &'tcx hir::VariantData,
+                        _: ast::Name,
+                        _: &'tcx hir::Generics,
+                        _: ast::NodeId) { }
+    fn check_struct_def_post(&mut self,
+                             _: &LateContext<'a, 'tcx>,
+                             _: &'tcx hir::VariantData,
+                             _: ast::Name,
+                             _: &'tcx hir::Generics,
+                             _: ast::NodeId) { }
+    fn check_struct_field(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::StructField) { }
+    fn check_variant(&mut self,
+                     _: &LateContext<'a, 'tcx>,
+                     _: &'tcx hir::Variant,
+                     _: &'tcx hir::Generics) { }
+    fn check_variant_post(&mut self,
+                          _: &LateContext<'a, 'tcx>,
+                          _: &'tcx hir::Variant,
+                          _: &'tcx hir::Generics) { }
+    fn check_lifetime(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::Lifetime) { }
+    fn check_lifetime_def(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::LifetimeDef) { }
+    fn check_path(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx hir::Path, _: ast::NodeId) { }
+    fn check_attribute(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx ast::Attribute) { }
 
     /// Called when entering a syntax node that can have lint attributes such
     /// as `#[allow(...)]`. Called with *all* the attributes of that node.
-    fn enter_lint_attrs<'a, 'tcx: 'a>(&mut self,
-                                      _: &'a LateContext<'a, 'tcx>,
-                                      _: &'tcx [ast::Attribute]) { }
+    fn enter_lint_attrs(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx [ast::Attribute]) { }
 
     /// Counterpart to `enter_lint_attrs`.
-    fn exit_lint_attrs<'a, 'tcx: 'a>(&mut self,
-                                     _: &'a LateContext<'a, 'tcx>,
-                                     _: &'tcx [ast::Attribute]) { }
+    fn exit_lint_attrs(&mut self, _: &LateContext<'a, 'tcx>, _: &'tcx [ast::Attribute]) { }
 }
 
 pub trait EarlyLintPass: LintPass {
@@ -282,7 +261,7 @@ pub trait EarlyLintPass: LintPass {
 
 /// A lint pass boxed up as a trait object.
 pub type EarlyLintPassObject = Box<EarlyLintPass + 'static>;
-pub type LateLintPassObject = Box<LateLintPass + 'static>;
+pub type LateLintPassObject = Box<for<'a, 'tcx> LateLintPass<'a, 'tcx> + 'static>;
 
 /// Identifies a lint known to the compiler.
 #[derive(Clone, Copy, Debug)]

--- a/src/librustc_lint/bad_style.rs
+++ b/src/librustc_lint/bad_style.rs
@@ -100,7 +100,7 @@ impl LintPass for NonCamelCaseTypes {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonCamelCaseTypes {
-    fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
+    fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
         let extern_repr_count = it.attrs
             .iter()
             .filter(|attr| {
@@ -133,9 +133,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonCamelCaseTypes {
         }
     }
 
-    fn check_generics(&mut self,
-                                    cx: &LateContext<'a, 'tcx>,
-                                    it: &'tcx hir::Generics) {
+    fn check_generics(&mut self, cx: &LateContext, it: &hir::Generics) {
         for gen in it.ty_params.iter() {
             self.check_case(cx, "type parameter", gen.name, gen.span);
         }
@@ -229,7 +227,7 @@ impl LintPass for NonSnakeCase {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonSnakeCase {
-    fn check_crate(&mut self, cx: &LateContext<'a, 'tcx>, cr: &'tcx hir::Crate) {
+    fn check_crate(&mut self, cx: &LateContext, cr: &hir::Crate) {
         let attr_crate_name = cr.attrs
             .iter()
             .find(|at| at.check_name("crate_name"))
@@ -242,12 +240,12 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonSnakeCase {
     }
 
     fn check_fn(&mut self,
-                              cx: &LateContext<'a, 'tcx>,
-                              fk: FnKind,
-                              _: &'tcx hir::FnDecl,
-                              _: &'tcx hir::Expr,
-                              span: Span,
-                              id: ast::NodeId) {
+                cx: &LateContext,
+                fk: FnKind,
+                _: &hir::FnDecl,
+                _: &hir::Expr,
+                span: Span,
+                id: ast::NodeId) {
         match fk {
             FnKind::Method(name, ..) => {
                 match method_context(cx, id, span) {
@@ -267,15 +265,13 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonSnakeCase {
         }
     }
 
-    fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
+    fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
         if let hir::ItemMod(_) = it.node {
             self.check_snake_case(cx, "module", &it.name.as_str(), Some(it.span));
         }
     }
 
-    fn check_trait_item(&mut self,
-                                      cx: &LateContext<'a, 'tcx>,
-                                      trait_item: &'tcx hir::TraitItem) {
+    fn check_trait_item(&mut self, cx: &LateContext, trait_item: &hir::TraitItem) {
         if let hir::MethodTraitItem(_, None) = trait_item.node {
             self.check_snake_case(cx,
                                   "trait method",
@@ -284,16 +280,14 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonSnakeCase {
         }
     }
 
-    fn check_lifetime_def(&mut self,
-                                        cx: &LateContext<'a, 'tcx>,
-                                        t: &'tcx hir::LifetimeDef) {
+    fn check_lifetime_def(&mut self, cx: &LateContext, t: &hir::LifetimeDef) {
         self.check_snake_case(cx,
                               "lifetime",
                               &t.lifetime.name.as_str(),
                               Some(t.lifetime.span));
     }
 
-    fn check_pat(&mut self, cx: &LateContext<'a, 'tcx>, p: &'tcx hir::Pat) {
+    fn check_pat(&mut self, cx: &LateContext, p: &hir::Pat) {
         // Exclude parameter names from foreign functions
         let parent_node = cx.tcx.map.get_parent_node(p.id);
         if let hir::map::NodeForeignItem(item) = cx.tcx.map.get(parent_node) {
@@ -308,11 +302,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonSnakeCase {
     }
 
     fn check_struct_def(&mut self,
-                                      cx: &LateContext<'a, 'tcx>,
-                                      s: &'tcx hir::VariantData,
-                                      _: ast::Name,
-                                      _: &'tcx hir::Generics,
-                                      _: ast::NodeId) {
+                        cx: &LateContext,
+                        s: &hir::VariantData,
+                        _: ast::Name,
+                        _: &hir::Generics,
+                        _: ast::NodeId) {
         for sf in s.fields() {
             self.check_snake_case(cx, "structure field", &sf.name.as_str(), Some(sf.span));
         }
@@ -355,7 +349,7 @@ impl LintPass for NonUpperCaseGlobals {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonUpperCaseGlobals {
-    fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
+    fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
         match it.node {
             hir::ItemStatic(..) => {
                 NonUpperCaseGlobals::check_upper_case(cx, "static variable", it.name, it.span);
@@ -367,9 +361,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonUpperCaseGlobals {
         }
     }
 
-    fn check_trait_item(&mut self,
-                                      cx: &LateContext<'a, 'tcx>,
-                                      ti: &'tcx hir::TraitItem) {
+    fn check_trait_item(&mut self, cx: &LateContext, ti: &hir::TraitItem) {
         match ti.node {
             hir::ConstTraitItem(..) => {
                 NonUpperCaseGlobals::check_upper_case(cx, "associated constant", ti.name, ti.span);
@@ -378,9 +370,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonUpperCaseGlobals {
         }
     }
 
-    fn check_impl_item(&mut self,
-                                     cx: &LateContext<'a, 'tcx>,
-                                     ii: &'tcx hir::ImplItem) {
+    fn check_impl_item(&mut self, cx: &LateContext, ii: &hir::ImplItem) {
         match ii.node {
             hir::ImplItemKind::Const(..) => {
                 NonUpperCaseGlobals::check_upper_case(cx, "associated constant", ii.name, ii.span);
@@ -389,7 +379,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonUpperCaseGlobals {
         }
     }
 
-    fn check_pat(&mut self, cx: &LateContext<'a, 'tcx>, p: &'tcx hir::Pat) {
+    fn check_pat(&mut self, cx: &LateContext, p: &hir::Pat) {
         // Lint for constants that look like binding identifiers (#7526)
         if let PatKind::Path(hir::QPath::Resolved(None, ref path)) = p.node {
             if !path.global && path.segments.len() == 1 && path.segments[0].parameters.is_empty() {

--- a/src/librustc_lint/bad_style.rs
+++ b/src/librustc_lint/bad_style.rs
@@ -99,8 +99,8 @@ impl LintPass for NonCamelCaseTypes {
     }
 }
 
-impl LateLintPass for NonCamelCaseTypes {
-    fn check_item<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonCamelCaseTypes {
+    fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
         let extern_repr_count = it.attrs
             .iter()
             .filter(|attr| {
@@ -133,7 +133,7 @@ impl LateLintPass for NonCamelCaseTypes {
         }
     }
 
-    fn check_generics<'a, 'tcx: 'a>(&mut self,
+    fn check_generics(&mut self,
                                     cx: &LateContext<'a, 'tcx>,
                                     it: &'tcx hir::Generics) {
         for gen in it.ty_params.iter() {
@@ -228,8 +228,8 @@ impl LintPass for NonSnakeCase {
     }
 }
 
-impl LateLintPass for NonSnakeCase {
-    fn check_crate<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, cr: &'tcx hir::Crate) {
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonSnakeCase {
+    fn check_crate(&mut self, cx: &LateContext<'a, 'tcx>, cr: &'tcx hir::Crate) {
         let attr_crate_name = cr.attrs
             .iter()
             .find(|at| at.check_name("crate_name"))
@@ -241,7 +241,7 @@ impl LateLintPass for NonSnakeCase {
         }
     }
 
-    fn check_fn<'a, 'tcx: 'a>(&mut self,
+    fn check_fn(&mut self,
                               cx: &LateContext<'a, 'tcx>,
                               fk: FnKind,
                               _: &'tcx hir::FnDecl,
@@ -267,13 +267,13 @@ impl LateLintPass for NonSnakeCase {
         }
     }
 
-    fn check_item<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
+    fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
         if let hir::ItemMod(_) = it.node {
             self.check_snake_case(cx, "module", &it.name.as_str(), Some(it.span));
         }
     }
 
-    fn check_trait_item<'a, 'tcx: 'a>(&mut self,
+    fn check_trait_item(&mut self,
                                       cx: &LateContext<'a, 'tcx>,
                                       trait_item: &'tcx hir::TraitItem) {
         if let hir::MethodTraitItem(_, None) = trait_item.node {
@@ -284,7 +284,7 @@ impl LateLintPass for NonSnakeCase {
         }
     }
 
-    fn check_lifetime_def<'a, 'tcx: 'a>(&mut self,
+    fn check_lifetime_def(&mut self,
                                         cx: &LateContext<'a, 'tcx>,
                                         t: &'tcx hir::LifetimeDef) {
         self.check_snake_case(cx,
@@ -293,7 +293,7 @@ impl LateLintPass for NonSnakeCase {
                               Some(t.lifetime.span));
     }
 
-    fn check_pat<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, p: &'tcx hir::Pat) {
+    fn check_pat(&mut self, cx: &LateContext<'a, 'tcx>, p: &'tcx hir::Pat) {
         // Exclude parameter names from foreign functions
         let parent_node = cx.tcx.map.get_parent_node(p.id);
         if let hir::map::NodeForeignItem(item) = cx.tcx.map.get(parent_node) {
@@ -307,7 +307,7 @@ impl LateLintPass for NonSnakeCase {
         }
     }
 
-    fn check_struct_def<'a, 'tcx: 'a>(&mut self,
+    fn check_struct_def(&mut self,
                                       cx: &LateContext<'a, 'tcx>,
                                       s: &'tcx hir::VariantData,
                                       _: ast::Name,
@@ -354,8 +354,8 @@ impl LintPass for NonUpperCaseGlobals {
     }
 }
 
-impl LateLintPass for NonUpperCaseGlobals {
-    fn check_item<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonUpperCaseGlobals {
+    fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
         match it.node {
             hir::ItemStatic(..) => {
                 NonUpperCaseGlobals::check_upper_case(cx, "static variable", it.name, it.span);
@@ -367,7 +367,7 @@ impl LateLintPass for NonUpperCaseGlobals {
         }
     }
 
-    fn check_trait_item<'a, 'tcx: 'a>(&mut self,
+    fn check_trait_item(&mut self,
                                       cx: &LateContext<'a, 'tcx>,
                                       ti: &'tcx hir::TraitItem) {
         match ti.node {
@@ -378,7 +378,7 @@ impl LateLintPass for NonUpperCaseGlobals {
         }
     }
 
-    fn check_impl_item<'a, 'tcx: 'a>(&mut self,
+    fn check_impl_item(&mut self,
                                      cx: &LateContext<'a, 'tcx>,
                                      ii: &'tcx hir::ImplItem) {
         match ii.node {
@@ -389,7 +389,7 @@ impl LateLintPass for NonUpperCaseGlobals {
         }
     }
 
-    fn check_pat<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, p: &'tcx hir::Pat) {
+    fn check_pat(&mut self, cx: &LateContext<'a, 'tcx>, p: &'tcx hir::Pat) {
         // Lint for constants that look like binding identifiers (#7526)
         if let PatKind::Path(hir::QPath::Resolved(None, ref path)) = p.node {
             if !path.global && path.segments.len() == 1 && path.segments[0].parameters.is_empty() {

--- a/src/librustc_lint/bad_style.rs
+++ b/src/librustc_lint/bad_style.rs
@@ -100,7 +100,7 @@ impl LintPass for NonCamelCaseTypes {
 }
 
 impl LateLintPass for NonCamelCaseTypes {
-    fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
+    fn check_item<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
         let extern_repr_count = it.attrs
             .iter()
             .filter(|attr| {
@@ -133,7 +133,9 @@ impl LateLintPass for NonCamelCaseTypes {
         }
     }
 
-    fn check_generics(&mut self, cx: &LateContext, it: &hir::Generics) {
+    fn check_generics<'a, 'tcx: 'a>(&mut self,
+                                    cx: &LateContext<'a, 'tcx>,
+                                    it: &'tcx hir::Generics) {
         for gen in it.ty_params.iter() {
             self.check_case(cx, "type parameter", gen.name, gen.span);
         }
@@ -227,7 +229,7 @@ impl LintPass for NonSnakeCase {
 }
 
 impl LateLintPass for NonSnakeCase {
-    fn check_crate(&mut self, cx: &LateContext, cr: &hir::Crate) {
+    fn check_crate<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, cr: &'tcx hir::Crate) {
         let attr_crate_name = cr.attrs
             .iter()
             .find(|at| at.check_name("crate_name"))
@@ -239,13 +241,13 @@ impl LateLintPass for NonSnakeCase {
         }
     }
 
-    fn check_fn(&mut self,
-                cx: &LateContext,
-                fk: FnKind,
-                _: &hir::FnDecl,
-                _: &hir::Expr,
-                span: Span,
-                id: ast::NodeId) {
+    fn check_fn<'a, 'tcx: 'a>(&mut self,
+                              cx: &LateContext<'a, 'tcx>,
+                              fk: FnKind,
+                              _: &'tcx hir::FnDecl,
+                              _: &'tcx hir::Expr,
+                              span: Span,
+                              id: ast::NodeId) {
         match fk {
             FnKind::Method(name, ..) => {
                 match method_context(cx, id, span) {
@@ -265,13 +267,15 @@ impl LateLintPass for NonSnakeCase {
         }
     }
 
-    fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
+    fn check_item<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
         if let hir::ItemMod(_) = it.node {
             self.check_snake_case(cx, "module", &it.name.as_str(), Some(it.span));
         }
     }
 
-    fn check_trait_item(&mut self, cx: &LateContext, trait_item: &hir::TraitItem) {
+    fn check_trait_item<'a, 'tcx: 'a>(&mut self,
+                                      cx: &LateContext<'a, 'tcx>,
+                                      trait_item: &'tcx hir::TraitItem) {
         if let hir::MethodTraitItem(_, None) = trait_item.node {
             self.check_snake_case(cx,
                                   "trait method",
@@ -280,14 +284,16 @@ impl LateLintPass for NonSnakeCase {
         }
     }
 
-    fn check_lifetime_def(&mut self, cx: &LateContext, t: &hir::LifetimeDef) {
+    fn check_lifetime_def<'a, 'tcx: 'a>(&mut self,
+                                        cx: &LateContext<'a, 'tcx>,
+                                        t: &'tcx hir::LifetimeDef) {
         self.check_snake_case(cx,
                               "lifetime",
                               &t.lifetime.name.as_str(),
                               Some(t.lifetime.span));
     }
 
-    fn check_pat(&mut self, cx: &LateContext, p: &hir::Pat) {
+    fn check_pat<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, p: &'tcx hir::Pat) {
         // Exclude parameter names from foreign functions
         let parent_node = cx.tcx.map.get_parent_node(p.id);
         if let hir::map::NodeForeignItem(item) = cx.tcx.map.get(parent_node) {
@@ -301,12 +307,12 @@ impl LateLintPass for NonSnakeCase {
         }
     }
 
-    fn check_struct_def(&mut self,
-                        cx: &LateContext,
-                        s: &hir::VariantData,
-                        _: ast::Name,
-                        _: &hir::Generics,
-                        _: ast::NodeId) {
+    fn check_struct_def<'a, 'tcx: 'a>(&mut self,
+                                      cx: &LateContext<'a, 'tcx>,
+                                      s: &'tcx hir::VariantData,
+                                      _: ast::Name,
+                                      _: &'tcx hir::Generics,
+                                      _: ast::NodeId) {
         for sf in s.fields() {
             self.check_snake_case(cx, "structure field", &sf.name.as_str(), Some(sf.span));
         }
@@ -349,7 +355,7 @@ impl LintPass for NonUpperCaseGlobals {
 }
 
 impl LateLintPass for NonUpperCaseGlobals {
-    fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
+    fn check_item<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
         match it.node {
             hir::ItemStatic(..) => {
                 NonUpperCaseGlobals::check_upper_case(cx, "static variable", it.name, it.span);
@@ -361,7 +367,9 @@ impl LateLintPass for NonUpperCaseGlobals {
         }
     }
 
-    fn check_trait_item(&mut self, cx: &LateContext, ti: &hir::TraitItem) {
+    fn check_trait_item<'a, 'tcx: 'a>(&mut self,
+                                      cx: &LateContext<'a, 'tcx>,
+                                      ti: &'tcx hir::TraitItem) {
         match ti.node {
             hir::ConstTraitItem(..) => {
                 NonUpperCaseGlobals::check_upper_case(cx, "associated constant", ti.name, ti.span);
@@ -370,7 +378,9 @@ impl LateLintPass for NonUpperCaseGlobals {
         }
     }
 
-    fn check_impl_item(&mut self, cx: &LateContext, ii: &hir::ImplItem) {
+    fn check_impl_item<'a, 'tcx: 'a>(&mut self,
+                                     cx: &LateContext<'a, 'tcx>,
+                                     ii: &'tcx hir::ImplItem) {
         match ii.node {
             hir::ImplItemKind::Const(..) => {
                 NonUpperCaseGlobals::check_upper_case(cx, "associated constant", ii.name, ii.span);
@@ -379,7 +389,7 @@ impl LateLintPass for NonUpperCaseGlobals {
         }
     }
 
-    fn check_pat(&mut self, cx: &LateContext, p: &hir::Pat) {
+    fn check_pat<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, p: &'tcx hir::Pat) {
         // Lint for constants that look like binding identifiers (#7526)
         if let PatKind::Path(hir::QPath::Resolved(None, ref path)) = p.node {
             if !path.global && path.segments.len() == 1 && path.segments[0].parameters.is_empty() {

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -104,7 +104,7 @@ impl LintPass for TypeLimits {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
-    fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx hir::Expr) {
+    fn check_expr(&mut self, cx: &LateContext, e: &hir::Expr) {
         match e.node {
             hir::ExprUnary(hir::UnNeg, ref expr) => {
                 if let hir::ExprLit(ref lit) = expr.node {
@@ -707,7 +707,7 @@ impl LintPass for ImproperCTypes {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ImproperCTypes {
-    fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
+    fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
         let mut vis = ImproperCTypesVisitor { cx: cx };
         if let hir::ItemForeignMod(ref nmod) = it.node {
             if nmod.abi != Abi::RustIntrinsic && nmod.abi != Abi::PlatformIntrinsic {
@@ -735,7 +735,7 @@ impl LintPass for VariantSizeDifferences {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for VariantSizeDifferences {
-    fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
+    fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
         if let hir::ItemEnum(ref enum_definition, ref gens) = it.node {
             if gens.ty_params.is_empty() {
                 // sizes only make sense for non-generic types

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -104,7 +104,7 @@ impl LintPass for TypeLimits {
 }
 
 impl LateLintPass for TypeLimits {
-    fn check_expr(&mut self, cx: &LateContext, e: &hir::Expr) {
+    fn check_expr<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx hir::Expr) {
         match e.node {
             hir::ExprUnary(hir::UnNeg, ref expr) => {
                 if let hir::ExprLit(ref lit) = expr.node {
@@ -707,7 +707,7 @@ impl LintPass for ImproperCTypes {
 }
 
 impl LateLintPass for ImproperCTypes {
-    fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
+    fn check_item<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
         let mut vis = ImproperCTypesVisitor { cx: cx };
         if let hir::ItemForeignMod(ref nmod) = it.node {
             if nmod.abi != Abi::RustIntrinsic && nmod.abi != Abi::PlatformIntrinsic {
@@ -735,7 +735,7 @@ impl LintPass for VariantSizeDifferences {
 }
 
 impl LateLintPass for VariantSizeDifferences {
-    fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
+    fn check_item<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
         if let hir::ItemEnum(ref enum_definition, ref gens) = it.node {
             if gens.ty_params.is_empty() {
                 // sizes only make sense for non-generic types

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -103,8 +103,8 @@ impl LintPass for TypeLimits {
     }
 }
 
-impl LateLintPass for TypeLimits {
-    fn check_expr<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx hir::Expr) {
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeLimits {
+    fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx hir::Expr) {
         match e.node {
             hir::ExprUnary(hir::UnNeg, ref expr) => {
                 if let hir::ExprLit(ref lit) = expr.node {
@@ -706,8 +706,8 @@ impl LintPass for ImproperCTypes {
     }
 }
 
-impl LateLintPass for ImproperCTypes {
-    fn check_item<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ImproperCTypes {
+    fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
         let mut vis = ImproperCTypesVisitor { cx: cx };
         if let hir::ItemForeignMod(ref nmod) = it.node {
             if nmod.abi != Abi::RustIntrinsic && nmod.abi != Abi::PlatformIntrinsic {
@@ -734,8 +734,8 @@ impl LintPass for VariantSizeDifferences {
     }
 }
 
-impl LateLintPass for VariantSizeDifferences {
-    fn check_item<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for VariantSizeDifferences {
+    fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
         if let hir::ItemEnum(ref enum_definition, ref gens) = it.node {
             if gens.ty_params.is_empty() {
                 // sizes only make sense for non-generic types

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -77,8 +77,8 @@ impl LintPass for UnusedMut {
     }
 }
 
-impl LateLintPass for UnusedMut {
-    fn check_expr<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx hir::Expr) {
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedMut {
+    fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx hir::Expr) {
         if let hir::ExprMatch(_, ref arms, _) = e.node {
             for a in arms {
                 self.check_unused_mut_pat(cx, &a.pats)
@@ -86,7 +86,7 @@ impl LateLintPass for UnusedMut {
         }
     }
 
-    fn check_stmt<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, s: &'tcx hir::Stmt) {
+    fn check_stmt(&mut self, cx: &LateContext<'a, 'tcx>, s: &'tcx hir::Stmt) {
         if let hir::StmtDecl(ref d, _) = s.node {
             if let hir::DeclLocal(ref l) = d.node {
                 self.check_unused_mut_pat(cx, slice::ref_slice(&l.pat));
@@ -94,7 +94,7 @@ impl LateLintPass for UnusedMut {
         }
     }
 
-    fn check_fn<'a, 'tcx: 'a>(&mut self,
+    fn check_fn(&mut self,
                               cx: &LateContext<'a, 'tcx>,
                               _: FnKind<'tcx>,
                               decl: &'tcx hir::FnDecl,
@@ -128,8 +128,8 @@ impl LintPass for UnusedResults {
     }
 }
 
-impl LateLintPass for UnusedResults {
-    fn check_stmt<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, s: &'tcx hir::Stmt) {
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
+    fn check_stmt(&mut self, cx: &LateContext<'a, 'tcx>, s: &'tcx hir::Stmt) {
         let expr = match s.node {
             hir::StmtSemi(ref expr, _) => &**expr,
             _ => return,
@@ -187,8 +187,8 @@ impl LintPass for UnusedUnsafe {
     }
 }
 
-impl LateLintPass for UnusedUnsafe {
-    fn check_expr<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx hir::Expr) {
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedUnsafe {
+    fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx hir::Expr) {
         if let hir::ExprBlock(ref blk) = e.node {
             // Don't warn about generated blocks, that'll just pollute the output.
             if blk.rules == hir::UnsafeBlock(hir::UserProvided) &&
@@ -214,8 +214,8 @@ impl LintPass for PathStatements {
     }
 }
 
-impl LateLintPass for PathStatements {
-    fn check_stmt<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, s: &'tcx hir::Stmt) {
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for PathStatements {
+    fn check_stmt(&mut self, cx: &LateContext<'a, 'tcx>, s: &'tcx hir::Stmt) {
         if let hir::StmtSemi(ref expr, _) = s.node {
             if let hir::ExprPath(_) = expr.node {
                 cx.span_lint(PATH_STATEMENTS, s.span, "path statement with no effect");
@@ -239,8 +239,8 @@ impl LintPass for UnusedAttributes {
     }
 }
 
-impl LateLintPass for UnusedAttributes {
-    fn check_attribute<'a, 'tcx: 'a>(&mut self,
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedAttributes {
+    fn check_attribute(&mut self,
                                      cx: &LateContext<'a, 'tcx>,
                                      attr: &'tcx ast::Attribute) {
         debug!("checking attribute: {:?}", attr);
@@ -435,8 +435,8 @@ impl LintPass for UnusedAllocation {
     }
 }
 
-impl LateLintPass for UnusedAllocation {
-    fn check_expr<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx hir::Expr) {
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedAllocation {
+    fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx hir::Expr) {
         match e.node {
             hir::ExprBox(_) => {}
             _ => return,

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -78,7 +78,7 @@ impl LintPass for UnusedMut {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedMut {
-    fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx hir::Expr) {
+    fn check_expr(&mut self, cx: &LateContext, e: &hir::Expr) {
         if let hir::ExprMatch(_, ref arms, _) = e.node {
             for a in arms {
                 self.check_unused_mut_pat(cx, &a.pats)
@@ -86,7 +86,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedMut {
         }
     }
 
-    fn check_stmt(&mut self, cx: &LateContext<'a, 'tcx>, s: &'tcx hir::Stmt) {
+    fn check_stmt(&mut self, cx: &LateContext, s: &hir::Stmt) {
         if let hir::StmtDecl(ref d, _) = s.node {
             if let hir::DeclLocal(ref l) = d.node {
                 self.check_unused_mut_pat(cx, slice::ref_slice(&l.pat));
@@ -95,12 +95,12 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedMut {
     }
 
     fn check_fn(&mut self,
-                              cx: &LateContext<'a, 'tcx>,
-                              _: FnKind<'tcx>,
-                              decl: &'tcx hir::FnDecl,
-                              _: &'tcx hir::Expr,
-                              _: Span,
-                              _: ast::NodeId) {
+                cx: &LateContext,
+                _: FnKind,
+                decl: &hir::FnDecl,
+                _: &hir::Expr,
+                _: Span,
+                _: ast::NodeId) {
         for a in &decl.inputs {
             self.check_unused_mut_pat(cx, slice::ref_slice(&a.pat));
         }
@@ -129,7 +129,7 @@ impl LintPass for UnusedResults {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
-    fn check_stmt(&mut self, cx: &LateContext<'a, 'tcx>, s: &'tcx hir::Stmt) {
+    fn check_stmt(&mut self, cx: &LateContext, s: &hir::Stmt) {
         let expr = match s.node {
             hir::StmtSemi(ref expr, _) => &**expr,
             _ => return,
@@ -188,7 +188,7 @@ impl LintPass for UnusedUnsafe {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedUnsafe {
-    fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx hir::Expr) {
+    fn check_expr(&mut self, cx: &LateContext, e: &hir::Expr) {
         if let hir::ExprBlock(ref blk) = e.node {
             // Don't warn about generated blocks, that'll just pollute the output.
             if blk.rules == hir::UnsafeBlock(hir::UserProvided) &&
@@ -215,7 +215,7 @@ impl LintPass for PathStatements {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for PathStatements {
-    fn check_stmt(&mut self, cx: &LateContext<'a, 'tcx>, s: &'tcx hir::Stmt) {
+    fn check_stmt(&mut self, cx: &LateContext, s: &hir::Stmt) {
         if let hir::StmtSemi(ref expr, _) = s.node {
             if let hir::ExprPath(_) = expr.node {
                 cx.span_lint(PATH_STATEMENTS, s.span, "path statement with no effect");
@@ -240,9 +240,7 @@ impl LintPass for UnusedAttributes {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedAttributes {
-    fn check_attribute(&mut self,
-                                     cx: &LateContext<'a, 'tcx>,
-                                     attr: &'tcx ast::Attribute) {
+    fn check_attribute(&mut self, cx: &LateContext, attr: &ast::Attribute) {
         debug!("checking attribute: {:?}", attr);
 
         // Note that check_name() marks the attribute as used if it matches.
@@ -436,7 +434,7 @@ impl LintPass for UnusedAllocation {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedAllocation {
-    fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx hir::Expr) {
+    fn check_expr(&mut self, cx: &LateContext, e: &hir::Expr) {
         match e.node {
             hir::ExprBox(_) => {}
             _ => return,

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -78,7 +78,7 @@ impl LintPass for UnusedMut {
 }
 
 impl LateLintPass for UnusedMut {
-    fn check_expr(&mut self, cx: &LateContext, e: &hir::Expr) {
+    fn check_expr<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx hir::Expr) {
         if let hir::ExprMatch(_, ref arms, _) = e.node {
             for a in arms {
                 self.check_unused_mut_pat(cx, &a.pats)
@@ -86,7 +86,7 @@ impl LateLintPass for UnusedMut {
         }
     }
 
-    fn check_stmt(&mut self, cx: &LateContext, s: &hir::Stmt) {
+    fn check_stmt<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, s: &'tcx hir::Stmt) {
         if let hir::StmtDecl(ref d, _) = s.node {
             if let hir::DeclLocal(ref l) = d.node {
                 self.check_unused_mut_pat(cx, slice::ref_slice(&l.pat));
@@ -94,13 +94,13 @@ impl LateLintPass for UnusedMut {
         }
     }
 
-    fn check_fn(&mut self,
-                cx: &LateContext,
-                _: FnKind,
-                decl: &hir::FnDecl,
-                _: &hir::Expr,
-                _: Span,
-                _: ast::NodeId) {
+    fn check_fn<'a, 'tcx: 'a>(&mut self,
+                              cx: &LateContext<'a, 'tcx>,
+                              _: FnKind<'tcx>,
+                              decl: &'tcx hir::FnDecl,
+                              _: &'tcx hir::Expr,
+                              _: Span,
+                              _: ast::NodeId) {
         for a in &decl.inputs {
             self.check_unused_mut_pat(cx, slice::ref_slice(&a.pat));
         }
@@ -129,7 +129,7 @@ impl LintPass for UnusedResults {
 }
 
 impl LateLintPass for UnusedResults {
-    fn check_stmt(&mut self, cx: &LateContext, s: &hir::Stmt) {
+    fn check_stmt<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, s: &'tcx hir::Stmt) {
         let expr = match s.node {
             hir::StmtSemi(ref expr, _) => &**expr,
             _ => return,
@@ -188,7 +188,7 @@ impl LintPass for UnusedUnsafe {
 }
 
 impl LateLintPass for UnusedUnsafe {
-    fn check_expr(&mut self, cx: &LateContext, e: &hir::Expr) {
+    fn check_expr<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx hir::Expr) {
         if let hir::ExprBlock(ref blk) = e.node {
             // Don't warn about generated blocks, that'll just pollute the output.
             if blk.rules == hir::UnsafeBlock(hir::UserProvided) &&
@@ -215,7 +215,7 @@ impl LintPass for PathStatements {
 }
 
 impl LateLintPass for PathStatements {
-    fn check_stmt(&mut self, cx: &LateContext, s: &hir::Stmt) {
+    fn check_stmt<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, s: &'tcx hir::Stmt) {
         if let hir::StmtSemi(ref expr, _) = s.node {
             if let hir::ExprPath(_) = expr.node {
                 cx.span_lint(PATH_STATEMENTS, s.span, "path statement with no effect");
@@ -240,7 +240,9 @@ impl LintPass for UnusedAttributes {
 }
 
 impl LateLintPass for UnusedAttributes {
-    fn check_attribute(&mut self, cx: &LateContext, attr: &ast::Attribute) {
+    fn check_attribute<'a, 'tcx: 'a>(&mut self,
+                                     cx: &LateContext<'a, 'tcx>,
+                                     attr: &'tcx ast::Attribute) {
         debug!("checking attribute: {:?}", attr);
 
         // Note that check_name() marks the attribute as used if it matches.
@@ -434,7 +436,7 @@ impl LintPass for UnusedAllocation {
 }
 
 impl LateLintPass for UnusedAllocation {
-    fn check_expr(&mut self, cx: &LateContext, e: &hir::Expr) {
+    fn check_expr<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx hir::Expr) {
         match e.node {
             hir::ExprBox(_) => {}
             _ => return,

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -101,8 +101,8 @@ impl<'a> AstValidator<'a> {
     }
 }
 
-impl<'a> Visitor for AstValidator<'a> {
-    fn visit_lifetime(&mut self, lt: &Lifetime) {
+impl<'a> Visitor<'a> for AstValidator<'a> {
+    fn visit_lifetime(&mut self, lt: &'a Lifetime) {
         if lt.name == "'_" {
             self.session.add_lint(lint::builtin::LIFETIME_UNDERSCORE,
                                   lt.id,
@@ -113,7 +113,7 @@ impl<'a> Visitor for AstValidator<'a> {
         visit::walk_lifetime(self, lt)
     }
 
-    fn visit_expr(&mut self, expr: &Expr) {
+    fn visit_expr(&mut self, expr: &'a Expr) {
         match expr.node {
             ExprKind::While(.., Some(ident)) |
             ExprKind::Loop(_, Some(ident)) |
@@ -129,7 +129,7 @@ impl<'a> Visitor for AstValidator<'a> {
         visit::walk_expr(self, expr)
     }
 
-    fn visit_ty(&mut self, ty: &Ty) {
+    fn visit_ty(&mut self, ty: &'a Ty) {
         match ty.node {
             TyKind::BareFn(ref bfty) => {
                 self.check_decl_no_pat(&bfty.decl, |span, _| {
@@ -153,7 +153,7 @@ impl<'a> Visitor for AstValidator<'a> {
         visit::walk_ty(self, ty)
     }
 
-    fn visit_path(&mut self, path: &Path, id: NodeId) {
+    fn visit_path(&mut self, path: &'a Path, id: NodeId) {
         if path.global && path.segments.len() > 0 {
             let ident = path.segments[0].identifier;
             if token::Ident(ident).is_path_segment_keyword() {
@@ -167,7 +167,7 @@ impl<'a> Visitor for AstValidator<'a> {
         visit::walk_path(self, path)
     }
 
-    fn visit_item(&mut self, item: &Item) {
+    fn visit_item(&mut self, item: &'a Item) {
         match item.node {
             ItemKind::Use(ref view_path) => {
                 let path = view_path.node.path();
@@ -249,7 +249,7 @@ impl<'a> Visitor for AstValidator<'a> {
         visit::walk_item(self, item)
     }
 
-    fn visit_foreign_item(&mut self, fi: &ForeignItem) {
+    fn visit_foreign_item(&mut self, fi: &'a ForeignItem) {
         match fi.node {
             ForeignItemKind::Fn(ref decl, _) => {
                 self.check_decl_no_pat(decl, |span, is_recent| {
@@ -272,7 +272,7 @@ impl<'a> Visitor for AstValidator<'a> {
         visit::walk_foreign_item(self, fi)
     }
 
-    fn visit_vis(&mut self, vis: &Visibility) {
+    fn visit_vis(&mut self, vis: &'a Visibility) {
         match *vis {
             Visibility::Restricted { ref path, .. } => {
                 if !path.segments.iter().all(|segment| segment.parameters.is_empty()) {

--- a/src/librustc_passes/hir_stats.rs
+++ b/src/librustc_passes/hir_stats.rs
@@ -48,7 +48,7 @@ pub fn print_hir_stats(krate: &hir::Crate) {
     collector.print("HIR STATS");
 }
 
-pub fn print_ast_stats(krate: &ast::Crate, title: &str) {
+pub fn print_ast_stats<'v>(krate: &'v ast::Crate, title: &str) {
     let mut collector = StatCollector {
         krate: None,
         data: FxHashMap(),
@@ -245,133 +245,133 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
     }
 }
 
-impl<'v> ast_visit::Visitor for StatCollector<'v> {
+impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
 
-    fn visit_mod(&mut self, m: &ast::Mod, _s: Span, _n: NodeId) {
+    fn visit_mod(&mut self, m: &'v ast::Mod, _s: Span, _n: NodeId) {
         self.record("Mod", Id::None, m);
         ast_visit::walk_mod(self, m)
     }
 
-    fn visit_foreign_item(&mut self, i: &ast::ForeignItem) {
+    fn visit_foreign_item(&mut self, i: &'v ast::ForeignItem) {
         self.record("ForeignItem", Id::None, i);
         ast_visit::walk_foreign_item(self, i)
     }
 
-    fn visit_item(&mut self, i: &ast::Item) {
+    fn visit_item(&mut self, i: &'v ast::Item) {
         self.record("Item", Id::None, i);
         ast_visit::walk_item(self, i)
     }
 
-    fn visit_local(&mut self, l: &ast::Local) {
+    fn visit_local(&mut self, l: &'v ast::Local) {
         self.record("Local", Id::None, l);
         ast_visit::walk_local(self, l)
     }
 
-    fn visit_block(&mut self, b: &ast::Block) {
+    fn visit_block(&mut self, b: &'v ast::Block) {
         self.record("Block", Id::None, b);
         ast_visit::walk_block(self, b)
     }
 
-    fn visit_stmt(&mut self, s: &ast::Stmt) {
+    fn visit_stmt(&mut self, s: &'v ast::Stmt) {
         self.record("Stmt", Id::None, s);
         ast_visit::walk_stmt(self, s)
     }
 
-    fn visit_arm(&mut self, a: &ast::Arm) {
+    fn visit_arm(&mut self, a: &'v ast::Arm) {
         self.record("Arm", Id::None, a);
         ast_visit::walk_arm(self, a)
     }
 
-    fn visit_pat(&mut self, p: &ast::Pat) {
+    fn visit_pat(&mut self, p: &'v ast::Pat) {
         self.record("Pat", Id::None, p);
         ast_visit::walk_pat(self, p)
     }
 
-    fn visit_expr(&mut self, ex: &ast::Expr) {
+    fn visit_expr(&mut self, ex: &'v ast::Expr) {
         self.record("Expr", Id::None, ex);
         ast_visit::walk_expr(self, ex)
     }
 
-    fn visit_ty(&mut self, t: &ast::Ty) {
+    fn visit_ty(&mut self, t: &'v ast::Ty) {
         self.record("Ty", Id::None, t);
         ast_visit::walk_ty(self, t)
     }
 
     fn visit_fn(&mut self,
-                fk: ast_visit::FnKind,
-                fd: &ast::FnDecl,
+                fk: ast_visit::FnKind<'v>,
+                fd: &'v ast::FnDecl,
                 s: Span,
                 _: NodeId) {
         self.record("FnDecl", Id::None, fd);
         ast_visit::walk_fn(self, fk, fd, s)
     }
 
-    fn visit_trait_item(&mut self, ti: &ast::TraitItem) {
+    fn visit_trait_item(&mut self, ti: &'v ast::TraitItem) {
         self.record("TraitItem", Id::None, ti);
         ast_visit::walk_trait_item(self, ti)
     }
 
-    fn visit_impl_item(&mut self, ii: &ast::ImplItem) {
+    fn visit_impl_item(&mut self, ii: &'v ast::ImplItem) {
         self.record("ImplItem", Id::None, ii);
         ast_visit::walk_impl_item(self, ii)
     }
 
-    fn visit_ty_param_bound(&mut self, bounds: &ast::TyParamBound) {
+    fn visit_ty_param_bound(&mut self, bounds: &'v ast::TyParamBound) {
         self.record("TyParamBound", Id::None, bounds);
         ast_visit::walk_ty_param_bound(self, bounds)
     }
 
-    fn visit_struct_field(&mut self, s: &ast::StructField) {
+    fn visit_struct_field(&mut self, s: &'v ast::StructField) {
         self.record("StructField", Id::None, s);
         ast_visit::walk_struct_field(self, s)
     }
 
     fn visit_variant(&mut self,
-                     v: &ast::Variant,
-                     g: &ast::Generics,
+                     v: &'v ast::Variant,
+                     g: &'v ast::Generics,
                      item_id: NodeId) {
         self.record("Variant", Id::None, v);
         ast_visit::walk_variant(self, v, g, item_id)
     }
 
-    fn visit_lifetime(&mut self, lifetime: &ast::Lifetime) {
+    fn visit_lifetime(&mut self, lifetime: &'v ast::Lifetime) {
         self.record("Lifetime", Id::None, lifetime);
         ast_visit::walk_lifetime(self, lifetime)
     }
 
-    fn visit_lifetime_def(&mut self, lifetime: &ast::LifetimeDef) {
+    fn visit_lifetime_def(&mut self, lifetime: &'v ast::LifetimeDef) {
         self.record("LifetimeDef", Id::None, lifetime);
         ast_visit::walk_lifetime_def(self, lifetime)
     }
 
-    fn visit_mac(&mut self, mac: &ast::Mac) {
+    fn visit_mac(&mut self, mac: &'v ast::Mac) {
         self.record("Mac", Id::None, mac);
     }
 
     fn visit_path_list_item(&mut self,
-                            prefix: &ast::Path,
-                            item: &ast::PathListItem) {
+                            prefix: &'v ast::Path,
+                            item: &'v ast::PathListItem) {
         self.record("PathListItem", Id::None, item);
         ast_visit::walk_path_list_item(self, prefix, item)
     }
 
     fn visit_path_segment(&mut self,
                           path_span: Span,
-                          path_segment: &ast::PathSegment) {
+                          path_segment: &'v ast::PathSegment) {
         self.record("PathSegment", Id::None, path_segment);
         ast_visit::walk_path_segment(self, path_span, path_segment)
     }
 
-    fn visit_assoc_type_binding(&mut self, type_binding: &ast::TypeBinding) {
+    fn visit_assoc_type_binding(&mut self, type_binding: &'v ast::TypeBinding) {
         self.record("TypeBinding", Id::None, type_binding);
         ast_visit::walk_assoc_type_binding(self, type_binding)
     }
 
-    fn visit_attribute(&mut self, attr: &ast::Attribute) {
+    fn visit_attribute(&mut self, attr: &'v ast::Attribute) {
         self.record("Attribute", Id::None, attr);
     }
 
-    fn visit_macro_def(&mut self, macro_def: &ast::MacroDef) {
+    fn visit_macro_def(&mut self, macro_def: &'v ast::MacroDef) {
         self.record("MacroDef", Id::None, macro_def);
         ast_visit::walk_macro_def(self, macro_def)
     }

--- a/src/librustc_passes/no_asm.rs
+++ b/src/librustc_passes/no_asm.rs
@@ -31,8 +31,8 @@ struct CheckNoAsm<'a> {
     sess: &'a Session,
 }
 
-impl<'a> Visitor for CheckNoAsm<'a> {
-    fn visit_expr(&mut self, e: &ast::Expr) {
+impl<'a> Visitor<'a> for CheckNoAsm<'a> {
+    fn visit_expr(&mut self, e: &'a ast::Expr) {
         match e.node {
             ast::ExprKind::InlineAsm(_) => {
                 span_err!(self.sess,

--- a/src/librustc_resolve/check_unused.rs
+++ b/src/librustc_resolve/check_unused.rs
@@ -74,8 +74,8 @@ impl<'a, 'b> UnusedImportCheckVisitor<'a, 'b> {
     }
 }
 
-impl<'a, 'b> Visitor for UnusedImportCheckVisitor<'a, 'b> {
-    fn visit_item(&mut self, item: &ast::Item) {
+impl<'a, 'b> Visitor<'a> for UnusedImportCheckVisitor<'a, 'b> {
+    fn visit_item(&mut self, item: &'a ast::Item) {
         visit::walk_item(self, item);
         // Ignore is_public import statements because there's no way to be sure
         // whether they're used or not. Also ignore imports with a dummy span

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -557,26 +557,28 @@ impl<T> ::std::ops::IndexMut<Namespace> for PerNS<T> {
     }
 }
 
-impl<'a> Visitor for Resolver<'a> {
-    fn visit_item(&mut self, item: &Item) {
+impl<'a, 'tcx> Visitor<'tcx> for Resolver<'a> {
+    fn visit_item(&mut self, item: &'tcx Item) {
         self.resolve_item(item);
     }
-    fn visit_arm(&mut self, arm: &Arm) {
+    fn visit_arm(&mut self, arm: &'tcx Arm) {
         self.resolve_arm(arm);
     }
-    fn visit_block(&mut self, block: &Block) {
+    fn visit_block(&mut self, block: &'tcx Block) {
         self.resolve_block(block);
     }
-    fn visit_expr(&mut self, expr: &Expr) {
+    fn visit_expr(&mut self, expr: &'tcx Expr) {
         self.resolve_expr(expr, None);
     }
-    fn visit_local(&mut self, local: &Local) {
+    fn visit_local(&mut self, local: &'tcx Local) {
         self.resolve_local(local);
     }
-    fn visit_ty(&mut self, ty: &Ty) {
+    fn visit_ty(&mut self, ty: &'tcx Ty) {
         self.resolve_type(ty);
     }
-    fn visit_poly_trait_ref(&mut self, tref: &ast::PolyTraitRef, m: &ast::TraitBoundModifier) {
+    fn visit_poly_trait_ref(&mut self,
+                            tref: &'tcx ast::PolyTraitRef,
+                            m: &'tcx ast::TraitBoundModifier) {
         let ast::Path { ref segments, span, global } = tref.trait_ref.path;
         let path: Vec<_> = segments.iter().map(|seg| seg.identifier).collect();
         let def = self.resolve_trait_reference(&path, global, None, span);
@@ -584,8 +586,8 @@ impl<'a> Visitor for Resolver<'a> {
         visit::walk_poly_trait_ref(self, tref, m);
     }
     fn visit_variant(&mut self,
-                     variant: &ast::Variant,
-                     generics: &Generics,
+                     variant: &'tcx ast::Variant,
+                     generics: &'tcx Generics,
                      item_id: ast::NodeId) {
         if let Some(ref dis_expr) = variant.node.disr_expr {
             // resolve the discriminator expr as a constant
@@ -601,7 +603,7 @@ impl<'a> Visitor for Resolver<'a> {
                                 item_id,
                                 variant.span);
     }
-    fn visit_foreign_item(&mut self, foreign_item: &ForeignItem) {
+    fn visit_foreign_item(&mut self, foreign_item: &'tcx ForeignItem) {
         let type_parameters = match foreign_item.node {
             ForeignItemKind::Fn(_, ref generics) => {
                 HasTypeParameters(generics, ItemRibKind)
@@ -613,8 +615,8 @@ impl<'a> Visitor for Resolver<'a> {
         });
     }
     fn visit_fn(&mut self,
-                function_kind: FnKind,
-                declaration: &FnDecl,
+                function_kind: FnKind<'tcx>,
+                declaration: &'tcx FnDecl,
                 _: Span,
                 node_id: NodeId) {
         let rib_kind = match function_kind {

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -741,7 +741,7 @@ impl PathCollector {
     }
 }
 
-impl Visitor for PathCollector {
+impl<'a> Visitor<'a> for PathCollector {
     fn visit_pat(&mut self, p: &ast::Pat) {
         match p.node {
             PatKind::Struct(ref path, ..) => {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -85,7 +85,7 @@ macro_rules! expansions {
                 }
             }
 
-            pub fn visit_with<V: Visitor>(&self, visitor: &mut V) {
+            pub fn visit_with<'a, V: Visitor<'a>>(&'a self, visitor: &mut V) {
                 match *self {
                     Expansion::OptExpr(Some(ref expr)) => visitor.visit_expr(expr),
                     Expansion::OptExpr(None) => {}

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -1014,7 +1014,7 @@ fn starts_with_digit(s: &str) -> bool {
     s.as_bytes().first().cloned().map_or(false, |b| b >= b'0' && b <= b'9')
 }
 
-impl<'a> Visitor for PostExpansionVisitor<'a> {
+impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
     fn visit_attribute(&mut self, attr: &ast::Attribute) {
         if !self.context.cm.span_allows_unstable(attr.span) {
             // check for gated attributes
@@ -1035,7 +1035,7 @@ impl<'a> Visitor for PostExpansionVisitor<'a> {
         }
     }
 
-    fn visit_item(&mut self, i: &ast::Item) {
+    fn visit_item(&mut self, i: &'a ast::Item) {
         match i.node {
             ast::ItemKind::ExternCrate(_) => {
                 if attr::contains_name(&i.attrs[..], "macro_reexport") {
@@ -1128,7 +1128,7 @@ impl<'a> Visitor for PostExpansionVisitor<'a> {
         visit::walk_item(self, i);
     }
 
-    fn visit_foreign_item(&mut self, i: &ast::ForeignItem) {
+    fn visit_foreign_item(&mut self, i: &'a ast::ForeignItem) {
         let links_to_llvm = match attr::first_attr_value_str_by_name(&i.attrs, "link_name") {
             Some(val) => val.as_str().starts_with("llvm."),
             _ => false
@@ -1141,7 +1141,7 @@ impl<'a> Visitor for PostExpansionVisitor<'a> {
         visit::walk_foreign_item(self, i)
     }
 
-    fn visit_ty(&mut self, ty: &ast::Ty) {
+    fn visit_ty(&mut self, ty: &'a ast::Ty) {
         match ty.node {
             ast::TyKind::BareFn(ref bare_fn_ty) => {
                 self.check_abi(bare_fn_ty.abi, ty.span);
@@ -1159,7 +1159,7 @@ impl<'a> Visitor for PostExpansionVisitor<'a> {
         visit::walk_ty(self, ty)
     }
 
-    fn visit_fn_ret_ty(&mut self, ret_ty: &ast::FunctionRetTy) {
+    fn visit_fn_ret_ty(&mut self, ret_ty: &'a ast::FunctionRetTy) {
         if let ast::FunctionRetTy::Ty(ref output_ty) = *ret_ty {
             match output_ty.node {
                 ast::TyKind::Never => return,
@@ -1169,7 +1169,7 @@ impl<'a> Visitor for PostExpansionVisitor<'a> {
         }
     }
 
-    fn visit_expr(&mut self, e: &ast::Expr) {
+    fn visit_expr(&mut self, e: &'a ast::Expr) {
         match e.node {
             ast::ExprKind::Box(_) => {
                 gate_feature_post!(&self, box_syntax, e.span, EXPLAIN_BOX_SYNTAX);
@@ -1208,7 +1208,7 @@ impl<'a> Visitor for PostExpansionVisitor<'a> {
         visit::walk_expr(self, e);
     }
 
-    fn visit_pat(&mut self, pattern: &ast::Pat) {
+    fn visit_pat(&mut self, pattern: &'a ast::Pat) {
         match pattern.node {
             PatKind::Slice(_, Some(_), ref last) if !last.is_empty() => {
                 gate_feature_post!(&self, advanced_slice_patterns,
@@ -1242,8 +1242,8 @@ impl<'a> Visitor for PostExpansionVisitor<'a> {
     }
 
     fn visit_fn(&mut self,
-                fn_kind: FnKind,
-                fn_decl: &ast::FnDecl,
+                fn_kind: FnKind<'a>,
+                fn_decl: &'a ast::FnDecl,
                 span: Span,
                 _node_id: NodeId) {
         // check for const fn declarations
@@ -1269,7 +1269,7 @@ impl<'a> Visitor for PostExpansionVisitor<'a> {
         visit::walk_fn(self, fn_kind, fn_decl, span);
     }
 
-    fn visit_trait_item(&mut self, ti: &ast::TraitItem) {
+    fn visit_trait_item(&mut self, ti: &'a ast::TraitItem) {
         match ti.node {
             ast::TraitItemKind::Const(..) => {
                 gate_feature_post!(&self, associated_consts,
@@ -1293,7 +1293,7 @@ impl<'a> Visitor for PostExpansionVisitor<'a> {
         visit::walk_trait_item(self, ti);
     }
 
-    fn visit_impl_item(&mut self, ii: &ast::ImplItem) {
+    fn visit_impl_item(&mut self, ii: &'a ast::ImplItem) {
         if ii.defaultness == ast::Defaultness::Default {
             gate_feature_post!(&self, specialization,
                               ii.span,
@@ -1316,7 +1316,7 @@ impl<'a> Visitor for PostExpansionVisitor<'a> {
         visit::walk_impl_item(self, ii);
     }
 
-    fn visit_vis(&mut self, vis: &ast::Visibility) {
+    fn visit_vis(&mut self, vis: &'a ast::Visibility) {
         let span = match *vis {
             ast::Visibility::Crate(span) => span,
             ast::Visibility::Restricted { ref path, .. } => path.span,
@@ -1327,7 +1327,7 @@ impl<'a> Visitor for PostExpansionVisitor<'a> {
         visit::walk_vis(self, vis)
     }
 
-    fn visit_generics(&mut self, g: &ast::Generics) {
+    fn visit_generics(&mut self, g: &'a ast::Generics) {
         for t in &g.ty_params {
             if !t.attrs.is_empty() {
                 gate_feature_post!(&self, generic_param_attrs, t.attrs[0].span,
@@ -1337,7 +1337,7 @@ impl<'a> Visitor for PostExpansionVisitor<'a> {
         visit::walk_generics(self, g)
     }
 
-    fn visit_lifetime_def(&mut self, lifetime_def: &ast::LifetimeDef) {
+    fn visit_lifetime_def(&mut self, lifetime_def: &'a ast::LifetimeDef) {
         if !lifetime_def.attrs.is_empty() {
             gate_feature_post!(&self, generic_param_attrs, lifetime_def.attrs[0].span,
                                "attributes on lifetime bindings are experimental");

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -940,8 +940,8 @@ mod tests {
         struct PatIdentVisitor {
             spans: Vec<Span>
         }
-        impl ::visit::Visitor for PatIdentVisitor {
-            fn visit_pat(&mut self, p: &ast::Pat) {
+        impl<'a> ::visit::Visitor<'a> for PatIdentVisitor {
+            fn visit_pat(&mut self, p: &'a ast::Pat) {
                 match p.node {
                     PatKind::Ident(_ , ref spannedident, _) => {
                         self.spans.push(spannedident.span.clone());

--- a/src/libsyntax/show_span.rs
+++ b/src/libsyntax/show_span.rs
@@ -44,29 +44,29 @@ struct ShowSpanVisitor<'a> {
     mode: Mode,
 }
 
-impl<'a> Visitor for ShowSpanVisitor<'a> {
-    fn visit_expr(&mut self, e: &ast::Expr) {
+impl<'a> Visitor<'a> for ShowSpanVisitor<'a> {
+    fn visit_expr(&mut self, e: &'a ast::Expr) {
         if let Mode::Expression = self.mode {
             self.span_diagnostic.span_warn(e.span, "expression");
         }
         visit::walk_expr(self, e);
     }
 
-    fn visit_pat(&mut self, p: &ast::Pat) {
+    fn visit_pat(&mut self, p: &'a ast::Pat) {
         if let Mode::Pattern = self.mode {
             self.span_diagnostic.span_warn(p.span, "pattern");
         }
         visit::walk_pat(self, p);
     }
 
-    fn visit_ty(&mut self, t: &ast::Ty) {
+    fn visit_ty(&mut self, t: &'a ast::Ty) {
         if let Mode::Type = self.mode {
             self.span_diagnostic.span_warn(t.span, "type");
         }
         visit::walk_ty(self, t);
     }
 
-    fn visit_mac(&mut self, mac: &ast::Mac) {
+    fn visit_mac(&mut self, mac: &'a ast::Mac) {
         visit::walk_mac(self, mac);
     }
 }

--- a/src/libsyntax/util/node_count.rs
+++ b/src/libsyntax/util/node_count.rs
@@ -26,7 +26,7 @@ impl NodeCounter {
     }
 }
 
-impl Visitor for NodeCounter {
+impl<'ast> Visitor<'ast> for NodeCounter {
     fn visit_ident(&mut self, span: Span, ident: Ident) {
         self.count += 1;
         walk_ident(self, span, ident);

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -49,56 +49,56 @@ pub enum FnKind<'a> {
 /// explicitly, you need to override each method.  (And you also need
 /// to monitor future changes to `Visitor` in case a new method with a
 /// new default implementation gets introduced.)
-pub trait Visitor: Sized {
+pub trait Visitor<'ast>: Sized {
     fn visit_name(&mut self, _span: Span, _name: Name) {
         // Nothing to do.
     }
     fn visit_ident(&mut self, span: Span, ident: Ident) {
         walk_ident(self, span, ident);
     }
-    fn visit_mod(&mut self, m: &Mod, _s: Span, _n: NodeId) { walk_mod(self, m) }
-    fn visit_foreign_item(&mut self, i: &ForeignItem) { walk_foreign_item(self, i) }
-    fn visit_item(&mut self, i: &Item) { walk_item(self, i) }
-    fn visit_local(&mut self, l: &Local) { walk_local(self, l) }
-    fn visit_block(&mut self, b: &Block) { walk_block(self, b) }
-    fn visit_stmt(&mut self, s: &Stmt) { walk_stmt(self, s) }
-    fn visit_arm(&mut self, a: &Arm) { walk_arm(self, a) }
-    fn visit_pat(&mut self, p: &Pat) { walk_pat(self, p) }
-    fn visit_expr(&mut self, ex: &Expr) { walk_expr(self, ex) }
-    fn visit_expr_post(&mut self, _ex: &Expr) { }
-    fn visit_ty(&mut self, t: &Ty) { walk_ty(self, t) }
-    fn visit_generics(&mut self, g: &Generics) { walk_generics(self, g) }
-    fn visit_fn(&mut self, fk: FnKind, fd: &FnDecl, s: Span, _: NodeId) {
+    fn visit_mod(&mut self, m: &'ast Mod, _s: Span, _n: NodeId) { walk_mod(self, m) }
+    fn visit_foreign_item(&mut self, i: &'ast ForeignItem) { walk_foreign_item(self, i) }
+    fn visit_item(&mut self, i: &'ast Item) { walk_item(self, i) }
+    fn visit_local(&mut self, l: &'ast Local) { walk_local(self, l) }
+    fn visit_block(&mut self, b: &'ast Block) { walk_block(self, b) }
+    fn visit_stmt(&mut self, s: &'ast Stmt) { walk_stmt(self, s) }
+    fn visit_arm(&mut self, a: &'ast Arm) { walk_arm(self, a) }
+    fn visit_pat(&mut self, p: &'ast Pat) { walk_pat(self, p) }
+    fn visit_expr(&mut self, ex: &'ast Expr) { walk_expr(self, ex) }
+    fn visit_expr_post(&mut self, _ex: &'ast Expr) { }
+    fn visit_ty(&mut self, t: &'ast Ty) { walk_ty(self, t) }
+    fn visit_generics(&mut self, g: &'ast Generics) { walk_generics(self, g) }
+    fn visit_fn(&mut self, fk: FnKind<'ast>, fd: &'ast FnDecl, s: Span, _: NodeId) {
         walk_fn(self, fk, fd, s)
     }
-    fn visit_trait_item(&mut self, ti: &TraitItem) { walk_trait_item(self, ti) }
-    fn visit_impl_item(&mut self, ii: &ImplItem) { walk_impl_item(self, ii) }
-    fn visit_trait_ref(&mut self, t: &TraitRef) { walk_trait_ref(self, t) }
-    fn visit_ty_param_bound(&mut self, bounds: &TyParamBound) {
+    fn visit_trait_item(&mut self, ti: &'ast TraitItem) { walk_trait_item(self, ti) }
+    fn visit_impl_item(&mut self, ii: &'ast ImplItem) { walk_impl_item(self, ii) }
+    fn visit_trait_ref(&mut self, t: &'ast TraitRef) { walk_trait_ref(self, t) }
+    fn visit_ty_param_bound(&mut self, bounds: &'ast TyParamBound) {
         walk_ty_param_bound(self, bounds)
     }
-    fn visit_poly_trait_ref(&mut self, t: &PolyTraitRef, m: &TraitBoundModifier) {
+    fn visit_poly_trait_ref(&mut self, t: &'ast PolyTraitRef, m: &'ast TraitBoundModifier) {
         walk_poly_trait_ref(self, t, m)
     }
-    fn visit_variant_data(&mut self, s: &VariantData, _: Ident,
-                          _: &Generics, _: NodeId, _: Span) {
+    fn visit_variant_data(&mut self, s: &'ast VariantData, _: Ident,
+                          _: &'ast Generics, _: NodeId, _: Span) {
         walk_struct_def(self, s)
     }
-    fn visit_struct_field(&mut self, s: &StructField) { walk_struct_field(self, s) }
-    fn visit_enum_def(&mut self, enum_definition: &EnumDef,
-                      generics: &Generics, item_id: NodeId, _: Span) {
+    fn visit_struct_field(&mut self, s: &'ast StructField) { walk_struct_field(self, s) }
+    fn visit_enum_def(&mut self, enum_definition: &'ast EnumDef,
+                      generics: &'ast Generics, item_id: NodeId, _: Span) {
         walk_enum_def(self, enum_definition, generics, item_id)
     }
-    fn visit_variant(&mut self, v: &Variant, g: &Generics, item_id: NodeId) {
+    fn visit_variant(&mut self, v: &'ast Variant, g: &'ast Generics, item_id: NodeId) {
         walk_variant(self, v, g, item_id)
     }
-    fn visit_lifetime(&mut self, lifetime: &Lifetime) {
+    fn visit_lifetime(&mut self, lifetime: &'ast Lifetime) {
         walk_lifetime(self, lifetime)
     }
-    fn visit_lifetime_def(&mut self, lifetime: &LifetimeDef) {
+    fn visit_lifetime_def(&mut self, lifetime: &'ast LifetimeDef) {
         walk_lifetime_def(self, lifetime)
     }
-    fn visit_mac(&mut self, _mac: &Mac) {
+    fn visit_mac(&mut self, _mac: &'ast Mac) {
         panic!("visit_mac disabled by default");
         // NB: see note about macros above.
         // if you really want a visitor that
@@ -106,29 +106,29 @@ pub trait Visitor: Sized {
         // definition in your trait impl:
         // visit::walk_mac(self, _mac)
     }
-    fn visit_path(&mut self, path: &Path, _id: NodeId) {
+    fn visit_path(&mut self, path: &'ast Path, _id: NodeId) {
         walk_path(self, path)
     }
-    fn visit_path_list_item(&mut self, prefix: &Path, item: &PathListItem) {
+    fn visit_path_list_item(&mut self, prefix: &'ast Path, item: &'ast PathListItem) {
         walk_path_list_item(self, prefix, item)
     }
-    fn visit_path_segment(&mut self, path_span: Span, path_segment: &PathSegment) {
+    fn visit_path_segment(&mut self, path_span: Span, path_segment: &'ast PathSegment) {
         walk_path_segment(self, path_span, path_segment)
     }
-    fn visit_path_parameters(&mut self, path_span: Span, path_parameters: &PathParameters) {
+    fn visit_path_parameters(&mut self, path_span: Span, path_parameters: &'ast PathParameters) {
         walk_path_parameters(self, path_span, path_parameters)
     }
-    fn visit_assoc_type_binding(&mut self, type_binding: &TypeBinding) {
+    fn visit_assoc_type_binding(&mut self, type_binding: &'ast TypeBinding) {
         walk_assoc_type_binding(self, type_binding)
     }
-    fn visit_attribute(&mut self, _attr: &Attribute) {}
-    fn visit_macro_def(&mut self, macro_def: &MacroDef) {
+    fn visit_attribute(&mut self, _attr: &'ast Attribute) {}
+    fn visit_macro_def(&mut self, macro_def: &'ast MacroDef) {
         walk_macro_def(self, macro_def)
     }
-    fn visit_vis(&mut self, vis: &Visibility) {
+    fn visit_vis(&mut self, vis: &'ast Visibility) {
         walk_vis(self, vis)
     }
-    fn visit_fn_ret_ty(&mut self, ret_ty: &FunctionRetTy) {
+    fn visit_fn_ret_ty(&mut self, ret_ty: &'ast FunctionRetTy) {
         walk_fn_ret_ty(self, ret_ty)
     }
 }
@@ -147,45 +147,46 @@ macro_rules! walk_list {
     }
 }
 
-pub fn walk_opt_name<V: Visitor>(visitor: &mut V, span: Span, opt_name: Option<Name>) {
+pub fn walk_opt_name<'a, V: Visitor<'a>>(visitor: &mut V, span: Span, opt_name: Option<Name>) {
     if let Some(name) = opt_name {
         visitor.visit_name(span, name);
     }
 }
 
-pub fn walk_opt_ident<V: Visitor>(visitor: &mut V, span: Span, opt_ident: Option<Ident>) {
+pub fn walk_opt_ident<'a, V: Visitor<'a>>(visitor: &mut V, span: Span, opt_ident: Option<Ident>) {
     if let Some(ident) = opt_ident {
         visitor.visit_ident(span, ident);
     }
 }
 
-pub fn walk_opt_sp_ident<V: Visitor>(visitor: &mut V, opt_sp_ident: &Option<Spanned<Ident>>) {
+pub fn walk_opt_sp_ident<'a, V: Visitor<'a>>(visitor: &mut V,
+                                             opt_sp_ident: &Option<Spanned<Ident>>) {
     if let Some(ref sp_ident) = *opt_sp_ident {
         visitor.visit_ident(sp_ident.span, sp_ident.node);
     }
 }
 
-pub fn walk_ident<V: Visitor>(visitor: &mut V, span: Span, ident: Ident) {
+pub fn walk_ident<'a, V: Visitor<'a>>(visitor: &mut V, span: Span, ident: Ident) {
     visitor.visit_name(span, ident.name);
 }
 
-pub fn walk_crate<V: Visitor>(visitor: &mut V, krate: &Crate) {
+pub fn walk_crate<'a, V: Visitor<'a>>(visitor: &mut V, krate: &'a Crate) {
     visitor.visit_mod(&krate.module, krate.span, CRATE_NODE_ID);
     walk_list!(visitor, visit_attribute, &krate.attrs);
     walk_list!(visitor, visit_macro_def, &krate.exported_macros);
 }
 
-pub fn walk_macro_def<V: Visitor>(visitor: &mut V, macro_def: &MacroDef) {
+pub fn walk_macro_def<'a, V: Visitor<'a>>(visitor: &mut V, macro_def: &'a MacroDef) {
     visitor.visit_ident(macro_def.span, macro_def.ident);
     walk_opt_ident(visitor, macro_def.span, macro_def.imported_from);
     walk_list!(visitor, visit_attribute, &macro_def.attrs);
 }
 
-pub fn walk_mod<V: Visitor>(visitor: &mut V, module: &Mod) {
+pub fn walk_mod<'a, V: Visitor<'a>>(visitor: &mut V, module: &'a Mod) {
     walk_list!(visitor, visit_item, &module.items);
 }
 
-pub fn walk_local<V: Visitor>(visitor: &mut V, local: &Local) {
+pub fn walk_local<'a, V: Visitor<'a>>(visitor: &mut V, local: &'a Local) {
     for attr in local.attrs.iter() {
         visitor.visit_attribute(attr);
     }
@@ -194,28 +195,30 @@ pub fn walk_local<V: Visitor>(visitor: &mut V, local: &Local) {
     walk_list!(visitor, visit_expr, &local.init);
 }
 
-pub fn walk_lifetime<V: Visitor>(visitor: &mut V, lifetime: &Lifetime) {
+pub fn walk_lifetime<'a, V: Visitor<'a>>(visitor: &mut V, lifetime: &'a Lifetime) {
     visitor.visit_name(lifetime.span, lifetime.name);
 }
 
-pub fn walk_lifetime_def<V: Visitor>(visitor: &mut V, lifetime_def: &LifetimeDef) {
+pub fn walk_lifetime_def<'a, V: Visitor<'a>>(visitor: &mut V, lifetime_def: &'a LifetimeDef) {
     visitor.visit_lifetime(&lifetime_def.lifetime);
     walk_list!(visitor, visit_lifetime, &lifetime_def.bounds);
     walk_list!(visitor, visit_attribute, &*lifetime_def.attrs);
 }
 
-pub fn walk_poly_trait_ref<V>(visitor: &mut V, trait_ref: &PolyTraitRef, _: &TraitBoundModifier)
-    where V: Visitor,
+pub fn walk_poly_trait_ref<'a, V>(visitor: &mut V,
+                                  trait_ref: &'a PolyTraitRef,
+                                  _: &TraitBoundModifier)
+    where V: Visitor<'a>,
 {
     walk_list!(visitor, visit_lifetime_def, &trait_ref.bound_lifetimes);
     visitor.visit_trait_ref(&trait_ref.trait_ref);
 }
 
-pub fn walk_trait_ref<V: Visitor>(visitor: &mut V, trait_ref: &TraitRef) {
+pub fn walk_trait_ref<'a, V: Visitor<'a>>(visitor: &mut V, trait_ref: &'a TraitRef) {
     visitor.visit_path(&trait_ref.path, trait_ref.ref_id)
 }
 
-pub fn walk_item<V: Visitor>(visitor: &mut V, item: &Item) {
+pub fn walk_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a Item) {
     visitor.visit_vis(&item.vis);
     visitor.visit_ident(item.span, item.ident);
     match item.node {
@@ -294,15 +297,18 @@ pub fn walk_item<V: Visitor>(visitor: &mut V, item: &Item) {
     walk_list!(visitor, visit_attribute, &item.attrs);
 }
 
-pub fn walk_enum_def<V: Visitor>(visitor: &mut V,
-                                 enum_definition: &EnumDef,
-                                 generics: &Generics,
+pub fn walk_enum_def<'a, V: Visitor<'a>>(visitor: &mut V,
+                                 enum_definition: &'a EnumDef,
+                                 generics: &'a Generics,
                                  item_id: NodeId) {
     walk_list!(visitor, visit_variant, &enum_definition.variants, generics, item_id);
 }
 
-pub fn walk_variant<V>(visitor: &mut V, variant: &Variant, generics: &Generics, item_id: NodeId)
-    where V: Visitor,
+pub fn walk_variant<'a, V>(visitor: &mut V,
+                           variant: &'a Variant,
+                           generics: &'a Generics,
+                           item_id: NodeId)
+    where V: Visitor<'a>,
 {
     visitor.visit_ident(variant.span, variant.node.name);
     visitor.visit_variant_data(&variant.node.data, variant.node.name,
@@ -311,7 +317,7 @@ pub fn walk_variant<V>(visitor: &mut V, variant: &Variant, generics: &Generics, 
     walk_list!(visitor, visit_attribute, &variant.node.attrs);
 }
 
-pub fn walk_ty<V: Visitor>(visitor: &mut V, typ: &Ty) {
+pub fn walk_ty<'a, V: Visitor<'a>>(visitor: &mut V, typ: &'a Ty) {
     match typ.node {
         TyKind::Slice(ref ty) | TyKind::Paren(ref ty) => {
             visitor.visit_ty(ty)
@@ -361,24 +367,30 @@ pub fn walk_ty<V: Visitor>(visitor: &mut V, typ: &Ty) {
     }
 }
 
-pub fn walk_path<V: Visitor>(visitor: &mut V, path: &Path) {
+pub fn walk_path<'a, V: Visitor<'a>>(visitor: &mut V, path: &'a Path) {
     for segment in &path.segments {
         visitor.visit_path_segment(path.span, segment);
     }
 }
 
-pub fn walk_path_list_item<V: Visitor>(visitor: &mut V, _prefix: &Path, item: &PathListItem) {
+pub fn walk_path_list_item<'a, V: Visitor<'a>>(visitor: &mut V,
+                                               _prefix: &Path,
+                                               item: &'a PathListItem) {
     visitor.visit_ident(item.span, item.node.name);
     walk_opt_ident(visitor, item.span, item.node.rename);
 }
 
-pub fn walk_path_segment<V: Visitor>(visitor: &mut V, path_span: Span, segment: &PathSegment) {
+pub fn walk_path_segment<'a, V: Visitor<'a>>(visitor: &mut V,
+                                             path_span: Span,
+                                             segment: &'a PathSegment) {
     visitor.visit_ident(path_span, segment.identifier);
     visitor.visit_path_parameters(path_span, &segment.parameters);
 }
 
-pub fn walk_path_parameters<V>(visitor: &mut V, _path_span: Span, path_parameters: &PathParameters)
-    where V: Visitor,
+pub fn walk_path_parameters<'a, V>(visitor: &mut V,
+                                   _path_span: Span,
+                                   path_parameters: &'a PathParameters)
+    where V: Visitor<'a>,
 {
     match *path_parameters {
         PathParameters::AngleBracketed(ref data) => {
@@ -393,12 +405,13 @@ pub fn walk_path_parameters<V>(visitor: &mut V, _path_span: Span, path_parameter
     }
 }
 
-pub fn walk_assoc_type_binding<V: Visitor>(visitor: &mut V, type_binding: &TypeBinding) {
+pub fn walk_assoc_type_binding<'a, V: Visitor<'a>>(visitor: &mut V,
+                                                   type_binding: &'a TypeBinding) {
     visitor.visit_ident(type_binding.span, type_binding.ident);
     visitor.visit_ty(&type_binding.ty);
 }
 
-pub fn walk_pat<V: Visitor>(visitor: &mut V, pattern: &Pat) {
+pub fn walk_pat<'a, V: Visitor<'a>>(visitor: &mut V, pattern: &'a Pat) {
     match pattern.node {
         PatKind::TupleStruct(ref path, ref children, _) => {
             visitor.visit_path(path, pattern.id);
@@ -443,7 +456,7 @@ pub fn walk_pat<V: Visitor>(visitor: &mut V, pattern: &Pat) {
     }
 }
 
-pub fn walk_foreign_item<V: Visitor>(visitor: &mut V, foreign_item: &ForeignItem) {
+pub fn walk_foreign_item<'a, V: Visitor<'a>>(visitor: &mut V, foreign_item: &'a ForeignItem) {
     visitor.visit_vis(&foreign_item.vis);
     visitor.visit_ident(foreign_item.span, foreign_item.ident);
 
@@ -458,7 +471,7 @@ pub fn walk_foreign_item<V: Visitor>(visitor: &mut V, foreign_item: &ForeignItem
     walk_list!(visitor, visit_attribute, &foreign_item.attrs);
 }
 
-pub fn walk_ty_param_bound<V: Visitor>(visitor: &mut V, bound: &TyParamBound) {
+pub fn walk_ty_param_bound<'a, V: Visitor<'a>>(visitor: &mut V, bound: &'a TyParamBound) {
     match *bound {
         TraitTyParamBound(ref typ, ref modifier) => {
             visitor.visit_poly_trait_ref(typ, modifier);
@@ -469,7 +482,7 @@ pub fn walk_ty_param_bound<V: Visitor>(visitor: &mut V, bound: &TyParamBound) {
     }
 }
 
-pub fn walk_generics<V: Visitor>(visitor: &mut V, generics: &Generics) {
+pub fn walk_generics<'a, V: Visitor<'a>>(visitor: &mut V, generics: &'a Generics) {
     for param in &generics.ty_params {
         visitor.visit_ident(param.span, param.ident);
         walk_list!(visitor, visit_ty_param_bound, &param.bounds);
@@ -504,13 +517,13 @@ pub fn walk_generics<V: Visitor>(visitor: &mut V, generics: &Generics) {
     }
 }
 
-pub fn walk_fn_ret_ty<V: Visitor>(visitor: &mut V, ret_ty: &FunctionRetTy) {
+pub fn walk_fn_ret_ty<'a, V: Visitor<'a>>(visitor: &mut V, ret_ty: &'a FunctionRetTy) {
     if let FunctionRetTy::Ty(ref output_ty) = *ret_ty {
         visitor.visit_ty(output_ty)
     }
 }
 
-pub fn walk_fn_decl<V: Visitor>(visitor: &mut V, function_declaration: &FnDecl) {
+pub fn walk_fn_decl<'a, V: Visitor<'a>>(visitor: &mut V, function_declaration: &'a FnDecl) {
     for argument in &function_declaration.inputs {
         visitor.visit_pat(&argument.pat);
         visitor.visit_ty(&argument.ty)
@@ -518,8 +531,8 @@ pub fn walk_fn_decl<V: Visitor>(visitor: &mut V, function_declaration: &FnDecl) 
     visitor.visit_fn_ret_ty(&function_declaration.output)
 }
 
-pub fn walk_fn<V>(visitor: &mut V, kind: FnKind, declaration: &FnDecl, _span: Span)
-    where V: Visitor,
+pub fn walk_fn<'a, V>(visitor: &mut V, kind: FnKind<'a>, declaration: &'a FnDecl, _span: Span)
+    where V: Visitor<'a>,
 {
     match kind {
         FnKind::ItemFn(_, generics, _, _, _, _, body) => {
@@ -539,7 +552,7 @@ pub fn walk_fn<V>(visitor: &mut V, kind: FnKind, declaration: &FnDecl, _span: Sp
     }
 }
 
-pub fn walk_trait_item<V: Visitor>(visitor: &mut V, trait_item: &TraitItem) {
+pub fn walk_trait_item<'a, V: Visitor<'a>>(visitor: &mut V, trait_item: &'a TraitItem) {
     visitor.visit_ident(trait_item.span, trait_item.ident);
     walk_list!(visitor, visit_attribute, &trait_item.attrs);
     match trait_item.node {
@@ -565,7 +578,7 @@ pub fn walk_trait_item<V: Visitor>(visitor: &mut V, trait_item: &TraitItem) {
     }
 }
 
-pub fn walk_impl_item<V: Visitor>(visitor: &mut V, impl_item: &ImplItem) {
+pub fn walk_impl_item<'a, V: Visitor<'a>>(visitor: &mut V, impl_item: &'a ImplItem) {
     visitor.visit_vis(&impl_item.vis);
     visitor.visit_ident(impl_item.span, impl_item.ident);
     walk_list!(visitor, visit_attribute, &impl_item.attrs);
@@ -587,22 +600,22 @@ pub fn walk_impl_item<V: Visitor>(visitor: &mut V, impl_item: &ImplItem) {
     }
 }
 
-pub fn walk_struct_def<V: Visitor>(visitor: &mut V, struct_definition: &VariantData) {
+pub fn walk_struct_def<'a, V: Visitor<'a>>(visitor: &mut V, struct_definition: &'a VariantData) {
     walk_list!(visitor, visit_struct_field, struct_definition.fields());
 }
 
-pub fn walk_struct_field<V: Visitor>(visitor: &mut V, struct_field: &StructField) {
+pub fn walk_struct_field<'a, V: Visitor<'a>>(visitor: &mut V, struct_field: &'a StructField) {
     visitor.visit_vis(&struct_field.vis);
     walk_opt_ident(visitor, struct_field.span, struct_field.ident);
     visitor.visit_ty(&struct_field.ty);
     walk_list!(visitor, visit_attribute, &struct_field.attrs);
 }
 
-pub fn walk_block<V: Visitor>(visitor: &mut V, block: &Block) {
+pub fn walk_block<'a, V: Visitor<'a>>(visitor: &mut V, block: &'a Block) {
     walk_list!(visitor, visit_stmt, &block.stmts);
 }
 
-pub fn walk_stmt<V: Visitor>(visitor: &mut V, statement: &Stmt) {
+pub fn walk_stmt<'a, V: Visitor<'a>>(visitor: &mut V, statement: &'a Stmt) {
     match statement.node {
         StmtKind::Local(ref local) => visitor.visit_local(local),
         StmtKind::Item(ref item) => visitor.visit_item(item),
@@ -619,11 +632,11 @@ pub fn walk_stmt<V: Visitor>(visitor: &mut V, statement: &Stmt) {
     }
 }
 
-pub fn walk_mac<V: Visitor>(_: &mut V, _: &Mac) {
+pub fn walk_mac<'a, V: Visitor<'a>>(_: &mut V, _: &Mac) {
     // Empty!
 }
 
-pub fn walk_expr<V: Visitor>(visitor: &mut V, expression: &Expr) {
+pub fn walk_expr<'a, V: Visitor<'a>>(visitor: &mut V, expression: &'a Expr) {
     for attr in expression.attrs.iter() {
         visitor.visit_attribute(attr);
     }
@@ -776,14 +789,14 @@ pub fn walk_expr<V: Visitor>(visitor: &mut V, expression: &Expr) {
     visitor.visit_expr_post(expression)
 }
 
-pub fn walk_arm<V: Visitor>(visitor: &mut V, arm: &Arm) {
+pub fn walk_arm<'a, V: Visitor<'a>>(visitor: &mut V, arm: &'a Arm) {
     walk_list!(visitor, visit_pat, &arm.pats);
     walk_list!(visitor, visit_expr, &arm.guard);
     visitor.visit_expr(&arm.body);
     walk_list!(visitor, visit_attribute, &arm.attrs);
 }
 
-pub fn walk_vis<V: Visitor>(visitor: &mut V, vis: &Visibility) {
+pub fn walk_vis<'a, V: Visitor<'a>>(visitor: &mut V, vis: &'a Visibility) {
     if let Visibility::Restricted { ref path, id } = *vis {
         visitor.visit_path(path, id);
     }

--- a/src/libsyntax_ext/deriving/custom.rs
+++ b/src/libsyntax_ext/deriving/custom.rs
@@ -21,7 +21,7 @@ use syntax::visit::Visitor;
 
 struct MarkAttrs<'a>(&'a [ast::Name]);
 
-impl<'a> Visitor for MarkAttrs<'a> {
+impl<'a> Visitor<'a> for MarkAttrs<'a> {
     fn visit_attribute(&mut self, attr: &Attribute) {
         if self.0.contains(&attr.name()) {
             mark_used(attr);
@@ -101,4 +101,3 @@ impl MultiItemModifier for CustomDerive {
         res
     }
 }
-

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -361,8 +361,8 @@ fn find_type_parameters(ty: &ast::Ty,
         types: Vec<P<ast::Ty>>,
     }
 
-    impl<'a, 'b> visit::Visitor for Visitor<'a, 'b> {
-        fn visit_ty(&mut self, ty: &ast::Ty) {
+    impl<'a, 'b> visit::Visitor<'a> for Visitor<'a, 'b> {
+        fn visit_ty(&mut self, ty: &'a ast::Ty) {
             match ty.node {
                 ast::TyKind::Path(_, ref path) if !path.global => {
                     if let Some(segment) = path.segments.first() {

--- a/src/test/compile-fail-fulldeps/auxiliary/lint_for_crate.rs
+++ b/src/test/compile-fail-fulldeps/auxiliary/lint_for_crate.rs
@@ -33,7 +33,7 @@ impl LintPass for Pass {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
-    fn check_crate(&mut self, cx: &LateContext<'a, 'tcx>, krate: &'tcx hir::Crate) {
+    fn check_crate(&mut self, cx: &LateContext, krate: &hir::Crate) {
         if !attr::contains_name(&krate.attrs, "crate_okay") {
             cx.span_lint(CRATE_NOT_OKAY, krate.span,
                          "crate is not marked with #![crate_okay]");

--- a/src/test/compile-fail-fulldeps/auxiliary/lint_for_crate.rs
+++ b/src/test/compile-fail-fulldeps/auxiliary/lint_for_crate.rs
@@ -32,8 +32,8 @@ impl LintPass for Pass {
     }
 }
 
-impl LateLintPass for Pass {
-    fn check_crate<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, krate: &'tcx hir::Crate) {
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
+    fn check_crate(&mut self, cx: &LateContext<'a, 'tcx>, krate: &'tcx hir::Crate) {
         if !attr::contains_name(&krate.attrs, "crate_okay") {
             cx.span_lint(CRATE_NOT_OKAY, krate.span,
                          "crate is not marked with #![crate_okay]");
@@ -43,5 +43,5 @@ impl LateLintPass for Pass {
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
-    reg.register_late_lint_pass(box Pass as LateLintPassObject);
+    reg.register_late_lint_pass(box Pass);
 }

--- a/src/test/compile-fail-fulldeps/auxiliary/lint_for_crate.rs
+++ b/src/test/compile-fail-fulldeps/auxiliary/lint_for_crate.rs
@@ -33,7 +33,7 @@ impl LintPass for Pass {
 }
 
 impl LateLintPass for Pass {
-    fn check_crate(&mut self, cx: &LateContext, krate: &hir::Crate) {
+    fn check_crate<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, krate: &'tcx hir::Crate) {
         if !attr::contains_name(&krate.attrs, "crate_okay") {
             cx.span_lint(CRATE_NOT_OKAY, krate.span,
                          "crate is not marked with #![crate_okay]");

--- a/src/test/compile-fail-fulldeps/auxiliary/lint_group_plugin_test.rs
+++ b/src/test/compile-fail-fulldeps/auxiliary/lint_group_plugin_test.rs
@@ -35,7 +35,7 @@ impl LintPass for Pass {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
-    fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
+    fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
         match &*it.name.as_str() {
             "lintme" => cx.span_lint(TEST_LINT, it.span, "item is named 'lintme'"),
             "pleaselintme" => cx.span_lint(PLEASE_LINT, it.span, "item is named 'pleaselintme'"),

--- a/src/test/compile-fail-fulldeps/auxiliary/lint_group_plugin_test.rs
+++ b/src/test/compile-fail-fulldeps/auxiliary/lint_group_plugin_test.rs
@@ -35,7 +35,7 @@ impl LintPass for Pass {
 }
 
 impl LateLintPass for Pass {
-    fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
+    fn check_item<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
         match &*it.name.as_str() {
             "lintme" => cx.span_lint(TEST_LINT, it.span, "item is named 'lintme'"),
             "pleaselintme" => cx.span_lint(PLEASE_LINT, it.span, "item is named 'pleaselintme'"),

--- a/src/test/compile-fail-fulldeps/auxiliary/lint_group_plugin_test.rs
+++ b/src/test/compile-fail-fulldeps/auxiliary/lint_group_plugin_test.rs
@@ -34,8 +34,8 @@ impl LintPass for Pass {
     }
 }
 
-impl LateLintPass for Pass {
-    fn check_item<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
+    fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
         match &*it.name.as_str() {
             "lintme" => cx.span_lint(TEST_LINT, it.span, "item is named 'lintme'"),
             "pleaselintme" => cx.span_lint(PLEASE_LINT, it.span, "item is named 'pleaselintme'"),
@@ -46,6 +46,6 @@ impl LateLintPass for Pass {
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
-    reg.register_late_lint_pass(box Pass as LateLintPassObject);
+    reg.register_late_lint_pass(box Pass);
     reg.register_lint_group("lint_me", vec![TEST_LINT, PLEASE_LINT]);
 }

--- a/src/test/run-pass-fulldeps/auxiliary/lint_for_crate.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/lint_for_crate.rs
@@ -33,7 +33,7 @@ impl LintPass for Pass {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
-    fn check_crate(&mut self, cx: &LateContext<'a, 'tcx>, krate: &'tcx hir::Crate) {
+    fn check_crate(&mut self, cx: &LateContext, krate: &hir::Crate) {
         if !attr::contains_name(&krate.attrs, "crate_okay") {
             cx.span_lint(CRATE_NOT_OKAY, krate.span,
                          "crate is not marked with #![crate_okay]");

--- a/src/test/run-pass-fulldeps/auxiliary/lint_for_crate.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/lint_for_crate.rs
@@ -32,8 +32,8 @@ impl LintPass for Pass {
     }
 }
 
-impl LateLintPass for Pass {
-    fn check_crate<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, krate: &'tcx hir::Crate) {
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
+    fn check_crate(&mut self, cx: &LateContext<'a, 'tcx>, krate: &'tcx hir::Crate) {
         if !attr::contains_name(&krate.attrs, "crate_okay") {
             cx.span_lint(CRATE_NOT_OKAY, krate.span,
                          "crate is not marked with #![crate_okay]");
@@ -43,5 +43,5 @@ impl LateLintPass for Pass {
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
-    reg.register_late_lint_pass(box Pass as LateLintPassObject);
+    reg.register_late_lint_pass(box Pass);
 }

--- a/src/test/run-pass-fulldeps/auxiliary/lint_for_crate.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/lint_for_crate.rs
@@ -33,7 +33,7 @@ impl LintPass for Pass {
 }
 
 impl LateLintPass for Pass {
-    fn check_crate(&mut self, cx: &LateContext, krate: &hir::Crate) {
+    fn check_crate<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, krate: &'tcx hir::Crate) {
         if !attr::contains_name(&krate.attrs, "crate_okay") {
             cx.span_lint(CRATE_NOT_OKAY, krate.span,
                          "crate is not marked with #![crate_okay]");

--- a/src/test/run-pass-fulldeps/auxiliary/lint_group_plugin_test.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/lint_group_plugin_test.rs
@@ -35,7 +35,7 @@ impl LintPass for Pass {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
-    fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
+    fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
         match &*it.name.as_str() {
             "lintme" => cx.span_lint(TEST_LINT, it.span, "item is named 'lintme'"),
             "pleaselintme" => cx.span_lint(PLEASE_LINT, it.span, "item is named 'pleaselintme'"),

--- a/src/test/run-pass-fulldeps/auxiliary/lint_group_plugin_test.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/lint_group_plugin_test.rs
@@ -35,7 +35,7 @@ impl LintPass for Pass {
 }
 
 impl LateLintPass for Pass {
-    fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
+    fn check_item<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
         match &*it.name.as_str() {
             "lintme" => cx.span_lint(TEST_LINT, it.span, "item is named 'lintme'"),
             "pleaselintme" => cx.span_lint(PLEASE_LINT, it.span, "item is named 'pleaselintme'"),

--- a/src/test/run-pass-fulldeps/auxiliary/lint_group_plugin_test.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/lint_group_plugin_test.rs
@@ -34,8 +34,8 @@ impl LintPass for Pass {
     }
 }
 
-impl LateLintPass for Pass {
-    fn check_item<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
+    fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, it: &'tcx hir::Item) {
         match &*it.name.as_str() {
             "lintme" => cx.span_lint(TEST_LINT, it.span, "item is named 'lintme'"),
             "pleaselintme" => cx.span_lint(PLEASE_LINT, it.span, "item is named 'pleaselintme'"),
@@ -46,6 +46,6 @@ impl LateLintPass for Pass {
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
-    reg.register_late_lint_pass(box Pass as LateLintPassObject);
+    reg.register_late_lint_pass(box Pass);
     reg.register_lint_group("lint_me", vec![TEST_LINT, PLEASE_LINT]);
 }

--- a/src/test/run-pass-fulldeps/issue-37290/auxiliary/lint.rs
+++ b/src/test/run-pass-fulldeps/issue-37290/auxiliary/lint.rs
@@ -39,8 +39,8 @@ impl LintPass for Pass {
     fn get_lints(&self) -> LintArray { lint_array!(REGION_HIERARCHY) }
 }
 
-impl LateLintPass for Pass {
-    fn check_fn<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>,
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
+    fn check_fn(&mut self, cx: &LateContext<'a, 'tcx>,
                               fk: FnKind<'tcx>, _: &'tcx hir::FnDecl, expr: &'tcx hir::Expr,
                               span: Span, node: ast::NodeId)
     {

--- a/src/test/run-pass-fulldeps/issue-37290/auxiliary/lint.rs
+++ b/src/test/run-pass-fulldeps/issue-37290/auxiliary/lint.rs
@@ -40,8 +40,8 @@ impl LintPass for Pass {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
-    fn check_fn(&mut self, cx: &LateContext<'a, 'tcx>,
-                              fk: FnKind<'tcx>, _: &'tcx hir::FnDecl, expr: &'tcx hir::Expr,
+    fn check_fn(&mut self, cx: &LateContext,
+                              fk: FnKind, _: &hir::FnDecl, expr: &hir::Expr,
                               span: Span, node: ast::NodeId)
     {
         if let FnKind::Closure(..) = fk { return }

--- a/src/test/run-pass-fulldeps/issue-37290/auxiliary/lint.rs
+++ b/src/test/run-pass-fulldeps/issue-37290/auxiliary/lint.rs
@@ -40,9 +40,9 @@ impl LintPass for Pass {
 }
 
 impl LateLintPass for Pass {
-    fn check_fn(&mut self, cx: &LateContext,
-                fk: FnKind, _: &hir::FnDecl, expr: &hir::Expr,
-                span: Span, node: ast::NodeId)
+    fn check_fn<'a, 'tcx: 'a>(&mut self, cx: &LateContext<'a, 'tcx>,
+                              fk: FnKind<'tcx>, _: &'tcx hir::FnDecl, expr: &'tcx hir::Expr,
+                              span: Span, node: ast::NodeId)
     {
         if let FnKind::Closure(..) = fk { return }
 


### PR DESCRIPTION
this unblocks clippy (rustup blocked after #37918)

clippy has lots of lints that internally call an `intravisit::Visitor`, but the current lifetimes on `LateLintPass` methods conflicted with the required lifetimes (there was no connection between the HIR elements and the `TyCtxt`)

r? @Manishearth 

