### PR TITLE
libstd: replace all `try!` with `?` in documentation examples

### DIFF
--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -497,7 +497,7 @@ pub fn home_dir() -> Option<PathBuf> {
 /// let mut dir = env::temp_dir();
 /// dir.push("foo.txt");
 ///
-/// let f = try!(File::create(dir));
+/// let f = File::create(dir)?;
 /// # Ok(())
 /// # }
 /// ```

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -42,8 +42,8 @@ use time::SystemTime;
 /// use std::io::prelude::*;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// let mut file = try!(File::create("foo.txt"));
-/// try!(file.write_all(b"Hello, world!"));
+/// let mut file = File::create("foo.txt")?;
+/// file.write_all(b"Hello, world!")?;
 /// # Ok(())
 /// # }
 /// ```
@@ -55,9 +55,9 @@ use time::SystemTime;
 /// use std::io::prelude::*;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// let mut file = try!(File::open("foo.txt"));
+/// let mut file = File::open("foo.txt")?;
 /// let mut contents = String::new();
-/// try!(file.read_to_string(&mut contents));
+/// file.read_to_string(&mut contents)?;
 /// assert_eq!(contents, "Hello, world!");
 /// # Ok(())
 /// # }
@@ -72,10 +72,10 @@ use time::SystemTime;
 /// use std::io::prelude::*;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// let file = try!(File::open("foo.txt"));
+/// let file = File::open("foo.txt")?;
 /// let mut buf_reader = BufReader::new(file);
 /// let mut contents = String::new();
-/// try!(buf_reader.read_to_string(&mut contents));
+/// buf_reader.read_to_string(&mut contents)?;
 /// assert_eq!(contents, "Hello, world!");
 /// # Ok(())
 /// # }
@@ -227,7 +227,7 @@ impl File {
     /// use std::fs::File;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut f = try!(File::open("foo.txt"));
+    /// let mut f = File::open("foo.txt")?;
     /// # Ok(())
     /// # }
     /// ```
@@ -251,7 +251,7 @@ impl File {
     /// use std::fs::File;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut f = try!(File::create("foo.txt"));
+    /// let mut f = File::create("foo.txt")?;
     /// # Ok(())
     /// # }
     /// ```
@@ -272,10 +272,10 @@ impl File {
     /// use std::io::prelude::*;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut f = try!(File::create("foo.txt"));
-    /// try!(f.write_all(b"Hello, world!"));
+    /// let mut f = File::create("foo.txt")?;
+    /// f.write_all(b"Hello, world!")?;
     ///
-    /// try!(f.sync_all());
+    /// f.sync_all()?;
     /// # Ok(())
     /// # }
     /// ```
@@ -303,10 +303,10 @@ impl File {
     /// use std::io::prelude::*;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut f = try!(File::create("foo.txt"));
-    /// try!(f.write_all(b"Hello, world!"));
+    /// let mut f = File::create("foo.txt")?;
+    /// f.write_all(b"Hello, world!")?;
     ///
-    /// try!(f.sync_data());
+    /// f.sync_data()?;
     /// # Ok(())
     /// # }
     /// ```
@@ -333,8 +333,8 @@ impl File {
     /// use std::fs::File;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut f = try!(File::create("foo.txt"));
-    /// try!(f.set_len(10));
+    /// let mut f = File::create("foo.txt")?;
+    /// f.set_len(10)?;
     /// # Ok(())
     /// # }
     /// ```
@@ -351,8 +351,8 @@ impl File {
     /// use std::fs::File;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut f = try!(File::open("foo.txt"));
-    /// let metadata = try!(f.metadata());
+    /// let mut f = File::open("foo.txt")?;
+    /// let metadata = f.metadata()?;
     /// # Ok(())
     /// # }
     /// ```
@@ -373,8 +373,8 @@ impl File {
     /// use std::fs::File;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut f = try!(File::open("foo.txt"));
-    /// let file_copy = try!(f.try_clone());
+    /// let mut f = File::open("foo.txt")?;
+    /// let file_copy = f.try_clone()?;
     /// # Ok(())
     /// # }
     /// ```
@@ -691,7 +691,7 @@ impl Metadata {
     /// # fn foo() -> std::io::Result<()> {
     /// use std::fs;
     ///
-    /// let metadata = try!(fs::metadata("foo.txt"));
+    /// let metadata = fs::metadata("foo.txt")?;
     ///
     /// println!("{:?}", metadata.file_type());
     /// # Ok(())
@@ -710,7 +710,7 @@ impl Metadata {
     /// # fn foo() -> std::io::Result<()> {
     /// use std::fs;
     ///
-    /// let metadata = try!(fs::metadata("foo.txt"));
+    /// let metadata = fs::metadata("foo.txt")?;
     ///
     /// assert!(!metadata.is_dir());
     /// # Ok(())
@@ -727,7 +727,7 @@ impl Metadata {
     /// # fn foo() -> std::io::Result<()> {
     /// use std::fs;
     ///
-    /// let metadata = try!(fs::metadata("foo.txt"));
+    /// let metadata = fs::metadata("foo.txt")?;
     ///
     /// assert!(metadata.is_file());
     /// # Ok(())
@@ -744,7 +744,7 @@ impl Metadata {
     /// # fn foo() -> std::io::Result<()> {
     /// use std::fs;
     ///
-    /// let metadata = try!(fs::metadata("foo.txt"));
+    /// let metadata = fs::metadata("foo.txt")?;
     ///
     /// assert_eq!(0, metadata.len());
     /// # Ok(())
@@ -761,7 +761,7 @@ impl Metadata {
     /// # fn foo() -> std::io::Result<()> {
     /// use std::fs;
     ///
-    /// let metadata = try!(fs::metadata("foo.txt"));
+    /// let metadata = fs::metadata("foo.txt")?;
     ///
     /// assert!(!metadata.permissions().readonly());
     /// # Ok(())
@@ -788,7 +788,7 @@ impl Metadata {
     /// # fn foo() -> std::io::Result<()> {
     /// use std::fs;
     ///
-    /// let metadata = try!(fs::metadata("foo.txt"));
+    /// let metadata = fs::metadata("foo.txt")?;
     ///
     /// if let Ok(time) = metadata.modified() {
     ///     println!("{:?}", time);
@@ -823,7 +823,7 @@ impl Metadata {
     /// # fn foo() -> std::io::Result<()> {
     /// use std::fs;
     ///
-    /// let metadata = try!(fs::metadata("foo.txt"));
+    /// let metadata = fs::metadata("foo.txt")?;
     ///
     /// if let Ok(time) = metadata.accessed() {
     ///     println!("{:?}", time);
@@ -854,7 +854,7 @@ impl Metadata {
     /// # fn foo() -> std::io::Result<()> {
     /// use std::fs;
     ///
-    /// let metadata = try!(fs::metadata("foo.txt"));
+    /// let metadata = fs::metadata("foo.txt")?;
     ///
     /// if let Ok(time) = metadata.created() {
     ///     println!("{:?}", time);
@@ -898,8 +898,8 @@ impl Permissions {
     /// use std::fs::File;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut f = try!(File::create("foo.txt"));
-    /// let metadata = try!(f.metadata());
+    /// let mut f = File::create("foo.txt")?;
+    /// let metadata = f.metadata()?;
     ///
     /// assert_eq!(false, metadata.permissions().readonly());
     /// # Ok(())
@@ -919,8 +919,8 @@ impl Permissions {
     /// use std::fs::File;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let f = try!(File::create("foo.txt"));
-    /// let metadata = try!(f.metadata());
+    /// let f = File::create("foo.txt")?;
+    /// let metadata = f.metadata()?;
     /// let mut permissions = metadata.permissions();
     ///
     /// permissions.set_readonly(true);
@@ -948,7 +948,7 @@ impl FileType {
     /// # fn foo() -> std::io::Result<()> {
     /// use std::fs;
     ///
-    /// let metadata = try!(fs::metadata("foo.txt"));
+    /// let metadata = fs::metadata("foo.txt")?;
     /// let file_type = metadata.file_type();
     ///
     /// assert_eq!(file_type.is_dir(), false);
@@ -966,7 +966,7 @@ impl FileType {
     /// # fn foo() -> std::io::Result<()> {
     /// use std::fs;
     ///
-    /// let metadata = try!(fs::metadata("foo.txt"));
+    /// let metadata = fs::metadata("foo.txt")?;
     /// let file_type = metadata.file_type();
     ///
     /// assert_eq!(file_type.is_file(), true);
@@ -995,7 +995,7 @@ impl FileType {
     /// # fn foo() -> std::io::Result<()> {
     /// use std::fs;
     ///
-    /// let metadata = try!(fs::symlink_metadata("foo.txt"));
+    /// let metadata = fs::symlink_metadata("foo.txt")?;
     /// let file_type = metadata.file_type();
     ///
     /// assert_eq!(file_type.is_symlink(), false);
@@ -1040,8 +1040,8 @@ impl DirEntry {
     /// ```
     /// use std::fs;
     /// # fn foo() -> std::io::Result<()> {
-    /// for entry in try!(fs::read_dir(".")) {
-    ///     let dir = try!(entry);
+    /// for entry in fs::read_dir(".")? {
+    ///     let dir = entry?;
     ///     println!("{:?}", dir.path());
     /// }
     /// # Ok(())
@@ -1193,7 +1193,7 @@ impl AsInner<fs_imp::DirEntry> for DirEntry {
 /// use std::fs;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// try!(fs::remove_file("a.txt"));
+/// fs::remove_file("a.txt")?;
 /// # Ok(())
 /// # }
 /// ```
@@ -1229,7 +1229,7 @@ pub fn remove_file<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// # fn foo() -> std::io::Result<()> {
 /// use std::fs;
 ///
-/// let attr = try!(fs::metadata("/some/file/path.txt"));
+/// let attr = fs::metadata("/some/file/path.txt")?;
 /// // inspect attr ...
 /// # Ok(())
 /// # }
@@ -1262,7 +1262,7 @@ pub fn metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
 /// # fn foo() -> std::io::Result<()> {
 /// use std::fs;
 ///
-/// let attr = try!(fs::symlink_metadata("/some/file/path.txt"));
+/// let attr = fs::symlink_metadata("/some/file/path.txt")?;
 /// // inspect attr ...
 /// # Ok(())
 /// # }
@@ -1305,7 +1305,7 @@ pub fn symlink_metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
 /// use std::fs;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// try!(fs::rename("a.txt", "b.txt")); // Rename a.txt to b.txt
+/// fs::rename("a.txt", "b.txt")?; // Rename a.txt to b.txt
 /// # Ok(())
 /// # }
 /// ```
@@ -1349,7 +1349,7 @@ pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<()> 
 /// use std::fs;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// try!(fs::copy("foo.txt", "bar.txt"));  // Copy foo.txt to bar.txt
+/// fs::copy("foo.txt", "bar.txt")?;  // Copy foo.txt to bar.txt
 /// # Ok(()) }
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1382,7 +1382,7 @@ pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<u64> {
 /// use std::fs;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// try!(fs::hard_link("a.txt", "b.txt")); // Hard link a.txt to b.txt
+/// fs::hard_link("a.txt", "b.txt")?; // Hard link a.txt to b.txt
 /// # Ok(())
 /// # }
 /// ```
@@ -1405,7 +1405,7 @@ pub fn hard_link<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<(
 /// use std::fs;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// try!(fs::soft_link("a.txt", "b.txt"));
+/// fs::soft_link("a.txt", "b.txt")?;
 /// # Ok(())
 /// # }
 /// ```
@@ -1441,7 +1441,7 @@ pub fn soft_link<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<(
 /// use std::fs;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// let path = try!(fs::read_link("a.txt"));
+/// let path = fs::read_link("a.txt")?;
 /// # Ok(())
 /// # }
 /// ```
@@ -1474,7 +1474,7 @@ pub fn read_link<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
 /// use std::fs;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// let path = try!(fs::canonicalize("../a/../foo.txt"));
+/// let path = fs::canonicalize("../a/../foo.txt")?;
 /// # Ok(())
 /// # }
 /// ```
@@ -1506,7 +1506,7 @@ pub fn canonicalize<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
 /// use std::fs;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// try!(fs::create_dir("/some/dir"));
+/// fs::create_dir("/some/dir")?;
 /// # Ok(())
 /// # }
 /// ```
@@ -1541,7 +1541,7 @@ pub fn create_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// use std::fs;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// try!(fs::create_dir_all("/some/dir"));
+/// fs::create_dir_all("/some/dir")?;
 /// # Ok(())
 /// # }
 /// ```
@@ -1573,7 +1573,7 @@ pub fn create_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// use std::fs;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// try!(fs::remove_dir("/some/dir"));
+/// fs::remove_dir("/some/dir")?;
 /// # Ok(())
 /// # }
 /// ```
@@ -1606,7 +1606,7 @@ pub fn remove_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// use std::fs;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// try!(fs::remove_dir_all("/some/dir"));
+/// fs::remove_dir_all("/some/dir")?;
 /// # Ok(())
 /// # }
 /// ```
@@ -1649,11 +1649,11 @@ pub fn remove_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// // one possible implementation of walking a directory only visiting files
 /// fn visit_dirs(dir: &Path, cb: &Fn(&DirEntry)) -> io::Result<()> {
 ///     if dir.is_dir() {
-///         for entry in try!(fs::read_dir(dir)) {
-///             let entry = try!(entry);
+///         for entry in fs::read_dir(dir)? {
+///             let entry = entry?;
 ///             let path = entry.path();
 ///             if path.is_dir() {
-///                 try!(visit_dirs(&path, cb));
+///                 visit_dirs(&path, cb)?;
 ///             } else {
 ///                 cb(&entry);
 ///             }
@@ -1690,9 +1690,9 @@ pub fn read_dir<P: AsRef<Path>>(path: P) -> io::Result<ReadDir> {
 /// # fn foo() -> std::io::Result<()> {
 /// use std::fs;
 ///
-/// let mut perms = try!(fs::metadata("foo.txt")).permissions();
+/// let mut perms = fs::metadata("foo.txt")?.permissions();
 /// perms.set_readonly(true);
-/// try!(fs::set_permissions("foo.txt", perms));
+/// fs::set_permissions("foo.txt", perms)?;
 /// # Ok(())
 /// # }
 /// ```

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -37,11 +37,11 @@ use memchr;
 /// use std::fs::File;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// let mut f = try!(File::open("log.txt"));
+/// let mut f = File::open("log.txt")?;
 /// let mut reader = BufReader::new(f);
 ///
 /// let mut line = String::new();
-/// let len = try!(reader.read_line(&mut line));
+/// let len = reader.read_line(&mut line)?;
 /// println!("First line is {} bytes long", len);
 /// # Ok(())
 /// # }
@@ -64,7 +64,7 @@ impl<R: Read> BufReader<R> {
     /// use std::fs::File;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut f = try!(File::open("log.txt"));
+    /// let mut f = File::open("log.txt")?;
     /// let mut reader = BufReader::new(f);
     /// # Ok(())
     /// # }
@@ -85,7 +85,7 @@ impl<R: Read> BufReader<R> {
     /// use std::fs::File;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut f = try!(File::open("log.txt"));
+    /// let mut f = File::open("log.txt")?;
     /// let mut reader = BufReader::with_capacity(10, f);
     /// # Ok(())
     /// # }
@@ -111,7 +111,7 @@ impl<R: Read> BufReader<R> {
     /// use std::fs::File;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut f1 = try!(File::open("log.txt"));
+    /// let mut f1 = File::open("log.txt")?;
     /// let mut reader = BufReader::new(f1);
     ///
     /// let f2 = reader.get_ref();
@@ -132,7 +132,7 @@ impl<R: Read> BufReader<R> {
     /// use std::fs::File;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut f1 = try!(File::open("log.txt"));
+    /// let mut f1 = File::open("log.txt")?;
     /// let mut reader = BufReader::new(f1);
     ///
     /// let f2 = reader.get_mut();
@@ -153,7 +153,7 @@ impl<R: Read> BufReader<R> {
     /// use std::fs::File;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut f1 = try!(File::open("log.txt"));
+    /// let mut f1 = File::open("log.txt")?;
     /// let mut reader = BufReader::new(f1);
     ///
     /// let f2 = reader.into_inner();
@@ -632,7 +632,7 @@ impl<W> fmt::Display for IntoInnerError<W> {
 /// I took the one less traveled by,
 /// And that has made all the difference.";
 ///
-/// let file = try!(File::create("poem.txt"));
+/// let file = File::create("poem.txt")?;
 /// let mut file = LineWriter::new(file);
 ///
 /// for &byte in road_not_taken.iter() {
@@ -640,10 +640,10 @@ impl<W> fmt::Display for IntoInnerError<W> {
 /// }
 ///
 /// // let's check we did the right thing.
-/// let mut file = try!(File::open("poem.txt"));
+/// let mut file = File::open("poem.txt")?;
 /// let mut contents = String::new();
 ///
-/// try!(file.read_to_string(&mut contents));
+/// file.read_to_string(&mut contents)?;
 ///
 /// assert_eq!(contents.as_bytes(), &road_not_taken[..]);
 /// # Ok(())
@@ -665,7 +665,7 @@ impl<W: Write> LineWriter<W> {
     /// use std::io::LineWriter;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let file = try!(File::create("poem.txt"));
+    /// let file = File::create("poem.txt")?;
     /// let file = LineWriter::new(file);
     /// # Ok(())
     /// # }
@@ -686,7 +686,7 @@ impl<W: Write> LineWriter<W> {
     /// use std::io::LineWriter;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let file = try!(File::create("poem.txt"));
+    /// let file = File::create("poem.txt")?;
     /// let file = LineWriter::with_capacity(100, file);
     /// # Ok(())
     /// # }
@@ -708,7 +708,7 @@ impl<W: Write> LineWriter<W> {
     /// use std::io::LineWriter;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let file = try!(File::create("poem.txt"));
+    /// let file = File::create("poem.txt")?;
     /// let file = LineWriter::new(file);
     ///
     /// let reference = file.get_ref();
@@ -730,7 +730,7 @@ impl<W: Write> LineWriter<W> {
     /// use std::io::LineWriter;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let file = try!(File::create("poem.txt"));
+    /// let file = File::create("poem.txt")?;
     /// let mut file = LineWriter::new(file);
     ///
     /// // we can use reference just like file
@@ -752,11 +752,11 @@ impl<W: Write> LineWriter<W> {
     /// use std::io::LineWriter;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let file = try!(File::create("poem.txt"));
+    /// let file = File::create("poem.txt")?;
     ///
     /// let writer: LineWriter<File> = LineWriter::new(file);
     ///
-    /// let file: File = try!(writer.into_inner());
+    /// let file: File = writer.into_inner()?;
     /// # Ok(())
     /// # }
     /// ```

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -45,10 +45,10 @@ use io::{self, SeekFrom, Error, ErrorKind};
 ///
 /// // a library function we've written
 /// fn write_ten_bytes_at_end<W: Write + Seek>(writer: &mut W) -> io::Result<()> {
-///     try!(writer.seek(SeekFrom::End(-10)));
+///     writer.seek(SeekFrom::End(-10))?;
 ///
 ///     for i in 0..10 {
-///         try!(writer.write(&[i]));
+///         writer.write(&[i])?;
 ///     }
 ///
 ///     // all went well
@@ -60,9 +60,9 @@ use io::{self, SeekFrom, Error, ErrorKind};
 /// //
 /// // We might want to use a BufReader here for efficiency, but let's
 /// // keep this example focused.
-/// let mut file = try!(File::create("foo.txt"));
+/// let mut file = File::create("foo.txt")?;
 ///
-/// try!(write_ten_bytes_at_end(&mut file));
+/// write_ten_bytes_at_end(&mut file)?;
 /// # Ok(())
 /// # }
 ///

--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -39,7 +39,7 @@ use convert::From;
 /// fn get_string() -> io::Result<String> {
 ///     let mut buffer = String::new();
 ///
-///     try!(io::stdin().read_line(&mut buffer));
+///     io::stdin().read_line(&mut buffer)?;
 ///
 ///     Ok(buffer)
 /// }

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -205,7 +205,8 @@
 //!
 //! Last, but certainly not least, is [`io::Result`]. This type is used
 //! as the return type of many `std::io` functions that can cause an error, and
-//! can be returned from your own functions as well.
+//! can be returned from your own functions as well. Many of the examples in this
+//! module use the [`?` operator]:
 //!
 //! ```
 //! use std::io;
@@ -249,6 +250,7 @@
 //! [`println!`]: ../macro.println.html
 //! [`Lines`]: struct.Lines.html
 //! [`io::Result`]: type.Result.html
+//! [`?` operator]: ../../book/syntax-index.html
 //! [`read()`]: trait.Read.html#tymethod.read
 
 #![stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -29,11 +29,11 @@
 //! use std::fs::File;
 //!
 //! # fn foo() -> io::Result<()> {
-//! let mut f = try!(File::open("foo.txt"));
+//! let mut f = File::open("foo.txt")?;
 //! let mut buffer = [0; 10];
 //!
 //! // read up to 10 bytes
-//! try!(f.read(&mut buffer));
+//! f.read(&mut buffer)?;
 //!
 //! println!("The bytes: {:?}", buffer);
 //! # Ok(())
@@ -58,14 +58,14 @@
 //! use std::fs::File;
 //!
 //! # fn foo() -> io::Result<()> {
-//! let mut f = try!(File::open("foo.txt"));
+//! let mut f = File::open("foo.txt")?;
 //! let mut buffer = [0; 10];
 //!
 //! // skip to the last 10 bytes of the file
-//! try!(f.seek(SeekFrom::End(-10)));
+//! f.seek(SeekFrom::End(-10))?;
 //!
 //! // read up to 10 bytes
-//! try!(f.read(&mut buffer));
+//! f.read(&mut buffer)?;
 //!
 //! println!("The bytes: {:?}", buffer);
 //! # Ok(())
@@ -93,12 +93,12 @@
 //! use std::fs::File;
 //!
 //! # fn foo() -> io::Result<()> {
-//! let f = try!(File::open("foo.txt"));
+//! let f = File::open("foo.txt")?;
 //! let mut reader = BufReader::new(f);
 //! let mut buffer = String::new();
 //!
 //! // read a line into buffer
-//! try!(reader.read_line(&mut buffer));
+//! reader.read_line(&mut buffer)?;
 //!
 //! println!("{}", buffer);
 //! # Ok(())
@@ -115,12 +115,12 @@
 //! use std::fs::File;
 //!
 //! # fn foo() -> io::Result<()> {
-//! let f = try!(File::create("foo.txt"));
+//! let f = File::create("foo.txt")?;
 //! {
 //!     let mut writer = BufWriter::new(f);
 //!
 //!     // write a byte to the buffer
-//!     try!(writer.write(&[42]));
+//!     writer.write(&[42])?;
 //!
 //! } // the buffer is flushed once writer goes out of scope
 //!
@@ -138,7 +138,7 @@
 //! # fn foo() -> io::Result<()> {
 //! let mut input = String::new();
 //!
-//! try!(io::stdin().read_line(&mut input));
+//! io::stdin().read_line(&mut input)?;
 //!
 //! println!("You typed: {}", input.trim());
 //! # Ok(())
@@ -152,7 +152,7 @@
 //! use std::io::prelude::*;
 //!
 //! # fn foo() -> io::Result<()> {
-//! try!(io::stdout().write(&[42]));
+//! io::stdout().write(&[42])?;
 //! # Ok(())
 //! # }
 //! ```
@@ -173,11 +173,11 @@
 //! use std::fs::File;
 //!
 //! # fn foo() -> io::Result<()> {
-//! let f = try!(File::open("foo.txt"));
+//! let f = File::open("foo.txt")?;
 //! let reader = BufReader::new(f);
 //!
 //! for line in reader.lines() {
-//!     println!("{}", try!(line));
+//!     println!("{}", line?);
 //! }
 //!
 //! # Ok(())
@@ -194,7 +194,7 @@
 //! use std::io;
 //!
 //! # fn foo() -> io::Result<()> {
-//! try!(io::copy(&mut io::stdin(), &mut io::stdout()));
+//! io::copy(&mut io::stdin(), &mut io::stdout())?;
 //! # Ok(())
 //! # }
 //! ```
@@ -214,7 +214,7 @@
 //! fn read_input() -> io::Result<()> {
 //!     let mut input = String::new();
 //!
-//!     try!(io::stdin().read_line(&mut input));
+//!     io::stdin().read_line(&mut input)?;
 //!
 //!     println!("You typed: {}", input.trim());
 //!
@@ -405,19 +405,19 @@ fn read_to_end<R: Read + ?Sized>(r: &mut R, buf: &mut Vec<u8>) -> Result<usize> 
 /// use std::fs::File;
 ///
 /// # fn foo() -> io::Result<()> {
-/// let mut f = try!(File::open("foo.txt"));
+/// let mut f = File::open("foo.txt")?;
 /// let mut buffer = [0; 10];
 ///
 /// // read up to 10 bytes
-/// try!(f.read(&mut buffer));
+/// f.read(&mut buffer)?;
 ///
 /// let mut buffer = vec![0; 10];
 /// // read the whole file
-/// try!(f.read_to_end(&mut buffer));
+/// f.read_to_end(&mut buffer)?;
 ///
 /// // read into a String, so that you don't need to do the conversion.
 /// let mut buffer = String::new();
-/// try!(f.read_to_string(&mut buffer));
+/// f.read_to_string(&mut buffer)?;
 ///
 /// // and more! See the other methods for more details.
 /// # Ok(())
@@ -465,11 +465,11 @@ pub trait Read {
     /// use std::fs::File;
     ///
     /// # fn foo() -> io::Result<()> {
-    /// let mut f = try!(File::open("foo.txt"));
+    /// let mut f = File::open("foo.txt")?;
     /// let mut buffer = [0; 10];
     ///
     /// // read 10 bytes
-    /// try!(f.read(&mut buffer[..]));
+    /// f.read(&mut buffer[..])?;
     /// # Ok(())
     /// # }
     /// ```
@@ -507,11 +507,11 @@ pub trait Read {
     /// use std::fs::File;
     ///
     /// # fn foo() -> io::Result<()> {
-    /// let mut f = try!(File::open("foo.txt"));
+    /// let mut f = File::open("foo.txt")?;
     /// let mut buffer = Vec::new();
     ///
     /// // read the whole file
-    /// try!(f.read_to_end(&mut buffer));
+    /// f.read_to_end(&mut buffer)?;
     /// # Ok(())
     /// # }
     /// ```
@@ -546,10 +546,10 @@ pub trait Read {
     /// use std::fs::File;
     ///
     /// # fn foo() -> io::Result<()> {
-    /// let mut f = try!(File::open("foo.txt"));
+    /// let mut f = File::open("foo.txt")?;
     /// let mut buffer = String::new();
     ///
-    /// try!(f.read_to_string(&mut buffer));
+    /// f.read_to_string(&mut buffer)?;
     /// # Ok(())
     /// # }
     /// ```
@@ -606,11 +606,11 @@ pub trait Read {
     /// use std::fs::File;
     ///
     /// # fn foo() -> io::Result<()> {
-    /// let mut f = try!(File::open("foo.txt"));
+    /// let mut f = File::open("foo.txt")?;
     /// let mut buffer = [0; 10];
     ///
     /// // read exactly 10 bytes
-    /// try!(f.read_exact(&mut buffer));
+    /// f.read_exact(&mut buffer)?;
     /// # Ok(())
     /// # }
     /// ```
@@ -649,7 +649,7 @@ pub trait Read {
     /// use std::fs::File;
     ///
     /// # fn foo() -> io::Result<()> {
-    /// let mut f = try!(File::open("foo.txt"));
+    /// let mut f = File::open("foo.txt")?;
     /// let mut buffer = Vec::new();
     /// let mut other_buffer = Vec::new();
     ///
@@ -657,12 +657,12 @@ pub trait Read {
     ///     let reference = f.by_ref();
     ///
     ///     // read at most 5 bytes
-    ///     try!(reference.take(5).read_to_end(&mut buffer));
+    ///     reference.take(5).read_to_end(&mut buffer)?;
     ///
     /// } // drop our &mut reference so we can use f again
     ///
     /// // original file still usable, read the rest
-    /// try!(f.read_to_end(&mut other_buffer));
+    /// f.read_to_end(&mut other_buffer)?;
     /// # Ok(())
     /// # }
     /// ```
@@ -688,7 +688,7 @@ pub trait Read {
     /// use std::fs::File;
     ///
     /// # fn foo() -> io::Result<()> {
-    /// let mut f = try!(File::open("foo.txt"));
+    /// let mut f = File::open("foo.txt")?;
     ///
     /// for byte in f.bytes() {
     ///     println!("{}", byte.unwrap());
@@ -725,7 +725,7 @@ pub trait Read {
     /// use std::fs::File;
     ///
     /// # fn foo() -> io::Result<()> {
-    /// let mut f = try!(File::open("foo.txt"));
+    /// let mut f = File::open("foo.txt")?;
     ///
     /// for c in f.chars() {
     ///     println!("{}", c.unwrap());
@@ -759,15 +759,15 @@ pub trait Read {
     /// use std::fs::File;
     ///
     /// # fn foo() -> io::Result<()> {
-    /// let mut f1 = try!(File::open("foo.txt"));
-    /// let mut f2 = try!(File::open("bar.txt"));
+    /// let mut f1 = File::open("foo.txt")?;
+    /// let mut f2 = File::open("bar.txt")?;
     ///
     /// let mut handle = f1.chain(f2);
     /// let mut buffer = String::new();
     ///
     /// // read the value into a String. We could use any Read method here,
     /// // this is just one example.
-    /// try!(handle.read_to_string(&mut buffer));
+    /// handle.read_to_string(&mut buffer)?;
     /// # Ok(())
     /// # }
     /// ```
@@ -795,13 +795,13 @@ pub trait Read {
     /// use std::fs::File;
     ///
     /// # fn foo() -> io::Result<()> {
-    /// let mut f = try!(File::open("foo.txt"));
+    /// let mut f = File::open("foo.txt")?;
     /// let mut buffer = [0; 5];
     ///
     /// // read at most five bytes
     /// let mut handle = f.take(5);
     ///
-    /// try!(handle.read(&mut buffer));
+    /// handle.read(&mut buffer)?;
     /// # Ok(())
     /// # }
     /// ```
@@ -839,9 +839,9 @@ pub trait Read {
 /// use std::fs::File;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// let mut buffer = try!(File::create("foo.txt"));
+/// let mut buffer = File::create("foo.txt")?;
 ///
-/// try!(buffer.write(b"some bytes"));
+/// buffer.write(b"some bytes")?;
 /// # Ok(())
 /// # }
 /// ```
@@ -879,9 +879,9 @@ pub trait Write {
     /// use std::fs::File;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut buffer = try!(File::create("foo.txt"));
+    /// let mut buffer = File::create("foo.txt")?;
     ///
-    /// try!(buffer.write(b"some bytes"));
+    /// buffer.write(b"some bytes")?;
     /// # Ok(())
     /// # }
     /// ```
@@ -904,10 +904,10 @@ pub trait Write {
     /// use std::fs::File;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut buffer = BufWriter::new(try!(File::create("foo.txt")));
+    /// let mut buffer = BufWriter::new(File::create("foo.txt")?);
     ///
-    /// try!(buffer.write(b"some bytes"));
-    /// try!(buffer.flush());
+    /// buffer.write(b"some bytes")?;
+    /// buffer.flush()?;
     /// # Ok(())
     /// # }
     /// ```
@@ -932,9 +932,9 @@ pub trait Write {
     /// use std::fs::File;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut buffer = try!(File::create("foo.txt"));
+    /// let mut buffer = File::create("foo.txt")?;
     ///
-    /// try!(buffer.write_all(b"some bytes"));
+    /// buffer.write_all(b"some bytes")?;
     /// # Ok(())
     /// # }
     /// ```
@@ -981,12 +981,12 @@ pub trait Write {
     /// use std::fs::File;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut buffer = try!(File::create("foo.txt"));
+    /// let mut buffer = File::create("foo.txt")?;
     ///
     /// // this call
-    /// try!(write!(buffer, "{:.*}", 2, 1.234567));
+    /// write!(buffer, "{:.*}", 2, 1.234567)?;
     /// // turns into this:
-    /// try!(buffer.write_fmt(format_args!("{:.*}", 2, 1.234567)));
+    /// buffer.write_fmt(format_args!("{:.*}", 2, 1.234567))?;
     /// # Ok(())
     /// # }
     /// ```
@@ -1037,12 +1037,12 @@ pub trait Write {
     /// use std::fs::File;
     ///
     /// # fn foo() -> std::io::Result<()> {
-    /// let mut buffer = try!(File::create("foo.txt"));
+    /// let mut buffer = File::create("foo.txt")?;
     ///
     /// let reference = buffer.by_ref();
     ///
     /// // we can use reference just like our original buffer
-    /// try!(reference.write_all(b"some bytes"));
+    /// reference.write_all(b"some bytes")?;
     /// # Ok(())
     /// # }
     /// ```
@@ -1069,10 +1069,10 @@ pub trait Write {
 /// use std::io::SeekFrom;
 ///
 /// # fn foo() -> io::Result<()> {
-/// let mut f = try!(File::open("foo.txt"));
+/// let mut f = File::open("foo.txt")?;
 ///
 /// // move the cursor 42 bytes from the start of the file
-/// try!(f.seek(SeekFrom::Start(42)));
+/// f.seek(SeekFrom::Start(42))?;
 /// # Ok(())
 /// # }
 /// ```
@@ -1193,7 +1193,7 @@ fn read_until<R: BufRead + ?Sized>(r: &mut R, delim: u8, buf: &mut Vec<u8>)
 /// use std::fs::File;
 ///
 /// # fn foo() -> io::Result<()> {
-/// let f = try!(File::open("foo.txt"));
+/// let f = File::open("foo.txt")?;
 /// let f = BufReader::new(f);
 ///
 /// for line in f.lines() {
@@ -1307,7 +1307,7 @@ pub trait BufRead: Read {
     /// let mut stdin = stdin.lock();
     /// let mut buffer = Vec::new();
     ///
-    /// try!(stdin.read_until(b'a', &mut buffer));
+    /// stdin.read_until(b'a', &mut buffer)?;
     ///
     /// println!("{:?}", buffer);
     /// # Ok(())
@@ -1526,7 +1526,7 @@ impl<T> Take<T> {
     /// use std::fs::File;
     ///
     /// # fn foo() -> io::Result<()> {
-    /// let f = try!(File::open("foo.txt"));
+    /// let f = File::open("foo.txt")?;
     ///
     /// // read at most five bytes
     /// let handle = f.take(5);
@@ -1548,11 +1548,11 @@ impl<T> Take<T> {
     /// use std::fs::File;
     ///
     /// # fn foo() -> io::Result<()> {
-    /// let mut file = try!(File::open("foo.txt"));
+    /// let mut file = File::open("foo.txt")?;
     ///
     /// let mut buffer = [0; 5];
     /// let mut handle = file.take(5);
-    /// try!(handle.read(&mut buffer));
+    /// handle.read(&mut buffer)?;
     ///
     /// let file = handle.into_inner();
     /// # Ok(())

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -205,8 +205,7 @@
 //!
 //! Last, but certainly not least, is [`io::Result`]. This type is used
 //! as the return type of many `std::io` functions that can cause an error, and
-//! can be returned from your own functions as well. Many of the examples in this
-//! module use the [`try!`] macro:
+//! can be returned from your own functions as well.
 //!
 //! ```
 //! use std::io;
@@ -250,7 +249,6 @@
 //! [`println!`]: ../macro.println.html
 //! [`Lines`]: struct.Lines.html
 //! [`io::Result`]: type.Result.html
-//! [`try!`]: ../macro.try.html
 //! [`read()`]: trait.Read.html#tymethod.read
 
 #![stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -182,7 +182,7 @@ pub struct StdinLock<'a> {
 ///
 /// # fn foo() -> io::Result<String> {
 /// let mut buffer = String::new();
-/// try!(io::stdin().read_to_string(&mut buffer));
+/// io::stdin().read_to_string(&mut buffer)?;
 /// # Ok(buffer)
 /// # }
 /// ```
@@ -197,7 +197,7 @@ pub struct StdinLock<'a> {
 /// let stdin = io::stdin();
 /// let mut handle = stdin.lock();
 ///
-/// try!(handle.read_to_string(&mut buffer));
+/// handle.read_to_string(&mut buffer)?;
 /// # Ok(buffer)
 /// # }
 /// ```
@@ -239,7 +239,7 @@ impl Stdin {
     /// let stdin = io::stdin();
     /// let mut handle = stdin.lock();
     ///
-    /// try!(handle.read_to_string(&mut buffer));
+    /// handle.read_to_string(&mut buffer)?;
     /// # Ok(buffer)
     /// # }
     /// ```
@@ -374,7 +374,7 @@ pub struct StdoutLock<'a> {
 /// use std::io::{self, Write};
 ///
 /// # fn foo() -> io::Result<()> {
-/// try!(io::stdout().write(b"hello world"));
+/// io::stdout().write(b"hello world")?;
 ///
 /// # Ok(())
 /// # }
@@ -389,7 +389,7 @@ pub struct StdoutLock<'a> {
 /// let stdout = io::stdout();
 /// let mut handle = stdout.lock();
 ///
-/// try!(handle.write(b"hello world"));
+/// handle.write(b"hello world")?;
 ///
 /// # Ok(())
 /// # }
@@ -427,7 +427,7 @@ impl Stdout {
     /// let stdout = io::stdout();
     /// let mut handle = stdout.lock();
     ///
-    /// try!(handle.write(b"hello world"));
+    /// handle.write(b"hello world")?;
     ///
     /// # Ok(())
     /// # }
@@ -510,7 +510,7 @@ pub struct StderrLock<'a> {
 /// use std::io::{self, Write};
 ///
 /// # fn foo() -> io::Result<()> {
-/// try!(io::stderr().write(b"hello world"));
+/// io::stderr().write(b"hello world")?;
 ///
 /// # Ok(())
 /// # }
@@ -525,7 +525,7 @@ pub struct StderrLock<'a> {
 /// let stderr = io::stderr();
 /// let mut handle = stderr.lock();
 ///
-/// try!(handle.write(b"hello world"));
+/// handle.write(b"hello world")?;
 ///
 /// # Ok(())
 /// # }
@@ -562,7 +562,7 @@ impl Stderr {
     ///     let stderr = io::stderr();
     ///     let mut handle = stderr.lock();
     ///
-    ///     try!(handle.write(b"hello world"));
+    ///     handle.write(b"hello world")?;
     ///
     ///     Ok(())
     /// }

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -37,7 +37,7 @@ use io::{self, Read, Write, ErrorKind, BufRead};
 /// let mut reader: &[u8] = b"hello";
 /// let mut writer: Vec<u8> = vec![];
 ///
-/// try!(io::copy(&mut reader, &mut writer));
+/// io::copy(&mut reader, &mut writer)?;
 ///
 /// assert_eq!(reader, &writer[..]);
 /// # Ok(())

--- a/src/libstd/net/mod.rs
+++ b/src/libstd/net/mod.rs
@@ -129,7 +129,7 @@ impl fmt::Debug for LookupHost {
 /// use std::net;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// for host in try!(net::lookup_host("rust-lang.org")) {
+/// for host in net::lookup_host("rust-lang.org")? {
 ///     println!("found address: {}", host);
 /// }
 /// # Ok(())

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -28,16 +28,16 @@ use time::Duration;
 ///
 /// # fn foo() -> std::io::Result<()> {
 /// {
-///     let mut socket = try!(UdpSocket::bind("127.0.0.1:34254"));
+///     let mut socket = UdpSocket::bind("127.0.0.1:34254")?;
 ///
 ///     // read from the socket
 ///     let mut buf = [0; 10];
-///     let (amt, src) = try!(socket.recv_from(&mut buf));
+///     let (amt, src) = socket.recv_from(&mut buf)?;
 ///
 ///     // send a reply to the socket we received data from
 ///     let buf = &mut buf[..amt];
 ///     buf.reverse();
-///     try!(socket.send_to(buf, &src));
+///     socket.send_to(buf, &src)?;
 ///     # Ok(())
 /// } // the socket is closed here
 /// # }

--- a/src/libstd/sys/redox/ext/fs.rs
+++ b/src/libstd/sys/redox/ext/fs.rs
@@ -30,8 +30,8 @@ pub trait PermissionsExt {
     /// use std::fs::File;
     /// use std::os::unix::fs::PermissionsExt;
     ///
-    /// let f = try!(File::create("foo.txt"));
-    /// let metadata = try!(f.metadata());
+    /// let f = File::create("foo.txt")?;
+    /// let metadata = f.metadata()?;
     /// let permissions = metadata.permissions();
     ///
     /// println!("permissions: {}", permissions.mode());
@@ -47,8 +47,8 @@ pub trait PermissionsExt {
     /// use std::fs::File;
     /// use std::os::unix::fs::PermissionsExt;
     ///
-    /// let f = try!(File::create("foo.txt"));
-    /// let metadata = try!(f.metadata());
+    /// let f = File::create("foo.txt")?;
+    /// let metadata = f.metadata()?;
     /// let mut permissions = metadata.permissions();
     ///
     /// permissions.set_mode(0o644); // Read/write for owner and read for others.
@@ -260,7 +260,7 @@ impl FileTypeExt for fs::FileType {
 /// use std::os::unix::fs;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// try!(fs::symlink("a.txt", "b.txt"));
+/// fs::symlink("a.txt", "b.txt")?;
 /// # Ok(())
 /// # }
 /// ```

--- a/src/libstd/sys/unix/ext/fs.rs
+++ b/src/libstd/sys/unix/ext/fs.rs
@@ -77,8 +77,8 @@ pub trait PermissionsExt {
     /// use std::fs::File;
     /// use std::os::unix::fs::PermissionsExt;
     ///
-    /// let f = try!(File::create("foo.txt"));
-    /// let metadata = try!(f.metadata());
+    /// let f = File::create("foo.txt")?;
+    /// let metadata = f.metadata()?;
     /// let permissions = metadata.permissions();
     ///
     /// println!("permissions: {}", permissions.mode());
@@ -94,8 +94,8 @@ pub trait PermissionsExt {
     /// use std::fs::File;
     /// use std::os::unix::fs::PermissionsExt;
     ///
-    /// let f = try!(File::create("foo.txt"));
-    /// let metadata = try!(f.metadata());
+    /// let f = File::create("foo.txt")?;
+    /// let metadata = f.metadata()?;
     /// let mut permissions = metadata.permissions();
     ///
     /// permissions.set_mode(0o644); // Read/write for owner and read for others.
@@ -335,7 +335,7 @@ impl DirEntryExt for fs::DirEntry {
 /// use std::os::unix::fs;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// try!(fs::symlink("a.txt", "b.txt"));
+/// fs::symlink("a.txt", "b.txt")?;
 /// # Ok(())
 /// # }
 /// ```

--- a/src/libstd/sys/windows/ext/fs.rs
+++ b/src/libstd/sys/windows/ext/fs.rs
@@ -257,7 +257,7 @@ impl MetadataExt for Metadata {
 /// use std::os::windows::fs;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// try!(fs::symlink_file("a.txt", "b.txt"));
+/// fs::symlink_file("a.txt", "b.txt")?;
 /// # Ok(())
 /// # }
 /// ```
@@ -278,7 +278,7 @@ pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q)
 /// use std::os::windows::fs;
 ///
 /// # fn foo() -> std::io::Result<()> {
-/// try!(fs::symlink_file("a", "b"));
+/// fs::symlink_file("a", "b")?;
 /// # Ok(())
 /// # }
 /// ```


### PR DESCRIPTION
See #38644.

For the record, I used the following Perl one-liner and then manually fixed a couple of things it got wrong:

    $ perl -p -i -e 's#(///.*)try!\((.*)\)#$1$2?#' src/libstd/**/*.rs