### PR TITLE
travis: Pass --enable-llvm-static-stdcpp

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -43,6 +43,7 @@ fi
 #        either automatically or manually.
 if [ "$DEPLOY" != "" ]; then
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=nightly"
+  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"
 
   if [ "$NO_LLVM_ASSERTIONS" = "1" ]; then
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --disable-llvm-assertions"


### PR DESCRIPTION
All our releases are compiled with this, so let's be sure to do so whenever
`DEPLOY` is set. This'll ensure that we don't have dynamic dependencies on
libstdc++ which LLVM depends on, but instead we link it all statically to have
more portable binaries.