### PR TITLE
Remove `note: ` prefix from type mismatch errors

### DIFF
--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -96,8 +96,13 @@ impl Diagnostic {
                                      -> &mut Self
     {
         // For now, just attach these as notes
-        self.note(&format!("expected {} `{}`{}", label, expected, expected_extra));
-        self.note(&format!("   found {} `{}`{}", label, found, found_extra));
+        self.top_level_note(&format!("expected {} `{}`{}", label, expected, expected_extra));
+        self.top_level_note(&format!("   found {} `{}`{}", label, found, found_extra));
+        self
+    }
+
+    pub fn top_level_note(&mut self, msg: &str) -> &mut Self {
+        self.sub(Level::TopLevel, msg, MultiSpan::new(), None);
         self
     }
 

--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -95,16 +95,17 @@ impl Diagnostic {
                                      found_extra: &fmt::Display)
                                      -> &mut Self
     {
-        // For now, just attach these as notes
-        self.top_level_note(&format!("expected {} `{}`{}", label, expected, expected_extra));
-        self.top_level_note(&format!("   found {} `{}`{}", label, found, found_extra));
+        self.sub(Level::Expected,
+                 &format!("{} `{}`{}", label, expected, expected_extra),
+                 MultiSpan::new(),
+                 None);
+        self.sub(Level::Found,
+                 &format!("{} `{}`{}", label, found, found_extra),
+                 MultiSpan::new(),
+                 None);
         self
     }
 
-    pub fn top_level_note(&mut self, msg: &str) -> &mut Self {
-        self.sub(Level::TopLevel, msg, MultiSpan::new(), None);
-        self
-    }
 
     pub fn note(&mut self, msg: &str) -> &mut Self {
         self.sub(Level::Note, msg, MultiSpan::new(), None);

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -91,6 +91,7 @@ impl<'a> DiagnosticBuilder<'a> {
             Level::Warning |
             Level::Note |
             Level::Help |
+            Level::TopLevel |
             Level::Cancelled => {
             }
         }

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -91,7 +91,8 @@ impl<'a> DiagnosticBuilder<'a> {
             Level::Warning |
             Level::Note |
             Level::Help |
-            Level::TopLevel |
+            Level::Expected |
+            Level::Found |
             Level::Cancelled => {
             }
         }

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -717,7 +717,7 @@ impl EmitterWriter {
             let msg_split = msg.split('`').collect::<Vec<&str>>();
             buffer.append(0, msg_split[0], Style::NoStyle);
             buffer.append(0, "`", Style::HeaderMsg);
-            buffer.append(0, msg_split[1], Style::UnderlinePrimary);
+            buffer.append(0, msg_split[1], Style::Highlight);
             buffer.append(0, "`", Style::HeaderMsg);
             buffer.append(0, msg_split[2], Style::NoStyle);
         }
@@ -1188,6 +1188,7 @@ impl Destination {
                 self.start_attr(term::Attr::Bold)?;
                 self.start_attr(term::Attr::ForegroundColor(l.color()))?;
             }
+            Style::Highlight => self.start_attr(term::Attr::Bold)?,
         }
         Ok(())
     }

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -713,6 +713,15 @@ impl EmitterWriter {
                             -> io::Result<()> {
         let mut buffer = StyledBuffer::new();
 
+        fn colorize_type_mismatch(buffer: &mut StyledBuffer, msg: &str) {
+            let msg_split = msg.split('`').collect::<Vec<&str>>();
+            buffer.append(0, msg_split[0], Style::NoStyle);
+            buffer.append(0, "`", Style::HeaderMsg);
+            buffer.append(0, msg_split[1], Style::UnderlinePrimary);
+            buffer.append(0, "`", Style::HeaderMsg);
+            buffer.append(0, msg_split[2], Style::NoStyle);
+        }
+
         if msp.primary_spans().is_empty() && msp.span_labels().is_empty() && is_secondary {
             // This is a secondary message with no span info
             for _ in 0..max_line_num_len {
@@ -723,18 +732,20 @@ impl EmitterWriter {
                 &Level::Expected => {
                     buffer.append(0, &level.to_string(), Style::NoStyle);
                     buffer.append(0, " ", Style::NoStyle);
+                    colorize_type_mismatch(&mut buffer, msg);
                 }
                 &Level::Found => {
                     buffer.append(0, "   ", Style::NoStyle);
                     buffer.append(0, &level.to_string(), Style::NoStyle);
                     buffer.append(0, " ", Style::NoStyle);
+                    colorize_type_mismatch(&mut buffer, msg);
                 },
                 _ => {
                     buffer.append(0, &level.to_string(), Style::HeaderMsg);
                     buffer.append(0, ": ", Style::NoStyle);
+                    buffer.append(0, msg, Style::NoStyle);
                 }
             }
-            buffer.append(0, msg, Style::NoStyle);
         } else {
             buffer.append(0, &level.to_string(), Style::Level(level.clone()));
             match code {
@@ -748,12 +759,7 @@ impl EmitterWriter {
             buffer.append(0, ": ", Style::HeaderMsg);
             match level {
                 &Level::Expected | &Level::Found => {
-                    let msg_split = msg.split('`').collect::<Vec<&str>>();
-                    buffer.append(0, msg_split[0], Style::HeaderMsg);
-                    buffer.append(0, "`", Style::HeaderMsg);
-                    buffer.append(0, msg_split[1], Style::UnderlinePrimary);
-                    buffer.append(0, "`", Style::HeaderMsg);
-                    buffer.append(0, msg_split[2], Style::HeaderMsg);
+                    colorize_type_mismatch(&mut buffer, msg);
                 }
                 _ => buffer.append(0, msg, Style::HeaderMsg),
             }

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -720,7 +720,15 @@ impl EmitterWriter {
             }
             draw_note_separator(&mut buffer, 0, max_line_num_len + 1);
             match level {
-                &Level::TopLevel => (),
+                &Level::Expected => {
+                    buffer.append(0, &level.to_string(), Style::NoStyle);
+                    buffer.append(0, " ", Style::NoStyle);
+                }
+                &Level::Found => {
+                    buffer.append(0, "  ", Style::NoStyle);
+                    buffer.append(0, &level.to_string(), Style::NoStyle);
+                    buffer.append(0, " ", Style::NoStyle);
+                },
                 _ => {
                     buffer.append(0, &level.to_string(), Style::HeaderMsg);
                     buffer.append(0, ": ", Style::NoStyle);
@@ -728,10 +736,7 @@ impl EmitterWriter {
             }
             buffer.append(0, msg, Style::NoStyle);
         } else {
-            match level {
-                &Level::TopLevel => (),
-                _ => buffer.append(0, &level.to_string(), Style::Level(level.clone())),
-            }
+            buffer.append(0, &level.to_string(), Style::Level(level.clone()));
             match code {
                 &Some(ref code) => {
                     buffer.append(0, "[", Style::Level(level.clone()));

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -746,7 +746,17 @@ impl EmitterWriter {
                 _ => {}
             }
             buffer.append(0, ": ", Style::HeaderMsg);
-            buffer.append(0, msg, Style::HeaderMsg);
+            match level {
+                &Level::Expected | &Level::Found => {
+                    let msg_split = msg.split('`').collect::<Vec<&str>>();
+                    buffer.append(0, msg_split[0], Style::HeaderMsg);
+                    buffer.append(0, "`", Style::HeaderMsg);
+                    buffer.append(0, msg_split[1], Style::UnderlinePrimary);
+                    buffer.append(0, "`", Style::HeaderMsg);
+                    buffer.append(0, msg_split[2], Style::HeaderMsg);
+                }
+                _ => buffer.append(0, msg, Style::HeaderMsg),
+            }
         }
 
         // Preprocess all the annotations so that they are grouped by file and by line number

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -719,11 +719,19 @@ impl EmitterWriter {
                 buffer.prepend(0, " ", Style::NoStyle);
             }
             draw_note_separator(&mut buffer, 0, max_line_num_len + 1);
-            buffer.append(0, &level.to_string(), Style::HeaderMsg);
-            buffer.append(0, ": ", Style::NoStyle);
+            match level {
+                &Level::TopLevel => (),
+                _ => {
+                    buffer.append(0, &level.to_string(), Style::HeaderMsg);
+                    buffer.append(0, ": ", Style::NoStyle);
+                }
+            }
             buffer.append(0, msg, Style::NoStyle);
         } else {
-            buffer.append(0, &level.to_string(), Style::Level(level.clone()));
+            match level {
+                &Level::TopLevel => (),
+                _ => buffer.append(0, &level.to_string(), Style::Level(level.clone())),
+            }
             match code {
                 &Some(ref code) => {
                     buffer.append(0, "[", Style::Level(level.clone()));

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -725,7 +725,7 @@ impl EmitterWriter {
                     buffer.append(0, " ", Style::NoStyle);
                 }
                 &Level::Found => {
-                    buffer.append(0, "  ", Style::NoStyle);
+                    buffer.append(0, "   ", Style::NoStyle);
                     buffer.append(0, &level.to_string(), Style::NoStyle);
                     buffer.append(0, " ", Style::NoStyle);
                 },

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -496,6 +496,8 @@ pub enum Level {
     Note,
     Help,
     Cancelled,
+    // A note without the `note: ` prefix in the presentation
+    TopLevel,
 }
 
 impl fmt::Display for Level {
@@ -515,7 +517,7 @@ impl Level {
                     term::color::YELLOW
                 }
             }
-            Note => term::color::BRIGHT_GREEN,
+            Note | TopLevel => term::color::BRIGHT_GREEN,
             Help => term::color::BRIGHT_CYAN,
             Cancelled => unreachable!(),
         }
@@ -527,6 +529,7 @@ impl Level {
             Fatal | PhaseFatal | Error => "error",
             Warning => "warning",
             Note => "note",
+            TopLevel => "note",
             Help => "help",
             Cancelled => panic!("Shouldn't call on cancelled error"),
         }

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -496,8 +496,9 @@ pub enum Level {
     Note,
     Help,
     Cancelled,
-    // A note without the `note: ` prefix in the presentation
-    TopLevel,
+    // Expected/Found type/struct/variant
+    Expected,
+    Found,
 }
 
 impl fmt::Display for Level {
@@ -517,7 +518,7 @@ impl Level {
                     term::color::YELLOW
                 }
             }
-            Note | TopLevel => term::color::BRIGHT_GREEN,
+            Note | Expected | Found => term::color::BRIGHT_GREEN,
             Help => term::color::BRIGHT_CYAN,
             Cancelled => unreachable!(),
         }
@@ -529,7 +530,8 @@ impl Level {
             Fatal | PhaseFatal | Error => "error",
             Warning => "warning",
             Note => "note",
-            TopLevel => "note",
+            Expected => "expected",
+            Found => "found",
             Help => "help",
             Cancelled => panic!("Shouldn't call on cancelled error"),
         }

--- a/src/librustc_errors/snippet.rs
+++ b/src/librustc_errors/snippet.rs
@@ -185,4 +185,5 @@ pub enum Style {
     NoStyle,
     ErrorCode,
     Level(Level),
+    Highlight,
 }

--- a/src/test/compile-fail-fulldeps/proc-macro/signature.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/signature.rs
@@ -17,7 +17,7 @@ extern crate proc_macro;
 pub unsafe extern fn foo(a: i32, b: u32) -> u32 {
     //~^ ERROR: mismatched types
     //~| NOTE: expected normal fn, found unsafe fn
-    //~| NOTE: expected type `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
-    //~| NOTE: found type `unsafe extern "C" fn(i32, u32) -> u32 {foo}`
+    //~| expected type `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
+    //~| found type `unsafe extern "C" fn(i32, u32) -> u32 {foo}`
     loop {}
 }

--- a/src/test/ui/compare-method/reordered-type-param.stderr
+++ b/src/test/ui/compare-method/reordered-type-param.stderr
@@ -7,8 +7,8 @@ error[E0053]: method `b` has an incompatible type for trait
 26 |   fn b<F:Clone,G>(&self, _x: G) -> G { panic!() } //~ ERROR method `b` has an incompatible type
    |                              ^ expected type parameter, found a different type parameter
    |
-   = note: expected type `fn(&E, F) -> F`
-   = note:    found type `fn(&E, G) -> G`
+   = expected type `fn(&E, F) -> F`
+   =    found type `fn(&E, G) -> G`
 
 error: aborting due to previous error
 

--- a/src/test/ui/mismatched_types/issue-35030.stderr
+++ b/src/test/ui/mismatched_types/issue-35030.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 19 |         Some(true)
    |              ^^^^ expected type parameter, found bool
    |
-   = note: expected type `bool` (type parameter)
-   = note:    found type `bool` (bool)
+   = expected type `bool` (type parameter)
+   =    found type `bool` (bool)
 
 error: aborting due to previous error
 

--- a/src/test/ui/mismatched_types/main.stderr
+++ b/src/test/ui/mismatched_types/main.stderr
@@ -6,8 +6,8 @@ error[E0308]: mismatched types
 13 | |     );
    | |_____^ ...ending here: expected u32, found ()
    |
-   = note: expected type `u32`
-   = note:    found type `()`
+   = expected type `u32`
+   =    found type `()`
 
 error: aborting due to previous error
 

--- a/src/test/ui/mismatched_types/trait-impl-fn-incompatibility.stderr
+++ b/src/test/ui/mismatched_types/trait-impl-fn-incompatibility.stderr
@@ -16,8 +16,8 @@ error[E0053]: method `bar` has an incompatible type for trait
 22 |     fn bar(&mut self, bar: &Bar) { }
    |                            ^^^^ types differ in mutability
    |
-   = note: expected type `fn(&mut Bar, &mut Bar)`
-   = note:    found type `fn(&mut Bar, &Bar)`
+   = expected type `fn(&mut Bar, &mut Bar)`
+   =    found type `fn(&mut Bar, &Bar)`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/resolve/token-error-correct-3.stderr
+++ b/src/test/ui/resolve/token-error-correct-3.stderr
@@ -34,8 +34,8 @@ error[E0308]: mismatched types
 25 |             fs::create_dir_all(path.as_ref()).map(|()| true) //~ ERROR: mismatched types
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found enum `std::result::Result`
    |
-   = note: expected type `()`
-   = note:    found type `std::result::Result<bool, std::io::Error>`
+   = expected type `()`
+   =    found type `std::result::Result<bool, std::io::Error>`
    = help: here are some functions which might fulfill your needs:
  - .unwrap()
  - .unwrap_err()

--- a/src/test/ui/span/coerce-suggestions.stderr
+++ b/src/test/ui/span/coerce-suggestions.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 17 |     let x: usize = String::new();
    |                    ^^^^^^^^^^^^^ expected usize, found struct `std::string::String`
    |
-   = note: expected type `usize`
-   = note:    found type `std::string::String`
+   = expected type `usize`
+   =    found type `std::string::String`
    = help: here are some functions which might fulfill your needs:
  - .capacity()
  - .len()
@@ -16,8 +16,8 @@ error[E0308]: mismatched types
 23 |     let x: &str = String::new();
    |                   ^^^^^^^^^^^^^ expected &str, found struct `std::string::String`
    |
-   = note: expected type `&str`
-   = note:    found type `std::string::String`
+   = expected type `&str`
+   =    found type `std::string::String`
    = help: here are some functions which might fulfill your needs:
  - .as_str()
  - .trim()
@@ -30,8 +30,8 @@ error[E0308]: mismatched types
 30 |     test(&y);
    |          ^^ types differ in mutability
    |
-   = note: expected type `&mut std::string::String`
-   = note:    found type `&std::string::String`
+   = expected type `&mut std::string::String`
+   =    found type `&std::string::String`
 
 error[E0308]: mismatched types
   --> $DIR/coerce-suggestions.rs:36:11
@@ -39,8 +39,8 @@ error[E0308]: mismatched types
 36 |     test2(&y);
    |           ^^ types differ in mutability
    |
-   = note: expected type `&mut i32`
-   = note:    found type `&std::string::String`
+   = expected type `&mut i32`
+   =    found type `&std::string::String`
 
 error[E0308]: mismatched types
   --> $DIR/coerce-suggestions.rs:42:9
@@ -48,8 +48,8 @@ error[E0308]: mismatched types
 42 |     f = box f;
    |         ^^^^^ cyclic type of infinite size
    |
-   = note: expected type `_`
-   = note:    found type `Box<_>`
+   = expected type `_`
+   =    found type `Box<_>`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/span/move-closure.stderr
+++ b/src/test/ui/span/move-closure.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 15 |     let x: () = move || ();
    |                 ^^^^^^^^^^ expected (), found closure
    |
-   = note: expected type `()`
-   = note:    found type `[closure@$DIR/move-closure.rs:15:17: 15:27]`
+   = expected type `()`
+   =    found type `[closure@$DIR/move-closure.rs:15:17: 15:27]`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Given file

```
fn main() {
    let x: usize = "";
}
```

provide the following output

```rust
error[E0308]: mismatched types
 --> file.rs:2:20
  |
2 |     let x: usize = "";
  |                    ^^ expected usize, found reference
  |
  = expected type `usize`
  =    found type `&'static str`
  = help: here are some functions which might fulfill your needs:
 - .len()
```

Fix #38901.