### PR TITLE
rustbuild: Move pretty test suites to host-only

### DIFF
--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -254,13 +254,6 @@ pub fn build_rules(build: &Build) -> Rules {
         suite("check-incremental", "src/test/incremental", "incremental",
               "incremental");
         suite("check-ui", "src/test/ui", "ui", "ui");
-        suite("check-pretty", "src/test/pretty", "pretty", "pretty");
-        suite("check-pretty-rpass", "src/test/run-pass/pretty", "pretty",
-              "run-pass");
-        suite("check-pretty-rfail", "src/test/run-pass/pretty", "pretty",
-              "run-fail");
-        suite("check-pretty-valgrind", "src/test/run-pass-valgrind", "pretty",
-              "run-pass-valgrind");
     }
 
     if build.config.build.contains("msvc") {
@@ -307,6 +300,13 @@ pub fn build_rules(build: &Build) -> Rules {
               "compile-fail", "compile-fail-fulldeps");
         suite("check-rmake", "src/test/run-make", "run-make", "run-make");
         suite("check-rustdoc", "src/test/rustdoc", "rustdoc", "rustdoc");
+        suite("check-pretty", "src/test/pretty", "pretty", "pretty");
+        suite("check-pretty-rpass", "src/test/run-pass/pretty", "pretty",
+              "run-pass");
+        suite("check-pretty-rfail", "src/test/run-pass/pretty", "pretty",
+              "run-fail");
+        suite("check-pretty-valgrind", "src/test/run-pass-valgrind", "pretty",
+              "run-pass-valgrind");
         suite("check-pretty-rpass-full", "src/test/run-pass-fulldeps",
               "pretty", "run-pass-fulldeps");
         suite("check-pretty-rfail-full", "src/test/run-fail-fulldeps",


### PR DESCRIPTION
In an ongoing effort to optimize the runtime of the Android cross builder this
commit updates the pretty test suites to run only for host platforms, not for
target platforms as well. This means we'll still keep running all the suites but
we'll only run them for configured hosts, not for configured targets. This
notably means that we won't be running these suites on Android or musl targets,
for example.