### PR TITLE
Specialize methods on iter::Cloned<I> where I::Item: Copy.

### DIFF
--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -422,6 +422,23 @@ impl<'a, I, T: 'a> Iterator for Cloned<I>
     }
 }
 
+#[stable(feature = "iter_cloned_copy", since = "1.13.0")]
+impl<'a, I, T: 'a> Iterator for Cloned<I>
+    where I: Iterator<Item=&'a T>, T: Copy
+{
+    fn nth(&mut self, n: usize) -> Option<T> {
+        self.it.nth(n).cloned()
+    }
+
+    fn last(self) -> Option<T> {
+        self.it.last().cloned()
+    }
+
+    fn count(self) -> usize {
+        self.it.count()
+    }
+}
+
 #[stable(feature = "iter_cloned", since = "1.1.0")]
 impl<'a, I, T: 'a> DoubleEndedIterator for Cloned<I>
     where I: DoubleEndedIterator<Item=&'a T>, T: Clone


### PR DESCRIPTION
Instead of cloning a bunch of copyable types only to drop them (in `nth`, `last`, and `count`), take advantage of [RFC 1521](https://github.com/rust-lang/rfcs/blob/master/text/1521-copy-clone-semantics.md) (Copy clone semantics) and don't bother cloning them in the first place (directly call `nth`, `last`, and `count` on the wrapped iterator). If the wrapped iterator optimizes these methods, `Cloned` now inherits this optimization.

This is a retry of #36791. It was blocked waiting for fixes for #36053 and #36848 to make it into a beta snapshot.