### PR TITLE
Display correct filename with --test option

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -35,6 +35,7 @@ use std::fmt::{self, Write};
 use std::slice;
 use std::str;
 use syntax::feature_gate::UnstableFeatures;
+use syntax::codemap::Span;
 
 use html::render::derive_id;
 use html::toc::TocBuilder;
@@ -429,7 +430,7 @@ pub fn render(w: &mut fmt::Formatter,
     }
 }
 
-pub fn find_testable_code(doc: &str, tests: &mut ::test::Collector, start_line: usize) {
+pub fn find_testable_code(doc: &str, tests: &mut ::test::Collector, position: Span) {
     extern fn block(_ob: *mut hoedown_buffer,
                     text: *const hoedown_buffer,
                     lang: *const hoedown_buffer,
@@ -454,11 +455,12 @@ pub fn find_testable_code(doc: &str, tests: &mut ::test::Collector, start_line: 
             });
             let text = lines.collect::<Vec<&str>>().join("\n");
             let line = tests.get_line() + line;
+            let filename = tests.get_filename();
             tests.add_test(text.to_owned(),
                            block_info.should_panic, block_info.no_run,
                            block_info.ignore, block_info.test_harness,
                            block_info.compile_fail, block_info.error_codes,
-                           line);
+                           line, filename);
         }
     }
 
@@ -479,7 +481,7 @@ pub fn find_testable_code(doc: &str, tests: &mut ::test::Collector, start_line: 
         }
     }
 
-    tests.set_line(start_line);
+    tests.set_position(position);
     unsafe {
         let ob = hoedown_buffer_new(DEF_OUNIT);
         let renderer = hoedown_html_renderer_new(0, 0);

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -18,6 +18,7 @@ use getopts;
 use testing;
 use rustc::session::search_paths::SearchPaths;
 use rustc::session::config::Externs;
+use syntax::codemap::DUMMY_SP;
 
 use externalfiles::{ExternalHtml, LoadStringError, load_string};
 
@@ -154,9 +155,8 @@ pub fn test(input: &str, cfgs: Vec<String>, libs: SearchPaths, externs: Externs,
     let mut opts = TestOptions::default();
     opts.no_crate_inject = true;
     let mut collector = Collector::new(input.to_string(), cfgs, libs, externs,
-                                       true, opts, maybe_sysroot, "input".to_string(),
-                                       None);
-    find_testable_code(&input_str, &mut collector, 0);
+                                       true, opts, maybe_sysroot, None);
+    find_testable_code(&input_str, &mut collector, DUMMY_SP);
     test_args.insert(0, "rustdoctest".to_string());
     testing::test_main(&test_args, collector.tests);
     0

--- a/src/test/rustdoc/test_option_check/bar.rs
+++ b/src/test/rustdoc/test_option_check/bar.rs
@@ -11,18 +11,9 @@
 // compile-flags: --test
 // check-test-line-numbers-match
 
-pub mod bar;
-
-/// This is a Foo;
+/// This looks like another awesome test!
 ///
 /// ```
-/// println!("baaaaaar");
+/// println!("foo?");
 /// ```
-pub struct Foo;
-
-/// This is a Bar;
-///
-/// ```
-/// println!("fooooo");
-/// ```
-pub struct Bar;
+pub fn foooo() {}

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -30,6 +30,7 @@ use std::io::{self, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, ExitStatus};
 use std::str;
+use std::collections::HashMap;
 
 use extract_gdb_version;
 
@@ -1902,17 +1903,28 @@ actual:\n\
         }
     }
 
