### PR TITLE
Avoid large number of stage 0 warnings about --no-stack-check

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -175,7 +175,7 @@ endif
 # that the snapshot will be generated with a statically linked rustc so we only
 # have to worry about the distribution of one file (with its native dynamic
 # dependencies)
-RUSTFLAGS_STAGE0 += -C prefer-dynamic -C no-stack-check
+RUSTFLAGS_STAGE0 += -C prefer-dynamic
 RUSTFLAGS_STAGE1 += -C prefer-dynamic
 RUST_LIB_FLAGS_ST2 += -C prefer-dynamic
 RUST_LIB_FLAGS_ST3 += -C prefer-dynamic


### PR DESCRIPTION
```
....

rustc: x86_64-pc-windows-gnu/stage0/lib/rustlib/x86_64-pc-windows-gnu/lib/libstd
warning: the --no-stack-check flag is deprecated and does nothing

rustc: x86_64-pc-windows-gnu/stage0/lib/rustlib/x86_64-pc-windows-gnu/lib/libgetopts
warning: the --no-stack-check flag is deprecated and does nothing

rustc: x86_64-pc-windows-gnu/stage0/lib/rustlib/x86_64-pc-windows-gnu/lib/libterm
warning: the --no-stack-check flag is deprecated and does nothing

rustc: x86_64-pc-windows-gnu/stage0/lib/rustlib/x86_64-pc-windows-gnu/lib/liblog
warning: the --no-stack-check flag is deprecated and does nothing

....
```

r? @alexcrichton 