### PR TITLE
Partial fix for #38489.

### DIFF
--- a/src/librustc_back/target/asmjs_unknown_emscripten.rs
+++ b/src/librustc_back/target/asmjs_unknown_emscripten.rs
@@ -9,11 +9,12 @@
 // except according to those terms.
 
 use super::{Target, TargetOptions};
+use super::emscripten_base::{cmd};
 
 pub fn target() -> Result<Target, String> {
     let opts = TargetOptions {
-        linker: "emcc".to_string(),
-        ar: "emar".to_string(),
+        linker: cmd("emcc"),
+        ar: cmd("emar"),
 
         dynamic_linking: false,
         executables: true,

--- a/src/librustc_back/target/emscripten_base.rs
+++ b/src/librustc_back/target/emscripten_base.rs
@@ -1,0 +1,19 @@
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[cfg(not(windows))]
+pub fn cmd(name: &str) -> String {
+    name.to_string()
+}
+
+#[cfg(windows)]
+pub fn cmd(name: &str) -> String {
+    [name, ".bat"].concat()
+}

--- a/src/librustc_back/target/emscripten_base.rs
+++ b/src/librustc_back/target/emscripten_base.rs
@@ -8,12 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[cfg(not(windows))]
 pub fn cmd(name: &str) -> String {
-    name.to_string()
-}
-
-#[cfg(windows)]
-pub fn cmd(name: &str) -> String {
-    [name, ".bat"].concat()
+    if cfg!(windows) {
+        format!("{}.bat", name)
+    } else {
+        name.to_string()
+    }
 }

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -58,6 +58,7 @@ mod apple_ios_base;
 mod arm_base;
 mod bitrig_base;
 mod dragonfly_base;
+mod emscripten_base;
 mod freebsd_base;
 mod haiku_base;
 mod linux_base;

--- a/src/librustc_back/target/wasm32_unknown_emscripten.rs
+++ b/src/librustc_back/target/wasm32_unknown_emscripten.rs
@@ -9,11 +9,12 @@
 // except according to those terms.
 
 use super::{Target, TargetOptions};
+use super::emscripten_base::{cmd};
 
 pub fn target() -> Result<Target, String> {
     let opts = TargetOptions {
-        linker: "emcc".to_string(),
-        ar: "emar".to_string(),
+        linker: cmd("emcc"),
+        ar: cmd("emar"),
 
         dynamic_linking: false,
         executables: true,


### PR DESCRIPTION
Fixes script name resolution for windows by invoking `emcc.bat` instead of `emcc`, etc.

Remaining issue:
```
Traceback (most recent call last):
  File "C:\Program Files\Emscripten\emscripten\1.35.0\\emcc", line 1309, in <module>
    final = shared.Building.llvm_opt(final, link_opts, DEFAULT_FINAL)
  File "C:\Program Files\Emscripten\emscripten\1.35.0\tools\shared.py", line 1471, in llvm_opt
    assert os.path.exists(target), 'Failed to run llvm optimizations: ' + output
AssertionError: Failed to run llvm optimizations:
```