### PR TITLE
Stop warning when doc testing proc macro crates

### DIFF
--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -67,6 +67,7 @@ pub fn run(input: &str,
         crate_types: vec![config::CrateTypeDylib],
         externs: externs.clone(),
         unstable_features: UnstableFeatures::from_environment(),
+        actually_rustdoc: true,
         ..config::basic_options().clone()
     };
 

--- a/src/test/run-pass-fulldeps/proc-macro/derive-test.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/derive-test.rs
@@ -17,6 +17,9 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 
+// ```
+// assert!(true);
+// ```
 #[proc_macro_derive(Foo)]
 pub fn derive_foo(_input: TokenStream) -> TokenStream {
     "".parse().unwrap()


### PR DESCRIPTION
Fixes #39064

Add the test option to the session struct that is passed
to phase_2_configure_and_expand function inside the
rustdoc test module.

This prevents the warning code from triggering when
parsing proc_macro_derive attributes, just like when
`--test` is normally invoked.

This change makes the warning disappear, but I'm not sure what else it might change. So this early PR is mainly to run the test suite, and to get feedback.