### PR TITLE
rustbuild: Print out failing commands

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -464,8 +464,7 @@ fn krate_emscripten(build: &Build,
          println!("running {}", test_file_name);
          let nodejs = build.config.nodejs.as_ref().expect("nodejs not configured");
          let mut cmd = Command::new(nodejs);
-         cmd.arg(&test_file_name)
-            .stderr(::std::process::Stdio::inherit());
+         cmd.arg(&test_file_name);
          if build.config.quiet_tests {
              cmd.arg("--quiet");
          }

--- a/src/build_helper/lib.rs
+++ b/src/build_helper/lib.rs
@@ -21,7 +21,8 @@ pub fn run(cmd: &mut Command) {
 pub fn run_silent(cmd: &mut Command) {
     let status = match cmd.status() {
         Ok(status) => status,
-        Err(e) => fail(&format!("failed to execute command: {}", e)),
+        Err(e) => fail(&format!("failed to execute command: {:?}\nerror: {}",
+                                cmd, e)),
     };
     if !status.success() {
         fail(&format!("command did not execute successfully: {:?}\n\
@@ -63,7 +64,8 @@ pub fn cc2ar(cc: &Path, target: &str) -> Option<PathBuf> {
 pub fn output(cmd: &mut Command) -> String {
     let output = match cmd.stderr(Stdio::inherit()).output() {
         Ok(status) => status,
-        Err(e) => fail(&format!("failed to execute command: {}", e)),
+        Err(e) => fail(&format!("failed to execute command: {:?}\nerror: {}",
+                                cmd, e)),
     };
     if !output.status.success() {
         panic!("command did not execute successfully: {:?}\n\


### PR DESCRIPTION
Just ensure that we always print out the command line which should aid in
debugging.

Closes #38228