### PR TITLE
Use fs::symlink_metadata in doc for is_symlink

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -89,12 +89,11 @@ pub struct File {
 
 /// Metadata information about a file.
 ///
-/// This structure is returned from the [`metadata`] or [`symlink_metadata`]
-/// functions or methods and represents known metadata about a file such as
-/// its permissions, size, modification times, etc.
+/// This structure is returned from the [`metadata`] function or method and
+/// represents known metadata about a file such as its permissions, size,
+/// modification times, etc.
 ///
 /// [`metadata`]: fn.metadata.html
-/// [`symlink_metadata`]: fn.symlink_metadata.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Clone)]
 pub struct Metadata(fs_imp::FileAttr);

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -975,13 +975,18 @@ impl FileType {
 
     /// Test whether this file type represents a symbolic link.
     ///
+    /// The Metadata struct needs to be retreived with
+    /// fs::symlink_metadata() not fs::metadata(). metadata()
+    /// always follows symbolic links, so is_symlink will
+    /// always return false for the underlying file.
+    ///
     /// # Examples
     ///
     /// ```
     /// # fn foo() -> std::io::Result<()> {
     /// use std::fs;
     ///
-    /// let metadata = try!(fs::metadata("foo.txt"));
+    /// let metadata = try!(fs::symlink_metadata("foo.txt"));
     /// let file_type = metadata.file_type();
     ///
     /// assert_eq!(file_type.is_symlink(), false);

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -89,11 +89,12 @@ pub struct File {
 
 /// Metadata information about a file.
 ///
-/// This structure is returned from the [`metadata`] function or method and
-/// represents known metadata about a file such as its permissions, size,
-/// modification times, etc.
+/// This structure is returned from the [`metadata`] or [`symlink_metadata`]
+/// functions or methods and represents known metadata about a file such as
+/// its permissions, size, modification times, etc.
 ///
 /// [`metadata`]: fn.metadata.html
+/// [`symlink_metadata`]: fn.symlink_metadata.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Clone)]
 pub struct Metadata(fs_imp::FileAttr);

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -975,10 +975,16 @@ impl FileType {
 
     /// Test whether this file type represents a symbolic link.
     ///
-    /// The Metadata struct needs to be retreived with
-    /// fs::symlink_metadata() not fs::metadata(). metadata()
-    /// always follows symbolic links, so is_symlink will
-    /// always return false for the underlying file.
+    /// The underlying [`Metadata`] struct needs to be retrieved
+    /// with the [`fs::symlink_metadata`] function and not the
+    /// [`fs::metadata`] function. The [`fs::metadata`] function
+    /// follows symbolic links, so [`is_symlink`] would always
+    /// return false for the target file.
+    ///
+    /// [`Metadata`]: struct.Metadata.html
+    /// [`fs::metadata`]: fn.metadata.html
+    /// [`fs::symlink_metadata`]: fn.symlink_metadata.html
+    /// [`is_symlink`]: struct.FileType.html#method.is_symlink
     ///
     /// # Examples
     ///


### PR DESCRIPTION
fs::metadata() follows symlinks so is_symlink() will always return
false. Use symlink_metadata instead in the example in the
documentation.

See issue #39088.