### PR TITLE
Uninhabited while-let pattern fix

### DIFF
--- a/src/librustc_const_eval/check_match.rs
+++ b/src/librustc_const_eval/check_match.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::ptr;
 use _match::{MatchCheckCtxt, Matrix, expand_pattern, is_useful};
 use _match::Usefulness::*;
 use _match::WitnessPreference::*;
@@ -274,7 +273,7 @@ fn check_arms<'a, 'tcx>(cx: &mut MatchCheckCtxt<'a, 'tcx>,
     let mut seen = Matrix::empty();
     let mut catchall = None;
     let mut printed_if_let_err = false;
-    for &(ref pats, guard) in arms {
+    for (arm_index, &(ref pats, guard)) in arms.iter().enumerate() {
         for &(pat, hir_pat) in pats {
             let v = vec![pat];
 
@@ -305,17 +304,23 @@ fn check_arms<'a, 'tcx>(cx: &mut MatchCheckCtxt<'a, 'tcx>,
                             let span = first_pat.0.span;
 
                             // check which arm we're on.
-                            if ptr::eq(first_arm_pats, pats) {
-                                let mut diagnostic = Diagnostic::new(Level::Warning,
-                                                                     "unreachable pattern");
-                                diagnostic.set_span(pat.span);
-                                cx.tcx.sess.add_lint_diagnostic(lint::builtin::UNREACHABLE_PATTERNS,
-                                                                hir_pat.id, diagnostic);
-                            } else {
-                                struct_span_err!(cx.tcx.sess, span, E0165,
-                                                 "irrefutable while-let pattern")
-                                    .span_label(span, &format!("irrefutable pattern"))
-                                    .emit();
+                            match arm_index {
+                                // The arm with the user-specified pattern.
+                                0 => {
+                                    let mut diagnostic = Diagnostic::new(Level::Warning,
+                                                                         "unreachable pattern");
+                                    diagnostic.set_span(pat.span);
+                                    cx.tcx.sess.add_lint_diagnostic(lint::builtin::UNREACHABLE_PATTERNS,
+                                                                    hir_pat.id, diagnostic);
+                                },
+                                // The arm with the wildcard pattern.
+                                1 => {
+                                    struct_span_err!(cx.tcx.sess, span, E0165,
+                                                     "irrefutable while-let pattern")
+                                        .span_label(span, &format!("irrefutable pattern"))
+                                        .emit();
+                                },
+                                _ => bug!(),
                             }
                         },
 

--- a/src/librustc_const_eval/check_match.rs
+++ b/src/librustc_const_eval/check_match.rs
@@ -310,8 +310,9 @@ fn check_arms<'a, 'tcx>(cx: &mut MatchCheckCtxt<'a, 'tcx>,
                                     let mut diagnostic = Diagnostic::new(Level::Warning,
                                                                          "unreachable pattern");
                                     diagnostic.set_span(pat.span);
-                                    cx.tcx.sess.add_lint_diagnostic(lint::builtin::UNREACHABLE_PATTERNS,
-                                                                    hir_pat.id, diagnostic);
+                                    cx.tcx.sess.add_lint_diagnostic(
+                                            lint::builtin::UNREACHABLE_PATTERNS,
+                                            hir_pat.id, diagnostic);
                                 },
                                 // The arm with the wildcard pattern.
                                 1 => {

--- a/src/librustc_const_eval/lib.rs
+++ b/src/librustc_const_eval/lib.rs
@@ -30,7 +30,6 @@
 #![feature(box_syntax)]
 #![feature(const_fn)]
 #![feature(i128_type)]
-#![feature(ptr_eq)]
 
 extern crate arena;
 #[macro_use] extern crate syntax;

--- a/src/librustc_const_eval/lib.rs
+++ b/src/librustc_const_eval/lib.rs
@@ -30,6 +30,7 @@
 #![feature(box_syntax)]
 #![feature(const_fn)]
 #![feature(i128_type)]
+#![feature(ptr_eq)]
 
 extern crate arena;
 #[macro_use] extern crate syntax;

--- a/src/test/compile-fail/uninhabited-patterns.rs
+++ b/src/test/compile-fail/uninhabited-patterns.rs
@@ -24,6 +24,10 @@ struct NotSoSecretlyEmpty {
     _priv: !,
 }
 
+fn foo() -> Option<NotSoSecretlyEmpty> {
+    None
+}
+
 fn main() {
     let x: &[!] = &[];
 
@@ -44,6 +48,10 @@ fn main() {
         Ok(_y) => (),
         Err(Err(_y)) => (),
         Err(Ok(_y)) => (),  //~ ERROR unreachable pattern
+    }
+
+    while let Some(_y) = foo() {
+        //~^ ERROR unreachable pattern
     }
 }
 


### PR DESCRIPTION
This fix makes it so while-let with an unsatisfiable pattern raises a correct warning rather than an incorrect error.