### PR TITLE
travis: Expand dist builder coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,14 @@ matrix:
     # Linux builders, all docker images
     - env: IMAGE=arm-android DEPLOY=1
     - env: IMAGE=cross DEPLOY=1
-    - env: IMAGE=dist-arm-unknown-linux-gnueabi DEPLOY=1
-    - env: IMAGE=dist-x86_64-unknown-freebsd DEPLOY=1
+    - env: IMAGE=dist-arm-linux DEPLOY=1
+    - env: IMAGE=dist-armv7-aarch64-linux DEPLOY=1
+    - env: IMAGE=dist-freebsd DEPLOY=1
+    - env: IMAGE=dist-mips-linux DEPLOY=1
+    - env: IMAGE=dist-mips64-linux DEPLOY=1
+    - env: IMAGE=dist-powerpc-linux DEPLOY=1
+    - env: IMAGE=dist-powerpc64-linux DEPLOY=1
+    - env: IMAGE=dist-s390x-linux-netbsd DEPLOY=1
     - env: IMAGE=i686-gnu DEPLOY=1
     - env: IMAGE=i686-gnu-nopt
     - env: IMAGE=x86_64-gnu DEPLOY=1

--- a/src/ci/docker/arm-android/Dockerfile
+++ b/src/ci/docker/arm-android/Dockerfile
@@ -53,4 +53,8 @@ ENV RUST_CONFIGURE_ARGS \
 # to all the targets above eventually.
 ENV SCRIPT \
   python2.7 ../x.py test --target arm-linux-androideabi && \
-  python2.7 ../x.py dist --target arm-linux-androideabi
+  python2.7 ../x.py dist \
+      --target arm-linux-androideabi \
+      --target armv7-linux-androideabi \
+      --target i686-linux-android \
+      --target aarch64-linux-android

--- a/src/ci/docker/dist-arm-linux/Dockerfile
+++ b/src/ci/docker/dist-arm-linux/Dockerfile
@@ -10,7 +10,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   git \
   cmake \
   sudo \
-  xz-utils
+  gdb \
+  xz-utils \
+  g++-arm-linux-gnueabi \
+  g++-arm-linux-gnueabihf
 
 ENV SCCACHE_DIGEST=7237e38e029342fa27b7ac25412cb9d52554008b12389727320bd533fd7f05b6a96d55485f305caf95e5c8f5f97c3313e10012ccad3e752aba2518f3522ba783
 RUN curl -L https://api.pub.build.mozilla.org/tooltool/sha512/$SCCACHE_DIGEST | \
@@ -21,21 +24,11 @@ RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-ini
     rm dumb-init_*.deb
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
-ENV TARGETS=asmjs-unknown-emscripten
-ENV TARGETS=$TARGETS,wasm32-unknown-emscripten
-
-#ENV TARGETS=$TARGETS,mips-unknown-linux-musl
-#ENV TARGETS=$TARGETS,arm-unknown-linux-musleabi
-#ENV TARGETS=$TARGETS,arm-unknown-linux-musleabihf
-#ENV TARGETS=$TARGETS,armv7-unknown-linux-musleabihf
-#ENV TARGETS=$TARGETS,x86_64-rumprun-netbsd
-
 ENV RUST_CONFIGURE_ARGS \
-      --target=$TARGETS \
-      --enable-rustbuild
-
-# Just a smoke test in dist to see if this works for now, we should expand this
-# to all the targets above eventually.
+      --host=arm-unknown-linux-gnueabi,arm-unknown-linux-gnueabihf
 ENV SCRIPT \
-  python2.7 ../x.py build && \
-  python2.7 ../x.py dist --target wasm32-unknown-emscripten
+      python2.7 ../x.py dist \
+        --host arm-unknown-linux-gnueabi \
+        --target arm-unknown-linux-gnueabi \
+        --host arm-unknown-linux-gnueabihf \
+        --target arm-unknown-linux-gnueabihf

--- a/src/ci/docker/dist-armv7-aarch64-linux/Dockerfile
+++ b/src/ci/docker/dist-armv7-aarch64-linux/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   sudo \
   gdb \
   xz-utils \
