### PR TITLE
rustdoc: Add aria-label to search field

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -72,7 +72,9 @@ r##"<!DOCTYPE html>
     <nav class="sub">
         <form class="search-form js-only">
             <div class="search-container">
-                <input class="search-input" name="search"
+                <input class="search-input"
+                       name="search"
+                       aria-label="Search"
                        autocomplete="off"
                        placeholder="Click or press ‘S’ to search, ‘?’ for more options…"
                        type="search">


### PR DESCRIPTION
For screen readers etc. Found through Google Chrome's accessibility audit tool. 

> ### Controls and media elements should have labels
> Unlabelled controls cause problems for users of assistive technology, as it can be unclear what the purpose of the control is. Particularly in cases where the label is not near the control in the document order, the user may have no way of knowing what the control is for.
> 
> Assistive technology will speak the name of a form element only if it is labelled using one of the following techniques:
> 
>   * `aria-labelledby` attribute
>   * `aria-label` attribute
>   * HTML `<label>`
>   * `alt` attribute, for `<img>` or `<input type='img'>` elements
>   * `title` attribute as a last resort.

From https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_text_01.
