### PR TITLE
[MSP430] Do not generate '@' character in symbol names.

### DIFF
--- a/src/librustc_data_structures/base_n.rs
+++ b/src/librustc_data_structures/base_n.rs
@@ -14,6 +14,8 @@
 use std::str;
 
 pub const MAX_BASE: u64 = 64;
+pub const ALPHANUMERIC_ONLY: u64 = 62;
+
 const BASE_64: &'static [u8; MAX_BASE as usize] =
     b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ@$";
 

--- a/src/librustc_trans/context.rs
+++ b/src/librustc_trans/context.rs
@@ -971,7 +971,7 @@ impl<'b, 'tcx> CrateContext<'b, 'tcx> {
         let mut name = String::with_capacity(prefix.len() + 6);
         name.push_str(prefix);
         name.push_str(".");
-        base_n::push_str(idx as u64, base_n::MAX_BASE, &mut name);
+        base_n::push_str(idx as u64, base_n::ALPHANUMERIC_ONLY, &mut name);
         name
     }
 }


### PR DESCRIPTION
MSP430 assembler does not like '@' character in symbol names, so we need
to replace it with some other character.

Fixes #38116 
