### PR TITLE
travis: Add builders without assertions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,20 @@ matrix:
       osx_image: xcode8.2
       install: *osx_install_sccache
 
+    # "alternate" deployments, these are "nightlies" but don't have assertions
+    # turned on, they're deployed to a different location primarily for projects
+    # which are stuck on nightly and don't want llvm assertions in the artifacts
+    # that they use.
+    - env: IMAGE=dist-x86-linux DEPLOY_ALT=1
+    - env: >
+        RUST_CHECK_TARGET=dist
+        RUST_CONFIGURE_ARGS="--enable-extended"
+        SRC=.
+        DEPLOY_ALT=1
+      os: osx
+      osx_image: xcode8.2
+      install: *osx_install_sccache
+
 env:
   global:
     - SCCACHE_BUCKET=rust-lang-ci-sccache
@@ -125,3 +139,19 @@ deploy:
     on:
       branch: auto
       condition: $DEPLOY = 1
+
+  # this is the same as the above deployment provider except that it uploads to
+  # a slightly different directory and has a different trigger
+  - provider: s3
+    bucket: rust-lang-ci
+    skip_cleanup: true
+    local_dir: deploy
+    upload_dir: rustc-builds-alt
+    acl: public_read
+    region: us-east-1
+    access_key_id: AKIAIPQVNYF2T3DTYIWQ
+    secret_access_key:
+      secure: "FBqDqOTeIPMu6v/WYPf4CFSlh9rLRZGKVtpLa5KkyuOhXRTrnEzBduEtS8/FMIxdQImvurhSvxWvqRybMOi4qoVfjMqqpHAI7uBbidbrvAcJoHNsx6BgUNVCIoH6a0UsAjTUtm6/YPIpzbHoLZXPL0GrHPMk6Mu04qVSmcYNWn4="
+    on:
+      branch: auto
+      condition: $DEPLOY_ALT = 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,6 +61,12 @@ environment:
     MINGW_DIR: mingw64
     DEPLOY: 1
 
+  # "alternate" deployment, see .travis.yml for more info
+  - MSYS_BITS: 64
+    RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-extended
+    SCRIPT: python x.py dist
+    DEPLOY_ALT: 1
+
 matrix:
   fast_finish: true
 
@@ -145,6 +151,22 @@ deploy:
     on:
       branch: auto
       DEPLOY: 1
+
+  # This provider is the same as the one above except that it has a slightly
+  # different upload directory and a slightly different trigger
+  - provider: S3
+    skip_cleanup: true
+    access_key_id: AKIAIPQVNYF2T3DTYIWQ
+    secret_access_key:
+      secure: +11jsUNFTQ9dq5Ad1i2+PeUJaXluFJ0zIJAXESE1dFT3Kdjku4/eDdgyjgsB6GnV
+    bucket: rust-lang-ci
+    set_public: true
+    region: us-east-1
+    artifact: /.*/
+    folder: rustc-builds-alt
+    on:
+      branch: auto
+      DEPLOY_ALT: 1
 
 # init:
 #   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -49,6 +49,7 @@ exec docker \
   $args \
   --env CARGO_HOME=/cargo \
   --env DEPLOY=$DEPLOY \
+  --env DEPLOY_ALT=$DEPLOY_ALT \
   --env LOCAL_USER_ID=`id -u` \
   --volume "$HOME/.cargo:/cargo" \
   --rm \

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -30,11 +30,13 @@ RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --disable-manage-submodules"
 #
 # FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
 #        either automatically or manually.
-if [ "$DEPLOY" != "" ]; then
+if [ "$DEPLOY$DEPLOY_ALT" != "" ]; then
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=nightly"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"
 
   if [ "$NO_LLVM_ASSERTIONS" = "1" ]; then
+    RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --disable-llvm-assertions"
+  elif [ "$DEPLOY_ALT" != "" ]; then
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --disable-llvm-assertions"
   fi
 else


### PR DESCRIPTION
This commit adds three new builders, one OSX, one Linux, and one MSVC, which
will produce "nightlies" with LLVM assertions disabled. Currently all nightly
releases have LLVM assertions enabled to catch bugs before they reach the
beta/stable channels. The beta/stable channels, however, do not have LLVM
assertions enabled.

Unfortunately though projects like Servo are stuck on nightlies for the near
future at least and are also suffering very long compile times. The purpose of
this commit is to provide artifacts to these projects which are not distributed
through normal channels (e.g. rustup) but are provided for developers to use
locally if need be.

Logistically these builds will all be uploaded to `rustc-builds-alt` instead of
the `rustc-builds` folder of the `rust-lang-ci` bucket. These builds will stay
there forever (until cleaned out if necessary) and there are no plans to
integrate this with rustup and/or the official release process.