### PR TITLE
incr.comp.: Avoid creating an edge to DepNode::Krate when generating debuginfo namespaces.

### DIFF
--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -310,8 +310,9 @@ impl<'ast> Map<'ast> {
                         id = p;
                     }
 
-                    RootCrate =>
-                        return DepNode::Krate,
+                    RootCrate => {
+                        return DepNode::Hir(DefId::local(CRATE_DEF_INDEX));
+                    }
 
                     RootInlinedParent(_) =>
                         bug!("node {} has inlined ancestor but is not inlined", id0),
@@ -782,7 +783,7 @@ impl<'ast> Map<'ast> {
             Some(EntryVisibility(_, &Visibility::Restricted { ref path, .. })) => path.span,
             Some(EntryVisibility(_, v)) => bug!("unexpected Visibility {:?}", v),
 
-            Some(RootCrate) => self.krate().span,
+            Some(RootCrate) => self.forest.krate.span,
             Some(RootInlinedParent(parent)) => parent.body.span,
             Some(NotPresent) | None => {
                 bug!("hir::map::Map::span: id not in map: {:?}", id)

--- a/src/librustc_incremental/calculate_svh/mod.rs
+++ b/src/librustc_incremental/calculate_svh/mod.rs
@@ -112,8 +112,9 @@ pub fn compute_incremental_hashes_map<'a, 'tcx: 'a>(tcx: TyCtxt<'a, 'tcx, 'tcx>)
         hash_spans: hash_spans,
     };
     record_time(&tcx.sess.perf_stats.incr_comp_hashes_time, || {
-        visitor.calculate_def_id(DefId::local(CRATE_DEF_INDEX),
-                                 |v| visit::walk_crate(v, krate));
+        visitor.calculate_def_id(DefId::local(CRATE_DEF_INDEX), |v| {
+            v.hash_crate_root_module(krate);
+        });
         krate.visit_all_item_likes(&mut visitor.as_deep_visitor());
 
         for macro_def in krate.exported_macros.iter() {

--- a/src/test/incremental/issue-38222.rs
+++ b/src/test/incremental/issue-38222.rs
@@ -1,0 +1,40 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that debuginfo does not introduce a dependency edge to the Krate
+// dep-node.
+
+// revisions:rpass1 rpass2
+
+#![feature(rustc_attrs)]
+
+
+#![rustc_partition_translated(module="issue_38222-mod1", cfg="rpass2")]
+
+// If trans had added a dependency edge to the Krate dep-node, nothing would
+// be re-used, so checking that this module was re-used is sufficient.
+#![rustc_partition_reused(module="issue_38222", cfg="rpass2")]
+
+//[rpass1] compile-flags: -C debuginfo=1
+//[rpass2] compile-flags: -C debuginfo=1
+
+pub fn main() {
+    mod1::some_fn();
+}
+
+mod mod1 {
+    pub fn some_fn() {
+        let _ = 1;
+    }
+
+    #[cfg(rpass2)]
+    fn _some_other_fn() {
+    }
+}


### PR DESCRIPTION
r? @nikomatsakis 

Fixes #38222