### PR TITLE
rustc: Link statically to the MSVCRT

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -205,6 +205,11 @@ fn main() {
                 }
             }
         }
+
+        if target.contains("pc-windows-msvc") {
+            cmd.arg("-Z").arg("unstable-options");
+            cmd.arg("-C").arg("target-feature=+crt-static");
+        }
     }
 
     if verbose > 1 {

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -99,6 +99,12 @@ pub fn llvm(build: &Build, target: &str) {
        .define("LLVM_TARGET_ARCH", target.split('-').next().unwrap())
        .define("LLVM_DEFAULT_TARGET_TRIPLE", target);
 
+    if target.contains("msvc") {
+        cfg.define("LLVM_USE_CRT_DEBUG", "MT");
+        cfg.define("LLVM_USE_CRT_RELEASE", "MT");
+        cfg.define("LLVM_USE_CRT_RELWITHDEBINFO", "MT");
+    }
+
     if target.starts_with("i686") {
         cfg.define("LLVM_BUILD_32_BITS", "ON");
     }

--- a/src/rustllvm/llvm-auto-clean-trigger
+++ b/src/rustllvm/llvm-auto-clean-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be forcibly cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2016-12-19
+2017-02-15


### PR DESCRIPTION
This commit changes all MSVC rustc binaries to be compiled with
`-C target-feature=+crt-static` to link statically against the MSVCRT instead of
dynamically (as it does today). This also necessitates compiling LLVM in a
different fashion, ensuring it's compiled with `/MT` instead of `/MD`.

cc #37406