### PR TITLE
Consider provided trait methods in middle::reachable

### DIFF
--- a/src/librustc_trans/back/symbol_export.rs
+++ b/src/librustc_trans/back/symbol_export.rs
@@ -51,8 +51,10 @@ impl ExportedSymbols {
                 scx.tcx().map.local_def_id(node_id)
             })
             .map(|def_id| {
-                (symbol_for_def_id(scx, def_id, symbol_map),
-                 export_level(scx, def_id))
+                let name = symbol_for_def_id(scx, def_id, symbol_map);
+                let export_level = export_level(scx, def_id);
+                debug!("EXPORTED SYMBOL (local): {} ({:?})", name, export_level);
+                (name, export_level)
             })
             .collect();
 
@@ -90,9 +92,10 @@ impl ExportedSymbols {
                 .exported_symbols(cnum)
                 .iter()
                 .map(|&def_id| {
-                    debug!("EXTERN-SYMBOL: {:?}", def_id);
                     let name = Instance::mono(scx, def_id).symbol_name(scx);
-                    (name, export_level(scx, def_id))
+                    let export_level = export_level(scx, def_id);
+                    debug!("EXPORTED SYMBOL (re-export): {} ({:?})", name, export_level);
+                    (name, export_level)
                 })
                 .collect();
 

--- a/src/test/run-pass/auxiliary/issue_38226_aux.rs
+++ b/src/test/run-pass/auxiliary/issue_38226_aux.rs
@@ -1,0 +1,33 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type="rlib"]
+
+#[inline(never)]
+pub fn foo<T>() {
+    let _: Box<SomeTrait> = Box::new(SomeTraitImpl);
+}
+
+pub fn bar() {
+    SomeTraitImpl.bar();
+}
+
+mod submod {
+    pub trait SomeTrait {
+        fn bar(&self) {
+            panic!("NO")
+        }
+    }
+}
+
+use self::submod::SomeTrait;
+
+pub struct SomeTraitImpl;
+impl SomeTrait for SomeTraitImpl {}

--- a/src/test/run-pass/issue-38226.rs
+++ b/src/test/run-pass/issue-38226.rs
@@ -1,0 +1,24 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This test makes sure that we don't run into a linker error because of the
+// middle::reachable pass missing trait methods with default impls.
+
+// aux-build:issue_38226_aux.rs
+
+// Need -Cno-prepopulate-passes to really disable inlining, otherwise the faulty
+// code gets optimized out:
+// compile-flags: -Cno-prepopulate-passes
+
+extern crate issue_38226_aux;
+
+fn main() {
+    issue_38226_aux::foo::<()>();
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/38226 by also considering trait methods with default implementation instead of just methods provided in an impl.

r? @alexcrichton 
cc @panicbit 