### PR TITLE
rustbuild: Actually test musl on the musl bot

### DIFF
--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -66,7 +66,7 @@ tidy:
 check-stage2-T-arm-linux-androideabi-H-x86_64-unknown-linux-gnu:
 	$(Q)$(BOOTSTRAP) test --target arm-linux-androideabi
 check-stage2-T-x86_64-unknown-linux-musl-H-x86_64-unknown-linux-gnu:
-	$(Q)$(BOOTSTRAP) test --target x86_64-unknown-linux-gnu
+	$(Q)$(BOOTSTRAP) test --target x86_64-unknown-linux-musl
 
 
 .PHONY: dist


### PR DESCRIPTION
A typo unfortunately meant that we haven't been testing musl for a bit, so now
it's time to discover if we accidentally introduced a regression!