### PR TITLE
Remove unnecessary LLVMRustPersonalityFn binding

### DIFF
--- a/src/librustc_llvm/ffi.rs
+++ b/src/librustc_llvm/ffi.rs
@@ -804,7 +804,7 @@ extern "C" {
                                     Name: *const c_char)
                                     -> ValueRef;
     pub fn LLVMRustAddHandler(CatchSwitch: ValueRef, Handler: BasicBlockRef);
-    pub fn LLVMRustSetPersonalityFn(B: BuilderRef, Pers: ValueRef);
+    pub fn LLVMSetPersonalityFn(Func: ValueRef, Pers: ValueRef);
 
     // Add a case to the switch instruction
     pub fn LLVMAddCase(Switch: ValueRef, OnVal: ValueRef, Dest: BasicBlockRef);

--- a/src/librustc_trans/builder.rs
+++ b/src/librustc_trans/builder.rs
@@ -1107,7 +1107,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
     pub fn set_personality_fn(&self, personality: ValueRef) {
         unsafe {
-            llvm::LLVMRustSetPersonalityFn(self.llbuilder, personality);
+            llvm::LLVMSetPersonalityFn(self.llfn(), personality);
         }
     }
 

--- a/src/librustc_trans/mir/mod.rs
+++ b/src/librustc_trans/mir/mod.rs
@@ -319,7 +319,9 @@ pub fn trans_mir<'a, 'tcx: 'a>(
     mircx.cleanup_kinds.iter_enumerated().map(|(bb, cleanup_kind)| {
         if let CleanupKind::Funclet = *cleanup_kind {
             let bcx = mircx.get_builder(bb);
-            bcx.set_personality_fn(mircx.ccx.eh_personality());
+            unsafe {
+                llvm::LLVMSetPersonalityFn(mircx.llfn, mircx.ccx.eh_personality());
+            }
             if base::wants_msvc_seh(ccx.sess()) {
                 return Some(Funclet::new(bcx.cleanup_pad(None, &[])));
             }

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -1082,14 +1082,6 @@ extern "C" void LLVMRustAddHandler(LLVMValueRef CatchSwitchRef,
 #endif
 }
 
-extern "C" void LLVMRustSetPersonalityFn(LLVMBuilderRef B,
-                                         LLVMValueRef Personality) {
-#if LLVM_VERSION_GE(3, 8)
-  unwrap(B)->GetInsertBlock()->getParent()->setPersonalityFn(
-      cast<Function>(unwrap(Personality)));
-#endif
-}
-
 #if LLVM_VERSION_GE(3, 8)
 extern "C" OperandBundleDef *LLVMRustBuildOperandBundleDef(const char *Name,
                                                            LLVMValueRef *Inputs,


### PR DESCRIPTION
LLVM Core C bindings provide this function for all the versions back to what we support (3.7), and
helps to avoid this unnecessary builder->function transition every time. Also a negative diff.

Fixes #38462 (although it was pretty much fixed already)