### PR TITLE
check inherent impls of traits for overlap as well

### DIFF
--- a/src/librustc_typeck/coherence/overlap.rs
+++ b/src/librustc_typeck/coherence/overlap.rs
@@ -102,6 +102,7 @@ impl<'cx, 'tcx, 'v> ItemLikeVisitor<'v> for OverlapChecker<'cx, 'tcx> {
         match item.node {
             hir::ItemEnum(..) |
             hir::ItemStruct(..) |
+            hir::ItemTrait(..) |
             hir::ItemUnion(..) => {
                 let type_def_id = self.tcx.map.local_def_id(item.id);
                 self.check_for_overlapping_inherent_impls(type_def_id);

--- a/src/test/compile-fail/coherence-overlapping-inherent-impl-trait.rs
+++ b/src/test/compile-fail/coherence-overlapping-inherent-impl-trait.rs
@@ -1,0 +1,17 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(dead_code)]
+#![deny(overlapping_inherent_impls)]
+
+trait C {}
+impl C { fn f() {} } //~ ERROR duplicate definitions with name `f`
+impl C { fn f() {} }
+fn main() { }


### PR DESCRIPTION
Simple oversight. Fixes #38967.

r? @eddyb 

