### PR TITLE
Make configure message re x.py not assume build dir == src dir

### DIFF
--- a/configure
+++ b/configure
@@ -1890,6 +1890,12 @@ else
     step_msg "complete"
 fi
 
+if [ "$CFG_SRC_DIR" = `pwd` ]; then
+    X_PY=x.py
+else
+    X_PY=${CFG_SRC_DIR_RELATIVE}x.py
+fi
+
 if [ -z "$CFG_DISABLE_RUSTBUILD" ]; then
     msg "NOTE you have now configured rust to use a rewritten build system"
     msg "     called rustbuild, and as a result this may have bugs that "
@@ -1897,7 +1903,7 @@ if [ -z "$CFG_DISABLE_RUSTBUILD" ]; then
     msg "     go back to the old build system with --disable-rustbuild and"
     msg "     please feel free to report any bugs!"
     msg ""
-    msg "run \`python x.py --help\`"
+    msg "run \`python ${X_PY} --help\`"
 else
     warn "the makefile-based build system is deprecated in favor of rustbuild"
     msg ""

--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -1,4 +1,4 @@
-# Copyright 20126 The Rust Project Developers. See the COPYRIGHT
+# Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.
 #


### PR DESCRIPTION
Fix #38251 but perhaps not BEST fix for it.

As driveby, fix copyright year in `Makefile.in`