### PR TITLE
Conversions between CStr, OsStr, Path and boxes

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -315,6 +315,14 @@ impl<T> Default for Box<[T]> {
     }
 }
 
+#[stable(feature = "default_box_extra", since = "1.17.0")]
+impl Default for Box<str> {
+    fn default() -> Box<str> {
+        let default: Box<[u8]> = Default::default();
+        unsafe { mem::transmute(default) }
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Clone> Clone for Box<T> {
     /// Returns a new box with a `clone()` of this box's contents.

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -204,6 +204,12 @@ impl OsString {
     pub fn reserve_exact(&mut self, additional: usize) {
         self.inner.reserve_exact(additional)
     }
+
+    /// Converts this `OsString` into a boxed `OsStr`.
+    #[unstable(feature = "into_boxed_os_str", issue = "0")]
+    pub fn into_boxed_os_str(self) -> Box<OsStr> {
+        unsafe { mem::transmute(self.inner.into_box()) }
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -442,6 +448,20 @@ impl OsStr {
     /// revealing the internal, platform-specific encodings.
     fn bytes(&self) -> &[u8] {
         unsafe { mem::transmute(&self.inner) }
+    }
+}
+
+#[stable(feature = "box_from_os_str", since = "1.17.0")]
+impl<'a> From<&'a OsStr> for Box<OsStr> {
+    fn from(s: &'a OsStr) -> Box<OsStr> {
+        unsafe { mem::transmute(s.inner.into_box()) }
+    }
+}
+
+#[stable(feature = "box_default_extra", since = "1.17.0")]
+impl Default for Box<OsStr> {
+    fn default() -> Box<OsStr> {
+        unsafe { mem::transmute(Slice::empty_box()) }
     }
 }
 
@@ -740,5 +760,23 @@ mod tests {
     fn test_os_str_default() {
         let os_str: &OsStr = Default::default();
         assert_eq!("", os_str);
+    }
+
+    #[test]
+    fn into_boxed() {
+        let orig = "Hello, world!";
+        let os_str = OsStr::new(orig);
+        let os_string = os_str.to_owned();
+        let box1: Box<OsStr> = Box::from(os_str);
+        let box2 = os_string.into_boxed_os_str();
+        assert_eq!(os_str, &*box1);
+        assert_eq!(box1, box2);
+        assert_eq!(&*box2, os_str);
+    }
+
+    #[test]
+    fn boxed_default() {
+        let boxed = <Box<OsStr>>::default();
+        assert!(boxed.is_empty());
     }
 }

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1194,6 +1194,28 @@ impl PathBuf {
     pub fn into_os_string(self) -> OsString {
         self.inner
     }
+
+    /// Converts this `PathBuf` into a boxed `Path`.
+    #[unstable(feature = "into_boxed_path", issue = "0")]
+    pub fn into_boxed_path(self) -> Box<Path> {
+        unsafe { mem::transmute(self.inner.into_boxed_os_str()) }
+    }
+}
+
+#[stable(feature = "box_from_path", since = "1.17.0")]
+impl<'a> From<&'a Path> for Box<Path> {
+    fn from(path: &'a Path) -> Box<Path> {
+        let boxed: Box<OsStr> = path.inner.into();
+        unsafe { mem::transmute(boxed) }
+    }
+}
+
+#[stable(feature = "box_default_extra", since = "1.17.0")]
+impl Default for Box<Path> {
+    fn default() -> Box<Path> {
+        let boxed: Box<OsStr> = Default::default();
+        unsafe { mem::transmute(boxed) }
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -3675,5 +3697,23 @@ mod tests {
         let expected = "Iter([])";
         let actual = format!("{:?}", iter);
         assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn into_boxed() {
+        let orig: &str = "some/sort/of/path";
+        let path = Path::new(orig);
+        let path_buf = path.to_owned();
+        let box1: Box<Path> = Box::from(path);
+        let box2 = path_buf.into_boxed_path();
+        assert_eq!(path, &*box1);
+        assert_eq!(box1, box2);
+        assert_eq!(&*box2, path);
+    }
+
+    #[test]
+    fn boxed_default() {
+        let boxed = <Box<Path>>::default();
+        assert!(boxed.as_os_str().is_empty());
     }
 }

--- a/src/libstd/sys/redox/os_str.rs
+++ b/src/libstd/sys/redox/os_str.rs
@@ -94,6 +94,11 @@ impl Buf {
     pub fn push_slice(&mut self, s: &Slice) {
         self.inner.extend_from_slice(&s.inner)
     }
+
+    #[inline]
+    pub fn into_box(self) -> Box<Slice> {
+        unsafe { mem::transmute(self.inner.into_boxed_slice()) }
+    }
 }
 
 impl Slice {
@@ -115,5 +120,16 @@ impl Slice {
 
     pub fn to_owned(&self) -> Buf {
         Buf { inner: self.inner.to_vec() }
+    }
+
+    #[inline]
+    pub fn into_box(&self) -> Box<Slice> {
+        let boxed: Box<[u8]> = self.inner.into();
+        unsafe { mem::transmute(boxed) }
+    }
+
+    pub fn empty_box() -> Box<Slice> {
+        let boxed: Box<[u8]> = Default::default();
+        unsafe { mem::transmute(boxed) }
     }
 }

--- a/src/libstd/sys/unix/os_str.rs
+++ b/src/libstd/sys/unix/os_str.rs
@@ -94,6 +94,11 @@ impl Buf {
     pub fn push_slice(&mut self, s: &Slice) {
         self.inner.extend_from_slice(&s.inner)
     }
+
+    #[inline]
+    pub fn into_box(self) -> Box<Slice> {
+        unsafe { mem::transmute(self.inner.into_boxed_slice()) }
+    }
 }
 
 impl Slice {
@@ -115,5 +120,16 @@ impl Slice {
 
     pub fn to_owned(&self) -> Buf {
         Buf { inner: self.inner.to_vec() }
+    }
+
+    #[inline]
+    pub fn into_box(&self) -> Box<Slice> {
+        let boxed: Box<[u8]> = self.inner.into();
+        unsafe { mem::transmute(boxed) }
+    }
+
+    pub fn empty_box() -> Box<Slice> {
+        let boxed: Box<[u8]> = Default::default();
+        unsafe { mem::transmute(boxed) }
     }
 }

--- a/src/libstd/sys/windows/os_str.rs
+++ b/src/libstd/sys/windows/os_str.rs
@@ -88,6 +88,11 @@ impl Buf {
     pub fn reserve_exact(&mut self, additional: usize) {
         self.inner.reserve_exact(additional)
     }
+
+    #[inline]
+    pub fn into_box(self) -> Box<Slice> {
+        unsafe { mem::transmute(self.inner.into_box()) }
+    }
 }
 
 impl Slice {
@@ -107,5 +112,14 @@ impl Slice {
         let mut buf = Wtf8Buf::with_capacity(self.inner.len());
         buf.push_wtf8(&self.inner);
         Buf { inner: buf }
+    }
+
+    #[inline]
+    pub fn into_box(&self) -> Box<Slice> {
+        unsafe { mem::transmute(self.inner.into_box()) }
+    }
+
+    pub fn empty_box() -> Box<Slice> {
+        unsafe { mem::transmute(Wtf8::empty_box()) }
     }
 }

--- a/src/libstd/sys_common/wtf8.rs
+++ b/src/libstd/sys_common/wtf8.rs
@@ -340,6 +340,12 @@ impl Wtf8Buf {
             }
         }
     }
+
+    /// Converts this `Wtf8Buf` into a boxed `Wtf8`.
+    #[inline]
+    pub fn into_box(self) -> Box<Wtf8> {
+        unsafe { mem::transmute(self.bytes.into_boxed_slice()) }
+    }
 }
 
 /// Create a new WTF-8 string from an iterator of code points.
@@ -582,6 +588,19 @@ impl Wtf8 {
             &[0xED, b2 @ 0xB0...0xBF, b3] => Some(decode_surrogate(b2, b3)),
             _ => None
         }
+    }
+
+    /// Boxes this `Wtf8`.
+    #[inline]
+    pub fn into_box(&self) -> Box<Wtf8> {
+        let boxed: Box<[u8]> = self.bytes.into();
+        unsafe { mem::transmute(boxed) }
+    }
+
+    /// Creates a boxed, empty `Wtf8`.
+    pub fn empty_box() -> Box<Wtf8> {
+        let boxed: Box<[u8]> = Default::default();
+        unsafe { mem::transmute(boxed) }
     }
 }
 


### PR DESCRIPTION
This closes a bit of the inconsistencies between `CStr`, `OsStr`, `Path`, and `str`, allowing people to create boxed versions of DSTs other than `str` and `[T]`.

Full list of additions:
* `Default` for `Box<str>`, `Box<CStr>`, `Box<OsStr>`
* `CString::into_boxed_c_str` (feature gated)
* `OsString::into_boxed_os_str` (feature gated)
* `Path::into_boxed_path` (feature gated)
* `From<&CStr> for Box<CStr>`
* `From<&OsStr> for Box<OsStr>`
* `From<&Path> for Box<Path>`

This also includes adding the internal methods:
* `sys::*::os_str::Buf::into_box`
* `sys::*::os_str::Slice::{into_box, empty_box}`
* `sys_common::wtf8::Wtf8Buf::into_box`
* `sys_common::wtf8::Wtf8::{into_box, empty_box}`