### PR TITLE
Fix struct_expr grammar: make base update part optional.

### DIFF
--- a/src/doc/grammar.md
+++ b/src/doc/grammar.md
@@ -512,7 +512,7 @@ unit_expr : "()" ;
 ```antlr
 struct_expr : expr_path '{' ident ':' expr
                       [ ',' ident ':' expr ] *
-                      [ ".." expr ] '}' |
+                      [ ".." expr ] ? '}' |
               expr_path '(' expr
                       [ ',' expr ] * ')' |
               expr_path ;


### PR DESCRIPTION
The current grammar rule 'struct_expr' does not set the base update part
as optional. ( S { x: 55, ..base } ).

Fixed by a single ?.

I noticed this in https://github.com/rust-lang/rust/pull/38956, but I'm not sure about the policy for PR. This seems like a disjoint change to me, therefore the separate PR. If things like this should be just mashed together to keep the queue cleaner, let me know.

The grammar also needs a lot of work (fix me everywhere). I might have time to make it more complete in the next weeks.

r? @steveklabnik