### PR TITLE
appveyor: Test/Dist i586 MSVC

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
     SCRIPT: python x.py test && python x.py dist
     DEPLOY: 1
   - MSYS_BITS: 32
-    RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc
+    RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc --target=i586-pc-windows-msvc
     SCRIPT: python x.py test && python x.py dist
     DEPLOY: 1
 


### PR DESCRIPTION
This is a target that we're shipping today, so this commit adds this matrix
entry to AppVeyor. This reuses the existing i686 MSVC matrix entry as it's
currently finishing about a half hour under two hours, which should hopefully
give it enough extra time to run this test suite.

cc #38531