### PR TITLE
End temporary lifetimes being extended by `let X: &_` hints

### DIFF
--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -23,7 +23,6 @@ use hir;
 use middle::free_region::FreeRegionMap;
 use middle::mem_categorization as mc;
 use middle::mem_categorization::McResult;
-use middle::region::CodeExtent;
 use middle::lang_items;
 use mir::tcx::LvalueTy;
 use ty::subst::{Kind, Subst, Substs};
@@ -1620,10 +1619,6 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
 
     pub fn is_method_call(&self, id: ast::NodeId) -> bool {
         self.tables.borrow().method_map.contains_key(&ty::MethodCall::expr(id))
-    }
-
-    pub fn temporary_scope(&self, rvalue_id: ast::NodeId) -> Option<CodeExtent> {
-        self.tcx.region_maps.temporary_scope(rvalue_id)
     }
 
     pub fn upvar_capture(&self, upvar_id: ty::UpvarId) -> Option<ty::UpvarCapture<'tcx>> {

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -296,6 +296,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
                 arg.id,
                 arg.pat.span,
                 fn_body_scope_r, // Args live only as long as the fn body.
+                fn_body_scope_r,
                 arg_ty);
 
             self.walk_irrefutable_pat(arg_cmt, &arg.pat);

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -272,6 +272,13 @@ pub struct RegionMaps {
     /// block (see `terminating_scopes`).
     rvalue_scopes: RefCell<NodeMap<CodeExtent>>,
 
+    /// Records the value of rvalue scopes before they were shrunk by
+    /// #36082, for error reporting.
+    ///
+    /// FIXME: this should be temporary. Remove this by 1.18.0 or
+    /// so.
+    shrunk_rvalue_scopes: RefCell<NodeMap<CodeExtent>>,
+
     /// Encodes the hierarchy of fn bodies. Every fn body (including
     /// closures) forms its own distinct region hierarchy, rooted in
     /// the block that is the fn body. This map points from the id of
@@ -419,11 +426,7 @@ impl RegionMaps {
             e(child, parent)
         }
     }
-    pub fn each_rvalue_scope<E>(&self, mut e:E) where E: FnMut(&ast::NodeId, &CodeExtent) {
-        for (child, parent) in self.rvalue_scopes.borrow().iter() {
-            e(child, parent)
-        }
-    }
+
     /// Records that `sub_fn` is defined within `sup_fn`. These ids
     /// should be the id of the block that is the fn body, which is
     /// also the root of the region hierarchy for that fn.
@@ -457,6 +460,12 @@ impl RegionMaps {
         self.rvalue_scopes.borrow_mut().insert(var, lifetime);
     }
 
