### PR TITLE
ignore more gdb versions with buggy rust support

### DIFF
--- a/src/test/debuginfo/borrowed-enum.rs
+++ b/src/test/debuginfo/borrowed-enum.rs
@@ -10,7 +10,7 @@
 
 // ignore-tidy-linelength
 // min-lldb-version: 310
-// ignore-gdb-version: 7.11.90 - 7.12
+// ignore-gdb-version: 7.11.90 - 7.12.9
 
 // compile-flags:-g
 

--- a/src/test/debuginfo/generic-struct-style-enum.rs
+++ b/src/test/debuginfo/generic-struct-style-enum.rs
@@ -10,7 +10,7 @@
 
 // ignore-tidy-linelength
 // min-lldb-version: 310
-// ignore-gdb-version: 7.11.90 - 7.12
+// ignore-gdb-version: 7.11.90 - 7.12.9
 
 // compile-flags:-g
 

--- a/src/test/debuginfo/generic-tuple-style-enum.rs
+++ b/src/test/debuginfo/generic-tuple-style-enum.rs
@@ -10,7 +10,7 @@
 
 // ignore-tidy-linelength
 // min-lldb-version: 310
-// ignore-gdb-version: 7.11.90 - 7.12
+// ignore-gdb-version: 7.11.90 - 7.12.9
 
 // compile-flags:-g
 

--- a/src/test/debuginfo/packed-struct.rs
+++ b/src/test/debuginfo/packed-struct.rs
@@ -10,7 +10,7 @@
 
 // ignore-tidy-linelength
 // min-lldb-version: 310
-// ignore-gdb-version: 7.11.90 - 7.12
+// ignore-gdb-version: 7.11.90 - 7.12.9
 
 // compile-flags:-g
 

--- a/src/test/debuginfo/recursive-struct.rs
+++ b/src/test/debuginfo/recursive-struct.rs
@@ -10,7 +10,7 @@
 
 // ignore-tidy-linelength
 // ignore-lldb
-// ignore-gdb-version: 7.11.90 - 7.12
+// ignore-gdb-version: 7.11.90 - 7.12.9
 
 // compile-flags:-g
 

--- a/src/test/debuginfo/struct-in-enum.rs
+++ b/src/test/debuginfo/struct-in-enum.rs
@@ -10,7 +10,7 @@
 
 // ignore-tidy-linelength
 // min-lldb-version: 310
-// ignore-gdb-version: 7.11.90 - 7.12
+// ignore-gdb-version: 7.11.90 - 7.12.9
 
 // compile-flags:-g
 

--- a/src/test/debuginfo/struct-style-enum.rs
+++ b/src/test/debuginfo/struct-style-enum.rs
@@ -10,7 +10,7 @@
 
 // ignore-tidy-linelength
 // min-lldb-version: 310
-// ignore-gdb-version: 7.11.90 - 7.12
+// ignore-gdb-version: 7.11.90 - 7.12.9
 
 // compile-flags:-g
 

--- a/src/test/debuginfo/tuple-style-enum.rs
+++ b/src/test/debuginfo/tuple-style-enum.rs
@@ -10,7 +10,7 @@
 
 // ignore-tidy-linelength
 // min-lldb-version: 310
-// ignore-gdb-version: 7.11.90 - 7.12
+// ignore-gdb-version: 7.11.90 - 7.12.9
 
 // compile-flags:-g
 

--- a/src/test/debuginfo/union-smoke.rs
+++ b/src/test/debuginfo/union-smoke.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // min-lldb-version: 310
-// ignore-gdb-version: 7.11.90 - 7.12
+// ignore-gdb-version: 7.11.90 - 7.12.9
 
 // compile-flags:-g
 

--- a/src/test/debuginfo/unique-enum.rs
+++ b/src/test/debuginfo/unique-enum.rs
@@ -10,7 +10,7 @@
 
 // ignore-tidy-linelength
 // min-lldb-version: 310
-// ignore-gdb-version: 7.11.90 - 7.12
+// ignore-gdb-version: 7.11.90 - 7.12.9
 
 // compile-flags:-g
 


### PR DESCRIPTION
This extends the versions of gdb which were ignored in #39039. While just ignoring gdb versions up to 7.12.1 would have been sufficient for now, I believe (after consulting https://sourceware.org/gdb/wiki/Internals%20Versions)  that ignoring versions up to 7.12.9 will prevent the tests failing again for 7.12.2, etc. while still running all tests for the development versions of gdb (which will be >= 7.12.10 as far as I can tell).

This should fix #39522.

cc @Manishearth, @michaelwoerister, #38948