### PR TITLE
Use struct name as span instead of entire block

### DIFF
--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -411,7 +411,7 @@ pub fn walk_trait_ref<'v, V>(visitor: &mut V, trait_ref: &'v TraitRef)
 
 pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
     visitor.visit_vis(&item.vis);
-    visitor.visit_name(item.span, item.name);
+    visitor.visit_name(item.span, item.name.node);
     match item.node {
         ItemExternCrate(opt_name) => {
             visitor.visit_id(item.id);
@@ -428,7 +428,7 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
             visitor.visit_expr(expr);
         }
         ItemFn(ref declaration, unsafety, constness, abi, ref generics, body_id) => {
-            visitor.visit_fn(FnKind::ItemFn(item.name,
+            visitor.visit_fn(FnKind::ItemFn(item.name.node,
                                             generics,
                                             unsafety,
                                             constness,
@@ -475,7 +475,11 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
         ItemUnion(ref struct_definition, ref generics) => {
             visitor.visit_generics(generics);
             visitor.visit_id(item.id);
-            visitor.visit_variant_data(struct_definition, item.name, generics, item.id, item.span);
+            visitor.visit_variant_data(struct_definition,
+                                       item.name.node,
+                                       generics,
+                                       item.id,
+                                       item.span);
         }
         ItemTrait(_, ref generics, ref bounds, ref methods) => {
             visitor.visit_id(item.id);

--- a/src/librustc/hir/map/blocks.rs
+++ b/src/librustc/hir/map/blocks.rs
@@ -27,6 +27,7 @@ use hir::{Expr, FnDecl};
 use hir::intravisit::FnKind;
 use syntax::abi;
 use syntax::ast::{Attribute, Name, NodeId};
+use syntax::codemap::Spanned;
 use syntax_pos::Span;
 
 /// An FnLikeNode is a Node that is like a fn, in that it has a decl
@@ -108,7 +109,7 @@ impl<'a> Code<'a> {
 /// These are all the components one can extract from a fn item for
 /// use when implementing FnLikeNode operations.
 struct ItemFnParts<'a> {
-    name:     Name,
+    name:     Spanned<Name>,
     decl:     &'a ast::FnDecl,
     unsafety: ast::Unsafety,
     constness: ast::Constness,
@@ -210,7 +211,7 @@ impl<'a> FnLikeNode<'a> {
 
     pub fn kind(self) -> FnKind<'a> {
         let item = |p: ItemFnParts<'a>| -> FnKind<'a> {
-            FnKind::ItemFn(p.name, p.generics, p.unsafety, p.constness, p.abi, p.vis, p.attrs)
+            FnKind::ItemFn(p.name.node, p.generics, p.unsafety, p.constness, p.abi, p.vis, p.attrs)
         };
         let closure = |c: ClosureParts<'a>| {
             FnKind::Closure(c.attrs)

--- a/src/librustc/hir/map/def_collector.rs
+++ b/src/librustc/hir/map/def_collector.rs
@@ -146,13 +146,13 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
                 DefPathData::Impl,
             ItemKind::Enum(..) | ItemKind::Struct(..) | ItemKind::Union(..) | ItemKind::Trait(..) |
             ItemKind::ExternCrate(..) | ItemKind::ForeignMod(..) | ItemKind::Ty(..) =>
-                DefPathData::TypeNs(i.ident.name.as_str()),
-            ItemKind::Mod(..) if i.ident == keywords::Invalid.ident() => {
+                DefPathData::TypeNs(i.ident.node.name.as_str()),
+            ItemKind::Mod(..) if i.ident.node == keywords::Invalid.ident() => {
                 return visit::walk_item(self, i);
             }
-            ItemKind::Mod(..) => DefPathData::Module(i.ident.name.as_str()),
+            ItemKind::Mod(..) => DefPathData::Module(i.ident.node.name.as_str()),
             ItemKind::Static(..) | ItemKind::Const(..) | ItemKind::Fn(..) =>
-                DefPathData::ValueNs(i.ident.name.as_str()),
+                DefPathData::ValueNs(i.ident.node.name.as_str()),
             ItemKind::Mac(..) if i.id == DUMMY_NODE_ID => return, // Scope placeholder
             ItemKind::Mac(..) => return self.visit_macro_invoc(i.id, false),
             ItemKind::Use(ref view_path) => {
@@ -176,9 +176,9 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
             match i.node {
                 ItemKind::Enum(ref enum_definition, _) => {
                     for v in &enum_definition.variants {
-                        let variant_def_index =
-                            this.create_def(v.node.data.id(),
-                                            DefPathData::EnumVariant(v.node.name.name.as_str()));
+                        let variant_def_index = this.create_def(
+                            v.node.data.id(),
+                            DefPathData::EnumVariant(v.node.name.node.name.as_str()));
                         this.with_parent(variant_def_index, |this| {
                             for (index, field) in v.node.data.fields().iter().enumerate() {
                                 let name = field.ident.map(|ident| ident.name)
@@ -231,8 +231,8 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
     fn visit_trait_item(&mut self, ti: &'a TraitItem) {
         let def_data = match ti.node {
             TraitItemKind::Method(..) | TraitItemKind::Const(..) =>
-                DefPathData::ValueNs(ti.ident.name.as_str()),
-            TraitItemKind::Type(..) => DefPathData::TypeNs(ti.ident.name.as_str()),
+                DefPathData::ValueNs(ti.ident.node.name.as_str()),
+            TraitItemKind::Type(..) => DefPathData::TypeNs(ti.ident.node.name.as_str()),
             TraitItemKind::Macro(..) => return self.visit_macro_invoc(ti.id, false),
         };
 
@@ -249,8 +249,8 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
     fn visit_impl_item(&mut self, ii: &'a ImplItem) {
         let def_data = match ii.node {
             ImplItemKind::Method(..) | ImplItemKind::Const(..) =>
-                DefPathData::ValueNs(ii.ident.name.as_str()),
-            ImplItemKind::Type(..) => DefPathData::TypeNs(ii.ident.name.as_str()),
+                DefPathData::ValueNs(ii.ident.node.name.as_str()),
+            ImplItemKind::Type(..) => DefPathData::TypeNs(ii.ident.node.name.as_str()),
             ImplItemKind::Macro(..) => return self.visit_macro_invoc(ii.id, false),
         };
 
@@ -349,9 +349,9 @@ impl<'ast> Visitor<'ast> for DefCollector<'ast> {
             hir::ItemEnum(..) | hir::ItemStruct(..) | hir::ItemUnion(..) |
             hir::ItemTrait(..) | hir::ItemExternCrate(..) | hir::ItemMod(..) |
             hir::ItemForeignMod(..) | hir::ItemTy(..) =>
-                DefPathData::TypeNs(i.name.as_str()),
+                DefPathData::TypeNs(i.name.node.as_str()),
             hir::ItemStatic(..) | hir::ItemConst(..) | hir::ItemFn(..) =>
-                DefPathData::ValueNs(i.name.as_str()),
+                DefPathData::ValueNs(i.name.node.as_str()),
             hir::ItemUse(..) => DefPathData::Misc,
         };
         let def = self.create_def(i.id, def_data);

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -707,7 +707,7 @@ impl<'ast> Map<'ast> {
     /// Returns the name associated with the given NodeId's AST.
     pub fn name(&self, id: NodeId) -> Name {
         match self.get(id) {
-            NodeItem(i) => i.name,
+            NodeItem(i) => i.name.node,
             NodeForeignItem(i) => i.name,
             NodeImplItem(ii) => ii.name,
             NodeTraitItem(ti) => ti.name,
@@ -764,7 +764,7 @@ impl<'ast> Map<'ast> {
     pub fn span(&self, id: NodeId) -> Span {
         self.read(id); // reveals span from node
         match self.find_entry(id) {
-            Some(EntryItem(_, item)) => item.span,
+            Some(EntryItem(_, item)) => item.name.span,
             Some(EntryForeignItem(_, foreign_item)) => foreign_item.span,
             Some(EntryTraitItem(_, trait_method)) => trait_method.span,
             Some(EntryImplItem(_, impl_item)) => impl_item.span,
@@ -843,7 +843,7 @@ impl<'a, 'ast> NodesMatchingSuffix<'a, 'ast> {
                 match map.find(id) {
                     None => return None,
                     Some(NodeItem(item)) if item_is_mod(&item) =>
-                        return Some((id, item.name)),
+                        return Some((id, item.name.node)),
                     _ => {}
                 }
                 let parent = map.get_parent(id);
@@ -899,7 +899,7 @@ trait Named {
 
 impl<T:Named> Named for Spanned<T> { fn name(&self) -> Name { self.node.name() } }
 
-impl Named for Item { fn name(&self) -> Name { self.name } }
+impl Named for Item { fn name(&self) -> Name { self.name.node } }
 impl Named for ForeignItem { fn name(&self) -> Name { self.name } }
 impl Named for Variant_ { fn name(&self) -> Name { self.name } }
 impl Named for StructField { fn name(&self) -> Name { self.name } }

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1540,7 +1540,7 @@ pub struct ItemId {
 /// The name might be a dummy name in case of anonymous items
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct Item {
-    pub name: Name,
+    pub name: Spanned<Name>,
     pub attrs: HirVec<Attribute>,
     pub id: NodeId,
     pub node: Item_,

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -673,7 +673,7 @@ impl<'a> State<'a> {
                     word(&mut self.s, "as")?;
                     space(&mut self.s)?;
                 }
-                self.print_name(item.name)?;
+                self.print_name(item.name.node)?;
                 word(&mut self.s, ";")?;
                 self.end()?; // end inner head-block
                 self.end()?; // end outer head-block
@@ -684,10 +684,10 @@ impl<'a> State<'a> {
 
                 match kind {
                     hir::UseKind::Single => {
-                        if path.segments.last().unwrap().name != item.name {
+                        if path.segments.last().unwrap().name != item.name.node {
                             space(&mut self.s)?;
                             self.word_space("as")?;
-                            self.print_name(item.name)?;
+                            self.print_name(item.name.node)?;
                         }
                         word(&mut self.s, ";")?;
                     }
@@ -702,7 +702,7 @@ impl<'a> State<'a> {
                 if m == hir::MutMutable {
                     self.word_space("mut")?;
                 }
-                self.print_name(item.name)?;
+                self.print_name(item.name.node)?;
                 self.word_space(":")?;
                 self.print_type(&ty)?;
                 space(&mut self.s)?;
@@ -715,7 +715,7 @@ impl<'a> State<'a> {
             }
             hir::ItemConst(ref ty, ref expr) => {
                 self.head(&visibility_qualified(&item.vis, "const"))?;
-                self.print_name(item.name)?;
+                self.print_name(item.name.node)?;
                 self.word_space(":")?;
                 self.print_type(&ty)?;
                 space(&mut self.s)?;
@@ -732,7 +732,7 @@ impl<'a> State<'a> {
                               unsafety,
                               constness,
                               abi,
-                              Some(item.name),
+                              Some(item.name.node),
                               typarams,
                               &item.vis)?;
                 word(&mut self.s, " ")?;
@@ -742,7 +742,7 @@ impl<'a> State<'a> {
             }
             hir::ItemMod(ref _mod) => {
                 self.head(&visibility_qualified(&item.vis, "mod"))?;
-                self.print_name(item.name)?;
+                self.print_name(item.name.node)?;
                 self.nbsp()?;
                 self.bopen()?;
                 self.print_mod(_mod, &item.attrs)?;
@@ -759,7 +759,7 @@ impl<'a> State<'a> {
                 self.ibox(indent_unit)?;
                 self.ibox(0)?;
                 self.word_nbsp(&visibility_qualified(&item.vis, "type"))?;
-                self.print_name(item.name)?;
+                self.print_name(item.name.node)?;
                 self.print_generics(params)?;
                 self.end()?; // end the inner ibox
 
@@ -771,15 +771,15 @@ impl<'a> State<'a> {
                 self.end()?; // end the outer ibox
             }
             hir::ItemEnum(ref enum_definition, ref params) => {
-                self.print_enum_def(enum_definition, params, item.name, item.span, &item.vis)?;
+                self.print_enum_def(enum_definition, params, item.name.node, item.span, &item.vis)?;
             }
             hir::ItemStruct(ref struct_def, ref generics) => {
                 self.head(&visibility_qualified(&item.vis, "struct"))?;
-                self.print_struct(struct_def, generics, item.name, item.span, true)?;
+                self.print_struct(struct_def, generics, item.name.node, item.span, true)?;
             }
             hir::ItemUnion(ref struct_def, ref generics) => {
                 self.head(&visibility_qualified(&item.vis, "union"))?;
-                self.print_struct(struct_def, generics, item.name, item.span, true)?;
+                self.print_struct(struct_def, generics, item.name.node, item.span, true)?;
             }
             hir::ItemDefaultImpl(unsafety, ref trait_ref) => {
                 self.head("")?;
@@ -841,7 +841,7 @@ impl<'a> State<'a> {
                 self.print_visibility(&item.vis)?;
                 self.print_unsafety(unsafety)?;
                 self.word_nbsp("trait")?;
-                self.print_name(item.name)?;
+                self.print_name(item.name.node)?;
                 self.print_generics(generics)?;
                 let mut real_bounds = Vec::with_capacity(bounds.len());
                 for b in bounds.iter() {

--- a/src/librustc/infer/error_reporting.rs
+++ b/src/librustc/infer/error_reporting.rs
@@ -1052,7 +1052,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                 ast_map::NodeItem(ref item) => {
                     match item.node {
                         hir::ItemFn(ref fn_decl, unsafety, constness, _, ref gen, _) => {
-                            Some((fn_decl, gen, unsafety, constness, item.name, item.span))
+                            Some((fn_decl, gen, unsafety, constness, item.name.node, item.span))
                         }
                         _ => None,
                     }

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -519,7 +519,7 @@ impl<'a, 'tcx> Visitor<'tcx> for DeadVisitor<'a, 'tcx> {
             self.warn_dead_code(
                 item.id,
                 item.span,
-                item.name,
+                item.name.node,
                 item.node.descriptive_variant()
             );
         } else {

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -93,7 +93,7 @@ fn entry_point_type(item: &Item, at_root: bool) -> EntryPointType {
                 EntryPointType::Start
             } else if attr::contains_name(&item.attrs, "main") {
                 EntryPointType::MainAttr
-            } else if item.name == "main" {
+            } else if item.name.node == "main" {
                 if at_root {
                     // This is a top-level function so can be 'main'
                     EntryPointType::MainNamed

--- a/src/librustc_lint/bad_style.rs
+++ b/src/librustc_lint/bad_style.rs
@@ -118,13 +118,13 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonCamelCaseTypes {
         match it.node {
             hir::ItemTy(..) |
             hir::ItemStruct(..) |
-            hir::ItemUnion(..) => self.check_case(cx, "type", it.name, it.span),
-            hir::ItemTrait(..) => self.check_case(cx, "trait", it.name, it.span),
+            hir::ItemUnion(..) => self.check_case(cx, "type", it.name.node, it.span),
+            hir::ItemTrait(..) => self.check_case(cx, "trait", it.name.node, it.span),
             hir::ItemEnum(ref enum_definition, _) => {
                 if has_extern_repr {
                     return;
                 }
-                self.check_case(cx, "type", it.name, it.span);
+                self.check_case(cx, "type", it.name.node, it.span);
                 for variant in &enum_definition.variants {
                     self.check_case(cx, "variant", variant.node.name, variant.span);
                 }
@@ -267,7 +267,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonSnakeCase {
 
     fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
         if let hir::ItemMod(_) = it.node {
-            self.check_snake_case(cx, "module", &it.name.as_str(), Some(it.span));
+            self.check_snake_case(cx, "module", &it.name.node.as_str(), Some(it.span));
         }
     }
 
@@ -352,10 +352,10 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonUpperCaseGlobals {
     fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
         match it.node {
             hir::ItemStatic(..) => {
-                NonUpperCaseGlobals::check_upper_case(cx, "static variable", it.name, it.span);
+                NonUpperCaseGlobals::check_upper_case(cx, "static variable", it.name.node, it.span);
             }
             hir::ItemConst(..) => {
-                NonUpperCaseGlobals::check_upper_case(cx, "constant", it.name, it.span);
+                NonUpperCaseGlobals::check_upper_case(cx, "constant", it.name.node, it.span);
             }
             _ => {}
         }

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -169,10 +169,10 @@ impl<'a> CrateLoader<'a> {
                                             Some(i.span));
                         name
                     }
-                    None => i.ident.name,
+                    None => i.ident.node.name,
                 };
                 Some(ExternCrateInfo {
-                    ident: i.ident.name,
+                    ident: i.ident.node.name,
                     name: name,
                     id: i.id,
                     dep_kind: if attr::contains_name(&i.attrs, "no_link") {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -598,7 +598,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Resolver<'a> {
 
         // `visit::walk_variant` without the discriminant expression.
         self.visit_variant_data(&variant.node.data,
-                                variant.node.name,
+                                variant.node.name.node,
                                 generics,
                                 item_id,
                                 variant.span);
@@ -1511,7 +1511,7 @@ impl<'a> Resolver<'a> {
     }
 
     fn resolve_item(&mut self, item: &Item) {
-        let name = item.ident.name;
+        let name = item.ident.node.name;
 
         debug!("(resolving item) resolving {}", name);
 
@@ -1815,7 +1815,7 @@ impl<'a> Resolver<'a> {
                                 ImplItemKind::Const(..) => {
                                     // If this is a trait impl, ensure the const
                                     // exists in trait
-                                    this.check_trait_item(impl_item.ident.name,
+                                    this.check_trait_item(impl_item.ident.node.name,
                                                           impl_item.span,
                                         |n, s| ResolutionError::ConstNotMemberOfTrait(n, s));
                                     visit::walk_impl_item(this, impl_item);
@@ -1823,7 +1823,7 @@ impl<'a> Resolver<'a> {
                                 ImplItemKind::Method(ref sig, _) => {
                                     // If this is a trait impl, ensure the method
                                     // exists in trait
-                                    this.check_trait_item(impl_item.ident.name,
+                                    this.check_trait_item(impl_item.ident.node.name,
                                                           impl_item.span,
                                         |n, s| ResolutionError::MethodNotMemberOfTrait(n, s));
 
@@ -1839,7 +1839,7 @@ impl<'a> Resolver<'a> {
                                 ImplItemKind::Type(ref ty) => {
                                     // If this is a trait impl, ensure the type
                                     // exists in trait
-                                    this.check_trait_item(impl_item.ident.name,
+                                    this.check_trait_item(impl_item.ident.node.name,
                                                           impl_item.span,
                                         |n, s| ResolutionError::TypeNotMemberOfTrait(n, s));
 

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -658,7 +658,7 @@ impl<'l, 'tcx: 'l, 'll, D: Dump + 'll> DumpVisitor<'l, 'tcx, 'll, D> {
         }
 
         for variant in &enum_definition.variants {
-            let name = variant.node.name.name.to_string();
+            let name = variant.node.name.node.name.to_string();
             let mut qualname = enum_data.qualname.clone();
             qualname.push_str("::");
             qualname.push_str(&name);
@@ -1113,7 +1113,7 @@ impl<'l, 'tcx: 'l, 'll, D: Dump + 'll> DumpVisitor<'l, 'tcx, 'll, D> {
         match trait_item.node {
             ast::TraitItemKind::Const(ref ty, Some(ref expr)) => {
                 self.process_assoc_const(trait_item.id,
-                                         trait_item.ident.name,
+                                         trait_item.ident.node.name,
                                          trait_item.span,
                                          &ty,
                                          &expr,
@@ -1125,7 +1125,7 @@ impl<'l, 'tcx: 'l, 'll, D: Dump + 'll> DumpVisitor<'l, 'tcx, 'll, D> {
                 self.process_method(sig,
                                     body.as_ref().map(|x| &**x),
                                     trait_item.id,
-                                    trait_item.ident.name,
+                                    trait_item.ident.node.name,
                                     Visibility::Public,
                                     &trait_item.attrs,
                                     trait_item.span);
@@ -1141,7 +1141,7 @@ impl<'l, 'tcx: 'l, 'll, D: Dump + 'll> DumpVisitor<'l, 'tcx, 'll, D> {
         match impl_item.node {
             ast::ImplItemKind::Const(ref ty, ref expr) => {
                 self.process_assoc_const(impl_item.id,
-                                         impl_item.ident.name,
+                                         impl_item.ident.node.name,
                                          impl_item.span,
                                          &ty,
                                          &expr,
@@ -1153,7 +1153,7 @@ impl<'l, 'tcx: 'l, 'll, D: Dump + 'll> DumpVisitor<'l, 'tcx, 'll, D> {
                 self.process_method(sig,
                                     Some(body),
                                     impl_item.id,
-                                    impl_item.ident.name,
+                                    impl_item.ident.node.name,
                                     From::from(&impl_item.vis),
                                     &impl_item.attrs,
                                     impl_item.span);

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1002,7 +1002,7 @@ fn convert_struct_def<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
     let did = ccx.tcx.map.local_def_id(it.id);
     // Use separate constructor id for unit/tuple structs and reuse did for braced structs.
     let ctor_id = if !def.is_struct() { Some(ccx.tcx.map.local_def_id(def.id())) } else { None };
-    let variants = vec![convert_struct_variant(ccx, ctor_id.unwrap_or(did), it.name,
+    let variants = vec![convert_struct_variant(ccx, ctor_id.unwrap_or(did), it.name.node,
                                                ConstInt::Infer(0), def)];
     let adt = ccx.tcx.alloc_adt_def(did, AdtKind::Struct, variants);
     if let Some(ctor_id) = ctor_id {
@@ -1020,7 +1020,7 @@ fn convert_union_def<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                 -> &'tcx ty::AdtDef
 {
     let did = ccx.tcx.map.local_def_id(it.id);
-    let variants = vec![convert_struct_variant(ccx, did, it.name, ConstInt::Infer(0), def)];
+    let variants = vec![convert_struct_variant(ccx, did, it.name.node, ConstInt::Infer(0), def)];
 
     let adt = ccx.tcx.alloc_adt_def(did, AdtKind::Union, variants);
     ccx.tcx.adt_defs.borrow_mut().insert(did, adt);

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -332,7 +332,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
     pub fn visit_item(&mut self, item: &hir::Item,
                       renamed: Option<ast::Name>, om: &mut Module) {
         debug!("Visiting item {:?}", item);
-        let name = renamed.unwrap_or(item.name);
+        let name = renamed.unwrap_or(item.name.node);
         match item.node {
             hir::ItemForeignMod(ref fm) => {
                 // If inlining we only want to include public functions.

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -18,7 +18,7 @@ pub use symbol::Symbol as Name;
 pub use util::ThinVec;
 
 use syntax_pos::{mk_sp, Span, DUMMY_SP, ExpnId};
-use codemap::{respan, Spanned};
+use codemap::{dummy_spanned, respan, Spanned};
 use abi::Abi;
 use ext::hygiene::SyntaxContext;
 use print::pprust;
@@ -50,6 +50,14 @@ impl Ident {
    /// Maps a string to an identifier with an empty syntax context.
    pub fn from_str(s: &str) -> Ident {
        Ident::with_empty_ctxt(Symbol::intern(s))
+   }
+
+   pub fn spanned(self, sp: Span) -> SpannedIdent {
+       respan(sp, self)
+   }
+
+   pub fn dummy_spanned(self) -> SpannedIdent {
+       dummy_spanned(self)
    }
 }
 
@@ -1175,7 +1183,7 @@ pub struct MethodSig {
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct TraitItem {
     pub id: NodeId,
-    pub ident: Ident,
+    pub ident: SpannedIdent,
     pub attrs: Vec<Attribute>,
     pub node: TraitItemKind,
     pub span: Span,
@@ -1192,7 +1200,7 @@ pub enum TraitItemKind {
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct ImplItem {
     pub id: NodeId,
-    pub ident: Ident,
+    pub ident: SpannedIdent,
     pub vis: Visibility,
     pub defaultness: Defaultness,
     pub attrs: Vec<Attribute>,
@@ -1656,7 +1664,7 @@ pub struct EnumDef {
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct Variant_ {
-    pub name: Ident,
+    pub name: SpannedIdent,
     pub attrs: Vec<Attribute>,
     pub data: VariantData,
     /// Explicit discriminant, e.g. `Foo = 1`
@@ -1831,12 +1839,18 @@ impl VariantData {
 /// The name might be a dummy name in case of anonymous items
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct Item {
-    pub ident: Ident,
+    pub ident: SpannedIdent,
     pub attrs: Vec<Attribute>,
     pub id: NodeId,
     pub node: ItemKind,
     pub vis: Visibility,
     pub span: Span,
+}
+
+impl Item {
+    pub fn spanned_symbol(&self) -> Spanned<Symbol> {
+        respan(self.ident.span, self.ident.node.name)
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -20,6 +20,7 @@
 pub use self::ExpnFormat::*;
 
 use std::cell::RefCell;
+use std::fmt;
 use std::path::{Path,PathBuf};
 use std::rc::Rc;
 
@@ -59,6 +60,12 @@ pub enum ExpnFormat {
 pub struct Spanned<T> {
     pub node: T,
     pub span: Span,
+}
+
+impl <T> fmt::Display for Spanned<T> where T: fmt::Display {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.node, f)
+    }
 }
 
 pub fn spanned<T>(lo: BytePos, hi: BytePos, t: T) -> Spanned<T> {

--- a/src/libsyntax/diagnostics/plugin.rs
+++ b/src/libsyntax/diagnostics/plugin.rs
@@ -14,6 +14,7 @@ use std::env;
 
 use ast;
 use ast::{Ident, Name};
+use codemap;
 use syntax_pos::Span;
 use ext::base::{ExtCtxt, MacEager, MacResult};
 use ext::build::AstBuilder;
@@ -227,7 +228,7 @@ pub fn expand_build_diagnostic_array<'cx>(ecx: &'cx mut ExtCtxt,
 
     MacEager::items(SmallVector::many(vec![
         P(ast::Item {
-            ident: name.clone(),
+            ident: codemap::dummy_spanned(name.clone()),
             attrs: Vec::new(),
             id: ast::DUMMY_NODE_ID,
             node: ast::ItemKind::Const(

--- a/src/libsyntax/entry.rs
+++ b/src/libsyntax/entry.rs
@@ -28,7 +28,7 @@ pub fn entry_point_type(item: &Item, depth: usize) -> EntryPointType {
                 EntryPointType::Start
             } else if attr::contains_name(&item.attrs, "main") {
                 EntryPointType::MainAttr
-            } else if item.ident.name == "main" {
+            } else if item.ident.node.name == "main" {
                 if depth == 1 {
                     // This is a top-level function so can be 'main'
                     EntryPointType::MainNamed

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -234,7 +234,7 @@ pub trait AstBuilder {
                output: P<ast::Ty>,
                body: P<ast::Block>) -> P<ast::Item>;
 
-    fn variant(&self, span: Span, name: Ident, tys: Vec<P<ast::Ty>> ) -> ast::Variant;
+    fn variant(&self, span: Span, name: ast::SpannedIdent, tys: Vec<P<ast::Ty>> ) -> ast::Variant;
     fn item_enum_poly(&self,
                       span: Span,
                       name: Ident,
@@ -1004,7 +1004,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         // FIXME: Would be nice if our generated code didn't violate
         // Rust coding conventions
         P(ast::Item {
-            ident: name,
+            ident: name.dummy_spanned(),
             attrs: attrs,
             id: ast::DUMMY_NODE_ID,
             node: node,
@@ -1047,7 +1047,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             body)
     }
 
-    fn variant(&self, span: Span, name: Ident, tys: Vec<P<ast::Ty>> ) -> ast::Variant {
+    fn variant(&self, span: Span, name: ast::SpannedIdent, tys: Vec<P<ast::Ty>> ) -> ast::Variant {
         let fields: Vec<_> = tys.into_iter().map(|ty| {
             ast::StructField {
                 span: ty.span,
@@ -1169,7 +1169,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                 vis: ast::Visibility, vp: P<ast::ViewPath>) -> P<ast::Item> {
         P(ast::Item {
             id: ast::DUMMY_NODE_ID,
-            ident: keywords::Invalid.ident(),
+            ident: keywords::Invalid.ident().dummy_spanned(),
             attrs: vec![],
             node: ast::ItemKind::Use(vp),
             vis: vis,

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -201,7 +201,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             attrs: krate.attrs,
             span: krate.span,
             node: ast::ItemKind::Mod(krate.module),
-            ident: keywords::Invalid.ident(),
+            ident: keywords::Invalid.ident().dummy_spanned(),
             id: ast::DUMMY_NODE_ID,
             vis: ast::Visibility::Public,
         })));
@@ -752,7 +752,7 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
                         self.collect(ExpansionKind::Items, InvocationKind::Bang {
                             mac: mac,
                             attrs: item.attrs,
-                            ident: Some(item.ident),
+                            ident: Some(item.ident.node),
                             span: item.span,
                         }).make_items()
                     }
@@ -760,13 +760,13 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
                 })
             }
             ast::ItemKind::Mod(ast::Mod { inner, .. }) => {
-                if item.ident == keywords::Invalid.ident() {
+                if item.ident.node == keywords::Invalid.ident() {
                     return noop_fold_item(item, self);
                 }
 
                 let orig_directory_ownership = self.cx.current_expansion.directory_ownership;
                 let mut module = (*self.cx.current_expansion.module).clone();
-                module.mod_path.push(item.ident);
+                module.mod_path.push(item.ident.node);
 
                 // Detect if this is an inline module (`mod m { ... }` as opposed to `mod m;`).
                 // In the non-inline case, `inner` is never the dummy span (c.f. `parse_item_mod`).
@@ -778,7 +778,7 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
                         self.cx.current_expansion.directory_ownership = DirectoryOwnership::Owned;
                         module.directory.push(&*path.as_str());
                     } else {
-                        module.directory.push(&*item.ident.name.as_str());
+                        module.directory.push(&*item.ident.node.name.as_str());
                     }
                 } else {
                     let mut path =

--- a/src/libsyntax/ext/placeholders.rs
+++ b/src/libsyntax/ext/placeholders.rs
@@ -43,15 +43,15 @@ pub fn placeholder(kind: ExpansionKind, id: ast::NodeId) -> Expansion {
         ExpansionKind::Expr => Expansion::Expr(expr_placeholder()),
         ExpansionKind::OptExpr => Expansion::OptExpr(Some(expr_placeholder())),
         ExpansionKind::Items => Expansion::Items(SmallVector::one(P(ast::Item {
-            id: id, span: span, ident: ident, vis: vis, attrs: attrs,
+            id: id, span: span, ident: ident.dummy_spanned(), vis: vis, attrs: attrs,
             node: ast::ItemKind::Mac(mac_placeholder()),
         }))),
         ExpansionKind::TraitItems => Expansion::TraitItems(SmallVector::one(ast::TraitItem {
-            id: id, span: span, ident: ident, attrs: attrs,
+            id: id, span: span, ident: ident.dummy_spanned(), attrs: attrs,
             node: ast::TraitItemKind::Macro(mac_placeholder()),
         })),
         ExpansionKind::ImplItems => Expansion::ImplItems(SmallVector::one(ast::ImplItem {
-            id: id, span: span, ident: ident, vis: vis, attrs: attrs,
+            id: id, span: span, ident: ident.dummy_spanned(), vis: vis, attrs: attrs,
             node: ast::ImplItemKind::Macro(mac_placeholder()),
             defaultness: ast::Defaultness::Final,
         })),
@@ -175,7 +175,7 @@ impl<'a, 'b> Folder for PlaceholderExpander<'a, 'b> {
                 // Scope placeholder
                 if let ast::StmtKind::Item(ref item) = stmt.node {
                     if let ast::ItemKind::Mac(..) = item.node {
-                        macros.push(item.ident.ctxt.data().outer_mark);
+                        macros.push(item.ident.node.ctxt.data().outer_mark);
                         return None;
                     }
                 }
@@ -217,7 +217,7 @@ impl<'a, 'b> Folder for PlaceholderExpander<'a, 'b> {
 
 pub fn reconstructed_macro_rules(def: &ast::MacroDef) -> Expansion {
     Expansion::Items(SmallVector::one(P(ast::Item {
-        ident: def.ident,
+        ident: def.ident.dummy_spanned(),
         attrs: def.attrs.clone(),
         id: ast::DUMMY_NODE_ID,
         node: ast::ItemKind::Mac(ast::Mac {

--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -229,7 +229,7 @@ impl<'a> Parser<'a> {
             ast::MetaItemKind::Word
         };
         let hi = self.prev_span.hi;
-        Ok(ast::MetaItem { name: ident.name, node: node, span: mk_sp(lo, hi) })
+        Ok(ast::MetaItem { name: ident.node.name, node: node, span: mk_sp(lo, hi) })
     }
 
     /// matches meta_item_inner : (meta_item | UNSUFFIXED_LIT) ;

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -609,7 +609,7 @@ mod tests {
     use super::*;
     use std::rc::Rc;
     use syntax_pos::{self, Span, BytePos, Pos, NO_EXPANSION};
-    use codemap::Spanned;
+    use codemap::{Spanned, dummy_spanned};
     use ast::{self, Ident, PatKind};
     use abi::Abi;
     use attr::first_attr_value_str_by_name;
@@ -833,7 +833,7 @@ mod tests {
         // this test depends on the intern order of "fn" and "i32"
         assert_eq!(string_to_item("fn a (b : i32) { b; }".to_string()),
                   Some(
-                      P(ast::Item{ident:Ident::from_str("a"),
+                      P(ast::Item{dummy_spanned(ident:Ident::from_str("a")),
                             attrs:Vec::new(),
                             id: ast::DUMMY_NODE_ID,
                             node: ast::ItemKind::Fn(P(ast::FnDecl {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -71,7 +71,7 @@ bitflags! {
     }
 }
 
-type ItemInfo = (Ident, ItemKind, Option<Vec<Attribute> >);
+type ItemInfo = (Ident, ItemKind, Option<Vec<Attribute>>);
 
 /// How to parse a path. There are three different kinds of paths, all of which
 /// are parsed somewhat differently.
@@ -5005,8 +5005,9 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse struct Foo { ... }
-    fn parse_item_struct(&mut self) -> PResult<'a, ItemInfo> {
+    fn parse_item_struct(&mut self) -> PResult<'a, (ItemInfo, Span)> {
         let class_name = self.parse_ident()?;
+        let sp = self.prev_span;  // struct's name's span
         let mut generics = self.parse_generics()?;
 
         // There is a special case worth noting here, as reported in issue #17904.
@@ -5050,7 +5051,7 @@ impl<'a> Parser<'a> {
                                             name, found `{}`", token_str)))
         };
 
-        Ok((class_name, ItemKind::Struct(vdata, generics), None))
+        Ok(((class_name, ItemKind::Struct(vdata, generics), None), sp))
     }
 
     /// Parse union Foo { ... }
@@ -5920,10 +5921,9 @@ impl<'a> Parser<'a> {
         }
         if self.eat_keyword(keywords::Struct) {
             // STRUCT ITEM
-            let (ident, item_, extra_attrs) = self.parse_item_struct()?;
-            let prev_span = self.prev_span;
-            let item = self.mk_item(lo,
-                                    prev_span.hi,
+            let ((ident, item_, extra_attrs), sp) = self.parse_item_struct()?;
+            let item = self.mk_item(sp.lo,
+                                    sp.hi,
                                     ident,
                                     item_,
                                     visibility,

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1150,7 +1150,7 @@ impl<'a> State<'a> {
                     try!(word(&mut self.s, "as"));
                     try!(space(&mut self.s));
                 }
-                try!(self.print_ident(item.ident));
+                try!(self.print_ident(item.ident.node));
                 try!(word(&mut self.s, ";"));
                 try!(self.end()); // end inner head-block
                 try!(self.end()); // end outer head-block
@@ -1167,7 +1167,7 @@ impl<'a> State<'a> {
                 if m == ast::Mutability::Mutable {
                     try!(self.word_space("mut"));
                 }
-                try!(self.print_ident(item.ident));
+                try!(self.print_ident(item.ident.node));
                 try!(self.word_space(":"));
                 try!(self.print_type(&ty));
                 try!(space(&mut self.s));
@@ -1180,7 +1180,7 @@ impl<'a> State<'a> {
             }
             ast::ItemKind::Const(ref ty, ref expr) => {
                 try!(self.head(&visibility_qualified(&item.vis, "const")));
-                try!(self.print_ident(item.ident));
+                try!(self.print_ident(item.ident.node));
                 try!(self.word_space(":"));
                 try!(self.print_type(&ty));
                 try!(space(&mut self.s));
@@ -1198,7 +1198,7 @@ impl<'a> State<'a> {
                     unsafety,
                     constness.node,
                     abi,
-                    Some(item.ident),
+                    Some(item.ident.node),
                     typarams,
                     &item.vis
                 ));
@@ -1207,7 +1207,7 @@ impl<'a> State<'a> {
             }
             ast::ItemKind::Mod(ref _mod) => {
                 try!(self.head(&visibility_qualified(&item.vis, "mod")));
-                try!(self.print_ident(item.ident));
+                try!(self.print_ident(item.ident.node));
                 try!(self.nbsp());
                 try!(self.bopen());
                 try!(self.print_mod(_mod, &item.attrs));
@@ -1224,7 +1224,7 @@ impl<'a> State<'a> {
                 try!(self.ibox(INDENT_UNIT));
                 try!(self.ibox(0));
                 try!(self.word_nbsp(&visibility_qualified(&item.vis, "type")));
-                try!(self.print_ident(item.ident));
+                try!(self.print_ident(item.ident.node));
                 try!(self.print_generics(params));
                 try!(self.end()); // end the inner ibox
 
@@ -1239,18 +1239,18 @@ impl<'a> State<'a> {
                 try!(self.print_enum_def(
                     enum_definition,
                     params,
-                    item.ident,
+                    item.ident.node,
                     item.span,
                     &item.vis
                 ));
             }
             ast::ItemKind::Struct(ref struct_def, ref generics) => {
                 try!(self.head(&visibility_qualified(&item.vis, "struct")));
-                try!(self.print_struct(&struct_def, generics, item.ident, item.span, true));
+                try!(self.print_struct(&struct_def, generics, item.ident.node, item.span, true));
             }
             ast::ItemKind::Union(ref struct_def, ref generics) => {
                 try!(self.head(&visibility_qualified(&item.vis, "union")));
-                try!(self.print_struct(&struct_def, generics, item.ident, item.span, true));
+                try!(self.print_struct(&struct_def, generics, item.ident.node, item.span, true));
             }
             ast::ItemKind::DefaultImpl(unsafety, ref trait_ref) => {
                 try!(self.head(""));
@@ -1309,7 +1309,7 @@ impl<'a> State<'a> {
                 try!(self.print_visibility(&item.vis));
                 try!(self.print_unsafety(unsafety));
                 try!(self.word_nbsp("trait"));
-                try!(self.print_ident(item.ident));
+                try!(self.print_ident(item.ident.node));
                 try!(self.print_generics(generics));
                 let mut real_bounds = Vec::with_capacity(bounds.len());
                 for b in bounds.iter() {
@@ -1334,7 +1334,7 @@ impl<'a> State<'a> {
                 try!(self.print_visibility(&item.vis));
                 try!(self.print_path(&node.path, false, 0));
                 try!(word(&mut self.s, "! "));
-                try!(self.print_ident(item.ident));
+                try!(self.print_ident(item.ident.node));
                 try!(self.cbox(INDENT_UNIT));
                 try!(self.popen());
                 try!(self.print_tts(&node.tts[..]));
@@ -1516,7 +1516,7 @@ impl<'a> State<'a> {
     pub fn print_variant(&mut self, v: &ast::Variant) -> io::Result<()> {
         try!(self.head(""));
         let generics = ast::Generics::default();
-        try!(self.print_struct(&v.node.data, &generics, v.node.name, v.span, false));
+        try!(self.print_struct(&v.node.data, &generics, v.node.name.node, v.span, false));
         match v.node.disr_expr {
             Some(ref d) => {
                 try!(space(&mut self.s));
@@ -1549,7 +1549,7 @@ impl<'a> State<'a> {
         try!(self.print_outer_attributes(&ti.attrs));
         match ti.node {
             ast::TraitItemKind::Const(ref ty, ref default) => {
-                try!(self.print_associated_const(ti.ident, &ty,
+                try!(self.print_associated_const(ti.ident.node, &ty,
                                             default.as_ref().map(|expr| &**expr),
                                             &ast::Visibility::Inherited));
             }
@@ -1557,7 +1557,7 @@ impl<'a> State<'a> {
                 if body.is_some() {
                     try!(self.head(""));
                 }
-                try!(self.print_method_sig(ti.ident, sig, &ast::Visibility::Inherited));
+                try!(self.print_method_sig(ti.ident.node, sig, &ast::Visibility::Inherited));
                 if let Some(ref body) = *body {
                     try!(self.nbsp());
                     try!(self.print_block_with_attrs(body, &ti.attrs));
@@ -1566,7 +1566,7 @@ impl<'a> State<'a> {
                 }
             }
             ast::TraitItemKind::Type(ref bounds, ref default) => {
-                try!(self.print_associated_type(ti.ident, Some(bounds),
+                try!(self.print_associated_type(ti.ident.node, Some(bounds),
                                            default.as_ref().map(|ty| &**ty)));
             }
             ast::TraitItemKind::Macro(codemap::Spanned { ref node, .. }) => {
@@ -1594,16 +1594,16 @@ impl<'a> State<'a> {
         }
         match ii.node {
             ast::ImplItemKind::Const(ref ty, ref expr) => {
-                try!(self.print_associated_const(ii.ident, &ty, Some(&expr), &ii.vis));
+                try!(self.print_associated_const(ii.ident.node, &ty, Some(&expr), &ii.vis));
             }
             ast::ImplItemKind::Method(ref sig, ref body) => {
                 try!(self.head(""));
-                try!(self.print_method_sig(ii.ident, sig, &ii.vis));
+                try!(self.print_method_sig(ii.ident.node, sig, &ii.vis));
                 try!(self.nbsp());
                 try!(self.print_block_with_attrs(body, &ii.attrs));
             }
             ast::ImplItemKind::Type(ref ty) => {
-                try!(self.print_associated_type(ii.ident, None, Some(ty)));
+                try!(self.print_associated_type(ii.ident.node, None, Some(ty)));
             }
             ast::ImplItemKind::Macro(codemap::Spanned { ref node, .. }) => {
                 // code copied from ItemKind::Mac:
@@ -3107,7 +3107,7 @@ mod tests {
         let ident = ast::Ident::from_str("principal_skinner");
 
         let var = codemap::respan(syntax_pos::DUMMY_SP, ast::Variant_ {
-            name: ident,
+            name: codemap::dummy_spanned(ident),
             attrs: Vec::new(),
             // making this up as I go.... ?
             data: ast::VariantData::Unit(ast::DUMMY_NODE_ID),

--- a/src/libsyntax/std_inject.rs
+++ b/src/libsyntax/std_inject.rs
@@ -60,7 +60,7 @@ pub fn maybe_inject_crates_ref(sess: &ParseSess,
                                         attr::mk_word_item(Symbol::intern("macro_use")))],
         vis: ast::Visibility::Inherited,
         node: ast::ItemKind::ExternCrate(Some(crate_name)),
-        ident: ast::Ident::from_str(name),
+        ident: ast::Ident::from_str(name).dummy_spanned(),
         id: ast::DUMMY_NODE_ID,
         span: DUMMY_SP,
     }));
@@ -88,7 +88,7 @@ pub fn maybe_inject_crates_ref(sess: &ParseSess,
             span: span,
         })))),
         id: ast::DUMMY_NODE_ID,
-        ident: keywords::Invalid.ident(),
+        ident: keywords::Invalid.ident().dummy_spanned(),
         span: span,
     }));
 

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -114,8 +114,8 @@ impl<'a> fold::Folder for TestHarnessGenerator<'a> {
 
     fn fold_item(&mut self, i: P<ast::Item>) -> SmallVector<P<ast::Item>> {
         let ident = i.ident;
-        if ident.name != keywords::Invalid.name() {
-            self.cx.path.push(ident);
+        if ident.node.name != keywords::Invalid.name() {
+            self.cx.path.push(ident.node);
         }
         debug!("current path: {}", path_name_i(&self.cx.path));
 
@@ -135,7 +135,7 @@ impl<'a> fold::Folder for TestHarnessGenerator<'a> {
                         should_panic: should_panic(&i, &self.cx)
                     };
                     self.cx.testfns.push(test);
-                    self.tests.push(i.ident);
+                    self.tests.push(i.ident.node);
                 }
             }
         }
@@ -163,7 +163,7 @@ impl<'a> fold::Folder for TestHarnessGenerator<'a> {
             }
             item.node = ast::ItemKind::Mod(mod_folded);
         }
-        if ident.name != keywords::Invalid.name() {
+        if ident.node.name != keywords::Invalid.name() {
             self.cx.path.pop();
         }
         SmallVector::one(P(item))
@@ -254,7 +254,7 @@ fn mk_reexport_mod(cx: &mut TestCtxt,
     let parent = if parent == ast::DUMMY_NODE_ID { ast::CRATE_NODE_ID } else { parent };
     cx.ext_cx.current_expansion.mark = cx.ext_cx.resolver.get_module_scope(parent);
     let it = cx.ext_cx.monotonic_expander().fold_item(P(ast::Item {
-        ident: sym.clone(),
+        ident: sym.clone().dummy_spanned(),
         attrs: Vec::new(),
         id: ast::DUMMY_NODE_ID,
         node: ast::ItemKind::Mod(reexport_mod),
@@ -471,7 +471,7 @@ fn mk_std(cx: &TestCtxt) -> P<ast::Item> {
     };
     P(ast::Item {
         id: ast::DUMMY_NODE_ID,
-        ident: ident,
+        ident: ident.dummy_spanned(),
         node: vi,
         attrs: vec![],
         vis: vis,
@@ -511,7 +511,7 @@ fn mk_main(cx: &mut TestCtxt) -> P<ast::Item> {
                            dummy_spanned(ast::Constness::NotConst),
                            ::abi::Abi::Rust, ast::Generics::default(), main_body);
     let main = P(ast::Item {
-        ident: Ident::from_str("main"),
+        ident: Ident::from_str("main").dummy_spanned(),
         attrs: vec![main_attr],
         id: ast::DUMMY_NODE_ID,
         node: main,
@@ -543,7 +543,7 @@ fn mk_test_module(cx: &mut TestCtxt) -> (P<ast::Item>, Option<P<ast::Item>>) {
     let mut expander = cx.ext_cx.monotonic_expander();
     let item = expander.fold_item(P(ast::Item {
         id: ast::DUMMY_NODE_ID,
-        ident: mod_ident,
+        ident: mod_ident.dummy_spanned(),
         attrs: vec![],
         node: item_,
         vis: ast::Visibility::Public,
@@ -559,7 +559,7 @@ fn mk_test_module(cx: &mut TestCtxt) -> (P<ast::Item>, Option<P<ast::Item>>) {
 
         expander.fold_item(P(ast::Item {
             id: ast::DUMMY_NODE_ID,
-            ident: keywords::Invalid.ident(),
+            ident: keywords::Invalid.ident().dummy_spanned(),
             attrs: vec![],
             node: ast::ItemKind::Use(P(use_path)),
             vis: ast::Visibility::Inherited,

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -220,7 +220,7 @@ pub fn walk_trait_ref<'a, V: Visitor<'a>>(visitor: &mut V, trait_ref: &'a TraitR
 
 pub fn walk_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a Item) {
     visitor.visit_vis(&item.vis);
-    visitor.visit_ident(item.span, item.ident);
+    visitor.visit_ident(item.span, item.ident.node);
     match item.node {
         ItemKind::ExternCrate(opt_name) => {
             walk_opt_name(visitor, item.span, opt_name)
@@ -248,7 +248,7 @@ pub fn walk_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a Item) {
             visitor.visit_expr(expr);
         }
         ItemKind::Fn(ref declaration, unsafety, constness, abi, ref generics, ref body) => {
-            visitor.visit_fn(FnKind::ItemFn(item.ident, generics, unsafety,
+            visitor.visit_fn(FnKind::ItemFn(item.ident.node, generics, unsafety,
                                             constness, abi, &item.vis, body),
                              declaration,
                              item.span,
@@ -284,7 +284,7 @@ pub fn walk_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a Item) {
         ItemKind::Struct(ref struct_definition, ref generics) |
         ItemKind::Union(ref struct_definition, ref generics) => {
             visitor.visit_generics(generics);
-            visitor.visit_variant_data(struct_definition, item.ident,
+            visitor.visit_variant_data(struct_definition, item.ident.node,
                                      generics, item.id, item.span);
         }
         ItemKind::Trait(_, ref generics, ref bounds, ref methods) => {
@@ -310,8 +310,8 @@ pub fn walk_variant<'a, V>(visitor: &mut V,
                            item_id: NodeId)
     where V: Visitor<'a>,
 {
-    visitor.visit_ident(variant.span, variant.node.name);
-    visitor.visit_variant_data(&variant.node.data, variant.node.name,
+    visitor.visit_ident(variant.span, variant.node.name.node);
+    visitor.visit_variant_data(&variant.node.data, variant.node.name.node,
                              generics, item_id, variant.span);
     walk_list!(visitor, visit_expr, &variant.node.disr_expr);
     walk_list!(visitor, visit_attribute, &variant.node.attrs);
@@ -553,7 +553,7 @@ pub fn walk_fn<'a, V>(visitor: &mut V, kind: FnKind<'a>, declaration: &'a FnDecl
 }
 
 pub fn walk_trait_item<'a, V: Visitor<'a>>(visitor: &mut V, trait_item: &'a TraitItem) {
-    visitor.visit_ident(trait_item.span, trait_item.ident);
+    visitor.visit_ident(trait_item.span, trait_item.ident.node);
     walk_list!(visitor, visit_attribute, &trait_item.attrs);
     match trait_item.node {
         TraitItemKind::Const(ref ty, ref default) => {
@@ -565,7 +565,7 @@ pub fn walk_trait_item<'a, V: Visitor<'a>>(visitor: &mut V, trait_item: &'a Trai
             walk_fn_decl(visitor, &sig.decl);
         }
         TraitItemKind::Method(ref sig, Some(ref body)) => {
-            visitor.visit_fn(FnKind::Method(trait_item.ident, sig, None, body),
+            visitor.visit_fn(FnKind::Method(trait_item.ident.node, sig, None, body),
                              &sig.decl, trait_item.span, trait_item.id);
         }
         TraitItemKind::Type(ref bounds, ref default) => {
@@ -580,7 +580,7 @@ pub fn walk_trait_item<'a, V: Visitor<'a>>(visitor: &mut V, trait_item: &'a Trai
 
 pub fn walk_impl_item<'a, V: Visitor<'a>>(visitor: &mut V, impl_item: &'a ImplItem) {
     visitor.visit_vis(&impl_item.vis);
-    visitor.visit_ident(impl_item.span, impl_item.ident);
+    visitor.visit_ident(impl_item.span, impl_item.ident.node);
     walk_list!(visitor, visit_attribute, &impl_item.attrs);
     match impl_item.node {
         ImplItemKind::Const(ref ty, ref expr) => {
@@ -588,7 +588,7 @@ pub fn walk_impl_item<'a, V: Visitor<'a>>(visitor: &mut V, impl_item: &'a ImplIt
             visitor.visit_expr(expr);
         }
         ImplItemKind::Method(ref sig, ref body) => {
-            visitor.visit_fn(FnKind::Method(impl_item.ident, sig, Some(&impl_item.vis), body),
+            visitor.visit_fn(FnKind::Method(impl_item.ident.node, sig, Some(&impl_item.vis), body),
                              &sig.decl, impl_item.span, impl_item.id);
         }
         ImplItemKind::Type(ref ty) => {

--- a/src/libsyntax_ext/deriving/clone.rs
+++ b/src/libsyntax_ext/deriving/clone.rs
@@ -168,7 +168,7 @@ fn cs_clone(name: &str,
             vdata = vdata_;
         }
         EnumMatching(_, variant, ref af) => {
-            ctor_path = cx.path(trait_span, vec![substr.type_ident, variant.node.name]);
+            ctor_path = cx.path(trait_span, vec![substr.type_ident, variant.node.name.node]);
             all_fields = af;
             vdata = &variant.node.data;
         }

--- a/src/libsyntax_ext/deriving/debug.rs
+++ b/src/libsyntax_ext/deriving/debug.rs
@@ -60,7 +60,7 @@ fn show_substructure(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> P<E
     // based on the "shape".
     let (ident, is_struct) = match *substr.fields {
         Struct(vdata, _) => (substr.type_ident, vdata.is_struct()),
-        EnumMatching(_, v, _) => (v.node.name, v.node.data.is_struct()),
+        EnumMatching(_, v, _) => (v.node.name.node, v.node.data.is_struct()),
         EnumNonMatchingCollapsed(..) |
         StaticStruct(..) |
         StaticEnum(..) => cx.span_bug(span, "nonsensical .fields in `#[derive(Debug)]`"),

--- a/src/libsyntax_ext/deriving/encodable.rs
+++ b/src/libsyntax_ext/deriving/encodable.rs
@@ -265,7 +265,7 @@ fn encodable_substructure(cx: &mut ExtCtxt,
             }
 
             let blk = cx.lambda_stmts_1(trait_span, stmts, blkarg);
-            let name = cx.expr_str(trait_span, variant.node.name.name);
+            let name = cx.expr_str(trait_span, variant.node.name.node.name);
             let call = cx.expr_method_call(trait_span,
                                            blkencoder,
                                            cx.ident_of("emit_enum_variant"),

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -414,15 +414,19 @@ impl<'a> TraitDef<'a> {
             Annotatable::Item(ref item) => {
                 let newitem = match item.node {
                     ast::ItemKind::Struct(ref struct_def, ref generics) => {
-                        self.expand_struct_def(cx, &struct_def, item.ident, generics, from_scratch)
+                        self.expand_struct_def(cx,
+                                               &struct_def,
+                                               item.ident.node,
+                                               generics,
+                                               from_scratch)
                     }
                     ast::ItemKind::Enum(ref enum_def, ref generics) => {
                         self.expand_enum_def(cx, enum_def, &item.attrs,
-                                             item.ident, generics, from_scratch)
+                                             item.ident.node, generics, from_scratch)
                     }
                     ast::ItemKind::Union(ref struct_def, ref generics) => {
                         if self.supports_unions {
-                            self.expand_struct_def(cx, &struct_def, item.ident,
+                            self.expand_struct_def(cx, &struct_def, item.ident.node,
                                                    generics, from_scratch)
                         } else {
                             cx.span_err(mitem.span,
@@ -502,7 +506,7 @@ impl<'a> TraitDef<'a> {
             ast::ImplItem {
                 id: ast::DUMMY_NODE_ID,
                 span: self.span,
-                ident: ident,
+                ident: ident.dummy_spanned(),
                 vis: ast::Visibility::Inherited,
                 defaultness: ast::Defaultness::Final,
                 attrs: Vec::new(),
@@ -921,7 +925,7 @@ impl<'a> MethodDef<'a> {
             span: trait_.span,
             vis: ast::Visibility::Inherited,
             defaultness: ast::Defaultness::Final,
-            ident: method_ident,
+            ident: method_ident.dummy_spanned(),
             node: ast::ImplItemKind::Method(ast::MethodSig {
                                                 generics: fn_generics,
                                                 abi: abi,
@@ -1459,7 +1463,7 @@ impl<'a> MethodDef<'a> {
         let summary = enum_def.variants
             .iter()
             .map(|v| {
-                let ident = v.node.name;
+                let ident = v.node.name.node;
                 let sp = Span { expn_id: trait_.span.expn_id, ..v.span };
                 let summary = trait_.summarise_struct(cx, &v.node.data);
                 (ident, sp, summary)
@@ -1578,7 +1582,7 @@ impl<'a> TraitDef<'a> {
          -> (P<ast::Pat>, Vec<(Span, Option<Ident>, P<Expr>, &'a [ast::Attribute])>) {
         let variant_ident = variant.node.name;
         let sp = Span { expn_id: self.span.expn_id, ..variant.span };
-        let variant_path = cx.path(sp, vec![enum_ident, variant_ident]);
+        let variant_path = cx.path(sp, vec![enum_ident, variant_ident.node]);
         self.create_struct_pattern(cx, variant_path, &variant.node.data, prefix, mutbl)
     }
 }

--- a/src/libsyntax_ext/proc_macro_registrar.rs
+++ b/src/libsyntax_ext/proc_macro_registrar.rs
@@ -231,7 +231,7 @@ impl<'a> Visitor<'a> for CollectCustomDerives<'a> {
             self.derives.push(CustomDerive {
                 span: item.span,
                 trait_name: trait_name,
-                function_name: item.ident,
+                function_name: item.ident.node,
                 attrs: proc_attrs,
             });
         } else {

--- a/src/test/compile-fail-fulldeps/auxiliary/lint_group_plugin_test.rs
+++ b/src/test/compile-fail-fulldeps/auxiliary/lint_group_plugin_test.rs
@@ -36,7 +36,7 @@ impl LintPass for Pass {
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
     fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
-        match &*it.name.as_str() {
+        match &*it.name.node.as_str() {
             "lintme" => cx.span_lint(TEST_LINT, it.span, "item is named 'lintme'"),
             "pleaselintme" => cx.span_lint(PLEASE_LINT, it.span, "item is named 'pleaselintme'"),
             _ => {}

--- a/src/test/compile-fail-fulldeps/auxiliary/lint_plugin_test.rs
+++ b/src/test/compile-fail-fulldeps/auxiliary/lint_plugin_test.rs
@@ -36,7 +36,7 @@ impl LintPass for Pass {
 
 impl EarlyLintPass for Pass {
     fn check_item(&mut self, cx: &EarlyContext, it: &ast::Item) {
-        if it.ident.name == "lintme" {
+        if it.ident.node.name == "lintme" {
             cx.span_lint(TEST_LINT, it.span, "item is named 'lintme'");
         }
     }

--- a/src/test/compile-fail-fulldeps/auxiliary/macro_crate_test.rs
+++ b/src/test/compile-fail-fulldeps/auxiliary/macro_crate_test.rs
@@ -18,6 +18,7 @@ extern crate rustc;
 extern crate rustc_plugin;
 
 use syntax::ast::{self, Item, MetaItem, ItemKind};
+use syntax::codemap::dummy_spanned;
 use syntax::ext::base::*;
 use syntax::parse;
 use syntax::ptr::P;
@@ -122,19 +123,19 @@ fn expand_duplicate(cx: &mut ExtCtxt,
         Annotatable::Item(it) => {
             let mut new_it = (*it).clone();
             new_it.attrs.clear();
-            new_it.ident = copy_name;
+            new_it.ident = dummy_spanned(copy_name);
             push(Annotatable::Item(P(new_it)));
         }
         Annotatable::ImplItem(it) => {
             let mut new_it = (*it).clone();
             new_it.attrs.clear();
-            new_it.ident = copy_name;
+            new_it.ident = dummy_spanned(copy_name);
             push(Annotatable::ImplItem(P(new_it)));
         }
         Annotatable::TraitItem(tt) => {
             let mut new_it = (*tt).clone();
             new_it.attrs.clear();
-            new_it.ident = copy_name;
+            new_it.ident = dummy_spanned(copy_name);
             push(Annotatable::TraitItem(P(new_it)));
         }
     }

--- a/src/test/run-pass-fulldeps/auxiliary/lint_group_plugin_test.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/lint_group_plugin_test.rs
@@ -36,7 +36,7 @@ impl LintPass for Pass {
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
     fn check_item(&mut self, cx: &LateContext, it: &hir::Item) {
-        match &*it.name.as_str() {
+        match &*it.name.node.as_str() {
             "lintme" => cx.span_lint(TEST_LINT, it.span, "item is named 'lintme'"),
             "pleaselintme" => cx.span_lint(PLEASE_LINT, it.span, "item is named 'pleaselintme'"),
             _ => {}

--- a/src/test/run-pass-fulldeps/auxiliary/lint_plugin_test.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/lint_plugin_test.rs
@@ -36,7 +36,7 @@ impl LintPass for Pass {
 
 impl EarlyLintPass for Pass {
     fn check_item(&mut self, cx: &EarlyContext, it: &ast::Item) {
-        if it.ident.name == "lintme" {
+        if it.ident.node.name == "lintme" {
             cx.span_lint(TEST_LINT, it.span, "item is named 'lintme'");
         }
     }

--- a/src/test/run-pass-fulldeps/auxiliary/macro_crate_test.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/macro_crate_test.rs
@@ -18,7 +18,7 @@ extern crate rustc_plugin;
 extern crate syntax_pos;
 
 use syntax::ast::{self, Item, MetaItem, ItemKind};
-use syntax::codemap::DUMMY_SP;
+use syntax::codemap::{DUMMY_SP, dummy_spanned};
 use syntax::ext::base::*;
 use syntax::ext::quote::rt::ToTokens;
 use syntax::parse::{self, token};
@@ -128,19 +128,19 @@ fn expand_duplicate(cx: &mut ExtCtxt,
         Annotatable::Item(it) => {
             let mut new_it = (*it).clone();
             new_it.attrs.clear();
-            new_it.ident = copy_name;
+            new_it.ident = dummy_spanned(copy_name);
             push(Annotatable::Item(P(new_it)));
         }
         Annotatable::ImplItem(it) => {
             let mut new_it = (*it).clone();
             new_it.attrs.clear();
-            new_it.ident = copy_name;
+            new_it.ident = dummy_spanned(copy_name);
             push(Annotatable::ImplItem(P(new_it)));
         }
         Annotatable::TraitItem(tt) => {
             let mut new_it = (*tt).clone();
             new_it.attrs.clear();
-            new_it.ident = copy_name;
+            new_it.ident = dummy_spanned(copy_name);
             push(Annotatable::TraitItem(P(new_it)));
         }
     }


### PR DESCRIPTION
```
error[E0072]: recursive type `ListNode` has infinite size
  --> ../../../src/test/compile-fail/E0072.rs:11:8
   |
11 | struct ListNode { //~ ERROR E0072
   |        ^^^^^^^^ recursive type has infinite size
   |
   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `ListNode` representable
```

instead of

```
error[E0072]: recursive type `ListNode` has infinite size
  --> <anon>:11:1
   |
11 |   struct ListNode { //~ ERROR E0072
   |  _^ starting here...
12 | |                   //~| NOTE recursive type has infinite size
13 | |     head: u8,
14 | |     tail: Option<ListNode>,
15 | | }
   | |_^ ...ending here: recursive type has infinite size
   |
   = help: insert indirection (e.g., a `Box`, `Rc`, or `&`) at some point to make `ListNode` representable
```

Re #35965, #38246.