### PR TITLE
Add `eprint!` and `eprintln!` macros to the prelude.

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -277,6 +277,8 @@ pub use self::util::{copy, sink, Sink, empty, Empty, repeat, Repeat};
 pub use self::stdio::{stdin, stdout, stderr, _print, Stdin, Stdout, Stderr};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::stdio::{StdoutLock, StderrLock, StdinLock};
+#[unstable(feature = "eprint", issue="39228")]
+pub use self::stdio::_eprint;
 #[unstable(feature = "libstd_io_internals", issue = "0")]
 #[doc(no_inline, hidden)]
 pub use self::stdio::{set_panic, set_print};

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -68,6 +68,9 @@ macro_rules! panic {
 /// necessary to use `io::stdout().flush()` to ensure the output is emitted
 /// immediately.
 ///
+/// Use `print!` only for the primary output of your program.  Use
+/// `eprint!` instead to print error and progress messages.
+///
 /// # Panics
 ///
 /// Panics if writing to `io::stdout()` fails.
@@ -105,6 +108,9 @@ macro_rules! print {
 /// Use the `format!` syntax to write data to the standard output.
 /// See `std::fmt` for more information.
 ///
+/// Use `println!` only for the primary output of your program.  Use
+/// `eprintln!` instead to print error and progress messages.
+///
 /// # Panics
 ///
 /// Panics if writing to `io::stdout()` fails.
@@ -122,6 +128,45 @@ macro_rules! println {
     () => (print!("\n"));
     ($fmt:expr) => (print!(concat!($fmt, "\n")));
     ($fmt:expr, $($arg:tt)*) => (print!(concat!($fmt, "\n"), $($arg)*));
+}
+
+/// Macro for printing to the standard error.
+///
+/// Equivalent to the `print!` macro, except that output goes to
+/// `io::stderr()` instead of `io::stdout()`.  See `print!` for
+/// example usage.
+///
+/// Use `eprint!` only for error and progress messages.  Use `print!`
+/// instead for the primary output of your program.
+///
+/// # Panics
+///
+/// Panics if writing to `io::stderr()` fails.
+#[macro_export]
+#[unstable(feature = "eprint", issue="39228")]
+#[allow_internal_unstable]
+macro_rules! eprint {
+    ($($arg:tt)*) => ($crate::io::_eprint(format_args!($($arg)*)));
+}
+
+/// Macro for printing to the standard error, with a newline.
+///
+/// Equivalent to the `println!` macro, except that output goes to
+/// `io::stderr()` instead of `io::stdout()`.  See `println!` for
+/// example usage.
+///
+/// Use `eprintln!` only for error and progress messages.  Use `println!`
+/// instead for the primary output of your program.
+///
+/// # Panics
+///
+/// Panics if writing to `io::stderr()` fails.
+#[macro_export]
+#[unstable(feature = "eprint", issue="39228")]
+macro_rules! eprintln {
+    () => (eprint!("\n"));
+    ($fmt:expr) => (eprint!(concat!($fmt, "\n")));
+    ($fmt:expr, $($arg:tt)*) => (eprint!(concat!($fmt, "\n"), $($arg)*));
 }
 
 /// A macro to select an event from a number of receivers.

--- a/src/test/run-pass/print-stdout-eprint-stderr.rs
+++ b/src/test/run-pass/print-stdout-eprint-stderr.rs
@@ -1,0 +1,40 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(eprint)]
+
+use std::{env, process};
+
+fn child() {
+    print!("[stdout 0]");
+    print!("[stdout {}]", 1);
+    println!("[stdout {}]", 2);
+    println!();
+    eprint!("[stderr 0]");
+    eprint!("[stderr {}]", 1);
+    eprintln!("[stderr {}]", 2);
+    eprintln!();
+}
+
+fn parent() {
+    let this = env::args().next().unwrap();
+    let output = process::Command::new(this).arg("-").output().unwrap();
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+
+    assert_eq!(stdout, "[stdout 0][stdout 1][stdout 2]\n\n");
+    assert_eq!(stderr, "[stderr 0][stderr 1][stderr 2]\n\n");
+}
+
+fn main() {
+    if env::args().count() == 2 { child() } else { parent() }
+}


### PR DESCRIPTION
These are exactly the same as `print!` and `println!` except that they write to stderr instead of stdout.  See issue #39228 and/or https://internals.rust-lang.org/t/extremely-pre-rfc-eprintln/4635 for further discussion.  Currently gated on `#![feature(eprint)]` but I hope they can be stabilized in time for 1.16.

I have not checked through the documentation for places where these should be used / recommended in place of `print(ln)!`.