### PR TITLE
expect_err for Result.

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -798,6 +798,31 @@ impl<T: fmt::Debug, E> Result<T, E> {
             Err(e) => e,
         }
     }
+
+    /// Unwraps a result, yielding the content of an `Err`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is an `Ok`, with a panic message including the
+    /// passed message, and the content of the `Ok`.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```{.should_panic}
+    /// # #![feature(result_expect_err)]
+    /// let x: Result<u32, &str> = Ok(10);
+    /// x.expect_err("Testing expect_err"); // panics with `Testing expect_err: 10`
+    /// ```
+    #[inline]
+    #[unstable(feature = "result_expect_err", issue = "39041")]
+    pub fn expect_err(self, msg: &str) -> E {
+        match self {
+            Ok(t) => unwrap_failed(msg, t),
+            Err(e) => e,
+        }
+    }
 }
 
 impl<T: Default, E> Result<T, E> {

--- a/src/libcoretest/lib.rs
+++ b/src/libcoretest/lib.rs
@@ -23,6 +23,7 @@
 #![feature(nonzero)]
 #![feature(rand)]
 #![feature(raw)]
+#![feature(result_expect_err)]
 #![feature(sip_hash_13)]
 #![feature(slice_patterns)]
 #![feature(step_by)]

--- a/src/libcoretest/result.rs
+++ b/src/libcoretest/result.rs
@@ -151,6 +151,19 @@ pub fn test_expect_err() {
     err.expect("Got expected error");
 }
 
+
+#[test]
+pub fn test_expect_err_err() {
+    let ok: Result<&'static str, isize> = Err(100);
+    assert_eq!(ok.expect_err("Unexpected ok"), 100);
+}
+#[test]
+#[should_panic(expected="Got expected ok: \"All good\"")]
+pub fn test_expect_err_ok() {
+    let err: Result<&'static str, isize> = Ok("All good");
+    err.expect_err("Got expected ok");
+}
+
 #[test]
 pub fn test_iter() {
     let ok: Result<isize, &'static str> = Ok(100);


### PR DESCRIPTION
This adds an `expect_err` method to `Result`. Considering how `unwrap_err` already exists, this seems to make sense. Inconsistency noted in Manishearth/rust-clippy#1435.