### PR TITLE
Remove the workaround for gh32959

### DIFF
--- a/src/librustc_mir/build/block.rs
+++ b/src/librustc_mir/build/block.rs
@@ -16,8 +16,6 @@ use rustc::hir;
 impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     pub fn ast_block(&mut self,
                      destination: &Lvalue<'tcx>,
-                     // FIXME(#32959): temporary measure for the issue
-                     dest_is_unit: bool,
                      mut block: BasicBlock,
                      ast_block: &'tcx hir::Block)
                      -> BlockAnd<()> {
@@ -83,8 +81,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             // of the block.
             if let Some(expr) = expr {
                 unpack!(block = this.into(destination, block, expr));
-            } else if dest_is_unit {
-                // FIXME(#31472)
+            } else {
                 let source_info = this.source_info(span);
                 this.cfg.push_assign_unit(block, source_info, destination);
             }

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -40,7 +40,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 this.in_scope(extent, block, |this| this.into(destination, block, value))
             }
             ExprKind::Block { body: ast_block } => {
-                this.ast_block(destination, expr.ty.is_nil(), block, ast_block)
+                this.ast_block(destination, block, ast_block)
             }
             ExprKind::Match { discriminant, arms } => {
                 this.match_expr(destination, expr_span, block, discriminant, arms)


### PR DESCRIPTION
This workaround is no longer necessary as Rust, and by extension MIR, now support uninhabited type
properly. This removes the workaround for the gh32959 that was introduced in gh33267.

Fixes #32959