### PR TITLE
mk: Fix compile with makefiles

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -87,7 +87,6 @@ dependencies = [
 name = "compiletest"
 version = "0.0.0"
 dependencies = [
- "build_helper 0.1.0",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serialize 0.0.0",

--- a/src/tools/compiletest/Cargo.toml
+++ b/src/tools/compiletest/Cargo.toml
@@ -8,4 +8,3 @@ build = "build.rs"
 log = "0.3"
 env_logger = { version = "0.3.5", default-features = false }
 serialize = { path = "../../libserialize" }
-build_helper = { path = "../../build_helper" }

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate build_helper;
-
 use common::Config;
 use common::{CompileFail, ParseFail, Pretty, RunFail, RunPass, RunPassValgrind};
 use common::{Codegen, DebugInfoLldb, DebugInfoGdb, Rustdoc, CodegenUnits};
@@ -2110,7 +2108,16 @@ actual:\n\
         }
         self.create_dir_racy(&tmpdir);
 
-        let mut cmd = Command::new(build_helper::make(&self.config.host));
+        let host = &self.config.host;
+        let make = if host.contains("bitrig") || host.contains("dragonfly") ||
+            host.contains("freebsd") || host.contains("netbsd") ||
+            host.contains("openbsd") {
+            "gmake"
+        } else {
+            "make"
+        };
+
+        let mut cmd = Command::new(make);
         cmd.current_dir(&self.testpaths.file)
            .env("TARGET", &self.config.target)
            .env("PYTHON", &self.config.docck_python)


### PR DESCRIPTION
A tweak was made to dependencies in #38451 but the makefiles weren't updated to
accompany this. Instead of trying to integerate the `build_helper` crate into
the makefiles (which currently isn't present) this commit takes the approach of
just duplicating the required logic, which should be small enough for now.