+    fn record_shrunk_rvalue_scope(&self, var: ast::NodeId, lifetime: CodeExtent) {
+        debug!("record_rvalue_scope(sub={:?}, sup={:?})", var, lifetime);
+        assert!(var != lifetime.node_id(self));
+        self.shrunk_rvalue_scopes.borrow_mut().insert(var, lifetime);
+    }
+
     pub fn opt_encl_scope(&self, id: CodeExtent) -> Option<CodeExtent> {
         //! Returns the narrowest scope that encloses `id`, if any.
         self.scope_map.borrow()[id.0 as usize].into_option()
@@ -474,6 +483,30 @@ impl RegionMaps {
             Some(&r) => r,
             None => { bug!("no enclosing scope for id {:?}", var_id); }
         }
+    }
+
+    pub fn temporary_scope2(&self, expr_id: ast::NodeId) -> (Option<CodeExtent>, bool) {
+        let temporary_scope = self.temporary_scope(expr_id);
+        let was_shrunk = match self.shrunk_rvalue_scopes.borrow().get(&expr_id) {
+            Some(&s) => {
+                info!("temporary_scope2({:?}, scope={:?}, shrunk={:?})",
+                      expr_id, temporary_scope, s);
+                temporary_scope != Some(s)
+            }
+            _ => false
+        };
+        info!("temporary_scope2({:?}) - was_shrunk={:?}", expr_id, was_shrunk);
+        (temporary_scope, was_shrunk)
+    }
+
+    pub fn old_and_new_temporary_scope(&self, expr_id: ast::NodeId) ->
+        (Option<CodeExtent>, Option<CodeExtent>)
+    {
+        let temporary_scope = self.temporary_scope(expr_id);
+        (temporary_scope,
+         self.shrunk_rvalue_scopes
+             .borrow().get(&expr_id).cloned()
+             .or(temporary_scope))
     }
 
     pub fn temporary_scope(&self, expr_id: ast::NodeId) -> Option<CodeExtent> {
@@ -929,8 +962,10 @@ fn resolve_local<'a, 'tcx>(visitor: &mut RegionResolutionVisitor<'tcx, 'a>,
         let is_borrow =
             if let Some(ref ty) = local.ty { is_borrowed_ty(&ty) } else { false };
 
-        if is_binding_pat(&local.pat) || is_borrow {
-            record_rvalue_scope(visitor, &expr, blk_scope);
+        if is_binding_pat(&local.pat) {
+            record_rvalue_scope(visitor, &expr, blk_scope, false);
+        } else if is_borrow {
+            record_rvalue_scope(visitor, &expr, blk_scope, true);
         }
     }
 
@@ -995,7 +1030,7 @@ fn resolve_local<'a, 'tcx>(visitor: &mut RegionResolutionVisitor<'tcx, 'a>,
         match expr.node {
             hir::ExprAddrOf(_, ref subexpr) => {
                 record_rvalue_scope_if_borrow_expr(visitor, &subexpr, blk_id);
-                record_rvalue_scope(visitor, &subexpr, blk_id);
+                record_rvalue_scope(visitor, &subexpr, blk_id, false);
             }
             hir::ExprStruct(_, ref fields, _) => {
                 for field in fields {
@@ -1040,7 +1075,8 @@ fn resolve_local<'a, 'tcx>(visitor: &mut RegionResolutionVisitor<'tcx, 'a>,
     /// Note: ET is intended to match "rvalues or lvalues based on rvalues".
     fn record_rvalue_scope<'a>(visitor: &mut RegionResolutionVisitor,
                                expr: &'a hir::Expr,
-                               blk_scope: CodeExtent) {
+                               blk_scope: CodeExtent,
+                               is_shrunk: bool) {
         let mut expr = expr;
         loop {
             // Note: give all the expressions matching `ET` with the
@@ -1048,7 +1084,12 @@ fn resolve_local<'a, 'tcx>(visitor: &mut RegionResolutionVisitor<'tcx, 'a>,
             // because in trans if we must compile e.g. `*rvalue()`
             // into a temporary, we request the temporary scope of the
             // outer expression.
-            visitor.region_maps.record_rvalue_scope(expr.id, blk_scope);
+            if is_shrunk {
+                // this changed because of #36082
+                visitor.region_maps.record_shrunk_rvalue_scope(expr.id, blk_scope);
+            } else {
+                visitor.region_maps.record_rvalue_scope(expr.id, blk_scope);
+            }
 
             match expr.node {
                 hir::ExprAddrOf(_, ref subexpr) |
@@ -1225,6 +1266,7 @@ pub fn resolve_crate(sess: &Session, map: &ast_map::Map) -> RegionMaps {
         scope_map: RefCell::new(vec![]),
         var_map: RefCell::new(NodeMap()),
         rvalue_scopes: RefCell::new(NodeMap()),
+        shrunk_rvalue_scopes: RefCell::new(NodeMap()),
         fn_tree: RefCell::new(NodeMap()),
     };
     let root_extent = maps.bogus_code_extent(

--- a/src/librustc_borrowck/borrowck/gather_loans/lifetime.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/lifetime.rs
@@ -108,7 +108,7 @@ impl<'a, 'tcx> GuaranteeLifetimeContext<'a, 'tcx> {
         //! rooting etc, and presuming `cmt` is not mutated.
 
         match cmt.cat {
-            Categorization::Rvalue(temp_scope) => {
+            Categorization::Rvalue(temp_scope, _) => {
                 temp_scope
             }
             Categorization::Upvar(..) => {

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -967,7 +967,7 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
             err_mutbl => self.note_and_explain_mutbl_error(db, &err, &error_span),
             err_out_of_scope(super_scope, sub_scope, cause) => {
                 let (value_kind, value_msg) = match err.cmt.cat {
-                    mc::Categorization::Rvalue(_) =>
+                    mc::Categorization::Rvalue(..) =>
                         ("temporary value", "temporary value created here"),
                     _ =>
                         ("borrowed value", "borrow occurs here")
@@ -1060,6 +1060,17 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
 
                 if let Some(_) = statement_scope_span(self.tcx, super_scope) {
                     db.note("consider using a `let` binding to increase its lifetime");
+                }
+
+
+
+                match err.cmt.cat {
+                    mc::Categorization::Rvalue(r, or) if r != or => {
+                        db.note("\
+before rustc 1.16, this temporary lived longer - see issue #39283 \
+(https://github.com/rust-lang/rust/issues/39283)");
+                    }
+                    _ => {}
                 }
             }
 

--- a/src/librustc_mir/build/expr/as_constant.rs
+++ b/src/librustc_mir/build/expr/as_constant.rs
@@ -26,7 +26,8 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
 
     fn expr_as_constant(&mut self, expr: Expr<'tcx>) -> Constant<'tcx> {
         let this = self;
-        let Expr { ty, temp_lifetime: _, span, kind } = expr;
+        let Expr { ty, temp_lifetime: _, temp_lifetime_was_shrunk: _, span, kind }
+            = expr;
         match kind {
             ExprKind::Scope { extent: _, value } =>
                 this.as_constant(value),

--- a/src/librustc_mir/build/expr/as_temp.rs
+++ b/src/librustc_mir/build/expr/as_temp.rs
@@ -39,6 +39,13 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         let expr_span = expr.span;
         let source_info = this.source_info(expr_span);
 
+        if expr.temp_lifetime_was_shrunk && this.hir.needs_drop(expr_ty) {
+            this.hir.tcx().sess.span_warn(
+                expr_span,
+                "this temporary used to live longer - see issue #39283 \
+(https://github.com/rust-lang/rust/issues/39283)");
+        }
+
         if temp_lifetime.is_some() {
             this.cfg.push(block, Statement {
                 source_info: source_info,

--- a/src/librustc_mir/hair/cx/block.rs
+++ b/src/librustc_mir/hair/cx/block.rs
@@ -83,10 +83,11 @@ pub fn to_expr_ref<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                                    block: &'tcx hir::Block)
                                    -> ExprRef<'tcx> {
     let block_ty = cx.tables().node_id_to_type(block.id);
-    let temp_lifetime = cx.tcx.region_maps.temporary_scope(block.id);
+    let (temp_lifetime, was_shrunk) = cx.tcx.region_maps.temporary_scope2(block.id);
     let expr = Expr {
         ty: block_ty,
         temp_lifetime: temp_lifetime,
+        temp_lifetime_was_shrunk: was_shrunk,
         span: block.span,
         kind: ExprKind::Block { body: block },
     };

--- a/src/librustc_mir/hair/mod.rs
+++ b/src/librustc_mir/hair/mod.rs
@@ -97,6 +97,9 @@ pub struct Expr<'tcx> {
     /// temporary; should be None only if in a constant context
     pub temp_lifetime: Option<CodeExtent>,
 
+    /// whether this temp lifetime was shrunk by #36082.
+    pub temp_lifetime_was_shrunk: bool,
+
     /// span of the expression in the source
     pub span: Span,
 

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -996,7 +996,7 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
                                                      cmt: mc::cmt<'tcx>,
                                                      span: Span) {
         match cmt.cat {
-            Categorization::Rvalue(region) => {
+            Categorization::Rvalue(region, _) => {
                 match *region {
                     ty::ReScope(rvalue_scope) => {
                         let typ = self.resolve_type(cmt.ty);
@@ -1113,7 +1113,8 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
         for arg in args {
             let arg_ty = self.node_ty(arg.id);
             let re_scope = self.tcx.mk_region(ty::ReScope(body_scope));
-            let arg_cmt = mc.cat_rvalue(arg.id, arg.pat.span, re_scope, arg_ty);
+            let arg_cmt = mc.cat_rvalue(
+                arg.id, arg.pat.span, re_scope, re_scope, arg_ty);
             debug!("arg_ty={:?} arg_cmt={:?} arg={:?}",
                    arg_ty,
                    arg_cmt,

--- a/src/librustc_typeck/check/upvar.rs
+++ b/src/librustc_typeck/check/upvar.rs
@@ -339,7 +339,7 @@ impl<'a, 'gcx, 'tcx> AdjustBorrowKind<'a, 'gcx, 'tcx> {
 
             Categorization::Deref(.., mc::UnsafePtr(..)) |
             Categorization::StaticItem |
-            Categorization::Rvalue(_) |
+            Categorization::Rvalue(..) |
             Categorization::Local(_) |
             Categorization::Upvar(..) => {
                 return;
@@ -371,7 +371,7 @@ impl<'a, 'gcx, 'tcx> AdjustBorrowKind<'a, 'gcx, 'tcx> {
 
             Categorization::Deref(.., mc::UnsafePtr(..)) |
             Categorization::StaticItem |
-            Categorization::Rvalue(_) |
+            Categorization::Rvalue(..) |
             Categorization::Local(_) |
             Categorization::Upvar(..) => {
             }

--- a/src/test/compile-fail/issue-36082.rs
+++ b/src/test/compile-fail/issue-36082.rs
@@ -1,0 +1,27 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::cell::RefCell;
+
+fn main() {
+    let mut r = 0;
+    let s = 0;
+    let x = RefCell::new((&mut r,s));
+
+    let val: &_ = x.borrow().0;
+    //~^ WARNING this temporary used to live longer - see issue #39283
+    //~^^ ERROR borrowed value does not live long enough
+    //~| temporary value dropped here while still borrowed
+    //~| temporary value created here
+    //~| consider using a `let` binding to increase its lifetime
+    //~| before rustc 1.16, this temporary lived longer - see issue #39283
+    println!("{}", val);
+}
+//~^ temporary value needs to live until here


### PR DESCRIPTION
cc #39283

r? @nikomatsakis 
