### PR TITLE
Remove dead recursive partial eq impl

### DIFF
--- a/src/librustc_data_structures/accumulate_vec.rs
+++ b/src/librustc_data_structures/accumulate_vec.rs
@@ -25,7 +25,7 @@ use rustc_serialize::{Encodable, Encoder, Decodable, Decoder};
 
 use array_vec::{self, Array, ArrayVec};
 
-#[derive(PartialEq, Eq, Hash, Debug)]
+#[derive(Hash, Debug)]
 pub enum AccumulateVec<A: Array> {
     Array(ArrayVec<A>),
     Heap(Vec<A::Element>)

--- a/src/librustc_data_structures/array_vec.rs
+++ b/src/librustc_data_structures/array_vec.rs
@@ -52,14 +52,6 @@ impl<A> Hash for ArrayVec<A>
     }
 }
 
-impl<A: Array> PartialEq for ArrayVec<A> {
-    fn eq(&self, other: &Self) -> bool {
-        self == other
-    }
-}
-
-impl<A: Array> Eq for ArrayVec<A> {}
-
 impl<A> Clone for ArrayVec<A>
     where A: Array,
           A::Element: Clone {


### PR DESCRIPTION
Its nowhere used (if it had been used used, the rust stack would have overflown
due to the recursion). Its presence was confusing for mrustc.

cc @thepowersgang 