### PR TITLE
Fix indentation of error message

### DIFF
--- a/src/librustc/ty/inhabitedness/mod.rs
+++ b/src/librustc/ty/inhabitedness/mod.rs
@@ -187,7 +187,7 @@ impl<'a, 'gcx, 'tcx> TyS<'tcx> {
                         //      which contains a Foo<((T, T), (T, T))>
                         //      which contains a Foo<(((T, T), (T, T)), ((T, T), (T, T)))>
                         //      etc.
-                        let error = format!("reached recursion limit while checking
+                        let error = format!("reached recursion limit while checking \
                                              inhabitedness of `{}`", self);
                         tcx.sess.fatal(&error);
                     }


### PR DESCRIPTION
So I just encountered this error for the first time. It's unclear what
it means, why I encountered it, or how to fix it. But worst of all, it
has a random newline and weird indentation! This commit fixes that last
bit.

<img width="680" alt="screen shot 2017-02-18 at 4 35 36 pm" src="https://cloud.githubusercontent.com/assets/1529387/23097087/0ef5ac4a-f5f9-11e6-9132-18ce759f7092.png">