### PR TITLE
Remove proc_macro from the tidy whitelist again

### DIFF
--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -115,9 +115,10 @@ pub fn check(path: &Path, bad: &mut bool) {
         }
     });
 
-    super::walk(&path.join("test/compile-fail"),
-                &mut |path| super::filter_dirs(path),
-                &mut |file| {
+    super::walk_many(&[&path.join("test/compile-fail"),
+                       &path.join("test/compile-fail-fulldeps")],
+                     &mut |path| super::filter_dirs(path),
+                     &mut |file| {
         let filename = file.file_name().unwrap().to_string_lossy();
         if !filename.ends_with(".rs") || filename == "features.rs" ||
            filename == "diagnostic_list.rs" {
@@ -170,7 +171,7 @@ pub fn check(path: &Path, bad: &mut bool) {
         "cfg_target_has_atomic", "staged_api", "const_indexing",
         "unboxed_closures", "stmt_expr_attributes",
         "cfg_target_thread_local", "unwind_attributes",
-        "inclusive_range_syntax", "proc_macro"
+        "inclusive_range_syntax"
     ];
 
     // Only check the number of lang features.

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -71,6 +71,11 @@ fn filter_dirs(path: &Path) -> bool {
     skip.iter().any(|p| path.ends_with(p))
 }
 
+fn walk_many(paths: &[&Path], skip: &mut FnMut(&Path) -> bool, f: &mut FnMut(&Path)) {
+    for path in paths {
+        walk(path, skip, f);
+    }
+}
 
 fn walk(path: &Path, skip: &mut FnMut(&Path) -> bool, f: &mut FnMut(&Path)) {
     for entry in t!(fs::read_dir(path), path) {


### PR DESCRIPTION
PR #38842 has exposed that we were missing the src/test/compile-fail-fulldeps
directory in the search for feature gate tests. Because the detection didn't
work despite the effort to name the test appropriately and add a correct
"// gate-test-proc_macro" comment, proc_macro was added to the whitelist.

We fix this little weakness in the feature gate tidy check and add
the src/test/compile-fail-fulldeps directory to the checked directories.

Part of issue #39059 .