### PR TITLE
Refactor macro resolution errors + add derive macro suggestions

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -51,6 +51,7 @@ use syntax::ext::hygiene::{Mark, SyntaxContext};
 use syntax::ast::{self, Name, NodeId, Ident, SpannedIdent, FloatTy, IntTy, UintTy};
 use syntax::ext::base::SyntaxExtension;
 use syntax::ext::base::Determinacy::{Determined, Undetermined};
+use syntax::ext::base::MacroKind;
 use syntax::symbol::{Symbol, keywords};
 use syntax::util::lev_distance::find_best_match_for_name;
 
@@ -785,7 +786,7 @@ pub struct ModuleData<'a> {
     normal_ancestor_id: DefId,
 
     resolutions: RefCell<FxHashMap<(Ident, Namespace), &'a RefCell<NameResolution<'a>>>>,
-    legacy_macro_resolutions: RefCell<Vec<(Mark, Ident, Span)>>,
+    legacy_macro_resolutions: RefCell<Vec<(Mark, Ident, Span, MacroKind)>>,
     macro_resolutions: RefCell<Vec<(Box<[Ident]>, Span)>>,
 
     // Macro invocations that can expand into items in this module.
@@ -1117,6 +1118,7 @@ pub struct Resolver<'a> {
     macro_map: FxHashMap<DefId, Rc<SyntaxExtension>>,
     macro_exports: Vec<Export>,
     pub whitelisted_legacy_custom_derives: Vec<Name>,
+    pub found_unresolved_macro: bool,
 
     // Maps the `Mark` of an expansion to its containing module or block.
     invocations: FxHashMap<Mark, &'a InvocationData<'a>>,
@@ -1315,6 +1317,7 @@ impl<'a> Resolver<'a> {
             warned_proc_macros: FxHashSet(),
             potentially_unused_imports: Vec::new(),
             struct_constructors: DefIdMap(),
+            found_unresolved_macro: false,
         }
     }
 

--- a/src/test/compile-fail-fulldeps/gated-quote.rs
+++ b/src/test/compile-fail-fulldeps/gated-quote.rs
@@ -25,32 +25,45 @@ extern crate syntax;
 
 use syntax::ast;
 use syntax::parse;
-use syntax_pos::Span;
 
 struct ParseSess;
 
 impl ParseSess {
     fn cfg(&self) -> ast::CrateConfig { loop { } }
     fn parse_sess<'a>(&'a self) -> &'a parse::ParseSess { loop { } }
-    fn call_site(&self) -> Span { loop { } }
+    fn call_site(&self) -> () { loop { } }
     fn ident_of(&self, st: &str) -> ast::Ident { loop { } }
     fn name_of(&self, st: &str) -> ast::Name { loop { } }
 }
 
 pub fn main() {
     let ecx = &ParseSess;
-    let x = quote_tokens!(ecx, 3);    //~ ERROR macro undefined: `quote_tokens`
-    let x = quote_expr!(ecx, 3);      //~ ERROR macro undefined: `quote_expr`
-    let x = quote_ty!(ecx, 3);        //~ ERROR macro undefined: `quote_ty`
-    let x = quote_method!(ecx, 3);    //~ ERROR macro undefined: `quote_method`
-    let x = quote_item!(ecx, 3);      //~ ERROR macro undefined: `quote_item`
-    let x = quote_pat!(ecx, 3);       //~ ERROR macro undefined: `quote_pat`
-    let x = quote_arm!(ecx, 3);       //~ ERROR macro undefined: `quote_arm`
-    let x = quote_stmt!(ecx, 3);      //~ ERROR macro undefined: `quote_stmt`
-    let x = quote_matcher!(ecx, 3);   //~ ERROR macro undefined: `quote_matcher`
-    let x = quote_attr!(ecx, 3);      //~ ERROR macro undefined: `quote_attr`
-    let x = quote_arg!(ecx, 3);       //~ ERROR macro undefined: `quote_arg`
-    let x = quote_block!(ecx, 3);     //~ ERROR macro undefined: `quote_block`
-    let x = quote_meta_item!(ecx, 3); //~ ERROR macro undefined: `quote_meta_item`
-    let x = quote_path!(ecx, 3);      //~ ERROR macro undefined: `quote_path`
+    let x = quote_tokens!(ecx, 3);
+    //~^ ERROR cannot find macro `quote_tokens!` in this scope
+    let x = quote_expr!(ecx, 3);
+    //~^ ERROR cannot find macro `quote_expr!` in this scope
+    let x = quote_ty!(ecx, 3);
+    //~^ ERROR cannot find macro `quote_ty!` in this scope
+    let x = quote_method!(ecx, 3);
+    //~^ ERROR cannot find macro `quote_method!` in this scope
+    let x = quote_item!(ecx, 3);
+    //~^ ERROR cannot find macro `quote_item!` in this scope
+    let x = quote_pat!(ecx, 3);
+    //~^ ERROR cannot find macro `quote_pat!` in this scope
+    let x = quote_arm!(ecx, 3);
+    //~^ ERROR cannot find macro `quote_arm!` in this scope
+    let x = quote_stmt!(ecx, 3);
+    //~^ ERROR cannot find macro `quote_stmt!` in this scope
+    let x = quote_matcher!(ecx, 3);
+    //~^ ERROR cannot find macro `quote_matcher!` in this scope
+    let x = quote_attr!(ecx, 3);
+    //~^ ERROR cannot find macro `quote_attr!` in this scope
+    let x = quote_arg!(ecx, 3);
+    //~^ ERROR cannot find macro `quote_arg!` in this scope
+    let x = quote_block!(ecx, 3);
+    //~^ ERROR cannot find macro `quote_block!` in this scope
+    let x = quote_meta_item!(ecx, 3);
+    //~^ ERROR cannot find macro `quote_meta_item!` in this scope
+    let x = quote_path!(ecx, 3);
+    //~^ ERROR cannot find macro `quote_path!` in this scope
 }

