### PR TITLE
rustbuild: Hotfix to unbreak nightly

### DIFF
--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -843,7 +843,7 @@ invalid rule dependency graph detected, was a rule added and maybe typo'd?
             let arr = if rule.host {
                 if self.build.flags.target.len() > 0 &&
                    self.build.flags.host.len() == 0 {
-                    &hosts[..0]
+                    &[]
                 } else {
                     hosts
                 }

--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -838,9 +838,10 @@ invalid rule dependency graph detected, was a rule added and maybe typo'd?
             } else {
                 &self.build.config.target
             };
-            // If --target was specified but --host wasn't specified, don't run
-            // any host-only tests
+            // Determine the actual targets participating in this rule.
             let arr = if rule.host {
+                // If --target was specified but --host wasn't specified,
+                // don't run any host-only tests
                 if self.build.flags.target.len() > 0 &&
                    self.build.flags.host.len() == 0 {
                     &[]

--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -839,14 +839,20 @@ invalid rule dependency graph detected, was a rule added and maybe typo'd?
                 &self.build.config.target
             };
             // Determine the actual targets participating in this rule.
+            // NOTE: We should keep the full projection from build triple to
+            // the hosts for the dist steps, now that the hosts array above is
+            // truncated to avoid duplication of work in that case. Therefore
+            // the original non-shadowed hosts array is used below.
             let arr = if rule.host {
                 // If --target was specified but --host wasn't specified,
-                // don't run any host-only tests
-                if self.build.flags.target.len() > 0 &&
-                   self.build.flags.host.len() == 0 {
+                // don't run any host-only tests. Also, respect any `--host`
+                // overrides as done for `hosts`.
+                if self.build.flags.host.len() > 0 {
+                    &self.build.flags.host[..]
+                } else if self.build.flags.target.len() > 0 {
                     &[]
                 } else {
-                    hosts
+                    &self.build.config.host[..]
                 }
             } else {
                 targets


### PR DESCRIPTION
Fixes an oversight unnoticed in #38468 that eventually broke nightly packaging. I didn't realize this until some moments ago, when I finally found out the failure is actually deterministic. Many apologies for eating 3 nightlies during the holidays.

r? @alexcrichton 