### PR TITLE
make lifetimes that only appear in return type early-bound

### DIFF
--- a/src/librustc/infer/error_reporting.rs
+++ b/src/librustc/infer/error_reporting.rs
@@ -72,13 +72,12 @@ use super::region_inference::SameRegions;
 use hir::map as hir_map;
 use hir;
 
-use lint;
 use hir::def_id::DefId;
 use infer;
 use middle::region;
 use traits::{ObligationCause, ObligationCauseCode};
 use ty::{self, TyCtxt, TypeFoldable};
-use ty::{Region, ReFree};
+use ty::{Region, ReFree, Issue32330};
 use ty::error::TypeError;
 
 use std::fmt;
@@ -610,6 +609,39 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         self.tcx.note_and_explain_type_err(diag, terr, span);
     }
 
+    pub fn note_issue_32330(&self,
+                            diag: &mut DiagnosticBuilder<'tcx>,
+                            terr: &TypeError<'tcx>)
+    {
+        debug!("note_issue_32330: terr={:?}", terr);
+        match *terr {
+            TypeError::RegionsInsufficientlyPolymorphic(_, &Region::ReVar(vid)) |
+            TypeError::RegionsOverlyPolymorphic(_, &Region::ReVar(vid)) => {
+                match self.region_vars.var_origin(vid) {
+                    RegionVariableOrigin::EarlyBoundRegion(_, _, Some(Issue32330 {
+                        fn_def_id,
+                        region_name
+                    })) => {
+                        diag.note(
+                            &format!("lifetime parameter `{0}` declared on fn `{1}` \
+                                      appears only in the return type, \
+                                      but here is required to be higher-ranked, \
+                                      which means that `{0}` must appear in both \
+                                      argument and return types",
+                                     region_name,
+                                     self.tcx.item_path_str(fn_def_id)));
+                        diag.note(
+                            &format!("this error is the result of a recent bug fix; \
+                                      for more information, see issue #33685 \
+                                      <https://github.com/rust-lang/rust/issues/33685>"));
+                    }
+                    _ => { }
+                }
+            }
+            _ => { }
+        }
+    }
+
     pub fn report_and_explain_type_error(&self,
                                          trace: TypeTrace<'tcx>,
                                          terr: &TypeError<'tcx>)
@@ -629,6 +661,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             }
         };
         self.note_type_err(&mut diag, &trace.cause, None, Some(trace.values), terr);
+        self.note_issue_32330(&mut diag, terr);
         diag
     }
 
@@ -1053,27 +1086,6 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             err.emit();
         }
     }
-
-    pub fn issue_32330_warnings(&self, span: Span, issue32330s: &[ty::Issue32330]) {
-        for issue32330 in issue32330s {
-            match *issue32330 {
-                ty::Issue32330::WontChange => { }
-                ty::Issue32330::WillChange { fn_def_id, region_name } => {
-                    self.tcx.sess.add_lint(
-                        lint::builtin::HR_LIFETIME_IN_ASSOC_TYPE,
-                        ast::CRATE_NODE_ID,
-                        span,
-                        format!("lifetime parameter `{0}` declared on fn `{1}` \
-                                 appears only in the return type, \
-                                 but here is required to be higher-ranked, \
-                                 which means that `{0}` must appear in both \
-                                 argument and return types",
-                                region_name,
-                                self.tcx.item_path_str(fn_def_id)));
-                }
-            }
-        }
-    }
 }
 
 impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
@@ -1104,7 +1116,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                 format!(" for lifetime parameter {}in trait containing associated type `{}`",
                         br_string(br), type_name)
             }
