### PR TITLE
tidy features: use 2-parameter form of internal try macro for open err

### DIFF
--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -67,7 +67,7 @@ pub fn check(path: &Path, bad: &mut bool) {
         }
 
         contents.truncate(0);
-        t!(t!(File::open(file)).read_to_string(&mut contents));
+        t!(t!(File::open(&file), &file).read_to_string(&mut contents));
 
         for (i, line) in contents.lines().enumerate() {
             let mut err = |msg: &str| {


### PR DESCRIPTION
This tiny patch merely applies @bluss's suggestion for how to get a more
informative error message when the feature check can't open a file, a
matter that had briefly annoyed the present author, leading to the
filing of #38417.

Resolves #38417.