### PR TITLE
resolve: don't `unused_qualifications`-check global paths

### DIFF
--- a/src/test/compile-fail/lint-qualification.rs
+++ b/src/test/compile-fail/lint-qualification.rs
@@ -21,8 +21,9 @@ fn main() {
 
     let _ = || -> Result<(), ()> { try!(Ok(())); Ok(()) }; // issue #37345
 
-    macro_rules! m {
-        () => { $crate::foo::bar(); }
-    }
-    m!(); // issue #37357
+    macro_rules! m { () => {
+        $crate::foo::bar(); // issue #37357
+        ::foo::bar(); // issue #38682
+    } }
+    m!();
 }


### PR DESCRIPTION
We started `unused_qualifications`-checking global paths in #38014, causing #38682.
Fixes #38682.
r? @nrc 