### PR TITLE
From<&T> for T.

### DIFF
--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -278,6 +278,12 @@ impl<T> From<T> for T {
     fn from(t: T) -> T { t }
 }
 
+// From accepts clonable references as well
+#[stable(feature = "convert_from_ref", since = "1.17.0")]
+impl<'a, T: Clone + 'a> From<&'a T> for T {
+    fn from(t: &'a T) -> T { t.clone() }
+}
+
 
 // TryFrom implies TryInto
 #[unstable(feature = "try_from", issue = "33417")]


### PR DESCRIPTION
I originally posted this in rust-lang/rfcs#1799. This is definitely a breaking change, and a crater run would be necessary. More discussion on why this would be useful is listed in the original thread.

Note that this would only work if `T: Clone`.