### PR TITLE
Remove some hacks and unignore some tests on early stages thanks to beta update

### DIFF
--- a/src/libcompiler_builtins/lib.rs
+++ b/src/libcompiler_builtins/lib.rs
@@ -544,8 +544,7 @@ pub mod reimpls {
         const MD1 : u32 = MANTISSA_DIGITS + 1;
         const MD2 : u32 = MANTISSA_DIGITS + 2;
 
-        // SNAP: replace this with !0u128
-        let negn :u128 = !0;
+        let negn = !0u128;
 
         if sd > MANTISSA_DIGITS {
             a = match sd {
@@ -579,8 +578,7 @@ pub mod reimpls {
         const MD1 : u32 = MANTISSA_DIGITS + 1;
         const MD2 : u32 = MANTISSA_DIGITS + 2;
 
-        // SNAP: replace this with !0u128
-        let negn :u128 = !0;
+        let negn = !0u128;
 
         if sd > MANTISSA_DIGITS {
             a = match sd {

--- a/src/librustc_const_eval/eval.rs
+++ b/src/librustc_const_eval/eval.rs
@@ -483,11 +483,8 @@ fn eval_const_expr_partial<'a, 'tcx>(cx: &ConstContext<'a, 'tcx>,
                     return Ok(Integral(I64(i64::min_value())))
                 },
                 (&LitKind::Int(n, _), Some(&ty::TyInt(IntTy::I128))) |
-                (&LitKind::Int(n, Signed(IntTy::I128)), _) => {
-                    // SNAP: replace n in pattern with I128_OVERFLOW and remove this if.
-                    if n == I128_OVERFLOW {
-                        return Ok(Integral(I128(i128::min_value())))
-                    }
+                (&LitKind::Int(I128_OVERFLOW, Signed(IntTy::I128)), _) => {
+                    return Ok(Integral(I128(i128::min_value())))
                 },
                 (&LitKind::Int(n, _), Some(&ty::TyInt(IntTy::Is))) |
                 (&LitKind::Int(n, Signed(IntTy::Is)), _) => {

--- a/src/librustc_const_math/int.rs
+++ b/src/librustc_const_math/int.rs
@@ -155,13 +155,11 @@ impl ConstInt {
             (InferSigned(a @ 0...ibounds::U8MAX), U8(_)) => U8(a as u8),
             (InferSigned(a @ 0...ibounds::U16MAX), U16(_)) => U16(a as u16),
             (InferSigned(a @ 0...ibounds::U32MAX), U32(_)) => U32(a as u32),
-            // SNAP: replace with U64MAX
-            (InferSigned(a @ 0...ibounds::I64MAX), U64(_)) => U64(a as u64),
+            (InferSigned(a @ 0...ibounds::U64MAX), U64(_)) => U64(a as u64),
             (InferSigned(a @ 0...ibounds::I128MAX), U128(_)) => U128(a as u128),
             (InferSigned(a @ 0...ibounds::U16MAX), Usize(Us16(_))) => Usize(Us16(a as u16)),
             (InferSigned(a @ 0...ibounds::U32MAX), Usize(Us32(_))) => Usize(Us32(a as u32)),
-            // SNAP: replace with U64MAX
-            (InferSigned(a @ 0...ibounds::I64MAX), Usize(Us64(_))) => Usize(Us64(a as u64)),
+            (InferSigned(a @ 0...ibounds::U64MAX), Usize(Us64(_))) => Usize(Us64(a as u64)),
             (InferSigned(_), _) => return Err(ConstMathErr::NotInRange),
             _ => self, // already known types
         };

--- a/src/librustc_trans/common.rs
+++ b/src/librustc_trans/common.rs
@@ -230,14 +230,9 @@ pub fn C_integral(t: Type, u: u64, sign_extend: bool) -> ValueRef {
 }
 
 pub fn C_big_integral(t: Type, u: u128, sign_extend: bool) -> ValueRef {
-    if ::std::mem::size_of::<u128>() == 16 {
-        unsafe {
-            let words = [u as u64, u.wrapping_shr(64) as u64];
-            llvm::LLVMConstIntOfArbitraryPrecision(t.to_ref(), 2, words.as_ptr())
-        }
-    } else {
-        // SNAP: remove after snapshot
-        C_integral(t, u as u64, sign_extend)
+    unsafe {
+        let words = [u as u64, u.wrapping_shr(64) as u64];
+        llvm::LLVMConstIntOfArbitraryPrecision(t.to_ref(), 2, words.as_ptr())
     }
 }
 

--- a/src/test/run-pass/i128-ffi.rs
+++ b/src/test/run-pass/i128-ffi.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-stage0
-// ignore-stage1
-
 // MSVC doesn't support 128 bit integers, and other Windows
 // C compilers have very inconsistent views on how the ABI
 // should look like.

--- a/src/test/run-pass/i128.rs
+++ b/src/test/run-pass/i128.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-stage0
-// ignore-stage1
-
 // ignore-emscripten
 
 #![feature(i128_type, test)]

--- a/src/test/run-pass/issue-38987.rs
+++ b/src/test/run-pass/issue-38987.rs
@@ -7,11 +7,8 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(i128_type)]
 
-// SNAP: run on all stages after snapshot, i128 currently doesn't work on stages 0 and 1
-// ignore-stage1
-// ignore-stage0
+#![feature(i128_type)]
 
 fn main() {
     let _ = -0x8000_0000_0000_0000_0000_0000_0000_0000i128;

--- a/src/test/run-pass/u128.rs
+++ b/src/test/run-pass/u128.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-stage0
-// ignore-stage1
-
 // ignore-emscripten
 
 #![feature(i128_type, test)]


### PR DESCRIPTION
With #39463 merged, we don't need to ignore i128 tests on stage 0 and 1 any more. Also, we can remove some hacks from the compiler that were required for bootstrap.

r? @alexcrichton 
cc @nagisa