### PR TITLE
Fix type hint bug in eval_const_expr_partial() (issue #39548)

### DIFF
--- a/src/test/run-pass/issue-39548.rs
+++ b/src/test/run-pass/issue-39548.rs
@@ -1,0 +1,14 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+fn main() {
+    let _ : [(); ((1 < 2) == false) as usize] = [];
+}


### PR DESCRIPTION
When evaluating const expressions for things like array lengths, rustc assumes that the operands in comparison expressions (a < b, a == b, a >= b etc) are booleans and sets their type hints accordingly, causing an incorrect compilation error in the case "(FOO < 4)" with "const FOO: i32 = 3" and a compiler panic in the case "(3 < 4)".

This fix makes sure that rustc does not assume anything about the types of those operands.