### PR TITLE
Add std::process::Command::envs()

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -377,6 +377,38 @@ impl Command {
         self
     }
 
+    /// Add or update multiple environment variable mappings.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    /// ```no_run
+    /// use std::process::{Command, Stdio};
+    /// use std::env;
+    ///
+    /// let filtered_env : Vec<(String, String)> =
+    ///     env::vars().filter(|&(ref k, _)|
+    ///         k == "TERM" || k == "TZ" || k == "LANG" || k == "PATH"
+    ///     ).collect();
+    ///
+    /// Command::new("printenv")
+    ///         .stdin(Stdio::null())
+    ///         .stdout(Stdio::inherit())
+    ///         .env_clear()
+    ///         .envs(&filtered_env)
+    ///         .spawn()
+    ///         .expect("printenv failed to start");
+    /// ```
+    #[stable(feature = "process", since = "1.16.0")]
+    pub fn envs<K, V>(&mut self, vars: &[(K, V)]) -> &mut Command
+        where K: AsRef<OsStr>, V: AsRef<OsStr>
+    {
+        for &(ref key, ref val) in vars {
+            self.inner.env(key.as_ref(), val.as_ref());
+        }
+        self
+    }
+
     /// Removes an environment variable mapping.
     ///
     /// # Examples

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -345,7 +345,9 @@ impl Command {
     ///         .expect("ls command failed to start");
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
-    pub fn args<S: AsRef<OsStr>>(&mut self, args: &[S]) -> &mut Command {
+    pub fn args<I, S>(&mut self, args: I) -> &mut Command
+        where I: IntoIterator<Item=S>, S: AsRef<OsStr>
+    {
         for arg in args {
             self.arg(arg.as_ref());
         }
@@ -385,8 +387,9 @@ impl Command {
     /// ```no_run
     /// use std::process::{Command, Stdio};
     /// use std::env;
+    /// use std::collections::HashMap;
     ///
-    /// let filtered_env : Vec<(String, String)> =
+    /// let filtered_env : HashMap<String, String> =
     ///     env::vars().filter(|&(ref k, _)|
     ///         k == "TERM" || k == "TZ" || k == "LANG" || k == "PATH"
     ///     ).collect();
@@ -399,11 +402,11 @@ impl Command {
     ///         .spawn()
     ///         .expect("printenv failed to start");
     /// ```
-    #[stable(feature = "command_envs", since = "1.16.0")]
-    pub fn envs<K, V>(&mut self, vars: &[(K, V)]) -> &mut Command
-        where K: AsRef<OsStr>, V: AsRef<OsStr>
+    #[unstable(feature = "command_envs", issue = "38526")]
+    pub fn envs<I, K, V>(&mut self, vars: I) -> &mut Command
+        where I: IntoIterator<Item=(K, V)>, K: AsRef<OsStr>, V: AsRef<OsStr>
     {
-        for &(ref key, ref val) in vars {
+        for (ref key, ref val) in vars {
             self.inner.env(key.as_ref(), val.as_ref());
         }
         self

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -399,7 +399,7 @@ impl Command {
     ///         .spawn()
     ///         .expect("printenv failed to start");
     /// ```
-    #[stable(feature = "process", since = "1.16.0")]
+    #[stable(feature = "command_envs", since = "1.16.0")]
     pub fn envs<K, V>(&mut self, vars: &[(K, V)]) -> &mut Command
         where K: AsRef<OsStr>, V: AsRef<OsStr>
     {

--- a/src/test/run-pass/process-envs.rs
+++ b/src/test/run-pass/process-envs.rs
@@ -1,0 +1,60 @@
+// Copyright 2014, 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-emscripten
+
+use std::process::Command;
+use std::env;
+
+#[cfg(all(unix, not(target_os="android")))]
+pub fn env_cmd() -> Command {
+    Command::new("env")
+}
+#[cfg(target_os="android")]
+pub fn env_cmd() -> Command {
+    let mut cmd = Command::new("/system/bin/sh");
+    cmd.arg("-c").arg("set");
+    cmd
+}
+
+#[cfg(windows)]
+pub fn env_cmd() -> Command {
+    let mut cmd = Command::new("cmd");
+    cmd.arg("/c").arg("set");
+    cmd
+}
+
+fn main() {
+    // save original environment
+    let old_env = env::var_os("RUN_TEST_NEW_ENV");
+
+    env::set_var("RUN_TEST_NEW_ENV", "123");
+
+    // create filtered environment vector
+    let filtered_env : Vec<(String, String)> =
+        env::vars().filter(|&(ref k, _)| k == "PATH").collect();
+
+    let mut cmd = env_cmd()
+        .env_clear()
+        .envs(&filtered_env);
+
+    // restore original environment
+    match old_env {
+        None => env::remove_var("RUN_TEST_NEW_ENV"),
+        Some(val) => env::set_var("RUN_TEST_NEW_ENV", &val)
+    }
+
+    let prog = cmd.spawn().unwrap();
+    let result = prog.wait_with_output().unwrap();
+    let output = String::from_utf8_lossy(&result.stdout);
+
+    assert!(!output.contains("RUN_TEST_NEW_ENV"),
+            "found RUN_TEST_NEW_ENV inside of:\n\n{}", output);
+}

--- a/src/test/run-pass/process-envs.rs
+++ b/src/test/run-pass/process-envs.rs
@@ -41,9 +41,9 @@ fn main() {
     let filtered_env : Vec<(String, String)> =
         env::vars().filter(|&(ref k, _)| k == "PATH").collect();
 
-    let mut cmd = env_cmd()
-        .env_clear()
-        .envs(&filtered_env);
+    let mut cmd = env_cmd();
+    cmd.env_clear();
+    cmd.envs(&filtered_env);
 
     // restore original environment
     match old_env {
@@ -51,8 +51,7 @@ fn main() {
         Some(val) => env::set_var("RUN_TEST_NEW_ENV", &val)
     }
 
-    let prog = cmd.spawn().unwrap();
-    let result = prog.wait_with_output().unwrap();
+    let result = cmd.output().unwrap();
     let output = String::from_utf8_lossy(&result.stdout);
 
     assert!(!output.contains("RUN_TEST_NEW_ENV"),

--- a/src/test/run-pass/process-envs.rs
+++ b/src/test/run-pass/process-envs.rs
@@ -10,8 +10,11 @@
 
 // ignore-emscripten
 
+#![feature(command_envs)]
+
 use std::process::Command;
 use std::env;
+use std::collections::HashMap;
 
 #[cfg(all(unix, not(target_os="android")))]
 pub fn env_cmd() -> Command {
@@ -38,7 +41,7 @@ fn main() {
     env::set_var("RUN_TEST_NEW_ENV", "123");
 
     // create filtered environment vector
-    let filtered_env : Vec<(String, String)> =
+    let filtered_env : HashMap<String, String> =
         env::vars().filter(|&(ref k, _)| k == "PATH").collect();
 
     let mut cmd = env_cmd();

--- a/src/test/run-pass/process-remove-from-env.rs
+++ b/src/test/run-pass/process-remove-from-env.rs
@@ -46,8 +46,7 @@ fn main() {
         Some(val) => env::set_var("RUN_TEST_NEW_ENV", &val)
     }
 
-    let prog = cmd.spawn().unwrap();
-    let result = prog.wait_with_output().unwrap();
+    let result = cmd.output().unwrap();
     let output = String::from_utf8_lossy(&result.stdout);
 
     assert!(!output.contains("RUN_TEST_NEW_ENV"),


### PR DESCRIPTION
`Command::envs()` adds a vector of key-value pairs to the child
process environment all at once.  Suggested in #38526.

This is not fully baked and frankly I'm not sure it even _works_, but I need some help finishing it up, and this is the simplest way to show you what I've got.  The problems I know exist and don't know how to solve, from most to least important, are:

* [ ] I don't know if the type signature of the new function is correct.
* [x] The new test might not be getting run.  I didn't see it go by in the output of `x.py test src/libstd --stage 1`.
* [x] The tidy check says ``process.rs:402: different `since` than before`` which I don't know what it means.

r? @brson