### PR TITLE
std: Add ToString trait specialization for Cow<'a, str> and String

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -1866,6 +1866,22 @@ impl ToString for str {
     }
 }
 
+#[stable(feature = "cow_str_to_string_specialization", since = "1.17.0")]
+impl<'a> ToString for Cow<'a, str> {
+    #[inline]
+    fn to_string(&self) -> String {
+        self[..].to_owned()
+    }
+}
+
+#[stable(feature = "string_to_string_specialization", since = "1.17.0")]
+impl ToString for String {
+    #[inline]
+    fn to_string(&self) -> String {
+        self.to_owned()
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl AsRef<str> for String {
     #[inline]


### PR DESCRIPTION
There is a specialized version of ToString for str type in std. I think there are other types can also benefit from specialization. `Cow` and `String` are the most obvious one.

r? @bluss 