### PR TITLE
erase lifetimes when translating specialized substs

### DIFF
--- a/src/librustc/traits/specialize/mod.rs
+++ b/src/librustc/traits/specialize/mod.rs
@@ -127,6 +127,7 @@ pub fn find_method<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 let substs = substs.rebase_onto(tcx, trait_def_id, impl_data.substs);
                 let substs = translate_substs(&infcx, impl_data.impl_def_id,
                                               substs, node_item.node);
+                let substs = infcx.tcx.erase_regions(&substs);
                 tcx.lift(&substs).unwrap_or_else(|| {
                     bug!("find_method: translate_substs \
                           returned {:?} which contains inference types/regions",

--- a/src/test/run-pass/specialization/specialization-translate-projections-with-lifetimes.rs
+++ b/src/test/run-pass/specialization/specialization-translate-projections-with-lifetimes.rs
@@ -1,0 +1,41 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(specialization)]
+
+trait Iterator {
+    fn next(&self);
+}
+
+trait WithAssoc {
+    type Item;
+}
+
+impl<'a> WithAssoc for &'a () {
+    type Item = &'a u32;
+}
+
+struct Cloned<I>(I);
+
+impl<'a, I, T: 'a> Iterator for Cloned<I>
+    where I: WithAssoc<Item=&'a T>, T: Clone
+{
+    fn next(&self) {}
+}
+
+impl<'a, I, T: 'a> Iterator for Cloned<I>
+    where I: WithAssoc<Item=&'a T>, T: Copy
+{
+
+}
+
+fn main() {
+    Cloned(&()).next();
+}


### PR DESCRIPTION
Projections can generate lifetime variables with equality constraints,
that will not be resolved by `resolve_type_vars_if_possible`, so substs
need to be lifetime-erased after that.

Fixes #36848.