### PR TITLE
Fix stage 1 tests broken because i128 doesn't work in stage 1

### DIFF
--- a/src/test/run-pass/issue-38987.rs
+++ b/src/test/run-pass/issue-38987.rs
@@ -9,6 +9,10 @@
 // except according to those terms.
 #![feature(i128_type)]
 
+// SNAP: run on all stages after snapshot, i128 currently doesn't work on stages 0 and 1
+// ignore-stage1
+// ignore-stage0
+
 fn main() {
     let _ = -0x8000_0000_0000_0000_0000_0000_0000_0000i128;
 }


### PR DESCRIPTION
Broken by https://github.com/rust-lang/rust/pull/38992.