### PR TITLE
[LLVM 4.0] Move debuginfo alignment argument

### DIFF
--- a/src/librustc_llvm/ffi.rs
+++ b/src/librustc_llvm/ffi.rs
@@ -1417,7 +1417,8 @@ extern "C" {
                                                  Ty: DIType,
                                                  isLocalToUnit: bool,
                                                  Val: ValueRef,
-                                                 Decl: DIDescriptor)
+                                                 Decl: DIDescriptor,
+                                                 AlignInBits: u64)
                                                  -> DIGlobalVariable;
 
     pub fn LLVMRustDIBuilderCreateVariable(Builder: DIBuilderRef,
@@ -1429,7 +1430,8 @@ extern "C" {
                                            Ty: DIType,
                                            AlwaysPreserve: bool,
                                            Flags: DIFlags,
-                                           ArgNo: c_uint)
+                                           ArgNo: c_uint,
+                                           AlignInBits: u64)
                                            -> DIVariable;
 
     pub fn LLVMRustDIBuilderCreateArrayType(Builder: DIBuilderRef,

--- a/src/librustc_trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/debuginfo/metadata.rs
@@ -1763,6 +1763,10 @@ pub fn create_global_var_metadata(cx: &CrateContext,
 
     let var_name = CString::new(var_name).unwrap();
     let linkage_name = CString::new(linkage_name).unwrap();
+
+    let ty = cx.tcx().item_type(node_def_id);
+    let global_align = type_of::align_of(cx, ty);
+
     unsafe {
         llvm::LLVMRustDIBuilderCreateStaticVariable(DIB(cx),
                                                     var_scope,
@@ -1773,7 +1777,9 @@ pub fn create_global_var_metadata(cx: &CrateContext,
                                                     type_metadata,
                                                     is_local_to_unit,
                                                     global,
-                                                    ptr::null_mut());
+                                                    ptr::null_mut(),
+                                                    global_align as u64,
+        );
     }
 }
 

--- a/src/librustc_trans/debuginfo/mod.rs
+++ b/src/librustc_trans/debuginfo/mod.rs
@@ -462,6 +462,7 @@ pub fn declare_local<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         LocalVariable    |
         CapturedVariable => (0, DW_TAG_auto_variable)
     };
+    let align = ::type_of::align_of(cx, variable_type);
 
     let name = CString::new(variable_name.as_str().as_bytes()).unwrap();
     match (variable_access, &[][..]) {
@@ -478,7 +479,9 @@ pub fn declare_local<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                     type_metadata,
                     cx.sess().opts.optimize != config::OptLevel::No,
                     DIFlags::FlagZero,
-                    argument_index)
+                    argument_index,
+                    align as u64,
+                )
             };
             source_loc::set_debug_location(cx, None,
                 InternalDebugLocation::new(scope_metadata, loc.line, loc.col.to_usize()));

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -552,8 +552,13 @@ extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreateBasicType(
     uint64_t AlignInBits,
     unsigned Encoding) {
     return wrap(Builder->createBasicType(
-        Name, SizeInBits,
-        AlignInBits, Encoding));
+        Name,
+        SizeInBits,
+#if LLVM_VERSION_LE(3, 9)
+        AlignInBits,
+#endif
+        Encoding
+    ));
 }
 
 extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreatePointerType(
@@ -645,8 +650,11 @@ extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreateStaticVariable(
     LLVMRustMetadataRef Ty,
     bool isLocalToUnit,
     LLVMValueRef Val,
-    LLVMRustMetadataRef Decl = NULL) {
-    return wrap(Builder->createGlobalVariable(unwrapDI<DIDescriptor>(Context),
+    LLVMRustMetadataRef Decl = NULL,
+    uint64_t AlignInBits = 0)
+{
+    return wrap(Builder->createGlobalVariable(
+        unwrapDI<DIDescriptor>(Context),
         Name,
         LinkageName,
         unwrapDI<DIFile>(File),
@@ -654,7 +662,11 @@ extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreateStaticVariable(
         unwrapDI<DIType>(Ty),
         isLocalToUnit,
         cast<Constant>(unwrap(Val)),
-        unwrapDIptr<MDNode>(Decl)));
+        unwrapDIptr<MDNode>(Decl)
+#if LLVM_VERSION_GE(4, 0)
+        , AlignInBits
+#endif
+    ));
 }
 
 extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreateVariable(
@@ -667,14 +679,23 @@ extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreateVariable(
     LLVMRustMetadataRef Ty,
     bool AlwaysPreserve,
     LLVMRustDIFlags Flags,
-    unsigned ArgNo) {
+    unsigned ArgNo,
+    uint64_t AlignInBits)
+{
 #if LLVM_VERSION_GE(3, 8)
     if (Tag == 0x100) { // DW_TAG_auto_variable
         return wrap(Builder->createAutoVariable(
-            unwrapDI<DIDescriptor>(Scope), Name,
+            unwrapDI<DIDescriptor>(Scope),
+            Name,
             unwrapDI<DIFile>(File),
             LineNo,
-            unwrapDI<DIType>(Ty), AlwaysPreserve, from_rust(Flags)));
+            unwrapDI<DIType>(Ty),
+            AlwaysPreserve,
+            from_rust(Flags)
+#if LLVM_VERSION_GE(4,0)
+            , AlignInBits
+#endif
+        ));
     } else {
         return wrap(Builder->createParameterVariable(
             unwrapDI<DIDescriptor>(Scope), Name, ArgNo,


### PR DESCRIPTION
Alignment was removed from createBasicType and moved to

- createGlobalVariable
- createAutoVariable
- createStaticMemberType (unused in Rust)
- createTempGlobalVariableFwdDecl (unused in Rust)

https://github.com/llvm-mirror/llvm/commit/e69c459a6e9756ca1ff3acb1dcfc434843aee80f