### PR TITLE
A few ergonomic From impls for SocketAddr/IpAddr

### DIFF
--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -456,6 +456,13 @@ impl From<SocketAddrV6> for SocketAddr {
     }
 }
 
+#[stable(feature = "addr_from_into_ip", since = "1.17.0")]
+impl<I: Into<IpAddr>> From<(I, u16)> for SocketAddr {
+    fn from(pieces: (I, u16)) -> SocketAddr {
+        SocketAddr::new(pieces.0.into(), pieces.1)
+    }
+}
+
 impl<'a> IntoInner<(*const c::sockaddr, c::socklen_t)> for &'a SocketAddr {
     fn into_inner(self) -> (*const c::sockaddr, c::socklen_t) {
         match *self {

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -1183,8 +1183,8 @@ impl From<[u8; 16]> for IpAddr {
 
 #[stable(feature = "ip_from_slice", since = "1.17.0")]
 impl From<[u16; 8]> for IpAddr {
-    fn from(octets: [u16; 8]) -> IpAddr {
-        IpAddr::V6(Ipv6Addr::from(octets))
+    fn from(segments: [u16; 8]) -> IpAddr {
+        IpAddr::V6(Ipv6Addr::from(segments))
     }
 }
 

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -656,6 +656,13 @@ impl From<[u8; 4]> for Ipv4Addr {
     }
 }
 
+#[stable(feature = "ip_from_slice", since = "1.17.0")]
+impl From<[u8; 4]> for IpAddr {
+    fn from(octets: [u8; 4]) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::from(octets))
+    }
+}
+
 impl Ipv6Addr {
     /// Creates a new IPv6 address from eight 16-bit segments.
     ///
@@ -1163,6 +1170,21 @@ impl From<[u16; 8]> for Ipv6Addr {
     fn from(segments: [u16; 8]) -> Ipv6Addr {
         let [a, b, c, d, e, f, g, h] = segments;
         Ipv6Addr::new(a, b, c, d, e, f, g, h)
+    }
+}
+
+
+#[stable(feature = "ip_from_slice", since = "1.17.0")]
+impl From<[u8; 16]> for IpAddr {
+    fn from(octets: [u8; 16]) -> IpAddr {
+        IpAddr::V6(Ipv6Addr::from(octets))
+    }
+}
+
+#[stable(feature = "ip_from_slice", since = "1.17.0")]
+impl From<[u16; 8]> for IpAddr {
+    fn from(octets: [u16; 8]) -> IpAddr {
+        IpAddr::V6(Ipv6Addr::from(octets))
     }
 }
 


### PR DESCRIPTION
My main motivation is removing things like this: `"127.0.0.1:3000".parse().unwrap()`. Instead, this now works: `SocketAddr::from(([127, 0, 0, 1], 3000))` or even `([127, 0, 0, 1], 3000).into())` when passing to a function.