### PR TITLE
Reinstate while loop in deaggregator pass

### DIFF
--- a/src/test/mir-opt/deaggregator_test_enum_2.rs
+++ b/src/test/mir-opt/deaggregator_test_enum_2.rs
@@ -1,0 +1,57 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that deaggregate fires in more than one basic block
+
+enum Foo {
+    A(i32),
+    B(i32),
+}
+
+fn test1(x: bool, y: i32) -> Foo {
+    if x {
+        Foo::A(y)
+    } else {
+        Foo::B(y)
+    }
+}
+
+fn main() {}
+
+// END RUST SOURCE
+// START rustc.node12.Deaggregator.before.mir
+//  bb1: {
+//      _6 = _4;
+//      _0 = Foo::A(_6,);
+//      goto -> bb3;
+//  }
+//
+//  bb2: {
+//      _7 = _4;
+//      _0 = Foo::B(_7,);
+//      goto -> bb3;
+//  }
+// END rustc.node12.Deaggregator.before.mir
+// START rustc.node12.Deaggregator.after.mir
+//  bb1: {
+//      _6 = _4;
+//      ((_0 as A).0: i32) = _6;
+//      discriminant(_0) = 0;
+//      goto -> bb3;
+//  }
+//
+//  bb2: {
+//      _7 = _4;
+//      ((_0 as B).0: i32) = _7;
+//      discriminant(_0) = 1;
+//      goto -> bb3;
+//  }
+// END rustc.node12.Deaggregator.after.mir
+//

--- a/src/test/mir-opt/deaggregator_test_multiple.rs
+++ b/src/test/mir-opt/deaggregator_test_multiple.rs
@@ -1,0 +1,48 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that deaggregate fires more than once per block
+
+enum Foo {
+    A(i32),
+    B,
+}
+
+fn test(x: i32) -> [Foo; 2] {
+    [Foo::A(x), Foo::A(x)]
+}
+
+fn main() { }
+
+// END RUST SOURCE
+// START rustc.node10.Deaggregator.before.mir
+// bb0: {
+//     _2 = _1;
+//     _4 = _2;
+//     _3 = Foo::A(_4,);
+//     _6 = _2;
+//     _5 = Foo::A(_6,);
+//     _0 = [_3, _5];
+//     return;
+// }
+// END rustc.node10.Deaggregator.before.mir
+// START rustc.node10.Deaggregator.after.mir
+// bb0: {
+//     _2 = _1;
+//     _4 = _2;
+//     ((_3 as A).0: i32) = _4;
+//     discriminant(_3) = 0;
+//     _6 = _2;
+//     ((_5 as A).0: i32) = _6;
+//     discriminant(_5) = 0;
+//     _0 = [_3, _5];
+//     return;
+// }
+// END rustc.node10.Deaggregator.after.mir


### PR DESCRIPTION
A previous commit must have removed the `while let` loop here by
mistake; for each basic block, it should find and deaggregate multiple
statements in their index order, and the `curr` index tracks the
progress through the block.

This fixes both the case of deaggregating statements in separate
basic blocks (preserving `curr` could prevent that) as well
as multiple times in the same block (missing loop prevented that).

The loop was lost in commit bda46c21fe30377b9587b584c64ffe99da6c14ce.