### PR TITLE
Add PartialOrd, Ord derivations to TypeId

### DIFF
--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -338,6 +338,10 @@ impl Any+Send {
 ///
 /// A `TypeId` is currently only available for types which ascribe to `'static`,
 /// but this limitation may be removed in the future.
+///
+/// While `TypeId` implements `Hash`, `PartialOrd`, and `Ord`, it is worth
+/// noting that the hashes and ordering will vary between Rust releases. Beware
+/// of relying on them outside of your code!
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct TypeId {

--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -338,7 +338,7 @@ impl Any+Send {
 ///
 /// A `TypeId` is currently only available for types which ascribe to `'static`,
 /// but this limitation may be removed in the future.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct TypeId {
     t: u64,


### PR DESCRIPTION
I want to be able to sort a `Vec` of types which contain `TypeId`s, so an `Ord` derivation would be very useful to me. `Hash` and `PartialEq`/`Eq` already exist, so the missing `PartialOrd` and `Ord` derivations feel like an oversight to me.