### PR TITLE
travis: Enable testing i686 musl

### DIFF
--- a/src/ci/docker/linux-tested-targets/Dockerfile
+++ b/src/ci/docker/linux-tested-targets/Dockerfile
@@ -32,10 +32,10 @@ ENV RUST_CONFIGURE_ARGS \
       --musl-root-x86_64=/musl-x86_64 \
       --musl-root-i686=/musl-i686
 
-# FIXME should also test i686-unknown-linux-musl
 ENV SCRIPT \
       python2.7 ../x.py test \
           --target x86_64-unknown-linux-musl \
+          --target i686-unknown-linux-musl \
           --target i586-unknown-linux-gnu \
           && \
       python2.7 ../x.py dist \

--- a/src/ci/docker/linux-tested-targets/build-musl.sh
+++ b/src/ci/docker/linux-tested-targets/build-musl.sh
@@ -57,7 +57,7 @@ cp lib/libunwind.a /musl-x86_64/lib
 # for x86_64 again)
 rm -rf *
 # for i686
-CFLAGS="$CFLAGS -m32 -g" CXXFLAGS="$CXXFLAGS -m32 -g" cmake ../libunwind-release_37 \
+CFLAGS="$CFLAGS -m32" CXXFLAGS="$CXXFLAGS -m32" cmake ../libunwind-release_37 \
           -DLLVM_PATH=/build/llvm-release_37 \
           -DLIBUNWIND_ENABLE_SHARED=0
 make -j10

--- a/src/librustc_back/target/i686_unknown_linux_musl.rs
+++ b/src/librustc_back/target/i686_unknown_linux_musl.rs
@@ -17,6 +17,20 @@ pub fn target() -> TargetResult {
     base.pre_link_args.push("-m32".to_string());
     base.pre_link_args.push("-Wl,-melf_i386".to_string());
 
+    // The unwinder used by i686-unknown-linux-musl, the LLVM libunwind
+    // implementation, apparently relies on frame pointers existing... somehow.
+    // It's not clear to me why nor where this dependency is introduced, but the
+    // test suite does not pass with frame pointers eliminated and it passes
+    // with frame pointers present.
+    //
+    // If you think that this is no longer necessary, then please feel free to
+    // ignore! If it still passes the test suite and the bots then sounds good
+    // to me.
+    //
+    // This may or may not be related to this bug:
+    // https://llvm.org/bugs/show_bug.cgi?id=30879
+    base.eliminate_frame_pointer = false;
+
     Ok(Target {
         llvm_target: "i686-unknown-linux-musl".to_string(),
         target_endian: "little".to_string(),


### PR DESCRIPTION
This fixes the final issues with the target related to unwinding by disabling
removal of frame pointers.