### PR TITLE
mk: Fix `make check`

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -22,7 +22,7 @@ $(eval $(call RUST_CRATE,coretest))
 DEPS_collectionstest :=
 $(eval $(call RUST_CRATE,collectionstest))
 
-TEST_TARGET_CRATES = $(filter-out core rustc_unicode alloc_system libc \
+TEST_TARGET_CRATES = $(filter-out core std_unicode alloc_system libc \
 		     		  alloc_jemalloc panic_unwind \
 				  panic_abort,$(TARGET_CRATES)) \
 			collectionstest coretest


### PR DESCRIPTION
When the rustc-unicode crate was renamed to std-unicode we just need to continue
to filter it out of the crates being tested.