### PR TITLE
Change deprecation warning to indicate custom derive support was removed

### DIFF
--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -957,12 +957,11 @@ pub const EXPLAIN_ALLOW_INTERNAL_UNSTABLE: &'static str =
     "allow_internal_unstable side-steps feature gating and stability checks";
 
 pub const EXPLAIN_CUSTOM_DERIVE: &'static str =
-    "`#[derive]` for custom traits is not stable enough for use. It is deprecated and will \
-     be removed in v1.15";
+    "`#[derive]` for custom traits is deprecated and will be removed in the future.";
 
 pub const EXPLAIN_DEPR_CUSTOM_DERIVE: &'static str =
-    "`#[derive]` for custom traits is deprecated and will be removed in v1.15. Prefer using \
-     procedural macro custom derive";
+    "`#[derive]` for custom traits is deprecated and will be removed in the future. \
+    Prefer using procedural macro custom derive.";
 
 pub const EXPLAIN_DERIVE_UNDERSCORE: &'static str =
     "attributes of the form `#[derive_*]` are reserved for the compiler";


### PR DESCRIPTION

I'm very new to Rust and the message was confusing to me (using nightly and not really sure if I was > 1.15 or not).