-  g++-arm-linux-gnueabi
+  g++-arm-linux-gnueabihf \
+  g++-aarch64-linux-gnu
 
 ENV SCCACHE_DIGEST=7237e38e029342fa27b7ac25412cb9d52554008b12389727320bd533fd7f05b6a96d55485f305caf95e5c8f5f97c3313e10012ccad3e752aba2518f3522ba783
 RUN curl -L https://api.pub.build.mozilla.org/tooltool/sha512/$SCCACHE_DIGEST | \
@@ -23,8 +24,11 @@ RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-ini
     rm dumb-init_*.deb
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
-ENV RUST_CONFIGURE_ARGS --host=arm-unknown-linux-gnueabi
+ENV RUST_CONFIGURE_ARGS \
+      --host=armv7-unknown-linux-gnueabihf,aarch64-unknown-linux-gnu
 ENV SCRIPT \
       python2.7 ../x.py dist \
-        --host arm-unknown-linux-gnueabi \
-        --target arm-unknown-linux-gnueabi
+        --host armv7-unknown-linux-gnueabihf \
+        --target armv7-unknown-linux-gnueabihf \
+        --host aarch64-unknown-linux-gnu \
+        --target aarch64-unknown-linux-gnu

--- a/src/ci/docker/dist-freebsd/Dockerfile
+++ b/src/ci/docker/dist-freebsd/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  g++ \
+  make \
+  file \
+  curl \
+  ca-certificates \
+  python2.7 \
+  git \
+  cmake \
+  sudo \
+  bzip2 \
+  xz-utils \
+  wget
+
+COPY build-toolchain.sh /tmp/
+RUN /tmp/build-toolchain.sh x86_64
+RUN /tmp/build-toolchain.sh i686
+
+RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
+    dpkg -i dumb-init_*.deb && \
+    rm dumb-init_*.deb
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
+ENV SCCACHE_DIGEST=7237e38e029342fa27b7ac25412cb9d52554008b12389727320bd533fd7f05b6a96d55485f305caf95e5c8f5f97c3313e10012ccad3e752aba2518f3522ba783
+RUN curl -L https://api.pub.build.mozilla.org/tooltool/sha512/$SCCACHE_DIGEST | \
+      tar xJf - -C /usr/local/bin --strip-components=1
+
+ENV \
+    AR_x86_64_unknown_freebsd=x86_64-unknown-freebsd10-ar \
+    CC_x86_64_unknown_freebsd=x86_64-unknown-freebsd10-gcc \
+    CXX_x86_64_unknown_freebsd=x86_64-unknown-freebsd10-g++ \
+    AR_i686_unknown_freebsd=i686-unknown-freebsd10-ar \
+    CC_i686_unknown_freebsd=i686-unknown-freebsd10-gcc \
+    CXX_i686_unknown_freebsd=i686-unknown-freebsd10-g++
+
+ENV RUST_CONFIGURE_ARGS \
+        --host=x86_64-unknown-freebsd,i686-unknown-freebsd
+ENV SCRIPT \
+      python2.7 ../x.py dist \
+        --host x86_64-unknown-freebsd \
+        --target x86_64-unknown-freebsd \
+        --host i686-unknown-freebsd \
+        --target i686-unknown-freebsd

--- a/src/ci/docker/dist-mips-linux/Dockerfile
+++ b/src/ci/docker/dist-mips-linux/Dockerfile
@@ -10,7 +10,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   git \
   cmake \
   sudo \
-  xz-utils
+  gdb \
+  xz-utils \
+  g++-mips-linux-gnu \
+  g++-mipsel-linux-gnu
 
 ENV SCCACHE_DIGEST=7237e38e029342fa27b7ac25412cb9d52554008b12389727320bd533fd7f05b6a96d55485f305caf95e5c8f5f97c3313e10012ccad3e752aba2518f3522ba783
 RUN curl -L https://api.pub.build.mozilla.org/tooltool/sha512/$SCCACHE_DIGEST | \
