### PR TITLE
appveyor: Attempt to debug flaky test runs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -96,6 +96,13 @@ install:
   - 7z x -y sccache.tar > nul
   - set PATH=%PATH%;%CD%\sccache2
 
+  # Help debug some handle issues on AppVeyor
+  - ps: Invoke-WebRequest -Uri https://download.sysinternals.com/files/Handle.zip -OutFile handle.zip
+  - mkdir handle
+  - ps: Expand-Archive handle.zip -dest handle
+  - set PATH=%PATH%;%CD%\handle
+  - handle.exe -accepteula -help
+
 test_script:
   - git submodule update --init
   - set SRC=.


### PR DESCRIPTION
This commit is an attempt to debug #38620 since we're unable to reproduce it
locally. It follows the [advice] of those with AppVeyor to use the `handle.exe`
tool to try to debug what processes have a handle to the file open.

This won't be guaranteed to actually help us, but hopefully it'll diagnose
something at some point?

[advice]: http://help.appveyor.com/discussions/questions/2898