### PR TITLE
Exclude top-level macro expansions from source location override.

### DIFF
--- a/src/test/debuginfo/macro-stepping.inc
+++ b/src/test/debuginfo/macro-stepping.inc
@@ -1,0 +1,17 @@
+// Copyright 2013-2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn included() {
+    foo!(); // #inc-loc1
+
+    foo2!(); // #inc-loc2
+
+    zzz(); // #inc-loc3
+}

--- a/src/test/debuginfo/macro-stepping.rs
+++ b/src/test/debuginfo/macro-stepping.rs
@@ -44,6 +44,17 @@ extern crate macro_stepping; // exports new_scope!()
 // gdb-command:frame
 // gdb-check:[...]#loc6[...]
 
+// gdb-command:continue
+// gdb-command:step
+// gdb-command:frame
+// gdb-check:[...]#inc-loc1[...]
+// gdb-command:next
+// gdb-command:frame
+// gdb-check:[...]#inc-loc2[...]
+// gdb-command:next
+// gdb-command:frame
+// gdb-check:[...]#inc-loc3[...]
+
 // === LLDB TESTS ==================================================================================
 
 // lldb-command:set set stop-line-count-before 0
@@ -67,6 +78,17 @@ extern crate macro_stepping; // exports new_scope!()
 // lldb-command:next
 // lldb-command:frame select
 // lldb-check:[...]#loc5[...]
+
+// lldb-command:continue
+// lldb-command:step
+// lldb-command:frame select
+// lldb-check:[...]#inc-loc1[...]
+// lldb-command:next
+// lldb-command:frame select
+// lldb-check:[...]#inc-loc2[...]
+// lldb-command:next
+// lldb-command:frame select
+// lldb-check:[...]#inc-loc3[...]
 
 macro_rules! foo {
     () => {
@@ -99,6 +121,10 @@ fn main() {
              "world");
 
     zzz(); // #loc6
+
+    included(); // #break
 }
 
 fn zzz() {()}
+
+include!("macro-stepping.inc");


### PR DESCRIPTION
It occurred to me that a simple heuristic can address the issue #36382: any macros that expand into items (including `include!()`) don't need to be stepped over because there's not code to step through above a function scope level.

r? @michaelwoerister 