### PR TITLE
Fix unaligned load in librustc_metadata::index.

### DIFF
--- a/src/librustc_metadata/index.rs
+++ b/src/librustc_metadata/index.rs
@@ -96,8 +96,16 @@ impl<'tcx> LazySeq<Index> {
 }
 
 #[repr(packed)]
-#[derive(Copy, Clone)]
+#[derive(Copy)]
 struct Unaligned<T>(T);
+
+// The derived Clone impl is unsafe for this packed struct since it needs to pass a reference to
+// the field to `T::clone`, but this reference may not be properly aligned.
+impl<T: Copy> Clone for Unaligned<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 
 impl<T> Unaligned<T> {
     fn get(self) -> T { self.0 }


### PR DESCRIPTION
The derived `Clone` impl contains UB and will be unsafe when we fix https://github.com/rust-lang/rust/issues/27060. See [this comment](https://github.com/rust-lang/rust/issues/27060#issuecomment-278617096) for more context.

r? @bluss