### PR TITLE
rustc: Disable NEON on armv7 android.

### DIFF
--- a/src/librustc_back/target/aarch64_linux_android.rs
+++ b/src/librustc_back/target/aarch64_linux_android.rs
@@ -10,6 +10,9 @@
 
 use target::{Target, TargetOptions, TargetResult};
 
+// See https://developer.android.com/ndk/guides/abis.html#arm64-v8a
+// for target ABI requirements.
+
 pub fn target() -> TargetResult {
     let mut base = super::android_base::opts();
     base.max_atomic_width = Some(128);

--- a/src/librustc_back/target/armv7_linux_androideabi.rs
+++ b/src/librustc_back/target/armv7_linux_androideabi.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -12,7 +12,7 @@ use target::{Target, TargetOptions, TargetResult};
 
 pub fn target() -> TargetResult {
     let mut base = super::android_base::opts();
-    base.features = "+v7,+thumb2,+vfp3,+d16".to_string();
+    base.features = "+v7,+thumb2,+vfp3,+d16,-neon".to_string();
     base.max_atomic_width = Some(64);
 
     Ok(Target {

--- a/src/librustc_back/target/armv7_linux_androideabi.rs
+++ b/src/librustc_back/target/armv7_linux_androideabi.rs
@@ -10,6 +10,9 @@
 
 use target::{Target, TargetOptions, TargetResult};
 
+// See https://developer.android.com/ndk/guides/abis.html#v7a
+// for target ABI requirements.
+
 pub fn target() -> TargetResult {
     let mut base = super::android_base::opts();
     base.features = "+v7,+thumb2,+vfp3,+d16,-neon".to_string();

--- a/src/librustc_back/target/i686_linux_android.rs
+++ b/src/librustc_back/target/i686_linux_android.rs
@@ -10,6 +10,9 @@
 
 use target::{Target, TargetResult};
 
+// See https://developer.android.com/ndk/guides/abis.html#x86
+// for target ABI requirements.
+
 pub fn target() -> TargetResult {
     let mut base = super::android_base::opts();
 


### PR DESCRIPTION
We thought Google's ABI for arvm7 required neon, but it is
currently optional, perhaps because there is a significant
population of Tegra 2 devices still in use.

This turns off neon code generation outside #[target-feature]
blocks just like we do on armv7-unknown-linux-gnu, but unlike
most other armv7 targets. LLVM defaults to +neon for this target,
so an explicit disable is necessary.

See https://developer.android.com/ndk/guides/abis.html#v7a
for instruction set extension requirements.

Closes #38402.