### PR TITLE
Feature gate `&Void`'s uninhabitedness.

### DIFF
--- a/src/librustc/ty/inhabitedness/mod.rs
+++ b/src/librustc/ty/inhabitedness/mod.rs
@@ -190,7 +190,13 @@ impl<'a, 'gcx, 'tcx> TyS<'tcx> {
                     ty.uninhabited_from(visited, tcx)
                 }
             }
-            TyRef(_, ref tm) => tm.ty.uninhabited_from(visited, tcx),
+            TyRef(_, ref tm) => {
+                if tcx.sess.features.borrow().never_type {
+                    tm.ty.uninhabited_from(visited, tcx)
+                } else {
+                    DefIdForest::empty()
+                }
+            }
 
             _ => DefIdForest::empty(),
         }

--- a/src/test/compile-fail/uninhabited-reference-type-feature-gated.rs
+++ b/src/test/compile-fail/uninhabited-reference-type-feature-gated.rs
@@ -1,0 +1,19 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum Void {}
+
+fn main() {
+    let x: Result<u32, &'static Void> = Ok(23);
+    let _ = match x {   //~ ERROR non-exhaustive
+        Ok(n) => n,
+    };
+}
+

--- a/src/test/run-pass/empty-types-in-patterns.rs
+++ b/src/test/run-pass/empty-types-in-patterns.rs
@@ -55,6 +55,11 @@ fn main() {
         Err(e) => match e {},
     };
 
+    let x: Result<u32, &!> = Ok(123);
+    match x {
+        Ok(y) => y,
+    };
+
     bar(&[]);
 }
 


### PR DESCRIPTION
Here's a totally crazy PR which should never be merged.