### PR TITLE
Change unreachable pattern ICEs to warnings

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1834,13 +1834,10 @@ impl<'a> LoweringContext<'a> {
                 ExprKind::Try(ref sub_expr) => {
                     // to:
                     //
-                    // #[allow(unreachable_patterns)]
                     // match Carrier::translate(<expr>) {
-                    //     Ok(val) => {
-                    //         #[allow(unreachable_code)]
-                    //         val
-                    //     }
-                    //     Err(err) => return Carrier::from_error(From::from(err))
+                    //     Ok(val) => #[allow(unreachable_code)] val,
+                    //     Err(err) => #[allow(unreachable_code)]
+                    //                 return Carrier::from_error(From::from(err)),
                     // }
                     let unstable_span = self.allow_internal_unstable("?", e.span);
 

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1815,8 +1815,7 @@ impl<'a> LoweringContext<'a> {
                     let match_expr = P(self.expr_match(e.span,
                                                        into_iter_expr,
                                                        hir_vec![iter_arm],
-                                                       hir::MatchSource::ForLoopDesugar,
-                                                       ThinVec::new()));
+                                                       hir::MatchSource::ForLoopDesugar));
 
                     // `{ let _result = ...; _result }`
                     // underscore prevents an unused_variables lint if the head diverges
@@ -1911,23 +1910,8 @@ impl<'a> LoweringContext<'a> {
                         self.arm(hir_vec![err_pat], ret_expr)
                     };
 
-                    // #[allow(unreachable_patterns)]
-                    let match_attr = {
-                        // allow(unreachable_patterns)
-                        let allow = {
-                            let allow_ident = self.str_to_ident("allow");
-                            let up_ident = self.str_to_ident("unreachable_patterns");
-                            let up_meta_item = attr::mk_spanned_word_item(e.span, up_ident);
-                            let up_nested = NestedMetaItemKind::MetaItem(up_meta_item);
-                            let up_spanned = respan(e.span, up_nested);
-                            attr::mk_spanned_list_item(e.span, allow_ident, vec![up_spanned])
-                        };
-                        attr::mk_spanned_attr_outer(e.span, attr::mk_attr_id(), allow)
-                    };
-
-                    let attrs = From::from(vec![match_attr]);
                     return self.expr_match(e.span, discr, hir_vec![err_arm, ok_arm],
-                                           hir::MatchSource::TryDesugar, attrs);
+                                           hir::MatchSource::TryDesugar);
                 }
 
                 ExprKind::Mac(_) => panic!("Shouldn't exist here"),
@@ -2110,10 +2094,9 @@ impl<'a> LoweringContext<'a> {
                   span: Span,
                   arg: P<hir::Expr>,
                   arms: hir::HirVec<hir::Arm>,
-                  source: hir::MatchSource,
-                  attrs: ThinVec<Attribute>)
+                  source: hir::MatchSource)
                   -> hir::Expr {
-        self.expr(span, hir::ExprMatch(arg, arms, source), attrs)
+        self.expr(span, hir::ExprMatch(arg, arms, source), ThinVec::new())
     }
 
     fn expr_block(&mut self, b: P<hir::Block>, attrs: ThinVec<Attribute>) -> hir::Expr {

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1869,20 +1869,21 @@ impl<'a> LoweringContext<'a> {
                     };
                     let attrs = vec![attr];
 
-                    // Ok(val) => { #[allow(unreachable_code)] val }
+                    // Ok(val) => #[allow(unreachable_code)] val,
                     let ok_arm = {
                         let val_ident = self.str_to_ident("val");
                         let val_pat = self.pat_ident(e.span, val_ident);
                         let val_expr = P(self.expr_ident_with_attrs(e.span,
                                                                     val_ident,
                                                                     val_pat.id,
-                                                                    From::from(attrs.clone())));
+                                                                    ThinVec::from(attrs.clone())));
                         let ok_pat = self.pat_ok(e.span, val_pat);
 
                         self.arm(hir_vec![ok_pat], val_expr)
                     };
 
