### PR TITLE
[LLVM 4.0] Use 32-bits for alignment

### DIFF
--- a/src/librustc_llvm/ffi.rs
+++ b/src/librustc_llvm/ffi.rs
@@ -1363,14 +1363,14 @@ extern "C" {
     pub fn LLVMRustDIBuilderCreateBasicType(Builder: DIBuilderRef,
                                             Name: *const c_char,
                                             SizeInBits: u64,
-                                            AlignInBits: u64,
+                                            AlignInBits: u32,
                                             Encoding: c_uint)
                                             -> DIBasicType;
 
     pub fn LLVMRustDIBuilderCreatePointerType(Builder: DIBuilderRef,
                                               PointeeTy: DIType,
                                               SizeInBits: u64,
-                                              AlignInBits: u64,
+                                              AlignInBits: u32,
                                               Name: *const c_char)
                                               -> DIDerivedType;
 
@@ -1380,7 +1380,7 @@ extern "C" {
                                              File: DIFile,
                                              LineNumber: c_uint,
                                              SizeInBits: u64,
-                                             AlignInBits: u64,
+                                             AlignInBits: u32,
                                              Flags: DIFlags,
                                              DerivedFrom: DIType,
                                              Elements: DIArray,
@@ -1395,7 +1395,7 @@ extern "C" {
                                              File: DIFile,
                                              LineNo: c_uint,
                                              SizeInBits: u64,
-                                             AlignInBits: u64,
+                                             AlignInBits: u32,
                                              OffsetInBits: u64,
                                              Flags: DIFlags,
                                              Ty: DIType)
@@ -1423,7 +1423,7 @@ extern "C" {
                                                  isLocalToUnit: bool,
                                                  Val: ValueRef,
                                                  Decl: DIDescriptor,
-                                                 AlignInBits: u64)
+                                                 AlignInBits: u32)
                                                  -> DIGlobalVariable;
 
     pub fn LLVMRustDIBuilderCreateVariable(Builder: DIBuilderRef,
@@ -1436,19 +1436,19 @@ extern "C" {
                                            AlwaysPreserve: bool,
                                            Flags: DIFlags,
                                            ArgNo: c_uint,
-                                           AlignInBits: u64)
+                                           AlignInBits: u32)
                                            -> DIVariable;
 
     pub fn LLVMRustDIBuilderCreateArrayType(Builder: DIBuilderRef,
                                             Size: u64,
-                                            AlignInBits: u64,
+                                            AlignInBits: u32,
                                             Ty: DIType,
                                             Subscripts: DIArray)
                                             -> DIType;
 
     pub fn LLVMRustDIBuilderCreateVectorType(Builder: DIBuilderRef,
                                              Size: u64,
-                                             AlignInBits: u64,
+                                             AlignInBits: u32,
                                              Ty: DIType,
                                              Subscripts: DIArray)
                                              -> DIType;
@@ -1483,7 +1483,7 @@ extern "C" {
                                                   File: DIFile,
                                                   LineNumber: c_uint,
                                                   SizeInBits: u64,
-                                                  AlignInBits: u64,
+                                                  AlignInBits: u32,
                                                   Elements: DIArray,
                                                   ClassType: DIType)
                                                   -> DIType;
@@ -1494,7 +1494,7 @@ extern "C" {
                                             File: DIFile,
                                             LineNumber: c_uint,
                                             SizeInBits: u64,
-                                            AlignInBits: u64,
+                                            AlignInBits: u32,
                                             Flags: DIFlags,
                                             Elements: DIArray,
                                             RunTimeLang: c_uint,

--- a/src/librustc_trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/debuginfo/metadata.rs
@@ -299,7 +299,7 @@ fn fixed_vec_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
         llvm::LLVMRustDIBuilderCreateArrayType(
             DIB(cx),
             bytes_to_bits(array_size_in_bytes),
-            bytes_to_bits(element_type_align),
+            bytes_to_bits(element_type_align) as u32,
             element_type_metadata,
             subscripts)
     };
@@ -730,7 +730,7 @@ fn basic_type_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             DIB(cx),
             name.as_ptr(),
             bytes_to_bits(size),
-            bytes_to_bits(align),
+            bytes_to_bits(align) as u32,
             encoding)
     };
 
