### PR TITLE
Added compile time optimization for bytewise slice comparison

### DIFF
--- a/src/libcore/Cargo.toml
+++ b/src/libcore/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Rust Project Developers"]
 name = "core"
 version = "0.0.0"
+build = "build.rs"
 
 [lib]
 name = "core"

--- a/src/libcore/build.rs
+++ b/src/libcore/build.rs
@@ -20,6 +20,9 @@
 //!             3 => cmp!($a, $b, u16, 0) && cmp!($a, $b, u8, 2),
 //!             4 => cmp!($a, $b, u32, 0),
 //!             ...
+//!         }
+//!     }}
+//! );
 //! ```
 //!
 //! The supported slice length can be set by changing the `OPT_LEN` variable.

--- a/src/libcore/build.rs
+++ b/src/libcore/build.rs
@@ -1,3 +1,15 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Code generation for bytewise slice comparison
+
 use std::{env, iter, io};
 use std::fs::File;
 use std::io::Write;

--- a/src/libcore/build.rs
+++ b/src/libcore/build.rs
@@ -1,0 +1,59 @@
+use std::{env, iter, io};
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+use std::error::Error;
+
+// Generates the code for the compile time optimization for bytewise slice comparison
+pub fn main() {
+    run().expect("Could not generate slice comparison source code.");
+}
+
+fn fill(indent: usize) -> String {
+    iter::repeat(' ').take(indent).collect()
+}
+
+fn run() -> Result<(), Box<Error>> {
+    let out_dir = env::var("OUT_DIR")?;
+    let dest_path = Path::new(&out_dir).join("memcmp_optimization.rs");
+    let mut f = File::create(&dest_path)?;
+
+    // Generate the slice comparison source code
+    writeln!(f, "macro_rules! slice_compare (")?;
+    writeln!(f, "{}($a:expr, $b:expr, $len:expr) => {{{{", fill(4))?;
+    writeln!(f, "{}match $len {{", fill(8))?;
+
+    for i in 1..257 {
+        let mut bits = i * 8 as usize;
+        let mut sizes = vec![8, 16, 32, 64];
+        let mut offset = 0;
+
+        write!(f, "{}{} => ", fill(12), i)?;
+        while !sizes.is_empty() {
+            let size = sizes.last().ok_or(io::Error::from(io::ErrorKind::Other))?.clone();
+            if bits >= size {
+                if offset > 0 {
+                    write!(f, " && ")?;
+                }
+                write!(f, "cmp!($a, $b, u{}, {})", size, offset)?;
+                bits = bits.checked_sub(size).ok_or(io::Error::from(io::ErrorKind::Other))?;
+                offset += size / 8;
+            } else {
+                sizes.pop();
+            }
+            if bits == 0 {
+                break;
+            }
+        }
+        writeln!(f, ",")?;
+    }
+
+    writeln!(f,
+             "{}_ => unsafe {{ memcmp($a, $b, $len) == 0 }},",
+             fill(12))?;
+
+    writeln!(f, "{}}}", fill(8))?;
+    writeln!(f, "{}}}}}", fill(4))?;
+    writeln!(f, ");")?;
+    Ok(())
+}

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -2177,6 +2177,16 @@ pub unsafe fn from_raw_parts_mut<'a, T>(p: *mut T, len: usize) -> &'a mut [T] {
 // Comparison traits
 //
 
+// A compile time optimization for faster bytewise slice comparison
+include!(concat!(env!("OUT_DIR"), "/memcmp_optimization.rs"));
+
+// The compare macro for the bytewise slice comparison
+macro_rules! cmp (
+    ($left:expr, $right: expr, $var:ident, $offset:expr) => {{
+        unsafe {*($left.offset($offset) as *const $var) == *($right.offset($offset) as *const $var)}
+    }}
+);
+
 extern {
     /// Call implementation provided memcmp
     ///
@@ -2254,11 +2264,8 @@ impl<A> SlicePartialEq<A> for [A]
         if self.as_ptr() == other.as_ptr() {
             return true;
         }
-        unsafe {
-            let size = mem::size_of_val(self);
-            memcmp(self.as_ptr() as *const u8,
-                   other.as_ptr() as *const u8, size) == 0
-        }
+        let size = mem::size_of_val(self);
+        slice_compare!(other.as_ptr() as *const u8, self.as_ptr() as *const u8, size)
     }
 }
 


### PR DESCRIPTION
Inspiration for this change is my crate [fastcmp](https://github.com/saschagrunert/fastcmp). The idea is to add an additional step before calling directly `memcmp`, which will optimize the `PartialEq` trait for slices up to `256` bytes.

I think this will relate some how to #16913.