### PR TITLE
Use multiline Diagnostic for candidate in other module

### DIFF
--- a/src/test/ui/resolve/enums-are-namespaced-xc.stderr
+++ b/src/test/ui/resolve/enums-are-namespaced-xc.stderr
@@ -5,7 +5,7 @@ error[E0425]: cannot find value `A` in module `namespaced_enums`
    |             ^^^^^^^^^^^^^^^^^^^ not found in `namespaced_enums`
    |
    = help: possible candidate is found in another module, you can import it into scope:
-   = help:   `use namespaced_enums::Foo::A;`
+             `use namespaced_enums::Foo::A;`
 
 error[E0425]: cannot find function `B` in module `namespaced_enums`
   --> $DIR/enums-are-namespaced-xc.rs:18:13
@@ -14,7 +14,7 @@ error[E0425]: cannot find function `B` in module `namespaced_enums`
    |             ^^^^^^^^^^^^^^^^^^^ not found in `namespaced_enums`
    |
    = help: possible candidate is found in another module, you can import it into scope:
-   = help:   `use namespaced_enums::Foo::B;`
+             `use namespaced_enums::Foo::B;`
 
 error[E0422]: cannot find struct, variant or union type `C` in module `namespaced_enums`
   --> $DIR/enums-are-namespaced-xc.rs:21:13
@@ -23,7 +23,7 @@ error[E0422]: cannot find struct, variant or union type `C` in module `namespace
    |             ^^^^^^^^^^^^^^^^^^^ not found in `namespaced_enums`
    |
    = help: possible candidate is found in another module, you can import it into scope:
-   = help:   `use namespaced_enums::Foo::C;`
+             `use namespaced_enums::Foo::C;`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/resolve/issue-16058.stderr
+++ b/src/test/ui/resolve/issue-16058.stderr
@@ -5,9 +5,9 @@ error[E0574]: expected struct, variant or union type, found enum `Result`
    |         ^^^^^^ not a struct, variant or union type
    |
    = help: possible better candidates are found in other modules, you can import them into scope:
-   = help:   `use std::fmt::Result;`
-   = help:   `use std::io::Result;`
-   = help:   `use std::thread::Result;`
+             `use std::fmt::Result;`
+             `use std::io::Result;`
+             `use std::thread::Result;`
 
 error: aborting due to previous error
 

--- a/src/test/ui/resolve/issue-17518.stderr
+++ b/src/test/ui/resolve/issue-17518.stderr
@@ -5,7 +5,7 @@ error[E0422]: cannot find struct, variant or union type `E` in this scope
    |     ^ not found in this scope
    |
    = help: possible candidate is found in another module, you can import it into scope:
-   = help:   `use SomeEnum::E;`
+             `use SomeEnum::E;`
 
 error: aborting due to previous error
 

--- a/src/test/ui/resolve/issue-21221-1.stderr
+++ b/src/test/ui/resolve/issue-21221-1.stderr
@@ -5,9 +5,9 @@ error[E0405]: cannot find trait `Mul` in this scope
    |      ^^^ not found in this scope
    |
    = help: possible candidates are found in other modules, you can import them into scope:
-   = help:   `use mul1::Mul;`
-   = help:   `use mul2::Mul;`
-   = help:   `use std::ops::Mul;`
+             `use mul1::Mul;`
+             `use mul2::Mul;`
+             `use std::ops::Mul;`
 
 error[E0412]: cannot find type `Mul` in this scope
   --> $DIR/issue-21221-1.rs:72:16
@@ -16,11 +16,11 @@ error[E0412]: cannot find type `Mul` in this scope
    |                ^^^ not found in this scope
    |
    = help: possible candidates are found in other modules, you can import them into scope:
-   = help:   `use mul1::Mul;`
-   = help:   `use mul2::Mul;`
-   = help:   `use mul3::Mul;`
-   = help:   `use mul4::Mul;`
-   = help:   and 2 other candidates
+             `use mul1::Mul;`
+             `use mul2::Mul;`
+             `use mul3::Mul;`
+             `use mul4::Mul;`
+           and 2 other candidates
 
 error[E0405]: cannot find trait `ThisTraitReallyDoesntExistInAnyModuleReally` in this scope
   --> $DIR/issue-21221-1.rs:83:6
@@ -35,7 +35,7 @@ error[E0405]: cannot find trait `Div` in this scope
    |      ^^^ not found in this scope
    |
    = help: possible candidate is found in another module, you can import it into scope:
-   = help:   `use std::ops::Div;`
+             `use std::ops::Div;`
 
 error: cannot continue compilation due to previous error
 

--- a/src/test/ui/resolve/issue-21221-2.stderr
+++ b/src/test/ui/resolve/issue-21221-2.stderr
@@ -5,7 +5,7 @@ error[E0405]: cannot find trait `T` in this scope
    |      ^ not found in this scope
    |
    = help: possible candidate is found in another module, you can import it into scope:
-   = help:   `use foo::bar::T;`
+             `use foo::bar::T;`
 
 error: main function not found
 

--- a/src/test/ui/resolve/issue-21221-3.stderr
+++ b/src/test/ui/resolve/issue-21221-3.stderr
@@ -5,7 +5,7 @@ error[E0405]: cannot find trait `OuterTrait` in this scope
    |      ^^^^^^^^^^ not found in this scope
    |
    = help: possible candidate is found in another module, you can import it into scope:
-   = help:   `use issue_21221_3::outer::OuterTrait;`
+             `use issue_21221_3::outer::OuterTrait;`
 
 error: cannot continue compilation due to previous error
 

--- a/src/test/ui/resolve/issue-21221-4.stderr
+++ b/src/test/ui/resolve/issue-21221-4.stderr
@@ -5,7 +5,7 @@ error[E0405]: cannot find trait `T` in this scope
    |      ^ not found in this scope
    |
    = help: possible candidate is found in another module, you can import it into scope:
-   = help:   `use issue_21221_4::T;`
+             `use issue_21221_4::T;`
 
 error: cannot continue compilation due to previous error
 

--- a/src/test/ui/resolve/issue-3907.stderr
+++ b/src/test/ui/resolve/issue-3907.stderr
@@ -5,7 +5,7 @@ error[E0404]: expected trait, found type alias `Foo`
    |      ^^^ type aliases cannot be used for traits
    |
    = help: possible better candidate is found in another module, you can import it into scope:
-   = help:   `use issue_3907::Foo;`
+             `use issue_3907::Foo;`
 
 error: cannot continue compilation due to previous error
 

--- a/src/test/ui/span/issue-35987.stderr
+++ b/src/test/ui/span/issue-35987.stderr
@@ -5,7 +5,7 @@ error[E0404]: expected trait, found type parameter `Add`
    |                     ^^^ not a trait
    |
    = help: possible better candidate is found in another module, you can import it into scope:
-   = help:   `use std::ops::Add;`
+             `use std::ops::Add;`
 
 error: main function not found
 


### PR DESCRIPTION
```
error[E0574]: expected struct, variant or union type, found enum `Result`
  --> $DIR/issue-16058.rs:19:9
   |
19 |         Result {
   |         ^^^^^^ not a struct, variant or union type
   |
   = help: possible better candidates are found in other modules, you can import them into scope:
             `use std::fmt::Result;`
             `use std::io::Result;`
             `use std::thread::Result;`

error: aborting due to previous error
```