### PR TITLE
cleanup: remove the *san Cargo features from std

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -613,7 +613,7 @@ impl Build {
     /// Get the space-separated set of activated features for the standard
     /// library.
     fn std_features(&self) -> String {
-        let mut features = "panic-unwind asan lsan msan tsan".to_string();
+        let mut features = "panic-unwind".to_string();
 
         if self.config.debug_jemalloc {
             features.push_str(" debug-jemalloc");

--- a/src/librustc_asan/Cargo.toml
+++ b/src/librustc_asan/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.0.0"
 [lib]
 name = "rustc_asan"
 path = "lib.rs"
+test = false
 
 [build-dependencies]
 build_helper = { path = "../build_helper" }

--- a/src/librustc_lsan/Cargo.toml
+++ b/src/librustc_lsan/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.0.0"
 [lib]
 name = "rustc_lsan"
 path = "lib.rs"
+test = false
 
 [build-dependencies]
 build_helper = { path = "../build_helper" }

--- a/src/librustc_msan/Cargo.toml
+++ b/src/librustc_msan/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.0.0"
 [lib]
 name = "rustc_msan"
 path = "lib.rs"
+test = false
 
 [build-dependencies]
 build_helper = { path = "../build_helper" }

--- a/src/librustc_tsan/Cargo.toml
+++ b/src/librustc_tsan/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.0.0"
 [lib]
 name = "rustc_tsan"
 path = "lib.rs"
+test = false
 
 [build-dependencies]
 build_helper = { path = "../build_helper" }

--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -24,22 +24,18 @@ std_unicode = { path = "../libstd_unicode" }
 unwind = { path = "../libunwind" }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
-rustc_asan = { path = "../librustc_asan", optional = true }
-rustc_lsan = { path = "../librustc_lsan", optional = true }
-rustc_msan = { path = "../librustc_msan", optional = true }
-rustc_tsan = { path = "../librustc_tsan", optional = true }
+rustc_asan = { path = "../librustc_asan" }
+rustc_lsan = { path = "../librustc_lsan" }
+rustc_msan = { path = "../librustc_msan" }
+rustc_tsan = { path = "../librustc_tsan" }
 
 [build-dependencies]
 build_helper = { path = "../build_helper" }
 gcc = "0.3.27"
 
 [features]
-asan = ["rustc_asan"]
 backtrace = []
 debug-jemalloc = ["alloc_jemalloc/debug"]
 jemalloc = ["alloc_jemalloc"]
 force_alloc_system = []
-lsan = ["rustc_lsan"]
-msan = ["rustc_msan"]
 panic-unwind = ["panic_unwind"]
-tsan = ["rustc_tsan"]


### PR DESCRIPTION
these belong to a previous iteration of the sanitizer implementation

r? @alexcrichton
cc @whitequark