### PR TITLE
Don't suggest to use things which weren't found either

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -639,7 +639,19 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
                 let names = resolutions.iter().filter_map(|(&(ref i, _), resolution)| {
                     if *i == ident { return None; } // Never suggest the same name
                     match *resolution.borrow() {
-                        NameResolution { binding: Some(_), .. } => Some(&i.name),
+                        NameResolution { binding: Some(name_binding), .. } => {
+                            match name_binding.kind {
+                                NameBindingKind::Import { binding, .. } => {
+                                    match binding.kind {
+                                        // Never suggest the name that has binding error
+                                        // i.e. the name that cannot be previously resolved
+                                        NameBindingKind::Def(Def::Err) => return None,
+                                        _ => Some(&i.name),
+                                    }
+                                },
+                                _ => Some(&i.name),
+                            }
+                        },
                         NameResolution { single_imports: SingleImports::None, .. } => None,
                         _ => Some(&i.name),
                     }

--- a/src/test/ui/did_you_mean/issue-38054-do-not-show-unresolved-names.rs
+++ b/src/test/ui/did_you_mean/issue-38054-do-not-show-unresolved-names.rs
@@ -1,0 +1,15 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use Foo;
+
+use Foo1;
+
+fn main() {}

--- a/src/test/ui/did_you_mean/issue-38054-do-not-show-unresolved-names.stderr
+++ b/src/test/ui/did_you_mean/issue-38054-do-not-show-unresolved-names.stderr
@@ -1,0 +1,14 @@
+error[E0432]: unresolved import `Foo`
+  --> $DIR/issue-38054-do-not-show-unresolved-names.rs:11:5
+   |
+11 | use Foo;
+   |     ^^^ no `Foo` in the root
+
+error[E0432]: unresolved import `Foo1`
+  --> $DIR/issue-38054-do-not-show-unresolved-names.rs:13:5
+   |
+13 | use Foo1;
+   |     ^^^^ no `Foo1` in the root
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #38054

The best code I can come up with, suggestions are welcome.

Basically, removing ```. Did you mean to use `DoesntExist1`?``` in the code below, because it is useless.

```rust
error[E0432]: unresolved import `DoesntExist1`
 --> src/lib.rs:1:5
  |
1 | use DoesntExist1;
  |     ^^^^^^^^^^^^ no `DoesntExist1` in the root

error[E0432]: unresolved import `DoesntExist2`
 --> src/lib.rs:2:5
  |
2 | use DoesntExist2;
  |     ^^^^^^^^^^^^ no `DoesntExist2` in the root. Did you mean to use `DoesntExist1`?
```