### PR TITLE
Updates to src/libcore/ops.rs docs for RFC#1228 (Placement Left Arrow)

### DIFF
--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -2747,7 +2747,7 @@ impl<T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for *mut T {}
 #[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for *const T {}
 
-/// Both `in (PLACE) EXPR` and `box EXPR` desugar into expressions
+/// Both `PLACE <- EXPR` and `box EXPR` desugar into expressions
 /// that allocate an intermediate "place" that holds uninitialized
 /// state.  The desugaring evaluates EXPR, and writes the result at
 /// the address returned by the `pointer` method of this trait.
@@ -2762,7 +2762,7 @@ impl<T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for *const T {}
 /// converting the agent to an instance of the owning pointer, via the
 /// appropriate `finalize` method (see the `InPlace`.
 ///
-/// If evaluating EXPR fails, then the destructor for the
+/// If evaluating EXPR fails, then it is up to the destructor for the
 /// implementation of Place to clean up any intermediate state
 /// (e.g. deallocate box storage, pop a stack, etc).
 #[unstable(feature = "placement_new_protocol", issue = "27779")]
@@ -2773,9 +2773,9 @@ pub trait Place<Data: ?Sized> {
     fn pointer(&mut self) -> *mut Data;
 }
 
-/// Interface to implementations of  `in (PLACE) EXPR`.
+/// Interface to implementations of  `PLACE <- EXPR`.
 ///
-/// `in (PLACE) EXPR` effectively desugars into:
+/// `PLACE <- EXPR` effectively desugars into:
 ///
 /// ```rust,ignore
 /// let p = PLACE;
@@ -2788,7 +2788,7 @@ pub trait Place<Data: ?Sized> {
 /// }
 /// ```
 ///
-/// The type of `in (PLACE) EXPR` is derived from the type of `PLACE`;
+/// The type of `PLACE <- EXPR` is derived from the type of `PLACE`;
 /// if the type of `PLACE` is `P`, then the final type of the whole
 /// expression is `P::Place::Owner` (see the `InPlace` and `Boxed`
 /// traits).
@@ -2806,12 +2806,12 @@ pub trait Placer<Data: ?Sized> {
     fn make_place(self) -> Self::Place;
 }
 
-/// Specialization of `Place` trait supporting `in (PLACE) EXPR`.
+/// Specialization of `Place` trait supporting `PLACE <- EXPR`.
 #[unstable(feature = "placement_new_protocol", issue = "27779")]
 pub trait InPlace<Data: ?Sized>: Place<Data> {
-    /// `Owner` is the type of the end value of `in (PLACE) EXPR`
+    /// `Owner` is the type of the end value of `PLACE <- EXPR`
     ///
-    /// Note that when `in (PLACE) EXPR` is solely used for
+    /// Note that when `PLACE <- EXPR` is solely used for
     /// side-effecting an existing data-structure,
     /// e.g. `Vec::emplace_back`, then `Owner` need not carry any
     /// information at all (e.g. it can be the unit type `()` in that


### PR DESCRIPTION
Also fixed a minor typo in docs for `core::ops::Place`.