@@ -750,7 +750,7 @@ fn pointer_type_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             DIB(cx),
             pointee_type_metadata,
             bytes_to_bits(pointer_size),
-            bytes_to_bits(pointer_align),
+            bytes_to_bits(pointer_align) as u32,
             name.as_ptr())
     };
     return ptr_metadata;
@@ -1504,7 +1504,7 @@ fn prepare_enum_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                         file_metadata,
                         UNKNOWN_LINE_NUMBER,
                         bytes_to_bits(discriminant_size),
-                        bytes_to_bits(discriminant_align),
+                        bytes_to_bits(discriminant_align) as u32,
                         create_DIArray(DIB(cx), &enumerators_metadata),
                         discriminant_base_type_metadata)
                 };
@@ -1546,7 +1546,7 @@ fn prepare_enum_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
         file_metadata,
         UNKNOWN_LINE_NUMBER,
         bytes_to_bits(enum_type_size),
-        bytes_to_bits(enum_type_align),
+        bytes_to_bits(enum_type_align) as u32,
         DIFlags::FlagZero,
         ptr::null_mut(),
         0, // RuntimeLang
@@ -1648,7 +1648,7 @@ fn set_members_of_composite_type(cx: &CrateContext,
                     unknown_file_metadata(cx),
                     UNKNOWN_LINE_NUMBER,
                     bytes_to_bits(member_size),
-                    bytes_to_bits(member_align),
+                    bytes_to_bits(member_align) as u32,
                     bytes_to_bits(member_offset),
                     member_description.flags,
                     member_description.type_metadata)
@@ -1691,7 +1691,7 @@ fn create_struct_stub(cx: &CrateContext,
             unknown_file_metadata(cx),
             UNKNOWN_LINE_NUMBER,
             bytes_to_bits(struct_size),
-            bytes_to_bits(struct_align),
+            bytes_to_bits(struct_align) as u32,
             DIFlags::FlagZero,
             ptr::null_mut(),
             empty_array,
@@ -1728,7 +1728,7 @@ fn create_union_stub(cx: &CrateContext,
             unknown_file_metadata(cx),
             UNKNOWN_LINE_NUMBER,
             bytes_to_bits(union_size),
-            bytes_to_bits(union_align),
+            bytes_to_bits(union_align) as u32,
             DIFlags::FlagZero,
             empty_array,
             0, // RuntimeLang
@@ -1783,7 +1783,7 @@ pub fn create_global_var_metadata(cx: &CrateContext,
                                                     is_local_to_unit,
                                                     global,
                                                     ptr::null_mut(),
-                                                    global_align as u64,
+                                                    global_align as u32,
         );
     }
 }

--- a/src/librustc_trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/debuginfo/metadata.rs
@@ -299,7 +299,7 @@ fn fixed_vec_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
         llvm::LLVMRustDIBuilderCreateArrayType(
             DIB(cx),
             bytes_to_bits(array_size_in_bytes),
-            bytes_to_bits(element_type_align) as u32,
+            bytes_to_bits(element_type_align),
             element_type_metadata,
             subscripts)
     };
@@ -730,7 +730,7 @@ fn basic_type_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             DIB(cx),
             name.as_ptr(),
             bytes_to_bits(size),
-            bytes_to_bits(align) as u32,
+            bytes_to_bits(align),
             encoding)
     };
 
@@ -750,7 +750,7 @@ fn pointer_type_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             DIB(cx),
             pointee_type_metadata,
             bytes_to_bits(pointer_size),
