### PR TITLE
Path::is_empty

### DIFF
--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1490,6 +1490,24 @@ impl Path {
         PathBuf::from(self.inner.to_os_string())
     }
 
+    /// Checks whether the `Path` is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::path::Path;
+    ///
+    /// let path = Path::new("");
+    /// assert!(path.is_empty())
+    ///
+    /// let path = Path::new("tmp");
+    /// assert!(!path.is_empty())
+    /// ```
+    #[unstable(feature = "path_is_empty", issue = "0")]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
     /// A path is *absolute* if it is independent of the current directory.
     ///
     /// * On Unix, a path is absolute if it starts with the root, so


### PR DESCRIPTION
While an empty path may not necessarily have semantic significance, because `PathBuf::new` returns an empty path, I feel that having this method is reasonable.

I left out `len` because it could easily be confused for the number of components in the path. However, `is_empty` seems useful and unambiguous.