### PR TITLE
Use __SIZEOF_INT128__ to test __int128 presence

### DIFF
--- a/src/rt/rust_test_helpers.c
+++ b/src/rt/rust_test_helpers.c
@@ -269,7 +269,7 @@ LARGE_INTEGER increment_all_parts(LARGE_INTEGER li) {
     return li;
 }
 
-#if !(defined(WIN32) || defined(_WIN32) || defined(__WIN32)) && defined(__amd64__)
+#if __SIZEOF_INT128__ == 16
 
 unsigned __int128 identity(unsigned __int128 a) {
     return a;


### PR DESCRIPTION
Previously we tested whether a handful of preprocessor variables indicating certain 64 bit
platforms, but this does not work for other 64 bit targets which have support for __int128 in C
compiler.

Use the `__SIZEOF__INT128__` preprocessor variable instead. This variable gets set to 16 by gcc and
clang for every target where __int128 is supported.