### PR TITLE
rustbuild: Implement distcheck

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -284,6 +284,11 @@ pub fn std(build: &Build, compiler: &Compiler, target: &str) {
     t!(fs::remove_dir_all(&image));
 }
 
+pub fn rust_src_location(build: &Build) -> PathBuf {
+    let plain_name = format!("rustc-{}-src", package_vers(build));
+    distdir(build).join(&format!("{}.tar.gz", plain_name))
+}
+
 /// Creates the `rust-src` installer component and the plain source tarball
 pub fn rust_src(build: &Build) {
     println!("Dist src");
@@ -374,7 +379,7 @@ pub fn rust_src(build: &Build) {
 
     // Create plain source tarball
     let mut cmd = Command::new("tar");
-    cmd.arg("-czf").arg(sanitize_sh(&distdir(build).join(&format!("{}.tar.gz", plain_name))))
+    cmd.arg("-czf").arg(sanitize_sh(&rust_src_location(build)))
        .arg(&plain_name)
        .current_dir(&dst);
     build.run(&mut cmd);

--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -55,6 +55,8 @@ check-cargotest:
 	$(Q)$(BOOTSTRAP) test src/tools/cargotest $(BOOTSTRAP_ARGS)
 dist:
 	$(Q)$(BOOTSTRAP) dist $(BOOTSTRAP_ARGS)
+distcheck:
+	$(Q)$(BOOTSTRAP) test distcheck
 install:
 	$(Q)$(BOOTSTRAP) dist --install $(BOOTSTRAP_ARGS)
 tidy:

--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -198,14 +198,6 @@ pub fn build_rules(build: &Build) -> Rules {
              });
     }
     for (krate, path, default) in krates("rustc-main") {
-        // We hijacked the `src/rustc` path above for "build just the compiler"
-        // so let's not reinterpret it here as everything and redirect the
-        // `src/rustc` path to a nonexistent path.
-        let path = if path == "src/rustc" {
-            "path/to/nowhere"
-        } else {
-            path
-        };
         rules.build(&krate.build_step, path)
              .dep(|s| s.name("libtest"))
              .dep(move |s| s.name("llvm").host(&build.config.build).stage(0))
@@ -403,6 +395,10 @@ pub fn build_rules(build: &Build) -> Rules {
          .default(true)
          .host(true)
          .run(move |s| check::docs(build, &s.compiler()));
+    rules.test("check-distcheck", "distcheck")
+         .dep(|s| s.name("dist-src"))
+         .run(move |_| check::distcheck(build));
+
 
     rules.build("test-helpers", "src/rt/rust_test_helpers.c")
          .run(move |s| native::test_helpers(build, s.target));


### PR DESCRIPTION
This commit implements the `distcheck` target for rustbuild which is only ever
run on our nightly bots. This essentially just creates a tarball, un-tars it,
and then runs a full build, validating that the release tarballs do indeed have
everything they need to build Rust.