### PR TITLE
Additional cleanup to rustc_trans

### DIFF
--- a/src/librustc_trans/abi.rs
+++ b/src/librustc_trans/abi.rs
@@ -294,9 +294,7 @@ impl ArgType {
         }
     }
 
-    pub fn store_fn_arg(
-        &self, bcx: &Builder, idx: &mut usize, dst: ValueRef
-    ) {
+    pub fn store_fn_arg(&self, bcx: &Builder, idx: &mut usize, dst: ValueRef) {
         if self.pad.is_some() {
             *idx += 1;
         }

--- a/src/librustc_trans/abi.rs
+++ b/src/librustc_trans/abi.rs
@@ -10,7 +10,8 @@
 
 use llvm::{self, ValueRef, Integer, Pointer, Float, Double, Struct, Array, Vector, AttributePlace};
 use base;
-use common::{type_is_fat_ptr, BlockAndBuilder, C_uint};
+use builder::Builder;
+use common::{type_is_fat_ptr, C_uint};
 use context::CrateContext;
 use cabi_x86;
 use cabi_x86_64;
@@ -236,7 +237,7 @@ impl ArgType {
     /// lvalue for the original Rust type of this argument/return.
     /// Can be used for both storing formal arguments into Rust variables
     /// or results of call/invoke instructions into their destinations.
-    pub fn store(&self, bcx: &BlockAndBuilder, mut val: ValueRef, dst: ValueRef) {
+    pub fn store(&self, bcx: &Builder, mut val: ValueRef, dst: ValueRef) {
         if self.is_ignore() {
             return;
         }
@@ -269,7 +270,7 @@ impl ArgType {
                 //   bitcasting to the struct type yields invalid cast errors.
 
                 // We instead thus allocate some scratch space...
-                let llscratch = bcx.fcx().alloca(ty, "abi_cast");
+                let llscratch = bcx.alloca(ty, "abi_cast");
                 base::Lifetime::Start.call(bcx, llscratch);
 
                 // ...where we first store the value...
@@ -293,14 +294,16 @@ impl ArgType {
         }
     }
 
-    pub fn store_fn_arg(&self, bcx: &BlockAndBuilder, idx: &mut usize, dst: ValueRef) {
+    pub fn store_fn_arg(
+        &self, bcx: &Builder, idx: &mut usize, dst: ValueRef
+    ) {
         if self.pad.is_some() {
             *idx += 1;
         }
         if self.is_ignore() {
             return;
         }
-        let val = llvm::get_param(bcx.fcx().llfn, *idx as c_uint);
+        let val = llvm::get_param(bcx.llfn(), *idx as c_uint);
         *idx += 1;
         self.store(bcx, val, dst);
     }

--- a/src/librustc_trans/adt.rs
+++ b/src/librustc_trans/adt.rs
@@ -359,7 +359,7 @@ pub fn trans_get_discr<'a, 'tcx>(
         layout::RawNullablePointer { nndiscr, .. } => {
             let cmp = if nndiscr == 0 { IntEQ } else { IntNE };
             let llptrty = type_of::sizing_type_of(bcx.ccx,
-                monomorphize::field_ty(bcx.ccx.tcx(), substs,
+                monomorphize::field_ty(bcx.tcx(), substs,
                 &def.variants[nndiscr as usize].fields[0]));
             bcx.icmp(cmp, bcx.load(scrutinee), C_null(llptrty))
         }
@@ -486,7 +486,7 @@ pub fn trans_set_discr<'a, 'tcx>(
 }
 
 fn target_sets_discr_via_memset<'a, 'tcx>(bcx: &Builder<'a, 'tcx>) -> bool {
-    bcx.ccx.sess().target.target.arch == "arm" || bcx.ccx.sess().target.target.arch == "aarch64"
+    bcx.sess().target.target.arch == "arm" || bcx.sess().target.target.arch == "aarch64"
 }
 
 fn assert_discr_in_range(min: Disr, max: Disr, discr: Disr) {
@@ -524,7 +524,7 @@ pub fn trans_field_ptr<'a, 'tcx>(
         }
         layout::General { discr: d, ref variants, .. } => {
             let mut fields = compute_fields(bcx.ccx, t, discr.0 as usize, false);
-            fields.insert(0, d.to_ty(&bcx.ccx.tcx(), false));
+            fields.insert(0, d.to_ty(&bcx.tcx(), false));
             struct_field_ptr(bcx, &variants[discr.0 as usize],
              &fields,
              val, ix + 1, true)

--- a/src/librustc_trans/asm.rs
+++ b/src/librustc_trans/asm.rs
@@ -62,7 +62,7 @@ pub fn trans_inline_asm<'a, 'tcx>(
 
     // Default per-arch clobbers
     // Basically what clang does
-    let arch_clobbers = match &bcx.ccx.sess().target.target.arch[..] {
+    let arch_clobbers = match &bcx.sess().target.target.arch[..] {
         "x86" | "x86_64" => vec!["~{dirflag}", "~{fpsr}", "~{flags}"],
         _                => Vec::new()
     };

--- a/src/librustc_trans/asm.rs
+++ b/src/librustc_trans/asm.rs
@@ -15,6 +15,7 @@ use base;
 use common::*;
 use type_of;
 use type_::Type;
+use builder::Builder;
 
 use rustc::hir;
 use rustc::ty::Ty;
@@ -25,7 +26,7 @@ use libc::{c_uint, c_char};
 
 // Take an inline assembly expression and splat it out via LLVM
 pub fn trans_inline_asm<'a, 'tcx>(
-    bcx: &BlockAndBuilder<'a, 'tcx>,
+    bcx: &Builder<'a, 'tcx>,
     ia: &hir::InlineAsm,
     outputs: Vec<(ValueRef, Ty<'tcx>)>,
     mut inputs: Vec<ValueRef>
@@ -61,7 +62,7 @@ pub fn trans_inline_asm<'a, 'tcx>(
 
     // Default per-arch clobbers
     // Basically what clang does
-    let arch_clobbers = match &bcx.sess().target.target.arch[..] {
+    let arch_clobbers = match &bcx.ccx.sess().target.target.arch[..] {
         "x86" | "x86_64" => vec!["~{dirflag}", "~{fpsr}", "~{flags}"],
         _                => Vec::new()
     };

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -610,7 +610,7 @@ pub fn trans_ctor_shim<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     let sig = ccx.tcx().erase_late_bound_regions_and_normalize(&ctor_ty.fn_sig());
     let fn_ty = FnType::new(ccx, Abi::Rust, &sig, &[]);
 
-    let bcx = Builder::entry_block(ccx, llfn);
+    let bcx = Builder::new_block(ccx, llfn, "entry-block");
     if !fn_ty.ret.is_ignore() {
         // But if there are no nested returns, we skip the indirection
         // and have a single retslot

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -38,7 +38,7 @@ use rustc::hir::def_id::{DefId, LOCAL_CRATE};
 use middle::lang_items::StartFnLangItem;
 use rustc::ty::subst::Substs;
 use rustc::traits;
-use rustc::ty::{self, Ty, TyCtxt, TypeFoldable};
+use rustc::ty::{self, Ty, TyCtxt};
 use rustc::ty::adjustment::CustomCoerceUnsized;
 use rustc::dep_graph::{DepNode, WorkProduct};
 use rustc::hir::map as hir_map;
@@ -51,7 +51,7 @@ use adt;
 use attributes;
 use builder::Builder;
 use callee::{Callee};
-use common::{BlockAndBuilder, C_bool, C_bytes_in_context, C_i32, C_uint};
+use common::{C_bool, C_bytes_in_context, C_i32, C_uint};
 use collector::{self, TransItemCollectionMode};
 use common::{C_struct_in_context, C_u64, C_undef};
 use common::{CrateContext, FunctionContext};
@@ -161,7 +161,7 @@ pub fn bin_op_to_fcmp_predicate(op: hir::BinOp_) -> llvm::RealPredicate {
 }
 
 pub fn compare_simd_types<'a, 'tcx>(
-    bcx: &BlockAndBuilder<'a, 'tcx>,
+    bcx: &Builder<'a, 'tcx>,
     lhs: ValueRef,
     rhs: ValueRef,
     t: Ty<'tcx>,
@@ -218,7 +218,7 @@ pub fn unsized_info<'ccx, 'tcx>(ccx: &CrateContext<'ccx, 'tcx>,
 
 /// Coerce `src` to `dst_ty`. `src_ty` must be a thin pointer.
 pub fn unsize_thin_ptr<'a, 'tcx>(
-    bcx: &BlockAndBuilder<'a, 'tcx>,
+    bcx: &Builder<'a, 'tcx>,
     src: ValueRef,
     src_ty: Ty<'tcx>,
     dst_ty: Ty<'tcx>
@@ -242,7 +242,7 @@ pub fn unsize_thin_ptr<'a, 'tcx>(
 
 /// Coerce `src`, which is a reference to a value of type `src_ty`,
 /// to a value of type `dst_ty` and store the result in `dst`
-pub fn coerce_unsized_into<'a, 'tcx>(bcx: &BlockAndBuilder<'a, 'tcx>,
+pub fn coerce_unsized_into<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
                                      src: ValueRef,
                                      src_ty: Ty<'tcx>,
                                      dst: ValueRef,
@@ -272,10 +272,10 @@ pub fn coerce_unsized_into<'a, 'tcx>(bcx: &BlockAndBuilder<'a, 'tcx>,
             assert_eq!(def_a, def_b);
 
             let src_fields = def_a.variants[0].fields.iter().map(|f| {
-                monomorphize::field_ty(bcx.tcx(), substs_a, f)
+                monomorphize::field_ty(bcx.ccx.tcx(), substs_a, f)
             });
             let dst_fields = def_b.variants[0].fields.iter().map(|f| {
-                monomorphize::field_ty(bcx.tcx(), substs_b, f)
+                monomorphize::field_ty(bcx.ccx.tcx(), substs_b, f)
             });
 
             let src = adt::MaybeSizedValue::sized(src);
@@ -322,7 +322,7 @@ pub fn custom_coerce_unsize_info<'scx, 'tcx>(scx: &SharedCrateContext<'scx, 'tcx
 }
 
 pub fn cast_shift_expr_rhs(
-    cx: &BlockAndBuilder, op: hir::BinOp_, lhs: ValueRef, rhs: ValueRef
+    cx: &Builder, op: hir::BinOp_, lhs: ValueRef, rhs: ValueRef
 ) -> ValueRef {
     cast_shift_rhs(op, lhs, rhs, |a, b| cx.trunc(a, b), |a, b| cx.zext(a, b))
 }
@@ -421,7 +421,7 @@ pub fn load_ty<'a, 'tcx>(b: &Builder<'a, 'tcx>, ptr: ValueRef, t: Ty<'tcx>) -> V
 
 /// Helper for storing values in memory. Does the necessary conversion if the in-memory type
 /// differs from the type used for SSA values.
-pub fn store_ty<'a, 'tcx>(cx: &BlockAndBuilder<'a, 'tcx>, v: ValueRef, dst: ValueRef, t: Ty<'tcx>) {
+pub fn store_ty<'a, 'tcx>(cx: &Builder<'a, 'tcx>, v: ValueRef, dst: ValueRef, t: Ty<'tcx>) {
     debug!("store_ty: {:?} : {:?} <- {:?}", Value(dst), t, Value(v));
 
     if common::type_is_fat_ptr(cx.ccx, t) {
@@ -433,7 +433,7 @@ pub fn store_ty<'a, 'tcx>(cx: &BlockAndBuilder<'a, 'tcx>, v: ValueRef, dst: Valu
     }
 }
 
-pub fn store_fat_ptr<'a, 'tcx>(cx: &BlockAndBuilder<'a, 'tcx>,
+pub fn store_fat_ptr<'a, 'tcx>(cx: &Builder<'a, 'tcx>,
                                data: ValueRef,
                                extra: ValueRef,
                                dst: ValueRef,
@@ -459,7 +459,7 @@ pub fn load_fat_ptr<'a, 'tcx>(
     (ptr, meta)
 }
 
-pub fn from_immediate(bcx: &BlockAndBuilder, val: ValueRef) -> ValueRef {
+pub fn from_immediate(bcx: &Builder, val: ValueRef) -> ValueRef {
     if val_ty(val) == Type::i1(bcx.ccx) {
         bcx.zext(val, Type::i8(bcx.ccx))
     } else {
@@ -467,7 +467,7 @@ pub fn from_immediate(bcx: &BlockAndBuilder, val: ValueRef) -> ValueRef {
     }
 }
 
-pub fn to_immediate(bcx: &BlockAndBuilder, val: ValueRef, ty: Ty) -> ValueRef {
+pub fn to_immediate(bcx: &Builder, val: ValueRef, ty: Ty) -> ValueRef {
     if ty.is_bool() {
         bcx.trunc(val, Type::i1(bcx.ccx))
     } else {
@@ -523,11 +523,13 @@ pub fn call_memcpy<'a, 'tcx>(b: &Builder<'a, 'tcx>,
     b.call(memcpy, &[dst_ptr, src_ptr, size, align, volatile], None);
 }
 
-pub fn memcpy_ty<'a, 'tcx>(bcx: &BlockAndBuilder<'a, 'tcx>,
-                           dst: ValueRef,
-                           src: ValueRef,
-                           t: Ty<'tcx>,
-                           align: Option<u32>) {
+pub fn memcpy_ty<'a, 'tcx>(
+    bcx: &Builder<'a, 'tcx>,
+    dst: ValueRef,
+    src: ValueRef,
+    t: Ty<'tcx>,
+    align: Option<u32>,
+) {
     let ccx = bcx.ccx;
 
     if type_is_zero_size(ccx, t) {
@@ -551,11 +553,6 @@ pub fn call_memset<'a, 'tcx>(b: &Builder<'a, 'tcx>,
     let llintrinsicfn = b.ccx.get_intrinsic(&intrinsic_key);
     let volatile = C_bool(b.ccx, volatile);
     b.call(llintrinsicfn, &[ptr, fill_byte, size, align, volatile], None)
-}
-
-pub fn alloc_ty<'a, 'tcx>(bcx: &BlockAndBuilder<'a, 'tcx>, ty: Ty<'tcx>, name: &str) -> ValueRef {
-    assert!(!ty.has_param_types());
-    bcx.fcx().alloca(type_of::type_of(bcx.ccx, ty), name)
 }
 
 pub fn trans_instance<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, instance: Instance<'tcx>) {
@@ -623,7 +620,7 @@ pub fn trans_ctor_shim<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
             // We create an alloca to hold a pointer of type `ret.original_ty`
             // which will hold the pointer to the right alloca which has the
             // final ret value
-            fcx.alloca(fn_ty.ret.memory_ty(ccx), "sret_slot")
+            bcx.alloca(fn_ty.ret.memory_ty(ccx), "sret_slot")
         };
         let dest_val = adt::MaybeSizedValue::sized(dest); // Can return unsized value
         let mut llarg_idx = fn_ty.ret.is_indirect() as usize;
@@ -756,12 +753,7 @@ pub fn maybe_create_entry_wrapper(ccx: &CrateContext) {
         // `main` should respect same config for frame pointer elimination as rest of code
         attributes::set_frame_pointer_elimination(ccx, llfn);
 
-        let llbb = unsafe {
-            let name = CString::new("top").unwrap();
-            llvm::LLVMAppendBasicBlockInContext(ccx.llcx(), llfn, name.as_ptr())
-        };
-        let bld = Builder::with_ccx(ccx);
-        bld.position_at_end(llbb);
+        let bld = Builder::new_block(ccx, llfn, "top");
 
         debuginfo::gdb::insert_reference_to_gdb_debug_scripts_section_global(ccx, &bld);
 

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -289,8 +289,8 @@ pub fn coerce_unsized_into<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
                     continue;
                 }
 
-                let src_f = adt::trans_field_ptr(bcx, src, i);
-                let dst_f = adt::trans_field_ptr(bcx, dst, i);
+                let src_f = src.trans_field_ptr(bcx, i);
+                let dst_f = dst.trans_field_ptr(bcx, i);
                 if src_fty == dst_fty {
                     memcpy_ty(bcx, dst_f, src_f, src_fty, None);
                 } else {
@@ -632,7 +632,7 @@ pub fn trans_ctor_shim<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
         let mut llarg_idx = fn_ty.ret.is_indirect() as usize;
         let mut arg_idx = 0;
         for (i, arg_ty) in sig.inputs().iter().enumerate() {
-            let lldestptr = adt::trans_field_ptr(&bcx, dest_val, i);
+            let lldestptr = dest_val.trans_field_ptr(&bcx, i);
             let arg = &fn_ty.args[arg_idx];
             arg_idx += 1;
             if common::type_is_fat_ptr(bcx.ccx, arg_ty) {

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -272,10 +272,10 @@ pub fn coerce_unsized_into<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
             assert_eq!(def_a, def_b);
 
             let src_fields = def_a.variants[0].fields.iter().map(|f| {
-                monomorphize::field_ty(bcx.ccx.tcx(), substs_a, f)
+                monomorphize::field_ty(bcx.tcx(), substs_a, f)
             });
             let dst_fields = def_b.variants[0].fields.iter().map(|f| {
-                monomorphize::field_ty(bcx.ccx.tcx(), substs_b, f)
+                monomorphize::field_ty(bcx.tcx(), substs_b, f)
             });
 
             let src = adt::MaybeSizedValue::sized(src);

--- a/src/librustc_trans/builder.rs
+++ b/src/librustc_trans/builder.rs
@@ -19,7 +19,8 @@ use machine::llalign_of_pref;
 use type_::Type;
 use value::Value;
 use libc::{c_uint, c_char};
-use rustc::ty::{Ty, TypeFoldable};
+use rustc::ty::{Ty, TyCtxt, TypeFoldable};
+use rustc::session::Session;
 use type_of;
 
 use std::borrow::Cow;
@@ -91,6 +92,14 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         };
         builder.position_at_end(llbb);
         builder
+    }
+
+    pub fn sess(&self) -> &Session {
+        self.ccx.sess()
+    }
+
+    pub fn tcx(&self) -> TyCtxt<'a, 'tcx, 'tcx> {
+        self.ccx.tcx()
     }
 
     pub fn llfn(&self) -> ValueRef {

--- a/src/librustc_trans/builder.rs
+++ b/src/librustc_trans/builder.rs
@@ -51,10 +51,6 @@ fn noname() -> *const c_char {
 }
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {
-    pub fn entry_block(ccx: &'a CrateContext<'a, 'tcx>, llfn: ValueRef) -> Self {
-        Builder::new_block(ccx, llfn, "entry-block")
-    }
-
     pub fn new_block<'b>(ccx: &'a CrateContext<'a, 'tcx>, llfn: ValueRef, name: &'b str) -> Self {
         let builder = Builder::with_ccx(ccx);
         let llbb = unsafe {

--- a/src/librustc_trans/builder.rs
+++ b/src/librustc_trans/builder.rs
@@ -50,6 +50,10 @@ fn noname() -> *const c_char {
 }
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {
+    pub fn entry_block(ccx: &'a CrateContext<'a, 'tcx>, llfn: ValueRef) -> Self {
+        Builder::new_block(ccx, llfn, "entry-block")
+    }
+
     pub fn new_block<'b>(ccx: &'a CrateContext<'a, 'tcx>, llfn: ValueRef, name: &'b str) -> Self {
         let builder = Builder::with_ccx(ccx);
         let llbb = unsafe {

--- a/src/librustc_trans/builder.rs
+++ b/src/librustc_trans/builder.rs
@@ -80,18 +80,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         }
     }
 
-    pub fn build_new_block<'b>(&self, name: &'b str) -> Builder<'a, 'tcx> {
-        let builder = Builder::with_ccx(self.ccx);
-        let llbb = unsafe {
-            let name = CString::new(name).unwrap();
-            llvm::LLVMAppendBasicBlockInContext(
-                self.ccx.llcx(),
-                self.llfn(),
-                name.as_ptr()
-            )
-        };
-        builder.position_at_end(llbb);
-        builder
+    pub fn build_sibling_block<'b>(&self, name: &'b str) -> Builder<'a, 'tcx> {
+        Builder::new_block(self.ccx, self.llfn(), name)
     }
 
     pub fn sess(&self) -> &Session {

--- a/src/librustc_trans/builder.rs
+++ b/src/librustc_trans/builder.rs
@@ -19,12 +19,16 @@ use machine::llalign_of_pref;
 use type_::Type;
 use value::Value;
 use libc::{c_uint, c_char};
+use rustc::ty::{Ty, TypeFoldable};
+use type_of;
 
 use std::borrow::Cow;
 use std::ffi::CString;
 use std::ptr;
 use syntax_pos::Span;
 
+// All Builders must have an llfn associated with them
+#[must_use]
 pub struct Builder<'a, 'tcx: 'a> {
     pub llbuilder: BuilderRef,
     pub ccx: &'a CrateContext<'a, 'tcx>,
@@ -46,6 +50,20 @@ fn noname() -> *const c_char {
 }
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {
+    pub fn new_block<'b>(ccx: &'a CrateContext<'a, 'tcx>, llfn: ValueRef, name: &'b str) -> Self {
+        let builder = Builder::with_ccx(ccx);
+        let llbb = unsafe {
+            let name = CString::new(name).unwrap();
+            llvm::LLVMAppendBasicBlockInContext(
+                ccx.llcx(),
+                llfn,
+                name.as_ptr()
+            )
+        };
+        builder.position_at_end(llbb);
+        builder
+    }
+
     pub fn with_ccx(ccx: &'a CrateContext<'a, 'tcx>) -> Self {
         // Create a fresh builder from the crate context.
         let llbuilder = unsafe {
@@ -54,6 +72,32 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         Builder {
             llbuilder: llbuilder,
             ccx: ccx,
+        }
+    }
+
+    pub fn build_new_block<'b>(&self, name: &'b str) -> Builder<'a, 'tcx> {
+        let builder = Builder::with_ccx(self.ccx);
+        let llbb = unsafe {
+            let name = CString::new(name).unwrap();
+            llvm::LLVMAppendBasicBlockInContext(
+                self.ccx.llcx(),
+                self.llfn(),
+                name.as_ptr()
+            )
+        };
+        builder.position_at_end(llbb);
+        builder
+    }
+
+    pub fn llfn(&self) -> ValueRef {
+        unsafe {
+            llvm::LLVMGetBasicBlockParent(self.llbb())
+        }
+    }
+
+    pub fn llbb(&self) -> BasicBlockRef {
+        unsafe {
+            llvm::LLVMGetInsertBlock(self.llbuilder)
         }
     }
 
@@ -433,6 +477,19 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         unsafe {
             llvm::LLVMBuildNot(self.llbuilder, v, noname())
         }
+    }
+
+    pub fn alloca(&self, ty: Type, name: &str) -> ValueRef {
+        let builder = Builder::with_ccx(self.ccx);
+        builder.position_at_start(unsafe {
+            llvm::LLVMGetFirstBasicBlock(self.llfn())
+        });
+        builder.dynamic_alloca(ty, name)
+    }
+
+    pub fn alloca_ty(&self, ty: Ty<'tcx>, name: &str) -> ValueRef {
+        assert!(!ty.has_param_types());
+        self.alloca(type_of::type_of(self.ccx, ty), name)
     }
 
     pub fn dynamic_alloca(&self, ty: Type, name: &str) -> ValueRef {

--- a/src/librustc_trans/callee.rs
+++ b/src/librustc_trans/callee.rs
@@ -329,7 +329,7 @@ fn trans_fn_once_adapter_shim<'a, 'tcx>(
     attributes::set_frame_pointer_elimination(ccx, lloncefn);
 
     let orig_fn_ty = fn_ty;
-    let mut bcx = Builder::entry_block(ccx, lloncefn);
+    let mut bcx = Builder::new_block(ccx, lloncefn, "entry-block");
 
     let callee = Callee {
         data: Fn(llreffn),
@@ -489,7 +489,7 @@ fn trans_fn_pointer_shim<'a, 'tcx>(
     let llfn = declare::define_internal_fn(ccx, &function_name, tuple_fn_ty);
     attributes::set_frame_pointer_elimination(ccx, llfn);
     //
-    let bcx = Builder::entry_block(ccx, llfn);
+    let bcx = Builder::new_block(ccx, llfn, "entry-block");
 
     let mut llargs = get_params(llfn);
 

--- a/src/librustc_trans/callee.rs
+++ b/src/librustc_trans/callee.rs
@@ -26,7 +26,7 @@ use base;
 use builder::Builder;
 use common::{self, CrateContext, SharedCrateContext};
 use cleanup::CleanupScope;
-use adt::MaybeSizedValue;
+use mir::lvalue::LvalueRef;
 use consts;
 use declare;
 use value::Value;
@@ -364,7 +364,7 @@ fn trans_fn_once_adapter_shim<'a, 'tcx>(
     // Call the by-ref closure body with `self` in a cleanup scope,
     // to drop `self` when the body returns, or in case it unwinds.
     let self_scope = CleanupScope::schedule_drop_mem(
-        &bcx, MaybeSizedValue::sized(llenv), closure_ty
+        &bcx, LvalueRef::new_sized_ty(llenv, closure_ty)
     );
 
     let llfn = callee.reify(bcx.ccx);

--- a/src/librustc_trans/callee.rs
+++ b/src/librustc_trans/callee.rs
@@ -370,7 +370,7 @@ fn trans_fn_once_adapter_shim<'a, 'tcx>(
     let llfn = callee.reify(bcx.ccx);
     let llret;
     if let Some(landing_pad) = self_scope.landing_pad {
-        let normal_bcx = bcx.build_new_block("normal-return");
+        let normal_bcx = bcx.build_sibling_block("normal-return");
         llret = bcx.invoke(llfn, &llargs[..], normal_bcx.llbb(), landing_pad, None);
         bcx = normal_bcx;
     } else {

--- a/src/librustc_trans/cleanup.rs
+++ b/src/librustc_trans/cleanup.rs
@@ -54,7 +54,7 @@ impl<'tcx> DropValue<'tcx> {
     /// This should only be called once per function, as it creates an alloca for the landingpad.
     fn get_landing_pad<'a>(&self, bcx: &Builder<'a, 'tcx>) -> BasicBlockRef {
         debug!("get_landing_pad");
-        let bcx = bcx.build_new_block("cleanup_unwind");
+        let bcx = bcx.build_sibling_block("cleanup_unwind");
         let llpersonality = bcx.ccx.eh_personality();
         bcx.set_personality_fn(llpersonality);
 

--- a/src/librustc_trans/cleanup.rs
+++ b/src/librustc_trans/cleanup.rs
@@ -59,7 +59,7 @@ impl<'tcx> DropValue<'tcx> {
         let llpersonality = bcx.ccx.eh_personality();
         bcx.set_personality_fn(llpersonality);
 
-        if base::wants_msvc_seh(bcx.ccx.sess()) {
+        if base::wants_msvc_seh(bcx.sess()) {
             let pad = bcx.cleanup_pad(None, &[]);
             let funclet = Some(Funclet::new(pad));
             self.trans(funclet.as_ref(), &bcx);
@@ -80,7 +80,7 @@ impl<'tcx> DropValue<'tcx> {
             // Insert cleanup instructions into the cleanup block
             self.trans(None, &bcx);
 
-            if !bcx.ccx.sess().target.target.options.custom_unwind_resume {
+            if !bcx.sess().target.target.options.custom_unwind_resume {
                 bcx.resume(llretval);
             } else {
                 let exc_ptr = bcx.extract_value(llretval, 0);
@@ -132,7 +132,7 @@ impl<'a, 'tcx> CleanupScope<'tcx> {
     fn new(bcx: &Builder<'a, 'tcx>, drop_val: DropValue<'tcx>) -> CleanupScope<'tcx> {
         CleanupScope {
             cleanup: Some(drop_val),
-            landing_pad: if !bcx.ccx.sess().no_landing_pads() {
+            landing_pad: if !bcx.sess().no_landing_pads() {
                 Some(drop_val.get_landing_pad(bcx))
             } else {
                 None

--- a/src/librustc_trans/common.rs
+++ b/src/librustc_trans/common.rs
@@ -15,7 +15,6 @@
 use llvm;
 use llvm::{ValueRef, ContextRef, TypeKind};
 use llvm::{True, False, Bool, OperandBundleDef};
-use rustc::hir::def::Def;
 use rustc::hir::def_id::DefId;
 use rustc::hir::map::DefPathData;
 use rustc::util::common::MemoizationMap;
@@ -38,7 +37,7 @@ use std::borrow::Cow;
 use std::iter;
 
 use syntax::ast;
-use syntax::symbol::{Symbol, InternedString};
+use syntax::symbol::InternedString;
 use syntax_pos::Span;
 
 use rustc_i128::u128;
@@ -168,55 +167,6 @@ pub fn type_is_zero_size<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, ty: Ty<'tcx>) -
 * some helper task such as bringing a task to life, allocating memory, etc.
 *
 */
-
-use Disr;
-
-/// The concrete version of ty::FieldDef. The name is the field index if
-/// the field is numeric.
-pub struct Field<'tcx>(pub ast::Name, pub Ty<'tcx>);
-
-/// The concrete version of ty::VariantDef
-pub struct VariantInfo<'tcx> {
-    pub discr: Disr,
-    pub fields: Vec<Field<'tcx>>
-}
-
-impl<'a, 'tcx> VariantInfo<'tcx> {
-    pub fn from_ty(tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                   ty: Ty<'tcx>,
-                   opt_def: Option<Def>)
-                   -> Self
-    {
-        match ty.sty {
-            ty::TyAdt(adt, substs) => {
-                let variant = match opt_def {
-                    None => adt.struct_variant(),
-                    Some(def) => adt.variant_of_def(def)
-                };
-
-                VariantInfo {
-                    discr: Disr::from(variant.disr_val),
-                    fields: variant.fields.iter().map(|f| {
-                        Field(f.name, monomorphize::field_ty(tcx, substs, f))
-                    }).collect()
-                }
-            }
-
-            ty::TyTuple(ref v) => {
-                VariantInfo {
-                    discr: Disr(0),
-                    fields: v.iter().enumerate().map(|(i, &t)| {
-                        Field(Symbol::intern(&i.to_string()), t)
-                    }).collect()
-                }
-            }
-
-            _ => {
-                bug!("cannot get field types from the type {:?}", ty);
-            }
-        }
-    }
-}
 
 /// A structure representing an active landing pad for the duration of a basic
 /// block.

--- a/src/librustc_trans/common.rs
+++ b/src/librustc_trans/common.rs
@@ -12,7 +12,6 @@
 
 //! Code that is useful in various trans modules.
 
-use session::Session;
 use llvm;
 use llvm::{ValueRef, BasicBlockRef, ContextRef, TypeKind};
 use llvm::{True, False, Bool, OperandBundleDef};
@@ -37,7 +36,6 @@ use rustc::hir;
 use libc::{c_uint, c_char};
 use std::borrow::Cow;
 use std::iter;
-use std::ops::Deref;
 use std::ffi::CString;
 
 use syntax::ast;
@@ -235,8 +233,6 @@ pub struct FunctionContext<'a, 'tcx: 'a> {
 
     // This function's enclosing crate context.
     pub ccx: &'a CrateContext<'a, 'tcx>,
-
-    alloca_builder: Builder<'a, 'tcx>,
 }
 
 impl<'a, 'tcx> FunctionContext<'a, 'tcx> {
@@ -247,30 +243,18 @@ impl<'a, 'tcx> FunctionContext<'a, 'tcx> {
             llfn: llfndecl,
             alloca_insert_pt: None,
             ccx: ccx,
-            alloca_builder: Builder::with_ccx(ccx),
         };
 
-        let val = {
-            let entry_bcx = fcx.build_new_block("entry-block");
-            let val = entry_bcx.load(C_null(Type::i8p(ccx)));
-            fcx.alloca_builder.position_at_start(entry_bcx.llbb());
-            val
-        };
-
+        let entry_bcx = Builder::new_block(fcx.ccx, fcx.llfn, "entry-block");
+        entry_bcx.position_at_start(entry_bcx.llbb());
         // Use a dummy instruction as the insertion point for all allocas.
         // This is later removed in the drop of FunctionContext.
-        fcx.alloca_insert_pt = Some(val);
+        fcx.alloca_insert_pt = Some(entry_bcx.load(C_null(Type::i8p(ccx))));
 
         fcx
     }
 
-    pub fn get_entry_block(&'a self) -> BlockAndBuilder<'a, 'tcx> {
-        BlockAndBuilder::new(unsafe {
-            llvm::LLVMGetFirstBasicBlock(self.llfn)
-        }, self)
-    }
-
-    pub fn new_block(&'a self, name: &str) -> BasicBlockRef {
+    pub fn new_block(&self, name: &str) -> BasicBlockRef {
         unsafe {
             let name = CString::new(name).unwrap();
             llvm::LLVMAppendBasicBlockInContext(
@@ -281,12 +265,14 @@ impl<'a, 'tcx> FunctionContext<'a, 'tcx> {
         }
     }
 
-    pub fn build_new_block(&'a self, name: &str) -> BlockAndBuilder<'a, 'tcx> {
-        BlockAndBuilder::new(self.new_block(name), self)
+    pub fn build_new_block(&self, name: &str) -> Builder<'a, 'tcx> {
+        Builder::new_block(self.ccx, self.llfn, name)
     }
 
-    pub fn alloca(&self, ty: Type, name: &str) -> ValueRef {
-        self.alloca_builder.dynamic_alloca(ty, name)
+    pub fn get_entry_block(&'a self) -> Builder<'a, 'tcx> {
+        let builder = Builder::with_ccx(self.ccx);
+        builder.position_at_end(unsafe { llvm::LLVMGetFirstBasicBlock(self.llfn) });
+        builder
     }
 }
 
@@ -295,65 +281,6 @@ impl<'a, 'tcx> Drop for FunctionContext<'a, 'tcx> {
         unsafe {
             llvm::LLVMInstructionEraseFromParent(self.alloca_insert_pt.unwrap());
         }
-    }
-}
-
-#[must_use]
-pub struct BlockAndBuilder<'a, 'tcx: 'a> {
-    // The BasicBlockRef returned from a call to
-    // llvm::LLVMAppendBasicBlock(llfn, name), which adds a basic
-    // block to the function pointed to by llfn.  We insert
-    // instructions into that block by way of this block context.
-    // The block pointing to this one in the function's digraph.
-    llbb: BasicBlockRef,
-
-    // The function context for the function to which this block is
-    // attached.
-    fcx: &'a FunctionContext<'a, 'tcx>,
-
-    builder: Builder<'a, 'tcx>,
-}
-
-impl<'a, 'tcx> BlockAndBuilder<'a, 'tcx> {
-    pub fn new(llbb: BasicBlockRef, fcx: &'a FunctionContext<'a, 'tcx>) -> Self {
-        let builder = Builder::with_ccx(fcx.ccx);
-        // Set the builder's position to this block's end.
-        builder.position_at_end(llbb);
-        BlockAndBuilder {
-            llbb: llbb,
-            fcx: fcx,
-            builder: builder,
-        }
-    }
-
-    pub fn at_start<F, R>(&self, f: F) -> R
-        where F: FnOnce(&BlockAndBuilder<'a, 'tcx>) -> R
-    {
-        self.position_at_start(self.llbb);
-        let r = f(self);
-        self.position_at_end(self.llbb);
-        r
-    }
-
-    pub fn fcx(&self) -> &'a FunctionContext<'a, 'tcx> {
-        self.fcx
-    }
-    pub fn tcx(&self) -> TyCtxt<'a, 'tcx, 'tcx> {
-        self.ccx.tcx()
-    }
-    pub fn sess(&self) -> &'a Session {
-        self.ccx.sess()
-    }
-
-    pub fn llbb(&self) -> BasicBlockRef {
-        self.llbb
-    }
-}
-
-impl<'a, 'tcx> Deref for BlockAndBuilder<'a, 'tcx> {
-    type Target = Builder<'a, 'tcx>;
-    fn deref(&self) -> &Self::Target {
-        &self.builder
     }
 }
 
@@ -725,7 +652,7 @@ pub fn langcall(tcx: TyCtxt,
 // of Java. (See related discussion on #1877 and #10183.)
 
 pub fn build_unchecked_lshift<'a, 'tcx>(
-    bcx: &BlockAndBuilder<'a, 'tcx>,
+    bcx: &Builder<'a, 'tcx>,
     lhs: ValueRef,
     rhs: ValueRef
 ) -> ValueRef {
@@ -736,7 +663,7 @@ pub fn build_unchecked_lshift<'a, 'tcx>(
 }
 
 pub fn build_unchecked_rshift<'a, 'tcx>(
-    bcx: &BlockAndBuilder<'a, 'tcx>, lhs_t: Ty<'tcx>, lhs: ValueRef, rhs: ValueRef
+    bcx: &Builder<'a, 'tcx>, lhs_t: Ty<'tcx>, lhs: ValueRef, rhs: ValueRef
 ) -> ValueRef {
     let rhs = base::cast_shift_expr_rhs(bcx, hir::BinOp_::BiShr, lhs, rhs);
     // #1877, #10183: Ensure that input is always valid
@@ -749,13 +676,13 @@ pub fn build_unchecked_rshift<'a, 'tcx>(
     }
 }
 
-fn shift_mask_rhs<'a, 'tcx>(bcx: &BlockAndBuilder<'a, 'tcx>, rhs: ValueRef) -> ValueRef {
+fn shift_mask_rhs<'a, 'tcx>(bcx: &Builder<'a, 'tcx>, rhs: ValueRef) -> ValueRef {
     let rhs_llty = val_ty(rhs);
     bcx.and(rhs, shift_mask_val(bcx, rhs_llty, rhs_llty, false))
 }
 
 pub fn shift_mask_val<'a, 'tcx>(
-    bcx: &BlockAndBuilder<'a, 'tcx>,
+    bcx: &Builder<'a, 'tcx>,
     llty: Type,
     mask_llty: Type,
     invert: bool

--- a/src/librustc_trans/debuginfo/create_scope_map.rs
+++ b/src/librustc_trans/debuginfo/create_scope_map.rs
@@ -14,7 +14,7 @@ use super::utils::{DIB, span_start};
 
 use llvm;
 use llvm::debuginfo::{DIScope, DISubprogram};
-use common::{CrateContext, FunctionContext};
+use common::CrateContext;
 use rustc::mir::{Mir, VisibilityScope};
 
 use libc::c_uint;
@@ -44,7 +44,7 @@ impl MirDebugScope {
 
 /// Produce DIScope DIEs for each MIR Scope which has variables defined in it.
 /// If debuginfo is disabled, the returned vector is empty.
-pub fn create_mir_scopes(fcx: &FunctionContext, mir: &Mir, debug_context: &FunctionDebugContext)
+pub fn create_mir_scopes(ccx: &CrateContext, mir: &Mir, debug_context: &FunctionDebugContext)
     -> IndexVec<VisibilityScope, MirDebugScope> {
     let null_scope = MirDebugScope {
         scope_metadata: ptr::null_mut(),
@@ -71,7 +71,7 @@ pub fn create_mir_scopes(fcx: &FunctionContext, mir: &Mir, debug_context: &Funct
     // Instantiate all scopes.
     for idx in 0..mir.visibility_scopes.len() {
         let scope = VisibilityScope::new(idx);
-        make_mir_scope(fcx.ccx, &mir, &has_variables, fn_metadata, scope, &mut scopes);
+        make_mir_scope(ccx, &mir, &has_variables, fn_metadata, scope, &mut scopes);
     }
 
     scopes

--- a/src/librustc_trans/debuginfo/doc.rs
+++ b/src/librustc_trans/debuginfo/doc.rs
@@ -45,7 +45,7 @@
 //!
 //! All private state used by the module is stored within either the
 //! CrateDebugContext struct (owned by the CrateContext) or the
-//! FunctionDebugContext (owned by the FunctionContext).
+//! FunctionDebugContext (owned by the MirContext).
 //!
 //! This file consists of three conceptual sections:
 //! 1. The public interface of the module

--- a/src/librustc_trans/debuginfo/mod.rs
+++ b/src/librustc_trans/debuginfo/mod.rs
@@ -27,7 +27,8 @@ use rustc::hir::def_id::DefId;
 use rustc::ty::subst::Substs;
 
 use abi::Abi;
-use common::{CrateContext, BlockAndBuilder};
+use common::CrateContext;
+use builder::Builder;
 use monomorphize::{self, Instance};
 use rustc::ty::{self, Ty};
 use rustc::mir;
@@ -423,7 +424,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
     }
 }
 
-pub fn declare_local<'a, 'tcx>(bcx: &BlockAndBuilder<'a, 'tcx>,
+pub fn declare_local<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
                                dbg_context: &FunctionDebugContext,
                                variable_name: ast::Name,
                                variable_type: Ty<'tcx>,

--- a/src/librustc_trans/debuginfo/source_loc.rs
+++ b/src/librustc_trans/debuginfo/source_loc.rs
@@ -38,7 +38,7 @@ pub fn set_source_location(
     };
 
     let dbg_loc = if function_debug_context.source_locations_enabled.get() {
-        debug!("set_source_location: {}", builder.ccx.sess().codemap().span_to_string(span));
+        debug!("set_source_location: {}", builder.sess().codemap().span_to_string(span));
         let loc = span_start(builder.ccx, span);
         InternalDebugLocation::new(scope, loc.line, loc.col.to_usize())
     } else {

--- a/src/librustc_trans/glue.rs
+++ b/src/librustc_trans/glue.rs
@@ -411,7 +411,7 @@ fn drop_structural_ty<'a, 'tcx>(cx: Builder<'a, 'tcx>, ptr: LvalueRef<'tcx>) -> 
                 substs: substs,
                 variant_index: variant_index,
             };
-            let field_ptr = adt::trans_field_ptr(&cx, av, i);
+            let field_ptr = av.trans_field_ptr(&cx, i);
             drop_ty(&cx, LvalueRef::new_sized_ty(field_ptr, arg));
         }
     }
@@ -421,7 +421,7 @@ fn drop_structural_ty<'a, 'tcx>(cx: Builder<'a, 'tcx>, ptr: LvalueRef<'tcx>) -> 
     match t.sty {
         ty::TyClosure(def_id, substs) => {
             for (i, upvar_ty) in substs.upvar_tys(def_id, cx.tcx()).enumerate() {
-                let llupvar = adt::trans_field_ptr(&cx, ptr, i);
+                let llupvar = ptr.trans_field_ptr(&cx, i);
                 drop_ty(&cx, LvalueRef::new_sized_ty(llupvar, upvar_ty));
             }
         }
@@ -439,7 +439,7 @@ fn drop_structural_ty<'a, 'tcx>(cx: Builder<'a, 'tcx>, ptr: LvalueRef<'tcx>) -> 
         }
         ty::TyTuple(ref args) => {
             for (i, arg) in args.iter().enumerate() {
-                let llfld_a = adt::trans_field_ptr(&cx, ptr, i);
+                let llfld_a = ptr.trans_field_ptr(&cx, i);
                 drop_ty(&cx, LvalueRef::new_sized_ty(llfld_a, *arg));
             }
         }
@@ -453,7 +453,7 @@ fn drop_structural_ty<'a, 'tcx>(cx: Builder<'a, 'tcx>, ptr: LvalueRef<'tcx>) -> 
                         substs: substs,
                         variant_index: Disr::from(discr).0 as usize,
                     };
-                    let llfld_a = adt::trans_field_ptr(&cx, ptr, i);
+                    let llfld_a = ptr.trans_field_ptr(&cx, i);
                     let ptr = if cx.ccx.shared().type_is_sized(field_ty) {
                         LvalueRef::new_sized_ty(llfld_a, field_ty)
                     } else {

--- a/src/librustc_trans/glue.rs
+++ b/src/librustc_trans/glue.rs
@@ -173,7 +173,7 @@ pub fn implement_drop_glue<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, g: DropGlueKi
     assert_eq!(g.ty(), get_drop_glue_type(ccx.shared(), g.ty()));
     let (llfn, _) = ccx.drop_glues().borrow().get(&g).unwrap().clone();
 
-    let mut bcx = Builder::entry_block(ccx, llfn);
+    let mut bcx = Builder::new_block(ccx, llfn, "entry-block");
 
     ccx.stats().n_glues_created.set(ccx.stats().n_glues_created.get() + 1);
     // All glue functions take values passed *by alias*; this is a

--- a/src/librustc_trans/intrinsic.rs
+++ b/src/librustc_trans/intrinsic.rs
@@ -16,6 +16,7 @@ use llvm;
 use llvm::{ValueRef};
 use abi::{Abi, FnType};
 use adt;
+use mir::lvalue::LvalueRef;
 use base::*;
 use common::*;
 use declare;
@@ -549,10 +550,10 @@ pub fn trans_intrinsic_call<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
                         // destructors, and the contents are SIMD
                         // etc.
                         assert!(!bcx.ccx.shared().type_needs_drop(arg_type));
-                        let arg = adt::MaybeSizedValue::sized(llarg);
+                        let arg = LvalueRef::new_sized_ty(llarg, arg_type);
                         (0..contents.len())
                             .map(|i| {
-                                bcx.load(adt::trans_field_ptr(bcx, arg_type, arg, Disr(0), i))
+                                bcx.load(adt::trans_field_ptr(bcx, arg, Disr(0), i))
                             })
                             .collect()
                     }

--- a/src/librustc_trans/intrinsic.rs
+++ b/src/librustc_trans/intrinsic.rs
@@ -25,7 +25,6 @@ use type_of;
 use machine;
 use type_::Type;
 use rustc::ty::{self, Ty};
-use Disr;
 use rustc::hir;
 use syntax::ast;
 use syntax::symbol::Symbol;
@@ -553,7 +552,7 @@ pub fn trans_intrinsic_call<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
                         let arg = LvalueRef::new_sized_ty(llarg, arg_type);
                         (0..contents.len())
                             .map(|i| {
-                                bcx.load(adt::trans_field_ptr(bcx, arg, Disr(0), i))
+                                bcx.load(adt::trans_field_ptr(bcx, arg, i))
                             })
                             .collect()
                     }

--- a/src/librustc_trans/intrinsic.rs
+++ b/src/librustc_trans/intrinsic.rs
@@ -694,7 +694,7 @@ fn try_intrinsic<'a, 'tcx>(
         bcx.call(func, &[data], None);
         bcx.store(C_null(Type::i8p(&bcx.ccx)), dest, None);
     } else if wants_msvc_seh(bcx.sess()) {
-        trans_msvc_try(bcx, fcx, func, data, local_ptr, dest);
+        trans_msvc_try(bcx, ccx, func, data, local_ptr, dest);
     } else {
         trans_gnu_try(bcx, ccx, func, data, local_ptr, dest);
     }

--- a/src/librustc_trans/intrinsic.rs
+++ b/src/librustc_trans/intrinsic.rs
@@ -718,10 +718,10 @@ fn trans_msvc_try<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
 
         bcx.set_personality_fn(bcx.ccx.eh_personality());
 
-        let normal = bcx.build_new_block("normal");
-        let catchswitch = bcx.build_new_block("catchswitch");
-        let catchpad = bcx.build_new_block("catchpad");
-        let caught = bcx.build_new_block("caught");
+        let normal = bcx.build_sibling_block("normal");
+        let catchswitch = bcx.build_sibling_block("catchswitch");
+        let catchpad = bcx.build_sibling_block("catchpad");
+        let caught = bcx.build_sibling_block("caught");
 
         let func = llvm::get_param(bcx.llfn(), 0);
         let data = llvm::get_param(bcx.llfn(), 1);
@@ -837,8 +837,8 @@ fn trans_gnu_try<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
         // expected to be `*mut *mut u8` for this to actually work, but that's
         // managed by the standard library.
 
-        let then = bcx.build_new_block("then");
-        let catch = bcx.build_new_block("catch");
+        let then = bcx.build_sibling_block("then");
+        let catch = bcx.build_sibling_block("catch");
 
         let func = llvm::get_param(bcx.llfn(), 0);
         let data = llvm::get_param(bcx.llfn(), 1);

--- a/src/librustc_trans/intrinsic.rs
+++ b/src/librustc_trans/intrinsic.rs
@@ -883,7 +883,7 @@ fn gen_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
         sig: ty::Binder(sig)
     }));
     let llfn = declare::define_internal_fn(ccx, name, rust_fn_ty);
-    let bcx = Builder::entry_block(ccx, llfn);
+    let bcx = Builder::new_block(ccx, llfn, "entry-block");
     trans(bcx);
     llfn
 }

--- a/src/librustc_trans/intrinsic.rs
+++ b/src/librustc_trans/intrinsic.rs
@@ -694,7 +694,7 @@ fn try_intrinsic<'a, 'tcx>(
     local_ptr: ValueRef,
     dest: ValueRef,
 ) {
-    if bcx.ccx.sess().no_landing_pads() {
+    if bcx.sess().no_landing_pads() {
         bcx.call(func, &[data], None);
         bcx.store(C_null(Type::i8p(&bcx.ccx)), dest, None);
     } else if wants_msvc_seh(bcx.sess()) {
@@ -937,7 +937,7 @@ fn generic_simd_intrinsic<'a, 'tcx>(
         };
         ($msg: tt, $($fmt: tt)*) => {
             span_invalid_monomorphization_error(
-                bcx.ccx.sess(), span,
+                bcx.sess(), span,
                 &format!(concat!("invalid monomorphization of `{}` intrinsic: ",
                                  $msg),
                          name, $($fmt)*));
@@ -959,7 +959,7 @@ fn generic_simd_intrinsic<'a, 'tcx>(
 
 
 
-    let tcx = bcx.ccx.tcx();
+    let tcx = bcx.tcx();
     let sig = tcx.erase_late_bound_regions_and_normalize(callee_ty.fn_sig());
     let arg_tys = sig.inputs();
 

--- a/src/librustc_trans/intrinsic.rs
+++ b/src/librustc_trans/intrinsic.rs
@@ -550,11 +550,7 @@ pub fn trans_intrinsic_call<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
                         // etc.
                         assert!(!bcx.ccx.shared().type_needs_drop(arg_type));
                         let arg = LvalueRef::new_sized_ty(llarg, arg_type);
-                        (0..contents.len())
-                            .map(|i| {
-                                bcx.load(adt::trans_field_ptr(bcx, arg, i))
-                            })
-                            .collect()
+                        (0..contents.len()).map(|i| bcx.load(arg.trans_field_ptr(bcx, i))).collect()
                     }
                     intrinsics::Type::Pointer(_, Some(ref llvm_elem), _) => {
                         let llvm_elem = one(ty_to_type(bcx.ccx, llvm_elem, &mut false));

--- a/src/librustc_trans/meth.rs
+++ b/src/librustc_trans/meth.rs
@@ -76,10 +76,9 @@ pub fn trans_object_shim<'a, 'tcx>(ccx: &'a CrateContext<'a, 'tcx>,
     let llfn = declare::define_internal_fn(ccx, &function_name, callee.ty);
     attributes::set_frame_pointer_elimination(ccx, llfn);
 
-    let fcx = FunctionContext::new(ccx, llfn);
-    let bcx = fcx.get_entry_block();
+    let bcx = Builder::entry_block(ccx, llfn);
 
-    let mut llargs = get_params(fcx.llfn);
+    let mut llargs = get_params(llfn);
     let fn_ret = callee.ty.fn_ret();
     let fn_ty = callee.direct_fn_type(ccx, &[]);
 

--- a/src/librustc_trans/meth.rs
+++ b/src/librustc_trans/meth.rs
@@ -76,7 +76,7 @@ pub fn trans_object_shim<'a, 'tcx>(ccx: &'a CrateContext<'a, 'tcx>,
     let llfn = declare::define_internal_fn(ccx, &function_name, callee.ty);
     attributes::set_frame_pointer_elimination(ccx, llfn);
 
-    let bcx = Builder::entry_block(ccx, llfn);
+    let bcx = Builder::new_block(ccx, llfn, "entry-block");
 
     let mut llargs = get_params(llfn);
     let fn_ret = callee.ty.fn_ret();

--- a/src/librustc_trans/meth.rs
+++ b/src/librustc_trans/meth.rs
@@ -13,6 +13,7 @@ use llvm::{ValueRef, get_params};
 use rustc::traits;
 use callee::{Callee, CalleeData};
 use common::*;
+use builder::Builder;
 use consts;
 use declare;
 use glue;
@@ -27,7 +28,7 @@ use rustc::ty;
 const VTABLE_OFFSET: usize = 3;
 
 /// Extracts a method from a trait object's vtable, at the specified index.
-pub fn get_virtual_method<'a, 'tcx>(bcx: &BlockAndBuilder<'a, 'tcx>,
+pub fn get_virtual_method<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
                                     llvtable: ValueRef,
                                     vtable_index: usize)
                                     -> ValueRef {

--- a/src/librustc_trans/mir/block.rs
+++ b/src/librustc_trans/mir/block.rs
@@ -209,7 +209,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                     };
                     let llslot = match op.val {
                         Immediate(_) | Pair(..) => {
-                            let llscratch = bcx.fcx().alloca(ret.original_ty, "ret");
+                            let llscratch = bcx.alloca(ret.original_ty, "ret");
                             self.store_operand(&bcx, llscratch, op, None);
                             llscratch
                         }
@@ -651,7 +651,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
         let (mut llval, by_ref) = match op.val {
             Immediate(_) | Pair(..) => {
                 if arg.is_indirect() || arg.cast.is_some() {
-                    let llscratch = bcx.fcx().alloca(arg.original_ty, "arg");
+                    let llscratch = bcx.alloca(arg.original_ty, "arg");
                     self.store_operand(bcx, llscratch, op, None);
                     (llscratch, true)
                 } else {

--- a/src/librustc_trans/mir/block.rs
+++ b/src/librustc_trans/mir/block.rs
@@ -709,7 +709,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
             Ref(llval) => {
                 for (n, &ty) in arg_types.iter().enumerate() {
                     let ptr = adt::trans_field_ptr(
-                        bcx, LvalueRef::new_sized_ty(llval, tuple.ty), Disr(0), n
+                        bcx, LvalueRef::new_sized_ty(llval, tuple.ty), n
                     );
                     let val = if common::type_is_fat_ptr(bcx.ccx, ty) {
                         let (lldata, llextra) = base::load_fat_ptr(bcx, ptr, ty);

--- a/src/librustc_trans/mir/block.rs
+++ b/src/librustc_trans/mir/block.rs
@@ -708,9 +708,8 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
         match tuple.val {
             Ref(llval) => {
                 for (n, &ty) in arg_types.iter().enumerate() {
-                    let ptr = adt::trans_field_ptr(
-                        bcx, LvalueRef::new_sized_ty(llval, tuple.ty), n
-                    );
+                    let ptr = LvalueRef::new_sized_ty(llval, tuple.ty);
+                    let ptr = ptr.trans_field_ptr(bcx, n);
                     let val = if common::type_is_fat_ptr(bcx.ccx, ty) {
                         let (lldata, llextra) = base::load_fat_ptr(bcx, ptr, ty);
                         Pair(lldata, llextra)

--- a/src/librustc_trans/mir/block.rs
+++ b/src/librustc_trans/mir/block.rs
@@ -580,14 +580,12 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
 
                     if let Some((_, target)) = *destination {
                         let ret_bcx = self.get_builder(target);
-                        ret_bcx.position_at_start(ret_bcx.llbb());
                         self.set_debug_loc(&ret_bcx, terminator.source_info);
                         let op = OperandRef {
                             val: Immediate(invokeret),
                             ty: sig.output(),
                         };
                         self.store_return(&ret_bcx, ret_dest, fn_ty.ret, op);
-                        ret_bcx.position_at_end(ret_bcx.llbb());
                     }
                 } else {
                     let llret = bcx.call(fn_ptr, &llargs, cleanup_bundle);

--- a/src/librustc_trans/mir/constant.rs
+++ b/src/librustc_trans/mir/constant.rs
@@ -24,10 +24,11 @@ use rustc::ty::subst::Substs;
 use rustc_data_structures::indexed_vec::{Idx, IndexVec};
 use {abi, adt, base, Disr, machine};
 use callee::Callee;
-use common::{self, BlockAndBuilder, CrateContext, const_get_elt, val_ty};
+use builder::Builder;
+use common::{self, CrateContext, const_get_elt, val_ty};
 use common::{C_array, C_bool, C_bytes, C_floating_f64, C_integral, C_big_integral};
 use common::{C_null, C_struct, C_str_slice, C_undef, C_uint};
-use common::{const_to_opt_u128};
+use common::const_to_opt_u128;
 use consts;
 use monomorphize::{self, Instance};
 use type_of;
@@ -900,7 +901,7 @@ pub fn const_scalar_checked_binop<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
 impl<'a, 'tcx> MirContext<'a, 'tcx> {
     pub fn trans_constant(&mut self,
-                          bcx: &BlockAndBuilder<'a, 'tcx>,
+                          bcx: &Builder<'a, 'tcx>,
                           constant: &mir::Constant<'tcx>)
                           -> Const<'tcx>
     {

--- a/src/librustc_trans/mir/constant.rs
+++ b/src/librustc_trans/mir/constant.rs
@@ -18,7 +18,7 @@ use rustc::hir::def_id::DefId;
 use rustc::infer::TransNormalize;
 use rustc::mir;
 use rustc::mir::tcx::LvalueTy;
-use rustc::ty::{self, Ty, TyCtxt, TypeFoldable};
+use rustc::ty::{self, layout, Ty, TyCtxt, TypeFoldable};
 use rustc::ty::cast::{CastTy, IntTy};
 use rustc::ty::subst::Substs;
 use rustc_data_structures::indexed_vec::{Idx, IndexVec};
@@ -27,7 +27,7 @@ use callee::Callee;
 use builder::Builder;
 use common::{self, CrateContext, const_get_elt, val_ty};
 use common::{C_array, C_bool, C_bytes, C_floating_f64, C_integral, C_big_integral};
-use common::{C_null, C_struct, C_str_slice, C_undef, C_uint};
+use common::{C_null, C_struct, C_str_slice, C_undef, C_uint, C_vector, is_undef};
 use common::const_to_opt_u128;
 use consts;
 use monomorphize::{self, Instance};
@@ -549,16 +549,7 @@ impl<'a, 'tcx> MirConstContext<'a, 'tcx> {
                     mir::AggregateKind::Adt(..) |
                     mir::AggregateKind::Closure(..) |
                     mir::AggregateKind::Tuple => {
-                        let disr = match *kind {
-                            mir::AggregateKind::Adt(adt_def, index, _, _) => {
-                                Disr::from(adt_def.variants[index].disr_val)
-                            }
-                            _ => Disr(0)
-                        };
-                        Const::new(
-                            adt::trans_const(self.ccx, dest_ty, disr, &fields),
-                            dest_ty
-                        )
+                        Const::new(trans_const(self.ccx, dest_ty, kind, &fields), dest_ty)
                     }
                 }
             }
@@ -945,4 +936,160 @@ pub fn trans_static_initializer(ccx: &CrateContext, def_id: DefId)
                                 -> Result<ValueRef, ConstEvalErr> {
     let instance = Instance::mono(ccx.shared(), def_id);
     MirConstContext::trans_def(ccx, instance, IndexVec::new()).map(|c| c.llval)
+}
+
+/// Construct a constant value, suitable for initializing a
+/// GlobalVariable, given a case and constant values for its fields.
+/// Note that this may have a different LLVM type (and different
+/// alignment!) from the representation's `type_of`, so it needs a
+/// pointer cast before use.
+///
+/// The LLVM type system does not directly support unions, and only
+/// pointers can be bitcast, so a constant (and, by extension, the
+/// GlobalVariable initialized by it) will have a type that can vary
+/// depending on which case of an enum it is.
+///
+/// To understand the alignment situation, consider `enum E { V64(u64),
+/// V32(u32, u32) }` on Windows.  The type has 8-byte alignment to
+/// accommodate the u64, but `V32(x, y)` would have LLVM type `{i32,
+/// i32, i32}`, which is 4-byte aligned.
+///
+/// Currently the returned value has the same size as the type, but
+/// this could be changed in the future to avoid allocating unnecessary
+/// space after values of shorter-than-maximum cases.
+fn trans_const<'a, 'tcx>(
+    ccx: &CrateContext<'a, 'tcx>,
+    t: Ty<'tcx>,
+    kind: &mir::AggregateKind,
+    vals: &[ValueRef]
+) -> ValueRef {
+    let l = ccx.layout_of(t);
+    let dl = &ccx.tcx().data_layout;
+    let variant_index = match *kind {
+        mir::AggregateKind::Adt(_, index, _, _) => index,
+        _ => 0,
+    };
+    match *l {
+        layout::CEnum { discr: d, min, max, .. } => {
+            let discr = match *kind {
+                mir::AggregateKind::Adt(adt_def, _, _, _) => {
+                    Disr::from(adt_def.variants[variant_index].disr_val)
+                },
+                _ => Disr(0),
+            };
+            assert_eq!(vals.len(), 0);
+            adt::assert_discr_in_range(Disr(min), Disr(max), discr);
+            C_integral(Type::from_integer(ccx, d), discr.0, true)
+        }
+        layout::General { discr: d, ref variants, .. } => {
+            let variant = &variants[variant_index];
+            let lldiscr = C_integral(Type::from_integer(ccx, d), variant_index as u64, true);
+            let mut vals_with_discr = vec![lldiscr];
+            vals_with_discr.extend_from_slice(vals);
+            let mut contents = build_const_struct(ccx, &variant, &vals_with_discr[..]);
+            let needed_padding = l.size(dl).bytes() - variant.stride().bytes();
+            if needed_padding > 0 {
+                contents.push(padding(ccx, needed_padding));
+            }
+            C_struct(ccx, &contents[..], false)
+        }
+        layout::UntaggedUnion { ref variants, .. }=> {
+            assert_eq!(variant_index, 0);
+            let contents = build_const_union(ccx, variants, vals[0]);
+            C_struct(ccx, &contents, variants.packed)
+        }
+        layout::Univariant { ref variant, .. } => {
+            assert_eq!(variant_index, 0);
+            let contents = build_const_struct(ccx, &variant, vals);
+            C_struct(ccx, &contents[..], variant.packed)
+        }
+        layout::Vector { .. } => {
+            C_vector(vals)
+        }
+        layout::RawNullablePointer { nndiscr, .. } => {
+            let nnty = adt::compute_fields(ccx, t, nndiscr as usize, false)[0];
+            if variant_index as u64 == nndiscr {
+                assert_eq!(vals.len(), 1);
+                vals[0]
+            } else {
+                C_null(type_of::sizing_type_of(ccx, nnty))
+            }
+        }
+        layout::StructWrappedNullablePointer { ref nonnull, nndiscr, .. } => {
+            if variant_index as u64 == nndiscr {
+                C_struct(ccx, &build_const_struct(ccx, &nonnull, vals), false)
+            } else {
+                let fields = adt::compute_fields(ccx, t, nndiscr as usize, false);
+                let vals = fields.iter().map(|&ty| {
+                    // Always use null even if it's not the `discrfield`th
+                    // field; see #8506.
+                    C_null(type_of::sizing_type_of(ccx, ty))
+                }).collect::<Vec<ValueRef>>();
+                C_struct(ccx, &build_const_struct(ccx, &nonnull, &vals[..]), false)
+            }
+        }
+        _ => bug!("trans_const: cannot handle type {} repreented as {:#?}", t, l)
+    }
+}
+
+/// Building structs is a little complicated, because we might need to
+/// insert padding if a field's value is less aligned than its type.
+///
+/// Continuing the example from `trans_const`, a value of type `(u32,
+/// E)` should have the `E` at offset 8, but if that field's
+/// initializer is 4-byte aligned then simply translating the tuple as
+/// a two-element struct will locate it at offset 4, and accesses to it
+/// will read the wrong memory.
+fn build_const_struct<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
+                                st: &layout::Struct,
+                                vals: &[ValueRef])
+                                -> Vec<ValueRef> {
+    assert_eq!(vals.len(), st.offsets.len());
+
+    if vals.len() == 0 {
+        return Vec::new();
+    }
+
+    // offset of current value
+    let mut offset = 0;
+    let mut cfields = Vec::new();
+    cfields.reserve(st.offsets.len()*2);
+
+    let parts = st.field_index_by_increasing_offset().map(|i| {
+        (&vals[i], st.offsets[i].bytes())
+    });
+    for (&val, target_offset) in parts {
+        if offset < target_offset {
+            cfields.push(padding(ccx, target_offset - offset));
+            offset = target_offset;
+        }
+        assert!(!is_undef(val));
+        cfields.push(val);
+        offset += machine::llsize_of_alloc(ccx, val_ty(val));
+    }
+
+    if offset < st.stride().bytes() {
+        cfields.push(padding(ccx, st.stride().bytes() - offset));
+    }
+
+    cfields
+}
+
+fn build_const_union<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
+                               un: &layout::Union,
+                               field_val: ValueRef)
+                               -> Vec<ValueRef> {
+    let mut cfields = vec![field_val];
+
+    let offset = machine::llsize_of_alloc(ccx, val_ty(field_val));
+    let size = un.stride().bytes();
+    if offset != size {
+        cfields.push(padding(ccx, size - offset));
+    }
+
+    cfields
+}
+
+fn padding(ccx: &CrateContext, size: u64) -> ValueRef {
+    C_undef(Type::array(&Type::i8(ccx), size))
 }

--- a/src/librustc_trans/mir/lvalue.rs
+++ b/src/librustc_trans/mir/lvalue.rs
@@ -167,7 +167,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                         let llindex = C_uint(bcx.ccx, from);
                         let llbase = project_index(llindex);
 
-                        let base_ty = tr_base.ty.to_ty(bcx.ccx.tcx());
+                        let base_ty = tr_base.ty.to_ty(bcx.tcx());
                         match base_ty.sty {
                             ty::TyArray(..) => {
                                 // must cast the lvalue pointer type to the new

--- a/src/librustc_trans/mir/mod.rs
+++ b/src/librustc_trans/mir/mod.rs
@@ -268,7 +268,7 @@ pub fn trans_mir<'a, 'tcx: 'a>(
                 // User variable
                 let source_info = decl.source_info.unwrap();
                 let debug_scope = mircx.scopes[source_info.scope];
-                let dbg = debug_scope.is_valid() && bcx.ccx.sess().opts.debuginfo == FullDebugInfo;
+                let dbg = debug_scope.is_valid() && bcx.sess().opts.debuginfo == FullDebugInfo;
 
                 if !lvalue_locals.contains(local.index()) && !dbg {
                     debug!("alloc: {:?} ({}) -> operand", local, name);
@@ -367,13 +367,13 @@ fn arg_local_refs<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
                             lvalue_locals: &BitVector)
                             -> Vec<LocalRef<'tcx>> {
     let mir = mircx.mir;
-    let tcx = bcx.ccx.tcx();
+    let tcx = bcx.tcx();
     let mut idx = 0;
     let mut llarg_idx = mircx.fn_ty.ret.is_indirect() as usize;
 
     // Get the argument scope, if it exists and if we need it.
     let arg_scope = scopes[mir::ARGUMENT_VISIBILITY_SCOPE];
-    let arg_scope = if arg_scope.is_valid() && bcx.ccx.sess().opts.debuginfo == FullDebugInfo {
+    let arg_scope = if arg_scope.is_valid() && bcx.sess().opts.debuginfo == FullDebugInfo {
         Some(arg_scope.scope_metadata)
     } else {
         None
@@ -433,7 +433,7 @@ fn arg_local_refs<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
 
         let arg = &mircx.fn_ty.args[idx];
         idx += 1;
-        let llval = if arg.is_indirect() && bcx.ccx.sess().opts.debuginfo != FullDebugInfo {
+        let llval = if arg.is_indirect() && bcx.sess().opts.debuginfo != FullDebugInfo {
             // Don't copy an indirect argument to an alloca, the caller
             // already put it in a temporary alloca and gave it up, unless
             // we emit extra-debug-info, which requires local allocas :(.

--- a/src/librustc_trans/mir/mod.rs
+++ b/src/librustc_trans/mir/mod.rs
@@ -218,9 +218,9 @@ pub fn trans_mir<'a, 'tcx: 'a>(
     let block_bcxs: IndexVec<mir::BasicBlock, BasicBlockRef> =
         mir.basic_blocks().indices().map(|bb| {
             if bb == mir::START_BLOCK {
-                bcx.build_new_block("start").llbb()
+                bcx.build_sibling_block("start").llbb()
             } else {
-                bcx.build_new_block(&format!("{:?}", bb)).llbb()
+                bcx.build_sibling_block(&format!("{:?}", bb)).llbb()
             }
         }).collect();
 

--- a/src/librustc_trans/mir/mod.rs
+++ b/src/librustc_trans/mir/mod.rs
@@ -519,7 +519,7 @@ fn arg_local_refs<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
             // doesn't actually strip the offset when splitting the closure
             // environment into its components so it ends up out of bounds.
             let env_ptr = if !env_ref {
-                let alloc = bcx.fcx().alloca(common::val_ty(llval), "__debuginfo_env_ptr");
+                let alloc = bcx.alloca(common::val_ty(llval), "__debuginfo_env_ptr");
                 bcx.store(llval, alloc, None);
                 alloc
             } else {

--- a/src/librustc_trans/mir/mod.rs
+++ b/src/librustc_trans/mir/mod.rs
@@ -210,7 +210,7 @@ pub fn trans_mir<'a, 'tcx: 'a>(
     debug!("fn_ty: {:?}", fn_ty);
     let debug_context =
         debuginfo::create_function_debug_context(ccx, instance, sig, abi, llfn, mir);
-    let bcx = Builder::entry_block(ccx, llfn);
+    let bcx = Builder::new_block(ccx, llfn, "entry-block");
 
     let cleanup_kinds = analyze::cleanup_kinds(&mir);
 

--- a/src/librustc_trans/mir/mod.rs
+++ b/src/librustc_trans/mir/mod.rs
@@ -31,7 +31,6 @@ use syntax::symbol::keywords;
 use syntax::abi::Abi;
 
 use std::iter;
-use std::ffi::CString;
 
 use rustc_data_structures::bitvec::BitVector;
 use rustc_data_structures::indexed_vec::{IndexVec, Idx};
@@ -218,17 +217,10 @@ pub fn trans_mir<'a, 'tcx: 'a>(
     // Allocate a `Block` for every basic block
     let block_bcxs: IndexVec<mir::BasicBlock, BasicBlockRef> =
         mir.basic_blocks().indices().map(|bb| {
-            let name = if bb == mir::START_BLOCK {
-                CString::new("start").unwrap()
+            if bb == mir::START_BLOCK {
+                bcx.build_new_block("start").llbb()
             } else {
-                CString::new(format!("{:?}", bb)).unwrap()
-            };
-            unsafe {
-                llvm::LLVMAppendBasicBlockInContext(
-                    ccx.llcx(),
-                    llfn,
-                    name.as_ptr()
-                )
+                bcx.build_new_block(&format!("{:?}", bb)).llbb()
             }
         }).collect();
 

--- a/src/librustc_trans/mir/mod.rs
+++ b/src/librustc_trans/mir/mod.rs
@@ -326,7 +326,7 @@ pub fn trans_mir<'a, 'tcx: 'a>(
     let funclets: IndexVec<mir::BasicBlock, Option<Funclet>> =
     mircx.cleanup_kinds.iter_enumerated().map(|(bb, cleanup_kind)| {
         if let CleanupKind::Funclet = *cleanup_kind {
-            let bcx = mircx.build_block(bb);
+            let bcx = mircx.get_builder(bb);
             bcx.set_personality_fn(mircx.ccx.eh_personality());
             if base::wants_msvc_seh(ccx.sess()) {
                 return Some(Funclet::new(bcx.cleanup_pad(None, &[])));

--- a/src/librustc_trans/mir/mod.rs
+++ b/src/librustc_trans/mir/mod.rs
@@ -38,7 +38,7 @@ use rustc_data_structures::indexed_vec::{IndexVec, Idx};
 pub use self::constant::trans_static_initializer;
 
 use self::analyze::CleanupKind;
-use self::lvalue::{LvalueRef};
+use self::lvalue::LvalueRef;
 use rustc::mir::traversal;
 
 use self::operand::{OperandRef, OperandValue};
@@ -578,7 +578,7 @@ fn arg_local_refs<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
 mod analyze;
 mod block;
 mod constant;
-mod lvalue;
+pub mod lvalue;
 mod operand;
 mod rvalue;
 mod statement;

--- a/src/librustc_trans/mir/operand.rs
+++ b/src/librustc_trans/mir/operand.rs
@@ -14,7 +14,8 @@ use rustc::mir;
 use rustc_data_structures::indexed_vec::Idx;
 
 use base;
-use common::{self, BlockAndBuilder};
+use common;
+use builder::Builder;
 use value::Value;
 use type_of;
 use type_::Type;
@@ -85,8 +86,7 @@ impl<'a, 'tcx> OperandRef<'tcx> {
 
     /// If this operand is a Pair, we return an
     /// Immediate aggregate with the two values.
-    pub fn pack_if_pair(mut self, bcx: &BlockAndBuilder<'a, 'tcx>)
-                        -> OperandRef<'tcx> {
+    pub fn pack_if_pair(mut self, bcx: &Builder<'a, 'tcx>) -> OperandRef<'tcx> {
         if let OperandValue::Pair(a, b) = self.val {
             // Reconstruct the immediate aggregate.
             let llty = type_of::type_of(bcx.ccx, self.ty);
@@ -107,8 +107,7 @@ impl<'a, 'tcx> OperandRef<'tcx> {
 
     /// If this operand is a pair in an Immediate,
     /// we return a Pair with the two halves.
-    pub fn unpack_if_pair(mut self, bcx: &BlockAndBuilder<'a, 'tcx>)
-                          -> OperandRef<'tcx> {
+    pub fn unpack_if_pair(mut self, bcx: &Builder<'a, 'tcx>) -> OperandRef<'tcx> {
         if let OperandValue::Immediate(llval) = self.val {
             // Deconstruct the immediate aggregate.
             if common::type_is_imm_pair(bcx.ccx, self.ty) {
@@ -136,7 +135,7 @@ impl<'a, 'tcx> OperandRef<'tcx> {
 
 impl<'a, 'tcx> MirContext<'a, 'tcx> {
     pub fn trans_load(&mut self,
-                      bcx: &BlockAndBuilder<'a, 'tcx>,
+                      bcx: &Builder<'a, 'tcx>,
                       llval: ValueRef,
                       ty: Ty<'tcx>)
                       -> OperandRef<'tcx>
@@ -165,7 +164,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
     }
 
     pub fn trans_consume(&mut self,
-                         bcx: &BlockAndBuilder<'a, 'tcx>,
+                         bcx: &Builder<'a, 'tcx>,
                          lvalue: &mir::Lvalue<'tcx>)
                          -> OperandRef<'tcx>
     {
@@ -212,12 +211,12 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
         // for most lvalues, to consume them we just load them
         // out from their home
         let tr_lvalue = self.trans_lvalue(bcx, lvalue);
-        let ty = tr_lvalue.ty.to_ty(bcx.tcx());
+        let ty = tr_lvalue.ty.to_ty(bcx.ccx.tcx());
         self.trans_load(bcx, tr_lvalue.llval, ty)
     }
 
     pub fn trans_operand(&mut self,
-                         bcx: &BlockAndBuilder<'a, 'tcx>,
+                         bcx: &Builder<'a, 'tcx>,
                          operand: &mir::Operand<'tcx>)
                          -> OperandRef<'tcx>
     {
@@ -242,7 +241,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
     }
 
     pub fn store_operand(&mut self,
-                         bcx: &BlockAndBuilder<'a, 'tcx>,
+                         bcx: &Builder<'a, 'tcx>,
                          lldest: ValueRef,
                          operand: OperandRef<'tcx>,
                          align: Option<u32>) {

--- a/src/librustc_trans/mir/operand.rs
+++ b/src/librustc_trans/mir/operand.rs
@@ -211,7 +211,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
         // for most lvalues, to consume them we just load them
         // out from their home
         let tr_lvalue = self.trans_lvalue(bcx, lvalue);
-        let ty = tr_lvalue.ty.to_ty(bcx.ccx.tcx());
+        let ty = tr_lvalue.ty.to_ty(bcx.tcx());
         self.trans_load(bcx, tr_lvalue.llval, ty)
     }
 

--- a/src/librustc_trans/mir/rvalue.rs
+++ b/src/librustc_trans/mir/rvalue.rs
@@ -17,8 +17,9 @@ use middle::lang_items::ExchangeMallocFnLangItem;
 
 use asm;
 use base;
+use builder::Builder;
 use callee::Callee;
-use common::{self, val_ty, C_bool, C_null, C_uint, BlockAndBuilder};
+use common::{self, val_ty, C_bool, C_null, C_uint};
 use common::{C_integral};
 use adt;
 use machine;
@@ -35,10 +36,10 @@ use super::lvalue::{LvalueRef};
 
 impl<'a, 'tcx> MirContext<'a, 'tcx> {
     pub fn trans_rvalue(&mut self,
-                        bcx: BlockAndBuilder<'a, 'tcx>,
+                        bcx: Builder<'a, 'tcx>,
                         dest: LvalueRef<'tcx>,
                         rvalue: &mir::Rvalue<'tcx>)
-                        -> BlockAndBuilder<'a, 'tcx>
+                        -> Builder<'a, 'tcx>
     {
         debug!("trans_rvalue(dest.llval={:?}, rvalue={:?})",
                Value(dest.llval), rvalue);
@@ -79,7 +80,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                         // index into the struct, and this case isn't
                         // important enough for it.
                         debug!("trans_rvalue: creating ugly alloca");
-                        let lltemp = base::alloc_ty(&bcx, operand.ty, "__unsize_temp");
+                        let lltemp = bcx.alloca_ty(operand.ty, "__unsize_temp");
                         base::store_ty(&bcx, llval, lltemp, operand.ty);
                         lltemp
                     }
@@ -91,7 +92,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
 
             mir::Rvalue::Repeat(ref elem, ref count) => {
                 let tr_elem = self.trans_operand(&bcx, elem);
-                let size = count.value.as_u64(bcx.tcx().sess.target.uint_type);
+                let size = count.value.as_u64(bcx.ccx.tcx().sess.target.uint_type);
                 let size = C_uint(bcx.ccx, size);
                 let base = base::get_dataptr(&bcx, dest.llval);
                 tvec::slice_for_each(&bcx, base, tr_elem.ty, size, |bcx, llslot| {
@@ -103,7 +104,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                 match *kind {
                     mir::AggregateKind::Adt(adt_def, variant_index, _, active_field_index) => {
                         let disr = Disr::from(adt_def.variants[variant_index].disr_val);
-                        let dest_ty = dest.ty.to_ty(bcx.tcx());
+                        let dest_ty = dest.ty.to_ty(bcx.ccx.tcx());
                         adt::trans_set_discr(&bcx, dest_ty, dest.llval, Disr::from(disr));
                         for (i, operand) in operands.iter().enumerate() {
                             let op = self.trans_operand(&bcx, operand);
@@ -119,7 +120,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                     },
                     _ => {
                         // If this is a tuple or closure, we need to translate GEP indices.
-                        let layout = bcx.ccx.layout_of(dest.ty.to_ty(bcx.tcx()));
+                        let layout = bcx.ccx.layout_of(dest.ty.to_ty(bcx.ccx.tcx()));
                         let translation = if let Layout::Univariant { ref variant, .. } = *layout {
                             Some(&variant.memory_index)
                         } else {
@@ -149,7 +150,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
             mir::Rvalue::InlineAsm { ref asm, ref outputs, ref inputs } => {
                 let outputs = outputs.iter().map(|output| {
                     let lvalue = self.trans_lvalue(&bcx, output);
-                    (lvalue.llval, lvalue.ty.to_ty(bcx.tcx()))
+                    (lvalue.llval, lvalue.ty.to_ty(bcx.ccx.tcx()))
                 }).collect();
 
                 let input_vals = inputs.iter().map(|input| {
@@ -170,9 +171,9 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
     }
 
     pub fn trans_rvalue_operand(&mut self,
-                                bcx: BlockAndBuilder<'a, 'tcx>,
+                                bcx: Builder<'a, 'tcx>,
                                 rvalue: &mir::Rvalue<'tcx>)
-                                -> (BlockAndBuilder<'a, 'tcx>, OperandRef<'tcx>)
+                                -> (Builder<'a, 'tcx>, OperandRef<'tcx>)
     {
         assert!(rvalue_creates_operand(rvalue), "cannot trans {:?} to operand", rvalue);
 
@@ -344,9 +345,9 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
             mir::Rvalue::Ref(_, bk, ref lvalue) => {
                 let tr_lvalue = self.trans_lvalue(&bcx, lvalue);
 
-                let ty = tr_lvalue.ty.to_ty(bcx.tcx());
-                let ref_ty = bcx.tcx().mk_ref(
-                    bcx.tcx().mk_region(ty::ReErased),
+                let ty = tr_lvalue.ty.to_ty(bcx.ccx.tcx());
+                let ref_ty = bcx.ccx.tcx().mk_ref(
+                    bcx.ccx.tcx().mk_region(ty::ReErased),
                     ty::TypeAndMut { ty: ty, mutbl: bk.to_mutbl_lossy() }
                 );
 
@@ -371,7 +372,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                 let tr_lvalue = self.trans_lvalue(&bcx, lvalue);
                 let operand = OperandRef {
                     val: OperandValue::Immediate(tr_lvalue.len(bcx.ccx)),
-                    ty: bcx.tcx().types.usize,
+                    ty: bcx.ccx.tcx().types.usize,
                 };
                 (bcx, operand)
             }
@@ -398,7 +399,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                 };
                 let operand = OperandRef {
                     val: OperandValue::Immediate(llresult),
-                    ty: op.ty(bcx.tcx(), lhs.ty, rhs.ty),
+                    ty: op.ty(bcx.ccx.tcx(), lhs.ty, rhs.ty),
                 };
                 (bcx, operand)
             }
@@ -408,8 +409,8 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                 let result = self.trans_scalar_checked_binop(&bcx, op,
                                                              lhs.immediate(), rhs.immediate(),
                                                              lhs.ty);
-                let val_ty = op.ty(bcx.tcx(), lhs.ty, rhs.ty);
-                let operand_ty = bcx.tcx().intern_tup(&[val_ty, bcx.tcx().types.bool]);
+                let val_ty = op.ty(bcx.ccx.tcx(), lhs.ty, rhs.ty);
+                let operand_ty = bcx.ccx.tcx().intern_tup(&[val_ty, bcx.ccx.tcx().types.bool]);
                 let operand = OperandRef {
                     val: result,
                     ty: operand_ty
@@ -443,16 +444,16 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                 let align = type_of::align_of(bcx.ccx, content_ty);
                 let llalign = C_uint(bcx.ccx, align);
                 let llty_ptr = llty.ptr_to();
-                let box_ty = bcx.tcx().mk_box(content_ty);
+                let box_ty = bcx.ccx.tcx().mk_box(content_ty);
 
                 // Allocate space:
-                let def_id = match bcx.tcx().lang_items.require(ExchangeMallocFnLangItem) {
+                let def_id = match bcx.ccx.tcx().lang_items.require(ExchangeMallocFnLangItem) {
                     Ok(id) => id,
                     Err(s) => {
-                        bcx.sess().fatal(&format!("allocation of `{}` {}", box_ty, s));
+                        bcx.ccx.sess().fatal(&format!("allocation of `{}` {}", box_ty, s));
                     }
                 };
-                let r = Callee::def(bcx.ccx, def_id, bcx.tcx().intern_substs(&[]))
+                let r = Callee::def(bcx.ccx, def_id, bcx.ccx.tcx().intern_substs(&[]))
                     .reify(bcx.ccx);
                 let val = bcx.pointercast(bcx.call(r, &[llsize, llalign], None), llty_ptr);
 
@@ -477,7 +478,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
     }
 
     pub fn trans_scalar_binop(&mut self,
-                              bcx: &BlockAndBuilder<'a, 'tcx>,
+                              bcx: &Builder<'a, 'tcx>,
                               op: mir::BinOp,
                               lhs: ValueRef,
                               rhs: ValueRef,
@@ -552,7 +553,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
     }
 
     pub fn trans_fat_ptr_binop(&mut self,
-                               bcx: &BlockAndBuilder<'a, 'tcx>,
+                               bcx: &Builder<'a, 'tcx>,
                                op: mir::BinOp,
                                lhs_addr: ValueRef,
                                lhs_extra: ValueRef,
@@ -599,7 +600,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
     }
 
     pub fn trans_scalar_checked_binop(&mut self,
-                                      bcx: &BlockAndBuilder<'a, 'tcx>,
+                                      bcx: &Builder<'a, 'tcx>,
                                       op: mir::BinOp,
                                       lhs: ValueRef,
                                       rhs: ValueRef,
@@ -617,7 +618,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
         // will only succeed if both operands are constant.
         // This is necessary to determine when an overflow Assert
         // will always panic at runtime, and produce a warning.
-        if let Some((val, of)) = const_scalar_checked_binop(bcx.tcx(), op, lhs, rhs, input_ty) {
+        if let Some((val, of)) = const_scalar_checked_binop(bcx.ccx.tcx(), op, lhs, rhs, input_ty) {
             return OperandValue::Pair(val, C_bool(bcx.ccx, of));
         }
 
@@ -681,12 +682,12 @@ enum OverflowOp {
     Add, Sub, Mul
 }
 
-fn get_overflow_intrinsic(oop: OverflowOp, bcx: &BlockAndBuilder, ty: Ty) -> ValueRef {
+fn get_overflow_intrinsic(oop: OverflowOp, bcx: &Builder, ty: Ty) -> ValueRef {
     use syntax::ast::IntTy::*;
     use syntax::ast::UintTy::*;
     use rustc::ty::{TyInt, TyUint};
 
-    let tcx = bcx.tcx();
+    let tcx = bcx.ccx.tcx();
 
     let new_sty = match ty.sty {
         TyInt(Is) => match &tcx.sess.target.target.target_pointer_width[..] {

--- a/src/librustc_trans/mir/rvalue.rs
+++ b/src/librustc_trans/mir/rvalue.rs
@@ -118,7 +118,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                                     substs: self.monomorphize(&substs),
                                     variant_index: disr.0 as usize,
                                 };
-                                let lldest_i = adt::trans_field_ptr(&bcx, val, field_index);
+                                let lldest_i = val.trans_field_ptr(&bcx, field_index);
                                 self.store_operand(&bcx, lldest_i, op, None);
                             }
                         }

--- a/src/librustc_trans/mir/rvalue.rs
+++ b/src/librustc_trans/mir/rvalue.rs
@@ -110,10 +110,9 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                             let op = self.trans_operand(&bcx, operand);
                             // Do not generate stores and GEPis for zero-sized fields.
                             if !common::type_is_zero_size(bcx.ccx, op.ty) {
-                                let val = adt::MaybeSizedValue::sized(dest.llval);
+                                let val = LvalueRef::new_sized_ty(dest.llval, dest_ty);
                                 let field_index = active_field_index.unwrap_or(i);
-                                let lldest_i = adt::trans_field_ptr(&bcx, dest_ty, val, disr,
-                                    field_index);
+                                let lldest_i = adt::trans_field_ptr(&bcx, val, disr, field_index);
                                 self.store_operand(&bcx, lldest_i, op, None);
                             }
                         }

--- a/src/librustc_trans/mir/statement.rs
+++ b/src/librustc_trans/mir/statement.rs
@@ -11,7 +11,8 @@
 use rustc::mir;
 
 use base;
-use common::{self, BlockAndBuilder};
+use common;
+use builder::Builder;
 
 use super::MirContext;
 use super::LocalRef;
@@ -20,9 +21,9 @@ use super::super::disr::Disr;
 
 impl<'a, 'tcx> MirContext<'a, 'tcx> {
     pub fn trans_statement(&mut self,
-                           bcx: BlockAndBuilder<'a, 'tcx>,
+                           bcx: Builder<'a, 'tcx>,
                            statement: &mir::Statement<'tcx>)
-                           -> BlockAndBuilder<'a, 'tcx> {
+                           -> Builder<'a, 'tcx> {
         debug!("trans_statement(statement={:?})", statement);
 
         self.set_debug_loc(&bcx, statement.source_info);
@@ -77,10 +78,10 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
     }
 
     fn trans_storage_liveness(&self,
-                              bcx: BlockAndBuilder<'a, 'tcx>,
+                              bcx: Builder<'a, 'tcx>,
                               lvalue: &mir::Lvalue<'tcx>,
                               intrinsic: base::Lifetime)
-                              -> BlockAndBuilder<'a, 'tcx> {
+                              -> Builder<'a, 'tcx> {
         if let mir::Lvalue::Local(index) = *lvalue {
             if let LocalRef::Lvalue(tr_lval) = self.locals[index] {
                 intrinsic.call(&bcx, tr_lval.llval);

--- a/src/librustc_trans/tvec.rs
+++ b/src/librustc_trans/tvec.rs
@@ -29,9 +29,9 @@ pub fn slice_for_each<'a, 'tcx, F>(
         bcx.inbounds_gep(a, &[b])
     };
 
-    let body_bcx = bcx.build_new_block("slice_loop_body");
-    let next_bcx = bcx.build_new_block("slice_loop_next");
-    let header_bcx = bcx.build_new_block("slice_loop_header");
+    let body_bcx = bcx.build_sibling_block("slice_loop_body");
+    let next_bcx = bcx.build_sibling_block("slice_loop_next");
+    let header_bcx = bcx.build_sibling_block("slice_loop_header");
 
     let start = if zst {
         C_uint(bcx.ccx, 0usize)

--- a/src/librustc_trans/tvec.rs
+++ b/src/librustc_trans/tvec.rs
@@ -9,28 +9,29 @@
 // except according to those terms.
 
 use llvm;
+use builder::Builder;
 use llvm::ValueRef;
 use common::*;
 use rustc::ty::Ty;
 
 pub fn slice_for_each<'a, 'tcx, F>(
-    bcx: &BlockAndBuilder<'a, 'tcx>,
+    bcx: &Builder<'a, 'tcx>,
     data_ptr: ValueRef,
     unit_ty: Ty<'tcx>,
     len: ValueRef,
     f: F
-) -> BlockAndBuilder<'a, 'tcx> where F: FnOnce(&BlockAndBuilder<'a, 'tcx>, ValueRef) {
+) -> Builder<'a, 'tcx> where F: FnOnce(&Builder<'a, 'tcx>, ValueRef) {
     // Special-case vectors with elements of size 0  so they don't go out of bounds (#9890)
     let zst = type_is_zero_size(bcx.ccx, unit_ty);
-    let add = |bcx: &BlockAndBuilder, a, b| if zst {
+    let add = |bcx: &Builder, a, b| if zst {
         bcx.add(a, b)
     } else {
         bcx.inbounds_gep(a, &[b])
     };
 
-    let body_bcx = bcx.fcx().build_new_block("slice_loop_body");
-    let next_bcx = bcx.fcx().build_new_block("slice_loop_next");
-    let header_bcx = bcx.fcx().build_new_block("slice_loop_header");
+    let body_bcx = bcx.build_new_block("slice_loop_body");
+    let next_bcx = bcx.build_new_block("slice_loop_next");
+    let header_bcx = bcx.build_new_block("slice_loop_header");
 
     let start = if zst {
         C_uint(bcx.ccx, 0usize)

--- a/src/test/codegen/stores.rs
+++ b/src/test/codegen/stores.rs
@@ -24,8 +24,8 @@ pub struct Bytes {
 // dependent alignment
 #[no_mangle]
 pub fn small_array_alignment(x: &mut [i8; 4], y: [i8; 4]) {
-// CHECK: %arg1 = alloca [4 x i8]
 // CHECK: [[TMP:%.+]] = alloca i32
+// CHECK: %arg1 = alloca [4 x i8]
 // CHECK: store i32 %1, i32* [[TMP]]
 // CHECK: [[Y8:%[0-9]+]] = bitcast [4 x i8]* %arg1 to i8*
 // CHECK: [[TMP8:%[0-9]+]] = bitcast i32* [[TMP]] to i8*
@@ -38,8 +38,8 @@ pub fn small_array_alignment(x: &mut [i8; 4], y: [i8; 4]) {
 // dependent alignment
 #[no_mangle]
 pub fn small_struct_alignment(x: &mut Bytes, y: Bytes) {
-// CHECK: %arg1 = alloca %Bytes
 // CHECK: [[TMP:%.+]] = alloca i32
+// CHECK: %arg1 = alloca %Bytes
 // CHECK: store i32 %1, i32* [[TMP]]
 // CHECK: [[Y8:%[0-9]+]] = bitcast %Bytes* %arg1 to i8*
 // CHECK: [[TMP8:%[0-9]+]] = bitcast i32* [[TMP]] to i8*


### PR DESCRIPTION
Removes `BlockAndBuilder`, `FunctionContext`, and `MaybeSizedValue`.

`LvalueRef` is used instead of `MaybeSizedValue`, which has the added benefit of making functions operating on `Lvalue`s be able to take just that (since it encodes the type with an `LvalueTy`, which can carry discriminant information) instead of a `MaybeSizedValue` and a discriminant.

r? @eddyb 