### PR TITLE
Use ARM instead of SystemZ for testing uninstalled targets

### DIFF
--- a/src/test/compile-fail/issue-37131.rs
+++ b/src/test/compile-fail/issue-37131.rs
@@ -11,8 +11,8 @@
 // Tests that compiling for a target which is not installed will result in a helpful
 // error message.
 
-// compile-flags: --target=s390x-unknown-linux-gnu
-// ignore s390x
+// compile-flags: --target=thumbv6m-none-eabi
+// ignore-arm
 
 // error-pattern:target may not be installed
 fn main() { }


### PR DESCRIPTION
This needs some explanation.
`config.toml` has section `targets` listing backends that are built during LLVM build:
```
targets = "X86;ARM;AArch64;Mips;PowerPC;SystemZ;JSBackend;MSP430;Sparc;NVPTX"
```
It would be reasonable to expect that `targets = "X86"` would be enough for doing a local build in typical case (building on x86 and not working on some non-x86 platform-specific functionality).
However, for `x.py test` to pass successfully you have to add ARM and SystemZ to the target list as well (`targets = "X86;ARM;SystemZ"`), because two tests (`compile-fail/issue-37131.rs` and `run-make\target-without-atomics`) require these architectures to be enabled in LLVM.
This patch moves `compile-fail/issue-37131.rs` from SystemZ to ARM, so `targets = "X86;ARM"` becomes sufficient for running the full test suite without errors.