### PR TITLE
rustbuild: Update Cargo download location

### DIFF
--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -13,4 +13,4 @@
 # released on `$date`
 
 rustc: beta-2016-12-16
-cargo: nightly-2016-11-16
+cargo: fbeea902d2c9a5be6d99cc35681565d8f7832592


### PR DESCRIPTION
I updated the beta compiler used to bootstrap the master branch in #38438 with
the intention of fixing Travis OSX linkage issues but I mistakenly forgot that
the PR only updated rustc, not Cargo itself. Cargo has a new release process
with downloads in a different location, so this commit updates rustbuild to
download from this new location by tracking revisions instead of Cargo nightly
dates.