### PR TITLE
use help rather than span note for no method error; a slight rephrasing

### DIFF
--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -199,17 +199,16 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                     let field_ty = field.ty(tcx, substs);
 
                                     if self.is_fn_ty(&field_ty, span) {
-                                        err.span_note(span,
-                                                      &format!("use `({0}.{1})(...)` if you \
-                                                                meant to call the function \
-                                                                stored in the `{1}` field",
-                                                               expr_string,
-                                                               item_name));
+                                        err.help(&format!("use `({0}.{1})(...)` if you \
+                                                           meant to call the function \
+                                                           stored in the `{1}` field",
+                                                          expr_string,
+                                                          item_name));
                                     } else {
-                                        err.span_note(span,
-                                                      &format!("did you mean to write `{0}.{1}`?",
-                                                               expr_string,
-                                                               item_name));
+                                        err.help(&format!("did you mean to access the field \
+                                                           `{0}.{1}`?",
+                                                          expr_string,
+                                                          item_name));
                                     }
                                     break;
                                 }

--- a/src/test/compile-fail/issue-18343.rs
+++ b/src/test/compile-fail/issue-18343.rs
@@ -15,5 +15,5 @@ struct Obj<F> where F: FnMut() -> u32 {
 fn main() {
     let o = Obj { closure: || 42 };
     o.closure(); //~ ERROR no method named `closure` found
-    //~^ NOTE use `(o.closure)(...)` if you meant to call the function stored in the `closure` field
+    //~^ HELP use `(o.closure)(...)` if you meant to call the function stored in the `closure` field
 }

--- a/src/test/compile-fail/issue-2392.rs
+++ b/src/test/compile-fail/issue-2392.rs
@@ -48,45 +48,45 @@ fn main() {
 
     let o_closure = Obj { closure: || 42, not_closure: 42 };
     o_closure.closure(); //~ ERROR no method named `closure` found
-    //~^ NOTE use `(o_closure.closure)(...)` if you meant to call the function stored
+    //~^ HELP use `(o_closure.closure)(...)` if you meant to call the function stored
 
     o_closure.not_closure(); //~ ERROR no method named `not_closure` found
-    //~^ NOTE did you mean to write `o_closure.not_closure`?
+    //~^ HELP did you mean to access the field `o_closure.not_closure`?
 
     let o_func = Obj { closure: func, not_closure: 5 };
     o_func.closure(); //~ ERROR no method named `closure` found
-    //~^ NOTE use `(o_func.closure)(...)` if you meant to call the function stored
+    //~^ HELP use `(o_func.closure)(...)` if you meant to call the function stored
 
     let boxed_fn = BoxedObj { boxed_closure: Box::new(func) };
     boxed_fn.boxed_closure();//~ ERROR no method named `boxed_closure` found
-    //~^ NOTE use `(boxed_fn.boxed_closure)(...)` if you meant to call the function stored
+    //~^ HELP use `(boxed_fn.boxed_closure)(...)` if you meant to call the function stored
 
     let boxed_closure = BoxedObj { boxed_closure: Box::new(|| 42_u32) as Box<FnBox() -> u32> };
     boxed_closure.boxed_closure();//~ ERROR no method named `boxed_closure` found
-    //~^ NOTE use `(boxed_closure.boxed_closure)(...)` if you meant to call the function stored
+    //~^ HELP use `(boxed_closure.boxed_closure)(...)` if you meant to call the function stored
 
     // test expression writing in the notes
 
     let w = Wrapper { wrap: o_func };
     w.wrap.closure();//~ ERROR no method named `closure` found
-    //~^ NOTE use `(w.wrap.closure)(...)` if you meant to call the function stored
+    //~^ HELP use `(w.wrap.closure)(...)` if you meant to call the function stored
 
     w.wrap.not_closure();//~ ERROR no method named `not_closure` found
-    //~^ NOTE did you mean to write `w.wrap.not_closure`?
+    //~^ HELP did you mean to access the field `w.wrap.not_closure`?
 
     check_expression().closure();//~ ERROR no method named `closure` found
-    //~^ NOTE use `(check_expression().closure)(...)` if you meant to call the function stored
+    //~^ HELP use `(check_expression().closure)(...)` if you meant to call the function stored
 }
 
 impl FuncContainerOuter {
     fn run(&self) {
         unsafe {
             (*self.container).f1(1); //~ ERROR no method named `f1` found
-            //~^ NOTE use `((*self.container).f1)(...)`
+            //~^ HELP use `((*self.container).f1)(...)`
             (*self.container).f2(1); //~ ERROR no method named `f2` found
-            //~^ NOTE use `((*self.container).f2)(...)`
+            //~^ HELP use `((*self.container).f2)(...)`
             (*self.container).f3(1); //~ ERROR no method named `f3` found
-            //~^ NOTE use `((*self.container).f3)(...)`
+            //~^ HELP use `((*self.container).f3)(...)`
         }
     }
 }

--- a/src/test/compile-fail/issue-32128.rs
+++ b/src/test/compile-fail/issue-32128.rs
@@ -20,6 +20,6 @@ fn main() {
     };
 
     demo.example(1);    //~ ERROR no method named `example`
-                        //~^ NOTE use `(demo.example)(...)`
+                        //~^ HELP use `(demo.example)(...)`
     // (demo.example)(1);
 }

--- a/src/test/compile-fail/issue-33784.rs
+++ b/src/test/compile-fail/issue-33784.rs
@@ -35,12 +35,12 @@ fn main() {
     let o = Obj { fn_ptr: empty, closure: || 42 };
     let p = &o;
     p.closure(); //~ ERROR no method named `closure` found
-    //~^ NOTE use `(p.closure)(...)` if you meant to call the function stored in the `closure` field
+    //~^ HELP use `(p.closure)(...)` if you meant to call the function stored in the `closure` field
     let q = &p;
     q.fn_ptr(); //~ ERROR no method named `fn_ptr` found
-    //~^ NOTE use `(q.fn_ptr)(...)` if you meant to call the function stored in the `fn_ptr` field
+    //~^ HELP use `(q.fn_ptr)(...)` if you meant to call the function stored in the `fn_ptr` field
     let r = D(C { c_fn_ptr: empty });
     let s = &r;
     s.c_fn_ptr(); //~ ERROR no method named `c_fn_ptr` found
-    //~^ NOTE use `(s.c_fn_ptr)(...)` if you meant to call the function stored in the `c_fn_ptr`
+    //~^ HELP use `(s.c_fn_ptr)(...)` if you meant to call the function stored in the `c_fn_ptr`
 }


### PR DESCRIPTION
The use of the `span_note` diagnostic method resulted in error messages
that some users (including the present author) found very confusing: the
code snippet and highlighted span displayed with the "did you mean" note
was easy to interpret as a suggested edit (as if it had been set by
`span_suggestion`), but was in fact identical to the snippet/span
displayed just above, indicating the error in the original code, making
it look as if the compiler was suggesting a no-op change.

To remedy this, we use `help` instead of `span_note`, and reword one of
the affected messages to emphasize the concept of accessing a field
being different from calling a method (when the message just said, "did
you mean to write `self.foo`", it was not immediately obvious that this
was meant in contrast to `self.foo()`, with method-call parens).

Resolves #38321.

----

**Addendum (1 Feb)**: screenshot by reviewer request—
![no_method_error_retrospective](https://cloud.githubusercontent.com/assets/1076988/22535063/542a51a2-e8ad-11e6-905d-3488fb7d39b5.png)