### PR TITLE
transition borrowck to visit all **bodies** and not item-likes

### DIFF
--- a/src/librustc/cfg/mod.rs
+++ b/src/librustc/cfg/mod.rs
@@ -59,7 +59,7 @@ pub type CFGEdge = graph::Edge<CFGEdgeData>;
 
 impl CFG {
     pub fn new<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                         body: &hir::Expr) -> CFG {
+                         body: &hir::Body) -> CFG {
         construct::construct(tcx, body)
     }
 

--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -115,6 +115,7 @@ pub enum DepNode<D: Clone + Debug> {
     SizedConstraint(D),
     AssociatedItemDefIds(D),
     InherentImpls(D),
+    TypeckBodiesKrate,
     TypeckTables(D),
     UsedTraitImports(D),
     MonomorphicConstEval(D),
@@ -211,6 +212,7 @@ impl<D: Clone + Debug> DepNode<D> {
         match *self {
             Krate => Some(Krate),
             BorrowCheckKrate => Some(BorrowCheckKrate),
+            TypeckBodiesKrate => Some(TypeckBodiesKrate),
             CollectLanguageItems => Some(CollectLanguageItems),
             CheckStaticRecursion => Some(CheckStaticRecursion),
             ResolveLifetimes => Some(ResolveLifetimes),

--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -91,6 +91,7 @@ pub enum DepNode<D: Clone + Debug> {
     // things read/modify that MIR.
     Mir(D),
 
+    BorrowCheckKrate,
     BorrowCheck(D),
     RvalueCheck(D),
     Reachability,
@@ -209,6 +210,7 @@ impl<D: Clone + Debug> DepNode<D> {
 
         match *self {
             Krate => Some(Krate),
+            BorrowCheckKrate => Some(BorrowCheckKrate),
             CollectLanguageItems => Some(CollectLanguageItems),
             CheckStaticRecursion => Some(CheckStaticRecursion),
             ResolveLifetimes => Some(ResolveLifetimes),

--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -89,6 +89,7 @@ pub enum DepNode<D: Clone + Debug> {
 
     // Represents the MIR for a fn; also used as the task node for
     // things read/modify that MIR.
+    MirKrate,
     Mir(D),
 
     BorrowCheckKrate,
@@ -212,6 +213,7 @@ impl<D: Clone + Debug> DepNode<D> {
         match *self {
             Krate => Some(Krate),
             BorrowCheckKrate => Some(BorrowCheckKrate),
+            MirKrate => Some(MirKrate),
             TypeckBodiesKrate => Some(TypeckBodiesKrate),
             CollectLanguageItems => Some(CollectLanguageItems),
             CheckStaticRecursion => Some(CheckStaticRecursion),

--- a/src/librustc/dep_graph/mod.rs
+++ b/src/librustc/dep_graph/mod.rs
@@ -25,5 +25,6 @@ pub use self::dep_node::WorkProductId;
 pub use self::graph::DepGraph;
 pub use self::graph::WorkProduct;
 pub use self::query::DepGraphQuery;
+pub use self::visit::visit_all_bodies_in_krate;
 pub use self::visit::visit_all_item_likes_in_krate;
 pub use self::raii::DepTask;

--- a/src/librustc/dep_graph/visit.rs
+++ b/src/librustc/dep_graph/visit.rs
@@ -74,3 +74,13 @@ pub fn visit_all_item_likes_in_krate<'a, 'tcx, V, F>(tcx: TyCtxt<'a, 'tcx, 'tcx>
     };
     krate.visit_all_item_likes(&mut tracking_visitor)
 }
+
+pub fn visit_all_bodies_in_krate<'a, 'tcx, C>(tcx: TyCtxt<'a, 'tcx, 'tcx>, callback: C)
+    where C: Fn(/* body_owner */ DefId, /* body id */ hir::BodyId),
+{
+    let krate = tcx.hir.krate();
+    for body_id in krate.bodies.keys().cloned() {
+        let body_owner_def_id = tcx.hir.body_owner_def_id(body_id);
+        callback(body_owner_def_id, body_id);
+    }
+}

--- a/src/librustc/dep_graph/visit.rs
+++ b/src/librustc/dep_graph/visit.rs
@@ -11,6 +11,7 @@
 use hir;
 use hir::def_id::DefId;
 use hir::itemlikevisit::ItemLikeVisitor;
+use hir::intravisit::{self, NestedVisitorMap, Visitor};
 use ty::TyCtxt;
 
 use super::dep_node::DepNode;
@@ -78,9 +79,30 @@ pub fn visit_all_item_likes_in_krate<'a, 'tcx, V, F>(tcx: TyCtxt<'a, 'tcx, 'tcx>
 pub fn visit_all_bodies_in_krate<'a, 'tcx, C>(tcx: TyCtxt<'a, 'tcx, 'tcx>, callback: C)
     where C: Fn(/* body_owner */ DefId, /* body id */ hir::BodyId),
 {
+    // NB: we use a visitor here rather than walking the keys of the
+    // hashmap so as to ensure we visit the bodies "in order".
+
     let krate = tcx.hir.krate();
-    for body_id in krate.bodies.keys().cloned() {
-        let body_owner_def_id = tcx.hir.body_owner_def_id(body_id);
-        callback(body_owner_def_id, body_id);
+    intravisit::walk_crate(&mut V { tcx, callback }, krate);
+
+    struct V<'a, 'tcx: 'a, C> {
+        tcx: TyCtxt<'a, 'tcx, 'tcx>,
+        callback: C
+    }
+
+    impl<'a, 'tcx, C> Visitor<'tcx> for V<'a, 'tcx, C>
+        where C: Fn(/* body_owner */ DefId, /* body id */ hir::BodyId),
+    {
+        fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
+            NestedVisitorMap::All(&self.tcx.hir)
+        }
+
+        fn visit_body(&mut self, body: &'tcx hir::Body) {
+            let body_id = body.id();
+            let body_owner_def_id = self.tcx.hir.body_owner_def_id(body_id);
+            (self.callback)(body_owner_def_id, body_id);
+
+            intravisit::walk_body(self, body);
+        }
     }
 }

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -196,6 +196,7 @@ impl<'a> LoweringContext<'a> {
         let module = self.lower_mod(&c.module);
         let attrs = self.lower_attrs(&c.attrs);
         let exported_macros = c.exported_macros.iter().map(|m| self.lower_macro_def(m)).collect();
+        let body_ids = body_ids(&self.bodies);
 
         hir::Crate {
             module: module,
@@ -206,6 +207,7 @@ impl<'a> LoweringContext<'a> {
             trait_items: self.trait_items,
             impl_items: self.impl_items,
             bodies: self.bodies,
+            body_ids: body_ids,
             trait_impls: self.trait_impls,
             trait_default_impl: self.trait_default_impl,
         }
@@ -2523,4 +2525,12 @@ impl<'a> LoweringContext<'a> {
             name: keywords::Invalid.name()
         }
     }
+}
+
+fn body_ids(bodies: &BTreeMap<hir::BodyId, hir::Body>) -> Vec<hir::BodyId> {
+    // Sorting by span ensures that we get things in order within a
+    // file, and also puts the files in a sensible order.
+    let mut body_ids: Vec<_> = bodies.keys().cloned().collect();
+    body_ids.sort_by_key(|b| bodies[b].value.span);
+    body_ids
 }

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -46,7 +46,7 @@ use hir::map::definitions::DefPathData;
 use hir::def_id::{DefIndex, DefId};
 use hir::def::{Def, PathResolution};
 use session::Session;
-use util::nodemap::{DefIdMap, NodeMap, FxHashMap};
+use util::nodemap::{DefIdMap, NodeMap};
 
 use std::collections::BTreeMap;
 use std::iter;
@@ -78,7 +78,7 @@ pub struct LoweringContext<'a> {
 
     trait_items: BTreeMap<hir::TraitItemId, hir::TraitItem>,
     impl_items: BTreeMap<hir::ImplItemId, hir::ImplItem>,
-    bodies: FxHashMap<hir::BodyId, hir::Body>,
+    bodies: BTreeMap<hir::BodyId, hir::Body>,
 
     trait_impls: BTreeMap<DefId, Vec<NodeId>>,
     trait_default_impl: BTreeMap<DefId, NodeId>,
@@ -118,7 +118,7 @@ pub fn lower_crate(sess: &Session,
         items: BTreeMap::new(),
         trait_items: BTreeMap::new(),
         impl_items: BTreeMap::new(),
-        bodies: FxHashMap(),
+        bodies: BTreeMap::new(),
         trait_impls: BTreeMap::new(),
         trait_default_impl: BTreeMap::new(),
         loop_scopes: Vec::new(),

--- a/src/librustc/hir/map/def_collector.rs
+++ b/src/librustc/hir/map/def_collector.rs
@@ -259,6 +259,7 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
             TyKind::ImplTrait(..) => {
                 self.create_def(ty.id, DefPathData::ImplTrait);
             }
+            TyKind::Typeof(ref expr) => self.visit_ast_const_integer(expr),
             _ => {}
         }
         visit::walk_ty(self, ty);

--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -260,7 +260,9 @@ pub enum DefPathData {
     /// Pattern binding
     Binding(InternedString),
     /// An `impl Trait` type node.
-    ImplTrait
+    ImplTrait,
+    /// A `typeof` type node.
+    Typeof,
 }
 
 impl Definitions {
@@ -387,7 +389,8 @@ impl DefPathData {
             ClosureExpr |
             StructCtor |
             Initializer |
-            ImplTrait => None
+            ImplTrait |
+            Typeof => None
         }
     }
 
@@ -415,6 +418,7 @@ impl DefPathData {
             StructCtor => "{{constructor}}",
             Initializer => "{{initializer}}",
             ImplTrait => "{{impl-Trait}}",
+            Typeof => "{{typeof}}",
         };
 
         Symbol::intern(s).as_str()

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -168,43 +168,48 @@ impl<'hir> MapEntry<'hir> {
         })
     }
 
-    fn is_body_owner(self, node_id: NodeId) -> bool {
+    fn associated_body(self) -> Option<BodyId> {
         match self {
             EntryItem(_, item) => {
                 match item.node {
                     ItemConst(_, body) |
                     ItemStatic(.., body) |
-                    ItemFn(_, _, _, _, _, body) => body.node_id == node_id,
-                    _ => false
+                    ItemFn(_, _, _, _, _, body) => Some(body),
+                    _ => None,
                 }
             }
 
             EntryTraitItem(_, item) => {
                 match item.node {
                     TraitItemKind::Const(_, Some(body)) |
-                    TraitItemKind::Method(_, TraitMethod::Provided(body)) => {
-                        body.node_id == node_id
-                    }
-                    _ => false
+                    TraitItemKind::Method(_, TraitMethod::Provided(body)) => Some(body),
+                    _ => None
                 }
             }
 
             EntryImplItem(_, item) => {
                 match item.node {
                     ImplItemKind::Const(_, body) |
-                    ImplItemKind::Method(_, body) => body.node_id == node_id,
-                    _ => false
+                    ImplItemKind::Method(_, body) => Some(body),
+                    _ => None,
                 }
             }
 
             EntryExpr(_, expr) => {
                 match expr.node {
-                    ExprClosure(.., body, _) => body.node_id == node_id,
-                    _ => false
+                    ExprClosure(.., body, _) => Some(body),
+                    _ => None,
                 }
             }
 
-            _ => false
+            _ => None
+        }
+    }
+
+    fn is_body_owner(self, node_id: NodeId) -> bool {
+        match self.associated_body() {
+            Some(b) => b.node_id == node_id,
+            None => false,
         }
     }
 }

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -31,7 +31,7 @@ pub use self::PathParameters::*;
 
 use hir::def::Def;
 use hir::def_id::DefId;
-use util::nodemap::{NodeMap, FxHashMap, FxHashSet};
+use util::nodemap::{NodeMap, FxHashSet};
 
 use syntax_pos::{Span, ExpnId, DUMMY_SP};
 use syntax::codemap::{self, Spanned};
@@ -409,8 +409,7 @@ pub struct Crate {
 
     pub trait_items: BTreeMap<TraitItemId, TraitItem>,
     pub impl_items: BTreeMap<ImplItemId, ImplItem>,
-    pub bodies: FxHashMap<BodyId, Body>,
-
+    pub bodies: BTreeMap<BodyId, Body>,
     pub trait_impls: BTreeMap<DefId, Vec<NodeId>>,
     pub trait_default_impl: BTreeMap<DefId, NodeId>,
 }

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -412,6 +412,12 @@ pub struct Crate {
     pub bodies: BTreeMap<BodyId, Body>,
     pub trait_impls: BTreeMap<DefId, Vec<NodeId>>,
     pub trait_default_impl: BTreeMap<DefId, NodeId>,
+
+    /// A list of the body ids written out in the order in which they
+    /// appear in the crate. If you're going to process all the bodies
+    /// in the crate, you should iterate over this list rather than the keys
+    /// of bodies.
+    pub body_ids: Vec<BodyId>,
 }
 
 impl Crate {

--- a/src/librustc/middle/free_region.rs
+++ b/src/librustc/middle/free_region.rs
@@ -19,7 +19,7 @@ use ty::{self, TyCtxt, FreeRegion, Region};
 use ty::wf::ImpliedBound;
 use rustc_data_structures::transitive_relation::TransitiveRelation;
 
-#[derive(Clone)]
+#[derive(Clone, RustcEncodable, RustcDecodable)]
 pub struct FreeRegionMap {
     // Stores the relation `a < b`, where `a` and `b` are regions.
     relation: TransitiveRelation<Region>
@@ -28,6 +28,10 @@ pub struct FreeRegionMap {
 impl FreeRegionMap {
     pub fn new() -> FreeRegionMap {
         FreeRegionMap { relation: TransitiveRelation::new() }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.relation.is_empty()
     }
 
     pub fn relate_free_regions_from_implied_bounds<'tcx>(&mut self,

--- a/src/librustc/ty/item_path.rs
+++ b/src/librustc/ty/item_path.rs
@@ -180,7 +180,8 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             data @ DefPathData::MacroDef(..) |
             data @ DefPathData::ClosureExpr |
             data @ DefPathData::Binding(..) |
-            data @ DefPathData::ImplTrait => {
+            data @ DefPathData::ImplTrait |
+            data @ DefPathData::Typeof => {
                 let parent_def_id = self.parent_def_id(def_id).unwrap();
                 self.push_item_path(buffer, parent_def_id);
                 buffer.push(&data.as_interned_str());

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2613,6 +2613,17 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         dep_graph::visit_all_item_likes_in_krate(self.global_tcx(), dep_node_fn, visitor);
     }
 
+    /// Invokes `callback` for each body in the krate. This will
+    /// create a read edge from `DepNode::Krate` to the current task;
+    /// it is meant to be run in the context of some global task like
+    /// `BorrowckCrate`. The callback would then create a task like
+    /// `BorrowckBody(DefId)` to process each individual item.
+    pub fn visit_all_bodies_in_krate<C>(self, callback: C)
+        where C: Fn(/* body_owner */ DefId, /* body id */ hir::BodyId),
+    {
+        dep_graph::visit_all_bodies_in_krate(self.global_tcx(), callback)
+    }
+
     /// Looks up the span of `impl_did` if the impl is local; otherwise returns `Err`
     /// with the name of the crate containing the impl.
     pub fn span_of_impl(self, impl_did: DefId) -> Result<Span, Symbol> {

--- a/src/librustc_borrowck/borrowck/fragments.rs
+++ b/src/librustc_borrowck/borrowck/fragments.rs
@@ -27,7 +27,7 @@ use rustc::middle::mem_categorization as mc;
 use std::mem;
 use std::rc::Rc;
 use syntax::ast;
-use syntax_pos::{Span, DUMMY_SP};
+use syntax_pos::DUMMY_SP;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 enum Fragment {
@@ -200,13 +200,14 @@ impl FragmentSets {
 
 pub fn instrument_move_fragments<'a, 'tcx>(this: &MoveData<'tcx>,
                                            tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                                           sp: Span,
                                            id: ast::NodeId) {
     let span_err = tcx.hir.attrs(id).iter()
                           .any(|a| a.check_name("rustc_move_fragments"));
     let print = tcx.sess.opts.debugging_opts.print_move_fragments;
 
     if !span_err && !print { return; }
+
+    let sp = tcx.hir.span(id);
 
     let instrument_all_paths = |kind, vec_rc: &Vec<MovePathIndex>| {
         for (i, mpi) in vec_rc.iter().enumerate() {

--- a/src/librustc_borrowck/borrowck/gather_loans/mod.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/mod.rs
@@ -547,8 +547,14 @@ impl<'a, 'tcx> Visitor<'tcx> for StaticInitializerCtxt<'a, 'tcx> {
     }
 }
 
-pub fn gather_loans_in_static_initializer(bccx: &mut BorrowckCtxt, body: hir::BodyId) {
+pub fn gather_loans_in_static_initializer<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
+                                                    body: hir::BodyId) {
     debug!("gather_loans_in_static_initializer(expr={:?})", body);
+
+    let bccx = &BorrowckCtxt {
+        tcx: tcx,
+        tables: None
+    };
 
     let mut sicx = StaticInitializerCtxt {
         bccx: bccx,

--- a/src/librustc_borrowck/borrowck/gather_loans/mod.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/mod.rs
@@ -28,9 +28,6 @@ use rustc::ty::{self, TyCtxt};
 use syntax::ast;
 use syntax_pos::Span;
 use rustc::hir;
-use rustc::hir::Expr;
-use rustc::hir::intravisit;
-use rustc::hir::intravisit::{Visitor, NestedVisitorMap};
 
 use self::restrictions::RestrictionResult;
 
@@ -514,53 +511,3 @@ impl<'a, 'tcx> GatherLoanCtxt<'a, 'tcx> {
     }
 }
 
-/// Context used while gathering loans on static initializers
-///
-/// This visitor walks static initializer's expressions and makes
-/// sure the loans being taken are sound.
-struct StaticInitializerCtxt<'a, 'tcx: 'a> {
-    bccx: &'a BorrowckCtxt<'a, 'tcx>,
-    body_id: hir::BodyId,
-}
-
-impl<'a, 'tcx> Visitor<'tcx> for StaticInitializerCtxt<'a, 'tcx> {
-    fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
-        NestedVisitorMap::None
-    }
-
-    fn visit_expr(&mut self, ex: &'tcx Expr) {
-        if let hir::ExprAddrOf(mutbl, ref base) = ex.node {
-            let infcx = self.bccx.tcx.borrowck_fake_infer_ctxt(self.body_id);
-            let mc = mc::MemCategorizationContext::new(&infcx);
-            let base_cmt = mc.cat_expr(&base).unwrap();
-            let borrow_kind = ty::BorrowKind::from_mutbl(mutbl);
-            // Check that we don't allow borrows of unsafe static items.
-            let err = check_aliasability(self.bccx, ex.span,
-                                         BorrowViolation(euv::AddrOf),
-                                         base_cmt, borrow_kind).is_err();
-            if err {
-                return; // reported an error, no sense in reporting more.
-            }
-        }
-
-        intravisit::walk_expr(self, ex);
-    }
-}
-
-pub fn gather_loans_in_static_initializer<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                                                    body: hir::BodyId) {
-    debug!("gather_loans_in_static_initializer(expr={:?})", body);
-
-    let bccx = &BorrowckCtxt {
-        tcx: tcx,
-        tables: None
-    };
-
-    let mut sicx = StaticInitializerCtxt {
-        bccx: bccx,
-        body_id: body
-    };
-
-    let body = sicx.bccx.tcx.hir.body(body);
-    sicx.visit_body(body);
-}

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -104,33 +104,9 @@ pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>) {
     let mut bccx = BorrowckCtxt {
         tcx: tcx,
         tables: None,
-        stats: BorrowStats {
-            loaned_paths_same: 0,
-            loaned_paths_imm: 0,
-            stable_paths: 0,
-            guaranteed_paths: 0
-        }
     };
 
     tcx.visit_all_item_likes_in_krate(DepNode::BorrowCheck, &mut bccx.as_deep_visitor());
-
-    if tcx.sess.borrowck_stats() {
-        println!("--- borrowck stats ---");
-        println!("paths requiring guarantees: {}",
-                 bccx.stats.guaranteed_paths);
-        println!("paths requiring loans     : {}",
-                 make_stat(&bccx, bccx.stats.loaned_paths_same));
-        println!("paths requiring imm loans : {}",
-                 make_stat(&bccx, bccx.stats.loaned_paths_imm));
-        println!("stable paths              : {}",
-                 make_stat(&bccx, bccx.stats.stable_paths));
-    }
-
-    fn make_stat(bccx: &BorrowckCtxt, stat: usize) -> String {
-        let total = bccx.stats.guaranteed_paths as f64;
-        let perc = if total == 0.0 { 0.0 } else { stat as f64 * 100.0 / total };
-        format!("{} ({:.0}%)", stat, perc)
-    }
 }
 
 fn borrowck_item<'a, 'tcx>(this: &mut BorrowckCtxt<'a, 'tcx>, item: &'tcx hir::Item) {
@@ -245,12 +221,6 @@ pub fn build_borrowck_dataflow_data_for_fn<'a, 'tcx>(
     let mut bccx = BorrowckCtxt {
         tcx: tcx,
         tables: None,
-        stats: BorrowStats {
-            loaned_paths_same: 0,
-            loaned_paths_imm: 0,
-            stable_paths: 0,
-            guaranteed_paths: 0
-        }
     };
 
     let dataflow_data = build_borrowck_dataflow_data(&mut bccx, cfg, body);
@@ -266,17 +236,6 @@ pub struct BorrowckCtxt<'a, 'tcx: 'a> {
     // tables for the current thing we are checking; set to
     // Some in `borrowck_fn` and cleared later
     tables: Option<&'a ty::TypeckTables<'tcx>>,
-
-    // Statistics:
-    stats: BorrowStats
-}
-
-#[derive(Clone)]
-struct BorrowStats {
-    loaned_paths_same: usize,
-    loaned_paths_imm: usize,
-    stable_paths: usize,
-    guaranteed_paths: usize
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -801,11 +801,13 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
             }
             mc::AliasableStatic |
             mc::AliasableStaticMut => {
-                let mut err = struct_span_err!(
-                    self.tcx.sess, span, E0388,
-                    "{} in a static location", prefix);
-                err.span_label(span, &format!("cannot write data in a static definition"));
-                err
+                // This path cannot occur. It happens when we have an
+                // `&mut` or assignment to a static. But in the case
+                // of `static X`, we get a mutability violation first,
+                // and never get here. In the case of `static mut X`,
+                // that is unsafe and hence the aliasability error is
+                // ignored.
+                span_bug!(span, "aliasability violation for static `{}`", prefix)
             }
             mc::AliasableBorrowed => {
                 let mut e = struct_span_err!(

--- a/src/librustc_borrowck/diagnostics.rs
+++ b/src/librustc_borrowck/diagnostics.rs
@@ -287,27 +287,7 @@ https://doc.rust-lang.org/std/cell/
 "##,
 
 E0388: r##"
-A mutable borrow was attempted in a static location.
-
-Erroneous code example:
-
-```compile_fail,E0388
-static X: i32 = 1;
-
-static STATIC_REF: &'static mut i32 = &mut X;
-// error: cannot borrow data mutably in a static location
-
-const CONST_REF: &'static mut i32 = &mut X;
-// error: cannot borrow data mutably in a static location
-```
-
-To fix this error, you have to use constant borrow:
-
-```
-static X: i32 = 1;
-
-static STATIC_REF: &'static i32 = &X;
-```
+E0388 was removed and is no longer issued.
 "##,
 
 E0389: r##"

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -28,6 +28,7 @@
 #![feature(shared)]
 #![feature(collections_range)]
 #![feature(collections_bound)]
+#![cfg_attr(stage0,feature(field_init_shorthand))]
 #![feature(nonzero)]
 #![feature(rustc_private)]
 #![feature(staged_api)]

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -24,6 +24,7 @@
 #![deny(warnings)]
 
 #![feature(box_syntax)]
+#![feature(loop_break_value)]
 #![feature(libc)]
 #![feature(quote)]
 #![feature(rustc_diagnostic_macros)]

--- a/src/librustc_incremental/calculate_svh/svh_visitor.rs
+++ b/src/librustc_incremental/calculate_svh/svh_visitor.rs
@@ -1167,9 +1167,9 @@ impl<'a, 'hash, 'tcx> StrictVersionHashVisitor<'a, 'hash, 'tcx> {
             trait_items: _,
             impl_items: _,
             bodies: _,
-
             trait_impls: _,
             trait_default_impl: _,
+            body_ids: _,
         } = *krate;
 
         visit::Visitor::visit_mod(self, module, span, ast::CRATE_NODE_ID);

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -712,7 +712,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnconditionalRecursion {
         // to have behaviour like the above, rather than
         // e.g. accidentally recurring after an assert.
 
-        let cfg = cfg::CFG::new(cx.tcx, &body.value);
+        let cfg = cfg::CFG::new(cx.tcx, &body);
 
         let mut work_queue = vec![cfg.entry];
         let mut reached_exit_without_self_call = false;

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -120,6 +120,9 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             rcx.visit_region_obligations(id);
         }
         rcx.resolve_regions_and_report_errors();
+
+        assert!(self.tables.borrow().free_region_map.is_empty());
+        self.tables.borrow_mut().free_region_map = rcx.free_region_map;
     }
 
     /// Region checking during the WF phase for items. `wf_tys` are the
@@ -154,10 +157,11 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
         rcx.resolve_regions_and_report_errors();
 
-        // For the top-level fn, store the free-region-map. We don't store
-        // any map for closures; they just share the same map as the
-        // function that created them.
-        self.tcx.store_free_region_map(fn_id, rcx.free_region_map);
+        // In this mode, we also copy the free-region-map into the
+        // tables of the enclosing fcx. In the other regionck modes
+        // (e.g., `regionck_item`), we don't have an enclosing tables.
+        assert!(self.tables.borrow().free_region_map.is_empty());
+        self.tables.borrow_mut().free_region_map = rcx.free_region_map;
     }
 }
 

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -50,6 +50,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         wbcx.visit_type_nodes();
         wbcx.visit_cast_types();
         wbcx.visit_lints();
+        wbcx.visit_free_region_map();
 
         let used_trait_imports = mem::replace(&mut self.tables.borrow_mut().used_trait_imports,
                                               DefIdSet());
@@ -272,6 +273,10 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
 
     fn visit_lints(&mut self) {
         self.fcx.tables.borrow_mut().lints.transfer(&mut self.tables.lints);
+    }
+
+    fn visit_free_region_map(&mut self) {
+        self.tables.free_region_map = self.fcx.tables.borrow().free_region_map.clone();
     }
 
     fn visit_anon_types(&mut self) {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1147,6 +1147,7 @@ fn ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
         NodeExpr(_) => match tcx.hir.get(tcx.hir.get_parent_node(node_id)) {
             NodeTy(&hir::Ty { node: TyArray(_, body), .. }) |
+            NodeTy(&hir::Ty { node: TyTypeof(body), .. }) |
             NodeExpr(&hir::Expr { node: ExprRepeat(_, body), .. })
                 if body.node_id == node_id => tcx.types.usize,
 

--- a/src/test/compile-fail/E0017.rs
+++ b/src/test/compile-fail/E0017.rs
@@ -19,8 +19,7 @@ static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0017
                                               //~| NOTE statics require immutable values
                                               //~| ERROR E0017
                                               //~| NOTE statics require immutable values
-                                              //~| ERROR E0388
-                                              //~| NOTE cannot write data in a static definition
+                                              //~| ERROR cannot borrow
 static CONST_REF: &'static mut i32 = &mut C; //~ ERROR E0017
                                              //~| NOTE statics require immutable values
                                              //~| ERROR E0017

--- a/src/test/compile-fail/E0388.rs
+++ b/src/test/compile-fail/E0388.rs
@@ -15,7 +15,7 @@ const CR: &'static mut i32 = &mut C; //~ ERROR E0017
                                      //~| ERROR E0017
 static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0017
                                               //~| ERROR E0017
-                                              //~| ERROR E0388
+                                              //~| ERROR cannot borrow
 static CONST_REF: &'static mut i32 = &mut C; //~ ERROR E0017
                                              //~| ERROR E0017
 

--- a/src/test/compile-fail/borrowck/move-in-static-initializer-issue-38520.rs
+++ b/src/test/compile-fail/borrowck/move-in-static-initializer-issue-38520.rs
@@ -1,0 +1,28 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for #38520. Check that moves of `Foo` are not
+// permitted as `Foo` is not copy (even in a static/const
+// initializer).
+
+#![feature(const_fn)]
+
+struct Foo(usize);
+
+const fn get(x: Foo) -> usize {
+    x.0
+}
+
+const X: Foo = Foo(22);
+static Y: usize = get(*&X); //~ ERROR E0507
+const Z: usize = get(*&X); //~ ERROR E0507
+
+fn main() {
+}

--- a/src/test/compile-fail/issue-18118.rs
+++ b/src/test/compile-fail/issue-18118.rs
@@ -13,6 +13,6 @@ pub fn main() {
         //~^ ERROR blocks in constants are limited to items and tail expressions
         let p = 3;
         //~^ ERROR blocks in constants are limited to items and tail expressions
-        &p
+        &p //~ ERROR `p` does not live long enough
     };
 }

--- a/src/test/ui/span/mut-arg-hint.stderr
+++ b/src/test/ui/span/mut-arg-hint.stderr
@@ -1,18 +1,18 @@
 error: cannot borrow immutable borrowed content `*a` as mutable
-  --> $DIR/mut-arg-hint.rs:18:5
-   |
-17 | pub fn foo<'a>(mut a: &'a String) {
-   |                       ---------- use `&'a mut String` here to make mutable
-18 |     a.push_str("foo");
-   |     ^ cannot borrow as mutable
-
-error: cannot borrow immutable borrowed content `*a` as mutable
   --> $DIR/mut-arg-hint.rs:13:9
    |
 12 |     fn foo(mut a: &String) {
    |                   ------- use `&mut String` here to make mutable
 13 |         a.push_str("bar");
    |         ^ cannot borrow as mutable
+
+error: cannot borrow immutable borrowed content `*a` as mutable
+  --> $DIR/mut-arg-hint.rs:18:5
+   |
+17 | pub fn foo<'a>(mut a: &'a String) {
+   |                       ---------- use `&'a mut String` here to make mutable
+18 |     a.push_str("foo");
+   |     ^ cannot borrow as mutable
 
 error: cannot borrow immutable borrowed content `*a` as mutable
   --> $DIR/mut-arg-hint.rs:25:9


### PR DESCRIPTION
This is a better structure for incremental compilation and also more compatible with the eventual borrowck mir. It also fixes #38520 as a drive-by fix.

r? @eddyb 