### PR TITLE
linkchecker: Fix checking links which are just fragments

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -650,15 +650,15 @@ Rust syntax is restricted in two ways:
 
 [RFC 550]: https://github.com/rust-lang/rfcs/blob/master/text/0550-macro-future-proofing.md
 
-## Procedrual Macros
+## Procedural Macros
 
-"Procedrual macros" are the second way to implement a macro. For now, the only
+"Procedural macros" are the second way to implement a macro. For now, the only
 thing they can be used for is to implement derive on your own types. See
 [the book][procedural macros] for a tutorial.
 
 Procedural macros involve a few different parts of the language and its
 standard libraries. First is the `proc_macro` crate, included with Rust,
-that defines an interface for building a procedrual macro. The 
+that defines an interface for building a procedural macro. The
 `#[proc_macro_derive(Foo)]` attribute is used to mark the the deriving
 function. This function must have the type signature:
 
@@ -3805,7 +3805,7 @@ impl From<i32> for String {
 }
 ```
 
-The notation `Self` in the impl refers to the implementing type: `String`. In another 
+The notation `Self` in the impl refers to the implementing type: `String`. In another
 example:
 
 ```

--- a/src/tools/linkchecker/main.rs
+++ b/src/tools/linkchecker/main.rs
@@ -151,9 +151,6 @@ fn check(cache: &mut Cache,
         }
         let mut parts = url.splitn(2, "#");
         let url = parts.next().unwrap();
-        if url.is_empty() {
-            return
-        }
         let fragment = parts.next();
         let mut parts = url.splitn(2, "?");
         let url = parts.next().unwrap();
@@ -161,14 +158,16 @@ fn check(cache: &mut Cache,
         // Once we've plucked out the URL, parse it using our base url and
         // then try to extract a file path.
         let mut path = file.to_path_buf();
-        path.pop();
-        for part in Path::new(url).components() {
-            match part {
-                Component::Prefix(_) |
-                Component::RootDir => panic!(),
-                Component::CurDir => {}
-                Component::ParentDir => { path.pop(); }
-                Component::Normal(s) => { path.push(s); }
+        if !url.is_empty() {
+            path.pop();
+            for part in Path::new(url).components() {
+                match part {
+                    Component::Prefix(_) |
+                    Component::RootDir => panic!(),
+                    Component::CurDir => {}
+                    Component::ParentDir => { path.pop(); }
+                    Component::Normal(s) => { path.push(s); }
+                }
             }
         }
 


### PR DESCRIPTION
Also fix a typo which linkchecker should have caught.

It was broken by 31a8638e5e716bec90f4398a57c58fb34e492667.

r? @alexcrichton