@@ -21,21 +24,11 @@ RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-ini
     rm dumb-init_*.deb
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
-ENV TARGETS=asmjs-unknown-emscripten
-ENV TARGETS=$TARGETS,wasm32-unknown-emscripten
-
-#ENV TARGETS=$TARGETS,mips-unknown-linux-musl
-#ENV TARGETS=$TARGETS,arm-unknown-linux-musleabi
-#ENV TARGETS=$TARGETS,arm-unknown-linux-musleabihf
-#ENV TARGETS=$TARGETS,armv7-unknown-linux-musleabihf
-#ENV TARGETS=$TARGETS,x86_64-rumprun-netbsd
-
 ENV RUST_CONFIGURE_ARGS \
-      --target=$TARGETS \
-      --enable-rustbuild
-
-# Just a smoke test in dist to see if this works for now, we should expand this
-# to all the targets above eventually.
+      --host=mips-unknown-linux-gnu,mipsel-unknown-linux-gnu
 ENV SCRIPT \
-  python2.7 ../x.py build && \
-  python2.7 ../x.py dist --target wasm32-unknown-emscripten
+      python2.7 ../x.py dist \
+        --host mips-unknown-linux-gnu \
+        --target mips-unknown-linux-gnu \
+        --host mipsel-unknown-linux-gnu \
+        --target mipsel-unknown-linux-gnu

--- a/src/ci/docker/dist-mips64-linux/Dockerfile
+++ b/src/ci/docker/dist-mips64-linux/Dockerfile
@@ -10,7 +10,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   git \
   cmake \
   sudo \
-  xz-utils
+  gdb \
+  xz-utils \
+  g++-mips64-linux-gnuabi64 \
+  g++-mips64el-linux-gnuabi64
 
 ENV SCCACHE_DIGEST=7237e38e029342fa27b7ac25412cb9d52554008b12389727320bd533fd7f05b6a96d55485f305caf95e5c8f5f97c3313e10012ccad3e752aba2518f3522ba783
 RUN curl -L https://api.pub.build.mozilla.org/tooltool/sha512/$SCCACHE_DIGEST | \
@@ -21,21 +24,11 @@ RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-ini
     rm dumb-init_*.deb
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
-ENV TARGETS=asmjs-unknown-emscripten
-ENV TARGETS=$TARGETS,wasm32-unknown-emscripten
-
-#ENV TARGETS=$TARGETS,mips-unknown-linux-musl
-#ENV TARGETS=$TARGETS,arm-unknown-linux-musleabi
-#ENV TARGETS=$TARGETS,arm-unknown-linux-musleabihf
-#ENV TARGETS=$TARGETS,armv7-unknown-linux-musleabihf
-#ENV TARGETS=$TARGETS,x86_64-rumprun-netbsd
-
 ENV RUST_CONFIGURE_ARGS \
-      --target=$TARGETS \
-      --enable-rustbuild
-
-# Just a smoke test in dist to see if this works for now, we should expand this
-# to all the targets above eventually.
+      --host=mips64-unknown-linux-gnuabi64,mips64el-unknown-linux-gnuabi64
 ENV SCRIPT \
-  python2.7 ../x.py build && \
-  python2.7 ../x.py dist --target wasm32-unknown-emscripten
+      python2.7 ../x.py dist \
+        --host mips64-unknown-linux-gnuabi64 \
+        --target mips64-unknown-linux-gnuabi64 \
+        --host mips64el-unknown-linux-gnuabi64 \
+        --target mips64el-unknown-linux-gnuabi64

--- a/src/ci/docker/dist-powerpc-linux/Dockerfile
+++ b/src/ci/docker/dist-powerpc-linux/Dockerfile
@@ -10,7 +10,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   git \
   cmake \
   sudo \
-  xz-utils
+  gdb \
+  xz-utils \
+  g++-powerpc-linux-gnu
 
 ENV SCCACHE_DIGEST=7237e38e029342fa27b7ac25412cb9d52554008b12389727320bd533fd7f05b6a96d55485f305caf95e5c8f5f97c3313e10012ccad3e752aba2518f3522ba783
 RUN curl -L https://api.pub.build.mozilla.org/tooltool/sha512/$SCCACHE_DIGEST | \
