### PR TITLE
Add prefix to config.toml

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -266,7 +266,7 @@ impl Config {
             set(&mut config.llvm_version_check, llvm.version_check);
             set(&mut config.llvm_static_stdcpp, llvm.static_libstdcpp);
         }
-        
+
         if let Some(ref rust) = toml.rust {
             set(&mut config.rust_debug_assertions, rust.debug_assertions);
             set(&mut config.rust_debuginfo, rust.debuginfo);

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -126,6 +126,7 @@ struct Build {
     target: Vec<String>,
     cargo: Option<String>,
     rustc: Option<String>,
+    prefix: Option<String>,
     compiler_docs: Option<bool>,
     docs: Option<bool>,
     submodules: Option<bool>,
@@ -238,6 +239,7 @@ impl Config {
         }
         config.rustc = build.rustc.map(PathBuf::from);
         config.cargo = build.cargo.map(PathBuf::from);
+        config.prefix = build.prefix;
         config.nodejs = build.nodejs.map(PathBuf::from);
         config.gdb = build.gdb.map(PathBuf::from);
         config.python = build.python.map(PathBuf::from);

--- a/src/bootstrap/config.toml.example
+++ b/src/bootstrap/config.toml.example
@@ -70,7 +70,7 @@
 # specified, use this rustc binary instead as the stage0 snapshot compiler.
 #rustc = "/path/to/bin/rustc"
 
-# Instead of installing installing to /usr/local, install to this path instead.
+# Instead of installing to /usr/local, install to this path instead.
 #prefix = "/path/to/install"
 
 # Flag to specify whether any documentation is built. If false, rustdoc and

--- a/src/bootstrap/config.toml.example
+++ b/src/bootstrap/config.toml.example
@@ -70,6 +70,9 @@
 # specified, use this rustc binary instead as the stage0 snapshot compiler.
 #rustc = "/path/to/bin/rustc"
 
+# Instead of installing installing to /usr/local, install to this path instead.
+#prefix = "/path/to/install"
+
 # Flag to specify whether any documentation is built. If false, rustdoc and
 # friends will still be compiled but they will not be used to generate any
 # documentation.

--- a/src/bootstrap/config.toml.example
+++ b/src/bootstrap/config.toml.example
@@ -70,9 +70,6 @@
 # specified, use this rustc binary instead as the stage0 snapshot compiler.
 #rustc = "/path/to/bin/rustc"
 
-# Instead of installing to /usr/local, install to this path instead.
-#prefix = "/path/to/install"
-
 # Flag to specify whether any documentation is built. If false, rustdoc and
 # friends will still be compiled but they will not be used to generate any
 # documentation.
@@ -100,6 +97,14 @@
 
 # Indicate whether the vendored sources are used for Rust dependencies or not
 #vendor = false
+
+# =============================================================================
+# General install configuration options
+# =============================================================================
+[install]
+
+# Instead of installing to /usr/local, install to this path instead.
+#prefix = "/path/to/install"
 
 # =============================================================================
 # Options for compiling Rust code itself


### PR DESCRIPTION
This allows `rustbuild` to be used to install to a prefix. 
```toml
[build]
prefix = "/path/to/install"
```
For example, the following `config.toml` will cause `x.py dist --install` to install to `/path/to/install`