### PR TITLE
Print attributes on expressions when pretty printing.

### DIFF
--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -1210,6 +1210,7 @@ impl<'a> State<'a> {
 
     pub fn print_expr(&mut self, expr: &hir::Expr) -> io::Result<()> {
         self.maybe_print_comment(expr.span.lo)?;
+        self.print_outer_attributes(&expr.attrs)?;
         self.ibox(indent_unit)?;
         self.ann.pre(self, NodeExpr(expr))?;
         match expr.node {


### PR DESCRIPTION
Test case: `rustc -Z unstable-options --unpretty=hir <(echo 'fn main() { #[allow()] main() }')`