### PR TITLE
macros: fix inert attributes from `proc_macro_derives` with `#![feature(proc_macro)]`

### DIFF
--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -616,10 +616,9 @@ impl<'a> CrateLoader<'a> {
                                       trait_name: &str,
                                       expand: fn(TokenStream) -> TokenStream,
                                       attributes: &[&'static str]) {
-                let attrs = attributes.iter().cloned().map(Symbol::intern).collect();
-                let derive = SyntaxExtension::ProcMacroDerive(
-                    Box::new(ProcMacroDerive::new(expand, attrs))
-                );
+                let attrs = attributes.iter().cloned().map(Symbol::intern).collect::<Vec<_>>();
+                let derive = ProcMacroDerive::new(expand, attrs.clone());
+                let derive = SyntaxExtension::ProcMacroDerive(Box::new(derive), attrs);
                 self.0.push((Symbol::intern(trait_name), Rc::new(derive)));
             }
 

--- a/src/libsyntax/ext/derive.rs
+++ b/src/libsyntax/ext/derive.rs
@@ -8,124 +8,42 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ast::Name;
-use attr;
-use ast::{self, NestedMetaItem}; use ext::base::{ExtCtxt, SyntaxExtension};
-use codemap;
+use attr::HasAttrs;
+use {ast, codemap};
+use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use symbol::Symbol;
 use syntax_pos::Span;
 
-pub fn derive_attr_trait<'a>(cx: &mut ExtCtxt, attr: &'a ast::Attribute)
-                             -> Option<&'a NestedMetaItem> {
-    if attr.name() != "derive" {
-        return None;
-    }
-    if attr.value_str().is_some() {
-        cx.span_err(attr.span, "unexpected value in `derive`");
-        return None;
-    }
-
-    let traits = attr.meta_item_list().unwrap_or(&[]);
-
-    if traits.is_empty() {
-        cx.span_warn(attr.span, "empty trait list in `derive`");
-        return None;
-    }
-
-    return traits.get(0);
-}
-
-pub fn verify_derive_attrs(cx: &mut ExtCtxt, attrs: &[ast::Attribute]) {
-    for attr in attrs {
+pub fn collect_derives(cx: &mut ExtCtxt, attrs: &mut Vec<ast::Attribute>) -> Vec<(Symbol, Span)> {
+    let mut result = Vec::new();
+    attrs.retain(|attr| {
         if attr.name() != "derive" {
-            continue;
+            return true;
         }
 
         if attr.value_str().is_some() {
             cx.span_err(attr.span, "unexpected value in `derive`");
+            return false;
         }
 
         let traits = attr.meta_item_list().unwrap_or(&[]).to_owned();
-
         if traits.is_empty() {
             cx.span_warn(attr.span, "empty trait list in `derive`");
-            attr::mark_used(&attr);
-            continue;
+            return false;
         }
+
         for titem in traits {
             if titem.word().is_none() {
                 cx.span_err(titem.span, "malformed `derive` entry");
+                return false;
             }
-        }
-    }
-}
-
-#[derive(PartialEq, Debug, Clone, Copy)]
-pub enum DeriveType {
-    ProcMacro,
-    Builtin
-}
-
-impl DeriveType {
-    // Classify a derive trait name by resolving the macro.
-    pub fn classify(cx: &mut ExtCtxt, tname: Name) -> DeriveType {
-        match cx.resolver.resolve_builtin_macro(tname) {
-            Ok(ext) => match *ext {
-                SyntaxExtension::BuiltinDerive(..) => DeriveType::Builtin,
-                _ => DeriveType::ProcMacro,
-            },
-            Err(_) => DeriveType::ProcMacro,
-        }
-    }
-}
-
-pub fn get_derive_attr(cx: &mut ExtCtxt, attrs: &mut Vec<ast::Attribute>,
-                       derive_type: DeriveType) -> Option<ast::Attribute> {
-    for i in 0..attrs.len() {
-        if attrs[i].name() != "derive" {
-            continue;
+            result.push((titem.name().unwrap(), titem.span));
         }
 
-        if attrs[i].value_str().is_some() {
-            continue;
-        }
-
-        let mut traits = attrs[i].meta_item_list().unwrap_or(&[]).to_owned();
-
-        // First, weed out malformed #[derive]
-        traits.retain(|titem| titem.word().is_some());
-
-        let mut titem = None;
-
-        // See if we can find a matching trait.
-        for j in 0..traits.len() {
-            let tname = match traits[j].name() {
-                Some(tname) => tname,
-                _ => continue,
-            };
-
-            if DeriveType::classify(cx, tname) == derive_type {
-                titem = Some(traits.remove(j));
-                break;
-            }
-        }
-
-        // If we find a trait, remove the trait from the attribute.
-        if let Some(titem) = titem {
-            if traits.len() == 0 {
-                attrs.remove(i);
-            } else {
-                let derive = Symbol::intern("derive");
-                let mitem = cx.meta_list(titem.span, derive, traits);
-                attrs[i] = cx.attribute(titem.span, mitem);
-            }
-            let derive = Symbol::intern("derive");
-            let mitem = cx.meta_list(titem.span, derive, vec![titem]);
-            return Some(cx.attribute(mitem.span, mitem));
-        }
-    }
-    return None;
+        true
+    });
+    result
 }
 
 fn allow_unstable(cx: &mut ExtCtxt, span: Span, attr_name: &str) -> Span {
@@ -142,43 +60,25 @@ fn allow_unstable(cx: &mut ExtCtxt, span: Span, attr_name: &str) -> Span {
     }
 }
 
-pub fn add_derived_markers(cx: &mut ExtCtxt, attrs: &mut Vec<ast::Attribute>) {
-    if attrs.is_empty() {
-        return;
-    }
+pub fn add_derived_markers<T: HasAttrs>(cx: &mut ExtCtxt, traits: &[(Symbol, Span)], item: T) -> T {
+    let span = match traits.get(0) {
+        Some(&(_, span)) => span,
+        None => return item,
+    };
 
-    let titems = attrs.iter().filter(|a| {
-        a.name() == "derive"
-    }).flat_map(|a| {
-        a.meta_item_list().unwrap_or(&[]).iter()
-    }).filter_map(|titem| {
-        titem.name()
-    }).collect::<Vec<_>>();
-
-    let span = attrs[0].span;
-
-    if !attrs.iter().any(|a| a.name() == "structural_match") &&
-       titems.iter().any(|t| *t == "PartialEq") && titems.iter().any(|t| *t == "Eq") {
-        let structural_match = Symbol::intern("structural_match");
-        let span = allow_unstable(cx, span, "derive(PartialEq, Eq)");
-        let meta = cx.meta_word(span, structural_match);
-        attrs.push(cx.attribute(span, meta));
-    }
-
-    if !attrs.iter().any(|a| a.name() == "rustc_copy_clone_marker") &&
-       titems.iter().any(|t| *t == "Copy") && titems.iter().any(|t| *t == "Clone") {
-        let structural_match = Symbol::intern("rustc_copy_clone_marker");
-        let span = allow_unstable(cx, span, "derive(Copy, Clone)");
-        let meta = cx.meta_word(span, structural_match);
-        attrs.push(cx.attribute(span, meta));
-    }
-}
-
-pub fn find_derive_attr(cx: &mut ExtCtxt, attrs: &mut Vec<ast::Attribute>)
-                        -> Option<ast::Attribute> {
-    verify_derive_attrs(cx, attrs);
-    get_derive_attr(cx, attrs, DeriveType::ProcMacro).or_else(|| {
-        add_derived_markers(cx, attrs);
-        get_derive_attr(cx, attrs, DeriveType::Builtin)
+    item.map_attrs(|mut attrs| {
+        if traits.iter().any(|&(name, _)| name == "PartialEq") &&
+           traits.iter().any(|&(name, _)| name == "Eq") {
+            let span = allow_unstable(cx, span, "derive(PartialEq, Eq)");
+            let meta = cx.meta_word(span, Symbol::intern("structural_match"));
+            attrs.push(cx.attribute(span, meta));
+        }
+        if traits.iter().any(|&(name, _)| name == "Copy") &&
+           traits.iter().any(|&(name, _)| name == "Clone") {
+            let span = allow_unstable(cx, span, "derive(Copy, Clone)");
+            let meta = cx.meta_word(span, Symbol::intern("rustc_copy_clone_marker"));
+            attrs.push(cx.attribute(span, meta));
+        }
+        attrs
     })
 }

--- a/src/libsyntax/ext/placeholders.rs
+++ b/src/libsyntax/ext/placeholders.rs
@@ -84,8 +84,17 @@ impl<'a, 'b> PlaceholderExpander<'a, 'b> {
         }
     }
 
-    pub fn add(&mut self, id: ast::NodeId, expansion: Expansion) {
-        let expansion = expansion.fold_with(self);
+    pub fn add(&mut self, id: ast::NodeId, expansion: Expansion, derives: Vec<Mark>) {
+        let mut expansion = expansion.fold_with(self);
+        if let Expansion::Items(mut items) = expansion {
+            for derive in derives {
+                match self.remove(derive.as_placeholder_id()) {
+                    Expansion::Items(derived_items) => items.extend(derived_items),
+                    _ => unreachable!(),
+                }
+            }
+            expansion = Expansion::Items(items);
+        }
         self.expansions.insert(id, expansion);
     }
 

--- a/src/libsyntax_ext/deriving/custom.rs
+++ b/src/libsyntax_ext/deriving/custom.rs
@@ -107,12 +107,10 @@ impl MultiItemModifier for ProcMacroDerive {
             }
         });
 
-        let mut res = vec![Annotatable::Item(item)];
         // Reassign spans of all expanded items to the input `item`
         // for better errors here.
-        res.extend(new_items.into_iter().flat_map(|item| {
-            ChangeSpan { span: span }.fold_item(item)
-        }).map(Annotatable::Item));
-        res
+        new_items.into_iter().map(|item| {
+            Annotatable::Item(ChangeSpan { span: span }.fold_item(item).expect_one(""))
+        }).collect()
     }
 }

