### PR TITLE
Set CompilerDesugaring expn_info for all desugared expressions

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -677,7 +677,8 @@ impl EmitterWriter {
                         }
                         // Check to make sure we're not in any <*macros>
                         if !cm.span_to_filename(def_site).contains("macros>") &&
-                           !trace.macro_decl_name.starts_with("#[") {
+                           !trace.macro_decl_name.starts_with("#[") &&
+                           !trace.macro_decl_name.starts_with("desugaring of") {
                             new_labels.push((trace.call_site,
                                              "in this macro invocation".to_string()));
                             break;

--- a/src/test/compile-fail/if-let-arm-types.rs
+++ b/src/test/compile-fail/if-let-arm-types.rs
@@ -13,6 +13,8 @@ fn main() {
         //~^ expected (), found integral variable
         //~| expected type `()`
         //~| found type `{integer}`
+        //~| NOTE: in this expansion of desugaring of `if let`
+        //~| NOTE: in this expansion of desugaring of `if let`
         ()
     } else {                //~ NOTE: `if let` arm with an incompatible type
         1

--- a/src/test/run-make/save-analysis/Makefile
+++ b/src/test/run-make/save-analysis/Makefile
@@ -2,7 +2,8 @@
 all: code
 krate2: krate2.rs
 	$(RUSTC) $<
-code: foo.rs krate2
+code: foo.rs krate2 sugar.rs
 	$(RUSTC) foo.rs -Zsave-analysis-csv
 	$(RUSTC) foo.rs -Zsave-analysis
 	$(RUSTC) foo.rs -Zsave-analysis-api
+	$(RUSTC) sugar.rs -Zsave-analysis-csv

--- a/src/test/run-make/save-analysis/sugar.rs
+++ b/src/test/run-make/save-analysis/sugar.rs
@@ -1,0 +1,30 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let _ = foo();
+
+    for x in vec![1, 2, 3, 4] {
+        println!("{}", x);
+    }
+
+    while let Some(x) = Some(1) {
+        println!("{}", x);
+    }
+}
+
+fn foo() -> Result<(), ()> {
+    bar()?;
+    Ok(())
+}
+
+fn bar() -> Result<(), ()> {
+    Ok(())
+}

--- a/src/test/ui/compiler_desugaring.rs
+++ b/src/test/ui/compiler_desugaring.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,11 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn main() {
-    let xs : Vec<Option<i32>> = vec![Some(1), None];
+// checks that errors on compiler-desugared spans don't have
+// useless `in this macro invocation` notes.
 
-    for Some(x) in xs {}
-    //~^ ERROR E0297
-    //~| NOTE pattern `None` not covered
-    //~| NOTE in this expansion of desugaring of `for`
+fn main() {
+    let _ = foo();
 }
+
+fn foo() -> Result<(), ()> {
+    let _: i32 = bar()?; //~ ERROR E0308
+    Ok(())
+}
+
+fn bar() -> Result<(), ()> {
+    Ok(())
+}
+

--- a/src/test/ui/compiler_desugaring.stderr
+++ b/src/test/ui/compiler_desugaring.stderr
@@ -1,0 +1,16 @@
+error[E0308]: match arms have incompatible types
+  --> $DIR/compiler_desugaring.rs:19:18
+   |
+19 |     let _: i32 = bar()?; //~ ERROR E0308
+   |                  ^^^^^^ expected i32, found ()
+   |
+   = note: expected type `i32`
+              found type `()`
+note: match arm with an incompatible type
+  --> $DIR/compiler_desugaring.rs:19:18
+   |
+19 |     let _: i32 = bar()?; //~ ERROR E0308
+   |                  ^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This PR adds `CompilerDesugaring` expn_info for all compiler desugared expressions. This will ease writing lints which need to exclude them (for example https://github.com/Manishearth/rust-clippy/pull/1513).

However, it will add `in this macro invocation` note for every error on syntax-sugar span, which is unhelpful. The 2nd commit removes them.