### PR TITLE
Checker:: Execute levenshtein before other context checking

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2312,6 +2312,14 @@ impl<'a> Resolver<'a> {
                 }
             }
 
+            let mut levenshtein_worked = false;
+
+            // Try Levenshtein.
+            if let Some(candidate) = this.lookup_typo_candidate(path, ns, is_expected) {
+                err.span_label(ident_span, &format!("did you mean `{}`?", candidate));
+                levenshtein_worked = true;
+            }
+
             // Try context dependent help if relaxed lookup didn't work.
             if let Some(def) = def {
                 match (def, source) {
@@ -2354,14 +2362,10 @@ impl<'a> Resolver<'a> {
                 }
             }
 
-            // Try Levenshtein if nothing else worked.
-            if let Some(candidate) = this.lookup_typo_candidate(path, ns, is_expected) {
-                err.span_label(ident_span, &format!("did you mean `{}`?", candidate));
-                return err;
-            }
-
             // Fallback label.
-            err.span_label(base_span, &fallback_label);
+            if !levenshtein_worked {
+                err.span_label(base_span, &fallback_label);
+            }
             err
         };
         let report_errors = |this: &mut Self, def: Option<Def>| {

--- a/src/test/ui/resolve/issue-39226.rs
+++ b/src/test/ui/resolve/issue-39226.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+struct Handle {}
+
+struct Something {
+    handle: Handle
+}
+
+fn main() {
+    let handle: Handle = Handle {};
+
+    let s: Something = Something {
+        handle: Handle
+        //~^ ERROR cannot find value `Handle` in this scope
+        //~| NOTE did you mean `handle`?
+    };
+}

--- a/src/test/ui/resolve/issue-39226.stderr
+++ b/src/test/ui/resolve/issue-39226.stderr
@@ -1,0 +1,11 @@
+error[E0423]: expected value, found struct `Handle`
+  --> $DIR/issue-39226.rs:20:17
+   |
+20 |         handle: Handle
+   |                 ^^^^^^
+   |                 |
+   |                 did you mean `handle`?
+   |                 did you mean `Handle { /* fields */ }`?
+
+error: aborting due to previous error
+

--- a/src/test/ui/resolve/issue-5035.stderr
+++ b/src/test/ui/resolve/issue-5035.stderr
@@ -8,7 +8,10 @@ error[E0404]: expected trait, found type alias `K`
   --> $DIR/issue-5035.rs:13:6
    |
 13 | impl K for isize {} //~ ERROR expected trait, found type alias `K`
-   |      ^ type aliases cannot be used for traits
+   |      ^
+   |      |
+   |      type aliases cannot be used for traits
+   |      did you mean `I`?
 
 error: cannot continue compilation due to previous error
 

--- a/src/test/ui/resolve/privacy-struct-ctor.stderr
+++ b/src/test/ui/resolve/privacy-struct-ctor.stderr
@@ -5,6 +5,7 @@ error[E0423]: expected value, found struct `Z`
    |         ^
    |         |
    |         did you mean `Z { /* fields */ }`?
+   |         did you mean `S`?
    |         constructor is not visible here due to private fields
    |
    = help: possible better candidate is found in another module, you can import it into scope:

--- a/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.stderr
+++ b/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.stderr
@@ -26,8 +26,9 @@ error[E0423]: expected value, found module `a::b`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:45:5
    |
 45 |     a::b.J
-   |     ^^^^--
-   |     |
+   |     ^^^---
+   |     |  |
+   |     |  did you mean `I`?
    |     did you mean `a::b::J`?
 
 error[E0423]: expected value, found module `a`
@@ -50,8 +51,9 @@ error[E0423]: expected value, found module `a::b`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:61:5
    |
 61 |     a::b.f()
-   |     ^^^^----
-   |     |
+   |     ^^^-----
+   |     |  |
+   |     |  did you mean `I`?
    |     did you mean `a::b::f(...)`?
 
 error[E0423]: expected value, found module `a::b`

--- a/src/test/ui/resolve/tuple-struct-alias.stderr
+++ b/src/test/ui/resolve/tuple-struct-alias.stderr
@@ -14,13 +14,19 @@ error[E0423]: expected function, found type alias `A`
   --> $DIR/tuple-struct-alias.rs:24:13
    |
 24 |     let s = A(0, 1);
-   |             ^ did you mean `A { /* fields */ }`?
+   |             ^
+   |             |
+   |             did you mean `S`?
+   |             did you mean `A { /* fields */ }`?
 
 error[E0532]: expected tuple struct/variant, found type alias `A`
   --> $DIR/tuple-struct-alias.rs:26:9
    |
 26 |         A(..) => {}
-   |         ^ did you mean `A { /* fields */ }`?
+   |         ^
+   |         |
+   |         did you mean `S`?
+   |         did you mean `A { /* fields */ }`?
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
As explain [here]() i think it's better to check for a miss typing before checking context dependent help.

```rust
struct Handle {}

struct Something {
     handle: Handle
}

fn main() {
     let handle: Handle = Handle {};

     let s: Something = Something {
         // Checker detect an error and propose a solution with `Handle { /* ... */ }`
         // but it's a miss typing of `handle`
         handle: Handle 
    };
}
```

Ping: @nagisa for #39226 

Signed-off-by: Freyskeyd <simon.paitrault@gmail.com>