### PR TITLE
Prevent where < ident > from parsing.

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4389,7 +4389,7 @@ impl<'a> Parser<'a> {
                     *t == token::Gt || *t == token::Comma || *t == token::Colon
                 });
                 if gt_comma_or_colon {
-                    self.err("syntax `where<T>` is reserved for future use");
+                    self.span_err(self.span, "syntax `where<T>` is reserved for future use");
                 }
             }
         }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4377,6 +4377,23 @@ impl<'a> Parser<'a> {
             return Ok(where_clause);
         }
 
+        // This is a temporary hack.
+        //
+        // We are considering adding generics to the `where` keyword as an alternative higher-rank
+        // parameter syntax (as in `where<'a>` or `where<T>`. To avoid that being a breaking
+        // change, for now we refuse to parse `where < (ident | lifetime) (> | , | :)`.
+        if token::Lt == self.token {
+            let ident_or_lifetime = self.look_ahead(1, |t| t.is_ident() || t.is_lifetime());
+            if ident_or_lifetime {
+                let gt_comma_or_colon = self.look_ahead(2, |t| {
+                    *t == token::Gt || *t == token::Comma || *t == token::Colon
+                });
+                if gt_comma_or_colon {
+                    return Err(self.fatal("TODO How to even explain this error?"));
+                }
+            }
+        }
+
         let mut parsed_something = false;
         loop {
             let lo = self.span.lo;

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4389,7 +4389,7 @@ impl<'a> Parser<'a> {
                     *t == token::Gt || *t == token::Comma || *t == token::Colon
                 });
                 if gt_comma_or_colon {
-                    return Err(self.fatal("TODO How to even explain this error?"));
+                    self.err("syntax `where<T>` is reserved for future use");
                 }
             }
         }

--- a/src/test/parse-fail/where_with_bound.rs
+++ b/src/test/parse-fail/where_with_bound.rs
@@ -1,0 +1,16 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z parse-only
+
+fn foo<T>() where <T>::Item: ToString, T: Iterator { }
+               //~^ syntax `where<T>` is reserved for future use
+
+fn main() {}


### PR DESCRIPTION
In order to be forward compatible with `where<'a>` syntax for higher
rank parameters, prevent potential conflicts with UFCS from parsing
correctly for the near term.