### PR TITLE
MIR EndRegion Statements (was MIR dataflow for Borrows)

### DIFF
--- a/src/librustc/ich/impls_mir.rs
+++ b/src/librustc/ich/impls_mir.rs
@@ -226,6 +226,9 @@ for mir::StatementKind<'tcx> {
             mir::StatementKind::StorageDead(ref lvalue) => {
                 lvalue.hash_stable(hcx, hasher);
             }
+            mir::StatementKind::EndRegion(ref extents) => {
+                extents.hash_stable(hcx, hasher);
+            }
             mir::StatementKind::Nop => {}
             mir::StatementKind::InlineAsm { ref asm, ref outputs, ref inputs } => {
                 asm.hash_stable(hcx, hasher);

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1176,12 +1176,22 @@ impl<'tcx> Debug for Rvalue<'tcx> {
             UnaryOp(ref op, ref a) => write!(fmt, "{:?}({:?})", op, a),
             Discriminant(ref lval) => write!(fmt, "discriminant({:?})", lval),
             NullaryOp(ref op, ref t) => write!(fmt, "{:?}({:?})", op, t),
-            Ref(_, borrow_kind, ref lv) => {
+            Ref(region, borrow_kind, ref lv) => {
                 let kind_str = match borrow_kind {
                     BorrowKind::Shared => "",
                     BorrowKind::Mut | BorrowKind::Unique => "mut ",
                 };
-                write!(fmt, "&{}{:?}", kind_str, lv)
+
+                // When identifying regions, add trailing space if
+                // necessary.
+                let region = if ppaux::identify_regions() {
+                    let mut region = format!("{}", region);
+                    if region.len() > 0 { region.push(' '); }
+                    region
+                } else {
+                    "".to_owned()
+                };
+                write!(fmt, "&{}{}{:?}", region, kind_str, lv)
             }
 
             Aggregate(ref kind, ref lvs) => {

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1224,7 +1224,11 @@ impl<'tcx> Debug for Rvalue<'tcx> {
 
                     AggregateKind::Closure(def_id, _) => ty::tls::with(|tcx| {
                         if let Some(node_id) = tcx.hir.as_local_node_id(def_id) {
-                            let name = format!("[closure@{:?}]", tcx.hir.span(node_id));
+                            let name = if tcx.sess.opts.debugging_opts.span_free_formats {
+                                format!("[closure@{:?}]", node_id)
+                            } else {
+                                format!("[closure@{:?}]", tcx.hir.span(node_id))
+                            };
                             let mut struct_fmt = fmt.debug_struct(&name);
 
                             tcx.with_freevars(node_id, |freevars| {

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -325,6 +325,7 @@ macro_rules! make_mir_visitor {
                                           ref $($mutability)* rvalue) => {
                         self.visit_assign(block, lvalue, rvalue, location);
                     }
+                    StatementKind::EndRegion(_) => {}
                     StatementKind::SetDiscriminant{ ref $($mutability)* lvalue, .. } => {
                         self.visit_lvalue(lvalue, LvalueContext::Store, location);
                     }

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -895,6 +895,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
         "in general, enable more debug printouts"),
     span_free_formats: bool = (false, parse_bool, [UNTRACKED],
         "when debug-printing compiler state, do not include spans"), // o/w tests have closure@path
+    identify_regions: bool = (false, parse_bool, [UNTRACKED],
+        "make unnamed regions display as '# (where # is some non-ident unique id)"),
     time_passes: bool = (false, parse_bool, [UNTRACKED],
         "measure time of each rustc pass"),
     count_llvm_insns: bool = (false, parse_bool,

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -893,6 +893,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
          DB_OPTIONS, db_type_desc, dbsetters,
     verbose: bool = (false, parse_bool, [UNTRACKED],
         "in general, enable more debug printouts"),
+    span_free_formats: bool = (false, parse_bool, [UNTRACKED],
+        "when debug-printing compiler state, do not include spans"), // o/w tests have closure@path
     time_passes: bool = (false, parse_bool, [UNTRACKED],
         "measure time of each rustc pass"),
     count_llvm_insns: bool = (false, parse_bool,

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -789,7 +789,11 @@ impl<'tcx> fmt::Display for ty::TypeVariants<'tcx> {
                 write!(f, "[closure")?;
 
                 if let Some(node_id) = tcx.hir.as_local_node_id(did) {
-                    write!(f, "@{:?}", tcx.hir.span(node_id))?;
+                    if tcx.sess.opts.debugging_opts.span_free_formats {
+                        write!(f, "@{:?}", node_id)?;
+                    } else {
+                        write!(f, "@{:?}", tcx.hir.span(node_id))?;
+                    }
                     let mut sep = " ";
                     tcx.with_freevars(node_id, |freevars| {
                         for (freevar, upvar_ty) in freevars.iter().zip(upvar_tys) {

--- a/src/librustc_borrowck/borrowck/mir/dataflow/impls.rs
+++ b/src/librustc_borrowck/borrowck/mir/dataflow/impls.rs
@@ -474,6 +474,7 @@ impl<'a, 'tcx> BitDenotation for MovingOutStatements<'a, 'tcx> {
             mir::StatementKind::StorageLive(_) |
             mir::StatementKind::StorageDead(_) |
             mir::StatementKind::InlineAsm { .. } |
+            mir::StatementKind::EndRegion(_) |
             mir::StatementKind::Nop => {}
         }
     }

--- a/src/librustc_borrowck/borrowck/mir/dataflow/sanity_check.rs
+++ b/src/librustc_borrowck/borrowck/mir/dataflow/sanity_check.rs
@@ -105,6 +105,7 @@ fn each_block<'a, 'tcx, O>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             mir::StatementKind::StorageLive(_) |
             mir::StatementKind::StorageDead(_) |
             mir::StatementKind::InlineAsm { .. } |
+            mir::StatementKind::EndRegion(_) |
             mir::StatementKind::Nop => continue,
             mir::StatementKind::SetDiscriminant{ .. } =>
                 span_bug!(stmt.source_info.span,

--- a/src/librustc_borrowck/borrowck/mir/elaborate_drops.rs
+++ b/src/librustc_borrowck/borrowck/mir/elaborate_drops.rs
@@ -585,11 +585,6 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
                             // drop elaboration should handle that by itself
                             continue
                         }
-                        TerminatorKind::Resume => {
-                            // We can replace resumes with gotos
-                            // jumping to a canonical resume.
-                            continue
-                        }
                         TerminatorKind::DropAndReplace { .. } => {
                             // this contains the move of the source and
                             // the initialization of the destination. We
@@ -598,6 +593,11 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
                             // *after* the destination is dropped.
                             assert!(self.patch.is_patched(bb));
                             allow_initializations = false;
+                        }
+                        TerminatorKind::Resume => {
+                            // It is possible for `Resume` to be patched
+                            // (in particular it can be patched to be replaced with
+                            // a Goto; see `MirPatch::new`).
                         }
                         _ => {
                             assert!(!self.patch.is_patched(bb));

--- a/src/librustc_borrowck/borrowck/mir/elaborate_drops.rs
+++ b/src/librustc_borrowck/borrowck/mir/elaborate_drops.rs
@@ -585,6 +585,11 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
                             // drop elaboration should handle that by itself
                             continue
                         }
+                        TerminatorKind::Resume => {
+                            // We can replace resumes with gotos
+                            // jumping to a canonical resume.
+                            continue
+                        }
                         TerminatorKind::DropAndReplace { .. } => {
                             // this contains the move of the source and
                             // the initialization of the destination. We

--- a/src/librustc_borrowck/borrowck/mir/gather_moves.rs
+++ b/src/librustc_borrowck/borrowck/mir/gather_moves.rs
@@ -413,6 +413,7 @@ impl<'a, 'tcx> MoveDataBuilder<'a, 'tcx> {
                           "SetDiscriminant should not exist during borrowck");
             }
             StatementKind::InlineAsm { .. } |
+            StatementKind::EndRegion(_) |
             StatementKind::Nop => {}
         }
     }

--- a/src/librustc_borrowck/borrowck/mir/mod.rs
+++ b/src/librustc_borrowck/borrowck/mir/mod.rs
@@ -394,6 +394,7 @@ fn drop_flag_effects_for_location<'a, 'tcx, F>(
             mir::StatementKind::StorageLive(_) |
             mir::StatementKind::StorageDead(_) |
             mir::StatementKind::InlineAsm { .. } |
+            mir::StatementKind::EndRegion(_) |
             mir::StatementKind::Nop => {}
         },
         None => {

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -912,6 +912,9 @@ pub fn phase_3_run_analysis_passes<'tcx, F, R>(sess: &'tcx Session,
     let mut passes = Passes::new();
     passes.push_hook(mir::transform::dump_mir::DumpMir);
 
+    // Remove all `EndRegion` statements that are not involved in borrows.
+    passes.push_pass(MIR_CONST, mir::transform::clean_end_regions::CleanEndRegions);
+
     // What we need to do constant evaluation.
     passes.push_pass(MIR_CONST, mir::transform::simplify::SimplifyCfg::new("initial"));
     passes.push_pass(MIR_CONST, mir::transform::type_check::TypeckMir);

--- a/src/librustc_mir/build/block.rs
+++ b/src/librustc_mir/build/block.rs
@@ -71,7 +71,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         let outer_visibility_scope = this.visibility_scope;
         let source_info = this.source_info(span);
         for stmt in stmts {
-            let Stmt { span: _, kind, opt_destruction_extent } = this.hir.mirror(stmt);
+            let Stmt { span, kind, opt_destruction_extent } = this.hir.mirror(stmt);
             match kind {
                 StmtKind::Expr { scope, expr } => {
                     unpack!(block = this.in_opt_scope(
@@ -122,7 +122,6 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         if let Some(expr) = expr {
             unpack!(block = this.into(destination, block, expr));
         } else {
-            let source_info = this.source_info(span);
             this.cfg.push_assign_unit(block, source_info, destination);
         }
         // Finally, we pop all the let scopes before exiting out from the scope of block

--- a/src/librustc_mir/build/cfg.rs
+++ b/src/librustc_mir/build/cfg.rs
@@ -14,6 +14,7 @@
 //! Routines for manipulating the control-flow graph.
 
 use build::CFG;
+use rustc::middle::region::CodeExtent;
 use rustc::mir::*;
 
 impl<'tcx> CFG<'tcx> {
@@ -41,6 +42,16 @@ impl<'tcx> CFG<'tcx> {
     pub fn push(&mut self, block: BasicBlock, statement: Statement<'tcx>) {
         debug!("push({:?}, {:?})", block, statement);
         self.block_data_mut(block).statements.push(statement);
+    }
+
+    pub fn push_end_region(&mut self,
+                           block: BasicBlock,
+                           source_info: SourceInfo,
+                           extent: CodeExtent) {
+        self.push(block, Statement {
+            source_info: source_info,
+            kind: StatementKind::EndRegion(extent),
+        });
     }
 
     pub fn push_assign(&mut self,

--- a/src/librustc_mir/build/expr/as_lvalue.rs
+++ b/src/librustc_mir/build/expr/as_lvalue.rs
@@ -40,7 +40,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         let source_info = this.source_info(expr_span);
         match expr.kind {
             ExprKind::Scope { extent, value } => {
-                this.in_scope(extent, block, |this| this.as_lvalue(block, value))
+                this.in_scope((extent, source_info), block, |this| this.as_lvalue(block, value))
             }
             ExprKind::Field { lhs, name } => {
                 let lvalue = unpack!(block = this.as_lvalue(block, lhs));

--- a/src/librustc_mir/build/expr/as_operand.rs
+++ b/src/librustc_mir/build/expr/as_operand.rs
@@ -56,6 +56,8 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         let this = self;
 
         if let ExprKind::Scope { extent, value } = expr.kind {
+            let source_info = this.source_info(expr.span);
+            let extent = (extent, source_info);
             return this.in_scope(extent, block, |this| {
                 this.as_operand(block, scope, value)
             });

--- a/src/librustc_mir/build/expr/as_rvalue.rs
+++ b/src/librustc_mir/build/expr/as_rvalue.rs
@@ -59,6 +59,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
 
         match expr.kind {
             ExprKind::Scope { extent, value } => {
+                let extent = (extent, source_info);
                 this.in_scope(extent, block, |this| this.as_rvalue(block, scope, value))
             }
             ExprKind::Repeat { value, count } => {
@@ -99,7 +100,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 // to start, malloc some memory of suitable type (thus far, uninitialized):
                 let box_ = Rvalue::NullaryOp(NullOp::Box, value.ty);
                 this.cfg.push_assign(block, source_info, &result, box_);
-                this.in_scope(value_extents, block, |this| {
+                this.in_scope((value_extents, source_info), block, |this| {
                     // schedule a shallow free of that memory, lest we unwind:
                     this.schedule_box_free(expr_span, value_extents, &result, value.ty);
                     // initialize the box contents:

--- a/src/librustc_mir/build/expr/as_temp.rs
+++ b/src/librustc_mir/build/expr/as_temp.rs
@@ -49,7 +49,6 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
 
         let expr_ty = expr.ty.clone();
         let temp = this.temp(expr_ty.clone(), expr_span);
-        let source_info = this.source_info(expr_span);
 
         if !expr_ty.is_never() && temp_lifetime.is_some() {
             this.cfg.push(block, Statement {

--- a/src/librustc_mir/build/expr/as_temp.rs
+++ b/src/librustc_mir/build/expr/as_temp.rs
@@ -39,14 +39,15 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                block, temp_lifetime, expr);
         let this = self;
 
+        let expr_span = expr.span;
+        let source_info = this.source_info(expr_span);
         if let ExprKind::Scope { extent, value } = expr.kind {
-            return this.in_scope(extent, block, |this| {
+            return this.in_scope((extent, source_info), block, |this| {
                 this.as_temp(block, temp_lifetime, value)
             });
         }
 
         let expr_ty = expr.ty.clone();
-        let expr_span = expr.span;
         let temp = this.temp(expr_ty.clone(), expr_span);
         let source_info = this.source_info(expr_span);
 

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -39,6 +39,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
 
         match expr.kind {
             ExprKind::Scope { extent, value } => {
+                let extent = (extent, source_info);
                 this.in_scope(extent, block, |this| this.into(destination, block, value))
             }
             ExprKind::Block { body: ast_block } => {

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -234,7 +234,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                             .collect();
 
                     let success = this.cfg.start_new_block();
-                    let cleanup = this.diverge_cleanup();
+                    let cleanup = this.diverge_cleanup(expr_span);
                     this.cfg.terminate(block, source_info, TerminatorKind::Call {
                         func: fun,
                         args: args,

--- a/src/librustc_mir/build/expr/stmt.rs
+++ b/src/librustc_mir/build/expr/stmt.rs
@@ -24,7 +24,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         match expr.kind {
             ExprKind::Scope { extent, value } => {
                 let value = this.hir.mirror(value);
-                this.in_scope(extent, block, |this| this.stmt_expr(block, value))
+                this.in_scope((extent, source_info), block, |this| this.stmt_expr(block, value))
             }
             ExprKind::Assign { lhs, rhs } => {
                 let lhs = this.hir.mirror(lhs);
@@ -81,7 +81,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                     *this.find_breakable_scope(expr_span, label);
                 let continue_block = continue_block.expect(
                     "Attempted to continue in non-continuable breakable block");
-                this.exit_scope(expr_span, extent, block, continue_block);
+                this.exit_scope(expr_span, (extent, source_info), block, continue_block);
                 this.cfg.start_new_block().unit()
             }
             ExprKind::Break { label, value } => {
@@ -99,7 +99,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 } else {
                     this.cfg.push_assign_unit(block, source_info, &destination)
                 }
-                this.exit_scope(expr_span, extent, block, break_block);
+                this.exit_scope(expr_span, (extent, source_info), block, break_block);
                 this.cfg.start_new_block().unit()
             }
             ExprKind::Return { value } => {
@@ -116,7 +116,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 };
                 let extent = this.extent_of_return_scope();
                 let return_block = this.return_block();
-                this.exit_scope(expr_span, extent, block, return_block);
+                this.exit_scope(expr_span, (extent, source_info), block, return_block);
                 this.cfg.start_new_block().unit()
             }
             ExprKind::InlineAsm { asm, outputs, inputs } => {

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -306,7 +306,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                     let bool_ty = self.hir.bool_ty();
                     let eq_result = self.temp(bool_ty, test.span);
                     let eq_block = self.cfg.start_new_block();
-                    let cleanup = self.diverge_cleanup();
+                    let cleanup = self.diverge_cleanup(test.span);
                     self.cfg.terminate(block, source_info, TerminatorKind::Call {
                         func: Operand::Constant(box Constant {
                             span: test.span,

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -339,8 +339,9 @@ fn construct_fn<'a, 'gcx, 'tcx, A>(hir: Cx<'a, 'gcx, 'tcx>,
     let call_site_extent = CodeExtent::CallSiteScope(body.id());
     let arg_extent = CodeExtent::ParameterScope(body.id());
     let mut block = START_BLOCK;
-    unpack!(block = builder.in_scope(call_site_extent, block, |builder| {
-        unpack!(block = builder.in_scope(arg_extent, block, |builder| {
+    let source_info = builder.source_info(span);
+    unpack!(block = builder.in_scope((call_site_extent, source_info), block, |builder| {
+        unpack!(block = builder.in_scope((arg_extent, source_info), block, |builder| {
             builder.args_and_body(block, &arguments, arg_extent, &body.value)
         }));
         // Attribute epilogue to function's closing brace

--- a/src/librustc_mir/hair/mod.rs
+++ b/src/librustc_mir/hair/mod.rs
@@ -33,6 +33,7 @@ pub use rustc_const_eval::pattern::{BindingMode, Pattern, PatternKind, FieldPatt
 pub struct Block<'tcx> {
     pub targeted_by_break: bool,
     pub extent: CodeExtent,
+    pub opt_destruction_extent: Option<CodeExtent>,
     pub span: Span,
     pub stmts: Vec<StmtRef<'tcx>>,
     pub expr: Option<ExprRef<'tcx>>,
@@ -47,6 +48,7 @@ pub enum StmtRef<'tcx> {
 pub struct Stmt<'tcx> {
     pub span: Span,
     pub kind: StmtKind<'tcx>,
+    pub opt_destruction_extent: Option<CodeExtent>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/librustc_mir/transform/clean_end_regions.rs
+++ b/src/librustc_mir/transform/clean_end_regions.rs
@@ -1,0 +1,84 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! This module provides one pass, `CleanEndRegions`, that reduces the
+//! set of `EndRegion` statements in the MIR.
+//!
+//! The "pass" is actually implemented as two traversals (aka visits)
+//! of the input MIR. The first traversal, `GatherBorrowedRegions`,
+//! finds all of the regions in the MIR that are involved in a borrow.
+//!
+//! The second traversal, `DeleteTrivialEndRegions`, walks over the
+//! MIR and removes any `EndRegion` that is applied to a region that
+//! was not seen in the previous pass.
+
+use rustc_data_structures::fx::FxHashSet;
+
+use rustc::middle::region::CodeExtent;
+use rustc::mir::transform::{MirPass, MirSource};
+use rustc::mir::{BasicBlock, Location, Mir, Rvalue, Statement, StatementKind};
+use rustc::mir::visit::{MutVisitor, Visitor};
+use rustc::ty::{RegionKind, TyCtxt};
+
+pub struct CleanEndRegions;
+
+struct GatherBorrowedRegions {
+    seen_regions: FxHashSet<CodeExtent>,
+}
+
+struct DeleteTrivialEndRegions<'a> {
+    seen_regions: &'a FxHashSet<CodeExtent>,
+}
+
+impl MirPass for CleanEndRegions {
+    fn run_pass<'a, 'tcx>(&self,
+                          _tcx: TyCtxt<'a, 'tcx, 'tcx>,
+                          _source: MirSource,
+                          mir: &mut Mir<'tcx>) {
+        let mut gather = GatherBorrowedRegions { seen_regions: FxHashSet() };
+        gather.visit_mir(mir);
+
+        let mut delete = DeleteTrivialEndRegions { seen_regions: &mut gather.seen_regions };
+        delete.visit_mir(mir);
+    }
+}
+
+impl<'tcx> Visitor<'tcx> for GatherBorrowedRegions {
+    fn visit_rvalue(&mut self,
+                    rvalue: &Rvalue<'tcx>,
+                    location: Location) {
+        if let Rvalue::Ref(r, _, _) = *rvalue {
+            if let RegionKind::ReScope(ce) = *r {
+                self.seen_regions.insert(ce);
+            }
+        }
+        self.super_rvalue(rvalue, location);
+    }
+}
+
+impl<'a, 'tcx> MutVisitor<'tcx> for DeleteTrivialEndRegions<'a> {
+    fn visit_statement(&mut self,
+                       block: BasicBlock,
+                       statement: &mut Statement<'tcx>,
+                       location: Location) {
+        let mut delete_it = false;
+
+        if let StatementKind::EndRegion(ref extent) = statement.kind {
+            if !self.seen_regions.contains(extent) {
+                delete_it = true;
+            }
+        }
+
+        if delete_it {
+            statement.kind = StatementKind::Nop;
+        }
+        self.super_statement(block, statement, location);
+    }
+}

--- a/src/librustc_mir/transform/erase_regions.rs
+++ b/src/librustc_mir/transform/erase_regions.rs
@@ -65,6 +65,15 @@ impl<'a, 'tcx> MutVisitor<'tcx> for EraseRegionsVisitor<'a, 'tcx> {
                             substs: &mut ClosureSubsts<'tcx>) {
         *substs = self.tcx.erase_regions(substs);
     }
+
+    fn visit_statement(&mut self,
+                       _block: BasicBlock,
+                       statement: &mut Statement<'tcx>,
+                       _location: Location) {
+        if let StatementKind::EndRegion(_) = statement.kind {
+            statement.kind = StatementKind::Nop;
+        }
+    }
 }
 
 pub struct EraseRegions;

--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -24,6 +24,7 @@ use syntax::ast;
 use syntax_pos::{DUMMY_SP, Span};
 use transform;
 
+pub mod clean_end_regions;
 pub mod simplify_branches;
 pub mod simplify;
 pub mod erase_regions;

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -907,6 +907,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Qualifier<'a, 'tcx, 'tcx> {
                 StatementKind::StorageLive(_) |
                 StatementKind::StorageDead(_) |
                 StatementKind::InlineAsm {..} |
+                StatementKind::EndRegion(_) |
                 StatementKind::Nop => {}
             }
         });

--- a/src/librustc_mir/transform/type_check.rs
+++ b/src/librustc_mir/transform/type_check.rs
@@ -413,6 +413,7 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
                 }
             }
             StatementKind::InlineAsm { .. } |
+            StatementKind::EndRegion(_) |
             StatementKind::Nop => {}
         }
     }

--- a/src/librustc_mir/util/patch.rs
+++ b/src/librustc_mir/util/patch.rs
@@ -46,6 +46,7 @@ impl<'tcx> MirPatch<'tcx> {
         for (bb, block) in mir.basic_blocks().iter_enumerated() {
             if let TerminatorKind::Resume = block.terminator().kind {
                 if block.statements.len() > 0 {
+                    assert!(resume_stmt_block.is_none());
                     resume_stmt_block = Some(bb);
                 } else {
                     resume_block = Some(bb);

--- a/src/librustc_passes/mir_stats.rs
+++ b/src/librustc_passes/mir_stats.rs
@@ -125,6 +125,7 @@ impl<'a, 'tcx> mir_visit::Visitor<'tcx> for StatCollector<'a, 'tcx> {
         self.record("Statement", statement);
         self.record(match statement.kind {
             StatementKind::Assign(..) => "StatementKind::Assign",
+            StatementKind::EndRegion(..) => "StatementKind::EndRegion",
             StatementKind::SetDiscriminant { .. } => "StatementKind::SetDiscriminant",
             StatementKind::StorageLive(..) => "StatementKind::StorageLive",
             StatementKind::StorageDead(..) => "StatementKind::StorageDead",

--- a/src/librustc_trans/mir/constant.rs
+++ b/src/librustc_trans/mir/constant.rs
@@ -284,6 +284,7 @@ impl<'a, 'tcx> MirConstContext<'a, 'tcx> {
                     }
                     mir::StatementKind::StorageLive(_) |
                     mir::StatementKind::StorageDead(_) |
+                    mir::StatementKind::EndRegion(_) |
                     mir::StatementKind::Nop => {}
                     mir::StatementKind::InlineAsm { .. } |
                     mir::StatementKind::SetDiscriminant{ .. } => {

--- a/src/librustc_trans/mir/statement.rs
+++ b/src/librustc_trans/mir/statement.rs
@@ -86,6 +86,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                 asm::trans_inline_asm(&bcx, asm, outputs, input_vals);
                 bcx
             }
+            mir::StatementKind::EndRegion(_) |
             mir::StatementKind::Nop => bcx,
         }
     }

--- a/src/test/codegen/drop.rs
+++ b/src/test/codegen/drop.rs
@@ -32,9 +32,9 @@ pub fn droppy() {
 // CHECK-NOT: invoke{{.*}}drop{{.*}}SomeUniqueName
 // CHECK: call{{.*}}drop{{.*}}SomeUniqueName
 // CHECK: call{{.*}}drop{{.*}}SomeUniqueName
-// CHECK: call{{.*}}drop{{.*}}SomeUniqueName
 // CHECK-NOT: call{{.*}}drop{{.*}}SomeUniqueName
 // CHECK: invoke{{.*}}drop{{.*}}SomeUniqueName
+// CHECK: call{{.*}}drop{{.*}}SomeUniqueName
 // CHECK: invoke{{.*}}drop{{.*}}SomeUniqueName
 // CHECK: call{{.*}}drop{{.*}}SomeUniqueName
 // CHECK-NOT: {{(call|invoke).*}}drop{{.*}}SomeUniqueName

--- a/src/test/mir-opt/README.md
+++ b/src/test/mir-opt/README.md
@@ -22,7 +22,32 @@ All the test information is in comments so the test is runnable.
 
 For each $file_name, compiletest expects [$expected_line_0, ...,
 $expected_line_N] to appear in the dumped MIR in order.  Currently it allows
-other non-matched lines before, after and in-between.  
+other non-matched lines before, after and in-between. Note that this includes
+lines that end basic blocks or begin new ones; it is good practice
+in your tests to include the terminator for each of your basic blocks as an
+internal sanity check guarding against a test like:
+
+```
+bb0: {
+    StorageLive(_1);
+    _1 = const true;
+    StorageDead(_1);
+}
+```
+
+that will inadvertantly pattern-matching against:
+
+```
+bb0: {
+    StorageLive(_1);
+    _1 = const true;
+    goto -> bb1
+}
+bb1: {
+    StorageDead(_1);
+    return;
+}
+```
 
 Lines match ignoring whitespace, and the prefix "//" is removed.
 

--- a/src/test/mir-opt/basic_assignment.rs
+++ b/src/test/mir-opt/basic_assignment.rs
@@ -50,7 +50,7 @@ fn main() {
 //         StorageLive(_6);
 //         StorageLive(_7);
 //         _7 = _4;
-//         replace(_6 <- _7) -> [return: bb5, unwind: bb4];
+//         replace(_6 <- _7) -> [return: bb6, unwind: bb7];
 //     }
 //     bb1: {
 //         resume;
@@ -59,24 +59,30 @@ fn main() {
 //         drop(_4) -> bb1;
 //     }
 //     bb3: {
-//         drop(_6) -> bb2;
+//         goto -> bb2;
 //     }
 //     bb4: {
-//         drop(_7) -> bb3;
+//         drop(_6) -> bb3;
 //     }
 //     bb5: {
-//         drop(_7) -> [return: bb6, unwind: bb3];
+//         goto -> bb4;
 //     }
 //     bb6: {
-//         StorageDead(_7);
-//         _0 = ();
-//         drop(_6) -> [return: bb7, unwind: bb2];
+//         drop(_7) -> [return: bb8, unwind: bb4];
 //     }
 //     bb7: {
-//         StorageDead(_6);
-//         drop(_4) -> bb8;
+//         drop(_7) -> bb5;
 //     }
 //     bb8: {
+//         StorageDead(_7);
+//         _0 = ();
+//         drop(_6) -> [return: bb9, unwind: bb2];
+//     }
+//     bb9: {
+//         StorageDead(_6);
+//         drop(_4) -> bb10;
+//     }
+//     bb10: {
 //         StorageDead(_4);
 //         StorageDead(_2);
 //         StorageDead(_1);

--- a/src/test/mir-opt/end_region_1.rs
+++ b/src/test/mir-opt/end_region_1.rs
@@ -1,0 +1,38 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z identify_regions
+// ignore-tidy-linelength
+
+// This is just about the simplest program that exhibits an EndRegion.
+
+fn main() {
+    let a = 3;
+    let b = &a;
+}
+
+// END RUST SOURCE
+// START rustc.node4.SimplifyCfg-qualify-consts.after.mir
+//     let mut _0: ();
+//     let _1: i32;
+//     let _2: &'6_1rce i32;
+//
+//     bb0: {
+//         StorageLive(_1);
+//         _1 = const 3i32;
+//         StorageLive(_2);
+//         _2 = &'6_1rce _1;
+//         _0 = ();
+//         StorageDead(_2);
+//         EndRegion('6_1rce);
+//         StorageDead(_1);
+//         return;
+//     }
+// END rustc.node4.SimplifyCfg-qualify-consts.after.mir

--- a/src/test/mir-opt/end_region_2.rs
+++ b/src/test/mir-opt/end_region_2.rs
@@ -1,0 +1,66 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z identify_regions
+// ignore-tidy-linelength
+
+// We will EndRegion for borrows in a loop that occur before break but
+// not those after break.
+
+fn main() {
+    loop {
+        let a = true;
+        let b = &a;
+        if a { break; }
+        let c = &a;
+    }
+}
+
+// END RUST SOURCE
+// START rustc.node4.SimplifyCfg-qualify-consts.after.mir
+//     let mut _0: ();
+//     let _2: bool;
+//     let _3: &'7_1rce bool;
+//     let _7: &'7_3rce bool;
+//     let mut _4: ();
+//     let mut _5: bool;
+//     bb0: {
+//         goto -> bb1;
+//     }
+//     bb1: {
+//         StorageLive(_2);
+//         _2 = const true;
+//         StorageLive(_3);
+//         _3 = &'7_1rce _2;
+//         StorageLive(_5);
+//         _5 = _2;
+//         switchInt(_5) -> [0u8: bb3, otherwise: bb2];
+//     }
+//     bb2: {
+//         _0 = ();
+//         StorageDead(_5);
+//         StorageDead(_3);
+//         EndRegion('7_1rce);
+//         StorageDead(_2);
+//         return;
+//     }
+//     bb3: {
+//         StorageDead(_5);
+//         StorageLive(_7);
+//         _7 = &'7_3rce _2;
+//         _1 = ();
+//         StorageDead(_7);
+//         EndRegion('7_3rce);
+//         StorageDead(_3);
+//         EndRegion('7_1rce);
+//         StorageDead(_2);
+//         goto -> bb1;
+//     }
+// END rustc.node4.SimplifyCfg-qualify-consts.after.mir

--- a/src/test/mir-opt/end_region_3.rs
+++ b/src/test/mir-opt/end_region_3.rs
@@ -1,0 +1,69 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z identify_regions
+// ignore-tidy-linelength
+
+// Binding the borrow's subject outside the loop does not increase the
+// scope of the borrow.
+
+fn main() {
+    let mut a;
+    loop {
+        a = true;
+        let b = &a;
+        if a { break; }
+        let c = &a;
+    }
+}
+
+// END RUST SOURCE
+// START rustc.node4.SimplifyCfg-qualify-consts.after.mir
+//     let mut _0: ();
+//     let mut _1: bool;
+//     let _3: &'9_1rce bool;
+//     let _7: &'9_3rce bool;
+//     let mut _2: ();
+//     let mut _4: ();
+//     let mut _5: bool;
+//
+//     bb0: {
+//         StorageLive(_1);
+//         goto -> bb1;
+//     }
+//     bb1: {
+//         _1 = const true;
+//         StorageLive(_3);
+//         _3 = &'9_1rce _1;
+//         StorageLive(_5);
+//         _5 = _1;
+//         switchInt(_5) -> [0u8: bb3, otherwise: bb2];
+//     }
+//     bb2: {
+//         _0 = ();
+//         StorageDead(_5);
+//         StorageDead(_3);
+//         EndRegion('9_1rce);
+//         StorageDead(_1);
+//         return;
+//     }
+//     bb3: {
+//         _4 = ();
+//         StorageDead(_5);
+//         StorageLive(_7);
+//         _7 = &'9_3rce _1;
+//         _2 = ();
+//         StorageDead(_7);
+//         EndRegion('9_3rce);
+//         StorageDead(_3);
+//         EndRegion('9_1rce);
+//         goto -> bb1;
+//     }
+// END rustc.node4.SimplifyCfg-qualify-consts.after.mir

--- a/src/test/mir-opt/end_region_4.rs
+++ b/src/test/mir-opt/end_region_4.rs
@@ -1,0 +1,75 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z identify_regions
+// ignore-tidy-linelength
+
+// Unwinding should EndRegion for in-scope borrows: Direct borrows.
+
+fn main() {
+    let d = D(0);
+    let a = 0;
+    let b = &a;
+    foo(*b);
+    let c = &a;
+}
+
+struct D(i32);
+impl Drop for D { fn drop(&mut self) { println!("dropping D({})", self.0); } }
+
+fn foo(i: i32) {
+    if i > 0 { panic!("im positive"); }
+}
+
+// END RUST SOURCE
+// START rustc.node4.SimplifyCfg-qualify-consts.after.mir
+//     let mut _0: ();
+//     let _1: D;
+//     let _3: i32;
+//     let _4: &'6_2rce i32;
+//     let _7: &'6_4rce i32;
+//     let mut _5: ();
+//     let mut _6: i32;
+//
+//     bb0: {
+//         StorageLive(_1);
+//         _1 = D::{{constructor}}(const 0i32,);
+//         StorageLive(_3);
+//         _3 = const 0i32;
+//         StorageLive(_4);
+//         _4 = &'6_2rce _3;
+//         StorageLive(_6);
+//         _6 = (*_4);
+//         _5 = const foo(_6) -> [return: bb2, unwind: bb3];
+//     }
+//     bb1: {
+//         resume;
+//     }
+//     bb2: {
+//         StorageDead(_6);
+//         StorageLive(_7);
+//         _7 = &'6_4rce _3;
+//         _0 = ();
+//         StorageDead(_7);
+//         EndRegion('6_4rce);
+//         StorageDead(_4);
+//         EndRegion('6_2rce);
+//         StorageDead(_3);
+//         drop(_1) -> bb4;
+//     }
+//     bb3: {
+//         EndRegion('6_2rce);
+//         drop(_1) -> bb1;
+//     }
+//     bb4: {
+//         StorageDead(_1);
+//         return;
+//     }
+// END rustc.node4.SimplifyCfg-qualify-consts.after.mir

--- a/src/test/mir-opt/end_region_5.rs
+++ b/src/test/mir-opt/end_region_5.rs
@@ -1,0 +1,80 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z identify_regions -Z span_free_formats
+// ignore-tidy-linelength
+
+// Unwinding should EndRegion for in-scope borrows: Borrowing via by-ref closure.
+
+fn main() {
+    let d = D(0);
+    foo(|| -> i32 { d.0 });
+}
+
+struct D(i32);
+impl Drop for D { fn drop(&mut self) { println!("dropping D({})", self.0); } }
+
+fn foo<F>(f: F) where F: FnOnce() -> i32 {
+    if f() > 0 { panic!("im positive"); }
+}
+
+// END RUST SOURCE
+// START rustc.node4.SimplifyCfg-qualify-consts.after.mir
+// fn main() -> () {
+//     let mut _0: ();
+//     let _1: D;
+//     let mut _2: ();
+//     let mut _3: ();
+//     let mut _4: [closure@NodeId(18) d: &'19mce D];
+//     let mut _5: &'19mce D;
+//
+//     bb0: {
+//         StorageLive(_1);
+//         _1 = D::{{constructor}}(const 0i32,);
+//         StorageLive(_4);
+//         StorageLive(_5);
+//         _5 = &'19mce _1;
+//         _4 = [closure@NodeId(18)] { d: _5 };
+//         StorageDead(_5);
+//         _3 = const foo(_4) -> [return: bb2, unwind: bb3];
+//     }
+//     bb1: {
+//         resume;
+//     }
+//     bb2: {
+//         StorageDead(_4);
+//         EndRegion('19mce);
+//         _0 = ();
+//         drop(_1) -> bb4;
+//     }
+//     bb3: {
+//         EndRegion('19mce);
+//         drop(_1) -> bb1;
+//     }
+//     bb4: {
+//         StorageDead(_1);
+//         return;
+//     }
+// }
+// END rustc.node4.SimplifyCfg-qualify-consts.after.mir
+
+// START rustc.node18.SimplifyCfg-qualify-consts.after.mir
+// fn main::{{closure}}(_1: [closure@NodeId(18) d:&'19mce D]) -> i32 {
+//    let mut _0: i32;
+//    let mut _2: i32;
+//
+//    bb0: {
+//        StorageLive(_2);
+//        _2 = ((*(_1.0: &'19mce D)).0: i32);
+//        _0 = _2;
+//        StorageDead(_2);
+//        return;
+//    }
+// END rustc.node18.SimplifyCfg-qualify-consts.after.mir

--- a/src/test/mir-opt/end_region_6.rs
+++ b/src/test/mir-opt/end_region_6.rs
@@ -1,0 +1,83 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z identify_regions -Z span_free_formats
+// ignore-tidy-linelength
+
+// Unwinding should EndRegion for in-scope borrows: 2nd borrow within by-ref closure.
+
+fn main() {
+    let d = D(0);
+    foo(|| -> i32 { let r = &d; r.0 });
+}
+
+struct D(i32);
+impl Drop for D { fn drop(&mut self) { println!("dropping D({})", self.0); } }
+
+fn foo<F>(f: F) where F: FnOnce() -> i32 {
+    if f() > 0 { panic!("im positive"); }
+}
+
+// END RUST SOURCE
+// START rustc.node4.SimplifyCfg-qualify-consts.after.mir
+//     let mut _0: ();
+//     let _1: D;
+//     let mut _2: ();
+//     let mut _3: ();
+//     let mut _4: [closure@NodeId(22) d:&'23mce D];
+//     let mut _5: &'23mce D;
+//
+//     bb0: {
+//         StorageLive(_1);
+//         _1 = D::{{constructor}}(const 0i32,);
+//         StorageLive(_4);
+//         StorageLive(_5);
+//         _5 = &'23mce _1;
+//         _4 = [closure@NodeId(22)] { d: _5 };
+//         StorageDead(_5);
+//         _3 = const foo(_4) -> [return: bb2, unwind: bb3];
+//     }
+//     bb1: {
+//         resume;
+//     }
+//     bb2: {
+//         StorageDead(_4);
+//         EndRegion('23mce);
+//         _0 = ();
+//         drop(_1) -> bb4;
+//     }
+//     bb3: {
+//         EndRegion('23mce);
+//         drop(_1) -> bb1;
+//     }
+//     bb4: {
+//         StorageDead(_1);
+//         return;
+//     }
+// END rustc.node4.SimplifyCfg-qualify-consts.after.mir
+
+// START rustc.node22.SimplifyCfg-qualify-consts.after.mir
+// fn main::{{closure}}(_1: [closure@NodeId(22) d:&'23mce D]) -> i32 {
+//     let mut _0: i32;
+//     let _2: &'14_0rce D;
+//     let mut _3: i32;
+//
+//     bb0: {
+//         StorageLive(_2);
+//         _2 = &'14_0rce (*(_1.0: &'23mce D));
+//         StorageLive(_3);
+//         _3 = ((*_2).0: i32);
+//         _0 = _3;
+//         StorageDead(_3);
+//         StorageDead(_2);
+//         EndRegion('14_0rce);
+//         return;
+//     }
+// END rustc.node22.SimplifyCfg-qualify-consts.after.mir

--- a/src/test/mir-opt/end_region_7.rs
+++ b/src/test/mir-opt/end_region_7.rs
@@ -1,0 +1,97 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z identify_regions -Z span_free_formats
+// ignore-tidy-linelength
+
+// Unwinding should EndRegion for in-scope borrows: Borrow of moved data.
+
+fn main() {
+    let d = D(0);
+    foo(move || -> i32 { let r = &d; r.0 });
+}
+
+struct D(i32);
+impl Drop for D { fn drop(&mut self) { println!("dropping D({})", self.0); } }
+
+fn foo<F>(f: F) where F: FnOnce() -> i32 {
+    if f() > 0 { panic!("im positive"); }
+}
+
+// END RUST SOURCE
+// START rustc.node4.SimplifyCfg-qualify-consts.after.mir
+// fn main() -> () {
+//     let mut _0: ();
+//     let _1: D;
+//     let mut _2: ();
+//     let mut _3: ();
+//     let mut _4: [closure@NodeId(22) d:D];
+//     let mut _5: D;
+//
+//     bb0: {
+//         StorageLive(_1);
+//         _1 = D::{{constructor}}(const 0i32,);
+//         StorageLive(_4);
+//         StorageLive(_5);
+//         _5 = _1;
+//         _4 = [closure@NodeId(22)] { d: _5 };
+//         drop(_5) -> [return: bb4, unwind: bb3];
+//     }
+//     bb1: {
+//         resume;
+//     }
+//     bb2: {
+//         drop(_1) -> bb1;
+//     }
+//     bb3: {
+//         drop(_4) -> bb2;
+//     }
+//     bb4: {
+//         StorageDead(_5);
+//         _3 = const foo(_4) -> [return: bb5, unwind: bb3];
+//     }
+//     bb5: {
+//         drop(_4) -> [return: bb6, unwind: bb2];
+//     }
+//     bb6: {
+//         StorageDead(_4);
+//         _0 = ();
+//         drop(_1) -> bb7;
+//     }
+//     bb7: {
+//         StorageDead(_1);
+//         return;
+//     }
+// }
+// END rustc.node4.SimplifyCfg-qualify-consts.after.mir
+
+// START rustc.node22.SimplifyCfg-qualify-consts.after.mir
+// fn main::{{closure}}(_1: [closure@NodeId(22) d:D]) -> i32 {
+//     let mut _0: i32;
+//     let _2: &'14_0rce D;
+//     let mut _3: ();
+//     let mut _4: i32;
+//
+//     bb0: {
+//         StorageLive(_2);
+//         _2 = &'14_0rce (_1.0: D);
+//         StorageLive(_4);
+//         _4 = ((*_2).0: i32);
+//         _0 = _4;
+//         StorageDead(_4);
+//         StorageDead(_2);
+//         EndRegion('14_0rce);
+//         drop(_1) -> bb1;
+//     }
+//     bb1: {
+//         return;
+//     }
+// }
+// END rustc.node22.SimplifyCfg-qualify-consts.after.mir

--- a/src/test/mir-opt/end_region_8.rs
+++ b/src/test/mir-opt/end_region_8.rs
@@ -1,0 +1,86 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z identify_regions -Z span_free_formats
+// ignore-tidy-linelength
+
+// Unwinding should EndRegion for in-scope borrows: Move of borrow into closure.
+
+fn main() {
+    let d = D(0);
+    let r = &d;
+    foo(move || -> i32 { r.0 });
+}
+
+struct D(i32);
+impl Drop for D { fn drop(&mut self) { println!("dropping D({})", self.0); } }
+
+fn foo<F>(f: F) where F: FnOnce() -> i32 {
+    if f() > 0 { panic!("im positive"); }
+}
+
+// END RUST SOURCE
+// START rustc.node4.SimplifyCfg-qualify-consts.after.mir
+// fn main() -> () {
+//     let mut _0: ();
+//     let _1: D;
+//     let _3: &'6_1rce D;
+//     let mut _2: ();
+//     let mut _4: ();
+//     let mut _5: [closure@NodeId(22) r:&'6_1rce D];
+//     let mut _6: &'6_1rce D;
+//
+//     bb0: {
+//         StorageLive(_1);
+//         _1 = D::{{constructor}}(const 0i32,);
+//         StorageLive(_3);
+//         _3 = &'6_1rce _1;
+//         StorageLive(_5);
+//         StorageLive(_6);
+//         _6 = _3;
+//         _5 = [closure@NodeId(22)] { r: _6 };
+//         StorageDead(_6);
+//         _4 = const foo(_5) -> [return: bb2, unwind: bb3];
+//     }
+//     bb1: {
+//         resume;
+//     }
+//     bb2: {
+//         StorageDead(_5);
+//         _0 = ();
+//         StorageDead(_3);
+//         EndRegion('6_1rce);
+//         drop(_1) -> bb4;
+//     }
+//     bb3: {
+//         EndRegion('6_1rce);
+//         drop(_1) -> bb1;
+//     }
+//     bb4: {
+//         StorageDead(_1);
+//         return;
+//     }
+// }
+// END rustc.node4.SimplifyCfg-qualify-consts.after.mir
+
+// START rustc.node22.SimplifyCfg-qualify-consts.after.mir
+// fn main::{{closure}}(_1: [closure@NodeId(22) r:&'6_1rce D]) -> i32 {
+//     let mut _0: i32;
+//     let mut _2: i32;
+//
+//     bb0: {
+//         StorageLive(_2);
+//         _2 = ((*(_1.0: &'6_1rce D)).0: i32);
+//         _0 = _2;
+//         StorageDead(_2);
+//         return;
+//     }
+// }
+// END rustc.node22.SimplifyCfg-qualify-consts.after.mir

--- a/src/test/mir-opt/end_region_9.rs
+++ b/src/test/mir-opt/end_region_9.rs
@@ -1,0 +1,85 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z identify_regions -Z span_free_formats
+// ignore-tidy-linelength
+
+// This test models a scenario that arielb1 found during review.
+// Namely, any filtering of EndRegions must ensure to continue to emit
+// any necessary EndRegions that occur earlier in the source than the
+// first borrow involving that region.
+//
+// It is tricky to actually construct examples of this, which is the
+// main reason that I am keeping this test even though I have now
+// removed the pre-filter that motivated the test in the first place.
+
+fn main() {
+    let mut second_iter = false;
+    let x = 3;
+    'a: loop {
+        let mut y;
+        loop {
+            if second_iter {
+                break 'a; // want to generate `EndRegion('a)` here
+            } else {
+                y = &/*'a*/ x;
+            }
+            second_iter = true;
+        }
+    }
+}
+
+// END RUST SOURCE
+// START rustc.node4.SimplifyCfg-qualify-consts.after.mir
+// fn main() -> () {
+//     let mut _0: ();
+//     let mut _1: bool;
+//     let _2: i32;
+//     let mut _4: &'13_0rce i32;
+//     let mut _3: ();
+//     let mut _5: !;
+//     let mut _6: ();
+//     let mut _7: bool;
+//     let mut _8: !;
+//
+//     bb0: {
+//        StorageLive(_1);
+//        _1 = const false;
+//        StorageLive(_2);
+//        _2 = const 3i32;
+//        StorageLive(_4);
+//        goto -> bb1;
+//    }
+//
+//    bb1: {
+//        StorageLive(_7);
+//        _7 = _1;
+//        switchInt(_7) -> [0u8: bb3, otherwise: bb2];
+//    }
+//
+//    bb2: {
+//        _0 = ();
+//        StorageDead(_7);
+//        StorageDead(_4);
+//        EndRegion('13_0rce);
+//        StorageDead(_2);
+//        StorageDead(_1);
+//        return;
+//    }
+//
+//    bb3: {
+//        _4 = &'13_0rce _2;
+//        _6 = ();
+//        StorageDead(_7);
+//        _1 = const true;
+//        _3 = ();
+//        goto -> bb1;
+//    }
+// }


### PR DESCRIPTION
This PR adds an `EndRegion` statement to MIR (where the `EndRegion` statement is what terminates a borrow).

An earlier version of the PR implemented a dataflow analysis on borrow expressions, but I am now factoring that into a follow-up PR so that reviewing this one is easier. (And also because there are some revisions I want to make to that dataflow code, but I want this PR to get out of WIP status...)

This is a baby step towards MIR borrowck. I just want to get the review process going while I independently work on the remaining steps.