### PR TITLE
Use check_variant for non_camel_case_types lint

### DIFF
--- a/src/librustc_lint/bad_style.rs
+++ b/src/librustc_lint/bad_style.rs
@@ -117,20 +117,16 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonCamelCaseTypes {
 
         match it.node {
             hir::ItemTy(..) |
+            hir::ItemEnum(..) |
             hir::ItemStruct(..) |
             hir::ItemUnion(..) => self.check_case(cx, "type", it.name, it.span),
             hir::ItemTrait(..) => self.check_case(cx, "trait", it.name, it.span),
-            hir::ItemEnum(ref enum_definition, _) => {
-                if has_extern_repr {
-                    return;
-                }
-                self.check_case(cx, "type", it.name, it.span);
-                for variant in &enum_definition.variants {
-                    self.check_case(cx, "variant", variant.node.name, variant.span);
-                }
-            }
             _ => (),
         }
+    }
+
+    fn check_variant(&mut self, cx: &LateContext, v: &hir::Variant, _: &hir::Generics) {
+        self.check_case(cx, "variant", v.node.name, v.span);
     }
 
     fn check_generics(&mut self, cx: &LateContext, it: &hir::Generics) {

--- a/src/test/run-pass/test-allow-non-camel-case-variant.rs
+++ b/src/test/run-pass/test-allow-non-camel-case-variant.rs
@@ -1,0 +1,18 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(non_camel_case_types)]
+
+pub enum Foo {
+    #[allow(non_camel_case_types)]
+    bar
+}
+
+fn main() {}


### PR DESCRIPTION
This way we automatically consider lint attributes.

Fix #38452.