### PR TITLE
rustbuild: Don't enable debuginfo in rustc

### DIFF
--- a/configure
+++ b/configure
@@ -647,6 +647,7 @@ opt_nosave debug-assertions 0 "build with debugging assertions"
 opt_nosave llvm-release-debuginfo 0 "build LLVM with debugger metadata"
 opt_nosave debuginfo 0 "build with debugger metadata"
 opt_nosave debuginfo-lines 0 "build with line number debugger metadata"
+opt_nosave debuginfo-only-std 0 "build only libstd with debugging information"
 opt_nosave debug-jemalloc 0 "build jemalloc with --enable-debug --enable-fill"
 
 valopt localstatedir "/var/lib" "local state directory"
@@ -733,15 +734,17 @@ case "$CFG_RELEASE_CHANNEL" in
     nightly )
 	msg "overriding settings for $CFG_RELEASE_CHANNEL"
 	CFG_ENABLE_LLVM_ASSERTIONS=1
-
-        # FIXME(#37364) shouldn't have to disable this on windows-gnu
+        # FIXME(stage0) re-enable this on the next stage0 now that #35566 is
+        # fixed
         case "$CFG_BUILD" in
           *-pc-windows-gnu)
             ;;
           *)
-	    CFG_ENABLE_DEBUGINFO_LINES=1
+            CFG_ENABLE_DEBUGINFO_LINES=1
+            CFG_ENABLE_DEBUGINFO_ONLY_STD=1
             ;;
         esac
+
 	;;
     beta | stable)
 	msg "overriding settings for $CFG_RELEASE_CHANNEL"
@@ -749,7 +752,8 @@ case "$CFG_RELEASE_CHANNEL" in
           *-pc-windows-gnu)
             ;;
           *)
-	    CFG_ENABLE_DEBUGINFO_LINES=1
+            CFG_ENABLE_DEBUGINFO_LINES=1
+            CFG_ENABLE_DEBUGINFO_ONLY_STD=1
             ;;
         esac
 	;;
@@ -785,6 +789,7 @@ if [ -n "$CFG_ENABLE_DEBUG_ASSERTIONS" ]; then putvar CFG_ENABLE_DEBUG_ASSERTION
 if [ -n "$CFG_ENABLE_LLVM_RELEASE_DEBUGINFO" ]; then putvar CFG_ENABLE_LLVM_RELEASE_DEBUGINFO; fi
 if [ -n "$CFG_ENABLE_DEBUGINFO" ]; then putvar CFG_ENABLE_DEBUGINFO; fi
 if [ -n "$CFG_ENABLE_DEBUGINFO_LINES" ]; then putvar CFG_ENABLE_DEBUGINFO_LINES; fi
+if [ -n "$CFG_ENABLE_DEBUGINFO_ONLY_STD" ]; then putvar CFG_ENABLE_DEBUGINFO_ONLY_STD; fi
 if [ -n "$CFG_ENABLE_DEBUG_JEMALLOC" ]; then putvar CFG_ENABLE_DEBUG_JEMALLOC; fi
 
 step_msg "looking for build programs"

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -189,6 +189,13 @@ pub fn rustc(build: &Build, target: &str, compiler: &Compiler) {
          .env("CFG_PREFIX", build.config.prefix.clone().unwrap_or(String::new()))
          .env("CFG_LIBDIR_RELATIVE", "lib");
 
+    // If we're not building a compiler with debugging information then remove
+    // these two env vars which would be set otherwise.
+    if build.config.rust_debuginfo_only_std {
+        cargo.env_remove("RUSTC_DEBUGINFO");
+        cargo.env_remove("RUSTC_DEBUGINFO_LINES");
+    }
+
     if let Some(ref ver_date) = build.ver_date {
         cargo.env("CFG_VER_DATE", ver_date);
     }

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -63,6 +63,7 @@ pub struct Config {
     pub rust_debug_assertions: bool,
     pub rust_debuginfo: bool,
     pub rust_debuginfo_lines: bool,
+    pub rust_debuginfo_only_std: bool,
     pub rust_rpath: bool,
     pub rustc_default_linker: Option<String>,
     pub rustc_default_ar: Option<String>,
@@ -179,6 +180,7 @@ struct Rust {
     debug_assertions: Option<bool>,
     debuginfo: Option<bool>,
     debuginfo_lines: Option<bool>,
+    debuginfo_only_std: Option<bool>,
     debug_jemalloc: Option<bool>,
     use_jemalloc: Option<bool>,
     backtrace: Option<bool>,
@@ -298,6 +300,7 @@ impl Config {
             set(&mut config.rust_debug_assertions, rust.debug_assertions);
             set(&mut config.rust_debuginfo, rust.debuginfo);
             set(&mut config.rust_debuginfo_lines, rust.debuginfo_lines);
+            set(&mut config.rust_debuginfo_only_std, rust.debuginfo_only_std);
             set(&mut config.rust_optimize, rust.optimize);
             set(&mut config.rust_optimize_tests, rust.optimize_tests);
             set(&mut config.rust_debuginfo_tests, rust.debuginfo_tests);
@@ -390,6 +393,7 @@ impl Config {
                 ("DEBUG_ASSERTIONS", self.rust_debug_assertions),
                 ("DEBUGINFO", self.rust_debuginfo),
                 ("DEBUGINFO_LINES", self.rust_debuginfo_lines),
+                ("DEBUGINFO_ONLY_STD", self.rust_debuginfo_only_std),
                 ("JEMALLOC", self.use_jemalloc),
                 ("DEBUG_JEMALLOC", self.debug_jemalloc),
                 ("RPATH", self.rust_rpath),

--- a/src/bootstrap/config.toml.example
+++ b/src/bootstrap/config.toml.example
@@ -149,6 +149,11 @@
 # Whether or not line number debug information is emitted
 #debuginfo-lines = false
 
+# Whether or not to only build debuginfo for the standard library if enabled.
+# If enabled, this will not compile the compiler with debuginfo, just the
+# standard library.
+#debuginfo-only-std = false
+
 # Whether or not jemalloc is built and enabled
 #use-jemalloc = true
 


### PR DESCRIPTION
In #37280 we enabled line number debugging information in release artifacts,
primarily to close out #36452 where debugging information was critical for MSVC
builds of Rust to be useful in production. This commit, however, apparently had
some unfortunate side effects.

Namely it was noticed in #37477 that if `RUST_BACKTRACE=1` was set then any
compiler error would take a very long time for the compiler to exit. The cause
of the problem here was somewhat deep:

* For all compiler errors, the compiler will `panic!` with a known value. This
  tears down the main compiler thread and allows cleaning up all the various
  resources. By default, however, this panic output is suppressed for "normal"
  compiler errors.
* When `RUST_BACKTRACE=1` was set this caused every compiler error to generate a
  backtrace.
* The libbacktrace library hits a pathological case where it spends a very long
  time in its custom allocation function, `backtrace_alloc`, because the
  compiler has so much debugging information. More information about this can be
  found in #29293 with a summary at the end of #37477.

To solve this problem this commit simply removes debuginfo from the compiler but
not from the standard library. This should allow us to keep #36452 closed while
also closing #37477. I've measured the difference to be orders of magnitude
faster than it was before, so we should see a much quicker time-to-exit after a
compile error when `RUST_BACKTRACE=1` is set.

Closes #37477
Closes #37571