### PR TITLE
compiletest: Don't limit all suites on Android

### DIFF
--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -261,7 +261,24 @@ pub fn run_tests(config: &Config) {
         // android debug-info test uses remote debugger
         // so, we test 1 thread at once.
         // also trying to isolate problems with adb_run_wrapper.sh ilooping
-        env::set_var("RUST_TEST_THREADS","1");
+        match config.mode {
+            // These tests don't actually run code or don't run for android, so
+            // we don't need to limit ourselves there
+            Mode::Ui |
+            Mode::CompileFail |
+            Mode::ParseFail |
+            Mode::RunMake |
+            Mode::Codegen |
+            Mode::CodegenUnits |
+            Mode::Pretty |
+            Mode::Rustdoc |
+            Mode::Incremental => {}
+
+            _ => {
+                env::set_var("RUST_TEST_THREADS", "1");
+            }
+
+        }
     }
 
     match config.mode {


### PR DESCRIPTION
On Android we only have one test thread for supposed problems with concurrency
and the remote debugger. Not all of our suites require one concurrency, however,
and suites like compile-fail or pretty can be much faster if they're
parallelized on Travis.

This commit only sets the test threads to one on Android for suites which
actually run code, and other suites aren't tampered with.