### PR TITLE
Fix race condition in fs::create_dir_all

### DIFF
--- a/src/librustc/util/fs.rs
+++ b/src/librustc/util/fs.rs
@@ -109,23 +109,3 @@ pub fn rename_or_copy_remove<P: AsRef<Path>, Q: AsRef<Path>>(p: P,
         }
     }
 }
-
-// Like std::fs::create_dir_all, except handles concurrent calls among multiple
-// threads or processes.
-pub fn create_dir_racy(path: &Path) -> io::Result<()> {
-    match fs::create_dir(path) {
-        Ok(()) => return Ok(()),
-        Err(ref e) if e.kind() == io::ErrorKind::AlreadyExists => return Ok(()),
-        Err(ref e) if e.kind() == io::ErrorKind::NotFound => (),
-        Err(e) => return Err(e),
-    }
-    match path.parent() {
-        Some(p) => try!(create_dir_racy(p)),
-        None => return Err(io::Error::new(io::ErrorKind::Other, "failed to create whole tree")),
-    }
-    match fs::create_dir(path) {
-        Ok(()) => Ok(()),
-        Err(ref e) if e.kind() == io::ErrorKind::AlreadyExists => Ok(()),
-        Err(e) => Err(e),
-    }
-}

--- a/src/librustc_incremental/persist/fs.rs
+++ b/src/librustc_incremental/persist/fs.rs
@@ -461,7 +461,7 @@ fn generate_session_dir_path(crate_dir: &Path) -> PathBuf {
 }
 
 fn create_dir(sess: &Session, path: &Path, dir_tag: &str) -> Result<(),()> {
-    match fs_util::create_dir_racy(path) {
+    match std_fs::create_dir_all(path) {
         Ok(()) => {
             debug!("{} directory created successfully", dir_tag);
             Ok(())

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -885,7 +885,7 @@ pub fn process_crate<'l, 'tcx>(tcx: TyCtxt<'l, 'tcx, 'tcx>,
         },
     };
 
-    if let Err(e) = rustc::util::fs::create_dir_racy(&root_path) {
+    if let Err(e) = std::fs::create_dir_all(&root_path) {
         tcx.sess.err(&format!("Could not create directory {}: {}",
                               root_path.display(),
                               e));

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1775,6 +1775,10 @@ impl DirBuilder {
     }
 
     fn create_dir_all(&self, path: &Path) -> io::Result<()> {
+        if path == Path::new("") {
+            return Ok(())
+        }
+
         match self.inner.mkdir(path) {
             Ok(()) => return Ok(()),
             Err(ref e) if e.kind() == io::ErrorKind::NotFound => {}
@@ -2300,6 +2304,16 @@ mod tests {
     #[test]
     fn recursive_mkdir_slash() {
         check!(fs::create_dir_all(&Path::new("/")));
+    }
+
+    #[test]
+    fn recursive_mkdir_dot() {
+        check!(fs::create_dir_all(&Path::new(".")));
+    }
+
+    #[test]
+    fn recursive_mkdir_empty() {
+        check!(fs::create_dir_all(&Path::new("")));
     }
 
     #[test]

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1777,8 +1777,7 @@ impl DirBuilder {
     fn create_dir_all(&self, path: &Path) -> io::Result<()> {
         match self.inner.mkdir(path) {
             Ok(()) => return Ok(()),
-            Err(ref e)
-                if e.kind() == io::ErrorKind::AlreadyExists && path.is_dir() => return Ok(()),
+            Err(_) if path.is_dir() => return Ok(()),
             Err(ref e) if e.kind() == io::ErrorKind::NotFound => {}
             Err(e) => return Err(e),
         }
@@ -1788,7 +1787,7 @@ impl DirBuilder {
         }
         match self.inner.mkdir(path) {
             Ok(()) => Ok(()),
-            Err(ref e) if e.kind() == io::ErrorKind::AlreadyExists && path.is_dir() => Ok(()),
+            Err(_) if path.is_dir() => Ok(()),
             Err(e) => Err(e),
         }
     }
@@ -2280,7 +2279,7 @@ mod tests {
 
     #[test]
     fn concurrent_recursive_mkdir() {
-        for _ in 0..100 {
+        for _ in 0..50 {
             let mut dir = tmpdir().join("a");
             for _ in 0..100 {
                 dir = dir.join("a");

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1777,8 +1777,8 @@ impl DirBuilder {
     fn create_dir_all(&self, path: &Path) -> io::Result<()> {
         match self.inner.mkdir(path) {
             Ok(()) => return Ok(()),
-            Err(_) if path.is_dir() => return Ok(()),
             Err(ref e) if e.kind() == io::ErrorKind::NotFound => {}
+            Err(_) if path.is_dir() => return Ok(()),
             Err(e) => return Err(e),
         }
         match path.parent() {

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1777,7 +1777,7 @@ impl DirBuilder {
     fn create_dir_all(&self, path: &Path) -> io::Result<()> {
         match self.inner.mkdir(path) {
             Ok(()) => return Ok(()),
-            Err(ref e) if e.kind() == io::ErrorKind::AlreadyExists => return Ok(()),
+            Err(ref e) if e.kind() == io::ErrorKind::AlreadyExists && path.is_dir() => return Ok(()),
             Err(ref e) if e.kind() == io::ErrorKind::NotFound => {}
             Err(e) => return Err(e),
         }
@@ -1787,7 +1787,7 @@ impl DirBuilder {
         }
         match self.inner.mkdir(path) {
             Ok(()) => Ok(()),
-            Err(ref e) if e.kind() == io::ErrorKind::AlreadyExists => Ok(()),
+            Err(ref e) if e.kind() == io::ErrorKind::AlreadyExists && path.is_dir() => Ok(()),
             Err(e) => Err(e),
         }
     }

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1777,7 +1777,8 @@ impl DirBuilder {
     fn create_dir_all(&self, path: &Path) -> io::Result<()> {
         match self.inner.mkdir(path) {
             Ok(()) => return Ok(()),
-            Err(ref e) if e.kind() == io::ErrorKind::AlreadyExists && path.is_dir() => return Ok(()),
+            Err(ref e)
+                if e.kind() == io::ErrorKind::AlreadyExists && path.is_dir() => return Ok(()),
             Err(ref e) if e.kind() == io::ErrorKind::NotFound => {}
             Err(e) => return Err(e),
         }

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -2283,9 +2283,10 @@ mod tests {
 
     #[test]
     fn concurrent_recursive_mkdir() {
-        for _ in 0..50 {
-            let mut dir = tmpdir().join("a");
-            for _ in 0..100 {
+        for _ in 0..100 {
+            let dir = tmpdir();
+            let mut dir = dir.join("a");
+            for _ in 0..40 {
                 dir = dir.join("a");
             }
             let mut join = vec!();


### PR DESCRIPTION
The code would crash if the directory was created after create_dir_all
checked whether the directory already existed.  This was contrary to
the documentation which claimed to create the directory if it doesn't
exist, implying (but not stating) that there would not be a failure
due to the directory existing.