### PR TITLE
rustbuild: fix dist-analysis with full bootstrap disabled

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -320,10 +320,18 @@ pub fn analysis(build: &Build, compiler: &Compiler, target: &str) {
         return
     }
 
+    // Package save-analysis from stage1 if not doing a full bootstrap, as the
+    // stage2 artifacts is simply copied from stage1 in that case.
+    let compiler = if build.force_use_stage1(compiler, target) {
+        Compiler::new(1, compiler.host)
+    } else {
+        compiler.clone()
+    };
+
     let name = format!("rust-analysis-{}", package_vers(build));
     let image = tmpdir(build).join(format!("{}-{}-image", name, target));
 
-    let src = build.stage_out(compiler, Mode::Libstd).join(target).join("release").join("deps");
+    let src = build.stage_out(&compiler, Mode::Libstd).join(target).join("release").join("deps");
 
     let image_src = src.join("save-analysis");
     let dst = image.join("lib/rustlib").join(target).join("analysis");


### PR DESCRIPTION
Really fixes #38734, per discussion in #38752 which was solving the underlying problem the wrong way.

This just mirrors the [similar logic] in documentation building as suggested, that just takes the stage1 compiler artifacts instead in case of non-full-bootstrap builds. Actually copying the artifacts around seems to be unnecessary.

r? @alexcrichton 


[similar logic]: https://github.com/rust-lang/rust/blob/7b659cfdbce094a790dbb246da2681a47565782a/src/bootstrap/doc.rs#L140-L144