### PR TITLE
rustdoc: Remove broken src links from reexported items from macros

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1468,6 +1468,13 @@ impl<'a> Item<'a> {
                 return None;
             }
         } else {
+            // Macros from other libraries get special filenames which we can
+            // safely ignore.
+            if self.item.source.filename.starts_with("<") &&
+               self.item.source.filename.ends_with("macros>") {
+                return None;
+            }
+
             let (krate, src_root) = match cache.extern_locations.get(&self.item.def_id.krate) {
                 Some(&(ref name, ref src, Local)) => (name, src),
                 Some(&(ref name, ref src, Remote(ref s))) => {


### PR DESCRIPTION
When an item is defined in an external macro it doesn't get a real
filename so we need to filter out these when generating src links for
reexported items.