@@ -21,21 +23,13 @@ RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-ini
     rm dumb-init_*.deb
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
-ENV TARGETS=asmjs-unknown-emscripten
-ENV TARGETS=$TARGETS,wasm32-unknown-emscripten
-
-#ENV TARGETS=$TARGETS,mips-unknown-linux-musl
-#ENV TARGETS=$TARGETS,arm-unknown-linux-musleabi
-#ENV TARGETS=$TARGETS,arm-unknown-linux-musleabihf
-#ENV TARGETS=$TARGETS,armv7-unknown-linux-musleabihf
-#ENV TARGETS=$TARGETS,x86_64-rumprun-netbsd
-
 ENV RUST_CONFIGURE_ARGS \
-      --target=$TARGETS \
-      --enable-rustbuild
-
-# Just a smoke test in dist to see if this works for now, we should expand this
-# to all the targets above eventually.
+      --host=powerpc-unknown-linux-gnu
 ENV SCRIPT \
-  python2.7 ../x.py build && \
-  python2.7 ../x.py dist --target wasm32-unknown-emscripten
+      python2.7 ../x.py dist \
+        --host powerpc-unknown-linux-gnu \
+        --target powerpc-unknown-linux-gnu
+
+# FIXME(#36150) this will fail the bootstrap. Probably means something bad is
+#               happening!
+ENV NO_LLVM_ASSERTIONS 1

--- a/src/ci/docker/dist-powerpc64-linux/Dockerfile
+++ b/src/ci/docker/dist-powerpc64-linux/Dockerfile
@@ -10,7 +10,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   git \
   cmake \
   sudo \
-  xz-utils
+  gdb \
+  xz-utils \
+  g++-powerpc64-linux-gnu \
+  g++-powerpc64le-linux-gnu
 
 ENV SCCACHE_DIGEST=7237e38e029342fa27b7ac25412cb9d52554008b12389727320bd533fd7f05b6a96d55485f305caf95e5c8f5f97c3313e10012ccad3e752aba2518f3522ba783
 RUN curl -L https://api.pub.build.mozilla.org/tooltool/sha512/$SCCACHE_DIGEST | \
@@ -21,21 +24,16 @@ RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-ini
     rm dumb-init_*.deb
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
-ENV TARGETS=asmjs-unknown-emscripten
-ENV TARGETS=$TARGETS,wasm32-unknown-emscripten
-
-#ENV TARGETS=$TARGETS,mips-unknown-linux-musl
-#ENV TARGETS=$TARGETS,arm-unknown-linux-musleabi
-#ENV TARGETS=$TARGETS,arm-unknown-linux-musleabihf
-#ENV TARGETS=$TARGETS,armv7-unknown-linux-musleabihf
-#ENV TARGETS=$TARGETS,x86_64-rumprun-netbsd
+ENV \
+    AR_powerpc64_unknown_linux_gnu=powerpc64-linux-gnu-ar \
+    CC_powerpc64_unknown_linux_gnu=powerpc64-linux-gnu-gcc \
+    CXX_powerpc64_unknown_linux_gnu=powerpc64-linux-gnu-g++
 
 ENV RUST_CONFIGURE_ARGS \
-      --target=$TARGETS \
-      --enable-rustbuild
-
-# Just a smoke test in dist to see if this works for now, we should expand this
-# to all the targets above eventually.
+      --host=powerpc64-unknown-linux-gnu,powerpc64le-unknown-linux-gnu
 ENV SCRIPT \
-  python2.7 ../x.py build && \
-  python2.7 ../x.py dist --target wasm32-unknown-emscripten
+      python2.7 ../x.py dist \
+        --host powerpc64-unknown-linux-gnu \
+        --target powerpc64-unknown-linux-gnu \
+        --host powerpc64le-unknown-linux-gnu \
+        --target powerpc64le-unknown-linux-gnu

--- a/src/ci/docker/dist-s390x-linux-netbsd/Dockerfile
+++ b/src/ci/docker/dist-s390x-linux-netbsd/Dockerfile
@@ -12,7 +12,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   sudo \
   bzip2 \
   xz-utils \
-  wget
+  wget \
+  patch \
+  g++-s390x-linux-gnu
 
 COPY build-toolchain.sh /tmp/
 RUN sh /tmp/build-toolchain.sh
@@ -27,12 +29,15 @@ RUN curl -L https://api.pub.build.mozilla.org/tooltool/sha512/$SCCACHE_DIGEST | 
       tar xJf - -C /usr/local/bin --strip-components=1
 
 ENV \
