### PR TITLE
target spec: add an asm-args field to pass arguments to the external ..

### DIFF
--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -267,6 +267,9 @@ pub struct TargetOptions {
     /// user-defined libraries.
     pub post_link_args: Vec<String>,
 
+    /// Extra arguments to pass to the external assembler (when used)
+    pub asm_args: Vec<String>,
+
     /// Default CPU to pass to LLVM. Corresponds to `llc -mcpu=$cpu`. Defaults
     /// to "generic".
     pub cpu: String,
@@ -394,6 +397,7 @@ impl Default for TargetOptions {
             ar: option_env!("CFG_DEFAULT_AR").unwrap_or("ar").to_string(),
             pre_link_args: Vec::new(),
             post_link_args: Vec::new(),
+            asm_args: Vec::new(),
             cpu: "generic".to_string(),
             features: "".to_string(),
             dynamic_linking: false,
@@ -561,6 +565,7 @@ impl Target {
         key!(late_link_args, list);
         key!(post_link_objects, list);
         key!(post_link_args, list);
+        key!(asm_args, list);
         key!(cpu);
         key!(features);
         key!(dynamic_linking, bool);
@@ -723,6 +728,7 @@ impl ToJson for Target {
         target_option_val!(late_link_args);
         target_option_val!(post_link_objects);
         target_option_val!(post_link_args);
+        target_option_val!(asm_args);
         target_option_val!(cpu);
         target_option_val!(features);
         target_option_val!(dynamic_linking);

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -1085,6 +1085,10 @@ fn run_work_multithreaded(sess: &Session,
 pub fn run_assembler(sess: &Session, outputs: &OutputFilenames) {
     let (pname, mut cmd, _) = get_linker(sess);
 
+    for arg in &sess.target.target.options.asm_args {
+        cmd.arg(arg);
+    }
+
     cmd.arg("-c").arg("-o").arg(&outputs.path(OutputType::Object))
                            .arg(&outputs.temp_path(OutputType::Assembly, None));
     debug!("{:?}", cmd);


### PR DESCRIPTION
assembler

The main use case is the (still out of tree) msp430 target. For that target we use an external assembler, `mps430-elf-gcc`, to produce object files from the assembly rustc/llvm outputs. The problem is that by default `msp430-elf-gcc` produces object files for the MSP430**X** ABI but we want to use produce objects using the MSP430 (note: no X) ABI. To do that we have to pass `-mcpu=msp430` to the assembler and that's what this flag is for.

r? @alexcrichton 
cc @pftbest 