### PR TITLE
improve error message when two-arg assert_eq! receives a trailing comma

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -103,7 +103,7 @@ macro_rules! assert {
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
 macro_rules! assert_eq {
-    ($left:expr , $right:expr) => ({
+    ($left:expr, $right:expr) => ({
         match (&$left, &$right) {
             (left_val, right_val) => {
                 if !(*left_val == *right_val) {
@@ -113,13 +113,13 @@ macro_rules! assert_eq {
             }
         }
     });
-    ($left:expr , $right:expr, $($arg:tt)*) => ({
+    ($left:expr, $right:expr, $($arg:tt)+) => ({
         match (&($left), &($right)) {
             (left_val, right_val) => {
                 if !(*left_val == *right_val) {
                     panic!("assertion failed: `(left == right)` \
                            (left: `{:?}`, right: `{:?}`): {}", left_val, right_val,
-                           format_args!($($arg)*))
+                           format_args!($($arg)+))
                 }
             }
         }
@@ -146,7 +146,7 @@ macro_rules! assert_eq {
 #[macro_export]
 #[stable(feature = "assert_ne", since = "1.12.0")]
 macro_rules! assert_ne {
-    ($left:expr , $right:expr) => ({
+    ($left:expr, $right:expr) => ({
         match (&$left, &$right) {
             (left_val, right_val) => {
                 if *left_val == *right_val {
@@ -156,13 +156,13 @@ macro_rules! assert_ne {
             }
         }
     });
-    ($left:expr , $right:expr, $($arg:tt)*) => ({
+    ($left:expr, $right:expr, $($arg:tt)+) => ({
         match (&($left), &($right)) {
             (left_val, right_val) => {
                 if *left_val == *right_val {
                     panic!("assertion failed: `(left != right)` \
                            (left: `{:?}`, right: `{:?}`): {}", left_val, right_val,
-                           format_args!($($arg)*))
+                           format_args!($($arg)+))
                 }
             }
         }

--- a/src/test/ui/macros/assert_eq_trailing_comma.rs
+++ b/src/test/ui/macros/assert_eq_trailing_comma.rs
@@ -1,0 +1,13 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    assert_eq!(1, 1,);
+}

--- a/src/test/ui/macros/assert_eq_trailing_comma.stderr
+++ b/src/test/ui/macros/assert_eq_trailing_comma.stderr
@@ -1,0 +1,6 @@
+error: unexpected end of macro invocation
+  --> $DIR/assert_eq_trailing_comma.rs:12:20
+   |
+12 |     assert_eq!(1, 1,);
+   |                    ^
+

--- a/src/test/ui/macros/assert_ne_trailing_comma.rs
+++ b/src/test/ui/macros/assert_ne_trailing_comma.rs
@@ -1,0 +1,13 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    assert_ne!(1, 2,);
+}

--- a/src/test/ui/macros/assert_ne_trailing_comma.stderr
+++ b/src/test/ui/macros/assert_ne_trailing_comma.stderr
@@ -1,0 +1,6 @@
+error: unexpected end of macro invocation
+  --> $DIR/assert_ne_trailing_comma.rs:12:20
+   |
+12 |     assert_ne!(1, 2,);
+   |                    ^
+


### PR DESCRIPTION
Previously, `assert_eq!(left, right,)` (respectively, `assert_ne!(left,
right,)`; note the trailing comma) would result in a confusing "requires
at least a format string argument" error. In reality, a format string is
optional, but the trailing comma puts us into the "match a token tree of
zero or more tokens" branch of the macro (in order to support the
optional format string), and passing the empty token tree into
`format_args!` results in the confusing error. If instead we match a
token tree of one or more tokens, we get a much more sensible
"unexpected end of macro invocation" error.

While we're here, fix up a stray space before a comma in the match
guards.

Resolves #39369.

-----

**Before:**
```
$ rustc scratch.rs 
error: requires at least a format string argument
 --> scratch.rs:2:5
  |
2 |     assert_eq!(1, 2,);
  |     ^^^^^^^^^^^^^^^^^^
  |
  = note: this error originates in a macro outside of the current crate

error: aborting due to previous error
```

**After:**
```
$ ./build/x86_64-unknown-linux-gnu/stage1/bin/rustc scratch.rs 
error: unexpected end of macro invocation
 --> scratch.rs:2:20
  |
2 |     assert_eq!(1, 2,);
  |                    ^
```