-            bytes_to_bits(pointer_align) as u32,
+            bytes_to_bits(pointer_align),
             name.as_ptr())
     };
     return ptr_metadata;
@@ -1504,7 +1504,7 @@ fn prepare_enum_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                         file_metadata,
                         UNKNOWN_LINE_NUMBER,
                         bytes_to_bits(discriminant_size),
-                        bytes_to_bits(discriminant_align) as u32,
+                        bytes_to_bits(discriminant_align),
                         create_DIArray(DIB(cx), &enumerators_metadata),
                         discriminant_base_type_metadata)
                 };
@@ -1546,7 +1546,7 @@ fn prepare_enum_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
         file_metadata,
         UNKNOWN_LINE_NUMBER,
         bytes_to_bits(enum_type_size),
-        bytes_to_bits(enum_type_align) as u32,
+        bytes_to_bits(enum_type_align),
         DIFlags::FlagZero,
         ptr::null_mut(),
         0, // RuntimeLang
@@ -1648,7 +1648,7 @@ fn set_members_of_composite_type(cx: &CrateContext,
                     unknown_file_metadata(cx),
                     UNKNOWN_LINE_NUMBER,
                     bytes_to_bits(member_size),
-                    bytes_to_bits(member_align) as u32,
+                    bytes_to_bits(member_align),
                     bytes_to_bits(member_offset),
                     member_description.flags,
                     member_description.type_metadata)
@@ -1691,7 +1691,7 @@ fn create_struct_stub(cx: &CrateContext,
             unknown_file_metadata(cx),
             UNKNOWN_LINE_NUMBER,
             bytes_to_bits(struct_size),
-            bytes_to_bits(struct_align) as u32,
+            bytes_to_bits(struct_align),
             DIFlags::FlagZero,
             ptr::null_mut(),
             empty_array,
@@ -1728,7 +1728,7 @@ fn create_union_stub(cx: &CrateContext,
             unknown_file_metadata(cx),
             UNKNOWN_LINE_NUMBER,
             bytes_to_bits(union_size),
-            bytes_to_bits(union_align) as u32,
+            bytes_to_bits(union_align),
             DIFlags::FlagZero,
             empty_array,
             0, // RuntimeLang
@@ -1783,7 +1783,7 @@ pub fn create_global_var_metadata(cx: &CrateContext,
                                                     is_local_to_unit,
                                                     global,
                                                     ptr::null_mut(),
-                                                    global_align as u32,
+                                                    global_align,
         );
     }
 }

--- a/src/librustc_trans/debuginfo/mod.rs
+++ b/src/librustc_trans/debuginfo/mod.rs
@@ -464,7 +464,7 @@ pub fn declare_local<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
                     cx.sess().opts.optimize != config::OptLevel::No,
                     DIFlags::FlagZero,
                     argument_index,