-                    // Err(err) => return Carrier::from_error(From::from(err))
+                    // Err(err) => #[allow(unreachable_code)]
+                    //             return Carrier::from_error(From::from(err)),
                     let err_arm = {
                         let err_ident = self.str_to_ident("err");
                         let err_local = self.pat_ident(e.span, err_ident);
@@ -1902,7 +1903,7 @@ impl<'a> LoweringContext<'a> {
 
                         let ret_expr = P(self.expr(e.span,
                                                    hir::Expr_::ExprRet(Some(from_err_expr)),
-                                                                       From::from(attrs)));
+                                                                       ThinVec::from(attrs)));
 
                         let err_pat = self.pat_err(e.span, err_local);
                         self.arm(hir_vec![err_pat], ret_expr)

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1876,12 +1876,9 @@ impl<'a> LoweringContext<'a> {
                                                                     val_ident,
                                                                     val_pat.id,
                                                                     attrs));
-                        let val_block = P(self.block_expr(val_expr));
-                        let ok_expr = P(self.expr_block(val_block, ThinVec::new()));
-
                         let ok_pat = self.pat_ok(e.span, val_pat);
 
-                        self.arm(hir_vec![ok_pat], ok_expr)
+                        self.arm(hir_vec![ok_pat], val_expr)
                     };
 
                     // Err(err) => return Carrier::from_error(From::from(err))

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1866,14 +1866,17 @@ impl<'a> LoweringContext<'a> {
                                 let allow_ident = self.str_to_ident("allow");
                                 let uc_ident = self.str_to_ident("unreachable_code");
                                 let uc_meta_item = attr::mk_spanned_word_item(e.span, uc_ident);
-                                let uc_nested_meta_item = NestedMetaItemKind::MetaItem(uc_meta_item);
-                                let uc_spanned = respan(e.span, uc_nested_meta_item);
+                                let uc_nested = NestedMetaItemKind::MetaItem(uc_meta_item);
+                                let uc_spanned = respan(e.span, uc_nested);
                                 attr::mk_spanned_list_item(e.span, allow_ident, vec![uc_spanned])
                             };
                             attr::mk_spanned_attr_outer(e.span, attr::mk_attr_id(), allow)
                         };
                         let attrs = From::from(vec![val_attr]);
-                        let val_expr = P(self.expr_ident_with_attrs(e.span, val_ident, val_pat.id, attrs));
+                        let val_expr = P(self.expr_ident_with_attrs(e.span,
+                                                                    val_ident,
+                                                                    val_pat.id,
+                                                                    attrs));
                         let val_block = P(self.block_expr(val_expr));
                         let ok_expr = P(self.expr_block(val_block, ThinVec::new()));
 
@@ -1915,8 +1918,8 @@ impl<'a> LoweringContext<'a> {
                             let allow_ident = self.str_to_ident("allow");
                             let up_ident = self.str_to_ident("unreachable_patterns");
                             let up_meta_item = attr::mk_spanned_word_item(e.span, up_ident);
-                            let up_nested_meta_item = NestedMetaItemKind::MetaItem(up_meta_item);
-                            let up_spanned = respan(e.span, up_nested_meta_item);
+                            let up_nested = NestedMetaItemKind::MetaItem(up_meta_item);
+                            let up_spanned = respan(e.span, up_nested);
                             attr::mk_spanned_list_item(e.span, allow_ident, vec![up_spanned])
                         };
                         attr::mk_spanned_attr_outer(e.span, attr::mk_attr_id(), allow)

--- a/src/librustc_const_eval/check_match.rs
+++ b/src/librustc_const_eval/check_match.rs
@@ -322,6 +322,8 @@ fn check_arms<'a, 'tcx>(cx: &mut MatchCheckCtxt<'a, 'tcx>,
                                                             hir_pat.id, diagnostic);
                         },
 
+                        // Unreachable patterns in try expressions occur when one of the arms
+                        // are an uninhabited type. Which is OK.
                         hir::MatchSource::TryDesugar => {}
                     }
                 }

--- a/src/librustc_const_eval/check_match.rs
+++ b/src/librustc_const_eval/check_match.rs
@@ -308,14 +308,7 @@ fn check_arms<'a, 'tcx>(cx: &mut MatchCheckCtxt<'a, 'tcx>,
                                 .emit();
                         },
 
