### PR TITLE
Fix another endianness issue in i128 trans

### DIFF
--- a/src/librustc_trans/common.rs
+++ b/src/librustc_trans/common.rs
@@ -234,7 +234,8 @@ pub fn C_integral(t: Type, u: u64, sign_extend: bool) -> ValueRef {
 pub fn C_big_integral(t: Type, u: u128, sign_extend: bool) -> ValueRef {
     if ::std::mem::size_of::<u128>() == 16 {
         unsafe {
-            llvm::LLVMConstIntOfArbitraryPrecision(t.to_ref(), 2, &u as *const u128 as *const u64)
+            let words = [u as u64, u.wrapping_shr(64) as u64];
+            llvm::LLVMConstIntOfArbitraryPrecision(t.to_ref(), 2, words.as_ptr())
         }
     } else {
         // SNAP: remove after snapshot


### PR DESCRIPTION
Apparently LLVMArbitraryPrecisionInteger demands integers to be in low-endian 64-bytes, rather than host-endian 64-bytes. This is weird, and obviously, not documented. And rustc now works a teeny bit more on big endians.

r? @eddyb 