### PR TITLE
Report full details of inference errors

### DIFF
--- a/src/test/compile-fail/issue-17728.rs
+++ b/src/test/compile-fail/issue-17728.rs
@@ -108,9 +108,6 @@ impl Debug for Player {
 
 fn str_to_direction(to_parse: &str) -> RoomDirection {
     match to_parse { //~ ERROR match arms have incompatible types
-    //~^ expected enum `RoomDirection`, found enum `std::option::Option`
-    //~| expected type `RoomDirection`
-    //~| found type `std::option::Option<_>`
         "w" | "west" => RoomDirection::West,
         "e" | "east" => RoomDirection::East,
         "n" | "north" => RoomDirection::North,
@@ -119,7 +116,7 @@ fn str_to_direction(to_parse: &str) -> RoomDirection {
         "out" => RoomDirection::Out,
         "up" => RoomDirection::Up,
         "down" => RoomDirection::Down,
-        _ => None //~ NOTE match arm with an incompatible type
+        _ => None
     }
 }
 

--- a/src/test/run-pass/const-enum-vec-index.rs
+++ b/src/test/run-pass/const-enum-vec-index.rs
@@ -8,7 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[derive(Copy, Clone)]
 enum E { V1(isize), V0 }
+
 const C: &'static [E] = &[E::V0, E::V1(0xDEADBEE)];
 static C0: E = C[0];
 static C1: E = C[1];

--- a/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else.rs
+++ b/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else.rs
@@ -1,0 +1,15 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn foo<'a>(x: &'a i32, y: &i32) -> &'a i32 {
+    if x > y { x } else { y }
+}
+
+fn main() { }

--- a/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else.stderr
+++ b/src/test/ui/lifetime-errors/ex1-return-one-existing-name-if-else.stderr
@@ -1,0 +1,25 @@
+error[E0312]: lifetime of reference outlives lifetime of borrowed content...
+  --> $DIR/ex1-return-one-existing-name-if-else.rs:12:27
+   |
+12 |     if x > y { x } else { y }
+   |                           ^
+   |
+note: ...the reference is valid for the lifetime 'a as defined on the body at 11:43...
+  --> $DIR/ex1-return-one-existing-name-if-else.rs:11:44
+   |
+11 |   fn foo<'a>(x: &'a i32, y: &i32) -> &'a i32 {
+   |  ____________________________________________^ starting here...
+12 | |     if x > y { x } else { y }
+13 | | }
+   | |_^ ...ending here
+note: ...but the borrowed content is only valid for the anonymous lifetime #1 defined on the body at 11:43
+  --> $DIR/ex1-return-one-existing-name-if-else.rs:11:44
+   |
+11 |   fn foo<'a>(x: &'a i32, y: &i32) -> &'a i32 {
+   |  ____________________________________________^ starting here...
+12 | |     if x > y { x } else { y }
+13 | | }
+   | |_^ ...ending here
+
+error: aborting due to previous error
+

--- a/src/test/ui/lifetime-errors/ex1b-return-no-names-if-else.rs
+++ b/src/test/ui/lifetime-errors/ex1b-return-no-names-if-else.rs
@@ -1,0 +1,15 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn foo(x: &i32, y: &i32) -> &i32 {
+    if x > y { x } else { y }
+}
+
+fn main() { }

--- a/src/test/ui/lifetime-errors/ex1b-return-no-names-if-else.stderr
+++ b/src/test/ui/lifetime-errors/ex1b-return-no-names-if-else.stderr
@@ -1,0 +1,10 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/ex1b-return-no-names-if-else.rs:11:29
+   |
+11 | fn foo(x: &i32, y: &i32) -> &i32 {
+   |                             ^ expected lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `x` or `y`
+
+error: aborting due to previous error
+

--- a/src/test/ui/lifetime-errors/ex2a-push-one-existing-name.rs
+++ b/src/test/ui/lifetime-errors/ex2a-push-one-existing-name.rs
@@ -1,0 +1,19 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Ref<'a, T: 'a> {
+    data: &'a T
+}
+
+fn foo<'a>(x: &mut Vec<Ref<'a, i32>>, y: Ref<i32>) {
+    x.push(y);
+}
+
+fn main() { }

--- a/src/test/ui/lifetime-errors/ex2a-push-one-existing-name.stderr
+++ b/src/test/ui/lifetime-errors/ex2a-push-one-existing-name.stderr
@@ -1,0 +1,27 @@
+error[E0308]: mismatched types
+  --> $DIR/ex2a-push-one-existing-name.rs:16:12
+   |
+16 |     x.push(y);
+   |            ^ lifetime mismatch
+   |
+   = note: expected type `Ref<'a, i32>`
+              found type `Ref<'_, i32>`
+note: the anonymous lifetime #2 defined on the body at 15:51...
+  --> $DIR/ex2a-push-one-existing-name.rs:15:52
+   |
+15 |   fn foo<'a>(x: &mut Vec<Ref<'a, i32>>, y: Ref<i32>) {
+   |  ____________________________________________________^ starting here...
+16 | |     x.push(y);
+17 | | }
+   | |_^ ...ending here
+note: ...does not necessarily outlive the lifetime 'a as defined on the body at 15:51
+  --> $DIR/ex2a-push-one-existing-name.rs:15:52
+   |
+15 |   fn foo<'a>(x: &mut Vec<Ref<'a, i32>>, y: Ref<i32>) {
+   |  ____________________________________________________^ starting here...
+16 | |     x.push(y);
+17 | | }
+   | |_^ ...ending here
+
+error: aborting due to previous error
+

