### PR TITLE
Actually fix manifest generation

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -178,8 +178,8 @@ impl Builder {
         // and wrap it up in a `Value::Table`.
         let mut manifest = BTreeMap::new();
         manifest.insert("manifest-version".to_string(),
-                        toml::encode(&manifest_version));
-        manifest.insert("date".to_string(), toml::encode(&date));
+                        toml::Value::String(manifest_version));
+        manifest.insert("date".to_string(), toml::Value::String(date));
         manifest.insert("pkg".to_string(), toml::encode(&pkg));
         let manifest = toml::Value::Table(manifest).to_string();
 


### PR DESCRIPTION
The previous fix contained an error where `toml::encode` returned a runtime
error, so this version just constructs a literal `toml::Value`.