### PR TITLE
Deprecate `#[unsafe_destructor_blind_to_params]`

### DIFF
--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -691,10 +691,10 @@ pub const BUILTIN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeG
                                                        cfg_fn!(omit_gdb_pretty_printer_section))),
     ("unsafe_destructor_blind_to_params",
      Normal,
-     Gated(Stability::Unstable,
+     Gated(Stability::Deprecated("https://github.com/rust-lang/rust/issues/34761"),
            "dropck_parametricity",
-           "unsafe_destructor_blind_to_params has unstable semantics \
-            and may be removed in the future",
+           "unsafe_destructor_blind_to_params has been replaced by \
+            may_dangle and will be removed in the future",
            cfg_fn!(dropck_parametricity))),
     ("may_dangle",
      Normal,

--- a/src/test/compile-fail/feature-gate-dropck-ugeh-2.rs
+++ b/src/test/compile-fail/feature-gate-dropck-ugeh-2.rs
@@ -1,0 +1,22 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(deprecated)]
+#![feature(dropck_parametricity)]
+
+struct Foo;
+
+impl Drop for Foo {
+    #[unsafe_destructor_blind_to_params]
+    //~^ ERROR use of deprecated attribute `dropck_parametricity`
+    fn drop(&mut self) {}
+}
+
+fn main() {}

--- a/src/test/compile-fail/feature-gate-dropck-ugeh.rs
+++ b/src/test/compile-fail/feature-gate-dropck-ugeh.rs
@@ -25,7 +25,7 @@ struct Foo<T> { data: Vec<T> }
 
 impl<T> Drop for Foo<T> {
     #[unsafe_destructor_blind_to_params] // This is the UGEH attribute
-    //~^ ERROR unsafe_destructor_blind_to_params has unstable semantics
+    //~^ ERROR unsafe_destructor_blind_to_params has been replaced
     fn drop(&mut self) { }
 }
 


### PR DESCRIPTION
CC #34761 

r? @pnkfelix 