### PR TITLE
Fix rustbuild to work with --libdir.

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -185,8 +185,14 @@ pub fn rustc(build: &Build, target: &str, compiler: &Compiler) {
     cargo.env("CFG_RELEASE", &build.release)
          .env("CFG_RELEASE_CHANNEL", &build.config.channel)
          .env("CFG_VERSION", &build.version)
-         .env("CFG_PREFIX", build.config.prefix.clone().unwrap_or(PathBuf::new()))
-         .env("CFG_LIBDIR_RELATIVE", "lib");
+         .env("CFG_PREFIX", build.config.prefix.clone().unwrap_or(PathBuf::new()));
+
+    if compiler.stage == 0 {
+        cargo.env("CFG_LIBDIR_RELATIVE", "lib");
+    } else {
+        let libdir_relative = build.config.libdir_relative.clone().unwrap_or(PathBuf::from("lib"));
+        cargo.env("CFG_LIBDIR_RELATIVE", libdir_relative);
+    }
 
     // If we're not building a compiler with debugging information then remove
     // these two env vars which would be set otherwise.

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -90,6 +90,7 @@ pub struct Config {
     pub prefix: Option<PathBuf>,
     pub docdir: Option<PathBuf>,
     pub libdir: Option<PathBuf>,
+    pub libdir_relative: Option<PathBuf>,
     pub mandir: Option<PathBuf>,
     pub codegen_tests: bool,
     pub nodejs: Option<PathBuf>,
@@ -476,6 +477,9 @@ impl Config {
                 }
                 "CFG_LIBDIR" => {
                     self.libdir = Some(PathBuf::from(value));
+                }
+                "CFG_LIBDIR_RELATIVE" => {
+                    self.libdir_relative = Some(PathBuf::from(value));
                 }
                 "CFG_MANDIR" => {
                     self.mandir = Some(PathBuf::from(value));


### PR DESCRIPTION
Similar to the makefiles, pass CFG_LIBDIR_RELATIVE to cargo when building
rustc in stages > 0.  This tells rustc to check the different directory.

I'm not sure how you want this handled in the toml system (my distribution, Gentoo, uses configure still).  I have a feeling the system needs a rework anyways for rustbuild.  If there is some discussion that needs to happen, could you merge this in the mean time?  I'd be happy to help transition this to a better method.