### PR TITLE
add solaris rustbuild support

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -345,6 +345,21 @@ class RustBuild(object):
             ostype = 'unknown-openbsd'
         elif ostype == 'NetBSD':
             ostype = 'unknown-netbsd'
+        elif ostype == 'SunOS':
+            ostype = 'sun-solaris'
+            # On Solaris, uname -m will return a machine classification instead
+            # of a cpu type, so uname -p is recommended instead.  However, the
+            # output from that option is too generic for our purposes (it will
+            # always emit 'i386' on x86/amd64 systems).  As such, isainfo -k
+            # must be used instead.
+            try:
+                cputype = subprocess.check_output(['isainfo',
+                  '-k']).strip().decode(default_encoding)
+            except (subprocess.CalledProcessError, WindowsError):
+                err = "isainfo not found"
+                if self.verbose:
+                    raise Exception(err)
+                sys.exit(err)
         elif ostype == 'Darwin':
             ostype = 'apple-darwin'
         elif ostype.startswith('MINGW'):

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -315,7 +315,7 @@ class RustBuild(object):
         try:
             ostype = subprocess.check_output(['uname', '-s']).strip().decode(default_encoding)
             cputype = subprocess.check_output(['uname', '-m']).strip().decode(default_encoding)
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, OSError):
             if sys.platform == 'win32':
                 return 'x86_64-pc-windows-msvc'
             err = "uname not found"

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -315,7 +315,7 @@ class RustBuild(object):
         try:
             ostype = subprocess.check_output(['uname', '-s']).strip().decode(default_encoding)
             cputype = subprocess.check_output(['uname', '-m']).strip().decode(default_encoding)
-        except (subprocess.CalledProcessError, WindowsError):
+        except subprocess.CalledProcessError:
             if sys.platform == 'win32':
                 return 'x86_64-pc-windows-msvc'
             err = "uname not found"

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -355,7 +355,7 @@ class RustBuild(object):
             try:
                 cputype = subprocess.check_output(['isainfo',
                   '-k']).strip().decode(default_encoding)
-            except (subprocess.CalledProcessError, WindowsError):
+            except (subprocess.CalledProcessError, OSError):
                 err = "isainfo not found"
                 if self.verbose:
                     raise Exception(err)

--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -46,6 +46,8 @@ fn main() {
     } else if target.contains("dragonfly") || target.contains("bitrig") ||
               target.contains("netbsd") || target.contains("openbsd") {
         println!("cargo:rustc-link-lib=pthread");
+    } else if target.contains("solaris") {
+        println!("cargo:rustc-link-lib=gcc_s");
     } else if target.contains("apple-darwin") {
         println!("cargo:rustc-link-lib=System");
     } else if target.contains("apple-ios") {

--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -46,8 +46,6 @@ fn main() {
     } else if target.contains("dragonfly") || target.contains("bitrig") ||
               target.contains("netbsd") || target.contains("openbsd") {
         println!("cargo:rustc-link-lib=pthread");
-    } else if target.contains("solaris") {
-        println!("cargo:rustc-link-lib=gcc_s");
     } else if target.contains("apple-darwin") {
         println!("cargo:rustc-link-lib=System");
     } else if target.contains("apple-ios") {

--- a/src/libunwind/build.rs
+++ b/src/libunwind/build.rs
@@ -27,6 +27,8 @@ fn main() {
         println!("cargo:rustc-link-lib=gcc_s");
     } else if target.contains("openbsd") {
         println!("cargo:rustc-link-lib=gcc");
+    } else if target.contains("solaris") {
+        println!("cargo:rustc-link-lib=gcc_s");
     } else if target.contains("bitrig") {
         println!("cargo:rustc-link-lib=c++abi");
     } else if target.contains("dragonfly") {


### PR DESCRIPTION
Add Solaris as recognized ostype
Add cputype recognition for Solaris

Fixes #39729

A future pull request will discriminate between the commercial release and older opensource derivatives to account for divergence, for now, this is compatible with both.