### PR TITLE
[stable] next

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,11 @@
+Version 1.15.1 (2017-02-07)
+===========================
+
+* [Fix IntoIter::as_mut_slice's signature][39466]
+
+[39466]: https://github.com/rust-lang/rust/pull/39466
+
+
 Version 1.15.0 (2017-02-02)
 ===========================
 

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -13,7 +13,7 @@
 ######################################################################
 
 # The version number
-CFG_RELEASE_NUM=1.15.0
+CFG_RELEASE_NUM=1.15.1
 
 # An optional number to put after the label, e.g. '.2' -> '-beta.2'
 # NB Make sure it starts with a dot to conform to semver pre-release

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1929,7 +1929,7 @@ impl<T> IntoIter<T> {
     /// assert_eq!(into_iter.next().unwrap(), 'z');
     /// ```
     #[stable(feature = "vec_into_iter_as_slice", since = "1.15.0")]
-    pub fn as_mut_slice(&self) -> &mut [T] {
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
         unsafe {
             slice::from_raw_parts_mut(self.ptr as *mut T, self.len())
         }


### PR DESCRIPTION
The relnotes schedule the release for Tuesday.

- https://github.com/rust-lang/rust/pull/39466

r? @alexcrichton 

[RELEASES.md](https://github.com/brson/rust/blob/stable-next/RELEASES.md).