-    AR_x86_64_unknown_freebsd=x86_64-unknown-freebsd10-ar \
-    CC_x86_64_unknown_freebsd=x86_64-unknown-freebsd10-gcc \
-    CXX_x86_64_unknown_freebsd=x86_64-unknown-freebsd10-g++
+    AR_x86_64_unknown_netbsd=x86_64-unknown-netbsd-ar \
+    CC_x86_64_unknown_netbsd=x86_64-unknown-netbsd-gcc \
+    CXX_x86_64_unknown_netbsd=x86_64-unknown-netbsd-g++
 
-ENV RUST_CONFIGURE_ARGS --host=x86_64-unknown-freebsd
+ENV RUST_CONFIGURE_ARGS \
+        --host=x86_64-unknown-netbsd,s390x-unknown-linux-gnu
 ENV SCRIPT \
       python2.7 ../x.py dist \
-        --host x86_64-unknown-freebsd \
-        --target x86_64-unknown-freebsd
+        --host x86_64-unknown-netbsd \
+        --target x86_64-unknown-netbsd \
+        --host s390x-unknown-linux-gnu \
+        --target s390x-unknown-linux-gnu

--- a/src/ci/docker/dist-s390x-linux-netbsd/build-toolchain.sh
+++ b/src/ci/docker/dist-s390x-linux-netbsd/build-toolchain.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+# ignore-tidy-linelength
+
+set -ex
+
+BINUTILS=2.25.1
+GCC=5.3.0
+
+# First up, build binutils
+mkdir binutils
+cd binutils
+curl https://ftp.gnu.org/gnu/binutils/binutils-$BINUTILS.tar.bz2 | tar xjf -
+mkdir binutils-build
+cd binutils-build
+../binutils-$BINUTILS/configure \
+  --target=x86_64-unknown-netbsd
+make -j10
+make install
+cd ../..
+rm -rf binutils
+
+# Next, download the NetBSD libc and relevant header files
+mkdir netbsd
+curl https://ftp.netbsd.org/pub/NetBSD/NetBSD-7.0/amd64/binary/sets/base.tgz | \
+  tar xzf - -C netbsd ./usr/include ./usr/lib ./lib
+curl https://ftp.netbsd.org/pub/NetBSD/NetBSD-7.0/amd64/binary/sets/comp.tgz | \
+  tar xzf - -C netbsd ./usr/include ./usr/lib
+
+dst=/usr/local/x86_64-unknown-netbsd
+cp -r netbsd/usr/include $dst
+cp netbsd/usr/lib/crt0.o $dst/lib
+cp netbsd/usr/lib/crti.o $dst/lib
+cp netbsd/usr/lib/crtn.o $dst/lib
+cp netbsd/usr/lib/crtbeginS.o $dst/lib
+cp netbsd/usr/lib/crtendS.o $dst/lib
+cp netbsd/usr/lib/crtbegin.o $dst/lib
+cp netbsd/usr/lib/crtend.o $dst/lib
+cp netbsd/usr/lib/gcrt0.o $dst/lib
+cp netbsd/usr/lib/libc.a $dst/lib
+cp netbsd/usr/lib/libc_p.a $dst/lib
+cp netbsd/usr/lib/libc_pic.a $dst/lib
+cp netbsd/lib/libc.so.12.193.1 $dst/lib
+cp netbsd/lib/libutil.so.7.21 $dst/lib
+cp netbsd/usr/lib/libm.a $dst/lib
+cp netbsd/usr/lib/libm_p.a $dst/lib
+cp netbsd/usr/lib/libm_pic.a $dst/lib
+cp netbsd/lib/libm.so.0.11 $dst/lib
+cp netbsd/usr/lib/librt.so.1.1 $dst/lib
+cp netbsd/usr/lib/libpthread.a $dst/lib
+cp netbsd/usr/lib/libpthread_p.a $dst/lib
+cp netbsd/usr/lib/libpthread_pic.a $dst/lib
+cp netbsd/usr/lib/libpthread.so.1.2 $dst/lib
+
+ln -s libc.so.12.193.1 $dst/lib/libc.so
+ln -s libc.so.12.193.1 $dst/lib/libc.so.12
+ln -s libm.so.0.11 $dst/lib/libm.so
+ln -s libm.so.0.11 $dst/lib/libm.so.0
+ln -s libutil.so.7.21 $dst/lib/libutil.so
+ln -s libutil.so.7.21 $dst/lib/libutil.so.7
+ln -s libpthread.so.1.2 $dst/lib/libpthread.so
+ln -s libpthread.so.1.2 $dst/lib/libpthread.so.1
+ln -s librt.so.1.1 $dst/lib/librt.so
+
+rm -rf netbsd
+
+# Finally, download and build gcc to target NetBSD
+mkdir gcc
+cd gcc
+curl https://ftp.gnu.org/gnu/gcc/gcc-$GCC/gcc-$GCC.tar.bz2 | tar xjf -
+cd gcc-$GCC
+./contrib/download_prerequisites
+
+# Originally from
+# ftp://ftp.netbsd.org/pub/pkgsrc/pkgsrc-2016Q4/pkgsrc/lang/gcc5/patches/patch-libstdc%2B%2B-v3_config_os_bsd_netbsd_ctype__base.h
+PATCHES="https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-01-13-netbsd-patch1.patch"
+
+# Originally from
+# ftp://ftp.netbsd.org/pub/pkgsrc/pkgsrc-2016Q4/pkgsrc/lang/gcc5/patches/patch-libstdc%2B%2B-v3_config_os_bsd_netbsd_ctype__configure__char.cc
+PATCHES="$PATCHES https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/2017-01-13-netbsd-patch2.patch"
+
+for patch in $PATCHES; do
+  curl $patch | patch -Np0
+done
+
+mkdir ../gcc-build
+cd ../gcc-build
+../gcc-$GCC/configure                            \
+  --enable-languages=c,c++                       \
+  --target=x86_64-unknown-netbsd                 \
+  --disable-libcilkrts                           \
+  --disable-multilib                             \
+  --disable-nls                                  \
+  --disable-libgomp                              \
+  --disable-libquadmath                          \
+  --disable-libssp                               \
+  --disable-libvtv                               \
+  --disable-libcilkrt                            \
+  --disable-libada                               \
+  --disable-libsanitizer                         \
+  --disable-libquadmath-support                  \
+  --disable-lto
+make -j10
+make install
+
+cd ../..
+rm -rf gcc

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -25,8 +25,10 @@ docker \
   -t rust-ci \
   "`dirname "$script"`/$image"
 
