### PR TITLE
Fix covered-switch-default warnings in RustWrapper

### DIFF
--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -148,9 +148,8 @@ static Attribute::AttrKind fromRust(LLVMRustAttribute Kind) {
     return Attribute::ZExt;
   case InReg:
     return Attribute::InReg;
-  default:
-    llvm_unreachable("bad AttributeKind");
   }
+  llvm_unreachable("bad AttributeKind");
 }
 
 extern "C" void LLVMRustAddCallSiteAttribute(LLVMValueRef Instr, unsigned Index,
@@ -1233,9 +1232,8 @@ static LLVMLinkage fromRust(LLVMRustLinkage Linkage) {
     return LLVMExternalWeakLinkage;
   case LLVMRustLinkage::CommonLinkage:
     return LLVMCommonLinkage;
-  default:
-    llvm_unreachable("Invalid LLVMRustLinkage value!");
   }
+  llvm_unreachable("Invalid LLVMRustLinkage value!");
 }
 
 extern "C" LLVMRustLinkage LLVMRustGetLinkage(LLVMValueRef V) {
@@ -1282,10 +1280,8 @@ static LLVMRustVisibility toRust(LLVMVisibility Vis) {
     return LLVMRustVisibility::Hidden;
   case LLVMProtectedVisibility:
     return LLVMRustVisibility::Protected;
-
-  default:
-    llvm_unreachable("Invalid LLVMRustVisibility value!");
   }
+  llvm_unreachable("Invalid LLVMRustVisibility value!");
 }
 
 static LLVMVisibility fromRust(LLVMRustVisibility Vis) {
@@ -1296,10 +1292,8 @@ static LLVMVisibility fromRust(LLVMRustVisibility Vis) {
     return LLVMHiddenVisibility;
   case LLVMRustVisibility::Protected:
     return LLVMProtectedVisibility;
-
-  default:
-    llvm_unreachable("Invalid LLVMRustVisibility value!");
   }
+  llvm_unreachable("Invalid LLVMRustVisibility value!");
 }
 
 extern "C" LLVMRustVisibility LLVMRustGetVisibility(LLVMValueRef V) {


### PR DESCRIPTION
These switch statements cover all possible values, so the default case is dead code (it contains an `llvm_unreachable anyway`), triggering a `-Wcovered-switch-default` warning that pollutes the build output. Moving the unreachable after the switch resolves these warnings.

r? @rkruppe