### PR TITLE
If submodule init fails, try from scratch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,10 +71,10 @@ script:
       if [ "$ALLOW_PR" = "" ] && [ "$TRAVIS_BRANCH" != "auto" ]; then
           echo skipping, not a full build;
       elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
-          travis_retry git submodule update --init &&
+          travis_retry sh -c 'git submodule deinit -f . && git submodule update --init' &&
           src/ci/run.sh;
       else
-          travis_retry git submodule update --init &&
+          travis_retry sh -c 'git submodule deinit -f . && git submodule update --init' &&
           src/ci/docker/run.sh $IMAGE;
       fi
 


### PR DESCRIPTION
See #39051

I wonder if the cause could be some strange not-quite-checked-out state in a submodule. Try and fix this by force deinitialising everything before initialising (this will not throw away downloaded objects, git will skip them on the next attempt at cloning).

r? @alexcrichton 