### PR TITLE
Avoid ICE when pretty-printing non-local MIR item.

### DIFF
--- a/src/librustc_mir/pretty.rs
+++ b/src/librustc_mir/pretty.rs
@@ -92,7 +92,7 @@ pub fn write_mir_pretty<'a, 'b, 'tcx, I>(tcx: TyCtxt<'b, 'tcx, 'tcx>,
     where I: Iterator<Item=DefId>, 'tcx: 'a
 {
     let mut first = true;
-    for def_id in iter {
+    for def_id in iter.filter(DefId::is_local) {
         let mir = &tcx.item_mir(def_id);
 
         if first {


### PR DESCRIPTION
This comes up when using `-Zunstable-options --unpretty=mir`. Previously, rustc would ICE due to an unwrap later in this function (after `as_local_node_id`). Instead, we should just ignore items from other crates when pretty-printing MIR.

This was reported in #rust: [this playground code](https://is.gd/PSMBZS) causes an ICE if you click the MIR button. The problem is the mention of the non-local item `std::usize::MAX`, so you can reduce the test case [a lot](https://is.gd/SaLjaa).

r? @eddyb