--- a/src/test/compile-fail-fulldeps/gated-quote.rs
+++ b/src/test/compile-fail-fulldeps/gated-quote.rs
@@ -39,18 +39,18 @@ impl ParseSess {
 
 pub fn main() {
     let ecx = &ParseSess;
-    let x = quote_tokens!(ecx, 3);    //~ ERROR macro undefined: 'quote_tokens!'
-    let x = quote_expr!(ecx, 3);      //~ ERROR macro undefined: 'quote_expr!'
-    let x = quote_ty!(ecx, 3);        //~ ERROR macro undefined: 'quote_ty!'
-    let x = quote_method!(ecx, 3);    //~ ERROR macro undefined: 'quote_method!'
-    let x = quote_item!(ecx, 3);      //~ ERROR macro undefined: 'quote_item!'
-    let x = quote_pat!(ecx, 3);       //~ ERROR macro undefined: 'quote_pat!'
-    let x = quote_arm!(ecx, 3);       //~ ERROR macro undefined: 'quote_arm!'
-    let x = quote_stmt!(ecx, 3);      //~ ERROR macro undefined: 'quote_stmt!'
-    let x = quote_matcher!(ecx, 3);   //~ ERROR macro undefined: 'quote_matcher!'
-    let x = quote_attr!(ecx, 3);      //~ ERROR macro undefined: 'quote_attr!'
-    let x = quote_arg!(ecx, 3);       //~ ERROR macro undefined: 'quote_arg!'
-    let x = quote_block!(ecx, 3);     //~ ERROR macro undefined: 'quote_block!'
-    let x = quote_meta_item!(ecx, 3); //~ ERROR macro undefined: 'quote_meta_item!'
-    let x = quote_path!(ecx, 3);      //~ ERROR macro undefined: 'quote_path!'
+    let x = quote_tokens!(ecx, 3);    //~ ERROR macro undefined: `quote_tokens`
+    let x = quote_expr!(ecx, 3);      //~ ERROR macro undefined: `quote_expr`
+    let x = quote_ty!(ecx, 3);        //~ ERROR macro undefined: `quote_ty`
+    let x = quote_method!(ecx, 3);    //~ ERROR macro undefined: `quote_method`
+    let x = quote_item!(ecx, 3);      //~ ERROR macro undefined: `quote_item`
+    let x = quote_pat!(ecx, 3);       //~ ERROR macro undefined: `quote_pat`
+    let x = quote_arm!(ecx, 3);       //~ ERROR macro undefined: `quote_arm`
+    let x = quote_stmt!(ecx, 3);      //~ ERROR macro undefined: `quote_stmt`
+    let x = quote_matcher!(ecx, 3);   //~ ERROR macro undefined: `quote_matcher`
+    let x = quote_attr!(ecx, 3);      //~ ERROR macro undefined: `quote_attr`
+    let x = quote_arg!(ecx, 3);       //~ ERROR macro undefined: `quote_arg`
+    let x = quote_block!(ecx, 3);     //~ ERROR macro undefined: `quote_block`
+    let x = quote_meta_item!(ecx, 3); //~ ERROR macro undefined: `quote_meta_item`
+    let x = quote_path!(ecx, 3);      //~ ERROR macro undefined: `quote_path`
 }

--- a/src/test/compile-fail-fulldeps/macro-crate-unexported-macro.rs
+++ b/src/test/compile-fail-fulldeps/macro-crate-unexported-macro.rs
@@ -14,5 +14,5 @@
 extern crate macro_crate_test;
 
 fn main() {
-    assert_eq!(3, unexported_macro!()); //~ ERROR macro undefined: 'unexported_macro!'
+    assert_eq!(3, unexported_macro!()); //~ ERROR macro undefined: `unexported_macro`
 }

--- a/src/test/compile-fail/feature-gate-rustc-diagnostic-macros.rs
+++ b/src/test/compile-fail/feature-gate-rustc-diagnostic-macros.rs
@@ -12,12 +12,12 @@
 // gate
 
 __register_diagnostic!(E0001);
-//~^ ERROR macro undefined: '__register_diagnostic!'
+//~^ ERROR macro undefined: `__register_diagnostic`
 
 fn main() {
     __diagnostic_used!(E0001);
-    //~^ ERROR macro undefined: '__diagnostic_used!'
+    //~^ ERROR macro undefined: `__diagnostic_used`
 }
 
 __build_diagnostic_array!(DIAGNOSTICS);
-//~^ ERROR macro undefined: '__build_diagnostic_array!'
+//~^ ERROR macro undefined: `__build_diagnostic_array`

--- a/src/test/compile-fail/issue-11692.rs
+++ b/src/test/compile-fail/issue-11692.rs
@@ -10,9 +10,9 @@
 
 fn main() {
     print!(test!());
-    //~^ ERROR: macro undefined: 'test!'
+    //~^ ERROR: macro undefined: `test`
     //~^^ ERROR: format argument must be a string literal
 
     concat!(test!());
-    //~^ ERROR: macro undefined: 'test!'
+    //~^ ERROR: macro undefined: `test`
 }

--- a/src/test/compile-fail/issue-19734.rs
+++ b/src/test/compile-fail/issue-19734.rs
@@ -11,5 +11,5 @@
 fn main() {}
 
 impl Type {
-    undef!(); //~ ERROR macro undefined: 'undef!'
+    undef!(); //~ ERROR macro undefined: `undef`
 }

--- a/src/test/compile-fail/macro-error.rs
+++ b/src/test/compile-fail/macro-error.rs
@@ -16,5 +16,5 @@ fn main() {
     foo!(0); // Check that we report errors at macro definition, not expansion.
 
     let _: cfg!(foo) = (); //~ ERROR non-type macro in type position
-    derive!(); //~ ERROR macro undefined: 'derive!'
+    derive!(); //~ ERROR macro undefined: `derive`
 }

--- a/src/test/compile-fail/macro_undefined.rs
+++ b/src/test/compile-fail/macro_undefined.rs
@@ -18,8 +18,8 @@ mod m {
 }
 
 fn main() {
-    k!(); //~ ERROR macro undefined: 'k!'
+    k!(); //~ ERROR macro undefined: `k`
           //~^ HELP did you mean `kl!`?
-    kl!(); //~ ERROR macro undefined: 'kl!'
+    kl!(); //~ ERROR macro undefined: `kl`
            //~^ HELP have you added the `#[macro_use]` on the module/import?
 }

--- a/src/test/compile-fail/self_type_keyword.rs
+++ b/src/test/compile-fail/self_type_keyword.rs
@@ -25,7 +25,7 @@ pub fn main() {
         ref mut Self => (),
         //~^ ERROR expected identifier, found keyword `Self`
         Self!() => (),
-        //~^ ERROR macro undefined: 'Self!'
+        //~^ ERROR macro undefined: `Self`
         Foo { Self } => (),
         //~^ ERROR expected identifier, found keyword `Self`
     }

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/derive-a.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/derive-a.rs
@@ -20,6 +20,5 @@ use proc_macro::TokenStream;
 pub fn derive(input: TokenStream) -> TokenStream {
     let input = input.to_string();
     assert!(input.contains("struct A;"));
-    assert!(input.contains("#[derive(Debug, PartialEq, Eq, Copy, Clone)]"));
     "".parse().unwrap()
 }

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/derive-atob.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/derive-atob.rs
@@ -19,6 +19,6 @@ use proc_macro::TokenStream;
 #[proc_macro_derive(AToB)]
 pub fn derive(input: TokenStream) -> TokenStream {
     let input = input.to_string();
-    assert_eq!(input, "#[derive(Copy, Clone)]\nstruct A;");
+    assert_eq!(input, "struct A;");
     "struct B;".parse().unwrap()
 }

--- a/src/test/run-pass-fulldeps/proc-macro/auxiliary/derive-b.rs
+++ b/src/test/run-pass-fulldeps/proc-macro/auxiliary/derive-b.rs
@@ -22,6 +22,5 @@ pub fn derive(input: TokenStream) -> TokenStream {
     assert!(input.contains("#[B]"));
     assert!(input.contains("struct B {"));
     assert!(input.contains("#[C]"));
-    assert!(input.contains("#[derive(Debug, PartialEq, Eq, Copy, Clone)]"));
     "".parse().unwrap()
 }


### PR DESCRIPTION
This PR refactors collection of `proc_macro_derive` invocations to fix #39347.

After this PR, the input to a `#[proc_macro_derive]` function no longer sees `#[derive]`s on the underlying item. For example, consider:
```rust
extern crate my_derives;
use my_derives::{Trait, Trait2};

#[derive(Copy, Clone)]
#[derive(Trait)]
#[derive(Trait2)]
struct S;
```

Today, the input to the `Trait` derive is `#[derive(Copy, Clone, Trait2)] struct S;`, and the input to the `Trait2` derive is `#[derive(Copy, Clone)] struct S;`. More generally, a `proc_macro_derive` sees all builtin derives, as well as all `proc_macro_derive`s listed *after* the one being invoked.

After this PR, both `Trait` and `Trait2` will see `struct S;`.
This is a [breaking-change], but I believe it is highly unlikely to cause breakage in practice.

r? @nrc 