### PR TITLE
Make rustbuild force_alloc_system rather than relying on stage0

### DIFF
--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -31,4 +31,5 @@ gcc = "0.3.27"
 backtrace = []
 debug-jemalloc = ["alloc_jemalloc/debug"]
 jemalloc = ["alloc_jemalloc"]
+force_alloc_system = []
 panic-unwind = ["panic_unwind"]

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -219,9 +219,10 @@
 // Tell the compiler to link to either panic_abort or panic_unwind
 #![needs_panic_runtime]
 
-// Always use alloc_system during stage0 since jemalloc might be unavailable or
-// disabled (Issue #30592)
-#![cfg_attr(stage0, feature(alloc_system))]
+// Always use alloc_system during stage0 since we don't know if the alloc_*
+// crate the stage0 compiler will pick by default is available (most
+// obviously, if the user has disabled jemalloc in `./configure`).
+#![cfg_attr(any(stage0, feature = "force_alloc_system"), feature(alloc_system))]
 
 // Turn warnings into errors, but only after stage0, where it can be useful for
 // code to emit warnings during language transitions
@@ -333,7 +334,7 @@ extern crate libc;
 // We always need an unwinder currently for backtraces
 extern crate unwind;
 
-#[cfg(stage0)]
+#[cfg(any(stage0, feature = "force_alloc_system"))]
 extern crate alloc_system;
 
 // compiler-rt intrinsics

--- a/src/rustc/std_shim/Cargo.toml
+++ b/src/rustc/std_shim/Cargo.toml
@@ -38,4 +38,5 @@ core = { path = "../../libcore" }
 backtrace = ["std/backtrace"]
 debug-jemalloc = ["std/debug-jemalloc"]
 jemalloc = ["std/jemalloc"]
+force_alloc_system = ["std/force_alloc_system"]
 panic-unwind = ["std/panic-unwind"]


### PR DESCRIPTION
This 'fixes' jemalloc-less local rebuilds, where we tell cargo that we're actually stage1 (this only fixes the rustbuild path, since I wasn't enthusiastic to dive into the makefiles).

There should be one effect from this PR: `--enable-local-rebuild --disable-jemalloc` will successfully build a stage0 std (rather than erroring). Ideally I think it'd be nice to specify an allocator preference in Cargo.toml/cargo command line (used when an allocator must be picked i.e. dylibs, not rlibs), but since that's not possible we can make do with a force_alloc_system feature. Sadly this locks you into a single allocator in the build libstd, making any eventual implementation of #38575 not quite right in this edge case, but clearly not many people exercise the combination of these two flags.

This PR is also a substitute for #37975 I think. The crucial difference is that the feature name here is distinct from the jemalloc feature (reused in the previous PR) - we don't want someone to be forced into alloc_system just for disabling jemalloc!

Fixes #39054

r? @alexcrichton 