### PR TITLE
Update beta bootstrap compiler

### DIFF
--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,5 +12,5 @@
 # tarball for a stable release you'll likely see `1.x.0-$date` where `1.x.0` was
 # released on `$date`
 
-rustc: beta-2016-11-16
+rustc: beta-2016-12-16
 cargo: nightly-2016-11-16


### PR DESCRIPTION
The current beta that rustc is bootstrapping from contains a bug in Cargo that
erroneously links to OpenSSL in /usr/local, but this is fixed in the most recent
1.14 beta, so let's use that.