### PR TITLE
[LLVM 4.0] Explicitly call constructor of 'llvm::Error'

### DIFF
--- a/src/rustllvm/ArchiveWrapper.cpp
+++ b/src/rustllvm/ArchiveWrapper.cpp
@@ -37,6 +37,8 @@ struct RustArchiveIterator {
     Archive::child_iterator end;
 #if LLVM_VERSION_GE(3, 9)
     Error err;
+
+    RustArchiveIterator() : err(Error::success()) { }
 #endif
 };
 


### PR DESCRIPTION
The implicit constructor has been deleted. We should use
Error::success() instead.

The constructor in the LLVM headers mentions that "success" should be
used instead of the deleted constructor for clarity.