### PR TITLE
Fix regression with duplicate `#[macro_export] macro_rules!`

### DIFF
--- a/src/test/run-pass/auxiliary/issue_38715.rs
+++ b/src/test/run-pass/auxiliary/issue_38715.rs
@@ -1,0 +1,15 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_export]
+macro_rules! foo { ($i:ident) => {} }
+
+#[macro_export]
+macro_rules! foo { () => {} }

--- a/src/test/run-pass/issue-38715.rs
+++ b/src/test/run-pass/issue-38715.rs
@@ -1,0 +1,20 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue_38715.rs
+
+// Test that `#[macro_export] macro_rules!` shadow earlier `#[macro_export] macro_rules!`
+
+#[macro_use]
+extern crate issue_38715;
+
+fn main() {
+    foo!();
+}


### PR DESCRIPTION
Fixes #38715.
r? @nrc 