### PR TITLE
cargotest: Add xsv to tested crates

### DIFF
--- a/src/tools/cargotest/main.rs
+++ b/src/tools/cargotest/main.rs
@@ -52,6 +52,12 @@ const TEST_REPOS: &'static [Test] = &[
         sha: "999001b223152441198f117a68fb81f57bc086dd",
         lock: None,
     },
+    Test {
+        name: "xsv",
+        repo: "https://github.com/BurntSushi/xsv",
+        sha: "a9a7163f2a2953cea426fee1216bec914fe2f56a",
+        lock: None,
+    },
 ];
 
 fn main() {


### PR DESCRIPTION
This was intended to land in #37149 but I ended up backing it out to land the
rollup (#38697) last night as I was itching to do so. This morning though xsv
has been fixed now (BurntSushi/xsv#53) so we should be able to add it!