### PR TITLE
rework `TraitSelect` to avoid a vec and just use two def-ids

### DIFF
--- a/src/librustc_trans/context.rs
+++ b/src/librustc_trans/context.rs
@@ -208,7 +208,8 @@ impl<'gcx> DepTrackingMapConfig for ProjectionCache<'gcx> {
                    _ => None,
                })
                .collect();
-        DepNode::TraitSelect(def_ids)
+
+        DepNode::ProjectionCache { def_ids: def_ids }
     }
 }
 


### PR DESCRIPTION
r? @eddyb 