-                        hir::MatchSource::ForLoopDesugar => {
-                            // this is a bug, because on `match iter.next()` we cover
-                            // `Some(<head>)` and `None`. It's impossible to have an unreachable
-                            // pattern
-                            // (see libsyntax/ext/expand.rs for the full expansion of a for loop)
-                            span_bug!(pat.span, "unreachable for-loop pattern")
-                        },
-
+                        hir::MatchSource::ForLoopDesugar |
                         hir::MatchSource::Normal => {
                             let mut diagnostic = Diagnostic::new(Level::Warning,
                                                                  "unreachable pattern");
@@ -329,9 +322,7 @@ fn check_arms<'a, 'tcx>(cx: &mut MatchCheckCtxt<'a, 'tcx>,
                                                             hir_pat.id, diagnostic);
                         },
 
-                        hir::MatchSource::TryDesugar => {
-                            span_bug!(pat.span, "unreachable try pattern")
-                        },
+                        hir::MatchSource::TryDesugar => {}
                     }
                 }
                 Useful => (),

--- a/src/test/compile-fail/recursive-types-are-not-uninhabited.rs
+++ b/src/test/compile-fail/recursive-types-are-not-uninhabited.rs
@@ -1,0 +1,26 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//#![feature(never_type)]
+
+struct R<'a> {
+    r: &'a R<'a>,
+}
+
+fn foo(res: Result<u32, &R>) -> u32 {
+    let Ok(x) = res;
+    //~^ ERROR refutable pattern
+    x
+}
+
+fn main() {
+    foo(Ok(23));
+}
+

--- a/src/test/compile-fail/unreachable-loop-patterns.rs
+++ b/src/test/compile-fail/unreachable-loop-patterns.rs
@@ -1,0 +1,20 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(never_type)]
+#![deny(unreachable_patterns)]
+
+fn main() {
+    let x: &[!] = &[];
+
+    for _ in x {}
+    //~^ ERROR unreachable pattern
+}
+

--- a/src/test/compile-fail/unreachable-try-pattern.rs
+++ b/src/test/compile-fail/unreachable-try-pattern.rs
@@ -16,7 +16,15 @@ fn bar(x: Result<!, i32>) -> Result<u32, i32> {
     x?
 }
 
+fn foo(x: Result<!, i32>) -> Result<u32, i32> {
+    let y = (match x { Ok(n) => Ok(n as u32), Err(e) => Err(e) })?;
+    //~^ ERROR unreachable pattern
+    //~| ERROR unreachable expression
+    Ok(y)
+}
+
 fn main() {
     let _ = bar(Err(123));
+    let _ = foo(Err(123));
 }
 

--- a/src/test/compile-fail/unreachable-try-pattern.rs
+++ b/src/test/compile-fail/unreachable-try-pattern.rs
@@ -12,6 +12,14 @@
 #![deny(unreachable_code)]
 #![deny(unreachable_patterns)]
 
+enum Void {}
+
+impl From<Void> for i32 {
+    fn from(v: Void) -> i32 {
+        match v {}
+    }
+}
+
 fn bar(x: Result<!, i32>) -> Result<u32, i32> {
     x?
 }
@@ -23,8 +31,20 @@ fn foo(x: Result<!, i32>) -> Result<u32, i32> {
     Ok(y)
 }
 
+fn qux(x: Result<u32, Void>) -> Result<u32, i32> {
+    Ok(x?)
+}
+
+fn vom(x: Result<u32, Void>) -> Result<u32, i32> {
+    let y = (match x { Ok(n) => Ok(n), Err(e) => Err(e) })?;
+    //~^ ERROR unreachable pattern
+    Ok(y)
+}
+
 fn main() {
     let _ = bar(Err(123));
     let _ = foo(Err(123));
+    let _ = qux(Ok(123));
+    let _ = vom(Ok(123));
 }
 

--- a/src/test/run-pass/unreachable-try-pattern.rs
+++ b/src/test/run-pass/unreachable-try-pattern.rs
@@ -1,0 +1,22 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(never_type)]
+#![deny(unreachable_code)]
+#![deny(unreachable_patterns)]
+
+fn bar(x: Result<!, i32>) -> Result<u32, i32> {
+    x?
+}
+
+fn main() {
+    let _ = bar(Err(123));
+}
+


### PR DESCRIPTION
Allow code with unreachable `?` and `for` patterns to compile.
Add some tests.