### PR TITLE
Use libc errno in Redox submodule

### DIFF
--- a/src/libstd/sys/redox/os.rs
+++ b/src/libstd/sys/redox/os.rs
@@ -33,9 +33,16 @@ use vec;
 const TMPBUF_SZ: usize = 128;
 static ENV_LOCK: Mutex = Mutex::new();
 
+extern {
+    #[link_name = "__errno_location"]
+    fn errno_location() -> *mut i32;
+}
+
 /// Returns the platform-specific value of errno
 pub fn errno() -> i32 {
-    0
+    unsafe {
+        (*errno_location())
+    }
 }
 
 /// Gets a detailed string description for the given error number.


### PR DESCRIPTION
This fixes https://github.com/redox-os/redox/issues/830, and is necessary when using libc in Redox