### PR TITLE
rustbuild: Add x.py to source tarballs

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -381,7 +381,8 @@ pub fn rust_src(build: &Build) {
         "README.md",
         "RELEASES.md",
         "configure",
-        "Makefile.in"
+        "Makefile.in",
+        "x.py",
     ];
     let src_dirs = [
         "man",


### PR DESCRIPTION
We should be sure to add our build system entry point!

Closes #39476