### PR TITLE
Vec, LinkedList, VecDeque, String, and Option NatVis visualizations

### DIFF
--- a/src/etc/natvis/libcollections.natvis
+++ b/src/etc/natvis/libcollections.natvis
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="collections::vec::Vec&lt;*&gt;">
+    <DisplayString>{{ size={len} }}</DisplayString>
+    <Expand>
+      <Item Name="[size]" ExcludeView="simple">len</Item>
+      <Item Name="[capacity]" ExcludeView="simple">buf.cap</Item>
+      <ArrayItems>
+        <Size>len</Size>
+        <ValuePointer>buf.ptr.pointer.__0</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+  <Type Name="collections::vec_deque::VecDeque&lt;*&gt;">
+    <DisplayString>{{ size={tail &lt;= head ? head - tail : buf.cap - tail + head} }}</DisplayString>
+    <Expand>
+      <Item Name="[size]" ExcludeView="simple">tail &lt;= head ? head - tail : buf.cap - tail + head</Item>
+      <Item Name="[capacity]" ExcludeView="simple">buf.cap</Item>
+      <CustomListItems>
+        <Variable Name="i" InitialValue="tail" />
+
+        <Size>tail &lt;= head ? head - tail : buf.cap - tail + head</Size>
+        <Loop>
+          <If Condition="i == head">
+            <Break/>
+          </If>
+          <Item>buf.ptr.pointer.__0 + i</Item>
+          <Exec>i = (i + 1 == buf.cap ? 0 : i + 1)</Exec>
+        </Loop>
+      </CustomListItems>
+    </Expand>
+  </Type>
+  <Type Name="collections::linked_list::LinkedList&lt;*&gt;">
+    <DisplayString>{{ size={len} }}</DisplayString>
+    <Expand>
+      <LinkedListItems>
+        <Size>len</Size>
+        <HeadPointer>*(collections::linked_list::Node&lt;$T1&gt; **)&amp;head</HeadPointer>
+        <NextPointer>*(collections::linked_list::Node&lt;$T1&gt; **)&amp;next</NextPointer>
+        <ValueNode>element</ValueNode>
+      </LinkedListItems>
+    </Expand>
+  </Type>
+  <Type Name="collections::string::String">
+    <DisplayString>{*(char**)this,[vec.len]}</DisplayString>
+    <StringView>*(char**)this,[vec.len]</StringView>
+    <Expand>
+      <Item Name="[size]" ExcludeView="simple">vec.len</Item>
+      <Item Name="[capacity]" ExcludeView="simple">vec.buf.cap</Item>
+      <ArrayItems>
+        <Size>vec.len</Size>
+        <ValuePointer>*(char**)this</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+</AutoVisualizer>

--- a/src/etc/natvis/libcore.natvis
+++ b/src/etc/natvis/libcore.natvis
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="core::ptr::Unique&lt;*&gt;">
+    <DisplayString>{{ Unique {*pointer.__0} }}</DisplayString>
+    <Expand>
+      <Item Name="[ptr]">pointer.__0</Item>
+    </Expand>
+  </Type>
+  <Type Name="core::ptr::Shared&lt;*&gt;">
+    <DisplayString>{{ Shared {*pointer.__0} }}</DisplayString>
+    <Expand>
+      <Item Name="[ptr]">pointer.__0</Item>
+    </Expand>
+  </Type>
+  <Type Name="core::option::Option&lt;*&gt;">
+    <DisplayString Condition="RUST$ENUM$DISR == 0x0">{{ None }}</DisplayString>
+    <DisplayString Condition="RUST$ENUM$DISR == 0x1">{{ Some {__0} }}</DisplayString>
+    <Expand>
+      <Item Name="[size]" ExcludeView="simple">(ULONG)(RUST$ENUM$DISR != 0)</Item>
+      <Item Name="[value]" ExcludeView="simple">__0</Item>
+      <ArrayItems>
+        <Size>(ULONG)(RUST$ENUM$DISR != 0)</Size>
+        <ValuePointer>&amp;__0</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+  <Type Name="core::option::Option&lt;*&gt;" Priority="MediumLow">
+    <DisplayString Condition="*(PVOID *)this == nullptr">{{ None }}</DisplayString>
+    <DisplayString>{{ Some {($T1 *)this} }}</DisplayString>
+    <Expand>
+      <Item Name="[size]" ExcludeView="simple">(ULONG)(*(PVOID *)this != nullptr)</Item>
+      <Item Name="[value]" ExcludeView="simple" Condition="*(PVOID *)this != nullptr">($T1 *)this</Item>
+      <ArrayItems>
+        <Size>(ULONG)(*(PVOID *)this != nullptr)</Size>
+        <ValuePointer>($T1 *)this</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+</AutoVisualizer>


### PR DESCRIPTION
I've added some basic [NatVis](https://msdn.microsoft.com/en-us/library/jj620914.aspx) visualizations for core Rust collections and types. This helps address a need filed in issue #36503. NatVis visualizations are similar to gdb/lldb pretty printers, but for windbg and the Visual Studio debugger on Windows.