--- a/src/test/compile-fail-fulldeps/macro-crate-unexported-macro.rs
+++ b/src/test/compile-fail-fulldeps/macro-crate-unexported-macro.rs
@@ -14,5 +14,6 @@
 extern crate macro_crate_test;
 
 fn main() {
-    assert_eq!(3, unexported_macro!()); //~ ERROR macro undefined: `unexported_macro`
+    unexported_macro!();
+    //~^ ERROR cannot find macro `unexported_macro!` in this scope
 }

--- a/src/test/compile-fail-fulldeps/proc-macro/auxiliary/derive-clona.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/auxiliary/derive-clona.rs
@@ -8,8 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[derive(FromPrimitive)] //~ ERROR cannot find derive macro `FromPrimitive` in this scope
-enum Foo {}
+// force-host
+// no-prefer-dynamic
 
-fn main() {}
+#![crate_type = "proc-macro"]
 
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_derive(Clona)]
+pub fn derive_clonea(input: TokenStream) -> TokenStream {
+    "".parse().unwrap()
+}

--- a/src/test/compile-fail-fulldeps/proc-macro/auxiliary/derive-foo.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/auxiliary/derive-foo.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,11 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn main() {
-    print!(test!());
-    //~^ ERROR: macro undefined: `test`
-    //~^^ ERROR: format argument must be a string literal
+// force-host
+// no-prefer-dynamic
 
-    concat!(test!());
-    //~^ ERROR: macro undefined: `test`
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_derive(FooWithLongName)]
+pub fn derive_foo(input: TokenStream) -> TokenStream {
+    "".parse().unwrap()
 }

--- a/src/test/compile-fail-fulldeps/proc-macro/resolve-error.rs
+++ b/src/test/compile-fail-fulldeps/proc-macro/resolve-error.rs
@@ -1,0 +1,44 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:derive-foo.rs
+// aux-build:derive-clona.rs
+// aux-build:attr_proc_macro.rs
+
+#![feature(proc_macro)]
+
+#[macro_use]
+extern crate derive_foo;
+#[macro_use]
+extern crate derive_clona;
+extern crate attr_proc_macro;
+
+use attr_proc_macro::attr_proc_macro;
+
+#[derive(FooWithLongNam)]
+//~^ ERROR cannot find derive macro `FooWithLongNam` in this scope
+//~^^ HELP did you mean `FooWithLongName`?
+struct Foo;
+
+#[attr_proc_macra]
+//~^ ERROR cannot find attribute macro `attr_proc_macra` in this scope
+struct Bar;
+
+#[derive(Dlone)]
+//~^ ERROR cannot find derive macro `Dlone` in this scope
+//~^^ HELP did you mean `Clone`?
+struct A;
+
+#[derive(Dlona)]
+//~^ ERROR cannot find derive macro `Dlona` in this scope
+//~^^ HELP did you mean `Clona`?
+struct B;
+
+fn main() {}

