### PR TITLE
[LLVM 4.0] Support a debug info API change for LLVM 4.0

### DIFF
--- a/src/librustc_llvm/ffi.rs
+++ b/src/librustc_llvm/ffi.rs
@@ -8,6 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// FIXME: Rename 'DIGlobalVariable' to 'DIGlobalVariableExpression'
+// once support for LLVM 3.9 is dropped.
+//
+// This method was changed in this LLVM patch:
+// https://reviews.llvm.org/D26769
+
 use debuginfo::{DIBuilderRef, DIDescriptor, DIFile, DILexicalBlock, DISubprogram, DIType,
                 DIBasicType, DIDerivedType, DICompositeType, DIScope, DIVariable,
                 DIGlobalVariable, DIArray, DISubrange, DITemplateTypeParameter, DIEnumerator,

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -588,7 +588,11 @@ extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreateStaticVariable(
   }
 #endif
 
+#if LLVM_VERSION_GE(4, 0)
+  return wrap(Builder->createGlobalVariableExpression(
+#else
   return wrap(Builder->createGlobalVariable(
+#endif
       unwrapDI<DIDescriptor>(Context), Name, LinkageName,
       unwrapDI<DIFile>(File), LineNo, unwrapDI<DIType>(Ty), IsLocalToUnit,
 #if LLVM_VERSION_GE(4, 0)


### PR DESCRIPTION
Instead of directly creating a `DIGlobalVariable`, we now have to create
a `DIGlobalVariableExpression` which itself contains a reference to a
'DIGlobalVariable'.

This is a straightforward change.

In the future, we should rename `DIGlobalVariable` in the FFI
bindings, assuming we will only refer to `DIGlobalVariableExpression`
and not `DIGlobalVariable`.