### PR TITLE
resolve: clean up the semantics of `self` in an import list

### DIFF
--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -168,6 +168,7 @@ impl<'a> Resolver<'a> {
                             target: binding,
                             source: source,
                             result: self.per_ns(|_, _| Cell::new(Err(Undetermined))),
+                            type_ns_only: false,
                         };
                         self.add_import_directive(
                             module_path, subclass, view_path.span, item.id, vis, expansion,
@@ -195,10 +196,10 @@ impl<'a> Resolver<'a> {
 
                         for source_item in source_items {
                             let node = source_item.node;
-                            let (module_path, ident, rename) = {
+                            let (module_path, ident, rename, type_ns_only) = {
                                 if node.name.name != keywords::SelfValue.name() {
                                     let rename = node.rename.unwrap_or(node.name);
-                                    (module_path.clone(), node.name, rename)
+                                    (module_path.clone(), node.name, rename, false)
                                 } else {
                                     let ident = *module_path.last().unwrap();
                                     if ident.name == keywords::CrateRoot.name() {
@@ -212,13 +213,14 @@ impl<'a> Resolver<'a> {
                                     }
                                     let module_path = module_path.split_last().unwrap().1;
                                     let rename = node.rename.unwrap_or(ident);
-                                    (module_path.to_vec(), ident, rename)
+                                    (module_path.to_vec(), ident, rename, true)
                                 }
                             };
                             let subclass = SingleImport {
                                 target: rename,
                                 source: ident,
                                 result: self.per_ns(|_, _| Cell::new(Err(Undetermined))),
+                                type_ns_only: type_ns_only,
                             };
                             let id = source_item.node.id;
                             self.add_import_directive(

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -894,6 +894,7 @@ enum NameBindingKind<'a> {
         binding: &'a NameBinding<'a>,
         directive: &'a ImportDirective<'a>,
         used: Cell<bool>,
+        legacy_self_import: bool,
     },
     Ambiguity {
         b1: &'a NameBinding<'a>,
@@ -1346,8 +1347,13 @@ impl<'a> Resolver<'a> {
         }
 
         match binding.kind {
-            NameBindingKind::Import { directive, binding, ref used } if !used.get() => {
+            NameBindingKind::Import { directive, binding, ref used, legacy_self_import }
+                    if !used.get() => {
                 used.set(true);
+                if legacy_self_import {
+                    self.warn_legacy_self_import(directive);
+                    return false;
+                }
                 self.used_imports.insert((directive.id, ns));
                 self.add_to_glob_map(directive.id, ident);
                 self.record_use(ident, ns, binding, span)
@@ -3109,6 +3115,12 @@ impl<'a> Resolver<'a> {
         }
         err.emit();
         self.name_already_seen.insert(name, span);
+    }
+
+    fn warn_legacy_self_import(&self, directive: &'a ImportDirective<'a>) {
+        let (id, span) = (directive.id, directive.span);
+        let msg = "`self` no longer imports values".to_string();
+        self.session.add_lint(lint::builtin::LEGACY_IMPORTS, id, span, msg);
     }
 }
 

--- a/src/test/compile-fail/issue-28075.rs
+++ b/src/test/compile-fail/issue-28075.rs
@@ -18,7 +18,5 @@ extern crate lint_stability;
 
 use lint_stability::{unstable, deprecated}; //~ ERROR use of unstable library feature 'test_feature'
 
-use lint_stability::unstable::{self as u}; //~ ERROR use of unstable library feature 'test_feature'
-
 fn main() {
 }

--- a/src/test/compile-fail/issue-38293.rs
+++ b/src/test/compile-fail/issue-38293.rs
@@ -10,22 +10,24 @@
 
 // Test that `fn foo::bar::{self}` only imports `bar` in the type namespace.
 
+#![allow(unused)]
+#![deny(legacy_imports)]
+
 mod foo {
     pub fn f() { }
 }
 use foo::f::{self};
-//~^ ERROR unresolved import
-//~| NOTE no `f` in `foo`
+//~^ ERROR `self` no longer imports values
+//~| WARN hard error
 
 mod bar {
     pub fn baz() {}
     pub mod baz {}
 }
 use bar::baz::{self};
+//~^ ERROR `self` no longer imports values
+//~| WARN hard error
 
 fn main() {
     baz();
-    //~^ ERROR unresolved name `baz`
-    //~| NOTE unresolved name
-    //~| HELP module `baz` cannot be used as an expression
 }

--- a/src/test/compile-fail/issue-38293.rs
+++ b/src/test/compile-fail/issue-38293.rs
@@ -1,0 +1,31 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that `fn foo::bar::{self}` only imports `bar` in the type namespace.
+
+mod foo {
+    pub fn f() { }
+}
+use foo::f::{self};
+//~^ ERROR unresolved import
+//~| NOTE no `f` in `foo`
+
+mod bar {
+    pub fn baz() {}
+    pub mod baz {}
+}
+use bar::baz::{self};
+
+fn main() {
+    baz();
+    //~^ ERROR unresolved name `baz`
+    //~| NOTE unresolved name
+    //~| HELP module `baz` cannot be used as an expression
+}


### PR DESCRIPTION
Change `self` in an import list `use foo::bar::{self, ...};` to import `bar` only in the type namespace. Today, `bar` is imported in every namespace in which `foo::bar` is defined.

This is a [breaking-change], see https://github.com/rust-lang/rust/issues/38293#issue-194817974 for examples of code that would break.

Fixes #38293.
r? @nrc 