### PR TITLE
Remove `Sized`-relaxation for Index's `Idx` type

### DIFF
--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -1940,7 +1940,7 @@ shr_assign_impl_all! { u128 i128 }
 #[lang = "index"]
 #[rustc_on_unimplemented = "the type `{Self}` cannot be indexed by `{Idx}`"]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait Index<Idx: ?Sized> {
+pub trait Index<Idx> {
     /// The returned type after indexing
     #[stable(feature = "rust1", since = "1.0.0")]
     type Output: ?Sized;
@@ -2028,7 +2028,7 @@ pub trait Index<Idx: ?Sized> {
 #[lang = "index_mut"]
 #[rustc_on_unimplemented = "the type `{Self}` cannot be mutably indexed by `{Idx}`"]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait IndexMut<Idx: ?Sized>: Index<Idx> {
+pub trait IndexMut<Idx>: Index<Idx> {
     /// The method for the mutable indexing (`container[index]`) operation
     #[stable(feature = "rust1", since = "1.0.0")]
     fn index_mut(&mut self, index: Idx) -> &mut Self::Output;


### PR DESCRIPTION
`Idx` is used by value as method argument and can't be unsized anyway. The `?Sized` relaxation was probably forgotten to be removed.

In theory, this change should not break any code. But maybe I have forgotten a special case?

The idea for removing the useless relaxation started [in this StackOverflow question][1]. The `?Sized` doesn't
cause any harm either, it's just confusing and useless. We were just curious to see what would happen to a PR like this.

[1]: http://stackoverflow.com/questions/41513631/why-is-the-idx-type-parameter-of-the-index-trait-allowed-to-be-unsized