### PR TITLE
Fix LLVMRustDIBuilderCreateCompileUnit for LLVM 4

### DIFF
--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -477,8 +477,16 @@ extern "C" LLVMRustMetadataRef LLVMRustDIBuilderCreateCompileUnit(
     LLVMRustDIBuilderRef Builder, unsigned Lang, const char *File,
     const char *Dir, const char *Producer, bool isOptimized, const char *Flags,
     unsigned RuntimeVer, const char *SplitName) {
+#if LLVM_VERSION_GE(4, 0)
+  StringRef FileRef = StringRef(File);
+  StringRef DirRef = StringRef(Dir);
+  DIFile *DIFileRef = Builder->createFile(FileRef, DirRef);
+  return wrap(Builder->createCompileUnit(Lang, DIFileRef, Producer, isOptimized,
+                                         Flags, RuntimeVer, SplitName));
+#else
   return wrap(Builder->createCompileUnit(Lang, File, Dir, Producer, isOptimized,
                                          Flags, RuntimeVer, SplitName));
+#endif
 }
 
 extern "C" LLVMRustMetadataRef


### PR DESCRIPTION
cc #37609 

This simple fix seems to work (tests pass). We might want to have rustllvm functions that match LLVM 4 more closely (something like `LLVMRustDIBuilderCreateFile(file, dir) -> RustDIFileRef`) but this change was [recently added](https://github.com/llvm-mirror/llvm/commit/faaafe58c6aaa5c523892eaf5b65fc642097513c) so that needs to wait until LLVM 3.5-3.9 are no longer supported. OTOH, if `DiFile` isn't used anywhere else, perhaps we just leave this function as-is?