### PR TITLE
make dist/save-analysis: fix directory naming problem.

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -306,7 +306,7 @@ pub fn analysis(build: &Build, compiler: &Compiler, target: &str) {
 
     let src = build.stage_out(compiler, Mode::Libstd).join(target).join("release").join("deps");
 
-    let image_src = src.join("save-analysis");
+    let image_src = src.join("analysis");
     let dst = image.join("lib/rustlib").join(target).join("analysis");
     t!(fs::create_dir_all(&dst));
     cp_r(&image_src, &dst);
@@ -324,6 +324,13 @@ pub fn analysis(build: &Build, compiler: &Compiler, target: &str) {
        .arg("--legacy-manifest-dirs=rustlib,cargo");
     build.run(&mut cmd);
     t!(fs::remove_dir_all(&image));
+
+    // Create plain source tarball
+    let mut cmd = Command::new("tar");
+    cmd.arg("-czf").arg(sanitize_sh(&distdir(build).join(&format!("{}-{}.tar.gz", name, target))))
+       .arg("analysis")
+       .current_dir(&src);
+    build.run(&mut cmd);
 }
 
 /// Creates the `rust-src` installer component and the plain source tarball

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -827,8 +827,8 @@ pub fn process_crate<'l, 'tcx>(tcx: TyCtxt<'l, 'tcx, 'tcx>,
     let mut root_path = match env::var_os("RUST_SAVE_ANALYSIS_FOLDER") {
         Some(val) => PathBuf::from(val),
         None => match odir {
-            Some(val) => val.join("save-analysis"),
-            None => PathBuf::from("save-analysis-temp"),
+            Some(val) => val.join("analysis"),
+            None => PathBuf::from("analysis-temp"),
         },
     };
 


### PR DESCRIPTION
Restores source tar-ball of anlaysis data in make dist.

Breaking change (for tools using `-Zsave-analysis`) - changes the directory used of save-analysis data from 'save-analysis' to 'analysis'.

r? @alexcrichton 