### PR TITLE
Fix a manifest-generation bug on beta

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -317,6 +317,8 @@ impl Builder {
     fn filename(&self, component: &str, target: &str) -> String {
         if component == "rust-src" {
             format!("rust-src-{}.tar.gz", self.channel)
+        } else if component == "cargo" {
+            format!("cargo-nightly-{}.tar.gz", target)
         } else {
             format!("{}-{}-{}.tar.gz", component, self.channel, target)
         }


### PR DESCRIPTION
Right now all Cargo release tarballs are 'nightly', they're not on the standard
channels yet.