### PR TITLE
Add an official do-while loop to the core lib

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -557,12 +557,23 @@ macro_rules! unimplemented {
 /// # Examples
 ///
 /// ```
+/// # macro_rules! do_while {
+/// #     (($while_b:expr) $($do_b:tt)+) => {
+/// #         loop {
+/// #             $($do_b)*
+/// #             if !( $while_b ) { break; }
+/// #         }
+/// #     }
+/// # }
+/// # 
+/// # fn main() {
 /// let mut i = 0;
 ///
 /// do_while!{ (i < 0)
 ///     println!("{}", i);
 ///     i += 1;
 /// }
+/// # }
 /// ```
 #[macro_export]
 #[unstable(feature = "do_while", issue="0")]

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -565,7 +565,7 @@ macro_rules! unimplemented {
 /// }
 /// ```
 #[macro_export]
-#[stable(feature = "core", since = "1.16.0")]
+#[unstable(feature = "do_while")]
 macro_rules! do_while {
     (($while_b:expr) $($do_b:tt)+) => {
         loop {

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -565,7 +565,7 @@ macro_rules! unimplemented {
 /// }
 /// ```
 #[macro_export]
-#[unstable(feature = "do_while")]
+#[unstable(feature = "do_while", issue="0")]
 macro_rules! do_while {
     (($while_b:expr) $($do_b:tt)+) => {
         loop {

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -565,6 +565,7 @@ macro_rules! unimplemented {
 /// }
 /// ```
 #[macro_export]
+#[stable(feature = "core", since = "1.16.0")]
 macro_rules! do_while {
     (($while_b:expr) $($do_b:tt)+) => {
         loop {

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -547,6 +547,33 @@ macro_rules! unimplemented {
     () => (panic!("not yet implemented"))
 }
 
+/// Macro to mimick a do-while loop.
+///
+/// Equivalent to a `while` loop, except that the body of the loop is
+/// always executed at least once.
+///
+/// Note that the condition has to be in parentheses.
+///
+/// # Examples
+///
+/// ```
+/// let mut i = 0;
+///
+/// do_while!{ (i < 0)
+///     println!("{}", i);
+///     i += 1;
+/// }
+/// ```
+#[macro_export]
+macro_rules! do_while {
+    (($while_b:expr) $($do_b:tt)+) => {
+        loop {
+            $($do_b)*
+            if !( $while_b ) { break; }
+        }
+    }
+}
+
 /// Built-in macros to the compiler itself.
 ///
 /// These macros do not have any corresponding definition with a `macro_rules!`


### PR DESCRIPTION
I know we have [this horrible hack](https://gist.github.com/huonw/8435502) to act like a do-while loop, but it would seem wiser to have a nice macro that will always work instead.