-            infer::EarlyBoundRegion(_, name) => {
+            infer::EarlyBoundRegion(_, name, _) => {
                 format!(" for lifetime parameter `{}`",
                         name)
             }

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -368,7 +368,7 @@ pub enum RegionVariableOrigin {
     Coercion(Span),
 
     // Region variables created as the values for early-bound regions
-    EarlyBoundRegion(Span, ast::Name),
+    EarlyBoundRegion(Span, ast::Name, Option<ty::Issue32330>),
 
     // Region variables created for bound regions
     // in a function or method that is called
@@ -1184,7 +1184,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                               span: Span,
                               def: &ty::RegionParameterDef)
                               -> &'tcx ty::Region {
-        self.next_region_var(EarlyBoundRegion(span, def.name))
+        self.next_region_var(EarlyBoundRegion(span, def.name, def.issue_32330))
     }
 
     /// Create a type inference variable for the given
@@ -1761,7 +1761,7 @@ impl RegionVariableOrigin {
             AddrOfRegion(a) => a,
             Autoref(a) => a,
             Coercion(a) => a,
-            EarlyBoundRegion(a, _) => a,
+            EarlyBoundRegion(a, ..) => a,
             LateBoundRegion(a, ..) => a,
             BoundRegionInCoherence(_) => syntax_pos::DUMMY_SP,
             UpvarRegion(_, a) => a

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -606,6 +606,7 @@ pub struct RegionParameterDef {
     pub name: Name,
     pub def_id: DefId,
     pub index: u32,
+    pub issue_32330: Option<ty::Issue32330>,
 
     /// `pure_wrt_drop`, set by the (unsafe) `#[may_dangle]` attribute
     /// on generic parameter `'a`, asserts data of lifetime `'a`
@@ -622,8 +623,7 @@ impl RegionParameterDef {
     }
 
     pub fn to_bound_region(&self) -> ty::BoundRegion {
-        // this is an early bound region, so unaffected by #32330
-        ty::BoundRegion::BrNamed(self.def_id, self.name, Issue32330::WontChange)
+        ty::BoundRegion::BrNamed(self.def_id, self.name)
     }
 }
 

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -58,7 +58,7 @@ pub enum BoundRegion {
     ///
     /// The def-id is needed to distinguish free regions in
     /// the event of shadowing.
-    BrNamed(DefId, Name, Issue32330),
+    BrNamed(DefId, Name),
 
     /// Fresh bound identifiers created during GLB computations.
     BrFresh(u32),
@@ -68,23 +68,18 @@ pub enum BoundRegion {
     BrEnv
 }
 
-/// True if this late-bound region is unconstrained, and hence will
-/// become early-bound once #32330 is fixed.
+/// When a region changed from late-bound to early-bound when #32330
+/// was fixed, its `RegionParameterDef` will have one of these
+/// structures that we can use to give nicer errors.
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash,
          RustcEncodable, RustcDecodable)]
