### PR TITLE
rustbuild: Don't run pretty tests by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - env: IMAGE=i686-gnu-nopt
     - env: IMAGE=x86_64-freebsd
     - env: IMAGE=x86_64-gnu
-    - env: IMAGE=x86_64-gnu-cargotest
+    - env: IMAGE=x86_64-gnu-aux
     - env: IMAGE=x86_64-gnu-debug
     - env: IMAGE=x86_64-gnu-nopt
     - env: IMAGE=x86_64-gnu-make

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ environment:
   # MSVC cargotest
   - MSYS_BITS: 64
     NO_VENDOR: 1
-    RUST_CHECK_TARGET: check-cargotest
+    RUST_CHECK_TARGET: check-aux
     RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc
 
   # 32/64-bit MinGW builds.

--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -51,8 +51,16 @@ standalone-docs:
 	$(Q)$(BOOTSTRAP) doc src/doc $(BOOTSTRAP_ARGS)
 check:
 	$(Q)$(BOOTSTRAP) test $(BOOTSTRAP_ARGS)
-check-cargotest:
-	$(Q)$(BOOTSTRAP) test src/tools/cargotest $(BOOTSTRAP_ARGS)
+check-aux:
+	$(Q)$(BOOTSTRAP) test \
+		src/tools/cargotest \
+		src/test/pretty \
+		src/test/run-pass/pretty \
+		src/test/run-fail/pretty \
+		src/test/run-pass-valgrind/pretty \
+		src/test/run-pass-fulldeps/pretty \
+		src/test/run-fail-fulldeps/pretty \
+		$(BOOTSTRAP_ARGS)
 dist:
 	$(Q)$(BOOTSTRAP) dist $(BOOTSTRAP_ARGS)
 distcheck:

--- a/src/bootstrap/step.rs
+++ b/src/bootstrap/step.rs
@@ -221,7 +221,7 @@ pub fn build_rules(build: &Build) -> Rules {
     //
     // Various unit tests and tests suites we can run
     {
-        let mut suite = |name, path, dir, mode| {
+        let mut suite = |name, path, mode, dir| {
             rules.test(name, path)
                  .dep(|s| s.name("libtest"))
                  .dep(|s| s.name("tool-compiletest").target(s.host))
@@ -233,9 +233,9 @@ pub fn build_rules(build: &Build) -> Rules {
                          Step::noop()
                      }
                  })
-                 .default(true)
+                 .default(mode != "pretty") // pretty tests don't run everywhere
                  .run(move |s| {
-                     check::compiletest(build, &s.compiler(), s.target, dir, mode)
+                     check::compiletest(build, &s.compiler(), s.target, mode, dir)
                  });
         };
 
@@ -254,12 +254,13 @@ pub fn build_rules(build: &Build) -> Rules {
         suite("check-incremental", "src/test/incremental", "incremental",
               "incremental");
         suite("check-ui", "src/test/ui", "ui", "ui");
+
         suite("check-pretty", "src/test/pretty", "pretty", "pretty");
         suite("check-pretty-rpass", "src/test/run-pass/pretty", "pretty",
               "run-pass");
-        suite("check-pretty-rfail", "src/test/run-pass/pretty", "pretty",
+        suite("check-pretty-rfail", "src/test/run-fail/pretty", "pretty",
               "run-fail");
-        suite("check-pretty-valgrind", "src/test/run-pass-valgrind", "pretty",
+        suite("check-pretty-valgrind", "src/test/run-pass-valgrind/pretty", "pretty",
               "run-pass-valgrind");
     }
 
@@ -290,14 +291,14 @@ pub fn build_rules(build: &Build) -> Rules {
                                          s.target));
 
     {
-        let mut suite = |name, path, dir, mode| {
+        let mut suite = |name, path, mode, dir| {
             rules.test(name, path)
                  .dep(|s| s.name("librustc"))
                  .dep(|s| s.name("tool-compiletest").target(s.host))
-                 .default(true)
+                 .default(mode != "pretty")
                  .host(true)
                  .run(move |s| {
-                     check::compiletest(build, &s.compiler(), s.target, dir, mode)
+                     check::compiletest(build, &s.compiler(), s.target, mode, dir)
                  });
         };
 
@@ -307,9 +308,10 @@ pub fn build_rules(build: &Build) -> Rules {
               "compile-fail", "compile-fail-fulldeps");
         suite("check-rmake", "src/test/run-make", "run-make", "run-make");
         suite("check-rustdoc", "src/test/rustdoc", "rustdoc", "rustdoc");
-        suite("check-pretty-rpass-full", "src/test/run-pass-fulldeps",
+
+        suite("check-pretty-rpass-full", "src/test/run-pass-fulldeps/pretty",
               "pretty", "run-pass-fulldeps");
-        suite("check-pretty-rfail-full", "src/test/run-fail-fulldeps",
+        suite("check-pretty-rfail-full", "src/test/run-fail-fulldeps/pretty",
               "pretty", "run-fail-fulldeps");
     }
 

--- a/src/ci/docker/x86_64-gnu-aux/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-aux/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-ini
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu
-ENV RUST_CHECK_TARGET check-cargotest
+ENV RUST_CHECK_TARGET check-aux
 ENV NO_VENDOR 1
 RUN mkdir /tmp/obj
 RUN chmod 777 /tmp/obj


### PR DESCRIPTION
This commit relegates all pretty tests to not get run by default and rather get
run as part of an "aux" test suite. This "aux" suite is renamed from the old
"cargotest" suite to just collect tests that don't need to run everywhere but
should at least pass on Unix/Windows.