### PR TITLE
rustdoc: mark FFI functions with unsafety icon

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1806,12 +1806,13 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
                     String::new()
                 };
 
-                let mut unsafety_flag = "";
-                if let clean::FunctionItem(ref func) = myitem.inner {
-                    if func.unsafety == hir::Unsafety::Unsafe {
-                        unsafety_flag = "<a title='unsafe function' href='#'><sup>⚠</sup></a>";
+                let unsafety_flag = match myitem.inner {
+                    clean::FunctionItem(ref func) | clean::ForeignFunctionItem(ref func)
+                    if func.unsafety == hir::Unsafety::Unsafe => {
+                        "<a title='unsafe function' href='#'><sup>⚠</sup></a>"
                     }
-                }
+                    _ => "",
+                };
 
                 let doc_value = myitem.doc_value().unwrap_or("");
                 write!(w, "


### PR DESCRIPTION
Currently, in the list of functions, unsafe functions are marked with a superscript ⚠, but unsafe FFI functions are not. This patch treats unsafe FFI functions like other unsafe functions in this regard.