### PR TITLE
Docs: Better explanation of return values for min, max functions for the Iterator trait

### DIFF
--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -1616,7 +1616,9 @@ pub trait Iterator {
     /// Returns the maximum element of an iterator.
     ///
     /// If several elements are equally maximum, the last element is
-    /// returned.
+    /// returned. If the iterator is empty, [`None`] is returned.
+    ///
+    /// [`None`]: ../../std/option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -1624,8 +1626,10 @@ pub trait Iterator {
     ///
     /// ```
     /// let a = [1, 2, 3];
+    /// let b: Vec<u32> = Vec::new();
     ///
     /// assert_eq!(a.iter().max(), Some(&3));
+    /// assert_eq!(b.iter().max(), None);
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -1642,7 +1646,9 @@ pub trait Iterator {
     /// Returns the minimum element of an iterator.
     ///
     /// If several elements are equally minimum, the first element is
-    /// returned.
+    /// returned. If the iterator is empty, [`None`] is returned.
+    ///
+    /// [`None`]: ../../std/option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -1650,8 +1656,10 @@ pub trait Iterator {
     ///
     /// ```
     /// let a = [1, 2, 3];
+    /// let b: Vec<u32> = Vec::new();
     ///
     /// assert_eq!(a.iter().min(), Some(&1));
+    /// assert_eq!(b.iter().min(), None);
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -1669,7 +1677,9 @@ pub trait Iterator {
     /// specified function.
     ///
     /// If several elements are equally maximum, the last element is
-    /// returned.
+    /// returned. If the iterator is empty, [`None`] is returned.
+    ///
+    /// [`None`]: ../../std/option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -1694,7 +1704,9 @@ pub trait Iterator {
     /// specified comparison function.
     ///
     /// If several elements are equally maximum, the last element is
-    /// returned.
+    /// returned. If the iterator is empty, [`None`] is returned.
+    ///
+    /// [`None`]: ../../std/option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -1719,7 +1731,9 @@ pub trait Iterator {
     /// specified function.
     ///
     /// If several elements are equally minimum, the first element is
-    /// returned.
+    /// returned. If the iterator is empty, [`None`] is returned.
+    ///
+    /// [`None`]: ../../std/option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -1743,7 +1757,9 @@ pub trait Iterator {
     /// specified comparison function.
     ///
     /// If several elements are equally minimum, the first element is
-    /// returned.
+    /// returned. If the iterator is empty, [`None`] is returned.
+    ///
+    /// [`None`]: ../../std/option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Added an explanation that `None` is returned if an iterator is empty.

Also added examples for `max` and `min`. I chose not to add examples for other functions like `max_by_key` etc. so that the examples stay concised and focused on the main functionality.