### PR TITLE
Add support for the x86-interrupt calling convention

### DIFF
--- a/src/librustc_llvm/ffi.rs
+++ b/src/librustc_llvm/ffi.rs
@@ -53,6 +53,7 @@ pub enum CallConv {
     X86_64_SysV = 78,
     X86_64_Win64 = 79,
     X86_VectorCall = 80,
+    X86_Intr = 83,
 }
 
 /// LLVMRustLinkage

--- a/src/librustc_trans/abi.rs
+++ b/src/librustc_trans/abi.rs
@@ -355,6 +355,7 @@ impl FnType {
             Aapcs => llvm::ArmAapcsCallConv,
             PtxKernel => llvm::PtxKernel,
             Msp430Interrupt => llvm::Msp430Intr,
+            X86Interrupt => llvm::X86_Intr,
 
             // These API constants ought to be more specific...
             Cdecl => llvm::CCallConv,

--- a/src/libsyntax/abi.rs
+++ b/src/libsyntax/abi.rs
@@ -25,6 +25,7 @@ pub enum Abi {
     SysV64,
     PtxKernel,
     Msp430Interrupt,
+    X86Interrupt,
 
     // Multiplatform / generic ABIs
     Rust,
@@ -59,6 +60,7 @@ const AbiDatas: &'static [AbiData] = &[
     AbiData {abi: Abi::SysV64, name: "sysv64", generic: false },
     AbiData {abi: Abi::PtxKernel, name: "ptx-kernel", generic: false },
     AbiData {abi: Abi::Msp430Interrupt, name: "msp430-interrupt", generic: false },
+    AbiData {abi: Abi::X86Interrupt, name: "x86-interrupt", generic: false },
 
     // Cross-platform ABIs
     AbiData {abi: Abi::Rust, name: "Rust", generic: true },

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -330,6 +330,9 @@ declare_features! (
     // Used to identify crates that contain sanitizer runtimes
     // rustc internal
     (active, sanitizer_runtime, "1.17.0", None),
+
+    // `extern "x86-interrupt" fn()`
+    (active, abi_x86_interrupt, "1.17.0", Some(40180)),
 );
 
 declare_features! (
@@ -1035,6 +1038,10 @@ impl<'a> PostExpansionVisitor<'a> {
             Abi::Msp430Interrupt => {
                 gate_feature_post!(&self, abi_msp430_interrupt, span,
                                    "msp430-interrupt ABI is experimental and subject to change");
+            },
+            Abi::X86Interrupt => {
+                gate_feature_post!(&self, abi_x86_interrupt, span,
+                                   "x86-interrupt ABI is experimental and subject to change");
             },
             // Stable
             Abi::Cdecl |

--- a/src/test/codegen/abi-x86-interrupt.rs
+++ b/src/test/codegen/abi-x86-interrupt.rs
@@ -1,0 +1,28 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Checks if the correct annotation for the x86-interrupt ABI is passed to
+// llvm. Also checks that the abi_x86_interrupt feature gate allows usage
+// of the x86-interrupt abi.
+
+// ignore-arm
+// ignore-aarch64
+// min-llvm-version 3.8
+
+// compile-flags: -C no-prepopulate-passes
+
+#![crate_type = "lib"]
+#![feature(abi_x86_interrupt)]
+
+// CHECK: define x86_intrcc i64 @has_x86_interrupt_abi
+#[no_mangle]
+pub extern "x86-interrupt" fn has_x86_interrupt_abi(a: i64) -> i64 {
+    a * 2
+}

--- a/src/test/compile-fail/feature-gate-abi.rs
+++ b/src/test/compile-fail/feature-gate-abi.rs
@@ -12,6 +12,7 @@
 // gate-test-platform_intrinsics
 // gate-test-abi_vectorcall
 // gate-test-abi_ptx
+// gate-test-abi_x86_interrupt
 
 // Functions
 extern "rust-intrinsic" fn f1() {} //~ ERROR intrinsics are subject to change
@@ -20,6 +21,7 @@ extern "vectorcall" fn f3() {} //~ ERROR vectorcall is experimental and subject 
 extern "rust-call" fn f4() {} //~ ERROR rust-call ABI is subject to change
 extern "msp430-interrupt" fn f5() {} //~ ERROR msp430-interrupt ABI is experimental
 extern "ptx-kernel" fn f6() {} //~ ERROR PTX ABIs are experimental and subject to change
+extern "x86-interrupt" fn f7() {} //~ ERROR x86-interrupt ABI is experimental
 
 // Methods in trait definition
 trait Tr {
@@ -29,6 +31,7 @@ trait Tr {
     extern "rust-call" fn m4(); //~ ERROR rust-call ABI is subject to change
     extern "msp430-interrupt" fn m5(); //~ ERROR msp430-interrupt ABI is experimental
     extern "ptx-kernel" fn m6(); //~ ERROR PTX ABIs are experimental and subject to change
+    extern "x86-interrupt" fn m7(); //~ ERROR x86-interrupt ABI is experimental
 
     extern "rust-intrinsic" fn dm1() {} //~ ERROR intrinsics are subject to change
     extern "platform-intrinsic" fn dm2() {} //~ ERROR platform intrinsics are experimental
@@ -36,6 +39,7 @@ trait Tr {
     extern "rust-call" fn dm4() {} //~ ERROR rust-call ABI is subject to change
     extern "msp430-interrupt" fn dm5() {} //~ ERROR msp430-interrupt ABI is experimental
     extern "ptx-kernel" fn dm6() {} //~ ERROR PTX ABIs are experimental and subject to change
+    extern "x86-interrupt" fn dm7() {} //~ ERROR x86-interrupt ABI is experimental
 }
 
 struct S;
@@ -48,6 +52,7 @@ impl Tr for S {
     extern "rust-call" fn m4() {} //~ ERROR rust-call ABI is subject to change
     extern "msp430-interrupt" fn m5() {} //~ ERROR msp430-interrupt ABI is experimental
     extern "ptx-kernel" fn m6() {} //~ ERROR PTX ABIs are experimental and subject to change
+    extern "x86-interrupt" fn m7() {} //~ ERROR x86-interrupt ABI is experimental
 }
 
 // Methods in inherent impl
@@ -58,6 +63,7 @@ impl S {
     extern "rust-call" fn im4() {} //~ ERROR rust-call ABI is subject to change
     extern "msp430-interrupt" fn im5() {} //~ ERROR msp430-interrupt ABI is experimental
     extern "ptx-kernel" fn im6() {} //~ ERROR PTX ABIs are experimental and subject to change
+    extern "x86-interrupt" fn im7() {} //~ ERROR x86-interrupt ABI is experimental
 }
 
 // Function pointer types
@@ -67,6 +73,7 @@ type A3 = extern "vectorcall" fn(); //~ ERROR vectorcall is experimental and sub
 type A4 = extern "rust-call" fn(); //~ ERROR rust-call ABI is subject to change
 type A5 = extern "msp430-interrupt" fn(); //~ ERROR msp430-interrupt ABI is experimental
 type A6 = extern "ptx-kernel" fn (); //~ ERROR PTX ABIs are experimental and subject to change
+type A7 = extern "x86-interrupt" fn(); //~ ERROR x86-interrupt ABI is experimental
 
 // Foreign modules
 extern "rust-intrinsic" {} //~ ERROR intrinsics are subject to change
@@ -75,5 +82,6 @@ extern "vectorcall" {} //~ ERROR vectorcall is experimental and subject to chang
 extern "rust-call" {} //~ ERROR rust-call ABI is subject to change
 extern "msp430-interrupt" {} //~ ERROR msp430-interrupt ABI is experimental
 extern "ptx-kernel" {} //~ ERROR PTX ABIs are experimental and subject to change
+extern "x86-interrupt" {} //~ ERROR x86-interrupt ABI is experimental
 
 fn main() {}

--- a/src/test/ui/codemap_tests/unicode.stderr
+++ b/src/test/ui/codemap_tests/unicode.stderr
@@ -1,4 +1,4 @@
-error: invalid ABI: expected one of [cdecl, stdcall, fastcall, vectorcall, aapcs, win64, sysv64, ptx-kernel, msp430-interrupt, Rust, C, system, rust-intrinsic, rust-call, platform-intrinsic, unadjusted], found `路濫狼á́́`
+error: invalid ABI: expected one of [cdecl, stdcall, fastcall, vectorcall, aapcs, win64, sysv64, ptx-kernel, msp430-interrupt, x86-interrupt, Rust, C, system, rust-intrinsic, rust-call, platform-intrinsic, unadjusted], found `路濫狼á́́`
   --> $DIR/unicode.rs:11:8
    |
 11 | extern "路濫狼á́́" fn foo() {}


### PR DESCRIPTION
## Overview

This calling convention can be used for definining interrupt handlers on 32-bit and 64-bit x86 targets. The compiler then uses `iret` instead of `ret` for returning and ensures that all registers are restored to their
original values.

Usage:

```rust
extern "x86-interrupt" fn handler(stack_frame: &ExceptionStackFrame) {…}
```

for interrupts and exceptions without error code and

```rust
extern "x86-interrupt" fn handler_with_err_code(stack_frame: &ExceptionStackFrame,
                                                error_code: u64) {…}
```

for exceptions that push an error code (e.g., page faults or general protection faults). The programmer must ensure that the correct version is used for each interrupt.

For more details see the [LLVM PR][1] and the corresponding [proposal][2].

[1]: https://reviews.llvm.org/D15567
[2]: http://lists.llvm.org/pipermail/cfe-dev/2015-September/045171.html

## Compared to naked functions

It is also possible to implement interrupt handlers on x86 through [naked functions](https://github.com/rust-lang/rfcs/blob/master/text/1201-naked-fns.md). In fact, almost all existing Rust OS projects for x86 use naked functions for this, including [Redox](https://github.com/redox-os/kernel/blob/b9793deb59c7650f0805dea96adb6b773ad99336/arch/x86_64/src/lib.rs#L109-L147), [IntermezzOS](https://github.com/intermezzOS/kernel/blob/f959cc18c78b1ba153f3ff7039d9ecc07f397628/interrupts/src/lib.rs#L28-L72), and [blog_os](https://github.com/phil-opp/blog_os/blob/844d739379ffdea6a7ede88365ec6e21a725bbf5/src/interrupts/mod.rs#L49-L64). So support for the `x86-interrupt` calling convention isn't absolutely needed.

However, it has a number of benefits to naked functions:

- **No inline assembly needed**: [Inline assembly](https://doc.rust-lang.org/book/inline-assembly.html) is highly unstable and dangerous. It's pretty easy to mess things up. Also, it uses an arcane syntax and requires that the programmer knows x86 assembly.
- **Higher performance**: A naked wrapper function always saves _all_ registers before calling the Rust function. This isn't needed for a compiler supported calling convention, since the compiler knows which registers are clobbered by the interrupt handler. Thus, only these registers need to be saved and restored.
- **Safer interfaces**: We can write a `set_handler` function that takes a `extern "x86-interrupt" fn(&ExceptionStackFrame)` and the compiler ensures that we always use the right function type for all handler functions. This isn't possible with the `#[naked]` attribute.
- **More convenient**: Instead of writing [tons of assembly boilerplate](https://github.com/redox-os/kernel/blob/b9793deb59c7650f0805dea96adb6b773ad99336/arch/x86_64/src/lib.rs#L109-L147) and desperately trying to improve things [through macros](https://github.com/phil-opp/blog_os/blob/844d739379ffdea6a7ede88365ec6e21a725bbf5/src/interrupts/mod.rs#L17-L92), we can just write [code like this](https://github.com/phil-opp/blog_os/blob/e6a61f9507a4c4fef6fb4e3474bc596391bc97d2/src/interrupts/mod.rs#L85-L89).
- **Naked functions are unreliable**: It is allowed to use Rust code inside a naked function, which sometimes works and sometimes not. For example, [calling a function](https://github.com/redox-os/kernel/blob/b9793deb59c7650f0805dea96adb6b773ad99336/arch/x86_64/src/lib.rs#L132) through Rust code seems to work fine without function prologue, but [code declaring a variable](https://is.gd/NQYXqE) silently adds a prologue even though the function is naked (look at the generated assembly, there is a `movl` instruction before the `nop`).

## Known issues

**Edit**: See the [tracking issue](https://github.com/rust-lang/rust/issues/40180) for an updated list of issues.

Unfortunately, the implementation of the `x86-interrupt` calling convention in LLVM has some issues that make it unsuitable for 64-bit kernels at the moment:

- LLVM always tries to backup the `xmm` registers on 64-bit platforms even if the target doesn't support SSE. This leads to invalid opcode exceptions whenever an interrupt handler is invoked. I submitted a fix to LLVM in [D29959](https://reviews.llvm.org/D29959). The fix is really small (<10 lines), so maybe we could backport it to [Rust's LLVM fork](https://github.com/rust-lang/llvm)?. **Edit**: The fix was merged to LLVM trunk in [rL295347](https://reviews.llvm.org/rL295347). Backported in https://github.com/rust-lang/llvm/pull/63.

- On targets with SSE support, LLVM uses the `movaps` instruction for saving the `xmm` registers, which requires an alignment of 16. For handlers with error codes, however, the stack alignment is only 8, so a alignment exception occurs. This issue is tracked in [bug 26413](https://bugs.llvm.org/show_bug.cgi?id=26413). ~~Unfortunately, I don't know enough about LLVM to fix this.~~ **Edit**: Fix submitted in [D30049](https://reviews.llvm.org/D30049).

## About this PR

This PR adds experimental support for this calling convention under the `abi_x86_interrupt` feature gate. The implementation is very similar to #38465 and was surprisingly simple :).

There is no accepted RFC for this change. In fact, the [RFC for interrupt calling convention](https://github.com/rust-lang/rfcs/pull/1275) from 2015 was closed in favor of naked functions. However, the reactions to the recent [PR](https://github.com/rust-lang/rust/pull/38465) for a MSP430 interrupt calling convention were [in favor of experimental interrupt ABIs](https://github.com/rust-lang/rust/pull/38465#issuecomment-270015470).

## Todo

- [x] Add compile-fail tests for the feature gate.
- [x] Create tracking issue for the `abi_x86_interrupt` feature (and link it in code). **Edit**: Tracking issue: #40180
- [x] Backport [rL295347](https://reviews.llvm.org/rL295347) to Rust's LLVM fork. **Edit**: Done in https://github.com/rust-lang/llvm/pull/63

## CC

@tari @steveklabnik @jackpot51 @ticki @hawkw @thepowersgang, you might be interested in this.