### PR TITLE
libcompiler_builtins: Don't build emutls.c

### DIFF
--- a/src/libcompiler_builtins/build.rs
+++ b/src/libcompiler_builtins/build.rs
@@ -242,10 +242,6 @@ fn main() {
                          "atomic_thread_fence.c"]);
     }
 
-    if !target.contains("redox") && !target.contains("windows") {
-        sources.extend(&["emutls.c"]);
-    }
-
     if target.contains("msvc") {
         if target.contains("x86_64") {
             sources.extend(&["x86_64/floatdidf.c", "x86_64/floatdisf.c", "x86_64/floatdixf.c"]);


### PR DESCRIPTION
Rather than improving the check, let's ditch emutls.c entirely.