### PR TITLE
Simplify use of mir_opt_level

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -269,7 +269,6 @@ top_level_options!(
 
         test: bool [TRACKED],
         error_format: ErrorOutputType [UNTRACKED],
-        mir_opt_level: usize [TRACKED],
 
         // if Some, enable incremental compilation, using the given
         // directory to store intermediate results
@@ -435,7 +434,6 @@ pub fn basic_options() -> Options {
         maybe_sysroot: None,
         target_triple: host_triple().to_string(),
         test: false,
-        mir_opt_level: 1,
         incremental: None,
         debugging_opts: basic_debugging_options(),
         prints: Vec::new(),
@@ -916,8 +914,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
           "print layout information for each type encountered"),
     print_trans_items: Option<String> = (None, parse_opt_string, [UNTRACKED],
           "print the result of the translation item collection pass"),
-    mir_opt_level: Option<usize> = (None, parse_opt_uint, [TRACKED],
-          "set the MIR optimization level (0-3)"),
+    mir_opt_level: usize = (1, parse_uint, [TRACKED],
+          "set the MIR optimization level (0-3, default: 1)"),
     dump_mir: Option<String> = (None, parse_opt_string, [UNTRACKED],
           "dump MIR state at various points in translation"),
     dump_mir_dir: Option<String> = (None, parse_opt_string, [UNTRACKED],
@@ -1322,8 +1320,6 @@ pub fn build_session_options_and_crate_config(matches: &getopts::Matches)
 
     let debugging_opts = build_debugging_options(matches, error_format);
 
-    let mir_opt_level = debugging_opts.mir_opt_level.unwrap_or(1);
-
     let mut output_types = BTreeMap::new();
     if !debugging_opts.parse_only {
         for list in matches.opt_strs("emit") {
@@ -1532,7 +1528,6 @@ pub fn build_session_options_and_crate_config(matches: &getopts::Matches)
         maybe_sysroot: sysroot_opt,
         target_triple: target,
         test: test,
-        mir_opt_level: mir_opt_level,
         incremental: incremental,
         debugging_opts: debugging_opts,
         prints: prints,
@@ -2475,7 +2470,7 @@ mod tests {
         assert!(reference.dep_tracking_hash() != opts.dep_tracking_hash());
 
         opts = reference.clone();
-        opts.debugging_opts.mir_opt_level = Some(1);
+        opts.debugging_opts.mir_opt_level = 3;
         assert!(reference.dep_tracking_hash() != opts.dep_tracking_hash());
     }
 }

--- a/src/librustc_mir/transform/copy_prop.rs
+++ b/src/librustc_mir/transform/copy_prop.rs
@@ -65,11 +65,10 @@ impl<'tcx> MirPass<'tcx> for CopyPropagation {
             }
         }
 
-        // We only run when the MIR optimization level is at least 1. This avoids messing up debug
-        // info.
-        match tcx.sess.opts.debugging_opts.mir_opt_level {
-            Some(0) | None => return,
-            _ => {}
+        // We only run when the MIR optimization level is > 1.
+        // This avoids a slow pass, and messing up debug info.
+        if tcx.sess.opts.debugging_opts.mir_opt_level <= 1 {
+            return;
         }
 
         loop {

--- a/src/librustc_mir/transform/deaggregator.rs
+++ b/src/librustc_mir/transform/deaggregator.rs
@@ -23,13 +23,10 @@ impl<'tcx> MirPass<'tcx> for Deaggregator {
         let node_id = source.item_id();
         let node_path = tcx.item_path_str(tcx.map.local_def_id(node_id));
         debug!("running on: {:?}", node_path);
-        // we only run when mir_opt_level > 1
-        match tcx.sess.opts.debugging_opts.mir_opt_level {
-            Some(0) |
-            Some(1) |
-            None => { return; },
-            _ => {}
-        };
+        // we only run when mir_opt_level > 2
+        if tcx.sess.opts.debugging_opts.mir_opt_level <= 2 {
+            return;
+        }
 
         // Do not trigger on constants.  Could be revised in future
         if let MirSource::Fn(_) = source {} else { return; }

--- a/src/librustc_mir/transform/instcombine.rs
+++ b/src/librustc_mir/transform/instcombine.rs
@@ -38,7 +38,7 @@ impl<'tcx> MirPass<'tcx> for InstCombine {
                     _: MirSource,
                     mir: &mut Mir<'tcx>) {
         // We only run when optimizing MIR (at any level).
-        if tcx.sess.opts.debugging_opts.mir_opt_level == Some(0) {
+        if tcx.sess.opts.debugging_opts.mir_opt_level == 0 {
             return
         }
 


### PR DESCRIPTION
Remove the unused top level option by the same name, and retain the
debug option.

Use -Zmir-opt-level=1 as default.

One pass is enabled by default but wants to be optional:

- Instcombine requires mir_opt_level > 0

Copy propagation is not used by default, but used to be activated by
explicit -Zmir-opt-level=1. It must move one higher to be off by
default:

- CopyPropagation requires mir_opt_level > 1

Deaggregate is not used by default, and used to be on a different level
than CopyPropagation:

- Deaggreate requires mir_opt_level > 2