### PR TITLE
rustbuild: Skip the build_helper crate in tests

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -373,10 +373,16 @@ pub fn krate(build: &Build,
             let mut visited = HashSet::new();
             let mut next = vec![root];
             while let Some(name) = next.pop() {
-                // Right now jemalloc is our only target-specific crate in the sense
-                // that it's not present on all platforms. Custom skip it here for now,
-                // but if we add more this probably wants to get more generalized.
-                if !name.contains("jemalloc") {
+                // Right now jemalloc is our only target-specific crate in the
+                // sense that it's not present on all platforms. Custom skip it
+                // here for now, but if we add more this probably wants to get
+                // more generalized.
+                //
+                // Also skip `build_helper` as it's not compiled normally for
+                // target during the bootstrap and it's just meant to be a
+                // helper crate, not tested. If it leaks through then it ends up
+                // messing with various mtime calculations and such.
+                if !name.contains("jemalloc") && name != "build_helper" {
                     cargo.arg("-p").arg(name);
                 }
                 for dep in build.crates[name].deps.iter() {


### PR DESCRIPTION
I've been noticing some spurious recompiles of the final stage on Travis lately
and in debugging them I found a case where we were a little to eager to update
a stamp file due to the build_helper library being introduced during the testing
phase.

Part of the rustbuild system detects when libstd is recompiled and automatically
cleans out future directories to ensure that dirtyness propagation works. To do
this rustbuild doesn't know the artifact name of the standard library so it just
probes everything in the target directory, looking to see if anything changed.

The problem here happened where:

* First, rustbuild would compile everything (a normal build)
* Next, rustbuild would run all tests
* During testing, the libbuild_helper library was introduced into the target
  directory, making it look like a change happened because a file is newer
  than the newest was before
* Detecting a change, the next compilation would then cause rustbuild to clean
  out old artifacts and recompile everything again.

This commit fixes this problem by correcting rustbuild to just not test the
build_helper crate at all. This crate doesn't have any unit tests, nor is it
intended to. That way the target directories should stay the same throughout
testing after a previous build.