### PR TITLE
Fix UB in test helpers

### DIFF
--- a/src/rt/rust_test_helpers.c
+++ b/src/rt/rust_test_helpers.c
@@ -269,10 +269,7 @@ LARGE_INTEGER increment_all_parts(LARGE_INTEGER li) {
     return li;
 }
 
-#define DO_INT128_TEST !(defined(WIN32) || defined(_WIN32) || defined(__WIN32)) && \
-    defined(__amd64__)
-
-#if DO_INT128_TEST
+#if !(defined(WIN32) || defined(_WIN32) || defined(__WIN32)) && defined(__amd64__)
 
 unsigned __int128 identity(unsigned __int128 a) {
     return a;


### PR DESCRIPTION
Macro expansion producing defined has undefined behavior in C/C++.