### PR TITLE
travis: Update the OSX image we run tests in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ git:
   depth: 1
   submodules: false
 
+osx_image: xcode8.2
+
 matrix:
   include:
     # Linux builders, all docker images

--- a/src/test/debuginfo/union-smoke.rs
+++ b/src/test/debuginfo/union-smoke.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // min-lldb-version: 310
+// ignore-macos FIXME(#37479)
 
 // compile-flags:-g
 


### PR DESCRIPTION
The current image is `xcode7.3`, Travis's current default. Unfortunately this
has a version of LLDB which doesn't support debuginfo-lldb tests (see #32520),
so we're not running LLDB tests on Travis yet.

This switches us to the newest image from Travis, `xcode8.2`, which should have
a newer version of LLDB we can run tests against.