### PR TITLE
rustdoc: Add an attribute to ignore collecting tests per-item.

### DIFF
--- a/src/doc/book/documentation.md
+++ b/src/doc/book/documentation.md
@@ -651,6 +651,16 @@ through the `#![doc(test(..))]` attribute.
 This allows unused variables within the examples, but will fail the test for any
 other lint warning thrown.
 
+You can also ignore tests for a given item and all the nested items under it
+with:
+
+```rust
+#![doc(test(ignore))]
+```
+
+Tests for documentation examples for that item or nested items won't be
+generated.
+
 ## Generation options
 
 `rustdoc` also contains a few other options on the command line, for further customization:

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -20,6 +20,7 @@
 
 #![feature(box_patterns)]
 #![feature(box_syntax)]
+#![feature(conservative_impl_trait)]
 #![feature(libc)]
 #![feature(rustc_private)]
 #![feature(set_stdio)]

--- a/src/test/rustdoc/ignore.rs
+++ b/src/test/rustdoc/ignore.rs
@@ -1,0 +1,59 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:--test
+
+#[doc(test(ignore))]
+pub mod foo {
+    /**
+     * This doc example should be ignored.
+     *
+     * ```
+     * this is invalid rust, and thus would fail the test.
+     * ```
+     */
+    pub fn bar() { }
+
+    /// Just like this.
+    ///
+    /// ```
+    /// moar invalid code
+    /// ```
+    pub struct Foo(());
+
+    impl Foo {
+        /// And this too.
+        ///
+        /// ```rust
+        /// void* foo = bar();
+        /// foo->do_baz();
+        /// ```
+        pub fn baz(&self) -> i32 {
+            unreachable!();
+        }
+    }
+}
+
+pub mod boo {
+    /// This one should run though.
+    ///
+    /// ```
+    /// let foo = 0xbadc0de;
+    /// ```
+    pub fn bar() {}
+
+    /// But this should be ignored.
+    ///
+    /// ```rust
+    /// moar code that wouldn't compile in ages.
+    /// ```
+    #[doc(test(ignore))]
+    pub struct Bar;
+}


### PR DESCRIPTION
This allows to ignore tests in modules we know they have uneffective tests, or
tests not under our control, like for example in:

https://github.com/servo/rust-bindgen/issues/378

r? @alexcrichton 