--- a/src/test/ui/lifetime-errors/ex2b-push-no-existing-names.rs
+++ b/src/test/ui/lifetime-errors/ex2b-push-no-existing-names.rs
@@ -1,0 +1,19 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Ref<'a, T: 'a> {
+    data: &'a T
+}
+
+fn foo(x: &mut Vec<Ref<i32>>, y: Ref<i32>) {
+    x.push(y);
+}
+
+fn main() { }

--- a/src/test/ui/lifetime-errors/ex2b-push-no-existing-names.stderr
+++ b/src/test/ui/lifetime-errors/ex2b-push-no-existing-names.stderr
@@ -1,0 +1,27 @@
+error[E0308]: mismatched types
+  --> $DIR/ex2b-push-no-existing-names.rs:16:12
+   |
+16 |     x.push(y);
+   |            ^ lifetime mismatch
+   |
+   = note: expected type `Ref<'_, i32>`
+              found type `Ref<'_, i32>`
+note: the anonymous lifetime #3 defined on the body at 15:43...
+  --> $DIR/ex2b-push-no-existing-names.rs:15:44
+   |
+15 |   fn foo(x: &mut Vec<Ref<i32>>, y: Ref<i32>) {
+   |  ____________________________________________^ starting here...
+16 | |     x.push(y);
+17 | | }
+   | |_^ ...ending here
+note: ...does not necessarily outlive the anonymous lifetime #2 defined on the body at 15:43
+  --> $DIR/ex2b-push-no-existing-names.rs:15:44
+   |
+15 |   fn foo(x: &mut Vec<Ref<i32>>, y: Ref<i32>) {
+   |  ____________________________________________^ starting here...
+16 | |     x.push(y);
+17 | | }
+   | |_^ ...ending here
+
+error: aborting due to previous error
+

--- a/src/test/ui/lifetime-errors/ex2c-push-inference-variable.rs
+++ b/src/test/ui/lifetime-errors/ex2c-push-inference-variable.rs
@@ -1,0 +1,20 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Ref<'a, T: 'a> {
+    data: &'a T
+}
+
+fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
+    let z = Ref { data: y.data };
+    x.push(z);
+}
+
+fn main() { }

--- a/src/test/ui/lifetime-errors/ex2c-push-inference-variable.stderr
+++ b/src/test/ui/lifetime-errors/ex2c-push-inference-variable.stderr
@@ -3,6 +3,35 @@ error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` d
    |
 16 |     let z = Ref { data: y.data };
    |             ^^^
+   |
+note: first, the lifetime cannot outlive the lifetime 'c as defined on the body at 15:66...
+  --> $DIR/ex2c-push-inference-variable.rs:15:67
+   |
+15 |   fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
+   |  ___________________________________________________________________^ starting here...
+16 | |     let z = Ref { data: y.data };
+17 | |     x.push(z);
+18 | | }
+   | |_^ ...ending here
+note: ...so that reference does not outlive borrowed content
+  --> $DIR/ex2c-push-inference-variable.rs:16:25
+   |
+16 |     let z = Ref { data: y.data };
+   |                         ^^^^^^
+note: but, the lifetime must be valid for the lifetime 'b as defined on the body at 15:66...
+  --> $DIR/ex2c-push-inference-variable.rs:15:67
+   |
+15 |   fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
+   |  ___________________________________________________________________^ starting here...
+16 | |     let z = Ref { data: y.data };
+17 | |     x.push(z);
+18 | | }
+   | |_^ ...ending here
+note: ...so that expression is assignable (expected Ref<'b, i32>, found Ref<'_, i32>)
+  --> $DIR/ex2c-push-inference-variable.rs:17:12
+   |
+17 |     x.push(z);
+   |            ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex2c-push-inference-variable.stderr
+++ b/src/test/ui/lifetime-errors/ex2c-push-inference-variable.stderr
@@ -1,0 +1,8 @@
+error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
+  --> $DIR/ex2c-push-inference-variable.rs:16:13
+   |
+16 |     let z = Ref { data: y.data };
+   |             ^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/lifetime-errors/ex2d-push-inference-variable-2.rs
+++ b/src/test/ui/lifetime-errors/ex2d-push-inference-variable-2.rs
@@ -1,0 +1,21 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Ref<'a, T: 'a> {
+    data: &'a T
+}
+
+fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
+    let a: &mut Vec<Ref<i32>> = x;
+    let b = Ref { data: y.data };
+    a.push(b);
+}
+
+fn main() { }

--- a/src/test/ui/lifetime-errors/ex2d-push-inference-variable-2.stderr
+++ b/src/test/ui/lifetime-errors/ex2d-push-inference-variable-2.stderr
@@ -3,6 +3,37 @@ error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` d
    |
 17 |     let b = Ref { data: y.data };
    |             ^^^
