### PR TITLE
Unignore u128 test for stage 0,1

### DIFF
--- a/src/test/run-pass/u128.rs
+++ b/src/test/run-pass/u128.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-stage0
-// ignore-stage1
-
 // ignore-emscripten
 
 #![feature(i128_type, test)]


### PR DESCRIPTION
Even more SNAP cleanup.

Follow-up of #39519.

Sorry, I didn't check twice.