### PR TITLE
Remove allocation in impl Display for path::Display #38879

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -250,6 +250,7 @@
 #![feature(const_fn)]
 #![feature(core_float)]
 #![feature(core_intrinsics)]
+#![feature(decode_utf8)]
 #![feature(dropck_eyepatch)]
 #![feature(exact_size_is_empty)]
 #![feature(float_extras)]


### PR DESCRIPTION
Fixes #38879 

I wasn't too sure about testing this, but I threw in a test for checking that the non-unicode sequences were converted to `'\u{fffd}'`