### PR TITLE
travis: Wrap submodules updates in travis_retry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,10 +69,10 @@ script:
       if [ "$ALLOW_PR" = "" ] && [ "$TRAVIS_BRANCH" != "auto" ]; then
           echo skipping, not a full build;
       elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
-          git submodule update --init &&
+          travis_retry git submodule update --init &&
           src/ci/run.sh;
       else
-          git submodule update --init &&
+          travis_retry git submodule update --init &&
           src/ci/docker/run.sh $IMAGE;
       fi
 


### PR DESCRIPTION
Let's try to squash some of those network issues with a `travis_retry`
tool to just retry the command a few times.