### PR TITLE
Bump the beta bootstrap compiler

### DIFF
--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,5 +12,5 @@
 # tarball for a stable release you'll likely see `1.x.0-$date` where `1.x.0` was
 # released on `$date`
 
-rustc: beta-2016-12-16
+rustc: 1.14.0-2016-12-18
 cargo: nightly-2016-11-16


### PR DESCRIPTION
I think this is all that needs to be done on beta, though I'm not clear on the role of the `cargo:` key here. Presumably it will change to pull in https://github.com/rust-lang/rust/pull/38470.

r? @alexcrichton 