### PR TITLE
book: size and align in trait object vtables are used

### DIFF
--- a/src/doc/book/trait-objects.md
+++ b/src/doc/book/trait-objects.md
@@ -263,8 +263,7 @@ any resources of the vtable’s type: for `u8` it is trivial, but for `String` i
 will free the memory. This is necessary for owning trait objects like
 `Box<Foo>`, which need to clean-up both the `Box` allocation as well as the
 internal type when they go out of scope. The `size` and `align` fields store
-the size of the erased type, and its alignment requirements; these are
-used by the `std::mem::size_of_val` and `std::mem::align_of_val` functions.
+the size of the erased type, and its alignment requirements.
 
 Suppose we’ve got some values that implement `Foo`. The explicit form of
 construction and use of `Foo` trait objects might look a bit like (ignoring the

--- a/src/doc/book/trait-objects.md
+++ b/src/doc/book/trait-objects.md
@@ -264,9 +264,7 @@ will free the memory. This is necessary for owning trait objects like
 `Box<Foo>`, which need to clean-up both the `Box` allocation as well as the
 internal type when they go out of scope. The `size` and `align` fields store
 the size of the erased type, and its alignment requirements; these are
-essentially unused at the moment since the information is embedded in the
-destructor, but will be used in the future, as trait objects are progressively
-made more flexible.
+used by the `std::mem::size_of_val` and `std::mem::align_of_val` functions.
 
 Suppose we’ve got some values that implement `Foo`. The explicit form of
 construction and use of `Foo` trait objects might look a bit like (ignoring the


### PR DESCRIPTION
The book currently claims that the `size` and `align` fields in the
trait object vtable are not used, but this is false. These two fields
are used by the stable `mem::size_of_val` and `mem::align_of_val`
functions.

See the `ty::TyDynamic` case of the `glue::size_and_align_of_dst`
function in librustc_trans, which is used to implement both intrinsics
in the unsized case.

r? @steveklabnik