### PR TITLE
Expand E0309 explanation with motivating example

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -1236,6 +1236,23 @@ struct Foo<'a, T: 'a> {
     foo: &'a T
 }
 ```
+
+To see why this is important, consider the case where `T` is itself a reference
+(e.g., `T = &str`). If we don't include the restriction that `T: 'a`, the
+following code would be perfectly legal:
+
+```compile_fail,E0309
+struct Foo<'a, T> {
+    foo: &'a T
+}
+
+fn main() {
+    let v = "42".to_string();
+    let f = Foo{foo: &v};
+    drop(v);
+    println!("{}", f.foo); // but we've already dropped v!
+}
+```
 "##,
 
 E0310: r##"


### PR DESCRIPTION
I recently started reading @Gankro's "[Learning Rust With Entirely Too Many Linked Lists](http://cglab.ca/~abeinges/blah/too-many-lists/book/README.html)", and came across [a part](http://cglab.ca/~abeinges/blah/too-many-lists/book/second-iter.html) where he comes across `E0309`, and after showing `rustc --explain E0309` prompty says

> This is dumb. I think it's dumb. You have to do it.

Humor aside, I think this says something about the current explanation being somewhat lacking.

This patch introduces a motivating example saying why `T: 'a` is a necessary restriction. Hopefully, this will help new Rustaceans understand why leaving out the `'a` bound on `T` might lead to broken code.