### PR TITLE
Fix rustdoc highlighting of `&` and `*`

### DIFF
--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -218,9 +218,11 @@ impl<'a> Classifier<'a> {
             token::Comment => Class::Comment,
             token::DocComment(..) => Class::DocComment,
 
-            // If this '&' token is directly adjacent to another token, assume
-            // that it's the address-of operator instead of the and-operator.
-            token::BinOp(token::And) if self.lexer.peek().sp.lo == tas.sp.hi => Class::RefKeyWord,
+            // If this '&' or '*' token is followed by a non-whitespace token, assume that it's the
+            // reference or dereference operator or a reference or pointer type, instead of the
+            // bit-and or multiplication operator.
+            token::BinOp(token::And) | token::BinOp(token::Star)
+                if self.lexer.peek().tok != token::Whitespace => Class::RefKeyWord,
 
             // Consider this as part of a macro invocation if there was a
             // leading identifier.


### PR DESCRIPTION
Whitespace tokens were included, so the span check used with `&` was incorrect, and it was never highlighted as kw-2 (RefKeyword).

The `*` in `*foo` and `*const T` should also be highlighted kw-2, so I added them. Note that this *will* cause mishighlighting of code like `1*2`, but that should have been written `1 * 2`. Same deal with `1&2`.