### PR TITLE
travis: Disable source tarballs on most builders

### DIFF
--- a/configure
+++ b/configure
@@ -650,6 +650,7 @@ opt ninja 0 "build LLVM using the Ninja generator (for MSVC, requires building i
 opt locked-deps 0 "force Cargo.lock to be up to date"
 opt vendor 0 "enable usage of vendored Rust crates"
 opt sanitizers 0 "build the sanitizer runtimes (asan, lsan, msan, tsan)"
+opt dist-src 1 "when building tarballs enables building a source tarball"
 
 # Optimization and debugging options. These may be overridden by the release channel, etc.
 opt_nosave optimize 1 "build optimized rust code"

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -72,6 +72,7 @@ pub struct Config {
     pub rustc_default_ar: Option<String>,
     pub rust_optimize_tests: bool,
     pub rust_debuginfo_tests: bool,
+    pub rust_dist_src: bool,
 
     pub build: String,
     pub host: Vec<String>,
@@ -183,6 +184,7 @@ struct Dist {
     sign_folder: Option<String>,
     gpg_password_file: Option<String>,
     upload_addr: Option<String>,
+    src_tarball: Option<bool>,
 }
 
 #[derive(RustcDecodable)]
@@ -246,6 +248,7 @@ impl Config {
         config.build = build.to_string();
         config.channel = "dev".to_string();
         config.codegen_tests = true;
+        config.rust_dist_src = true;
 
         let toml = file.map(|file| {
             let mut f = t!(File::open(&file));
@@ -380,6 +383,7 @@ impl Config {
             config.dist_sign_folder = t.sign_folder.clone().map(PathBuf::from);
             config.dist_gpg_password_file = t.gpg_password_file.clone().map(PathBuf::from);
             config.dist_upload_addr = t.upload_addr.clone();
+            set(&mut config.rust_dist_src, t.src_tarball);
         }
 
         return config
@@ -448,6 +452,7 @@ impl Config {
                 ("FULL_BOOTSTRAP", self.full_bootstrap),
                 ("EXTENDED", self.extended),
                 ("SANITIZERS", self.sanitizers),
+                ("DIST_SRC", self.rust_dist_src),
             }
 
             match key {

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -364,6 +364,10 @@ const CARGO_VENDOR_VERSION: &'static str = "0.1.4";
 
 /// Creates the `rust-src` installer component and the plain source tarball
 pub fn rust_src(build: &Build) {
+    if !build.config.rust_dist_src {
+        return
+    }
+
     println!("Dist src");
 
     let name = pkgname(build, "rust-src");

--- a/src/ci/docker/dist-x86-linux/Dockerfile
+++ b/src/ci/docker/dist-x86-linux/Dockerfile
@@ -82,5 +82,9 @@ RUN curl -L https://api.pub.build.mozilla.org/tooltool/sha512/$SCCACHE_DIGEST | 
 ENV HOSTS=i686-unknown-linux-gnu
 ENV HOSTS=$HOSTS,x86_64-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS --host=$HOSTS --enable-extended --enable-sanitizers
+ENV RUST_CONFIGURE_ARGS \
+      --host=$HOSTS \
+      --enable-extended \
+      --enable-sanitizers
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
+ENV DIST_SRC 1

--- a/src/ci/docker/x86_64-gnu-distcheck/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-distcheck/Dockerfile
@@ -26,3 +26,4 @@ ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu
 ENV SCRIPT python2.7 ../x.py test distcheck
+ENV DIST_SRC 1

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -25,6 +25,10 @@ RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-quiet-tests"
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --disable-manage-submodules"
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-locked-deps"
 
+if [ "$DIST_SRC" = "" ]; then
+  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --disable-dist-src"
+fi
+
 # If we're deploying artifacts then we set the release channel, otherwise if
 # we're not deploying then we want to be sure to enable all assertions becauase
 # we'll be running tests


### PR DESCRIPTION
Currently we create a source tarball on almost all of the `DEPLOY=1` builders
but this has the adverse side effect of all source tarballs overriding
themselves in the S3 bucket. Normally this is ok but unfortunately a source
tarball created on Windows is not buildable on Unix.

On Windows the vendored sources contain paths with `\` characters in them which
when interpreted on Unix end up in "file not found" errors.

Instead of this overwriting behavior, whitelist just one linux builder for
producing tarballs and avoid producing tarballs on all other hosts.