--- a/src/test/compile-fail/empty-macro-use.rs
+++ b/src/test/compile-fail/empty-macro-use.rs
@@ -14,5 +14,6 @@
 extern crate two_macros;
 
 pub fn main() {
-    macro_two!();  //~ ERROR macro undefined
+    macro_two!();
+    //~^ ERROR cannot find macro
 }

--- a/src/test/compile-fail/ext-nonexistent.rs
+++ b/src/test/compile-fail/ext-nonexistent.rs
@@ -8,5 +8,5 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:macro undefined
+// error-pattern:cannot find macro
 fn main() { iamnotanextensionthatexists!(""); }

--- a/src/test/compile-fail/feature-gate-rustc-diagnostic-macros.rs
+++ b/src/test/compile-fail/feature-gate-rustc-diagnostic-macros.rs
@@ -12,12 +12,12 @@
 // gate
 
 __register_diagnostic!(E0001);
-//~^ ERROR macro undefined: `__register_diagnostic`
+//~^ ERROR cannot find macro `__register_diagnostic!` in this scope
 
 fn main() {
     __diagnostic_used!(E0001);
-    //~^ ERROR macro undefined: `__diagnostic_used`
+    //~^ ERROR cannot find macro `__diagnostic_used!` in this scope
 }
 
 __build_diagnostic_array!(DIAGNOSTICS);
-//~^ ERROR macro undefined: `__build_diagnostic_array`
+//~^ ERROR cannot find macro `__build_diagnostic_array!` in this scope

--- a/src/test/compile-fail/issue-11692-1.rs
+++ b/src/test/compile-fail/issue-11692-1.rs
@@ -8,20 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Test macro_undefined issue
-
-mod m {
-    #[macro_export]
-    macro_rules! kl {
-        () => ()
-    }
-}
-
 fn main() {
-    k!();
-    //~^ ERROR cannot find macro `k!` in this scope
-    //~^^ HELP did you mean `kl!`?
-    kl!();
-    //~^ ERROR cannot find macro `kl!` in this scope
-    //~^^ HELP have you added the `#[macro_use]` on the module/import?
+    print!(test!());
+    //~^ ERROR: format argument must be a string literal
 }

--- a/src/test/compile-fail/issue-11692-2.rs
+++ b/src/test/compile-fail/issue-11692-2.rs
@@ -8,20 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Test macro_undefined issue
-
-mod m {
-    #[macro_export]
-    macro_rules! kl {
-        () => ()
-    }
-}
-
 fn main() {
-    k!();
-    //~^ ERROR cannot find macro `k!` in this scope
-    //~^^ HELP did you mean `kl!`?
-    kl!();
-    //~^ ERROR cannot find macro `kl!` in this scope
-    //~^^ HELP have you added the `#[macro_use]` on the module/import?
+    concat!(test!());
+    //~^ ERROR cannot find macro `test!` in this scope
 }

--- a/src/test/compile-fail/issue-19734.rs
+++ b/src/test/compile-fail/issue-19734.rs
@@ -10,6 +10,9 @@
 
 fn main() {}
 
+struct Type;
+
 impl Type {
-    undef!(); //~ ERROR macro undefined: `undef`
+    undef!();
+    //~^ ERROR cannot find macro `undef!` in this scope
 }

--- a/src/test/compile-fail/macro-error.rs
+++ b/src/test/compile-fail/macro-error.rs
@@ -16,5 +16,4 @@ fn main() {
     foo!(0); // Check that we report errors at macro definition, not expansion.
 
     let _: cfg!(foo) = (); //~ ERROR non-type macro in type position
-    derive!(); //~ ERROR macro undefined: `derive`
 }

