### PR TITLE
build: Mention rustbuild in Makefile.in comments

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -17,6 +17,10 @@
 # most intimate workings of the compiler itself, you've come to the
 # right place. Let's see what's on the menu.
 #
+# Please note that most of these options only work if configure was
+# run with --disable-rustbuild. For documentation on the new build
+# system, see CONTRIBUTING.md.
+#
 # First, start with one of these build targets:
 #
 #   * all - The default. Build a complete, bootstrapped compiler.


### PR DESCRIPTION
I think this patch will help newcomers like myself with the build system. I didn't understand that the make targets listed in the Makefile.in comments only worked with the old system, until it was pointed out to me in #39256.