### PR TITLE
Stabilize `-Zincremental` as `-Cincremental`

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -110,7 +110,7 @@ fn main() {
 
         // Pass down incremental directory, if any.
         if let Ok(dir) = env::var("RUSTC_INCREMENTAL") {
-            cmd.arg(format!("-Zincremental={}", dir));
+            cmd.arg(format!("-Cincremental={}", dir));
 
             if verbose > 0 {
                 cmd.arg("-Zincremental-info");

--- a/src/librustc_incremental/calculate_svh/svh_visitor.rs
+++ b/src/librustc_incremental/calculate_svh/svh_visitor.rs
@@ -1145,8 +1145,8 @@ impl<'a, 'hash, 'tcx> StrictVersionHashVisitor<'a, 'hash, 'tcx> {
                 //            in a stable way, in addition to the HIR.
                 //            Since this is hardly used anywhere, just emit a
                 //            warning for now.
-                if self.tcx.sess.opts.debugging_opts.incremental.is_some() {
-                    let msg = format!("Quasi-quoting might make incremental \
+                if self.tcx.sess.opts.incremental.is_some() {
+                    let msg = format!("quasi-quoting might make incremental \
                                        compilation very inefficient: {:?}",
                                       non_terminal);
                     self.tcx.sess.span_warn(error_reporting_span, &msg[..]);

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -667,7 +667,7 @@ pub fn run_passes(sess: &Session,
 
     // Sanity check
     assert!(trans.modules.len() == sess.opts.cg.codegen_units ||
-            sess.opts.debugging_opts.incremental.is_some());
+            sess.opts.incremental.is_some());
 
     let tm = create_target_machine(sess);
 

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -869,7 +869,7 @@ fn internalize_symbols<'a, 'tcx>(sess: &Session,
     let scx = ccxs.shared();
     let tcx = scx.tcx();
 
-    let incr_comp = sess.opts.debugging_opts.incremental.is_some();
+    let incr_comp = sess.opts.incremental.is_some();
 
     // 'unsafe' because we are holding on to CStr's from the LLVM module within
     // this block.
@@ -1572,7 +1572,7 @@ fn collect_and_partition_translation_items<'a, 'tcx>(scx: &SharedCrateContext<'a
 
     let symbol_map = SymbolMap::build(scx, items.iter().cloned());
 
-    let strategy = if scx.sess().opts.debugging_opts.incremental.is_some() {
+    let strategy = if scx.sess().opts.incremental.is_some() {
         PartitioningStrategy::PerModule
     } else {
         PartitioningStrategy::FixedUnitCount(scx.sess().opts.cg.codegen_units)
@@ -1586,7 +1586,7 @@ fn collect_and_partition_translation_items<'a, 'tcx>(scx: &SharedCrateContext<'a
     });
 
     assert!(scx.tcx().sess.opts.cg.codegen_units == codegen_units.len() ||
-            scx.tcx().sess.opts.debugging_opts.incremental.is_some());
+            scx.tcx().sess.opts.incremental.is_some());
 
     {
         let mut ccx_map = scx.translation_items().borrow_mut();

--- a/src/test/codegen-units/partitioning/extern-drop-glue.rs
+++ b/src/test/codegen-units/partitioning/extern-drop-glue.rs
@@ -10,9 +10,9 @@
 
 // ignore-tidy-linelength
 
-// We specify -Z incremental here because we want to test the partitioning for
+// We specify -C incremental here because we want to test the partitioning for
 // incremental compilation
-// compile-flags:-Zprint-trans-items=lazy -Zincremental=tmp/partitioning-tests/extern-drop-glue
+// compile-flags:-Zprint-trans-items=lazy -Cincremental=tmp/partitioning-tests/extern-drop-glue
 
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/extern-generic.rs
+++ b/src/test/codegen-units/partitioning/extern-generic.rs
@@ -9,9 +9,9 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// We specify -Z incremental here because we want to test the partitioning for
+// We specify -C incremental here because we want to test the partitioning for
 // incremental compilation
-// compile-flags:-Zprint-trans-items=eager -Zincremental=tmp/partitioning-tests/extern-generic
+// compile-flags:-Zprint-trans-items=eager -Cincremental=tmp/partitioning-tests/extern-generic
 
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/inlining-from-extern-crate.rs
+++ b/src/test/codegen-units/partitioning/inlining-from-extern-crate.rs
@@ -9,9 +9,9 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// We specify -Z incremental here because we want to test the partitioning for
+// We specify -C incremental here because we want to test the partitioning for
 // incremental compilation
-// compile-flags:-Zprint-trans-items=lazy -Zincremental=tmp/partitioning-tests/inlining-from-extern-crate
+// compile-flags:-Zprint-trans-items=lazy -Cincremental=tmp/partitioning-tests/inlining-from-extern-crate
 
 #![crate_type="lib"]
 

--- a/src/test/codegen-units/partitioning/local-drop-glue.rs
+++ b/src/test/codegen-units/partitioning/local-drop-glue.rs
@@ -9,9 +9,9 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// We specify -Z incremental here because we want to test the partitioning for
+// We specify -C incremental here because we want to test the partitioning for
 // incremental compilation
-// compile-flags:-Zprint-trans-items=lazy -Zincremental=tmp/partitioning-tests/local-drop-glue
+// compile-flags:-Zprint-trans-items=lazy -Cincremental=tmp/partitioning-tests/local-drop-glue
 
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/local-generic.rs
+++ b/src/test/codegen-units/partitioning/local-generic.rs
@@ -9,9 +9,9 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// We specify -Z incremental here because we want to test the partitioning for
+// We specify -C incremental here because we want to test the partitioning for
 // incremental compilation
-// compile-flags:-Zprint-trans-items=eager -Zincremental=tmp/partitioning-tests/local-generic
+// compile-flags:-Zprint-trans-items=eager -Cincremental=tmp/partitioning-tests/local-generic
 
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/local-inlining.rs
+++ b/src/test/codegen-units/partitioning/local-inlining.rs
@@ -9,9 +9,9 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// We specify -Z incremental here because we want to test the partitioning for
+// We specify -C incremental here because we want to test the partitioning for
 // incremental compilation
-// compile-flags:-Zprint-trans-items=lazy -Zincremental=tmp/partitioning-tests/local-inlining
+// compile-flags:-Zprint-trans-items=lazy -Cincremental=tmp/partitioning-tests/local-inlining
 
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/local-transitive-inlining.rs
+++ b/src/test/codegen-units/partitioning/local-transitive-inlining.rs
@@ -9,9 +9,9 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// We specify -Z incremental here because we want to test the partitioning for
+// We specify -C incremental here because we want to test the partitioning for
 // incremental compilation
-// compile-flags:-Zprint-trans-items=lazy -Zincremental=tmp/partitioning-tests/local-transitive-inlining
+// compile-flags:-Zprint-trans-items=lazy -Cincremental=tmp/partitioning-tests/local-transitive-inlining
 
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/methods-are-with-self-type.rs
+++ b/src/test/codegen-units/partitioning/methods-are-with-self-type.rs
@@ -14,9 +14,9 @@
 // ignore-test
 
 // ignore-tidy-linelength
-// We specify -Z incremental here because we want to test the partitioning for
+// We specify -C incremental here because we want to test the partitioning for
 // incremental compilation
-// compile-flags:-Zprint-trans-items=lazy -Zincremental=tmp/partitioning-tests/methods-are-with-self-type
+// compile-flags:-Zprint-trans-items=lazy -Cincremental=tmp/partitioning-tests/methods-are-with-self-type
 
 #![allow(dead_code)]
 

--- a/src/test/codegen-units/partitioning/regular-modules.rs
+++ b/src/test/codegen-units/partitioning/regular-modules.rs
@@ -9,9 +9,9 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// We specify -Z incremental here because we want to test the partitioning for
+// We specify -C incremental here because we want to test the partitioning for
 // incremental compilation
-// compile-flags:-Zprint-trans-items=eager -Zincremental=tmp/partitioning-tests/regular-modules
+// compile-flags:-Zprint-trans-items=eager -Cincremental=tmp/partitioning-tests/regular-modules
 
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/codegen-units/partitioning/statics.rs
+++ b/src/test/codegen-units/partitioning/statics.rs
@@ -9,9 +9,9 @@
 // except according to those terms.
 
 // ignore-tidy-linelength
-// We specify -Z incremental here because we want to test the partitioning for
+// We specify -C incremental here because we want to test the partitioning for
 // incremental compilation
-// compile-flags:-Zprint-trans-items=lazy -Zincremental=tmp/partitioning-tests/statics
+// compile-flags:-Zprint-trans-items=lazy -Cincremental=tmp/partitioning-tests/statics
 
 #![crate_type="lib"]
 

--- a/src/test/codegen-units/partitioning/vtable-through-const.rs
+++ b/src/test/codegen-units/partitioning/vtable-through-const.rs
@@ -10,9 +10,9 @@
 
 // ignore-tidy-linelength
 
-// We specify -Z incremental here because we want to test the partitioning for
+// We specify -C incremental here because we want to test the partitioning for
 // incremental compilation
-// compile-flags:-Zprint-trans-items=lazy -Zincremental=tmp/partitioning-tests/vtable-through-const
+// compile-flags:-Zprint-trans-items=lazy -Cincremental=tmp/partitioning-tests/vtable-through-const
 
 // This test case makes sure, that references made through constants are
 // recorded properly in the InliningMap.

--- a/src/test/compile-fail/incr_comp_with_macro_export.rs
+++ b/src/test/compile-fail/incr_comp_with_macro_export.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Zincremental=tmp/cfail-tests/incr_comp_with_macro_export
+// compile-flags: -Cincremental=tmp/cfail-tests/incr_comp_with_macro_export
 // must-compile-successfully
 
 

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1356,8 +1356,7 @@ actual:\n\
 
         if let Some(ref incremental_dir) = self.props.incremental_dir {
             args.extend(vec![
-                format!("-Z"),
-                format!("incremental={}", incremental_dir.display()),
+                format!("-Cincremental={}", incremental_dir.display()),
             ]);
         }
 
@@ -2077,12 +2076,12 @@ actual:\n\
         //   - if `cfail`, expect compilation to fail
         //   - if `rfail`, expect execution to fail
         // - create a directory build/foo/bar.incremental
-        // - compile foo/bar.rs with -Z incremental=.../foo/bar.incremental and -C rpass1
+        // - compile foo/bar.rs with -C incremental=.../foo/bar.incremental and -C rpass1
         //   - because name of revision starts with "rpass", expect success
-        // - compile foo/bar.rs with -Z incremental=.../foo/bar.incremental and -C cfail2
+        // - compile foo/bar.rs with -C incremental=.../foo/bar.incremental and -C cfail2
         //   - because name of revision starts with "cfail", expect an error
         //   - load expected errors as usual, but filter for those that end in `[rfail2]`
-        // - compile foo/bar.rs with -Z incremental=.../foo/bar.incremental and -C rpass3
+        // - compile foo/bar.rs with -C incremental=.../foo/bar.incremental and -C rpass3
         //   - because name of revision starts with "rpass", expect success
         // - execute build/foo/bar.exe and save output
         //


### PR DESCRIPTION
The `-Zincremental` option remains temporarily, but we issue a warning.

If you use `-Cincremental` on stable, it has no effect.

r? @michaelwoerister 
cc @alexcrichton @rust-lang/compiler 