### PR TITLE
only consider value items when searching for methods, not types

### DIFF
--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -1261,10 +1261,17 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
     ///////////////////////////////////////////////////////////////////////////
     // MISCELLANY
     fn has_applicable_self(&self, item: &ty::AssociatedItem) -> bool {
-        // "fast track" -- check for usage of sugar
+        // "Fast track" -- check for usage of sugar when in method call
+        // mode.
+        //
+        // In Path mode (i.e., resolving a value like `T::next`), consider any
+        // associated value (i.e., methods, constants) but not types.
         match self.mode {
             Mode::MethodCall => item.method_has_self_argument,
-            Mode::Path => true
+            Mode::Path => match item.kind {
+                ty::AssociatedKind::Type => false,
+                ty::AssociatedKind::Method | ty::AssociatedKind::Const => true
+            },
         }
         // FIXME -- check for types that deref to `Self`,
         // like `Rc<Self>` and so on.

--- a/src/libsyntax/json.rs
+++ b/src/libsyntax/json.rs
@@ -296,7 +296,7 @@ impl DiagnosticSpanLine {
                          h_end: usize)
                          -> DiagnosticSpanLine {
         DiagnosticSpanLine {
-            text: fm.get_line(index).unwrap().to_owned(),
+            text: fm.get_line(index).unwrap_or("").to_owned(),
             highlight_start: h_start,
             highlight_end: h_end,
         }

--- a/src/test/compile-fail/issue-38919.rs
+++ b/src/test/compile-fail/issue-38919.rs
@@ -1,0 +1,15 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn foo<T: Iterator>() {
+    T::Item; //~ ERROR no associated item named `Item` found for type `T`
+}
+
+fn main() { }

--- a/src/test/compile-fail/issue-38919.rs
+++ b/src/test/compile-fail/issue-38919.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 fn foo<T: Iterator>() {
-    T::Item; //~ ERROR no associated item named `Item` found for type `T`
+    T::Item; //~ ERROR no associated item named `Item` found for type `T` in the current scope
 }
 
 fn main() { }


### PR DESCRIPTION
Fixes #38919 

r? @eddyb 