### PR TITLE
Add 128-bit atomics

### DIFF
--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -1314,6 +1314,24 @@ atomic_int! {
     unstable(feature = "integer_atomics", issue = "32976"),
     u64 AtomicU64 ATOMIC_U64_INIT
 }
+#[cfg(not(stage0))]
+#[cfg(target_has_atomic = "128")]
+atomic_int! {
+    unstable(feature = "i128", issue = "35118"),
+    unstable(feature = "i128", issue = "35118"),
+    unstable(feature = "i128", issue = "35118"),
+    unstable(feature = "i128", issue = "35118"),
+    i128 AtomicI128 ATOMIC_I128_INIT
+}
+#[cfg(not(stage0))]
+#[cfg(target_has_atomic = "128")]
+atomic_int! {
+    unstable(feature = "i128", issue = "35118"),
+    unstable(feature = "i128", issue = "35118"),
+    unstable(feature = "i128", issue = "35118"),
+    unstable(feature = "i128", issue = "35118"),
+    u128 AtomicU128 ATOMIC_U128_INIT
+}
 #[cfg(target_has_atomic = "ptr")]
 atomic_int!{
     stable(feature = "rust1", since = "1.0.0"),

--- a/src/test/run-make/atomic-lock-free/atomic_lock_free.rs
+++ b/src/test/run-make/atomic-lock-free/atomic_lock_free.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(cfg_target_has_atomic, no_core, intrinsics, lang_items)]
+#![feature(cfg_target_has_atomic, no_core, intrinsics, lang_items, i128_type)]
 #![crate_type="rlib"]
 #![no_core]
 
@@ -52,6 +52,14 @@ pub unsafe fn atomic_u64(x: *mut u64) {
 }
 #[cfg(target_has_atomic = "64")]
 pub unsafe fn atomic_i64(x: *mut i64) {
+    atomic_xadd(x, 1);
+}
+#[cfg(target_has_atomic = "128")]
+pub unsafe fn atomic_u128(x: *mut u128) {
+    atomic_xadd(x, 1);
+}
+#[cfg(target_has_atomic = "128")]
+pub unsafe fn atomic_i128(x: *mut i128) {
     atomic_xadd(x, 1);
 }
 #[cfg(target_has_atomic = "ptr")]


### PR DESCRIPTION
This is currently only supported on AArch64 since that is the only target which unconditionally supports 128-bit atomic operations.

cc #35118 