### PR TITLE
generate MIR for the nightlies' standard library

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -169,12 +169,16 @@ fn main() {
             }
         }
 
+        let channel = env::var("RUSTC_CHANNEL").unwrap_or(String::new());
+
         // Generate MIR for all functions in the Rust libraries
         // Since users will never build the stdlib themselves, they can't
         // obtain an stdlib with full MIR. Thus we simply emit MIR always
         // for the stdlib
         // Don't do this for stage0 yet, since always_encode_mir isn't part of it yet
-        if stage != "0" {
+        // Only do this for the nightly and dev channels, we don't want to increase
+        // the size of stable libraries, and noone is able to use MIR on stable anyway
+        if channel != "stable" && channel != "beta" && stage != "0" {
             cmd.arg("-Zalways_encode_mir");
         }
     }

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -179,7 +179,7 @@ fn main() {
         // Only do this for the nightly and dev channels, we don't want to increase
         // the size of stable libraries, and noone is able to use MIR on stable anyway
         if channel != "stable" && channel != "beta" && stage != "0" {
-            cmd.arg("-Zalways_encode_mir");
+            cmd.arg("-Zalways-encode-mir");
         }
     }
 

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -168,6 +168,15 @@ fn main() {
                 cmd.arg("-C").arg(format!("link-args={}", rpath));
             }
         }
+
+        // Generate MIR for all functions in the Rust libraries
+        // Since users will never build the stdlib themselves, they can't
+        // obtain an stdlib with full MIR. Thus we simply emit MIR always
+        // for the stdlib
+        // Don't do this for stage0 yet, since always_encode_mir isn't part of it yet
+        if stage != "0" {
+            cmd.arg("-Zalways_encode_mir");
+        }
     }
 
     // Actually run the compiler!

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -491,6 +491,7 @@ impl Build {
              .env("RUSTC_RPATH", self.config.rust_rpath.to_string())
              .env("RUSTDOC", self.out.join("bootstrap/debug/rustdoc"))
              .env("RUSTDOC_REAL", self.rustdoc(compiler))
+             .env("RUSTC_CHANNEL", &self.config.channel)
              .env("RUSTC_FLAGS", self.rustc_flags(target).join(" "));
 
         // Enable usage of unstable features


### PR DESCRIPTION
sizes of files in /lib after this PR:

```
20K	libarena-73fff20938e5b4a0.so
48K	libflate-da0248732d23c024.so
48K	libfmt_macros-aedc6fc60322f45d.so
136K	libgetopts-b7de4ad01093c191.so
64K	libgraphviz-4cddbfded062cc67.so
80K	liblog-244814ed5548eb1d.so
44K	libproc_macro-07e61644036f16f4.so
156K	libproc_macro_plugin-08f1f3a23d0dda62.so
40K	libproc_macro_tokens-cb251390161800b9.so
11M	librustc-989ff71a3ff3f468.so
808K	librustc_back-4035e0e266e96bc8.so
1,4M	librustc_borrowck-9ab1ee1b865353ac.so
780K	librustc_const_eval-b4de6eae684ba589.so
212K	librustc_const_math-ff165bf6aed2dfa9.so
356K	librustc_data_structures-c66020d79d96a10c.so
2,1M	librustc_driver-c54f645e9ae37a10.so
380K	librustc_errors-841d081d1aef6867.so
960K	librustc_incremental-bc29c6e1de862741.so
636K	librustc_lint-8a4590e690bc08ab.so
39M	librustc_llvm-4f865650e23ee0b2.so
1,6M	librustc_metadata-d8c96d0eb7b4f6b3.so
1,6M	librustc_mir-d0713934d969099b.so
496K	librustc_passes-17b84294efc81a54.so
872K	librustc_platform_intrinsics-1626fdb9b5f1c718.so
76K	librustc_plugin-ea8df9fc2fcc4acc.so
204K	librustc_privacy-97dcf115ef96d8e6.so
1,3M	librustc_resolve-cae471b5c573a33b.so
1,5M	librustc_save_analysis-125beb4408fb5450.so
3,6M	librustc_trans-b01bcf4a676e8b18.so
3,7M	librustc_typeck-773fa7021f4cbc93.so
4,8M	librustdoc-cdda68154a149cb4.so
604K	libserialize-134f515a17a30f2c.so
5,0M	libstd-c26b46dac555a4f4.so
1,4M	libsyntax_ext-97f59ffcd48cfaad.so
6,8M	libsyntax-fa53ad3a8b4ce82b.so
124K	libsyntax_pos-ba2dd9baed5c77d7.so
316K	libterm-7beb204b9e7a957c.so
380K	libtest-a8f9282521afb4b8.so
130M	rustlib
```

sizes of files in /lib before this PR:

```
20K	libarena-73fff20938e5b4a0.so
48K	libflate-da0248732d23c024.so
36K	libfmt_macros-aedc6fc60322f45d.so
104K	libgetopts-b7de4ad01093c191.so
56K	libgraphviz-4cddbfded062cc67.so
68K	liblog-244814ed5548eb1d.so
44K	libproc_macro-07e61644036f16f4.so
132K	libproc_macro_plugin-08f1f3a23d0dda62.so
36K	libproc_macro_tokens-cb251390161800b9.so
7,9M	librustc-989ff71a3ff3f468.so
548K	librustc_back-4035e0e266e96bc8.so
1,1M	librustc_borrowck-9ab1ee1b865353ac.so
588K	librustc_const_eval-b4de6eae684ba589.so
136K	librustc_const_math-ff165bf6aed2dfa9.so
320K	librustc_data_structures-c66020d79d96a10c.so
2,0M	librustc_driver-c54f645e9ae37a10.so
268K	librustc_errors-841d081d1aef6867.so
760K	librustc_incremental-bc29c6e1de862741.so
520K	librustc_lint-8a4590e690bc08ab.so
39M	librustc_llvm-4f865650e23ee0b2.so
1,3M	librustc_metadata-d8c96d0eb7b4f6b3.so
1,1M	librustc_mir-d0713934d969099b.so
400K	librustc_passes-17b84294efc81a54.so
672K	librustc_platform_intrinsics-1626fdb9b5f1c718.so
60K	librustc_plugin-ea8df9fc2fcc4acc.so
144K	librustc_privacy-97dcf115ef96d8e6.so
976K	librustc_resolve-cae471b5c573a33b.so
1,3M	librustc_save_analysis-125beb4408fb5450.so
2,3M	librustc_trans-b01bcf4a676e8b18.so
2,7M	librustc_typeck-773fa7021f4cbc93.so
3,5M	librustdoc-cdda68154a149cb4.so
532K	libserialize-134f515a17a30f2c.so
4,5M	libstd-c26b46dac555a4f4.so
1,1M	libsyntax_ext-97f59ffcd48cfaad.so
5,3M	libsyntax-fa53ad3a8b4ce82b.so
104K	libsyntax_pos-ba2dd9baed5c77d7.so
260K	libterm-7beb204b9e7a957c.so
336K	libtest-a8f9282521afb4b8.so
116M	rustlib
```

so there's about a 10% increase in library size