### PR TITLE
Some i128 tests

### DIFF
--- a/src/rt/rust_test_helpers.c
+++ b/src/rt/rust_test_helpers.c
@@ -268,3 +268,22 @@ LARGE_INTEGER increment_all_parts(LARGE_INTEGER li) {
     li.QuadPart += 1;
     return li;
 }
+
+#define DO_INT128_TEST !(defined(WIN32) || defined(_WIN32) || defined(__WIN32)) && \
+    defined(__amd64__)
+
+#if DO_INT128_TEST
+
+unsigned __int128 identity(unsigned __int128 a) {
+    return a;
+}
+
+__int128 square(__int128 a) {
+    return a * a;
+}
+
+__int128 sub(__int128 a, __int128 b) {
+    return a - b;
+}
+
+#endif

--- a/src/test/run-pass/i128-ffi.rs
+++ b/src/test/run-pass/i128-ffi.rs
@@ -1,0 +1,45 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-stage0
+// ignore-stage1
+
+// MSVC doesn't support 128 bit integers, and other Windows
+// C compilers have very inconsistent views on how the ABI
+// should look like.
+
+// ignore-windows
+
+// Ignore 32 bit targets:
+// ignore-x86, ignore-arm
+
+#![feature(i128_type)]
+
+#[link(name = "rust_test_helpers", kind = "static")]
+extern "C" {
+    fn identity(f: u128) -> u128;
+    fn square(f: i128) -> i128;
+    fn sub(f: i128, f: i128) -> i128;
+}
+
+fn main() {
+    unsafe {
+        let a = 0x734C_C2F2_A521;
+        let b = 0x33EE_0E2A_54E2_59DA_A0E7_8E41;
+        let b_out = identity(b);
+        assert_eq!(b, b_out);
+        let a_square = square(a);
+        assert_eq!(b, a_square as u128);
+        let k = 0x1234_5678_9ABC_DEFF_EDCB_A987_6543_210;
+        let k_d = 0x2468_ACF1_3579_BDFF_DB97_530E_CA86_420;
+        let k_out = sub(k_d, k);
+        assert_eq!(k, k_out);
+    }
+}

--- a/src/test/run-pass/i128.rs
+++ b/src/test/run-pass/i128.rs
@@ -96,4 +96,12 @@ fn main() {
     assert_eq!((-z).checked_mul(-z), Some(0x734C_C2F2_A521));
     assert_eq!((z).checked_mul(z), Some(0x734C_C2F2_A521));
     assert_eq!((k).checked_mul(k), None);
+    let l: i128 = b(i128::min_value());
+    let o: i128 = b(17);
+    assert_eq!(l.checked_sub(b(2)), None);
+    assert_eq!(l.checked_add(l), None);
+    assert_eq!((-(l + 1)).checked_add(2), None);
+    assert_eq!(l.checked_sub(l), Some(0));
+    assert_eq!(b(1u128).checked_shl(b(127)), Some(1 << 127));
+    assert_eq!(o.checked_shl(b(128)), None);
 }

--- a/src/test/run-pass/u128.rs
+++ b/src/test/run-pass/u128.rs
@@ -10,7 +10,10 @@
 
 // ignore-stage0
 // ignore-stage1
-#![feature(i128_type)]
+#![feature(i128_type, test)]
+
+extern crate test;
+use test::black_box as b;
 
 fn main() {
     let x: u128 = 0xFFFF_FFFF_FFFF_FFFF__FFFF_FFFF_FFFF_FFFF;
@@ -63,5 +66,15 @@ fn main() {
         format!("{}", u128::max_value()));
     assert_eq!("147573952589676412928", format!("{:?}", j));
     // common traits
-    x.clone();
+    assert_eq!(x, b(x.clone()));
+    // overflow checks
+    assert_eq!((z).checked_mul(z), Some(0x734C_C2F2_A521));
+    assert_eq!((k).checked_mul(k), None);
+    let l: u128 = b(u128::max_value() - 10);
+    let o: u128 = b(17);
+    assert_eq!(l.checked_add(b(11)), None);
+    assert_eq!(l.checked_sub(l), Some(0));
+    assert_eq!(o.checked_sub(b(18)), None);
+    assert_eq!(b(1u128).checked_shl(b(127)), Some(1 << 127));
+    assert_eq!(o.checked_shl(b(128)), None);
 }


### PR DESCRIPTION
* Add some FFI tests for i128 on architectures where we have sort of working "C" FFI support. On all other architectures we ignore the test.
* enhance the u128 overflow tests