### PR TITLE
erase late bound regions in `get_vtable_methods()`

### DIFF
--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -628,6 +628,11 @@ pub fn get_vtable_methods<'a, 'tcx>(
                                           |_, _| tcx.mk_region(ty::ReErased),
                                           |def, _| trait_ref.substs().type_for_def(def));
 
+            // the trait type may have higher-ranked lifetimes in it;
+            // so erase them if they appear, so that we get the type
+            // at some particular call site
+            let substs = tcx.erase_late_bound_regions_and_normalize(&ty::Binder(substs));
+
             // It's possible that the method relies on where clauses that
             // do not hold for this particular set of type parameters.
             // Note that this method could then never be called, so we

--- a/src/librustc_trans/collector.rs
+++ b/src/librustc_trans/collector.rs
@@ -1090,12 +1090,15 @@ fn create_trans_items_for_vtable_methods<'a, 'tcx>(scx: &SharedCrateContext<'a, 
                                                    trait_ty: ty::Ty<'tcx>,
                                                    impl_ty: ty::Ty<'tcx>,
                                                    output: &mut Vec<TransItem<'tcx>>) {
-    assert!(!trait_ty.needs_subst() && !impl_ty.needs_subst());
+    assert!(!trait_ty.needs_subst() && !trait_ty.has_escaping_regions() &&
+            !impl_ty.needs_subst() && !impl_ty.has_escaping_regions());
 
     if let ty::TyDynamic(ref trait_ty, ..) = trait_ty.sty {
         if let Some(principal) = trait_ty.principal() {
             let poly_trait_ref = principal.with_self_ty(scx.tcx(), impl_ty);
             let param_substs = scx.tcx().intern_substs(&[]);
+
+            assert!(!poly_trait_ref.has_escaping_regions());
 
             // Walk all methods of the trait, including those of its supertraits
             let methods = traits::get_vtable_methods(scx.tcx(), poly_trait_ref);

--- a/src/test/run-pass/issue-39292.rs
+++ b/src/test/run-pass/issue-39292.rs
@@ -1,0 +1,26 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for issue #39292. The object vtable was being
+// incorrectly left with a null pointer.
+
+trait Foo<T> {
+    fn print<'a>(&'a self) where T: 'a { println!("foo"); }
+}
+
+impl<'a> Foo<&'a ()> for () { }
+
+trait Bar: for<'a> Foo<&'a ()> { }
+
+impl Bar for () {}
+
+fn main() {
+    (&() as &Bar).print(); // Segfault
+}


### PR DESCRIPTION
Higher-ranked object types can otherwise cause late-bound regions to
sneak into the substs, leading to the false conclusion that some method
is unreachable. 

r? @arielb1, who wrote the heart of this patch anyhow

Fixes #39292 