+objdir=$root_dir/obj
+
 mkdir -p $HOME/.cargo
-mkdir -p $root_dir/obj
+mkdir -p $objdir
 
 args=
 if [ "$SCCACHE_BUCKET" != "" ]; then
@@ -41,7 +43,7 @@ fi
 exec docker \
   run \
   --volume "$root_dir:/checkout:ro" \
-  --volume "$root_dir/obj:/checkout/obj" \
+  --volume "$objdir:/checkout/obj" \
   --workdir /checkout/obj \
   --env SRC=/checkout \
   $args \


### PR DESCRIPTION
This commit adds six new travis matrix entires for doing cross-compiled
distribution builds of the compiler. The support added in #38731 allows us to
quickly compile a complete suite of distribution artifacts for cross-compiled
platforms, and currently each matrix entry (when fully cached) clocks in around
an hour to finish. Note that a full test run typically takes about two hours
right now.

With further optimizations coming down the pike in #39026 this commit also
starts doubling up cross-compiled distribution builders on each matrix entry. We
initially planned to do one build per entry, but it's looking like we may be
able to get by with more than one in each entry. Depending on how long these
builds take we may even be able to up it to three, but we'll start with two
first.

This commit then completes the suite of cross-compiled compilers that we're
going to compile, adding it for a whole litany of platforms detailed in the
changes to the docker files here. The existing `cross` image is also trimmed
down quite a bit to avoid duplicate work, and we'll eventually provision it for
far more cross compilation as well.

Note that the gcc toolchains installed to compile most of these compilers are
inappropriate for actualy distribution. The glibc they pull in is much newer
than we'd like, so before we turn nightlies off we'll need to tweak these docker
files to custom build toolchains like the current `linux-cross` docker image
does.