### PR TITLE
rustbuild: check for final stage properly and so on

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -537,6 +537,14 @@ impl Config {
     pub fn very_verbose(&self) -> bool {
         self.verbose > 1
     }
+
+    pub fn final_stage(&self) -> u32 {
+        if self.full_bootstrap {
+            2
+        } else {
+            1
+        }
+    }
 }
 
 #[cfg(not(windows))]

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -315,8 +315,8 @@ pub fn analysis(build: &Build, compiler: &Compiler, target: &str) {
         println!("\tskipping - not a build host");
         return
     }
-    if compiler.stage != 2 {
-        println!("\tskipping - not stage2");
+    if !compiler.is_final_stage(build) {
+        println!("\tskipping - not final stage");
         return
     }
 

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -910,6 +910,10 @@ impl Build {
             compiler.stage >= 2 &&
             self.config.host.iter().any(|h| h == target)
     }
+
+    fn final_stage(&self) -> u32 {
+        self.config.final_stage()
+    }
 }
 
 impl<'a> Compiler<'a> {


### PR DESCRIPTION
The current non-full-bootstrap build is *not* stopped at stage1, but rather it's faking a stage2 and making adjustments for that here and there with the `force_use_stage1` usage. This is causing major headache and for example, contributed to the partial fix of #38736 which fixed the envvar setup in `lib.rs` but failed to account for the broken contract in `dist.rs`. I was in a hurry so I didn't actually run `./x.py dist` but instead was only looking for the environment variable, so that oversight also went unnoticed. The fact that the bug even survived code review and got `r+`'d is also highly indicative of the situation right now.

Let's clean this up by properly stopping at stage1 for non-full-bootstrap builds. Stage dependency is properly indicated to the `dist` rules, and default stage for top-level steps are configured from build config instead of being hardcoded to 2.

With that I did a `./x.py dist` (with channel set to `nightly` to observe `dist-analysis`) and IMO it's working as desired:

bootstrap plan of `dist`:
```
bootstrap top targets:
        Step { name: "dist-analysis", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "dist-rustc", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "dist-docs", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "dist-mingw", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "dist-src", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "dist-std", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
bootstrap build plan:
        Step { name: "create-sysroot", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "startup-objects", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "create-sysroot", stage: 0, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "rustc", stage: 0, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "startup-objects", stage: 0, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "build-crate-std_shim", stage: 0, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "libstd-link", stage: 0, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "libstd", stage: 0, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "build-crate-test_shim", stage: 0, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "libtest-link", stage: 0, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "libtest", stage: 0, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "llvm", stage: 0, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "build-crate-rustc-main", stage: 0, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "librustc-link", stage: 0, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "librustc", stage: 0, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "rustc", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "build-crate-std_shim", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "libstd-link", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "build-crate-test_shim", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "libtest-link", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "build-crate-rustc-main", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "librustc-link", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "dist-std", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "dist-analysis", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "dist-rustc", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "tool-rustbook", stage: 0, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "doc-book", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "doc-nomicon", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "doc-crate-std_shim", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "tool-error-index", stage: 0, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "doc-error-index", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "doc-standalone", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "dist-docs", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "dist-mingw", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
        Step { name: "dist-src", stage: 1, host: "x86_64-unknown-linux-gnu", target: "x86_64-unknown-linux-gnu" }
```

`ls build/dist`:

```
doc
rust-analysis-nightly-x86_64-unknown-linux-gnu.tar.gz
rustc-nightly-src.tar.gz
rustc-nightly-x86_64-unknown-linux-gnu.tar.gz
rust-docs-nightly-x86_64-unknown-linux-gnu.tar.gz
rust-src-nightly.tar.gz
rust-std-nightly-x86_64-unknown-linux-gnu.tar.gz
```

And with that the `force_use_stage1` workaround could be dropped altogether, but I'm yet to do that. Hopefully we can at least get a `2017-01-02` nightly for everyone's rustup pleasure...

r? @alexcrichton (Sorry for so many rustbuild PRs and bugs introduced by my forgetfulness. I'm always trying to understand everything up there but sometimes I do forget details.)