### PR TITLE
Fix regression in parsing of trait object types

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1277,10 +1277,17 @@ impl<'a> Parser<'a> {
                           "at least one type parameter bound \
                           must be specified");
         }
-        if let TyKind::Path(None, ref path) = lhs.node {
+
+        let mut lhs = lhs.unwrap();
+        if let TyKind::Paren(ty) = lhs.node {
+            // We have to accept the first bound in parens for backward compatibility.
+            // Example: `(Bound) + Bound + Bound`
+            lhs = ty.unwrap();
+        }
+        if let TyKind::Path(None, path) = lhs.node {
             let poly_trait_ref = PolyTraitRef {
                 bound_lifetimes: Vec::new(),
-                trait_ref: TraitRef { path: path.clone(), ref_id: lhs.id },
+                trait_ref: TraitRef { path: path, ref_id: lhs.id },
                 span: lhs.span,
             };
             let poly_trait_ref = TraitTyParamBound(poly_trait_ref, TraitBoundModifier::None);

--- a/src/test/parse-fail/bounds-obj-parens.rs
+++ b/src/test/parse-fail/bounds-obj-parens.rs
@@ -1,0 +1,15 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z parse-only
+
+type A = Box<(Fn(D::Error) -> E) + 'static + Send + Sync>; // OK
+
+FAIL //~ ERROR


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/39169

Accepting parens in this position is a regression itself, introduced in Rust 1.6 by https://github.com/rust-lang/rust/pull/29870, so I hope to revert this in my next bounds refactoring patch (possibly with a warning,  crater run, etc).

r? @eddyb 