### PR TITLE
rustbuild: Package rust-mingw by default

### DIFF
--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -490,7 +490,12 @@ pub fn build_rules(build: &Build) -> Rules {
          .default(true)
          .run(move |s| dist::std(build, &s.compiler(), s.target));
     rules.dist("dist-mingw", "path/to/nowhere")
-         .run(move |s| dist::mingw(build, s.target));
+         .default(true)
+         .run(move |s| {
+             if s.target.contains("pc-windows-gnu") {
+                 dist::mingw(build, s.target)
+             }
+         });
     rules.dist("dist-src", "src")
          .default(true)
          .host(true)


### PR DESCRIPTION
This fixes the `make dist` step on MinGW to package the `rust-mingw` component
by default. This should hopefully be the last step in fixing nightlies.