### PR TITLE
Allow `foo.rs` to be parent to `foo/bar.rs`

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -898,9 +898,16 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
                 } else {
                     let mut path =
                         PathBuf::from(self.cx.parse_sess.codemap().span_to_filename(inner));
-                    let directory_ownership = match path.file_name().unwrap().to_str() {
-                        Some("mod.rs") => DirectoryOwnership::Owned,
-                        _ => DirectoryOwnership::UnownedViaMod(false),
+                    let directory_ownership = {
+                        let file_name = path.file_name().unwrap();
+                        match file_name.to_str() {
+                            Some("mod.rs") => DirectoryOwnership::Owned,
+                            Some(s) if s.ends_with(".rs") && s.len() > 3 => {
+                                let directory_name = s.rsplitn(2, '.').skip(1).next().unwrap();
+                                DirectoryOwnership::OwnedUnder(Ident::from_str(directory_name))
+                            }
+                            _ => DirectoryOwnership::UnownedViaMod(true),
+                        }
                     };
                     path.pop();
                     module.directory = path;

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -10,7 +10,7 @@
 
 //! The main parser interface
 
-use ast::{self, CrateConfig};
+use ast::{self, CrateConfig, Ident};
 use codemap::CodeMap;
 use syntax_pos::{self, Span, FileMap};
 use errors::{Handler, ColorConfig, DiagnosticBuilder};
@@ -87,6 +87,7 @@ pub enum DirectoryOwnership {
     Owned,
     UnownedViaBlock,
     UnownedViaMod(bool /* legacy warnings? */),
+    OwnedUnder(Ident),
 }
 
 // a bunch of utility functions of the form parse_<thing>_from_<source>


### PR DESCRIPTION
Prior to this commit, in order for a module to have submodules, it had
to be at the `/foo/mod.rs` filepath. After this commit, modules at the
`/foo.rs` filepath have submodules located in the `/foo/` directory.