### PR TITLE
remove wrong packed struct test

### DIFF
--- a/src/test/run-pass/dst-field-align.rs
+++ b/src/test/run-pass/dst-field-align.rs
@@ -25,12 +25,6 @@ struct Baz<T: ?Sized> {
     a: T
 }
 
-#[repr(packed)]
-struct Packed<T: ?Sized> {
-    a: u8,
-    b: T
-}
-
 struct HasDrop<T: ?Sized> {
     ptr: Box<usize>,
     data: T

--- a/src/test/run-pass/dst-field-align.rs
+++ b/src/test/run-pass/dst-field-align.rs
@@ -55,12 +55,6 @@ fn main() {
     // The pointers should be the same
     assert_eq!(ptr1, ptr2);
 
-    // Test that packed structs are handled correctly
-    let p : Packed<usize> = Packed { a: 0, b: 13 };
-    assert_eq!(p.b.get(), 13);
-    let p : &Packed<Bar> = &p;
-    assert_eq!(p.b.get(), 13);
-
     // Test that nested DSTs work properly
     let f : Foo<Foo<usize>> = Foo { a: 0, b: Foo { a: 1, b: 17 }};
     assert_eq!(f.b.b.get(), 17);


### PR DESCRIPTION
This UB was found by running the test under [Miri](https://github.com/solson/miri) which rejects these unsafe unaligned loads. :smile: