### PR TITLE
Improve unused `extern crate` and unused `#[macro_use]` warnings

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -212,16 +212,13 @@ dependencies = [
  "proc_macro_tokens 0.0.0",
  "rustc_plugin 0.0.0",
  "syntax 0.0.0",
- "syntax_pos 0.0.0",
 ]
 
 [[package]]
 name = "proc_macro_tokens"
 version = "0.0.0"
 dependencies = [
- "log 0.0.0",
  "syntax 0.0.0",
- "syntax_pos 0.0.0",
 ]
 
 [[package]]
@@ -240,7 +237,6 @@ name = "rustc"
 version = "0.0.0"
 dependencies = [
  "arena 0.0.0",
- "flate 0.0.0",
  "fmt_macros 0.0.0",
  "graphviz 0.0.0",
  "log 0.0.0",
@@ -310,7 +306,6 @@ dependencies = [
  "rustc_data_structures 0.0.0",
  "rustc_errors 0.0.0",
  "rustc_i128 0.0.0",
- "serialize 0.0.0",
  "syntax 0.0.0",
  "syntax_pos 0.0.0",
 ]
@@ -319,7 +314,6 @@ dependencies = [
 name = "rustc_const_math"
 version = "0.0.0"
 dependencies = [
- "log 0.0.0",
  "rustc_i128 0.0.0",
  "serialize 0.0.0",
  "syntax 0.0.0",
@@ -339,7 +333,6 @@ name = "rustc_driver"
 version = "0.0.0"
 dependencies = [
  "arena 0.0.0",
- "flate 0.0.0",
  "graphviz 0.0.0",
  "log 0.0.0",
  "proc_macro_plugin 0.0.0",
@@ -371,8 +364,6 @@ dependencies = [
 name = "rustc_errors"
 version = "0.0.0"
 dependencies = [
- "log 0.0.0",
- "serialize 0.0.0",
  "syntax_pos 0.0.0",
 ]
 
@@ -388,7 +379,6 @@ dependencies = [
  "log 0.0.0",
  "rustc 0.0.0",
  "rustc_data_structures 0.0.0",
- "rustc_i128 0.0.0",
  "serialize 0.0.0",
  "syntax 0.0.0",
  "syntax_pos 0.0.0",
@@ -443,7 +433,6 @@ dependencies = [
  "graphviz 0.0.0",
  "log 0.0.0",
  "rustc 0.0.0",
- "rustc_back 0.0.0",
  "rustc_bitflags 0.0.0",
  "rustc_const_eval 0.0.0",
  "rustc_const_math 0.0.0",
@@ -474,10 +463,8 @@ version = "0.0.0"
 name = "rustc_plugin"
 version = "0.0.0"
 dependencies = [
- "log 0.0.0",
  "rustc 0.0.0",
  "rustc_back 0.0.0",
- "rustc_bitflags 0.0.0",
  "rustc_errors 0.0.0",
  "rustc_metadata 0.0.0",
  "syntax 0.0.0",
@@ -520,9 +507,7 @@ dependencies = [
 name = "rustc_trans"
 version = "0.0.0"
 dependencies = [
- "arena 0.0.0",
  "flate 0.0.0",
- "graphviz 0.0.0",
  "log 0.0.0",
  "rustc 0.0.0",
  "rustc_back 0.0.0",
@@ -535,7 +520,6 @@ dependencies = [
  "rustc_incremental 0.0.0",
  "rustc_llvm 0.0.0",
  "rustc_platform_intrinsics 0.0.0",
- "serialize 0.0.0",
  "syntax 0.0.0",
  "syntax_pos 0.0.0",
 ]
@@ -585,7 +569,6 @@ dependencies = [
 name = "serialize"
 version = "0.0.0"
 dependencies = [
- "log 0.0.0",
  "rustc_i128 0.0.0",
 ]
 

--- a/src/libproc_macro_plugin/Cargo.toml
+++ b/src/libproc_macro_plugin/Cargo.toml
@@ -11,5 +11,4 @@ crate-type = ["dylib"]
 log = { path = "../liblog" }
 rustc_plugin = { path = "../librustc_plugin" }
 syntax = { path = "../libsyntax" }
-syntax_pos = { path = "../libsyntax_pos" }
 proc_macro_tokens = { path = "../libproc_macro_tokens" }

--- a/src/libproc_macro_plugin/lib.rs
+++ b/src/libproc_macro_plugin/lib.rs
@@ -88,7 +88,6 @@
 
 extern crate rustc_plugin;
 extern crate syntax;
-extern crate syntax_pos;
 extern crate proc_macro_tokens;
 #[macro_use] extern crate log;
 

--- a/src/libproc_macro_tokens/Cargo.toml
+++ b/src/libproc_macro_tokens/Cargo.toml
@@ -10,5 +10,3 @@ crate-type = ["dylib"]
 
 [dependencies]
 syntax = { path = "../libsyntax" }
-syntax_pos = { path = "../libsyntax_pos" }
-log = { path = "../liblog" }

--- a/src/libproc_macro_tokens/build.rs
+++ b/src/libproc_macro_tokens/build.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate syntax;
-extern crate syntax_pos;
-
 use syntax::ast::Ident;
 use syntax::codemap::DUMMY_SP;
 use syntax::parse::token::{self, Token};

--- a/src/libproc_macro_tokens/lib.rs
+++ b/src/libproc_macro_tokens/lib.rs
@@ -58,8 +58,6 @@
 #![feature(rustc_private)]
 
 extern crate syntax;
-extern crate syntax_pos;
-extern crate log;
 
 pub mod build;
 pub mod parse;

--- a/src/libproc_macro_tokens/lib.rs
+++ b/src/libproc_macro_tokens/lib.rs
@@ -59,7 +59,7 @@
 
 extern crate syntax;
 extern crate syntax_pos;
-#[macro_use] extern crate log;
+extern crate log;
 
 pub mod build;
 pub mod parse;

--- a/src/libproc_macro_tokens/parse.rs
+++ b/src/libproc_macro_tokens/parse.rs
@@ -10,8 +10,6 @@
 
 //! Parsing utilities for writing procedural macros.
 
-extern crate syntax;
-
 use syntax::parse::{ParseSess, filemap_to_tts};
 use syntax::tokenstream::TokenStream;
 

--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = ["dylib"]
 
 [dependencies]
 arena = { path = "../libarena" }
-flate = { path = "../libflate" }
 fmt_macros = { path = "../libfmt_macros" }
 graphviz = { path = "../libgraphviz" }
 log = { path = "../liblog" }

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -26,7 +26,6 @@
 #![feature(associated_consts)]
 #![feature(box_patterns)]
 #![feature(box_syntax)]
-#![feature(collections)]
 #![feature(conservative_impl_trait)]
 #![feature(const_fn)]
 #![feature(core_intrinsics)]
@@ -39,11 +38,9 @@
 #![feature(slice_patterns)]
 #![feature(staged_api)]
 #![feature(unboxed_closures)]
-#![cfg_attr(test, feature(test))]
 
 extern crate arena;
 extern crate core;
-extern crate flate;
 extern crate fmt_macros;
 extern crate getopts;
 extern crate graphviz;
@@ -52,7 +49,6 @@ extern crate rustc_llvm as llvm;
 extern crate rustc_back;
 extern crate rustc_data_structures;
 extern crate serialize;
-extern crate collections;
 extern crate rustc_const_math;
 extern crate rustc_errors as errors;
 #[macro_use] extern crate log;
@@ -64,9 +60,6 @@ extern crate serialize as rustc_serialize; // used by deriving
 
 // SNAP:
 extern crate rustc_i128;
-
-#[cfg(test)]
-extern crate test;
 
 #[macro_use]
 mod macros;

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -57,7 +57,7 @@ extern crate rustc_const_math;
 extern crate rustc_errors as errors;
 #[macro_use] extern crate log;
 #[macro_use] extern crate syntax;
-#[macro_use] extern crate syntax_pos;
+extern crate syntax_pos;
 #[macro_use] #[no_link] extern crate rustc_bitflags;
 
 extern crate serialize as rustc_serialize; // used by deriving

--- a/src/librustc_const_eval/Cargo.toml
+++ b/src/librustc_const_eval/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["dylib"]
 [dependencies]
 arena = { path = "../libarena" }
 log = { path = "../liblog" }
-serialize = { path = "../libserialize" }
 rustc = { path = "../librustc" }
 rustc_back = { path = "../librustc_back" }
 rustc_const_math = { path = "../librustc_const_math" }

--- a/src/librustc_const_eval/lib.rs
+++ b/src/librustc_const_eval/lib.rs
@@ -40,7 +40,6 @@ extern crate rustc_data_structures;
 extern crate rustc_errors;
 extern crate graphviz;
 extern crate syntax_pos;
-extern crate serialize as rustc_serialize; // used by deriving
 
 extern crate rustc_i128;
 

--- a/src/librustc_const_math/Cargo.toml
+++ b/src/librustc_const_math/Cargo.toml
@@ -9,7 +9,6 @@ path = "lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-log = { path = "../liblog" }
 serialize = { path = "../libserialize" }
 syntax = { path = "../libsyntax" }
 rustc_i128 = { path = "../librustc_i128" }

--- a/src/librustc_const_math/lib.rs
+++ b/src/librustc_const_math/lib.rs
@@ -28,8 +28,8 @@
 #![feature(const_fn)]
 #![cfg_attr(not(stage0), feature(i128))]
 
-#[macro_use] extern crate log;
-#[macro_use] extern crate syntax;
+extern crate log;
+extern crate syntax;
 
 // SNAP: remove use of this crate
 extern crate rustc_i128;

--- a/src/librustc_const_math/lib.rs
+++ b/src/librustc_const_math/lib.rs
@@ -28,7 +28,6 @@
 #![feature(const_fn)]
 #![cfg_attr(not(stage0), feature(i128))]
 
-extern crate log;
 extern crate syntax;
 
 // SNAP: remove use of this crate

--- a/src/librustc_driver/Cargo.toml
+++ b/src/librustc_driver/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = ["dylib"]
 
 [dependencies]
 arena = { path = "../libarena" }
-flate = { path = "../libflate" }
 graphviz = { path = "../libgraphviz" }
 log = { path = "../liblog" }
 proc_macro_plugin = { path = "../libproc_macro_plugin" }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -32,7 +32,6 @@
 #![feature(staged_api)]
 
 extern crate arena;
-extern crate flate;
 extern crate getopts;
 extern crate graphviz;
 extern crate libc;

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -57,7 +57,6 @@ extern crate serialize;
 extern crate rustc_llvm as llvm;
 #[macro_use]
 extern crate log;
-#[macro_use]
 extern crate syntax;
 extern crate syntax_ext;
 extern crate syntax_pos;

--- a/src/librustc_errors/Cargo.toml
+++ b/src/librustc_errors/Cargo.toml
@@ -9,6 +9,4 @@ path = "lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-log = { path = "../liblog" }
-serialize = { path = "../libserialize" }
 syntax_pos = { path = "../libsyntax_pos" }

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -27,9 +27,7 @@
 
 extern crate serialize;
 extern crate term;
-#[macro_use]
 extern crate log;
-#[macro_use]
 extern crate libc;
 extern crate std_unicode;
 extern crate serialize as rustc_serialize; // used by deriving

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -23,14 +23,9 @@
 #![feature(staged_api)]
 #![feature(range_contains)]
 #![feature(libc)]
-#![feature(unicode)]
 
-extern crate serialize;
 extern crate term;
-extern crate log;
 extern crate libc;
-extern crate std_unicode;
-extern crate serialize as rustc_serialize; // used by deriving
 extern crate syntax_pos;
 
 pub use emitter::ColorConfig;

--- a/src/librustc_incremental/Cargo.toml
+++ b/src/librustc_incremental/Cargo.toml
@@ -16,4 +16,3 @@ serialize = { path = "../libserialize" }
 log = { path = "../liblog" }
 syntax = { path = "../libsyntax" }
 syntax_pos = { path = "../libsyntax_pos" }
-rustc_i128 = { path = "../librustc_i128" }

--- a/src/librustc_incremental/lib.rs
+++ b/src/librustc_incremental/lib.rs
@@ -33,8 +33,6 @@ extern crate serialize as rustc_serialize;
 extern crate syntax;
 extern crate syntax_pos;
 
-extern crate rustc_i128;
-
 const ATTR_DIRTY: &'static str = "rustc_dirty";
 const ATTR_CLEAN: &'static str = "rustc_clean";
 const ATTR_DIRTY_METADATA: &'static str = "rustc_metadata_dirty";

--- a/src/librustc_incremental/lib.rs
+++ b/src/librustc_incremental/lib.rs
@@ -30,7 +30,7 @@ extern crate rustc_data_structures;
 extern crate serialize as rustc_serialize;
 
 #[macro_use] extern crate log;
-#[macro_use] extern crate syntax;
+extern crate syntax;
 extern crate syntax_pos;
 
 extern crate rustc_i128;

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -37,7 +37,6 @@
 #![feature(slice_patterns)]
 #![feature(staged_api)]
 
-#[macro_use]
 extern crate syntax;
 #[macro_use]
 extern crate rustc;

--- a/src/librustc_mir/Cargo.toml
+++ b/src/librustc_mir/Cargo.toml
@@ -12,7 +12,6 @@ crate-type = ["dylib"]
 graphviz = { path = "../libgraphviz" }
 log = { path = "../liblog" }
 rustc = { path = "../librustc" }
-rustc_back = { path = "../librustc_back" }
 rustc_const_eval = { path = "../librustc_const_eval" }
 rustc_const_math = { path = "../librustc_const_math" }
 rustc_data_structures = { path = "../librustc_data_structures" }

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -31,7 +31,6 @@ extern crate graphviz as dot;
 #[macro_use]
 extern crate rustc;
 extern crate rustc_data_structures;
-extern crate rustc_back;
 #[macro_use]
 #[no_link]
 extern crate rustc_bitflags;

--- a/src/librustc_passes/lib.rs
+++ b/src/librustc_passes/lib.rs
@@ -27,7 +27,6 @@
 #![feature(staged_api)]
 #![feature(rustc_private)]
 
-extern crate core;
 #[macro_use]
 extern crate rustc;
 extern crate rustc_const_eval;

--- a/src/librustc_plugin/Cargo.toml
+++ b/src/librustc_plugin/Cargo.toml
@@ -10,7 +10,6 @@ path = "lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-log = { path = "../liblog" }
 rustc = { path = "../librustc" }
 rustc_back = { path = "../librustc_back" }
 rustc_metadata = { path = "../librustc_metadata" }

--- a/src/librustc_plugin/Cargo.toml
+++ b/src/librustc_plugin/Cargo.toml
@@ -13,7 +13,6 @@ crate-type = ["dylib"]
 log = { path = "../liblog" }
 rustc = { path = "../librustc" }
 rustc_back = { path = "../librustc_back" }
-rustc_bitflags = { path = "../librustc_bitflags" }
 rustc_metadata = { path = "../librustc_metadata" }
 syntax = { path = "../libsyntax" }
 syntax_pos = { path = "../libsyntax_pos" }

--- a/src/librustc_plugin/lib.rs
+++ b/src/librustc_plugin/lib.rs
@@ -63,7 +63,6 @@
 #![feature(rustc_diagnostic_macros)]
 #![feature(rustc_private)]
 
-extern crate log;
 #[macro_use] extern crate syntax;
 
 extern crate rustc;

--- a/src/librustc_plugin/lib.rs
+++ b/src/librustc_plugin/lib.rs
@@ -63,9 +63,8 @@
 #![feature(rustc_diagnostic_macros)]
 #![feature(rustc_private)]
 
-#[macro_use] extern crate log;
+extern crate log;
 #[macro_use] extern crate syntax;
-#[macro_use] #[no_link] extern crate rustc_bitflags;
 
 extern crate rustc;
 extern crate rustc_back;

--- a/src/librustc_resolve/check_unused.rs
+++ b/src/librustc_resolve/check_unused.rs
@@ -125,6 +125,11 @@ pub fn check_crate(resolver: &mut Resolver, krate: &ast::Crate) {
                 let msg = "unused extern crate".to_string();
                 resolver.session.add_lint(lint, directive.id, directive.span, msg);
             }
+            ImportDirectiveSubclass::MacroUse => {
+                let lint = lint::builtin::UNUSED_IMPORTS;
+                let msg = "unused `#[macro_use]` import".to_string();
+                resolver.session.add_lint(lint, directive.id, directive.span, msg);
+            }
             _ => {}
         }
     }

--- a/src/librustc_resolve/check_unused.rs
+++ b/src/librustc_resolve/check_unused.rs
@@ -22,8 +22,9 @@
 use std::ops::{Deref, DerefMut};
 
 use Resolver;
+use resolve_imports::ImportDirectiveSubclass;
 
-use rustc::lint;
+use rustc::{lint, ty};
 use rustc::util::nodemap::NodeMap;
 use syntax::ast::{self, ViewPathGlob, ViewPathList, ViewPathSimple};
 use syntax::visit::{self, Visitor};
@@ -86,16 +87,6 @@ impl<'a, 'b> Visitor<'a> for UnusedImportCheckVisitor<'a, 'b> {
         }
 
         match item.node {
-            ast::ItemKind::ExternCrate(_) => {
-                if let Some(crate_num) = self.session.cstore.extern_mod_stmt_cnum(item.id) {
-                    if !self.used_crates.contains(&crate_num) {
-                        self.session.add_lint(lint::builtin::UNUSED_EXTERN_CRATES,
-                                              item.id,
-                                              item.span,
-                                              "unused extern crate".to_string());
-                    }
-                }
-            }
             ast::ItemKind::Use(ref p) => {
                 match p.node {
                     ViewPathSimple(..) => {
@@ -124,6 +115,20 @@ impl<'a, 'b> Visitor<'a> for UnusedImportCheckVisitor<'a, 'b> {
 }
 
 pub fn check_crate(resolver: &mut Resolver, krate: &ast::Crate) {
+    for directive in resolver.potentially_unused_imports.iter() {
+        match directive.subclass {
+            _ if directive.used.get() ||
+                 directive.vis.get() == ty::Visibility::Public ||
+                 directive.span.source_equal(&DUMMY_SP) => {}
+            ImportDirectiveSubclass::ExternCrate => {
+                let lint = lint::builtin::UNUSED_EXTERN_CRATES;
+                let msg = "unused extern crate".to_string();
+                resolver.session.add_lint(lint, directive.id, directive.span, msg);
+            }
+            _ => {}
+        }
+    }
+
     let mut visitor = UnusedImportCheckVisitor {
         resolver: resolver,
         unused_imports: NodeMap(),

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -341,12 +341,15 @@ impl<'a> Resolver<'a> {
             };
         }
 
-        let binding = match binding {
-            Some(binding) => MacroBinding::Legacy(binding),
-            None => match self.builtin_macros.get(&name).cloned() {
-                Some(binding) => MacroBinding::Modern(binding),
-                None => return None,
-            },
+        let binding = if let Some(binding) = binding {
+            MacroBinding::Legacy(binding)
+        } else if let Some(binding) = self.builtin_macros.get(&name).cloned() {
+            if !self.use_extern_macros {
+                self.record_use(Ident::with_empty_ctxt(name), MacroNS, binding, DUMMY_SP);
+            }
+            MacroBinding::Modern(binding)
+        } else {
+            return None;
         };
 
         if !self.use_extern_macros {
@@ -378,6 +381,7 @@ impl<'a> Resolver<'a> {
             let (legacy_resolution, resolution) = match (legacy_resolution, resolution) {
                 (Some(legacy_resolution), Ok(resolution)) => (legacy_resolution, resolution),
                 (Some(MacroBinding::Modern(binding)), Err(_)) => {
+                    self.record_use(ident, MacroNS, binding, span);
                     self.err_if_macro_use_proc_macro(ident.name, span, binding);
                     continue
                 },

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -49,6 +49,7 @@ pub enum ImportDirectiveSubclass<'a> {
         // n.b. `max_vis` is only used in `finalize_import` to check for reexport errors.
     },
     ExternCrate,
+    MacroUse,
 }
 
 /// One import directive.
@@ -835,5 +836,6 @@ fn import_directive_subclass_to_string(subclass: &ImportDirectiveSubclass) -> St
         SingleImport { source, .. } => source.to_string(),
         GlobImport { .. } => "*".to_string(),
         ExternCrate => "<extern crate>".to_string(),
+        MacroUse => "#[macro_use]".to_string(),
     }
 }

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -62,6 +62,7 @@ pub struct ImportDirective<'a> {
     pub span: Span,
     pub vis: Cell<ty::Visibility>,
     pub expansion: Mark,
+    pub used: Cell<bool>,
 }
 
 impl<'a> ImportDirective<'a> {
@@ -257,6 +258,7 @@ impl<'a> Resolver<'a> {
             id: id,
             vis: Cell::new(vis),
             expansion: expansion,
+            used: Cell::new(false),
         });
 
         self.indeterminate_imports.push(directive);

--- a/src/librustc_trans/Cargo.toml
+++ b/src/librustc_trans/Cargo.toml
@@ -10,9 +10,7 @@ crate-type = ["dylib"]
 test = false
 
 [dependencies]
-arena = { path = "../libarena" }
 flate = { path = "../libflate" }
-graphviz = { path = "../libgraphviz" }
 log = { path = "../liblog" }
 rustc = { path = "../librustc" }
 rustc_back = { path = "../librustc_back" }
@@ -25,6 +23,5 @@ rustc_incremental = { path = "../librustc_incremental" }
 rustc_llvm = { path = "../librustc_llvm" }
 rustc_i128 = { path = "../librustc_i128" }
 rustc_platform_intrinsics = { path = "../librustc_platform_intrinsics" }
-serialize = { path = "../libserialize" }
 syntax = { path = "../libsyntax" }
 syntax_pos = { path = "../libsyntax_pos" }

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -40,10 +40,7 @@
 
 use rustc::dep_graph::WorkProduct;
 
-extern crate arena;
 extern crate flate;
-extern crate getopts;
-extern crate graphviz;
 extern crate libc;
 #[macro_use] extern crate rustc;
 extern crate rustc_back;
@@ -51,7 +48,6 @@ extern crate rustc_data_structures;
 extern crate rustc_incremental;
 pub extern crate rustc_llvm as llvm;
 extern crate rustc_platform_intrinsics as intrinsics;
-extern crate serialize;
 extern crate rustc_const_math;
 extern crate rustc_const_eval;
 #[macro_use]

--- a/src/libserialize/Cargo.toml
+++ b/src/libserialize/Cargo.toml
@@ -9,5 +9,4 @@ path = "lib.rs"
 crate-type = ["dylib", "rlib"]
 
 [dependencies]
-log = { path = "../liblog" }
 rustc_i128 = { path = "../librustc_i128" }

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -39,7 +39,7 @@ Core encoding and decoding interfaces.
 
 // test harness access
 #[cfg(test)] extern crate test;
-#[macro_use] extern crate log;
+extern crate log;
 
 extern crate std_unicode;
 extern crate collections;

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -31,17 +31,10 @@ Core encoding and decoding interfaces.
 #![feature(collections)]
 #![feature(core_intrinsics)]
 #![feature(enumset)]
-#![feature(rustc_private)]
 #![feature(specialization)]
 #![feature(staged_api)]
-#![feature(unicode)]
 #![cfg_attr(test, feature(test))]
 
-// test harness access
-#[cfg(test)] extern crate test;
-extern crate log;
-
-extern crate std_unicode;
 extern crate collections;
 
 extern crate rustc_i128;

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -26,7 +26,6 @@
 
 #![feature(associated_consts)]
 #![feature(const_fn)]
-#![feature(libc)]
 #![feature(optin_builtin_traits)]
 #![feature(rustc_private)]
 #![feature(staged_api)]
@@ -35,10 +34,7 @@
 #![feature(rustc_diagnostic_macros)]
 #![feature(specialization)]
 
-extern crate core;
 extern crate serialize;
-extern crate term;
-extern crate libc;
 #[macro_use] extern crate log;
 #[macro_use] #[no_link] extern crate rustc_bitflags;
 extern crate std_unicode;

--- a/src/test/compile-fail/imports/unused-macro-use.rs
+++ b/src/test/compile-fail/imports/unused-macro-use.rs
@@ -1,0 +1,21 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(unused)]
+
+#[macro_use] //~ ERROR unused `#[macro_use]` import
+extern crate core;
+
+#[macro_use(
+    panic //~ ERROR unused `#[macro_use]` import
+)]
+extern crate core as core_2;
+
+fn main() {}

--- a/src/test/compile-fail/lint-unused-extern-crate.rs
+++ b/src/test/compile-fail/lint-unused-extern-crate.rs
@@ -33,6 +33,11 @@ use rand::isaac::IsaacRng;
 
 use other::*;
 
+mod foo {
+    // Test that this is unused even though an earler `extern crate rand` is used.
+    extern crate rand; //~ ERROR unused extern crate
+}
+
 fn main() {
     let x: collecs::vec::Vec<usize> = Vec::new();
     let y = foo();

--- a/src/test/compile-fail/lint-unused-extern-crate.rs
+++ b/src/test/compile-fail/lint-unused-extern-crate.rs
@@ -26,8 +26,6 @@ extern crate rand; // no error, the use marks it as used
 
 extern crate lint_unused_extern_crate as other; // no error, the use * marks it as used
 
-#[macro_use] extern crate core; // no error, the `#[macro_use]` marks it as used
-
 #[allow(unused_imports)]
 use rand::isaac::IsaacRng;
 

--- a/src/tools/cargotest/main.rs
+++ b/src/tools/cargotest/main.rs
@@ -25,7 +25,7 @@ const TEST_REPOS: &'static [Test] = &[
     Test {
         name: "cargo",
         repo: "https://github.com/rust-lang/cargo",
-        sha: "b7be4f2ef2cf743492edc6dfb55d087ed88f2d76",
+        sha: "2324c2bbaf7fc6ea9cbdd77c034ef1af769cb617",
         lock: None,
     },
     Test {


### PR DESCRIPTION
This PR
 - adds `unused_imports` warnings for unused `#[macro_use] extern crate` macro imports,
 - improves `unused_extern_crates` warnings (avoids false negatives), and
 - removes unused `#[macro_use]` imports and unused `extern crate`s.

r? @nrc 