### PR TITLE
travis: Turn off core dumps on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,17 +43,9 @@ matrix:
         SRC=.
       os: osx
       osx_image: xcode8.2
-      before_script: &osx_before_script >
-        ulimit -c unlimited
       install: &osx_install_sccache >
         curl -L https://api.pub.build.mozilla.org/tooltool/sha512/d0025b286468cc5ada83b23d3fafbc936b9f190eaa7d4a981715b18e8e3bf720a7bcee7bfe758cfdeb8268857f6098fd52dcdd8818232692a30ce91039936596 |
           tar xJf - -C /usr/local/bin --strip-components=1
-      after_failure: &osx_after_failure >
-        echo 'bt all' > cmds;
-        for file in $(ls /cores); do
-          echo core file $file;
-          lldb -c /cores/$file `which ld` -b -s cmds;
-        done
 
     - env: >
         SCRIPT="./x.py test && ./x.py dist"
@@ -62,18 +54,14 @@ matrix:
         DEPLOY=1
       os: osx
       osx_image: xcode8.2
-      before_script: *osx_before_script
       install: *osx_install_sccache
-      after_failure: *osx_after_failure
     - env: >
         RUST_CHECK_TARGET=check
         RUST_CONFIGURE_ARGS=--build=x86_64-apple-darwin --disable-rustbuild
         SRC=.
       os: osx
       osx_image: xcode8.2
-      before_script: *osx_before_script
       install: *osx_install_sccache
-      after_failure: *osx_after_failure
     - env: >
         RUST_CHECK_TARGET=dist
         RUST_CONFIGURE_ARGS="--target=aarch64-apple-ios,armv7-apple-ios,armv7s-apple-ios,i386-apple-ios,x86_64-apple-ios --enable-extended"
@@ -81,9 +69,7 @@ matrix:
         DEPLOY=1
       os: osx
       osx_image: xcode8.2
-      before_script: *osx_before_script
       install: *osx_install_sccache
-      after_failure: *osx_after_failure
 
 env:
   global:


### PR DESCRIPTION
I've seen these take up quite a bit of log space and I have the sneaking
suspicion that they're just making our test suite take longer (sometimes timing
out on 32-bit OSX now). In any case the backtraces haven't proven too useful,
unfortunately.