### PR TITLE
DoubleEndedIterator and ExactSizeIterator for To*case.

### DIFF
--- a/src/libstd_unicode/lib.rs
+++ b/src/libstd_unicode/lib.rs
@@ -35,9 +35,11 @@
 #![feature(char_escape_debug)]
 #![feature(core_char_ext)]
 #![feature(decode_utf8)]
+#![feature(exact_size_is_empty)]
 #![feature(fused)]
 #![feature(lang_items)]
 #![feature(staged_api)]
+#![feature(trusted_len)]
 #![feature(try_from)]
 
 mod tables;


### PR DESCRIPTION
Because the iterator itself is exact, I see no reason to not implement these traits. Sort of iffy in hindsight about `DoubleEndedIterator` but I've offered both to see what people think.