### PR TITLE
Allow rustc data structures compile to android

### DIFF
--- a/src/librustc_data_structures/flock.rs
+++ b/src/librustc_data_structures/flock.rs
@@ -27,7 +27,7 @@ mod imp {
     use std::io;
     use libc;
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     mod os {
         use libc;
 


### PR DESCRIPTION
flock structure is defined in asm*/fcntl.h. This file on android is
generated from the linux kernel source, so they are the same.