### PR TITLE
[beta] travis: Really delete the `doc` folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,11 +109,12 @@ cache:
 
 before_deploy:
   - mkdir -p deploy/$TRAVIS_COMMIT
-  - rm -rf build/dist/doc
   - >
       if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+          rm -rf build/dist/doc &&
           cp -r build/dist/* deploy/$TRAVIS_COMMIT;
       else
+          rm -rf obj/build/dist/doc &&
           cp -r obj/build/dist/* deploy/$TRAVIS_COMMIT;
       fi
 


### PR DESCRIPTION
This is a backport of https://github.com/rust-lang/rust/pull/39415 so we can test out release infrastructure with Travis on beta.