### PR TITLE
parser: fix ICE when parsing token trees after an error

### DIFF
--- a/src/test/compile-fail/issue-39388.rs
+++ b/src/test/compile-fail/issue-39388.rs
@@ -1,0 +1,17 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! assign {
+    (($($a:tt)*) = ($($b:tt))*) => { //~ ERROR expected `*` or `+`
+        $($a)* = $($b)*
+    }
+}
+
+fn main() {}

--- a/src/test/compile-fail/issue-39616.rs
+++ b/src/test/compile-fail/issue-39616.rs
@@ -1,0 +1,15 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn foo(a: [0; 1]) {} //~ ERROR expected type, found `0`
+//~| ERROR expected one of `->`, `where`, or `{`, found `]`
+// FIXME(jseyfried): avoid emitting the second error (preexisting)
+
+fn main() {}


### PR DESCRIPTION
Fixes #39388, fixes #39616.
r? @nrc 