### PR TITLE
Add notes about capacity effects to Vec::truncate()

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -999,6 +999,9 @@ impl String {
     /// If `new_len` is greater than the string's current length, this has no
     /// effect.
     ///
+    /// Note that this method has no effect on the allocated capacity
+    /// of the string
+    ///
     /// # Panics
     ///
     /// Panics if `new_len` does not lie on a [`char`] boundary.

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -545,6 +545,9 @@ impl<T> Vec<T> {
     /// The [`drain`] method can emulate `truncate`, but causes the excess
     /// elements to be returned instead of dropped.
     ///
+    /// Note that this method has no effect on the allocated capacity
+    /// of the vector.
+    ///
     /// # Examples
     ///
     /// Truncating a five element vector to two elements:
@@ -1088,6 +1091,9 @@ impl<T> Vec<T> {
     }
 
     /// Clears the vector, removing all values.
+    ///
+    /// Note that this method has no effect on the allocated capacity
+    /// of the vector.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Add notes about the effects of Vec::truncate() and Vec::clear() on the capacity of a vector.