### PR TITLE
Fix full path being output with `rustdoc -h`

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -193,7 +193,7 @@ pub fn main_args(args: &[String]) -> isize {
     nightly_options::check_nightly_options(&matches, &opts());
 
     if matches.opt_present("h") || matches.opt_present("help") {
-        usage(&args[0]);
+        usage("rustdoc");
         return 0;
     } else if matches.opt_present("version") {
         rustc_driver::version("rustdoc", &matches);


### PR DESCRIPTION
rustdoc would output the full path to the binary when calling it with
the `-h` or `--help` flags. This is undesired behavior. It has been
replaced with a hardcoded string `rustdoc` to fix the issue.

Fixes #39310