### PR TITLE
Fix pre-cfg_attr notation in comment

### DIFF
--- a/src/test/run-make/test-harness/Makefile
+++ b/src/test/run-make/test-harness/Makefile
@@ -1,7 +1,7 @@
 -include ../tools.mk
 
 all:
-	# check that #[ignore(cfg(...))] does the right thing.
+	# check that #[cfg_attr(..., ignore)] does the right thing.
 	$(RUSTC) --test test-ignore-cfg.rs --cfg ignorecfg
 	$(call RUN,test-ignore-cfg) | grep 'shouldnotignore ... ok'
 	$(call RUN,test-ignore-cfg) | grep 'shouldignore ... ignored'


### PR DESCRIPTION
Commit aa3b1261b164eeac3e68573bfc698d1ca943fb05 has changed notation
in the test from `#[ignore(cfg(ignorecfg))]` to `#[cfg_attr(ignorecfg, ignore)]`,
but missed to change the comment in the accompanying Makefile.