+   |
+note: first, the lifetime cannot outlive the lifetime 'c as defined on the body at 15:66...
+  --> $DIR/ex2d-push-inference-variable-2.rs:15:67
+   |
+15 |   fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
+   |  ___________________________________________________________________^ starting here...
+16 | |     let a: &mut Vec<Ref<i32>> = x;
+17 | |     let b = Ref { data: y.data };
+18 | |     a.push(b);
+19 | | }
+   | |_^ ...ending here
+note: ...so that reference does not outlive borrowed content
+  --> $DIR/ex2d-push-inference-variable-2.rs:17:25
+   |
+17 |     let b = Ref { data: y.data };
+   |                         ^^^^^^
+note: but, the lifetime must be valid for the lifetime 'b as defined on the body at 15:66...
+  --> $DIR/ex2d-push-inference-variable-2.rs:15:67
+   |
+15 |   fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
+   |  ___________________________________________________________________^ starting here...
+16 | |     let a: &mut Vec<Ref<i32>> = x;
+17 | |     let b = Ref { data: y.data };
+18 | |     a.push(b);
+19 | | }
+   | |_^ ...ending here
+note: ...so that expression is assignable (expected &mut std::vec::Vec<Ref<'_, i32>>, found &mut std::vec::Vec<Ref<'b, i32>>)
+  --> $DIR/ex2d-push-inference-variable-2.rs:16:33
+   |
+16 |     let a: &mut Vec<Ref<i32>> = x;
+   |                                 ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex2d-push-inference-variable-2.stderr
+++ b/src/test/ui/lifetime-errors/ex2d-push-inference-variable-2.stderr
@@ -1,0 +1,8 @@
+error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
+  --> $DIR/ex2d-push-inference-variable-2.rs:17:13
+   |
+17 |     let b = Ref { data: y.data };
+   |             ^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/lifetime-errors/ex2e-push-inference-variable-3.rs
+++ b/src/test/ui/lifetime-errors/ex2e-push-inference-variable-3.rs
@@ -1,0 +1,21 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Ref<'a, T: 'a> {
+    data: &'a T
+}
+
+fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
+    let a: &mut Vec<Ref<i32>> = x;
+    let b = Ref { data: y.data };
+    Vec::push(a, b);
+}
+
+fn main() { }

--- a/src/test/ui/lifetime-errors/ex2e-push-inference-variable-3.stderr
+++ b/src/test/ui/lifetime-errors/ex2e-push-inference-variable-3.stderr
@@ -3,6 +3,37 @@ error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` d
    |
 17 |     let b = Ref { data: y.data };
    |             ^^^
+   |
+note: first, the lifetime cannot outlive the lifetime 'c as defined on the body at 15:66...
+  --> $DIR/ex2e-push-inference-variable-3.rs:15:67
+   |
+15 |   fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
+   |  ___________________________________________________________________^ starting here...
+16 | |     let a: &mut Vec<Ref<i32>> = x;
+17 | |     let b = Ref { data: y.data };
+18 | |     Vec::push(a, b);
+19 | | }
+   | |_^ ...ending here
+note: ...so that reference does not outlive borrowed content
+  --> $DIR/ex2e-push-inference-variable-3.rs:17:25
+   |
+17 |     let b = Ref { data: y.data };
+   |                         ^^^^^^
+note: but, the lifetime must be valid for the lifetime 'b as defined on the body at 15:66...
+  --> $DIR/ex2e-push-inference-variable-3.rs:15:67
+   |
+15 |   fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {
+   |  ___________________________________________________________________^ starting here...
+16 | |     let a: &mut Vec<Ref<i32>> = x;
+17 | |     let b = Ref { data: y.data };
+18 | |     Vec::push(a, b);
+19 | | }
+   | |_^ ...ending here
+note: ...so that expression is assignable (expected &mut std::vec::Vec<Ref<'_, i32>>, found &mut std::vec::Vec<Ref<'b, i32>>)
+  --> $DIR/ex2e-push-inference-variable-3.rs:16:33
+   |
+16 |     let a: &mut Vec<Ref<i32>> = x;
+   |                                 ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/lifetime-errors/ex2e-push-inference-variable-3.stderr
+++ b/src/test/ui/lifetime-errors/ex2e-push-inference-variable-3.stderr
@@ -1,0 +1,8 @@
+error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
+  --> $DIR/ex2e-push-inference-variable-3.rs:17:13
+   |
+17 |     let b = Ref { data: y.data };
+   |             ^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
When the old suggestion machinery was removed by @brson in https://github.com/rust-lang/rust/pull/37057, it was not completely removed. There was a bit of code that had the job of going through errors and finding those for which suggestions were applicable, and it remained, causing us not to emit the full details of such errors.  This PR removes that.

I've also added various lifetime tests to the UI test suite (so you can also see the before/after there). I have some concrete thoughts on how to improve these cases and am planning on writing those up in some mentoring issues (@CengizIO has expressed interest in working on those changes, so I plan to work with him on it, at least to start).

cc @jonathandturner 