### PR TITLE
rustbuild: Build jemalloc and libbacktrace only once (take 2)

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -61,6 +61,9 @@ dependencies = [
 [[package]]
 name = "build_helper"
 version = "0.1.0"
+dependencies = [
+ "filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cargotest"

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "std_shim"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "core 0.0.0",
  "std 0.0.0",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "test_shim"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "test 0.0.0",
 ]

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -383,7 +383,7 @@ pub fn krate(build: &Build,
                 // helper crate, not tested. If it leaks through then it ends up
                 // messing with various mtime calculations and such.
                 if !name.contains("jemalloc") && name != "build_helper" {
-                    cargo.arg("-p").arg(name);
+                    cargo.arg("-p").arg(&format!("{}:0.0.0", name));
                 }
                 for dep in build.crates[name].deps.iter() {
                     if visited.insert(dep) {

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -21,10 +21,10 @@ use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use build_helper::output;
+use build_helper::{output, mtime};
 use filetime::FileTime;
 
-use util::{exe, libdir, mtime, is_dylib, copy};
+use util::{exe, libdir, is_dylib, copy};
 use {Build, Compiler, Mode};
 
 /// Build the standard library.

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -22,7 +22,8 @@ use std::io::prelude::*;
 use std::process::Command;
 
 use {Build, Compiler, Mode};
-use util::{up_to_date, cp_r};
+use util::cp_r;
+use build_helper::up_to_date;
 
 /// Invoke `rustbook` as compiled in `stage` for `target` for the doc book
 /// `name` into the `out` path.

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -66,6 +66,7 @@
 
 #![deny(warnings)]
 
+#[macro_use]
 extern crate build_helper;
 extern crate cmake;
 extern crate filetime;
@@ -83,24 +84,9 @@ use std::fs::{self, File};
 use std::path::{Component, PathBuf, Path};
 use std::process::Command;
 
-use build_helper::{run_silent, output};
+use build_helper::{run_silent, output, mtime};
 
-use util::{exe, mtime, libdir, add_lib_path};
-
-/// A helper macro to `unwrap` a result except also print out details like:
-///
-/// * The file/line of the panic
-/// * The expression that failed
-/// * The error itself
-///
-/// This is currently used judiciously throughout the build system rather than
-/// using a `Result` with `try!`, but this may change one day...
-macro_rules! t {
-    ($e:expr) => (match $e {
-        Ok(e) => e,
-        Err(e) => panic!("{} failed with {}", stringify!($e), e),
-    })
-}
+use util::{exe, libdir, add_lib_path};
 
 mod cc;
 mod channel;

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -482,7 +482,8 @@ impl Build {
         //
         // These variables are primarily all read by
         // src/bootstrap/bin/{rustc.rs,rustdoc.rs}
-        cargo.env("RUSTC", self.out.join("bootstrap/debug/rustc"))
+        cargo.env("RUSTBUILD_NATIVE_DIR", self.native_dir(target))
+             .env("RUSTC", self.out.join("bootstrap/debug/rustc"))
              .env("RUSTC_REAL", self.compiler_path(compiler))
              .env("RUSTC_STAGE", stage.to_string())
              .env("RUSTC_DEBUGINFO", self.config.rust_debuginfo.to_string())
@@ -746,10 +747,15 @@ impl Build {
         }
     }
 
+    /// Directory for libraries built from C/C++ code and shared between stages.
+    fn native_dir(&self, target: &str) -> PathBuf {
+        self.out.join(target).join("native")
+    }
+
     /// Root output directory for rust_test_helpers library compiled for
     /// `target`
     fn test_helpers_out(&self, target: &str) -> PathBuf {
-        self.out.join(target).join("rust-test-helpers")
+        self.native_dir(target).join("rust-test-helpers")
     }
 
     /// Adds the compiler's directory of dynamic libraries to `cmd`'s dynamic

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -28,7 +28,8 @@ use cmake;
 use gcc;
 
 use Build;
-use util::{self, up_to_date};
+use util;
+use build_helper::up_to_date;
 
 /// Compile LLVM for `target`.
 pub fn llvm(build: &Build, target: &str) {

--- a/src/build_helper/Cargo.toml
+++ b/src/build_helper/Cargo.toml
@@ -6,3 +6,6 @@ authors = ["The Rust Project Developers"]
 [lib]
 name = "build_helper"
 path = "lib.rs"
+
+[dependencies]
+filetime = "0.1"

--- a/src/build_helper/lib.rs
+++ b/src/build_helper/lib.rs
@@ -88,6 +88,21 @@ pub fn output(cmd: &mut Command) -> String {
     String::from_utf8(output.stdout).unwrap()
 }
 
+pub fn rerun_if_changed_anything_in_dir(dir: &Path) {
+    let mut stack = dir.read_dir().unwrap()
+                       .map(|e| e.unwrap())
+                       .filter(|e| &*e.file_name() != ".git")
+                       .collect::<Vec<_>>();
+    while let Some(entry) = stack.pop() {
+        let path = entry.path();
+        if entry.file_type().unwrap().is_dir() {
+            stack.extend(path.read_dir().unwrap().map(|e| e.unwrap()));
+        } else {
+            println!("cargo:rerun-if-changed={}", path.display());
+        }
+    }
+}
+
 fn fail(s: &str) -> ! {
     println!("\n\n{}\n\n", s);
     std::process::exit(1);

--- a/src/liballoc_jemalloc/build.rs
+++ b/src/liballoc_jemalloc/build.rs
@@ -31,6 +31,7 @@ fn main() {
     // targets, which means we have to build the alloc_jemalloc crate
     // for targets like emscripten, even if we don't use it.
     let target = env::var("TARGET").expect("TARGET was not set");
+    let host = env::var("HOST").expect("HOST was not set");
     if target.contains("rumprun") || target.contains("bitrig") || target.contains("openbsd") ||
        target.contains("msvc") || target.contains("emscripten") || target.contains("fuchsia") ||
        target.contains("redox") {
@@ -68,11 +69,10 @@ fn main() {
     } else if !target.contains("windows") && !target.contains("musl") {
         println!("cargo:rustc-link-lib=pthread");
     }
-    if !cfg!(stage0) {
+    if !cfg!(stage0) && target == host {
         return
     }
 
-    let host = env::var("HOST").expect("HOST was not set");
     let src_dir = env::current_dir().unwrap().join("../jemalloc");
     rerun_if_changed_anything_in_dir(&src_dir);
     let compiler = gcc::Config::new().get_compiler();

--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -71,7 +71,7 @@ fn build_libbacktrace(host: &str, target: &str) {
 
     println!("cargo:rustc-link-lib=static=backtrace");
     println!("cargo:rustc-link-search=native={}/.libs", build_dir.display());
-    if !cfg!(stage0) {
+    if !cfg!(stage0) && target == host {
         return
     }
 

--- a/src/rustc/std_shim/Cargo.toml
+++ b/src/rustc/std_shim/Cargo.toml
@@ -21,7 +21,7 @@
 
 [package]
 name = "std_shim"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["The Rust Project Developers"]
 
 [lib]

--- a/src/rustc/test_shim/Cargo.toml
+++ b/src/rustc/test_shim/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "test_shim"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["The Rust Project Developers"]
 
 [lib]


### PR DESCRIPTION
This is a rebase of https://github.com/rust-lang/rust/pull/38583 without any additions, but with implemented @alexcrichton's suggestions.
~~This includes `exists(Makefile)` => `cfg(stage0)` suggestion... but it will break cross-compilation, no? Are `libstd/liballoc_jemalloc` cross-compiled for `target != host` built during `stage0`?~~

r? @alexcrichton 