### PR TITLE
Add regression test for debuginfo + LTO

### DIFF
--- a/src/test/run-pass/auxiliary/debuginfo-lto-aux.rs
+++ b/src/test/run-pass/auxiliary/debuginfo-lto-aux.rs
@@ -1,0 +1,39 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -g --crate-type=rlib
+
+pub struct StructWithLifetime<'a>(&'a i32);
+pub fn mk_struct_with_lt<'a>(x: &'a i32) -> StructWithLifetime<'a> {
+    StructWithLifetime(x)
+}
+
+pub struct RegularStruct(u32);
+pub fn mk_regular_struct(x: u32) -> RegularStruct {
+    RegularStruct(x)
+}
+
+pub fn take_fn(f: fn(i32) -> i32, x: i32) -> i32 {
+    f(x)
+}
+
+pub fn with_closure(x: i32) -> i32 {
+    let closure = |i| { x + i };
+
+    closure(1) + closure(2)
+}
+
+pub fn generic_fn<T>(x: T) -> (T, u32) {
+    (x, 1)
+}
+
+pub fn user_of_generic_fn(x: f32) -> (f32, u32) {
+    generic_fn(x)
+}

--- a/src/test/run-pass/auxiliary/sepcomp_lib.rs
+++ b/src/test/run-pass/auxiliary/sepcomp_lib.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -C codegen-units=3 --crate-type=rlib,dylib
+// compile-flags: -C codegen-units=3 --crate-type=rlib,dylib -g
 
 pub mod a {
     pub fn one() -> usize {

--- a/src/test/run-pass/debuginfo-lto.rs
+++ b/src/test/run-pass/debuginfo-lto.rs
@@ -1,0 +1,33 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This test case makes sure that we don't run into LLVM's dreaded
+// "possible ODR violation" assertion when compiling with LTO + Debuginfo.
+// It covers cases that have traditionally been prone to cause this error.
+// If new cases emerge, add them to this file.
+
+// aux-build:debuginfo-lto-aux.rs
+// compile-flags: -C lto -g
+// no-prefer-dynamic
+
+extern crate debuginfo_lto_aux;
+
+fn some_fn(x: i32) -> i32 {
+    x + 1
+}
+
+fn main() {
+    let i = 0;
+    let _ = debuginfo_lto_aux::mk_struct_with_lt(&i);
+    let _ = debuginfo_lto_aux::mk_regular_struct(1);
+    let _ = debuginfo_lto_aux::take_fn(some_fn, 1);
+    let _ = debuginfo_lto_aux::with_closure(22);
+    let _ = debuginfo_lto_aux::generic_fn(0f32);
+}

--- a/src/test/run-pass/sepcomp-lib-lto.rs
+++ b/src/test/run-pass/sepcomp-lib-lto.rs
@@ -12,7 +12,7 @@
 // separately compiled.
 
 // aux-build:sepcomp_lib.rs
-// compile-flags: -C lto
+// compile-flags: -C lto -g
 // no-prefer-dynamic
 // ignore-android FIXME #18800
 


### PR DESCRIPTION
Fixes #25270, which cannot be reproduced with the current nightly version of the compiler anymore (due to various fixes to debuginfo generation in the past).

Should we run into the "possible ODR violation" again, the test added by this PR can be extend with the new case.

r? @alexcrichton 