### PR TITLE
Fix parsing for casting an empty return expression

### DIFF
--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -163,7 +163,7 @@ impl Token {
     pub fn can_begin_expr(&self) -> bool {
         match *self {
             OpenDelim(..)               => true,
-            Ident(..)                   => true,
+            ref ident @ Ident(..)       => !ident.is_keyword(keywords::As),
             Literal(..)                 => true,
             Not                         => true,
             BinOp(Minus)                => true,

--- a/src/test/run-pass/return-as.rs
+++ b/src/test/run-pass/return-as.rs
@@ -1,0 +1,13 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {
+    return as ()
+}


### PR DESCRIPTION
Partial fix for #28784.