### PR TITLE
Redox x86_64 target support

### DIFF
--- a/mk/cfg/x86_64-unknown-redox.mk
+++ b/mk/cfg/x86_64-unknown-redox.mk
@@ -1,0 +1,1 @@
+# rustbuild-only target

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -69,6 +69,7 @@ mod windows_base;
 mod windows_msvc_base;
 mod thumb_base;
 mod fuchsia_base;
+mod redox_base;
 
 pub type TargetResult = Result<Target, String>;
 
@@ -183,6 +184,8 @@ supported_targets! {
 
     ("aarch64-unknown-fuchsia", aarch64_unknown_fuchsia),
     ("x86_64-unknown-fuchsia", x86_64_unknown_fuchsia),
+
+    ("x86_64-unknown-redox", x86_64_unknown_redox),
 
     ("i386-apple-ios", i386_apple_ios),
     ("x86_64-apple-ios", x86_64_apple_ios),

--- a/src/librustc_back/target/redox_base.rs
+++ b/src/librustc_back/target/redox_base.rs
@@ -36,6 +36,7 @@ pub fn opts() -> TargetOptions {
         relocation_model: "static".to_string(),
         disable_redzone: true,
         eliminate_frame_pointer: false,
+        target_family: Some("redox".to_string()),
         linker_is_gnu: true,
         no_default_libraries: true,
         has_elf_tls: true,

--- a/src/librustc_back/target/redox_base.rs
+++ b/src/librustc_back/target/redox_base.rs
@@ -1,0 +1,45 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use target::TargetOptions;
+use std::default::Default;
+
+pub fn opts() -> TargetOptions {
+    TargetOptions {
+        pre_link_args: vec![
+            // We want to be able to strip as much executable code as possible
+            // from the linker command line, and this flag indicates to the
+            // linker that it can avoid linking in dynamic libraries that don't
+            // actually satisfy any symbols up to that point (as with many other
+            // resolutions the linker does). This option only applies to all
+            // following libraries so we're sure to pass it as one of the first
+            // arguments.
+            "-Wl,--as-needed".to_string(),
+
+            // Always enable NX protection when it is available
+            "-Wl,-z,noexecstack".to_string(),
+
+            // Do not link libc
+            "-nostdlib".to_string(),
+
+            // Static link
+            "-static".to_string()
+        ],
+        executables: true,
+        relocation_modal: "static".to_string(),
+        disable_redzone: true,
+        eliminate_frame_pointer: false,
+        linker_is_gnu: true,
+        no_compiler_rt: true,
+        no_default_libraries: true,
+        has_elf_tls: true,
+        .. Default::default()
+    }
+}

--- a/src/librustc_back/target/redox_base.rs
+++ b/src/librustc_back/target/redox_base.rs
@@ -40,6 +40,8 @@ pub fn opts() -> TargetOptions {
         target_family: Some("redox".to_string()),
         linker_is_gnu: true,
         no_default_libraries: true,
+        lib_allocation_crate: "alloc_system".to_string(),
+        exe_allocation_crate: "alloc_system".to_string(),
         has_elf_tls: true,
         panic_strategy: PanicStrategy::Abort,
         .. Default::default()

--- a/src/librustc_back/target/redox_base.rs
+++ b/src/librustc_back/target/redox_base.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use PanicStrategy;
 use target::TargetOptions;
 use std::default::Default;
 
@@ -40,6 +41,7 @@ pub fn opts() -> TargetOptions {
         linker_is_gnu: true,
         no_default_libraries: true,
         has_elf_tls: true,
+        panic_strategy: PanicStrategy::Abort,
         .. Default::default()
     }
 }

--- a/src/librustc_back/target/redox_base.rs
+++ b/src/librustc_back/target/redox_base.rs
@@ -33,11 +33,10 @@ pub fn opts() -> TargetOptions {
             "-static".to_string()
         ],
         executables: true,
-        relocation_modal: "static".to_string(),
+        relocation_model: "static".to_string(),
         disable_redzone: true,
         eliminate_frame_pointer: false,
         linker_is_gnu: true,
-        no_compiler_rt: true,
         no_default_libraries: true,
         has_elf_tls: true,
         .. Default::default()

--- a/src/librustc_back/target/x86_64_unknown_redox.rs
+++ b/src/librustc_back/target/x86_64_unknown_redox.rs
@@ -1,0 +1,30 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use target::{Target, TargetResult};
+
+pub fn target() -> TargetResult {
+    let mut base = super::redox_base::opts();
+    base.cpu = "x86-64".to_string();
+    base.max_atomic_width = Some(64);
+    base.pre_link_args.push("-m64".to_string());
+
+    Ok(Target {
+        llvm_target: "x86_64-unknown-redox".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "64".to_string(),
+        data_layout: "e-m:e-i64:64-f80:128-n8:16:32:64-S128".to_string(),
+        arch: "x86_64".to_string(),
+        target_os: "redox".to_string(),
+        target_env: "".to_string(),
+        target_vendor: "unknown".to_string(),
+        options: base,
+    })
+}


### PR DESCRIPTION
This adds support for the x86_64 architecture of Redox to `rustc`. This patch will generate #[no_std] executables and, following the merge of #37702, the cross compiling of the standard library will be possible.

This differs from other targets in that it does not link `libc`, as Redox does not have a dependency on `libc`.

It is possible that `libopenlibm` will be added to post_link_args for math functions in the future.