### PR TITLE
E0088/E0090 fix

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4565,7 +4565,6 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         // Check provided lifetime parameters.
         let lifetime_defs = segment.map_or(&[][..], |(_, generics)| &generics.regions);
         if lifetimes.len() > lifetime_defs.len() {
-            let span = lifetimes[lifetime_defs.len()].span;
             struct_span_err!(self.tcx.sess, span, E0088,
                              "too many lifetime parameters provided: \
                               expected {}, found {}",
@@ -4573,6 +4572,14 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                               count(lifetimes.len()))
                 .span_label(span, &format!("unexpected lifetime parameter{}",
                                            match lifetimes.len() { 1 => "", _ => "s" }))
+                .emit();
+        } else if lifetimes.len() > 0 && lifetimes.len() < lifetime_defs.len() {
+            struct_span_err!(self.tcx.sess, span, E0090,
+                             "too few lifetime parameters provided: \
+                             expected {}, found {}",
+                             count(lifetime_defs.len()),
+                             count(lifetimes.len()))
+                .span_label(span, &format!("too few lifetime parameters"))
                 .emit();
         }
 

--- a/src/test/compile-fail/E0090.rs
+++ b/src/test/compile-fail/E0090.rs
@@ -1,0 +1,5 @@
+fn foo<'a: 'b, 'b: 'a>() {}
+fn main() {
+    foo::<'static>();//~ ERROR E0090
+                     //~^ too few lifetime parameters
+}

--- a/src/test/compile-fail/E0090.rs
+++ b/src/test/compile-fail/E0090.rs
@@ -1,3 +1,13 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 fn foo<'a: 'b, 'b: 'a>() {}
 fn main() {
     foo::<'static>();//~ ERROR E0090


### PR DESCRIPTION
This fixes an issue reported by @eddyb (https://github.com/rust-lang/rust/pull/36208#issuecomment-2707092230) where the check for "too few lifetime parameters" was removed in one of the error message PRs.

I also removed the span shrinking from E0088, as early bound lifetimes give you a confusing underline in some cases.

r=eddyb