### PR TITLE
Make AsRef and AsMut reflexive

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1819,20 +1819,6 @@ impl<T: fmt::Debug> fmt::Debug for Vec<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> AsRef<Vec<T>> for Vec<T> {
-    fn as_ref(&self) -> &Vec<T> {
-        self
-    }
-}
-
-#[stable(feature = "vec_as_mut", since = "1.5.0")]
-impl<T> AsMut<Vec<T>> for Vec<T> {
-    fn as_mut(&mut self) -> &mut Vec<T> {
-        self
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<T> AsRef<[T]> for Vec<T> {
     fn as_ref(&self) -> &[T] {
         self

--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -224,6 +224,14 @@ pub trait TryFrom<T>: Sized {
 // GENERIC IMPLS
 ////////////////////////////////////////////////////////////////////////////////
 
+// As is reflexive
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<'a, T: ?Sized> AsRef<T> for T {
+    fn as_ref(&self) -> &T {
+        self
+    }
+}
+
 // As lifts over &
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T: ?Sized, U: ?Sized> AsRef<U> for &'a T where T: AsRef<U> {
@@ -247,6 +255,14 @@ impl<'a, T: ?Sized, U: ?Sized> AsRef<U> for &'a mut T where T: AsRef<U> {
 //         self.deref().as_ref()
 //     }
 // }
+
+// AsMut is reflexive
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<'a, T: ?Sized> AsMut<T> for T {
+    fn as_mut(&mut self) -> &mut T {
+        self
+    }
+}
 
 // AsMut lifts over &mut
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -286,31 +302,5 @@ impl<T, U> TryInto<U> for T where U: TryFrom<T> {
 
     fn try_into(self) -> Result<U, U::Err> {
         U::try_from(self)
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// CONCRETE IMPLS
-////////////////////////////////////////////////////////////////////////////////
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<T> AsRef<[T]> for [T] {
-    fn as_ref(&self) -> &[T] {
-        self
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<T> AsMut<[T]> for [T] {
-    fn as_mut(&mut self) -> &mut [T] {
-        self
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl AsRef<str> for str {
-    #[inline]
-    fn as_ref(&self) -> &str {
-        self
     }
 }

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -708,13 +708,6 @@ impl ops::Index<ops::RangeFull> for CString {
 }
 
 #[stable(feature = "cstring_asref", since = "1.7.0")]
-impl AsRef<CStr> for CStr {
-    fn as_ref(&self) -> &CStr {
-        self
-    }
-}
-
-#[stable(feature = "cstring_asref", since = "1.7.0")]
 impl AsRef<CStr> for CString {
     fn as_ref(&self) -> &CStr {
         self

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -576,13 +576,6 @@ impl ToOwned for OsStr {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl AsRef<OsStr> for OsStr {
-    fn as_ref(&self) -> &OsStr {
-        self
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
 impl AsRef<OsStr> for OsString {
     fn as_ref(&self) -> &OsStr {
         self

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -2130,13 +2130,6 @@ impl cmp::Ord for Path {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl AsRef<Path> for Path {
-    fn as_ref(&self) -> &Path {
-        self
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
 impl AsRef<Path> for OsStr {
     fn as_ref(&self) -> &Path {
         Path::new(self)


### PR DESCRIPTION
This would probably require a crater run.

I found it weird that `T` didn't implement `AsRef` and `AsMut`, considering how the conversions are trivial.