### PR TITLE
rustbuild: Fix `copy` helper with existing files

### DIFF
--- a/src/bootstrap/util.rs
+++ b/src/bootstrap/util.rs
@@ -41,6 +41,12 @@ pub fn mtime(path: &Path) -> FileTime {
 /// Copies a file from `src` to `dst`, attempting to use hard links and then
 /// falling back to an actually filesystem copy if necessary.
 pub fn copy(src: &Path, dst: &Path) {
+    // A call to `hard_link` will fail if `dst` exists, so remove it if it
+    // already exists so we can try to help `hard_link` succeed.
+    let _ = fs::remove_file(&dst);
+
+    // Attempt to "easy copy" by creating a hard link (symlinks don't work on
+    // windows), but if that fails just fall back to a slow `copy` operation.
     let res = fs::hard_link(src, dst);
     let res = res.or_else(|_| fs::copy(src, dst).map(|_| ()));
     if let Err(e) = res {


### PR DESCRIPTION
This erroneously truncated files when the destination already existed and was an
existing hard link to the source. This in turn caused weird bugs!

Closes #37745