### PR TITLE
Drop the `Sized` constraint on `impl Error for Box<T>`

### DIFF
--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -278,7 +278,7 @@ impl Error for char::DecodeUtf16Error {
 }
 
 #[stable(feature = "box_error", since = "1.7.0")]
-impl<T: Error> Error for Box<T> {
+impl<T: Error + ?Sized> Error for Box<T> {
     fn description(&self) -> &str {
         Error::description(&**self)
     }

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -161,14 +161,14 @@ pub trait Error: Debug + Display {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, E: Error + 'a> From<E> for Box<Error + 'a> {
-    fn from(err: E) -> Box<Error + 'a> {
+    default fn from(err: E) -> Box<Error + 'a> {
         Box::new(err)
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, E: Error + Send + Sync + 'a> From<E> for Box<Error + Send + Sync + 'a> {
-    fn from(err: E) -> Box<Error + Send + Sync + 'a> {
+    default fn from(err: E) -> Box<Error + Send + Sync + 'a> {
         Box::new(err)
     }
 }

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -292,6 +292,7 @@
 #![feature(slice_bytes)]
 #![feature(slice_concat_ext)]
 #![feature(slice_patterns)]
+#![feature(specialization)]
 #![feature(staged_api)]
 #![feature(stmt_expr_attributes)]
 #![feature(str_char)]


### PR DESCRIPTION
Because of the implicit `Sized` constraint, `Box<Error>` does not
implement `Error`, which is potentially surprising when trying to pass
to a type which requires `T: Error`.