### PR TITLE
Document that `Metadata` can be obtained from `symlink_metadata`

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -90,11 +90,13 @@ pub struct File {
 
 /// Metadata information about a file.
 ///
-/// This structure is returned from the [`metadata`] function or method and
-/// represents known metadata about a file such as its permissions, size,
-/// modification times, etc.
+/// This structure is returned from the [`metadata`] or
+/// [`symlink_metadata`] function or method and represents known
+/// metadata about a file such as its permissions, size, modification
+/// times, etc.
 ///
 /// [`metadata`]: fn.metadata.html
+/// [`symlink_metadata`]: fn.symlink_metadata.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Clone)]
 pub struct Metadata(fs_imp::FileAttr);


### PR DESCRIPTION
When retrieving the information about a syslink (specifically, when invoking `Metadata::is_symlink`) you generally want the `syslink_metadata`. It would be natural to point at both options to retrieve a `Metadata` value, as they are both appropriate (for different use cases).
