### PR TITLE
resolve: Do not use "resolve"/"resolution" in error messages

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2084,10 +2084,25 @@ impl<'a> Resolver<'a> {
             let expected = source.descr_expected();
             let path_str = names_to_string(path);
             let code = source.error_code(def.is_some());
-            let base_msg = if let Some(def) = def {
-                format!("expected {}, found {} `{}`", expected, def.kind_name(), path_str)
+            let (base_msg, fallback_label) = if let Some(def) = def {
+                (format!("expected {}, found {} `{}`", expected, def.kind_name(), path_str),
+                 format!("not a {}", expected))
             } else {
-                format!("unresolved {} `{}`", expected, path_str)
+                let item_str = path[path.len() - 1];
+                let (mod_prefix, mod_str) = if path.len() == 1 {
+                    (format!(""), format!("this scope"))
+                } else if path.len() == 2 && path[0].name == keywords::CrateRoot.name() {
+                    (format!(""), format!("the crate root"))
+                } else {
+                    let mod_path = &path[..path.len() - 1];
+                    let mod_prefix = match this.resolve_path(mod_path, Some(TypeNS), None) {
+                        PathResult::Module(module) => module.def(),
+                        _ => None,
+                    }.map_or(format!(""), |def| format!("{} ", def.kind_name()));
+                    (mod_prefix, format!("`{}`", names_to_string(mod_path)))
+                };
+                (format!("cannot find {} `{}` in {}{}", expected, item_str, mod_prefix, mod_str),
+                 format!("not found in {}", mod_str))
             };
             let mut err = this.session.struct_span_err_with_code(span, &base_msg, code);
 
@@ -2177,12 +2192,8 @@ impl<'a> Resolver<'a> {
                 }
             }
 
-            // Fallback labels.
-            if def.is_some() {
-                err.span_label(span, &format!("not a {}", expected));
-            } else {
-                err.span_label(span, &format!("no resolution found"));
-            }
+            // Fallback label.
+            err.span_label(span, &fallback_label);
             err
         };
         let report_errors = |this: &mut Self, def: Option<Def>| {
@@ -2983,8 +2994,8 @@ impl<'a> Resolver<'a> {
             let participle = |binding: &NameBinding| {
                 if binding.is_import() { "imported" } else { "defined" }
             };
-            let msg1 = format!("`{}` could resolve to the name {} here", name, participle(b1));
-            let msg2 = format!("`{}` could also resolve to the name {} here", name, participle(b2));
+            let msg1 = format!("`{}` could refer to the name {} here", name, participle(b1));
+            let msg2 = format!("`{}` could also refer to the name {} here", name, participle(b2));
             let note = if !lexical && b1.is_glob_import() {
                 format!("consider adding an explicit import of `{}` to disambiguate", name)
             } else if let Def::Macro(..) = b1.def() {

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -380,8 +380,8 @@ impl<'a> Resolver<'a> {
                 MacroBinding::Modern(binding) => (binding.span, "imported"),
                 MacroBinding::Legacy(binding) => (binding.span, "defined"),
             };
-            let msg1 = format!("`{}` could resolve to the macro {} here", ident, participle);
-            let msg2 = format!("`{}` could also resolve to the macro imported here", ident);
+            let msg1 = format!("`{}` could refer to the macro {} here", ident, participle);
+            let msg2 = format!("`{}` could also refer to the macro imported here", ident);
             self.session.struct_span_err(span, &format!("`{}` is ambiguous", ident))
                 .span_note(legacy_span, &msg1)
                 .span_note(resolution.span, &msg2)

--- a/src/test/compile-fail-fulldeps/macro-crate-doesnt-resolve.rs
+++ b/src/test/compile-fail-fulldeps/macro-crate-doesnt-resolve.rs
@@ -14,5 +14,5 @@
 extern crate macro_crate_test;
 
 fn main() {
-    macro_crate_test::foo(); //~ ERROR unresolved function `macro_crate_test::foo`
+    macro_crate_test::foo(); //~ ERROR cannot find function `foo` in module `macro_crate_test`
 }

--- a/src/test/compile-fail-fulldeps/qquote.rs
+++ b/src/test/compile-fail-fulldeps/qquote.rs
@@ -39,6 +39,6 @@ fn main() {
 
     assert_eq!(pprust::expr_to_string(&*quote_expr!(&cx, 23)), "23");
 
-    let expr = quote_expr!(&cx, 2 - $abcd + 7); //~ ERROR unresolved value `abcd`
+    let expr = quote_expr!(&cx, 2 - $abcd + 7); //~ ERROR cannot find value `abcd` in this scope
     assert_eq!(pprust::expr_to_string(&*expr), "2 - $abcd + 7");
 }

--- a/src/test/compile-fail/associated-path-shl.rs
+++ b/src/test/compile-fail/associated-path-shl.rs
@@ -11,10 +11,10 @@
 // Check that associated paths starting with `<<` are successfully parsed.
 
 fn main() {
-    let _: <<A>::B>::C; //~ ERROR unresolved type `A`
-    let _ = <<A>::B>::C; //~ ERROR unresolved type `A`
-    let <<A>::B>::C; //~ ERROR unresolved type `A`
-    let 0 ... <<A>::B>::C; //~ ERROR unresolved type `A`
+    let _: <<A>::B>::C; //~ ERROR cannot find type `A` in this scope
+    let _ = <<A>::B>::C; //~ ERROR cannot find type `A` in this scope
+    let <<A>::B>::C; //~ ERROR cannot find type `A` in this scope
+    let 0 ... <<A>::B>::C; //~ ERROR cannot find type `A` in this scope
                            //~^ ERROR only char and numeric types are allowed in range patterns
-    <<A>::B>::C; //~ ERROR unresolved type `A`
+    <<A>::B>::C; //~ ERROR cannot find type `A` in this scope
 }

--- a/src/test/compile-fail/associated-types-eq-1.rs
+++ b/src/test/compile-fail/associated-types-eq-1.rs
@@ -17,7 +17,7 @@ pub trait Foo {
 }
 
 fn foo2<I: Foo>(x: I) {
-    let _: A = x.boo(); //~ ERROR unresolved type `A`
+    let _: A = x.boo(); //~ ERROR cannot find type `A` in this scope
 }
 
 pub fn main() {}

--- a/src/test/compile-fail/bad-expr-path.rs
+++ b/src/test/compile-fail/bad-expr-path.rs
@@ -12,7 +12,7 @@ mod m1 {}
 
 fn main(arguments: Vec<String>) { //~ ERROR main function has wrong type
     log(debug, m1::arguments);
-    //~^ ERROR unresolved function `log`
-    //~| ERROR unresolved value `debug`
-    //~| ERROR unresolved value `m1::arguments`
+    //~^ ERROR cannot find function `log` in this scope
+    //~| ERROR cannot find value `debug` in this scope
+    //~| ERROR cannot find value `arguments` in module `m1`
 }

--- a/src/test/compile-fail/bad-expr-path2.rs
+++ b/src/test/compile-fail/bad-expr-path2.rs
@@ -14,7 +14,7 @@ mod m1 {
 
 fn main(arguments: Vec<String>) { //~ ERROR main function has wrong type
     log(debug, m1::arguments);
-    //~^ ERROR unresolved function `log`
-    //~| ERROR unresolved value `debug`
+    //~^ ERROR cannot find function `log` in this scope
+    //~| ERROR cannot find value `debug` in this scope
     //~| ERROR expected value, found module `m1::arguments`
 }

--- a/src/test/compile-fail/class-missing-self.rs
+++ b/src/test/compile-fail/class-missing-self.rs
@@ -16,8 +16,8 @@ impl cat {
     fn sleep(&self) { loop{} }
     fn meow(&self) {
       println!("Meow");
-      meows += 1; //~ ERROR unresolved value `meows`
-      sleep();     //~ ERROR unresolved function `sleep`
+      meows += 1; //~ ERROR cannot find value `meows` in this scope
+      sleep();     //~ ERROR cannot find function `sleep` in this scope
     }
 
 }

--- a/src/test/compile-fail/coherence-error-suppression.rs
+++ b/src/test/compile-fail/coherence-error-suppression.rs
@@ -16,7 +16,7 @@ impl Foo for i8 {}
 impl Foo for i16 {}
 impl Foo for i32 {}
 impl Foo for i64 {}
-impl Foo for DoesNotExist {} //~ ERROR unresolved type `DoesNotExist`
+impl Foo for DoesNotExist {} //~ ERROR cannot find type `DoesNotExist` in this scope
 impl Foo for u8 {}
 impl Foo for u16 {}
 impl Foo for u32 {}

--- a/src/test/compile-fail/derived-errors/issue-31997.rs
+++ b/src/test/compile-fail/derived-errors/issue-31997.rs
@@ -20,7 +20,7 @@ fn closure<F, T>(x: F) -> Result<T, ()>
 }
 
 fn foo() -> Result<(), ()> {
-    try!(closure(|| bar(0 as *mut _))); //~ ERROR unresolved function `bar`
+    try!(closure(|| bar(0 as *mut _))); //~ ERROR cannot find function `bar` in this scope
     Ok(())
 }
 

--- a/src/test/compile-fail/does-nothing.rs
+++ b/src/test/compile-fail/does-nothing.rs
@@ -9,4 +9,4 @@
 // except according to those terms.
 
 fn main() { println!("doing"); this_does_nothing_what_the; println!("boing"); }
-//~^ ERROR unresolved value `this_does_nothing_what_the`
+//~^ ERROR cannot find value `this_does_nothing_what_the` in this scope

--- a/src/test/compile-fail/enums-pats-not-idents.rs
+++ b/src/test/compile-fail/enums-pats-not-idents.rs
@@ -9,5 +9,5 @@
 // except according to those terms.
 
 fn main() {
-    let a(1) = 13; //~ ERROR unresolved tuple struct/variant `a`
+    let a(1) = 13; //~ ERROR cannot find tuple struct/variant `a` in this scope
 }

--- a/src/test/compile-fail/export.rs
+++ b/src/test/compile-fail/export.rs
@@ -10,11 +10,11 @@
 
 mod foo {
     pub fn x(y: isize) { log(debug, y); }
-    //~^ ERROR unresolved function `log`
-    //~| ERROR unresolved value `debug`
+    //~^ ERROR cannot find function `log` in this scope
+    //~| ERROR cannot find value `debug` in this scope
     fn z(y: isize) { log(debug, y); }
-    //~^ ERROR unresolved function `log`
-    //~| ERROR unresolved value `debug`
+    //~^ ERROR cannot find function `log` in this scope
+    //~| ERROR cannot find value `debug` in this scope
 }
 
 fn main() { foo::z(10); } //~ ERROR function `z` is private

--- a/src/test/compile-fail/extern-with-type-bounds.rs
+++ b/src/test/compile-fail/extern-with-type-bounds.rs
@@ -24,7 +24,7 @@ extern "rust-intrinsic" {
 
     // Unresolved bounds should still error.
     fn align_of<T: NoSuchTrait>() -> usize;
-    //~^ ERROR unresolved trait `NoSuchTrait`
+    //~^ ERROR cannot find trait `NoSuchTrait` in this scope
 }
 
 fn main() {}

--- a/src/test/compile-fail/for-expn.rs
+++ b/src/test/compile-fail/for-expn.rs
@@ -13,7 +13,7 @@
 fn main() {
     // Odd formatting to make sure we get the right span.
     for t in &
-      foo //~ ERROR unresolved value `foo`
+      foo //~ ERROR cannot find value `foo` in this scope
     {
     }
 }

--- a/src/test/compile-fail/for-loop-hygiene.rs
+++ b/src/test/compile-fail/for-loop-hygiene.rs
@@ -13,6 +13,6 @@
 
 fn main() {
     for _ in 0..10 {
-        iter.next();  //~ ERROR unresolved value `iter`
+        iter.next();  //~ ERROR cannot find value `iter` in this scope
     }
 }

--- a/src/test/compile-fail/glob-resolve1.rs
+++ b/src/test/compile-fail/glob-resolve1.rs
@@ -29,13 +29,13 @@ mod bar {
 fn foo<T>() {}
 
 fn main() {
-    fpriv(); //~ ERROR unresolved function `fpriv`
-    epriv(); //~ ERROR unresolved function `epriv`
+    fpriv(); //~ ERROR cannot find function `fpriv` in this scope
+    epriv(); //~ ERROR cannot find function `epriv` in this scope
     B; //~ ERROR expected value, found enum `B`
-    C; //~ ERROR unresolved value `C`
-    import(); //~ ERROR: unresolved function `import`
+    C; //~ ERROR cannot find value `C` in this scope
+    import(); //~ ERROR: cannot find function `import` in this scope
 
-    foo::<A>(); //~ ERROR: unresolved type `A`
-    foo::<C>(); //~ ERROR: unresolved type `C`
-    foo::<D>(); //~ ERROR: unresolved type `D`
+    foo::<A>(); //~ ERROR: cannot find type `A` in this scope
+    foo::<C>(); //~ ERROR: cannot find type `C` in this scope
+    foo::<D>(); //~ ERROR: cannot find type `D` in this scope
 }

--- a/src/test/compile-fail/import-glob-0.rs
+++ b/src/test/compile-fail/import-glob-0.rs
@@ -21,6 +21,6 @@ mod module_of_many_things {
 fn main() {
     f1();
     f2();
-    f999(); //~ ERROR unresolved function `f999`
+    f999(); //~ ERROR cannot find function `f999` in this scope
     f4();
 }

--- a/src/test/compile-fail/import-glob-circular.rs
+++ b/src/test/compile-fail/import-glob-circular.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: unresolved
-
 mod circ1 {
     pub use circ2::f2;
     pub fn f1() { println!("f1"); }
@@ -25,5 +23,5 @@ mod circ2 {
 mod test {
     use circ1::*;
 
-    fn test() { f1066(); }
+    fn test() { f1066(); } //~ ERROR cannot find function `f1066` in this scope
 }

--- a/src/test/compile-fail/imports/duplicate.rs
+++ b/src/test/compile-fail/imports/duplicate.rs
@@ -32,13 +32,13 @@ mod e {
 }
 
 mod f {
-    pub use a::*; //~ NOTE `foo` could resolve to the name imported here
-    pub use b::*; //~ NOTE `foo` could also resolve to the name imported here
+    pub use a::*; //~ NOTE `foo` could refer to the name imported here
+    pub use b::*; //~ NOTE `foo` could also refer to the name imported here
 }
 
 mod g {
-    pub use a::*; //~ NOTE `foo` could resolve to the name imported here
-    pub use f::*; //~ NOTE `foo` could also resolve to the name imported here
+    pub use a::*; //~ NOTE `foo` could refer to the name imported here
+    pub use f::*; //~ NOTE `foo` could also refer to the name imported here
 }
 
 fn main() {

--- a/src/test/compile-fail/imports/macro-paths.rs
+++ b/src/test/compile-fail/imports/macro-paths.rs
@@ -21,22 +21,22 @@ mod foo {
 }
 
 fn f() {
-    use foo::*; //~ NOTE could also resolve to the name imported here
+    use foo::*; //~ NOTE could also refer to the name imported here
     bar::m! { //~ ERROR ambiguous
               //~| NOTE macro-expanded items do not shadow when used in a macro invocation path
-        mod bar { pub use two_macros::m; } //~ NOTE could resolve to the name defined here
+        mod bar { pub use two_macros::m; } //~ NOTE could refer to the name defined here
                                            //~^^^ NOTE in this expansion
     }
 }
 
-pub mod baz { //~ NOTE could also resolve to the name defined here
+pub mod baz { //~ NOTE could also refer to the name defined here
     pub use two_macros::m;
 }
 
 fn g() {
     baz::m! { //~ ERROR ambiguous
               //~| NOTE macro-expanded items do not shadow when used in a macro invocation path
-        mod baz { pub use two_macros::m; } //~ NOTE could resolve to the name defined here
+        mod baz { pub use two_macros::m; } //~ NOTE could refer to the name defined here
                                            //~^^^ NOTE in this expansion
     }
 }

--- a/src/test/compile-fail/imports/macros.rs
+++ b/src/test/compile-fail/imports/macros.rs
@@ -24,16 +24,16 @@ mod m1 {
 }
 
 mod m2 {
-    use two_macros::*; //~ NOTE could also resolve
+    use two_macros::*; //~ NOTE could also refer
     m! { //~ ERROR ambiguous
          //~| NOTE macro-expanded macro imports do not shadow
-        use foo::m; //~ NOTE could resolve to the name imported here
+        use foo::m; //~ NOTE could refer to the name imported here
                     //~^^^ NOTE in this expansion
     }
 }
 
 mod m3 {
-    use two_macros::m; //~ NOTE could also resolve
+    use two_macros::m; //~ NOTE could also refer
     fn f() {
         use two_macros::n as m; // This shadows the above import
         m!();
@@ -42,14 +42,14 @@ mod m3 {
     fn g() {
         m! { //~ ERROR ambiguous
              //~| NOTE macro-expanded macro imports do not shadow
-            use two_macros::n as m; //~ NOTE could resolve to the name imported here
+            use two_macros::n as m; //~ NOTE could refer to the name imported here
                                     //~^^^ NOTE in this expansion
         }
     }
 }
 
 mod m4 {
-    macro_rules! m { () => {} } //~ NOTE could resolve to the macro defined here
-    use two_macros::m; //~ NOTE could also resolve to the macro imported here
+    macro_rules! m { () => {} } //~ NOTE could refer to the macro defined here
+    use two_macros::m; //~ NOTE could also refer to the macro imported here
     m!(); //~ ERROR ambiguous
 }

--- a/src/test/compile-fail/imports/rfc-1560-warning-cycle.rs
+++ b/src/test/compile-fail/imports/rfc-1560-warning-cycle.rs
@@ -17,8 +17,8 @@ mod bar {
     struct Foo;
 
     mod baz {
-        use *; //~ NOTE `Foo` could resolve to the name imported here
-        use bar::*; //~ NOTE `Foo` could also resolve to the name imported here
+        use *; //~ NOTE `Foo` could refer to the name imported here
+        use bar::*; //~ NOTE `Foo` could also refer to the name imported here
         fn f(_: Foo) {}
         //~^ WARN `Foo` is ambiguous
         //~| WARN hard error in a future release

--- a/src/test/compile-fail/issue-1476.rs
+++ b/src/test/compile-fail/issue-1476.rs
@@ -9,5 +9,5 @@
 // except according to those terms.
 
 fn main() {
-    println!("{}", x); //~ ERROR unresolved value `x`
+    println!("{}", x); //~ ERROR cannot find value `x` in this scope
 }

--- a/src/test/compile-fail/issue-15167.rs
+++ b/src/test/compile-fail/issue-15167.rs
@@ -11,10 +11,10 @@
 // macro f should not be able to inject a reference to 'n'.
 
 macro_rules! f { () => (n) }
-//~^ ERROR unresolved value `n`
-//~| ERROR unresolved value `n`
-//~| ERROR unresolved value `n`
-//~| ERROR unresolved value `n`
+//~^ ERROR cannot find value `n` in this scope
+//~| ERROR cannot find value `n` in this scope
+//~| ERROR cannot find value `n` in this scope
+//~| ERROR cannot find value `n` in this scope
 
 fn main() -> (){
     for n in 0..1 {

--- a/src/test/compile-fail/issue-18058.rs
+++ b/src/test/compile-fail/issue-18058.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 impl Undefined {}
-//~^ ERROR unresolved type `Undefined`
+//~^ ERROR cannot find type `Undefined` in this scope
 
 fn main() {}

--- a/src/test/compile-fail/issue-19883.rs
+++ b/src/test/compile-fail/issue-19883.rs
@@ -17,7 +17,7 @@ trait From<Src> {
 trait To: Sized {
     fn to<Dst: From<Self>>(self) ->
         <Dst as From<Self>>::Dst
-        //~^ ERROR unresolved associated type `From::Dst`
+        //~^ ERROR cannot find associated type `Dst` in trait `From`
     {
         From::from(self)
     }

--- a/src/test/compile-fail/issue-22037.rs
+++ b/src/test/compile-fail/issue-22037.rs
@@ -11,7 +11,7 @@
 trait A {
     type Output;
     fn a(&self) -> <Self as A>::X;
-    //~^ ERROR unresolved associated type `A::X`
+    //~^ ERROR cannot find associated type `X` in trait `A`
 }
 
 impl A for u32 {

--- a/src/test/compile-fail/issue-22384.rs
+++ b/src/test/compile-fail/issue-22384.rs
@@ -14,5 +14,5 @@ trait Trait {
 
 fn main() {
     <<i32 as Copy>::foobar as Trait>::foo();
-    //~^ ERROR unresolved associated type `Copy::foobar`
+    //~^ ERROR cannot find associated type `foobar` in trait `Copy`
 }

--- a/src/test/compile-fail/issue-2281-part1.rs
+++ b/src/test/compile-fail/issue-2281-part1.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn main() { println!("{}", foobar); } //~ ERROR unresolved value `foobar`
+fn main() { println!("{}", foobar); } //~ ERROR cannot find value `foobar` in this scope

--- a/src/test/compile-fail/issue-28388-1.rs
+++ b/src/test/compile-fail/issue-28388-1.rs
@@ -10,6 +10,6 @@
 
 // Prefix in imports with empty braces should be resolved and checked privacy, stability, etc.
 
-use foo::{}; //~ ERROR unresolved module or enum `foo`
+use foo::{}; //~ ERROR cannot find module or enum `foo` in the crate root
 
 fn main() {}

--- a/src/test/compile-fail/issue-30589.rs
+++ b/src/test/compile-fail/issue-30589.rs
@@ -10,7 +10,7 @@
 
 use std::fmt;
 
-impl fmt::Display for DecoderError { //~ ERROR unresolved type `DecoderError`
+impl fmt::Display for DecoderError { //~ ERROR cannot find type `DecoderError` in this scope
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Missing data: {}", self.0)
     }

--- a/src/test/compile-fail/issue-31212.rs
+++ b/src/test/compile-fail/issue-31212.rs
@@ -16,5 +16,5 @@ mod foo {
 }
 
 fn main() {
-    foo::f(); //~ ERROR unresolved
+    foo::f(); //~ ERROR cannot find function `f` in module `foo`
 }

--- a/src/test/compile-fail/issue-31845.rs
+++ b/src/test/compile-fail/issue-31845.rs
@@ -14,7 +14,7 @@ fn f() {
     fn g() {}
     mod foo {
         fn h() {
-           g(); //~ ERROR unresolved function `g`
+           g(); //~ ERROR cannot find function `g` in this scope
         }
     }
 }

--- a/src/test/compile-fail/issue-34334.rs
+++ b/src/test/compile-fail/issue-34334.rs
@@ -11,5 +11,5 @@
 fn main () {
     let sr: Vec<(u32, _, _) = vec![]; //~ ERROR expected one of `+`, `,`, or `>`, found `=`
     let sr2: Vec<(u32, _, _)> = sr.iter().map(|(faction, th_sender, th_receiver)| {}).collect();
-    //~^ ERROR unresolved value `sr`
+    //~^ ERROR cannot find value `sr` in this scope
 }

--- a/src/test/compile-fail/issue-35075.rs
+++ b/src/test/compile-fail/issue-35075.rs
@@ -9,11 +9,11 @@
 // except according to those terms.
 
 struct Bar<T> {
-    inner: Foo<T> //~ ERROR unresolved type `Foo`
+    inner: Foo<T> //~ ERROR cannot find type `Foo` in this scope
 }
 
 enum Baz<T> {
-    Foo(Foo<T>) //~ ERROR unresolved type `Foo`
+    Foo(Foo<T>) //~ ERROR cannot find type `Foo` in this scope
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-37534.rs
+++ b/src/test/compile-fail/issue-37534.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 struct Foo<T: ?Hash> { }
-//~^ ERROR unresolved trait `Hash`
+//~^ ERROR cannot find trait `Hash` in this scope
 //~^^ ERROR parameter `T` is never used
 //~^^^ WARN default bound relaxed for a type parameter, but this does nothing
 

--- a/src/test/compile-fail/issue-4366-2.rs
+++ b/src/test/compile-fail/issue-4366-2.rs
@@ -23,7 +23,7 @@ mod a {
     pub mod sub {
         use a::b::*;
         fn sub() -> bar { 1 }
-        //~^ ERROR unresolved type `bar`
+        //~^ ERROR cannot find type `bar` in this scope
     }
 }
 

--- a/src/test/compile-fail/issue-4366.rs
+++ b/src/test/compile-fail/issue-4366.rs
@@ -25,7 +25,7 @@ mod a {
     }
     pub mod sub {
         use a::b::*;
-        fn sub() -> isize { foo(); 1 } //~ ERROR unresolved function `foo`
+        fn sub() -> isize { foo(); 1 } //~ ERROR cannot find function `foo` in this scope
     }
 }
 

--- a/src/test/compile-fail/issue-5099.rs
+++ b/src/test/compile-fail/issue-5099.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 
-trait B < A > { fn a() -> A { this.a } } //~ ERROR unresolved value `this`
+trait B < A > { fn a() -> A { this.a } } //~ ERROR cannot find value `this` in this scope
 
 fn main() {}

--- a/src/test/compile-fail/issue-5927.rs
+++ b/src/test/compile-fail/issue-5927.rs
@@ -11,8 +11,8 @@
 
 fn main() {
     let z = match 3 {
-        x(1) => x(1) //~ ERROR unresolved tuple struct/variant `x`
-        //~^ ERROR unresolved function `x`
+        x(1) => x(1) //~ ERROR cannot find tuple struct/variant `x` in this scope
+        //~^ ERROR cannot find function `x` in this scope
     };
     assert!(z == 3);
 }

--- a/src/test/compile-fail/issue-7607-1.rs
+++ b/src/test/compile-fail/issue-7607-1.rs
@@ -12,7 +12,7 @@ struct Foo {
     x: isize
 }
 
-impl Fo { //~ ERROR unresolved type `Fo`
+impl Fo { //~ ERROR cannot find type `Fo` in this scope
     fn foo() {}
 }
 

--- a/src/test/compile-fail/issue-8767.rs
+++ b/src/test/compile-fail/issue-8767.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-impl B { //~ ERROR unresolved type `B`
+impl B { //~ ERROR cannot find type `B` in this scope
 }
 
 fn main() {

--- a/src/test/compile-fail/keyword-self-as-identifier.rs
+++ b/src/test/compile-fail/keyword-self-as-identifier.rs
@@ -9,5 +9,5 @@
 // except according to those terms.
 
 fn main() {
-    let Self = "foo"; //~ ERROR unresolved unit struct/variant or constant `Self`
+    let Self = "foo"; //~ ERROR cannot find unit struct/variant or constant `Self` in this scope
 }

--- a/src/test/compile-fail/macro-outer-attributes.rs
+++ b/src/test/compile-fail/macro-outer-attributes.rs
@@ -25,6 +25,6 @@ test!(b,
 // test1!(#[bar])
 #[qux]
 fn main() {
-    a::bar(); //~ ERROR unresolved function `a::bar`
+    a::bar(); //~ ERROR cannot find function `bar` in module `a`
     b::bar();
 }

--- a/src/test/compile-fail/macro-parameter-span.rs
+++ b/src/test/compile-fail/macro-parameter-span.rs
@@ -18,6 +18,6 @@ macro_rules! foo {
 // not to the macro variable '$id'
 fn main() {
     foo!(
-        x //~ ERROR unresolved value `x`
+        x //~ ERROR cannot find value `x` in this scope
         );
 }

--- a/src/test/compile-fail/match-join.rs
+++ b/src/test/compile-fail/match-join.rs
@@ -16,6 +16,6 @@ fn my_panic() -> ! { panic!(); }
 fn main() {
     match true { false => { my_panic(); } true => { } }
 
-    println!("{}", x); //~ ERROR unresolved value `x`
+    println!("{}", x); //~ ERROR cannot find value `x` in this scope
     let x: isize;
 }

--- a/src/test/compile-fail/match-vec-mismatch.rs
+++ b/src/test/compile-fail/match-vec-mismatch.rs
@@ -34,7 +34,7 @@ fn main() {
         [0, 1, 2, 3, x..] => {} //~ ERROR pattern requires
     };
 
-    match does_not_exist { //~ ERROR unresolved value `does_not_exist`
+    match does_not_exist { //~ ERROR cannot find value `does_not_exist` in this scope
         [] => {}
     };
 }

--- a/src/test/compile-fail/mod_file_correct_spans.rs
+++ b/src/test/compile-fail/mod_file_correct_spans.rs
@@ -13,5 +13,6 @@
 mod mod_file_aux;
 
 fn main() {
-    assert!(mod_file_aux::bar() == 10); //~ ERROR unresolved function `mod_file_aux::bar`
+    assert!(mod_file_aux::bar() == 10);
+    //~^ ERROR cannot find function `bar` in module `mod_file_aux`
 }

--- a/src/test/compile-fail/name-clash-nullary.rs
+++ b/src/test/compile-fail/name-clash-nullary.rs
@@ -13,6 +13,6 @@ use std::option::*;
 fn main() {
   let None: isize = 42; //~ ERROR let bindings cannot shadow unit variants
   log(debug, None);
-  //~^ ERROR unresolved function `log`
-  //~| ERROR unresolved value `debug`
+  //~^ ERROR cannot find function `log` in this scope
+  //~| ERROR cannot find value `debug` in this scope
 }

--- a/src/test/compile-fail/namespaced-enum-glob-import-no-impls-xcrate.rs
+++ b/src/test/compile-fail/namespaced-enum-glob-import-no-impls-xcrate.rs
@@ -18,8 +18,8 @@ mod m {
 pub fn main() {
     use namespaced_enums::Foo::*;
 
-    foo(); //~ ERROR unresolved function `foo`
-    m::foo(); //~ ERROR unresolved function `m::foo`
-    bar(); //~ ERROR unresolved function `bar`
-    m::bar(); //~ ERROR unresolved function `m::bar`
+    foo(); //~ ERROR cannot find function `foo` in this scope
+    m::foo(); //~ ERROR cannot find function `foo` in module `m`
+    bar(); //~ ERROR cannot find function `bar` in this scope
+    m::bar(); //~ ERROR cannot find function `bar` in module `m`
 }

--- a/src/test/compile-fail/namespaced-enum-glob-import-no-impls.rs
+++ b/src/test/compile-fail/namespaced-enum-glob-import-no-impls.rs
@@ -28,8 +28,8 @@ mod m {
 pub fn main() {
     use m2::Foo::*;
 
-    foo(); //~ ERROR unresolved function `foo`
-    m::foo(); //~ ERROR unresolved function `m::foo`
-    bar(); //~ ERROR unresolved function `bar`
-    m::bar(); //~ ERROR unresolved function `m::bar`
+    foo(); //~ ERROR cannot find function `foo` in this scope
+    m::foo(); //~ ERROR cannot find function `foo` in module `m`
+    bar(); //~ ERROR cannot find function `bar` in this scope
+    m::bar(); //~ ERROR cannot find function `bar` in module `m`
 }

--- a/src/test/compile-fail/nested-cfg-attrs.rs
+++ b/src/test/compile-fail/nested-cfg-attrs.rs
@@ -11,4 +11,4 @@
 #[cfg_attr(all(), cfg_attr(all(), cfg(foo)))]
 fn f() {}
 
-fn main() { f() } //~ ERROR unresolved function `f`
+fn main() { f() } //~ ERROR cannot find function `f` in this scope

--- a/src/test/compile-fail/no-implicit-prelude-nested.rs
+++ b/src/test/compile-fail/no-implicit-prelude-nested.rs
@@ -18,26 +18,26 @@
 mod foo {
     mod baz {
         struct Test;
-        impl Add for Test {} //~ ERROR unresolved trait `Add`
-        impl Clone for Test {} //~ ERROR unresolved trait `Clone`
-        impl Iterator for Test {} //~ ERROR unresolved trait `Iterator`
-        impl ToString for Test {} //~ ERROR unresolved trait `ToString`
-        impl Writer for Test {} //~ ERROR unresolved trait `Writer`
+        impl Add for Test {} //~ ERROR cannot find trait `Add` in this scope
+        impl Clone for Test {} //~ ERROR cannot find trait `Clone` in this scope
+        impl Iterator for Test {} //~ ERROR cannot find trait `Iterator` in this scope
+        impl ToString for Test {} //~ ERROR cannot find trait `ToString` in this scope
+        impl Writer for Test {} //~ ERROR cannot find trait `Writer` in this scope
 
         fn foo() {
-            drop(2) //~ ERROR unresolved function `drop`
+            drop(2) //~ ERROR cannot find function `drop` in this scope
         }
     }
 
     struct Test;
-    impl Add for Test {} //~ ERROR unresolved trait `Add`
-    impl Clone for Test {} //~ ERROR unresolved trait `Clone`
-    impl Iterator for Test {} //~ ERROR unresolved trait `Iterator`
-    impl ToString for Test {} //~ ERROR unresolved trait `ToString`
-    impl Writer for Test {} //~ ERROR unresolved trait `Writer`
+    impl Add for Test {} //~ ERROR cannot find trait `Add` in this scope
+    impl Clone for Test {} //~ ERROR cannot find trait `Clone` in this scope
+    impl Iterator for Test {} //~ ERROR cannot find trait `Iterator` in this scope
+    impl ToString for Test {} //~ ERROR cannot find trait `ToString` in this scope
+    impl Writer for Test {} //~ ERROR cannot find trait `Writer` in this scope
 
     fn foo() {
-        drop(2) //~ ERROR unresolved function `drop`
+        drop(2) //~ ERROR cannot find function `drop` in this scope
     }
 }
 
@@ -45,14 +45,14 @@ fn qux() {
     #[no_implicit_prelude]
     mod qux_inner {
         struct Test;
-        impl Add for Test {} //~ ERROR unresolved trait `Add`
-        impl Clone for Test {} //~ ERROR unresolved trait `Clone`
-        impl Iterator for Test {} //~ ERROR unresolved trait `Iterator`
-        impl ToString for Test {} //~ ERROR unresolved trait `ToString`
-        impl Writer for Test {} //~ ERROR unresolved trait `Writer`
+        impl Add for Test {} //~ ERROR cannot find trait `Add` in this scope
+        impl Clone for Test {} //~ ERROR cannot find trait `Clone` in this scope
+        impl Iterator for Test {} //~ ERROR cannot find trait `Iterator` in this scope
+        impl ToString for Test {} //~ ERROR cannot find trait `ToString` in this scope
+        impl Writer for Test {} //~ ERROR cannot find trait `Writer` in this scope
 
         fn foo() {
-            drop(2) //~ ERROR unresolved function `drop`
+            drop(2) //~ ERROR cannot find function `drop` in this scope
         }
     }
 }

--- a/src/test/compile-fail/no-implicit-prelude.rs
+++ b/src/test/compile-fail/no-implicit-prelude.rs
@@ -17,12 +17,12 @@
 // fail with the same error message).
 
 struct Test;
-impl Add for Test {} //~ ERROR unresolved trait `Add`
-impl Clone for Test {} //~ ERROR unresolved trait `Clone`
-impl Iterator for Test {} //~ ERROR unresolved trait `Iterator`
-impl ToString for Test {} //~ ERROR unresolved trait `ToString`
-impl Writer for Test {} //~ ERROR unresolved trait `Writer`
+impl Add for Test {} //~ ERROR cannot find trait `Add` in this scope
+impl Clone for Test {} //~ ERROR cannot find trait `Clone` in this scope
+impl Iterator for Test {} //~ ERROR cannot find trait `Iterator` in this scope
+impl ToString for Test {} //~ ERROR cannot find trait `ToString` in this scope
+impl Writer for Test {} //~ ERROR cannot find trait `Writer` in this scope
 
 fn main() {
-    drop(2) //~ ERROR unresolved function `drop`
+    drop(2) //~ ERROR cannot find function `drop` in this scope
 }

--- a/src/test/compile-fail/no-link.rs
+++ b/src/test/compile-fail/no-link.rs
@@ -15,5 +15,5 @@ extern crate empty_struct;
 //~^ WARN custom derive crates and `#[no_link]` crates have no effect without `#[macro_use]`
 
 fn main() {
-    empty_struct::XEmpty1; //~ ERROR unresolved value `empty_struct::XEmpty1`
+    empty_struct::XEmpty1; //~ ERROR cannot find value `XEmpty1` in module `empty_struct`
 }

--- a/src/test/compile-fail/parser-recovery-1.rs
+++ b/src/test/compile-fail/parser-recovery-1.rs
@@ -14,11 +14,11 @@
 
 trait Foo {
     fn bar() {
-        let x = foo(); //~ ERROR unresolved function `foo`
+        let x = foo(); //~ ERROR cannot find function `foo` in this scope
 
 }
 
 fn main() {
     let x = y.;  //~ ERROR unexpected token
-                 //~^ ERROR unresolved value `y`
+                 //~^ ERROR cannot find value `y` in this scope
 } //~ ERROR this file contains an un-closed delimiter

--- a/src/test/compile-fail/parser-recovery-2.rs
+++ b/src/test/compile-fail/parser-recovery-2.rs
@@ -14,11 +14,11 @@
 
 trait Foo {
     fn bar() {
-        let x = foo(); //~ ERROR unresolved function `foo`
+        let x = foo(); //~ ERROR cannot find function `foo` in this scope
     ) //~ ERROR incorrect close delimiter: `)`
 }
 
 fn main() {
     let x = y.;  //~ ERROR unexpected token
-                 //~^ ERROR unresolved value `y`
+                 //~^ ERROR cannot find value `y` in this scope
 }

--- a/src/test/compile-fail/pattern-macro-hygiene.rs
+++ b/src/test/compile-fail/pattern-macro-hygiene.rs
@@ -12,5 +12,5 @@ macro_rules! foo { () => ( x ) }
 
 fn main() {
     let foo!() = 2;
-    x + 1; //~ ERROR unresolved value `x`
+    x + 1; //~ ERROR cannot find value `x` in this scope
 }

--- a/src/test/compile-fail/privacy-ns1.rs
+++ b/src/test/compile-fail/privacy-ns1.rs
@@ -57,8 +57,8 @@ pub mod foo3 {
 fn test_glob3() {
     use foo3::*;
 
-    Bar();  //~ ERROR unresolved function `Bar`
-    let _x: Box<Bar>;  //~ ERROR unresolved type `Bar`
+    Bar();  //~ ERROR cannot find function `Bar` in this scope
+    let _x: Box<Bar>;  //~ ERROR cannot find type `Bar` in this scope
 }
 
 fn main() {

--- a/src/test/compile-fail/privacy/restricted/ty-params.rs
+++ b/src/test/compile-fail/privacy/restricted/ty-params.rs
@@ -20,7 +20,7 @@ m!{ S<u8> } //~ ERROR type or lifetime parameters in visibility path
 
 mod foo {
     struct S(pub(foo<T>) ()); //~ ERROR type or lifetime parameters in visibility path
-    //~^ ERROR unresolved type `T`
+    //~^ ERROR cannot find type `T` in this scope
 }
 
 fn main() {}

--- a/src/test/compile-fail/recursive-reexports.rs
+++ b/src/test/compile-fail/recursive-reexports.rs
@@ -12,6 +12,6 @@
 
 extern crate recursive_reexports;
 
-fn f() -> recursive_reexports::S {} //~ ERROR unresolved type `recursive_reexports::S`
+fn f() -> recursive_reexports::S {} //~ ERROR cannot find type `S` in module `recursive_reexports`
 
 fn main() {}

--- a/src/test/compile-fail/resolve-bad-import-prefix.rs
+++ b/src/test/compile-fail/resolve-bad-import-prefix.rs
@@ -19,6 +19,6 @@ use m::{}; // OK
 use E::{}; // OK
 use S::{}; //~ ERROR expected module or enum, found struct `S`
 use Tr::{}; //~ ERROR expected module or enum, found trait `Tr`
-use Nonexistent::{}; //~ ERROR unresolved module or enum `Nonexistent`
+use Nonexistent::{}; //~ ERROR cannot find module or enum `Nonexistent` in the crate root
 
 fn main () {}

--- a/src/test/compile-fail/resolve-bad-visibility.rs
+++ b/src/test/compile-fail/resolve-bad-visibility.rs
@@ -16,8 +16,8 @@ trait Tr {}
 pub(E) struct S; //~ ERROR expected module, found enum `E`
 pub(Tr) struct Z; //~ ERROR expected module, found trait `Tr`
 pub(std::vec) struct F; //~ ERROR visibilities can only be restricted to ancestor modules
-pub(nonexistent) struct G; //~ ERROR unresolved module `nonexistent`
-pub(too_soon) struct H; //~ ERROR unresolved module `too_soon`
+pub(nonexistent) struct G; //~ ERROR cannot find module `nonexistent` in the crate root
+pub(too_soon) struct H; //~ ERROR cannot find module `too_soon` in the crate root
 
 // Visibilities are resolved eagerly without waiting for modules becoming fully populated.
 // Visibilities can only use ancestor modules legally which are always available in time,

--- a/src/test/compile-fail/resolve-primitive-fallback.rs
+++ b/src/test/compile-fail/resolve-primitive-fallback.rs
@@ -16,5 +16,5 @@ fn main() {
 
     // Make sure primitive type fallback doesn't work with global paths
     let _: ::u8;
-    //~^ ERROR unresolved type `u8`
+    //~^ ERROR cannot find type `u8` in the crate root
 }

--- a/src/test/compile-fail/resolve-unknown-trait.rs
+++ b/src/test/compile-fail/resolve-unknown-trait.rs
@@ -10,10 +10,10 @@
 
 
 trait NewTrait : SomeNonExistentTrait {}
-//~^ ERROR unresolved trait `SomeNonExistentTrait`
+//~^ ERROR cannot find trait `SomeNonExistentTrait` in this scope
 
 impl SomeNonExistentTrait for isize {}
-//~^ ERROR unresolved trait `SomeNonExistentTrait`
+//~^ ERROR cannot find trait `SomeNonExistentTrait` in this scope
 
 fn f<T:SomeNonExistentTrait>() {}
-//~^ ERROR unresolved trait `SomeNonExistentTrait`
+//~^ ERROR cannot find trait `SomeNonExistentTrait` in this scope

--- a/src/test/compile-fail/rmeta.rs
+++ b/src/test/compile-fail/rmeta.rs
@@ -14,5 +14,5 @@
 // Check that building a metadata crate finds an error.
 
 fn main() {
-    let _ = Foo; //~ ERROR unresolved value `Foo`
+    let _ = Foo; //~ ERROR cannot find value `Foo` in this scope
 }

--- a/src/test/compile-fail/self_type_keyword-2.rs
+++ b/src/test/compile-fail/self_type_keyword-2.rs
@@ -12,12 +12,12 @@ use self::Self as Foo; //~ ERROR unresolved import `self::Self`
 
 pub fn main() {
     let Self = 5;
-    //~^ ERROR unresolved unit struct/variant or constant `Self`
+    //~^ ERROR cannot find unit struct/variant or constant `Self` in this scope
 
     match 15 {
         Self => (),
-        //~^ ERROR unresolved unit struct/variant or constant `Self`
+        //~^ ERROR cannot find unit struct/variant or constant `Self` in this scope
         Foo { x: Self } => (),
-        //~^ ERROR unresolved unit struct/variant or constant `Self`
+        //~^ ERROR cannot find unit struct/variant or constant `Self` in this scope
     }
 }

--- a/src/test/compile-fail/struct-fields-shorthand-unresolved.rs
+++ b/src/test/compile-fail/struct-fields-shorthand-unresolved.rs
@@ -19,6 +19,6 @@ fn main() {
     let x = 0;
     let foo = Foo {
         x,
-        y //~ ERROR unresolved value `y`
+        y //~ ERROR cannot find value `y` in this scope
     };
 }

--- a/src/test/compile-fail/syntax-extension-minor.rs
+++ b/src/test/compile-fail/syntax-extension-minor.rs
@@ -18,7 +18,7 @@ pub fn main() {
     // this now fails (correctly, I claim) because hygiene prevents
     // the assembled identifier from being a reference to the binding.
     assert!(concat_idents!(asd, f_f, dsa) == "<.<".to_string());
-    //~^ ERROR unresolved value `asdf_fdsa`
+    //~^ ERROR cannot find value `asdf_fdsa` in this scope
 
     assert_eq!(stringify!(use_mention_distinction), "use_mention_distinction");
 }

--- a/src/test/compile-fail/test-cfg.rs
+++ b/src/test/compile-fail/test-cfg.rs
@@ -14,5 +14,5 @@
 fn foo() {}
 
 fn main() {
-    foo(); //~ ERROR unresolved function `foo`
+    foo(); //~ ERROR cannot find function `foo` in this scope
 }

--- a/src/test/compile-fail/ufcs-partially-resolved.rs
+++ b/src/test/compile-fail/ufcs-partially-resolved.rs
@@ -26,37 +26,37 @@ enum E { Y }
 type A = u32;
 
 fn main() {
-    let _: <u8 as Tr>::N; //~ ERROR unresolved associated type `Tr::N`
-    let _: <u8 as E>::N; //~ ERROR unresolved associated type `E::N`
-    let _: <u8 as A>::N; //~ ERROR unresolved associated type `A::N`
-    <u8 as Tr>::N; //~ ERROR unresolved method or associated constant `Tr::N`
-    <u8 as E>::N; //~ ERROR unresolved method or associated constant `E::N`
-    <u8 as A>::N; //~ ERROR unresolved method or associated constant `A::N`
+    let _: <u8 as Tr>::N; //~ ERROR cannot find associated type `N` in trait `Tr`
+    let _: <u8 as E>::N; //~ ERROR cannot find associated type `N` in enum `E`
+    let _: <u8 as A>::N; //~ ERROR cannot find associated type `N` in `A`
+    <u8 as Tr>::N; //~ ERROR cannot find method or associated constant `N` in trait `Tr`
+    <u8 as E>::N; //~ ERROR cannot find method or associated constant `N` in enum `E`
+    <u8 as A>::N; //~ ERROR cannot find method or associated constant `N` in `A`
     let _: <u8 as Tr>::Y; // OK
     let _: <u8 as E>::Y; //~ ERROR expected associated type, found variant `E::Y`
     <u8 as Tr>::Y; // OK
     <u8 as E>::Y; //~ ERROR expected method or associated constant, found unit variant `E::Y`
 
-    let _: <u8 as Tr>::N::NN; //~ ERROR unresolved associated type `Tr::N`
-    let _: <u8 as E>::N::NN; //~ ERROR unresolved associated type `E::N`
-    let _: <u8 as A>::N::NN; //~ ERROR unresolved associated type `A::N`
-    <u8 as Tr>::N::NN; //~ ERROR unresolved associated type `Tr::N`
-    <u8 as E>::N::NN; //~ ERROR unresolved associated type `E::N`
-    <u8 as A>::N::NN; //~ ERROR unresolved associated type `A::N`
+    let _: <u8 as Tr>::N::NN; //~ ERROR cannot find associated type `N` in trait `Tr`
+    let _: <u8 as E>::N::NN; //~ ERROR cannot find associated type `N` in enum `E`
+    let _: <u8 as A>::N::NN; //~ ERROR cannot find associated type `N` in `A`
+    <u8 as Tr>::N::NN; //~ ERROR cannot find associated type `N` in trait `Tr`
+    <u8 as E>::N::NN; //~ ERROR cannot find associated type `N` in enum `E`
+    <u8 as A>::N::NN; //~ ERROR cannot find associated type `N` in `A`
     let _: <u8 as Tr>::Y::NN; //~ ERROR ambiguous associated type
     let _: <u8 as E>::Y::NN; //~ ERROR expected associated type, found variant `E::Y`
     <u8 as Tr>::Y::NN; //~ ERROR no associated item named `NN` found for type `<u8 as Tr>::Y`
     <u8 as E>::Y::NN; //~ ERROR expected associated type, found variant `E::Y`
 
-    let _: <u8 as Tr::N>::NN; //~ ERROR unresolved associated type `Tr::N::NN`
-    let _: <u8 as E::N>::NN; //~ ERROR unresolved associated type `E::N::NN`
-    let _: <u8 as A::N>::NN; //~ ERROR unresolved associated type `A::N::NN`
-    <u8 as Tr::N>::NN; //~ ERROR unresolved method or associated constant `Tr::N::NN`
-    <u8 as E::N>::NN; //~ ERROR unresolved method or associated constant `E::N::NN`
-    <u8 as A::N>::NN; //~ ERROR unresolved method or associated constant `A::N::NN`
-    let _: <u8 as Tr::Y>::NN; //~ ERROR unresolved associated type `Tr::Y::NN`
+    let _: <u8 as Tr::N>::NN; //~ ERROR cannot find associated type `NN` in `Tr::N`
+    let _: <u8 as E::N>::NN; //~ ERROR cannot find associated type `NN` in `E::N`
+    let _: <u8 as A::N>::NN; //~ ERROR cannot find associated type `NN` in `A::N`
+    <u8 as Tr::N>::NN; //~ ERROR cannot find method or associated constant `NN` in `Tr::N`
+    <u8 as E::N>::NN; //~ ERROR cannot find method or associated constant `NN` in `E::N`
+    <u8 as A::N>::NN; //~ ERROR cannot find method or associated constant `NN` in `A::N`
+    let _: <u8 as Tr::Y>::NN; //~ ERROR cannot find associated type `NN` in `Tr::Y`
     let _: <u8 as E::Y>::NN; //~ ERROR failed to resolve. Not a module `Y`
-    <u8 as Tr::Y>::NN; //~ ERROR unresolved method or associated constant `Tr::Y::NN`
+    <u8 as Tr::Y>::NN; //~ ERROR cannot find method or associated constant `NN` in `Tr::Y`
     <u8 as E::Y>::NN; //~ ERROR failed to resolve. Not a module `Y`
 
     let _: <u8 as Dr>::Z; //~ ERROR expected associated type, found method `Dr::Z`

--- a/src/test/ui/codemap_tests/tab.stderr
+++ b/src/test/ui/codemap_tests/tab.stderr
@@ -1,8 +1,8 @@
-error[E0425]: unresolved value `bar`
+error[E0425]: cannot find value `bar` in this scope
   --> $DIR/tab.rs:14:2
    |
 14 | \tbar;
-   | \t^^^ no resolution found
+   | \t^^^ not found in this scope
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/macro-backtrace-nested.stderr
+++ b/src/test/ui/macros/macro-backtrace-nested.stderr
@@ -1,17 +1,17 @@
-error[E0425]: unresolved value `fake`
+error[E0425]: cannot find value `fake` in this scope
   --> $DIR/macro-backtrace-nested.rs:15:12
    |
 15 |     () => (fake)
-   |            ^^^^ no resolution found
+   |            ^^^^ not found in this scope
 ...
 27 |     1 + call_nested_expr!();
    |         ------------------- in this macro invocation
 
-error[E0425]: unresolved value `fake`
+error[E0425]: cannot find value `fake` in this scope
   --> $DIR/macro-backtrace-nested.rs:15:12
    |
 15 |     () => (fake)
-   |            ^^^^ no resolution found
+   |            ^^^^ not found in this scope
 ...
 28 |     call_nested_expr_sum!();
    |     ------------------------ in this macro invocation

--- a/src/test/ui/resolve/enums-are-namespaced-xc.stderr
+++ b/src/test/ui/resolve/enums-are-namespaced-xc.stderr
@@ -1,26 +1,26 @@
-error[E0425]: unresolved value `namespaced_enums::A`
+error[E0425]: cannot find value `A` in module `namespaced_enums`
   --> $DIR/enums-are-namespaced-xc.rs:15:13
    |
 15 |     let _ = namespaced_enums::A;
-   |             ^^^^^^^^^^^^^^^^^^^ no resolution found
+   |             ^^^^^^^^^^^^^^^^^^^ not found in `namespaced_enums`
    |
    = help: possible candidate is found in another module, you can import it into scope:
    = help:   `use namespaced_enums::Foo::A;`
 
-error[E0425]: unresolved function `namespaced_enums::B`
+error[E0425]: cannot find function `B` in module `namespaced_enums`
   --> $DIR/enums-are-namespaced-xc.rs:18:13
    |
 18 |     let _ = namespaced_enums::B(10);
-   |             ^^^^^^^^^^^^^^^^^^^ no resolution found
+   |             ^^^^^^^^^^^^^^^^^^^ not found in `namespaced_enums`
    |
    = help: possible candidate is found in another module, you can import it into scope:
    = help:   `use namespaced_enums::Foo::B;`
 
-error[E0422]: unresolved struct, variant or union type `namespaced_enums::C`
+error[E0422]: cannot find struct, variant or union type `C` in module `namespaced_enums`
   --> $DIR/enums-are-namespaced-xc.rs:21:13
    |
 21 |     let _ = namespaced_enums::C { a: 10 };
-   |             ^^^^^^^^^^^^^^^^^^^ no resolution found
+   |             ^^^^^^^^^^^^^^^^^^^ not found in `namespaced_enums`
    |
    = help: possible candidate is found in another module, you can import it into scope:
    = help:   `use namespaced_enums::Foo::C;`

--- a/src/test/ui/resolve/issue-14254.stderr
+++ b/src/test/ui/resolve/issue-14254.stderr
@@ -1,142 +1,142 @@
-error[E0425]: unresolved function `baz`
+error[E0425]: cannot find function `baz` in this scope
   --> $DIR/issue-14254.rs:29:9
    |
 29 |         baz();
    |         ^^^ did you mean `self.baz(...)`?
 
-error[E0425]: unresolved value `a`
+error[E0425]: cannot find value `a` in this scope
   --> $DIR/issue-14254.rs:32:9
    |
 32 |         a;
-   |         ^ no resolution found
+   |         ^ not found in this scope
 
-error[E0425]: unresolved function `baz`
+error[E0425]: cannot find function `baz` in this scope
   --> $DIR/issue-14254.rs:40:9
    |
 40 |         baz();
    |         ^^^ did you mean `self.baz(...)`?
 
-error[E0425]: unresolved value `x`
+error[E0425]: cannot find value `x` in this scope
   --> $DIR/issue-14254.rs:43:9
    |
 43 |         x;
    |         ^ did you mean `self.x`?
 
-error[E0425]: unresolved value `y`
+error[E0425]: cannot find value `y` in this scope
   --> $DIR/issue-14254.rs:46:9
    |
 46 |         y;
    |         ^ did you mean `self.y`?
 
-error[E0425]: unresolved value `a`
+error[E0425]: cannot find value `a` in this scope
   --> $DIR/issue-14254.rs:49:9
    |
 49 |         a;
-   |         ^ no resolution found
+   |         ^ not found in this scope
 
-error[E0425]: unresolved value `bah`
+error[E0425]: cannot find value `bah` in this scope
   --> $DIR/issue-14254.rs:52:9
    |
 52 |         bah;
    |         ^^^ did you mean `Self::bah`?
 
-error[E0425]: unresolved value `b`
+error[E0425]: cannot find value `b` in this scope
   --> $DIR/issue-14254.rs:55:9
    |
 55 |         b;
-   |         ^ no resolution found
+   |         ^ not found in this scope
 
-error[E0425]: unresolved function `baz`
+error[E0425]: cannot find function `baz` in this scope
   --> $DIR/issue-14254.rs:63:9
    |
 63 |         baz();
    |         ^^^ did you mean `self.baz(...)`?
 
-error[E0425]: unresolved value `x`
+error[E0425]: cannot find value `x` in this scope
   --> $DIR/issue-14254.rs:66:9
    |
 66 |         x;
    |         ^ did you mean `self.x`?
 
-error[E0425]: unresolved value `y`
+error[E0425]: cannot find value `y` in this scope
   --> $DIR/issue-14254.rs:69:9
    |
 69 |         y;
    |         ^ did you mean `self.y`?
 
-error[E0425]: unresolved value `a`
+error[E0425]: cannot find value `a` in this scope
   --> $DIR/issue-14254.rs:72:9
    |
 72 |         a;
-   |         ^ no resolution found
+   |         ^ not found in this scope
 
-error[E0425]: unresolved value `bah`
+error[E0425]: cannot find value `bah` in this scope
   --> $DIR/issue-14254.rs:75:9
    |
 75 |         bah;
    |         ^^^ did you mean `Self::bah`?
 
-error[E0425]: unresolved value `b`
+error[E0425]: cannot find value `b` in this scope
   --> $DIR/issue-14254.rs:78:9
    |
 78 |         b;
-   |         ^ no resolution found
+   |         ^ not found in this scope
 
-error[E0425]: unresolved function `baz`
+error[E0425]: cannot find function `baz` in this scope
   --> $DIR/issue-14254.rs:86:9
    |
 86 |         baz();
    |         ^^^ did you mean `self.baz(...)`?
 
-error[E0425]: unresolved value `bah`
+error[E0425]: cannot find value `bah` in this scope
   --> $DIR/issue-14254.rs:89:9
    |
 89 |         bah;
    |         ^^^ did you mean `Self::bah`?
 
-error[E0425]: unresolved function `baz`
+error[E0425]: cannot find function `baz` in this scope
   --> $DIR/issue-14254.rs:97:9
    |
 97 |         baz();
    |         ^^^ did you mean `self.baz(...)`?
 
-error[E0425]: unresolved value `bah`
+error[E0425]: cannot find value `bah` in this scope
    --> $DIR/issue-14254.rs:100:9
     |
 100 |         bah;
     |         ^^^ did you mean `Self::bah`?
 
-error[E0425]: unresolved function `baz`
+error[E0425]: cannot find function `baz` in this scope
    --> $DIR/issue-14254.rs:108:9
     |
 108 |         baz();
     |         ^^^ did you mean `self.baz(...)`?
 
-error[E0425]: unresolved value `bah`
+error[E0425]: cannot find value `bah` in this scope
    --> $DIR/issue-14254.rs:111:9
     |
 111 |         bah;
     |         ^^^ did you mean `Self::bah`?
 
-error[E0425]: unresolved function `baz`
+error[E0425]: cannot find function `baz` in this scope
    --> $DIR/issue-14254.rs:119:9
     |
 119 |         baz();
     |         ^^^ did you mean `self.baz(...)`?
 
-error[E0425]: unresolved value `bah`
+error[E0425]: cannot find value `bah` in this scope
    --> $DIR/issue-14254.rs:122:9
     |
 122 |         bah;
     |         ^^^ did you mean `Self::bah`?
 
-error[E0425]: unresolved function `baz`
+error[E0425]: cannot find function `baz` in this scope
    --> $DIR/issue-14254.rs:130:9
     |
 130 |         baz();
     |         ^^^ did you mean `self.baz(...)`?
 
-error[E0425]: unresolved value `bah`
+error[E0425]: cannot find value `bah` in this scope
    --> $DIR/issue-14254.rs:133:9
     |
 133 |         bah;

--- a/src/test/ui/resolve/issue-17518.stderr
+++ b/src/test/ui/resolve/issue-17518.stderr
@@ -1,8 +1,8 @@
-error[E0422]: unresolved struct, variant or union type `E`
+error[E0422]: cannot find struct, variant or union type `E` in this scope
   --> $DIR/issue-17518.rs:16:5
    |
 16 |     E { name: "foobar" }; //~ ERROR unresolved struct, variant or union type `E`
-   |     ^ no resolution found
+   |     ^ not found in this scope
    |
    = help: possible candidate is found in another module, you can import it into scope:
    = help:   `use SomeEnum::E;`

--- a/src/test/ui/resolve/issue-21221-1.stderr
+++ b/src/test/ui/resolve/issue-21221-1.stderr
@@ -1,19 +1,19 @@
-error[E0405]: unresolved trait `Mul`
+error[E0405]: cannot find trait `Mul` in this scope
   --> $DIR/issue-21221-1.rs:53:6
    |
 53 | impl Mul for Foo {
-   |      ^^^ no resolution found
+   |      ^^^ not found in this scope
    |
    = help: possible candidates are found in other modules, you can import them into scope:
    = help:   `use mul1::Mul;`
    = help:   `use mul2::Mul;`
    = help:   `use std::ops::Mul;`
 
-error[E0412]: unresolved type `Mul`
+error[E0412]: cannot find type `Mul` in this scope
   --> $DIR/issue-21221-1.rs:72:16
    |
 72 | fn getMul() -> Mul {
-   |                ^^^ no resolution found
+   |                ^^^ not found in this scope
    |
    = help: possible candidates are found in other modules, you can import them into scope:
    = help:   `use mul1::Mul;`
@@ -22,17 +22,17 @@ error[E0412]: unresolved type `Mul`
    = help:   `use mul4::Mul;`
    = help:   and 2 other candidates
 
-error[E0405]: unresolved trait `ThisTraitReallyDoesntExistInAnyModuleReally`
+error[E0405]: cannot find trait `ThisTraitReallyDoesntExistInAnyModuleReally` in this scope
   --> $DIR/issue-21221-1.rs:83:6
    |
 83 | impl ThisTraitReallyDoesntExistInAnyModuleReally for Foo {
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no resolution found
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
 
-error[E0405]: unresolved trait `Div`
+error[E0405]: cannot find trait `Div` in this scope
   --> $DIR/issue-21221-1.rs:88:6
    |
 88 | impl Div for Foo {
-   |      ^^^ no resolution found
+   |      ^^^ not found in this scope
    |
    = help: possible candidate is found in another module, you can import it into scope:
    = help:   `use std::ops::Div;`

--- a/src/test/ui/resolve/issue-21221-2.stderr
+++ b/src/test/ui/resolve/issue-21221-2.stderr
@@ -1,8 +1,8 @@
-error[E0405]: unresolved trait `T`
+error[E0405]: cannot find trait `T` in this scope
   --> $DIR/issue-21221-2.rs:28:6
    |
 28 | impl T for Foo { }
-   |      ^ no resolution found
+   |      ^ not found in this scope
    |
    = help: possible candidate is found in another module, you can import it into scope:
    = help:   `use foo::bar::T;`

--- a/src/test/ui/resolve/issue-21221-3.stderr
+++ b/src/test/ui/resolve/issue-21221-3.stderr
@@ -1,8 +1,8 @@
-error[E0405]: unresolved trait `OuterTrait`
+error[E0405]: cannot find trait `OuterTrait` in this scope
   --> $DIR/issue-21221-3.rs:25:6
    |
 25 | impl OuterTrait for Foo {}
-   |      ^^^^^^^^^^ no resolution found
+   |      ^^^^^^^^^^ not found in this scope
    |
    = help: possible candidate is found in another module, you can import it into scope:
    = help:   `use issue_21221_3::outer::OuterTrait;`

--- a/src/test/ui/resolve/issue-21221-4.stderr
+++ b/src/test/ui/resolve/issue-21221-4.stderr
@@ -1,8 +1,8 @@
-error[E0405]: unresolved trait `T`
+error[E0405]: cannot find trait `T` in this scope
   --> $DIR/issue-21221-4.rs:20:6
    |
 20 | impl T for Foo {}
-   |      ^ no resolution found
+   |      ^ not found in this scope
    |
    = help: possible candidate is found in another module, you can import it into scope:
    = help:   `use issue_21221_4::T;`

--- a/src/test/ui/resolve/issue-23305.stderr
+++ b/src/test/ui/resolve/issue-23305.stderr
@@ -1,4 +1,4 @@
-error[E0411]: unresolved type `Self`
+error[E0411]: cannot find type `Self` in this scope
   --> $DIR/issue-23305.rs:15:12
    |
 15 | impl ToNbt<Self> {}

--- a/src/test/ui/resolve/issue-2356.stderr
+++ b/src/test/ui/resolve/issue-2356.stderr
@@ -1,22 +1,22 @@
-error[E0425]: unresolved function `shave`
+error[E0425]: cannot find function `shave` in this scope
   --> $DIR/issue-2356.rs:27:5
    |
 27 |     shave();
-   |     ^^^^^ no resolution found
+   |     ^^^^^ not found in this scope
 
-error[E0425]: unresolved function `clone`
+error[E0425]: cannot find function `clone` in this scope
   --> $DIR/issue-2356.rs:35:5
    |
 35 |     clone();
    |     ^^^^^ did you mean `self.clone(...)`?
 
-error[E0425]: unresolved function `default`
+error[E0425]: cannot find function `default` in this scope
   --> $DIR/issue-2356.rs:43:5
    |
 43 |     default();
    |     ^^^^^^^ did you mean `Self::default`?
 
-error[E0425]: unresolved value `whiskers`
+error[E0425]: cannot find value `whiskers` in this scope
   --> $DIR/issue-2356.rs:52:5
    |
 52 |     whiskers -= other;
@@ -25,41 +25,41 @@ error[E0425]: unresolved value `whiskers`
    |     did you mean `self.whiskers`?
    |     `self` value is only available in methods with `self` parameter
 
-error[E0425]: unresolved function `shave`
+error[E0425]: cannot find function `shave` in this scope
   --> $DIR/issue-2356.rs:57:5
    |
 57 |     shave(4);
    |     ^^^^^ did you mean `Self::shave`?
 
-error[E0425]: unresolved function `purr`
+error[E0425]: cannot find function `purr` in this scope
   --> $DIR/issue-2356.rs:60:5
    |
 60 |     purr();
-   |     ^^^^ no resolution found
+   |     ^^^^ not found in this scope
 
-error[E0425]: unresolved function `static_method`
+error[E0425]: cannot find function `static_method` in this scope
   --> $DIR/issue-2356.rs:70:9
    |
 70 |         static_method();
-   |         ^^^^^^^^^^^^^ no resolution found
+   |         ^^^^^^^^^^^^^ not found in this scope
 
-error[E0425]: unresolved function `purr`
+error[E0425]: cannot find function `purr` in this scope
   --> $DIR/issue-2356.rs:73:9
    |
 73 |         purr();
-   |         ^^^^ no resolution found
+   |         ^^^^ not found in this scope
 
-error[E0425]: unresolved function `purr`
+error[E0425]: cannot find function `purr` in this scope
   --> $DIR/issue-2356.rs:76:9
    |
 76 |         purr();
-   |         ^^^^ no resolution found
+   |         ^^^^ not found in this scope
 
-error[E0425]: unresolved function `purr`
+error[E0425]: cannot find function `purr` in this scope
   --> $DIR/issue-2356.rs:79:9
    |
 79 |         purr();
-   |         ^^^^ no resolution found
+   |         ^^^^ not found in this scope
 
 error[E0424]: expected value, found module `self`
   --> $DIR/issue-2356.rs:87:8
@@ -67,25 +67,25 @@ error[E0424]: expected value, found module `self`
 87 |     if self.whiskers > 3 {
    |        ^^^^ `self` value is only available in methods with `self` parameter
 
-error[E0425]: unresolved function `grow_older`
+error[E0425]: cannot find function `grow_older` in this scope
   --> $DIR/issue-2356.rs:95:5
    |
 95 |     grow_older();
-   |     ^^^^^^^^^^ no resolution found
+   |     ^^^^^^^^^^ not found in this scope
 
-error[E0425]: unresolved function `shave`
+error[E0425]: cannot find function `shave` in this scope
   --> $DIR/issue-2356.rs:98:5
    |
 98 |     shave();
-   |     ^^^^^ no resolution found
+   |     ^^^^^ not found in this scope
 
-error[E0425]: unresolved value `whiskers`
+error[E0425]: cannot find value `whiskers` in this scope
    --> $DIR/issue-2356.rs:104:5
     |
 104 |     whiskers = 0;
     |     ^^^^^^^^ did you mean `self.whiskers`?
 
-error[E0425]: unresolved value `whiskers`
+error[E0425]: cannot find value `whiskers` in this scope
    --> $DIR/issue-2356.rs:110:5
     |
 110 |     whiskers = 4;
@@ -94,11 +94,11 @@ error[E0425]: unresolved value `whiskers`
     |     did you mean `self.whiskers`?
     |     `self` value is only available in methods with `self` parameter
 
-error[E0425]: unresolved function `purr_louder`
+error[E0425]: cannot find function `purr_louder` in this scope
    --> $DIR/issue-2356.rs:115:5
     |
 115 |     purr_louder();
-    |     ^^^^^^^^^^^ no resolution found
+    |     ^^^^^^^^^^^ not found in this scope
 
 error[E0424]: expected value, found module `self`
    --> $DIR/issue-2356.rs:122:5

--- a/src/test/ui/resolve/issue-24968.stderr
+++ b/src/test/ui/resolve/issue-24968.stderr
@@ -1,4 +1,4 @@
-error[E0411]: unresolved type `Self`
+error[E0411]: cannot find type `Self` in this scope
   --> $DIR/issue-24968.rs:11:11
    |
 11 | fn foo(_: Self) {

--- a/src/test/ui/resolve/resolve-assoc-suggestions.stderr
+++ b/src/test/ui/resolve/resolve-assoc-suggestions.stderr
@@ -1,52 +1,52 @@
-error[E0412]: unresolved type `field`
+error[E0412]: cannot find type `field` in this scope
   --> $DIR/resolve-assoc-suggestions.rs:26:16
    |
 26 |         let _: field;
-   |                ^^^^^ no resolution found
+   |                ^^^^^ not found in this scope
 
-error[E0531]: unresolved tuple struct/variant `field`
+error[E0531]: cannot find tuple struct/variant `field` in this scope
   --> $DIR/resolve-assoc-suggestions.rs:29:13
    |
 29 |         let field(..);
-   |             ^^^^^ no resolution found
+   |             ^^^^^ not found in this scope
 
-error[E0425]: unresolved value `field`
+error[E0425]: cannot find value `field` in this scope
   --> $DIR/resolve-assoc-suggestions.rs:32:9
    |
 32 |         field;
    |         ^^^^^ did you mean `self.field`?
 
-error[E0412]: unresolved type `Type`
+error[E0412]: cannot find type `Type` in this scope
   --> $DIR/resolve-assoc-suggestions.rs:36:16
    |
 36 |         let _: Type;
    |                ^^^^ did you mean `Self::Type`?
 
-error[E0531]: unresolved tuple struct/variant `Type`
+error[E0531]: cannot find tuple struct/variant `Type` in this scope
   --> $DIR/resolve-assoc-suggestions.rs:39:13
    |
 39 |         let Type(..);
-   |             ^^^^ no resolution found
+   |             ^^^^ not found in this scope
 
-error[E0425]: unresolved value `Type`
+error[E0425]: cannot find value `Type` in this scope
   --> $DIR/resolve-assoc-suggestions.rs:42:9
    |
 42 |         Type;
-   |         ^^^^ no resolution found
+   |         ^^^^ not found in this scope
 
-error[E0412]: unresolved type `method`
+error[E0412]: cannot find type `method` in this scope
   --> $DIR/resolve-assoc-suggestions.rs:46:16
    |
 46 |         let _: method;
-   |                ^^^^^^ no resolution found
+   |                ^^^^^^ not found in this scope
 
-error[E0531]: unresolved tuple struct/variant `method`
+error[E0531]: cannot find tuple struct/variant `method` in this scope
   --> $DIR/resolve-assoc-suggestions.rs:49:13
    |
 49 |         let method(..);
-   |             ^^^^^^ no resolution found
+   |             ^^^^^^ not found in this scope
 
-error[E0425]: unresolved value `method`
+error[E0425]: cannot find value `method` in this scope
   --> $DIR/resolve-assoc-suggestions.rs:52:9
    |
 52 |         method;

--- a/src/test/ui/resolve/resolve-speculative-adjustment.stderr
+++ b/src/test/ui/resolve/resolve-speculative-adjustment.stderr
@@ -1,22 +1,22 @@
-error[E0425]: unresolved value `field`
+error[E0425]: cannot find value `field` in this scope
   --> $DIR/resolve-speculative-adjustment.rs:27:13
    |
 27 |             field;
-   |             ^^^^^ no resolution found
+   |             ^^^^^ not found in this scope
 
-error[E0425]: unresolved function `method`
+error[E0425]: cannot find function `method` in this scope
   --> $DIR/resolve-speculative-adjustment.rs:30:13
    |
 30 |             method();
-   |             ^^^^^^ no resolution found
+   |             ^^^^^^ not found in this scope
 
-error[E0425]: unresolved value `field`
+error[E0425]: cannot find value `field` in this scope
   --> $DIR/resolve-speculative-adjustment.rs:35:9
    |
 35 |         field;
    |         ^^^^^ did you mean `self.field`?
 
-error[E0425]: unresolved function `method`
+error[E0425]: cannot find function `method` in this scope
   --> $DIR/resolve-speculative-adjustment.rs:38:9
    |
 38 |         method();

--- a/src/test/ui/resolve/token-error-correct-2.stderr
+++ b/src/test/ui/resolve/token-error-correct-2.stderr
@@ -10,11 +10,11 @@ note: unclosed delimiter
 14 |     if foo {
    |            ^
 
-error[E0425]: unresolved value `foo`
+error[E0425]: cannot find value `foo` in this scope
   --> $DIR/token-error-correct-2.rs:14:8
    |
 14 |     if foo {
-   |        ^^^ no resolution found
+   |        ^^^ not found in this scope
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/resolve/token-error-correct-3.stderr
+++ b/src/test/ui/resolve/token-error-correct-3.stderr
@@ -22,11 +22,11 @@ error: expected one of `.`, `;`, `?`, `}`, or an operator, found `)`
 29 |         } else { //~ ERROR: incorrect close delimiter: `}`
    |         ^
 
-error[E0425]: unresolved function `is_directory`
+error[E0425]: cannot find function `is_directory` in this scope
   --> $DIR/token-error-correct-3.rs:21:13
    |
 21 |         if !is_directory(path.as_ref()) { //~ ERROR: unresolved function `is_directory`
-   |             ^^^^^^^^^^^^ no resolution found
+   |             ^^^^^^^^^^^^ not found in this scope
 
 error[E0308]: mismatched types
   --> $DIR/token-error-correct-3.rs:25:13

--- a/src/test/ui/resolve/token-error-correct.stderr
+++ b/src/test/ui/resolve/token-error-correct.stderr
@@ -40,17 +40,17 @@ error: expected expression, found `)`
 23 | }
    | ^
 
-error[E0425]: unresolved function `foo`
+error[E0425]: cannot find function `foo` in this scope
   --> $DIR/token-error-correct.rs:14:5
    |
 14 |     foo(bar(;
-   |     ^^^ no resolution found
+   |     ^^^ not found in this scope
 
-error[E0425]: unresolved function `bar`
+error[E0425]: cannot find function `bar` in this scope
   --> $DIR/token-error-correct.rs:14:9
    |
 14 |     foo(bar(;
-   |         ^^^ no resolution found
+   |         ^^^ not found in this scope
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/resolve/unboxed-closure-sugar-nonexistent-trait.stderr
+++ b/src/test/ui/resolve/unboxed-closure-sugar-nonexistent-trait.stderr
@@ -1,8 +1,8 @@
-error[E0405]: unresolved trait `Nonexist`
+error[E0405]: cannot find trait `Nonexist` in this scope
   --> $DIR/unboxed-closure-sugar-nonexistent-trait.rs:11:8
    |
 11 | fn f<F:Nonexist(isize) -> isize>(x: F) {}
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^ no resolution found
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
 
 error[E0404]: expected trait, found type alias `Typedef`
   --> $DIR/unboxed-closure-sugar-nonexistent-trait.rs:17:8

--- a/src/test/ui/resolve/unresolved_static_type_field.stderr
+++ b/src/test/ui/resolve/unresolved_static_type_field.stderr
@@ -1,4 +1,4 @@
-error[E0425]: unresolved value `cx`
+error[E0425]: cannot find value `cx` in this scope
   --> $DIR/unresolved_static_type_field.rs:19:11
    |
 19 |         f(cx);

--- a/src/test/ui/span/typo-suggestion.stderr
+++ b/src/test/ui/span/typo-suggestion.stderr
@@ -1,10 +1,10 @@
-error[E0425]: unresolved value `bar`
+error[E0425]: cannot find value `bar` in this scope
   --> $DIR/typo-suggestion.rs:15:26
    |
 15 |     println!("Hello {}", bar);
-   |                          ^^^ no resolution found
+   |                          ^^^ not found in this scope
 
-error[E0425]: unresolved value `fob`
+error[E0425]: cannot find value `fob` in this scope
   --> $DIR/typo-suggestion.rs:18:26
    |
 18 |     println!("Hello {}", fob);


### PR DESCRIPTION
Use less jargon-y wording instead.
`cannot find <struct> <S> in <this scope>` and `cannot find <struct> <S> in <module a::b>` are used for base messages (this also harmonizes nicely with "you can import it into scope" suggestions) and `not found in <this scope>` and `not found in <a::b>` are used for short labels in fall-back case.
I tweaked some other diagnostics to avoid using "resolve" (see, e.g., `librustc_resolve/macros.rs`), but haven't touched messages for imports.

Closes https://github.com/rust-lang/rust/issues/38750
r? @nrc 