### PR TITLE
Force backline on all where in docs

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -165,7 +165,7 @@ impl<'a> fmt::Display for WhereClause<'a> {
         if f.alternate() {
             clause.push_str(" where ");
         } else {
-            clause.push_str(" <span class='where'>where ");
+            clause.push_str(" <span class='where fmt-newline'>where ");
         }
         for (i, pred) in gens.where_predicates.iter().enumerate() {
             if i > 0 {
@@ -208,10 +208,9 @@ impl<'a> fmt::Display for WhereClause<'a> {
             clause.push_str("</span>");
             let plain = format!("{:#}", self);
             if plain.len() + pad > 80 {
-                //break it onto its own line regardless, but make sure method impls and trait
-                //blocks keep their fixed padding (2 and 9, respectively)
+                // break it onto its own line regardless, but make sure method impls and trait
+                // blocks keep their fixed padding (2 and 9, respectively)
                 let padding = if pad > 10 {
-                    clause = clause.replace("class='where'", "class='where fmt-newline'");
                     repeat("&nbsp;").take(8).collect::<String>()
                 } else {
                     repeat("&nbsp;").take(pad + 6).collect::<String>()


### PR DESCRIPTION
Pictures are better than words in this case:

Before:

<img width="1440" alt="screen shot 2017-01-21 at 15 34 27" src="https://cloud.githubusercontent.com/assets/3050060/22175139/6e7c75d8-dfef-11e6-9904-023d63e609d2.png">

After:

<img width="1440" alt="screen shot 2017-01-21 at 15 34 32" src="https://cloud.githubusercontent.com/assets/3050060/22175140/75cc3846-dfef-11e6-9799-fffb213653e4.png">

r? @steveklabnik

cc @rust-lang/docs 