### PR TITLE
travis: Attempt to fix Android flakiness

### DIFF
--- a/src/ci/docker/arm-android/start-emulator.sh
+++ b/src/ci/docker/arm-android/start-emulator.sh
@@ -11,5 +11,7 @@
 
 set -ex
 ANDROID_EMULATOR_FORCE_32BIT=true \
-  emulator @arm-18 -no-window -partition-size 2047 &
+  nohup nohup emulator @arm-18 -no-window -partition-size 2047 \
+  0<&- &>/dev/null &
+adb wait-for-device
 exec "$@"


### PR DESCRIPTION
There's been some flaky runs on Travis where the Android emulator is having
problems staying alive... presumably? For example:

* https://travis-ci.org/rust-lang/rust/jobs/186736745

This commit spawns the emulator in the same way as buildbot with `nohup` to hope
that it goes into the background successfully, followed by a `wait-for-device`
command. I'm not actually sure if this'll fix the problems we're seeing, but I
figure it can't hurt to test out.