### PR TITLE
rustbuild: Add cli option --keep-stage

### DIFF
--- a/src/bootstrap/README.md
+++ b/src/bootstrap/README.md
@@ -42,6 +42,15 @@ The script accepts commands, flags, and filters to determine what to do:
   ./x.py build --stage 0 src/libtest
   ```
 
+  If files are dirty that would normally be rebuilt from stage 0, that can be
+  overidden using `--keep-stage 0`. Using `--keep-stage n` will skip all steps
+  that belong to stage n or earlier:
+
+  ```
+  # keep old build products for stage 0 and build stage 1
+  ./x.py build --keep-stage 0 --stage 1
+  ```
+
 * `test` - a command for executing unit tests. Like the `build` command this
   will execute the entire test suite by default, and otherwise it can be used to
   select which test suite is run:

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -29,6 +29,7 @@ use step;
 pub struct Flags {
     pub verbose: bool,
     pub stage: Option<u32>,
+    pub keep_stage: Option<u32>,
     pub build: String,
     pub host: Vec<String>,
     pub target: Vec<String>,
@@ -68,6 +69,7 @@ impl Flags {
         opts.optmulti("", "host", "host targets to build", "HOST");
         opts.optmulti("", "target", "target targets to build", "TARGET");
         opts.optopt("", "stage", "stage to build", "N");
+        opts.optopt("", "keep-stage", "stage to keep without recompiling", "N");
         opts.optopt("", "src", "path to the root of the rust checkout", "DIR");
         opts.optopt("j", "jobs", "number of jobs to run in parallel", "JOBS");
         opts.optflag("h", "help", "print this help message");
@@ -258,6 +260,7 @@ To learn more about a subcommand, run `./x.py <command> -h`
         Flags {
             verbose: m.opt_present("v"),
             stage: m.opt_str("stage").map(|j| j.parse().unwrap()),
+            keep_stage: m.opt_str("keep-stage").map(|j| j.parse().unwrap()),
             build: m.opt_str("build").unwrap_or_else(|| {
                 env::var("BUILD").unwrap()
             }),

--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -871,6 +871,10 @@ invalid rule dependency graph detected, was a rule added and maybe typo'd?
 
         // And finally, iterate over everything and execute it.
         for step in order.iter() {
+            if self.build.flags.keep_stage.map_or(false, |s| step.stage <= s) {
+                self.build.verbose(&format!("keeping step {:?}", step));
+                continue;
+            }
             self.build.verbose(&format!("executing step {:?}", step));
             (self.rules[step.name].run)(step);
         }


### PR DESCRIPTION
This option is intended to be used like:

./x.py build --stage 1 --keep-stage 0

Which skips all stage 0 steps, so that stage 1 can be recompiled
directly (even if for example libcore has changes).

This is useful when working on `cfg(not(stage0))` parts of the
libraries or when re-running stage 1 tests in libraries in general.

Fixes #38326