### PR TITLE
macros: allow a `path` fragment to be parsed as a type parameter bound

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4173,7 +4173,7 @@ impl<'a> Parser<'a> {
                     }));
                     self.bump();
                 }
-                token::ModSep | token::Ident(..) => {
+                _ if self.token.is_path_start() || self.token.is_keyword(keywords::For) => {
                     let poly_trait_ref = self.parse_poly_trait_ref()?;
                     let modifier = if ate_question {
                         TraitBoundModifier::Maybe

--- a/src/test/run-pass/issue-8521.rs
+++ b/src/test/run-pass/issue-8521.rs
@@ -1,0 +1,34 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Foo1 {}
+
+trait A {}
+
+macro_rules! foo1(($t:path) => {
+    impl<T: $t> Foo1 for T {}
+});
+
+foo1!(A);
+
+trait Foo2 {}
+
+trait B<T> {}
+
+#[allow(unused)]
+struct C {}
+
+macro_rules! foo2(($t:path) => {
+    impl<T: $t> Foo2 for T {}
+});
+
+foo2!(B<C>);
+
+fn main() {}

--- a/src/test/ui/macros/macro_path_as_generic_bound.rs
+++ b/src/test/ui/macros/macro_path_as_generic_bound.rs
@@ -1,0 +1,19 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Foo {}
+
+macro_rules! foo(($t:path) => {
+    impl<T: $t> Foo for T {}
+});
+
+foo!(m::m2::A);
+
+fn main() {}

--- a/src/test/ui/macros/macro_path_as_generic_bound.stderr
+++ b/src/test/ui/macros/macro_path_as_generic_bound.stderr
@@ -1,0 +1,11 @@
+error[E0433]: failed to resolve. Use of undeclared type or module `m`
+  --> $DIR/macro_path_as_generic_bound.rs:17:6
+   |
+17 | foo!(m::m2::A);
+   | -----^^^^^^^^--
+   | |    |
+   | |    Use of undeclared type or module `m`
+   | in this macro invocation
+
+error: cannot continue compilation due to previous error
+


### PR DESCRIPTION
Allow a `path` fragment to be parsed as a type parameter bound.
Fixes #8521.