### PR TITLE
rustdoc: Suppress warnings/errors with --test

### DIFF
--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -429,8 +429,12 @@ impl Collector {
                 should_panic: testing::ShouldPanic::No,
             },
             testfn: testing::DynTestFn(box move |()| {
+                let panic = io::set_panic(None);
+                let print = io::set_print(None);
                 match {
                     rustc_driver::in_rustc_thread(move || {
+                        io::set_panic(panic);
+                        io::set_print(print);
                         runtest(&test,
                                 &cratename,
                                 cfgs,


### PR DESCRIPTION
Threads spawned by the test framework have their output captured by default, so
for `rustdoc --test` threads this propagates that capturing to the spawned
thread that we now have.

Closes #39327