### PR TITLE
correct version in which more_struct_aliases was/will be stable

### DIFF
--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -381,7 +381,7 @@ declare_features! (
     (accepted, dotdot_in_tuple_patterns, "1.14.0", Some(33627)),
     (accepted, item_like_imports, "1.14.0", Some(35120)),
     // Allows using `Self` and associated types in struct expressions and patterns.
-    (accepted, more_struct_aliases, "1.14.0", Some(37544)),
+    (accepted, more_struct_aliases, "1.16.0", Some(37544)),
 );
 // (changing above list without updating src/doc/reference.md makes @cmr sad)
 


### PR DESCRIPTION
The stabilizing commit is 5056a437, which is not in 1.14, but is (at
time of writing) on the 1.16 beta branch. [See discussion](https://github.com/rust-lang/rust/pull/39282#discussion_r99481687).