### PR TITLE
rustdoc: Only include a stability span if needed.

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -327,17 +327,27 @@ impl Item {
         }
     }
 
-    pub fn stability_class(&self) -> String {
-        self.stability.as_ref().map(|ref s| {
-            let mut base = match s.level {
-                stability::Unstable => "unstable".to_string(),
-                stability::Stable => String::new(),
-            };
-            if !s.deprecated_since.is_empty() {
-                base.push_str(" deprecated");
+    pub fn stability_class(&self) -> Option<String> {
+        match self.stability {
+            Some(ref s) => {
+                let mut classes = Vec::with_capacity(2);
+
+                if s.level == stability::Unstable {
+                    classes.push("unstable");
+                }
+
+                if !s.deprecated_since.is_empty() {
+                    classes.push("deprecated");
+                }
+
+                if classes.len() != 0 {
+                    Some(classes.join(" "))
+                } else {
+                    None
+                }
             }
-            base
-        }).unwrap_or(String::new())
+            None => None,
+        }
     }
 
     pub fn stable_since(&self) -> Option<&str> {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -328,26 +328,23 @@ impl Item {
     }
 
     pub fn stability_class(&self) -> Option<String> {
-        match self.stability {
-            Some(ref s) => {
-                let mut classes = Vec::with_capacity(2);
+        self.stability.as_ref().and_then(|ref s| {
+            let mut classes = Vec::with_capacity(2);
 
-                if s.level == stability::Unstable {
-                    classes.push("unstable");
-                }
-
-                if !s.deprecated_since.is_empty() {
-                    classes.push("deprecated");
-                }
-
-                if classes.len() != 0 {
-                    Some(classes.join(" "))
-                } else {
-                    None
-                }
+            if s.level == stability::Unstable {
+                classes.push("unstable");
             }
-            None => None,
-        }
+
+            if !s.deprecated_since.is_empty() {
+                classes.push("deprecated");
+            }
+
+            if classes.len() != 0 {
+                Some(classes.join(" "))
+            } else {
+                None
+            }
+        })
     }
 
     pub fn stable_since(&self) -> Option<&str> {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2417,7 +2417,6 @@ fn item_union(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                 write!(w, "<span class='stab {stab}'></span>",
                     stab = stability_class)?;
             }
-            write!(w, "</span>")?;
             document(w, cx, field)?;
         }
     }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1827,7 +1827,7 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
                        stab_docs = stab_docs,
                        docs = shorter(Some(&Markdown(doc_value).to_string())),
                        class = myitem.type_(),
-                       stab = myitem.stability_class(),
+                       stab = myitem.stability_class().unwrap_or("".to_string()),
                        unsafety_flag = unsafety_flag,
                        href = item_path(myitem.type_(), myitem.name.as_ref().unwrap()),
                        title = full_path(cx, myitem))?;
@@ -2369,13 +2369,16 @@ fn item_struct(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                 write!(w, "<span id='{id}' class='{item_type}'>
                            <span id='{ns_id}' class='invisible'>
                            <code>{name}: {ty}</code>
-                           </span></span><span class='stab {stab}'></span>",
+                           </span></span>",
                        item_type = ItemType::StructField,
                        id = id,
                        ns_id = ns_id,
-                       stab = field.stability_class(),
                        name = field.name.as_ref().unwrap(),
                        ty = ty)?;
+                if let Some(stability_class) = field.stability_class() {
+                    write!(w, "<span class='stab {stab}'></span>",
+                        stab = stability_class)?;
+                }
                 document(w, cx, field)?;
             }
         }
@@ -2406,11 +2409,15 @@ fn item_union(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
         write!(w, "<h2 class='fields'>Fields</h2>")?;
         for (field, ty) in fields {
             write!(w, "<span id='{shortty}.{name}' class='{shortty}'><code>{name}: {ty}</code>
-                       </span><span class='stab {stab}'></span>",
+                       </span>",
                    shortty = ItemType::StructField,
-                   stab = field.stability_class(),
                    name = field.name.as_ref().unwrap(),
                    ty = ty)?;
+            if let Some(stability_class) = field.stability_class() {
+                write!(w, "<span class='stab {stab}'></span>",
+                    stab = stability_class)?;
+            }
+            write!(w, "</span>")?;
             document(w, cx, field)?;
         }
     }


### PR DESCRIPTION
This patch gets rid of the empty stability boxes in docs by only including the span that creates it when the item actually has a stability class.

Here are images of the issue on `std::process::Output`:

Before:

<img width="340" alt="before" src="https://cloud.githubusercontent.com/assets/122457/22853638/ff88d1b2-f010-11e6-90d6-bf3d10e2fffa.png">

After:

<img width="333" alt="after" src="https://cloud.githubusercontent.com/assets/122457/22853639/06bfe7cc-f011-11e6-9892-f0ea2cc6ec90.png">

This is my first non-trivial patch to Rust, so I'm sure some of my approach is not idiomatic. Let me know how you'd like me to adjust!
