### PR TITLE
Adding compile fail test for staged_api feature

### DIFF
--- a/src/test/compile-fail/feature-gate-staged_api.rs
+++ b/src/test/compile-fail/feature-gate-staged_api.rs
@@ -1,0 +1,24 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![stable(feature = "a", since = "b")]
+//~^ ERROR stability attributes may not be used outside of the standard library
+mod inner_private_module {
+    // UnnameableTypeAlias isn't marked as reachable, so no stability annotation is required here
+    pub type UnnameableTypeAlias = u8;
+}
+
+#[stable(feature = "a", since = "b")]
+//~^ ERROR stability attributes may not be used outside of the standard library
+pub fn f() -> inner_private_module::UnnameableTypeAlias {
+    0
+}
+
+fn main() {}

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -167,7 +167,7 @@ pub fn check(path: &Path, bad: &mut bool) {
     // FIXME get this whitelist empty.
     let whitelist = vec![
         "abi_ptx", "simd", "static_recursion",
-        "cfg_target_has_atomic", "staged_api",
+        "cfg_target_has_atomic",
         "unboxed_closures", "stmt_expr_attributes",
         "cfg_target_thread_local", "unwind_attributes",
         "inclusive_range_syntax"


### PR DESCRIPTION
Issue #39059
r? @est31

@est31 running the tests for this feature fails. Is that expected since this is the `compile-fail`suite?

I copied this test from the run-pass suite: `rust/src/test/run-pass/reachable-unnameable-type-alias.rs`. What are the differences between these suites in operation and why they are used?