### PR TITLE
[beta] rustbuild: Pass -fPIC on 32-bit non-Windows platforms

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -843,6 +843,11 @@ impl Build {
             },
             _ => {},
         }
+
+        if !target.contains("windows") && target.contains("i686") {
+            base.push("-fPIC".into());
+        }
+
         return base
     }
 


### PR DESCRIPTION
This is a smaller and more targeted backport of #39523 which drives to the heart
of the issue, just passing `-fPIC` on 32-bit platforms. More rationale for this
commit can be found in #39523 itself.