### PR TITLE
back: Limit the number of LLVM worker threads.

### DIFF
--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -27,6 +27,7 @@ use errors::emitter::Emitter;
 use syntax_pos::MultiSpan;
 use context::{is_pie_binary, get_reloc_model};
 
+use std::cmp;
 use std::ffi::CString;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -754,10 +755,13 @@ pub fn run_passes(sess: &Session,
     }
 
     // Process the work items, optionally using worker threads.
-    // NOTE: This code is not really adapted to incremental compilation where
-    //       the compiler decides the number of codegen units (and will
-    //       potentially create hundreds of them).
-    let num_workers = work_items.len() - 1;
+    // NOTE: We are hardcoding a limit of worker threads for now. With
+    //       incremental compilation we can run into situations where we would
+    //       open hundreds of threads otherwise -- which can make things slower
+    //       if things don't fit into memory anymore, or can cause the compiler
+    //       to crash because of too many open file handles. See #39280 for
+    //       some discussion on how to improve this in the future.
+    let num_workers = cmp::min(work_items.len() - 1, 32);
     if num_workers <= 1 {
         run_work_singlethreaded(sess, &trans.exported_symbols, work_items);
     } else {


### PR DESCRIPTION
This should fix issue https://github.com/rust-lang/rust/issues/39568.
Also see https://github.com/rust-lang/rust/issues/39280.

r? @nikomatsakis 