### PR TITLE
trans: Exit earlier from base::trans_crate() when compiling rmeta crates.

### DIFF
--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -667,7 +667,8 @@ pub fn run_passes(sess: &Session,
 
     // Sanity check
     assert!(trans.modules.len() == sess.opts.cg.codegen_units ||
-            sess.opts.debugging_opts.incremental.is_some());
+            sess.opts.debugging_opts.incremental.is_some() ||
+            !sess.opts.output_types.should_trans());
 
     let tm = create_target_machine(sess);
 
@@ -756,7 +757,7 @@ pub fn run_passes(sess: &Session,
     //       the compiler decides the number of codegen units (and will
     //       potentially create hundreds of them).
     let num_workers = work_items.len() - 1;
-    if num_workers == 1 {
+    if num_workers <= 1 {
         run_work_singlethreaded(sess, &trans.exported_symbols, work_items);
     } else {
         run_work_multithreaded(sess, work_items, num_workers);


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/38964.
r? @eddyb 
cc @nrc 