### PR TITLE
book: binary prefixed are defined by IEC and not in SI

### DIFF
--- a/src/doc/book/src/the-stack-and-the-heap.md
+++ b/src/doc/book/src/the-stack-and-the-heap.md
@@ -86,7 +86,7 @@ to a large number, representing how much RAM your computer has. For example, if
 you have a gigabyte of RAM, your addresses go from `0` to `1,073,741,823`. That
 number comes from 2<sup>30</sup>, the number of bytes in a gigabyte. [^gigabyte]
 
-[^gigabyte]: ‘Gigabyte’ can mean two things: 10^9, or 2^30. The SI standard resolved this by stating that ‘gigabyte’ is 10^9, and ‘gibibyte’ is 2^30. However, very few people use this terminology, and rely on context to differentiate. We follow in that tradition here.
+[^gigabyte]: ‘Gigabyte’ can mean two things: 10<sup>9</sup>, or 2<sup>30</sup>. The IEC standard resolved this by stating that ‘gigabyte’ is 10<sup>9</sup>, and ‘gibibyte’ is 2<sup>30</sup>. However, very few people use this terminology, and rely on context to differentiate. We follow in that tradition here.
 
 This memory is kind of like a giant array: addresses start at zero and go
 up to the final number. So here’s a diagram of our first stack frame:


### PR DESCRIPTION
Binary prefixes (such as Gi for ‘gibi-’ in GiB) are defined by
International Electrotechnical Commission (IEC) and not in the
International System of Units (SI).

Though to be honest I’d just reword the previous paragraph to use ‘1 GiB’.