### PR TITLE
Fix current_exe() on DragonFly (again)

### DIFF
--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -78,7 +78,7 @@ pub fn errno() -> i32 {
         static errno: c_int;
     }
 
-    errno as i32
+    unsafe { errno as i32 }
 }
 
 /// Gets a detailed string description for the given error number.
@@ -193,7 +193,7 @@ impl StdError for JoinPathsError {
     fn description(&self) -> &str { "failed to join paths" }
 }
 
-#[cfg(target_os = "freebsd")]
+#[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
 pub fn current_exe() -> io::Result<PathBuf> {
     unsafe {
         let mut mib = [libc::CTL_KERN as c_int,
@@ -216,11 +216,6 @@ pub fn current_exe() -> io::Result<PathBuf> {
         v.set_len(sz - 1); // chop off trailing NUL
         Ok(PathBuf::from(OsString::from_vec(v)))
     }
-}
-
-#[cfg(target_os = "dragonfly")]
-pub fn current_exe() -> io::Result<PathBuf> {
-    ::fs::read_link("/proc/curproc/file")
 }
 
 #[cfg(target_os = "netbsd")]


### PR DESCRIPTION
This is a follow up on [this pull request][1].

Since DragonFly 4.6.1 ([this commit][2]), the ```kern.proc.pathname```
sysctl works correctly, i.e. it does not return paths including a ```:```
(see [here][3]). Use it and don't try to fix old versions of DragonFly!
There are not many DragonFly installations out there that we can't
control and no one is compiling Rust from source. If someone wants to
run Rust on a pre-4.6.1 DragonFly system, the ports system should
provide a patch.

[1]: https://github.com/rust-lang/rust/pull/35494
[2]: https://gitweb.dragonflybsd.org/dragonfly.git/commit/726f7ca07e193db73635e9c4e24e40c96087d6d9
[3]: https://gist.github.com/mneumann/a2f6b6a0a03935b561d6185872a4b222