### PR TITLE
[MIR] SwitchInt Everywhere

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -578,6 +578,7 @@ dependencies = [
  "rustc_const_math 0.0.0",
  "rustc_data_structures 0.0.0",
  "rustc_errors 0.0.0",
+ "rustc_i128 0.0.0",
  "rustc_platform_intrinsics 0.0.0",
  "syntax 0.0.0",
  "syntax_pos 0.0.0",

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -578,7 +578,6 @@ dependencies = [
  "rustc_const_math 0.0.0",
  "rustc_data_structures 0.0.0",
  "rustc_errors 0.0.0",
- "rustc_i128 0.0.0",
  "rustc_platform_intrinsics 0.0.0",
  "syntax 0.0.0",
  "syntax_pos 0.0.0",

--- a/src/librustc/middle/const_val.rs
+++ b/src/librustc/middle/const_val.rs
@@ -11,12 +11,15 @@
 use syntax::symbol::InternedString;
 use syntax::ast;
 use std::rc::Rc;
+use std::borrow::Cow;
 use hir::def_id::DefId;
 use rustc_const_math::*;
 use self::ConstVal::*;
 pub use rustc_const_math::ConstInt;
 
 use std::collections::BTreeMap;
+
+pub static BOOL_SWITCH_TRUE: Cow<'static, [ConstInt]> = Cow::Borrowed(&[ConstInt::Infer(1)]);
 
 #[derive(Clone, Debug, Hash, RustcEncodable, RustcDecodable, Eq, PartialEq)]
 pub enum ConstVal {
@@ -47,6 +50,16 @@ impl ConstVal {
             Array(..) => "array",
             Repeat(..) => "repeat",
             Char(..) => "char",
+        }
+    }
+
+    pub fn to_const_int(&self) -> Option<ConstInt> {
+        match *self {
+            ConstVal::Integral(i) => Some(i),
+            ConstVal::Bool(true) => Some(ConstInt::Infer(1)),
+            ConstVal::Bool(false) => Some(ConstInt::Infer(0)),
+            ConstVal::Char(ch) => Some(ConstInt::U32(ch as u32)),
+            _ => None
         }
     }
 }

--- a/src/librustc/middle/const_val.rs
+++ b/src/librustc/middle/const_val.rs
@@ -11,15 +11,12 @@
 use syntax::symbol::InternedString;
 use syntax::ast;
 use std::rc::Rc;
-use std::borrow::Cow;
 use hir::def_id::DefId;
 use rustc_const_math::*;
 use self::ConstVal::*;
 pub use rustc_const_math::ConstInt;
 
 use std::collections::BTreeMap;
-
-pub static BOOL_SWITCH_TRUE: Cow<'static, [ConstInt]> = Cow::Borrowed(&[ConstInt::Infer(1)]);
 
 #[derive(Clone, Debug, Hash, RustcEncodable, RustcDecodable, Eq, PartialEq)]
 pub enum ConstVal {

--- a/src/librustc/middle/const_val.rs
+++ b/src/librustc/middle/const_val.rs
@@ -14,6 +14,7 @@ use std::rc::Rc;
 use hir::def_id::DefId;
 use rustc_const_math::*;
 use self::ConstVal::*;
+pub use rustc_const_math::ConstInt;
 
 use std::collections::BTreeMap;
 

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -997,6 +997,12 @@ pub enum Rvalue<'tcx> {
 
     UnaryOp(UnOp, Operand<'tcx>),
 
+    /// Read the discriminant of an ADT.
+    ///
+    /// Undefined (i.e. no effort is made to make it defined, but there’s no reason why it cannot
+    /// be defined to return, say, a 0) if ADT is not an enum.
+    Discriminant(Lvalue<'tcx>),
+
     /// Creates an *uninitialized* Box
     Box(Ty<'tcx>),
 
@@ -1111,6 +1117,7 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                 write!(fmt, "Checked{:?}({:?}, {:?})", op, a, b)
             }
             UnaryOp(ref op, ref a) => write!(fmt, "{:?}({:?})", op, a),
+            Discriminant(ref lval) => write!(fmt, "discriminant({:?})", lval),
             Box(ref t) => write!(fmt, "Box({:?})", t),
             InlineAsm { ref asm, ref outputs, ref inputs } => {
                 write!(fmt, "asm!({:?} : {:?} : {:?})", asm, outputs, inputs)

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -469,10 +469,17 @@ pub enum TerminatorKind<'tcx> {
         /// are found in the corresponding indices from the `targets` vector.
         values: Cow<'tcx, [ConstInt]>,
 
-        /// Possible branch sites. The length of this vector should be
-        /// equal to the length of the `values` vector plus 1 -- the
-        /// extra item is the block to branch to if none of the values
-        /// fit.
+        /// Possible branch sites. The last element of this vector is used
+        /// for the otherwise branch, so values.len() == targets.len() + 1
+        /// should hold.
+        // This invariant is quite non-obvious and also could be improved.
+        // One way to make this invariant is to have something like this instead:
+        //
+        // branches: Vec<(ConstInt, BasicBlock)>,
+        // otherwise: Option<BasicBlock> // exhaustive if None
+        //
+        // However we’ve decided to keep this as-is until we figure a case
+        // where some other approach seems to be strictly better than other.
         targets: Vec<BasicBlock>,
     },
 

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -447,7 +447,7 @@ pub struct Terminator<'tcx> {
 }
 
 /// For use in SwitchInt, for switching on bools.
-pub static BOOL_SWITCH_TRUE: Cow<'static, [ConstInt]> = Cow::Borrowed(&[ConstInt::Infer(1)]);
+pub static BOOL_SWITCH_FALSE: Cow<'static, [ConstInt]> = Cow::Borrowed(&[ConstInt::Infer(0)]);
 
 #[derive(Clone, RustcEncodable, RustcDecodable)]
 pub enum TerminatorKind<'tcx> {

--- a/src/librustc/mir/tcx.rs
+++ b/src/librustc/mir/tcx.rs
@@ -17,6 +17,7 @@ use mir::*;
 use ty::subst::{Subst, Substs};
 use ty::{self, AdtDef, Ty, TyCtxt};
 use ty::fold::{TypeFoldable, TypeFolder, TypeVisitor};
+use syntax::attr;
 use hir;
 
 #[derive(Copy, Clone, Debug)]
@@ -170,9 +171,14 @@ impl<'tcx> Rvalue<'tcx> {
                 Some(operand.ty(mir, tcx))
             }
             Rvalue::Discriminant(ref lval) => {
-                if let ty::TyAdt(_, _) = lval.ty(mir, tcx).to_ty(tcx).sty {
-                    // TODO
-                    None
+                if let ty::TyAdt(adt_def, _) = lval.ty(mir, tcx).to_ty(tcx).sty {
+                    // FIXME: Why this does not work?
+                    // Some(adt_def.discr_ty.to_ty(tcx))
+                    let ty = match adt_def.discr_ty {
+                        attr::SignedInt(i) => tcx.mk_mach_int(i),
+                        attr::UnsignedInt(i) => tcx.mk_mach_uint(i),
+                    };
+                    Some(ty)
                 } else {
                     None
                 }

--- a/src/librustc/mir/tcx.rs
+++ b/src/librustc/mir/tcx.rs
@@ -171,10 +171,13 @@ impl<'tcx> Rvalue<'tcx> {
                 Some(operand.ty(mir, tcx))
             }
             Rvalue::Discriminant(ref lval) => {
-                if let ty::TyAdt(adt_def, _) = lval.ty(mir, tcx).to_ty(tcx).sty {
+                let ty = lval.ty(mir, tcx).to_ty(tcx);
+                if let ty::TyAdt(adt_def, _) = ty.sty {
                     Some(adt_def.discr_ty.to_ty(tcx))
                 } else {
-                    None
+                    // Undefined behaviour, bug for now; may want to return something for
+                    // the `discriminant` intrinsic later.
+                    bug!("Rvalue::Discriminant on Lvalue of type {:?}", ty);
                 }
             }
             Rvalue::Box(t) => {

--- a/src/librustc/mir/tcx.rs
+++ b/src/librustc/mir/tcx.rs
@@ -17,8 +17,8 @@ use mir::*;
 use ty::subst::{Subst, Substs};
 use ty::{self, AdtDef, Ty, TyCtxt};
 use ty::fold::{TypeFoldable, TypeFolder, TypeVisitor};
-use syntax::attr;
 use hir;
+use ty::util::IntTypeExt;
 
 #[derive(Copy, Clone, Debug)]
 pub enum LvalueTy<'tcx> {
@@ -172,13 +172,7 @@ impl<'tcx> Rvalue<'tcx> {
             }
             Rvalue::Discriminant(ref lval) => {
                 if let ty::TyAdt(adt_def, _) = lval.ty(mir, tcx).to_ty(tcx).sty {
-                    // FIXME: Why this does not work?
-                    // Some(adt_def.discr_ty.to_ty(tcx))
-                    let ty = match adt_def.discr_ty {
-                        attr::SignedInt(i) => tcx.mk_mach_int(i),
-                        attr::UnsignedInt(i) => tcx.mk_mach_uint(i),
-                    };
-                    Some(ty)
+                    Some(adt_def.discr_ty.to_ty(tcx))
                 } else {
                     None
                 }

--- a/src/librustc/mir/tcx.rs
+++ b/src/librustc/mir/tcx.rs
@@ -135,15 +135,15 @@ impl<'tcx> Lvalue<'tcx> {
 impl<'tcx> Rvalue<'tcx> {
     pub fn ty<'a, 'gcx>(&self, mir: &Mir<'tcx>, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> Option<Ty<'tcx>>
     {
-        match self {
-            &Rvalue::Use(ref operand) => Some(operand.ty(mir, tcx)),
-            &Rvalue::Repeat(ref operand, ref count) => {
+        match *self {
+            Rvalue::Use(ref operand) => Some(operand.ty(mir, tcx)),
+            Rvalue::Repeat(ref operand, ref count) => {
                 let op_ty = operand.ty(mir, tcx);
                 let count = count.value.as_u64(tcx.sess.target.uint_type);
                 assert_eq!(count as usize as u64, count);
                 Some(tcx.mk_array(op_ty, count as usize))
             }
-            &Rvalue::Ref(reg, bk, ref lv) => {
+            Rvalue::Ref(reg, bk, ref lv) => {
                 let lv_ty = lv.ty(mir, tcx).to_ty(tcx);
                 Some(tcx.mk_ref(reg,
                     ty::TypeAndMut {
@@ -152,27 +152,35 @@ impl<'tcx> Rvalue<'tcx> {
                     }
                 ))
             }
-            &Rvalue::Len(..) => Some(tcx.types.usize),
-            &Rvalue::Cast(.., ty) => Some(ty),
-            &Rvalue::BinaryOp(op, ref lhs, ref rhs) => {
+            Rvalue::Len(..) => Some(tcx.types.usize),
+            Rvalue::Cast(.., ty) => Some(ty),
+            Rvalue::BinaryOp(op, ref lhs, ref rhs) => {
                 let lhs_ty = lhs.ty(mir, tcx);
                 let rhs_ty = rhs.ty(mir, tcx);
                 Some(op.ty(tcx, lhs_ty, rhs_ty))
             }
-            &Rvalue::CheckedBinaryOp(op, ref lhs, ref rhs) => {
+            Rvalue::CheckedBinaryOp(op, ref lhs, ref rhs) => {
                 let lhs_ty = lhs.ty(mir, tcx);
                 let rhs_ty = rhs.ty(mir, tcx);
                 let ty = op.ty(tcx, lhs_ty, rhs_ty);
                 let ty = tcx.intern_tup(&[ty, tcx.types.bool], false);
                 Some(ty)
             }
-            &Rvalue::UnaryOp(_, ref operand) => {
+            Rvalue::UnaryOp(_, ref operand) => {
                 Some(operand.ty(mir, tcx))
             }
-            &Rvalue::Box(t) => {
+            Rvalue::Discriminant(ref lval) => {
+                if let ty::TyAdt(_, _) = lval.ty(mir, tcx).to_ty(tcx).sty {
+                    // TODO
+                    None
+                } else {
+                    None
+                }
+            }
+            Rvalue::Box(t) => {
                 Some(tcx.mk_box(t))
             }
-            &Rvalue::Aggregate(ref ak, ref ops) => {
+            Rvalue::Aggregate(ref ak, ref ops) => {
                 match *ak {
                     AggregateKind::Array => {
                         if let Some(operand) = ops.get(0) {
@@ -196,7 +204,7 @@ impl<'tcx> Rvalue<'tcx> {
                     }
                 }
             }
-            &Rvalue::InlineAsm { .. } => None
+            Rvalue::InlineAsm { .. } => None
         }
     }
 }

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -223,6 +223,12 @@ macro_rules! make_mir_visitor {
                 self.super_const_val(const_val);
             }
 
+            fn visit_const_int(&mut self,
+                               const_int: &ConstInt,
+                               _: Location) {
+                self.super_const_int(const_int);
+            }
+
             fn visit_const_usize(&mut self,
                                  const_usize: & $($mutability)* ConstUsize,
                                  _: Location) {
@@ -364,12 +370,12 @@ macro_rules! make_mir_visitor {
 
                     TerminatorKind::SwitchInt { ref $($mutability)* discr,
                                                 ref $($mutability)* switch_ty,
-                                                ref $($mutability)* values,
+                                                ref values,
                                                 ref targets } => {
                         self.visit_operand(discr, source_location);
                         self.visit_ty(switch_ty);
-                        for value in values {
-                            self.visit_const_val(value, source_location);
+                        for value in &values[..] {
+                            self.visit_const_int(value, source_location);
                         }
                         for &target in targets {
                             self.visit_branch(block, target);
@@ -698,10 +704,13 @@ macro_rules! make_mir_visitor {
                                     _substs: & $($mutability)* ClosureSubsts<'tcx>) {
             }
 
-            fn super_const_val(&mut self, _substs: & $($mutability)* ConstVal) {
+            fn super_const_val(&mut self, _const_val: & $($mutability)* ConstVal) {
             }
 
-            fn super_const_usize(&mut self, _substs: & $($mutability)* ConstUsize) {
+            fn super_const_int(&mut self, _const_int: &ConstInt) {
+            }
+
+            fn super_const_usize(&mut self, _const_usize: & $($mutability)* ConstUsize) {
             }
 
             // Convenience methods

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -14,7 +14,6 @@ use ty::subst::Substs;
 use ty::{ClosureSubsts, Region, Ty};
 use mir::*;
 use rustc_const_math::ConstUsize;
-use rustc_data_structures::tuple_slice::TupleSlice;
 use rustc_data_structures::indexed_vec::Idx;
 use syntax_pos::Span;
 
@@ -363,14 +362,6 @@ macro_rules! make_mir_visitor {
                         self.visit_branch(block, target);
                     }
 
-                    TerminatorKind::If { ref $($mutability)* cond,
-                                         ref $($mutability)* targets } => {
-                        self.visit_operand(cond, source_location);
-                        for &target in targets.as_slice() {
-                            self.visit_branch(block, target);
-                        }
-                    }
-
                     TerminatorKind::Switch { ref $($mutability)* discr,
                                              adt_def: _,
                                              ref targets } => {
@@ -384,7 +375,7 @@ macro_rules! make_mir_visitor {
                                                 ref $($mutability)* switch_ty,
                                                 ref $($mutability)* values,
                                                 ref targets } => {
-                        self.visit_lvalue(discr, LvalueContext::Inspect, source_location);
+                        self.visit_operand(discr, source_location);
                         self.visit_ty(switch_ty);
                         for value in values {
                             self.visit_const_val(value, source_location);

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -506,6 +506,10 @@ macro_rules! make_mir_visitor {
                         self.visit_operand(op, location);
                     }
 
+                    Rvalue::Discriminant(ref $($mutability)* lvalue) => {
+                        self.visit_lvalue(lvalue, LvalueContext::Inspect, location);
+                    }
+
                     Rvalue::Box(ref $($mutability)* ty) => {
                         self.visit_ty(ty);
                     }

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -362,15 +362,6 @@ macro_rules! make_mir_visitor {
                         self.visit_branch(block, target);
                     }
 
-                    TerminatorKind::Switch { ref $($mutability)* discr,
-                                             adt_def: _,
-                                             ref targets } => {
-                        self.visit_lvalue(discr, LvalueContext::Inspect, source_location);
-                        for &target in targets {
-                            self.visit_branch(block, target);
-                        }
-                    }
-
                     TerminatorKind::SwitchInt { ref $($mutability)* discr,
                                                 ref $($mutability)* switch_ty,
                                                 ref $($mutability)* values,

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -673,10 +673,12 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     pub fn alloc_adt_def(self,
                          did: DefId,
                          kind: AdtKind,
+                         discr_ty: Option<attr::IntType>,
                          variants: Vec<ty::VariantDef>,
                          repr: ReprOptions)
                          -> &'gcx ty::AdtDef {
-        let def = ty::AdtDef::new(self, did, kind, variants, repr);
+        let discr_ty = discr_ty.unwrap_or(attr::UnsignedInt(ast::UintTy::U8));
+        let def = ty::AdtDef::new(self, did, kind, discr_ty, variants, repr);
         self.global_arenas.adt_def.alloc(def)
     }
 

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -453,13 +453,8 @@ impl Integer {
     /// signed discriminant range and #[repr] attribute.
     /// N.B.: u64 values above i64::MAX will be treated as signed, but
     /// that shouldn't affect anything, other than maybe debuginfo.
-<<<<<<< HEAD
-    fn repr_discr(tcx: TyCtxt, ty: Ty, repr: &ReprOptions, min: i64, max: i64)
+    fn repr_discr(tcx: TyCtxt, ty: Ty, repr: &ReprOptions, min: i128, max: i128)
                       -> (Integer, bool) {
-=======
-    pub fn repr_discr(tcx: TyCtxt, hints: &[attr::ReprAttr], min: i128, max: i128)
-    -> (Integer, bool) {
->>>>>>> cade130ae8... AdtDef now contains discr_ty same as layouted
         // Theoretically, negative values could be larger in unsigned representation
         // than the unsigned representation of the signed minimum. However, if there
         // are any negative values, the only valid unsigned representation is u64
@@ -470,7 +465,6 @@ impl Integer {
         let mut min_from_extern = None;
         let min_default = I8;
 
-<<<<<<< HEAD
         if let Some(ity) = repr.int {
             let discr = Integer::from_attr(&tcx.data_layout, ity);
             let fit = if ity.is_signed() { signed_fit } else { unsigned_fit };
@@ -489,36 +483,6 @@ impl Integer {
                 // lower bound.  However, we don't run on those yet...?
                 "arm" => min_from_extern = Some(I32),
                 _ => min_from_extern = Some(I32),
-=======
-        for &r in hints.iter() {
-            match r {
-                attr::ReprInt(ity) => {
-                    let discr = Integer::from_attr(&tcx.data_layout, ity);
-                    let fit = if ity.is_signed() { signed_fit } else { unsigned_fit };
-                    if discr < fit {
-                        bug!("Integer::repr_discr: `#[repr]` hint too small for \
-                              discriminant range of enum")
-                    }
-                    return (discr, ity.is_signed());
-                }
-                attr::ReprExtern => {
-                    match &tcx.sess.target.target.arch[..] {
-                        // WARNING: the ARM EABI has two variants; the one corresponding
-                        // to `at_least == I32` appears to be used on Linux and NetBSD,
-                        // but some systems may use the variant corresponding to no
-                        // lower bound.  However, we don't run on those yet...?
-                        "arm" => min_from_extern = Some(I32),
-                        _ => min_from_extern = Some(I32),
-                    }
-                }
-                attr::ReprAny => {},
-                attr::ReprPacked => {
-                    bug!("Integer::repr_discr: found #[repr(packed)] on enum");
-                }
-                attr::ReprSimd => {
-                    bug!("Integer::repr_discr: found #[repr(simd)] on enum");
-                }
->>>>>>> cade130ae8... AdtDef now contains discr_ty same as layouted
             }
         }
 

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -400,7 +400,7 @@ impl Integer {
     }
 
     /// Find the smallest Integer type which can represent the signed value.
-    pub fn fit_signed(x: i64) -> Integer {
+    pub fn fit_signed(x: i128) -> Integer {
         match x {
             -0x0000_0000_0000_0001...0x0000_0000_0000_0000 => I1,
             -0x0000_0000_0000_0080...0x0000_0000_0000_007f => I8,
@@ -412,7 +412,7 @@ impl Integer {
     }
 
     /// Find the smallest Integer type which can represent the unsigned value.
-    pub fn fit_unsigned(x: u64) -> Integer {
+    pub fn fit_unsigned(x: u128) -> Integer {
         match x {
             0...0x0000_0000_0000_0001 => I1,
             0...0x0000_0000_0000_00ff => I8,

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -20,7 +20,6 @@ use ty::{self, Ty, TyCtxt, TypeFoldable, ReprOptions};
 use syntax::ast::{FloatTy, IntTy, UintTy};
 use syntax::attr;
 use syntax_pos::DUMMY_SP;
-use rustc_const_math::ConstInt;
 
 use std::cmp;
 use std::fmt;
@@ -1183,10 +1182,12 @@ impl<'a, 'gcx, 'tcx> Layout {
                                                             i64::min_value(),
                                                             true);
                     for v in &def.variants {
-                        let x = match v.disr_val.erase_type() {
-                            ConstInt::InferSigned(i) => i as i64,
-                            ConstInt::Infer(i) => i as u64 as i64,
-                            _ => bug!()
+                        let x = match def.discr_ty {
+                            attr::IntType::SignedInt(IntTy::I128) |
+                            attr::IntType::UnsignedInt(UintTy::U128) =>
+                                bug!("128-bit discriminants not yet supported"),
+                            attr::IntType::SignedInt(_) => v.disr_val as i64,
+                            attr::IntType::UnsignedInt(_) => v.disr_val as u64 as i64,
                         };
                         if x == 0 { non_zero = false; }
                         if x < min { min = x; }
@@ -1247,7 +1248,7 @@ impl<'a, 'gcx, 'tcx> Layout {
                 // non-empty body, explicit discriminants should have
                 // been rejected by a checker before this point.
                 for (i, v) in def.variants.iter().enumerate() {
-                    if i as u128 != v.disr_val.to_u128_unchecked() {
+                    if i as u128 != v.disr_val {
                         bug!("non-C-like enum {} with specified discriminants",
                             tcx.item_path_str(def.did));
                     }

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -1190,9 +1190,7 @@ impl<'a, 'gcx, 'tcx> Layout {
 
                     // FIXME: should handle i128? signed-value based impl is weird and hard to
                     // grok.
-                    let (discr, signed) = Integer::repr_discr(tcx, ty, &hints[..],
-                                                              min,
-                                                              max);
+                    let (discr, signed) = Integer::repr_discr(tcx, ty, &def.repr, min, max);
                     return success(CEnum {
                         discr: discr,
                         signed: signed,
@@ -1309,7 +1307,7 @@ impl<'a, 'gcx, 'tcx> Layout {
                 // The general case.
                 let discr_max = (variants.len() - 1) as i64;
                 assert!(discr_max >= 0);
-                let (min_ity, _) = Integer::repr_discr(tcx, ty, &hints[..], 0, discr_max);
+                let (min_ity, _) = Integer::repr_discr(tcx, ty, &def.repr, 0, discr_max);
                 let mut align = dl.aggregate_align;
                 let mut size = Size::from_bytes(0);
 

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -45,7 +45,6 @@ use syntax::attr;
 use syntax::symbol::{Symbol, InternedString};
 use syntax_pos::{DUMMY_SP, Span};
 
-use rustc_const_math::ConstInt;
 use rustc_data_structures::accumulate_vec::IntoIter as AccIntoIter;
 
 use hir;
@@ -72,6 +71,8 @@ pub use self::context::{Lift, TypeckTables};
 
 pub use self::trait_def::{TraitDef, TraitFlags};
 
+use rustc_i128::u128;
+
 pub mod adjustment;
 pub mod cast;
 pub mod error;
@@ -96,7 +97,7 @@ mod flags;
 mod structural_impls;
 mod sty;
 
-pub type Disr = ConstInt;
+pub type Disr = u128;
 
 // Data types
 
@@ -1325,6 +1326,7 @@ pub struct FieldDef {
 /// table.
 pub struct AdtDef {
     pub did: DefId,
+    pub discr_ty: attr::IntType, // Type of the discriminant
     pub variants: Vec<VariantDef>,
     destructor: Cell<Option<DefId>>,
     flags: Cell<AdtFlags>,
@@ -1387,6 +1389,7 @@ impl<'a, 'gcx, 'tcx> AdtDef {
     fn new(tcx: TyCtxt<'a, 'gcx, 'tcx>,
            did: DefId,
            kind: AdtKind,
+           discr_ty: attr::IntType,
            variants: Vec<VariantDef>,
            repr: ReprOptions) -> Self {
         let mut flags = AdtFlags::NO_ADT_FLAGS;
@@ -1410,6 +1413,7 @@ impl<'a, 'gcx, 'tcx> AdtDef {
         }
         AdtDef {
             did: did,
+            discr_ty: discr_ty,
             variants: variants,
             flags: Cell::new(flags),
             destructor: Cell::new(None),

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -71,8 +71,6 @@ pub use self::context::{Lift, TypeckTables};
 
 pub use self::trait_def::{TraitDef, TraitFlags};
 
-use rustc_i128::u128;
-
 pub mod adjustment;
 pub mod cast;
 pub mod error;

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -1326,7 +1326,12 @@ pub struct FieldDef {
 /// table.
 pub struct AdtDef {
     pub did: DefId,
-    pub discr_ty: attr::IntType, // Type of the discriminant
+    /// Type of the discriminant
+    ///
+    /// Note, that this is the type specified in `repr()` or a default type of some sort, and might
+    /// not match the actual type that layout algorithm decides to use when translating this type
+    /// into LLVM. That being said, layout algorithm may not use a type larger than specified here.
+    pub discr_ty: attr::IntType,
     pub variants: Vec<VariantDef>,
     destructor: Cell<Option<DefId>>,
     flags: Cell<AdtFlags>,

--- a/src/librustc/ty/util.rs
+++ b/src/librustc/ty/util.rs
@@ -39,14 +39,14 @@ use rustc_i128::i128;
 use hir;
 
 pub trait IntTypeExt {
-    fn to_ty<'a, 'tcx>(self, tcx: TyCtxt<'a, 'tcx, 'tcx>) -> Ty<'tcx>;
+    fn to_ty<'a, 'gcx: 'a+'tcx, 'tcx: 'a>(self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> Ty<'tcx>;
     fn disr_incr<'a, 'tcx>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>, val: Option<Disr>)
                            -> Option<Disr>;
     fn initial_discriminant<'a, 'tcx>(&self, _: TyCtxt<'a, 'tcx, 'tcx>) -> Disr;
 }
 
 impl IntTypeExt for attr::IntType {
-    fn to_ty<'a, 'gcx, 'tcx>(self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> Ty<'tcx> {
+    fn to_ty<'a, 'gcx: 'a+'tcx, 'tcx: 'a>(self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> Ty<'tcx> {
         match self {
             SignedInt(i) => tcx.mk_mach_int(i),
             UnsignedInt(i) => tcx.mk_mach_uint(i),

--- a/src/librustc/ty/util.rs
+++ b/src/librustc/ty/util.rs
@@ -39,27 +39,17 @@ use rustc_i128::i128;
 use hir;
 
 pub trait IntTypeExt {
-    fn to_ty<'a, 'tcx>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>) -> Ty<'tcx>;
+    fn to_ty<'a, 'tcx>(self, tcx: TyCtxt<'a, 'tcx, 'tcx>) -> Ty<'tcx>;
     fn disr_incr<'a, 'tcx>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>, val: Option<Disr>)
                            -> Option<Disr>;
     fn initial_discriminant<'a, 'tcx>(&self, _: TyCtxt<'a, 'tcx, 'tcx>) -> Disr;
 }
 
 impl IntTypeExt for attr::IntType {
-    fn to_ty<'a, 'tcx>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>) -> Ty<'tcx> {
-        match *self {
-            SignedInt(ast::IntTy::I8)      => tcx.types.i8,
-            SignedInt(ast::IntTy::I16)     => tcx.types.i16,
-            SignedInt(ast::IntTy::I32)     => tcx.types.i32,
-            SignedInt(ast::IntTy::I64)     => tcx.types.i64,
-            SignedInt(ast::IntTy::I128)     => tcx.types.i128,
-            SignedInt(ast::IntTy::Is)   => tcx.types.isize,
-            UnsignedInt(ast::UintTy::U8)    => tcx.types.u8,
-            UnsignedInt(ast::UintTy::U16)   => tcx.types.u16,
-            UnsignedInt(ast::UintTy::U32)   => tcx.types.u32,
-            UnsignedInt(ast::UintTy::U64)   => tcx.types.u64,
-            UnsignedInt(ast::UintTy::U128)   => tcx.types.u128,
-            UnsignedInt(ast::UintTy::Us) => tcx.types.usize,
+    fn to_ty<'a, 'gcx, 'tcx>(self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> Ty<'tcx> {
+        match self {
+            SignedInt(i) => tcx.mk_mach_int(i),
+            UnsignedInt(i) => tcx.mk_mach_uint(i),
         }
     }
 

--- a/src/librustc/ty/util.rs
+++ b/src/librustc/ty/util.rs
@@ -23,7 +23,7 @@ use ty::TypeVariants::*;
 use util::nodemap::FxHashMap;
 use middle::lang_items;
 
-use rustc_const_math::{ConstInt, ConstIsize, ConstUsize};
+use rustc_const_math::ConstInt;
 use rustc_data_structures::stable_hasher::{StableHasher, StableHasherResult};
 
 use std::cell::RefCell;
@@ -34,14 +34,15 @@ use syntax::ast::{self, Name};
 use syntax::attr::{self, SignedInt, UnsignedInt};
 use syntax_pos::Span;
 
+use rustc_i128::i128;
+
 use hir;
 
 pub trait IntTypeExt {
     fn to_ty<'a, 'tcx>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>) -> Ty<'tcx>;
     fn disr_incr<'a, 'tcx>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>, val: Option<Disr>)
                            -> Option<Disr>;
-    fn assert_ty_matches(&self, val: Disr);
-    fn initial_discriminant<'a, 'tcx>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>) -> Disr;
+    fn initial_discriminant<'a, 'tcx>(&self, _: TyCtxt<'a, 'tcx, 'tcx>) -> Disr;
 }
 
 impl IntTypeExt for attr::IntType {
@@ -62,56 +63,18 @@ impl IntTypeExt for attr::IntType {
         }
     }
 
-    fn initial_discriminant<'a, 'tcx>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>) -> Disr {
-        match *self {
-            SignedInt(ast::IntTy::I8)    => ConstInt::I8(0),
-            SignedInt(ast::IntTy::I16)   => ConstInt::I16(0),
-            SignedInt(ast::IntTy::I32)   => ConstInt::I32(0),
-            SignedInt(ast::IntTy::I64)   => ConstInt::I64(0),
-            SignedInt(ast::IntTy::I128)   => ConstInt::I128(0),
-            SignedInt(ast::IntTy::Is) => match tcx.sess.target.int_type {
-                ast::IntTy::I16 => ConstInt::Isize(ConstIsize::Is16(0)),
-                ast::IntTy::I32 => ConstInt::Isize(ConstIsize::Is32(0)),
-                ast::IntTy::I64 => ConstInt::Isize(ConstIsize::Is64(0)),
-                _ => bug!(),
-            },
-            UnsignedInt(ast::UintTy::U8)  => ConstInt::U8(0),
-            UnsignedInt(ast::UintTy::U16) => ConstInt::U16(0),
-            UnsignedInt(ast::UintTy::U32) => ConstInt::U32(0),
-            UnsignedInt(ast::UintTy::U64) => ConstInt::U64(0),
-            UnsignedInt(ast::UintTy::U128) => ConstInt::U128(0),
-            UnsignedInt(ast::UintTy::Us) => match tcx.sess.target.uint_type {
-                ast::UintTy::U16 => ConstInt::Usize(ConstUsize::Us16(0)),
-                ast::UintTy::U32 => ConstInt::Usize(ConstUsize::Us32(0)),
-                ast::UintTy::U64 => ConstInt::Usize(ConstUsize::Us64(0)),
-                _ => bug!(),
-            },
-        }
+    fn initial_discriminant<'a, 'tcx>(&self, _: TyCtxt<'a, 'tcx, 'tcx>) -> Disr {
+        0
     }
 
-    fn assert_ty_matches(&self, val: Disr) {
-        match (*self, val) {
-            (SignedInt(ast::IntTy::I8), ConstInt::I8(_)) => {},
-            (SignedInt(ast::IntTy::I16), ConstInt::I16(_)) => {},
-            (SignedInt(ast::IntTy::I32), ConstInt::I32(_)) => {},
-            (SignedInt(ast::IntTy::I64), ConstInt::I64(_)) => {},
-            (SignedInt(ast::IntTy::I128), ConstInt::I128(_)) => {},
-            (SignedInt(ast::IntTy::Is), ConstInt::Isize(_)) => {},
-            (UnsignedInt(ast::UintTy::U8), ConstInt::U8(_)) => {},
-            (UnsignedInt(ast::UintTy::U16), ConstInt::U16(_)) => {},
-            (UnsignedInt(ast::UintTy::U32), ConstInt::U32(_)) => {},
-            (UnsignedInt(ast::UintTy::U64), ConstInt::U64(_)) => {},
-            (UnsignedInt(ast::UintTy::U128), ConstInt::U128(_)) => {},
-            (UnsignedInt(ast::UintTy::Us), ConstInt::Usize(_)) => {},
-            _ => bug!("disr type mismatch: {:?} vs {:?}", self, val),
-        }
-    }
-
+    /// None = overflow
     fn disr_incr<'a, 'tcx>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>, val: Option<Disr>)
-                           -> Option<Disr> {
+    -> Option<Disr> {
         if let Some(val) = val {
-            self.assert_ty_matches(val);
-            (val + ConstInt::Infer(1)).ok()
+            match *self {
+                SignedInt(it) => ConstInt::new_signed(val as i128, it, tcx.sess.target.int_type),
+                UnsignedInt(it) => ConstInt::new_unsigned(val, it, tcx.sess.target.uint_type),
+            }.and_then(|l| (l + ConstInt::Infer(1)).ok()).map(|v| v.to_u128_unchecked())
         } else {
             Some(self.initial_discriminant(tcx))
         }

--- a/src/librustc_borrowck/borrowck/mir/dataflow/mod.rs
+++ b/src/librustc_borrowck/borrowck/mir/dataflow/mod.rs
@@ -454,10 +454,6 @@ impl<'a, 'tcx: 'a, D> DataflowAnalysis<'a, 'tcx, D>
                 self.propagate_bits_into_entry_set_for(in_out, changed, target);
                 self.propagate_bits_into_entry_set_for(in_out, changed, unwind);
             }
-            mir::TerminatorKind::If { ref targets, .. } => {
-                self.propagate_bits_into_entry_set_for(in_out, changed, &targets.0);
-                self.propagate_bits_into_entry_set_for(in_out, changed, &targets.1);
-            }
             mir::TerminatorKind::Switch { ref targets, .. } |
             mir::TerminatorKind::SwitchInt { ref targets, .. } => {
                 for target in targets {

--- a/src/librustc_borrowck/borrowck/mir/dataflow/mod.rs
+++ b/src/librustc_borrowck/borrowck/mir/dataflow/mod.rs
@@ -454,7 +454,6 @@ impl<'a, 'tcx: 'a, D> DataflowAnalysis<'a, 'tcx, D>
                 self.propagate_bits_into_entry_set_for(in_out, changed, target);
                 self.propagate_bits_into_entry_set_for(in_out, changed, unwind);
             }
-            mir::TerminatorKind::Switch { ref targets, .. } |
             mir::TerminatorKind::SwitchInt { ref targets, .. } => {
                 for target in targets {
                     self.propagate_bits_into_entry_set_for(in_out, changed, target);

--- a/src/librustc_borrowck/borrowck/mir/elaborate_drops.rs
+++ b/src/librustc_borrowck/borrowck/mir/elaborate_drops.rs
@@ -813,9 +813,12 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
             (true, false) => on_set,
             (true, true) => {
                 let flag = self.drop_flag(c.path).unwrap();
-                self.new_block(c, is_cleanup, TerminatorKind::If {
-                    cond: Operand::Consume(flag),
-                    targets: (on_set, on_unset)
+                let boolty = self.tcx.types.bool;
+                self.new_block(c, is_cleanup, TerminatorKind::SwitchInt {
+                    discr: Operand::Consume(flag),
+                    switch_ty: boolty,
+                    values: vec![ConstVal::Bool(true)],
+                    targets: vec![on_set, on_unset],
                 })
             }
         }

--- a/src/librustc_borrowck/borrowck/mir/elaborate_drops.rs
+++ b/src/librustc_borrowck/borrowck/mir/elaborate_drops.rs
@@ -842,13 +842,8 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
             (true, false) => on_set,
             (true, true) => {
                 let flag = self.drop_flag(c.path).unwrap();
-                let boolty = self.tcx.types.bool;
-                self.new_block(c, is_cleanup, TerminatorKind::SwitchInt {
-                    discr: Operand::Consume(flag),
-                    switch_ty: boolty,
-                    values: BOOL_SWITCH_FALSE.clone(),
-                    targets: vec![on_unset, on_set],
-                })
+                let term = TerminatorKind::if_(self.tcx, Operand::Consume(flag), on_set, on_unset);
+                self.new_block(c, is_cleanup, term)
             }
         }
     }

--- a/src/librustc_borrowck/borrowck/mir/elaborate_drops.rs
+++ b/src/librustc_borrowck/borrowck/mir/elaborate_drops.rs
@@ -706,8 +706,6 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
                             switch_ty: discr_ty,
                             values: From::from(values),
                             targets: blocks,
-                            // adt_def: adt,
-                            // targets: variant_drops
                         }
                     }),
                     is_cleanup: c.is_cleanup,

--- a/src/librustc_borrowck/borrowck/mir/elaborate_drops.rs
+++ b/src/librustc_borrowck/borrowck/mir/elaborate_drops.rs
@@ -679,7 +679,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
                     let discr = ConstInt::new_inttype(variant.disr_val, adt.discr_ty,
                                                       self.tcx.sess.target.uint_type,
                                                       self.tcx.sess.target.int_type).unwrap();
-                    values.push(ConstVal::Integral(discr));
+                    values.push(discr);
                     blocks.push(self.open_drop_for_variant(c, &mut drop_block, adt, substs, idx));
                 }
                 // If there are multiple variants, then if something
@@ -704,7 +704,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
                         kind: TerminatorKind::SwitchInt {
                             discr: Operand::Consume(discr),
                             switch_ty: discr_ty,
-                            values: values,
+                            values: From::from(values),
                             targets: blocks,
                             // adt_def: adt,
                             // targets: variant_drops
@@ -836,7 +836,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
                 self.new_block(c, is_cleanup, TerminatorKind::SwitchInt {
                     discr: Operand::Consume(flag),
                     switch_ty: boolty,
-                    values: vec![ConstVal::Bool(true)],
+                    values: BOOL_SWITCH_TRUE.clone(),
                     targets: vec![on_set, on_unset],
                 })
             }

--- a/src/librustc_borrowck/borrowck/mir/elaborate_drops.rs
+++ b/src/librustc_borrowck/borrowck/mir/elaborate_drops.rs
@@ -846,8 +846,8 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
                 self.new_block(c, is_cleanup, TerminatorKind::SwitchInt {
                     discr: Operand::Consume(flag),
                     switch_ty: boolty,
-                    values: BOOL_SWITCH_TRUE.clone(),
-                    targets: vec![on_set, on_unset],
+                    values: BOOL_SWITCH_FALSE.clone(),
+                    targets: vec![on_unset, on_set],
                 })
             }
         }

--- a/src/librustc_borrowck/borrowck/mir/gather_moves.rs
+++ b/src/librustc_borrowck/borrowck/mir/gather_moves.rs
@@ -465,8 +465,7 @@ impl<'a, 'tcx> MoveDataBuilder<'a, 'tcx> {
             }
 
             TerminatorKind::Assert { .. } |
-            TerminatorKind::SwitchInt { .. } |
-            TerminatorKind::Switch { .. } => {
+            TerminatorKind::SwitchInt { .. } => {
                 // branching terminators - these don't move anything
             }
 

--- a/src/librustc_borrowck/borrowck/mir/gather_moves.rs
+++ b/src/librustc_borrowck/borrowck/mir/gather_moves.rs
@@ -464,7 +464,6 @@ impl<'a, 'tcx> MoveDataBuilder<'a, 'tcx> {
                 self.gather_move(loc, &Lvalue::Local(RETURN_POINTER));
             }
 
-            TerminatorKind::If { .. } |
             TerminatorKind::Assert { .. } |
             TerminatorKind::SwitchInt { .. } |
             TerminatorKind::Switch { .. } => {

--- a/src/librustc_borrowck/borrowck/mir/gather_moves.rs
+++ b/src/librustc_borrowck/borrowck/mir/gather_moves.rs
@@ -435,6 +435,7 @@ impl<'a, 'tcx> MoveDataBuilder<'a, 'tcx> {
                 }
             }
             Rvalue::Ref(..) |
+            Rvalue::Discriminant(..) |
             Rvalue::Len(..) |
             Rvalue::InlineAsm { .. } => {}
             Rvalue::Box(..) => {

--- a/src/librustc_const_math/int.rs
+++ b/src/librustc_const_math/int.rs
@@ -77,6 +77,14 @@ mod ibounds {
 }
 
 impl ConstInt {
+    pub fn new_inttype(val: u128, ty: IntType, usize_ty: UintTy, isize_ty: IntTy)
+    -> Option<ConstInt> {
+        match ty {
+            IntType::SignedInt(i) => ConstInt::new_signed(val as i128, i, isize_ty),
+            IntType::UnsignedInt(i) => ConstInt::new_unsigned(val, i, usize_ty),
+        }
+    }
+
     /// Creates a new unsigned ConstInt with matching type while also checking that overflow does
     /// not happen.
     pub fn new_unsigned(val: u128, ty: UintTy, usize_ty: UintTy) -> Option<ConstInt> {

--- a/src/librustc_data_structures/bitvec.rs
+++ b/src/librustc_data_structures/bitvec.rs
@@ -30,6 +30,10 @@ impl BitVector {
         }
     }
 
+    pub fn count(&self) -> usize {
+        self.data.iter().map(|e| e.count_ones() as usize).sum()
+    }
+
     #[inline]
     pub fn contains(&self, bit: usize) -> bool {
         let (word, mask) = word_mask(bit);

--- a/src/librustc_llvm/ffi.rs
+++ b/src/librustc_llvm/ffi.rs
@@ -1084,11 +1084,11 @@ extern "C" {
                                 DestTy: TypeRef,
                                 Name: *const c_char)
                                 -> ValueRef;
-    pub fn LLVMBuildIntCast(B: BuilderRef,
-                            Val: ValueRef,
-                            DestTy: TypeRef,
-                            Name: *const c_char)
-                            -> ValueRef;
+    pub fn LLVMRustBuildIntCast(B: BuilderRef,
+                                Val: ValueRef,
+                                DestTy: TypeRef,
+                                IsSized: bool)
+                                -> ValueRef;
     pub fn LLVMBuildFPCast(B: BuilderRef,
                            Val: ValueRef,
                            DestTy: TypeRef,

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -546,12 +546,12 @@ impl<'a, 'tcx> CrateMetadata {
         let did = self.local_def_id(item_id);
         let (kind, ty) = match item.kind {
             EntryKind::Enum(dt, _) => (ty::AdtKind::Enum, Some(dt.decode(self))),
-            EntryKind::Struct(_) => (ty::AdtKind::Struct, None),
-            EntryKind::Union(_) => (ty::AdtKind::Union, None),
+            EntryKind::Struct(_, _) => (ty::AdtKind::Struct, None),
+            EntryKind::Union(_, _) => (ty::AdtKind::Union, None),
             _ => bug!("get_adt_def called on a non-ADT {:?}", did),
         };
         let mut ctor_index = None;
-        let variants = if let EntryKind::Enum(_) = item.kind {
+        let variants = if let ty::AdtKind::Enum = kind {
             item.children
                 .decode(self)
                 .map(|index| {

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -25,8 +25,6 @@ use rustc::session::Session;
 use rustc::ty::{self, Ty, TyCtxt};
 use rustc::ty::subst::Substs;
 
-use rustc_const_math::ConstInt;
-
 use rustc::mir::Mir;
 
 use std::borrow::Cow;
@@ -435,7 +433,7 @@ impl<'tcx> EntryKind<'tcx> {
             EntryKind::Mod(_) => Def::Mod(did),
             EntryKind::Variant(_) => Def::Variant(did),
             EntryKind::Trait(_) => Def::Trait(did),
-            EntryKind::Enum(_) => Def::Enum(did),
+            EntryKind::Enum(..) => Def::Enum(did),
             EntryKind::MacroDef(_) => Def::Macro(did),
 
             EntryKind::ForeignMod |
@@ -535,7 +533,7 @@ impl<'a, 'tcx> CrateMetadata {
                     vis: f.visibility.decode(self)
                 }
             }).collect(),
-            disr_val: ConstInt::Infer(data.disr),
+            disr_val: data.disr,
             ctor_kind: data.ctor_kind,
         }, data.struct_ctor)
     }
@@ -546,6 +544,12 @@ impl<'a, 'tcx> CrateMetadata {
                        -> &'tcx ty::AdtDef {
         let item = self.entry(item_id);
         let did = self.local_def_id(item_id);
+        let (kind, ty) = match item.kind {
+            EntryKind::Enum(dt, _) => (ty::AdtKind::Enum, Some(dt.decode(self))),
+            EntryKind::Struct(_) => (ty::AdtKind::Struct, None),
+            EntryKind::Union(_) => (ty::AdtKind::Union, None),
+            _ => bug!("get_adt_def called on a non-ADT {:?}", did),
+        };
         let mut ctor_index = None;
         let variants = if let EntryKind::Enum(_) = item.kind {
             item.children
@@ -562,13 +566,13 @@ impl<'a, 'tcx> CrateMetadata {
             vec![variant]
         };
         let (kind, repr) = match item.kind {
-            EntryKind::Enum(repr) => (ty::AdtKind::Enum, repr),
+            EntryKind::Enum(_, repr) => (ty::AdtKind::Enum, repr),
             EntryKind::Struct(_, repr) => (ty::AdtKind::Struct, repr),
             EntryKind::Union(_, repr) => (ty::AdtKind::Union, repr),
             _ => bug!("get_adt_def called on a non-ADT {:?}", did),
         };
 
-        let adt = tcx.alloc_adt_def(did, kind, variants, repr);
+        let adt = tcx.alloc_adt_def(did, kind, ty, variants, repr);
         if let Some(ctor_index) = ctor_index {
             // Make adt definition available through constructor id as well.
             tcx.adt_defs.borrow_mut().insert(self.local_def_id(ctor_index), adt);

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -261,7 +261,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
 
         let data = VariantData {
             ctor_kind: variant.ctor_kind,
-            disr: variant.disr_val.to_u128_unchecked(),
+            disr: variant.disr_val,
             struct_ctor: None,
         };
 
@@ -388,7 +388,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
 
         let data = VariantData {
             ctor_kind: variant.ctor_kind,
-            disr: variant.disr_val.to_u128_unchecked(),
+            disr: variant.disr_val,
             struct_ctor: Some(def_id.index),
         };
 
@@ -661,7 +661,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             }
             hir::ItemForeignMod(_) => EntryKind::ForeignMod,
             hir::ItemTy(..) => EntryKind::Type,
-            hir::ItemEnum(..) => EntryKind::Enum(get_repr_options(&tcx, def_id)),
+            hir::ItemEnum(..) => EntryKind::Enum(self.lazy(&tcx.lookup_adt_def(def_id).discr_ty), get_repr_options(&tcx, def_id)),
             hir::ItemStruct(ref struct_def, _) => {
                 let variant = tcx.lookup_adt_def(def_id).struct_variant();
 
@@ -678,7 +678,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
 
                 EntryKind::Struct(self.lazy(&VariantData {
                     ctor_kind: variant.ctor_kind,
-                    disr: variant.disr_val.to_u128_unchecked(),
+                    disr: variant.disr_val,
                     struct_ctor: struct_ctor,
                 }), repr_options)
             }
@@ -688,7 +688,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
 
                 EntryKind::Union(self.lazy(&VariantData {
                     ctor_kind: variant.ctor_kind,
-                    disr: variant.disr_val.to_u128_unchecked(),
+                    disr: variant.disr_val,
                     struct_ctor: None,
                 }), repr_options)
             }

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -661,7 +661,8 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             }
             hir::ItemForeignMod(_) => EntryKind::ForeignMod,
             hir::ItemTy(..) => EntryKind::Type,
-            hir::ItemEnum(..) => EntryKind::Enum(self.lazy(&tcx.lookup_adt_def(def_id).discr_ty), get_repr_options(&tcx, def_id)),
+            hir::ItemEnum(..) => EntryKind::Enum(self.lazy(&tcx.lookup_adt_def(def_id).discr_ty),
+                                                 get_repr_options(&tcx, def_id)),
             hir::ItemStruct(ref struct_def, _) => {
                 let variant = tcx.lookup_adt_def(def_id).struct_variant();
 

--- a/src/librustc_metadata/schema.rs
+++ b/src/librustc_metadata/schema.rs
@@ -228,7 +228,7 @@ pub enum EntryKind<'tcx> {
     ForeignMutStatic,
     ForeignMod,
     Type,
-    Enum(ReprOptions),
+    Enum(Lazy<attr::IntType>, ReprOptions),
     Field,
     Variant(Lazy<VariantData>),
     Struct(Lazy<VariantData>, ReprOptions),

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -72,8 +72,8 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 this.cfg.terminate(block, source_info, TerminatorKind::SwitchInt {
                     discr: operand,
                     switch_ty: this.hir.bool_ty(),
-                    values: BOOL_SWITCH_TRUE.clone(),
-                    targets: vec![then_block, else_block],
+                    values: BOOL_SWITCH_FALSE.clone(),
+                    targets: vec![else_block, then_block],
                 });
 
                 unpack!(then_block = this.into(destination, then_block, then_expr));
@@ -113,13 +113,13 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
 
                 let lhs = unpack!(block = this.as_operand(block, lhs));
                 let blocks = match op {
-                    LogicalOp::And => vec![else_block, false_block],
-                    LogicalOp::Or => vec![true_block, else_block],
+                    LogicalOp::And => vec![false_block, else_block],
+                    LogicalOp::Or => vec![else_block, true_block],
                 };
                 this.cfg.terminate(block, source_info, TerminatorKind::SwitchInt {
                     discr: lhs,
                     switch_ty: this.hir.bool_ty(),
-                    values: BOOL_SWITCH_TRUE.clone(),
+                    values: BOOL_SWITCH_FALSE.clone(),
                     targets: blocks,
                 });
 
@@ -127,8 +127,8 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 this.cfg.terminate(else_block, source_info, TerminatorKind::SwitchInt {
                     discr: rhs,
                     switch_ty: this.hir.bool_ty(),
-                    values: BOOL_SWITCH_TRUE.clone(),
-                    targets: vec![true_block, false_block],
+                    values: BOOL_SWITCH_FALSE.clone(),
+                    targets: vec![false_block, true_block],
                 });
 
                 this.cfg.push_assign_constant(
@@ -191,8 +191,8 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                                                TerminatorKind::SwitchInt {
                                                    discr: cond,
                                                    switch_ty: this.hir.bool_ty(),
-                                                   values: BOOL_SWITCH_TRUE.clone(),
-                                                   targets: vec![body_block, exit_block],
+                                                   values: BOOL_SWITCH_FALSE.clone(),
+                                                   targets: vec![exit_block, body_block],
                                                });
 
                             // if the test is false, there's no `break` to assign `destination`, so

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -15,7 +15,6 @@ use build::expr::category::{Category, RvalueFunc};
 use hair::*;
 use rustc::ty;
 use rustc::mir::*;
-use rustc::middle::const_val::ConstVal;
 
 impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     /// Compile `expr`, storing the result into `destination`, which
@@ -73,7 +72,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 this.cfg.terminate(block, source_info, TerminatorKind::SwitchInt {
                     discr: operand,
                     switch_ty: this.hir.bool_ty(),
-                    values: vec![ConstVal::Bool(true)],
+                    values: BOOL_SWITCH_TRUE.clone(),
                     targets: vec![then_block, else_block],
                 });
 
@@ -120,7 +119,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 this.cfg.terminate(block, source_info, TerminatorKind::SwitchInt {
                     discr: lhs,
                     switch_ty: this.hir.bool_ty(),
-                    values: vec![ConstVal::Bool(true)],
+                    values: BOOL_SWITCH_TRUE.clone(),
                     targets: blocks,
                 });
 
@@ -128,7 +127,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 this.cfg.terminate(else_block, source_info, TerminatorKind::SwitchInt {
                     discr: rhs,
                     switch_ty: this.hir.bool_ty(),
-                    values: vec![ConstVal::Bool(true)],
+                    values: BOOL_SWITCH_TRUE.clone(),
                     targets: vec![true_block, false_block],
                 });
 
@@ -192,7 +191,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                                                TerminatorKind::SwitchInt {
                                                    discr: cond,
                                                    switch_ty: this.hir.bool_ty(),
-                                                   values: vec![ConstVal::Bool(true)],
+                                                   values: BOOL_SWITCH_TRUE.clone(),
                                                    targets: vec![body_block, exit_block],
                                                });
 

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -672,9 +672,12 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             let source_info = self.source_info(guard.span);
             let cond = unpack!(block = self.as_operand(block, guard));
             let otherwise = self.cfg.start_new_block();
-            self.cfg.terminate(block, source_info,
-                               TerminatorKind::If { cond: cond,
-                                                    targets: (arm_block, otherwise)});
+            self.cfg.terminate(block, source_info, TerminatorKind::SwitchInt {
+                discr: cond,
+                switch_ty: self.hir.bool_ty(),
+                values: vec![ConstVal::Bool(true)],
+                targets: vec![arm_block, otherwise],
+            });
             Some(otherwise)
         } else {
             let source_info = self.source_info(candidate.span);

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -672,12 +672,8 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             let source_info = self.source_info(guard.span);
             let cond = unpack!(block = self.as_operand(block, guard));
             let otherwise = self.cfg.start_new_block();
-            self.cfg.terminate(block, source_info, TerminatorKind::SwitchInt {
-                discr: cond,
-                switch_ty: self.hir.bool_ty(),
-                values: BOOL_SWITCH_FALSE.clone(),
-                targets: vec![otherwise, arm_block],
-            });
+            self.cfg.terminate(block, source_info,
+                               TerminatorKind::if_(self.hir.tcx(), cond, arm_block, otherwise));
             Some(otherwise)
         } else {
             let source_info = self.source_info(candidate.span);

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -675,8 +675,8 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             self.cfg.terminate(block, source_info, TerminatorKind::SwitchInt {
                 discr: cond,
                 switch_ty: self.hir.bool_ty(),
-                values: BOOL_SWITCH_TRUE.clone(),
-                targets: vec![arm_block, otherwise],
+                values: BOOL_SWITCH_FALSE.clone(),
+                targets: vec![otherwise, arm_block],
             });
             Some(otherwise)
         } else {

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -675,7 +675,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             self.cfg.terminate(block, source_info, TerminatorKind::SwitchInt {
                 discr: cond,
                 switch_ty: self.hir.bool_ty(),
-                values: vec![ConstVal::Bool(true)],
+                values: BOOL_SWITCH_TRUE.clone(),
                 targets: vec![arm_block, otherwise],
             });
             Some(otherwise)

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -22,10 +22,10 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::bitvec::BitVector;
 use rustc::middle::const_val::{ConstVal, ConstInt};
 use rustc::ty::{self, Ty};
+use rustc::ty::util::IntTypeExt;
 use rustc::mir::*;
 use rustc::hir::RangeEnd;
 use syntax_pos::Span;
-use syntax::attr;
 use std::cmp::Ordering;
 
 impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
@@ -212,13 +212,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 }
                 debug!("num_enum_variants: {}, tested variants: {:?}, variants: {:?}",
                        num_enum_variants, values, variants);
-                // FIXME: WHY THIS DOES NOT WORK?!
-                // let discr_ty = adt_def.discr_ty.to_ty(tcx);
-                let discr_ty = match adt_def.discr_ty {
-                    attr::SignedInt(i) => tcx.mk_mach_int(i),
-                    attr::UnsignedInt(i) => tcx.mk_mach_uint(i),
-                };
-
+                let discr_ty = adt_def.discr_ty.to_ty(tcx);
                 let discr = self.temp(discr_ty);
                 self.cfg.push_assign(block, source_info, &discr,
                                      Rvalue::Discriminant(lvalue.clone()));

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -236,7 +236,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                         &ConstVal::Bool(false) => vec![false_bb, true_bb],
                         v => span_bug!(test.span, "expected boolean value but got {:?}", v)
                     };
-                    (BOOL_SWITCH_TRUE.clone(), vec![true_bb, false_bb], ret)
+                    (BOOL_SWITCH_FALSE.clone(), vec![false_bb, true_bb], ret)
                 } else {
                     // The switch may be inexhaustive so we
                     // add a catch all block
@@ -326,8 +326,8 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                     self.cfg.terminate(eq_block, source_info, TerminatorKind::SwitchInt {
                         discr: Operand::Consume(eq_result),
                         switch_ty: self.hir.bool_ty(),
-                        values: BOOL_SWITCH_TRUE.clone(),
-                        targets: vec![block, fail],
+                        values: BOOL_SWITCH_FALSE.clone(),
+                        targets: vec![fail, block],
                     });
                     vec![block, fail]
                 } else {
@@ -375,8 +375,8 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 self.cfg.terminate(block, source_info, TerminatorKind::SwitchInt {
                     discr: Operand::Consume(result),
                     switch_ty: self.hir.bool_ty(),
-                    values: BOOL_SWITCH_TRUE.clone(),
-                    targets: vec![true_bb, false_bb],
+                    values: BOOL_SWITCH_FALSE.clone(),
+                    targets: vec![false_bb, true_bb],
                 });
                 vec![true_bb, false_bb]
             }
@@ -403,8 +403,8 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         self.cfg.terminate(block, source_info, TerminatorKind::SwitchInt {
             discr: Operand::Consume(result),
             switch_ty: self.hir.bool_ty(),
-            values: BOOL_SWITCH_TRUE.clone(),
-            targets: vec![target_block, fail_block]
+            values: BOOL_SWITCH_FALSE.clone(),
+            targets: vec![fail_block, target_block]
         });
         target_block
     }

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -221,10 +221,11 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                             v => span_bug!(test.span, "expected boolean value but got {:?}", v)
                         };
 
-                        (targets,
-                         TerminatorKind::If {
-                             cond: Operand::Consume(lvalue.clone()),
-                             targets: (true_bb, else_bb)
+                        (targets, TerminatorKind::SwitchInt {
+                             discr: Operand::Consume(lvalue.clone()),
+                             switch_ty: self.hir.bool_ty(),
+                             values: vec![ConstVal::Bool(true)],
+                             targets: vec![true_bb, else_bb]
                          })
 
                     }
@@ -240,7 +241,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
 
                         (targets.clone(),
                          TerminatorKind::SwitchInt {
-                             discr: lvalue.clone(),
+                             discr: Operand::Consume(lvalue.clone()),
                              switch_ty: switch_ty,
                              values: options.clone(),
                              targets: targets
@@ -314,9 +315,11 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
 
                     // check the result
                     let block = self.cfg.start_new_block();
-                    self.cfg.terminate(eq_block, source_info, TerminatorKind::If {
-                        cond: Operand::Consume(eq_result),
-                        targets: (block, fail),
+                    self.cfg.terminate(eq_block, source_info, TerminatorKind::SwitchInt {
+                        discr: Operand::Consume(eq_result),
+                        switch_ty: self.hir.bool_ty(),
+                        values: vec![ConstVal::Bool(true)],
+                        targets: vec![block, fail],
                     });
 
                     vec![block, fail]
@@ -362,9 +365,11 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 // branch based on result
                 let target_blocks: Vec<_> = vec![self.cfg.start_new_block(),
                                                  self.cfg.start_new_block()];
-                self.cfg.terminate(block, source_info, TerminatorKind::If {
-                    cond: Operand::Consume(result),
-                    targets: (target_blocks[0], target_blocks[1])
+                self.cfg.terminate(block, source_info, TerminatorKind::SwitchInt {
+                    discr: Operand::Consume(result),
+                    switch_ty: self.hir.bool_ty(),
+                    values: vec![ConstVal::Bool(true)],
+                    targets: target_blocks.clone(),
                 });
 
                 target_blocks
@@ -389,9 +394,11 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
 
         // branch based on result
         let target_block = self.cfg.start_new_block();
-        self.cfg.terminate(block, source_info, TerminatorKind::If {
-            cond: Operand::Consume(result),
-            targets: (target_block, fail_block)
+        self.cfg.terminate(block, source_info, TerminatorKind::SwitchInt {
+            discr: Operand::Consume(result),
+            switch_ty: self.hir.bool_ty(),
+            values: vec![ConstVal::Bool(true)],
+            targets: vec![target_block, fail_block]
         });
 
         target_block

--- a/src/librustc_mir/hair/mod.rs
+++ b/src/librustc_mir/hair/mod.rs
@@ -134,7 +134,8 @@ pub enum ExprKind<'tcx> {
         op: LogicalOp,
         lhs: ExprRef<'tcx>,
         rhs: ExprRef<'tcx>,
-    },
+    }, // NOT overloaded!
+       // LogicalOp is distinct from BinaryOp because of lazy evaluation of the operands.
     Unary {
         op: UnOp,
         arg: ExprRef<'tcx>,

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -26,6 +26,8 @@ Rust MIR: a lowered representation of Rust. Also: an experiment!
 #![feature(rustc_diagnostic_macros)]
 #![feature(rustc_private)]
 #![feature(staged_api)]
+#![feature(placement_in_syntax)]
+#![feature(collection_placement)]
 
 #[macro_use] extern crate log;
 extern crate graphviz as dot;

--- a/src/librustc_mir/transform/no_landing_pads.rs
+++ b/src/librustc_mir/transform/no_landing_pads.rs
@@ -28,7 +28,6 @@ impl<'tcx> MutVisitor<'tcx> for NoLandingPads {
             TerminatorKind::Resume |
             TerminatorKind::Return |
             TerminatorKind::Unreachable |
-            TerminatorKind::If { .. } |
             TerminatorKind::Switch { .. } |
             TerminatorKind::SwitchInt { .. } => {
                 /* nothing to do */

--- a/src/librustc_mir/transform/no_landing_pads.rs
+++ b/src/librustc_mir/transform/no_landing_pads.rs
@@ -28,7 +28,6 @@ impl<'tcx> MutVisitor<'tcx> for NoLandingPads {
             TerminatorKind::Resume |
             TerminatorKind::Return |
             TerminatorKind::Unreachable |
-            TerminatorKind::Switch { .. } |
             TerminatorKind::SwitchInt { .. } => {
                 /* nothing to do */
             },

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -739,6 +739,14 @@ impl<'a, 'tcx> Visitor<'tcx> for Qualifier<'a, 'tcx, 'tcx> {
                 }
             }
 
+            Rvalue::Discriminant(..) => {
+                // FIXME discriminant
+                self.add(Qualif::NOT_CONST);
+                if self.mode != Mode::Fn {
+                    bug!("implement discriminant const qualify");
+                }
+            }
+
             Rvalue::Box(_) => {
                 self.add(Qualif::NOT_CONST);
                 if self.mode != Mode::Fn {

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -394,7 +394,6 @@ impl<'a, 'tcx> Qualifier<'a, 'tcx, 'tcx> {
                     return Qualif::empty();
                 }
 
-                TerminatorKind::Switch {..} |
                 TerminatorKind::SwitchInt {..} |
                 TerminatorKind::DropAndReplace { .. } |
                 TerminatorKind::Resume |

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -394,7 +394,6 @@ impl<'a, 'tcx> Qualifier<'a, 'tcx, 'tcx> {
                     return Qualif::empty();
                 }
 
-                TerminatorKind::If {..} |
                 TerminatorKind::Switch {..} |
                 TerminatorKind::SwitchInt {..} |
                 TerminatorKind::DropAndReplace { .. } |

--- a/src/librustc_mir/transform/simplify.rs
+++ b/src/librustc_mir/transform/simplify.rs
@@ -209,7 +209,6 @@ impl<'a, 'tcx: 'a> CfgSimplifier<'a, 'tcx> {
     // turn a branch with all successors identical to a goto
     fn simplify_branch(&mut self, terminator: &mut Terminator<'tcx>) -> bool {
         match terminator.kind {
-            TerminatorKind::Switch { .. } |
             TerminatorKind::SwitchInt { .. } => {},
             _ => return false
         };

--- a/src/librustc_mir/transform/simplify.rs
+++ b/src/librustc_mir/transform/simplify.rs
@@ -209,7 +209,6 @@ impl<'a, 'tcx: 'a> CfgSimplifier<'a, 'tcx> {
     // turn a branch with all successors identical to a goto
     fn simplify_branch(&mut self, terminator: &mut Terminator<'tcx>) -> bool {
         match terminator.kind {
-            TerminatorKind::If { .. } |
             TerminatorKind::Switch { .. } |
             TerminatorKind::SwitchInt { .. } => {},
             _ => return false

--- a/src/librustc_mir/transform/simplify_branches.rs
+++ b/src/librustc_mir/transform/simplify_branches.rs
@@ -30,26 +30,30 @@ impl<'l, 'tcx> MirPass<'tcx> for SimplifyBranches<'l> {
         for block in mir.basic_blocks_mut() {
             let terminator = block.terminator_mut();
             terminator.kind = match terminator.kind {
-                // TerminatorKind::If { ref targets, cond: Operand::Constant(Constant {
-                //     literal: Literal::Value {
-                //         value: ConstVal::Bool(cond)
-                //     }, ..
-                // }) } => {
-                //     if cond {
-                //         TerminatorKind::Goto { target: targets.0 }
-                //     } else {
-                //         TerminatorKind::Goto { target: targets.1 }
-                //     }
-                // }
-
+                TerminatorKind::SwitchInt { discr: Operand::Constant(Constant {
+                    literal: Literal::Value { ref value }, ..
+                }), ref values, ref targets, .. } => {
+                    if let Some(ref constint) = value.to_const_int() {
+                        let (otherwise, targets) = targets.split_last().unwrap();
+                        let mut ret = TerminatorKind::Goto { target: *otherwise };
+                        for (v, t) in values.iter().zip(targets.iter()) {
+                            if v == constint {
+                                ret = TerminatorKind::Goto { target: *t };
+                                break;
+                            }
+                        }
+                        ret
+                    } else {
+                        continue
+                    }
+                },
                 TerminatorKind::Assert { target, cond: Operand::Constant(Constant {
                     literal: Literal::Value {
                         value: ConstVal::Bool(cond)
                     }, ..
                 }), expected, .. } if cond == expected => {
                     TerminatorKind::Goto { target: target }
-                }
-
+                },
                 _ => continue
             };
         }

--- a/src/librustc_mir/transform/simplify_branches.rs
+++ b/src/librustc_mir/transform/simplify_branches.rs
@@ -30,17 +30,17 @@ impl<'l, 'tcx> MirPass<'tcx> for SimplifyBranches<'l> {
         for block in mir.basic_blocks_mut() {
             let terminator = block.terminator_mut();
             terminator.kind = match terminator.kind {
-                TerminatorKind::If { ref targets, cond: Operand::Constant(Constant {
-                    literal: Literal::Value {
-                        value: ConstVal::Bool(cond)
-                    }, ..
-                }) } => {
-                    if cond {
-                        TerminatorKind::Goto { target: targets.0 }
-                    } else {
-                        TerminatorKind::Goto { target: targets.1 }
-                    }
-                }
+                // TerminatorKind::If { ref targets, cond: Operand::Constant(Constant {
+                //     literal: Literal::Value {
+                //         value: ConstVal::Bool(cond)
+                //     }, ..
+                // }) } => {
+                //     if cond {
+                //         TerminatorKind::Goto { target: targets.0 }
+                //     } else {
+                //         TerminatorKind::Goto { target: targets.1 }
+                //     }
+                // }
 
                 TerminatorKind::Assert { target, cond: Operand::Constant(Constant {
                     literal: Literal::Value {

--- a/src/librustc_mir/transform/type_check.rs
+++ b/src/librustc_mir/transform/type_check.rs
@@ -436,19 +436,6 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
                 }
                 // FIXME: check the values
             }
-            TerminatorKind::Switch { ref discr, adt_def, ref targets } => {
-                let discr_ty = discr.ty(mir, tcx).to_ty(tcx);
-                match discr_ty.sty {
-                    ty::TyAdt(def, _) if def.is_enum() &&
-                                         def == adt_def &&
-                                         adt_def.variants.len() == targets.len()
-                      => {},
-                    _ => {
-                        span_mirbug!(self, term, "bad Switch ({:?} on {:?})",
-                                     adt_def, discr_ty);
-                    }
-                }
-            }
             TerminatorKind::Call { ref func, ref args, ref destination, .. } => {
                 let func_ty = func.ty(mir, tcx);
                 debug!("check_terminator: call, func_ty={:?}", func_ty);
@@ -593,7 +580,6 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
         match block.terminator().kind {
             TerminatorKind::Goto { target } =>
                 self.assert_iscleanup(mir, block, target, is_cleanup),
-            TerminatorKind::Switch { ref targets, .. } |
             TerminatorKind::SwitchInt { ref targets, .. } => {
                 for target in targets {
                     self.assert_iscleanup(mir, block, *target, is_cleanup);

--- a/src/librustc_mir/transform/type_check.rs
+++ b/src/librustc_mir/transform/type_check.rs
@@ -423,18 +423,8 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
                                  lv_ty, rv_ty, terr);
                 }
             }
-
-            TerminatorKind::If { ref cond, .. } => {
-                let cond_ty = cond.ty(mir, tcx);
-                match cond_ty.sty {
-                    ty::TyBool => {}
-                    _ => {
-                        span_mirbug!(self, term, "bad If ({:?}, not bool", cond_ty);
-                    }
-                }
-            }
             TerminatorKind::SwitchInt { ref discr, switch_ty, .. } => {
-                let discr_ty = discr.ty(mir, tcx).to_ty(tcx);
+                let discr_ty = discr.ty(mir, tcx);
                 if let Err(terr) = self.sub_types(discr_ty, switch_ty) {
                     span_mirbug!(self, term, "bad SwitchInt ({:?} on {:?}): {:?}",
                                  switch_ty, discr_ty, terr);
@@ -603,10 +593,6 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
         match block.terminator().kind {
             TerminatorKind::Goto { target } =>
                 self.assert_iscleanup(mir, block, target, is_cleanup),
-            TerminatorKind::If { targets: (on_true, on_false), .. } => {
-                self.assert_iscleanup(mir, block, on_true, is_cleanup);
-                self.assert_iscleanup(mir, block, on_false, is_cleanup);
-            }
             TerminatorKind::Switch { ref targets, .. } |
             TerminatorKind::SwitchInt { ref targets, .. } => {
                 for target in targets {

--- a/src/librustc_passes/mir_stats.rs
+++ b/src/librustc_passes/mir_stats.rs
@@ -148,7 +148,6 @@ impl<'a, 'tcx> mir_visit::Visitor<'tcx> for StatCollector<'a, 'tcx> {
         self.record("TerminatorKind", kind);
         self.record(match *kind {
             TerminatorKind::Goto { .. } => "TerminatorKind::Goto",
-            TerminatorKind::If { .. } => "TerminatorKind::If",
             TerminatorKind::Switch { .. } => "TerminatorKind::Switch",
             TerminatorKind::SwitchInt { .. } => "TerminatorKind::SwitchInt",
             TerminatorKind::Resume => "TerminatorKind::Resume",

--- a/src/librustc_passes/mir_stats.rs
+++ b/src/librustc_passes/mir_stats.rs
@@ -186,6 +186,7 @@ impl<'a, 'tcx> mir_visit::Visitor<'tcx> for StatCollector<'a, 'tcx> {
             Rvalue::BinaryOp(..) => "Rvalue::BinaryOp",
             Rvalue::CheckedBinaryOp(..) => "Rvalue::CheckedBinaryOp",
             Rvalue::UnaryOp(..) => "Rvalue::UnaryOp",
+            Rvalue::Discriminant(..) => "Rvalue::Discriminant",
             Rvalue::Box(..) => "Rvalue::Box",
             Rvalue::Aggregate(ref kind, ref _operands) => {
                 // AggregateKind is not distinguished by visit API, so

--- a/src/librustc_passes/mir_stats.rs
+++ b/src/librustc_passes/mir_stats.rs
@@ -148,7 +148,6 @@ impl<'a, 'tcx> mir_visit::Visitor<'tcx> for StatCollector<'a, 'tcx> {
         self.record("TerminatorKind", kind);
         self.record(match *kind {
             TerminatorKind::Goto { .. } => "TerminatorKind::Goto",
-            TerminatorKind::Switch { .. } => "TerminatorKind::Switch",
             TerminatorKind::SwitchInt { .. } => "TerminatorKind::SwitchInt",
             TerminatorKind::Resume => "TerminatorKind::Resume",
             TerminatorKind::Return => "TerminatorKind::Return",

--- a/src/librustc_trans/adt.rs
+++ b/src/librustc_trans/adt.rs
@@ -318,7 +318,7 @@ pub fn trans_get_discr<'a, 'tcx>(
     };
     match cast_to {
         None => val,
-        Some(llty) => if is_discr_signed(&l) { bcx.sext(val, llty) } else { bcx.zext(val, llty) }
+        Some(llty) => bcx.intcast(val, llty, is_discr_signed(&l))
     }
 }
 

--- a/src/librustc_trans/base.rs
+++ b/src/librustc_trans/base.rs
@@ -536,7 +536,7 @@ pub fn call_memcpy<'a, 'tcx>(b: &Builder<'a, 'tcx>,
     let memcpy = ccx.get_intrinsic(&key);
     let src_ptr = b.pointercast(src, Type::i8p(ccx));
     let dst_ptr = b.pointercast(dst, Type::i8p(ccx));
-    let size = b.intcast(n_bytes, ccx.int_type());
+    let size = b.intcast(n_bytes, ccx.int_type(), false);
     let align = C_i32(ccx, align as i32);
     let volatile = C_bool(ccx, false);
     b.call(memcpy, &[dst_ptr, src_ptr, size, align, volatile], None);

--- a/src/librustc_trans/builder.rs
+++ b/src/librustc_trans/builder.rs
@@ -780,10 +780,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         }
     }
 
-    pub fn intcast(&self, val: ValueRef, dest_ty: Type) -> ValueRef {
+    pub fn intcast(&self, val: ValueRef, dest_ty: Type, is_signed: bool) -> ValueRef {
         self.count_insn("intcast");
         unsafe {
-            llvm::LLVMBuildIntCast(self.llbuilder, val, dest_ty.to_ref(), noname())
+            llvm::LLVMRustBuildIntCast(self.llbuilder, val, dest_ty.to_ref(), is_signed)
         }
     }
 

--- a/src/librustc_trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/debuginfo/metadata.rs
@@ -1473,7 +1473,7 @@ fn prepare_enum_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                     DIB(cx),
                     name.as_ptr(),
                     // FIXME: what if enumeration has i128 discriminant?
-                    v.disr_val.to_u128_unchecked() as u64)
+                    v.disr_val as u64)
             }
         })
         .collect();

--- a/src/librustc_trans/disr.rs
+++ b/src/librustc_trans/disr.rs
@@ -27,7 +27,7 @@ impl ::std::ops::BitAnd for Disr {
 impl From<::rustc::ty::Disr> for Disr {
     fn from(i: ::rustc::ty::Disr) -> Disr {
         // FIXME: what if discr has 128 bit discr?
-        Disr(i.to_u128_unchecked() as u64)
+        Disr(i as u64)
     }
 }
 

--- a/src/librustc_trans/mir/analyze.rs
+++ b/src/librustc_trans/mir/analyze.rs
@@ -204,7 +204,6 @@ pub fn cleanup_kinds<'a, 'tcx>(mir: &mir::Mir<'tcx>) -> IndexVec<mir::BasicBlock
                 TerminatorKind::Resume |
                 TerminatorKind::Return |
                 TerminatorKind::Unreachable |
-                TerminatorKind::Switch { .. } |
                 TerminatorKind::SwitchInt { .. } => {
                     /* nothing to do */
                 }

--- a/src/librustc_trans/mir/analyze.rs
+++ b/src/librustc_trans/mir/analyze.rs
@@ -156,10 +156,10 @@ impl<'mir, 'a, 'tcx> Visitor<'tcx> for LocalAnalyzer<'mir, 'a, 'tcx> {
 
                 LvalueContext::StorageLive |
                 LvalueContext::StorageDead |
+                LvalueContext::Inspect |
                 LvalueContext::Consume => {}
 
                 LvalueContext::Store |
-                LvalueContext::Inspect |
                 LvalueContext::Borrow { .. } |
                 LvalueContext::Projection(..) => {
                     self.mark_as_lvalue(index);

--- a/src/librustc_trans/mir/analyze.rs
+++ b/src/librustc_trans/mir/analyze.rs
@@ -204,7 +204,6 @@ pub fn cleanup_kinds<'a, 'tcx>(mir: &mir::Mir<'tcx>) -> IndexVec<mir::BasicBlock
                 TerminatorKind::Resume |
                 TerminatorKind::Return |
                 TerminatorKind::Unreachable |
-                TerminatorKind::If { .. } |
                 TerminatorKind::Switch { .. } |
                 TerminatorKind::SwitchInt { .. } => {
                     /* nothing to do */

--- a/src/librustc_trans/mir/rvalue.rs
+++ b/src/librustc_trans/mir/rvalue.rs
@@ -286,17 +286,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
 
                         let newval = match (r_t_in, r_t_out) {
                             (CastTy::Int(_), CastTy::Int(_)) => {
-                                let srcsz = ll_t_in.int_width();
-                                let dstsz = ll_t_out.int_width();
-                                if srcsz == dstsz {
-                                    bcx.bitcast(llval, ll_t_out)
-                                } else if srcsz > dstsz {
-                                    bcx.trunc(llval, ll_t_out)
-                                } else if signed {
-                                    bcx.sext(llval, ll_t_out)
-                                } else {
-                                    bcx.zext(llval, ll_t_out)
-                                }
+                                bcx.intcast(llval, ll_t_out, signed)
                             }
                             (CastTy::Float, CastTy::Float) => {
                                 let srcsz = ll_t_in.float_width();
@@ -439,7 +429,7 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                 let discr_ty = rvalue.ty(&*self.mir, bcx.tcx()).unwrap();
                 let discr_type = type_of::immediate_type_of(bcx.ccx, discr_ty);
                 let discr = adt::trans_get_discr(&bcx, enum_ty, discr_lvalue.llval,
-                                                 Some(discr_type), true);
+                                                  discr_lvalue.alignment, Some(discr_type), true);
                 (bcx, OperandRef {
                     val: OperandValue::Immediate(discr),
                     ty: discr_ty

--- a/src/librustc_trans/mir/rvalue.rs
+++ b/src/librustc_trans/mir/rvalue.rs
@@ -438,7 +438,6 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                 let enum_ty = discr_lvalue.ty.to_ty(bcx.tcx());
                 let discr_ty = rvalue.ty(&*self.mir, bcx.tcx()).unwrap();
                 let discr_type = type_of::immediate_type_of(bcx.ccx, discr_ty);
-                // FIXME: inline this
                 let discr = adt::trans_get_discr(&bcx, enum_ty, discr_lvalue.llval, None, true);
                 let discr = if common::val_ty(discr) == Type::i1(bcx.ccx) {
                     bcx.zext(discr, discr_type)

--- a/src/librustc_trans/mir/rvalue.rs
+++ b/src/librustc_trans/mir/rvalue.rs
@@ -438,12 +438,8 @@ impl<'a, 'tcx> MirContext<'a, 'tcx> {
                 let enum_ty = discr_lvalue.ty.to_ty(bcx.tcx());
                 let discr_ty = rvalue.ty(&*self.mir, bcx.tcx()).unwrap();
                 let discr_type = type_of::immediate_type_of(bcx.ccx, discr_ty);
-                let discr = adt::trans_get_discr(&bcx, enum_ty, discr_lvalue.llval, None, true);
-                let discr = if common::val_ty(discr) == Type::i1(bcx.ccx) {
-                    bcx.zext(discr, discr_type)
-                } else {
-                    bcx.trunc(discr, discr_type)
-                };
+                let discr = adt::trans_get_discr(&bcx, enum_ty, discr_lvalue.llval,
+                                                 Some(discr_type), true);
                 (bcx, OperandRef {
                     val: OperandValue::Immediate(discr),
                     ty: discr_ty

--- a/src/librustc_typeck/Cargo.toml
+++ b/src/librustc_typeck/Cargo.toml
@@ -22,4 +22,3 @@ rustc_data_structures = { path = "../librustc_data_structures" }
 rustc_platform_intrinsics = { path = "../librustc_platform_intrinsics" }
 syntax_pos = { path = "../libsyntax_pos" }
 rustc_errors = { path = "../librustc_errors" }
-rustc_i128 = { path = "../librustc_i128" }

--- a/src/librustc_typeck/Cargo.toml
+++ b/src/librustc_typeck/Cargo.toml
@@ -22,3 +22,4 @@ rustc_data_structures = { path = "../librustc_data_structures" }
 rustc_platform_intrinsics = { path = "../librustc_platform_intrinsics" }
 syntax_pos = { path = "../libsyntax_pos" }
 rustc_errors = { path = "../librustc_errors" }
+rustc_i128 = { path = "../librustc_i128" }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1047,7 +1047,8 @@ fn evaluate_disr_expr(ccx: &CrateCtxt, repr_ty: attr::IntType, body: hir::BodyId
     let hint = UncheckedExprHint(ty_hint);
     match ConstContext::new(ccx.tcx, body).eval(e, hint) {
         Ok(ConstVal::Integral(i)) => {
-            // FIXME: eval should return an error if the hint is wrong
+            // FIXME: eval should return an error if the hint does not match the type of the body.
+            // i.e. eventually the match below would not exist.
             match (repr_ty, i) {
                 (attr::SignedInt(ast::IntTy::I8), ConstInt::I8(_)) |
                 (attr::SignedInt(ast::IntTy::I16), ConstInt::I16(_)) |

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -98,6 +98,8 @@ extern crate rustc_const_eval;
 extern crate rustc_data_structures;
 extern crate rustc_errors as errors;
 
+extern crate rustc_i128;
+
 pub use rustc::dep_graph;
 pub use rustc::hir;
 pub use rustc::lint;

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -98,8 +98,6 @@ extern crate rustc_const_eval;
 extern crate rustc_data_structures;
 extern crate rustc_errors as errors;
 
-extern crate rustc_i128;
-
 pub use rustc::dep_graph;
 pub use rustc::hir;
 pub use rustc::lint;

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -1308,6 +1308,12 @@ extern "C" LLVMRustVisibility LLVMRustGetVisibility(LLVMValueRef V) {
   return toRust(LLVMGetVisibility(V));
 }
 
+// Oh hey, a binding that makes sense for once? (because LLVM’s own do not)
+extern "C" LLVMValueRef LLVMRustBuildIntCast(LLVMBuilderRef B, LLVMValueRef Val,
+                                             LLVMTypeRef DestTy, bool isSigned) {
+  return wrap(unwrap(B)->CreateIntCast(unwrap(Val), unwrap(DestTy), isSigned, ""));
+}
+
 extern "C" void LLVMRustSetVisibility(LLVMValueRef V,
                                       LLVMRustVisibility RustVisibility) {
   LLVMSetVisibility(V, fromRust(RustVisibility));

--- a/src/test/codegen/match.rs
+++ b/src/test/codegen/match.rs
@@ -20,9 +20,13 @@ pub enum E {
 // CHECK-LABEL: @exhaustive_match
 #[no_mangle]
 pub fn exhaustive_match(e: E) {
-// CHECK: switch{{.*}}, label %[[DEFAULT:[a-zA-Z0-9_]+]]
-// CHECK: [[DEFAULT]]:
-// CHECK-NEXT: unreachable
+// CHECK: switch{{.*}}, label %[[OTHERWISE:[a-zA-Z0-9_]+]] [
+// CHECK-NEXT: i8 [[DISCR:[0-9]+]], label %[[TRUE:[a-zA-Z0-9_]+]]
+// CHECK-NEXT: ]
+// CHECK: [[TRUE]]:
+// CHECK-NEXT: br label %[[EXIT:[a-zA-Z0-9_]+]]
+// CHECK: [[OTHERWISE]]:
+// CHECK-NEXT: br label %[[EXIT:[a-zA-Z0-9_]+]]
     match e {
         E::A => (),
         E::B => (),

--- a/src/test/codegen/match.rs
+++ b/src/test/codegen/match.rs
@@ -21,7 +21,7 @@ pub enum E {
 #[no_mangle]
 pub fn exhaustive_match(e: E) {
 // CHECK: switch{{.*}}, label %[[OTHERWISE:[a-zA-Z0-9_]+]] [
-// CHECK-NEXT: i8 [[DISCR:[0-9]+]], label %[[TRUE:[a-zA-Z0-9_]+]]
+// CHECK-NEXT: i[[TY:[0-9]+]] [[DISCR:[0-9]+]], label %[[TRUE:[a-zA-Z0-9_]+]]
 // CHECK-NEXT: ]
 // CHECK: [[TRUE]]:
 // CHECK-NEXT: br label %[[EXIT:[a-zA-Z0-9_]+]]

--- a/src/test/compile-fail/E0081.rs
+++ b/src/test/compile-fail/E0081.rs
@@ -9,10 +9,10 @@
 // except according to those terms.
 
 enum Enum {
-    P = 3, //~ NOTE first use of `3isize`
+    P = 3, //~ NOTE first use of `3`
     X = 3,
-    //~^ ERROR discriminant value `3isize` already exists
-    //~| NOTE enum already has `3isize`
+    //~^ ERROR discriminant value `3` already exists
+    //~| NOTE enum already has `3`
     Y = 5
 }
 

--- a/src/test/compile-fail/issue-15524.rs
+++ b/src/test/compile-fail/issue-15524.rs
@@ -12,20 +12,20 @@ const N: isize = 1;
 
 enum Foo {
     A = 1,
-    //~^ NOTE first use of `1isize`
-    //~| NOTE first use of `1isize`
-    //~| NOTE first use of `1isize`
+    //~^ NOTE first use of `1`
+    //~| NOTE first use of `1`
+    //~| NOTE first use of `1`
     B = 1,
-    //~^ ERROR discriminant value `1isize` already exists
-    //~| NOTE enum already has `1isize`
+    //~^ ERROR discriminant value `1` already exists
+    //~| NOTE enum already has `1`
     C = 0,
     D,
-    //~^ ERROR discriminant value `1isize` already exists
-    //~| NOTE enum already has `1isize`
+    //~^ ERROR discriminant value `1` already exists
+    //~| NOTE enum already has `1`
 
     E = N,
-    //~^ ERROR discriminant value `1isize` already exists
-    //~| NOTE enum already has `1isize`
+    //~^ ERROR discriminant value `1` already exists
+    //~| NOTE enum already has `1`
 
 }
 

--- a/src/test/mir-opt/simplify_if.rs
+++ b/src/test/mir-opt/simplify_if.rs
@@ -17,7 +17,7 @@ fn main() {
 // END RUST SOURCE
 // START rustc.node4.SimplifyBranches.initial-before.mir
 // bb0: {
-//     if(const false) -> [true: bb1, false: bb2];
+//     switchInt(const false) -> [0: bb2, otherwise: bb1];
 // }
 // END rustc.node4.SimplifyBranches.initial-before.mir
 // START rustc.node4.SimplifyBranches.initial-after.mir

--- a/src/test/ui/custom-derive/issue-36935.rs
+++ b/src/test/ui/custom-derive/issue-36935.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:plugin.rs
+// ignore-stage1
 
 #![feature(proc_macro)]
 

--- a/src/test/ui/custom-derive/issue-36935.stderr
+++ b/src/test/ui/custom-derive/issue-36935.stderr
@@ -1,7 +1,7 @@
 error: proc-macro derive panicked
-  --> $DIR/issue-36935.rs:17:15
+  --> $DIR/issue-36935.rs:18:15
    |
-17 | #[derive(Foo, Bar)]
+18 | #[derive(Foo, Bar)]
    |               ^^^
    |
    = help: message: lolnope


### PR DESCRIPTION
Something I've been meaning to do for a very long while. This PR essentially gets rid of 3 kinds of conditional branching and only keeps the most general one - `SwitchInt`. Primary benefits are such that dealing with MIR now does not involve dealing with 3 different ways to do conditional control flow. On the other hand, constructing a `SwitchInt` currently requires more code than what previously was necessary to build an equivalent `If` terminator. Something trivially "fixable" with some constructor methods somewhere (MIR needs stuff like that badly in general).

Some timings (tl;dr: slightly faster^1 (unexpected), but also uses slightly more memory at peak (expected)):

^1: Not sure if the speed benefits are because of LLVM liking the generated code better or the compiler itself getting compiled better. Either way, its a net benefit. The CORE and SYNTAX timings done for compilation without optimisation.

```
AFTER:
Building stage1 std artifacts (x86_64-unknown-linux-gnu -> x86_64-unknown-linux-gnu)
    Finished release [optimized] target(s) in 31.50 secs
    Finished release [optimized] target(s) in 31.42 secs
Building stage1 compiler artifacts (x86_64-unknown-linux-gnu -> x86_64-unknown-linux-gnu)
    Finished release [optimized] target(s) in 439.56 secs
    Finished release [optimized] target(s) in 435.15 secs

CORE: 99% (24.81 real, 0.13 kernel, 24.57 user); 358536k resident
CORE: 99% (24.56 real, 0.15 kernel, 24.36 user); 359168k resident
SYNTAX: 99% (49.98 real, 0.48 kernel, 49.42 user); 653416k resident
SYNTAX: 99% (50.07 real, 0.58 kernel, 49.43 user); 653604k resident

BEFORE:
Building stage1 std artifacts (x86_64-unknown-linux-gnu -> x86_64-unknown-linux-gnu)
    Finished release [optimized] target(s) in 31.84 secs
Building stage1 compiler artifacts (x86_64-unknown-linux-gnu -> x86_64-unknown-linux-gnu)
    Finished release [optimized] target(s) in 451.17 secs

CORE: 99% (24.66 real, 0.20 kernel, 24.38 user); 351096k resident
CORE: 99% (24.36 real, 0.17 kernel, 24.18 user); 352284k resident
SYNTAX: 99% (52.24 real, 0.56 kernel, 51.66 user); 645544k resident
SYNTAX: 99% (51.55 real, 0.48 kernel, 50.99 user); 646428k resident
```

cc @nikomatsakis @eddyb 