### PR TITLE
std: Ignore close_read_wakes_up on Windows

### DIFF
--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -1179,6 +1179,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)] // test doesn't work on Windows, see #31657
     fn close_read_wakes_up() {
         each_ip(&mut |addr| {
             let a = t!(TcpListener::bind(&addr));


### PR DESCRIPTION
It looks like in practice at least this test will not pass on Windows.
Empirically it is prone to blocking forever, presumably because a call to
`shutdown` doesn't actually wake up other threads on Windows.

We don't document this as a guarantee for `shutdown`, nor do we internally rely
on it. This test originated in a time long since passed when it was leveraged
for canceling I/O, but nowadays there's nothing fancy happening in the standard
library so it's not really a productive test anyway, hence just ignoring it on
Windows.

Closes #31657