### PR TITLE
Mark safe_suggestion and pushpop_unsafe as removed in feature_gate.rs

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -926,7 +926,6 @@ impl<'feat> ExpansionConfig<'feat> {
         fn enable_trace_macros = trace_macros,
         fn enable_allow_internal_unstable = allow_internal_unstable,
         fn enable_custom_derive = custom_derive,
-        fn enable_pushpop_unsafe = pushpop_unsafe,
     }
 }
 

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -127,9 +127,6 @@ declare_features! (
     (active, reflect, "1.0.0", Some(27749)),
     (active, unboxed_closures, "1.0.0", Some(29625)),
 
-    // rustc internal.
-    (active, pushpop_unsafe, "1.2.0", None),
-
     (active, allocator, "1.0.0", Some(27389)),
     (active, fundamental, "1.0.0", Some(29635)),
     (active, main, "1.0.0", Some(29634)),
@@ -341,6 +338,7 @@ declare_features! (
     // Allows using items which are missing stability attributes
     // rustc internal
     (removed, unmarked_api, "1.0.0", None),
+    (removed, pushpop_unsafe, "1.2.0", None),
 );
 
 declare_features! (

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -313,9 +313,6 @@ declare_features! (
     // Allows #[target_feature(...)]
     (active, target_feature, "1.15.0", None),
 
-    // Allow safe suggestions for potential type conversions.
-    (active, safe_suggestion, "1.0.0", Some(37384)),
-
     // `extern "ptx-*" fn()`
     (active, abi_ptx, "1.15.0", None),
 

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -165,7 +165,7 @@ pub fn check(path: &Path, bad: &mut bool) {
 
     // FIXME get this whitelist empty.
     let whitelist = vec![
-        "abi_ptx", "simd", "safe_suggestion", "macro_reexport",
+        "abi_ptx", "simd", "macro_reexport",
         "more_struct_aliases", "static_recursion", "reflect",
         "quote", "cfg_target_has_atomic", "custom_attribute",
         "default_type_parameter_fallback", "pushpop_unsafe",

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -168,7 +168,7 @@ pub fn check(path: &Path, bad: &mut bool) {
         "abi_ptx", "simd", "macro_reexport",
         "more_struct_aliases", "static_recursion", "reflect",
         "quote", "cfg_target_has_atomic", "custom_attribute",
-        "default_type_parameter_fallback", "pushpop_unsafe",
+        "default_type_parameter_fallback",
         "use_extern_macros", "staged_api", "const_indexing",
         "unboxed_closures", "stmt_expr_attributes",
         "cfg_target_thread_local", "unwind_attributes",


### PR DESCRIPTION
This removes two features from feature_gate.rs: `safe_suggestion` and `pushpop_unsafe`. Both had been removed in other places already, but were forgotten to be removed from feature_gate.rs.

* `safe_suggestion` was added in commit 164f0105bb65f31b89e5fb7f368c9e6f5833a3f8 and then removed again in commit c11fe553df269d6f47b4c48f5c47c08efdd373dc both in the same PR #38099. 

* `pushpop_unsafe` was added in commit 1829fa5199bae5a192c771807c532badce14be37 and removed again in commit d399098fd82e0bf3ed61bbbbcdbb0b6adfa4c808

Removes two elements from the whitelist of non gate tested unstable lang features (issue #39059).