### PR TITLE
travis: Fix the cargotest bot

### DIFF
--- a/src/ci/docker/x86_64-gnu-cargotest/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-cargotest/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   ccache \
   libssl-dev \
   sudo \
-  xz-utils
+  xz-utils \
+  pkg-config
 
 ENV SCCACHE_DIGEST=7237e38e029342fa27b7ac25412cb9d52554008b12389727320bd533fd7f05b6a96d55485f305caf95e5c8f5f97c3313e10012ccad3e752aba2518f3522ba783
 RUN curl -L https://api.pub.build.mozilla.org/tooltool/sha512/$SCCACHE_DIGEST | \


### PR DESCRIPTION
Recently the Cargo revision running on cargotest was updated in #38051, and the
updated version of Cargo pulls in the openssl-sys 0.9 crate instead of the old
openssl-sys 0.7 crate. The 0.9 release of openssl-sys has slightly different
requirements and logic for detecting OpenSSL, namely it requires `pkg-config` to
be present on Linux typically.

This commit fixes this problem by installing pkg-config in the cargotest
container that's running on the bots. This in turn should hopefully fix the
build script and allow it to find the already-installed local OpenSSL libraries.