### PR TITLE
travis: Stop uploading sha256 files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,11 +119,9 @@ before_deploy:
   - mkdir -p deploy/$TRAVIS_COMMIT
   - >
       if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-          cp build/dist/*.tar.gz deploy/$TRAVIS_COMMIT &&
-          find "deploy/$TRAVIS_COMMIT" -maxdepth 1 -type f -exec sh -c 'shasum -a 256 -b "{}" > "{}.sha256"' \;;
+          cp build/dist/*.tar.gz deploy/$TRAVIS_COMMIT;
       else
-          cp obj/build/dist/*.tar.gz deploy/$TRAVIS_COMMIT &&
-          find "deploy/$TRAVIS_COMMIT" -maxdepth 1 -type f -exec sh -c 'sha256sum -b "{}" > "{}.sha256"' \;;
+          cp obj/build/dist/*.tar.gz deploy/$TRAVIS_COMMIT;
       fi
 
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -131,9 +131,6 @@ before_deploy:
   - ps: |
         New-Item -Path deploy -ItemType directory
         Get-ChildItem -Path build\dist -Filter '*.tar.gz' | Move-Item -Destination deploy
-        Get-FileHash .\deploy\* | ForEach-Object {
-          [io.file]::WriteAllText($_.Path + ".sha256", $_.Hash.ToLower() + "`n")
-        }
         Get-ChildItem -Path deploy | Foreach-Object {
           Push-AppveyorArtifact $_.FullName -FileName ${env:APPVEYOR_REPO_COMMIT}/$_
         }
@@ -147,7 +144,7 @@ deploy:
     bucket: rust-lang-ci
     set_public: true
     region: us-east-1
-    artifact: /.*\.(tar.gz|sha256)/
+    artifact: /.*\.tar.gz/
     folder: rustc-builds
     on:
       branch: auto


### PR DESCRIPTION
We'll generate these later in the build process and otherwise they could just
cause spurious failures with files overwriting one another.

cc #38531