### PR TITLE
Fix ICE on i686 when calling immediate() on OperandValue::Ref in return

### DIFF
--- a/src/librustc_trans/mir/block.rs
+++ b/src/librustc_trans/mir/block.rs
@@ -223,7 +223,11 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                     load
                 } else {
                     let op = self.trans_consume(&bcx, &mir::Lvalue::Local(mir::RETURN_POINTER));
-                    op.pack_if_pair(&bcx).immediate()
+                    if let Ref(llval) = op.val {
+                        base::load_ty(&bcx, llval, op.ty)
+                    } else {
+                        op.pack_if_pair(&bcx).immediate()
+                    }
                 };
                 bcx.ret(llval);
             }

--- a/src/test/run-pass/issue-38727.rs
+++ b/src/test/run-pass/issue-38727.rs
@@ -1,0 +1,21 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[repr(u64)]
+enum A {
+    A = 0u64,
+    B = !0u64,
+}
+
+fn cmp() -> A {
+    A::B
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #38727, and adds a test case.

r? @eddyb 