### PR TITLE
[stable] More fixes for 1.15.1

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,9 +1,11 @@
-Version 1.15.1 (2017-02-08)
+Version 1.15.1 (2017-02-09)
 ===========================
 
 * [Fix IntoIter::as_mut_slice's signature][39466]
+* [Compile compiler builtins with `-fPIC` on 32-bit platforms][39523]
 
 [39466]: https://github.com/rust-lang/rust/pull/39466
+[39523]: https://github.com/rust-lang/rust/pull/39523
 
 
 Version 1.15.0 (2017-02-02)
@@ -971,7 +973,7 @@ Tooling
 * [Test binaries now support a `--test-threads` argument to specify the number
   of threads used to run tests, and which acts the same as the
   `RUST_TEST_THREADS` environment variable]
-  (https://github.com/rust-lang/rust/pull/35414)  
+  (https://github.com/rust-lang/rust/pull/35414)
 * [The test runner now emits a warning when tests run over 60 seconds]
   (https://github.com/rust-lang/rust/pull/35405)
 * [rustdoc: Fix methods in search results]

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -812,6 +812,11 @@ impl Build {
             },
             _ => {},
         }
+
+        if !target.contains("windows") && target.contains("i686") {
+            base.push("-fPIC".into());
+        }
+
         return base
     }
 


### PR DESCRIPTION
* Include https://github.com/rust-lang/rust/pull/39667 as a backport to stable
* Update the release notes