### PR TITLE
[libcollections] [doc] Fix typo in documentation

### DIFF
--- a/src/doc/book/ffi.md
+++ b/src/doc/book/ffi.md
@@ -309,7 +309,7 @@ However it is often desired that the callback is targeted to a special
 Rust object. This could be the object that represents the wrapper for the
 respective C object.
 
-This can be achieved by passing an raw pointer to the object down to the
+This can be achieved by passing a raw pointer to the object down to the
 C library. The C library can then include the pointer to the Rust object in
 the notification. This will allow the callback to unsafely access the
 referenced Rust object.

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -423,7 +423,7 @@ impl<T> [T] {
         core_slice::SliceExt::get_unchecked_mut(self, index)
     }
 
-    /// Returns an raw pointer to the slice's buffer.
+    /// Returns a raw pointer to the slice's buffer.
     ///
     /// The caller must ensure that the slice outlives the pointer this
     /// function returns, or else it will end up pointing to garbage.


### PR DESCRIPTION
Replace two instances of `an raw` with `a raw` in documentation blocks.