### PR TITLE
Don't include directory names in shasums

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -350,7 +350,8 @@ impl Builder {
     fn hash(&self, path: &Path) -> String {
         let sha = t!(Command::new("shasum")
                         .arg("-a").arg("256")
-                        .arg(path)
+                        .arg(path.file_name().unwrap())
+                        .current_dir(path.parent().unwrap())
                         .output());
         assert!(sha.status.success());
 


### PR DESCRIPTION
Right now we just run `shasum` on an absolute path but right now the shasum
files only include filenames, so let's use `current_dir` and just the file name
to only have the file name emitted.