### PR TITLE
drop_in_place is stable now, don't #![feature] it in the nomicon and a test.

### DIFF
--- a/src/doc/nomicon/destructors.md
+++ b/src/doc/nomicon/destructors.md
@@ -26,7 +26,7 @@ this is totally fine.
 For instance, a custom implementation of `Box` might write `Drop` like this:
 
 ```rust
-#![feature(alloc, heap_api, drop_in_place, unique)]
+#![feature(alloc, heap_api, unique)]
 
 extern crate alloc;
 
@@ -57,7 +57,7 @@ use-after-free the `ptr` because when drop exits, it becomes inaccessible.
 However this wouldn't work:
 
 ```rust
-#![feature(alloc, heap_api, drop_in_place, unique)]
+#![feature(alloc, heap_api, unique)]
 
 extern crate alloc;
 
@@ -135,7 +135,7 @@ The classic safe solution to overriding recursive drop and allowing moving out
 of Self during `drop` is to use an Option:
 
 ```rust
-#![feature(alloc, heap_api, drop_in_place, unique)]
+#![feature(alloc, heap_api, unique)]
 
 extern crate alloc;
 

--- a/src/test/run-pass/extern_fat_drop.rs
+++ b/src/test/run-pass/extern_fat_drop.rs
@@ -10,8 +10,6 @@
 
 // aux-build:fat_drop.rs
 
-#![feature(drop_in_place)]
-
 extern crate fat_drop;
 
 fn main() {


### PR DESCRIPTION
It was stable since Rust 1.8.

r? @GuillaumeGomez 

