### PR TITLE
[LLVM 4.0] Update rustllvm to understand the new DIBulder::createBasicType API

### DIFF
--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -553,7 +553,10 @@ extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreateBasicType(
     unsigned Encoding) {
     return wrap(Builder->createBasicType(
         Name, SizeInBits,
-        AlignInBits, Encoding));
+#if LLVM_VERSION_LE(3, 9)
+        AlignInBits,
+#endif
+        Encoding));
 }
 
 extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreatePointerType(


### PR DESCRIPTION
This lets Rust work with the createBasicType API in LLVM 4.0.

The alignment argument was dropped in D25073.

- https://reviews.llvm.org/D25073