### PR TITLE
Removes magenta build warning.

### DIFF
--- a/src/libstd/sys/unix/process/magenta.rs
+++ b/src/libstd/sys/unix/process/magenta.rs
@@ -23,7 +23,6 @@ pub type mx_rights_t = u32;
 pub type mx_status_t = i32;
 
 pub type mx_size_t = usize;
-pub type mx_ssize_t = isize;
 
 pub const MX_HANDLE_INVALID: mx_handle_t = 0;
 


### PR DESCRIPTION
Small bug fix to remove an unused type in the magenta process code that causes build failures for magenta's rustc.

r? @alexcrichton

@tedsta @raphlinus