### PR TITLE
Make tidy check for lang gate tests

### DIFF
--- a/COMPILER_TESTS.md
+++ b/COMPILER_TESTS.md
@@ -45,6 +45,10 @@ whole, instead of just a few lines inside the test.
 * `should-fail` indicates that the test should fail; used for "meta testing",
   where we test the compiletest program itself to check that it will generate
   errors in appropriate scenarios. This header is ignored for pretty-printer tests.
+* `gate-test-X` where `X` is a feature marks the test as "gate test" for feature X.
+  Such tests are supposed to ensure that the compiler errors when usage of a gated
+  feature is attempted without the proper `#![feature(X)]` tag.
+  Each unstable lang feature is required to have a gate test.
 
 ## Revisions
 

--- a/src/test/compile-fail/asm-gated.rs
+++ b/src/test/compile-fail/asm-gated.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-asm
+
 fn main() {
     unsafe {
         asm!(""); //~ ERROR inline assembly is not stable enough

--- a/src/test/compile-fail/asm-gated2.rs
+++ b/src/test/compile-fail/asm-gated2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-asm
+
 fn main() {
     unsafe {
         println!("{}", asm!("")); //~ ERROR inline assembly is not stable

--- a/src/test/compile-fail/attr-on-generic-formals-wo-feature-gate.rs
+++ b/src/test/compile-fail/attr-on-generic-formals-wo-feature-gate.rs
@@ -16,6 +16,8 @@
 // using `rustc_attrs` feature. There is a separate compile-fail/ test
 // ensuring that the attribute feature-gating works in this context.)
 
+// gate-test-generic_param_attrs
+
 #![feature(rustc_attrs)]
 #![allow(dead_code)]
 

--- a/src/test/compile-fail/check-static-values-constraints.rs
+++ b/src/test/compile-fail/check-static-values-constraints.rs
@@ -10,6 +10,8 @@
 
 // Verifies all possible restrictions for statics values.
 
+// gate-test-drop_types_in_const
+
 #![feature(box_syntax)]
 
 use std::marker;

--- a/src/test/compile-fail/concat_idents-gate.rs
+++ b/src/test/compile-fail/concat_idents-gate.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-concat_idents
+
 const XY_1: i32 = 10;
 
 fn main() {

--- a/src/test/compile-fail/concat_idents-gate2.rs
+++ b/src/test/compile-fail/concat_idents-gate2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-concat_idents
+
 const XY_1: i32 = 10;
 
 fn main() {

--- a/src/test/compile-fail/const-fn-stability.rs
+++ b/src/test/compile-fail/const-fn-stability.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-const_fn
+
 // Test use of const fn without feature gate.
 
 const fn foo() -> usize { 0 } //~ ERROR const fn is unstable

--- a/src/test/compile-fail/feature-gate-abi.rs
+++ b/src/test/compile-fail/feature-gate-abi.rs
@@ -8,6 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-intrinsics
+// gate-test-platform_intrinsics
+// gate-test-abi_vectorcall
+
 // Functions
 extern "rust-intrinsic" fn f1() {} //~ ERROR intrinsics are subject to change
 extern "platform-intrinsic" fn f2() {} //~ ERROR platform intrinsics are experimental

--- a/src/test/compile-fail/feature-gate-advanced-slice-features.rs
+++ b/src/test/compile-fail/feature-gate-advanced-slice-features.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-advanced_slice_patterns
+
 #![feature(slice_patterns)]
 
 fn main() {

--- a/src/test/compile-fail/feature-gate-allow-internal-unstable-nested-macro.rs
+++ b/src/test/compile-fail/feature-gate-allow-internal-unstable-nested-macro.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-allow_internal_unstable
+
 macro_rules! bar {
     () => {
         // more layers don't help:

--- a/src/test/compile-fail/feature-gate-assoc-type-defaults.rs
+++ b/src/test/compile-fail/feature-gate-assoc-type-defaults.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-associated_type_defaults
+
 trait Foo {
     type Bar = u8; //~ ERROR associated type defaults are unstable
 }

--- a/src/test/compile-fail/feature-gate-box-expr.rs
+++ b/src/test/compile-fail/feature-gate-box-expr.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-box_syntax
+
 // Check that `box EXPR` is feature-gated.
 //
 // See also feature-gate-placement-expr.rs

--- a/src/test/compile-fail/feature-gate-box-pat.rs
+++ b/src/test/compile-fail/feature-gate-box-pat.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-box_patterns
+
 fn main() {
     let box x = Box::new('c'); //~ ERROR box pattern syntax is experimental
     println!("x: {}", x);

--- a/src/test/compile-fail/feature-gate-dropck-ugeh.rs
+++ b/src/test/compile-fail/feature-gate-dropck-ugeh.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-dropck_parametricity
+
 // Ensure that attempts to use the unsafe attribute are feature-gated.
 
 // Example adapted from RFC 1238 text (just left out the feature gate).

--- a/src/test/compile-fail/feature-gate-may-dangle.rs
+++ b/src/test/compile-fail/feature-gate-may-dangle.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-dropck_eyepatch
+
 // Check that `may_dangle` is rejected if `dropck_eyepatch` feature gate is absent.
 
 #![feature(generic_param_attrs)]

--- a/src/test/compile-fail/feature-gate-placement-expr.rs
+++ b/src/test/compile-fail/feature-gate-placement-expr.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-placement_in_syntax
+
 // Check that `in PLACE { EXPR }` is feature-gated.
 //
 // See also feature-gate-box-expr.rs

--- a/src/test/compile-fail/gated-associated_consts.rs
+++ b/src/test/compile-fail/gated-associated_consts.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-associated_consts
+
 trait MyTrait {
     const C: bool;
     //~^ associated constants are experimental

--- a/src/test/compile-fail/gated-attr-literals.rs
+++ b/src/test/compile-fail/gated-attr-literals.rs
@@ -10,6 +10,8 @@
 
 // Check that literals in attributes don't parse without the feature gate.
 
+// gate-test-attr_literals
+
 #![feature(rustc_attrs)]
 #![allow(dead_code)]
 #![allow(unused_variables)]

--- a/src/test/compile-fail/gated-box-syntax.rs
+++ b/src/test/compile-fail/gated-box-syntax.rs
@@ -10,6 +10,8 @@
 
 // Test that the use of the box syntax is gated by `box_syntax` feature gate.
 
+// gate-test-box_syntax
+
 fn main() {
     let x = box 3;
     //~^ ERROR box expression syntax is experimental; you can call `Box::new` instead.

--- a/src/test/compile-fail/gated-concat_idents.rs
+++ b/src/test/compile-fail/gated-concat_idents.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-concat_idents
+
 fn main() {
     concat_idents!(a, b); //~ ERROR `concat_idents` is not stable enough
 }

--- a/src/test/compile-fail/gated-link-args.rs
+++ b/src/test/compile-fail/gated-link-args.rs
@@ -11,6 +11,8 @@
 // Test that `#[link_args]` attribute is gated by `link_args`
 // feature gate.
 
+// gate-test-link_args
+
 #[link_args = "aFdEfSeVEEE"]
 extern {}
 //~^ ERROR the `link_args` attribute is not portable across platforms

--- a/src/test/compile-fail/gated-link-llvm-intrinsics.rs
+++ b/src/test/compile-fail/gated-link-llvm-intrinsics.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-link_llvm_intrinsics
+
 extern {
     #[link_name = "llvm.sqrt.f32"]
     fn sqrt(x: f32) -> f32;

--- a/src/test/compile-fail/gated-naked_functions.rs
+++ b/src/test/compile-fail/gated-naked_functions.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-naked_functions
+
 #[naked]
 //~^ the `#[naked]` attribute is an experimental feature
 fn naked() {}

--- a/src/test/compile-fail/gated-no-core.rs
+++ b/src/test/compile-fail/gated-no-core.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-no_core
+
 #![no_core] //~ ERROR no_core is experimental
 
 fn main() {}

--- a/src/test/compile-fail/gated-non-ascii-idents.rs
+++ b/src/test/compile-fail/gated-non-ascii-idents.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-non_ascii_idents
+
 extern crate core as bäz; //~ ERROR non-ascii idents
 
 use föö::bar; //~ ERROR non-ascii idents

--- a/src/test/compile-fail/gated-plugin_registrar.rs
+++ b/src/test/compile-fail/gated-plugin_registrar.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-plugin_registrar
+
 // Test that `#[plugin_registrar]` attribute is gated by `plugin_registrar`
 // feature gate.
 

--- a/src/test/compile-fail/gated-target_feature.rs
+++ b/src/test/compile-fail/gated-target_feature.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-target_feature
+
 #[target_feature = "+sse2"]
 //~^ the `#[target_feature]` attribute is an experimental feature
 fn foo() {}

--- a/src/test/compile-fail/gated-thread-local.rs
+++ b/src/test/compile-fail/gated-thread-local.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-thread_local
+
 // Test that `#[thread_local]` attribute is gated by `thread_local`
 // feature gate.
 //

--- a/src/test/compile-fail/gated-trace_macros.rs
+++ b/src/test/compile-fail/gated-trace_macros.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-trace_macros
 
 fn main() {
     trace_macros!(true); //~ ERROR: `trace_macros` is not stable

--- a/src/test/compile-fail/i128-feature-2.rs
+++ b/src/test/compile-fail/i128-feature-2.rs
@@ -7,6 +7,9 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
+// gate-test-i128_type
+
 fn test1() -> i128 { //~ ERROR 128-bit type is unstable
     0
 }

--- a/src/test/compile-fail/i128-feature.rs
+++ b/src/test/compile-fail/i128-feature.rs
@@ -7,6 +7,9 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
+// gate-test-i128_type
+
 fn test2() {
     0i128; //~ ERROR 128-bit integers are not stable
 }

--- a/src/test/compile-fail/impl-trait/feature-gate.rs
+++ b/src/test/compile-fail/impl-trait/feature-gate.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-conservative_impl_trait
+
 fn foo() -> impl Fn() { || {} }
 //~^ ERROR `impl Trait` is experimental
 

--- a/src/test/compile-fail/link-cfg-gated.rs
+++ b/src/test/compile-fail/link-cfg-gated.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-link_cfg
+
 #[link(name = "foo", cfg(foo))]
 //~^ ERROR: is feature gated
 extern {}

--- a/src/test/compile-fail/linkage1.rs
+++ b/src/test/compile-fail/linkage1.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-linkage
+
 extern {
     #[linkage = "extern_weak"] static foo: isize;
     //~^ ERROR: the `linkage` attribute is experimental and not portable

--- a/src/test/compile-fail/log-syntax-gate.rs
+++ b/src/test/compile-fail/log-syntax-gate.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-log_syntax
+
 fn main() {
     log_syntax!() //~ ERROR `log_syntax!` is not stable enough
 }

--- a/src/test/compile-fail/log-syntax-gate2.rs
+++ b/src/test/compile-fail/log-syntax-gate2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-log_syntax
+
 fn main() {
     println!("{}", log_syntax!()); //~ ERROR `log_syntax!` is not stable
 }

--- a/src/test/compile-fail/never-disabled.rs
+++ b/src/test/compile-fail/never-disabled.rs
@@ -10,6 +10,8 @@
 
 // Test that ! errors when used in illegal positions with feature(never_type) disabled
 
+// gate-test-never_type
+
 trait Foo {
     type Wub;
 }

--- a/src/test/compile-fail/no-core-gated.rs
+++ b/src/test/compile-fail/no-core-gated.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-no_core
+
 #![no_core] //~ ERROR no_core is experimental
 
 fn main() {}

--- a/src/test/compile-fail/numeric-fields-feature-gate.rs
+++ b/src/test/compile-fail/numeric-fields-feature-gate.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-relaxed_adts
+
 struct S(u8);
 
 fn main() {

--- a/src/test/compile-fail/panic-runtime/needs-gate.rs
+++ b/src/test/compile-fail/panic-runtime/needs-gate.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-needs_panic_runtime
+// gate-test-panic_runtime
+
 #![panic_runtime] //~ ERROR: is an experimental feature
 #![needs_panic_runtime] //~ ERROR: is an experimental feature
 

--- a/src/test/compile-fail/privacy/restricted/feature-gate.rs
+++ b/src/test/compile-fail/privacy/restricted/feature-gate.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-pub_restricted
+
 pub(crate) //~ ERROR experimental
 mod foo {}
 

--- a/src/test/compile-fail/rfc1445/feature-gate.rs
+++ b/src/test/compile-fail/rfc1445/feature-gate.rs
@@ -14,6 +14,8 @@
 
 // revisions: with_gate no_gate
 
+// gate-test-structural_match
+
 #![allow(dead_code)]
 #![deny(future_incompatible)]
 #![feature(rustc_attrs)]

--- a/src/test/compile-fail/single-derive-attr.rs
+++ b/src/test/compile-fail/single-derive-attr.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-custom_derive
+
 #[derive_Clone]
 //~^ ERROR attributes of the form `#[derive_*]` are reserved
 struct Test;

--- a/src/test/compile-fail/specialization/specialization-feature-gate-default.rs
+++ b/src/test/compile-fail/specialization/specialization-feature-gate-default.rs
@@ -10,6 +10,8 @@
 
 // Check that specialization must be ungated to use the `default` keyword
 
+// gate-test-specialization
+
 trait Foo {
     fn foo(&self);
 }

--- a/src/test/compile-fail/specialization/specialization-feature-gate-overlap.rs
+++ b/src/test/compile-fail/specialization/specialization-feature-gate-overlap.rs
@@ -10,6 +10,8 @@
 
 // Check that writing an overlapping impl is not allow unless specialization is ungated.
 
+// gate-test-specialization
+
 trait Foo {
     fn foo(&self);
 }

--- a/src/test/compile-fail/static-mut-not-constant.rs
+++ b/src/test/compile-fail/static-mut-not-constant.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-drop_types_in_const
+
 #![feature(box_syntax)]
 
 static mut a: Box<isize> = box 3;

--- a/src/test/compile-fail/struct-field-attr-feature-gate.rs
+++ b/src/test/compile-fail/struct-field-attr-feature-gate.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-struct_field_attributes
+
 struct Foo {
     present: (),
 }

--- a/src/test/compile-fail/type-ascription-feature-gate.rs
+++ b/src/test/compile-fail/type-ascription-feature-gate.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-type_ascription
+
 // Type ascription is feature gated
 
 fn main() {

--- a/src/test/compile-fail/unadjusted-unstable.rs
+++ b/src/test/compile-fail/unadjusted-unstable.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-abi_unadjusted
+
 extern "unadjusted" fn foo() {
 //~^ ERROR: unadjusted ABI is an implementation detail and perma-unstable
 }

--- a/src/test/compile-fail/union/union-feature-gate.rs
+++ b/src/test/compile-fail/union/union-feature-gate.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-untagged_unions
+
 union U { //~ ERROR unions are unstable and possibly buggy
     a: u8,
 }

--- a/src/test/compile-fail/windows-subsystem-gated.rs
+++ b/src/test/compile-fail/windows-subsystem-gated.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// gate-test-windows_subsystem
+
 #![windows_subsystem = "console"]
 //~^ ERROR: the windows subsystem attribute is currently unstable
 

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -124,6 +124,9 @@ pub fn check(path: &Path, bad: &mut bool) {
             return;
         }
 
+        let filen_underscore = filename.replace("-","_").replace(".rs","");
+        test_filen_gate(&filen_underscore, &mut features);
+
         contents.truncate(0);
         t!(t!(File::open(&file), &file).read_to_string(&mut contents));
 
@@ -212,6 +215,19 @@ fn find_attr_val<'a>(line: &'a str, attr: &str) -> Option<&'a str> {
         .and_then(|i| line[i..].find('"').map(|j| i + j + 1))
         .and_then(|i| line[i..].find('"').map(|j| (i, i + j)))
         .map(|(i, j)| &line[i..j])
+}
+
+fn test_filen_gate(filen_underscore: &str,
+                   features: &mut HashMap<String, Feature>) -> bool {
+    if filen_underscore.starts_with("feature_gate") {
+        for (n, f) in features.iter_mut() {
+            if filen_underscore == format!("feature_gate_{}", n) {
+                f.has_gate_test = true;
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 fn collect_lang_features(path: &Path) -> HashMap<String, Feature> {

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -166,7 +166,7 @@ pub fn check(path: &Path, bad: &mut bool) {
                                 .count();
 
     // FIXME get this number down to zero.
-    let gate_untested_expected = 98;
+    let gate_untested_expected = 94;
 
     if gate_untested != gate_untested_expected {
         print!("Expected {} gate untested features, but found {}. ",

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -16,7 +16,7 @@
 //! * The set of library features is disjoint from the set of language features
 //! * Library features have at most one stability level
 //! * Library features have at most one `since` value
-//! * All stability attributes have tests to ensure they are actually stable/unstable
+//! * All unstable lang features have tests to ensure they are actually unstable
 
 use std::collections::HashMap;
 use std::fmt;
@@ -27,6 +27,7 @@ use std::path::Path;
 #[derive(PartialEq)]
 enum Status {
     Stable,
+    Removed,
     Unstable,
 }
 
@@ -35,6 +36,7 @@ impl fmt::Display for Status {
         let as_str = match *self {
             Status::Stable => "stable",
             Status::Unstable => "unstable",
+            Status::Removed => "removed",
         };
         fmt::Display::fmt(as_str, f)
     }
@@ -221,7 +223,7 @@ fn collect_lang_features(path: &Path) -> HashMap<String, Feature> {
             let mut parts = line.trim().split(",");
             let level = match parts.next().map(|l| l.trim().trim_left_matches('(')) {
                 Some("active") => Status::Unstable,
-                Some("removed") => Status::Unstable,
+                Some("removed") => Status::Removed,
                 Some("accepted") => Status::Stable,
                 _ => return None,
             };


### PR DESCRIPTION
Add gate tests to the checks that tidy performs. Excerpt from the commit message of the main commit:

    Require compile-fail tests for new lang features

    Its non trivial to test lang feature gates, and people
    forget to add such tests. So we extend the features lint
    of the tidy tool to ensure that all new lang features
    contain a new compile-fail test.
    
    Of course, one could drop this requirement and just
    grep all tests in run-pass for #![feature(abc)] and
    then run this test again, removing the mention,
    requiring that it fails.
    
    But this only tests for the existence of a compilation
    failure. Manual tests ensure that also the correct lines
    spawn the error, and also test the actual error message.
    
    For library features, it makes no sense to require such
    a test, as here code is used that is generic for all
    library features.

The tidy lint extension now checks the compile-fail test suite for occurences of "gate-test-X" where X is a feature. Alternatively, it also accepts file names with the form "feature-gate-X.rs". If a lang feature is found that has no such check, we emit a tidy error.

I've applied the markings to all tests I could find in the test suite. I left a small (20 elements) whitelist of features that right now have no gate test, or where I couldn't find one. Once this PR gets merged, I'd like to close issue #22820 and open a new one on suggestion of @nikomatsakis to track the removal of all elements from that whitelist (already have a draft). Writing such a small test can be a good opportunity for a first contribution, so I won't touch it (let others have the fun xD).

cc @brson , @pnkfelix (they both discussed about this in the issue linked above).