-    fn check_rustdoc_test_option(&self, res: ProcRes) {
-        let mut file = fs::File::open(&self.testpaths.file)
+    fn get_lines<P: AsRef<Path>>(&self, path: &P,
+                                 mut other_files: Option<&mut Vec<String>>) -> Vec<usize> {
+        let mut file = fs::File::open(path)
                                 .expect("markdown_test_output_check_entry File::open failed");
         let mut content = String::new();
         file.read_to_string(&mut content)
             .expect("markdown_test_output_check_entry read_to_string failed");
         let mut ignore = false;
-        let mut v: Vec<usize> =
-            content.lines()
-                   .enumerate()
-                   .filter_map(|(line_nb, line)| {
+        content.lines()
+               .enumerate()
+               .filter_map(|(line_nb, line)| {
+                   if (line.trim_left().starts_with("pub mod ") ||
+                       line.trim_left().starts_with("mod ")) &&
+                      line.ends_with(";") {
+                       if let Some(ref mut other_files) = other_files {
+                           other_files.push(line.rsplit("mod ")
+                                      .next()
+                                      .unwrap()
+                                      .replace(";", ""));
+                       }
+                       None
+                   } else {
                        let sline = line.split("///").last().unwrap_or("");
                        let line = sline.trim_left();
                        if line.starts_with("```") {
@@ -1926,8 +1938,21 @@ actual:\n\
                        } else {
                            None
                        }
-                   })
-                   .collect();
+                   }
+               })
+               .collect()
+    }
+
+    fn check_rustdoc_test_option(&self, res: ProcRes) {
+        let mut other_files = Vec::new();
+        let mut files: HashMap<String, Vec<usize>> = HashMap::new();
+        files.insert(self.testpaths.file.to_str().unwrap().to_owned(),
+                     self.get_lines(&self.testpaths.file, Some(&mut other_files)));
+        for other_file in other_files {
+            let mut path = self.testpaths.file.clone();
+            path.set_file_name(&format!("{}.rs", other_file));
+            files.insert(path.to_str().unwrap().to_owned(), self.get_lines(&path, None));
+        }
 
         let mut tested = 0;
         for _ in res.stdout.split("\n")
@@ -1935,27 +1960,35 @@ actual:\n\
                            .inspect(|s| {
                                let tmp: Vec<&str> = s.split(" - line ").collect();
                                if tmp.len() == 2 {
-                                   tested += 1;
-                                   let line = tmp[1].split(" ...")
-                                                    .next()
-                                                    .unwrap_or("0")
-                                                    .parse()
-                                                    .unwrap_or(0);
-                                   if let Ok(pos) = v.binary_search(&line) {
-                                       v.remove(pos);
-                                   } else {
-                                       self.fatal_proc_rec(
-                                           &format!("Not found doc test: \"{}\" in {:?}", s, v),
-                                           &res);
+                                   let path = tmp[0].rsplit("test ").next().unwrap();
+                                   if let Some(ref mut v) = files.get_mut(path) {
+                                       tested += 1;
+                                       let line = tmp[1].split(" ...")
+                                                        .next()
+                                                        .unwrap_or("0")
+                                                        .parse()
+                                                        .unwrap_or(0);
+                                       if let Ok(pos) = v.binary_search(&line) {
+                                           v.remove(pos);
+                                       } else {
+                                           self.fatal_proc_rec(
+                                               &format!("Not found doc test: \"{}\" in \"{}\":{:?}",
+                                                        s, path, v),
+                                               &res);
+                                       }
                                    }
                                }
                            }) {}
         if tested == 0 {
-            self.fatal_proc_rec("No test has been found", &res);
-        } else if v.len() != 0 {
-            self.fatal_proc_rec(&format!("Not found test at line{} {:?}",
-                                         if v.len() > 1 { "s" } else { "" }, v),
-                                &res);
+            self.fatal_proc_rec(&format!("No test has been found... {:?}", files), &res);
+        } else {
+            for (entry, v) in &files {
+                if v.len() != 0 {
+                    self.fatal_proc_rec(&format!("Not found test at line{} \"{}\":{:?}",
+                                                 if v.len() > 1 { "s" } else { "" }, entry, v),
+                                        &res);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #39592.

With the current files:

### test.rs

```rust
pub mod foo;

/// This is a Foo;
///
/// ```
/// println!("baaaaaar");
/// ```
#[unstable]
pub struct Foo;

/// This is a Bar;
///
/// ```
/// println!("fooooo");
/// ```
pub struct Bar;
```

### foo.rs

```rust
// note the whitespaces
/// ```
/// println!("foo");
/// ```
pub fn foo() {}
```

It displays:

```
./build/x86_64-apple-darwin/stage1/bin/rustdoc --test test.rs

running 3 tests
test test.rs - line 13 ... ok
test test.rs - line 5 ... ok
test foo.rs - line 2 ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured
```

### And with a markdown file:

```
# foo

` ``
println!("lol");
` ``

asdjnfasd

asd
```

It displays:

```
./build/x86_64-apple-darwin/stage1/bin/rustdoc --test foo.md

running 1 test
test <input> - line 3 ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
```

r? @alexcrichton 