### PR TITLE
libbacktrace: Fix uninitialized variable

### DIFF
--- a/src/libbacktrace/pecoff.c
+++ b/src/libbacktrace/pecoff.c
@@ -607,7 +607,9 @@ coff_add (struct backtrace_state *state, int descriptor,
   //       against the upstream libbacktrace, that's what's going on.
   uint32_t str_size;
   off_t str_off;
-  struct backtrace_view syms_view;
+  // NOTE: upstream doesn't have `{0}`, this is a fix for Rust issue #39468.
+  //       If syms_view is not initialized, then `free(syms_view.base)` may segfault later.
+  struct backtrace_view syms_view = {0};
   off_t syms_off;
   size_t syms_size;
   int syms_view_valid;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/39468