### PR TITLE
travis: Get an emscripten builder online

### DIFF
--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -45,7 +45,7 @@ pub fn check(build: &mut Build) {
             let target = path.join(cmd);
             let mut cmd_alt = cmd.to_os_string();
             cmd_alt.push(".exe");
-            if target.exists() ||
+            if target.is_file() ||
                target.with_extension("exe").exists() ||
                target.join(cmd_alt).exists() {
                 return Some(target);

--- a/src/ci/docker/emscripten/Dockerfile
+++ b/src/ci/docker/emscripten/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  g++ \
+  make \
+  file \
+  curl \
+  ca-certificates \
+  python \
+  git \
+  cmake \
+  sudo \
+  gdb \
+  xz-utils \
+  lib32stdc++6
+
+ENV SCCACHE_DIGEST=7237e38e029342fa27b7ac25412cb9d52554008b12389727320bd533fd7f05b6a96d55485f305caf95e5c8f5f97c3313e10012ccad3e752aba2518f3522ba783
+RUN curl -L https://api.pub.build.mozilla.org/tooltool/sha512/$SCCACHE_DIGEST | \
+      tar xJf - -C /usr/local/bin --strip-components=1
+
+RUN curl -OL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
+    dpkg -i dumb-init_*.deb && \
+    rm dumb-init_*.deb
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
+WORKDIR /tmp
+COPY build-emscripten.sh /tmp/
+RUN ./build-emscripten.sh
+ENV PATH=$PATH:/tmp/emsdk_portable
+ENV PATH=$PATH:/tmp/emsdk_portable/clang/tag-e1.37.1/build_tag-e1.37.1_32/bin
+ENV PATH=$PATH:/tmp/emsdk_portable/node/4.1.1_32bit/bin
+ENV PATH=$PATH:/tmp/emsdk_portable/emscripten/tag-1.37.1
+ENV EMSCRIPTEN=/tmp/emsdk_portable/emscripten/tag-1.37.1
+
+ENV RUST_CONFIGURE_ARGS --target=asmjs-unknown-emscripten
+
+# Run `emcc` first as it's got a prompt and doesn't actually do anything, after
+# that's done with do the real build.
+ENV SCRIPT emcc && \
+      python2.7 ../x.py test --target asmjs-unknown-emscripten
+

--- a/src/ci/docker/emscripten/build-emscripten.sh
+++ b/src/ci/docker/emscripten/build-emscripten.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+set -ex
+
+curl https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz | \
+      tar xzf -
+source emsdk_portable/emsdk_env.sh
+emsdk update
+emsdk install --build=Release sdk-tag-1.37.1-32bit
+emsdk activate --build=Release sdk-tag-1.37.1-32bit

--- a/src/libstd/net/test.rs
+++ b/src/libstd/net/test.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[allow(dead_code)] // not used on emscripten
+#![allow(warnings)] // not used on emscripten
 
 use env;
 use net::{SocketAddr, SocketAddrV4, SocketAddrV6, Ipv4Addr, Ipv6Addr, ToSocketAddrs};

--- a/src/libstd/num.rs
+++ b/src/libstd/num.rs
@@ -172,6 +172,7 @@ mod tests {
 
     macro_rules! test_checked_next_power_of_two {
         ($test_name:ident, $T:ident) => (
+            #[cfg_attr(target_os = "emscripten", ignore)] // FIXME(#39119)
             fn $test_name() {
                 #![test]
                 assert_eq!((0 as $T).checked_next_power_of_two(), Some(1));

--- a/src/test/codegen/fastcall-inreg.rs
+++ b/src/test/codegen/fastcall-inreg.rs
@@ -53,6 +53,7 @@
 // ignore-shave
 // ignore-wasm32
 // ignore-wasm64
+// ignore-emscripten
 
 // compile-flags: -C no-prepopulate-passes
 

--- a/src/test/compile-fail/asm-bad-clobber.rs
+++ b/src/test/compile-fail/asm-bad-clobber.rs
@@ -12,6 +12,7 @@
 // ignore-arm
 // ignore-aarch64
 // ignore-s390x
+// ignore-emscripten
 
 #![feature(asm, rustc_attrs)]
 

--- a/src/test/compile-fail/asm-in-bad-modifier.rs
+++ b/src/test/compile-fail/asm-in-bad-modifier.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-s390x
+// ignore-emscripten
 
 #![feature(asm)]
 

--- a/src/test/compile-fail/asm-misplaced-option.rs
+++ b/src/test/compile-fail/asm-misplaced-option.rs
@@ -12,6 +12,7 @@
 // ignore-arm
 // ignore-aarch64
 // ignore-s390x
+// ignore-emscripten
 
 #![feature(asm, rustc_attrs)]
 

--- a/src/test/compile-fail/asm-out-assign-imm.rs
+++ b/src/test/compile-fail/asm-out-assign-imm.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-s390x
+// ignore-emscripten
 
 #![feature(asm)]
 

--- a/src/test/compile-fail/asm-out-no-modifier.rs
+++ b/src/test/compile-fail/asm-out-no-modifier.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-s390x
+// ignore-emscripten
 
 #![feature(asm)]
 

--- a/src/test/compile-fail/asm-out-read-uninit.rs
+++ b/src/test/compile-fail/asm-out-read-uninit.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-s390x
+// ignore-emscripten
 
 #![feature(asm)]
 

--- a/src/test/compile-fail/asm-src-loc-codegen-units.rs
+++ b/src/test/compile-fail/asm-src-loc-codegen-units.rs
@@ -12,6 +12,7 @@
 // ignore-stage1
 // compile-flags: -C codegen-units=2
 // error-pattern: build without -C codegen-units for more exact errors
+// ignore-emscripten
 
 #![feature(asm)]
 

--- a/src/test/compile-fail/asm-src-loc.rs
+++ b/src/test/compile-fail/asm-src-loc.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
+
 #![feature(asm)]
 
 fn main() {

--- a/src/test/compile-fail/cdylib-deps-must-be-static.rs
+++ b/src/test/compile-fail/cdylib-deps-must-be-static.rs
@@ -11,6 +11,7 @@
 // error-pattern: dependency `cdylib_dep` not found in rlib format
 // aux-build:cdylib-dep.rs
 // ignore-musl
+// ignore-emscripten
 
 #![crate_type = "cdylib"]
 

--- a/src/test/compile-fail/macro-expanded-include/test.rs
+++ b/src/test/compile-fail/macro-expanded-include/test.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
+
 #![feature(asm, rustc_attrs)]
 #![allow(unused)]
 

--- a/src/test/compile-fail/panic-runtime/abort-link-to-unwind-dylib.rs
+++ b/src/test/compile-fail/panic-runtime/abort-link-to-unwind-dylib.rs
@@ -10,6 +10,7 @@
 
 // compile-flags:-C panic=abort -C prefer-dynamic
 // ignore-musl - no dylibs here
+// ignore-emscripten
 // error-pattern:`panic_unwind` is not compiled with this crate's panic strategy
 
 // This is a test where the local crate, compiled with `panic=abort`, links to

--- a/src/test/compile-fail/two-allocators-3.rs
+++ b/src/test/compile-fail/two-allocators-3.rs
@@ -11,6 +11,7 @@
 // aux-build:allocator1.rs
 // error-pattern: cannot link together two allocators
 // ignore-musl no dylibs on musl yet
+// ignore-emscripten
 
 // We're linking std dynamically (via -C prefer-dynamic for this test) which
 // has an allocator and then we're also linking in a new allocator (allocator1)

--- a/src/test/run-pass-valgrind/down-with-thread-dtors.rs
+++ b/src/test/run-pass-valgrind/down-with-thread-dtors.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // no-prefer-dynamic
+// ignore-emscripten
 
 thread_local!(static FOO: Foo = Foo);
 thread_local!(static BAR: Bar = Bar(1));

--- a/src/test/run-pass-valgrind/exit-flushes.rs
+++ b/src/test/run-pass-valgrind/exit-flushes.rs
@@ -11,6 +11,7 @@
 // no-prefer-dynamic
 // ignore-macos this needs valgrind 3.11 or higher; see
 // https://github.com/rust-lang/rust/pull/30365#issuecomment-165763679
+// ignore-emscripten
 
 use std::env;
 use std::process::{exit, Command};

--- a/src/test/run-pass/i128-ffi.rs
+++ b/src/test/run-pass/i128-ffi.rs
@@ -20,6 +20,8 @@
 // Ignore 32 bit targets:
 // ignore-x86, ignore-arm
 
+// ignore-emscripten
+
 #![feature(i128_type)]
 
 #[link(name = "rust_test_helpers", kind = "static")]

--- a/src/test/run-pass/i128.rs
+++ b/src/test/run-pass/i128.rs
@@ -10,6 +10,9 @@
 
 // ignore-stage0
 // ignore-stage1
+
+// ignore-emscripten
+
 #![feature(i128_type, test)]
 
 extern crate test;

--- a/src/test/run-pass/stdio-is-blocking.rs
+++ b/src/test/run-pass/stdio-is-blocking.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
+
 use std::env;
 use std::io::prelude::*;
 use std::process::Command;

--- a/src/test/run-pass/try-wait.rs
+++ b/src/test/run-pass/try-wait.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-emscripten
+
 #![feature(process_try_wait)]
 
 use std::env;

--- a/src/test/run-pass/u128.rs
+++ b/src/test/run-pass/u128.rs
@@ -10,6 +10,9 @@
 
 // ignore-stage0
 // ignore-stage1
+
+// ignore-emscripten
+
 #![feature(i128_type, test)]
 
 extern crate test;


### PR DESCRIPTION
This commit adds a new entry to the Travis matrix which will execute emscripten
test suites. Along the way it updates a few bits of the test suite to continue
passing on emscripten, such as:

* Ignoring i128/u128 tests as they're presumably just not working (didn't
  investigate as to why)
* Disabling a few process tests (not working on emscripten)
* Ignore some num tests in libstd (#39119)
* Fix some warnings when compiling