--- a/src/test/compile-fail/macro-expansion-tests.rs
+++ b/src/test/compile-fail/macro-expansion-tests.rs
@@ -12,14 +12,16 @@ mod macros_cant_escape_fns {
     fn f() {
         macro_rules! m { () => { 3 + 4 } }
     }
-    fn g() -> i32 { m!() } //~ ERROR macro undefined
+    fn g() -> i32 { m!() }
+    //~^ ERROR cannot find macro
 }
 
 mod macros_cant_escape_mods {
     mod f {
         macro_rules! m { () => { 3 + 4 } }
     }
-    fn g() -> i32 { m!() } //~ ERROR macro undefined
+    fn g() -> i32 { m!() }
+    //~^ ERROR cannot find macro
 }
 
 mod macros_can_escape_flattened_mods_test {

--- a/src/test/compile-fail/macro-name-typo.rs
+++ b/src/test/compile-fail/macro-name-typo.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 fn main() {
-    printlx!("oh noes!"); //~ ERROR macro undefined
-    //~^ HELP did you mean `println!`?
+    printlx!("oh noes!");
+    //~^ ERROR cannot find macro
+    //~^^ HELP did you mean `println!`?
 }

--- a/src/test/compile-fail/macro-no-implicit-reexport.rs
+++ b/src/test/compile-fail/macro-no-implicit-reexport.rs
@@ -15,5 +15,6 @@
 extern crate macro_non_reexport_2;
 
 fn main() {
-    assert_eq!(reexported!(), 3);  //~ ERROR macro undefined
+    assert_eq!(reexported!(), 3);
+    //~^ ERROR cannot find macro `reexported!` in this scope
 }

--- a/src/test/compile-fail/macro-reexport-not-locally-visible.rs
+++ b/src/test/compile-fail/macro-reexport-not-locally-visible.rs
@@ -17,5 +17,6 @@
 extern crate macro_reexport_1;
 
 fn main() {
-    assert_eq!(reexported!(), 3);  //~ ERROR macro undefined
+    assert_eq!(reexported!(), 3);
+    //~^ ERROR cannot find macro
 }

--- a/src/test/compile-fail/macro-use-wrong-name.rs
+++ b/src/test/compile-fail/macro-use-wrong-name.rs
@@ -14,5 +14,6 @@
 extern crate two_macros;
 
 pub fn main() {
-    macro_two!();  //~ ERROR macro undefined
+    macro_two!();
+    //~^ ERROR cannot find macro
 }

--- a/src/test/compile-fail/macros-nonfatal-errors.rs
+++ b/src/test/compile-fail/macros-nonfatal-errors.rs
@@ -14,15 +14,10 @@
 #![feature(asm)]
 #![feature(trace_macros, concat_idents)]
 
-#[derive(Zero)] //~ ERROR
-struct CantDeriveThis;
-
 #[derive(Default)] //~ ERROR
 enum OrDeriveThis {}
 
 fn main() {
-    doesnt_exist!(); //~ ERROR
-
     asm!(invalid); //~ ERROR
 
     concat_idents!("not", "idents"); //~ ERROR

--- a/src/test/compile-fail/missing-macro-use.rs
+++ b/src/test/compile-fail/missing-macro-use.rs
@@ -13,5 +13,6 @@
 extern crate two_macros;
 
 pub fn main() {
-    macro_two!();  //~ ERROR macro undefined
+    macro_two!();
+    //~^ ERROR cannot find macro `macro_two!` in this scope
 }

--- a/src/test/compile-fail/self_type_keyword.rs
+++ b/src/test/compile-fail/self_type_keyword.rs
@@ -10,11 +10,15 @@
 
 // compile-flags: -Z continue-parse-after-error
 
-struct Self;
-//~^ ERROR expected identifier, found keyword `Self`
+mod foo {
+  struct Self;
+  //~^ ERROR expected identifier, found keyword `Self`
+}
 
 struct Bar<'Self>;
 //~^ ERROR lifetimes cannot use keyword names
+
+struct Foo;
 
 pub fn main() {
     match 15 {
@@ -25,7 +29,7 @@ pub fn main() {
         ref mut Self => (),
         //~^ ERROR expected identifier, found keyword `Self`
         Self!() => (),
-        //~^ ERROR macro undefined: `Self`
+        //~^ ERROR cannot find macro `Self!` in this scope
         Foo { Self } => (),
         //~^ ERROR expected identifier, found keyword `Self`
     }


### PR DESCRIPTION
Move legacy macro resolution error reporting to `finalize_current_module_macro_resolutions`, and provide suggestions for derive macros.

Fixes #39323 

cc https://github.com/rust-lang/rust/issues/30197

r? @jseyfried 