### PR TITLE
Suggest solutions for `fn foo(&foo: Foo)`

### DIFF
--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -30,10 +30,14 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         self.check_pat_arg(pat, expected, false);
     }
 
+    /// The `is_arg` argument indicates whether this pattern is the
+    /// *outermost* pattern in an argument (e.g., in `fn foo(&x:
+    /// &u32)`, it is true for the `&x` pattern but not `x`). This is
+    /// used to tailor error reporting.
     pub fn check_pat_arg(&self, pat: &'gcx hir::Pat, expected: Ty<'tcx>, is_arg: bool) {
         let tcx = self.tcx;
 
-        debug!("check_pat(pat={:?},expected={:?})", pat, expected);
+        debug!("check_pat(pat={:?},expected={:?},is_arg={})", pat, expected, is_arg);
 
         let ty = match pat.node {
             PatKind::Wild => {
@@ -206,6 +210,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     // can, to avoid creating needless variables.  This
                     // also helps with the bad interactions of the given
                     // hack detailed in (*) below.
+                    debug!("check_pat_arg: expected={:?}", expected);
                     let (rptr_ty, inner_ty) = match expected.sty {
                         ty::TyRef(_, mt) if mt.mutbl == mutbl => {
                             (expected, mt.ty)
@@ -216,15 +221,21 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                             let mt = ty::TypeAndMut { ty: inner_ty, mutbl: mutbl };
                             let region = self.next_region_var(infer::PatternRegion(pat.span));
                             let rptr_ty = tcx.mk_ref(region, mt);
+                            debug!("check_pat_arg: demanding {:?} = {:?}", expected, rptr_ty);
                             let err = self.demand_eqtype_diag(pat.span, expected, rptr_ty);
+
+                            // Look for a case like `fn foo(&foo: u32)` and suggest
+                            // `fn foo(foo: &u32)`
                             if let Some(mut err) = err {
                                 if is_arg {
-                                    if let Ok(snippet) = self.sess().codemap()
-                                        .span_to_snippet(pat.span)
-                                    {
-                                        err.help(&format!("did you mean `{}: &{}`?",
-                                                          &snippet[1..],
-                                                          expected));
+                                    if let PatKind::Binding(..) = inner.node {
+                                        if let Ok(snippet) = self.sess().codemap()
+                                                                        .span_to_snippet(pat.span)
+                                        {
+                                            err.help(&format!("did you mean `{}: &{}`?",
+                                                              &snippet[1..],
+                                                              expected));
+                                        }
                                     }
                                 }
                                 err.emit();

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -223,9 +223,6 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                         .span_to_snippet(pat.span)
                                     {
                                         err.help(&format!("did you mean `{}: &{}`?",
-                                                          snippet,
-                                                          expected));
-                                        err.help(&format!("did you mean `{}: {}`?",
                                                           &snippet[1..],
                                                           expected));
                                     }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -798,7 +798,7 @@ fn check_fn<'a, 'gcx, 'tcx>(inherited: &'a Inherited<'a, 'gcx, 'tcx>,
         fcx.register_old_wf_obligation(arg_ty, arg.pat.span, traits::MiscObligation);
 
         // Check the pattern.
-        fcx.check_pat(&arg.pat, arg_ty);
+        fcx.check_pat_arg(&arg.pat, arg_ty, true);
         fcx.write_ty(arg.id, arg_ty);
     }
 

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -505,7 +505,9 @@ impl<'ccx, 'gcx> CheckTypeWellFormedVisitor<'ccx, 'gcx> {
         debug!("check_method_receiver: receiver ty = {:?}", rcvr_ty);
 
         let cause = fcx.cause(span, ObligationCauseCode::MethodReceiver);
-        fcx.demand_eqtype_with_origin(&cause, rcvr_ty, self_arg_ty);
+        if let Some(mut err) = fcx.demand_eqtype_with_origin(&cause, rcvr_ty, self_arg_ty) {
+            err.emit();
+        }
     }
 
     fn check_variances_for_type_defn(&self,

--- a/src/test/ui/mismatched_types/issue-38371.rs
+++ b/src/test/ui/mismatched_types/issue-38371.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -7,20 +7,28 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+#![feature(slice_patterns)]
+
 
 struct Foo {
 }
 
-fn foo(&foo: Foo) {  // illegal syntax
+fn foo(&foo: Foo) {
 }
 
-fn bar(foo: Foo) {  // legal
+fn bar(foo: Foo) {
 }
 
-fn qux(foo: &Foo) {  // legal
+fn qux(foo: &Foo) {
 }
 
-fn zar(&foo: &Foo) {  // legal
+fn zar(&foo: &Foo) {
+}
+
+fn agh(&&bar: &u32) {
+}
+
+fn ugh(&[bar]: &u32) {
 }
 
 fn main() {}

--- a/src/test/ui/mismatched_types/issue-38371.rs
+++ b/src/test/ui/mismatched_types/issue-38371.rs
@@ -28,6 +28,9 @@ fn zar(&foo: &Foo) {
 fn agh(&&bar: &u32) {
 }
 
+fn bgh(&&bar: u32) {
+}
+
 fn ugh(&[bar]: &u32) {
 }
 

--- a/src/test/ui/mismatched_types/issue-38371.rs
+++ b/src/test/ui/mismatched_types/issue-38371.rs
@@ -1,0 +1,26 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo {
+}
+
+fn foo(&foo: Foo) {  // illegal syntax
+}
+
+fn bar(foo: Foo) {  // legal
+}
+
+fn qux(foo: &Foo) {  // legal
+}
+
+fn zar(&foo: &Foo) {  // legal
+}
+
+fn main() {}

--- a/src/test/ui/mismatched_types/issue-38371.stderr
+++ b/src/test/ui/mismatched_types/issue-38371.stderr
@@ -17,11 +17,20 @@ error[E0308]: mismatched types
    = note: expected type `u32`
    = note:    found type `&_`
 
-error[E0529]: expected an array or slice, found `u32`
-  --> $DIR/issue-38371.rs:31:9
+error[E0308]: mismatched types
+  --> $DIR/issue-38371.rs:31:8
    |
-31 | fn ugh(&[bar]: &u32) {
+31 | fn bgh(&&bar: u32) {
+   |        ^^^^^ expected u32, found reference
+   |
+   = note: expected type `u32`
+   = note:    found type `&_`
+
+error[E0529]: expected an array or slice, found `u32`
+  --> $DIR/issue-38371.rs:34:9
+   |
+34 | fn ugh(&[bar]: &u32) {
    |         ^^^^^ pattern cannot match with input type `u32`
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/mismatched_types/issue-38371.stderr
+++ b/src/test/ui/mismatched_types/issue-38371.stderr
@@ -1,12 +1,27 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-38371.rs:14:8
+  --> $DIR/issue-38371.rs:16:8
    |
-14 | fn foo(&foo: Foo) {  // illegal syntax
+16 | fn foo(&foo: Foo) {
    |        ^^^^ expected struct `Foo`, found reference
    |
    = note: expected type `Foo`
    = note:    found type `&_`
    = help: did you mean `foo: &Foo`?
 
-error: aborting due to previous error
+error[E0308]: mismatched types
+  --> $DIR/issue-38371.rs:28:9
+   |
+28 | fn agh(&&bar: &u32) {
+   |         ^^^^ expected u32, found reference
+   |
+   = note: expected type `u32`
+   = note:    found type `&_`
+
+error[E0529]: expected an array or slice, found `u32`
+  --> $DIR/issue-38371.rs:31:9
+   |
+31 | fn ugh(&[bar]: &u32) {
+   |         ^^^^^ pattern cannot match with input type `u32`
+
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/mismatched_types/issue-38371.stderr
+++ b/src/test/ui/mismatched_types/issue-38371.stderr
@@ -6,8 +6,7 @@ error[E0308]: mismatched types
    |
    = note: expected type `Foo`
    = note:    found type `&_`
-   = help: did you mean `&foo: &Foo`?
-   = help: did you mean `foo: Foo`?
+   = help: did you mean `foo: &Foo`?
 
 error: aborting due to previous error
 

--- a/src/test/ui/mismatched_types/issue-38371.stderr
+++ b/src/test/ui/mismatched_types/issue-38371.stderr
@@ -1,0 +1,13 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-38371.rs:14:8
+   |
+14 | fn foo(&foo: Foo) {  // illegal syntax
+   |        ^^^^ expected struct `Foo`, found reference
+   |
+   = note: expected type `Foo`
+   = note:    found type `&_`
+   = help: did you mean `&foo: &Foo`?
+   = help: did you mean `foo: Foo`?
+
+error: aborting due to previous error
+


### PR DESCRIPTION
For a given file:

```rust
struct Foo {}

fn foo(&foo: Foo) {}
```

suggest:

```
error[E0308]: mismatched types
 --> file.rs:3:8
  |
3 | fn foo(&foo: Foo) {}
  |        ^^^^ expected struct `Foo`, found reference
  |
  = note: expected type `Foo`
  = note:    found type `&_`
  = help: did you mean `foo: &Foo`?
```

Fix #38371.