### PR TITLE
Avoid using load/stores on first class aggregates

### DIFF
--- a/src/librustc_trans/common.rs
+++ b/src/librustc_trans/common.rs
@@ -58,9 +58,6 @@ pub fn type_is_fat_ptr<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, ty: Ty<'tcx>) -> 
 }
 
 pub fn type_is_immediate<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, ty: Ty<'tcx>) -> bool {
-    use machine::llsize_of_alloc;
-    use type_of::sizing_type_of;
-
     let simple = ty.is_scalar() ||
         ty.is_unique() || ty.is_region_ptr() ||
         ty.is_simd();
@@ -70,13 +67,7 @@ pub fn type_is_immediate<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, ty: Ty<'tcx>) -
     if !ccx.shared().type_is_sized(ty) {
         return false;
     }
-    match ty.sty {
-        ty::TyAdt(..) | ty::TyTuple(..) | ty::TyArray(..) | ty::TyClosure(..) => {
-            let llty = sizing_type_of(ccx, ty);
-            llsize_of_alloc(ccx, llty) <= llsize_of_alloc(ccx, ccx.int_type())
-        }
-        _ => type_is_zero_size(ccx, ty)
-    }
+    type_is_zero_size(ccx, ty)
 }
 
 /// Returns Some([a, b]) if the type has a pair of fields with types a and b.


### PR DESCRIPTION
LLVM usually prefers using memcpys over direct loads/store of first
class aggregates. The check in type_is_immediate to mark certain small
structs was originally part of the code to handle such immediates in
function arguments, and it had a counterpart in load_ty/store_ty to
actually convert small aggregates to integers.

But since then, the ABI handling has been refactored and takes care of
converting small aggregates to integers. During that refactoring, the
code to handle small aggregates in load_ty/store_ty has been removed,
and so we accidentally started using loads/stores on FCA values.

Since type_is_immediate() is no longer responsible for ABI-related
conversions, and using a memcpy even for small aggregates is usually
better than performing a FCA load/store, we can remove that code part
and only handle simple types as immediates there.