### PR TITLE
Added RefCell methods `update` and `update_in_place`

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -489,6 +489,30 @@ impl<T> RefCell<T> {
         debug_assert!(self.borrow.get() == UNUSED);
         unsafe { self.value.into_inner() }
     }
+
+    /// Updates the underlying data by applying the supplied function, which must return a new
+    /// value without mutating the old value.
+    ///
+    /// This lets you treat an update atomically, which helps prevent accidentally borrowing the
+    /// data twice, avoiding possible panics.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(refcell_update)]
+    /// use std::cell::RefCell;
+    ///
+    /// let c = RefCell::new(5);
+    /// c.update(|n| n + 1);
+    ///
+    /// assert_eq!(c, RefCell::new(6));
+    /// ```
+    #[unstable(feature = "refcell_update", issue = "38741")]
+    #[inline]
+    pub fn update<F> (&self, f: F) where F: Fn(&T) -> T {
+        let mut x = self.borrow_mut();
+        *x = f(&x);
+    }
 }
 
 impl<T: ?Sized> RefCell<T> {
@@ -740,6 +764,30 @@ impl<T: ?Sized> RefCell<T> {
         unsafe {
             &mut *self.value.get()
         }
+    }
+
+    /// Updates the underlying data by applying the supplied function, which is expected to mutate
+    /// the data.
+    ///
+    /// This lets you treat an update atomically, which helps prevent accidentally borrowing the
+    /// data twice, avoiding possible panics.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(refcell_update)]
+    /// use std::cell::RefCell;
+    ///
+    /// let c = RefCell::new(5);
+    /// c.update_in_place(|n| *n += 1);
+    ///
+    /// assert_eq!(c, RefCell::new(6));
+    /// ```
+    #[unstable(feature = "refcell_update", issue = "38741")]
+    #[inline]
+    pub fn update_in_place<F> (&self, f: F) where F: Fn(&mut T) {
+        let mut x = self.borrow_mut();
+        f(&mut x);
     }
 }
 


### PR DESCRIPTION
These two small methods help you protect yourself from accidentally mutably borrowing from a RefCell twice. This can happen easily when you need to update the data in a RefCell, when the new value depends on the old data.

The two variants are for ergonomic reasons, as you may have a method already of one form or the other. Or mutating the data in place may be more efficient sometimes.

Example usage with methods:

```Rust
struct S {
   s: u32
}

impl S {
    fn new(n: u32) -> S {
        S { s: n }
    }
    fn incremented(&self) -> S {
        S { s: self.s + 1 }
    }
    fn increment(&mut self) {
        self.s += 1;
    }
}


fn main() {
    let rc = RefCell::new(S::new(0));
    
    println!("{:?}", rc.borrow().s); // 0
    
    rc.update(S::incremented);
    rc.update_in_place(S::increment);
    
    println!("{:?}", rc.borrow().s); // 2
}

```

As a slightly contrived example of a problem case, the following code panics because the first borrow is still alive when the next one is requested:

```Rust
use std::cell::RefCell;

struct C {
    initial_val: u32,
    val: RefCell<u32>
}

impl C {
    fn new(n: u32) -> C {
        C { val: RefCell::new(n), initial_val: n }
    }
    
    fn reset(&self){
        let mut v = self.val.borrow_mut();
        *v = self.initial_val;
    }
    
    fn tick(&self){
        let mut v = self.val.borrow_mut();
        if *v > 0 {
            *v -= 1;
        }
        
        if *v == 0 {
            self.reset(); // problem: reset() also mutably borrows self.val
        }
    }
}

fn main() {
    let n = 3u32;
    let c = C::new(n);
    c.tick(); // panics if n < 2
}
```

This bug can be fixed by putting the borrow in its own block, so that it's dropped before it's needed again. But that not always obvious and might not be fixed if this only happens in an edge case or triggered by an untested error condition. 

Using `update_in_place`, there is no possibility to make this mistake:

```Rust
    fn tick(&self){
        self.val.update_in_place(|v| if *v > 0 {
            *v -= 1;
        });
        if *self.val.borrow() == 0 {
            self.reset();
        }
    }
```