### PR TITLE
book: match enum warning

### DIFF
--- a/src/doc/book/match.md
+++ b/src/doc/book/match.md
@@ -82,7 +82,7 @@ fn process_message(msg: Message) {
     match msg {
         Message::Quit => quit(),
         Message::ChangeColor(r, g, b) => change_color(r, g, b),
-        Message::Move { x: x, y: y } => move_cursor(x, y),
+        Message::Move { x, y: new_name_for_y } => move_cursor(x, new_name_for_y),
         Message::Write(s) => println!("{}", s),
     };
 }


### PR DESCRIPTION
Matching enums with named fields in the previous way yielded the "non_shorthand_field_patterns" warning.
The new code shows the shorthand syntax as well as field renaming, so it should be exhaustive ;-)