### PR TITLE
WIP: Replace warning by error in const evaluation

### DIFF
--- a/src/librustc_passes/consts.rs
+++ b/src/librustc_passes/consts.rs
@@ -73,12 +73,11 @@ impl<'a, 'gcx> CheckCrateVisitor<'a, 'gcx> {
                 ErroneousReferencedConstant(_) => {}
                 BadType(_) => {}
                 _ => {
-                    self.tcx.sess.add_lint(CONST_ERR,
-                                           expr.id,
-                                           expr.span,
-                                           format!("constant evaluation error: {}. This will \
-                                                    become a HARD ERROR in the future",
-                                                   err.description().into_oneline()))
+                    span_err!(self.tcx.sess,
+                              expr.span,
+                              E0080,
+                              "constant evaluation error: {}",
+                              err.description().into_oneline());
                 }
             }
         }

--- a/src/librustc_passes/diagnostics.rs
+++ b/src/librustc_passes/diagnostics.rs
@@ -244,6 +244,7 @@ match 5u32 {
 }
 
 register_diagnostics! {
+    E0080, // error evaluating constant
     E0472, // asm! is unsupported on this target
     E0561, // patterns aren't allowed in function pointer types
     E0571, // `break` with a value in a non-`loop`-loop

--- a/src/test/compile-fail/issue-37998.rs
+++ b/src/test/compile-fail/issue-37998.rs
@@ -1,0 +1,15 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+const WHY: i32 = 1 / 0; //~ERROR E0080
+
+fn main() {
+    println!("{}", WHY);
+}


### PR DESCRIPTION
Fixes #37998

cc @oli-obk 

I marked this as a WIP because it made other compile-fail tests fail. The problem is that there are other checks to constants providing more specific error messages. However, those checks are executed later on (at least some of them are in `librustc_mir::transform`). Therefore, replacing the warning by an error means that a general error is printed, instead of a specific one.

See for instance the output when testing `compile-fail\E0010.rs`:

```
---- [compile-fail] compile-fail\E0010.rs stdout ----

error: .../rust/src/test/compile-fail/E0010.rs:13: unexpected "error": '13:24: 13:29: constant evaluation error: unsupported constant expr [E0080]'

error: .../rust/src/test/compile-fail/E0010.rs:13: expected error not found: E0010

error: .../rust/src/test/compile-fail/E0010.rs:13: expected note not found: allocation not allowed in

error: 1 unexpected errors found, 2 expected errors not found
status: exit code: 101
```

Any ideas on how to tackle this? Should we remove `check_const_eval` and check for division by zero in a mir pass?

---

For the record, the other failures are:

```
failures:
    [compile-fail] compile-fail\E0010.rs
    [compile-fail] compile-fail\E0394.rs
    [compile-fail] compile-fail\check-static-values-constraints.rs
    [compile-fail] compile-fail\const-err-early.rs
    [compile-fail] compile-fail\const-eval-overflow-2.rs
    [compile-fail] compile-fail\const-eval-overflow.rs
    [compile-fail] compile-fail\issue-14227.rs
    [compile-fail] compile-fail\issue-16538.rs
    [compile-fail] compile-fail\issue-17450.rs
    [compile-fail] compile-fail\issue-17718-references.rs
    [compile-fail] compile-fail\issue-28113.rs
    [compile-fail] compile-fail\issue-7364.rs
    [compile-fail] compile-fail\static-mut-not-constant.rs
    [compile-fail] compile-fail\static-vec-repeat-not-constant.rs
```