### PR TITLE
Add intrinsics & target features for rd{rand,seed}

### DIFF
--- a/src/etc/platform-intrinsics/x86/rdrand.json
+++ b/src/etc/platform-intrinsics/x86/rdrand.json
@@ -1,0 +1,27 @@
+{
+    "intrinsic_prefix": "_rdrand",
+    "llvm_prefix": "llvm.x86.rdrand.",
+    "intrinsics": [
+        {
+            "intrinsic": "16_step",
+            "width": ["0"],
+            "llvm": "16",
+            "ret": "(U16,S32)",
+            "args": []
+        },
+        {
+            "intrinsic": "32_step",
+            "width": ["0"],
+            "llvm": "32",
+            "ret": "(U32,S32)",
+            "args": []
+        },
+        {
+            "intrinsic": "64_step",
+            "width": ["0"],
+            "llvm": "64",
+            "ret": "(U64,S32)",
+            "args": []
+        }
+    ]
+}

--- a/src/etc/platform-intrinsics/x86/rdseed.json
+++ b/src/etc/platform-intrinsics/x86/rdseed.json
@@ -1,0 +1,27 @@
+{
+    "intrinsic_prefix": "_rdseed",
+    "llvm_prefix": "llvm.x86.rdseed.",
+    "intrinsics": [
+        {
+            "intrinsic": "16_step",
+            "width": ["0"],
+            "llvm": "16",
+            "ret": "(U16,S32)",
+            "args": []
+        },
+        {
+            "intrinsic": "32_step",
+            "width": ["0"],
+            "llvm": "32",
+            "ret": "(U32,S32)",
+            "args": []
+        },
+        {
+            "intrinsic": "64_step",
+            "width": ["0"],
+            "llvm": "64",
+            "ret": "(U64,S32)",
+            "args": []
+        }
+    ]
+}

--- a/src/librustc_driver/target_features.rs
+++ b/src/librustc_driver/target_features.rs
@@ -25,7 +25,7 @@ const ARM_WHITELIST: &'static [&'static str] = &["neon\0", "vfp2\0", "vfp3\0", "
 const X86_WHITELIST: &'static [&'static str] = &["avx\0", "avx2\0", "bmi\0", "bmi2\0", "sse\0",
                                                  "sse2\0", "sse3\0", "sse4.1\0", "sse4.2\0",
                                                  "ssse3\0", "tbm\0", "lzcnt\0", "popcnt\0",
-                                                 "sse4a\0"];
+                                                 "sse4a\0", "rdrnd\0", "rdseed\0"];
 
 /// Add `target_feature = "..."` cfgs for a variety of platform
 /// specific features (SSE, NEON etc.).

--- a/src/librustc_platform_intrinsics/x86.rs
+++ b/src/librustc_platform_intrinsics/x86.rs
@@ -872,6 +872,36 @@ pub fn find(name: &str) -> Option<Intrinsic> {
             output: &::F64x4,
             definition: Named("llvm.x86.fma.vfnmsub.pd.256")
         },
+        "_rdrand16_step" => Intrinsic {
+            inputs: { static INPUTS: [&'static Type; 0] = []; &INPUTS },
+            output: { static AGG: Type = Type::Aggregate(false, { static PARTS: [&'static Type; 2] = [&::U16, &::I32]; &PARTS }); &AGG },
+            definition: Named("llvm.x86.rdrand.16")
+        },
+        "_rdrand32_step" => Intrinsic {
+            inputs: { static INPUTS: [&'static Type; 0] = []; &INPUTS },
+            output: { static AGG: Type = Type::Aggregate(false, { static PARTS: [&'static Type; 2] = [&::U32, &::I32]; &PARTS }); &AGG },
+            definition: Named("llvm.x86.rdrand.32")
+        },
+        "_rdrand64_step" => Intrinsic {
+            inputs: { static INPUTS: [&'static Type; 0] = []; &INPUTS },
+            output: { static AGG: Type = Type::Aggregate(false, { static PARTS: [&'static Type; 2] = [&::U64, &::I32]; &PARTS }); &AGG },
+            definition: Named("llvm.x86.rdrand.64")
+        },
+        "_rdseed16_step" => Intrinsic {
+            inputs: { static INPUTS: [&'static Type; 0] = []; &INPUTS },
+            output: { static AGG: Type = Type::Aggregate(false, { static PARTS: [&'static Type; 2] = [&::U16, &::I32]; &PARTS }); &AGG },
+            definition: Named("llvm.x86.rdseed.16")
+        },
+        "_rdseed32_step" => Intrinsic {
+            inputs: { static INPUTS: [&'static Type; 0] = []; &INPUTS },
+            output: { static AGG: Type = Type::Aggregate(false, { static PARTS: [&'static Type; 2] = [&::U32, &::I32]; &PARTS }); &AGG },
+            definition: Named("llvm.x86.rdseed.32")
+        },
+        "_rdseed64_step" => Intrinsic {
+            inputs: { static INPUTS: [&'static Type; 0] = []; &INPUTS },
+            output: { static AGG: Type = Type::Aggregate(false, { static PARTS: [&'static Type; 2] = [&::U64, &::I32]; &PARTS }); &AGG },
+            definition: Named("llvm.x86.rdseed.64")
+        },
         "_mm_adds_epi8" => Intrinsic {
             inputs: { static INPUTS: [&'static Type; 2] = [&::I8x16, &::I8x16]; &INPUTS },
             output: &::I8x16,


### PR DESCRIPTION
One question is whether or not we want to map feature name `rdrnd` to `rdrand` instead.

EDIT: as for use case, I would like to port my rdrand crate from inline assembly to these intrinsics.