### PR TITLE
rustbuild: Pass --retry 3 to curl

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -72,7 +72,7 @@ def download(path, url, probably_big, verbose):
             option = "-#"
         else:
             option = "-s"
-        run(["curl", option, "-Sf", "-o", path, url], verbose=verbose)
+        run(["curl", option, "--retry", "3", "-Sf", "-o", path, url], verbose=verbose)
 
 
 def verify(path, sha_path, verbose):


### PR DESCRIPTION
Try to handle spurious network failures on Travis by automatically
retrying failed downloads on Travis.