-pub enum Issue32330 {
-    WontChange,
+pub struct Issue32330 {
+    /// fn where is region declared
+    pub fn_def_id: DefId,
 
-    /// this region will change from late-bound to early-bound once
-    /// #32330 is fixed.
-    WillChange {
-        /// fn where is region declared
-        fn_def_id: DefId,
-
-        /// name of region; duplicates the info in BrNamed but convenient
-        /// to have it here, and this code is only temporary
-        region_name: ast::Name,
-    }
+    /// name of region; duplicates the info in BrNamed but convenient
+    /// to have it here, and this code is only temporary
+    pub region_name: ast::Name,
 }
 
 // NB: If you change this, you'll probably want to change the corresponding

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -276,7 +276,7 @@ fn in_binder<'a, 'gcx, 'tcx, T, U>(f: &mut fmt::Formatter,
     let new_value = tcx.replace_late_bound_regions(&value, |br| {
         let _ = start_or_continue(f, "for<", ", ");
         let br = match br {
-            ty::BrNamed(_, name, _) => {
+            ty::BrNamed(_, name) => {
                 let _ = write!(f, "{}", name);
                 br
             }
@@ -286,8 +286,7 @@ fn in_binder<'a, 'gcx, 'tcx, T, U>(f: &mut fmt::Formatter,
                 let name = Symbol::intern("'r");
                 let _ = write!(f, "{}", name);
                 ty::BrNamed(tcx.hir.local_def_id(CRATE_NODE_ID),
-                            name,
-                            ty::Issue32330::WontChange)
+                            name)
             }
         };
         tcx.mk_region(ty::ReLateBound(ty::DebruijnIndex::new(1), br))
@@ -435,7 +434,7 @@ impl fmt::Display for ty::BoundRegion {
         }
 
         match *self {
-            BrNamed(_, name, _) => write!(f, "{}", name),
+            BrNamed(_, name) => write!(f, "{}", name),
             BrAnon(_) | BrFresh(_) | BrEnv => Ok(())
         }
     }
@@ -446,9 +445,9 @@ impl fmt::Debug for ty::BoundRegion {
         match *self {
             BrAnon(n) => write!(f, "BrAnon({:?})", n),
             BrFresh(n) => write!(f, "BrFresh({:?})", n),
-            BrNamed(did, name, issue32330) => {
-                write!(f, "BrNamed({:?}:{:?}, {:?}, {:?})",
-                       did.krate, did.index, name, issue32330)
+            BrNamed(did, name) => {
+                write!(f, "BrNamed({:?}:{:?}, {:?})",
+                       did.krate, did.index, name)
             }
             BrEnv => "BrEnv".fmt(f),
         }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1418,7 +1418,7 @@ impl<'a, 'gcx, 'tcx> AstConv<'gcx, 'tcx> for FnCtxt<'a, 'gcx, 'tcx> {
     fn re_infer(&self, span: Span, def: Option<&ty::RegionParameterDef>)
                 -> Option<&'tcx ty::Region> {
         let v = match def {
-            Some(def) => infer::EarlyBoundRegion(span, def.name),
+            Some(def) => infer::EarlyBoundRegion(span, def.name, def.issue_32330),
             None => infer::MiscVariable(span)
         };
         Some(self.next_region_var(v))

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -108,7 +108,7 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
             };
             match *r {
                 ty::ReFree(ty::FreeRegion {
-                    bound_region: ty::BoundRegion::BrNamed(def_id, name, _), ..
+                    bound_region: ty::BoundRegion::BrNamed(def_id, name), ..
                 }) => {
                     let bound_region = gcx.mk_region(ty::ReEarlyBound(ty::EarlyBoundRegion {
                         index: i as u32,

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1442,11 +1442,15 @@ fn generics_of_def_id<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
 
         let early_lifetimes = early_bound_lifetimes_from_generics(ccx, ast_generics);
         let regions = early_lifetimes.iter().enumerate().map(|(i, l)| {
+            let issue_32330 = ccx.tcx.named_region_map.issue_32330
+                                                      .get(&l.lifetime.id)
+                                                      .cloned();
             ty::RegionParameterDef {
                 name: l.lifetime.name,
                 index: own_start + i as u32,
                 def_id: tcx.hir.local_def_id(l.lifetime.id),
                 pure_wrt_drop: l.pure_wrt_drop,
+                issue_32330: issue_32330,
             }
         }).collect::<Vec<_>>();
 
@@ -1675,7 +1679,7 @@ fn early_bound_lifetimes_from_generics<'a, 'tcx, 'hir>(
     ast_generics
         .lifetimes
         .iter()
-        .filter(|l| !ccx.tcx.named_region_map.late_bound.contains_key(&l.lifetime.id))
+        .filter(|l| !ccx.tcx.named_region_map.late_bound.contains(&l.lifetime.id))
         .collect()
 }
 

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -4056,6 +4056,74 @@ fn main() {
 ```
 "##,
 
+E0581: r##"
+In a `fn` type, a lifetime appears only in the return type,
+and not in the arguments types.
+
+Erroneous code example:
+
+```compile_fail,E0581
+fn main() {
+    // Here, `'a` appears only in the return type:
+    let x: for<'a> fn() -> &'a i32;
+}
+```
+
+To fix this issue, either use the lifetime in the arguments, or use
+`'static`. Example:
+
+```
+fn main() {
+    // Here, `'a` appears only in the return type:
+    let x: for<'a> fn(&'a i32) -> &'a i32;
+    let y: fn() -> &'static i32;
+}
+```
+
+Note: The examples above used to be (erroneously) accepted by the
+compiler, but this was since corrected. See [issue #33685] for more
+details.
+
+[issue #33685]: https://github.com/rust-lang/rust/issues/33685
+"##,
+
+    E0582: r##"
+A lifetime appears only in an associated-type binding,
+and not in the input types to the trait.
+
+Erroneous code example:
+
+```compile_fail,E0582
+fn bar<F>(t: F)
+    // No type can satisfy this requirement, since `'a` does not
+    // appear in any of the input types (here, `i32`):
+    where F: for<'a> Fn(i32) -> Option<&'a i32>
+{
+}
+
+fn main() { }
+```
+
+To fix this issue, either use the lifetime in the inputs, or use
+`'static`. Example:
+
+```
+fn bar<F, G>(t: F, u: G)
+    where F: for<'a> Fn(&'a i32) -> Option<&'a i32>,
+          G: Fn(i32) -> Option<&'static i32>,
+{
+}
+
+fn main() { }
+```
+
+Note: The examples above used to be (erroneously) accepted by the
+compiler, but this was since corrected. See [issue #33685] for more
+details.
+
+[issue #33685]: https://github.com/rust-lang/rust/issues/33685
+"##,
+
 }
 
 register_diagnostics! {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -810,7 +810,7 @@ impl Clean<Option<Lifetime>> for ty::Region {
     fn clean(&self, cx: &DocContext) -> Option<Lifetime> {
         match *self {
             ty::ReStatic => Some(Lifetime::statik()),
-            ty::ReLateBound(_, ty::BrNamed(_, name, _)) => Some(Lifetime(name.to_string())),
+            ty::ReLateBound(_, ty::BrNamed(_, name)) => Some(Lifetime(name.to_string())),
             ty::ReEarlyBound(ref data) => Some(Lifetime(data.name.clean(cx))),
 
             ty::ReLateBound(..) |

--- a/src/test/compile-fail/E0582.rs
+++ b/src/test/compile-fail/E0582.rs
@@ -12,7 +12,6 @@
 // stopped compiling when #32330 is fixed.
 
 #![allow(dead_code, unused_variables)]
-#![deny(hr_lifetime_in_assoc_type)]
 
 use std::str::Chars;
 
@@ -31,16 +30,21 @@ fn mk_unexpected_char_err<'a>() -> Option<&'a i32> {
 
 fn foo<'a>(data: &mut Chars<'a>) {
     bar(mk_unexpected_char_err)
-    //~^ ERROR lifetime parameter `'a` declared on fn `mk_unexpected_char_err`
-    //~| WARNING hard error in a future release
 }
 
 fn bar<F>(t: F)
     // No type can satisfy this requirement, since `'a` does not
     // appear in any of the input types:
     where F: for<'a> Fn() -> Option<&'a i32>
-    //~^ ERROR associated type `Output` references lifetime `'a`, which does not
-    //~| WARNING hard error in a future release
+    //~^ ERROR E0582
+{
+}
+
+fn baz<F>(t: F)
+    // No type can satisfy this requirement, since `'a` does not
+    // appear in any of the input types:
+    where F: for<'a> Iterator<Item=&'a i32>
+    //~^ ERROR E0582
 {
 }
 

--- a/src/test/compile-fail/associated-types/bound-lifetime-constrained.rs
+++ b/src/test/compile-fail/associated-types/bound-lifetime-constrained.rs
@@ -12,7 +12,7 @@
 
 #![allow(dead_code)]
 #![feature(rustc_attrs)]
-#![deny(hr_lifetime_in_assoc_type)]
+#![allow(hr_lifetime_in_assoc_type)]
 
 trait Foo<'a> {
     type Item;
@@ -25,40 +25,34 @@ impl<'a> Foo<'a> for() {
 // Check that appearing in a projection input in the argument is not enough:
 #[cfg(func)]
 fn func1(_: for<'a> fn(<() as Foo<'a>>::Item) -> &'a i32) {
-    //[func]~^ ERROR return type references lifetime `'a`
-    //[func]~| WARNING previously accepted
+    //[func]~^ ERROR E0581
 }
 
 // Check that appearing in a projection input in the return still
 // causes an error:
 #[cfg(func)]
 fn func2(_: for<'a> fn() -> <() as Foo<'a>>::Item) {
-    //[func]~^ ERROR return type references lifetime `'a`
-    //[func]~| WARNING previously accepted
+    //[func]~^ ERROR E0581
 }
 
 #[cfg(object)]
 fn object1(_: Box<for<'a> Fn(<() as Foo<'a>>::Item) -> &'a i32>) {
-    //[object]~^ ERROR `Output` references lifetime `'a`
-    //[object]~| WARNING previously accepted
+    //[object]~^ ERROR E0582
 }
 
 #[cfg(object)]
 fn object2(_: Box<for<'a> Fn() -> <() as Foo<'a>>::Item>) {
-    //[object]~^ ERROR `Output` references lifetime `'a`
-    //[object]~| WARNING previously accepted
+    //[object]~^ ERROR E0582
 }
 
 #[cfg(clause)]
 fn clause1<T>() where T: for<'a> Fn(<() as Foo<'a>>::Item) -> &'a i32 {
     //[clause]~^ ERROR `Output` references lifetime `'a`
-    //[clause]~| WARNING previously accepted
 }
 
 #[cfg(clause)]
 fn clause2<T>() where T: for<'a> Fn() -> <() as Foo<'a>>::Item {
     //[clause]~^ ERROR `Output` references lifetime `'a`
-    //[clause]~| WARNING previously accepted
 }
 
 #[rustc_error]

--- a/src/test/compile-fail/associated-types/bound-lifetime-in-binding-only.rs
+++ b/src/test/compile-fail/associated-types/bound-lifetime-in-binding-only.rs
@@ -13,7 +13,6 @@
 #![allow(dead_code)]
 #![feature(rustc_attrs)]
 #![feature(unboxed_closures)]
-#![deny(hr_lifetime_in_assoc_type)]
 
 trait Foo {
     type Item;
@@ -22,49 +21,41 @@ trait Foo {
 #[cfg(angle)]
 fn angle<T: for<'a> Foo<Item=&'a i32>>() {
     //[angle]~^ ERROR binding for associated type `Item` references lifetime `'a`
-    //[angle]~| WARNING previously accepted
 }
 
 #[cfg(angle)]
 fn angle1<T>() where T: for<'a> Foo<Item=&'a i32> {
     //[angle]~^ ERROR binding for associated type `Item` references lifetime `'a`
-    //[angle]~| WARNING previously accepted
 }
 
 #[cfg(angle)]
 fn angle2<T>() where for<'a> T: Foo<Item=&'a i32> {
     //[angle]~^ ERROR binding for associated type `Item` references lifetime `'a`
-    //[angle]~| WARNING previously accepted
 }
 
 #[cfg(angle)]
 fn angle3(_: &for<'a> Foo<Item=&'a i32>) {
     //[angle]~^ ERROR binding for associated type `Item` references lifetime `'a`
-    //[angle]~| WARNING previously accepted
 }
 
 #[cfg(paren)]
 fn paren<T: for<'a> Fn() -> &'a i32>() {
     //[paren]~^ ERROR binding for associated type `Output` references lifetime `'a`
-    //[paren]~| WARNING previously accepted
 }
 
 #[cfg(paren)]
 fn paren1<T>() where T: for<'a> Fn() -> &'a i32 {
     //[paren]~^ ERROR binding for associated type `Output` references lifetime `'a`
-    //[paren]~| WARNING previously accepted
 }
 
 #[cfg(paren)]
 fn paren2<T>() where for<'a> T: Fn() -> &'a i32 {
     //[paren]~^ ERROR binding for associated type `Output` references lifetime `'a`
-    //[paren]~| WARNING previously accepted
 }
 
 #[cfg(paren)]
 fn paren3(_: &for<'a> Fn() -> &'a i32) {
     //[paren]~^ ERROR binding for associated type `Output` references lifetime `'a`
-    //[paren]~| WARNING previously accepted
 }
 
 #[cfg(elision)]

--- a/src/test/compile-fail/associated-types/bound-lifetime-in-return-only.rs
+++ b/src/test/compile-fail/associated-types/bound-lifetime-in-return-only.rs
@@ -22,27 +22,23 @@ trait Foo {
 #[cfg(sig)]
 fn sig1(_: for<'a> fn() -> &'a i32) {
     //[sig]~^ ERROR return type references lifetime `'a`
-    //[sig]~| WARNING previously accepted
 }
 
 #[cfg(sig)]
 fn sig2(_: for<'a, 'b> fn(&'b i32) -> &'a i32) {
     //[sig]~^ ERROR return type references lifetime `'a`
-    //[sig]~| WARNING previously accepted
 }
 
 #[cfg(local)]
 fn local1() {
     let _: for<'a> fn() -> &'a i32 = loop { };
     //[local]~^ ERROR return type references lifetime `'a`
-    //[local]~| WARNING previously accepted
 }
 
 #[cfg(structure)]
 struct Struct1 {
     x: for<'a> fn() -> &'a i32
     //[structure]~^ ERROR return type references lifetime `'a`
-    //[structure]~| WARNING previously accepted
 }
 
 #[cfg(elision)]

--- a/src/test/ui/regions-fn-subtyping-return-static.rs
+++ b/src/test/ui/regions-fn-subtyping-return-static.rs
@@ -53,15 +53,5 @@ fn supply_F() {
     want_F(baz);
 }
 
-fn supply_G() {
-    want_G(foo);
-    want_G(bar);
-    want_G(baz);
-    //~^ ERROR mismatched types
-    //~| expected type `fn(&'cx S) -> &'static S`
-    //~| found type `fn(&S) -> &S {baz}`
-    //~| expected concrete lifetime, found bound lifetime parameter 'cx
-}
-
 pub fn main() {
 }

--- a/src/test/ui/regions-fn-subtyping-return-static.stderr
+++ b/src/test/ui/regions-fn-subtyping-return-static.stderr
@@ -1,0 +1,13 @@
+error[E0308]: mismatched types
+  --> $DIR/regions-fn-subtyping-return-static.rs:51:12
+   |
+51 |     want_F(bar); //~ ERROR E0308
+   |            ^^^ expected concrete lifetime, found bound lifetime parameter 'cx
+   |
+   = note: expected type `fn(&'cx S) -> &'cx S`
+              found type `fn(&'a S) -> &S {bar::<'_>}`
+   = note: lifetime parameter `'b` declared on fn `bar` appears only in the return type, but here is required to be higher-ranked, which means that `'b` must appear in both argument and return types
+   = note: this error is the result of a recent bug fix; for more information, see issue #33685 <https://github.com/rust-lang/rust/issues/33685>
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This is the full and proper fix for #32330. This also makes some effort to give a nice error message (as evidenced by the `ui` test), sending users over to the tracking issue for a fuller explanation and offering a `--explain` message in some cases.

This needs a crater run before we land.

r? @arielb1 