### PR TITLE
resolve: Levenshtein-based suggestions for non-import paths

### DIFF
--- a/src/test/ui/resolve/levenshtein.rs
+++ b/src/test/ui/resolve/levenshtein.rs
@@ -1,0 +1,33 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+const MAX_ITEM: usize = 10;
+
+fn foo_bar() {}
+
+fn foo(c: esize) {} // Misspelled primitive type name.
+
+enum Bar { }
+
+type A = Baz; // Misspelled type name.
+type B = Opiton<u8>; // Misspelled type name from the prelude.
+
+mod m {
+    type A = Baz; // No suggestion here, Bar is not visible
+
+    pub struct First;
+    pub struct Second;
+}
+
+fn main() {
+    let v = [0u32; MAXITEM]; // Misspelled constant name.
+    foobar(); // Misspelled function name.
+    let b: m::first = m::second; // Misspelled item in module.
+}

--- a/src/test/ui/resolve/levenshtein.stderr
+++ b/src/test/ui/resolve/levenshtein.stderr
@@ -1,0 +1,56 @@
+error[E0412]: cannot find type `esize` in this scope
+  --> $DIR/levenshtein.rs:15:11
+   |
+15 | fn foo(c: esize) {} // Misspelled primitive type name.
+   |           ^^^^^ did you mean `isize`?
+
+error[E0412]: cannot find type `Baz` in this scope
+  --> $DIR/levenshtein.rs:19:10
+   |
+19 | type A = Baz; // Misspelled type name.
+   |          ^^^ did you mean `Bar`?
+
+error[E0412]: cannot find type `Opiton` in this scope
+  --> $DIR/levenshtein.rs:20:10
+   |
+20 | type B = Opiton<u8>; // Misspelled type name from the prelude.
+   |          ^^^^^^^^^^ did you mean `Option`?
+
+error[E0412]: cannot find type `Baz` in this scope
+  --> $DIR/levenshtein.rs:23:14
+   |
+23 |     type A = Baz; // No suggestion here, Bar is not visible
+   |              ^^^ not found in this scope
+
+error[E0425]: cannot find value `MAXITEM` in this scope
+  --> $DIR/levenshtein.rs:30:20
+   |
+30 |     let v = [0u32; MAXITEM]; // Misspelled constant name.
+   |                    ^^^^^^^ did you mean `MAX_ITEM`?
+
+error[E0425]: cannot find function `foobar` in this scope
+  --> $DIR/levenshtein.rs:31:5
+   |
+31 |     foobar(); // Misspelled function name.
+   |     ^^^^^^ did you mean `foo_bar`?
+
+error[E0412]: cannot find type `first` in module `m`
+  --> $DIR/levenshtein.rs:32:12
+   |
+32 |     let b: m::first = m::second; // Misspelled item in module.
+   |            ^^^^^^^^ did you mean `m::First`?
+
+error[E0425]: cannot find value `second` in module `m`
+  --> $DIR/levenshtein.rs:32:23
+   |
+32 |     let b: m::first = m::second; // Misspelled item in module.
+   |                       ^^^^^^^^^ did you mean `m::Second`?
+
+error[E0080]: constant evaluation error
+  --> $DIR/levenshtein.rs:30:20
+   |
+30 |     let v = [0u32; MAXITEM]; // Misspelled constant name.
+   |                    ^^^^^^^ unresolved path in constant expression
+
+error: aborting due to previous error
+

--- a/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.stderr
+++ b/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.stderr
@@ -32,7 +32,7 @@ error[E0423]: expected value, found module `a::b`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:55:12
    |
 55 |     v.push(a::b);
-   |            ^^^^ not a value
+   |            ^^^^ did you mean `a::I`?
 
 error[E0423]: expected value, found module `a::b`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:61:5
@@ -44,13 +44,13 @@ error[E0423]: expected value, found module `a::b`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:67:5
    |
 67 |     a::b
-   |     ^^^^ not a value
+   |     ^^^^ did you mean `a::I`?
 
 error[E0423]: expected function, found module `a::b`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:73:5
    |
 73 |     a::b()
-   |     ^^^^ not a function
+   |     ^^^^ did you mean `a::I`?
 
 error: main function not found
 


### PR DESCRIPTION
This patch addresses both items from https://github.com/rust-lang/rust/issues/30197#issuecomment-264846000 and therefore implements the largest part of https://github.com/rust-lang/rust/issues/30197.

r? @jseyfried 