### PR TITLE
Remove strictly-unnecessary flags for docker

### DIFF
--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -48,7 +48,5 @@ exec docker \
   --env CARGO_HOME=/cargo \
   --env LOCAL_USER_ID=`id -u` \
   --volume "$HOME/.cargo:/cargo" \
-  --interactive \
-  --tty \
   rust-ci \
   /checkout/src/ci/run.sh


### PR DESCRIPTION
cc #39035

In addition to `--tty` I've removed `--interactive` as I don't think there's any reason for it to be there (it only hooks up stdin, which shouldn't be used anyway).

If this looks like it's working over a few days then I'll also alter the libc scripts.

r? @alexcrichton 