For example, Vec without the supplied NatVis looks like this in windbg using the "dx" command:
```
0:000> dx some_64_bit_vec
some_64_bit_vec                 [Type: collections::vec::Vec<u64>]
    [+0x000] buf              [Type: alloc::raw_vec::RawVec<u64>]
    [+0x010] len              : 0x4 [Type: unsigned __int64]
```

With the NatVis, the elements of the Vec are displayed:
```
0:000> dx some_64_bit_vec
some_64_bit_vec                 : { size=0x4 } [Type: collections::vec::Vec<u64>]
    [<Raw View>]     [Type: collections::vec::Vec<u64>]
    [size]           : 0x4 [Type: unsigned __int64]
    [capacity]       : 0x4 [Type: unsigned __int64]
    [0]              : 0x4 [Type: unsigned __int64]
    [1]              : 0x4f [Type: unsigned __int64]
    [2]              : 0x1a [Type: unsigned __int64]
    [3]              : 0x184 [Type: unsigned __int64]
```

In fact, the vector can be treated as an array by the NatVis expression evaluator:
```
0:000> dx some_64_bit_vec[2]
some_64_bit_vec[2] : 0x1a [Type: unsigned __int64]
```

In general, it works with any NatVis command that understands collections, such as NatVis LINQ expressions:
```
0:000> dx some_64_bit_vec.Select(x => x * 2)
some_64_bit_vec.Select(x => x * 2)                
    [0]              : 0x8
    [1]              : 0x9e
    [2]              : 0x34
    [3]              : 0x308
```

std::string::String is implemented, as well:
```
0:000> dv
    hello_world = "Hello, world!"
          empty = ""
            new = ""
0:000> dx hello_world
hello_world                 : "Hello, world!" [Type: collections::string::String]
    [<Raw View>]     [Type: collections::string::String]
    [size]           : 0xd [Type: unsigned __int64]
    [capacity]       : 0xd [Type: unsigned __int64]
    [0]              : 72 'H' [Type: char]
    [1]              : 101 'e' [Type: char]
...
    [12]             : 33 '!' [Type: char]
0:000> dx empty
empty                 : "" [Type: collections::string::String]
    [<Raw View>]     [Type: collections::string::String]
    [size]           : 0x0 [Type: unsigned __int64]
    [capacity]       : 0x0 [Type: unsigned __int64]

```

VecDeque and LinkedList are also implemented.

My biggest concern is the implementation for Option due to the different layouts it can receive based on whether the sentinel value can be embedded with-in the Some value or must be stored separately.

It seems to work, but my testing isn't exhaustive:
```
0:000> dv
          three = { Some 3 }
           none = { None }
         no_str = { None }
       some_str = { Some "Hello!" }
0:000> dx three
three                 : { Some 3 } [Type: core::option::Option<i32>]
    [<Raw View>]     [Type: core::option::Option<i32>]
    [size]           : 0x1 [Type: ULONG]
    [value]          : 3 [Type: int]
    [0]              : 3 [Type: int]
0:000> dx none
none                 : { None } [Type: core::option::Option<i32>]
    [<Raw View>]     [Type: core::option::Option<i32>]
    [size]           : 0x0 [Type: ULONG]
    [value]          : 4 [Type: int]
0:000> dx no_str
no_str                 : { None } [Type: core::option::Option<collections::string::String>]
    [<Raw View>]     [Type: core::option::Option<collections::string::String>]
    [size]           : 0x0 [Type: ULONG]
0:000> dx some_str
some_str                 : { Some "Hello!" } [Type: core::option::Option<collections::string::String>]
    [<Raw View>]     [Type: core::option::Option<collections::string::String>]
    [size]           : 0x1 [Type: ULONG]
    [value]          : 0x4673df710 : "Hello!" [Type: collections::string::String *]
    [0]              : "Hello!" [Type: collections::string::String]
```

For now all of these visualizations work in windbg, but I've only gotten the visualizations in libcore.natvis working in the VS debugger. My priority is windbg, but somebody else may be interested in investigating the issues related to VS.

You can load these visualizations into a windbg sessions using the .nvload command:
```
0:000> .nvload ..\rust\src\etc\natvis\libcollections.natvis; .nvload ..\rust\src\etc\natvis\libcore.natvis
Successfully loaded visualizers in "..\rust\src\etc\natvis\libcollections.natvis"
Successfully loaded visualizers in "..\rust\src\etc\natvis\libcore.natvis"
```

There are some issues with the symbols that Rust and LLVM conspire to emit into the PDB that inhibit debugging in windbg generally, and by extension make writing visualizations more difficult. Additionally, there are some bugs in windbg itself that complicate or disable some use of the NatVis visualizations for Rust. Significantly, due to NatVis limitations in windbg around allowable type names, you cannot write a visualization for [T] or str. I'll report separate issues as I isolate them.

In the near term, I hope to fill out these NatVis files with more of Rust's core collections and types. In the long run, I hope that we can ship NatVis files with crates and streamline their deployment when debugging Rust programs on windows.