### PR TITLE
[WIP] Simplify mismatched types by removing same subtypes

### DIFF
--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2259,7 +2259,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     /// `DefId` is really just an interned def-path).
     ///
     /// Note that if `id` is not local to this crate, the result will
-    //  be a non-local `DefPath`.
+    ///  be a non-local `DefPath`.
     pub fn def_path(self, id: DefId) -> hir_map::DefPath {
         if id.is_local() {
             self.hir.def_path(id)

--- a/src/librustc_errors/diagnostic.rs
+++ b/src/librustc_errors/diagnostic.rs
@@ -81,8 +81,8 @@ impl Diagnostic {
 
     pub fn note_expected_found(&mut self,
                                label: &fmt::Display,
-                               expected: &fmt::Display,
-                               found: &fmt::Display)
+                               expected: &[(String, bool)],
+                               found: &[(String, bool)])
                                -> &mut Self
     {
         self.note_expected_found_extra(label, expected, found, &"", &"")
@@ -90,21 +90,23 @@ impl Diagnostic {
 
     pub fn note_expected_found_extra(&mut self,
                                      label: &fmt::Display,
-                                     expected: &fmt::Display,
-                                     found: &fmt::Display,
+                                     expected: &[(String, bool)],
+                                     found: &[(String, bool)],
                                      expected_extra: &fmt::Display,
                                      found_extra: &fmt::Display)
                                      -> &mut Self
     {
+        let mut msg: Vec<_> = vec![(format!("expected {} `", label), Style::NoStyle)];
+        msg.extend(expected.iter()
+                   .map(|x| (x.0.to_owned(), if x.1 { Style::Highlight } else { Style::NoStyle })));
+        msg.push((format!("`{}\n", expected_extra), Style::NoStyle));
+        msg.push((format!("   found {} `", label), Style::NoStyle));
+        msg.extend(found.iter()
+                   .map(|x| (x.0.to_owned(), if x.1 { Style::Highlight } else { Style::NoStyle })));
+        msg.push((format!("`{}", found_extra), Style::NoStyle));
+
         // For now, just attach these as notes
-        self.highlighted_note(vec![
-            (format!("expected {} `", label), Style::NoStyle),
-            (format!("{}", expected), Style::Highlight),
-            (format!("`{}\n", expected_extra), Style::NoStyle),
-            (format!("   found {} `", label), Style::NoStyle),
-            (format!("{}", found), Style::Highlight),
-            (format!("`{}", found_extra), Style::NoStyle),
-        ]);
+        self.highlighted_note(msg);
         self
     }
 

--- a/src/librustc_errors/diagnostic_builder.rs
+++ b/src/librustc_errors/diagnostic_builder.rs
@@ -115,14 +115,14 @@ impl<'a> DiagnosticBuilder<'a> {
 
     forward!(pub fn note_expected_found(&mut self,
                                         label: &fmt::Display,
-                                        expected: &fmt::Display,
-                                        found: &fmt::Display)
+                                        expected: &[(String, bool)],
+                                        found: &[(String, bool)])
                                         -> &mut Self);
 
     forward!(pub fn note_expected_found_extra(&mut self,
                                               label: &fmt::Display,
-                                              expected: &fmt::Display,
-                                              found: &fmt::Display,
+                                              expected: &[(String, bool)],
+                                              found: &[(String, bool)],
                                               expected_extra: &fmt::Display,
                                               found_extra: &fmt::Display)
                                               -> &mut Self);

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1037,7 +1037,9 @@ fn evaluate_disr_expr(ccx: &CrateCtxt, repr_ty: attr::IntType, body: hir::BodyId
     let ty_hint = repr_ty.to_ty(ccx.tcx);
     let print_err = |cv: ConstVal| {
         struct_span_err!(ccx.tcx.sess, e.span, E0079, "mismatched types")
-            .note_expected_found(&"type", &ty_hint, &format!("{}", cv.description()))
+            .note_expected_found(&"type",
+                                 &[(format!("{}", ty_hint), true)],
+                                 &[(format!("{}", cv.description()), true)])
             .span_label(e.span, &format!("expected '{}' type", ty_hint))
             .emit();
     };

--- a/src/test/ui/mismatched_types/abridged.rs
+++ b/src/test/ui/mismatched_types/abridged.rs
@@ -1,0 +1,57 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum Bar {
+    Qux,
+    Zar,
+}
+
+struct Foo {
+    bar: usize,
+}
+
+struct X<T1, T2> {
+    x: T1,
+    y: T2,
+}
+
+fn a() -> Foo {
+    Some(Foo { bar: 1 })
+}
+
+fn b() -> Option<Foo> {
+    Foo { bar: 1 }
+}
+
+fn c() -> Result<Foo, Bar> {
+    Foo { bar: 1 }
+}
+
+fn d() -> X<X<String, String>, String> {
+    X {
+        x: X {
+            x: "".to_string(),
+            y: 2,
+        },
+        y: 3,
+    }
+}
+
+fn e() -> X<X<String, String>, String> {
+    X {
+        x: X {
+            x: "".to_string(),
+            y: 2,
+        },
+        y: "".to_string(),
+    }
+}
+
+fn main() {}

--- a/src/test/ui/mismatched_types/abridged.stderr
+++ b/src/test/ui/mismatched_types/abridged.stderr
@@ -1,0 +1,63 @@
+error[E0308]: mismatched types
+  --> $DIR/abridged.rs:26:5
+   |
+26 |     Some(Foo { bar: 1 })
+   |     ^^^^^^^^^^^^^^^^^^^^ expected struct `Foo`, found enum `std::option::Option`
+   |
+   = note: expected type `Foo`
+              found type `std::option::Option<Foo>`
+   = help: here are some functions which might fulfill your needs:
+           - .unwrap()
+
+error[E0308]: mismatched types
+  --> $DIR/abridged.rs:30:5
+   |
+30 |     Foo { bar: 1 }
+   |     ^^^^^^^^^^^^^^ expected enum `std::option::Option`, found struct `Foo`
+   |
+   = note: expected type `std::option::Option<Foo>`
+              found type `Foo`
+
+error[E0308]: mismatched types
+  --> $DIR/abridged.rs:34:5
+   |
+34 |     Foo { bar: 1 }
+   |     ^^^^^^^^^^^^^^ expected enum `std::result::Result`, found struct `Foo`
+   |
+   = note: expected type `std::result::Result<Foo, Bar>`
+              found type `Foo`
+
+error[E0308]: mismatched types
+  --> $DIR/abridged.rs:38:5
+   |
+38 |       X {
+   |  _____^ starting here...
+39 | |         x: X {
+40 | |             x: "".to_string(),
+41 | |             y: 2,
+42 | |         },
+43 | |         y: 3,
+44 | |     }
+   | |_____^ ...ending here: expected struct `std::string::String`, found integral variable
+   |
+   = note: expected type `X<X<_, std::string::String>, std::string::String>`
+              found type `X<X<_, {integer}>, {integer}>`
+
+error[E0308]: mismatched types
+  --> $DIR/abridged.rs:48:5
+   |
+48 |       X {
+   |  _____^ starting here...
+49 | |         x: X {
+50 | |             x: "".to_string(),
+51 | |             y: 2,
+52 | |         },
+53 | |         y: "".to_string(),
+54 | |     }
+   | |_____^ ...ending here: expected struct `std::string::String`, found integral variable
+   |
+   = note: expected type `X<X<_, std::string::String>, _>`
+              found type `X<X<_, {integer}>, _>`
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
Simplify mismatched types errors by replacing subtypes that are not
different with `_`, and highlighting only the subtypes that are
different.

Given a file

```rust
struct X<T1, T2> {
    x: T1,
    y: T2,
}

fn foo() -> X<X<String, String>, String> {
    X { x: X {x: "".to_string(), y: 2}, y: "".to_string()}
}
```

provide the following output

```rust
error[E0308]: mismatched types
 --> file.rs:6:5
  |
6 |     X { x: X {x: "".to_string(), y: 2}, y: "".to_string()}
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `std::string::String`, found {integer}
  |
  = note: expected type `X<X<_, std::string::String>, _>`
             found type `X<X<_, {integer}>, _>`
```

Relates to #21025.