### PR TITLE
Update vec.rs

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -370,7 +370,8 @@ impl<T> Vec<T> {
     /// * `capacity` needs to be the capacity that the pointer was allocated with.
     ///
     /// Violating these may cause problems like corrupting the allocator's
-    /// internal datastructures.
+    /// internal datastructures. For example it is **not** safe
+    /// to build a `Vec<u8>` from a C pointer to a char array and a `size_t`.
     ///
     /// The ownership of `ptr` is effectively transferred to the
     /// `Vec<T>` which may then deallocate, reallocate or change the

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -371,7 +371,7 @@ impl<T> Vec<T> {
     ///
     /// Violating these may cause problems like corrupting the allocator's
     /// internal datastructures. For example it is **not** safe
-    /// to build a `Vec<u8>` from a C pointer to a char array and a `size_t`.
+    /// to build a `Vec<u8>` from a pointer to a C `char` array and a `size_t`.
     ///
     /// The ownership of `ptr` is effectively transferred to the
     /// `Vec<T>` which may then deallocate, reallocate or change the


### PR DESCRIPTION
Add a warning not to convert  char* from c to Vec<u8> (I thought you could until I asked on irc).

Reasoning is that it will help people avoid an error that could cause crashes and undefined behaviour. Only drawback is that it could confuse someone not familiar with C, but beginners are unlikely to be using this function anyway.