### PR TITLE
Don't use "unadjusted" ABI on non windows platforms

### DIFF
--- a/src/libcompiler_builtins/lib.rs
+++ b/src/libcompiler_builtins/lib.rs
@@ -652,17 +652,17 @@ pub mod reimpls {
         }
 
         #[export_name="__fixunssfti"]
-        pub extern "unadjusted" fn f32_as_u128(a: f32) -> u128 {
+        pub extern $unadj fn f32_as_u128(a: f32) -> u128 {
             float_as_unsigned!(a, f32, u128)
         }
 
         #[export_name="__fixdfti"]
-        pub extern "unadjusted" fn f64_as_i128(a: f64) -> i128 {
+        pub extern $unadj fn f64_as_i128(a: f64) -> i128 {
             float_as_signed!(a, f64, i128)
         }
 
         #[export_name="__fixsfti"]
-        pub extern "unadjusted" fn f32_as_i128(a: f32) -> i128 {
+        pub extern $unadj fn f32_as_i128(a: f32) -> i128 {
             float_as_signed!(a, f32, i128)
         }
 


### PR DESCRIPTION
We introduced the unadjusted ABI to work around wrong
(buggy) ABI expectations by LLVM on Windows [1].
Therefore, it should be solely used on Windows and not
on other platforms, like right now is the case.

[1]: see this comment for details https://github.com/rust-lang/rust/pull/38482#issuecomment-269074031