### PR TITLE
treat setting the number of test-threads to 0 as an error

### DIFF
--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -439,6 +439,8 @@ pub fn parse_opts(args: &[String]) -> Option<OptRes> {
     let test_threads = match matches.opt_str("test-threads") {
         Some(n_str) =>
             match n_str.parse::<usize>() {
+                Ok(0) => 
+                    return Some(Err(format!("argument for --test-threads must not be 0"))),
                 Ok(n) => Some(n),
                 Err(e) =>
                     return Some(Err(format!("argument for --test-threads must be a number > 0 \

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -439,7 +439,7 @@ pub fn parse_opts(args: &[String]) -> Option<OptRes> {
     let test_threads = match matches.opt_str("test-threads") {
         Some(n_str) =>
             match n_str.parse::<usize>() {
-                Ok(0) => 
+                Ok(0) =>
                     return Some(Err(format!("argument for --test-threads must not be 0"))),
                 Ok(n) => Some(n),
                 Err(e) =>


### PR DESCRIPTION
It is currently possible to call `cargo test -- --test-threads=0` which will cause cargo to hang until aborted. This change will fix that and will report an appropriate error to the user.