-                    align as u32,
+                    align,
                 )
             };
             source_loc::set_debug_location(bcx,

--- a/src/librustc_trans/debuginfo/mod.rs
+++ b/src/librustc_trans/debuginfo/mod.rs
@@ -464,7 +464,7 @@ pub fn declare_local<'a, 'tcx>(bcx: &Builder<'a, 'tcx>,
                     cx.sess().opts.optimize != config::OptLevel::No,
                     DIFlags::FlagZero,
                     argument_index,
-                    align as u64,
+                    align as u32,
                 )
             };
             source_loc::set_debug_location(bcx,

--- a/src/librustc_trans/debuginfo/utils.rs
+++ b/src/librustc_trans/debuginfo/utils.rs
@@ -24,6 +24,8 @@ use type_::Type;
 use syntax_pos::{self, Span};
 use syntax::ast;
 
+use std::ops;
+
 pub fn is_node_local_to_unit(cx: &CrateContext, node_id: ast::NodeId) -> bool
 {
     // The is_local_to_unit flag indicates whether a function is local to the
@@ -49,12 +51,13 @@ pub fn span_start(cx: &CrateContext, span: Span) -> syntax_pos::Loc {
     cx.sess().codemap().lookup_char_pos(span.lo)
 }
 
-pub fn size_and_align_of(cx: &CrateContext, llvm_type: Type) -> (u64, u64) {
-    (machine::llsize_of_alloc(cx, llvm_type), machine::llalign_of_min(cx, llvm_type) as u64)
+pub fn size_and_align_of(cx: &CrateContext, llvm_type: Type) -> (u64, u32) {
+    (machine::llsize_of_alloc(cx, llvm_type), machine::llalign_of_min(cx, llvm_type))
 }
 
-pub fn bytes_to_bits(bytes: u64) -> u64 {
-    bytes * 8
+pub fn bytes_to_bits<T>(bytes: T) -> T
+    where T: ops::Mul<Output=T> + From<u8> {
+    bytes * 8u8.into()
 }
 
 #[inline]

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -513,7 +513,7 @@ extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreateFunction(
 
 extern "C" LLVMRustMetadataRef
 LLVMRustDIBuilderCreateBasicType(LLVMRustDIBuilderRef Builder, const char *Name,
-                                 uint64_t SizeInBits, uint64_t AlignInBits,
+                                 uint64_t SizeInBits, uint32_t AlignInBits,
                                  unsigned Encoding) {
   return wrap(Builder->createBasicType(Name, SizeInBits,
 #if LLVM_VERSION_LE(3, 9)
@@ -524,7 +524,7 @@ LLVMRustDIBuilderCreateBasicType(LLVMRustDIBuilderRef Builder, const char *Name,
 
 extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreatePointerType(
     LLVMRustDIBuilderRef Builder, LLVMRustMetadataRef PointeeTy,
-    uint64_t SizeInBits, uint64_t AlignInBits, const char *Name) {
+    uint64_t SizeInBits, uint32_t AlignInBits, const char *Name) {
   return wrap(Builder->createPointerType(unwrapDI<DIType>(PointeeTy),
                                          SizeInBits, AlignInBits, Name));
 }
@@ -532,7 +532,7 @@ extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreatePointerType(
 extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreateStructType(
     LLVMRustDIBuilderRef Builder, LLVMRustMetadataRef Scope, const char *Name,
     LLVMRustMetadataRef File, unsigned LineNumber, uint64_t SizeInBits,
-    uint64_t AlignInBits, LLVMRustDIFlags Flags,
+    uint32_t AlignInBits, LLVMRustDIFlags Flags,
     LLVMRustMetadataRef DerivedFrom, LLVMRustMetadataRef Elements,
     unsigned RunTimeLang, LLVMRustMetadataRef VTableHolder,
     const char *UniqueId) {
@@ -546,7 +546,7 @@ extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreateStructType(
 extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreateMemberType(
     LLVMRustDIBuilderRef Builder, LLVMRustMetadataRef Scope, const char *Name,
     LLVMRustMetadataRef File, unsigned LineNo, uint64_t SizeInBits,
-    uint64_t AlignInBits, uint64_t OffsetInBits, LLVMRustDIFlags Flags,
+    uint32_t AlignInBits, uint64_t OffsetInBits, LLVMRustDIFlags Flags,
     LLVMRustMetadataRef Ty) {
   return wrap(Builder->createMemberType(unwrapDI<DIDescriptor>(Scope), Name,
                                         unwrapDI<DIFile>(File), LineNo,
@@ -573,7 +573,7 @@ extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreateStaticVariable(
     LLVMRustDIBuilderRef Builder, LLVMRustMetadataRef Context, const char *Name,
     const char *LinkageName, LLVMRustMetadataRef File, unsigned LineNo,
     LLVMRustMetadataRef Ty, bool IsLocalToUnit, LLVMValueRef V,
-    LLVMRustMetadataRef Decl = nullptr, uint64_t AlignInBits = 0) {
+    LLVMRustMetadataRef Decl = nullptr, uint32_t AlignInBits = 0) {
   Constant *InitVal = cast<Constant>(unwrap(V));
 
 #if LLVM_VERSION_GE(4, 0)
@@ -608,7 +608,7 @@ extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreateVariable(
     LLVMRustDIBuilderRef Builder, unsigned Tag, LLVMRustMetadataRef Scope,
     const char *Name, LLVMRustMetadataRef File, unsigned LineNo,
     LLVMRustMetadataRef Ty, bool AlwaysPreserve, LLVMRustDIFlags Flags,
-    unsigned ArgNo, uint64_t AlignInBits) {
+    unsigned ArgNo, uint32_t AlignInBits) {
 #if LLVM_VERSION_GE(3, 8)
   if (Tag == 0x100) { // DW_TAG_auto_variable
     return wrap(Builder->createAutoVariable(
@@ -633,7 +633,7 @@ extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreateVariable(
 
 extern "C" LLVMRustMetadataRef
 LLVMRustDIBuilderCreateArrayType(LLVMRustDIBuilderRef Builder, uint64_t Size,
-                                 uint64_t AlignInBits, LLVMRustMetadataRef Ty,
+                                 uint32_t AlignInBits, LLVMRustMetadataRef Ty,
                                  LLVMRustMetadataRef Subscripts) {
   return wrap(
       Builder->createArrayType(Size, AlignInBits, unwrapDI<DIType>(Ty),
@@ -642,7 +642,7 @@ LLVMRustDIBuilderCreateArrayType(LLVMRustDIBuilderRef Builder, uint64_t Size,
 
 extern "C" LLVMRustMetadataRef
 LLVMRustDIBuilderCreateVectorType(LLVMRustDIBuilderRef Builder, uint64_t Size,
-                                  uint64_t AlignInBits, LLVMRustMetadataRef Ty,
+                                  uint32_t AlignInBits, LLVMRustMetadataRef Ty,
                                   LLVMRustMetadataRef Subscripts) {
   return wrap(
       Builder->createVectorType(Size, AlignInBits, unwrapDI<DIType>(Ty),
@@ -683,7 +683,7 @@ LLVMRustDIBuilderCreateEnumerator(LLVMRustDIBuilderRef Builder,
 extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreateEnumerationType(
     LLVMRustDIBuilderRef Builder, LLVMRustMetadataRef Scope, const char *Name,
     LLVMRustMetadataRef File, unsigned LineNumber, uint64_t SizeInBits,
-    uint64_t AlignInBits, LLVMRustMetadataRef Elements,
+    uint32_t AlignInBits, LLVMRustMetadataRef Elements,
     LLVMRustMetadataRef ClassTy) {
   return wrap(Builder->createEnumerationType(
       unwrapDI<DIDescriptor>(Scope), Name, unwrapDI<DIFile>(File), LineNumber,
@@ -694,7 +694,7 @@ extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreateEnumerationType(
 extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreateUnionType(
     LLVMRustDIBuilderRef Builder, LLVMRustMetadataRef Scope, const char *Name,
     LLVMRustMetadataRef File, unsigned LineNumber, uint64_t SizeInBits,
-    uint64_t AlignInBits, LLVMRustDIFlags Flags, LLVMRustMetadataRef Elements,
+    uint32_t AlignInBits, LLVMRustDIFlags Flags, LLVMRustMetadataRef Elements,
     unsigned RunTimeLang, const char *UniqueId) {
   return wrap(Builder->createUnionType(
       unwrapDI<DIDescriptor>(Scope), Name, unwrapDI<DIFile>(File), LineNumber,


### PR DESCRIPTION
LLVM 4.0 changes this. This change is fine to make for LLVM 3.9 as we
won't have alignments greater than 2^32-1.