### PR TITLE
Improve doc cfg(test) and tests directory

### DIFF
--- a/src/doc/book/testing.md
+++ b/src/doc/book/testing.md
@@ -499,6 +499,10 @@ be imported in every test with `mod common;`
 That's all there is to the `tests` directory. The `tests` module isn't needed
 here, since the whole thing is focused on tests.
 
+Note, when building integration tests, cargo will not pass the `test` attribute
+to the compiler. It means that all parts in `cfg(test)` won't be included in
+the build used in your integration tests.
+
 Let's finally check out that third section: documentation tests.
 
 # Documentation tests


### PR DESCRIPTION
Hi,

I was facing a problem with my code organisation. I was using a tests directory and i defined some `#[cfg(test)]` in my `src/`. But i was not able to use it in my `tests` folder.

```bash
.
├── Cargo.lock
├── Cargo.toml
├── src
│   ├── lib.rs
│   └── test.rs
└── tests
    └── x.rs
```
> src/lib.rs
```rust
#[cfg(test)]
pub mod test;

#[test]
fn tesst() {
    assert!(test::t());
}
```
> src/test.rs
```rust
pub fn t() -> bool { true }
```
> test/x.rs
```rust
extern crate testt;

use testt::test;
#[test]
fn tesst() {
    assert!(test::t());
}
```

I was unable to compile using `cargo test`:
```bash
error[E0432]: unresolved import `testt::test`
 --> tests/x.rs:3:5
  |
3 | use testt::test;
  |     ^^^^^^^^^^^ no `test` in `testt`
```

If i remove the `tests` directory everything works fine. To use an utils module in your `tests` directory, you need to create a module in the directory (like `tests/utils.rs`). My `tests/x.rs` look like this now:

```rust
extern crate testt;

mod utils;

#[test]
fn tesst() {
    assert!(utils::t());
}
```

And my tree:
```bash
.
├── Cargo.lock
├── Cargo.toml
├── src
│   └── lib.rs
└── tests
    ├── utils.rs
    └── x.rs
```

I think that thing must be documented in the book.

Ping:
- @badboy : Because he's the one who showed me the path
- @shahn : Because he helped me too to find the solution

Signed-off-by: Freyskeyd <simon.paitrault@iadvize.com>