### PR TITLE
travis: Upload all artifacts in build/dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,9 +124,9 @@ before_deploy:
   - mkdir -p deploy/$TRAVIS_COMMIT
   - >
       if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-          cp build/dist/*.tar.gz deploy/$TRAVIS_COMMIT;
+          cp -r build/dist deploy/$TRAVIS_COMMIT;
       else
-          cp obj/build/dist/*.tar.gz deploy/$TRAVIS_COMMIT;
+          cp -r obj/build/dist deploy/$TRAVIS_COMMIT;
       fi
 
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -137,7 +137,7 @@ branches:
 before_deploy:
   - ps: |
         New-Item -Path deploy -ItemType directory
-        Get-ChildItem -Path build\dist -Filter '*.tar.gz' | Move-Item -Destination deploy
+        Get-ChildItem -Path build\dist | Move-Item -Destination deploy
         Get-ChildItem -Path deploy | Foreach-Object {
           Push-AppveyorArtifact $_.FullName -FileName ${env:APPVEYOR_REPO_COMMIT}/$_
         }
@@ -151,7 +151,7 @@ deploy:
     bucket: rust-lang-ci
     set_public: true
     region: us-east-1
-    artifact: /.*\.tar.gz/
+    artifact: /.*/
     folder: rustc-builds
     on:
       branch: auto


### PR DESCRIPTION
Previously we only uploaded tarballs, but this modifies Travis/AppVeyor to
upload everything. We shouldn't have anything else in there to worry about and
otherwise we need to be sure to pick up pkg/msi/exe installers.