### PR TITLE
Fix branch name Cargo's downloaded from

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -517,9 +517,7 @@ pub fn cargo(build: &Build, stage: u32, target: &str) {
 
     let branch = match &build.config.channel[..] {
         "stable" |
-        "beta" => {
-            build.release.split(".").take(2).collect::<Vec<_>>().join(".")
-        }
+        "beta" => format!("rust-{}", build.release_num),
         _ => "master".to_string(),
     };
 


### PR DESCRIPTION
This landed on beta in #39546 and this is bringing the patch back to master.